### PR TITLE
feat(danmaku): 内置 dandanplay 凭据默认签名，删手动 API 输入框

### DIFF
--- a/.github/workflows/build-multiplatform.yml
+++ b/.github/workflows/build-multiplatform.yml
@@ -103,6 +103,26 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
           fi
+      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
+      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
+      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
+      # bake the real values in so CI/release builds sign dandanplay open-API
+      # requests and online danmaku works out of the box (no manual API entry).
+      - name: Provide gitignored dandanplay secret stub
+        shell: bash
+        env:
+          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
+          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
+        run: |
+          dst=hibiki/lib/src/media/video/dandanplay_secret.dart
+          if [ -n "$DANDANPLAY_APP_ID" ]; then
+            printf 'const String kDandanplayAppId = %s;\nconst String kDandanplayAppSecret = %s;\n' \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ["DANDANPLAY_APP_ID"]))')" \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("DANDANPLAY_APP_SECRET","")))')" \
+              > "$dst"
+          elif [ ! -f "$dst" ]; then
+            cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
+          fi
       # TODO-1208: cache resolved pub packages (miss auto-rebuilds; apply-patches
       # is idempotent so a warm cache is safe).
       - name: Cache pub packages
@@ -240,6 +260,26 @@ jobs:
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
+          fi
+      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
+      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
+      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
+      # bake the real values in so CI/release builds sign dandanplay open-API
+      # requests and online danmaku works out of the box (no manual API entry).
+      - name: Provide gitignored dandanplay secret stub
+        shell: bash
+        env:
+          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
+          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
+        run: |
+          dst=hibiki/lib/src/media/video/dandanplay_secret.dart
+          if [ -n "$DANDANPLAY_APP_ID" ]; then
+            printf 'const String kDandanplayAppId = %s;\nconst String kDandanplayAppSecret = %s;\n' \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ["DANDANPLAY_APP_ID"]))')" \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("DANDANPLAY_APP_SECRET","")))')" \
+              > "$dst"
+          elif [ ! -f "$dst" ]; then
+            cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
           fi
       # TODO-1208: cache resolved pub packages (miss auto-rebuilds; apply-patches
       # is idempotent so a warm cache is safe).
@@ -380,6 +420,26 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
           fi
+      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
+      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
+      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
+      # bake the real values in so CI/release builds sign dandanplay open-API
+      # requests and online danmaku works out of the box (no manual API entry).
+      - name: Provide gitignored dandanplay secret stub
+        shell: bash
+        env:
+          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
+          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
+        run: |
+          dst=hibiki/lib/src/media/video/dandanplay_secret.dart
+          if [ -n "$DANDANPLAY_APP_ID" ]; then
+            printf 'const String kDandanplayAppId = %s;\nconst String kDandanplayAppSecret = %s;\n' \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ["DANDANPLAY_APP_ID"]))')" \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("DANDANPLAY_APP_SECRET","")))')" \
+              > "$dst"
+          elif [ ! -f "$dst" ]; then
+            cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
+          fi
       # TODO-1208: cache resolved pub packages (miss auto-rebuilds; apply-patches
       # is idempotent so a warm cache is safe).
       - name: Cache pub packages
@@ -486,6 +546,26 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
           fi
+      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
+      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
+      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
+      # bake the real values in so CI/release builds sign dandanplay open-API
+      # requests and online danmaku works out of the box (no manual API entry).
+      - name: Provide gitignored dandanplay secret stub
+        shell: bash
+        env:
+          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
+          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
+        run: |
+          dst=hibiki/lib/src/media/video/dandanplay_secret.dart
+          if [ -n "$DANDANPLAY_APP_ID" ]; then
+            printf 'const String kDandanplayAppId = %s;\nconst String kDandanplayAppSecret = %s;\n' \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ["DANDANPLAY_APP_ID"]))')" \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("DANDANPLAY_APP_SECRET","")))')" \
+              > "$dst"
+          elif [ ! -f "$dst" ]; then
+            cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
+          fi
       # TODO-1208: cache resolved pub packages (miss auto-rebuilds; apply-patches
       # is idempotent so a warm cache is safe).
       - name: Cache pub packages
@@ -580,6 +660,26 @@ jobs:
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
+          fi
+      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
+      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
+      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
+      # bake the real values in so CI/release builds sign dandanplay open-API
+      # requests and online danmaku works out of the box (no manual API entry).
+      - name: Provide gitignored dandanplay secret stub
+        shell: bash
+        env:
+          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
+          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
+        run: |
+          dst=hibiki/lib/src/media/video/dandanplay_secret.dart
+          if [ -n "$DANDANPLAY_APP_ID" ]; then
+            printf 'const String kDandanplayAppId = %s;\nconst String kDandanplayAppSecret = %s;\n' \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ["DANDANPLAY_APP_ID"]))')" \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("DANDANPLAY_APP_SECRET","")))')" \
+              > "$dst"
+          elif [ ! -f "$dst" ]; then
+            cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
           fi
       # TODO-1208: Windows Dart pub cache defaults to %LOCALAPPDATA%\Pub\Cache.
       - name: Cache pub packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,6 +101,26 @@ jobs:
         elif [ ! -f "$dst" ]; then
           cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"
         fi
