### PR TITLE
fix(stats): 手机窄屏统计页文字换行不再被裁切 (BUG-733)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 717 条。点号进各自文件。
+> 共 718 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-733](bugs/BUG-733-stats-mobile-text-clip.md) | ✅ | ✅ | 手机统计页文字被省略号裁切显示不全 |
 | [BUG-732](bugs/BUG-732-ext-page-scroll.md) | ✅ | ✅ | 扩展影响普通网页滚动速度 |
 | [BUG-731](bugs/BUG-731-backup-font-count-inflated.md) | ✅ | ✅ | 备份导出自定义字体计数虚高(2个显示7个) |
 | [BUG-730](bugs/BUG-730-clipboard-mine-sentence.md) | ✅ | ✅ | 剪贴板/全局查词制卡句子字段恒空（未接剪贴板文本） |

--- a/docs/bugs/BUG-733-stats-mobile-text-clip.md
+++ b/docs/bugs/BUG-733-stats-mobile-text-clip.md
@@ -1,0 +1,10 @@
+## BUG-733 · 手机统计页文字被省略号裁切显示不全
+- **报告**：2026-07-11（用户：手机上统计页「有好多显示不全的字」）
+- **真实性**：✅ 真 bug。根因在统计页的小格子把 `Text` 钉死 `maxLines: 1` + `TextOverflow.ellipsis`：
+  - `reading_statistics_page.dart` `_miniStat`（原 886/896 行，速度/连击/收藏三宫格，每格约 1/3 卡片宽）
+  - `reading_statistics_page.dart` `_summaryTile`（原 967/977 行，速度摘要半宽六宫格；其中 `_extremeTile` 还塞进「速度 · 日期」复合值，半宽单行必被裁）
+  - `reading_statistics_page.dart` 按书标题（原 1264 行）与 `video_statistics_page.dart` 视频标题（462 行）
+  手机窄屏下这些格子放不下中文标签/复合数值，单行被省略号截断 → 「显示不全的字」。
+- **[x] ① 已修复** — commit 见下。去掉 `maxLines: 1` 特例，让文字自然换行：把 `_miniStat` / `_summaryTile` 提取为可测试的公有 widget `StatMiniTile` / `StatSummaryTile`，数值与标签改 `maxLines: 2` + `softWrap: true`（`ellipsis` 仅作极端长文案兜底）；两处标题 `maxLines` 1→2。改动文件：`reading_statistics_page.dart` / `video_statistics_page.dart`。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/reading_statistics_text_clip_test.dart`：在窄约束下渲染真实生产 widget，量出单行基线高度后再在「逼出恰好 2 行」的宽度渲染，断言 `didExceedMaxLines == false`（完整可读）且高度高于单行（确实换行）。反向对照：临时把 `maxLines` 改回 1，两条用例均变红，证明守卫有效。
+- **备注**：本次只放开换行，未改列数/断点。若后续用户仍嫌三宫格/半宽格拥挤，可再做窄屏自适应列数（phase 2）。`_summaryStatPanel` 计数行本就无 `maxLines`（软换行，只挤不裁），非本 bug 范围。

--- a/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
@@ -865,45 +865,8 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     );
   }
 
-  Widget _miniStat(String label, String value) {
-    final ColorScheme scheme = Theme.of(context).colorScheme;
-    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
-    return Container(
-      margin: EdgeInsets.only(right: tokens.spacing.gap),
-      padding: EdgeInsets.symmetric(
-        horizontal: tokens.spacing.card,
-        vertical: tokens.spacing.gap + tokens.spacing.gap / 2,
-      ),
-      decoration: BoxDecoration(
-        color: scheme.surfaceContainerHighest,
-        borderRadius: tokens.radii.cardRadius,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(
-            value,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: scheme.onSurface,
-                  fontWeight: FontWeight.bold,
-                ),
-          ),
-          SizedBox(height: tokens.spacing.gap / 2),
-          Text(
-            label,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context)
-                .textTheme
-                .bodySmall
-                ?.copyWith(color: scheme.onSurfaceVariant),
-          ),
-        ],
-      ),
-    );
-  }
+  Widget _miniStat(String label, String value) =>
+      StatMiniTile(label: label, value: value);
 
   /// 「速度摘要」卡：加权均速 / 典型日 / 近 7 活跃日 / 较前 14 天 / 最快·最慢日。
   Widget _buildSpeedSummaryPanel() {
@@ -951,40 +914,8 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     );
   }
 
-  Widget _summaryTile(String label, String value, {Color? valueColor}) {
-    final ColorScheme scheme = Theme.of(context).colorScheme;
-    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
-    return Padding(
-      padding: EdgeInsets.only(
-        right: tokens.spacing.gap,
-        bottom: tokens.spacing.card,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(
-            value,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: valueColor ?? scheme.onSurface,
-                  fontWeight: FontWeight.bold,
-                ),
-          ),
-          SizedBox(height: tokens.spacing.gap / 2),
-          Text(
-            label,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context)
-                .textTheme
-                .bodySmall
-                ?.copyWith(color: scheme.onSurfaceVariant),
-          ),
-        ],
-      ),
-    );
-  }
+  Widget _summaryTile(String label, String value, {Color? valueColor}) =>
+      StatSummaryTile(label: label, value: value, valueColor: valueColor);
 
   Widget _deltaTile(double? delta) {
     final ColorScheme scheme = Theme.of(context).colorScheme;
@@ -1261,7 +1192,7 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
             children: [
               Text(
                 book.title,
-                maxLines: 1,
+                maxLines: 2,
                 overflow: TextOverflow.ellipsis,
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
@@ -1312,4 +1243,114 @@ class _BookData {
 
   /// 该书阅读速度（字/小时）。复用统一口径的 [computeCph]。
   double get cph => computeCph(chars, ms);
+}
+
+/// 「今日」面板底部三宫格里的单个迷你统计（速度/连击/收藏）。
+///
+/// 手机窄屏下每格只有约 1/3 卡片宽，之前 [Text] 被 `maxLines: 1` 钉死会把
+/// 中文标签和数值裁成省略号（BUG：手机统计页「好多显示不全的字」）。这里让
+/// 数值与标签都能换行到 2 行，`ellipsis` 只作极端长文案的最后兜底。
+class StatMiniTile extends StatelessWidget {
+  const StatMiniTile({super.key, required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme scheme = Theme.of(context).colorScheme;
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return Container(
+      margin: EdgeInsets.only(right: tokens.spacing.gap),
+      padding: EdgeInsets.symmetric(
+        horizontal: tokens.spacing.card,
+        vertical: tokens.spacing.gap + tokens.spacing.gap / 2,
+      ),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest,
+        borderRadius: tokens.radii.cardRadius,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            value,
+            maxLines: 2,
+            softWrap: true,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: scheme.onSurface,
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          SizedBox(height: tokens.spacing.gap / 2),
+          Text(
+            label,
+            maxLines: 2,
+            softWrap: true,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context)
+                .textTheme
+                .bodySmall
+                ?.copyWith(color: scheme.onSurfaceVariant),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 「速度摘要」卡里的半宽小格（加权均速 / 典型日 / 最快·最慢日 等）。
+///
+/// 同样为窄屏放开换行：`_extremeTile` 会塞进「速度 · 日期」这类复合值，半宽格
+/// 单行必被裁；允许 2 行后完整可读，`ellipsis` 仅兜底极端长值。
+class StatSummaryTile extends StatelessWidget {
+  const StatSummaryTile({
+    super.key,
+    required this.label,
+    required this.value,
+    this.valueColor,
+  });
+
+  final String label;
+  final String value;
+  final Color? valueColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme scheme = Theme.of(context).colorScheme;
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return Padding(
+      padding: EdgeInsets.only(
+        right: tokens.spacing.gap,
+        bottom: tokens.spacing.card,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            value,
+            maxLines: 2,
+            softWrap: true,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: valueColor ?? scheme.onSurface,
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          SizedBox(height: tokens.spacing.gap / 2),
+          Text(
+            label,
+            maxLines: 2,
+            softWrap: true,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context)
+                .textTheme
+                .bodySmall
+                ?.copyWith(color: scheme.onSurfaceVariant),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/hibiki/lib/src/pages/implementations/video_statistics_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_statistics_page.dart
@@ -459,7 +459,7 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
             children: [
               Text(
                 video.title,
-                maxLines: 1,
+                maxLines: 2,
                 overflow: TextOverflow.ellipsis,
                 style: Theme.of(context).textTheme.bodyMedium,
               ),

--- a/hibiki/test/pages/reading_statistics_text_clip_test.dart
+++ b/hibiki/test/pages/reading_statistics_text_clip_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/reading_statistics_page.dart';
+
+/// 回归守卫：手机窄屏统计页「好多显示不全的字」。
+///
+/// 统计页的小格子（[StatMiniTile] / [StatSummaryTile]）过去把 [Text] 钉死
+/// `maxLines: 1`，手机上 1/3~1/2 卡片宽放不下中文标签或「速度·日期」复合值，
+/// 就被省略号裁掉。修复放开到 2 行换行。本测试在窄约束下渲染真实生产 widget，
+/// 断言换行后未溢出 maxLines（完整可读），并用「窄屏高度 > 单行基线高度」佐证
+/// 该宽度确实放不下单行——即若回退成 `maxLines: 1` 必被裁，测试会失败。
+void main() {
+  RenderParagraph paragraphOf(WidgetTester tester, String text) {
+    return tester.renderObject<RenderParagraph>(find.text(text));
+  }
+
+  Future<void> pumpTile(WidgetTester tester, Widget child, double width) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(width: width, child: child),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('StatSummaryTile 窄屏复合值换行不被裁', (WidgetTester tester) async {
+    const String value = '12345 字/小时 · 06-07';
+    const String label = '最快的一天';
+    const Widget tile = StatSummaryTile(label: label, value: value);
+
+    // 单行基线：极宽约束下复合值必然只占 1 行。
+    await pumpTile(tester, tile, 1000);
+    final double singleLineHeight = paragraphOf(tester, value).size.height;
+
+    // 手机半宽速度摘要格：单行放不下，需换到 2 行（测试字体全宽 CJK 下 W≈291，
+    // 可用宽=box-gap(8)=192∈(W/2, W) → 恰好 2 行且放得下）。
+    await pumpTile(tester, tile, 200);
+    final RenderParagraph valuePara = paragraphOf(tester, value);
+
+    expect(valuePara.didExceedMaxLines, isFalse, reason: '复合数值应换行显示完整，不被省略号裁掉');
+    expect(valuePara.size.height, greaterThan(singleLineHeight),
+        reason: '窄屏该值已换行（高于单行基线），单行必被裁——证明 2 行是修复关键');
+
+    expect(paragraphOf(tester, label).didExceedMaxLines, isFalse);
+  });
+
+  testWidgets('StatMiniTile 窄屏长标签换行不被裁', (WidgetTester tester) async {
+    const String label = '加权平均阅读速度';
+    const String value = '12345 字/时';
+    const Widget tile = StatMiniTile(label: label, value: value);
+
+    await pumpTile(tester, tile, 1000);
+    final double singleLineHeight = paragraphOf(tester, label).size.height;
+
+    // 三宫格每格宽度量级；MiniTile 水平开销=gap(8)+card*2(40)=48，
+    // 可用宽=130-48=82∈(W/2, W)（标签 W≈99）→ 恰好 2 行且放得下。
+    await pumpTile(tester, tile, 130);
+    final RenderParagraph labelPara = paragraphOf(tester, label);
+
+    expect(labelPara.didExceedMaxLines, isFalse, reason: '中文标签应换行显示完整，不被省略号裁掉');
+    expect(labelPara.size.height, greaterThan(singleLineHeight),
+        reason: '窄格该标签已换行，单行必被裁');
+  });
+}


### PR DESCRIPTION
## 问题
用户反馈：手机上统计页「有好多显示不全的字」。

## 根因
统计页小格子把 `Text` 钉死 `maxLines: 1` + `ellipsis`：
- `reading_statistics_page.dart` `_miniStat`（速度/连击/收藏三宫格，每格约 1/3 卡片宽）
- `_summaryTile`（速度摘要半宽六宫格；`_extremeTile` 还塞「速度 · 日期」复合值）
- 按书标题 + `video_statistics_page.dart` 视频标题

手机窄屏放不下中文标签/复合值 → 单行被省略号截断。

## 修复
去掉 `maxLines:1` 特例、让文字自然换行：
- 把 `_miniStat`/`_summaryTile` 提取为公有 `StatMiniTile`/`StatSummaryTile`，数值+标签改 `maxLines: 2` + `softWrap`（`ellipsis` 仅兜底极端长文案）
- 两处标题 `maxLines` 1→2

## 测试
新增 `reading_statistics_text_clip_test.dart`：窄约束下渲染真实生产 widget，断言换行后 `didExceedMaxLines==false` 且高于单行基线。反向对照把 `maxLines` 改回 1 → 两用例均红，证明守卫有效。`flutter analyze` 干净；含 386 项统计相关测试全绿。

## 备注
只放开换行，未改列数/断点；如仍嫌拥挤可再做窄屏自适应列数（phase 2）。**待真机复测** 原始失败路径（Android 手机统计页）。