### PR TITLE
fix(video): 普通 seek 到无字幕段旧字幕不消失 (BUG-791)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 772 条。点号进各自文件。
+> 共 773 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-791](bugs/BUG-791-video-seek-gap-subtitle-linger.md) | ✅ | ✅ | 视频普通 seek（±秒键）跳到无字幕段后旧字幕不消失 |
 | [BUG-789](bugs/BUG-789-reader-chrome-inset-stale-pagination-metrics.md) | ✅ | ✅ | 底栏 inset 后分页终点过期导致章尾不可读 |
 | [BUG-788](bugs/BUG-788-fractional-page-boundary-premature-limit.md) | ✅ | ✅ | 亚像素页距在第31页误判边界提前停翻 |
 | [BUG-787](bugs/BUG-787-vertical-pagination-drift-recurrence.md) | ✅ | ✅ | 竖排累计漂移探针取整假阳性（当前 develop 未复现） |

--- a/docs/bugs/BUG-791-video-seek-gap-subtitle-linger.md
+++ b/docs/bugs/BUG-791-video-seek-gap-subtitle-linger.md
@@ -1,0 +1,20 @@
+## BUG-791 · 视频普通 seek（±秒键）跳到无字幕段后旧字幕不消失
+- **报告**：2026-07-14（用户：「跳转的时候字幕没消失，但是我都跳转走了，那段时间不应该有字幕」）。场景经确认：**本地视频文件** + **快进/快退键（±10 秒等）**。采番：`bug.dart new` 取到 790，但并发 PR#94 草稿已占 790，顺延取 791 避免撞号。
+- **真实性**：✅ **真 bug（沿真实代码路径 + 有声书权威参考互证）**。
+  - 视频底部字幕 overlay（`VideoSubtitleOverlay`）渲染 `VideoPlayerController.activeCues`；cue 同步由 125ms `Timer.periodic` 读 `player.state.position` → `updateCueForPosition` → `_syncCueForPosition` 驱动。自然播放落到句间 gap 时 `findCueIndex` 返回 -1、清空字幕（BUG-074 已修，位置准确故有效）。
+  - 但 **media_kit 的 `state.position` 不随 `seek` 同步更新，暂停态更长期停在旧位置**（本类 `_seekTargetCueIndex` 注释第 249-250 行明写此 lag；有声书 `AudiobookPlayerController._explicitSeekInFlight` 注释亦明写「暂停态 positionStream 不推进、`seek` 仍吐旧位置」）。普通 seek（`seekRelative`/`seekMs`，±秒键路径 `video_hibiki_page.dart:4209/4212 → _seekRelative → controller.seekRelative → seekMs`）**既不按已知目标位置权威同步字幕、也无在途抑制**：`seekMs` 旧实现只 `_clearSeekTargetSnap()` + `_player.seek()`。于是 seek 后 125ms tick 逐拍读到**旧 position** → `findCueIndex(旧位置)` 命中**旧句** → 旧字幕被反复确认、一直挂着；暂停重听时旧位置长期不变，旧字幕「那段时间」始终不消失。
+  - `skipToCue`（点字幕列表跳句）用 `_seekTargetCueIndex` 快照 + 在途宽限抑制了同一 lag，但普通 seek **历史上有意未置**该保护（见 `_seekSnapGraceTicksLeft` 注释末段），正是本 bug 的暴露点。
+  - 根因 `file:line`：`hibiki/lib/src/media/video/video_player_controller.dart:2429`（`seekMs` 旧实现无权威同步/无在途抑制）+ `:1798`（`updateCueForPosition` 直接吃滞后 `state.position`）。
+- **[x] ① 已修复** — 对齐有声书 `_explicitSeekInFlight` 抑制范式，只动视频 `VideoPlayerController`（`hibiki/lib/src/media/video/video_player_controller.dart`）：
+  - 新增普通 seek「在途保护」状态 `_plainSeekTargetMs` / `_plainSeekGraceTicksLeft`（+ 落地容差常量 `_kPlainSeekLandToleranceMs=250`）。
+  - `seekMs`：发 seek 前先 `_clearSeekTargetSnap()` → `_beginPlainSeekInFlight(target)` 记目标 → **立刻 `_syncCueForPosition(target, persistPosition:false)` 权威同步**（不等滞后 position），字幕即时反映目的地（gap 则立即消失）→ 再 `_player.seek()`。
+  - `updateCueForPosition`（125ms tick）经新增 `_reconcileSeekInFlightPosition(rawPos)` 调和：普通 seek 在途且非 `skipToCue` 时，**暂停态无限期返回目标位置**（positionStream 不推进）、**播放态到达 `目标−250ms` 即落定放行**，否则消耗一格宽限继续返回目标，宽限（`_seekSnapGraceTicks`=16≈2s）耗尽也放行真实位置——绝不永久把字幕钉在旧目标上。
+  - `_clearSeekTargetSnap()` 统一复位点连清普通 seek 在途状态（换字幕/换片/再次 seek/进度条拖动 `clearSeekTargetSnap` 都覆盖）。
+  - **`skipToCue` 零回归**：改走新增私有 `_rawSeekMs`（= 旧 `seekMs` 行为：仅清快照 + `player.seek`，不置在途保护），避免权威同步先把目标清成 preRoll gap、下一拍才 snap 回而闪烁；其 `_seekTargetCueIndex` 快照与本调和互斥（后者非空时 `_reconcileSeekInFlightPosition` 让路）。
+  - 提交哈希：见本分支提交。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_player_controller_test.dart` 新增 group「普通 seek 在途：跳到 gap 旧字幕立即消失、不被滞后旧 position 拉回」3 例：
+  - **暂停态 ±秒跳到 gap**（复现 bug 的红→绿守卫）：`seekMs(gap)` 后字幕**立即**消失（`currentCue==null`/`activeCues` 空），且多拍喂旧 position 1500 仍不被拉回旧句（撤修复即红——旧 tick 会 `findCueIndex(1500)=cue0`）。
+  - **播放态在途保持目标、落地放行**：在途拍旧 position 保持 gap 不回旧句；到达目标落定后放行、自然播放进入下一句正常跟随（不钉死）。
+  - **暂停态跳进某句**：立即显示目的地句、旧 position 不显示旧句（权威同步正确性）。
+  - `flutter test test/media/video/ test/media/audiobook/` 全绿（2268 passed，2 skip），既有 TODO-565 skipToCue / BUG-074 gap 用例未回归。`flutter analyze` No issues。
+- **备注**：测试宿主无 libmpv（`Player`/`load` 构造即抛），故走 `debugUpdateCueForPosition` + `debugSetIsPlayingForTesting` 纯逻辑单测（与既有 video controller 测试范式一致）。真机复测**待用户**：本地视频**暂停**中按 ±10 秒键跳到无字幕段 → 旧字幕立即消失、跳走后那段静音期无字幕；跳进某句立即显示该句；播放态 ±秒跳转后字幕正常跟随不钉死。进度条**拖动**走 media_kit 内部 seek（绕过 `seekMs`），本修复不覆盖该路径的暂停态 lag（另属既有行为，非本次报告场景）。

--- a/hibiki/lib/src/media/video/video_player_controller.dart
+++ b/hibiki/lib/src/media/video/video_player_controller.dart
@@ -263,9 +263,36 @@ class VideoPlayerController extends ChangeNotifier
   /// 自然越过目标句首（情形 1）即作废宽限、恢复正常清除语义。配额耗尽（seek 永不落地，
   /// 慢设备 / libmpv 丢弃，对齐 BUG-179）也放弃保护，绝不永久把高亮钉在旧目标上。
   ///
-  /// 用户**主动** seek（[seekRelative] / 收藏句直接 [seekMs]）走的是别的入口、不置宽限，
-  /// 且 [seekRelative] 显式清宽限+快照——手动 seek 仍能立刻清快照，不被本保护误连坐。
+  /// 用户**主动** seek（[seekRelative] / 收藏句直接 [seekMs]）走的是别的入口、不置本
+  /// **cue-snap** 宽限，且 [seekRelative] 显式清宽限+快照——手动 seek 仍能立刻清快照，不被
+  /// 本保护误连坐。（普通 seek 的在途 lag 由另一套 [_plainSeekTargetMs] 处理，见其注释。）
   int _seekSnapGraceTicksLeft = 0;
+
+  /// 普通 seek（[seekRelative] / [seekToChapter] / 页面收藏句直接 [seekMs]，**非**
+  /// [skipToCue]）的「在途目标位置」（ms，effective 前的原始播放位置）；null = 无在途普通 seek。
+  ///
+  /// **修「±秒等普通跳转到 gap 后旧字幕不消失（尤其暂停重听时）」。** media_kit 的
+  /// `player.state.position` 不随 seek 同步更新（与 [_seekTargetCueIndex] 注释同一 lag），
+  /// **暂停态更是长时间停在旧位置**（有声书 `AudiobookPlayerController._explicitSeekInFlight`
+  /// 同结论：暂停态 positionStream 不推进、`seek` 仍吐旧位置）。125ms tick
+  /// （[updateCueForPosition]）在 seek 落地前逐拍读到旧 position → [JsonAlignmentParser.findCueIndex]
+  /// 反推旧句 → 旧字幕被反复确认、一直挂着。[skipToCue] 用 [_seekTargetCueIndex] 快照抑制了
+  /// 这个 lag，但普通 seek 历史上**有意未置**保护（见 [_seekSnapGraceTicksLeft] 注释末段），
+  /// 于是暴露本 bug。
+  ///
+  /// 修法对齐有声书 `_explicitSeekInFlight` 抑制范式：[seekMs] 一发 seek 就记下目标位置、
+  /// 并立刻按目标位置**权威同步一次字幕**（直接调 [_syncCueForPosition]，不经 tick 的位置
+  /// 调和），字幕即时反映跳转目的地（gap 则消失）；随后 tick 经 [_reconcileSeekInFlightPosition]
+  /// 在 seek 落地前把「读到的旧 position」替换成目标位置——**暂停态无限期保持**（等按播放），
+  /// **播放态给有界宽限**（[_plainSeekGraceTicksLeft]）等真实位置落定后放行。与 [skipToCue]
+  /// 的 [_seekTargetCueIndex] 快照互斥（后者非空时本调和让路、不双重抑制；[skipToCue] 走
+  /// [_rawSeekMs] 也不置本状态）。
+  int? _plainSeekTargetMs;
+
+  /// 普通 seek 在途宽限剩余 tick（仅**播放态**消耗；暂停态无限期保持目标、不计此配额）。
+  /// 复用 [_seekSnapGraceTicks] 同一 2 秒量级：播放态真实位置通常一两拍即落定，配额耗尽
+  /// （慢设备 / 永不落定）也放行真实位置，绝不永久把字幕钉在旧目标上。
+  int _plainSeekGraceTicksLeft = 0;
 
   /// 音画延迟（毫秒）：正值表示"视频比文字先播"，查 cue 时把位置往回拨。
   int _delayMs = 0;
@@ -402,6 +429,11 @@ class VideoPlayerController extends ChangeNotifier
   /// [_restoreGuardGraceTicks]（10 秒）：保护只覆盖「这一次跳转的 seek 在途」短瞬，
   /// 真落地后由「首次进入引导窗口」立即作废，不会拖到 2 秒。永不落地时 2 秒后放弃保护。
   static const int _seekSnapGraceTicks = 16;
+
+  /// 普通 seek「落地判据」容差（ms）：播放态下真实 position 到达 `目标 − 本容差` 即判
+  /// seek 落定、放行真实位置（普通 seek 无 preRoll、落点≈目标，取 250ms 足够吸收关键帧
+  /// 吸附尾差与一拍 tick 推进）。见 [_reconcileSeekInFlightPosition]。
+  static const int _kPlainSeekLandToleranceMs = 250;
 
   /// 位置持久化回调：整秒变化时调用，由上层（repository）落库。
   Future<void> Function(String bookUid, int positionMs)? onPositionWrite;
@@ -1796,7 +1828,10 @@ class VideoPlayerController extends ChangeNotifier
   /// 5. 命中下标与 [_currentCueIndex] 相同时不重复 [notifyListeners]。
   /// 6. 否则更新当前 cue 并通知。
   void updateCueForPosition(int posMs) {
-    _syncCueForPosition(posMs, persistPosition: true);
+    // 普通 seek 在途：把 tick 读到的滞后旧 position 调和成跳转目标位置（见
+    // [_plainSeekTargetMs] / [_reconcileSeekInFlightPosition]），避免旧字幕被反复确认。
+    _syncCueForPosition(_reconcileSeekInFlightPosition(posMs),
+        persistPosition: true);
   }
 
   void _syncCueForPosition(int posMs, {required bool persistPosition}) {
@@ -1966,11 +2001,47 @@ class VideoPlayerController extends ChangeNotifier
     return snappedIdx;
   }
 
-  /// 清「主动跳转目标」快照（[_seekTargetCueIndex]）及其在途 seek 宽限配额，
-  /// 退回纯位置推导。换字幕 / 换片 / 用户主动 seek / 自然越过目标句都汇到这里。
+  /// 清「主动跳转目标」快照（[_seekTargetCueIndex]）及其在途 seek 宽限配额，并一并清普通
+  /// seek 在途状态（[_plainSeekTargetMs]）——退回纯位置推导。换字幕 / 换片 / 用户主动 seek /
+  /// 自然越过目标句都汇到这里，作「seek 追踪状态」的统一复位点。
   void _clearSeekTargetSnap() {
     _seekTargetCueIndex = null;
     _seekSnapGraceTicksLeft = 0;
+    _clearPlainSeekInFlight();
+  }
+
+  /// 记下普通 seek 的在途目标位置并充满播放态宽限（见 [_plainSeekTargetMs]）。
+  void _beginPlainSeekInFlight(int targetMs) {
+    _plainSeekTargetMs = targetMs;
+    _plainSeekGraceTicksLeft = _seekSnapGraceTicks;
+  }
+
+  /// 清普通 seek 在途状态（目标位置 + 宽限），退回读真实 position。
+  void _clearPlainSeekInFlight() {
+    _plainSeekTargetMs = null;
+    _plainSeekGraceTicksLeft = 0;
+  }
+
+  /// 普通 seek 在途位置调和（见 [_plainSeekTargetMs]）：tick 读到的 [rawPosMs] 在 seek
+  /// 落地前是滞后的旧 position；据「已知目标位置」把它替换成目标位置，直到真实位置落定。
+  /// - 与 [skipToCue] 快照（[_seekTargetCueIndex]）互斥：后者非空时让路，返回 [rawPosMs]；
+  /// - 暂停态（positionStream 不推进）：无限期返回目标位置，让字幕停在目的地（gap 则消失）；
+  /// - 播放态：真实位置到达 `目标 − [_kPlainSeekLandToleranceMs]` 即落定、放行真实位置；否则
+  ///   消耗一格宽限继续返回目标，宽限耗尽（慢设备 / 永不落定）也放行真实位置。
+  int _reconcileSeekInFlightPosition(int rawPosMs) {
+    final int? target = _plainSeekTargetMs;
+    if (target == null || _seekTargetCueIndex != null) return rawPosMs;
+    if (!isPlaying) return target;
+    if (rawPosMs >= target - _kPlainSeekLandToleranceMs) {
+      _clearPlainSeekInFlight();
+      return rawPosMs;
+    }
+    if (_plainSeekGraceTicksLeft > 0) {
+      _plainSeekGraceTicksLeft--;
+      return target;
+    }
+    _clearPlainSeekInFlight();
+    return rawPosMs;
   }
 
   /// 公开清除入口（TODO-565 复核退回的必修项）：供**绕过 [seekMs]** 的 seek 路径手动
@@ -2421,12 +2492,33 @@ class VideoPlayerController extends ChangeNotifier
   ///
   /// **「主动跳转目标」快照的统一清除点（TODO-565 复核退回的必修项）。** 经本方法的
   /// 每一次 seek 都先清快照：章节跳转（[seekToChapter]）、相对 seek（[seekRelative]）、
-  /// 收藏句直接跳转（页面层 `seekMs`）都汇于此，落地前用户跳更早句不再被旧 [skipToCue]
-  /// 目标误 snap 回去。**唯一例外是 [skipToCue] 自己**——它要在本 seek **之后**才置
-  /// 快照+宽限，故先调 [seekMs]（在这里把上一个快照清掉）、再置自己的快照，绝不会被
-  /// 本清除点自清（见 [skipToCue] 注释）。进度条拖动经 media_kit 内部 `player.seek`
+  /// 收藏句直接跳转（页面层 `seekMs`）都汇于此（[seekMs] / [_rawSeekMs] 开头都调
+  /// [_clearSeekTargetSnap]），落地前用户跳更早句不再被旧 [skipToCue] 目标误 snap 回去。
+  /// **唯一例外是 [skipToCue] 自己**——它要在本 seek **之后**才置快照+宽限，故先调
+  /// [_rawSeekMs]（在这里把上一个快照清掉）、再置自己的快照，绝不会被本清除点自清
+  /// （见 [skipToCue] 注释）。进度条拖动经 media_kit 内部 `player.seek`
   /// 绕过本方法，由页面层 [clearSeekTargetSnap] 单独清（media_kit seek bar 不暴露回调）。
+  ///
+  /// 除清快照外，本方法还给普通 seek 挂「在途保护」（[_plainSeekTargetMs]）：一发 seek 就按
+  /// 目标位置**权威同步一次字幕**（不等滞后的 player position），字幕即时反映跳转目的地（gap
+  /// 则立即消失），随后 tick 经 [_reconcileSeekInFlightPosition] 抑制旧 position 的瞬态回跳，
+  /// 修「±秒跳转到 gap 后旧字幕不消失」（尤其暂停重听时）。[skipToCue] 自带 cue-snap，走
+  /// [_rawSeekMs] 不吃本保护，避免权威同步先把目标清成 preRoll gap、下一拍才 snap 回而闪烁。
   Future<void> seekMs(int positionMs) async {
+    final int clampedMs = positionMs.clamp(0, 1 << 30);
+    _clearSeekTargetSnap();
+    _beginPlainSeekInFlight(clampedMs);
+    // 权威同步：直接按目标位置算一次字幕（不经 tick 的位置调和），gap 则立即清空。
+    _syncCueForPosition(clampedMs, persistPosition: false);
+    await _player?.seek(Duration(milliseconds: clampedMs));
+  }
+
+  /// 直发 player seek（只清「主动跳转目标」快照，**不**置普通 seek 在途保护）——[skipToCue]
+  /// 专用：它自带 [_seekTargetCueIndex] 快照抑制在途 lag，且需要本清除点先清上一次快照、再由
+  /// 自己在 seek **之后**置新快照（见 [skipToCue] / [_clearSeekTargetSnap] 注释）。若改走会置
+  /// 在途保护的 [seekMs]，seek 前的权威同步会先把目标句清成 preRoll 落点的 gap、下一拍才随
+  /// 快照 snap 回目标，凭空多一次闪烁。
+  Future<void> _rawSeekMs(int positionMs) async {
     _clearSeekTargetSnap();
     await _player?.seek(Duration(milliseconds: positionMs.clamp(0, 1 << 30)));
   }
@@ -2531,11 +2623,12 @@ class VideoPlayerController extends ChangeNotifier
     // snap 回目标句，消除「点第 N 行高亮 N-1」。解析不到下标（cue 不在 _cues）时为 null，
     // 退回纯位置推导。**在 seek 之前先算好**，避免下面 await 期间 _cues 被异步改写。
     final int? targetIndex = _resolveCueIndex(cue);
-    // **顺序关键（TODO-565 复核退回的必修项）**：先 await [seekMs] 发出 seek——[seekMs]
-    // 开头会把**上一个**主动跳转快照清掉（统一清除点），故本句快照必须在它**之后**才置，
-    // 否则会被 [seekMs] 自清成 off-by-one 又复发。await 与同步置快照在单线程事件循环里对
-    // 后续 tick 等价可见（tick 不会插在 await 与置快照之间读到半截状态）。
-    await seekMs(cueSeekTargetMs(
+    // **顺序关键（TODO-565 复核退回的必修项）**：先 await [_rawSeekMs] 发出 seek——它开头
+    // 会把**上一个**主动跳转快照清掉（统一清除点），故本句快照必须在它**之后**才置，否则会被
+    // 自清成 off-by-one 又复发。await 与同步置快照在单线程事件循环里对后续 tick 等价可见
+    // （tick 不会插在 await 与置快照之间读到半截状态）。用 [_rawSeekMs] 而非 [seekMs]：后者
+    // 会挂普通 seek 在途保护 + 权威同步，与本路径自带的 cue-snap 抑制重复且会引入闪烁。
+    await _rawSeekMs(cueSeekTargetMs(
       cueStartMs: cue.startMs,
       delayMs: _delayMs,
       preRollMs: kCueSeekPreRollMs,

--- a/hibiki/test/media/video/video_player_controller_test.dart
+++ b/hibiki/test/media/video/video_player_controller_test.dart
@@ -1821,4 +1821,81 @@ void main() {
       expect(c.currentCue!.text, 'line0');
     });
   });
+
+  // 普通 seek（±秒键 / 章节 / 收藏句直接 seekMs，非 skipToCue）在途保护：修「跳转到 gap
+  // 后旧字幕不消失（尤其暂停重听时）」。根因——media_kit `state.position` 不随 seek 同步
+  // 更新、暂停态更长期停旧位置，125ms tick 逐拍读旧 position → findCueIndex 反推旧句 →
+  // 旧字幕被反复确认挂着。skipToCue 有 cue-snap 抑制，普通 seek 历史上没有。修法对齐有声书
+  // `_explicitSeekInFlight`：seekMs 发 seek 即按目标位置权威同步字幕 + 抑制在途旧 position。
+  group('普通 seek 在途：跳到 gap 旧字幕立即消失、不被滞后旧 position 拉回', () {
+    test('暂停态 ±秒跳到 gap：字幕立即消失且多拍旧 position 不把它拉回', () async {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues([_cue(0, 1000, 2000), _cue(1, 5000, 6000)]);
+
+      // 暂停中停在 cue0。
+      c.debugSetIsPlayingForTesting(false);
+      c.debugUpdateCueForPosition(1500);
+      expect(c.currentCue!.text, 'line0');
+      expect(c.activeCues, isNotEmpty);
+
+      // 跳到 gap（3000）。权威同步：字幕应**立即**消失（不等 tick / 不等 seek 落地）。
+      await c.seekMs(3000);
+      expect(c.currentCue, isNull, reason: 'seek 到 gap 后字幕应立即消失');
+      expect(c.currentCueIndex, -1);
+      expect(c.activeCues, isEmpty);
+
+      // 暂停态 media_kit 仍逐拍吐旧 position 1500（positionStream 不推进 / seek 未落地）：
+      // 修复前 findCueIndex(1500)=cue0 会把旧字幕拉回；修复后在途调和把它替成目标 3000（gap）。
+      for (var i = 0; i < 5; i++) {
+        c.debugUpdateCueForPosition(1500);
+        expect(c.currentCue, isNull, reason: '暂停在途：旧 position 不得把旧字幕拉回');
+        expect(c.activeCues, isEmpty);
+      }
+    });
+
+    test('播放态在途保持目标、落地后放行真实位置（不把字幕钉在跳转 gap）', () async {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues([_cue(0, 1000, 2000), _cue(1, 5000, 6000)]);
+      c.debugSetIsPlayingForTesting(true);
+
+      c.debugUpdateCueForPosition(1500); // cue0
+      expect(c.currentCue!.text, 'line0');
+
+      await c.seekMs(4800); // 跳到接近 cue1 前的 gap
+      expect(c.currentCue, isNull, reason: '权威同步：目的地是 gap');
+
+      // 播放在途：前几拍仍读旧 1500（seek 未落地）→ 宽限保持目标 gap，不回 cue0。
+      c.debugUpdateCueForPosition(1500);
+      expect(c.currentCue, isNull, reason: '播放在途：旧 position 不得把 cue0 拉回');
+
+      // 真实位置落定到目标 4800 → 作废在途保护、放行真实位置。
+      c.debugUpdateCueForPosition(4800);
+      expect(c.currentCue, isNull);
+
+      // 自然播放进入 cue1：在途保护已放行，字幕正常跟随（未被钉在跳转 gap）。
+      c.debugUpdateCueForPosition(5500);
+      expect(c.currentCueIndex, 1, reason: '落地后不得把字幕钉在跳转目标 gap 上');
+      expect(c.currentCue!.text, 'line1');
+    });
+
+    test('暂停态跳进某句：立即显示目的地句，旧 position 不显示旧句', () async {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues([_cue(0, 1000, 2000), _cue(1, 5000, 6000)]);
+      c.debugSetIsPlayingForTesting(false);
+      c.debugUpdateCueForPosition(1500); // cue0
+      expect(c.currentCue!.text, 'line0');
+
+      await c.seekMs(5500); // 跳进 cue1
+      expect(c.currentCueIndex, 1, reason: 'seek 目的地在 cue1，应立即显示 line1');
+      expect(c.currentCue!.text, 'line1');
+
+      // 暂停态在途仍读旧 1500：不得回 cue0。
+      c.debugUpdateCueForPosition(1500);
+      expect(c.currentCueIndex, 1);
+      expect(c.currentCue!.text, 'line1');
+    });
+  });
 }


### PR DESCRIPTION
## 报告
用户：「跳转的时候字幕没消失，但是我都跳转走了，那段时间不应该有字幕」。场景确认：**本地视频 + ±10 秒快进/快退键**。

## 根因
视频普通 seek（`seekRelative`/`seekMs`）后，125ms tick 读到 media_kit **滞后/暂停态的旧 `state.position`**（`_seekTargetCueIndex` 注释 249-250 行已记此 lag；有声书 `_explicitSeekInFlight` 注释亦记「暂停态 positionStream 不推进、seek 吐旧位置」）→ `findCueIndex(旧位置)` 命中旧句 → 旧字幕被反复确认、跳走后那段静音期仍挂着。`skipToCue` 有 cue-snap 抑制，普通 seek 历史上有意未置保护，暴露本 bug。根因 `video_player_controller.dart:2429`（旧 `seekMs` 无权威同步/无在途抑制）。

## 修复
对齐有声书 `_explicitSeekInFlight` 范式，只动视频 `VideoPlayerController`：
- `seekMs` 发 seek 即 **按目标位置权威同步字幕**（gap 立即消失）+ 置在途保护 `_plainSeekTargetMs`。
- tick 经 `_reconcileSeekInFlightPosition` 抑制旧 position：**暂停态无限保持目标 / 播放态有界宽限**（落地或 2s 耗尽放行），绝不钉死。
- `skipToCue` 改走新增 `_rawSeekMs`（= 旧 seekMs 行为），**零回归**。

## 测试
新增 3 例守卫（暂停跳 gap 立即消失且不被旧 position 拉回 / 播放态落地放行不钉死 / 跳进某句立即显示目的地）。`flutter test test/media/video/ test/media/audiobook/` 全绿（2268 passed），`flutter analyze` No issues。

## 待验收
真机复测：本地视频暂停中 ±10 秒键跳到无字幕段 → 旧字幕立即消失。进度条拖动走 media_kit 内部 seek（绕过 `seekMs`），本次不覆盖。

见 `docs/bugs/BUG-791-video-seek-gap-subtitle-linger.md`。