### PR TITLE
fix(popup): per-base furigana anchor stops multi-kanji ruby superimposing (BUG-722)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 706 条。点号进各自文件。
+> 共 707 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-722](bugs/BUG-722-popup-multibase-ruby-furigana-overlap.md) | ✅ | ✅ | 词典弹窗多基字词逐字振假名完全重叠(勝負/将棋) |
 | [BUG-721](bugs/BUG-721-clipboard-panel-close-drops-lookups.md) | ✅ | ✅ | 剪贴板面板关闭后被永久暂停：第二个词出不来 |
 | [BUG-720](bugs/BUG-720-sasayaki-lookup-ruby-lane-misalign.md) | ✅ | ✅ | 有声书/查词注音高亮 narrow-lane 错位 |
 | [BUG-718](bugs/BUG-718-vn-restore-charoffset-cloak.md) | ✅ | ✅ | VN模式按字符偏移恢复时FOUC遮罩未移除致整页空白 |

--- a/docs/bugs/BUG-722-popup-multibase-ruby-furigana-overlap.md
+++ b/docs/bugs/BUG-722-popup-multibase-ruby-furigana-overlap.md
@@ -1,0 +1,17 @@
+## BUG-722 · 词典弹窗多基字词逐字振假名完全重叠(勝負/将棋)
+- **报告**：2026-07-11（用户：截图 小学館例解学習国語「終盤」例句「碁や将棋などで、勝負が終わり…」，勝負(しょう/ぶ)、将棋(しょう/ぎ) 注音重叠）
+- **真实性**：✅ 真 bug，根因 `hibiki/assets/popup/popup.css:822-831`（BUG-345/363 引入的 glossary `rt{position:absolute; left:0; right:0}`）+ `hibiki/assets/popup/popup.js:2589` `postProcessRuby`（只把基字裸文本换成 `<span>`，`<rt>` 仍是 `<ruby>` 的直接子）。
+- **[x] ① 已修复** — 分支 `worktree-popup-ruby-per-base-anchor`：把「每个 `<rt>` 的定位锚」从整个 `<ruby>` 下沉到**每基字**的 `<span class="ruby-unit">`。
+  - `popup.js` `postProcessRuby`：对每个 glossary `<ruby>`，把每个基字文本节点包成 `<span class="ruby-unit">`，并把紧随其后的该基字自己的 `<rt>`（跳过 `<rp>`/空白）`appendChild` **移进**该 span。基字文本仍是 `.ruby-unit` 里的活文本节点 → 划词选区不变量（BUG-110/123/125/129）不回退。
+  - `popup.css`：新增 `:where(.glossary-group,.glossary-content) .ruby-unit{display:inline-block;position:relative;line-height:1;padding-top:0.55em;vertical-align:baseline}`，把 BUG-345 横向紧凑 + BUG-363 纵向 em 预留从裸 `ruby` 迁到 `.ruby-unit`；裸 `ruby` 只保留 `inline-block;position:relative` 作 postProcess 失败时的兜底锚。`rt` 规则不变（`position:absolute;left:0;right:0;top:0`），现锚到 `.ruby-unit`（自身漢字宽）而非 `<ruby>`（整词宽）。
+  - 三镜像同步：`assets/popup/` → `assets/browser_extension/vendor/` + `tools/browser-extension/vendor/`（popup.js/popup.css 字节一致，TODO-1267 parity 守卫）；`content.css` 由 `tools/browser-extension/scripts/generate-content-css.mjs` 重新生成（两份 50140 bytes 一致）。Windows 端 `_winCss` 内联同一份 popup.css，自动覆盖。
+- **[x] ② 已加自动化测试** —
+  - 新增 `hibiki/test/pages/popup_glossary_ruby_per_base_anchor_guard_test.dart`：断言 popup.css 有 `.ruby-unit{position:relative}` 的 per-base 锚 + popup.js `postProcessRuby` 创建 `.ruby-unit` 且把 `<rt>`（`sib.tagName==='RT'`）`unit.appendChild(sib)` 移进单元（BUG-722 契约两端）。
+  - 更新既有两守卫把「横向紧凑 + 纵向 em 预留」的断言从裸 `ruby` 迁到 `.ruby-unit`：`popup_glossary_ruby_hspacing_guard_test.dart`、`popup_glossary_ruby_lineheight_guard_test.dart`（BUG-345/363 不回退，只是锚点下沉）。
+  - 全部通过（17/17，含 `browser_extension_popup_parity_guard_test.dart` 字节一致 + content.css 完整性）。
+- **备注**：
+  - **根因机理**：小学館等词典的例句振假名是**一个 `<ruby>` 里含多对「基字+`<rt>`」**（如 `<ruby>将<rt>しょう</rt>棋<rt>ぎ</rt></ruby>`）。BUG-345 为压紧基字把 `<rt>` 改 `position:absolute; left:0; right:0`——但绝对定位的 `left/right` 解析相对**最近定位祖先**。BUG-345/363 里那个祖先是整个 `position:relative` 的 `<ruby>`，于是一个词里的**每个 `<rt>` 都被拉成整词宽的同一条带、完全叠在一起**。BUG-345 的无头复现只喂了「单基字单 `<rt>`」的明鏡逐字 ruby（此时 ruby 宽=基字宽，`left:0;right:0` 恰好=单字，只 ~5px 墨迹外溢，可接受），从未覆盖多基字词 ruby，故漏了这个几何。
+  - **无头复现（Chrome/Blink CDP `getBoundingClientRect`，Windows 系统日文字体 Yu Gothic 20px）**：
+    - 修复前：`<ruby>将<rt>しょう</rt>棋<rt>ぎ</rt></ruby>` 里 しょう 与 ぎ 的 rt 盒坐标**完全相同**（left=172.89,right=212.89），相邻 rt 盒间距 **−40px（100% 重叠）**；勝負 同理。
+    - 修复后（`.ruby-unit` 逐字锚）：相邻 rt 盒间距 **0px（无重叠）**；每个读音居中于自身漢字（rt 中心 = 基字中心，delta 0）、rt 盒收敛到自身 20px 单元；基线与相邻纯假名对齐（delta 0）；纵向预留在 zoom=1/1.5/3 下对上一行墨迹均 **≥0（不撞行）**。残留仅：3 モーラ读音(しょう)对单漢字的 ~10px 右向墨迹外溢（BUG-345 既有可接受残留，非重叠）。
+  - **仍需真机验**：无头 Chromium 与 WebView2 同 Blink，但真机需用真实 WebView2(Win)/系统 WebView + 真实 Hiragino/Noto CJK，在词典弹窗打开 小学館「終盤」等含多基字词振假名的词条，确认：① 勝負/将棋 逐字注音各居其字、不重叠；② 划词仍可选中 ruby 文字并查词（BUG-110/123/125/129 不回退）；③ 词典字号调大档(zoom 1.5/2/3)注音不飘高、不压上行。

