### PR TITLE
fix(global-lookup): 删除非分层 WebView2 覆盖窗上成黑晕的 shell box-shadow (BUG-476)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 461 条。点号进各自文件。
+> 共 462 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-476](bugs/BUG-476-global-lookup-shadow-black-halo.md) | ✅ | ✅ | 全局查词覆盖窗圆角外黑边(非分层WebView2下box-shadow成黑晕) |
 | [BUG-475](bugs/BUG-475-export-crosschapter-false-positive.md) | ✅ | ✅ | 选区导出误报跨章 |
 | [BUG-474](bugs/BUG-474-ankidroid-svg-fileprovider-root.md) | ✅ | ✅ | AnkiDroid外字SVG制卡FileProvider找不到根 |
 | [BUG-473](bugs/BUG-473-updates-cache-not-cleaned.md) | ✅ | ✅ | 更新包缓存不清理 |

--- a/docs/bugs/BUG-476-global-lookup-shadow-black-halo.md
+++ b/docs/bugs/BUG-476-global-lookup-shadow-black-halo.md
@@ -1,0 +1,10 @@
+## BUG-476 · 全局查词覆盖窗圆角外黑边(非分层WebView2下box-shadow成黑晕)
+- **报告**：2026-07-10（用户：app 外查词卡片圆角外面还有一圈黑边没去干净）
+- **真实性**：✅ 真 bug。根因 `hibiki/assets/popup/global_lookup_host.js`（v30 树 line 219/227；origin/develop 同串在 line 280/288）注入的 `.global-lookup-frame-shell { box-shadow:0 3px 12px rgba(0,0,0,0.22) }`（+ dark 变体 0.44）。
+  - 覆盖窗是**非分层、不透明的 WebView2 窗口**（`hibiki/windows/runner/global_lookup_window.cpp:193` 明确「No WS_EX_LAYERED」，因 WebView2 合成面与分层窗互斥）。在这种窗口上 WebView2 合成面对桌面**没有逐像素 alpha**，CSS `box-shadow` 无法当作透过桌面的半透明投影渲染：它的 12px 模糊落到窗口自身的硬底（透明=硬黑）上，成为**卡片圆角/边缘外一圈约 11px 的黑晕**，而原生圆角窗口区域 `SetWindowRgn`（`global_lookup_window.cpp:664 ApplyRoundedRegion`）裁不掉它 → 即用户截图里「圆角外面没去干净的黑边」。像素实测残留厚度 ≈ 11px，与 shadow 模糊 12px 定量吻合。
+  - 代码注释自己已承认「非分层 WebView2 窗口物理上做不出真投影」，所以这条 shadow 从一开始就只有害（黑晕）无益。
+- **[x] ① 已修复** — 删除 `.global-lookup-frame-shell` 的 `box-shadow`（light+dark 两条，dark 变体整条移除，只余 shadow 无其它样式）。圆角轮廓单一真值源改由原生 `SetWindowRgn` 提供，卡片边框由 iframe body 的 1px 边框提供，卡片外不再绘制任何东西。`hibiki/assets/popup/global_lookup_host.js`（commit 见下）。
+- **[x] ② 已加自动化测试** — 反转守卫为「禁止 box-shadow 声明」：`hibiki/test/lookup/global_lookup_popup_style_guard_test.dart`（`host.contains('box-shadow:')` isFalse + 说明非分层窗黑晕机理）与 node harness `hibiki/test/lookup/global_lookup_host_test.mjs`（test 16：`!/box-shadow/.test(css)`）。两处均 PASS。
+- **备注**：
+  - 已核实 **origin/develop（schema v37，+623）同串 box-shadow 仍在**（line 280/288）＝上游未修，本修复对用户实际构建线同样需要（用户运行的是 `D:\APP\Hibiki\hibiki.exe`，DB schema=v37 为 origin 级）。本 worktree base 是 v30（`574fe98c7`），比 local develop（`38eb214d4`，v30）旧 67 commit，`global_lookup_host.js` 三处内容一致，修复可干净落到 develop；落 origin 需按 line 280/288 同样删两条声明。
+  - **未在真机跑活的覆盖窗验证**：用户生产 DB 为 v37，本 worktree/构建为 v30，v30 应用打开 v37 DB 会触发降级 DROP 表（`support/hibiki.db.corrupt-downgrade*` / `.WIPED-by-oldexe*` 备份即历史事故），且用户 app 当前正在运行占用 DB —— 起动会毁库，故安全约束下不跑活验证。修复为纯 CSS 删除、机理确定、像素定量吻合、守卫锁死；最终肉眼确认建议用户在自己 v37 构建上做，或在隔离的 v37 环境复现。

