### PR TITLE
fix(extension): app 升级自动刷新已解压扩展副本 + 指纹自 reload（BUG-724 浏览器弹窗与 app 内不一致）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 706 条。点号进各自文件。
+> 共 707 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-724](bugs/BUG-724-ext-unpacked-copy-never-refreshed.md) | ✅ | ✅ | 浏览器扩展已解压副本永不随app升级刷新导致弹窗停留旧版 |
 | [BUG-721](bugs/BUG-721-clipboard-panel-close-drops-lookups.md) | ✅ | ✅ | 剪贴板面板关闭后被永久暂停：第二个词出不来 |
 | [BUG-720](bugs/BUG-720-sasayaki-lookup-ruby-lane-misalign.md) | ✅ | ✅ | 有声书/查词注音高亮 narrow-lane 错位 |
 | [BUG-718](bugs/BUG-718-vn-restore-charoffset-cloak.md) | ✅ | ✅ | VN模式按字符偏移恢复时FOUC遮罩未移除致整页空白 |

--- a/docs/bugs/BUG-724-ext-unpacked-copy-never-refreshed.md
+++ b/docs/bugs/BUG-724-ext-unpacked-copy-never-refreshed.md
@@ -1,0 +1,43 @@
+## BUG-724 · 浏览器扩展已解压副本永不随app升级刷新导致弹窗停留旧版
+- **报告**：2026-07-11（用户：浏览器的查词弹窗，明显和app内的查词弹窗不一样，需要修复）
+- **真实性**：✅ 真 bug（部署通道缺失，不是样式又坏了）。证据链：
+  - 用户机上运行中的 app 是新的：curl `127.0.0.1:19633 /api/lookup/dictionary`，响应 `theme`
+    已含 `--text-color` / `--hibiki-color-scheme`（= BUG-688 修复在跑）。
+  - 但用户机 `<appSupport>/hibiki-browser-extension/`（`D:/APP/HIBIKI_date/support/`）里的
+    已解压副本：`vendor/popup.js` 75546 字节（正是 BUG-621 描述的「75 KB 旧版」，当前
+    156797）、`vendor/content.css` 16920（当前 54210）、`content.js` 41284（当前 75409）
+    —— 停在 2026-07-08 之前，BUG-621 parity / BUG-688 主题两轮修复全都没到达浏览器。
+  - 根因：`hibiki/lib/src/lookup/browser_extension_installer.dart` 的
+    `prepareBundledBrowserExtension` **只有一个调用点** =
+    `settings_schema_lookup.dart` 的手动「安装扩展」入口；app 升级从不刷新磁盘副本，
+    浏览器加载的未解压扩展就永远停在用户最后一次跑助手那天。弹窗渲染器/样式
+    （popup.js/content.css）随 app 演进越走越远 → 「明显和 app 内不一样」按月复发。
+- **[x] ① 已修复** — 打通「app 升级 → 磁盘副本刷新 → 扩展自 reload」全自动链路（提交 见 PR）：
+  1. 指纹身份：`computeBrowserExtensionFingerprint`（内置扩展全资产 sha256 前 16 hex，排除
+     解压时必被重写的 `hibiki-defaults.js`）；解压时写进 `hibiki-defaults.js` 的 `build` 键。
+  2. 启动刷新：`AppModel.initialise` 桌面端 fire-and-forget 调 `refreshBrowserExtensionCopy`
+     → `refreshBundledBrowserExtensionIfStale`（副本目录存在 && build ≠ 内置指纹才整目录
+     重解压并注入当前 server host/port/token；没装过不落盘）。
+  3. 自 reload：查词响应新增 `extensionBuild` 字段（`hibiki_remote_api_handlers.dart`，经
+     `YomitanApiServer(Manager)` 注入，未注入不带字段=向后兼容）；扩展 `background.js` 在
+     lookup `sendResponse` 之后比对 `HIBIKI_DEFAULTS.build`，不一致且非 Netflix 录制中 →
+     `chrome.runtime.reload()` 从磁盘拉新（storage 记录已 reload 指纹防「磁盘没刷成」死循环；
+     任一侧缺指纹不动，旧 app/占位默认永不空转）。
+  4. 镜像同步：`background.js` / `hibiki-defaults.js` 已同步 `tools/browser-extension/`。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/lookup/browser_extension_installer_test.dart`：指纹确定性/序无关/排除
+    defaults/内容变则指纹变；`build` 键写入+`parseBrowserExtensionBuild` round-trip；
+    解压写指纹的源码接线守卫。
+  - `hibiki/test/lookup/browser_extension_auto_refresh_guard_test.dart`（新）：AppModel 启动
+    挂刷新 + provider 接线；刷新仅针对已安装副本；background.js 自 reload 三重防护
+    （sendResponse 之后 / 防循环 / 录制中跳过）；background.js 双镜像字节一致。
+  - `hibiki/test/sync/yomitan_api_server_extension_endpoints_test.dart`：`extensionBuild`
+    随查词响应透传 + 未注入不带字段（向后兼容）。
+- **备注**：
+  - **用户侧一次性动作**：本修复进用户构建后，app 启动会把磁盘副本刷到最新，但**当前已加载
+    的旧扩展没有自 reload 逻辑**，需在 `edge://extensions` / `chrome://extensions` 点一次
+    「重新加载」（或重启浏览器）。此后 app 每次升级，扩展在下一次查词时自动 reload 拉新，
+    不再需要任何手动步骤。
+  - 扩展 `manifest.json` version 恒 0.1.0 无 bump 纪律，故身份用内容指纹而非语义版本。
+  - 与 BUG-621（vendor 版本漂移，已修 `9b3ee8d`）/BUG-688（主题分裂，已修）区分：那两轮修的
+    是仓库内 parity；本轮修的是仓库→用户浏览器的**部署通道**。

