### PR TITLE
fix(video): 进度条拖动/点击到无字幕段旧字幕不消失 (BUG-796 follow-up)

### DIFF
--- a/docs/bugs/BUG-796-video-seek-gap-subtitle-linger.md
+++ b/docs/bugs/BUG-796-video-seek-gap-subtitle-linger.md
@@ -17,4 +17,16 @@
   - **播放态在途保持目标、落地放行**：在途拍旧 position 保持 gap 不回旧句；到达目标落定后放行、自然播放进入下一句正常跟随（不钉死）。
   - **暂停态跳进某句**：立即显示目的地句、旧 position 不显示旧句（权威同步正确性）。
   - `flutter test test/media/video/ test/media/audiobook/` 全绿（2268 passed，2 skip），既有 TODO-565 skipToCue / BUG-074 gap 用例未回归。`flutter analyze` No issues。
-- **备注**：测试宿主无 libmpv（`Player`/`load` 构造即抛），故走 `debugUpdateCueForPosition` + `debugSetIsPlayingForTesting` 纯逻辑单测（与既有 video controller 测试范式一致）。真机复测**待用户**：本地视频**暂停**中按 ±10 秒键跳到无字幕段 → 旧字幕立即消失、跳走后那段静音期无字幕；跳进某句立即显示该句；播放态 ±秒跳转后字幕正常跟随不钉死。进度条**拖动**走 media_kit 内部 seek（绕过 `seekMs`），本修复不覆盖该路径的暂停态 lag（另属既有行为，非本次报告场景）。
+- **备注**：测试宿主无 libmpv（`Player`/`load` 构造即抛），故走 `debugUpdateCueForPosition` + `debugSetIsPlayingForTesting` 纯逻辑单测（与既有 video controller 测试范式一致）。真机复测**待用户**：本地视频**暂停**中按 ±10 秒键跳到无字幕段 → 旧字幕立即消失、跳走后那段静音期无字幕；跳进某句立即显示该句；播放态 ±秒跳转后字幕正常跟随不钉死。~~进度条**拖动**走 media_kit 内部 seek（绕过 `seekMs`），本修复不覆盖该路径~~ → 见下方 follow-up，进度条路径已补齐。
+
+### Follow-up（2026-07-14，用户：「进度条拖动走 media_kit 的问题」）：进度条拖动/点击同病已补齐
+- **同根因不同入口**：进度条（seek bar）在 vendored fork `media_kit_video` 内部直接 `controller(context).player.seek(...)`，绕过 `VideoPlayerController.seekMs`，故 ①无按目标位置权威同步字幕 ②无在途抑制——暂停态拖到无字幕段旧字幕同样不消失（与 ±秒键同 lag）。host 侧无法从任何既有回调拿到拖动**落点位置**（fork 只透出无参 `onSeekStart`）。
+- **[x] 已修复**：
+  - **fork 补丁**（`third_party/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart` + `material.dart`）：两个 theme data 类新增 `void Function(Duration)? onSeekEnd`（构造 + copyWith）；各 seek bar 内部 `onSeekEnd` 由 `VoidCallback?` **retype** 成 `void Function(Duration)?`，在 `onPointerUp` 提交点传落点 `duration * slider`；实例化处合并 `_theme(context).onSeekEnd?.call(target)`。无回调注入时行为与 pub.dev 一致。见 `third_party/media_kit_video/PATCHES.md`（BUG-796 follow-up 段）。
+  - **控制器**（`video_player_controller.dart`）新增 `notifyExternalSeek(int targetMs)`：`_clearSeekTargetSnap()` → `_beginPlainSeekInFlight(target)` → `_syncCueForPosition(target, persistPosition:false)` 权威同步，**不重复 `player.seek`**（进度条内部已 seek）；随后 tick 复用同一 `_reconcileSeekInFlightPosition` 抑制滞后旧 position。
+  - **host 接线**（`controls_theme.part.dart`）：桌面 + 移动两个 theme 均 `onSeekEnd: (Duration target) => controller.notifyExternalSeek(target.inMilliseconds)`。只在 commit（pointer-up/tap）通知，拖动中间的连续 seek 不通知。
+- **[x] 已加测试**：
+  - `video_player_controller_test.dart` 新增 group「notifyExternalSeek（进度条落点）」2 例：暂停态拖到 gap 立即消失且旧 position 不拉回；拖进某句立即显示、落地后放行不钉死。
+  - `media_kit_video_seekbar_guard_test.dart` 新增源码守卫 group「BUG-796 follow-up」：两 fork 文件的 `onSeekEnd(Duration)` 字段 / copyWith / `onSeekEnd?.call(duration * slider)` / `_theme(context).onSeekEnd?.call(target)`，及 host 两个 theme 的 `onSeekEnd -> notifyExternalSeek` 接线。
+  - `flutter analyze lib/` No issues；`flutter test` 相关目录全绿。
+- **未覆盖**：视频区**横滑 seek 手势**（mobile，`material.dart` 另一处 `player.seek(result)`，TODO-916）同样绕过 `seekMs`，非本次「进度条」报告范围，暂留。真机复测**待用户**：暂停中拖进度条到无字幕段 → 旧字幕立即消失。

