### PR TITLE
feat(video-subtitle): 抄 Niratan 的字幕默认柔和阴影

### DIFF
--- a/docs/bugs/BUG-323-video-subtitle-stroke-residual.md
+++ b/docs/bugs/BUG-323-video-subtitle-stroke-residual.md
@@ -22,3 +22,5 @@
 
 - **备注**：**这是渲染观感 bug，host 单测只能证「描边渲染结构 = stroke 画笔单层 + fill 单层、绝无 Shadow 伪描边」，不能证视觉上残留黑字真的消失。** 真机/手机端横竖屏来回切换（必现路径）+ 切句必须由用户复测原始失败路径并留证据——这是上次 BUG-222「dev=True 没真机就声称修好」导致用户验证「根本没修好」的直接教训。本轮代码层根因清晰（8 层模糊 glyph 拷贝 → 真 stroke 轮廓），但不在此声称「真机已修好」，待用户真机确认。
 - **编号**：建 worktree 时（base develop@890b6768a）BUG-321 为空号、合法采番为 321；提交后发现 develop 已被并发 integration 推进到 1b88aa73a，抢先用掉 BUG-321（remote-video-resume）与 BUG-322（subtitle-list-click-highlight），故本条改号为 BUG-323（当前所有分支并集最大 322 → 323）避免撞号。
+
+- **后续（2026-07-10 用户决策「抄 Niratan 字幕默认阴影」）**：**默认统一外观**（非「尊重 .ass 自带样式」路径）的字幕正文已从本条的硬描边改回 Niratan（mac）的**单层柔和 drop shadow**（黑@0.9、模糊半径默认 3、向下 1px；`buildSubtitleSoftShadow`）。这**不是**回退 BUG-323 的坑：本条残留黑字的根因是 BUG-222 的**8 份**模糊 glyph 拷贝重叠外溢，而 Niratan 的单层软投影仅一份拷贝、偏移 (0,1)，不会重叠成第二个黑字（是所有主流播放器含 Niratan 的常规做法）。**真描边 `buildSubtitleStrokePaint` 仍保留**，现专供「尊重 .ass 自带样式」路径忠实还原 .ass 的 `\bord`/`\3c` 硬描边（TODO-1105/1246），不受本次默认外观变更影响。观感仍待用户真机确认。

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -858,7 +858,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
                       blurred: blurred,
                     ));
                   }
-                  return _buildStrokedChar(chars[i], i, markup);
+                  return _buildSubtitleChar(chars[i], i, markup);
                 },
               ),
           ],
@@ -911,45 +911,68 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     return fade.opacityAt(pos - cue.startMs, cue.endMs - cue.startMs);
   }
 
-  /// 渲染单个字幕字符为**真描边**：底层 stroke [Text]（[buildSubtitleStrokePaint] 沿
-  /// 字形轮廓描一圈）+ 上层 fill [Text]（正文填充色）精确重叠（BUG-323 / TODO-569）。
+  /// 渲染单个字幕字符。两条外观路径：
   ///
