### PR TITLE
fix(video): 字幕听力沉浸模糊随字号缩放，修模糊度不够 (BUG-738)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 722 条。点号进各自文件。
+> 共 723 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-738](bugs/BUG-738-subtitle-blur-weak.md) | ✅ | ✅ | 视频听力沉浸字幕模糊度不够(固定8px不随字号缩放) |
 | [BUG-737](bugs/BUG-737-selfclosing-anchor-blocks-lookup.md) | ✅ | ✅ | 自闭合a锚点被HTML解析成未闭合a包裹正文导致点字查词被链接守卫拒绝 |
 | [BUG-736](bugs/BUG-736-extension-popup-theme-vars.md) | ✅ | ✅ | 浏览器扩展查词弹窗主题与 app 不一致(漏发4个CSS变量) |
 | [BUG-735](bugs/BUG-735-shelf-add-button-size.md) | ✅ | ✅ | 书架添加按钮尺寸位置与其它头部按钮不一致 |

--- a/docs/bugs/BUG-738-subtitle-blur-weak.md
+++ b/docs/bugs/BUG-738-subtitle-blur-weak.md
@@ -1,0 +1,6 @@
+## BUG-738 · 视频听力沉浸字幕模糊度不够(固定8px不随字号缩放)
+- **报告**：2026-07-11（用户：qqbotxiaoxiao）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/video/video_subtitle_overlay.dart:829`——听力沉浸「模糊态」的高斯模糊 sigma 硬编码为 `ui.ImageFilter.blur(sigmaX: 8, sigmaY: 8)`，是个**与字幕字号无关的绝对像素值**。默认字号 36 时 8/36≈0.22×，本就偏浅；用户把字幕字号调大（外观设置或 respectAssStyle 放大）后，8px 相对更大的字形占比更小，字仍读得清，遮蔽失效——违背「听力沉浸=读不出、仅悬停/点击显形」的本意。
+- **[x] ① 已修复** — commit 见下。把固定 8 换成随字号缩放的纯函数 `VideoSubtitleOverlay.obscureBlurSigma(fontSize) = max(12, fontSize×0.45)`（默认 36→16.2≈旧值两倍，60→27），调用点 `video_subtitle_overlay.dart` `_wrapInteractive` 模糊态用 `widget.fontSize` 求 sigma。消除「固定绝对像素」这一特殊情况，任何字号下遮蔽强度同构且足够。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_obscure_blur_sigma_test.dart`：钉死 sigma 随字号单调递增、默认 36 显著强于旧值 8、大字号更强、小字号有下限、比例正确。
+- **备注**：未新增用户可调设置（避免过度设计）；根因是缩放缺失，不是缺开关。真机目视验证（大字号字幕开听力沉浸应真读不出）待用户在设备上确认。

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -215,6 +215,20 @@ class VideoSubtitleOverlay extends StatefulWidget {
   /// 出现前既有行为、不受影响）。
   final bool respectAssStyle;
 
+  /// 听力沉浸「模糊态」的高斯模糊 sigma（逻辑像素）。以前是硬编码 8——一个只对默认字号
+  /// 36 勉强够用的绝对值（8/36≈0.22×字宽），用户把字幕字号调大后同样的 8px 相对字形就
+  /// 太浅、字还读得清（用户报「模糊度不够」）。字幕遮蔽的本意是**让人读不出**（只在悬停/
+  /// 点击时显形），故模糊强度必须随字号同构缩放而非固定绝对像素：sigma = fontSize×0.45，
+  /// 并取下限 12 保证小字号也真正糊掉。默认 36 → 16.2（约旧值两倍），60 → 27。纯函数、
+  /// 无副作用，供守卫测试直接钉不变式。
+  @visibleForTesting
+  static double obscureBlurSigma(double fontSize) {
+    const double ratio = 0.45;
+    const double minSigma = 12;
+    final double scaled = fontSize * ratio;
+    return scaled < minSigma ? minSigma : scaled;
+  }
+
   @override
   State<VideoSubtitleOverlay> createState() => _VideoSubtitleOverlayState();
 }
