### PR TITLE
查词弹窗尺寸 Phase C+D（覆盖窗 Windows 原生拖拽 / 扩展 DOM 拖拽经 bridge 回写）

### DIFF
--- a/hibiki/assets/browser_extension/background.js
+++ b/hibiki/assets/browser_extension/background.js
@@ -170,6 +170,17 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         // base URL + token to build GET /api/media/dictionary. Same source as
         // lookup/mine (cfg()): installer-injected defaults or options override.
         sendResponse({ ok: true, base, token });
+      } else if (msg.type === 'popupSize') {
+        // 弹窗尺寸精细化 Phase D：content.js 拖弹窗右下角把手松手后，把最终基准最大宽高经此
+        // 回写 app（POST /api/extension/popup-size，Basic auth 与查词同源）。app 侧 clamp
+        // (250-2000/200-1600) + 「拖即解锁」extensionPopupIndependentSize=true + 写扩展键，
+        // 下次查词以新尺寸下发。lookup 样板同款鉴权头，不新开无鉴权入口。
+        const r = await fetch(base + '/api/extension/popup-size', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
+          body: JSON.stringify({ maxWidth: msg.maxWidth, maxHeight: msg.maxHeight }),
+        });
+        sendResponse({ ok: r.ok, status: r.status });
       } else if (msg.type === 'lookup') {
         const r = await fetch(base + '/api/lookup/dictionary', {
           method: 'POST',

--- a/hibiki/assets/browser_extension/content.js
+++ b/hibiki/assets/browser_extension/content.js
@@ -1054,13 +1054,6 @@ function hibikiRemoveContainer() {
   if (hibikiHost) { hibikiHost.remove(); hibikiHost = null; }
   hibikiContainer = null;
   window.__hibikiRoot = null;
-  // Phase D：关窗即撤拖拽把手 + 清尺寸拖拽状态（把手随弹窗生命周期，下次开窗 place() 重建）。
-  if (hibikiResizeGrip) {
-    try { hibikiResizeGrip.remove(); } catch (_) { /* 已脱离文档 */ }
-    hibikiResizeGrip = null;
-  }
-  hibikiResizeDrag = null;
-  hibikiResizeBox = null;
   // TODO-1272：关窗即撤覆盖层高亮（被查词高亮跟随弹窗生命周期，弹窗在则在、弹窗关则撤）。
   hibikiClearHighlightOverlay();
   // TODO-1150（yomitan 式）：关窗即撤 selection 状态与任何 DOM 包裹高亮（嵌套查词用）。hoshiSelection 未加载/无选区时是 no-op。
@@ -1069,6 +1062,13 @@ function hibikiRemoveContainer() {
       window.hoshiSelection.clearSelection();
     }
   } catch (_) { /* no-op */ }
+  // Phase D：关窗即撤拖拽把手 + 清尺寸拖拽状态（把手随弹窗生命周期，下次开窗 place() 重建）。
+  if (hibikiResizeGrip) {
+    try { hibikiResizeGrip.remove(); } catch (_) { /* 已脱离文档 */ }
+    hibikiResizeGrip = null;
+  }
+  hibikiResizeDrag = null;
+  hibikiResizeBox = null;
 }
 
 // 流媒体字幕的取词兜底：Netflix 等在字幕**上面**盖了视频覆盖层（如 .watch-video--flag-container），

--- a/hibiki/assets/browser_extension/content.js
+++ b/hibiki/assets/browser_extension/content.js
@@ -1355,6 +1355,7 @@ function hibikiInstallResizeDrag(grip) {
     const baseH = hibikiHost.getBoundingClientRect().height / z;
     hibikiResizeDrag = {
       startX: x, startY: y, baseW: baseW, baseH: baseH, zoom: z,
+      moved: false,
       bounds: {
         minW: HIBIKI_POPUP_MIN_WIDTH, minH: HIBIKI_POPUP_MIN_HEIGHT,
         // 视口可用空间（右/下边界 − 弹窗左上角）÷zoom = 基准尺度上界；不撑出视口、不遮被查词。
@@ -1366,6 +1367,10 @@ function hibikiInstallResizeDrag(grip) {
   const move = (x, y) => {
     if (!hibikiResizeDrag || !hibikiHost) return;
     const d = hibikiResizeDrag;
+    // 位移超阈值才算真拖拽（区分纯点击与拖动，见 up() 的「拖即解锁」门控）。
+    if (!d.moved && Math.abs(x - d.startX) + Math.abs(y - d.startY) > 3) {
+      d.moved = true;
+    }
     const size = hibikiComputeResizedSize(
       { width: d.baseW, height: d.baseH },
       { dx: x - d.startX, dy: y - d.startY },
@@ -1375,8 +1380,11 @@ function hibikiInstallResizeDrag(grip) {
     hibikiPositionResizeGrip();
   };
   const up = () => {
-    if (!hibikiResizeDrag || !hibikiHost) { hibikiResizeDrag = null; return; }
+    const d = hibikiResizeDrag;
     hibikiResizeDrag = null;
+    // 拖即解锁：仅当本次确实拖动过（位移超阈值）才回写尺寸 + 翻 independent；
+    // 纯点击（把手盖住的内容点击）不脱钩「跟随 app 内尺寸」（BUG review LOW）。
+    if (!d || !hibikiHost || !d.moved) return;
     const w = parseFloat(hibikiHost.style.width);
     const h = parseFloat(hibikiHost.style.maxHeight);
     if (w > 0 && h > 0) hibikiSendPopupSize(w, h);

--- a/hibiki/assets/browser_extension/content.js
+++ b/hibiki/assets/browser_extension/content.js
@@ -32,6 +32,16 @@ let hibikiLastX = -1;
 let hibikiLastY = -1;
 let hibikiPending = false;
 
+// 弹窗尺寸精细化 Phase D：拖拽调整扩展弹窗尺寸。
+// hibikiResizeGrip：右下角拖拽把手（顶层 position:fixed overlay，与高亮层同父挂在
+//   fullscreenElement||body；不放进 host 的 shadow，避开 host 的 zoom 建立包含块干扰 fixed）。
+// hibikiResizeBox：place() 每次落点后存的夹取上下文——弹窗视口左上角 + 视口可用空间右/下边界
+//   （已内含 BUG-767「拖大也不许遮住被查词」约束）+ 当前 zoom，供拖拽把「视口位移」折回基准尺度。
+// hibikiResizeDrag：一次拖拽的起始快照 {startX,startY,baseW,baseH,zoom,bounds}；null=未在拖。
+let hibikiResizeGrip = null;
+let hibikiResizeBox = null;
+let hibikiResizeDrag = null;
+
 // 扩展重载/更新/禁用后，已注入到**已打开标签**里的旧 content script 会「上下文失效」：
 // chrome.runtime 变 undefined / 访问抛异常 → 再调 chrome.runtime.sendMessage 就报
 // 「Cannot read properties of undefined (reading 'sendMessage')」。守卫掉：失效即静默停手，
@@ -1044,6 +1054,13 @@ function hibikiRemoveContainer() {
   if (hibikiHost) { hibikiHost.remove(); hibikiHost = null; }
   hibikiContainer = null;
   window.__hibikiRoot = null;
+  // Phase D：关窗即撤拖拽把手 + 清尺寸拖拽状态（把手随弹窗生命周期，下次开窗 place() 重建）。
+  if (hibikiResizeGrip) {
+    try { hibikiResizeGrip.remove(); } catch (_) { /* 已脱离文档 */ }
+    hibikiResizeGrip = null;
+  }
+  hibikiResizeDrag = null;
+  hibikiResizeBox = null;
   // TODO-1272：关窗即撤覆盖层高亮（被查词高亮跟随弹窗生命周期，弹窗在则在、弹窗关则撤）。
   hibikiClearHighlightOverlay();
   // TODO-1150（yomitan 式）：关窗即撤 selection 状态与任何 DOM 包裹高亮（嵌套查词用）。hoshiSelection 未加载/无选区时是 no-op。
@@ -1281,6 +1298,130 @@ function hibikiComputePlacement(anchor, size, viewport) {
   return { left, top, maxHeight };
 }
 
+// 弹窗尺寸精细化 Phase D：拖拽右下角把手把「起始基准最大宽高 + 本次累计位移」折算成新的基准
+// （未缩放）最大宽高并 clamp。纯函数（不碰 DOM），便于单测。
+// start：拖拽开始时的基准 {width, height}（= host.style.width / 渲染高÷zoom，未乘 zoom）。
+// delta：指针在视口(**已缩放**)坐标系里的累计位移 {dx, dy}；除以 zoom 折回基准尺度
+//   （与 place() 里 `pos.left / zoom` 折算同源——host 带 zoom，视口位移 = 基准位移 × zoom）。
+// bounds：{minW, minH, maxW, maxH}（基准尺度上下限；maxW/maxH 由视口可用空间÷zoom 得来，已内含
+//   BUG-767「不遮词」约束）。zoom<=0 按 1 兜底（不除零）。clamp 上界恒 >= 下界（视口过小也不倒挂）。
+function hibikiComputeResizedSize(start, delta, zoom, bounds) {
+  const z = zoom > 0 ? zoom : 1;
+  const clamp = (v, lo, hi) => Math.min(Math.max(v, lo), Math.max(lo, hi));
+  const width = clamp(start.width + delta.dx / z, bounds.minW, bounds.maxW);
+  const height = clamp(start.height + delta.dy / z, bounds.minH, bounds.maxH);
+  return { width: width, height: height };
+}
+
+// 基准最大宽/高的允许范围（逻辑像素）。与 app 设置页两滑杆 + Dart 侧
+// effective_lookup_size.dart 的 kLookupPopupMin/MaxWidth/Height 单一同源——拖拽与滑杆写同一
+// 真值，故边界必须一致，否则拖拽能写出滑杆写不出的越界值（app 侧仍会再 clamp 一次兜底）。
+const HIBIKI_POPUP_MIN_WIDTH = 250;
+const HIBIKI_POPUP_MIN_HEIGHT = 200;
+const HIBIKI_RESIZE_GRIP_SIZE = 18;
+
+// 把拖拽把手移到弹窗当前渲染矩形的右下角（视口坐标；host 是 fixed，坐标即视口系）。
+function hibikiPositionResizeGrip() {
+  if (!hibikiResizeGrip || !hibikiHost) return;
+  const r = hibikiHost.getBoundingClientRect();
+  const s = HIBIKI_RESIZE_GRIP_SIZE;
+  hibikiResizeGrip.style.left = (r.right - s) + 'px';
+  hibikiResizeGrip.style.top = (r.bottom - s) + 'px';
+}
+
+// Phase D：把拖出来的最终基准最大宽高经 background → app（POST /api/extension/popup-size）。
+// app 侧 clamp(250-2000/200-1600) + 「拖即解锁」extensionPopupIndependentSize=true + 写扩展键，
+// 下一次查词 browserExtensionThemeColors 读新 extensionPopupEffectiveSize 即以新尺寸下发（闭环）。
+function hibikiSendPopupSize(maxWidth, maxHeight) {
+  try {
+    chrome.runtime.sendMessage(
+      { type: 'popupSize', maxWidth: Math.round(maxWidth), maxHeight: Math.round(maxHeight) },
+      () => { void chrome.runtime.lastError; });
+  } catch (_) { /* 扩展上下文失效：静默（尺寸只是没落库，不崩查词） */ }
+}
+
+// 在把手上装拖拽逻辑（每个 grip 只装一次）。pointerdown 快照起始基准 + 视口可用空间夹取上界，
+// pointermove 经纯函数 hibikiComputeResizedSize 实时改 host 的 width/maxHeight（place() 只在查词当
+// 帧跑一次、无 rAF 循环，故手动尺寸不会被每帧覆盖回去），pointerup 落库并经 bridge 回写 app。
+function hibikiInstallResizeDrag(grip) {
+  if (!grip || grip.__hibikiResizeHooked) return;
+  grip.__hibikiResizeHooked = true;
+  const down = (x, y) => {
+    if (!hibikiHost || !hibikiResizeBox) return;
+    const box = hibikiResizeBox;
+    const z = box.zoom > 0 ? box.zoom : 1;
+    const baseW = parseFloat(hibikiHost.style.width) || 0;
+    // 当前基准高度：host 渲染高÷zoom（style.maxHeight 可能是 min()/px/未设 → 用真实 rect 最稳）。
+    const baseH = hibikiHost.getBoundingClientRect().height / z;
+    hibikiResizeDrag = {
+      startX: x, startY: y, baseW: baseW, baseH: baseH, zoom: z,
+      bounds: {
+        minW: HIBIKI_POPUP_MIN_WIDTH, minH: HIBIKI_POPUP_MIN_HEIGHT,
+        // 视口可用空间（右/下边界 − 弹窗左上角）÷zoom = 基准尺度上界；不撑出视口、不遮被查词。
+        maxW: (box.maxRight - box.left) / z,
+        maxH: (box.maxBottom - box.top) / z,
+      },
+    };
+  };
+  const move = (x, y) => {
+    if (!hibikiResizeDrag || !hibikiHost) return;
+    const d = hibikiResizeDrag;
+    const size = hibikiComputeResizedSize(
+      { width: d.baseW, height: d.baseH },
+      { dx: x - d.startX, dy: y - d.startY },
+      d.zoom, d.bounds);
+    hibikiHost.style.width = size.width + 'px';
+    hibikiHost.style.maxHeight = size.height + 'px';
+    hibikiPositionResizeGrip();
+  };
+  const up = () => {
+    if (!hibikiResizeDrag || !hibikiHost) { hibikiResizeDrag = null; return; }
+    hibikiResizeDrag = null;
+    const w = parseFloat(hibikiHost.style.width);
+    const h = parseFloat(hibikiHost.style.maxHeight);
+    if (w > 0 && h > 0) hibikiSendPopupSize(w, h);
+  };
+  grip.addEventListener('pointerdown', (e) => {
+    if (e.button !== undefined && e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    try { grip.setPointerCapture(e.pointerId); } catch (_) { /* 某些上下文无指针捕获 */ }
+    down(e.clientX, e.clientY);
+  });
+  grip.addEventListener('pointermove', (e) => {
+    if (!hibikiResizeDrag) return;
+    e.preventDefault();
+    move(e.clientX, e.clientY);
+  });
+  grip.addEventListener('pointerup', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try { grip.releasePointerCapture(e.pointerId); } catch (_) { /* 同上 */ }
+    up();
+  });
+  grip.addEventListener('pointercancel', () => { up(); });
+}
+
+// 确保拖拽把手已创建并挂到弹窗同父节点（fullscreenElement||body，与高亮层同源，全屏也可见）。
+function hibikiEnsureResizeGrip() {
+  const parent = document.fullscreenElement || document.body;
+  if (!parent) return;
+  if (!hibikiResizeGrip) {
+    const g = document.createElement('div');
+    g.id = 'hibiki-popup-resize-grip';
+    // 顶层 fixed；z-index 与 host 齐平（同值时 DOM 靠后者胜出 → 把手可点）；斜纹视觉暗示可拖。
+    g.style.cssText =
+      'position:fixed;left:0;top:0;width:' + HIBIKI_RESIZE_GRIP_SIZE + 'px;height:' +
+      HIBIKI_RESIZE_GRIP_SIZE + 'px;z-index:2147483647;cursor:nwse-resize;' +
+      'pointer-events:auto;touch-action:none;' +
+      'background:linear-gradient(135deg,transparent 0 46%,rgba(128,128,128,0.75) 46% 54%,' +
+      'transparent 54% 66%,rgba(128,128,128,0.75) 66% 74%,transparent 74%);';
+    hibikiInstallResizeDrag(g);
+    hibikiResizeGrip = g;
+  }
+  if (hibikiResizeGrip.parentNode !== parent) parent.appendChild(hibikiResizeGrip);
+}
+
 function hibikiRender(popupJson, termLen, theme, anchorRect) {
   const c = hibikiEnsureContainer();
   // BUG-530：查词响应带回当前 app 主题色（--md-*），套到弹窗容器上，弹窗实时跟随用户主题
@@ -1371,6 +1512,22 @@ function hibikiRender(popupJson, termLen, theme, anchorRect) {
       if (pos.maxHeight != null) hibikiHost.style.maxHeight = (pos.maxHeight / zoom) + 'px';
       hibikiHost.style.left = (pos.left / zoom) + 'px';
       hibikiHost.style.top = (pos.top / zoom) + 'px';
+      // Phase D：记录本次落点的视口可用空间夹取上下文（视口坐标；host fixed，pos.* 即视口系），
+      // 供拖拽把手把视口位移折回基准并夹取——不撑出视口、且拖大也不遮被查词（BUG-767 延续）。
+      // 弹窗落在词上方(pos.top<ay)时弹窗底不得越过词顶(ay-G)；否则(落词下方/无锚点)可长到视口底。
+      const resizeGap = 4;
+      const maxBottom = (wordRect && pos.top < ay)
+          ? (ay - resizeGap)
+          : (window.innerHeight - 8);
+      hibikiResizeBox = {
+        left: pos.left,
+        top: pos.top,
+        maxRight: window.innerWidth - 8,
+        maxBottom: maxBottom,
+        zoom: zoom,
+      };
+      hibikiEnsureResizeGrip();
+      hibikiPositionResizeGrip();
     }
     c.style.visibility = 'visible';
   };
@@ -1380,5 +1537,11 @@ function hibikiRender(popupJson, termLen, theme, anchorRect) {
 document.addEventListener('mousedown', (e) => {
   // BUG-688：shadow 内点击 e.target 被 retarget 成 hibikiHost，故 contains 判定天然把
   // 「点弹窗内部」算作命中（不关窗）；只有点 host 之外才关。
+  // Phase D：拖拽把手是 host 之外的顶层兄弟节点（避开 host 的 zoom 包含块），点它属正常操作
+  // （开始拖拽调尺寸），不能触发关窗——否则一按把手弹窗就没了。故命中把手也算「点在弹窗上」。
+  if (hibikiResizeGrip &&
+      (e.target === hibikiResizeGrip || hibikiResizeGrip.contains(e.target))) {
+    return;
+  }
   if (hibikiHost && !hibikiHost.contains(e.target)) hibikiRemoveContainer();
 });

--- a/hibiki/assets/popup/global_lookup_host.js
+++ b/hibiki/assets/popup/global_lookup_host.js
@@ -340,6 +340,15 @@
         '.global-lookup-frame-shell[data-theme="dark"] ' +
         '.global-lookup-close:hover{' +
         'background:rgba(235,235,245,0.16);color:rgba(235,235,245,0.92);}' +
+        // Phase C（弹窗尺寸精细化 2026-07-13）— 瞬态覆盖窗（cascade 模式）ROOT 卡的
+        // 右下角 resize grip：拖它进 native 模态 size 循环（beginWindowResize，与面板
+        // grip 同一通路）。必须挂在 SHELL 内（z-index 高于 iframe、pointer-events:auto），
+        // 因为瞬态窗被 native 按 shell 卡矩形做区域裁剪（BUG-749 gap click-through）——
+        // 挂在窗口层的角落 grip 会被裁掉不可见/不可点，只有 root 卡区域在裁剪区内。
+        // 透明无背景（cursor 提示可拖），与面板 grip 一致，避免遮挡卡片文字。
+        '.global-lookup-frame-shell .global-lookup-resize-grip{' +
+        'position:absolute;right:0;bottom:0;width:16px;height:16px;' +
+        'z-index:6;cursor:nwse-resize;pointer-events:auto;}' +
         // spec 2026-07-10 — panel top bar (grip + pin + close). Fixed to the
         // window top, above the root shell (which starts at PANEL_BAR_HEIGHT).
         // pointer-events:auto so the grip mousedown reaches the drag handler
@@ -738,6 +747,35 @@
     return btn;
   }
 
+  // Phase C（弹窗尺寸精细化 2026-07-13）— 瞬态覆盖窗 ROOT 卡的右下角 resize grip。
+  // mousedown 直接 postToHost('beginWindowResize')（host 顶层 DOM，无需 iframe 桥，
+  // 与面板 grip 一致）：native 收到后 PostMessage(WM_NCLBUTTONDOWN, HTBOTTOMRIGHT)
+  // 进模态 size 循环，松手经 WM_EXITSIZEMOVE 回报窗口 rect 给 Dart 落 overlay 尺寸键。
+  // preventDefault + stopPropagation(capture)：不让这次 mousedown 触发 host 的
+  // 点外关闭 / 拖出选区。返回 null 时（node harness 无 DOM）createRecord 照常健壮。
+  function createResizeGrip() {
+    if (!document || typeof document.createElement !== 'function') {
+      return null;
+    }
+    var grip = document.createElement('div');
+    grip.className = 'global-lookup-resize-grip';
+    grip.setAttribute('role', 'button');
+    grip.setAttribute('aria-label', 'Resize');
+    var onDown = function (event) {
+      if (event) {
+        if (typeof event.preventDefault === 'function') event.preventDefault();
+        if (typeof event.stopPropagation === 'function') {
+          event.stopPropagation();
+        }
+      }
+      postToHost('beginWindowResize', []);
+    };
+    if (typeof grip.addEventListener === 'function') {
+      grip.addEventListener('mousedown', onDown, true);
+    }
+    return grip;
+  }
+
   function createRecord(layer, descriptor) {
     var shell = document.createElement('div');
     shell.className = 'global-lookup-frame-shell';
@@ -770,6 +808,17 @@
     var closeBtn = createCloseButton(descriptor.id);
     if (closeBtn) {
       shell.appendChild(closeBtn);
+    }
+    // Phase C — 只给瞬态覆盖窗（cascade）的 ROOT 卡（parentIndex < 0）挂 resize grip：
+    // 调整的是 overlay「最大卡尺寸」真值，子级级联卡由它派生，故不各自加把手；面板
+    // 模式另有窗口级 #global-lookup-panel-resize，不在此重复。
+    if (layoutMode !== 'panel' && descriptor &&
+        typeof descriptor.parentIndex === 'number' &&
+        descriptor.parentIndex < 0) {
+      var grip = createResizeGrip();
+      if (grip) {
+        shell.appendChild(grip);
+      }
     }
     layer.appendChild(shell);
 

--- a/hibiki/lib/src/lookup/effective_lookup_size.dart
+++ b/hibiki/lib/src/lookup/effective_lookup_size.dart
@@ -114,3 +114,26 @@ LookupSize resolveOverlayResizeFromWindow({
       .clamp(minHeight, maxHeight);
   return LookupSize(width, height);
 }
+
+/// Phase D（2026-07-13）— 浏览器扩展弹窗被拖右下角把手调整尺寸后，content.js 经
+/// 扩展 ↔ app bridge（POST `/api/extension/popup-size`）回写的**基准（未缩放）最大
+/// 宽高**（逻辑像素）。扩展侧已按视口可用空间夹过一次并保证下限（不撑出屏幕、不遮被查
+/// 词），但**未夹 2000/1600 上界**（4K 屏视口空间可远超上界）。本函数把它 clamp 到与
+/// 设置页两滑杆同一 [kLookupPopupMinWidth]..[kLookupPopupMaxHeight] 单一同源——拖拽与
+/// 滑杆写同一真值，故 app 侧再兜底 clamp 一次，任何客户端（含异常/恶意值）都写不出越界
+/// 尺寸。非有限值（NaN/Inf）按下限兜底。纯函数（min/max 边界 + 非有限兜底），直接单测。
+LookupSize resolveExtensionPopupSize({
+  required double maxWidth,
+  required double maxHeight,
+  double minWidth = kLookupPopupMinWidth,
+  double maxWidthLimit = kLookupPopupMaxWidth,
+  double minHeight = kLookupPopupMinHeight,
+  double maxHeightLimit = kLookupPopupMaxHeight,
+}) {
+  final double w = maxWidth.isFinite ? maxWidth : minWidth;
+  final double h = maxHeight.isFinite ? maxHeight : minHeight;
+  return LookupSize(
+    w.clamp(minWidth, maxWidthLimit),
+    h.clamp(minHeight, maxHeightLimit),
+  );
+}

--- a/hibiki/lib/src/lookup/effective_lookup_size.dart
+++ b/hibiki/lib/src/lookup/effective_lookup_size.dart
@@ -79,3 +79,38 @@ LookupSize resolveDraggedLookupSize({
       (currentBaseHeight + deltaHeightPx / scale).clamp(minHeight, maxHeight);
   return LookupSize(width, height);
 }
+
+/// Phase C（2026-07-13）— 「app 外瞬态覆盖查词窗」被拖角调整尺寸后，native 模态
+/// size 循环结束回报**最终窗口物理像素**尺寸，本函数把它倒推回 overlay 场景的
+/// 「基准（未缩放）最大宽高」并 clamp。app 内拖拽写 [resolveDraggedLookupSize]（增量
+/// 折算），覆盖窗走这里（绝对窗口尺寸折算）——两者都不引入第二套「固定尺寸」概念，
+/// 只是把同一「最大宽高」真值换一种输入编辑。
+///
+/// 正向链（controller 算窗口物理尺寸，见 global_lookup_controller）：
+/// `cardW = overlayEffective.width × appUiScale`，再 `× dpr` 传 native 建窗，
+/// 故单卡窗口物理宽 ≈ `overlayLogicalW × uiScale × dpr`。倒推即：
+/// `overlayLogicalW = 窗口物理宽 / dpr / uiScale`。
+///
+/// [dpr] / [uiScale] 非正时按 1 兜底（不除零、不反向缩放）。结果先**下取整**到整
+/// 逻辑像素（避免一次拖拽因四舍五入把值顶上去 / 多次往返累积漂移），再 clamp 到
+/// [kLookupPopupMinWidth]..[kLookupPopupMaxHeight]——与滑杆同一 min/max 单一同源。
+/// 纯函数（含 dpr、uiScale、下取整、clamp 边界），直接单测。
+LookupSize resolveOverlayResizeFromWindow({
+  required double windowPhysicalWidth,
+  required double windowPhysicalHeight,
+  required double dpr,
+  required double uiScale,
+  double minWidth = kLookupPopupMinWidth,
+  double maxWidth = kLookupPopupMaxWidth,
+  double minHeight = kLookupPopupMinHeight,
+  double maxHeight = kLookupPopupMaxHeight,
+}) {
+  final double d = dpr > 0 ? dpr : 1.0;
+  final double s = uiScale > 0 ? uiScale : 1.0;
+  final double width =
+      (windowPhysicalWidth / d / s).floorToDouble().clamp(minWidth, maxWidth);
+  final double height = (windowPhysicalHeight / d / s)
+      .floorToDouble()
+      .clamp(minHeight, maxHeight);
+  return LookupSize(width, height);
+}

--- a/hibiki/lib/src/lookup/global_lookup_controller.dart
+++ b/hibiki/lib/src/lookup/global_lookup_controller.dart
@@ -682,9 +682,54 @@ class GlobalLookupController {
     onHidden?.call();
   }
 
+  /// Phase C（弹窗尺寸精细化 2026-07-13）— 覆盖窗拖角 resize 落库。native（模态
+  /// size 循环结束）回报的 [message] args = [left, top, width, height]（**窗口物理
+  /// px**）；只取 width/height 倒推 overlay 场景「基准最大宽高」（÷dpr ÷appUiScale +
+  /// 下取整 + clamp，见 [resolveOverlayResizeFromWindow]），再按「拖即解锁」好品味写
+  /// 真值：一动手定制 overlay 尺寸就脱钩「跟随 app 内」——
+  /// [AppModel.setOverlayLookupIndependentSize]`(true)` + 写 overlay 宽/高键。滑杆与
+  /// 拖拽写同一真值，下次查词沿用新尺寸（预期行为）。**绝不写 clipboardPanelRect /
+  /// popupMaxWidth**——那是剪贴板面板与 app 内弹窗各自的真值，串台就破坏它们。
+  void _onOverlayResized(Map<String, Object?> message) {
+    final AppModel? model = _appModel;
+    if (model == null) {
+      return;
+    }
+    final Object? args = message['args'];
+    if (args is! List || args.length < 4) {
+      return;
+    }
+    double num2(Object? v) => (v is num) ? v.toDouble() : 0;
+    final double physW = num2(args[2]);
+    final double physH = num2(args[3]);
+    if (physW <= 0 || physH <= 0) {
+      return;
+    }
+    final double dpr = _devicePixelRatio();
+    final LookupSize size = resolveOverlayResizeFromWindow(
+      windowPhysicalWidth: physW,
+      windowPhysicalHeight: physH,
+      dpr: dpr,
+      uiScale: model.appUiScale,
+    );
+    unawaited(model.setOverlayLookupIndependentSize(true));
+    model.setOverlayLookupMaxWidth(size.width);
+    model.setOverlayLookupMaxHeight(size.height);
+    glog('overlay resized -> unlock independent, ${size.width}x${size.height} '
+        '(phys=${physW}x$physH dpr=$dpr uiScale=${model.appUiScale})');
+  }
+
   void _onJsMessage(Map<String, Object?> message) {
     final Object? handler = message['handler'];
     glog('js: handler=$handler args=${message['args']}');
+    // Phase C（弹窗尺寸精细化 2026-07-13）— 瞬态覆盖窗被用户拖右下角 grip 调整
+    // 尺寸：native 模态 size 循环结束后经 WM_EXITSIZEMOVE 回报最终窗口 rect（物理
+    // px，args=[left,top,width,height]），与剪贴板面板走同一 windowMoved 通道，但
+    // 本实例（global_lookup channel）的去向只落 overlay 键。见 _onOverlayResized。
+    if (handler == 'windowMoved') {
+      _onOverlayResized(message);
+      return;
+    }
     if (handler == 'tapOutside' || handler == 'dismiss') {
       // TODO-867 P3c C3 — a tapOutside stamped with the source layer's frame id
       // (by the host shim) means "tap inside layer L outside its glossary" ->

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -3948,6 +3948,24 @@ class AppModel with ChangeNotifier {
         sharedHeight: popupMaxHeight,
       );
 
+  /// 弹窗尺寸精细化 Phase D：浏览器扩展弹窗被拖右下角把手调整尺寸后，content.js 经
+  /// 扩展 ↔ app bridge（POST `/api/extension/popup-size`）回写最终基准最大宽高，由
+  /// [YomitanApiServer] 的 `onExtensionPopupSize` sink 调到这里。先 clamp 到与设置页两滑杆
+  /// 同一 250-2000/200-1600（[resolveExtensionPopupSize]，任何异常/越界客户端都写不穿），
+  /// 再按「拖即解锁」好品味写真值：一动手定制扩展尺寸就脱钩「跟随 app 内」——置
+  /// [setExtensionPopupIndependentSize]`(true)` + 写 extension 宽/高键。滑杆与拖拽写同一真
+  /// 值，下次查词 [extensionPopupEffectiveSize] 以新值下发（预期行为）。**只写扩展键**，
+  /// 绝不碰 overlay / popupMax（app 内 / app 外覆盖窗各自的真值，串台即破坏它们）。
+  void _applyExtensionPopupSize(double maxWidth, double maxHeight) {
+    final LookupSize size = resolveExtensionPopupSize(
+      maxWidth: maxWidth,
+      maxHeight: maxHeight,
+    );
+    unawaited(setExtensionPopupIndependentSize(true));
+    setExtensionPopupMaxWidth(size.width);
+    setExtensionPopupMaxHeight(size.height);
+  }
+
   bool get popupInstantScroll => prefsRepo.popupInstantScroll;
   Future<void> setPopupInstantScroll(bool value) =>
       prefsRepo.setPopupInstantScroll(value);
@@ -4396,6 +4414,10 @@ class AppModel with ChangeNotifier {
       // 与自身 HIBIKI_DEFAULTS.build 比对，不一致即 chrome.runtime.reload() 从磁盘拉新。
       // 指纹由 refreshBrowserExtensionCopy 在启动时算好缓存；算好前返回 null（字段省略）。
       extensionBuildProvider: () => _browserExtensionBuild,
+      // 弹窗尺寸精细化 Phase D：扩展弹窗被拖角调整尺寸后经 bridge 回写的 sink——clamp + 拖即
+      // 解锁 + 只写扩展键（下次查词 browserExtensionThemeColors 读新 extensionPopupEffectiveSize
+      // 即以新尺寸下发，闭环）。
+      onExtensionPopupSize: _applyExtensionPopupSize,
       tokenizer: JapaneseLanguage.instance.textToWords,
       readingResolver: (String w) {
         if (!HoshiDicts.isInitialized) return '';

--- a/hibiki/lib/src/sync/yomitan_api_server.dart
+++ b/hibiki/lib/src/sync/yomitan_api_server.dart
@@ -44,6 +44,7 @@ class YomitanApiServer {
     Map<String, String> Function()? themeColorsProvider,
     List<String> Function()? audioSourcesProvider,
     String? Function()? extensionBuildProvider,
+    void Function(double maxWidth, double maxHeight)? onExtensionPopupSize,
     String? apiKey,
     bool allowLan = false,
   })  : _requestedPort = port,
@@ -55,6 +56,7 @@ class YomitanApiServer {
         _themeColorsProvider = themeColorsProvider,
         _audioSourcesProvider = audioSourcesProvider,
         _extensionBuildProvider = extensionBuildProvider,
+        _onExtensionPopupSize = onExtensionPopupSize,
         _apiKey = apiKey,
         _allowLan = allowLan;
 
@@ -70,6 +72,10 @@ class YomitanApiServer {
   final List<String> Function()? _audioSourcesProvider;
   // BUG-726：app 内置扩展内容指纹供给器，随查词响应下发，驱动扩展自 reload 拉新。
   final String? Function()? _extensionBuildProvider;
+  // 弹窗尺寸精细化 Phase D：扩展弹窗被拖角调整尺寸后，content.js 经 bridge 回写最终基准
+  // 最大宽高；这个 sink 收到（未 clamp 的原始逻辑像素）→ app 侧 clamp + 拖即解锁 + 写扩展键。
+  // 未注入（旧 app / 配对 sync host）时端点 404（向后兼容，无写偏好副作用）。
+  final void Function(double maxWidth, double maxHeight)? _onExtensionPopupSize;
   final String? _apiKey;
   final bool _allowLan;
 
@@ -210,6 +216,8 @@ class YomitanApiServer {
         return _handleMine(request);
       case '/api/duplicate':
         return _handleDuplicate(request);
+      case '/api/extension/popup-size':
+        return _handleExtensionPopupSize(request);
       default:
         return shelf.Response.notFound('Unknown endpoint');
     }
@@ -254,6 +262,27 @@ class YomitanApiServer {
       return _json(<String, dynamic>{'duplicate': false});
     }
     return _json(await buildRemoteDuplicateResponse(body, mining: mining));
+  }
+
+  /// 弹窗尺寸精细化 Phase D：浏览器扩展弹窗被拖右下角把手调整尺寸后，content.js 经
+  /// background（POST `/api/extension/popup-size` {maxWidth,maxHeight}）回写最终基准最大宽
+  /// 高。走与查词同一 [_authMiddleware]（Basic `hibiki:'+key`）鉴权——**不在**免鉴权白名
+  /// 单里，绝不新开无鉴权写入口。收到 → 交给注入的 [_onExtensionPopupSize] sink（app 侧
+  /// clamp 250-2000/200-1600 + 「拖即解锁」extensionPopupIndependentSize + 只写扩展键，
+  /// 绝不碰 overlay/popupMax）。未注入（旧 app / 配对 host）时 404，无副作用（向后兼容）。
+  Future<shelf.Response> _handleExtensionPopupSize(
+      shelf.Request request) async {
+    final void Function(double, double)? sink = _onExtensionPopupSize;
+    if (sink == null) return shelf.Response.notFound('Popup size sink off');
+    final Map<String, dynamic>? body = await _readJson(request);
+    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
+    final dynamic w = body['maxWidth'];
+    final dynamic h = body['maxHeight'];
+    if (w is! num || h is! num) {
+      return shelf.Response(400, body: 'Missing maxWidth/maxHeight');
+    }
+    sink(w.toDouble(), h.toDouble());
+    return _json(<String, dynamic>{'ok': true});
   }
 
   /// 单词音频①解析：POST /api/lookup/audio {expression,reading}。用与 app 同一

--- a/hibiki/lib/src/sync/yomitan_api_server_manager.dart
+++ b/hibiki/lib/src/sync/yomitan_api_server_manager.dart
@@ -15,6 +15,7 @@ class YomitanApiServerManager {
     Map<String, String> Function()? themeColorsProvider,
     List<String> Function()? audioSourcesProvider,
     String? Function()? extensionBuildProvider,
+    void Function(double maxWidth, double maxHeight)? onExtensionPopupSize,
   })  : _lookup = lookupService,
         _mining = miningService,
         _history = historyService,
@@ -22,7 +23,8 @@ class YomitanApiServerManager {
         _readingResolver = readingResolver,
         _themeColorsProvider = themeColorsProvider,
         _audioSourcesProvider = audioSourcesProvider,
-        _extensionBuildProvider = extensionBuildProvider;
+        _extensionBuildProvider = extensionBuildProvider,
+        _onExtensionPopupSize = onExtensionPopupSize;
 
   final HibikiRemoteLookupService _lookup;
   final HibikiRemoteMiningService? _mining;
@@ -35,6 +37,8 @@ class YomitanApiServerManager {
   final List<String> Function()? _audioSourcesProvider;
   // BUG-726：扩展内容指纹供给器，透传给 [YomitanApiServer]，驱动扩展自 reload 拉新。
   final String? Function()? _extensionBuildProvider;
+  // 弹窗尺寸精细化 Phase D：扩展弹窗拖角调整后回写尺寸的 sink，透传给 [YomitanApiServer]。
+  final void Function(double maxWidth, double maxHeight)? _onExtensionPopupSize;
 
   YomitanApiServer? _server;
 
@@ -53,6 +57,7 @@ class YomitanApiServerManager {
       themeColorsProvider: _themeColorsProvider,
       audioSourcesProvider: _audioSourcesProvider,
       extensionBuildProvider: _extensionBuildProvider,
+      onExtensionPopupSize: _onExtensionPopupSize,
       apiKey: apiKey.isEmpty ? null : apiKey,
       allowLan: true,
     );

--- a/hibiki/test/lookup/effective_lookup_size_test.dart
+++ b/hibiki/test/lookup/effective_lookup_size_test.dart
@@ -71,6 +71,79 @@ void main() {
       expect(independent(2000, 1600), const LookupSize(640, 480));
     });
 
+    test('resolveOverlayResizeFromWindow — 覆盖窗拖角倒推 + 解锁真值', () {
+      // 正向：cardW = overlayLogicalW × uiScale，窗口物理宽 = cardW × dpr。
+      // 取 overlayLogicalW=600, uiScale=1.25, dpr=1.5 → 物理宽 = 600×1.25×1.5 = 1125。
+      final LookupSize size = resolveOverlayResizeFromWindow(
+        windowPhysicalWidth: 1125,
+        windowPhysicalHeight: 900, // 480×1.25×1.5 = 900 → 逻辑高 480
+        dpr: 1.5,
+        uiScale: 1.25,
+      );
+      expect(size, const LookupSize(600, 480));
+    });
+
+    test('resolveOverlayResizeFromWindow — dpr/uiScale 非正按 1 兜底（不除零）', () {
+      final LookupSize size = resolveOverlayResizeFromWindow(
+        windowPhysicalWidth: 800,
+        windowPhysicalHeight: 600,
+        dpr: 0,
+        uiScale: -1,
+      );
+      expect(size, const LookupSize(800, 600));
+    });
+
+    test('resolveOverlayResizeFromWindow — 下取整到整逻辑像素', () {
+      // 900.9 / 1 / 1 = 900.9 → floor 900；700.2 → 700。
+      final LookupSize size = resolveOverlayResizeFromWindow(
+        windowPhysicalWidth: 900.9,
+        windowPhysicalHeight: 700.2,
+        dpr: 1,
+        uiScale: 1,
+      );
+      expect(size, const LookupSize(900, 700));
+    });
+
+    test('resolveOverlayResizeFromWindow — clamp 到滑杆同源 min/max', () {
+      // 过小 → 夹到 (250,200)；过大 → 夹到 (2000,1600)。
+      final LookupSize tiny = resolveOverlayResizeFromWindow(
+        windowPhysicalWidth: 10,
+        windowPhysicalHeight: 10,
+        dpr: 1,
+        uiScale: 1,
+      );
+      expect(
+          tiny, const LookupSize(kLookupPopupMinWidth, kLookupPopupMinHeight));
+      final LookupSize huge = resolveOverlayResizeFromWindow(
+        windowPhysicalWidth: 99999,
+        windowPhysicalHeight: 99999,
+        dpr: 1,
+        uiScale: 1,
+      );
+      expect(
+          huge, const LookupSize(kLookupPopupMaxWidth, kLookupPopupMaxHeight));
+    });
+
+    test('resolveOverlayResizeFromWindow — 拖出的尺寸即解锁独立键的写入值', () {
+      // 语义验证：倒推值直接作为 overlayLookupMaxWidth/Height 写入，effective 在
+      // independent=true 下即读它——拖拽与滑杆写同一真值。
+      final LookupSize dragged = resolveOverlayResizeFromWindow(
+        windowPhysicalWidth: 1400,
+        windowPhysicalHeight: 1000,
+        dpr: 2,
+        uiScale: 1,
+      );
+      expect(dragged, const LookupSize(700, 500));
+      final LookupSize effective = effectiveLookupSize(
+        independent: true,
+        sceneWidth: dragged.width,
+        sceneHeight: dragged.height,
+        sharedWidth: 400,
+        sharedHeight: 360,
+      );
+      expect(effective, const LookupSize(700, 500));
+    });
+
     test('默认场景键 == app 内默认（解锁瞬间不跳尺寸）', () {
       // 场景键默认值应等于 app 内默认（400×360），使 independent 从 false→true 的
       // 那一刻有效尺寸不变——这是「一动手才脱钩」好品味的前提。

--- a/hibiki/test/lookup/effective_lookup_size_test.dart
+++ b/hibiki/test/lookup/effective_lookup_size_test.dart
@@ -166,4 +166,42 @@ void main() {
       expect(unlocked, followed);
     });
   });
+
+  group('resolveExtensionPopupSize（Phase D — 扩展拖角回写 clamp）', () {
+    test('范围内尺寸原样透传', () {
+      expect(resolveExtensionPopupSize(maxWidth: 640, maxHeight: 520),
+          const LookupSize(640, 520));
+    });
+
+    test('超上界夹到 2000×1600（4K 屏视口空间远超上界）', () {
+      // 扩展侧只按视口可用空间夹（可远超上界），app 侧必须再兜底夹到滑杆同款上界。
+      expect(resolveExtensionPopupSize(maxWidth: 5000, maxHeight: 4000),
+          const LookupSize(kLookupPopupMaxWidth, kLookupPopupMaxHeight));
+    });
+
+    test('低于下界夹到 250×200', () {
+      expect(resolveExtensionPopupSize(maxWidth: 10, maxHeight: 10),
+          const LookupSize(kLookupPopupMinWidth, kLookupPopupMinHeight));
+    });
+
+    test('非有限值（NaN/Inf）按下限兜底', () {
+      expect(
+          resolveExtensionPopupSize(
+              maxWidth: double.nan, maxHeight: double.infinity),
+          const LookupSize(kLookupPopupMinWidth, kLookupPopupMinHeight));
+    });
+
+    test('clamp 后即扩展场景独立键的写入值（拖拽与滑杆写同一真值）', () {
+      final LookupSize dragged =
+          resolveExtensionPopupSize(maxWidth: 720, maxHeight: 600);
+      final LookupSize effective = effectiveLookupSize(
+        independent: true,
+        sceneWidth: dragged.width,
+        sceneHeight: dragged.height,
+        sharedWidth: 400,
+        sharedHeight: 360,
+      );
+      expect(effective, const LookupSize(720, 600));
+    });
+  });
 }

--- a/hibiki/test/lookup/overlay_resize_wiring_guard_test.dart
+++ b/hibiki/test/lookup/overlay_resize_wiring_guard_test.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Phase C（弹窗尺寸精细化 2026-07-13）源码级 guard。
+///
+/// 「app 外瞬态覆盖查词窗拖角 resize」这条链横跨三个无法在本环境运行验证的表面：
+/// host.js（渲染 grip）→ C++（模态 size 循环 + 回报 rect + 拖拽期挂起区域裁剪）→
+/// Dart controller（windowMoved → 倒推 → 解锁 + 写 overlay 键）。纯函数倒推由
+/// [effective_lookup_size_test.dart] 单测守住；本 guard 直接对三处源码断言接线令牌
+/// 存在，捕获「接线被删/改名」这一行为测试照样绿的失败场景。重命名回调可同步更新清单。
+void main() {
+  group('Phase C 覆盖窗 resize 接线', () {
+    test('host.js — 瞬态 overlay ROOT 卡渲染右下角 resize grip 发 beginWindowResize',
+        () {
+      final File file = File('assets/popup/global_lookup_host.js');
+      expect(file.existsSync(), isTrue);
+      final String src = file.readAsStringSync();
+      // grip 元素 + 创建函数 + 发同一 native 通路 + 只在 cascade（非 panel）ROOT 挂。
+      expect(src.contains('global-lookup-resize-grip'), isTrue,
+          reason: 'grip 的 class/CSS 被删——覆盖窗拖不动');
+      expect(src.contains('function createResizeGrip'), isTrue,
+          reason: 'createResizeGrip 接线被删');
+      expect(src.contains("postToHost('beginWindowResize'"), isTrue,
+          reason: 'grip 未发 beginWindowResize——进不了 native 模态 size 循环');
+      expect(src.contains("layoutMode !== 'panel'"), isTrue,
+          reason: 'grip 未按 cascade 门控——会漏挂到面板或漏挂瞬态窗');
+    });
+
+    test('controller — windowMoved 落 overlay 键（拖即解锁）且不串 panel/app 内键', () {
+      final File file = File('lib/src/lookup/global_lookup_controller.dart');
+      expect(file.existsSync(), isTrue);
+      final String src = file.readAsStringSync();
+      expect(src.contains("handler == 'windowMoved'"), isTrue,
+          reason: 'overlay 未接 windowMoved 回报——拖完不落库');
+      expect(src.contains('resolveOverlayResizeFromWindow'), isTrue,
+          reason: '倒推未走同源纯函数');
+      expect(src.contains('setOverlayLookupIndependentSize'), isTrue,
+          reason: '拖动未解锁 overlay 独立尺寸');
+      expect(src.contains('setOverlayLookupMaxWidth'), isTrue);
+      expect(src.contains('setOverlayLookupMaxHeight'), isTrue);
+      // 红线：覆盖窗 controller 绝不写另外两个表面的真值。
+      expect(src.contains('setClipboardPanelRect'), isFalse,
+          reason: '覆盖窗 resize 串写了剪贴板面板 rect——破坏面板');
+      expect(src.contains('setPopupMaxWidth'), isFalse,
+          reason: '覆盖窗 resize 串写了 app 内共享键——破坏 app 内弹窗');
+    });
+
+    test('C++ — 瞬态窗放开模态 resize + 拖拽期挂起 shell 区域裁剪', () {
+      final File file = File('windows/runner/global_lookup_window.cpp');
+      expect(file.existsSync(), isTrue);
+      final String src = file.readAsStringSync();
+      expect(src.contains('WM_ENTERSIZEMOVE'), isTrue,
+          reason: '未在进入模态 size 循环时挂起区域裁剪');
+      expect(src.contains('resizing_'), isTrue,
+          reason: 'resizing_ 门控被删——拖拽时窗口区域钉死旧卡，看不到变大');
+      // 回报最终 rect 的通道保留（WM_EXITSIZEMOVE + windowMoved）。
+      expect(src.contains('WM_EXITSIZEMOVE'), isTrue);
+      expect(src.contains('windowMoved'), isTrue,
+          reason: 'WM_EXITSIZEMOVE 不再回报窗口 rect——拖完不落库');
+    });
+
+    test('C++ header — resizing_ 成员存在', () {
+      final File file = File('windows/runner/global_lookup_window.h');
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsStringSync().contains('bool resizing_'), isTrue);
+    });
+  });
+}

--- a/hibiki/test/sync/yomitan_api_server_extension_endpoints_test.dart
+++ b/hibiki/test/sync/yomitan_api_server_extension_endpoints_test.dart
@@ -126,6 +126,7 @@ void main() {
       Map<String, String> Function()? themeColorsProvider,
       List<String> Function()? audioSourcesProvider,
       String? Function()? extensionBuildProvider,
+      void Function(double maxWidth, double maxHeight)? onExtensionPopupSize,
     }) async {
       lookup = _FakeLookup();
       mining = _FakeMining();
@@ -138,6 +139,7 @@ void main() {
         themeColorsProvider: themeColorsProvider,
         audioSourcesProvider: audioSourcesProvider,
         extensionBuildProvider: extensionBuildProvider,
+        onExtensionPopupSize: onExtensionPopupSize,
         apiKey: apiKey,
       );
       await server.start();
@@ -440,6 +442,99 @@ void main() {
       );
       expect(resp.statusCode, 401);
       await resp.drain<void>();
+    });
+
+    // 弹窗尺寸精细化 Phase D：扩展拖角 resize 回写端点 /api/extension/popup-size。
+    test('/api/extension/popup-size 把原始尺寸交给 sink（未 clamp，clamp 在 app 侧）',
+        () async {
+      double? gotW;
+      double? gotH;
+      await startServer(
+        apiKey: 'k123',
+        onExtensionPopupSize: (double w, double h) {
+          gotW = w;
+          gotH = h;
+        },
+      );
+      final HttpClientResponse resp = await _post(
+        server.port,
+        '/api/extension/popup-size',
+        <String, dynamic>{'maxWidth': 720, 'maxHeight': 600},
+        auth: _basic('k123'),
+      );
+      expect(resp.statusCode, 200);
+      expect((await _json(resp))['ok'], true);
+      // server 不 clamp（透传原始值给 app 侧 resolveExtensionPopupSize）。
+      expect(gotW, 720);
+      expect(gotH, 600);
+    });
+
+    test('/api/extension/popup-size 数值型 int/double 都接受', () async {
+      double? gotW;
+      double? gotH;
+      await startServer(
+        apiKey: 'k123',
+        onExtensionPopupSize: (double w, double h) {
+          gotW = w;
+          gotH = h;
+        },
+      );
+      final HttpClientResponse resp = await _post(
+        server.port,
+        '/api/extension/popup-size',
+        <String, dynamic>{'maxWidth': 640.5, 'maxHeight': 480},
+        auth: _basic('k123'),
+      );
+      expect(resp.statusCode, 200);
+      expect(gotW, 640.5);
+      expect(gotH, 480.0);
+    });
+
+    test('/api/extension/popup-size 缺字段/类型错 → 400，不触发 sink', () async {
+      bool called = false;
+      await startServer(
+        apiKey: 'k123',
+        onExtensionPopupSize: (double w, double h) => called = true,
+      );
+      final HttpClientResponse resp = await _post(
+        server.port,
+        '/api/extension/popup-size',
+        <String, dynamic>{'maxWidth': 'wide'},
+        auth: _basic('k123'),
+      );
+      expect(resp.statusCode, 400);
+      await resp.drain<void>();
+      expect(called, isFalse);
+    });
+
+    test('/api/extension/popup-size 未注入 sink → 404（旧 app / 配对 host 向后兼容）',
+        () async {
+      await startServer(apiKey: 'k123'); // onExtensionPopupSize 缺省 null
+      final HttpClientResponse resp = await _post(
+        server.port,
+        '/api/extension/popup-size',
+        <String, dynamic>{'maxWidth': 720, 'maxHeight': 600},
+        auth: _basic('k123'),
+      );
+      expect(resp.statusCode, 404);
+      await resp.drain<void>();
+    });
+
+    test('/api/extension/popup-size 错 token → 401，不触发 sink（鉴权守卫）', () async {
+      bool called = false;
+      await startServer(
+        apiKey: 'k123',
+        onExtensionPopupSize: (double w, double h) => called = true,
+      );
+      final HttpClientResponse resp = await _post(
+        server.port,
+        '/api/extension/popup-size',
+        <String, dynamic>{'maxWidth': 720, 'maxHeight': 600},
+        auth: _basic('WRONG'),
+      );
+      expect(resp.statusCode, 401);
+      await resp.drain<void>();
+      expect(called, isFalse);
     });
   });
 }

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -1294,7 +1294,11 @@ void GlobalLookupWindow::ApplyRoundedRegion() {
   }
   // 10 logical px radius -> diameter = 20 logical px, scaled to physical px.
   const int diameter = MulDiv(20, static_cast<int>(dpi), 96);
-  if (!shell_rects_css_.empty()) {
+  // Phase C（弹窗尺寸精细化 2026-07-13）— 用户正拖右下角 grip 调整瞬态窗尺寸时，跳过
+  // shell 卡矩形裁剪、临时用整窗区域，让窗口可见地随拖拽增长（否则区域钉死在旧卡矩形，
+  // 拖拽毫无视觉变化）。WM_EXITSIZEMOVE 结束时 resizing_=false 并重新 ApplyRoundedRegion
+  // 复原 shell 裁剪。面板实例 shell_rects_css_ 恒空，本就走整窗区域，此条件对它是 no-op。
+  if (!shell_rects_css_.empty() && !resizing_) {
     const double dpr = static_cast<double>(dpi) / 96.0;
     HRGN union_region = CreateRectRgn(0, 0, 0, 0);
     if (union_region != nullptr) {
@@ -1427,13 +1431,22 @@ LRESULT GlobalLookupWindow::HandleMessage(UINT message, WPARAM wparam,
       // border supplies the card frame, this region supplies the rounded corners.
       ApplyRoundedRegion();
       return 0;
+    case WM_ENTERSIZEMOVE:
+      // Phase C（弹窗尺寸精细化 2026-07-13）— 进入模态 move/size 循环（面板拖动/调整，
+      // 或 —— Phase C 起 —— 瞬态覆盖窗拖右下角 grip）。瞬态窗平时按 shell 卡矩形裁剪
+      // 窗口区域，裁剪区不随窗口增大 → 拖拽看不到窗口变大；置 resizing_ 并立即重算区域，
+      // 拖拽期间改用整窗区域（见 ApplyRoundedRegion）。面板实例区域本就是整窗，此为 no-op。
+      resizing_ = true;
+      ApplyRoundedRegion();
+      return 0;
     case WM_EXITSIZEMOVE: {
-      // spec 2026-07-10 panel — the modal move/size loop (entered via the
-      // posted WM_NCLBUTTONDOWN HTCAPTION/HTBOTTOMRIGHT, see the
-      // beginWindowDrag intercept) just ended: report the final rect so Dart
-      // persists the panel position/size. The transient lookup overlay never
-      // enters a modal loop (no drag chrome), so this only ever fires for the
-      // panel instance.
+      // 模态 move/size 循环结束（面板拖动/调整，或 Phase C 起的瞬态覆盖窗拖角 resize）：
+      // 回报最终窗口 rect（物理 px）供 Dart 持久化。同一 windowMoved 通道，两实例各自的
+      // message_cb_ 落不同真值——面板落 clipboardPanelRect，瞬态窗落 overlay 尺寸键（Dart
+      // 侧按实例区分去向，见各自 controller 的 _onJsMessage / windowMoved 分支）。
+      // Phase C — 先复原 resize 期间临时挂起的 shell 区域裁剪（resizing_ 归零后重算）。
+      resizing_ = false;
+      ApplyRoundedRegion();
       if (message_cb_ && hwnd_ != nullptr) {
         RECT r{};
         GetWindowRect(hwnd_, &r);

--- a/hibiki/windows/runner/global_lookup_window.h
+++ b/hibiki/windows/runner/global_lookup_window.h
@@ -237,6 +237,12 @@ class GlobalLookupWindow {
   // cache into pending_json_ until NavigationCompleted re-arms
   // webview_ready_.
   bool recovering_ = false;
+  // Phase C（弹窗尺寸精细化 2026-07-13）— 用户正拖右下角 grip 调整窗口尺寸（在
+  // WM_ENTERSIZEMOVE..WM_EXITSIZEMOVE 之间为 true）。瞬态覆盖窗平时按 shell 卡矩形
+  // 裁剪窗口区域（BUG-749 gap click-through），裁剪区不随窗口增大 → 拖拽看不到窗口
+  // 变大；resize 期间 ApplyRoundedRegion 改用整窗区域，让窗口可见地随拖拽增长，结束
+  // 复原 shell 裁剪。面板实例 shell_rects_css_ 为空，此标志对它无副作用。
+  bool resizing_ = false;
   // spec 2026-07-10 — panel-instance data knobs (defaults == the historical
   // lookup-overlay behaviour, so the first instance is byte-for-byte unchanged).
   bool arm_dismiss_hooks_ = true;

--- a/tools/browser-extension/background.js
+++ b/tools/browser-extension/background.js
@@ -170,6 +170,17 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         // base URL + token to build GET /api/media/dictionary. Same source as
         // lookup/mine (cfg()): installer-injected defaults or options override.
         sendResponse({ ok: true, base, token });
+      } else if (msg.type === 'popupSize') {
+        // 弹窗尺寸精细化 Phase D：content.js 拖弹窗右下角把手松手后，把最终基准最大宽高经此
+        // 回写 app（POST /api/extension/popup-size，Basic auth 与查词同源）。app 侧 clamp
+        // (250-2000/200-1600) + 「拖即解锁」extensionPopupIndependentSize=true + 写扩展键，
+        // 下次查词以新尺寸下发。lookup 样板同款鉴权头，不新开无鉴权入口。
+        const r = await fetch(base + '/api/extension/popup-size', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
+          body: JSON.stringify({ maxWidth: msg.maxWidth, maxHeight: msg.maxHeight }),
+        });
+        sendResponse({ ok: r.ok, status: r.status });
       } else if (msg.type === 'lookup') {
         const r = await fetch(base + '/api/lookup/dictionary', {
           method: 'POST',

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -1054,13 +1054,6 @@ function hibikiRemoveContainer() {
   if (hibikiHost) { hibikiHost.remove(); hibikiHost = null; }
   hibikiContainer = null;
   window.__hibikiRoot = null;
-  // Phase D：关窗即撤拖拽把手 + 清尺寸拖拽状态（把手随弹窗生命周期，下次开窗 place() 重建）。
-  if (hibikiResizeGrip) {
-    try { hibikiResizeGrip.remove(); } catch (_) { /* 已脱离文档 */ }
-    hibikiResizeGrip = null;
-  }
-  hibikiResizeDrag = null;
-  hibikiResizeBox = null;
   // TODO-1272：关窗即撤覆盖层高亮（被查词高亮跟随弹窗生命周期，弹窗在则在、弹窗关则撤）。
   hibikiClearHighlightOverlay();
   // TODO-1150（yomitan 式）：关窗即撤 selection 状态与任何 DOM 包裹高亮（嵌套查词用）。hoshiSelection 未加载/无选区时是 no-op。
@@ -1069,6 +1062,13 @@ function hibikiRemoveContainer() {
       window.hoshiSelection.clearSelection();
     }
   } catch (_) { /* no-op */ }
+  // Phase D：关窗即撤拖拽把手 + 清尺寸拖拽状态（把手随弹窗生命周期，下次开窗 place() 重建）。
+  if (hibikiResizeGrip) {
+    try { hibikiResizeGrip.remove(); } catch (_) { /* 已脱离文档 */ }
+    hibikiResizeGrip = null;
+  }
+  hibikiResizeDrag = null;
+  hibikiResizeBox = null;
 }
 
 // 流媒体字幕的取词兜底：Netflix 等在字幕**上面**盖了视频覆盖层（如 .watch-video--flag-container），

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -1355,6 +1355,7 @@ function hibikiInstallResizeDrag(grip) {
     const baseH = hibikiHost.getBoundingClientRect().height / z;
     hibikiResizeDrag = {
       startX: x, startY: y, baseW: baseW, baseH: baseH, zoom: z,
+      moved: false,
       bounds: {
         minW: HIBIKI_POPUP_MIN_WIDTH, minH: HIBIKI_POPUP_MIN_HEIGHT,
         // 视口可用空间（右/下边界 − 弹窗左上角）÷zoom = 基准尺度上界；不撑出视口、不遮被查词。
@@ -1366,6 +1367,10 @@ function hibikiInstallResizeDrag(grip) {
   const move = (x, y) => {
     if (!hibikiResizeDrag || !hibikiHost) return;
     const d = hibikiResizeDrag;
+    // 位移超阈值才算真拖拽（区分纯点击与拖动，见 up() 的「拖即解锁」门控）。
+    if (!d.moved && Math.abs(x - d.startX) + Math.abs(y - d.startY) > 3) {
+      d.moved = true;
+    }
     const size = hibikiComputeResizedSize(
       { width: d.baseW, height: d.baseH },
       { dx: x - d.startX, dy: y - d.startY },
@@ -1375,8 +1380,11 @@ function hibikiInstallResizeDrag(grip) {
     hibikiPositionResizeGrip();
   };
   const up = () => {
-    if (!hibikiResizeDrag || !hibikiHost) { hibikiResizeDrag = null; return; }
+    const d = hibikiResizeDrag;
     hibikiResizeDrag = null;
+    // 拖即解锁：仅当本次确实拖动过（位移超阈值）才回写尺寸 + 翻 independent；
+    // 纯点击（把手盖住的内容点击）不脱钩「跟随 app 内尺寸」（BUG review LOW）。
+    if (!d || !hibikiHost || !d.moved) return;
     const w = parseFloat(hibikiHost.style.width);
     const h = parseFloat(hibikiHost.style.maxHeight);
     if (w > 0 && h > 0) hibikiSendPopupSize(w, h);

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -32,6 +32,16 @@ let hibikiLastX = -1;
 let hibikiLastY = -1;
 let hibikiPending = false;
 
+// 弹窗尺寸精细化 Phase D：拖拽调整扩展弹窗尺寸。
+// hibikiResizeGrip：右下角拖拽把手（顶层 position:fixed overlay，与高亮层同父挂在
+//   fullscreenElement||body；不放进 host 的 shadow，避开 host 的 zoom 建立包含块干扰 fixed）。
+// hibikiResizeBox：place() 每次落点后存的夹取上下文——弹窗视口左上角 + 视口可用空间右/下边界
+//   （已内含 BUG-767「拖大也不许遮住被查词」约束）+ 当前 zoom，供拖拽把「视口位移」折回基准尺度。
+// hibikiResizeDrag：一次拖拽的起始快照 {startX,startY,baseW,baseH,zoom,bounds}；null=未在拖。
+let hibikiResizeGrip = null;
+let hibikiResizeBox = null;
+let hibikiResizeDrag = null;
+
 // 扩展重载/更新/禁用后，已注入到**已打开标签**里的旧 content script 会「上下文失效」：
 // chrome.runtime 变 undefined / 访问抛异常 → 再调 chrome.runtime.sendMessage 就报
 // 「Cannot read properties of undefined (reading 'sendMessage')」。守卫掉：失效即静默停手，
@@ -1044,6 +1054,13 @@ function hibikiRemoveContainer() {
   if (hibikiHost) { hibikiHost.remove(); hibikiHost = null; }
   hibikiContainer = null;
   window.__hibikiRoot = null;
+  // Phase D：关窗即撤拖拽把手 + 清尺寸拖拽状态（把手随弹窗生命周期，下次开窗 place() 重建）。
+  if (hibikiResizeGrip) {
+    try { hibikiResizeGrip.remove(); } catch (_) { /* 已脱离文档 */ }
+    hibikiResizeGrip = null;
+  }
+  hibikiResizeDrag = null;
+  hibikiResizeBox = null;
   // TODO-1272：关窗即撤覆盖层高亮（被查词高亮跟随弹窗生命周期，弹窗在则在、弹窗关则撤）。
   hibikiClearHighlightOverlay();
   // TODO-1150（yomitan 式）：关窗即撤 selection 状态与任何 DOM 包裹高亮（嵌套查词用）。hoshiSelection 未加载/无选区时是 no-op。
@@ -1281,6 +1298,130 @@ function hibikiComputePlacement(anchor, size, viewport) {
   return { left, top, maxHeight };
 }
 
+// 弹窗尺寸精细化 Phase D：拖拽右下角把手把「起始基准最大宽高 + 本次累计位移」折算成新的基准
+// （未缩放）最大宽高并 clamp。纯函数（不碰 DOM），便于单测。
+// start：拖拽开始时的基准 {width, height}（= host.style.width / 渲染高÷zoom，未乘 zoom）。
+// delta：指针在视口(**已缩放**)坐标系里的累计位移 {dx, dy}；除以 zoom 折回基准尺度
+//   （与 place() 里 `pos.left / zoom` 折算同源——host 带 zoom，视口位移 = 基准位移 × zoom）。
+// bounds：{minW, minH, maxW, maxH}（基准尺度上下限；maxW/maxH 由视口可用空间÷zoom 得来，已内含
+//   BUG-767「不遮词」约束）。zoom<=0 按 1 兜底（不除零）。clamp 上界恒 >= 下界（视口过小也不倒挂）。
+function hibikiComputeResizedSize(start, delta, zoom, bounds) {
+  const z = zoom > 0 ? zoom : 1;
+  const clamp = (v, lo, hi) => Math.min(Math.max(v, lo), Math.max(lo, hi));
+  const width = clamp(start.width + delta.dx / z, bounds.minW, bounds.maxW);
+  const height = clamp(start.height + delta.dy / z, bounds.minH, bounds.maxH);
+  return { width: width, height: height };
+}
+
+// 基准最大宽/高的允许范围（逻辑像素）。与 app 设置页两滑杆 + Dart 侧
+// effective_lookup_size.dart 的 kLookupPopupMin/MaxWidth/Height 单一同源——拖拽与滑杆写同一
+// 真值，故边界必须一致，否则拖拽能写出滑杆写不出的越界值（app 侧仍会再 clamp 一次兜底）。
+const HIBIKI_POPUP_MIN_WIDTH = 250;
+const HIBIKI_POPUP_MIN_HEIGHT = 200;
+const HIBIKI_RESIZE_GRIP_SIZE = 18;
+
+// 把拖拽把手移到弹窗当前渲染矩形的右下角（视口坐标；host 是 fixed，坐标即视口系）。
+function hibikiPositionResizeGrip() {
+  if (!hibikiResizeGrip || !hibikiHost) return;
+  const r = hibikiHost.getBoundingClientRect();
+  const s = HIBIKI_RESIZE_GRIP_SIZE;
+  hibikiResizeGrip.style.left = (r.right - s) + 'px';
+  hibikiResizeGrip.style.top = (r.bottom - s) + 'px';
+}
+
+// Phase D：把拖出来的最终基准最大宽高经 background → app（POST /api/extension/popup-size）。
+// app 侧 clamp(250-2000/200-1600) + 「拖即解锁」extensionPopupIndependentSize=true + 写扩展键，
+// 下一次查词 browserExtensionThemeColors 读新 extensionPopupEffectiveSize 即以新尺寸下发（闭环）。
+function hibikiSendPopupSize(maxWidth, maxHeight) {
+  try {
+    chrome.runtime.sendMessage(
+      { type: 'popupSize', maxWidth: Math.round(maxWidth), maxHeight: Math.round(maxHeight) },
+      () => { void chrome.runtime.lastError; });
+  } catch (_) { /* 扩展上下文失效：静默（尺寸只是没落库，不崩查词） */ }
+}
+
+// 在把手上装拖拽逻辑（每个 grip 只装一次）。pointerdown 快照起始基准 + 视口可用空间夹取上界，
+// pointermove 经纯函数 hibikiComputeResizedSize 实时改 host 的 width/maxHeight（place() 只在查词当
+// 帧跑一次、无 rAF 循环，故手动尺寸不会被每帧覆盖回去），pointerup 落库并经 bridge 回写 app。
+function hibikiInstallResizeDrag(grip) {
+  if (!grip || grip.__hibikiResizeHooked) return;
+  grip.__hibikiResizeHooked = true;
+  const down = (x, y) => {
+    if (!hibikiHost || !hibikiResizeBox) return;
+    const box = hibikiResizeBox;
+    const z = box.zoom > 0 ? box.zoom : 1;
+    const baseW = parseFloat(hibikiHost.style.width) || 0;
+    // 当前基准高度：host 渲染高÷zoom（style.maxHeight 可能是 min()/px/未设 → 用真实 rect 最稳）。
+    const baseH = hibikiHost.getBoundingClientRect().height / z;
+    hibikiResizeDrag = {
+      startX: x, startY: y, baseW: baseW, baseH: baseH, zoom: z,
+      bounds: {
+        minW: HIBIKI_POPUP_MIN_WIDTH, minH: HIBIKI_POPUP_MIN_HEIGHT,
+        // 视口可用空间（右/下边界 − 弹窗左上角）÷zoom = 基准尺度上界；不撑出视口、不遮被查词。
+        maxW: (box.maxRight - box.left) / z,
+        maxH: (box.maxBottom - box.top) / z,
+      },
+    };
+  };
+  const move = (x, y) => {
+    if (!hibikiResizeDrag || !hibikiHost) return;
+    const d = hibikiResizeDrag;
+    const size = hibikiComputeResizedSize(
+      { width: d.baseW, height: d.baseH },
+      { dx: x - d.startX, dy: y - d.startY },
+      d.zoom, d.bounds);
+    hibikiHost.style.width = size.width + 'px';
+    hibikiHost.style.maxHeight = size.height + 'px';
+    hibikiPositionResizeGrip();
+  };
+  const up = () => {
+    if (!hibikiResizeDrag || !hibikiHost) { hibikiResizeDrag = null; return; }
+    hibikiResizeDrag = null;
+    const w = parseFloat(hibikiHost.style.width);
+    const h = parseFloat(hibikiHost.style.maxHeight);
+    if (w > 0 && h > 0) hibikiSendPopupSize(w, h);
+  };
+  grip.addEventListener('pointerdown', (e) => {
+    if (e.button !== undefined && e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    try { grip.setPointerCapture(e.pointerId); } catch (_) { /* 某些上下文无指针捕获 */ }
+    down(e.clientX, e.clientY);
+  });
+  grip.addEventListener('pointermove', (e) => {
+    if (!hibikiResizeDrag) return;
+    e.preventDefault();
+    move(e.clientX, e.clientY);
+  });
+  grip.addEventListener('pointerup', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try { grip.releasePointerCapture(e.pointerId); } catch (_) { /* 同上 */ }
+    up();
+  });
+  grip.addEventListener('pointercancel', () => { up(); });
+}
+
+// 确保拖拽把手已创建并挂到弹窗同父节点（fullscreenElement||body，与高亮层同源，全屏也可见）。
+function hibikiEnsureResizeGrip() {
+  const parent = document.fullscreenElement || document.body;
+  if (!parent) return;
+  if (!hibikiResizeGrip) {
+    const g = document.createElement('div');
+    g.id = 'hibiki-popup-resize-grip';
+    // 顶层 fixed；z-index 与 host 齐平（同值时 DOM 靠后者胜出 → 把手可点）；斜纹视觉暗示可拖。
+    g.style.cssText =
+      'position:fixed;left:0;top:0;width:' + HIBIKI_RESIZE_GRIP_SIZE + 'px;height:' +
+      HIBIKI_RESIZE_GRIP_SIZE + 'px;z-index:2147483647;cursor:nwse-resize;' +
+      'pointer-events:auto;touch-action:none;' +
+      'background:linear-gradient(135deg,transparent 0 46%,rgba(128,128,128,0.75) 46% 54%,' +
+      'transparent 54% 66%,rgba(128,128,128,0.75) 66% 74%,transparent 74%);';
+    hibikiInstallResizeDrag(g);
+    hibikiResizeGrip = g;
+  }
+  if (hibikiResizeGrip.parentNode !== parent) parent.appendChild(hibikiResizeGrip);
+}
+
 function hibikiRender(popupJson, termLen, theme, anchorRect) {
   const c = hibikiEnsureContainer();
   // BUG-530：查词响应带回当前 app 主题色（--md-*），套到弹窗容器上，弹窗实时跟随用户主题
@@ -1371,6 +1512,22 @@ function hibikiRender(popupJson, termLen, theme, anchorRect) {
       if (pos.maxHeight != null) hibikiHost.style.maxHeight = (pos.maxHeight / zoom) + 'px';
       hibikiHost.style.left = (pos.left / zoom) + 'px';
       hibikiHost.style.top = (pos.top / zoom) + 'px';
+      // Phase D：记录本次落点的视口可用空间夹取上下文（视口坐标；host fixed，pos.* 即视口系），
+      // 供拖拽把手把视口位移折回基准并夹取——不撑出视口、且拖大也不遮被查词（BUG-767 延续）。
+      // 弹窗落在词上方(pos.top<ay)时弹窗底不得越过词顶(ay-G)；否则(落词下方/无锚点)可长到视口底。
+      const resizeGap = 4;
+      const maxBottom = (wordRect && pos.top < ay)
+          ? (ay - resizeGap)
+          : (window.innerHeight - 8);
+      hibikiResizeBox = {
+        left: pos.left,
+        top: pos.top,
+        maxRight: window.innerWidth - 8,
+        maxBottom: maxBottom,
+        zoom: zoom,
+      };
+      hibikiEnsureResizeGrip();
+      hibikiPositionResizeGrip();
     }
     c.style.visibility = 'visible';
   };
@@ -1380,5 +1537,11 @@ function hibikiRender(popupJson, termLen, theme, anchorRect) {
 document.addEventListener('mousedown', (e) => {
   // BUG-688：shadow 内点击 e.target 被 retarget 成 hibikiHost，故 contains 判定天然把
   // 「点弹窗内部」算作命中（不关窗）；只有点 host 之外才关。
+  // Phase D：拖拽把手是 host 之外的顶层兄弟节点（避开 host 的 zoom 包含块），点它属正常操作
+  // （开始拖拽调尺寸），不能触发关窗——否则一按把手弹窗就没了。故命中把手也算「点在弹窗上」。
+  if (hibikiResizeGrip &&
+      (e.target === hibikiResizeGrip || hibikiResizeGrip.contains(e.target))) {
+    return;
+  }
   if (hibikiHost && !hibikiHost.contains(e.target)) hibikiRemoveContainer();
 });

--- a/tools/browser-extension/popup-placement.test.js
+++ b/tools/browser-extension/popup-placement.test.js
@@ -15,8 +15,9 @@ const vm = require('node:vm');
 
 const CONTENT = path.join(__dirname, 'content.js');
 
-// 加载 content.js 到最小 vm 沙箱，仅为拿到顶层纯函数 hibikiComputePlacement（不触发任何 DOM 定位）。
-function loadPlacement() {
+// 加载 content.js 到最小 vm 沙箱，返回 sandbox 以取顶层纯函数（hibikiComputePlacement /
+// hibikiComputeResizedSize，均不触发任何 DOM 定位）。
+function loadSandbox() {
   const src = fs.readFileSync(CONTENT, 'utf8');
   const noop = () => {};
   const el = () => ({
@@ -55,7 +56,15 @@ function loadPlacement() {
   sandbox.window.window = sandbox.window;
   vm.createContext(sandbox);
   vm.runInContext(src, sandbox, { filename: 'content.js' });
-  return sandbox.hibikiComputePlacement;
+  return sandbox;
+}
+
+function loadPlacement() {
+  return loadSandbox().hibikiComputePlacement;
+}
+
+function loadResized() {
+  return loadSandbox().hibikiComputeResizedSize;
 }
 
 // 弹窗实际渲染高度：被夹高时用 maxHeight，否则用自然高度。
@@ -128,4 +137,60 @@ test('词贴视口底时弹窗翻到词上方且不覆盖', () => {
   const pos = fn(anchor, SIZE_SHORT, VP);
   assert.ok(pos.top + popupHeight(pos, SIZE_SHORT) <= anchor.y + 0.5, '弹窗未落在词上方');
   assert.ok(!overlapsVertically(pos, SIZE_SHORT, anchor), '弹窗覆盖了被查词');
+});
+
+// ── Phase D：拖拽调整尺寸的纯函数 hibikiComputeResizedSize ──
+// 宽敞 bounds（视口大、可用空间远超上下限），只考验位移折算与下限。
+const WIDE_BOUNDS = { minW: 250, minH: 200, maxW: 2000, maxH: 1600 };
+
+test('顶层纯函数 hibikiComputeResizedSize 存在', () => {
+  assert.strictEqual(typeof loadResized(), 'function',
+    'content.js 未导出 hibikiComputeResizedSize 全局函数');
+});
+
+test('zoom=1：位移直接加到基准宽高', () => {
+  const fn = loadResized();
+  const r = fn({ width: 400, height: 360 }, { dx: 120, dy: 80 }, 1, WIDE_BOUNDS);
+  assert.strictEqual(r.width, 520);
+  assert.strictEqual(r.height, 440);
+});
+
+test('zoom>1：视口位移除以 zoom 折回基准尺度', () => {
+  const fn = loadResized();
+  // 渲染盒 = 基准 × zoom；拖动发生在已缩放坐标系，故 base delta = 视口 delta / zoom。
+  const r = fn({ width: 400, height: 360 }, { dx: 200, dy: 100 }, 2, WIDE_BOUNDS);
+  assert.strictEqual(r.width, 500); // 400 + 200/2
+  assert.strictEqual(r.height, 410); // 360 + 100/2
+});
+
+test('zoom<=0 兜底为 1（不除零/不反向缩放）', () => {
+  const fn = loadResized();
+  const r = fn({ width: 400, height: 360 }, { dx: 50, dy: 50 }, 0, WIDE_BOUNDS);
+  assert.strictEqual(r.width, 450);
+  assert.strictEqual(r.height, 410);
+});
+
+test('缩小时夹到下限 250×200', () => {
+  const fn = loadResized();
+  const r = fn({ width: 300, height: 240 }, { dx: -400, dy: -400 }, 1, WIDE_BOUNDS);
+  assert.strictEqual(r.width, 250);
+  assert.strictEqual(r.height, 200);
+});
+
+test('放大时夹到 bounds 上限（视口可用空间÷zoom，不撑出视口/不遮词）', () => {
+  const fn = loadResized();
+  // maxW/maxH 由 place() 用视口可用空间÷zoom 算出（此处模拟为 700×500）。
+  const bounds = { minW: 250, minH: 200, maxW: 700, maxH: 500 };
+  const r = fn({ width: 400, height: 360 }, { dx: 9999, dy: 9999 }, 1, bounds);
+  assert.strictEqual(r.width, 700);
+  assert.strictEqual(r.height, 500);
+});
+
+test('视口过小导致上界<下界时仍返回下限（不倒挂）', () => {
+  const fn = loadResized();
+  // maxW/maxH 折算后小于下限（极小视口 / 大 zoom）：clamp 上界取 max(lo,hi)=lo，恒返回下限。
+  const bounds = { minW: 250, minH: 200, maxW: 100, maxH: 90 };
+  const r = fn({ width: 400, height: 360 }, { dx: 0, dy: 0 }, 1, bounds);
+  assert.strictEqual(r.width, 250);
+  assert.strictEqual(r.height, 200);
 });


### PR DESCRIPTION
查词弹窗尺寸精细化 + 拖拽调整的 **Phase C + D**（接 #83 已合入的 Phase A+B）。设计真值：`docs/specs/2026-07-13-lookup-popup-resize-design.md`。

## 本 PR 内容
- **Phase C — app 外覆盖查词窗拖角 resize（仅 Windows 原生）**：瞬态覆盖窗右下角加 resize grip（`global_lookup_host.js` 只挂 ROOT 卡）；`global_lookup_window.cpp/.h` 放开瞬态窗模态 size 循环（`resizing_` 期间用整窗区域让拖拽可见增长，`WM_EXITSIZEMOVE` 复原 shell 裁剪并回报 rect）；`global_lookup_controller` 收 `windowMoved`→纯函数 `resolveOverlayResizeFromWindow`（÷dpr÷appUiScale + floor + clamp）→**拖即解锁** `setOverlayLookupIndependentSize(true)` + 写 overlay 键。**只写 overlay 键，不串 clipboardPanelRect/popupMaxWidth**。
- **Phase D — 浏览器扩展弹窗 DOM 拖角 resize + 经 bridge 回写 app**：`content.js`（两镜像）加顶层 fixed 拖拽把手 + 纯函数 `hibikiComputeResizedSize`（÷zoom + clamp，尊重 `hibikiComputePlacement` 不遮词）；`pointerup` 经 `chrome.runtime.sendMessage`→`background.js`→新端点 `POST /api/extension/popup-size`（`yomitan_api_server.dart`，走既有 `_authMiddleware` Basic 鉴权，非白名单）→clamp→`setExtensionPopupIndependentSize(true)`+写 extension 键。下次查词 theme 下发以新值为准。**拖拽阈值 >3px 才解锁，纯点击不脱钩跟随**。

## 平台边界（设计已明确）
app 外覆盖窗仅 Windows 有；macOS/Linux 无覆盖窗、Android 独立悬浮服务、iOS 无 app 外查词——Phase C 天然只对 Windows 用户可见。

## 验证
- `flutter analyze` 全干净。
- Dart：`effective_lookup_size` / `overlay_resize_wiring_guard` / `yomitan_api_server_extension_endpoints`（含鉴权 401/404/400 边界、键隔离）全过。
- 扩展：`node popup-placement.test.js` 12/12；三镜像 parity guard + highlight guard 全过；content.js 两镜像字节一致。
- **Phase C 的 C++ 已 `flutter build windows --debug` 编译通过**（`√ Built hibiki.exe`）。
- 键隔离/鉴权/镜像同步经独立 verify + 对抗审查（1 条 LOW 拖拽阈值已修）。

## 待真机/浏览器验收
- Windows 真机：瞬态覆盖窗拖 grip → 松手落 overlay 键 → 下次查词沿用；设置页「app 外覆盖窗」独立开关自动开。**已知 UX 取舍**：松手瞬间当前卡先缩回、放大在下次查词生效（符合「拖拽改的是最大尺寸偏好」本质；如需松手即时填充可后续增强）。剪贴板面板/嵌套卡/reveal 几何回归须复测。
- Chrome/Edge：扩展拖角 resize → app 收到 → 下次查词沿用；纯点击不误解锁。
