### PR TITLE
fix(video): Android 默认回 Impeller + 可发现一键切 Skia 降级 (TODO-1232/BUG-597)

### DIFF
--- a/hibiki/android/app/src/main/java/app/hibiki/reader/MainActivity.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/MainActivity.java
@@ -424,17 +424,20 @@ public class MainActivity extends AudioServiceActivity {
     }
 
     // TODO-1232: the effective "disable Impeller (use Skia)" decision for THIS
-    // launch. Android DEFAULTS TO SKIA (disable Impeller) so media_kit's external
-    // SurfaceProducer video texture composites out of the box -- Impeller silently
-    // fails to composite it on some Android GPUs (e.g. Mali-G76 / Android 11,
-    // BUG-597), leaving video black while decode + texture handshake are fully
-    // green. An EXPLICIT user choice (Settings > Diagnostics switch) overrides this
-    // default in either direction (explicit > platform default); only the
-    // never-set case falls back to Skia. Mirrors
+    // launch. Android DEFAULTS TO IMPELLER (never-set -> false) so the majority
+    // keeps Impeller's smoother rendering / no Skia first-frame shader jank.
+    // Impeller silently fails to composite media_kit's external SurfaceProducer
+    // video texture on a FEW Android GPUs (e.g. Mali-G76 / Android 11, BUG-597),
+    // leaving video black while decode + texture handshake are fully green -- those
+    // devices degrade via the discoverable one-tap "switch to Skia + restart" entry
+    // in the player settings sheet (writes this pref = true, then restarts), rather
+    // than flipping every Android user to Skia. An EXPLICIT user choice overrides
+    // this default in either direction (explicit > platform default); only the
+    // never-set case falls back to Impeller. Mirrors
     // RenderBackendService.resolveImpellerDisabled(storedPref, isAndroid: true).
     private boolean isImpellerDisabledPref() {
         Boolean raw = getImpellerDisabledRawPref();
-        return raw != null ? raw : true;
+        return raw != null ? raw : false;
     }
 
     // TODO-1232: raw persisted intent as a tri-state -- null when the user has

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 38726 (2278 per locale)
+/// Strings: 38811 (2283 per locale)
 ///
-/// Built on 2026-07-12 at 05:57 UTC
+/// Built on 2026-07-12 at 10:13 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3012,6 +3012,15 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get collection_default_name => 'New collection';
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -8162,6 +8171,20 @@ class _StringsAr extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -13435,6 +13458,20 @@ class _StringsDe extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -18725,6 +18762,20 @@ class _StringsEs extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -24034,6 +24085,20 @@ class _StringsFr extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -29245,6 +29310,20 @@ class _StringsId extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -34517,6 +34596,20 @@ class _StringsIt extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -39515,6 +39608,20 @@ class _StringsJa extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -44517,6 +44624,20 @@ class _StringsKo extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -49757,6 +49878,20 @@ class _StringsNl extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -55020,6 +55155,20 @@ class _StringsPtBr extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -60258,6 +60407,20 @@ class _StringsRu extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -65409,6 +65572,20 @@ class _StringsTh extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -70615,6 +70792,20 @@ class _StringsTr extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -75796,6 +75987,20 @@ class _StringsVi extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -80627,6 +80832,16 @@ class _StringsZhCn extends _StringsEn {
   String get backup_import_contents_hint => '取消勾选某项即可跳过它。';
   @override
   String get clipboard_panel_window_title => 'Hibiki 剪贴板查词';
+  @override
+  String get video_render_skia_fix_confirm_title => '切换到 Skia 并重启？';
+  @override
+  String get video_render_skia_fix_confirm_body => '将关闭 Impeller 渲染器并重启应用使其生效。';
+  @override
+  String get video_render_skia_fix_confirm_action => '重启';
+  @override
+  String get video_render_skia_fix_title => '画面全黑？切换渲染器（Skia）';
+  @override
+  String get video_render_skia_fix_hint => '有声音但画面全黑时用。关闭 Impeller，重启后生效。';
 }
 
 // Path: retrying_in