--- a/hibiki/lib/src/media/video/video_player_controller.dart
+++ b/hibiki/lib/src/media/video/video_player_controller.dart
@@ -2062,11 +2062,27 @@ class VideoPlayerController extends ChangeNotifier
   /// 公开清除入口（TODO-565 复核退回的必修项）：供**绕过 [seekMs]** 的 seek 路径手动
   /// 作废「主动跳转目标」快照。唯一调用方是页面层 media_kit 进度条（seek bar）——它在
   /// media_kit / vendored fork 内部直接调 `player.seek`，既不经本类 [seekMs]、也不向页面
-  /// 层暴露 onSeek 回调（fork 的 onSeekStart/End 写死给控制条隐藏计时、不透出 theme），
-  /// 故 [seekMs] 的统一清除点覆盖不到它。页面层在进度条交互的可观测点调本方法补清，避免
-  /// 「[skipToCue] 宽限窗口内拖进度条到更早句被误 snap 回旧目标」。
+  /// 层暴露 seek 目标（fork 的 onSeekStart 只透出「开始拖动」信号、无目标位置），故
+  /// [seekMs] 的统一清除点覆盖不到它。页面层在**开始拖动**（fork onSeekStart）时调本方法补清，
+  /// 避免「[skipToCue] 宽限窗口内拖进度条到更早句被误 snap 回旧目标」；拖动**落点**的字幕在途
+  /// 保护由 [notifyExternalSeek] 承载（见其注释）。
   void clearSeekTargetSnap() {
     _clearSeekTargetSnap();
+  }
+
+  /// 外部 seek（media_kit 进度条拖动 / 点击，绕过 [seekMs] 直接 `player.seek`）**落点**通知：
+  /// 页面在 fork 的 `onSeekEnd(target)` 回调里调本方法，补上与 [seekMs] 同款「普通 seek 在途
+  /// 保护」——按 [targetMs] 权威同步一次字幕（gap 立即消失）+ 抑制随后 tick 的滞后旧 position
+  /// （暂停无限保持 / 播放有界宽限），**但不重复 `player.seek`**（进度条内部已 seek）。
+  ///
+  /// 修「进度条拖到无字幕段后旧字幕不消失」（尤其暂停重听时）：进度条走 media_kit 内部 seek，
+  /// [seekMs] 的权威同步 + 在途抑制覆盖不到它，旧字幕会被滞后旧 position 逐拍确认（同 BUG-796
+  /// ±秒键根因）。本方法把同一保护补到进度条落点。
+  void notifyExternalSeek(int targetMs) {
+    final int clampedMs = targetMs.clamp(0, 1 << 30);
+    _clearSeekTargetSnap();
+    _beginPlainSeekInFlight(clampedMs);
+    _syncCueForPosition(clampedMs, persistPosition: false);
   }
 
   /// 主动跳转目标 snap 的纯决策（TODO-565，越界判据 BUG-378 收紧到 endMs）。所有几何在

