### PR TITLE
剪切板浮窗：背景逐像素透明（阶段二）+ 面板栏悬停显示（阶段三）

### DIFF
--- a/hibiki/assets/popup/global_lookup_host.js
+++ b/hibiki/assets/popup/global_lookup_host.js
@@ -162,6 +162,28 @@
   // SetTopmost applies it); Dart syncs this visual via setPanelPinnedVisual on
   // panel show so the bar icon matches the remembered pref.
   var panelPinnedVisual = true;
+  // 阶段三 — 面板栏「悬停显示」(peek)：true 时面板栏平时收起（透明+上移、不挡内容），
+  // 鼠标移到窗口顶部触发区才淡入；只剩文字浮着，需要拖/钉/关时把鼠标移上去即可。
+  var panelPeekEnabled = false;
+
+  // className 字符串增删（面板 host 不用 classList——node 假 DOM 只有 className 串，
+  // 与 setPanelPinnedVisual 的字符串走法一致，保证同一代码路径可离屏测）。
+  function hasClass(el, cls) {
+    return (' ' + ((el && el.className) || '') + ' ').indexOf(
+      ' ' + cls + ' ') >= 0;
+  }
+  function addClass(el, cls) {
+    if (el && !hasClass(el, cls)) {
+      el.className = (((el.className || '') + ' ' + cls)).replace(/^\s+/, '');
+    }
+  }
+  function removeClass(el, cls) {
+    if (el) {
+      el.className = (' ' + (el.className || '') + ' ')
+        .split(' ' + cls + ' ').join(' ')
+        .replace(/^\s+|\s+$/g, '');
+    }
+  }
 
   // Post a message to C++ (and on to Dart) via the TOP-LEVEL chrome.webview
   // bridge. Mirrors the adapter envelope { handler, args } so _onJsMessage routes
@@ -381,6 +403,17 @@
         '#global-lookup-panel-bar[data-theme="dark"] .panel-btn:hover{' +
         'background:rgba(235,235,245,0.24);color:rgba(235,235,245,0.95);}' +
         '#global-lookup-panel-bar .panel-btn.panel-pin-off{opacity:0.45;}' +
+        // 阶段三 — peek：面板栏平时收起（透明+上移、不吃点击），移入顶部触发区
+        // （global-lookup-panel-peek-zone）才淡入（.panel-peek-shown）。
+        '#global-lookup-panel-bar.panel-peek{opacity:0;' +
+        'transform:translateY(-100%);' +
+        'transition:opacity 0.18s ease,transform 0.18s ease;' +
+        'pointer-events:none;}' +
+        '#global-lookup-panel-bar.panel-peek.panel-peek-shown{opacity:1;' +
+        'transform:translateY(0);pointer-events:auto;}' +
+        '#global-lookup-panel-peek-zone{position:fixed;left:0;top:0;right:0;' +
+        'height:14px;z-index:2147483000;pointer-events:auto;' +
+        'background:transparent;}' +
         // Bottom-right resize grip (posts beginWindowResize).
         '#global-lookup-panel-resize{' +
         'position:fixed;right:0;bottom:0;width:16px;height:16px;' +
@@ -476,6 +509,41 @@
     }, true);
     (document.body || document.documentElement).appendChild(resize);
     return bar;
+  }
+
+  // 阶段三 — 应用/取消面板栏「悬停显示」(peek)。启用：给栏加 panel-peek（CSS 收起），
+  // 并在窗口顶部装一条透明触发区，鼠标进入→显示栏（栏显示后覆盖在触发区之上）；
+  // 鼠标移出栏→收回。禁用：移除 peek 类 + 触发区。幂等，仅面板模式调用。
+  function applyPanelPeek(bar, enabled) {
+    panelPeekEnabled = !!enabled;
+    if (!bar) {
+      return;
+    }
+    if (!enabled) {
+      removeClass(bar, 'panel-peek');
+      removeClass(bar, 'panel-peek-shown');
+      var oldZone = document.getElementById &&
+          document.getElementById('global-lookup-panel-peek-zone');
+      if (oldZone && oldZone.parentNode &&
+          typeof oldZone.parentNode.removeChild === 'function') {
+        oldZone.parentNode.removeChild(oldZone);
+      }
+      return;
+    }
+    addClass(bar, 'panel-peek');
+    var zone = document.getElementById &&
+        document.getElementById('global-lookup-panel-peek-zone');
+    if (!zone) {
+      zone = document.createElement('div');
+      zone.id = 'global-lookup-panel-peek-zone';
+      zone.addEventListener('mouseenter', function () {
+        addClass(bar, 'panel-peek-shown');
+      }, false);
+      (document.body || document.documentElement).appendChild(zone);
+      bar.addEventListener('mouseleave', function () {
+        removeClass(bar, 'panel-peek-shown');
+      }, false);
+    }
   }
 
   // spec 2026-07-10 — syncs the pin button's VISUAL state to the Dart pref
@@ -1261,6 +1329,9 @@
       if (panelBar && (rootTheme === 'dark' || rootTheme === 'light')) {
         panelBar.setAttribute('data-theme', rootTheme);
       }
+      // 阶段三 — 面板栏「悬停显示」：payload.peek 驱动收起/常显（每次渲染重申，
+      // Dart 侧开关切换即时生效）。
+      applyPanelPeek(panelBar, !!(payload && payload.peek));
     }
     if (!popups.length) {
       removeMissing([]);
@@ -1776,6 +1847,7 @@
     dismissRootWithSlide: dismissRootWithSlide,
     // spec 2026-07-10 — panel-mode hooks (no-ops in cascade mode).
     setPanelPinnedVisual: setPanelPinnedVisual,
+    applyPanelPeek: applyPanelPeek,
     _frames: frames,
     // TODO-1188 — exposed for the node bridge-routing harness only (never used to
     // drive behaviour): the live globalId -> {frameId, localId} route map.

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39661 (2333 per locale)
+/// Strings: 39695 (2335 per locale)
 ///
-/// Built on 2026-07-13 at 15:49 UTC
+/// Built on 2026-07-13 at 16:24 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3091,6 +3091,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get desktop_clipboard_auto_lookup => 'Auto-look-up on copy';
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -8375,6 +8378,11 @@ class _StringsAr extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -13782,6 +13790,11 @@ class _StringsDe extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -19206,6 +19219,11 @@ class _StringsEs extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -24649,6 +24667,11 @@ class _StringsFr extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -29994,6 +30017,11 @@ class _StringsId extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -35400,6 +35428,11 @@ class _StringsIt extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -40531,6 +40564,11 @@ class _StringsJa extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -45667,6 +45705,11 @@ class _StringsKo extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -51041,6 +51084,11 @@ class _StringsNl extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -56438,6 +56486,11 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -61810,6 +61863,11 @@ class _StringsRu extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -67095,6 +67153,11 @@ class _StringsTh extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -72435,6 +72498,11 @@ class _StringsTr extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -77750,6 +77818,11 @@ class _StringsVi extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -82701,6 +82774,11 @@ class _StringsZhCn extends _StringsEn {
   String get desktop_clipboard_auto_lookup => '复制后自动查词';
   @override
   String get desktop_clipboard_auto_lookup_hint => '关闭后面板只显示复制到的文字，点词才查词。';
+  @override
+  String get clipboard_panel_transparent => '面板背景透明';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      '逐像素透明：只显示文字，背后的游戏画面透过来（Windows）。';
 }
 
 // Path: retrying_in
@@ -87734,6 +87812,11 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get desktop_clipboard_auto_lookup_hint =>
       'When off, the panel shows only the copied text; tap a word to look it up.';
+  @override
+  String get clipboard_panel_transparent => 'Transparent panel background';
+  @override
+  String get clipboard_panel_transparent_hint =>
+      'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
 }
 
 // Path: retrying_in