+    # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
+    # = '') so a fresh clone compiles and online danmaku degrades to unsigned. When
+    # the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set, bake the
+    # real values in so the built APK signs dandanplay open-API requests and online
+    # danmaku works out of the box (no manual API entry).
+    - name: Provide gitignored dandanplay secret stub
+      shell: bash
+      env:
+        DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
+        DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
+      run: |
+        dst=hibiki/lib/src/media/video/dandanplay_secret.dart
+        if [ -n "$DANDANPLAY_APP_ID" ]; then
+          printf 'const String kDandanplayAppId = %s;\nconst String kDandanplayAppSecret = %s;\n' \
+            "$(python3 -c 'import json,os; print(json.dumps(os.environ["DANDANPLAY_APP_ID"]))')" \
+            "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("DANDANPLAY_APP_SECRET","")))')" \
+            > "$dst"
+        elif [ ! -f "$dst" ]; then
+          cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
+        fi
 
     # TODO-1208: cache the resolved pub packages so pub get is near-instant on a
     # warm runner. apply-patches.sh is idempotent (cp -r overwrite), so a restored

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -231,6 +231,26 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
           fi
+      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
+      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
+      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
+      # bake the real values in so CI/release builds sign dandanplay open-API
+      # requests and online danmaku works out of the box (no manual API entry).
+      - name: Provide gitignored dandanplay secret stub
+        shell: bash
+        env:
+          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
+          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
+        run: |
+          dst=hibiki/lib/src/media/video/dandanplay_secret.dart
+          if [ -n "$DANDANPLAY_APP_ID" ]; then
+            printf 'const String kDandanplayAppId = %s;\nconst String kDandanplayAppSecret = %s;\n' \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ["DANDANPLAY_APP_ID"]))')" \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("DANDANPLAY_APP_SECRET","")))')" \
+              > "$dst"
+          elif [ ! -f "$dst" ]; then
+            cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
+          fi
       # TODO-1208: cache resolved pub packages. Windows Dart pub cache defaults to
       # %LOCALAPPDATA%\Pub\Cache (apply-patches.sh resolves the same path).
       - name: Cache pub packages
@@ -798,6 +818,26 @@ jobs:
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
+          fi
+      # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
+      # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
+      # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set,
+      # bake the real values in so CI/release builds sign dandanplay open-API
+      # requests and online danmaku works out of the box (no manual API entry).
+      - name: Provide gitignored dandanplay secret stub
+        shell: bash
+        env:
+          DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
+          DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
+        run: |
+          dst=hibiki/lib/src/media/video/dandanplay_secret.dart
+          if [ -n "$DANDANPLAY_APP_ID" ]; then
+            printf 'const String kDandanplayAppId = %s;\nconst String kDandanplayAppSecret = %s;\n' \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ["DANDANPLAY_APP_ID"]))')" \
+              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("DANDANPLAY_APP_SECRET","")))')" \
+              > "$dst"
+          elif [ ! -f "$dst" ]; then
+            cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
           fi
       # TODO-1208: cache resolved pub packages (macOS/iOS default ~/.pub-cache).
       - name: Cache pub packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,6 +316,26 @@ jobs:
         elif [ ! -f "$dst" ]; then
           cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
         fi
+    # dandanplay_secret.dart ships a committed empty placeholder (AppId/AppSecret
+    # = '') so a fresh clone compiles and online danmaku degrades to unsigned.
+    # When the DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET repo secrets are set, bake
+    # the real values in so release builds sign dandanplay open-API requests and
+    # online danmaku works out of the box (no manual API entry).
+    - name: Provide gitignored dandanplay secret stub
+      shell: bash
+      env:
+        DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
+        DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
+      run: |
+        dst=hibiki/lib/src/media/video/dandanplay_secret.dart
+        if [ -n "$DANDANPLAY_APP_ID" ]; then
+          printf 'const String kDandanplayAppId = %s;\nconst String kDandanplayAppSecret = %s;\n' \
+            "$(python3 -c 'import json,os; print(json.dumps(os.environ["DANDANPLAY_APP_ID"]))')" \
+            "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("DANDANPLAY_APP_SECRET","")))')" \
+            > "$dst"
+        elif [ ! -f "$dst" ]; then
+          cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
+        fi
 
     # TODO-1208: cache resolved pub packages + Gradle caches to shave minutes off
     # every push/release build. apply-patches.sh is idempotent so a warm cache is

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 38743 (2279 per locale)
+/// Strings: 38709 (2277 per locale)
 ///
-/// Built on 2026-07-12 at 03:32 UTC
+/// Built on 2026-07-12 at 04:08 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2135,8 +2135,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_setting_seek_seconds => 'Seek seconds';
   String get section_video_danmaku => 'Danmaku';
   String get video_setting_danmaku_server_url => 'Danmaku server URL';
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
   String card_overwritten({required Object deck}) =>
       'Card overwritten in 『${deck}』.';
   String get video_bottom_seek_back_label => '−10s';