--- a/hibiki/assets/browser_extension/vendor/content.css
+++ b/hibiki/assets/browser_extension/vendor/content.css
@@ -765,17 +765,30 @@
     padding: 0 8px;
 }
 
-/* Furigana inside dictionary glossary bodies. Two layout invariants live in
-   this rule pair and must stay together:
-     - Horizontal compaction (BUG-345 / TODO-620): popup.js's postProcessRuby
-       replaces each <ruby>'s base text node with a bare <span> so the ruby text
-       stays selectable (BUG-110/123/125/129), but that <span> is still a ruby
-       base box and Blink sizes every base box to max(base, rt). With
+/* Furigana inside dictionary glossary bodies. Three layout invariants live in
+   this rule group and must stay together. The anchor of all three is the
+   per-base UNIT box (.ruby-unit), NOT the <ruby> element — popup.js's
+   postProcessRuby wraps each base text node in a <span class="ruby-unit"> and
+   moves that base's own <rt> INTO the span, so every rt sizes and positions
+   against its own kanji.
+     - Per-base anchoring (BUG-722): a dictionary word is one <ruby> holding
+       several base+<rt> pairs (e.g. <ruby>将<rt>しょう</rt>棋<rt>ぎ</rt></ruby>).
+       An absolutely-positioned rt with left:0/right:0 resolves against its
+       nearest positioned ancestor. When that ancestor was the whole <ruby>,
+       EVERY rt in the word stretched to the full ruby width and printed on top
+       of each other — しょう and ぎ (and 勝負's しょう/ぶ) fully superimposed
+       (headless Blink measured −40px / 100% overlap). Making the base <span>
+       the positioned ancestor collapses each rt back to its own kanji and
+       centres it there, so multi-kanji-word readings never collide.
+     - Horizontal compaction (BUG-345 / TODO-620): the base <span> is still a
+       ruby base box and Blink would size it to max(base, rt); with
        rt{font-size:0.5em} a >=3-kana reading is wider than its kanji, so each
-       ruby base would be stretched to its own annotation width and 明鏡-style
-       逐字 ruby lines go ragged. Keeping the <rt> out of the inline flow
-       (position:absolute) collapses every base box back to the kanji width
-       while centring the furigana above it.
+       base would stretch to its annotation width and 明鏡-style 逐字 ruby lines
+       go ragged. Keeping the <rt> out of the inline flow (position:absolute)
+       collapses every base box back to the kanji width while centring the
+       furigana above it. (The reading may still spill a few px past a very
+       narrow single kanji, as before — that residual ink overhang is BUG-345's
+       accepted trade-off; the fix above only kills the full-width superimposition.)
      - Vertical reserve, zoom-immune (BUG-108 + BUG-363 / TODO-643): the popup
        scales its whole content with documentElement.style.zoom when the user
        enlarges the dictionary font size or UI scale (dictionary_popup_webview
@@ -785,11 +798,21 @@
        box that also depended on the PREVIOUS line's leading. Under zoom!=1 that
        rounding (amplified by the zoom factor and real CJK line metrics) made the
        furigana drift up and collide with the line above. The reserve is now
-       intrinsic to the ruby element and expressed purely in em: padding-top
-       reserves room for the <rt>, which anchors to the ruby's own top (top:0).
+       intrinsic to the .ruby-unit and expressed purely in em: padding-top
+       reserves room for the <rt>, which anchors to the unit's own top (top:0).
        Reserve and annotation live on one element on one em chain, so they scale
-       together under any zoom and never depend on the neighbouring line. */
+       together under any zoom and never depend on the neighbouring line.
+   The <ruby> itself stays inline-block+relative only as a fallback anchor: if
+   postProcessRuby ever failed to wrap (never in practice), a bare <rt> would
+   still pin to the <ruby> instead of escaping to the viewport. */
 :where(.glossary-group, .glossary-content) ruby {
+    display: inline-block;
+    position: relative;
+    line-height: 1;
+    vertical-align: baseline;
+}
+
+:where(.glossary-group, .glossary-content) .ruby-unit {
     display: inline-block;
     position: relative;
     line-height: 1;

--- a/hibiki/assets/browser_extension/vendor/popup.css
+++ b/hibiki/assets/browser_extension/vendor/popup.css
@@ -787,17 +787,30 @@ html[data-theme="dark"] .glossary-group {
     padding: 0 8px;
 }
 
-/* Furigana inside dictionary glossary bodies. Two layout invariants live in
-   this rule pair and must stay together:
-     - Horizontal compaction (BUG-345 / TODO-620): popup.js's postProcessRuby
-       replaces each <ruby>'s base text node with a bare <span> so the ruby text
-       stays selectable (BUG-110/123/125/129), but that <span> is still a ruby
-       base box and Blink sizes every base box to max(base, rt). With
+/* Furigana inside dictionary glossary bodies. Three layout invariants live in
+   this rule group and must stay together. The anchor of all three is the
+   per-base UNIT box (.ruby-unit), NOT the <ruby> element — popup.js's
+   postProcessRuby wraps each base text node in a <span class="ruby-unit"> and
+   moves that base's own <rt> INTO the span, so every rt sizes and positions
+   against its own kanji.
+     - Per-base anchoring (BUG-722): a dictionary word is one <ruby> holding
+       several base+<rt> pairs (e.g. <ruby>将<rt>しょう</rt>棋<rt>ぎ</rt></ruby>).
+       An absolutely-positioned rt with left:0/right:0 resolves against its
+       nearest positioned ancestor. When that ancestor was the whole <ruby>,
+       EVERY rt in the word stretched to the full ruby width and printed on top
+       of each other — しょう and ぎ (and 勝負's しょう/ぶ) fully superimposed
+       (headless Blink measured −40px / 100% overlap). Making the base <span>
+       the positioned ancestor collapses each rt back to its own kanji and
+       centres it there, so multi-kanji-word readings never collide.
+     - Horizontal compaction (BUG-345 / TODO-620): the base <span> is still a
+       ruby base box and Blink would size it to max(base, rt); with
        rt{font-size:0.5em} a >=3-kana reading is wider than its kanji, so each
-       ruby base would be stretched to its own annotation width and 明鏡-style
-       逐字 ruby lines go ragged. Keeping the <rt> out of the inline flow
-       (position:absolute) collapses every base box back to the kanji width
-       while centring the furigana above it.
+       base would stretch to its annotation width and 明鏡-style 逐字 ruby lines
+       go ragged. Keeping the <rt> out of the inline flow (position:absolute)
+       collapses every base box back to the kanji width while centring the
+       furigana above it. (The reading may still spill a few px past a very
+       narrow single kanji, as before — that residual ink overhang is BUG-345's
+       accepted trade-off; the fix above only kills the full-width superimposition.)
      - Vertical reserve, zoom-immune (BUG-108 + BUG-363 / TODO-643): the popup
        scales its whole content with documentElement.style.zoom when the user
        enlarges the dictionary font size or UI scale (dictionary_popup_webview
@@ -807,11 +820,21 @@ html[data-theme="dark"] .glossary-group {
        box that also depended on the PREVIOUS line's leading. Under zoom!=1 that
        rounding (amplified by the zoom factor and real CJK line metrics) made the
        furigana drift up and collide with the line above. The reserve is now
-       intrinsic to the ruby element and expressed purely in em: padding-top
-       reserves room for the <rt>, which anchors to the ruby's own top (top:0).
+       intrinsic to the .ruby-unit and expressed purely in em: padding-top
+       reserves room for the <rt>, which anchors to the unit's own top (top:0).
        Reserve and annotation live on one element on one em chain, so they scale
-       together under any zoom and never depend on the neighbouring line. */
+       together under any zoom and never depend on the neighbouring line.
+   The <ruby> itself stays inline-block+relative only as a fallback anchor: if
+   postProcessRuby ever failed to wrap (never in practice), a bare <rt> would
+   still pin to the <ruby> instead of escaping to the viewport. */
 :where(.glossary-group, .glossary-content) ruby {
+    display: inline-block;
+    position: relative;
+    line-height: 1;
+    vertical-align: baseline;
+}
+
+:where(.glossary-group, .glossary-content) .ruby-unit {
     display: inline-block;
     position: relative;
     line-height: 1;

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -2588,13 +2588,37 @@ function buildEntryElement(entry, idx) {
 
 function postProcessRuby(container) {
     container.querySelectorAll('.glossary-content ruby').forEach(ruby => {
-        ruby.childNodes.forEach(node => {
-            if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
-                const span = document.createElement('span');
-                span.textContent = node.textContent;
-                node.replaceWith(span);
+        // Wrap each base text node in a <span class="ruby-unit"> and pull that
+        // base's OWN <rt> into the span. popup.css positions the rt absolutely
+        // (left:0/right:0) against its nearest positioned ancestor; making the
+        // per-base unit that ancestor keeps each rt sized/centred over its own
+        // kanji. Without this, a multi-kanji word (one <ruby> with several
+        // base+<rt> pairs, e.g. 将<rt>しょう</rt>棋<rt>ぎ</rt>) had every rt
+        // stretch to the full <ruby> width and superimpose (BUG-722). Keeping
+        // the base text as a live text node inside a <span> preserves ruby
+        // lookup selection (BUG-110/123/125/129 must not regress).
+        const children = Array.from(ruby.childNodes);
+        for (const node of children) {
+            if (node.nodeType !== Node.TEXT_NODE || !node.textContent.trim()) {
+                continue;
             }
-        });
+            const unit = document.createElement('span');
+            unit.className = 'ruby-unit';
+            unit.textContent = node.textContent;
+            node.replaceWith(unit);
+            // Move the immediately-following <rt> into the unit, stepping over
+            // <rp> fallback parens and whitespace text nodes that sit between a
+            // base and its reading.
+            let sib = unit.nextSibling;
+            while (sib &&
+                   ((sib.nodeType === Node.TEXT_NODE && !sib.textContent.trim()) ||
+                    (sib.nodeType === Node.ELEMENT_NODE && sib.tagName === 'RP'))) {
+                sib = sib.nextSibling;
+            }
+            if (sib && sib.nodeType === Node.ELEMENT_NODE && sib.tagName === 'RT') {
+                unit.appendChild(sib);
+            }
+        }
     });
 }
 

--- a/hibiki/assets/popup/popup.css
+++ b/hibiki/assets/popup/popup.css
@@ -787,17 +787,30 @@ html[data-theme="dark"] .glossary-group {
     padding: 0 8px;
 }
 
-/* Furigana inside dictionary glossary bodies. Two layout invariants live in
-   this rule pair and must stay together:
-     - Horizontal compaction (BUG-345 / TODO-620): popup.js's postProcessRuby
-       replaces each <ruby>'s base text node with a bare <span> so the ruby text
-       stays selectable (BUG-110/123/125/129), but that <span> is still a ruby
-       base box and Blink sizes every base box to max(base, rt). With
+/* Furigana inside dictionary glossary bodies. Three layout invariants live in
+   this rule group and must stay together. The anchor of all three is the
+   per-base UNIT box (.ruby-unit), NOT the <ruby> element — popup.js's
+   postProcessRuby wraps each base text node in a <span class="ruby-unit"> and
+   moves that base's own <rt> INTO the span, so every rt sizes and positions
+   against its own kanji.
+     - Per-base anchoring (BUG-722): a dictionary word is one <ruby> holding
+       several base+<rt> pairs (e.g. <ruby>将<rt>しょう</rt>棋<rt>ぎ</rt></ruby>).
+       An absolutely-positioned rt with left:0/right:0 resolves against its
+       nearest positioned ancestor. When that ancestor was the whole <ruby>,
+       EVERY rt in the word stretched to the full ruby width and printed on top
+       of each other — しょう and ぎ (and 勝負's しょう/ぶ) fully superimposed
+       (headless Blink measured −40px / 100% overlap). Making the base <span>
+       the positioned ancestor collapses each rt back to its own kanji and
+       centres it there, so multi-kanji-word readings never collide.
+     - Horizontal compaction (BUG-345 / TODO-620): the base <span> is still a
+       ruby base box and Blink would size it to max(base, rt); with
        rt{font-size:0.5em} a >=3-kana reading is wider than its kanji, so each
-       ruby base would be stretched to its own annotation width and 明鏡-style
-       逐字 ruby lines go ragged. Keeping the <rt> out of the inline flow
-       (position:absolute) collapses every base box back to the kanji width
-       while centring the furigana above it.
+       base would stretch to its annotation width and 明鏡-style 逐字 ruby lines
+       go ragged. Keeping the <rt> out of the inline flow (position:absolute)
+       collapses every base box back to the kanji width while centring the
+       furigana above it. (The reading may still spill a few px past a very
+       narrow single kanji, as before — that residual ink overhang is BUG-345's
+       accepted trade-off; the fix above only kills the full-width superimposition.)
      - Vertical reserve, zoom-immune (BUG-108 + BUG-363 / TODO-643): the popup
        scales its whole content with documentElement.style.zoom when the user
        enlarges the dictionary font size or UI scale (dictionary_popup_webview
@@ -807,11 +820,21 @@ html[data-theme="dark"] .glossary-group {
        box that also depended on the PREVIOUS line's leading. Under zoom!=1 that
        rounding (amplified by the zoom factor and real CJK line metrics) made the
        furigana drift up and collide with the line above. The reserve is now
-       intrinsic to the ruby element and expressed purely in em: padding-top
-       reserves room for the <rt>, which anchors to the ruby's own top (top:0).
+       intrinsic to the .ruby-unit and expressed purely in em: padding-top
+       reserves room for the <rt>, which anchors to the unit's own top (top:0).
        Reserve and annotation live on one element on one em chain, so they scale
-       together under any zoom and never depend on the neighbouring line. */
+       together under any zoom and never depend on the neighbouring line.
+   The <ruby> itself stays inline-block+relative only as a fallback anchor: if
+   postProcessRuby ever failed to wrap (never in practice), a bare <rt> would
+   still pin to the <ruby> instead of escaping to the viewport. */
 :where(.glossary-group, .glossary-content) ruby {
+    display: inline-block;
+    position: relative;
+    line-height: 1;
+    vertical-align: baseline;
+}
+
+:where(.glossary-group, .glossary-content) .ruby-unit {
     display: inline-block;
     position: relative;
     line-height: 1;

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -2588,13 +2588,37 @@ function buildEntryElement(entry, idx) {
 
 function postProcessRuby(container) {
     container.querySelectorAll('.glossary-content ruby').forEach(ruby => {
-        ruby.childNodes.forEach(node => {
-            if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
-                const span = document.createElement('span');
-                span.textContent = node.textContent;
-                node.replaceWith(span);
+        // Wrap each base text node in a <span class="ruby-unit"> and pull that
+        // base's OWN <rt> into the span. popup.css positions the rt absolutely
+        // (left:0/right:0) against its nearest positioned ancestor; making the
+        // per-base unit that ancestor keeps each rt sized/centred over its own
+        // kanji. Without this, a multi-kanji word (one <ruby> with several
+        // base+<rt> pairs, e.g. 将<rt>しょう</rt>棋<rt>ぎ</rt>) had every rt
+        // stretch to the full <ruby> width and superimpose (BUG-722). Keeping
+        // the base text as a live text node inside a <span> preserves ruby
+        // lookup selection (BUG-110/123/125/129 must not regress).
+        const children = Array.from(ruby.childNodes);
+        for (const node of children) {
+            if (node.nodeType !== Node.TEXT_NODE || !node.textContent.trim()) {
+                continue;
             }
-        });
+            const unit = document.createElement('span');
+            unit.className = 'ruby-unit';
+            unit.textContent = node.textContent;
+            node.replaceWith(unit);
+            // Move the immediately-following <rt> into the unit, stepping over
+            // <rp> fallback parens and whitespace text nodes that sit between a
+            // base and its reading.
+            let sib = unit.nextSibling;
+            while (sib &&
+                   ((sib.nodeType === Node.TEXT_NODE && !sib.textContent.trim()) ||
+                    (sib.nodeType === Node.ELEMENT_NODE && sib.tagName === 'RP'))) {
+                sib = sib.nextSibling;
+            }
+            if (sib && sib.nodeType === Node.ELEMENT_NODE && sib.tagName === 'RT') {
+                unit.appendChild(sib);
+            }
+        }
     });
 }
 

--- a/hibiki/test/pages/popup_glossary_ruby_hspacing_guard_test.dart
+++ b/hibiki/test/pages/popup_glossary_ruby_hspacing_guard_test.dart
@@ -4,62 +4,66 @@ import 'package:flutter_test/flutter_test.dart';
 
 // BUG-345 / TODO-620: in the dictionary popup, glossary bodies that carry
 // per-character furigana (明鏡-style 逐字 ruby, e.g. 顔(かお)を洗(あら)う…) rendered
-// with ragged horizontal spacing. popup.js's postProcessRuby replaces each
-// <ruby>'s base text node with a bare <span> so the ruby text stays
-// selectable (BUG-110/123/125/129 must not regress), but that <span> is still a
-// ruby base box: Blink sizes every ruby base box to max(base, rt). With
-// rt{font-size:0.5em}, a reading of >=3 kana is wider than its 1em kanji, so
-// each ruby base is stretched to its own annotation width and the line goes
-// ragged. The fix takes the <rt> out of the inline flow (position:absolute) so
-// it no longer widens the base box, while keeping the furigana centred above
-// the kanji.
+// with ragged horizontal spacing. popup.js's postProcessRuby wraps each
+// <ruby>'s base text node in a <span> so the ruby text stays selectable
+// (BUG-110/123/125/129 must not regress), but that <span> is still a ruby base
+// box: Blink sizes every ruby base box to max(base, rt). With rt{font-size:0.5em}
+// a reading of >=3 kana is wider than its 1em kanji, so each base is stretched
+// to its own annotation width and the line goes ragged. The fix takes the <rt>
+// out of the inline flow (position:absolute) so it no longer widens the base
+// box, while keeping the furigana centred above the kanji.
 //
-// BUG-363 / TODO-643 then made the vertical reserve zoom-immune: the old
-// reserve borrowed ruby{line-height:2} half-leading and anchored the <rt> with
-// bottom:100% (a percentage against a per-fragment-rounded, neighbour-dependent
-// line box), which drifted under the popup's content zoom. The reserve is now
-// an em-relative padding-top on the ruby element with the <rt> at top:0 — both
-// invariants live in the same rule pair and must stay together.
+// BUG-722 then moved that base box (and the reserve below) from the bare <ruby>
+// onto a per-base <span class="ruby-unit">, so the absolutely-positioned <rt>
+// anchors to its OWN kanji: a multi-kanji word is one <ruby> with several
+// base+<rt> pairs, and anchoring the rt to the whole <ruby> made every rt
+// stretch to the full word width and superimpose. So the compaction + reserve
+// invariants now live on `.ruby-unit`; the bare `ruby` keeps display:inline-block
+// + position:relative only as a fallback anchor.
 //
 // Ruby geometry can't render headless in a WebView, so guard the CSS rules'
 // presence (the headless-Chromium repro proved horizontal spread 18.25px -> 0px
-// and the zoom vertical overlap -22.5px -> 0.00px). The Windows popup inlines
+// and the multi-kanji superimposition -40px -> 0px). The Windows popup inlines
 // this same popup.css via _winCss, so one guard covers all platforms.
 void main() {
   final String css = File('assets/popup/popup.css').readAsStringSync();
 
+  final RegExp rubyUnitRule = RegExp(
+    r':where\([^)]*\bglossary-group\b[^)]*,[^)]*\bglossary-content\b[^)]*\)\s*\.ruby-unit\s*\{([^}]*)\}',
+  );
+
   test(
-      'glossary ruby is laid out as inline-block + relative so rt cannot '
-      'stretch the base box (BUG-345)', () {
-    final RegExp rubyRule = RegExp(
-      r':where\([^)]*\bglossary-group\b[^)]*,[^)]*\bglossary-content\b[^)]*\)\s*ruby\s*\{([^}]*)\}',
-    );
-    final RegExpMatch? match = rubyRule.firstMatch(css);
+      'per-base .ruby-unit is inline-block + relative so rt cannot stretch the '
+      'base box and anchors to its own kanji (BUG-345 / BUG-722)', () {
+    final RegExpMatch? match = rubyUnitRule.firstMatch(css);
     expect(
       match,
       isNotNull,
-      reason: 'popup.css must scope a ruby block to the glossary surfaces '
-          '(.glossary-group / .glossary-content)',
+      reason:
+          'popup.css must scope a .ruby-unit block to the glossary surfaces '
+          '(.glossary-group / .glossary-content) — that per-base box is the '
+          'anchor for the absolute <rt> (BUG-722)',
     );
     final String body = match!.group(1)!;
     expect(
       RegExp(r'display\s*:\s*inline-block').hasMatch(body),
       isTrue,
-      reason: 'glossary <ruby> must be display:inline-block so the base box '
+      reason: '.ruby-unit must be display:inline-block so the base box '
           'collapses to the kanji width instead of being stretched to the '
           'rt width (BUG-345)',
     );
     expect(
       RegExp(r'position\s*:\s*relative').hasMatch(body),
       isTrue,
-      reason: 'glossary <ruby> must be position:relative so the absolutely '
-          'positioned <rt> anchors to its own base (BUG-345)',
+      reason: '.ruby-unit must be position:relative so the absolutely '
+          'positioned <rt> anchors to its own kanji, not the full-width '
+          '<ruby> — otherwise multi-kanji-word readings superimpose (BUG-722)',
     );
   });
 
   test(
       'glossary rt is taken out of the inline flow (absolute, anchored to the '
-      'ruby top) so it cannot widen the base box (BUG-345 / BUG-363)', () {
+      'unit top) so it cannot widen the base box (BUG-345 / BUG-363)', () {
     final RegExp rtRule = RegExp(
       r':where\([^)]*\bglossary-group\b[^)]*,[^)]*\bglossary-content\b[^)]*\)\s*rt\s*\{([^}]*)\}',
     );
@@ -79,27 +83,24 @@ void main() {
     expect(
       RegExp(r'top\s*:\s*0\b').hasMatch(body),
       isTrue,
-      reason: 'glossary <rt> must anchor to the ruby top (top:0) inside the em '
+      reason: 'glossary <rt> must anchor to the unit top (top:0) inside the em '
           'padding-top reserve, so its position scales cleanly with the popup '
           'zoom instead of drifting (BUG-363)',
     );
   });
 
   test(
-      'the vertical furigana reserve is an em padding-top on the ruby, not the '
-      'old line-height:2 leading (BUG-108 reserve preserved, zoom-immune for '
-      'BUG-363)', () {
-    final RegExp rubyRule = RegExp(
-      r':where\([^)]*\bglossary-group\b[^)]*,[^)]*\bglossary-content\b[^)]*\)\s*ruby\s*\{([^}]*)\}',
-    );
-    final String body = rubyRule.firstMatch(css)!.group(1)!;
+      'the vertical furigana reserve is an em padding-top on the per-base '
+      '.ruby-unit, not the old line-height:2 leading (BUG-108 reserve '
+      'preserved, zoom-immune for BUG-363)', () {
+    final String body = rubyUnitRule.firstMatch(css)!.group(1)!;
     expect(
       RegExp(r'padding-top\s*:\s*[\d.]+em').hasMatch(body),
       isTrue,
-      reason: 'glossary <ruby> must reserve furigana room with an em-relative '
-          'padding-top — the absolutely positioned furigana relies on that '
-          'reserve to clear the line above, and the em unit keeps it correct '
-          'under any popup zoom (BUG-108 reserve + BUG-363 zoom-immunity)',
+      reason: 'glossary .ruby-unit must reserve furigana room with an '
+          'em-relative padding-top — the absolutely positioned furigana relies '
+          'on that reserve to clear the line above, and the em unit keeps it '
+          'correct under any popup zoom (BUG-108 reserve + BUG-363 zoom-immunity)',
     );
   });
 }

--- a/hibiki/test/pages/popup_glossary_ruby_lineheight_guard_test.dart
+++ b/hibiki/test/pages/popup_glossary_ruby_lineheight_guard_test.dart
@@ -12,60 +12,64 @@ import 'package:flutter_test/flutter_test.dart';
 // ruby{line-height:2} and anchored the <rt> with bottom:100%. That percentage
 // resolves against a per-fragment-rounded line box that also depends on the
 // PREVIOUS line, so under zoom!=1 the furigana drifted up and collided with the
-// line above (BUG-363). The reserve is now intrinsic to the ruby element and
-// expressed purely in em (padding-top) with the <rt> anchored to the ruby's own
-// top (top:0) — one element, one em chain, scales cleanly under any zoom.
+// line above (BUG-363). The reserve became an em padding-top with the <rt>
+// anchored to top:0 — one element, one em chain, scales cleanly under any zoom.
+//
+// BUG-722 then moved the reserve from the bare <ruby> onto the per-base
+// <span class="ruby-unit"> (so each rt anchors to its own kanji instead of
+// stretching across a multi-kanji word). The reserve + anchor therefore now
+// live on `.ruby-unit`; this guard tracks them there.
 //
 // Ruby geometry can't render headless in a WebView, so guard the CSS rules'
 // presence. The headless-Chromium repro proved the old scheme overlapped the
 // line above by -7.5/-11.25/-22.5px at zoom 1/1.5/3, while the new scheme keeps
-// rtTop flush with the previous line's bottom (0.00px) at every zoom.
+// rtTop flush with (>=0 above) the previous line's bottom at every zoom.
 void main() {
   final String css = File('assets/popup/popup.css').readAsStringSync();
 
-  final RegExp glossaryRubyRule = RegExp(
-    r':where\([^)]*\bglossary-group\b[^)]*,[^)]*\bglossary-content\b[^)]*\)\s*ruby\s*\{([^}]*)\}',
+  final RegExp glossaryRubyUnitRule = RegExp(
+    r':where\([^)]*\bglossary-group\b[^)]*,[^)]*\bglossary-content\b[^)]*\)\s*\.ruby-unit\s*\{([^}]*)\}',
   );
   final RegExp glossaryRtRule = RegExp(
     r':where\([^)]*\bglossary-group\b[^)]*,[^)]*\bglossary-content\b[^)]*\)\s*rt\s*\{([^}]*)\}',
   );
 
   test(
-      'glossary ruby reserves vertical room with an em padding-top, not the '
-      'fragile line-height:2 leading (BUG-108 / BUG-363)', () {
-    final RegExpMatch? match = glossaryRubyRule.firstMatch(css);
+      'glossary .ruby-unit reserves vertical room with an em padding-top, not '
+      'the fragile line-height:2 leading (BUG-108 / BUG-363)', () {
+    final RegExpMatch? match = glossaryRubyUnitRule.firstMatch(css);
     expect(match, isNotNull,
-        reason: 'popup.css must scope a ruby block to the glossary surfaces '
-            '(.glossary-group / .glossary-content)');
+        reason: 'popup.css must scope a .ruby-unit block to the glossary '
+            'surfaces (.glossary-group / .glossary-content)');
     final String body = match!.group(1)!;
-    // The reserve must be an em-relative padding-top on the ruby element itself,
-    // so it scales 1:1 with the popup zoom and never borrows the line box.
+    // The reserve must be an em-relative padding-top on the unit itself, so it
+    // scales 1:1 with the popup zoom and never borrows the line box.
     expect(
       RegExp(r'padding-top\s*:\s*[\d.]+em').hasMatch(body),
       isTrue,
-      reason: 'glossary <ruby> must reserve furigana room with an em-relative '
-          'padding-top (intrinsic + zoom-immune), not the implicit line box '
-          'leading (BUG-363 / TODO-643)',
+      reason: 'glossary .ruby-unit must reserve furigana room with an '
+          'em-relative padding-top (intrinsic + zoom-immune), not the implicit '
+          'line box leading (BUG-363 / TODO-643)',
     );
-    // line-height:1 keeps the ruby from re-borrowing leading; the absolute <rt>
+    // line-height:1 keeps the unit from re-borrowing leading; the absolute <rt>
     // lives in the padding instead.
     expect(
       RegExp(r'line-height\s*:\s*1\b').hasMatch(body),
       isTrue,
-      reason: 'glossary <ruby> must use line-height:1 so the vertical reserve '
-          'comes only from the em padding-top, not the line box (BUG-363)',
+      reason: 'glossary .ruby-unit must use line-height:1 so the vertical '
+          'reserve comes only from the em padding-top, not the line box (BUG-363)',
     );
     // The old fragile reserve must be gone.
     expect(
       RegExp(r'line-height\s*:\s*2\b').hasMatch(body),
       isFalse,
-      reason: 'glossary <ruby> must NOT use the old line-height:2 leading '
+      reason: 'glossary .ruby-unit must NOT use the old line-height:2 leading '
           'reserve — it drifts under zoom (BUG-363)',
     );
   });
 
   test(
-      'glossary rt anchors to the ruby top (top:0), not bottom:100% which drifts '
+      'glossary rt anchors to the unit top (top:0), not bottom:100% which drifts '
       'under zoom (BUG-363)', () {
     final RegExpMatch? match = glossaryRtRule.firstMatch(css);
     expect(match, isNotNull,
@@ -80,7 +84,7 @@ void main() {
     expect(
       RegExp(r'top\s*:\s*0\b').hasMatch(body),
       isTrue,
-      reason: 'glossary <rt> must anchor to the ruby element top (top:0), '
+      reason: 'glossary <rt> must anchor to the .ruby-unit top (top:0), '
           'inside the em padding-top reserve, so its position scales cleanly '
           'with zoom (BUG-363)',
     );

--- a/hibiki/test/pages/popup_glossary_ruby_per_base_anchor_guard_test.dart
+++ b/hibiki/test/pages/popup_glossary_ruby_per_base_anchor_guard_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+// BUG-722: dictionary popup glossary furigana of multi-kanji words (勝負 / 将棋)
+// fully superimposed — しょう printed on top of ぶ, しょう on top of ぎ.
+//
+// Root cause: a dictionary word is ONE <ruby> holding several base+<rt> pairs
+// (e.g. <ruby>将<rt>しょう</rt>棋<rt>ぎ</rt></ruby>). popup.css positions each
+// <rt> absolutely with left:0/right:0, which resolves against the nearest
+// positioned ancestor. When that ancestor was the whole <ruby>, EVERY rt in the
+// word stretched to the full ruby width and printed in the same band (headless
+// Blink measured −40px / 100% overlap between consecutive rt boxes).
+//
+// Fix: popup.js's postProcessRuby wraps each base text node in a
+// <span class="ruby-unit"> (position:relative) and moves that base's own <rt>
+// INTO the span, so each rt anchors to — and centres over — its own kanji
+// (headless: consecutive rt-box gap −40px → 0px, each rt clamped to its 20px
+// unit). The base text stays a live text node inside the span, so ruby lookup
+// selection is unchanged (BUG-110/123/125/129 must not regress).
+//
+// Ruby geometry can't render in a headless Flutter test, so guard the two
+// halves of the contract in source: (1) popup.css scopes the per-base anchor to
+// .ruby-unit; (2) postProcessRuby creates .ruby-unit per base and relocates the
+// following <rt> into it. The Windows popup inlines the same popup.css/js and
+// both extension mirrors are byte-identical (TODO-1267 parity guard), so this
+// one guard covers every surface.
+void main() {
+  final String css = File('assets/popup/popup.css').readAsStringSync();
+  final String js = File('assets/popup/popup.js').readAsStringSync();
+
+  test(
+      'popup.css gives each furigana base its own positioned .ruby-unit '
+      'anchor (BUG-722)', () {
+    final RegExp rubyUnitRule = RegExp(
+      r':where\([^)]*\bglossary-group\b[^)]*,[^)]*\bglossary-content\b[^)]*\)\s*\.ruby-unit\s*\{([^}]*)\}',
+    );
+    final RegExpMatch? m = rubyUnitRule.firstMatch(css);
+    expect(m, isNotNull,
+        reason: 'popup.css must scope a .ruby-unit block to the glossary '
+            'surfaces so each base kanji is its own positioned box (BUG-722)');
+    expect(RegExp(r'position\s*:\s*relative').hasMatch(m!.group(1)!), isTrue,
+        reason: '.ruby-unit must be position:relative so the absolute <rt> '
+            'anchors to its own kanji, not the full-width <ruby> (BUG-722)');
+  });
+
+  test(
+      'postProcessRuby wraps each base in .ruby-unit and moves its <rt> into '
+      'the unit (BUG-722)', () {
+    expect(js.contains('function postProcessRuby('), isTrue,
+        reason: 'popup.js must define postProcessRuby');
+    // Per-base unit is created…
+    expect(js.contains("className = 'ruby-unit'"), isTrue,
+        reason: 'postProcessRuby must wrap each base in a .ruby-unit span so '
+            'its <rt> can anchor per-kanji (BUG-722)');
+    // …and the base\'s own <rt> is relocated INTO that unit. If the rt stayed a
+    // sibling of the whole ruby it would re-collapse to the full word width.
+    expect(js.contains("sib.tagName === 'RT'"), isTrue,
+        reason: 'postProcessRuby must find the base\'s following <rt> element');
+    expect(js.contains('unit.appendChild(sib)'), isTrue,
+        reason:
+            'postProcessRuby must move each base\'s <rt> INTO its .ruby-unit '
+            '(appendChild) — otherwise every rt anchors to the whole <ruby> and '
+            'multi-kanji-word readings superimpose (BUG-722)');
+  });
+}

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -765,17 +765,30 @@
     padding: 0 8px;
 }
 
-/* Furigana inside dictionary glossary bodies. Two layout invariants live in
-   this rule pair and must stay together:
-     - Horizontal compaction (BUG-345 / TODO-620): popup.js's postProcessRuby
-       replaces each <ruby>'s base text node with a bare <span> so the ruby text
-       stays selectable (BUG-110/123/125/129), but that <span> is still a ruby
-       base box and Blink sizes every base box to max(base, rt). With
+/* Furigana inside dictionary glossary bodies. Three layout invariants live in
+   this rule group and must stay together. The anchor of all three is the
+   per-base UNIT box (.ruby-unit), NOT the <ruby> element — popup.js's
+   postProcessRuby wraps each base text node in a <span class="ruby-unit"> and
+   moves that base's own <rt> INTO the span, so every rt sizes and positions
+   against its own kanji.
+     - Per-base anchoring (BUG-722): a dictionary word is one <ruby> holding
+       several base+<rt> pairs (e.g. <ruby>将<rt>しょう</rt>棋<rt>ぎ</rt></ruby>).
+       An absolutely-positioned rt with left:0/right:0 resolves against its
+       nearest positioned ancestor. When that ancestor was the whole <ruby>,
+       EVERY rt in the word stretched to the full ruby width and printed on top
+       of each other — しょう and ぎ (and 勝負's しょう/ぶ) fully superimposed
+       (headless Blink measured −40px / 100% overlap). Making the base <span>
+       the positioned ancestor collapses each rt back to its own kanji and
+       centres it there, so multi-kanji-word readings never collide.
+     - Horizontal compaction (BUG-345 / TODO-620): the base <span> is still a
+       ruby base box and Blink would size it to max(base, rt); with
        rt{font-size:0.5em} a >=3-kana reading is wider than its kanji, so each
-       ruby base would be stretched to its own annotation width and 明鏡-style
-       逐字 ruby lines go ragged. Keeping the <rt> out of the inline flow
-       (position:absolute) collapses every base box back to the kanji width
-       while centring the furigana above it.
+       base would stretch to its annotation width and 明鏡-style 逐字 ruby lines
+       go ragged. Keeping the <rt> out of the inline flow (position:absolute)
+       collapses every base box back to the kanji width while centring the
+       furigana above it. (The reading may still spill a few px past a very
+       narrow single kanji, as before — that residual ink overhang is BUG-345's
+       accepted trade-off; the fix above only kills the full-width superimposition.)
      - Vertical reserve, zoom-immune (BUG-108 + BUG-363 / TODO-643): the popup
        scales its whole content with documentElement.style.zoom when the user
        enlarges the dictionary font size or UI scale (dictionary_popup_webview
@@ -785,11 +798,21 @@
        box that also depended on the PREVIOUS line's leading. Under zoom!=1 that
        rounding (amplified by the zoom factor and real CJK line metrics) made the
        furigana drift up and collide with the line above. The reserve is now
-       intrinsic to the ruby element and expressed purely in em: padding-top
-       reserves room for the <rt>, which anchors to the ruby's own top (top:0).
+       intrinsic to the .ruby-unit and expressed purely in em: padding-top
+       reserves room for the <rt>, which anchors to the unit's own top (top:0).
        Reserve and annotation live on one element on one em chain, so they scale
-       together under any zoom and never depend on the neighbouring line. */
+       together under any zoom and never depend on the neighbouring line.
+   The <ruby> itself stays inline-block+relative only as a fallback anchor: if
+   postProcessRuby ever failed to wrap (never in practice), a bare <rt> would
+   still pin to the <ruby> instead of escaping to the viewport. */
 :where(.glossary-group, .glossary-content) ruby {
+    display: inline-block;
+    position: relative;
+    line-height: 1;
+    vertical-align: baseline;
+}
+
+:where(.glossary-group, .glossary-content) .ruby-unit {
     display: inline-block;
     position: relative;
     line-height: 1;

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -787,17 +787,30 @@ html[data-theme="dark"] .glossary-group {
     padding: 0 8px;
 }
 
-/* Furigana inside dictionary glossary bodies. Two layout invariants live in
-   this rule pair and must stay together:
-     - Horizontal compaction (BUG-345 / TODO-620): popup.js's postProcessRuby
-       replaces each <ruby>'s base text node with a bare <span> so the ruby text
-       stays selectable (BUG-110/123/125/129), but that <span> is still a ruby
-       base box and Blink sizes every base box to max(base, rt). With
+/* Furigana inside dictionary glossary bodies. Three layout invariants live in
+   this rule group and must stay together. The anchor of all three is the
+   per-base UNIT box (.ruby-unit), NOT the <ruby> element — popup.js's
+   postProcessRuby wraps each base text node in a <span class="ruby-unit"> and
+   moves that base's own <rt> INTO the span, so every rt sizes and positions
+   against its own kanji.
+     - Per-base anchoring (BUG-722): a dictionary word is one <ruby> holding
+       several base+<rt> pairs (e.g. <ruby>将<rt>しょう</rt>棋<rt>ぎ</rt></ruby>).
+       An absolutely-positioned rt with left:0/right:0 resolves against its
+       nearest positioned ancestor. When that ancestor was the whole <ruby>,
+       EVERY rt in the word stretched to the full ruby width and printed on top
+       of each other — しょう and ぎ (and 勝負's しょう/ぶ) fully superimposed
+       (headless Blink measured −40px / 100% overlap). Making the base <span>
+       the positioned ancestor collapses each rt back to its own kanji and
+       centres it there, so multi-kanji-word readings never collide.
+     - Horizontal compaction (BUG-345 / TODO-620): the base <span> is still a
+       ruby base box and Blink would size it to max(base, rt); with
        rt{font-size:0.5em} a >=3-kana reading is wider than its kanji, so each
-       ruby base would be stretched to its own annotation width and 明鏡-style
-       逐字 ruby lines go ragged. Keeping the <rt> out of the inline flow
-       (position:absolute) collapses every base box back to the kanji width
-       while centring the furigana above it.
+       base would stretch to its annotation width and 明鏡-style 逐字 ruby lines
+       go ragged. Keeping the <rt> out of the inline flow (position:absolute)
+       collapses every base box back to the kanji width while centring the
+       furigana above it. (The reading may still spill a few px past a very
+       narrow single kanji, as before — that residual ink overhang is BUG-345's
+       accepted trade-off; the fix above only kills the full-width superimposition.)
      - Vertical reserve, zoom-immune (BUG-108 + BUG-363 / TODO-643): the popup
        scales its whole content with documentElement.style.zoom when the user
        enlarges the dictionary font size or UI scale (dictionary_popup_webview
@@ -807,11 +820,21 @@ html[data-theme="dark"] .glossary-group {
        box that also depended on the PREVIOUS line's leading. Under zoom!=1 that
        rounding (amplified by the zoom factor and real CJK line metrics) made the
        furigana drift up and collide with the line above. The reserve is now
-       intrinsic to the ruby element and expressed purely in em: padding-top
-       reserves room for the <rt>, which anchors to the ruby's own top (top:0).
+       intrinsic to the .ruby-unit and expressed purely in em: padding-top
+       reserves room for the <rt>, which anchors to the unit's own top (top:0).
        Reserve and annotation live on one element on one em chain, so they scale
-       together under any zoom and never depend on the neighbouring line. */
+       together under any zoom and never depend on the neighbouring line.
+   The <ruby> itself stays inline-block+relative only as a fallback anchor: if
+   postProcessRuby ever failed to wrap (never in practice), a bare <rt> would
+   still pin to the <ruby> instead of escaping to the viewport. */
 :where(.glossary-group, .glossary-content) ruby {
+    display: inline-block;
+    position: relative;
+    line-height: 1;
+    vertical-align: baseline;
+}
+
+:where(.glossary-group, .glossary-content) .ruby-unit {
     display: inline-block;
     position: relative;
     line-height: 1;

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -2588,13 +2588,37 @@ function buildEntryElement(entry, idx) {
 
 function postProcessRuby(container) {
     container.querySelectorAll('.glossary-content ruby').forEach(ruby => {
-        ruby.childNodes.forEach(node => {
-            if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
-                const span = document.createElement('span');
-                span.textContent = node.textContent;
-                node.replaceWith(span);
+        // Wrap each base text node in a <span class="ruby-unit"> and pull that
+        // base's OWN <rt> into the span. popup.css positions the rt absolutely
+        // (left:0/right:0) against its nearest positioned ancestor; making the
+        // per-base unit that ancestor keeps each rt sized/centred over its own
+        // kanji. Without this, a multi-kanji word (one <ruby> with several
+        // base+<rt> pairs, e.g. 将<rt>しょう</rt>棋<rt>ぎ</rt>) had every rt
+        // stretch to the full <ruby> width and superimpose (BUG-722). Keeping
+        // the base text as a live text node inside a <span> preserves ruby
+        // lookup selection (BUG-110/123/125/129 must not regress).
+        const children = Array.from(ruby.childNodes);
+        for (const node of children) {
+            if (node.nodeType !== Node.TEXT_NODE || !node.textContent.trim()) {
+                continue;
             }
-        });
+            const unit = document.createElement('span');
+            unit.className = 'ruby-unit';
+            unit.textContent = node.textContent;
+            node.replaceWith(unit);
+            // Move the immediately-following <rt> into the unit, stepping over
+            // <rp> fallback parens and whitespace text nodes that sit between a
+            // base and its reading.
+            let sib = unit.nextSibling;
+            while (sib &&
+                   ((sib.nodeType === Node.TEXT_NODE && !sib.textContent.trim()) ||
+                    (sib.nodeType === Node.ELEMENT_NODE && sib.tagName === 'RP'))) {
+                sib = sib.nextSibling;
+            }
+            if (sib && sib.nodeType === Node.ELEMENT_NODE && sib.tagName === 'RT') {
+                unit.appendChild(sib);
+            }
+        }
     });
 }
 


### PR DESCRIPTION
## 问题
词典弹窗中，一个 `<ruby>` 含多对「基字+`<rt>`」的词（如 `将<rt>しょう</rt>棋<rt>ぎ</rt>`、`勝<rt>しょう</rt>負<rt>ぶ</rt>`）逐字振假名**完全重叠**（用户截图 小学館「終盤」例句 勝負/将棋）。

## 根因
BUG-345/363 为压紧基字把 glossary `rt` 改 `position:absolute; left:0; right:0`，但绝对定位的 `left/right` 解析相对**最近定位祖先** = 整个 `position:relative` 的 `<ruby>`。多基字词里每个 rt 都被拉成整词宽同一条带 → 叠在一起。无头 Blink 实测相邻 rt 盒间距 **−40px（100% 重叠）**。BUG-345 复现只覆盖单基字单 rt，漏了此几何。

## 修复（方案 B：每基字独立锚，保持紧凑字间）
- `postProcessRuby`：每个基字包成 `<span class="ruby-unit">`(position:relative)，把其 `<rt>` `appendChild` 移入 → rt 锚自身漢字宽。基字仍是活文本节点，划词选区(BUG-110/123/125/129)不回退。
- `popup.css`：横向紧凑(BUG-345)+纵向 em 预留(BUG-363)锚点从裸 `ruby` 迁到 `.ruby-unit`；裸 `ruby` 仅留兜底锚。
- 三镜像字节同步 + `content.css` 由 generate-content-css.mjs 重生成(TODO-1267 parity)。

## 验证
- 无头 Chrome/Blink（Windows 系统日文字体）：相邻 rt 间距 **−40px→0px**，每读音居中于自身漢字(delta 0)，基线对齐(0)，zoom 1/1.5/3 纵向预留 ≥0。残留仅 ~10px 单漢字宽读音右向墨迹外溢（BUG-345 既有可接受残留）。
- `flutter analyze`：No issues found。
- `flutter test`：新增 `popup_glossary_ruby_per_base_anchor_guard_test.dart` + 更新两既有 ruby 守卫 + parity 守卫，17/17 通过。
- **仍需真机验**：真实 WebView2/系统 WebView + Hiragino/Noto CJK 打开含多基字词振假名词条，确认逐字注音各居其字、划词仍可查、大字号 zoom 不飘。