--- a/hibiki/lib/src/pages/implementations/video_hibiki/controls_theme.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/controls_theme.part.dart
@@ -48,6 +48,11 @@ extension _VideoControlsTheme on _VideoHibikiPageState {
       // 的在途 seek 宽限窗口内拖进度条到更早句，会被误 snap 回旧目标句。fork 的 seek
       // bar 把内部 onSeekStart 与本回调合并调用（third_party/media_kit_video）。
       onSeekStart: () => controller.clearSeekTargetSnap(),
+      // BUG-796 后续：进度条拖动/点击落点经 media_kit 内部 player.seek 绕过 controller.seekMs
+      // 的「权威同步 + 在途抑制」——暂停态拖到无字幕段旧字幕不消失（同 ±秒键根因）。fork 在
+      // onSeekEnd 透出落点 target，页面补调 notifyExternalSeek 应用同款保护（不重复 seek）。
+      onSeekEnd: (Duration target) =>
+          controller.notifyExternalSeek(target.inMilliseconds),
       // TODO-669：进度条 hover 缩略图预览。seek bar hover 时 fork 把 hover 比例
       // （轨道内宽权威值）回调给 [_onSeekBarHover]，桌面转发到取帧调度器、移动端不接
       // （触屏无 hover，故仅桌面 theme 接线）。null 时 fork 零行为变化。
@@ -152,6 +157,10 @@ extension _VideoControlsTheme on _VideoHibikiPageState {
       // 的在途 seek 宽限窗口内拖进度条到更早句，会被误 snap 回旧目标句。fork 的 seek
       // bar 把内部 onSeekStart 与本回调合并调用（third_party/media_kit_video）。
       onSeekStart: () => controller.clearSeekTargetSnap(),
+      // BUG-796 后续（同桌面 theme）：进度条落点补调 notifyExternalSeek，暂停态拖到无字幕段
+      // 旧字幕立即消失、不被滞后旧 position 拉回；不重复 seek（进度条内部已 seek）。
+      onSeekEnd: (Duration target) =>
+          controller.notifyExternalSeek(target.inMilliseconds),
       // TODO-057: 启用 media_kit 移动控制条内建的「左半区竖滑调亮度 / 右半区竖滑
       // 调音量」手势，指示器由 Hibiki 的左右百分比 HUD 接管。仅移动端有此控制条；桌面走
       // [_desktopControlsTheme]（无此手势，屏幕亮度本就不可控，诚实降级）。横滑 seek

--- a/hibiki/test/media/video/video_player_controller_test.dart
+++ b/hibiki/test/media/video/video_player_controller_test.dart
@@ -1898,4 +1898,57 @@ void main() {
       expect(c.currentCue!.text, 'line1');
     });
   });
