### PR TITLE
fix(extension): file:// opaque-origin safe cross-world postMessage (BUG-766)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 748 条。点号进各自文件。
+> 共 749 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-766](bugs/BUG-766-nf-postmessage-file-origin.md) | ✅ | ✅ | Netflix字幕面板file://下postMessage因opaque origin报错致列表空 |
 | [BUG-765](bugs/BUG-765-reader-selection-handles-cannot-drag.md) | ✅ | ✅ | 阅读器移动端自绘选区两端手柄拖不动 |
 | [BUG-764](bugs/BUG-764-scm-cross-paragraph-no-next.md) | ✅ | ✅ | 制卡「后加一句/前退一句」跨段落无反应（不支持跨 `<p>`） |
 | [BUG-763](bugs/BUG-763-scm-modal-clipped.md) | ✅ | ✅ | 制卡「选择句子上下文」模态显示不全（预览被按钮区遮挡） |

--- a/docs/bugs/BUG-766-nf-postmessage-file-origin.md
+++ b/docs/bugs/BUG-766-nf-postmessage-file-origin.md
@@ -1,0 +1,37 @@
+## BUG-766 · Netflix字幕面板file://下postMessage因opaque origin报错致列表空
+
+- **报告**：2026-07-13（用户：控制台报错 + 截图）
+- **真实性**：✅ 真 bug。根因：跨世界自投消息用 `location.origin` 作 `postMessage` 的
+  `targetOrigin`，在 `file://` 页（opaque origin）下 recipient 真实源序列化为 `'null'`，而
+  `location.origin` 返回 `'file://'` → 二者不匹配，浏览器抛
+  `Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('file://')
+  does not match the recipient window's origin ('null')` 并丢弃消息。
+  - 发送端（全部同窗自投）：
+    - `content.js`：`window.postMessage({ __hibikiNf: 'replayCues' }, location.origin)`（用户报错行）
+    - `content.js`：`window.postMessage({ __hibikiNf: 'seek', ms }, window.location.origin)`
+    - `hibiki/assets/browser_extension/subtitle-panel.js:140`：`seek` 自投
+    - `hibiki/assets/browser_extension/netflix-bridge.js:25`：`cues` 自投；`:131`：`seekDone` 自投
+  - 接收端：`hibiki/assets/browser_extension/netflix-bridge.js:9,119`：
+    `var ORIGIN = window.location.origin;` + `if (e.origin !== ORIGIN ...) return;`
+    —— `file://` 下 `e.origin==='null'` ≠ `ORIGIN==='file://'`，即便消息送达也被拒。
+  - 症状链：content.js `document_idle` 就绪后发 `replayCues` 请求 bridge 重放已存档 cue，
+    但该 postMessage 在 `file://` 页直接抛错永不送达 → bridge 不重放 → 面板 store 空、
+    勾选开关无物可挂、列表只剩预取的下一集轨（空）。content.js 走 `<all_urls>` 注入，故任何
+    `file://` 页都会触发这条握手。
+- **[x] ① 已修复** — 同窗自投一律改用 `targetOrigin '/'`（= 仅同源同窗才投递，对不透明源恒成立、
+  不做 URL 解析，故 `file://` 与 `https` 都送达）；接收端期望源改用 `window.origin`（不透明源
+  返回 `'null'`，与 `e.origin` 一致；`https` 下与 `location.origin` 等价），保留原「拒绝异源」守卫。
+  改动文件（两镜像 `hibiki/assets/browser_extension/` + `tools/browser-extension/` 字节一致）：
+  `netflix-bridge.js`（`ORIGIN=window.origin` + 两处 `'/'`）、`subtitle-panel.js`（seek `'/'`）、
+  `content.js`（replayCues/seek `'/'`）。
+- **[x] ② 已加自动化测试** —
+  - `tools/browser-extension/netflix-bridge.test.js`：新增
+    `BUG-766 opaque origin（file://）下 cue 往返不丢` —— 以 `windowOrigin:'null'/locationOrigin:'file://'`
+    加载桥，断言抓轨自投 `targetOrigin==='/'`，且 `e.origin==='null'` 的 `replayCues` 被接收端认可整批重放。
+  - `hibiki/test/build/browser_extension_dict_media_mirror_guard_test.dart`：新增
+    `cross-world postMessage is file:// opaque-origin safe` 源码扫描守卫 —— 两镜像的
+    `netflix-bridge.js`/`subtitle-panel.js`/`content.js` 均不得再用 `location.origin` 作 targetOrigin，
+    且桥接收端必须 `var ORIGIN = window.origin;`、不得出现 `window.location.origin`。
+- **备注**：验证 `node --test netflix-bridge.test.js`（15/15）+
+  `flutter test test/build/browser_extension_dict_media_mirror_guard_test.dart`（59/59）全绿。
+  待用户在真机 `file://` 页复测原始失败路径。

