### PR TITLE
fix(popup): 查词弹窗复制/搜索穿透同源 iframe 读选区 (BUG-792)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 774 条。点号进各自文件。
+> 共 775 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-792](bugs/BUG-792-popup-copy-search-selection.md) | ✅ | ✅ | 查词弹窗选中后复制/搜索无效 |
 | [BUG-791](bugs/BUG-791-popup-empty-reading-split.md) | ✅ | ✅ | 查词弹窗同词因空读音拆成两张卡 |
 | [BUG-790](bugs/BUG-790-video-collection-count-remote.md) | ✅ | ✅ | 视频合集行计数只数本地成员导致全云端合集显示0集 |
 | [BUG-789](bugs/BUG-789-reader-chrome-inset-stale-pagination-metrics.md) | ✅ | ✅ | 底栏 inset 后分页终点过期导致章尾不可读 |

--- a/docs/bugs/BUG-792-popup-copy-search-selection.md
+++ b/docs/bugs/BUG-792-popup-copy-search-selection.md
@@ -1,0 +1,10 @@
+## BUG-792 · 查词弹窗选中后复制/搜索无效
+
+- **报告**：2026-07-14（用户：）
+- **真实性**：✅ 真 bug。根因两层：
+  - **① 桌面 fork 未实现 `getSelectedText`**：`packages/flutter_inappwebview_windows/windows/in_app_webview/webview_channel_delegate.cpp:285` 的 method 分发里**没有 `getSelectedText` 分支**，落到默认 `result->NotImplemented()` → Dart 侧 `_controller.getSelectedText()` 返回 null。
+  - **② 选区在同源子 iframe 内**：查词弹窗把每张词条卡渲染成独立**同源** iframe（`hibiki/assets/popup/global_lookup_host.js:8`「Why iframes」），用户拖选的原生文本落在 CHILD iframe 的 `window.getSelection()` 里；即便 `getSelectedText` 可用，它也只读顶层文档，取不到 iframe 内选区。
+  - 两条右键菜单路径都靠它取选区：非 Windows 的 `menuItems` 查词项（`dictionary_popup_webview.dart:975`）+ Windows 的 `_showWindowsContextMenu` 复制/搜索（同文件旧 `final String text = (await _controller?.getSelectedText()) ?? ''`）。拿到空串 → `if (text.isEmpty) return` 早退 → 复制/搜索表现为无效。
+- **[x] ① 已修复** — 新增穿透同源 iframe 的选区读取：`_selectedTextAcrossFramesJs`（递归遍历 `iframe.contentWindow` 的 `window.getSelection()`，`JSON.stringify` 收口回传）+ `_selectedTextAcrossFrames()` helper，替换全部 3 处 `getSelectedText()` 调用（menuItems 查词项 + Windows 菜单复制/搜索）。用已实现的 `evaluateJavascript` 下发，桌面+移动一处修复通吃。文件 `hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart`。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/popup_selection_copy_search_iframe_guard_test.dart`：① 剥注释后弹窗源码不得再出现 `getSelectedText`；② 必须存在遍历 iframe 的选区 JS（含 `iframe`/`contentWindow`/`getSelection` 递归）。并更新既有守卫 `test/pages/dictionary_popup_webview_test.dart:629` 把旧的「复制走 getSelectedText」断言改为「走 _selectedTextAcrossFrames」。
+- **备注**：源码扫描守卫已挡回归；跨 iframe 真实选区行为需真机复测（Windows 桌面弹窗拖选→右键复制/搜索；Android 弹窗拖选→原生菜单查词）作为最终验收门。

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -371,6 +371,31 @@ class DictionaryPopupWebViewState
 })();
 ''';
 
+  // BUG-792：查词弹窗把每张词条卡渲染成独立**同源** iframe（global_lookup_host.js），
+  // 用户在词典正文里拖选的原生文本落在 CHILD iframe 的 `window.getSelection()` 里。桌面
+  // flutter_inappwebview_windows fork 根本没实现 `getSelectedText`（channel delegate 无
+  // 分支 → `NotImplemented()` → Dart 侧返回 null），移动端 `getSelectedText` 也只读顶层
+  // 文档 → 两端都取不到 iframe 内选区，右键「复制/搜索」拿到空串直接早退（表现为无效）。
+  // 改用已实现的 `evaluateJavascript` 递归遍历同源子 frame（无 sandbox，可跨 frame 读
+  // contentWindow），返回第一个非空选区文本。`JSON.stringify` 收口成确定的字符串回传，
+  // 与 [ReaderCaretScripts] 同惯例；跨源 frame 访问抛异常被 try/catch 吞成空串。
+  static const String _selectedTextAcrossFramesJs = r'''
+JSON.stringify((function(){
+  function readSel(win){
+    var out = '';
+    try { var s = win.getSelection && win.getSelection(); if (s) out = String(s); } catch (e) {}
+    if (out) return out;
+    var frames;
+    try { frames = win.document.querySelectorAll('iframe,frame'); } catch (e) { return ''; }
+    for (var i = 0; i < frames.length; i++) {
+      try { var r = readSel(frames[i].contentWindow); if (r) return r; } catch (e) {}
+    }
+    return '';
+  }
+  return readSel(window) || '';
+})())
+''';
+
   // TODO-854 M1a-2：下滑关闭弹窗的注入 JS 收口到 kPopupTopPullReleaseJs（单一真相，
   // 桌面 in-app 弹窗与 Windows 全局查词覆盖窗共用）。touch + pointer/mouse 两套识别，
   // 解决桌面 WebView2 不触发 touch 导致下滑关闭失效。
@@ -444,6 +469,25 @@ class DictionaryPopupWebViewState
         insetBottom: 0,
       ),
     );
+  }
+
+  /// BUG-792：读取当前拖选文本，穿透词条卡的同源 iframe（见 [_selectedTextAcrossFramesJs]）。
+  /// 替代桌面上未实现、且天然只读顶层文档的 `_controller.getSelectedText()`——右键
+  /// 「复制/搜索」都靠它拿选区。空选区（或 controller 未就绪）返回空串，调用方据此早退。
+  Future<String> _selectedTextAcrossFrames() async {
+    final Object? raw = await _controller?.evaluateJavascript(
+        source: _selectedTextAcrossFramesJs);
+    if (raw == null) return '';
+    final String trimmed = raw.toString().trim();
+    if (trimmed.isEmpty || trimmed == 'null') return '';
+    try {
+      final Object? decoded = jsonDecode(trimmed);
+      if (decoded is String) return decoded;
+    } catch (_) {
+      // 某些平台已返回裸字符串（非 JSON），直接用原值。
+      return raw.toString();
+    }
+    return '';
   }
 
   Future<String> caretEnter() async {
@@ -973,8 +1017,10 @@ class DictionaryPopupWebViewState
             id: 1,
             title: t.search,
             action: () async {
-              final text = await _controller?.getSelectedText();
-              if (text != null && text.isNotEmpty) {
+              // BUG-792：选区在同源子 iframe 里，`getSelectedText` 只读顶层文档取不到，
+              // 改用穿透 iframe 的 [_selectedTextAcrossFrames]（否则「查词」项无效）。
+              final String text = await _selectedTextAcrossFrames();
+              if (text.isNotEmpty) {
                 widget.onTextSelected?.call(text, Rect.zero);
               }
             },
@@ -1670,7 +1716,9 @@ class DictionaryPopupWebViewState
   /// 映射到 showMenu 所用 [Overlay] 的 [RenderBox] 坐标系（`localToGlobal(..., ancestor:
   /// overlayObject)`），界面大小（appUiScale）的 FittedBox 缩放残差被 ancestor 变换自动
   /// 吸收，菜单对准鼠标。菜单项：「查词」（平移自原 WebView2 自定义项）+「复制」（原是
-  /// WebView2 原生项，禁原生后用 BUG-402 范式 `getSelectedText` + [Clipboard.setData] 自补）。
+  /// WebView2 原生项，禁原生后自补 [Clipboard.setData]）。BUG-792：选区读取从早年的
+  /// `getSelectedText`（桌面 fork 未实现 + 只读顶层文档）改为穿透同源 iframe 的
+  /// [_selectedTextAcrossFrames]，否则复制/搜索拿到空串永远无效。
   Future<void> _showWindowsContextMenu(
       BuildContext context, Offset globalPosition) async {
     final RenderObject? overlayObject =
@@ -1701,7 +1749,9 @@ class DictionaryPopupWebViewState
       ],
     );
     if (action == null) return;
