### PR TITLE
fix(ext): 查词弹窗永不覆盖被查词 (BUG-767)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 749 条。点号进各自文件。
+> 共 750 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-767](bugs/BUG-767-ext-popup-covers-word.md) | ✅ | ✅ | 网页扩展 Shift 查词弹窗遮住被查词 |
 | [BUG-766](bugs/BUG-766-video-batch-book-counter.md) | ✅ | ✅ | 视频页批量删除/打标签文案误用「本书」量詞 |
 | [BUG-765](bugs/BUG-765-reader-selection-handles-cannot-drag.md) | ✅ | ✅ | 阅读器移动端自绘选区两端手柄拖不动 |
 | [BUG-764](bugs/BUG-764-scm-cross-paragraph-no-next.md) | ✅ | ✅ | 制卡「后加一句/前退一句」跨段落无反应（不支持跨 `<p>`） |

--- a/docs/bugs/BUG-767-ext-popup-covers-word.md
+++ b/docs/bugs/BUG-767-ext-popup-covers-word.md
@@ -1,0 +1,6 @@
+## BUG-767 · 网页扩展 Shift 查词弹窗遮住被查词
+- **报告**：2026-07-13（用户：）
+- **真实性**：✅ 真 bug。根因在 `hibiki/assets/browser_extension/content.js` 的 `hibikiRender()` 内 `place()` 落点逻辑（原 `content.js:1327` 一带的翻转分支）：默认把弹窗落在词下方 `top = ay + ah + 4`；当下方放不下（`top + 弹窗高 > vh - 8`）时翻到词上方 `top = Math.max(8, ay - 弹窗高 - 4)`，**但从不把弹窗高度夹到可用空间**。词典结果多时弹窗较高，若视口不够高（`vh < ~2×弹窗高`）且被查词在上半屏，翻上方后 `ay - 弹窗高 - 4 < 8` 被夹成 `top = 8`，弹窗从视口顶 8px 处往下铺开，直接盖住被查词。实测 `vh=700 / 词 y=340 高 20 / 弹窗高 360` → 弹窗 `[8, 368]` 覆盖词 `[340, 360]`。
+- **[x] ① 已修复** — 把落点收敛进纯函数 `hibikiComputePlacement(anchor, size, viewport)`（`content.js`，两份镜像 `hibiki/assets/browser_extension/` + `tools/browser-extension/` 同步）：下方能放整只→落词下方；上方能放整只→落词上方；两侧都放不下→选空间更大的一侧，并把弹窗 `maxHeight` 夹到该侧可用空间（内部滚动），使弹窗底/顶恰贴词边，绝不覆盖被查词。`place()` 改为调用它并按 zoom 写回 `left/top/maxHeight`。提交：（见本分支）。
+- **[x] ② 已加自动化测试** — `tools/browser-extension/popup-placement.test.js`（`node --test`）：在受控 vm 里真加载 `content.js`，直接调其顶层纯函数，断言弹窗矩形纵向**永不**与被查词矩形重叠且落在视口内，含旧逻辑必然翻车的高弹窗矮视口场景（已单独验证旧算法在该场景 `top=8` 覆盖词、守卫会失败）。5/5 通过。
+- **备注**：改动仅两份 `content.js` 镜像（未碰 `popup.css`，无需重生成 `content.css`）。同目录 `highlight-overlay.test.js` 3 项失败为**既有 bitrot**（在原始未改 `content.js` 上同样 3/3 失败，与本次无关，未在 CI 中运行）。真机复测：需在浏览器扩展里 Shift 查上半屏的词、结果较多时确认弹窗落词下方/上方而非盖住词。

--- a/hibiki/assets/browser_extension/content.js
+++ b/hibiki/assets/browser_extension/content.js
@@ -1242,6 +1242,45 @@ window.__hibikiOnLinkClick = function (query) {
   } catch (_) { /* 扩展上下文失效：静默 */ }
 };
 