--- a/docs/bugs/BUG-724-ext-unpacked-copy-never-refreshed.md
+++ b/docs/bugs/BUG-724-ext-unpacked-copy-never-refreshed.md
@@ -12,7 +12,7 @@
     `settings_schema_lookup.dart` 的手动「安装扩展」入口；app 升级从不刷新磁盘副本，
     浏览器加载的未解压扩展就永远停在用户最后一次跑助手那天。弹窗渲染器/样式
     （popup.js/content.css）随 app 演进越走越远 → 「明显和 app 内不一样」按月复发。
-- **[x] ① 已修复** — 打通「app 升级 → 磁盘副本刷新 → 扩展自 reload」全自动链路（提交 见 PR）：
+- **[x] ① 已修复** — 打通「app 升级 → 磁盘副本刷新 → 扩展自 reload」全自动链路（提交 `aee00d2b5`）：
   1. 指纹身份：`computeBrowserExtensionFingerprint`（内置扩展全资产 sha256 前 16 hex，排除
      解压时必被重写的 `hibiki-defaults.js`）；解压时写进 `hibiki-defaults.js` 的 `build` 键。
   2. 启动刷新：`AppModel.initialise` 桌面端 fire-and-forget 调 `refreshBrowserExtensionCopy`

--- a/hibiki/assets/browser_extension/background.js
+++ b/hibiki/assets/browser_extension/background.js
@@ -16,6 +16,26 @@ async function cfg() {
 }
 function authHeader(token) { return 'Basic ' + btoa('hibiki:' + token); }
 
+// BUG-724：扩展自更新。app 启动时会把 <appSupport> 的已解压副本刷新到当前内置版本，并把
+// 内容指纹写进 hibiki-defaults.js（build）+ 随查词响应下发（extensionBuild）。这里比对
+// 两者：不一致 = 磁盘上已有新版而当前加载的还是旧版 → chrome.runtime.reload() 从磁盘拉新
+// （等价于扩展管理页的「重新加载」，未解压包路径不变）。防护：
+// - 任一侧缺指纹（旧 app / 占位默认）→ 不动（向后兼容，绝不空转 reload）；
+// - storage 记录已为该指纹 reload 过 → 不再重试（防「磁盘没刷成」时无限循环）；
+// - 正在 Netflix 逐句回放录制 → 跳过（reload 会杀掉 offscreen 录制，等录完下次查词再说）。
+async function maybeSelfReload(data) {
+  try {
+    const remote = data && data.extensionBuild;
+    const local = HIBIKI_DEFAULTS.build;
+    if (!remote || !local || remote === local) return;
+    if (await isOffscreenRecording()) return;
+    const st = await chrome.storage.local.get(['hibikiReloadedForBuild']);
+    if (st.hibikiReloadedForBuild === remote) return;
+    await chrome.storage.local.set({ hibikiReloadedForBuild: remote });
+    chrome.runtime.reload();
+  } catch (_) { /* 自更新失败不影响查词本身 */ }
+}
+
 // TODO-1000 Netflix：offscreen 文档承载 tabCapture MediaRecorder。批量生成时按字幕逐句「回放
 // 录制」——每句 seek 到句首、播到句尾录成一段自包含 webm（beginClip/endClip），随 mineClip 发给
 // Hibiki 转 GIF+句子音频。点扩展图标启动（需 activeTab 手势 + 关硬件加速才非黑），跨集自动切换。
@@ -156,7 +176,10 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
           body: JSON.stringify({ term: msg.term, record: msg.record === true }),
         });
