### PR TITLE
fix(video): 本地视频卡补桌面右键弹菜单 (BUG-758)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 742 条。点号进各自文件。
+> 共 743 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-758](bugs/BUG-758-local-video-card-right-click.md) | ✅ | ✅ | 本地视频卡不支持右键弹菜单 |
 | [BUG-757](bugs/BUG-757-lyrics-audio-follow-snap.md) | ✅ | ✅ | 歌词模式音频跟随失效（followAudio 门控 + snap 回中不生效） |
 | [BUG-756](bugs/BUG-756-lyrics-input-no-chrome-no-esc.md) | ✅ | ✅ | 歌词模式唤不出隐藏底栏 + esc 退不出 |
 | [BUG-755](bugs/BUG-755-interconnect-token-label-clipped.md) | ✅ | ✅ | 互联对端访问令牌浮动标签上半截被折叠区裁剪 |

--- a/docs/bugs/BUG-758-local-video-card-right-click.md
+++ b/docs/bugs/BUG-758-local-video-card-right-click.md
@@ -1,0 +1,7 @@
+## BUG-758 · 本地视频卡不支持右键弹菜单
+
+- **报告**：2026-07-12（用户：qqbotxiaoxiao）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/home_video_page.dart:2168` 本地视频卡 `HibikiCard` 只挂了 `onLongPress: _showVideoMenu`、漏挂 `onSecondaryTap`。`HibikiCard` 本身支持 `onSecondaryTap`（桌面鼠标右键），书架书卡（`reader_history/card_widgets.part.dart` 的 `_bookCardShell` 同绑 onLongPress+onSecondaryTap）与远端视频卡（`home_video_page.dart` `_buildRemoteVideoCard` 同绑两者）都支持右键，唯本地视频卡漏配，故桌面右键本地视频无反应。用户对照书架「右键打开对应书籍菜单」报此缺失。
+- **[x] ① 已修复** — `home_video_page.dart` 本地视频卡补 `onSecondaryTap: _selectionMode ? null : () => _showVideoMenu(book)`，与 onLongPress 同链路、同选择态门控，与书卡/远端视频卡一致。提交见分支 `worktree-video-card-right-click`。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/home_video_page_menu_test.dart` 新增用例「桌面右键（次按钮）本地视频卡弹出同一动作面板（BUG-758）」：用 `tester.tap(card, buttons: kSecondaryButton)` 模拟右键，断言弹出与长按相同的 `HibikiDialogFrame` 动作面板。
+- **备注**：根因是遗漏配置而非平台限制；移动端无次按钮，`onSecondaryTap` 自然永不触发，行为与历史一致。

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -2165,7 +2165,11 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
       onTap: _selectionMode
           ? () => _toggleSelection(book.bookUid)
           : () => _open(book, playlistCollectionId: playlistCollectionId),
+      // 长按 / 桌面右键都弹管理菜单，与书架书卡（_bookCardShell）、远端视频卡
+      // （_buildRemoteVideoCard）一致——本地视频卡此前只挂了 onLongPress、漏了
+      // onSecondaryTap，故桌面右键本地视频卡无反应（BUG-758）。
       onLongPress: _selectionMode ? null : () => _showVideoMenu(book),
+      onSecondaryTap: _selectionMode ? null : () => _showVideoMenu(book),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[

--- a/hibiki/test/pages/home_video_page_menu_test.dart
+++ b/hibiki/test/pages/home_video_page_menu_test.dart
@@ -331,6 +331,25 @@ void main() {
     expect(find.text(t.dialog_read), findsNothing);
   });
 
+  testWidgets('桌面右键（次按钮）本地视频卡弹出同一动作面板（BUG-758）', (WidgetTester tester) async {
+    // BUG-758：本地视频卡此前只挂 onLongPress、漏了 onSecondaryTap，桌面右键无反应
+    // （书架书卡 / 远端视频卡都支持右键）。此处直接模拟次按钮点击，断言与长按同一面板。
+    await seedTaggedVideo();
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(HibikiCard).first, buttons: kSecondaryButton);
+    await tester.pumpAndSettle();
+
+    // 右键与长按同链路（都走 _showVideoMenu）：应弹出同一封面背景动作面板。
+    expect(find.byType(HibikiDialogFrame), findsOneWidget);
+    expect(find.text(t.tag_label), findsOneWidget);
+    expect(find.text(t.video_rename), findsOneWidget);
+    expect(find.text(t.srt_import_pick_cover), findsOneWidget);
+    expect(find.text(t.video_import_pick_subtitle), findsOneWidget);
+    expect(find.text(t.dialog_delete), findsOneWidget);
+  });
+
   testWidgets(
       'first video open prompts for Anime4K recommended shaders (desktop)',
       (WidgetTester tester) async {


### PR DESCRIPTION
## 问题
用户报「视频不支持右键」，对照「书架右键会打开对应书籍的菜单」。

## 根因
`home_video_page.dart` 本地视频卡 `HibikiCard` 只挂了 `onLongPress: _showVideoMenu`，漏挂 `onSecondaryTap`。`HibikiCard` 本身支持 `onSecondaryTap`（桌面鼠标右键）；书架书卡（`_bookCardShell` 同绑 onLongPress+onSecondaryTap）与远端视频卡（`_buildRemoteVideoCard`）都支持右键，唯本地视频卡漏配，故桌面右键本地视频无反应。

## 修复
本地视频卡补 `onSecondaryTap: _selectionMode ? null : () => _showVideoMenu(book)`，与 onLongPress 同链路、同选择态门控，与书卡/远端视频卡一致。移动端无次按钮，永不触发，行为与历史一致。

## 测试
`test/pages/home_video_page_menu_test.dart` 新增用例「桌面右键（次按钮）本地视频卡弹出同一动作面板（BUG-758）」，用 `tester.tap(card, buttons: kSecondaryButton)` 模拟右键并断言弹出 `HibikiDialogFrame`。全文件 14 个用例通过，`flutter analyze` 干净。

待真机复测桌面右键路径。