### PR TITLE
fix(video): 合集行头集数改与行体同源，全云端合集不再显示「0 集」(BUG-790)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 772 条。点号进各自文件。
+> 共 773 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-790](bugs/BUG-790-video-collection-count-remote.md) | ✅ | ✅ | 视频合集行计数只数本地成员导致全云端合集显示0集 |
 | [BUG-789](bugs/BUG-789-reader-chrome-inset-stale-pagination-metrics.md) | ✅ | ✅ | 底栏 inset 后分页终点过期导致章尾不可读 |
 | [BUG-788](bugs/BUG-788-fractional-page-boundary-premature-limit.md) | ✅ | ✅ | 亚像素页距在第31页误判边界提前停翻 |
 | [BUG-787](bugs/BUG-787-vertical-pagination-drift-recurrence.md) | ✅ | ✅ | 竖排累计漂移探针取整假阳性（当前 develop 未复现） |

--- a/docs/bugs/BUG-790-video-collection-count-remote.md
+++ b/docs/bugs/BUG-790-video-collection-count-remote.md
@@ -1,0 +1,10 @@
+## BUG-790 · 视频合集行计数只数本地成员导致全云端合集显示0集
+- **报告**：2026-07-14（用户：截图圈出「0 集查看全部」）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/home_video_page.dart`（旧 `_buildVideoCollectionRow` 内 `localCount = group.items.where((it) => it.payload.local != null).length`）。
+- **[x] ① 已修复** — 行头计数改与行体 `itemCount` 同源（`memberCount = group.items.length`），见 `home_video_page.dart:2089/2100-2101`。提交见本轮 commit。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/unified_collections_architecture_guard_test.dart` 新增守卫「BUG-790：视频合集行头集数 = 行体成员数（本地+远端占位同源）」：① 禁 `localCount` 只数本地过滤喂 `video_playlist_episodes`；② 断言行头 `countLabel` 的 count 与 `itemCount` 引用同一变量（同源）。已实证：注回旧 `localCount` 口径该守卫转红，修复后转绿。
+- **备注**：
+  - 现象：多端库联合视图（任务10）把「远端有本地无」的未下载剧集折进本地合集行，行体（`itemCount`）渲染全部成员（本地 + 远端云占位卡供流播/下载），但旧口径行头**只数本地成员**。全为未下载远端剧集的合集（如「小林さんちのメイドラゴン」「Senpai wa Otoko」）行里明明有云占位卡，行头却显示「0 集」，与眼前所见割裂。有 12 集本地的「からかい上手」显示「12 集」正常，佐证是「远端成员不入计数」而非计数彻底坏。
+  - 根因层：`RemoteVideoInfo` 远端占位在 `_groupVideos` 里以 `video.id` 为 entryKey 混入 `_VideoSlot` union，`payload.local == null`；旧 `localCount` 过滤掉它们。
+  - 用户拍板口径（方案一）：行头集数 = 行里看得见的全部卡片数（本地 + 云端占位）。已落地。
+  - **未在本 bug 内处理的联合视图第二部分**：合集详情页（点「查看全部」→ `MediaCollectionDetailPage`）目前仍只读本地成员（`getCollectionItems` → `getByBookUid` 映射，纯远端成员无本地行被排除），故纯云端合集点进详情页会是空/少。这是**该 develop 既有行为**（非本次改动引入），且远端成员是 host 下发 `RemoteCollectionMembership` 的**内存匹配临时占位**、并非 `MediaCollectionItems` 真实条目，让详情页也联合展示涉及拖拽落盘/串流/移出等设计问题，属 feature 级改动，另行规划。

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -2083,10 +2083,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
           completed: it.payload.local?.completedAt != null,
         ),
     ]);