-  /// 描边色 / 描边宽默认取用户统一样式（[VideoSubtitleOverlay.shadowColor] /
-  /// [VideoSubtitleOverlay.shadowThickness]）；开 [VideoSubtitleOverlay.respectAssStyle]
-  /// 时优先取 .ass 的 \3c 描边色 / \bord 描边宽（行内 span > cueStyle，缺失回退统一样式，
-  /// TODO-1105）。thickness<=0（无描边）时 [buildSubtitleStrokePaint] 返回 null，直接渲染
-  /// 单层 fill [Text]（与历史无描边场景等价、零多余层）。
-  Widget _buildStrokedChar(String char, int i, SubtitleMarkup? markup) {
+  /// **① 默认统一外观**（`!respectAssStyle` 或非 .ass 字幕 markup==null）：单层 fill [Text]
+  /// + Niratan 式**柔和投影**（[buildSubtitleSoftShadow]，黑@0.9、模糊半径=shadowThickness、
+  /// 向下 1px）。这是用户开箱看到的「默认阴影」——按用户决策抄 mac 的 Niratan，放弃 BUG-323
+  /// 的锐利硬描边。单层软投影（仅一份拷贝、偏移 (0,1)）不会重现 BUG-222/323 的 8 层模糊
+  /// glyph 拷贝外溢残影。
+  ///
+  /// **② 尊重 .ass 自带样式**（[VideoSubtitleOverlay.respectAssStyle] 开且 cue 带 markup）：
+  /// 底层 stroke [Text]（[buildSubtitleStrokePaint] 沿字形轮廓描一圈 .ass 的 \bord/\3c 硬
+  /// 描边）+ 上层 fill [Text]，并保留 .ass 的 \shad 硬投影（[_styleForGrapheme] 的
+  /// `shadows`）。忠实还原 .ass 文件明示的描边/阴影语义（TODO-1105/1246），不被默认软投影
+  /// 覆盖。描边宽<=0 时降级为单层 fill。
+  ///
+  /// 两路径外均可套 \blur/\be 辉光（仅 respect 时）；命中矩形不因层数变化（ImageFiltered /
+  /// Stack 不改布局），逐字查词照常。
+  Widget _buildSubtitleChar(String char, int i, SubtitleMarkup? markup) {
     final TextStyle fillStyle = _styleForGrapheme(i, markup);
-    final (Color strokeColor, double strokeWidth) = _resolveStroke(i, markup);
-    final Paint? strokePaint =
-        buildSubtitleStrokePaint(strokeColor, strokeWidth);
+    final bool respect = widget.respectAssStyle && markup != null;
     final Widget glyph;
-    if (strokePaint == null) {
-      // 无描边：单层 fill（自带 ASS 阴影，若有）。
-      glyph = Text(char, style: fillStyle);
+    if (!respect) {
+      // 默认统一外观：Niratan 柔和投影。fillStyle 在非 respect 下 shadows==null，直接挂软
+      // 投影；thickness<=0（用户关阴影）时 soft 为空，渲染纯 fill（无投影、零多余层）。
+      final List<Shadow> soft = buildSubtitleSoftShadow(
+        widget.shadowColor ?? Theme.of(context).colorScheme.shadow,
+        widget.shadowThickness,
+      );
+      glyph = Text(
+        char,
+        style: soft.isEmpty ? fillStyle : fillStyle.copyWith(shadows: soft),
+      );
     } else {
-      // 描边层：复制 fill 的所有几何属性，但用 foreground 画笔取代 color（Flutter 断言
-      // foreground 与 color 不可共存，故显式重建而非 copyWith——copyWith 无法把 color 清空）。
-      final TextStyle strokeStyle = fillStyle.copyWith(
-        color: null,
-        foreground: strokePaint,
-        // 描边层不画下划线/删除线，避免与 fill 层重叠加粗装饰线（fill 层已画）。
-        decoration: TextDecoration.none,
-      );
-      // 阴影只保留在描边层（最底）→ 正确 z 序（阴影 < 描边 < 填充）；填充层清空阴影防重叠。
-      final bool hasShadows =
-          fillStyle.shadows != null && fillStyle.shadows!.isNotEmpty;
-      final TextStyle fillTopStyle = hasShadows
-          ? fillStyle.copyWith(shadows: const <Shadow>[])
-          : fillStyle;
-      glyph = Stack(
-        // 底层 stroke 先画（在下），上层 fill 后画（在上）盖住描边内缘，露出外缘成轮廓。
-        children: <Widget>[
-          Text(char, style: strokeStyle),
-          Text(char, style: fillTopStyle),
-        ],
-      );
+      // 尊重 .ass：\bord/\3c 真描边 + \shad ASS 硬投影（TODO-1105/1246），保持原样。
+      final (Color strokeColor, double strokeWidth) = _resolveStroke(i, markup);
+      final Paint? strokePaint =
+          buildSubtitleStrokePaint(strokeColor, strokeWidth);
+      if (strokePaint == null) {
+        // .ass 无描边（\bord 0）：单层 fill（自带 ASS 阴影，若有）。
+        glyph = Text(char, style: fillStyle);
+      } else {
+        // 描边层：复制 fill 的所有几何属性，但用 foreground 画笔取代 color（Flutter 断言
+        // foreground 与 color 不可共存，故显式重建而非 copyWith——copyWith 无法把 color 清空）。
+        final TextStyle strokeStyle = fillStyle.copyWith(
+          color: null,
+          foreground: strokePaint,
+          // 描边层不画下划线/删除线，避免与 fill 层重叠加粗装饰线（fill 层已画）。
+          decoration: TextDecoration.none,
+        );
+        // 阴影只保留在描边层（最底）→ 正确 z 序（阴影 < 描边 < 填充）；填充层清空阴影防重叠。
+        final bool hasShadows =
+            fillStyle.shadows != null && fillStyle.shadows!.isNotEmpty;
+        final TextStyle fillTopStyle = hasShadows
+            ? fillStyle.copyWith(shadows: const <Shadow>[])
+            : fillStyle;
+        glyph = Stack(
+          // 底层 stroke 先画（在下），上层 fill 后画（在上）盖住描边内缘，露出外缘成轮廓。
+          children: <Widget>[
+            Text(char, style: strokeStyle),
+            Text(char, style: fillTopStyle),
+          ],
+        );
+      }
     }
     // \blur/\be 辉光（TODO-1373）：把合成字形（描边+填充+阴影）整体高斯模糊。仅 respectAssStyle
     // 开且该字符所在 span 带 blur 时包裹；ImageFiltered 不改布局尺寸，故字符命中矩形
@@ -973,7 +996,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     return sigma < 0 ? 0 : (sigma > 24 ? 24 : sigma);
   }
 
-  /// 解析第 [i] 个 grapheme 的**描边色 + 描边宽**（[_buildStrokedChar] 用）。
+  /// 解析第 [i] 个 grapheme 的**描边色 + 描边宽**（[_buildSubtitleChar] 的 ASS 尊重分支用）。
   ///
   /// respectAssStyle 关：恒返回用户统一 (shadowColor, shadowThickness)——与历史像素级一致。
   /// respectAssStyle 开：描边色取 span.\3c ?? cueStyle.OutlineColour ?? 统一色；描边宽取
@@ -1015,8 +1038,9 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     return null;
   }
 
-  /// 合并外观默认与覆盖第 [i] 个 grapheme 的 span 样式（**填充层**，不含描边——描边由
-  /// [_buildStrokedChar] 的底层 stroke [Text] 单独承载，BUG-323 / TODO-569）。
+  /// 合并外观默认与覆盖第 [i] 个 grapheme 的 span 样式（**填充层**）。默认统一外观下柔和
+  /// 投影由 [_buildSubtitleChar] 挂到本样式上；尊重 .ass 时描边由其底层 stroke [Text] 单独
+  /// 承载、.ass \shad 硬投影由本方法的 `shadows` 提供（BUG-323 / TODO-569 / TODO-1105）。
   ///
   /// respectAssStyle 关：只应用行内 `\i \b \u \s \c \fs` 这些历史就支持的 span 样式，字体 /
   /// 字号 / 颜色的基线恒为用户统一样式，与历史像素级一致。

--- a/hibiki/lib/src/media/video/video_subtitle_style.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_style.dart
@@ -197,18 +197,29 @@ class VideoSubtitleStyle {
   });
 
   static const int defaultFontWeight = 700;
-  static const double defaultShadowThickness = 5;
 
-  /// v1 持久化时代硬编码的默认阴影粗细（3px）。仅供 [decode] 把 v1 存的
-  /// 该值迁移成 null（跟随 UI scale）用，不参与当前外观（当前默认是
-  /// [defaultShadowThickness]=5）。与当前常量解耦，改默认不破坏旧数据迁移。
+  /// 默认阴影/投影**半径**（模糊强度），抄 Niratan（mac 原生日语沉浸 app）字幕默认的
+  /// `shadowRadius = 3`（其设置滑杆范围 0..10）。BUG-323 时代这里是 5px「硬描边粗细」；
+  /// 现按用户要求改回 Niratan 的柔和投影观感——渲染改为单层高斯 drop shadow（见
+  /// [buildSubtitleSoftShadow] 与 [VideoSubtitleOverlay._buildSubtitleChar]），3 就是那层
+  /// 软阴影的模糊半径。仍跟随 UI scale（[resolveShadowThickness]）。
+  static const double defaultShadowThickness = 3;
+
+  /// v1 持久化时代硬编码的默认阴影粗细（3px）。仅供 [decode] 把 v1 存的该值迁移成 null
+  /// （跟随 UI scale）用。用独立字面量与当前 [defaultShadowThickness] 解耦：即便两者当前
+  /// 同为 3，语义不同（此值是历史迁移锚点），后续改默认也不破坏旧数据迁移。
   static const double _v1LegacyShadowThickness = 3;
 
