### PR TITLE
feat(mining): 制卡前「选择句子上下文」预览模态（抄 Niratan mac 版）

### DIFF
--- a/hibiki/assets/browser_extension/vendor/content.css
+++ b/hibiki/assets/browser_extension/vendor/content.css
@@ -1252,6 +1252,159 @@
     border-radius: 2px;
 }
 
+/* ── Niratan「制卡前调整·选择句子上下文」模态 ────────────────────────────────
+   由词条上的「调整上下文」按钮（.ctx-adjust-button）打开。全部 class-rooted 选择器，
+   content.css 生成器自动 scope 进 #entries-container（扩展侧 sentenceContextPreviewEnabled
+   恒 undefined，不渲染，纯 dead style）。颜色走 popup 主题变量，暗/亮自适应。 */
+.sentence-context-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 2147483000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(0, 0, 0, 0.42);
+    -webkit-user-select: none;
+    user-select: none;
+    box-sizing: border-box;
+}
+
+.scm-card {
+    width: 100%;
+    max-width: 460px;
+    max-height: 92%;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    padding: 16px;
+    border-radius: var(--hibiki-radius-card, 14px);
+    background: var(--background-color, #fff);
+    color: var(--text-color, #000);
+    border: 1px solid var(--outline-variant, rgba(128, 128, 128, 0.32));
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+
+.scm-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.scm-eyebrow {
+    font-size: 0.78em;
+    color: var(--text-color-light3, #777);
+}
+
+.scm-x {
+    flex: 0 0 auto;
+    opacity: 0.7;
+}
+
+.scm-title {
+    font-size: 1.12em;
+    font-weight: 600;
+    margin-top: 2px;
+}
+
+.scm-count {
+    font-size: 0.82em;
+    color: var(--text-color-light3, #777);
+    margin: 6px 0 10px;
+}
+
+.scm-boxes {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.scm-box {
+    border-radius: 10px;
+    padding: 8px 10px;
+    background: var(--surface-container, rgba(128, 128, 128, 0.10));
+    border: 1px solid transparent;
+}
+
+.scm-box.scm-current {
+    background: var(--surface-container-high, rgba(128, 128, 128, 0.14));
+    border-color: var(--primary-color, #386A58);
+}
+
+.scm-box-label {
+    font-size: 0.72em;
+    color: var(--text-color-light3, #777);
+    margin-bottom: 3px;
+}
+
+.scm-box-text {
+    font-size: 0.95em;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.scm-box-text.scm-empty {
+    color: var(--text-color-light4, #888);
+    font-style: italic;
+}
+
+.scm-hl {
+    color: var(--primary-color, #386A58);
+    background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.18));
+    border-radius: 3px;
+    padding: 0 1px;
+    font-weight: 600;
+}
+
+.scm-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 12px;
+}
+
+.scm-btn {
+    font-family: inherit;
+    font-size: 0.9em;
+    padding: 7px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--outline-variant, rgba(128, 128, 128, 0.32));
+    background: var(--surface-container, rgba(128, 128, 128, 0.10));
+    color: var(--text-color, #000);
+    cursor: pointer;
+}
+
+.scm-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.scm-adjust {
+    flex: 1 1 42%;
+}
+
+.scm-foot {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 14px;
+}
+
+.scm-confirm {
+    background: var(--primary-color, #386A58);
+    border-color: var(--primary-color, #386A58);
+    color: #fff;
+    font-weight: 600;
+}
+
+.ctx-adjust-button {
+    opacity: 0.85;
+}
+
 /*
  *  content-css-overlay.css — extension-only additions appended to the generated
  *  content.css (see generate-content-css.mjs).

--- a/hibiki/assets/browser_extension/vendor/popup.css
+++ b/hibiki/assets/browser_extension/vendor/popup.css
@@ -1345,3 +1345,156 @@ html.global-lookup .glossary-section > .category-body > .glossary-group {
     background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.22));
     border-radius: 2px;
 }
+
+/* ── Niratan「制卡前调整·选择句子上下文」模态 ────────────────────────────────
+   由词条上的「调整上下文」按钮（.ctx-adjust-button）打开。全部 class-rooted 选择器，
+   content.css 生成器自动 scope 进 #entries-container（扩展侧 sentenceContextPreviewEnabled
+   恒 undefined，不渲染，纯 dead style）。颜色走 popup 主题变量，暗/亮自适应。 */
+.sentence-context-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 2147483000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(0, 0, 0, 0.42);
+    -webkit-user-select: none;
+    user-select: none;
+    box-sizing: border-box;
+}
+
+.scm-card {
+    width: 100%;
+    max-width: 460px;
+    max-height: 92%;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    padding: 16px;
+    border-radius: var(--hibiki-radius-card, 14px);
+    background: var(--background-color, #fff);
+    color: var(--text-color, #000);
+    border: 1px solid var(--outline-variant, rgba(128, 128, 128, 0.32));
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+
+.scm-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.scm-eyebrow {
+    font-size: 0.78em;
+    color: var(--text-color-light3, #777);
+}
+
+.scm-x {
+    flex: 0 0 auto;
+    opacity: 0.7;
+}
+
+.scm-title {
+    font-size: 1.12em;
+    font-weight: 600;
+    margin-top: 2px;
+}
+
+.scm-count {
+    font-size: 0.82em;
+    color: var(--text-color-light3, #777);
+    margin: 6px 0 10px;
+}
+
+.scm-boxes {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.scm-box {
+    border-radius: 10px;
+    padding: 8px 10px;
+    background: var(--surface-container, rgba(128, 128, 128, 0.10));
+    border: 1px solid transparent;
+}
+
+.scm-box.scm-current {
+    background: var(--surface-container-high, rgba(128, 128, 128, 0.14));
+    border-color: var(--primary-color, #386A58);
+}
+
+.scm-box-label {
+    font-size: 0.72em;
+    color: var(--text-color-light3, #777);
+    margin-bottom: 3px;
+}
+
+.scm-box-text {
+    font-size: 0.95em;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.scm-box-text.scm-empty {
+    color: var(--text-color-light4, #888);
+    font-style: italic;
+}
+
+.scm-hl {
+    color: var(--primary-color, #386A58);
+    background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.18));
+    border-radius: 3px;
+    padding: 0 1px;
+    font-weight: 600;
+}
+
+.scm-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 12px;
+}
+
+.scm-btn {
+    font-family: inherit;
+    font-size: 0.9em;
+    padding: 7px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--outline-variant, rgba(128, 128, 128, 0.32));
+    background: var(--surface-container, rgba(128, 128, 128, 0.10));
+    color: var(--text-color, #000);
+    cursor: pointer;
+}
+
+.scm-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.scm-adjust {
+    flex: 1 1 42%;
+}
+
+.scm-foot {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 14px;
+}
+
+.scm-confirm {
+    background: var(--primary-color, #386A58);
+    border-color: var(--primary-color, #386A58);
+    color: #fff;
+    font-weight: 600;
+}
+
+.ctx-adjust-button {
+    opacity: 0.85;
+}

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -343,6 +343,209 @@ function buildSentenceContextPicker() {
     return picker;
 }
 
+// ── Niratan「制卡前调整·选择句子上下文」模态 ──────────────────────────────────
+// 与旧「上 N / 下 N」内联步进器（kSentenceContextPickerEnabled 恒 false，永不渲染）互
+// 独立的新特性：点词条上的「调整上下文」按钮打开一个模态，展示**前文 / 当前句(查到的
+// 词高亮) / 后文**的真实文本 + 前退/前加/后退/后加一句调整 + 取消/确认制卡。一键「+」
+// 制卡保持不变（不打开模态）。数据流复用既有 sentenceCtxPrev/Next 镜像 + setSentenceContext
+// 桥接（宿主整体解析上下文句进草稿），文本由新的只读 sentenceContextPreview 桥接回传；
+// 「确认制卡」直接点回该词条的 mineButton，复用其全部制卡/查重/覆写逻辑。
+
+function ctxI18n() {
+    return window.i18nCtx || {};
+}
+
+// 只读拉取宿主当前草稿的上下文预览（前/当前/后真实句 + 词在当前句的偏移）。宿主未接入
+// / 出错时回空对象，模态侧兜底不渲染文本（绝不崩制卡主流程）。
+async function fetchSentenceContextPreview() {
+    try {
+        const reply = await window.flutter_inappwebview.callHandler('sentenceContextPreview');
+        return (reply && typeof reply === 'object') ? reply : {};
+    } catch (e) {
+        console.error('sentenceContextPreview failed', e);
+        return {};
+    }
+}
+
+// 用当前句文本 + 词偏移 + 词表现形，构造一个带 <span class="scm-hl"> 高亮的文本盒。**不用
+// innerHTML 拼用户文本**（句子是书内容，杜绝 HTML 注入）——纯 textNode + 一个高亮 span。
+// offset 命中优先（与卡片渲染 _sentenceValue 同容错），失配回退首次出现匹配，再失配无高亮。
+function buildHighlightedCurrentText(text, offset, matched) {
+    const box = el('div', { className: 'scm-box-text' });
+    if (!text) {
+        box.classList.add('scm-empty');
+        box.textContent = ctxI18n().boxEmpty || '';
+        return box;
+    }
+    let start = -1;
+    if (matched) {
+        if (typeof offset === 'number' && offset >= 0 &&
+            text.substr(offset, matched.length) === matched) {
+            start = offset;
+        } else {
+            start = text.indexOf(matched);
+        }
+    }
+    if (start < 0 || !matched) {
+        box.textContent = text;
+        return box;
+    }
+    box.appendChild(document.createTextNode(text.slice(0, start)));
+    box.appendChild(el('span', {
+        className: 'scm-hl',
+        textContent: text.slice(start, start + matched.length),
+    }));
+    box.appendChild(document.createTextNode(text.slice(start + matched.length)));
+    return box;
+}
+
+// 渲染一个上下文盒（前文 / 后文）：标签 + 每句一行。空 → 占位「（无）」。纯 textNode。
+function buildContextBox(labelText, sentences, extraClass) {
+    const wrap = el('div', { className: 'scm-box ' + (extraClass || '') });
+    wrap.appendChild(el('div', { className: 'scm-box-label', textContent: labelText }));
+    if (!sentences || !sentences.length) {
+        wrap.appendChild(el('div', {
+            className: 'scm-box-text scm-empty',
+            textContent: ctxI18n().boxEmpty || '',
+        }));
+        return wrap;
+    }
+    const t = el('div', { className: 'scm-box-text' });
+    sentences.forEach(function(s, i) {
+        if (i) t.appendChild(el('br'));
+        t.appendChild(document.createTextNode(String(s)));
+    });
+    wrap.appendChild(t);
+    return wrap;
+}
+
+let __sentenceContextModalOpen = false;
+
+// 打开「制卡前调整」模态。[mineButton]：该词条的制卡按钮（确认制卡时点它复用全部逻辑）；
+// [matched]：查到的词表现形（用于在当前句里高亮）。同一时刻只允许一个模态。
+async function openSentenceContextModal(mineButton, matched) {
+    if (__sentenceContextModalOpen) return;
+    __sentenceContextModalOpen = true;
+    const i = ctxI18n();
+    // 记住打开时的镜像；取消 = 还原到此（不把半调整的草稿留给后续「+」一键制卡）。
+    const snapPrev = sentenceCtxPrev;
+    const snapNext = sentenceCtxNext;
+
+    const overlay = el('div', { className: 'sentence-context-modal' });
+    const card = el('div', { className: 'scm-card' });
+    overlay.appendChild(card);
+
+    const head = el('div', { className: 'scm-head' });
+    head.appendChild(el('span', { className: 'scm-eyebrow', textContent: i.eyebrow || '' }));
+    const closeBtn = el('button', { className: 'inline-action-button scm-x' });
+    setButtonIcon(closeBtn, 'close');
+    head.appendChild(closeBtn);
+    card.appendChild(head);
+    card.appendChild(el('div', { className: 'scm-title', textContent: i.title || '' }));
+    const countEl = el('div', { className: 'scm-count' });
+    card.appendChild(countEl);
+
+    const boxes = el('div', { className: 'scm-boxes' });
+    card.appendChild(boxes);
+
+    let busy = false;
+    const makeAdjustBtn = function(dir, sign, label) {
+        const btn = el('button', {
+            className: 'scm-btn scm-adjust ' + dir + '-' + sign,
+            textContent: label,
+        });
+        btn.dataset.dir = dir;
+        btn.dataset.sign = sign;
+        btn.onclick = function() { adjust(dir, sign); };
+        return btn;
+    };
+    const prevMinusBtn = makeAdjustBtn('prev', 'minus', i.prevMinus || '');
+    const prevPlusBtn = makeAdjustBtn('prev', 'plus', i.prevPlus || '');
+    const nextMinusBtn = makeAdjustBtn('next', 'minus', i.nextMinus || '');
+    const nextPlusBtn = makeAdjustBtn('next', 'plus', i.nextPlus || '');
+    const actions = el('div', { className: 'scm-actions' });
+    actions.appendChild(prevMinusBtn);
+    actions.appendChild(prevPlusBtn);
+    actions.appendChild(nextMinusBtn);
+    actions.appendChild(nextPlusBtn);
+    card.appendChild(actions);
+
+    const cancelBtn = el('button', { className: 'scm-btn scm-cancel', textContent: i.cancel || '' });
+    const confirmBtn = el('button', { className: 'scm-btn scm-confirm', textContent: i.confirm || '' });
+    const foot = el('div', { className: 'scm-foot' });
+    foot.appendChild(cancelBtn);
+    foot.appendChild(confirmBtn);
+    card.appendChild(foot);
+
+    function renderPreview(preview) {
+        const prev = Array.isArray(preview.prev) ? preview.prev : [];
+        const next = Array.isArray(preview.next) ? preview.next : [];
+        const current = typeof preview.current === 'string' ? preview.current : '';
+        const total = typeof preview.total === 'number' ? preview.total : (prev.length + next.length);
+        // 镜像与宿主真实句数对齐：宿主按段落/cue 边界封顶，到边界再「加」是空操作，
+        // 计数不再上涨——honest feedback（不像旧步进器让镜像无界上涨）。
+        sentenceCtxPrev = prev.length;
+        sentenceCtxNext = next.length;
+        sentenceDraftCount = total;
+        countEl.textContent = (i.count || '%d').replace('%d', String(total));
+        boxes.textContent = '';
+        boxes.appendChild(buildContextBox(i.boxPrev || '', prev, 'scm-prev'));
+        const curBox = el('div', { className: 'scm-box scm-current selected' });
+        curBox.appendChild(el('div', { className: 'scm-box-label', textContent: i.boxCurrent || '' }));
+        curBox.appendChild(buildHighlightedCurrentText(current, preview.currentOffset, matched));
+        boxes.appendChild(curBox);
+        boxes.appendChild(buildContextBox(i.boxNext || '', next, 'scm-next'));
+        prevMinusBtn.disabled = prev.length <= 0;
+        nextMinusBtn.disabled = next.length <= 0;
+    }
+
+    async function refresh() {
+        renderPreview(await fetchSentenceContextPreview());
+    }
+
+    async function adjust(dir, sign) {
+        if (busy) return;
+        busy = true;
+        card.dataset.busy = '1';
+        try {
+            const cur = dir === 'prev' ? sentenceCtxPrev : sentenceCtxNext;
+            const nextN = sign === 'plus' ? cur + 1 : Math.max(0, cur - 1);
+            if (dir === 'prev') sentenceCtxPrev = nextN;
+            else sentenceCtxNext = nextN;
+            await setSentenceContextOnHost();
+            await refresh();
+        } finally {
+            busy = false;
+            card.dataset.busy = '';
+        }
+    }
+
+    function close() {
+        if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+        __sentenceContextModalOpen = false;
+    }
+    async function cancel() {
+        // 取消：还原到打开时的选择（取消不改草稿），再关。
+        sentenceCtxPrev = snapPrev;
+        sentenceCtxNext = snapNext;
+        try { await setSentenceContextOnHost(); } catch (e) { /* 取消尽力而为 */ }
+        close();
+    }
+    closeBtn.onclick = cancel;
+    cancelBtn.onclick = cancel;
+    overlay.onclick = function(e) { if (e.target === overlay) cancel(); };
+    confirmBtn.onclick = function() {
+        close();
+        // 复用该词条制卡按钮的全部逻辑（查重/覆写/制卡后清理都在里面）。
+        if (mineButton && !mineButton.disabled) mineButton.click();
+    };
+
+    (document.body || __hibikiRootNode()).appendChild(overlay);
+    // 先用镜像画个占位，再异步拉真实预览覆盖（避免打开瞬间空白）。
+    renderPreview({ prev: [], next: [], current: '', total: sentenceCtxPrev + sentenceCtxNext });
+    await refresh();
+}
+
 
 function el(tag, props = {}, children = []) {
     const element = document.createElement(tag);
@@ -383,6 +586,8 @@ const ICON_PATHS = {
     remove: 'M19 13H5v-2h14v2z',
     // close（清空草稿 / 标签说明遮罩关闭 ×）
     close: 'M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z',
+    // tune（Niratan「调整上下文」按钮：打开制卡前句子上下文调整模态）
+    tune: 'M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z',
 };
 
 function iconSvg(name) {
@@ -2254,6 +2459,21 @@ function createEntryHeader(entry, idx) {
         setButtonIcon(clearButton, 'close');
         refreshClearDraftButton(clearButton);
         buttonsContainer.appendChild(clearButton);
+    }
+
+    // Niratan「制卡前调整·选择句子上下文」：独立于上面被砍掉的内联步进器
+    // （kSentenceContextPickerEnabled 恒 false）。支持草稿且宿主接入了预览回调的表面
+    // （reader/有声书/视频，window.sentenceContextPreviewEnabled 为真）渲染一个「调整
+    // 上下文」按钮，点开模态在里面看前/当前/后真实句并增减上下文、确认制卡。一键「+」
+    // 制卡不受影响。
+    if (window.sentenceContextPreviewEnabled) {
+        const adjustBtn = el('button', {
+            className: 'inline-action-button ctx-adjust-button',
+            title: (window.i18nCtx && window.i18nCtx.adjust) || '',
+            onclick: function() { openSentenceContextModal(mineButton, matched); },
+        });
+        setButtonIcon(adjustBtn, 'tune');
+        buttonsContainer.appendChild(adjustBtn);
     }
 
     header.appendChild(buttonsContainer);

--- a/hibiki/assets/popup/popup.css
+++ b/hibiki/assets/popup/popup.css
@@ -1345,3 +1345,156 @@ html.global-lookup .glossary-section > .category-body > .glossary-group {
     background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.22));
     border-radius: 2px;
 }
+
+/* ── Niratan「制卡前调整·选择句子上下文」模态 ────────────────────────────────
+   由词条上的「调整上下文」按钮（.ctx-adjust-button）打开。全部 class-rooted 选择器，
+   content.css 生成器自动 scope 进 #entries-container（扩展侧 sentenceContextPreviewEnabled
+   恒 undefined，不渲染，纯 dead style）。颜色走 popup 主题变量，暗/亮自适应。 */
+.sentence-context-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 2147483000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(0, 0, 0, 0.42);
+    -webkit-user-select: none;
+    user-select: none;
+    box-sizing: border-box;
+}
+
+.scm-card {
+    width: 100%;
+    max-width: 460px;
+    max-height: 92%;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    padding: 16px;
+    border-radius: var(--hibiki-radius-card, 14px);
+    background: var(--background-color, #fff);
+    color: var(--text-color, #000);
+    border: 1px solid var(--outline-variant, rgba(128, 128, 128, 0.32));
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+
+.scm-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.scm-eyebrow {
+    font-size: 0.78em;
+    color: var(--text-color-light3, #777);
+}
+
+.scm-x {
+    flex: 0 0 auto;
+    opacity: 0.7;
+}
+
+.scm-title {
+    font-size: 1.12em;
+    font-weight: 600;
+    margin-top: 2px;
+}
+
+.scm-count {
+    font-size: 0.82em;
+    color: var(--text-color-light3, #777);
+    margin: 6px 0 10px;
+}
+
+.scm-boxes {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.scm-box {
+    border-radius: 10px;
+    padding: 8px 10px;
+    background: var(--surface-container, rgba(128, 128, 128, 0.10));
+    border: 1px solid transparent;
+}
+
+.scm-box.scm-current {
+    background: var(--surface-container-high, rgba(128, 128, 128, 0.14));
+    border-color: var(--primary-color, #386A58);
+}
+
+.scm-box-label {
+    font-size: 0.72em;
+    color: var(--text-color-light3, #777);
+    margin-bottom: 3px;
+}
+
+.scm-box-text {
+    font-size: 0.95em;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.scm-box-text.scm-empty {
+    color: var(--text-color-light4, #888);
+    font-style: italic;
+}
+
+.scm-hl {
+    color: var(--primary-color, #386A58);
+    background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.18));
+    border-radius: 3px;
+    padding: 0 1px;
+    font-weight: 600;
+}
+
+.scm-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 12px;
+}
+
+.scm-btn {
+    font-family: inherit;
+    font-size: 0.9em;
+    padding: 7px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--outline-variant, rgba(128, 128, 128, 0.32));
+    background: var(--surface-container, rgba(128, 128, 128, 0.10));
+    color: var(--text-color, #000);
+    cursor: pointer;
+}
+
+.scm-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.scm-adjust {
+    flex: 1 1 42%;
+}
+
+.scm-foot {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 14px;
+}
+
+.scm-confirm {
+    background: var(--primary-color, #386A58);
+    border-color: var(--primary-color, #386A58);
+    color: #fff;
+    font-weight: 600;
+}
+
+.ctx-adjust-button {
+    opacity: 0.85;
+}

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -343,6 +343,209 @@ function buildSentenceContextPicker() {
     return picker;
 }
 
+// ── Niratan「制卡前调整·选择句子上下文」模态 ──────────────────────────────────
+// 与旧「上 N / 下 N」内联步进器（kSentenceContextPickerEnabled 恒 false，永不渲染）互
+// 独立的新特性：点词条上的「调整上下文」按钮打开一个模态，展示**前文 / 当前句(查到的
+// 词高亮) / 后文**的真实文本 + 前退/前加/后退/后加一句调整 + 取消/确认制卡。一键「+」
+// 制卡保持不变（不打开模态）。数据流复用既有 sentenceCtxPrev/Next 镜像 + setSentenceContext
+// 桥接（宿主整体解析上下文句进草稿），文本由新的只读 sentenceContextPreview 桥接回传；
+// 「确认制卡」直接点回该词条的 mineButton，复用其全部制卡/查重/覆写逻辑。
+
+function ctxI18n() {
+    return window.i18nCtx || {};
+}
+
+// 只读拉取宿主当前草稿的上下文预览（前/当前/后真实句 + 词在当前句的偏移）。宿主未接入
+// / 出错时回空对象，模态侧兜底不渲染文本（绝不崩制卡主流程）。
+async function fetchSentenceContextPreview() {
+    try {
+        const reply = await window.flutter_inappwebview.callHandler('sentenceContextPreview');
+        return (reply && typeof reply === 'object') ? reply : {};
+    } catch (e) {
+        console.error('sentenceContextPreview failed', e);
+        return {};
+    }
+}
+
+// 用当前句文本 + 词偏移 + 词表现形，构造一个带 <span class="scm-hl"> 高亮的文本盒。**不用
+// innerHTML 拼用户文本**（句子是书内容，杜绝 HTML 注入）——纯 textNode + 一个高亮 span。
+// offset 命中优先（与卡片渲染 _sentenceValue 同容错），失配回退首次出现匹配，再失配无高亮。
+function buildHighlightedCurrentText(text, offset, matched) {
+    const box = el('div', { className: 'scm-box-text' });
+    if (!text) {
+        box.classList.add('scm-empty');
+        box.textContent = ctxI18n().boxEmpty || '';
+        return box;
+    }
+    let start = -1;
+    if (matched) {
+        if (typeof offset === 'number' && offset >= 0 &&
+            text.substr(offset, matched.length) === matched) {
+            start = offset;
+        } else {
+            start = text.indexOf(matched);
+        }
+    }
+    if (start < 0 || !matched) {
+        box.textContent = text;
+        return box;
+    }
+    box.appendChild(document.createTextNode(text.slice(0, start)));
+    box.appendChild(el('span', {
+        className: 'scm-hl',
+        textContent: text.slice(start, start + matched.length),
+    }));
+    box.appendChild(document.createTextNode(text.slice(start + matched.length)));
+    return box;
+}
+
+// 渲染一个上下文盒（前文 / 后文）：标签 + 每句一行。空 → 占位「（无）」。纯 textNode。
+function buildContextBox(labelText, sentences, extraClass) {
+    const wrap = el('div', { className: 'scm-box ' + (extraClass || '') });
+    wrap.appendChild(el('div', { className: 'scm-box-label', textContent: labelText }));
+    if (!sentences || !sentences.length) {
+        wrap.appendChild(el('div', {
+            className: 'scm-box-text scm-empty',
+            textContent: ctxI18n().boxEmpty || '',
+        }));
+        return wrap;
+    }
+    const t = el('div', { className: 'scm-box-text' });
+    sentences.forEach(function(s, i) {
+        if (i) t.appendChild(el('br'));
+        t.appendChild(document.createTextNode(String(s)));
+    });
+    wrap.appendChild(t);
+    return wrap;
+}
+
+let __sentenceContextModalOpen = false;
+
+// 打开「制卡前调整」模态。[mineButton]：该词条的制卡按钮（确认制卡时点它复用全部逻辑）；
+// [matched]：查到的词表现形（用于在当前句里高亮）。同一时刻只允许一个模态。
+async function openSentenceContextModal(mineButton, matched) {
+    if (__sentenceContextModalOpen) return;
+    __sentenceContextModalOpen = true;
+    const i = ctxI18n();
+    // 记住打开时的镜像；取消 = 还原到此（不把半调整的草稿留给后续「+」一键制卡）。
+    const snapPrev = sentenceCtxPrev;
+    const snapNext = sentenceCtxNext;
+
+    const overlay = el('div', { className: 'sentence-context-modal' });
+    const card = el('div', { className: 'scm-card' });
+    overlay.appendChild(card);
+
+    const head = el('div', { className: 'scm-head' });
+    head.appendChild(el('span', { className: 'scm-eyebrow', textContent: i.eyebrow || '' }));
+    const closeBtn = el('button', { className: 'inline-action-button scm-x' });
+    setButtonIcon(closeBtn, 'close');
+    head.appendChild(closeBtn);
+    card.appendChild(head);
+    card.appendChild(el('div', { className: 'scm-title', textContent: i.title || '' }));
+    const countEl = el('div', { className: 'scm-count' });
+    card.appendChild(countEl);
+
+    const boxes = el('div', { className: 'scm-boxes' });
+    card.appendChild(boxes);
+
+    let busy = false;
+    const makeAdjustBtn = function(dir, sign, label) {
+        const btn = el('button', {
+            className: 'scm-btn scm-adjust ' + dir + '-' + sign,
+            textContent: label,
+        });
+        btn.dataset.dir = dir;
+        btn.dataset.sign = sign;
+        btn.onclick = function() { adjust(dir, sign); };
+        return btn;
+    };
+    const prevMinusBtn = makeAdjustBtn('prev', 'minus', i.prevMinus || '');
+    const prevPlusBtn = makeAdjustBtn('prev', 'plus', i.prevPlus || '');
+    const nextMinusBtn = makeAdjustBtn('next', 'minus', i.nextMinus || '');
+    const nextPlusBtn = makeAdjustBtn('next', 'plus', i.nextPlus || '');
+    const actions = el('div', { className: 'scm-actions' });
+    actions.appendChild(prevMinusBtn);
+    actions.appendChild(prevPlusBtn);
+    actions.appendChild(nextMinusBtn);
+    actions.appendChild(nextPlusBtn);
+    card.appendChild(actions);
+
+    const cancelBtn = el('button', { className: 'scm-btn scm-cancel', textContent: i.cancel || '' });
+    const confirmBtn = el('button', { className: 'scm-btn scm-confirm', textContent: i.confirm || '' });
+    const foot = el('div', { className: 'scm-foot' });
+    foot.appendChild(cancelBtn);
+    foot.appendChild(confirmBtn);
+    card.appendChild(foot);
+
+    function renderPreview(preview) {
+        const prev = Array.isArray(preview.prev) ? preview.prev : [];
+        const next = Array.isArray(preview.next) ? preview.next : [];
+        const current = typeof preview.current === 'string' ? preview.current : '';
+        const total = typeof preview.total === 'number' ? preview.total : (prev.length + next.length);
+        // 镜像与宿主真实句数对齐：宿主按段落/cue 边界封顶，到边界再「加」是空操作，
+        // 计数不再上涨——honest feedback（不像旧步进器让镜像无界上涨）。
+        sentenceCtxPrev = prev.length;
+        sentenceCtxNext = next.length;
+        sentenceDraftCount = total;
+        countEl.textContent = (i.count || '%d').replace('%d', String(total));
+        boxes.textContent = '';
+        boxes.appendChild(buildContextBox(i.boxPrev || '', prev, 'scm-prev'));
+        const curBox = el('div', { className: 'scm-box scm-current selected' });
+        curBox.appendChild(el('div', { className: 'scm-box-label', textContent: i.boxCurrent || '' }));
+        curBox.appendChild(buildHighlightedCurrentText(current, preview.currentOffset, matched));
+        boxes.appendChild(curBox);
+        boxes.appendChild(buildContextBox(i.boxNext || '', next, 'scm-next'));
+        prevMinusBtn.disabled = prev.length <= 0;
+        nextMinusBtn.disabled = next.length <= 0;
+    }
+
+    async function refresh() {
+        renderPreview(await fetchSentenceContextPreview());
+    }
+
+    async function adjust(dir, sign) {
+        if (busy) return;
+        busy = true;
+        card.dataset.busy = '1';
+        try {
+            const cur = dir === 'prev' ? sentenceCtxPrev : sentenceCtxNext;
+            const nextN = sign === 'plus' ? cur + 1 : Math.max(0, cur - 1);
+            if (dir === 'prev') sentenceCtxPrev = nextN;
+            else sentenceCtxNext = nextN;
+            await setSentenceContextOnHost();
+            await refresh();
+        } finally {
+            busy = false;
+            card.dataset.busy = '';
+        }
+    }
+
+    function close() {
+        if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+        __sentenceContextModalOpen = false;
+    }
+    async function cancel() {
+        // 取消：还原到打开时的选择（取消不改草稿），再关。
+        sentenceCtxPrev = snapPrev;
+        sentenceCtxNext = snapNext;
+        try { await setSentenceContextOnHost(); } catch (e) { /* 取消尽力而为 */ }
+        close();
+    }
+    closeBtn.onclick = cancel;
+    cancelBtn.onclick = cancel;
+    overlay.onclick = function(e) { if (e.target === overlay) cancel(); };
+    confirmBtn.onclick = function() {
+        close();
+        // 复用该词条制卡按钮的全部逻辑（查重/覆写/制卡后清理都在里面）。
+        if (mineButton && !mineButton.disabled) mineButton.click();
+    };
+
+    (document.body || __hibikiRootNode()).appendChild(overlay);
+    // 先用镜像画个占位，再异步拉真实预览覆盖（避免打开瞬间空白）。
+    renderPreview({ prev: [], next: [], current: '', total: sentenceCtxPrev + sentenceCtxNext });
+    await refresh();
+}
+
 
 function el(tag, props = {}, children = []) {
     const element = document.createElement(tag);
@@ -383,6 +586,8 @@ const ICON_PATHS = {
     remove: 'M19 13H5v-2h14v2z',
     // close（清空草稿 / 标签说明遮罩关闭 ×）
     close: 'M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z',
+    // tune（Niratan「调整上下文」按钮：打开制卡前句子上下文调整模态）
+    tune: 'M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z',
 };
 
 function iconSvg(name) {
@@ -2254,6 +2459,21 @@ function createEntryHeader(entry, idx) {
         setButtonIcon(clearButton, 'close');
         refreshClearDraftButton(clearButton);
         buttonsContainer.appendChild(clearButton);
+    }
+
+    // Niratan「制卡前调整·选择句子上下文」：独立于上面被砍掉的内联步进器
+    // （kSentenceContextPickerEnabled 恒 false）。支持草稿且宿主接入了预览回调的表面
+    // （reader/有声书/视频，window.sentenceContextPreviewEnabled 为真）渲染一个「调整
+    // 上下文」按钮，点开模态在里面看前/当前/后真实句并增减上下文、确认制卡。一键「+」
+    // 制卡不受影响。
+    if (window.sentenceContextPreviewEnabled) {
+        const adjustBtn = el('button', {
+            className: 'inline-action-button ctx-adjust-button',
+            title: (window.i18nCtx && window.i18nCtx.adjust) || '',
+            onclick: function() { openSentenceContextModal(mineButton, matched); },
+        });
+        setButtonIcon(adjustBtn, 'tune');
+        buttonsContainer.appendChild(adjustBtn);
     }
 
     header.appendChild(buttonsContainer);

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 38131 (2243 per locale)
+/// Strings: 38369 (2257 per locale)
 ///
-/// Built on 2026-07-10 at 12:03 UTC
+/// Built on 2026-07-10 at 18:01 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2975,6 +2975,20 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Card background opacity of the floating lookup panel (requires Windows 11 backdrop)';
   String get sync_client_connected => 'Connected';
   String get sync_client_token_manual => 'Enter token manually';
+  String get popup_ctx_adjust_button => 'Adjust context';
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  String get popup_ctx_modal_title => 'Select sentence context';
+  String get popup_ctx_modal_count => 'Selected %d';
+  String get popup_ctx_box_prev => 'Before';
+  String get popup_ctx_box_current => 'Current';
+  String get popup_ctx_box_next => 'After';
+  String get popup_ctx_box_empty => '(none)';
+  String get popup_ctx_prev_minus => 'Remove before';
+  String get popup_ctx_prev_plus => 'Add before';
+  String get popup_ctx_next_minus => 'Remove after';
+  String get popup_ctx_next_plus => 'Add after';
+  String get popup_ctx_confirm => 'Confirm';
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -8053,6 +8067,34 @@ class _StringsAr extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -13254,6 +13296,34 @@ class _StringsDe extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -18472,6 +18542,34 @@ class _StringsEs extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -23709,6 +23807,34 @@ class _StringsFr extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -28848,6 +28974,34 @@ class _StringsId extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -34048,6 +34202,34 @@ class _StringsIt extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -38974,6 +39156,34 @@ class _StringsJa extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -43904,6 +44114,34 @@ class _StringsKo extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -49072,6 +49310,34 @@ class _StringsNl extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -54263,6 +54529,34 @@ class _StringsPtBr extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -59429,6 +59723,34 @@ class _StringsRu extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -64508,6 +64830,34 @@ class _StringsTh extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -69642,6 +69992,34 @@ class _StringsTr extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -74751,6 +75129,34 @@ class _StringsVi extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -79513,6 +79919,34 @@ class _StringsZhCn extends _StringsEn {
   String get sync_client_connected => '已连接';
   @override
   String get sync_client_token_manual => '手动填写令牌';
+  @override
+  String get popup_ctx_adjust_button => '调整上下文';
+  @override
+  String get popup_ctx_modal_eyebrow => '制卡前调整';
+  @override
+  String get popup_ctx_modal_title => '选择句子上下文';
+  @override
+  String get popup_ctx_modal_count => '已选择 %d 句';
+  @override
+  String get popup_ctx_box_prev => '前文';
+  @override
+  String get popup_ctx_box_current => '当前句';
+  @override
+  String get popup_ctx_box_next => '后文';
+  @override
+  String get popup_ctx_box_empty => '（无）';
+  @override
+  String get popup_ctx_prev_minus => '前退一句';
+  @override
+  String get popup_ctx_prev_plus => '前加一句';
+  @override
+  String get popup_ctx_next_minus => '后退一句';
+  @override
+  String get popup_ctx_next_plus => '后加一句';
+  @override
+  String get popup_ctx_confirm => '确认制卡';
+  @override
+  String get popup_ctx_cancel => '取消';
 }
 
 // Path: retrying_in
@@ -84341,6 +84775,34 @@ class _StringsZhHk extends _StringsEn {
   String get sync_client_connected => 'Connected';
   @override
   String get sync_client_token_manual => 'Enter token manually';
+  @override
+  String get popup_ctx_adjust_button => 'Adjust context';
+  @override
+  String get popup_ctx_modal_eyebrow => 'Before mining';
+  @override
+  String get popup_ctx_modal_title => 'Select sentence context';
+  @override
+  String get popup_ctx_modal_count => 'Selected %d';
+  @override
+  String get popup_ctx_box_prev => 'Before';
+  @override
+  String get popup_ctx_box_current => 'Current';
+  @override
+  String get popup_ctx_box_next => 'After';
+  @override
+  String get popup_ctx_box_empty => '(none)';
+  @override
+  String get popup_ctx_prev_minus => 'Remove before';
+  @override
+  String get popup_ctx_prev_plus => 'Add before';
+  @override
+  String get popup_ctx_next_minus => 'Remove after';
+  @override
+  String get popup_ctx_next_plus => 'Add after';
+  @override
+  String get popup_ctx_confirm => 'Confirm';
+  @override
+  String get popup_ctx_cancel => 'Cancel';
 }
 
 // Path: retrying_in
@@ -88965,6 +89427,34 @@ extension on _StringsEn {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -93549,6 +94039,34 @@ extension on _StringsAr {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -98155,6 +98673,34 @@ extension on _StringsDe {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -102759,6 +103305,34 @@ extension on _StringsEs {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -107370,6 +107944,34 @@ extension on _StringsFr {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -111961,6 +112563,34 @@ extension on _StringsId {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -116569,6 +117199,34 @@ extension on _StringsIt {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -121135,6 +121793,34 @@ extension on _StringsJa {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -125704,6 +126390,34 @@ extension on _StringsKo {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -130305,6 +131019,34 @@ extension on _StringsNl {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -134903,6 +135645,34 @@ extension on _StringsPtBr {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -139505,6 +140275,34 @@ extension on _StringsRu {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -144089,6 +144887,34 @@ extension on _StringsTh {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -148682,6 +149508,34 @@ extension on _StringsTr {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -153269,6 +154123,34 @@ extension on _StringsVi {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }
@@ -157822,6 +158704,34 @@ extension on _StringsZhCn {
         return '已连接';
       case 'sync_client_token_manual':
         return '手动填写令牌';
+      case 'popup_ctx_adjust_button':
+        return '调整上下文';
+      case 'popup_ctx_modal_eyebrow':
+        return '制卡前调整';
+      case 'popup_ctx_modal_title':
+        return '选择句子上下文';
+      case 'popup_ctx_modal_count':
+        return '已选择 %d 句';
+      case 'popup_ctx_box_prev':
+        return '前文';
+      case 'popup_ctx_box_current':
+        return '当前句';
+      case 'popup_ctx_box_next':
+        return '后文';
+      case 'popup_ctx_box_empty':
+        return '（无）';
+      case 'popup_ctx_prev_minus':
+        return '前退一句';
+      case 'popup_ctx_prev_plus':
+        return '前加一句';
+      case 'popup_ctx_next_minus':
+        return '后退一句';
+      case 'popup_ctx_next_plus':
+        return '后加一句';
+      case 'popup_ctx_confirm':
+        return '确认制卡';
+      case 'popup_ctx_cancel':
+        return '取消';
       default:
         return null;
     }
@@ -162380,6 +163290,34 @@ extension on _StringsZhHk {
         return 'Connected';
       case 'sync_client_token_manual':
         return 'Enter token manually';
+      case 'popup_ctx_adjust_button':
+        return 'Adjust context';
+      case 'popup_ctx_modal_eyebrow':
+        return 'Before mining';
+      case 'popup_ctx_modal_title':
+        return 'Select sentence context';
+      case 'popup_ctx_modal_count':
+        return 'Selected %d';
+      case 'popup_ctx_box_prev':
+        return 'Before';
+      case 'popup_ctx_box_current':
+        return 'Current';
+      case 'popup_ctx_box_next':
+        return 'After';
+      case 'popup_ctx_box_empty':
+        return '(none)';
+      case 'popup_ctx_prev_minus':
+        return 'Remove before';
+      case 'popup_ctx_prev_plus':
+        return 'Add before';
+      case 'popup_ctx_next_minus':
+        return 'Remove after';
+      case 'popup_ctx_next_plus':
+        return 'Add after';
+      case 'popup_ctx_confirm':
+        return 'Confirm';
+      case 'popup_ctx_cancel':
+        return 'Cancel';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "面板不透明度",
   "clipboard_panel_opacity_hint": "悬浮查词面板的卡片背景不透明度（需要 Windows 11 背景材质支持）",
   "sync_client_connected": "已连接",
-  "sync_client_token_manual": "手动填写令牌"
+  "sync_client_token_manual": "手动填写令牌",
+  "popup_ctx_adjust_button": "调整上下文",
+  "popup_ctx_modal_eyebrow": "制卡前调整",
+  "popup_ctx_modal_title": "选择句子上下文",
+  "popup_ctx_modal_count": "已选择 %d 句",
+  "popup_ctx_box_prev": "前文",
+  "popup_ctx_box_current": "当前句",
+  "popup_ctx_box_next": "后文",
+  "popup_ctx_box_empty": "（无）",
+  "popup_ctx_prev_minus": "前退一句",
+  "popup_ctx_prev_plus": "前加一句",
+  "popup_ctx_next_minus": "后退一句",
+  "popup_ctx_next_plus": "后加一句",
+  "popup_ctx_confirm": "确认制卡",
+  "popup_ctx_cancel": "取消"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2249,5 +2249,19 @@
   "clipboard_panel_opacity": "Panel opacity",
   "clipboard_panel_opacity_hint": "Card background opacity of the floating lookup panel (requires Windows 11 backdrop)",
   "sync_client_connected": "Connected",
-  "sync_client_token_manual": "Enter token manually"
+  "sync_client_token_manual": "Enter token manually",
+  "popup_ctx_adjust_button": "Adjust context",
+  "popup_ctx_modal_eyebrow": "Before mining",
+  "popup_ctx_modal_title": "Select sentence context",
+  "popup_ctx_modal_count": "Selected %d",
+  "popup_ctx_box_prev": "Before",
+  "popup_ctx_box_current": "Current",
+  "popup_ctx_box_next": "After",
+  "popup_ctx_box_empty": "(none)",
+  "popup_ctx_prev_minus": "Remove before",
+  "popup_ctx_prev_plus": "Add before",
+  "popup_ctx_next_minus": "Remove after",
+  "popup_ctx_next_plus": "Add after",
+  "popup_ctx_confirm": "Confirm",
+  "popup_ctx_cancel": "Cancel"
 }

--- a/hibiki/lib/src/media/audiobook/mining_sentence_draft.dart
+++ b/hibiki/lib/src/media/audiobook/mining_sentence_draft.dart
@@ -97,6 +97,38 @@ class MiningSentenceDraft {
   }
 }
 
+/// 制卡前「上下文预览」纯数据（Niratan「选择句子上下文」模态）：宿主把当前草稿的
+/// 真实上下文句（[MiningSentenceDraft.prevSentences] / [nextSentences]，已按阅读顺序）+
+/// 当前正查句 [current] + 查到的词在当前句里的字符偏移 [currentOffset] 打包成一个
+/// JSON-safe Map 回给弹窗，供其渲染「前文 / 当前句(词高亮) / 后文」三栏预览。
+///
+/// 返回结构（字段名与 popup.js 的 `sentenceContextPreview` 消费方约定一致）：
+/// ```
+/// { 'prev': [句...], 'current': '当前句', 'currentOffset': int?, 'next': [句...],
+///   'total': prev.length + next.length }
+/// ```
+/// [currentOffset] 只是给 JS 定位高亮起点用（词的实际表现形由弹窗侧持有），失配时
+/// 弹窗回退到首次出现匹配——与卡片渲染 `_sentenceValue` 同一容错策略。纯函数、可单测。
+Map<String, Object?> buildSentenceContextPreview({
+  required MiningSentenceDraft draft,
+  required String current,
+  int? currentOffset,
+}) {
+  final List<String> prev = <String>[
+    for (final MiningDraftSentence e in draft.prevSentences) e.sentence,
+  ];
+  final List<String> next = <String>[
+    for (final MiningDraftSentence e in draft.nextSentences) e.sentence,
+  ];
+  return <String, Object?>{
+    'prev': prev,
+    'current': current,
+    'currentOffset': currentOffset,
+    'next': next,
+    'total': prev.length + next.length,
+  };
+}
+
 /// 把多句合成一段制卡用文本。纯函数（无副作用、可单测）。
 ///
 /// 与视频 `buildSelectedSubtitleCueContext` 的 `join('\n')` 语义一致：逐句 trim、

--- a/hibiki/lib/src/pages/base_source_page.dart
+++ b/hibiki/lib/src/pages/base_source_page.dart
@@ -693,6 +693,10 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
             supportsSentenceDraft ? onSetSentenceContextToDraft : null,
         onClearSentenceDraft:
             supportsSentenceDraft ? onClearSentenceDraftToDraft : null,
+        // Niratan「制卡前调整·选择句子上下文」模态：弹窗按需拉取当前草稿的真实上下
+        // 文句（前/当前/后）+ 词偏移做预览。只在支持草稿的表面接线，其余传 null。
+        onSentenceContextPreview:
+            supportsSentenceDraft ? onSentenceContextPreviewFromDraft : null,
       ),
     );
   }
@@ -762,6 +766,15 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
   /// 默认 no-op（[supportsSentenceDraft] 为 false 时不会被调用）。reader/视频覆写。
   @protected
   Future<int> onClearSentenceDraftToDraft() async => 0;
+
+  /// Niratan「制卡前调整·选择句子上下文」：把当前会话级草稿的真实上下文句
+  /// （上 N / 下 N，已按阅读顺序）+ 当前正查句 + 词在当前句里的偏移打包成 JSON-safe
+  /// Map（[buildSentenceContextPreview] 的结构）回给弹窗渲染三栏预览。默认返回空 Map
+  /// （[supportsSentenceDraft] 为 false 时不会被调用）。reader/视频覆写：各自提供当前
+  /// 正查句与词偏移来源。
+  @protected
+  Future<Map<String, Object?>> onSentenceContextPreviewFromDraft() async =>
+      const <String, Object?>{};
 
   /// Called when a non-last popup layer is dismissed (the stack shrinks but a
   /// parent popup remains). Override (reader) to keep the char cursor following

--- a/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -86,6 +86,13 @@ mixin DictionaryPageMixin {
   /// 对称，纯查词页不渲染清空入口）。视频页覆写返回非空闭包清掉 [MiningSentenceDraft]。
   Future<int> Function()? get onClearSentenceDraftToDraft => null;
 
+  /// Niratan「制卡前调整·选择句子上下文」（视频/首页查词车道）：弹窗打开模态时拉取当前
+  /// 草稿真实上下文句 + 当前正查句 + 词偏移做预览。默认 null = 不支持（纯查词页无草稿）。
+  /// 视频页覆写返回非空闭包（[buildSentenceContextPreview]）。与 reader 车道
+  /// （[BaseSourcePageState.onSentenceContextPreviewFromDraft]）对称。
+  Future<Map<String, Object?>> Function()?
+      get onSentenceContextPreviewToDraft => null;
+
   // 今日统计 dateKey 走 stat_activity 的权威实现（statTodayKey），不在此重复格式化。
   String _statTodayKey() => statTodayKey();
 
@@ -517,6 +524,7 @@ mixin DictionaryPageMixin {
         onAppendSentence: onAppendSentenceToDraft,
         onSetSentenceContext: onSetSentenceContextToDraft,
         onClearSentenceDraft: onClearSentenceDraftToDraft,
+        onSentenceContextPreview: onSentenceContextPreviewToDraft,
         headerWidget: buildPopupHeaderFor(index),
       ),
     );

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -315,6 +315,7 @@ class DictionaryPopupLayer extends StatelessWidget {
     this.onAppendSentence,
     this.onSetSentenceContext,
     this.onClearSentenceDraft,
+    this.onSentenceContextPreview,
     this.isSearching = false,
     this.keepWebViewWarm = false,
     this.hasChildPopup = false,
@@ -389,6 +390,11 @@ class DictionaryPopupLayer extends StatelessWidget {
   /// TODO-382「+句」可撤销：弹窗点「清空已加句子」清空宿主草稿，返回清空后句数（恒 0）。
   /// 与 [onAppendSentence] 同生命周期：支持草稿的表面非空，纯查词页 null（不渲染清空入口）。
   final Future<int> Function()? onClearSentenceDraft;
+
+  /// Niratan「制卡前调整·选择句子上下文」：弹窗拉取当前草稿真实上下文句 + 词偏移做
+  /// 预览的回调，透传给 webview。null 时弹窗不渲染「调整上下文」按钮（与 [onSetSentenceContext]
+  /// 同生命周期，仅支持草稿的表面非空）。
+  final Future<Map<String, Object?>> Function()? onSentenceContextPreview;
   final VoidCallback? onTapOutside;
   final VoidCallback? onScrolledToBottom;
   final VoidCallback? onRendered;
@@ -657,6 +663,7 @@ class DictionaryPopupLayer extends StatelessWidget {
             onAppendSentence: onAppendSentence,
             onSetSentenceContext: onSetSentenceContext,
             onClearSentenceDraft: onClearSentenceDraft,
+            onSentenceContextPreview: onSentenceContextPreview,
             onScrolledToBottom: onScrolledToBottom,
             onRendered: onRendered,
             onRenderError: onRenderError,

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -85,6 +85,7 @@ class DictionaryPopupWebView extends ConsumerStatefulWidget {
     this.onAppendSentence,
     this.onSetSentenceContext,
     this.onClearSentenceDraft,
+    this.onSentenceContextPreview,
     this.onScrolledToBottom,
     this.onTopPullReleased,
     this.onRendered,
@@ -161,6 +162,13 @@ class DictionaryPopupWebView extends ConsumerStatefulWidget {
   /// 处理器触发本回调，宿主清空草稿并回传清空后句数（恒 0），popup 据此把所有「+句」
   /// 角标归零。非空才在 popup 渲染清空入口（与 [onAppendSentence] 同生命周期）。
   final Future<int> Function()? onClearSentenceDraft;
+
+  /// Niratan「制卡前调整·选择句子上下文」：popup 点「调整上下文」打开模态时经
+  /// `sentenceContextPreview` JS 处理器触发本回调，宿主把当前草稿的真实上下文句
+  /// （前/当前/后）+ 词在当前句的偏移打包成 JSON-safe Map（见 `buildSentenceContextPreview`）
+  /// 回给 popup 渲染三栏预览。非空才在 popup 渲染「调整上下文」按钮（与 [onSetSentenceContext]
+  /// 同生命周期；reader/视频启用）。
+  final Future<Map<String, Object?>> Function()? onSentenceContextPreview;
   final VoidCallback? onScrolledToBottom;
   final VoidCallback? onTopPullReleased;
 
@@ -738,6 +746,28 @@ class DictionaryPopupWebViewState
       window.i18nClearSentenceDraftTooltip = ${jsonEncode(t.popup_clear_sentence_draft_tooltip)};
       window.i18nContextPrevLabel = ${jsonEncode(t.popup_sentence_context_prev_label)};
       window.i18nContextNextLabel = ${jsonEncode(t.popup_sentence_context_next_label)};
+      // Niratan「制卡前调整·选择句子上下文」：独立于旧内联步进器（kSentenceContextPickerEnabled
+      // 恒 false）的新特性门控——宿主接入了预览回调（reader/有声书/视频，supportsSentenceDraft
+      // 为真）才为真，popup.js 据此渲染「调整上下文」按钮。app 外 / 悬浮独立窗不走本注入块，
+      // 该 flag undefined → 按钮不渲染。
+      window.sentenceContextPreviewEnabled = ${widget.onSentenceContextPreview != null};
+      // Niratan「制卡前调整·选择句子上下文」模态文案（popup.js 无自带 i18n，靠宿主注入）。
+      window.i18nCtx = {
+        adjust: ${jsonEncode(t.popup_ctx_adjust_button)},
+        eyebrow: ${jsonEncode(t.popup_ctx_modal_eyebrow)},
+        title: ${jsonEncode(t.popup_ctx_modal_title)},
+        count: ${jsonEncode(t.popup_ctx_modal_count)},
+        boxPrev: ${jsonEncode(t.popup_ctx_box_prev)},
+        boxCurrent: ${jsonEncode(t.popup_ctx_box_current)},
+        boxNext: ${jsonEncode(t.popup_ctx_box_next)},
+        boxEmpty: ${jsonEncode(t.popup_ctx_box_empty)},
+        prevMinus: ${jsonEncode(t.popup_ctx_prev_minus)},
+        prevPlus: ${jsonEncode(t.popup_ctx_prev_plus)},
+        nextMinus: ${jsonEncode(t.popup_ctx_next_minus)},
+        nextPlus: ${jsonEncode(t.popup_ctx_next_plus)},
+        confirm: ${jsonEncode(t.popup_ctx_confirm)},
+        cancel: ${jsonEncode(t.popup_ctx_cancel)},
+      };
       $beforeRenderJs
       ${needsScrollCheck ? _scrollCheckJs : ""}
     ''').then((_) {
@@ -1339,6 +1369,26 @@ class DictionaryPopupWebViewState
                   return widget.onClearSentenceDraft!();
                 }
                 return 0;
+              },
+            );
+          },
+        );
+
+        // Niratan「制卡前调整·选择句子上下文」：popup 打开模态 / 每次调整后拉取当前草稿
+        // 的真实上下文句（前/当前/后）+ 词偏移做预览。只读，不改草稿（调整仍走
+        // setSentenceContext）。宿主未接入 / 出错时回传空 Map，popup 侧兜底不渲染文本。
+        controller.addJavaScriptHandler(
+          handlerName: 'sentenceContextPreview',
+          callback: (_) async {
+            return _guardJsBridge<Object?>(
+              'DictPopupWebview.sentenceContextPreview',
+              const <String, Object?>{},
+              ErrorLogService.instance,
+              () async {
+                if (widget.onSentenceContextPreview == null) {
+                  return const <String, Object?>{};
+                }
+                return widget.onSentenceContextPreview!();
               },
             );
           },

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -2689,6 +2689,21 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
     return _miningDraft.length;
   }
 
+  /// Niratan「制卡前调整·选择句子上下文」：把当前草稿真实上下文句 + 当前正查句 + 词偏移
+  /// 打包给弹窗预览。当前句取制卡同一来源（[MediaSource.currentSentence]，见
+  /// [_prepareMiningContext]），词偏移取查词时缓存的 [_cachedSentenceOffset]，保证预览
+  /// 与真正落卡的 sentence 字段一致。
+  @override
+  Future<Map<String, Object?>> onSentenceContextPreviewFromDraft() async {
+    final String current =
+        appModel.currentMediaSource?.currentSentence.text ?? '';
+    return buildSentenceContextPreview(
+      draft: _miningDraft,
+      current: current,
+      currentOffset: _cachedSentenceOffset,
+    );
+  }
+
   @override
   Future<MinePopupResult> onMineFromPopup(Map<String, String> fields) {
     // TODO-644 / BUG-357：经制卡串行队列执行，杜绝快速连制两张卡时两次 prepare→mine

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -1186,6 +1186,18 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   Future<int> Function()? get onClearSentenceDraftToDraft =>
       _clearSentenceDraft;
 
+  /// Niratan「制卡前调整·选择句子上下文」（视频车道）：把当前草稿真实上下文句 + 当前
+  /// 正查字幕句（[_lastLookupSentence]）打包给弹窗预览。视频无「词在句中的字符偏移」
+  /// 缓存（cue 文本非阅读器 DOM 选区），词偏移传 null——弹窗侧回退到首次出现高亮。
+  @override
+  Future<Map<String, Object?>> Function()?
+      get onSentenceContextPreviewToDraft =>
+          () async => buildSentenceContextPreview(
+                draft: _miningDraft,
+                current: _lastLookupSentence,
+                currentOffset: null,
+              );
+
   /// 「本次查词浮层是我们因查词而主动暂停了正在播放的视频」标记。
   ///
   /// 查词暂停 / 关浮层恢复与阅读器 [ReaderHibikiPage] 同源：浮层打开时若视频在播放则

--- a/hibiki/test/media/audiobook/mining_sentence_draft_test.dart
+++ b/hibiki/test/media/audiobook/mining_sentence_draft_test.dart
@@ -225,4 +225,57 @@ void main() {
       expect(() => draft.nextSentences.add(s('x')), throwsUnsupportedError);
     });
   });
+
+  group('buildSentenceContextPreview (Niratan 制卡前调整模态)', () {
+    MiningDraftSentence s(String text) => MiningDraftSentence(sentence: text);
+
+    test('empty draft yields prev/next empty, total 0, current + offset echoed',
+        () {
+      final MiningSentenceDraft draft = MiningSentenceDraft();
+      final Map<String, Object?> p = buildSentenceContextPreview(
+        draft: draft,
+        current: '当前句。',
+        currentOffset: 3,
+      );
+      expect(p['prev'], <String>[]);
+      expect(p['next'], <String>[]);
+      expect(p['current'], '当前句。');
+      expect(p['currentOffset'], 3);
+      expect(p['total'], 0);
+    });
+
+    test('prev/next real texts echoed in reading order, total = prev + next',
+        () {
+      final MiningSentenceDraft draft = MiningSentenceDraft();
+      draft.setContext(
+        prev: <MiningDraftSentence>[s('前々。'), s('前。')],
+        next: <MiningDraftSentence>[s('后。')],
+      );
+      final Map<String, Object?> p = buildSentenceContextPreview(
+        draft: draft,
+        current: '当前。',
+        currentOffset: null,
+      );
+      expect(p['prev'], <String>['前々。', '前。']);
+      expect(p['next'], <String>['后。']);
+      expect(p['current'], '当前。');
+      expect(p['currentOffset'], isNull);
+      expect(p['total'], 3);
+    });
+
+    test('result is JSON-safe (bridge-serializable) — String/int/List<String>',
+        () {
+      final MiningSentenceDraft draft = MiningSentenceDraft()
+        ..setContext(prev: <MiningDraftSentence>[s('前。')]);
+      final Map<String, Object?> p = buildSentenceContextPreview(
+        draft: draft,
+        current: 'x',
+        currentOffset: 0,
+      );
+      expect(p['prev'], isA<List<String>>());
+      expect(p['next'], isA<List<String>>());
+      expect(p['current'], isA<String>());
+      expect(p['total'], isA<int>());
+    });
+  });
 }

--- a/hibiki/test/pages/sentence_context_modal_guard_test.dart
+++ b/hibiki/test/pages/sentence_context_modal_guard_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'reader_hibiki_page_source_corpus.dart';
+
+/// Niratan「制卡前调整·选择句子上下文」模态接线守卫。
+///
+/// 这是**独立于**旧内联步进器（`kSentenceContextPickerEnabled` 恒 false，永不渲染）的新
+/// 特性：词条上的「调整上下文」按钮打开一个模态，展示前文/当前句(词高亮)/后文的真实文本，
+/// 用前退/前加/后退/后加一句调整、确认制卡。数据经宿主只读回调 `onSentenceContextPreview`
+/// （→ `sentenceContextPreview` JS handler）回传；调整仍走既有 `setSentenceContext`；确认
+/// 制卡复用词条 mineButton。无头测试照不到真实 WebView，故用源码扫描守卫钉死每段接线。
+void main() {
+  String read(String relativePath) {
+    final File file = File(relativePath);
+    expect(file.existsSync(), isTrue, reason: 'missing $relativePath');
+    return file.readAsStringSync();
+  }
+
+  test('webview registers sentenceContextPreview handler + injects flag/i18n',
+      () {
+    final String src =
+        read('lib/src/pages/implementations/dictionary_popup_webview.dart');
+    expect(src, contains("handlerName: 'sentenceContextPreview'"));
+    expect(src, contains('widget.onSentenceContextPreview'));
+    // 独立门控 flag，从宿主回调是否接入派生（不复用被砍掉的 sentenceDraftEnabled）。
+    expect(
+      src,
+      contains(
+          r'window.sentenceContextPreviewEnabled = ${widget.onSentenceContextPreview != null};'),
+      reason: '按钮门控 flag 必须从 onSentenceContextPreview 是否接入派生',
+    );
+    // 模态文案注入（popup.js 无自带 i18n）。
+    expect(src, contains('window.i18nCtx = {'));
+    expect(src, contains('t.popup_ctx_modal_title'));
+    expect(src, contains('t.popup_ctx_confirm'));
+  });
+
+  test('popup layer forwards onSentenceContextPreview to the webview', () {
+    final String src =
+        read('lib/src/pages/implementations/dictionary_popup_layer.dart');
+    // 字段声明 + 构造透传 + 转发给 webview 三处都在。
+    expect(
+        src,
+        contains(
+            'final Future<Map<String, Object?>> Function()? onSentenceContextPreview;'));
+    expect(src, contains('this.onSentenceContextPreview,'));
+    expect(src, contains('onSentenceContextPreview: onSentenceContextPreview'));
+  });
+
+  test('base page wires preview only when the surface supports drafts', () {
+    final String src = read('lib/src/pages/base_source_page.dart');
+    expect(
+      src,
+      contains(
+          'supportsSentenceDraft ? onSentenceContextPreviewFromDraft : null'),
+    );
+    // 默认返回空 Map（纯查词页不支持草稿）。
+    expect(
+      src,
+      contains(
+          'Future<Map<String, Object?>> onSentenceContextPreviewFromDraft() async =>'),
+    );
+  });
+
+  test('reader overrides preview using the draft + cached word offset', () {
+    final String src = readReaderPageSource();
+    expect(
+      src,
+      contains(
+          'Future<Map<String, Object?>> onSentenceContextPreviewFromDraft() async'),
+    );
+    expect(src, contains('buildSentenceContextPreview('));
+    // 当前句取制卡同源（currentSentence），词偏移取查词缓存——保证预览=真实落卡。
+    expect(src, contains('currentOffset: _cachedSentenceOffset'));
+  });
+
+  test('video + mixin wire the preview callback symmetrically', () {
+    final String video =
+        read('lib/src/pages/implementations/video_hibiki_page.dart');
+    expect(video, contains('get onSentenceContextPreviewToDraft'));
+    expect(video, contains('buildSentenceContextPreview('));
+    final String mixin =
+        read('lib/src/pages/implementations/dictionary_page_mixin.dart');
+    expect(mixin,
+        contains('onSentenceContextPreview: onSentenceContextPreviewToDraft'));
+  });
+
+  test('popup.js renders the adjust button + modal, gated on the new flag', () {
+    final String js = read('assets/popup/popup.js');
+    // 独立门控（不是被砍掉的 sentenceDraftEnabled）。
+    expect(js, contains('if (window.sentenceContextPreviewEnabled)'));
+    expect(js, contains('ctx-adjust-button'));
+    expect(js, contains("setButtonIcon(adjustBtn, 'tune')"));
+    // 模态本体 + 只读预览桥接。
+    expect(js, contains('function openSentenceContextModal('));
+    expect(js, contains("callHandler('sentenceContextPreview')"));
+    expect(js, contains('sentence-context-modal'));
+    // 前退/前加/后退/后加一句四向调整（复用镜像 + setSentenceContext）。
+    expect(js, contains("makeAdjustBtn('prev', 'minus'"));
+    expect(js, contains("makeAdjustBtn('next', 'plus'"));
+    // 确认制卡复用词条 mineButton（不复制制卡逻辑）。
+    expect(js, contains('mineButton.click();'));
+  });
+
+  test('modal highlights the looked-up word without innerHTML injection', () {
+    final String js = read('assets/popup/popup.js');
+    // 当前句高亮用 textNode + 高亮 span 构造，绝不 innerHTML 拼用户句子文本。
+    expect(js, contains('function buildHighlightedCurrentText('));
+    expect(js, contains('scm-hl'));
+    expect(js, contains('document.createTextNode('));
+  });
+
+  test('popup.css ships the modal styles (theme-aware, token radius)', () {
+    final String css = read('assets/popup/popup.css');
+    expect(css, contains('.sentence-context-modal'));
+    expect(css, contains('.scm-card'));
+    expect(css, contains('.scm-box.scm-current'));
+    expect(css, contains('.scm-hl'));
+    // 卡片圆角走注入 token（与 kanji-card / global-lookup-sentence 一致，不硬编码）。
+    expect(css, contains('var(--hibiki-radius-card'));
+  });
+
+  test('extension content.css mirrors carry the scoped modal selectors', () {
+    for (final String root in const <String>[
+      'assets/browser_extension',
+      '../tools/browser-extension',
+    ]) {
+      final String content = read('$root/vendor/content.css');
+      expect(content.contains('.sentence-context-modal'), isTrue,
+          reason: '$root/vendor/content.css missing .sentence-context-modal '
+              '(re-run generate-content-css.mjs)');
+      expect(content.contains('.scm-hl'), isTrue,
+          reason: '$root/vendor/content.css missing .scm-hl');
+    }
+  });
+}

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -1252,6 +1252,159 @@
     border-radius: 2px;
 }
 
+/* ── Niratan「制卡前调整·选择句子上下文」模态 ────────────────────────────────
+   由词条上的「调整上下文」按钮（.ctx-adjust-button）打开。全部 class-rooted 选择器，
+   content.css 生成器自动 scope 进 #entries-container（扩展侧 sentenceContextPreviewEnabled
+   恒 undefined，不渲染，纯 dead style）。颜色走 popup 主题变量，暗/亮自适应。 */
+.sentence-context-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 2147483000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(0, 0, 0, 0.42);
+    -webkit-user-select: none;
+    user-select: none;
+    box-sizing: border-box;
+}
+
+.scm-card {
+    width: 100%;
+    max-width: 460px;
+    max-height: 92%;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    padding: 16px;
+    border-radius: var(--hibiki-radius-card, 14px);
+    background: var(--background-color, #fff);
+    color: var(--text-color, #000);
+    border: 1px solid var(--outline-variant, rgba(128, 128, 128, 0.32));
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+
+.scm-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.scm-eyebrow {
+    font-size: 0.78em;
+    color: var(--text-color-light3, #777);
+}
+
+.scm-x {
+    flex: 0 0 auto;
+    opacity: 0.7;
+}
+
+.scm-title {
+    font-size: 1.12em;
+    font-weight: 600;
+    margin-top: 2px;
+}
+
+.scm-count {
+    font-size: 0.82em;
+    color: var(--text-color-light3, #777);
+    margin: 6px 0 10px;
+}
+
+.scm-boxes {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.scm-box {
+    border-radius: 10px;
+    padding: 8px 10px;
+    background: var(--surface-container, rgba(128, 128, 128, 0.10));
+    border: 1px solid transparent;
+}
+
+.scm-box.scm-current {
+    background: var(--surface-container-high, rgba(128, 128, 128, 0.14));
+    border-color: var(--primary-color, #386A58);
+}
+
+.scm-box-label {
+    font-size: 0.72em;
+    color: var(--text-color-light3, #777);
+    margin-bottom: 3px;
+}
+
+.scm-box-text {
+    font-size: 0.95em;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.scm-box-text.scm-empty {
+    color: var(--text-color-light4, #888);
+    font-style: italic;
+}
+
+.scm-hl {
+    color: var(--primary-color, #386A58);
+    background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.18));
+    border-radius: 3px;
+    padding: 0 1px;
+    font-weight: 600;
+}
+
+.scm-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 12px;
+}
+
+.scm-btn {
+    font-family: inherit;
+    font-size: 0.9em;
+    padding: 7px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--outline-variant, rgba(128, 128, 128, 0.32));
+    background: var(--surface-container, rgba(128, 128, 128, 0.10));
+    color: var(--text-color, #000);
+    cursor: pointer;
+}
+
+.scm-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.scm-adjust {
+    flex: 1 1 42%;
+}
+
+.scm-foot {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 14px;
+}
+
+.scm-confirm {
+    background: var(--primary-color, #386A58);
+    border-color: var(--primary-color, #386A58);
+    color: #fff;
+    font-weight: 600;
+}
+
+.ctx-adjust-button {
+    opacity: 0.85;
+}
+
 /*
  *  content-css-overlay.css — extension-only additions appended to the generated
  *  content.css (see generate-content-css.mjs).

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -1345,3 +1345,156 @@ html.global-lookup .glossary-section > .category-body > .glossary-group {
     background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.22));
     border-radius: 2px;
 }
+
+/* ── Niratan「制卡前调整·选择句子上下文」模态 ────────────────────────────────
+   由词条上的「调整上下文」按钮（.ctx-adjust-button）打开。全部 class-rooted 选择器，
+   content.css 生成器自动 scope 进 #entries-container（扩展侧 sentenceContextPreviewEnabled
+   恒 undefined，不渲染，纯 dead style）。颜色走 popup 主题变量，暗/亮自适应。 */
+.sentence-context-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 2147483000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(0, 0, 0, 0.42);
+    -webkit-user-select: none;
+    user-select: none;
+    box-sizing: border-box;
+}
+
+.scm-card {
+    width: 100%;
+    max-width: 460px;
+    max-height: 92%;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    padding: 16px;
+    border-radius: var(--hibiki-radius-card, 14px);
+    background: var(--background-color, #fff);
+    color: var(--text-color, #000);
+    border: 1px solid var(--outline-variant, rgba(128, 128, 128, 0.32));
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+
+.scm-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.scm-eyebrow {
+    font-size: 0.78em;
+    color: var(--text-color-light3, #777);
+}
+
+.scm-x {
+    flex: 0 0 auto;
+    opacity: 0.7;
+}
+
+.scm-title {
+    font-size: 1.12em;
+    font-weight: 600;
+    margin-top: 2px;
+}
+
+.scm-count {
+    font-size: 0.82em;
+    color: var(--text-color-light3, #777);
+    margin: 6px 0 10px;
+}
+
+.scm-boxes {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.scm-box {
+    border-radius: 10px;
+    padding: 8px 10px;
+    background: var(--surface-container, rgba(128, 128, 128, 0.10));
+    border: 1px solid transparent;
+}
+
+.scm-box.scm-current {
+    background: var(--surface-container-high, rgba(128, 128, 128, 0.14));
+    border-color: var(--primary-color, #386A58);
+}
+
+.scm-box-label {
+    font-size: 0.72em;
+    color: var(--text-color-light3, #777);
+    margin-bottom: 3px;
+}
+
+.scm-box-text {
+    font-size: 0.95em;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.scm-box-text.scm-empty {
+    color: var(--text-color-light4, #888);
+    font-style: italic;
+}
+
+.scm-hl {
+    color: var(--primary-color, #386A58);
+    background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.18));
+    border-radius: 3px;
+    padding: 0 1px;
+    font-weight: 600;
+}
+
+.scm-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 12px;
+}
+
+.scm-btn {
+    font-family: inherit;
+    font-size: 0.9em;
+    padding: 7px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--outline-variant, rgba(128, 128, 128, 0.32));
+    background: var(--surface-container, rgba(128, 128, 128, 0.10));
+    color: var(--text-color, #000);
+    cursor: pointer;
+}
+
+.scm-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.scm-adjust {
+    flex: 1 1 42%;
+}
+
+.scm-foot {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 14px;
+}
+
+.scm-confirm {
+    background: var(--primary-color, #386A58);
+    border-color: var(--primary-color, #386A58);
+    color: #fff;
+    font-weight: 600;
+}
+
+.ctx-adjust-button {
+    opacity: 0.85;
+}

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -343,6 +343,209 @@ function buildSentenceContextPicker() {
     return picker;
 }
 
+// ── Niratan「制卡前调整·选择句子上下文」模态 ──────────────────────────────────
+// 与旧「上 N / 下 N」内联步进器（kSentenceContextPickerEnabled 恒 false，永不渲染）互
+// 独立的新特性：点词条上的「调整上下文」按钮打开一个模态，展示**前文 / 当前句(查到的
+// 词高亮) / 后文**的真实文本 + 前退/前加/后退/后加一句调整 + 取消/确认制卡。一键「+」
+// 制卡保持不变（不打开模态）。数据流复用既有 sentenceCtxPrev/Next 镜像 + setSentenceContext
+// 桥接（宿主整体解析上下文句进草稿），文本由新的只读 sentenceContextPreview 桥接回传；
+// 「确认制卡」直接点回该词条的 mineButton，复用其全部制卡/查重/覆写逻辑。
+
+function ctxI18n() {
+    return window.i18nCtx || {};
+}
+
+// 只读拉取宿主当前草稿的上下文预览（前/当前/后真实句 + 词在当前句的偏移）。宿主未接入
+// / 出错时回空对象，模态侧兜底不渲染文本（绝不崩制卡主流程）。
+async function fetchSentenceContextPreview() {
+    try {
+        const reply = await window.flutter_inappwebview.callHandler('sentenceContextPreview');
+        return (reply && typeof reply === 'object') ? reply : {};
+    } catch (e) {
+        console.error('sentenceContextPreview failed', e);
+        return {};
+    }
+}
+
+// 用当前句文本 + 词偏移 + 词表现形，构造一个带 <span class="scm-hl"> 高亮的文本盒。**不用
+// innerHTML 拼用户文本**（句子是书内容，杜绝 HTML 注入）——纯 textNode + 一个高亮 span。
+// offset 命中优先（与卡片渲染 _sentenceValue 同容错），失配回退首次出现匹配，再失配无高亮。
+function buildHighlightedCurrentText(text, offset, matched) {
+    const box = el('div', { className: 'scm-box-text' });
+    if (!text) {
+        box.classList.add('scm-empty');
+        box.textContent = ctxI18n().boxEmpty || '';
+        return box;
+    }
+    let start = -1;
+    if (matched) {
+        if (typeof offset === 'number' && offset >= 0 &&
+            text.substr(offset, matched.length) === matched) {
+            start = offset;
+        } else {
+            start = text.indexOf(matched);
+        }
+    }
+    if (start < 0 || !matched) {
+        box.textContent = text;
+        return box;
+    }
+    box.appendChild(document.createTextNode(text.slice(0, start)));
+    box.appendChild(el('span', {
+        className: 'scm-hl',
+        textContent: text.slice(start, start + matched.length),
+    }));
+    box.appendChild(document.createTextNode(text.slice(start + matched.length)));
+    return box;
+}
+
+// 渲染一个上下文盒（前文 / 后文）：标签 + 每句一行。空 → 占位「（无）」。纯 textNode。
+function buildContextBox(labelText, sentences, extraClass) {
+    const wrap = el('div', { className: 'scm-box ' + (extraClass || '') });
+    wrap.appendChild(el('div', { className: 'scm-box-label', textContent: labelText }));
+    if (!sentences || !sentences.length) {
+        wrap.appendChild(el('div', {
+            className: 'scm-box-text scm-empty',
+            textContent: ctxI18n().boxEmpty || '',
+        }));
+        return wrap;
+    }
+    const t = el('div', { className: 'scm-box-text' });
+    sentences.forEach(function(s, i) {
+        if (i) t.appendChild(el('br'));
+        t.appendChild(document.createTextNode(String(s)));
+    });
+    wrap.appendChild(t);
+    return wrap;
+}
+
+let __sentenceContextModalOpen = false;
+
+// 打开「制卡前调整」模态。[mineButton]：该词条的制卡按钮（确认制卡时点它复用全部逻辑）；
+// [matched]：查到的词表现形（用于在当前句里高亮）。同一时刻只允许一个模态。
+async function openSentenceContextModal(mineButton, matched) {
+    if (__sentenceContextModalOpen) return;
+    __sentenceContextModalOpen = true;
+    const i = ctxI18n();
+    // 记住打开时的镜像；取消 = 还原到此（不把半调整的草稿留给后续「+」一键制卡）。
+    const snapPrev = sentenceCtxPrev;
+    const snapNext = sentenceCtxNext;
+
+    const overlay = el('div', { className: 'sentence-context-modal' });
+    const card = el('div', { className: 'scm-card' });
+    overlay.appendChild(card);
+
+    const head = el('div', { className: 'scm-head' });
+    head.appendChild(el('span', { className: 'scm-eyebrow', textContent: i.eyebrow || '' }));
+    const closeBtn = el('button', { className: 'inline-action-button scm-x' });
+    setButtonIcon(closeBtn, 'close');
+    head.appendChild(closeBtn);
+    card.appendChild(head);
+    card.appendChild(el('div', { className: 'scm-title', textContent: i.title || '' }));
+    const countEl = el('div', { className: 'scm-count' });
+    card.appendChild(countEl);
+
+    const boxes = el('div', { className: 'scm-boxes' });
+    card.appendChild(boxes);
+
+    let busy = false;
+    const makeAdjustBtn = function(dir, sign, label) {
+        const btn = el('button', {
+            className: 'scm-btn scm-adjust ' + dir + '-' + sign,
+            textContent: label,
+        });
+        btn.dataset.dir = dir;
+        btn.dataset.sign = sign;
+        btn.onclick = function() { adjust(dir, sign); };
+        return btn;
+    };
+    const prevMinusBtn = makeAdjustBtn('prev', 'minus', i.prevMinus || '');
+    const prevPlusBtn = makeAdjustBtn('prev', 'plus', i.prevPlus || '');
+    const nextMinusBtn = makeAdjustBtn('next', 'minus', i.nextMinus || '');
+    const nextPlusBtn = makeAdjustBtn('next', 'plus', i.nextPlus || '');
+    const actions = el('div', { className: 'scm-actions' });
+    actions.appendChild(prevMinusBtn);
+    actions.appendChild(prevPlusBtn);
+    actions.appendChild(nextMinusBtn);
+    actions.appendChild(nextPlusBtn);
+    card.appendChild(actions);
+
+    const cancelBtn = el('button', { className: 'scm-btn scm-cancel', textContent: i.cancel || '' });
+    const confirmBtn = el('button', { className: 'scm-btn scm-confirm', textContent: i.confirm || '' });
+    const foot = el('div', { className: 'scm-foot' });
+    foot.appendChild(cancelBtn);
+    foot.appendChild(confirmBtn);
+    card.appendChild(foot);
+
+    function renderPreview(preview) {
+        const prev = Array.isArray(preview.prev) ? preview.prev : [];
+        const next = Array.isArray(preview.next) ? preview.next : [];
+        const current = typeof preview.current === 'string' ? preview.current : '';
+        const total = typeof preview.total === 'number' ? preview.total : (prev.length + next.length);
+        // 镜像与宿主真实句数对齐：宿主按段落/cue 边界封顶，到边界再「加」是空操作，
+        // 计数不再上涨——honest feedback（不像旧步进器让镜像无界上涨）。
+        sentenceCtxPrev = prev.length;
+        sentenceCtxNext = next.length;
+        sentenceDraftCount = total;
+        countEl.textContent = (i.count || '%d').replace('%d', String(total));
+        boxes.textContent = '';
+        boxes.appendChild(buildContextBox(i.boxPrev || '', prev, 'scm-prev'));
+        const curBox = el('div', { className: 'scm-box scm-current selected' });
+        curBox.appendChild(el('div', { className: 'scm-box-label', textContent: i.boxCurrent || '' }));
+        curBox.appendChild(buildHighlightedCurrentText(current, preview.currentOffset, matched));
+        boxes.appendChild(curBox);
+        boxes.appendChild(buildContextBox(i.boxNext || '', next, 'scm-next'));
+        prevMinusBtn.disabled = prev.length <= 0;
+        nextMinusBtn.disabled = next.length <= 0;
+    }
+
+    async function refresh() {
+        renderPreview(await fetchSentenceContextPreview());
+    }
+
+    async function adjust(dir, sign) {
+        if (busy) return;
+        busy = true;
+        card.dataset.busy = '1';
+        try {
+            const cur = dir === 'prev' ? sentenceCtxPrev : sentenceCtxNext;
+            const nextN = sign === 'plus' ? cur + 1 : Math.max(0, cur - 1);
+            if (dir === 'prev') sentenceCtxPrev = nextN;
+            else sentenceCtxNext = nextN;
+            await setSentenceContextOnHost();
+            await refresh();
+        } finally {
+            busy = false;
+            card.dataset.busy = '';
+        }
+    }
+
+    function close() {
+        if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+        __sentenceContextModalOpen = false;
+    }
+    async function cancel() {
+        // 取消：还原到打开时的选择（取消不改草稿），再关。
+        sentenceCtxPrev = snapPrev;
+        sentenceCtxNext = snapNext;
+        try { await setSentenceContextOnHost(); } catch (e) { /* 取消尽力而为 */ }
+        close();
+    }
+    closeBtn.onclick = cancel;
+    cancelBtn.onclick = cancel;
+    overlay.onclick = function(e) { if (e.target === overlay) cancel(); };
+    confirmBtn.onclick = function() {
+        close();
+        // 复用该词条制卡按钮的全部逻辑（查重/覆写/制卡后清理都在里面）。
+        if (mineButton && !mineButton.disabled) mineButton.click();
+    };
+
+    (document.body || __hibikiRootNode()).appendChild(overlay);
+    // 先用镜像画个占位，再异步拉真实预览覆盖（避免打开瞬间空白）。
+    renderPreview({ prev: [], next: [], current: '', total: sentenceCtxPrev + sentenceCtxNext });
+    await refresh();
+}
+
 
 function el(tag, props = {}, children = []) {
     const element = document.createElement(tag);
@@ -383,6 +586,8 @@ const ICON_PATHS = {
     remove: 'M19 13H5v-2h14v2z',
     // close（清空草稿 / 标签说明遮罩关闭 ×）
     close: 'M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z',
+    // tune（Niratan「调整上下文」按钮：打开制卡前句子上下文调整模态）
+    tune: 'M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z',
 };
 
 function iconSvg(name) {
@@ -2254,6 +2459,21 @@ function createEntryHeader(entry, idx) {
         setButtonIcon(clearButton, 'close');
         refreshClearDraftButton(clearButton);
         buttonsContainer.appendChild(clearButton);
+    }
+
+    // Niratan「制卡前调整·选择句子上下文」：独立于上面被砍掉的内联步进器
+    // （kSentenceContextPickerEnabled 恒 false）。支持草稿且宿主接入了预览回调的表面
+    // （reader/有声书/视频，window.sentenceContextPreviewEnabled 为真）渲染一个「调整
+    // 上下文」按钮，点开模态在里面看前/当前/后真实句并增减上下文、确认制卡。一键「+」
+    // 制卡不受影响。
+    if (window.sentenceContextPreviewEnabled) {
+        const adjustBtn = el('button', {
+            className: 'inline-action-button ctx-adjust-button',
+            title: (window.i18nCtx && window.i18nCtx.adjust) || '',
+            onclick: function() { openSentenceContextModal(mineButton, matched); },
+        });
+        setButtonIcon(adjustBtn, 'tune');
+        buttonsContainer.appendChild(adjustBtn);
     }
 
     header.appendChild(buttonsContainer);


### PR DESCRIPTION
## 做了什么

抄 Niratan mac 版的「制卡前调整·选择句子上下文」：查词弹窗词条上新增一个「调整上下文」按钮（tune 图标），点开一个模态，展示**前文 / 当前句（查到的词蓝色高亮）/ 后文**的真实文本 + 「已选择 N 句」，用 `前退/前加/后退/后加一句` 调整上下文，`取消 / 确认制卡`。

一键「+」制卡**保持不变**（不打开模态，Never break userspace）——按用户选择「保留一键制卡 + 调整按钮」实现。

## 关键设计

- **独立门控**：旧内联「上N/下N」步进器早已被 `kSentenceContextPickerEnabled = false`（TODO-426）砍掉、永不渲染。本模态是**独立新特性**，用新 flag `window.sentenceContextPreviewEnabled`（= 宿主 `onSentenceContextPreview` 是否接入）门控，**完全不碰**那个 false 常量和旧 picker 代码（旧守卫全绿）。
- **只读预览桥接**：宿主新增 `onSentenceContextPreview` 回调（→ `sentenceContextPreview` JS handler），把当前草稿的真实上下文句 `prev/next` + 当前句 + 词偏移打包成 JSON-safe Map。纯函数 `buildSentenceContextPreview` 收口；reader 用 `currentSentence`+`_cachedSentenceOffset`，video 用 `_lastLookupSentence`（无偏移→回退首次匹配高亮）。
- **调整复用既有链路**：`前加/前退…` 仍走既有 `setSentenceContext`（宿主整体解析上下文进 `MiningSentenceDraft`，按段落/cue 边界封顶）；`确认制卡` 直接 `mineButton.click()`，**不复制**制卡/查重/覆写逻辑。预览与真正落卡的 sentence 字段同源，保证一致。
- **无注入**：当前句词高亮用 `createTextNode` + 高亮 `span` 构造，绝不 `innerHTML` 拼书内容。
- **三层桥接对称**：`base_source_page`（reader/有声书）+ `dictionary_page_mixin`（video/首页）两条车道都接。
- **扩展镜像**：`popup.js/css` 改动同步两个 vendor 镜像 + 重新生成 `content.css`（TODO-1267 parity 守卫绿）。
- **i18n**：14 个新键经 `i18n_sync` + `slang` 生成（EN + zh-CN 到位，其余语言英文回退）。

## 验证

- `flutter analyze`（含 test）：**No issues found**
- `flutter test` 全量：**10757 passed / 3 skipped**
- 新增 `buildSentenceContextPreview` 纯函数单测 + `sentence_context_modal_guard_test.dart` 接线守卫；既有 sentence-draft / niratan-visual / 扩展 parity 守卫均绿

## ⚠️ 待真机

无头测试照不到真实 WebView。模态在真机上的**视觉观感、暗/亮主题、弹窗窄宽下的排版、词高亮定位**需在真实模拟器/桌面复测（阅读器 + 视频两条路径）。