### PR TITLE
feat/perf(lookup): 统一入场淡入 + 解耦 app 内查词显示与高亮 eval(BUG-717②)

### DIFF
--- a/hibiki/assets/browser_extension/content.js
+++ b/hibiki/assets/browser_extension/content.js
@@ -913,7 +913,10 @@ function hibikiEnsureContainer() {
     // 「CSS zoom × 100vw × shadow shrink-to-fit」相互作用干扰。host 宽/高/zoom 由 hibikiRender
     // 按查词响应下发的 --hibiki-popup-* 设置；#entries-container 在 shadow 内中和为 width:100%。
     hibikiHost.style.cssText =
-        'position:fixed;top:0;left:0;z-index:2147483647;overflow-x:hidden;overflow-y:auto;';
+        'position:fixed;top:0;left:0;z-index:2147483647;overflow-x:hidden;overflow-y:auto;' +
+        // 入场淡入：与 app 内 parkedPopupLayer 及 app 外 .global-lookup-frame-shell 的
+        // 200ms ease-out 对齐。首帧 opacity:0，place() 定位后 reflow 触发 0→1 淡入。
+        'opacity:0;transition:opacity 200ms ease-out;';
     hibikiInstallSwipeClose(hibikiHost); // 水平拖关手势（是否生效由 hibikiSwipeCloseEnabled 门控）
     const shadow = hibikiHost.attachShadow({ mode: 'open' });
     // 中和 content.css 里 #entries-container 自带的尺寸盒/zoom（那套是给「容器自身即 fixed 元素」
@@ -1040,8 +1043,10 @@ function hibikiDrawHighlightOverlay(rects) {
 
 function hibikiRemoveContainer() {
   // BUG-688：移除 shadow 宿主即连带整个 shadow root（弹窗内容）；清 __hibikiRoot 让 popup.js
-  // 的 helper 回落到 document（下次开窗 hibikiEnsureContainer 会重建）。
-  if (hibikiHost) { hibikiHost.remove(); hibikiHost = null; }
+  // 的 helper 回落到 document（下次开窗 hibikiEnsureContainer 会重建）。host 引用即刻置空，
+  // 让并发 re-lookup 重建新 host；旧节点先淡出、末尾才从 DOM 移除（高亮/选区仍即时清）。
+  const dying = hibikiHost;
+  hibikiHost = null;
   hibikiContainer = null;
   window.__hibikiRoot = null;
   // TODO-1272：关窗即撤覆盖层高亮（被查词高亮跟随弹窗生命周期，弹窗在则在、弹窗关则撤）。
@@ -1052,6 +1057,21 @@ function hibikiRemoveContainer() {
       window.hoshiSelection.clearSelection();
     }
   } catch (_) { /* no-op */ }
+  // 淡出后再从 DOM 移除 host 节点（与入场淡入及 app 外 .global-lookup-dismissing 的 200ms
+  // ease-out 对齐）。pointer-events:none 避免淡出期误吞点击；transitionend 用 setTimeout
+  // 兜底（reduced-motion / 离屏也能移除）。高亮/选区已在上面即时清，不随淡出延迟残留。
+  if (dying) {
+    dying.style.pointerEvents = 'none';
+    dying.style.opacity = '0';
+    let dropped = false;
+    const drop = () => {
+      if (dropped) return;
+      dropped = true;
+      try { dying.remove(); } catch (_) { /* 已脱离文档 */ }
+    };
+    dying.addEventListener('transitionend', drop, { once: true });
+    setTimeout(drop, 260);
+  }
 }
 
 // 流媒体字幕的取词兜底：Netflix 等在字幕**上面**盖了视频覆盖层（如 .watch-video--flag-container），
@@ -1373,6 +1393,14 @@ function hibikiRender(popupJson, termLen, theme, anchorRect) {
       hibikiHost.style.top = (pos.top / zoom) + 'px';
     }
     c.style.visibility = 'visible';
+    // 入场淡入：把 host 压到 0 并强制回流提交为过渡基线，再翻 1 触发 200ms ease-out
+    // 淡入（同帧 0→1 无 reflow 会被浏览器合并、跳过过渡）。重复查词复用同一 host 时
+    // 亦从 0 重新淡入，与 app 内每次「隐藏→可见」淡入一致。
+    if (hibikiHost) {
+      hibikiHost.style.opacity = '0';
+      void hibikiHost.offsetWidth;
+      hibikiHost.style.opacity = '1';
+    }
   };
   requestAnimationFrame(place);
 }

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -254,9 +254,73 @@ Widget parkedPopupLayer({
       maintainState: true,
       maintainAnimation: true,
       maintainSize: true,
-      child: child,
+      // TODO-890 姊妹项：入场淡入。四表面共用此收口，一处补齐全部。
+      child: _PopupEntranceFade(visible: visible, child: child),
     ),
   );