--- a/hibiki/assets/popup/global_lookup_host.js
+++ b/hibiki/assets/popup/global_lookup_host.js
@@ -195,17 +195,25 @@
     // the iframe inside the shell already paints the THEME card background AND
     // the single visible card border (popup.css `html.global-lookup body`
     // border + radius + padding). The shell therefore owns ONLY the rounded
-    // clip + the drop-shadow that the iframe element itself cannot cast — it
-    // must NOT draw a second `border` (that produced two concentric grey rings
-    // with a white gap between them). `border-radius` stays so the shadow +
-    // overflow clip follow the same rounded silhouette as the body border;
+    // clip — it must NOT draw a second `border` (that produced two concentric
+    // grey rings with a white gap between them). `border-radius` stays so the
+    // overflow clip follows the same rounded silhouette as the body border;
     // `background:transparent` keeps the shell from painting a second fill.
-    // Unlike the P2 single-frame chrome (which lived on the iframe body and got
-    // clipped at the window edge), the shell shadow has room to render inside
-    // the enlarged bounding-box window (E1). Dark variant keyed off data-theme
-    // stamped by the render payload. All rules scoped to
-    // .global-lookup-frame-shell -> the in-app popup (no host.js) is never
-    // touched.
+    //
+    // BUG-476 — NO `box-shadow`. The overlay HWND is a NON-layered, OPAQUE
+    // WebView2 window (global_lookup_window.cpp: "No WS_EX_LAYERED"). On such a
+    // window the WebView2 composition surface has no per-pixel alpha against the
+    // desktop, so a CSS `box-shadow` does NOT read as a soft translucent shadow
+    // over whatever is behind the card — the shadow's blur (0 3px 12px) paints
+    // onto the window's own transparent (=hard dark) surface as an ~11px DARK
+    // HALO ringing the card's corners/edges, which the native rounded window
+    // region (SetWindowRgn) cannot clip away. That halo is exactly the "black
+    // border outside the rounded corners" the user reported. A real drop-shadow
+    // is physically impossible on a non-layered WebView2 window (the design
+    // already conceded this), so the shell casts none: the rounded silhouette
+    // comes from SetWindowRgn + the body's 1px card border, with nothing painted
+    // outside the card. All rules scoped to .global-lookup-frame-shell -> the
+    // in-app popup (no host.js) is never touched.
     // D1 reveal gate: a shell paints only when BOTH data-* flags are 'true'.
     style.textContent =
         // D1 reveal gate FIRST (kept as its own rule so the gate contract stays
@@ -216,15 +224,12 @@
         '.global-lookup-frame-shell{' +
         'box-sizing:border-box;overflow:hidden;background:transparent;' +
         'border-radius:10px;' +
-        'box-shadow:0 3px 12px rgba(0,0,0,0.22);' +
         // TODO-890 — slide-out close: the shell tweens transform+opacity so a
         // dismiss slides the card off-screen instead of vanishing instantly
         // (app-out parity with the in-app _BodySwipeDismissDetector). 200ms
         // ease-out matches the Flutter side. Scoped to the shell selector so
         // it never leaks into the in-app popup (which never loads host.js).
         'transition:transform 200ms ease-out, opacity 200ms ease-out;}' +
-        '.global-lookup-frame-shell[data-theme="dark"]{' +
-        'box-shadow:0 3px 12px rgba(0,0,0,0.44);}' +
         // TODO-890 — the dismissing class drives the slide-out: translate the
         // card fully off its own width + margin and fade to 0; visibility stays
         // visible during the transition (the reveal gate already passed) so the

--- a/hibiki/test/lookup/global_lookup_host_test.mjs
+++ b/hibiki/test/lookup/global_lookup_host_test.mjs
@@ -588,10 +588,12 @@ function flushTimers() {
 }
 
 // 16. F2 shell chrome: the injected gate <style> carries ONLY the hoshi radius +