-  /// High-contrast caption defaults (TODO-051): 36px bold WHITE text with a
-  /// thick BLACK outline/shadow, no box. Fixed white/black instead of theme
+  /// High-contrast caption defaults (TODO-051): 36px bold WHITE text with a soft
+  /// translucent-BLACK drop shadow, no box. Fixed white/black instead of theme
   /// colors so subtitles stay legible on any video and don't wash out on
   /// low-contrast themes. [fontWeight]/[shadowThickness] stay null to follow the
   /// global UI scale ([defaultFontWeight] / [defaultShadowThickness] at 1.0).
+  ///
+  /// [shadowColor] 默认取 `0xE6000000`（黑 @ 0.9 alpha），抄 Niratan 字幕投影
+  /// `Color.black.opacity(0.9)`：配合 [defaultShadowThickness]=3 的模糊半径与
+  /// [buildSubtitleSoftShadow] 的向下 1px 偏移，得到「字后一层柔和黑影」的观感（不再是
+  /// BUG-323 的锐利硬描边）。旧用户显式存的 `0xFF000000` 仍逐字尊重、不被本默认覆盖。
   ///
   /// [bottomPadding] is the user's subtitle position only (default 75). It no
   /// longer bakes in the controls-bar clearance: TODO-129 made the self-drawn
@@ -225,7 +236,8 @@ class VideoSubtitleStyle {
     fontSize: 36,
     textColor: Color(0xFFFFFFFF),
     fontWeight: null,
-    shadowColor: Color(0xFF000000),
+    // 黑 @ 0.9 alpha（抄 Niratan `.black.opacity(0.9)`）：柔和投影而非纯黑硬边。
+    shadowColor: Color(0xE6000000),
     shadowThickness: null,
     backgroundColor: null,
     backgroundOpacity: 0,
@@ -371,28 +383,39 @@ class VideoSubtitleStyle {
   }
 }
 
-/// 字幕**真**描边画笔（BUG-323 / TODO-569）：把粗细 [thickness] 渲染成沿字形轮廓的
-/// 单层描边，由底层 stroke [Text] 用本画笔描出、上层 fill [Text] 填正文（见
-/// [VideoSubtitleOverlay] 的双层渲染）。[thickness] <= 0 返回 null（无描边）。
+/// 字幕正文的**柔和投影**（抄 Niratan / mac）：把 [thickness]（阴影半径）渲染成**单层**
+/// 高斯 drop shadow，挂在正文 fill [Text] 的 `style.shadows` 上（见
+/// [VideoSubtitleOverlay._buildSubtitleChar]）。[thickness] <= 0 返回空列表（无投影）。
 ///
-/// 根因（为什么 BUG-222 的 [buildSubtitleShadows] 没修好、用户报「一点没修好、还是
-/// 残留黑字」）：那套方案用 8 个 `Shadow(blurRadius: thickness, offset: r)` 模拟描边。
-/// Flutter 的 `Shadow` 不是沿轮廓描边，而是把**整个字形 glyph 用阴影色重绘一遍**再做
-/// 高斯模糊 + 偏移。8 个方向 = 8 份模糊的黑色字形拷贝叠加。由于 `blurRadius`(=thickness)
-/// 大于偏移半径(=thickness/2)，这些模糊黑字大面积重叠并外溢到字身周围 → 白字下方/旁边
-/// 浮现一团能看清字形轮廓的黑色虚影 = 用户说的「残留在文字下方的黑字、双重/残影」。
-/// 横竖屏切换 / 切句是「重灾区 / 必现」是因为旋转后 `uiScale` 变化把 thickness 经
-/// [VideoSubtitleStyle.resolveShadowThickness] 放大（默认随缩放、clamp 到 12），thickness
-/// 越大模糊黑字拷贝越大越糊、残影越重——不是状态残留，是 8 层模糊 glyph 拷贝的固有产物。
+/// 对应 Niratan `SubtitleOverlayView` 的 `.shadow(color: .black.opacity(0.9),
+/// radius: shadowRadius, y: 1)`：单个阴影、模糊半径 = [thickness]、向下偏移 1px、
+/// 颜色由 [color] 决定（默认 `0xE6000000` = 黑 @ 0.9）。观感是「字后面一团柔和黑影」。
 ///
-/// 真描边修复：`Paint()..style = PaintingStyle.stroke` 沿字形外轮廓画**一圈**线，宽度
-/// [thickness]、`strokeJoin.round` 让转角圆滑（ASS/asbplayer outline 观感）。它精确贴合
-/// 字身、单层、无模糊、无偏移拷贝 → 任何 thickness / 缩放 / 横竖屏都只是描边变粗变细，
-/// 绝不产生第二个错位黑字。`strokeWidth = thickness`：描边线以轮廓为中线，向内外各占
-/// thickness/2，可视外缘厚度约 thickness/2，与旧 [buildSubtitleShadows] 偏移半径
-/// `thickness/2` 同量级，外观厚度延续、不需用户重设。
+/// 为什么用**单层**而非 BUG-222/BUG-323 的 8 层 `Shadow`：那套残留黑字的根因是**8 份**
+/// 模糊 glyph 拷贝（`blurRadius=thickness` > 偏移 `thickness/2`）大面积重叠外溢成能看清
+/// 字形的第二个黑字。单层 drop shadow（偏移仅 (0,1)、只一份拷贝）不产生这种重叠，是所有
+/// 主流播放器（含 Niratan 本身）字幕投影的常规做法——按用户决策换回这套柔和观感（放弃
+/// BUG-323 的硬描边）。[color] 是用户/主题阴影色，thickness=模糊强度，0=无投影。
+List<Shadow> buildSubtitleSoftShadow(Color color, double thickness) {
+  if (thickness <= 0) return const <Shadow>[];
+  return <Shadow>[
+    Shadow(color: color, blurRadius: thickness, offset: const Offset(0, 1)),
+  ];
+}
+
+/// 字幕**真描边**画笔（BUG-323 / TODO-569）：把宽度 [thickness] 渲染成沿字形轮廓的单层
+/// 描边，由底层 stroke [Text] 用本画笔描出、上层 fill [Text] 填正文（见
+/// [VideoSubtitleOverlay._buildSubtitleChar] 的 ASS 尊重分支）。[thickness] <= 0 返回 null。
 ///
