### PR TITLE
feat(video-mining): 视频制卡封面图片模式三选一（GIF / 制卡时截图 / 字幕开头截图）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39100 (2300 per locale)
+/// Strings: 39185 (2305 per locale)
 ///
-/// Built on 2026-07-13 at 03:56 UTC
+/// Built on 2026-07-13 at 05:32 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3042,6 +3042,13 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Removed tag "${name}" from ${n} video(s).';
   String get stat_daily_average => 'Daily avg';
   String get handlebar_sentence_audio => 'Sentence Audio';
+  String get video_mining_image_mode => 'Video card image';
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -8244,6 +8251,18 @@ class _StringsAr extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -13569,6 +13588,18 @@ class _StringsDe extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -18911,6 +18942,18 @@ class _StringsEs extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -24272,6 +24315,18 @@ class _StringsFr extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -29535,6 +29590,18 @@ class _StringsId extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -34859,6 +34926,18 @@ class _StringsIt extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -39908,6 +39987,18 @@ class _StringsJa extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -44962,6 +45053,18 @@ class _StringsKo extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -50254,6 +50357,18 @@ class _StringsNl extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -55569,6 +55684,18 @@ class _StringsPtBr extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -60859,6 +60986,18 @@ class _StringsRu extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -66062,6 +66201,18 @@ class _StringsTh extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -71320,6 +71471,18 @@ class _StringsTr extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -76553,6 +76716,18 @@ class _StringsVi extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -81431,6 +81606,16 @@ class _StringsZhCn extends _StringsEn {
   String get stat_daily_average => '日均';
   @override
   String get handlebar_sentence_audio => '句子音频';
+  @override
+  String get video_mining_image_mode => '视频卡片图片';
+  @override
+  String get video_mining_image_mode_hint => '视频制卡封面用动图还是截图';
+  @override
+  String get video_mining_image_mode_gif => '动图 GIF（字幕片段）';
+  @override
+  String get video_mining_image_mode_current_frame => '制卡时截图';
+  @override
+  String get video_mining_image_mode_subtitle_start => '字幕开头截图';
 }
 
 // Path: retrying_in
@@ -86382,6 +86567,18 @@ class _StringsZhHk extends _StringsEn {
   String get stat_daily_average => 'Daily avg';
   @override
   String get handlebar_sentence_audio => 'Sentence Audio';
+  @override
+  String get video_mining_image_mode => 'Video card image';
+  @override
+  String get video_mining_image_mode_hint =>
+      'How covers on video cards are captured';
+  @override
+  String get video_mining_image_mode_gif => 'Animated GIF (subtitle clip)';
+  @override
+  String get video_mining_image_mode_current_frame => 'Screenshot at mining';
+  @override
+  String get video_mining_image_mode_subtitle_start =>
+      'Screenshot at subtitle start';
 }
 
 // Path: retrying_in
