### PR TITLE
fix(video): 修复反复切换音频设备视频音量衰减/静音 (BUG-737)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 721 条。点号进各自文件。
+> 共 722 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-737](bugs/BUG-737-video-volume-device-switch.md) | ✅ | ✅ | 反复切换音频输出设备后视频音量逐步变小甚至静音 |
 | [BUG-736](bugs/BUG-736-extension-popup-theme-vars.md) | ✅ | ✅ | 浏览器扩展查词弹窗主题与 app 不一致(漏发4个CSS变量) |
 | [BUG-735](bugs/BUG-735-shelf-add-button-size.md) | ✅ | ✅ | 书架添加按钮尺寸位置与其它头部按钮不一致 |
 | [BUG-734](bugs/BUG-734-stats-mobile-text-clip.md) | ✅ | ✅ | 手机统计页文字被省略号裁切显示不全 |

--- a/docs/bugs/BUG-737-video-volume-device-switch.md
+++ b/docs/bugs/BUG-737-video-volume-device-switch.md
@@ -1,0 +1,20 @@
+## BUG-737 · 反复切换音频输出设备后视频音量逐步变小甚至静音
+- **报告**：2026-07-11（用户：反复切换音频设备后 hibiki 视频音量会变小，有时直接没声；仅视频音量，查词音频正常）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/video/video_player_controller.dart:781`（`volume` getter 直接信任 libmpv `state.volume`）+ 全仓库缺音频设备切换监听（app 从不在设备切换后回补音量目标）。
+- **[x] ① 已修复** — `video_player_controller.dart`：首次建 `Player` 时订阅 media_kit `stream.audioDevice`，设备切换后重新下发音量目标 `_muted ? 0.0 : _lastVolume`；`dispose` 取消订阅。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_volume_device_switch_guard_test.dart`（源码扫描：订阅存在 + 回补 `_lastVolume`/尊重静音 + dispose 取消 + 根因注释 + 查词对照）。
+- **备注**：
+
+  **现象**：反复切换系统音频输出设备后，视频播放器的音量逐步变小，多次切换后甚至完全静音。查词弹窗读音的音量正常（明显比视频大，用户正是由此察觉）。
+
+  **根因**（沿真实代码路径确证，非臆测）：
+  - 视频走 media_kit **裸 `Player()`**（`audio-device=auto`），不经 just_audio。音量只在两处下发给 libmpv：`video_player_controller.dart:1436-1439`（`load()`，取自 prefs）和用户手动调音量（`setVolume`/`adjustVolume`/`toggleMute`）。
+  - 之后 `volume` getter（`:781` `_player?.state.volume ?? _lastVolume`）**直接把 libmpv 的 `state.volume` 当真值**，app 从不回补目标音量。
+  - 全仓库 grep `setAudioDevice`/`audioDevice`/`onDeviceChanged` **零命中**——切换输出设备完全由 libmpv 内部处理：它重建 ao，软件 `volume` 属性被重置/衰减，media_kit（`media_kit-1.2.6/.../real.dart:1619-1624` 被动观察 `volume` 属性）把降低值镜像进 `state.volume`。**反复切换即逐步衰减直至归零**。
+  - 已排除 app 层累积衰减：`_lastVolume` 只在 load（prefs）/用户操作时写，无 `stream.volume` 回写反馈环，reload 也从 prefs 取值不读回衰减值。故衰减纯在 libmpv 层，app 的缺陷是**从不回补**。
+
+  **为何查词音频免疫**：`hibiki/lib/src/utils/misc/desktop_audio_playback.dart:123` 每个 clip 播放前都 `setVolume(volume.clamp(...))` 重设**绝对**音量，天然把 libmpv 漂移抹平 → 永远正常。
+
+  **修复**：`VideoPlayerController` 首次建 `Player` 时订阅 `player.stream.audioDevice`（media_kit 内部 `distinct` 去重），设备变化时把音量目标 `_muted ? 0.0 : _lastVolume` 重新 `setVolume` 给 libmpv——恢复「libmpv 音量 == app 目标」不变量，与查词路径每次重设绝对音量同构。订阅随 `Player` 生命周期挂一次（换集复用不重挂，避免叠加）、`dispose` 取消。这是根因修复（补上缺失的平台边界回补契约），非延迟/重试/吞异常绕过。
+
+  **待真机**：需在桌面真机（Windows/macOS）播放视频时反复切换系统音频输出设备，复测音量保持不衰减、且不误解除用户静音。自动化测试只能守住「订阅存在且回补目标音量」的静态不变量；真实 libmpv ao 重建时序与音量表现需人工目测确认。

--- a/hibiki/lib/src/media/video/video_player_controller.dart
+++ b/hibiki/lib/src/media/video/video_player_controller.dart
@@ -336,6 +336,16 @@ class VideoPlayerController extends ChangeNotifier
   /// 章节读取和进度条章节刻度都依赖这个信号，而不是 open() 返回后的时间猜测。
   StreamSubscription<Duration>? _durationReadySub;
 
