### PR TITLE
fix(sync): 隐藏互联客户端令牌到「手动填写」折叠，去掉困惑的令牌说明 (TODO-1330)

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 38012 (2236 per locale)
 ///
-/// Built on 2026-07-10 at 08:07 UTC
+/// Built on 2026-07-10 at 11:30 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2895,10 +2895,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       '${lang} (translated)';
   String get video_subtitle_youtube_empty => 'This caption track has no text';
   String get sync_client_token => 'Peer access token';
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
   String get theme_eyecare => 'Eye Care';
   String get reader_theme_eyecare => 'Eye Care';
   String get video_settings_cat_audio => 'Audio';
@@ -2968,6 +2964,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Network error. Check your connection and try again.';
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  String get sync_client_connected => 'Connected';
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -7906,12 +7904,6 @@ class _StringsAr extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -8032,6 +8024,10 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -13093,12 +13089,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -13219,6 +13209,10 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -18297,12 +18291,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -18423,6 +18411,10 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -23520,12 +23512,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -23646,6 +23632,10 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -28645,12 +28635,6 @@ class _StringsId extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -28771,6 +28755,10 @@ class _StringsId extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -33831,12 +33819,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -33957,6 +33939,10 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -38743,12 +38729,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -38869,6 +38849,10 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -43659,12 +43643,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -43785,6 +43763,10 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -48813,12 +48795,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -48939,6 +48915,10 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -53990,12 +53970,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -54116,6 +54090,10 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -59142,12 +59120,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -59268,6 +59240,10 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -64207,12 +64183,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -64333,6 +64303,10 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -69327,12 +69301,6 @@ class _StringsTr extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -69453,6 +69421,10 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -74422,12 +74394,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => 'Eye Care';
   @override
   String get reader_theme_eyecare => 'Eye Care';
@@ -74548,6 +74514,10 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -79185,12 +79155,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get sync_client_token => '对端访问令牌';
   @override
-  String get sync_client_token_hint =>
-      '配对成功后由对端自动签发并填入；这是对端发给本设备的专属令牌，与对端服务器显示的共享令牌不同，两者都能连接。';
-  @override
-  String get sync_server_token_self_hint =>
-      '本设备的服务器共享令牌；已配对的设备会另获各自的专属令牌，此共享令牌也可手动填入连接。';
-  @override
   String get theme_eyecare => '护眼';
   @override
   String get reader_theme_eyecare => '护眼';
@@ -79298,6 +79262,10 @@ class _StringsZhCn extends _StringsEn {
   String get video_danmaku_manual_network_error => '网络错误，请检查连接后重试。';
   @override
   String get video_danmaku_manual_server_error => '搜索失败，请稍后重试。';
+  @override
+  String get sync_client_connected => '已连接';
+  @override
+  String get sync_client_token_manual => '手动填写令牌';
 }
 
 // Path: retrying_in
@@ -83986,12 +83954,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get sync_client_token => 'Peer access token';
   @override
-  String get sync_client_token_hint =>
-      'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-  @override
-  String get sync_server_token_self_hint =>
-      'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
-  @override
   String get theme_eyecare => '護眼';
   @override
   String get reader_theme_eyecare => '護眼';
@@ -84112,6 +84074,10 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_danmaku_manual_server_error =>
       'Search failed. Try again later.';
+  @override
+  String get sync_client_connected => 'Connected';
+  @override
+  String get sync_client_token_manual => 'Enter token manually';
 }
 
 // Path: retrying_in
