### PR TITLE
fix(popup+extension): 词典多列平分整行 + 浏览器扩展多列生效 & 滑动关闭手势

### DIFF
--- a/hibiki/assets/browser_extension/content.js
+++ b/hibiki/assets/browser_extension/content.js
@@ -839,6 +839,62 @@ try {
   });
 } catch (_) {}
 
+// 「滑动关闭查词弹窗」——app 的 enableSwipeToClose 偏好经查词响应 theme 的
+// --hibiki-swipe-close（'1'/'0'）下发；in-app 走 Flutter 手势层 / WebView topPullReleased，
+// 扩展的浮动弹窗是纯 DOM，这里在弹窗宿主上装同语义的**水平拖关**手势（设置项文案即「水平
+// 滑动关闭查词弹窗」）。默认 Windows/Linux 关（鼠标框选正文与拖手势同形易误触），跟随 app 偏好。
+let hibikiSwipeCloseEnabled = false;
+let hibikiSwipeStart = null;
+// 水平拖过此像素即关（固定阈值；in-app 的灵敏度滑块暂不移植，待真机再定是否需要）。
+const HIBIKI_SWIPE_CLOSE_THRESHOLD = 64;
+
+// 在弹窗宿主 [host] 上装水平拖关手势（每个 host 只装一次）。监听始终挂上，是否真正关窗由
+// hibikiSwipeCloseEnabled 门控（theme 到达后置位）→ 关时纯 no-op，开时水平主导且过阈才关。
+// pointer 路径只接 mouse/pen（touch 由 touch 家族处理，避免同一次拖动双触发）；全部 passive。
+function hibikiInstallSwipeClose(host) {
+  if (!host || host.__hibikiSwipeHooked) return;
+  host.__hibikiSwipeHooked = true;
+  const start = (x, y) => { hibikiSwipeStart = { x: x, y: y }; };
+  const move = (x, y) => {
+    if (!hibikiSwipeCloseEnabled || !hibikiSwipeStart) return;
+    const dx = x - hibikiSwipeStart.x;
+    const dy = y - hibikiSwipeStart.y;
+    // 水平主导（|dx| > 1.5·|dy|，避开竖向滚动/选竖排）且过阈 → 关。
+    if (Math.abs(dx) > HIBIKI_SWIPE_CLOSE_THRESHOLD &&
+        Math.abs(dx) > Math.abs(dy) * 1.5) {
+      hibikiSwipeStart = null;
+      hibikiRemoveContainer();
+    }
+  };
+  const end = () => { hibikiSwipeStart = null; };
+  host.addEventListener('pointerdown', (e) => {
+    if (e.pointerType === 'touch') return;
+    if (e.button !== undefined && e.button !== 0) return;
+    start(e.clientX, e.clientY);
+  }, { passive: true });
+  host.addEventListener('pointermove', (e) => {
+    if (e.pointerType === 'touch') return;
+    move(e.clientX, e.clientY);
+  }, { passive: true });
+  host.addEventListener('pointerup', (e) => {
+    if (e.pointerType === 'touch') return;
+    end();
+  }, { passive: true });
+  host.addEventListener('pointercancel', (e) => {
+    if (e.pointerType === 'touch') return;
+    end();
+  }, { passive: true });
+  host.addEventListener('touchstart', (e) => {
+    if (!e.touches || e.touches.length !== 1) return;
+    start(e.touches[0].clientX, e.touches[0].clientY);
+  }, { passive: true });
+  host.addEventListener('touchmove', (e) => {
+    if (!e.touches || e.touches.length !== 1) return;
+    move(e.touches[0].clientX, e.touches[0].clientY);
+  }, { passive: true });
+  host.addEventListener('touchend', end, { passive: true });
+}
+
 function hibikiEnsureContainer() {
   // BUG-530：全屏时（Netflix 看片常全屏）挂在 document.body 上的弹窗会被全屏元素盖住看不见
   // （浏览器全屏只渲染 fullscreenElement 及其后代）→ shift 划词其实触发了但弹窗不可见=「没反应」。
@@ -858,6 +914,7 @@ function hibikiEnsureContainer() {
     // 按查词响应下发的 --hibiki-popup-* 设置；#entries-container 在 shadow 内中和为 width:100%。
     hibikiHost.style.cssText =
         'position:fixed;top:0;left:0;z-index:2147483647;overflow-x:hidden;overflow-y:auto;';
+    hibikiInstallSwipeClose(hibikiHost); // 水平拖关手势（是否生效由 hibikiSwipeCloseEnabled 门控）
     const shadow = hibikiHost.attachShadow({ mode: 'open' });
     // 中和 content.css 里 #entries-container 自带的尺寸盒/zoom（那套是给「容器自身即 fixed 元素」
     // 的旧模型用的）；现在 host 才是尺寸/缩放/定位主体，容器只做 100% 透传。
@@ -1199,6 +1256,24 @@ function hibikiRender(popupJson, termLen, theme, anchorRect) {
     // （用户报「和 app 内完全不一样」：黑底 + 米卡 + 灰字）。主题单一来源于 app，与 in-app 一致。
     const cs = theme['--hibiki-color-scheme'];
     if (cs === 'dark' || cs === 'light') c.setAttribute('data-theme', cs);
+    // 多列词典（masonry）根因修：popup.js 的 dictColumns() 与 updateEffectiveDictColumns()
+    // 都从 document.documentElement 读 --dict-columns（in-app 时 documentElement 就是弹窗自身
+    // 文档，注入在那里）。扩展里弹窗挂在宿主页的 shadow root，上面把 --dict-columns 连同其它
+    // theme 变量 setProperty 到 #entries-container（c）——masonry 读 documentElement 读不到 →
+    // 恒 1 列，且 updateEffectiveDictColumns 把 --dict-columns-effective 算成 1 写回
+    // documentElement 又继承进 grid，连 CSS grid 兜底也塌成单列（用户报「浏览器多列不生效」）。
+    // 这里把列数额外落到宿主页 documentElement（与 in-app dictionary_popup_webview 同源、整数
+    // 字符串），让 masonry 读数、effective 收敛、grid 继承三条路径全部命中。命名空间自定义属性，
+    // 宿主页 CSS 不消费，无副作用。
+    const dictCols = theme['--dict-columns'];
+    if (typeof dictCols === 'string' && dictCols) {
+      try {
+        document.documentElement.style.setProperty('--dict-columns', dictCols);
+      } catch (_) { /* 宿主页禁写 style 时静默：多列退化为单列，不崩查词 */ }
+    }
+    // 「滑动关闭」偏好（app enableSwipeToClose）随 theme 下发（'1'/'0'）；置位后弹窗宿主上已挂的
+    // 水平拖关手势才真正关窗（缺该 key = 旧 app，保持关闭，向后兼容）。
+    hibikiSwipeCloseEnabled = theme['--hibiki-swipe-close'] === '1';
     // BUG-688：尺寸盒 + zoom 落到 host（视口坐标，确定宽度 → header 满宽、按钮右推、不再全屏铺开）。
     if (hibikiHost) {
       hibikiHost.style.width = theme['--hibiki-popup-max-width'] || '400px';

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -3088,15 +3088,22 @@ function resetMasonryBody(body) {
 
 function layoutMasonry() {
     if (HAS_NATIVE_MASONRY) return; // 浏览器原生 masonry 时交给 CSS（未来分支）
-    const cols = dictColumns();
+    const configured = dictColumns();
     const gap = masonryGap();
     masonryBodies().forEach(body => {
         const items = [...body.children].filter(c => c.classList.contains('glossary-group'));
-        // 单列 / 单卡：不做 masonry，清 inline 回落 CSS（单卡满宽、单列纵向堆叠 + CSS margin-top）。
-        if (cols <= 1 || items.length <= 1) {
+        // 经典单列（设置=1）或该词条无词典卡：不做 masonry，清 inline 回落 CSS
+        //（block 纵向堆叠 + CSS margin-top / 空容器）。
+        if (configured <= 1 || items.length === 0) {
             resetMasonryBody(body);
             return;
         }
+        // 有效列数封顶到该词条实际的词典卡片数：词典数 < 设置列数时（如上限 2 但只有 1 本），
+        // 现有卡片平分整行宽度——单卡走 cols=1 满宽、2 卡 3 列走 cols=2 各半，不再让右侧空出
+        // 没有卡片的列。cols 每 body 独立计算（不同词条词典数不同）；masonry 仍绝对定位、按
+        // 最短列打包。cols=1 时 columnWidth=整宽、单卡 translate(0,0) 即满宽（取代旧「单卡回落
+        // 半宽 grid」——grid 用全局 --dict-columns 无法感知本词条只有 1 本词典）。
+        const cols = Math.min(configured, items.length);
         body.style.position = 'relative';
         body.style.display = 'block';
         const columnWidth = (body.clientWidth - (cols - 1) * gap) / cols;

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -3088,15 +3088,22 @@ function resetMasonryBody(body) {
 
 function layoutMasonry() {
     if (HAS_NATIVE_MASONRY) return; // 浏览器原生 masonry 时交给 CSS（未来分支）
-    const cols = dictColumns();
+    const configured = dictColumns();
     const gap = masonryGap();
     masonryBodies().forEach(body => {
         const items = [...body.children].filter(c => c.classList.contains('glossary-group'));
-        // 单列 / 单卡：不做 masonry，清 inline 回落 CSS（单卡满宽、单列纵向堆叠 + CSS margin-top）。
-        if (cols <= 1 || items.length <= 1) {
+        // 经典单列（设置=1）或该词条无词典卡：不做 masonry，清 inline 回落 CSS
+        //（block 纵向堆叠 + CSS margin-top / 空容器）。
+        if (configured <= 1 || items.length === 0) {
             resetMasonryBody(body);
             return;
         }
+        // 有效列数封顶到该词条实际的词典卡片数：词典数 < 设置列数时（如上限 2 但只有 1 本），
+        // 现有卡片平分整行宽度——单卡走 cols=1 满宽、2 卡 3 列走 cols=2 各半，不再让右侧空出
+        // 没有卡片的列。cols 每 body 独立计算（不同词条词典数不同）；masonry 仍绝对定位、按
+        // 最短列打包。cols=1 时 columnWidth=整宽、单卡 translate(0,0) 即满宽（取代旧「单卡回落
+        // 半宽 grid」——grid 用全局 --dict-columns 无法感知本词条只有 1 本词典）。
+        const cols = Math.min(configured, items.length);
         body.style.position = 'relative';
         body.style.display = 'block';
         const columnWidth = (body.clientWidth - (cols - 1) * gap) / cols;

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -2327,6 +2327,11 @@ class AppModel with ChangeNotifier {
       '--hibiki-popup-max-height': '${popupMaxHeight.round()}px',
       '--hibiki-popup-zoom': zoom.toStringAsFixed(4),
       '--dict-columns': '$popupDictionaryColumns',
+      // 「滑动关闭查词弹窗」偏好（enableSwipeToClose）下发给扩展 content.js：非 CSS 变量、
+      // 仅 JS 消费（content.js 据此决定是否给浮动弹窗启用水平拖关手势）。走 theme 传输通道
+      // 与 --hibiki-color-scheme 同法（那个也被当 data-theme 而非 CSS 值消费）。值 '1'/'0'。
+      '--hibiki-swipe-close':
+          ReaderHibikiSource.instance.enableSwipeToClose ? '1' : '0',
     };
   }
 

--- a/hibiki/test/lookup/browser_extension_dict_columns_swipe_guard_test.dart
+++ b/hibiki/test/lookup/browser_extension_dict_columns_swipe_guard_test.dart
@@ -1,0 +1,84 @@
+// 浏览器扩展查词弹窗两处 app-parity 回归守卫（用户报「浏览器上多列不生效 + 滑动关闭没反应」）：
+//
+//  1) 多列词典：server 的 browserExtensionThemeColors() 早已随 theme 下发 --dict-columns，但
+//     content.js 把每个 theme key setProperty 到 shadow 内的 #entries-container，而 popup.js 的
+//     masonry dictColumns() / updateEffectiveDictColumns() 从 document.documentElement 读
+//     --dict-columns（in-app 时那就是弹窗自身文档）。扩展里 documentElement 是宿主页 html，读不到
+//     → 恒 1 列（连 CSS grid 也因 effective 算成 1 而单列）。修法：content.js 额外把 --dict-columns
+//     落到 document.documentElement，让 masonry 读数 / effective 收敛 / grid 继承三条路径命中。
+//
+//  2) 滑动关闭：app 的 enableSwipeToClose 偏好此前未随 theme 下发，扩展浮动弹窗也没有任何拖手势
+//     （只 mousedown 点外部关窗）。修法：browserExtensionThemeColors() 下发 --hibiki-swipe-close
+//     ('1'/'0')，content.js 据此在弹窗宿主上启用水平拖关手势（设置项文案即「水平滑动关闭查词弹窗」）。
+//
+// 纯源码不变量（CI 只跑 .dart）。两 content.js 镜像的字节一致由
+// browser_extension_dict_media_mirror_guard_test.dart 另行守卫；真实手感待桌面/真机复测。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('browser extension dict-columns + swipe-close app parity', () {
+    test('browserExtensionThemeColors 下发 --dict-columns 与 --hibiki-swipe-close',
+        () {
+      final String src =
+          File('lib/src/models/app_model.dart').readAsStringSync();
+      expect(src, contains('browserExtensionThemeColors()'),
+          reason: 'app_model.dart 应存在 browserExtensionThemeColors()');
+      // 多列：列数（popupDictionaryColumns）随 theme 下发。
+      expect(src, contains("'--dict-columns': '\$popupDictionaryColumns'"),
+          reason: 'theme 必须下发 --dict-columns（扩展多列布局的列数来源）');
+      // 滑动关闭：把 enableSwipeToClose 偏好以 '1'/'0' 随 theme 下发给 content.js。
+      expect(src, contains("'--hibiki-swipe-close'"),
+          reason: 'theme 必须下发 --hibiki-swipe-close 供 content.js 决定是否启用拖关手势');
+      expect(
+          RegExp(r'ReaderHibikiSource\.instance\.enableSwipeToClose\s*\?\s*'
+                  "'1'\\s*:\\s*'0'")
+              .hasMatch(src),
+          isTrue,
+          reason: '--hibiki-swipe-close 值必须取自 enableSwipeToClose 偏好（1/0）');
+    });
+
+    test(
+        'content.js 把 --dict-columns 落到 document.documentElement（masonry 才读得到）',
+        () {
+      final String js =
+          File('assets/browser_extension/content.js').readAsStringSync();
+      // 从 theme 取列数并写到宿主页 documentElement：这是让 popup.js masonry/effective 读到的关键。
+      expect(js, contains("theme['--dict-columns']"),
+          reason: 'content.js 必须从下发的 theme 读 --dict-columns');
+      expect(
+          RegExp(r'document\.documentElement\.style\.setProperty\(\s*'
+                  r"'--dict-columns'")
+              .hasMatch(js),
+          isTrue,
+          reason: 'content.js 必须把 --dict-columns 写到 document.documentElement，'
+              '否则 popup.js masonry 从 documentElement 读不到 → 恒单列（用户报的多列不生效）');
+    });
+
+    test('content.js 读 --hibiki-swipe-close 并装水平拖关手势', () {
+      final String js =
+          File('assets/browser_extension/content.js').readAsStringSync();
+      // 偏好门控标志：只有开启才真正关窗。
+      expect(js, contains("theme['--hibiki-swipe-close']"),
+          reason: 'content.js 必须读 app 下发的 --hibiki-swipe-close 偏好');
+      expect(js, contains('hibikiSwipeCloseEnabled'),
+          reason: '必须有门控标志 hibikiSwipeCloseEnabled（关时纯 no-op）');
+      // 手势安装函数存在、挂在弹窗宿主上、并调 hibikiRemoveContainer 关窗。
+      expect(js, contains('function hibikiInstallSwipeClose('),
+          reason: '必须有水平拖关手势安装函数 hibikiInstallSwipeClose');
+      expect(js, contains('hibikiInstallSwipeClose(hibikiHost)'),
+          reason: '手势必须挂到弹窗宿主 hibikiHost 上');
+      // 水平主导判据 + 过阈才关（避免竖向滚动/选区误触）。
+      expect(js, contains('HIBIKI_SWIPE_CLOSE_THRESHOLD'),
+          reason: '必须有水平拖关阈值常量');
+      expect(js, contains('hibikiRemoveContainer()'),
+          reason: '过阈后必须调 hibikiRemoveContainer() 真正关窗');
+      // pointer（桌面鼠标）+ touch（移动浏览器）双家族，且 pointer 路径排除 touch 避免双触发。
+      expect(js, contains("addEventListener('pointerdown'"),
+          reason: '桌面鼠标走 pointer 路径');
+      expect(js, contains("addEventListener('touchstart'"),
+          reason: '移动浏览器走 touch 路径');
+    });
+  });
+}

--- a/hibiki/test/reader/popup_dict_masonry_guard_test.dart
+++ b/hibiki/test/reader/popup_dict_masonry_guard_test.dart
@@ -8,9 +8,11 @@ import 'package:flutter_test/flutter_test.dart';
 /// 同行卡片被最高者顶到同一水平线、矮卡片下方留空白）。
 ///
 /// 实现取舍（见 popup.js 注释）：CSS grid 规则原样保留作「无 JS 兜底」，masonry 是叠在
-/// grid 之上的运行时 inline-style 覆盖层——`--dict-columns > 1` 且多卡时接管绝对定位，
-/// `<=1` 或单卡时清 inline 回落 grid/block。因此这里锁 popup.js 的 masonry 不变量，而
-/// popup.css 的 grid 守卫（popup_dict_card_guard / popup_dictionary_columns）不受影响。
+/// grid 之上的运行时 inline-style 覆盖层——设置列数 `--dict-columns > 1` 且该词条至少有 1 本
+/// 词典时接管绝对定位，有效列数封顶到实际卡片数 `min(设置列数, 卡片数)`（词典数 < 列数时
+/// 现有卡片平分整行、单卡满宽）；设置=1（经典单列）或无卡时清 inline 回落 grid/block。
+/// 因此这里锁 popup.js 的 masonry 不变量，而 popup.css 的 grid 守卫（popup_dict_card_guard /
+/// popup_dictionary_columns）不受影响。
 ///
 /// 纯源码不变量（CI 只跑 .dart，node 守卫 CI 不跑），故在 Dart 层断言以进 CI 真跑；
 /// 真实排列观感另由桌面离屏真机复测（reader/popup 布局问题的验证纪律）。
@@ -67,13 +69,25 @@ void main() {
         reason: 'resetMasonryBody 必须清粘着列记录，避免陈旧列号跨单列/多列切换复用');
   });
 
-  test('单列 / 单卡回落 CSS 兜底：cols<=1 或 items<=1 时清 inline', () {
+  test('回落条件：设置=1（经典单列）或无卡才清 inline，单卡不再回落半宽 grid', () {
     expect(
-        RegExp(r'cols\s*<=\s*1\s*\|\|\s*items\.length\s*<=\s*1').hasMatch(js),
+        RegExp(r'configured\s*<=\s*1\s*\|\|\s*items\.length\s*===\s*0')
+            .hasMatch(js),
         isTrue,
-        reason: '单列或单卡不做 masonry，清 inline 回落 CSS grid/block（不破坏单卡满宽 / 单列纵堆）');
+        reason: '只有设置列数=1 或该词条无词典卡才回落 CSS grid/block；'
+            '单卡改由 masonry cols=1 满宽承载，不再落进 N 列 grid 只占 1/N 宽');
     expect(js.contains('function resetMasonryBody('), isTrue,
         reason: '回落时必须清掉 position/width/transform/height 等 inline，让 CSS 接管');
+  });
+
+  test('有效列数封顶到词典卡片数：词典数 < 设置列数时现有卡片平分整行（单卡满宽）', () {
+    // 核心新契约：cols = min(设置列数, 该词条实际词典卡片数)。上限 2 但只有 1 本 → cols=1
+    // → columnWidth 取整宽、单卡满宽；2 卡 3 列 → cols=2 各半，右侧不再空出无卡的列。
+    expect(
+        RegExp(r'Math\.min\(\s*configured\s*,\s*items\.length\s*\)')
+            .hasMatch(js),
+        isTrue,
+        reason: '有效列数必须 min(设置列数, 卡片数)，卡片才会平分整行、不留空列');
   });
 
   test('高度变化用 ResizeObserver 兜底（<details> 折叠 / 图片异步 / ruby / 字体）', () {

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -839,6 +839,62 @@ try {
   });
 } catch (_) {}
 
+// 「滑动关闭查词弹窗」——app 的 enableSwipeToClose 偏好经查词响应 theme 的
+// --hibiki-swipe-close（'1'/'0'）下发；in-app 走 Flutter 手势层 / WebView topPullReleased，
+// 扩展的浮动弹窗是纯 DOM，这里在弹窗宿主上装同语义的**水平拖关**手势（设置项文案即「水平
+// 滑动关闭查词弹窗」）。默认 Windows/Linux 关（鼠标框选正文与拖手势同形易误触），跟随 app 偏好。
+let hibikiSwipeCloseEnabled = false;
+let hibikiSwipeStart = null;
+// 水平拖过此像素即关（固定阈值；in-app 的灵敏度滑块暂不移植，待真机再定是否需要）。
+const HIBIKI_SWIPE_CLOSE_THRESHOLD = 64;
+
+// 在弹窗宿主 [host] 上装水平拖关手势（每个 host 只装一次）。监听始终挂上，是否真正关窗由
+// hibikiSwipeCloseEnabled 门控（theme 到达后置位）→ 关时纯 no-op，开时水平主导且过阈才关。
+// pointer 路径只接 mouse/pen（touch 由 touch 家族处理，避免同一次拖动双触发）；全部 passive。
+function hibikiInstallSwipeClose(host) {
+  if (!host || host.__hibikiSwipeHooked) return;
+  host.__hibikiSwipeHooked = true;
+  const start = (x, y) => { hibikiSwipeStart = { x: x, y: y }; };
+  const move = (x, y) => {
+    if (!hibikiSwipeCloseEnabled || !hibikiSwipeStart) return;
+    const dx = x - hibikiSwipeStart.x;
+    const dy = y - hibikiSwipeStart.y;
+    // 水平主导（|dx| > 1.5·|dy|，避开竖向滚动/选竖排）且过阈 → 关。
+    if (Math.abs(dx) > HIBIKI_SWIPE_CLOSE_THRESHOLD &&
+        Math.abs(dx) > Math.abs(dy) * 1.5) {
+      hibikiSwipeStart = null;
+      hibikiRemoveContainer();
+    }
+  };
+  const end = () => { hibikiSwipeStart = null; };
+  host.addEventListener('pointerdown', (e) => {
+    if (e.pointerType === 'touch') return;
+    if (e.button !== undefined && e.button !== 0) return;
+    start(e.clientX, e.clientY);
+  }, { passive: true });
+  host.addEventListener('pointermove', (e) => {
+    if (e.pointerType === 'touch') return;
+    move(e.clientX, e.clientY);
+  }, { passive: true });
+  host.addEventListener('pointerup', (e) => {
+    if (e.pointerType === 'touch') return;
+    end();
+  }, { passive: true });
+  host.addEventListener('pointercancel', (e) => {
+    if (e.pointerType === 'touch') return;
+    end();
+  }, { passive: true });
+  host.addEventListener('touchstart', (e) => {
+    if (!e.touches || e.touches.length !== 1) return;
+    start(e.touches[0].clientX, e.touches[0].clientY);
+  }, { passive: true });
+  host.addEventListener('touchmove', (e) => {
+    if (!e.touches || e.touches.length !== 1) return;
+    move(e.touches[0].clientX, e.touches[0].clientY);
+  }, { passive: true });
+  host.addEventListener('touchend', end, { passive: true });
+}
+
 function hibikiEnsureContainer() {
   // BUG-530：全屏时（Netflix 看片常全屏）挂在 document.body 上的弹窗会被全屏元素盖住看不见
   // （浏览器全屏只渲染 fullscreenElement 及其后代）→ shift 划词其实触发了但弹窗不可见=「没反应」。
@@ -858,6 +914,7 @@ function hibikiEnsureContainer() {
     // 按查词响应下发的 --hibiki-popup-* 设置；#entries-container 在 shadow 内中和为 width:100%。
     hibikiHost.style.cssText =
         'position:fixed;top:0;left:0;z-index:2147483647;overflow-x:hidden;overflow-y:auto;';
+    hibikiInstallSwipeClose(hibikiHost); // 水平拖关手势（是否生效由 hibikiSwipeCloseEnabled 门控）
     const shadow = hibikiHost.attachShadow({ mode: 'open' });
     // 中和 content.css 里 #entries-container 自带的尺寸盒/zoom（那套是给「容器自身即 fixed 元素」
     // 的旧模型用的）；现在 host 才是尺寸/缩放/定位主体，容器只做 100% 透传。
@@ -1199,6 +1256,24 @@ function hibikiRender(popupJson, termLen, theme, anchorRect) {
     // （用户报「和 app 内完全不一样」：黑底 + 米卡 + 灰字）。主题单一来源于 app，与 in-app 一致。
     const cs = theme['--hibiki-color-scheme'];
     if (cs === 'dark' || cs === 'light') c.setAttribute('data-theme', cs);
+    // 多列词典（masonry）根因修：popup.js 的 dictColumns() 与 updateEffectiveDictColumns()
+    // 都从 document.documentElement 读 --dict-columns（in-app 时 documentElement 就是弹窗自身
+    // 文档，注入在那里）。扩展里弹窗挂在宿主页的 shadow root，上面把 --dict-columns 连同其它
+    // theme 变量 setProperty 到 #entries-container（c）——masonry 读 documentElement 读不到 →
+    // 恒 1 列，且 updateEffectiveDictColumns 把 --dict-columns-effective 算成 1 写回
+    // documentElement 又继承进 grid，连 CSS grid 兜底也塌成单列（用户报「浏览器多列不生效」）。
+    // 这里把列数额外落到宿主页 documentElement（与 in-app dictionary_popup_webview 同源、整数
+    // 字符串），让 masonry 读数、effective 收敛、grid 继承三条路径全部命中。命名空间自定义属性，
+    // 宿主页 CSS 不消费，无副作用。
+    const dictCols = theme['--dict-columns'];
+    if (typeof dictCols === 'string' && dictCols) {
+      try {
+        document.documentElement.style.setProperty('--dict-columns', dictCols);
+      } catch (_) { /* 宿主页禁写 style 时静默：多列退化为单列，不崩查词 */ }
+    }
+    // 「滑动关闭」偏好（app enableSwipeToClose）随 theme 下发（'1'/'0'）；置位后弹窗宿主上已挂的
+    // 水平拖关手势才真正关窗（缺该 key = 旧 app，保持关闭，向后兼容）。
+    hibikiSwipeCloseEnabled = theme['--hibiki-swipe-close'] === '1';
     // BUG-688：尺寸盒 + zoom 落到 host（视口坐标，确定宽度 → header 满宽、按钮右推、不再全屏铺开）。
     if (hibikiHost) {
       hibikiHost.style.width = theme['--hibiki-popup-max-width'] || '400px';

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -3088,15 +3088,22 @@ function resetMasonryBody(body) {
 
 function layoutMasonry() {
     if (HAS_NATIVE_MASONRY) return; // 浏览器原生 masonry 时交给 CSS（未来分支）
-    const cols = dictColumns();
+    const configured = dictColumns();
     const gap = masonryGap();
     masonryBodies().forEach(body => {
         const items = [...body.children].filter(c => c.classList.contains('glossary-group'));
-        // 单列 / 单卡：不做 masonry，清 inline 回落 CSS（单卡满宽、单列纵向堆叠 + CSS margin-top）。
-        if (cols <= 1 || items.length <= 1) {
+        // 经典单列（设置=1）或该词条无词典卡：不做 masonry，清 inline 回落 CSS
+        //（block 纵向堆叠 + CSS margin-top / 空容器）。
+        if (configured <= 1 || items.length === 0) {
             resetMasonryBody(body);
             return;
         }
+        // 有效列数封顶到该词条实际的词典卡片数：词典数 < 设置列数时（如上限 2 但只有 1 本），
+        // 现有卡片平分整行宽度——单卡走 cols=1 满宽、2 卡 3 列走 cols=2 各半，不再让右侧空出
+        // 没有卡片的列。cols 每 body 独立计算（不同词条词典数不同）；masonry 仍绝对定位、按
+        // 最短列打包。cols=1 时 columnWidth=整宽、单卡 translate(0,0) 即满宽（取代旧「单卡回落
+        // 半宽 grid」——grid 用全局 --dict-columns 无法感知本词条只有 1 本词典）。
+        const cols = Math.min(configured, items.length);
         body.style.position = 'relative';
         body.style.display = 'block';
         const columnWidth = (body.clientWidth - (cols - 1) * gap) / cols;


### PR DESCRIPTION
查词弹窗词典多列布局的三处修复（in-app + 浏览器扩展）。

## 1. in-app：词典数少于设置列数时卡片平分整行（单卡满宽）
每词条词典盒容器两层布局：CSS grid 兜底用全局 `--dict-columns`（不感知本词条几本词典），masonry `layoutMasonry()` 是真实渲染层。旧逻辑 `cols<=1||items.length<=1` 单卡回落 CSS grid → grid 仍 N 列 → 单卡只占 1/N 宽。
**修**：masonry 有效列数封顶到实际卡片数 `cols=Math.min(configured, items.length)`（per-body）。单卡 cols=1 满宽，2 卡 3 列各半，经典单列/无卡仍回落 CSS。

## 2. 扩展：浏览器上多列不生效
server `browserExtensionThemeColors()` 早已随 theme 下发 `--dict-columns`，但 content.js 把它 setProperty 到 shadow 内 `#entries-container`，而 popup.js masonry 从宿主页 `document.documentElement` 读 → 读不到 → 恒 1 列（连 grid 也因 effective 算成 1 而单列）。
**修**：content.js 额外把 `--dict-columns` 落到 `document.documentElement`，让 masonry 读数 / effective 收敛 / grid 继承三条路径命中。

## 3. 扩展：滑动关闭没反应
in-app 走 Flutter 手势层 / WebView `topPullReleased` 桥，扩展浮动弹窗纯 DOM、无此桥也无任何拖手势。
**修**：`browserExtensionThemeColors()` 新增下发 `--hibiki-swipe-close`（取自 `enableSwipeToClose` 偏好，'1'/'0'）；content.js 在弹窗宿主上装水平拖关手势（pointer 覆盖桌面鼠标 + touch 覆盖移动浏览器，水平主导且过 64px 阈才关，门控在该偏好）。设置项文案即「水平滑动关闭查词弹窗」，方向取水平。

## 影响面 & 验证
- popup.js 三镜像 & content.js 两镜像 byte-identical（各有 parity 守卫）；popup.css 未改，content.css 无需重生成。
- 新增/更新守卫：`popup_dict_masonry_guard`（min 封顶+回落条件新契约）、`browser_extension_dict_columns_swipe_guard`（两条扩展契约）。
- 全量 `flutter analyze` 无问题；masonry + 扩展 theme/parity/mirror 守卫共 148 项测试全过；两 content.js `node --check` 语法 OK。
- **假设**：扩展拖关阈值固定 64px、暂不移植 in-app 灵敏度滑块。
- **真实观感（单卡满宽 / 扩展多列 / 扩展水平拖关）待桌面离屏 + 真机复测**（reader/popup 布局验证纪律）。