+// BUG-767：计算查词弹窗落点，保证**永不覆盖被查词**。纯函数（不碰 DOM），便于单测。
+// anchor：被查词的视口矩形 {x, y, height}（x/y=左上角，height=词高，均视口坐标系）。
+// size：弹窗自然尺寸 {width, height}（已按主题 max-height 夹住的可见尺寸）。
+// viewport：{width, height}。返回 {left, top, maxHeight}；maxHeight!=null 表示上下两侧
+// 都放不下整只弹窗，需把弹窗高度夹到所选一侧的可用空间（内部滚动），故渲染后不会压到词上。
+// 旧实现只把 top 夹到边距 8，弹窗高时（词典结果多）会从 8 往下铺开盖住上半屏的词——本函数修掉。
+function hibikiComputePlacement(anchor, size, viewport) {
+  const M = 8; // 视口边距
+  const G = 4; // 词与弹窗之间的间隙
+  const vw = viewport.width;
+  const vh = viewport.height;
+  const ax = anchor.x;
+  const ay = anchor.y;
+  const ah = anchor.height || 0;
+  const pw = size.width;
+  const ph = size.height;
+  // 横向：左对齐词左缘，右/左溢出各自贴边（原行为，未变）。
+  let left = ax;
+  if (left + pw > vw - M) left = Math.max(M, vw - pw - M);
+  if (left < M) left = M;
+  // 纵向：词下方 / 上方各自的可用高度（含留出的视口边距）。
+  const belowSpace = vh - (ay + ah) - M; // 词底 → 视口底
+  const aboveSpace = ay - M;             // 视口顶 → 词顶
+  let top;
+  let maxHeight = null;
+  if (ph + G <= belowSpace) {
+    top = ay + ah + G;                   // 下方放得下整只弹窗：落词下方
+  } else if (ph + G <= aboveSpace) {
+    top = ay - G - ph;                   // 上方放得下整只弹窗：落词上方
+  } else if (belowSpace >= aboveSpace) {
+    top = ay + ah + G;                   // 两侧都放不下、下方空间更大：贴词下方并夹高度
+    maxHeight = Math.max(64, belowSpace - G);
+  } else {
+    maxHeight = Math.max(64, aboveSpace - G); // 上方空间更大：夹高度使弹窗底恰落词顶之上
+    top = Math.max(M, ay - G - maxHeight);
+  }
+  return { left, top, maxHeight };
+}
+
 function hibikiRender(popupJson, termLen, theme, anchorRect) {
   const c = hibikiEnsureContainer();
   // BUG-530：查词响应带回当前 app 主题色（--md-*），套到弹窗容器上，弹窗实时跟随用户主题
@@ -1314,25 +1353,24 @@ function hibikiRender(popupJson, termLen, theme, anchorRect) {
     // BUG-688：量 host 的 rect（被 max-height 夹住=可见尺寸），不是容器（overflow:visible=全内容
     // 高度，会把弹窗错误地翻到词上方）。host 无则回落容器。
     const rect = (hibikiHost || c).getBoundingClientRect();
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
     // 锚点=被查词的视口坐标。容器 position:fixed（BUG-530 全屏可见），坐标即视口系，故**不加**
     // scrollX/Y（加了反而在滚动页面上错位）。拿不到 bbox → 回落最后鼠标视口坐标。
     const ax = wordRect ? wordRect.x : hibikiLastX;
     const ay = wordRect ? wordRect.y : hibikiLastY;
     const ah = wordRect ? wordRect.height : 0;
-    let left = ax;
-    let top = ay + ah + 4; // 默认落在词下方
-    if (left + rect.width > vw - 8) left = Math.max(8, vw - rect.width - 8); // 右溢出→贴右
-    if (left < 8) left = 8;
-    if (top + rect.height > vh - 8) top = Math.max(8, ay - rect.height - 4); // 下溢出→翻到词上方
-    if (top < 8) top = 8;
-    // BUG-688：host 现在带 zoom（尺寸盒随之缩放），故 fixed 定位坐标写入前除以 zoom，
-    // 使渲染值(styleLeft×zoom)落回目标视口坐标；zoom 缺省 1 时零影响。
+    // BUG-767：落点交给纯函数算，保证永不覆盖被查词（旧逻辑翻到词上方时会被夹到边距 8 → 盖住词）。
+    const pos = hibikiComputePlacement(
+      { x: ax, y: ay, height: ah },
+      { width: rect.width, height: rect.height },
+      { width: window.innerWidth, height: window.innerHeight });
+    // BUG-688：host 现在带 zoom（尺寸盒随之缩放），故 fixed 定位坐标 / 夹高写入前除以 zoom，
+    // 使渲染值(style×zoom)落回目标视口尺度；zoom 缺省 1 时零影响。
     const zoom = parseFloat(hibikiHost && hibikiHost.style.zoom) || 1;
     if (hibikiHost) {
-      hibikiHost.style.left = (left / zoom) + 'px';
-      hibikiHost.style.top = (top / zoom) + 'px';
+      // BUG-767：两侧都放不下时把弹窗高度夹到可用空间（内部滚动），弹窗底恰在词上方/下方，绝不压到词。
+      if (pos.maxHeight != null) hibikiHost.style.maxHeight = (pos.maxHeight / zoom) + 'px';
+      hibikiHost.style.left = (pos.left / zoom) + 'px';
+      hibikiHost.style.top = (pos.top / zoom) + 'px';
     }
     c.style.visibility = 'visible';
   };

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -1242,6 +1242,45 @@ window.__hibikiOnLinkClick = function (query) {
   } catch (_) { /* 扩展上下文失效：静默 */ }
 };
 
