### PR TITLE
fix(shelf): 继续阅读 hero 纳入有声书 (BUG-804)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 785 条。点号进各自文件。
+> 共 786 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-804](bugs/BUG-804-shelf-continue-excludes-audiobook.md) | ✅ | ✅ | 书架继续阅读hero排除有声书永不更新 |
 | [BUG-803](bugs/BUG-803-inline-gaiji-width.md) | ✅ | ✅ | 词典行内外字图标撑开相邻链接 |
 | [BUG-802](bugs/BUG-802-popup-copy-search-selection.md) | ✅ | ✅ | 查词弹窗选中后复制/搜索无效 |
 | [BUG-801](bugs/BUG-801-android-native-subtitleview-duplicate.md) | ✅ | ✅ | 安卓视频原生SubtitleView与可点浮层字幕重复(控制条显示时上下两条) |

--- a/docs/bugs/BUG-804-shelf-continue-excludes-audiobook.md
+++ b/docs/bugs/BUG-804-shelf-continue-excludes-audiobook.md
@@ -1,0 +1,13 @@
+## BUG-804 · 书架继续阅读hero排除有声书永不更新
+- **报告**：2026-07-14（用户：「书架的继续阅读一直不更新」；追问确认「刚读的那本是有声书/带字幕同步的书」）
+- **真实性**：✅ 真 bug。根因链（BUG-777 修的是「读 importedAt 序、写 updatedAt」字段错位，已入 develop；本 bug 是另一条独立缺陷——候选集把有声书整类排除）：
+  - `hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart:924-929` — `epubBooks` = `books` 里剔除「bookKey ∈ srtBookKeys」的书。有声书 = EPUB 正文行 + SRT 字幕行同 bookKey，故被剔出 `epubBooks`（本意只为主网格卡去重：有声书渲染成单张 SRT 卡，别再画一张 EPUB 卡）。
+  - 同页 `:1125`（改前）— 继续阅读 hero + 概览统计 `_buildShelfOverviewSection(epubBooks, srtBooks)` 只吃 srt 过滤后的 `epubBooks`；`:717/:727`（改前）hero 候选 `inProgress` 只遍历它。于是有声书虽有真实 EPUB 进度（`position/duration`，来自 `hibikiBooksProvider`）、也有 `lastReadAt`（`reader_positions.updatedAt`，EPUB/SRT 同走 bookKey，BUG-723 已确认同源），却永远进不了 hero 候选——读多少遍有声书，「继续阅读」都不会变成它，表现为「一直不更新」。
+  - `mostRecentlyReadCandidate`（`shelf_sort.dart:127-141`）在候选全 miss（`?? 0`）时退化返回列表首位（importedAt 倒序第一本），进一步坐实「冻在同一本」的观感。
+  - 数据边界：纯字幕、无 EPUB 正文的书（无 `books` 行 → 无 `position/duration`）本就无进度维度，不进候选，属诚实边界，非本 bug。
+- **[x] ① 已修复** — hero/概览统计改吃**未过滤的全量 EPUB-backed `books`**（含有声书），主网格卡渲染仍用过滤后的 `epubBooks`（卡片零变化，不重复渲染）。`_buildShelfOverviewSection(progressBooks, libraryTotal)`：`progressBooks=books`、`libraryTotal=epubBooks.length+srtBooks.length`（有声书作单张 SRT 卡只计一次）。在读/读完/候选分类抽成纯函数 `tallyShelfProgress`（`shelf_sort.dart`）。提交 51890d9dd。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/shelf_sort_test.dart` 新增 `tallyShelfProgress` 组：分类正确性 + **复现场景「全量列表里最近读的有声书当选 hero」** + 空候选；`hibiki/test/pages/unified_collections_architecture_guard_test.dart` 新增 BUG-804 源码守卫：概览 section 调用点必须传未过滤的 `books`、正则禁 `_buildShelfOverviewSection(epubBooks`、分类必走 `tallyShelfProgress`。提交 51890d9dd。
+- **备注**：
+  1. 与 BUG-777 是两条独立缺陷，勿混：777 已修 hero 在**纯 EPUB 内**按最近阅读选书；804 修 hero **候选集**把有声书整类漏掉。两者叠加前，有声书用户「继续阅读」双重失灵。
+  2. 真机复测：读一本有声书（翻页/听书推进进度）→ 返回书架 → 「继续阅读」应更新成这本、显示其已读 %；再对照读一本纯 EPUB 仍正常。
+  3. 纯字幕无正文的有声书（若存在）无 EPUB 进度维度，仍不进候选，属边界；用户所报「带字幕同步的书」是文本+音频型，有正文行，本修复覆盖。

--- a/docs/bugs/BUG-804-shelf-continue-excludes-audiobook.md
+++ b/docs/bugs/BUG-804-shelf-continue-excludes-audiobook.md
@@ -5,8 +5,8 @@
   - 同页 `:1125`（改前）— 继续阅读 hero + 概览统计 `_buildShelfOverviewSection(epubBooks, srtBooks)` 只吃 srt 过滤后的 `epubBooks`；`:717/:727`（改前）hero 候选 `inProgress` 只遍历它。于是有声书虽有真实 EPUB 进度（`position/duration`，来自 `hibikiBooksProvider`）、也有 `lastReadAt`（`reader_positions.updatedAt`，EPUB/SRT 同走 bookKey，BUG-723 已确认同源），却永远进不了 hero 候选——读多少遍有声书，「继续阅读」都不会变成它，表现为「一直不更新」。
   - `mostRecentlyReadCandidate`（`shelf_sort.dart:127-141`）在候选全 miss（`?? 0`）时退化返回列表首位（importedAt 倒序第一本），进一步坐实「冻在同一本」的观感。
   - 数据边界：纯字幕、无 EPUB 正文的书（无 `books` 行 → 无 `position/duration`）本就无进度维度，不进候选，属诚实边界，非本 bug。
-- **[x] ① 已修复** — hero/概览统计改吃**未过滤的全量 EPUB-backed `books`**（含有声书），主网格卡渲染仍用过滤后的 `epubBooks`（卡片零变化，不重复渲染）。`_buildShelfOverviewSection(progressBooks, libraryTotal)`：`progressBooks=books`、`libraryTotal=epubBooks.length+srtBooks.length`（有声书作单张 SRT 卡只计一次）。在读/读完/候选分类抽成纯函数 `tallyShelfProgress`（`shelf_sort.dart`）。提交 51890d9dd。
-- **[x] ② 已加自动化测试** — `hibiki/test/media/shelf_sort_test.dart` 新增 `tallyShelfProgress` 组：分类正确性 + **复现场景「全量列表里最近读的有声书当选 hero」** + 空候选；`hibiki/test/pages/unified_collections_architecture_guard_test.dart` 新增 BUG-804 源码守卫：概览 section 调用点必须传未过滤的 `books`、正则禁 `_buildShelfOverviewSection(epubBooks`、分类必走 `tallyShelfProgress`。提交 51890d9dd。
+- **[x] ① 已修复** — hero/概览统计改吃**未过滤的全量 EPUB-backed `books`**（含有声书），主网格卡渲染仍用过滤后的 `epubBooks`（卡片零变化，不重复渲染）。`_buildShelfOverviewSection(progressBooks, libraryTotal)`：`progressBooks=books`、`libraryTotal=epubBooks.length+srtBooks.length`（有声书作单张 SRT 卡只计一次）。在读/读完/候选分类抽成纯函数 `tallyShelfProgress`（`shelf_sort.dart`）。提交 82fa99682。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/shelf_sort_test.dart` 新增 `tallyShelfProgress` 组：分类正确性 + **复现场景「全量列表里最近读的有声书当选 hero」** + 空候选；`hibiki/test/pages/unified_collections_architecture_guard_test.dart` 新增 BUG-804 源码守卫：概览 section 调用点必须传未过滤的 `books`、正则禁 `_buildShelfOverviewSection(epubBooks`、分类必走 `tallyShelfProgress`。提交 82fa99682。
 - **备注**：
   1. 与 BUG-777 是两条独立缺陷，勿混：777 已修 hero 在**纯 EPUB 内**按最近阅读选书；804 修 hero **候选集**把有声书整类漏掉。两者叠加前，有声书用户「继续阅读」双重失灵。
   2. 真机复测：读一本有声书（翻页/听书推进进度）→ 返回书架 → 「继续阅读」应更新成这本、显示其已读 %；再对照读一本纯 EPUB 仍正常。

--- a/hibiki/lib/src/media/collections/shelf_sort.dart
+++ b/hibiki/lib/src/media/collections/shelf_sort.dart
@@ -139,3 +139,52 @@ T? mostRecentlyReadCandidate<T>(
   }
   return best;
 }
+
+/// 书架概览统计（在读数 / 读完数 / 在读候选列表）。
+///
+/// BUG-804：输入必须是**全量 EPUB-backed 书**——含有声书（EPUB 正文 + SRT
+/// 字幕同 bookKey，走阅读器落 `reader_positions`，有真实 position/duration）。旧
+/// 实现只喂 srt 过滤后的纯 EPUB 列表（`epubBooks`），把有声书整类排除，导致读了
+/// 有声书回书架「继续阅读」hero 永不更新（有声书虽有进度与 lastReadAt 却进不了
+/// 候选）。过滤到纯 EPUB 只为主网格卡去重（有声书渲染成 SRT 卡），与概览统计/
+/// hero 选书无关，不能复用到这里。
+///
+/// 分类：`duration<=0` 跳过（无进度维度，如纯字幕、无 EPUB 正文的书）；
+/// `position>=duration` 计读完；`0<position<duration` 计在读并进候选。
+class ShelfProgressTally<T> {
+  const ShelfProgressTally({
+    required this.reading,
+    required this.finished,
+    required this.inProgress,
+  });
+
+  final int reading;
+  final int finished;
+  final List<T> inProgress;
+}
+
+ShelfProgressTally<T> tallyShelfProgress<T>(
+  Iterable<T> epubBackedBooks,
+  int Function(T) position,
+  int Function(T) duration,
+) {
+  int reading = 0;
+  int finished = 0;
+  final List<T> inProgress = <T>[];
+  for (final T book in epubBackedBooks) {
+    final int dur = duration(book);
+    if (dur <= 0) continue;
+    final int pos = position(book);
+    if (pos >= dur) {
+      finished++;
+    } else if (pos > 0) {
+      reading++;
+      inProgress.add(book);
+    }
+  }
+  return ShelfProgressTally<T>(
+    reading: reading,
+    finished: finished,
+    inProgress: inProgress,
+  );
+}

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -700,39 +700,40 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
 
   /// UI v2：书架顶部「继续阅读 hero + 书库概览」条（对齐视频页）。
   ///
-  /// 数据边界（诚实外显）：hero = 在读（0<position<duration）EPUB 中「最后阅读
-  /// 时间」（[bookLastReadAtProvider]，即 reader_positions.updatedAt）最新者，
-  /// 显示「已读 x%」；无候选整块只剩统计。BUG-777：旧实现取列表第一本在读书，
-  /// 但列表序 = getAllEpubBooks 的 importedAt 倒序，选中的是「最近导入」而非
-  /// 「最近阅读」的书。统计 = 总数（EPUB+SRT）/ 在读 / 读完（后两格按 EPUB
-  /// 进度；SRT 卡无统一进度数据，不硬造）。宽 >=720 并排、窄屏堆叠。
+  /// 数据边界（诚实外显）：hero = 在读（0<position<duration）EPUB-backed 书中
+  /// 「最后阅读时间」（[bookLastReadAtProvider]，即 reader_positions.updatedAt）
+  /// 最新者，显示「已读 x%」；无候选整块只剩统计。BUG-777：旧实现取列表第一本
+  /// 在读书，但列表序 = getAllEpubBooks 的 importedAt 倒序，选中的是「最近导入」
+  /// 而非「最近阅读」的书。
+  ///
+  /// BUG-804：[progressBooks] 必须是**未按 srt 过滤的全量 EPUB-backed 列表**
+  /// （`hibikiBooksProvider` 全部行，含有声书——EPUB 正文 + SRT 字幕同 bookKey）。
+  /// 旧实现只喂 srt 过滤后的 `epubBooks`，有声书虽有进度与 lastReadAt 却被整类
+  /// 排除，读了有声书回书架「继续阅读」永不更新。过滤到纯 EPUB 只为主网格卡
+  /// 去重（有声书渲染成 SRT 卡），与 hero/统计无关。
+  ///
+  /// 统计 = 总数（[libraryTotal] = 纯 EPUB 卡 + SRT 卡，有声书计一次）/ 在读 /
+  /// 读完（后两格按 EPUB-backed 进度；纯字幕无 EPUB 正文的书无进度维度，跳过）。
+  /// 宽 >=720 并排、窄屏堆叠。
   Widget _buildShelfOverviewSection(
-    List<MediaItem> epubBooks,
-    List<SrtBook> srtBooks,
+    List<MediaItem> progressBooks,
+    int libraryTotal,
   ) {
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
-    final List<MediaItem> inProgress = <MediaItem>[];
-    int reading = 0;
-    int finished = 0;
-    for (final MediaItem item in epubBooks) {
-      final int duration = item.duration;
-      if (duration <= 0) continue;
-      if (item.position >= duration) {
-        finished++;
-      } else if (item.position > 0) {
-        reading++;
-        inProgress.add(item);
-      }
-    }
+    final ShelfProgressTally<MediaItem> tally = tallyShelfProgress<MediaItem>(
+      progressBooks,
+      (MediaItem item) => item.position,
+      (MediaItem item) => item.duration,
+    );
     final MediaItem? hero = mostRecentlyReadCandidate(
-      inProgress,
+      tally.inProgress,
       (MediaItem item) =>
           _lastReadAtByBookKey[_parseBookKey(item.mediaIdentifier)] ?? 0,
     );
     final Widget stats = _buildShelfOverviewStats(
-      total: epubBooks.length + srtBooks.length,
-      reading: reading,
-      finished: finished,
+      total: libraryTotal,
+      reading: tally.reading,
+      finished: tally.finished,
       tokens: tokens,
     );
     final Widget? heroCard =
@@ -1119,9 +1120,16 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
               SliverToBoxAdapter(child: SizedBox(height: tokens.spacing.gap)),
               // UI v2：书架顶部「继续阅读 hero + 书库概览」条（对齐视频页，用户
               // 拍板「书架也要有」）。空库隐藏；统计按未过滤全量描述整库。
+              // BUG-804：hero/在读统计喂**未过滤的全量 EPUB-backed `books`**（含
+              // 有声书），不是 srt 过滤后的 `epubBooks`——否则读了有声书「继续
+              // 阅读」永不更新。libraryTotal 仍按可见卡数（纯 EPUB + SRT）计，
+              // 有声书渲染成单张 SRT 卡只计一次。
               if (epubBooks.isNotEmpty || srtBooks.isNotEmpty)
                 SliverToBoxAdapter(
-                  child: _buildShelfOverviewSection(epubBooks, srtBooks),
+                  child: _buildShelfOverviewSection(
+                    books,
+                    epubBooks.length + srtBooks.length,
+                  ),
                 ),
               // TODO-902: 书架不再按类型分区（删 srt_books_section / section_epub
               // 两个分区头），SRT 有声书卡与 EPUB 卡混排进同一网格（SRT 在前、EPUB

--- a/hibiki/test/media/shelf_sort_test.dart
+++ b/hibiki/test/media/shelf_sort_test.dart
@@ -138,4 +138,70 @@ void main() {
       expect(ShelfSortMode.fromName(''), ShelfSortMode.recent);
     });
   });
