### PR TITLE
ci(release): 快速发版 skip_tests 开关 + bump 1.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ on:
       release_name:
         description: 'Optional GitHub Release title.'
         required: false
+      skip_tests:
+        description: 'Fast build: skip the analyze/unit/package test suites and go straight to compile+publish. Only honored on workflow_dispatch (push-triggered debug builds always run the tests).'
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: hibiki-release-${{ github.event.release.tag_name || github.event.inputs.tag_name || github.sha }}
@@ -367,15 +372,23 @@ jobs:
         chmod +x ci/apply-patches.sh
         bash ci/apply-patches.sh
 
+    # Fast-build path (TODO-fast-release): a workflow_dispatch with skip_tests:true
+    # skips the analyze/unit/package suites and goes straight to compile+publish.
+    # push/release events never carry the input (github.event.inputs.skip_tests is
+    # '') so they keep running the full gate -- the continuous test signal on
+    # main/develop is preserved; only the manual, user-waited release is fast.
     - name: Run dart analyze
+      if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.skip_tests == 'true') }}
       working-directory: hibiki
       run: flutter analyze
 
     - name: Run unit tests (main app)
+      if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.skip_tests == 'true') }}
       working-directory: hibiki
       run: dart run tool/flutter_test_failures.dart --exclude-tags golden
 
     - name: Run package tests
+      if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.skip_tests == 'true') }}
       run: |
         for pkg in packages/hibiki_core packages/hibiki_dictionary packages/hibiki_anki packages/hibiki_audio packages/hibiki_platform; do
           if [ -d "$pkg/test" ]; then

--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -40,6 +40,14 @@ Android / Windows / macOS / iOS debug/beta workflow 必须使用跨 workflow 统
 - formal（手动）：通过手动 GitHub Release 或 `workflow_dispatch` 选择 `formal`。默认 tag 为 `v<version>`；Android 产物包含 debug APK 与 split ABI release APK，Windows 产物为 installer，macOS 为 app zip，iOS 为 no-codesign IPA。formal 是唯一允许成为 Latest 的通道。
 - 禁止事项：不要把 push、debug tag、debug APK 或 beta/test workflow 接到 formal/Latest；不要让 push 上传正式 release APK 或发布 formal/Latest；不要把 beta/test 发布成 non-prerelease 或 Latest。
 
+### 快速发版（跳测试）
+
+手动发版嫌慢时用「快速编译」路径：`release.yml`（Android）的 `workflow_dispatch` 带 `skip_tests` 输入，**默认 `true`**——手动 dispatch（debug/beta/formal 任意通道）默认跳过 `flutter analyze` + 主 app 单元测试 + 5 个 package 测试，直接进编译+发布。`release build` 步骤本身仍会挡住硬编译失败，发版前的真机验证仍按 [CLAUDE.md](../../CLAUDE.md) 走。约束：
+- `skip_tests` **只在 `workflow_dispatch` 生效**；`push`（自动 debug）与 `release`（手动 GitHub Release）事件的 `github.event.inputs.skip_tests` 为空，恒跑完整测试门——`main`/`develop` 的持续测试信号不被削弱，慢的只让手动、你在等的那次发版跳过。
+- 想手动发版也跑测试：dispatch 时把 `skip_tests` 取消勾选（设为 `false`）。
+- `release-desktop.yml`（Win/mac/iOS）本就无测试步骤，天生快，无需该开关。
+- 平台并行：Android（`release.yml`）与桌面（`release-desktop.yml`）是两条独立 workflow，同时 dispatch 即并行；桌面内部 `apple needs: windows` 是**故意串行**，避免两 job 抢同一 release 上传，勿改。
+
 ## 版本号与 build number
 
 Flutter 版本号以 `hibiki/pubspec.yaml` 的 `version: X.Y.Z+build` 为准。准备 push 前先判断本轮改动是否影响用户可安装/可分发产物：

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.0.1+691
+version: 1.1.0+692
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"


### PR DESCRIPTION
## 目标
手动发版嫌每次跑测试太慢，加一个「快速编译、跳测试」的发版路径，并把版本 bump 到 1.1.0。

## 改动
- `.github/workflows/release.yml`：`workflow_dispatch` 新增 `skip_tests` 布尔输入（**默认 true**），gate `flutter analyze` + 主 app 单元测试 + 5 个 package 测试三步。手动 dispatch（debug/beta/formal 任意通道）默认跳测试直接编译+发布。
- `push`（自动 debug）与 `release`（手动 GitHub Release）事件不带该输入，`github.event.inputs.skip_tests` 为空 → **恒跑完整测试门**，main/develop 持续测试信号不削弱。
- `hibiki/pubspec.yaml`：`1.0.1+691` → `1.1.0+692`。
- `docs/agent/build.md`：新增「快速发版（跳测试）」小节。

## 设计取舍
- 测试只在 `release.yml`（Android）里跑；`release-desktop.yml`（Win/mac/iOS）本就无测试步骤，天生快，未改。
- `apple needs: windows` 的故意串行**未动**（避免两 job 抢同一 release 上传的 softprops 竞态）。
- `release build` 步骤仍会挡硬编译失败；发版前真机验证仍按 CLAUDE.md。

## 验证
- `tool/check_release_policy.ps1` → passed（新开关不触碰任何守卫 needle）。
- 两个 workflow YAML `yaml.safe_load` 解析 OK。

## 未做（需你拍板的不可逆动作）
- **未触发任何正式发布**。formal=Latest 是你定的红线，做完准备后由你手动 dispatch。发版命令见 PR 评论/会话。