### PR TITLE
查词弹窗尺寸精细化+拖拽调整（三套独立尺寸/边角拖拽/列数自动封顶）

### DIFF
--- a/docs/specs/2026-07-13-lookup-popup-resize-design.md
+++ b/docs/specs/2026-07-13-lookup-popup-resize-design.md
@@ -1,0 +1,119 @@
+# 查词弹窗尺寸精细化 + 拖拽调整 设计（spec）
+
+- 日期：2026-07-13
+- 分支：`worktree-lookup-popup-resize`
+- 状态：设计已确认，分期实现中（A→B→C→D）
+
+## 1. 目标
+
+让查词弹窗的**最大宽/高**可精细调整，且三种形态（app 内、app 外覆盖窗、浏览器扩展）可各自独立；并支持**直接拖拽弹窗边角**调整尺寸。列数改为「自动填充、封顶用户设定」。
+
+## 2. 平台现实（约束设计的硬事实）
+
+| 弹窗形态 | 存在平台 | 当前尺寸来源 | 当前可拖拽 |
+|---|---|---|---|
+| app 内查词弹窗（阅读器/视频） | 全 5 平台（Flutter overlay） | Dart 侧 `Positioned` = `popupMaxWidth×popupMaxHeight`，随屏幕/选区 clamp | 否 |
+| app 外覆盖查词卡（瞬态悬浮） | **仅 Windows** 原生窗；macOS/Linux 不弹（退回主窗 tab）；Android 另一套独立悬浮服务；iOS 无 | 同 `popupMaxWidth/H × appUiScale × dpr`，native 明确「瞬态窗不进模态循环、无 chrome」 | 否 |
+| 剪贴板查词面板 | 仅 Windows | 独立 `clipboardPanelRect` | **是**（Win32 grip，已有） |
+| 浏览器扩展弹窗 | 平台无关（网页 DOM） | app theme 变量 `--hibiki-popup-max-*` 下发 | 否 |
+
+**后果：** 「app 外拖拽」仅 Windows 可落地；app 内弹窗是唯一一次覆盖全 5 平台的表面；剪贴板面板已有拖拽，本设计不动它。
+
+## 3. 数据模型（真值 = 偏好键）
+
+```
+app内（沿用现有）:   popupMaxWidth / popupMaxHeight
+app外覆盖窗:         overlayLookupIndependentSize(bool, 默认 false)
+                    + overlayLookupMaxWidth / overlayLookupMaxHeight
+浏览器扩展:          extensionPopupIndependentSize(bool, 默认 false)
+                    + extensionPopupMaxWidth / extensionPopupMaxHeight
+列数（沿用现有语义收敛）: popupDictionaryColumns  → 语义改为「最多列数（自动填充）」
+```
+
+**有效尺寸解析**（纯函数，单元可测）：
+
+```
+effectiveLookupSize(scene) =
+  scene.independent ? (scene.maxWidth, scene.maxHeight)
+                    : (popupMaxWidth, popupMaxHeight)
+```
+
+- app 内始终用 `popupMaxWidth/H`。
+- app 外 / 扩展默认 `independent=false` → 跟随 app 内；用户显式解锁后用各自键。
+
+**拖拽的「解锁」规则（好品味）：** 在一个「跟随中」（`independent=false`）的表面上拖边角 = 自动把该场景 `independent` 置 `true` 并写入拖出来的尺寸。一动手定制它就脱钩。滑杆与拖拽写同一真值，实时同步。绝不引入「固定尺寸 override」这种第二套概念——弹窗仍是「撑到最大尺寸的准固定盒」，拖拽只是可视化地改这个「最大」。
+
+## 4. 列数（自动为主 + 上限）
+
+现状已是 `有效列数 = min(popupDictionaryColumns, 视口能装下的列数)`（`content.css` `--dict-columns-effective` / `popup.js updateEffectiveDictColumns`）——本质已是「自动填充、封顶用户值」。改动：
+
+- 设置项文案/语义改为「**词典最多列数（自动填充）**」；默认自动最多 3 列。
+- 确认三处（app 内 / app 外 / 扩展）都吃同一条 effective 逻辑。
+- 不引入「列宽」新概念（YAGNI）。
+
+## 5. 高度上限放宽
+
+当前高度滑杆上限 800（宽度已 2000）。放宽高度上限到 1600，步进保持细粒度，让「精细/更大」有空间。
+
+## 6. 分期与文件触点
+
+### Phase A — 三套独立尺寸键 + 跟随/解锁 UI + 列数封顶语义 + 高度上限放宽（全平台配置，无原生）
+
+- `hibiki/lib/src/models/preferences_repository.dart`：新增 6 个键的 getter/setter（overlay/extension 各 independent+maxW+maxH），默认值。参照现有 `popup_max_width/height`（:527-546）。
+- `hibiki/lib/src/models/app_model.dart`：
+  - 暴露新键（参照 `popupMaxWidth/H` 暴露处 :3895-3901）。
+  - `browserExtensionThemeColors()`（:2298, 写 `--hibiki-popup-max-*` 于 :2349-2352）改为读扩展有效键。
+- `hibiki/lib/src/lookup/global_lookup_controller.dart`：`cardW/cardH`（:512-513, :1068-1069, :210-211）改读 app 外有效键。
+- `hibiki/lib/src/settings/settings_schema_lookup.dart`：
+  - 现有 `popup_max_width`(:675-692) / `popup_max_height`(:693-707) 保留为 app 内；高度上限 800→1600。
+  - 新增「app 外覆盖窗」「浏览器扩展」两组：各一个 `独立尺寸` 开关 + 条件展开的宽/高滑杆。
+  - 列数项（:630 `popupDictionaryColumns`）文案改「最多列数（自动填充）」。
+- i18n：新增 key 一律走 `hibiki/tool/i18n_sync.dart --add`，改完 `dart run slang` + `dart format`（17 语言）。
+- 纯函数 `effectiveLookupSize` 抽到可测位置（如 lookup 下的 helper），Phase C/D 复用。
+
+**验证：** `flutter analyze` + `flutter test`；新增 `effectiveLookupSize` / 解锁语义单元测试。
+
+### Phase B — app 内弹窗拖拽 resize（全 5 平台，纯 Flutter）
+
+- `hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart`：
+  - `HibikiPopupSurface`（:482-487）叠角落拖拽把手 widget（`GestureDetector`/`Listener`）。
+  - 拖动改「有效宽高」，经缩放折算（宿主读的是 `popupMaxWidth * appUiScale`，见 `base_source_page.dart:457-458` / `dictionary_page_mixin.dart:125-126`）回写 `setPopupMaxWidth/Height`（`preferences_repository.dart:532-546`）。
+  - reader 与 video 共用 `resolvePopupRect`/`parkedPopupLayer`（:190-260），改一处即覆盖两家。
+- 交互：拖动时实时预览（可临时 state），松手落偏好；尊重屏幕/选区 clamp。
+
+**验证：** widget 测试断言拖动后 `popupMaxWidth/H` 真写穿偏好；`flutter analyze` + `flutter test`；Windows 离屏 + 真机焦点驱动复测。
+
+### Phase C — app 外覆盖窗拖拽（仅 Windows，原生）
+
+- `hibiki/windows/runner/global_lookup_window.cpp`：给瞬态覆盖窗补 resize chrome（当前 native 明确「瞬态窗不进模态循环、无 chrome」，:1434-1436）；复用 `beginWindowResize` → `WM_NCLBUTTONDOWN(HTBOTTOMRIGHT)` 通路（:1011-1022），`WM_EXITSIZEMOVE` 回报 rect（:1430-1445）。
+- `hibiki/assets/popup/global_lookup_host.js`：瞬态覆盖窗渲染 resize grip（当前 grip 仅 panel 模式，:375-391）。
+- Dart 侧 `global_lookup_controller.dart`：接收 native 回报的 rect → 拖即解锁（`overlayLookupIndependentSize=true`）+ 写 app 外键。
+
+**验证：** 本环境无法编译/运行 Windows 原生；**必须 Windows 真机复测并留证据**（本期交付标注「待真机」）。
+
+### Phase D — 扩展弹窗拖拽（DOM）+ 经 bridge 回写 app
+
+- `tools/browser-extension/content.js`（+ 镜像 `hibiki/assets/browser_extension/content.js`）：弹窗加拖拽手柄，拖动改 `hibikiHost` maxW/H（当前尺寸盒在 :1316-1323，placement 在 `hibikiComputePlacement` :1251-1282）。
+- 拖完经 bridge 回写 app 的扩展键（拖即解锁 `extensionPopupIndependentSize=true`）；app 下一次 theme 下发时以新值为准。
+- 三镜像 parity：改共享词典样式改 `assets/popup/popup.css` 后跑 `node tools/browser-extension/scripts/generate-content-css.mjs`；改扩展专属改 `content-css-overlay.css`。content.js 两份镜像字节相同。
+
+**验证：** `browser_extension_popup_parity_guard_test.dart` + `popup-placement.test.js`；扩展需浏览器手测。
+
+## 7. 测试与验收纪律
+
+- 纯函数（有效尺寸解析、拖拽折算/解锁）→ 单元测试。
+- 列数封顶 → popup.js 相关守卫。
+- 三镜像 parity → 现有 guard test。
+- app 内拖拽 → widget 测试写穿偏好。
+- 声明「修好」前：`dart format .` + `flutter analyze`（含 test）+ `flutter test`；阅读器/查词路径按项目要求 Windows 离屏 + 真机焦点驱动复测留证据。
+- Phase C（Windows 原生）、Phase D（扩展）交付标注「待真机/浏览器验收」。
+
+## 8. 显式风险 / 取舍
+
+- **app 外拖拽仅 Windows**：macOS/Linux 无覆盖窗，Android 是独立悬浮服务（`FloatingDictService`，不共享 Win32 机制），iOS 无 app 外查词。Android 悬浮窗 resize 若要做单开一期，不在本设计内。
+- 独立尺寸键新增须走 i18n_sync + slang 重生成，勿手改生成文件。
+- 拖拽写全局偏好 = 下次查词沿用新尺寸（预期行为，非 bug）。
+
+## 9. 一句话本质
+
+弹窗尺寸是一个「最大宽高」真值；滑杆和拖边角是它的两种编辑入口；三形态默认共享、可解锁独立；列数自动填充封顶。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39185 (2305 per locale)
+/// Strings: 39321 (2313 per locale)
 ///
-/// Built on 2026-07-13 at 05:32 UTC
+/// Built on 2026-07-13 at 08:31 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2409,9 +2409,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get remote_book_info_has_audiobook => 'Includes audiobook';
   String get remote_video_info => 'Info';
   String get remote_video_info_has_subtitle => 'Includes subtitles';
-  String get popup_dictionary_columns => 'Dictionaries per row';
-  String get popup_dictionary_columns_hint =>
-      'Show multiple dictionaries side by side; use fewer columns on narrow screens';
   String card_exported_audio_failed({required Object reason}) =>
       'Card exported, but the audio failed to download (${reason}).';
   String get card_mined_without_sentence_audio =>
@@ -3049,6 +3046,22 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_mining_image_mode_current_frame => 'Screenshot at mining';
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  String get extension_popup_max_width => 'Extension popup max width';
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -7116,11 +7129,6 @@ class _StringsAr extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => 'يتضمّن ترجمات';
   @override
-  String get popup_dictionary_columns => 'القواميس في كل صف';
-  @override
-  String get popup_dictionary_columns_hint =>
-      'عرض عدة قواميس جنبًا إلى جنب؛ استخدم أعمدة أقل على الشاشات الضيقة';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'تم تصدير البطاقة، لكن فشل تنزيل الصوت (${reason}).';
   @override
@@ -8263,6 +8271,32 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -12452,11 +12486,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => 'Enthält Untertitel';
   @override
-  String get popup_dictionary_columns => 'Wörterbücher pro Zeile';
-  @override
-  String get popup_dictionary_columns_hint =>
-      'Mehrere Wörterbücher nebeneinander anzeigen; auf schmalen Bildschirmen weniger Spalten verwenden';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'Karte exportiert, aber das Audio konnte nicht heruntergeladen werden (${reason}).';
   @override
@@ -13600,6 +13629,32 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -17806,11 +17861,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => 'Incluye subtítulos';
   @override
-  String get popup_dictionary_columns => 'Diccionarios por fila';
-  @override
-  String get popup_dictionary_columns_hint =>
-      'Muestra varios diccionarios en paralelo; usa menos columnas en pantallas estrechas';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'Tarjeta exportada, pero falló la descarga del audio (${reason}).';
   @override
@@ -18954,6 +19004,32 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -23179,11 +23255,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => 'Sous-titres inclus';
   @override
-  String get popup_dictionary_columns => 'Dictionnaires par ligne';
-  @override
-  String get popup_dictionary_columns_hint =>
-      'Afficher plusieurs dictionnaires côte à côte ; réduisez les colonnes sur écrans étroits';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'Carte exportée, mais le téléchargement de l\'audio a échoué (${reason}).';
   @override
@@ -24327,6 +24398,32 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -28454,11 +28551,6 @@ class _StringsId extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => 'Termasuk subtitle';
   @override
-  String get popup_dictionary_columns => 'Kamus per baris';
-  @override
-  String get popup_dictionary_columns_hint =>
-      'Tampilkan beberapa kamus berdampingan; gunakan lebih sedikit kolom pada layar sempit';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'Kartu diekspor, tetapi audio gagal diunduh (${reason}).';
   @override
@@ -29602,6 +29694,32 @@ class _StringsId extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -33790,11 +33908,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => 'Include sottotitoli';
   @override
-  String get popup_dictionary_columns => 'Dizionari per riga';
-  @override
-  String get popup_dictionary_columns_hint =>
-      'Mostra più dizionari affiancati; usa meno colonne su schermi stretti';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'Carta esportata, ma il download dell\'audio non è riuscito (${reason}).';
   @override