+
+  // BUG-796 后续：进度条拖动/点击落点经 media_kit 内部 player.seek 绕过 seekMs，由 fork 的
+  // onSeekEnd(target) 回调把落点透出给页面，页面调 notifyExternalSeek 应用与普通 seek 同款
+  // 「按目标位置权威同步字幕 + 抑制滞后旧 position」（但不重复 seek）。修「进度条拖到无字幕段
+  // 后旧字幕不消失」（尤其暂停）。
+  group('notifyExternalSeek（进度条落点）：拖到 gap 旧字幕立即消失、不被滞后旧 position 拉回', () {
+    test('暂停态进度条拖到 gap：字幕立即消失且多拍旧 position 不把它拉回', () {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues([_cue(0, 1000, 2000), _cue(1, 5000, 6000)]);
+
+      c.debugSetIsPlayingForTesting(false);
+      c.debugUpdateCueForPosition(1500); // 停在 cue0
+      expect(c.currentCue!.text, 'line0');
+
+      // 进度条落点在 gap（3000）：notifyExternalSeek 权威同步 → 字幕立即消失（不重复 seek）。
+      c.notifyExternalSeek(3000);
+      expect(c.currentCue, isNull, reason: '进度条拖到 gap 后字幕应立即消失');
+      expect(c.currentCueIndex, -1);
+      expect(c.activeCues, isEmpty);
+
+      // 暂停态 media_kit 仍逐拍吐旧 position 1500：在途保护把它替成目标 3000（gap），不回旧句。
+      for (var i = 0; i < 5; i++) {
+        c.debugUpdateCueForPosition(1500);
+        expect(c.currentCue, isNull, reason: '暂停在途：旧 position 不得把旧字幕拉回');
+        expect(c.activeCues, isEmpty);
+      }
+    });
+
+    test('进度条拖进某句：立即显示目的地句，落地后放行真实位置', () {
+      final c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues([_cue(0, 1000, 2000), _cue(1, 5000, 6000)]);
+      c.debugSetIsPlayingForTesting(true);
+
+      c.debugUpdateCueForPosition(1500); // cue0
+      expect(c.currentCue!.text, 'line0');
+
+      c.notifyExternalSeek(5500); // 拖进 cue1
+      expect(c.currentCueIndex, 1, reason: '进度条落点在 cue1，应立即显示 line1');
+      expect(c.currentCue!.text, 'line1');
+
+      // 播放在途仍读旧 1500 → 宽限保持目标 cue1，不回 cue0。
+      c.debugUpdateCueForPosition(1500);
+      expect(c.currentCueIndex, 1);
+
+      // 真实位置落定到 5500 → 放行；自然播放越过 cue1 进 gap 正常清空（不钉死）。
+      c.debugUpdateCueForPosition(5500);
+      expect(c.currentCueIndex, 1);
+      c.debugUpdateCueForPosition(6500);
+      expect(c.currentCue, isNull, reason: '落地后不得把字幕钉在跳转目标上');
+    });
+  });
 }

--- a/hibiki/test/third_party/media_kit_video_seekbar_guard_test.dart
+++ b/hibiki/test/third_party/media_kit_video_seekbar_guard_test.dart
@@ -249,4 +249,79 @@ void main() {
       );
     });
   });
