### PR TITLE
feat(audio): 内置 Anki 本地音频服务器(5050)预设，默认关闭

### DIFF
--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4257,6 +4257,10 @@ class AppModel with ChangeNotifier {
   static const List<String> defaultAudioSources =
       PreferencesRepository.defaultAudioSources;
 
+  /// Anki 本地音频服务器（5050）内置预设 URL 的镜像，供 UI（重置默认）引用。
+  static const String ankiLocalAudioUrl =
+      PreferencesRepository.ankiLocalAudioUrl;
+
   List<String> get audioSources => prefsRepo.audioSources;
 
   List<AudioSourceConfig> get audioSourceConfigs {

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -1228,6 +1228,13 @@ class PreferencesRepository extends ChangeNotifier {
     'https://hoshi-reader.manhhaoo-do.workers.dev/?term={term}&reading={reading}',
   ];
 
+  /// Anki 本地音频服务器（local-audio-yomichan，默认端口 5050）的内置预设 URL。
+  /// 用户装了该服务器后，在「管理音频来源」里打开开关即用；默认关闭——本地第三方
+  /// 服务不经用户同意不参与查词发音（与 hibikiRemote / worker 默认源同策）。
+  /// 由 [_withDefaultAudioSources] 对所有用户「缺则补」为一条 disabled 源。
+  static const String ankiLocalAudioUrl =
+      'http://localhost:5050/?term={term}&reading={reading}';
+
   List<String> get audioSources {
     final result = getPref('audio_sources', defaultValue: defaultAudioSources);
     if (result is List<String>) return result;
@@ -1273,14 +1280,31 @@ class PreferencesRepository extends ChangeNotifier {
   List<AudioSourceConfig> _withDefaultAudioSources(
     List<AudioSourceConfig> sources,
   ) {
-    final bool hasHibikiRemote = sources.any(
+    final List<AudioSourceConfig> result = <AudioSourceConfig>[...sources];
+
+    // hibikiRemote 恒在列首（缺则补），历史行为不变。
+    final bool hasHibikiRemote = result.any(
       (AudioSourceConfig source) => source.kind == AudioSourceKind.hibikiRemote,
     );
-    if (hasHibikiRemote) return sources;
-    return <AudioSourceConfig>[
-      AudioSourceConfig.hibikiRemote(),
-      ...sources,
-    ];
+    if (!hasHibikiRemote) {
+      result.insert(0, AudioSourceConfig.hibikiRemote());
+    }
+
+    // Anki 本地音频服务器（5050）内置预设：对所有用户「缺则补」为一条 disabled 源，
+    // 追加在列尾。用户装了服务器打开开关即用；删掉后下次读取会 disabled 重生，与
+    // hibikiRemote 恒补策略一致（TODO-083 范式）。
+    final bool hasAnki = result.any((AudioSourceConfig source) =>
+        source.kind == AudioSourceKind.remoteAudio &&
+        source.url == ankiLocalAudioUrl);
+    if (!hasAnki) {
+      result.add(AudioSourceConfig.remoteAudio(
+        url: ankiLocalAudioUrl,
+        label: 'Anki',
+        enabled: false,
+      ));
+    }
+
+    return result;
   }
 
   void setAudioSources(List<String> sources) async {

--- a/hibiki/lib/src/pages/implementations/dictionary_settings_dialog_page.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_settings_dialog_page.dart
@@ -379,6 +379,12 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
       _sources = <AudioSourceConfig>[
         if (hadHibiki) AudioSourceConfig.hibikiRemote(),
         ...AudioSourceConfig.fromLegacyUrls(AppModel.defaultAudioSources),
+        // Anki 本地音频服务器内置预设：重置默认后也在列（默认关闭，与新装一致）。
+        AudioSourceConfig.remoteAudio(
+          url: AppModel.ankiLocalAudioUrl,
+          label: 'Anki',
+          enabled: false,
+        ),
         ...locals,
       ];
     });

--- a/hibiki/test/models/preferences_repository_test.dart
+++ b/hibiki/test/models/preferences_repository_test.dart
@@ -112,6 +112,12 @@ void main() {
           ...AudioSourceConfig.fromLegacyUrls(
             PreferencesRepository.defaultAudioSources,
           ).map((AudioSourceConfig s) => s.copyWith(enabled: false)),
+          // 内置 Anki 本地音频服务器（5050）预设，追加在列尾、默认关闭。
+          AudioSourceConfig.remoteAudio(
+            url: PreferencesRepository.ankiLocalAudioUrl,
+            label: 'Anki',
+            enabled: false,
+          ),
         ],
       );
       // 没有任何源默认启用。
@@ -135,15 +141,39 @@ void main() {
 
       final PreferencesRepository repo2 = PreferencesRepository(db);
       await repo2.loadFromDb();
-      final List<AudioSourceConfig> remotes = repo2.audioSourceConfigs
-          .where((AudioSourceConfig s) => s.kind == AudioSourceKind.remoteAudio)
+      // 老用户的已启用 URL 必须仍在、仍 enabled；内置 Anki 预设会被回填但默认关闭，
+      // 故按「已启用的 remoteAudio」而非「全部 remoteAudio」定位老用户的源。
+      final List<AudioSourceConfig> enabledRemotes = repo2.audioSourceConfigs
+          .where((AudioSourceConfig s) =>
+              s.kind == AudioSourceKind.remoteAudio && s.enabled)
           .toList();
-      expect(remotes, hasLength(1));
+      expect(enabledRemotes, hasLength(1));
       expect(
-        remotes.single.url,
+        enabledRemotes.single.url,
         'https://legacy.test/?term={term}&reading={reading}',
       );
-      expect(remotes.single.enabled, isTrue);
+      repo2.dispose();
+    });
+
+    test(
+        'ankiLocalAudioUrl preset is back-filled DISABLED for existing users '
+        'who already have saved configs', () async {
+      // 已有 typed 配置但不含 Anki 源的用户：读取时必须回填一条 disabled 的 Anki
+      // 预设（标签 Anki），让所有用户都能在「管理音频来源」里打开这个开关即用。
+      await repo.setAudioSourceConfigs(<AudioSourceConfig>[
+        AudioSourceConfig.hibikiRemote(enabled: true),
+      ]);
+
+      final PreferencesRepository repo2 = PreferencesRepository(db);
+      await repo2.loadFromDb();
+      final Iterable<AudioSourceConfig> anki = repo2.audioSourceConfigs.where(
+        (AudioSourceConfig s) =>
+            s.kind == AudioSourceKind.remoteAudio &&
+            s.url == PreferencesRepository.ankiLocalAudioUrl,
+      );
+      expect(anki, hasLength(1));
+      expect(anki.single.enabled, isFalse);
+      expect(anki.single.label, 'Anki');
       repo2.dispose();
     });
 
@@ -350,6 +380,12 @@ void main() {
         AudioSourceConfig.remoteAudio(
           label: 'B',
           url: 'https://b.com/{reading}',
+          enabled: false,
+        ),
+        // 内置 Anki 本地音频服务器预设：保存的列表不含它 → 读取时回填（disabled）。
+        AudioSourceConfig.remoteAudio(
+          url: PreferencesRepository.ankiLocalAudioUrl,
+          label: 'Anki',
           enabled: false,
         ),
       ]);


### PR DESCRIPTION
## 需求
在默认音频源里加一条 `http://localhost:5050/?term={term}&reading={reading}`（local-audio-yomichan / Anki 本地音频服务器，读 Anki 里的单词发音），**默认关闭**，用户装了服务器打开开关即用。

## 现状调研
Hibiki 的音频源机制本就照 Yomitan 协议做：`remoteAudio` 源用 `{term}`/`{reading}` 占位符 + 解析 `{type:"audioSourceList",...}` JSON（`word_audio_resolver.dart`）；本地库吃 Yomitan Local Audio Server 的 SQLite。唯一缺口是没有内置 Anki-5050 预设。

## 改动
- `PreferencesRepository.ankiLocalAudioUrl` 常量 + `AppModel` 镜像
- `_withDefaultAudioSources` 仿 `hibikiRemote`「缺则补」：对**所有用户**（新装 + 已有配置）回填一条 disabled Anki 源（label `Anki`，追加列尾）
  - 顺带修原早返回 bug：`hibikiRemote` 已在时也要跑 Anki 回填
- 对话框「重置默认」也含 Anki（disabled）
- 语义与既有 `hibikiRemote`/worker 默认源一致：第三方本地服务不经用户同意不参与发音；删掉后下次读取 disabled 重生

## 验证
- `flutter analyze lib test` → No issues found
- `flutter test`（preferences_repository / app_model_audio_sources / audio_source_config / audio_sources_dialog_page）→ 全过
- 新增回填测试：老用户已有 typed 配置但无 Anki 时读取回填 disabled Anki

## 待真机
真机确认：默认列表出现关着的 Anki 开关；装了 5050 服务器打开后查词有发音。