### PR TITLE
fix(video): 修特殊多声道布局(6.1 FLC)无声 (BUG-792)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 772 条。点号进各自文件。
+> 共 773 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-792](bugs/BUG-792-exotic-audio-layout-silence.md) | ✅ | ✅ | 特殊多声道音频布局(6.1 FLC)无声 |
 | [BUG-789](bugs/BUG-789-reader-chrome-inset-stale-pagination-metrics.md) | ✅ | ✅ | 底栏 inset 后分页终点过期导致章尾不可读 |
 | [BUG-788](bugs/BUG-788-fractional-page-boundary-premature-limit.md) | ✅ | ✅ | 亚像素页距在第31页误判边界提前停翻 |
 | [BUG-787](bugs/BUG-787-vertical-pagination-drift-recurrence.md) | ✅ | ✅ | 竖排累计漂移探针取整假阳性（当前 develop 未复现） |

--- a/docs/bugs/BUG-792-exotic-audio-layout-silence.md
+++ b/docs/bugs/BUG-792-exotic-audio-layout-silence.md
@@ -1,0 +1,9 @@
+## BUG-792 · 特殊多声道音频布局(6.1 FLC)无声
+- **报告**：2026-07-14（用户：4K FLAC 片源「千与千寻」视频有画面无声，附 `hibiki_error_log (3).txt`）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/video/video_mpv_config.dart:455`（原 `out['audio-channels'] = config.audioChannels;` 默认透传 `auto-safe`）。
+  - 片源 FLAC 音轨为 6.1 布局 `FL+FR+FC+LFE+BL+BR+FLC`（含罕见 `FLC`＝前左中央声道）。
+  - mpv 默认 `audio-channels=auto-safe`（media_kit 未覆盖，见 pub-cache `media_kit-1.2.6/.../player/real.dart:2389-2416`）把该源布局**原样当输出目标**透传给 AO；libswresample **无法为含 FLC 的输出布局建重采样矩阵**（FFmpeg 已知限制：FLC/FRC 可在下混输入端处理，不能作输出目标）→ `swr_init` 失败 → 整条音频滤镜链建不起来 → 彻底无声，画面正常。
+  - 日志实证：`SWR: Output channel layout '7 channels (FL+FR+FC+LFE+BL+BR+FLC)' is not supported` / `libswresample failed to initialize` / `[af] Cannot convert decoder/filter output to any format supported by the output`。
+- **[x] ① 已修复** — `hibiki/lib/src/media/video/video_mpv_config.dart` 新增纯函数 `resolveAudioChannels`：`auto-safe` 不再透传源布局，改下发标准布局白名单 `7.1,5.1,stereo`（高→低有序，末位 stereo 永远兜底）。对齐 mpv 桌面「给标准布局清单、按 AO 实际能力挑最匹配并自动转换（下混/上混）」的做法——环绕设备仍拿到环绕（源 6.1-FLC → 标准 7.1/5.1 重采样，FLC 只在输入端 swr 支持），普通立体声设备下混到 stereo；FLC 奇异布局永不作输出目标 → 不再无声。`stereo`/`mono`（用户显式强制）原样透传，不破坏环绕（Never break userspace）。`buildMpvProperties` 第 486 行改用该解析。提交：<pending>
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_mpv_config_test.dart` 新增 `resolveAudioChannels (BUG-792 exotic layout silence)` group（4 例）：auto-safe→白名单、白名单末位 stereo 且不含 FLC/FRC、stereo/mono 透传、buildMpvProperties 显式 stereo 保留；并更新默认断言 `audio-channels == '7.1,5.1,stereo'`。`flutter test test/media/video/video_mpv_config_test.dart` 全绿（54 例）。提交：<pending>
+- **备注**：桌面 libmpv（Windows/macOS/Linux）实测受益；音频输出真机验证需用户在原片源上确认声音回来（playback 类改动，本机无法可靠验证音频输出）。回避策略：视频设置→「声道布局」手动切 `立体声` 亦可即时恢复。

--- a/hibiki/lib/src/media/video/video_mpv_config.dart
+++ b/hibiki/lib/src/media/video/video_mpv_config.dart
@@ -384,6 +384,34 @@ Map<String, String> resolveScaleProperties(bool highQuality, {bool? isMobile}) {
   };
 }
 
