### PR TITLE
feat(dict): 非 Yomitan 词典保真——MDX 加密解密 + MDD 媒体 + CSS 内联 + 屈折查词修复 (BUG-723/719)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 707 条。点号进各自文件。
+> 共 708 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-723](bugs/BUG-723-mdx-encrypted-keyinfo.md) | ✅ | ✅ | MDX Encrypted=2 词典导入失败 empty key block info |
 | [BUG-722](bugs/BUG-722-popup-multibase-ruby-furigana-overlap.md) | ✅ | ✅ | 词典弹窗多基字词逐字振假名完全重叠(勝負/将棋) |
 | [BUG-721](bugs/BUG-721-clipboard-panel-close-drops-lookups.md) | ✅ | ✅ | 剪贴板面板关闭后被永久暂停：第二个词出不来 |
 | [BUG-720](bugs/BUG-720-sasayaki-lookup-ruby-lane-misalign.md) | ✅ | ✅ | 有声书/查词注音高亮 narrow-lane 错位 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,7 +27,7 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 708 条。点号进各自文件。
+> 共 709 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
@@ -35,6 +35,7 @@
 | [BUG-722](bugs/BUG-722-popup-multibase-ruby-furigana-overlap.md) | ✅ | ✅ | 词典弹窗多基字词逐字振假名完全重叠(勝負/将棋) |
 | [BUG-721](bugs/BUG-721-clipboard-panel-close-drops-lookups.md) | ✅ | ✅ | 剪贴板面板关闭后被永久暂停：第二个词出不来 |
 | [BUG-720](bugs/BUG-720-sasayaki-lookup-ruby-lane-misalign.md) | ✅ | ✅ | 有声书/查词注音高亮 narrow-lane 错位 |
+| [BUG-719](bugs/BUG-719-simple-dict-inflected-lookup.md) | ✅ | ✅ | MDX/StarDict/DSL 等 simple 词典屈折形查词命中丢失 |
 | [BUG-718](bugs/BUG-718-vn-restore-charoffset-cloak.md) | ✅ | ✅ | VN模式按字符偏移恢复时FOUC遮罩未移除致整页空白 |
 | [BUG-717](bugs/BUG-717-lookup-latency-half-second.md) | ✅ | ✅ | 查词全链路延迟半秒级 |
 | [BUG-716](bugs/BUG-716-bilingual-bottom-marginv-overlap.md) | ✅ | ✅ | 双语底部对白 MarginV 塌陷重叠 |

--- a/docs/bugs/BUG-719-simple-dict-inflected-lookup.md
+++ b/docs/bugs/BUG-719-simple-dict-inflected-lookup.md
@@ -14,12 +14,12 @@
   - `importer.cpp` `process_simple_entries`：simple 词条改写 `rules="*"`（通配词性）。
   - `deinflector.cpp` `pos_to_conditions`：遇 token `"*"` 返回全 1 位（`~0`），使
     `filter_by_pos` 的 erase 判据对通配词条永不触发。只影响 simple dict；Yomitan
-    词条从不用 `"*"`，行为不变。提交哈希：<待填>。
+    词条从不用 `"*"`，行为不变。提交哈希：cf5f817d5。
 - **[x] ② 已加自动化测试** — `native/hoshidicts/tests/simple_dict_deinflection_test.cpp`
   （CMake 注册 `simple_dict_deinflection_test`）：① `pos_to_conditions({"*"})==~0`、真
   tag/未知 tag/空各自正常且通配与真位有交集；② `write_simple_dict` 写一条后
   `DictionaryQuery::query` 取回 `rules=="*"`，证明通配真落到 term 记录。全套 15 个
-  native 测试通过（含 kanji/media/freq/pitch/ipa 查词回归门）。提交哈希：<待填>。
+  native 测试通过（含 kanji/media/freq/pitch/ipa 查词回归门）。提交哈希：cf5f817d5。
 - **备注**：term 记录读取侧 `query.cpp:229-230` 本就按 `rules_len` 变长读取（Yomitan
   词条 rules 非空），故 `rules_len 0→1` 安全无需改读取。真机复测：桌面导入一本 MDX/
   StarDict 后查一个动词屈折形，应能命中释义（待真机）。号从 724 改到 719 以避开另一

--- a/docs/bugs/BUG-719-simple-dict-inflected-lookup.md
+++ b/docs/bugs/BUG-719-simple-dict-inflected-lookup.md
@@ -1,0 +1,26 @@
+## BUG-719 · MDX/StarDict/DSL 等 simple 词典屈折形查词命中丢失
+- **报告**：2026-07-11（内部审计：讨论 MDX 支持时发现「查词大概率有问题」，沿代码路径证实）
+- **真实性**：✅ 真 bug。根因 `native/hoshidicts/hoshidicts_src/importer.cpp:889`（改前 `rules_len=0`）
+  ＋ `native/hoshidicts/hoshidicts_src/lookup.cpp:139-142`（`filter_by_pos`）。
+  MDX/StarDict/DSL 全走 `write_simple_dict`；`process_simple_entries` 给每条词写
+  `rules_len=0`（无词性）。查词时 `Lookup::filter_by_pos`：当查询经过去屈折
+  （`d.conditions != 0`，如动词过去式 食べた→食べる）时，会 `std::erase_if` 删掉
+  `(pos_to_conditions(term.rules) & d.conditions) == 0` 的词条；空 rules →
+  `pos_to_conditions([])=0` → 与任何 `d.conditions` 无交集 → **被删**。
+  结果：simple 词典只有「词头原形直接命中」（conditions==0 那支）才留得住，凡屈折形
+  命中一律丢结果。Yomitan 词典自带真实词性（v5/adj-i…）不受影响——这是「其他格式
+  词典查词有问题」的真根因，不只是缺媒体/CSS。
+- **[x] ① 已修复** — 「修数据结构」而非特例化共享过滤器：
+  - `importer.cpp` `process_simple_entries`：simple 词条改写 `rules="*"`（通配词性）。
+  - `deinflector.cpp` `pos_to_conditions`：遇 token `"*"` 返回全 1 位（`~0`），使
+    `filter_by_pos` 的 erase 判据对通配词条永不触发。只影响 simple dict；Yomitan
+    词条从不用 `"*"`，行为不变。提交哈希：<待填>。
+- **[x] ② 已加自动化测试** — `native/hoshidicts/tests/simple_dict_deinflection_test.cpp`
+  （CMake 注册 `simple_dict_deinflection_test`）：① `pos_to_conditions({"*"})==~0`、真
+  tag/未知 tag/空各自正常且通配与真位有交集；② `write_simple_dict` 写一条后
+  `DictionaryQuery::query` 取回 `rules=="*"`，证明通配真落到 term 记录。全套 15 个
+  native 测试通过（含 kanji/media/freq/pitch/ipa 查词回归门）。提交哈希：<待填>。
+- **备注**：term 记录读取侧 `query.cpp:229-230` 本就按 `rules_len` 变长读取（Yomitan
+  词条 rules 非空），故 `rules_len 0→1` 安全无需改读取。真机复测：桌面导入一本 MDX/
+  StarDict 后查一个动词屈折形，应能命中释义（待真机）。号从 724 改到 719 以避开另一
+  未合分支的 BUG-724（扩展弹窗 deploy channel，PR#34）撞号。

--- a/docs/bugs/BUG-723-mdx-encrypted-keyinfo.md
+++ b/docs/bugs/BUG-723-mdx-encrypted-keyinfo.md
@@ -1,0 +1,27 @@
+## BUG-723 · MDX Encrypted=2 词典导入失败 empty key block info
+- **报告**：2026-07-11（用户：导入 `T4jiJuk.mdx` 失败，`MDX parse error: mdx: empty key block info`）
+- **真实性**：✅ 真 bug。根因 `native/hoshidicts/hoshidicts_src/mdx/mdx_reader.cpp:181`（改前）。
+  该词典头部 `Encrypted="2"`（大修館 四字熟語辞典），MDX 用 MDict 自带的
+  RIPEMD-128 + 滚动 XOR/半字节交换算法把已 zlib 压缩的 key-block-info 段整体
+  加扰（bit 1，无需注册码即可还原）。旧 `mdx_reader` 完全无加密处理，直接把加扰
+  数据喂给 `libdeflate_zlib_decompress` → 解压失败返回 `{}` →
+  `key_block_info.empty()` 为真 → 抛 `mdx: empty key block info`（旧 181 行）。
+  验真过程：解析头部确认 `Encrypted="2"`；用独立 Python 实现 RIPEMD-128 +
+  fast_decrypt 解密该文件 key-block-info，解压得 722 字节（==头声明 decomp_size），
+  解析出 9/9 个 key block、7965 条词条（==`num_entries`），证明就是加密未还原。
+- **[x] ① 已修复** — `native/hoshidicts/hoshidicts_src/mdx/mdx_reader.cpp`：
+  匿名命名空间新增 `ripemd128()` / `mdx_fast_decrypt()`；解析头部新增 `Encrypted`
+  位域（bit 1=key-block-info 加扰，可还原；bit 0=记录块加密需注册码，不处理）；
+  key-block-info 解压前，若 `encrypted & 2`，先用 `ripemd128(kbi[4..8) ++ 0x3695 LE)`
+  作密钥对 `kbi[8..)` 原地还原，再走原 zlib 解压路径。提交哈希：e0f2e1cb0。
+- **[x] ② 已加自动化测试** — `native/hoshidicts/tests/mdx_encrypted_keyinfo_test.cpp`
+  （CMake 注册 `mdx_encrypted_keyinfo_test`）：在内存中构造一本 `Encrypted="2"` MDX
+  fixture（用独立重写的 RIPEMD-128 + 逆向 fast_decrypt 加扰），断言 `mdx_reader::parse`
+  还原出 headword/definition；另加 RIPEMD-128 三个标准 KAT 向量（空串/abc/message
+  digest）。逻辑闭环：fixture 解密成功 ⇒ reader 的 RIPEMD == 测试的 RIPEMD；KAT 通过
+  ⇒ 测试的 RIPEMD == 规范 ⇒ reader 的 RIPEMD 规范正确。提交哈希：e0f2e1cb0。
+- **备注**：真机/端到端已在本机 Windows/MSVC 验证：链接真实 `hoshidicts.lib` 的探针对
+  用户原始文件 `T4jiJuk.mdx` 解析成功（title=大修館 四字熟語辞典，entries=7965，
+  词条 `あいきこつりつ` 等正确）。native 库在 app 构建时从源码编译进
+  `hoshidicts_ffi.dll`/`.so`/`.dylib`，无 checked-in 预编译二进制，下次构建即生效。
+  仅还原 key-block-info（bit 1）；bit 0（记录块加密、需购买注册码）仍不支持，属外部限制。

