### PR TITLE
fix(lookup): app外查词覆盖窗吞点击(BUG-744)+第二张卡永远不可见(BUG-745)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 728 条。点号进各自文件。
+> 共 729 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-744](bugs/BUG-744-lookup-window-floor-region-eats-clicks.md) | ✅ | ✅ | app外查词覆盖窗铺满工作区吞掉下一次点击 |
 | [BUG-743](bugs/BUG-743-dual-subtitle-bounce-and-large-display-overlap.md) | ✅ | ✅ | 双轨字幕来回弹跳 + 大屏底部双语塌陷重叠 |
 | [BUG-742](bugs/BUG-742-subtitle-blur-weak.md) | ✅ | ✅ | 视频听力沉浸字幕模糊度不够(固定8px不随字号缩放) |
 | [BUG-741](bugs/BUG-741-transient-lookup-window-owned-pulls-main-foreground.md) | ✅ | ✅ | 悬浮字幕点词瞬态查词窗owned·Z序连带把主窗拉前台 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 729 条。点号进各自文件。
+> 共 730 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-745](bugs/BUG-745-lookup-slide-class-leak-invisible-cards.md) | ✅ | ✅ | app外查词第二张卡永远不可见——滑出class泄漏在复用根壳上 |
 | [BUG-744](bugs/BUG-744-lookup-window-floor-region-eats-clicks.md) | ✅ | ✅ | app外查词覆盖窗铺满工作区吞掉下一次点击 |
 | [BUG-743](bugs/BUG-743-dual-subtitle-bounce-and-large-display-overlap.md) | ✅ | ✅ | 双轨字幕来回弹跳 + 大屏底部双语塌陷重叠 |
 | [BUG-742](bugs/BUG-742-subtitle-blur-weak.md) | ✅ | ✅ | 视频听力沉浸字幕模糊度不够(固定8px不随字号缩放) |

