### PR TITLE
fix(sync): 互联令牌浮动标签上半截被折叠区裁剪 (BUG-755)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 738 条。点号进各自文件。
+> 共 739 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-755](bugs/BUG-755-interconnect-token-label-clipped.md) | ✅ | ✅ | 互联对端访问令牌浮动标签上半截被折叠区裁剪 |
 | [BUG-753](bugs/BUG-753-header-pill-crushes-title.md) | ✅ | ✅ | 页头标签药丸按本地宽降级失败·挤压书架标题重叠 |
 | [BUG-752](bugs/BUG-752-ext-content-css-reset-specificity.md) | ✅ | ✅ | 扩展查词弹窗与app内完全不一样：content.css生成器把通用reset抬到ID特异性压死低特异性margin/padding |
 | [BUG-751](bugs/BUG-751-panel-header-buttons-washed-out.md) | ✅ | ✅ | 剪贴板半透明面板顶部按钮(制卡/音频/收藏)几乎不可见 |

--- a/docs/bugs/BUG-755-interconnect-token-label-clipped.md
+++ b/docs/bugs/BUG-755-interconnect-token-label-clipped.md
@@ -1,0 +1,11 @@
+## BUG-755 · 互联对端访问令牌浮动标签上半截被折叠区裁剪
+- **报告**：2026-07-12（用户：截图「手动填写令牌」展开区里「对端访问令牌」标签只显示下半截，上半部分不显示）
+- **真实性**：✅ 真 bug（纯视觉裁剪，可稳定复现；令牌取值/鉴权/连接均正常）。
+  - 根因链（worktree `worktree-fix-token-label-clip`，基于 origin/develop）：
+    - 令牌输入框是 `hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart` 里「手动填写令牌」`ExpansionTile`（`childrenPadding: EdgeInsets.zero`）的**唯一且首个**展开子项 `HibikiTextField(labelText: t.sync_client_token)`。
+    - `HibikiTextField`（`hibiki/lib/src/utils/components/hibiki_material_components.dart:487`）用 `OutlineInputBorder` + `floatingLabelStyle: tokens.type.sectionLabel`（labelLarge 14sp/w600）。字段有值时标签浮动，浮动标签骑在字段顶边、中心落在顶边线上：Flutter `input_decorator.dart:1620` `outlinedFloatingY = -labelHeight*0.75/2 - strokeOffset/2`，即标签上半部分溢出到字段顶边**之上**约 7px（测试字体实测 4.75px，真机 CJK 字体更大）。
+    - `ExpansionTile` 的展开体被 `Expansible` 包在 `ClipRect(child: Align(heightFactor:...))` 里（Flutter `widgets/expansible.dart:466`）。`childrenPadding` 顶部为 0 时，`ClipRect` 上沿恰好压在字段顶边，把溢出到顶边之上的那半个浮动标签裁掉——于是「对端访问令牌」只剩下半截。
+  - 判定：不是令牌显示错误（BUG-637 已澄清取值/文案），是浮动标签几何 + 折叠区裁剪的布局问题。给该 `ExpansionTile` 顶部留出浮动标签的溢出高度即可根治，不动任何令牌取值/鉴权/文案。
+- **[x] ① 已修复** — `interconnect.part.dart` 该 `ExpansionTile` `childrenPadding: EdgeInsets.zero` → `const EdgeInsets.only(top: 10)`（>= 浮动标签溢出高度 ~7px，把字段整体下移让浮动标签落在 `ClipRect` 内），并加注释说明溢出/裁剪机理。提交：见 ② 同一提交。
+- **[x] ② 已加自动化测试** — widget 行为守卫 `hibiki/test/sync/interconnect_token_label_clip_guard_test.dart`：在真实的 `ExpansionTile`（含 `Expansible` 的 `ClipRect` 展开体）里放 `HibikiTextField(带浮动标签)`——① `childrenPadding: EdgeInsets.zero` 时断言浮动标签 painted top 位于 `ClipRect` 顶沿**之上**（复现裁剪）；② 用与源码一致的 `EdgeInsets.only(top: 10)` 时断言标签 painted top 落在 `ClipRect` **之内**（验修复）。`flutter test` 该文件 + `interconnect_token_display_guard_test` 全绿；`flutter analyze` 净。
+- **备注**：真机验收：桌面/手机进「互联」设置 → 展开「手动填写令牌」→「对端访问令牌」标签应完整显示（上下都不缺）。相邻的服务端令牌显示、`_validateAuth` 双接受、per-peer 签发均不受影响。

