### PR TITLE
style(popup): 词典义项卡照抄 Niratan 描边卡样式

### DIFF
--- a/hibiki/assets/browser_extension/vendor/content.css
+++ b/hibiki/assets/browser_extension/vendor/content.css
@@ -619,31 +619,30 @@
     background: transparent;
 }
 
-/* TODO-1325 #7（按用户 Niratan「卡片」决策，超越 TODO-877 的扁平化）：每部词典的义项块
-   (.glossary-group) 做成「玻璃卡片」——圆角(走 --hibiki-radius-card token，与弹窗其余卡片
-   统一) + 分层投影(近距 1px 贴地 + 远距柔性扩散) + 顶部内高光(inset 白线)营造玻璃质感；
-   展开/收起三角(下方 TODO-1337 纯 CSS 边框三角)作卡片头。皮肤纯 CSS，不改 DOM/JS，四端
-   (in-app 弹窗 + 两 vendor)共用一处。TODO-776 的 grid 行距模型不变：行距仍走 margin-top
-   (grid 不折叠 item margin，父只设 column-gap)，padding 是 border-box 内边距不撑 grid track。
-   暗色变体降内高光、加深投影。 */
+/* 按用户「照抄 Niratan」决策（取代 TODO-1325 #7 的玻璃卡皮肤）：每部词典的义项块
+   (.glossary-group) 逐字对齐 Niratan Features/Popup/popup.css `.glossary-group` ——
+   描边卡而非填充玻璃卡：1px 半透明描边(rgba 0,0,0,.14) + 顶部 inset 白高光 + 薄贴地投影，
+   无 background 填充，观感更扁平、与 Niratan 一致。padding 6px 8px、radius 8px 亦照抄
+   (Niratan 的 calc(8px*--popup-scale) 在 Hibiki 走 documentElement.zoom 整体缩放，故直接 8px)。
+   皮肤纯 CSS，不改 DOM/JS，四端(in-app 弹窗 + 两 vendor)共用一处。TODO-776 的 grid 行距模型不变：
+   行距仍走 margin-top(grid 不折叠 item margin，父只设 column-gap)，padding 是 border-box 内边距
+   不撑 grid track。暗色变体：描边转白(rgba 255,255,255,.09) + 加深贴地投影(照抄 Niratan 暗色分支)。 */
 .glossary-group {
     position: relative;
     margin-top: 5px;
-    padding: 8px 10px;
-    border-radius: var(--hibiki-radius-card, 10px);
-    background: var(--surface-container);
+    min-width: 0;
+    padding: 6px 8px;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 0, 0, 0.14);
     box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.12),
-        0 2px 8px rgba(0, 0, 0, 0.08),
-        inset 0 1px 0 rgba(255, 255, 255, 0.35);
+        inset 0 0 0 1px rgba(255, 255, 255, 0.42),
+        0 0 0 1px rgba(255, 255, 255, 0.22),
+        0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 #entries-container[data-theme="dark"] .glossary-group {
-    background: var(--surface-container-high);
-    box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.5),
-        0 3px 10px rgba(0, 0, 0, 0.35),
-        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.09);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.36);
 }
 
 .glossary-group > summary {

--- a/hibiki/assets/browser_extension/vendor/popup.css
+++ b/hibiki/assets/browser_extension/vendor/popup.css
@@ -641,31 +641,30 @@ html[data-theme="dark"] .gloss-image-link[data-appearance="monochrome"] img.glos
     background: transparent;
 }
 
-/* TODO-1325 #7（按用户 Niratan「卡片」决策，超越 TODO-877 的扁平化）：每部词典的义项块
-   (.glossary-group) 做成「玻璃卡片」——圆角(走 --hibiki-radius-card token，与弹窗其余卡片
-   统一) + 分层投影(近距 1px 贴地 + 远距柔性扩散) + 顶部内高光(inset 白线)营造玻璃质感；
-   展开/收起三角(下方 TODO-1337 纯 CSS 边框三角)作卡片头。皮肤纯 CSS，不改 DOM/JS，四端
-   (in-app 弹窗 + 两 vendor)共用一处。TODO-776 的 grid 行距模型不变：行距仍走 margin-top
-   (grid 不折叠 item margin，父只设 column-gap)，padding 是 border-box 内边距不撑 grid track。
-   暗色变体降内高光、加深投影。 */
+/* 按用户「照抄 Niratan」决策（取代 TODO-1325 #7 的玻璃卡皮肤）：每部词典的义项块
+   (.glossary-group) 逐字对齐 Niratan Features/Popup/popup.css `.glossary-group` ——
+   描边卡而非填充玻璃卡：1px 半透明描边(rgba 0,0,0,.14) + 顶部 inset 白高光 + 薄贴地投影，
+   无 background 填充，观感更扁平、与 Niratan 一致。padding 6px 8px、radius 8px 亦照抄
+   (Niratan 的 calc(8px*--popup-scale) 在 Hibiki 走 documentElement.zoom 整体缩放，故直接 8px)。
+   皮肤纯 CSS，不改 DOM/JS，四端(in-app 弹窗 + 两 vendor)共用一处。TODO-776 的 grid 行距模型不变：
+   行距仍走 margin-top(grid 不折叠 item margin，父只设 column-gap)，padding 是 border-box 内边距
+   不撑 grid track。暗色变体：描边转白(rgba 255,255,255,.09) + 加深贴地投影(照抄 Niratan 暗色分支)。 */
 .glossary-group {
     position: relative;
     margin-top: 5px;
-    padding: 8px 10px;
-    border-radius: var(--hibiki-radius-card, 10px);
-    background: var(--surface-container);
+    min-width: 0;
+    padding: 6px 8px;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 0, 0, 0.14);
     box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.12),
