### PR TITLE
refactor(anki): rename {sasayaki-audio} handlebar to neutral {sentence-audio}

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39083 (2299 per locale)
+/// Strings: 39100 (2300 per locale)
 ///
-/// Built on 2026-07-12 at 20:35 UTC
+/// Built on 2026-07-13 at 03:56 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2620,7 +2620,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get card_mined_unmapped_sentence_field =>
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   String get audiobook_export_clip_saved => 'Clip saved';
   String get audiobook_export_clip_failed => 'Clip export failed';
@@ -3041,6 +3041,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String batch_tag_removed_video({required Object name, required Object n}) =>
       'Removed tag "${name}" from ${n} video(s).';
   String get stat_daily_average => 'Daily avg';
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -7489,7 +7490,7 @@ class _StringsAr extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -8241,6 +8242,8 @@ class _StringsAr extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -12812,7 +12815,7 @@ class _StringsDe extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -13564,6 +13567,8 @@ class _StringsDe extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -18152,7 +18157,7 @@ class _StringsEs extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -18904,6 +18909,8 @@ class _StringsEs extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -23511,7 +23518,7 @@ class _StringsFr extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -24263,6 +24270,8 @@ class _StringsFr extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -28772,7 +28781,7 @@ class _StringsId extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -29524,6 +29533,8 @@ class _StringsId extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -34094,7 +34105,7 @@ class _StringsIt extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -34846,6 +34857,8 @@ class _StringsIt extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -39142,7 +39155,7 @@ class _StringsJa extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -39893,6 +39906,8 @@ class _StringsJa extends _StringsEn {
       '${n} 本の動画からタグ「${name}」を削除しました。';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -44193,7 +44208,7 @@ class _StringsKo extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -44945,6 +44960,8 @@ class _StringsKo extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -49483,7 +49500,7 @@ class _StringsNl extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -50235,6 +50252,8 @@ class _StringsNl extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -54796,7 +54815,7 @@ class _StringsPtBr extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -55548,6 +55567,8 @@ class _StringsPtBr extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -60084,7 +60105,7 @@ class _StringsRu extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -60836,6 +60857,8 @@ class _StringsRu extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -65285,7 +65308,7 @@ class _StringsTh extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -66037,6 +66060,8 @@ class _StringsTh extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -70541,7 +70566,7 @@ class _StringsTr extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -71293,6 +71318,8 @@ class _StringsTr extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -75772,7 +75799,7 @@ class _StringsVi extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -76524,6 +76551,8 @@ class _StringsVi extends _StringsEn {
       'Removed tag "${name}" from ${n} video(s).';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -80699,7 +80728,7 @@ class _StringsZhCn extends _StringsEn {
       '卡片已创建，但当前 Anki 卡片模板没有任何字段映射到句子。请用设置页『一键创建 Lapis 卡组』，或把某字段映射到 {sentence}。';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      '卡片已创建并含句子音频，但当前 Anki 卡片模板没有字段映射到它。请把某字段映射到 {sasayaki-audio}。';
+      '卡片已创建并含句子音频，但当前 Anki 卡片模板没有字段映射到它。请把某字段映射到 {sentence-audio}。';
   @override
   String get audiobook_export_clip_in_progress => '正在导出片段…';
   @override
@@ -81400,6 +81429,8 @@ class _StringsZhCn extends _StringsEn {
       '已从 ${n} 个视频移除标签「${name}」。';
   @override
   String get stat_daily_average => '日均';
+  @override
+  String get handlebar_sentence_audio => '句子音频';
 }
 
 // Path: retrying_in
@@ -85598,7 +85629,7 @@ class _StringsZhHk extends _StringsEn {
       'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
   @override
   String get card_mined_unmapped_sentence_audio_field =>
-      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+      'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
   @override
   String get audiobook_export_clip_in_progress => 'Exporting clip…';
   @override
@@ -86349,6 +86380,8 @@ class _StringsZhHk extends _StringsEn {
       '已從 ${n} 個影片移除標籤「${name}」。';
   @override
   String get stat_daily_average => 'Daily avg';
+  @override
+  String get handlebar_sentence_audio => 'Sentence Audio';
 }
 
 // Path: retrying_in
@@ -90416,7 +90449,7 @@ extension on _StringsEn {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -91088,6 +91121,8 @@ extension on _StringsEn {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -95115,7 +95150,7 @@ extension on _StringsAr {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -95787,6 +95822,8 @@ extension on _StringsAr {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -99836,7 +99873,7 @@ extension on _StringsDe {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -100508,6 +100545,8 @@ extension on _StringsDe {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -104555,7 +104594,7 @@ extension on _StringsEs {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -105227,6 +105266,8 @@ extension on _StringsEs {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -109281,7 +109322,7 @@ extension on _StringsFr {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -109953,6 +109994,8 @@ extension on _StringsFr {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -113987,7 +114030,7 @@ extension on _StringsId {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -114659,6 +114702,8 @@ extension on _StringsId {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -118710,7 +118755,7 @@ extension on _StringsIt {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -119382,6 +119427,8 @@ extension on _StringsIt {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -123391,7 +123438,7 @@ extension on _StringsJa {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -124062,6 +124109,8 @@ extension on _StringsJa {
             '${n} 本の動画からタグ「${name}」を削除しました。';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -128074,7 +128123,7 @@ extension on _StringsKo {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -128746,6 +128795,8 @@ extension on _StringsKo {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -132790,7 +132841,7 @@ extension on _StringsNl {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -133462,6 +133513,8 @@ extension on _StringsNl {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -137503,7 +137556,7 @@ extension on _StringsPtBr {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -138175,6 +138228,8 @@ extension on _StringsPtBr {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -142220,7 +142275,7 @@ extension on _StringsRu {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -142892,6 +142947,8 @@ extension on _StringsRu {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -146919,7 +146976,7 @@ extension on _StringsTh {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -147591,6 +147648,8 @@ extension on _StringsTh {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -151627,7 +151686,7 @@ extension on _StringsTr {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -152299,6 +152358,8 @@ extension on _StringsTr {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -156329,7 +156390,7 @@ extension on _StringsVi {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -157001,6 +157062,8 @@ extension on _StringsVi {
             'Removed tag "${name}" from ${n} video(s).';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }
@@ -160999,7 +161062,7 @@ extension on _StringsZhCn {
       case 'card_mined_unmapped_sentence_field':
         return '卡片已创建，但当前 Anki 卡片模板没有任何字段映射到句子。请用设置页『一键创建 Lapis 卡组』，或把某字段映射到 {sentence}。';
       case 'card_mined_unmapped_sentence_audio_field':
-        return '卡片已创建并含句子音频，但当前 Anki 卡片模板没有字段映射到它。请把某字段映射到 {sasayaki-audio}。';
+        return '卡片已创建并含句子音频，但当前 Anki 卡片模板没有字段映射到它。请把某字段映射到 {sentence-audio}。';
       case 'audiobook_export_clip_in_progress':
         return '正在导出片段…';
       case 'audiobook_export_clip_saved':
@@ -161668,6 +161731,8 @@ extension on _StringsZhCn {
             '已从 ${n} 个视频移除标签「${name}」。';
       case 'stat_daily_average':
         return '日均';
+      case 'handlebar_sentence_audio':
+        return '句子音频';
       default:
         return null;
     }
@@ -165669,7 +165734,7 @@ extension on _StringsZhHk {
       case 'card_mined_unmapped_sentence_field':
         return 'Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> \'Create Lapis deck\' or map a field to {sentence}.';
       case 'card_mined_unmapped_sentence_audio_field':
-        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.';
+        return 'Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.';
       case 'audiobook_export_clip_in_progress':
         return 'Exporting clip…';
       case 'audiobook_export_clip_saved':
@@ -166340,6 +166405,8 @@ extension on _StringsZhHk {
             '已從 ${n} 個影片移除標籤「${name}」。';
       case 'stat_daily_average':
         return 'Daily avg';
+      case 'handlebar_sentence_audio':
+        return 'Sentence Audio';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "$n 本の動画を削除しました。",
   "batch_tag_added_video": "$n 本の動画にタグ「$name」を追加しました。",
   "batch_tag_removed_video": "$n 本の動画からタグ「$name」を削除しました。",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "Deleted $n video(s).",
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "该选区暂不支持导出（跨章或跨音频文件）",
   "card_mined_no_sentence_captured": "卡片已创建，但未捕获到句子（请重新选词，或该处内容无法识别句子）。",
   "card_mined_unmapped_sentence_field": "卡片已创建，但当前 Anki 卡片模板没有任何字段映射到句子。请用设置页『一键创建 Lapis 卡组』，或把某字段映射到 {sentence}。",
-  "card_mined_unmapped_sentence_audio_field": "卡片已创建并含句子音频，但当前 Anki 卡片模板没有字段映射到它。请把某字段映射到 {sasayaki-audio}。",
+  "card_mined_unmapped_sentence_audio_field": "卡片已创建并含句子音频，但当前 Anki 卡片模板没有字段映射到它。请把某字段映射到 {sentence-audio}。",
   "audiobook_export_clip_in_progress": "正在导出片段…",
   "audiobook_export_clip_saved": "片段已保存",
   "audiobook_export_clip_failed": "片段导出失败",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "已删除 $n 个视频。",
   "batch_tag_added_video": "已为 $n 个视频添加标签「$name」。",
   "batch_tag_removed_video": "已从 $n 个视频移除标签「$name」。",
-  "stat_daily_average": "日均"
+  "stat_daily_average": "日均",
+  "handlebar_sentence_audio": "句子音频"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1974,7 +1974,7 @@
   "audiobook_export_clip_unsupported_range": "This selection can't be exported (crosses chapter or audio file)",
   "card_mined_no_sentence_captured": "Card created, but no sentence was captured (re-select the word, or this text has no recognizable sentence).",
   "card_mined_unmapped_sentence_field": "Card created, but your Anki note type has no field mapped to the sentence. Use Settings -> 'Create Lapis deck' or map a field to {sentence}.",
-  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sasayaki-audio}.",
+  "card_mined_unmapped_sentence_audio_field": "Card created with sentence audio, but your Anki note type has no field mapped to it. Map a field to {sentence-audio}.",
   "audiobook_export_clip_in_progress": "Exporting clip…",
   "audiobook_export_clip_saved": "Clip saved",
   "audiobook_export_clip_failed": "Clip export failed",
@@ -2305,5 +2305,6 @@
   "batch_delete_success_video": "已刪除 $n 個影片。",
   "batch_tag_added_video": "已為 $n 個影片添加標籤「$name」。",
   "batch_tag_removed_video": "已從 $n 個影片移除標籤「$name」。",
-  "stat_daily_average": "Daily avg"
+  "stat_daily_average": "Daily avg",
+  "handlebar_sentence_audio": "Sentence Audio"
 }

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -497,6 +497,8 @@ String ankiHandlebarLabel(String option) {
       return t.handlebar_book_cover;
     case '{video-clip}':
       return t.handlebar_video_clip;
+    case '{sentence-audio}':
+      return t.handlebar_sentence_audio;
     case '{sasayaki-audio}':
       return t.handlebar_sasayaki_audio;
     default:

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/mining.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/mining.part.dart
@@ -186,7 +186,7 @@ extension _ReaderMining on _ReaderHibikiPageState {
 
     // TODO-948/952 诊断可见性：制卡链路自身字节稳定，但用户报「卡片没有句子/句子
     // 音频」。真因是运行时二选一——句子真空（抽句回空）或 Anki 卡片模板没有字段
-    // 映射到 {sentence}/{sasayaki-audio}（字段恒空）。这里在制卡前把『为什么会空』
+    // 映射到 {sentence}/{sentence-audio}（字段恒空）。这里在制卡前把『为什么会空』
     // 摊到用户面前（toast + 日志），不改任何制卡行为（卡照常创建）。
     await _emitSentenceDiagnostics(repo, miningContext);
 
@@ -272,7 +272,7 @@ extension _ReaderMining on _ReaderHibikiPageState {
   /// - [context].sentence 为空 → 运行时根本没捕获到句子（无标点/无 <p> 等内容让
   ///   JS 抽句回空，或没选词）。
   /// - 句子非空、但当前 Anki note-type 的 fieldMappings **没有任何字段消费**
-  ///   `{sentence}`/`{cue-sentence}`（句子）或 `{sasayaki-audio}`（句子音频）→ 字段
+  ///   `{sentence}`/`{cue-sentence}`（句子）或 `{sentence-audio}`（句子音频）→ 字段
   ///   渲染恒空，卡片上自然「没有句子」。判据复用 hibiki_anki 的纯函数
   ///   [AnkiHandlebarOptions.anyFieldConsumesSentence] / [anyFieldConsumesToken]，
   ///   与 [AnkiHandlebarRenderer] 同一套 token 语义，不自己重造解析。
@@ -311,10 +311,9 @@ extension _ReaderMining on _ReaderHibikiPageState {
 
     final bool hasSentenceAudio = (context.sasayakiAudioPath ?? '').isNotEmpty;
     if (hasSentenceAudio &&
-        !AnkiHandlebarOptions.anyFieldConsumesToken(
-            fieldMappings, '{sasayaki-audio}')) {
+        !AnkiHandlebarOptions.anyFieldConsumesSentenceAudio(fieldMappings)) {
       debugPrint('[mine-diag] sentence audio attached but no field maps '
-          '{sasayaki-audio}; the audio will not land on the card.');
+          '{sentence-audio}; the audio will not land on the card.');
       HibikiToast.show(msg: t.card_mined_unmapped_sentence_audio_field);
     }
   }

--- a/hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart
@@ -88,7 +88,7 @@ extension _VideoLookupMining on _VideoHibikiPageState {
   /// 制卡（覆写 [DictionaryPageMixin.onMineEntry]）：在词典 [fields]（已含单词
   /// 发音 `{audio}`、例句字段等）基础上，注入视频专属上下文——当前帧截图
   /// coverPath（→`{book-cover}`）+ 当前字幕 cue 的音频片段（裁**当前选中音轨**）
-  /// sasayakiAudioPath（→`{sasayaki-audio}`）+ 例句 sentence。复用现有 Anki 字段。
+  /// sasayakiAudioPath（→`{sentence-audio}`）+ 例句 sentence。复用现有 Anki 字段。
   bool _isCueSelectedForCard(AudioCue cue) =>
       _selectedMiningCueStarts.contains(cue.startMs);
 

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -3387,7 +3387,7 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// 制卡（覆写 [DictionaryPageMixin.onMineEntry]）：在词典 [fields]（已含单词
   /// 发音 `{audio}`、例句字段等）基础上，注入视频专属上下文——当前帧截图
   /// coverPath（→`{book-cover}`）+ 当前字幕 cue 的音频片段（裁**当前选中音轨**）
-  /// sasayakiAudioPath（→`{sasayaki-audio}`）+ 例句 sentence。复用现有 Anki 字段。
+  /// sasayakiAudioPath（→`{sentence-audio}`）+ 例句 sentence。复用现有 Anki 字段。
   /// 方法体搬到 [_VideoLookupMining] part（TODO-590 batch14），@override 留瘦转发器。
   @override
   Future<MinePopupResult> onMineEntry(Map<String, String> fields) =>

--- a/hibiki/test/anki/lapis_note_type_test.dart
+++ b/hibiki/test/anki/lapis_note_type_test.dart
@@ -79,7 +79,7 @@ void main() {
       }
       expect(LapisNoteType.defaultFieldMappings['Picture'], '{card-image}');
       expect(LapisNoteType.defaultFieldMappings['SentenceAudio'],
-          '{sasayaki-audio}');
+          '{sentence-audio}');
       expect(LapisNoteType.defaultFieldMappings['IsWordAndSentenceCard'], 'x');
     });
   });

--- a/packages/hibiki_anki/lib/src/anki_models.dart
+++ b/packages/hibiki_anki/lib/src/anki_models.dart
@@ -468,6 +468,13 @@ class AnkiHandlebarRenderer {
         return context.coverPath ?? '';
       case '{video-clip}':
         return context.coverPath ?? '';
+      // {sentence-audio} 是句子音频的通用键（语义中性、名副其实）：对应 Lapis
+      // SentenceAudio 字段的默认映射，值就是 sasayakiAudioPath（有声书 cue / 视频
+      // 例句音频片段）。
+      case '{sentence-audio}':
+        return context.sasayakiAudioPath ?? '';
+      // {sasayaki-audio} 是 {sentence-audio} 的旧别名（历史命名），保留以兼容老配置
+      // 与老卡片模板：两者读同一个 sasayakiAudioPath，运行时零分叉、媒体嵌入零改动。
       case '{sasayaki-audio}':
         return context.sasayakiAudioPath ?? '';
       default:
@@ -543,6 +550,7 @@ class AnkiHandlebarOptions {
     '{card-image}',
     '{book-cover}',
     '{video-clip}',
+    '{sentence-audio}',
     '{sasayaki-audio}',
   ];
 
@@ -553,7 +561,7 @@ class AnkiHandlebarOptions {
 
   /// TODO-948/952 诊断（纯函数）：当前 note-type 的 [fieldMappings]（Anki 字段名 →
   /// handlebar 模板）里是否**有任何一个字段消费了** [token]（如 `{sentence}` /
-  /// `{sasayaki-audio}`）。字段模板可以是裸 token，也可以是把多个 token 拼进 HTML 的
+  /// `{sentence-audio}`）。字段模板可以是裸 token，也可以是把多个 token 拼进 HTML 的
   /// 大模板，故按子串包含判断（与 [AnkiHandlebarRenderer.render] 用同一套 `{...}`
   /// token 语义）。fieldMappings 为空、或所有字段都映成 `-`/纯字面量时返回 false——
   /// 这正是「句子写进了 context 但卡片没字段接它 → 字段恒空」的可见判据。
@@ -572,6 +580,15 @@ class AnkiHandlebarOptions {
   static bool anyFieldConsumesSentence(Map<String, String> fieldMappings) =>
       anyFieldConsumesToken(fieldMappings, '{sentence}') ||
       anyFieldConsumesToken(fieldMappings, '{cue-sentence}');
+
+  /// 是否有字段消费句子音频（`{sentence-audio}` 或语义等价的旧别名
+  /// `{sasayaki-audio}`）。两者任一被引用即视为「句子音频有去处」，避免把用了新名
+  /// 或老名的配置误报成未映射（与 [AnkiHandlebarRenderer.render] 同一套别名语义）。
+  static bool anyFieldConsumesSentenceAudio(
+    Map<String, String> fieldMappings,
+  ) =>
+      anyFieldConsumesToken(fieldMappings, '{sentence-audio}') ||
+      anyFieldConsumesToken(fieldMappings, '{sasayaki-audio}');
 }
 
 String mimeTypeForPath(String path) {

--- a/packages/hibiki_anki/lib/src/lapis_note_type.dart
+++ b/packages/hibiki_anki/lib/src/lapis_note_type.dart
@@ -67,7 +67,7 @@ class LapisNoteType {
     'SelectionText': '{popup-selection-text}',
     'MainDefinition': '{glossary-first}',
     'Sentence': '{sentence}',
-    'SentenceAudio': '{sasayaki-audio}',
+    'SentenceAudio': '{sentence-audio}',
     'Picture': '{card-image}',
     'Glossary': '{glossary}',
     'PitchPosition': '{pitch-accent-positions}',

--- a/packages/hibiki_anki/test/handlebar_sentence_audio_test.dart
+++ b/packages/hibiki_anki/test/handlebar_sentence_audio_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+/// 通用句子音频键 `{sentence-audio}` 守卫 + 旧别名向后兼容。
+///
+/// `{sentence-audio}` 是句子音频的通用占位符（语义中性、名副其实），取代名不副实的
+/// 内部历史命名 `{sasayaki-audio}` 成为 Lapis `SentenceAudio` 字段的默认映射。旧键
+/// `{sasayaki-audio}` 保留为别名：两者都读同一个 `context.sasayakiAudioPath`，渲染
+/// 结果必须逐字节相同——老配置 / 老卡片模板不受影响。
+void main() {
+  const AnkiMiningPayload payload = AnkiMiningPayload(expression: '言葉');
+
+  AnkiMiningContext contextWithAudio(String? audio) => AnkiMiningContext(
+        sentence: 'これは言葉です。',
+        sasayakiAudioPath: audio,
+      );
+
+  group('AnkiHandlebarRenderer {sentence-audio}', () {
+    test('renders context.sasayakiAudioPath', () {
+      final String value = AnkiHandlebarRenderer.render(
+        '{sentence-audio}',
+        payload,
+        contextWithAudio('sentence.mp3'),
+      );
+      expect(value, 'sentence.mp3');
+    });
+
+    test('{sentence-audio} == {sasayaki-audio} 逐字节相同（向后兼容）', () {
+      final AnkiMiningContext ctx = contextWithAudio('hibiki_audio_x.mp3');
+      final String sentenceAudio =
+          AnkiHandlebarRenderer.render('{sentence-audio}', payload, ctx);
+      final String sasayakiAudio =
+          AnkiHandlebarRenderer.render('{sasayaki-audio}', payload, ctx);
+      expect(sentenceAudio, sasayakiAudio);
+    });
+
+    test('sasayakiAudioPath 为 null 时两者都渲染空串', () {
+      final AnkiMiningContext ctx = contextWithAudio(null);
+      expect(
+          AnkiHandlebarRenderer.render('{sentence-audio}', payload, ctx), '');
+      expect(
+          AnkiHandlebarRenderer.render('{sasayaki-audio}', payload, ctx), '');
+    });
+
+    test('两者都渲染媒体引用串（模拟 backend 落盘后回填）逐字节相同', () {
+      // backend 把音频落盘后用 `[sound:ref]` 覆盖 sasayakiAudioPath 再渲染。
+      const String mediaRef = '[sound:hibiki_audio_abc.mp3]';
+      final AnkiMiningContext ctx = contextWithAudio(mediaRef);
+      expect(AnkiHandlebarRenderer.render('{sentence-audio}', payload, ctx),
+          mediaRef);
+      expect(
+        AnkiHandlebarRenderer.render('{sentence-audio}', payload, ctx),
+        AnkiHandlebarRenderer.render('{sasayaki-audio}', payload, ctx),
+      );
+    });
+  });
+
+  group('AnkiHandlebarOptions.coreOptions', () {
+    test('含新键 {sentence-audio} 且仍保留旧别名 {sasayaki-audio}', () {
+      expect(AnkiHandlebarOptions.coreOptions, contains('{sentence-audio}'));
+      expect(AnkiHandlebarOptions.coreOptions, contains('{sasayaki-audio}'));
+    });
+  });
+
+  group('AnkiHandlebarOptions.anyFieldConsumesSentenceAudio', () {
+    test('新键 {sentence-audio} 被消费时为 true', () {
+      expect(
+        AnkiHandlebarOptions.anyFieldConsumesSentenceAudio(
+            {'SentenceAudio': '{sentence-audio}'}),
+        isTrue,
+      );
+    });
+
+    test('旧别名 {sasayaki-audio} 被消费时也为 true（向后兼容诊断）', () {
+      expect(
+        AnkiHandlebarOptions.anyFieldConsumesSentenceAudio(
+            {'SentenceAudio': '{sasayaki-audio}'}),
+        isTrue,
+      );
+    });
+
+    test('没有字段消费任一句子音频键时为 false', () {
+      expect(
+        AnkiHandlebarOptions.anyFieldConsumesSentenceAudio(
+            {'Expression': '{expression}'}),
+        isFalse,
+      );
+      expect(AnkiHandlebarOptions.anyFieldConsumesSentenceAudio({}), isFalse);
+    });
+  });
+
+  group('LapisNoteType default mapping', () {
+    test('SentenceAudio 默认映射到通用键 {sentence-audio}（不再是内部命名 sasayaki）', () {
+      expect(LapisNoteType.defaultFieldMappings['SentenceAudio'],
+          '{sentence-audio}');
+    });
+  });
+}


### PR DESCRIPTION
## 背景
用户反馈：句子音频（sentenceAudio）字段的 handlebar token `{sasayaki-audio}` 命名要改——和书籍图片一样改成名副其实的名字。

内部历史命名 `{sasayaki-audio}`（囁き，有声书旁白轨的内部叫法）用户看不懂。这里完全仿照已落地的 `{book-cover}`/`{video-clip}` → `{card-image}`（TODO-1298）做法。

## 改动
- **新主键 `{sentence-audio}`**（语义中性、名副其实）成为 Lapis `SentenceAudio` 字段默认映射；旧键 `{sasayaki-audio}` 保留为**向后兼容别名**，两者读同一个 `sasayakiAudioPath`，运行时零分叉、媒体嵌入零改动。老配置 / 老卡片模板不受影响。
- `anki_models`：新增渲染分支 + `coreOptions` 收录 + 纯函数 `anyFieldConsumesSentenceAudio`（认新名+旧别名），消除 mining 诊断处两 token 的特例判断。
- `lapis_note_type`：`SentenceAudio` 默认映射改为 `{sentence-audio}`。
- `anki_settings_page`：新 token → 本地化标签 `handlebar_sentence_audio`。
- `reader_hibiki/mining`：未映射句子音频诊断改用新 helper。
- i18n：新增 `handlebar_sentence_audio`（Sentence Audio / 句子音频，17 语言经 i18n_sync 补齐）；未映射提示消息 token 同步改名；重生成 `strings.g.dart`。

## 验证
- `packages/hibiki_anki` 全量 155 tests 通过（含新增 `handlebar_sentence_audio_test`：渲染/别名逐字节相同/coreOptions/诊断/默认映射）。
- `hibiki/test/anki` + `hibiki/test/i18n` 125 tests 通过。
- `flutter analyze` hibiki_anki 无新增问题（唯一 warning 在未触碰的旧测试文件）；`strings.g.dart` 的 scriptCode warning 为 develop 既有 slang 基线（构造器 + ignore 注释与 HEAD 逐字节相同）。
- ⏳ 待真机验收：有声书划词制卡时句子音频真正落到 Lapis SentenceAudio 字段。

🤖 Generated with [Claude Code](https://claude.com/claude-code)