### PR TITLE
fix(lookup): 覆盖窗HWND被外部销毁后自愈重建 (BUG-737)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 722 条。点号进各自文件。
+> 共 723 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-738](bugs/BUG-738-transient-lookup-window-owned-pulls-main-foreground.md) | ✅ | ✅ | 悬浮字幕点词瞬态查词窗owned·Z序连带把主窗拉前台 |
 | [BUG-737](bugs/BUG-737-overlay-window-dead-handle-no-recreate.md) | ✅ | ✅ | 覆盖窗HWND被外部销毁后悬垂hwnd_不重建·第二个弹窗出不来 |
 | [BUG-736](bugs/BUG-736-extension-popup-theme-vars.md) | ✅ | ✅ | 浏览器扩展查词弹窗主题与 app 不一致(漏发4个CSS变量) |
 | [BUG-735](bugs/BUG-735-shelf-add-button-size.md) | ✅ | ✅ | 书架添加按钮尺寸位置与其它头部按钮不一致 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 721 条。点号进各自文件。
+> 共 722 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-737](bugs/BUG-737-overlay-window-dead-handle-no-recreate.md) | ✅ | ✅ | 覆盖窗HWND被外部销毁后悬垂hwnd_不重建·第二个弹窗出不来 |
 | [BUG-736](bugs/BUG-736-extension-popup-theme-vars.md) | ✅ | ✅ | 浏览器扩展查词弹窗主题与 app 不一致(漏发4个CSS变量) |
 | [BUG-735](bugs/BUG-735-shelf-add-button-size.md) | ✅ | ✅ | 书架添加按钮尺寸位置与其它头部按钮不一致 |
 | [BUG-734](bugs/BUG-734-stats-mobile-text-clip.md) | ✅ | ✅ | 手机统计页文字被省略号裁切显示不全 |