@@ -822,11 +836,15 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
 
     if (blurred) {
       // 模糊态（仅主层）：盖一层高斯模糊 + 拦字符点击（避免误触查词）+ 显形热区。
+      // 模糊强度随字号缩放（见 [VideoSubtitleOverlay.obscureBlurSigma]），字号越大糊得越狠，
+      // 保证任何字号下都真读不出（旧的固定 8px 对大字号太浅，用户报「模糊度不够」）。
+      final double sigma =
+          VideoSubtitleOverlay.obscureBlurSigma(widget.fontSize);
       content = Stack(
         clipBehavior: Clip.none,
         children: <Widget>[
           ImageFiltered(
-            imageFilter: ui.ImageFilter.blur(sigmaX: 8, sigmaY: 8),
+            imageFilter: ui.ImageFilter.blur(sigmaX: sigma, sigmaY: sigma),
             child: content,
           ),
           Positioned.fill(

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.0.1+662
+version: 1.0.1+663
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/video/video_subtitle_obscure_blur_sigma_test.dart
+++ b/hibiki/test/media/video/video_subtitle_obscure_blur_sigma_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_subtitle_overlay.dart';
+
+/// BUG-738：听力沉浸「模糊态」的高斯模糊强度守卫。
+///
+/// 旧实现把 sigma 硬编码为绝对 8px（与字号无关），字号调大后字仍读得清 →「模糊度不够」。
+/// 修复把 sigma 改成随字号缩放的纯函数 [VideoSubtitleOverlay.obscureBlurSigma]，本测试
+/// 把「随字号单调递增 + 默认字号显著强于旧的 8 + 小字号有下限 + 比例正确」钉成不变式，
+/// 防止有人再退回固定值。
+void main() {
+  group('VideoSubtitleOverlay.obscureBlurSigma', () {
+    test('默认字号 36 时明显强于旧的固定 8px', () {
+      final double sigma = VideoSubtitleOverlay.obscureBlurSigma(36);
+      expect(sigma, greaterThan(8),
+          reason: '默认字号下的模糊必须比旧值 8 更强，否则仍读得出（BUG-738）');
+      // 36×0.45 = 16.2
+      expect(sigma, closeTo(16.2, 1e-9));
+    });
+
+    test('随字号单调递增：字号越大糊得越狠', () {
+      final double small = VideoSubtitleOverlay.obscureBlurSigma(30);
+      final double mid = VideoSubtitleOverlay.obscureBlurSigma(48);
+      final double large = VideoSubtitleOverlay.obscureBlurSigma(72);
+      expect(mid, greaterThan(small));
+      expect(large, greaterThan(mid));
+      // 48×0.45 = 21.6，72×0.45 = 32.4
+      expect(mid, closeTo(21.6, 1e-9));
+      expect(large, closeTo(32.4, 1e-9));
+    });
+
+    test('小字号取下限 12（保证再小也真糊掉）', () {
+      // 20×0.45 = 9 < 12 → 下限 12
+      expect(VideoSubtitleOverlay.obscureBlurSigma(20), 12);
+      expect(VideoSubtitleOverlay.obscureBlurSigma(10), 12);
+      // 下限拐点：fontSize=12/0.45≈26.67，略高于此走比例
+      expect(VideoSubtitleOverlay.obscureBlurSigma(28), closeTo(12.6, 1e-9));
+    });
+
+    test('比例恒为 0.45（大字号未被上限截断）', () {
+      for (final double fontSize in <double>[36, 48, 60, 100]) {
+        expect(VideoSubtitleOverlay.obscureBlurSigma(fontSize),
+            closeTo(fontSize * 0.45, 1e-9),
+            reason: '$fontSize 的 sigma 应等于 fontSize×0.45');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## 问题
用户报「视频开启字幕模糊时模糊度不够」。听力沉浸「模糊态」的高斯模糊 sigma 硬编码为 `ImageFilter.blur(sigmaX: 8, sigmaY: 8)`（`video_subtitle_overlay.dart:829`），是与字幕字号无关的绝对像素值。默认字号 36 时 8/36≈0.22×本就偏浅；字号调大后相对占比更小，字仍读得清 → 遮蔽失效。

## 根因修复
把固定 8 换成随字号缩放的纯函数：
```dart
VideoSubtitleOverlay.obscureBlurSigma(fontSize) = max(12, fontSize × 0.45)
```
默认 36→16.2（约旧值两倍），60→27，20→下限 12。消除「固定绝对像素」这一特殊情况，任何字号下遮蔽强度同构且足够。未新增用户可调设置（根因是缩放缺失，不是缺开关）。

## 测试
- 新增 `video_subtitle_obscure_blur_sigma_test.dart`：钉死随字号单调递增、默认字号强于旧的 8、小字号下限 12、比例 0.45。
- 相关 overlay/markup/obscure-mode 测试全过（59 passed）。
- `flutter analyze` No issues found。

## 待验证
真机目视：大字号字幕开听力沉浸应真读不出（悬停/点击才显形）。

BUG-738