### PR TITLE
fix(extension): 扩展查词弹窗补发 4 个漏掉的主题 CSS 变量 (BUG-735)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 719 条。点号进各自文件。
+> 共 720 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-735](bugs/BUG-735-extension-popup-theme-vars.md) | ✅ | ✅ | 浏览器扩展查词弹窗主题与 app 不一致(漏发4个CSS变量) |
 | [BUG-734](bugs/BUG-734-stats-mobile-text-clip.md) | ✅ | ✅ | 手机统计页文字被省略号裁切显示不全 |
 | [BUG-733](bugs/BUG-733-popup-glossary-ruby-element-base-overlap.md) | ✅ | ✅ | 词典弹窗释义正文元素基字 ruby 注音塌到基字上 |
 | [BUG-732](bugs/BUG-732-ext-page-scroll.md) | ✅ | ✅ | 扩展影响普通网页滚动速度 |

--- a/docs/bugs/BUG-735-extension-popup-theme-vars.md
+++ b/docs/bugs/BUG-735-extension-popup-theme-vars.md
@@ -1,0 +1,26 @@
+## BUG-735 · 浏览器扩展查词弹窗主题与 app 不一致(漏发4个CSS变量)
+- **报告**：2026-07-11（用户：查词弹窗在浏览器里和 app 内不一样）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/models/app_model.dart:2288`（`browserExtensionThemeColors()` 返回的 theme map）。
+- **[x] ① 已修复** — `app_model.dart` `browserExtensionThemeColors()` 补发 4 个变量（提交见备注）。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/browser_extension_theme_var_parity_guard_test.dart`（源码扫描：断言 in-app 注入的每个变量都在服务器 map 中 + 4 个变量显式钉死）。
+- **备注**：
+
+  **现象**：浏览器扩展（Netflix/YouTube/任意网页划词）里的查词弹窗和 app 内的观感不一样，最明显是**查到的词高亮成灰色**，而 app 内是主题主色。
+
+  **根因**：扩展弹窗和 app 内用**同一份 popup.js/css**，但主题注入是两套：
+  - app 内：Flutter 直接往弹窗 `documentElement` `setProperty` 全套 CSS 变量（`popup_settings_injection.dart` / `dictionary_popup_webview.dart`）。
+  - 扩展：靠查词响应的 `theme` 字段下发（`AppModel.browserExtensionThemeColors()`），`content.js` 只把该 map 里**有的** key `setProperty` 到 `#entries-container`。
+
+  服务器 map 只发了 13 个变量，**漏了 in-app 注入器里的 4 个**，扩展只能吃 popup.css 硬编码兜底：
+  | 变量 | 漏发后兜底 | 影响 |
+  |---|---|---|
+  | `--hoshi-primary-highlight` | 灰 `rgba(160,160,160,0.4)` | 查到词高亮变灰（最扎眼） |
+  | `--md-on-primary` | 白 `#fff` | 主色上文字色 |
+  | `--hibiki-radius-card` | `10px` | 卡片圆角 |
+  | `--hibiki-card-bg-rgb` | 纯白 `255,255,255` | 卡片底色 alpha |
+
+  用实际运行的服务器（`127.0.0.1:19633`，app build `86ca7bd`）curl `/api/lookup/dictionary`，回的 `theme` 确实只有 13 键、缺这 4 个 → 证据确凿。`extensionBuild` 与装机扩展 build 一致，排除「扩展过期」。
+
+  **修复**：在 `browserExtensionThemeColors()` 里补发这 4 个变量，表达式与两个 in-app 注入器逐字节同源（`--hoshi-primary-highlight`=primary@0.35、`--md-on-primary`=onPrimary、`--hibiki-radius-card`=`HibikiRadii.cardValue`、`--hibiki-card-bg-rgb`=bg 三元组）。改主题即实时生效，无需重装扩展。
+
+  **待真机**：需在真实浏览器扩展里划词复测高亮/圆角/文字色与 app 一致（自动化测试只能守住「变量已下发」，渲染观感需人工确认）。

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -2278,6 +2278,16 @@ class AppModel with ChangeNotifier {
     String rgb(Color c) => 'rgb(${(c.r * 255.0).round().clamp(0, 255)}, '
         '${(c.g * 255.0).round().clamp(0, 255)}, '
         '${(c.b * 255.0).round().clamp(0, 255)})';
+    // BUG-735：以下两个 helper 与 in-app 弹窗注入器（popup_settings_injection /
+    // dictionary_popup_webview）同款，用于补齐扩展此前漏发、退化成灰高亮/白字/直角的
+    // 变量。rgba035：查到词高亮色（primary @0.35 alpha）；triplet：卡片底色 RGB 三元组。
+    String rgba035(Color c) => 'rgba(${(c.r * 255.0).round().clamp(0, 255)}, '
+        '${(c.g * 255.0).round().clamp(0, 255)}, '
+        '${(c.b * 255.0).round().clamp(0, 255)}, 0.35)';
+    String triplet(Color c) => '${(c.r * 255.0).round().clamp(0, 255)}, '
+        '${(c.g * 255.0).round().clamp(0, 255)}, '
+        '${(c.b * 255.0).round().clamp(0, 255)}';
+    final Color bgColor = _overrideDictionaryColor ?? s.surface;
     // BUG-688：浏览器浮动弹窗只跟「词典字号」，**不叠加** app 的「界面大小」(appUiScale)。
     // 叠加 appUiScale 会把弹窗放大到 1.5×+ → 浮在网页上盖住大半屏、需滚动条，且大 zoom 作用于
     // 嵌套容器时触发 Blink「CSS zoom + 振假名(rt)绝对定位错位」→ 假名与正文重叠（app 内缩放的
@@ -2291,7 +2301,13 @@ class AppModel with ChangeNotifier {
       // 与 in-app _themeVariablesJs 一致地下发这两个核心变量；漏了它们会导致弹窗容器色回落到
       // data-theme 块的 #000/#fff 或宿主页继承（主题分裂：米卡 + 黑底 + 灰字）。
       '--text-color': rgb(s.onSurface),
-      '--background-color': rgb(_overrideDictionaryColor ?? s.surface),
+      '--background-color': rgb(bgColor),
+      // BUG-735：查到词的高亮色。漏发时 popup.css 回落到灰 rgba(160,160,160,0.4)，与 app
+      // 内的主题主色高亮不一致（这是「扩展弹窗和 app 不一样」最扎眼的一处）。
+      '--hoshi-primary-highlight': rgba035(s.primary),
+      // BUG-735：卡片底色 alpha 合成用的 RGB 三元组（配 popup.css 的 --hibiki-card-bg-alpha）。
+      // 漏发时回落到纯白 255,255,255。
+      '--hibiki-card-bg-rgb': triplet(bgColor),
       // BUG-688：app 当前明暗，content.js 据此把 #entries-container 的 data-theme 对齐 app
       // （而非宿主网页 prefers-color-scheme），根除「data-theme 跟宿主页 / --md-* 跟 app」的分裂。
       '--hibiki-color-scheme': themeNotifier.isDarkMode ? 'dark' : 'light',
@@ -2302,6 +2318,11 @@ class AppModel with ChangeNotifier {
       '--md-on-surface-variant': rgb(s.onSurfaceVariant),
       '--md-outline-variant': rgb(s.outlineVariant),
       '--md-primary': rgb(s.primary),
+      // BUG-735：主色上的文字/图标色（popup.css `color: var(--md-on-primary,#fff)`）。
+      '--md-on-primary': rgb(s.onPrimary),
+      // BUG-735：卡片圆角。漏发时 popup.css 回落到硬编码 10px，与 app 内用户设定的圆角
+      // （HibikiRadii.cardValue）不一致。与两个 in-app 注入器逐字节同源。
+      '--hibiki-radius-card': '${HibikiRadii.cardValue.toInt()}px',
       '--hibiki-popup-max-width': '${popupMaxWidth.round()}px',
       '--hibiki-popup-max-height': '${popupMaxHeight.round()}px',
       '--hibiki-popup-zoom': zoom.toStringAsFixed(4),

--- a/hibiki/test/pages/browser_extension_theme_var_parity_guard_test.dart
+++ b/hibiki/test/pages/browser_extension_theme_var_parity_guard_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-735 防回归守卫：浏览器扩展查词弹窗的主题变量必须与 app 内弹窗注入的**同一套** CSS
+/// 变量对齐。
+///
+/// 根因：扩展弹窗不吃 Flutter 直接注入，而是靠查词响应 `theme` 字段
+/// （[AppModel.browserExtensionThemeColors]）下发，content.js 只把该 map 里**有的** key
+/// `setProperty` 到 `#entries-container`。app 内两个注入器（popup_settings_injection /
+/// dictionary_popup_webview）设了 `--hoshi-primary-highlight` / `--md-on-primary` /
+/// `--hibiki-radius-card` / `--hibiki-card-bg-rgb`，但服务器 map 漏发 → 扩展退化成灰高亮 /
+/// 白字 / 直角 / 纯白底，肉眼「和 app 不一样」。
+///
+/// 本守卫钉死：popup_settings_injection.dart 每一个 `setProperty('--x', …)` 的变量，都必须
+/// 作为 key 出现在 `browserExtensionThemeColors()` 返回的 map 里（服务器 ⊇ in-app）。将来谁
+/// 给 in-app 加了主题变量却忘了同步扩展，本测试转红。
+void main() {
+  String read(String p) {
+    final File f = File(p);
+    expect(f.existsSync(), isTrue, reason: 'missing $p');
+    return f.readAsStringSync();
+  }
+
+  /// popup_settings_injection.dart 里所有 `setProperty('--x', …)` 的变量名。
+  Set<String> inAppInjectedVars() {
+    final String src =
+        read('lib/src/pages/implementations/popup_settings_injection.dart');
+    return RegExp(r"setProperty\('(--[a-z0-9-]+)'")
+        .allMatches(src)
+        .map((Match m) => m.group(1)!)
+        .toSet();
+  }
+
+  /// `browserExtensionThemeColors()` 返回 map 里的所有 `'--x':` key。
+  Set<String> serverThemeVars() {
+    final String src = read('lib/src/models/app_model.dart');
+    final int start = src.indexOf('browserExtensionThemeColors()');
+    expect(start, greaterThanOrEqualTo(0),
+        reason: 'browserExtensionThemeColors() not found in app_model.dart');
+    // 方法体到第一个 `};`（map 字面量的结束）。
+    final int mapEnd = src.indexOf('};', start);
+    expect(mapEnd, greaterThan(start));
+    final String body = src.substring(start, mapEnd);
+    return RegExp(r"'(--[a-z0-9-]+)':")
+        .allMatches(body)
+        .map((Match m) => m.group(1)!)
+        .toSet();
+  }
+
+  test('server theme map ships every var the in-app popup injects (BUG-735)',
+      () {
+    final Set<String> inApp = inAppInjectedVars();
+    final Set<String> server = serverThemeVars();
+    expect(inApp, isNotEmpty, reason: 'sanity: in-app injector parse failed');
+    final List<String> missing =
+        inApp.where((String v) => !server.contains(v)).toList()..sort();
+    expect(
+      missing,
+      isEmpty,
+      reason: 'browserExtensionThemeColors() 漏发了 in-app 弹窗注入的主题变量 '
+          '$missing —— 扩展弹窗会在这些变量上退化成 CSS 兜底值，和 app 不一致（BUG-735）。'
+          '在 app_model.dart 的 map 里补上同源的值。',
+    );
+  });
+
+  test('the four BUG-735 vars are explicitly present (regression pin)', () {
+    final Set<String> server = serverThemeVars();
+    for (final String v in const <String>[
+      '--hoshi-primary-highlight',
+      '--md-on-primary',
+      '--hibiki-radius-card',
+      '--hibiki-card-bg-rgb',
+    ]) {
+      expect(server.contains(v), isTrue,
+          reason: 'BUG-735 修复不得回退：server theme map 必须含 $v');
+    }
+  });
+}


### PR DESCRIPTION
## 现象
浏览器扩展（Netflix / YouTube / 任意网页划词）里的查词弹窗和 **app 内不一样**——最扎眼的是**查到的词高亮成灰色**，app 内是主题主色。

## 根因（用运行中的服务器实测确认）
扩展弹窗和 app 内用**同一份 popup.js/css**，但主题注入是两套：app 内 Flutter 直接 `setProperty` 全套变量；扩展靠查词响应的 `theme` 字段下发（`AppModel.browserExtensionThemeColors()`），`content.js` 只把 map 里**有的** key `setProperty` 到 `#entries-container`。

curl 运行中的服务器 `127.0.0.1:19633 /api/lookup/dictionary`，`theme` 只回 **13 个变量**，漏了 in-app 注入器里的 **4 个** → 扩展吃 popup.css 硬编码兜底：

| 变量 | 漏发兜底 | 影响 |
|---|---|---|
| `--hoshi-primary-highlight` | 灰 `rgba(160,160,160,0.4)` | 查到词高亮变灰（最扎眼） |
| `--md-on-primary` | 白 | 主色上文字色 |
| `--hibiki-radius-card` | `10px` | 卡片圆角 |
| `--hibiki-card-bg-rgb` | 纯白 | 卡片底色 alpha |

`extensionBuild` 与装机扩展 build 一致 → **排除扩展过期**；不是 DOM 结构、不是 content.css 缺样式，就是**服务器下发的主题变量不全**。

## 修复
`app_model.dart` `browserExtensionThemeColors()` 补发这 4 个变量，表达式与两个 in-app 注入器（`popup_settings_injection` / `dictionary_popup_webview`）逐字节同源。改主题即实时生效，无需重装扩展。

## 验证
- `flutter analyze`（含 test）：**No issues found**
- 新增 `browser_extension_theme_var_parity_guard_test.dart`（源码扫描：in-app 注入的每个变量都必须在服务器 map + 4 变量显式钉死）：**2 test 通过**
- BUG-735 记录（`docs/bugs/`，一 bug 一文件，①修复 ②测试 两勾）

## ⚠️ 待真机
自动化测试只能守「变量已下发」；实际扩展里划词的**高亮/圆角/文字色是否与 app 一致**需在真实浏览器人工复测。