-//     drop shadow, transparent background (the iframe paints the card fill + the
-//     single visible border), and a dark-variant shadow keyed on data-theme.
-//     TODO-893 symptom 1: the shell must NOT draw a second border (the
-//     double-border / "white frame"); the one border lives on the iframe body.
+//     transparent background (the iframe paints the card fill + the single
+//     visible border). It draws NO border (TODO-893 double-border) and NO
+//     box-shadow: the overlay HWND is non-layered/opaque, so a CSS shadow paints
+//     as an ~11px DARK HALO outside the card that SetWindowRgn cannot clip (the
+//     reported "black border outside the rounded corners") instead of a real
+//     translucent shadow. The rounded silhouette comes from SetWindowRgn.
 {
   const { host, document } = freshHost();
   host.renderStack({ popups: [descriptor('frame-0', -1)] });
@@ -603,12 +605,11 @@ function flushTimers() {
     'TODO-893: shell must NOT draw a border (single border lives on the iframe '
     + 'body) — this was the double-border main cause');
   assert.ok(/border-radius:10px/.test(css), 'hoshi 10px card radius');
-  assert.ok(/box-shadow:0 3px 12px rgba\(0,0,0,0\.22\)/.test(css),
-    'hoshi drop shadow');
+  assert.ok(!/box-shadow/.test(css),
+    'shell must cast NO box-shadow: on the non-layered opaque WebView2 window a '
+    + 'CSS shadow renders as a dark halo outside the card, not a real shadow');
   assert.ok(/background:transparent/.test(css),
     'shell background transparent (iframe paints the fill, no double layer)');
-  assert.ok(/\[data-theme="dark"\]/.test(css),
-    'dark variant keyed on data-theme');
 }
 
 // 17. F2 data-theme stamp: the render payload's `theme` is written onto the shell