--- a/docs/bugs/BUG-744-lookup-window-floor-region-eats-clicks.md
+++ b/docs/bugs/BUG-744-lookup-window-floor-region-eats-clicks.md
@@ -1,0 +1,47 @@
+## BUG-744 · app外查词覆盖窗铺满工作区吞掉下一次点击
+- **报告**：2026-07-12（用户：「app外查词，第二个弹窗闪一下消失，然后后面的弹窗连闪都不闪了」，build 7532）
+- **真实性**：✅ 真 bug（根因 `hibiki/assets/popup/global_lookup_host.js` measureAndReport 的 origin floor 拉 min-corner + `hibiki/windows/runner/global_lookup_window.cpp:ApplyRoundedRegion` 整窗 region；回归引入 = d2c57193a TODO-1345/BUG-583 round5，2026-07-09）
+- **[x] ① 已修复** — host 每次测量把 per-shell 窗口相对矩形（CSS px CSV）发 `shellRects` 给 native；native `ApplyRoundedRegion` 在 rects 非空时用 per-shell 圆角矩形并集 `SetWindowRgn`（窗口矩形不动，BUG-583 零位移保留；空隙点击物理穿透）；`Hide`/`ForgetDeadWindow` 清 rects、host `beginLookup` 重置去重键；`handleGlobalClick` gap dismiss 改立即 post（防 stale-dismiss 杀新卡）
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/global_lookup_host_test.mjs`（R1-R3：rects 内容/顺序/去重、beginLookup 重置、gap 即时 dismiss）+ `hibiki/test/lookup/global_lookup_shell_region_guard_test.dart`（7 用例源码扫描守卫，`flutter test` 绿）
+- **备注**：诊断还发现用户 `clipboard_panel_pinned=false`（面板非置顶被游戏/编辑器压底 =「连闪都不闪」的另一半），属用户可自复原状态（面板右上角图钉），非代码缺陷。
+
+### 根因
+
+TODO-1345（BUG-583 round5，d2c57193a，2026-07-09）为消除嵌套子卡打开时父卡位移，把 reveal
+bbox 的 min-corner 预拉到 Dart 计算的级联 origin floor（朝屏幕内部的 headroom）。光标在
+屏幕右/下半区时 floor ≈ 工作区左上角 → **瞬态覆盖窗 reveal 时铺满几乎整个工作区**
+（真机日志 `reveal(box)` 高恒 =1440 全屏高、宽 2335~2560 CSS）。
+
+该窗是**不透明**普通窗（无 WS_EX_LAYERED——与 WebView2 组合面不兼容，见 ShowAt 注释），
+`ApplyRoundedRegion` 做的是**整窗**圆角 region。于是卡片在屏时：
+
+1. 用户点剪贴板面板里的**下一个词** → 点击落在覆盖窗上（它盖住了面板）→ WebView/hook
+   判「卡外」→ 关卡 + **点击被吞**（面板没收到点击、不查词）——「第二个弹窗闪一下消失」
+   =用户瞄准下个词的那次点击亲手关掉了上一张卡且查词丢失，每查一个词要点两下。
+2. 用户点游戏推进文本 → 游戏激活升到非置顶面板之上（用户图钉恰为关）→ 面板沉底 →
+   后续点击全落游戏 →「连闪都不闪」。
+
+7-9 之前窗口只有卡片并集大小，卡旁点击落在窗外：LL 钩子关卡**且**点击照常到达面板
+（一次点击=关旧卡+查新词）——本修复恢复该语义而不牺牲 BUG-583 零位移。
+
+### 修复
+
+- `global_lookup_host.js`：measureAndReport 在 overlaySize **之前** post
+  `shellRects`（`l,t,w,h;…`，窗口相对 = shell − bbox min）；独立去重键
+  `lastShellRectsKey`（bbox 不变但子卡落在 floor 内时也必须刷新 region）；
+  beginLookup/空栈/换根时重置；`handleGlobalClick` 未命中 shell 的 gap dismiss
+  改为**立即** post `dismissPopupAt [0]`（同一次物理点击此刻已穿透到底下的应用并
+  可能发起新 lookup，200ms slide 延迟的 dismiss 会 post 在新卡种栈之后把它杀掉）。
+- `global_lookup_window.cpp/h`：WebMessageReceived 原生拦截 `shellRects`（不转发
+  Dart）；`SetShellRectsFromCsv` 解析并缓存；`ApplyRoundedRegion` rects 非空时
+  per-shell `CreateRoundRectRgn` + `CombineRgn(RGN_OR)` 并集 `SetWindowRgn`，空则
+  维持原整窗圆角（面板实例 panel mode 短路 measureAndReport 永不发 rects，行为
+  不变）；`Hide()`/`ForgetDeadWindow()` 清缓存。窗口矩形/origin 全程不动。
+
+### 待验证（真机）
+
+- 面板点释义词 → 卡片弹出（视觉为卡片本身而非大片）；卡片在屏时**直接点面板里
+  下一个词** → 旧卡关、新卡一次点击弹出（不再吞点击）。
+- 嵌套：卡内点词出子卡，父卡不位移（BUG-583 无回归）；点子卡正常交互。
+- 空隙点击落在游戏/其他应用上正常生效且卡片关闭。
+- 面板先点右上角图钉恢复置顶（`clipboard_panel_pinned` 当前为 false）。

--- a/docs/bugs/BUG-745-lookup-slide-class-leak-invisible-cards.md
+++ b/docs/bugs/BUG-745-lookup-slide-class-leak-invisible-cards.md
@@ -1,0 +1,38 @@
+## BUG-745 · app外查词第二张卡永远不可见——滑出class泄漏在复用根壳上
+- **报告**：2026-07-12（用户：「0.6s的弹窗我还看不见吗，他根本没出现在屏幕上」「我现在看不见弹窗，除了第一次」，build 7532）
+- **真实性**：✅ 真 bug（根因 `hibiki/assets/popup/global_lookup_host.js`：`dismissRootWithSlide` 只 `classList.add('global-lookup-dismissing')`，全文件无任何 remove；根壳跨查词复用（TODO-1095 stable root id））
+- **[x] ① 已修复** — `beginLookup` 对复用根壳 `classList.remove('global-lookup-dismissing')` + 复位 `dismissingRoot` 锁（分支 worktree-fix-lookup-gap-clickthrough，与 BUG-744 同 PR#51）
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/global_lookup_host_test.mjs` R4（复现下毒→断言 beginLookup 解毒→新渲染不复发）
+- **备注**：与 [BUG-744](BUG-744-lookup-window-floor-region-eats-clicks.md) 是同一次真机现场分出的两个独立根因；两者叠加才是完整症状。
+
+### 根因
+
+TODO-890（86be9b6b4，6-27）给根卡加了滑出关闭动画：`dismissRootWithSlide` 往根壳
+`classList.add('global-lookup-dismissing')`（CSS：`translateX(120%)` + `opacity:0`），
+等 transitionend 再 post dismiss。**但这个 class 从来没有任何代码移除**，而根壳是
+跨查词复用的（TODO-1095：root iframe/shell 稳定 id、只复用不重建）。
+
+于是会话内第一次走 JS 滑出路径关卡之后：
+
+- 之后每一次查词，Dart/native 全部正常（lookupText → searched → showAt →
+  popupRendered → overlaySize → reveal 日志齐全），
+- 但卡片渲染在一个「已滑出窗外 120% + 全透明」的壳里——**屏幕上永远什么都没有**。
+
+触发面被 TODO-1345（BUG-744 的全屏 floor 窗）放大成必现：窗口≈全屏后所有
+点外关卡都落在窗内 → 全走 JS 滑出路径 → 会话第一次关卡即「下毒」。7-9 之前
+窗口只有卡片大小，点外多走 native 钩子 Hide（不加 class），所以极少复现。
+
+用户描述的「闪一下消失/不在正常位置」= 那 200ms 横向滑出动画本身；
+「除了第一次全都看不见」= 下毒后的必然结果。
+
+### 修复
+
+`global_lookup_host.js` `beginLookup`（每次新查词、renderStack 之前必经的
+复位点）：对复用根壳 `classList.remove('global-lookup-dismissing')`，并复位
+`dismissingRoot` 锁（防被新查词打断的滑出留下卡死的 latch）。窗口此刻还在
+屏外/隐藏，摘 class 无可见副作用。
+
+### 待验证（真机）
+
+- 面板点词 → 卡片出现；点外关掉；**再点词 → 第二张卡正常出现**（原来必黑）。
+- 连续查 N 次全部可见；关闭动画（滑出）本身仍正常播放。

--- a/hibiki/assets/popup/global_lookup_host.js
+++ b/hibiki/assets/popup/global_lookup_host.js
@@ -103,6 +103,12 @@
   var bridgeSeq = 0;
   var bridgeRoutes = new Map();
   var lastBBoxKey = '';
