### PR TITLE
fix(video): Anime4K 着色器空下发根因修复 (BUG-759)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 742 条。点号进各自文件。
+> 共 743 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-759](bugs/BUG-759-anime4k-shader-noop.md) | ✅ | ✅ | Anime4K 着色器开了跟没开一样（glsl-shaders-append 非法 property 空下发） |
 | [BUG-757](bugs/BUG-757-lyrics-audio-follow-snap.md) | ✅ | ✅ | 歌词模式音频跟随失效（followAudio 门控 + snap 回中不生效） |
 | [BUG-756](bugs/BUG-756-lyrics-input-no-chrome-no-esc.md) | ✅ | ✅ | 歌词模式唤不出隐藏底栏 + esc 退不出 |
 | [BUG-755](bugs/BUG-755-interconnect-token-label-clipped.md) | ✅ | ✅ | 互联对端访问令牌浮动标签上半截被折叠区裁剪 |

--- a/docs/bugs/BUG-759-anime4k-shader-noop.md
+++ b/docs/bugs/BUG-759-anime4k-shader-noop.md
@@ -1,0 +1,60 @@
+## BUG-759 · Anime4K 着色器开了跟没开一样（glsl-shaders-append 非法 property 空下发）
+- **报告**：2026-07-12（用户：hibiki 的 anime4k 跟没开一样，mpv 的正常）
+- **真实性**：✅ 真 bug，根因 `hibiki/lib/src/media/video/video_shader_manager.dart:282-285`（修复前）
+- **[x] ① 已修复** — 提交 `a2509591f`
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_shader_manager_test.dart`（纯函数 + 源码守卫）；`hibiki/integration_test/video_shader_apply_readback_itest.dart`（Windows 实机回读）
+- **备注**：
+
+### 现象
+用户在着色器对话框勾选/下载了 Anime4K，视频画面「开了跟没开一样」；同一台 Windows 上用**独立 mpv** 加载同一套着色器则正常。
+
+### 根因（数据流 + 平台边界）
+着色器应用路径 `applyShadersToPlayer`（修复前）：
+```dart
+await native.setProperty('glsl-shaders', '');          // 清空成功
+for (path in absolutePaths) {
+  await native.setProperty('glsl-shaders-append', path); // ← 静默失败
+}
+```
+`native` 是 media_kit `NativePlayer`，`setProperty` 底层是 `mpv_set_property_string`
+（`media_kit-1.2.6/.../native/player/real.dart:1239`）。
+
+- mpv 的 `-append` / `-clr` 等**后缀 action 只在命令行 / 配置文件**解析路径
+  （`options/m_config_frontend.c` 的 `m_config_mogrify_cli_opt`，仅被 `m_config_set_option_cli` 调用）被识别。
+- 作为 **property** 名经 `mpv_set_property_string` → `player/command.c` 的
+  `mp_property_generic_option` → `m_config_get_co` **精确名查找（不剥后缀）** → 找不到
+  `glsl-shaders-append` → 返回 `MPV_ERROR_PROPERTY_NOT_FOUND`。
+- 而 media_kit 的 `setProperty` **丢弃 `mpv_set_property_string` 的返回码、不抛异常**
+  （real.dart:1239-1246 调用后直接 free 返回），于是 `applyShadersToPlayer` 里的 `catch`
+  **永不触发**，append 静默失败。
+
+净效果：`glsl-shaders` 被清空后一个都没挂回去 → 恒为空 → 着色器从未进 libmpv 渲染管线
+→「开了跟没开一样」。独立 mpv 正常，是因为它经 input.conf / 命令行路径下发（`-append` 在
+那条路径合法）。
+
+> 与 Windows ANGLE(OpenGL ES) 渲染后端无关：若真是 GLES 编译失败，`glsl-shaders` 会非空
+> 且日志有 shader compile error；这里列表始终为空，mpv 根本没走到编译着色器那一步。
+
+### 修复
+改用 mpv 官方运行时改列表机制 `change-list` 命令，经 `NativePlayer.command(List<String>)`
+（`mpv_command` 数组形式）下发——把每个路径作为**独立命令参数**传入，天然规避平台路径分隔符
+（Unix `:` / Windows `;`）与 Windows 盘符 `:` 的转义问题：
+```dart
+for (cmd in buildShaderChangeListCommands(paths)) await native.command(cmd);
+// buildShaderChangeListCommands: [ [change-list,glsl-shaders,clr,''],
+//   [change-list,glsl-shaders,append,<path1>], ... ]
+```
+新增纯函数 `buildShaderChangeListCommands`（`video_shader_manager.dart`）便于单测；
+`applyShadersToPlayer` 只把命令逐条 `command` 下发，best-effort 静默降级不变。五平台
+libmpv 一致（移动端 `command` 同样写穿，不是移动端 no-op）。
+
+### 测试
+- 单测（CI 可跑）：`test/media/video/video_shader_manager_test.dart`
+  - `buildShaderChangeListCommands`：空集→仅 clr；多路径→clr+逐个 append 保序；
+    Windows 盘符路径（含 `:`/反斜杠）作为独立参数原样传入；**绝不出现 `glsl-shaders-append`**。
+  - 源码守卫：apply 路径用 `native.command(`、不再有 `setProperty('glsl-shaders-append'`。
+- 实机（Windows + libmpv）：`integration_test/video_shader_apply_readback_itest.dart`
+  建 media_kit `Player`，`applyShadersToPlayer` 下发两个真实 `.glsl` 后
+  `getProperty('glsl-shaders')` 回读 → 断言含两个路径（修复生效）；对照旧
+  `glsl-shaders-append` property 写法回读为空（复现空下发根因）。
+</content>

--- a/docs/bugs/BUG-759-anime4k-shader-noop.md
+++ b/docs/bugs/BUG-759-anime4k-shader-noop.md
@@ -1,7 +1,7 @@
 ## BUG-759 · Anime4K 着色器开了跟没开一样（glsl-shaders-append 非法 property 空下发）
 - **报告**：2026-07-12（用户：hibiki 的 anime4k 跟没开一样，mpv 的正常）
 - **真实性**：✅ 真 bug，根因 `hibiki/lib/src/media/video/video_shader_manager.dart:282-285`（修复前）
-- **[x] ① 已修复** — 提交 `a2509591f`
+- **[x] ① 已修复** — 提交 `8d69c7b55`
 - **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_shader_manager_test.dart`（纯函数 + 源码守卫）；`hibiki/integration_test/video_shader_apply_readback_itest.dart`（Windows 实机回读）
 - **备注**：
 

--- a/hibiki/integration_test/video_shader_apply_readback_itest.dart
+++ b/hibiki/integration_test/video_shader_apply_readback_itest.dart
@@ -1,0 +1,80 @@
+// 真机集成测试（Windows 桌面 + media_kit 原生 libmpv）：证实 BUG-759 根因与修复。
+//
+// 直接建 media_kit Player，用两个真实临时 .glsl 走 applyShadersToPlayer 下发着色器，再
+// getProperty('glsl-shaders') 回读 libmpv 实际生效的着色器链：
+//   ① 修复后（change-list append）：回读非空、含两个路径 → 着色器真进渲染管线。
+//   ② 对照被证伪的旧法（setProperty('glsl-shaders-append', ...)）：回读为空 → 复现
+//      「Anime4K 开了跟没开一样」的空下发根因（media_kit 丢弃 mpv 返回码、静默失败）。
+//
+// 运行：hibiki/ 下 `.\tool\run_windows_itest.ps1 integration_test\video_shader_apply_readback_itest.dart`
+// 不联网、不需测试视频——glsl-shaders 是 mpv ctx 级属性，无需 open 文件即可读写。
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki/src/media/video/video_shader_manager.dart';
+
+/// 最小合法 mpv 用户着色器（MAIN 直通，能被 mpv 解析/编译）。
+const String _kPassthroughShader = '//!HOOK MAIN\n'
+    '//!BIND HOOKED\n'
+    'vec4 hook() { return HOOKED_tex(HOOKED_pos); }\n';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'applyShadersToPlayer 经 change-list 真写穿 glsl-shaders（旧 append property 空下发）',
+    (WidgetTester tester) async {
+      MediaKit.ensureInitialized();
+
+      final Directory dir =
+          Directory.systemTemp.createTempSync('shader_readback_');
+      final File a = File(p.join(dir.path, 'A_Restore.glsl'))
+        ..writeAsStringSync(_kPassthroughShader);
+      final File b = File(p.join(dir.path, 'B_Upscale.glsl'))
+        ..writeAsStringSync(_kPassthroughShader);
+      final List<String> paths = <String>[a.path, b.path];
+
+      final Player player = Player();
+      try {
+        final dynamic native = player.platform;
+        expect(native, isNotNull, reason: '桌面应为 libmpv NativePlayer');
+
+        // ── ① 修复路径：applyShadersToPlayer → change-list append → 回读非空 ──
+        await applyShadersToPlayer(player, paths);
+        final String afterFix =
+            await native.getProperty('glsl-shaders') as String;
+        debugPrint('[shader-readback] after change-list apply: "$afterFix"');
+        expect(afterFix.contains('A_Restore.glsl'), isTrue,
+            reason: 'change-list append 后 glsl-shaders 必须含第一个着色器路径');
+        expect(afterFix.contains('B_Upscale.glsl'), isTrue,
+            reason: 'change-list append 后 glsl-shaders 必须含第二个着色器路径');
+
+        // ── ② 对照被证伪的旧法：clr 后用 glsl-shaders-append property → 回读空 ──
+        await native
+            .command(<String>['change-list', 'glsl-shaders', 'clr', '']);
+        for (final String path in paths) {
+          // 这正是 BUG-759 的旧写法：作为 property 名非法，mpv 返回
+          // PROPERTY_NOT_FOUND，media_kit 丢弃返回码、静默失败。
+          await native.setProperty('glsl-shaders-append', path);
+        }
+        final String afterOld =
+            await native.getProperty('glsl-shaders') as String;
+        debugPrint(
+            '[shader-readback] after legacy append property: "$afterOld"');
+        expect(afterOld.trim(), isEmpty,
+            reason: 'glsl-shaders-append 作为 property 空下发——复现 BUG-759 根因');
+      } finally {
+        await player.dispose();
+        try {
+          dir.deleteSync(recursive: true);
+        } catch (_) {}
+      }
+    },
+    skip: !Platform.isWindows /* needs Windows desktop + media_kit native */,
+  );
+}

