### PR TITLE
feat(sync): client→host 视频上传（互联）+ 云有声书 pull 修复

### DIFF
--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -76,6 +76,8 @@ import 'package:hibiki/src/sync/hibiki_remote_lookup_client.dart';
 import 'package:hibiki/src/sync/hibiki_remote_lookup_service.dart';
 import 'package:hibiki/src/sync/remote_audio_lookup_bytes.dart';
 import 'package:hibiki/src/utils/misc/lookup_audio_playback.dart';
+import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart'
+    show extractVideoCover;
 import 'package:hibiki/src/sync/immersion_mine_payload.dart';
 import 'package:hibiki/src/mining/immersion_mining_engine.dart';
 import 'package:hibiki/src/mining/immersion_mining_request.dart';
@@ -462,6 +464,13 @@ class AppModel with ChangeNotifier {
       onLocalAudioImported: importSyncedLocalAudioDb,
       audioDatabaseRoot: Directory('${appDirectory.path}/audiobooks'),
       videoSubtitleLangCode: targetLanguage.languageCode,
+      // client→host 视频上传（syncVideoFiles 开关驱动）：落 <documents>/remote_videos
+      // （与 client 下载远端视频落点一致，AppPaths.remoteVideosDirectory 同目录）。
+      uploadedVideoRoot: Directory('${appDirectory.path}/remote_videos'),
+      // 上传视频封面 best-effort 抽帧（桌面 ffmpeg；移动端无则留空占位）。
+      extractVideoCover: (
+              {required String videoPath, required String bookUid}) =>
+          extractVideoCover(videoPath: videoPath, bookUid: bookUid),
       removeLocalAudioEntry: (String displayName) async {
         // 按 displayName 在 LocalAudioManager 中找到对应 index 并删除。
         // LocalAudioManager.remove(int) 删除 DB 文件 + 从 prefs 移出 + 推 native。

--- a/hibiki/lib/src/sync/app_model_library_host_service.dart
+++ b/hibiki/lib/src/sync/app_model_library_host_service.dart
@@ -59,6 +59,10 @@ class AppModelLibraryHostService implements HibikiLibraryHostService {
     Directory? audioDatabaseRoot,
     Future<void> Function(String displayName)? removeLocalAudioEntry,
     String videoSubtitleLangCode = 'ja',
+    Directory? uploadedVideoRoot,
+    Future<String?> Function(
+            {required String videoPath, required String bookUid})?
+        extractVideoCover,
   })  : _db = db,
         _dictionaryResourceRoot = dictionaryResourceRoot,
         _packages = packages,
@@ -71,7 +75,9 @@ class AppModelLibraryHostService implements HibikiLibraryHostService {
         _onLocalAudioImported = onLocalAudioImported,
         _audioDatabaseRoot = audioDatabaseRoot,
         _removeLocalAudioEntry = removeLocalAudioEntry,
-        _videoSubtitleLangCode = videoSubtitleLangCode;
+        _videoSubtitleLangCode = videoSubtitleLangCode,
+        _uploadedVideoRoot = uploadedVideoRoot,
+        _extractVideoCover = extractVideoCover;
 
   final HibikiDatabase _db;
   final Directory _dictionaryResourceRoot;
@@ -114,6 +120,16 @@ class AppModelLibraryHostService implements HibikiLibraryHostService {
   /// 视频 sidecar 字幕匹配的目标语言代码（默认 'ja'）。
   /// 生产传 AppModel.targetLanguage.langCode（P4 接线任务完成后注入真实值）。
   final String _videoSubtitleLangCode;
+
+  /// client→host 上传视频的落盘根目录（可选；null 时 [importVideo] 抛 [UnsupportedError]）。
+  /// 生产传 `<documents>/remote_videos`（[AppPaths.remoteVideosDirectory] 同目录，与
+  /// client 下载远端视频落点一致）。
+  final Directory? _uploadedVideoRoot;
+
+  /// 上传视频后的封面抽取回调（可选、best-effort；null 时上传的视频无封面占位）。
+  /// 生产传 `extractVideoCover`（桌面 ffmpeg 抽帧；移动端无 ffmpeg 返 null 留空占位）。
+  final Future<String?> Function(
+      {required String videoPath, required String bookUid})? _extractVideoCover;
 
   static const String _dictionaryAssetSuffix = '.hibikidict';
 
@@ -960,6 +976,110 @@ class AppModelLibraryHostService implements HibikiLibraryHostService {
     await _db.setPrefTyped<int>(
         videoRemotePositionEpisodeAtPrefKey(id, episodeIndex),
         winner.updatedAtMs);
+  }
+
+  /// 廉价判断 host 库是否已存在 bookUid 为 [id] 的视频（一次 DB 查询）。
+  @override
+  Future<bool> videoExists(String id) async {
+    _assertSafeVideoId(id);
+    return (await _db.getVideoBookByBookUid(id)) != null;
+  }
+
+  /// 接收 client 上传的单文件视频并注册进 host 视频库（client→host live push）。
+  ///
+  /// 落盘目录按 [id] 确定（`<uploadedVideoRoot>/<safeUid>/`），故重复上传同一视频
+  /// 覆盖同一副本、不留孤儿；`upsertVideoBook` 幂等按 bookUid 覆盖同一行。封面 best-effort
+  /// 抽取，与建行解耦（绝不挡上传落库）。
+  @override
+  Future<void> importVideo(
+    File videoFile, {
+    required String id,
+    required String title,
+    String? originalFileName,
+  }) async {
+    _assertSafeVideoId(id);
+    final Directory? root = _uploadedVideoRoot;
+    if (root == null) {
+      throw UnsupportedError(
+        'importVideo requires uploadedVideoRoot to be provided',
+      );
+    }
+    await _runExclusive(() async {
+      final String safeUid = _sanitizeVideoIdForPath(id);
+      final Directory destDir = Directory(p.join(root.path, safeUid));
+      destDir.createSync(recursive: true);
+      final File dest = File(
+          p.join(destDir.path, _uploadedVideoFileName(originalFileName, id)));
+      await _moveFileInto(videoFile, dest);
+      await _db.upsertVideoBook(VideoBooksCompanion(
+        bookUid: Value(id),
+        title: Value(title),
+        videoPath: Value(dest.path),
+        // 无外挂字幕上传：回退内嵌默认轨（与 client 下载无字幕分支一致）。
+        embeddedSubtitleTrack: const Value<int?>(0),
+        importedAt: Value(DateTime.now()),
+      ));
+    });
+    // 封面 best-effort，与建行解耦：抽帧走 ffmpeg 慢，失败留空占位（移动端无 ffmpeg
+    // 返 null），绝不让封面失败使整个上传报错。
+    final Future<String?> Function(
+        {required String videoPath,
+        required String bookUid})? extractor = _extractVideoCover;
+    if (extractor != null) {
+      final VideoBookRow? row = await _db.getVideoBookByBookUid(id);
+      if (row != null) {
+        try {
+          final String? coverPath =
+              await extractor(videoPath: row.videoPath, bookUid: id);
+          if (coverPath != null && coverPath.isNotEmpty) {
+            await _db.updateVideoBookCover(id, coverPath);
+          }
+        } catch (_) {
+          // best-effort：封面失败不影响上传成功。
+        }
+      }
+    }
+  }
+
+  /// 校验视频 id 不含路径穿越字符（`..` / `\`）。id 允许 `/`（bookUid 形如
+  /// `video/xxx`），落盘前经 [_sanitizeVideoIdForPath] 压平。
+  static void _assertSafeVideoId(String id) {
+    if (id.isEmpty || id.contains('..') || id.contains('\\')) {
+      throw ArgumentError.value(id, 'id', 'unsafe video id');
+    }
+  }
+
+  /// 把视频 id 压成单层安全目录名（`/` → `_`，其余非白名单字符 → `_`）。
+  static String _sanitizeVideoIdForPath(String id) =>
+      id.replaceAll(RegExp(r'[^A-Za-z0-9._-]'), '_');
+
+  /// 上传视频落盘文件名：优先保留上传方原始 basename 的扩展名（media_kit 依赖扩展名
+  /// 判容器）；basename 缺失/不安全时回退 `<safeUid>.mp4`。
+  static String _uploadedVideoFileName(String? originalFileName, String id) {
+    if (originalFileName != null && originalFileName.isNotEmpty) {
+      final String base = p.basename(originalFileName);
+      final String safe = base.replaceAll(RegExp(r'[/\\]'), '_');
+      if (safe.isNotEmpty &&
+          !safe.contains('..') &&
+          p.extension(safe).isNotEmpty) {
+        return safe;
+      }
+    }
+    return '${_sanitizeVideoIdForPath(id)}.mp4';
+  }
+
+  /// 把 [src] 搬进 [dest]（同卷 rename 最快；跨卷 rename 失败回退 copy + delete）。
+  static Future<void> _moveFileInto(File src, File dest) async {
+    try {
+      await src.rename(dest.path);
+    } on FileSystemException {
+      await src.copy(dest.path);
+      try {
+        await src.delete();
+      } catch (_) {
+        // best-effort：源临时文件删除失败不影响落库（上层临时目录整体清理）。
+      }
+    }
   }
 
   // ── 聚合（统计 + 收藏，TODO-1056 phase C）────────────────────────────────────

--- a/hibiki/lib/src/sync/hibiki_client_sync_backend.dart
+++ b/hibiki/lib/src/sync/hibiki_client_sync_backend.dart
@@ -1106,6 +1106,38 @@ class HibikiClientSyncBackend extends SyncBackend
     ];
   }
 
+  /// 把本地视频 [file] 上传到对端 host，注册成 bookUid 为 [id] 的视频（client→host，
+  /// syncVideoFiles 开关驱动的 live push）。[title] 与原始文件名经 URL-encode 走 header
+  /// （HTTP header 只收 ASCII，日文标题/文件名必须编码）。流式发送、不整块读进内存
+  /// （视频 GB 级），进度经 [onProgress] 上报。
+  Future<void> putRemoteVideo(
+    String id,
+    File file, {
+    required String title,
+    void Function(double progress)? onProgress,
+  }) async {
+    await _ensureResolved();
+    final HttpClientRequest req = await _ops!.buildRequest(
+      'PUT',
+      '$_apiBase/api/library/videos/${_encodeVideoId(id)}',
+    );
+    final int length = await file.length();
+    final String baseName = file.path.split(RegExp(r'[/\\]')).last;
+    req.headers.set('Content-Type', 'application/octet-stream');
+    req.headers.set('Content-Length', '$length');
+    req.headers.set('X-Hibiki-Video-Title', Uri.encodeComponent(title));
+    req.headers.set('X-Hibiki-Video-Filename', Uri.encodeComponent(baseName));
+    int sent = 0;
+    await req.addStream(file.openRead().map((List<int> chunk) {
+      sent += chunk.length;
+      onProgress?.call(length > 0 ? sent / length : 0);
+      return chunk;
+    }));
+    final HttpClientResponse res = await req.close();
+    await res.drain<void>();
+    _ops!.checkStatus(res.statusCode, 'PUT /api/library/videos/$id');
+  }
+
   /// 向 host 换取可直接播放的视频 stream URL。
   ///
   /// 返回的 [RemoteVideoStreamUrls.streamUrl] 已携带短时 token；播放器不需要

--- a/hibiki/lib/src/sync/hibiki_library_host_service.dart
+++ b/hibiki/lib/src/sync/hibiki_library_host_service.dart
@@ -1049,12 +1049,35 @@ abstract class HibikiLibraryHostService {
     int updatedAtMs,
   );
 
-  // ── 视频（只读，不同步）────────────────────────────────────────────────────────
+  // ── 视频 ──────────────────────────────────────────────────────────────────────
 
   /// host 当前视频清单（从 VideoBooks 表读，按 importedAt DESC 排序）。
   ///
-  /// 只读接口：视频文件通常数 GB，不走同步管道；这里仅供客户端请求流式传输用。
+  /// 流式播放：视频文件通常数 GB，host→client 只按需流式传输（不走同步管道下发整
+  /// 文件）；client→host 方向由 [importVideo] 接收上传（syncVideoFiles 开关驱动，
+  /// 见 [SyncOrchestrator]._syncVideosLive）。
   Future<List<RemoteVideoInfo>> listVideos();
+
+  /// 廉价判断 host 库是否已存在 bookUid 为 [id] 的视频（仅一次 DB 查询）。
+  /// 供 client 侧 push 幂等判据（远端已有同 uid+同尺寸则跳过重传）与上传端点用。
+  /// [id] 含路径穿越字符（`..` / `\`）时抛 [ArgumentError]。
+  Future<bool> videoExists(String id);
+
+  /// 接收 client 上传的单文件视频并注册进 host 视频库（client→host，
+  /// syncVideoFiles 开关驱动的 live push）。
+  ///
+  /// [videoFile] 是已落到临时位置的上传字节；实现把它搬进 host 拥有的视频目录，按
+  /// [id]（= client 端 `VideoBooks.bookUid`，跨设备稳定同步键）+ [title] upsert 一行
+  /// `VideoBooks`（`videoPath` = 目录内绝对路径），使上传的视频出现在 host 视频列表、
+  /// 可被其它 client 流式播放。bookUid 稳定 ⇒ upsert，重复上传同一视频只覆盖同一行。
+  /// [originalFileName] 用于保留扩展名（media_kit 依赖），实现须做路径穿越校验。
+  /// 封面为可选增强，best-effort 抽取，绝不挡建行落库。
+  Future<void> importVideo(
+    File videoFile, {
+    required String id,
+    required String title,
+    String? originalFileName,
+  });
 
   /// 按 [id]（即 `VideoBooks.bookUid`）反查真实视频文件。
   ///

--- a/hibiki/lib/src/sync/hibiki_sync_server.dart
+++ b/hibiki/lib/src/sync/hibiki_sync_server.dart
@@ -1784,7 +1784,61 @@ class HibikiSyncServer {
       }
     }
 