@@ -88614,10 +88580,6 @@ extension on _StringsEn {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -88722,6 +88684,10 @@ extension on _StringsEn {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -93184,10 +93150,6 @@ extension on _StringsAr {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -93292,6 +93254,10 @@ extension on _StringsAr {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -97776,10 +97742,6 @@ extension on _StringsDe {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -97884,6 +97846,10 @@ extension on _StringsDe {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -102366,10 +102332,6 @@ extension on _StringsEs {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -102474,6 +102436,10 @@ extension on _StringsEs {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -106963,10 +106929,6 @@ extension on _StringsFr {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -107071,6 +107033,10 @@ extension on _StringsFr {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -111540,10 +111506,6 @@ extension on _StringsId {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -111648,6 +111610,10 @@ extension on _StringsId {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -116134,10 +116100,6 @@ extension on _StringsIt {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -116242,6 +116204,10 @@ extension on _StringsIt {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -120686,10 +120652,6 @@ extension on _StringsJa {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -120794,6 +120756,10 @@ extension on _StringsJa {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -125241,10 +125207,6 @@ extension on _StringsKo {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -125349,6 +125311,10 @@ extension on _StringsKo {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -129828,10 +129794,6 @@ extension on _StringsNl {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -129936,6 +129898,10 @@ extension on _StringsNl {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -134412,10 +134378,6 @@ extension on _StringsPtBr {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -134520,6 +134482,10 @@ extension on _StringsPtBr {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -139000,10 +138966,6 @@ extension on _StringsRu {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -139108,6 +139070,10 @@ extension on _StringsRu {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -143570,10 +143536,6 @@ extension on _StringsTh {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -143678,6 +143640,10 @@ extension on _StringsTh {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -148149,10 +148115,6 @@ extension on _StringsTr {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -148257,6 +148219,10 @@ extension on _StringsTr {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -152722,10 +152688,6 @@ extension on _StringsVi {
         return 'This caption track has no text';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return 'Eye Care';
       case 'reader_theme_eyecare':
@@ -152830,6 +152792,10 @@ extension on _StringsVi {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }
@@ -157261,10 +157227,6 @@ extension on _StringsZhCn {
         return '该字幕轨没有文字';
       case 'sync_client_token':
         return '对端访问令牌';
-      case 'sync_client_token_hint':
-        return '配对成功后由对端自动签发并填入；这是对端发给本设备的专属令牌，与对端服务器显示的共享令牌不同，两者都能连接。';
-      case 'sync_server_token_self_hint':
-        return '本设备的服务器共享令牌；已配对的设备会另获各自的专属令牌，此共享令牌也可手动填入连接。';
       case 'theme_eyecare':
         return '护眼';
       case 'reader_theme_eyecare':
@@ -157369,6 +157331,10 @@ extension on _StringsZhCn {
         return '网络错误，请检查连接后重试。';
       case 'video_danmaku_manual_server_error':
         return '搜索失败，请稍后重试。';
+      case 'sync_client_connected':
+        return '已连接';
+      case 'sync_client_token_manual':
+        return '手动填写令牌';
       default:
         return null;
     }
@@ -161805,10 +161771,6 @@ extension on _StringsZhHk {
         return '該字幕軌沒有文字';
       case 'sync_client_token':
         return 'Peer access token';
-      case 'sync_client_token_hint':
-        return 'Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer\'s shared server token, and both can connect.';
-      case 'sync_server_token_self_hint':
-        return 'This device\'s shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.';
       case 'theme_eyecare':
         return '護眼';
       case 'reader_theme_eyecare':
@@ -161913,6 +161875,10 @@ extension on _StringsZhHk {
         return 'Network error. Check your connection and try again.';
       case 'video_danmaku_manual_server_error':
         return 'Search failed. Try again later.';
+      case 'sync_client_connected':
+        return 'Connected';
+      case 'sync_client_token_manual':
+        return 'Enter token manually';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang (translated)",
   "video_subtitle_youtube_empty": "This caption track has no text",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "Eye Care",
   "reader_theme_eyecare": "Eye Care",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang（翻译）",
   "video_subtitle_youtube_empty": "该字幕轨没有文字",
   "sync_client_token": "对端访问令牌",
-  "sync_client_token_hint": "配对成功后由对端自动签发并填入；这是对端发给本设备的专属令牌，与对端服务器显示的共享令牌不同，两者都能连接。",
-  "sync_server_token_self_hint": "本设备的服务器共享令牌；已配对的设备会另获各自的专属令牌，此共享令牌也可手动填入连接。",
   "theme_eyecare": "护眼",
   "reader_theme_eyecare": "护眼",
   "video_settings_cat_audio": "音频",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "搜索",
   "video_danmaku_manual_no_result": "未找到匹配的番剧。",
   "video_danmaku_manual_network_error": "网络错误，请检查连接后重试。",
-  "video_danmaku_manual_server_error": "搜索失败，请稍后重试。"
+  "video_danmaku_manual_server_error": "搜索失败，请稍后重试。",
+  "sync_client_connected": "已连接",
+  "sync_client_token_manual": "手动填写令牌"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2189,8 +2189,6 @@
   "video_subtitle_youtube_translated": "$lang（翻譯）",
   "video_subtitle_youtube_empty": "該字幕軌沒有文字",
   "sync_client_token": "Peer access token",
-  "sync_client_token_hint": "Auto-filled after pairing: a device-specific token the peer issued to this device. It differs from the peer's shared server token, and both can connect.",
-  "sync_server_token_self_hint": "This device's shared server token. Paired devices each get their own device-specific token; this shared token can also be entered manually to connect.",
   "theme_eyecare": "護眼",
   "reader_theme_eyecare": "護眼",
   "video_settings_cat_audio": "Audio",
@@ -2242,5 +2240,7 @@
   "video_danmaku_manual_search_action": "Search",
   "video_danmaku_manual_no_result": "No matching anime found.",
   "video_danmaku_manual_network_error": "Network error. Check your connection and try again.",
-  "video_danmaku_manual_server_error": "Search failed. Try again later."
+  "video_danmaku_manual_server_error": "Search failed. Try again later.",
+  "sync_client_connected": "Connected",
+  "sync_client_token_manual": "Enter token manually"
 }

--- a/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
@@ -455,24 +455,44 @@ class _HibikiServerConfigWidgetState extends State<_HibikiServerConfigWidget>
             ),
           ),
           const SizedBox(height: 12),
-          HibikiTextField(
-            controller: _tokenController,
-            focusNode: _tokenFocus,
-            // TODO-1330 ④：客户端令牌框显示的是「连接对端所用的令牌」，配对成功后由
-            // host 自动签发并填入。host 接线 onPeerPaired 且本机上报 clientDeviceId 时，
-            // host 会铸造一枚 per-peer token（≠ host 端显示的共享 sync_server_password，
-            // 见 hibiki_sync_server.dart _issuePeerToken），_validateAuth 同时受理共享
-            // 令牌与任一 per-peer token。故两端「访问令牌」天生不同——用独立标签 + 说明
-            // 消除「明明用互联连接了、两个数为何不一样」的困惑。
-            labelText: t.sync_client_token,
-            onChanged: (_) => _saveToken(),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            t.sync_client_token_hint,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
+          // TODO-1330 ④（改）：客户端令牌在配对成功后由 host 自动签发并填入，值是 host 按
+          // 设备铸造的 per-peer token，与 host 面板显示的共享令牌天生不同。旧设计把这枚
+          // 原始令牌当成一个显眼数字摆出来、再加说明解释「为何两端不一样」，反而让用户困惑。
+          // 现在改为：已连接就只显示状态，原始令牌收进「手动填写」折叠项——手动粘贴对端令牌
+          // 连接的回退路径仍在，只是不再和 host 端令牌摆成两个对不上的数字。per-peer 签发/
+          // 鉴权/按设备吊销等后端安全机制一概不动。
+          if (_tokenController.text.trim().isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                children: <Widget>[
+                  Icon(Icons.check_circle_outline,
+                      size: 18, color: theme.colorScheme.primary),
+                  const SizedBox(width: 6),
+                  Text(
+                    t.sync_client_connected,
+                    style: theme.textTheme.bodySmall
+                        ?.copyWith(color: theme.colorScheme.primary),
+                  ),
+                ],
+              ),
             ),
+          ExpansionTile(
+            tilePadding: EdgeInsets.zero,
+            childrenPadding: EdgeInsets.zero,
+            title: Text(
+              t.sync_client_token_manual,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+            children: <Widget>[
+              HibikiTextField(
+                controller: _tokenController,
+                focusNode: _tokenFocus,
+                labelText: t.sync_client_token,
+                onChanged: (_) => _saveToken(),
+              ),
+            ],
           ),
           const SizedBox(height: 12),
           Align(
@@ -1012,17 +1032,6 @@ class _ServerModeWidgetState extends State<_ServerModeWidget> {
                     fontFamily: 'monospace',
                   ),
               maxLines: 2,
-            ),
-            const SizedBox(height: 4),
-            // TODO-1330 ④：点明这是「本设备的服务器共享令牌」。配对成功的设备会另获
-            // 各自的 per-peer token（见下方已配对设备列表 + hibiki_sync_server
-            // _issuePeerToken），故 client 端令牌框显示的值与此不同；此共享令牌仍可被
-            // 手动填入连接。与客户端「对端访问令牌」语义不同，避免用户误以为两端应相同。
-            Text(
-              t.sync_server_token_self_hint,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
             ),
             const SizedBox(height: 8),
             Row(

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.0.1+623
+version: 1.0.1+624
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/sync/interconnect_token_display_guard_test.dart
+++ b/hibiki/test/sync/interconnect_token_display_guard_test.dart
@@ -4,17 +4,20 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'sync_settings_schema_source_corpus.dart';
 
-/// TODO-1330 ④ 源码守卫：互联「访问令牌」两端显示的语义区分不被回退。
+/// TODO-1330 ④ 源码守卫：互联「访问令牌」两端显示不再摆出两个对不上的数字。
 ///
 /// 根因是 UI 呈现困惑，不是功能 bug：host 端显示的是共享服务器令牌
-/// (getServerPassword / sync_server_password)；client 端令牌框显示的是配对时 host 按
-/// 设备铸造的 per-peer token (getHibikiClientToken，见 hibiki_sync_server
-/// _issuePeerToken)。二者天生不同、且 _validateAuth 同时受理——用户见「明明用互联
-/// 连接了、两端访问令牌不一样」而困惑。修复只加独立标签 + 说明文案，不改任何令牌取值
-/// 或鉴权。本守卫钉住：
-///  (1) client 令牌框用独立标签 sync_client_token（不再复用 sync_server_token），带说明
-///      sync_client_token_hint；
-///  (2) server 令牌显示保留 sync_server_token 并带说明 sync_server_token_self_hint；
+/// (getServerPassword / sync_server_password)；client 端存的是配对时 host 按设备铸造的
+/// per-peer token (getHibikiClientToken)。二者天生不同、且 _validateAuth 同时受理——过去
+/// 把 client 令牌当成一个显眼数字摆出来 + 加说明解释「为何两端不一样」，反而更困惑。
+///
+/// 现在的修复：client 令牌配对后自动填入，已连接就只显示「已连接」状态，原始令牌收进
+/// 「手动填写」折叠项（ExpansionTile），不再和 host 端令牌摆成两个数字。两条解释性说明
+/// (sync_client_token_hint / sync_server_token_self_hint) 一并删除。令牌取值来源与后端
+/// 鉴权双接受一概不动（Never break userspace）。本守卫钉住：
+///  (1) client 令牌框收进「手动填写」折叠 (ExpansionTile + sync_client_token_manual)，
+///      已连接显示 sync_client_connected 状态，且不再带 sync_client_token_hint 说明；
+///  (2) server 令牌显示保留 sync_server_token，且不再带 sync_server_token_self_hint 说明；
 ///  (3) 令牌取值来源不被对调：client 读 getHibikiClientToken、server 读 getServerPassword；
 ///  (4) server _validateAuth 仍「共享令牌 + 任一 per-peer token」双接受（澄清 UI 不得
 ///      连带砍掉双接受，Never break userspace）。
@@ -35,25 +38,33 @@ void main() {
     return corpus.substring(start, end);
   }
 
-  test('client 令牌框用独立标签 sync_client_token + 说明，不复用 sync_server_token', () {
+  test('client 令牌收进「手动填写」折叠 + 已连接只显示状态，不再带 per-peer 说明文案', () {
     final String corpus = readSyncSettingsSchemaSource();
     final String client = clientWidgetSlice(corpus);
+    // 令牌输入框仍在（手动粘贴对端令牌的回退路径），但收进 ExpansionTile 折叠项。
+    expect(client.contains('ExpansionTile('), isTrue,
+        reason: 'client 令牌框未收进折叠项——原始令牌又被摆成显眼数字会重现困惑。');
+    expect(client.contains('t.sync_client_token_manual'), isTrue,
+        reason: '「手动填写令牌」折叠标题丢失。');
+    expect(client.contains('t.sync_client_connected'), isTrue,
+        reason: '已连接状态提示丢失——应以状态代替摆出原始令牌数字。');
     expect(client.contains('labelText: t.sync_client_token'), isTrue,
-        reason: 'client 令牌框未用独立标签——回退到 sync_server_token 会让两端同名而困惑。');
-    expect(client.contains('t.sync_client_token_hint'), isTrue,
-        reason: 'client 令牌框缺说明文案（per-peer token 与对端共享令牌不同）。');
+        reason: '折叠项内的令牌输入框标签丢失（手填回退路径必须保留）。');
+    // 解释「两端为何不一样」的说明已删除——改用隐藏令牌而非加说明。
+    expect(client.contains('t.sync_client_token_hint'), isFalse,
+        reason: 'client 不应再带解释性说明——隐藏令牌后无需解释差异。');
     expect(client.contains('labelText: t.sync_server_token'), isFalse,
-        reason: 'client 令牌框不得再用 sync_server_token 标签（与 host 端同名即回退）。');
+        reason: 'client 令牌框不得用 sync_server_token 标签。');
   });
 
-  test('server 令牌显示保留 sync_server_token + 独立说明 sync_server_token_self_hint',
+  test('server 令牌显示保留 sync_server_token，且不再带 sync_server_token_self_hint 说明',
       () {
     final String corpus = readSyncSettingsSchemaSource();
     final String server = serverWidgetSlice(corpus);
     expect(server.contains('Text(t.sync_server_token'), isTrue,
         reason: 'server 共享令牌显示标签丢失。');
-    expect(server.contains('t.sync_server_token_self_hint'), isTrue,
-        reason: 'server 令牌缺「本设备共享令牌」说明。');
+    expect(server.contains('t.sync_server_token_self_hint'), isFalse,
+        reason: 'server 令牌不应再带解释性说明——隐藏 client 令牌后无需解释差异。');
   });
 
   test('令牌取值来源不被对调：client 读 getHibikiClientToken、server 读 getServerPassword',
@@ -62,9 +73,9 @@ void main() {
     final String client = clientWidgetSlice(corpus);
     final String server = serverWidgetSlice(corpus);
     expect(client.contains('getHibikiClientToken()'), isTrue,
-        reason: 'client 必须显示 per-peer 客户端令牌（getHibikiClientToken）。');
+        reason: 'client 必须读 per-peer 客户端令牌（getHibikiClientToken）。');
     expect(client.contains('getServerPassword()'), isFalse,
-        reason: 'client 不得显示 host 共享令牌（会把两端令牌显示成相同）。');
+        reason: 'client 不得读 host 共享令牌。');
     expect(server.contains('getServerPassword()'), isTrue,
         reason: 'server 必须显示共享服务器令牌（getServerPassword）。');
     expect(server.contains('getHibikiClientToken()'), isFalse,


### PR DESCRIPTION
## 问题
互联设置里客户端「对端访问令牌」和服务端「访问令牌」显示两个**不一样的数字**，还各配一条解释性说明。根因是 UI 呈现：host 显示的是共享服务器令牌，client 存的是配对时 host 按设备铸造的 per-peer token，二者天生不同；旧设计把这枚原始令牌摆成显眼数字、再加说明解释「为何两端不一样」，反而更困惑。

## 方案（隐藏而非解释）
- 客户端配对成功后**只显示「已连接」状态**，原始令牌收进「手动填写」`ExpansionTile` 折叠——手动粘贴对端令牌连接的回退路径仍在。
- 删除两条解释性说明 `sync_client_token_hint` / `sync_server_token_self_hint`。
- 新增 `sync_client_connected` / `sync_client_token_manual`（17 locale；非中英 locale 为英文占位，待翻译）。

## 不动的部分（Never break userspace）
per-peer 令牌**签发/鉴权/按设备吊销**等后端安全机制、已配对设备列表 UI、DB、已配对的旧设备一概不动。只改客户端 UI 呈现 + 服务端删一条说明。

## 验证
- `flutter analyze` 全量（含 test）**No issues found**。
- `flutter test test/sync test/i18n` **1236 通过**，含：未改的 per-peer 后端 6 测试全绿、i18n 完整性、zh-CN mojibake guard。
- 改写 `interconnect_token_display_guard_test` 钉住新「隐藏令牌」设计，保留 `_validateAuth` 双接受守卫。

> 注：基于 origin/develop 最新（本地主 checkout 落后 ~1094 commit）。版本 `+build` 单调 +1（1.0.1+623 → +624）。