--- a/docs/bugs/BUG-737-overlay-window-dead-handle-no-recreate.md
+++ b/docs/bugs/BUG-737-overlay-window-dead-handle-no-recreate.md
@@ -1,0 +1,35 @@
+## BUG-737 · 覆盖窗HWND被外部销毁后悬垂hwnd_不重建·第二个弹窗出不来
+- **报告**：2026-07-11（用户：手动关闭第一个弹窗/面板后，第二个弹窗出不来；有时"说出来了但不知道去哪里了"；不重启 app 不恢复）
+- **真实性**：✅ 真 bug（根因 `hibiki/windows/runner/global_lookup_window.cpp:267`（旧 `ShowAt` 幂等守卫）+ `:626`（旧 `IsShowing`）+ `:200`（`hwnd_` 仅在析构置 null））
+- **[x] ① 已修复** — `windows/runner/global_lookup_window.cpp` 新增 `OwnsLiveWindow()`/`ForgetDeadWindow()`；`ShowAt`/`PrewarmWebView`/`IsShowing` 改用之（commit 待填）
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/global_lookup_dead_window_recreate_guard_test.dart`（源码扫描守卫，6 用例，`flutter test` 绿）
+- **备注**：
+
+### 根因（数据结构缺陷）
+
+app 外全局查词/剪贴板面板覆盖窗（`GlobalLookupWindow`，剪贴板面板与瞬态查词窗是同一 C++ 类的两个实例）的成员 `hwnd_` **只在析构函数才置 `nullptr`**（`:200-220`，运行期唯一的 `DestroyWindow` 也只在析构里）。当 HWND 被**外部**拆掉——WebView2 运行时后台更新/崩溃、owner 主窗 teardown 联动销毁 owned 瞬态窗、或任何外部 `DestroyWindow`——`hwnd_` 就变成**悬垂的非 null 句柄**，同时毒死两条本该自愈的路径：
+
+1. `ShowAt` 的 `if (hwnd_ == nullptr)`（旧 `:267`）为假 → 走 else 分支对**死句柄** `SetWindowPos`（静默失败）→ **永不 `CreateWindowExW` 重建**。
+2. `IsShowing()`（旧 `:626`）的 `hwnd_ != nullptr` 被悬垂/被回收句柄骗过（Windows 会把 HWND 数值回收给别的可见窗，`IsWindowVisible` 返 true）→ Dart 侧 `ClipboardPanelController.update()` / `GlobalLookupController` 的 `isShowing` 复检被绕过 → **跳过重建**、往不存在的窗口渲染，并记 `panel: updated` / `reveal(box)` **成功**。
+
+于是 Dart 确信弹窗还在、日志一切正常，**用户屏幕上什么都没有，且不重启 app 永远回不来**。
+
+### 实证（真机 glog + Win32 窗口探测）
+
+- 20:54–21:08：`EnumWindows` 枚举 1788 个顶层窗，`HibikiGlobalLookupWindow` 类**零个**；同期 Dart 持续 `panel: updated "N chars"` / 热键路径 `showAt→overlaySize→reveal(box)` 全"成功"。
+- 21:13:18 `start: called`（用户重启 app）→ 21:17 `panel: shown` 窗口全新重建、恢复正常。
+- `Hide()`（`:588`）确认是 `SW_HIDE` 不销毁——排除"只是被隐藏"（隐藏窗 `EnumWindows` 仍枚举得到）。
+
+### 修复（Linus 式消除"悬垂句柄"特殊情况：`hwnd_` 非空 ⟺ 存在属于我们的活窗）
+
+- `OwnsLiveWindow()`：`hwnd_ != nullptr && IsWindow(hwnd_) && GetWindowLongPtr(hwnd_, GWLP_USERDATA) == this`——死句柄 `IsWindow` 假；句柄被回收给别的窗时 USERDATA≠this，双重防漏。
+- `ForgetDeadWindow()`：非我方活窗时清 `hwnd_` + 释放死 `controller_/webview_/env_` COM 代理（照 `RecoverDeadWebView` 范式）+ 复位 `webview_ready_/visible_/revealed_`；并 `error_cb_` 记一行"发现死窗→重建"到设备日志（让销毁者可诊断，即 Layer A 取证）。
+- `ShowAt` / `PrewarmWebView` 在创建/幂等守卫**前**先 `ForgetDeadWindow()` → 悬垂句柄触发**真正重建**。
+- `IsShowing()` 改用 `OwnsLiveWindow()`。
+
+对"到底谁销毁的（Layer A）"不敏感——让系统**自愈**：下一次复制/热键即重建覆盖窗，不再需要重启。若 `error_cb_` 日志证明是我们自己间接触发的销毁，再追加堵源头。
+
+### 待验证
+
+- Windows Release 真机：制造外部销毁（如 `taskkill` WebView2 msedgewebview2 进程树 / WebView2 运行时更新）后，下一次热键/复制应自动重建覆盖窗并弹出（设备日志出现"overlay window found destroyed — rebuilding"一行且随后 `reveal(box)` 有真窗）。
+- 相邻回归：正常 open→close→reopen、面板拖动/×/Ctrl+Alt+D、瞬态窗连点，均不受影响（`ForgetDeadWindow` 仅在句柄非活时动作，活窗路径逐字节不变）。

--- a/docs/bugs/BUG-738-transient-lookup-window-owned-pulls-main-foreground.md
+++ b/docs/bugs/BUG-738-transient-lookup-window-owned-pulls-main-foreground.md
@@ -1,0 +1,27 @@
+## BUG-738 · 悬浮字幕点词瞬态查词窗owned·Z序连带把主窗拉前台
+- **报告**：2026-07-12（用户：悬浮字幕点词时 app 主窗被拉到前台；面板窗也不该把主窗拉前台）
+- **真实性**：✅ 真 bug（根因 `hibiki/windows/runner/flutter_window.cpp` 瞬态 `global_lookup_window_->ShowAt` / `PrewarmWebView` 传 `GetHandle()`=主窗 HWND 当 owner）
+- **[x] ① 已修复** — 瞬态窗 owner 改 `nullptr`（showAt + prewarm 两处），与面板窗一致（commit 待填）
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/global_lookup_transient_no_owner_guard_test.dart`（源码扫描守卫，3 用例，`flutter test` 绿）
+- **备注**：
+
+### 根因
+
+app 外查词覆盖窗有两个 `GlobalLookupWindow` 实例：瞬态查词窗（`global_lookup_window_`，悬浮字幕点词/全局热键/面板点释义弹的跟光标卡片）与常驻剪贴板面板（`clipboard_panel_window_`）。真机第 4 轮已发现 **owned 顶层窗（owner=主窗 HWND）的 Z 序变更会连带把 owner 主窗拉到前台**，当时把**面板**改成无 owner 修好，但**瞬态窗被刻意"保持 owned"**（`flutter_window.cpp` 旧注释："短命窗，随主窗收纳是合理语义"）。
+
+代价即用户症状：悬浮字幕点词（Windows 上优先走瞬态覆盖窗 `lookupText`，`lyrics.part.dart:_lookupFromFloatingLyric` → `tryFloatingLyricGlobalLookup`）时，瞬态窗 owned by 主窗 → 弹出的 Z 序变更把主窗拽到前台，盖住底下的游戏/视频，违反覆盖窗「绝不夺前台」契约（design §5 guarantee 3，native 覆盖窗本身全程 `NOACTIVATE`、无 `SetForegroundWindow`——夺前台**只**来自 owner 连带）。
+
+注：面板窗已无 owner，激活它（`SetActivatable(true)`，为滚轮不穿透）只让面板窗自身前台、不连带主窗；用户"面板也不该拉主窗"的诉求已被无 owner 满足。悬浮字幕**回落路径**（覆盖窗不可用时 `bringPendingLookupToFront`）拉主窗是正确的——那时结果只能进主窗词典 tab，不在本 bug 范围。
+
+### 修复（用户否决「随主窗收纳」取舍：不夺前台 > 随主窗收纳）
+
+`flutter_window.cpp` 瞬态实例两处 owner `GetHandle()` → `nullptr`：
+- `global_lookup_window_->ShowAt(..., nullptr)`
+- `global_lookup_window_->PrewarmWebView(..., nullptr)`（须与 showAt 一致，否则 BUG-737 的 `ForgetDeadWindow` 重建时 owner 漂移）
+
+瞬态窗短命且 `arm_dismiss_hooks=true`（前台切换即 `ForegroundHookProc`→`Hide`），主窗最小化=前台切换=瞬态窗自关，故"随主窗收纳"语义仍在，无孤儿悬浮窗回归。
+
+### 待验证
+
+- Windows 真机：听书时主窗最小化/置后台，点悬浮字幕上的词 → 卡片弹在光标处、**主窗不被拉到前台**；再验热键 Ctrl+Alt+D、面板点释义同样不夺前台。
+- 相邻回归：主窗最小化时瞬态卡片仍随之收起（前台钩子自关）；BUG-737 死窗重建路径不受 owner 改动影响。

