### PR TITLE
feat(danmaku): 弹幕 overlay 默认关闭

### DIFF
--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -772,9 +772,9 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// 视频弹幕 overlay 开关：默认开启，只在有本地/在线弹幕源时显示。
+  /// 视频弹幕 overlay 开关：**默认关闭**，用户显式开启后才显示（且需有本地/在线弹幕源）。
   bool get videoDanmakuEnabled =>
-      getPref('video_danmaku_enabled', defaultValue: true) as bool;
+      getPref('video_danmaku_enabled', defaultValue: false) as bool;
 
   Future<void> setVideoDanmakuEnabled(bool value) async {
     await setPref('video_danmaku_enabled', value);

--- a/hibiki/test/media/video/video_danmaku_settings_test.dart
+++ b/hibiki/test/media/video/video_danmaku_settings_test.dart
@@ -28,8 +28,9 @@ void main() {
       await db.close();
     });
 
-    test('defaults enable local sidecar MVP with a bounded active limit', () {
-      expect(repo.videoDanmakuEnabled, isTrue);
+    test('danmaku overlay defaults OFF with a bounded active limit', () {
+      expect(repo.videoDanmakuEnabled, isFalse,
+          reason: '弹幕默认关闭，用户显式开启后才显示');
       expect(repo.videoDanmakuMaxActive, kDefaultVideoDanmakuMaxActive);
     });
 


### PR DESCRIPTION
## 改动
把视频弹幕主开关 `video_danmaku_enabled` 默认值 **true→false**：弹幕默认关闭,用户在设置页/播放页显式开启后才显示;在线匹配 `video_danmaku_online_enabled` 仍受此主开关门控,主关则不发任何 dandanplay 请求。

## 验证
- `flutter analyze`:No issues found。
- danmaku 相关测试全绿(已更新默认值断言 isTrue→isFalse)。

## 备注(与本 PR 无关,给你参考)
你遇到的「搜索失败,请稍后重试」不是 bug:实测未签名请求 → dandanplay 返回 403 `Missing Authentication Headers`。根因是当前构建里内置的 dandanplay AppId/AppSecret 还是**空占位**。需把真值编进构建(填 `dandanplay_secret.dart` + skip-worktree,或加 `DANDANPLAY_APP_ID`/`DANDANPLAY_APP_SECRET` GitHub secrets)后重新构建,搜索/在线弹幕才会通。