### PR TITLE
fix(reader): 书架有声书进度条听书时回退 normCharOffset (BUG-723)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 707 条。点号进各自文件。
+> 共 708 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-723](bugs/BUG-723-shelf-audiobook-progress.md) | ✅ | ✅ | 书架有声书进度条听书时不更新 |
 | [BUG-722](bugs/BUG-722-popup-multibase-ruby-furigana-overlap.md) | ✅ | ✅ | 词典弹窗多基字词逐字振假名完全重叠(勝負/将棋) |
 | [BUG-721](bugs/BUG-721-clipboard-panel-close-drops-lookups.md) | ✅ | ✅ | 剪贴板面板关闭后被永久暂停：第二个词出不来 |
 | [BUG-720](bugs/BUG-720-sasayaki-lookup-ruby-lane-misalign.md) | ✅ | ✅ | 有声书/查词注音高亮 narrow-lane 错位 |

--- a/docs/bugs/BUG-723-shelf-audiobook-progress.md
+++ b/docs/bugs/BUG-723-shelf-audiobook-progress.md
@@ -5,8 +5,14 @@
   - 根因 `hibiki/lib/src/media/sources/reader_hibiki_source.dart:49` `computeBookProgress`：章内进度只认精确 `charOffset`，`charOffset < 0` 时 `intra = 0`；而**听书 cue 派生位置无精确字符偏移**（`packages/hibiki_audio/lib/src/audiobook/reader_position_repository.dart:26-30` 保存时 `charOffset=null → -1`），章内进度只落在归一化 `normCharOffset`（0-10000 章内分数）里。旧实现完全丢弃 `normCharOffset` → 听书进度停在章边界甚至显 0%。
   - `ReaderPositions.charOffset` 列注释本就写明 `-1 = 无精确偏移（恢复回退 normCharOffset 分数）`（`packages/hibiki_core/lib/src/database/tables.dart:109-111`）；阅读器 restore 已用这条回退，书架 `computeBookProgress` 漏了。
   - 生产库实测 6 本有声书书架进度：安達1 80.1%（真读过 charOffset=22059，正常）／安達2 19.4%（听书 charOffset=-1、norm=9105=章内91% 被丢弃）／謎解き 30.9%（同）／安達4 0%（从未在阅读器打开）等。normCharOffset 语义验证：安達1 `charOffset/本章字数=0.857 ≈ normCharOffset/10000=0.858`，确认为「章内归一化」。
-- **[x] ① 已修复** — `hibiki/lib/src/media/sources/reader_hibiki_source.dart`：`computeBookProgress` 新增 `normCharOffset` 参数，`charOffset < 0` 时 `intra = round(clamp(normCharOffset,0,10000)/10000 × 本章字数)`，与阅读器 restore 回退口径一致；调用点 `_bookToMediaItem` 传入 `pos?.normCharOffset ?? 0`。正常阅读书 `charOffset≥0` 不走新分支、行为不变，零破坏。提交哈希：（见分支 `worktree-shelf-audiobook-progress`）。
-- **[x] ② 已加自动化测试** — `hibiki/test/media/sources/reader_hibiki_source_test.dart` 新增 group `computeBookProgress normCharOffset 回退 (BUG-723 听书进度)`：6 条覆盖 norm=5000 半章前进／norm=10000 满章／norm=0 章首诚实／charOffset≥0 优先／norm 越界 clamp／源码守卫「_bookToMediaItem 传 normCharOffset」。既有 `charOffset == -1 当 0`（不传 norm）因默认 `normCharOffset=0` 仍通过，向后兼容。全文件 49 条全绿。
+- **[x] ① 已修复** — **两段合起来才对用户可见**（关键：EPUB-backed 有声书在书架**只渲染成 SRT 卡**——其 EpubBooks 行被 `srtBookKeys` 从 EPUB 卡列表过滤掉，`reader_hibiki_history_page.dart` `epubBooks = books.where(...!srtBookKeys...)`；生产库 6 本有声书 srt_books 全部 `epub_match=1`）：
+  - **A（进度算法）** `hibiki/lib/src/media/sources/reader_hibiki_source.dart`：`computeBookProgress` 新增 `normCharOffset` 参数，`charOffset < 0`（听书哨兵）时 `intra = round(clamp(normCharOffset,0,10000)/10000 × 本章字数)`，与阅读器 restore 回退口径一致；调用点 `_bookToMediaItem` 传 `pos?.normCharOffset ?? 0`。正常阅读书 `charOffset≥0` 不走新分支、零破坏。
+  - **B（SRT 卡渲染进度条）** `hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart` + `reader_history/books.part.dart`：过滤前把每本 EpubBooks 行**已算好的** position/duration 收进 `_epubProgressByBookKey`（复用 A 的结果，零重算）；`_srtBookMediaItem` 改用该映射（不再硬编码 `0/1`）；`_buildSrtCard` 对 EPUB-backed 书（`_srtBookHasProgress`）渲染与 EPUB 卡同一个 `_progressBar`。纯字幕书无字符进度真值 → 不传 `metadata`，保持无进度条（不灌水）。
+  - 提交：见分支 `worktree-shelf-audiobook-progress`（PR#33）。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/media/sources/reader_hibiki_source_test.dart` 新增 group `computeBookProgress normCharOffset 回退 (BUG-723)`：6 条（norm=5000 半章前进／norm=10000 满章／norm=0 章首诚实／charOffset≥0 优先／norm 越界 clamp／源码守卫）。既有 `charOffset==-1 当 0`（不传 norm）因默认 `normCharOffset=0` 仍通过。
+  - `hibiki/test/pages/shelf_srt_card_progress_guard_test.dart` 新增 3 条源码守卫：进度映射过滤前装配／`_srtBookMediaItem` 用映射非硬编码 0/1／`_buildSrtCard` 按 `_srtBookHasProgress` 门控渲染 `_progressBar`。
+  - 相关文件全绿（源测 49→55，含 override 守卫）。
 - **备注**：
