### PR TITLE
fix(video): 分类tab换行 + \blur对齐mpv + 内嵌字体加载

### DIFF
--- a/hibiki/lib/src/media/video/subtitle_embedded_fonts.dart
+++ b/hibiki/lib/src/media/video/subtitle_embedded_fonts.dart
@@ -1,0 +1,337 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show FontLoader;
+import 'package:hibiki/src/media/video/ffmpeg_backend.dart';
+import 'package:hibiki/src/utils/misc/error_log_service.dart';
+import 'package:path/path.dart' as p;
+
+/// 视频容器（MKV 等）里的一条字体附件（attachment stream）的最小描述。
+///
+/// [attachmentOrdinal] 是**附件流之间的相对序号**（0 基），对应 ffmpeg
+/// `-dump_attachment:t:<ordinal>` 的 `t:` 索引；不是 ffprobe 的绝对 `index`。
+class EmbeddedFontAttachment {
+  const EmbeddedFontAttachment({
+    required this.attachmentOrdinal,
+    required this.fileName,
+  });
+
+  final int attachmentOrdinal;
+
+  /// 附件的原始文件名（`tags.filename`，可能缺失 → 兜底 `attachment_<n>`）。
+  /// 仅用于给抽出的临时文件挑扩展名，字体真实 family 名一律从 sfnt name 表解析。
+  final String fileName;
+}
+
+/// 从 ffprobe（`-select_streams t -show_streams -print_format json`）的 JSON 输出里
+/// 解析出**字体**附件流列表（纯函数，可单测）。判据：`codec_type == attachment` 且
+/// （`codec_name` 是 ttf/otf/…，或 `tags.mimetype` 是字体 MIME，或 `tags.filename`
+/// 扩展名是字体扩展名）。非字体附件（字幕引用的封面图等）跳过。解析失败返回空列表
+/// （诚实降级，不抛）。
+List<EmbeddedFontAttachment> parseFfprobeFontAttachments(String jsonText) {
+  if (jsonText.trim().isEmpty) return const <EmbeddedFontAttachment>[];
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(jsonText);
+  } catch (_) {
+    return const <EmbeddedFontAttachment>[];
+  }
+  if (decoded is! Map) return const <EmbeddedFontAttachment>[];
+  final Object? streams = decoded['streams'];
+  if (streams is! List) return const <EmbeddedFontAttachment>[];
+
+  final List<EmbeddedFontAttachment> result = <EmbeddedFontAttachment>[];
+  int ordinal = 0; // 附件流相对序号（只在 attachment 流上递增）。
+  for (final Object? s in streams) {
+    if (s is! Map) continue;
+    if (s['codec_type'] != 'attachment') continue;
+    final int thisOrdinal = ordinal;
+    ordinal++;
+
+    final String codecName = (s['codec_name'] as String? ?? '').toLowerCase();
+    final Object? tagsObj = s['tags'];
+    final Map<Object?, Object?> tags =
+        tagsObj is Map ? tagsObj : const <Object?, Object?>{};
+    final String fileName =
+        (tags['filename'] as String? ?? tags['FILENAME'] as String? ?? '')
+            .trim();
+    final String mime =
+        (tags['mimetype'] as String? ?? tags['MIMETYPE'] as String? ?? '')
+            .toLowerCase();
+
+    if (_isFontAttachment(
+      codecName: codecName,
+      mimetype: mime,
+      fileName: fileName,
+    )) {
+      result.add(EmbeddedFontAttachment(
+        attachmentOrdinal: thisOrdinal,
+        fileName: fileName.isEmpty ? 'attachment_$thisOrdinal' : fileName,
+      ));
+    }
+  }
+  return result;
+}
+
+/// 字体附件判据：codec 名 / MIME / 文件名扩展名任一命中字体即可。
+bool _isFontAttachment({
+  required String codecName,
+  required String mimetype,
+  required String fileName,
+}) {
+  const Set<String> fontCodecs = <String>{'ttf', 'otf', 'sfnt'};
+  if (fontCodecs.contains(codecName)) return true;
+  // 常见字体 MIME（各 muxer 写法不一）。
+  if (mimetype.contains('font') ||
+      mimetype == 'application/x-truetype-font' ||
+      mimetype == 'application/vnd.ms-opentype' ||
+      mimetype == 'application/x-font-ttf' ||
+      mimetype == 'application/x-font-otf') {
+    return true;
+  }
+  final String ext = p.extension(fileName).toLowerCase();
+  return ext == '.ttf' || ext == '.otf' || ext == '.ttc';
+}
+
+/// 从 sfnt 字体字节（ttf/otf/ttc）解析所有声明的 **family 名**（纯函数，可单测）。
+///
+/// 读 `name` 表的 nameID 1（Family）与 16（Typographic/Preferred Family）——ASS `Fontname`
+/// 对应的正是字体内部声明的 family 名，附件的**文件名往往与之不同**（如
+/// `matisse.otf` vs `FOT-Matisse ProN B`），必须以 name 表为准才能把附件注册成 ASS 能
+/// 命中的 family。TTC（`ttcf`）遍历其中每个子字体。任何越界 / 格式异常静默跳过、返回已
+/// 解析到的名字（诚实降级，绝不抛）。
+Set<String> parseSfntFamilyNames(Uint8List bytes) {
+  final Set<String> out = <String>{};
+  try {
+    if (bytes.length < 12) return out;
+    final ByteData data = ByteData.sublistView(bytes);
+    final int tag = data.getUint32(0);
+    const int ttcfTag = 0x74746366; // 'ttcf'
+    if (tag == ttcfTag) {
+      // TTC 头：'ttcf'(4) major(2) minor(2) numFonts(uint32@8) offsets[numFonts]。
+      if (bytes.length < 12) return out;
+      final int numFonts = data.getUint32(8);
+      for (int i = 0; i < numFonts; i++) {
+        final int offPos = 12 + i * 4;
+        if (offPos + 4 > bytes.length) break;
+        final int fontOffset = data.getUint32(offPos);
+        _parseSfntNameTableAt(data, bytes.length, fontOffset, out);
+      }
+    } else {
+      _parseSfntNameTableAt(data, bytes.length, 0, out);
+    }
+  } catch (_) {
+    // 越界 / 非法字体：返回已解析到的（可能为空），不抛。
+  }
+  return out;
+}
+
+/// 解析从 [base] 偏移开始的单个 sfnt 表目录里的 `name` 表，family 名并入 [out]。
+void _parseSfntNameTableAt(
+  ByteData data,
+  int length,
+  int base,
+  Set<String> out,
+) {
+  if (base + 12 > length) return;
+  final int numTables = data.getUint16(base + 4);
+  int nameOffset = -1;
+  for (int i = 0; i < numTables; i++) {
+    final int rec = base + 12 + i * 16;
+    if (rec + 16 > length) return;
+    final int recTag = data.getUint32(rec);
+    const int nameTag = 0x6E616D65; // 'name'
+    if (recTag == nameTag) {
+      nameOffset = data.getUint32(rec + 8);
+      break;
+    }
+  }
+  if (nameOffset < 0 || nameOffset + 6 > length) return;
+
+  final int count = data.getUint16(nameOffset + 2);
+  final int stringStorage = nameOffset + data.getUint16(nameOffset + 4);
+  for (int i = 0; i < count; i++) {
+    final int rec = nameOffset + 6 + i * 12;
+    if (rec + 12 > length) return;
+    final int platformId = data.getUint16(rec);
+    final int nameId = data.getUint16(rec + 6);
+    // 只要 Family(1) 与 Typographic Family(16)。
+    if (nameId != 1 && nameId != 16) continue;
+    final int strLen = data.getUint16(rec + 8);
+    final int strOff = stringStorage + data.getUint16(rec + 10);
+    if (strLen <= 0 || strOff + strLen > length) continue;
+    final Uint8List raw =
+        data.buffer.asUint8List(data.offsetInBytes + strOff, strLen);
+    final String? name = _decodeNameRecord(platformId, raw);
+    if (name != null && name.trim().isNotEmpty) out.add(name.trim());
+  }
+}
+
+/// 按 platformID 解码 name 记录字节：Windows(3)/Unicode(0) 是 UTF-16BE；Mac(1) 近似
+/// Latin1（ASCII 安全，日文 Mac 记录罕见，解不出就交给 UTF-16 记录兜底）。
+String? _decodeNameRecord(int platformId, Uint8List raw) {
+  try {
+    if (platformId == 3 || platformId == 0) {
+      // UTF-16BE。
+      if (raw.length.isOdd) return null;
+      final StringBuffer sb = StringBuffer();
+      for (int i = 0; i + 1 < raw.length; i += 2) {
+        sb.writeCharCode((raw[i] << 8) | raw[i + 1]);
+      }
+      return sb.toString();
+    }
+    // Mac / 其它：Latin1 兜底。
+    return latin1.decode(raw, allowInvalid: true);
+  } catch (_) {
+    return null;
+  }
+}
+
+/// 从视频容器抽取内嵌字体附件、注册进 Flutter 引擎，供自绘字幕 overlay 按 ASS
+/// `Fontname` 命中真实字体（对齐 mpv/libass 的 attachment 字体加载）。
+///
+/// 背景：Hibiki 自绘渲染字幕（为逐字查词，不走 libass），故不像 mpv 那样自动加载 MKV
+/// 内嵌字体 → 商用日文字体缺失时 fallback 替换、观感与 mpv 差。本加载器补上这条链路：
+/// ffprobe 枚举附件 → ffmpeg `-dump_attachment` 抽到临时目录 → 解析每个字体的 sfnt
+/// name 表拿 family 名 → [FontLoader] 注册。注册后 overlay 的 `_styleForGrapheme` 用
+/// `cue.fontName` 作 `fontFamily` 即可命中（无需改 overlay）。
+///
+/// 降级链（任一失败都不崩、回退系统字体）：非本地文件 / 无 ffmpeg / 无附件 / 解析失败
+/// → 返回空集，overlay 继续走既有 CJK fallback。
+class SubtitleEmbeddedFontLoader {
+  SubtitleEmbeddedFontLoader({FfmpegBackend? backend})
+      : _backend = backend ?? resolveFfmpegBackend();
+
+  final FfmpegBackend _backend;
+
+  /// 已注册的 family 名（[FontLoader] 不能卸载，重复注册无意义）。进程级去重。
+  static final Set<String> _registeredFamilies = <String>{};
+
+  /// 按视频路径缓存本次解析出的 family 名集，避免同一视频反复抽取。
+  final Map<String, Set<String>> _byVideoPath = <String, Set<String>>{};
+
+  static const Duration _probeTimeout = Duration(seconds: 20);
+  static const Duration _dumpTimeout = Duration(seconds: 40);
+
+  /// 为 [videoPath] 加载内嵌字体，返回**成功注册**的 family 名集合（可空）。幂等：
+  /// 同一路径二次调用直接回缓存。非本地存在文件直接返回空集（网络流 / HLS 无附件可抽）。
+  Future<Set<String>> loadForVideo(String videoPath) async {
+    if (videoPath.isEmpty) return const <String>{};
+    final Set<String>? cached = _byVideoPath[videoPath];
+    if (cached != null) return cached;
+
+    final Set<String> families = <String>{};
+    try {
+      if (!File(videoPath).existsSync()) {
+        _byVideoPath[videoPath] = families;
+        return families;
+      }
+      final List<EmbeddedFontAttachment> fonts =
+          await _enumerateFontAttachments(videoPath);
+      if (fonts.isEmpty) {
+        _byVideoPath[videoPath] = families;
+        return families;
+      }
+      final Directory tempDir =
+          await Directory.systemTemp.createTemp('hibiki_subfonts_');
+      try {
+        final List<File> extracted =
+            await _dumpAttachments(videoPath, fonts, tempDir);
+        for (final File file in extracted) {
+          await _registerFontFile(file, families);
+        }
+      } finally {
+        // 注册后字节已进引擎，临时文件可删（best-effort）。
+        try {
+          await tempDir.delete(recursive: true);
+        } catch (_) {}
+      }
+    } catch (e, stack) {
+      ErrorLogService.instance
+          .log('SubtitleEmbeddedFontLoader.loadForVideo', e, stack);
+    }
+    _byVideoPath[videoPath] = families;
+    return families;
+  }
+
+  /// ffprobe 枚举字体附件流（JSON）。失败返回空列表。
+  Future<List<EmbeddedFontAttachment>> _enumerateFontAttachments(
+    String videoPath,
+  ) async {
+    final FfmpegRunResult probe = await _backend.runProbe(
+      <String>[
+        '-v', 'quiet',
+        '-print_format', 'json',
+        '-show_streams',
+        '-select_streams', 't', // 只列附件流。
+        videoPath,
+      ],
+      _probeTimeout,
+    );
+    if (!probe.isSuccess) return const <EmbeddedFontAttachment>[];
+    return parseFfprobeFontAttachments(probe.output);
+  }
+
+  /// 一次 ffmpeg 调用把所有字体附件抽到 [tempDir]（`-dump_attachment:t:<ordinal>`）。
+  /// ffmpeg 无输出文件会以非 0 退出但**附件已在输入解析阶段写盘**，故不看退出码，只收集
+  /// 真正写出的文件。
+  Future<List<File>> _dumpAttachments(
+    String videoPath,
+    List<EmbeddedFontAttachment> fonts,
+    Directory tempDir,
+  ) async {
+    final List<String> args = <String>['-y'];
+    final List<File> targets = <File>[];
+    for (final EmbeddedFontAttachment font in fonts) {
+      final String ext = _fontExtension(font.fileName);
+      final File out = File(p.join(
+        tempDir.path,
+        'font_${font.attachmentOrdinal}$ext',
+      ));
+      args
+        ..add('-dump_attachment:t:${font.attachmentOrdinal}')
+        ..add(out.path);
+      targets.add(out);
+    }
+    args
+      ..add('-i')
+      ..add(videoPath);
+    // 退出码忽略（无输出文件恒非 0）；只认写出的文件。
+    await _backend.run(args, _dumpTimeout);
+    return <File>[
+      for (final File f in targets)
+        if (f.existsSync() && f.lengthSync() > 0) f,
+    ];
+  }
+
+  /// 读字体文件 → 解析 family 名 → 按每个 family 名注册（同字节可挂多名）。
+  Future<void> _registerFontFile(File file, Set<String> families) async {
+    final Uint8List bytes = await file.readAsBytes();
+    final Set<String> names = parseSfntFamilyNames(bytes);
+    if (names.isEmpty) return;
+    for (final String family in names) {
+      families.add(family);
+      if (_registeredFamilies.contains(family)) continue;
+      try {
+        final FontLoader loader = FontLoader(family)
+          ..addFont(Future<ByteData>.value(
+            bytes.buffer.asByteData(bytes.offsetInBytes, bytes.lengthInBytes),
+          ));
+        await loader.load();
+        _registeredFamilies.add(family);
+      } catch (e, stack) {
+        ErrorLogService.instance
+            .log('SubtitleEmbeddedFontLoader.register($family)', e, stack);
+      }
+    }
+  }
+
+  /// 附件文件名的字体扩展名，缺失/异常回退 `.ttf`（仅决定临时文件名，不影响解析）。
+  String _fontExtension(String fileName) {
+    final String ext = p.extension(fileName).toLowerCase();
+    if (ext == '.ttf' || ext == '.otf' || ext == '.ttc') return ext;
+    return '.ttf';
+  }
+}