-    // #5：行头计数只数**本地成员**（远端占位成员不入 n），与合集详情页口径一致——详情页
-    // 只显示本地成员。行体（itemCount）仍渲染全部成员（含远端占位卡供流播/下载），故不变。
-    final int localCount =
-        group.items.where((it) => it.payload.local != null).length;
+    // 行头计数 = 行体实际渲染的成员数（本地 + 远端占位），与 itemCount 同源（BUG-790）。
+    // 旧口径只数本地成员，导致「全为未下载远端剧集」的合集行明明有云占位卡却显示「0 集」，
+    // 与眼前所见割裂（用户实报）。行头数字必须诚实反映该行看得见的卡片数。
+    final int memberCount = group.items.length;
     return Padding(
       padding: EdgeInsets.fromLTRB(
         tokens.spacing.card,
@@ -2097,8 +2097,8 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
       child: CollectionShelfRow(
         key: ValueKey<String>('home_video_collection_row_${collection.id}'),
         title: collection.name,
-        countLabel: t.video_playlist_episodes(count: localCount),
-        itemCount: group.items.length,
+        countLabel: t.video_playlist_episodes(count: memberCount),
+        itemCount: memberCount,
         // 与散卡网格 cell 同宽同高（unifiedShelfCardLayout；218 = 封面区 + 标题 +
         // Phase D 观看进度行）。
         itemWidth: cardLayout.cardWidth,

--- a/hibiki/test/pages/unified_collections_architecture_guard_test.dart
+++ b/hibiki/test/pages/unified_collections_architecture_guard_test.dart
@@ -345,4 +345,38 @@ void main() {
     expect(historySrc.contains("mediaType: 'remote-book'"), isFalse,
         reason: '远端书占位须给真实 mediaType（epub）才能与本地成员共键折叠');
   });
+
+  test('BUG-790：视频合集行头集数 = 行体成员数（本地+远端占位同源），全云端合集不再显示「0 集」', () {
+    // 根因：旧口径 localCount = group.items.where(local != null).length 只数本地成员，
+    // 但行体 itemCount = group.items.length 渲染全部成员（含远端未下载占位卡）。全为
+    // 远端剧集的合集行明明有云占位卡却显示「0 集」，与眼前所见割裂（用户实报）。
+    // 修复：行头计数与行体 itemCount 同源。回退到「行头只数本地」或「与 itemCount 异源」
+    // 即转红。
+    final int rowFn = homeSrc.indexOf('Widget _buildVideoCollectionRow(');
+    expect(rowFn, isNonNegative, reason: '缺 _buildVideoCollectionRow');
+    final int rowEnd = homeSrc.indexOf('\n  /// ', rowFn + 1);
+    final String rowSrc =
+        homeSrc.substring(rowFn, rowEnd < 0 ? homeSrc.length : rowEnd);
+
+    // ① 行头计数不得再用「只数本地成员」的过滤式喂 video_playlist_episodes。
+    expect(rowSrc.contains('.where((it) => it.payload.local != null).length'),
+        isFalse,
+        reason: 'BUG-790：不得再用「只数本地」过滤统计行头集数（localCount）');
+    expect(
+        RegExp(r'video_playlist_episodes\(\s*count:\s*\w*[Ll]ocal')
+            .hasMatch(rowSrc),
+        isFalse,
+        reason: 'BUG-790：行头计数不得喂 localCount，须与行体 itemCount 同源');
+
+    // ② 行头 countLabel 的 count 与 itemCount 必须引用同一变量（同源）。
+    final Match? countMatch =
+        RegExp(r'countLabel:\s*t\.video_playlist_episodes\(count:\s*(\w+)\)')
+            .firstMatch(rowSrc);
+    final Match? itemMatch = RegExp(r'itemCount:\s*(\w+)').firstMatch(rowSrc);
+    expect(countMatch, isNotNull, reason: '未找到行头 countLabel 表达式');
+    expect(itemMatch, isNotNull, reason: '未找到 itemCount 表达式');
+    expect(countMatch!.group(1), equals(itemMatch!.group(1)),
+        reason: 'BUG-790：行头集数与行体 itemCount 必须同源（同一变量），'
+            '否则「看得见却 0 集」回潮');
+  });
 }


### PR DESCRIPTION
## 现象
视频页合集行头显示「0 集查看全部」，但行里明明有云端剧集卡片（未下载占位卡）。「小林さんちのメイドラゴン」「Senpai wa Otoko」等**全为未下载远端剧集**的合集受影响；有本地集的「からかい上手」正常显示「12 集」。

## 根因
多端库联合视图（任务10）把远端占位卡（`_VideoSlot`，`payload.local == null`）折进本地合集行，行体 `itemCount = group.items.length` 渲染全部成员，但旧口径行头 `localCount = group.items.where((it) => it.payload.local != null).length` **只数本地成员** → 全云端合集行头恒「0 集」，与眼前所见割裂。

## 修复（用户拍板方案一）
行头集数 = 行里看得见的全部卡片数（本地 + 云端占位），与行体 `itemCount` 同源：
```dart
final int memberCount = group.items.length;
...
countLabel: t.video_playlist_episodes(count: memberCount),
itemCount: memberCount,
```
零破坏、单一目标。

## 测试
`hibiki/test/pages/unified_collections_architecture_guard_test.dart` 新增守卫：禁 `localCount` 只数本地喂计数 + 断言行头 count 与 `itemCount` 同源。**已实证**注回旧口径转红、修复后转绿。`flutter analyze` 变更文件 0 issue；per-file bug 守卫通过。

## 未含（另行规划）
合集详情页（查看全部）目前仍只读本地成员（该 develop 既有行为，非本次引入）。远端成员是 host 下发的内存匹配临时占位、非 `MediaCollectionItems` 真实条目，让详情页也联合展示涉及拖拽落盘/串流/移出等设计问题，属 feature 级改动。

BUG-790。待真机复测：视频页含未下载远端剧集的合集行头显示正确集数。