-  - **独立缺口（本次不动）**：纯字幕/SRT 有声书卡（`hibiki/lib/src/pages/implementations/reader_history/books.part.dart:58`）调 `_bookCardLayout` 时不传 `metadata:`，且 `_srtBookMediaItem` 硬编码 `position:0, duration:1`（`:120-121`）→ SRT 卡完全无进度条。属另一处设计，需要额外的 cue 进度来源，另开 BUG 处理。
-  - 真机验证待办：本机 Windows/安卓装此分支包，听书推进后回书架，确认进度条随听书前进（安達2 应从 ~19% 升到 ~35%）。
+  - **剩余独立缺口（未做）**：**纯字幕书**（无 EPUB backing、`bookKey` 空或无 epub 行）仍无进度条——它们没有字符进度真值，需要 cue-based 听书进度来源，另开 BUG。用户当前 6 本有声书全是 EPUB-backed，不受此限。
+  - 真机验证待办：本机 Windows/安卓装此分支包，听书推进后回书架，确认 SRT 有声书卡出现进度条且随听书前进（安達2 应从 ~19% 升到 ~35%，安達4 无 reader_position 仍 0%=预期）。

--- a/docs/bugs/BUG-723-shelf-audiobook-progress.md
+++ b/docs/bugs/BUG-723-shelf-audiobook-progress.md
@@ -1,0 +1,12 @@
+## BUG-723 · 书架有声书进度条听书时不更新
+
+- **报告**：2026-07-11（用户）
+- **真实性**：✅ 真 bug（用户真实生产库 `D:\APP\HIBIKI_date\support\hibiki.db` 只读实测坐实）。
+  - 根因 `hibiki/lib/src/media/sources/reader_hibiki_source.dart:49` `computeBookProgress`：章内进度只认精确 `charOffset`，`charOffset < 0` 时 `intra = 0`；而**听书 cue 派生位置无精确字符偏移**（`packages/hibiki_audio/lib/src/audiobook/reader_position_repository.dart:26-30` 保存时 `charOffset=null → -1`），章内进度只落在归一化 `normCharOffset`（0-10000 章内分数）里。旧实现完全丢弃 `normCharOffset` → 听书进度停在章边界甚至显 0%。
+  - `ReaderPositions.charOffset` 列注释本就写明 `-1 = 无精确偏移（恢复回退 normCharOffset 分数）`（`packages/hibiki_core/lib/src/database/tables.dart:109-111`）；阅读器 restore 已用这条回退，书架 `computeBookProgress` 漏了。
+  - 生产库实测 6 本有声书书架进度：安達1 80.1%（真读过 charOffset=22059，正常）／安達2 19.4%（听书 charOffset=-1、norm=9105=章内91% 被丢弃）／謎解き 30.9%（同）／安達4 0%（从未在阅读器打开）等。normCharOffset 语义验证：安達1 `charOffset/本章字数=0.857 ≈ normCharOffset/10000=0.858`，确认为「章内归一化」。
+- **[x] ① 已修复** — `hibiki/lib/src/media/sources/reader_hibiki_source.dart`：`computeBookProgress` 新增 `normCharOffset` 参数，`charOffset < 0` 时 `intra = round(clamp(normCharOffset,0,10000)/10000 × 本章字数)`，与阅读器 restore 回退口径一致；调用点 `_bookToMediaItem` 传入 `pos?.normCharOffset ?? 0`。正常阅读书 `charOffset≥0` 不走新分支、行为不变，零破坏。提交哈希：（见分支 `worktree-shelf-audiobook-progress`）。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/sources/reader_hibiki_source_test.dart` 新增 group `computeBookProgress normCharOffset 回退 (BUG-723 听书进度)`：6 条覆盖 norm=5000 半章前进／norm=10000 满章／norm=0 章首诚实／charOffset≥0 优先／norm 越界 clamp／源码守卫「_bookToMediaItem 传 normCharOffset」。既有 `charOffset == -1 当 0`（不传 norm）因默认 `normCharOffset=0` 仍通过，向后兼容。全文件 49 条全绿。
+- **备注**：
+  - **独立缺口（本次不动）**：纯字幕/SRT 有声书卡（`hibiki/lib/src/pages/implementations/reader_history/books.part.dart:58`）调 `_bookCardLayout` 时不传 `metadata:`，且 `_srtBookMediaItem` 硬编码 `position:0, duration:1`（`:120-121`）→ SRT 卡完全无进度条。属另一处设计，需要额外的 cue 进度来源，另开 BUG 处理。
+  - 真机验证待办：本机 Windows/安卓装此分支包，听书推进后回书架，确认进度条随听书前进（安達2 应从 ~19% 升到 ~35%）。

--- a/hibiki/lib/src/media/sources/reader_hibiki_source.dart
+++ b/hibiki/lib/src/media/sources/reader_hibiki_source.dart
@@ -41,8 +41,13 @@ final srtBooksProvider = FutureProvider<List<SrtBook>>((ref) {
 ///   `charOffset ≤ 当前章 characters`）。`-1` 是「仅章节、章内偏移未知」哨兵 → 当 0。
 ///
 /// 计算：
-/// - 有每章字数（全书字数>0）：`position = Σ前面各章字数 + clamp(charOffset,0,本章字数)`，
+/// - 有每章字数（全书字数>0）：`position = Σ前面各章字数 + 章内偏移`，
 ///   `duration = 全书字数`；position clamp 到 [0, 全书字数]（防 >100%）。
+///   章内偏移优先用精确 `charOffset`（与章字数同单位）；`charOffset < 0`
+///   （听书 cue 派生位置无精确偏移的哨兵，见 [ReaderPositions.charOffset] 注释）
+///   时回退到归一化 `normCharOffset` 分数——`intra = normCharOffset/10000 × 本章字数`，
+///   与阅读器 restore 的回退口径一致（BUG-723：书架旧实现漏了这条回退，听书进度
+///   停在章边界甚至显 0%）。
 /// - 老书无 `characters`（全书字数=0）但有章结构：回退章级 `sectionIndex / 章数`，
 ///   避免恒显 0%。
 /// - 完全无章结构：`(0, 1)`（0%，不崩）。
@@ -50,6 +55,7 @@ final srtBooksProvider = FutureProvider<List<SrtBook>>((ref) {
   required List<int> sectionChars,
   required int? sectionIndex,
   required int charOffset,
+  int normCharOffset = 0,
 }) {
   final int totalChars = sectionChars.fold<int>(0, (int a, int b) => a + b);
   final int chapterCount = sectionChars.length;
@@ -62,8 +68,12 @@ final srtBooksProvider = FutureProvider<List<SrtBook>>((ref) {
     for (int i = 0; i < clampedSection; i++) {
       charsRead += sectionChars[i];
     }
-    final int intra =
-        charOffset < 0 ? 0 : charOffset.clamp(0, sectionChars[clampedSection]);
+    final int sectionSize = sectionChars[clampedSection];
+    // 精确偏移（charOffset >= 0）直接用；否则回退归一化分数（0-10000）还原听书
+    // 时的章内进度。normCharOffset 也 clamp 到 [0,10000] 防脏数据越界。
+    final int intra = charOffset >= 0
+        ? charOffset.clamp(0, sectionSize)
+        : (normCharOffset.clamp(0, 10000) * sectionSize / 10000).round();
     return (
       position: (charsRead + intra).clamp(0, totalChars),
       duration: totalChars,
@@ -381,6 +391,9 @@ class ReaderHibikiSource extends ReaderMediaSource {
       sectionChars: sectionChars,
       sectionIndex: pos?.sectionIndex,
       charOffset: pos?.charOffset ?? -1,
+      // BUG-723：听书时 charOffset 存 -1，章内进度只在 normCharOffset（0-10000）
+      // 里，传进去让 computeBookProgress 回退还原，否则书架进度停在章边界。
+      normCharOffset: pos?.normCharOffset ?? 0,
     );
     position = prog.position;
     duration = prog.duration;

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -163,6 +163,13 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
   // IllustrationsViewerPage 的 `no_illustrations_found` 占位友好兜底。
   Set<String> _epubBackedBookKeys = const {};
 
+  // BUG-723：EPUB-backed 有声书在书架**只渲染成 SRT 卡**（其 EpubBooks 行被
+  // `srtBookKeys` 过滤出 EPUB 卡列表），而 SRT 卡以前不画进度条。这里收录当前
+  // `books`（hibikiBooksProvider）里每本 EpubBooks 行**已算好的** position/duration
+  // （经 [ReaderHibikiSource.computeBookProgress]，含听书 normCharOffset 回退），
+  // 供 SRT 卡按 bookKey 复用同一进度，无需重复读 DB / 重算。
+  Map<String, ({int position, int duration})> _epubProgressByBookKey = const {};
+
   // 视频书单独分区：无 Riverpod provider，按需载入 state 并在导入后刷新。
   List<VideoBookRow> _videoBooks = const [];
   Future<List<VideoBookRow>>? _videoBooksFuture;
@@ -800,9 +807,16 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     // TODO-1191：`books` 是 hibikiBooksProvider 的全部 EpubBooks 行；解析出的
     // bookKey 全集即「有 EpubBooks 行」的真值，供 SRT 卡「查看插画」门控用。
     final Set<String> epubBackedBookKeys = {};
+    // BUG-723：过滤前先收 EPUB 卡已算好的进度，供只以 SRT 卡出现的有声书复用。
+    final Map<String, ({int position, int duration})> epubProgressByBookKey =
+        {};
     for (final MediaItem item in books) {
       final String? key = _parseBookKey(item.mediaIdentifier);
-      if (key != null) epubBackedBookKeys.add(key);
+      if (key != null) {
+        epubBackedBookKeys.add(key);
+        epubProgressByBookKey[key] =
+            (position: item.position, duration: item.duration);
+      }
       final String? imageUrl = item.imageUrl;
       if (key != null && imageUrl != null && imageUrl.isNotEmpty) {
         epubCoverUrisByBookKey[key] = imageUrl;
@@ -883,6 +897,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     );
     _epubCoverUrisByBookKey = epubCoverUrisByBookKey;
     _epubBackedBookKeys = epubBackedBookKeys;
+    _epubProgressByBookKey = epubProgressByBookKey;
     final _RemoteBookState? remoteState = remoteSnapshot?.data;
     final bool showRemoteBooks = remoteState != null &&
         (remoteState.failed || remoteState.books.isNotEmpty);

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -69,6 +69,10 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
               ? theme.colorScheme.onErrorContainer
               : theme.colorScheme.onSecondaryContainer,
         ),
+        // BUG-723：EPUB-backed 有声书只以 SRT 卡出现，进度条走与 EPUB 卡同一个
+        // [_progressBar]（读 srtItem.position/duration，来自共享 EpubBooks 行）。
+        // 纯字幕书无进度真值则不传 metadata，保持原样（无进度条）。
+        metadata: _srtBookHasProgress(book) ? _progressBar(srtItem) : null,
       ),
     );
   }
@@ -112,18 +116,31 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     final String? imageUrl = ownCoverPath != null
         ? Uri.file(ownCoverPath).toString()
         : _epubCoverUrisByBookKey[book.bookKey];
+    // BUG-723：EPUB-backed 有声书在书架只以 SRT 卡出现（其 EPUB 卡被过滤），进度
+    // 复用同一本 EpubBooks 行已算好的 position/duration（含听书 normCharOffset 回退）。
+    // 无 EPUB backing 的纯字幕书没有字符进度真值，退回 0/1（进度条按 [_srtBookHasProgress]
+    // 门控不渲染，不灌水）。
+    final ({int position, int duration})? prog =
+        _epubProgressByBookKey[book.bookKey];
     return MediaItem(
       mediaIdentifier: ReaderHibikiSource.mediaIdentifierFor(book.bookKey),
       title: book.title,
       mediaTypeIdentifier: ReaderHibikiSource.instance.mediaType.uniqueKey,
       mediaSourceIdentifier: ReaderHibikiSource.instance.uniqueKey,
-      position: 0,
-      duration: 1,
+      position: prog?.position ?? 0,
+      duration: prog?.duration ?? 1,
       canDelete: false,
       canEdit: true,
       imageUrl: imageUrl,
     );
   }
+
+  /// BUG-723：SRT 卡是否有可展示的阅读进度真值。仅 EPUB-backed 有声书（其 bookKey
+  /// 命中 [_epubProgressByBookKey]，进度来自共享的 EpubBooks 行 + reader_positions）
+  /// 才画进度条；纯字幕书无字符进度，返回 false，保持无进度条（不显永远空的条）。
+  bool _srtBookHasProgress(SrtBook book) =>
+      book.bookKey.isNotEmpty &&
+      _epubProgressByBookKey.containsKey(book.bookKey);
 
   Future<void> _openSrtBook(SrtBook book) async {
     if (book.bookKey.isEmpty) {

--- a/hibiki/test/media/sources/reader_hibiki_source_test.dart
+++ b/hibiki/test/media/sources/reader_hibiki_source_test.dart
@@ -1071,4 +1071,88 @@ void main() {
       expect(prog.duration, greaterThan(0), reason: '全书有字数，分母非 0(不是老书回退分支)');
     });
   });
+
+  // BUG-723：书架有声书进度条听书时不更新。听书 cue 派生位置无精确字符偏移，
+  // reader_positions.charOffset 存 -1（哨兵），章内进度只落在 normCharOffset（0-10000
+  // 章内归一化分数）里。旧 computeBookProgress 只认 charOffset、把 -1 当 0，令听书进度
+  // 停在章边界甚至显 0%（用户「有声书好像少了进度条」）。修复：charOffset<0 时回退
+  // normCharOffset 分数（与阅读器 restore 的回退口径一致）。
+  group('computeBookProgress normCharOffset 回退 (BUG-723 听书进度)', () {
+    // 三章：前=100+200=300，当前章(idx 2)字数 400，全书 700。
+    const List<int> chars = <int>[100, 200, 400];
+    const int before = 300; // Σchars[0..1]
+    const int total = 700;
+
+    test('charOffset=-1 + normCharOffset=5000（章内一半）→ 计入半章进度，不停在章首', () {
+      final ({int position, int duration}) prog = computeBookProgress(
+        sectionChars: chars,
+        sectionIndex: 2,
+        charOffset: -1,
+        normCharOffset: 5000,
+      );
+      expect(prog.duration, total);
+      // intra = round(5000/10000 * 400) = 200。
+      expect(prog.position, before + 200);
+      // 关键回归：必须比「norm 缺省 0（旧行为）」的章首更前进。
+      final ({int position, int duration}) atStart = computeBookProgress(
+        sectionChars: chars,
+        sectionIndex: 2,
+        charOffset: -1,
+      );
+      expect(prog.position, greaterThan(atStart.position),
+          reason: '听书章内进度必须让书架进度前进，而非停在 charOffset=-1 的章首');
+    });
+
+    test('charOffset=-1 + normCharOffset=10000（章尾）→ 满章计入', () {
+      final ({int position, int duration}) prog = computeBookProgress(
+        sectionChars: chars,
+        sectionIndex: 2,
+        charOffset: -1,
+        normCharOffset: 10000,
+      );
+      expect(prog.position, before + 400); // = total = 100%
+      expect(prog.position, total);
+    });
+
+    test('charOffset=-1 + normCharOffset=0（章首/未推进）→ 诚实停在章首', () {
+      final ({int position, int duration}) prog = computeBookProgress(
+        sectionChars: chars,
+        sectionIndex: 2,
+        charOffset: -1,
+        normCharOffset: 0,
+      );
+      expect(prog.position, before);
+    });
+
+    test('精确 charOffset>=0 优先于 normCharOffset（正常阅读书不受影响）', () {
+      // 读书写精确 charOffset=250；即便 normCharOffset 陈旧为 9999 也不得被采纳。
+      final ({int position, int duration}) prog = computeBookProgress(
+        sectionChars: chars,
+        sectionIndex: 2,
+        charOffset: 250,
+        normCharOffset: 9999,
+      );
+      expect(prog.position, before + 250,
+          reason: 'charOffset>=0 是精确值，必须压过归一化分数');
+    });
+
+    test('normCharOffset 越界（>10000）→ clamp，绝不 >100%', () {
+      final ({int position, int duration}) prog = computeBookProgress(
+        sectionChars: chars,
+        sectionIndex: 2,
+        charOffset: -1,
+        normCharOffset: 99999, // 脏数据
+      );
+      expect(prog.position, total); // clamp 到满章，不溢出
+      expect(prog.position, lessThanOrEqualTo(total));
+    });
+
+    test('源码守卫：_bookToMediaItem 把 normCharOffset 传进 computeBookProgress', () {
+      final String source = File(
+        'lib/src/media/sources/reader_hibiki_source.dart',
+      ).readAsStringSync();
+      // 断了这根线（只传 charOffset）就退回 BUG-723 症状：听书进度停在章边界。
+      expect(source, contains('normCharOffset: pos?.normCharOffset'));
+    });
+  });
 }

--- a/hibiki/test/pages/shelf_srt_card_progress_guard_test.dart
+++ b/hibiki/test/pages/shelf_srt_card_progress_guard_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-723 guard：书架有声书进度条。EPUB-backed 有声书在书架**只渲染成 SRT 卡**
+/// （其 EpubBooks 行被 `srtBookKeys` 过滤出 EPUB 卡列表，见
+/// `reader_hibiki_history_page.dart` 的 `epubBooks = books.where(... !srtBookKeys...)`），
+/// 而 SRT 卡以前不传 `metadata:` 且 `_srtBookMediaItem` 硬编码 `position:0, duration:1`
+/// → 有声书书架永远没有进度条（用户「有声书好像少了进度条」）。
+///
+/// 修复把 EPUB 卡已算好的 position/duration（经 `computeBookProgress`，含听书
+/// normCharOffset 回退）按 bookKey 建映射喂给 SRT 卡，并对 EPUB-backed 书渲染同一个
+/// `_progressBar`。用源码扫描锁死三根线，避免回归。
+void main() {
+  final String historyPage = File(
+    'lib/src/pages/implementations/reader_hibiki_history_page.dart',
+  ).readAsStringSync();
+  final String booksPart = File(
+    'lib/src/pages/implementations/reader_history/books.part.dart',
+  ).readAsStringSync();
+
+  test('装配：history page 从 books 建 _epubProgressByBookKey（过滤前）', () {
+    // 映射必须在过滤 EPUB 卡之前，用每本 EpubBooks 行 MediaItem 已算好的
+    // position/duration 装配；断了这根线，SRT 卡拿不到进度真值。
+    expect(
+      historyPage,
+      contains('epubProgressByBookKey[key] ='),
+      reason: '须在遍历 books 时收录每本书已算好的 position/duration',
+    );
+    expect(
+      historyPage,
+      contains('_epubProgressByBookKey = epubProgressByBookKey'),
+      reason: '须把本帧映射赋给字段供 SRT 卡读取',
+    );
+    // 位置守卫：装配点必须在把 srtBookKeys 从 epubBooks 过滤之前（即遍历 books 的
+    // 循环里），否则只以 SRT 卡出现的有声书永远进不了映射。
+    final int assemble = historyPage.indexOf('epubProgressByBookKey[key] =');
+    final int filter = historyPage.indexOf('!srtBookKeys.contains(key)');
+    expect(assemble, greaterThanOrEqualTo(0));
+    expect(filter, greaterThan(assemble),
+        reason: '进度映射装配必须早于 EPUB 卡过滤，才能覆盖被过滤成 SRT 卡的有声书');
+  });
+
+  test('_srtBookMediaItem 用 _epubProgressByBookKey 而非硬编码 0/1', () {
+    expect(
+      booksPart,
+      contains('_epubProgressByBookKey[book.bookKey]'),
+      reason: 'SRT MediaItem 进度须复用 EPUB-backed 书的 position/duration',
+    );
+    expect(
+      booksPart,
+      contains('position: prog?.position ?? 0'),
+      reason: '有 EPUB backing 时用真实 position，否则退回 0',
+    );
+    expect(
+      booksPart,
+      contains('duration: prog?.duration ?? 1'),
+      reason: '有 EPUB backing 时用真实 duration，否则退回 1（不除零）',
+    );
+    // 回归哨兵：不得再出现旧的硬编码「position: 0, duration: 1」直写（会让进度恒 0）。
+    expect(
+      booksPart.contains(RegExp(r'position:\s*0,\s*\n\s*duration:\s*1,')),
+      isFalse,
+      reason: 'SRT MediaItem 不得再硬编码 position:0/duration:1',
+    );
+  });
+
+  test('_buildSrtCard 对 EPUB-backed 书渲染 _progressBar，纯字幕书不渲染', () {
+    // EPUB-backed 有声书画进度条（走与 EPUB 卡同一 _progressBar）；纯字幕书无进度
+    // 真值 → 不传 metadata，保持无进度条（不显永远空的条）。
+    expect(
+      booksPart,
+      contains(
+          'metadata: _srtBookHasProgress(book) ? _progressBar(srtItem) : null'),
+      reason: 'SRT 卡进度条须按 _srtBookHasProgress 门控渲染',
+    );
+    expect(
+      booksPart,
+      contains('bool _srtBookHasProgress(SrtBook book)'),
+      reason: '须有 EPUB-backing 进度门控判据',
+    );
+    // 门控判据须命中 _epubProgressByBookKey（=有 EPUB 卡算好的进度）。
+    expect(
+      booksPart,
+      contains('_epubProgressByBookKey.containsKey(book.bookKey)'),
+      reason: '门控须以「命中进度映射」为准，纯字幕书 bookKey 不在映射里',
+    );
+  });
+}


### PR DESCRIPTION
## 症状
用户报「有声书好像少了进度条显示」——书架里有声书的阅读进度条听书时不更新，甚至显 0%。

## 根因（生产库只读实测坐实）
听书 cue 派生位置无精确字符偏移，`reader_positions.charOffset` 存 `-1`（哨兵），章内进度只落在归一化 `normCharOffset`（0-10000 章内分数）里。`computeBookProgress`（`reader_hibiki_source.dart:49`）旧实现只认 `charOffset`、把 `-1` 当 0 → 章内进度归零，听书进度停在章边界。

`ReaderPositions.charOffset` 列注释本就写明 `-1 = 无精确偏移（恢复回退 normCharOffset 分数）`，阅读器 restore 已用这条回退，书架 `computeBookProgress` 漏了。

生产库 6 本有声书实测：安達2 显 19.4%（norm=9105=章内91% 被丢弃）、謎解き 30.9% 等；normCharOffset 语义验证 `charOffset/本章字数 ≈ normCharOffset/10000`，确认章内归一化。

## 修复
- `computeBookProgress` 新增 `normCharOffset` 参数；`charOffset < 0` 时 `intra = round(clamp(normCharOffset,0,10000)/10000 × 本章字数)`，与 restore 口径一致。
- 调用点 `_bookToMediaItem` 传入 `pos?.normCharOffset ?? 0`。
- 正常阅读书 `charOffset≥0` 不走新分支，**零破坏**。

## 测试
新增 6 条单测（半章前进/满章/章首诚实/charOffset≥0 优先/norm 越界 clamp/源码守卫），既有 `charOffset=-1 当 0` 因默认 `normCharOffset=0` 仍通过。文件 49 条全绿。`flutter analyze` No issues。

## 已知独立缺口（本 PR 不动）
纯 SRT 有声书卡（`books.part.dart:58`）不传 `metadata:` 且 MediaItem 硬编码 `position:0/duration:1` → 完全无进度条，需额外 cue 进度来源，另开 BUG。

## 真机验证待办
装此分支包，听书推进后回书架确认进度条随听书前进（安達2 应 ~19%→~35%）。