### PR TITLE
剪切板浮窗：关自动查词（阶段一）+ 背景逐像素透明（阶段二 WIP）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39627 (2331 per locale)
+/// Strings: 39661 (2333 per locale)
 ///
-/// Built on 2026-07-13 at 09:47 UTC
+/// Built on 2026-07-13 at 15:49 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3088,6 +3088,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Give the browser-extension lookup popup its own max size instead of following the in-app popup';
   String get extension_popup_max_width => 'Extension popup max width';
   String get extension_popup_max_height => 'Extension popup max height';
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -8367,6 +8370,11 @@ class _StringsAr extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -13769,6 +13777,11 @@ class _StringsDe extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -19188,6 +19201,11 @@ class _StringsEs extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -24626,6 +24644,11 @@ class _StringsFr extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -29966,6 +29989,11 @@ class _StringsId extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -35367,6 +35395,11 @@ class _StringsIt extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -40493,6 +40526,11 @@ class _StringsJa extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -45624,6 +45662,11 @@ class _StringsKo extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -50993,6 +51036,11 @@ class _StringsNl extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -56385,6 +56433,11 @@ class _StringsPtBr extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -61752,6 +61805,11 @@ class _StringsRu extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -67032,6 +67090,11 @@ class _StringsTh extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -72367,6 +72430,11 @@ class _StringsTr extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -77677,6 +77745,11 @@ class _StringsVi extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -82624,6 +82697,10 @@ class _StringsZhCn extends _StringsEn {
   String get extension_popup_max_width => '扩展弹窗最大宽度';
   @override
   String get extension_popup_max_height => '扩展弹窗最大高度';
+  @override
+  String get desktop_clipboard_auto_lookup => '复制后自动查词';
+  @override
+  String get desktop_clipboard_auto_lookup_hint => '关闭后面板只显示复制到的文字，点词才查词。';
 }
 
 // Path: retrying_in
@@ -87652,6 +87729,11 @@ class _StringsZhHk extends _StringsEn {
   String get extension_popup_max_width => 'Extension popup max width';
   @override
   String get extension_popup_max_height => 'Extension popup max height';
+  @override
+  String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
+  @override
+  String get desktop_clipboard_auto_lookup_hint =>
+      'When off, the panel shows only the copied text; tap a word to look it up.';
 }
 
 // Path: retrying_in