@@ -91123,6 +91320,16 @@ extension on _StringsEn {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -95824,6 +96031,16 @@ extension on _StringsAr {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -100547,6 +100764,16 @@ extension on _StringsDe {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -105268,6 +105495,16 @@ extension on _StringsEs {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -109996,6 +110233,16 @@ extension on _StringsFr {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -114704,6 +114951,16 @@ extension on _StringsId {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -119429,6 +119686,16 @@ extension on _StringsIt {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -124111,6 +124378,16 @@ extension on _StringsJa {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -128797,6 +129074,16 @@ extension on _StringsKo {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -133515,6 +133802,16 @@ extension on _StringsNl {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -138230,6 +138527,16 @@ extension on _StringsPtBr {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -142949,6 +143256,16 @@ extension on _StringsRu {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -147650,6 +147967,16 @@ extension on _StringsTh {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -152360,6 +152687,16 @@ extension on _StringsTr {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -157064,6 +157401,16 @@ extension on _StringsVi {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }
@@ -161733,6 +162080,16 @@ extension on _StringsZhCn {
         return '日均';
       case 'handlebar_sentence_audio':
         return '句子音频';
+      case 'video_mining_image_mode':
+        return '视频卡片图片';
+      case 'video_mining_image_mode_hint':
+        return '视频制卡封面用动图还是截图';
+      case 'video_mining_image_mode_gif':
+        return '动图 GIF（字幕片段）';
+      case 'video_mining_image_mode_current_frame':
+        return '制卡时截图';
+      case 'video_mining_image_mode_subtitle_start':
+        return '字幕开头截图';
       default:
         return null;
     }
@@ -166407,6 +166764,16 @@ extension on _StringsZhHk {
         return 'Daily avg';
       case 'handlebar_sentence_audio':
         return 'Sentence Audio';
+      case 'video_mining_image_mode':
+        return 'Video card image';
+      case 'video_mining_image_mode_hint':
+        return 'How covers on video cards are captured';
+      case 'video_mining_image_mode_gif':
+        return 'Animated GIF (subtitle clip)';
+      case 'video_mining_image_mode_current_frame':
+        return 'Screenshot at mining';
+      case 'video_mining_image_mode_subtitle_start':
+        return 'Screenshot at subtitle start';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "$n 本の動画にタグ「$name」を追加しました。",
   "batch_tag_removed_video": "$n 本の動画からタグ「$name」を削除しました。",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "Added tag \"$name\" to $n video(s).",
   "batch_tag_removed_video": "Removed tag \"$name\" from $n video(s).",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "已为 $n 个视频添加标签「$name」。",
   "batch_tag_removed_video": "已从 $n 个视频移除标签「$name」。",
   "stat_daily_average": "日均",
-  "handlebar_sentence_audio": "句子音频"
+  "handlebar_sentence_audio": "句子音频",
+  "video_mining_image_mode": "视频卡片图片",
+  "video_mining_image_mode_hint": "视频制卡封面用动图还是截图",
+  "video_mining_image_mode_gif": "动图 GIF（字幕片段）",
+  "video_mining_image_mode_current_frame": "制卡时截图",
+  "video_mining_image_mode_subtitle_start": "字幕开头截图"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2306,5 +2306,10 @@
   "batch_tag_added_video": "已為 $n 個影片添加標籤「$name」。",
   "batch_tag_removed_video": "已從 $n 個影片移除標籤「$name」。",
   "stat_daily_average": "Daily avg",
-  "handlebar_sentence_audio": "Sentence Audio"
+  "handlebar_sentence_audio": "Sentence Audio",
+  "video_mining_image_mode": "Video card image",
+  "video_mining_image_mode_hint": "How covers on video cards are captured",
+  "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
+  "video_mining_image_mode_current_frame": "Screenshot at mining",
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
 }

--- a/hibiki/lib/src/mining/immersion_mining_engine.dart
+++ b/hibiki/lib/src/mining/immersion_mining_engine.dart
@@ -99,8 +99,15 @@ class ImmersionMiningEngine {
 
     final String? src = req.mediaSource;
 
-    if (coverPath == null && src != null && req.hasRange) {
-      coverPath = await _gif(
+    // 三种封面来源封成本地闭包（各自带前置守卫，源不可用即返 null）。三个 [VideoMiningImageMode]
+    // 只是它们的不同优先级排列，把原来手写的三段 `if (coverPath == null && ...)` 阶梯归一成
+    // 「一张优先级表」——GIF 模式排列与旧代码逐字等价（Never break userspace），静态模式只是
+    // 换个排列且不置 degradedToStill（用户主动选静态图，非降级）。
+    //
+    // 抽字幕区间动图（GIF）到临时文件；无 src / 无区间 → null。
+    Future<String?> tryGif() async {
+      if (src == null || !req.hasRange) return null;
+      return _gif(
         inputPath: src,
         startMs: req.clipStartMs,
         endMs: req.clipEndMs,
@@ -110,29 +117,53 @@ class ImmersionMiningEngine {
         onFailure: onFailure,
       );
     }
-    if (coverPath == null && src != null) {
-      final String? framePath = await _frame(
+
+    // 抽字幕 cue 起始时间点的单帧；无 src → null。
+    Future<String?> tryStartFrame() async {
+      if (src == null) return null;
+      return _frame(
         inputPath: src,
         outputPath: '$tempDir/immersion_frame.jpg',
         atSeconds: req.clipStartMs / 1000.0,
         onFailure: onFailure,
       );
-      if (framePath != null) {
-        coverPath = framePath;
-        degradedToStill = true;
-      }
     }
-    if (coverPath == null && req.stillFallback != null) {
+
+    // 当前解码帧（`controller.screenshot`，点词已自动暂停）→ 降采样写盘；无 stillFallback → null。
+    Future<String?> tryCurrentFrame() async {
+      if (req.stillFallback == null) return null;
       final Uint8List? shot = await req.stillFallback!();
-      if (shot != null) {
-        final Uint8List small = downsampleCardScreenshot(
-          shot,
-          maxLongEdge: compression.screenshotMaxLongEdge,
-          quality: compression.screenshotQuality,
-        );
-        coverPath = await _writeBytes(tempDir, 'immersion_shot.jpg', small);
-        // 无区间(无cue)截当前帧不算降级，不弹「降级为静态」OSD。
-        degradedToStill = req.hasRange;
+      if (shot == null) return null;
+      final Uint8List small = downsampleCardScreenshot(
+        shot,
+        maxLongEdge: compression.screenshotMaxLongEdge,
+        quality: compression.screenshotQuality,
+      );
+      return _writeBytes(tempDir, 'immersion_shot.jpg', small);
+    }
+
+    if (coverPath == null) {
+      switch (req.imageMode) {
+        case VideoMiningImageMode.gif:
+          // 现状阶梯：GIF 主 → 起点单帧降级 → 当前帧兜底（逐字等价于旧三段 if）。
+          coverPath = await tryGif();
+          if (coverPath == null) {
+            coverPath = await tryStartFrame();
+            if (coverPath != null) degradedToStill = true;
+          }
+          if (coverPath == null) {
+            coverPath = await tryCurrentFrame();
+            // 无区间(无cue)截当前帧不算降级，不弹「降级为静态」OSD。
+            if (coverPath != null) degradedToStill = req.hasRange;
+          }
+        case VideoMiningImageMode.subtitleStart:
+          // 用户选「字幕开头截图」：起点单帧优先，失败退当前帧。主动选静态图，非降级。
+          coverPath = await tryStartFrame();
+          coverPath ??= await tryCurrentFrame();
+        case VideoMiningImageMode.currentFrame:
+          // 用户选「制卡时截图」：当前解码帧优先，失败退起点单帧。主动选静态图，非降级。
+          coverPath = await tryCurrentFrame();
+          coverPath ??= await tryStartFrame();
       }
     }
 

--- a/hibiki/lib/src/mining/immersion_mining_request.dart
+++ b/hibiki/lib/src/mining/immersion_mining_request.dart
@@ -21,6 +21,39 @@ String immersionMiningAudioExtensionFor({required bool isIOS}) =>
 String immersionMiningAudioExtension() =>
     immersionMiningAudioExtensionFor(isIOS: Platform.isIOS);
 
+/// 视频制卡的封面图片模式（用户在 Anki 设置里三选一，默认 [gif]=现状零破坏）：
+/// - [gif]：字幕区间动图（现默认，`extractClipGifViaFfmpeg`）。抽取失败按旧阶梯降级为
+///   静态帧，并弹「降级为静态帧」OSD。
+/// - [currentFrame]：制卡那一刻的当前解码帧（`controller.screenshot`，点词已自动暂停）。
+///   用户主动选的静态图，非降级 → 不弹降级 OSD。
+/// - [subtitleStart]：当前字幕 cue 起始时间点的帧（`extractVideoFrameViaFfmpeg`，
+///   `atSeconds = clipStartMs/1000`）。同为主动选择的静态图。
+///
+/// 持久化用 [wireName]（存进偏好的字符串），解析用 [fromWireName]（未知值回退 [gif]，
+/// 向后兼容）。远端来源（Netflix providedCoverBytes / YouTube）请求不设本字段，保持 [gif]
+/// 默认——它们直接给字节或走既有阶梯，不受影响。
+enum VideoMiningImageMode {
+  gif('gif'),
+  currentFrame('current_frame'),
+  subtitleStart('subtitle_start');
+
+  const VideoMiningImageMode(this.wireName);
+
+  /// 偏好持久化用的稳定字符串键（勿随枚举名改动）。
+  final String wireName;
+
+  /// 从偏好字符串解析；未知/null → [gif]（默认，向后兼容）。
+  static VideoMiningImageMode fromWireName(String? name) {
+    for (final VideoMiningImageMode mode in VideoMiningImageMode.values) {
+      if (mode.wireName == name) return mode;
+    }
+    return VideoMiningImageMode.gif;
+  }
+
+  /// 是否为静态截图模式（用户主动选静态图，非 GIF 降级）。
+  bool get isStill => this != VideoMiningImageMode.gif;
+}
+
 /// 统一沉浸制卡请求。任何来源（本地/YouTube/Netflix）都构造这个喂 [ImmersionMiningEngine]。
 ///
 /// [mediaSource] 是 ffmpeg 的 inputPath——本地绝对路径 或 可 seek 的 http 流 URL。
@@ -47,6 +80,7 @@ class ImmersionMiningRequest {
     this.providedAudioBytes,
     this.providedAudioName,
     this.requireAudio = true,
+    this.imageMode = VideoMiningImageMode.gif,
   });
 
   final Map<String, String> fields;
@@ -79,6 +113,10 @@ class ImmersionMiningRequest {
 
   /// true = 无音频则中止制卡（本地/YouTube 默认）；false = 允许无音频卡（Netflix 2A 截图卡）。
   final bool requireAudio;
+
+  /// 视频制卡封面图片模式（见 [VideoMiningImageMode]）。默认 [VideoMiningImageMode.gif]
+  /// = 现状。仅本地/有 range 的封面解析路径读取；providedCoverBytes 路径不受影响。
+  final VideoMiningImageMode imageMode;
 
   bool get hasRange => clipEndMs > clipStartMs;
 }

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4023,6 +4023,12 @@ class AppModel with ChangeNotifier {
   bool get compressMiningMedia => prefsRepo.compressMiningMedia;
   void toggleCompressMiningMedia() => prefsRepo.toggleCompressMiningMedia();
 
+  // 视频制卡封面图片模式（GIF / 制卡时当前帧 / 字幕开头帧，透传 prefsRepo）。默认 gif=现状。
+  VideoMiningImageMode get videoMiningImageMode =>
+      prefsRepo.videoMiningImageMode;
+  void setVideoMiningImageMode(VideoMiningImageMode mode) =>
+      prefsRepo.setVideoMiningImageMode(mode);
+
   bool get deduplicatePitchAccents => prefsRepo.deduplicatePitchAccents;
   void toggleDeduplicatePitchAccents() =>
       prefsRepo.toggleDeduplicatePitchAccents();

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -8,6 +8,8 @@ import 'package:hibiki/src/media/video/video_danmaku_model.dart';
 import 'package:hibiki/src/media/video/video_control_customization.dart';
 import 'package:hibiki/src/media/video/video_immersive_mode.dart';
 import 'package:hibiki/src/media/video/video_subtitle_obscure_mode.dart';
+import 'package:hibiki/src/mining/immersion_mining_request.dart'
+    show VideoMiningImageMode;
 import 'package:hibiki/src/models/audio_source_config.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki/src/utils/misc/update_check_cache.dart';
@@ -1053,6 +1055,17 @@ class PreferencesRepository extends ChangeNotifier {
 
   void toggleCompressMiningMedia() async {
     await setPref('compress_mining_media', !compressMiningMedia);
+    notifyListeners();
+  }
+
+  // 视频制卡封面图片模式（GIF 动图 / 制卡时当前帧 / 字幕开头帧）。默认 gif=现状零破坏。
+  // 存稳定字符串键（[VideoMiningImageMode.wireName]），解析未知值回退 gif（向后兼容）。
+  VideoMiningImageMode get videoMiningImageMode =>
+      VideoMiningImageMode.fromWireName(
+          getPref('video_mining_image_mode', defaultValue: null) as String?);
+
+  void setVideoMiningImageMode(VideoMiningImageMode mode) async {
+    await setPref('video_mining_image_mode', mode.wireName);
     notifyListeners();
   }
 

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -7,6 +7,8 @@ import 'package:hibiki/utils.dart';
 
 import 'package:hibiki_anki/hibiki_anki.dart';
 import 'package:hibiki/src/anki/anki_view_model.dart';
+import 'package:hibiki/src/mining/immersion_mining_request.dart'
+    show VideoMiningImageMode;
 import 'package:hibiki/src/profile/profile_selector.dart';
 
 /// Anki 设置正文（无脚手架）。直接平铺进「制卡」设置 destination 详情页
@@ -192,9 +194,41 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
                 setState(() {});
               },
             ),
+            _buildVideoMiningImageModePicker(),
           ],
         ),
       ],
+    );
+  }
+
+  /// 视频制卡封面图片模式三选一：gif=字幕区间动图（默认，现状零破坏）；currentFrame=
+  /// 制卡那一刻的当前解码帧（点词已自动暂停）；subtitleStart=当前字幕 cue 起始时间点的帧。
+  /// 全局设置，透传 [AppModel.videoMiningImageMode]，所有视频制卡生效。
+  Widget _buildVideoMiningImageModePicker() {
+    return AdaptiveSettingsPickerRow<VideoMiningImageMode>(
+      title: t.video_mining_image_mode,
+      subtitle: t.video_mining_image_mode_hint,
+      icon: Icons.photo_library_outlined,
+      controlBelow: true,
+      selected: appModel.videoMiningImageMode,
+      options: [
+        AdaptiveSettingsPickerOption<VideoMiningImageMode>(
+          value: VideoMiningImageMode.gif,
+          label: t.video_mining_image_mode_gif,
+        ),
+        AdaptiveSettingsPickerOption<VideoMiningImageMode>(
+          value: VideoMiningImageMode.currentFrame,
+          label: t.video_mining_image_mode_current_frame,
+        ),
+        AdaptiveSettingsPickerOption<VideoMiningImageMode>(
+          value: VideoMiningImageMode.subtitleStart,
+          label: t.video_mining_image_mode_subtitle_start,
+        ),
+      ],
+      onChanged: (VideoMiningImageMode mode) {
+        appModel.setVideoMiningImageMode(mode);
+        setState(() {});
+      },
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart
@@ -306,6 +306,9 @@ extension _VideoLookupMining on _VideoHibikiPageState {
             : null,
         updateNoteId: updateNoteId,
         stillFallback: controller.screenshot,
+        // 用户在 Anki 设置里选的封面图片模式（GIF / 制卡时当前帧 / 字幕开头帧）；
+        // 默认 gif=现状。静态模式引擎不置 degradedToStill，故不弹「降级为静态」OSD。
+        imageMode: appModel.videoMiningImageMode,
       ),
       compression: mediaCompression,
       tempDir: tmp.path,

--- a/hibiki/test/mining/immersion_mining_engine_test.dart
+++ b/hibiki/test/mining/immersion_mining_engine_test.dart
@@ -319,4 +319,132 @@ void main() {
     expect(res.abortReason, contains('no cover'));
     expect(repo.minedContext, isNull);
   });
+
+  // ── 视频制卡封面图片模式（VideoMiningImageMode）─────────────────────────
+  // gif 模式与旧阶梯逐字等价（上面 'gif+audio success' / 'gif fails -> frame fallback'
+  // 已覆盖，且 imageMode 默认 gif）。以下覆盖两个静态模式：主动选静态图不置 degradedToStill、
+  // 走对的来源、且不调 GIF。
+
+  // 制卡时截图：当前解码帧（stillFallback → immersion_shot.jpg）优先，不抽 GIF、非降级。
+  test('imageMode=currentFrame uses screenshot, no gif, not degraded',
+      () async {
+    final repo = _FakeRepo();
+    bool gifCalled = false;
+    Future<String?> flagGif(
+        {required String inputPath,
+        required int startMs,
+        required int endMs,
+        required String outputPath,
+        int fps = 8,
+        int width = 320,
+        FfmpegFailureReporter? onFailure}) async {
+      gifCalled = true;
+      return outputPath;
+    }
+
+    final res = await build(gif: flagGif, audio: okAudio, frame: okFrame).mine(
+        ImmersionMiningRequest(
+            fields: const {'expression': 'x'},
+            mediaSource: '/v.mp4',
+            clipStartMs: 1000,
+            clipEndMs: 3000,
+            sentence: 's',
+            imageMode: VideoMiningImageMode.currentFrame,
+            stillFallback: () async => Uint8List.fromList(<int>[9, 9, 9])),
+        compression: MiningMediaCompression.compressed,
+        tempDir: tmp.path,
+        repo: repo);
+    expect(res.aborted, false);
+    expect(gifCalled, false, reason: '静态模式不该抽 GIF');
+    expect(res.degradedToStill, false, reason: '用户主动选静态图，非降级');
+    expect(repo.minedContext!.coverPath, endsWith('immersion_shot.jpg'));
+  });
+
+  // 字幕开头截图：字幕起点单帧（immersion_frame.jpg）优先，不抽 GIF、非降级。
+  test('imageMode=subtitleStart uses start frame, no gif, not degraded',
+      () async {
+    final repo = _FakeRepo();
+    bool gifCalled = false;
+    Future<String?> flagGif(
+        {required String inputPath,
+        required int startMs,
+        required int endMs,
+        required String outputPath,
+        int fps = 8,
+        int width = 320,
+        FfmpegFailureReporter? onFailure}) async {
+      gifCalled = true;
+      return outputPath;
+    }
+
+    final res = await build(gif: flagGif, audio: okAudio, frame: okFrame).mine(
+        const ImmersionMiningRequest(
+            fields: {'expression': 'x'},
+            mediaSource: '/v.mp4',
+            clipStartMs: 1000,
+            clipEndMs: 3000,
+            sentence: 's',
+            imageMode: VideoMiningImageMode.subtitleStart),
+        compression: MiningMediaCompression.compressed,
+        tempDir: tmp.path,
+        repo: repo);
+    expect(res.aborted, false);
+    expect(gifCalled, false, reason: '静态模式不该抽 GIF');
+    expect(res.degradedToStill, false, reason: '用户主动选静态图，非降级');
+    expect(repo.minedContext!.coverPath, endsWith('immersion_frame.jpg'));
+  });
+
+  // currentFrame 无 stillFallback（如无当前帧）→ 退字幕起点单帧，仍非降级。
+  test('imageMode=currentFrame without screenshot falls back to start frame',
+      () async {
+    final repo = _FakeRepo();
+    final res = await build(gif: nullGif, audio: okAudio, frame: okFrame).mine(
+        const ImmersionMiningRequest(
+            fields: {'expression': 'x'},
+            mediaSource: '/v.mp4',
+            clipStartMs: 1000,
+            clipEndMs: 3000,
+            sentence: 's',
+            imageMode: VideoMiningImageMode.currentFrame),
+        compression: MiningMediaCompression.compressed,
+        tempDir: tmp.path,
+        repo: repo);
+    expect(res.aborted, false);
+    expect(res.degradedToStill, false);
+    expect(repo.minedContext!.coverPath, endsWith('immersion_frame.jpg'));
+  });
+
+  // subtitleStart 起点帧失败 → 退当前解码帧（immersion_shot.jpg），仍非降级。
+  test('imageMode=subtitleStart with frame failure falls back to screenshot',
+      () async {
+    final repo = _FakeRepo();
+    final res = await build(gif: okGif, audio: okAudio, frame: nullFrame).mine(
+        ImmersionMiningRequest(
+            fields: const {'expression': 'x'},
+            mediaSource: '/v.mp4',
+            clipStartMs: 1000,
+            clipEndMs: 3000,
+            sentence: 's',
+            imageMode: VideoMiningImageMode.subtitleStart,
+            stillFallback: () async => Uint8List.fromList(<int>[7, 7, 7])),
+        compression: MiningMediaCompression.compressed,
+        tempDir: tmp.path,
+        repo: repo);
+    expect(res.aborted, false);
+    expect(res.degradedToStill, false);
+    expect(repo.minedContext!.coverPath, endsWith('immersion_shot.jpg'));
+  });
+
+  // wireName 往返 + 未知值回退 gif（持久化契约，向后兼容）。
+  test('VideoMiningImageMode.fromWireName round-trips and defaults to gif', () {
+    for (final VideoMiningImageMode mode in VideoMiningImageMode.values) {
+      expect(VideoMiningImageMode.fromWireName(mode.wireName), mode);
+    }
+    expect(VideoMiningImageMode.fromWireName(null), VideoMiningImageMode.gif);
+    expect(VideoMiningImageMode.fromWireName('nonsense'),
+        VideoMiningImageMode.gif);
+    expect(VideoMiningImageMode.gif.isStill, false);
+    expect(VideoMiningImageMode.currentFrame.isStill, true);
+    expect(VideoMiningImageMode.subtitleStart.isStill, true);
+  });
 }

--- a/hibiki/test/pages/video_mining_context_guard_test.dart
+++ b/hibiki/test/pages/video_mining_context_guard_test.dart
@@ -166,8 +166,10 @@ void main() {
     expect(mineCard, contains(r'sentence audio export failed: $lastFailure'),
         reason: '用户可见错误应含实际 executable/fallback/0xC000007B 等摘要。');
     // 引擎把 onFailure 转发给 GIF/音频抽取器，故 GIF 失败也留下 ffmpeg 诊断。
+    // TODO-<image-mode>：GIF 调用搬进 tryGif() 闭包（封面模式排列器），`await` 移位；
+    // 守卫改锚 `_gif(` 调用点 + onFailure 转发（不再钉死 `await _gif(` 这一实现细节）。
     expect(
-        engineNorm.contains('await _gif(') &&
+        engineNorm.contains('_gif(') &&
             engineNorm.contains('onFailure: onFailure'),
         isTrue,
         reason: 'GIF 导出失败虽可回退截图，也必须经 onFailure 留下 ffmpeg 诊断。');


### PR DESCRIPTION
## 需求
视频制卡支持选择 GIF / 制卡时截图 / 字幕开头截图。

## 方案
在 Anki 设置加**全局**「视频卡片图片」三选一（默认 GIF，零行为破坏）：
- **GIF（默认）**：字幕区间动图，抽取失败按旧阶梯降级为静帧 + 弹降级 OSD。
- **制卡时截图**：制卡那一刻的当前解码帧（`controller.screenshot`，点词已自动暂停）。
- **字幕开头截图**：当前字幕 cue 起始时间点的帧（`clipStartMs`）。

三种能力的底层抽取器（`extractClipGifViaFfmpeg` / `extractVideoFrameViaFfmpeg` / `controller.screenshot`）**都已存在**，本 PR 只加「模式选择 + 引擎按模式排列封面来源」，不造新能力。

## 改动
- `immersion_mining_request.dart`：新增 `VideoMiningImageMode` 枚举（`wireName` 持久化、未知值回退 gif）+ 请求字段（默认 gif）。
- `immersion_mining_engine.dart`：把原手写三段 `if` 封面阶梯归一成三个来源闭包 + 一张按模式排列的优先级表。**GIF 模式逐字等价旧代码**（Never break userspace）；两个静态模式换排列且**不置 `degradedToStill`**（用户主动选静态图非降级，不弹「降级为静态」OSD）。
- `preferences_repository.dart` / `app_model.dart`：加 `video_mining_image_mode` 偏好透传。
- `anki_settings_page.dart`：加 `AdaptiveSettingsPickerRow` 三选一（复用 overwrite-scope 同款控件）。
- i18n：5 key × 17 语言（`i18n_sync.dart` + `dart run slang` 重生成）。

## 测试
- 引擎三模式分支 + `wireName` 往返：5 个新单测（`immersion_mining_engine_test.dart`）。
- BUG-296 守卫：GIF 调用搬进 `tryGif()` 闭包（`await` 移位），松锚为 `_gif(` + `onFailure` 转发（意图不变）。
- ✅ `flutter analyze` 全绿；i18n 完整性 / settings schema 覆盖 / 挖词引擎 / 视频制卡上下文守卫全过。

## 待验证
- ⏳ 真机复测三模式实际出图（GIF / 当前帧 / 字幕起点帧）——本地无法驱动 media_kit 截帧。

🤖 Generated with [Claude Code](https://claude.com/claude-code)