### PR TITLE
fix(reader): hide 每页列数 setting in continuous/VN mode (BUG-634 round 4)

### DIFF
--- a/docs/bugs/BUG-634-page-columns-noop.md
+++ b/docs/bugs/BUG-634-page-columns-noop.md
@@ -62,3 +62,39 @@ Harness：`hibiki/integration_test/desktop_reader_columns_dom_test.dart`
 BUG-679 修复日（2026-07-09），或图多/短内容页的视觉错觉。**未改任何阅读器代码**（避免对已工作
 的几何引回归）；本轮产物 = 真 WebView2 离屏守卫 harness + 本节验证记录。证据：
 `.codex-test/todo1285-webview2-columns-measurement.md`。
+
+### 第四次复诉 · 真正根因 = 连续模式下设置项本就无效却仍可见（2026-07-10）
+
+用户第四次报「每页当前列数功能没法用」（Windows 竖排书截图）。**这次不是构建过旧** —— 直接
+量了用户本机：
+
+- 已安装构建 `debug.7338`（今日 18:23 装到 `D:\APP\Hibiki`）。TODO-1285 三个核心修复的
+  rev-count 为 6873 / 6897 / 6912，BUG-679 图片夹取为 7188，**全部 < 7338** → 用户构建
+  **已含**全部功能修复（7338 之后只有 7339 的真 WebView2 测试守卫与 7359 的 +625 版本 bump，
+  均不改阅读器行为）。前三轮「构建过旧」的结论对本次不成立。
+- 用户生产 DB（schema v37）实测：`ttu_view_mode = **continuous**`、`ttu_page_columns = 4`、
+  `ttu_writing_mode = vertical-rl`。
+
+**真正根因**：`ttu_view_mode = continuous`。CSS multicol 列模型只存在于翻页布局
+（`reader_content_styles.dart` 只把 `columnsCss` 传给 `_paginatedLayoutCss`；
+`_continuousLayoutCss` 连 `columnsCss` 形参都没有，VN 走 `_vnLayoutCss` 亦无）。连续滚动无
+「页」可分列，列数天生无效。但设置页 + 书内快捷面板在**连续/VN 模式下仍把「每页列数」显示为
+可调**，用户设成 4 无反应 → 误判「坏了」。这也是前三轮一直被引向「构建过旧」的元凶：没人查
+用户 DB 的 view_mode，只盯着渲染层。
+
+### 修复（第四轮）
+
+- **[x] ① 根因修复** — 非翻页模式隐藏「每页列数」项：`settings_schema_reading.dart` 加
+  `isPaginated(c) => c.readerSource.ttuViewMode == 'paginated'` 谓词，给
+  `reading_display.page_columns` 项加 `visible: isPaginated`。复用既有 `visible:` 门控惯例
+  （如同组 `isVertical` 门控竖排专属项），设置页与书内快捷面板共用 `section.visibleCopy` →
+  `isVisible` 过滤，一处谓词两处生效。连续/VN 模式下该项不再出现；切回「翻页」即出现并生效。
+  未改任何阅读器几何/CSS 代码（零回归风险）。
+- **[x] ② 自动化测试** — `hibiki/test/settings/page_columns_paginated_only_test.dart`：
+  ① schema 层——从生产 schema 取该项，断言 `paginated` 可见、`continuous`/`vn` 隐藏；
+  ② CSS 层——`pageColumns=4` 竖排下，连续模式生成的 CSS **不含** `column-count`、翻页模式
+  **含** `column-count: 4`，直接证明「连续下确实无效」（隐藏是对的，不是藏掉可工作功能）。
+  3 例全 PASS；`flutter analyze` 干净；相邻 `reader_content_styles_test` /
+  `reader_quick_settings_sheet_static_test` / `settings_redesign_static_test` 128 例无回归。
+- **用户侧即时解法**：阅读器设置 →「布局与显示」→「翻页 / 滚动」切到「翻页」，`每页列数=4`
+  即生效（竖排下每页沿上下分成 4 条列带）。