@@ -92458,6 +92540,10 @@ extension on _StringsEn {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -97224,6 +97310,10 @@ extension on _StringsAr {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -102012,6 +102102,10 @@ extension on _StringsDe {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -106798,6 +106892,10 @@ extension on _StringsEs {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -111591,6 +111689,10 @@ extension on _StringsFr {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -116364,6 +116466,10 @@ extension on _StringsId {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -121154,6 +121260,10 @@ extension on _StringsIt {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -125901,6 +126011,10 @@ extension on _StringsJa {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -130652,6 +130766,10 @@ extension on _StringsKo {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -135435,6 +135553,10 @@ extension on _StringsNl {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -140215,6 +140337,10 @@ extension on _StringsPtBr {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -144999,6 +145125,10 @@ extension on _StringsRu {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -149765,6 +149895,10 @@ extension on _StringsTh {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -154540,6 +154674,10 @@ extension on _StringsTr {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -159309,6 +159447,10 @@ extension on _StringsVi {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }
@@ -164042,6 +164184,10 @@ extension on _StringsZhCn {
         return '扩展弹窗最大宽度';
       case 'extension_popup_max_height':
         return '扩展弹窗最大高度';
+      case 'desktop_clipboard_auto_lookup':
+        return '复制后自动查词';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return '关闭后面板只显示复制到的文字，点词才查词。';
       default:
         return null;
     }
@@ -168781,6 +168927,10 @@ extension on _StringsZhHk {
         return 'Extension popup max width';
       case 'extension_popup_max_height':
         return 'Extension popup max height';
+      case 'desktop_clipboard_auto_lookup':
+        return 'Auto-look-up on copy';
+      case 'desktop_clipboard_auto_lookup_hint':
+        return 'When off, the panel shows only the copied text; tap a word to look it up.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "浏览器扩展独立尺寸",
   "extension_popup_independent_size_hint": "让浏览器扩展查词弹窗使用独立最大尺寸，而非跟随 app 内查词弹窗",
   "extension_popup_max_width": "扩展弹窗最大宽度",
-  "extension_popup_max_height": "扩展弹窗最大高度"
+  "extension_popup_max_height": "扩展弹窗最大高度",
+  "desktop_clipboard_auto_lookup": "复制后自动查词",
+  "desktop_clipboard_auto_lookup_hint": "关闭后面板只显示复制到的文字，点词才查词。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2337,5 +2337,7 @@
   "extension_popup_independent_size": "Separate size for browser extension",
   "extension_popup_independent_size_hint": "Give the browser-extension lookup popup its own max size instead of following the in-app popup",
   "extension_popup_max_width": "Extension popup max width",
-  "extension_popup_max_height": "Extension popup max height"
+  "extension_popup_max_height": "Extension popup max height",
+  "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
 }

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -88,6 +88,11 @@ class ClipboardPanelController {
   int _frameSeq = 0;
   String _currentSentence = '';
 
+  /// 「关自动查词」纯文字态：面板只显示句子横幅（逐字可点）、不显示词典结果块。
+  /// [_showTextOnly] 置 true；任何真查词（自动查词 / 点句中字 / 嵌套子查词）置
+  /// false，使点词后释义正常显示。[_renderPanel] 据此给面板 root 帧传 sentenceOnly。
+  bool _sentenceOnly = false;
+
   /// 真机第 4 轮 — 选词区当前查词起点（整句里的码点下标）。剪贴板更新回 0；
   /// 点句子条某字后为该字下标，配合根结果 bestLength 在横幅整词高亮。
   int _rootHitStart = 0;
@@ -163,6 +168,14 @@ class ClipboardPanelController {
   Future<void> update(DesktopLookupRequest request) async {
     final AppModel? model = _appModel;
     if (!_started || model == null) return;
+    // 「关自动查词」纯文字态：只显示复制到的句子文字（逐字可点），不自动 searchDictionary、
+    // 不弹释义、不朗读、不记查词计数。用户点句中字才走 panelSentenceLookup 手动查
+    // （那条路径重置 _sentenceOnly=false，释义正常出）。总开关 desktopClipboardEnabled
+    // 仍决定「是否监听剪贴板」，本开关只决定「监听到之后自不自动查词」，两者正交。
+    if (!model.desktopClipboardAutoLookup) {
+      await _showTextOnly(model, request.text);
+      return;
+    }
     // latest-wins：领取序号；每个 await 后核对，过期即弃（VN 流乱序守卫）。
     final int seq = ++_updateSeq;
     try {
@@ -175,6 +188,7 @@ class ClipboardPanelController {
         return;
       }
       _recordLookupCount(model);
+      _sentenceOnly = false;
       _currentSentence = request.text;
       // 新句：rootQuery=整句，故基准码点下标=0；真正词首由 rootHitRange 再补偿被归一化
       // 剥掉的句首标点长度（BUG-773），不再假设词从句首第 0 字符开始。
@@ -195,6 +209,28 @@ class ClipboardPanelController {
     } catch (e, st) {
       glog('panel: update EXCEPTION $e\n$st');
     }
+  }
+
+  /// 「关自动查词」纯文字态：不查词，只把复制到的句子作为 root 帧的横幅显示
+  /// （逐字可点，点字走 panelSentenceLookup 手动查）。seed 一个空结果的 root 帧
+  /// 让 [_renderPanel] 有 payload 可渲染，并置 [_sentenceOnly] 使渲染脚本摘掉
+  /// 「No results」结果块。与自动查词路径共用同一 latest-wins 序号，避免与并发的
+  /// 手动查词/后到的剪贴板句乱序。
+  Future<void> _showTextOnly(AppModel model, String text) async {
+    final int seq = ++_updateSeq;
+    _sentenceOnly = true;
+    _currentSentence = text;
+    _rootHitStart = 0;
+    // 空结果（无 entries）：popup.js 渲染句子横幅 + No results 块，后者由渲染脚本
+    // 的 sentenceOnly 分支就地摘除，只剩句子文字。
+    _seedRootFrame(text, DictionarySearchResult(searchTerm: text));
+    if (!_visible || !await _channel.isShowing()) {
+      _visible = false;
+      await _showPanel(model);
+      if (seq != _updateSeq) return;
+    }
+    await _renderPanel(model);
+    glog('panel: text-only "${text.length} chars" (auto-lookup off)');
   }
 
   /// TODO-1204 对齐——面板查词与瞬态覆盖窗同口径记一次查词计数（source
@@ -305,6 +341,8 @@ class ClipboardPanelController {
         // 面板 root 恒带整句横幅（剪贴板文本天然就是句子上下文，兼作制卡
         // sentence 字段）；子卡不带（与瞬态窗一致）。
         sentence: frame.id == kGlobalLookupRootFrameId ? _currentSentence : '',
+        // 纯文字态只对面板 root 帧生效：摘掉空结果的「No results」块只剩句子。
+        sentenceOnly: _sentenceOnly && frame.id == kGlobalLookupRootFrameId,
       ));
     }
     if (payloads.isEmpty) return;
@@ -465,6 +503,8 @@ class ClipboardPanelController {
         searchWithWildcards: false,
       );
       if (seq != _updateSeq) return;
+      // 点句中字=真手动查词：退出纯文字态，释义正常显示。
+      _sentenceOnly = false;
       _rootHitStart = hitStart < 0 ? 0 : hitStart;
       _seedRootFrame(suffix, result);
       await _renderPanel(model);

--- a/hibiki/lib/src/lookup/global_lookup_render.dart
+++ b/hibiki/lib/src/lookup/global_lookup_render.dart
@@ -52,6 +52,7 @@ String buildFrameSettingsJs({
   bool panelRoot = false,
   int sentenceHitStart = -1,
   int sentenceHitLength = 0,
+  bool sentenceOnly = false,
 }) {
   final String settingsJs = buildPopupSettingsJs(
     appModel: appModel,
@@ -97,6 +98,15 @@ String buildFrameSettingsJs({
           '    window.__globalLookupSentenceHit = '
           '{start: $sentenceHitStart, length: $sentenceHitLength};\n'
       : '';
+  // 剪切板「关自动查词」纯文字态：面板只显示句子横幅（逐字可点），不显示词典结果。
+  // 传入的是空结果（无 entries），popup.js 会渲染句子横幅 + 一块「No results」提示；
+  // 这里在 renderPopup 之后就地摘掉那块提示节点，达成「只剩文字」。仅面板 root、仅
+  // sentenceOnly 时注入，故自动查词路径 settingsJs 逐字节不变（host 以此判重渲）。
+  // 走 app 侧渲染脚本而非改 popup.js，避开浏览器扩展三镜像 + content.css 重生成。
+  final String sentenceOnlyLine = sentenceOnly
+      ? 'var __hibikiNoRes = document.querySelector(".no-results"); '
+          'if (__hibikiNoRes) __hibikiNoRes.remove();\n'
+      : '';
   return '''
     $settingsJs
     $kPopupTopPullReleaseJs
@@ -106,6 +116,7 @@ String buildFrameSettingsJs({
     window.__globalLookupSentence = ${jsonEncode(sentence)};
     $panelRootLines
     window.renderPopup && window.renderPopup();
+    $sentenceOnlyLine
 ''';
 }
 
@@ -123,10 +134,15 @@ class GlobalLookupFramePayload {
     this.anchorRect,
     this.isVertical = false,
     this.sentence = '',
+    this.sentenceOnly = false,
   });
 
   final GlobalLookupFrame frame;
   final DictionarySearchResult result;
+
+  /// 剪切板「关自动查词」纯文字态：只渲染句子横幅、摘掉「No results」结果块。
+  /// 仅面板 root 帧有意义（子卡/瞬态窗恒 false）。
+  final bool sentenceOnly;
 
   /// TODO-1030 M0 — the current sentence to show as a context banner in this
   /// card (only the ROOT frame carries it; empty = no banner). Body text stays
@@ -277,6 +293,7 @@ String buildStackRenderScript({
       panelRoot: isPanelRoot,
       sentenceHitStart: isPanelRoot ? sentenceHitStart : -1,
       sentenceHitLength: isPanelRoot ? sentenceHitLength : 0,
+      sentenceOnly: isPanelRoot && p.sentenceOnly,
     );
     final Map<String, Object?> map = p.frame.toRenderMap();
     map['theme'] = shellTheme;

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4191,6 +4191,13 @@ class AppModel with ChangeNotifier {
     await applyDesktopClipboardLifecycle();
   }
 
+  /// 剪切板复制后是否自动查词（默认 true=现状）。false 时面板只显示文字、点词才查。
+  /// 与总开关 [desktopClipboardEnabled] 正交，不影响监听生命周期，故无需重跑
+  /// [applyDesktopClipboardLifecycle]。
+  bool get desktopClipboardAutoLookup => prefsRepo.desktopClipboardAutoLookup;
+  Future<void> setDesktopClipboardAutoLookup(bool v) =>
+      prefsRepo.setDesktopClipboardAutoLookup(v);
+
   /// spec 2026-07-10 §7 生命周期上移：剪贴板监听归 AppModel 持有（开=start /
   /// 关=stop），HomeDictionaryPage 退化为 destination==main 分区的消费者。此前
   /// start/stop 绑词典 tab 挂载周期——那是「去向只有主窗 tab」时代的产物；

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -448,6 +448,19 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 剪切板复制后是否自动查词（默认 true=保持现状）。false 时剪切板面板只显示
+  /// 复制到的句子文字（逐字可点），不自动 [searchDictionary]、不弹释义、不朗读；
+  /// 用户点句中字才手动查（走面板既有 panelSentenceLookup 桥）。总开关
+  /// [desktopClipboardEnabled] 仍决定「是否监听剪切板」，本开关只决定「监听到之后
+  /// 自不自动查词」，两者正交。
+  bool get desktopClipboardAutoLookup =>
+      getPref('desktop_clipboard_auto_lookup', defaultValue: true) as bool;
+
+  Future<void> setDesktopClipboardAutoLookup(bool value) async {
+    await setPref('desktop_clipboard_auto_lookup', value);
+    notifyListeners();
+  }
+
   // TODO-1030 M0 — 全局查词（应用外）是否抓取选中文本周围的上下文句。默认 false：
   // 抓取要读前台应用的 UIA 文本，隐私敏感，用户显式开启才启用；关闭时全局查词只用
   // 剪贴板拿到的纯选中串（现状），不接触前台应用文本。

--- a/hibiki/lib/src/settings/settings_schema_lookup.dart
+++ b/hibiki/lib/src/settings/settings_schema_lookup.dart
@@ -306,6 +306,24 @@ SettingsDestination buildLookupDestination() {
               settingsContext.refresh();
             },
           ),
+          // 复制后是否自动查词。关掉后剪贴板面板/查词只显示复制到的文字，点词才查
+          // （见 ClipboardPanelController 纯文字态）。仅桌面 + 剪贴板总开关开时可见。
+          SettingsSwitchItem(
+            id: 'lookup.desktop_clipboard_auto_lookup',
+            title: t.desktop_clipboard_auto_lookup,
+            subtitle: t.desktop_clipboard_auto_lookup_hint,
+            icon: Icons.search_off_outlined,
+            visible: (SettingsContext settingsContext) =>
+                DesktopLookupService.isDesktop &&
+                settingsContext.appModel.desktopClipboardEnabled,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.desktopClipboardAutoLookup,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel
+                  .setDesktopClipboardAutoLookup(value);
+              settingsContext.refresh();
+            },
+          ),
           SettingsSegmentedItem<DesktopClipboardWindowMode>(
             id: 'lookup.desktop_clipboard_window_mode',
             title: t.desktop_clipboard_window_mode,

--- a/hibiki/test/lookup/clipboard_panel_controller_test.dart
+++ b/hibiki/test/lookup/clipboard_panel_controller_test.dart
@@ -204,6 +204,38 @@ void main() {
       );
     });
 
+    test('关自动查词：update 走 _showTextOnly 分区、不 searchDictionary', () {
+      // 契约：desktopClipboardAutoLookup=false 时，update 早退到纯文字态
+      // （_showTextOnly），不自动查词、不弹释义；点句中字才手动查。
+      final int updAt = controllerSrc.indexOf('Future<void> update(');
+      expect(updAt, greaterThan(0));
+      final int gateAt =
+          controllerSrc.indexOf('if (!model.desktopClipboardAutoLookup)', updAt);
+      final int textOnlyAt =
+          controllerSrc.indexOf('_showTextOnly(model, request.text)', gateAt);
+      expect(gateAt, greaterThan(updAt),
+          reason: 'update 必须在关自动查词时早退到纯文字态');
+      expect(textOnlyAt, greaterThan(gateAt));
+      // _showTextOnly 里没有 searchDictionary（纯文字态绝不自动查词）。
+      final int fnAt = controllerSrc.indexOf('Future<void> _showTextOnly(');
+      expect(fnAt, greaterThan(0));
+      final int fnEnd = controllerSrc.indexOf('\n  }', fnAt);
+      final String body = controllerSrc.substring(fnAt, fnEnd);
+      expect(body.contains('searchDictionary'), isFalse,
+          reason: '纯文字态不得自动查词');
+      expect(body.contains('_sentenceOnly = true'), isTrue,
+          reason: '纯文字态须置 sentenceOnly，渲染脚本据此摘掉 No results 块');
+    });
+
+    test('点句中字（_lookupFromBanner）退出纯文字态，释义正常出', () {
+      final int fnAt = controllerSrc.indexOf('Future<void> _lookupFromBanner(');
+      expect(fnAt, greaterThan(0));
+      final int fnEnd = controllerSrc.indexOf('\n  }', fnAt);
+      final String body = controllerSrc.substring(fnAt, fnEnd);
+      expect(body.contains('_sentenceOnly = false'), isTrue,
+          reason: '手动查词必须清纯文字态，否则点词后释义被 sentenceOnly 摘掉');
+    });
+
     test('dispatcher panel 分区调 ClipboardPanelController.update', () {
       expect(
         dispatcherSrc.contains('ClipboardPanelController.instance.update'),

--- a/hibiki/test/models/preferences_repository_test.dart
+++ b/hibiki/test/models/preferences_repository_test.dart
@@ -499,6 +499,27 @@ void main() {
       repo2.dispose();
     });
 
+    test('desktopClipboardAutoLookup defaults true and round-trips', () async {
+      // 默认 true=保持现状（复制自动查词）；关掉后跨实例 reload 仍为 false
+      // （落 Drift preferences、记住设置）。与总开关 desktopClipboardEnabled 正交。
+      expect(repo.desktopClipboardAutoLookup, true);
+      await repo.setDesktopClipboardAutoLookup(false);
+      expect(repo.desktopClipboardAutoLookup, false);
+
+      final PreferencesRepository repo2 = PreferencesRepository(db);
+      await repo2.loadFromDb();
+      addTearDown(repo2.dispose);
+      expect(repo2.desktopClipboardAutoLookup, false,
+          reason: '剪切板自动查词开关必须跨实例 reload 记住');
+
+      // 开回 true 也持久。
+      await repo.setDesktopClipboardAutoLookup(true);
+      final PreferencesRepository repo3 = PreferencesRepository(db);
+      await repo3.loadFromDb();
+      addTearDown(repo3.dispose);
+      expect(repo3.desktopClipboardAutoLookup, true);
+    });
+
     test('legacy desktop clipboard always-on-top pref maps to lookup mode',
         () async {
       await repo.setPref('desktop_clipboard_always_on_top', true);


### PR DESCRIPTION
用户诉求（Windows 剪切板查词浮窗，VN/游戏 + Textractor 场景）：① 关掉复制自动查词——复制只显示文字、点词才查；② 背景**逐像素**真透明（游戏透过来、文字实心），不是现在的整窗统一变淡。

## 阶段一：关自动查词 ✅ 已完成、已测
- 新 pref `desktop_clipboard_auto_lookup`（默认 true=现状不变，零破坏）。
- 关掉后 `ClipboardPanelController` 走纯文字态：不 `searchDictionary`、面板只显示句子横幅（逐字可点），点句中字才手动查（`_lookupFromBanner` 重置纯文字态、释义正常出）。
- 「只剩文字」经渲染脚本 `sentenceOnly` 就地摘掉空结果的 No results 块（**app 侧脚本，不改 popup.js、免浏览器扩展三镜像**）。
- 设置「查词行为」加开关 + i18n（17 语言）。

## 阶段二：背景逐像素透明 ✅ 代码完成 + 编译通过 + 全测试绿；⚠️ 待真机视觉验证
把**仅面板实例**的 `GlobalLookupWindow` 从 windowed WebView2 改成 **composition + DirectComposition**（瞬态查词窗保持 windowed 不动、隔离风险）：
- Task5 `composition_mode_` 旗标 + CMake 链 `dcomp/dxguid`（no-op 脚手架）。
- Task6 `WS_EX_NOREDIRECTIONBITMAP` 建窗 + D3D11/DComp device/target/visual + `CreateCoreWebView2CompositionController` + `put_RootVisualTarget` + `Commit`，透明像素真透到桌面。**DComp 设备创建失败优雅回退 windowed**（面板照常工作、只是不透明，永不因透明改造黑屏/崩溃）。
- Task7 输入转发：composition 无子 HWND，客户区鼠标/滚轮消息 → `SendMouseInput`；`add_CursorChanged` + `WM_SETCURSOR` 接管光标。透明面板由此可点句/滚释义/光标正确。
- Task9 新 pref `clipboard_panel_transparent`（默认 false）+ 设置开关：开启→卡背景 `cardBgAlpha=0`（只剩文字浮在游戏上）；关闭→不透明卡（零破坏）。composition 下整窗 `SetWindowAlpha` 已 no-op，透明改由逐像素卡背景承担。

**验证状态**：`flutter analyze` 全项目 clean；`flutter test test/` 全绿（11231 通过）；Windows debug 构建 3 次编译通过（Task5/6/7）。**尚未做真机视觉验证**——透明合成的像素证据（浮窗压在游戏上背景透、文字实、可点/可拖/图钉/嵌套查词）需在真实 Windows + 游戏场景复测（本 PR 保持 draft 直到验证）。

## 阶段三：收起只剩文字 / 鼠标悬停展开 ⏳ 未做（可选打磨）
host CSS/JS 的 collapse/peek 交互，依赖 Task7 的鼠标 enter/leave 已就位，后续可加。

> 全程默认值 = 旧行为（`auto_lookup=true`、`transparent=false`），老用户无感知。透明是 Windows composition 能力，非 Windows / 无 GPU 环境自动回退不透明。计划详见 worktree 内 `docs/superpowers/plans/2026-07-13-clipboard-panel-transparent-textonly.md`。