+
+  // BUG-796 后续：进度条 seek 落点在途保护补丁（onSeekEnd(target)）必须在 re-vendor 后存活。
+  // 缺任一环，进度条拖到无字幕段（尤其暂停）旧字幕不消失的 bug 复发。
+  group(
+      'BUG-796 follow-up: seek-bar onSeekEnd(target) patch survives re-vendor',
+      () {
+    for (final String path in <String>[controlsPath, mobileControlsPath]) {
+      test('$path theme data class exposes onSeekEnd(Duration) field', () {
+        final String source = File(path).readAsStringSync();
+        expect(
+          source.contains(RegExp(r'void Function\(Duration\)\?\s+onSeekEnd')),
+          isTrue,
+          reason: 'the theme data class must expose a '
+              'void Function(Duration)? onSeekEnd field (BUG-796 follow-up); '
+              'without it the host cannot learn the progress-bar seek target.',
+        );
+      });
+
+      test('$path copyWith carries onSeekEnd', () {
+        final String source = File(path).readAsStringSync();
+        expect(
+          source
+              .contains(RegExp(r'onSeekEnd:\s*onSeekEnd \?\? this\.onSeekEnd')),
+          isTrue,
+          reason: 'copyWith must propagate onSeekEnd (BUG-796 follow-up).',
+        );
+      });
+
+      test('$path seek bar forwards the committed target to onSeekEnd', () {
+        final String source = File(path).readAsStringSync();
+        // The seek-commit point passes the target Duration (duration * slider).
+        expect(
+          source.contains(
+              RegExp(r'widget\.onSeekEnd\?\.call\(duration \* slider\)')),
+          isTrue,
+          reason: 'the seek bar onPointerUp must call '
+              'onSeekEnd(duration * slider) so the host gets the destination '
+              '(BUG-796 follow-up).',
+        );
+        // The widget instantiation forwards the theme callback with the target.
+        expect(
+          source.contains(
+              RegExp(r'_theme\(context\)\s*\.onSeekEnd\s*\?\.call\(target\)')),
+          isTrue,
+          reason: 'the seek bar must be constructed forwarding '
+              '_theme(context).onSeekEnd(target) (BUG-796 follow-up), or the '
+              "host's callback never fires.",
+        );
+      });
+    }
+
+    test('host wires onSeekEnd -> notifyExternalSeek in BOTH control themes',
+        () {
+      final String themeSrc = File(
+        'lib/src/pages/implementations/video_hibiki/controls_theme.part.dart',
+      ).readAsStringSync();
+      final int desktopStart = themeSrc.indexOf('_desktopControlsTheme(');
+      final int mobileStart = themeSrc.indexOf('_mobileControlsTheme(');
+      expect(desktopStart, isNonNegative);
+      expect(mobileStart, isNonNegative);
+      final String desktopBody = themeSrc.substring(desktopStart, mobileStart);
+      final String mobileBody = themeSrc.substring(mobileStart);
+      final RegExp wiring = RegExp(
+        r'onSeekEnd:\s*\(Duration target\)\s*=>\s*'
+        r'controller\.notifyExternalSeek\(target\.inMilliseconds\)',
+      );
+      expect(wiring.hasMatch(desktopBody), isTrue,
+          reason: 'desktop controls theme must wire onSeekEnd to '
+              'notifyExternalSeek (BUG-796 follow-up).');
+      expect(wiring.hasMatch(mobileBody), isTrue,
+          reason: 'mobile controls theme must wire onSeekEnd to '
+              'notifyExternalSeek (BUG-796 follow-up) — progress-bar drag '
+              'affects touch too.');
+    });
+  });
 }

--- a/third_party/media_kit_video/PATCHES.md
+++ b/third_party/media_kit_video/PATCHES.md
@@ -151,6 +151,42 @@ snapshot just like every other seek entry point.
 
 Source-guard test: `hibiki/test/third_party/media_kit_video_seekbar_guard_test.dart`.
 
+## BUG-796 follow-up: surface the committed seek target on drag/tap (`onSeekEnd(Duration)`)
+
+`lib/media_kit_video_controls/src/controls/material_desktop.dart` and
+`material.dart`, both theme data classes and the seek-bar States.
+
+Every Hibiki-initiated seek funnels through `VideoPlayerController.seekMs`, which
+(BUG-796) authoritatively re-syncs the bottom subtitle to the destination and
+suppresses the *lagging* post-seek `player.state.position` (media_kit doesn't
+update position synchronously with `seek`, and while **paused** it stays at the
+old position for a long time — the 125ms cue tick then keeps re-affirming the
+*old* subtitle, so seeking to a silent gap leaves the previous subtitle stuck on
+screen). The progress (seek) bar drives `controller(context).player.seek(...)`
+directly inside media_kit and bypasses `seekMs`, so it never got that protection.
+
+Upstream's seek bar's internal `onSeekEnd` is a `VoidCallback` wired only to the
+controls' auto-hide timer, and carries no target. The patch:
+
+- adds an optional `final void Function(Duration)? onSeekEnd;` to both theme data
+  classes (wired through their constructors and `copyWith`);
+- **retypes** each seek bar's internal `onSeekEnd` from `VoidCallback?` to
+  `void Function(Duration)?` and passes the committed target `duration * slider`
+  at the `onPointerUp` seek-commit;
+- merges `_theme(context).onSeekEnd?.call(target)` into that seek bar's internal
+  `onSeekEnd` callback (alongside the existing auto-hide-timer logic).
+
+When no callback is injected the behaviour is identical to pub.dev. Hibiki injects
+`(Duration target) => controller.notifyExternalSeek(target.inMilliseconds)` through
+**both** control themes (`_desktopControlsTheme` / `_mobileControlsTheme` in
+`video_hibiki_page.dart`). `notifyExternalSeek` applies the same in-flight
+protection as `seekMs` (authoritative cue re-sync + suppress the lagging position)
+**without** re-issuing `player.seek` (the bar already sought). Only the commit
+(pointer-up / tap) notifies; intermediate drag-move seeks do not.
+
+Source-guard test: `hibiki/test/third_party/media_kit_video_seekbar_guard_test.dart`
+(group `BUG-796 follow-up: seek-bar onSeekEnd(target) patch survives re-vendor`).
+
 ## BUG-374: play/pause on `onTap` (arena-respecting), not `onTapDown`
 
 `lib/media_kit_video_controls/src/controls/material_desktop.dart`,