--- a/hibiki/test/lookup/global_lookup_dead_window_recreate_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_dead_window_recreate_guard_test.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG — 覆盖窗 HWND 死亡自愈契约（源码扫描守卫）。
+///
+/// 真机根因（与 [global_lookup_dead_webview_selfheal_guard_test] 的死 WebView2
+/// 是姊妹，但这里死的是 **Win32 窗口本身**）：app 外全局查词/剪贴板面板覆盖窗
+/// （`windows/runner/global_lookup_window.cpp`）的 HWND 被外部拆掉（WebView2
+/// 运行时后台更新/崩溃、owner 主窗 teardown、任何外部 `DestroyWindow`）后，
+/// 成员 `hwnd_` 只在析构里才置 null——于是变成**悬垂的非 null 句柄**：
+/// - `ShowAt` 的旧 `if (hwnd_ == nullptr)` 守卫为假 → 走 else 分支对死句柄
+///   `SetWindowPos`（静默失败）→ **永不 `CreateWindowExW` 重建**；
+/// - `IsShowing()` 的 `hwnd_ != nullptr` 被悬垂/回收句柄骗过 → Dart 复检跳过重建、
+///   往不存在的窗口渲染并记 `panel: updated`/`reveal(box)` 成功。
+///
+/// 用户症状：手动关闭第一个弹窗/面板后，第二个**弹不出来**，Dart 日志却一切正常，
+/// 且**不重启 app 永远回不来**（实测探测 0 个 `HibikiGlobalLookupWindow` 窗口，
+/// 但 Dart 持续记 reveal 成功；重启后恢复）。
+///
+/// 修复契约：
+/// 1. `OwnsLiveWindow()`：`hwnd_ != nullptr && IsWindow(hwnd_)`（死句柄 `IsWindow`
+///    返 false）**且** `GetWindowLongPtr(hwnd_, GWLP_USERDATA) == this`（句柄被
+///    Windows 回收给别的窗时 USERDATA≠this，双重防漏）。
+/// 2. `ForgetDeadWindow()`：句柄非我方活窗时清 `hwnd_` + 释放 controller_/webview_/
+///    env_ 死代理 + 复位 webview_ready_/visible_/revealed_，让下一次 ShowAt/
+///    PrewarmWebView 从零重建。
+/// 3. `ShowAt` 与 `PrewarmWebView` 在创建/幂等守卫前必须先 `ForgetDeadWindow()`。
+/// 4. `IsShowing()` 用 `OwnsLiveWindow()` 而不是裸 `hwnd_ != nullptr`。
+///
+/// 覆盖窗真弹出依赖 native WebView2，headless 测不了，故用源码扫描钉住契约。
+void main() {
+  String read(String p) => File(p).readAsStringSync().replaceAll('\r\n', '\n');
+
+  late String cpp;
+  late String hdr;
+  setUpAll(() {
+    cpp = read('windows/runner/global_lookup_window.cpp');
+    hdr = read('windows/runner/global_lookup_window.h');
+  });
+
+  /// 抽出一个顶层函数体（从签名行到下一个左对齐 `}`）。
+  String functionBody(String src, String signature) {
+    final int at = src.indexOf(signature);
+    expect(at, greaterThanOrEqualTo(0), reason: '必须存在：$signature');
+    final int end = src.indexOf('\n}', at);
+    expect(end, greaterThan(at));
+    return src.substring(at, end);
+  }
+
+  test('OwnsLiveWindow：IsWindow + GWLP_USERDATA==this 双重校验', () {
+    final String body =
+        functionBody(cpp, 'bool GlobalLookupWindow::OwnsLiveWindow()');
+    expect(body, contains('IsWindow(hwnd_)'),
+        reason: '死句柄必须被 IsWindow() 拒绝（否则悬垂句柄冒充活窗）');
+    expect(body, contains('GetWindowLongPtr(hwnd_, GWLP_USERDATA)'),
+        reason: 'HWND 会被 Windows 回收给别的窗，必须核对 USERDATA 仍指向本实例');
+    expect(body, contains('== this'), reason: 'USERDATA 必须等于 this 才算「我方」活窗');
+  });
+
+  test('ForgetDeadWindow：非活窗则清 hwnd_ + 释放死 COM 代理 + 复位状态', () {
+    final String body =
+        functionBody(cpp, 'void GlobalLookupWindow::ForgetDeadWindow()');
+    expect(body, contains('OwnsLiveWindow()'),
+        reason: '判据必须复用 OwnsLiveWindow（单一真值源）');
+    expect(body, contains('hwnd_ = nullptr'),
+        reason: '悬垂句柄必须清空，否则 ShowAt 仍走 SetWindowPos 死句柄分支');
+    for (final String member in <String>[
+      'controller_ = nullptr',
+      'webview_ = nullptr',
+      'env_ = nullptr',
+    ]) {
+      expect(body, contains(member), reason: '死进程树下的 COM 代理必须释放：$member');
+    }
+    expect(body, contains('webview_ready_ = false'),
+        reason: '必须打断「dead-but-ready」状态，重建后由 NavigationCompleted 重臂');
+    expect(body, contains('error_cb_'), reason: '发现死窗必须记进设备日志，让销毁者可诊断，而不是静默重建');
+  });
+
+  test('ShowAt 在创建守卫前先 ForgetDeadWindow（悬垂句柄触发真重建）', () {
+    final String body = functionBody(cpp, 'bool GlobalLookupWindow::ShowAt(');
+    final int forget = body.indexOf('ForgetDeadWindow()');
+    final int guard = body.indexOf('if (hwnd_ == nullptr)');
+    expect(forget, greaterThanOrEqualTo(0), reason: 'ShowAt 必须先丢弃死句柄');
+    expect(guard, greaterThan(forget),
+        reason: 'ForgetDeadWindow 必须在 `if (hwnd_ == nullptr)` 重建守卫之前，'
+            '否则死句柄仍走 else 的 SetWindowPos 分支、永不 CreateWindowExW');
+  });
+
+  test('PrewarmWebView 幂等守卫前先 ForgetDeadWindow', () {
+    final String body =
+        functionBody(cpp, 'void GlobalLookupWindow::PrewarmWebView(');
+    final int forget = body.indexOf('ForgetDeadWindow()');
+    final int guard = body.indexOf('if (hwnd_ != nullptr)');
+    expect(forget, greaterThanOrEqualTo(0), reason: '死掉的预热窗必须被重建');
+    expect(guard, greaterThan(forget),
+        reason: 'ForgetDeadWindow 必须在「已预热就返回」守卫之前');
+  });
+
+  test('IsShowing 用 OwnsLiveWindow 而非裸 hwnd_ != nullptr', () {
+    final String body =
+        functionBody(cpp, 'bool GlobalLookupWindow::IsShowing()');
+    expect(body, contains('OwnsLiveWindow()'),
+        reason: '否则悬垂/回收句柄让 IsShowing 报 true，Dart 跳过重建');
+    expect(body.contains('hwnd_ != nullptr && IsWindowVisible'), isFalse,
+        reason: '不得退回裸 hwnd_ != nullptr 判据（BUG 回归signature）');
+  });
+
+  test('头文件声明 OwnsLiveWindow 与 ForgetDeadWindow', () {
+    expect(hdr, contains('bool OwnsLiveWindow() const;'));
+    expect(hdr, contains('void ForgetDeadWindow();'));
+  });
+}

