### PR TITLE
fix(video-subtitle): ASS \blur 只糊描边 (BUG-796) + 双语闪烁两修 (BUG-797) + Bold=0 假粗体 (BUG-808)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 772 条。点号进各自文件。
+> 共 774 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-797](bugs/BUG-797-subtitle-group-element-reuse-flicker.md) | ✅ | ✅ | 双语字幕重叠进出场时在屏字幕元素被跨 cue 复用导致闪烁 |
+| [BUG-796](bugs/BUG-796-ass-blur-border-only.md) | ✅ | ✅ | ASS `\blur` 有描边时整字被糊成一团（应只糊描边、留锐利字面） |
 | [BUG-789](bugs/BUG-789-reader-chrome-inset-stale-pagination-metrics.md) | ✅ | ✅ | 底栏 inset 后分页终点过期导致章尾不可读 |
 | [BUG-788](bugs/BUG-788-fractional-page-boundary-premature-limit.md) | ✅ | ✅ | 亚像素页距在第31页误判边界提前停翻 |
 | [BUG-787](bugs/BUG-787-vertical-pagination-drift-recurrence.md) | ✅ | ✅ | 竖排累计漂移探针取整假阳性（当前 develop 未复现） |

--- a/docs/bugs/BUG-796-ass-blur-border-only.md
+++ b/docs/bugs/BUG-796-ass-blur-border-only.md
@@ -1,0 +1,6 @@
+## BUG-796 · ASS `\blur` 有描边时整字被糊成一团（应只糊描边、留锐利字面）
+- **报告**：2026-07-14（用户：视频字幕截图，`{\blur5}かわいい娘ができて　幸せ`，Nekomoe kissaten ASSx2 Text_JP2 样式 Outline=2.5，整行白字被糊成不可读的一团，黑描边完全消失；mpv 渲染为清晰白字+柔光黑晕）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/video/video_subtitle_overlay.dart:1148-1153`（修复前）——TODO-1373 的 `\blur/\be` 实现把**合成字形（描边+填充+阴影）整体**包进 `ImageFiltered` 高斯模糊。libass 语义（`ass_bitmap.c`）是：**`\bord>0` 时只对描边位图做高斯，字面填充保持锐利**（阴影是模糊后描边位图的平移拷贝，随之同糊）；只有 `\bord==0` 才糊字形本身。fansub 对白常用「白字+细黑边+`\blur`」组合追求柔光晕效果，整体糊直接毁掉可读性。
+- **[x] ① 已修复** — `_buildSubtitleChar` 把 sigma 提前算：有描边分支只把 `ImageFiltered` 包在描边层（stroke Text，含 ASS 阴影）上，fill 层留在滤镜外保持锐利；无描边分支维持整字形糊（libass 同语义）。命中矩形不变（ImageFiltered/Stack 不改布局），逐字查词照常。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_blur_border_semantics_test.dart`：①有描边+`\blur`：stroke 层必须在 `ImageFiltered` 内、fill 层必须不在（修复前红）；②无描边+`\blur`：整字形糊保留；③无 `\blur`：零 `ImageFiltered`。既有 `video_subtitle_overlay_markup_test.dart` / `video_subtitle_obscure_blur_sigma_test.dart` 无回归。
+- **备注**：与 PR#65 的 `\blur` 量级修正（`2/sqrt(ln256)` 因子，`assBlurValueToSigma`）正交——那次修的是 sigma 数值，本次修的是施加对象。真机观感（柔光晕 vs mpv）待用户复测。姊妹 bug：[[BUG-797]]（同截图会话报的双语字幕闪烁）。