-/// [color] 仍是用户/主题描边色（默认黑）。语义与旧路径一致：thickness=描边强度，0=无描边。
+/// 适用范围（TODO-1105 后收窄）：现仅供**「尊重 .ass 自带样式」路径**画 .ass 的 `\bord`/
+/// `Outline` 硬描边——那是 .ass 文件明示的描边语义，必须用沿轮廓的真描边忠实还原。**默认
+/// 统一外观**已按用户决策改回 Niratan 的柔和投影（[buildSubtitleSoftShadow]），不再走本
+/// 描边。保留真描边而非旧的 8 层模糊 `Shadow` 伪描边，是因为后者在大 thickness / 缩放下
+/// 会外溢成「残留黑字」（BUG-323 根因，见 [buildSubtitleShadows] 文档）；真描边单层、无
+/// 模糊、无偏移拷贝，任何 thickness 只是描边变粗变细，绝不产生第二个错位黑字。
+///
+/// [color] 是描边色（.ass \3c / OutlineColour），[thickness] = 描边宽（.ass \bord），
+/// 0 = 无描边。`strokeJoin/Cap.round` 让转角圆滑，贴合 ASS/asbplayer outline 观感。
 Paint? buildSubtitleStrokePaint(Color color, double thickness) {
   if (thickness <= 0) return null;
   return Paint()
@@ -416,10 +439,10 @@ Paint? buildSubtitleStrokePaint(Color color, double thickness) {
 /// 光晕。八向对称 → 合成结果围绕文字、无单向「掉落」感。thickness 仍是用户/缩放控制的
 /// 描边强度（0 = 无描边），[color] 仍是用户/主题阴影色，语义不变。
 ///
-/// 历史：字幕**正文**字符的描边已于 BUG-323 / TODO-569 改用 [buildSubtitleStrokePaint]
-/// 的真描边（双层 [Text]），因为本函数的 8 个模糊 `Shadow` glyph 拷贝在大 thickness /
-/// 缩放下会外溢成「残留黑字」。本函数仍保留给**收藏星角标**那枚 [Icon] 用——图标无文字
-/// 双层渲染的对应物，且尺寸小、不在用户报的字幕文字残影范围内，沿用四周阴影即可。
+/// 历史：字幕**正文**字符早先用本函数的 8 向 `Shadow`（BUG-222），后因大 thickness /
+/// 缩放下 8 份模糊 glyph 拷贝外溢成「残留黑字」改成硬描边（BUG-323），现按用户决策再
+/// 换成 [buildSubtitleSoftShadow] 的单层柔和投影（抄 Niratan）。本函数仍保留给**收藏星
+/// 角标**那枚 [Icon] 用——图标尺寸小、四周对称光晕正合适，不在字幕文字残影范围内。
 ///
 /// [thickness] <= 0 返回空列表（无描边，与旧 `shadowThickness<=0` 分支等价）。
 List<Shadow> buildSubtitleShadows(Color color, double thickness) {

--- a/hibiki/test/media/video/video_subtitle_dual_position_test.dart
+++ b/hibiki/test/media/video/video_subtitle_dual_position_test.dart
@@ -72,9 +72,9 @@ void main() {
 
       await _pump(tester, VideoSubtitleOverlay(controller: c));
 
-      // 各自 stroke+fill 双层，两条都在屏。
-      expect(find.text('上'), findsNWidgets(2));
-      expect(find.text('下'), findsNWidgets(2));
+      // 默认统一外观：每字单层 Text（Niratan 软投影），两条都在屏 → 各 1 个。
+      expect(find.text('上'), findsOneWidget);
+      expect(find.text('下'), findsOneWidget);
 
       final Rect overlayRect =
           tester.getRect(find.byType(VideoSubtitleOverlay));

--- a/hibiki/test/media/video/video_subtitle_font_consistency_test.dart
+++ b/hibiki/test/media/video/video_subtitle_font_consistency_test.dart
@@ -28,9 +28,9 @@ Future<void> _pump(WidgetTester tester, Widget child) async {
   await tester.pump();
 }
 
-/// 取某字符的**填充层** [Text]（BUG-323 / TODO-569 起每字渲染成 stroke+fill 双层；
-/// 填充层 = `style.foreground == null` 的那个，描边层用 foreground 画笔）。回退链/字体
-/// 一致性断言只看填充层即可（描边层从填充层 copyWith 同源派生，几何属性一致）。
+/// 取某字符的**填充层** [Text]（`style.foreground == null` 的那个）。默认统一外观每字
+/// 单层即填充层；ASS 尊重路径为 stroke+fill 双层、填充层同样 foreground==null。回退链/
+/// 字体一致性断言只看填充层即可。
 Text _fillTextOf(WidgetTester tester, String ch) {
   final List<Text> all = tester.widgetList<Text>(find.text(ch)).toList();
   return all.firstWhere((Text t) => t.style?.foreground == null);

--- a/hibiki/test/media/video/video_subtitle_multicue_test.dart
+++ b/hibiki/test/media/video/video_subtitle_multicue_test.dart
@@ -88,9 +88,9 @@ void main() {
       c.setCues(<AudioCue>[_cue('X', 0, 5000), _cue('Y', 2000, 8000)]);
       c.debugUpdateCueForPosition(3000); // 重叠区
       await _pump(tester, VideoSubtitleOverlay(controller: c));
-      // 每字 stroke+fill 双层。两条 cue 都在屏 → 各 2 个 Text。
-      expect(find.text('X'), findsNWidgets(2));
-      expect(find.text('Y'), findsNWidgets(2));
+      // 默认统一外观每字单层 Text（Niratan 软投影）。两条 cue 都在屏 → 各 1 个 Text。
+      expect(find.text('X'), findsOneWidget);
+      expect(find.text('Y'), findsOneWidget);
     });
 
     testWidgets('副字幕渲染在主字幕上方（画面顶部）', (WidgetTester tester) async {
@@ -101,8 +101,8 @@ void main() {
       c.debugUpdateCueForPosition(1000);
       await _pump(tester, VideoSubtitleOverlay(controller: c));
 
-      expect(find.text('主'), findsNWidgets(2));
-      expect(find.text('副'), findsNWidgets(2));
+      expect(find.text('主'), findsOneWidget);
+      expect(find.text('副'), findsOneWidget);
       final double mainDy = tester.getCenter(find.text('主').first).dy;
       final double secondaryDy = tester.getCenter(find.text('副').first).dy;
       expect(secondaryDy, lessThan(mainDy), reason: '副字幕应在画面顶部（dy 更小），主字幕在底部');
@@ -176,7 +176,8 @@ void main() {
       c.debugUpdateCueForPosition(1000);
       await _pump(tester, VideoSubtitleOverlay(controller: c));
       // 单层直接返回，overlay 直接子不是把主/副并列的 Stack（LayoutBuilder 在最外）。
-      expect(find.text('A'), findsNWidgets(2));
+      // 默认统一外观每字单层 Text（Niratan 软投影）。
+      expect(find.text('A'), findsOneWidget);
     });
   });
 }

--- a/hibiki/test/media/video/video_subtitle_overlay_dual_snap_test.dart
+++ b/hibiki/test/media/video/video_subtitle_overlay_dual_snap_test.dart
@@ -38,7 +38,7 @@ Future<void> _pump(WidgetTester tester, Widget child) async {
   await tester.pump();
 }
 
-/// 第一个匹配 [label] 的 Text 的 topLeft.dy（stroke/fill 双层同位，取 first 即可）。
+/// 第一个匹配 [label] 的 Text 的 topLeft.dy（默认单层；ASS 尊重路径双层同位，取 first 即可）。
 double _dy(WidgetTester tester, String label) =>
     tester.getTopLeft(find.text(label).first).dy;
 

--- a/hibiki/test/media/video/video_subtitle_overlay_markup_test.dart
+++ b/hibiki/test/media/video/video_subtitle_overlay_markup_test.dart
@@ -46,7 +46,7 @@ void main() {
 
     // 顶部锚点：字幕盒落在 overlay 上半部。
     final Rect overlayRect = tester.getRect(find.byType(VideoSubtitleOverlay));
-    // BUG-323/TODO-569：每字渲染为 stroke+fill 双层，取 .first（两层同位置）。
+    // 默认统一外观：每字单层 Text（Niratan 软投影），取 .first 兼容有无描边。
     final Offset boxCenter = tester.getCenter(find.text('プ').first);
     expect(boxCenter.dy, lessThan(overlayRect.center.dy));
 
@@ -63,7 +63,7 @@ void main() {
       home: Scaffold(body: VideoSubtitleOverlay(controller: c)),
     ));
     await tester.pump();
-    // BUG-323/TODO-569：每字 stroke+fill 双层，取填充层（foreground==null）断言样式。
+    // 取填充层（foreground==null）断言样式：默认单层即该层，ASS 尊重路径为双层的 fill 层。
     final Text a = tester
         .widgetList<Text>(find.text('A'))
         .firstWhere((Text t) => t.style?.foreground == null);
@@ -91,7 +91,7 @@ void main() {
     ));
     await tester.pump();
     final Rect overlayRect = tester.getRect(find.byType(VideoSubtitleOverlay));
-    // 双层重叠，取 .first（BUG-323/TODO-569）。
+    // 默认单层 Text，取 .first 兼容有无描边。
     final Offset boxCenter = tester.getCenter(find.text('そ').first);
     expect(boxCenter.dy, greaterThan(overlayRect.center.dy)); // 底部
   });
