### PR TITLE
fix(ext): 扩展 content-script 不再接管普通网页滚动 (BUG-731)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 714 条。点号进各自文件。
+> 共 715 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-731](bugs/BUG-731-ext-page-scroll.md) | ✅ | ✅ | 扩展影响普通网页滚动速度 |
 | [BUG-729](bugs/BUG-729-simple-dict-inflected-lookup.md) | ✅ | ✅ | MDX/StarDict/DSL 等 simple 词典屈折形查词命中丢失 |
 | [BUG-728](bugs/BUG-728-shelf-audiobook-progress.md) | ✅ | ✅ | 书架有声书进度条听书时不更新 |
 | [BUG-727](bugs/BUG-727-mdx-encrypted-keyinfo.md) | ✅ | ✅ | MDX Encrypted=2 词典导入失败 empty key block info |

--- a/docs/bugs/BUG-731-ext-page-scroll.md
+++ b/docs/bugs/BUG-731-ext-page-scroll.md
@@ -1,0 +1,9 @@
+## BUG-731 · 扩展影响普通网页滚动速度
+- **报告**：2026-07-11（用户）
+- **真实性**：✅ 真 bug。根因 `hibiki/assets/browser_extension/vendor/popup.js`（wheel 监听，本仓约 `popup.js:3639` 起）。
+  - 扩展 `manifest.json` 把 `vendor/popup.js` 作为 content script 注入到 `<all_urls>`（每个网页）。
+  - popup.js 的 `document.addEventListener('wheel', …, { passive: false })` 是为**查词弹窗**定制的缩放平滑滚动：`e.preventDefault()` 后用 `POPUP_WHEEL_PIXEL_FACTOR = 0.24` 缩放并自行 `scrollBy`。
+  - 该弹窗在扩展里是宿主页上的 shadow DOM 覆盖层。`__hibikiWheelScroller(e)` 只有滚轮 `composedPath` 穿过弹窗 shadow 才返回 host；否则返回 null，旧代码 fallthrough 到 `else { window.scrollBy(...) }`，把**整个普通网页**的滚动接管并降速到 24% 速度。shadow host 是懒创建的（`content.js` 弹窗显示时才建、关闭置 `window.__hibikiRoot = null`），所以宿主页大部分时间都被这条 null 分支接管。
+- **[x] ① 已修复** — `commit b4e9ec9cb`。在 `e.preventDefault()` 之前加放行守卫：扩展 content-script 上下文（`typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.id`）里，滚轮不在弹窗 shadow 内（`!scroller`）时直接 `return`，回落原生滚动。in-app 弹窗（有 `flutter_inappwebview`、无 `chrome`）与「滚轮就在弹窗内」两条路径的缩放滚动保持不变。三镜像（`assets/popup/popup.js` + 两份扩展 `vendor/popup.js`）逐字节同步（TODO-1267）。
+- **[x] ② 已加自动化测试** — `test/lookup/browser_extension_page_scroll_bug731_test.js`（Node 真执行 popup.js 的 wheel 监听：扩展宿主页不 preventDefault/不 window.scrollBy；扩展弹窗内滚 host；in-app 弹窗仍 window.scrollBy）+ `test/lookup/browser_extension_page_scroll_bug731_test.dart`（node 驱动 + 源码守卫 + 三镜像字节一致）。移除守卫行后 Case A 变红，已本地验证。
+- **备注**：BUG 号取 731 而非工具自动分配的 730——730 已被未合的剪贴板制卡 PR#36 占用，origin/develop 尚未含它导致工具误判空号。

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -3652,6 +3652,15 @@ document.addEventListener('wheel', (e) => {
     const deltaPx = popupWheelDeltaToPixels(e.deltaY, e.deltaMode, window.innerHeight);
     if (deltaPx === 0) return;
     if (popupAncestorAbsorbsVerticalWheel(__hibikiEventTarget(e), deltaPx)) return;
+    // BUG-731: 这段缩放平滑滚动只服务查词弹窗。扩展里弹窗是宿主页上的 shadow 覆盖层，
+    // __hibikiWheelScroller 仅当滚轮 composedPath 穿过弹窗 shadow 才返回 host；返回 null
+    // 时唯一合法「滚 window」的表面是 in-app 弹窗文档（整份文档即弹窗，且无 chrome.runtime）。
+    // 普通网页上扩展 content script 有 chrome.runtime.id，此时滚轮不在弹窗内绝不能接管：
+    // 否则整页被 POPUP_WHEEL_PIXEL_FACTOR(0.24) 降速 + preventDefault 抢走原生滚动。
+    const scroller = __hibikiWheelScroller(e);
+    const inExtensionContentScript =
+        typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
+    if (!scroller && inExtensionContentScript) return;
     e.preventDefault();
     // Scale each notch down first, cap unusually large visual deltas, then
     // divide by zoom so the on-screen step is zoom-independent.
@@ -3660,7 +3669,6 @@ document.addEventListener('wheel', (e) => {
     // the shadow host is the scroll container (the ancestor walk above cannot
     // cross the shadow boundary, so it never absorbs there). In-app popup and
     // wheels over the host page: the window, exactly as before the shadow move.
-    const scroller = __hibikiWheelScroller(e);
     const layoutStep = visualStep / popupCurrentZoom(scroller);
     // TODO-1387: carry the sub-pixel remainder across events. A precision touchpad
     // reports deltaMode=PIXEL with a tiny fractional deltaY (~1-4 per frame); after

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -3652,6 +3652,15 @@ document.addEventListener('wheel', (e) => {
     const deltaPx = popupWheelDeltaToPixels(e.deltaY, e.deltaMode, window.innerHeight);
     if (deltaPx === 0) return;
     if (popupAncestorAbsorbsVerticalWheel(__hibikiEventTarget(e), deltaPx)) return;
+    // BUG-731: 这段缩放平滑滚动只服务查词弹窗。扩展里弹窗是宿主页上的 shadow 覆盖层，
+    // __hibikiWheelScroller 仅当滚轮 composedPath 穿过弹窗 shadow 才返回 host；返回 null
+    // 时唯一合法「滚 window」的表面是 in-app 弹窗文档（整份文档即弹窗，且无 chrome.runtime）。
+    // 普通网页上扩展 content script 有 chrome.runtime.id，此时滚轮不在弹窗内绝不能接管：
+    // 否则整页被 POPUP_WHEEL_PIXEL_FACTOR(0.24) 降速 + preventDefault 抢走原生滚动。
+    const scroller = __hibikiWheelScroller(e);
+    const inExtensionContentScript =
+        typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
+    if (!scroller && inExtensionContentScript) return;
     e.preventDefault();
     // Scale each notch down first, cap unusually large visual deltas, then
     // divide by zoom so the on-screen step is zoom-independent.
@@ -3660,7 +3669,6 @@ document.addEventListener('wheel', (e) => {
     // the shadow host is the scroll container (the ancestor walk above cannot
     // cross the shadow boundary, so it never absorbs there). In-app popup and
     // wheels over the host page: the window, exactly as before the shadow move.
-    const scroller = __hibikiWheelScroller(e);
     const layoutStep = visualStep / popupCurrentZoom(scroller);
     // TODO-1387: carry the sub-pixel remainder across events. A precision touchpad
     // reports deltaMode=PIXEL with a tiny fractional deltaY (~1-4 per frame); after

--- a/hibiki/test/lookup/browser_extension_page_scroll_bug731_test.dart
+++ b/hibiki/test/lookup/browser_extension_page_scroll_bug731_test.dart
@@ -1,0 +1,109 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-731: Hibiki 的浏览器扩展把 popup.js 作为 content script 注入到所有网页
+/// （`<all_urls>`）。popup.js 的 document 'wheel' 监听为「查词弹窗」重写了滚动
+/// （按 POPUP_WHEEL_PIXEL_FACTOR=0.24 缩放 + preventDefault）。当滚轮落在宿主页
+/// （不在弹窗 shadow 内）时，旧代码回落到 `window.scrollBy`，等于把每个普通网页的
+/// 滚动都接管并降速到 24%。
+///
+/// 根因修复：扩展 content-script 上下文（`chrome.runtime.id` 存在）里，滚轮不在
+/// 弹窗 shadow 内时必须回落原生滚动（不 preventDefault）。in-app 弹窗
+/// （`flutter_inappwebview`，无 chrome）与「滚轮就在弹窗内」两条路径保持原有缩放滚动。
+///
+/// 两层守护：
+/// ① 行为级——用 Node 真执行 popup.js 的 wheel 监听，断言四种表面下 preventDefault /
+///    window.scrollBy / host.scrollBy 的调用。无 node 时 skip。
+/// ② 源码级 + 三镜像一致——保证守卫存在、按 `chrome.runtime.id` 判定，且
+///    assets/popup 与两份扩展 vendor 镜像逐字节一致（TODO-1267）。
+void main() {
+  test(
+    'BUG-731: extension host-page wheel falls through to native (executes popup.js via node)',
+    () async {
+      final String? nodeExe = _resolveNode();
+      if (nodeExe == null) {
+        markTestSkipped(
+            'node not found on PATH; skipping JS behavior execution');
+        return;
+      }
+
+      final File jsTest = File(
+        'test/lookup/browser_extension_page_scroll_bug731_test.js',
+      );
+      expect(jsTest.existsSync(), isTrue,
+          reason: 'behavior harness ${jsTest.path} must exist');
+
+      final ProcessResult result = await Process.run(
+        nodeExe,
+        <String>[jsTest.path],
+        workingDirectory: Directory.current.path,
+      );
+
+      expect(
+        result.exitCode,
+        0,
+        reason: 'BUG-731 wheel behavior test failed.\n'
+            'stdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+      );
+      expect(result.stdout.toString(), contains('all assertions passed'),
+          reason: 'behavior harness must reach its success marker');
+    },
+  );
+
+  test('popup.js wheel guard bails on the extension host page (source guard)',
+      () {
+    const List<String> popupCopies = <String>[
+      'assets/popup/popup.js',
+      'assets/browser_extension/vendor/popup.js',
+      '../tools/browser-extension/vendor/popup.js',
+    ];
+
+    for (final String path in popupCopies) {
+      final String src = File(path).readAsStringSync();
+
+      // The extension content-script discriminator: chrome.runtime.id present.
+      expect(src.contains('chrome.runtime && chrome.runtime.id'), isTrue,
+          reason: '[$path] 必须用 chrome.runtime.id 判定扩展 content-script 上下文');
+      // The bail: not over the popup shadow (scroller null) AND in the extension
+      // -> return before preventDefault so native scrolling wins.
+      expect(src.contains('if (!scroller && inExtensionContentScript) return;'),
+          isTrue,
+          reason: '[$path] 扩展宿主页（滚轮不在弹窗内）必须回落原生滚动，禁止 preventDefault');
+      // The guard must sit BEFORE preventDefault, otherwise the scaled scroll
+      // still hijacks the host page.
+      final int guardIdx =
+          src.indexOf('if (!scroller && inExtensionContentScript) return;');
+      final int preventIdx = src.indexOf('e.preventDefault();', guardIdx - 400);
+      expect(guardIdx >= 0 && preventIdx > guardIdx, isTrue,
+          reason: '[$path] 放行守卫必须在 e.preventDefault() 之前');
+    }
+  });
+
+  test('the three popup.js copies stay byte-identical (TODO-1267 parity)', () {
+    final String a = File('assets/popup/popup.js').readAsStringSync();
+    final String b =
+        File('assets/browser_extension/vendor/popup.js').readAsStringSync();
+    final String c =
+        File('../tools/browser-extension/vendor/popup.js').readAsStringSync();
+    expect(a == b, isTrue, reason: 'assets/popup 与扩展 vendor 镜像必须逐字节一致');
+    expect(a == c, isTrue, reason: 'assets/popup 与 tools 扩展镜像必须逐字节一致');
+  });
+}
+
+/// Resolve a usable `node` executable, returning null when none is on PATH.
+String? _resolveNode() {
+  final List<String> candidates =
+      Platform.isWindows ? <String>['node.exe', 'node'] : <String>['node'];
+  for (final String name in candidates) {
+    try {
+      final ProcessResult probe = Process.runSync(name, <String>['--version']);
+      if (probe.exitCode == 0) {
+        return name;
+      }
+    } on ProcessException {
+      // Not found; try next candidate.
+    }
+  }
+  return null;
+}

--- a/hibiki/test/lookup/browser_extension_page_scroll_bug731_test.js
+++ b/hibiki/test/lookup/browser_extension_page_scroll_bug731_test.js
@@ -1,0 +1,169 @@
+// BUG-731 behavior test: the shared lookup popup wheel handler must NOT hijack a
+// normal web page's scrolling when Hibiki's browser extension is installed.
+//
+// Root cause it locks: popup.js is injected as a content script on <all_urls>.
+// Its document 'wheel' listener re-implements scrolling for the *dictionary
+// popup* (scaled by POPUP_WHEEL_PIXEL_FACTOR = 0.24, with preventDefault). When
+// the wheel is over the host page (not the popup shadow) the handler used to fall
+// through to `window.scrollBy` — commandeering every normal page's scroll at 24%
+// speed. The fix: in the extension content-script context (chrome.runtime.id
+// present) a wheel that is NOT over the popup shadow must fall through to native
+// scrolling (no preventDefault). The in-app popup (flutter_inappwebview, no
+// chrome) and wheels over the popup itself keep the custom scaled scroll.
+//
+// This EXECUTES the real popup.js wheel handler against a minimal fake DOM and
+// asserts preventDefault / scrollBy per surface. Reverting the guard turns it red.
+//
+// Run: node hibiki/test/lookup/browser_extension_page_scroll_bug731_test.js
+// (also driven from browser_extension_page_scroll_bug731_test.dart inside
+//  `flutter test`).
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const popupPath = path.resolve(__dirname, '../../assets/popup/popup.js');
+const source = fs.readFileSync(popupPath, 'utf8');
+
+// Build a sandbox, load popup.js, and return the captured wheel handler plus
+// recorders for the behaviours we assert on.
+function loadWheelHandler(opts) {
+  const calls = {
+    prevented: false,
+    windowScrollBy: [],
+    hostScrollBy: [],
+  };
+
+  let wheelHandler = null;
+
+  const hostEl = {
+    style: {},
+    scrollBy(arg) { calls.hostScrollBy.push(arg); },
+  };
+
+  const documentObj = {
+    documentElement: { style: {} },
+    body: { tagName: 'BODY' },
+    addEventListener(type, handler) {
+      if (type === 'wheel') wheelHandler = handler;
+    },
+  };
+
+  const windowObj = {
+    innerHeight: 800,
+    addEventListener() {},
+    scrollBy(arg) { calls.windowScrollBy.push(arg); },
+    getSelection() { return { toString() { return ''; } }; },
+    getComputedStyle() { return {}; },
+  };
+  // __hibikiRoot.host is the shadow host; only present when a popup is open.
+  windowObj.__hibikiRoot = opts.popupOpen ? { host: hostEl } : undefined;
+  if (opts.flutter) {
+    windowObj.flutter_inappwebview = { callHandler() { return Promise.resolve(false); } };
+  }
+
+  const sandbox = {
+    Node: { TEXT_NODE: 3, ELEMENT_NODE: 1 },
+    Date, Math, URL, JSON, RegExp, Set, Map, Object, Array, Number, Boolean,
+    String, console,
+    performance: { now() { return 1000; } },
+    setTimeout, clearTimeout,
+    DOMParser: class { parseFromString() { return { body: {}, querySelectorAll() { return []; } }; } },
+    document: documentObj,
+    window: windowObj,
+    getComputedStyle() { return {}; },
+  };
+  if (opts.extension) {
+    sandbox.chrome = { runtime: { id: 'hibiki-extension-id' } };
+  }
+  sandbox.globalThis = sandbox;
+
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox, { filename: 'popup.js' });
+
+  assert.ok(typeof wheelHandler === 'function',
+    'popup.js must register a document wheel handler');
+
+  return { wheelHandler, calls, hostEl };
+}
+
+// A vertical mouse-notch wheel event over `target`; composedPath is [target,
+// ...ancestors]. deltaMode 0 (pixels) so deltaPx === deltaY.
+function makeWheelEvent(target, ancestors, calls) {
+  const pathArr = [target].concat(ancestors || []);
+  return {
+    ctrlKey: false,
+    deltaY: 100,
+    deltaX: 0,
+    deltaMode: 0,
+    target,
+    composedPath() { return pathArr; },
+    preventDefault() { calls.prevented = true; },
+  };
+}
+
+// Case A — the bug: extension installed, wheel over the HOST PAGE (no popup /
+// wheel not over the popup). Native scrolling must win: no preventDefault, no
+// custom window.scrollBy.
+(function extensionHostPageFallsThroughToNative() {
+  const { wheelHandler, calls } = loadWheelHandler({ extension: true, popupOpen: false });
+  const target = { nodeType: 1, parentElement: null };
+  wheelHandler(makeWheelEvent(target, [], calls));
+
+  assert.strictEqual(calls.prevented, false,
+    'extension host-page wheel must NOT call preventDefault (native scroll)');
+  assert.strictEqual(calls.windowScrollBy.length, 0,
+    'extension host-page wheel must NOT run the scaled window.scrollBy');
+})();
+
+// Case A2 — the bug persists even while a popup is open, as long as the wheel is
+// over the host page (composedPath does not cross the shadow host).
+(function extensionHostPageWithPopupOpenStillNative() {
+  const { wheelHandler, calls } = loadWheelHandler({ extension: true, popupOpen: true });
+  const target = { nodeType: 1, parentElement: null };
+  wheelHandler(makeWheelEvent(target, [], calls)); // path never includes hostEl
+
+  assert.strictEqual(calls.prevented, false,
+    'wheel over host page (popup open) must still fall through to native');
+  assert.strictEqual(calls.windowScrollBy.length, 0,
+    'wheel over host page (popup open) must not scroll the window custom');
+})();
+
+// Case B — extension, wheel OVER the popup shadow: the custom scaled scroll must
+// still drive the shadow host (the popup's real scroll container). Unchanged.
+(function extensionWheelOverPopupScrollsHost() {
+  const { wheelHandler, calls, hostEl } = loadWheelHandler({ extension: true, popupOpen: true });
+  const inner = { nodeType: 1, parentElement: null };
+  // composedPath crosses the shadow host -> __hibikiWheelScroller returns it.
+  wheelHandler(makeWheelEvent(inner, [hostEl], calls));
+
+  assert.strictEqual(calls.prevented, true,
+    'wheel over the popup must preventDefault (custom scaled scroll)');
+  assert.strictEqual(calls.hostScrollBy.length, 1,
+    'wheel over the popup must scroll the shadow host');
+  assert.strictEqual(calls.windowScrollBy.length, 0,
+    'wheel over the popup must not scroll the window');
+  const step = calls.hostScrollBy[0].top;
+  assert.ok(step > 0 && step <= 120,
+    'popup scroll step must be the scaled/clamped delta, got ' + step);
+})();
+
+// Case C — the in-app popup document (flutter_inappwebview, no chrome): the whole
+// document IS the popup, so window.scrollBy custom scroll must keep working. This
+// is the regression guard: the fix must not disable in-app popup scrolling.
+(function inAppPopupKeepsWindowScroll() {
+  const { wheelHandler, calls } = loadWheelHandler({ extension: false, flutter: true, popupOpen: false });
+  const target = { nodeType: 1, parentElement: null };
+  wheelHandler(makeWheelEvent(target, [], calls));
+
+  assert.strictEqual(calls.prevented, true,
+    'in-app popup wheel must preventDefault (custom document scroll)');
+  assert.strictEqual(calls.windowScrollBy.length, 1,
+    'in-app popup wheel must drive window.scrollBy');
+  const step = calls.windowScrollBy[0].top;
+  assert.ok(step > 0 && step <= 120,
+    'in-app popup scroll step must be the scaled/clamped delta, got ' + step);
+})();
+
+console.log('all assertions passed');

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -3652,6 +3652,15 @@ document.addEventListener('wheel', (e) => {
     const deltaPx = popupWheelDeltaToPixels(e.deltaY, e.deltaMode, window.innerHeight);
     if (deltaPx === 0) return;
     if (popupAncestorAbsorbsVerticalWheel(__hibikiEventTarget(e), deltaPx)) return;
+    // BUG-731: 这段缩放平滑滚动只服务查词弹窗。扩展里弹窗是宿主页上的 shadow 覆盖层，
+    // __hibikiWheelScroller 仅当滚轮 composedPath 穿过弹窗 shadow 才返回 host；返回 null
+    // 时唯一合法「滚 window」的表面是 in-app 弹窗文档（整份文档即弹窗，且无 chrome.runtime）。
+    // 普通网页上扩展 content script 有 chrome.runtime.id，此时滚轮不在弹窗内绝不能接管：
+    // 否则整页被 POPUP_WHEEL_PIXEL_FACTOR(0.24) 降速 + preventDefault 抢走原生滚动。
+    const scroller = __hibikiWheelScroller(e);
+    const inExtensionContentScript =
+        typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
+    if (!scroller && inExtensionContentScript) return;
     e.preventDefault();
     // Scale each notch down first, cap unusually large visual deltas, then
     // divide by zoom so the on-screen step is zoom-independent.
@@ -3660,7 +3669,6 @@ document.addEventListener('wheel', (e) => {
     // the shadow host is the scroll container (the ancestor walk above cannot
     // cross the shadow boundary, so it never absorbs there). In-app popup and
     // wheels over the host page: the window, exactly as before the shadow move.
-    const scroller = __hibikiWheelScroller(e);
     const layoutStep = visualStep / popupCurrentZoom(scroller);
     // TODO-1387: carry the sub-pixel remainder across events. A precision touchpad
     // reports deltaMode=PIXEL with a tiny fractional deltaY (~1-4 per frame); after


### PR DESCRIPTION
## 问题
用户报告：安装 Hibiki 浏览器扩展后，普通网页的滚动速度变慢。

## 根因
扩展 `manifest.json` 把 `vendor/popup.js` 作为 content script 注入到 `<all_urls>`（每个网页）。popup.js 的 `document` 'wheel' 监听是为**查词弹窗**定制的缩放平滑滚动：`e.preventDefault()` 后按 `POPUP_WHEEL_PIXEL_FACTOR = 0.24` 缩放并自行 `scrollBy`。

弹窗在扩展里是宿主页上的 shadow DOM 覆盖层。`__hibikiWheelScroller(e)` 仅当滚轮 `composedPath` 穿过弹窗 shadow 才返回 host；否则返回 null，旧代码 fallthrough 到 `else { window.scrollBy(...) }`，把**整个普通网页**的滚动接管并降速到 24%。shadow host 懒创建（弹窗关闭时 `window.__hibikiRoot = null`），所以宿主页大部分时间都走这条 null 分支。

## 修复
在 `e.preventDefault()` 之前加放行守卫：扩展 content-script 上下文（`typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.id`）里，滚轮不在弹窗 shadow 内（`!scroller`）时直接 `return`，回落原生滚动。

不变的两条路径：
- in-app 弹窗（有 `flutter_inappwebview`、无 `chrome`）——整份文档即弹窗，继续 `window.scrollBy` 缩放滚动。
- 扩展里滚轮就在弹窗内——继续滚 shadow host。

三镜像（`assets/popup/popup.js` + 两份扩展 `vendor/popup.js`）逐字节同步（TODO-1267）。

## 测试
- `test/lookup/browser_extension_page_scroll_bug731_test.js`：Node 真执行 popup.js 的 wheel 监听，断言四种表面（扩展宿主页/扩展宿主页+弹窗开/扩展弹窗内/in-app 弹窗）的 `preventDefault`、`window.scrollBy`、`host.scrollBy` 调用。移除守卫行后 Case A 立即变红（已本地验证）。
- `test/lookup/browser_extension_page_scroll_bug731_test.dart`：node 驱动 + 源码守卫（守卫在 preventDefault 之前 + `chrome.runtime.id` 判据）+ 三镜像字节一致。
- 相关既有守卫无回归：`browser_extension_popup_wheel_surface_guard_test` / `browser_extension_popup_parity_guard_test`（本 PR 相关 3 + 8 + 10 = 21 tests all passed）。

## 待验证
真机：装扩展后普通网页鼠标滚轮/触摸板滚动恢复原速；查词弹窗内滚动仍正常。

BUG-731（号取 731 而非工具自动分配的 730——730 被未合的 PR#36 占用）。