--- a/hibiki/lib/src/media/video/video_shader_manager.dart
+++ b/hibiki/lib/src/media/video/video_shader_manager.dart
@@ -262,28 +262,48 @@ Future<List<String>> discoverLocalMpvShaders({String? overrideDir}) async {
   return out;
 }
 
+/// 构建把 [absolutePaths] 应用为 libmpv `glsl-shaders` 列表的 `change-list` 命令序列。
+/// 纯函数（无副作用），便于单测。先 `clr` 清空整条着色器链，再逐个 `append`。
+///
+/// **为什么用 `change-list` 命令而非 `glsl-shaders-append` property**（BUG-759 根因）：
+/// `-append`/`-add`/`-clr` 这些后缀 action 只在 mpv 的**命令行 / 配置文件**解析路径
+/// （`m_config_mogrify_cli_opt`）里被识别；作为 property 名经 `mpv_set_property_string`
+/// 会走 `mp_property_generic_option` 的精确名查找（`m_config_get_co`，不剥后缀）→
+/// 返回 `PROPERTY_NOT_FOUND`。而 media_kit 的 `NativePlayer.setProperty` **丢弃**
+/// `mpv_set_property_string` 的返回码、不抛异常，于是 [applyShadersToPlayer] 里的
+/// `catch` 永不触发、append 静默失败、`glsl-shaders` 恒空——正是「Anime4K 开了跟没开
+/// 一样」。`change-list` 是 mpv 官方运行时改列表机制，把每个路径作为**独立命令参数**
+/// 传入（`mpv_command` 数组形式），天然规避平台路径分隔符（Unix `:` / Windows `;`）与
+/// Windows 盘符 `:` 的转义问题。
+List<List<String>> buildShaderChangeListCommands(List<String> absolutePaths) {
+  return <List<String>>[
+    <String>['change-list', 'glsl-shaders', 'clr', ''],
+    for (final String path in absolutePaths)
+      <String>['change-list', 'glsl-shaders', 'append', path],
+  ];
+}
+
 /// 把 [absolutePaths] 着色器应用到 media_kit [player]（libmpv 后端，五平台均生效）。
 ///