+// BUG-767：计算查词弹窗落点，保证**永不覆盖被查词**。纯函数（不碰 DOM），便于单测。
+// anchor：被查词的视口矩形 {x, y, height}（x/y=左上角，height=词高，均视口坐标系）。
+// size：弹窗自然尺寸 {width, height}（已按主题 max-height 夹住的可见尺寸）。
+// viewport：{width, height}。返回 {left, top, maxHeight}；maxHeight!=null 表示上下两侧
+// 都放不下整只弹窗，需把弹窗高度夹到所选一侧的可用空间（内部滚动），故渲染后不会压到词上。
+// 旧实现只把 top 夹到边距 8，弹窗高时（词典结果多）会从 8 往下铺开盖住上半屏的词——本函数修掉。
+function hibikiComputePlacement(anchor, size, viewport) {
+  const M = 8; // 视口边距
+  const G = 4; // 词与弹窗之间的间隙
+  const vw = viewport.width;
+  const vh = viewport.height;
+  const ax = anchor.x;
+  const ay = anchor.y;
+  const ah = anchor.height || 0;
+  const pw = size.width;
+  const ph = size.height;
+  // 横向：左对齐词左缘，右/左溢出各自贴边（原行为，未变）。
+  let left = ax;
+  if (left + pw > vw - M) left = Math.max(M, vw - pw - M);
+  if (left < M) left = M;
+  // 纵向：词下方 / 上方各自的可用高度（含留出的视口边距）。
+  const belowSpace = vh - (ay + ah) - M; // 词底 → 视口底
+  const aboveSpace = ay - M;             // 视口顶 → 词顶
+  let top;
+  let maxHeight = null;
+  if (ph + G <= belowSpace) {
+    top = ay + ah + G;                   // 下方放得下整只弹窗：落词下方
+  } else if (ph + G <= aboveSpace) {
+    top = ay - G - ph;                   // 上方放得下整只弹窗：落词上方
+  } else if (belowSpace >= aboveSpace) {
+    top = ay + ah + G;                   // 两侧都放不下、下方空间更大：贴词下方并夹高度
+    maxHeight = Math.max(64, belowSpace - G);
+  } else {
+    maxHeight = Math.max(64, aboveSpace - G); // 上方空间更大：夹高度使弹窗底恰落词顶之上
+    top = Math.max(M, ay - G - maxHeight);
+  }
+  return { left, top, maxHeight };
+}
+
 function hibikiRender(popupJson, termLen, theme, anchorRect) {
   const c = hibikiEnsureContainer();
   // BUG-530：查词响应带回当前 app 主题色（--md-*），套到弹窗容器上，弹窗实时跟随用户主题
@@ -1314,25 +1353,24 @@ function hibikiRender(popupJson, termLen, theme, anchorRect) {
     // BUG-688：量 host 的 rect（被 max-height 夹住=可见尺寸），不是容器（overflow:visible=全内容
     // 高度，会把弹窗错误地翻到词上方）。host 无则回落容器。
     const rect = (hibikiHost || c).getBoundingClientRect();
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
     // 锚点=被查词的视口坐标。容器 position:fixed（BUG-530 全屏可见），坐标即视口系，故**不加**
     // scrollX/Y（加了反而在滚动页面上错位）。拿不到 bbox → 回落最后鼠标视口坐标。
     const ax = wordRect ? wordRect.x : hibikiLastX;
     const ay = wordRect ? wordRect.y : hibikiLastY;
     const ah = wordRect ? wordRect.height : 0;
-    let left = ax;
-    let top = ay + ah + 4; // 默认落在词下方
-    if (left + rect.width > vw - 8) left = Math.max(8, vw - rect.width - 8); // 右溢出→贴右
-    if (left < 8) left = 8;
-    if (top + rect.height > vh - 8) top = Math.max(8, ay - rect.height - 4); // 下溢出→翻到词上方
-    if (top < 8) top = 8;
-    // BUG-688：host 现在带 zoom（尺寸盒随之缩放），故 fixed 定位坐标写入前除以 zoom，
-    // 使渲染值(styleLeft×zoom)落回目标视口坐标；zoom 缺省 1 时零影响。
+    // BUG-767：落点交给纯函数算，保证永不覆盖被查词（旧逻辑翻到词上方时会被夹到边距 8 → 盖住词）。
+    const pos = hibikiComputePlacement(
+      { x: ax, y: ay, height: ah },
+      { width: rect.width, height: rect.height },
+      { width: window.innerWidth, height: window.innerHeight });
+    // BUG-688：host 现在带 zoom（尺寸盒随之缩放），故 fixed 定位坐标 / 夹高写入前除以 zoom，
+    // 使渲染值(style×zoom)落回目标视口尺度；zoom 缺省 1 时零影响。
     const zoom = parseFloat(hibikiHost && hibikiHost.style.zoom) || 1;
     if (hibikiHost) {
-      hibikiHost.style.left = (left / zoom) + 'px';
-      hibikiHost.style.top = (top / zoom) + 'px';
+      // BUG-767：两侧都放不下时把弹窗高度夹到可用空间（内部滚动），弹窗底恰在词上方/下方，绝不压到词。
+      if (pos.maxHeight != null) hibikiHost.style.maxHeight = (pos.maxHeight / zoom) + 'px';
+      hibikiHost.style.left = (pos.left / zoom) + 'px';
+      hibikiHost.style.top = (pos.top / zoom) + 'px';
     }
     c.style.visibility = 'visible';
   };

--- a/tools/browser-extension/popup-placement.test.js
+++ b/tools/browser-extension/popup-placement.test.js
@@ -1,0 +1,131 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+// BUG-767 行为守卫：浏览器扩展「Shift 查词」弹窗**遮住被查词**。
+// 根因：content.js 的 place() 落点逻辑在「下方放不下 → 翻到词上方」时，只把 top 夹到边距 8
+// （`top = Math.max(8, ay - H - 4)`），从不把弹窗高度夹到可用空间。当词典结果多、弹窗较高而视口
+// 不够高（vh < ~2×弹窗高）时，翻上方后 top 被夹到 8，弹窗从 8 往下铺开，直接盖住上半屏的词。
+// 修复：把落点收敛进纯函数 hibikiComputePlacement——下方能放整只→落下方；上方能放整只→落上方；
+// 两侧都放不下→选空间更大的一侧并把弹窗高度夹到该侧空间（内部滚动），弹窗底/顶恰贴词边，绝不覆盖。
+// 本测试在受控 vm 里真加载 content.js，直接调用其顶层纯函数，断言：弹窗矩形在纵向上**永不**与被查
+// 词矩形重叠，且落在视口内。含旧逻辑必然翻车的高弹窗场景。
+
+const CONTENT = path.join(__dirname, 'content.js');
+
+// 加载 content.js 到最小 vm 沙箱，仅为拿到顶层纯函数 hibikiComputePlacement（不触发任何 DOM 定位）。
+function loadPlacement() {
+  const src = fs.readFileSync(CONTENT, 'utf8');
+  const noop = () => {};
+  const el = () => ({
+    style: { cssText: '', setProperty: noop, getPropertyValue: () => '' },
+    dataset: {}, classList: { add: noop }, children: [],
+    setAttribute: noop, getAttribute: () => null, appendChild: (c) => c,
+    insertBefore: (c) => c, remove: noop, contains: () => false, addEventListener: noop,
+    attachShadow: () => ({ appendChild: noop, getElementById: () => null }),
+    getBoundingClientRect: () => ({ x: 0, y: 0, left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 }),
+  });
+  const sandbox = {
+    console: { log: noop, warn: noop, error: noop },
+    setTimeout: () => 0, clearTimeout: noop, requestAnimationFrame: () => 0,
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+    URL, Node: { TEXT_NODE: 3, ELEMENT_NODE: 1 },
+    location: { hostname: 'example.com', href: 'https://example.com/p', pathname: '/p' },
+    navigator: { userAgent: 'node-test' },
+  };
+  sandbox.document = {
+    documentElement: el(), body: el(), fullscreenElement: null,
+    addEventListener: noop, removeEventListener: noop,
+    getElementById: () => null, querySelector: () => null, querySelectorAll: () => [],
+    createElement: () => el(), createTextNode: () => ({}),
+    createRange: () => ({ setStart: noop, setEnd: noop, getClientRects: () => [] }),
+    createTreeWalker: () => ({ nextNode: () => null }),
+  };
+  sandbox.chrome = {
+    runtime: { id: 'test-ext-id', lastError: null, onMessage: { addListener: noop }, sendMessage: noop },
+    storage: { local: { get: async () => ({}), set: async () => {} }, onChanged: { addListener: noop } },
+  };
+  sandbox.window = {
+    addEventListener: noop, innerWidth: 1200, innerHeight: 800,
+    matchMedia: () => ({ matches: false, addEventListener: noop }),
+    flutter_inappwebview: { callHandler: noop },
+  };
+  sandbox.window.window = sandbox.window;
+  vm.createContext(sandbox);
+  vm.runInContext(src, sandbox, { filename: 'content.js' });
+  return sandbox.hibikiComputePlacement;
+}
+
+// 弹窗实际渲染高度：被夹高时用 maxHeight，否则用自然高度。
+function popupHeight(pos, size) {
+  return pos.maxHeight != null ? pos.maxHeight : size.height;
+}
+
+// 纵向重叠：两个区间 [a0,a1) 与 [b0,b1) 有交集（允许 0.5px 容差消除等边争议）。
+function overlapsVertically(pos, size, anchor) {
+  const pTop = pos.top;
+  const pBot = pos.top + popupHeight(pos, size);
+  const wTop = anchor.y;
+  const wBot = anchor.y + anchor.height;
+  return pBot > wTop + 0.5 && pTop < wBot - 0.5;
+}
+
+const VP = { width: 1200, height: 800 };
+const SIZE_SHORT = { width: 400, height: 200 };
+const SIZE_TALL = { width: 400, height: 360 };
+
+test('顶层纯函数 hibikiComputePlacement 存在', () => {
+  const fn = loadPlacement();
+  assert.strictEqual(typeof fn, 'function', 'content.js 未导出 hibikiComputePlacement 全局函数');
+});
+
+// 核心回归：矮视口 + 高弹窗 + 词在上半屏——旧逻辑翻上方后夹到 top=8、从 8 往下盖住词，本例必须不覆盖。
+test('BUG-767 高弹窗矮视口场景弹窗不覆盖被查词', () => {
+  const fn = loadPlacement();
+  const vp = { width: 1200, height: 700 };
+  const anchor = { x: 200, y: 340, height: 20 }; // 词 340..360，位于上半屏
+  const pos = fn(anchor, SIZE_TALL, vp);
+  assert.ok(!overlapsVertically(pos, SIZE_TALL, anchor),
+    `弹窗覆盖了被查词：popup=[${pos.top}, ${pos.top + popupHeight(pos, SIZE_TALL)}] word=[${anchor.y}, ${anchor.y + anchor.height}]`);
+  // 且弹窗不溢出视口底（含被夹高时）。
+  assert.ok(pos.top + popupHeight(pos, SIZE_TALL) <= vp.height + 0.5, '弹窗底溢出视口');
+  assert.ok(pos.top >= -0.5, '弹窗顶溢出视口');
+});
+
+// 遍历词从顶到底、矮/高弹窗、矮/高视口的组合，弹窗**始终**不覆盖被查词。
+test('BUG-767 跨词位置/弹窗高度/视口高度弹窗均不覆盖被查词', () => {
+  const fn = loadPlacement();
+  for (const vh of [500, 700, 900]) {
+    for (const size of [SIZE_SHORT, SIZE_TALL]) {
+      for (let y = 8; y <= vh - 30; y += 37) {
+        const vp = { width: 1200, height: vh };
+        const anchor = { x: 300, y, height: 22 };
+        const pos = fn(anchor, size, vp);
+        assert.ok(!overlapsVertically(pos, size, anchor),
+          `覆盖被查词：vh=${vh} size.h=${size.height} y=${y} → popup=[${pos.top}, ${pos.top + popupHeight(pos, size)}] word=[${y}, ${y + 22}]`);
+        assert.ok(pos.left >= 8 - 0.5 && pos.left + size.width <= vp.width - 8 + 0.5,
+          `横向溢出：vh=${vh} y=${y} left=${pos.left}`);
+      }
+    }
+  }
+});
+
+// 有充足空间时优先落词下方（原行为不回归）。
+test('空间充足时弹窗落在词下方且不夹高', () => {
+  const fn = loadPlacement();
+  const anchor = { x: 100, y: 60, height: 18 };
+  const pos = fn(anchor, SIZE_SHORT, VP);
+  assert.strictEqual(pos.maxHeight, null, '空间充足不应夹高');
+  assert.ok(pos.top >= anchor.y + anchor.height, '弹窗未落在词下方');
+});
+
+// 词贴视口底、下方放不下时翻到词上方。
+test('词贴视口底时弹窗翻到词上方且不覆盖', () => {
+  const fn = loadPlacement();
+  const anchor = { x: 100, y: 760, height: 18 }; // 词 760..778，vh=800
+  const pos = fn(anchor, SIZE_SHORT, VP);
+  assert.ok(pos.top + popupHeight(pos, SIZE_SHORT) <= anchor.y + 0.5, '弹窗未落在词上方');
+  assert.ok(!overlapsVertically(pos, SIZE_SHORT, anchor), '弹窗覆盖了被查词');
+});


### PR DESCRIPTION
## BUG-767 · 网页扩展 Shift 查词弹窗遮住被查词

**根因**：`content.js` 的 `place()` 落点逻辑——下方放不下就翻到词上方 `top = Math.max(8, ay - 弹窗高 - 4)`，但**从不把弹窗高度夹到可用空间**。词典结果多（弹窗高）+ 视口不够高（`vh < ~2×弹窗高)` + 被查词在上半屏时，翻上方后被夹成 `top=8`，弹窗从视口顶往下铺开盖住词。实测 `vh=700 / 词 y=340 高 20 / 弹窗高 360` → 弹窗 `[8,368]` 覆盖词 `[340,360]`。

**修复**：落点收敛进纯函数 `hibikiComputePlacement(anchor, size, viewport)`——下方能放整只→落词下方；上方能放整只→落词上方；两侧都放不下→选空间更大一侧并把 `maxHeight` 夹到该侧空间（内部滚动），弹窗底/顶恰贴词边，绝不覆盖。两份 `content.js` 镜像（`hibiki/assets/browser_extension/` + `tools/browser-extension/`）同步。

**测试**：`tools/browser-extension/popup-placement.test.js`（`node --test`，5/5 通过）在 vm 里真加载 content.js 调纯函数，断言弹窗纵向永不与词重叠且在视口内；已单独验证旧算法在回归场景 `top=8` 覆盖词、守卫会失败。

未碰 `popup.css`，无需重生成 `content.css`。同目录 `highlight-overlay.test.js` 的 3 项失败为既有 bitrot（原始未改 content.js 上同样失败，非本次引入）。

**待真机**：浏览器扩展里 Shift 查上半屏的词、结果较多时确认弹窗落词下方/上方而非盖住词。