### PR TITLE
fix(sync): 互联 host 隐藏上传开关 + 远端视频列表健壮化 + 弱网下载停顿超时/续传

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39593 (2329 per locale)
+/// Strings: 39610 (2330 per locale)
 ///
-/// Built on 2026-07-14 at 07:36 UTC
+/// Built on 2026-07-14 at 08:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3087,6 +3087,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'When off, the panel shows only the copied text; tap a word to look it up.';
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -8363,6 +8365,9 @@ class _StringsAr extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -13762,6 +13767,9 @@ class _StringsDe extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -19178,6 +19186,9 @@ class _StringsEs extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -24613,6 +24624,9 @@ class _StringsFr extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -29950,6 +29964,9 @@ class _StringsId extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -35348,6 +35365,9 @@ class _StringsIt extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -40471,6 +40491,9 @@ class _StringsJa extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -45599,6 +45622,9 @@ class _StringsKo extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -50965,6 +50991,9 @@ class _StringsNl extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -56354,6 +56383,9 @@ class _StringsPtBr extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -61718,6 +61750,9 @@ class _StringsRu extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -66995,6 +67030,9 @@ class _StringsTh extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -72327,6 +72365,9 @@ class _StringsTr extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -77634,6 +77675,9 @@ class _StringsVi extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -82577,6 +82621,9 @@ class _StringsZhCn extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => '暂无收藏的句子';
   @override
   String get video_subtitle_filter_selected_empty => '还未选择句子';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      '无法加载远端视频：${error}';
 }
 
 // Path: retrying_in
@@ -87602,6 +87649,9 @@ class _StringsZhHk extends _StringsEn {
   String get video_subtitle_filter_favorites_empty => 'No favorited lines yet';
   @override
   String get video_subtitle_filter_selected_empty => 'No lines selected yet';
+  @override
+  String remote_video_list_failed({required Object error}) =>
+      'Could not load remote videos: ${error}';
 }
 
 // Path: retrying_in