-        0 2px 8px rgba(0, 0, 0, 0.08),
-        inset 0 1px 0 rgba(255, 255, 255, 0.35);
+        inset 0 0 0 1px rgba(255, 255, 255, 0.42),
+        0 0 0 1px rgba(255, 255, 255, 0.22),
+        0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 html[data-theme="dark"] .glossary-group {
-    background: var(--surface-container-high);
-    box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.5),
-        0 3px 10px rgba(0, 0, 0, 0.35),
-        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.09);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.36);
 }
 
 .glossary-group > summary {

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -2679,7 +2679,11 @@ window._renderGeneration = 0;
 // buildEntryElement / postProcessRuby throws. Without this a render exception
 // would swallow the `popupRendered` signal forever, leaving a cold nested popup
 // permanently hidden (pending reveal). Fired exactly once per render.
-function _firePopupRendered() {
+function _reportPopupHeight() {
+    // 把当前内容高度报给宿主（宿主据此给弹窗窗口/浮层定尺、并驱动 reveal 门）。
+    // 抽成独立函数是因为 masonry 铺完后容器高度会变（紧密堆比行对齐 grid 更矮），必须
+    // 复报一次，否则宿主拿的是 masonry 前的旧高度、弹窗底部会留空白。只报高度、不触发
+    // relayout，避免 _firePopupRendered→relayout→report→relayout 的死循环。
     try {
         window.flutter_inappwebview.callHandler('popupRendered',
             __hibikiScrollHeight(),
@@ -2687,6 +2691,143 @@ function _firePopupRendered() {
     } catch (e) {
         console.error('[popup] popupRendered callHandler failed', e);
     }
+}
+
+function _firePopupRendered() {
+    _reportPopupHeight();
+    // 词典方框排列：渲染完成后（含首条 + 其余条两次调用）铺 masonry。masonry 在下一帧
+    // RAF 里跑，跑完会自行 _reportPopupHeight() 复报修正后的高度。
+    window.hoshiRelayoutDictionaries();
+}
+
+// ===== N 列 masonry 词典方框排列（照抄 Niratan Features/Popup/popup.js layoutMasonry，
+//        一般化到 Hibiki 的 --dict-columns N 列）=====
+// develop 原本用 CSS grid `.glossary-section > .category-body`(repeat(--dict-columns,1fr))
+// 行对齐排列：同一行的词典卡片被该行最高者顶到同一水平线，矮卡片下方留空隙（Niratan 的
+// 紧密堆则无此空隙）。这里在 grid 之上叠一层运行时 masonry——cols>1 且多卡时用 inline-style
+// 把每张卡片绝对定位进「当前最矮的那一列」（最短列打包，无空隙，Pinterest 式），cols<=1 或
+// 单卡时清掉 inline 回落到 CSS grid/block。CSS 规则原样保留作「无 JS 兜底」，故所有现有 grid
+// 守卫测试不受影响。高度变化（<details> 展开/收起、图片异步加载、ruby、字体替换）由挂在每张
+// 卡片上的 ResizeObserver 捕捉重排（不依赖 toggle 事件跨 shadow 边界）；宽度变化走 resize。
+const HAS_NATIVE_MASONRY = (() => {
+    try { return CSS.supports('display', 'grid-lanes'); } catch (e) { return false; }
+})();
+let masonryRaf = null;
+let masonryObserver = null;
+
+// masonry 是叠在 CSS grid 之上的渐进增强：需要 ResizeObserver（捕捉卡片高度变化重排）
+// 与 requestAnimationFrame（合帧）。环境不具备（老 WebView / 非浏览器测试壳）时整体不做
+// masonry，静默回落到 CSS grid 行对齐布局——不崩、不报错，只是没有紧密堆。
+function masonrySupported() {
+    return typeof requestAnimationFrame === 'function'
+        && typeof ResizeObserver === 'function';
+}
+
+function dictColumns() {
+    // --dict-columns 由宿主注入到 documentElement（app_model / dictionary_popup_webview /
+    // popup_settings_injection 三面同源），即使弹窗挂在 shadow root 也从此处读。
+    const raw = getComputedStyle(document.documentElement).getPropertyValue('--dict-columns');
+    const n = Number.parseInt(raw, 10);
+    return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+function masonryGap() {
+    // 与 popup.css `.glossary-section > .category-body { column-gap: 6px }` 同源。
+    return 6;
+}
+
+function masonryBodies() {
+    const root = __hibikiContainer();
+    if (!root || typeof root.querySelectorAll !== 'function') return [];
+    // 只抓词典义项容器；frequency-section / pitch-section 也用 .category-body，不能误抓。
+    return [...root.querySelectorAll('.glossary-section > .category-body')];
+}
+
+function resetMasonryBody(body) {
+    body.style.position = '';
+    body.style.display = '';
+    body.style.height = '';
+    [...body.children].forEach(item => {
+        item.style.position = '';
+        item.style.left = '';
+        item.style.top = '';
+        item.style.width = '';
+        item.style.marginTop = '';
+        item.style.transform = '';
+    });
+}
+
+function layoutMasonry() {
+    if (HAS_NATIVE_MASONRY) return; // 浏览器原生 masonry 时交给 CSS（未来分支）
+    const cols = dictColumns();
+    const gap = masonryGap();
+    masonryBodies().forEach(body => {
+        const items = [...body.children].filter(c => c.classList.contains('glossary-group'));
+        // 单列 / 单卡：不做 masonry，清 inline 回落 CSS（单卡满宽、单列纵向堆叠 + CSS margin-top）。
+        if (cols <= 1 || items.length <= 1) {
+            resetMasonryBody(body);
+            return;
+        }
+        body.style.position = 'relative';
+        body.style.display = 'block';
+        const columnWidth = (body.clientWidth - (cols - 1) * gap) / cols;
+        const heights = new Array(cols).fill(0);
+        items.forEach(item => {
+            let c = 0;
+            for (let i = 1; i < cols; i++) {
+                if (heights[i] < heights[c]) c = i; // 当前最矮列
+            }
+            item.style.position = 'absolute';
+            item.style.left = '0';
+            item.style.top = '0';
+            item.style.marginTop = '0';
+            item.style.width = `${columnWidth}px`;
+            item.style.transform = `translate(${c * (columnWidth + gap)}px, ${heights[c]}px)`;
+            // 读 offsetHeight 前已设 width，浏览器按目标列宽回流后再量高。
+            heights[c] += item.offsetHeight + gap;
+        });
+        body.style.height = `${Math.max(...heights) - gap}px`;
+    });
+}
+
+function observeMasonryTargets() {
+    if (HAS_NATIVE_MASONRY || !masonrySupported()) return;
+    if (!masonryObserver) {
+        masonryObserver = new ResizeObserver(scheduleMasonry);
+    }
+    // 只观察卡片本身（内容高度变化），不观察容器（避免 body.style.height 自触发死循环）；
+    // 容器宽度变化由 window resize 覆盖。observe 同一元素幂等，增量新增卡片可安全重观察。
+    masonryBodies().forEach(body => {
+        [...body.children].forEach(item => {
+            if (item.classList.contains('glossary-group')) masonryObserver.observe(item);
+        });
+    });
+}
+
+function scheduleMasonry() {
+    if (HAS_NATIVE_MASONRY || !masonrySupported() || masonryRaf) return;
+    masonryRaf = requestAnimationFrame(() => {
+        masonryRaf = null;
+        layoutMasonry();
+        // 铺完复报高度（容器高度已由 masonry 改写），让宿主给弹窗重新定尺。
+        _reportPopupHeight();
+    });
+}
+
+// 宿主改列数 / 外部触发时可调；渲染钩子已在 _firePopupRendered / updatePopupIncremental 里调。
+window.hoshiRelayoutDictionaries = () => {
+    observeMasonryTargets();
+    scheduleMasonry();
+};
+
+// 顶层注册用 typeof 守卫：真实浏览器一定有 addEventListener；非浏览器测试壳缺此 API 时
+// 跳过注册即可（masonry 本就会被 masonrySupported 门控掉）。
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+    window.addEventListener('resize', scheduleMasonry);
+}
+// <details> 展开/收起改高度：capture 阶段兜底（ResizeObserver 已是主路，故 shadow 边界不影响正确性）。
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+    document.addEventListener('toggle', scheduleMasonry, true);
 }
 
 // TODO-1030 M0 — the app-external global-lookup capture (Windows UIA) hands the
@@ -2946,6 +3087,9 @@ window.updatePopupIncremental = function() {
     window._renderedGlossaryCounts = entries.map(e => e.glossaries.length);
     window._entryDomIndex = rebuiltDomIndex;
     applyCustomCSS();
+
+    // 增量追加了新的词典方框，重排 masonry 并观察新卡片。
+    window.hoshiRelayoutDictionaries();
 
     window.flutter_inappwebview.callHandler('popupRendered',
         __hibikiScrollHeight(),

--- a/hibiki/assets/popup/popup.css
+++ b/hibiki/assets/popup/popup.css
@@ -641,31 +641,30 @@ html[data-theme="dark"] .gloss-image-link[data-appearance="monochrome"] img.glos
     background: transparent;
 }
 
-/* TODO-1325 #7（按用户 Niratan「卡片」决策，超越 TODO-877 的扁平化）：每部词典的义项块
-   (.glossary-group) 做成「玻璃卡片」——圆角(走 --hibiki-radius-card token，与弹窗其余卡片
-   统一) + 分层投影(近距 1px 贴地 + 远距柔性扩散) + 顶部内高光(inset 白线)营造玻璃质感；
-   展开/收起三角(下方 TODO-1337 纯 CSS 边框三角)作卡片头。皮肤纯 CSS，不改 DOM/JS，四端
-   (in-app 弹窗 + 两 vendor)共用一处。TODO-776 的 grid 行距模型不变：行距仍走 margin-top
-   (grid 不折叠 item margin，父只设 column-gap)，padding 是 border-box 内边距不撑 grid track。
-   暗色变体降内高光、加深投影。 */
+/* 按用户「照抄 Niratan」决策（取代 TODO-1325 #7 的玻璃卡皮肤）：每部词典的义项块
+   (.glossary-group) 逐字对齐 Niratan Features/Popup/popup.css `.glossary-group` ——
+   描边卡而非填充玻璃卡：1px 半透明描边(rgba 0,0,0,.14) + 顶部 inset 白高光 + 薄贴地投影，
+   无 background 填充，观感更扁平、与 Niratan 一致。padding 6px 8px、radius 8px 亦照抄
+   (Niratan 的 calc(8px*--popup-scale) 在 Hibiki 走 documentElement.zoom 整体缩放，故直接 8px)。
+   皮肤纯 CSS，不改 DOM/JS，四端(in-app 弹窗 + 两 vendor)共用一处。TODO-776 的 grid 行距模型不变：
+   行距仍走 margin-top(grid 不折叠 item margin，父只设 column-gap)，padding 是 border-box 内边距
+   不撑 grid track。暗色变体：描边转白(rgba 255,255,255,.09) + 加深贴地投影(照抄 Niratan 暗色分支)。 */
 .glossary-group {
     position: relative;
     margin-top: 5px;
-    padding: 8px 10px;
-    border-radius: var(--hibiki-radius-card, 10px);
-    background: var(--surface-container);
+    min-width: 0;
+    padding: 6px 8px;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 0, 0, 0.14);
     box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.12),
-        0 2px 8px rgba(0, 0, 0, 0.08),
-        inset 0 1px 0 rgba(255, 255, 255, 0.35);
+        inset 0 0 0 1px rgba(255, 255, 255, 0.42),
+        0 0 0 1px rgba(255, 255, 255, 0.22),
+        0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 html[data-theme="dark"] .glossary-group {
-    background: var(--surface-container-high);
-    box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.5),
-        0 3px 10px rgba(0, 0, 0, 0.35),
-        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.09);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.36);
 }
 
 .glossary-group > summary {

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -2679,7 +2679,11 @@ window._renderGeneration = 0;
 // buildEntryElement / postProcessRuby throws. Without this a render exception
 // would swallow the `popupRendered` signal forever, leaving a cold nested popup
 // permanently hidden (pending reveal). Fired exactly once per render.
-function _firePopupRendered() {
+function _reportPopupHeight() {
+    // 把当前内容高度报给宿主（宿主据此给弹窗窗口/浮层定尺、并驱动 reveal 门）。
+    // 抽成独立函数是因为 masonry 铺完后容器高度会变（紧密堆比行对齐 grid 更矮），必须
+    // 复报一次，否则宿主拿的是 masonry 前的旧高度、弹窗底部会留空白。只报高度、不触发
+    // relayout，避免 _firePopupRendered→relayout→report→relayout 的死循环。
     try {
         window.flutter_inappwebview.callHandler('popupRendered',
             __hibikiScrollHeight(),
@@ -2687,6 +2691,143 @@ function _firePopupRendered() {
     } catch (e) {
         console.error('[popup] popupRendered callHandler failed', e);
     }
+}
+
+function _firePopupRendered() {
+    _reportPopupHeight();
+    // 词典方框排列：渲染完成后（含首条 + 其余条两次调用）铺 masonry。masonry 在下一帧
+    // RAF 里跑，跑完会自行 _reportPopupHeight() 复报修正后的高度。
+    window.hoshiRelayoutDictionaries();
+}
+
+// ===== N 列 masonry 词典方框排列（照抄 Niratan Features/Popup/popup.js layoutMasonry，
+//        一般化到 Hibiki 的 --dict-columns N 列）=====
+// develop 原本用 CSS grid `.glossary-section > .category-body`(repeat(--dict-columns,1fr))
+// 行对齐排列：同一行的词典卡片被该行最高者顶到同一水平线，矮卡片下方留空隙（Niratan 的
+// 紧密堆则无此空隙）。这里在 grid 之上叠一层运行时 masonry——cols>1 且多卡时用 inline-style
+// 把每张卡片绝对定位进「当前最矮的那一列」（最短列打包，无空隙，Pinterest 式），cols<=1 或
+// 单卡时清掉 inline 回落到 CSS grid/block。CSS 规则原样保留作「无 JS 兜底」，故所有现有 grid
+// 守卫测试不受影响。高度变化（<details> 展开/收起、图片异步加载、ruby、字体替换）由挂在每张
+// 卡片上的 ResizeObserver 捕捉重排（不依赖 toggle 事件跨 shadow 边界）；宽度变化走 resize。
+const HAS_NATIVE_MASONRY = (() => {
+    try { return CSS.supports('display', 'grid-lanes'); } catch (e) { return false; }
+})();
+let masonryRaf = null;
+let masonryObserver = null;
+
+// masonry 是叠在 CSS grid 之上的渐进增强：需要 ResizeObserver（捕捉卡片高度变化重排）
+// 与 requestAnimationFrame（合帧）。环境不具备（老 WebView / 非浏览器测试壳）时整体不做
+// masonry，静默回落到 CSS grid 行对齐布局——不崩、不报错，只是没有紧密堆。
+function masonrySupported() {
+    return typeof requestAnimationFrame === 'function'
+        && typeof ResizeObserver === 'function';
+}
+
+function dictColumns() {
+    // --dict-columns 由宿主注入到 documentElement（app_model / dictionary_popup_webview /
+    // popup_settings_injection 三面同源），即使弹窗挂在 shadow root 也从此处读。
+    const raw = getComputedStyle(document.documentElement).getPropertyValue('--dict-columns');
+    const n = Number.parseInt(raw, 10);
+    return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+function masonryGap() {
+    // 与 popup.css `.glossary-section > .category-body { column-gap: 6px }` 同源。
+    return 6;
+}
+
+function masonryBodies() {
+    const root = __hibikiContainer();
+    if (!root || typeof root.querySelectorAll !== 'function') return [];
+    // 只抓词典义项容器；frequency-section / pitch-section 也用 .category-body，不能误抓。
+    return [...root.querySelectorAll('.glossary-section > .category-body')];
+}
+
+function resetMasonryBody(body) {
+    body.style.position = '';
+    body.style.display = '';
+    body.style.height = '';
+    [...body.children].forEach(item => {
+        item.style.position = '';
+        item.style.left = '';
+        item.style.top = '';
+        item.style.width = '';
+        item.style.marginTop = '';
+        item.style.transform = '';
+    });
+}
+
+function layoutMasonry() {
+    if (HAS_NATIVE_MASONRY) return; // 浏览器原生 masonry 时交给 CSS（未来分支）
+    const cols = dictColumns();
+    const gap = masonryGap();
+    masonryBodies().forEach(body => {
+        const items = [...body.children].filter(c => c.classList.contains('glossary-group'));
+        // 单列 / 单卡：不做 masonry，清 inline 回落 CSS（单卡满宽、单列纵向堆叠 + CSS margin-top）。
+        if (cols <= 1 || items.length <= 1) {
+            resetMasonryBody(body);
+            return;
+        }
+        body.style.position = 'relative';
+        body.style.display = 'block';
+        const columnWidth = (body.clientWidth - (cols - 1) * gap) / cols;
+        const heights = new Array(cols).fill(0);
+        items.forEach(item => {
+            let c = 0;
+            for (let i = 1; i < cols; i++) {
+                if (heights[i] < heights[c]) c = i; // 当前最矮列
+            }
+            item.style.position = 'absolute';
+            item.style.left = '0';
+            item.style.top = '0';
+            item.style.marginTop = '0';
+            item.style.width = `${columnWidth}px`;
+            item.style.transform = `translate(${c * (columnWidth + gap)}px, ${heights[c]}px)`;
+            // 读 offsetHeight 前已设 width，浏览器按目标列宽回流后再量高。
+            heights[c] += item.offsetHeight + gap;
+        });
+        body.style.height = `${Math.max(...heights) - gap}px`;
+    });
+}
+
+function observeMasonryTargets() {
+    if (HAS_NATIVE_MASONRY || !masonrySupported()) return;
+    if (!masonryObserver) {
+        masonryObserver = new ResizeObserver(scheduleMasonry);
+    }
+    // 只观察卡片本身（内容高度变化），不观察容器（避免 body.style.height 自触发死循环）；
+    // 容器宽度变化由 window resize 覆盖。observe 同一元素幂等，增量新增卡片可安全重观察。
+    masonryBodies().forEach(body => {
+        [...body.children].forEach(item => {
+            if (item.classList.contains('glossary-group')) masonryObserver.observe(item);
+        });
+    });
+}
+
+function scheduleMasonry() {
+    if (HAS_NATIVE_MASONRY || !masonrySupported() || masonryRaf) return;
+    masonryRaf = requestAnimationFrame(() => {
+        masonryRaf = null;
+        layoutMasonry();
+        // 铺完复报高度（容器高度已由 masonry 改写），让宿主给弹窗重新定尺。
+        _reportPopupHeight();
+    });
+}
+
+// 宿主改列数 / 外部触发时可调；渲染钩子已在 _firePopupRendered / updatePopupIncremental 里调。
+window.hoshiRelayoutDictionaries = () => {
+    observeMasonryTargets();
+    scheduleMasonry();
+};
+
+// 顶层注册用 typeof 守卫：真实浏览器一定有 addEventListener；非浏览器测试壳缺此 API 时
+// 跳过注册即可（masonry 本就会被 masonrySupported 门控掉）。
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+    window.addEventListener('resize', scheduleMasonry);
+}
+// <details> 展开/收起改高度：capture 阶段兜底（ResizeObserver 已是主路，故 shadow 边界不影响正确性）。
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+    document.addEventListener('toggle', scheduleMasonry, true);
 }
 
 // TODO-1030 M0 — the app-external global-lookup capture (Windows UIA) hands the
@@ -2946,6 +3087,9 @@ window.updatePopupIncremental = function() {
     window._renderedGlossaryCounts = entries.map(e => e.glossaries.length);
     window._entryDomIndex = rebuiltDomIndex;
     applyCustomCSS();
+
+    // 增量追加了新的词典方框，重排 masonry 并观察新卡片。
+    window.hoshiRelayoutDictionaries();
 
     window.flutter_inappwebview.callHandler('popupRendered',
         __hibikiScrollHeight(),

--- a/hibiki/test/dictionary/popup_cards_nav_icon_guard_test.dart
+++ b/hibiki/test/dictionary/popup_cards_nav_icon_guard_test.dart
@@ -8,7 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 /// （in-app 弹窗 + 两份浏览器扩展 vendor 副本；byte-parity 由
 /// `browser_extension_popup_parity_guard` 另锁，此处锁语义约束防回退）。
 ///
-///   #7 词典卡片：`.glossary-group` 是玻璃卡片（圆角走 token + 分层投影 + inset 内高光）。
+///   #7 词典卡片：`.glossary-group` 是 Niratan 描边卡（1px 描边 + 圆角 + inset 顶部高光 +
+///      薄贴地投影，无 background 填充；照抄 Niratan Features/Popup/popup.css）。
 ///   #5 词条导航：popup.js 暴露 `hoshiFocusDictionaryEntry/Move/Reset`，当前词条走
 ///      `.entry-current` 的 #1a73e8 纯 CSS 边框蓝三角（零字体依赖）。
 ///   #1338 制卡图标乱码：制卡按钮保留 ✓/✓↩ 文本标记（应用户要求不走 SVG），但用
@@ -47,14 +48,18 @@ void main() {
       late final String css;
       setUpAll(() => css = read(relPath));
 
-      test('#7 词典卡片：.glossary-group 圆角(token)+投影+inset 内高光', () {
+      test('#7 词典卡片：.glossary-group 是 Niratan 描边卡（描边+圆角+inset高光投影，无填充）', () {
         final String body = ruleBody(css, r'\.glossary-group');
-        expect(body.contains('var(--hibiki-radius-card'), isTrue,
-            reason: '卡片圆角走 --hibiki-radius-card token，与弹窗其余卡片统一');
+        expect(RegExp(r'(^|[;{\s])border\s*:').hasMatch(body), isTrue,
+            reason: 'Niratan 描边卡靠 1px 描边定形，非 background 填充');
+        expect(RegExp(r'border-radius\s*:').hasMatch(body), isTrue,
+            reason: '卡片要有圆角');
         expect(RegExp(r'box-shadow\s*:').hasMatch(body), isTrue,
-            reason: '卡片要有分层投影');
+            reason: '卡片要有薄贴地投影 + 顶部 inset 白高光');
         expect(body.contains('inset'), isTrue,
-            reason: 'box-shadow 含 inset 顶部内高光（玻璃质感）');
+            reason: 'box-shadow 含 inset 顶部内高光（照抄 Niratan）');
+        expect(RegExp(r'background\s*:').hasMatch(body), isFalse,
+            reason: 'Niratan 描边卡无 background 填充；有填充即退回玻璃卡');
       });
 
       test('#5 当前词条蓝三角 = 纯 CSS 边框三角 #1a73e8（零字体依赖）', () {

--- a/hibiki/test/reader/popup_dict_card_guard_test.dart
+++ b/hibiki/test/reader/popup_dict_card_guard_test.dart
@@ -2,10 +2,11 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// TODO-1325 #7 守卫（超越 TODO-877/TODO-849 的往返，按用户 Niratan「卡片」决策）：查词
-/// 弹窗里每本词典的义项块 (`.glossary-group`) 是一枚「玻璃卡片」——圆角(走 token
-/// `--hibiki-radius-card`，与弹窗其余卡片统一) + 分层投影 + 顶部内高光 + 内边距。皮肤挂在
-/// 基类 `.glossary-group` 上（四端共用），暗色变体单独一条。
+/// 守卫（按用户「照抄 Niratan」决策，取代 TODO-1325 #7 的玻璃卡皮肤）：查词弹窗里每本
+/// 词典的义项块 (`.glossary-group`) 逐字对齐 Niratan Features/Popup/popup.css 的
+/// **描边卡**——1px 半透明描边 + 圆角 + 顶部 inset 白高光 + 薄贴地投影 + 内边距，**无
+/// background 填充**（比玻璃卡更扁平，与 Niratan 一致）。皮肤挂在基类 `.glossary-group`
+/// 上（四端共用），暗色变体单独一条（描边转白 + 加深投影）。
 ///
 /// 同时仍锁住原 TODO-877/TODO-776 的两个不变量不被卡片改动破坏：
 ///   * 间距模型：`.glossary-section > .category-body > .glossary-group` 仍走 margin-top +
@@ -30,27 +31,27 @@ void main() {
     return m!.group(1)!;
   }
 
-  test('每本词典义项块是玻璃卡片：基类 .glossary-group 有圆角/投影/底色/内边距 (TODO-1325 #7)', () {
+  test('每本词典义项块是 Niratan 描边卡：基类 .glossary-group 有描边/圆角/inset高光投影/内边距，无填充', () {
     final String body = ruleBody(r'\.glossary-group');
+    expect(RegExp(r'(^|[;{\s])border\s*:').hasMatch(body), isTrue,
+        reason: 'Niratan 描边卡靠 1px 描边定形（rgba 0,0,0,.14），非 background 填充');
     expect(RegExp(r'border-radius\s*:').hasMatch(body), isTrue,
         reason: '卡片要有圆角');
-    expect(body.contains('var(--hibiki-radius-card'), isTrue,
-        reason: '圆角走 --hibiki-radius-card token，与弹窗其余卡片统一，不硬编码');
     expect(RegExp(r'box-shadow\s*:').hasMatch(body), isTrue,
-        reason: '卡片要有分层投影 + 内高光（玻璃质感）');
+        reason: '卡片要有薄贴地投影 + 顶部 inset 白高光');
     expect(body.contains('inset'), isTrue,
-        reason: 'box-shadow 含 inset 顶部高光营造玻璃质感');
-    expect(RegExp(r'background\s*:').hasMatch(body), isTrue,
-        reason: '卡片要有底色（--surface-container 分层）');
+        reason: 'box-shadow 含 inset 顶部高光（照抄 Niratan）');
     expect(RegExp(r'padding\s*:').hasMatch(body), isTrue, reason: '卡片要有内边距');
+    expect(RegExp(r'background\s*:').hasMatch(body), isFalse,
+        reason: 'Niratan 描边卡无 background 填充；有填充即偏离本家、退回玻璃卡');
   });
 
-  test('暗色主题有独立卡片变体（降内高光 / 加深投影）(TODO-1325 #7)', () {
+  test('暗色主题有独立描边卡变体（描边转白 + 加深投影）', () {
     final String body = ruleBody(r'html\[data-theme="dark"\] \.glossary-group');
+    expect(RegExp(r'border-color\s*:').hasMatch(body), isTrue,
+        reason: '暗色卡片单独把描边转白（rgba 255,255,255,.09）');
     expect(RegExp(r'box-shadow\s*:').hasMatch(body), isTrue,
-        reason: '暗色卡片单独调投影 / 内高光强度');
-    expect(RegExp(r'background\s*:').hasMatch(body), isTrue,
-        reason: '暗色卡片单独底色');
+        reason: '暗色卡片单独加深贴地投影');
   });
 
   test('间距仍走 margin-top + min-width，未破坏 TODO-776 grid 间距模型', () {
@@ -118,7 +119,7 @@ void main() {
     expect(rule.contains('repeat(var(--dict-columns'), isTrue);
   });
 
-  test('玻璃卡片不钉死高度，取自然内容高度 (BUG-683)', () {
+  test('描边卡不钉死高度，取自然内容高度 (BUG-683)', () {
     final String body = stripComments(ruleBody(r'\.glossary-group'));
     expect(RegExp(r'(^|[;{\s])height\s*:').hasMatch(body), isFalse,
         reason: '卡片不能钉死 height，否则内容高度失真、又回到等高观感');

--- a/hibiki/test/reader/popup_dict_masonry_guard_test.dart
+++ b/hibiki/test/reader/popup_dict_masonry_guard_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 守卫（按用户「照抄 Niratan 词典方框排列」决策）：查词弹窗里多本词典的方框
+/// (`.glossary-group`) 按 Niratan Features/Popup/popup.js 的 masonry「最短列打包」排列
+/// ——每张卡片放进当前最矮的那一列，紧密堆叠不留空隙（对照 develop 原本的 CSS grid 行对齐：
+/// 同行卡片被最高者顶到同一水平线、矮卡片下方留空白）。
+///
+/// 实现取舍（见 popup.js 注释）：CSS grid 规则原样保留作「无 JS 兜底」，masonry 是叠在
+/// grid 之上的运行时 inline-style 覆盖层——`--dict-columns > 1` 且多卡时接管绝对定位，
+/// `<=1` 或单卡时清 inline 回落 grid/block。因此这里锁 popup.js 的 masonry 不变量，而
+/// popup.css 的 grid 守卫（popup_dict_card_guard / popup_dictionary_columns）不受影响。
+///
+/// 纯源码不变量（CI 只跑 .dart，node 守卫 CI 不跑），故在 Dart 层断言以进 CI 真跑；
+/// 真实排列观感另由桌面离屏真机复测（reader/popup 布局问题的验证纪律）。
+void main() {
+  late String js;
+
+  setUpAll(() {
+    js = File('assets/popup/popup.js').readAsStringSync();
+  });
+
+  test('存在 masonry 布局函数，且列数从 --dict-columns 读取（一般化 Niratan 的写死 2 列）', () {
+    expect(js.contains('function layoutMasonry('), isTrue,
+        reason: 'masonry 主函数 layoutMasonry 必须存在');
+    expect(js.contains('function dictColumns('), isTrue,
+        reason: '列数来源 dictColumns() 必须存在');
+    expect(
+        RegExp(r"getPropertyValue\(\s*'--dict-columns'\s*\)").hasMatch(js) ||
+            RegExp(r'getPropertyValue\(\s*"--dict-columns"\s*\)').hasMatch(js),
+        isTrue,
+        reason: '列数必须从宿主注入的 --dict-columns 读取，保留已发布的列数设置');
+  });
+
+  test('核心是「最短列打包」：每张卡片放进当前最矮列（无空隙紧密堆）', () {
+    // 选列逻辑：遍历列高数组，取更矮的一列。锁住这条 heights[i] < heights[c] 的最短列判据，
+    // 防止退回按顺序填列（那会重现行对齐的空隙）。
+    expect(RegExp(r'heights\[i\]\s*<\s*heights\[c\]').hasMatch(js), isTrue,
+        reason: '必须按「当前最矮列」选列，才是 masonry 紧密堆，而非顺序/行对齐');
+    expect(js.contains('offsetHeight'), isTrue,
+        reason: '按卡片实测高度累加列高，才能把下一张压到最矮列底部');
+  });
+
+  test('masonry 用绝对定位 + translate 摆放，容器撑到最高列高度', () {
+    expect(RegExp(r"position\s*=\s*'absolute'").hasMatch(js), isTrue,
+        reason: '卡片绝对定位脱离行对齐流');
+    expect(RegExp(r'transform\s*=\s*`translate\(').hasMatch(js), isTrue,
+        reason: '用 transform: translate(x, y) 摆到目标列/行位置');
+    expect(RegExp(r'Math\.max\(\.\.\.heights\)').hasMatch(js), isTrue,
+        reason: '容器高度取最高列，避免绝对定位后容器塌陷');
+  });
+
+  test('单列 / 单卡回落 CSS 兜底：cols<=1 或 items<=1 时清 inline', () {
+    expect(
+        RegExp(r'cols\s*<=\s*1\s*\|\|\s*items\.length\s*<=\s*1').hasMatch(js),
+        isTrue,
+        reason: '单列或单卡不做 masonry，清 inline 回落 CSS grid/block（不破坏单卡满宽 / 单列纵堆）');
+    expect(js.contains('function resetMasonryBody('), isTrue,
+        reason: '回落时必须清掉 position/width/transform/height 等 inline，让 CSS 接管');
+  });
+
+  test('高度变化用 ResizeObserver 兜底（<details> 折叠 / 图片异步 / ruby / 字体）', () {
+    expect(js.contains('new ResizeObserver('), isTrue,
+        reason: '卡片高度变化必须由 ResizeObserver 捕捉重排，不能只靠一次性布局');
+    // 只观察卡片、不观察容器：容器随 masonry 改 height 会自触发死循环。
+    expect(RegExp(r'function observeMasonryTargets\(').hasMatch(js), isTrue,
+        reason: '观察目标集中在 observeMasonryTargets，只挂卡片避免容器 height 自触发死循环');
+  });
+
+  test('只对词典容器排版，不误抓 frequency / pitch 的 category-body', () {
+    expect(js.contains('.glossary-section > .category-body'), isTrue,
+        reason: 'masonry 容器必须限定 .glossary-section > .category-body，'
+            'frequency-section / pitch-section 也用 .category-body、不能被 masonry 抓走');
+  });
+
+  test('渲染 + 增量都触发重排，且宿主可外部触发（改列数时）', () {
+    expect(js.contains('window.hoshiRelayoutDictionaries'), isTrue,
+        reason: '暴露 hoshiRelayoutDictionaries 供宿主改列数后重排 / 外部触发');
+    // _firePopupRendered 是首条 + 其余条两次都会调的收尾钩子。
+    final int fireAt = js.indexOf('function _firePopupRendered(');
+    expect(fireAt, isNonNegative);
+    final int fireEnd = js.indexOf('\n}', fireAt);
+    expect(fireEnd, greaterThan(fireAt));
+    expect(js.substring(fireAt, fireEnd).contains('hoshiRelayoutDictionaries'),
+        isTrue,
+        reason: '渲染收尾 _firePopupRendered 必须重排 masonry（覆盖首条 + 其余条）');
+  });
+}

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -619,31 +619,30 @@
     background: transparent;
 }
 
-/* TODO-1325 #7（按用户 Niratan「卡片」决策，超越 TODO-877 的扁平化）：每部词典的义项块
-   (.glossary-group) 做成「玻璃卡片」——圆角(走 --hibiki-radius-card token，与弹窗其余卡片
-   统一) + 分层投影(近距 1px 贴地 + 远距柔性扩散) + 顶部内高光(inset 白线)营造玻璃质感；
-   展开/收起三角(下方 TODO-1337 纯 CSS 边框三角)作卡片头。皮肤纯 CSS，不改 DOM/JS，四端
-   (in-app 弹窗 + 两 vendor)共用一处。TODO-776 的 grid 行距模型不变：行距仍走 margin-top
-   (grid 不折叠 item margin，父只设 column-gap)，padding 是 border-box 内边距不撑 grid track。
-   暗色变体降内高光、加深投影。 */
+/* 按用户「照抄 Niratan」决策（取代 TODO-1325 #7 的玻璃卡皮肤）：每部词典的义项块
+   (.glossary-group) 逐字对齐 Niratan Features/Popup/popup.css `.glossary-group` ——
+   描边卡而非填充玻璃卡：1px 半透明描边(rgba 0,0,0,.14) + 顶部 inset 白高光 + 薄贴地投影，
+   无 background 填充，观感更扁平、与 Niratan 一致。padding 6px 8px、radius 8px 亦照抄
+   (Niratan 的 calc(8px*--popup-scale) 在 Hibiki 走 documentElement.zoom 整体缩放，故直接 8px)。
+   皮肤纯 CSS，不改 DOM/JS，四端(in-app 弹窗 + 两 vendor)共用一处。TODO-776 的 grid 行距模型不变：
+   行距仍走 margin-top(grid 不折叠 item margin，父只设 column-gap)，padding 是 border-box 内边距
+   不撑 grid track。暗色变体：描边转白(rgba 255,255,255,.09) + 加深贴地投影(照抄 Niratan 暗色分支)。 */
 .glossary-group {
     position: relative;
     margin-top: 5px;
-    padding: 8px 10px;
-    border-radius: var(--hibiki-radius-card, 10px);
-    background: var(--surface-container);
+    min-width: 0;
+    padding: 6px 8px;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 0, 0, 0.14);
     box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.12),
-        0 2px 8px rgba(0, 0, 0, 0.08),
-        inset 0 1px 0 rgba(255, 255, 255, 0.35);
+        inset 0 0 0 1px rgba(255, 255, 255, 0.42),
+        0 0 0 1px rgba(255, 255, 255, 0.22),
+        0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 #entries-container[data-theme="dark"] .glossary-group {
-    background: var(--surface-container-high);
-    box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.5),
-        0 3px 10px rgba(0, 0, 0, 0.35),
-        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.09);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.36);
 }
 
 .glossary-group > summary {

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -641,31 +641,30 @@ html[data-theme="dark"] .gloss-image-link[data-appearance="monochrome"] img.glos
     background: transparent;
 }
 
-/* TODO-1325 #7（按用户 Niratan「卡片」决策，超越 TODO-877 的扁平化）：每部词典的义项块
-   (.glossary-group) 做成「玻璃卡片」——圆角(走 --hibiki-radius-card token，与弹窗其余卡片
-   统一) + 分层投影(近距 1px 贴地 + 远距柔性扩散) + 顶部内高光(inset 白线)营造玻璃质感；
-   展开/收起三角(下方 TODO-1337 纯 CSS 边框三角)作卡片头。皮肤纯 CSS，不改 DOM/JS，四端
-   (in-app 弹窗 + 两 vendor)共用一处。TODO-776 的 grid 行距模型不变：行距仍走 margin-top
-   (grid 不折叠 item margin，父只设 column-gap)，padding 是 border-box 内边距不撑 grid track。
-   暗色变体降内高光、加深投影。 */
+/* 按用户「照抄 Niratan」决策（取代 TODO-1325 #7 的玻璃卡皮肤）：每部词典的义项块
+   (.glossary-group) 逐字对齐 Niratan Features/Popup/popup.css `.glossary-group` ——
+   描边卡而非填充玻璃卡：1px 半透明描边(rgba 0,0,0,.14) + 顶部 inset 白高光 + 薄贴地投影，
+   无 background 填充，观感更扁平、与 Niratan 一致。padding 6px 8px、radius 8px 亦照抄
+   (Niratan 的 calc(8px*--popup-scale) 在 Hibiki 走 documentElement.zoom 整体缩放，故直接 8px)。
+   皮肤纯 CSS，不改 DOM/JS，四端(in-app 弹窗 + 两 vendor)共用一处。TODO-776 的 grid 行距模型不变：
+   行距仍走 margin-top(grid 不折叠 item margin，父只设 column-gap)，padding 是 border-box 内边距
+   不撑 grid track。暗色变体：描边转白(rgba 255,255,255,.09) + 加深贴地投影(照抄 Niratan 暗色分支)。 */
 .glossary-group {
     position: relative;
     margin-top: 5px;
-    padding: 8px 10px;
-    border-radius: var(--hibiki-radius-card, 10px);
-    background: var(--surface-container);
+    min-width: 0;
+    padding: 6px 8px;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 0, 0, 0.14);
     box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.12),
-        0 2px 8px rgba(0, 0, 0, 0.08),
-        inset 0 1px 0 rgba(255, 255, 255, 0.35);
+        inset 0 0 0 1px rgba(255, 255, 255, 0.42),
+        0 0 0 1px rgba(255, 255, 255, 0.22),
+        0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 html[data-theme="dark"] .glossary-group {
-    background: var(--surface-container-high);
-    box-shadow:
-        0 1px 2px rgba(0, 0, 0, 0.5),
-        0 3px 10px rgba(0, 0, 0, 0.35),
-        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.09);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.36);
 }
 
 .glossary-group > summary {

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -2679,7 +2679,11 @@ window._renderGeneration = 0;
 // buildEntryElement / postProcessRuby throws. Without this a render exception
 // would swallow the `popupRendered` signal forever, leaving a cold nested popup
 // permanently hidden (pending reveal). Fired exactly once per render.
-function _firePopupRendered() {
+function _reportPopupHeight() {
+    // 把当前内容高度报给宿主（宿主据此给弹窗窗口/浮层定尺、并驱动 reveal 门）。
+    // 抽成独立函数是因为 masonry 铺完后容器高度会变（紧密堆比行对齐 grid 更矮），必须
+    // 复报一次，否则宿主拿的是 masonry 前的旧高度、弹窗底部会留空白。只报高度、不触发
+    // relayout，避免 _firePopupRendered→relayout→report→relayout 的死循环。
     try {
         window.flutter_inappwebview.callHandler('popupRendered',
             __hibikiScrollHeight(),
@@ -2687,6 +2691,143 @@ function _firePopupRendered() {
     } catch (e) {
         console.error('[popup] popupRendered callHandler failed', e);
     }
+}
+
+function _firePopupRendered() {
+    _reportPopupHeight();
+    // 词典方框排列：渲染完成后（含首条 + 其余条两次调用）铺 masonry。masonry 在下一帧
+    // RAF 里跑，跑完会自行 _reportPopupHeight() 复报修正后的高度。
+    window.hoshiRelayoutDictionaries();
+}
+
+// ===== N 列 masonry 词典方框排列（照抄 Niratan Features/Popup/popup.js layoutMasonry，
+//        一般化到 Hibiki 的 --dict-columns N 列）=====
+// develop 原本用 CSS grid `.glossary-section > .category-body`(repeat(--dict-columns,1fr))
+// 行对齐排列：同一行的词典卡片被该行最高者顶到同一水平线，矮卡片下方留空隙（Niratan 的
+// 紧密堆则无此空隙）。这里在 grid 之上叠一层运行时 masonry——cols>1 且多卡时用 inline-style
+// 把每张卡片绝对定位进「当前最矮的那一列」（最短列打包，无空隙，Pinterest 式），cols<=1 或
+// 单卡时清掉 inline 回落到 CSS grid/block。CSS 规则原样保留作「无 JS 兜底」，故所有现有 grid
+// 守卫测试不受影响。高度变化（<details> 展开/收起、图片异步加载、ruby、字体替换）由挂在每张
+// 卡片上的 ResizeObserver 捕捉重排（不依赖 toggle 事件跨 shadow 边界）；宽度变化走 resize。
+const HAS_NATIVE_MASONRY = (() => {
+    try { return CSS.supports('display', 'grid-lanes'); } catch (e) { return false; }
+})();
+let masonryRaf = null;
+let masonryObserver = null;
+
+// masonry 是叠在 CSS grid 之上的渐进增强：需要 ResizeObserver（捕捉卡片高度变化重排）
+// 与 requestAnimationFrame（合帧）。环境不具备（老 WebView / 非浏览器测试壳）时整体不做
+// masonry，静默回落到 CSS grid 行对齐布局——不崩、不报错，只是没有紧密堆。
+function masonrySupported() {
+    return typeof requestAnimationFrame === 'function'
+        && typeof ResizeObserver === 'function';
+}
+
+function dictColumns() {
+    // --dict-columns 由宿主注入到 documentElement（app_model / dictionary_popup_webview /
+    // popup_settings_injection 三面同源），即使弹窗挂在 shadow root 也从此处读。
+    const raw = getComputedStyle(document.documentElement).getPropertyValue('--dict-columns');
+    const n = Number.parseInt(raw, 10);
+    return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+function masonryGap() {
+    // 与 popup.css `.glossary-section > .category-body { column-gap: 6px }` 同源。
+    return 6;
+}
+
+function masonryBodies() {
+    const root = __hibikiContainer();
+    if (!root || typeof root.querySelectorAll !== 'function') return [];
+    // 只抓词典义项容器；frequency-section / pitch-section 也用 .category-body，不能误抓。
+    return [...root.querySelectorAll('.glossary-section > .category-body')];
+}
+
+function resetMasonryBody(body) {
+    body.style.position = '';
+    body.style.display = '';
+    body.style.height = '';
+    [...body.children].forEach(item => {
+        item.style.position = '';
+        item.style.left = '';
+        item.style.top = '';
+        item.style.width = '';
+        item.style.marginTop = '';
+        item.style.transform = '';
+    });
+}
+
+function layoutMasonry() {
+    if (HAS_NATIVE_MASONRY) return; // 浏览器原生 masonry 时交给 CSS（未来分支）
+    const cols = dictColumns();
+    const gap = masonryGap();
+    masonryBodies().forEach(body => {
+        const items = [...body.children].filter(c => c.classList.contains('glossary-group'));
+        // 单列 / 单卡：不做 masonry，清 inline 回落 CSS（单卡满宽、单列纵向堆叠 + CSS margin-top）。
+        if (cols <= 1 || items.length <= 1) {
+            resetMasonryBody(body);
+            return;
+        }
+        body.style.position = 'relative';
+        body.style.display = 'block';
+        const columnWidth = (body.clientWidth - (cols - 1) * gap) / cols;
+        const heights = new Array(cols).fill(0);
+        items.forEach(item => {
+            let c = 0;
+            for (let i = 1; i < cols; i++) {
+                if (heights[i] < heights[c]) c = i; // 当前最矮列
+            }
+            item.style.position = 'absolute';
+            item.style.left = '0';
+            item.style.top = '0';
+            item.style.marginTop = '0';
+            item.style.width = `${columnWidth}px`;
+            item.style.transform = `translate(${c * (columnWidth + gap)}px, ${heights[c]}px)`;
+            // 读 offsetHeight 前已设 width，浏览器按目标列宽回流后再量高。
+            heights[c] += item.offsetHeight + gap;
+        });
+        body.style.height = `${Math.max(...heights) - gap}px`;
+    });
+}
+
+function observeMasonryTargets() {
+    if (HAS_NATIVE_MASONRY || !masonrySupported()) return;
+    if (!masonryObserver) {
+        masonryObserver = new ResizeObserver(scheduleMasonry);
+    }
+    // 只观察卡片本身（内容高度变化），不观察容器（避免 body.style.height 自触发死循环）；
+    // 容器宽度变化由 window resize 覆盖。observe 同一元素幂等，增量新增卡片可安全重观察。
+    masonryBodies().forEach(body => {
+        [...body.children].forEach(item => {
+            if (item.classList.contains('glossary-group')) masonryObserver.observe(item);
+        });
+    });
+}
+
+function scheduleMasonry() {
+    if (HAS_NATIVE_MASONRY || !masonrySupported() || masonryRaf) return;
+    masonryRaf = requestAnimationFrame(() => {
+        masonryRaf = null;
+        layoutMasonry();
+        // 铺完复报高度（容器高度已由 masonry 改写），让宿主给弹窗重新定尺。
+        _reportPopupHeight();
+    });
+}
+
+// 宿主改列数 / 外部触发时可调；渲染钩子已在 _firePopupRendered / updatePopupIncremental 里调。
+window.hoshiRelayoutDictionaries = () => {
+    observeMasonryTargets();
+    scheduleMasonry();
+};
+
+// 顶层注册用 typeof 守卫：真实浏览器一定有 addEventListener；非浏览器测试壳缺此 API 时
+// 跳过注册即可（masonry 本就会被 masonrySupported 门控掉）。
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+    window.addEventListener('resize', scheduleMasonry);
+}
+// <details> 展开/收起改高度：capture 阶段兜底（ResizeObserver 已是主路，故 shadow 边界不影响正确性）。
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+    document.addEventListener('toggle', scheduleMasonry, true);
 }
 
 // TODO-1030 M0 — the app-external global-lookup capture (Windows UIA) hands the
@@ -2946,6 +3087,9 @@ window.updatePopupIncremental = function() {
     window._renderedGlossaryCounts = entries.map(e => e.glossaries.length);
     window._entryDomIndex = rebuiltDomIndex;
     applyCustomCSS();
+
+    // 增量追加了新的词典方框，重排 masonry 并观察新卡片。
+    window.hoshiRelayoutDictionaries();
 
     window.flutter_inappwebview.callHandler('popupRendered',
         __hibikiScrollHeight(),


### PR DESCRIPTION
## 背景
用户要「抄 Niratan（W1ght/Niratan，Hoshi Reader 派生）查词弹窗的词典方框」。develop 已有方框堆叠（TODO-1325 玻璃卡），但那是 Hibiki 自制的**填充玻璃卡**，与 Niratan 本家的**描边卡**观感不同。

## 本 PR（① 方框样式）
逐字对齐 Niratan `Features/Popup/popup.css` 的 `.glossary-group`：
- 1px 半透明描边(rgba 0,0,0,.14) + 8px 圆角 + 顶部 inset 白高光 + 薄贴地投影
- **去掉** develop 的 `--surface-container` 填充与多层玻璃投影 → 更扁平、与 Niratan 一致
- 暗色变体：描边转白(rgba 255,255,255,.09) + 加深贴地投影（照抄 Niratan 暗色分支）
- `padding 6px 8px` / `radius 8px`（Niratan `calc(8px*--popup-scale)` 在 Hibiki 走 documentElement.zoom，故直接 8px）

改写 `popup_dict_card_guard_test` 锁描边卡不变量（有 border / 无 background）；TODO-776 grid 间距模型、`--dict-columns`、`align-items:start`(BUG-683)、`.dict-label` 等既有不变量与测试**全部保留**。

## 验证
`flutter test` 相关守卫 50/50 通过；`dart format` / `flutter analyze` 干净。纯 CSS 皮肤，四端(in-app + 两 vendor)共用一处。

## 未做（② 方框排列 masonry）——待用户拍板
Niratan 多词典用 **2 列 JS masonry**（最短列打包 + ResizeObserver），develop 用 CSS grid `--dict-columns` 行对齐。用户还要「抄排列」。此块是 JS 引擎移植，**推翻 TODO-1325 明确拒绝 masonry 的决定**、动已发布的 `--dict-columns` 三面接线、且运行时布局必须真机复测，故拆出单独跟进。