--- a/hibiki/lib/src/media/video/video_quick_settings_sheet.dart
+++ b/hibiki/lib/src/media/video/video_quick_settings_sheet.dart
@@ -590,38 +590,38 @@ class _VideoQuickSettingsSheetState extends State<VideoQuickSettingsSheet> {
     ];
   }
 
-  /// 宽窗顶部横向分类条（TODO-556 / TODO-1351）：大分类用横滑 chip 行，固定在 sheet
-  /// 顶部、不随下方详情滚动；放不下时横向滚动（与窄窗 push 的导航行、宽窗左栏不同）。
-  /// 选中 chip 高亮，点击切下方详情。
+  /// 宽窗顶部分类条（TODO-556 / TODO-1351 / BUG：末位分类被裁）：大分类用 chip 行，固定
+  /// 在 sheet 顶部、不随下方详情滚动；选中 chip 高亮，点击切下方详情。
   ///
-  /// TODO-1351（用户复诉）：分类 tab 必须「图标 + 完整文字」显示（参考「检查器」式
-  /// tab），不得截成省略号、也不得压成纯图标 + tooltip（TODO-640 曾为省顶栏空间改
-  /// 仅图标，用户要求恢复完整文字标签）。标签经
-  /// [HibikiSelectableChip.allowLabelOverflow] 按固有宽度完整渲染（无 ellipsis），
-  /// 顶栏放不下时整条横向滚动——窄窗 / 高 UI scale 下可横滑，单个标签永不截断。
+  /// **放不下时换行堆叠**（[Wrap]）而非横向滚动裁断（用户报「弹幕 / 控制 分类被截在视口
+  /// 外、看不全」）。旧实现用横向 [SingleChildScrollView] + [Row]：视口装不下 7 个「图标 +
+  /// 完整文字」chip 时，末位分类被推到视口右侧外、无滚动条提示，用户不知还有分类、也点不
+  /// 到。改 [Wrap] 后所有 chip 恒可见：一行放不下就自动折到第二行，宽度越窄行数越多，
+  /// 永不裁断（[spacing] 行内间距、[runSpacing] 行间距均走 token，无裸值）。
+  ///
+  /// TODO-1351（用户复诉）：分类 tab 仍是「图标 + 完整文字」（参考「检查器」式 tab），不得
+  /// 截成省略号、也不得压成纯图标 + tooltip（TODO-640 曾为省顶栏空间改仅图标，用户要求恢复
+  /// 完整文字标签）。标签经 [HibikiSelectableChip.allowLabelOverflow] 按固有宽度完整渲染
+  /// （无 ellipsis）；换行由 [Wrap] 承载，单个标签永不截断。
   Widget _buildTopCategoryBar(String selectedId) {
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: Row(
-        children: <Widget>[
-          for (final ({String id, IconData icon, String label}) cat
-              in _categories())
-            Padding(
-              padding: EdgeInsets.only(right: tokens.spacing.gap),
-              child: HibikiSelectableChip(
-                // 稳定 key：测试 / 焦点驱动靠 id key 命中分类（不依赖标签文案）。
-                key: ValueKey<String>('video-settings-cat-${cat.id}'),
-                label: cat.label,
-                leadingIcon: cat.icon,
-                selected: cat.id == selectedId,
-                // TODO-1351：标签完整渲染、不省略；空间不够由外层横滑条兜底。
-                allowLabelOverflow: true,
-                onSelected: (_) => _selectSubPage(cat.id),
-              ),
-            ),
-        ],
-      ),
+    return Wrap(
+      spacing: tokens.spacing.gap,
+      runSpacing: tokens.spacing.gap / 2,
+      children: <Widget>[
+        for (final ({String id, IconData icon, String label}) cat
+            in _categories())
+          HibikiSelectableChip(
+            // 稳定 key：测试 / 焦点驱动靠 id key 命中分类（不依赖标签文案）。
+            key: ValueKey<String>('video-settings-cat-${cat.id}'),
+            label: cat.label,
+            leadingIcon: cat.icon,
+            selected: cat.id == selectedId,
+            // TODO-1351：标签完整渲染、不省略；空间不够由 Wrap 换行兜底（不裁断）。
+            allowLabelOverflow: true,
+            onSelected: (_) => _selectSubPage(cat.id),
+          ),
+      ],
     );
   }
 

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -78,6 +78,24 @@ int resolveSubtitleCharHit(
   return bestIndex;
 }
 