--- a/hibiki/assets/browser_extension/content.js
+++ b/hibiki/assets/browser_extension/content.js
@@ -189,7 +189,7 @@ window.addEventListener('message', (e) => {
 // netflix-bridge.js document_start 就装好 hook——Netflix 播放清单/字幕轨常在**本 listener 注册前**
 // 就被抓取并 postMessage 出去，fire-and-forget 的消息永久丢失 → store 空、勾选开关无物可挂、
 // 面板只剩预取的下一集轨（列表空）。接收端就位后立刻请求 bridge 重放已存档的 cue 消息，消除时序运气。
-try { window.postMessage({ __hibikiNf: 'replayCues' }, location.origin); } catch (_) {}
+try { window.postMessage({ __hibikiNf: 'replayCues' }, '/'); } catch (_) {}
 
 // ── TODO-1363：通用字幕轨 provider（所有站点） ──
 // 数据契约不变：window.hibikiEpisodeCues[`${videoKey}|${lang}`] = [{startMs,endMs,text}]，新数据到达
@@ -524,7 +524,7 @@ async function hibikiRunNetflixBatch() {
     v.addEventListener('seeked', onSeeked);
     window.addEventListener('message', onMsg);
     // 走 Netflix 官方播放器 API seek（主世界 netflix-bridge.js 执行），不改 currentTime → 不触发 M7375。
-    try { window.postMessage({ __hibikiNf: 'seek', ms: ms }, window.location.origin); } catch (_) {}
+    try { window.postMessage({ __hibikiNf: 'seek', ms: ms }, '/'); } catch (_) {}
     setTimeout(finish, 5000); // 兜底：seeked / seekDone 都不来也继续
   });
   try {

--- a/hibiki/assets/browser_extension/netflix-bridge.js
+++ b/hibiki/assets/browser_extension/netflix-bridge.js
@@ -6,7 +6,11 @@
 // **之前**装好 JSON.parse hook，拦到整集字幕轨。seek 路径不受影响：nfSeek 里 videoPlayer 是收到
 // seek 消息时才惰性解析（非脚本加载时），document_start 只是提前注册 listener + hook，安全。
 (function () {
-  var ORIGIN = window.location.origin;
+  // BUG-766：跨世界自投消息全部用 targetOrigin '/'（仅同源同窗才投递），而非 location.origin。
+  // file:// 页 opaque origin 序列化成 'null'，但 location.origin 返回 'file://' → 二者不匹配，
+  // postMessage 直接抛异常/静默丢弃。'/' 对不透明源同样成立（同窗自投恒同源），且不做 URL 解析。
+  // 接收端比对期望源用 window.origin（不透明源返回 'null'，与 e.origin 一致），location.origin 会错序列化。
+  var ORIGIN = window.origin;
 
   // ── TODO-1219 P1：整集字幕拦截（数据源） ──
   // Netflix 播放清单 timedtexttracks[] 列出每条字幕轨的下载地址（明文 WebVTT/TTML，非 DRM；只有
@@ -22,7 +26,7 @@
   var cueArchive = [];
   var CUE_ARCHIVE_MAX = 80;
   function postCuesMessage(payload) {
-    try { window.postMessage(payload, ORIGIN); } catch (_) {}
+    try { window.postMessage(payload, '/'); } catch (_) {}
   }
 
   function pickTrackUrl(track) {
@@ -128,7 +132,7 @@
     var replied = false;
     var reply = function (ok, err) {
       if (replied) return; replied = true;
-      try { window.postMessage({ __hibikiNf: 'seekDone', ok: ok, err: err || '' }, ORIGIN); } catch (_) {}
+      try { window.postMessage({ __hibikiNf: 'seekDone', ok: ok, err: err || '' }, '/'); } catch (_) {}
     };
     try { nfSeek(d.ms, function () { reply(true, ''); }); }
     catch (x) { reply(false, String(x)); }

--- a/hibiki/assets/browser_extension/subtitle-panel.js
+++ b/hibiki/assets/browser_extension/subtitle-panel.js
@@ -137,7 +137,8 @@
     ms = Math.max(0, Math.round(ms));
     if (/(^|\.)netflix\.com$/.test(location.hostname)) {
       // Netflix（DRM 平台边界）：走主世界 bridge 的官方 player.seek（直接改 currentTime 会触发 M7375）。
-      try { window.postMessage({ __hibikiNf: 'seek', ms: ms }, location.origin); } catch (_) {}
+      // BUG-766：自投用 targetOrigin '/'，file:// opaque origin 下 location.origin('file://')≠recipient('null') 会抛错。
+      try { window.postMessage({ __hibikiNf: 'seek', ms: ms }, '/'); } catch (_) {}
       return;
     }
     var v = videoEl();

--- a/hibiki/test/build/browser_extension_dict_media_mirror_guard_test.dart
+++ b/hibiki/test/build/browser_extension_dict_media_mirror_guard_test.dart
@@ -287,6 +287,39 @@ void main() {
                 'cues receiver (injection-order race, TODO-1219)');
       });
 
+      // BUG-766 根因守卫：跨世界自投消息在 file:// 页 opaque origin 下会炸。opaque origin 序列化成
+      // 'null'，但 location.origin 返回 'file://' → 二者不匹配 → postMessage 抛 SyntaxError/静默丢弃，
+      // 整条 cue 桥（含 replayCues 握手）在 file:// 下死掉 → 面板 store 空、列表空。正确做法：自投一律
+      // 用 targetOrigin '/'（仅同源同窗投递，对不透明源恒成立、不做 URL 解析），接收端比对期望源用
+      // window.origin（不透明源返回 'null'，与 e.origin 一致）。两镜像、三文件都锁死防回归。
+      test('[$name] cross-world postMessage is file:// opaque-origin safe', () {
+        const List<String> selfPostFiles = <String>[
+          'netflix-bridge.js',
+          'subtitle-panel.js',
+          'content.js',
+        ];
+        final RegExp badTarget =
+            RegExp(r'postMessage\([^;]*?,\s*(window\.)?location\.origin\s*\)');
+        for (final String rel in selfPostFiles) {
+          final String src = File('$root/$rel').readAsStringSync();
+          expect(badTarget.hasMatch(src), isFalse,
+              reason:
+                  '$root $rel must not use location.origin as a postMessage '
+                  'targetOrigin (BUG-766: throws on file:// opaque origin — '
+                  'use a bare-slash targetOrigin instead)');
+        }
+        // 接收端期望源改用 window.origin，绝不能退回 window.location.origin（file:// 会错序列化成 'file://'）。
+        final String bridge =
+            File('$root/netflix-bridge.js').readAsStringSync();
+        expect(bridge.contains('var ORIGIN = window.origin;'), isTrue,
+            reason: '$root netflix-bridge.js receiver must compare against '
+                'window.origin (opaque-origin safe), not location.origin');
+        expect(bridge.contains('window.location.origin'), isFalse,
+            reason:
+                '$root netflix-bridge.js must not read window.location.origin '
+                '(BUG-766: mis-serializes opaque file:// origin)');
+      });
+
       // TODO-1363 通用化守卫：面板不再是 Netflix 专属——数据源抽象（provider 全在 content.js，
       // 面板消费同一个 store），面板文件不得再按 hostname 早退。
       test('[$name] subtitle-panel.js is universal (no Netflix hostname gate)',

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -189,7 +189,7 @@ window.addEventListener('message', (e) => {
 // netflix-bridge.js document_start 就装好 hook——Netflix 播放清单/字幕轨常在**本 listener 注册前**
 // 就被抓取并 postMessage 出去，fire-and-forget 的消息永久丢失 → store 空、勾选开关无物可挂、
 // 面板只剩预取的下一集轨（列表空）。接收端就位后立刻请求 bridge 重放已存档的 cue 消息，消除时序运气。
-try { window.postMessage({ __hibikiNf: 'replayCues' }, location.origin); } catch (_) {}
+try { window.postMessage({ __hibikiNf: 'replayCues' }, '/'); } catch (_) {}
 
 // ── TODO-1363：通用字幕轨 provider（所有站点） ──
 // 数据契约不变：window.hibikiEpisodeCues[`${videoKey}|${lang}`] = [{startMs,endMs,text}]，新数据到达
@@ -524,7 +524,7 @@ async function hibikiRunNetflixBatch() {
     v.addEventListener('seeked', onSeeked);
     window.addEventListener('message', onMsg);
     // 走 Netflix 官方播放器 API seek（主世界 netflix-bridge.js 执行），不改 currentTime → 不触发 M7375。
-    try { window.postMessage({ __hibikiNf: 'seek', ms: ms }, window.location.origin); } catch (_) {}
+    try { window.postMessage({ __hibikiNf: 'seek', ms: ms }, '/'); } catch (_) {}
     setTimeout(finish, 5000); // 兜底：seeked / seekDone 都不来也继续
   });
   try {

--- a/tools/browser-extension/netflix-bridge.js
+++ b/tools/browser-extension/netflix-bridge.js
@@ -6,7 +6,11 @@
 // **之前**装好 JSON.parse hook，拦到整集字幕轨。seek 路径不受影响：nfSeek 里 videoPlayer 是收到
 // seek 消息时才惰性解析（非脚本加载时），document_start 只是提前注册 listener + hook，安全。
 (function () {
-  var ORIGIN = window.location.origin;
+  // BUG-766：跨世界自投消息全部用 targetOrigin '/'（仅同源同窗才投递），而非 location.origin。
+  // file:// 页 opaque origin 序列化成 'null'，但 location.origin 返回 'file://' → 二者不匹配，
+  // postMessage 直接抛异常/静默丢弃。'/' 对不透明源同样成立（同窗自投恒同源），且不做 URL 解析。
+  // 接收端比对期望源用 window.origin（不透明源返回 'null'，与 e.origin 一致），location.origin 会错序列化。
+  var ORIGIN = window.origin;
 
   // ── TODO-1219 P1：整集字幕拦截（数据源） ──
   // Netflix 播放清单 timedtexttracks[] 列出每条字幕轨的下载地址（明文 WebVTT/TTML，非 DRM；只有
@@ -22,7 +26,7 @@
   var cueArchive = [];
   var CUE_ARCHIVE_MAX = 80;
   function postCuesMessage(payload) {
-    try { window.postMessage(payload, ORIGIN); } catch (_) {}
+    try { window.postMessage(payload, '/'); } catch (_) {}
   }
 
   function pickTrackUrl(track) {
@@ -128,7 +132,7 @@
     var replied = false;
     var reply = function (ok, err) {
       if (replied) return; replied = true;
-      try { window.postMessage({ __hibikiNf: 'seekDone', ok: ok, err: err || '' }, ORIGIN); } catch (_) {}
+      try { window.postMessage({ __hibikiNf: 'seekDone', ok: ok, err: err || '' }, '/'); } catch (_) {}
     };
     try { nfSeek(d.ms, function () { reply(true, ''); }); }
     catch (x) { reply(false, String(x)); }

--- a/tools/browser-extension/netflix-bridge.test.js
+++ b/tools/browser-extension/netflix-bridge.test.js
@@ -13,13 +13,19 @@ const vm = require('node:vm');
 
 const BRIDGE = path.join(__dirname, 'netflix-bridge.js');
 
-function loadBridge() {
+function loadBridge(opts) {
+  opts = opts || {};
+  // BUG-766：window.origin 与 location.origin 在 file:// 下不同——前者是 opaque origin 序列化 'null'，
+  // 后者是 'file://'。桥的接收端比对期望源现改用 window.origin，故 harness 两者都要能独立设置。
+  const locationOrigin = opts.locationOrigin || 'https://www.netflix.com';
+  const windowOrigin = opts.windowOrigin || locationOrigin;
   const src = fs.readFileSync(BRIDGE, 'utf8');
   const posted = [];
   const listeners = [];
   const fetched = [];
   const windowObj = {
-    location: { origin: 'https://www.netflix.com' },
+    location: { origin: locationOrigin },
+    origin: windowOrigin,
     postMessage: (msg, origin) => posted.push({ msg, origin }),
     addEventListener: (t, fn) => { if (t === 'message') listeners.push(fn); },
   };
@@ -100,4 +106,30 @@ test('replayCues 只认同源同窗消息（不被宿主页第三方 iframe 驱�
     fn({ origin: 'https://www.netflix.com', source: {}, data: { __hibikiNf: 'replayCues' } });
   }
   assert.strictEqual(h.posted.length, 0, '跨源/跨窗的 replayCues 必须被忽略');
+});
+
+test('BUG-766 opaque origin（file://）下 cue 往返不丢：自投用 "/"、接收端认 window.origin', async () => {
+  // file:// 页 opaque origin：window.origin 序列化成 'null'，而 location.origin 返回 'file://'。
+  // 旧代码自投用 location.origin('file://') 作 targetOrigin → 与 recipient 真实源 'null' 不匹配 →
+  // postMessage 抛错、消息永久丢失（store 空、面板列表空）；接收端 e.origin 比对 location.origin 也永远失败。
+  const h = loadBridge({ locationOrigin: 'file://', windowOrigin: 'null' });
+  vm.runInContext('JSON.parse(' + JSON.stringify(JSON.stringify(makeManifest())) + ')', h.ctx);
+  await settle();
+  const cues = h.posted.filter((p) => p.msg && p.msg.__hibikiNf === 'cues');
+  assert.strictEqual(cues.length, 3, 'file:// 下仍抓全 3 轨');
+  // targetOrigin 必须是 "/"（= 仅同源同窗投递，对不透明源成立）；绝不能是 location.origin/'file://'。
+  for (const p of cues) {
+    assert.strictEqual(p.origin, '/', 'file:// 自投必须用 "/" 作 targetOrigin');
+  }
+
+  // content.js 晚注入后请求重放：e.origin 为不透明源序列化 'null'，接收端须认可（ORIGIN=window.origin='null'）。
+  h.posted.length = 0;
+  for (const fn of h.listeners) {
+    fn({ origin: 'null', source: h.windowObj, data: { __hibikiNf: 'replayCues' } });
+  }
+  const replayed = h.posted.filter((p) => p.msg && p.msg.__hibikiNf === 'cues');
+  assert.strictEqual(replayed.length, 3, 'file:// opaque origin 的 replayCues 必须被接收端认可并整批重放');
+  for (const p of replayed) {
+    assert.strictEqual(p.origin, '/', '重放同样用 "/" 作 targetOrigin');
+  }
 });

--- a/tools/browser-extension/subtitle-panel.js
+++ b/tools/browser-extension/subtitle-panel.js
@@ -137,7 +137,8 @@
     ms = Math.max(0, Math.round(ms));
     if (/(^|\.)netflix\.com$/.test(location.hostname)) {
       // Netflix（DRM 平台边界）：走主世界 bridge 的官方 player.seek（直接改 currentTime 会触发 M7375）。
-      try { window.postMessage({ __hibikiNf: 'seek', ms: ms }, location.origin); } catch (_) {}
+      // BUG-766：自投用 targetOrigin '/'，file:// opaque origin 下 location.origin('file://')≠recipient('null') 会抛错。
+      try { window.postMessage({ __hibikiNf: 'seek', ms: ms }, '/'); } catch (_) {}
       return;
     }
     var v = videoEl();


### PR DESCRIPTION
## 根因
Netflix 字幕面板/查词的跨世界桥用 `location.origin` 作 `postMessage` 的 `targetOrigin`。在 `file://` 页（opaque origin）下，recipient 真实源序列化为 `'null'`，而 `location.origin` 返回 `'file://'` → 不匹配，浏览器抛错并丢弃消息：

```
Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('file://') does not match the recipient window's origin ('null').
```

`content.js` 走 `<all_urls>` 注入，其 `document_idle` 就绪后发的 `{__hibikiNf:'replayCues'}` 握手在 `file://` 页永不送达 → bridge 不重放已存档 cue → 面板 store 空、勾选开关无物可挂、列表只剩预取的下一集轨（空）。接收端 `e.origin !== ORIGIN`（ORIGIN=location.origin）在 `file://` 下也永远失败。

## 修复
- **发送端**（全部同窗自投）：`targetOrigin` 由 `location.origin` 改为 `'/'` —— 仅同源同窗才投递，对不透明源恒成立、不做 URL 解析，`file://` 与 `https` 都送达。
- **接收端**：`var ORIGIN = window.location.origin` → `window.origin`（不透明源返回 `'null'`，与 `e.origin` 一致；`https` 下与 `location.origin` 等价），保留原「拒绝异源」守卫。
- 改动文件（两镜像 `hibiki/assets/browser_extension/` + `tools/browser-extension/` 字节一致）：`netflix-bridge.js`、`subtitle-panel.js`、`content.js`。

## 测试
- `tools/browser-extension/netflix-bridge.test.js`：新增 `file://` opaque-origin cue 往返测试（自投 `'/'` + 接收端认 `window.origin`）。node `--test` 15/15。
- `hibiki/test/build/browser_extension_dict_media_mirror_guard_test.dart`：新增源码扫描守卫（两镜像三文件不得再用 `location.origin` 作 targetOrigin；桥必须 `window.origin`）。flutter test 59/59。

## 待办
真机 `file://` 页复测原始失败路径。