-/// 先把 `glsl-shaders` 清空，再逐个 `glsl-shaders-append`——用 append 规避
-/// `glsl-shaders` 单串里的**平台路径分隔符差异**（Unix `:` vs Windows `;`，且
-/// Windows 路径含 `:`）。media_kit 在 Android/iOS 同样是 libmpv + `vo=gpu`（见本文件头
-/// doc 的 media_kit 源码出处），故此处的 `setProperty` 在移动端也写穿、着色器进渲染管线，
-/// **不是移动端 no-op**。best-effort：仅在 `player.platform` 非 libmpv（无 setProperty）
-/// 或属性不支持时静默吞掉。
+/// 经 libmpv 的 `change-list glsl-shaders` 命令下发（先 `clr` 再逐个 `append`，见
+/// [buildShaderChangeListCommands] 的根因说明——**不能**用 `glsl-shaders-append`
+/// property，那不是合法 property 名，会被 media_kit 静默吞掉导致空下发）。media_kit 在
+/// Android/iOS 同样是 libmpv + `vo=gpu`（见本文件头 doc 的 media_kit 源码出处），故此处的
+/// `command` 在移动端也写穿、着色器进渲染管线，**不是移动端 no-op**。best-effort：仅在
+/// `player.platform` 非 libmpv（无 `command`）或命令不被接受时静默吞掉。
 Future<void> applyShadersToPlayer(
     Player player, List<String> absolutePaths) async {
-  // media_kit 的原生后端是 NativePlayer（libmpv），五平台一致，暴露 setProperty(name,
-  // value) → mpv_set_property_string。用 dynamic 避免硬耦合 media_kit 内部导出；这是
-  // 外部播放器边界，失败即静默是合理降级（见上方 doc）。移动端走 vo=gpu 渲染路径，属性
-  // 同样生效，这里不按平台门控。
+  // media_kit 的原生后端是 NativePlayer（libmpv），五平台一致，暴露 command(List<String>)
+  // → mpv_command。用 dynamic 避免硬耦合 media_kit 内部导出；这是外部播放器边界，失败即
+  // 静默是合理降级（见上方 doc）。移动端走 vo=gpu 渲染路径，命令同样生效，不按平台门控。
   final dynamic native = player.platform;
   if (native == null) return;
   try {
-    await native.setProperty('glsl-shaders', '');
-    for (final String path in absolutePaths) {
-      await native.setProperty('glsl-shaders-append', path);
+    for (final List<String> cmd
+        in buildShaderChangeListCommands(absolutePaths)) {
+      await native.command(cmd);
     }
   } catch (_) {
-    // 非 libmpv 后端 / 属性不支持：静默 no-op（非按平台门控——移动端 libmpv 同样生效）。
+    // 非 libmpv 后端 / 命令不支持：静默 no-op（非按平台门控——移动端 libmpv 同样生效）。
   }
 }

--- a/hibiki/test/media/video/video_shader_manager_test.dart
+++ b/hibiki/test/media/video/video_shader_manager_test.dart
@@ -291,4 +291,63 @@ void main() {
       expect(resolveShaderPathsIn(dir, <String>['x.glsl']), isEmpty);
     });
   });