+/// libass 把 ASS `\blur` 值换算成高斯半径时乘的常数 `2 / sqrt(ln 256)`（≈0.8493）。见
+/// libass `ass_render.c`：`blur_radius_scale = 2 / sqrt(log(256))`，最终下发给高斯的半径 =
+/// `\blur 值 × (显示/PlayRes 缩放) × blur_radius_scale`。**ASS 的 `\blur` 数值不是直接的高斯
+/// sigma**——少了这个因子就比 mpv/libass 明显偏糊（约 1/0.8493 ≈ 1.18×）。
+final double kLibassBlurRadiusScale = 2 / math.sqrt(math.log(256));
+
+/// 把 ASS `\blur` 值 [blurValue] 换算成 Flutter 高斯模糊 sigma（逻辑像素），对齐 libass/mpv：
+/// `sigma = blurValue × [assFontScale]（显示区高 / PlayResY）× [kLibassBlurRadiusScale]`，
+/// 再夹到 [0, 24]（防 PlayResY 异常时糊爆）。纯函数，overlay 渲染与单测共享真相源。
+///
+/// 此前 overlay 漏乘 [kLibassBlurRadiusScale]，把 `\blur` 值当 sigma 直接 × 缩放，导致比
+/// mpv 明显偏糊（用户报「一条清晰一条发虚」的发虚那条来自字幕自带 `\blur4`，且比 mpv 更糊）。
+@visibleForTesting
+double assBlurValueToSigma(double blurValue, double assFontScale) {
+  final double sigma = blurValue * assFontScale * kLibassBlurRadiusScale;
+  return sigma < 0 ? 0 : (sigma > 24 ? 24 : sigma);
+}
+
 /// 视频底部当前句字幕 overlay；监听 [VideoPlayerController.currentCue]。
 ///
 /// 字幕逐字符可点击：点击第 [int] 个 grapheme 时回调