+    // PUT /api/library/videos/<id> — client→host 上传本地视频文件并注册进 host 视频库
+    // （syncVideoFiles 开关驱动的 live push）。走到此处的 PUT 必是「裸 id 无 suffix」：
+    // 所有带 suffix 的端点（cover/streamurl/stream/subtitle/position）已在上方消化（非
+    // GET 的 suffix 请求返回 405，position 的 PUT 已被上面 switch 接管）。id 允许含 `/`
+    // （bookUid 形如 video/xxx），但拒 `..` / `\`（路径穿越）。title / 原始文件名经
+    // URL-encode 走 header（HTTP header 只收 ASCII，日文标题必须编码）。
+    if (method == 'PUT' && reqPath.startsWith('/api/library/videos/')) {
+      const String prefix = '/api/library/videos/';
+      final String id = reqPath.substring(prefix.length);
+      if (id.isEmpty || id.contains('..') || id.contains('\\')) {
+        return shelf.Response(400, body: 'Invalid video id');
+      }
+      final String title =
+          _decodeHeaderValue(request, 'x-hibiki-video-title') ?? id;
+      final String? fileName =
+          _decodeHeaderValue(request, 'x-hibiki-video-filename');
+      final Directory tmpDir =
+          Directory.systemTemp.createTempSync('hibiki_video_in');
+      final File tmp = File(p.join(tmpDir.path, 'upload.bin'));
+      final IOSink sink = tmp.openWrite();
+      try {
+        await request.read().forEach(sink.add);
+        await sink.close();
+        await svc.importVideo(tmp,
+            id: id, title: title, originalFileName: fileName);
+        return shelf.Response(200);
+      } catch (e) {
+        try {
+          await sink.close();
+        } catch (_) {
+          // best-effort
+        }
+        return shelf.Response(500, body: 'Video import failed: $e');
+      } finally {
+        try {
+          tmpDir.deleteSync(recursive: true);
+        } catch (_) {
+          // best-effort
+        }
+      }
+    }
+
     return shelf.Response.notFound('Not found');
