### PR TITLE
fix(danmaku): 弹幕按帧插值，消除跳格（「刷新率太低」）

### DIFF
--- a/hibiki/lib/src/media/video/video_danmaku_overlay.dart
+++ b/hibiki/lib/src/media/video/video_danmaku_overlay.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
 import 'package:hibiki/src/media/video/video_danmaku_layout.dart';
 import 'package:hibiki/src/media/video/video_danmaku_model.dart';
@@ -9,6 +10,8 @@ class VideoDanmakuOverlay extends StatefulWidget {
     required this.enabled,
     required this.maxActive,
     required this.positionMs,
+    this.isPlaying,
+    this.speed,
     this.maxLanes = kDefaultVideoDanmakuMaxLanes,
     this.style = VideoDanmakuStyle.defaults,
     super.key,
@@ -18,7 +21,18 @@ class VideoDanmakuOverlay extends StatefulWidget {
   final bool enabled;
   final int maxActive;
   final int maxLanes;
+
+  /// 播放器时钟（毫秒）。真值来自 media_kit `state.position`，**约每 200ms 才更新
+  /// 一次**；overlay 每帧读取会读到同一陈旧值，故内部按帧插值（见 [_smoothPositionMs]）
+  /// 平滑弹幕运动，避免「刷新率太低」的跳格观感。
   final int Function() positionMs;
+
+  /// 是否正在播放（可选）。为空视为一直播放。暂停时插值冻结在 [positionMs] 真值，
+  /// 不再外推，避免暂停后弹幕继续漂移。
+  final bool Function()? isPlaying;
+
+  /// 播放速率（可选，默认 1.0）。长按倍速等场景下按帧外推需按此缩放，保持同步。
+  final double Function()? speed;
 
   /// TODO-1376：字号/不透明度/速度/显示区域样式（即改即生效，源自全局偏好）。
   final VideoDanmakuStyle style;
@@ -35,6 +49,14 @@ class _VideoDanmakuOverlayState extends State<VideoDanmakuOverlay>
   );
 
   bool get _shouldTick => widget.enabled && widget.items.isNotEmpty;
+
+  /// 平滑播放时钟（毫秒）。null = 尚未锚定（下一帧用真值锚定）。
+  int? _smoothMs;
+
+  /// 上一帧的 [SchedulerBinding.currentFrameTimeStamp]（毫秒），用于求帧间隔。
+  /// 该时钟在生产环境按 vsync 逐帧推进、在 widget 测试里按 `pump(duration)` 推进，
+  /// 故插值在测试中确定、不依赖真实墙钟。
+  int _lastFrameMs = 0;
 
   @override
   void initState() {
@@ -57,9 +79,50 @@ class _VideoDanmakuOverlayState extends State<VideoDanmakuOverlay>
   void _syncTicker() {
     if (_shouldTick) {
       if (!_ticker.isAnimating) _ticker.repeat();
-    } else if (_ticker.isAnimating) {
-      _ticker.stop(canceled: false);
+    } else {
+      if (_ticker.isAnimating) _ticker.stop(canceled: false);
+      // 不在动画时丢弃锚点：下次开启（换视频/重新开弹幕）从真值重新锚定，
+      // 不把上个视频的陈旧平滑时钟带过来。
+      _smoothMs = null;
     }
+  }
+
+  /// 按帧插值出的平滑播放位置（毫秒），消除 media_kit `state.position` ~200ms 才更新
+  /// 一次导致的弹幕跳格。
+  ///
+  /// 每帧按真实帧间隔 × 速率推进内部时钟；对播放器真值做**软校正**（小漂移每帧拉近
+  /// 15%，避免可见回跳），漂移过大（seek / 大失步）直接吸附真值；暂停时冻结在真值。
+  int _smoothPositionMs() {
+    final int raw = widget.positionMs();
+    final int frameMs =
+        SchedulerBinding.instance.currentFrameTimeStamp.inMilliseconds;
+    final bool playing = widget.isPlaying?.call() ?? true;
+    final double speed = widget.speed?.call() ?? 1.0;
+
+    if (_smoothMs == null) {
+      _smoothMs = raw;
+      _lastFrameMs = frameMs;
+      return raw;
+    }
+    final int dtMs = frameMs - _lastFrameMs;
+    _lastFrameMs = frameMs;
+
+    if (!playing || dtMs <= 0) {
+      // 暂停 / 无时间推进：钉在真值，避免外推。
+      _smoothMs = raw;
+      return raw;
+    }
+
+    int next = _smoothMs! + (dtMs * speed).round();
+    final int drift = raw - next;
+    if (drift.abs() > 400) {
+      next = raw; // seek 或大失步（后台丢帧）→ 直接对齐真值。
+    } else {
+      next += (drift * 0.15).round(); // 小漂移软校正，肉眼无回跳。
+    }
+    if (next < 0) next = 0;
+    _smoothMs = next;
+    return next;
   }
 
   @override
@@ -83,7 +146,7 @@ class _VideoDanmakuOverlayState extends State<VideoDanmakuOverlay>
               final VideoDanmakuLayoutSnapshot snapshot =
                   VideoDanmakuLayout.layout(
                 items: widget.items,
-                positionMs: widget.positionMs(),
+                positionMs: _smoothPositionMs(),
                 viewportSize: constraints.biggest,
                 maxActive: widget.maxActive,
                 maxLanes: widget.maxLanes,

--- a/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
@@ -313,6 +313,10 @@ extension _VideoLayout on _VideoHibikiPageState {
                           enabled: appModel.videoDanmakuEnabled,
                           maxActive: appModel.videoDanmakuMaxActive,
                           positionMs: () => controller.positionMs ?? 0,
+                          // 播放器时钟 ~200ms 才更新，overlay 内按帧插值需知道是否在播放
+                          // 与当前速率，才能平滑外推且暂停时冻结、倍速时同步。
+                          isPlaying: () => controller.isPlaying,
+                          speed: () => controller.speed,
                           style: _danmakuStyle,
                         ),
                       ),

--- a/hibiki/test/media/video/video_danmaku_overlay_test.dart
+++ b/hibiki/test/media/video/video_danmaku_overlay_test.dart
@@ -108,4 +108,84 @@ void main() {
       const Duration(milliseconds: 120),
     );
   });