+
+  group('buildShaderChangeListCommands（BUG-759 根因守卫）', () {
+    test('空启用集 → 只有一条 clr（清空整链）', () {
+      expect(buildShaderChangeListCommands(const <String>[]), <List<String>>[
+        <String>['change-list', 'glsl-shaders', 'clr', ''],
+      ]);
+    });
+
+    test('多路径 → clr 打头，再逐个 append，保持勾选顺序', () {
+      final List<List<String>> cmds = buildShaderChangeListCommands(<String>[
+        '/shaders/Restore.glsl',
+        '/shaders/Upscale.glsl',
+      ]);
+      expect(cmds, <List<String>>[
+        <String>['change-list', 'glsl-shaders', 'clr', ''],
+        <String>[
+          'change-list',
+          'glsl-shaders',
+          'append',
+          '/shaders/Restore.glsl'
+        ],
+        <String>[
+          'change-list',
+          'glsl-shaders',
+          'append',
+          '/shaders/Upscale.glsl'
+        ],
+      ]);
+    });
+
+    test('Windows 盘符路径（含 : 与反斜杠）作为独立参数原样传入，绝不拼分隔符', () {
+      const String winPath =
+          r'D:\APP\HIBIKI_date\support\mpv_shaders\Anime4K_Clamp_Highlights.glsl';
+      final List<List<String>> cmds =
+          buildShaderChangeListCommands(<String>[winPath]);
+      // append 命令的第 4 个参数必须是原始路径（未被任何分隔符切分/转义）。
+      expect(cmds.last,
+          <String>['change-list', 'glsl-shaders', 'append', winPath]);
+      // 关键回归守卫：绝不出现被证伪的 `glsl-shaders-append` property 名（空下发根因）。
+      for (final List<String> cmd in cmds) {
+        expect(cmd.contains('glsl-shaders-append'), isFalse,
+            reason: 'glsl-shaders-append 不是合法 property 名，会被 media_kit '
+                '静默吞掉导致着色器空下发（BUG-759）——必须走 change-list 命令');
+      }
+    });
+  });
+
+  group('applyShadersToPlayer 源码守卫（BUG-759）', () {
+    test('apply 路径用 native.command，且不再用 glsl-shaders-append property', () {
+      final String src = File('lib/src/media/video/video_shader_manager.dart')
+          .readAsStringSync();
+      // 必须经 command 下发 change-list（正确的运行时改列表机制）。
+      expect(src.contains('native.command('), isTrue,
+          reason: '着色器必须经 NativePlayer.command 下发 change-list');
+      // 绝不再用 setProperty 设 glsl-shaders-append（会 PROPERTY_NOT_FOUND 空下发）。
+      expect(src.contains("setProperty('glsl-shaders-append'"), isFalse,
+          reason: 'glsl-shaders-append 作为 property 非法，会导致空下发（BUG-759）');
+    });
+  });
 }