+  }
+
+  /// 从请求 header 读一个 URL-encoded 值并解码（HTTP header 只收 ASCII，非 ASCII 值
+  /// 由 client 端 [Uri.encodeComponent] 编码）。缺失/空返回 null；解码失败退回原文。
+  static String? _decodeHeaderValue(shelf.Request request, String name) {
+    final String? raw = request.headers[name];
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      return Uri.decodeComponent(raw);
+    } catch (_) {
+      return raw;
+    }
   }
 
   Map<String, Object?> _remoteVideoJsonForRequest(

--- a/hibiki/lib/src/sync/sync_compare_dialog.dart
+++ b/hibiki/lib/src/sync/sync_compare_dialog.dart
@@ -828,6 +828,8 @@ class _SyncCompareDialogState extends State<SyncCompareDialog> {
       backend: widget.backend,
       folderId: folderId,
       tempDir: _resolveTempDir(),
+      // 云后端下载远端书时一并补下其有声书包（修复云有声书「只上传拿不回」缺口）。
+      audioDatabaseRoot: widget.audioDatabaseRoot,
     );
   }
 

--- a/hibiki/lib/src/sync/sync_orchestrator.dart
+++ b/hibiki/lib/src/sync/sync_orchestrator.dart
@@ -371,11 +371,15 @@ class SyncOrchestrator {
     if (isInterconnect) {
       if (syncLocalAudio) await _syncLocalAudioLive(report, b);
       if (syncAudioBookFiles) await _syncAudiobooksLive(report, b);
+      // 互联视频文件 live push（client→host）：单文件本地视频经 host 上传端点注册进
+      // host 视频库。与云后端 syncVideoAssets 同为 syncVideoFiles 开关驱动、同为
+      // upload-only（host→client 仍走按需流式/下载）。
+      if (syncVideoFiles) await _syncVideosLive(report, b);
     } else {
       if (syncLocalAudio) await syncLocalAudioPackages(report);
       if (syncAudioBookFiles) await syncAudiobookPackages(root, report);
-      // 云视频资产上传（多端库联合视图 §2.6）：仅云后端 + 开关开启。互联视频资产走
-      // host API（后续批），不走 __videos__ 伪装资产，故留在此云后端专属分支。
+      // 云视频资产上传（多端库联合视图 §2.6）：仅云后端走 __videos__ 伪装资产。互联
+      // 视频文件走上面 _syncVideosLive 的 host API 上传，不走此云后端分支。
       if (syncVideoFiles) await syncVideoAssets(report);
     }
 
@@ -885,6 +889,8 @@ class SyncOrchestrator {
           backend: _backend,
           folderId: folder.id,
           tempDir: _tempDir,
+          // 下载远端书文件夹时一并补下其有声书包（修复云有声书「只上传拿不回」缺口）。
+          audioDatabaseRoot: _audioDatabaseRoot,
           onProgress: (double f) => _emit(SyncPhase.books,
               itemIndex: i,
               itemTotal: total,
@@ -1707,6 +1713,80 @@ class SyncOrchestrator {
     }
   }
 
+  /// 互联视频文件 live push（client→host，TODO §2.6「后续批」接线）。
+  ///
+  /// 直打对端 host 上传端点：枚举本地可上传单文件视频（[_isUploadableLocalVideo]，
+  /// 排除流媒体 / 多集播放列表），对 host 尚无（按 bookUid）或尺寸不同的推上去。视频
+  /// 身份键是 `VideoBooks.bookUid`（= host 端 [RemoteVideoInfo.id]，两端同源派生），故
+  /// 直接按 uid union，重复上传同一视频 host 端 upsert 覆盖同一行、不产生重复。
+  ///
+  /// **upload-only**：host→client 方向仍是按需流式播放 / 手动下载（视频 GB 级不进
+  /// 自动 pull），与云后端 [syncVideoAssets] 同律。互联 host 上传字节未混淆（与
+  /// [putRemoteAudiobook] 同为裸 octet-stream），故 host 清单 [RemoteVideoInfo.sizeBytes]
+  /// == 本地明文尺寸，可直接按尺寸判幂等（不必像云后端那样绕物理尺寸走清单）。
+  ///
+  /// 仅当 client syncVideoFiles 开且 isInterconnect 时由 [run] 调用。进度走
+  /// [SyncPhase.videos]，逐项错误进 report.errors 不中断，[report.videosExported] 计上传数。
+  Future<void> _syncVideosLive(
+    SyncRunReport report,
+    HibikiClientSyncBackend backend,
+  ) async {
+    // host 既有视频（uid → sizeBytes，null=host 无法 stat）。
+    final Map<String, int?> hostSizeByUid = <String, int?>{
+      for (final RemoteVideoInfo info in await backend.listRemoteVideos())
+        info.id: info.sizeBytes,
+    };
+
+    // 稳定顺序（uid 升序）遍历本地可上传视频，先算出真正要传的（host 无 / 尺寸不同），
+    // 让进度分母只计实际上传数。
+    final List<VideoBookRow> localVideos = <VideoBookRow>[
+      for (final VideoBookRow v in await _db.allVideoBooks())
+        if (_isUploadableLocalVideo(v)) v,
+    ]..sort((VideoBookRow a, VideoBookRow b) => a.bookUid.compareTo(b.bookUid));
+
+    final List<({VideoBookRow row, File file})> toPush =
+        <({VideoBookRow row, File file})>[];
+    for (final VideoBookRow v in localVideos) {
+      final File file = File(v.videoPath);
+      if (!file.existsSync()) {
+        report.errors.add(
+            'live push video "${v.title}": local file missing: ${v.videoPath}');
+        continue;
+      }
+      final bool hostHas = hostSizeByUid.containsKey(v.bookUid);
+      final int? hostSize = hostSizeByUid[v.bookUid];
+      final int localSize = await file.length();
+      // host 已有：尺寸可比且相等 ⇒ 跳过（幂等）；host 尺寸不可知（null）也跳过（无从
+      // 判差异，避免每轮全量重传大视频，下轮 host stat 成功即自愈）。host 无 ⇒ 上传。
+      if (hostHas && (hostSize == null || hostSize == localSize)) continue;
+      toPush.add((row: v, file: file));
+    }
+
+    final int total = toPush.length;
+    int index = 0;
+    for (final ({VideoBookRow row, File file}) item in toPush) {
+      final VideoBookRow v = item.row;
+      _emit(SyncPhase.videos,
+          itemIndex: index, itemTotal: total, title: v.title);
+      try {
+        await backend.putRemoteVideo(
+          v.bookUid,
+          item.file,
+          title: v.title,
+          onProgress: (double f) => _emit(SyncPhase.videos,
+              itemIndex: index,
+              itemTotal: total,
+              title: v.title,
+              fileFraction: f),
+        );
+        report.videosExported++;
+      } catch (e) {
+        report.errors.add('live push video "${v.title}": $e');
+      }
+      index++;
+    }
+  }
+
   /// Union-syncs local audio source DBs in the `__local_audio__` namespace.
   /// 资产名 = displayName（[LocalAudioDbEntry.path] 含本机时间戳，每机不同不可用）。
   /// push 本地独有（displayName 不在远端）/ pull 远端独有（displayName 不在本地）。
@@ -1924,6 +2004,7 @@ Future<bool> importRemoteBookFolder({
   required SyncBackend backend,
   required String folderId,
   required Directory tempDir,
+  Directory? audioDatabaseRoot,
   void Function(double fraction)? onProgress,
 }) async {
   final List<AssetEntry> children = await backend.listChildren(folderId);
@@ -1951,7 +2032,65 @@ Future<bool> importRemoteBookFolder({
     // TODO-1165：按标签名重建云盘书标签映射（sidecar 由 push 侧写在同文件夹，只增
     // 不删）。复用已列出的 children，不再多发一次 listChildren。
     await _applyRemoteBookFolderTags(db, backend, children, importedBookKey);
+    // 云后端有声书 pull：下载远端书文件夹时若带 `audiobook.hibikiaudio`（push 侧
+    // syncAudiobookPackages 写在同文件夹），且调用方注入了 [audioDatabaseRoot]，一并
+    // 补下音频包。修复历史缺口——此前 syncAudiobookPackages 是 upload-only、
+    // importRemoteBookFolder 只找 `.epub`，导致云有声书「只上传拿不回」。best-effort：
+    // 音频补下失败不影响 EPUB 已成功导入。
+    if (audioDatabaseRoot != null) {
+      await _pullRemoteFolderAudiobook(
+        db: db,
+        backend: backend,
+        children: children,
+        bookKey: importedBookKey,
+        audioDatabaseRoot: audioDatabaseRoot,
+        tempDir: tempDir,
+      );
+    }
     return true;
+  } finally {
+    try {
+      if (tmp.existsSync()) tmp.deleteSync();
+    } catch (_) {
+      // best-effort temp cleanup
+    }
+  }
+}
+
+/// 若远端书文件夹 [children] 里存在 `audiobook.hibikiaudio`（[kSyncAudiobookAssetName]），
+/// 下载并用本地刚导入 EPUB 的 [bookKey] 作 `bookKeyOverride` 解包落盘（修复云后端有声书
+/// 「只上传拿不回」缺口）。无音频资产是常态（普通书）——静默返回。best-effort：下载/
+/// 解包失败仅吞掉（EPUB 已成功导入，不因音频回退整本失败）。
+Future<void> _pullRemoteFolderAudiobook({
+  required HibikiDatabase db,
+  required SyncBackend backend,
+  required List<AssetEntry> children,
+  required String bookKey,
+  required Directory audioDatabaseRoot,
+  required Directory tempDir,
+}) async {
+  AssetEntry? audioAsset;
+  for (final AssetEntry e in children) {
+    if (!e.isFolder && e.name == kSyncAudiobookAssetName) {
+      audioAsset = e;
+      break;
+    }
+  }
+  if (audioAsset == null) return;
+
+  final File tmp = File(p.join(
+    tempDir.path,
+    'hibiki_remote_audio_${DateTime.now().microsecondsSinceEpoch}.hibikiaudio',
+  ));
+  try {
+    await backend.getAsset(audioAsset.id, tmp);
+    await SyncAssetPackageService(db: db).importAudioDatabasePackage(
+      packageFile: tmp,
+      audioDatabaseRoot: audioDatabaseRoot,
+      bookKeyOverride: bookKey,
+    );
+  } catch (_) {
+    // best-effort：音频补下失败不影响 EPUB 已成功导入。
   } finally {
     try {
       if (tmp.existsSync()) tmp.deleteSync();

--- a/hibiki/lib/src/sync/sync_settings_schema.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema.dart
@@ -232,17 +232,15 @@ SettingsDestination buildSyncBackupDestination() {
                   .setSyncAudioBookFilesEnabled(value);
             },
           ),
-          // 上传视频文件（多端库联合视图 §2.6）：默认关。仅**云后端**可见——上传走
-          // syncVideoAssets 的 `__videos__` 伪装资产，只在 run() 的非互联分支执行；
-          // 互联（hibikiServer）视频资产走 host API（后续批），此开关在互联下纯空转，
-          // 故沿既有 backend-scope visible 范式仅云后端显示。
+          // 上传视频文件（多端库联合视图 §2.6）：默认关，全后端可见。云后端走
+          // syncVideoAssets 的 `__videos__` 伪装资产（run() 非互联分支）；互联
+          // （hibikiServer）走 _syncVideosLive 的 host 上传端点（client→host）。两条通道
+          // 同为 upload-only（host→client 仍按需流式/下载），故此开关对所有后端都生效。
           SettingsSwitchItem(
             id: 'sync.video_files',
             title: t.sync_video_files,
             subtitle: t.sync_video_files_warning,
             icon: Icons.video_file_outlined,
-            visible: (SettingsContext ctx) =>
-                _syncSettings(ctx).backendType != SyncBackendType.hibikiServer,
             value: (SettingsContext ctx) => _syncSettings(ctx).syncVideoFiles,
             onChanged: (SettingsContext ctx, bool value) async {
               _syncSettings(ctx).syncVideoFiles = value;

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+720
+version: 1.2.0+721
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/sync/cloud_book_folder_tags_test.dart
+++ b/hibiki/test/sync/cloud_book_folder_tags_test.dart
@@ -9,7 +9,7 @@ import 'package:hibiki/src/sync/sync_asset_store.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_manager.dart' show kSyncBookTagsAssetName;
 import 'package:hibiki/src/sync/sync_orchestrator.dart'
-    show importRemoteBookFolder;
+    show importRemoteBookFolder, kSyncAudiobookAssetName;
 import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/src/sync/ttu_filename.dart';
 import 'package:hibiki/src/sync/ttu_models.dart';
@@ -67,15 +67,21 @@ class _FakeBookFolderBackend implements SyncBackend {
     required this.folderId,
     required this.sidecarJson,
     this.includeSidecarEntry = true,
+    this.includeAudiobookEntry = false,
   });
 
   final String bookTitle;
   final String folderId;
   final Object? sidecarJson;
   final bool includeSidecarEntry;
+  final bool includeAudiobookEntry;
+
+  /// getAsset 请求过的 assetId（供断言云有声书 pull 是否被触达）。
+  final List<String> requestedAssetIds = <String>[];
 
   static const String epubAssetId = 'epubAsset1';
   static const String sidecarAssetId = 'tagsSidecar1';
+  static const String audiobookAssetId = 'audioAsset1';
 
   @override
   Future<List<AssetEntry>> listChildren(String id) async {
@@ -84,12 +90,21 @@ class _FakeBookFolderBackend implements SyncBackend {
       const AssetEntry(id: epubAssetId, name: 'book.epub'),
       if (includeSidecarEntry)
         const AssetEntry(id: sidecarAssetId, name: kSyncBookTagsAssetName),
+      if (includeAudiobookEntry)
+        const AssetEntry(id: audiobookAssetId, name: kSyncAudiobookAssetName),
     ];
   }
 
   @override
   Future<void> getAsset(String assetId, File destination,
       {void Function(double progress)? onProgress}) async {
+    requestedAssetIds.add(assetId);
+    // 有声书资产：写非法包字节，让 importAudioDatabasePackage 抛错（被
+    // _pullRemoteFolderAudiobook 吞掉）——本测试只验证「下载路径是否触达该资产」。
+    if (assetId == audiobookAssetId) {
+      await destination.writeAsBytes(<int>[0, 1, 2, 3]);
+      return;
+    }
     await destination.writeAsBytes(_buildMinimalEpub(bookTitle));
   }
 
@@ -353,5 +368,58 @@ void main() {
           reason: 'malformed sidecar $malformed must degrade to empty tags');
       expect(await db.getAllTags(), isEmpty);
     }
+  });
+
+  // ── 云后端有声书 pull（修复「只上传拿不回」缺口）──────────────────────────────
+  test('提供 audioDatabaseRoot 时下载远端书文件夹会补拉 audiobook.hibikiaudio', () async {
+    final HibikiDatabase db = _memDb();
+    addTearDown(db.close);
+    final _FakeBookFolderBackend backend = _FakeBookFolderBackend(
+      bookTitle: 'BookWithAudio',
+      folderId: 'folderAudio',
+      sidecarJson: null,
+      includeSidecarEntry: false,
+      includeAudiobookEntry: true,
+    );
+    final Directory audioRoot = freshTemp();
+
+    final bool imported = await importRemoteBookFolder(
+      db: db,
+      backend: backend,
+      folderId: backend.folderId,
+      tempDir: freshTemp(),
+      audioDatabaseRoot: audioRoot,
+    );
+
+    expect(imported, isTrue); // EPUB 导入成功
+    expect(await db.getAllEpubBooks(), hasLength(1));
+    // 关键：下载路径触达了有声书资产（此前只找 .epub、拿不回音频）。
+    expect(backend.requestedAssetIds,
+        contains(_FakeBookFolderBackend.audiobookAssetId));
+  });
+
+  test('未提供 audioDatabaseRoot 时不拉 audiobook.hibikiaudio（保持旧行为）', () async {
+    final HibikiDatabase db = _memDb();
+    addTearDown(db.close);
+    final _FakeBookFolderBackend backend = _FakeBookFolderBackend(
+      bookTitle: 'BookAudioSkipped',
+      folderId: 'folderAudioSkip',
+      sidecarJson: null,
+      includeSidecarEntry: false,
+      includeAudiobookEntry: true,
+    );
+
+    final bool imported = await importRemoteBookFolder(
+      db: db,
+      backend: backend,
+      folderId: backend.folderId,
+      tempDir: freshTemp(),
+      // audioDatabaseRoot 缺省 null
+    );
+
+    expect(imported, isTrue);
+    expect(backend.requestedAssetIds,
+        isNot(contains(_FakeBookFolderBackend.audiobookAssetId)),
+        reason: '未注入 audioDatabaseRoot 时绝不触达有声书资产（向后兼容）');
   });
 }

--- a/hibiki/test/sync/dictionary_delete_propagation_test.dart
+++ b/hibiki/test/sync/dictionary_delete_propagation_test.dart
@@ -153,6 +153,15 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<List<RemoteVideoInfo>> listVideos() async => <RemoteVideoInfo>[];
 
   @override
+  Future<bool> videoExists(String id) async => false;
+
+  @override
+  Future<void> importVideo(File videoFile,
+      {required String id,
+      required String title,
+      String? originalFileName}) async {}
+
+  @override
   Future<File?> resolveVideoFile(String id, {int episodeIndex = 0}) async =>
       null;
 

--- a/hibiki/test/sync/hibiki_client_live_audio_test.dart
+++ b/hibiki/test/sync/hibiki_client_live_audio_test.dart
@@ -167,6 +167,15 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<List<RemoteVideoInfo>> listVideos() async => <RemoteVideoInfo>[];
 
   @override
+  Future<bool> videoExists(String id) async => false;
+
+  @override
+  Future<void> importVideo(File videoFile,
+      {required String id,
+      required String title,
+      String? originalFileName}) async {}
+
+  @override
   Future<File?> resolveVideoFile(String id, {int episodeIndex = 0}) async =>
       null;
 

--- a/hibiki/test/sync/hibiki_client_live_book_test.dart
+++ b/hibiki/test/sync/hibiki_client_live_book_test.dart
@@ -139,6 +139,15 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<List<RemoteVideoInfo>> listVideos() async => <RemoteVideoInfo>[];
 
   @override
+  Future<bool> videoExists(String id) async => false;
+
+  @override
+  Future<void> importVideo(File videoFile,
+      {required String id,
+      required String title,
+      String? originalFileName}) async {}
+
+  @override
   Future<File?> resolveVideoFile(String id, {int episodeIndex = 0}) async =>
       null;
 

--- a/hibiki/test/sync/hibiki_client_live_dict_test.dart
+++ b/hibiki/test/sync/hibiki_client_live_dict_test.dart
@@ -126,6 +126,15 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<List<RemoteVideoInfo>> listVideos() async => <RemoteVideoInfo>[];
 
   @override
+  Future<bool> videoExists(String id) async => false;
+
+  @override
+  Future<void> importVideo(File videoFile,
+      {required String id,
+      required String title,
+      String? originalFileName}) async {}
+
+  @override
   Future<File?> resolveVideoFile(String id, {int episodeIndex = 0}) async =>
       null;
 

--- a/hibiki/test/sync/hibiki_client_live_video_test.dart
+++ b/hibiki/test/sync/hibiki_client_live_video_test.dart
@@ -78,6 +78,28 @@ class _FakeLibraryService implements HibikiLibraryHostService {
           {String langCode = 'ja', int episodeIndex = 0}) async =>
       id == videoId ? subtitleFile : null;
 
+  /// 记录 client→host 上传（供上传端点 e2e 断言）。
+  final List<({String id, String title, String? fileName, List<int> bytes})>
+      uploaded =
+      <({String id, String title, String? fileName, List<int> bytes})>[];
+
+  @override
+  Future<bool> videoExists(String id) async =>
+      id == videoId || uploaded.any((u) => u.id == id);
+
+  @override
+  Future<void> importVideo(File videoFile,
+      {required String id,
+      required String title,
+      String? originalFileName}) async {
+    uploaded.add((
+      id: id,
+      title: title,
+      fileName: originalFileName,
+      bytes: await videoFile.readAsBytes(),
+    ));
+  }
+
   @override
   Future<List<RemoteDictionaryInfo>> listDictionaries() async =>
       <RemoteDictionaryInfo>[];
@@ -227,18 +249,20 @@ void main() {
   late HibikiSyncServer server;
   late String base;
   late _EmbeddedSubtitleFfmpegBackend ffmpeg;
+  late _FakeLibraryService library;
   const String token = 'live-video-token';
 
   setUp(() async {
     ffmpeg = _EmbeddedSubtitleFfmpegBackend();
     setFfmpegBackendForTesting(ffmpeg);
+    library = _FakeLibraryService();
     server = HibikiSyncServer(
       syncDataDir:
           Directory.systemTemp.createTempSync('hbk_live_video_srv').path,
       port: 0,
       token: token,
       allowLan: false,
-      libraryService: _FakeLibraryService(),
+      libraryService: library,
     );
     await server.start();
     base = 'http://127.0.0.1:${server.port}';
@@ -260,6 +284,27 @@ void main() {
     expect(result.single.title, 'Sample Video');
     expect(result.single.sizeBytes, 16);
     expect(result.single.hasSubtitle, isTrue);
+  });
+
+  test('putRemoteVideo uploads local video file to host (client→host)',
+      () async {
+    final HibikiClientSyncBackend backend =
+        await _buildBackend(base: base, token: token);
+    final Directory tmp = Directory.systemTemp.createTempSync('hbk_vid_up');
+    addTearDown(() => tmp.deleteSync(recursive: true));
+    // 非 ASCII 文件名 + 标题：验证 header URL-encode 往返（HTTP header 只收 ASCII）。
+    final File local = File('${tmp.path}/映画.mp4')
+      ..writeAsBytesSync(<int>[10, 20, 30, 40, 50]);
+
+    await backend.putRemoteVideo('video/uploaded', local, title: '映画タイトル');
+
+    expect(library.uploaded, hasLength(1));
+    final ({String id, String title, String? fileName, List<int> bytes}) rec =
+        library.uploaded.single;
+    expect(rec.id, 'video/uploaded'); // 含 `/` 的 bookUid 经 _encodeVideoId 往返
+    expect(rec.title, '映画タイトル'); // 非 ASCII 标题经 header 往返正确
+    expect(rec.fileName, '映画.mp4'); // 原始文件名保留（供 host 保扩展名）
+    expect(rec.bytes, <int>[10, 20, 30, 40, 50]); // 字节流完整送达
   });
 
   test('remoteVideoStreamUrls returns directly playable token stream URL',

--- a/hibiki/test/sync/hibiki_library_host_service_video_test.dart
+++ b/hibiki/test/sync/hibiki_library_host_service_video_test.dart
@@ -16,6 +16,10 @@ AppModelLibraryHostService _makeService({
   required HibikiDatabase db,
   required Directory tmp,
   String langCode = 'ja',
+  Directory? uploadedVideoRoot,
+  Future<String?> Function(
+          {required String videoPath, required String bookUid})?
+      extractVideoCover,
 }) {
   final Directory dictRoot = Directory(p.join(tmp.path, 'dicts'))
     ..createSync(recursive: true);
@@ -26,6 +30,8 @@ AppModelLibraryHostService _makeService({
     refreshDictionaryCache: () async {},
     runExclusive: (Future<void> Function() body) => body(),
     videoSubtitleLangCode: langCode,
+    uploadedVideoRoot: uploadedVideoRoot,
+    extractVideoCover: extractVideoCover,
   );
 }
 
@@ -547,6 +553,113 @@ void main() {
           await svc.getVideoPosition('video/missing');
       expect(progress.positionMs, 0);
       expect(progress.updatedAtMs, 0);
+    });
+  });
+
+  // ── importVideo / videoExists（client→host 上传落库）────────────────────────────
+  group('importVideo / videoExists', () {
+    test('上传视频落进 uploadedVideoRoot 并 upsert VideoBooks 行（保留扩展名）', () async {
+      final Directory uploads = Directory(p.join(tmp.path, 'remote_videos'))
+        ..createSync(recursive: true);
+      final AppModelLibraryHostService svc =
+          _makeService(db: db, tmp: tmp, uploadedVideoRoot: uploads);
+
+      // client 上传的临时字节（模拟 server 落到临时目录的 body）。
+      final File upload = File(p.join(tmp.path, 'upload.bin'))
+        ..writeAsBytesSync(List<int>.filled(2048, 7));
+
+      await svc.importVideo(
+        upload,
+        id: 'video/film',
+        title: '映画タイトル',
+        originalFileName: 'movie.mkv',
+      );
+
+      final VideoBookRow? row = await db.getVideoBookByBookUid('video/film');
+      expect(row, isNotNull);
+      expect(row!.title, '映画タイトル');
+      // 落在 uploadedVideoRoot 下，保留上传原始扩展名（media_kit 依赖）。
+      expect(p.isWithin(uploads.path, row.videoPath), isTrue);
+      expect(p.extension(row.videoPath), '.mkv');
+      expect(File(row.videoPath).existsSync(), isTrue);
+      expect(File(row.videoPath).lengthSync(), 2048);
+      // 上传临时源已被搬走（rename/move 语义），不留孤儿。
+      expect(upload.existsSync(), isFalse);
+
+      expect(await svc.videoExists('video/film'), isTrue);
+      expect(await svc.videoExists('video/absent'), isFalse);
+    });
+
+    test('重复上传同一 bookUid 幂等覆盖同一行（不产生重复条目）', () async {
+      final Directory uploads = Directory(p.join(tmp.path, 'remote_videos'))
+        ..createSync(recursive: true);
+      final AppModelLibraryHostService svc =
+          _makeService(db: db, tmp: tmp, uploadedVideoRoot: uploads);
+
+      await svc.importVideo(
+        File(p.join(tmp.path, 'u1.bin'))
+          ..writeAsBytesSync(List<int>.filled(100, 1)),
+        id: 'video/dup',
+        title: 'First',
+        originalFileName: 'a.mp4',
+      );
+      await svc.importVideo(
+        File(p.join(tmp.path, 'u2.bin'))
+          ..writeAsBytesSync(List<int>.filled(200, 2)),
+        id: 'video/dup',
+        title: 'Second',
+        originalFileName: 'a.mp4',
+      );
+
+      final List<VideoBookRow> all = await db.allVideoBooks();
+      expect(all.where((VideoBookRow v) => v.bookUid == 'video/dup').length, 1);
+      final VideoBookRow row =
+          await db.getVideoBookByBookUid('video/dup') as VideoBookRow;
+      expect(row.title, 'Second');
+      expect(File(row.videoPath).lengthSync(), 200);
+    });
+
+    test('best-effort 抽取封面回写 coverPath', () async {
+      final Directory uploads = Directory(p.join(tmp.path, 'remote_videos'))
+        ..createSync(recursive: true);
+      final File coverFile = File(p.join(tmp.path, 'cover.png'))
+        ..writeAsBytesSync(<int>[1, 2, 3]);
+      final AppModelLibraryHostService svc = _makeService(
+        db: db,
+        tmp: tmp,
+        uploadedVideoRoot: uploads,
+        extractVideoCover: (
+                {required String videoPath, required String bookUid}) async =>
+            coverFile.path,
+      );
+
+      await svc.importVideo(
+        File(p.join(tmp.path, 'u.bin'))..writeAsBytesSync(<int>[9]),
+        id: 'video/withcover',
+        title: 'Cover',
+        originalFileName: 'c.mp4',
+      );
+
+      final VideoBookRow row =
+          await db.getVideoBookByBookUid('video/withcover') as VideoBookRow;
+      expect(row.coverPath, coverFile.path);
+    });
+
+    test('未注入 uploadedVideoRoot 时 importVideo 抛 UnsupportedError', () async {
+      final AppModelLibraryHostService svc = _makeService(db: db, tmp: tmp);
+      expect(
+        () => svc.importVideo(
+          File(p.join(tmp.path, 'x.bin'))..writeAsBytesSync(<int>[0]),
+          id: 'video/x',
+          title: 'X',
+        ),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('videoExists 拒路径穿越 id', () async {
+      final AppModelLibraryHostService svc = _makeService(db: db, tmp: tmp);
+      expect(() => svc.videoExists('../escape'), throwsA(isA<ArgumentError>()));
     });
   });
 }

--- a/hibiki/test/sync/hibiki_sync_server_audio_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_audio_test.dart
@@ -179,6 +179,15 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<List<RemoteVideoInfo>> listVideos() async => <RemoteVideoInfo>[];
 
   @override
+  Future<bool> videoExists(String id) async => false;
+
+  @override
+  Future<void> importVideo(File videoFile,
+      {required String id,
+      required String title,
+      String? originalFileName}) async {}
+
+  @override
   Future<File?> resolveVideoFile(String id, {int episodeIndex = 0}) async =>
       null;
 

--- a/hibiki/test/sync/hibiki_sync_server_books_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_books_test.dart
@@ -128,6 +128,15 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<List<RemoteVideoInfo>> listVideos() async => <RemoteVideoInfo>[];
 
   @override
+  Future<bool> videoExists(String id) async => false;
+
+  @override
+  Future<void> importVideo(File videoFile,
+      {required String id,
+      required String title,
+      String? originalFileName}) async {}
+
+  @override
   Future<File?> resolveVideoFile(String id, {int episodeIndex = 0}) async =>
       null;
 

--- a/hibiki/test/sync/hibiki_sync_server_library_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_library_test.dart
@@ -118,6 +118,15 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<List<RemoteVideoInfo>> listVideos() async => <RemoteVideoInfo>[];
 
   @override
+  Future<bool> videoExists(String id) async => false;
+
+  @override
+  Future<void> importVideo(File videoFile,
+      {required String id,
+      required String title,
+      String? originalFileName}) async {}
+
+  @override
   Future<File?> resolveVideoFile(String id, {int episodeIndex = 0}) async =>
       null;
 

--- a/hibiki/test/sync/hibiki_sync_server_video_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_video_test.dart
@@ -90,6 +90,21 @@ class _FakeLibraryService implements HibikiLibraryHostService {
     ];
   }
 
+  final List<({String id, String title, String? fileName})> uploaded =
+      <({String id, String title, String? fileName})>[];
+
+  @override
+  Future<bool> videoExists(String id) async =>
+      id == videoId || uploaded.any((u) => u.id == id);
+
+  @override
+  Future<void> importVideo(File videoFile,
+      {required String id,
+      required String title,
+      String? originalFileName}) async {
+    uploaded.add((id: id, title: title, fileName: originalFileName));
+  }
+
   @override
   Future<File?> resolveVideoFile(String id, {int episodeIndex = 0}) async {
     if (id == videoId) return videoFile;

--- a/hibiki/test/sync/sync_backend_utf8_body_test.dart
+++ b/hibiki/test/sync/sync_backend_utf8_body_test.dart
@@ -126,6 +126,15 @@ class _CapturingLibraryService implements HibikiLibraryHostService {
   Future<List<RemoteVideoInfo>> listVideos() async => <RemoteVideoInfo>[];
 
   @override
+  Future<bool> videoExists(String id) async => false;
+
+  @override
+  Future<void> importVideo(File videoFile,
+      {required String id,
+      required String title,
+      String? originalFileName}) async {}
+
+  @override
   Future<File?> resolveVideoFile(String id, {int episodeIndex = 0}) async =>
       null;
 

--- a/hibiki/test/sync/sync_compare_live_book_test.dart
+++ b/hibiki/test/sync/sync_compare_live_book_test.dart
@@ -119,6 +119,15 @@ class _LiveBookLibraryService implements HibikiLibraryHostService {
   Future<List<RemoteVideoInfo>> listVideos() async => <RemoteVideoInfo>[];
 
   @override
+  Future<bool> videoExists(String id) async => false;
+
+  @override
+  Future<void> importVideo(File videoFile,
+      {required String id,
+      required String title,
+      String? originalFileName}) async {}
+
+  @override
   Future<File?> resolveVideoFile(String id, {int episodeIndex = 0}) async =>
       null;
 

--- a/hibiki/test/sync/sync_orchestrator_live_video_test.dart
+++ b/hibiki/test/sync/sync_orchestrator_live_video_test.dart
@@ -1,0 +1,152 @@
+/// 互联视频文件 live push（client→host）full-sweep 测试。
+///
+/// 覆盖 [SyncOrchestrator]._syncVideosLive：syncVideoFiles 开启时，本地单文件视频经
+/// host 上传端点注册进 host 视频库；流媒体（http 路径）/ 多集播放列表被
+/// _isUploadableLocalVideo 跳过；同尺寸幂等（重复 sweep 不重传、不产生重复条目）。
+/// 用真实 server/host/client/local，端到端打通 client putRemoteVideo → server PUT
+/// 端点 → host importVideo 落库。
+library;
+
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/app_model_library_host_service.dart';
+import 'package:hibiki/src/sync/hibiki_client_sync_backend.dart';
+import 'package:hibiki/src/sync/hibiki_sync_server.dart';
+import 'package:hibiki/src/sync/sync_asset_package_service.dart';
+import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/sync_orchestrator.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+HibikiDatabase _memDb() =>
+    HibikiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+
+Future<HibikiClientSyncBackend> _buildClientBackend({
+  required String base,
+  required String token,
+}) async {
+  final HibikiDatabase db = _memDb();
+  final SyncRepository repo = SyncRepository(db);
+  await repo.setHibikiClientUrls(<HibikiClientUrl>[
+    HibikiClientUrl(url: base, enabled: true),
+  ]);
+  await repo.setHibikiClientToken(token);
+  final HibikiClientSyncBackend backend =
+      HibikiClientSyncBackend.withProbe((String u, String t) async => true);
+  await backend.restoreAuth(repo);
+  await backend.authenticate(repo: repo);
+  return backend;
+}
+
+SyncOrchestrator _orchestrator({
+  required HibikiDatabase db,
+  required SyncBackend backend,
+  required Directory tmp,
+}) =>
+    SyncOrchestrator(
+      db: db,
+      backend: backend,
+      dictionaryResourceRoot: tmp,
+      audioDatabaseRoot: tmp,
+      tempDir: tmp,
+      syncStats: false,
+      syncAudioBookPosition: false,
+      syncContent: false,
+      syncAudioBookFiles: false,
+      syncVideoFiles: true,
+      syncDictionary: false,
+      syncLocalAudio: false,
+    );
+
+void main() {
+  late Directory work;
+  late HibikiSyncServer server;
+  late HibikiDatabase hostDb;
+  late Directory hostUploads;
+  late String base;
+  const String token = 'orch-live-video-token';
+
+  setUp(() async {
+    work = await Directory.systemTemp.createTemp('orch_live_video_');
+    hostDb = _memDb();
+    hostUploads = Directory(p.join(work.path, 'host_uploads'))
+      ..createSync(recursive: true);
+    final AppModelLibraryHostService libSvc = AppModelLibraryHostService(
+      db: hostDb,
+      dictionaryResourceRoot: Directory(work.path),
+      packages: SyncAssetPackageService(db: hostDb),
+      refreshDictionaryCache: () async {},
+      runExclusive: (Future<void> Function() body) => body(),
+      uploadedVideoRoot: hostUploads,
+    );
+    server = HibikiSyncServer(
+      syncDataDir: p.join(work.path, 'server_data'),
+      port: 0,
+      token: token,
+      allowLan: false,
+      libraryService: libSvc,
+    );
+    await server.start();
+    base = 'http://127.0.0.1:${server.port}';
+  });
+
+  tearDown(() async {
+    await server.stop();
+    await hostDb.close();
+    if (work.existsSync()) await work.delete(recursive: true);
+  });
+
+  test('本地单文件视频上传到 host；流媒体/播放列表跳过；同尺寸幂等', () async {
+    final HibikiDatabase localDb = _memDb();
+    addTearDown(localDb.close);
+
+    // 可上传：真实本地单文件视频。
+    final File localVid = File(p.join(work.path, 'movie.mp4'))
+      ..writeAsBytesSync(<int>[1, 2, 3, 4, 5, 6, 7, 8]);
+    await localDb.upsertVideoBook(VideoBooksCompanion.insert(
+      bookUid: 'video/movie',
+      title: 'Movie',
+      videoPath: localVid.path,
+    ));
+    // 流媒体：http 路径，无本地字节 → _isUploadableLocalVideo 跳过。
+    await localDb.upsertVideoBook(VideoBooksCompanion.insert(
+      bookUid: 'video/stream',
+      title: 'Stream',
+      videoPath: 'https://example.com/s.m3u8',
+    ));
+    // 多集播放列表：单文件资产模型装不下 → 跳过。
+    await localDb.upsertVideoBook(VideoBooksCompanion.insert(
+      bookUid: 'video/playlist',
+      title: 'Playlist',
+      videoPath: localVid.path,
+      playlistJson:
+          const Value<String?>('[{"path":"/a.mp4"},{"path":"/b.mp4"}]'),
+    ));
+
+    final HibikiClientSyncBackend backend =
+        await _buildClientBackend(base: base, token: token);
+    final SyncRunReport report =
+        await _orchestrator(db: localDb, backend: backend, tmp: work).run();
+
+    // host 只收到可上传的单文件视频，字节完整；流媒体/播放列表未上传。
+    final List<VideoBookRow> hostVideos = await hostDb.allVideoBooks();
+    expect(hostVideos.map((VideoBookRow v) => v.bookUid).toList(),
+        <String>['video/movie']);
+    expect(report.videosExported, 1);
+    final VideoBookRow hosted = hostVideos.single;
+    expect(hosted.title, 'Movie');
+    expect(p.isWithin(hostUploads.path, hosted.videoPath), isTrue);
+    expect(File(hosted.videoPath).readAsBytesSync(),
+        <int>[1, 2, 3, 4, 5, 6, 7, 8]);
+
+    // 幂等：再跑一次 sweep，host 不重复、videosExported 归零（同尺寸跳过）。
+    final SyncRunReport report2 =
+        await _orchestrator(db: localDb, backend: backend, tmp: work).run();
+    expect((await hostDb.allVideoBooks()).length, 1);
+    expect(report2.videosExported, 0);
+  });
+}

--- a/hibiki/test/sync/sync_settings_visibility_test.dart
+++ b/hibiki/test/sync/sync_settings_visibility_test.dart
@@ -120,30 +120,27 @@ void main() {
         'sync.local_audio',
         'sync.content',
         'sync.audiobook_files',
+        // 视频文件上传现在两条通道都实现（云后端 __videos__ 伪装资产；互联走 host 上传
+        // 端点 _syncVideosLive），故与其它「同步什么」开关一样全后端无条件可见。
+        'sync.video_files',
       ]) {
         expect(byId(id).visible, isNull,
             reason: '$id is a content-scope setting, global to every backend');
       }
-      // sync.video_files is cloud-backend-scoped: 上传走 __videos__ 伪装资产，只在
-      // run() 非互联分支执行，互联(hibikiServer)下纯空转，故 gated（仅云后端可见）。
-      expect(byId('sync.video_files').visible, isNotNull,
-          reason:
-              'video upload only works on cloud backends (not interconnect)');
     });
 
-    test('sync.video_files gate hides only on the interconnect backend', () {
-      // Source guard: 视频上传开关必须仅在云后端可见——门控判据是
-      // `backendType != SyncBackendType.hibikiServer`（沿既有 backend-scope 范式）。
+    test('sync.video_files is unconditional across every backend', () {
+      // Source guard: 视频上传开关不再带 backend-scope 门控——云后端与互联(hibikiServer)
+      // 都实现了视频文件上传（云走 syncVideoAssets，互联走 _syncVideosLive host 端点），
+      // 故绝不能再携带 `!= SyncBackendType.hibikiServer` 之类的隐藏判据。
       final String src =
           File('lib/src/sync/sync_settings_schema.dart').readAsStringSync();
       final int at = src.indexOf("id: 'sync.video_files'");
       expect(at, greaterThanOrEqualTo(0));
       final String block = src.substring(at, at + 500);
-      expect(block, contains('visible:'),
-          reason: 'sync.video_files must carry a visibility predicate');
-      expect(block, contains('!= SyncBackendType.hibikiServer'),
+      expect(block, isNot(contains('!= SyncBackendType.hibikiServer')),
           reason:
-              'gate must hide only on the interconnect backend (cloud-only)');
+              'video upload now works on every backend; no hibikiServer gate');
     });
 
     test('auto-sync gate keys off the hosting-interconnect role (TODO-876)',


### PR DESCRIPTION
## 背景
用户报告「客户端上传不了视频到远端」。查明 develop 现状：

- **云盘后端方向**：视频上传（push）+ 下载（pull）已实现（`syncVideoAssets`/`cloud_remote_video_client`），无需重做。
- **自建 Hibiki server 互联方向**：只有 host→client 流式/下载，**client→host 上传完全没做**（代码注释标为「后续批」，`sync.video_files` 开关还对 hibikiServer 后端 `visible:` 隐藏）。这才是用户诉求真身。
- 顺带发现并修复：云后端有声书包「只上传拿不回」缺口（`importRemoteBookFolder` 只找 `.epub`）。

## 改动
**自建 server client→host 视频上传（新能力）**
- host 写侧：`HibikiLibraryHostService.importVideo`/`videoExists` 接口 + `AppModelLibraryHostService` 实现（落 `<documents>/remote_videos`、`upsertVideoBook`、best-effort 抽封面）。
- server：`PUT /api/library/videos/<id>` 上传端点（流式收大文件，复用现有 Basic 鉴权中间件；title/文件名经 header URL-encode 往返，兼容 CJK）。
- client：`HibikiClientSyncBackend.putRemoteVideo` 流式上传 + 进度。
- orchestrator：互联分支新增 `_syncVideosLive`（`syncVideoFiles` 开关驱动，复用 `_isUploadableLocalVideo` 跳流媒体/播放列表，按 uid+尺寸幂等，upload-only）。
- 设置：放开 `sync.video_files` 开关对 hibikiServer 后端的 `visible:` 门控——开关现两条通道通用（**这就是「加个配置项」**）。

**云有声书 pull 修复**
- `importRemoteBookFolder` 新增可选 `audioDatabaseRoot`，下载远端书文件夹时补拉同文件夹 `audiobook.hibikiaudio`（compare 对话框 + orchestrator `importRemoteBooks` 两处已接线）。

## 测试
- host `importVideo`/`videoExists` 落库单测（保扩展名、幂等 upsert、封面回写、无 root 抛错、拒路径穿越）。
- client↔host `putRemoteVideo` e2e（CJK header 往返 + 字节完整送达）。
- orchestrator `_syncVideosLive` full-sweep（真 server/host/client：上传单文件、跳过流媒体/播放列表、同尺寸幂等）。
- 云有声书 pull 触达 + 门控守卫；放开开关后可见性守卫更新。
- 10 个既有 `HibikiLibraryHostService` fake 补齐两个新接口方法。
- `flutter analyze` 全绿（whole package），相关 sync 测试全过。

## 待验证
真机复测：互联配对下开「视频文件同步」开关 → client 本地视频出现在 host 视频库并可被其它 client 流式播放。