### PR TITLE
fix(header): 页头标签药丸按本地宽降级，不再挤压书架标题 (BUG-753)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,11 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 737 条。点号进各自文件。
+> 共 738 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-752](bugs/BUG-752-ext-content-css-reset-specificity.md) | 🚧 | 🚧 | 扩展查词弹窗与app内完全不一样：content.css生成器把通用reset抬到ID特异性压死低特异性margin/padding |
+| [BUG-753](bugs/BUG-753-header-pill-crushes-title.md) | ✅ | ✅ | 页头标签药丸按本地宽降级失败·挤压书架标题重叠 |
+| [BUG-752](bugs/BUG-752-ext-content-css-reset-specificity.md) | ✅ | ✅ | 扩展查词弹窗与app内完全不一样：content.css生成器把通用reset抬到ID特异性压死低特异性margin/padding |
 | [BUG-751](bugs/BUG-751-panel-header-buttons-washed-out.md) | ✅ | ✅ | 剪贴板半透明面板顶部按钮(制卡/音频/收藏)几乎不可见 |
 | [BUG-750](bugs/BUG-750-remote-tab-reload.md) | ✅ | ✅ | 远端视频/书切 tab 每次重新加载（顶层 tab 无保活） |
 | [BUG-749](bugs/BUG-749-lookup-window-floor-region-eats-clicks.md) | ✅ | ✅ | app外查词覆盖窗铺满工作区吞掉下一次点击 |