+  // BUG-744 — last posted shell-rects payload (window-relative CSS px CSV).
+  // De-duped independently of lastBBoxKey: a nested child that lands INSIDE the
+  // reserved-floor bbox leaves the bbox key unchanged (overlaySize suppressed)
+  // but MUST still refresh the native hit/paint region, or clicks on the new
+  // card would fall through the stale region hole.
+  var lastShellRectsKey = '';
   // TODO-1079 (C) / TODO-1095 — the root frame id of the currently-rendered
   // stack. TODO-1095 makes the root frame id STABLE across hotkey lookups (the
   // root iframe is REUSED, not rebuilt per lookup — see beginLookup), so the
@@ -1103,6 +1109,9 @@
   // renderStack); only the CONTENT half of the two-flag gate is re-armed.
   function beginLookup(rootId) {
     lastBBoxKey = '';
+    // BUG-744 — native cleared its shell rects on Hide(); force a re-post even
+    // when the fresh card's rects CSV equals the previous lookup's.
+    lastShellRectsKey = '';
     // TODO-1231 v3 (BUG-583) — a NEW hotkey lookup re-reveals the window from a
     // fresh origin; drop the committed layer origin so a stale NEGATIVE origin left
     // by a PREVIOUS lookup's up/left cascade cannot falsely mark THIS lookup's
@@ -1188,6 +1197,7 @@
     if (!popups.length) {
       removeMissing([]);
       lastBBoxKey = '';
+      lastShellRectsKey = '';
       lastRootId = null;
       return;
     }
@@ -1208,6 +1218,7 @@
     if (rootId !== lastRootId) {
       lastRootId = rootId;
       lastBBoxKey = '';
+      lastShellRectsKey = '';
     }
     removeMissing(ids);
     scheduleMeasure();
@@ -1266,6 +1277,7 @@
     var minTopAll = Infinity;
     var maxRight = -Infinity;
     var maxBottom = -Infinity;
+    var shellRects = [];
     frames.forEach(function (record) {
       var left = parseFloat(record.shell.style.left) || 0;
       var top = parseFloat(record.shell.style.top) || 0;
@@ -1275,6 +1287,9 @@
       if (measured > 0 && (height <= 0 || measured < height)) {
         height = measured;
       }
+      // BUG-744 — collect every placed shell (same left/top/height the bbox
+      // uses) for the native hit/paint region below.
+      shellRects.push([left, top, width, height]);
       // MAX-corner (window size) + the bootstrap origin fallback see EVERY placed
       // shell, so the window pre-grows to cover a not-yet-ready child (no clip).
       if (left < minLeftAll) minLeftAll = left;
@@ -1327,6 +1342,25 @@
     // DWM window and the WebView2 surface cannot move in the SAME frame across the
     // JS/window boundary, so a ~1 frame residual remains (vs the old multi-frame
     // desync) — and only for a left/up cascade (dx/dy != 0; down-right stays 0).
+    // BUG-744 — report the per-shell rects (window-relative CSS px: the window
+    // is positioned at the bbox MIN-corner, so window-relative = shell − min)
+    // BEFORE overlaySize. Native clips the opaque overlay window's region to
+    // the UNION of these card rects (global_lookup_window.cpp
+    // ApplyRoundedRegion), so a click in the reserved-floor GAP passes through
+    // to the app below (clipboard panel next-word tap works in ONE click)
+    // instead of being swallowed by a near-fullscreen invisible sheet — the
+    // TODO-1345 floor regression. Posting before overlaySize means the region
+    // is already correct when Dart reveals the window (no clipped first frame).
+    // The window rect/origin itself never changes → BUG-583 zero-motion holds.
+    var rectsCsv = shellRects.map(function (r) {
+      return [r[0] - minLeft, r[1] - minTop, r[2], r[3]].map(function (v) {
+        return Math.round(v * 100) / 100;
+      }).join(',');
+    }).join(';');
+    if (rectsCsv !== lastShellRectsKey) {
+      lastShellRectsKey = rectsCsv;
+      postToHost('shellRects', [rectsCsv]);
+    }
     var dpr = (typeof window.devicePixelRatio === 'number' &&
                window.devicePixelRatio > 0) ? window.devicePixelRatio : 1;
     var box = {
@@ -1515,7 +1549,14 @@
     if (frameId != null) {
       return true; // Card hit: popup.js owns the per-layer decision.
     }
-    dismissRootWithSlide();
+    // BUG-744 — post the root dismiss IMMEDIATELY (no TODO-890 slide-out).
+    // With the shell-union window region the SAME physical gap click also
+    // lands in the app below (region hole) and may start a NEW lookup there
+    // (clipboard panel word tap → lookupText). A dismiss delayed 200ms by the
+    // slide would post AFTER the fresh card seeded and kill it (stale-dismiss
+    // race); posted now it always precedes the new lookup's stack reset
+    // (searchDictionary alone takes longer than the bridge round-trip).
+    postToHost('dismissPopupAt', [0]);
     return false;
   }
 

--- a/hibiki/assets/popup/global_lookup_host.js
+++ b/hibiki/assets/popup/global_lookup_host.js
@@ -1137,6 +1137,22 @@
     if (record.shell && typeof record.shell.setAttribute === 'function') {
       record.shell.setAttribute(ATTR_CONTENT_READY, 'false');
     }
+    // BUG-745 — strip the TODO-890 slide-out class off the REUSED root shell.
+    // dismissRootWithSlide adds .global-lookup-dismissing (translateX(120%) +
+    // opacity 0) and NOTHING ever removed it, while the root shell survives
+    // across lookups (stable root id, TODO-1095). After the first slide
+    // dismissal every later card therefore rendered ALREADY slid off-window and
+    // fully transparent: native revealed the window, popupRendered/overlaySize
+    // all fired, but the user saw NOTHING ("第一次正常，之后的弹窗根本不出
+    // 现"). The TODO-1345 floor window made every click-outside take the JS
+    // slide path (clicks always land inside the near-fullscreen window), so a
+    // session was poisoned on its very first dismissal.
+    if (record.shell && record.shell.classList &&
+        typeof record.shell.classList.remove === 'function') {
+      record.shell.classList.remove('global-lookup-dismissing');
+    }
+    // A slide interrupted by this new lookup must not leave the latch stuck.
+    dismissingRoot = false;
     // TODO-1231 (BUG-583) -- tear down the PREVIOUS lookup's content observer +
     // safety timer, but DO NOT re-arm an observer off the stale card here. The
     // reused iframe still holds the previous lookup's `.glossary-content`, so

--- a/hibiki/test/lookup/global_lookup_host_test.mjs
+++ b/hibiki/test/lookup/global_lookup_host_test.mjs
@@ -1745,4 +1745,78 @@ function flushTimers() {
   );
 }
 
+// ---- BUG-744 shell-union region + immediate gap dismiss --------------------
+
+// R1. measureAndReport posts shellRects (window-relative CSS px = shell − bbox
+//     min corner, CSV encoded) BEFORE overlaySize — native applies the region
+//     before Dart ever reveals the window — and de-dupes an identical
+//     re-measure.
+{
+  const { host } = freshHost();
+  hostPostLog = [];
+  host.renderStack({
+    popups: [
+      { id: 'frame-0', parentIndex: -1, frame: { left: 0, top: 0, width: 100, height: 80 }, settingsJs: '' },
+      { id: 'frame-1', parentIndex: 0, frame: { left: -40, top: 60, width: 100, height: 80 }, settingsJs: '' },
+    ],
+  });
+  // renderStack may run interim measure passes while shells are placed one by
+  // one; the LAST posts are the settled pair (same convention as test 11).
+  const idxRects = hostPostLog.map((m) => m.handler).lastIndexOf('shellRects');
+  const idxSize = hostPostLog.map((m) => m.handler).lastIndexOf('overlaySize');
+  assert.ok(idxRects >= 0, 'BUG-744: shellRects posted');
+  assert.ok(idxSize >= 0, 'overlaySize posted');
+  assert.ok(idxRects < idxSize,
+    'BUG-744: shellRects posted BEFORE overlaySize (region correct at reveal)');
+  // min corner = (-40, 0): frame-0 -> (40,0,100,80), frame-1 -> (0,60,100,80).
+  assert.strictEqual(hostPostLog[idxRects].args[0],
+    '40,0,100,80;0,60,100,80',
+    'BUG-744: rects are window-relative (shell − bbox min), CSV encoded');
+  hostPostLog = [];
+  host.measureAndReport();
+  assert.ok(!hostPostLog.some((m) => m.handler === 'shellRects'),
+    'BUG-744: identical re-measure is de-duped (no shellRects spam)');
+}
+
+// R2. beginLookup resets the shellRects de-dup key: native clears its cached
+//     rects on Hide(), so the next lookup must re-post even when its cascade
+//     geometry is byte-identical to the previous one.
+{
+  const { host } = freshHost();
+  host.renderStack({ popups: [descriptor('frame-0', -1)] });
+  hostPostLog = [];
+  host.beginLookup('frame-0');
+  host.measureAndReport();
+  assert.ok(hostPostLog.some((m) => m.handler === 'shellRects'),
+    'BUG-744: shellRects re-posted after beginLookup even when unchanged');
+}
+
+// R3. BUG-744: a hook-forwarded gap click posts the root dismiss IMMEDIATELY —
+//     never deferred behind the TODO-890 slide-out. With the shell-union
+//     window region the same physical click also lands in the app below and
+//     may start a NEW lookup there (clipboard panel word tap); a dismiss
+//     delayed 200ms would post after the fresh card seeded and kill it.
+{
+  const { host, document } = freshHost({ withObserver: true, withTimers: true });
+  host.renderStack({ popups: [descriptor('frame-0', -1)] });
+  const shell = shellsOf(document)[0];
+  // Give the root shell an animatable classList: a slide-based dismiss would
+  // DEFER its post to transitionend/safety-timer — the gap path must post NOW.
+  const classes = new Set();
+  shell.classList = {
+    add: (c) => classes.add(c),
+    remove: (c) => classes.delete(c),
+    contains: (c) => classes.has(c),
+  };
+  shell.addEventListener = () => {}; // transitionend never fires
+  shell.removeEventListener = () => {};
+  hostPostLog = [];
+  const hit = host.handleGlobalClick(5000, 5000);
+  assert.strictEqual(hit, false, 'gap click misses all shells');
+  const dismiss = hostPostLog.find((m) => m.handler === 'dismissPopupAt');
+  assert.ok(dismiss,
+    'BUG-744: gap dismiss posted synchronously (no slide-out deferral)');
+  assert.strictEqual(dismiss.args[0], 0, 'dismiss targets the root (index 0)');
+}
+
 console.log('global_lookup_host_test: PASS');

--- a/hibiki/test/lookup/global_lookup_host_test.mjs
+++ b/hibiki/test/lookup/global_lookup_host_test.mjs
@@ -1819,4 +1819,43 @@ function flushTimers() {
   assert.strictEqual(dismiss.args[0], 0, 'dismiss targets the root (index 0)');
 }
 
+// R4. BUG-745: the TODO-890 slide-out class must be stripped from the REUSED
+//     root shell when a new lookup begins. dismissRootWithSlide adds
+//     .global-lookup-dismissing (translateX(120%) + opacity 0) and nothing ever
+//     removed it while the root shell survives across lookups (stable root id)
+//     — so after the first slide dismissal EVERY later card rendered already
+//     slid off-window and fully transparent (native reveal fine, screen empty:
+//     「第一次正常，之后的弹窗根本不出现」).
+{
+  const { host, document } = freshHost({ withObserver: true, withTimers: true });
+  host.renderStack({ popups: [descriptor('frame-0', -1)] });
+  const shell = shellsOf(document)[0];
+  const classes = new Set(['global-lookup-frame-shell']);
+  shell.classList = {
+    add: (c) => classes.add(c),
+    remove: (c) => classes.delete(c),
+    contains: (c) => classes.has(c),
+  };
+  let endHandler = null;
+  shell.addEventListener = (type, fn) => {
+    if (type === 'transitionend') endHandler = fn;
+  };
+  shell.removeEventListener = () => {};
+  host.dismissRootWithSlide();
+  assert.ok(classes.has('global-lookup-dismissing'),
+    'slide dismissal poisons the reused root shell (precondition)');
+  endHandler({ propertyName: 'transform' });
+  assert.ok(classes.has('global-lookup-dismissing'),
+    'nothing removes the class at post time (the leak this test pins)');
+  // A NEW lookup begins: beginLookup must strip the class so the fresh card
+  // does not render slid-out + transparent (invisible).
+  host.beginLookup('frame-0');
+  assert.ok(!classes.has('global-lookup-dismissing'),
+    'BUG-745: beginLookup strips the slide-out class off the reused root shell');
+  // And the fresh renderStack must not re-add it.
+  host.renderStack({ popups: [descriptor('frame-0', -1)] });
+  assert.ok(!classes.has('global-lookup-dismissing'),
+    'BUG-745: the fresh render stays un-poisoned');
+}
+
 console.log('global_lookup_host_test: PASS');

--- a/hibiki/test/lookup/global_lookup_shell_region_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_shell_region_guard_test.dart
@@ -1,0 +1,125 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-744 — 瞬态查词覆盖窗命中/绘制区域必须裁到卡片矩形并集（源码扫描守卫）。
+///
+/// 真机根因链：TODO-1345（BUG-583 round5, d2c57193a）给 reveal bbox 预留级联
+/// origin floor 后，瞬态覆盖窗 reveal 时≈铺满整个工作区（真机日志 box 高恒为
+/// 全屏高）。该窗是**不透明**窗（无 WS_EX_LAYERED，WebView2 组合面限制），
+/// 全窗 region 意味着：卡片在屏时，点剪贴板面板里下一个词的点击落在覆盖窗上
+/// → host 判「卡外」→ 关卡 + **点击被吞**（用户症状=「第二个弹窗闪一下消失、
+/// 每次都要点两下」）。
+///
+/// 修复契约：
+/// 1. host（global_lookup_host.js）每次 measureAndReport 把各 shell 的
+///    窗口相对矩形（CSS px）以 `shellRects` CSV 消息发给 native，且在
+///    overlaySize 之前（窗口 reveal 时 region 已就位）。
+/// 2. native（global_lookup_window.cpp）在 WebMessageReceived 拦截
+///    shellRects（不转发 Dart），`ApplyRoundedRegion` 在 rects 非空时用
+///    per-shell 圆角矩形**并集**做 SetWindowRgn——空隙点击物理穿透到底下的
+///    应用（面板一次点击=关旧卡+查新词）；窗口矩形本身不动（BUG-583 零位移
+///    语义保留）。面板实例（panel mode 短路 measureAndReport）永不发 rects，
+///    维持整窗 region。
+/// 3. `Hide()` 与 `ForgetDeadWindow()` 清空缓存 rects；host 在 beginLookup
+///    重置去重键，保证下一次 lookup 重新发送。
+/// 4. host 的 hook 转发 gap 点击（handleGlobalClick 未命中 shell）必须**立即**
+///    post dismissPopupAt——同一次物理点击此刻也落进了底下的应用并可能已发起
+///    新 lookup，200ms slide 延迟的 dismiss 会杀掉新卡（stale-dismiss 竞态）。
+///
+/// 覆盖窗真渲染依赖 native WebView2，headless 测不了，故源码扫描钉住契约；
+/// 行为面由 node harness（global_lookup_host_test.mjs R1-R3）覆盖。
+void main() {
+  String read(String p) => File(p).readAsStringSync().replaceAll('\r\n', '\n');
+
+  late String cpp;
+  late String hdr;
+  late String hostJs;
+  setUpAll(() {
+    cpp = read('windows/runner/global_lookup_window.cpp');
+    hdr = read('windows/runner/global_lookup_window.h');
+    hostJs = read('assets/popup/global_lookup_host.js');
+  });
+
+  /// 抽出一个顶层函数体（从签名行到下一个左对齐 `}`）。
+  String functionBody(String src, String signature) {
+    final int at = src.indexOf(signature);
+    expect(at, greaterThanOrEqualTo(0), reason: '必须存在：$signature');
+    final int end = src.indexOf('\n}', at);
+    expect(end, greaterThan(at));
+    return src.substring(at, end);
+  }
+
+  test('native 拦截 shellRects 且不转发 Dart（region 是纯 Win32 状态）', () {
+    final int intercept = cpp.indexOf('"\\"handler\\":\\"shellRects\\""');
+    expect(intercept, greaterThanOrEqualTo(0),
+        reason: 'WebMessageReceived 必须按带引号的 handler 名拦截 shellRects');
+    final int forward = cpp.indexOf('if (message_cb_)', intercept);
+    final int handle = cpp.indexOf('SetShellRectsFromCsv(body)', intercept);
+    expect(handle, greaterThanOrEqualTo(0), reason: '拦截后必须解析并应用 region');
+    expect(handle, lessThan(forward),
+        reason: 'shellRects 必须在 message_cb_ 转发之前拦截（return，不进 Dart 日志）');
+  });
+
+  test('ApplyRoundedRegion：rects 非空走 per-shell 并集，空退回整窗圆角', () {
+    final String body =
+        functionBody(cpp, 'void GlobalLookupWindow::ApplyRoundedRegion()');
+    expect(body, contains('!shell_rects_css_.empty()'),
+        reason: '必须按 shell rects 有无分流');
+    expect(body, contains('CombineRgn'), reason: '卡片矩形必须以 RGN_OR 并集合成命中/绘制区域');
+    expect(body, contains('RGN_OR'), reason: '并集语义（不是交集/差集）');
+    expect(
+        'CreateRoundRectRgn'.allMatches(body).length, greaterThanOrEqualTo(2),
+        reason: 'per-shell 圆角矩形 + 整窗圆角回退两条路径都必须存在');
+  });
+
+  test('Hide 与 ForgetDeadWindow 清空缓存 rects（防 stale region 裁掉下一张卡）', () {
+    final String hide = functionBody(cpp, 'void GlobalLookupWindow::Hide(');
+    expect(hide, contains('shell_rects_css_.clear()'),
+        reason: 'Hide 必须清 rects：下一次 lookup 由 host 重新发送');
+    final String forget =
+        functionBody(cpp, 'void GlobalLookupWindow::ForgetDeadWindow()');
+    expect(forget, contains('shell_rects_css_.clear()'),
+        reason: '死窗重建路径同样不得携带旧 region');
+  });
+
+  test('头文件声明 SetShellRectsFromCsv 与 shell_rects_css_', () {
+    expect(
+        hdr, contains('void SetShellRectsFromCsv(const std::string& body);'));
+    expect(
+        hdr, contains('std::vector<std::array<double, 4>> shell_rects_css_;'));
+  });
+
+  test('host：measureAndReport 发 shellRects 且在 overlaySize 之前', () {
+    final int at = hostJs.indexOf('function measureAndReport()');
+    expect(at, greaterThanOrEqualTo(0));
+    final int end = hostJs.indexOf('\n  function ', at + 10);
+    final String body = hostJs.substring(at, end > at ? end : hostJs.length);
+    final int rects = body.indexOf("postToHost('shellRects'");
+    final int size = body.indexOf("postToHost('overlaySize'");
+    expect(rects, greaterThanOrEqualTo(0),
+        reason: 'measureAndReport 必须上报 per-shell 矩形');
+    expect(size, greaterThan(rects),
+        reason: 'shellRects 必须先于 overlaySize（reveal 时 region 已就位）');
+  });
+
+  test('host：beginLookup 重置 shellRects 去重键', () {
+    final int at = hostJs.indexOf('function beginLookup(');
+    expect(at, greaterThanOrEqualTo(0));
+    final int end = hostJs.indexOf('\n  }', at);
+    final String body = hostJs.substring(at, end);
+    expect(body, contains("lastShellRectsKey = ''"),
+        reason: 'native 在 Hide 清掉了 rects，新 lookup 相同几何也必须重发');
+  });
+
+  test('host：handleGlobalClick 的 gap dismiss 立即 post（不走 200ms slide）', () {
+    final int at = hostJs.indexOf('function handleGlobalClick(');
+    expect(at, greaterThanOrEqualTo(0));
+    final int end = hostJs.indexOf('\n  }', at);
+    final String body = hostJs.substring(at, end);
+    expect(body, contains("postToHost('dismissPopupAt', [0])"),
+        reason: 'gap 点击的 dismiss 必须同步 post——同一次点击可能已在底下发起新 lookup');
+    expect(body.contains('dismissRootWithSlide()'), isFalse,
+        reason: '不得回退到 slide 延迟路径（stale-dismiss 会杀掉新卡，回归 signature）');
+  });
+}

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -3,6 +3,7 @@
 #include <dwmapi.h>
 #include <shlwapi.h>
 
+#include <cmath>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -289,6 +290,7 @@ void GlobalLookupWindow::ForgetDeadWindow() {
   recovering_ = false;
   visible_ = false;
   revealed_ = false;
+  shell_rects_css_.clear();  // BUG-744 — stale rects must not clip a rebuild.
 }
 
 bool GlobalLookupWindow::ShowAt(int x, int y, int width, int height,
@@ -635,6 +637,10 @@ void GlobalLookupWindow::Hide(bool notify) {
   const bool was_showing = visible_;
   visible_ = false;
   revealed_ = false;
+  // BUG-744 — drop the per-shell region rects: the next lookup renders a new
+  // cascade and re-posts fresh rects (the host resets its de-dup key in
+  // beginLookup), so a stale region can never clip the next card.
+  shell_rects_css_.clear();
   if (foreground_hook_ != nullptr) {
     UnhookWinEvent(foreground_hook_);
     foreground_hook_ = nullptr;
@@ -971,6 +977,16 @@ void GlobalLookupWindow::ConfigureWebView() {
               // HandleMessage）统一回报最终 rect 给 Dart 持久化。Matching
               // quoted handler names keeps glossary text that merely mentions
               // the words from triggering this.
+              // BUG-744 — the transient host reports its per-shell card rects
+              // (window-relative CSS px) whenever the cascade layout changes.
+              // Handled fully natively (region update is pure Win32 state, no
+              // Dart decision involved) and NOT forwarded, so the Dart message
+              // log is not spammed once per measure pass.
+              if (body.find("\"handler\":\"shellRects\"") !=
+                  std::string::npos) {
+                SetShellRectsFromCsv(body);
+                return S_OK;
+              }
               if (body.find("\"handler\":\"beginWindowDrag\"") !=
                       std::string::npos ||
                   body.find("\"handler\":\"beginWindowResize\"") !=
@@ -1228,6 +1244,18 @@ LRESULT CALLBACK GlobalLookupWindow::WndProc(HWND hwnd, UINT message,
 // lookup window has rounded corners that match popup.css's 10px card radius.
 // Called on every WM_SIZE. The corner diameter (2 * radius) is scaled by the
 // window DPI so the rounding stays a constant ~10 logical px across monitors.
+//
+// BUG-744 — when the host has reported per-shell rects (transient cascade
+// mode), the region is the UNION of those rounded card rects instead of the
+// full window. Root cause chain: the TODO-1345 reserved cascade floor makes
+// the revealed window span ~the whole work area (so a nested child never
+// moves the window = BUG-583 zero-motion); this window is OPAQUE (no
+// WS_EX_LAYERED, WebView2 composition), so a full-window region both painted
+// a near-fullscreen sheet AND swallowed every click meant for the app below —
+// the user's "click the next word in the clipboard panel → the card just
+// vanishes and the click is eaten" regression. Clipping the region to the
+// real cards keeps the window geometry 100% untouched (zero-motion holds)
+// while gap clicks physically pass through to whatever is beneath.
 void GlobalLookupWindow::ApplyRoundedRegion() {
   if (hwnd_ == nullptr) {
     return;
@@ -1245,12 +1273,97 @@ void GlobalLookupWindow::ApplyRoundedRegion() {
   }
   // 10 logical px radius -> diameter = 20 logical px, scaled to physical px.
   const int diameter = MulDiv(20, static_cast<int>(dpi), 96);
+  if (!shell_rects_css_.empty()) {
+    const double dpr = static_cast<double>(dpi) / 96.0;
+    HRGN union_region = CreateRectRgn(0, 0, 0, 0);
+    if (union_region != nullptr) {
+      bool any = false;
+      for (const std::array<double, 4>& r : shell_rects_css_) {
+        if (r[2] <= 0 || r[3] <= 0) {
+          continue;
+        }
+        const int l = static_cast<int>(std::floor(r[0] * dpr));
+        const int t = static_cast<int>(std::floor(r[1] * dpr));
+        const int rt = static_cast<int>(std::ceil((r[0] + r[2]) * dpr));
+        const int b = static_cast<int>(std::ceil((r[1] + r[3]) * dpr));
+        HRGN shell = CreateRoundRectRgn(l, t, rt + 1, b + 1, diameter, diameter);
+        if (shell != nullptr) {
+          CombineRgn(union_region, union_region, shell, RGN_OR);
+          DeleteObject(shell);
+          any = true;
+        }
+      }
+      if (any) {
+        // SetWindowRgn takes ownership on success; the system frees it.
+        SetWindowRgn(hwnd_, union_region, TRUE);
+        return;
+      }
+      DeleteObject(union_region);
+    }
+    // Region build failed -> fall through to the full-window region (worse UX,
+    // never a missing/garbage region).
+  }
   HRGN region =
       CreateRoundRectRgn(0, 0, width + 1, height + 1, diameter, diameter);
   if (region != nullptr) {
     // SetWindowRgn takes ownership of the region on success; the system frees it.
     SetWindowRgn(hwnd_, region, TRUE);
   }
+}
+
+// BUG-744 — parse {handler:'shellRects', args:['l,t,w,h;l,t,w,h;…']} (window-
+// relative CSS px, numbers only — produced by global_lookup_host.js
+// measureAndReport) and re-apply the window region. A malformed payload (or a
+// glossary string that merely contains the handler name) parses to zero rects
+// and leaves the previous region untouched — degraded, never garbage.
+void GlobalLookupWindow::SetShellRectsFromCsv(const std::string& body) {
+  const std::string args_marker = "\"args\":[\"";
+  const size_t args_at = body.find(args_marker);
+  if (args_at == std::string::npos) {
+    return;
+  }
+  const size_t start = args_at + args_marker.size();
+  const size_t end = body.find('"', start);
+  if (end == std::string::npos || end <= start) {
+    return;
+  }
+  const std::string csv = body.substr(start, end - start);
+  std::vector<std::array<double, 4>> rects;
+  size_t pos = 0;
+  while (pos < csv.size()) {
+    size_t next = csv.find(';', pos);
+    if (next == std::string::npos) {
+      next = csv.size();
+    }
+    const std::string rect_str = csv.substr(pos, next - pos);
+    std::array<double, 4> rect{};
+    int idx = 0;
+    size_t p = 0;
+    bool ok = true;
+    while (idx < 4 && p <= rect_str.size()) {
+      size_t comma = rect_str.find(',', p);
+      if (comma == std::string::npos) {
+        comma = rect_str.size();
+      }
+      try {
+        rect[idx] = std::stod(rect_str.substr(p, comma - p));
+      } catch (...) {
+        ok = false;
+        break;
+      }
+      ++idx;
+      p = comma + 1;
+    }
+    if (ok && idx == 4) {
+      rects.push_back(rect);
+    }
+    pos = next + 1;
+  }
+  if (rects.empty()) {
+    return;
+  }
+  shell_rects_css_ = std::move(rects);
+  ApplyRoundedRegion();
 }
 
 void GlobalLookupWindow::ForwardGlobalClickToHost(int screen_x, int screen_y) {

--- a/hibiki/windows/runner/global_lookup_window.h
+++ b/hibiki/windows/runner/global_lookup_window.h
@@ -26,6 +26,7 @@
 #include <wil/com.h>
 #pragma warning(pop)
 
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -181,7 +182,15 @@ class GlobalLookupWindow {
   LRESULT HandleMessage(UINT message, WPARAM wparam, LPARAM lparam);
   int OffscreenX() const;
   // TODO-867 P2: round the window corners to match popup.css's card radius.
+  // BUG-744: when the host has reported per-shell rects (transient cascade
+  // mode), the region is the UNION of those card rects instead of the full
+  // window — the TODO-1345 reserved-floor window spans ~the whole work area,
+  // and an opaque full-window region both paints a giant sheet and swallows
+  // every click meant for the app below (clipboard panel next-word tap).
   void ApplyRoundedRegion();
+  // BUG-744 — parses the host's {handler:'shellRects', args:['l,t,w,h;…']}
+  // message (window-relative CSS px) and re-applies the window region.
+  void SetShellRectsFromCsv(const std::string& body);
   // TODO-867 P3c E2: forward a global click (screen physical px) into the web
   // host as host CSS px relative to the window, so the host hit-tests its shells
   // and dismisses the appropriate layer (the host owns the shell geometry truth).
@@ -227,6 +236,11 @@ class GlobalLookupWindow {
   std::wstring user_data_leaf_ = L"GlobalLookupWebView2";
   std::wstring popup_assets_dir_;
   std::string pending_json_;
+  // BUG-744 — host-reported shell rects (window-relative CSS px, one
+  // {l,t,w,h} per card). Non-empty only on the transient cascade instance
+  // (the panel host short-circuits measureAndReport and never posts them).
+  // Cleared on Hide()/ForgetDeadWindow() so a fresh lookup re-posts.
+  std::vector<std::array<double, 4>> shell_rects_css_;
 
   wil::com_ptr<ICoreWebView2Environment> env_;
   wil::com_ptr<ICoreWebView2Controller> controller_;


### PR DESCRIPTION
## 症状（用户 build 7532）
app外查词：第一张卡正常；之后「弹窗闪一下消失/不在正常位置」，再往后「根本没出现在屏幕上」，面板持续正常更新、日志全绿。

## 两个独立根因（同一现场）

### BUG-745：第二张卡永远不可见（「根本没出现」的真根因）
TODO-890（86be9b6b4）滑出关闭动画给根壳加 `.global-lookup-dismissing`（translateX(120%)+opacity:0），**全文件没有任何 remove**；根壳跨查词复用（TODO-1095 stable root id）。会话第一次走 JS 滑出关卡后，之后每张卡都渲染在「已滑出+全透明」的壳里：native reveal/popupRendered/overlaySize 全正常，屏幕永远空。「闪一下消失」=那 200ms 滑出动画本身。
**修**：`beginLookup` 摘 class + 复位 dismissingRoot 锁。harness R4 复现下毒→解毒。

### BUG-744：全屏隐形窗吞掉下一次点击（触发面放大器）
TODO-1345（d2c57193a）origin floor 让 reveal 窗≈铺满工作区（不透明窗+整窗 region）→ 卡片在屏时点面板下一个词的点击被覆盖窗吃掉（只关卡不查词），且所有点外关卡都被推上 JS 滑出路径=BUG-745 必现。
**修**：host 每次测量发 per-shell 矩形，native `ApplyRoundedRegion` 用卡片圆角矩形并集 SetWindowRgn——空隙点击物理穿透（一次点击=关旧卡+出新卡）；窗口矩形不动（BUG-583 零位移保留）；hook gap dismiss 改立即 post 防 stale-dismiss 竞态。

## 验证
- node harness R1-R4 全绿（rects 内容/顺序/去重、beginLookup 重置、gap 即时 dismiss、滑出 class 解毒）
- 守卫 `global_lookup_shell_region_guard_test.dart` 7 用例绿；`flutter test test/lookup/` 389 全绿；`flutter analyze` 清零；`flutter build windows --debug` 通过

## 待真机
- 面板点词→卡出现→点外关→**再点词第二张卡正常出现**，连续 N 次全部可见
- 卡在屏时直接点下一个词：旧卡关+新卡一次点击弹出（不吞点击）
- 嵌套子卡打开父卡不位移（BUG-583 无回归）；空隙点击对底下应用正常生效
- 另：用户面板图钉当前为关（clipboard_panel_pinned=false），面板被压底需点亮图钉（PR#52 任务栏图标是兜底找回）

docs/bugs/BUG-744 / BUG-745