### PR TITLE
fix(clipboard-panel): 句子横幅整词高亮补偿句首标点剥离 (BUG-773)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 755 条。点号进各自文件。
+> 共 756 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-773](bugs/BUG-773-clipboard-sentence-hit-offset.md) | ✅ | ✅ | 剪贴板面板句子横幅整词高亮左移吞句首标点 |
 | [BUG-772](bugs/BUG-772-video-startup-freeze.md) | ✅ | ✅ | 快速进出视频后 Windows 启动冻死在 loading |
 | [BUG-771](bugs/BUG-771-lyrics-reload-flicker-first-cue.md) | ✅ | ✅ | 歌词模式进入后一直闪烁 + 高亮恒第一句（不是正在听的那句） |
 | [BUG-770](bugs/BUG-770-ext-popup-covers-word.md) | ✅ | ✅ | 网页扩展 Shift 查词弹窗遮住被查词 |

--- a/docs/bugs/BUG-773-clipboard-sentence-hit-offset.md
+++ b/docs/bugs/BUG-773-clipboard-sentence-hit-offset.md
@@ -8,7 +8,7 @@
   用 `_punctuationRegex=^[\p{P}\p{S}]+|[\p{P}\p{S}]+$` 剥掉句首 `『`，引擎才从 `呪術廻戦…` 的 0 位
   匹配、`bestLength=4`）。两端坐标系差一个被剥的句首 `『`：高亮从 `『` 起铺 4 码点 = `『呪術廻`
   （吞了 `『`、缺了词尾 `戦`），而不是 `呪術廻戦`。popup.js 逐字上色见 `hibiki/assets/popup/popup.js:3193-3199`。
-- **[x] ① 已修复** — `2fb?`（见提交）。修复=把整词高亮起点从「句首第 0 字符」右移「归一化剥掉的句首标点长度」再从真正词首量 `bestLength`：
+- **[x] ① 已修复** — `8ec88f008`。修复=把整词高亮起点从「句首第 0 字符」右移「归一化剥掉的句首标点长度」再从真正词首量 `bestLength`：
   - `hibiki/lib/src/models/app_model.dart`：新增纯函数 `leadingPunctuationStripUnits(raw, punctuationRegex)`（返回句首被剥 UTF-16 长度，复用同一 `_punctuationRegex`=单一真相）+ AppModel 公开包装 `lookupLeadingStripUnits`。
   - `hibiki/lib/src/lookup/clipboard_panel_controller.dart`：新增纯函数 `rootHitRange({query, baseStartCp, leadingUnits, bestLength})`，起点=`baseStartCp + 句首剥离码点`、长度=从词首起量 `bestLength`（复用 `hitLengthCodePoints` 钳位）；`_renderPanel` 改用它；删除多余的私有 `_hitLengthCodePoints` 包装。
   - 点字后缀路径（`_lookupFromBanner`，`_rootHitStart=i`）同链受益：后缀句首标点也补偿。