+
+  double scrollLeft(WidgetTester tester, String text) => tester
+      .widget<Positioned>(
+        find
+            .ancestor(of: find.text(text), matching: find.byType(Positioned))
+            .first,
+      )
+      .left!;
+
+  testWidgets(
+      'scroll danmaku interpolates between low-frequency position samples',
+      (WidgetTester tester) async {
+    // 播放器时钟固定不动（模拟 media_kit state.position ~200ms 才更新的那段间隙），
+    // 但时间在推进 + 正在播放：插值必须让滚动弹幕继续左移，而不是卡住等下次采样。
+    await _pump(
+      tester,
+      VideoDanmakuOverlay(
+        items: <VideoDanmakuItem>[_item(0, 'x')],
+        enabled: true,
+        maxActive: 20,
+        positionMs: () => 2000,
+        isPlaying: () => true,
+        speed: () => 1.0,
+      ),
+    );
+
+    final double before = scrollLeft(tester, 'x');
+    await tester.pump(const Duration(milliseconds: 50));
+    final double after = scrollLeft(tester, 'x');
+
+    expect(after, lessThan(before),
+        reason: '真值未更新的帧里，插值让滚动弹幕平滑左移（消除 ~200ms 跳格）');
+  });
+
+  testWidgets('paused danmaku freezes (no extrapolation drift)',
+      (WidgetTester tester) async {
+    await _pump(
+      tester,
+      VideoDanmakuOverlay(
+        items: <VideoDanmakuItem>[_item(0, 'x')],
+        enabled: true,
+        maxActive: 20,
+        positionMs: () => 2000,
+        isPlaying: () => false,
+        speed: () => 1.0,
+      ),
+    );
+
+    final double before = scrollLeft(tester, 'x');
+    await tester.pump(const Duration(milliseconds: 200));
+    final double after = scrollLeft(tester, 'x');
+
+    expect(after, before, reason: '暂停时插值冻结在真值，弹幕不应继续漂移');
+  });
+
+  testWidgets('speed scales interpolation (2x drifts ~twice as far)',
+      (WidgetTester tester) async {
+    Future<double> travel(double speed) async {
+      await _pump(
+        tester,
+        VideoDanmakuOverlay(
+          items: <VideoDanmakuItem>[_item(0, 'x')],
+          enabled: true,
+          maxActive: 20,
+          positionMs: () => 2000,
+          isPlaying: () => true,
+          speed: () => speed,
+        ),
+      );
+      final double before = scrollLeft(tester, 'x');
+      await tester.pump(const Duration(milliseconds: 60));
+      final double after = scrollLeft(tester, 'x');
+      return before - after; // 左移距离（正数）
+    }
+
+    final double at1x = await travel(1.0);
+    final double at2x = await travel(2.0);
+    expect(at2x, greaterThan(at1x),
+        reason: '倍速时按帧外推更快，弹幕单帧左移更远');
+  });
 }


### PR DESCRIPTION
## 根因
`VideoDanmakuOverlay` 每帧(vsync 60/120fps)重建,但弹幕位置来自 `controller.positionMs` = media_kit `state.position`——这个值由 position 流驱动,**约 200ms 才更新一次**。overlay 每帧读到同一个陈旧值,滚动弹幕就每 ~200ms 才跳一格 ≈ **5fps**,观感就是用户报的「刷新率太低,看着好难受」。字幕不受影响(一句才变一次,跳格看不出来)。

## 修复
overlay 内引入**按帧平滑时钟**:
- 用 `SchedulerBinding.currentFrameTimeStamp`(生产按 vsync 逐帧推进、widget 测试按 `pump(duration)` 推进 → 插值确定可测)求帧间隔。
- 每帧按 `帧间隔 × 速率` 外推播放位置;对播放器真值做**软校正**(小漂移每帧拉近 15%,肉眼无回跳),漂移 >400ms(seek / 后台丢帧)直接吸附真值;**暂停冻结**在真值不外推。
- 刷新率无关:60Hz/120Hz 都按真实帧时间推进。

新增可选 `isPlaying` / `speed` 回调(播放页注入 `controller.isPlaying` / `controller.speed`),保证暂停冻结、长按倍速同步。

## 验证
- `flutter analyze`:No issues found。
- overlay 测试全绿,含 3 个新回归:真值不更新的帧里滚动弹幕仍平滑左移 / 暂停冻结 / 倍速外推更远。
- 全量套件仅 1 个 `sync_compare_download_test` 因满载 isolate 加载超时 flake,**隔离重跑通过**,与本改动无关(未碰任何 sync 文件)。

## 待真机
真机播放目视弹幕是否顺滑。若仍有卡顿,下一手是渲染优化:每条弹幕现在包了一层 `Opacity` widget(每帧 `saveLayer`,几十条同屏时是真 GPU 开销),可折进文字/阴影的颜色 alpha 去掉 saveLayer——本 PR 未含,视真机表现再上。