### PR TITLE
fix(popup): declare UTF-8 in popup HTML — mine ✓ mojibake on Android (BUG-736)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 720 条。点号进各自文件。
+> 共 721 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-736](bugs/BUG-736-mine-icon-charset-mojibake.md) | ✅ | ✅ | 手机制卡后制卡按钮图标乱码 âœ (UTF-8 编码丢失/file:// opaque origin 外链脚本回退 1252) |
 | [BUG-735](bugs/BUG-735-shelf-add-button-size.md) | ✅ | ✅ | 书架添加按钮尺寸位置与其它头部按钮不一致 |
 | [BUG-734](bugs/BUG-734-stats-mobile-text-clip.md) | ✅ | ✅ | 手机统计页文字被省略号裁切显示不全 |
 | [BUG-733](bugs/BUG-733-popup-glossary-ruby-element-base-overlap.md) | ✅ | ✅ | 词典弹窗释义正文元素基字 ruby 注音塌到基字上 |

--- a/docs/bugs/BUG-736-mine-icon-charset-mojibake.md
+++ b/docs/bugs/BUG-736-mine-icon-charset-mojibake.md
@@ -1,0 +1,18 @@
+## BUG-736 · 手机制卡后制卡按钮图标乱码 âœ (UTF-8 编码丢失/file:// opaque origin 外链脚本回退 1252)
+- **报告**：2026-07-11（用户：「手机制卡以后 +号的图标会变成乱码」）
+- **真实性**：✅ 真 bug — 真机复现（OnePlus CPH2747 / ColorOS / Android 16 / System WebView Chromium 149）。查词弹窗已制卡词条的制卡按钮渲染成 `âœ"`（放大截图确认）。根因 `hibiki/assets/popup/popup.html:3`（`<head>` 缺 `<meta charset>`）+ 加载路径 `hibiki/lib/src/utils/misc/webview_asset_url.dart:13`（Android 走 `file:///android_asset/flutter_assets/...`）。
+- **根因链**：制卡按钮是「文本字形」`'✓↩︎'`（`popup.js` `setMineState`，应用户要求不走 SVG；audio/favorite 是 SVG）。Android 上弹窗从 `file:///android_asset/.../popup.html` 加载（无 HTTP `charset` 头），且 popup.html **无 `<meta charset>`**。`file://` 是 opaque origin，外链 `<script src="popup.js">` 的字符编码**不继承文档默认编码**，回退到 legacy **windows-1252** → popup.js 里 `'✓'`(UTF-8 `E2 9C 93`) 被按 1252 解码成 `â`(E2)`œ`(9C)`"`(93) = `âœ"`。制卡按钮是唯一用文本字形的顶部按钮，故只有它乱码。
+  - 判据：`âœ"` 正是 U+2713 的 UTF-8 三字节按 windows-1252 解读；词条正文（日文释义）不乱码，因其经 Dart `evaluateJavascript`（`window.lookupEntries=…`，UTF-8 桥）注入，非静态 popup.js。
+  - 为何 iOS/Windows 不复现：`dictionary_popup_webview.dart` `_shouldInlinePopupAssets` 对 iOS/Windows 把 popup 资源**内联**进 `InAppWebViewInitialData(encoding:'utf-8')`，编码显式 UTF-8。
+  - 为何 `global_lookup_host.html` 不复现：它一直有 `<meta charset="utf-8">`。
+  - 为何 fork 的 `defaultTextEncodingName="UTF-8"`（`InAppWebViewSettings.java:76`）救不了：它只作用于**文档本体**解码，不改变 opaque-origin 外链脚本的编码判定。
+  - **注**：BUG-691（内嵌 "Hibiki Symbols" 字体）此前把本症状误诊为「Android 缺符号字体」——字体方案没错但治不了乱码，因为 ✓ 在到达字体前已被编码破坏成 `âœ"`。本 bug 是真根因；BUG-691 的字体兜底保留（无害，且确保即使 ✓ 正确解码后任何 ROM 都有字形）。参见旧例 [BUG-234](BUG-234-popup-i18n-mojibake.md)（popup i18n 同类编码问题）。
+- **[x] ① 已修复** — 根因修（显式声明 UTF-8）：
+  - `hibiki/assets/popup/popup.html` + `hibiki/assets/popup/definition.html`：`<head>` 首个元素加 `<meta charset="utf-8">`（在任何外链 `<script>` 之前 → 文档编码显式 UTF-8，外链脚本随之按 UTF-8 解码），并给每个 `<script src>` 直接加 `charset="utf-8"`（opaque-origin 下第二层钉死）。
+  - 真机验证：见文末「验证」。
+  - 提交：`812982cae`
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/dictionary/popup_html_charset_guard_test.dart`：源码扫描守卫，锁 popup.html / definition.html / global_lookup_host.html 三宿主 ①含 `<meta charset="utf-8">`；②charset 出现在第一个 `<script>` 之前；③每个外链 `<script src>` 带 `charset="utf-8"`。
+  - 提交：`812982cae`
+- **验证**：真机 OnePlus CPH2747（release-signed 就地升级，用户数据保留）——制卡前截图制卡按钮=`âœ"`（乱码），装修复版后同词条=干净 `✓`。截图证据 `.codex-test/`（不入库）。
+- **备注**：`_shouldInlinePopupAssets` 未改（内联仅 iOS/Windows 需要，Android `<meta charset>` 已足够根治；不为省一个 meta 去改动加载路径，避免牵动 file:// 主帧 bootstrap 的既有行为）。

--- a/hibiki/assets/popup/definition.html
+++ b/hibiki/assets/popup/definition.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <!-- BUG-736: 见 popup.html 同名注释——file:// opaque origin 下外链脚本回退 windows-1252，
+         必须显式 <meta charset> + script charset 钉死 UTF-8，否则脚本里的非 ASCII 文本乱码。 -->
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <link rel="stylesheet" href="popup.css">
-    <script src="dict-media.js"></script>
-    <script src="definition.js"></script>
+    <script src="dict-media.js" charset="utf-8"></script>
+    <script src="definition.js" charset="utf-8"></script>
 </head>
 <body>
     <div id="content" class="yomitan-glossary"></div>

--- a/hibiki/assets/popup/popup.html
+++ b/hibiki/assets/popup/popup.html
@@ -1,11 +1,20 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <!-- BUG-736: 必须在任何外链脚本前显式声明 UTF-8。Android 从 file:///android_asset
+         加载本文档时无 HTTP charset 头；file:// 是 opaque origin，外链 <script> 的编码
+         不继承文档默认编码而回退到 legacy windows-1252 → popup.js 里的 '✓'(UTF-8
+         E2 9C 93) 被按 1252 解码成乱码 'âœ"'（制卡按钮是文本字形，故只有它乱码；audio/
+         favorite 是 SVG 不受影响）。<meta charset> 把文档编码显式定为 UTF-8，外链脚本随之
+         按 UTF-8 解码；script 上的 charset 属性再直接钉死一层，双保险。global_lookup_host.html
+         一直有 charset 故从不乱码，本文件与 definition.html 之前漏了。fork 的
+         defaultTextEncodingName 虽默认 UTF-8，但只作用于文档本体，救不了 opaque-origin 外链脚本。 -->
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <link rel="stylesheet" href="popup.css">
-    <script src="dict-media.js"></script>
-    <script src="selection.js"></script>
-    <script src="popup.js"></script>
+    <script src="dict-media.js" charset="utf-8"></script>
+    <script src="selection.js" charset="utf-8"></script>
+    <script src="popup.js" charset="utf-8"></script>
 </head>
 <body>
     <div id="entries-container"></div>

--- a/hibiki/test/dictionary/popup_html_charset_guard_test.dart
+++ b/hibiki/test/dictionary/popup_html_charset_guard_test.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-736 守卫：查词弹窗宿主 HTML 必须在任何外链 `<script>` 之前显式声明 UTF-8。
+///
+/// 根因：Android 从 `file:///android_asset/...` 加载 popup.html（无 HTTP charset 头），
+/// `file://` 是 opaque origin，外链 `<script>` 的字符编码不继承文档默认编码而回退到
+/// legacy windows-1252。popup.js 里制卡按钮的文本字形 `'✓↩︎'`（UTF-8 E2 9C 93 …）被按
+/// 1252 解码成乱码 `âœ"`（用户报「制卡后 +号图标变乱码」）。audio/favorite 是 SVG 不受影响，
+/// 故只有制卡按钮乱码。fork 的 `defaultTextEncodingName` 默认 UTF-8 只作用于文档本体，
+/// 救不了 opaque-origin 外链脚本。
+///
+/// 修复：宿主 HTML 顶部 `<meta charset="utf-8">`（显式声明文档编码 → 外链脚本随之按 UTF-8
+/// 解码）+ 每个 `<script src>` 直接带 `charset="utf-8"`（钉死第二层）。global_lookup_host.html
+/// 一直有 charset 故从不复现，本守卫锁 popup.html / definition.html / global_lookup_host.html
+/// 三个宿主都不回退。
+///
+/// flutter test cwd 是 hibiki 包根。
+void main() {
+  const List<String> popupHosts = <String>[
+    'assets/popup/popup.html',
+    'assets/popup/definition.html',
+    'assets/popup/global_lookup_host.html',
+  ];
+
+  final RegExp charsetMeta =
+      RegExp(r'<meta\s+charset\s*=\s*"utf-8"', caseSensitive: false);
+  final RegExp firstScript = RegExp(r'<script\b', caseSensitive: false);
+
+  for (final String host in popupHosts) {
+    group('[$host] BUG-736 UTF-8 编码声明', () {
+      late final String html;
+      setUpAll(() => html = File(host).readAsStringSync());
+
+      test('含 <meta charset="utf-8">', () {
+        expect(charsetMeta.hasMatch(html), isTrue,
+            reason: '$host 缺 <meta charset="utf-8">；file:// 加载时外链脚本会按 '
+                'windows-1252 解码，popup.js 的 ✓ 变乱码 âœ"（BUG-736）');
+      });
+
+      test('<meta charset> 出现在第一个 <script> 之前（否则对外链脚本无效）', () {
+        // 先剥掉 HTML 注释——本文件的说明注释里出现了字面 "<script>"，不能算真标签。
+        final String noComments =
+            html.replaceAll(RegExp(r'<!--.*?-->', dotAll: true), '');
+        final int metaAt = noComments.indexOf(charsetMeta);
+        final int scriptAt = noComments.indexOf(firstScript);
+        // 无外链脚本的宿主天然不受影响，跳过顺序断言。
+        if (scriptAt < 0) return;
+        expect(metaAt, greaterThanOrEqualTo(0));
+        expect(metaAt, lessThan(scriptAt),
+            reason: 'charset 声明必须在外链 <script> 之前，才能决定其解码编码');
+      });
+
+      test('每个外链 <script src> 直接带 charset="utf-8"（第二层钉死）', () {
+        final RegExp externalScript =
+            RegExp(r'<script\b[^>]*\bsrc\s*=', caseSensitive: false);
+        for (final RegExpMatch m in externalScript.allMatches(html)) {
+          final String tag = html.substring(
+              m.start, html.indexOf('>', m.start) + 1);
+          expect(RegExp(r'charset\s*=\s*"utf-8"', caseSensitive: false)
+              .hasMatch(tag), isTrue,
+              reason: '$host 的外链脚本标签缺 charset="utf-8"：$tag');
+        }
+      });
+    });
+  }
+}


### PR DESCRIPTION
## 症状
用户：手机制卡后制卡按钮 +号图标变乱码。真机复现（OnePlus CPH2747 / ColorOS / WebView Chromium 149）：已制卡词条的制卡按钮渲染成 `âœ"`。

## 根因（真机 + 机制双确认，非字体问题）
制卡按钮是文本字形 `'✓↩︎'`（popup.js，audio/favorite 是 SVG）。Android 从 `file:///android_asset/.../popup.html` 加载（无 HTTP charset 头），`file://` 是 opaque origin → 外链 `<script src=popup.js>` 的编码**不继承文档默认编码**，回退 legacy **windows-1252** → `'✓'`(UTF-8 `E2 9C 93`) 被解成 `â``œ``"` = `âœ"`。
- `âœ"` 正是 U+2713 三字节按 1252 解读；词条日文正文经 Dart evaluateJavascript UTF-8 桥注入故不乱码。
- iOS/Windows 不复现：`_shouldInlinePopupAssets` 把资源内联进 `InAppWebViewInitialData(encoding:'utf-8')`。
- `global_lookup_host.html` 不复现：一直有 `<meta charset>`。
- fork `defaultTextEncodingName=UTF-8` 只作用于文档本体，救不了 opaque-origin 外链脚本。
- **BUG-691（内嵌字体）是对本症状的误诊**——✓ 在到字体前已被编码破坏；字体兜底无害保留。

## 修复
popup.html / definition.html：`<head>` 首加 `<meta charset="utf-8">`（外链脚本前）+ 每个 `<script src>` 带 `charset="utf-8"`。

## 验证
- 守卫测试 `popup_html_charset_guard_test.dart`（9/9 通过），`flutter analyze` No issues。
- 真机 release-signed 就地升级（数据保留）：修复前 `âœ"` → 修复后干净 `✓`（同词条 エネルギー）。

BUG-736