@@ -1136,14 +1154,13 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   }
 
   /// 覆盖第 [i] 个 grapheme 的 `\blur`/`\be` 换算成 Flutter 高斯模糊 sigma（逻辑像素）。
-  /// respectAssStyle 关 / 无 blur 返回 0。ASS blur 是相对 PlayResY 的绝对像素（与字号 / 描边 /
-  /// 阴影同源），故按 [_assFontScale] 缩放到显示尺寸，再夹到 [0,24] 防 PlayResY 异常时糊爆。
+  /// respectAssStyle 关 / 无 blur 返回 0。真换算（含 libass `2/sqrt(ln256)` 因子 + 夹范围）
+  /// 委托纯函数 [assBlurValueToSigma]（可单测），本方法只负责取 span 的 `\blur` 值 + 缩放。
   double _blurSigmaFor(int i, SubtitleMarkup? markup) {
     if (!widget.respectAssStyle || markup == null) return 0;
     final double? blur = _spanAt(i, markup)?.blur;
     if (blur == null || blur <= 0) return 0;
-    final double sigma = blur * _assFontScale(markup);
-    return sigma < 0 ? 0 : (sigma > 24 ? 24 : sigma);
+    return assBlurValueToSigma(blur, _assFontScale(markup));
   }
 
   /// 解析第 [i] 个 grapheme 的**描边色 + 描边宽**（[_buildSubtitleChar] 的 ASS 尊重分支用）。