--- a/hibiki/test/lookup/global_lookup_transient_no_owner_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_transient_no_owner_guard_test.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-738 — 瞬态查词覆盖窗（悬浮字幕点词/全局热键/面板点释义）不得 owned by
+/// 主窗（源码扫描守卫）。
+///
+/// 真机根因：`flutter_window.cpp` 里瞬态实例 `global_lookup_window_` 的 `ShowAt`
+/// / `PrewarmWebView` 曾把主窗 HWND（`GetHandle()`）当 owner 传入。owned 顶层窗
+/// 的 Z 序变更**连带把 owner 主窗拉到前台**（真机第 4 轮对面板确认的同一机制，
+/// 见 `flutter_window.cpp` 面板 prewarm 注释）——用户症状=悬浮字幕点词/热键查词
+/// 时 app 主窗被拽到前台，盖住底下的游戏/视频，违反 app 外查词覆盖窗「绝不夺
+/// 前台」契约（design §5 guarantee 3）。
+///
+/// 修复：瞬态窗与面板窗一致，owner 传 `nullptr`（无 owner）。瞬态窗短命且
+/// `arm_dismiss_hooks=true`（前台切换即自关），主窗最小化时照样收纳，无孤儿窗。
+///
+/// 覆盖窗真弹出依赖 native，headless 测不了，故用源码扫描钉住契约。
+void main() {
+  String read(String p) => File(p).readAsStringSync().replaceAll('\r\n', '\n');
+
+  late String cpp;
+  setUpAll(() {
+    cpp = read('windows/runner/flutter_window.cpp');
+  });
+
+  /// 抽出从某个方法调用起点到其结尾 `);` 的片段。
+  String callArgs(String src, String callee) {
+    final int at = src.indexOf(callee);
+    expect(at, greaterThanOrEqualTo(0), reason: '必须存在调用：$callee');
+    final int end = src.indexOf(');', at);
+    expect(end, greaterThan(at));
+    return src.substring(at, end + 2);
+  }
+
+  test('瞬态 global_lookup_window_->ShowAt 用 nullptr owner（不拉主窗前台）', () {
+    final String seg = callArgs(cpp, 'global_lookup_window_->ShowAt(');
+    expect(seg, contains('nullptr'),
+        reason: 'BUG-738：owner 必须 nullptr，否则 owned 窗 Z 序连带拉主窗前台');
+    expect(seg.contains('GetHandle()'), isFalse,
+        reason: '不得把主窗 HWND 当 owner（回归 signature）');
+  });
+
+  test('瞬态 global_lookup_window_->PrewarmWebView 用 nullptr owner', () {
+    final String seg = callArgs(cpp, 'global_lookup_window_->PrewarmWebView(');
+    expect(seg, contains('nullptr'),
+        reason: 'prewarm 与 showAt owner 必须一致，否则 ForgetDeadWindow 重建 owner 漂移');
+    expect(seg.contains('GetHandle()'), isFalse, reason: '不得把主窗 HWND 当 owner');
+  });
+
+  test('面板 clipboard_panel_window_ 同样保持 nullptr owner（回归保护）', () {
+    for (final String callee in <String>[
+      'clipboard_panel_window_->ShowAt(',
+      'clipboard_panel_window_->PrewarmWebView(',
+    ]) {
+      final String seg = callArgs(cpp, callee);
+      expect(seg, contains('nullptr'), reason: '面板窗必须无 owner：$callee');
+      expect(seg.contains('GetHandle()'), isFalse,
+          reason: '面板窗不得 owned：$callee');
+    }
+  });
+}

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -877,9 +877,11 @@ void FlutterWindow::RegisterGlobalLookupChannel() {
           // TODO-1079 — build the overlay window + WebView2 off-screen at
           // startup so the first hotkey lookup hits a WARM surface (no cold
           // create-chain race that left the popup blank / self-closed).
+          // nullptr owner：与 showAt 同源解耦（无 owner，不拉主窗前台）。prewarm
+          // 与 showAt 的 owner 必须一致，否则 ForgetDeadWindow 重建时 owner 漂移。
           global_lookup_window_->PrewarmWebView(
               IntFromValue(args, "width", 420),
-              IntFromValue(args, "height", 600), GetHandle());
+              IntFromValue(args, "height", 600), nullptr);
           result->Success();
         } else if (method == "isWebViewReady") {
           // TODO-1079 — the ready-driven reveal fallback confirms the WebView2
@@ -900,9 +902,14 @@ void FlutterWindow::RegisterGlobalLookupChannel() {
               y = pt.y + 8;
             }
           }