--- a/hibiki/lib/src/settings/settings_schema_reading.dart
+++ b/hibiki/lib/src/settings/settings_schema_reading.dart
@@ -9,6 +9,12 @@ import 'package:hibiki/utils.dart';
 SettingsDestination buildReadingDestination() {
   bool isVertical(SettingsContext c) =>
       c.readerSource.ttuWritingMode.startsWith('vertical');
+  // 「每页列数」(pageColumns) 只在翻页(paginated)模式生效：CSS multicol 列模型只
+  // 存在于 _paginatedLayoutCss，连续(continuous)滚动与 VN 模式的布局根本不含
+  // column-count / 子列宽（reader_content_styles.dart 只把 columnsCss 传给
+  // _paginatedLayoutCss）。故非翻页模式下把该项隐藏，避免用户改了没反应、误判「功能坏了」。
+  bool isPaginated(SettingsContext c) =>
+      c.readerSource.ttuViewMode == 'paginated';
   return SettingsDestination(
     id: SettingsDestinationId.reading,
     title: t.settings_destination_reading,
@@ -177,6 +183,7 @@ SettingsDestination buildReadingDestination() {
             id: 'reading_display.page_columns',
             title: t.columns_per_page,
             icon: Icons.view_column_outlined,
+            visible: isPaginated,
             min: 0,
             max: 4,
             step: 1,

--- a/hibiki/test/settings/page_columns_paginated_only_test.dart
+++ b/hibiki/test/settings/page_columns_paginated_only_test.dart
@@ -1,0 +1,127 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/media.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/reader/reader_content_styles.dart';
+import 'package:hibiki/src/reader/reader_settings.dart';
+import 'package:hibiki/src/settings/settings_context.dart';
+import 'package:hibiki/src/settings/settings_destination.dart';
+import 'package:hibiki/src/settings/settings_schema.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// BUG-634 第四次复诉根因（连续模式误导）守卫：
+/// 「每页列数」(pageColumns / `reading_display.page_columns`) 的 CSS multicol 列模型
+/// 只存在于翻页(paginated)布局（`reader_content_styles.dart` 只把 columnsCss 传给
+/// `_paginatedLayoutCss`）；连续滚动(continuous)与 VN 模式的布局根本不含 column-count。
+/// 用户在连续模式把它设成 4 却无任何变化 → 误判「功能坏了」（此前三轮 triage 都被引到
+/// 「构建过旧」上，因为没人看用户 DB 的 `ttu_view_mode=continuous`）。
+///
+/// 根因修复 = 非翻页模式隐藏该设置项（`visible: isPaginated`）。本守卫两层：
+/// ① schema 层：该项仅在 `ttu_view_mode == 'paginated'` 时可见；
+/// ② CSS 层：连续模式即便 pageColumns>0 也不发 `column-count`，翻页模式才发——
+///    证明隐藏是对的（连续下它确实无效），而非藏掉一个本可工作的功能。
+void main() {
+  /// 从真实生产 schema 取出「每页列数」这条 stepper（测的是生产配置本身）。
+  SettingsStepperItem pageColumnsItem(SettingsContext settingsContext) {
+    return buildSettingsSchema(settingsContext)
+        .expand((SettingsDestination d) => d.sections)
+        .expand((SettingsSection s) => s.items)
+        .whereType<SettingsStepperItem>()
+        .firstWhere(
+            (SettingsStepperItem i) => i.id == 'reading_display.page_columns');
+  }
+
+  group('page columns visibility (schema)', () {
+    late HibikiDatabase db;
+    late ReaderSettings readerSettings;
+
+    setUp(() async {
+      db = HibikiDatabase.forTesting(NativeDatabase.memory());
+      MediaSource.setDatabase(db);
+      readerSettings = ReaderSettings(db);
+      await readerSettings.refreshFromDb();
+      ReaderHibikiSource.readerSettings = readerSettings;
+    });
+
+    tearDown(() async {
+      ReaderHibikiSource.readerSettings = null;
+      await db.close();
+    });
+
+    testWidgets('shown in paginated, hidden in continuous / vn', (
+      WidgetTester tester,
+    ) async {
+      // 捕获真实 SettingsContext + 生产 schema 里的该项；`isVisible` 只读
+      // `readerSource.ttuViewMode`，不依赖 BuildContext，故可在帧外异步切模式后复查。
+      late SettingsContext settingsContext;
+      late SettingsStepperItem item;
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Consumer(
+              builder: (BuildContext context, WidgetRef ref, _) {
+                settingsContext = SettingsContext(
+                  context: context,
+                  appModel: AppModel(testPlatformServices()),
+                  ref: ref,
+                  readerSource: ReaderHibikiSource.instance,
+                  refresh: () {},
+                );
+                item = pageColumnsItem(settingsContext);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+
+      await readerSettings.setViewMode('paginated');
+      expect(item.isVisible(settingsContext), isTrue,
+          reason: '翻页模式：每页列数生效，必须显示');
+
+      await readerSettings.setViewMode('continuous');
+      expect(item.isVisible(settingsContext), isFalse,
+          reason: '连续滚动无「页」可分列 → 该项无效 → 隐藏，避免误导');
+
+      await readerSettings.setViewMode('vn');
+      expect(item.isVisible(settingsContext), isFalse,
+          reason: 'VN 模式单屏 stage 布局无 multicol → 隐藏');
+    });
+  });
+
+  group('page columns CSS effect (behavior)', () {
+    late HibikiDatabase db;
+    late ReaderSettings settings;
+
+    setUp(() async {
+      db = HibikiDatabase.forTesting(NativeDatabase.memory());
+      settings = ReaderSettings(db);
+      await settings.refreshFromDb();
+      // 用户实测场景：竖排、列数设成 4。
+      await settings.setWritingMode('vertical-rl');
+      await settings.setPageColumns(4);
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('continuous mode ignores pageColumns (no column-count)', () async {
+      await settings.setViewMode('continuous');
+      final String css = ReaderContentStyles.css(settings: settings);
+      expect(css, isNot(contains('column-count')),
+          reason: '连续模式布局不含 multicol，列数无从生效——正是隐藏该设置的理由');
+    });
+
+    test('paginated mode honors pageColumns (column-count: 4)', () async {
+      await settings.setViewMode('paginated');
+      final String css = ReaderContentStyles.css(settings: settings);
+      expect(css, contains('column-count: 4'),
+          reason: '翻页模式必须真发 column-count:4，每页排 4 列');
+    });
+  });
+}


### PR DESCRIPTION
## 背景（BUG-634 第四次复诉）

用户第 4 次报「每页列数没法用」（Windows 竖排书）。前 3 轮 triage 都结论「构建过旧」，但本轮直接量了用户本机 —— **构建不旧**：

- 已装 `debug.7338`（今日 18:23）。TODO-1285 核心修复 rev 6873/6897/6912 + BUG-679 图片 7188 **全部 < 7338**，用户构建已含全部功能修复。
- 用户生产 DB：`ttu_view_mode=**continuous**`、`ttu_page_columns=4`、`vertical-rl`。

## 真正根因

CSS multicol 列模型只存在于翻页布局（`reader_content_styles.dart` 只把 `columnsCss` 传给 `_paginatedLayoutCss`；`_continuousLayoutCss` 无此形参，VN 走 `_vnLayoutCss`）。**连续滚动无「页」可分列，列数天生无效**。但设置页 + 书内快捷面板在连续/VN 模式下仍把「每页列数」显示为可调 → 用户设 4 无反应 → 误判坏了。这也是前 3 轮被引向「构建过旧」的元凶（没人查 view_mode）。

## 修复

- **根因 UX 修复**：给 `reading_display.page_columns` 加 `visible: isPaginated`（`ttuViewMode == 'paginated'`），复用既有 `visible:` 门控惯例。一处谓词经 `section.visibleCopy → isVisible` 同时作用于设置页与书内快捷面板。**未改任何阅读器几何/CSS**（零回归）。
- **测试守卫** `test/settings/page_columns_paginated_only_test.dart`：① schema 可见性（paginated 显示 / continuous+vn 隐藏）；② CSS 行为（连续不发 `column-count`、翻页发 `column-count: 4`）。

## 验证

- 新测试 3 例 PASS；`flutter analyze` 干净；相邻 `reader_content_styles_test` / `reader_quick_settings_sheet_static_test` / `settings_redesign_static_test` 128 例无回归。
- 用户即时解法：设置 → 布局与显示 →「翻页 / 滚动」切「翻页」，每页列数=4 即生效。