--- a/docs/bugs/BUG-773-clipboard-sentence-hit-offset.md
+++ b/docs/bugs/BUG-773-clipboard-sentence-hit-offset.md
@@ -1,0 +1,19 @@
+## BUG-773 · 剪贴板面板句子横幅整词高亮左移吞句首标点
+- **报告**：2026-07-13（用户：截图 `『呪術廻戦 第1期』…`，查词 `呪術廻戦` 但高亮不对）
+- **真实性**：✅ 真 bug。表面=桌面「剪贴板查词面板」(clipboard panel) 句子横幅整词高亮 `.global-lookup-sentence-hit`。
+  根因=**坐标系错位**：`hibiki/lib/src/lookup/clipboard_panel_controller.dart:175` 把 `_rootHitStart=0`
+  钉在**原始**句的第 0 字符（=句首 `『`），而 `_renderPanel`（原 `clipboard_panel_controller.dart:314`）
+  用 `bestLength` 从该 0 位铺高亮。但 `bestLength` 是引擎在
+  **归一化（首尾标点已剥离）后**的串上量出的匹配长度（`app_model.dart` `normalizeSearchTerm`
+  用 `_punctuationRegex=^[\p{P}\p{S}]+|[\p{P}\p{S}]+$` 剥掉句首 `『`，引擎才从 `呪術廻戦…` 的 0 位
+  匹配、`bestLength=4`）。两端坐标系差一个被剥的句首 `『`：高亮从 `『` 起铺 4 码点 = `『呪術廻`
+  （吞了 `『`、缺了词尾 `戦`），而不是 `呪術廻戦`。popup.js 逐字上色见 `hibiki/assets/popup/popup.js:3193-3199`。
+- **[x] ① 已修复** — `2fb?`（见提交）。修复=把整词高亮起点从「句首第 0 字符」右移「归一化剥掉的句首标点长度」再从真正词首量 `bestLength`：
+  - `hibiki/lib/src/models/app_model.dart`：新增纯函数 `leadingPunctuationStripUnits(raw, punctuationRegex)`（返回句首被剥 UTF-16 长度，复用同一 `_punctuationRegex`=单一真相）+ AppModel 公开包装 `lookupLeadingStripUnits`。
+  - `hibiki/lib/src/lookup/clipboard_panel_controller.dart`：新增纯函数 `rootHitRange({query, baseStartCp, leadingUnits, bestLength})`，起点=`baseStartCp + 句首剥离码点`、长度=从词首起量 `bestLength`（复用 `hitLengthCodePoints` 钳位）；`_renderPanel` 改用它；删除多余的私有 `_hitLengthCodePoints` 包装。
+  - 点字后缀路径（`_lookupFromBanner`，`_rootHitStart=i`）同链受益：后缀句首标点也补偿。
+- **[x] ② 已加自动化测试** — 纯逻辑单测（最强可落地层）：
+  - `hibiki/test/lookup/clipboard_panel_controller_test.dart` group `rootHitRange`：5 例，含复现用例「`『呪術廻戦 第1期』…` + leadingUnits=1 + bestLength=4 → start=1,length=4=`呪術廻戦`」、无标点零回归、点字 baseStartCp 叠加、代理对码点折算、越界/空串钳位。
+  - `hibiki/test/models/app_model_search_pure_logic_test.dart` group `leadingPunctuationStripUnits`：5 例，含与真实 `normalizeSearchTerm` 句首移除量一致性校验。
+  - 全部通过：`flutter test test/models/app_model_search_pure_logic_test.dart test/lookup/clipboard_panel_controller_test.dart` → All tests passed (52)。
+- **备注**：`bestLength` 假定=4（`呪術廻戦` 词条长度，大辞泉第二版有此见出）。若真机上高亮**长度**仍越出 `呪術廻戦`（吞到 `第1期』`），那是引擎匹配长度 `bestLength` 本身过大（另一层：远端/词典把标题当长词条），与本坐标系修复无关，届时另立 bug。桌面真机复测（剪贴板复制含句首 `『「（` 的句子→面板高亮对齐词本身）留待用户验收。

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -176,7 +176,9 @@ class ClipboardPanelController {
       }
       _recordLookupCount(model);
       _currentSentence = request.text;
-      _rootHitStart = 0; // 新句：选词起点回句首（高亮引擎从句首匹配到的词）。
+      // 新句：rootQuery=整句，故基准码点下标=0；真正词首由 rootHitRange 再补偿被归一化
+      // 剥掉的句首标点长度（BUG-773），不再假设词从句首第 0 字符开始。
+      _rootHitStart = 0;
       _seedRootFrame(request.text, result);
       // 真机修复（"只显示一次"）：不能只信 Dart 侧 _visible——窗口可能被系统
       // 藏掉（历史 owned-minimize 联动、显式全屏切换等）而 Dart 不知情，之后
@@ -306,14 +308,23 @@ class ClipboardPanelController {
       ));
     }
     if (payloads.isEmpty) return;
-    // 真机第 4 轮 — 选词区整词高亮：起点=_rootHitStart（点击字/句首），长度=
-    // 根结果的引擎匹配长度（bestLength，即「正常的断词」），码点单位。
+    // 真机第 4 轮 — 选词区整词高亮：_rootHitStart（点击字/句首）为 rootQuery 在显示
+    // 句子里的起始码点下标，长度=根结果的引擎匹配长度（bestLength，即「正常的断词」）。
+    // BUG-773 — 归一化查词前剥掉了 rootQuery 的句首标点（『「"( 等），引擎从剥离串 0
+    // 位匹配、bestLength 以剥离串为坐标系，而横幅显示**原始**句（含句首标点）。若直接
+    // 从 _rootHitStart 铺 bestLength 会左移吞括号、右缺词尾（呪術廻戦→高亮成『呪術廻）。
+    // 故把起点再右移「被剥句首标点」长度，再从真正词首量 bestLength（见 rootHitRange）。
     final DictionarySearchResult? rootResult =
         _frameResults[kGlobalLookupRootFrameId];
     final String rootQuery = _stack.isEmpty ? '' : _stack.frames.first.query;