+
+  group('tallyShelfProgress（BUG-804：概览统计 + hero 候选含有声书）', () {
+    // 测试项 = (position, duration, lastReadAt)；有声书与纯 EPUB 在这一层无区别，
+    // 都是有 position/duration 的 EPUB-backed 书——bug 在于旧调用点把有声书从
+    // 输入里过滤掉了，这里锁死「只要喂进来就正确分类/入候选」。
+    ({int position, int duration, int lastReadAt}) item(
+      int position,
+      int duration, {
+      int lastReadAt = 0,
+    }) =>
+        (position: position, duration: duration, lastReadAt: lastReadAt);
+
+    test('分类：读完 / 在读 / 无进度维度(duration<=0)跳过 / 未开始(position=0)不计', () {
+      final tally = tallyShelfProgress(
+        <({int position, int duration, int lastReadAt})>[
+          item(100, 100), // 读完
+          item(30, 100), // 在读
+          item(0, 100), // 未开始（不计在读也不计读完）
+          item(5, 0), // duration<=0：无进度维度，跳过
+          item(200, 100), // position>=duration 也算读完（越界钳到读完）
+        ],
+        (it) => it.position,
+        (it) => it.duration,
+      );
+      expect(tally.finished, 2, reason: 'position>=duration 计读完（含越界）');
+      expect(tally.reading, 1);
+      expect(tally.inProgress.length, 1, reason: '只有真在读的进候选');
+      expect(tally.inProgress.single.position, 30);
+    });
+
+    test('复现 BUG-804：全量列表里「最近读的有声书」必须能当选 hero', () {
+      // 模拟：一本更晚导入的纯 EPUB（在读，lastReadAt 旧）+ 一本有声书（在读，
+      // lastReadAt 新——刚听完）。旧实现把有声书过滤出候选，hero 恒选纯 EPUB；
+      // 修复后有声书在候选里，按 lastReadAt 胜出。
+      final List<({int position, int duration, int lastReadAt})> allEpubBacked =
+          <({int position, int duration, int lastReadAt})>[
+        item(10, 100, lastReadAt: 100), // 纯 EPUB，较早读
+        item(40, 100, lastReadAt: 500), // 有声书，刚听完（最近）
+      ];
+      final tally = tallyShelfProgress(
+        allEpubBacked,
+        (it) => it.position,
+        (it) => it.duration,
+      );
+      expect(tally.inProgress.length, 2, reason: '有声书不得被排除在候选外');
+      final hero = mostRecentlyReadCandidate(
+        tally.inProgress,
+        (it) => it.lastReadAt,
+      );
+      expect(hero?.lastReadAt, 500, reason: '刚听完的有声书必须赢过更早读的纯 EPUB');
+    });
+
+    test('空/全无进度 → 无候选（hero 整块只剩统计）', () {
+      final tally = tallyShelfProgress(
+        <({int position, int duration, int lastReadAt})>[
+          item(0, 100),
+          item(3, 0),
+        ],
+        (it) => it.position,
+        (it) => it.duration,
+      );
+      expect(tally.reading, 0);
+      expect(tally.finished, 0);
+      expect(tally.inProgress, isEmpty);
+    });
+  });
 }