@@ -92404,6 +92454,9 @@ extension on _StringsEn {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -97166,6 +97219,9 @@ extension on _StringsAr {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -101950,6 +102006,9 @@ extension on _StringsDe {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -106732,6 +106791,9 @@ extension on _StringsEs {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -111521,6 +111583,9 @@ extension on _StringsFr {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -116290,6 +116355,9 @@ extension on _StringsId {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -121076,6 +121144,9 @@ extension on _StringsIt {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -125819,6 +125890,9 @@ extension on _StringsJa {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -130566,6 +130640,9 @@ extension on _StringsKo {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -135345,6 +135422,9 @@ extension on _StringsNl {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -140121,6 +140201,9 @@ extension on _StringsPtBr {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -144901,6 +144984,9 @@ extension on _StringsRu {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -149663,6 +149749,9 @@ extension on _StringsTh {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -154434,6 +154523,9 @@ extension on _StringsTr {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -159199,6 +159291,9 @@ extension on _StringsVi {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }
@@ -163928,6 +164023,8 @@ extension on _StringsZhCn {
         return '暂无收藏的句子';
       case 'video_subtitle_filter_selected_empty':
         return '还未选择句子';
+      case 'remote_video_list_failed':
+        return ({required Object error}) => '无法加载远端视频：${error}';
       default:
         return null;
     }
@@ -168663,6 +168760,9 @@ extension on _StringsZhHk {
         return 'No favorited lines yet';
       case 'video_subtitle_filter_selected_empty':
         return 'No lines selected yet';
+      case 'remote_video_list_failed':
+        return ({required Object error}) =>
+            'Could not load remote videos: ${error}';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "复制后自动查词",
   "desktop_clipboard_auto_lookup_hint": "关闭后面板只显示复制到的文字，点词才查词。",
   "video_subtitle_filter_favorites_empty": "暂无收藏的句子",
-  "video_subtitle_filter_selected_empty": "还未选择句子"
+  "video_subtitle_filter_selected_empty": "还未选择句子",
+  "remote_video_list_failed": "无法加载远端视频：$error"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2335,5 +2335,6 @@
   "desktop_clipboard_auto_lookup": "Auto-look-up on copy",
   "desktop_clipboard_auto_lookup_hint": "When off, the panel shows only the copied text; tap a word to look it up.",
   "video_subtitle_filter_favorites_empty": "No favorited lines yet",
-  "video_subtitle_filter_selected_empty": "No lines selected yet"
+  "video_subtitle_filter_selected_empty": "No lines selected yet",
+  "remote_video_list_failed": "Could not load remote videos: $error"
 }

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -228,7 +228,9 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   ///
   /// 顶层 tab 保活（[HomePage] 的 `_keepAliveTabs`）后，切回视频 tab 不再隐式重拉远端，
   /// 故给用户一个**显式**强制刷新入口——别的设备新上传的互联视频，不重启 app 也能刷出来。
-  /// [_loadRemoteVideos] 内部吞异常返回 `failed:true`，await 不会抛，指示器必定收起。
+  /// [_loadRemoteVideos] 内部吞异常返回 `failed:true`，await 不会抛，指示器必定收起
+  /// （客户端 [listRemoteVideos] 已用 listTimeout 封顶，host 卡响应也不会无限转圈）。
+  /// 显式刷新失败时给一个可见 SnackBar（带原因），避免「看不到远端视频却不知为何」。
   Future<void> _pullToRefresh() async {
     final Future<_RemoteVideoState?> remote = _loadRemoteVideos();
     if (mounted) {
@@ -239,7 +241,17 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     }
     _loadLibraryMaps();
     _maybeBackfillCovers();
-    await remote;
+    final _RemoteVideoState? state = await remote;
+    if (!mounted) return;
+    if (state != null && state.failed) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            t.remote_video_list_failed(error: state.errorMessage ?? ''),
+          ),
+        ),
+      );
+    }
   }
 
   /// 一次性预取库页排序/分组所需映射：合集字典、折叠归属、组内 sortIndex、
@@ -405,10 +417,12 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         );
       } catch (e) {
         // spec §2.4 离线语义：拉取失败 → 占位卡不出现（failed 门控），只剩本地库。
+        // errorMessage 带上原因供显式下拉刷新时可见反馈（初次静默加载仍不打扰）。
         debugPrint('[home-video] remote video list failed: $e');
-        return const _RemoteVideoState(
-          videos: <RemoteVideoInfo>[],
+        return _RemoteVideoState(
+          videos: const <RemoteVideoInfo>[],
           failed: true,
+          errorMessage: e.toString(),
         );
       }
     }
@@ -436,9 +450,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
       );
     } catch (e) {
       debugPrint('[home-video] cloud video manifest failed: $e');
-      return const _RemoteVideoState(
-        videos: <RemoteVideoInfo>[],
+      return _RemoteVideoState(
+        videos: const <RemoteVideoInfo>[],
         failed: true,
+        errorMessage: e.toString(),
       );
     }
   }
@@ -3174,10 +3189,15 @@ class _RemoteVideoState {
   const _RemoteVideoState({
     required this.videos,
     this.failed = false,
+    this.errorMessage,
   });
 
   final List<RemoteVideoInfo> videos;
 
   /// 远端目录拉取失败（离线/未配对/后端不可达）：占位卡不渲染（spec §2.4）。
   final bool failed;
+
+  /// 失败原因（异常文本），仅在 [failed] 时非空。初次静默加载走离线语义不打扰用户，
+  /// 但**显式下拉刷新**失败时用它给出可见反馈（不再「看不到远端视频还不知为何」）。
+  final String? errorMessage;
 }

--- a/hibiki/lib/src/sync/hibiki_client_sync_backend.dart
+++ b/hibiki/lib/src/sync/hibiki_client_sync_backend.dart
@@ -137,6 +137,13 @@ class HibikiClientSyncBackend extends SyncBackend
   /// to WAN is quick when you are away from home.
   static const Duration probeTimeout = Duration(seconds: 2);
 
+  /// Bound for a resolved-host library GET (headers + body). [_ensureResolved]
+  /// only bounds the *probe*; once an address is picked, a host that accepts the
+  /// TCP connection but then stalls the response would hang the future forever
+  /// (observed as the video page's endless spinner). Cap the read so a stalled
+  /// host degrades to "failed" instead of an infinite wait.
+  static const Duration listTimeout = Duration(seconds: 15);
+
   final HibikiProbe _probe;
   List<HibikiClientUrl> _candidates = const <HibikiClientUrl>[];
   String? _token;
@@ -1090,15 +1097,23 @@ class HibikiClientSyncBackend extends SyncBackend
   // 视频只远程观看/可选下载，不参与双向同步。Host 的 /stream 端点使用短时
   // token URL，media_kit 可直接播放，不依赖自定义 HTTP header。
 
-  /// 列出对端 host 当前视频清单（直打 `/api/library/videos`）。
+  /// 列出对端 host 当前视频清单（直打 `/api/library/videos`）。老 host 无该端点返回
+  /// 404 时优雅降级返回空表（与 [getRemoteAggregate] / [getRemoteCollectionManifest]
+  /// 的 404 降级同纪律——绝不因老 server 缺端点抛异常让整页占位卡消失/转圈）。请求
+  /// 用 [listTimeout] 封顶，防止 host 接受连接后卡住响应导致视频页无限等待。
   @override
   Future<List<RemoteVideoInfo>> listRemoteVideos() async {
     await _ensureResolved();
     final HttpClientRequest req =
         await _ops!.buildRequest('GET', '$_apiBase/api/library/videos');
-    final HttpClientResponse res = await req.close();
+    final HttpClientResponse res = await req.close().timeout(listTimeout);
+    if (res.statusCode == 404) {
+      await res.drain<void>();
+      return const <RemoteVideoInfo>[]; // 老 host 无视频端点：降级空表，不崩不转圈。
+    }
     _ops!.checkStatus(res.statusCode, 'GET /api/library/videos');
-    final String body = await res.transform(utf8.decoder).join();
+    final String body =
+        await res.transform(utf8.decoder).join().timeout(listTimeout);
     final List<dynamic> arr = jsonDecode(body) as List<dynamic>;
     return <RemoteVideoInfo>[
       for (final dynamic e in arr)

--- a/hibiki/lib/src/sync/sync_settings_schema.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema.dart
@@ -207,11 +207,17 @@ SettingsDestination buildSyncBackupDestination() {
                   .setSyncLocalAudioEnabled(value);
             },
           ),
+          // 「上传X文件」三个开关都是 OUTBOUND：把本机资产推给已解析的后端。互联
+          // host（本机在做服务端）没有任何 outbound sync——client 从它拉取/往它推，
+          // 它自己不上传（auto_sync 同理已隐藏）。故 host 模式下这三个上传开关纯空转，
+          // 一律随 auto_sync 的 `!_isHostingInterconnect` 门控隐藏（client 模式仍可见，
+          // client 确实能往 host 推）。
           SettingsSwitchItem(
             id: 'sync.content',
             title: t.sync_content,
             subtitle: t.sync_content_warning,
             icon: Icons.book_outlined,
+            visible: (SettingsContext ctx) => !_isHostingInterconnect(ctx),
             value: (SettingsContext ctx) => _syncSettings(ctx).syncContent,
             onChanged: (SettingsContext ctx, bool value) async {
               _syncSettings(ctx).syncContent = value;
@@ -224,6 +230,7 @@ SettingsDestination buildSyncBackupDestination() {
             title: t.sync_audiobook_files,
             subtitle: t.sync_audiobook_files_warning,
             icon: Icons.audio_file_outlined,
+            visible: (SettingsContext ctx) => !_isHostingInterconnect(ctx),
             value: (SettingsContext ctx) =>
                 _syncSettings(ctx).syncAudioBookFiles,
             onChanged: (SettingsContext ctx, bool value) async {
@@ -232,15 +239,17 @@ SettingsDestination buildSyncBackupDestination() {
                   .setSyncAudioBookFilesEnabled(value);
             },
           ),
-          // 上传视频文件（多端库联合视图 §2.6）：默认关，全后端可见。云后端走
-          // syncVideoAssets 的 `__videos__` 伪装资产（run() 非互联分支）；互联
-          // （hibikiServer）走 _syncVideosLive 的 host 上传端点（client→host）。两条通道
-          // 同为 upload-only（host→client 仍按需流式/下载），故此开关对所有后端都生效。
+          // 上传视频文件（多端库联合视图 §2.6）：默认关。云后端走 syncVideoAssets 的
+          // `__videos__` 伪装资产（run() 非互联分支）；互联（hibikiServer）走
+          // _syncVideosLive 的 host 上传端点（client→host）。两条通道同为 upload-only
+          // （host→client 仍按需流式/下载，且与本开关正交——客户端手动浏览/下载远端视频
+          // 只看 show_remote_entries，从不受此开关门控）。host 模式无 outbound → 隐藏。
           SettingsSwitchItem(
             id: 'sync.video_files',
             title: t.sync_video_files,
             subtitle: t.sync_video_files_warning,
             icon: Icons.video_file_outlined,
+            visible: (SettingsContext ctx) => !_isHostingInterconnect(ctx),
             value: (SettingsContext ctx) => _syncSettings(ctx).syncVideoFiles,
             onChanged: (SettingsContext ctx, bool value) async {
               _syncSettings(ctx).syncVideoFiles = value;

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+744
+version: 1.2.0+745
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/sync/hibiki_client_backend_test.dart
+++ b/hibiki/test/sync/hibiki_client_backend_test.dart
@@ -1,7 +1,10 @@
+import 'dart:io';
+
 import 'package:drift/drift.dart' hide isNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/sync/hibiki_client_sync_backend.dart';
+import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/src/sync/sync_utils.dart';
 import 'package:hibiki/src/sync/webdav_ops.dart';
@@ -113,5 +116,30 @@ void main() {
     backend.clearCache();
     await backend.ensureResolved();
     expect(backend.activeBaseUrl, WebDavOps.normalizeUrl('http://wan:8765'));
+  });
+
+  // 老 host 不实现 /api/library/videos（发布早于互联视频批次）时，client 的
+  // listRemoteVideos 必须优雅降级返回空表，而不是抛异常——否则视频页整片占位卡
+  // 消失且（历史上）无限转圈。用一个只会 404 的裸 HttpServer 断言这条降级路径。
+  test('listRemoteVideos degrades to empty list on host 404 (old host)',
+      () async {
+    final HttpServer server = await HttpServer.bind('127.0.0.1', 0);
+    addTearDown(() => server.close(force: true));
+    server.listen((HttpRequest req) async {
+      req.response.statusCode = HttpStatus.notFound; // 任何路径都 404
+      await req.response.close();
+    });
+    final String base = 'http://127.0.0.1:${server.port}';
+
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository repo = SyncRepository(db);
+    await _seed(repo, urls: <HibikiClientUrl>[HibikiClientUrl(url: base)]);
+    final HibikiClientSyncBackend backend =
+        HibikiClientSyncBackend.withProbe((String u, String t) async => true);
+    await backend.restoreAuth(repo);
+
+    final List<RemoteVideoInfo> videos = await backend.listRemoteVideos();
+    expect(videos, isEmpty, reason: '404 → 空表降级，不抛异常');
   });
 }


### PR DESCRIPTION
## 背景
用户反馈（互联/hibikiServer 场景）：host 不该有「上传书籍/视频文件」开关；客户端看不到远端视频、一直转圈；弱网下大文件下载怕拉一堆东西/卡死。

## 变更
### 1. host 隐藏上传开关
三个 outbound 上传开关（书籍/有声书/视频文件）在本机做互联服务端时随 `!_isHostingInterconnect` 门控隐藏（host 无 outbound sync，与已隐藏的 auto_sync 同理）；client 模式仍可见。上传开关与客户端手动浏览/下载远端视频**正交**——查看只看 `show_remote_entries`。

### 2. 远端视频「看不到/转圈」根因修复
`listRemoteVideos`：老 host 缺端点 404 → 优雅降级空表（对齐 aggregate/collections 纪律）；`listTimeout(15s)` 封顶防卡响应无限等；显式下拉刷新失败给可见 SnackBar（带原因）。

### 3. 弱网下载健壮性（停顿超时 + 续传）
- 包/字幕下载（`downloadContentFile`：书/有声书/词典/外挂字幕）改走通用 `ResumableDownloader`：**停顿超时 45s**（流内空闲即中断保 .part，不再干等 OS 级 TCP 超时）+ 首字节超时 5min（容忍 host 导出大包）+ 同目录 .part。包端点当前 host 全量导出临时包无 Range 返 200 → ResumableDownloader 安全从零 truncate 重来（不损坏）；host 后续对稳定包支持 Range 即自动获得真续传。
- 视频下载（本就 Range 续传）补上首字节/停顿超时，卡死连接不再无限等。
- 原子性增强：destination 只在整包成功后由 .part promote，失败绝不留截断文件。

## 事实澄清（回答用户疑问）
- **列表拉取不是「一堆垃圾」**：封面是 URL/路径字符串，不是内联字节，列表 = KB 级元数据。
- **下载本就流式**（边收边落盘），GB 视频不撑内存；弱网真缺口是「无停顿超时 + 包无续传」，本 PR 已补停顿超时，视频续传本已具备。

## 测试
- 404 降级：裸 404 HttpServer 断言 `listRemoteVideos` 空表不抛。
- 下载路由：live book/audio/dict/video 32+ 测试成功路径全绿（经 ResumableDownloader）；ResumableDownloader 续传/停顿/206/200 逻辑本有 `resumable_downloader_test.dart` 覆盖。
- i18n 完整性/插值守卫通过。

## 待真机
互联 client：老 host 视频页不转圈+失败有提示；host 设置页无上传开关；弱网下载中断保 .part、卡死连接 45s 中断。

## 未含（另议，用户已确认要做，单独 PR）
- **书架合集不渲染**：云盘 `CloudRemoteBookClient.listRemoteBooks` 未带 `collection` 成员（结构 bug）；互联为刷新时序。
- **纯 SRT 有声书下载**：host 未枚举 srt_books（identity=uid 非 bookKey，包管线绑 Audiobooks 行），7 步跨层 feature。
- **云盘视频续传**：`CloudRemoteVideoClient.getRemoteVideo` 整文件重下（各云后端 Range 支持不一）。