-    final String text = (await _controller?.getSelectedText()) ?? '';
+    // BUG-792：桌面 fork 未实现 getSelectedText 且选区在同源子 iframe 内，改用穿透 iframe
+    // 的 [_selectedTextAcrossFrames]，否则复制/搜索永远拿到空串直接早退（表现为无效）。
+    final String text = await _selectedTextAcrossFrames();
     if (text.isEmpty) return;
     switch (action) {
       case _PopupContextMenuAction.search:

--- a/hibiki/test/pages/dictionary_popup_webview_test.dart
+++ b/hibiki/test/pages/dictionary_popup_webview_test.dart
@@ -637,9 +637,11 @@ void main() {
       expect(body.contains('_PopupContextMenuAction.copy'), isTrue,
           reason: '「复制」必须自补（原是 WebView2 原生项，禁原生后丢失）');
       expect(body.contains('t.copy'), isTrue);
-      // 复制走 BUG-402 范式：getSelectedText + Clipboard.setData。
-      expect(body.contains('_controller?.getSelectedText()'), isTrue,
-          reason: '复制取选区文本（BUG-402：桌面 WebView2 原生复制键转发受限）');
+      // 复制/搜索取选区文本 + Clipboard.setData（BUG-402）。BUG-792：选区读取从早年的
+      // getSelectedText（桌面 fork 未实现 + 只读顶层文档取不到词条卡 iframe 内选区）改为
+      // 穿透同源 iframe 的 _selectedTextAcrossFrames，否则复制/搜索永远拿空串无效。
+      expect(body.contains('_selectedTextAcrossFrames()'), isTrue,
+          reason: '复制/搜索经穿透 iframe 的 _selectedTextAcrossFrames 取选区（BUG-792）');
       expect(
           body.contains('Clipboard.setData(ClipboardData(text: text))'), isTrue,
           reason: '把选区文本写系统剪贴板（BUG-402 范式）');

--- a/hibiki/test/pages/popup_selection_copy_search_iframe_guard_test.dart
+++ b/hibiki/test/pages/popup_selection_copy_search_iframe_guard_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-792 守卫：查词弹窗里选中词典正文后，右键「复制/搜索」曾完全无效。两层根因：
+///
+///   1. 弹窗把每张词条卡渲染成独立**同源** iframe（global_lookup_host.js），用户拖选的
+///      原生文本落在 CHILD iframe 的 `window.getSelection()` 里，顶层文档选区永远是空。
+///   2. 桌面 flutter_inappwebview_windows fork **根本没实现 `getSelectedText`**
+///      （webview_channel_delegate.cpp 无该 method 分支 → `NotImplemented()` → Dart 侧
+///      返回 null）；移动端 `getSelectedText` 也只读顶层文档。
+///
+///   两条 contextMenu 路径（非 Windows 的 `menuItems` 查词项 + Windows 的
+///   `_showWindowsContextMenu` 复制/搜索）都靠 `getSelectedText()` 拿选区 → 空串 → 早退 →
+///   无效。修复改用穿透同源 iframe 的 `evaluateJavascript`（[_selectedTextAcrossFrames]）。
+///
+///   本守卫锁死：① 弹窗源码不得再用 `getSelectedText`（否则回退成 Windows 恒空 + iframe
+///   盲）；② 必须存在遍历 iframe 的选区读取 JS（含 `iframe` 与 `contentWindow` 递归）。
+void main() {
+  final File file = File(
+    'lib/src/pages/implementations/dictionary_popup_webview.dart',
+  );
+
+  /// 剥掉纯注释行（trim 后以 `//` 开头）——本守卫检查的是**代码**是否调用失效 API，
+  /// 注释里为解释根因会提到 `getSelectedText`，不能让它触发误判。
+  String stripCommentLines(String source) {
+    return source
+        .split('\n')
+        .where((String line) => !line.trimLeft().startsWith('//'))
+        .join('\n');
+  }
+
+  test('popup copy/search must not read selection via getSelectedText', () {
+    expect(file.existsSync(), isTrue,
+        reason: 'popup webview source not found at ${file.path}');
+    final String code = stripCommentLines(file.readAsStringSync());
+
+    // getSelectedText 在桌面 fork 未实现（恒 null）且天然只读顶层文档，取不到 iframe 内
+    // 选区。弹窗任何选区读取都不许再走它，否则复制/搜索回归无效。
+    expect(
+      code.contains('getSelectedText'),
+      isFalse,
+      reason: '弹窗不得用 getSelectedText 读选区：桌面 fork 未实现（NotImplemented→null），'
+          '且只读顶层文档取不到子 iframe 选区。改用 _selectedTextAcrossFrames（BUG-792）。',
+    );
+  });
+
+  test('popup exposes an iframe-piercing selection reader (BUG-792)', () {
+    final String source = file.readAsStringSync();
+
+    // 穿透 iframe 的选区读取 helper 与其 JS 必须存在。
+    expect(
+      source.contains('_selectedTextAcrossFrames'),
+      isTrue,
+      reason: '缺少穿透 iframe 的选区读取 helper _selectedTextAcrossFrames',
+    );
+    expect(
+      source.contains('_selectedTextAcrossFramesJs'),
+      isTrue,
+      reason: '缺少穿透 iframe 的选区读取 JS 常量 _selectedTextAcrossFramesJs',
+    );
+
+    // JS 必须真正递归遍历子 frame（读 contentWindow / 查 iframe），否则只读顶层文档
+    // 仍取不到词条卡 iframe 内的选区。
+    final int jsStart = source.indexOf('_selectedTextAcrossFramesJs');
+    expect(jsStart, isNonNegative);
+    final int jsEnd =
+        source.indexOf("'''", source.indexOf("r'''", jsStart) + 4);
+    expect(jsEnd, isNonNegative, reason: 'selection JS 常量未正常闭合');
+    final String js = source.substring(jsStart, jsEnd);
+    expect(js.contains('iframe'), isTrue, reason: '选区 JS 必须查询 iframe 子 frame');
+    expect(js.contains('contentWindow'), isTrue,
+        reason: '选区 JS 必须递归读 iframe.contentWindow 的选区');
+    expect(js.contains('getSelection'), isTrue,
+        reason: '选区 JS 必须读 window.getSelection()');
+  });
+}


### PR DESCRIPTION
## 现象
查词弹窗里选中词典正文后，右键点「复制」或「搜索」完全无效。

## 根因（两层）
1. **桌面 fork 未实现 `getSelectedText`**：`flutter_inappwebview_windows` 的 `webview_channel_delegate.cpp` method 分发无 `getSelectedText` 分支 → 默认 `NotImplemented()` → Dart 侧返回 null。
2. **选区在同源子 iframe 内**：弹窗把每张词条卡渲染成独立同源 iframe（`global_lookup_host.js`），用户拖选的原生文本落在 CHILD iframe 的 `window.getSelection()` 里；`getSelectedText` 即便可用也只读顶层文档，取不到 iframe 内选区。

两条右键菜单路径（非 Windows `menuItems` 查词项 + Windows `_showWindowsContextMenu` 复制/搜索）都靠它取选区 → 空串 → `text.isEmpty` 早退 → 无效。

## 修复
新增 `_selectedTextAcrossFramesJs`（递归遍历同源 `iframe.contentWindow` 的 `window.getSelection()`，`JSON.stringify` 收口）+ `_selectedTextAcrossFrames()` helper，用已实现的 `evaluateJavascript` 下发，替换全部 3 处 `getSelectedText()` 调用。桌面+移动一处修复通吃。

## 测试
- 新增 `popup_selection_copy_search_iframe_guard_test.dart`：源码不得再用 `getSelectedText`（剥注释后扫描）+ 必须存在遍历 iframe 的选区 JS。
- 更新既有 `dictionary_popup_webview_test.dart` 守卫：复制断言从 `getSelectedText` 改为 `_selectedTextAcrossFrames`。
- `flutter analyze` 干净；相关弹窗测试全绿（16/16）。

## 验收门
源码守卫已挡回归；跨 iframe 真实选区行为需真机复测（Windows 桌面弹窗拖选→右键复制/搜索；Android 弹窗拖选→原生菜单查词）。

详见 `docs/bugs/BUG-792-popup-copy-search-selection.md`。