-        sendResponse({ ok: r.ok, status: r.status, data: r.ok ? await r.json() : null });
+        const data = r.ok ? await r.json() : null;
+        sendResponse({ ok: r.ok, status: r.status, data });
+        // BUG-724：先回结果再检查自更新（reload 杀 SW，绝不能挡在 sendResponse 前面）。
+        maybeSelfReload(data);
       } else if (msg.type === 'lookupAudio') {
         // 单词音频：POST /api/lookup/audio {expression,reading}（Basic auth）→ server 用
         // 与 app 同一 lookupAudio（本地音频库）解析出音频字节，回 {url,contentType}，url 是

--- a/hibiki/assets/browser_extension/hibiki-defaults.js
+++ b/hibiki/assets/browser_extension/hibiki-defaults.js
@@ -7,6 +7,10 @@
 //
 // 优先级：chrome.storage.local（用户在 options 手动覆盖） > 本文件内置默认。
 // service worker（background.js）用 importScripts 引入；options 页用 <script> 引入。
+//
+// BUG-724：安装助手/启动刷新还会写入 build（扩展内容指纹）。background.js 用它与查词
+// 响应里的 extensionBuild 比对，不一致即 chrome.runtime.reload() 从磁盘拉新（自更新）。
+// 占位默认不带 build（→ 永不触发 reload）。
 self.HIBIKI_DEFAULTS = {
   host: '127.0.0.1',
   port: 19633,

--- a/hibiki/lib/src/lookup/browser_extension_installer.dart
+++ b/hibiki/lib/src/lookup/browser_extension_installer.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data' show BytesBuilder, Uint8List;
 
+import 'package:crypto/crypto.dart' show sha256;
 import 'package:flutter/services.dart' show AssetManifest, ByteData, rootBundle;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -50,7 +52,15 @@ const String _kDefaultsFileName = 'hibiki-defaults.js';
 
 /// 生成扩展 `hibiki-defaults.js` 的内容：注入当前 server 真值作为默认。
 /// 纯函数，便于测试；host/token 走 JSON 编码避免注入/转义问题。
-String buildBrowserExtensionDefaultsJs(BrowserExtensionServerConfig config) {
+///
+/// BUG-724：[build] 是本次解压的扩展内容指纹（[computeBrowserExtensionFingerprint]）。
+/// server 随查词响应下发同一指纹（`extensionBuild`），扩展 background 对比自身
+/// `HIBIKI_DEFAULTS.build`，不一致即 `chrome.runtime.reload()` 从磁盘拉新——app 升级
+/// 后弹窗自动跟上，无需用户重装/手动 reload。null（占位/旧调用）时不写该键。
+String buildBrowserExtensionDefaultsJs(
+  BrowserExtensionServerConfig config, {
+  String? build,
+}) {
   final String host = jsonEncode(config.host);
   final String token = jsonEncode(config.token);
   final StringBuffer b = StringBuffer();
@@ -60,8 +70,35 @@ String buildBrowserExtensionDefaultsJs(BrowserExtensionServerConfig config) {
   b.writeln('  host: $host,');
   b.writeln('  port: ${config.port},');
   b.writeln('  token: $token,');
+  if (build != null) {
+    b.writeln('  build: ${jsonEncode(build)},');
+  }
   b.writeln('};');
   return b.toString();
+}
+
+/// BUG-724：扩展内容指纹。对「相对路径 → 字节」的全量 map（排除安装时会被重写的
+/// `hibiki-defaults.js`）按路径排序后做 sha256，取前 16 hex。纯函数，便于测试；
+/// 同一份内置扩展在任何机器上指纹恒等，内容变（app 升级带来新扩展）指纹必变。
+String computeBrowserExtensionFingerprint(Map<String, List<int>> assets) {
+  final List<String> keys =
+      assets.keys.where((String k) => k != _kDefaultsFileName).toList()..sort();
+  final BytesBuilder input = BytesBuilder(copy: false);
+  for (final String key in keys) {
+    input.add(utf8.encode(key));
+    input.addByte(0);
+    input.add(assets[key]!);
+    input.addByte(0);
+  }
+  return sha256.convert(input.takeBytes()).toString().substring(0, 16);
+}
+
+/// BUG-724：从已解压副本的 `hibiki-defaults.js` 源码里解析 `build` 指纹。
+/// 旧版副本（无 build 键）返回 null —— 与当前指纹必然不等，触发刷新，正是所求。
+String? parseBrowserExtensionBuild(String defaultsJs) {
+  final RegExpMatch? m =
+      RegExp('build:\\s*"([0-9a-f]+)"').firstMatch(defaultsJs);
+  return m?.group(1);
 }
 
 /// 把随 app 打包的扩展文件解压到 `<appSupport>/hibiki-browser-extension/`，返回该目录
@@ -73,34 +110,84 @@ String buildBrowserExtensionDefaultsJs(BrowserExtensionServerConfig config) {
 Future<String> prepareBundledBrowserExtension({
   BrowserExtensionServerConfig? serverConfig,
 }) async {
-  final Directory support = await getApplicationSupportDirectory();
-  final Directory dest =
-      Directory(p.join(support.path, 'hibiki-browser-extension'));
+  final Directory dest = await _extensionDestDir();
   if (dest.existsSync()) {
     await dest.delete(recursive: true);
   }
   await dest.create(recursive: true);
 
+  final Map<String, Uint8List> assets = await _loadBundledExtensionAssets();
+  for (final MapEntry<String, Uint8List> entry in assets.entries) {
+    final File out =
+        File(p.join(dest.path, p.joinAll(p.posix.split(entry.key))));
+    await out.parent.create(recursive: true);
+    await out.writeAsBytes(entry.value);
+  }
+
+  // TODO-1087：用当前 server 真值覆盖占位默认，实现自动配置。
+  // BUG-724：同时写入内容指纹 build，供「app 升级 → 磁盘副本刷新 → 扩展自 reload」链路。
+  if (serverConfig != null) {
+    final File defaults = File(p.join(dest.path, _kDefaultsFileName));
+    await defaults.writeAsString(buildBrowserExtensionDefaultsJs(
+      serverConfig,
+      build: computeBrowserExtensionFingerprint(assets),
+    ));
+  }
+  return dest.path;
+}
+
+Future<Directory> _extensionDestDir() async {
+  final Directory support = await getApplicationSupportDirectory();
+  return Directory(p.join(support.path, 'hibiki-browser-extension'));
+}
+
+/// 读出随 app 打包的全部扩展资产（相对路径 → 字节）。
+Future<Map<String, Uint8List>> _loadBundledExtensionAssets() async {
   final AssetManifest manifest =
       await AssetManifest.loadFromAssetBundle(rootBundle);
   final Iterable<String> keys =
       manifest.listAssets().where((String k) => k.startsWith(_kBundlePrefix));
+  final Map<String, Uint8List> assets = <String, Uint8List>{};
   for (final String key in keys) {
     final String rel = key.substring(_kBundlePrefix.length);
     if (rel.isEmpty) continue;
     final ByteData data = await rootBundle.load(key);
-    final File out = File(p.join(dest.path, p.joinAll(p.posix.split(rel))));
-    await out.parent.create(recursive: true);
-    await out.writeAsBytes(data.buffer.asUint8List(
+    assets[rel] = data.buffer.asUint8List(
       data.offsetInBytes,
       data.lengthInBytes,
-    ));
+    );
   }
+  return assets;
+}
 
-  // TODO-1087：用当前 server 真值覆盖占位默认，实现自动配置。
-  if (serverConfig != null) {
-    final File defaults = File(p.join(dest.path, _kDefaultsFileName));
-    await defaults.writeAsString(buildBrowserExtensionDefaultsJs(serverConfig));
+/// BUG-724：当前 app 内置扩展的内容指纹（进程内缓存；内置资产运行期不变）。
+Future<String> bundledBrowserExtensionFingerprint() async {
+  return _bundledFingerprintCache ??=
+      computeBrowserExtensionFingerprint(await _loadBundledExtensionAssets());
+}
+
+String? _bundledFingerprintCache;
+
+/// BUG-724：app 启动时把 `<appSupport>/hibiki-browser-extension/` 的已解压副本刷新到
+/// 当前内置版本。此前该副本只在用户手动跑「安装扩展」助手时写入，app 升级从不刷新——
+/// 用户浏览器里的扩展弹窗永远停在安装当天的旧版（BUG-621/688 修了也到不了浏览器）。
+///
+/// - 副本目录不存在（用户从没装过扩展）→ 不落盘、返回 false；
+/// - 副本 `hibiki-defaults.js` 里的 build 指纹与内置一致 → 已最新、返回 false；
+/// - 否则整目录重解压（注入 [serverConfig] 真值 + 新指纹）→ 返回 true。
+Future<bool> refreshBundledBrowserExtensionIfStale({
+  required BrowserExtensionServerConfig serverConfig,
+}) async {
+  final Directory dest = await _extensionDestDir();
+  if (!dest.existsSync()) return false;
+  final File defaults = File(p.join(dest.path, _kDefaultsFileName));
+  final String? installed = defaults.existsSync()
+      ? parseBrowserExtensionBuild(await defaults.readAsString())
+      : null;
+  if (installed != null &&
+      installed == await bundledBrowserExtensionFingerprint()) {
+    return false;
   }
-  return dest.path;
+  await prepareBundledBrowserExtension(serverConfig: serverConfig);
+  return true;
 }

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -36,6 +36,7 @@ import 'package:hibiki/src/models/app_font_loader.dart';
 import 'package:hibiki/src/models/builtin_tags.dart';
 import 'package:hibiki/src/epub/epub_importer.dart';
 import 'package:hibiki/src/reader/reader_settings.dart';
+import 'package:hibiki/src/lookup/browser_extension_installer.dart';
 import 'package:hibiki/src/models/dictionary_repository.dart';
 import 'package:hibiki/src/models/media_history_repository.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
@@ -2010,6 +2011,15 @@ class AppModel with ChangeNotifier {
       if (yomitanApiServerEnabled) {
         unawaited(startYomitanApiServer().catchError((Object _) {}));
       }
+      // BUG-724：桌面端启动时把 <appSupport> 下已解压的浏览器扩展副本刷新到当前内置版本
+      // （只在用户装过扩展、指纹不一致时重解压；没装过不落盘）。此前该副本只在手动跑
+      // 「安装扩展」助手时写入 → app 升级后磁盘副本永远停在安装当天的旧版，扩展弹窗与
+      // app 内弹窗漂移（BUG-621/688 修了也到不了用户浏览器）。fire-and-forget 不阻塞 init。
+      unawaited(
+          refreshBrowserExtensionCopy().catchError((Object e, StackTrace s) {
+        ErrorLogService.instance
+            .log('AppModel.refreshBrowserExtensionCopy', e, s);
+      }));
       if (texthookerEnabled) {
         TexthookerWsClientHost.instance.start(texthookerUrls);
       }
@@ -4279,6 +4289,10 @@ class AppModel with ChangeNotifier {
       // 单词音频（1139②）：已启用音频源随查词响应下发，扩展弹窗据此渲染 ♪ 按钮
       // （点击 → /api/lookup/audio 解析 → HTML5 Audio 播放）。
       audioSourcesProvider: () => enabledAudioSources,
+      // BUG-724：内置扩展内容指纹随查词响应下发（`extensionBuild`），扩展 background
+      // 与自身 HIBIKI_DEFAULTS.build 比对，不一致即 chrome.runtime.reload() 从磁盘拉新。
+      // 指纹由 refreshBrowserExtensionCopy 在启动时算好缓存；算好前返回 null（字段省略）。
+      extensionBuildProvider: () => _browserExtensionBuild,
       tokenizer: JapaneseLanguage.instance.textToWords,
       readingResolver: (String w) {
         if (!HoshiDicts.isInitialized) return '';
@@ -4286,6 +4300,24 @@ class AppModel with ChangeNotifier {
             HoshiDicts.instance.lookup(w, maxResults: 1);
         return r.isEmpty ? '' : r.first.term.reading;
       },
+    );
+  }
+
+  // BUG-724：内置扩展指纹缓存（refreshBrowserExtensionCopy 启动时填充）。
+  String? _browserExtensionBuild;
+
+  /// BUG-724：把已解压的浏览器扩展副本刷新到当前 app 内置版本（详见
+  /// [refreshBundledBrowserExtensionIfStale]），并缓存内置指纹供查词响应下发。
+  /// 仅桌面（扩展解压引导仅桌面有意义）；移动端 no-op。
+  Future<void> refreshBrowserExtensionCopy() async {
+    if (!DesktopLookupService.isDesktop) return;
+    _browserExtensionBuild = await bundledBrowserExtensionFingerprint();
+    await refreshBundledBrowserExtensionIfStale(
+      serverConfig: BrowserExtensionServerConfig(
+        host: '127.0.0.1',
+        port: yomitanApiPort,
+        token: yomitanApiKey,
+      ),
     );
   }
 

--- a/hibiki/lib/src/sync/hibiki_remote_api_handlers.dart
+++ b/hibiki/lib/src/sync/hibiki_remote_api_handlers.dart
@@ -27,12 +27,17 @@ Future<Map<String, dynamic>> buildRemoteDictionaryLookupResponse(
   HibikiRemoteHistoryService? history,
   Map<String, String> Function()? themeColorsProvider,
   List<String> Function()? audioSourcesProvider,
+  String? Function()? extensionBuildProvider,
 }) async {
   final Map<String, String>? theme = themeColorsProvider?.call();
   // 单词音频：把 app 当前已启用的音频源随查词响应下发，扩展 content.js 据此设
   // window.audioSources（非空 → popup.js 渲染 ♪ 按钮）。null（未注入，如 sync host）
   // 时不带该字段（向后兼容）。
   final List<String>? audioSources = audioSourcesProvider?.call();
+  // BUG-724：app 内置扩展的内容指纹随查词响应下发。扩展 background 对比自身
+  // HIBIKI_DEFAULTS.build，不一致即 chrome.runtime.reload() 从磁盘拉新（磁盘副本由
+  // app 启动时刷新）。null（未注入 / 指纹尚未算好）时不带该字段（向后兼容）。
+  final String? extensionBuild = extensionBuildProvider?.call();
   final String term = body['term']?.toString() ?? '';
   if (term.trim().isEmpty) {
     return <String, dynamic>{
@@ -41,6 +46,7 @@ Future<Map<String, dynamic>> buildRemoteDictionaryLookupResponse(
       'popupJson': null,
       if (theme != null) 'theme': theme,
       if (audioSources != null) 'audioSources': audioSources,
+      if (extensionBuild != null) 'extensionBuild': extensionBuild,
     };
   }
   final bool wildcards = body['wildcards'] as bool? ?? false;
@@ -59,6 +65,7 @@ Future<Map<String, dynamic>> buildRemoteDictionaryLookupResponse(
     'popupJson': result?.popupJson,
     if (theme != null) 'theme': theme,
     if (audioSources != null) 'audioSources': audioSources,
+    if (extensionBuild != null) 'extensionBuild': extensionBuild,
   };
 }
 

--- a/hibiki/lib/src/sync/yomitan_api_server.dart
+++ b/hibiki/lib/src/sync/yomitan_api_server.dart
@@ -43,6 +43,7 @@ class YomitanApiServer {
     HibikiRemoteHistoryService? historyService,
     Map<String, String> Function()? themeColorsProvider,
     List<String> Function()? audioSourcesProvider,
+    String? Function()? extensionBuildProvider,
     String? apiKey,
     bool allowLan = false,
   })  : _requestedPort = port,
@@ -53,6 +54,7 @@ class YomitanApiServer {
         _readingResolver = readingResolver,
         _themeColorsProvider = themeColorsProvider,
         _audioSourcesProvider = audioSourcesProvider,
+        _extensionBuildProvider = extensionBuildProvider,
         _apiKey = apiKey,
         _allowLan = allowLan;
 
@@ -66,6 +68,8 @@ class YomitanApiServer {
   final Map<String, String> Function()? _themeColorsProvider;
   // 单词音频：当前 app 已启用的音频源供给器，随查词响应下发给扩展弹窗。
   final List<String> Function()? _audioSourcesProvider;
+  // BUG-724：app 内置扩展内容指纹供给器，随查词响应下发，驱动扩展自 reload 拉新。
+  final String? Function()? _extensionBuildProvider;
   final String? _apiKey;
   final bool _allowLan;
 
@@ -221,6 +225,7 @@ class YomitanApiServer {
       history: _history,
       themeColorsProvider: _themeColorsProvider,
       audioSourcesProvider: _audioSourcesProvider,
+      extensionBuildProvider: _extensionBuildProvider,
     ));
   }
 

--- a/hibiki/lib/src/sync/yomitan_api_server_manager.dart
+++ b/hibiki/lib/src/sync/yomitan_api_server_manager.dart
@@ -14,13 +14,15 @@ class YomitanApiServerManager {
     HibikiRemoteHistoryService? historyService,
     Map<String, String> Function()? themeColorsProvider,
     List<String> Function()? audioSourcesProvider,
+    String? Function()? extensionBuildProvider,
   })  : _lookup = lookupService,
         _mining = miningService,
         _history = historyService,
         _tokenizer = tokenizer,
         _readingResolver = readingResolver,
         _themeColorsProvider = themeColorsProvider,
-        _audioSourcesProvider = audioSourcesProvider;
+        _audioSourcesProvider = audioSourcesProvider,
+        _extensionBuildProvider = extensionBuildProvider;
 
   final HibikiRemoteLookupService _lookup;
   final HibikiRemoteMiningService? _mining;
@@ -31,6 +33,8 @@ class YomitanApiServerManager {
   final Map<String, String> Function()? _themeColorsProvider;
   // 单词音频：已启用音频源供给器，透传给 [YomitanApiServer]，随查词响应下发给扩展。
   final List<String> Function()? _audioSourcesProvider;
+  // BUG-724：扩展内容指纹供给器，透传给 [YomitanApiServer]，驱动扩展自 reload 拉新。
+  final String? Function()? _extensionBuildProvider;
 
   YomitanApiServer? _server;
 
@@ -48,6 +52,7 @@ class YomitanApiServerManager {
       readingResolver: _readingResolver,
       themeColorsProvider: _themeColorsProvider,
       audioSourcesProvider: _audioSourcesProvider,
+      extensionBuildProvider: _extensionBuildProvider,
       apiKey: apiKey.isEmpty ? null : apiKey,
       allowLan: true,
     );

--- a/hibiki/test/lookup/browser_extension_auto_refresh_guard_test.dart
+++ b/hibiki/test/lookup/browser_extension_auto_refresh_guard_test.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-724 生产接线守卫（源码扫描）：浏览器扩展「app 升级 → 磁盘副本刷新 → 扩展自
+/// reload」链路的三段接线缺一不可。历史事故：BUG-621/688 把扩展弹窗 parity/主题修好
+/// 入库，但已解压副本只在用户手动跑「安装扩展」助手时写入 → app 升级后用户浏览器里
+/// 的扩展永远停在安装当天的旧版，修复到不了浏览器，弹窗与 app 内持续漂移。
+void main() {
+  group('BUG-724 extension auto-refresh wiring', () {
+    test('AppModel.initialise fires refreshBrowserExtensionCopy', () {
+      final String src =
+          File('lib/src/models/app_model.dart').readAsStringSync();
+      // 启动路径必须挂上磁盘副本刷新（fire-and-forget，不阻塞 init）。
+      // 用格式无关的正则（dart format 会在 unawaited( 后换行）。
+      expect(
+          RegExp('unawaited\\(\\s*refreshBrowserExtensionCopy\\(\\)')
+              .hasMatch(src),
+          isTrue,
+          reason: '启动时必须刷新已解压的扩展副本，否则 app 升级永远到不了用户浏览器');
+      // 刷新实现必须走「装过才刷」的条件重解压，而不是无条件落盘。
+      expect(src, contains('refreshBundledBrowserExtensionIfStale('));
+      // yomitan-api server 必须下发内置扩展指纹（extensionBuild 自更新信号）。
+      expect(src,
+          contains('extensionBuildProvider: () => _browserExtensionBuild'));
+    });
+
+    test('installer refresh is conditional on an existing install', () {
+      final String src = File('lib/src/lookup/browser_extension_installer.dart')
+          .readAsStringSync();
+      final int fn =
+          src.indexOf('Future<bool> refreshBundledBrowserExtensionIfStale');
+      expect(fn, greaterThanOrEqualTo(0));
+      final String body = src.substring(fn);
+      // 副本目录不存在（用户从没装过）→ 绝不落盘：不能给没装扩展的用户凭空写文件。
+      expect(body, contains('if (!dest.existsSync()) return false;'),
+          reason: '刷新只针对已安装副本；未安装用户不落盘');
+    });
+
+    test('background.js self-reload is guarded (loop / recording / legacy)',
+        () {
+      final String src =
+          File('assets/browser_extension/background.js').readAsStringSync();
+      // 查词响应回完后才检查自更新（reload 杀 SW，不能挡响应）。
+      final int respond =
+          src.indexOf('sendResponse({ ok: r.ok, status: r.status, data });');
+      final int reloadCall = src.indexOf('maybeSelfReload(data);');
+      expect(respond, greaterThanOrEqualTo(0));
+      expect(reloadCall, greaterThan(respond),
+          reason: 'maybeSelfReload 必须在 lookup 的 sendResponse 之后');
+      // 三重防护：任一侧缺指纹不动 / 已为该指纹 reload 过不再重试 / 录制中跳过。
+      expect(
+          src, contains('if (!remote || !local || remote === local) return;'));
+      expect(src, contains('hibikiReloadedForBuild'));
+      final int fn = src.indexOf('async function maybeSelfReload');
+      expect(fn, greaterThanOrEqualTo(0));
+      final int reload = src.indexOf('chrome.runtime.reload()', fn);
+      expect(reload, greaterThan(fn),
+          reason: 'maybeSelfReload 内必须真正调用 chrome.runtime.reload()');
+      final String body = src.substring(fn, reload);
+      expect(body, contains('isOffscreenRecording()'),
+          reason: 'Netflix 逐句回放录制中禁止 reload（会杀掉 offscreen 录制）');
+    });
+
+    test('mirror copy of background.js stays byte-identical', () {
+      // 双镜像契约（TODO-1000）：assets/ 与 tools/ 必须逐字节一致。installer_test 已
+      // 全量互比；这里单独点名 background.js，让本守卫失败信息直指自更新改动没同步镜像。
+      final List<int> bundled =
+          File('assets/browser_extension/background.js').readAsBytesSync();
+      final List<int> source =
+          File('../tools/browser-extension/background.js').readAsBytesSync();
+      expect(bundled, source, reason: '改 background.js 必须同步两个镜像');
+    });
+  });
+}

--- a/hibiki/test/lookup/browser_extension_installer_test.dart
+++ b/hibiki/test/lookup/browser_extension_installer_test.dart
@@ -80,6 +80,69 @@ void main() {
     });
   });
 
+  // BUG-724：扩展内容指纹 + build 注入/解析。指纹是「app 升级 → 磁盘副本刷新 → 扩展自
+  // reload」链路的身份真值：解压时写进 hibiki-defaults.js（build），查词响应下发同一指纹
+  //（extensionBuild），两侧一致 = 最新，不一致 = 扩展 reload 拉新。
+  group('browser extension fingerprint (BUG-724)', () {
+    test('deterministic over content, order-independent', () {
+      final Map<String, List<int>> a = <String, List<int>>{
+        'background.js': <int>[1, 2, 3],
+        'vendor/popup.js': <int>[4, 5],
+      };
+      final Map<String, List<int>> b = <String, List<int>>{
+        'vendor/popup.js': <int>[4, 5],
+        'background.js': <int>[1, 2, 3],
+      };
+      expect(computeBrowserExtensionFingerprint(a),
+          computeBrowserExtensionFingerprint(b));
+      expect(computeBrowserExtensionFingerprint(a), hasLength(16));
+    });
+
+    test('changes when any file content changes', () {
+      final Map<String, List<int>> a = <String, List<int>>{
+        'background.js': <int>[1, 2, 3],
+      };
+      final Map<String, List<int>> b = <String, List<int>>{
+        'background.js': <int>[1, 2, 4],
+      };
+      expect(computeBrowserExtensionFingerprint(a),
+          isNot(computeBrowserExtensionFingerprint(b)));
+    });
+
+    test('ignores hibiki-defaults.js (rewritten on every extract)', () {
+      final Map<String, List<int>> a = <String, List<int>>{
+        'background.js': <int>[1],
+        'hibiki-defaults.js': <int>[9, 9],
+      };
+      final Map<String, List<int>> b = <String, List<int>>{
+        'background.js': <int>[1],
+        'hibiki-defaults.js': <int>[7],
+      };
+      expect(computeBrowserExtensionFingerprint(a),
+          computeBrowserExtensionFingerprint(b));
+    });
+
+    test('defaults js build key round-trips through parse', () {
+      const BrowserExtensionServerConfig cfg = BrowserExtensionServerConfig(
+          host: '127.0.0.1', port: 19633, token: 't');
+      final String withBuild =
+          buildBrowserExtensionDefaultsJs(cfg, build: 'deadbeef01234567');
+      expect(parseBrowserExtensionBuild(withBuild), 'deadbeef01234567');
+      // 不传 build（旧调用/占位）→ 不写键、解析回 null（与旧副本一致 → 触发刷新）。
+      final String withoutBuild = buildBrowserExtensionDefaultsJs(cfg);
+      expect(withoutBuild, isNot(contains('build:')));
+      expect(parseBrowserExtensionBuild(withoutBuild), isNull);
+    });
+
+    test('prepareBundledBrowserExtension writes fingerprint into defaults', () {
+      // 生产接线守卫（源码扫描）：解压时必须把指纹写进 hibiki-defaults.js 的 build，
+      // 否则启动刷新（refreshBundledBrowserExtensionIfStale）恒判陈旧、每次启动全量重写。
+      final String src = File('lib/src/lookup/browser_extension_installer.dart')
+          .readAsStringSync();
+      expect(src, contains('build: computeBrowserExtensionFingerprint('));
+    });
+  });
+
   // TODO-1087：扩展默认端口/主机守卫。打包扩展的 hibiki-defaults.js 与 background.js
   // 的默认必须指向本机环回 + kYomitanApiDefaultPort(19633)，否则「加载已解压」后默认连不上。
   group('bundled extension default connection', () {

--- a/hibiki/test/sync/yomitan_api_server_extension_endpoints_test.dart
+++ b/hibiki/test/sync/yomitan_api_server_extension_endpoints_test.dart
@@ -125,6 +125,7 @@ void main() {
       String? apiKey,
       Map<String, String> Function()? themeColorsProvider,
       List<String> Function()? audioSourcesProvider,
+      String? Function()? extensionBuildProvider,
     }) async {
       lookup = _FakeLookup();
       mining = _FakeMining();
@@ -136,6 +137,7 @@ void main() {
         readingResolver: rr,
         themeColorsProvider: themeColorsProvider,
         audioSourcesProvider: audioSourcesProvider,
+        extensionBuildProvider: extensionBuildProvider,
         apiKey: apiKey,
       );
       await server.start();
@@ -198,6 +200,34 @@ void main() {
       final Map<String, dynamic> j = await _json(resp);
       // 无 provider（旧 app / server 未注入）→ 不带 theme，扩展 CSS 回落默认 400x360。
       expect(j.containsKey('theme'), isFalse);
+    });
+
+    test(
+        'lookup response carries extensionBuild from provider and omits it '
+        'when absent (BUG-724)', () async {
+      // BUG-724：扩展自更新信号。app 把内置扩展内容指纹随查词响应下发（extensionBuild），
+      // 扩展 background 与自身 HIBIKI_DEFAULTS.build 比对，不一致即 runtime.reload 拉新。
+      await startServer(apiKey: 'k123', extensionBuildProvider: () => 'abc123');
+      final HttpClientResponse resp = await _post(
+        server.port,
+        '/api/lookup/dictionary',
+        <String, dynamic>{'term': '猫', 'record': false},
+        auth: _basic('k123'),
+      );
+      expect(resp.statusCode, 200);
+      final Map<String, dynamic> j = await _json(resp);
+      expect(j['extensionBuild'], 'abc123');
+
+      // 未注入（旧 app / sync host）→ 不带该字段（向后兼容：旧扩展代码不受影响）。
+      await server.stop();
+      await startServer(apiKey: 'k123');
+      final Map<String, dynamic> j2 = await _json(await _post(
+        server.port,
+        '/api/lookup/dictionary',
+        <String, dynamic>{'term': '猫', 'record': false},
+        auth: _basic('k123'),
+      ));
+      expect(j2.containsKey('extensionBuild'), isFalse);
     });
 
     test('/api/mine with screenshot routes to mineImmersion', () async {

--- a/tools/browser-extension/background.js
+++ b/tools/browser-extension/background.js
@@ -16,6 +16,26 @@ async function cfg() {
 }
 function authHeader(token) { return 'Basic ' + btoa('hibiki:' + token); }
 
+// BUG-724：扩展自更新。app 启动时会把 <appSupport> 的已解压副本刷新到当前内置版本，并把
+// 内容指纹写进 hibiki-defaults.js（build）+ 随查词响应下发（extensionBuild）。这里比对
+// 两者：不一致 = 磁盘上已有新版而当前加载的还是旧版 → chrome.runtime.reload() 从磁盘拉新
+// （等价于扩展管理页的「重新加载」，未解压包路径不变）。防护：
+// - 任一侧缺指纹（旧 app / 占位默认）→ 不动（向后兼容，绝不空转 reload）；
+// - storage 记录已为该指纹 reload 过 → 不再重试（防「磁盘没刷成」时无限循环）；
+// - 正在 Netflix 逐句回放录制 → 跳过（reload 会杀掉 offscreen 录制，等录完下次查词再说）。
+async function maybeSelfReload(data) {
+  try {
+    const remote = data && data.extensionBuild;
+    const local = HIBIKI_DEFAULTS.build;
+    if (!remote || !local || remote === local) return;
+    if (await isOffscreenRecording()) return;
+    const st = await chrome.storage.local.get(['hibikiReloadedForBuild']);
+    if (st.hibikiReloadedForBuild === remote) return;
+    await chrome.storage.local.set({ hibikiReloadedForBuild: remote });
+    chrome.runtime.reload();
+  } catch (_) { /* 自更新失败不影响查词本身 */ }
+}
+
 // TODO-1000 Netflix：offscreen 文档承载 tabCapture MediaRecorder。批量生成时按字幕逐句「回放
 // 录制」——每句 seek 到句首、播到句尾录成一段自包含 webm（beginClip/endClip），随 mineClip 发给
 // Hibiki 转 GIF+句子音频。点扩展图标启动（需 activeTab 手势 + 关硬件加速才非黑），跨集自动切换。
@@ -156,7 +176,10 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
           body: JSON.stringify({ term: msg.term, record: msg.record === true }),
         });
-        sendResponse({ ok: r.ok, status: r.status, data: r.ok ? await r.json() : null });
+        const data = r.ok ? await r.json() : null;
+        sendResponse({ ok: r.ok, status: r.status, data });
+        // BUG-724：先回结果再检查自更新（reload 杀 SW，绝不能挡在 sendResponse 前面）。
+        maybeSelfReload(data);
       } else if (msg.type === 'lookupAudio') {
         // 单词音频：POST /api/lookup/audio {expression,reading}（Basic auth）→ server 用
         // 与 app 同一 lookupAudio（本地音频库）解析出音频字节，回 {url,contentType}，url 是

--- a/tools/browser-extension/hibiki-defaults.js
+++ b/tools/browser-extension/hibiki-defaults.js
@@ -7,6 +7,10 @@
 //
 // 优先级：chrome.storage.local（用户在 options 手动覆盖） > 本文件内置默认。
 // service worker（background.js）用 importScripts 引入；options 页用 <script> 引入。
+//
+// BUG-724：安装助手/启动刷新还会写入 build（扩展内容指纹）。background.js 用它与查词
+// 响应里的 extensionBuild 比对，不一致即 chrome.runtime.reload() 从磁盘拉新（自更新）。
+// 占位默认不带 build（→ 永不触发 reload）。
 self.HIBIKI_DEFAULTS = {
   host: '127.0.0.1',
   port: 19633,


### PR DESCRIPTION
## BUG-724 · 浏览器扩展已解压副本永不随 app 升级刷新

**用户报告**：浏览器的查词弹窗，明显和 app 内的查词弹窗不一样。

### 根因（部署通道缺失，不是样式又坏了）

- 用户机运行中的 app 是**新的**（curl `19633/api/lookup/dictionary`：theme 已含 `--text-color`/`--hibiki-color-scheme` = BUG-688 修复在跑）
- 但 `<appSupport>/hibiki-browser-extension/` 磁盘副本停在 2026-07-08 之前：`vendor/popup.js` 75546B（BUG-621 描述的「75 KB 旧版」，当前 156797）、`content.css` 16920B（当前 54210）
- `prepareBundledBrowserExtension` 只有设置页手动「安装扩展」一个调用点 → app 升级从不刷新磁盘副本 → BUG-621 parity / BUG-688 主题两轮修复全都到不了用户浏览器，弹窗漂移按月复发

### 修复：打通「app 升级 → 磁盘副本刷新 → 扩展自 reload」自动链路

1. **指纹身份**：内置扩展全资产 sha256 前 16 hex（排除解压必重写的 `hibiki-defaults.js`），解压时写进 defaults 的 `build` 键（manifest version 恒 0.1.0 无纪律，故用内容指纹）
2. **启动刷新**：`AppModel.initialise` 桌面端 fire-and-forget → 副本存在且指纹不符才整目录重解压（注入当前 server host/port/token；没装过不落盘）
3. **自 reload**：查词响应新增 `extensionBuild` 字段（未注入不带 = 向后兼容）；`background.js` 在 lookup `sendResponse` **之后**比对 `HIBIKI_DEFAULTS.build`，不符 → 一次性 `chrome.runtime.reload()` 从磁盘拉新。三重防护：任一侧缺指纹不动 / storage 记录已 reload 指纹防死循环 / Netflix 录制中跳过
4. 镜像已同步 `tools/browser-extension/`（byte-parity 守卫绿）

### 测试

- 全量 `flutter analyze` No issues；全量 `flutter test` **10756 passed**
- 新增：指纹纯函数（确定性/序无关/排除 defaults）、`build` round-trip、`extensionBuild` 端点透传+向后兼容、接线守卫（启动挂钩/条件刷新/自 reload 三防护/镜像字节一致）
- `tools/browser-extension` node 测试：highlight-overlay 7 个失败为**基线预先存在**（stash 前后对比确认），与本轮无关

### 用户一次性动作（写在 BUG-724 备注）

本修复进构建后 app 启动会刷磁盘副本，但**当前已加载的旧扩展没有自 reload 逻辑**，需在 `edge://extensions` 点一次「重新加载」（或重启浏览器）。此后 app 每次升级，扩展下一次查词自动拉新，永不再手动。