@@ -34938,6 +35051,32 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -38854,11 +38993,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => '字幕を含む';
   @override
-  String get popup_dictionary_columns => '1 行あたりの辞書数';
-  @override
-  String get popup_dictionary_columns_hint =>
-      '複数の辞書を横並びで表示します。画面が狭い場合は列数を減らしてください';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'カードを書き出しましたが、音声のダウンロードに失敗しました（${reason}）。';
   @override
@@ -39999,6 +40133,32 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -43919,11 +44079,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => '자막 포함';
   @override
-  String get popup_dictionary_columns => '한 줄당 사전 수';
-  @override
-  String get popup_dictionary_columns_hint =>
-      '여러 사전을 나란히 표시합니다. 화면이 좁으면 열 수를 줄이세요';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       '카드를 내보냈지만 오디오 다운로드에 실패했습니다(${reason}).';
   @override
@@ -45065,6 +45220,32 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -49221,11 +49402,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => 'Bevat ondertitels';
   @override
-  String get popup_dictionary_columns => 'Woordenboeken per rij';
-  @override
-  String get popup_dictionary_columns_hint =>
-      'Meerdere woordenboeken naast elkaar tonen; gebruik minder kolommen op smalle schermen';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'Kaart geëxporteerd, maar de audio kon niet worden gedownload (${reason}).';
   @override
@@ -50369,6 +50545,32 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -54548,11 +54750,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => 'Inclui legendas';
   @override
-  String get popup_dictionary_columns => 'Dicionários por linha';
-  @override
-  String get popup_dictionary_columns_hint =>
-      'Mostrar vários dicionários lado a lado; use menos colunas em telas estreitas';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'Cartão exportado, mas o download do áudio falhou (${reason}).';
   @override
@@ -55696,6 +55893,32 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -59850,11 +60073,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => 'Включает субтитры';
   @override
-  String get popup_dictionary_columns => 'Словарей в ряду';
-  @override
-  String get popup_dictionary_columns_hint =>
-      'Показывать несколько словарей рядом; на узких экранах используйте меньше столбцов';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'Карточка экспортирована, но не удалось загрузить аудио (${reason}).';
   @override
@@ -60998,6 +61216,32 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -65066,11 +65310,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => 'มีคำบรรยาย';
   @override
-  String get popup_dictionary_columns => 'จำนวนพจนานุกรมต่อแถว';
-  @override
-  String get popup_dictionary_columns_hint =>
-      'แสดงพจนานุกรมหลายเล่มเคียงข้างกัน ใช้คอลัมน์น้อยลงบนหน้าจอแคบ';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'ส่งออกการ์ดแล้ว แต่ดาวน์โหลดเสียงไม่สำเร็จ (${reason})';
   @override
@@ -66213,6 +66452,32 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -70335,11 +70600,6 @@ class _StringsTr extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => 'Altyazı içerir';
   @override
-  String get popup_dictionary_columns => 'Satır başına sözlük';
-  @override
-  String get popup_dictionary_columns_hint =>
-      'Birden çok sözlüğü yan yana göster; dar ekranlarda daha az sütun kullan';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'Kart aktarıldı ancak ses indirilemedi (${reason}).';
   @override
@@ -71483,6 +71743,32 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -75581,11 +75867,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => 'Bao gồm phụ đề';
   @override
-  String get popup_dictionary_columns => 'Số từ điển mỗi hàng';
-  @override
-  String get popup_dictionary_columns_hint =>
-      'Hiển thị nhiều từ điển cạnh nhau; dùng ít cột hơn trên màn hình hẹp';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       'Đã xuất thẻ, nhưng tải âm thanh thất bại (${reason}).';
   @override
@@ -76728,6 +77009,32 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -80545,10 +80852,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => '包含字幕';
   @override
-  String get popup_dictionary_columns => '每行词典数';
-  @override
-  String get popup_dictionary_columns_hint => '在一行内并排显示多个词典；窄屏建议少列';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       '卡片已导出，但音频下载失败（${reason}）。';
   @override
@@ -81616,6 +81919,28 @@ class _StringsZhCn extends _StringsEn {
   String get video_mining_image_mode_current_frame => '制卡时截图';
   @override
   String get video_mining_image_mode_subtitle_start => '字幕开头截图';
+  @override
+  String get popup_dictionary_max_columns => '词典最多列数（自动填充）';
+  @override
+  String get popup_dictionary_max_columns_hint => '每行自动填充词典，最多不超过此列数；窄屏会自动减少';
+  @override
+  String get overlay_lookup_independent_size => '弹出查词窗独立尺寸';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      '让 app 外弹出查词窗使用独立最大尺寸，而非跟随 app 内查词弹窗';
+  @override
+  String get overlay_lookup_max_width => '弹出查词窗最大宽度';
+  @override
+  String get overlay_lookup_max_height => '弹出查词窗最大高度';
+  @override
+  String get extension_popup_independent_size => '浏览器扩展独立尺寸';
+  @override
+  String get extension_popup_independent_size_hint =>
+      '让浏览器扩展查词弹窗使用独立最大尺寸，而非跟随 app 内查词弹窗';
+  @override
+  String get extension_popup_max_width => '扩展弹窗最大宽度';
+  @override
+  String get extension_popup_max_height => '扩展弹窗最大高度';
 }
 
 // Path: retrying_in
@@ -85436,10 +85761,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get remote_video_info_has_subtitle => '包含字幕';
   @override
-  String get popup_dictionary_columns => '每行詞典數';
-  @override
-  String get popup_dictionary_columns_hint => '在一行內並排顯示多個詞典；窄螢幕建議少列';
-  @override
   String card_exported_audio_failed({required Object reason}) =>
       '卡片已匯出，但音訊下載失敗（${reason}）。';
   @override
@@ -86579,6 +86900,32 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_mining_image_mode_subtitle_start =>
       'Screenshot at subtitle start';
+  @override
+  String get popup_dictionary_max_columns =>
+      'Max dictionary columns (auto-fill)';
+  @override
+  String get popup_dictionary_max_columns_hint =>
+      'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+  @override
+  String get overlay_lookup_independent_size =>
+      'Separate size for pop-out lookup';
+  @override
+  String get overlay_lookup_independent_size_hint =>
+      'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+  @override
+  String get overlay_lookup_max_width => 'Pop-out lookup max width';
+  @override
+  String get overlay_lookup_max_height => 'Pop-out lookup max height';
+  @override
+  String get extension_popup_independent_size =>
+      'Separate size for browser extension';
+  @override
+  String get extension_popup_independent_size_hint =>
+      'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+  @override
+  String get extension_popup_max_width => 'Extension popup max width';
+  @override
+  String get extension_popup_max_height => 'Extension popup max height';
 }
 
 // Path: retrying_in
