### PR TITLE
fix(backup): 字体计数按catalog条目 + 视频per-item选择 + 消除书籍重复观感 (BUG-730)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 714 条。点号进各自文件。
+> 共 715 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-730](bugs/BUG-730-backup-font-count-inflated.md) | ✅ | ✅ | 备份导出自定义字体计数虚高(2个显示7个) |
 | [BUG-729](bugs/BUG-729-simple-dict-inflected-lookup.md) | ✅ | ✅ | MDX/StarDict/DSL 等 simple 词典屈折形查词命中丢失 |
 | [BUG-728](bugs/BUG-728-shelf-audiobook-progress.md) | ✅ | ✅ | 书架有声书进度条听书时不更新 |
 | [BUG-727](bugs/BUG-727-mdx-encrypted-keyinfo.md) | ✅ | ✅ | MDX Encrypted=2 词典导入失败 empty key block info |

--- a/docs/bugs/BUG-730-backup-font-count-inflated.md
+++ b/docs/bugs/BUG-730-backup-font-count-inflated.md
@@ -1,0 +1,6 @@
+## BUG-730 · 备份导出自定义字体计数虚高(2个显示7个)
+- **报告**：2026-07-11（用户：）
+- **真实性**：✅ 真 bug — 根因 `hibiki/lib/src/sync/backup_service.dart:652`（原 `summarizeExportContent` 用 `_countFilesInTree(custom_fonts/)` 递归统计目录内**所有文件数**，而非用户认知的字体条目数）。字体的逻辑单位是字体目录 catalog 条目（`font_catalog` pref，字体页列表显示的数量）；`custom_fonts/` 目录会累积孤儿垃圾：失败下载残留的 `_tmp_*` 临时文件、被删/覆盖但无引用的旧字体文件（`custom_fonts_page.dart:850` 临时文件建在目录内、`:1067` 仅在无引用时删物理文件）。用户仅下载 2 个字体（每个下载路径只写 1 文件）却显示 7 = 目录里有 5 个孤儿文件。导出预览计数、归档回读计数、实际打包三处原本都数文件，彼此一致但与用户认知差一个量纲。
+- **[x] ① 已修复** — `backup_service.dart`：新增 `_referencedFontFiles()`（读 `font_catalog` + 4 个 legacy 影子 pref 的 `path` 字段，只保留 custom_fonts/ 根下且真实存在的文件，按归一化路径去重），计数改为其条目数；新增 `_collectReferencedFontFiles()` 打包时**只打被 catalog 引用的字体文件**，孤儿/临时文件不再进备份。三处口径（预览计数 / 打包内容 / 归档回读）自然一致。系统字体（path 在 custom_fonts/ 外）不计不打包（本就无文件可备份）。提交见分支 `worktree-backup-export-picker-font-count`。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/backup_font_count_video_selection_test.dart`：2 个 catalog 字体 + 3 个孤儿/临时文件 → `summarizeExportContent` 报 2、导出 zip 只含 2 个引用文件；legacy 影子列表（无 catalog）仍计数；无 catalog 无 legacy 时孤儿不计（0）。另 `backup_categories_test.dart` 的 `buildFullSource` 补种 `font_catalog` 以匹配新契约。
+- **备注**：同分支一并做了两处用户报告的导出对话框 UX：①"书籍内容"开关与"选择书籍"子选择器视觉脱节像重复 → 子选择器移到父开关正下方；②给"视频"分类补 per-video「选择视频」逐项选择器（服务层 `videoKeys` + `_retainVideos` 剥离未选视频行，与书籍 TODO-1195 对称，顺带修了"取消视频分类仍留幽灵视频行"的既有缺口）。待真机验证导出/导入往返。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 38369 (2257 per locale)
+/// Strings: 38437 (2261 per locale)
 ///
-/// Built on 2026-07-11 at 04:56 UTC
+/// Built on 2026-07-11 at 06:03 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2989,6 +2989,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get popup_ctx_next_plus => 'Add after';
   String get popup_ctx_confirm => 'Confirm';
   String get popup_ctx_cancel => 'Cancel';
+  String get backup_export_choose_videos => 'Choose videos';
+  String get backup_export_videos_all => 'All videos';
+  String get backup_export_no_videos => 'No videos to choose from';
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -8095,6 +8100,15 @@ class _StringsAr extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -13324,6 +13338,15 @@ class _StringsDe extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -18570,6 +18593,15 @@ class _StringsEs extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -23835,6 +23867,15 @@ class _StringsFr extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -29002,6 +29043,15 @@ class _StringsId extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -34230,6 +34280,15 @@ class _StringsIt extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -39184,6 +39243,15 @@ class _StringsJa extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -44142,6 +44210,15 @@ class _StringsKo extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -49338,6 +49415,15 @@ class _StringsNl extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -54557,6 +54643,15 @@ class _StringsPtBr extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -59751,6 +59846,15 @@ class _StringsRu extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -64858,6 +64962,15 @@ class _StringsTh extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -70020,6 +70133,15 @@ class _StringsTr extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -75157,6 +75279,15 @@ class _StringsVi extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -79947,6 +80078,15 @@ class _StringsZhCn extends _StringsEn {
   String get popup_ctx_confirm => '确认制卡';
   @override
   String get popup_ctx_cancel => '取消';
+  @override
+  String get backup_export_choose_videos => '选择视频';
+  @override
+  String get backup_export_videos_all => '全部视频';
+  @override
+  String get backup_export_no_videos => '没有可选的视频';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '已选 ${count} 个视频';
 }
 
 // Path: retrying_in
@@ -84803,6 +84943,15 @@ class _StringsZhHk extends _StringsEn {
   String get popup_ctx_confirm => 'Confirm';
   @override
   String get popup_ctx_cancel => 'Cancel';
+  @override
+  String get backup_export_choose_videos => 'Choose videos';
+  @override
+  String get backup_export_videos_all => 'All videos';
+  @override
+  String get backup_export_no_videos => 'No videos to choose from';
+  @override
+  String backup_export_videos_selected({required Object count}) =>
+      '${count} videos selected';
 }
 
 // Path: retrying_in
@@ -89455,6 +89604,14 @@ extension on _StringsEn {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -94067,6 +94224,14 @@ extension on _StringsAr {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -98701,6 +98866,14 @@ extension on _StringsDe {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -103333,6 +103506,14 @@ extension on _StringsEs {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -107972,6 +108153,14 @@ extension on _StringsFr {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -112591,6 +112780,14 @@ extension on _StringsId {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -117227,6 +117424,14 @@ extension on _StringsIt {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -121821,6 +122026,14 @@ extension on _StringsJa {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -126418,6 +126631,14 @@ extension on _StringsKo {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -131047,6 +131268,14 @@ extension on _StringsNl {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -135673,6 +135902,14 @@ extension on _StringsPtBr {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -140303,6 +140540,14 @@ extension on _StringsRu {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -144915,6 +145160,14 @@ extension on _StringsTh {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -149536,6 +149789,14 @@ extension on _StringsTr {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -154151,6 +154412,14 @@ extension on _StringsVi {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }
@@ -158732,6 +159001,14 @@ extension on _StringsZhCn {
         return '确认制卡';
       case 'popup_ctx_cancel':
         return '取消';
+      case 'backup_export_choose_videos':
+        return '选择视频';
+      case 'backup_export_videos_all':
+        return '全部视频';
+      case 'backup_export_no_videos':
+        return '没有可选的视频';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '已选 ${count} 个视频';
       default:
         return null;
     }
@@ -163318,6 +163595,14 @@ extension on _StringsZhHk {
         return 'Confirm';
       case 'popup_ctx_cancel':
         return 'Cancel';
+      case 'backup_export_choose_videos':
+        return 'Choose videos';
+      case 'backup_export_videos_all':
+        return 'All videos';
+      case 'backup_export_no_videos':
+        return 'No videos to choose from';
+      case 'backup_export_videos_selected':
+        return ({required Object count}) => '${count} videos selected';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "后退一句",
   "popup_ctx_next_plus": "后加一句",
   "popup_ctx_confirm": "确认制卡",
-  "popup_ctx_cancel": "取消"
+  "popup_ctx_cancel": "取消",
+  "backup_export_choose_videos": "选择视频",
+  "backup_export_videos_all": "全部视频",
+  "backup_export_no_videos": "没有可选的视频",
+  "backup_export_videos_selected": "已选 $count 个视频"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2263,5 +2263,9 @@
   "popup_ctx_next_minus": "Remove after",
   "popup_ctx_next_plus": "Add after",
   "popup_ctx_confirm": "Confirm",
-  "popup_ctx_cancel": "Cancel"
+  "popup_ctx_cancel": "Cancel",
+  "backup_export_choose_videos": "Choose videos",
+  "backup_export_videos_all": "All videos",
+  "backup_export_no_videos": "No videos to choose from",
+  "backup_export_videos_selected": "$count videos selected"
 }

--- a/hibiki/lib/src/sync/backup_service.dart
+++ b/hibiki/lib/src/sync/backup_service.dart
@@ -649,9 +649,12 @@ class BackupService {
     final int audiobooks = (await _db.getAllAudiobooks()).length;
     final int videos = (await _db.allVideoBooks()).length;
     final int dictionaries = (await _db.getAllDictionaryMetadata()).length;
-    final int fonts = _fontsRootDirectory == null
-        ? 0
-        : await _countFilesInTree(Directory(_fontsRootDirectory));
+    // Count the fonts the USER manages (catalog entries whose file lives under
+    // custom_fonts/), not every file in the tree: failed `_tmp_*` downloads and
+    // replaced-but-unreferenced old files inflated the count (a user with 2
+    // fonts saw 7). This is also exactly what the export packs, so the preview
+    // count, the packed content and the import readback all agree.
+    final int fonts = (await _referencedFontFiles()).length;
     final int localAudio = await _countLocalAudioDbs();
     final Map<BackupCategory, int> counts = <BackupCategory, int>{
       BackupCategory.dictionary: dictionaries,
@@ -670,13 +673,76 @@ class BackupService {
     );
   }
 
-  static Future<int> _countFilesInTree(Directory root) async {
-    if (!await root.exists()) return 0;
-    int n = 0;
-    await for (final FileSystemEntity e in root.list(recursive: true)) {
-      if (e is File) n++;
+  /// The custom-font files under [_fontsRootDirectory] the user actually
+  /// manages: every `path` referenced by the canonical font catalog (or its
+  /// legacy shadow lists) that resolves to an existing file under the fonts
+  /// root. Orphan/temp leftovers in the tree (failed `_tmp_*` downloads,
+  /// replaced-but-unreferenced old files) are excluded, so the export count and
+  /// the packed content match the custom-fonts page instead of the raw file
+  /// total (root fix for "2 fonts shown as 7"). System fonts, whose catalog
+  /// entries point outside custom_fonts/, are excluded because no file travels.
+  /// Returned paths keep their original (as-stored) form, deduped by their
+  /// forward-slash-normalized value.
+  Future<List<String>> _referencedFontFiles() async {
+    final String? root = _fontsRootDirectory;
+    if (root == null) return const <String>[];
+    final Directory rootDir = Directory(root);
+    if (!await rootDir.exists()) return const <String>[];
+    final String rootNorm = rootDir.path.replaceAll(r'\', '/');
+    final Set<String> seen = <String>{};
+    final List<String> result = <String>[];
+    for (final String key in <String>[
+      _fontCatalogPrefKey,
+      ..._legacyFontPrefKeys,
+    ]) {
+      final String? json = await _db.getPref(key);
+      if (json == null || json.isEmpty) continue;
+      for (final String path in _fontPathsFromPrefJson(json)) {
+        if (path.isEmpty) continue;
+        if (!_isUnderRoot(path, rootNorm)) continue;
+        if (!await File(path).exists()) continue;
+        if (seen.add(path.replaceAll(r'\', '/'))) result.add(path);
+      }
     }
-    return n;
+    return result;
+  }
+
+  /// Extracts font-file `path` strings from a persisted font pref [json]: the
+  /// canonical catalog `{version, fonts:[{id, name, path}]}` or a legacy list
+  /// `[{name, path, enabled}]`. A malformed value yields nothing rather than
+  /// throwing (a corrupt pref never aborts an export summary).
+  static Iterable<String> _fontPathsFromPrefJson(String json) sync* {
+    dynamic decoded;
+    try {
+      decoded = jsonDecode(json);
+    } catch (_) {
+      return;
+    }
+    final Iterable<dynamic>? entries =
+        decoded is Map && decoded['fonts'] is List
+            ? decoded['fonts'] as List<dynamic>
+            : decoded is List
+                ? decoded
+                : null;
+    if (entries == null) return;
+    for (final dynamic e in entries) {
+      if (e is Map && e['path'] is String) yield e['path'] as String;
+    }
+  }
+
+  /// Packs ONLY the custom-font files the catalog references (see
+  /// [_referencedFontFiles]) into [into] under the `custom_fonts/` prefix, keyed
+  /// by each file's path relative to the fonts root (mirrors [_collectTreeFiles]
+  /// so import restores identically). Orphan/temp leftovers are skipped so the
+  /// backup carries only the fonts the user manages, and the archive font-file
+  /// count matches the export preview.
+  Future<void> _collectReferencedFontFiles(Map<String, String> into) async {
+    final String? root = _fontsRootDirectory;
+    if (root == null) return;
+    for (final String abs in await _referencedFontFiles()) {
+      final String rel = p.relative(abs, from: root).replaceAll(r'\', '/');
+      into[p.posix.join(_fontsPrefix, rel)] = abs;
+    }
   }
 
   Future<int> _countLocalAudioDbs() async {
@@ -708,10 +774,18 @@ class BackupService {
   /// categories (dictionaries / statistics / settings / videos / local audio)
   /// are unaffected. When the [BackupCategory.books] category itself is excluded
   /// no book records or content travel at all, regardless of [bookKeys].
+  ///
+  /// [videoKeys] is the per-video analogue (by `video_books.book_uid`): null
+  /// (default) exports every video (legacy); a non-null set exports ONLY those
+  /// videos — both their `video_books` records (every unselected row is stripped
+  /// from the DB copy so restore never resurrects a "ghost video" with no file)
+  /// AND their `videos/` content. Ignored when the [BackupCategory.videos]
+  /// category itself is excluded (then no video rows or files travel at all).
   Future<BackupMeta> exportBackup(
     String outputPath, {
     Set<BackupCategory>? categories,
     Set<String>? bookKeys,
+    Set<String>? videoKeys,
   }) async {
     bool wants(BackupCategory c) =>
         categories == null || categories.contains(c);
@@ -779,6 +853,18 @@ class BackupService {
       if (retainBookKeys != null) {
         await _retainBooks(tmpDir.path, retainBookKeys);
       }
+      // Which video records survive in the exported DB copy — mirrors books:
+      //  - video category unticked     → keep NONE (strip every video_books row).
+      //  - a per-video selection given → keep ONLY the selected book_uids.
+      //  - otherwise                   → keep all (null = legacy full export).
+      // Stripping the row (not just skipping the file) is what stops a restore
+      // from resurrecting a "ghost video" whose file never travelled.
+      final bool includeVideos = wants(BackupCategory.videos);
+      final Set<String>? retainVideoKeys =
+          !includeVideos ? const <String>{} : videoKeys; // null = every video
+      if (retainVideoKeys != null) {
+        await _retainVideos(tmpDir.path, retainVideoKeys);
+      }
 
       // TODO-1193: the four data categories (progress / statistics / settings /
       // profiles) live only in the DB blob, so when the user unticks any of
@@ -821,8 +907,8 @@ class BackupService {
         _dbName: cleanDbPath,
       };
       Map<String, String> videoFiles = const <String, String>{};
-      if (wants(BackupCategory.videos)) {
-        videoFiles = await _collectVideoFiles(files);
+      if (includeVideos) {
+        videoFiles = await _collectVideoFiles(files, videoKeys: videoKeys);
       }
       if (wants(BackupCategory.localAudio)) {
         await _collectLocalAudioFiles(files);
@@ -830,15 +916,20 @@ class BackupService {
 
       // TODO-1261: the confirm dialog's "N books" must count EVERY shelf item
       // that will travel usably, not just EPUBs. A video book travels usably iff
-      // its file was packed (in [videoFiles]) or it is a streaming book (http(s)
-      // URL, self-contained) — the SAME reachability the merge/preview enforce,
-      // so a video-only backup no longer reports "0 books" while 19 videos land.
+      // it is selected (video category on + not filtered out by [videoKeys]) AND
+      // either its file was packed (in [videoFiles]) or it is a streaming book
+      // (http(s) URL, self-contained) — the SAME reachability the merge/preview
+      // enforce, so a video-only backup no longer reports "0 books" while 19
+      // videos land, and an unticked/deselected video is not counted.
+      bool videoTravels(VideoBookRow v) {
+        if (!includeVideos) return false;
+        if (videoKeys != null && !videoKeys.contains(v.bookUid)) return false;
+        return _isStreamingVideoPath(v.videoPath) ||
+            videoFiles.containsKey(v.videoPath);
+      }
+
       final List<VideoBookRow> allVideos = await _db.allVideoBooks();
-      final int usableVideoCount = allVideos
-          .where((VideoBookRow v) =>
-              _isStreamingVideoPath(v.videoPath) ||
-              videoFiles.containsKey(v.videoPath))
-          .length;
+      final int usableVideoCount = allVideos.where(videoTravels).length;
 
       // "Statistics records" spans reading + video + mining buckets, not reading
       // alone, so a video-watcher's backup no longer reports "0 statistics".
@@ -902,8 +993,7 @@ class BackupService {
             Directory(_audiobooksRootDirectory), _audiobooksPrefix, files);
       }
       if (_fontsRootDirectory != null && wants(BackupCategory.fonts)) {
-        await _collectTreeFiles(
-            Directory(_fontsRootDirectory), _fontsPrefix, files);
+        await _collectReferencedFontFiles(files);
       }
 
       final String metaJson =
@@ -2069,6 +2159,31 @@ class BackupService {
     }
   }
 
+  /// Per-video analogue of [_retainBooks]: DELETEs every `video_books` row whose
+  /// `book_uid` is NOT in [keep] (plus its dependent rows — subtitle cues, tag
+  /// mappings, shelf entry — via the canonical [HibikiDatabase.deleteVideoBook]
+  /// cascade). [keep] empty strips every video (the video category was
+  /// unticked); a non-empty set keeps only the user-selected videos (per-video
+  /// export). Same root fix as books: without stripping the row a restore/merge
+  /// would insert a video record whose file never travelled = an un-openable
+  /// "ghost video".
+  static Future<void> _retainVideos(
+    String dbDirectory,
+    Set<String> keep,
+  ) async {
+    final HibikiDatabase db = HibikiDatabase(dbDirectory);
+    try {
+      for (final VideoBookRow v in await db.allVideoBooks()) {
+        if (keep.contains(v.bookUid)) continue;
+        await db.deleteVideoBook(v.bookUid);
+      }
+      await db.customStatement('VACUUM');
+      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+    } finally {
+      await db.close();
+    }
+  }
+
   /// Packs ONLY the selected [bookKeys]' book content into [into] (per-book
   /// export, TODO-1195 part A). For each selected [EpubBookRow] its extracted
   /// content directory subtree plus the epub file and cover file are added,
@@ -2177,13 +2292,18 @@ class BackupService {
     }
   }
 
+  /// Packs the referenced video files into [into] under the `videos/` prefix.
+  /// [videoKeys] (by `video_books.book_uid`) restricts packing to the selected
+  /// videos (per-video export); null packs every video (legacy full export).
   Future<Map<String, String>> _collectVideoFiles(
-    Map<String, String> into,
-  ) async {
+    Map<String, String> into, {
+    Set<String>? videoKeys,
+  }) async {
     final Map<String, String> sourcePathToArchiveRelative = <String, String>{};
     final Set<String> usedArchiveRelativePaths = <String>{};
     final List<VideoBookRow> rows = await _db.allVideoBooks();
     for (final VideoBookRow row in rows) {
+      if (videoKeys != null && !videoKeys.contains(row.bookUid)) continue;
       int index = 0;
       for (final String videoPath in _videoPathsForRow(row)) {
         if (videoPath.isEmpty ||

--- a/hibiki/lib/src/sync/sync_settings_schema/backup.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/backup.part.dart
@@ -105,6 +105,12 @@ class _BackupExportWidgetState extends State<_BackupExportWidget> {
   /// it); only consulted when the Books category is selected.
   Set<String>? _selectedBookKeys;
 
+  /// Per-video export selection (books analogue). null = every video (legacy
+  /// full export); a non-null set = only those `video_books.book_uid`s travel.
+  /// Persists across dialog opens within this settings session; only consulted
+  /// when the Videos category is selected.
+  Set<String>? _selectedVideoKeys;
+
   Future<void> _export() async {
     // Re-entrant guard: the row's Activate (A/Enter) and the trailing button
     // both call this, so ignore a second trigger while an export is running.
@@ -147,6 +153,9 @@ class _BackupExportWidgetState extends State<_BackupExportWidget> {
         categories: categories,
         bookKeys: categories.contains(BackupCategory.books)
             ? _selectedBookKeys
+            : null,
+        videoKeys: categories.contains(BackupCategory.videos)
+            ? _selectedVideoKeys
             : null,
       );
 
@@ -199,6 +208,9 @@ class _BackupExportWidgetState extends State<_BackupExportWidget> {
     // Per-book selection (TODO-1195 part A). Mutated by the nested book picker;
     // written back to [_selectedBookKeys] only when the dialog is confirmed.
     Set<String>? chosenBooks = _selectedBookKeys;
+    // Per-video selection (the books analogue). Mutated by the nested video
+    // picker; written back to [_selectedVideoKeys] only on confirm.
+    Set<String>? chosenVideos = _selectedVideoKeys;
     String labelFor(BackupCategory c) {
       switch (c) {
         case BackupCategory.dictionary:
@@ -260,7 +272,12 @@ class _BackupExportWidgetState extends State<_BackupExportWidget> {
                     style: Theme.of(ctx).textTheme.bodySmall,
                   ),
                   const SizedBox(height: 4),
-                  for (final BackupCategory c in BackupCategory.values)
+                  // Each category is a toggle; the Books/Videos toggles carry a
+                  // nested per-item picker glued DIRECTLY beneath them (not
+                  // floated to the list bottom) so "选择书籍/选择视频" reads as a
+                  // sub-option of its category instead of a duplicate top row.
+                  for (final BackupCategory c
+                      in BackupCategory.values) ...<Widget>[
                     AdaptiveSettingsSwitchRow(
                       title: labelFor(c),
                       subtitle: summary.counts.containsKey(c)
@@ -276,22 +293,41 @@ class _BackupExportWidgetState extends State<_BackupExportWidget> {
                         }
                       }),
                     ),
-                  // Per-book selection row (TODO-1195 part A): only meaningful
-                  // when the Books category itself is packed.
-                  if (selected.contains(BackupCategory.books))
-                    AdaptiveSettingsRow(
-                      title: t.backup_export_choose_books,
-                      subtitle: chosenBooks == null
-                          ? t.backup_export_books_all
-                          : t.backup_export_books_selected(
-                              count: chosenBooks!.length.toString()),
-                      trailing: const Icon(Icons.chevron_right),
-                      onTap: () async {
-                        final Set<String>? picked =
-                            await _pickBooks(chosenBooks);
-                        setLocal(() => chosenBooks = picked);
-                      },
-                    ),
+                    // Per-book selection row (TODO-1195 part A): only meaningful
+                    // when the Books category itself is packed.
+                    if (c == BackupCategory.books &&
+                        selected.contains(BackupCategory.books))
+                      AdaptiveSettingsRow(
+                        title: t.backup_export_choose_books,
+                        subtitle: chosenBooks == null
+                            ? t.backup_export_books_all
+                            : t.backup_export_books_selected(
+                                count: chosenBooks!.length.toString()),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () async {
+                          final Set<String>? picked =
+                              await _pickBooks(chosenBooks);
+                          setLocal(() => chosenBooks = picked);
+                        },
+                      ),
+                    // Per-video selection row (books analogue): only meaningful
+                    // when the Videos category itself is packed.
+                    if (c == BackupCategory.videos &&
+                        selected.contains(BackupCategory.videos))
+                      AdaptiveSettingsRow(
+                        title: t.backup_export_choose_videos,
+                        subtitle: chosenVideos == null
+                            ? t.backup_export_videos_all
+                            : t.backup_export_videos_selected(
+                                count: chosenVideos!.length.toString()),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () async {
+                          final Set<String>? picked =
+                              await _pickVideos(chosenVideos);
+                          setLocal(() => chosenVideos = picked);
+                        },
+                      ),
+                  ],
                 ],
               ),
               footer: Wrap(
@@ -317,8 +353,10 @@ class _BackupExportWidgetState extends State<_BackupExportWidget> {
       ),
     );
     if (confirmed != true) return null;
-    // Commit the per-book selection only on confirm (cancel leaves it as-was).
+    // Commit the per-book / per-video selection only on confirm (cancel leaves
+    // them as-was).
     _selectedBookKeys = chosenBooks;
+    _selectedVideoKeys = chosenVideos;
     return selected;
   }
 
@@ -432,6 +470,121 @@ class _BackupExportWidgetState extends State<_BackupExportWidget> {
     if (confirmed != true) return current;
     // "All ticked" collapses back to null so the export takes the legacy
     // full-book path (and stays correct if a book is added/removed later).
+    if (sel.length == keys.length) return null;
+    return sel;
+  }
+
+  /// Nested picker for per-video export (books analogue). Loads the video
+  /// library and lets the user tick which videos travel; [current] seeds the
+  /// initial state (null = every video). Returns the chosen set, collapsing
+  /// "all ticked" back to null (the legacy full-export path), or [current]
+  /// unchanged on cancel.
+  Future<Set<String>?> _pickVideos(Set<String>? current) async {
+    final List<VideoBookRow> videos =
+        await widget.settingsContext.appModel.database.allVideoBooks();
+    // State.context guarded by State.mounted (coherent for the lint): the
+    // settings page may have unmounted while the library loaded.
+    if (!mounted) return current;
+    if (videos.isEmpty) {
+      _showSnackBar(context, t.backup_export_no_videos);
+      return current;
+    }
+    final List<String> keys =
+        videos.map((VideoBookRow v) => v.bookUid).toList(growable: false);
+    // Seed: null (all) → every video ticked; otherwise the given subset.
+    final Set<String> sel = current == null
+        ? keys.toSet()
+        : keys.where((String k) => current.contains(k)).toSet();
+
+    final bool? confirmed = await showAppDialog<bool>(
+      context: context,
+      builder: (BuildContext ctx) => StatefulBuilder(
+        builder: (BuildContext ctx, StateSetter setLocal) {
+          final HibikiDesignTokens tokens = HibikiDesignTokens.of(ctx);
+          return HibikiDialogFrame(
+            maxWidth: 460,
+            insetPadding: EdgeInsets.symmetric(
+              horizontal: tokens.spacing.card,
+              vertical: tokens.spacing.card,
+            ),
+            scrollable: false,
+            child: HibikiModalSheetFrame(
+              title: t.backup_export_choose_videos,
+              scrollable: true,
+              bodyPadding: EdgeInsets.fromLTRB(
+                tokens.spacing.card,
+                0,
+                tokens.spacing.card,
+                tokens.spacing.gap,
+              ),
+              footerPadding: EdgeInsets.fromLTRB(
+                tokens.spacing.card,
+                tokens.spacing.gap,
+                tokens.spacing.card,
+                tokens.spacing.card,
+              ),
+              body: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      Text('${sel.length} / ${keys.length}',
+                          style: Theme.of(ctx).textTheme.bodySmall),
+                      const Spacer(),
+                      adaptiveDialogAction(
+                        context: ctx,
+                        onPressed: () => setLocal(() => sel
+                          ..clear()
+                          ..addAll(keys)),
+                        child: Text(t.backup_export_select_all),
+                      ),
+                      adaptiveDialogAction(
+                        context: ctx,
+                        onPressed: () => setLocal(sel.clear),
+                        child: Text(t.backup_export_select_none),
+                      ),
+                    ],
+                  ),
+                  for (final VideoBookRow v in videos)
+                    AdaptiveSettingsSwitchRow(
+                      title: v.title,
+                      value: sel.contains(v.bookUid),
+                      onChanged: (bool tick) => setLocal(() {
+                        if (tick) {
+                          sel.add(v.bookUid);
+                        } else {
+                          sel.remove(v.bookUid);
+                        }
+                      }),
+                    ),
+                ],
+              ),
+              footer: Wrap(
+                alignment: WrapAlignment.end,
+                spacing: tokens.spacing.gap,
+                children: <Widget>[
+                  adaptiveDialogAction(
+                    context: ctx,
+                    onPressed: () => Navigator.pop(ctx, false),
+                    child: Text(t.dialog_cancel),
+                  ),
+                  adaptiveDialogAction(
+                    context: ctx,
+                    isDefaultAction: true,
+                    onPressed: () => Navigator.pop(ctx, true),
+                    child: Text(t.dialog_ok),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+    if (confirmed != true) return current;
+    // "All ticked" collapses back to null so the export takes the legacy
+    // full-video path (and stays correct if a video is added/removed later).
     if (sel.length == keys.length) return null;
     return sel;
   }
@@ -601,8 +754,8 @@ class _BackupImportWidgetState extends State<_BackupImportWidget> {
       return;
     }
 
-    final _BackupImportChoice? choice = await _showConfirmDialog(
-        rootCtx, meta, mergePreview, summary);
+    final _BackupImportChoice? choice =
+        await _showConfirmDialog(rootCtx, meta, mergePreview, summary);
     if (choice == null) {
       // 用户取消确认 → 彻底退出遮罩态，回到设置页（validating 遮罩已退出）。
       if (mounted) setState(() => _isImporting = false);

--- a/hibiki/test/sync/backup_categories_test.dart
+++ b/hibiki/test/sync/backup_categories_test.dart
@@ -94,6 +94,22 @@ void main() {
         },
       ])),
     ));
+    // The font catalog references MyFont.ttf: the export packs (and counts)
+    // ONLY catalog-referenced files, so without this the font would be treated
+    // as an orphan and skipped.
+    await db.setPref(
+      'src:reader_ttu:font_catalog',
+      jsonEncode(<String, Object?>{
+        'version': 1,
+        'fonts': <Map<String, Object?>>[
+          <String, Object?>{
+            'id': 'f1',
+            'name': 'MyFont',
+            'path': p.join(fonts, 'MyFont.ttf'),
+          },
+        ],
+      }),
+    );
 
     final service = BackupService(
       db: db,

--- a/hibiki/test/sync/backup_font_count_video_selection_test.dart
+++ b/hibiki/test/sync/backup_font_count_video_selection_test.dart
@@ -1,0 +1,287 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/backup_service.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+import 'temp_dir_cleanup.dart';
+
+/// The custom-font count / packing must reflect the fonts the USER manages
+/// (catalog entries whose file lives under custom_fonts/), not every file in
+/// the tree. Failed `_tmp_*` downloads and replaced-but-unreferenced old files
+/// used to inflate both the export-dialog count and the packed archive (a user
+/// with 2 fonts saw 7). Per-video export is the books analogue: [videoKeys]
+/// packs ONLY the selected videos AND strips every other `video_books` row from
+/// the DB copy so no "ghost video" survives a restore.
+void main() {
+  late Directory src;
+  late Directory dst;
+
+  setUp(() async {
+    src = await Directory.systemTemp.createTemp('bk_fv_src_');
+    dst = await Directory.systemTemp.createTemp('bk_fv_dst_');
+  });
+  tearDown(() async {
+    for (final Directory d in <Directory>[src, dst]) {
+      try {
+        if (d.existsSync()) await cleanupTempDir(d);
+      } on PathNotFoundException {
+        // Windows recursive cleanup can race with already-removed temp paths.
+      }
+    }
+  });
+
+  Future<void> writeFile(String path, String content) async {
+    final File f = File(path);
+    f.parent.createSync(recursive: true);
+    await f.writeAsString(content);
+  }
+
+  Future<Archive> readZip(String zipPath) async {
+    final InputFileStream input = InputFileStream(zipPath);
+    try {
+      return ZipDecoder().decodeBuffer(input);
+    } finally {
+      await input.close();
+    }
+  }
+
+  Future<HibikiDatabase> openBackupDb(String zipPath, Directory into) async {
+    final Archive archive = await readZip(zipPath);
+    final ArchiveFile dbFile = archive.findFile('hibiki.db')!;
+    final Directory dir = Directory(p.join(into.path, 'exdb'))
+      ..createSync(recursive: true);
+    File(p.join(dir.path, 'hibiki.db'))
+        .writeAsBytesSync(dbFile.content as List<int>);
+    return HibikiDatabase(dir.path);
+  }
+
+  Future<int> countRows(HibikiDatabase db, String table) async {
+    final row =
+        await db.customSelect('SELECT COUNT(*) AS c FROM $table').getSingle();
+    return row.data['c'] as int;
+  }
+
+  group('font count / packing = catalog entries, not raw file count', () {
+    test('counts + packs only catalog-referenced files, skips orphans/temp',
+        () async {
+      final String dbDir = p.join(src.path, 'db');
+      final String fonts = p.join(src.path, 'custom_fonts');
+      Directory(dbDir).createSync(recursive: true);
+
+      // Two managed fonts + three garbage files the tree accumulated: a failed
+      // download temp file and two replaced-but-unreferenced old files.
+      await writeFile(p.join(fonts, 'Klee.ttf'), 'FONT-A');
+      await writeFile(p.join(fonts, 'Mincho.otf'), 'FONT-B');
+      await writeFile(p.join(fonts, '_tmp_1700000000000'), 'HALF-DOWNLOAD');
+      await writeFile(p.join(fonts, 'OldDeleted.ttf'), 'ORPHAN-1');
+      await writeFile(p.join(fonts, 'AlsoUnreferenced.woff2'), 'ORPHAN-2');
+
+      final HibikiDatabase db =
+          HibikiDatabase.forTesting(NativeDatabase.memory());
+      await db.setPref(
+        'src:reader_ttu:font_catalog',
+        jsonEncode(<String, Object?>{
+          'version': 1,
+          'fonts': <Map<String, Object?>>[
+            <String, Object?>{
+              'id': 'a',
+              'name': 'Klee',
+              'path': p.join(fonts, 'Klee.ttf'),
+            },
+            <String, Object?>{
+              'id': 'b',
+              'name': 'Mincho',
+              'path': p.join(fonts, 'Mincho.otf'),
+            },
+          ],
+        }),
+      );
+
+      final BackupService service = BackupService(
+        db: db,
+        dbDirectory: dbDir,
+        appVersion: '1.0.0',
+        fontsRootDirectory: fonts,
+      );
+
+      // The five files on disk must NOT inflate the count: only the two
+      // catalog entries are reported (root fix for "2 fonts shown as 7").
+      final BackupContentSummary summary =
+          await service.summarizeExportContent();
+      expect(summary.countFor(BackupCategory.fonts), 2);
+
+      final String zip = p.join(src.path, 'fonts.zip');
+      await service.exportBackup(zip);
+      await db.close();
+
+      final Archive archive = await readZip(zip);
+      expect(archive.findFile('custom_fonts/Klee.ttf'), isNotNull);
+      expect(archive.findFile('custom_fonts/Mincho.otf'), isNotNull);
+      // The garbage never travels.
+      expect(archive.findFile('custom_fonts/_tmp_1700000000000'), isNull);
+      expect(archive.findFile('custom_fonts/OldDeleted.ttf'), isNull);
+      expect(archive.findFile('custom_fonts/AlsoUnreferenced.woff2'), isNull);
+      // The archive font-file count agrees with the export-dialog count.
+      final int packedFonts = archive.files
+          .where((ArchiveFile f) =>
+              f.isFile &&
+              f.name.startsWith('custom_fonts/') &&
+              f.name.length > 'custom_fonts/'.length)
+          .length;
+      expect(packedFonts, 2);
+    });
+
+    test('legacy shadow font list (no catalog) is still counted', () async {
+      final String dbDir = p.join(src.path, 'db');
+      final String fonts = p.join(src.path, 'custom_fonts');
+      Directory(dbDir).createSync(recursive: true);
+      await writeFile(p.join(fonts, 'Legacy.ttf'), 'FONT');
+      await writeFile(p.join(fonts, '_tmp_999'), 'ORPHAN');
+
+      final HibikiDatabase db =
+          HibikiDatabase.forTesting(NativeDatabase.memory());
+      await db.setPref(
+        'src:reader_ttu:custom_fonts',
+        jsonEncode(<Map<String, Object?>>[
+          <String, Object?>{
+            'name': 'Legacy',
+            'path': p.join(fonts, 'Legacy.ttf'),
+            'enabled': true,
+          },
+        ]),
+      );
+      final BackupService service = BackupService(
+        db: db,
+        dbDirectory: dbDir,
+        appVersion: '1.0.0',
+        fontsRootDirectory: fonts,
+      );
+      final BackupContentSummary summary =
+          await service.summarizeExportContent();
+      await db.close();
+      expect(summary.countFor(BackupCategory.fonts), 1);
+    });
+
+    test('no catalog + no legacy list → zero fonts (orphans do not count)',
+        () async {
+      final String dbDir = p.join(src.path, 'db');
+      final String fonts = p.join(src.path, 'custom_fonts');
+      Directory(dbDir).createSync(recursive: true);
+      await writeFile(p.join(fonts, '_tmp_1'), 'ORPHAN');
+      await writeFile(p.join(fonts, 'strays.ttf'), 'ORPHAN');
+
+      final HibikiDatabase db =
+          HibikiDatabase.forTesting(NativeDatabase.memory());
+      final BackupService service = BackupService(
+        db: db,
+        dbDirectory: dbDir,
+        appVersion: '1.0.0',
+        fontsRootDirectory: fonts,
+      );
+      final BackupContentSummary summary =
+          await service.summarizeExportContent();
+      await db.close();
+      expect(summary.countFor(BackupCategory.fonts), 0);
+    });
+  });
+
+  group('per-video export selection (videoKeys)', () {
+    /// Lays out three local videos (A/B/C) and returns the service + db.
+    Future<({BackupService service, HibikiDatabase db})> buildThreeVideos()
+        async {
+      final String dbDir = p.join(src.path, 'db');
+      final String videos = p.join(src.path, 'external_videos');
+      Directory(dbDir).createSync(recursive: true);
+      await writeFile(p.join(videos, 'A.mp4'), 'VID-A');
+      await writeFile(p.join(videos, 'B.mp4'), 'VID-B');
+      await writeFile(p.join(videos, 'C.mp4'), 'VID-C');
+
+      final HibikiDatabase db =
+          HibikiDatabase.forTesting(NativeDatabase.memory());
+      for (final String k in <String>['A', 'B', 'C']) {
+        await db.upsertVideoBook(VideoBooksCompanion.insert(
+          bookUid: 'video/$k',
+          title: 'Video $k',
+          videoPath: p.join(videos, '$k.mp4'),
+        ));
+      }
+      final BackupService service = BackupService(
+        db: db,
+        dbDirectory: dbDir,
+        appVersion: '1.0.0',
+      );
+      return (service: service, db: db);
+    }
+
+    test('videoKeys packs only selected files AND strips other rows', () async {
+      final ({BackupService service, HibikiDatabase db}) built =
+          await buildThreeVideos();
+      final String zip = p.join(src.path, 'videos.zip');
+      final BackupMeta meta = await built.service.exportBackup(
+        zip,
+        videoKeys: <String>{'video/A', 'video/C'},
+      );
+      await built.db.close();
+
+      final Archive archive = await readZip(zip);
+      final List<String> videoNames = archive.files
+          .where((ArchiveFile f) => f.isFile && f.name.startsWith('videos/'))
+          .map((ArchiveFile f) => f.name)
+          .toList();
+      // Exactly the two selected videos' files travel.
+      expect(videoNames.length, 2);
+      expect(videoNames.any((String n) => n.contains('A')), isTrue);
+      expect(videoNames.any((String n) => n.contains('C')), isTrue);
+      expect(videoNames.any((String n) => n.contains('B')), isFalse);
+
+      // The deselected video's DB row is stripped (no ghost video on restore).
+      final HibikiDatabase exdb = await openBackupDb(zip, dst);
+      final List<VideoBookRow> rows = await exdb.allVideoBooks();
+      await exdb.close();
+      expect(rows.map((VideoBookRow v) => v.bookUid).toSet(),
+          <String>{'video/A', 'video/C'});
+      // bookCount is honest to what travels (2 usable videos, 0 epub books).
+      expect(meta.bookCount, 2);
+    });
+
+    test('null videoKeys exports every video (legacy full export)', () async {
+      final ({BackupService service, HibikiDatabase db}) built =
+          await buildThreeVideos();
+      final String zip = p.join(src.path, 'videos_all.zip');
+      final BackupMeta meta = await built.service.exportBackup(zip);
+      await built.db.close();
+
+      final HibikiDatabase exdb = await openBackupDb(zip, dst);
+      expect(await countRows(exdb, 'video_books'), 3);
+      await exdb.close();
+      expect(meta.bookCount, 3);
+    });
+
+    test('excluding the videos category strips every video row', () async {
+      final ({BackupService service, HibikiDatabase db}) built =
+          await buildThreeVideos();
+      final String zip = p.join(src.path, 'no_videos.zip');
+      final BackupMeta meta = await built.service.exportBackup(
+        zip,
+        categories: BackupCategory.values.toSet()
+          ..remove(BackupCategory.videos),
+      );
+      await built.db.close();
+
+      final Archive archive = await readZip(zip);
+      expect(
+        archive.files.any((ArchiveFile f) => f.name.startsWith('videos/')),
+        isFalse,
+      );
+      final HibikiDatabase exdb = await openBackupDb(zip, dst);
+      expect(await countRows(exdb, 'video_books'), 0);
+      await exdb.close();
+      expect(meta.bookCount, 0);
+    });
+  });
+}


### PR DESCRIPTION
用户报告的三处备份导出问题，一并根因修复。

## 1. 自定义字体计数虚高（2 个显示 7 个 · BUG-730）
- 根因：`summarizeExportContent` 用 `_countFilesInTree(custom_fonts/)` 递归数**目录内所有文件**，非用户认知的字体条目数。目录累积孤儿垃圾（失败下载残留 `_tmp_*`、被删/覆盖但无引用的旧字体文件）。
- 修复：`_referencedFontFiles()`（读 `font_catalog` + 4 个 legacy 影子 pref 的 `path`，只保留 custom_fonts/ 根下真实存在的文件、归一化去重）；计数与打包（`_collectReferencedFontFiles`）都只认被 catalog 引用的文件。预览计数 / 打包内容 / 归档回读三处口径自然一致；孤儿/临时不再进备份。

## 2. 视频加 per-item「选择视频」选择器（books 的对称实现）
- `exportBackup` 新增 `videoKeys`（按 `video_books.book_uid`）；`_retainVideos` 剥离未选视频行（经 `deleteVideoBook` 级联），与书籍 TODO-1195 对称，顺带修了"取消视频分类仍留幽灵视频行"的既有缺口。

## 3. 消除"书籍内容/选择书籍"重复观感
- 把子选择器从列表底部移到父开关正下方（书籍 + 视频同理），明确从属关系。

## i18n
- 新增 `backup_export_choose_videos` / `videos_all` / `videos_selected` / `no_videos`（17 语言，经 `i18n_sync.dart` + `slang`）。

## 测试
- `test/sync/backup_font_count_video_selection_test.dart`：字体计数=catalog 条目、孤儿不计、legacy 影子列表仍计；`videoKeys` 只打选中文件 + 剥离未选行。
- `backup_categories_test.dart` 的 `buildFullSource` 补种 `font_catalog` 匹配新契约。
- `flutter analyze` 洁净；`flutter test` 10792 通过。

## 待办
- 真机验证导出 → 导入往返（字体只带 2 个、视频子集、导入还原）。