### PR TITLE
fix(video): 视频批量删除/打标签文案改用「个视频」量詞 (BUG-766)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 748 条。点号进各自文件。
+> 共 749 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-766](bugs/BUG-766-video-batch-book-counter.md) | ✅ | ✅ | 视频页批量删除/打标签文案误用「本书」量詞 |
 | [BUG-765](bugs/BUG-765-reader-selection-handles-cannot-drag.md) | ✅ | ✅ | 阅读器移动端自绘选区两端手柄拖不动 |
 | [BUG-764](bugs/BUG-764-scm-cross-paragraph-no-next.md) | ✅ | ✅ | 制卡「后加一句/前退一句」跨段落无反应（不支持跨 `<p>`） |
 | [BUG-763](bugs/BUG-763-scm-modal-clipped.md) | ✅ | ✅ | 制卡「选择句子上下文」模态显示不全（预览被按钮区遮挡） |

--- a/docs/bugs/BUG-766-video-batch-book-counter.md
+++ b/docs/bugs/BUG-766-video-batch-book-counter.md
@@ -1,0 +1,6 @@
+## BUG-766 · 视频页批量删除/打标签文案误用「本书」量詞
+- **报告**：2026-07-13（用户：截图 — 视频多选删除弹窗写「确定删除 26 本书？」）
+- **真实性**：✅ 真 bug。`home_video_page.dart` 的批量操作复用了书架专用的 i18n key（`batch_delete_confirm` / `batch_delete_success` / `batch_tag_added` / `batch_tag_removed`），其 zh-CN 文案用书籍量詞「本书」（`确定删除 $n 本书？`），但视频不是书，量詞应为「个视频」。根因：`hibiki/lib/src/pages/implementations/home_video_page.dart:397/441/2499/2506` 直接调用书架量詞 key。
+- **[x] ① 已修复** — 新增 4 个视频专用 i18n key（`batch_delete_confirm_video` / `batch_delete_success_video` / `batch_tag_added_video` / `batch_tag_removed_video`，经 `tool/i18n_sync.dart --add` 同步全 17 语言，zh-CN/zh-HK/ja 落真值「个视频 / 個影片 / 本の動画」，其余语言英文占位），并把视频页 4 处调用改指向 `*_video` 变体；`dart run slang` 重生成 `strings.g.dart`。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/home_video_batch_counter_guard_test.dart`：① 源码守卫视频页必须调 `*_video` 变体且不得回落到书架量詞 key；② zh-CN 四个 `*_video` 值必须含「视频」且不得含「本书」。
+- **备注**：待真机/桌面复测原始失败路径（视频多选 → 删除弹窗读「个视频」）。提交哈希见 PR。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 38998 (2294 per locale)
+/// Strings: 39066 (2298 per locale)
 ///
-/// Built on 2026-07-12 at 11:45 UTC
+/// Built on 2026-07-12 at 18:13 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3032,6 +3032,14 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get sort_imported => 'Import date';
   String get collection_sort_by_title => 'Sort by name';
   String get collection_sort_by_imported => 'Sort by import date';
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -8218,6 +8226,18 @@ class _StringsAr extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -13527,6 +13547,18 @@ class _StringsDe extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -18853,6 +18885,18 @@ class _StringsEs extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -24198,6 +24242,18 @@ class _StringsFr extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -29445,6 +29501,18 @@ class _StringsId extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -34753,6 +34821,18 @@ class _StringsIt extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -39787,6 +39867,17 @@ class _StringsJa extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      '${n} 本の動画を削除しますか？この操作は元に戻せません。';
+  @override
+  String batch_delete_success_video({required Object n}) => '${n} 本の動画を削除しました。';
+  @override
+  String batch_tag_added_video({required Object n, required Object name}) =>
+      '${n} 本の動画にタグ「${name}」を追加しました。';
+  @override
+  String batch_tag_removed_video({required Object n, required Object name}) =>
+      '${n} 本の動画からタグ「${name}」を削除しました。';
 }
 
 // Path: retrying_in
@@ -44825,6 +44916,18 @@ class _StringsKo extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -50101,6 +50204,18 @@ class _StringsNl extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -55400,6 +55515,18 @@ class _StringsPtBr extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -60674,6 +60801,18 @@ class _StringsRu extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -65861,6 +66000,18 @@ class _StringsTh extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -71103,6 +71254,18 @@ class _StringsTr extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -76320,6 +76483,18 @@ class _StringsVi extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      'Delete ${n} video(s)? This cannot be undone.';
+  @override
+  String batch_delete_success_video({required Object n}) =>
+      'Deleted ${n} video(s).';
+  @override
+  String batch_tag_added_video({required Object name, required Object n}) =>
+      'Added tag "${name}" to ${n} video(s).';
+  @override
+  String batch_tag_removed_video({required Object name, required Object n}) =>
+      'Removed tag "${name}" from ${n} video(s).';
 }
 
 // Path: retrying_in
@@ -81183,6 +81358,17 @@ class _StringsZhCn extends _StringsEn {
   String get collection_sort_by_title => '按名称排序';
   @override
   String get collection_sort_by_imported => '按导入时间排序';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      '确定删除 ${n} 个视频？此操作不可撤销。';
+  @override
+  String batch_delete_success_video({required Object n}) => '已删除 ${n} 个视频。';
+  @override
+  String batch_tag_added_video({required Object n, required Object name}) =>
+      '已为 ${n} 个视频添加标签「${name}」。';
+  @override
+  String batch_tag_removed_video({required Object n, required Object name}) =>
+      '已从 ${n} 个视频移除标签「${name}」。';
 }
 
 // Path: retrying_in
@@ -86119,6 +86305,17 @@ class _StringsZhHk extends _StringsEn {
   String get collection_sort_by_title => 'Sort by name';
   @override
   String get collection_sort_by_imported => 'Sort by import date';
+  @override
+  String batch_delete_confirm_video({required Object n}) =>
+      '確定刪除 ${n} 個影片？此操作不可撤銷。';
+  @override
+  String batch_delete_success_video({required Object n}) => '已刪除 ${n} 個影片。';
+  @override
+  String batch_tag_added_video({required Object n, required Object name}) =>
+      '已為 ${n} 個影片添加標籤「${name}」。';
+  @override
+  String batch_tag_removed_video({required Object n, required Object name}) =>
+      '已從 ${n} 個影片移除標籤「${name}」。';
 }
 
 // Path: retrying_in
@@ -90845,6 +91042,17 @@ extension on _StringsEn {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -95531,6 +95739,17 @@ extension on _StringsAr {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -100239,6 +100458,17 @@ extension on _StringsDe {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -104945,6 +105175,17 @@ extension on _StringsEs {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -109658,6 +109899,17 @@ extension on _StringsFr {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -114351,6 +114603,17 @@ extension on _StringsId {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -119061,6 +119324,17 @@ extension on _StringsIt {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -123729,6 +124003,16 @@ extension on _StringsJa {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) => '${n} 本の動画を削除しますか？この操作は元に戻せません。';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => '${n} 本の動画を削除しました。';
+      case 'batch_tag_added_video':
+        return ({required Object n, required Object name}) =>
+            '${n} 本の動画にタグ「${name}」を追加しました。';
+      case 'batch_tag_removed_video':
+        return ({required Object n, required Object name}) =>
+            '${n} 本の動画からタグ「${name}」を削除しました。';
       default:
         return null;
     }
@@ -128400,6 +128684,17 @@ extension on _StringsKo {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -133103,6 +133398,17 @@ extension on _StringsNl {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -137803,6 +138109,17 @@ extension on _StringsPtBr {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -142507,6 +142824,17 @@ extension on _StringsRu {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -147193,6 +147521,17 @@ extension on _StringsTh {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -151888,6 +152227,17 @@ extension on _StringsTr {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -156577,6 +156927,17 @@ extension on _StringsVi {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) =>
+            'Delete ${n} video(s)? This cannot be undone.';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => 'Deleted ${n} video(s).';
+      case 'batch_tag_added_video':
+        return ({required Object name, required Object n}) =>
+            'Added tag "${name}" to ${n} video(s).';
+      case 'batch_tag_removed_video':
+        return ({required Object name, required Object n}) =>
+            'Removed tag "${name}" from ${n} video(s).';
       default:
         return null;
     }
@@ -161232,6 +161593,16 @@ extension on _StringsZhCn {
         return '按名称排序';
       case 'collection_sort_by_imported':
         return '按导入时间排序';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) => '确定删除 ${n} 个视频？此操作不可撤销。';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => '已删除 ${n} 个视频。';
+      case 'batch_tag_added_video':
+        return ({required Object n, required Object name}) =>
+            '已为 ${n} 个视频添加标签「${name}」。';
+      case 'batch_tag_removed_video':
+        return ({required Object n, required Object name}) =>
+            '已从 ${n} 个视频移除标签「${name}」。';
       default:
         return null;
     }
@@ -165892,6 +166263,16 @@ extension on _StringsZhHk {
         return 'Sort by name';
       case 'collection_sort_by_imported':
         return 'Sort by import date';
+      case 'batch_delete_confirm_video':
+        return ({required Object n}) => '確定刪除 ${n} 個影片？此操作不可撤銷。';
+      case 'batch_delete_success_video':
+        return ({required Object n}) => '已刪除 ${n} 個影片。';
+      case 'batch_tag_added_video':
+        return ({required Object n, required Object name}) =>
+            '已為 ${n} 個影片添加標籤「${name}」。';
+      case 'batch_tag_removed_video':
+        return ({required Object n, required Object name}) =>
+            '已從 ${n} 個影片移除標籤「${name}」。';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "$n 本の動画を削除しますか？この操作は元に戻せません。",
+  "batch_delete_success_video": "$n 本の動画を削除しました。",
+  "batch_tag_added_video": "$n 本の動画にタグ「$name」を追加しました。",
+  "batch_tag_removed_video": "$n 本の動画からタグ「$name」を削除しました。"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "Delete $n video(s)? This cannot be undone.",
+  "batch_delete_success_video": "Deleted $n video(s).",
+  "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
+  "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s)."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "名称",
   "sort_imported": "导入时间",
   "collection_sort_by_title": "按名称排序",
-  "collection_sort_by_imported": "按导入时间排序"
+  "collection_sort_by_imported": "按导入时间排序",
+  "batch_delete_confirm_video": "确定删除 $n 个视频？此操作不可撤销。",
+  "batch_delete_success_video": "已删除 $n 个视频。",
+  "batch_tag_added_video": "已为 $n 个视频添加标签「$name」。",
+  "batch_tag_removed_video": "已从 $n 个视频移除标签「$name」。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2300,5 +2300,9 @@
   "sort_title": "Name",
   "sort_imported": "Import date",
   "collection_sort_by_title": "Sort by name",
-  "collection_sort_by_imported": "Sort by import date"
+  "collection_sort_by_imported": "Sort by import date",
+  "batch_delete_confirm_video": "確定刪除 $n 個影片？此操作不可撤銷。",
+  "batch_delete_success_video": "已刪除 $n 個影片。",
+  "batch_tag_added_video": "已為 $n 個影片添加標籤「$name」。",
+  "batch_tag_removed_video": "已從 $n 個影片移除標籤「$name」。"
 }

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -394,7 +394,7 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
       context: context,
       builder: (BuildContext ctx) => AlertDialog(
         title: Text(t.dialog_delete),
-        content: Text(t.batch_delete_confirm(n: count)),
+        content: Text(t.batch_delete_confirm_video(n: count)),
         actions: <Widget>[
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
@@ -438,7 +438,7 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
       await widget.repo.compactAfterVideoDeleteBestEffort();
     }
     if (!mounted) return;
-    HibikiToast.show(msg: t.batch_delete_success(n: deleted));
+    HibikiToast.show(msg: t.batch_delete_success_video(n: deleted));
   }
 
   Future<void> _waitForVideoCardsToUnmount() async {
@@ -2496,14 +2496,20 @@ class _VideoBatchTagPickerDialogState
       final BookTagRow tag =
           widget.allTags.firstWhere((BookTagRow row) => row.id == tagId);
       HibikiToast.show(
-        msg: t.batch_tag_added(name: tag.name, n: widget.selectedUids.length),
+        msg: t.batch_tag_added_video(
+          name: tag.name,
+          n: widget.selectedUids.length,
+        ),
       );
     }
     for (final int tagId in _removeTagIds) {
       final BookTagRow tag =
           widget.allTags.firstWhere((BookTagRow row) => row.id == tagId);
       HibikiToast.show(
-        msg: t.batch_tag_removed(name: tag.name, n: widget.selectedUids.length),
+        msg: t.batch_tag_removed_video(
+          name: tag.name,
+          n: widget.selectedUids.length,
+        ),
       );
     }
     Navigator.pop(context);

--- a/hibiki/test/pages/home_video_batch_counter_guard_test.dart
+++ b/hibiki/test/pages/home_video_batch_counter_guard_test.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-766 source guard: the video home page must not reuse the book-worded
+/// batch strings (`batch_delete_confirm` / `batch_delete_success` /
+/// `batch_tag_added` / `batch_tag_removed`), whose zh-CN copy counts items with
+/// the book measure word「本书」. Videos are not books; the confirm dialog read
+/// "确定删除 26 本书？" for a video multi-select. The page must call the
+/// `*_video` variants instead, and those variants must carry video wording.
+void main() {
+  final File pageFile = File(
+    'lib/src/pages/implementations/home_video_page.dart',
+  );
+
+  group('video batch strings use the video measure word (BUG-766)', () {
+    test('home_video_page.dart calls the *_video batch keys', () {
+      final String source = pageFile.readAsStringSync();
+
+      const List<String> requiredKeys = <String>[
+        't.batch_delete_confirm_video(',
+        't.batch_delete_success_video(',
+        't.batch_tag_added_video(',
+        't.batch_tag_removed_video(',
+      ];
+      for (final String key in requiredKeys) {
+        expect(
+          source.contains(key),
+          isTrue,
+          reason: 'video page must call $key',
+        );
+      }
+
+      // The book-worded variants must not leak back into the video page.
+      final RegExp bookKey = RegExp(
+        r't\.batch_(delete_confirm|delete_success|tag_added|tag_removed)\(',
+      );
+      expect(
+        bookKey.hasMatch(source),
+        isFalse,
+        reason: 'video page must not reuse the book-worded batch strings; '
+            'use the *_video variants (BUG-766).',
+      );
+    });
+
+    test('zh-CN video batch strings say 视频, never 本书', () {
+      final Map<String, dynamic> zhCn = jsonDecode(
+        File('lib/i18n/strings_zh-CN.i18n.json').readAsStringSync(),
+      ) as Map<String, dynamic>;
+
+      const List<String> videoKeys = <String>[
+        'batch_delete_confirm_video',
+        'batch_delete_success_video',
+        'batch_tag_added_video',
+        'batch_tag_removed_video',
+      ];
+      for (final String key in videoKeys) {
+        final String value = zhCn[key] as String;
+        expect(value.contains('视频'), isTrue, reason: '$key must mention 视频');
+        expect(
+          value.contains('本书'),
+          isFalse,
+          reason: '$key must not use the book measure word 本书 (BUG-766)',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## 问题
视频页多选删除弹窗读「确定删除 26 本书？」——视频被当成书数（量詞「本书」）。见用户截图。

## 根因
`home_video_page.dart` 的批量删除/打标签复用了书架专用 i18n key（`batch_delete_confirm` / `batch_delete_success` / `batch_tag_added` / `batch_tag_removed`），其 zh-CN 文案是书籍量詞「本书」。

## 修复
- 新增 4 个视频专用 key `*_video`（`tool/i18n_sync.dart --add` 同步全 17 语言）：zh-CN「个视频」、zh-HK「個影片」、ja「本の動画」落真值，其余英文占位。
- 视频页 4 处调用改指向 `*_video` 变体；`dart run slang` 重生成 `strings.g.dart`。

## 测试
- 新增 `test/pages/home_video_batch_counter_guard_test.dart`：源码守卫 + zh-CN 量詞守卫，PASS。
- `flutter analyze` No issues；`flutter test test/i18n/` 全 PASS。
- ⚠️ 待真机/桌面复测原始失败路径（视频多选→删除弹窗读「个视频」）。

BUG-766