+/// 把 [audioChannels] 偏好解析成「实际下发给 libmpv 的 `audio-channels` 值」。纯函数。
+///
+/// **根治「特殊多声道布局（如 6.1 `FL+FR+FC+LFE+BL+BR+FLC`）无声」（BUG-792）。** 用户
+/// 4K FLAC 片源音轨是 6.1（含罕见的 `FLC`＝前左中央声道）。mpv 默认 `audio-channels=auto-safe`
+/// 会把这个源布局**原样当输出目标**透传给音频输出（AO），而 libswresample **无法为含 `FLC`
+/// 的输出布局建重采样矩阵**（FFmpeg 已知限制：FLC/FRC 可在下混**输入**里处理，但不能作
+/// **输出**目标）→ `swr_init` 失败 → 整条音频滤镜链建不起来 → 彻底无声（日志
+/// `SWR: Output channel layout '7 channels (...FLC)' is not supported` /
+/// `libswresample failed to initialize`）；画面正常。
+///
+/// 修复=对齐 mpv 桌面版「给一组标准布局清单、按 AO 实际能力挑最匹配并自动转换」的做法：
+/// `auto-safe` 不再透传源布局，而是下发标准布局白名单 [_standardChannelLayouts]
+/// （`7.1,5.1,stereo`，高→低有序）。mpv 会选**第一个 AO 支持的**布局并「converting the audio
+/// if necessary」（下混/上混）——7.1/5.1 环绕设备仍拿到环绕（源 6.1-FLC → 标准 7.1/5.1
+/// 重采样，FLC 只在输入端，swr 支持），普通立体声设备回落到永远支持的 `stereo`（下混，
+/// 用户听到全部声道内容）。**任何设备都不会再让 FLC 奇异布局成为输出目标 → 不再无声**。
+///
+/// `stereo` / `mono`（用户显式强制）原样透传，语义不变。这是**对齐 mpv 标准布局协商**的根因
+/// 修复，不是给某个片源打特例；不破坏环绕输出（Never break userspace）。
+String resolveAudioChannels(String audioChannels) {
+  if (audioChannels == 'auto-safe') return _standardChannelLayouts;
+  return audioChannels; // stereo / mono（用户显式强制）原样透传。
+}
+
+/// mpv `audio-channels` 标准布局白名单：高→低有序，末位 `stereo` 永远兜底（不会无声）。
+/// 见 [resolveAudioChannels]（BUG-792）。
+const String _standardChannelLayouts = '7.1,5.1,stereo';
+
 /// 构建 Android 专用的「10-bit → 8-bit 降位」视频滤镜属性 map（`vf`）。纯函数。
 ///
 /// **根治 realme 8 / Mali-G76「10-bit HEVC 视频闪烁 + 无画面」（TODO-1196；用户 BUG-465
@@ -452,7 +480,10 @@ Map<String, String> buildMpvProperties(VideoMpvConfig config,
   // 音频
   out['audio-delay'] = (config.audioDelayMs / 1000).toString(); // 秒
   out['audio-pitch-correction'] = config.audioPitchCorrection ? 'yes' : 'no';
-  out['audio-channels'] = config.audioChannels;
+  // 声道：auto-safe 下发标准布局白名单（7.1,5.1,stereo）而非透传源布局，绕开含 FLC
+  // 的奇异布局做输出目标时 libswresample 无法初始化 → 无声（BUG-792）。见
+  // [resolveAudioChannels]；stereo/mono（用户显式强制）原样透传。
+  out['audio-channels'] = resolveAudioChannels(config.audioChannels);
   out['audio-normalize-downmix'] = config.normalizeDownmix ? 'yes' : 'no';
   // 播放
   out['loop-file'] = config.loopFile ? 'inf' : 'no';

--- a/hibiki/test/media/video/video_mpv_config_test.dart
+++ b/hibiki/test/media/video/video_mpv_config_test.dart
@@ -57,7 +57,9 @@ keep-open=yes
       expect(m['panscan'], '0.0');
       expect(m['audio-delay'], '0.0');
       expect(m['audio-pitch-correction'], 'yes'); // mpv 默认 yes
-      expect(m['audio-channels'], 'auto-safe');
+      // BUG-792：auto-safe 下发标准布局白名单（而非透传源布局），绕开含 FLC 的奇异
+      // 布局做输出目标时 libswresample 无法初始化 → 无声。末位 stereo 永远兜底。
+      expect(m['audio-channels'], '7.1,5.1,stereo');
       expect(m['audio-normalize-downmix'], 'no');
     });
 