--- a/docs/bugs/BUG-723-mdx-encrypted-keyinfo.md
+++ b/docs/bugs/BUG-723-mdx-encrypted-keyinfo.md
@@ -13,13 +13,13 @@
   匿名命名空间新增 `ripemd128()` / `mdx_fast_decrypt()`；解析头部新增 `Encrypted`
   位域（bit 1=key-block-info 加扰，可还原；bit 0=记录块加密需注册码，不处理）；
   key-block-info 解压前，若 `encrypted & 2`，先用 `ripemd128(kbi[4..8) ++ 0x3695 LE)`
-  作密钥对 `kbi[8..)` 原地还原，再走原 zlib 解压路径。提交哈希：e0f2e1cb0。
+  作密钥对 `kbi[8..)` 原地还原，再走原 zlib 解压路径。提交哈希：dd85406ac。
 - **[x] ② 已加自动化测试** — `native/hoshidicts/tests/mdx_encrypted_keyinfo_test.cpp`
   （CMake 注册 `mdx_encrypted_keyinfo_test`）：在内存中构造一本 `Encrypted="2"` MDX
   fixture（用独立重写的 RIPEMD-128 + 逆向 fast_decrypt 加扰），断言 `mdx_reader::parse`
   还原出 headword/definition；另加 RIPEMD-128 三个标准 KAT 向量（空串/abc/message
   digest）。逻辑闭环：fixture 解密成功 ⇒ reader 的 RIPEMD == 测试的 RIPEMD；KAT 通过
-  ⇒ 测试的 RIPEMD == 规范 ⇒ reader 的 RIPEMD 规范正确。提交哈希：e0f2e1cb0。
+  ⇒ 测试的 RIPEMD == 规范 ⇒ reader 的 RIPEMD 规范正确。提交哈希：dd85406ac。
 - **备注**：真机/端到端已在本机 Windows/MSVC 验证：链接真实 `hoshidicts.lib` 的探针对
   用户原始文件 `T4jiJuk.mdx` 解析成功（title=大修館 四字熟語辞典，entries=7965，
   词条 `あいきこつりつ` 等正确）。native 库在 app 构建时从源码编译进