--- a/docs/bugs/BUG-753-header-pill-crushes-title.md
+++ b/docs/bugs/BUG-753-header-pill-crushes-title.md
@@ -1,0 +1,8 @@
+## BUG-753 · 页头标签药丸按本地宽降级失败·挤压书架标题重叠
+- **报告**：2026-07-12（用户：）截图书架页头大标题「书架」被挤到贴按钮、折成两行（书/架），带文字的动作药丸（导入书/管理来源/收藏夹/阅读统计）没有降级成纯图标（用户：「已经重叠了还没降级成无字」）。
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/utils/components/hibiki_icon_button.dart:157` 的 `_labelExpanded` 只按**整窗**宽（`MediaQuery.sizeOf`）判定是否展开 label 药丸，与页头实际可用宽脱钩。桌面带导航栏 / 分栏时整窗 ≥600（甚至 ≥840）但页头本地宽更窄，窗宽判定仍把 4 个动作展开成药丸，`HibikiPageHeader`（`hibiki_material_components.dart` `_HibikiPageHeaderRow`）里 `Expanded` 的标题被压到 0 附近、贴着按钮并折成两行。
+- **[x] ① 已修复** — 展开判定改由 `_HibikiPageHeaderRow` 的 `LayoutBuilder` 用**本地可用宽**（`constraints.maxWidth`，经 `windowSizeClassReal` 乘回 UI 缩放还原真实宽）判定，仅 `WindowSizeClass.expanded`（真实 ≥840）才展开，结果经新增的 `HibikiHeaderLabelScope` InheritedWidget 下发给后代 `HibikiIconButton`；域外独立使用的带 label 按钮回退整窗判定（`!= compact`），行为零变化。提交见分支 `worktree-header-pill-collapse`。
+  - `hibiki/lib/src/utils/components/hibiki_icon_button.dart`：新增 `HibikiHeaderLabelScope`；`_labelExpanded` 优先读作用域、域外回退整窗。
+  - `hibiki/lib/src/utils/components/hibiki_material_components.dart`：`_HibikiPageHeaderRow` 按本地宽算 `expandLabels` 并包裹 actions。
+- **[x] ② 已加自动化测试** — `hibiki/test/widgets/hibiki_material_components_test.dart` 新增两条：整窗 1200(expanded) + 页头本地宽 720(medium) 时带 label 动作回落纯图标（无文字、标题「书架」不被挤）；本地宽 1000(expanded) 时展开成图标+文字药丸。`flutter test test/widgets test/pages` 2153 通过，`flutter analyze` 全库 No issues。
+- **备注**：号段可能与并发 agent（PR#56 提到的 BUG-753 词头迷你滚动条）撞号，集成合并时由 integration owner 决定改号一个 + reindex。真机 / 离屏目视复测桌面带导航栏窄页头的降级观感待补（本次已用 widget test 在失败几何上确定性验证机制）。

--- a/hibiki/lib/src/utils/components/hibiki_icon_button.dart
+++ b/hibiki/lib/src/utils/components/hibiki_icon_button.dart
@@ -7,6 +7,37 @@ import 'package:hibiki/src/utils/app_ui_scale.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
 import 'package:hibiki/src/utils/misc/platform_utils.dart';
 
+/// 页头动作按钮「展开文字标签」的作用域开关。
+///
+/// BUG：`_labelExpanded` 原本只按**整窗**宽（[MediaQuery.sizeOf]）判定，与页头
+/// 实际可用宽脱钩。桌面带导航栏 / 分栏时整窗 ≥840 但页头本地宽更窄，窗宽判定仍把
+/// 4 个动作展开成药丸，[HibikiPageHeader] 里 [Expanded] 的标题被挤到贴着按钮甚至
+/// 折成两行（用户反馈「已经重叠了还没降级成无字」）。
+///
+/// 修法：由 [HibikiPageHeader] 的行布局用 [LayoutBuilder] 拿到的**本地可用宽**
+/// （经 UI 缩放还原真实宽）判定，仅 [WindowSizeClass.expanded]（真实 ≥840）才展开，
+/// 结果经本作用域下发给后代 [HibikiIconButton]。域外（无此祖先，独立使用的带 label
+/// 按钮）回退整窗判定，行为零变化。
+class HibikiHeaderLabelScope extends InheritedWidget {
+  const HibikiHeaderLabelScope({
+    required this.expandLabels,
+    required super.child,
+    super.key,
+  });
+
+  /// 本作用域内的带 [HibikiIconButton.label] 按钮是否展开成图标+文字药丸。
+  final bool expandLabels;
+
+  /// 就近作用域的展开开关；无祖先返回 null（由调用方回退整窗判定）。
+  static bool? maybeOf(BuildContext context) => context
+      .dependOnInheritedWidgetOfExactType<HibikiHeaderLabelScope>()
+      ?.expandLabels;
+
+  @override
+  bool updateShouldNotify(HibikiHeaderLabelScope oldWidget) =>
+      expandLabels != oldWidget.expandLabels;
+}
+
 /// A button that can be set as busy. When busy, the icon is faded out when its
 /// [onTap] action is on-going and processing, which can be used to
 /// indicate when a button cannot be pressed once its click action has been
@@ -36,10 +67,11 @@ class HibikiIconButton extends StatefulWidget {
   /// The icon to display within the button.
   final IconData icon;
 
-  /// 可展开文字标签：非空时，在非 compact 宽度（真实视口 ≥600，经
-  /// [windowSizeClassReal] 判定）渲染成「图标 + 文字」的描边药丸按钮（页头动作在
-  /// 宽窗展开可读，对齐 Jellyfin 式工具栏）；compact 窄窗自动回落为纯图标圆钮，
-  /// 行为与 null 完全一致。busy / enabled / 焦点注册在两种形态间共享同一路径。
+  /// 可展开文字标签：非空时渲染成「图标 + 文字」的描边药丸按钮（页头动作在宽窗展开
+  /// 可读，对齐 Jellyfin 式工具栏），窄窗自动回落为纯图标圆钮，行为与 null 完全一致。
+  /// 是否展开由 [_labelExpanded] 决定——[HibikiPageHeader] 内经 [HibikiHeaderLabelScope]
+  /// 按**页头本地可用宽**判定（真实 ≥840 才展开，避免挤压标题）；域外独立使用回退整窗
+  /// 宽（非 compact 即展开）。busy / enabled / 焦点注册在两种形态间共享同一路径。
   final String? label;
 
   /// The size of the icon. By default, this is 24.0.
@@ -154,14 +186,18 @@ class _HibikiIconButtonState extends State<HibikiIconButton> {
   Color get disabledColor =>
       widget.disabledColor ?? Theme.of(context).colorScheme.onSurfaceVariant;
 
-  /// 宽窗判定与 [HibikiPageHeader] 同源：真实视口宽（BUG-401，乘回 UI 缩放）
-  /// 非 compact 才展开文字标签。
-  bool _labelExpanded(BuildContext context) =>
-      windowSizeClassReal(
-        MediaQuery.sizeOf(context).width,
-        HibikiAppUiScale.of(context),
-      ) !=
-      WindowSizeClass.compact;
+  /// 是否展开文字标签。优先取 [HibikiHeaderLabelScope]（页头按**本地可用宽**下发的
+  /// 权威判定）；域外独立使用时回退整窗宽判定（BUG-401，乘回 UI 缩放还原真实宽），
+  /// 非 compact 即展开——保持独立按钮行为不变。
+  bool _labelExpanded(BuildContext context) {
+    final bool? scoped = HibikiHeaderLabelScope.maybeOf(context);
+    if (scoped != null) return scoped;
+    return windowSizeClassReal(
+          MediaQuery.sizeOf(context).width,
+          HibikiAppUiScale.of(context),
+        ) !=
+        WindowSizeClass.compact;
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/hibiki/lib/src/utils/components/hibiki_material_components.dart
+++ b/hibiki/lib/src/utils/components/hibiki_material_components.dart
@@ -1766,6 +1766,16 @@ class _HibikiPageHeaderRow extends StatelessWidget {
           final double maxActionsWidth = constraints.maxWidth.isFinite
               ? (constraints.maxWidth - actionsGap).clamp(0.0, double.infinity)
               : double.infinity;
+          // 带 label 的动作是否展开成药丸：按**页头本地可用宽**（而非整窗宽）判定，经
+          // UI 缩放还原真实宽后仅 expanded（≥840）才展开。桌面带导航栏 / 分栏时整窗
+          // ≥840 但本地宽更窄，若按整窗判定会误展开、把 [Expanded] 标题挤到贴按钮/折行
+          // （用户反馈「已经重叠了还没降级成无字」）。经 [HibikiHeaderLabelScope] 下发。
+          final bool expandLabels = constraints.maxWidth.isFinite &&
+              windowSizeClassReal(
+                    constraints.maxWidth,
+                    HibikiAppUiScale.of(context),
+                  ) ==
+                  WindowSizeClass.expanded;
           children
             ..add(SizedBox(width: actionsGap))
             ..add(
@@ -1774,7 +1784,10 @@ class _HibikiPageHeaderRow extends StatelessWidget {
                 child: SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
                   physics: const ClampingScrollPhysics(),
-                  child: actions,
+                  child: HibikiHeaderLabelScope(
+                    expandLabels: expandLabels,
+                    child: actions!,
+                  ),
                 ),
               ),
             );

--- a/hibiki/test/widgets/hibiki_material_components_test.dart
+++ b/hibiki/test/widgets/hibiki_material_components_test.dart
@@ -360,6 +360,126 @@ void main() {
     expect(statisticsTop, importTop);
   });
 
+  // BUG（页头药丸挤标题）：带 label 的动作是否展开成「图标+文字」药丸，必须按
+  // **页头本地可用宽**（而非整窗宽）判定。桌面带导航栏 / 分栏时整窗 expanded（≥840）
+  // 但页头本地宽只到 medium，旧实现按整窗宽（[MediaQuery.sizeOf]）误展开 4 个药丸，
+  // 把 [Expanded] 标题挤到贴按钮甚至折成两行（用户反馈「已经重叠了还没降级成无字」）。
+  // 守卫：整窗放宽到 1200(expanded)、页头本地宽压到 720(medium) 时，带 label 动作回落
+  // 纯图标（无文字），标题不再被挤。
+  testWidgets(
+      'HibikiPageHeader collapses labeled actions to icons by local width '
+      'even when the window is wide', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      buildSubject(
+        Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 720, // 页头本地宽 = medium（600–840），整窗 1200 = expanded
+            child: HibikiPageHeader(
+              title: '书架',
+              padding: EdgeInsets.zero,
+              actions: <Widget>[
+                HibikiIconButton(
+                  tooltip: 'Import',
+                  label: 'Import',
+                  icon: Icons.library_add_outlined,
+                  onTap: () {},
+                ),
+                HibikiIconButton(
+                  tooltip: 'Manage',
+                  label: 'Manage sources',
+                  icon: Icons.folder_copy_outlined,
+                  onTap: () {},
+                ),
+                HibikiIconButton(
+                  tooltip: 'Collections',
+                  label: 'Collections',
+                  icon: Icons.collections_bookmark_outlined,
+                  onTap: () {},
+                ),
+                HibikiIconButton(
+                  tooltip: 'Statistics',
+                  label: 'Statistics',
+                  icon: Icons.bar_chart_outlined,
+                  onTap: () {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    // 本地 medium → 回落纯图标（无 label 文字），标题不再被药丸挤压。
+    for (final String label in <String>[
+      'Import',
+      'Manage sources',
+      'Collections',
+      'Statistics',
+    ]) {
+      expect(find.text(label), findsNothing, reason: '$label 应折叠为纯图标');
+    }
+    for (final IconData icon in <IconData>[
+      Icons.library_add_outlined,
+      Icons.folder_copy_outlined,
+      Icons.collections_bookmark_outlined,
+      Icons.bar_chart_outlined,
+    ]) {
+      expect(find.byIcon(icon), findsOneWidget, reason: '$icon 应仍可见');
+    }
+    expect(find.text('书架'), findsOneWidget);
+  });
+
+  // 反向守卫：页头本地宽达到 expanded（≥840）时，带 label 动作展开成图标+文字药丸
+  // （宽窗零行为变化）。
+  testWidgets(
+      'HibikiPageHeader expands labeled actions when local width is expanded',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      buildSubject(
+        Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 1000, // 页头本地宽 = expanded（≥840）
+            child: HibikiPageHeader(
+              title: '书架',
+              padding: EdgeInsets.zero,
+              actions: <Widget>[
+                HibikiIconButton(
+                  tooltip: 'Import',
+                  label: 'Import',
+                  icon: Icons.library_add_outlined,
+                  onTap: () {},
+                ),
+                HibikiIconButton(
+                  tooltip: 'Statistics',
+                  label: 'Statistics',
+                  icon: Icons.bar_chart_outlined,
+                  onTap: () {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Import'), findsOneWidget);
+    expect(find.text('Statistics'), findsOneWidget);
+  });
+
   // TODO-955: 内容放得下时，4 个动作 icon 必须贴页头最右侧（回归前被 7ce19740c 的
   // Flexible+反向 ScrollView 平分宽度推到了页头中间）。断言最右动作的右缘 ~= 页头右
   // 内边界，而非停在中部。


### PR DESCRIPTION
## 现象
书架页头大标题「书架」被挤到贴按钮、折成两行（书/架），带文字的动作药丸（导入书/管理来源/收藏夹/阅读统计）没有降级成纯图标（用户：「已经重叠了还没降级成无字」）。

## 根因
`HibikiIconButton._labelExpanded` 只按**整窗**宽（`MediaQuery.sizeOf`）判定是否把带 `label` 的动作展开成药丸，与页头**实际可用宽**脱钩。桌面带导航栏 / 分栏时整窗 ≥600（甚至 ≥840）但页头本地宽更窄，窗宽判定仍展开 4 个药丸，`HibikiPageHeader` 里 `Expanded` 的标题被压到 0 附近并折两行。

## 修法
- `_HibikiPageHeaderRow` 的 `LayoutBuilder` 用**本地可用宽**（`constraints.maxWidth`，经 `windowSizeClassReal` 乘回 UI 缩放还原真实宽）判定，仅 `WindowSizeClass.expanded`（真实 ≥840）才展开，结果经新增的 `HibikiHeaderLabelScope` InheritedWidget 下发给后代 `HibikiIconButton`。
- 域外独立使用的带 label 按钮回退整窗判定（`!= compact`），行为零变化，blast radius 收敛在页头。

## 测试
- 新增 `test/widgets/hibiki_material_components_test.dart` 两条：整窗 1200(expanded) + 页头本地宽 720(medium) → 带 label 动作回落纯图标（无文字、标题「书架」不被挤）；本地宽 1000(expanded) → 展开图标+文字药丸。
- `flutter analyze` 全库 No issues；`flutter test test/widgets test/pages` 2153 通过。

## 待办
- 真机 / 离屏目视复测桌面带导航栏窄页头的降级观感（本次已用 widget test 在失败几何上确定性验证机制）。
- 号段可能与并发 BUG-753（PR#56 词头迷你滚动条）撞号，集成时由 owner 决定改号一个 + reindex。