### PR TITLE
fix(clipboard-panel): 关闭面板后不再永久暂停，下一条剪贴板复制重开 (BUG-717)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 702 条。点号进各自文件。
+> 共 703 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-717](bugs/BUG-717-clipboard-panel-close-drops-lookups.md) | ✅ | ✅ | 剪贴板面板关闭后被永久暂停：第二个词出不来 |
 | [BUG-716](bugs/BUG-716-bilingual-bottom-marginv-overlap.md) | ✅ | ✅ | 双语底部对白 MarginV 塌陷重叠 |
 | [BUG-715](bugs/BUG-715-nested-popup-searching-placeholder-zorder.md) | ✅ | ✅ | 嵌套查词子弹窗渲染前显示在父弹窗下方图层(视频/首页/悬浮歌词) |
 | [BUG-714](bugs/BUG-714-interconnect-live-book-push-500.md) | ✅ | ✅ | 互联 live 书籍推送全部 HTTP 500(host 未接线 importBookFromFile) |

--- a/docs/bugs/BUG-717-clipboard-panel-close-drops-lookups.md
+++ b/docs/bugs/BUG-717-clipboard-panel-close-drops-lookups.md
@@ -1,0 +1,22 @@
+## BUG-717 · 剪贴板面板关闭后被永久暂停：第二个词出不来
+- **报告**：2026-07-11（用户：「第一个关掉了，第二个就出不来了」，剪贴板去向=panel）
+- **真实性**：✅ 真 bug（根因 `hibiki/lib/src/lookup/clipboard_panel_controller.dart` `update` 的 `if (paused && request.origin != DesktopLookupOrigin.hotkey) { drop }` 门 + `hidePanel(pause:true)`）
+- **[x] ① 已修复** — 整条移除 `paused` 门：删 `paused` 字段、`update` 里的 paused-drop、`hidePanel` 的 `pause` 参数。关面板 = 藏窗（`_visible=false`），下一条剪贴板复制经 `update` 的 `!_visible` 分支无条件 `_showPanel` 重开。用户 2026-07-11 拍板「下一次复制重新弹出面板」。提交见分支 `worktree-fix-transient-lookup-latestwins`
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/clipboard_panel_controller_test.dart` 源码扫描守卫改写：钉住 `bool paused` 字段移除、`request.origin != DesktopLookupOrigin.hotkey` 丢弃门移除、`update` 在 `!_visible` 时重开、`hidePanel()` 无参且不设阻塞标志
+- **备注**：与最初报的覆盖窗/瞬态 bug（[BUG-578](BUG-578-desktop-floating-lyric-global-lookup-blank.md)）**无关**——瞬态光标查词 close→reopen 在 +624 构建实测每次都正常（真机 glog `hotkey→reveal(box)→dismissed→hotkey→reveal(box)`）；本条是**面板去向**独有的暂停语义。
+
+### 现象
+Windows 桌面剪贴板查词去向设 `panel`（Floating panel）。剪贴板复制第一个词 → 面板弹出正常；**点面板栏 × 关掉后**，再复制词 → 面板**不再弹出**，日志刷 `panel: paused — drop DesktopLookupOrigin.clipboard`。
+
+### 真机日志证据（`<systemTemp>\hibiki_glookup.log`，用户真实运行 2026-07-10~11）
+- `23:42:49 panel: shown` → 用户点 × 关面板 → `23:48:20 / 23:54:14 panel: paused — drop DesktopLookupOrigin.clipboard`：关面板后每次复制都被丢弃。
+- 对照同段瞬态路径（hotkey Ctrl+Alt+D）：`23:18:16 lookup→showAt(atCursor)→overlaySize→reveal(box)` → `dismissed` → `23:18:29 lookup→reveal(box)` **第二次照常弹出**，证明 close→reopen 只有面板去向坏、瞬态没坏。
+
+### 根因
+`ClipboardPanelController`：`hidePanel({pause:true})`（面板栏 × 与 root 卡 × 都调它）把 `paused=true`；`update` 开头 `if (paused && request.origin != DesktopLookupOrigin.hotkey) { glog('paused — drop'); return; }` 把之后所有非 hotkey（=剪贴板）事件丢弃，直到 `Ctrl+Shift+D`（origin=hotkey）才 `paused=false` 解除。设计本意是「× 后别再打扰、想要再按 Ctrl+Shift+D」，但用户预期是「关掉当前卡，下一条复制自然重开」，于是体验成「第二个词出不来」。
+
+### 修复
+移除整个 `paused` 特例（好品味：消除特殊情况，而不是加分支）：删 `bool paused` 字段、`update` 的 paused-drop 块、`hidePanel` 的 `pause` 参数。关面板只 `_visible=false`+藏窗；下一条剪贴板 `update` 见 `!_visible` 直接 `_showPanel` 重开。想彻底静默面板走设置里的剪贴板查词总开关 / 切换去向，不再靠这个隐藏暂停门。`Ctrl+Shift+D` 仍可手动唤面板（只是不再承担「解除暂停」的特殊角色）。
+
+### 待验（真机）
+面板是 native WebView2 窗口，headless 测不了。需真机：剪贴板去向设 panel → 复制词（面板弹）→ 点面板栏 × 关掉 → 再复制词 → 面板**重新弹出**并显示新词（glog 出现 `panel: shown` + `panel: updated`，不再是 `panel: paused — drop`）。

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -72,10 +72,6 @@ class ClipboardPanelController {
   bool _started = false;
   bool _visible = false;
 
-  /// ×（面板栏关闭钮）后为 true：剪贴板事件不再更新面板，直到 Ctrl+Shift+D
-  /// （origin=hotkey 的显式意图）或重开设置开关解除。
-  bool paused = false;
-
   bool _backdropApplied = false;
 
   /// spec §6 gate — Win11 acrylic backdrop 是否被 OS 接受。false（Win10 /
@@ -144,15 +140,14 @@ class ClipboardPanelController {
   /// 剪贴板/热键请求入口（DesktopLookupDispatcher 的 panel 分区）。
   /// 语义：整句查一次（引擎按前缀/去屈折从句首匹配）+ 句子横幅逐字可点；
   /// 面板未显示则按记忆位显示；已显示则原地更新（固定 rect 无窗口运动）。
-  /// paused 时只有 origin=hotkey（Ctrl+Shift+D 显式意图）解除暂停并继续。
+  /// BUG-717（用户 2026-07-11 拍板）：× 关面板只清当前卡，**不**永久暂停路由——
+  /// 下一条剪贴板复制（或任何来源）都无条件重开面板。旧的 `paused` 门（× 后丢弃
+  /// 非 hotkey 事件、直到 Ctrl+Shift+D 才解除）让用户「关掉后第二个词就出不来」，
+  /// 已整条移除：关面板 = 藏窗（`_visible=false`），下一次 update 见 `!_visible`
+  /// 直接 `_showPanel` 重开。想彻底静默走设置里的剪贴板查词总开关，不再靠这个门。
   Future<void> update(DesktopLookupRequest request) async {
     final AppModel? model = _appModel;
     if (!_started || model == null) return;
-    if (paused && request.origin != DesktopLookupOrigin.hotkey) {
-      glog('panel: paused — drop ${request.origin}');
-      return;
-    }
-    paused = false;
     // latest-wins：领取序号；每个 await 后核对，过期即弃（VN 流乱序守卫）。
     final int seq = ++_updateSeq;
     try {
@@ -201,9 +196,9 @@ class ClipboardPanelController {
     await _renderPanel(model);
   }
 
-  /// 面板栏 ×：藏窗 + 暂停路由（Ctrl+Shift+D 或设置重开解除）。
-  Future<void> hidePanel({bool pause = true}) async {
-    paused = pause || paused;
+  /// 面板栏 × / root 卡 ×：藏窗即可。BUG-717：不再暂停路由——下一条剪贴板复制
+  /// 会经 [update] 的 `!_visible` 分支重开面板（关掉后第二个词照样弹）。
+  Future<void> hidePanel() async {
     _visible = false;
     await _channel.hide(notify: false);
   }

--- a/hibiki/lib/src/settings/settings_schema_lookup.dart
+++ b/hibiki/lib/src/settings/settings_schema_lookup.dart
@@ -300,8 +300,7 @@ SettingsDestination buildLookupDestination() {
                   unawaited(
                       ClipboardPanelController.instance.ensurePrewarmed());
                 } else if (!value) {
-                  await ClipboardPanelController.instance
-                      .hidePanel(pause: false);
+                  await ClipboardPanelController.instance.hidePanel();
                 }
               }
               settingsContext.refresh();
@@ -387,17 +386,15 @@ SettingsDestination buildLookupDestination() {
             ) async {
               await settingsContext.appModel
                   .setDesktopClipboardDestination(value);
-              // 去向切走时收起面板（不留孤儿常驻窗）；切到面板时解除 × 暂停
-              // （从设置重开面板的直觉路径，spec §5）并补预热（启动预热仅
-              // destination==panel 时做——默认 main 不常驻第二 WebView2）。
+              // 去向切走时收起面板（不留孤儿常驻窗）；切到面板时补预热（启动预热仅
+              // destination==panel 时做——默认 main 不常驻第二 WebView2）。BUG-717：
+              // 面板不再有 × 暂停态，切回面板无需「解除暂停」，下一条剪贴板自然重开。
               if (ClipboardPanelController.isSupported) {
                 if (value == DesktopClipboardDestination.panel) {
-                  ClipboardPanelController.instance.paused = false;
                   unawaited(
                       ClipboardPanelController.instance.ensurePrewarmed());
                 } else {
-                  await ClipboardPanelController.instance
-                      .hidePanel(pause: false);
+                  await ClipboardPanelController.instance.hidePanel();
                 }
               }
               settingsContext.refresh();

--- a/hibiki/test/lookup/clipboard_panel_controller_test.dart
+++ b/hibiki/test/lookup/clipboard_panel_controller_test.dart
@@ -1,6 +1,6 @@
 // spec 2026-07-10 — ClipboardPanelController 的可离屏部分：rect 记忆纯函数、
-// paused 语义（× 后仅 hotkey 显式意图解除）、面板栏高度跨端契约、
-// dispatcher panel 分区接线守卫。运行时链（真窗口/真查词）归 M4 真机 gate。
+// 关面板不永久暂停（BUG-717：× 只清当前卡，下一条剪贴板复制重开）、面板栏高度
+// 跨端契约、dispatcher panel 分区接线守卫。运行时链（真窗口/真查词）归 M4 真机 gate。
 
 import 'dart:io';
 
@@ -47,13 +47,35 @@ void main() {
         File('lib/src/lookup/desktop_lookup_dispatcher.dart')
             .readAsStringSync();
 
-    test('paused 语义：仅 hotkey 显式意图穿透暂停', () {
+    test('BUG-717：× 关面板不永久暂停，下一条剪贴板复制重开', () {
+      // 旧的 paused 门（× 后丢弃非 hotkey 事件、直到 Ctrl+Shift+D 才解除）整条移除：
+      // 用户「第一个关掉了第二个就出不来」的根因就是这个门。
+      expect(controllerSrc.contains('bool paused'), isFalse,
+          reason: 'BUG-717：paused 字段必须移除');
       expect(
-        controllerSrc
-            .contains('paused && request.origin != DesktopLookupOrigin.hotkey'),
-        isTrue,
-        reason: '× 后剪贴板事件不再打扰；Ctrl+Shift+D（显式意图）重唤并继续',
+        controllerSrc.contains('request.origin != DesktopLookupOrigin.hotkey'),
+        isFalse,
+        reason: 'BUG-717：不得再有「paused 时丢弃非 hotkey 剪贴板事件」的门',
       );
+      // 正向契约：update 见 !_visible 无条件 _showPanel，故关面板（_visible=false）
+      // 后下一条剪贴板复制会重开面板。
+      final int updAt = controllerSrc.indexOf('Future<void> update(');
+      final int visAt = controllerSrc.indexOf('if (!_visible) {', updAt);
+      final int showAt =
+          controllerSrc.indexOf('await _showPanel(model);', visAt);
+      expect(visAt, greaterThan(updAt),
+          reason: 'update 必须在 !_visible 时重新显示面板（关掉后重开的机制）');
+      expect(showAt, greaterThan(visAt));
+    });
+
+    test('hidePanel 只藏窗、不设阻塞标志（关掉后下一条复制照弹）', () {
+      final int hideAt = controllerSrc.indexOf('Future<void> hidePanel()');
+      expect(hideAt, greaterThanOrEqualTo(0),
+          reason: 'BUG-717：hidePanel 无参（不再有 pause 开关）');
+      final int end = controllerSrc.indexOf('}', hideAt);
+      final String body = controllerSrc.substring(hideAt, end);
+      expect(body.contains('_visible = false'), isTrue);
+      expect(body.contains('paused'), isFalse, reason: 'hidePanel 不得设任何暂停标志');
     });
 
     test('九根 DEFERRED 桥经共享权威 handler（红线：不复制）', () {


### PR DESCRIPTION
## 根因（真机 glog 定位）
用户报「剪贴板查词第一个关掉了、第二个就出不来了」。真机 `%TEMP%\hibiki_glookup.log` 实证：剪贴板去向=panel 时，点面板栏 × 关面板后，后续每次复制都刷 `panel: paused — drop DesktopLookupOrigin.clipboard`。

`ClipboardPanelController.hidePanel(pause:true)` 把 `paused=true`，`update` 开头 `if (paused && origin != hotkey) { drop }` 把之后所有剪贴板事件丢弃，直到 Ctrl+Shift+D 才解除——设计的「× 后别打扰」暂停态，用户体验成「第二个词出不来」。

> 对照：瞬态/光标查词（hotkey Ctrl+Alt+D）close→reopen 在同一份 glog 里每次都正常（`reveal(box)→dismissed→reveal(box)`），本 bug 只在 **面板去向** 存在。与 BUG-578（瞬态 reveal-race）无关。

## 修复（用户 2026-07-11 拍板：下一次复制重开面板）
整条移除 `paused` 特例（消除特殊情况而非加分支）：
- 删 `bool paused` 字段、`update` 的 paused-drop 块、`hidePanel` 的 `pause` 参数
- 关面板只 `_visible=false`+藏窗；下一条剪贴板 `update` 见 `!_visible` 直接 `_showPanel` 重开
- 设置里两处依赖 pause 的钩子（总开关关、去向切换）同步简化
- 彻底静默改走「剪贴板查词总开关 / 切换去向」，不再靠隐藏暂停门；Ctrl+Shift+D 仍可手动唤面板

## 测试 / 验证
- `clipboard_panel_controller_test.dart` 源码扫描守卫改写：钉住 paused 字段移除、非-hotkey 丢弃门移除、`!_visible` 重开、`hidePanel()` 无阻塞标志
- `flutter analyze` 全包 No issues；`clipboard_panel_controller_test` / `desktop_lookup_dispatcher_test` / `desktop_clipboard_destination_test` 全绿（16/16）
- **待真机**：面板是 native WebView2，headless 测不了。真机复测：去向=panel → 复制（弹）→ × 关 → 再复制 → 面板重开（glog `panel: shown`+`panel: updated`，不再 `paused — drop`）

> 注：分支名 `worktree-fix-transient-lookup-latestwins` 是早期误判并发竞态时起的，已废弃那条路子；实际改动是本 PR 的面板暂停语义。