### PR TITLE
fix(video): BUG-791 open 前 sub-auto=no 阻止 sidecar 字幕被原生 SubtitleView 重复渲染

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 772 条。点号进各自文件。
+> 共 773 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-791](bugs/BUG-791-android-native-subtitleview-duplicate.md) | 🚧 | 🚧 | 安卓视频原生SubtitleView与可点浮层字幕重复(控制条显示时上下两条) |
 | [BUG-789](bugs/BUG-789-reader-chrome-inset-stale-pagination-metrics.md) | ✅ | ✅ | 底栏 inset 后分页终点过期导致章尾不可读 |
 | [BUG-788](bugs/BUG-788-fractional-page-boundary-premature-limit.md) | ✅ | ✅ | 亚像素页距在第31页误判边界提前停翻 |
 | [BUG-787](bugs/BUG-787-vertical-pagination-drift-recurrence.md) | ✅ | ✅ | 竖排累计漂移探针取整假阳性（当前 develop 未复现） |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -31,7 +31,7 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-791](bugs/BUG-791-android-native-subtitleview-duplicate.md) | 🚧 | 🚧 | 安卓视频原生SubtitleView与可点浮层字幕重复(控制条显示时上下两条) |
+| [BUG-791](bugs/BUG-791-android-native-subtitleview-duplicate.md) | ✅ | ✅ | 安卓视频原生SubtitleView与可点浮层字幕重复(控制条显示时上下两条) |
 | [BUG-789](bugs/BUG-789-reader-chrome-inset-stale-pagination-metrics.md) | ✅ | ✅ | 底栏 inset 后分页终点过期导致章尾不可读 |
 | [BUG-788](bugs/BUG-788-fractional-page-boundary-premature-limit.md) | ✅ | ✅ | 亚像素页距在第31页误判边界提前停翻 |
 | [BUG-787](bugs/BUG-787-vertical-pagination-drift-recurrence.md) | ✅ | ✅ | 竖排累计漂移探针取整假阳性（当前 develop 未复现） |

