### PR TITLE
fix(clip): 导出片段逐句高亮滞后=12fps帧量化 → 提到24fps (BUG-709)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 694 条。点号进各自文件。
+> 共 695 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-709](bugs/BUG-709-clip-highlight-fps-quantization-lag.md) | ✅ | ✅ | 有声书导出片段逐句高亮系统性滞后=12fps帧量化 |
 | [BUG-708](bugs/BUG-708-interconnect-repair-blocked-by-lingering-pin-dialog.md) | ✅ | ✅ | 公网PIN配对取消后重新配对被host常驻PIN弹窗挡成拒绝 |
 | [BUG-707](bugs/BUG-707-selection-capture-clipboard-echo.md) | ✅ | ✅ | 全局查词抓选区的剪贴板回声泄漏进剪贴板查词管线 |
 | [BUG-706](bugs/BUG-706-lookup-popup-blank.md) | ✅ | ✅ | 查词弹窗全空白: __hibikiRoot 函数名与 window.__hibikiRoot marker 冲突 |

--- a/docs/bugs/BUG-709-clip-highlight-fps-quantization-lag.md
+++ b/docs/bugs/BUG-709-clip-highlight-fps-quantization-lag.md
@@ -1,0 +1,15 @@
+## BUG-709 · 有声书导出片段逐句高亮系统性滞后=12fps帧量化
+- **报告**：2026-07-10（用户：导出片段高亮进度慢了。追问确认=高亮单向滞后于声音，且测试用的是最新 develop 构建）
+- **真实性**：✅ 真 bug（纯函数确定性复现帧量化滞后；最终观感需真机导出复测）
+  - 功能：有声书「导出片段」的「多句连读 + 逐句高亮跟随」短视频。帧计划 `hibiki/lib/src/media/audiobook/mining_audio_clip.dart:763` `clipFramePlan` 逐帧算「此刻高亮哪句」，`_synthDynamicClipVideo`（`hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart:1442` 原 `const int fps = 12`）把去重母帧展开成 image2 序列帧 + 音频合成。
+  - 根因 `mining_audio_clip.dart:786`（帧中心采样 `t = globalStartMs + ((i+0.5)*msPerFrame).round()`）：逐句高亮切换被帧率量化到 Δ=1000/fps 的网格。句起点 S 的高亮在视频时刻 `round(S/Δ)·Δ` 出现，与锁定音频对称误差 ≤Δ/2。**12fps 下 Δ≈83ms，约一半 cue 的高亮晚最多 ~42ms**（越过人眼音画同步阈值 ≈45ms 的边缘）→ 用户主观「高亮进度慢/滞后」。
+  - 与播放侧对比确认这是导出独有：播放高亮走 `JsonAlignmentParser.findCueIndex`（`packages/hibiki_audio/lib/src/parsers/json_alignment_parser.dart:102`）按**连续**音频位置判 `startMs<=pos<=endMs`，卡着声音切换、无帧量化；导出侧被离散帧采样量化。`delayMs`（A/V 偏移）对音频窗口与 cue 起止**一致平移**（`audiobook.part.dart:1135-1145`）、帧编号 1:1（`audiobook.part.dart:1523-1540`），均无系统性偏移——唯一残差就是帧量化。
+  - 历史：原始帧起点采样（ceil）→ 最多晚 Δ（迟钝）；TODO-1147 帧尾采样（floor）→ 最多早 Δ（矫枉过正「对不上」）；TODO-1256 帧中心采样（round）→ 对称 ±Δ/2。**三次都只在 ±Δ 里挪、没动 Δ 本身**，故用户在 1256 上仍报滞后。真正的杠杆是 Δ=1000/fps。
+- **[x] ① 已修复** — 导出 fps `12 → 24`（`audiobook.part.dart:1442`，round 采样不变）。最大滞后 Δ/2 从 ≈41.7ms 降到 ≈20.8ms，两个方向都压到不可感知，从根上消除来回震荡。成本极小：母帧按去重 `highlightCueIndex` **逐句只渲一次**（渲染开销 = O(不同句数)，与 fps 无关），提 fps 只多廉价的 JPEG 母帧复制 + ffmpeg mjpeg 帧、不增内存（TODO-1167 流式，任一时刻只驻一帧）。提交：<本轮 commit>。
+  - 范围：只动动态高亮导出路径的 fps 常量；不碰单图静态路径（其 ffmpeg builder 默认 fps=12 仅用于单张静态图，无需高帧率）、不碰采样算法、不碰 cue→offset 链路。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/audiobook/mining_audio_clip_highlight_lateness_test.dart`：
+  - 行为（确定性相位扫描 1..2000ms 驱动真实 `clipFramePlan`）：①「最大滞后 ≤ Δ/2 = 500/fps」对 fps=12/24 均成立；②红→绿「12fps 最大滞后 >40ms（可感知）、24fps ≤21ms（不可感知）」——证明提 fps 把滞后压到阈下。
+  - 源码守卫：动态导出路径 `const int fps = N` 必须 N≥24，防有人改回 12（或更低）令帧量化滞后回归。
+- **备注**：
+  - 验证：`flutter test test/media/audiobook`（含新守卫 + 帧计划/导出/合成/ANR-OOM 回归）全绿；`flutter analyze` 改动文件 No issues。
+  - **待真机**：最终观感需在真实有声书上导出一段多句片段、逐帧比对高亮与朗读声音，确认「滞后」主观消失、且 24fps 未显著拖慢移动端导出耗时 / 撑大文件体积到不可接受。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
@@ -1430,7 +1430,16 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
     required File videoFile,
     required bool isDesktop,
   }) async {
-    const int fps = 12;
+    // BUG-709（用户回访「导出片段高亮进度慢了」根因·帧量化残差）：逐句高亮切换被帧
+    // 率量化到 Δ=1000/fps 的网格上。clipFramePlan 用帧中心（round）采样后，句起点 S 的
+    // 高亮在视频时刻 round(S/Δ)·Δ 出现，与锁定音频对称误差 ≤Δ/2——12fps 下 Δ≈83ms、
+    // 约一半 cue 的高亮晚最多 42ms（>人眼音画同步阈值 ≈45ms 的边缘，主观「滞后」）。
+    // TODO-1147(floor→早)/TODO-1256(round→对称) 三次改采样都只在 ±Δ 里挪，没动 Δ 本身。
+    // 真正的杠杆是 Δ=1000/fps：母帧按去重的 highlightCueIndex 逐句只渲一次（渲染开销
+    // = O(不同句数)，与 fps 无关，见下方 distinctIndices），提 fps 只多廉价的 JPEG 母帧
+    // 复制 + ffmpeg mjpeg 帧，不增内存（TODO-1167 流式，任一时刻只驻一帧）。24fps →
+    // Δ≈41.7ms → 最大滞后 ≤20.8ms，两个方向都降到不可感知，从根上消除来回震荡。
+    const int fps = 24;
     // 帧计划：每帧此刻高亮哪一句（相邻同句合并计数）。
     final List<AudioCue> planCues = plan.cueSpans
         .map((AudiobookClipCueSpan s) => AudioCue()

--- a/hibiki/test/media/audiobook/mining_audio_clip_highlight_lateness_test.dart
+++ b/hibiki/test/media/audiobook/mining_audio_clip_highlight_lateness_test.dart
@@ -1,0 +1,122 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/audiobook/mining_audio_clip.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+/// BUG-709 守卫：有声书导出片段「逐句高亮进度慢了」的根因是**帧量化残差**——
+/// [clipFramePlan] 用帧中心（round）采样，句起点 S 的高亮在视频时刻 `round(S/Δ)·Δ`
+/// 出现（Δ=1000/fps，音视频锁定），与真实音频对称误差 ≤Δ/2。fps 越低 Δ 越大、滞后越
+/// 明显：12fps 下 Δ≈83ms，约一半 cue 晚最多 ~42ms（可感知）。TODO-1147/1256 三次改采样
+/// 都只在 ±Δ 里挪、没动 Δ；根治是提高 fps 缩小 Δ。
+///
+/// 覆盖两层：
+/// 1. 行为（红→绿）：给定一批跨多个「相位偏移」的 cue，导出高亮相对音频的**最大滞后**
+///    严格 ≤ Δ/2 = 500/fps；fps=12 时该上限 >40ms（旧行为可感知），fps=24 时 ≤21ms
+///    （不可感知）——量化提 fps 确实把滞后压到阈下。
+/// 2. 源码守卫：动态导出路径 [_synthDynamicClipVideo] 的导出 fps 常量 ≥ 24，防止有人
+///    改回 12（或更低）令帧量化滞后回归。
+void main() {
+  group('BUG-709 导出高亮帧量化滞后', () {
+    // 每个 cue 高亮在导出视频里**首次出现**的帧时刻（相对 globalStart，ms）。
+    // clipFramePlan 返回 run-length（highlightCueIndex + frameCount）；某句首个 run 之前
+    // 的累计帧数 × Δ 即该句高亮第一次亮起的视频时刻。
+    Map<int, double> highlightOnsetMs({
+      required List<ClipFrameSpec> plan,
+      required int fps,
+    }) {
+      final double msPerFrame = 1000.0 / fps;
+      final Map<int, double> onset = <int, double>{};
+      int cumulativeFrames = 0;
+      for (final ClipFrameSpec spec in plan) {
+        onset.putIfAbsent(
+          spec.highlightCueIndex,
+          () => cumulativeFrames * msPerFrame,
+        );
+        cumulativeFrames += spec.frameCount;
+      }
+      return onset;
+    }
+
+    // 确定性相位扫描：对每个句起点 S 建 [cue0(0..S), cueTarget(S..S+500)]，驱动真实
+    // clipFramePlan，测 cueTarget 高亮亮起时刻相对 S 的滞后，取全扫描最大值。1ms 步长密集
+    // 覆盖 round 采样的所有相位，必然扫到「最坏相位」（frac(S/Δ)→0.5+ → 高亮等到下一帧）。
+    double maxLatenessMs({required int fps}) {
+      double worst = 0;
+      for (int s = 1; s <= 2000; s++) {
+        final List<AudioCue> cues = <AudioCue>[
+          _cue(startMs: 0, endMs: s),
+          _cue(startMs: s, endMs: s + 500),
+        ];
+        final List<ClipFrameSpec> plan = clipFramePlan(
+          cues: cues,
+          globalStartMs: 0,
+          globalEndMs: s + 500,
+          fps: fps,
+        );
+        final Map<int, double> onset = highlightOnsetMs(plan: plan, fps: fps);
+        final double? shownAt = onset[1];
+        if (shownAt == null) continue;
+        // 滞后 = 高亮亮起时刻 − 该句真实音频起点；>0 即高亮晚于声音（用户感知的「慢」）。
+        final double lateness = shownAt - s;
+        if (lateness > worst) worst = lateness;
+      }
+      return worst;
+    }
+
+    test('高亮最大滞后 ≤ Δ/2 = 500/fps（帧中心采样的数学上界）', () {
+      // fps=24：上界 500/24≈20.83ms，取整容差 1ms。
+      expect(maxLatenessMs(fps: 24), lessThanOrEqualTo(500.0 / 24 + 1.0));
+      // fps=12：上界 500/12≈41.67ms。
+      expect(maxLatenessMs(fps: 12), lessThanOrEqualTo(500.0 / 12 + 1.0));
+    });
+
+    test('提高 fps 把可感知滞后压到阈下：12fps 会 >40ms，24fps ≤21ms', () {
+      // 旧行为（12fps）：最坏相位下滞后确实越过 ~40ms（用户可感知「滞后」）。
+      expect(
+        maxLatenessMs(fps: 12),
+        greaterThan(40.0),
+        reason: '12fps 帧量化让部分 cue 高亮晚 >40ms，即用户报告的「导出高亮进度慢」',
+      );
+      // 新行为（24fps）：最坏滞后 ≤21ms，落在人眼音画同步阈值以下。
+      expect(
+        maxLatenessMs(fps: 24),
+        lessThanOrEqualTo(21.0),
+        reason: '24fps 把最大滞后压到 ≤Δ/2≈20.8ms，不可感知',
+      );
+    });
+
+    test('源码守卫：动态导出路径 fps 常量 ≥ 24（防退回 12fps 帧量化滞后）', () {
+      final String body = File(
+              'lib/src/pages/implementations/reader_hibiki/audiobook.part.dart')
+          .readAsStringSync()
+          .replaceAll('\r\n', '\n');
+      final RegExp fpsDecl = RegExp(r'const int fps = (\d+);');
+      final Iterable<RegExpMatch> matches = fpsDecl.allMatches(body);
+      expect(matches, isNotEmpty, reason: '未找到导出 fps 常量声明，测试锚点可能已漂移，请更新守卫');
+      for (final RegExpMatch m in matches) {
+        final int fps = int.parse(m.group(1)!);
+        expect(fps, greaterThanOrEqualTo(24),
+            reason: 'BUG-709：导出 fps 必须 ≥24 以把逐句高亮滞后压到 ≤Δ/2≈21ms；'
+                '回到 12fps 会让约一半 cue 高亮晚最多 ~42ms 重现「进度慢」');
+      }
+    });
+  });
+}
+
+AudioCue _cue({
+  required int startMs,
+  required int endMs,
+  int audioFileIndex = 0,
+  String text = '文',
+}) {
+  return AudioCue()
+    ..bookKey = ''
+    ..chapterHref = ''
+    ..sentenceIndex = 0
+    ..textFragmentId = ''
+    ..text = text
+    ..startMs = startMs
+    ..endMs = endMs
+    ..audioFileIndex = audioFileIndex;
+}


### PR DESCRIPTION
## 用户报告
「导出片段高亮进度慢了」。追问确认=导出短视频里逐句高亮**单向滞后**于朗读声音，且测试用的是**最新 develop 构建**（已含 TODO-1256 帧中心采样）。

## 根因（帧量化残差）
有声书「多句连读+逐句高亮跟随」导出视频，高亮切换被 `clipFramePlan`（`mining_audio_clip.dart:786`）量化到 Δ=1000/fps 的帧网格。round 采样下句起点 S 的高亮在 `round(S/Δ)·Δ` 出现，与锁定音频对称误差 ≤Δ/2。**12fps 下 Δ≈83ms，约一半 cue 高亮晚最多 ~42ms**（越过人眼音画同步阈 ≈45ms 边缘）→ 主观滞后。

对比确认导出独有：播放高亮走 `JsonAlignmentParser.findCueIndex` 按**连续**音频位置切换、无量化；delayMs 一致平移、帧编号 1:1，均无系统性偏移。历史三次改采样（ceil→晚 / TODO-1147 floor→早 / TODO-1256 round→对称）都只在 ±Δ 里挪、**没动 Δ 本身**，故 1256 上仍滞后。

## 修复
导出 fps `12 → 24`（`audiobook.part.dart:1442`，round 采样不变）。最大滞后 41.7ms→20.8ms，两方向都压到不可感知。成本极小：母帧按去重句**只渲一次**（渲染开销与 fps 无关），提 fps 只多廉价 JPEG 母帧复制+mjpeg 帧、不增内存（TODO-1167 流式）。

## 测试
`mining_audio_clip_highlight_lateness_test.dart`：①确定性相位扫描证「最大滞后 ≤ Δ/2」；②红→绿「12fps>40ms、24fps≤21ms」；③源码守卫 fps≥24。`flutter test test/media/audiobook` 全绿，`flutter analyze` 改动文件 No issues。

## 待真机
最终观感需真机导出多句片段逐帧比对高亮与声音，确认滞后主观消失、且 24fps 未显著拖慢移动端导出/撑大文件体积。