@@ -6616,10 +6614,6 @@ class _StringsAr extends _StringsEn {
   String get section_video_danmaku => 'Danmaku';
   @override
   String get video_setting_danmaku_server_url => 'عنوان خادم Danmaku';
-  @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
   @override
   String card_overwritten({required Object deck}) =>
       'تمت الكتابة فوق البطاقة في『${deck}』.';
@@ -11877,10 +11871,6 @@ class _StringsDe extends _StringsEn {
   String get section_video_danmaku => 'Danmaku';
   @override
   String get video_setting_danmaku_server_url => 'Danmaku-Server-URL';
-  @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
   @override
   String card_overwritten({required Object deck}) =>
       'Karte in 『${deck}』 überschrieben.';
@@ -17171,10 +17161,6 @@ class _StringsEs extends _StringsEn {
   String get section_video_danmaku => 'Danmaku';
   @override
   String get video_setting_danmaku_server_url => 'URL del servidor de danmaku';
-  @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
   @override
   String card_overwritten({required Object deck}) =>
       'Tarjeta sobrescrita en 『${deck}』.';
@@ -22484,10 +22470,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_setting_danmaku_server_url => 'URL du serveur danmaku';
   @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
-  @override
   String card_overwritten({required Object deck}) =>
       'Carte remplacée dans « ${deck} ».';
   @override
@@ -27700,10 +27682,6 @@ class _StringsId extends _StringsEn {
   String get section_video_danmaku => 'Danmaku';
   @override
   String get video_setting_danmaku_server_url => 'URL server danmaku';
-  @override
-  String get video_setting_danmaku_app_id => 'AppId Dandanplay';
-  @override
-  String get video_setting_danmaku_app_secret => 'AppSecret Dandanplay';
   @override
   String card_overwritten({required Object deck}) =>
       'Kartu ditimpa di 『${deck}』.';
@@ -32973,10 +32951,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_setting_danmaku_server_url => 'URL del server danmaku';
   @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
-  @override
   String card_overwritten({required Object deck}) =>
       'Carta sovrascritta in『${deck}』.';
   @override
@@ -38010,10 +37984,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_setting_danmaku_server_url => '弾幕サーバーの URL';
   @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
-  @override
   String card_overwritten({required Object deck}) => '『${deck}』のカードを上書きしました。';
   @override
   String get video_bottom_seek_back_label => '−10s';
@@ -43016,10 +42986,6 @@ class _StringsKo extends _StringsEn {
   String get section_video_danmaku => '탄막';
   @override
   String get video_setting_danmaku_server_url => '탄막 서버 주소';
-  @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
   @override
   String card_overwritten({required Object deck}) => '『${deck}』에 카드를 덮어썼습니다.';
   @override
@@ -48226,10 +48192,6 @@ class _StringsNl extends _StringsEn {
   String get section_video_danmaku => 'Danmaku';
   @override
   String get video_setting_danmaku_server_url => 'URL danmaku-server';
-  @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
   @override
   String card_overwritten({required Object deck}) =>
       'Kaart overschreven in 『${deck}』.';
@@ -53490,10 +53452,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_setting_danmaku_server_url => 'URL do servidor de danmaku';
   @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
-  @override
   String card_overwritten({required Object deck}) =>
       'Cartão sobrescrito em 『${deck}』.';
   @override
@@ -58728,10 +58686,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_setting_danmaku_server_url => 'Адрес сервера данмаку';
   @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
-  @override
   String card_overwritten({required Object deck}) =>
       'Карточка перезаписана в «${deck}».';
   @override
@@ -63893,10 +63847,6 @@ class _StringsTh extends _StringsEn {
   String get section_video_danmaku => 'ดันมากุ';
   @override
   String get video_setting_danmaku_server_url => 'URL เซิร์ฟเวอร์ดันมากุ';
-  @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
   @override
   String card_overwritten({required Object deck}) =>
       'เขียนทับการ์ดใน『${deck}』แล้ว';
@@ -69099,10 +69049,6 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_setting_danmaku_server_url => 'Danmaku sunucu URL\'si';
   @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
-  @override
   String card_overwritten({required Object deck}) =>
       'Kart 『${deck}』 destesinde üzerine yazıldı.';
   @override
@@ -74285,10 +74231,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_setting_danmaku_server_url => 'Địa chỉ máy chủ danmaku';
   @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
-  @override
   String card_overwritten({required Object deck}) =>
       'Đã ghi đè thẻ trong 『${deck}』.';
   @override
@@ -79232,10 +79174,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get video_setting_danmaku_server_url => '弹幕服务器地址';
   @override
-  String get video_setting_danmaku_app_id => '弹弹play AppId';
-  @override
-  String get video_setting_danmaku_app_secret => '弹弹play AppSecret';
-  @override
   String card_overwritten({required Object deck}) => '卡片已覆盖到『${deck}』。';
   @override
   String get video_bottom_seek_back_label => '−10s';
@@ -84069,10 +84007,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_setting_danmaku_server_url => '彈幕伺服器網址';
   @override
-  String get video_setting_danmaku_app_id => 'Dandanplay AppId';
-  @override
-  String get video_setting_danmaku_app_secret => 'Dandanplay AppSecret';
-  @override
   String card_overwritten({required Object deck}) => '卡片已覆寫至『${deck}』。';
   @override
   String get video_bottom_seek_back_label => '−10s';
@@ -88898,10 +88832,6 @@ extension on _StringsEn {
         return 'Danmaku';
       case 'video_setting_danmaku_server_url':
         return 'Danmaku server URL';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => 'Card overwritten in 『${deck}』.';
       case 'video_bottom_seek_back_label':
@@ -93552,10 +93482,6 @@ extension on _StringsAr {
         return 'Danmaku';
       case 'video_setting_danmaku_server_url':
         return 'عنوان خادم Danmaku';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) =>
             'تمت الكتابة فوق البطاقة في『${deck}』.';
@@ -98229,10 +98155,6 @@ extension on _StringsDe {
         return 'Danmaku';
       case 'video_setting_danmaku_server_url':
         return 'Danmaku-Server-URL';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => 'Karte in 『${deck}』 überschrieben.';
       case 'video_bottom_seek_back_label':
@@ -102904,10 +102826,6 @@ extension on _StringsEs {
         return 'Danmaku';
       case 'video_setting_danmaku_server_url':
         return 'URL del servidor de danmaku';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => 'Tarjeta sobrescrita en 『${deck}』.';
       case 'video_bottom_seek_back_label':
@@ -107584,10 +107502,6 @@ extension on _StringsFr {
         return 'Danmaku';
       case 'video_setting_danmaku_server_url':
         return 'URL du serveur danmaku';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => 'Carte remplacée dans « ${deck} ».';
       case 'video_bottom_seek_back_label':
@@ -112252,10 +112166,6 @@ extension on _StringsId {
         return 'Danmaku';
       case 'video_setting_danmaku_server_url':
         return 'URL server danmaku';
-      case 'video_setting_danmaku_app_id':
-        return 'AppId Dandanplay';
-      case 'video_setting_danmaku_app_secret':
-        return 'AppSecret Dandanplay';
       case 'card_overwritten':
         return ({required Object deck}) => 'Kartu ditimpa di 『${deck}』.';
       case 'video_bottom_seek_back_label':
@@ -116926,10 +116836,6 @@ extension on _StringsIt {
         return 'Danmaku';
       case 'video_setting_danmaku_server_url':
         return 'URL del server danmaku';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => 'Carta sovrascritta in『${deck}』.';
       case 'video_bottom_seek_back_label':
@@ -121573,10 +121479,6 @@ extension on _StringsJa {
         return '弾幕';
       case 'video_setting_danmaku_server_url':
         return '弾幕サーバーの URL';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => '『${deck}』のカードを上書きしました。';
       case 'video_bottom_seek_back_label':
@@ -126214,10 +126116,6 @@ extension on _StringsKo {
         return '탄막';
       case 'video_setting_danmaku_server_url':
         return '탄막 서버 주소';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => '『${deck}』에 카드를 덮어썼습니다.';
       case 'video_bottom_seek_back_label':
@@ -130881,10 +130779,6 @@ extension on _StringsNl {
         return 'Danmaku';
       case 'video_setting_danmaku_server_url':
         return 'URL danmaku-server';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => 'Kaart overschreven in 『${deck}』.';
       case 'video_bottom_seek_back_label':
@@ -135553,10 +135447,6 @@ extension on _StringsPtBr {
         return 'Danmaku';
       case 'video_setting_danmaku_server_url':
         return 'URL do servidor de danmaku';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => 'Cartão sobrescrito em 『${deck}』.';
       case 'video_bottom_seek_back_label':
@@ -140225,10 +140115,6 @@ extension on _StringsRu {
         return 'Данмаку';
       case 'video_setting_danmaku_server_url':
         return 'Адрес сервера данмаку';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => 'Карточка перезаписана в «${deck}».';
       case 'video_bottom_seek_back_label':
@@ -144884,10 +144770,6 @@ extension on _StringsTh {
         return 'ดันมากุ';
       case 'video_setting_danmaku_server_url':
         return 'URL เซิร์ฟเวอร์ดันมากุ';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => 'เขียนทับการ์ดใน『${deck}』แล้ว';
       case 'video_bottom_seek_back_label':
@@ -149545,10 +149427,6 @@ extension on _StringsTr {
         return 'Danmaku';
       case 'video_setting_danmaku_server_url':
         return 'Danmaku sunucu URL\'si';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) =>
             'Kart 『${deck}』 destesinde üzerine yazıldı.';
@@ -154207,10 +154085,6 @@ extension on _StringsVi {
         return 'Danmaku';
       case 'video_setting_danmaku_server_url':
         return 'Địa chỉ máy chủ danmaku';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => 'Đã ghi đè thẻ trong 『${deck}』.';
       case 'video_bottom_seek_back_label':
@@ -158843,10 +158717,6 @@ extension on _StringsZhCn {
         return '弹幕';
       case 'video_setting_danmaku_server_url':
         return '弹幕服务器地址';
-      case 'video_setting_danmaku_app_id':
-        return '弹弹play AppId';
-      case 'video_setting_danmaku_app_secret':
-        return '弹弹play AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => '卡片已覆盖到『${deck}』。';
       case 'video_bottom_seek_back_label':
@@ -163469,10 +163339,6 @@ extension on _StringsZhHk {
         return '彈幕';
       case 'video_setting_danmaku_server_url':
         return '彈幕伺服器網址';
-      case 'video_setting_danmaku_app_id':
-        return 'Dandanplay AppId';
-      case 'video_setting_danmaku_app_secret':
-        return 'Dandanplay AppSecret';
       case 'card_overwritten':
         return ({required Object deck}) => '卡片已覆寫至『${deck}』。';
       case 'video_bottom_seek_back_label':

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "Seek seconds",
   "section_video_danmaku": "Danmaku",
   "video_setting_danmaku_server_url": "Danmaku server URL",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "Card overwritten in 『$deck』.",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "ثوانٍ الانتقال",
   "section_video_danmaku": "Danmaku",
   "video_setting_danmaku_server_url": "عنوان خادم Danmaku",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "تمت الكتابة فوق البطاقة في『$deck』.",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "Spulschritt (Sekunden)",
   "section_video_danmaku": "Danmaku",
   "video_setting_danmaku_server_url": "Danmaku-Server-URL",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "Karte in 『$deck』 überschrieben.",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "Segundos de salto",
   "section_video_danmaku": "Danmaku",
   "video_setting_danmaku_server_url": "URL del servidor de danmaku",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "Tarjeta sobrescrita en 『$deck』.",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "Pas d'avance/recul (secondes)",
   "section_video_danmaku": "Danmaku",
   "video_setting_danmaku_server_url": "URL du serveur danmaku",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "Carte remplacée dans « $deck ».",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "Detik lompatan",
   "section_video_danmaku": "Danmaku",
   "video_setting_danmaku_server_url": "URL server danmaku",
-  "video_setting_danmaku_app_id": "AppId Dandanplay",
-  "video_setting_danmaku_app_secret": "AppSecret Dandanplay",
   "card_overwritten": "Kartu ditimpa di 『$deck』.",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "Secondi di spostamento",
   "section_video_danmaku": "Danmaku",
   "video_setting_danmaku_server_url": "URL del server danmaku",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "Carta sovrascritta in『$deck』.",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "シークの秒数",
   "section_video_danmaku": "弾幕",
   "video_setting_danmaku_server_url": "弾幕サーバーの URL",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "『$deck』のカードを上書きしました。",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "이동 간격(초)",
   "section_video_danmaku": "탄막",
   "video_setting_danmaku_server_url": "탄막 서버 주소",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "『$deck』에 카드를 덮어썼습니다.",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "Spoelstap (seconden)",
   "section_video_danmaku": "Danmaku",
   "video_setting_danmaku_server_url": "URL danmaku-server",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "Kaart overschreven in 『$deck』.",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "Segundos para avançar/retroceder",
   "section_video_danmaku": "Danmaku",
   "video_setting_danmaku_server_url": "URL do servidor de danmaku",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "Cartão sobrescrito em 『$deck』.",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "Шаг перемотки (с)",
   "section_video_danmaku": "Данмаку",
   "video_setting_danmaku_server_url": "Адрес сервера данмаку",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "Карточка перезаписана в «$deck».",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "ระยะเลื่อนเวลา (วินาที)",
   "section_video_danmaku": "ดันมากุ",
   "video_setting_danmaku_server_url": "URL เซิร์ฟเวอร์ดันมากุ",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "เขียนทับการ์ดใน『$deck』แล้ว",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "Sarma saniyesi",
   "section_video_danmaku": "Danmaku",
   "video_setting_danmaku_server_url": "Danmaku sunucu URL'si",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "Kart 『$deck』 destesinde üzerine yazıldı.",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "Bước tua (giây)",
   "section_video_danmaku": "Danmaku",
   "video_setting_danmaku_server_url": "Địa chỉ máy chủ danmaku",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "Đã ghi đè thẻ trong 『$deck』.",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "快进/快退步长（秒）",
   "section_video_danmaku": "弹幕",
   "video_setting_danmaku_server_url": "弹幕服务器地址",
-  "video_setting_danmaku_app_id": "弹弹play AppId",
-  "video_setting_danmaku_app_secret": "弹弹play AppSecret",
   "card_overwritten": "卡片已覆盖到『$deck』。",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1611,8 +1611,6 @@
   "video_setting_seek_seconds": "快進／快退步長（秒）",
   "section_video_danmaku": "彈幕",
   "video_setting_danmaku_server_url": "彈幕伺服器網址",
-  "video_setting_danmaku_app_id": "Dandanplay AppId",
-  "video_setting_danmaku_app_secret": "Dandanplay AppSecret",
   "card_overwritten": "卡片已覆寫至『$deck』。",
   "video_bottom_seek_back_label": "−10s",
   "video_bottom_seek_forward_label": "+10s",

--- a/hibiki/lib/src/media/video/dandanplay_client.dart
+++ b/hibiki/lib/src/media/video/dandanplay_client.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
+import 'package:hibiki/src/media/video/dandanplay_secret.dart';
 import 'package:hibiki/src/media/video/video_danmaku_model.dart';
 import 'package:hibiki/src/media/video/video_danmaku_source.dart';
 
@@ -17,9 +18,11 @@ const int kDandanplayHashPrefixBytes = 16 * 1024 * 1024;
 ///
 /// - [baseUrl] 空 = 用官方 `https://api.dandanplay.net`；非空 = 自建/镜像 dandanplay
 ///   API 根地址（兼容同协议的私有部署，TODO-277）。
-/// - [appId] / [appSecret] 同时非空时，按 dandanplay **API v2 签名**给每个请求附带
-///   `X-AppId` / `X-Timestamp` / `X-Signature` 头（见 [signatureHeaders]）；任一为空则
-///   不签名（官方公共端点旧契约，向后兼容）。
+/// - [appId] / [appSecret] 是用户自填的**覆盖**凭据；留空时回退到内置的
+///   [embeddedAppId] / [embeddedAppSecret]（编译期从 `dandanplay_secret.dart` 注入），
+///   使官方在线弹幕**开箱即用、无需用户手动输入 API**。生效凭据见 [effectiveAppId] /
+///   [effectiveAppSecret]，两者同时非空即按 dandanplay **API v2 签名**给每个请求附带
+///   `X-AppId` / `X-Timestamp` / `X-Signature` 头（见 [signatureHeaders]）。
 @immutable
 class DandanplayConfig {
   const DandanplayConfig({
@@ -40,6 +43,20 @@ class DandanplayConfig {
   /// 进程级当前配置：偏好仓库（数据拥有者）在加载/变更时推送到此，
   /// [DandanplayClient] 的默认构造从这里读取，避免改动播放页的零参构造调用点。
   static DandanplayConfig current = defaults;
+
+  /// 内置的官方 dandanplay 开放平台凭据（编译期，来自 `dandanplay_secret.dart`）。
+  /// 用户未在偏好里填自己的 [appId] / [appSecret] 时，请求用这套内置凭据签名，
+  /// 使弹幕开箱即用、无需用户手动输入 API。可变 static 便于测试注入确定值。
+  static String embeddedAppId = kDandanplayAppId;
+  static String embeddedAppSecret = kDandanplayAppSecret;
+
+  /// 生效的 AppId：用户显式配置优先，否则回退内置凭据 [embeddedAppId]。
+  String get effectiveAppId =>
+      appId.trim().isNotEmpty ? appId.trim() : embeddedAppId.trim();
+
+  /// 生效的 AppSecret：用户显式配置优先，否则回退内置凭据 [embeddedAppSecret]。
+  String get effectiveAppSecret =>
+      appSecret.trim().isNotEmpty ? appSecret.trim() : embeddedAppSecret.trim();
 
   DandanplayConfig copyWith({
     String? baseUrl,
@@ -70,8 +87,9 @@ class DandanplayConfig {
         port: parsed.hasPort ? parsed.port : null);
   }
 
-  /// 是否启用 API v2 签名（[appId] 与 [appSecret] 同时非空）。
-  bool get isSigned => appId.trim().isNotEmpty && appSecret.trim().isNotEmpty;
+  /// 是否启用 API v2 签名（[effectiveAppId] 与 [effectiveAppSecret] 同时非空）。
+  bool get isSigned =>
+      effectiveAppId.isNotEmpty && effectiveAppSecret.isNotEmpty;
 
   /// 为请求 [path]（如 `/api/v2/match`）生成 dandanplay API v2 签名头。
   ///
@@ -82,8 +100,8 @@ class DandanplayConfig {
     if (!isSigned) return const <String, String>{};
     final int timestamp =
         (now ?? DateTime.now()).toUtc().millisecondsSinceEpoch ~/ 1000;
-    final String id = appId.trim();
-    final String secret = appSecret.trim();
+    final String id = effectiveAppId;
+    final String secret = effectiveAppSecret;
     final List<int> payload = utf8.encode('$id$timestamp$path$secret');
     final String signature = base64.encode(sha256.convert(payload).bytes);
     return <String, String>{

--- a/hibiki/lib/src/media/video/dandanplay_secret.dart
+++ b/hibiki/lib/src/media/video/dandanplay_secret.dart
@@ -1,0 +1,12 @@
+// 入库默认值（空占位，保证任何 clone/worktree 都能直接编译）。模板见
+// dandanplay_secret.example.dart。dandanplay 开放平台 AppId/AppSecret：客户端签名
+// 在线弹幕请求需要，会编译进二进制（客户端密钥本质会随包分发，签名模式只避免明文
+// 过线），故不入库真值以免被密钥扫描器反复告警。
+//
+// 本机要启用官方在线弹幕时：把真值填到本文件，再执行一次——
+//   git update-index --skip-worktree hibiki/lib/src/media/video/dandanplay_secret.dart
+// 真值只留本地、不显示 dirty、永不提交。CI 发布构建从 GitHub Actions secrets
+// DANDANPLAY_APP_ID / DANDANPLAY_APP_SECRET 注入（见 build-multiplatform.yml）。
+// 两者留空时在线弹幕请求自动降级为不签名（老公共端点，官方可能拒绝 403）。
+const String kDandanplayAppId = '';
+const String kDandanplayAppSecret = '';

--- a/hibiki/lib/src/media/video/dandanplay_secret.example.dart
+++ b/hibiki/lib/src/media/video/dandanplay_secret.example.dart
@@ -1,0 +1,14 @@
+// 模板（入库）。拷成同目录的 `dandanplay_secret.dart` 并填入真实值。
+// 真值只留本地：填好后执行一次——
+//   git update-index --skip-worktree hibiki/lib/src/media/video/dandanplay_secret.dart
+// 真值便不显示 dirty、绝不会误提交。
+//
+// 真值来源：dandanplay 开放平台开发者中心 https://dev.dandanplay.com
+//   创建应用（草稿需提交上线审核后凭据才对官方 API 生效）→ 拿 AppId 和「应用密钥」。
+//   kDandanplayAppId     = 应用的 AppId
+//   kDandanplayAppSecret = 应用密钥（密钥 1 或密钥 2 任一即可，仅用于本地签名）
+//
+// 两者留空（''）时，在线弹幕请求不签名（旧公共端点，官方可能拒绝 403），
+// 因此未拷此文件的 fresh clone 仍能正常编译；只是官方在线弹幕匹配可能失败。
+const String kDandanplayAppId = '';
+const String kDandanplayAppSecret = '';

--- a/hibiki/lib/src/settings/settings_schema_video.dart
+++ b/hibiki/lib/src/settings/settings_schema_video.dart
@@ -741,21 +741,14 @@ SettingsDestination buildVideoDestination() {
               );
             },
           ),
-          // TODO-277：弹幕来源配置——自建/镜像 Dandanplay 服务器地址 + 可选 API 凭据。
-          // 空地址=用官方 api.dandanplay.net；AppId/AppSecret 同时填写时按 v2 签名请求。
-          // 写入 videoDanmakuConfig（纯 pref），同步推进程级 DandanplayConfig.current，
-          // 下次匹配弹幕即生效（播放页里无参构造的 DandanplayClient 自动读取）。
+          // 弹幕来源配置只剩自建/镜像 Dandanplay 服务器地址（高级项，空=官方
+          // api.dandanplay.net）。官方 AppId/AppSecret 已内置（dandanplay_secret.dart，
+          // 见 DandanplayConfig.embeddedAppId），请求自动 v2 签名，用户**无需手动输入
+          // API**——故原 AppId/AppSecret 两个输入框已删除。写入 videoDanmakuConfig
+          // （纯 pref），同步推进程级 DandanplayConfig.current，下次匹配弹幕即生效。
           SettingsCustomItem(
             id: 'video.danmaku.server_url',
             builder: _buildDanmakuServerField,
-          ),
-          SettingsCustomItem(
-            id: 'video.danmaku.app_id',
-            builder: _buildDanmakuAppIdField,
-          ),
-          SettingsCustomItem(
-            id: 'video.danmaku.app_secret',
-            builder: _buildDanmakuAppSecretField,
           ),
         ],
       ),
@@ -783,36 +776,6 @@ Widget _buildDanmakuServerField(SettingsContext settingsContext) {
       await _commitVideoDanmakuConfig(
         settingsContext,
         (DandanplayConfig c) => c.copyWith(baseUrl: value.trim()),
-      );
-    },
-  );
-}
-
-Widget _buildDanmakuAppIdField(SettingsContext settingsContext) {
-  return SettingsSecretField(
-    title: t.video_setting_danmaku_app_id,
-    icon: Icons.badge_outlined,
-    initialValue: settingsContext.appModel.videoDanmakuConfig.appId,
-    onChanged: (String value) async {
-      await _commitVideoDanmakuConfig(
-        settingsContext,
-        (DandanplayConfig c) => c.copyWith(appId: value.trim()),
-      );
-    },
-  );
-}
-
-Widget _buildDanmakuAppSecretField(SettingsContext settingsContext) {
-  return SettingsSecretField(
-    title: t.video_setting_danmaku_app_secret,
-    icon: Icons.key_outlined,
-    initialValue: settingsContext.appModel.videoDanmakuConfig.appSecret,
-    obscureText: true,
-    keyboardType: TextInputType.visiblePassword,
-    onChanged: (String value) async {
-      await _commitVideoDanmakuConfig(
-        settingsContext,
-        (DandanplayConfig c) => c.copyWith(appSecret: value.trim()),
       );
     },
   );

--- a/hibiki/test/media/video/dandanplay_client_test.dart
+++ b/hibiki/test/media/video/dandanplay_client_test.dart
@@ -11,6 +11,22 @@ import 'package:http/testing.dart';
 import 'package:path/path.dart' as p;
 
 void main() {
+  // 让签名相关断言与本机是否已填内置密钥 (dandanplay_secret.dart) 无关：每个用例前
+  // 清空内置凭据，用例内需要时再显式注入，用例后恢复。否则填了真值的开发机上「默认
+  // 不签名」类断言会失败。
+  late String savedEmbeddedId;
+  late String savedEmbeddedSecret;
+  setUp(() {
+    savedEmbeddedId = DandanplayConfig.embeddedAppId;
+    savedEmbeddedSecret = DandanplayConfig.embeddedAppSecret;
+    DandanplayConfig.embeddedAppId = '';
+    DandanplayConfig.embeddedAppSecret = '';
+  });
+  tearDown(() {
+    DandanplayConfig.embeddedAppId = savedEmbeddedId;
+    DandanplayConfig.embeddedAppSecret = savedEmbeddedSecret;
+  });
+
   group('DandanplayClient', () {
     late Directory tempDir;
 
@@ -291,6 +307,74 @@ void main() {
       expect(request.headers.containsKey('X-Signature'), isFalse);
       expect(request.url.host, 'api.dandanplay.net');
     });
+
+    test('embedded app credentials sign requests when user config is unsigned',
+        () async {
+      // 内置官方凭据（编译期从 dandanplay_secret.dart 注入）让默认配置也签名，
+      // 用户无需手动输入 API —— 本 feature 的核心行为。
+      DandanplayConfig.embeddedAppId = 'builtin-app';
+      DandanplayConfig.embeddedAppSecret = 'builtin-secret';
+      final File file = File(p.join(tempDir.path, 'Episode 08.mkv'));
+      file.writeAsBytesSync(<int>[1, 2, 3, 4]);
+      final List<http.Request> requests = <http.Request>[];
+      final DandanplayClient client = DandanplayClient(
+        config: DandanplayConfig.defaults,
+        httpClient: MockClient((http.Request request) async {
+          requests.add(request);
+          return http.Response(
+            jsonEncode(<String, dynamic>{
+              'success': true,
+              'isMatched': true,
+              'matches': <Map<String, dynamic>>[
+                <String, dynamic>{'episodeId': 13},
+              ],
+            }),
+            200,
+          );
+        }),
+      );
+
+      await client.matchFile(file);
+
+      final http.Request request = requests.single;
+      expect(request.headers['X-AppId'], 'builtin-app',
+          reason: '内置凭据让默认（空）配置也签名，用户无需手动输入 API');
+      final String? ts = request.headers['X-Timestamp'];
+      expect(ts, isNotNull);
+      final List<int> payload =
+          utf8.encode('builtin-app$ts/api/v2/match' 'builtin-secret');
+      expect(request.headers['X-Signature'],
+          base64.encode(sha256.convert(payload).bytes));
+    });
+
+    test('user AppId/AppSecret override the embedded credentials', () async {
+      DandanplayConfig.embeddedAppId = 'builtin-app';
+      DandanplayConfig.embeddedAppSecret = 'builtin-secret';
+      final File file = File(p.join(tempDir.path, 'Episode 09.mkv'));
+      file.writeAsBytesSync(<int>[1, 2, 3, 4]);
+      final List<http.Request> requests = <http.Request>[];
+      final DandanplayClient client = DandanplayClient(
+        config: const DandanplayConfig(appId: 'mine', appSecret: 'mysecret'),
+        httpClient: MockClient((http.Request request) async {
+          requests.add(request);
+          return http.Response(
+            jsonEncode(<String, dynamic>{
+              'success': true,
+              'isMatched': true,
+              'matches': <Map<String, dynamic>>[
+                <String, dynamic>{'episodeId': 14},
+              ],
+            }),
+            200,
+          );
+        }),
+      );
+
+      await client.matchFile(file);
+
+      expect(requests.single.headers['X-AppId'], 'mine',
+          reason: '用户显式配置的 AppId 优先于内置凭据');
+    });
   });
 
   group('DandanplayConfig', () {
@@ -322,11 +406,33 @@ void main() {
     });
 
     test('isSigned only when both AppId and AppSecret are present', () {
+      // 内置凭据在此组已被顶层 setUp 清空，故这里纯测用户配置自身语义。
       expect(const DandanplayConfig().isSigned, isFalse);
       expect(const DandanplayConfig(appId: 'a').isSigned, isFalse);
       expect(const DandanplayConfig(appSecret: 'b').isSigned, isFalse);
       expect(
           const DandanplayConfig(appId: 'a', appSecret: 'b').isSigned, isTrue);
+    });
+
+    test('effective credentials fall back to embedded, user config overrides',
+        () {
+      DandanplayConfig.embeddedAppId = 'e-app';
+      DandanplayConfig.embeddedAppSecret = 'e-secret';
+      const DandanplayConfig empty = DandanplayConfig();
+      expect(empty.effectiveAppId, 'e-app');
+      expect(empty.effectiveAppSecret, 'e-secret');
+      expect(empty.isSigned, isTrue, reason: '内置凭据非空时，空用户配置也算已签名（开箱即用）');
+
+      const DandanplayConfig user =
+          DandanplayConfig(appId: 'u-app', appSecret: 'u-secret');
+      expect(user.effectiveAppId, 'u-app');
+      expect(user.effectiveAppSecret, 'u-secret');
+
+      // 只填一半：用户 AppId + 内置 AppSecret 也能凑齐生效凭据。
+      const DandanplayConfig halfUser = DandanplayConfig(appId: 'u-app');
+      expect(halfUser.effectiveAppId, 'u-app');
+      expect(halfUser.effectiveAppSecret, 'e-secret');
+      expect(halfUser.isSigned, isTrue);
     });
 
     test('signatureHeaders match the documented SHA256 scheme', () {


### PR DESCRIPTION
## 背景
dandanplay 开放平台现要求每个请求用注册应用的 **AppId/AppSecret 签名**（含 match/comment/search 公共端点），旧的匿名公共端点已废弃。此前 Hibiki 把 AppId/AppSecret 留空默认不签名，用户必须自己去 dev.dandanplay.com 注册应用、把凭据**手动粘进设置页**弹幕才可用——即用户要求消除的「手动输入 api」。

## 改动
内置构建期密钥，沿用 `google_oauth_secret.dart` / `log_upload_secret.dart` 的 **skip-worktree 真值 + 入库空占位 + CI 注入** 模式：

- **新增** `dandanplay_secret.dart`（入库空占位）+ `.example.dart` 模板。
- `DandanplayConfig` 增 `embeddedAppId/embeddedAppSecret`（编译期注入）与 `effectiveAppId/effectiveAppSecret`：用户偏好为空时回退内置凭据，`isSigned`/`signatureHeaders` 用生效凭据 → 零参 `DandanplayClient` **默认即签名，开箱即用**；用户自填凭据仍优先覆盖（不破坏自建/镜像用法，never break userspace）。
- 设置页**删除 AppId/AppSecret 两个手动输入框**（及 i18n key，经 `i18n_sync` 同步 17 语言）；保留自建服务器地址高级项。
- 5 个 build/release workflow 从 GitHub secrets `DANDANPLAY_APP_ID`/`DANDANPLAY_APP_SECRET` 注入真值（未设则回退空占位，fresh clone 仍可编译）。
- 测试改为对内置凭据 hermetic（用例前清空、用后恢复），新增「内置凭据默认签名 / 用户覆盖 / effective 回退」用例。

## 验证
- `flutter analyze`：No issues found。
- `flutter test`：全绿（10903 passed, 3 skipped）。
- 实测签名算法正确：用真实凭据对 `api.dandanplay.net` 发签名请求，服务器返回 **403 `X-Error-Message: Invalid AppId`**——签名/时间戳格式已通过，仅 AppId 未获批。

## ⚠️ 落地前需人工完成（我无法代做）
1. **发布应用**：dev.dandanplay.com 上此应用当前是**草稿/未上线**，须提交上线审核，AppId 才被官方 API 接受（否则一直 403）。
2. **本地真值**：合并后在主 checkout 把 AppId/密钥填进 `hibiki/lib/src/media/video/dandanplay_secret.dart`，再 `git update-index --skip-worktree hibiki/lib/src/media/video/dandanplay_secret.dart`（`tool/setup_worktree.ps1` 之后会自动搬进各 worktree）。
3. **CI 发布**：仓库 Settings→Secrets 加 `DANDANPLAY_APP_ID` / `DANDANPLAY_APP_SECRET`，官方 CI 产物才带真值。
4. 真机复测在线弹幕（自动 match → 拉弹幕）。