--- a/docs/bugs/BUG-791-android-native-subtitleview-duplicate.md
+++ b/docs/bugs/BUG-791-android-native-subtitleview-duplicate.md
@@ -1,0 +1,40 @@
+## BUG-791 · 安卓视频原生SubtitleView与可点浮层字幕重复(控制条显示时上下两条)
+- **报告**：2026-07-14（用户：安卓视频，字幕；截图 OP staffroll 场景 00:06，外挂 .ass，所有视频都复现）
+- **真实性**：✅ 真 bug。根因方向已定位（见下），**确切失效环节 + 修复验证需真机（当前 adb 无设备在线）**。
+- **[ ] ① 未修复** — 需真机 logcat 定位是「字幕轨残留被选中」还是「visible 标志未生效」，再改并复测原始失败路径
+- **[ ] ② 未加自动化测试** — 修好后加守卫（抑制序列 / SubtitleView 不渲染）
+- **备注**：本条与草稿 PR#94 的 BUG-790 撞号，已手动改 791。
+
+---
+
+### 症状
+安卓视频播放：**控制条隐藏时字幕正常（1 条）；控制条显示时字幕变成上下两条**（同一句文本）。
+- 上面一条：**较大**、干净、随控制条出现被抬到画面中部（躲进度条）。
+- 下面一条：**较小**、钉在最底部、被进度条/控制按钮盖住，不随控制条移动。
+
+截图证据：两条字幕**字号明显不同** = 两个不同渲染器。桌面端不复现（安卓特有）。
+
+### 验真过程（沿真实代码路径）
+1. **浮层只有一个实例、只有它渲染 cue**：全仓 `VideoSubtitleOverlay(` 仅 `layout.part.dart:324` 一处，且已 wired `controlsVisible: _videoControlsVisible`（会随控制条上抬）。唯一消费 `activeCues` 渲染的组件就是它（`video_subtitle_overlay.dart:478`）。
+2. **数据层无重复**：用 app 的 `AssParser.parseString` 解析用户真实文件（`Shunkashuutou…S01E08…ToonsHub.ass`），6000ms 处**只有 1 条 cue**（`ああ　四季庁よりも2人の意思を\N優先するよう動いてくれ`，`Text_JP` 样式 Alignment=2 底部、MarginV=30、无 `\pos`），全片仅出现 1 次。单 cue → 单渲染（widget 测试证实一条底部 cue 正确避让、只出一个盒子）。
+3. **下面那条是 media_kit 原生 `SubtitleView`**：
+   - `libass = false`（media_kit 默认 `platform_player.dart:526`，Hibiki 构造 `Player()` 从不设 libass，`video_player_controller.dart:1257-1263`）→ libmpv **不**把字幕烤进纹理。
+   - fork `third_party/media_kit_video/lib/src/video/video_texture.dart:450-460`：`SubtitleView` 仅在 `subtitleViewConfiguration.visible && !libass` 时渲染，且**位于 controls（Hibiki 浮层）之下**（`:461-463`）。z 序、字号差、"随控制条上抬的是上面那条浮层、下面那条不动" 全部吻合。
+   - `MaterialVideoControls` 不自渲染字幕（只 `shiftSubtitle` 改 padding，且 `shiftSubtitlesOnControlsVisibilityChange` 默认 false，`material.dart:759`）——排除控制条自带字幕。
+4. **`SubtitleView` 出字的必要条件**：① `subtitleViewConfiguration.visible == true`（运行时）**且** ② `player.state.subtitle` 非空（= libmpv 里有被选中的字幕轨在吐 `sub-text`）。Hibiki 本应把 ① 压成 `visible:false`（`layout.part.dart:79`、`fullscreen.part.dart:140`）、把 ② 压成空（`setSubtitleTrack(SubtitleTrack.no())` + `sub-auto=no` + `sub-visibility=no`，`video_player_controller.dart:1413-1425`）。**安卓上没压住**。
+   - 因为 `libass=false`，"下面那条能出字" 反证 **② 成立**：libmpv 里确有一条字幕轨被选中（该视频是 AMZN WEB-DL，含**内嵌**日文字幕轨；用户又外挂了 ToonsHub 同内容 .ass 走可点浮层 → 内嵌轨经原生 SubtitleView 冒出来 = 同句、异字号、双份）。
+   - 外挂字幕**从不**交给 libmpv（无 `SubtitleTrack.uri`/`sub-add`，仅解析成 cue），故原生那条不是外挂、而是**视频内嵌轨**。
+
+### 根因（方向已定，确切环节待真机）
+抑制在 `load()` 里 `open()` 后**只下发一次**（`video_player_controller.dart:1413-1425`）。已知竞态（代码注释 `:1415-1421`）：内嵌字幕轨是 `open` 后**异步解析就绪**的，mpv 默认 `sub-auto=exact` 会自动选中。安卓上（容器解析时序不同）疑似出现：`setSubtitleTrack(no())`（1413）执行时轨列表尚未就绪 → no-op；轨随后就绪被自动选中；`sub-auto=no`（1422）只阻止**未来**自动重选、**不会反选已选中的那条** → 内嵌轨残留被选中，`player.state.subtitle` 持续非空，被（visible 未真正生效的）`SubtitleView` 渲染。
+
+### 修复方向（待真机验证后落地）
+根治点 = **强制"非图形字幕模式下 libmpv 字幕轨恒为未选中"的不变量**（把条件 ② 钉死，`SubtitleView` 自然不出字，与 ① 是否生效无关）：
+- 订阅 `player.stream.track`，当选中的字幕轨非 `no()`/`auto` 且 `!_graphicSubtitleActive` 时，重下发 `setSubtitleTrack(SubtitleTrack.no())`（沿用 `_isCurrentLoad` use-after-free 双判据；注意 `selectEmbeddedGraphicTrack` 需在选轨**前**置 `_graphicSubtitleActive=true` 并在各早退路径复位，避免误反选图形轨）。
+- 或最小改动：抑制序列在 `sub-auto=no` **之后**、等轨列表就绪再补一次 `setSubtitleTrack(no())`（非图形模式）关掉竞态窗口里被选中的轨。
+- 该区域涉及 BUG-190/122/301 与原生 use-after-free 守卫，**盲改风险高**；必须真机复测原始失败路径（安卓 + 含内嵌字幕的视频 + 外挂 .ass + 显示控制条）+ 验证图形字幕（PGS）不回归。
+
+### 待办
+- [ ] 真机 logcat：确认是「内嵌轨残留被选中」（预期）还是「`subtitleViewConfiguration.visible` 未生效」；打印 `player.state.track.subtitle` / `player.state.subtitle`。
+- [ ] 按上面方向根治并加守卫测试。
+- [ ] 真机复测 + 图形字幕不回归。