--- a/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
@@ -479,7 +479,12 @@ class _HibikiServerConfigWidgetState extends State<_HibikiServerConfigWidget>
             ),
           ExpansionTile(
             tilePadding: EdgeInsets.zero,
-            childrenPadding: EdgeInsets.zero,
+            // 唯一的展开子项是带浮动标签的 OutlineInputBorder 字段：浮动后的标签骑在
+            // 字段顶边、上半部分会溢出到字段上方（14sp 标签约 7px）。ExpansionTile 的
+            // 展开体被 Expansible 包在 ClipRect 里（flutter widgets/expansible.dart），
+            // childrenPadding 顶部为 0 时这半个标签被裁掉（BUG-755：「对端访问令牌」
+            // 上半截不显示）。顶部留出浮动标签的溢出高度即可让标签完整渲染。
+            childrenPadding: const EdgeInsets.only(top: 10),
             title: Text(
               t.sync_client_token_manual,
               style: theme.textTheme.bodySmall

--- a/hibiki/test/sync/interconnect_token_label_clip_guard_test.dart
+++ b/hibiki/test/sync/interconnect_token_label_clip_guard_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
+
+/// BUG-755 守卫：互联「手动填写令牌」折叠区里的 [HibikiTextField] 是带浮动标签的
+/// OutlineInputBorder 字段。浮动标签会骑在字段顶边、上半部分溢出到字段上方；而
+/// [ExpansionTile] 的展开体被 Flutter `Expansible` 包在 `ClipRect` 里，若
+/// `childrenPadding` 顶部为 0，溢出的半个标签会被裁掉（「对端访问令牌」只剩下半截）。
+///
+/// 这两个用例用真实的 `ExpansionTile`（含 `Expansible` 的 `ClipRect`）复现裁剪 /
+/// 验证修复：断言浮动标签 painted top 相对包住它的 `ClipRect` 顶沿的位置。
+Future<double> _labelTopMinusClipTop(
+  WidgetTester tester,
+  EdgeInsetsGeometry childrenPadding,
+) async {
+  final TextEditingController controller = TextEditingController(
+    text: 'mwr9S6dz5OQQrc4yWTXAHT2RKYLZ8Pl3KD3PWzDXAPw=',
+  );
+  addTearDown(controller.dispose);
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 500,
+            child: ExpansionTile(
+              initiallyExpanded: true,
+              tilePadding: EdgeInsets.zero,
+              childrenPadding: childrenPadding,
+              title: const Text('手动填写令牌'),
+              children: <Widget>[
+                HibikiTextField(
+                  controller: controller,
+                  labelText: '对端访问令牌',
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  final Rect labelRect = tester.getRect(find.text('对端访问令牌'));
+  // Expansible wraps the expanded body in ClipRect(child: Align(...)).
+  final Finder clip = find
+      .ancestor(of: find.text('对端访问令牌'), matching: find.byType(ClipRect))
+      .first;
+  final Rect clipRect = tester.getRect(clip);
+  // > 0 => label sits below the clip top (fully visible).
+  // < 0 => label top is above the clip top (top half clipped away).
+  return labelRect.top - clipRect.top;
+}
+
+void main() {
+  testWidgets(
+      'BUG-755 repro: zero childrenPadding clips the floating label top half',
+      (WidgetTester tester) async {
+    final double delta = await _labelTopMinusClipTop(tester, EdgeInsets.zero);
+    expect(
+      delta < 0,
+      isTrue,
+      reason:
+          'floating label top ($delta) should be above the Expansible ClipRect '
+          'top when childrenPadding is zero (this is the clipped state)',
+    );
+  });
+
+  testWidgets(
+      'BUG-755 fix: top childrenPadding keeps the floating label inside clip',
+      (WidgetTester tester) async {
+    // Must match the value used in interconnect.part.dart.
+    final double delta =
+        await _labelTopMinusClipTop(tester, const EdgeInsets.only(top: 10));
+    expect(
+      delta >= 0,
+      isTrue,
+      reason:
+          'floating label top ($delta) must sit within the Expansible ClipRect '
+          '(fully visible) once top childrenPadding is applied',
+    );
+  });
+}


### PR DESCRIPTION
## 现象
「互联」设置 → 展开「手动填写令牌」→「对端访问令牌」标签只显示下半截（用户截图）。

## 根因
- 令牌框是该 `ExpansionTile`（`childrenPadding: EdgeInsets.zero`）唯一且首个展开子项 `HibikiTextField`，用 `OutlineInputBorder` + 浮动标签（`sectionLabel` 14sp/w600）。
- 字段有值时标签浮动，骑在字段顶边、上半部分溢出到字段上方约 7px（Flutter `input_decorator.dart:1620` `outlinedFloatingY = -labelHeight*0.75/2 - strokeOffset/2`）。
- `ExpansionTile` 展开体被 `Expansible` 包在 `ClipRect`（`widgets/expansible.dart:466`）里，`childrenPadding` 顶部为 0 时 `ClipRect` 上沿压在字段顶边，把溢出的半个标签裁掉。

## 修复
`childrenPadding: EdgeInsets.zero` → `const EdgeInsets.only(top: 10)`，把字段整体下移让浮动标签落回 `ClipRect` 内。不动任何令牌取值/鉴权/文案（BUG-637 澄清逻辑不受影响）。

## 测试
新增 `hibiki/test/sync/interconnect_token_label_clip_guard_test.dart`（真实 `ExpansionTile`+`ClipRect` 树）：padding 0 时断言标签 painted top 在 ClipRect 上沿之上（复现裁剪，实测 -4.75px）；`top:10` 时断言落在 ClipRect 内（验修复）。`flutter analyze` 全净，`flutter test` 该文件 + 既有 `interconnect_token_display_guard_test` 全绿。

## 待真机
桌面/手机进「互联」展开「手动填写令牌」，确认「对端访问令牌」标签上下完整。