-    final int hitLength = rootResult == null
-        ? 0
-        : _hitLengthCodePoints(rootResult.bestLength, rootQuery);
+    final ({int start, int length}) hit = rootResult == null
+        ? (start: 0, length: 0)
+        : rootHitRange(
+            query: rootQuery,
+            baseStartCp: _rootHitStart,
+            leadingUnits: model.lookupLeadingStripUnits(rootQuery),
+            bestLength: rootResult.bestLength,
+          );
     final String script = buildStackRenderScript(
       context: ctx,
       appModel: model,
@@ -326,8 +337,8 @@ class ClipboardPanelController {
       // spec §6 真机修正：透明改整窗 LWA_ALPHA，卡背景恒不透明（双重变淡会
       // 让文字更虚；CSS alpha 基建保留供未来 DComp 逐像素路线复用）。
       cardBgAlpha: 1.0,
-      sentenceHitStart: hitLength > 0 ? _rootHitStart : -1,
-      sentenceHitLength: hitLength,
+      sentenceHitStart: hit.length > 0 ? hit.start : -1,
+      sentenceHitLength: hit.length,
     );
     // pin 视觉态并进同一渲染脚本：native pending_json_ 是单槽缓存，冷启动时
     // 独立脚本会互相覆盖；同一 ExecuteScript 保证 pin 图标与卡片同帧就位。
@@ -504,8 +515,34 @@ class ClipboardPanelController {
     return query.substring(0, units).runes.length;
   }
 
-  int _hitLengthCodePoints(int bestLength, String query) =>
-      hitLengthCodePoints(bestLength, query);
+  /// 句子横幅整词高亮区间（**码点**坐标，对应 popup.js `Array.from` 的码点数组）。
+  /// BUG-773：归一化查词前用 [AppModel.lookupLeadingStripUnits] 剥掉 [query] 的句首
+  /// 标点，引擎才从剥离串 0 位匹配、[bestLength] 以剥离串为坐标系；而横幅显示的是
+  /// **原始** query（含句首标点）。若从 [baseStartCp] 直接铺 bestLength 会左移吞进
+  /// 句首括号、右缺词尾。故起点右移 [leadingUnits]（句首被剥的 UTF-16 长度）落到真正
+  /// 词首，长度从词首起量 bestLength。
+  ///
+  /// [query]=当前根查询串（整句或点字后缀），[baseStartCp]=query 在显示句子里的起始
+  /// 码点下标（整句=0，点字=点击码点下标），[leadingUnits]=query 句首被归一化剥掉的
+  /// UTF-16 长度，[bestLength]=引擎匹配长度（UTF-16 code units）。返回 (start,length)
+  /// 均为码点。纯函数，直接单测。
+  @visibleForTesting
+  static ({int start, int length}) rootHitRange({
+    required String query,
+    required int baseStartCp,
+    required int leadingUnits,
+    required int bestLength,
+  }) {
+    if (bestLength <= 0 || query.isEmpty) return (start: 0, length: 0);
+    final int lead = leadingUnits < 0
+        ? 0
+        : (leadingUnits > query.length ? query.length : leadingUnits);
+    final int leadCp = query.substring(0, lead).runes.length;
+    // 词首之后的子串上再量 bestLength → 码点（复用 hitLengthCodePoints 的钳位）。
+    final int lenCp = hitLengthCodePoints(bestLength, query.substring(lead));
+    final int base = baseStartCp < 0 ? 0 : baseStartCp;
+    return (start: base + leadCp, length: lenCp);
+  }
 
   Future<void> _lookupNested(String query, Rect? anchorRect) async {
     final AppModel? model = _appModel;

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -303,6 +303,21 @@ NormalizedSearchTerm normalizeSearchTerm(
   );
 }
 
+/// [normalizeSearchTerm] 在查词前用 [punctuationRegex]（`^[\p{P}\p{S}]+|[\p{P}\p{S}]+$`）
+/// 剥掉查询串的**句首/句尾**标点/符号（『「"( 等），引擎才从剥离串的 0 位去屈折/前缀
+/// 匹配，`bestLength` 也以剥离串为坐标系。返回原始串**句首**被剥掉的 UTF-16 code unit
+/// 数（无句首标点=0）。剪贴板面板的句子横幅显示的是**原始**句子（含句首标点），整词
+/// 高亮起点必须右移这段长度，否则高亮左移吞进句首括号、右缺词尾（BUG-773）。
+///
+/// 与 [normalizeSearchTerm] 共用同一 [punctuationRegex]（单一真相）：只取句首分支
+/// （`match.start == 0` 的命中）；只有句尾标点时命中不在句首，返回 0。
+@visibleForTesting
+int leadingPunctuationStripUnits(String raw, RegExp punctuationRegex) {
+  if (raw.isEmpty) return 0;
+  final Match? m = punctuationRegex.firstMatch(raw);
+  return (m != null && m.start == 0) ? m.end : 0;
+}
+
 /// 词典搜索结果缓存键的单一真相，逐字不变（变=缓存击穿/旧条目命中不了）。格式：
 /// `<term.length>:<term>/<maxTerms>/<maxResults>`。此前是 [AppModel.searchDictionary]
 /// 内联插值，无法独立断言「键格式不漂移」。
@@ -751,6 +766,14 @@ class AppModel with ChangeNotifier {
   static final RegExp _loneSurrogateRegex = RegExp(
     '[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]',
   );
+
+  /// 剪贴板面板句子横幅整词高亮定位（BUG-773）：查词前 [normalizeSearchTerm] 用
+  /// [_punctuationRegex] 剥掉 [rawQuery] 的句首标点/符号，引擎才从剥离串 0 位匹配、
+  /// `bestLength` 以剥离串为坐标系。横幅显示原始句（含句首标点），故高亮起点须右移
+  /// 这段被剥长度。委托 [leadingPunctuationStripUnits]（同一正则=单一真相），返回
+  /// 句首被剥掉的 UTF-16 code unit 数。
+  int lookupLeadingStripUnits(String rawQuery) =>
+      leadingPunctuationStripUnits(rawQuery, _punctuationRegex);
 
   /// Used to notify toggling incognito. Updates the app logo to and from
   /// grayscale.

--- a/hibiki/test/lookup/clipboard_panel_controller_test.dart
+++ b/hibiki/test/lookup/clipboard_panel_controller_test.dart
@@ -46,6 +46,84 @@ void main() {
     });
   });
 