--- a/docs/bugs/BUG-797-subtitle-group-element-reuse-flicker.md
+++ b/docs/bugs/BUG-797-subtitle-group-element-reuse-flicker.md
@@ -1,0 +1,6 @@
+## BUG-797 · 双语字幕重叠进出场时在屏字幕元素被跨 cue 复用导致闪烁
+- **报告**：2026-07-14（用户：「双重弹幕(双语双轨字幕)还是会闪烁」——PR#49（BUG-743 相邻对白弹跳）修复后仍闪）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/video/video_subtitle_overlay.dart:765-787`（修复前）——字幕组 `Column` 的子节点**无 key**，且底部锚组用 `slots.reversed` 渲染（新槽位追加到 Column 头部）。双语（ASSx2 / 单 .ass 双样式）相邻对白时间不齐、重叠进出场时，组内 cue 数量变化 → Flutter 按 **Column 位置**而非 cue 身份复用 element：在屏那条字幕的 element 被喂成**另一条** cue 的文本 + `\fad` 不透明度（`_fadeOpacityFor` 立即改用新 cue 的 startMs 求值，透明度 1→0 瞬跳）= 视觉闪一下。PR#49（TODO-1372/BUG-698 `_groupSlots`）让**槽位数据层**跨帧稳定，但没有 key，稳定性传导不到 element 层——这就是「修了还闪」的结构缺口。
+- **[x] ① 已修复** — `_positionCueGroup` 给每个槽位包 `KeyedSubtree(key: ObjectKey(slot.cue))`：Flutter 按 cue 身份匹配 element，组内增减/reversed 位移不再窃用在屏 cue 的 element；槽位被新 cue 补占时 key 变化、正常重建（语义正确）。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_group_element_stability_test.dart`：JP1/CH1 在屏时 JP2/CH2 重叠进场（组 2→4 条），断言 JP1/CH1 的 fill Text element **原样保留**（`identical`）。修复前红（element 被按位置复用成新 cue）、修复后绿。
+- **备注**：次要嫌疑（未在本轮动）：`\fad` 期间 `_fadeTicker` 每帧整树重建 × 每字符一个 `ImageFiltered` saveLayer（双语长句 ~35 个/帧、无 `RepaintBoundary`）→ 掉帧型闪烁；若真机复测挂 key 后仍闪且形态是「卡顿掉帧」而非「瞬跳」，下一步做 RepaintBoundary/整盒 blur 优化。另查明：secondary 轨选择无「≠primary」去重校验（`subtitle.part.dart:420-489`），用户把同一 .ass 同时选 primary+secondary 且其自带 `\an8` 时会顶部叠印双份——需用户显式误配，暂不动。姊妹 bug：[[BUG-796]]（同会话报的 `\blur` 整字糊）。

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -768,22 +768,30 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: <Widget>[
+        // 每个槽位按 **cue 身份**挂 key：组内 cue 数量变化（相邻/重叠对白进出场）时，
+        // Flutter 按身份而非 Column 位置复用 element。没有 key 时，底部锚组的 reversed
+        // 顺序让新 cue 追加在 Column 头部，在屏 cue 的 element 被按位置复用成**另一条**
+        // cue（文本+\fad 不透明度瞬跳 1→0）——双语字幕闪烁的直接根因。槽位数据层的跨帧
+        // 稳定（TODO-1372/BUG-698）必须传导到 element 层才有效。
         for (final _GroupSlot slot in topToBottom)
-          if (slot.alive)
-            _buildCueBox(context, slot.cue,
-                isSecondary: isSecondary, blurred: blurred)
-          else
-            // 离场 cue 的隐形占位：保持原盒尺寸撑住远端在屏字幕的槽位（不登记查词命中、
-            // 不响应指针、无收藏角标）。libass「事件在屏期间位置不变」语义的槽位版。
-            IgnorePointer(
-              child: Opacity(
-                opacity: 0,
-                child: _buildCueBox(context, slot.cue,
-                    isSecondary: isSecondary,
-                    blurred: blurred,
-                    registerHits: false),
-              ),
-            ),
+          KeyedSubtree(
+            key: ObjectKey(slot.cue),
+            child: slot.alive
+                ? _buildCueBox(context, slot.cue,
+                    isSecondary: isSecondary, blurred: blurred)
+                // 离场 cue 的隐形占位：保持原盒尺寸撑住远端在屏字幕的槽位（不登记查词
+                // 命中、不响应指针、无收藏角标）。libass「事件在屏期间位置不变」语义的
+                // 槽位版。
+                : IgnorePointer(
+                    child: Opacity(
+                      opacity: 0,
+                      child: _buildCueBox(context, slot.cue,
+                          isSecondary: isSecondary,
+                          blurred: blurred,
+                          registerHits: false),
+                    ),
+                  ),
+          ),
       ],
     );
 
@@ -1093,11 +1101,15 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// `shadows`）。忠实还原 .ass 文件明示的描边/阴影语义（TODO-1105/1246），不被默认软投影
   /// 覆盖。描边宽<=0 时降级为单层 fill。
   ///
-  /// 两路径外均可套 \blur/\be 辉光（仅 respect 时）；命中矩形不因层数变化（ImageFiltered /
-  /// Stack 不改布局），逐字查词照常。
+  /// \blur/\be 辉光（TODO-1373，仅 respect 时）对齐 libass `ass_bitmap.c` 语义：
+  /// **\bord>0 时只糊「描边（含 \shad 阴影）」层，字面 fill 保持锐利**（mpv 观感=清晰
+  /// 字面+柔光晕）；\bord==0 才糊整个字形（字面边缘发虚）。此前无条件把合成字形
+  /// （描边+填充+阴影）整体 [ImageFiltered]，带描边的 `{\blur5}` 对白被糊成一团不可读。
+  /// 命中矩形不因层数变化（ImageFiltered / Stack 不改布局），逐字查词照常。
   Widget _buildSubtitleChar(String char, int i, SubtitleMarkup? markup) {
     final TextStyle fillStyle = _styleForGrapheme(i, markup);
     final bool respect = widget.respectAssStyle && markup != null;
+    final double sigma = _blurSigmaFor(i, markup);
     final Widget glyph;
     if (!respect) {
       // 默认统一外观：Niratan 柔和投影。fillStyle 在非 respect 下 shadows==null，直接挂软
@@ -1133,19 +1145,26 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
         final TextStyle fillTopStyle = hasShadows
             ? fillStyle.copyWith(shadows: const <Shadow>[])
             : fillStyle;
-        glyph = Stack(
-          // 底层 stroke 先画（在下），上层 fill 后画（在上）盖住描边内缘，露出外缘成轮廓。
+        // \bord>0 + \blur：只糊描边层（阴影挂在描边层上，随之同糊——libass 的阴影本就是
+        // 模糊后描边位图的平移拷贝）；fill 层留在 ImageFiltered 外保持锐利。
+        Widget strokeLayer = Text(char, style: strokeStyle);
+        if (sigma > 0) {
+          strokeLayer = ImageFiltered(
+            imageFilter: ui.ImageFilter.blur(sigmaX: sigma, sigmaY: sigma),
+            child: strokeLayer,
+          );
+        }
+        // 底层 stroke 先画（在下），上层 fill 后画（在上）盖住描边内缘，露出外缘成轮廓。
+        return Stack(
           children: <Widget>[
-            Text(char, style: strokeStyle),
+            strokeLayer,
             Text(char, style: fillTopStyle),
           ],
         );
       }
     }
-    // \blur/\be 辉光（TODO-1373）：把合成字形（描边+填充+阴影）整体高斯模糊。仅 respectAssStyle
-    // 开且该字符所在 span 带 blur 时包裹；ImageFiltered 不改布局尺寸，故字符命中矩形
-    // （_charEntries）不变、逐字查词照常。sigma<=0 不包裹（外观像素级不变）。
-    final double sigma = _blurSigmaFor(i, markup);
+    // 无描边（\bord 0 的 respect 分支；非 respect 分支 sigma 恒 0）：糊整个字形——libass
+    // 在没有描边位图时对字形位图本身做高斯，字面边缘发虚是原作者点名要的效果。
     if (sigma <= 0) return glyph;
     return ImageFiltered(
       imageFilter: ui.ImageFilter.blur(sigmaX: sigma, sigmaY: sigma),

--- a/hibiki/test/media/video/video_subtitle_blur_border_semantics_test.dart
+++ b/hibiki/test/media/video/video_subtitle_blur_border_semantics_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_player_controller.dart';
+import 'package:hibiki/src/media/video/video_subtitle_overlay.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+/// BUG 守卫：ASS `\blur` 的 libass 语义 —— **有描边（\bord>0）时只糊描边层，字面
+/// fill 保持锐利**；无描边（\bord==0）才糊整个字形。
+///
+/// 回归背景：`{\blur5}` + Outline=2.5 的对白（Nekomoe kissaten ASSx2 发布常见写法）
+/// 此前被整字 [ImageFiltered] 高斯，白字黑边糊成一团不可读；mpv/libass 渲染为
+/// 「清晰白字 + 柔光黑晕」（libass `ass_bitmap.c`：有描边位图糊描边、无描边才糊字形）。
+AudioCue _cue(String raw) {
+  final SubtitleMarkup m = parseSubtitleMarkup(raw);
+  return AudioCue()
+    ..bookKey = 'b'
+    ..chapterHref = 'c'
+    ..sentenceIndex = 0
+    ..textFragmentId = '[data-cue-id="0"]'
+    ..text = m.plainText
+    ..markup = m
+    ..startMs = 0
+    ..endMs = 5000
+    ..audioFileIndex = 0;
+}
+
+VideoPlayerController _stubWithCue(AudioCue cue) {
+  final VideoPlayerController c = VideoPlayerController();
+  c.setCues(<AudioCue>[cue]);
+  c.debugUpdateCueForPosition(cue.startMs + 1);
+  return c;
+}
+
+Future<void> _pump(
+  WidgetTester tester,
+  AudioCue cue, {
+  required double shadowThickness,
+}) async {
+  final VideoPlayerController c = _stubWithCue(cue);
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: VideoSubtitleOverlay(
+        controller: c,
+        textColor: const Color(0xFFFFFFFF),
+        shadowColor: const Color(0xFF000000),
+        shadowThickness: shadowThickness,
+        respectAssStyle: true,
+      ),
+    ),
+  ));
+  await tester.pump();
+}
+
+/// 填充层（foreground==null）/描边层（foreground!=null）的精确 widget finder。
+Finder _fillText(String ch) => find.byWidgetPredicate(
+    (Widget w) => w is Text && w.data == ch && w.style?.foreground == null);
+Finder _strokeText(String ch) => find.byWidgetPredicate(
+    (Widget w) => w is Text && w.data == ch && w.style?.foreground != null);
+
+void main() {
+  testWidgets(
+      r'\blur with outline: stroke layer blurred, fill layer stays sharp '
+      '(libass border-only blur)', (WidgetTester tester) async {
+    // shadowThickness=5 → _resolveStroke 回退统一描边宽 → strokePaint 非空（双层）。
+    await _pump(tester, _cue(r'{\blur5}あ'), shadowThickness: 5);
+
+    expect(_strokeText('あ'), findsOneWidget);
+    expect(_fillText('あ'), findsOneWidget);
+
+    // 描边层必须在 ImageFiltered 里（辉光糊在描边上）……
+    expect(
+      find.ancestor(of: _strokeText('あ'), matching: find.byType(ImageFiltered)),
+      findsWidgets,
+    );
+    // ……而字面 fill 层绝不能被任何 ImageFiltered 包住（保持锐利、可读）。
+    expect(
+      find.ancestor(of: _fillText('あ'), matching: find.byType(ImageFiltered)),
+      findsNothing,
+    );
+  });
+
+  testWidgets(
+      r'\blur without outline: whole glyph blurred (edge blur preserved)',
+      (WidgetTester tester) async {
+    // shadowThickness=0 且 markup 无 ASS 描边 → strokePaint 为 null → 单层 fill。
+    await _pump(tester, _cue(r'{\blur5}あ'), shadowThickness: 0);
+
+    expect(_strokeText('あ'), findsNothing);
+    expect(_fillText('あ'), findsOneWidget);
+    // 无描边位图可糊 → libass 糊字形本身：fill 层在 ImageFiltered 里。
+    expect(
+      find.ancestor(of: _fillText('あ'), matching: find.byType(ImageFiltered)),
+      findsWidgets,
+    );
+  });
+
+  testWidgets(r'no \blur: neither layer wrapped in ImageFiltered',
+      (WidgetTester tester) async {
+    await _pump(tester, _cue('あ'), shadowThickness: 5);
+    expect(find.byType(ImageFiltered), findsNothing);
+  });
+}

--- a/hibiki/test/media/video/video_subtitle_group_element_stability_test.dart
+++ b/hibiki/test/media/video/video_subtitle_group_element_stability_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_player_controller.dart';
+import 'package:hibiki/src/media/video/video_subtitle_overlay.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+/// BUG 守卫：字幕组内 cue 数量变化时，在屏 cue 的 **element 身份**必须稳定。
+///
+/// 回归背景：底部锚组渲染用 `slots.reversed` 且 Column 子节点无 key——双语（ASSx2 /
+/// 单 .ass 双样式）相邻对白重叠进场时，新 cue 追加到 Column 头部，在屏 cue 的
+/// element 被 Flutter 按**位置**复用成另一条 cue（文本 + \fad 不透明度 1→0 瞬跳），
+/// 表现为字幕闪一下。PR#49（TODO-1372/BUG-698）已让槽位数据层跨帧稳定，但没有 key
+/// 时该稳定性传导不到 element 层。修复 = 每槽位按 cue 身份挂 [KeyedSubtree]。
+AudioCue _cue(String text, {required int start, required int end}) => AudioCue()
+  ..bookKey = 'b'
+  ..chapterHref = 'c'
+  ..sentenceIndex = 0
+  ..textFragmentId = '[data-cue-id="0"]'
+  ..text = text
+  ..markup = SubtitleMarkup(
+    plainText: text,
+    spans: const <SubtitleSpan>[],
+    anchor: const SubtitleAnchor(SubtitleVAlign.bottom, SubtitleHAlign.center),
+  )
+  ..startMs = start
+  ..endMs = end
+  ..audioFileIndex = 0;
+
+/// 填充层（foreground==null）的精确 finder（ASS 尊重路径每字双层：stroke+fill）。
+Finder _fillText(String ch) => find.byWidgetPredicate(
+    (Widget w) => w is Text && w.data == ch && w.style?.foreground == null);
+
+void main() {
+  testWidgets(
+      'overlapping cues entering a bottom group do not steal on-screen '
+      'cue elements (identity-keyed slots)', (WidgetTester tester) async {
+    final VideoPlayerController c = VideoPlayerController();
+    addTearDown(c.dispose);
+    // 双语对 JP1/CH1 在屏时，下一对 JP2/CH2 提前重叠进场（ASSx2 时间不齐的常态）。
+    c.setCues(<AudioCue>[
+      _cue('あ', start: 0, end: 8000), // JP1
+      _cue('い', start: 0, end: 8000), // CH1
+      _cue('う', start: 6000, end: 12000), // JP2
+      _cue('え', start: 6000, end: 12000), // CH2
+    ]);
+    c.debugUpdateCueForPosition(100); // 只有 JP1/CH1 活跃
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: VideoSubtitleOverlay(controller: c, respectAssStyle: true),
+      ),
+    ));
+    await tester.pump();
+    expect(_fillText('あ'), findsOneWidget);
+    expect(_fillText('い'), findsOneWidget);
+    final Element jp1Before = tester.element(_fillText('あ'));
+    final Element ch1Before = tester.element(_fillText('い'));
+
+    // JP2/CH2 重叠进场：组内 4 条活跃，底部锚 reversed 后新 cue 排到 Column 头部。
+    c.debugUpdateCueForPosition(6500);
+    await tester.pump();
+    expect(_fillText('う'), findsOneWidget);
+    expect(_fillText('え'), findsOneWidget);
+
+    // 在屏 JP1/CH1 的 element 必须原样保留（身份 key 让 Flutter 按 cue 匹配而非按
+    // Column 位置复用）；否则它们的 widget 被喂成 JP2/CH2 的文本/透明度 → 视觉闪烁。
+    expect(identical(tester.element(_fillText('あ')), jp1Before), isTrue,
+        reason: 'JP1 element must survive group growth');
+    expect(identical(tester.element(_fillText('い')), ch1Before), isTrue,
+        reason: 'CH1 element must survive group growth');
+  });
+}


### PR DESCRIPTION
## 用户报告
同一会话两症状（截图为证）：
1. **`{\blur5}` 对白整字被糊成一团**（Nekomoe ASSx2，Text_JP2 Outline=2.5；mpv 渲染为清晰白字+柔光黑晕，我们这里黑边消失、白字不可读）
2. **双语双轨字幕还是会闪烁**（PR#49 修过弹跳后仍在）

## 根因与修复
### BUG-796 · `\blur` 施加对象错误
`video_subtitle_overlay.dart` 此前把合成字形（描边+填充+阴影）**整体** ImageFiltered。libass（`ass_bitmap.c`）语义：**`\bord>0` 只糊描边位图、字面保持锐利**；`\bord==0` 才糊字形。修复：有描边分支只包描边层（含 ASS 阴影），fill 留在滤镜外。与 PR#65 的 sigma 量级修正正交。

### BUG-797 · 组内 element 被跨 cue 复用
字幕组 Column 子节点**无 key** + 底部锚组 `slots.reversed`：双语相邻对白重叠进出场时，在屏 cue 的 element 被按 Column 位置复用成另一条 cue（文本+\fad 透明度 1→0 瞬跳）=闪。PR#49 只稳定了槽位数据层，没传导到 element 层。修复：每槽位 `KeyedSubtree(ObjectKey(slot.cue))`。

## 验证
- 两个守卫测试均验证**修复前红/修复后绿**（stash 源文件复跑取证）
- `test/media/video/` 全目录 1494 测试全绿
- `flutter analyze` 零问题（含 test）

## 待真机
- `\blur` 柔光晕观感 vs mpv 对照
- 双语实片闪烁复测；若挂 key 后仍有「卡顿掉帧型」闪烁，下一步做 RepaintBoundary/整盒 blur 优化（每字 saveLayer ~35 个/帧的性能嫌疑已记录在 BUG-797 备注）