### PR DESCRIPTION
## 现象
用户报告：hibiki 的 Anime4K「开了跟没开一样」，同一台 Windows 上用独立 mpv 加载同一套着色器正常。

## 根因（数据流 + 平台边界）
`applyShadersToPlayer` 用 `setProperty('glsl-shaders-append', path)` 逐个下发着色器。但：
- mpv 的 `-append`/`-clr` 等**后缀 action 只在命令行/配置文件**解析路径识别（`m_config_mogrify_cli_opt`）。
- 作为 **property** 名经 `mpv_set_property_string` 走 `mp_property_generic_option` → `m_config_get_co` **精确名查找（不剥后缀）** → `PROPERTY_NOT_FOUND`。
- media_kit 的 `NativePlayer.setProperty` **丢弃 mpv 返回码、不抛异常**（`real.dart:1239`），于是 `catch` 永不触发、append 静默失败。

净效果：`glsl-shaders` 被 `setProperty('glsl-shaders','')` 清空后一个都没挂回去 → **恒为空** → 着色器从未进 libmpv 渲染管线。独立 mpv 正常，是因为它走 input.conf/命令行路径（`-append` 在那条路径合法）。与 Windows ANGLE/GLES 无关（列表为空根本没走到编译着色器）。

## 修复
改用 mpv 官方运行时改列表机制 **`change-list`**，经 `NativePlayer.command(List<String>)`（`mpv_command` 数组形式）下发——每个路径作为**独立命令参数**传入，天然规避平台路径分隔符（Win `;`/Unix `:`）与 Windows 盘符 `:` 的转义。新增纯函数 `buildShaderChangeListCommands` 便于单测。五平台 libmpv 一致。

## 测试
- **单测（CI 可跑）** `test/media/video/video_shader_manager_test.dart`：`buildShaderChangeListCommands` 空集/多路径保序/Windows 盘符路径原样传入/绝不出现 `glsl-shaders-append`；源码守卫用 `native.command`。全部通过。
- **实机（Windows libmpv 回读，已通过）** `integration_test/video_shader_apply_readback_itest.dart`：
  - change-list 修复后 `getProperty('glsl-shaders')` = `...A_Restore.glsl;...B_Upscale.glsl`（非空，两路径都在）✅
  - 对照旧 `glsl-shaders-append` property 回读为 `""`（空）——复现根因 ✅

## 备注
次要项（未改，属既有设计）：着色器仅在「画质增强」主开关（`VideoMpvConfig.highQuality`，默认 on）为真时应用（`video_hibiki_page.dart:2398`）。若用户关了该开关，即便本修复也不下发着色器——这是有意的旁路耦合，不在本 BUG 范围。

BUG-759