### PR TITLE
fix(shelf): 书架添加按钮尺寸与其它头部按钮对齐 (BUG-735)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 719 条。点号进各自文件。
+> 共 720 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-735](bugs/BUG-735-shelf-add-button-size.md) | ✅ | ✅ | 书架添加按钮尺寸位置与其它头部按钮不一致 |
 | [BUG-734](bugs/BUG-734-stats-mobile-text-clip.md) | ✅ | ✅ | 手机统计页文字被省略号裁切显示不全 |
 | [BUG-733](bugs/BUG-733-popup-glossary-ruby-element-base-overlap.md) | ✅ | ✅ | 词典弹窗释义正文元素基字 ruby 注音塌到基字上 |
 | [BUG-732](bugs/BUG-732-ext-page-scroll.md) | ✅ | ✅ | 扩展影响普通网页滚动速度 |

--- a/docs/bugs/BUG-735-shelf-add-button-size.md
+++ b/docs/bugs/BUG-735-shelf-add-button-size.md
@@ -1,0 +1,6 @@
+## BUG-735 · 书架添加按钮尺寸位置与其它头部按钮不一致
+- **报告**：2026-07-11（用户：）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/sources/reader_hibiki_source.dart:304`（修复前）——`buildBookImportButton` 唯一显式传了 `size: Theme.of(context).textTheme.titleLarge?.fontSize`（Material3 里约 22），而书架页头同排的其它按钮（管理来源/合集/统计）走 `_headerAction → HibikiIconButton`（`reader_hibiki_history_page.dart:410`）不传 size、用默认 24（见 `hibiki_icon_button.dart:36`）；视频 tab 的导入按钮（`home_video_page.dart:1425`）同样默认 24。于是「添加」按钮图标小 2px、外框（同 gap padding 内的更小图标）也短一截，看起来大小和位置都对不齐。
+- **[x] ① 已修复** — 去掉 `buildBookImportButton` 的 `size` 覆盖，回落默认 24 与所有兄弟按钮对齐（`reader_hibiki_source.dart:303` 附近）。提交见下。
+- **[x] ② 已加自动化测试** — `hibiki/test/tools/shelf_import_button_size_guard_test.dart`：源码扫描守卫，断言 `buildBookImportButton` 方法体内不得再出现显式 `size:`，防止回归。
+- **备注**：纯尺寸对齐修复，无逻辑改动；`context` 参数仍被 `showAppDialog` 使用未变悬空。真机目视待用户确认。

--- a/hibiki/lib/src/media/sources/reader_hibiki_source.dart
+++ b/hibiki/lib/src/media/sources/reader_hibiki_source.dart
@@ -300,8 +300,11 @@ class ReaderHibikiSource extends ReaderMediaSource {
     required AppModel appModel,
     HibikiFocusId? focusId,
   }) {
+    // 不覆盖 size：书架页头同排的其它按钮（管理来源 / 合集 / 统计，走
+    // _headerAction → HibikiIconButton）与视频 tab 的导入按钮都用默认 24。
+    // 此前这里显式塞 titleLarge.fontSize(~22) 让「添加」按钮比兄弟小一圈、
+    // 外框也短一截，看起来大小和位置都对不齐（BUG-735）。回落默认即对齐。
     return HibikiIconButton(
-      size: Theme.of(context).textTheme.titleLarge?.fontSize,
       tooltip: t.srt_import,
       icon: Icons.library_add_outlined,
       focusId: focusId,

--- a/hibiki/test/tools/shelf_import_button_size_guard_test.dart
+++ b/hibiki/test/tools/shelf_import_button_size_guard_test.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards the BUG-735 fix: the shelf "添加" (book import) header button must
+/// match the size of its sibling header buttons (管理来源 / 合集 / 统计, which
+/// go through `_headerAction` → `HibikiIconButton` with the default 24) and the
+/// video tab's own import button (also default 24).
+///
+/// The regression was `buildBookImportButton` passing an explicit
+/// `size: Theme.of(context).textTheme.titleLarge?.fontSize` (~22), making the
+/// add button visibly smaller and its box shorter than its neighbours, so it
+/// read as "位置大小不一样". A source-level guard is the strongest landing layer:
+/// it prevents anyone re-introducing a `size:` override into that one builder
+/// without having to stand up the full shelf page (AppModel + DB) in a widget
+/// test.
+void main() {
+  test('buildBookImportButton passes no explicit size (BUG-735)', () {
+    final String source =
+        File('lib/src/media/sources/reader_hibiki_source.dart')
+            .readAsStringSync();
+
+    // Isolate the buildBookImportButton method body up to the closing of the
+    // returned HibikiIconButton so we only inspect this one builder.
+    final int start = source.indexOf('Widget buildBookImportButton(');
+    expect(start, greaterThanOrEqualTo(0),
+        reason:
+            'buildBookImportButton must exist in reader_hibiki_source.dart.');
+    final int end = source.indexOf('\n  }', start);
+    expect(end, greaterThan(start),
+        reason: 'Could not find the end of buildBookImportButton.');
+    final String body = source.substring(start, end);
+
+    // The returned HibikiIconButton must NOT set an explicit icon size — a
+    // `size:` argument here diverges from the default-24 sibling buttons and
+    // re-opens BUG-735.
+    expect(body.contains('size:'), isFalse,
+        reason: 'buildBookImportButton must not pass an explicit `size:` to '
+            'HibikiIconButton — the shelf/video header buttons use the default '
+            '24, and overriding it made the add button smaller (BUG-735).');
+  });
+}


### PR DESCRIPTION
## 问题
书架页头「添加」按钮比同排其它按钮（管理来源/合集/统计）小一圈，位置也对不齐。

## 根因
`buildBookImportButton`（`reader_hibiki_source.dart`）唯一显式传了 `size: Theme.of(context).textTheme.titleLarge?.fontSize`（Material3 约 22），而兄弟按钮走 `_headerAction → HibikiIconButton` 用默认 24；视频 tab 导入按钮同样默认 24。图标小 2px、外框也短一截 → 大小位置都错位。

## 修复
去掉该 `size` 覆盖，回落默认 24 与所有兄弟按钮对齐。纯尺寸对齐，无逻辑改动。

## 测试
- 新增源码扫描守卫 `test/tools/shelf_import_button_size_guard_test.dart`：断言 `buildBookImportButton` 不得再显式传 `size:`（防回归）。✅ 通过
- `flutter analyze`：No issues found

真机目视待用户确认。