@@ -90300,10 +90647,6 @@ extension on _StringsEn {
         return 'Info';
       case 'remote_video_info_has_subtitle':
         return 'Includes subtitles';
-      case 'popup_dictionary_columns':
-        return 'Dictionaries per row';
-      case 'popup_dictionary_columns_hint':
-        return 'Show multiple dictionaries side by side; use fewer columns on narrow screens';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'Card exported, but the audio failed to download (${reason}).';
@@ -91330,6 +91673,26 @@ extension on _StringsEn {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -95011,10 +95374,6 @@ extension on _StringsAr {
         return 'معلومات';
       case 'remote_video_info_has_subtitle':
         return 'يتضمّن ترجمات';
-      case 'popup_dictionary_columns':
-        return 'القواميس في كل صف';
-      case 'popup_dictionary_columns_hint':
-        return 'عرض عدة قواميس جنبًا إلى جنب؛ استخدم أعمدة أقل على الشاشات الضيقة';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'تم تصدير البطاقة، لكن فشل تنزيل الصوت (${reason}).';
@@ -96041,6 +96400,26 @@ extension on _StringsAr {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -99744,10 +100123,6 @@ extension on _StringsDe {
         return 'Info';
       case 'remote_video_info_has_subtitle':
         return 'Enthält Untertitel';
-      case 'popup_dictionary_columns':
-        return 'Wörterbücher pro Zeile';
-      case 'popup_dictionary_columns_hint':
-        return 'Mehrere Wörterbücher nebeneinander anzeigen; auf schmalen Bildschirmen weniger Spalten verwenden';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'Karte exportiert, aber das Audio konnte nicht heruntergeladen werden (${reason}).';
@@ -100774,6 +101149,26 @@ extension on _StringsDe {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -104475,10 +104870,6 @@ extension on _StringsEs {
         return 'Información';
       case 'remote_video_info_has_subtitle':
         return 'Incluye subtítulos';
-      case 'popup_dictionary_columns':
-        return 'Diccionarios por fila';
-      case 'popup_dictionary_columns_hint':
-        return 'Muestra varios diccionarios en paralelo; usa menos columnas en pantallas estrechas';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'Tarjeta exportada, pero falló la descarga del audio (${reason}).';
@@ -105505,6 +105896,26 @@ extension on _StringsEs {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -109213,10 +109624,6 @@ extension on _StringsFr {
         return 'Infos';
       case 'remote_video_info_has_subtitle':
         return 'Sous-titres inclus';
-      case 'popup_dictionary_columns':
-        return 'Dictionnaires par ligne';
-      case 'popup_dictionary_columns_hint':
-        return 'Afficher plusieurs dictionnaires côte à côte ; réduisez les colonnes sur écrans étroits';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'Carte exportée, mais le téléchargement de l\'audio a échoué (${reason}).';
@@ -110243,6 +110650,26 @@ extension on _StringsFr {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -113931,10 +114358,6 @@ extension on _StringsId {
         return 'Info';
       case 'remote_video_info_has_subtitle':
         return 'Termasuk subtitle';
-      case 'popup_dictionary_columns':
-        return 'Kamus per baris';
-      case 'popup_dictionary_columns_hint':
-        return 'Tampilkan beberapa kamus berdampingan; gunakan lebih sedikit kolom pada layar sempit';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'Kartu diekspor, tetapi audio gagal diunduh (${reason}).';
@@ -114961,6 +115384,26 @@ extension on _StringsId {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -118666,10 +119109,6 @@ extension on _StringsIt {
         return 'Info';
       case 'remote_video_info_has_subtitle':
         return 'Include sottotitoli';
-      case 'popup_dictionary_columns':
-        return 'Dizionari per riga';
-      case 'popup_dictionary_columns_hint':
-        return 'Mostra più dizionari affiancati; usa meno colonne su schermi stretti';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'Carta esportata, ma il download dell\'audio non è riuscito (${reason}).';
@@ -119696,6 +120135,26 @@ extension on _StringsIt {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -123359,10 +123818,6 @@ extension on _StringsJa {
         return '情報';
       case 'remote_video_info_has_subtitle':
         return '字幕を含む';
-      case 'popup_dictionary_columns':
-        return '1 行あたりの辞書数';
-      case 'popup_dictionary_columns_hint':
-        return '複数の辞書を横並びで表示します。画面が狭い場合は列数を減らしてください';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'カードを書き出しましたが、音声のダウンロードに失敗しました（${reason}）。';
@@ -124388,6 +124843,26 @@ extension on _StringsJa {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -128054,10 +128529,6 @@ extension on _StringsKo {
         return '정보';
       case 'remote_video_info_has_subtitle':
         return '자막 포함';
-      case 'popup_dictionary_columns':
-        return '한 줄당 사전 수';
-      case 'popup_dictionary_columns_hint':
-        return '여러 사전을 나란히 표시합니다. 화면이 좁으면 열 수를 줄이세요';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             '카드를 내보냈지만 오디오 다운로드에 실패했습니다(${reason}).';
@@ -129084,6 +129555,26 @@ extension on _StringsKo {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -132782,10 +133273,6 @@ extension on _StringsNl {
         return 'Info';
       case 'remote_video_info_has_subtitle':
         return 'Bevat ondertitels';
-      case 'popup_dictionary_columns':
-        return 'Woordenboeken per rij';
-      case 'popup_dictionary_columns_hint':
-        return 'Meerdere woordenboeken naast elkaar tonen; gebruik minder kolommen op smalle schermen';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'Kaart geëxporteerd, maar de audio kon niet worden gedownload (${reason}).';
@@ -133812,6 +134299,26 @@ extension on _StringsNl {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -137507,10 +138014,6 @@ extension on _StringsPtBr {
         return 'Informações';
       case 'remote_video_info_has_subtitle':
         return 'Inclui legendas';
-      case 'popup_dictionary_columns':
-        return 'Dicionários por linha';
-      case 'popup_dictionary_columns_hint':
-        return 'Mostrar vários dicionários lado a lado; use menos colunas em telas estreitas';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'Cartão exportado, mas o download do áudio falhou (${reason}).';
@@ -138537,6 +139040,26 @@ extension on _StringsPtBr {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -142236,10 +142759,6 @@ extension on _StringsRu {
         return 'Сведения';
       case 'remote_video_info_has_subtitle':
         return 'Включает субтитры';
-      case 'popup_dictionary_columns':
-        return 'Словарей в ряду';
-      case 'popup_dictionary_columns_hint':
-        return 'Показывать несколько словарей рядом; на узких экранах используйте меньше столбцов';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'Карточка экспортирована, но не удалось загрузить аудио (${reason}).';
@@ -143266,6 +143785,26 @@ extension on _StringsRu {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -146947,10 +147486,6 @@ extension on _StringsTh {
         return 'ข้อมูล';
       case 'remote_video_info_has_subtitle':
         return 'มีคำบรรยาย';
-      case 'popup_dictionary_columns':
-        return 'จำนวนพจนานุกรมต่อแถว';
-      case 'popup_dictionary_columns_hint':
-        return 'แสดงพจนานุกรมหลายเล่มเคียงข้างกัน ใช้คอลัมน์น้อยลงบนหน้าจอแคบ';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'ส่งออกการ์ดแล้ว แต่ดาวน์โหลดเสียงไม่สำเร็จ (${reason})';
@@ -147977,6 +148512,26 @@ extension on _StringsTh {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -151667,10 +152222,6 @@ extension on _StringsTr {
         return 'Bilgi';
       case 'remote_video_info_has_subtitle':
         return 'Altyazı içerir';
-      case 'popup_dictionary_columns':
-        return 'Satır başına sözlük';
-      case 'popup_dictionary_columns_hint':
-        return 'Birden çok sözlüğü yan yana göster; dar ekranlarda daha az sütun kullan';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'Kart aktarıldı ancak ses indirilemedi (${reason}).';
@@ -152697,6 +153248,26 @@ extension on _StringsTr {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -156381,10 +156952,6 @@ extension on _StringsVi {
         return 'Thông tin';
       case 'remote_video_info_has_subtitle':
         return 'Bao gồm phụ đề';
-      case 'popup_dictionary_columns':
-        return 'Số từ điển mỗi hàng';
-      case 'popup_dictionary_columns_hint':
-        return 'Hiển thị nhiều từ điển cạnh nhau; dùng ít cột hơn trên màn hình hẹp';
       case 'card_exported_audio_failed':
         return ({required Object reason}) =>
             'Đã xuất thẻ, nhưng tải âm thanh thất bại (${reason}).';
@@ -157411,6 +157978,26 @@ extension on _StringsVi {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }
@@ -161066,10 +161653,6 @@ extension on _StringsZhCn {
         return '信息';
       case 'remote_video_info_has_subtitle':
         return '包含字幕';
-      case 'popup_dictionary_columns':
-        return '每行词典数';
-      case 'popup_dictionary_columns_hint':
-        return '在一行内并排显示多个词典；窄屏建议少列';
       case 'card_exported_audio_failed':
         return ({required Object reason}) => '卡片已导出，但音频下载失败（${reason}）。';
       case 'card_mined_without_sentence_audio':
@@ -162090,6 +162673,26 @@ extension on _StringsZhCn {
         return '制卡时截图';
       case 'video_mining_image_mode_subtitle_start':
         return '字幕开头截图';
+      case 'popup_dictionary_max_columns':
+        return '词典最多列数（自动填充）';
+      case 'popup_dictionary_max_columns_hint':
+        return '每行自动填充词典，最多不超过此列数；窄屏会自动减少';
+      case 'overlay_lookup_independent_size':
+        return '弹出查词窗独立尺寸';
+      case 'overlay_lookup_independent_size_hint':
+        return '让 app 外弹出查词窗使用独立最大尺寸，而非跟随 app 内查词弹窗';
+      case 'overlay_lookup_max_width':
+        return '弹出查词窗最大宽度';
+      case 'overlay_lookup_max_height':
+        return '弹出查词窗最大高度';
+      case 'extension_popup_independent_size':
+        return '浏览器扩展独立尺寸';
+      case 'extension_popup_independent_size_hint':
+        return '让浏览器扩展查词弹窗使用独立最大尺寸，而非跟随 app 内查词弹窗';
+      case 'extension_popup_max_width':
+        return '扩展弹窗最大宽度';
+      case 'extension_popup_max_height':
+        return '扩展弹窗最大高度';
       default:
         return null;
     }
@@ -165746,10 +166349,6 @@ extension on _StringsZhHk {
         return '資訊';
       case 'remote_video_info_has_subtitle':
         return '包含字幕';
-      case 'popup_dictionary_columns':
-        return '每行詞典數';
-      case 'popup_dictionary_columns_hint':
-        return '在一行內並排顯示多個詞典；窄螢幕建議少列';
       case 'card_exported_audio_failed':
         return ({required Object reason}) => '卡片已匯出，但音訊下載失敗（${reason}）。';
       case 'card_mined_without_sentence_audio':
@@ -166774,6 +167373,26 @@ extension on _StringsZhHk {
         return 'Screenshot at mining';
       case 'video_mining_image_mode_subtitle_start':
         return 'Screenshot at subtitle start';
+      case 'popup_dictionary_max_columns':
+        return 'Max dictionary columns (auto-fill)';
+      case 'popup_dictionary_max_columns_hint':
+        return 'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
+      case 'overlay_lookup_independent_size':
+        return 'Separate size for pop-out lookup';
+      case 'overlay_lookup_independent_size_hint':
+        return 'Give the app-external pop-out lookup window its own max size instead of following the in-app popup';
+      case 'overlay_lookup_max_width':
+        return 'Pop-out lookup max width';
+      case 'overlay_lookup_max_height':
+        return 'Pop-out lookup max height';
+      case 'extension_popup_independent_size':
+        return 'Separate size for browser extension';
+      case 'extension_popup_independent_size_hint':
+        return 'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
+      case 'extension_popup_max_width':
+        return 'Extension popup max width';
+      case 'extension_popup_max_height':
+        return 'Extension popup max height';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "Includes audiobook",
   "remote_video_info": "Info",
   "remote_video_info_has_subtitle": "Includes subtitles",
-  "popup_dictionary_columns": "Dictionaries per row",
-  "popup_dictionary_columns_hint": "Show multiple dictionaries side by side; use fewer columns on narrow screens",
   "card_exported_audio_failed": "Card exported, but the audio failed to download ($reason).",
   "card_mined_without_sentence_audio": "Card created without sentence audio (none found for this selection).",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "يتضمّن كتابًا صوتيًا",
   "remote_video_info": "معلومات",
   "remote_video_info_has_subtitle": "يتضمّن ترجمات",
-  "popup_dictionary_columns": "القواميس في كل صف",
-  "popup_dictionary_columns_hint": "عرض عدة قواميس جنبًا إلى جنب؛ استخدم أعمدة أقل على الشاشات الضيقة",
   "card_exported_audio_failed": "تم تصدير البطاقة، لكن فشل تنزيل الصوت ($reason).",
   "card_mined_without_sentence_audio": "تم إنشاء البطاقة بدون صوت الجملة (لم يُعثر على صوت لهذا التحديد).",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "Enthält Hörbuch",
   "remote_video_info": "Info",
   "remote_video_info_has_subtitle": "Enthält Untertitel",
-  "popup_dictionary_columns": "Wörterbücher pro Zeile",
-  "popup_dictionary_columns_hint": "Mehrere Wörterbücher nebeneinander anzeigen; auf schmalen Bildschirmen weniger Spalten verwenden",
   "card_exported_audio_failed": "Karte exportiert, aber das Audio konnte nicht heruntergeladen werden ($reason).",
   "card_mined_without_sentence_audio": "Karte ohne Satz-Audio erstellt (keines für diese Auswahl gefunden).",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "Incluye audiolibro",
   "remote_video_info": "Información",
   "remote_video_info_has_subtitle": "Incluye subtítulos",
-  "popup_dictionary_columns": "Diccionarios por fila",
-  "popup_dictionary_columns_hint": "Muestra varios diccionarios en paralelo; usa menos columnas en pantallas estrechas",
   "card_exported_audio_failed": "Tarjeta exportada, pero falló la descarga del audio ($reason).",
   "card_mined_without_sentence_audio": "Tarjeta creada sin audio de frase (no se encontró para esta selección).",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "Livre audio inclus",
   "remote_video_info": "Infos",
   "remote_video_info_has_subtitle": "Sous-titres inclus",
-  "popup_dictionary_columns": "Dictionnaires par ligne",
-  "popup_dictionary_columns_hint": "Afficher plusieurs dictionnaires côte à côte ; réduisez les colonnes sur écrans étroits",
   "card_exported_audio_failed": "Carte exportée, mais le téléchargement de l'audio a échoué ($reason).",
   "card_mined_without_sentence_audio": "Carte créée sans audio de phrase (aucun trouvé pour cette sélection).",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "Termasuk buku audio",
   "remote_video_info": "Info",
   "remote_video_info_has_subtitle": "Termasuk subtitle",
-  "popup_dictionary_columns": "Kamus per baris",
-  "popup_dictionary_columns_hint": "Tampilkan beberapa kamus berdampingan; gunakan lebih sedikit kolom pada layar sempit",
   "card_exported_audio_failed": "Kartu diekspor, tetapi audio gagal diunduh ($reason).",
   "card_mined_without_sentence_audio": "Kartu dibuat tanpa audio kalimat (tidak ditemukan untuk pilihan ini).",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "Include audiolibro",
   "remote_video_info": "Info",
   "remote_video_info_has_subtitle": "Include sottotitoli",
-  "popup_dictionary_columns": "Dizionari per riga",
-  "popup_dictionary_columns_hint": "Mostra più dizionari affiancati; usa meno colonne su schermi stretti",
   "card_exported_audio_failed": "Carta esportata, ma il download dell'audio non è riuscito ($reason).",
   "card_mined_without_sentence_audio": "Carta creata senza audio della frase (nessuno trovato per questa selezione).",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "オーディオブックを含む",
   "remote_video_info": "情報",
   "remote_video_info_has_subtitle": "字幕を含む",
-  "popup_dictionary_columns": "1 行あたりの辞書数",
-  "popup_dictionary_columns_hint": "複数の辞書を横並びで表示します。画面が狭い場合は列数を減らしてください",
   "card_exported_audio_failed": "カードを書き出しましたが、音声のダウンロードに失敗しました（$reason）。",
   "card_mined_without_sentence_audio": "カードを作成しましたが、今回の選択範囲では例文の音声が見つかりませんでした。",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "오디오북 포함",
   "remote_video_info": "정보",
   "remote_video_info_has_subtitle": "자막 포함",
-  "popup_dictionary_columns": "한 줄당 사전 수",
-  "popup_dictionary_columns_hint": "여러 사전을 나란히 표시합니다. 화면이 좁으면 열 수를 줄이세요",
   "card_exported_audio_failed": "카드를 내보냈지만 오디오 다운로드에 실패했습니다($reason).",
   "card_mined_without_sentence_audio": "카드를 만들었지만 이번 선택 범위에서 문장 오디오를 찾지 못했습니다.",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "Bevat luisterboek",
   "remote_video_info": "Info",
   "remote_video_info_has_subtitle": "Bevat ondertitels",
-  "popup_dictionary_columns": "Woordenboeken per rij",
-  "popup_dictionary_columns_hint": "Meerdere woordenboeken naast elkaar tonen; gebruik minder kolommen op smalle schermen",
   "card_exported_audio_failed": "Kaart geëxporteerd, maar de audio kon niet worden gedownload ($reason).",
   "card_mined_without_sentence_audio": "Kaart aangemaakt zonder zinsaudio (geen gevonden voor deze selectie).",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "Inclui audiolivro",
   "remote_video_info": "Informações",
   "remote_video_info_has_subtitle": "Inclui legendas",
-  "popup_dictionary_columns": "Dicionários por linha",
-  "popup_dictionary_columns_hint": "Mostrar vários dicionários lado a lado; use menos colunas em telas estreitas",
   "card_exported_audio_failed": "Cartão exportado, mas o download do áudio falhou ($reason).",
   "card_mined_without_sentence_audio": "Cartão criado sem áudio da frase (nenhum encontrado para esta seleção).",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "Включает аудиокнигу",
   "remote_video_info": "Сведения",
   "remote_video_info_has_subtitle": "Включает субтитры",
-  "popup_dictionary_columns": "Словарей в ряду",
-  "popup_dictionary_columns_hint": "Показывать несколько словарей рядом; на узких экранах используйте меньше столбцов",
   "card_exported_audio_failed": "Карточка экспортирована, но не удалось загрузить аудио ($reason).",
   "card_mined_without_sentence_audio": "Карточка создана без аудио предложения (для этого выделения ничего не найдено).",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "มีหนังสือเสียง",
   "remote_video_info": "ข้อมูล",
   "remote_video_info_has_subtitle": "มีคำบรรยาย",
-  "popup_dictionary_columns": "จำนวนพจนานุกรมต่อแถว",
-  "popup_dictionary_columns_hint": "แสดงพจนานุกรมหลายเล่มเคียงข้างกัน ใช้คอลัมน์น้อยลงบนหน้าจอแคบ",
   "card_exported_audio_failed": "ส่งออกการ์ดแล้ว แต่ดาวน์โหลดเสียงไม่สำเร็จ ($reason)",
   "card_mined_without_sentence_audio": "สร้างการ์ดโดยไม่มีเสียงประโยค (ไม่พบเสียงสำหรับส่วนที่เลือกนี้)",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "Sesli kitap içerir",
   "remote_video_info": "Bilgi",
   "remote_video_info_has_subtitle": "Altyazı içerir",
-  "popup_dictionary_columns": "Satır başına sözlük",
-  "popup_dictionary_columns_hint": "Birden çok sözlüğü yan yana göster; dar ekranlarda daha az sütun kullan",
   "card_exported_audio_failed": "Kart aktarıldı ancak ses indirilemedi ($reason).",
   "card_mined_without_sentence_audio": "Kart cümle sesi olmadan oluşturuldu (bu seçim için bulunamadı).",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "Bao gồm sách nói",
   "remote_video_info": "Thông tin",
   "remote_video_info_has_subtitle": "Bao gồm phụ đề",
-  "popup_dictionary_columns": "Số từ điển mỗi hàng",
-  "popup_dictionary_columns_hint": "Hiển thị nhiều từ điển cạnh nhau; dùng ít cột hơn trên màn hình hẹp",
   "card_exported_audio_failed": "Đã xuất thẻ, nhưng tải âm thanh thất bại ($reason).",
   "card_mined_without_sentence_audio": "Đã tạo thẻ nhưng không có âm thanh câu (không tìm thấy cho vùng chọn này).",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "包含有声书",
   "remote_video_info": "信息",
   "remote_video_info_has_subtitle": "包含字幕",
-  "popup_dictionary_columns": "每行词典数",
-  "popup_dictionary_columns_hint": "在一行内并排显示多个词典；窄屏建议少列",
   "card_exported_audio_failed": "卡片已导出，但音频下载失败（$reason）。",
   "card_mined_without_sentence_audio": "已制卡，但本次选区找不到句子音频。",
   "card_cover_degraded_to_static": "卡片封面已降级为静态帧（动图不可用）：$reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "视频制卡封面用动图还是截图",
   "video_mining_image_mode_gif": "动图 GIF（字幕片段）",
   "video_mining_image_mode_current_frame": "制卡时截图",
-  "video_mining_image_mode_subtitle_start": "字幕开头截图"
+  "video_mining_image_mode_subtitle_start": "字幕开头截图",
+  "popup_dictionary_max_columns": "词典最多列数（自动填充）",
+  "popup_dictionary_max_columns_hint": "每行自动填充词典，最多不超过此列数；窄屏会自动减少",
+  "overlay_lookup_independent_size": "弹出查词窗独立尺寸",
+  "overlay_lookup_independent_size_hint": "让 app 外弹出查词窗使用独立最大尺寸，而非跟随 app 内查词弹窗",
+  "overlay_lookup_max_width": "弹出查词窗最大宽度",
+  "overlay_lookup_max_height": "弹出查词窗最大高度",
+  "extension_popup_independent_size": "浏览器扩展独立尺寸",
+  "extension_popup_independent_size_hint": "让浏览器扩展查词弹窗使用独立最大尺寸，而非跟随 app 内查词弹窗",
+  "extension_popup_max_width": "扩展弹窗最大宽度",
+  "extension_popup_max_height": "扩展弹窗最大高度"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1804,8 +1804,6 @@
   "remote_book_info_has_audiobook": "包含有聲書",
   "remote_video_info": "資訊",
   "remote_video_info_has_subtitle": "包含字幕",
-  "popup_dictionary_columns": "每行詞典數",
-  "popup_dictionary_columns_hint": "在一行內並排顯示多個詞典；窄螢幕建議少列",
   "card_exported_audio_failed": "卡片已匯出，但音訊下載失敗（$reason）。",
   "card_mined_without_sentence_audio": "已製卡，但今次選取範圍找不到例句音訊。",
   "card_cover_degraded_to_static": "Card cover fell back to a still frame (animated clip unavailable): $reason",
@@ -2311,5 +2309,15 @@
   "video_mining_image_mode_hint": "How covers on video cards are captured",
   "video_mining_image_mode_gif": "Animated GIF (subtitle clip)",
   "video_mining_image_mode_current_frame": "Screenshot at mining",
-  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start"
+  "video_mining_image_mode_subtitle_start": "Screenshot at subtitle start",
+  "popup_dictionary_max_columns": "Max dictionary columns (auto-fill)",
+  "popup_dictionary_max_columns_hint": "Auto-fills up to this many dictionary columns per row; narrower screens use fewer",
+  "overlay_lookup_independent_size": "Separate size for pop-out lookup",
+  "overlay_lookup_independent_size_hint": "Give the app-external pop-out lookup window its own max size instead of following the in-app popup",
+  "overlay_lookup_max_width": "Pop-out lookup max width",
+  "overlay_lookup_max_height": "Pop-out lookup max height",
+  "extension_popup_independent_size": "Separate size for browser extension",
+  "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
+  "extension_popup_max_width": "Extension popup max width",
+  "extension_popup_max_height": "Extension popup max height"
 }

--- a/hibiki/lib/src/lookup/effective_lookup_size.dart
+++ b/hibiki/lib/src/lookup/effective_lookup_size.dart
@@ -1,0 +1,46 @@
+/// 查词弹窗「最大宽高」的有效尺寸解析（纯函数，单元可测）。
+///
+/// 弹窗尺寸只有一个真值——「最大宽高」。三种形态（app 内 / app 外覆盖窗 /
+/// 浏览器扩展）默认共享 app 内的 [popupMaxWidth]/[popupMaxHeight]；某个形态被
+/// 用户显式「解锁独立尺寸」后，改用该形态自己的宽/高键。这里把这条决策抽成不依赖
+/// 任何 Flutter/FFI 的纯函数，供 controller、app_model、Phase C/D 复用与单测。
+library;
+
+/// 一对「最大宽 × 最大高」逻辑像素值。
+class LookupSize {
+  const LookupSize(this.width, this.height);
+
+  final double width;
+  final double height;
+
+  @override
+  bool operator ==(Object other) =>
+      other is LookupSize && other.width == width && other.height == height;
+
+  @override
+  int get hashCode => Object.hash(width, height);
+
+  @override
+  String toString() => 'LookupSize(${width}x$height)';
+}
+
+/// 解析某个查词形态（app 外覆盖窗 / 浏览器扩展）的有效最大宽高。
+///
+/// - [independent] 为 `true`：该形态已解锁独立尺寸，用它自己的
+///   [sceneWidth]/[sceneHeight]。
+/// - [independent] 为 `false`：跟随 app 内共享值 [sharedWidth]/[sharedHeight]。
+///
+/// app 内弹窗本身无「跟随/独立」之分，恒等于共享值，直接读 [popupMaxWidth] 即可，
+/// 不必经此函数。
+LookupSize effectiveLookupSize({
+  required bool independent,
+  required double sceneWidth,
+  required double sceneHeight,
+  required double sharedWidth,
+  required double sharedHeight,
+}) {
+  if (independent) {
+    return LookupSize(sceneWidth, sceneHeight);
+  }
+  return LookupSize(sharedWidth, sharedHeight);
+}

--- a/hibiki/lib/src/lookup/effective_lookup_size.dart
+++ b/hibiki/lib/src/lookup/effective_lookup_size.dart
@@ -44,3 +44,38 @@ LookupSize effectiveLookupSize({
   }
   return LookupSize(sharedWidth, sharedHeight);
 }
+
+/// 查词弹窗「最大宽/高」的允许范围（基准逻辑像素）。与设置页两滑杆的 min/max
+/// 单一同源——拖拽角落把手与滑杆写同一真值，故 clamp 边界必须一致，否则拖拽能写出
+/// 滑杆写不出的越界值。
+const double kLookupPopupMinWidth = 250;
+const double kLookupPopupMaxWidth = 2000;
+const double kLookupPopupMinHeight = 200;
+const double kLookupPopupMaxHeight = 1600;
+
+/// 拖拽弹窗右下角把手时，把「当前基准尺寸 + 本次累计位移」折算成新的基准（未缩放）
+/// 最大宽高并 clamp 到 [kLookupPopupMinWidth]..[kLookupPopupMaxHeight] 范围。
+///
+/// 宿主渲染的弹窗盒宽 = `基准宽 × uiScale`（界面缩放，见 base_source_page /
+/// dictionary_page_mixin 的盒尺寸 getter）。把手的拖动位移 [deltaWidthPx] /
+/// [deltaHeightPx] 落在**已缩放**的盒坐标系里，故折算回基准要除以 [uiScale]：
+/// `新基准 = 当前基准 + delta / uiScale`。[uiScale] 非正时按 1 兜底（不除零 /
+/// 不反向缩放）。纯函数，方向 + clamp 单元可测，reader / video 两宿主共用。
+LookupSize resolveDraggedLookupSize({
+  required double currentBaseWidth,
+  required double currentBaseHeight,
+  required double deltaWidthPx,
+  required double deltaHeightPx,
+  required double uiScale,
+  double minWidth = kLookupPopupMinWidth,
+  double maxWidth = kLookupPopupMaxWidth,
+  double minHeight = kLookupPopupMinHeight,
+  double maxHeight = kLookupPopupMaxHeight,
+}) {
+  final double scale = uiScale > 0 ? uiScale : 1.0;
+  final double width =
+      (currentBaseWidth + deltaWidthPx / scale).clamp(minWidth, maxWidth);
+  final double height =
+      (currentBaseHeight + deltaHeightPx / scale).clamp(minHeight, maxHeight);
+  return LookupSize(width, height);
+}

--- a/hibiki/lib/src/lookup/global_lookup_controller.dart
+++ b/hibiki/lib/src/lookup/global_lookup_controller.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' hide ModifierKey;
+import 'package:hibiki/src/lookup/effective_lookup_size.dart';
 import 'package:hibiki/src/lookup/global_lookup_channel.dart';
 import 'package:hibiki/src/lookup/global_lookup_layout.dart';
 import 'package:hibiki/src/lookup/global_lookup_log.dart';
@@ -207,8 +208,10 @@ class GlobalLookupController {
   Future<void> _prewarmOverlay(AppModel model) async {
     try {
       final double dpr = _devicePixelRatio();
-      final int w = (model.popupMaxWidth * model.appUiScale * dpr).round();
-      final int h = (model.popupMaxHeight * model.appUiScale * dpr).round();
+      // 弹窗尺寸精细化：app 外覆盖窗默认跟随 app 内，解锁后用 overlay 自己的键。
+      final LookupSize overlaySize = model.overlayLookupEffectiveSize;
+      final int w = (overlaySize.width * model.appUiScale * dpr).round();
+      final int h = (overlaySize.height * model.appUiScale * dpr).round();
       await GlobalLookupChannel.prewarmWebView(width: w, height: h);
       glog('start: overlay prewarm requested w=$w h=$h');
     } catch (e) {
@@ -509,8 +512,9 @@ class GlobalLookupController {
       // the window-local origin clamped into the work area (TODO-1231
       // computeRootShellOffset), so a single-frame lookup still reveals exactly
       // at the card size after the bbox trims the bounds — no regression.
-      final double cardW = model.popupMaxWidth * model.appUiScale;
-      final double cardH = model.popupMaxHeight * model.appUiScale;
+      final LookupSize overlaySize = model.overlayLookupEffectiveSize;
+      final double cardW = overlaySize.width * model.appUiScale;
+      final double cardH = overlaySize.height * model.appUiScale;
       _layoutBoundsW = cardW * kGlobalLookupLayoutBoundsWidthFactor;
       _layoutBoundsH = cardH * kGlobalLookupLayoutBoundsHeightFactor;
       final int w0 = (_layoutBoundsW * dpr).round();
@@ -1065,8 +1069,9 @@ class GlobalLookupController {
     }
     // maxWidth/maxHeight are the single card size; children cascade and D2 bbox
     // trims the window down to the real extent.
-    final double cardW = model.popupMaxWidth * model.appUiScale;
-    final double cardH = model.popupMaxHeight * model.appUiScale;
+    final LookupSize overlaySize = model.overlayLookupEffectiveSize;
+    final double cardW = overlaySize.width * model.appUiScale;
+    final double cardH = overlaySize.height * model.appUiScale;
     // TODO-893 — screenWidth/screenHeight MUST be the real monitor work area
     // (CSS px), NOT the off-screen measurement canvas (_layoutBounds*). The
     // canvas is only ~2x the card, so computeFrameRect's showBelow (spaceBelow
@@ -1207,8 +1212,9 @@ class GlobalLookupController {
   /// scrollHeight, exactly as before D2. Kept as a fallback so a frame that
   /// somehow reports the scalar form still sizes correctly.
   void _applyOverlayScalar(AppModel model, double dpr, double physH) {
-    final int width = (model.popupMaxWidth * model.appUiScale * dpr).round();
-    final double maxHeight = model.popupMaxHeight * model.appUiScale * dpr;
+    final LookupSize overlaySize = model.overlayLookupEffectiveSize;
+    final int width = (overlaySize.width * model.appUiScale * dpr).round();
+    final double maxHeight = overlaySize.height * model.appUiScale * dpr;
     final int height = (physH > maxHeight ? maxHeight : physH).round();
     if (!_revealed) {
       _revealed = true;

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -37,6 +37,7 @@ import 'package:hibiki/src/models/builtin_tags.dart';
 import 'package:hibiki/src/epub/epub_importer.dart';
 import 'package:hibiki/src/reader/reader_settings.dart';
 import 'package:hibiki/src/lookup/browser_extension_installer.dart';
+import 'package:hibiki/src/lookup/effective_lookup_size.dart';
 import 'package:hibiki/src/models/dictionary_repository.dart';
 import 'package:hibiki/src/models/media_history_repository.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
@@ -2346,8 +2347,12 @@ class AppModel with ChangeNotifier {
       // BUG-736：卡片圆角。漏发时 popup.css 回落到硬编码 10px，与 app 内用户设定的圆角
       // （HibikiRadii.cardValue）不一致。与两个 in-app 注入器逐字节同源。
       '--hibiki-radius-card': '${HibikiRadii.cardValue.toInt()}px',
-      '--hibiki-popup-max-width': '${popupMaxWidth.round()}px',
-      '--hibiki-popup-max-height': '${popupMaxHeight.round()}px',
+      // 弹窗尺寸精细化：扩展弹窗默认跟随 app 内 popupMaxWidth/Height，用户显式
+      // 解锁「浏览器扩展独立尺寸」后改用扩展自己的键（extensionPopupEffectiveSize）。
+      '--hibiki-popup-max-width':
+          '${extensionPopupEffectiveSize.width.round()}px',
+      '--hibiki-popup-max-height':
+          '${extensionPopupEffectiveSize.height.round()}px',
       '--hibiki-popup-zoom': zoom.toStringAsFixed(4),
       '--dict-columns': '$popupDictionaryColumns',
       // 「滑动关闭查词弹窗」偏好（enableSwipeToClose）下发给扩展 content.js：非 CSS 变量、
@@ -3899,6 +3904,49 @@ class AppModel with ChangeNotifier {
   double get defaultPopupMaxHeight => prefsRepo.defaultPopupMaxHeight;
   double get popupMaxHeight => prefsRepo.popupMaxHeight;
   void setPopupMaxHeight(double height) => prefsRepo.setPopupMaxHeight(height);
+
+  // 查词弹窗尺寸精细化（2026-07-13）：app 外覆盖窗 / 浏览器扩展的独立尺寸键。
+  bool get overlayLookupIndependentSize =>
+      prefsRepo.overlayLookupIndependentSize;
+  Future<void> setOverlayLookupIndependentSize(bool value) =>
+      prefsRepo.setOverlayLookupIndependentSize(value);
+  double get overlayLookupMaxWidth => prefsRepo.overlayLookupMaxWidth;
+  void setOverlayLookupMaxWidth(double width) =>
+      prefsRepo.setOverlayLookupMaxWidth(width);
+  double get overlayLookupMaxHeight => prefsRepo.overlayLookupMaxHeight;
+  void setOverlayLookupMaxHeight(double height) =>
+      prefsRepo.setOverlayLookupMaxHeight(height);
+
+  bool get extensionPopupIndependentSize =>
+      prefsRepo.extensionPopupIndependentSize;
+  Future<void> setExtensionPopupIndependentSize(bool value) =>
+      prefsRepo.setExtensionPopupIndependentSize(value);
+  double get extensionPopupMaxWidth => prefsRepo.extensionPopupMaxWidth;
+  void setExtensionPopupMaxWidth(double width) =>
+      prefsRepo.setExtensionPopupMaxWidth(width);
+  double get extensionPopupMaxHeight => prefsRepo.extensionPopupMaxHeight;
+  void setExtensionPopupMaxHeight(double height) =>
+      prefsRepo.setExtensionPopupMaxHeight(height);
+
+  /// app 外覆盖查词卡的「有效最大宽高」（跟随 app 内 / 解锁后独立）。
+  /// controller 的窗口尺寸测算读它，而不是直接读 [popupMaxWidth]/[popupMaxHeight]。
+  LookupSize get overlayLookupEffectiveSize => effectiveLookupSize(
+        independent: overlayLookupIndependentSize,
+        sceneWidth: overlayLookupMaxWidth,
+        sceneHeight: overlayLookupMaxHeight,
+        sharedWidth: popupMaxWidth,
+        sharedHeight: popupMaxHeight,
+      );
+
+  /// 浏览器扩展弹窗的「有效最大宽高」（跟随 app 内 / 解锁后独立）。
+  /// [browserExtensionThemeColors] 下发的 `--hibiki-popup-max-*` 读它。
+  LookupSize get extensionPopupEffectiveSize => effectiveLookupSize(
+        independent: extensionPopupIndependentSize,
+        sceneWidth: extensionPopupMaxWidth,
+        sceneHeight: extensionPopupMaxHeight,
+        sharedWidth: popupMaxWidth,
+        sharedHeight: popupMaxHeight,
+      );
 
   bool get popupInstantScroll => prefsRepo.popupInstantScroll;
   Future<void> setPopupInstantScroll(bool value) =>

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -547,6 +547,62 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  // 查词弹窗尺寸精细化（2026-07-13 设计）：app 外覆盖窗 / 浏览器扩展各自可「独立尺寸」。
+  // 默认 independent=false → 跟随 app 内 popupMaxWidth/Height；用户显式解锁后用各自键。
+  // 各自宽/高默认值等于 app 内默认（400×360），保证解锁瞬间不跳尺寸。
+
+  bool get overlayLookupIndependentSize =>
+      getPref('overlay_lookup_independent_size', defaultValue: false) as bool;
+
+  Future<void> setOverlayLookupIndependentSize(bool value) async {
+    await setPref('overlay_lookup_independent_size', value);
+    notifyListeners();
+  }
+
+  double get overlayLookupMaxWidth =>
+      getPref('overlay_lookup_max_width', defaultValue: defaultPopupMaxWidth)
+          as double;
+
+  void setOverlayLookupMaxWidth(double width) async {
+    await setPref('overlay_lookup_max_width', width);
+    notifyListeners();
+  }
+
+  double get overlayLookupMaxHeight =>
+      getPref('overlay_lookup_max_height', defaultValue: defaultPopupMaxHeight)
+          as double;
+
+  void setOverlayLookupMaxHeight(double height) async {
+    await setPref('overlay_lookup_max_height', height);
+    notifyListeners();
+  }
+
+  bool get extensionPopupIndependentSize =>
+      getPref('extension_popup_independent_size', defaultValue: false) as bool;
+
+  Future<void> setExtensionPopupIndependentSize(bool value) async {
+    await setPref('extension_popup_independent_size', value);
+    notifyListeners();
+  }
+
+  double get extensionPopupMaxWidth =>
+      getPref('extension_popup_max_width', defaultValue: defaultPopupMaxWidth)
+          as double;
+
+  void setExtensionPopupMaxWidth(double width) async {
+    await setPref('extension_popup_max_width', width);
+    notifyListeners();
+  }
+
+  double get extensionPopupMaxHeight =>
+      getPref('extension_popup_max_height', defaultValue: defaultPopupMaxHeight)
+          as double;
+
+  void setExtensionPopupMaxHeight(double height) async {
+    await setPref('extension_popup_max_height', height);
+    notifyListeners();
+  }
+
   // TODO-776: number of dictionary blocks rendered per row inside one entry's
   // glossary section (experimental). Default 1 = the classic single vertical
   // column; clamped to 1..4 both on read and write so a corrupt/out-of-range

--- a/hibiki/lib/src/pages/base_source_page.dart
+++ b/hibiki/lib/src/pages/base_source_page.dart
@@ -514,6 +514,12 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
     }
   }
 
+  /// 拖拽被竞技场中途取消：丢弃预览态回到「读真值」，不落偏好。
+  void _onPopupResizeCancel() {
+    if (_popupResizePreview == null) return;
+    setState(() => _popupResizePreview = null);
+  }
+
   Widget buildDictionary() {
     return Theme(
       data: appModel.overrideDictionaryTheme ?? theme,
@@ -667,6 +673,7 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
         onResizeStart: _onPopupResizeStart,
         onResizeUpdate: _onPopupResizeUpdate,
         onResizeEnd: _onPopupResizeEnd,
+        onResizeCancel: _onPopupResizeCancel,
         // TODO-834：点**某层弹窗本体的空白区**（非内容区）只关该层衍生的后代层，
         // 保留本层 + 祖先（不关母代）。点顶层（无后代）= no-op 栈不变。
         onTapOutside: () => dismissDescendantsOf(index),

--- a/hibiki/lib/src/pages/base_source_page.dart
+++ b/hibiki/lib/src/pages/base_source_page.dart
@@ -7,6 +7,7 @@ import 'package:hibiki/media.dart';
 import 'package:hibiki/pages.dart';
 import 'package:hibiki/src/anki/anki_view_model.dart';
 import 'package:hibiki/src/anki/anki_mined_card_action_sheet.dart';
+import 'package:hibiki/src/lookup/effective_lookup_size.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_controller.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_layer.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_webview.dart';
@@ -455,8 +456,15 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
   // 弹窗盒子尺寸随「界面大小」一起放大：阅读器/词典页整树被 HibikiAppUiScaleNeutralizer
   // 中和回原生密度（净缩放=1），弹窗盒子若不乘 appUiScale，界面 200% 时它仍是原生小尺寸
   // （内容放大走 WebView 内 CSS zoom，见 DictionaryPopupWebView）。
-  double get popupMaxWidth => appModel.popupMaxWidth * appModel.appUiScale;
-  double get popupMaxHeight => appModel.popupMaxHeight * appModel.appUiScale;
+  //
+  // Phase B（尺寸拖拽）：拖动把手期间用预览态 [_popupResizePreview]（基准逻辑像素）临时
+  // 覆盖偏好真值，让盒子实时跟手放大/缩小；松手 [_onPopupResizeEnd] 才落偏好并清预览。
+  double get popupMaxWidth =>
+      (_popupResizePreview?.width ?? appModel.popupMaxWidth) *
+      appModel.appUiScale;
+  double get popupMaxHeight =>
+      (_popupResizePreview?.height ?? appModel.popupMaxHeight) *
+      appModel.appUiScale;
   double get popupPadding => 6;
   double get popupBottomReserve => 0;
   double get popupTopReserve => 0;
@@ -466,6 +474,45 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
   bool get popupVerticalWriting => false;
   late final Listenable _popupListenable =
       Listenable.merge([_popup, _isSearchingNotifier]);
+
+  /// Phase B 尺寸拖拽的预览态（基准逻辑像素，未缩放）。非空 = 正在拖把手，[popupMaxWidth]
+  /// / [popupMaxHeight] 用它临时覆盖偏好实时预览；null = 未拖，用已落库真值。松手清空。
+  LookupSize? _popupResizePreview;
+
+  /// 拖把手起手：把当前偏好基准尺寸存入预览态（后续增量累积其上）。
+  void _onPopupResizeStart() {
+    setState(() {
+      _popupResizePreview =
+          LookupSize(appModel.popupMaxWidth, appModel.popupMaxHeight);
+    });
+  }
+
+  /// 拖把手进行：把盒坐标系增量位移 [deltaPx] 经 [resolveDraggedLookupSize] 折算回基准
+  /// （除 appUiScale）并 clamp，实时驱动重建。
+  void _onPopupResizeUpdate(Offset deltaPx) {
+    final LookupSize base = _popupResizePreview ??
+        LookupSize(appModel.popupMaxWidth, appModel.popupMaxHeight);
+    setState(() {
+      _popupResizePreview = resolveDraggedLookupSize(
+        currentBaseWidth: base.width,
+        currentBaseHeight: base.height,
+        deltaWidthPx: deltaPx.dx,
+        deltaHeightPx: deltaPx.dy,
+        uiScale: appModel.appUiScale,
+      );
+    });
+  }
+
+  /// 松手：把预览尺寸一次性落偏好（`setPopupMaxWidth/Height` 单一真值，与设置滑杆同源），
+  /// 清空预览态回到「读真值」。
+  void _onPopupResizeEnd() {
+    final LookupSize? committed = _popupResizePreview;
+    setState(() => _popupResizePreview = null);
+    if (committed != null) {
+      appModel.setPopupMaxWidth(committed.width);
+      appModel.setPopupMaxHeight(committed.height);
+    }
+  }
 
   Widget buildDictionary() {
     return Theme(
@@ -614,6 +661,12 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
         onClose: () => _dismissPopupAt(index),
         // TODO-485：嵌套层即便禁用滑动关闭，也有显式返回父层入口。
         onBack: null,
+        // Phase B：app 内弹窗右下角尺寸拖拽把手（全 5 平台）。拖动 = 可视化改「最大宽高」
+        // 偏好（与设置滑杆同一真值）。任意层都能拖（都编辑共享真值），预览态在宿主级。
+        showResizeGrip: true,
+        onResizeStart: _onPopupResizeStart,
+        onResizeUpdate: _onPopupResizeUpdate,
+        onResizeEnd: _onPopupResizeEnd,
         // TODO-834：点**某层弹窗本体的空白区**（非内容区）只关该层衍生的后代层，
         // 保留本层 + 祖先（不关母代）。点顶层（无后代）= no-op 栈不变。
         onTapOutside: () => dismissDescendantsOf(index),

--- a/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -196,6 +196,12 @@ mixin DictionaryPageMixin {
     }
   }
 
+  /// 拖拽被竞技场中途取消：丢弃预览态回到「读真值」，不落偏好。
+  void _onMixinPopupResizeCancel() {
+    if (_popupResizePreview == null) return;
+    setState(() => _popupResizePreview = null);
+  }
+
   /// Mines the current dictionary entry to Anki.
   ///
   /// Shows a Fluttertoast for each outcome and returns `true` on success.
@@ -527,6 +533,7 @@ mixin DictionaryPageMixin {
         onResizeStart: _onMixinPopupResizeStart,
         onResizeUpdate: _onMixinPopupResizeUpdate,
         onResizeEnd: _onMixinPopupResizeEnd,
+        onResizeCancel: _onMixinPopupResizeCancel,
         // TODO-834：点**本层弹窗本体的空白区**只关该层衍生的后代层（index 更大的全部），
         // 保留本层 + 祖先。线性扁平栈里 index 即 depth，故后代 = `index+1..end`，用
         // [DictionaryPopupController.truncateTo] 精确裁。点本层无后代 = no-op 栈不变。

--- a/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -8,6 +8,7 @@ import 'package:hibiki/models.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 import 'package:hibiki/src/anki/anki_view_model.dart';
 import 'package:hibiki/src/anki/anki_mined_card_action_sheet.dart';
+import 'package:hibiki/src/lookup/effective_lookup_size.dart';
 import 'package:hibiki/src/pages/base_source_page.dart'
     show lookupHighlightCharCount;
 import 'package:hibiki/src/pages/implementations/dictionary_popup_controller.dart';
@@ -142,14 +143,57 @@ mixin DictionaryPageMixin {
   Rect _calcMixinPopupPosition(Rect selectionRect, Size screen) {
     // 与 base_source_page._calculatePopupPosition 共用 [resolvePopupRect]。mixin
     // 家族（video/首页/texthooker）不预留 reserve、不竖排避让（全用默认），盒子尺寸
-    // 随界面大小放大（同 base 的 popupMaxWidth/Height）。
+    // 随界面大小放大（同 base 的 popupMaxWidth/Height）。Phase B 拖把手时用预览态
+    // [_popupResizePreview] 临时覆盖偏好实时预览（松手落库，见 [_onMixinPopupResizeEnd]）。
     return resolvePopupRect(
       selectionRect: selectionRect,
       screen: screen,
       bottomDocked: mixinAppModel.popupBottomDocked,
-      maxWidth: mixinAppModel.popupMaxWidth * mixinAppModel.appUiScale,
-      maxHeight: mixinAppModel.popupMaxHeight * mixinAppModel.appUiScale,
+      maxWidth: (_popupResizePreview?.width ?? mixinAppModel.popupMaxWidth) *
+          mixinAppModel.appUiScale,
+      maxHeight: (_popupResizePreview?.height ?? mixinAppModel.popupMaxHeight) *
+          mixinAppModel.appUiScale,
     );
+  }
+
+  /// Phase B 尺寸拖拽的预览态（基准逻辑像素，未缩放）。非空 = 正在拖右下角把手；
+  /// null = 未拖，用已落库真值。reader 家族的对应态在 [BaseSourcePageState]。
+  LookupSize? _popupResizePreview;
+
+  /// 拖把手起手：存当前偏好基准尺寸为预览起点。
+  void _onMixinPopupResizeStart() {
+    setState(() {
+      _popupResizePreview = LookupSize(
+        mixinAppModel.popupMaxWidth,
+        mixinAppModel.popupMaxHeight,
+      );
+    });
+  }
+
+  /// 拖把手进行：盒坐标系增量位移 [deltaPx] 经 [resolveDraggedLookupSize] 折算回基准
+  /// （除 appUiScale）并 clamp，驱动实时重建。
+  void _onMixinPopupResizeUpdate(Offset deltaPx) {
+    final LookupSize base = _popupResizePreview ??
+        LookupSize(mixinAppModel.popupMaxWidth, mixinAppModel.popupMaxHeight);
+    setState(() {
+      _popupResizePreview = resolveDraggedLookupSize(
+        currentBaseWidth: base.width,
+        currentBaseHeight: base.height,
+        deltaWidthPx: deltaPx.dx,
+        deltaHeightPx: deltaPx.dy,
+        uiScale: mixinAppModel.appUiScale,
+      );
+    });
+  }
+
+  /// 松手：预览尺寸一次性落偏好（`setPopupMaxWidth/Height`，与设置滑杆同源真值）后清空。
+  void _onMixinPopupResizeEnd() {
+    final LookupSize? committed = _popupResizePreview;
+    setState(() => _popupResizePreview = null);
+    if (committed != null) {
+      mixinAppModel.setPopupMaxWidth(committed.width);
+      mixinAppModel.setPopupMaxHeight(committed.height);
+    }
   }
 
   /// Mines the current dictionary entry to Anki.
@@ -477,6 +521,12 @@ mixin DictionaryPageMixin {
         onClose: () => onPop(index),
         // TODO-485：嵌套层即便禁用滑动关闭，也有显式返回父层入口。
         onBack: null,
+        // Phase B：app 内弹窗右下角尺寸拖拽把手（video/首页/texthooker 共用此收口）。
+        // 拖动 = 可视化改「最大宽高」偏好（与设置滑杆同一真值）；预览态在 mixin 级。
+        showResizeGrip: true,
+        onResizeStart: _onMixinPopupResizeStart,
+        onResizeUpdate: _onMixinPopupResizeUpdate,
+        onResizeEnd: _onMixinPopupResizeEnd,
         // TODO-834：点**本层弹窗本体的空白区**只关该层衍生的后代层（index 更大的全部），
         // 保留本层 + 祖先。线性扁平栈里 index 即 depth，故后代 = `index+1..end`，用
         // [DictionaryPopupController.truncateTo] 精确裁。点本层无后代 = no-op 栈不变。

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -338,6 +338,7 @@ class DictionaryPopupLayer extends StatelessWidget {
     this.onResizeStart,
     this.onResizeUpdate,
     this.onResizeEnd,
+    this.onResizeCancel,
     super.key,
   });
 
@@ -452,6 +453,10 @@ class DictionaryPopupLayer extends StatelessWidget {
 
   /// 拖拽结束：宿主把预览尺寸一次性落偏好（`setPopupMaxWidth/Height`）。
   final VoidCallback? onResizeEnd;
+
+  /// 拖拽被竞技场中途取消（不走 [onResizeEnd]）：宿主借此丢弃预览态、还原到已落库
+  /// 尺寸，避免弹窗悬停在预览尺寸；偏好从不会因取消被写坏。
+  final VoidCallback? onResizeCancel;
 
   /// 拖拽把手的测试锚点（widget 测试用 `find.byKey` 定位后模拟 pan）。
   static const Key resizeGripKey =
@@ -578,6 +583,7 @@ class DictionaryPopupLayer extends StatelessWidget {
             onStart: onResizeStart,
             onUpdate: onResizeUpdate!,
             onEnd: onResizeEnd,
+            onCancel: onResizeCancel,
           ),
         ),
       ],
@@ -977,12 +983,17 @@ class _PopupResizeGrip extends StatelessWidget {
     required this.onUpdate,
     this.onStart,
     this.onEnd,
+    this.onCancel,
     super.key,
   });
 
   final VoidCallback? onStart;
   final void Function(Offset deltaPx) onUpdate;
   final VoidCallback? onEnd;
+
+  /// pan 被手势竞技场中途夺走（不走 [onEnd]）时触发：宿主借此丢弃预览态、还原到
+  /// 已落库尺寸，避免弹窗停在预览尺寸的悬挂态（偏好从不会因取消被写坏）。
+  final VoidCallback? onCancel;
 
   @override
   Widget build(BuildContext context) {
@@ -995,6 +1006,7 @@ class _PopupResizeGrip extends StatelessWidget {
         onPanStart: onStart == null ? null : (_) => onStart!(),
         onPanUpdate: (DragUpdateDetails details) => onUpdate(details.delta),
         onPanEnd: onEnd == null ? null : (_) => onEnd!(),
+        onPanCancel: onCancel,
         child: CustomPaint(
           size: const Size.square(_kResizeGripSize),
           painter: _ResizeGripPainter(color),

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -334,6 +334,10 @@ class DictionaryPopupLayer extends StatelessWidget {
     this.onClose,
     this.onBack,
     this.transparentDocumentBackground = false,
+    this.showResizeGrip = false,
+    this.onResizeStart,
+    this.onResizeUpdate,
+    this.onResizeEnd,
     super.key,
   });
 
@@ -433,6 +437,26 @@ class DictionaryPopupLayer extends StatelessWidget {
   /// in-app 行为，见 DictionaryPopupWebView.transparentDocumentBackground）。
   final bool transparentDocumentBackground;
 
+  /// 弹窗尺寸拖拽（2026-07-13 设计 Phase B）：为真时在弹窗右下角叠一个可拖拽把手，
+  /// 拖动 = 可视化地改「最大宽/高」偏好（`popupMaxWidth/Height`，与设置页两滑杆同一
+  /// 真值）。仅 app 内 reader / video 两宿主开启（默认 false，app 外覆盖窗 / 嵌套返回层
+  /// 不受影响）。三个回调都非空时才真正渲染并接线把手。
+  final bool showResizeGrip;
+
+  /// 拖拽开始：宿主据此把当前基准尺寸存入预览态（[onResizeUpdate] 累积于其上）。
+  final VoidCallback? onResizeStart;
+
+  /// 拖拽进行：[deltaPx] 是本次指针增量位移（弹窗盒坐标系，已缩放逻辑像素）。宿主
+  /// 经 `resolveDraggedLookupSize` 折算回基准并实时预览。
+  final void Function(Offset deltaPx)? onResizeUpdate;
+
+  /// 拖拽结束：宿主把预览尺寸一次性落偏好（`setPopupMaxWidth/Height`）。
+  final VoidCallback? onResizeEnd;
+
+  /// 拖拽把手的测试锚点（widget 测试用 `find.byKey` 定位后模拟 pan）。
+  static const Key resizeGripKey =
+      ValueKey<String>('dictionary-popup-resize-grip');
+
   /// TODO-406/407：滑动关闭是否生效——平台/偏好开关（[enableSwipeToClose]）与调用方
   /// 层级开关（[swipeDismissible]）同时为真才挂 [SwipeDismissWrapper]。
   bool get _swipeActive => swipeDismissible && enableSwipeToClose;
@@ -522,12 +546,41 @@ class DictionaryPopupLayer extends StatelessWidget {
       child: surface,
     );
 
-    if (topBar != null || !_swipeActive) return content;
+    final Widget shell = (topBar != null || !_swipeActive)
+        ? content
+        : SwipeDismissWrapper(
+            sensitivity: ReaderHibikiSource.instance.dismissSwipeSensitivity,
+            onDismiss: onDismiss,
+            child: content,
+          );
 
-    return SwipeDismissWrapper(
-      sensitivity: ReaderHibikiSource.instance.dismissSwipeSensitivity,
-      onDismiss: onDismiss,
-      child: content,
+    return _maybeWrapResizeGrip(shell);
+  }
+
+  /// 尺寸拖拽（Phase B）：仅当 [showResizeGrip] 且已接线 [onResizeUpdate] 时，在弹窗
+  /// 盒右下角叠一个拖拽把手。把手是 [Stack] 的**同级顶层**（不在 [SwipeDismissWrapper]
+  /// / [_BodySwipeDismissDetector] 子树内），其 `HitTestBehavior.opaque` 在右下角吸收
+  /// 命中，pan 识别器在竞技场天然赢过下面的滑关/关窗判定，故绝不破坏既有滑动关闭 /
+  /// barrier / 嵌套弹窗几何（Never break userspace）。外层 [Stack] 填满宿主给的
+  /// `Positioned` 盒，把手钉在 `right:0,bottom:0`（右下），向右增宽、向下增高——弹窗可能
+  /// 锚在词上方，几何 recompute 由 `resolvePopupRect` 处理，无需在此关心锚点方向。
+  Widget _maybeWrapResizeGrip(Widget shell) {
+    if (!showResizeGrip || onResizeUpdate == null) return shell;
+    return Stack(
+      clipBehavior: Clip.none,
+      children: <Widget>[
+        Positioned.fill(child: shell),
+        Positioned(
+          right: 0,
+          bottom: 0,
+          child: _PopupResizeGrip(
+            key: resizeGripKey,
+            onStart: onResizeStart,
+            onUpdate: onResizeUpdate!,
+            onEnd: onResizeEnd,
+          ),
+        ),
+      ],
     );
   }
 
@@ -910,4 +963,74 @@ class _BodySwipeDismissDetectorState extends State<_BodySwipeDismissDetector>
           : widget.child,
     );
   }
+}
+
+/// 尺寸拖拽把手的边长（逻辑像素）。桌面常显、移动端可触摸拖。
+const double _kResizeGripSize = 18.0;
+
+/// 查词弹窗右下角的尺寸拖拽把手（Phase B）。渲染成常见的对角抓手纹样，接 pan 手势：
+/// 起手 [onStart]（宿主存当前基准尺寸）、拖动 [onUpdate]（增量位移，宿主折算+实时预览）、
+/// 松手 [onEnd]（宿主落偏好）。`HitTestBehavior.opaque` 让整块把手区域吸收命中，pan
+/// 识别器在竞技场赢过下面的滑关/关窗，绝不误触。桌面附带右下拉伸鼠标指针。
+class _PopupResizeGrip extends StatelessWidget {
+  const _PopupResizeGrip({
+    required this.onUpdate,
+    this.onStart,
+    this.onEnd,
+    super.key,
+  });
+
+  final VoidCallback? onStart;
+  final void Function(Offset deltaPx) onUpdate;
+  final VoidCallback? onEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color color =
+        Theme.of(context).colorScheme.onSurfaceVariant.withValues(alpha: 0.55);
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeUpLeftDownRight,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onPanStart: onStart == null ? null : (_) => onStart!(),
+        onPanUpdate: (DragUpdateDetails details) => onUpdate(details.delta),
+        onPanEnd: onEnd == null ? null : (_) => onEnd!(),
+        child: CustomPaint(
+          size: const Size.square(_kResizeGripSize),
+          painter: _ResizeGripPainter(color),
+        ),
+      ),
+    );
+  }
+}
+
+/// 把手纹样：右下角两道由长到短的对角线（越靠角越长），是跨平台通用的 resize 抓手观感。
+class _ResizeGripPainter extends CustomPainter {
+  const _ResizeGripPainter(this.color);
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint paint = Paint()
+      ..color = color
+      ..strokeWidth = 1.5
+      ..strokeCap = StrokeCap.round;
+    const double margin = 3.0;
+    // 靠角的长线 + 更靠角的短线，形成阶梯状对角抓手。
+    canvas.drawLine(
+      Offset(size.width - margin, size.height - margin * 5),
+      Offset(size.width - margin * 5, size.height - margin),
+      paint,
+    );
+    canvas.drawLine(
+      Offset(size.width - margin, size.height - margin * 3),
+      Offset(size.width - margin * 3, size.height - margin),
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_ResizeGripPainter oldDelegate) =>
+      oldDelegate.color != color;
 }

--- a/hibiki/lib/src/settings/settings_schema_lookup.dart
+++ b/hibiki/lib/src/settings/settings_schema_lookup.dart
@@ -618,8 +618,10 @@ SettingsDestination buildLookupDestination() {
           // surfaced through a double slider, so value/onChanged bridge int↔double.
           SettingsSliderItem(
             id: 'lookup.popup_dictionary_columns',
-            title: t.popup_dictionary_columns,
-            subtitle: t.popup_dictionary_columns_hint +
+            // 语义收敛：列数一直是「自动填充、封顶用户值」（effective = min(用户值,
+            // 视口可容)），文案随之改为「词典最多列数（自动填充）」，不改底层算法。
+            title: t.popup_dictionary_max_columns,
+            subtitle: t.popup_dictionary_max_columns_hint +
                 t.settings_experimental_suffix,
             icon: Icons.view_column_outlined,
             min: 1,
@@ -692,16 +694,117 @@ SettingsDestination buildLookupDestination() {
           ),
           SettingsSliderItem(
             id: 'lookup.popup_max_height',
+            // TODO-1352 后续：放宽最大高度上限（800→1600），配合高分屏 / 精细调整；
+            // 实际高度仍由 resolvePopupRect 按当前屏高 clamp，绝不会超出屏幕。
+            // 步进保持 10px（1400/140）。
             title: t.popup_max_height,
             icon: Icons.height_outlined,
             min: 200,
-            max: 800,
-            divisions: 60,
+            max: 1600,
+            divisions: 140,
             value: (SettingsContext settingsContext) =>
                 settingsContext.appModel.popupMaxHeight,
             label: (double value) => value.round().toString(),
             onChanged: (SettingsContext settingsContext, double value) {
               settingsContext.appModel.setPopupMaxHeight(value);
+              settingsContext.refresh();
+            },
+          ),
+          // 弹窗尺寸精细化：app 外覆盖查词窗独立尺寸开关 + 仅在开启时展示的宽/高滑杆。
+          // 关闭时跟随上面的 app 内最大宽高（overlayLookupEffectiveSize 解析）。
+          SettingsSwitchItem(
+            id: 'lookup.overlay_lookup_independent_size',
+            title: t.overlay_lookup_independent_size,
+            subtitle: t.overlay_lookup_independent_size_hint,
+            icon: Icons.open_in_new_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.overlayLookupIndependentSize,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel
+                  .setOverlayLookupIndependentSize(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSliderItem(
+            id: 'lookup.overlay_lookup_max_width',
+            title: t.overlay_lookup_max_width,
+            icon: Icons.open_in_full_outlined,
+            min: 250,
+            max: 2000,
+            divisions: 175,
+            visible: (SettingsContext settingsContext) =>
+                settingsContext.appModel.overlayLookupIndependentSize,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.overlayLookupMaxWidth,
+            label: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) {
+              settingsContext.appModel.setOverlayLookupMaxWidth(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSliderItem(
+            id: 'lookup.overlay_lookup_max_height',
+            title: t.overlay_lookup_max_height,
+            icon: Icons.height_outlined,
+            min: 200,
+            max: 1600,
+            divisions: 140,
+            visible: (SettingsContext settingsContext) =>
+                settingsContext.appModel.overlayLookupIndependentSize,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.overlayLookupMaxHeight,
+            label: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) {
+              settingsContext.appModel.setOverlayLookupMaxHeight(value);
+              settingsContext.refresh();
+            },
+          ),
+          // 弹窗尺寸精细化：浏览器扩展弹窗独立尺寸开关 + 仅在开启时展示的宽/高滑杆。
+          // 关闭时跟随 app 内最大宽高（extensionPopupEffectiveSize 解析，经 theme 下发）。
+          SettingsSwitchItem(
+            id: 'lookup.extension_popup_independent_size',
+            title: t.extension_popup_independent_size,
+            subtitle: t.extension_popup_independent_size_hint,
+            icon: Icons.extension_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.extensionPopupIndependentSize,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel
+                  .setExtensionPopupIndependentSize(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSliderItem(
+            id: 'lookup.extension_popup_max_width',
+            title: t.extension_popup_max_width,
+            icon: Icons.open_in_full_outlined,
+            min: 250,
+            max: 2000,
+            divisions: 175,
+            visible: (SettingsContext settingsContext) =>
+                settingsContext.appModel.extensionPopupIndependentSize,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.extensionPopupMaxWidth,
+            label: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) {
+              settingsContext.appModel.setExtensionPopupMaxWidth(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSliderItem(
+            id: 'lookup.extension_popup_max_height',
+            title: t.extension_popup_max_height,
+            icon: Icons.height_outlined,
+            min: 200,
+            max: 1600,
+            divisions: 140,
+            visible: (SettingsContext settingsContext) =>
+                settingsContext.appModel.extensionPopupIndependentSize,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.extensionPopupMaxHeight,
+            label: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) {
+              settingsContext.appModel.setExtensionPopupMaxHeight(value);
               settingsContext.refresh();
             },
           ),

--- a/hibiki/test/lookup/effective_lookup_size_test.dart
+++ b/hibiki/test/lookup/effective_lookup_size_test.dart
@@ -1,0 +1,96 @@
+// 查词弹窗「有效最大宽高」纯函数 + 解锁语义单元测试。
+//
+// 纯 Dart，不依赖词典 FFI / sqlite native-assets，可 `flutter test` 单独跑过。
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/lookup/effective_lookup_size.dart';
+
+void main() {
+  group('LookupSize', () {
+    test('值相等即相等（可用于 widget rebuild 去重）', () {
+      expect(const LookupSize(400, 360), const LookupSize(400, 360));
+      expect(const LookupSize(400, 360).hashCode,
+          const LookupSize(400, 360).hashCode);
+    });
+
+    test('宽或高不同即不相等', () {
+      expect(const LookupSize(400, 360) == const LookupSize(401, 360), isFalse);
+      expect(const LookupSize(400, 360) == const LookupSize(400, 361), isFalse);
+    });
+  });
+
+  group('effectiveLookupSize — 解锁语义', () {
+    const double sharedW = 400;
+    const double sharedH = 360;
+    const double sceneW = 900;
+    const double sceneH = 1200;
+
+    test('跟随中（independent=false）→ 恒用 app 内共享宽高，忽略自身键', () {
+      final LookupSize size = effectiveLookupSize(
+        independent: false,
+        sceneWidth: sceneW,
+        sceneHeight: sceneH,
+        sharedWidth: sharedW,
+        sharedHeight: sharedH,
+      );
+      expect(size, const LookupSize(sharedW, sharedH));
+    });
+
+    test('解锁后（independent=true）→ 用自身场景宽高，脱钩共享值', () {
+      final LookupSize size = effectiveLookupSize(
+        independent: true,
+        sceneWidth: sceneW,
+        sceneHeight: sceneH,
+        sharedWidth: sharedW,
+        sharedHeight: sharedH,
+      );
+      expect(size, const LookupSize(sceneW, sceneH));
+    });
+
+    test('跟随时改共享值实时联动，自身键此刻无影响', () {
+      LookupSize follow(double w, double h) => effectiveLookupSize(
+            independent: false,
+            sceneWidth: 111,
+            sceneHeight: 222,
+            sharedWidth: w,
+            sharedHeight: h,
+          );
+      expect(follow(500, 600), const LookupSize(500, 600));
+      expect(follow(700, 800), const LookupSize(700, 800));
+    });
+
+    test('解锁后改共享值不影响，读的是自身键', () {
+      LookupSize independent(double sharedW, double sharedH) =>
+          effectiveLookupSize(
+            independent: true,
+            sceneWidth: 640,
+            sceneHeight: 480,
+            sharedWidth: sharedW,
+            sharedHeight: sharedH,
+          );
+      expect(independent(400, 360), const LookupSize(640, 480));
+      expect(independent(2000, 1600), const LookupSize(640, 480));
+    });
+
+    test('默认场景键 == app 内默认（解锁瞬间不跳尺寸）', () {
+      // 场景键默认值应等于 app 内默认（400×360），使 independent 从 false→true 的
+      // 那一刻有效尺寸不变——这是「一动手才脱钩」好品味的前提。
+      const double appDefaultW = 400;
+      const double appDefaultH = 360;
+      final LookupSize followed = effectiveLookupSize(
+        independent: false,
+        sceneWidth: appDefaultW,
+        sceneHeight: appDefaultH,
+        sharedWidth: appDefaultW,
+        sharedHeight: appDefaultH,
+      );
+      final LookupSize unlocked = effectiveLookupSize(
+        independent: true,
+        sceneWidth: appDefaultW,
+        sceneHeight: appDefaultH,
+        sharedWidth: appDefaultW,
+        sharedHeight: appDefaultH,
+      );
+      expect(unlocked, followed);
+    });
+  });
+}

--- a/hibiki/test/models/lookup_effective_size_wiring_test.dart
+++ b/hibiki/test/models/lookup_effective_size_wiring_test.dart
@@ -1,0 +1,121 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/lookup/effective_lookup_size.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// 接线测试（补 Phase A code review 的 LOW 发现）：
+///
+/// [effectiveLookupSize] 纯函数已有单测，但「[AppModel] 把 independent 标志接到
+/// 哪个宽/高键」这段接线之前无覆盖——接反参数（如把高度喂进 width）、写错偏好键、
+/// 或默认值漏跟随 app 内共享值，纯函数测试仍全绿，只能真机发现。
+///
+/// 这里用真实 [PreferencesRepository] + [AppModel] 驱动 overlay/extension 两个
+/// effective-size getter，断言：
+/// 1. 默认（未解锁）严格跟随 app 内 [AppModel.popupMaxWidth]/[popupMaxHeight]；
+/// 2. 解锁后用该场景自己的键，且宽/高不互串（用非对称值 700×900 抓接反参数）；
+/// 3. 两个场景相互隔离（解锁 overlay 不影响 extension 跟随）。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  // AppModel 构造时 DefaultCacheManager 会经 path_provider 平台通道，单测 mock 掉。
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('hibiki_path_provider');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      pathProviderDir.deleteSync(recursive: true);
+    }
+  });
+
+  late HibikiDatabase db;
+  late PreferencesRepository prefs;
+  late AppModel appModel;
+
+  setUp(() async {
+    db = HibikiDatabase.forTesting(
+      DatabaseConnection(NativeDatabase.memory()),
+    );
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    appModel = AppModel(testPlatformServices());
+    appModel.wireLocalAudioForTesting(
+      prefsRepo: prefs,
+      databaseDirectory: Directory.systemTemp.createTempSync('lookup_size'),
+    );
+  });
+
+  tearDown(() async {
+    prefs.dispose();
+    await db.close();
+  });
+
+  test('默认未解锁：overlay/extension 有效尺寸严格跟随 app 内共享值', () {
+    final LookupSize shared =
+        LookupSize(appModel.popupMaxWidth, appModel.popupMaxHeight);
+    expect(appModel.overlayLookupIndependentSize, isFalse);
+    expect(appModel.extensionPopupIndependentSize, isFalse);
+    expect(appModel.overlayLookupEffectiveSize, shared);
+    expect(appModel.extensionPopupEffectiveSize, shared);
+  });
+
+  test('解锁 overlay 后用自身非对称宽高（700×900），宽高不互串', () async {
+    await prefs.setPref('overlay_lookup_independent_size', true);
+    await prefs.setPref('overlay_lookup_max_width', 700.0);
+    await prefs.setPref('overlay_lookup_max_height', 900.0);
+
+    expect(appModel.overlayLookupIndependentSize, isTrue);
+    // 若 effective getter 把 sceneHeight 喂进了 width（接反参数），这里会拿到 900×700。
+    expect(appModel.overlayLookupEffectiveSize, const LookupSize(700.0, 900.0));
+
+    // 场景隔离：extension 仍未解锁，继续跟随 app 内共享值。
+    final LookupSize shared =
+        LookupSize(appModel.popupMaxWidth, appModel.popupMaxHeight);
+    expect(appModel.extensionPopupEffectiveSize, shared);
+  });
+
+  test('解锁 extension 后用自身非对称宽高（500×650），且不影响 overlay', () async {
+    await prefs.setPref('extension_popup_independent_size', true);
+    await prefs.setPref('extension_popup_max_width', 500.0);
+    await prefs.setPref('extension_popup_max_height', 650.0);
+
+    expect(appModel.extensionPopupIndependentSize, isTrue);
+    expect(
+        appModel.extensionPopupEffectiveSize, const LookupSize(500.0, 650.0));
+
+    // overlay 仍跟随共享值。
+    final LookupSize shared =
+        LookupSize(appModel.popupMaxWidth, appModel.popupMaxHeight);
+    expect(appModel.overlayLookupEffectiveSize, shared);
+  });
+
+  test('已写入独立宽高但开关关闭时，有效尺寸仍跟随共享值（不误用旧独立值）', () async {
+    // 先写独立值但保持 independent=false。
+    await prefs.setPref('overlay_lookup_max_width', 1200.0);
+    await prefs.setPref('overlay_lookup_max_height', 1500.0);
+    expect(appModel.overlayLookupIndependentSize, isFalse);
+
+    final LookupSize shared =
+        LookupSize(appModel.popupMaxWidth, appModel.popupMaxHeight);
+    expect(appModel.overlayLookupEffectiveSize, shared,
+        reason: '关闭独立开关时必须跟随 app 内，忽略已存在的独立宽高');
+  });
+}

--- a/hibiki/test/pages/lookup_popup_resize_grip_test.dart
+++ b/hibiki/test/pages/lookup_popup_resize_grip_test.dart
@@ -1,0 +1,277 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/lookup/effective_lookup_size.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/dictionary_popup_layer.dart';
+import 'package:hibiki/src/pages/implementations/dictionary_popup_webview.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// Phase B（查词弹窗尺寸拖拽）测试。分两层：
+///
+/// 1. 纯函数 [resolveDraggedLookupSize]：方向（右下增大 / 左上减小）、双向 clamp、
+///    界面缩放折算（拖动位移在已缩放盒坐标系，回写基准要除 uiScale）、uiScale 兜底。
+///    不依赖任何 harness。
+/// 2. widget：pump 一个带 resize grip 的 [DictionaryPopupLayer]（result=null → 走
+///    「未找到」占位分支，不挂平台 WebView），在 grip 上模拟 pan 拖动，断言拖动后
+///    真实 [AppModel]/偏好里的 `popupMaxWidth`/`popupMaxHeight` 按预期方向变化并被
+///    clamp——覆盖 grip 手势 → 折算 → 落偏好整条写穿链路。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('resolveDraggedLookupSize 纯函数', () {
+    test('右下拖动（正 delta）在 uiScale=1 时按位移等量增大', () {
+      final LookupSize s = resolveDraggedLookupSize(
+        currentBaseWidth: 400,
+        currentBaseHeight: 360,
+        deltaWidthPx: 200,
+        deltaHeightPx: 100,
+        uiScale: 1.0,
+      );
+      expect(s.width, 600);
+      expect(s.height, 460);
+    });
+
+    test('左上拖动（负 delta）减小', () {
+      final LookupSize s = resolveDraggedLookupSize(
+        currentBaseWidth: 800,
+        currentBaseHeight: 700,
+        deltaWidthPx: -150,
+        deltaHeightPx: -120,
+        uiScale: 1.0,
+      );
+      expect(s.width, 650);
+      expect(s.height, 580);
+    });
+
+    test('uiScale=2：盒坐标位移折算回基准要除以缩放', () {
+      final LookupSize s = resolveDraggedLookupSize(
+        currentBaseWidth: 400,
+        currentBaseHeight: 360,
+        deltaWidthPx: 200, // 盒里拖 200px，界面 2× → 基准只 +100
+        deltaHeightPx: 200,
+        uiScale: 2.0,
+      );
+      expect(s.width, 500);
+      expect(s.height, 460);
+    });
+
+    test('上界 clamp 到 2000×1600', () {
+      final LookupSize s = resolveDraggedLookupSize(
+        currentBaseWidth: 1900,
+        currentBaseHeight: 1500,
+        deltaWidthPx: 5000,
+        deltaHeightPx: 5000,
+        uiScale: 1.0,
+      );
+      expect(s.width, kLookupPopupMaxWidth);
+      expect(s.height, kLookupPopupMaxHeight);
+    });
+
+    test('下界 clamp 到 250×200', () {
+      final LookupSize s = resolveDraggedLookupSize(
+        currentBaseWidth: 300,
+        currentBaseHeight: 300,
+        deltaWidthPx: -5000,
+        deltaHeightPx: -5000,
+        uiScale: 1.0,
+      );
+      expect(s.width, kLookupPopupMinWidth);
+      expect(s.height, kLookupPopupMinHeight);
+    });
+
+    test('uiScale<=0 按 1 兜底，不除零/不反向', () {
+      final LookupSize s = resolveDraggedLookupSize(
+        currentBaseWidth: 400,
+        currentBaseHeight: 360,
+        deltaWidthPx: 50,
+        deltaHeightPx: 40,
+        uiScale: 0,
+      );
+      expect(s.width, 450);
+      expect(s.height, 400);
+    });
+  });
+
+  group('DictionaryPopupLayer resize grip widget', () {
+    // AppModel 构造时 DefaultCacheManager 经 path_provider 平台通道，单测 mock 掉。
+    late Directory pathProviderDir;
+    setUpAll(() {
+      pathProviderDir =
+          Directory.systemTemp.createTempSync('hibiki_path_provider');
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        (MethodCall call) async => pathProviderDir.path,
+      );
+    });
+    tearDownAll(() {
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        null,
+      );
+      if (pathProviderDir.existsSync()) {
+        pathProviderDir.deleteSync(recursive: true);
+      }
+    });
+
+    late HibikiDatabase db;
+    late PreferencesRepository prefs;
+    late AppModel appModel;
+
+    setUp(() async {
+      db = HibikiDatabase.forTesting(
+        DatabaseConnection(NativeDatabase.memory()),
+      );
+      prefs = PreferencesRepository(db);
+      await prefs.loadFromDb();
+      appModel = AppModel(testPlatformServices());
+      appModel.wireLocalAudioForTesting(
+        prefsRepo: prefs,
+        databaseDirectory: Directory.systemTemp.createTempSync('resize_grip'),
+      );
+    });
+
+    tearDown(() async {
+      prefs.dispose();
+      await db.close();
+    });
+
+    Future<void> pumpLayer(WidgetTester tester, {double uiScale = 1.0}) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: _ResizeTestHost(appModel: appModel, uiScale: uiScale),
+          ),
+        ),
+      );
+      await tester.pump();
+    }
+
+    testWidgets('grip 渲染在弹窗层里', (WidgetTester tester) async {
+      await pumpLayer(tester);
+      expect(find.byKey(DictionaryPopupLayer.resizeGripKey), findsOneWidget);
+    });
+
+    testWidgets('向右下拖动放大 → 偏好宽/高都增大', (WidgetTester tester) async {
+      await pumpLayer(tester);
+      expect(appModel.popupMaxWidth, appModel.defaultPopupMaxWidth); // 400
+      expect(appModel.popupMaxHeight, appModel.defaultPopupMaxHeight); // 360
+
+      await tester.drag(
+        find.byKey(DictionaryPopupLayer.resizeGripKey),
+        const Offset(180, 120),
+      );
+      await tester.pump();
+
+      expect(appModel.popupMaxWidth, greaterThan(400));
+      expect(appModel.popupMaxHeight, greaterThan(360));
+      // 不超上界。
+      expect(appModel.popupMaxWidth, lessThanOrEqualTo(kLookupPopupMaxWidth));
+      expect(appModel.popupMaxHeight, lessThanOrEqualTo(kLookupPopupMaxHeight));
+    });
+
+    testWidgets('向右下巨量拖动被 clamp 到上界 2000×1600', (WidgetTester tester) async {
+      await pumpLayer(tester);
+      await tester.drag(
+        find.byKey(DictionaryPopupLayer.resizeGripKey),
+        const Offset(5000, 5000),
+      );
+      await tester.pump();
+      expect(appModel.popupMaxWidth, kLookupPopupMaxWidth);
+      expect(appModel.popupMaxHeight, kLookupPopupMaxHeight);
+    });
+
+    testWidgets('向左上巨量拖动被 clamp 到下界 250×200', (WidgetTester tester) async {
+      await pumpLayer(tester);
+      await tester.drag(
+        find.byKey(DictionaryPopupLayer.resizeGripKey),
+        const Offset(-5000, -5000),
+      );
+      await tester.pump();
+      expect(appModel.popupMaxWidth, kLookupPopupMinWidth);
+      expect(appModel.popupMaxHeight, kLookupPopupMinHeight);
+    });
+  });
+}
+
+/// 复刻 reader/video 宿主的 resize 接线：持预览态、松手落偏好。uiScale 直接注入
+/// （单测 harness 未初始化 themeNotifier，故不读 appModel.appUiScale），其余逻辑与
+/// [BaseSourcePageState] / [DictionaryPageMixin] 的处理器一致。
+class _ResizeTestHost extends StatefulWidget {
+  const _ResizeTestHost({required this.appModel, required this.uiScale});
+
+  final AppModel appModel;
+  final double uiScale;
+
+  @override
+  State<_ResizeTestHost> createState() => _ResizeTestHostState();
+}
+
+class _ResizeTestHostState extends State<_ResizeTestHost> {
+  LookupSize? _preview;
+
+  double get _boxWidth =>
+      (_preview?.width ?? widget.appModel.popupMaxWidth) * widget.uiScale;
+  double get _boxHeight =>
+      (_preview?.height ?? widget.appModel.popupMaxHeight) * widget.uiScale;
+
+  LookupSize get _currentBase =>
+      LookupSize(widget.appModel.popupMaxWidth, widget.appModel.popupMaxHeight);
+
+  void _start() => setState(() => _preview = _currentBase);
+
+  void _update(Offset deltaPx) {
+    final LookupSize base = _preview ?? _currentBase;
+    setState(() {
+      _preview = resolveDraggedLookupSize(
+        currentBaseWidth: base.width,
+        currentBaseHeight: base.height,
+        deltaWidthPx: deltaPx.dx,
+        deltaHeightPx: deltaPx.dy,
+        uiScale: widget.uiScale,
+      );
+    });
+  }
+
+  void _end() {
+    final LookupSize? committed = _preview;
+    setState(() => _preview = null);
+    if (committed != null) {
+      widget.appModel.setPopupMaxWidth(committed.width);
+      widget.appModel.setPopupMaxHeight(committed.height);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox(
+        width: _boxWidth,
+        height: _boxHeight,
+        child: DictionaryPopupLayer(
+          result: null,
+          webViewKey: GlobalKey<DictionaryPopupWebViewState>(),
+          onDismiss: () {},
+          onTextSelected: (String text, Rect localRect) {},
+          onLinkClick: (String query, Rect localRect) {},
+          onMineEntry: (Map<String, String> fields) async =>
+              const MinePopupResult(),
+          onDuplicateCheck: (String expression, String reading) async => false,
+          enableSwipeToClose: false,
+          showResizeGrip: true,
+          onResizeStart: _start,
+          onResizeUpdate: _update,
+          onResizeEnd: _end,
+        ),
+      ),
+    );
+  }
+}

--- a/hibiki/test/pages/lookup_popup_resize_host_wiring_guard_test.dart
+++ b/hibiki/test/pages/lookup_popup_resize_host_wiring_guard_test.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 源码级 guard（补 Phase B code review 的 MEDIUM 发现）。
+///
+/// [lookup_popup_resize_grip_test.dart] 用 test 里的 `_ResizeTestHost` 平行副本
+/// 验证「grip 手势 → resolveDraggedLookupSize → setPopupMax*」这条链，但**守不住
+/// 两个真实宿主到底有没有把把手接上**：若有人删掉 base_source_page._buildPopupLayer
+/// 或 dictionary_page_mixin.buildNestedPopupLayer 里的 showResizeGrip/onResize*
+/// 接线、或把 appUiScale 读错/删掉，行为测试仍全绿。
+///
+/// 本 guard 直接对两宿主源码断言接线令牌存在，捕获「接线被删」这一失败场景。
+/// 令牌是宿主必须保留的最小接线契约；重命名回调可同步更新此清单。
+void main() {
+  const List<({String path, String name})> hosts =
+      <({String path, String name})>[
+    (
+      path: 'lib/src/pages/base_source_page.dart',
+      name: 'reader 家族宿主 (_buildPopupLayer)',
+    ),
+    (
+      path: 'lib/src/pages/implementations/dictionary_page_mixin.dart',
+      name: 'video/首页/texthooker 宿主 (buildNestedPopupLayer)',
+    ),
+  ];
+
+  // 每个宿主都必须保留的最小接线令牌：开启把手 + 四个回调 + 缩放折算 + 落库真值。
+  const List<String> requiredTokens = <String>[
+    'showResizeGrip: true',
+    'onResizeStart:',
+    'onResizeUpdate:',
+    'onResizeEnd:',
+    'onResizeCancel:',
+    'appUiScale', // 盒尺寸/折算必须按 UI 缩放换算
+    'resolveDraggedLookupSize', // 拖拽尺寸用同源纯函数（唯一真值算法）
+    'setPopupMaxWidth', // 落 app 内共享真值（非 overlay/extension 键）
+    'setPopupMaxHeight',
+  ];
+
+  for (final ({String path, String name}) host in hosts) {
+    test('${host.name} 保留弹窗拖拽 resize 接线', () {
+      final File file = File(host.path);
+      expect(file.existsSync(), isTrue, reason: '宿主文件应存在：${host.path}');
+      final String src = file.readAsStringSync();
+      for (final String token in requiredTokens) {
+        expect(src.contains(token), isTrue,
+            reason: '${host.name} 缺少 resize 接线令牌 `$token`——'
+                '把手接线被删/改名会让 app 内弹窗拖拽静默失效');
+      }
+    });
+  }
+}

--- a/hibiki/test/settings/popup_dictionary_columns_test.dart
+++ b/hibiki/test/settings/popup_dictionary_columns_test.dart
@@ -71,7 +71,7 @@ void main() {
   SettingsDestination columnsOnlyDestination(SettingsContext settingsContext) {
     return SettingsDestination(
       id: SettingsDestinationId.lookup,
-      title: t.popup_dictionary_columns,
+      title: t.popup_dictionary_max_columns,
       icon: Icons.view_column_outlined,
       sections: <SettingsSection>[
         SettingsSection(items: <SettingsItem>[columnsItem(settingsContext)]),
@@ -140,12 +140,12 @@ void main() {
       expect(slider.divisions, 3, reason: '1..4 共 4 档 = 3 个 division');
 
       // 标题 + 实时读数（titleReadout）。TODO-1357：桌面（测试 host = 桌面）未设默认 2 列。
-      expect(find.text('${t.popup_dictionary_columns} (2)'), findsOneWidget,
+      expect(find.text('${t.popup_dictionary_max_columns} (2)'), findsOneWidget,
           reason: 'TODO-1357：桌面默认 2 列，标题带实时读数');
 
       // 副标题 = hint + 实验性后缀，渲染成单个 Text。
       final String expectedSubtitle =
-          t.popup_dictionary_columns_hint + t.settings_experimental_suffix;
+          t.popup_dictionary_max_columns_hint + t.settings_experimental_suffix;
       expect(find.text(expectedSubtitle), findsOneWidget,
           reason: '副标题展示 hint 文案并标注实验性后缀');
       expect(expectedSubtitle, contains(t.settings_experimental_suffix.trim()),


### PR DESCRIPTION
查词弹窗尺寸精细化 + 拖拽调整（app内 / app外 / 浏览器扩展三套独立尺寸 + 边角拖拽 + 列数自动封顶）。

设计真值：`docs/specs/2026-07-13-lookup-popup-resize-design.md`。分四期 A→B→C→D，本 PR 随实现推进滚动更新。

## 已完成（已验证）
- **Phase A** — 三套独立尺寸键（app内沿用 `popupMaxWidth/H`；app外 `overlayLookup*`、扩展 `extensionPopup*` 各带 `独立尺寸` 开关，默认跟随 app内，解锁后用自身键）+ 有效尺寸纯函数 `effectiveLookupSize` + 跟随/解锁设置 UI + 列数「最多列数（自动填充）」文案 + 高度上限 800→1600 + 17 语言 i18n。含纯函数单测 7/7 与 AppModel 接线测试 4/4。
- **Phase B** — app 内阅读器/视频查词弹窗右下角**拖拽 resize**（纯 Flutter，覆盖全 5 平台）：拖动 = 可视化改 app内共享最大宽高（与滑杆同一真值），预览态实时跟手、松手落偏好；`resolveDraggedLookupSize` 除 `appUiScale` 折算 + clamp 250–2000/200–1600；`onPanCancel` 清预览。含 grip 行为测试 10/10 + 宿主接线 guard。

`flutter analyze` 全干净；上述纯 Dart 测试全过（native-assets 需 CI 下 sqlite3）。

## 待实现
- **Phase C** — app 外覆盖窗拖拽（**仅 Windows** 原生：macOS/Linux 无覆盖窗、Android 独立悬浮服务、iOS 无 app 外查词）。**需 Windows 真机验收。**
- **Phase D** — 浏览器扩展弹窗 DOM 拖拽 + 经 bridge 回写 app 扩展键（三镜像同步）。**需浏览器手测。**

## 验收
Phase A/B 已过 analyze + 单测/widget 测试；阅读器/查词交互按项目纪律仍需 **Windows 离屏 + 真机焦点驱动** 复测拖拽跟手/落库/触摸可用（待真机）。