+  group('rootHitRange（BUG-773 句首标点补偿：起点右移 + 从词首量长度）', () {
+    test('句首书名号：呪術廻戦 高亮到词本身，不吞 『、不缺 戦', () {
+      // 原始句 = 『呪術廻戦 第1期』…；归一化剥掉句首 『（leadingUnits=1），引擎从
+      // 剥离串匹配 呪術廻戦（bestLength=4，全 BMP）。修复前从句首铺 4 = 『呪術廻（错）；
+      // 修复后起点右移 1 落到 呪，长度 4 = 呪術廻戦（对）。
+      const String sentence = '『呪術廻戦 第1期』『チェンソーマン』';
+      final hit = ClipboardPanelController.rootHitRange(
+        query: sentence,
+        baseStartCp: 0,
+        leadingUnits: 1,
+        bestLength: 4,
+      );
+      expect(hit.start, 1); // 跳过句首 『
+      expect(hit.length, 4); // 呪術廻戦
+      // 码点区间对准的正是被查词。
+      final chars = sentence.runes.toList();
+      final matched = String.fromCharCodes(
+          chars.sublist(hit.start, hit.start + hit.length));
+      expect(matched, '呪術廻戦');
+    });
+
+    test('无句首标点：leadingUnits=0 时退化为旧语义（零回归）', () {
+      final hit = ClipboardPanelController.rootHitRange(
+        query: '呪術廻戦は面白い',
+        baseStartCp: 0,
+        leadingUnits: 0,
+        bestLength: 4,
+      );
+      expect(hit.start, 0);
+      expect(hit.length, 4);
+    });
+
+    test('点字后缀：baseStartCp 为句中码点下标，起点叠加', () {
+      // 点了句子第 5 个码点起的后缀，后缀本身无句首标点（leadingUnits=0）。
+      final hit = ClipboardPanelController.rootHitRange(
+        query: '第1期』の話',
+        baseStartCp: 5,
+        leadingUnits: 0,
+        bestLength: 3, // 第1期
+      );
+      expect(hit.start, 5);
+      expect(hit.length, 3);
+    });
+
+    test('代理对（罕见汉字）长度折算为码点', () {
+      // '𠮟' 2 code units / 1 code point；leadingUnits=1（句首标点 1 unit）。
+      final hit = ClipboardPanelController.rootHitRange(
+        query: '「𠮟る',
+        baseStartCp: 0,
+        leadingUnits: 1, // 「
+        bestLength: 3, // 𠮟(2) + る(1) = 3 code units
+      );
+      expect(hit.start, 1); // 跳过 「（1 码点）
+      expect(hit.length, 2); // 𠮟る = 2 码点
+    });
+
+    test('bestLength 越界/非法 钳位；空串安全', () {
+      final over = ClipboardPanelController.rootHitRange(
+        query: '『あ',
+        baseStartCp: 0,
+        leadingUnits: 1,
+        bestLength: 99,
+      );
+      expect(over.start, 1);
+      expect(over.length, 1); // 只剩 あ
+      expect(
+        ClipboardPanelController.rootHitRange(
+            query: 'ある', baseStartCp: 0, leadingUnits: 0, bestLength: 0),
+        (start: 0, length: 0),
+      );
+      expect(
+        ClipboardPanelController.rootHitRange(
+            query: '', baseStartCp: 3, leadingUnits: 0, bestLength: 2),
+        (start: 0, length: 0),
+      );
+    });
+  });
+
   test('面板栏高度与 host.js PANEL_BAR_HEIGHT 一致（跨端几何契约）', () {
     final String hostJs =
         File('assets/popup/global_lookup_host.js').readAsStringSync();

--- a/hibiki/test/models/app_model_search_pure_logic_test.dart
+++ b/hibiki/test/models/app_model_search_pure_logic_test.dart
@@ -251,4 +251,44 @@ void main() {
       expect(decodeDictTypeFromBlobHeader(b), null);
     });
   });