--- a/third_party/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/third_party/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -326,6 +326,16 @@ class MaterialVideoControlsThemeData {
   /// pub.dev. See third_party/media_kit_video/PATCHES.md.
   final void Function()? onSeekStart;
 
+  /// Hibiki patch (BUG-796 follow-up): fires when the user **commits** a seek-bar
+  /// seek (drag release / tap), with the target [Duration]. The seek bar drives
+  /// `player.seek` directly inside media_kit, bypassing the host's
+  /// `VideoPlayerController.seekMs` in-flight protection; Hibiki uses this to
+  /// re-sync the subtitle to the destination + suppress the lagging post-seek
+  /// position (else seeking to a gap, esp. while paused, leaves the previous
+  /// subtitle on screen). Null (upstream default) = no callback, behaviour
+  /// identical to pub.dev. See third_party/media_kit_video/PATCHES.md.
+  final void Function(Duration)? onSeekEnd;
+
   /// {@macro material_video_controls_theme_data}
   const MaterialVideoControlsThemeData({
     this.displaySeekBar = true,
@@ -393,6 +403,7 @@ class MaterialVideoControlsThemeData {
     this.visibilityNotifier,
     this.restartHideTimerSignal,
     this.onSeekStart,
+    this.onSeekEnd,
   });
 
   /// Creates a copy of this [MaterialVideoControlsThemeData] with the given fields replaced by the non-null parameter values.
@@ -449,6 +460,7 @@ class MaterialVideoControlsThemeData {
     ValueNotifier<bool>? visibilityNotifier,
     Listenable? restartHideTimerSignal,
     void Function()? onSeekStart,
+    void Function(Duration)? onSeekEnd,
   }) {
     return MaterialVideoControlsThemeData(
       displaySeekBar: displaySeekBar ?? this.displaySeekBar,
@@ -527,6 +539,7 @@ class MaterialVideoControlsThemeData {
       restartHideTimerSignal:
           restartHideTimerSignal ?? this.restartHideTimerSignal,
       onSeekStart: onSeekStart ?? this.onSeekStart,
+      onSeekEnd: onSeekEnd ?? this.onSeekEnd,
     );
   }
 }
@@ -1188,7 +1201,15 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                                         _theme(context).onSeekStart?.call();
                                         _timer?.cancel();
                                       },