+}
+
+/// TODO-890 姊妹项：查词弹窗**入场淡入**收口。app 外覆盖窗靠注入 CSS
+/// `transition:opacity 200ms ease-out` + 双 gate 翻 `opacity 0→1` 做平滑淡入；app 内
+/// 各表面（阅读器 / 视频 / 首页 / 安卓独立窗）此前经 [parkedPopupLayer] 的 [Visibility]
+/// **硬切**出现，观感生硬且冷路径显得慢。此包装器把「隐藏→可见」补成
+/// [_kSlideDuration] / easeOut 淡入，与 app 外及本层既有的 swipe 滑出淡出（同一常量 /
+/// 曲线）三处统一。
+///
+/// 关键：[ImplicitlyAnimatedWidget] 首帧取目标值不补间，故不能只写
+/// `AnimatedOpacity(opacity: visible ? 1 : 0)`——首次挂载即 `visible:true` 的
+/// 视频 / 首页 / 独立窗会跳过淡入。这里用「首帧强制 0 + post-frame 翻 1」保证每次进入
+/// 可见态都淡入（含首帧即可见），镜像 app 外「shell 默认 opacity:0，reveal gate 齐才翻 1」。
+class _PopupEntranceFade extends StatefulWidget {
+  const _PopupEntranceFade({required this.visible, required this.child});
+
+  final bool visible;
+  final Widget child;
+
+  @override
+  State<_PopupEntranceFade> createState() => _PopupEntranceFadeState();
+}
+
+class _PopupEntranceFadeState extends State<_PopupEntranceFade> {
+  /// 入场淡入是否已触发（[AnimatedOpacity] 目标翻 1）。隐藏态复位，下次可见重新淡入。
+  bool _revealed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.visible) _scheduleReveal();
+  }
+
+  @override
+  void didUpdateWidget(_PopupEntranceFade oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.visible && !oldWidget.visible) {
+      _revealed = false; // 重新进入可见态：复位以再次淡入。
+      _scheduleReveal();
+    } else if (!widget.visible && oldWidget.visible) {
+      _revealed = false; // 隐藏即复位，避免下次瞬间满不透明。
+    }
+  }
+
+  /// 下一帧把 [_revealed] 翻 true，使 [AnimatedOpacity] 从首帧的 0 补间到 1
+  /// （同帧内 0→1 会被隐式动画当作初值直接取 1、不补间）。
+  void _scheduleReveal() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && widget.visible && !_revealed) {
+        setState(() => _revealed = true);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedOpacity(
+      opacity: widget.visible && _revealed ? 1.0 : 0.0,
+      duration: _kSlideDuration,
+      curve: Curves.easeOut,
+      child: widget.child,
+    );
+  }
 }
 
 /// Maps a word rect reported in the popup WebView's own coordinate space

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -913,7 +913,10 @@ function hibikiEnsureContainer() {
     // 「CSS zoom × 100vw × shadow shrink-to-fit」相互作用干扰。host 宽/高/zoom 由 hibikiRender
     // 按查词响应下发的 --hibiki-popup-* 设置；#entries-container 在 shadow 内中和为 width:100%。
     hibikiHost.style.cssText =
-        'position:fixed;top:0;left:0;z-index:2147483647;overflow-x:hidden;overflow-y:auto;';
+        'position:fixed;top:0;left:0;z-index:2147483647;overflow-x:hidden;overflow-y:auto;' +
+        // 入场淡入：与 app 内 parkedPopupLayer 及 app 外 .global-lookup-frame-shell 的
+        // 200ms ease-out 对齐。首帧 opacity:0，place() 定位后 reflow 触发 0→1 淡入。
+        'opacity:0;transition:opacity 200ms ease-out;';
     hibikiInstallSwipeClose(hibikiHost); // 水平拖关手势（是否生效由 hibikiSwipeCloseEnabled 门控）
     const shadow = hibikiHost.attachShadow({ mode: 'open' });
     // 中和 content.css 里 #entries-container 自带的尺寸盒/zoom（那套是给「容器自身即 fixed 元素」
@@ -1040,8 +1043,10 @@ function hibikiDrawHighlightOverlay(rects) {
 
 function hibikiRemoveContainer() {
   // BUG-688：移除 shadow 宿主即连带整个 shadow root（弹窗内容）；清 __hibikiRoot 让 popup.js
-  // 的 helper 回落到 document（下次开窗 hibikiEnsureContainer 会重建）。
-  if (hibikiHost) { hibikiHost.remove(); hibikiHost = null; }
+  // 的 helper 回落到 document（下次开窗 hibikiEnsureContainer 会重建）。host 引用即刻置空，
+  // 让并发 re-lookup 重建新 host；旧节点先淡出、末尾才从 DOM 移除（高亮/选区仍即时清）。
+  const dying = hibikiHost;
+  hibikiHost = null;
   hibikiContainer = null;
   window.__hibikiRoot = null;
   // TODO-1272：关窗即撤覆盖层高亮（被查词高亮跟随弹窗生命周期，弹窗在则在、弹窗关则撤）。
@@ -1052,6 +1057,21 @@ function hibikiRemoveContainer() {
       window.hoshiSelection.clearSelection();
     }
   } catch (_) { /* no-op */ }
+  // 淡出后再从 DOM 移除 host 节点（与入场淡入及 app 外 .global-lookup-dismissing 的 200ms
+  // ease-out 对齐）。pointer-events:none 避免淡出期误吞点击；transitionend 用 setTimeout
+  // 兜底（reduced-motion / 离屏也能移除）。高亮/选区已在上面即时清，不随淡出延迟残留。
+  if (dying) {
+    dying.style.pointerEvents = 'none';
+    dying.style.opacity = '0';
+    let dropped = false;
+    const drop = () => {
+      if (dropped) return;
+      dropped = true;
+      try { dying.remove(); } catch (_) { /* 已脱离文档 */ }
+    };
+    dying.addEventListener('transitionend', drop, { once: true });
+    setTimeout(drop, 260);
+  }
 }
 
 // 流媒体字幕的取词兜底：Netflix 等在字幕**上面**盖了视频覆盖层（如 .watch-video--flag-container），
@@ -1373,6 +1393,14 @@ function hibikiRender(popupJson, termLen, theme, anchorRect) {
       hibikiHost.style.top = (pos.top / zoom) + 'px';
     }
     c.style.visibility = 'visible';
+    // 入场淡入：把 host 压到 0 并强制回流提交为过渡基线，再翻 1 触发 200ms ease-out
+    // 淡入（同帧 0→1 无 reflow 会被浏览器合并、跳过过渡）。重复查词复用同一 host 时
+    // 亦从 0 重新淡入，与 app 内每次「隐藏→可见」淡入一致。
+    if (hibikiHost) {
+      hibikiHost.style.opacity = '0';
+      void hibikiHost.offsetWidth;
+      hibikiHost.style.opacity = '1';
+    }
   };
   requestAnimationFrame(place);
 }