--- a/native/hoshidicts/hoshidicts_src/deinflector.cpp
+++ b/native/hoshidicts/hoshidicts_src/deinflector.cpp
@@ -217,6 +217,15 @@ void Deinflector::load_transforms_json(const std::string& json) {
 uint64_t Deinflector::pos_to_conditions(const std::vector<std::string>& part_of_speech) const {
   uint64_t result = 0;
   for (const auto& p : part_of_speech) {
+    if (p == "*") {
+      // Simple dictionaries (MDX / StarDict / DSL) carry no per-term part of
+      // speech, so their terms are stored with the wildcard rule "*". Returning
+      // all condition bits makes filter_by_pos keep them for ANY deinflected
+      // lookup (its `(dict_conditions & d.conditions) == 0` erase test can never
+      // fire), instead of dropping every inflected-form hit. Yomitan term banks
+      // carry real POS tags and never use "*", so they are unaffected.
+      return ~uint64_t{0};
+    }
     auto it = pos_to_condition_cache_.find(p);
     if (it != pos_to_condition_cache_.end()) {
       result |= it->second;

--- a/native/hoshidicts/hoshidicts_src/importer.cpp
+++ b/native/hoshidicts/hoshidicts_src/importer.cpp
@@ -894,7 +894,12 @@ ProcessedFile process_simple_entries(const std::vector<SimpleEntry>& entries) {
     processed.glossary_offsets.emplace_back(glossary_hash, glossary_offset);
 
     write_val<uint8_t>(processed.data, 0);  // def_tags_len = 0
-    write_val<uint8_t>(processed.data, 0);  // rules_len = 0
+    // rules = "*": simple dicts have no per-term POS. The wildcard makes
+    // filter_by_pos keep these terms for deinflected (inflected-form) lookups
+    // instead of erasing them; see Deinflector::pos_to_conditions. Stored as a
+    // normal variable-length rules string (reader consumes it by length).
+    write_val<uint8_t>(processed.data, 1);  // rules_len = 1
+    write_val<uint8_t>(processed.data, static_cast<uint8_t>('*'));
     write_val<uint8_t>(processed.data, 0);  // term_tags_len = 0
 
     processed.offsets.emplace_back(XXH3_64bits(expr.data(), expr.size()), offset);

--- a/native/hoshidicts/hoshidicts_src/importer.cpp
+++ b/native/hoshidicts/hoshidicts_src/importer.cpp
@@ -910,6 +910,21 @@ ProcessedFile process_simple_entries(const std::vector<SimpleEntry>& entries) {
   return processed;
 }
 
+// Read a stylesheet sitting next to a dictionary file, named by swapping the
+// extension to .css (Foo.mdx -> Foo.css). Returns "" if absent/empty/unreadable.
+std::string read_sibling_css(const std::string& primary_path) {
+  auto css_path = hoshi::fs_path(primary_path);
+  css_path.replace_extension(".css");
+  std::ifstream css_in(css_path, std::ios::binary | std::ios::ate);
+  if (!css_in) return "";
+  auto n = css_in.tellg();
+  if (n <= 0) return "";
+  std::string css(static_cast<size_t>(n), '\0');
+  css_in.seekg(0);
+  css_in.read(css.data(), static_cast<std::streamsize>(n));
+  return css;
+}
+
 ImportResult import_mdx(const std::string& mdx_path, const std::string& output_dir) {
   std::ifstream file(hoshi::fs_path(mdx_path), std::ios::binary | std::ios::ate);
   if (!file.is_open()) {
@@ -942,7 +957,13 @@ ImportResult import_mdx(const std::string& mdx_path, const std::string& output_d
     entries.push_back({std::move(e.key), std::move(e.definition)});
   }
 
-  return dictionary_importer::write_simple_dict(title, entries, output_dir);
+  // MDX glossaries are HTML that usually <link> a sibling stylesheet named after
+  // the dictionary (T4jiJuk.mdx -> T4jiJuk.css). Inline it as the dict's
+  // styles.css so the popup's constructDictCss scopes and injects it; otherwise
+  // the definitions render unstyled. Absent sibling -> empty -> no styles.css.
+  std::string styles_css = read_sibling_css(mdx_path);
+
+  return dictionary_importer::write_simple_dict(title, entries, output_dir, styles_css);
 }
 
 ImportResult import_mdx_from_zip(Zip& zip, const std::string& output_dir) {

--- a/native/hoshidicts/hoshidicts_src/importer.cpp
+++ b/native/hoshidicts/hoshidicts_src/importer.cpp
@@ -774,6 +774,43 @@ std::vector<char> build_offset_index(std::vector<std::pair<uint64_t, uint64_t>>&
   return offset_buf;
 }
 
+// Append one media record [u16 path_len][path][u32 blob_size][blob] to `media`,
+// recording (normalized_path, record_offset) for the sorted index. Shared by the
+// yomitan-zip writer and the .mdd writer so the on-disk media format stays
+// byte-identical (the query side binary-searches media.idx by path). Returns
+// false if the record was skipped (path too long).
+bool append_media_record(std::ofstream& media, uint32_t& write_pos,
+                         std::vector<std::pair<std::string, uint32_t>>& index_entries,
+                         std::string path, const void* blob, size_t blob_size) {
+  path = hoshidicts::normalize_media_path(std::move(path));
+  if (path.size() > std::numeric_limits<uint16_t>::max()) {
+    HOSHI_LOGW("media path too long (%zu bytes), skipping", path.size());
+    return false;
+  }
+  uint32_t record_start = write_pos;
+  std::vector<char> buf;
+  write_val<uint16_t>(buf, static_cast<uint16_t>(path.size()));
+  write_str(buf, path);
+  write_val<uint32_t>(buf, static_cast<uint32_t>(blob_size));
+  write_bytes(buf, blob, blob_size);
+  media.write(buf.data(), static_cast<std::streamsize>(buf.size()));
+  write_pos += static_cast<uint32_t>(buf.size());
+  index_entries.emplace_back(std::move(path), record_start);
+  return true;
+}
+
+// Finalize media.idx: [u32 count][u64 record_offset x count], sorted by path.
+void write_media_idx(std::ofstream& media_idx,
+                     std::vector<std::pair<std::string, uint32_t>>& index_entries) {
+  std::ranges::sort(index_entries);
+  std::vector<char> index_buf;
+  write_val<uint32_t>(index_buf, static_cast<uint32_t>(index_entries.size()));
+  for (const auto& [name, offset] : index_entries) {
+    write_val<uint64_t>(index_buf, offset);
+  }
+  media_idx.write(index_buf.data(), static_cast<std::streamsize>(index_buf.size()));
+}
+
 size_t write_media(const std::string& path, const Zip& zip, const std::vector<int>& files,
                    const std::string& breadcrumb_dir) {
   if (files.empty()) {
@@ -787,7 +824,6 @@ size_t write_media(const std::string& path, const Zip& zip, const std::vector<in
 
   size_t media_count = 0;
   uint32_t write_pos = 0;
-  std::vector<char> buf;
   std::vector<std::pair<std::string, uint32_t>> index_entries;
   int media_seq = 0;
   for (int file_index : files) {
@@ -801,34 +837,53 @@ size_t write_media(const std::string& path, const Zip& zip, const std::vector<in
     if (!media_file.has_value()) {
       continue;
     }
-
-    uint32_t record_start = write_pos;
-    media_file->path = hoshidicts::normalize_media_path(std::move(media_file->path));
-    if (media_file->path.size() > std::numeric_limits<uint16_t>::max()) {
-      HOSHI_LOGW("media path too long (%zu bytes), skipping", media_file->path.size());
-      continue;
+    if (append_media_record(media, write_pos, index_entries, std::move(media_file->path),
+                            media_file->blob.data(), media_file->blob.size())) {
+      media_count++;
     }
-    buf.clear();
-    write_val<uint16_t>(buf, static_cast<uint16_t>(media_file->path.size()));
-    write_str(buf, media_file->path);
-    write_val<uint32_t>(buf, static_cast<uint32_t>(media_file->blob.size()));
-    write_bytes(buf, media_file->blob.data(), media_file->blob.size());
-    media.write(buf.data(), static_cast<std::streamsize>(buf.size()));
-    write_pos += static_cast<uint32_t>(buf.size());
-
-    index_entries.emplace_back(std::move(media_file->path), record_start);
-    media_count++;
   }
 
-  std::ranges::sort(index_entries);
-  std::vector<char> index_buf;
-  write_val<uint32_t>(index_buf, static_cast<uint32_t>(index_entries.size()));
-  for (const auto& [name, offset] : index_entries) {
-    write_val<uint64_t>(index_buf, offset);
-  }
-
-  media_idx.write(index_buf.data(), static_cast<std::streamsize>(index_buf.size()));
+  write_media_idx(media_idx, index_entries);
   return media_count;
+}
+
+// Import an .mdd (MDX media companion) into an already-written dictionary
+// directory, producing media.bin/media.idx that the query side + popup image://
+// scheme consume unchanged. Media failure never aborts the host dictionary.
+size_t import_mdd_into(const std::string& mdd_path, const std::string& dict_dir) {
+  std::ifstream f(hoshi::fs_path(mdd_path), std::ios::binary | std::ios::ate);
+  if (!f) return 0;
+  auto n = f.tellg();
+  if (n <= 0) return 0;
+  std::vector<uint8_t> data(static_cast<size_t>(n));
+  f.seekg(0);
+  f.read(reinterpret_cast<char*>(data.data()), static_cast<std::streamsize>(n));
+
+  std::vector<MddEntry> media;
+  try {
+    media = mdx_reader::parse_mdd(data.data(), data.size());
+  } catch (const std::exception& e) {
+    HOSHI_LOGW("mdd parse failed (%s), continuing without media", e.what());
+    return 0;
+  }
+  if (media.empty()) return 0;
+
+  std::ofstream mbin(hoshi::fs_path(dict_dir + "/media.bin"), std::ios::binary);
+  std::ofstream midx(hoshi::fs_path(dict_dir + "/media.idx"), std::ios::binary);
+  setup_stream_exceptions(mbin);
+  setup_stream_exceptions(midx);
+
+  size_t count = 0;
+  uint32_t write_pos = 0;
+  std::vector<std::pair<std::string, uint32_t>> index_entries;
+  for (auto& m : media) {
+    if (append_media_record(mbin, write_pos, index_entries, std::move(m.path), m.blob.data(),
+                            m.blob.size())) {
+      count++;
+    }
+  }
+  write_media_idx(midx, index_entries);
+  return count;
 }
 
 ProcessedFile process_simple_entries(const std::vector<SimpleEntry>& entries) {
@@ -963,28 +1018,67 @@ ImportResult import_mdx(const std::string& mdx_path, const std::string& output_d
   // the definitions render unstyled. Absent sibling -> empty -> no styles.css.
   std::string styles_css = read_sibling_css(mdx_path);
 
-  return dictionary_importer::write_simple_dict(title, entries, output_dir, styles_css);
+  ImportResult result = dictionary_importer::write_simple_dict(title, entries, output_dir, styles_css);
+
+  // Auto-mount the media companion (Foo.mdx -> Foo.mdd) into the same dict dir,
+  // so <img>/<link> in the glossaries resolve via the image:// media scheme.
+  // Media is best-effort: a missing/broken .mdd never fails the dictionary.
+  if (result.success) {
+    auto mdd_path = hoshi::fs_path(mdx_path);
+    mdd_path.replace_extension(".mdd");
+    if (std::filesystem::exists(mdd_path)) {
+      import_mdd_into(hoshi::fs_to_utf8(mdd_path), output_dir + "/" + result.title);
+    }
+  }
+
+  return result;
 }
 
 ImportResult import_mdx_from_zip(Zip& zip, const std::string& output_dir) {
+  int mdx_index = -1;
   for (size_t i = 0; i < zip.entries.size(); i++) {
     const auto& name = zip.entries[i].name;
     if (name.size() > 4 && name.substr(name.size() - 4) == ".mdx") {
-      std::string temp_dir = output_dir + "/_mdx_temp";
-      std::filesystem::create_directories(hoshi::fs_path(temp_dir));
-      std::string temp_path = temp_dir + "/" + hoshi::fs_to_utf8(hoshi::fs_path(name).filename());
-      {
-        std::string content = zip.read(static_cast<int>(i));
-        std::ofstream out(hoshi::fs_path(temp_path), std::ios::binary);
-        setup_stream_exceptions(out);
-        out.write(content.data(), static_cast<std::streamsize>(content.size()));
-      }
-      auto result = import_mdx(temp_path, output_dir);
-      std::filesystem::remove_all(hoshi::fs_path(temp_dir));
-      return result;
+      mdx_index = static_cast<int>(i);
+      break;
     }
   }
-  return {.success = false, .errors = {"no .mdx file found in zip"}};
+  if (mdx_index < 0) {
+    return {.success = false, .errors = {"no .mdx file found in zip"}};
+  }
+
+  std::string temp_dir = output_dir + "/_mdx_temp";
+  std::filesystem::create_directories(hoshi::fs_path(temp_dir));
+
+  std::string mdx_filename = hoshi::fs_to_utf8(hoshi::fs_path(zip.entries[mdx_index].name).filename());
+  std::string stem = hoshi::fs_to_utf8(hoshi::fs_path(mdx_filename).stem());
+  std::string temp_path = temp_dir + "/" + mdx_filename;
+
+  auto extract = [&](int idx, const std::string& out_name) {
+    std::string content = zip.read(idx);
+    std::ofstream out(hoshi::fs_path(temp_dir + "/" + out_name), std::ios::binary);
+    setup_stream_exceptions(out);
+    out.write(content.data(), static_cast<std::streamsize>(content.size()));
+  };
+
+  // Extract the .mdx plus its sibling media (.mdd) / stylesheet (.css), renamed
+  // to share the .mdx stem, so import_mdx's sibling auto-mount finds them.
+  extract(mdx_index, mdx_filename);
+  for (size_t i = 0; i < zip.entries.size(); i++) {
+    if (static_cast<int>(i) == mdx_index) continue;
+    const auto& name = zip.entries[i].name;
+    if (name.empty() || name.back() == '/') continue;
+    std::string fn = hoshi::fs_to_utf8(hoshi::fs_path(name).filename());
+    std::string ext = hoshi::fs_to_utf8(hoshi::fs_path(fn).extension());
+    std::string fstem = hoshi::fs_to_utf8(hoshi::fs_path(fn).stem());
+    if ((ext == ".mdd" || ext == ".css") && fstem == stem) {
+      extract(static_cast<int>(i), stem + ext);
+    }
+  }
+
+  auto result = import_mdx(temp_path, output_dir);
+  std::filesystem::remove_all(hoshi::fs_path(temp_dir));
+  return result;
 }
 
 ImportResult import_stardict(const std::string& ifo_path, const std::string& output_dir) {

--- a/native/hoshidicts/hoshidicts_src/mdx/mdx_reader.cpp
+++ b/native/hoshidicts/hoshidicts_src/mdx/mdx_reader.cpp
@@ -3,6 +3,7 @@
 #include <libdeflate.h>
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <stdexcept>
 #include <string_view>
@@ -22,6 +23,107 @@ inline uint64_t be64(const uint8_t* p) { return (uint64_t(be32(p)) << 32) | be32
 
 inline uint32_t le32(const uint8_t* p) {
   return p[0] | (uint32_t(p[1]) << 8) | (uint32_t(p[2]) << 16) | (uint32_t(p[3]) << 24);
+}
+
+// --- MDX Encrypted="2" key-block-info obfuscation ---------------------------
+// MDict scrambles the (already zlib-compressed) key-block-info section with a
+// self-contained algorithm that needs no registration key: a RIPEMD-128 hash
+// of the section's own adler32 bytes seeds a rolling XOR/nibble-swap cipher.
+// Without undoing it, libdeflate sees garbage and the parse dies with
+// "empty key block info". This is bit 1 of the header's `Encrypted` attribute;
+// bit 0 (record encryption) genuinely needs a purchased key and is left alone.
+
+inline uint32_t rol32(uint32_t x, unsigned s) { return (x << s) | (x >> (32 - s)); }
+
+// RIPEMD-128 (16-byte digest). Follows the reference from
+// homes.esat.kuleuven.be/~bosselae/ripemd/rmd128.txt.
+std::array<uint8_t, 16> ripemd128(const uint8_t* msg, size_t len) {
+  static const unsigned rr[64] = {
+      0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 7,  4,  13, 1,  10, 6,
+      15, 3,  12, 0,  9,  5,  2,  14, 11, 8,  3,  10, 14, 4,  9,  15, 8,  1,  2,  7,  0,  6,
+      13, 11, 5,  12, 1,  9,  11, 10, 0,  8,  12, 4,  13, 3,  7,  15, 14, 5,  6,  2};
+  static const unsigned rrp[64] = {
+      5,  14, 7,  0,  9,  2,  11, 4,  13, 6,  15, 8,  1,  10, 3,  12, 6,  11, 3,  7,  0,  13,
+      5,  10, 14, 15, 8,  12, 4,  9,  1,  2,  15, 5,  1,  3,  7,  14, 6,  9,  11, 8,  12, 2,
+      10, 0,  4,  13, 8,  6,  4,  1,  3,  11, 15, 0,  5,  12, 2,  13, 9,  7,  10, 14};
+  static const unsigned ss[64] = {
+      11, 14, 15, 12, 5,  8,  7,  9,  11, 13, 14, 15, 6,  7,  9,  8,  7,  6,  8,  13, 11, 9,
+      7,  15, 7,  12, 15, 9,  11, 7,  13, 12, 11, 13, 6,  7,  14, 9,  13, 15, 14, 8,  13, 6,
+      5,  12, 7,  5,  11, 12, 14, 15, 14, 15, 9,  8,  9,  14, 5,  6,  8,  6,  5,  12};
+  static const unsigned ssp[64] = {
+      8,  9,  9,  11, 13, 15, 15, 5,  7,  7,  8,  11, 14, 14, 12, 6,  9,  13, 15, 7,  12, 8,
+      9,  11, 7,  7,  12, 7,  6,  15, 13, 11, 9,  7,  15, 11, 8,  6,  6,  14, 12, 13, 5,  14,
+      13, 13, 7,  5,  15, 5,  8,  11, 14, 14, 6,  14, 6,  9,  12, 9,  12, 5,  15, 8};
+
+  auto f = [](int j, uint32_t x, uint32_t y, uint32_t z) -> uint32_t {
+    if (j < 16) return x ^ y ^ z;
+    if (j < 32) return (x & y) | (~x & z);
+    if (j < 48) return (x | ~y) ^ z;
+    return (x & z) | (y & ~z);
+  };
+  auto K = [](int j) -> uint32_t {
+    if (j < 16) return 0x00000000u;
+    if (j < 32) return 0x5a827999u;
+    if (j < 48) return 0x6ed9eba1u;
+    return 0x8f1bbcdcu;
+  };
+  auto Kp = [](int j) -> uint32_t {
+    if (j < 16) return 0x50a28be6u;
+    if (j < 32) return 0x5c4dd124u;
+    if (j < 48) return 0x6d703ef3u;
+    return 0x00000000u;
+  };
+
+  // Pad: 0x80, then zeros to 56 mod 64, then 64-bit little-endian bit length.
+  std::vector<uint8_t> buf(msg, msg + len);
+  uint64_t bit_len = uint64_t(len) * 8;
+  buf.push_back(0x80);
+  while (buf.size() % 64 != 56) buf.push_back(0x00);
+  for (int i = 0; i < 8; i++) buf.push_back(uint8_t((bit_len >> (8 * i)) & 0xff));
+
+  uint32_t h0 = 0x67452301u, h1 = 0xefcdab89u, h2 = 0x98badcfeu, h3 = 0x10325476u;
+  for (size_t chunk = 0; chunk < buf.size(); chunk += 64) {
+    uint32_t X[16];
+    for (int i = 0; i < 16; i++) X[i] = le32(buf.data() + chunk + i * 4);
+    uint32_t A = h0, B = h1, C = h2, D = h3;
+    uint32_t Ap = h0, Bp = h1, Cp = h2, Dp = h3;
+    for (int j = 0; j < 64; j++) {
+      uint32_t t = rol32(A + f(j, B, C, D) + X[rr[j]] + K(j), ss[j]);
+      A = D;
+      D = C;
+      C = B;
+      B = t;
+      t = rol32(Ap + f(63 - j, Bp, Cp, Dp) + X[rrp[j]] + Kp(j), ssp[j]);
+      Ap = Dp;
+      Dp = Cp;
+      Cp = Bp;
+      Bp = t;
+    }
+    uint32_t t = h1 + C + Dp;
+    h1 = h2 + D + Ap;
+    h2 = h3 + A + Bp;
+    h3 = h0 + B + Cp;
+    h0 = t;
+  }
+
+  std::array<uint8_t, 16> out{};
+  uint32_t hs[4] = {h0, h1, h2, h3};
+  for (int i = 0; i < 4; i++)
+    for (int b = 0; b < 4; b++) out[i * 4 + b] = uint8_t((hs[i] >> (8 * b)) & 0xff);
+  return out;
+}
+
+// In-place undo of the MDX key-block-info cipher (rolling nibble-swap XOR).
+void mdx_fast_decrypt(uint8_t* data, size_t len, const uint8_t* key, size_t key_len) {
+  if (key_len == 0) return;
+  uint8_t prev = 0x36;
+  for (size_t i = 0; i < len; i++) {
+    uint8_t b = data[i];
+    uint8_t t = uint8_t((b >> 4) | (b << 4));
+    t = uint8_t(t ^ prev ^ uint8_t(i & 0xff) ^ key[i % key_len]);
+    prev = b;
+    data[i] = t;
+  }
 }
 
 std::string utf16le_to_utf8(const uint8_t* data, size_t byte_len) {
@@ -113,6 +215,24 @@ MdxResult mdx_reader::parse(const uint8_t* data, size_t size) {
   result.encoding = get_attribute(header_text, "Encoding");
   if (result.encoding.empty()) result.encoding = "utf-8";
 
+  // `Encrypted` is a bitfield: bit 1 (value 2) scrambles the key-block-info
+  // section (undoable, no key needed); bit 0 (value 1) encrypts record blocks
+  // and requires a purchased registration key we cannot supply. Older dicts
+  // wrote "No"/"Yes"; treat "Yes" as bit 0.
+  int encrypted = 0;
+  {
+    std::string enc = get_attribute(header_text, "Encrypted");
+    if (enc == "Yes" || enc == "yes") {
+      encrypted = 1;
+    } else if (!enc.empty()) {
+      try {
+        encrypted = std::stoi(enc);
+      } catch (...) {
+        encrypted = 0;
+      }
+    }
+  }
+
   // Normalize encoding
   std::string enc_lower = result.encoding;
   std::transform(enc_lower.begin(), enc_lower.end(), enc_lower.begin(), ::tolower);
@@ -164,17 +284,30 @@ MdxResult mdx_reader::parse(const uint8_t* data, size_t size) {
 
   if (pos + key_block_info_size > size) throw std::runtime_error("mdx: key block info overflow");
 
-  // Decompress key block info
+  // Decompress key block info. When Encrypted="2", the compressed payload
+  // (everything after the 8-byte comp_type+adler32 prefix) is scrambled and
+  // must be unscrambled before libdeflate can inflate it. The RIPEMD-128 key is
+  // derived from the section's own adler32 bytes [4..8) plus the fixed 0x3695
+  // little-endian salt.
   std::vector<uint8_t> key_block_info;
+  std::vector<uint8_t> kbi_plain;  // holds the decrypted section if needed
+  const uint8_t* kbi_ptr = data + pos;
+  if ((encrypted & 2) && key_block_info_size >= 8) {
+    kbi_plain.assign(data + pos, data + pos + key_block_info_size);
+    uint8_t seed[8] = {kbi_plain[4], kbi_plain[5], kbi_plain[6], kbi_plain[7], 0x95, 0x36, 0x00, 0x00};
+    auto key = ripemd128(seed, 8);
+    mdx_fast_decrypt(kbi_plain.data() + 8, kbi_plain.size() - 8, key.data(), key.size());
+    kbi_ptr = kbi_plain.data();
+  }
   if (is_v2 && key_block_info_size >= 8) {
-    uint32_t comp_type = le32(data + pos);
+    uint32_t comp_type = le32(kbi_ptr);
     if (comp_type == 2 || comp_type == 1) {
-      key_block_info = decompress_block(data + pos, key_block_info_size, key_block_info_decomp_size);
+      key_block_info = decompress_block(kbi_ptr, key_block_info_size, key_block_info_decomp_size);
     } else {
-      key_block_info.assign(data + pos, data + pos + key_block_info_size);
+      key_block_info.assign(kbi_ptr, kbi_ptr + key_block_info_size);
     }
   } else {
-    key_block_info.assign(data + pos, data + pos + key_block_info_size);
+    key_block_info.assign(kbi_ptr, kbi_ptr + key_block_info_size);
   }
   pos += key_block_info_size;
 

--- a/native/hoshidicts/hoshidicts_src/mdx/mdx_reader.cpp
+++ b/native/hoshidicts/hoshidicts_src/mdx/mdx_reader.cpp
@@ -189,8 +189,23 @@ struct BlockMeta {
 
 }  // namespace
 
-MdxResult mdx_reader::parse(const uint8_t* data, size_t size) {
-  MdxResult result;
+namespace {
+
+struct ContainerData {
+  std::string title;
+  std::string encoding;
+  int version_major = 0;
+  int version_minor = 0;
+  bool is_utf16 = false;
+  std::vector<KeyEntry> keys;
+  std::vector<uint8_t> all_records;
+};
+
+// Parse the MDX/MDD container down to decoded keys + the concatenated raw record
+// stream. Shared by parse() (text records) and parse_mdd() (binary records) --
+// they differ only in how each record slice is interpreted afterwards.
+ContainerData parse_container(const uint8_t* data, size_t size) {
+  ContainerData result;
   if (size < 8) throw std::runtime_error("mdx: file too small");
 
   size_t pos = 0;
@@ -499,24 +514,41 @@ MdxResult mdx_reader::parse(const uint8_t* data, size_t size) {
     pos += meta.compressed_size;
   }
 
-  // Build entries
-  result.entries.reserve(keys.size());
-  for (size_t i = 0; i < keys.size(); i++) {
-    uint64_t start = keys[i].record_offset;
-    uint64_t end = (i + 1 < keys.size()) ? keys[i + 1].record_offset : all_records.size();
+  result.is_utf16 = is_utf16;
+  result.keys = std::move(keys);
+  result.all_records = std::move(all_records);
+  return result;
+}
 
-    if (start >= all_records.size() || end > all_records.size() || start >= end) continue;
+}  // namespace
+
+MdxResult mdx_reader::parse(const uint8_t* data, size_t size) {
+  ContainerData c = parse_container(data, size);
+
+  MdxResult result;
+  result.title = std::move(c.title);
+  result.encoding = std::move(c.encoding);
+  result.version_major = c.version_major;
+  result.version_minor = c.version_minor;
+
+  // Build entries: each record slice is a text (HTML) definition.
+  result.entries.reserve(c.keys.size());
+  for (size_t i = 0; i < c.keys.size(); i++) {
+    uint64_t start = c.keys[i].record_offset;
+    uint64_t end = (i + 1 < c.keys.size()) ? c.keys[i + 1].record_offset : c.all_records.size();
+
+    if (start >= c.all_records.size() || end > c.all_records.size() || start >= end) continue;
 
     std::string definition;
-    if (is_utf16) {
-      definition = utf16le_to_utf8(all_records.data() + start, end - start);
+    if (c.is_utf16) {
+      definition = utf16le_to_utf8(c.all_records.data() + start, end - start);
     } else {
-      definition.assign(reinterpret_cast<const char*>(all_records.data() + start), end - start);
+      definition.assign(reinterpret_cast<const char*>(c.all_records.data() + start), end - start);
     }
 
     while (!definition.empty() && definition.back() == '\0') definition.pop_back();
 
-    result.entries.push_back({std::move(keys[i].headword), std::move(definition)});
+    result.entries.push_back({std::move(c.keys[i].headword), std::move(definition)});
   }
 
   // Resolve @@@LINK= redirects (follow chains up to 10 hops)
@@ -541,4 +573,25 @@ MdxResult mdx_reader::parse(const uint8_t* data, size_t size) {
   }
 
   return result;
+}
+
+std::vector<MddEntry> mdx_reader::parse_mdd(const uint8_t* data, size_t size) {
+  ContainerData c = parse_container(data, size);
+
+  // Each record slice is a raw binary file (image/audio/css/font); the key is
+  // its path. Keep bytes verbatim -- no transcoding, no trailing-NUL stripping
+  // (a PNG/JPEG legitimately ends in NUL bytes), no @@@LINK resolution.
+  std::vector<MddEntry> out;
+  out.reserve(c.keys.size());
+  for (size_t i = 0; i < c.keys.size(); i++) {
+    uint64_t start = c.keys[i].record_offset;
+    uint64_t end = (i + 1 < c.keys.size()) ? c.keys[i + 1].record_offset : c.all_records.size();
+
+    if (start >= c.all_records.size() || end > c.all_records.size() || start >= end) continue;
+
+    out.push_back(MddEntry{std::move(c.keys[i].headword),
+                           std::string(reinterpret_cast<const char*>(c.all_records.data() + start),
+                                       static_cast<size_t>(end - start))});
+  }
+  return out;
 }

--- a/native/hoshidicts/hoshidicts_src/mdx/mdx_reader.hpp
+++ b/native/hoshidicts/hoshidicts_src/mdx/mdx_reader.hpp
@@ -17,6 +17,17 @@ struct MdxResult {
   std::vector<MdxEntry> entries;
 };
 
+// One resource inside an .mdd container: `path` is the (normalized-later) file
+// path key, `blob` holds the raw bytes verbatim (image/audio/css/font).
+struct MddEntry {
+  std::string path;
+  std::string blob;
+};
+
 namespace mdx_reader {
 MdxResult parse(const uint8_t* data, size_t size);
+// Parse an .mdd (same container as .mdx, but records are binary files keyed by
+// path). Records are returned byte-exact: no text transcoding, no trailing-NUL
+// stripping, no @@@LINK resolution.
+std::vector<MddEntry> parse_mdd(const uint8_t* data, size_t size);
 }

--- a/native/hoshidicts/tests/CMakeLists.txt
+++ b/native/hoshidicts/tests/CMakeLists.txt
@@ -84,6 +84,13 @@ add_hoshi_test(zip_malformed_deflate_test zip_malformed_deflate_test.cpp
 add_hoshi_test(zip_high_ratio_bank_test zip_high_ratio_bank_test.cpp
     "${HOSHI_SRC}"
     "${HOSHI_ROOT}/hoshidicts_external/libdeflate")
+# BUG-723: MDX Encrypted="2" key-block-info must be unscrambled (RIPEMD-128 +
+# rolling XOR) before inflate. Builds a self-contained encrypted MDX fixture
+# and asserts the reader recovers its entries. Needs mdx_reader.hpp (mdx/ is an
+# internal subdir) and libdeflate (to compress the fixture's blocks).
+add_hoshi_test(mdx_encrypted_keyinfo_test mdx_encrypted_keyinfo_test.cpp
+    "${HOSHI_SRC}/mdx"
+    "${HOSHI_ROOT}/hoshidicts_external/libdeflate")
 # import_breadcrumb_test includes "util/import_breadcrumb.hpp" rooted at
 # hoshidicts_src/.
 add_hoshi_test(import_breadcrumb_test import_breadcrumb_test.cpp

--- a/native/hoshidicts/tests/CMakeLists.txt
+++ b/native/hoshidicts/tests/CMakeLists.txt
@@ -69,6 +69,9 @@ add_hoshi_test(media_import_query_test media_import_query_test.cpp)
 add_hoshi_test(freq_pitch_import_query_test freq_pitch_import_query_test.cpp)
 add_hoshi_test(freq_pitch_merge_query_test freq_pitch_merge_query_test.cpp)
 add_hoshi_test(ipa_import_query_test ipa_import_query_test.cpp)
+# Simple dicts (MDX/StarDict/DSL) store rules="*" so filter_by_pos keeps them
+# for inflected-form lookups; pins pos_to_conditions("*")==~0 + the stored rule.
+add_hoshi_test(simple_dict_deinflection_test simple_dict_deinflection_test.cpp)
 
 # --- TODO-892: malformed-DEFLATE / null-decompressor / breadcrumb guards ---
 # zip_malformed_deflate_test includes <libdeflate.h> (to forge a real deflate

--- a/native/hoshidicts/tests/CMakeLists.txt
+++ b/native/hoshidicts/tests/CMakeLists.txt
@@ -94,6 +94,10 @@ add_hoshi_test(zip_high_ratio_bank_test zip_high_ratio_bank_test.cpp
 add_hoshi_test(mdx_encrypted_keyinfo_test mdx_encrypted_keyinfo_test.cpp
     "${HOSHI_SRC}/mdx"
     "${HOSHI_ROOT}/hoshidicts_external/libdeflate")
+# BUG-719 Phase B: import_mdx inlines a sibling <base>.css as the dict styles.css.
+# Builds a real on-disk MDX (mdx_fixture.hpp) + sibling .css and asserts it lands.
+add_hoshi_test(simple_dict_css_test simple_dict_css_test.cpp
+    "${HOSHI_ROOT}/hoshidicts_external/libdeflate")
 # import_breadcrumb_test includes "util/import_breadcrumb.hpp" rooted at
 # hoshidicts_src/.
 add_hoshi_test(import_breadcrumb_test import_breadcrumb_test.cpp

--- a/native/hoshidicts/tests/CMakeLists.txt
+++ b/native/hoshidicts/tests/CMakeLists.txt
@@ -98,6 +98,11 @@ add_hoshi_test(mdx_encrypted_keyinfo_test mdx_encrypted_keyinfo_test.cpp
 # Builds a real on-disk MDX (mdx_fixture.hpp) + sibling .css and asserts it lands.
 add_hoshi_test(simple_dict_css_test simple_dict_css_test.cpp
     "${HOSHI_ROOT}/hoshidicts_external/libdeflate")
+# Phase A: MDD (MDX media companion) parses byte-exact and auto-mounts into the
+# dict as media.bin/idx; get_media_file returns the bytes by normalized path.
+add_hoshi_test(mdd_media_import_test mdd_media_import_test.cpp
+    "${HOSHI_SRC}/mdx"
+    "${HOSHI_ROOT}/hoshidicts_external/libdeflate")
 # import_breadcrumb_test includes "util/import_breadcrumb.hpp" rooted at
 # hoshidicts_src/.
 add_hoshi_test(import_breadcrumb_test import_breadcrumb_test.cpp

--- a/native/hoshidicts/tests/mdd_media_import_test.cpp
+++ b/native/hoshidicts/tests/mdd_media_import_test.cpp
@@ -1,0 +1,95 @@
+// MDD is the MDX media companion (same container, binary records keyed by file
+// path). This test covers two levels:
+//   1) mdx_reader::parse_mdd returns each record byte-exact (incl. embedded NUL)
+//      with its raw path key -- no transcoding, no NUL stripping, no @@@LINK.
+//   2) end-to-end: importing Foo.mdx auto-mounts a sibling Foo.mdd into the same
+//      dictionary dir, and DictionaryQuery::get_media_file returns the bytes via
+//      the normalized path -- exactly the image:// scheme the popup consumes.
+//
+// Red/green: revert parse_mdd (binary records) or import_mdx's sibling mount and
+// the retrieved blob is empty / wrong -> FAIL.
+//
+// Usage: mdd_media_import_test  (no args) -> exit 0 PASS, non-zero FAIL.
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "hoshidicts/importer.hpp"
+#include "hoshidicts/query.hpp"
+#include "mdx_fixture.hpp"
+#include "mdx_reader.hpp"
+#include "zip_fixture.hpp"
+
+namespace {
+int g_fail = 0;
+void fail(const char* msg) {
+  std::fprintf(stderr, "FAIL: %s\n", msg);
+  ++g_fail;
+}
+
+void write_file(const std::string& path, const std::vector<uint8_t>& bytes) {
+  std::ofstream f(std::filesystem::u8path(path), std::ios::binary);
+  f.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+}
+}  // namespace
+
+int main() {
+  // A fake PNG blob with an embedded NUL and a high byte, to prove byte-exact
+  // handling (a real image legitimately contains 0x00).
+  const std::string png("\x89PNG\x0D\x0A\x1A\x0A\x00\x01\xFF\x00T", 14);
+  const std::string mdd_key = "\\img\\a.png";  // real MDD keys use backslashes
+
+  // --- Part 1: parse_mdd byte-exactness -----------------------------------
+  {
+    auto mdd_bytes = mdx_fixture::build_mdd_plain("MediaDict", {{mdd_key, png}});
+    auto media = mdx_reader::parse_mdd(mdd_bytes.data(), mdd_bytes.size());
+    if (media.size() != 1) {
+      fail("parse_mdd expected 1 record");
+    } else {
+      if (media[0].path != mdd_key) {
+        std::fprintf(stderr, "FAIL parse_mdd path: got '%s' want '%s'\n", media[0].path.c_str(),
+                     mdd_key.c_str());
+        ++g_fail;
+      }
+      if (media[0].blob != png) {
+        std::fprintf(stderr, "FAIL parse_mdd blob byte-exactness (got %zu bytes want %zu)\n",
+                     media[0].blob.size(), png.size());
+        ++g_fail;
+      }
+    }
+  }
+
+  // --- Part 2: import Foo.mdx + sibling Foo.mdd -> queryable media ---------
+  const std::string base = hoshi_test::temp_dir() + "/hoshi_mdd";
+  std::filesystem::create_directories(std::filesystem::u8path(base));
+  const std::string mdx_path = base + "/M.mdx";
+  const std::string mdd_path = base + "/M.mdd";
+  const std::string out_dir = base + "/out";
+
+  write_file(mdx_path,
+             mdx_fixture::build_mdx_plain("MediaDict", {{"apple", "<img src=\"img/a.png\">def"}}));
+  write_file(mdd_path, mdx_fixture::build_mdd_plain("MediaDict", {{mdd_key, png}}));
+
+  ImportResult r = dictionary_importer::import(mdx_path, out_dir);
+  if (!r.success) {
+    fail(r.errors.empty() ? "import failed" : r.errors.front().c_str());
+  } else {
+    DictionaryQuery q;
+    q.add_term_dict(out_dir + "/" + r.title);
+    std::vector<char> blob = q.get_media_file(r.title, "img/a.png");
+    if (blob.empty()) {
+      fail("get_media_file returned empty (mdd not mounted / path not normalized)");
+    } else if (std::string(blob.begin(), blob.end()) != png) {
+      fail("get_media_file returned wrong bytes");
+    }
+  }
+
+  if (g_fail) {
+    std::fprintf(stderr, "%d FAIL\n", g_fail);
+    return 1;
+  }
+  std::printf("PASS\n");
+  return 0;
+}

--- a/native/hoshidicts/tests/mdx_encrypted_keyinfo_test.cpp
+++ b/native/hoshidicts/tests/mdx_encrypted_keyinfo_test.cpp
@@ -1,0 +1,266 @@
+// BUG-723: MDX dictionaries with Encrypted="2" (key-block-info obfuscation)
+// failed to import with "mdx: empty key block info" because mdx_reader fed the
+// scrambled section straight to libdeflate. This test builds a self-contained
+// Encrypted="2" MDX v2 fixture in memory -- scrambling its key-block-info with
+// the exact MDict RIPEMD-128 + rolling-XOR cipher the reader must undo -- and
+// asserts mdx_reader::parse recovers the headwords and definitions.
+//
+// The fixture builder reimplements RIPEMD-128 and the cipher independently of
+// the reader, so a transcription error in the reader's copy yields a wrong key,
+// garbage after decrypt, a failed inflate, and zero entries -> the assertions
+// fire. It therefore transitively pins the reader's RIPEMD-128 correctness.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <libdeflate.h>
+
+#include "mdx_reader.hpp"
+
+namespace {
+
+void put_be16(std::vector<uint8_t>& v, uint16_t x) {
+  v.push_back(uint8_t(x >> 8));
+  v.push_back(uint8_t(x & 0xff));
+}
+void put_be32(std::vector<uint8_t>& v, uint32_t x) {
+  for (int i = 3; i >= 0; i--) v.push_back(uint8_t((x >> (8 * i)) & 0xff));
+}
+void put_be64(std::vector<uint8_t>& v, uint64_t x) {
+  for (int i = 7; i >= 0; i--) v.push_back(uint8_t((x >> (8 * i)) & 0xff));
+}
+void put_le32(std::vector<uint8_t>& v, uint32_t x) {
+  for (int i = 0; i < 4; i++) v.push_back(uint8_t((x >> (8 * i)) & 0xff));
+}
+
+// --- RIPEMD-128, independent reimplementation (see reader for reference) ---
+uint32_t rol32(uint32_t x, unsigned s) { return (x << s) | (x >> (32 - s)); }
+std::vector<uint8_t> ripemd128(const std::vector<uint8_t>& msg) {
+  static const unsigned rr[64] = {
+      0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 7,  4,  13, 1,  10, 6,
+      15, 3,  12, 0,  9,  5,  2,  14, 11, 8,  3,  10, 14, 4,  9,  15, 8,  1,  2,  7,  0,  6,
+      13, 11, 5,  12, 1,  9,  11, 10, 0,  8,  12, 4,  13, 3,  7,  15, 14, 5,  6,  2};
+  static const unsigned rrp[64] = {
+      5,  14, 7,  0,  9,  2,  11, 4,  13, 6,  15, 8,  1,  10, 3,  12, 6,  11, 3,  7,  0,  13,
+      5,  10, 14, 15, 8,  12, 4,  9,  1,  2,  15, 5,  1,  3,  7,  14, 6,  9,  11, 8,  12, 2,
+      10, 0,  4,  13, 8,  6,  4,  1,  3,  11, 15, 0,  5,  12, 2,  13, 9,  7,  10, 14};
+  static const unsigned ss[64] = {
+      11, 14, 15, 12, 5,  8,  7,  9,  11, 13, 14, 15, 6,  7,  9,  8,  7,  6,  8,  13, 11, 9,
+      7,  15, 7,  12, 15, 9,  11, 7,  13, 12, 11, 13, 6,  7,  14, 9,  13, 15, 14, 8,  13, 6,
+      5,  12, 7,  5,  11, 12, 14, 15, 14, 15, 9,  8,  9,  14, 5,  6,  8,  6,  5,  12};
+  static const unsigned ssp[64] = {
+      8,  9,  9,  11, 13, 15, 15, 5,  7,  7,  8,  11, 14, 14, 12, 6,  9,  13, 15, 7,  12, 8,
+      9,  11, 7,  7,  12, 7,  6,  15, 13, 11, 9,  7,  15, 11, 8,  6,  6,  14, 12, 13, 5,  14,
+      13, 13, 7,  5,  15, 5,  8,  11, 14, 14, 6,  14, 6,  9,  12, 9,  12, 5,  15, 8};
+  auto f = [](int j, uint32_t x, uint32_t y, uint32_t z) -> uint32_t {
+    if (j < 16) return x ^ y ^ z;
+    if (j < 32) return (x & y) | (~x & z);
+    if (j < 48) return (x | ~y) ^ z;
+    return (x & z) | (y & ~z);
+  };
+  auto K = [](int j) -> uint32_t {
+    if (j < 16) return 0x00000000u;
+    if (j < 32) return 0x5a827999u;
+    if (j < 48) return 0x6ed9eba1u;
+    return 0x8f1bbcdcu;
+  };
+  auto Kp = [](int j) -> uint32_t {
+    if (j < 16) return 0x50a28be6u;
+    if (j < 32) return 0x5c4dd124u;
+    if (j < 48) return 0x6d703ef3u;
+    return 0x00000000u;
+  };
+  std::vector<uint8_t> buf = msg;
+  uint64_t bit_len = uint64_t(msg.size()) * 8;
+  buf.push_back(0x80);
+  while (buf.size() % 64 != 56) buf.push_back(0x00);
+  for (int i = 0; i < 8; i++) buf.push_back(uint8_t((bit_len >> (8 * i)) & 0xff));
+  uint32_t h0 = 0x67452301u, h1 = 0xefcdab89u, h2 = 0x98badcfeu, h3 = 0x10325476u;
+  for (size_t chunk = 0; chunk < buf.size(); chunk += 64) {
+    uint32_t X[16];
+    for (int i = 0; i < 16; i++) {
+      const uint8_t* p = buf.data() + chunk + i * 4;
+      X[i] = p[0] | (uint32_t(p[1]) << 8) | (uint32_t(p[2]) << 16) | (uint32_t(p[3]) << 24);
+    }
+    uint32_t A = h0, B = h1, C = h2, D = h3, Ap = h0, Bp = h1, Cp = h2, Dp = h3;
+    for (int j = 0; j < 64; j++) {
+      uint32_t t = rol32(A + f(j, B, C, D) + X[rr[j]] + K(j), ss[j]);
+      A = D; D = C; C = B; B = t;
+      t = rol32(Ap + f(63 - j, Bp, Cp, Dp) + X[rrp[j]] + Kp(j), ssp[j]);
+      Ap = Dp; Dp = Cp; Cp = Bp; Bp = t;
+    }
+    uint32_t t = h1 + C + Dp;
+    h1 = h2 + D + Ap;
+    h2 = h3 + A + Bp;
+    h3 = h0 + B + Cp;
+    h0 = t;
+  }
+  std::vector<uint8_t> out(16);
+  uint32_t hs[4] = {h0, h1, h2, h3};
+  for (int i = 0; i < 4; i++)
+    for (int b = 0; b < 4; b++) out[i * 4 + b] = uint8_t((hs[i] >> (8 * b)) & 0xff);
+  return out;
+}
+
+// Encrypt = inverse of the reader's mdx_fast_decrypt (nibble-swap is its own
+// inverse; chain on the *cipher* byte).
+void mdx_fast_encrypt(std::vector<uint8_t>& data, const std::vector<uint8_t>& key) {
+  uint8_t prev = 0x36;
+  for (size_t i = 0; i < data.size(); i++) {
+    uint8_t x = uint8_t(data[i] ^ prev ^ uint8_t(i & 0xff) ^ key[i % key.size()]);
+    uint8_t c = uint8_t((x >> 4) | (x << 4));
+    data[i] = c;
+    prev = c;
+  }
+}
+
+std::vector<uint8_t> zlib_compress(const std::vector<uint8_t>& in) {
+  auto* c = libdeflate_alloc_compressor(6);
+  size_t bound = libdeflate_zlib_compress_bound(c, in.size());
+  std::vector<uint8_t> out(bound);
+  size_t n = libdeflate_zlib_compress(c, in.data(), in.size(), out.data(), out.size());
+  libdeflate_free_compressor(c);
+  out.resize(n);
+  return out;
+}
+
+// comp_type(le32=2) + 4-byte checksum placeholder + zlib(payload)
+std::vector<uint8_t> make_zlib_block(const std::vector<uint8_t>& payload) {
+  std::vector<uint8_t> z = zlib_compress(payload);
+  std::vector<uint8_t> block;
+  put_le32(block, 2);              // zlib
+  put_le32(block, 0xDEADBEEF);     // checksum (reader ignores)
+  block.insert(block.end(), z.begin(), z.end());
+  return block;
+}
+
+int fail(const char* msg) {
+  std::fprintf(stderr, "FAIL: %s\n", msg);
+  return 1;
+}
+
+}  // namespace
+
+std::string hex(const std::vector<uint8_t>& v) {
+  static const char* h = "0123456789abcdef";
+  std::string s;
+  for (uint8_t b : v) {
+    s.push_back(h[b >> 4]);
+    s.push_back(h[b & 0xf]);
+  }
+  return s;
+}
+
+std::vector<uint8_t> bytes(const std::string& s) {
+  return std::vector<uint8_t>(s.begin(), s.end());
+}
+
+int main() {
+  // --- RIPEMD-128 known-answer vectors -----------------------------------
+  // Published test vectors (homes.esat.kuleuven.be/~bosselae/ripemd). This
+  // pins the fixture's RIPEMD-128 to the spec; because the fixture below only
+  // decrypts if the reader's RIPEMD-128 agrees with the fixture's, a passing
+  // suite proves the reader's RIPEMD-128 is spec-correct too.
+  if (hex(ripemd128(bytes(""))) != "cdf26213a150dc3ecb610f18f6b38b46")
+    return fail("RIPEMD-128(\"\") KAT mismatch");
+  if (hex(ripemd128(bytes("abc"))) != "c14a12199c66e4ba84636b0f69144c77")
+    return fail("RIPEMD-128(\"abc\") KAT mismatch");
+  if (hex(ripemd128(bytes("message digest"))) != "9e327b3d6e523062afc1132d7df9d1b8")
+    return fail("RIPEMD-128(\"message digest\") KAT mismatch");
+
+  // --- Two entries -> record stream + null-terminated definitions ---
+  const std::string k0 = "apple", k1 = "banana";
+  const std::string d0 = "def-apple", d1 = "def-banana";
+  std::vector<uint8_t> records;
+  uint64_t off0 = records.size();
+  records.insert(records.end(), d0.begin(), d0.end());
+  records.push_back(0);
+  uint64_t off1 = records.size();
+  records.insert(records.end(), d1.begin(), d1.end());
+  records.push_back(0);
+
+  // --- Key block (entries: be64 offset + headword + NUL) ---
+  std::vector<uint8_t> key_entries;
+  put_be64(key_entries, off0);
+  key_entries.insert(key_entries.end(), k0.begin(), k0.end());
+  key_entries.push_back(0);
+  put_be64(key_entries, off1);
+  key_entries.insert(key_entries.end(), k1.begin(), k1.end());
+  key_entries.push_back(0);
+  std::vector<uint8_t> key_block = make_zlib_block(key_entries);
+
+  // --- Key block info (one block meta), then compress + scramble ---
+  std::vector<uint8_t> kbi_plain;
+  put_be64(kbi_plain, 2);  // num entries in this key block
+  put_be16(kbi_plain, uint16_t(k0.size()));
+  kbi_plain.insert(kbi_plain.end(), k0.begin(), k0.end());
+  kbi_plain.push_back(0);
+  put_be16(kbi_plain, uint16_t(k1.size()));
+  kbi_plain.insert(kbi_plain.end(), k1.begin(), k1.end());
+  kbi_plain.push_back(0);
+  put_be64(kbi_plain, key_block.size());   // compressed size of the key block
+  put_be64(kbi_plain, key_entries.size()); // decompressed size of the key block
+
+  std::vector<uint8_t> kbi_z = zlib_compress(kbi_plain);
+  std::vector<uint8_t> kbi;
+  put_le32(kbi, 2);          // comp_type zlib
+  kbi.push_back(0x11);       // [4..8) adler bytes -- also the RIPEMD seed
+  kbi.push_back(0x22);
+  kbi.push_back(0x33);
+  kbi.push_back(0x44);
+  kbi.insert(kbi.end(), kbi_z.begin(), kbi_z.end());
+  // Scramble bytes [8..) exactly as the reader will unscramble them.
+  std::vector<uint8_t> seed = {kbi[4], kbi[5], kbi[6], kbi[7], 0x95, 0x36, 0x00, 0x00};
+  std::vector<uint8_t> key = ripemd128(seed);
+  std::vector<uint8_t> enc(kbi.begin() + 8, kbi.end());
+  mdx_fast_encrypt(enc, key);
+  std::copy(enc.begin(), enc.end(), kbi.begin() + 8);
+
+  // --- Record block info + record blocks ---
+  std::vector<uint8_t> record_block = make_zlib_block(records);
+  std::vector<uint8_t> record_block_info;
+  put_be64(record_block_info, record_block.size());
+  put_be64(record_block_info, records.size());
+
+  // --- Assemble the whole file ---
+  std::vector<uint8_t> file;
+  std::string header =
+      "<Dictionary GeneratedByEngineVersion=\"2.0\" Encrypted=\"2\" "
+      "Encoding=\"UTF-8\" Title=\"Fixture\"/>";
+  put_be32(file, uint32_t(header.size()));
+  file.insert(file.end(), header.begin(), header.end());
+  put_be32(file, 0);  // header adler (ignored)
+
+  put_be64(file, 1);                    // num key blocks
+  put_be64(file, 2);                    // num entries
+  put_be64(file, kbi_plain.size());     // key_block_info_decomp_size
+  put_be64(file, kbi.size());           // key_block_info_size
+  put_be64(file, key_block.size());     // key_blocks_size
+  put_be32(file, 0);                    // key block info adler (ignored)
+  file.insert(file.end(), kbi.begin(), kbi.end());
+  file.insert(file.end(), key_block.begin(), key_block.end());
+
+  put_be64(file, 1);                       // num record blocks
+  put_be64(file, 2);                       // num entries (ignored)
+  put_be64(file, record_block_info.size());
+  put_be64(file, record_block.size());     // record_blocks_total_size
+  file.insert(file.end(), record_block_info.begin(), record_block_info.end());
+  file.insert(file.end(), record_block.begin(), record_block.end());
+
+  // --- Parse and verify ---
+  MdxResult r = mdx_reader::parse(file.data(), file.size());
+  if (r.entries.size() != 2)
+    return fail(("expected 2 entries, got " + std::to_string(r.entries.size())).c_str());
+  if (r.entries[0].key != k0 || r.entries[0].definition != d0)
+    return fail("entry 0 mismatch");
+  if (r.entries[1].key != k1 || r.entries[1].definition != d1)
+    return fail("entry 1 mismatch");
+  if (r.title != "Fixture") return fail("title mismatch");
+
+  std::printf("OK: decrypted Encrypted=2 key-block-info, recovered %zu entries\n",
+              r.entries.size());
+  return 0;
+}

--- a/native/hoshidicts/tests/mdx_fixture.hpp
+++ b/native/hoshidicts/tests/mdx_fixture.hpp
@@ -1,0 +1,119 @@
+// Shared builder for a minimal, valid, UNENCRYPTED MDX v2 file (UTF-8 records),
+// used by tests that need a real .mdx on disk. Encrypted MDX fixtures live in
+// mdx_encrypted_keyinfo_test.cpp (they additionally exercise the RIPEMD-128
+// decrypt path). Container layout mirrors mdx_reader.cpp's parser.
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <libdeflate.h>
+
+namespace mdx_fixture {
+
+inline void put_be16(std::vector<uint8_t>& v, uint16_t x) {
+  v.push_back(uint8_t(x >> 8));
+  v.push_back(uint8_t(x & 0xff));
+}
+inline void put_be32(std::vector<uint8_t>& v, uint32_t x) {
+  for (int i = 3; i >= 0; i--) v.push_back(uint8_t((x >> (8 * i)) & 0xff));
+}
+inline void put_be64(std::vector<uint8_t>& v, uint64_t x) {
+  for (int i = 7; i >= 0; i--) v.push_back(uint8_t((x >> (8 * i)) & 0xff));
+}
+inline void put_le32(std::vector<uint8_t>& v, uint32_t x) {
+  for (int i = 0; i < 4; i++) v.push_back(uint8_t((x >> (8 * i)) & 0xff));
+}
+
+inline std::vector<uint8_t> zlib_compress(const std::vector<uint8_t>& in) {
+  auto* c = libdeflate_alloc_compressor(6);
+  size_t bound = libdeflate_zlib_compress_bound(c, in.size());
+  std::vector<uint8_t> out(bound);
+  size_t n = libdeflate_zlib_compress(c, in.data(), in.size(), out.data(), out.size());
+  libdeflate_free_compressor(c);
+  out.resize(n);
+  return out;
+}
+
+// comp_type(le32=2) + 4-byte checksum placeholder + zlib(payload)
+inline std::vector<uint8_t> make_zlib_block(const std::vector<uint8_t>& payload) {
+  std::vector<uint8_t> z = zlib_compress(payload);
+  std::vector<uint8_t> block;
+  put_le32(block, 2);            // zlib
+  put_le32(block, 0xDEADBEEF);   // checksum (reader ignores)
+  block.insert(block.end(), z.begin(), z.end());
+  return block;
+}
+
+// Build a single-key-block, single-record-block UTF-8 MDX v2 file (Encrypted=0)
+// from ordered (headword, definition) pairs. `title` becomes the <Title>.
+inline std::vector<uint8_t> build_mdx_plain(
+    const std::string& title, const std::vector<std::pair<std::string, std::string>>& entries) {
+  // Record stream: definitions concatenated, each NUL-terminated.
+  std::vector<uint8_t> records;
+  std::vector<uint64_t> offsets;
+  for (const auto& [k, d] : entries) {
+    (void)k;
+    offsets.push_back(records.size());
+    records.insert(records.end(), d.begin(), d.end());
+    records.push_back(0);
+  }
+
+  // Key block: (be64 record_offset + headword + NUL) per entry.
+  std::vector<uint8_t> key_entries;
+  for (size_t i = 0; i < entries.size(); i++) {
+    put_be64(key_entries, offsets[i]);
+    key_entries.insert(key_entries.end(), entries[i].first.begin(), entries[i].first.end());
+    key_entries.push_back(0);
+  }
+  std::vector<uint8_t> key_block = make_zlib_block(key_entries);
+
+  // Key block info (one block meta): plaintext then zlib (comp_type=2), no crypto.
+  std::vector<uint8_t> kbi_plain;
+  put_be64(kbi_plain, entries.size());  // num entries in this key block
+  const std::string& first = entries.front().first;
+  const std::string& last = entries.back().first;
+  put_be16(kbi_plain, uint16_t(first.size()));
+  kbi_plain.insert(kbi_plain.end(), first.begin(), first.end());
+  kbi_plain.push_back(0);
+  put_be16(kbi_plain, uint16_t(last.size()));
+  kbi_plain.insert(kbi_plain.end(), last.begin(), last.end());
+  kbi_plain.push_back(0);
+  put_be64(kbi_plain, key_block.size());    // compressed size of the key block
+  put_be64(kbi_plain, key_entries.size());  // decompressed size of the key block
+  std::vector<uint8_t> kbi = make_zlib_block(kbi_plain);
+
+  // Record block info + record block.
+  std::vector<uint8_t> record_block = make_zlib_block(records);
+  std::vector<uint8_t> record_block_info;
+  put_be64(record_block_info, record_block.size());
+  put_be64(record_block_info, records.size());
+
+  std::vector<uint8_t> file;
+  std::string header = "<Dictionary GeneratedByEngineVersion=\"2.0\" Encrypted=\"0\" "
+                       "Encoding=\"UTF-8\" Title=\"" + title + "\"/>";
+  put_be32(file, uint32_t(header.size()));
+  file.insert(file.end(), header.begin(), header.end());
+  put_be32(file, 0);  // header adler (ignored)
+
+  put_be64(file, 1);                    // num key blocks
+  put_be64(file, entries.size());       // num entries
+  put_be64(file, kbi_plain.size());     // key_block_info_decomp_size
+  put_be64(file, kbi.size());           // key_block_info_size
+  put_be64(file, key_block.size());     // key_blocks_size
+  put_be32(file, 0);                    // key block info adler (ignored)
+  file.insert(file.end(), kbi.begin(), kbi.end());
+  file.insert(file.end(), key_block.begin(), key_block.end());
+
+  put_be64(file, 1);                       // num record blocks
+  put_be64(file, entries.size());          // num entries (ignored)
+  put_be64(file, record_block_info.size());
+  put_be64(file, record_block.size());     // record_blocks_total_size
+  file.insert(file.end(), record_block_info.begin(), record_block_info.end());
+  file.insert(file.end(), record_block.begin(), record_block.end());
+  return file;
+}
+
+}  // namespace mdx_fixture

--- a/native/hoshidicts/tests/mdx_fixture.hpp
+++ b/native/hoshidicts/tests/mdx_fixture.hpp
@@ -47,18 +47,21 @@ inline std::vector<uint8_t> make_zlib_block(const std::vector<uint8_t>& payload)
   return block;
 }
 
-// Build a single-key-block, single-record-block UTF-8 MDX v2 file (Encrypted=0)
-// from ordered (headword, definition) pairs. `title` becomes the <Title>.
-inline std::vector<uint8_t> build_mdx_plain(
-    const std::string& title, const std::vector<std::pair<std::string, std::string>>& entries) {
-  // Record stream: definitions concatenated, each NUL-terminated.
+// Build a single-key-block, single-record-block UTF-8 MDX-family v2 container
+// (Encrypted=0) from ordered (key, record) pairs. When `null_terminate` is true
+// (MDX text records) each record is NUL-terminated; when false (MDD binary
+// files) records are concatenated byte-exact. `title` becomes the <Title>.
+inline std::vector<uint8_t> build_container(
+    const std::string& title, const std::vector<std::pair<std::string, std::string>>& entries,
+    bool null_terminate) {
+  // Record stream: records concatenated (MDX: each NUL-terminated).
   std::vector<uint8_t> records;
   std::vector<uint64_t> offsets;
   for (const auto& [k, d] : entries) {
     (void)k;
     offsets.push_back(records.size());
     records.insert(records.end(), d.begin(), d.end());
-    records.push_back(0);
+    if (null_terminate) records.push_back(0);
   }
 
   // Key block: (be64 record_offset + headword + NUL) per entry.
@@ -114,6 +117,18 @@ inline std::vector<uint8_t> build_mdx_plain(
   file.insert(file.end(), record_block_info.begin(), record_block_info.end());
   file.insert(file.end(), record_block.begin(), record_block.end());
   return file;
+}
+
+// MDX: text (HTML) records, NUL-terminated.
+inline std::vector<uint8_t> build_mdx_plain(
+    const std::string& title, const std::vector<std::pair<std::string, std::string>>& entries) {
+  return build_container(title, entries, /*null_terminate=*/true);
+}
+
+// MDD: binary file records keyed by path, byte-exact (no terminator).
+inline std::vector<uint8_t> build_mdd_plain(
+    const std::string& title, const std::vector<std::pair<std::string, std::string>>& entries) {
+  return build_container(title, entries, /*null_terminate=*/false);
 }
 
 }  // namespace mdx_fixture

--- a/native/hoshidicts/tests/simple_dict_css_test.cpp
+++ b/native/hoshidicts/tests/simple_dict_css_test.cpp
@@ -1,0 +1,71 @@
+// MDX glossaries are HTML that <link> a sibling stylesheet (Foo.mdx -> Foo.css).
+// import_mdx must inline that sibling .css as the dictionary's styles.css so the
+// popup can scope+inject it; otherwise definitions render unstyled. This test
+// writes a real .mdx + sibling .css to disk, imports, and asserts the dict's
+// styles.css exists with matching bytes.
+//
+// Red/green: revert import_mdx's read_sibling_css wiring and styles.css is
+// absent -> FAIL.
+//
+// Usage: simple_dict_css_test  (no args) -> exit 0 PASS, non-zero FAIL.
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "hoshidicts/importer.hpp"
+#include "mdx_fixture.hpp"
+#include "zip_fixture.hpp"
+
+namespace {
+int g_fail = 0;
+void fail(const char* msg) {
+  std::fprintf(stderr, "FAIL: %s\n", msg);
+  ++g_fail;
+}
+}  // namespace
+
+int main() {
+  const std::string base = hoshi_test::temp_dir() + "/hoshi_mdx_css";
+  std::filesystem::create_directories(std::filesystem::u8path(base));
+  const std::string mdx_path = base + "/CssDict.mdx";
+  const std::string css_path = base + "/CssDict.css";
+  const std::string out_dir = base + "/out";
+  const std::string css = "body{color:red}\n.hoshi{font-weight:bold}";
+
+  auto bytes = mdx_fixture::build_mdx_plain(
+      "CssDict", {{"apple", "<link rel=\"stylesheet\" href=\"CssDict.css\">def-apple"}});
+  {
+    std::ofstream f(std::filesystem::u8path(mdx_path), std::ios::binary);
+    f.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+  }
+  {
+    std::ofstream f(std::filesystem::u8path(css_path), std::ios::binary);
+    f.write(css.data(), static_cast<std::streamsize>(css.size()));
+  }
+
+  ImportResult r = dictionary_importer::import(mdx_path, out_dir);
+  if (!r.success) {
+    fail(r.errors.empty() ? "import failed" : r.errors.front().c_str());
+  } else {
+    const std::string styles_path = out_dir + "/" + r.title + "/styles.css";
+    std::ifstream sf(std::filesystem::u8path(styles_path), std::ios::binary);
+    if (!sf) {
+      fail("styles.css was not written from sibling .css");
+    } else {
+      std::string got((std::istreambuf_iterator<char>(sf)), std::istreambuf_iterator<char>());
+      if (got != css) {
+        std::fprintf(stderr, "FAIL styles.css: got '%s' want '%s'\n", got.c_str(), css.c_str());
+        ++g_fail;
+      }
+    }
+  }
+
+  if (g_fail) {
+    std::fprintf(stderr, "%d FAIL\n", g_fail);
+    return 1;
+  }
+  std::printf("PASS\n");
+  return 0;
+}

--- a/native/hoshidicts/tests/simple_dict_deinflection_test.cpp
+++ b/native/hoshidicts/tests/simple_dict_deinflection_test.cpp
@@ -1,0 +1,99 @@
+// Simple dictionaries (MDX / StarDict / DSL) carry no per-term part of speech.
+// They are stored via write_simple_dict, which used to write rules_len = 0.
+// Lookup::filter_by_pos erases any term whose POS conditions do not overlap the
+// deinflection's required conditions -- so an empty-rules term was dropped for
+// EVERY inflected-form lookup (e.g. querying 食べた never surfaced the 食べる
+// entry of an MDX/StarDict dict). Only the bare dictionary form survived.
+//
+// The fix stores the wildcard rule "*" on simple-dict terms, and makes
+// Deinflector::pos_to_conditions("*") return all condition bits, so
+// filter_by_pos keeps them for any deinflection. This test pins both halves:
+//   1) pos_to_conditions({"*"}) == ~0, while real/unknown tags behave normally.
+//   2) a dict written by write_simple_dict stores rules == "*" (query surfaces
+//      it), proving the wildcard actually reaches the term record.
+//
+// Red/green: revert either the deinflector "*" branch or the importer
+// rules="*" write and an assertion fails.
+//
+// Usage: simple_dict_deinflection_test  (no args) -> exit 0 PASS, non-zero FAIL.
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "hoshidicts/deinflector.hpp"
+#include "hoshidicts/importer.hpp"
+#include "hoshidicts/query.hpp"
+#include "zip_fixture.hpp"
+
+namespace {
+
+int g_fail = 0;
+
+void fail(const char* msg) {
+  std::fprintf(stderr, "FAIL: %s\n", msg);
+  ++g_fail;
+}
+
+// 食べる (ichidan verb, dictionary form)
+const std::string kTaberu = "\xE9\xA3\x9F\xE3\x81\xB9\xE3\x82\x8B";
+
+// Minimal one-condition descriptor: bare tag "v1" -> bit 0. No transforms.
+const std::string kTransforms =
+    "{\"language\":\"ja\",\"conditions\":{"
+    "\"v1\":{\"name\":\"ichidan verb\",\"isDictionaryForm\":true,\"subConditions\":[]}"
+    "},\"transforms\":{}}";
+
+}  // namespace
+
+int main() {
+  // --- Part 1: pos_to_conditions wildcard ---------------------------------
+  Deinflector d;
+  d.load_transforms_json(kTransforms);
+
+  if (d.pos_to_conditions({"*"}) != ~uint64_t{0}) {
+    fail("pos_to_conditions({\"*\"}) must be all-ones (wildcard)");
+  }
+  if (d.pos_to_conditions({}) != 0) {
+    fail("pos_to_conditions({}) must be 0");
+  }
+  if (d.pos_to_conditions({"totally-unknown-tag"}) != 0) {
+    fail("pos_to_conditions(unknown) must be 0");
+  }
+  const uint64_t v1_bits = d.pos_to_conditions({"v1"});
+  if (v1_bits == 0) {
+    fail("pos_to_conditions({\"v1\"}) must be non-zero");
+  }
+  if (v1_bits == ~uint64_t{0}) {
+    fail("a real tag must NOT resolve to the wildcard all-ones");
+  }
+  // The wildcard overlaps every real condition (this is what lets filter_by_pos
+  // keep a "*" term for a v1-requiring deinflection).
+  if ((d.pos_to_conditions({"*"}) & v1_bits) == 0) {
+    fail("wildcard must overlap real condition bits");
+  }
+
+  // --- Part 2: write_simple_dict stores rules == "*" ----------------------
+  const std::string out_dir = hoshi_test::temp_dir() + "/hoshi_simple_deinf_out";
+  std::vector<SimpleEntry> entries = {{kTaberu, "to eat"}};
+  ImportResult r = dictionary_importer::write_simple_dict("SimpleDeinfDict", entries, out_dir);
+  if (!r.success) {
+    fail(r.errors.empty() ? "write_simple_dict failed" : r.errors.front().c_str());
+  } else {
+    DictionaryQuery q;
+    q.add_term_dict(out_dir + "/" + r.title);
+    std::vector<TermResult> terms = q.query(kTaberu);
+    if (terms.empty()) {
+      fail("query(食べる) returned no terms");
+    } else if (terms.front().rules != "*") {
+      std::fprintf(stderr, "FAIL rules: got '%s' want '*'\n", terms.front().rules.c_str());
+      ++g_fail;
+    }
+  }
+
+  if (g_fail) {
+    std::fprintf(stderr, "%d FAIL\n", g_fail);
+    return 1;
+  }
+  std::printf("PASS\n");
+  return 0;
+}


### PR DESCRIPTION
非 Yomitan 词典（MDX/MDD/StarDict/DSL）在 Hibiki 里真正好用。全套 **17 个 native 测试通过**，零回归。

## BUG-723 · MDX `Encrypted="2"` 解密（原始报错）
用户导入 `T4jiJuk.mdx`（大修館 四字熟語辞典）报 `mdx: empty key block info`。头部 `Encrypted="2"`——MDict 用 RIPEMD-128 + 滚动 XOR 加扰已压缩的 key-block-info，旧 reader 直接喂 libdeflate 失败。新增 `ripemd128`/`mdx_fast_decrypt`，解析 `Encrypted` 位域，bit 1 时先还原再解压。探针实测解出 **7965 词条**。（`dd85406ac`，测试 `mdx_encrypted_keyinfo_test` 含 RIPEMD-128 KAT）

## BUG-719 · 其他格式词典查词真根因（shishamo 担心的「查词有问题」）
MDX/StarDict/DSL 走 `write_simple_dict`，term `rules_len=0`。`filter_by_pos` 在去屈折命中时删掉 `(pos_conditions & d.conditions)==0` 的词条 → **凡屈折形（动词变形等）命中一律丢结果**，只有原形直接命中留得住。修数据结构：simple 词条存 `rules="*"`，`pos_to_conditions("*")` 返回全 1 位通配；只影响 simple dict，Yomitan 不变。（`cf5f817d5`，测试 `simple_dict_deinflection_test`）

## Phase B · MDX CSS 内联
MDX 释义 HTML 常 `<link>` 同名样式表。`import_mdx` 读同名 `<base>.css` 作 `styles.css`，弹窗 `constructDictCss` 作用域注入。（`ed5cb0a13`，测试 `simple_dict_css_test`）

## Phase A · MDD 媒体导入（图片/音频/字体）
`mdx_reader` 抽公共容器解析内核 + `parse_mdd`（二进制记录、路径键、字节精确）。`importer` 抽 `append_media_record`/`write_media_idx`（zip 流式不回归）+ `import_mdd_into` 复用产出 media.bin/idx。`import_mdx` 自动挂载同名 `.mdd`，zip 内提取并列 `.mdd`/`.css`。下游 `get_media_file` + `image://` scheme 零改动即显示。（`00cfab3d4`，测试 `mdd_media_import_test`）

## 说明
- native 库 app 构建时从源码编译进 `hoshidicts_ffi.dll`/`.so`/`.dylib`，无预编译二进制，下次构建即生效。
- 桌面走用户原始文件路径（`file.path`），同名 `.mdd`/`.css` 可被找到；Android file_picker 可能缓存副本致同名文件不相邻（已知限制，后续可让 Dart 层显式传 .mdd）。
- 待真机：桌面导入 MDX(+.mdd/.css) → 阅读器查词，确认图片显示、CSS 生效、屈折形能查到。
- bit 0（记录块加密、需购买注册码）仍不支持，属外部限制。

实施计划：`docs/superpowers/plans/2026-07-11-nonyomitan-dict-media-css-recall.md`（本地）。