@@ -73,6 +75,36 @@ keep-open=yes
       expect(m['audio-pitch-correction'], 'no');
       expect(m['audio-channels'], 'stereo');
       expect(m['audio-normalize-downmix'], 'yes');
+    });
+
+    // BUG-792：特殊多声道布局（6.1 FL+FR+FC+LFE+BL+BR+FLC）无声——auto-safe 透传源布局
+    // 令 libswresample 无法为含 FLC 的输出布局建矩阵。修复=auto-safe 解析成标准布局白名单。
+    group('resolveAudioChannels (BUG-792 exotic layout silence)', () {
+      test('auto-safe -> standard layout whitelist (never exotic output)', () {
+        // 白名单只含标准布局（无 FLC/FRC），高→低有序，末位 stereo 永远兜底。
+        expect(resolveAudioChannels('auto-safe'), '7.1,5.1,stereo');
+      });
+
+      test('whitelist ends with stereo so audio never falls silent', () {
+        final String wl = resolveAudioChannels('auto-safe');
+        expect(wl.split(',').last, 'stereo');
+        // 白名单不含任何带 FLC/FRC 的奇异输出布局。
+        expect(wl.toLowerCase().contains('flc'), isFalse);
+        expect(wl.toLowerCase().contains('frc'), isFalse);
+      });
+
+      test('explicit stereo / mono pass through unchanged', () {
+        expect(resolveAudioChannels('stereo'), 'stereo');
+        expect(resolveAudioChannels('mono'), 'mono');
+      });
+
+      test('buildMpvProperties keeps explicit stereo (user forced downmix)',
+          () {
+        final Map<String, String> m = buildMpvProperties(
+            VideoMpvConfig.defaults.copyWith(audioChannels: 'stereo'),
+            isAndroid: false);
+        expect(m['audio-channels'], 'stereo');
+      });
     });
 
     test('hwdec value passes through (non-Android)', () {


### PR DESCRIPTION
## 症状
用户 4K FLAC 片源（千与千寻）视频**有画面无声**（日志 `hibiki_error_log (3).txt`）。

## 根因
片源 FLAC 音轨是 6.1 布局 `FL+FR+FC+LFE+BL+BR+FLC`（含罕见 `FLC`＝前左中央声道）。mpv 默认 `audio-channels=auto-safe`（media_kit 未覆盖）把该源布局**原样当输出目标**透传给 AO，libswresample **无法为含 FLC 的输出布局建重采样矩阵**（FFmpeg 已知限制：FLC/FRC 可在下混输入端处理，不能作输出目标）→ `swr_init` 失败 → 整条音频滤镜链建不起来 → 彻底无声，画面正常。

日志实证：
```
SWR: Output channel layout '7 channels (FL+FR+FC+LFE+BL+BR+FLC)' is not supported
libswresample failed to initialize.
[af] Cannot convert decoder/filter output to any format supported by the output.
```

## 修复
新增纯函数 `resolveAudioChannels`：`auto-safe` 不再透传源布局，改下发标准布局白名单 `7.1,5.1,stereo`（高→低有序，末位 stereo 永远兜底）。对齐 mpv 桌面「给标准布局清单、按 AO 实际能力挑最匹配并自动转换（下混/上混）」的做法——环绕设备仍拿到环绕（源 6.1-FLC → 标准 7.1/5.1 重采样，FLC 只在输入端 swr 支持），普通立体声设备下混到 stereo；FLC 奇异布局永不作输出目标 → 不再无声。`stereo`/`mono`（用户显式强制）原样透传，不破坏环绕（Never break userspace）。

## 测试
`hibiki/test/media/video/video_mpv_config_test.dart` 新增 `resolveAudioChannels` group（4 例）+ 更新默认断言；`flutter test` 全绿（54 例）。`flutter analyze` 无 issue。

## 待验证
音频输出真机验证需在原片源上确认声音回来（playback 类改动，本机无法可靠验证音频输出）。回避策略：设置→声道布局手动切「立体声」亦可即时恢复。

BUG-792。