### PR TITLE
fix(pr-sweep): done 单不再抑制未合并 PR 的重捞

### DIFF
--- a/tool/pr_sweep.sh
+++ b/tool/pr_sweep.sh
@@ -136,8 +136,11 @@ if not rows:
     sys.exit(0)
 
 # 去重：一次 list（全部未归档行，含 done 未归档）复用给所有项。
-# 判据 = token 出现在**标题开头**（list 行格式「[状态] TODO-N <标题> …」）——
-# 别的 todo 正文顺带提及 "PR#42" 不算已跟踪（对抗审查抓过的误抑制）。
+# 判据 = PR 号紧跟「] TODO-N 」出现在标题开头（别的 todo 正文顺带提及 "PR#42"
+# 不算已跟踪，对抗审查抓过的误抑制），**且该 todo 未 done**——只被 done 单跟踪的 PR
+# 会被重新落板：done 只代表「有人关了这条」，不代表 commit 真进了 develop（PR#41 假
+# 完成教训：原始合并落了 v38、合并后新推的 v39 没落却被手动标 done，旧去重把 done 单
+# 当已跟踪永久抑制，缺口再没被重捞）。只要检测阶段判定 commit 不在 base，就持续建 todo。
 lp = run_cli(["list"])
 if lp.returncode != 0:
     sys.stderr.write("vibe-coxswain list 失败（rc=%s）：%s\n"
@@ -145,11 +148,27 @@ if lp.returncode != 0:
     print("落板中止：看板 CLI 不可用——上面的只读巡检输出仍有效，下轮面板任务重试")
     sys.exit(3)  # 非零退出：面板任务徽章如实变 fail，下轮调度天然重试
 listing = lp.stdout
+# done 号单独取（用机器码 --status done，不解析中文标签，标签改了也不误伤）。
+# 取失败不致命：done_nums 为空 = 退回「done 也算跟踪」的旧保守行为，绝不误刷屏。
+dlp = run_cli(["list", "--status", "done"])
+done_nums = set(re.findall(r"TODO-(\d+)", dlp.stdout)) if dlp.returncode == 0 else set()
+
+# PR#41 不得匹配 PR#410：号后接非数字守卫（空格/全角括号/半角括号/句读都放行）。
+_PR_TODO_RE = r"\] TODO-(\d+) PR#%s(?![0-9])"
 
 
 def tracked(num: str) -> bool:
-    """该 PR 号是否已有对应 todo：token 必须紧跟「] TODO-N 」出现在标题开头。"""
-    return re.search(r"\] TODO-\d+ PR#%s " % re.escape(num), listing) is not None
+    """该 PR 号是否已有**未 done**的 todo（done 单不抑制 → 假完成能被重捞）。"""
+    for m in re.finditer(_PR_TODO_RE % re.escape(num), listing):
+        if m.group(1) not in done_nums:
+            return True
+    return False
+
+
+def prior_done(num: str) -> bool:
+    """该 PR 曾有 done 单却又被检出未落地 = 那条是假完成（关了但 commit 没进 base）。"""
+    return any(m.group(1) in done_nums
+               for m in re.finditer(_PR_TODO_RE % re.escape(num), listing))
 
 today: str = datetime.date.today().isoformat()
 added: list = []
@@ -172,6 +191,9 @@ for kind, num, title, branch, ahead, oldsha, newsha in rows:
                       "未进 → 走门禁再合并；已进/已废弃 → 删远端分支并注明。"
                       "来源：pr_sweep --file 自动落板 %s。" % (base, today))
         next_val = "%s→%s" % (oldsha, newsha)
+    if prior_done(num):  # 曾被标 done 又检出未落地 → 明说是假完成重捞，别让人以为是新单
+        acceptance += ("（⚠️重捞：此 PR 之前有 done 单，但 commit 仍不在 %s——"
+                       "上次「已完成」是假完成，本轮按当前 head 重新落板。）" % base)
     ap = run_cli(["add", todo_title, "--status", "todo"])
     m = re.search(r"TODO-(\d+)", ap.stdout or "")
     if ap.returncode != 0 or m is None:


### PR DESCRIPTION
## 问题
`tool/pr_sweep.sh --file` 的去重把「已 done 但未归档」的 todo 也算已跟踪，一旦某 PR 的合并后更新 todo 被（哪怕误标）done，缺口就永久被抑制、再不重捞。

**PR#41 实测**：原始合并落了 schema v38，合并后新推的 v39 五提交没进 develop，却被手动标 done——sweep 从此不再为它建单，假完成（「说合并了其实没合」）一直没被戳破。

## 改法
- 去重新增 `list --status done` 拿 done 号集合（机器码过滤，不解析中文标签）；`tracked()` 只在存在**非 done** todo 时抑制——只剩 done 单 = 已被误关但 commit 未必真进 base，继续建 todo 重捞。`--status done` 取失败则退回旧保守行为。
- PR 号匹配加 `(?![0-9])`（PR#41 不再误吞 PR#410），放行号后全角/半角括号（用户手打「PR#41（…」也识别）。
- 重捞时给 `acceptance` 追加「⚠️重捞：之前有 done 单但 commit 仍不在 base，上次『已完成』是假完成」提示。

## 验证
临时 DB（不碰生产看板）：seed 一条 done 的「PR#41 合并后更新」→ 跑 `--file` → 无视 done 单重新落 open 单（含重捞提示）；再跑一遍 → 新 open 单正常抑制、不重复。`bash -n` 通过。

⚠️ 合并到 develop 后主 checkout 的 `tool/pr_sweep.sh` 才更新，面板 sweep 才用上新去重。