+  /// BUG-737：当前音频输出设备变化订阅。libmpv `audio-device=auto` 在 OS 输出设备
+  /// 切换时重建 ao，其软件 `volume` 属性可能被重置/衰减，media_kit 被动把降低值镜像
+  /// 进 `state.volume`（[volume] getter 的真值来源）——反复切换设备使视频音量逐步变小
+  /// 甚至归零。app 只在 [load] 与用户操作时下发音量、之后从不回补，故必须在设备切换后
+  /// 把「音量目标」([_lastVolume] / 静音态) 重新下发（查词音频每次播放都重设绝对音量，
+  /// 天然免疫）。**随 [Player] 生命周期挂一次**（首次建 Player 时挂、[dispose] 取消），
+  /// 不随换集重挂——`stream.audioDevice` 在 media_kit 内部 `distinct` 去重，首个事件
+  /// 回补当前 [_lastVolume]（默认 100）无害，[load] 随后会再设一次。
+  StreamSubscription<AudioDevice>? _audioDeviceSub;
+
   /// 每次 [load] 递增。复用同一个 [Player] 换片时，单靠 player identity 无法区分
   /// 旧媒体的异步章节读取结果；token 让旧 load 的结果可被丢弃。
   int _loadToken = 0;
@@ -1258,6 +1268,13 @@ class VideoPlayerController extends ChangeNotifier
       // TODO-1212：登记文件句柄释放（幂等，只在首次建 Player 时登记一次）。
       _mediaHandleRegistration ??=
           MediaHandleRegistry.instance.register(_releaseMediaHandles);
+      // BUG-737：设备切换后回补音量目标（详见 [_audioDeviceSub] 字段注释）。随 Player
+      // 生命周期挂一次；换集复用同一 Player 不重挂，避免叠加订阅。
+      _audioDeviceSub = player.stream.audioDevice.listen((_) {
+        final Player? current = _player;
+        if (current == null) return;
+        unawaited(current.setVolume(_muted ? 0.0 : _lastVolume));
+      });
     }
     // TODO-1110：挂纹理 id 监听（Android 无画面诊断）。放在 controller 就绪后、诊断
     // 订阅块之前——首个 id 变化（native 纹理握手成功）能被记进日志。换集复用同一
@@ -2850,6 +2867,8 @@ class VideoPlayerController extends ChangeNotifier
     _bufferingReadySub = null;
     unawaited(_durationReadySub?.cancel());
     _durationReadySub = null;
+    unawaited(_audioDeviceSub?.cancel());
+    _audioDeviceSub = null;
     unawaited(_diagErrorSub?.cancel());
     _diagErrorSub = null;
     unawaited(_diagLogSub?.cancel());

