### PR TITLE
查词弹窗尺寸 Phase C/D 真机修复（覆盖窗乱跳=改增量折算 / 扩展拖拽关窗=popup.js 豁免 grip）+ 松手即时填充

### DIFF
--- a/hibiki/lib/src/lookup/global_lookup_controller.dart
+++ b/hibiki/lib/src/lookup/global_lookup_controller.dart
@@ -717,6 +717,13 @@ class GlobalLookupController {
     model.setOverlayLookupMaxHeight(size.height);
     glog('overlay resized -> unlock independent, ${size.width}x${size.height} '
         '(phys=${physW}x$physH dpr=$dpr uiScale=${model.appUiScale})');
+    // 松手即时填充（2026-07-13）— setPref 同步更新 prefCache，故此刻
+    // [AppModel.overlayLookupEffectiveSize] 已是新尺寸；立即重排当前卡，复用嵌套卡
+    // 同款的 overlaySize→_applyOverlayBox→revealStack resize 分支把窗口长到位并填满
+    // 卡片，无需等下次查词、不重新查词（[_renderStack] 自守空栈）。右下角 resize 原点
+    // (top-left) 不动 → 棘轮 [ratchetOverlayOrigin] 天然 no-op，不碰脆弱 reveal 几何。
+    // 高度按内容封顶：拖高于内容会回落到内容高度（符合「最大高度」语义），宽度填满。
+    unawaited(_renderStack());
   }
 
   void _onJsMessage(Map<String, Object?> message) {

--- a/hibiki/test/lookup/overlay_resize_wiring_guard_test.dart
+++ b/hibiki/test/lookup/overlay_resize_wiring_guard_test.dart
@@ -44,6 +44,15 @@ void main() {
           reason: '覆盖窗 resize 串写了剪贴板面板 rect——破坏面板');
       expect(src.contains('setPopupMaxWidth'), isFalse,
           reason: '覆盖窗 resize 串写了 app 内共享键——破坏 app 内弹窗');
+      // 松手即时填充：_onOverlayResized 方法体内必须重触发 _renderStack，当前卡才即时
+      // 长到新尺寸（否则回落到「下次查词才生效」）。切到方法边界内断言，避免全局误命中。
+      final int mStart = src.indexOf('void _onOverlayResized(');
+      expect(mStart, greaterThanOrEqualTo(0),
+          reason: '_onOverlayResized 方法不存在/改名');
+      final int mEnd = src.indexOf('void _onJsMessage(', mStart);
+      final String body = src.substring(mStart, mEnd < 0 ? src.length : mEnd);
+      expect(body.contains('_renderStack('), isTrue,
+          reason: '拖完未重排当前卡——松手即时填充失效，退回下次查词才生效');
     });
 
     test('C++ — 瞬态窗放开模态 resize + 拖拽期挂起 shell 区域裁剪', () {


### PR DESCRIPTION
查词弹窗尺寸 Phase C/D 的**真机 bug 修复 + 松手即时填充**（接 #86 已合入的 C+D、#83 已合入的 A+B）。用户真机（界面缩放 150%）反馈：Phase C 覆盖窗拖拽**乱跳**、Phase D 扩展拖拽**把弹窗关掉**。三个 commit：

## 1. Phase C 覆盖窗拖角松手即时填充（356901e52）
`_onOverlayResized` 写完 overlay 键后 `_renderStack()`，复用嵌套卡 measure→reveal 循环即时长到新尺寸（不重新查词）。

## 2. Phase D 拖 resize 把手不再关窗（f1ed886e0）
根因：弹窗有两条「点外关闭」路径，原 impl 只给 content.js mousedown 加了 grip 豁免；真正关窗的是 shadow 内 **popup.js 的 click→tapOutside**（grip 是宿主页 body 顶层兄弟，命中不了弹窗内部选择器→判为点外→关）。修：popup.js click handler 按 `#hibiki-popup-resize-grip` 豁免（三镜像同步；app 内文档无此元素故 no-op）。

## 3. Phase C 覆盖窗 resize 改增量折算，修尺寸暴涨/乱跳（7ca0de08f）
根因：`_onOverlayResized` 把 `GetWindowRect` 的**整窗**尺寸当卡片尺寸倒推，但瞬态窗因 reserve-to-edge 级联余量恒比卡片大（那段被 region 裁掉不可见）→ 折算尺寸系统性暴涨（顶到上限/工作区）→ immediate-fill 立即套用 → 卡片爆炸放大 + `computeRootShellOffset` 甩到工作区角 = **乱跳**。折算数学在 150% 下本身对称，错的是**输入**（整窗含余量）。
修：改**增量**折算——native（WM_ENTERSIZEMOVE 抓起始窗口物理尺寸，WM_EXITSIZEMOVE 一并回报）给出「起止两尺寸」，Dart 用二者之差（恒定余量在相减中抵消，与余量值/方向无关）折算 overlay 增量叠加到当前值。size 不再暴涨 → 不再甩边/乱跳。

## 验证
- `flutter analyze` 干净；overlay resize guard + 增量折算纯函数（含 150% 例、余量抵消、clamp、非正兜底）21/21 通过；扩展三镜像 parity guard + node placement 12/12 通过；三镜像字节一致。
- **Phase C 的 C++ 改动已 `flutter build windows --debug` 编译通过**（`√ Built hibiki.exe`）。

## 待真机复测
- Windows 覆盖窗：拖 grip 尺寸随手 1:1（150% 下不暴涨/不甩边）、松手即时填充、下次查词沿用。**残留待观察**：拖得比内容高时高度会按内容封顶（「最大高度」语义，宽度填满）；WM_EXITSIZEMOVE 先复原旧卡矩形再重排新 shellRects 理论上 1 帧区域两跳——真机若仍见闪烁再做区域延迟复原。
- Chrome/Edge：扩展拖 grip 不再关窗、尺寸经 bridge 回写、下次查词沿用。