--- a/hibiki/test/pages/unified_collections_architecture_guard_test.dart
+++ b/hibiki/test/pages/unified_collections_architecture_guard_test.dart
@@ -308,6 +308,30 @@ void main() {
         reason: '列表下标假名次已删（provider 序 = importedAt 倒序，不是访问序）');
   });
 
+  test('BUG-804：继续阅读 hero/概览统计喂全量 EPUB-backed（含有声书），不喂 srt 过滤后的 epubBooks', () {
+    // 有声书 = EPUB 正文 + SRT 字幕同 bookKey，有真实 position/duration 与
+    // lastReadAt。旧实现把 srt 过滤后的 `epubBooks` 喂给 _buildShelfOverviewSection，
+    // 有声书整类被排除，读了有声书回书架「继续阅读」永不更新。守卫：概览 section
+    // 调用点必须传未过滤的 `books`（hibikiBooksProvider 全部 EPUB-backed 行）。
+    final int callAt = historySrc.lastIndexOf('_buildShelfOverviewSection(');
+    expect(callAt, isNonNegative);
+    final String callArgs = historySrc.substring(
+      callAt,
+      (callAt + 80).clamp(0, historySrc.length),
+    );
+    expect(callArgs.contains('books,'), isTrue,
+        reason: 'hero/统计必须吃未过滤的全量 EPUB-backed 列表 books');
+    // 绝不能回退到把 srt 过滤后的 epubBooks 当概览/hero 输入（有声书会被排除）。
+    expect(
+        RegExp(r'_buildShelfOverviewSection\(\s*epubBooks\b')
+            .hasMatch(historySrc),
+        isFalse,
+        reason: 'hero 输入不得是 srt 过滤后的 epubBooks（有声书会被排除，BUG-804 回退）');
+    // 在读/读完/候选分类抽成纯函数 tallyShelfProgress（可单测，见 shelf_sort_test）。
+    expect(historySrc.contains('tallyShelfProgress'), isTrue,
+        reason: '书架概览分类必须走纯函数 tallyShelfProgress（BUG-804 单测锁）');
+  });
+
   test('多端库联合视图 §2.2/§2.6：云视频占位必经 CloudRemoteVideoClient（不自造清单解析）', () {
     // 云后端分支必须经 CloudRemoteVideoClient（唯一清单解析入口）而非在页面里自己
     // ensureNamespace/读 videos.json/构造 RemoteVideoManifest——把解析散进页面即转红。


### PR DESCRIPTION
## 现象
用户报「书架的继续阅读一直不更新」，追问确认刚读的是**有声书/带字幕同步的书**。

## 根因（非 BUG-777，独立缺陷）
`reader_hibiki_history_page.dart:924-929` 把「bookKey ∈ srtBookKeys」的书从 `epubBooks` 剔除（本意只为主网格卡去重——有声书渲染成单张 SRT 卡）。但继续阅读 hero + 概览统计 `_buildShelfOverviewSection(epubBooks,…)` 只吃这个过滤后的列表，`inProgress` 候选只遍历它。

有声书 = EPUB 正文行 + SRT 字幕行同 bookKey，**有真实进度**（`position/duration`，来自 `hibikiBooksProvider`）、**有 lastReadAt**（`reader_positions.updatedAt`，EPUB/SRT 同 bookKey），却被整类排除出 hero 候选 → 读多少遍有声书，「继续阅读」都不会变成它 → 「一直不更新」。

## 修复
- hero/概览统计改吃**未过滤的全量 EPUB-backed `books`**（含有声书）；主网格卡渲染仍用 `epubBooks` 去重，卡片零变化。
- `_buildShelfOverviewSection(progressBooks, libraryTotal)`：`progressBooks=books`、`libraryTotal=epubBooks.length+srtBooks.length`（有声书作单张 SRT 卡只计一次，无双计）。
- 在读/读完/候选分类抽成纯函数 `tallyShelfProgress`（`shelf_sort.dart`）。

## 测试
- `test/media/shelf_sort_test.dart`：`tallyShelfProgress` 分类正确性 + **复现「全量列表里最近读的有声书当选 hero」** + 空候选。
- `test/pages/unified_collections_architecture_guard_test.dart`：源码守卫锁调用点必须传 `books`、正则禁 `_buildShelfOverviewSection(epubBooks`、分类必走 `tallyShelfProgress`。
- `flutter test`（4 文件 33 例）全绿；`flutter analyze` 改动文件 No issues。

## 待验
真机复测：读有声书推进进度 → 返回书架 → 继续阅读应更新成这本、显示已读 %；对照纯 EPUB 仍正常。

BUG-804 · docs/bugs/BUG-804-shelf-continue-excludes-audiobook.md