### PR TITLE
fix(dict-popup): 空读音条目并入同一 headword 卡 (BUG-791)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 772 条。点号进各自文件。
+> 共 773 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-791](bugs/BUG-791-popup-empty-reading-split.md) | ✅ | ✅ | 查词弹窗同词因空读音拆成两张卡 |
 | [BUG-789](bugs/BUG-789-reader-chrome-inset-stale-pagination-metrics.md) | ✅ | ✅ | 底栏 inset 后分页终点过期导致章尾不可读 |
 | [BUG-788](bugs/BUG-788-fractional-page-boundary-premature-limit.md) | ✅ | ✅ | 亚像素页距在第31页误判边界提前停翻 |
 | [BUG-787](bugs/BUG-787-vertical-pagination-drift-recurrence.md) | ✅ | ✅ | 竖排累计漂移探针取整假阳性（当前 develop 未复现） |

--- a/docs/bugs/BUG-791-popup-empty-reading-split.md
+++ b/docs/bugs/BUG-791-popup-empty-reading-split.md
@@ -1,7 +1,7 @@
 ## BUG-791 · 查词弹窗同词因空读音拆成两张卡
 - **报告**：2026-07-14（用户）
 - **真实性**：✅ 真 bug — 根因 `packages/hibiki_dictionary/lib/src/language/language.dart:522` 与 `hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart:1749`
-- **[x] ① 已修复** — 见下「根因 / 修复」，提交 <PENDING>
+- **[x] ① 已修复** — 见下「根因 / 修复」，提交 `77548db8a`
 - **[x] ② 已加自动化测试** — `hibiki/test/pages/dictionary_popup_empty_reading_group_test.dart`
 - **备注**：
 

