### PR TITLE
fix(sync): 互联服务端模式隐藏「测试连接」按钮 (BUG-722)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 706 条。点号进各自文件。
+> 共 707 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-722](bugs/BUG-722-interconnect-testconn-button-in-server-mode.md) | ✅ | ✅ | 互联服务端模式仍显示测试连接按钮 |
 | [BUG-721](bugs/BUG-721-clipboard-panel-close-drops-lookups.md) | ✅ | ✅ | 剪贴板面板关闭后被永久暂停：第二个词出不来 |
 | [BUG-720](bugs/BUG-720-sasayaki-lookup-ruby-lane-misalign.md) | ✅ | ✅ | 有声书/查词注音高亮 narrow-lane 错位 |
 | [BUG-718](bugs/BUG-718-vn-restore-charoffset-cloak.md) | ✅ | ✅ | VN模式按字符偏移恢复时FOUC遮罩未移除致整页空白 |

--- a/docs/bugs/BUG-722-interconnect-testconn-button-in-server-mode.md
+++ b/docs/bugs/BUG-722-interconnect-testconn-button-in-server-mode.md
@@ -1,0 +1,7 @@
+## BUG-722 · 互联服务端模式仍显示测试连接按钮
+- **报告**：2026-07-11（用户：hibiki 互联作为服务端不应该有测试连接按钮）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart:497`（`_HibikiServerConfigWidgetState.build` 里「测试连接」按钮无条件渲染，未被 `lockedByServer` 门控）。
+  互联后端（`SyncBackendType.hibikiServer`）的设置里，客户端配置区 `_HibikiServerConfigWidget` 与服务端开关区 `_ServerModeWidget` 同屏显示，靠 role-locking 互斥。当本机启用服务端（`serverEnabled == true` → `lockedByServer == true`）时，客户端区的地址增改虽已被禁用，但「测试连接」按钮（`_testAll` → 探测出站地址可达性）仍显示且可点。本机作为服务端时是一台被动数据源，没有出站客户端连接可测——此按钮既无意义又误导（与 BUG-084「服务端隐藏 sync now / compare」是同一类问题）。
+- **[x] ① 已修复** — 用 `if (!lockedByServer) ...<Widget>[ ... ]` 门控「测试连接」按钮块（含其上方 `SizedBox(height:12)` 与 `_isTesting` spinner），服务端模式下整块隐藏；客户端模式行为零变化。见 `hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart` 提交 <PENDING>。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/interconnect_pairing_fixes_guard_test.dart` 新增源码切片守卫「BUG-722：服务端模式隐藏「测试连接」按钮」：断言 `t.sync_test_connection` 全语料仅一处、且其前存在 `if (!lockedByServer) ...<Widget>[` 门控（`guardIdx < buttonIdx`）。这类私有客户端 UI widget 无低成本 widget 测试可落地，沿用同文件既有源码守卫风格。
+- **备注**：号段与另一未合并分支（PR#28 多基字注音重叠）撞号——722 在 develop 上是空号，两分支各自独立取了 722，落地时由 integration owner 改号其一。

--- a/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
@@ -494,20 +494,27 @@ class _HibikiServerConfigWidgetState extends State<_HibikiServerConfigWidget>
               ),
             ],
           ),
-          const SizedBox(height: 12),
-          Align(
-            alignment: Alignment.centerRight,
-            child: _isTesting
-                ? SizedBox(
-                    width: 24,
-                    height: 24,
-                    child: adaptiveIndicator(context: context, strokeWidth: 2),
-                  )
-                : FilledButton.tonal(
-                    onPressed: _testAll,
-                    child: Text(t.sync_test_connection),
-                  ),
-          ),
+          // 「测试连接」只在本机作为客户端（连出到其它 host）时有意义：它探测配置的
+          // 出站地址是否可达。本机作为服务端（serverEnabled → lockedByServer）时是一台
+          // 被动数据源，没有出站连接可测，此时显示测试连接按钮既无意义又误导用户（与
+          // BUG-084「服务端隐藏 sync now / compare」同一设计）。故服务端模式下隐藏。
+          if (!lockedByServer) ...<Widget>[
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: _isTesting
+                  ? SizedBox(
+                      width: 24,
+                      height: 24,
+                      child:
+                          adaptiveIndicator(context: context, strokeWidth: 2),
+                    )
+                  : FilledButton.tonal(
+                      onPressed: _testAll,
+                      child: Text(t.sync_test_connection),
+                    ),
+            ),
+          ],
         ],
       ),
     );