-                                      onSeekEnd: () {
+                                      onSeekEnd: (Duration target) {
+                                        // Hibiki patch (BUG-796 follow-up):
+                                        // surface the committed seek target to the
+                                        // host so it re-syncs the subtitle +
+                                        // suppresses the lagging post-seek
+                                        // position. See PATCHES.md.
+                                        _theme(context)
+                                            .onSeekEnd
+                                            ?.call(target);
                                         _timer = Timer(
                                           _theme(context).controlsHoverDuration,
                                           () {
@@ -1653,7 +1674,11 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
 class MaterialSeekBar extends StatefulWidget {
   final ValueNotifier<Duration>? delta;
   final VoidCallback? onSeekStart;
-  final VoidCallback? onSeekEnd;
+
+  /// Hibiki patch (BUG-796 follow-up): retyped from `VoidCallback?` to carry the
+  /// committed seek target [Duration] to the host (theme `onSeekEnd`). See
+  /// third_party/media_kit_video/PATCHES.md.
+  final void Function(Duration)? onSeekEnd;
 
   const MaterialSeekBar({
     super.key,
@@ -1784,7 +1809,10 @@ class MaterialSeekBarState extends State<MaterialSeekBar> {
     // unmounted, matching the State's existing `if (mounted)` setState guard.
     // See third_party/media_kit_video/PATCHES.md.
     if (!mounted) return;
-    widget.onSeekEnd?.call();
+    // Hibiki patch (BUG-796 follow-up): carry the committed seek target so the
+    // host can re-sync the subtitle to the destination + suppress the lagging
+    // post-seek position (progress-bar seek bypasses seekMs). See PATCHES.md.
+    widget.onSeekEnd?.call(duration * slider);
     setState(() {
       // Explicitly set the position to prevent the slider from jumping.
       tapped = false;

--- a/third_party/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
+++ b/third_party/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
@@ -206,6 +206,18 @@ class MaterialDesktopVideoControlsThemeData {
   /// pub.dev. See third_party/media_kit_video/PATCHES.md.
   final void Function()? onSeekStart;
 
+  /// Hibiki patch (BUG-796 follow-up): fires when the user **commits** a seek-bar
+  /// seek (drag release / tap), with the target [Duration] the bar just seeked to.
+  /// The seek bar drives `player.seek` directly inside media_kit, bypassing the
+  /// host's `VideoPlayerController.seekMs` (which authoritatively re-syncs the
+  /// subtitle to the destination and suppresses the lagging post-seek position).
+  /// Hibiki uses this to apply the *same* in-flight protection to progress-bar
+  /// seeks — otherwise seeking (esp. while paused) to a gap leaves the previous
+  /// subtitle on screen because the 125ms tick keeps reading the stale old
+  /// position. Null (upstream default) = no callback, behaviour identical to
+  /// pub.dev. See third_party/media_kit_video/PATCHES.md.
+  final void Function(Duration)? onSeekEnd;
+
   // SEEK BAR HOVER POSITION (Hibiki patch)
 
   /// Optional callback fired with the current hover position (fraction `[0,1]`
@@ -270,6 +282,7 @@ class MaterialDesktopVideoControlsThemeData {
     this.shiftSubtitlesOnControlsVisibilityChange = true,
     this.visibilityNotifier,
     this.onSeekStart,
+    this.onSeekEnd,
     this.onHoverPosition,
   });
 
@@ -314,6 +327,7 @@ class MaterialDesktopVideoControlsThemeData {
     bool? shiftSubtitlesOnControlsVisibilityChange,
     ValueNotifier<bool>? visibilityNotifier,
     void Function()? onSeekStart,
+    void Function(Duration)? onSeekEnd,
     void Function(double? fraction)? onHoverPosition,
   }) {
     return MaterialDesktopVideoControlsThemeData(
@@ -371,6 +385,7 @@ class MaterialDesktopVideoControlsThemeData {
               this.shiftSubtitlesOnControlsVisibilityChange,
       visibilityNotifier: visibilityNotifier ?? this.visibilityNotifier,
       onSeekStart: onSeekStart ?? this.onSeekStart,
+      onSeekEnd: onSeekEnd ?? this.onSeekEnd,
       onHoverPosition: onHoverPosition ?? this.onHoverPosition,
     );
   }
@@ -874,7 +889,15 @@ class _MaterialDesktopVideoControlsState
                                                   ?.call();
                                               _timer?.cancel();
                                             },
-                                            onSeekEnd: () {
+                                            onSeekEnd: (Duration target) {
+                                              // Hibiki patch (BUG-796 follow-up):
+                                              // surface the committed seek target
+                                              // to the host so it re-syncs the
+                                              // subtitle + suppresses the lagging
+                                              // post-seek position. See PATCHES.md.
+                                              _theme(context)
+                                                  .onSeekEnd
+                                                  ?.call(target);
                                               _timer = Timer(
                                                 _theme(context)
                                                     .controlsHoverDuration,
@@ -987,7 +1010,11 @@ class _MaterialDesktopVideoControlsState
 /// Material design seek bar.
 class MaterialDesktopSeekBar extends StatefulWidget {
   final VoidCallback? onSeekStart;
-  final VoidCallback? onSeekEnd;
+
+  /// Hibiki patch (BUG-796 follow-up): retyped from `VoidCallback?` to carry the
+  /// committed seek target [Duration] to the host (theme `onSeekEnd`). See
+  /// third_party/media_kit_video/PATCHES.md.
+  final void Function(Duration)? onSeekEnd;
 
   /// Hibiki patch (TODO-669): hover position callback (fraction `[0,1]` of the
   /// track width, or null on exit). See third_party/media_kit_video/PATCHES.md.
@@ -1107,7 +1134,10 @@ class MaterialDesktopSeekBarState extends State<MaterialDesktopSeekBar> {
     // Bail out when unmounted, matching the State's existing `if (mounted)`
     // setState guard. See third_party/media_kit_video/PATCHES.md.
     if (!mounted) return;
-    widget.onSeekEnd?.call();
+    // Hibiki patch (BUG-796 follow-up): carry the committed seek target so the
+    // host can re-sync the subtitle to the destination + suppress the lagging
+    // post-seek position (progress-bar seek bypasses seekMs). See PATCHES.md.
+    widget.onSeekEnd?.call(duration * slider);
     setState(() {
       // Explicitly set the position to prevent the slider from jumping.
       click = false;


### PR DESCRIPTION
## 背景
BUG-796（±秒键跳到无字幕段旧字幕不消失，已合 develop ）的备注写明**进度条拖动走 media_kit 内部 seek、绕过 `seekMs`，未覆盖**。用户要求补齐该路径。

## 根因（同 BUG-796，不同入口）
进度条 seek bar 在 vendored fork `media_kit_video` 内部直接 `player.seek(...)`，绕过 `VideoPlayerController.seekMs` 的「权威同步 + 在途抑制」。暂停态 media_kit `state.position` 长期停旧位置，125ms tick 逐拍读旧 position → 命中旧句 → 拖到无字幕段旧字幕不消失。host 侧从既有回调拿不到拖动**落点**（fork 只透出无参 `onSeekStart`）。

## 修复
- **fork 补丁**（`material_desktop.dart` + `material.dart`）：两 theme data 类加 `void Function(Duration)? onSeekEnd`（构造 + copyWith）；seekbar 内部 `onSeekEnd` retype 成带 `Duration`，`onPointerUp` 提交点传落点 `duration*slider`；实例化合并 `_theme(context).onSeekEnd?.call(target)`。无注入时行为同 pub.dev。见 `PATCHES.md`。
- **控制器** 新增 `notifyExternalSeek(targetMs)`：按落点权威同步字幕 + 复用 `_reconcileSeekInFlightPosition` 抑制滞后旧 position，**不重复 seek**（进度条已 seek）。
- **host** 桌面/移动两 theme 均 `onSeekEnd: (t) => controller.notifyExternalSeek(t.inMilliseconds)`；只在 commit（pointer-up/tap）通知。

## 测试
- 控制器单测新增 group「notifyExternalSeek（进度条落点）」2 例（暂停拖到 gap 立即消失且不被旧 position 拉回 / 拖进某句立即显示、落地放行不钉死）。
- `media_kit_video_seekbar_guard_test.dart` 新增源码守卫 group（两 fork 文件字段/copyWith/call 点 + host 两端接线）。
- `flutter analyze`（lib+test）No issues；`flutter test test/media/video/ test/third_party/` 全绿（127 + 56）。

## 待验收 / 未覆盖
真机：暂停中拖进度条到无字幕段 → 旧字幕立即消失。视频区**横滑 seek 手势**（mobile，TODO-916）同绕 seekMs，非「进度条」范围，暂留。

见 `docs/bugs/BUG-796-...md` 的 Follow-up 段。