@@ -92544,6 +92627,10 @@ extension on _StringsEn {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -97314,6 +97401,10 @@ extension on _StringsAr {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -102106,6 +102197,10 @@ extension on _StringsDe {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -106896,6 +106991,10 @@ extension on _StringsEs {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -111693,6 +111792,10 @@ extension on _StringsFr {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -116470,6 +116573,10 @@ extension on _StringsId {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -121264,6 +121371,10 @@ extension on _StringsIt {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -126015,6 +126126,10 @@ extension on _StringsJa {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -130770,6 +130885,10 @@ extension on _StringsKo {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -135557,6 +135676,10 @@ extension on _StringsNl {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -140341,6 +140464,10 @@ extension on _StringsPtBr {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -145129,6 +145256,10 @@ extension on _StringsRu {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -149899,6 +150030,10 @@ extension on _StringsTh {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -154678,6 +154813,10 @@ extension on _StringsTr {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -159451,6 +159590,10 @@ extension on _StringsVi {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }
@@ -164188,6 +164331,10 @@ extension on _StringsZhCn {
         return '复制后自动查词';
       case 'desktop_clipboard_auto_lookup_hint':
         return '关闭后面板只显示复制到的文字，点词才查词。';
+      case 'clipboard_panel_transparent':
+        return '面板背景透明';
+      case 'clipboard_panel_transparent_hint':
+        return '逐像素透明：只显示文字，背后的游戏画面透过来（Windows）。';
       default:
         return null;
     }
@@ -168931,6 +169078,10 @@ extension on _StringsZhHk {
         return 'Auto-look-up on copy';
       case 'desktop_clipboard_auto_lookup_hint':
         return 'When off, the panel shows only the copied text; tap a word to look it up.';
+      case 'clipboard_panel_transparent':
+        return 'Transparent panel background';
+      case 'clipboard_panel_transparent_hint':
+        return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39695 (2335 per locale)
+/// Strings: 39729 (2337 per locale)
 ///
-/// Built on 2026-07-13 at 16:24 UTC
+/// Built on 2026-07-13 at 17:43 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3094,6 +3094,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get clipboard_panel_transparent => 'Transparent panel background';
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -8383,6 +8386,11 @@ class _StringsAr extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -13795,6 +13803,11 @@ class _StringsDe extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -19224,6 +19237,11 @@ class _StringsEs extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -24672,6 +24690,11 @@ class _StringsFr extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -30022,6 +30045,11 @@ class _StringsId extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -35433,6 +35461,11 @@ class _StringsIt extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -40569,6 +40602,11 @@ class _StringsJa extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -45710,6 +45748,11 @@ class _StringsKo extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -51089,6 +51132,11 @@ class _StringsNl extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -56491,6 +56539,11 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -61868,6 +61921,11 @@ class _StringsRu extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -67158,6 +67216,11 @@ class _StringsTh extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -72503,6 +72566,11 @@ class _StringsTr extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -77823,6 +77891,11 @@ class _StringsVi extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -82779,6 +82852,10 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       '逐像素透明：只显示文字，背后的游戏画面透过来（Windows）。';
+  @override
+  String get clipboard_panel_peek => '面板栏悬停显示';
+  @override
+  String get clipboard_panel_peek_hint => '隐藏拖动/图钉/关闭栏；鼠标移到顶部才显示。';
 }
 
 // Path: retrying_in
@@ -87817,6 +87894,11 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get clipboard_panel_transparent_hint =>
       'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+  @override
+  String get clipboard_panel_peek => 'Auto-hide panel bar';
+  @override
+  String get clipboard_panel_peek_hint =>
+      'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
 }
 
 // Path: retrying_in
@@ -92631,6 +92713,10 @@ extension on _StringsEn {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -97405,6 +97491,10 @@ extension on _StringsAr {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -102201,6 +102291,10 @@ extension on _StringsDe {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -106995,6 +107089,10 @@ extension on _StringsEs {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -111796,6 +111894,10 @@ extension on _StringsFr {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -116577,6 +116679,10 @@ extension on _StringsId {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -121375,6 +121481,10 @@ extension on _StringsIt {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -126130,6 +126240,10 @@ extension on _StringsJa {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -130889,6 +131003,10 @@ extension on _StringsKo {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -135680,6 +135798,10 @@ extension on _StringsNl {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -140468,6 +140590,10 @@ extension on _StringsPtBr {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -145260,6 +145386,10 @@ extension on _StringsRu {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -150034,6 +150164,10 @@ extension on _StringsTh {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -154817,6 +154951,10 @@ extension on _StringsTr {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -159594,6 +159732,10 @@ extension on _StringsVi {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }
@@ -164335,6 +164477,10 @@ extension on _StringsZhCn {
         return '面板背景透明';
       case 'clipboard_panel_transparent_hint':
         return '逐像素透明：只显示文字，背后的游戏画面透过来（Windows）。';
+      case 'clipboard_panel_peek':
+        return '面板栏悬停显示';
+      case 'clipboard_panel_peek_hint':
+        return '隐藏拖动/图钉/关闭栏；鼠标移到顶部才显示。';
       default:
         return null;
     }
@@ -169082,6 +169228,10 @@ extension on _StringsZhHk {
         return 'Transparent panel background';
       case 'clipboard_panel_transparent_hint':
         return 'Per-pixel transparency: only the text shows, the game behind stays visible (Windows).';
+      case 'clipboard_panel_peek':
+        return 'Auto-hide panel bar';
+      case 'clipboard_panel_peek_hint':
+        return 'Hide the drag/pin/close bar; move the mouse to the top edge to reveal it.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "扩展弹窗最大宽度",
   "extension_popup_max_height": "扩展弹窗最大高度",
   "desktop_clipboard_auto_lookup": "复制后自动查词",
-  "desktop_clipboard_auto_lookup_hint": "关闭后面板只显示复制到的文字，点词才查词。"
+  "desktop_clipboard_auto_lookup_hint": "关闭后面板只显示复制到的文字，点词才查词。",
+  "clipboard_panel_transparent": "面板背景透明",
+  "clipboard_panel_transparent_hint": "逐像素透明：只显示文字，背后的游戏画面透过来（Windows）。"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "复制后自动查词",
   "desktop_clipboard_auto_lookup_hint": "关闭后面板只显示复制到的文字，点词才查词。",
   "clipboard_panel_transparent": "面板背景透明",
-  "clipboard_panel_transparent_hint": "逐像素透明：只显示文字，背后的游戏画面透过来（Windows）。"
+  "clipboard_panel_transparent_hint": "逐像素透明：只显示文字，背后的游戏画面透过来（Windows）。",
+  "clipboard_panel_peek": "面板栏悬停显示",
+  "clipboard_panel_peek_hint": "隐藏拖动/图钉/关闭栏；鼠标移到顶部才显示。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2341,5 +2341,7 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "clipboard_panel_transparent": "Transparent panel background",
-  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows).",
+  "clipboard_panel_peek": "Auto-hide panel bar",
+  "clipboard_panel_peek_hint": "Hide the drag/pin/close bar; move the mouse to the top edge to reveal it."
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2339,5 +2339,7 @@
   "extension_popup_max_width": "Extension popup max width",
   "extension_popup_max_height": "Extension popup max height",
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
-  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up."
+  "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
+  "clipboard_panel_transparent": "Transparent panel background",
+  "clipboard_panel_transparent_hint": "Per-pixel transparency: only the text shows, the game behind stays visible (Windows)."
 }

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -388,6 +388,8 @@ class ClipboardPanelController {
       // 关闭时恒 1.0（不透明卡，保持现观感、零破坏）。native 若回退 windowed（DComp
       // 不可用），cardBgAlpha=0 会露出黑（透明背景色），但那是无 GPU 的极端环境。
       cardBgAlpha: model.clipboardPanelTransparent ? 0.0 : 1.0,
+      // 阶段三 — 面板栏悬停显示：开启后面板栏平时收起、鼠标移顶部才淡入。
+      peek: model.clipboardPanelPeek,
       sentenceHitStart: hit.length > 0 ? hit.start : -1,
       sentenceHitLength: hit.length,
     );

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -257,6 +257,17 @@ class ClipboardPanelController {
     await _channel.setWindowAlpha((model.clipboardPanelOpacity * 100).round());
   }
 
+  /// 背景逐像素透明开关切换即时生效：composition 下透明由卡背景 alpha（cardBgAlpha）
+  /// 承担，重渲当前面板（若正显示）即更新观感；未显示则下一条剪切板更新自然带上
+  /// 新 cardBgAlpha。native setWindowAlpha 在 composition 下已 no-op，故此处只重渲。
+  Future<void> refreshTransparency() async {
+    final AppModel? model = _appModel;
+    if (!_started || model == null) return;
+    if (_visible && _stack.isNotEmpty) {
+      await _renderPanel(model);
+    }
+  }
+
   /// 面板栏 × / root 卡 ×：藏窗即可。BUG-717：不再暂停路由——下一条剪贴板复制
   /// 会经 [update] 的 `!_visible` 分支重开面板（关掉后第二个词照样弹）。
   Future<void> hidePanel() async {
@@ -372,9 +383,11 @@ class ClipboardPanelController {
       maxWidth: maxW,
       maxHeight: maxH,
       layoutMode: 'panel',
-      // spec §6 真机修正：透明改整窗 LWA_ALPHA，卡背景恒不透明（双重变淡会
-      // 让文字更虚；CSS alpha 基建保留供未来 DComp 逐像素路线复用）。
-      cardBgAlpha: 1.0,
+      // 背景逐像素透明（composition 模式）：clipboardPanelTransparent 开启时卡背景
+      // 透明（cardBgAlpha=0），只有文字/注音/高亮实心像素画，其余透到桌面（像字幕）。
+      // 关闭时恒 1.0（不透明卡，保持现观感、零破坏）。native 若回退 windowed（DComp
+      // 不可用），cardBgAlpha=0 会露出黑（透明背景色），但那是无 GPU 的极端环境。
+      cardBgAlpha: model.clipboardPanelTransparent ? 0.0 : 1.0,
       sentenceHitStart: hit.length > 0 ? hit.start : -1,
       sentenceHitLength: hit.length,
     );

--- a/hibiki/lib/src/lookup/global_lookup_render.dart
+++ b/hibiki/lib/src/lookup/global_lookup_render.dart
@@ -259,6 +259,8 @@ String buildStackRenderScript({
   // 帧的 settingsJs；cascade 模式忽略。
   int sentenceHitStart = -1,
   int sentenceHitLength = 0,
+  // 阶段三 — 面板栏「悬停显示」(peek)：仅面板模式携带，host 据此收起/常显面板栏。
+  bool peek = false,
 }) {
   // TODO-867 P3c F2 — the host shell (.global-lookup-frame-shell) is built in the
   // TOP-LEVEL host document, which carries no data-theme of its own (the theme
@@ -322,6 +324,10 @@ String buildStackRenderScript({
   // spec 2026-07-10 — 仅面板模式携带 layoutMode 键；cascade 载荷字节不变。
   if (layoutMode == 'panel') {
     payloadObj['layoutMode'] = 'panel';
+    // 阶段三 — 面板栏悬停显示：仅面板模式且开启时携带，cascade/关闭时载荷不变。
+    if (peek) {
+      payloadObj['peek'] = true;
+    }
   }
   // TODO-1345 (BUG-583 深层根因续) — reserve cascade headroom toward the screen
   // interior so an up/left child lands INSIDE the window origin committed at the

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4203,6 +4203,11 @@ class AppModel with ChangeNotifier {
   Future<void> setClipboardPanelTransparent(bool v) =>
       prefsRepo.setClipboardPanelTransparent(v);
 
+  /// 剪切板悬浮面板栏「悬停显示」（peek）。默认 false。
+  bool get clipboardPanelPeek => prefsRepo.clipboardPanelPeek;
+  Future<void> setClipboardPanelPeek(bool v) =>
+      prefsRepo.setClipboardPanelPeek(v);
+
   /// spec 2026-07-10 §7 生命周期上移：剪贴板监听归 AppModel 持有（开=start /
   /// 关=stop），HomeDictionaryPage 退化为 destination==main 分区的消费者。此前
   /// start/stop 绑词典 tab 挂载周期——那是「去向只有主窗 tab」时代的产物；

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4198,6 +4198,11 @@ class AppModel with ChangeNotifier {
   Future<void> setDesktopClipboardAutoLookup(bool v) =>
       prefsRepo.setDesktopClipboardAutoLookup(v);
 
+  /// 剪切板悬浮面板背景逐像素透明（composition 模式）。默认 false。
+  bool get clipboardPanelTransparent => prefsRepo.clipboardPanelTransparent;
+  Future<void> setClipboardPanelTransparent(bool v) =>
+      prefsRepo.setClipboardPanelTransparent(v);
+
   /// spec 2026-07-10 §7 生命周期上移：剪贴板监听归 AppModel 持有（开=start /
   /// 关=stop），HomeDictionaryPage 退化为 destination==main 分区的消费者。此前
   /// start/stop 绑词典 tab 挂载周期——那是「去向只有主窗 tab」时代的产物；

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -461,6 +461,19 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 剪切板悬浮面板背景是否**逐像素透明**（Windows composition 模式）：开启后卡背景
+  /// 透明（cardBgAlpha=0），只有文字/注音/高亮实心像素画，其余透到底下的游戏画面
+  /// （像字幕）。默认 false=不透明卡（保持现观感，零破坏）。区别于旧的整窗
+  /// [clipboardPanelOpacity]（整窗统一变淡、文字一起透）——composition 下整窗 alpha
+  /// 已 no-op，透明改由本开关的逐像素卡背景承担。仅 Windows 面板去向有意义。
+  bool get clipboardPanelTransparent =>
+      getPref('clipboard_panel_transparent', defaultValue: false) as bool;
+
+  Future<void> setClipboardPanelTransparent(bool value) async {
+    await setPref('clipboard_panel_transparent', value);
+    notifyListeners();
+  }
+
   // TODO-1030 M0 — 全局查词（应用外）是否抓取选中文本周围的上下文句。默认 false：
   // 抓取要读前台应用的 UIA 文本，隐私敏感，用户显式开启才启用；关闭时全局查词只用
   // 剪贴板拿到的纯选中串（现状），不接触前台应用文本。

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -474,6 +474,17 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 剪切板悬浮面板的面板栏是否「悬停显示」（peek）：开启后面板栏（拖动/图钉/关闭）
+  /// 平时收起，鼠标移到窗口顶部才淡入——平时只剩文字浮着，需要操作时把鼠标移上去。
+  /// 默认 false=面板栏常显（现观感，零破坏）。仅 Windows 面板去向有意义。
+  bool get clipboardPanelPeek =>
+      getPref('clipboard_panel_peek', defaultValue: false) as bool;
+
+  Future<void> setClipboardPanelPeek(bool value) async {
+    await setPref('clipboard_panel_peek', value);
+    notifyListeners();
+  }
+
   // TODO-1030 M0 — 全局查词（应用外）是否抓取选中文本周围的上下文句。默认 false：
   // 抓取要读前台应用的 UIA 文本，隐私敏感，用户显式开启才启用；关闭时全局查词只用
   // 剪贴板拿到的纯选中串（现状），不接触前台应用文本。

--- a/hibiki/lib/src/settings/settings_schema_lookup.dart
+++ b/hibiki/lib/src/settings/settings_schema_lookup.dart
@@ -467,6 +467,26 @@ SettingsDestination buildLookupDestination() {
               settingsContext.refresh();
             },
           ),
+          // 面板栏「悬停显示」：开启后拖动/图钉/关闭栏平时收起，鼠标移到窗口顶部
+          // 才淡入——平时只剩文字浮着，配合背景透明是完整的「字幕」观感。
+          SettingsSwitchItem(
+            id: 'lookup.clipboard_panel_peek',
+            title: t.clipboard_panel_peek,
+            subtitle: t.clipboard_panel_peek_hint,
+            icon: Icons.unfold_less_outlined,
+            visible: (SettingsContext settingsContext) =>
+                DesktopLookupService.isDesktop &&
+                settingsContext.appModel.desktopClipboardEnabled &&
+                settingsContext.appModel.desktopClipboardDestination ==
+                    DesktopClipboardDestination.panel,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.clipboardPanelPeek,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel.setClipboardPanelPeek(value);
+              await ClipboardPanelController.instance.refreshTransparency();
+              settingsContext.refresh();
+            },
+          ),
           // TODO-1030 M0：全局查词（应用外）抓取选中文本周围上下文句。开启后按热键
           // 查词时，除选中词外还经 UI Automation 读取前台应用选区前后各约 600 字，裁出
           // 当前句在弹窗展示（Yomitan {sentence} 风格）。隐私敏感——读前台应用文本，

--- a/hibiki/lib/src/settings/settings_schema_lookup.dart
+++ b/hibiki/lib/src/settings/settings_schema_lookup.dart
@@ -445,6 +445,28 @@ SettingsDestination buildLookupDestination() {
               await ClipboardPanelController.instance.refreshOpacity();
             },
           ),
+          // 背景逐像素透明（Windows composition 模式）：开启后面板卡背景透明，只有
+          // 文字/注音/高亮实心，其余透到底下的游戏画面（像字幕）。区别于上面的整窗
+          // 不透明度（整窗统一变淡、文字一起透）。destination==panel 即显示。
+          SettingsSwitchItem(
+            id: 'lookup.clipboard_panel_transparent',
+            title: t.clipboard_panel_transparent,
+            subtitle: t.clipboard_panel_transparent_hint,
+            icon: Icons.blur_on_outlined,
+            visible: (SettingsContext settingsContext) =>
+                DesktopLookupService.isDesktop &&
+                settingsContext.appModel.desktopClipboardEnabled &&
+                settingsContext.appModel.desktopClipboardDestination ==
+                    DesktopClipboardDestination.panel,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.clipboardPanelTransparent,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel
+                  .setClipboardPanelTransparent(value);
+              await ClipboardPanelController.instance.refreshTransparency();
+              settingsContext.refresh();
+            },
+          ),
           // TODO-1030 M0：全局查词（应用外）抓取选中文本周围上下文句。开启后按热键
           // 查词时，除选中词外还经 UI Automation 读取前台应用选区前后各约 600 字，裁出
           // 当前句在弹窗展示（Yomitan {sentence} 风格）。隐私敏感——读前台应用文本，

--- a/hibiki/test/lookup/clipboard_panel_controller_test.dart
+++ b/hibiki/test/lookup/clipboard_panel_controller_test.dart
@@ -185,12 +185,15 @@ void main() {
           reason: '回传必须走面板自己的 channel，与瞬态窗互不串线');
     });
 
-    test('渲染走 layoutMode panel；透明=整窗 LWA_ALPHA（spec §6 真机修正）', () {
+    test('渲染走 layoutMode panel；背景逐像素透明由 cardBgAlpha 承担（composition）', () {
       expect(controllerSrc.contains("layoutMode: 'panel'"), isTrue);
-      expect(controllerSrc.contains('setWindowAlpha'), isTrue,
-          reason: '真透视=整窗 alpha；acrylic 实测经 windowed WebView2 不透明');
-      expect(controllerSrc.contains('cardBgAlpha: 1.0'), isTrue,
-          reason: '卡背景恒不透明，避免与整窗 alpha 双重变淡');
+      // 背景逐像素透明：透明开关开→cardBgAlpha=0（卡背景透明、只剩文字），
+      // 关→1.0（不透明卡）。取代旧的「整窗 LWA_ALPHA 恒 cardBgAlpha:1.0」。
+      expect(
+        controllerSrc.contains('clipboardPanelTransparent ? 0.0 : 1.0'),
+        isTrue,
+        reason: '透明开关驱动卡背景 alpha：开=0（只剩文字），关=1（不透明卡）',
+      );
       expect(controllerSrc.contains('applyBackdrop'), isFalse,
           reason: 'acrylic backdrop 路线废弃（毛玻璃≠透视），面板不再调用');
     });

--- a/hibiki/test/lookup/clipboard_panel_guard_test.dart
+++ b/hibiki/test/lookup/clipboard_panel_guard_test.dart
@@ -247,10 +247,18 @@ void main() {
     });
 
     test('面板窗可激活（点击落焦点，滚轮不穿游戏）；瞬态窗保持 NOACTIVATE', () {
+      // 背景逐像素透明重构：activatable_ 分流收进 OverlayCreateExStyle 单一真相源，
+      // ShowAt/PrewarmWebView 两个创建点共用它（不再各写一份），比旧的「两处各写、
+      // 靠计数守一致」更强。
       expect(
         'activatable_ ? 0 : WS_EX_NOACTIVATE'.allMatches(cpp).length,
-        greaterThanOrEqualTo(2),
-        reason: 'ShowAt 与 PrewarmWebView 两处创建点都必须按 activatable_ 分流',
+        greaterThanOrEqualTo(1),
+        reason: 'activatable_ 分流在 OverlayCreateExStyle 里，两创建点共用',
+      );
+      expect(
+        'OverlayCreateExStyle()'.allMatches(cpp).length,
+        greaterThanOrEqualTo(3),
+        reason: '两个 CreateWindowExW 都调 OverlayCreateExStyle()（+ 定义 = ≥3）',
       );
       final int panelChannel = fw.indexOf('RegisterClipboardPanelChannel() {');
       expect(panelChannel, isNonNegative);

--- a/hibiki/test/lookup/clipboard_panel_taskbar_guard_test.dart
+++ b/hibiki/test/lookup/clipboard_panel_taskbar_guard_test.dart
@@ -45,14 +45,20 @@ void main() {
         reason: 'SetTaskbarPresence 必须在面板 channel 注册段里');
   });
 
-  test('两处 CreateWindowExW 都按 taskbar_presence_ 分流 APPWINDOW/TOOLWINDOW', () {
+  test('建窗 ex-style 经 OverlayCreateExStyle 统一分流（两创建点共用、不漂移）', () {
+    // 背景逐像素透明重构：两处 CreateWindowExW 的 ex-style 收进 OverlayCreateExStyle()，
+    // taskbar_presence_ 分流只此一处 → 两创建点结构性一致（预热窗与重建窗任务栏行为
+    // 不可能漂移，比旧的「两处各写一份、靠计数守一致」更强）。
     expect(
         'taskbar_presence_ ? WS_EX_APPWINDOW : WS_EX_TOOLWINDOW'
             .allMatches(cpp)
             .length,
-        2,
-        reason: 'ShowAt 懒建与 PrewarmWebView 预热两个创建点必须一致，'
-            '否则预热窗与重建窗任务栏行为漂移');
+        1,
+        reason: 'ex-style 分流收进 OverlayCreateExStyle 单一真相源');
+    expect('OverlayCreateExStyle()'.allMatches(cpp).length,
+        greaterThanOrEqualTo(3),
+        reason: 'ShowAt + PrewarmWebView 两个 CreateWindowExW 都调 '
+            'OverlayCreateExStyle()（+ 定义处 = 至少 3 次出现）');
     expect(
         'window_title_.c_str()'.allMatches(cpp).length, greaterThanOrEqualTo(2),
         reason: '两个创建点都必须用可设置的 window_title_（任务栏按钮文案）');

--- a/hibiki/test/lookup/global_lookup_host_test.mjs
+++ b/hibiki/test/lookup/global_lookup_host_test.mjs
@@ -1701,6 +1701,52 @@ function flushTimers() {
   );
 }
 
+// P-peek (阶段三). 面板栏「悬停显示」：payload.peek=true → bar 加 panel-peek（收起）
+//   + 窗口顶部触发区；触发区 mouseenter → panel-peek-shown（淡入）；bar mouseleave →
+//   收回。下次渲染 peek 缺省 → 撤销收起 + 移除触发区（常显，零回归）。
+{
+  const { host, document } = freshHost();
+  host.renderStack({
+    popups: [descriptor('panel-root', -1)],
+    layoutMode: 'panel',
+    peek: true,
+  });
+  const bar = document.getElementById('global-lookup-panel-bar');
+  assert.ok(bar, 'panel bar exists');
+  assert.ok(
+    /(^|\s)panel-peek(\s|$)/.test(bar.className),
+    'peek=true collapses the bar (panel-peek class)',
+  );
+  const zone = document.getElementById('global-lookup-panel-peek-zone');
+  assert.ok(zone, 'peek hover zone created at window top');
+  // 移入顶部触发区 → 面板栏淡入。
+  zone._listeners['mouseenter'][0]();
+  assert.ok(
+    /panel-peek-shown/.test(bar.className),
+    'hovering the top zone reveals the bar',
+  );
+  // 移出面板栏 → 收回。
+  bar._listeners['mouseleave'][0]();
+  assert.ok(
+    !/panel-peek-shown/.test(bar.className),
+    'leaving the bar hides it again',
+  );
+  // 关掉 peek（下一次渲染无 peek 键）→ 撤销收起 + 摘除触发区。
+  host.renderStack({
+    popups: [descriptor('panel-root', -1)],
+    layoutMode: 'panel',
+  });
+  assert.ok(
+    !/panel-peek/.test(bar.className),
+    'peek off restores the always-visible bar',
+  );
+  assert.strictEqual(
+    zone.parentNode,
+    null,
+    'peek off detaches the hover zone',
+  );
+}
+
 // P3. panel bar chrome: grip mousedown posts beginWindowDrag; pin toggles the
 //     visual + posts panelPin; close posts panelClose; setPanelPinnedVisual
 //     syncs the visual from the Dart pref.

--- a/hibiki/windows/runner/CMakeLists.txt
+++ b/hibiki/windows/runner/CMakeLists.txt
@@ -71,6 +71,9 @@ target_link_libraries(${BINARY_NAME} PRIVATE uiautomationcore.lib)
 # (RoInitialize / RoGetActivationFactory / WindowsCreateStringReference) and WIC
 # for PNG encode.
 target_link_libraries(${BINARY_NAME} PRIVATE d3d11 dxgi runtimeobject windowscodecs)
+# 剪切板面板背景逐像素透明（global_lookup_window composition 模式）：DirectComposition
+# 视觉树承载 WebView2 composition controller 的透明像素，dxguid 提供 DComp/DXGI IID。
+target_link_libraries(${BINARY_NAME} PRIVATE dcomp dxguid)
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 add_dependencies(${BINARY_NAME} flutter_assemble)
 

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -1015,6 +1015,9 @@ void FlutterWindow::RegisterClipboardPanelChannel() {
   // （图钉关）被游戏/浏览器压底时，点任务栏图标即可激活+拉回前台。瞬态查词窗
   // 不设，保持无任务栏项。
   clipboard_panel_window_->SetTaskbarPresence(true);
+  // 背景逐像素透明：面板走 composition + DirectComposition（透明像素真透到桌面，
+  // 背景全透 + 文字实心），取代整窗 LWA_ALPHA。瞬态查词窗不设，保持 windowed。
+  clipboard_panel_window_->SetCompositionMode(true);
   clipboard_panel_window_->SetWindowTitle(L"Hibiki");
   clipboard_panel_window_->SetUserDataLeaf(L"ClipboardPanelWebView2");
 

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -2,6 +2,7 @@
 
 #include <dwmapi.h>
 #include <shlwapi.h>
+#include <windowsx.h>  // GET_X_LPARAM / GET_KEYSTATE_WPARAM（composition 鼠标转发）
 
 #include "resource.h"
 
@@ -839,6 +840,63 @@ DWORD GlobalLookupWindow::OverlayCreateExStyle() {
          (composition_active_ ? WS_EX_NOREDIRECTIONBITMAP : 0);
 }
 
+// 背景逐像素透明（composition）— 把本窗收到的鼠标消息转发给 composition controller。
+// windowed 模式 WebView2 子窗自动收输入，不走这里。坐标：非滚轮消息 lParam 已是
+// 客户区物理像素（窗口 per-monitor DPI 感知，bounds 用 RAW_PIXELS，客户区=WebView 坐标）；
+// 滚轮消息 lParam 是屏幕坐标，需 ScreenToClient。virtualKeys 与 MK_* 位值一一对应，
+// 直接 cast。mouseData：滚轮=WHEEL_DELTA 倍数，其余 0。
+void GlobalLookupWindow::ForwardCompositionMouse(UINT message, WPARAM wparam,
+                                                 LPARAM lparam) {
+  if (composition_controller_ == nullptr) {
+    return;
+  }
+  const bool is_wheel =
+      (message == WM_MOUSEWHEEL || message == WM_MOUSEHWHEEL);
+  POINT point{GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam)};
+  UINT32 mouse_data = 0;
+  COREWEBVIEW2_MOUSE_EVENT_KIND kind = COREWEBVIEW2_MOUSE_EVENT_KIND_MOVE;
+  if (is_wheel) {
+    ScreenToClient(hwnd_, &point);  // 滚轮 lParam 是屏幕坐标。
+    mouse_data =
+        static_cast<UINT32>(GET_WHEEL_DELTA_WPARAM(wparam));
+    kind = (message == WM_MOUSEWHEEL)
+               ? COREWEBVIEW2_MOUSE_EVENT_KIND_WHEEL
+               : COREWEBVIEW2_MOUSE_EVENT_KIND_HORIZONTAL_WHEEL;
+  } else {
+    switch (message) {
+      case WM_MOUSEMOVE:
+        kind = COREWEBVIEW2_MOUSE_EVENT_KIND_MOVE;
+        break;
+      case WM_LBUTTONDOWN:
+        kind = COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_DOWN;
+        break;
+      case WM_LBUTTONUP:
+        kind = COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_UP;
+        break;
+      case WM_LBUTTONDBLCLK:
+        kind = COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_DOUBLE_CLICK;
+        break;
+      case WM_RBUTTONDOWN:
+        kind = COREWEBVIEW2_MOUSE_EVENT_KIND_RIGHT_BUTTON_DOWN;
+        break;
+      case WM_RBUTTONUP:
+        kind = COREWEBVIEW2_MOUSE_EVENT_KIND_RIGHT_BUTTON_UP;
+        break;
+      case WM_MBUTTONDOWN:
+        kind = COREWEBVIEW2_MOUSE_EVENT_KIND_MIDDLE_BUTTON_DOWN;
+        break;
+      case WM_MBUTTONUP:
+        kind = COREWEBVIEW2_MOUSE_EVENT_KIND_MIDDLE_BUTTON_UP;
+        break;
+      default:
+        return;
+    }
+  }
+  const auto keys = static_cast<COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS>(
+      GET_KEYSTATE_WPARAM(wparam));
+  composition_controller_->SendMouseInput(kind, keys, mouse_data, point);
+}
+
 void GlobalLookupWindow::EnsureWebView() {
   CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
   auto options = Make<CoreWebView2EnvironmentOptions>();
@@ -947,6 +1005,27 @@ void GlobalLookupWindow::EnsureWebView() {
                               // WebView 的 visual 挂到 DComp 视觉树 → Commit 上桌面。
                               composition_controller_->put_RootVisualTarget(
                                   dcomp_visual_.get());
+                              // 光标形状：composition 无子窗自动管光标，靠 WebView2
+                              // 的 CursorChanged 通知 + WM_SETCURSOR 应用（hover 链接
+                              // /文本时光标正确）。
+                              composition_controller_->add_CursorChanged(
+                                  Callback<
+                                      ICoreWebView2CursorChangedEventHandler>(
+                                      [this](
+                                          ICoreWebView2CompositionController*
+                                              sender,
+                                          IUnknown*) -> HRESULT {
+                                        HCURSOR cursor = nullptr;
+                                        if (sender != nullptr &&
+                                            SUCCEEDED(
+                                                sender->get_Cursor(&cursor))) {
+                                          composition_cursor_ = cursor;
+                                          SetCursor(cursor);
+                                        }
+                                        return S_OK;
+                                      })
+                                      .Get(),
+                                  nullptr);
                               RECT rc;
                               GetClientRect(hwnd_, &rc);
                               controller_->put_Bounds(rc);
@@ -1652,6 +1731,46 @@ LRESULT GlobalLookupWindow::HandleMessage(UINT message, WPARAM wparam,
       }
       return 0;
     }
+    // 背景逐像素透明（composition）— 无子 HWND，客户区鼠标消息直达本窗，转发给
+    // composition controller（否则透明面板点不动/滚不动）。windowed 瞬态窗
+    // composition_active_=false，落 default→DefWindowProc（子窗自动收输入，行为不变）。
+    case WM_MOUSEMOVE:
+    case WM_LBUTTONDOWN:
+    case WM_LBUTTONUP:
+    case WM_LBUTTONDBLCLK:
+    case WM_RBUTTONDOWN:
+    case WM_RBUTTONUP:
+    case WM_MBUTTONDOWN:
+    case WM_MBUTTONUP:
+    case WM_MOUSEWHEEL:
+    case WM_MOUSEHWHEEL:
+      if (composition_active_) {
+        if (message == WM_MOUSEMOVE) {
+          // 追踪离开事件（hover-reveal / 悬停状态需要 mouseleave）。
+          TRACKMOUSEEVENT tme{sizeof(TRACKMOUSEEVENT), TME_LEAVE, hwnd_, 0};
+          TrackMouseEvent(&tme);
+        }
+        ForwardCompositionMouse(message, wparam, lparam);
+        return 0;
+      }
+      return DefWindowProc(hwnd_, message, wparam, lparam);
+    case WM_MOUSELEAVE:
+      if (composition_active_ && composition_controller_ != nullptr) {
+        POINT pt{0, 0};
+        composition_controller_->SendMouseInput(
+            COREWEBVIEW2_MOUSE_EVENT_KIND_LEAVE,
+            COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS_NONE, 0, pt);
+        return 0;
+      }
+      return DefWindowProc(hwnd_, message, wparam, lparam);
+    case WM_SETCURSOR:
+      // composition 无子窗托管光标：客户区内用 WebView2 请求的光标形状。
+      if (composition_active_ && LOWORD(lparam) == HTCLIENT &&
+          composition_cursor_ != nullptr) {
+        SetCursor(composition_cursor_);
+        return TRUE;
+      }
+      return DefWindowProc(hwnd_, message, wparam, lparam);
     default:
       return DefWindowProc(hwnd_, message, wparam, lparam);
   }

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -292,6 +292,11 @@ void GlobalLookupWindow::ForgetDeadWindow() {
   controller_ = nullptr;
   webview_ = nullptr;
   env_ = nullptr;
+  // 背景逐像素透明：DComp target/visual + composition controller 绑在这个已死的
+  // HWND 上，必须一并释放，下次重建从头再建（d3d/dcomp 设备无 HWND 绑定，保留复用）。
+  composition_controller_ = nullptr;
+  dcomp_target_ = nullptr;
+  dcomp_visual_ = nullptr;
   webview_ready_ = false;
   recovering_ = false;
   visible_ = false;
@@ -323,12 +328,12 @@ bool GlobalLookupWindow::ShowAt(int x, int y, int width, int height,
     // SW_SHOWNOACTIVATE，流式更新不抢焦点。
     // 面板任务栏图标 — taskbar_presence_（面板实例）用 APPWINDOW 换掉
     // TOOLWINDOW：任务栏出现独立按钮，点它即可把被压底的面板拉回前台。
+    // 背景逐像素透明 — composition 模式下 OverlayCreateExStyle 带
+    // WS_EX_NOREDIRECTIONBITMAP（透明像素经 DComp 上桌面）。
     hwnd_ = CreateWindowExW(
-        WS_EX_TOPMOST |
-            (taskbar_presence_ ? WS_EX_APPWINDOW : WS_EX_TOOLWINDOW) |
-            (activatable_ ? 0 : WS_EX_NOACTIVATE),
-        kClassName, window_title_.c_str(), WS_POPUP, off_x, 0, width, height,
-        owner, nullptr, GetModuleHandle(nullptr), this);
+        OverlayCreateExStyle(), kClassName, window_title_.c_str(), WS_POPUP,
+        off_x, 0, width, height, owner, nullptr, GetModuleHandle(nullptr),
+        this);
     if (hwnd_ == nullptr) {
       return false;
     }
@@ -364,12 +369,10 @@ void GlobalLookupWindow::PrewarmWebView(int width, int height, HWND owner) {
   const int off_x = OffscreenX();
   const int w = width > 0 ? width : 420;
   const int h = height > 0 ? height : 600;
+  // 背景逐像素透明 — composition 模式带 WS_EX_NOREDIRECTIONBITMAP（见 ShowAt）。
   hwnd_ = CreateWindowExW(
-      WS_EX_TOPMOST |
-          (taskbar_presence_ ? WS_EX_APPWINDOW : WS_EX_TOOLWINDOW) |
-          (activatable_ ? 0 : WS_EX_NOACTIVATE),
-      kClassName, window_title_.c_str(), WS_POPUP, off_x, 0, w, h, owner,
-      nullptr, GetModuleHandle(nullptr), this);
+      OverlayCreateExStyle(), kClassName, window_title_.c_str(), WS_POPUP, off_x,
+      0, w, h, owner, nullptr, GetModuleHandle(nullptr), this);
   if (hwnd_ == nullptr) {
     return;
   }
@@ -638,6 +641,12 @@ void GlobalLookupWindow::SetWindowAlpha(int percent) {
   if (hwnd_ == nullptr) {
     return;
   }
+  // 背景逐像素透明（composition）模式：透明由 DComp per-pixel 承担，整窗
+  // WS_EX_LAYERED + LWA_ALPHA 会与之冲突（把文字一起变淡、甚至令 NOREDIRECTIONBITMAP
+  // 窗不渲染）。此模式下整窗 alpha 是 no-op，透明度语义交给 CSS 卡背景（cardBgAlpha）。
+  if (composition_active_) {
+    return;
+  }
   if (percent < 30) percent = 30;
   if (percent > 100) percent = 100;
   const LONG_PTR ex = GetWindowLongPtrW(hwnd_, GWL_EXSTYLE);
@@ -752,6 +761,84 @@ void GlobalLookupWindow::ReportOverlayError(const std::string& message,
   }
 }
 
+// 背景逐像素透明 — 建 D3D11 + DirectComposition 设备（无需 HWND，可在建窗前探测
+// 能力）。硬件设备失败回退 WARP（远程桌面/无 GPU），仍失败则整条回退 windowed
+// （composition_active_=false），面板照常工作、只是不透明。幂等（已建则直接 true）。
+bool GlobalLookupWindow::InitCompositionDevice() {
+  if (dcomp_device_ != nullptr) {
+    return true;
+  }
+  const UINT flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+  D3D_FEATURE_LEVEL feature_level = D3D_FEATURE_LEVEL_11_0;
+  HRESULT hr = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr,
+                                 flags, nullptr, 0, D3D11_SDK_VERSION,
+                                 &d3d_device_, &feature_level, nullptr);
+  if (FAILED(hr) || d3d_device_ == nullptr) {
+    // 无硬件 GPU / 远程桌面：WARP 软件设备兜底。
+    hr = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_WARP, nullptr, flags,
+                           nullptr, 0, D3D11_SDK_VERSION, &d3d_device_,
+                           &feature_level, nullptr);
+  }
+  if (FAILED(hr) || d3d_device_ == nullptr) {
+    ReportOverlayError("composition: D3D11CreateDevice failed", hr);
+    return false;
+  }
+  wil::com_ptr<IDXGIDevice> dxgi_device;
+  hr = d3d_device_->QueryInterface(IID_PPV_ARGS(&dxgi_device));
+  if (FAILED(hr) || dxgi_device == nullptr) {
+    ReportOverlayError("composition: QI IDXGIDevice failed", hr);
+    d3d_device_ = nullptr;
+    return false;
+  }
+  hr = DCompositionCreateDevice(dxgi_device.get(),
+                                IID_PPV_ARGS(&dcomp_device_));
+  if (FAILED(hr) || dcomp_device_ == nullptr) {
+    ReportOverlayError("composition: DCompositionCreateDevice failed", hr);
+    d3d_device_ = nullptr;
+    dcomp_device_ = nullptr;
+    return false;
+  }
+  return true;
+}
+
+// 背景逐像素透明 — 为已创建的 hwnd_ 建 DComp target + 承载 WebView 的根 visual。
+// composition controller 的 put_RootVisualTarget 挂到这个 visual，Commit 后透明像素
+// 上桌面。幂等。失败返回 false（调用方回退 / 报错）。
+bool GlobalLookupWindow::EnsureCompositionTargetVisual() {
+  if (dcomp_device_ == nullptr || hwnd_ == nullptr) {
+    return false;
+  }
+  if (dcomp_target_ != nullptr && dcomp_visual_ != nullptr) {
+    return true;
+  }
+  HRESULT hr =
+      dcomp_device_->CreateTargetForHwnd(hwnd_, TRUE, &dcomp_target_);
+  if (FAILED(hr) || dcomp_target_ == nullptr) {
+    ReportOverlayError("composition: CreateTargetForHwnd failed", hr);
+    return false;
+  }
+  hr = dcomp_device_->CreateVisual(&dcomp_visual_);
+  if (FAILED(hr) || dcomp_visual_ == nullptr) {
+    ReportOverlayError("composition: CreateVisual failed", hr);
+    return false;
+  }
+  dcomp_target_->SetRoot(dcomp_visual_.get());
+  return true;
+}
+
+DWORD GlobalLookupWindow::OverlayCreateExStyle() {
+  // 背景逐像素透明：composition 请求下先探测 D3D11+DComp 设备能力（无需 HWND），
+  // 成功才带 WS_EX_NOREDIRECTIONBITMAP（无重定向表面，透明像素经 DComp 上桌面）。
+  // 探测失败回退 composition_active_=false（windowed），面板不透明但照常工作。
+  if (composition_mode_ && !composition_active_) {
+    composition_active_ = InitCompositionDevice();
+  }
+  return WS_EX_TOPMOST |
+         (taskbar_presence_ ? WS_EX_APPWINDOW : WS_EX_TOOLWINDOW) |
+         (activatable_ ? 0 : WS_EX_NOACTIVATE) |
+         (composition_active_ ? WS_EX_NOREDIRECTIONBITMAP : 0);
+}
+
 void GlobalLookupWindow::EnsureWebView() {
   CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
   auto options = Make<CoreWebView2EnvironmentOptions>();
@@ -797,6 +884,101 @@ void GlobalLookupWindow::EnsureWebView() {
               return env_hr;
             }
             env_ = env;
+            // 背景逐像素透明 — composition 分区：QI env3 + DComp target/visual +
+            // composition controller，透明像素经 DComp 上桌面（背景全透、文字实心）。
+            // 瞬态窗 composition_active_=false，走下面 windowed 原路（一字不改）。任一
+            // 步失败仅在 InitCompositionDevice 已成功后才可能（composition_active_=true、
+            // 窗口已带 NOREDIRECTIONBITMAP），落到 windowed 也渲染不出——极罕见，已记日志。
+            if (composition_active_ && EnsureCompositionTargetVisual()) {
+              wil::com_ptr<ICoreWebView2Environment3> env3;
+              if (SUCCEEDED(env_->QueryInterface(IID_PPV_ARGS(&env3))) &&
+                  env3 != nullptr) {
+                HRESULT cc_call_hr =
+                    env3->CreateCoreWebView2CompositionController(
+                        hwnd_,
+                        Callback<
+                            ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler>(
+                            [this](HRESULT cc_hr,
+                                   ICoreWebView2CompositionController* cc)
+                                -> HRESULT {
+                              if (FAILED(cc_hr) || cc == nullptr) {
+                                ReportOverlayError(
+                                    "composition controller create failed",
+                                    cc_hr);
+                                return S_OK;
+                              }
+                              composition_controller_ = cc;
+                              wil::com_ptr<ICoreWebView2Controller> base;
+                              if (FAILED(composition_controller_->QueryInterface(
+                                      IID_PPV_ARGS(&base))) ||
+                                  base == nullptr) {
+                                ReportOverlayError(
+                                    "composition: QI ICoreWebView2Controller "
+                                    "failed",
+                                    E_NOINTERFACE);
+                                return S_OK;
+                              }
+                              controller_ = base;
+                              controller_->get_CoreWebView2(&webview_);
+                              controller_->put_IsVisible(TRUE);
+                              // 透明背景色（A=0）：只有实心像素画，其余透到桌面。
+                              wil::com_ptr<ICoreWebView2Controller2> controller2;
+                              if (SUCCEEDED(controller_->QueryInterface(
+                                      IID_PPV_ARGS(&controller2)))) {
+                                COREWEBVIEW2_COLOR transparent = {0, 0, 0, 0};
+                                controller2->put_DefaultBackgroundColor(
+                                    transparent);
+                              }
+                              // BoundsMode=RAW_PIXELS + rasterization scale 按 DPI。
+                              UINT dpi = GetDpiForWindow(hwnd_);
+                              if (dpi == 0) {
+                                dpi = 96;
+                              }
+                              wil::com_ptr<ICoreWebView2Controller3> controller3;
+                              if (SUCCEEDED(controller_->QueryInterface(
+                                      IID_PPV_ARGS(&controller3)))) {
+                                controller3->put_BoundsMode(
+                                    COREWEBVIEW2_BOUNDS_MODE_USE_RAW_PIXELS);
+                                controller3->put_ShouldDetectMonitorScaleChanges(
+                                    FALSE);
+                                controller3->put_RasterizationScale(
+                                    static_cast<double>(dpi) / 96.0);
+                              }
+                              // WebView 的 visual 挂到 DComp 视觉树 → Commit 上桌面。
+                              composition_controller_->put_RootVisualTarget(
+                                  dcomp_visual_.get());
+                              RECT rc;
+                              GetClientRect(hwnd_, &rc);
+                              controller_->put_Bounds(rc);
+                              if (dcomp_device_ != nullptr) {
+                                dcomp_device_->Commit();
+                              }
+                              ConfigureWebView();
+                              wil::com_ptr<ICoreWebView2_3> wv3;
+                              if (webview_ &&
+                                  SUCCEEDED(webview_->QueryInterface(
+                                      IID_PPV_ARGS(&wv3))) &&
+                                  !popup_assets_dir_.empty()) {
+                                wv3->SetVirtualHostNameToFolderMapping(
+                                    L"hibiki.popup", popup_assets_dir_.c_str(),
+                                    COREWEBVIEW2_HOST_RESOURCE_ACCESS_KIND_ALLOW);
+                              }
+                              if (webview_) {
+                                webview_->Navigate(
+                                    L"https://hibiki.popup/"
+                                    L"global_lookup_host.html");
+                              }
+                              return S_OK;
+                            })
+                            .Get());
+                if (FAILED(cc_call_hr)) {
+                  ReportOverlayError(
+                      "CreateCoreWebView2CompositionController call failed",
+                      cc_call_hr);
+                }
+                return S_OK;  // composition 路径已接管，不再走 windowed。
+              }
+            }
             HRESULT ctrl_hr = env_->CreateCoreWebView2Controller(
                 hwnd_,
                 Callback<
@@ -1223,6 +1405,9 @@ void GlobalLookupWindow::RecoverDeadWebView(const std::string& replay_script) {
   controller_ = nullptr;
   webview_ = nullptr;
   env_ = nullptr;
+  // 背景逐像素透明：composition controller 也在死进程里，释放它让重建分支重造并
+  // 重新 put_RootVisualTarget。hwnd_ 仍活，dcomp target/visual 保留复用（幂等）。
+  composition_controller_ = nullptr;
   if (hwnd_ != nullptr) {
     EnsureWebView();
   }
@@ -1422,6 +1607,16 @@ LRESULT GlobalLookupWindow::HandleMessage(UINT message, WPARAM wparam,
         RECT rc;
         GetClientRect(hwnd_, &rc);
         controller_->put_Bounds(rc);
+      }
+      // 背景逐像素透明（composition）：put_Bounds 后必须 Commit 才把新尺寸的透明帧
+      // 推上桌面；且**不**设窗口 region——逐像素透明已让圆角/卡间隙靠 CSS 呈现，
+      // 一个不透明的窗口 region 会硬裁并吞掉透明区（游戏区）的点击。windowed 瞬态
+      // 窗保持原有 ApplyRoundedRegion（非 layered，圆角只能靠 region）。
+      if (composition_active_) {
+        if (dcomp_device_ != nullptr) {
+          dcomp_device_->Commit();
+        }
+        return 0;
       }
       // TODO-867 P2: round the actual window corners to match popup.css's hoshi
       // card radius. The window is opaque (no WS_EX_LAYERED — it conflicts with

--- a/hibiki/windows/runner/global_lookup_window.h
+++ b/hibiki/windows/runner/global_lookup_window.h
@@ -26,6 +26,12 @@
 #include <wil/com.h>
 #pragma warning(pop)
 
+// 剪切板面板背景逐像素透明（composition 模式）：DirectComposition 视觉树承载
+// WebView2 composition controller 的透明像素，配 WS_EX_NOREDIRECTIONBITMAP 真透到桌面。
+#include <d3d11.h>
+#include <dxgi.h>
+#include <dcomp.h>
+
 #include <array>
 #include <cstdint>
 #include <functional>
@@ -222,6 +228,15 @@ class GlobalLookupWindow {
   bool OwnsLiveWindow() const;
   void ForgetDeadWindow();
   void EnsureWebView();
+  // 背景逐像素透明（composition 模式）辅助：
+  // InitCompositionDevice — 建 D3D11 + DComp 设备（无需 HWND），可在建窗前探测能力；
+  //   失败即 composition_active_=false，回退 windowed（面板照常工作、只是不透明）。
+  // EnsureCompositionTargetVisual — 为 hwnd_ 建 DComp target + 承载 WebView 的 visual。
+  bool InitCompositionDevice();
+  bool EnsureCompositionTargetVisual();
+  // 建窗 ex-style（含 composition 能力探测）：composition_active_ 时带
+  // WS_EX_NOREDIRECTIONBITMAP。ShowAt / PrewarmWebView 共用，避免两处重复。
+  DWORD OverlayCreateExStyle();
   void RecoverDeadWebView(const std::string& replay_script);
   // TODO-1153 -- logs + reports an overlay WebView2 bring-up failure (never
   // swallows it) so the "app-external lookup shows no popup" cause is visible.
@@ -258,6 +273,11 @@ class GlobalLookupWindow {
   // 背景逐像素透明模式（仅面板实例）：composition controller + DirectComposition。
   // 默认 false=windowed（瞬态窗与历史行为一字不改）。见 SetCompositionMode。
   bool composition_mode_ = false;
+  // composition_mode_ 请求下 DComp 设备真的建起来了才为 true：任何 D3D11/DComp/
+  // composition controller 创建失败都回退 composition_active_=false（windowed），
+  // 面板永不因透明改造而黑屏/崩溃（graceful degrade，只是不透明）。窗口样式、
+  // controller 分支、WM_SIZE 都以 composition_active_（而非 _mode_）为准。
+  bool composition_active_ = false;
   std::wstring window_title_ = L"Hibiki Lookup";
   std::wstring user_data_leaf_ = L"GlobalLookupWebView2";
   std::wstring popup_assets_dir_;
@@ -271,6 +291,13 @@ class GlobalLookupWindow {
   wil::com_ptr<ICoreWebView2Environment> env_;
   wil::com_ptr<ICoreWebView2Controller> controller_;
   wil::com_ptr<ICoreWebView2> webview_;
+
+  // 背景逐像素透明（composition 模式）COM 对象。composition_active_ 时才创建。
+  wil::com_ptr<ID3D11Device> d3d_device_;
+  wil::com_ptr<IDCompositionDevice> dcomp_device_;
+  wil::com_ptr<IDCompositionTarget> dcomp_target_;
+  wil::com_ptr<IDCompositionVisual> dcomp_visual_;
+  wil::com_ptr<ICoreWebView2CompositionController> composition_controller_;
 
   MediaResolver media_resolver_;
   MessageCallback message_cb_;

--- a/hibiki/windows/runner/global_lookup_window.h
+++ b/hibiki/windows/runner/global_lookup_window.h
@@ -153,6 +153,13 @@ class GlobalLookupWindow {
   // 则用于 CreateWindowExW；窗口已存在时经 SetWindowTextW 即时生效。
   void SetWindowTitle(const std::wstring& title);
 
+  // 剪切板面板背景逐像素透明 — 仅面板实例开启：窗口用 WS_EX_NOREDIRECTIONBITMAP
+  // 建、WebView2 走 composition controller + DirectComposition 视觉树，透明像素
+  // 真透到桌面（背景全透 + 文字实心），取代整窗 LWA_ALPHA 的「文字一起变淡」。
+  // 瞬态查词覆盖窗保持默认 false（windowed，行为一字不改）。必须在首次
+  // ShowAt/PrewarmWebView（窗口 + WebView 创建）前设置。
+  void SetCompositionMode(bool composition) { composition_mode_ = composition; }
+
   // spec §6 semi-transparency gate — asks DWM for a Win11 acrylic backdrop
   // behind the window's transparent WebView2 pixels. Returns whether the OS
   // accepted it (Win10 / pre-22H2 -> false; the panel then stays opaque and
@@ -248,6 +255,9 @@ class GlobalLookupWindow {
   bool arm_dismiss_hooks_ = true;
   bool activatable_ = false;
   bool taskbar_presence_ = false;
+  // 背景逐像素透明模式（仅面板实例）：composition controller + DirectComposition。
+  // 默认 false=windowed（瞬态窗与历史行为一字不改）。见 SetCompositionMode。
+  bool composition_mode_ = false;
   std::wstring window_title_ = L"Hibiki Lookup";
   std::wstring user_data_leaf_ = L"GlobalLookupWebView2";
   std::wstring popup_assets_dir_;

--- a/hibiki/windows/runner/global_lookup_window.h
+++ b/hibiki/windows/runner/global_lookup_window.h
@@ -237,6 +237,10 @@ class GlobalLookupWindow {
   // 建窗 ex-style（含 composition 能力探测）：composition_active_ 时带
   // WS_EX_NOREDIRECTIONBITMAP。ShowAt / PrewarmWebView 共用，避免两处重复。
   DWORD OverlayCreateExStyle();
+  // 背景逐像素透明（composition）无子 HWND，鼠标消息直达本窗：把它们转发给
+  // composition controller（SendMouseInput），否则透明面板点不动/滚不动。windowed
+  // 瞬态窗的 WebView2 子窗自动收输入，不经此路径。
+  void ForwardCompositionMouse(UINT message, WPARAM wparam, LPARAM lparam);
   void RecoverDeadWebView(const std::string& replay_script);
   // TODO-1153 -- logs + reports an overlay WebView2 bring-up failure (never
   // swallows it) so the "app-external lookup shows no popup" cause is visible.
@@ -298,6 +302,9 @@ class GlobalLookupWindow {
   wil::com_ptr<IDCompositionTarget> dcomp_target_;
   wil::com_ptr<IDCompositionVisual> dcomp_visual_;
   wil::com_ptr<ICoreWebView2CompositionController> composition_controller_;
+  // composition 模式下 WebView2 请求的光标（add_CursorChanged 回调更新）；
+  // WM_SETCURSOR 据此 SetCursor，让 hover 链接/文本时光标形状正确。
+  HCURSOR composition_cursor_ = nullptr;
 
   MediaResolver media_resolver_;
   MessageCallback message_cb_;


### PR DESCRIPTION
接 PR#92（阶段一「关自动查词」已合 develop）。**本 PR 携带阶段二 + 阶段三**——PR#92 合并时只带了阶段一，透明/peek 这 6 个 commit 未进 develop，在此 PR。

## 阶段二：背景逐像素透明（原生 composition + DirectComposition）
把**仅面板实例**的 `GlobalLookupWindow` 从 windowed WebView2 改成 composition + DComp（瞬态查词窗保持 windowed 不动、隔离风险）：
- `composition_mode_` 旗标 + CMake 链 `dcomp/dxguid`。
- `WS_EX_NOREDIRECTIONBITMAP` 建窗 + D3D11/DComp device/target/visual + `CreateCoreWebView2CompositionController` + `put_RootVisualTarget` + `Commit`，透明像素真透到桌面。**DComp 失败优雅回退 windowed**（不透明但照常工作，永不黑屏/崩溃）。
- 输入转发：客户区鼠标/滚轮 → `SendMouseInput`；`add_CursorChanged` + `WM_SETCURSOR` 接管光标；`WM_MOUSELEAVE`。
- `WM_SIZE` 走 `Commit` 且不设窗口 region；composition 下 `SetWindowAlpha` no-op。
- 新 pref `clipboard_panel_transparent`（默认 false）→ 卡背景 `cardBgAlpha=0`（只剩文字浮在游戏上）。

## 阶段三：面板栏悬停显示（peek）
用户原话「把所有面板隐藏，鼠标放到状态栏就整体显性」：
- 新 pref `clipboard_panel_peek`（默认 false）+ 设置开关。
- `global_lookup_host.js` `applyPanelPeek`：面板栏平时收起（`panel-peek` 透明+上移）+ 窗口顶部触发区 `mouseenter`→淡入、`mouseleave`→收回。node harness 加 P-peek 用例。

## 验证
- `flutter analyze` 全 clean；`flutter test test/` 全绿（11231）；Windows debug 构建编译过（Task5/6/7）；`node` host + style harness PASS。
- ⚠️ **真机视觉验证待做**：开「剪切板查词」+去向面板 + 开「面板背景透明」/「面板栏悬停显示」开关，看浮窗压游戏上背景透/文字实/可点拖钉、面板栏平时收起移顶部淡入。

> 全程默认值=旧行为，老用户无感知。透明是 Windows composition 能力，非 Windows/无 GPU 自动回退不透明。分支落后 develop 若冲突交 integration owner。