### PR DESCRIPTION
两轮改动,都针对「app 内查词不如 app 外查词窗」。

## 第一轮 — 入场淡入统一（commit ab9c796eb）
app 外覆盖窗有 CSS 200ms ease-out 淡入,app 内/扩展硬切出现。
- app 内:`parkedPopupLayer` 加 `_PopupEntranceFade`(200ms easeOut,首帧 0+post-frame 翻 1 绕 ImplicitlyAnimatedWidget 首帧不补间坑),覆盖阅读器/视频/首页/安卓独立窗。
- 扩展:`content.js` 两镜像同改,host 内联 opacity/transition(零 content.css 重生成),关窗淡出后移除。

## 第二轮 — 解耦查词显示与高亮 eval（commit 58819e8e2，BUG-717 ②）
用户复诉「app 内查词还是慢,没有 app 外快,慢了 5-10 倍」。这是**真实延迟**不是动画。
- **根因**:app 外显示门控全程在 WebView2 内 CSS(`popupRendered` 被 host.js 就地拦截翻 gate,不出 WebView);app 内旧 `_highlightAndShowPopup` **先 await 高亮 eval(打在正在渲染 EPUB 的大 reader WebView)、finally 才显示**——弹窗显示+弹窗 WebView 注入被死死串在繁忙大 reader WebView 之后,reader 忙时每跳 stall 数十 ms = 慢数倍的主乘数。正是 BUG-717 文档列的「② 高亮 eval 解耦——未实施」。
- **修复**:先用选区 rect 立即显示(弹窗 WebView 注入与高亮 eval 分属两 WebView 并行),高亮 eval 异步回来精修词 bbox 再 `reanchorTopPopup` 重锚(代次守卫 + reanchorEntry 三校验防迟到回调错位/抖动;当年搁置的精确锚点顾虑由重锚解决)。
- **诚实边界**:拆掉「被繁忙大 WebView 串行卡住」主乘数,但 app 内弹窗仍是 Flutter 架构(reveal 要 popupRendered 往返),无法完全等于 app 外纯 WebView 门控的 ~10ms;彻底对齐需把 in-app reveal 改纯 WebView CSS 门控(大改触 BUG-135/523/717/767 一片基础设施),**留独立决策**。

## 搁置
「app 外弹窗圆框外多余颜色没剪切」——待用户截图定位 CSS 层(主题色环)vs 原生层(黑框/方角)。

## 验证
- `flutter analyze`(全量):No issues found
- `flutter test test/pages/ test/lookup/`:**2281 全过**(含新增 `reanchorEntry` 四例、showDeferredPopup 挟具、BUG-717 P1 去重)
- 扩展 node 套件 67/70(3 个 highlight 失败为既有 jsdom 环境问题,已在 origin 基线确认非本次引入)

## 待真机
桌面/Android 实测三处淡入一致;app 内查词跟手度对比 app 外;扩展关窗淡出无残留。