@@ -85527,6 +85742,20 @@ class _StringsZhHk extends _StringsEn {
   String get backup_import_contents_hint => 'Untick an item to skip it.';
   @override
   String get clipboard_panel_window_title => 'Hibiki clipboard lookup';
+  @override
+  String get video_render_skia_fix_confirm_title =>
+      'Switch to Skia and restart?';
+  @override
+  String get video_render_skia_fix_confirm_body =>
+      'This disables the Impeller renderer and restarts the app to apply.';
+  @override
+  String get video_render_skia_fix_confirm_action => 'Restart';
+  @override
+  String get video_render_skia_fix_title =>
+      'Screen black? Switch renderer (Skia)';
+  @override
+  String get video_render_skia_fix_hint =>
+      'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
 }
 
 // Path: retrying_in
@@ -90221,6 +90450,16 @@ extension on _StringsEn {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -94875,6 +95114,16 @@ extension on _StringsAr {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -99551,6 +99800,16 @@ extension on _StringsDe {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -104225,6 +104484,16 @@ extension on _StringsEs {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -108906,6 +109175,16 @@ extension on _StringsFr {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -113567,6 +113846,16 @@ extension on _StringsId {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -118245,6 +118534,16 @@ extension on _StringsIt {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -122881,6 +123180,16 @@ extension on _StringsJa {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -127520,6 +127829,16 @@ extension on _StringsKo {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -132191,6 +132510,16 @@ extension on _StringsNl {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -136859,6 +137188,16 @@ extension on _StringsPtBr {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -141531,6 +141870,16 @@ extension on _StringsRu {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -146185,6 +146534,16 @@ extension on _StringsTh {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -150848,6 +151207,16 @@ extension on _StringsTr {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -155505,6 +155874,16 @@ extension on _StringsVi {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }
@@ -160128,6 +160507,16 @@ extension on _StringsZhCn {
         return '取消勾选某项即可跳过它。';
       case 'clipboard_panel_window_title':
         return 'Hibiki 剪贴板查词';
+      case 'video_render_skia_fix_confirm_title':
+        return '切换到 Skia 并重启？';
+      case 'video_render_skia_fix_confirm_body':
+        return '将关闭 Impeller 渲染器并重启应用使其生效。';
+      case 'video_render_skia_fix_confirm_action':
+        return '重启';
+      case 'video_render_skia_fix_title':
+        return '画面全黑？切换渲染器（Skia）';
+      case 'video_render_skia_fix_hint':
+        return '有声音但画面全黑时用。关闭 Impeller，重启后生效。';
       default:
         return null;
     }
@@ -164756,6 +165145,16 @@ extension on _StringsZhHk {
         return 'Untick an item to skip it.';
       case 'clipboard_panel_window_title':
         return 'Hibiki clipboard lookup';
+      case 'video_render_skia_fix_confirm_title':
+        return 'Switch to Skia and restart?';
+      case 'video_render_skia_fix_confirm_body':
+        return 'This disables the Impeller renderer and restarts the app to apply.';
+      case 'video_render_skia_fix_confirm_action':
+        return 'Restart';
+      case 'video_render_skia_fix_title':
+        return 'Screen black? Switch renderer (Skia)';
+      case 'video_render_skia_fix_hint':
+        return 'Use if audio plays but the video stays black. Disables Impeller; restarts to apply.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "已移出合集",
   "collection_default_name": "新合集",
   "backup_import_contents_hint": "取消勾选某项即可跳过它。",
-  "clipboard_panel_window_title": "Hibiki 剪贴板查词"
+  "clipboard_panel_window_title": "Hibiki 剪贴板查词",
+  "video_render_skia_fix_confirm_title": "切换到 Skia 并重启？",
+  "video_render_skia_fix_confirm_body": "将关闭 Impeller 渲染器并重启应用使其生效。",
+  "video_render_skia_fix_confirm_action": "重启",
+  "video_render_skia_fix_title": "画面全黑？切换渲染器（Skia）",
+  "video_render_skia_fix_hint": "有声音但画面全黑时用。关闭 Impeller，重启后生效。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2284,5 +2284,10 @@
   "collection_member_removed": "Removed from collection",
   "collection_default_name": "New collection",
   "backup_import_contents_hint": "Untick an item to skip it.",
-  "clipboard_panel_window_title": "Hibiki clipboard lookup"
+  "clipboard_panel_window_title": "Hibiki clipboard lookup",
+  "video_render_skia_fix_confirm_title": "Switch to Skia and restart?",
+  "video_render_skia_fix_confirm_body": "This disables the Impeller renderer and restarts the app to apply.",
+  "video_render_skia_fix_confirm_action": "Restart",
+  "video_render_skia_fix_title": "Screen black? Switch renderer (Skia)",
+  "video_render_skia_fix_hint": "Use if audio plays but the video stays black. Disables Impeller; restarts to apply."
 }

--- a/hibiki/lib/src/media/video/video_quick_settings_sheet.dart
+++ b/hibiki/lib/src/media/video/video_quick_settings_sheet.dart
@@ -91,6 +91,7 @@ class VideoQuickSettingsSheet extends StatefulWidget {
     this.qualityOptionCount = 0,
     this.qualityCurrentLabel,
     this.onOpenQuality,
+    this.onSwitchToSkiaRenderer,
     this.isTouchControls = false,
     this.uiScale = 1.0,
     this.initialMpvShaderDir = '',
@@ -252,6 +253,12 @@ class VideoQuickSettingsSheet extends StatefulWidget {
 
   /// 打开画质侧栏（关本设置面板、开画质面板）。[qualityOptionCount]>0 时才接线。
   final VoidCallback? onOpenQuality;
+
+  /// TODO-1232 / BUG-597：视频「有声无画」黑屏降级入口——在「播放」分类给一个可发现的
+  /// 一键「切 Skia 渲染器并重启」行。仅当调用方判定"本次跑 Impeller 且渲染后端 channel
+  /// 已接线（=Android）且用户未显式选 Skia"时接线；否则为 null 不显示该行。点按由页面侧
+  /// 处理确认弹窗 → 写 pref（关 Impeller）→ 重启 app（见 `_switchToSkiaAndRestart`）。
+  final VoidCallback? onSwitchToSkiaRenderer;
 
   /// 触屏控件（无右键菜单兜底）。为 true 时，控件布局编辑区禁止把「设置」按钮
   /// （玩家内进入设置/控件编辑器的唯一入口）拖入 hidden 移除，避免触屏用户把
@@ -766,6 +773,18 @@ class _VideoQuickSettingsSheetState extends State<VideoQuickSettingsSheet> {
                 : null,
             trailing: const Icon(Icons.chevron_right),
             onTap: widget.onOpenQuality,
+          ),
+        // TODO-1232 / BUG-597：视频黑屏（有声无画）降级入口——仅当页面判定本次跑
+        // Impeller 且渲染 channel 已接线（Android）时接线。点按 → 确认弹窗 → 关 Impeller
+        // 走 Skia + 重启。Android 默认已保持 Impeller，故此行只给受影响机型的显式降级。
+        if (widget.onSwitchToSkiaRenderer != null)
+          ListTile(
+            dense: true,
+            leading: const Icon(Icons.animation_outlined),
+            title: Text(t.video_render_skia_fix_title),
+            subtitle: Text(t.video_render_skia_fix_hint),
+            trailing: const Icon(Icons.restart_alt),
+            onTap: widget.onSwitchToSkiaRenderer,
           ),
         _buildVideoFitModeRow(),
         if (isDesktopPlatform)

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -5050,6 +5050,14 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
               ? t.video_quality_auto
               : _hlsVariants[_selectedHlsVariantIndex].qualityLabel),
       onOpenQuality: _hlsVariants.isEmpty ? null : _showQualityMenu,
+      // TODO-1232 / BUG-597：视频黑屏（有声无画）降级入口——仅当渲染 channel 已接线
+      // （Android）、本次运行确实跑 Impeller、且用户尚未选 Skia 时接线（=可能中招黑屏
+      // 的人群）；否则 null 不显示该行。点按走确认弹窗 → 关 Impeller → 重启。
+      onSwitchToSkiaRenderer: (RenderBackendService.instance.isSupported &&
+              !RenderBackendService.instance.impellerDisabled &&
+              !RenderBackendService.instance.activeImpellerDisabled)
+          ? _switchToSkiaAndRestart
+          : null,
       // TODO-554：触屏无右键菜单兜底，禁止把「设置」按钮拖入 hidden 移除，
       // 否则用户进不去设置/控件编辑器、无法加回，软锁死。
       isTouchControls: !_isDesktopVideoControls,
@@ -5093,6 +5101,48 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
       ));
     }
     return options;
+  }
+
+  /// TODO-1232 / BUG-597：播放器设置面板「切 Skia 并重启」降级行的动作。视频「有声无画」
+  /// 黑屏根因是本机 GPU 上 Impeller 合成不了 media_kit 外部纹理（SurfaceProducer）；Android
+  /// 默认已保持 Impeller（多数机型性能优先），本动作给受影响机型一个显式降级：确认弹窗 →
+  /// 写 native pref 关 Impeller（下次启动走 Skia）→ 重启 app 使其生效。渲染后端只能在引擎
+  /// 启动那一刻定，故必须重启；不支持重启的平台降级为 toast 提示手动重开。仅在
+  /// [_buildVideoQuickSettingsSheet] 判定本次跑 Impeller + channel 已接线时才接线此动作。
+  Future<void> _switchToSkiaAndRestart() async {
+    final bool confirmed = await showDialog<bool>(
+          context: context,
+          builder: (BuildContext ctx) => AlertDialog(
+            title: Text(t.video_render_skia_fix_confirm_title),
+            content: Text(t.video_render_skia_fix_confirm_body),
+            actions: <Widget>[
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(false),
+                child: Text(t.dialog_cancel),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.of(ctx).pop(true),
+                child: Text(t.video_render_skia_fix_confirm_action),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+    if (!confirmed) return;
+    final bool ok =
+        await RenderBackendService.instance.setImpellerDisabled(true);
+    if (!ok || !appModel.platformServices.lifecycle.supportsRestart) {
+      // pref 未写成（非 Android）或平台不支持自动重启：降级提示手动重开。
+      if (mounted) HibikiToast.show(msg: t.render_restart_required);
+      return;
+    }
+    try {
+      await appModel.platformServices.lifecycle.restartApp();
+    } catch (e) {
+      // 起新进程失败（Process.start 抛错等）→ 降级提示手动重开。
+      debugPrint('[render] switch to Skia restart failed: $e');
+      if (mounted) HibikiToast.show(msg: t.render_restart_required);
+    }
   }
 
   void _showPlayerSettings({

--- a/hibiki/lib/src/utils/misc/render_backend_service.dart
+++ b/hibiki/lib/src/utils/misc/render_backend_service.dart
@@ -28,24 +28,27 @@ class RenderBackendService {
   /// 设置里动过开关 / `true`＝显式选 Skia / `false`＝显式选 Impeller）解析成本平台
   /// **实际生效**的「关闭 Impeller（走 Skia）」决定。显式设置 > 平台默认：
   ///   * [storedPref] != null：用户显式设过 —— 直接遵从其选择，无视平台默认。
-  ///   * [storedPref] == null：用户从未设置 —— 回落到平台默认：
-  ///       - Android（[isAndroid]=true）：`true`（默认关 Impeller / 走 Skia），让
-  ///         media_kit 外部视频纹理（SurfaceProducer）开箱即出画。Impeller 在部分
-  ///         Android GPU（如 Mali-G76 / Android 11，见 BUG-597）静默不合成该外部纹理，
-  ///         解码/纹理握手全绿仍黑屏；Skia 是成熟稳定后端，作 Android 默认最简、覆盖
-  ///         最广，且可被本开关逆转。
-  ///       - 非 Android：`false`（此开关不适用，保持引擎默认 Impeller）。
+  ///   * [storedPref] == null：用户从未设置 —— 回落到平台默认 `false`（保持引擎默认
+  ///     Impeller），**所有平台一致**（Android 亦然）：
+  ///       - Impeller 是 Flutter 现默认，多数机型渲染更顺、无 Skia 首帧 shader 卡顿；
+  ///         为它保住这份收益，Android 不再全局默认翻到 Skia。
+  ///       - 少数 Android GPU（如 Mali-G76 / Android 11，见 BUG-597）上 Impeller 静默
+  ///         不合成 media_kit 外部视频纹理（SurfaceProducer），解码/纹理握手全绿仍黑屏。
+  ///         这些机型改由**播放器设置面板里可发现的一键「切 Skia 并重启」入口**降级
+  ///         （见 video_quick_settings_sheet 的渲染降级行 + [setImpellerDisabled]），
+  ///         而非拿全体用户的性能换少数机型的兼容。
   ///
   /// 纯函数、无副作用，便于离屏单测。与 native 权威决策同源：
-  /// `MainActivity.getFlutterShellArgs` 在引擎启动那一刻用等价逻辑（未设置→Android
-  /// 关 Impeller）决定是否追加 `--enable-impeller=false`；本函数是 Dart 侧镜像，供
+  /// `MainActivity.getFlutterShellArgs` 在引擎启动那一刻用等价逻辑（未设置→保持
+  /// Impeller）决定是否追加 `--enable-impeller=false`；本函数是 Dart 侧镜像，供
   /// 设置开关显示与诊断标签（守卫见 render_backend_service_test /
-  /// impeller_default_guard_test 锁两侧同默认）。
+  /// impeller_default_guard_test 锁两侧同默认）。[isAndroid] 保留在签名里以对齐 native
+  /// 决策点形状、便于将来再按平台分默认，当前所有平台默认同为 Impeller。
   static bool resolveImpellerDisabled({
     required bool? storedPref,
     required bool isAndroid,
   }) =>
-      storedPref ?? isAndroid;
+      storedPref ?? false;
 
   /// 可注入的 channel（测试替换成 mock messenger）；生产走真实 native channel。
   @visibleForTesting

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.0.1+678
+version: 1.0.1+679
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/android/impeller_default_guard_test.dart
+++ b/hibiki/test/android/impeller_default_guard_test.dart
@@ -2,11 +2,15 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// 源码扫描守卫（TODO-1232 / BUG-597）：Android 视频黑屏的根治手段是「默认关 Impeller
-/// 走 Skia」——该默认由 native `MainActivity.getFlutterShellArgs` 在**引擎启动那一刻**
-/// （Dart 尚不存在）决定，是权威决策点，无法用 flutter test 直接驱动引擎后端。故用源码
-/// 扫描锁死这层不变式，防有人把 Android 默认悄悄翻回 Impeller（=视频又全黑），并保证它
-/// 与 Dart 侧镜像 `RenderBackendService.resolveImpellerDisabled` 同默认。
+/// 源码扫描守卫（TODO-1232 / BUG-597）：Android 渲染后端默认由 native
+/// `MainActivity.getFlutterShellArgs` 在**引擎启动那一刻**（Dart 尚不存在）决定，是权威
+/// 决策点，无法用 flutter test 直接驱动引擎后端。故用源码扫描锁死这层不变式，并保证它与
+/// Dart 侧镜像 `RenderBackendService.resolveImpellerDisabled` 同默认。
+///
+/// 当前不变式：**未设置态默认保持 Impeller（raw==null → false）**，多数机型保住 Impeller
+/// 性能；少数 Mali-G76/Android 11 类黑屏机型（BUG-597）改由播放器设置面板可发现的一键
+/// 「切 Skia 并重启」入口显式降级，而非全局默认翻 Skia。此守卫防有人把默认改回
+/// `: true`（=又把全体 Android 用户翻到 Skia，牺牲多数人性能）。
 void main() {
   final File mainActivity = File(
     'android/app/src/main/java/app/hibiki/reader/MainActivity.java',
@@ -20,7 +24,7 @@ void main() {
     src = mainActivity.readAsStringSync();
   });
 
-  group('TODO-1232 Android 默认走 Skia（关 Impeller）', () {
+  group('TODO-1232 Android 默认保持 Impeller（黑屏机型走一键切 Skia 入口）', () {
     test('getFlutterShellArgs 命中时追加 --enable-impeller=false shell arg', () {
       expect(
           src.contains('public FlutterShellArgs getFlutterShellArgs()'), isTrue,
@@ -31,17 +35,15 @@ void main() {
           reason: 'shell arg 是否追加由 isImpellerDisabledPref() 这个权威决策点门控');
     });
 
-    test('isImpellerDisabledPref 未设置态回落到 true（Skia），不是 false（Impeller）', () {
-      // 这是「装新包即好」的根：pref 未被用户显式设置时，Android 默认关 Impeller。
-      expect(src.contains('return raw != null ? raw : true;'), isTrue,
-          reason: '未设置（raw==null）必须回落到 true=关 Impeller 走 Skia；'
-              '若改成 : false 则 Android 视频又全黑（BUG-597 复发）');
-      // 反向守卫：绝不能出现「未设置默认 false」的旧形状（会让默认跑 Impeller）。
-      expect(
-          src.contains(
-              'getBoolean(PreferenceKeys.RENDER_IMPELLER_DISABLED, false)\n'
-              '                .getBoolean'),
-          isFalse);
+    test('isImpellerDisabledPref 未设置态回落到 false（Impeller），不是 true（Skia）', () {
+      // 未被用户显式设置时保持引擎默认 Impeller（多数机型性能优先）；黑屏机型改由
+      // 播放器设置面板可发现的一键「切 Skia 并重启」入口显式降级。
+      expect(src.contains('return raw != null ? raw : false;'), isTrue,
+          reason: '未设置（raw==null）必须回落到 false=保持 Impeller；'
+              '若改回 : true 则又把全体 Android 用户翻到 Skia、牺牲多数人性能');
+      // 反向守卫：绝不能再出现「未设置默认 true（全局 Skia）」的旧形状。
+      expect(src.contains('return raw != null ? raw : true;'), isFalse,
+          reason: '旧的全局默认 Skia 形状不得复现（会牺牲多数机型 Impeller 性能）');
     });
 
     test('getImpellerDisabledRawPref 用 contains() 判「未设置」返回 null（三态）', () {

--- a/hibiki/test/pages/video_quick_settings_sheet_test.dart
+++ b/hibiki/test/pages/video_quick_settings_sheet_test.dart
@@ -48,12 +48,14 @@ VideoQuickSettingsSheet _sheet({
   String? currentThemeKey,
   void Function(String key)? onSelectThemeKey,
   VoidCallback? onSubtitleCategoryShown,
+  VoidCallback? onSwitchToSkiaRenderer,
 }) {
   return VideoQuickSettingsSheet(
     initialCategory: initialCategory,
     audioTrackSection: audioTrackSection,
     subtitleTrackSection: subtitleTrackSection,
     onSubtitleCategoryShown: onSubtitleCategoryShown,
+    onSwitchToSkiaRenderer: onSwitchToSkiaRenderer,
     themeOptions: themeOptions,
     currentThemeKey: currentThemeKey,
     onSelectThemeKey: onSelectThemeKey == null
@@ -854,6 +856,44 @@ void main() {
     await tester.tap(find.byIcon(Icons.chevron_right));
     await tester.pump();
     expect(delay, 50);
+  });
+
+  // ── TODO-1232 / BUG-597：视频黑屏（有声无画）降级行 ─────────────────────────
+  // Android 默认已保持 Impeller；受影响机型（Impeller 合成不了 media_kit 外部纹理，见
+  // BUG-597）经「播放」分类的一键「切 Skia 并重启」行显式降级。该行仅在页面判定本次跑
+  // Impeller + 渲染 channel 已接线（Android）时接线 onSwitchToSkiaRenderer；此处锁死
+  // 「有回调 → 行在 playback 详情渲染且可点触发」「无回调 → 不渲染该行」。
+  testWidgets('TODO-1232：提供 onSwitchToSkiaRenderer 时渲染「切 Skia」降级行并可触发',
+      (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1000, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    int switched = 0;
+    await _pump(tester, _sheet(onSwitchToSkiaRenderer: () => switched++));
+
+    // 宽窗默认选中 playback 分类，降级行随之渲染。
+    final Finder row = find.widgetWithText(
+      ListTile,
+      t.video_render_skia_fix_title,
+    );
+    await tester.ensureVisible(row);
+    await tester.pumpAndSettle();
+    expect(row, findsOneWidget,
+        reason: 'onSwitchToSkiaRenderer 非空时「切 Skia」降级行须在 playback 详情渲染');
+    await tester.tap(row);
+    await tester.pump();
+    expect(switched, 1, reason: '点降级行须触发 onSwitchToSkiaRenderer 回调');
+  });
+
+  testWidgets('TODO-1232：onSwitchToSkiaRenderer 为 null 时不渲染「切 Skia」降级行',
+      (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1000, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pump(tester, _sheet());
+
+    // 默认 playback 详情里字幕调轴行在（证明确在 playback 分类），但降级行不渲染。
+    expect(find.text(t.video_setting_av_delay), findsOneWidget);
+    expect(find.text(t.video_render_skia_fix_title), findsNothing,
+        reason: '无 onSwitchToSkiaRenderer 回调时不应渲染「切 Skia」降级行');
   });
 
   // ── TODO-060：字幕调轴（正名 + 滑条 + 数值输入） ───────────────────────────

--- a/hibiki/test/utils/misc/render_backend_service_test.dart
+++ b/hibiki/test/utils/misc/render_backend_service_test.dart
@@ -112,31 +112,32 @@ void main() {
     });
   });
 
-  group('TODO-1232 三态默认解析（resolveImpellerDisabled，Android 默认走 Skia）', () {
-    test('未设置 + Android → true（默认关 Impeller / 走 Skia，视频开箱即用）', () {
+  group('TODO-1232 三态默认解析（resolveImpellerDisabled，所有平台默认 Impeller）', () {
+    test('未设置 + Android → false（保持 Impeller；黑屏机型走一键切 Skia 入口降级）', () {
       expect(
         RenderBackendService.resolveImpellerDisabled(
             storedPref: null, isAndroid: true),
-        isTrue,
-        reason: '用户从未动开关时，Android 平台默认关 Impeller 走 Skia（BUG-597）',
+        isFalse,
+        reason: '用户从未动开关时，Android 亦保持引擎默认 Impeller（不再全局翻 Skia）；'
+            'BUG-597 黑屏机型改由播放器设置面板可发现的一键「切 Skia 并重启」降级',
       );
     });
 
-    test('未设置 + 非 Android → false（开关不适用，保持引擎默认 Impeller）', () {
+    test('未设置 + 非 Android → false（保持引擎默认 Impeller）', () {
       expect(
         RenderBackendService.resolveImpellerDisabled(
             storedPref: null, isAndroid: false),
         isFalse,
-        reason: '非 Android 平台此开关不适用，不擅自翻默认',
+        reason: '非 Android 平台此开关不适用，保持引擎默认 Impeller',
       );
     });
 
-    test('显式 false（用户选 Impeller）压过 Android 默认 → false', () {
+    test('显式 false（用户选 Impeller）→ false（与默认同向，仍遵从显式）', () {
       expect(
         RenderBackendService.resolveImpellerDisabled(
             storedPref: false, isAndroid: true),
         isFalse,
-        reason: '用户在设置里显式拨回「用 Impeller」时，显式选择 > 平台默认',
+        reason: '用户在设置里显式选「用 Impeller」时遵从其选择',
       );
     });
 
@@ -152,9 +153,9 @@ void main() {
 
   test('init 收到 null（用户未设置）→ 仍 supported，按平台默认解析', () async {
     // native 未设置该开关时 channel 返回 null（三态）。init 必须仍标记 supported
-    // （channel 有响应＝已接线），并用 Platform.isAndroid 兜底平台默认——测试宿主
-    // 物理 OS 非 Android，故未设置态解析为 false（保持 Impeller），恰好锁「非 Android
-    // 不擅自翻默认」这条边。真机 Android 上同一路径解析为 true（走 Skia）。
+    // （channel 有响应＝已接线），并用 Platform.isAndroid 兜底平台默认——所有平台
+    // （含 Android）未设置态现均解析为 false（保持 Impeller）；黑屏机型走播放器设置
+    // 面板的一键「切 Skia 并重启」入口显式降级，而非全局默认翻 Skia。
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(testChannel, (MethodCall call) async {
       if (call.method == 'isImpellerDisabled') return null; // 未设置
@@ -169,7 +170,7 @@ void main() {
         RenderBackendService.resolveImpellerDisabled(
             storedPref: null, isAndroid: Platform.isAndroid),
         reason: 'init 须用同一三态 helper + 物理 OS 兜底未设置态');
-    expect(service.impellerDisabled, Platform.isAndroid,
-        reason: '未设置态在 Android 解析为 true（Skia）、非 Android 为 false（Impeller）');
+    expect(service.impellerDisabled, isFalse,
+        reason: '未设置态在所有平台（含 Android）均解析为 false（保持 Impeller）');
   });
 }


### PR DESCRIPTION
## 背景
此前为修 media_kit 外部纹理黑屏（有声无画，BUG-597）把**全 Android 默认翻到 Skia**，牺牲了多数机型的 Impeller 性能（首帧 shader 卡顿等）。用户要求：默认保住 Impeller，只给受影响机型一个可发现的降级入口。

## 改动
- **翻回默认**：`resolveImpellerDisabled` / `MainActivity.isImpellerDisabledPref` 未设置态默认 `false`（保持 Impeller），所有平台一致。
- **可发现一键入口**：播放器设置面板（齿轮 →「播放」分类）新增一行「画面全黑？切换渲染器（Skia）」，点击 → 确认弹窗 → `setImpellerDisabled(true)` → `restartApp()`。
  - 仅在**本次运行确实跑 Impeller** + 渲染 channel 已接线（Android）+ 用户未选 Skia 时显示（= 可能中招黑屏的人群）；否则不渲染，零打扰。
  - 渲染后端只能在引擎启动那一刻定，故必须重启；不支持重启的平台降级为 toast 提示手动重开。
- **i18n**：5 个 `video_render_skia_fix_*` key（17 语言，经 i18n_sync + slang）。
- **守卫测试**：`impeller_default_guard` / `render_backend_service_test` 断言翻成「默认 Impeller」；`video_quick_settings_sheet_test` 新增降级行显示/隐藏/可点两条。

## 为什么这样修（根因，非补丁）
黑屏根因是 **Flutter 引擎 Impeller 合成不了 media_kit 的 `SurfaceProducer` 外部纹理**（mpv 解码/纹理握手全绿、有声音），换 Skia 合成即出画。mpv 本身无关。此改动动的是渲染后端默认值 + 显式降级路径，不是延迟/重试/吞异常。

## 取舍
受影响机型（Mali-G76 类）第一次看视频**会先黑一次**，直到用户用这个入口降级——这是拿「一次黑屏 + 一次重启」换「多数机型保住 Impeller 性能」，用户已知情并选择此方案。

## 验证
- `flutter analyze`：No issues。
- `flutter test`：全量 **10949 通过 / 3 skip / 0 失败**。
- **真机验收待用户**：装 1.0.1+679 后，在受影响机型上验证「设置面板出现降级行 → 点击 → 确认 → 重启 → 出画」，以及多数机型默认 Impeller 无回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)