### PR TITLE
feat(clipboard-panel): 面板独立任务栏图标，点击拉回前台

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 38743 (2279 per locale)
+/// Strings: 38760 (2280 per locale)
 ///
-/// Built on 2026-07-12 at 04:08 UTC
+/// Built on 2026-07-12 at 05:02 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3013,6 +3013,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get collection_member_removed => 'Removed from collection';
   String get collection_default_name => 'New collection';
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -8165,6 +8166,8 @@ class _StringsAr extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -13440,6 +13443,8 @@ class _StringsDe extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -18732,6 +18737,8 @@ class _StringsEs extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -24043,6 +24050,8 @@ class _StringsFr extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -29256,6 +29265,8 @@ class _StringsId extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -34530,6 +34541,8 @@ class _StringsIt extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -39530,6 +39543,8 @@ class _StringsJa extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -44534,6 +44549,8 @@ class _StringsKo extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -49776,6 +49793,8 @@ class _StringsNl extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -55041,6 +55060,8 @@ class _StringsPtBr extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -60281,6 +60302,8 @@ class _StringsRu extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -65434,6 +65457,8 @@ class _StringsTh extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -70642,6 +70667,8 @@ class _StringsTr extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -75825,6 +75852,8 @@ class _StringsVi extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -80658,6 +80687,8 @@ class _StringsZhCn extends _StringsEn {
   String get collection_default_name => '新合集';
   @override
   String get backup_import_contents_hint => '取消勾选某项即可跳过它。';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki 剪贴板查词';
 }
 
 // Path: retrying_in
@@ -85560,6 +85591,8 @@ class _StringsZhHk extends _StringsEn {
   String get collection_default_name => 'New collection';
   @override
   String get backup_import_contents_hint => 'Untick an item to skip it.';
+  @override
+  String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
 }
 
 // Path: retrying_in
