### PR TITLE
fix(clipboard-panel): 面板栏图钉/关闭暗窗可见 (BUG-766)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 748 条。点号进各自文件。
+> 共 749 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-766](bugs/BUG-766-clipboard-panel-btn-invisible.md) | ✅ | ✅ | 剪贴板面板图钉/关闭按钮暗背景不可见 |
 | [BUG-765](bugs/BUG-765-reader-selection-handles-cannot-drag.md) | ✅ | ✅ | 阅读器移动端自绘选区两端手柄拖不动 |
 | [BUG-764](bugs/BUG-764-scm-cross-paragraph-no-next.md) | ✅ | ✅ | 制卡「后加一句/前退一句」跨段落无反应（不支持跨 `<p>`） |
 | [BUG-763](bugs/BUG-763-scm-modal-clipped.md) | ✅ | ✅ | 制卡「选择句子上下文」模态显示不全（预览被按钮区遮挡） |

--- a/docs/bugs/BUG-766-clipboard-panel-btn-invisible.md
+++ b/docs/bugs/BUG-766-clipboard-panel-btn-invisible.md
@@ -1,0 +1,11 @@
+## BUG-766 · 剪贴板面板图钉/关闭按钮暗背景不可见
+- **报告**：2026-07-13（用户：截图 — 剪贴板面板栏右上的图钉📌和关闭×几乎看不见，要求「有个背景或者什么」）
+- **真实性**：✅ 真 bug。根因 `hibiki/assets/popup/global_lookup_host.js:358-365`（面板栏按钮样式）+ 缺失的主题转写。
+  面板栏 `#global-lookup-panel-bar` 是 `position:fixed` 挂在 `document.body`，在**任何 shell 之外**，所以永不继承 `applyShellStyle` 给每个 `.global-lookup-frame-shell` 打的 `data-theme`。`.panel-btn`（图钉/关闭）只定义了一个固定字色 `rgba(60,60,67,0.6)`（为亮主题设计的深灰），且默认无背景（仅 `:hover` 才出现背景）。暗窗上深灰字贴着暗底＝完全看不见。对照 `.global-lookup-close`（每卡 ×）在 `:334` 有 `[data-theme="dark"]` 浅色变种，面板栏按钮独独没有。
+- **[x] ① 已修复** — `global_lookup_host.js`：
+  1. `renderStack` 面板分支把 root descriptor（`popups[0].theme`）转写到面板栏 `data-theme`（`:1194` 附近），镜像 shell 的主题机制。
+  2. `.panel-btn` 加**常驻 chip 背景** `rgba(120,120,128,0.16)`（不再只 hover 才有）——直接满足用户「给它个背景」的诉求，在任意窗底都是可辨识的可点区。
+  3. 新增暗主题变种 `#global-lookup-panel-bar[data-theme="dark"] .panel-btn`：浅色字 `rgba(235,235,245,0.72)` + 浅色 chip，暗窗不再吃掉字形。
+  提交：<待填>
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/clipboard_panel_guard_test.dart` 新增 group「面板栏图钉/关闭可见（BUG-766 暗背景不可见）」三钉：① renderStack 把主题转写到面板栏 `data-theme`；② `.panel-btn` 规则块到 `:hover` 之间必含 `background:`（常驻 chip，防退回只 hover）；③ 暗主题浅色变种存在。全 23 例通过。提交：<待填>
+- **备注**：单源文件（其余为 build 产物），无 3-way 镜像需求（那是 popup.css）。行为级验证靠真机 / node harness；本轮离屏只跑源码守卫。待真机复测暗/亮两主题下图钉与关闭均清晰可见、图钉未固定态 `opacity:0.45` 仍生效。

--- a/docs/bugs/BUG-766-clipboard-panel-btn-invisible.md
+++ b/docs/bugs/BUG-766-clipboard-panel-btn-invisible.md
@@ -6,6 +6,6 @@
   1. `renderStack` 面板分支把 root descriptor（`popups[0].theme`）转写到面板栏 `data-theme`（`:1194` 附近），镜像 shell 的主题机制。
   2. `.panel-btn` 加**常驻 chip 背景** `rgba(120,120,128,0.16)`（不再只 hover 才有）——直接满足用户「给它个背景」的诉求，在任意窗底都是可辨识的可点区。
   3. 新增暗主题变种 `#global-lookup-panel-bar[data-theme="dark"] .panel-btn`：浅色字 `rgba(235,235,245,0.72)` + 浅色 chip，暗窗不再吃掉字形。