--- a/hibiki/test/media/video/video_volume_device_switch_guard_test.dart
+++ b/hibiki/test/media/video/video_volume_device_switch_guard_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 源码守卫（BUG-737）：**反复切换音频输出设备后视频音量不衰减的根因不变量**。
+///
+/// 背景：视频走 media_kit 裸 `Player()`（`audio-device=auto`）。OS 切换音频输出设备时，
+/// libmpv 重建 ao，其软件 `volume` 属性可能被重置/衰减，media_kit 被动把降低值镜像进
+/// `state.volume`。而 [VideoPlayerController.volume] getter 直接读 `state.volume` 作真值，
+/// app 只在 `load()` 与用户操作时下发音量、之后从不回补 —— 于是反复切换设备后视频音量
+/// 逐步变小甚至归零。查词音频（`desktop_audio_playback.dart`）每次播放前都 `setVolume`
+/// 绝对值，天然免疫，故只有视频受影响。
+///
+/// 根因修复：订阅 media_kit `stream.audioDevice`，在当前输出设备变化时把「音量目标」
+/// （`_lastVolume`，静音时为 0）重新下发给 libmpv，恢复「libmpv 音量 == app 目标」不变量
+/// （与查词路径每次重设绝对音量同构）。本守卫钉死这条订阅存在且回补的是目标音量，
+/// 防止有人删掉订阅或改成回补错误的值而悄悄回归本 bug。真实的设备切换音量行为只能在
+/// 桌面真机（Win/macOS）切换输出设备复测；此守卫锁住静态不变量。
+void main() {
+  String read(String relPath) {
+    for (final String prefix in <String>['', '../']) {
+      final File f = File('$prefix$relPath');
+      if (f.existsSync()) return f.readAsStringSync();
+    }
+    throw StateError('找不到文件：$relPath');
+  }
+
+  group('视频音量设备切换不衰减不变量 (BUG-737)', () {
+    final String src = read('lib/src/media/video/video_player_controller.dart');
+
+    test('VideoPlayerController 订阅 stream.audioDevice（设备切换后回补音量）', () {
+      expect(src.contains('stream.audioDevice.listen'), isTrue,
+          reason: '必须订阅 media_kit stream.audioDevice：OS 切换输出设备后 libmpv '
+              '重建 ao 会衰减软件 volume，app 需在设备变化时回补音量目标');
+    });
+
+    test('设备切换回调回补的是「音量目标」_lastVolume（静音时为 0），不是别的值', () {
+      // 锚到订阅回调体：`stream.audioDevice.listen(...) { ... setVolume(... _lastVolume ...) }`。
+      final int at = src.indexOf('stream.audioDevice.listen');
+      expect(at, greaterThanOrEqualTo(0),
+          reason: '找不到 stream.audioDevice.listen 订阅');
+      // 取订阅点之后一小段，确认回调里下发的是 _muted ? 0.0 : _lastVolume。
+      final String after = src.substring(at, at + 400);
+      expect(after.contains('setVolume'), isTrue,
+          reason: '设备切换回调必须调用 setVolume 把音量重新下发给 libmpv');
+      expect(after.contains('_lastVolume'), isTrue,
+          reason: '回补的必须是音量目标 _lastVolume（单一语义真值），而不是读回已衰减的 '
+              'state.volume/volume getter');
+      expect(after.contains('_muted'), isTrue,
+          reason: '回补须尊重静音态：静音时下发 0，否则设备切换会解除用户的静音');
+    });
+
+    test('_audioDeviceSub 在 dispose 里被取消（防订阅泄漏）', () {
+      expect(src.contains('_audioDeviceSub'), isTrue,
+          reason: '设备变化订阅须存字段以便取消');
+      expect(src.contains('_audioDeviceSub?.cancel()'), isTrue,
+          reason: 'dispose 必须取消 _audioDeviceSub，随 Player 生命周期释放');
+    });
+
+    test('保留根因说明注释（防注释丢失后被误删订阅）', () {
+      expect(src.contains('BUG-737'), isTrue,
+          reason: '订阅点/字段须保留 BUG-737 根因注释，让 reviewer 看到不变量来由');
+    });
+  });
+
+  group('查词音频每次播放重设绝对音量（对照：为何查词免疫 BUG-737）', () {
+    test('desktop_audio_playback 每次播放前 setVolume 绝对值', () {
+      final String src = read('lib/src/utils/misc/desktop_audio_playback.dart');
+      expect(src.contains('setVolume'), isTrue,
+          reason: '查词音频免疫本 bug 的根因：每个 clip 播放前都重设绝对音量，'
+              '天然抹平 libmpv 漂移。删掉它会让查词也回归设备切换音量衰减');
+    });
+  });
+}


### PR DESCRIPTION
## 问题
用户报：反复切换系统音频输出设备后，hibiki **视频**音量逐步变小，多次切换后甚至完全静音；查词弹窗读音的音量正常（用户由此察觉）。

## 根因（沿真实代码路径确证）
- 视频走 media_kit 裸 `Player()`（`audio-device=auto`）。音量只在 `load()`（`video_player_controller.dart:1436-1439`，取自 prefs）和用户手动操作时下发给 libmpv。
- `volume` getter（`:781` `_player?.state.volume ?? _lastVolume`）**直接信任 libmpv 的 `state.volume`**；全仓库无任何音频设备切换监听（grep `setAudioDevice/audioDevice/onDeviceChanged` 零命中）。
- OS 切换输出设备时 libmpv 重建 ao，软件 `volume` 属性被重置/衰减，media_kit 被动镜像进 `state.volume`——**app 从不回补目标音量**，故反复切换即逐步衰减直至归零。
- 已排除 app 层累积衰减：`_lastVolume` 无 `stream.volume` 回写反馈环。
- **查词免疫**：`desktop_audio_playback.dart:123` 每个 clip 播放前都重设**绝对**音量，天然抹平漂移。

## 修复
`VideoPlayerController` 首次建 `Player` 时订阅 `player.stream.audioDevice`（media_kit 内部 `distinct` 去重），设备变化时把音量目标 `_muted ? 0.0 : _lastVolume` 重新 `setVolume` 给 libmpv——恢复「libmpv 音量 == app 目标」不变量，与查词路径同构。订阅随 Player 生命周期挂一次（换集复用不重挂）、`dispose` 取消。根因修复，非延迟/重试绕过。

## 测试
- 新增源码守卫 `test/media/video/video_volume_device_switch_guard_test.dart`（6 项：订阅存在 + 回补 `_lastVolume`/尊重静音 + dispose 取消 + 根因注释 + 查词对照）——全绿。
- `flutter analyze`（全量）No issues found。

## 待真机
需桌面真机（Windows/macOS）播放视频时反复切换系统输出设备，目测音量保持不衰减、且不误解除静音。自动化只能守静态不变量，libmpv ao 重建时序需人工确认。

BUG 记录：`docs/bugs/BUG-737-video-volume-device-switch.md`