@@ -90256,6 +90289,8 @@ extension on _StringsEn {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -94912,6 +94947,8 @@ extension on _StringsAr {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -99590,6 +99627,8 @@ extension on _StringsDe {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -104266,6 +104305,8 @@ extension on _StringsEs {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -108949,6 +108990,8 @@ extension on _StringsFr {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -113612,6 +113655,8 @@ extension on _StringsId {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -118292,6 +118337,8 @@ extension on _StringsIt {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -122930,6 +122977,8 @@ extension on _StringsJa {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -127571,6 +127620,8 @@ extension on _StringsKo {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -132244,6 +132295,8 @@ extension on _StringsNl {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -136914,6 +136967,8 @@ extension on _StringsPtBr {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -141588,6 +141643,8 @@ extension on _StringsRu {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -146244,6 +146301,8 @@ extension on _StringsTh {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -150909,6 +150968,8 @@ extension on _StringsTr {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -155568,6 +155629,8 @@ extension on _StringsVi {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }
@@ -160193,6 +160256,8 @@ extension on _StringsZhCn {
         return '新合集';
       case 'backup_import_contents_hint':
         return '取消勾选某项即可跳过它。';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki 剪贴板查词';
       default:
         return null;
     }
@@ -164823,6 +164888,8 @@ extension on _StringsZhHk {
         return 'New collection';
       case 'backup_import_contents_hint':
         return 'Untick an item to skip it.';
+      case 'clipboard_panel_window_title':
+        return 'Hibiki clipboard lookup';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "将该条目移出合集？条目本身保留。",
   "collection_member_removed": "已移出合集",
   "collection_default_name": "新合集",
-  "backup_import_contents_hint": "取消勾选某项即可跳过它。"
+  "backup_import_contents_hint": "取消勾选某项即可跳过它。",
+  "clipboard_panel_window_title": "Hibiki 剪贴板查词"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2285,5 +2285,6 @@
   "collection_remove_member_confirm": "Remove this item from the collection? The item itself is kept.",
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
-  "backup_import_contents_hint": "Untick an item to skip it."
+  "backup_import_contents_hint": "Untick an item to skip it.",
+  "clipboard_panel_window_title": "Hibiki clipboard lookup"
 }

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -14,6 +14,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/lookup/global_lookup_controller.dart'
     show
         GlobalLookupController,
@@ -124,6 +125,9 @@ class ClipboardPanelController {
       onOverlayHidden: () => _visible = false,
     );
     await _channel.prepare(_popupAssetsDir());
+    // 面板任务栏图标 — 在预热（窗口创建）之前把本地化标题递给 native，任务栏
+    // 按钮 / Alt-Tab 项从第一帧起就是正确文案；面板被压底时点它即可拉回前台。
+    await _channel.setWindowTitle(t.clipboard_panel_window_title);
     if (appModel.desktopClipboardEnabled &&
         appModel.desktopClipboardDestination ==
             DesktopClipboardDestination.panel) {

--- a/hibiki/lib/src/lookup/overlay_window_channel.dart
+++ b/hibiki/lib/src/lookup/overlay_window_channel.dart
@@ -195,6 +195,14 @@ class OverlayWindowChannel {
         'pinned': pinned,
       });
 
+  /// 面板任务栏图标 — 任务栏按钮 / Alt-Tab 项的窗口标题（本地化文案）。
+  /// 窗口创建前设置则用于创建，已创建则即时更新。Only wired on the
+  /// clipboard-panel channel.
+  Future<void> setWindowTitle(String title) =>
+      _channel.invokeMethod<void>('setWindowTitle', <String, Object?>{
+        'title': title,
+      });
+
   /// spec §6 真机修正 — 整窗不透明度（WS_EX_LAYERED + LWA_ALPHA，30-100%）。
   /// 真透视：整窗（含文字）统一变淡，透出底下的游戏/网页；acrylic backdrop
   /// 实测经 windowed WebView2 呈现为不透明且毛玻璃本就不是「看见底下」。

--- a/hibiki/test/lookup/clipboard_panel_taskbar_guard_test.dart
+++ b/hibiki/test/lookup/clipboard_panel_taskbar_guard_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 面板任务栏图标（源码扫描守卫）。
+///
+/// 用户诉求：面板图钉关（非置顶）时被游戏/浏览器压到底下就找不回来了——
+/// 「面板能不能有个独立的任务栏图标，这样可以点击拉到前台」。
+///
+/// 契约：
+/// 1. 常驻剪贴板面板实例带任务栏按钮：`SetTaskbarPresence(true)` 只在
+///    RegisterClipboardPanelChannel 里设置；瞬态查词覆盖窗绝不设置（保持
+///    TOOLWINDOW，无任务栏项/Alt-Tab 项——查词卡不是"窗口"）。
+/// 2. 两处 CreateWindowExW（ShowAt 懒建 + PrewarmWebView 预热）都按
+///    `taskbar_presence_` 分流 WS_EX_APPWINDOW / WS_EX_TOOLWINDOW，并用
+///    `window_title_` 作窗口标题（任务栏按钮文案）。
+/// 3. 窗口类注册 hIcon（任务栏按钮/Alt-Tab 图标=app 图标 IDI_APP_ICON）。
+/// 4. 标题本地化：Dart 面板 start() 在预热（窗口创建）之前
+///    `setWindowTitle(t.clipboard_panel_window_title)`；native
+///    `SetWindowTitle` 对已建窗口走 SetWindowTextW 即时生效。
+///
+/// 任务栏激活自带 raise + activate，是被压底面板的兜底找回入口，与图钉
+/// （置顶）正交。真实按钮行为依赖 native，headless 测不了，源码扫描钉契约。
+void main() {
+  String read(String p) => File(p).readAsStringSync().replaceAll('\r\n', '\n');
+
+  late String cpp;
+  late String hdr;
+  late String fw;
+  late String controller;
+  setUpAll(() {
+    cpp = read('windows/runner/global_lookup_window.cpp');
+    hdr = read('windows/runner/global_lookup_window.h');
+    fw = read('windows/runner/flutter_window.cpp');
+    controller = read('lib/src/lookup/clipboard_panel_controller.dart');
+  });
+
+  test('只有面板实例 SetTaskbarPresence(true)，瞬态覆盖窗不上任务栏', () {
+    expect('->SetTaskbarPresence(true)'.allMatches(fw).length, 1,
+        reason: '任务栏按钮只属于常驻面板（瞬态查词卡不是窗口）');
+    final int panelChannel = fw.indexOf('RegisterClipboardPanelChannel()');
+    final int call = fw.indexOf('->SetTaskbarPresence(true)');
+    expect(panelChannel, greaterThanOrEqualTo(0));
+    expect(call, greaterThan(panelChannel),
+        reason: 'SetTaskbarPresence 必须在面板 channel 注册段里');
+  });
+
+  test('两处 CreateWindowExW 都按 taskbar_presence_ 分流 APPWINDOW/TOOLWINDOW', () {
+    expect(
+        'taskbar_presence_ ? WS_EX_APPWINDOW : WS_EX_TOOLWINDOW'
+            .allMatches(cpp)
+            .length,
+        2,
+        reason: 'ShowAt 懒建与 PrewarmWebView 预热两个创建点必须一致，'
+            '否则预热窗与重建窗任务栏行为漂移');
+    expect('window_title_.c_str()'.allMatches(cpp).length,
+        greaterThanOrEqualTo(2),
+        reason: '两个创建点都必须用可设置的 window_title_（任务栏按钮文案）');
+    expect(cpp.contains('L"Hibiki Lookup", WS_POPUP'), isFalse,
+        reason: '不得残留写死的创建标题（回归 signature）');
+  });
+
+  test('窗口类注册 app 图标（任务栏/Alt-Tab 图标）', () {
+    final int at = cpp.indexOf('RegisterClassExW(&wc)');
+    expect(at, greaterThanOrEqualTo(0));
+    final String before = cpp.substring(0, at);
+    expect(before, contains('MAKEINTRESOURCE(IDI_APP_ICON)'),
+        reason: '类注册前必须 LoadIcon(IDI_APP_ICON)，否则任务栏按钮是默认白框图标');
+  });
+
+  test('native SetWindowTitle 对已建窗口 SetWindowTextW 即时生效', () {
+    final int at = cpp.indexOf('void GlobalLookupWindow::SetWindowTitle(');
+    expect(at, greaterThanOrEqualTo(0));
+    final String body = cpp.substring(at, cpp.indexOf('\n}', at));
+    expect(body, contains('SetWindowTextW'), reason: '面板启动即预热，标题晚到必须能更新已存在的窗口');
+  });
+
+  test('头文件声明 SetTaskbarPresence / SetWindowTitle / 成员', () {
+    expect(hdr, contains('void SetTaskbarPresence(bool present)'));
+    expect(hdr, contains('void SetWindowTitle(const std::wstring& title);'));
+    expect(hdr, contains('bool taskbar_presence_ = false;'),
+        reason: '默认 false：瞬态覆盖窗零变化');
+  });
+
+  test('Dart 面板 start() 在预热前下发本地化标题', () {
+    final int title = controller.indexOf('setWindowTitle(');
+    final int prewarm = controller.indexOf('ensurePrewarmed()');
+    expect(title, greaterThanOrEqualTo(0),
+        reason: 'start() 必须下发 t.clipboard_panel_window_title');
+    expect(controller, contains('t.clipboard_panel_window_title'),
+        reason: '标题必须走 slang 本地化 key');
+    expect(title, lessThan(prewarm), reason: '标题必须在窗口创建（预热）之前就位，任务栏按钮首帧即正确文案');
+  });
+}

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -1011,6 +1011,11 @@ void FlutterWindow::RegisterClipboardPanelChannel() {
   clipboard_panel_window_ = std::make_unique<GlobalLookupWindow>();
   clipboard_panel_window_->SetArmDismissHooks(false);
   clipboard_panel_window_->SetActivatable(true);
+  // 面板任务栏图标 — 常驻面板有独立任务栏按钮（WS_EX_APPWINDOW）：面板未置顶
+  // （图钉关）被游戏/浏览器压底时，点任务栏图标即可激活+拉回前台。瞬态查词窗
+  // 不设，保持无任务栏项。
+  clipboard_panel_window_->SetTaskbarPresence(true);
+  clipboard_panel_window_->SetWindowTitle(L"Hibiki");
   clipboard_panel_window_->SetUserDataLeaf(L"ClipboardPanelWebView2");
 
   clipboard_panel_channel_ =
@@ -1167,6 +1172,11 @@ void FlutterWindow::RegisterClipboardPanelChannel() {
         } else if (method == "setPinned") {
           clipboard_panel_window_->SetTopmost(
               BoolFromValue(args, "pinned", true));
+          result->Success();
+        } else if (method == "setWindowTitle") {
+          // 面板任务栏图标 — Dart 传本地化标题（任务栏按钮 / Alt-Tab 项）。
+          clipboard_panel_window_->SetWindowTitle(
+              Utf8ToWideString(StringFromValue(args, "title", "")));
           result->Success();
         } else if (method == "setWindowAlpha") {
           // spec §6 真机修正 — 整窗 LWA_ALPHA 透明（真透视；acrylic 实测经

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -3,6 +3,8 @@
 #include <dwmapi.h>
 #include <shlwapi.h>
 
+#include "resource.h"
+
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -239,6 +241,10 @@ void GlobalLookupWindow::EnsureWindowClass() {
   wc.lpfnWndProc = GlobalLookupWindow::WndProc;
   wc.hInstance = GetModuleHandle(nullptr);
   wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
+  // 面板任务栏图标 — 类图标供任务栏按钮 / Alt-Tab 使用（瞬态覆盖窗是
+  // TOOLWINDOW 不上任务栏，带图标无副作用）。
+  wc.hIcon = LoadIcon(wc.hInstance, MAKEINTRESOURCE(IDI_APP_ICON));
+  wc.hIconSm = wc.hIcon;
   wc.lpszClassName = kClassName;
   RegisterClassExW(&wc);
   s_class_registered = true;
@@ -313,11 +319,14 @@ bool GlobalLookupWindow::ShowAt(int x, int y, int width, int height,
     // 真机第 4 轮 — 面板实例（activatable_）不带 NOACTIVATE：点击面板时焦点
     // 落面板，滚轮不再穿到底下仍持焦点的游戏。程序化路径全程 SWP_NOACTIVATE /
     // SW_SHOWNOACTIVATE，流式更新不抢焦点。
+    // 面板任务栏图标 — taskbar_presence_（面板实例）用 APPWINDOW 换掉
+    // TOOLWINDOW：任务栏出现独立按钮，点它即可把被压底的面板拉回前台。
     hwnd_ = CreateWindowExW(
-        WS_EX_TOPMOST | WS_EX_TOOLWINDOW |
+        WS_EX_TOPMOST |
+            (taskbar_presence_ ? WS_EX_APPWINDOW : WS_EX_TOOLWINDOW) |
             (activatable_ ? 0 : WS_EX_NOACTIVATE),
-        kClassName, L"Hibiki Lookup", WS_POPUP, off_x, 0, width, height, owner,
-        nullptr, GetModuleHandle(nullptr), this);
+        kClassName, window_title_.c_str(), WS_POPUP, off_x, 0, width, height,
+        owner, nullptr, GetModuleHandle(nullptr), this);
     if (hwnd_ == nullptr) {
       return false;
     }
@@ -354,10 +363,11 @@ void GlobalLookupWindow::PrewarmWebView(int width, int height, HWND owner) {
   const int w = width > 0 ? width : 420;
   const int h = height > 0 ? height : 600;
   hwnd_ = CreateWindowExW(
-      WS_EX_TOPMOST | WS_EX_TOOLWINDOW |
+      WS_EX_TOPMOST |
+          (taskbar_presence_ ? WS_EX_APPWINDOW : WS_EX_TOOLWINDOW) |
           (activatable_ ? 0 : WS_EX_NOACTIVATE),
-      kClassName, L"Hibiki Lookup", WS_POPUP, off_x, 0, w, h, owner, nullptr,
-      GetModuleHandle(nullptr), this);
+      kClassName, window_title_.c_str(), WS_POPUP, off_x, 0, w, h, owner,
+      nullptr, GetModuleHandle(nullptr), this);
   if (hwnd_ == nullptr) {
     return;
   }
@@ -598,6 +608,17 @@ bool GlobalLookupWindow::ApplySystemBackdrop() {
     return true;
   }
   return ApplyWin10AccentBlurBehind(hwnd_);
+}
+
+void GlobalLookupWindow::SetWindowTitle(const std::wstring& title) {
+  if (title.empty()) {
+    return;
+  }
+  window_title_ = title;
+  if (hwnd_ != nullptr) {
+    // 已创建（面板启动即预热）：任务栏按钮标题即时更新。
+    SetWindowTextW(hwnd_, window_title_.c_str());
+  }
 }
 
 void GlobalLookupWindow::SetTopmost(bool topmost) {

--- a/hibiki/windows/runner/global_lookup_window.h
+++ b/hibiki/windows/runner/global_lookup_window.h
@@ -143,6 +143,14 @@ class GlobalLookupWindow {
   // 覆盖窗保持默认 false（查词卡出现时前台键盘焦点原地不动，design §5 保证 3）。
   // 必须在首次 ShowAt/PrewarmWebView（窗口创建）前设置。
   void SetActivatable(bool activatable) { activatable_ = activatable; }
+  // 面板任务栏图标 — 常驻剪贴板面板要有独立任务栏按钮（WS_EX_APPWINDOW 而非
+  // WS_EX_TOOLWINDOW）：面板未置顶（图钉关）被游戏/浏览器压到底下时，点任务栏
+  // 图标即可激活+拉回前台（任务栏激活自带 raise），面板永远找得回来。瞬态查词
+  // 覆盖窗保持默认 false（工具窗，无任务栏项/Alt-Tab 项）。必须在窗口创建前设置。
+  void SetTaskbarPresence(bool present) { taskbar_presence_ = present; }
+  // 任务栏按钮 / Alt-Tab 项显示的窗口标题（Dart 侧传本地化文案）。创建前设置
+  // 则用于 CreateWindowExW；窗口已存在时经 SetWindowTextW 即时生效。
+  void SetWindowTitle(const std::wstring& title);
 
   // spec §6 semi-transparency gate — asks DWM for a Win11 acrylic backdrop
   // behind the window's transparent WebView2 pixels. Returns whether the OS
@@ -224,6 +232,8 @@ class GlobalLookupWindow {
   // lookup-overlay behaviour, so the first instance is byte-for-byte unchanged).
   bool arm_dismiss_hooks_ = true;
   bool activatable_ = false;
+  bool taskbar_presence_ = false;
+  std::wstring window_title_ = L"Hibiki Lookup";
   std::wstring user_data_leaf_ = L"GlobalLookupWebView2";
   std::wstring popup_assets_dir_;
   std::string pending_json_;


### PR DESCRIPTION
## 诉求
「面板能不能有个独立的任务栏图标，这样可以点击拉到前台」——面板图钉关（非置顶）时被游戏/浏览器压底就找不回来（BUG-744 诊断的另一半）。

## 实现
- 面板实例窗口样式 `WS_EX_TOOLWINDOW` → `WS_EX_APPWINDOW`（`SetTaskbarPresence(true)`，仅在 RegisterClipboardPanelChannel 设置）：任务栏出现独立按钮 + Alt-Tab 项，点它 Windows 自动激活+提升到前台。瞬态查词覆盖窗保持 TOOLWINDOW 不变（查词卡不是"窗口"）。
- 窗口类注册 `IDI_APP_ICON`（任务栏按钮/Alt-Tab 用 app 图标，非默认白框）。
- 标题本地化：新 i18n key `clipboard_panel_window_title`（i18n_sync 17 语言，en "Hibiki clipboard lookup" / zh "Hibiki 剪贴板查词"），Dart 面板 start() 在预热（窗口创建）前经新 channel 方法 `setWindowTitle` 下发；native 已建窗时 SetWindowTextW 即时生效。
- 面板隐藏（关闭）时按钮自动消失（窗口 SW_HIDE 语义）。

## 验证
- 新守卫 `clipboard_panel_taskbar_guard_test.dart` 6 用例绿（仅面板设 presence、双创建点分流、类图标、标题本地化时序）
- `flutter test test/lookup/ test/i18n/` 406 全绿；`flutter analyze` 清零；`flutter build windows --debug` 通过

## 待真机
面板显示时任务栏出现 Hibiki 图标按钮；用别的窗口盖住面板后点任务栏按钮 → 面板回到最前并激活；关闭面板按钮消失；瞬态查词卡不出现任务栏项。