### PR TITLE
fix(backup): 导入备份完成后自动重启，不再要手动重开

### DIFF
--- a/hibiki/lib/main.dart
+++ b/hibiki/lib/main.dart
@@ -1226,7 +1226,8 @@ class _HoshiReaderAppState extends ConsumerState<HoshiReaderApp>
     // TODO-1151: 本地备份「导入/恢复」期间会 closeDatabase() 置 isInitialised=false。
     // 若落到下面的裸 loading 分支，设置页会「突然消失」变近黑转圈，导入完再 exit(0)，
     // 用户误以为崩溃/失败。这里镜像上面的迁移遮罩：running 显「正在导入备份，请勿关闭」
-    // + 进度条；done 显结果 +「立即重启」按钮，由用户点按后再退出（backupImportRestart）。
+    // + 进度条；done 显结果，导入成功后 ~1s 自动重启（backupImportRestart 走 restartApp 真
+    // 拉新进程），「立即重启」按钮保留为手动兜底可提前点；失败态不自动、由用户读完原因手点。
     if (appModel.backupImportActive) {
       final brightness =
           WidgetsBinding.instance.platformDispatcher.platformBrightness;
@@ -1244,7 +1245,7 @@ class _HoshiReaderAppState extends ConsumerState<HoshiReaderApp>
             background: _savedSplashColor,
             // TODO-1183: 确定进度条监听（只进度条重建，不整树重绘）。
             progress: appModel.backupImportProgress,
-            onRestart: backupImportRestart,
+            onRestart: () => backupImportRestart(appModel),
             // TODO-1151: validating 相位的「取消」——作废 in-flight 校验 token 并退出
             // 遮罩回设置页（其它相位本视图不渲染取消按钮）。
             onCancel: appModel.cancelBackupValidating,

--- a/hibiki/lib/src/sync/sync_settings_schema/backup.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/backup.part.dart
@@ -86,27 +86,34 @@ const Set<BackupCategory> importSelectableCategories = <BackupCategory>{
 const Set<BackupCategory> importMergeSelectableCategories =
     importSelectableCategories;
 
-/// TODO-1151：备份导入完成后由 [BackupImportOverlayView] 的「立即重启」按钮触发的退出。
-/// 沿用旧导入实现的平台分支（移动端 [FlutterExitApp.exitApp]，桌面端 `exit(0)`），只把
-/// 触发时机从「延迟 500ms 自动退出」改为「用户点确认后退出」，退出行为本身不变
-/// （never-break）。抽成顶层函数供 `main.dart` 注入为 `onRestart`。
-void backupImportRestart() {
+/// TODO-1151：备份导入完成后的重启。DB 已在导入期 `closeDatabase()`，必须重启才能重载
+/// 新数据。既作为 [BackupImportOverlayView]「立即重启」按钮的手动出口，也在导入**成功**后由
+/// [_BackupImportWidgetState._import] 延时自动调用（用户诉求「导入完自动重启，不再手动重开」）。
+///
+/// **优先真重启**：委托 `lifecycle.restartApp()`——与数据根迁移成功路径同一条经过验证的重启
+/// 实现（桌面 detached 拉新进程 + 带 `--hibiki-restarted` 前台标志避免黑窗、macOS 经
+/// `open -n <bundle>` 规避直接起可执行文件在 Dart 启动前崩、移动端 `restart_app` 插件；三端
+/// `supportsRestart==true`）。消除了旧实现在本文件里 ad-hoc `Process.start(resolvedExecutable)`
+/// 的劣质重复（缺前台标志、macOS 会崩）。
+/// **兜底 never-break**：`restartApp` 起新进程失败或平台不支持时，退回旧的纯退出分支（移动端
+/// [FlutterExitApp.exitApp]、桌面端 `exit(0)`），至少让用户手动重开，绝不制造「老进程没了、新
+/// 进程也没起来」的假崩溃。抽成顶层函数供 `main.dart` 注入为 `onRestart`。
+Future<void> backupImportRestart(AppModel appModel) async {
+  final PlatformLifecycleService lifecycle =
+      appModel.platformServices.lifecycle;
+  if (lifecycle.supportsRestart) {
+    try {
+      await lifecycle.restartApp();
+      // restartApp 成功会拉新进程并退出本进程，正常不会执行到这里。
+      return;
+    } catch (e) {
+      // 起新进程失败 → 落到下面的纯退出兜底（用户手动重开），不把失败吞成假成功。
+      debugPrint('Backup import: restartApp failed, fall back to exit: $e');
+    }
+  }
   if (Platform.isAndroid || Platform.isIOS) {
     FlutterExitApp.exitApp();
   } else {
-    // Desktop: "立即重启" must actually RESTART, not just quit (the user hit
-    // "点重启没重启"). Launch a fresh detached instance of this executable, then
-    // exit the current one. Best-effort: if the relaunch fails we still exit, so
-    // behaviour never regresses below the old quit-only path.
-    try {
-      Process.start(
-        Platform.resolvedExecutable,
-        <String>[],
-        mode: ProcessStartMode.detached,
-      );
-    } catch (_) {
-      // Fall through to exit — a quit is still better than a stuck app.
-    }
     exit(0);
   }
 }
@@ -838,8 +845,16 @@ class _BackupImportWidgetState extends State<_BackupImportWidget> {
       }
 
       // TODO-1151: 导入成功。不再「延迟 500ms 后突然 exit」——那会让用户以为崩溃/失败。
-      // 切到确认视图（导入完成 → 立即重启），由用户点按后经 backupImportRestart 退出。
+      // 切到确认视图（导入完成 → 立即重启），并在其可见 ~1s 后自动重启（用户诉求「导入完
+      // 自动重启，不再手动重开」）。与旧「500ms 后突然 exit」的关键区别：backupImportRestart
+      // 走 restartApp 真拉新进程重启（app 会自己回来），不是纯退出「凭空消失」；延时让「导入
+      // 成功」先可见一瞬，避免误判失败。「立即重启」按钮保留为手动兜底（可提前点，走同一函数）。
       appModel.completeBackupImport(t.backup_import_success);
+      await Future<void>.delayed(const Duration(seconds: 1));
+      // restartApp 成功会拉新进程并退出本进程；backupImportRestart 内部已吞掉重启失败并退回
+      // 纯退出兜底，故此处不会把「重启失败」冒泡成 catch 里的 failBackupImport（避免把成功的
+      // 导入错报为失败）。
+      await backupImportRestart(appModel);
     } catch (e) {
       // TODO-1183: DB 已关闭，无论成败都必须重启；失败走 failBackupImport → 遮罩画红色
       // 错误图标 + 失败原因（根治 OOM/异常「失败却显绿✓成功」的误导）。

--- a/hibiki/test/sync/backup_import_overlay_test.dart
+++ b/hibiki/test/sync/backup_import_overlay_test.dart
@@ -258,8 +258,10 @@ void main() {
       expect(backupIdx, lessThan(loadingIdx),
           reason: '导入遮罩必须在裸 loading 分支之前命中，否则导入期回退近黑屏');
       expect(src.contains('BackupImportOverlayView('), isTrue);
-      // 退出由确认视图按钮驱动（onRestart 注入 backupImportRestart）。
-      expect(src.contains('onRestart: backupImportRestart'), isTrue);
+      // 重启由确认视图按钮 + 导入成功后的自动触发共同驱动（onRestart 注入 backupImportRestart，
+      // 需带 appModel 以委托 lifecycle.restartApp 真重启）。
+      expect(src.contains('onRestart: () => backupImportRestart(appModel)'),
+          isTrue);
     });
 
     test('backup.part：先 beginBackupImport 再 closeDatabase（遮罩→关库顺序）', () {
@@ -301,22 +303,49 @@ void main() {
           reason: '_import 里不得直接 exit(0)，退出改由确认视图按钮驱动');
     });
 
-    test('backup.part：backupImportRestart 保留原平台退出分支 + 桌面真重启', () {
+    test('backup.part：backupImportRestart 优先真重启(restartApp)+保留纯退出兜底', () {
       final String src =
           readSource('lib/src/sync/sync_settings_schema/backup.part.dart')
               .readAsStringSync();
-      final int fnIdx = src.indexOf('void backupImportRestart()');
-      expect(fnIdx, greaterThan(0), reason: '必须有供确认按钮调用的退出函数');
+      final int fnIdx =
+          src.indexOf('Future<void> backupImportRestart(AppModel appModel)');
+      expect(fnIdx, greaterThan(0), reason: '必须有供确认按钮+自动重启调用的重启函数');
       final int fnEnd = src.indexOf('\n}', fnIdx);
       final String fnBody = src.substring(fnIdx, fnEnd);
-      // never-break: 移动端仍走 FlutterExitApp，桌面端仍会退出当前进程。
+      // 优先走经过验证的 lifecycle.restartApp()（真拉新进程，带前台标志/ macOS bundle 处理），
+      // 由 supportsRestart 门控；消除本文件里 ad-hoc Process.start 的劣质重复。
+      expect(fnBody.contains('lifecycle.supportsRestart'), isTrue,
+          reason: '重启前必须先判 supportsRestart');
+      expect(fnBody.contains('lifecycle.restartApp()'), isTrue,
+          reason: '应委托经过验证的 restartApp 真重启，而非本文件里 ad-hoc Process.start');
+      // never-break 兜底: restartApp 失败/不支持时仍退回原平台纯退出分支。
       expect(fnBody.contains('FlutterExitApp.exitApp()'), isTrue);
       expect(fnBody.contains('exit(0)'), isTrue);
-      // 新增：桌面端「立即重启」必须真的重启——退出前拉起一个 detached 新实例
-      // （修「点重启没重启」）。
-      expect(fnBody.contains('Process.start'), isTrue,
-          reason: '桌面端应在退出前重新拉起可执行文件，实现真正的重启');
-      expect(fnBody.contains('ProcessStartMode.detached'), isTrue);
+    });
+
+    test('backup.part：导入成功后延时自动重启，失败态不自动（TODO-1151 自动重启）', () {
+      final String src =
+          readSource('lib/src/sync/sync_settings_schema/backup.part.dart')
+              .readAsStringSync();
+      final int importIdx = src.indexOf('Future<void> _import()');
+      final int nextTop =
+          src.indexOf('Future<_BackupImportChoice?>', importIdx);
+      final String importBody = src.substring(importIdx, nextTop);
+      // 成功路径：completeBackupImport 之后延时(~1s)自动调 backupImportRestart。
+      final int completeIdx =
+          importBody.indexOf('completeBackupImport(t.backup_import_success)');
+      final int autoRestartIdx =
+          importBody.indexOf('await backupImportRestart(appModel)');
+      expect(completeIdx, greaterThan(0));
+      expect(autoRestartIdx, greaterThan(completeIdx),
+          reason: '导入成功后必须自动调 backupImportRestart（用户诉求：不再手动重开）');
+      expect(importBody.contains('Duration(seconds: 1)'), isTrue,
+          reason: '自动重启前应短暂展示成功态(~1s)再拉新进程，避免像纯退出那样凭空消失');
+      // 失败路径：failBackupImport 之后不得再自动重启（保留手动按钮，用户先读失败原因）。
+      final int failIdx = importBody.indexOf('failBackupImport(');
+      expect(failIdx, greaterThan(0));
+      expect(importBody.indexOf('backupImportRestart', failIdx), -1,
+          reason: '失败态不得自动重启——保留手动「立即重启」按钮，用户读完原因再点');
     });
 
     test('app_model：BackupImportPhase 含 validating 相位 + token/取消/退出方法', () {


### PR DESCRIPTION
## 问题
导入/恢复备份完成后，遮罩停在「立即重启」按钮，用户必须**手点按钮**、且旧桌面路径只是 `exit(0)` 退出——用户还得**手动重开** app（用户报「不会自动重启，必须手动」）。

## 根因
- `backupImportRestart` 只作为按钮的手动出口，无自动触发。
- 桌面分支用 ad-hoc `Process.start(resolvedExecutable, [])`：缺 `--hibiki-restarted` 前台标志（Windows 新窗口可能不抢前台），且 macOS 上直接起可执行文件会在 Dart 启动前崩（`lifecycle.restartApp()` 专门用 `open -n <bundle>` 规避）。是 `lifecycle.restartApp()` 的劣质重复。

## 改动
1. **`backupImportRestart(appModel)`** 改委托 `lifecycle.restartApp()`——与数据根迁移成功路径同一条经过验证的重启实现（三端 `supportsRestart==true`）。`restartApp` 失败/不支持时退回旧的纯退出兜底（移动端 `FlutterExitApp.exitApp()`、桌面 `exit(0)`），never-break。
2. **自动触发**：导入成功 `completeBackupImport(...)` 后延时 ~1s 自动调 `backupImportRestart`。与旧「500ms 后突然 exit」的关键区别：`restartApp` **真拉新进程**（app 会自己回来），不是纯退出「凭空消失」误判失败；~1s 延时让「导入成功」先可见一瞬。「立即重启」按钮保留为手动兜底可提前点。
3. **失败态不自动重启**：保留手动按钮，用户先读失败原因（TODO-1183）。
4. `main.dart` `onRestart` 接线传 `appModel`；更新源码守卫测试（`restartApp`/`supportsRestart` 断言替代 `Process.start`）+新增自动重启守卫（成功后自动/失败不自动）。

## 验证
- `flutter analyze`（全项目）：No issues found。
- `flutter test`（全量）：`+10945 All tests passed!`（含 `test/sync/backup_import_overlay_test.dart` 16 条守卫）。
- ⚠️ 真机复测待办：桌面/Android/iOS 实机跑一次备份导入，确认成功后 ~1s 自动重启且新进程带回恢复后的数据、前台正常显示。