--- a/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
@@ -488,6 +488,25 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     controller.setSecondaryCues(cues);
   }
 
+  /// 视频内嵌字体加载（对齐 mpv/libass 的 attachment 字体）：本地视频 + 开「尊重 .ass
+  /// 自带样式」时，抽 MKV 内嵌字体附件注册进 Flutter 引擎，字幕 overlay 的
+  /// `_styleForGrapheme` 用 `cue.fontName` 即可命中真实字体（无需改 overlay）。加载完成若
+  /// 有 family 注册成功，[_rebuild] 触发 overlay 重渲染以套用新字体。
+  ///
+  /// 门控 [AppModel.videoRespectAssStyle]：关时字幕走 App 统一样式、不认 ASS 字体名，抽字体
+  /// 无意义（省一次 ffmpeg）。降级链在 [SubtitleEmbeddedFontLoader] 内：远端/无本地文件/无
+  /// ffmpeg/无附件/解析失败一律返回空集，overlay 继续走 [_kSubtitleCjkFallback]，不崩不阻塞
+  /// 播放（fire-and-forget）。
+  Future<void> _maybeLoadEmbeddedSubtitleFonts(String videoPath) async {
+    if (_isRemote) return;
+    if (!appModel.videoRespectAssStyle) return;
+    final Set<String> families =
+        await _embeddedFontLoader.loadForVideo(videoPath);
+    if (!mounted || families.isEmpty) return;
+    // 字体已进引擎；重建让字幕 overlay 按 cue.fontName 重解析并命中新注册的 family。
+    _rebuild(() {});
+  }
+
   /// Jimaku 搜索用的番名 query。能算出非空 query 时返回它，否则返回 null
   /// （= 字幕菜单不显示「自动获取字幕」入口）。
   ///

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -32,6 +32,7 @@ import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
 import 'package:hibiki/src/media/video/dandanplay_client.dart';
 import 'package:hibiki/src/media/video/danmaku_manual_match_panel.dart';
 import 'package:hibiki/src/media/video/stream_video_launch.dart';
+import 'package:hibiki/src/media/video/subtitle_embedded_fonts.dart';
 import 'package:hibiki/src/media/video/video_episode_start_policy.dart';
 import 'package:hibiki/src/media/video/m3u8_playlist.dart';
 import 'package:hibiki/src/media/video/url_stream_video.dart';
@@ -1302,6 +1303,12 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// 当前播放的视频文件绝对路径（枚举字幕源用）；未 load 时为 null。
   String? _currentVideoPath;
 
+  /// 视频内嵌字体加载器（对齐 mpv attachment 字体）：开视频时抽 MKV 内嵌字体附件注册进
+  /// 引擎，字幕 overlay 按 ASS `Fontname` 命中真实字体。内部按视频路径缓存 + 进程级 family
+  /// 去重，故可反复调（换集/重开）。见 [_maybeLoadEmbeddedSubtitleFonts]。
+  final SubtitleEmbeddedFontLoader _embeddedFontLoader =
+      SubtitleEmbeddedFontLoader();
+
   /// 远端模式（[_isRemote]）下 host 下发并下载到本地临时文件的那条外挂字幕路径；
   /// 无 host 字幕时为 null。远端没有本地视频文件，字幕菜单不能走 [_currentVideoPath]
   /// 的同目录枚举（恒 null → 早返回 → 点了没反应，#2），故单独记下这条 host 字幕，
