### PR TITLE
feat(reader): 悬停查词连续化(按住Shift滑动弹窗跟随) + 快捷键改名

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 38131 (2243 per locale)
 ///
-/// Built on 2026-07-10 at 12:03 UTC
+/// Built on 2026-07-11 at 03:43 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -1574,7 +1574,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get shortcut_action_reader_toggle_furigana => 'Toggle furigana';
   String get shortcut_action_reader_lookup_at_cursor =>
       'Lookup / activate cursor';
-  String get shortcut_action_reader_shift_lookup => 'Shift lookup';
+  String get shortcut_action_reader_shift_lookup => 'Look up word at caret';
   String get shortcut_action_reader_create_card_from_popup =>
       'Create card from popup';
   String get on_screen_keyboard => 'On-screen keyboard';
@@ -36552,7 +36552,7 @@ class _StringsJa extends _StringsEn {
   @override
   String get shortcut_action_reader_lookup_at_cursor => '辞書を引く／カーソルを有効化';
   @override
-  String get shortcut_action_reader_shift_lookup => 'Shift 辞書引き';
+  String get shortcut_action_reader_shift_lookup => 'カーソル位置で辞書引き';
   @override
   String get shortcut_action_reader_create_card_from_popup => 'ポップアップからカード作成';
   @override
@@ -77211,7 +77211,7 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get shortcut_action_reader_lookup_at_cursor => '查词/激活光标';
   @override
-  String get shortcut_action_reader_shift_lookup => 'Shift 查词';
+  String get shortcut_action_reader_shift_lookup => '光标处查词';
   @override
   String get shortcut_action_reader_create_card_from_popup => '从弹窗制卡';
   @override
@@ -81970,7 +81970,7 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get shortcut_action_reader_lookup_at_cursor => '查詞／啟用游標';
   @override
-  String get shortcut_action_reader_shift_lookup => 'Shift 查詞';
+  String get shortcut_action_reader_shift_lookup => '游標處查詞';
   @override
   String get shortcut_action_reader_create_card_from_popup => '由彈窗製卡';
   @override
@@ -86757,7 +86757,7 @@ extension on _StringsEn {
       case 'shortcut_action_reader_lookup_at_cursor':
         return 'Lookup / activate cursor';
       case 'shortcut_action_reader_shift_lookup':
-        return 'Shift lookup';
+        return 'Look up word at caret';
       case 'shortcut_action_reader_create_card_from_popup':
         return 'Create card from popup';
       case 'on_screen_keyboard':
@@ -118932,7 +118932,7 @@ extension on _StringsJa {
       case 'shortcut_action_reader_lookup_at_cursor':
         return '辞書を引く／カーソルを有効化';
       case 'shortcut_action_reader_shift_lookup':
-        return 'Shift 辞書引き';
+        return 'カーソル位置で辞書引き';
       case 'shortcut_action_reader_create_card_from_popup':
         return 'ポップアップからカード作成';
       case 'on_screen_keyboard':
@@ -155628,7 +155628,7 @@ extension on _StringsZhCn {
       case 'shortcut_action_reader_lookup_at_cursor':
         return '查词/激活光标';
       case 'shortcut_action_reader_shift_lookup':
-        return 'Shift 查词';
+        return '光标处查词';
       case 'shortcut_action_reader_create_card_from_popup':
         return '从弹窗制卡';
       case 'on_screen_keyboard':
@@ -160181,7 +160181,7 @@ extension on _StringsZhHk {
       case 'shortcut_action_reader_lookup_at_cursor':
         return '查詞／啟用游標';
       case 'shortcut_action_reader_shift_lookup':
-        return 'Shift 查詞';
+        return '游標處查詞';
       case 'shortcut_action_reader_create_card_from_popup':
         return '由彈窗製卡';
       case 'on_screen_keyboard':

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1165,7 +1165,7 @@
   "move_down": "Move down",
   "shortcut_action_reader_toggle_furigana": "Toggle furigana",
   "shortcut_action_reader_lookup_at_cursor": "Lookup / activate cursor",
-  "shortcut_action_reader_shift_lookup": "Shift lookup",
+  "shortcut_action_reader_shift_lookup": "Look up word at caret",
   "shortcut_action_reader_create_card_from_popup": "Create card from popup",
   "on_screen_keyboard": "On-screen keyboard",
   "app_ui_scale": "UI size",

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1165,7 +1165,7 @@
   "move_down": "下に移動",
   "shortcut_action_reader_toggle_furigana": "ふりがなの切替",
   "shortcut_action_reader_lookup_at_cursor": "辞書を引く／カーソルを有効化",
-  "shortcut_action_reader_shift_lookup": "Shift 辞書引き",
+  "shortcut_action_reader_shift_lookup": "カーソル位置で辞書引き",
   "shortcut_action_reader_create_card_from_popup": "ポップアップからカード作成",
   "on_screen_keyboard": "オンスクリーンキーボード",
   "app_ui_scale": "UIサイズ",

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1165,7 +1165,7 @@
   "move_down": "下移",
   "shortcut_action_reader_toggle_furigana": "切换振假名",
   "shortcut_action_reader_lookup_at_cursor": "查词/激活光标",
-  "shortcut_action_reader_shift_lookup": "Shift 查词",
+  "shortcut_action_reader_shift_lookup": "光标处查词",
   "shortcut_action_reader_create_card_from_popup": "从弹窗制卡",
   "on_screen_keyboard": "屏幕键盘",
   "app_ui_scale": "界面大小",

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1165,7 +1165,7 @@
   "move_down": "下移",
   "shortcut_action_reader_toggle_furigana": "切換振假名",
   "shortcut_action_reader_lookup_at_cursor": "查詞／啟用游標",
-  "shortcut_action_reader_shift_lookup": "Shift 查詞",
+  "shortcut_action_reader_shift_lookup": "游標處查詞",
   "shortcut_action_reader_create_card_from_popup": "由彈窗製卡",
   "on_screen_keyboard": "螢幕鍵盤",
   "app_ui_scale": "介面大小",

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -1564,10 +1564,12 @@ extension _ReaderWebView on _ReaderHibikiPageState {
           handlerName: 'onShiftHover',
           callback: (args) {
             if (args.length < 2) return;
-            // TODO-851「限一级弹窗」：已有可见弹窗时悬停不再查词，保证 hover 最多
-            // 叠一层（不在已有弹窗之上再起查词）。两个 hover 入口都要门控
-            // （另一处见 reader_hibiki_page.dart onDismissBarrierHover）。
-            if (isDictionaryShown) return;
+            // 连续查词（和鼠标一样）：**不再**门控 isDictionaryShown（旧 TODO-851
+            // 放开）。弹窗未出时这里出首弹；某些平台弹窗出现后 WebView DOM 仍收
+            // mousemove（barrier 不拦原生视图指针），此时也照常换词——与
+            // onDismissBarrierHover 入口一致，防平台事件路由差异漏网。换词经
+            // prunePopupStack(0) 复用热槽无缝替换，同词由 JS selectText 的 fromHover
+            // 同词短路去重，二者协同不叠层不闪。
             final double x = _ReaderHibikiPageState._toDouble(args[0]) ?? 0;
             final double y = _ReaderHibikiPageState._toDouble(args[1]) ?? 0;
             // TODO-851：悬停路径传 fromHover:true，命中空白不触发 onTapEmpty。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -2860,10 +2860,13 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
       _barrierHoverLastDy = -1;
       return;
     }
-    // TODO-851「限一级弹窗」：已有可见弹窗时遮罩上的悬停不再查词，保证 hover 最多
-    // 叠一层。这是第二个 hover 入口（另一处在 webview.part.dart onShiftHover），
-    // 两处必须都门控，否则遮罩 hover 路径漏网。
-    if (isDictionaryShown) return;
+    // 连续查词（和鼠标一样）：弹窗出现后，全屏 dismiss barrier 盖在 WebView 之上，
+    // WebView DOM 的 onShiftHover 收不到事件——此时唯一还能接 hover 的入口就是这里。
+    // 故此处**不再**门控 isDictionaryShown（旧 TODO-851「限一级弹窗」放开）：按住
+    // Shift 一路滑，命中新词就 _selectTextAt 换词。换词经 _runLookupAndHighlight →
+    // prunePopupStack(0) 复用热槽无缝替换（不叠层、不白屏，BUG-092/482 已验证），
+    // 命中同一个词由 JS selectText 的 fromHover 同词短路挡住（不重复 fire、不闪、不刷
+    // FFI）。下面的 8px 平方阈值仍在，避免每像素抖动都查。
     // TODO-806 真坐标系修复：[event.localPosition] 是相对**dismiss barrier**
     // （Positioned.fill 铺满页面 Stack）的逻辑像素，而 WebView 被 chrome inset
     // （顶栏 [_readerTopOffset] / 底栏预留）挤在 Stack 内部、原点 ≠ barrier 原点。

--- a/hibiki/lib/src/reader/reader_selection_scripts.dart
+++ b/hibiki/lib/src/reader/reader_selection_scripts.dart
@@ -993,6 +993,13 @@ window.hoshiSelection = {
       return null;
     }
     if (this.selection && hit.node === this.selection.startNode && hit.offset === this.selection.startOffset) {
+      // 悬停连续查词（fromHover）命中的还是同一个词：什么都不做，保留当前选区
+      // 高亮与弹窗——这是「按住 Shift 一路滑，弹窗跟着光标走」的去重基石。滑过一
+      // 个词只查一次，同词内继续移动不重复 fire onTextSelected，不闪、不刷 FFI /
+      // 查词历史。真点击（fromHover falsy）保持旧的 toggle 语义：再点同词 = 取消。
+      if (fromHover) {
+        return null;
+      }
       this.clearSelection();
       return null;
     }

--- a/hibiki/test/reader/reader_hover_lookup_guard_test.dart
+++ b/hibiki/test/reader/reader_hover_lookup_guard_test.dart
@@ -1,26 +1,35 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import '../pages/reader_hibiki_page_source_corpus.dart';
 
-/// TODO-851 守卫：悬停查词（hover）路径的两件事必须长在源码里，防退化。
+/// 悬停查词（hover）路径的连续化守卫（「按住 Shift 一路滑，弹窗跟着光标走」）。
 ///
-/// 1. 两个 hover 入口（`onShiftHover` / `onDismissBarrierHover`）调 `_selectTextAt`
-///    时必须带 `fromHover: true`——这样 JS `selectText` 命中空白时不再 fire
-///    `onTapEmpty`，避免悬停扫过正文空白反复 toggle 操作栏导致闪烁。
-/// 2. 两个 hover 入口都必须有 `if (isDictionaryShown) return;` 门控（限一级弹窗）：
-///    已有可见弹窗时悬停不再叠新查词。只加一个入口会让另一路径漏网。
+/// 历史：TODO-851 曾给两个 hover 入口（`onShiftHover` / `onDismissBarrierHover`）
+/// 都加 `if (isDictionaryShown) return;`「限一级弹窗」——弹窗一出就不再查新词，用户
+/// 必须先关弹窗才能查下一个，无法像鼠标词典那样连续。现改为连续查词，本守卫锁住三条
+/// 不变量，防退化：
 ///
-/// 真点击路径（`onTap` 的 `_selectTextAt`）刻意**不**带 fromHover（默认 false），
-/// 保留「点空白隐藏操作栏」旧行为；本守卫不强制它，只守 hover 两入口。
+/// 1. 两个 hover 入口调 `_selectTextAt` 仍必须带 `fromHover: true`——JS `selectText`
+///    命中空白时不 fire `onTapEmpty`，避免悬停扫过正文空白反复 toggle 操作栏闪烁。
+/// 2. 两个 hover 入口都**不再**有 `if (isDictionaryShown) return;` 门控：弹窗出现后
+///    继续按住 Shift 滑动能换词（连续查词）。换词经 `_runLookupAndHighlight →
+///    prunePopupStack(0)` 复用热槽无缝替换，不叠层不白屏（BUG-092/482）。
+/// 3. JS `selectText` 的「同词短路」在 `fromHover` 下必须**先于** `clearSelection()`
+///    直接 `return null`：连续 hover 命中同一个词时保留当前选区高亮与弹窗，不重复
+///    fire `onTextSelected`（去重、不闪、不刷 FFI / 查词历史）；真点击仍保持 toggle。
 ///
-/// 为什么用源码扫描而非 widget 行为测试：reader 页含真实 `InAppWebView` 平台视图，
-/// 无法在 widget 测试里挂载真控制器触发 onShiftHover / onDismissBarrierHover 的 JS
-/// 回调（照 reader_lookup_eval_guard_test.dart / BUG-005 成例）。
+/// 真点击路径（`onTap` 的 `_selectTextAt`）刻意**不**带 fromHover（默认 false），保留
+/// 「点空白隐藏操作栏」旧行为；本守卫不强制它，只守 hover 两入口 + JS 同词短路。
+///
+/// 为什么用源码扫描而非 widget 行为测试：reader 页含真实 `InAppWebView` 平台视图，无法
+/// 在 widget 测试里挂载真控制器触发 onShiftHover / onDismissBarrierHover 的 JS 回调
+/// （照 reader_lookup_eval_guard_test.dart / BUG-005 成例）。
 void main() {
   final String src = readReaderPageSource();
 
-  group('TODO-851 hover lookup guards', () {
+  group('hover lookup continuous guards', () {
     test('onShiftHover passes fromHover:true to _selectTextAt', () {
-      // onShiftHover handler 块内出现带 fromHover:true 的 _selectTextAt 调用。
       final RegExp re = RegExp(
         r"handlerName:\s*'onShiftHover'[\s\S]*?"
         r'_selectTextAt\([^;]*fromHover:\s*true[^;]*\);',
@@ -28,20 +37,7 @@ void main() {
       expect(
         re.hasMatch(src),
         isTrue,
-        reason: 'onShiftHover 必须以 fromHover:true 调 _selectTextAt（TODO-851）。',
-      );
-    });
-
-    test('onShiftHover gates lookup behind isDictionaryShown (one-layer)', () {
-      final RegExp re = RegExp(
-        r"handlerName:\s*'onShiftHover'[\s\S]*?"
-        r'if\s*\(\s*isDictionaryShown\s*\)\s*return;[\s\S]*?'
-        r'_selectTextAt\(',
-      );
-      expect(
-        re.hasMatch(src),
-        isTrue,
-        reason: 'onShiftHover 必须有 if (isDictionaryShown) return; 限一级弹窗门控。',
+        reason: 'onShiftHover 必须以 fromHover:true 调 _selectTextAt。',
       );
     });
 
@@ -53,22 +49,62 @@ void main() {
       expect(
         re.hasMatch(src),
         isTrue,
-        reason:
-            'onDismissBarrierHover 必须以 fromHover:true 调 _selectTextAt（TODO-851）。',
+        reason: 'onDismissBarrierHover 必须以 fromHover:true 调 _selectTextAt。',
       );
     });
 
-    test('onDismissBarrierHover gates lookup behind isDictionaryShown', () {
-      final RegExp re = RegExp(
+    test('onShiftHover no longer gates lookup behind isDictionaryShown', () {
+      // 截取 onShiftHover callback「进入 → 首个 _selectTextAt」这一段，断言其中不再
+      // 出现 isDictionaryShown 门控（连续查词：弹窗已出仍换词）。
+      final Match? m = RegExp(
+        r"handlerName:\s*'onShiftHover'[\s\S]*?_selectTextAt\(",
+      ).firstMatch(src);
+      expect(m, isNotNull, reason: 'onShiftHover handler 结构变了，守卫需同步更新。');
+      // 检测门控**语句** `if (isDictionaryShown) return;`，而非这个词——注释里会提到
+      // 「不再门控 isDictionaryShown」，用 contains(词) 会误命中散文。
+      expect(
+        RegExp(r'if\s*\(\s*isDictionaryShown\s*\)\s*return')
+            .hasMatch(m!.group(0)!),
+        isFalse,
+        reason: 'onShiftHover 不应再有 if (isDictionaryShown) return 门控（连续查词已放开）。',
+      );
+    });
+
+    test(
+        'onDismissBarrierHover no longer gates lookup behind isDictionaryShown',
+        () {
+      final Match? m = RegExp(
         r'void onDismissBarrierHover\(PointerHoverEvent event\)[\s\S]*?'
-        r'if\s*\(\s*isDictionaryShown\s*\)\s*return;[\s\S]*?'
         r'_selectTextAt\(',
+      ).firstMatch(src);
+      expect(m, isNotNull, reason: 'onDismissBarrierHover 结构变了，守卫需同步更新。');
+      expect(
+        RegExp(r'if\s*\(\s*isDictionaryShown\s*\)\s*return')
+            .hasMatch(m!.group(0)!),
+        isFalse,
+        reason:
+            'onDismissBarrierHover 不应再有 if (isDictionaryShown) return 门控（连续查词已放开）。',
+      );
+    });
+
+    test(
+        'JS selectText same-word short-circuit keeps selection under fromHover',
+        () {
+      final String js = File(
+        'lib/src/reader/reader_selection_scripts.dart',
+      ).readAsStringSync().replaceAll('\r\n', '\n');
+      // 同词分支：命中的还是当前选区起点 → fromHover 时必须先 return null，且这个
+      // return 出现在 clearSelection() 之前（保留高亮）。
+      final RegExp re = RegExp(
+        r'hit\.offset === this\.selection\.startOffset\)\s*\{'
+        r'[\s\S]*?if\s*\(\s*fromHover\s*\)\s*\{\s*return null;\s*\}'
+        r'[\s\S]*?this\.clearSelection\(\);',
       );
       expect(
-        re.hasMatch(src),
+        re.hasMatch(js),
         isTrue,
-        reason:
-            'onDismissBarrierHover 必须有 if (isDictionaryShown) return; 限一级弹窗门控。',
+        reason: 'selectText 同词分支必须在 fromHover 下先 return null（保留选区），'
+            '再对真点击走 clearSelection——否则连续 hover 会把当前词高亮抹掉/闪。',
       );
     });
   });


### PR DESCRIPTION
## 背景
用户反馈:「shift查词是什么意思, 这个名字和快捷键不对吧。让shift查词可以连续查词, 和鼠标一样」。

阅读器里有两个被混叫「Shift/查词」的东西:
- **① 快捷键「Shift 查词」**(设置里 `shortcut_action_reader_shift_lookup`): 显示名叫「Shift」但实际绑 `Shift+Enter`, 作用于键盘/手柄焦点光标 —— 名字误导。
- **② 鼠标「按住 Shift 悬停」查词**(`onShiftHover`): 桌面端按住 Shift 移动鼠标查词, 但被 `if (isDictionaryShown) return;`(TODO-851 限一级弹窗)卡住 —— 弹窗一出就不能连续查下一个词。

## 改动
### ② 连续化(核心)
- 放开两个 hover 入口(`onShiftHover` @ webview.part.dart / `onDismissBarrierHover` @ reader_hibiki_page.dart)的 `isDictionaryShown` 门控。弹窗出现后继续按住 Shift 滑动 → 弹窗跟着光标从一个词飘到下一个词。
- 换词经 `_runLookupAndHighlight → prunePopupStack(0)` **复用热槽无缝替换**(不叠层不白屏, BUG-092/482 已验证同路径)。
- 同词去重: JS `selectText` 的 fromHover 同词短路 —— 命中同一词时先 `return null` **保留选区高亮/弹窗**, 不重复 fire `onTextSelected`(不闪、不刷 FFI/查词历史); 真点击保持 toggle 语义。8px 平方阈值节流仍在。

### ① 快捷键改名(顺手)
- 显示名去掉误导的「Shift」→「光标处查词」/「Look up word at caret」(不含具体键, 跟随改键)。
- **只改 i18n 显示值**(en/zh-CN/zh-HK/ja) + 重生成 `strings.g.dart`; **不碰枚举 id** `reader_shift_lookup`(持久化 key, 改它会毁用户已保存改键)。

## 验证
- `flutter analyze`: **No issues found**。
- 守卫 `reader_hover_lookup_guard_test.dart` 重写为连续化不变量(两入口保留 fromHover:true / 不再有 isDictionaryShown 门控 / JS 同词短路 fromHover 保留选区), 5 项全过。
- i18n 完整性 + shortcuts 全套测试通过。

## ⚠️ 待真机
「按住 Shift 真鼠标滑动、弹窗连续跟随」的体验需在 **Windows 桌面真机**复测(bg 环境无法驱动真实鼠标 hover 坐标)。逻辑改动 + 静态守卫已验证, 真机确认无闪烁/无叠层后再合 develop。