--- a/docs/bugs/BUG-791-popup-empty-reading-split.md
+++ b/docs/bugs/BUG-791-popup-empty-reading-split.md
@@ -1,0 +1,42 @@
+## BUG-791 · 查词弹窗同词因空读音拆成两张卡
+- **报告**：2026-07-14（用户）
+- **真实性**：✅ 真 bug — 根因 `packages/hibiki_dictionary/lib/src/language/language.dart:522` 与 `hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart:1749`
+- **[x] ① 已修复** — 见下「根因 / 修复」，提交 <PENDING>
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/dictionary_popup_empty_reading_group_test.dart`
+- **备注**：
+
+### 现象
+查同一个假名词（如「それだけ」）时，弹窗把它拆成上下两张 headword 卡：一张含明鏡日汉双解 / アクセント辞典 / Pixiv，另一张只含小学館日中辞典 v3。卡头表记、注音看着完全一样，用户以为是重复。
+
+### 根因
+弹窗按 `表记 + "\n" + 读音` 拼 key 分组，key 相同才并进同一张卡：
+
+```dart
+final key = '${r.term.expression}\n${r.term.reading}';   // language.dart:522
+final key = '${entry.word}\n${entry.reading}';            // dictionary_popup_webview.dart:1749
+```
+
+「それだけ」本身是假名词。按 Yomitan/Yomichan 数据约定，**当读音与表记相同时词条库常把 reading 字段留空**（"空读音 = 读音同表记"的隐含语义）。小学館日中辞典转来的这条 reading 为空，而明鏡等给了显式读音 `それだけ`：
+
+- 显式：key = `それだけ\nそれだけ`
+- 空读音：key = `それだけ\n`
+
+两个 key 不等 → 同一个词被判成两组，画成上下两张卡。界面上看不出差异是因为卡头显示的是**表记**，读音的「有 vs 空」不可见。
+
+### 修复
+按"空读音 = 读音同表记"的正确语义，分组前把空读音归一到表记再拼 key（**只归一 key，不改存储的 display reading**，空读音仍无注音、符合现状）：
+
+```dart
+final effectiveReading = reading.isEmpty ? expression : reading;
+final key = '$expression\n$effectiveReading';
+```
+
+改动两条 Dart 分组路径：
+- `buildPopupJsonFromLookup`（当前运行主路径，BUG-712 P4 后走 Dart 侧）
+- `buildLookupEntriesJson`（fallback / popup_settings_injection 路径）
+
+原生 C++ `lookupPopupJson` 已非弹窗主路径，本次不动。
+
+### 边界（多读音 + 空读音）
+- **假名词**（それだけ）：本就不可能有 2 个不同读音，空读音归一后与显式读音同 key，合成一张。✓
+- **汉字多读音词**（辛い＝つらい／からい）+ 空读音：`つらい`、`からい` 各自成组；空读音归一到表记 → `辛い\n辛い` **自成第三组**，绝不会被硬塞进 つらい 或 からい。汉字词空读音本身是歧义数据，无法判定属于哪个读音，宁可单独显示也不乱认（乱合会把释义挂到错误读音下，才是真 bug）。✓

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -1746,7 +1746,12 @@ class DictionaryPopupWebViewState
             })>> rawGlossaries = {};
 
     for (final entry in entries) {
-      final key = '${entry.word}\n${entry.reading}';
+      // BUG-791：空读音按 Yomitan 约定等价于「读音同表记」。分组前归一，
+      // 免得同一个假名词（reading 有的显式给、有的留空）被拆成两张卡。
+      // 与 buildPopupJsonFromLookup 的 key 逻辑保持一致。
+      final String effectiveReading =
+          entry.reading.isEmpty ? entry.word : entry.reading;
+      final key = '${entry.word}\n$effectiveReading';
       final extraData = _decodeExtra(entry);
       if (!groups.containsKey(key)) {
         groupKeys.add(key);

--- a/hibiki/test/pages/dictionary_popup_empty_reading_group_test.dart
+++ b/hibiki/test/pages/dictionary_popup_empty_reading_group_test.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_dictionary/hibiki_dictionary.dart';
+
+/// BUG-791 守卫：查词弹窗按「表记 + 读音」分组时，空读音必须按 Yomitan
+/// 约定归一为「读音同表记」，否则同一个假名词（一部分词典给显式读音、一部分
+/// 留空读音）会被拆成两张 headword 卡。
+///
+/// 同时守住边界：汉字多读音词的空读音**不能**被硬塞进任一真读音组。
+void main() {
+  HoshiLookupResult makeResult({
+    required String expression,
+    required String reading,
+    required String dictName,
+    required String gloss,
+  }) {
+    return HoshiLookupResult(
+      matched: expression,
+      deinflected: expression,
+      trace: const [],
+      preprocessorSteps: 0,
+      term: HoshiTermResult(
+        expression: expression,
+        reading: reading,
+        rules: '',
+        glossaries: [
+          HoshiGlossaryEntry(
+            dictName: dictName,
+            glossary: jsonEncode(gloss),
+            definitionTags: '',
+            termTags: '',
+          ),
+        ],
+        frequencies: const [],
+        pitches: const [],
+      ),
+    );
+  }
+
+  List<Map<String, dynamic>> groups(List<HoshiLookupResult> results) {
+    final json = buildPopupJsonFromLookup(results: results, maximumTerms: 100);
+    return (jsonDecode(json) as List).cast<Map<String, dynamic>>();
+  }
+
+  group('buildPopupJsonFromLookup empty-reading grouping (BUG-791)', () {
+    test('假名词：显式读音与空读音合成一张卡', () {
+      // 「それだけ」：明鏡给 reading=それだけ，小学館日中辞典 reading 留空。
+      final result = groups([
+        makeResult(
+          expression: 'それだけ',
+          reading: 'それだけ',
+          dictName: '明鏡日汉双解辞典',
+          gloss: 'その程度に応じて。',
+        ),
+        makeResult(
+          expression: 'それだけ',
+          reading: '',
+          dictName: '小学館日中辞典v3',
+          gloss: '唯独，唯一。',
+        ),
+      ]);
+
+      expect(result.length, 1, reason: '空读音应归一到表记，与显式读音合成同一张 headword 卡');
+      final gloss = result.single['glossaries'] as List;
+      expect(gloss.length, 2, reason: '两本词典的释义都进这张卡');
+    });
+
+    test('两条都是空读音的假名词也只有一张卡', () {
+      final result = groups([
+        makeResult(
+          expression: 'それだけ',
+          reading: '',
+          dictName: 'A辞典',
+          gloss: 'a',
+        ),
+        makeResult(
+          expression: 'それだけ',
+          reading: '',
+          dictName: 'B辞典',
+          gloss: 'b',
+        ),
+      ]);
+      expect(result.length, 1);
+    });
+
+    test('汉字多读音 + 空读音：空读音不被塞进任一真读音组', () {
+      // 辛い＝つらい／からい，外加一条空读音。空读音归一到表记「辛い」，
+      // 不等于 つらい 也不等于 からい → 自成第三组，绝不污染真读音。
+      final result = groups([
+        makeResult(
+          expression: '辛い',
+          reading: 'つらい',
+          dictName: 'A',
+          gloss: 'painful',
+        ),
+        makeResult(
+          expression: '辛い',
+          reading: 'からい',
+          dictName: 'B',
+          gloss: 'spicy',
+        ),
+        makeResult(
+          expression: '辛い',
+          reading: '',
+          dictName: 'C',
+          gloss: 'blank-reading entry',
+        ),
+      ]);
+
+      expect(result.length, 3, reason: '两个真读音各一组，空读音自成一组，互不合并');
+      final tsurai = result.firstWhere((g) => g['reading'] == 'つらい');
+      final karai = result.firstWhere((g) => g['reading'] == 'からい');
+      expect((tsurai['glossaries'] as List).length, 1,
+          reason: 'つらい 组不能被空读音条目污染');
+      expect((karai['glossaries'] as List).length, 1,
+          reason: 'からい 组不能被空读音条目污染');
+    });
+  });
+}

--- a/packages/hibiki_dictionary/lib/src/language/language.dart
+++ b/packages/hibiki_dictionary/lib/src/language/language.dart
@@ -519,7 +519,12 @@ String buildPopupJsonFromLookup({
       if (entryCount >= maximumTerms) break outer;
       entryCount++;
 
-      final key = '${r.term.expression}\n${r.term.reading}';
+      // BUG-791：空读音按 Yomitan 约定等价于「读音同表记」。分组前归一，
+      // 免得同一个假名词（reading 有的显式给、有的留空）被拆成两张卡。
+      // 只归一分组 key，不改存储的 display reading（空读音仍无注音）。
+      final String effectiveReading =
+          r.term.reading.isEmpty ? r.term.expression : r.term.reading;
+      final key = '${r.term.expression}\n$effectiveReading';
       if (!groupExpression.containsKey(key)) {
         groupKeys.add(key);
         groupExpression[key] = r.term.expression;


### PR DESCRIPTION
## 现象
查同一个假名词（如「それだけ」）时，弹窗把它拆成上下两张 headword 卡：一张含明鏡日汉双解 / アクセント辞典 / Pixiv，另一张只含小学館日中辞典 v3。卡头表记、注音看着完全一样，用户以为是重复。

## 根因
弹窗按 `表记 + "\n" + 读音` 拼 key 分组（`language.dart:522`、`dictionary_popup_webview.dart:1749`）。「それだけ」是假名词，按 Yomitan/Yomichan 数据约定，**读音与表记相同时词条库常把 reading 留空**（空读音=读音同表记）。小学館日中辞典 reading 为空、明鏡给显式 `それだけ`：

- `それだけ\nそれだけ` vs `それだけ\n` → 两个 key → 两张卡

## 修复
分组前把空读音归一到表记再拼 key（**只归一 key，不改 display reading**）：

```dart
final effectiveReading = reading.isEmpty ? expression : reading;
final key = '$expression\n$effectiveReading';
```

改两条 Dart 分组路径：`buildPopupJsonFromLookup`（主路径）+ `buildLookupEntriesJson`（fallback）。原生 C++ `lookupPopupJson` 已非弹窗主路径，本次不动。

## 边界（多读音 + 空读音）
- 假名词：本就不可能有 2 个不同读音，空读音归一后合成一张。
- 汉字多读音词（辛い＝つらい／からい）+ 空读音：`つらい`、`からい` 各成组；空读音归一到 `辛い\n辛い` **自成第三组，绝不塞进任一真读音**。汉字空读音是歧义数据，宁可单独显示也不乱认（乱合会把释义挂错读音）。

## 测试
新增 `hibiki/test/pages/dictionary_popup_empty_reading_group_test.dart`：假名词合并、双空读音合并、汉字多读音+空读音不污染三个用例。本地 `flutter test` 全过（含原 parity 测试），`flutter analyze` 干净。

## 待验证
真机复测原始失败路径：查「それだけ」确认只出一张 headword 卡且两本词典释义都在。

BUG-791 / 文档见 `docs/bugs/BUG-791-popup-empty-reading-split.md`