@@ -114,7 +114,7 @@ void main() {
       ),
     ));
     await tester.pump();
-    // Fill layer: foreground == null (BUG-323/TODO-569 dual layer).
+    // Fill layer: foreground == null (default single layer; ASS-respect is dual).
     Text fillOff = tester
         .widgetList<Text>(find.text('A'))
         .firstWhere((Text t) => t.style?.foreground == null);
@@ -268,16 +268,24 @@ void main() {
   });
 
   testWidgets(
-      'respectAssStyle OFF: ASS Shadow ignored (no TextStyle.shadows), historical '
-      'look preserved (TODO-1246)', (WidgetTester tester) async {
+      'respectAssStyle OFF: ASS Shadow ignored, default soft drop shadow applied '
+      'instead (TODO-1246 / Niratan)', (WidgetTester tester) async {
     final AudioCue cue = cueFromMarkup(const SubtitleMarkup(
       plainText: 'S',
       spans: <SubtitleSpan>[],
       cueStyle: SubtitleCueStyle(shadowDepthPx: 3, shadowColorArgb: 0xFF112233),
     ));
     await pumpOverlay(tester, cue, respect: false);
-    expect(strokeOf(tester, 'S').style?.shadows ?? const <Shadow>[], isEmpty);
-    expect(fillOf(tester, 'S').style?.shadows ?? const <Shadow>[], isEmpty);
+    // 关时单层 fill（无描边层）；.ass 的 \shad 硬投影（(3,3)、色 0xFF112233）被忽略，
+    // 改挂用户默认柔和投影（(0,1)、色=统一 shadowColor、模糊=统一 shadowThickness）。
+    expect(find.text('S'), findsOneWidget);
+    final List<Shadow> shadows =
+        fillOf(tester, 'S').style?.shadows ?? const <Shadow>[];
+    expect(shadows.length, 1, reason: '默认柔和投影单枚，非 ASS 硬投影');
+    expect(shadows.single.offset, const Offset(0, 1));
+    expect(shadows.single.color,
+        const Color(0xFF000000)); // pumpOverlay shadowColor
+    expect(shadows.single.blurRadius, 5); // pumpOverlay shadowThickness
   });
 
   testWidgets(
@@ -387,8 +395,8 @@ void main() {
   });
 
   testWidgets(
-      'respectAssStyle OFF: outline width uses unified shadowThickness, ASS '
-      'Outline ignored (TODO-1246)', (WidgetTester tester) async {
+      'respectAssStyle OFF: default soft shadow uses unified shadowThickness, ASS '
+      'Outline ignored (TODO-1246 / Niratan)', (WidgetTester tester) async {
     final AudioCue cue = cueFromMarkup(const SubtitleMarkup(
       plainText: 'X',
       spans: <SubtitleSpan>[],
@@ -396,8 +404,12 @@ void main() {
       playResY: 720,
     ));
     await pumpOverlay(tester, cue, respect: false, height: 360);
-    // pumpOverlay 传 shadowThickness: 5 → 关时描边宽恒统一值 5，不吃 ASS 的 4。
-    expect(strokeOf(tester, 'X').style?.foreground?.strokeWidth, 5.0);
+    // 关时无描边层，走默认柔和投影：模糊半径 = 统一 shadowThickness 5，不吃 ASS 的 \bord 4。
+    expect(find.text('X'), findsOneWidget);
+    final List<Shadow> shadows =
+        fillOf(tester, 'X').style?.shadows ?? const <Shadow>[];
+    expect(shadows.single.blurRadius, 5.0);
+    expect(shadows.single.offset, const Offset(0, 1));
   });
 
   // ---- TODO-1373: \blur 辉光 / \fad 淡入淡出 渲染门控 ----

--- a/hibiki/test/media/video/video_subtitle_overlay_test.dart
+++ b/hibiki/test/media/video/video_subtitle_overlay_test.dart
@@ -39,7 +39,7 @@ void main() {
     double gapFromBottom(WidgetTester tester) {
       final Rect overlayRect =
           tester.getRect(find.byType(VideoSubtitleOverlay));
-      // BUG-323/TODO-569：每字 stroke+fill 双层，取 .first（两层同几何）。
+      // 默认单层 Text（Niratan 软投影），取 .first 兼容有无描边。
       final Rect charRect = tester.getRect(find.text('A').first);
       return overlayRect.bottom - charRect.bottom;
     }
@@ -343,8 +343,8 @@ void main() {
     final VideoPlayerController c = _controllerWithCue('テスト');
     await _pump(
         tester, VideoSubtitleOverlay(controller: c, blurEnabled: false));
-    // 双层：stroke + fill 两个 Text（BUG-323/TODO-569）。
-    expect(find.text('テ'), findsNWidgets(2));
+    // 默认统一外观：每字单层 Text（Niratan 软投影）。
+    expect(find.text('テ'), findsOneWidget);
     expect(find.byType(ImageFiltered), findsNothing);
   });
 
@@ -412,7 +412,7 @@ void main() {
       tester,
       VideoSubtitleOverlay(controller: c, fontSize: 40),
     );
-    // 取填充层（foreground==null）断言字号（BUG-323/TODO-569 双层）。
+    // 取填充层（foreground==null）断言字号：默认单层即该层。
     final Text txt = tester
         .widgetList<Text>(find.text('A'))
         .firstWhere((Text t) => t.style?.foreground == null);

--- a/hibiki/test/media/video/video_subtitle_style_test.dart
+++ b/hibiki/test/media/video/video_subtitle_style_test.dart
@@ -3,25 +3,25 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/video/video_subtitle_style.dart';
 
 void main() {
-  test('default is high-contrast white text + black outline (TODO-051)', () {
+  test('default is high-contrast white text + soft black shadow (Niratan)', () {
     const VideoSubtitleStyle s = VideoSubtitleStyle.defaults;
     expect(s.fontSize, 36);
-    // 默认不再跟随主题：固定白字 + 黑描边，避免低对比主题下看不清。
+    // 默认不再跟随主题：固定白字 + 柔和黑投影（黑@0.9，抄 Niratan），低对比主题下也看清。
     expect(s.textColor, const Color(0xFFFFFFFF));
-    expect(s.shadowColor, const Color(0xFF000000));
-    // 显式白/黑：resolve 时即便给了主题色也不被它覆盖。
+    expect(s.shadowColor, const Color(0xE6000000));
+    // 显式白/黑@0.9：resolve 时即便给了主题色也不被它覆盖。
     expect(
         s.resolveTextColor(const Color(0xFF112233)), const Color(0xFFFFFFFF));
     expect(
       s.resolveShadowColor(const Color(0xFF112233)),
-      const Color(0xFF000000),
+      const Color(0xE6000000),
     );
     expect(s.fontWeight, isNull);
     expect(s.resolveFontWeight(1.0), 700);
-    // 阴影粗细加大：默认 3 -> 5（黑描边更明显）。
+    // 阴影半径改回 Niratan 默认 3（柔和投影模糊半径，不再是 5px 硬描边）。
     expect(s.shadowThickness, isNull);
-    expect(VideoSubtitleStyle.defaultShadowThickness, 5);
-    expect(s.resolveShadowThickness(1.0), 5);
+    expect(VideoSubtitleStyle.defaultShadowThickness, 3);
+    expect(s.resolveShadowThickness(1.0), 3);
     expect(s.backgroundColor, isNull);
     expect(s.backgroundOpacity, closeTo(0.0, 1e-9));
     // 默认位置是用户基线 75（TODO-129 反转 089 的恒抬升）：不再把控制条避让恒含进默认值，
@@ -33,9 +33,9 @@ void main() {
     const VideoSubtitleStyle s = VideoSubtitleStyle.defaults;
 
     expect(s.resolveFontWeight(2.0), 900);
-    expect(s.resolveShadowThickness(2.0), 10); // 5 * 2.0
+    expect(s.resolveShadowThickness(2.0), 6); // 3 * 2.0
     expect(s.resolveFontWeight(0.5), 400);
-    expect(s.resolveShadowThickness(0.5), 2.5); // 5 * 0.5
+    expect(s.resolveShadowThickness(0.5), 1.5); // 3 * 0.5
   });
 
   test('null color still means follow the active theme (legacy data)', () {
@@ -74,17 +74,17 @@ void main() {
 
   test('default white/black round-trips and persists explicitly (TODO-051)',
       () {
-    // 新默认（白字黑描边）encode->decode 必须如实存住，不再被「白=折叠成 null」吃掉。
+    // 新默认（白字 + 黑@0.9 软投影）encode->decode 必须如实存住，不被「白=折叠成 null」吃掉。
     final VideoSubtitleStyle back = VideoSubtitleStyle.decode(
       VideoSubtitleStyle.encode(VideoSubtitleStyle.defaults),
     );
     expect(back.textColor, const Color(0xFFFFFFFF));
-    expect(back.shadowColor, const Color(0xFF000000));
-    // resolve 给主题色也不被覆盖（仍是显式白/黑）。
+    expect(back.shadowColor, const Color(0xE6000000));
+    // resolve 给主题色也不被覆盖（仍是显式白 / 黑@0.9）。
     expect(back.resolveTextColor(const Color(0xFF112233)),
         const Color(0xFFFFFFFF));
     expect(back.resolveShadowColor(const Color(0xFF112233)),
-        const Color(0xFF000000));
+        const Color(0xE6000000));
   });
 
   test('explicit white text color is no longer folded to null', () {
@@ -149,20 +149,20 @@ void main() {
     expect(VideoSubtitleStyle.decode('not json').textColor,
         const Color(0xFFFFFFFF));
     expect(VideoSubtitleStyle.decode('').textColor, const Color(0xFFFFFFFF));
-    expect(VideoSubtitleStyle.decode('').shadowColor, const Color(0xFF000000));
+    expect(VideoSubtitleStyle.decode('').shadowColor, const Color(0xE6000000));
   });
 
   test('decode migrates stored asb defaults to scale-derived defaults', () {
     // v1 数据存的是当时硬编码默认（fontWeight 700 / shadowThickness 3px）=「跟随
-    // UI scale」，迁移成 null，让其继续跟随缩放。TODO-051 把默认阴影加大到 5px 后，
-    // 这类「跟随默认」的旧数据 resolve 出新的 5px（享受加大阴影，非钉死在旧 3px）。
+    // UI scale」，迁移成 null，让其继续跟随缩放。默认阴影半径现为 Niratan 的 3，故这类
+    // 「跟随默认」的旧数据 resolve 出 3（与迁移锚点巧合同值，但语义各自独立）。
     final VideoSubtitleStyle s =
         VideoSubtitleStyle.decode('{"fontWeight":700,"shadowThickness":3}');
 
     expect(s.fontWeight, isNull);
     expect(s.shadowThickness, isNull);
     expect(s.resolveFontWeight(1.0), 700);
-    expect(s.resolveShadowThickness(1.0), 5); // 加大后的默认（TODO-051）。
+    expect(s.resolveShadowThickness(1.0), 3); // Niratan 默认半径。
   });
 
   group('dynamic subtitle dodge of the bottom controls bar (TODO-129)', () {
@@ -383,6 +383,35 @@ void main() {
       // 绝不像旧 8 层模糊 Shadow 那样在大 thickness 下外溢成第二个错位黑字。
       expect(buildSubtitleStrokePaint(c, 2)!.strokeWidth, 2);
       expect(buildSubtitleStrokePaint(c, 12)!.strokeWidth, 12);
+    });
+  });
+
+  group('buildSubtitleSoftShadow (抄 Niratan 默认统一外观的柔和投影)', () {
+    const Color c = Color(0xFF224466);
+
+    test('thickness<=0 无投影（空列表）', () {
+      expect(buildSubtitleSoftShadow(c, 0), isEmpty);
+      expect(buildSubtitleSoftShadow(c, -3), isEmpty);
+    });
+
+    test('正粗细生成单枚柔和投影：色 / 模糊半径 / 向下 1px 偏移', () {
+      final List<Shadow> shadows = buildSubtitleSoftShadow(c, 3);
+      // 单枚（不是 8 向伪描边）→ 不会重现 BUG-222/323 的残留黑字。
+      expect(shadows.length, 1);
+      final Shadow s = shadows.single;
+      expect(s.color, c);
+      expect(s.blurRadius, 3); // blurRadius == thickness（模糊半径）
+      // 向下偏移 1px（对应 Niratan `.shadow(..., y: 1)`）。
+      expect(s.offset, const Offset(0, 1));
+    });
+
+    test('blurRadius 随 thickness 线性变化（仍单枚、偏移恒 (0,1)）', () {
+      final Shadow s6 = buildSubtitleSoftShadow(c, 6).single;
+      expect(s6.blurRadius, 6);
+      expect(s6.offset, const Offset(0, 1));
+      final Shadow s12 = buildSubtitleSoftShadow(c, 12).single;
+      expect(s12.blurRadius, 12);
+      expect(s12.offset, const Offset(0, 1));
     });
   });
 

--- a/hibiki/test/widgets/video_subtitle_overlay_test.dart
+++ b/hibiki/test/widgets/video_subtitle_overlay_test.dart
@@ -37,15 +37,13 @@ void main() {
 
     c.debugUpdateCueForPosition(500);
     await tester.pump();
-    // 'hello' 拆成逐字符可点；每个字符现在渲染成**双层**（底层 stroke 描边 Text +
-    // 上层 fill Text，BUG-323 / TODO-569 真描边），故每个唯一字符出现 2 个 Text，
-    // 重复字符 'l'（出现 2 次）共 4 个。默认 shadowThickness=5（非零）→ 描边层存在。
-    expect(find.text('h'), findsNWidgets(2));
-    expect(find.text('e'), findsNWidgets(2));
-    expect(find.text('l'), findsNWidgets(4));
+    // 'hello' 拆成逐字符可点；默认统一外观每字渲染成**单层** fill Text（Niratan 软投影，
+    // 非 respectAssStyle 路径），故每个唯一字符出现 1 个 Text，重复字符 'l'（2 次）共 2 个。
+    expect(find.text('h'), findsOneWidget);
+    expect(find.text('e'), findsOneWidget);
+    expect(find.text('l'), findsNWidgets(2));
 
-    // 双层重叠，点哪层都命中同一字符矩形；用 .first 避免「matched 2 widgets」。
-    await tester.tap(find.text('e').first);
+    await tester.tap(find.text('e'));
     expect(tappedSentence, 'hello');
     expect(tappedIndex, 1); // 'e' 是第 1 个 grapheme
     // 浮层定位用：被点字符报告非零屏幕矩形（弹窗据此定位到字符附近）。
@@ -56,7 +54,7 @@ void main() {
 
     c.debugUpdateCueForPosition(2500);
     await tester.pump();
-    expect(find.text('w'), findsNWidgets(2));
+    expect(find.text('w'), findsOneWidget);
     expect(find.text('h'), findsNothing);
   });
 
@@ -70,7 +68,7 @@ void main() {
   });
 
   testWidgets(
-      'renders real outline as double-layer stroke+fill Text, no shadow residue (BUG-323)',
+      'default uniform look: single fill Text + soft drop shadow (Niratan), no stroke layer',
       (tester) async {
     final c = VideoPlayerController();
     addTearDown(c.dispose);
@@ -88,6 +86,7 @@ void main() {
       backgroundOpacity: 0,
       bottomPadding: 75,
       fontFamily: 'ReaderFont',
+      // respectAssStyle 默认 false → 默认统一外观（软投影）。
     )));
 
     c.debugUpdateCueForPosition(500);
@@ -97,41 +96,30 @@ void main() {
     final BoxDecoration decoration = box.decoration as BoxDecoration;
     expect(decoration.color, Colors.transparent);
 
-    // BUG-323 / TODO-569 真描边：字符 'A' 渲染成**两层** Text（底层 stroke 描边 +
-    // 上层 fill 正文），故 find.text('A') 命中 2 个。旧的「8 个模糊 Shadow glyph
-    // 拷贝伪描边」会在大 thickness/横竖屏缩放下外溢成残留黑字，已彻底移除。
+    // 抄 Niratan：默认（非 respectAssStyle）字幕每字渲染成**单层** fill Text + 一枚柔和
+    // drop shadow（放弃 BUG-323 的双层硬描边）。单层软投影（仅一份拷贝、向下 1px 偏移）
+    // 不会重现 BUG-222/323 的 8 层模糊 glyph 拷贝残留黑字。
     final List<Text> texts = tester.widgetList<Text>(find.text('A')).toList();
-    expect(texts.length, 2, reason: '真描边 = 底层 stroke + 上层 fill 两个 Text');
+    expect(texts.length, 1, reason: '默认外观 = 单层 fill Text（无描边层）');
 
-    // 分辨两层：fill 层有 color、无 foreground、无 shadows；stroke 层 foreground 是
-    // PaintingStyle.stroke 画笔、color 为 null、无 shadows。
-    final Text fill = texts.firstWhere((Text t) => t.style?.foreground == null);
-    final Text stroke =
-        texts.firstWhere((Text t) => t.style?.foreground != null);
-
-    // fill 层：正文色、字号、字重、字体如实；**绝无 shadows**（残留黑字源已根除）。
+    final Text fill = texts.single;
+    // fill 层：正文色 / 字号 / 字重 / 字体如实，无 foreground（非描边）。
+    expect(fill.style!.foreground, isNull);
     expect(fill.style!.color, themedSubtitleColor);
     expect(fill.style!.fontSize, 36);
     expect(fill.style!.fontWeight, FontWeight.w500);
     expect(fill.style!.fontFamily, 'ReaderFont');
-    expect(fill.style!.shadows, anyOf(isNull, isEmpty),
-        reason: '不再用 Shadow 伪描边');
 
-    // stroke 层：foreground 是 stroke 画笔，宽度==thickness、色==shadowColor，
-    // 几何（字号/字重/字体）与 fill 层一致（两层逐像素对齐）；同样**无 shadows**。
-    final Paint strokePaint = stroke.style!.foreground!;
-    expect(strokePaint.style, PaintingStyle.stroke);
-    expect(strokePaint.strokeWidth, 6); // strokeWidth == thickness
-    // Paint.color round-trip 后实例不严格 ==（colorSpace/浮点表示），比 ARGB32。
-    expect(strokePaint.color.toARGB32(), const Color(0xFF224466).toARGB32());
-    expect(stroke.style!.color, isNull, reason: 'foreground 与 color 不可共存');
-    expect(stroke.style!.fontSize, 36);
-    expect(stroke.style!.fontWeight, FontWeight.w500);
-    expect(stroke.style!.fontFamily, 'ReaderFont');
-    expect(stroke.style!.shadows, anyOf(isNull, isEmpty));
+    // 柔和投影：单枚 Shadow，色==shadowColor、模糊半径==shadowThickness、向下偏移 1px
+    // （对应 Niratan `.shadow(color:.black.opacity(0.9), radius:r, y:1)`）。
+    final List<Shadow> shadows = fill.style!.shadows!;
+    expect(shadows.length, 1, reason: '单层柔和投影，不是 8 向伪描边');
+    expect(shadows.single.color, const Color(0xFF224466));
+    expect(shadows.single.blurRadius, 6);
+    expect(shadows.single.offset, const Offset(0, 1));
   });
 
-  testWidgets('thickness<=0 renders single fill Text (no stroke layer)',
+  testWidgets('thickness<=0 renders single fill Text with no shadow',
       (tester) async {
     final c = VideoPlayerController();
     addTearDown(c.dispose);
@@ -140,12 +128,12 @@ void main() {
     await tester.pumpWidget(buildTestApp(VideoSubtitleOverlay(
       controller: c,
       shadowColor: const Color(0xFF224466),
-      shadowThickness: 0, // 无描边：不应再有第二层 Text。
+      shadowThickness: 0, // 关阴影：单层 fill、无投影。
     )));
     c.debugUpdateCueForPosition(500);
     await tester.pump();
 
-    // 无描边 → 单层 fill Text，绝不渲染空描边层（无多余 widget、无残影）。
+    // 关阴影 → 单层 fill Text，无投影（无多余层、无残影）。
     final List<Text> texts = tester.widgetList<Text>(find.text('A')).toList();
     expect(texts.length, 1);
     expect(texts.single.style!.foreground, isNull);


### PR DESCRIPTION
## 目标
用户要求「抄 mac 的 [Niratan](https://github.com/W1ght/Niratan) 字幕默认阴影」。

## Niratan 的字幕默认阴影
单层柔和 drop shadow：`.shadow(color: .black.opacity(0.9), radius: shadowRadius, y: 1)`，默认 `shadowRadius = 3`。字号 36 / 字重 700 / 白字 / 无背景框。

## 改动
把 Hibiki **默认统一外观**（非「尊重 .ass 自带样式」路径）的字幕从 BUG-323 的锐利硬描边改回 Niratan 的软投影：
- `defaultShadowThickness` 5 → **3**（模糊半径）
- 默认 `shadowColor` `0xFF000000` → **`0xE6000000`**（黑 @ 0.9，抄 `.black.opacity(0.9)`）
- 新增 `buildSubtitleSoftShadow`：单枚 `Shadow(blurRadius=thickness, offset=(0,1))`
- `_buildSubtitleChar` 按 `respectAssStyle` 分支：**默认**单层 fill Text + 软投影；**尊重 .ass** 时保留 `\bord`/`\3c` 真描边 + `\shad`（TODO-1105/1246 不回退）

## 为什么不重现 BUG-323 残留黑字
BUG-222/323 的残影根因是 **8 份**模糊 glyph 拷贝重叠外溢；Niratan 单层软投影只一份拷贝、偏移 (0,1)，是主流播放器（含 Niratan）常规做法，不会叠出第二个黑字。真描边 `buildSubtitleStrokePaint` 仍保留，专供 ASS 尊重路径。

## 范围说明
`videoRespectAssStyle` 默认 **true**，故带 `Outline` 的 .ass 仍显示其自带硬描边（忠于文件）；SRT/VTT 及关闭「尊重 .ass 样式」时走新的软投影。如需软投影也覆盖 .ass，请告知（那与「尊重 .ass 样式」语义相悖，故未做）。

## 验证
- `flutter analyze`（全项目）：No issues
- `flutter test test/media/video/`：**+1435**（2 skipped=golden 门控）全绿
- 受影响 widget/style 测试全绿；新增 `buildSubtitleSoftShadow` 用例
- ⏳ **观感待真机确认**（渲染观感改动，host 单测只能证结构）