@@ -2505,6 +2512,9 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
       // only after playback has opened so UI/video startup is not blocked.
       unawaited(prewarmEmbeddedSubtitleCache(videoPath));
       unawaited(_loadDanmakuForVideo(videoPath));
+      // 视频内嵌字体（对齐 mpv）：抽 MKV attachment 字体注册进引擎，字幕按 ASS Fontname
+      // 命中真实字体。仅本地 + 开「尊重 .ass 样式」时做；远端/无 ffmpeg/无附件静默降级。
+      unawaited(_maybeLoadEmbeddedSubtitleFonts(videoPath));
     } else {
       unawaited(_loadDanmakuForVideo(null));
     }

--- a/hibiki/test/media/video/subtitle_embedded_fonts_test.dart
+++ b/hibiki/test/media/video/subtitle_embedded_fonts_test.dart
@@ -1,0 +1,115 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/subtitle_embedded_fonts.dart';
+
+void _u16(List<int> out, int v) {
+  out.add((v >> 8) & 0xFF);
+  out.add(v & 0xFF);
+}
+
+void _u32(List<int> out, int v) {
+  out
+    ..add((v >> 24) & 0xFF)
+    ..add((v >> 16) & 0xFF)
+    ..add((v >> 8) & 0xFF)
+    ..add(v & 0xFF);
+}
+
+/// 构造一个最小合法单字体 sfnt：仅一张 `name` 表，含一条 Windows(3) UTF-16BE 的
+/// nameID=1（Family）记录 = [family]。用于验证 [parseSfntFamilyNames] 的解析路径。
+Uint8List _buildSfntWithFamily(String family, {int nameId = 1}) {
+  // name 表：format(0) count(1) stringOffset(6+12=18) + 1 记录 + 字符串存储。
+  final List<int> nameUtf16 = <int>[];
+  for (final int u in family.codeUnits) {
+    nameUtf16
+      ..add((u >> 8) & 0xFF)
+      ..add(u & 0xFF);
+  }
+  final int strLen = nameUtf16.length;
+  final List<int> nameTable = <int>[];
+  _u16(nameTable, 0); // format
+  _u16(nameTable, 1); // count
+  _u16(nameTable, 18); // stringOffset (6 header + 12 record)
+  // record: platformID=3, encodingID=1, languageID=0x0409, nameID, length, offset=0
+  _u16(nameTable, 3);
+  _u16(nameTable, 1);
+  _u16(nameTable, 0x0409);
+  _u16(nameTable, nameId);
+  _u16(nameTable, strLen);
+  _u16(nameTable, 0);
+  nameTable.addAll(nameUtf16);
+
+  const int nameOffset = 12 + 16; // sfnt header(12) + 1 table record(16)
+  final List<int> out = <int>[];
+  // sfnt header
+  _u32(out, 0x00010000); // sfntVersion
+  _u16(out, 1); // numTables
+  _u16(out, 0); // searchRange
+  _u16(out, 0); // entrySelector
+  _u16(out, 0); // rangeShift
+  // table record: tag 'name'
+  out.addAll(<int>[0x6E, 0x61, 0x6D, 0x65]); // 'name'
+  _u32(out, 0); // checksum
+  _u32(out, nameOffset); // offset
+  _u32(out, nameTable.length); // length
+  out.addAll(nameTable);
+  return Uint8List.fromList(out);
+}
+
+void main() {
+  group('parseSfntFamilyNames', () {
+    test('reads Windows UTF-16BE Family (nameID 1)', () {
+      final Uint8List bytes = _buildSfntWithFamily('FOT-Matisse ProN B');
+      expect(parseSfntFamilyNames(bytes), contains('FOT-Matisse ProN B'));
+    });
+
+    test('reads Typographic Family (nameID 16)', () {
+      final Uint8List bytes =
+          _buildSfntWithFamily('HYXuanSong 75S', nameId: 16);
+      expect(parseSfntFamilyNames(bytes), contains('HYXuanSong 75S'));
+    });
+
+    test('non-font / truncated bytes degrade to empty (no throw)', () {
+      expect(parseSfntFamilyNames(Uint8List.fromList(<int>[1, 2, 3])), isEmpty);
+      expect(parseSfntFamilyNames(Uint8List(0)), isEmpty);
+      // 合法头但 name 表 offset 越界 → 不崩、空集。
+      final Uint8List truncated = _buildSfntWithFamily('X').sublist(0, 20);
+      expect(parseSfntFamilyNames(truncated), isEmpty);
+    });
+  });
+
+  group('parseFfprobeFontAttachments', () {
+    test(
+        'keeps font attachments, skips non-font, ordinal counts all '
+        'attachment streams', () {
+      const String json = '''
+      {"streams":[
+        {"index":0,"codec_type":"video"},
+        {"index":1,"codec_type":"audio"},
+        {"index":3,"codec_type":"attachment","codec_name":"ttf",
+         "tags":{"filename":"matisse.ttf","mimetype":"application/x-truetype-font"}},
+        {"index":4,"codec_type":"attachment","codec_name":"otf",
+         "tags":{"filename":"hyxuansong.otf"}},
+        {"index":5,"codec_type":"attachment",
+         "tags":{"filename":"cover.jpg","mimetype":"image/jpeg"}},
+        {"index":6,"codec_type":"attachment",
+         "tags":{"filename":"noto.TTC","mimetype":"font/collection"}}
+      ]}''';
+      final List<EmbeddedFontAttachment> fonts =
+          parseFfprobeFontAttachments(json);
+      // matisse(ord0) + hyxuansong(ord1) + noto.TTC(ord3) are fonts; cover(ord2) not.
+      expect(fonts.map((EmbeddedFontAttachment f) => f.attachmentOrdinal),
+          <int>[0, 1, 3]);
+      expect(fonts.map((EmbeddedFontAttachment f) => f.fileName),
+          <String>['matisse.ttf', 'hyxuansong.otf', 'noto.TTC']);
+    });
+
+    test('empty / malformed json → empty list (no throw)', () {
+      expect(parseFfprobeFontAttachments(''), isEmpty);
+      expect(parseFfprobeFontAttachments('not json'), isEmpty);
+      expect(parseFfprobeFontAttachments('{"streams":[]}'), isEmpty);
+      expect(parseFfprobeFontAttachments('{"foo":1}'), isEmpty);
+    });
+  });
+}