+
+  group('leadingPunctuationStripUnits (BUG-773 句首标点剥离长度)', () {
+    int lead(String s) => leadingPunctuationStripUnits(s, punctuationRegex);
+
+    test('句首日文书名号 『 计 1 个 code unit', () {
+      expect(lead('『呪術廻戦 第1期』'), 1);
+    });
+
+    test('句首多重括号/引号连剥', () {
+      expect(lead('（「図書館」）'), 2); // （「 两个
+      expect(lead('！！！hello'), 3);
+    });
+
+    test('无句首标点 -> 0', () {
+      expect(lead('呪術廻戦'), 0);
+      expect(lead('図書館。'), 0, reason: '只有句尾标点，命中不在句首');
+    });
+
+    test('空串 -> 0', () {
+      expect(lead(''), 0);
+    });
+
+    // 单一真相校验：剥掉的句首长度必须恰好等于 normalizeSearchTerm 从句首移除的量。
+    // 对「仅句首标点、无 emoji/换行/代理项、无句尾标点」的输入，
+    // 原始长度 - 归一化后长度 == 句首剥离长度。
+    test('与 normalizeSearchTerm 句首移除量一致（无其他清洗时）', () {
+      for (final String s in <String>[
+        '『呪術廻戦',
+        '（図書館',
+        '「「テスト',
+        '！！！hello',
+        '普通の文', // 无句首标点：剥 0、归一化不变
+      ]) {
+        final int leadUnits = lead(s);
+        final int removedTotal = s.length - normalize(s).length;
+        expect(leadUnits, removedTotal,
+            reason: '「$s」句首剥离长度须等于归一化移除总量（无句尾标点样本）');
+      }
+    });
+  });
 }


### PR DESCRIPTION
## 现象
用户截图：剪贴板查词面板句子横幅 `『呪術廻戦 第1期』…`，查的是 `呪術廻戦`，但整词高亮左移吞了句首 `『`、缺了词尾 `戦`（高亮成 `『呪術廻`）。

## 根因（坐标系错位）
- `clipboard_panel_controller.dart` 把 `_rootHitStart=0` 钉在**原始**句第 0 字符（=句首 `『`）。
- 但 `bestLength` 是引擎在**归一化（首尾标点已剥离）后**的串上量的匹配长度：`normalizeSearchTerm` 用 `_punctuationRegex` 剥掉句首 `『`，引擎从 `呪術廻戦…` 的 0 位匹配、`bestLength=4`。
- 两端坐标系差一个被剥的句首 `『`，故高亮 `[0,4)=『呪術廻` 而非 `呪術廻戦`。

## 修复
- `app_model.dart`：`leadingPunctuationStripUnits(raw, punctuationRegex)`（复用同一 `_punctuationRegex`=单一真相）+ 公开包装 `lookupLeadingStripUnits`。
- `clipboard_panel_controller.dart`：`rootHitRange(...)` 起点右移句首剥离长度、从词首量 `bestLength`；`_renderPanel` 改用它；删多余私有 `_hitLengthCodePoints`。
- 点字后缀路径同链受益。

## 测试
- `rootHitRange` 5 例（含复现用例 → `呪術廻戦`）+ `leadingPunctuationStripUnits` 5 例（含与真实 `normalizeSearchTerm` 一致性校验）。
- `flutter analyze` No issues；`flutter test`（两文件）All passed (52)。

## 待验收
桌面真机：剪贴板复制含句首 `『「（` 的句子 → 面板高亮对齐词本身。备注：若真机上高亮**长度**仍越出词（吞 `第1期』`），那是 `bestLength` 本身过大（引擎/远端把标题当长词条），另一层问题，与本坐标系修复无关。

BUG-773。