### PR TITLE
fix(sync): wire host importBookFromFile so live book push stops 500ing (BUG-709)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 694 条。点号进各自文件。
+> 共 695 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-709](bugs/BUG-709-interconnect-live-book-push-500.md) | ✅ | ✅ | 互联 live 书籍推送全部 HTTP 500(host 未接线 importBookFromFile) |
 | [BUG-708](bugs/BUG-708-interconnect-repair-blocked-by-lingering-pin-dialog.md) | ✅ | ✅ | 公网PIN配对取消后重新配对被host常驻PIN弹窗挡成拒绝 |
 | [BUG-707](bugs/BUG-707-selection-capture-clipboard-echo.md) | ✅ | ✅ | 全局查词抓选区的剪贴板回声泄漏进剪贴板查词管线 |
 | [BUG-706](bugs/BUG-706-lookup-popup-blank.md) | ✅ | ✅ | 查词弹窗全空白: __hibikiRoot 函数名与 window.__hibikiRoot marker 冲突 |

--- a/docs/bugs/BUG-709-interconnect-live-book-push-500.md
+++ b/docs/bugs/BUG-709-interconnect-live-book-push-500.md
@@ -1,0 +1,35 @@
+## BUG-709 · 互联 live 书籍推送全部 HTTP 500(host 未接线 importBookFromFile)
+- **报告**：2026-07-10（用户：截图 `SyncRunReport.errors`）
+- **现象**：自动/立即同步时 `SyncRunReport.errors` 报
+  `live push book "<书名>": SyncBackendError: PUT /api/library/books/<书名> failed: HTTP 500`。
+  截图里是两本中文书（`一桩事先张扬的凶杀案` / `朝花夕拾`），但与书名/CJK 无关——凡有
+  本端独有书要推给 host，**每一本都 500**，截图那次恰好只有两本待推。
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/models/app_model.dart:419`
+  （`libraryServiceFactory` 构造 `AppModelLibraryHostService` 时**漏传**
+  `importBookFromFile`）。
+  - 调用链：client `sync_orchestrator.dart:553 putRemoteBook` → host
+    `hibiki_sync_server.dart` books `PUT` 分支写 tmp `.epub` 后 `svc.importBook(tmp)`
+    → `app_model_library_host_service.dart:298 importBook`：`_importBookFromFile` 为
+    null 时抛 `UnsupportedError('importBook requires importBookFromFile callback ...')`
+    → 服务端 `catch (e) { return shelf.Response(500, body: 'Import failed: $e'); }`
+    → client `webdav_ops.dart:254 checkStatus` 把 `>=400` 统一成
+    `SyncBackendError('$context failed: HTTP $statusCode')`（**丢弃了服务端响应体**，
+    所以用户只看到裸 `HTTP 500`，看不到真正的 `Import failed: UnsupportedError`）。
+  - 为何单测没挡住：`hibiki_library_host_service_*` / `hibiki_sync_server_books_test`
+    都自己注入了 `importBookFromFile` 假回调，唯独生产工厂忘了注入，测试照样绿。
+- **[x] ① 已修复** — `app_model.dart:419` 工厂接线
+  `importBookFromFile: (File epubFile) => EpubImporter.importFromPath(db: database,
+  filePath: epubFile.path, fileName: path.basename(epubFile.path))`
+  （文档约定的生产实现），并新增 `import '.../epub/epub_importer.dart'`。提交见分支
+  `worktree-fix-live-book-push-500`。
+- **[x] ② 已加自动化测试** — 源码级接线守卫
+  `hibiki/test/sync/host_book_import_wiring_guard_test.dart`：断言生产工厂里
+  `importBookFromFile:` 存在且接到真实原语 `EpubImporter.importFromPath(`。已验证
+  该守卫在剥掉接线后失败、接回后通过（防静默回退）。
+- **备注**：
+  - **相关未修（本 bug 范围外，另记）**：同一工厂也漏传 `cleanupBookOnDisk`，故 host 的
+    `DELETE /api/library/books/<title>` 只删 DB 行、不清 AudiobookStorage/SrtBook 等
+    磁盘资源（潜在孤儿文件，非本次 500 症状）。
+  - **可诊断性欠账**：`checkStatus` 只透传状态码、丢弃服务端 `Import failed: <e>` 响应体，
+    未来 import 失败仍只显示裸 `HTTP 500`。建议 `putRemoteBook` 读取并附上响应体片段
+    （另开条目，非本 bug 根因）。

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -34,6 +34,7 @@ import 'package:hibiki_anki/hibiki_anki.dart';
 import 'package:hibiki/src/media/floating_dict_channel.dart';
 import 'package:hibiki/src/models/app_font_loader.dart';
 import 'package:hibiki/src/models/builtin_tags.dart';
+import 'package:hibiki/src/epub/epub_importer.dart';
 import 'package:hibiki/src/reader/reader_settings.dart';
 import 'package:hibiki/src/models/dictionary_repository.dart';
 import 'package:hibiki/src/models/media_history_repository.dart';
@@ -425,6 +426,16 @@ class AppModel with ChangeNotifier {
         dictRepo.clearDictionaryResultsCache();
       },
       runExclusive: runExclusiveWithSync,
+      // BUG-709: 必须接线 importBookFromFile，否则 host 收到对端 client 的
+      // PUT /api/library/books/<title> 时 importBook 抛 UnsupportedError，被
+      // 服务端 catch 成 HTTP 500，互联/live 书籍推送（client→host）整体失效。
+      // 生产实现即文档约定的 EpubImporter.importFromPath（tmp 文件名 = <title>.epub，
+      // fileName 用作 epubPath 与标题回退）。
+      importBookFromFile: (File epubFile) => EpubImporter.importFromPath(
+        db: database,
+        filePath: epubFile.path,
+        fileName: path.basename(epubFile.path),
+      ),
       localAudioEntries: localAudioDbs,
       localAudioStagingDir: temporaryDirectory,
       onLocalAudioImported: importSyncedLocalAudioDb,

--- a/hibiki/test/sync/host_book_import_wiring_guard_test.dart
+++ b/hibiki/test/sync/host_book_import_wiring_guard_test.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-709 守卫：互联 live 书籍推送（client→host）全部 HTTP 500。
+///
+/// 历史 bug = `AppModelLibraryHostService` 的 `importBookFromFile` 回调是可选的
+/// （null 时 `importBook` 抛 `UnsupportedError`），而 `AppModel` 里唯一的生产
+/// 构造点（`libraryServiceFactory`）忘了接线它。于是 host 收到对端 client 的
+/// `PUT /api/library/books/<title>` 时，`importBook` 抛 `UnsupportedError`，被
+/// 服务端 `catch` 成 `HTTP 500`，互联/自动同步的书籍推送整体失效——`SyncRunReport`
+/// 只看得到裸 `HTTP 500`（client 侧丢弃了服务端的 `Import failed: <e>` 响应体）。
+///
+/// 单元测试无法挡住这个回归：`hibiki_library_host_service_*` 测试都自己注入了
+/// `importBookFromFile` 假回调，生产忘了注入照样绿。故在源码级钉死：生产工厂必须
+/// 把 `importBookFromFile` 接到真实导入原语 `EpubImporter.importFromPath`。
+void main() {
+  String read(String relative) {
+    final File f = File(relative);
+    expect(f.existsSync(), isTrue, reason: 'missing source file: $relative');
+    return f.readAsStringSync();
+  }
+
+  group('BUG-709 host library service wires book import in production factory',
+      () {
+    test(
+        'AppModel.libraryServiceFactory passes importBookFromFile bound to '
+        'EpubImporter.importFromPath', () {
+      final String src = read('lib/src/models/app_model.dart');
+
+      // 生产工厂里确实构造了 host service。
+      expect(src, contains('AppModelLibraryHostService('),
+          reason: 'app_model 必须构造 AppModelLibraryHostService 作为互联 host 服务');
+
+      // 关键接线：importBookFromFile 必须被显式传入（缺则 importBook 抛
+      // UnsupportedError → PUT 书籍 500）。
+      expect(src, contains('importBookFromFile:'),
+          reason: '生产工厂必须接线 importBookFromFile，否则互联书籍推送全部 HTTP 500');
+
+      // 接线的必须是真实导入原语 EpubImporter.importFromPath（不是空实现/桩）。
+      expect(src, contains('EpubImporter.importFromPath('),
+          reason: 'importBookFromFile 必须接到真实导入原语 EpubImporter.importFromPath');
+    });
+  });
+}


### PR DESCRIPTION
## 症状
用户截图 `SyncRunReport.errors`：
```
live push book "一桩事先张扬的凶杀案": SyncBackendError: PUT /api/library/books/... failed: HTTP 500
live push book "朝花夕拾": ... HTTP 500
```
与书名/CJK 无关——凡有本端独有书要推给 host，**每一本都 500**，截图那次恰好只有两本待推。

## 根因
`app_model.dart:419` 的 `libraryServiceFactory` 构造 `AppModelLibraryHostService` 时**漏传** `importBookFromFile`（可选、默认 null）。链路：client `putRemoteBook` → host books PUT 分支 `svc.importBook(tmp)` → `importBook` 见 `_importBookFromFile==null` 抛 `UnsupportedError` → 服务端 `catch` 成 `HTTP 500`。client `checkStatus` 又丢弃服务端 `Import failed: <e>` 响应体，用户只看到裸 `HTTP 500`。

单测没挡住：host-service 单测都自己注入了假回调，唯独生产工厂忘了注入，测试照样绿。

## 修复
- 工厂接线文档约定的生产原语 `EpubImporter.importFromPath`。
- 新增源码级接线守卫 `host_book_import_wiring_guard_test.dart`：断言工厂含 `importBookFromFile:` 且接到 `EpubImporter.importFromPath(`。已验证剥掉接线后守卫失败、接回后通过。

## 验证
- `flutter analyze`（全量含 test）：No issues found
- `flutter test test/sync/ test/epub/`：1427 passed（含新守卫 + 现有 host/server book 测试）

## 范围外（另记，非本次 500 症状）
- 同工厂也漏传 `cleanupBookOnDisk` → DELETE 只删 DB 行、不清磁盘资源（潜在孤儿）。
- `checkStatus` 丢弃服务端错误体，import 失败仍只显裸 500——建议 `putRemoteBook` 附响应体片段。