--- a/hibiki/test/media/video/video_subtitle_overlay_markup_test.dart
+++ b/hibiki/test/media/video/video_subtitle_overlay_markup_test.dart
@@ -422,8 +422,25 @@ void main() {
       ),
     ));
     await tester.pump();
-    // 无 PlayResY → _assFontScale=1 → sigma=5 → 该字符包一层高斯模糊 ImageFiltered。
+    // 无 PlayResY → _assFontScale=1 → sigma=5×0.8493≈4.25>0 → 该字符包一层高斯 ImageFiltered。
     expect(find.byType(ImageFiltered), findsWidgets);
+  });
+
+  // ASS `\blur` → 高斯 sigma 换算须带 libass 的 `2/sqrt(ln256)`≈0.8493 因子（对齐 mpv），
+  // 不能把 `\blur` 值直接当 sigma（会比 mpv 明显偏糊 ~1.18×）。锁死纯函数换算。
+  test(r'assBlurValueToSigma applies libass 2/sqrt(ln256) factor (mpv parity)',
+      () {
+    expect(kLibassBlurRadiusScale, closeTo(0.8493, 0.0005));
+    // \blur5，无缩放（scale=1）：libass 有效 sigma = 5×0.8493 ≈ 4.247，而非旧的 5。
+    expect(assBlurValueToSigma(5, 1), closeTo(5 * 0.8493218, 0.001));
+    expect(assBlurValueToSigma(5, 1), lessThan(5.0),
+        reason: '必须比裸 \\blur 值小（带 libass 因子），否则比 mpv 偏糊');
+    // \blur4 @ 2× 缩放（1080p 脚本渲染到 2160）：4×2×0.8493 ≈ 6.79，而非旧的 8。
+    expect(assBlurValueToSigma(4, 2), closeTo(4 * 2 * 0.8493218, 0.001));
+    expect(assBlurValueToSigma(4, 2), lessThan(8.0));
+    // 边界：0 → 0；超大值夹到 24。
+    expect(assBlurValueToSigma(0, 3), 0);
+    expect(assBlurValueToSigma(100, 3), 24);
   });
 
   testWidgets(r'respectAssStyle OFF: \blur ignored (no ImageFiltered)',

--- a/hibiki/test/pages/video_quick_settings_sheet_test.dart
+++ b/hibiki/test/pages/video_quick_settings_sheet_test.dart
@@ -852,7 +852,11 @@ void main() {
     await _pump(tester, _sheet(onSetDelay: (int v) => delay = v));
 
     // 播放详情只有延迟行 + 倍速行，chevron_right 仅出现在「+50ms」按钮
-    // （导航行的 chevron 在别的分类，playback 无导航行）。
+    // （导航行的 chevron 在别的分类，playback 无导航行）。顶栏分类条在窄宽窗
+    // （如 1000px；desktop 面板 maxWidth 900 更窄）会换行成两行、把详情下推，故先
+    // ensureVisible 把按钮滚进可点区域再点，不依赖顶栏恰好单行的脆弱位置假设。
+    await tester.ensureVisible(find.byIcon(Icons.chevron_right));
+    await tester.pumpAndSettle();
     await tester.tap(find.byIcon(Icons.chevron_right));
     await tester.pump();
     expect(delay, 50);
@@ -2233,7 +2237,7 @@ void main() {
               .readAsStringSync();
       // 宽窗大分类置顶：必须有顶栏构建器，且不再用左右 master-detail 容器/侧栏。
       expect(src, contains('_buildTopCategoryBar('),
-          reason: '宽窗分类须经顶栏横滑 chip 构建器渲染');
+          reason: '宽窗分类须经顶栏 chip 构建器渲染');
       expect(src, isNot(contains('MaterialSupportingPaneLayout(')),
           reason: '视频设置宽窗不得再回退到左右 master-detail（书籍设置才用它）');
       expect(src, isNot(contains('_buildWidePane(')),
@@ -2247,6 +2251,52 @@ void main() {
           reason: '顶栏分类 chip 不得退回仅图标模式（TODO-1351 用户复诉）');
       expect(src, contains('_buildWideDetailTitle('),
           reason: '宽窗详情顶部须渲染当前分类标题（详情区页头）');
+      // BUG（末位分类被裁）：顶栏须用 Wrap 换行堆叠，不得回退横向 SingleChildScrollView
+      // 裁断（旧实现把「弹幕 / 控制」推到视口外，用户看不全也点不到）。
+      final String barSrc = src.substring(
+        src.indexOf('Widget _buildTopCategoryBar('),
+        src.indexOf('Widget _buildWideDetailTitle('),
+      );
+      expect(barSrc, contains('Wrap('),
+          reason: '顶栏分类条须用 Wrap 换行堆叠（放不下自动折行，不裁断）');
+      expect(barSrc, isNot(contains('scrollDirection: Axis.horizontal')),
+          reason: '顶栏分类条不得回退横向滚动（会把末位分类裁到视口外）');
+    });
+
+    testWidgets('BUG（顶栏末位分类被裁）：窄宽窗顶栏 chip 换行堆叠，7 个分类全部可见不被右裁', (tester) async {
+      // 宽窗阈值 560×440；取 620 宽——进宽窗分支，但 7 个「图标 + 完整文字」chip 一行
+      // 装不下。旧横向滚动实现会把末位「弹幕 / 控制」推到视口右侧外裁掉；Wrap 换行后全可见。
+      await tester.binding.setSurfaceSize(const Size(620, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await _pump(tester, _sheet());
+
+      const List<String> ids = <String>[
+        'playback',
+        'audio',
+        'subtitle',
+        'shaders',
+        'mpv',
+        'danmaku',
+        'controls',
+      ];
+      for (final String id in ids) {
+        expect(_categoryChip(id), findsOneWidget, reason: '$id chip 必须在顶栏渲染');
+      }
+
+      // 末位分类「控制」的右缘不得超出面板宽度（不被横向裁到视口外）。
+      final Rect controls = tester.getRect(_categoryChip('controls'));
+      expect(controls.right, lessThanOrEqualTo(620.0),
+          reason: '末位分类 chip 不得被裁到视口右侧外（须换行，而非横向滚动裁断）');
+
+      // 一行放不下 → 换行：末位「控制」应落到比首位「播放」更低的行（dy 更大）。
+      final double playbackTop =
+          tester.getTopLeft(_categoryChip('playback')).dy;
+      final double controlsTop =
+          tester.getTopLeft(_categoryChip('controls')).dy;
+      expect(controlsTop, greaterThan(playbackTop),
+          reason: '装不下时顶栏必须换行堆叠（Wrap），末位分类落到下一行');
+
+      _expectNoFlutterErrors(tester);
     });
   });
 


### PR DESCRIPTION
视频字幕/设置一组修复（同一用户反馈）。

## 1. 视频设置分类 tab 被裁 → 换行堆叠
顶部分类条横向滚动装不下时把「弹幕/控制」裁到视口外。改 `Wrap` 换行堆叠，所有分类恒可见。守卫：620px 下 7 chip 全渲染不越右缘 + 源码守卫不得回退横向滚动。

## 2. 字幕 \blur 比 mpv 偏糊 → 对齐 libass 公式
用户「一虚一清」的发虚那条来自字幕自带 `{\blur4}`。Hibiki 漏了 libass 的 `blur_radius_scale = 2/sqrt(ln256)≈0.8493`，把 \blur 值当 sigma 直接用，偏糊约 1.18×。抽纯函数 `assBlurValueToSigma` 补因子 + 单测。

## 3. 内嵌字体加载 → 字体/字号对齐 mpv
「字体/字号不对」根因：字幕用 MKV 内嵌商用字体(FOT-Matisse/HYXuanSong)，mpv 从 attachment 加载，Hibiki 自绘 overlay(为逐字查词不走 libass)没加载→fallback 替换。新增 `SubtitleEmbeddedFontLoader`：ffprobe 枚举字体附件→ffmpeg dump_attachment 抽取→解析 sfnt name 表拿 family→FontLoader 注册→overlay 按 cue.fontName 命中。纯函数(name 表解析/附件枚举)有单测；抽取+注册运行期链路**待真机**(须真 MKV 带字体附件)。降级链完整(远端/无 ffmpeg/无附件→回退 CJK fallback)。

## 已查实但未纳入本 PR
- **22:10-22:28 字幕上下跳**：已由 **PR#49(BUG-738/743, develop 160911ef1, merged 2026-07-11)修复**(findActiveCueIndices 半开区间根除相邻对白幻影重叠)。本分支已含修复+守卫测试。用户看到=其 build 早于 PR#49，需更新 build 真机验证。**无需再改**。
- **letterbox 字号偏大(独立真 bug)**：`_assFontScale` 用含黑边的 overlay 高而非视频帧高，有黑边时字号/描边/MarginV 偏大 1.2~1.35×。用户视频无黑边→非其症状。已记 file:line，可另修。

## 验证
`flutter test`(embedded_fonts/overlay_markup/quick_settings/dual_bounce 等)123 passed；`flutter analyze` 改动文件 No issues。渲染观感(blur/字体)待真机。