+          // nullptr owner（不传主窗 HWND）：owned 窗显示/Z 序变更会连带把
+          // owner 主窗拉到前台（真机第 4 轮对面板确认的机制，见 1067 注释）。
+          // 用户诉求=悬浮字幕点词等 app 外查词绝不该夺前台（覆盖窗 §5 契约）：
+          // 瞬态窗也解耦成无 owner，与面板一致。短命窗（点外/前台切换即经
+          // arm_dismiss_hooks 自关），主窗最小化时照样收纳，无孤儿窗回归。
           const bool ok = global_lookup_window_->ShowAt(
               x, y, IntFromValue(args, "width", 420),
-              IntFromValue(args, "height", 600), GetHandle());
+              IntFromValue(args, "height", 600), nullptr);
           // TODO-893 (symptom 2) — report the CURSOR MONITOR work area
           // (physical px) so Dart's cascade layout uses the real screen, not
           // the off-screen measurement canvas. computeFrameRect's showBelow /
@@ -1067,8 +1074,9 @@ void FlutterWindow::RegisterClipboardPanelChannel() {
           // 真机修复：面板窗必须是**无 owner** 的顶层窗（nullptr，不传主窗
           // HWND）。owned window 有两个致命联动：owner 最小化时被系统一并隐藏
           // （真机症状=最小化 app 面板跟着消失），且 Z 序变更会连带 owner
-          // （点图钉把主 app 拉到前台）。常驻面板的生命周期必须与主窗解耦；
-          // 瞬态查词窗保持 owned 不变（短命窗，随主窗收纳是合理语义）。
+          // （点图钉把主 app 拉到前台）。常驻面板的生命周期必须与主窗解耦。
+          // BUG-738：瞬态查词窗（悬浮字幕点词/热键）此前保持 owned，同一 Z 序
+          // 连带把主窗拉前台——用户否决「随主窗收纳」取舍，故也改无 owner。
           clipboard_panel_window_->PrewarmWebView(
               IntFromValue(args, "width", 420),
               IntFromValue(args, "height", 600), nullptr);

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -253,9 +253,51 @@ int GlobalLookupWindow::OffscreenX() const {
          GetSystemMetrics(SM_CXVIRTUALSCREEN) + 200;
 }
 
+bool GlobalLookupWindow::OwnsLiveWindow() const {
+  if (hwnd_ == nullptr || !IsWindow(hwnd_)) {
+    return false;
+  }
+  // IsWindow() alone is not enough: Windows recycles HWND values, so a stale
+  // hwnd_ could name a DIFFERENT live window. Confirm the handle still points
+  // back at us via the GWLP_USERDATA we stamped in WM_NCCREATE.
+  return reinterpret_cast<GlobalLookupWindow*>(
+             GetWindowLongPtr(hwnd_, GWLP_USERDATA)) == this;
+}
+
+void GlobalLookupWindow::ForgetDeadWindow() {
+  if (hwnd_ == nullptr || OwnsLiveWindow()) {
+    return;
+  }
+  // The HWND was destroyed out from under us (WebView2 runtime crash/update,
+  // owner teardown, or any external DestroyWindow) yet hwnd_ stayed non-null,
+  // so every later ShowAt took the SetWindowPos(else) branch against a corpse
+  // and the app-external lookup/panel window "never came back without an app
+  // restart". Drop the dangling handle + the now-dead WebView2 proxies (the
+  // same release RecoverDeadWebView does) so the next ShowAt/PrewarmWebView
+  // rebuilds a fresh window from scratch. Surface it so the destroyer is
+  // diagnosable in the device log instead of a silent no-show.
+  if (error_cb_) {
+    error_cb_(
+        "overlay window found destroyed (external teardown) — rebuilding on "
+        "this lookup");
+  }
+  hwnd_ = nullptr;
+  controller_ = nullptr;
+  webview_ = nullptr;
+  env_ = nullptr;
+  webview_ready_ = false;
+  recovering_ = false;
+  visible_ = false;
+  revealed_ = false;
+}
+
 bool GlobalLookupWindow::ShowAt(int x, int y, int width, int height,
                                 HWND owner) {
   EnsureWindowClass();
+  // A previously-created window may have been destroyed out from under us; drop
+  // the dangling handle so the guard below rebuilds instead of SetWindowPos-ing
+  // a corpse (root cause of "second lookup / reopen shows nothing").
+  ForgetDeadWindow();
   // Remember where the card should ultimately appear; Reveal() uses it.
   pending_x_ = x;
   pending_y_ = y;
@@ -303,6 +345,7 @@ void GlobalLookupWindow::PrewarmWebView(int width, int height, HWND owner) {
   // path only renders + reveals. Semantics mirror the in-app keepWebViewWarm hot
   // slot, but for THIS bare overlay window (webview_prewarm.dart only warms the
   // in-app HeadlessInAppWebView, never this window — that gap was the root cause).
+  ForgetDeadWindow();  // A stale prewarm handle that died must be rebuilt.
   if (hwnd_ != nullptr) {
     return;  // Already warm (window + WebView2 exist) — idempotent.
   }
@@ -624,7 +667,10 @@ void GlobalLookupWindow::Hide(bool notify) {
 }
 
 bool GlobalLookupWindow::IsShowing() const {
-  return visible_ && hwnd_ != nullptr && IsWindowVisible(hwnd_);
+  // OwnsLiveWindow() (not a bare hwnd_ != nullptr) so a dangling/recycled handle
+  // can never report the overlay as showing — otherwise Dart's re-check skips
+  // the rebuild and renders into a window that no longer exists.
+  return visible_ && OwnsLiveWindow() && IsWindowVisible(hwnd_);
 }
 
 std::wstring GlobalLookupWindow::LoadAdapterScript() const {

--- a/hibiki/windows/runner/global_lookup_window.h
+++ b/hibiki/windows/runner/global_lookup_window.h
@@ -187,6 +187,16 @@ class GlobalLookupWindow {
   // and dismisses the appropriate layer (the host owns the shell geometry truth).
   void ForwardGlobalClickToHost(int screen_x, int screen_y);
   void EnsureWindowClass();
+  // Root fix: hwnd_ must be non-null IFF a LIVE window that is OURS exists.
+  // External teardown (WebView2 runtime crash/update, owner destroy, any
+  // DestroyWindow) left hwnd_ dangling-non-null, so ShowAt kept SetWindowPos-ing
+  // a corpse instead of rebuilding -> the app-external lookup/panel window
+  // "never came back without an app restart". OwnsLiveWindow() rejects a
+  // destroyed handle (IsWindow) AND a handle recycled to another window
+  // (GWLP_USERDATA != this); ForgetDeadWindow() drops such a handle + its dead
+  // WebView2 proxies so the next ShowAt/PrewarmWebView rebuilds from scratch.
+  bool OwnsLiveWindow() const;
+  void ForgetDeadWindow();
   void EnsureWebView();
   void RecoverDeadWebView(const std::string& replay_script);
   // TODO-1153 -- logs + reports an overlay WebView2 bring-up failure (never


### PR DESCRIPTION
## 用户报告
手动关闭第一个查词弹窗/剪贴板面板后，**第二个弹窗出不来**；有时"出来了但不知道去哪里了"；**不重启 app 不恢复**。

## 根因（数据结构缺陷，非路由/非全屏游戏）
覆盖窗 `GlobalLookupWindow`（剪贴板面板 + 瞬态查词窗同类两实例）的 `hwnd_` **只在析构才置 null**。HWND 被外部拆掉（WebView2 运行时更新/崩溃、owner 主窗 teardown、外部 `DestroyWindow`）后 `hwnd_` 悬垂为非 null，毒死两条自愈路径：
1. `ShowAt` 的 `if(hwnd_==nullptr)` 守卫为假 → 对死句柄 `SetWindowPos`（静默失败）→ **永不 `CreateWindowExW` 重建**。
2. `IsShowing()` 的 `hwnd_!=nullptr` 被悬垂/回收句柄骗过 → Dart 复检跳过重建、往不存在的窗口渲染并记 `reveal(box)`/`panel: updated` **成功**。

**实证**：20:54–21:08 `EnumWindows`(1788 窗) 中 `HibikiGlobalLookupWindow` **零个**，同期 Dart 持续记 reveal 成功；21:13 重启后恢复。

## 修复（Linus 式：恢复 `hwnd_` 非空 ⟺ 我方活窗 不变量）
- `OwnsLiveWindow()`：`IsWindow(hwnd_)` + `GWLP_USERDATA==this` 双判据（死句柄 / 被回收句柄都拒）
- `ForgetDeadWindow()`：非活窗则清 `hwnd_` + 释放死 `controller_/webview_/env_` + 复位状态 + `error_cb_` 记诊断日志
- `ShowAt`/`PrewarmWebView` 创建/幂等守卫前先 `ForgetDeadWindow()` → 触发真重建
- `IsShowing()` 改用 `OwnsLiveWindow()`

对"谁销毁的"不敏感——系统自愈，下一次复制/热键即重建，不再需要重启。诊断日志顺便坐实销毁者。

## 验证
- ✅ `flutter build windows --debug` 编译链接通过（改动零 warning）
- ✅ 守卫 `global_lookup_dead_window_recreate_guard_test.dart`（6 用例）绿
- ✅ `flutter analyze` 清零
- ⏳ **待真机**：制造外部销毁（`taskkill` msedgewebview2 进程树）后下一次热键/复制应自动重建并弹出（设备日志出现 `overlay window found destroyed — rebuilding`）

BUG 档：`docs/bugs/BUG-737-overlay-window-dead-handle-no-recreate.md`