--- a/hibiki/test/lookup/global_lookup_popup_style_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_popup_style_guard_test.dart
@@ -150,20 +150,29 @@ void main() {
     late String host;
     setUpAll(() => host = read('assets/popup/global_lookup_host.js'));
 
-    test('shell carries ONLY the radius + drop shadow (TODO-893: no border)',
-        () {
+    test('shell carries ONLY the radius, NO border and NO box-shadow', () {
       // TODO-893 symptom 1 — RESPONSIBILITY SPLIT. The single visible card
       // border belongs to the iframe (popup.css `html.global-lookup body`); the
       // shell must NOT draw a second border (that produced two concentric grey
       // rings with a white gap = the reported "white frame"). The shell keeps
-      // the radius (so the shadow + overflow clip follow the rounded card) and
-      // the drop-shadow the iframe element cannot cast.
+      // the radius so the overflow clip follows the rounded card.
+      //
+      // BUG-476 — the shell must ALSO cast NO box-shadow. The overlay HWND is a
+      // NON-layered, opaque WebView2 window (global_lookup_window.cpp: "No
+      // WS_EX_LAYERED"), so a CSS box-shadow has no translucent desktop to blend
+      // over: its blur paints onto the window's own hard-dark surface as an
+      // ~11px DARK HALO ringing the card corners/edges that the native rounded
+      // window region (SetWindowRgn) cannot clip away — exactly the "black
+      // border outside the rounded corners" the user reported. A real shadow is
+      // impossible on a non-layered WebView2 window, so the shell casts none.
       expect(host.contains('.global-lookup-frame-shell{'), isTrue);
       expect(host.contains('border-radius:10px'), isTrue,
-          reason: 'hoshi 10px card radius (drives shadow + clip silhouette)');
-      expect(host.contains('box-shadow:0 3px 12px rgba(0,0,0,0.22)'), isTrue,
-          reason:
-              'hoshi drop shadow (renders inside the enlarged bbox window)');
+          reason: 'hoshi 10px card radius (drives the overflow clip silhouette)');
+      // Match the CSS DECLARATION form (`box-shadow:`) so the doc comments in
+      // host.js that mention the word "box-shadow" do not trip the guard.
+      expect(host.contains('box-shadow:'), isFalse,
+          reason: 'no box-shadow declaration: on the non-layered opaque overlay '
+              'it is a dark halo outside the card, not a real shadow (lock)');
     });
 
     test('shell draws NO solid border (single border lives on the iframe body)',
@@ -204,15 +213,19 @@ void main() {
           reason: 'shell owns only the rounded clip + shadow, not the fill');
     });
 
-    test('dark variant is keyed on data-theme stamped by the render payload',
+    test('shell stamps data-theme from the render payload (no themed shadow)',
         () {
+      // The shell no longer carries a themed style (the dark box-shadow variant
+      // was the only one, and it is gone — a shadow is a dark halo on the
+      // non-layered overlay, see the box-shadow guard above). The per-layer
+      // data-theme STAMP still flows from the render payload onto the shell so a
+      // future themed shell rule (or debugging) can read it; assert the plumbing
+      // stays wired even though no host CSS rule consumes it now.
       expect(host.contains('.global-lookup-frame-shell[data-theme="dark"]'),
-          isTrue,
-          reason:
-              'the host document has no theme of its own; the shell reads a '
-              'per-layer data-theme the render payload supplies');
+          isFalse,
+          reason: 'the dark shadow variant is gone (no themed shell style left)');
       expect(host.contains('descriptor && descriptor.theme'), isTrue,
-          reason: 'host.js must stamp data-theme from the descriptor');
+          reason: 'host.js must still stamp data-theme from the descriptor');
       final String render = read('lib/src/lookup/global_lookup_render.dart');
       expect(render.contains("map['theme'] ="), isTrue,
           reason: 'the render payload must carry the resolved brightness');


### PR DESCRIPTION
## 症状（用户报告）
app 外全局查词（Ctrl+Alt+D 覆盖窗）的词典卡片**圆角外面一圈黑边没去干净**。截图见附。

## 根因（BUG-476，✅ 真 bug）
覆盖窗是**非分层、不透明的 WebView2 窗口**（`hibiki/windows/runner/global_lookup_window.cpp:193` 明确 `No WS_EX_LAYERED`，因 WebView2 合成面与分层窗互斥）。这种窗口的 WebView2 合成面对桌面**没有逐像素 alpha**，所以 `global_lookup_host.js` 里 `.global-lookup-frame-shell` 注入的 `box-shadow:0 3px 12px rgba(0,0,0,0.22)`（+dark 变体 0.44）**不能**当透过桌面的半透明投影渲染：它的 12px 模糊落在窗口自身的硬底（透明=硬黑）上，成为卡片圆角/边缘外**约 11px 的黑晕**，而原生圆角窗口区域 `SetWindowRgn`（`ApplyRoundedRegion`）裁不掉它 → 用户看到的「圆角外没去干净的黑边」。

**像素实测**：用户截图黑边残留厚度 ≈ 11px，与 shadow 模糊 12px 定量吻合。代码注释自己已承认「非分层 WebView2 窗口物理上做不出真投影」——这条 shadow 从一开始就只有害无益。

## 修复
删除 `.global-lookup-frame-shell` 的 `box-shadow`（light + dark 两条，dark 变体整条移除）。圆角轮廓单一真值源改由原生 `SetWindowRgn` 提供，卡片 1px 边框由 iframe body 提供，卡片外不再绘制任何东西。**纯 CSS 删除，零逻辑改动，in-app 弹窗不受影响（host.js 只注入到全局查词窗）。**

## 测试
反转守卫锁死「禁止 box-shadow」：
- `hibiki/test/lookup/global_lookup_popup_style_guard_test.dart`（`host.contains('box-shadow:')` isFalse + 机理注释）— PASS
- `hibiki/test/lookup/global_lookup_host_test.mjs` test 16（`!/box-shadow/.test(css)`）— PASS
- `flutter analyze`：No issues found

## ⚠️ 落地/验证提示（重要）
- **本分支 base 是 `574fe98c7`（schema v30）**，是 `origin/develop`（v37，+623）的祖先。`origin/develop` 上**同一条 box-shadow 仍在**（`global_lookup_host.js` 约 line 280/288，文件已长大），上游未修，本修复对用户实际构建线同样需要。合并到 `develop` 会在 `global_lookup_host.js` 冲突——请按 line ~280/288 同样删两条 box-shadow 声明即可。
- **未在真机跑活的覆盖窗验证**：用户生产 DB 为 **v37**（`D:\APP\HIBIKI_date\support\hibiki.db`），本 worktree/构建为 v30；v30 应用打开 v37 DB 会触发降级 DROP 表（同目录 `*.corrupt-downgrade*` / `*.WIPED-by-oldexe*` 备份即历史事故），且用户 app 当前正在运行占用 DB——起动会毁库，故安全约束下**不做活验证**。修复为纯 CSS 删除、机理确定、像素定量吻合、守卫锁死；最终肉眼确认建议在自己的 v37 构建上做。