--- a/hibiki/test/sync/interconnect_pairing_fixes_guard_test.dart
+++ b/hibiki/test/sync/interconnect_pairing_fixes_guard_test.dart
@@ -31,6 +31,30 @@ void main() {
     );
   });
 
+  test('BUG-722：服务端模式隐藏「测试连接」按钮（lockedByServer 门控）', () {
+    final String source = readSyncSettingsSchemaSource();
+    // 「测试连接」按钮多个后端都有（WebDav/FTP/SFTP/互联客户端），只切互联客户端
+    // 配置 widget 的类区块来断言，避免误伤其它后端的同名按钮。
+    final int start = source.indexOf('class _HibikiServerConfigWidgetState');
+    expect(start, greaterThanOrEqualTo(0),
+        reason: '_HibikiServerConfigWidgetState 丢失');
+    final int end = source.indexOf('mixin _PairingV2FlowMixin', start);
+    expect(end, greaterThan(start));
+    final String widgetSrc = source.substring(start, end);
+
+    final int buttonIdx = widgetSrc.indexOf('t.sync_test_connection');
+    expect(buttonIdx, greaterThanOrEqualTo(0), reason: '互联客户端配置区应有「测试连接」按钮');
+    final int guardIdx = widgetSrc.indexOf('if (!lockedByServer) ...<Widget>[');
+    expect(guardIdx, greaterThanOrEqualTo(0),
+        reason: '缺 if (!lockedByServer) 门控——服务端模式会重现测试连接按钮（BUG-722）。');
+    expect(
+      guardIdx < buttonIdx,
+      isTrue,
+      reason: '「测试连接」按钮未被 !lockedByServer 门控——本机作为服务端时不应显示出站测试'
+          '按钮（BUG-722，与 BUG-084 隐藏 sync now/compare 同一设计）。',
+    );
+  });
+
   test('#3：客户端地址行有「重新配对」入口，复用 _attemptManualPair', () {
     final String source = readSyncSettingsSchemaSource();
     expect(


### PR DESCRIPTION
## 问题
用户报告:Hibiki 互联作为**服务端**不应该有「测试连接」按钮。

## 根因
`hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart` 的 `_HibikiServerConfigWidgetState.build` 里,「测试连接」按钮(`_testAll` → 探测出站地址可达性)**无条件渲染**,未被 `lockedByServer` 门控。

互联后端(`SyncBackendType.hibikiServer`)下,客户端配置区(`_HibikiServerConfigWidget`)与服务端开关区(`_ServerModeWidget`)同屏显示,靠 role-locking 互斥。当本机启用服务端(`serverEnabled → lockedByServer`)时,客户端区的地址增改已禁用,但「测试连接」按钮仍显示且可点。本机作为服务端时是一台**被动数据源**,没有出站客户端连接可测——此按钮既无意义又误导(与 BUG-084「服务端隐藏 sync now / compare」同一类)。

## 修复
用 `if (!lockedByServer) ...<Widget>[ ... ]` 门控「测试连接」按钮块(含其上方间距与 `_isTesting` spinner),服务端模式下整块隐藏;**客户端模式行为零变化**。

## 测试
- `hibiki/test/sync/interconnect_pairing_fixes_guard_test.dart` 新增源码切片守卫:切到 `_HibikiServerConfigWidgetState` 类区块,断言「测试连接」按钮被 `if (!lockedByServer)` 门控(避免误伤 WebDav/FTP/SFTP 同名按钮)。
- `flutter test` 相关 4 用例全绿;`flutter analyze` No issues found。

## 备注
- BUG-722 号段与另一未合并分支(PR#28 多基字注音重叠)撞号——722 在 develop 上是空号,两分支各自独立取了 722,落地时由 integration owner 改号其一。
- 待真机验证互联设置页服务端开启后测试连接按钮消失。