--- a/docs/bugs/BUG-791-android-native-subtitleview-duplicate.md
+++ b/docs/bugs/BUG-791-android-native-subtitleview-duplicate.md
@@ -1,9 +1,9 @@
 ## BUG-791 · 安卓视频原生SubtitleView与可点浮层字幕重复(控制条显示时上下两条)
 - **报告**：2026-07-14（用户：安卓视频，字幕；截图 OP staffroll 场景 00:06，外挂 .ass，所有视频都复现）
-- **真实性**：✅ 真 bug。根因方向已定位（见下），**确切失效环节 + 修复验证需真机（当前 adb 无设备在线）**。
-- **[ ] ① 未修复** — 需真机 logcat 定位是「字幕轨残留被选中」还是「visible 标志未生效」，再改并复测原始失败路径
-- **[ ] ② 未加自动化测试** — 修好后加守卫（抑制序列 / SubtitleView 不渲染）
-- **备注**：本条与草稿 PR#94 的 BUG-790 撞号，已手动改 791。
+- **真实性**：✅ 真 bug。**确切根因已定位**：libmpv `sub-auto=exact` 在 `open()` 自动加载同名 sidecar 字幕，经 media_kit 原生 `SubtitleView` 渲染，与 Hibiki 可点 overlay 叠成双字幕。根因 `hibiki/lib/src/media/video/video_player_controller.dart`（抑制在 open **之后**才下发，太迟）。
+- **[x] ① 已修复** — 在 `player.open()` **之前**下发 `sub-auto=no`（`video_player_controller.dart` load()，commit 见下），libmpv 从一开始就不自动加载 sidecar。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_sidecar_autoload_guard_test.dart`（源码扫描守卫：抑制必须在 `player.open(` 之前）。
+- **备注**：本条与草稿 PR#94 的 BUG-790 撞号，已手动改 791。**待真机复测原始失败路径**（安卓 + 视频旁有同名 sidecar .ass + 显示控制条，确认只剩一条字幕；并验证 PGS 图形字幕不回归）。
 
 ---
 
@@ -22,19 +22,18 @@
    - fork `third_party/media_kit_video/lib/src/video/video_texture.dart:450-460`：`SubtitleView` 仅在 `subtitleViewConfiguration.visible && !libass` 时渲染，且**位于 controls（Hibiki 浮层）之下**（`:461-463`）。z 序、字号差、"随控制条上抬的是上面那条浮层、下面那条不动" 全部吻合。
    - `MaterialVideoControls` 不自渲染字幕（只 `shiftSubtitle` 改 padding，且 `shiftSubtitlesOnControlsVisibilityChange` 默认 false，`material.dart:759`）——排除控制条自带字幕。
 4. **`SubtitleView` 出字的必要条件**：① `subtitleViewConfiguration.visible == true`（运行时）**且** ② `player.state.subtitle` 非空（= libmpv 里有被选中的字幕轨在吐 `sub-text`）。Hibiki 本应把 ① 压成 `visible:false`（`layout.part.dart:79`、`fullscreen.part.dart:140`）、把 ② 压成空（`setSubtitleTrack(SubtitleTrack.no())` + `sub-auto=no` + `sub-visibility=no`，`video_player_controller.dart:1413-1425`）。**安卓上没压住**。
-   - 因为 `libass=false`，"下面那条能出字" 反证 **② 成立**：libmpv 里确有一条字幕轨被选中（该视频是 AMZN WEB-DL，含**内嵌**日文字幕轨；用户又外挂了 ToonsHub 同内容 .ass 走可点浮层 → 内嵌轨经原生 SubtitleView 冒出来 = 同句、异字号、双份）。
-   - 外挂字幕**从不**交给 libmpv（无 `SubtitleTrack.uri`/`sub-add`，仅解析成 cue），故原生那条不是外挂、而是**视频内嵌轨**。
+   - `ffprobe` 该视频（`…ToonsHub.mkv`）：只有 h264 视频 + eac3 音频，**无任何内嵌字幕轨**。故原生那条不是内嵌轨。
+   - **关键**：`.ass` 与 `.mkv` **同目录、同基础名**（`…ToonsHub.ass` / `…ToonsHub.mkv`）= 一个 **sidecar 外挂字幕**。libmpv 默认 `sub-auto=exact` 会在 `open()` 加载文件时**自动加载同名 sidecar** 并选成字幕轨 → `player.state.subtitle` 非空 → 原生 `SubtitleView` 渲染。Hibiki 又自己把同一 `.ass` 解析成 cue 走可点 overlay → 同句双份、异字号、异位置（原生小字号钉底 dy≈基线、overlay 大字号随控制条避让）。widget 测试量到两条正好落在「基线 531 / 避让 431」= 一条避让一条不避让，坐实两个渲染器。
+   - "所有视频都复现" 亦吻合：用户视频旁常年放同名 sidecar 字幕。
 
-### 根因（方向已定，确切环节待真机）
-抑制在 `load()` 里 `open()` 后**只下发一次**（`video_player_controller.dart:1413-1425`）。已知竞态（代码注释 `:1415-1421`）：内嵌字幕轨是 `open` 后**异步解析就绪**的，mpv 默认 `sub-auto=exact` 会自动选中。安卓上（容器解析时序不同）疑似出现：`setSubtitleTrack(no())`（1413）执行时轨列表尚未就绪 → no-op；轨随后就绪被自动选中；`sub-auto=no`（1422）只阻止**未来**自动重选、**不会反选已选中的那条** → 内嵌轨残留被选中，`player.state.subtitle` 持续非空，被（visible 未真正生效的）`SubtitleView` 渲染。
+### 根因（已确认）
+字幕抑制 `buildSubtitleSuppressionProperties()`（`sub-auto=no` + `sub-visibility=no`）在 `load()` 里**只在 `player.open()` 之后下发一次**（旧 `video_player_controller.dart:1422`）。但 **sidecar 的自动加载发生在 `open()` 那一刻**（libmpv `sub-auto=exact`），open 之后再设 `sub-auto=no` 已**太迟**——sidecar 早已被加载并选中，随后经原生 `SubtitleView` 渲染。桌面端亦有同源二层历史（BUG-190），但安卓 `SubtitleView`（libass=false 走 Flutter 层字幕）表现最直观。
 
-### 修复方向（待真机验证后落地）
-根治点 = **强制"非图形字幕模式下 libmpv 字幕轨恒为未选中"的不变量**（把条件 ② 钉死，`SubtitleView` 自然不出字，与 ① 是否生效无关）：
-- 订阅 `player.stream.track`，当选中的字幕轨非 `no()`/`auto` 且 `!_graphicSubtitleActive` 时，重下发 `setSubtitleTrack(SubtitleTrack.no())`（沿用 `_isCurrentLoad` use-after-free 双判据；注意 `selectEmbeddedGraphicTrack` 需在选轨**前**置 `_graphicSubtitleActive=true` 并在各早退路径复位，避免误反选图形轨）。
-- 或最小改动：抑制序列在 `sub-auto=no` **之后**、等轨列表就绪再补一次 `setSubtitleTrack(no())`（非图形模式）关掉竞态窗口里被选中的轨。
-- 该区域涉及 BUG-190/122/301 与原生 use-after-free 守卫，**盲改风险高**；必须真机复测原始失败路径（安卓 + 含内嵌字幕的视频 + 外挂 .ass + 显示控制条）+ 验证图形字幕（PGS）不回归。
+### 修复（已落地）
+在 `player.open()` **之前**先下发一次 `buildSubtitleSuppressionProperties()`（`sub-auto=no`），让 libmpv 从一开始就不自动加载 sidecar；open 之后仍保留原有那次做兜底（内嵌轨 open 后异步就绪的重选竞态）。不影响：内嵌轨仍被 demux 枚举（供 `_loadEmbeddedSubtitleIfNeeded` ffmpeg 抽取）、图形 PGS 轨仍由 `selectEmbeddedGraphicTrack` 显式选轨渲染（`sub-auto` 只管**自动**加载/选择，不管**显式** `setSubtitleTrack`）。
+- 代码：`video_player_controller.dart` load() `await player.open(` 之前插入 `applySubtitleMpvPropertiesToPlayer(player, buildSubtitleSuppressionProperties())`。
+- 守卫：`test/media/video/video_subtitle_sidecar_autoload_guard_test.dart`（源码扫描：抑制必须在 `player.open(` 之前）。
 
 ### 待办
-- [ ] 真机 logcat：确认是「内嵌轨残留被选中」（预期）还是「`subtitleViewConfiguration.visible` 未生效」；打印 `player.state.track.subtitle` / `player.state.subtitle`。
-- [ ] 按上面方向根治并加守卫测试。
-- [ ] 真机复测 + 图形字幕不回归。
+- [ ] 真机复测原始失败路径（安卓 CPH2747 + 视频旁同名 sidecar .ass + 显示控制条）：确认只剩一条可点 overlay 字幕、底部原生小字幕消失。
+- [ ] 验证 PGS 图形字幕（显式选图形轨）不回归。

--- a/hibiki/lib/src/media/video/video_player_controller.dart
+++ b/hibiki/lib/src/media/video/video_player_controller.dart
@@ -1371,6 +1371,21 @@ class VideoPlayerController extends ChangeNotifier
     // 取 httpHeaders 设 `http-header-fields` 后才真正打开 URL（media_kit-1.2.6 real.dart:2145），
     // 故 header 走 Media 构造参数才赶得上 open。open 后的 [applyHttpHeaderFieldsToPlayer] 保留，
     // 为随后（本方法内、seek/play 之前）外挂的 audio-only 音轨设全局属性（TODO-1280）。
+    // 根治 BUG-791：libmpv 默认 `sub-auto=exact` 会在 `open()` 加载文件时**自动加载与视频
+    // 同名的 sidecar 外挂字幕**（用户放在视频旁的 `<video>.ass/.srt`），把它选成字幕轨、
+    // 经 media_kit 的原生 `SubtitleView` 渲染，与 Hibiki 自己解析同一 .ass 得到的可点
+    // [VideoSubtitleOverlay] **叠成两条同句字幕**（原生较小钉底、overlay 较大随控制条避让）。
+    // 抑制属性（下面 open 之后的 [buildSubtitleSuppressionProperties]）设 `sub-auto=no` 已**太迟**
+    // ——sidecar 在 `open()` 那一刻就已随 `sub-auto=exact` 自动加载并选中。故必须在 **open 之前**
+    // 下发 `sub-auto=no`，让 libmpv 从一开始就不自动加载 sidecar；字幕一律走 Hibiki 自己的解析
+    // （sidecar/内嵌文本轨抽成 cue 走 overlay，图形 PGS 轨由 [selectEmbeddedGraphicTrack]
+    // 显式选轨渲染，均不受 `sub-auto=no` 影响）。open 后仍再下发一次做兜底（内嵌轨 open 后异步
+    // 就绪的重选竞态，BUG-190）。仅 libmpv 后端生效，非 libmpv 静默 no-op（见 helper）。
+    await applySubtitleMpvPropertiesToPlayer(
+      player,
+      buildSubtitleSuppressionProperties(),
+    );
+    if (!_isCurrentLoad(player, loadToken)) return; // open 前抑制下发后换片/销毁。
     await player.open(
       Media(
         sourceUri,

--- a/hibiki/test/media/video/video_subtitle_sidecar_autoload_guard_test.dart
+++ b/hibiki/test/media/video/video_subtitle_sidecar_autoload_guard_test.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-791 守卫（源码扫描）：libmpv 默认 `sub-auto=exact` 会在 `player.open()` 加载文件时
+/// 自动加载与视频**同名的 sidecar 外挂字幕**（`<video>.ass/.srt`），把它选成字幕轨经
+/// media_kit 原生 `SubtitleView` 渲染，与 Hibiki 自己解析同一 sidecar 得到的可点
+/// [VideoSubtitleOverlay] 叠成两条同句字幕（安卓等价 SubtitleView 尤其明显）。
+///
+/// 根治：字幕抑制（`sub-auto=no`）必须在 `player.open()` **之前**下发——open 之后再设已太迟
+/// （sidecar 在 open 那一刻已随 `sub-auto=exact` 自动加载并选中）。
+///
+/// 本守卫锁定「`load()` 里第一处 `applySubtitleMpvPropertiesToPlayer(...`
+/// `buildSubtitleSuppressionProperties())` 出现在 `await player.open(` 之前」这个顺序不变量，
+/// 防止后续重构把抑制挪回 open 之后（回归 BUG-791）。纯字符串扫描，无需 libmpv/真机。
+void main() {
+  test('sub-auto=no suppression is applied BEFORE player.open() in load()', () {
+    final File src = File(
+      'lib/src/media/video/video_player_controller.dart',
+    );
+    expect(src.existsSync(), isTrue,
+        reason: '找不到 video_player_controller.dart（路径随重构变了？）');
+    final String text = src.readAsStringSync();
+
+    final int openIdx = text.indexOf('await player.open(');
+    expect(openIdx, greaterThan(0), reason: '找不到 player.open() 调用');
+
+    // open 之前必须已经下发一次抑制（sub-auto=no）——否则 sidecar 已被 libmpv 自动加载。
+    final String beforeOpen = text.substring(0, openIdx);
+    final bool suppressedBeforeOpen = beforeOpen.contains(
+      'buildSubtitleSuppressionProperties()',
+    );
+    expect(
+      suppressedBeforeOpen,
+      isTrue,
+      reason:
+          'BUG-791 回归：字幕抑制（buildSubtitleSuppressionProperties / sub-auto=no）'
+          '必须在 `player.open()` **之前**下发，否则 libmpv 会在 open 时自动加载同名 sidecar '
+          '字幕并经原生 SubtitleView 渲染，与可点 overlay 叠成双字幕。',
+    );
+
+    // 纯函数本身仍须把 sub-auto 关掉（防止有人把它改成只关 sub-visibility）。
+    final File cfg = File('lib/src/media/video/video_mpv_config.dart');
+    final String cfgText = cfg.readAsStringSync();
+    final int fnIdx = cfgText
+        .indexOf('Map<String, String> buildSubtitleSuppressionProperties');
+    expect(fnIdx, greaterThan(0));
+    final String fnBody = cfgText.substring(fnIdx, fnIdx + 200);
+    expect(fnBody.contains("'sub-auto': 'no'"), isTrue,
+        reason:
+            'buildSubtitleSuppressionProperties 必须含 sub-auto=no（禁止 sidecar 自动加载）');
+  });
+}


### PR DESCRIPTION
## 症状
安卓视频，控制条显示时字幕变上下两条(同句)：上面大字号=Hibiki 可点浮层(随控制条避让上抬)，下面小字号=media_kit 原生 `SubtitleView`(钉底、被控制条盖)。

## 真因(已确认)
- 视频本身**无内嵌字幕**(ffprobe：只有 h264+eac3)。外挂 .ass 与 .mkv **同目录同基础名** = sidecar。
- libmpv 默认 `sub-auto=exact` 在 `open()` 加载文件时**自动加载同名 sidecar** 并选成字幕轨 → media_kit 原生 `SubtitleView` 渲染；App 又自己解析同一 .ass 走可点 overlay ⇒ 同句双份、异字号、异位置(widget 测试量到两条正好落「基线531 / 避让431」=一条避让一条不避让，坐实两个渲染器)。
- 抑制 `sub-auto=no` 原本在 `open()` **之后**才下发 = 太迟(sidecar 已在 open 那刻加载)。这也解释「所有(旁有 sidecar 的)视频都复现」。

## 修复
在 `player.open()` **之前**先下发 `buildSubtitleSuppressionProperties()`(`sub-auto=no`)，libmpv 从一开始就不自动加载 sidecar；open 后仍保留原有那次做兜底。不影响内嵌轨枚举/ffmpeg 抽取、图形 PGS 轨显式选轨(`sub-auto` 只管**自动**加载，不管显式 `setSubtitleTrack`)。
- `hibiki/lib/src/media/video/video_player_controller.dart` load()
- 守卫：`hibiki/test/media/video/video_subtitle_sidecar_autoload_guard_test.dart`(源码扫描：抑制必须在 `player.open(` 之前)
- `docs/bugs/BUG-791-*.md`

## 验证
- [x] flutter analyze / dart format 干净；守卫测试通过。
- [ ] **真机复测中**(安卓 CPH2747 + 视频旁同名 sidecar .ass + 显示控制条)：确认只剩一条可点 overlay 字幕、底部原生小字幕消失；并验证 PGS 图形字幕不回归。