-  提交：<待填>
-- **[x] ② 已加自动化测试** — `hibiki/test/lookup/clipboard_panel_guard_test.dart` 新增 group「面板栏图钉/关闭可见（BUG-766 暗背景不可见）」三钉：① renderStack 把主题转写到面板栏 `data-theme`；② `.panel-btn` 规则块到 `:hover` 之间必含 `background:`（常驻 chip，防退回只 hover）；③ 暗主题浅色变种存在。全 23 例通过。提交：<待填>
+  提交：5e51a48fb
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/clipboard_panel_guard_test.dart` 新增 group「面板栏图钉/关闭可见（BUG-766 暗背景不可见）」三钉：① renderStack 把主题转写到面板栏 `data-theme`；② `.panel-btn` 规则块到 `:hover` 之间必含 `background:`（常驻 chip，防退回只 hover）；③ 暗主题浅色变种存在。全 23 例通过。提交：5e51a48fb
 - **备注**：单源文件（其余为 build 产物），无 3-way 镜像需求（那是 popup.css）。行为级验证靠真机 / node harness；本轮离屏只跑源码守卫。待真机复测暗/亮两主题下图钉与关闭均清晰可见、图钉未固定态 `opacity:0.45` 仍生效。

--- a/hibiki/assets/popup/global_lookup_host.js
+++ b/hibiki/assets/popup/global_lookup_host.js
@@ -355,13 +355,22 @@
         'flex:1;height:100%;cursor:move;display:flex;align-items:center;' +
         'padding-left:10px;font-family:"Segoe UI",sans-serif;font-size:11px;' +
         'color:rgba(120,120,128,0.8);letter-spacing:2px;}' +
+        // BUG-766 — persistent chip background so the pin/close read as tappable
+        // affordances on ANY window surface (light or dark); glyph color is made
+        // theme-aware below so it stays legible against that chip.
         '#global-lookup-panel-bar .panel-btn{' +
         'width:24px;height:24px;line-height:24px;text-align:center;' +
         'margin-right:4px;font-family:"Segoe UI Symbol","Segoe UI",sans-serif;' +
         'font-size:14px;cursor:pointer;border-radius:12px;' +
-        'color:rgba(60,60,67,0.6);}' +
+        'background:rgba(120,120,128,0.16);color:rgba(60,60,67,0.75);}' +
         '#global-lookup-panel-bar .panel-btn:hover{' +
-        'background:rgba(120,120,128,0.16);color:rgba(60,60,67,0.9);}' +
+        'background:rgba(120,120,128,0.28);color:rgba(60,60,67,0.95);}' +
+        // BUG-766 — dark-window variant (stamped via data-theme in renderStack):
+        // light glyph + light chip so the buttons don't vanish on a dark surface.
+        '#global-lookup-panel-bar[data-theme="dark"] .panel-btn{' +
+        'background:rgba(235,235,245,0.14);color:rgba(235,235,245,0.72);}' +
+        '#global-lookup-panel-bar[data-theme="dark"] .panel-btn:hover{' +
+        'background:rgba(235,235,245,0.24);color:rgba(235,235,245,0.95);}' +
         '#global-lookup-panel-bar .panel-btn.panel-pin-off{opacity:0.45;}' +
         // Bottom-right resize grip (posts beginWindowResize).
         '#global-lookup-panel-resize{' +
@@ -1192,7 +1201,17 @@
     // transient overlay's payload/behaviour is byte-identical to pre-panel).
     layoutMode = (payload && payload.layoutMode) === 'panel' ? 'panel' : 'cascade';
     if (layoutMode === 'panel') {
-      ensurePanelBar();
+      var panelBar = ensurePanelBar();
+      // BUG-766 — the panel bar lives in document.body (fixed, OUTSIDE any shell),
+      // so it never inherits the per-shell data-theme. Without it the pin/close
+      // glyphs kept the light-theme dark-gray color (rgba(60,60,67,.6)) and
+      // vanished on a dark window. Stamp the root descriptor's resolved brightness
+      // onto the bar so the dark-theme .panel-btn variant applies (mirrors the
+      // per-shell .global-lookup-close dark variant).
+      var rootTheme = popups.length ? (popups[0] && popups[0].theme) : null;
+      if (panelBar && (rootTheme === 'dark' || rootTheme === 'light')) {
+        panelBar.setAttribute('data-theme', rootTheme);
+      }
     }
     if (!popups.length) {
       removeMissing([]);

--- a/hibiki/test/lookup/clipboard_panel_guard_test.dart
+++ b/hibiki/test/lookup/clipboard_panel_guard_test.dart
@@ -278,4 +278,39 @@ void main() {
       );
     });
   });
+
+  // BUG-766 — 面板栏（图钉/关闭）在 document.body、fixed，不继承 shell 的
+  // data-theme；旧代码只给 light 主题的深灰字色，暗窗上完全看不见。修复=把 root
+  // 主题转写到面板栏 + 常驻 chip 背景 + 暗主题浅色字。三处互钉，任一改回都回归。
+  group('面板栏图钉/关闭可见（BUG-766 暗背景不可见）', () {
+    test('renderStack 把 root descriptor 主题转写到面板栏 data-theme', () {
+      expect(hostJs.contains('panelBar.setAttribute('), isTrue,
+          reason: '面板栏必须拿到 data-theme，否则暗主题变种永不命中');
+      expect(hostJs.contains("popups[0] && popups[0].theme"), isTrue,
+          reason: '主题真值源=root 弹窗 descriptor（render 侧 map[theme]）');
+    });
+
+    test('.panel-btn 恒有 chip 背景（用户诉求：给它个背景）', () {
+      final int rule = hostJs.indexOf("'#global-lookup-panel-bar .panel-btn{'");
+      expect(rule, isNonNegative);
+      // 该规则块到 :hover 之间必须含 background（非仅 hover 才出现）。
+      final int hover = hostJs.indexOf(".panel-btn:hover", rule);
+      expect(hover, isNonNegative);
+      expect(
+        hostJs.substring(rule, hover).contains('background:'),
+        isTrue,
+        reason: '常驻 chip 背景=按钮在任意窗底都可见；不能退回只 hover 才有背景',
+      );
+    });
+
+    test('暗主题面板栏按钮有浅色变种（暗窗不再深灰吃掉）', () {
+      expect(
+        hostJs.contains(
+            '#global-lookup-panel-bar[data-theme="dark"] .panel-btn{'),
+        isTrue,
+        reason: '暗主题必须覆盖为浅色字 + 浅色 chip，镜像 .global-lookup-close 暗变种',
+      );
+      expect(hostJs.contains('rgba(235,235,245'), isTrue);
+    });
+  });
 }


### PR DESCRIPTION
## 现象
用户截图：剪贴板面板栏右上的图钉📌和关闭×在暗色窗底上几乎完全看不见。诉求「让他有个背景或者什么」。

## 根因
`#global-lookup-panel-bar` 是 `position:fixed` 挂在 `document.body`，在**任何 shell 之外**，永不继承 `applyShellStyle` 给每个 `.global-lookup-frame-shell` 打的 `data-theme`。`.panel-btn`（图钉/关闭）只有一个为亮主题设计的固定深灰字色 `rgba(60,60,67,0.6)`，且默认无背景（仅 `:hover` 才出现）。暗窗上深灰贴暗底＝隐形。对照 `.global-lookup-close`（每卡 ×）本就有 `[data-theme="dark"]` 浅色变种，面板栏按钮独独漏了。

## 修复（`hibiki/assets/popup/global_lookup_host.js`）
1. `renderStack` 面板分支把 root descriptor（`popups[0].theme`）转写到面板栏 `data-theme`，镜像 shell 主题机制。
2. `.panel-btn` 加**常驻 chip 背景**（不再只 hover 才有）——直接满足用户诉求，任意窗底都可辨识。
3. 新增暗主题变种：浅色字 + 浅色 chip。

## 测试
`hibiki/test/lookup/clipboard_panel_guard_test.dart` 新增 group 三钉（主题转写 / 常驻背景 / 暗变种）；`test/lookup/` 全 408 例通过。

## 待办
真机复测暗/亮两主题下图钉与关闭均清晰可见、图钉未固定态 `opacity:0.45` 仍生效。BUG-766。