### PR TITLE
fix(shelf)+feat(sync): 书架合集渲染修复 + 纯 SRT 有声书下载(7层)

### DIFF
--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -519,7 +519,12 @@ class AppModel with ChangeNotifier {
 
     if (report.booksImported > 0 ||
         report.audiobooksImported > 0 ||
-        report.localBookProgressPulled > 0) {
+        report.localBookProgressPulled > 0 ||
+        report.collectionsUpdated > 0) {
+      // 合集专属同步（仅 collectionsUpdated>0、无书内容导入）也必须刷新书架 tab：
+      // 否则后台把合集成员落库后，书架非响应式的 _shelfMapsFuture 永不重载，合集
+      // 不成组（书架合集不渲染，直到重启 app）。refreshTab 触发本 tab 的
+      // tabRefreshNotifier，ReaderHibikiHistoryPage 监听后重载合集折叠映射。
       ReaderMediaType.instance.refreshTab();
     }
 

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -574,11 +574,17 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
   /// [_epubImportedAtByKey]，srt 自带）。
   ShelfSortKey _shelfGroupSortKey(CollectionGroup<_ShelfBookSlot> group) {
     String titleOf(_ShelfBookSlot s) =>
-        s.srt?.title ?? s.epub?.title ?? s.remote?.title ?? '';
+        s.srt?.title ??
+        s.epub?.title ??
+        s.remote?.title ??
+        s.remoteSrt?.title ??
+        '';
     int recentOf(CollectionOrderingItem<_ShelfBookSlot> it) {
-      // 远端占位卡无本地阅读进度：退化到注入时编码的目录序（负 importedAt），稳定
-      // 排在本地条目之后（详见 [_ShelfBookSlot.remote]）。
-      if (it.payload.remote != null) return it.importedAt;
+      // 远端占位卡（EPUB 或纯 SRT）无本地阅读进度：退化到注入时编码的目录序（负
+      // importedAt），稳定排在本地条目之后（详见 [_ShelfBookSlot.remote]）。
+      if (it.payload.remote != null || it.payload.remoteSrt != null) {
+        return it.importedAt;
+      }
       final String? bookKey = it.payload.srt?.bookKey ??
           _parseBookKey(it.payload.epub!.mediaIdentifier);
       return _lastReadAtByBookKey[bookKey] ?? it.importedAt;
@@ -982,12 +988,16 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     // failed）→ 占位卡不出现（离线=只剩本地）；「显示远端条目」开关关闭 → 同样不
     // 渲染；标签筛选激活时占位卡不参与（远端书无本地标签），只在无筛选时混排。
     final _RemoteBookState? remoteState = remoteSnapshot?.data;
-    final List<RemoteBookInfo> remoteBooks = (remoteState != null &&
-            !remoteState.failed &&
-            !hasActiveFilter &&
-            appModel.prefsRepo.showRemoteEntries)
-        ? remoteState.books
-        : const <RemoteBookInfo>[];
+    final bool showRemote = remoteState != null &&
+        !remoteState.failed &&
+        !hasActiveFilter &&
+        appModel.prefsRepo.showRemoteEntries;
+    final List<RemoteBookInfo> remoteBooks =
+        showRemote ? remoteState.books : const <RemoteBookInfo>[];
+    // 纯 SRT（standalone）远端有声书占位（互联后端 listRemoteAudiobooks 的 standalone
+    // 项，本地无同 uid SrtBook）——与远端 EPUB 书同门控混排进主网格。
+    final List<RemoteAudiobookInfo> remoteSrtBooks =
+        showRemote ? remoteState.srtAudiobooks : const <RemoteAudiobookInfo>[];
     // 统一合集：把 SRT + EPUB 混排序列经 groupByCollections 折叠——散书每条单独成
     // group、同合集折叠成一组（组内序 = 合集 sortIndex，与详情页同源），再按当前
     // 排序方式排 group（散书与合集行同层混排）。「最近阅读」量纲 = 最后阅读时间
@@ -1015,6 +1025,19 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     // **真实 mediaType='epub' + entryKey=bookKey**（downloadId），使其能与本地 epub 成员
     // 共键折进合集。importedAt 用 `-1-index`：全为负，稳定排在所有本地条目（正毫秒戳）之后，
     // 组内保持远端目录序（spec §2.1「无本地 importedAt/lastReadAt 时目录序退化」）。
+    // 纯 SRT 远端有声书占位混入：mediaType='srt' + entryKey=uid，与本地 SRT 成员及
+    // 已同步的合集成员（entryKey=uid）**同键**，故经现有 _primaryCollectionByEntry 就能
+    // 折进合集（无需 epub 那样的 downloadId≠bookKey 回填）。importedAt 负值排本地之后。
+    for (int i = 0; i < remoteSrtBooks.length; i++) {
+      shelfItems.add(
+        CollectionOrderingItem<_ShelfBookSlot>(
+          mediaType: 'srt',
+          entryKey: remoteSrtBooks[i].identity,
+          importedAt: -1 - remoteBooks.length - i,
+          payload: _ShelfBookSlot(remoteSrt: remoteSrtBooks[i]),
+        ),
+      );
+    }
     for (int i = 0; i < remoteBooks.length; i++) {
       shelfItems.add(
         CollectionOrderingItem<_ShelfBookSlot>(
@@ -1263,8 +1286,10 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     // #5：行头计数只数**本地成员**（远端占位不入 n），与合集详情页口径一致（详情页只显示
     // 本地成员）。当前书侧合集成员本就全是本地（远端占位卡不进合集，见 _buildShelfMemberCard），
     // 此过滤是防御性对齐口径；行体（itemCount）仍渲染 group.items 全部。
-    final int localCount =
-        group.items.where((it) => it.payload.remote == null).length;
+    final int localCount = group.items
+        .where((it) =>
+            it.payload.remote == null && it.payload.remoteSrt == null)
+        .length;
     return Padding(
       // 水平不加 padding：书卡自带 12px 内边距，与网格散卡左缘逐像素对齐。
       padding: EdgeInsets.symmetric(
@@ -1311,9 +1336,12 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     Map<String, String> epubCoverUrisByBookKey, {
     bool selectable = true,
   }) {
-    // 远端占位卡不进合集（本批无合集归属），此分支纯防御避免 epub! 空断言。
+    // 远端占位卡（EPUB / 纯 SRT）现可折进合集（经已同步的合集成员归属），成员卡也要
+    // 分派到远端占位渲染，否则命中下面的 epub! 空断言。
     final RemoteBookInfo? remote = slot.remote;
     if (remote != null) return _buildRemoteBookCard(remote);
+    final RemoteAudiobookInfo? remoteSrt = slot.remoteSrt;
+    if (remoteSrt != null) return _buildRemoteSrtCard(remoteSrt);
     final SrtBook? srt = slot.srt;
     if (srt != null) {
       return _buildSrtCard(srt,
@@ -1339,6 +1367,10 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
       final RemoteBookInfo? remote = slot.remote;
       if (remote != null) {
         return _buildRemoteBookCard(remote);
+      }
+      final RemoteAudiobookInfo? remoteSrt = slot.remoteSrt;
+      if (remoteSrt != null) {
+        return _buildRemoteSrtCard(remoteSrt);
       }
       final SrtBook? srt = slot.srt;
       if (srt != null) {
@@ -1372,9 +1404,12 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     _ShelfBookSlot slot,
     Map<String, String> epubCoverUrisByBookKey,
   ) {
-    // 远端占位卡不进合集折叠堆叠封面（本批无合集归属），此分支纯防御。
+    // 远端占位卡的堆叠封面：EPUB 用远端封面，纯 SRT 用占位图标（无远端封面来源）。
     final RemoteBookInfo? remote = slot.remote;
     if (remote != null) return _buildRemoteBookCover(remote);
+    if (slot.remoteSrt != null) {
+      return _coverPlaceholderIcon(Icons.headphones_outlined);
+    }
     final SrtBook? srt = slot.srt;
     if (srt != null) {
       return _buildSrtCover(
@@ -1702,9 +1737,15 @@ class _ShelfBookSlot {
     this.srt,
     this.epub,
     this.remote,
+    this.remoteSrt,
   });
 
   final SrtBook? srt;
   final MediaItem? epub;
   final RemoteBookInfo? remote;
+
+  /// 纯 SRT（standalone）远端有声书占位卡（互联后端 listRemoteAudiobooks 的
+  /// standalone 项，本地尚无同 uid 的 SrtBook）。与 [remote] 同为「远端占位」，无本地
+  /// 阅读进度，排在本地条目之后；下载后原地变本地 SRT 卡。
+  final RemoteAudiobookInfo? remoteSrt;
 }

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -263,7 +263,29 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
   }
 
   @override
+  void initState() {
+    super.initState();
+    // 后台同步（关书后 / 启动）把合集成员落库后，只会 refreshTab() 通知本 tab；但
+    // 折叠映射（_collectionsById / _primaryCollectionByEntry / _memberSortIndex）走
+    // 非响应式的 _shelfMapsFuture，只在首帧 `??=` 懒加载一次，父 setState 不会让它
+    // 重跑（本 State 存活、future 非 null）。这里显式监听刷新信号重载映射，使后台
+    // 合集同步落库后书架立即成组（否则合集不渲染，直到重启 app）。
+    mediaType.tabRefreshNotifier.addListener(_reloadShelfMapsOnTabRefresh);
+  }
+
+  /// tabRefreshNotifier 回调：重载书架合集折叠映射。后台合集同步（仅
+  /// collectionsUpdated>0）现也触发 refreshTab（[AppModel.refreshAfterSyncRun]），
+  /// 落到这里重载 _shelfMapsFuture，让新同步进来的合集成员立即成组。
+  void _reloadShelfMapsOnTabRefresh() {
+    if (!mounted) return;
+    setState(() {
+      _shelfMapsFuture = _loadShelfMaps();
+    });
+  }
+
+  @override
   void dispose() {
+    mediaType.tabRefreshNotifier.removeListener(_reloadShelfMapsOnTabRefresh);
     assert(() {
       ReaderHibikiHistoryPage.debugOpenBook = null;
       return true;
@@ -1012,16 +1034,31 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     final Map<String, int> memberSortIndex =
         Map<String, int>.of(_memberSortIndex);
     for (final RemoteBookInfo book in remoteBooks) {
-      final RemoteCollectionMembership? membership = book.collection;
-      if (membership == null) continue;
-      final int? cid = _resolveLocalCollectionId(
-        membership.collectionName,
-        membership.collectionType,
-      );
-      if (cid == null) continue; // 归属解析不到本地合集 → 散卡降级
       final String key = 'epub|${book.downloadId}';
+      final RemoteCollectionMembership? membership = book.collection;
+      if (membership != null) {
+        // 互联/host 路径：host 下发 RemoteBookInfo.collection，按 (name,type) 解析
+        // 本地合集 id 注入折叠归属。
+        final int? cid = _resolveLocalCollectionId(
+          membership.collectionName,
+          membership.collectionType,
+        );
+        if (cid == null) continue; // 归属解析不到本地合集 → 散卡降级
+        primaryByEntry[key] = cid;
+        memberSortIndex[key] = membership.sortIndex;
+        continue;
+      }
+      // 云盘后端（CloudRemoteBookClient）没有 host 实时库 API，不下发 collection
+      // 字段。但合集成员已由 collection_sync_engine 落进本地 MediaCollectionItems
+      // （entryKey = 本地 bookKey = sanitizeTtuFilename(title)）。远端占位卡的 title
+      // 与本地书同名，故用其本地等价 bookKey 回查已同步的折叠归属注入——云盘远端书
+      // 也能折进对应合集行（否则云盘合集永远不成组，BUG：云盘书架合集不渲染）。
+      final String localKey = 'epub|${sanitizeTtuFilename(book.title)}';
+      final int? cid = _primaryCollectionByEntry[localKey];
+      if (cid == null) continue; // 本地无已同步的合集归属 → 散卡降级
       primaryByEntry[key] = cid;
-      memberSortIndex[key] = membership.sortIndex;
+      final int? sidx = _memberSortIndex[localKey];
+      if (sidx != null) memberSortIndex[key] = sidx;
     }
     final List<CollectionGroup<_ShelfBookSlot>> shelfGroups =
         groupByCollections<_ShelfBookSlot>(

--- a/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
@@ -44,12 +44,18 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
           localBooks.map((EpubBookRow r) => r.bookKey).toSet();
       final List<RemoteBookInfo> withContent =
           books.where((RemoteBookInfo book) => book.hasContent).toList();
+      // 纯 SRT（standalone）远端有声书：仅互联后端有 live 有声书 API。列出对端全部
+      // 有声书，只留 standalone（bookKey 空、身份=uid）且本地无同 uid SrtBook 的项，
+      // 作为可下载占位卡。云盘后端无此 API → 空列表（占位卡不出现，与能力边界一致）。
+      final List<RemoteAudiobookInfo> remoteSrt =
+          await _loadStandaloneRemoteSrtAudiobooks(client);
       return _RemoteBookState(
         books: dedupeRemoteBooks(
           remote: withContent,
           localBookKeys: localKeys,
           keyOf: sanitizeTtuFilename,
         ),
+        srtAudiobooks: remoteSrt,
       );
     } catch (e) {
       // spec §2.4 离线语义：拉取失败 → 占位卡不出现（failed 门控），只剩本地库。
@@ -497,6 +503,167 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
     }
   }
 
+  /// 拉取对端「纯 SRT（standalone）有声书」清单：仅互联后端有 live 有声书 API，
+  /// 只留 standalone（bookKey 空、身份=uid）且本地无同 uid SrtBook 的项作占位卡。
+  /// 云盘后端无此能力 → 空列表（占位卡不出现，与真实能力边界一致，不静默 fail-open）。
+  Future<List<RemoteAudiobookInfo>> _loadStandaloneRemoteSrtAudiobooks(
+    RemoteBookClient client,
+  ) async {
+    if (client is! HibikiClientSyncBackend) {
+      return const <RemoteAudiobookInfo>[];
+    }
+    List<RemoteAudiobookInfo> all;
+    try {
+      all = await client.listRemoteAudiobooks();
+    } catch (e) {
+      debugPrint('[reader-shelf] remote audiobook list failed: $e');
+      return const <RemoteAudiobookInfo>[];
+    }
+    final List<SrtBookRow> localSrt = await appModel.database.getAllSrtBooks();
+    final Set<String> localUids =
+        localSrt.map((SrtBookRow r) => r.uid).toSet();
+    return <RemoteAudiobookInfo>[
+      for (final RemoteAudiobookInfo ab in all)
+        if (ab.isStandaloneSrt &&
+            ab.identity.isNotEmpty &&
+            !localUids.contains(ab.identity))
+          ab,
+    ];
+  }
+
+  /// 纯 SRT 远端有声书占位卡：耳机类型徽章 + 云角标 + 下载按钮/进度。短按/下载按钮
+  /// 走 [_downloadRemoteSrtAudiobook]（拉包 → importAudioDatabasePackage 纯 SRT 分支
+  /// → 落 SrtBooks 行），完成后原地变本地 SRT 卡（重拉远端列表按 uid dedup 隐藏占位）。
+  Widget _buildRemoteSrtCard(RemoteAudiobookInfo book) {
+    final String title = book.title ?? book.identity;
+    final String safeKey = _safeRemoteBookKey(title);
+    final String dlKey = 'srt:${book.identity}';
+    final bool downloading = _downloadingBooks.containsKey(dlKey);
+    final ColorScheme cs = theme.colorScheme;
+    return _bookCardShell(
+      slotAspectRatio: kShelfBookCardAspectRatio,
+      cardKey: ValueKey<String>('remote_srt_card_$safeKey'),
+      focusId: HibikiFocusId('reader-shelf-remote-srt-$safeKey'),
+      onTap: () => _downloadRemoteSrtAudiobook(book),
+      // 长按 / 右键：与短按同为下载入口（远端占位卡无本地副本，唯一动作是下载；
+      // 内部已对同 identity 重复下载去重）。
+      onLongPress: () => _downloadRemoteSrtAudiobook(book),
+      child: _bookCardLayout(
+        title: title,
+        cover: Stack(
+          fit: StackFit.expand,
+          children: <Widget>[
+            _coverPlaceholderIcon(Icons.headphones_outlined),
+            PositionedDirectional(
+              bottom: 6,
+              start: 6,
+              child: _remoteCloudBadge(
+                key: ValueKey<String>('remote_srt_cloud_badge_$safeKey'),
+              ),
+            ),
+          ],
+        ),
+        leadingBadge: KeyedSubtree(
+          key: ValueKey<String>('remote_srt_type_badge_$safeKey'),
+          child: _cardBadge(
+            icon: Icons.headphones_outlined,
+            background: cs.secondaryContainer,
+            foreground: cs.onSecondaryContainer,
+          ),
+        ),
+        coverBadge: downloading
+            ? RemoteDownloadProgressBadge(
+                key: ValueKey<String>('remote_srt_downloading_$safeKey'),
+                progress: _downloadingBooks[dlKey],
+                tooltip: t.remote_book_downloading,
+              )
+            : IconButton.filledTonal(
+                key: ValueKey<String>('remote_srt_download_$safeKey'),
+                tooltip: t.remote_book_download,
+                iconSize: 18,
+                visualDensity: VisualDensity.compact,
+                icon: const Icon(Icons.download_outlined),
+                onPressed: () => _downloadRemoteSrtAudiobook(book),
+              ),
+      ),
+    );
+  }
+
+  /// 下载纯 SRT 远端有声书：`getRemoteAudiobook(identity=uid)` 拉 `.hibikiaudio` 包 →
+  /// `importAudioDatabasePackage` 纯 SRT 分支落 SrtBooks 行（bookKey 恒空、cue 走 uid）。
+  /// 只互联后端可达（云盘无 live 有声书 API）。完成后刷新书架（占位卡按 uid dedup 隐藏）。
+  Future<void> _downloadRemoteSrtAudiobook(RemoteAudiobookInfo book) async {
+    final RemoteBookClient? client = _remoteBookClient;
+    if (client is! HibikiClientSyncBackend) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.remote_book_unavailable)),
+      );
+      return;
+    }
+    final String dlKey = 'srt:${book.identity}';
+    if (_downloadingBooks.containsKey(dlKey)) return;
+    _rebuild(() => _downloadingBooks[dlKey] = null);
+    File? audioTmp;
+    try {
+      audioTmp = await _remoteSrtDestination(book);
+      await client.getRemoteAudiobook(
+        book.identity,
+        audioTmp,
+        onProgress: (double progress) {
+          if (!mounted) return;
+          _rebuild(() => _downloadingBooks[dlKey] = progress);
+        },
+      );
+      await SyncAssetPackageService(db: appModel.database)
+          .importAudioDatabasePackage(
+        packageFile: audioTmp,
+        audioDatabaseRoot: _audiobookDatabaseRoot(),
+        // 纯 SRT 包无 audiobook 段：importAudioDatabasePackage 走 standalone 分支、
+        // 忽略 bookKeyOverride，bookKey 保持空、身份=uid。
+      );
+    } catch (e, stack) {
+      ErrorLogService.instance
+          .log('ReaderHibikiHistoryPage.downloadRemoteSrtAudiobook', e, stack);
+      if (audioTmp != null) {
+        try {
+          if (audioTmp.existsSync()) audioTmp.deleteSync();
+        } catch (_) {/* best-effort */}
+      }
+      if (mounted) {
+        _rebuild(() => _downloadingBooks.remove(dlKey));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(t.remote_book_download_failed)),
+        );
+      } else {
+        _downloadingBooks.remove(dlKey);
+      }
+      return;
+    }
+    try {
+      if (audioTmp.existsSync()) audioTmp.deleteSync();
+    } catch (_) {/* best-effort */}
+    if (!mounted) {
+      _downloadingBooks.remove(dlKey);
+      return;
+    }
+    _rebuild(() => _downloadingBooks.remove(dlKey));
+    _refreshSrtBooks(); // 失效本地 SRT provider + 重拉远端（按 uid dedup 隐藏占位）
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(t.remote_book_downloaded)),
+    );
+  }
+
+  /// 纯 SRT 有声书包下载临时目标文件（`.hibikiaudio`）。
+  Future<File> _remoteSrtDestination(RemoteAudiobookInfo book) async {
+    final Directory temp = await getTemporaryDirectory();
+    final Directory dir =
+        Directory(p.join(temp.path, 'hibiki_remote_audiobooks'));
+    await dir.create(recursive: true);
+    final String safeKey = _safeRemoteBookKey(book.title ?? book.identity);
+    return File(p.join(dir.path, 'srt_$safeKey.hibikiaudio'));
+  }
+
   /// 有声书包下载临时目标文件（`.hibikiaudio`）。
   Future<File> _remoteAudiobookDestination(RemoteBookInfo book) async {
     final Directory temp = await getTemporaryDirectory();
@@ -559,10 +726,15 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
 class _RemoteBookState {
   const _RemoteBookState({
     required this.books,
+    this.srtAudiobooks = const <RemoteAudiobookInfo>[],
     this.failed = false,
   });
 
   final List<RemoteBookInfo> books;
+
+  /// 纯 SRT（standalone）远端有声书（互联后端 listRemoteAudiobooks 的 standalone 项，
+  /// 本地无同 uid 的 SrtBook）。云盘后端无 live 有声书 API → 恒空。
+  final List<RemoteAudiobookInfo> srtAudiobooks;
 
   /// 远端目录拉取失败（离线/未配对/后端不可达）：占位卡不渲染（spec §2.4）。
   final bool failed;

--- a/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
@@ -81,6 +81,9 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
     final Future<_RemoteBookState?> future = _loadRemoteBooks();
     _rebuild(() {
       _remoteBooksFuture = future;
+      // 合集折叠映射也一并重载：下拉刷新前若后台同步落了新合集成员，只失效书列表
+      // 而不重载 _shelfMapsFuture 会让新成员仍不成组（合集不渲染）。
+      _shelfMapsFuture = _loadShelfMaps();
     });
     await future;
   }

--- a/hibiki/lib/src/sync/app_model_library_host_service.dart
+++ b/hibiki/lib/src/sync/app_model_library_host_service.dart
@@ -566,42 +566,91 @@ class AppModelLibraryHostService implements HibikiLibraryHostService {
   }
 
   /// host 当前可导出的有声书清单。
+  ///
+  /// 两类：
+  /// - **srt-backed**（既有 Audiobooks 又有 SrtBooks 行）：身份键 = bookKey（不变）。
+  /// - **纯 SRT（standalone）有声书**（SrtBooks 行 bookKey 为空、无 Audiobooks 行）：
+  ///   身份键 = uid。旧枚举只遍历 Audiobooks 表，完全遗漏这类书 → 无法跨设备下载。
   @override
   Future<List<RemoteAudiobookInfo>> listAudiobooks() async {
     final List<AudiobookRow> rows = await _db.getAllAudiobooks();
     final List<RemoteAudiobookInfo> result = <RemoteAudiobookInfo>[];
+    final Set<String> emittedUids = <String>{};
     for (final AudiobookRow r in rows) {
       final SrtBookRow? srt = await _db.getSrtBookByBookKey(r.bookKey);
       if (srt == null) continue;
-      result.add(RemoteAudiobookInfo(bookKey: r.bookKey, title: srt.title));
+      result.add(RemoteAudiobookInfo(
+        bookKey: r.bookKey,
+        uid: srt.uid,
+        title: srt.title,
+      ));
+      emittedUids.add(srt.uid);
+    }
+    // 纯 SRT（standalone）有声书：bookKey 为空、不落 Audiobooks 行，身份 = uid。
+    final List<SrtBookRow> srtRows = await _db.getAllSrtBooks();
+    for (final SrtBookRow srt in srtRows) {
+      if (srt.bookKey.isNotEmpty) continue; // srt-backed 已在上面枚举
+      if (!emittedUids.add(srt.uid)) continue; // 去重（防重复 uid）
+      result.add(RemoteAudiobookInfo(
+        bookKey: '',
+        uid: srt.uid,
+        title: srt.title,
+      ));
     }
     return result;
   }
 
-  /// 即时把 bookKey 为 [bookKey] 的有声书打包成临时文件，返回该文件。
+  /// 即时把身份键为 [identity] 的有声书打包成临时文件，返回该文件。
   /// 调用方负责删除返回的临时文件（及其父临时目录）。
-  /// [bookKey] 含路径穿越字符时抛 [ArgumentError]；
-  /// 找不到有声书（Audiobooks 行或 SrtBooks 行缺失）时抛 [StateError]。
+  ///
+  /// [identity] 解析：先按 bookKey 查 Audiobooks（srt-backed），命中即打含 audiobook
+  /// 段的包；否则按 uid 查 SrtBooks（纯 SRT standalone），命中即打无 audiobook 段的
+  /// 纯 SRT 包。两者都查不到抛 [StateError]。含路径穿越字符时抛 [ArgumentError]。
   @override
-  Future<File> exportAudiobook(String bookKey) async {
-    _assertSafeName(bookKey);
+  Future<File> exportAudiobook(String identity) async {
+    _assertSafeName(identity);
 
-    final AudiobookRow? ab = await _db.getAudiobookByBookKey(bookKey);
-    if (ab == null) {
-      throw StateError('audiobook not found for bookKey: $bookKey');
-    }
-    final SrtBookRow? srt = await _db.getSrtBookByBookKey(bookKey);
-    if (srt == null) {
-      throw StateError('srtBook not found for bookKey: $bookKey');
+    // srt-backed：identity = bookKey，Audiobooks 行 + SrtBooks 行齐备。
+    final AudiobookRow? ab = await _db.getAudiobookByBookKey(identity);
+    if (ab != null) {
+      final SrtBookRow? srt = await _db.getSrtBookByBookKey(identity);
+      if (srt == null) {
+        throw StateError('srtBook not found for bookKey: $identity');
+      }
+      return _packAudiobook(
+        identity: identity,
+        srtBookUid: srt.uid,
+        bookKey: identity,
+      );
     }
 
+    // 纯 SRT（standalone）：identity = uid，无 Audiobooks 行，bookKey 空。
+    final SrtBookRow? srtStandalone = await _db.getSrtBookByUid(identity);
+    if (srtStandalone != null) {
+      return _packAudiobook(
+        identity: identity,
+        srtBookUid: identity,
+        bookKey: null, // 无 Audiobooks 行 → 打纯 SRT 包
+      );
+    }
+
+    throw StateError('audiobook not found for identity: $identity');
+  }
+
+  /// 打包成 `<identity>.hibikiaudio` 临时文件（srt-backed 传 [bookKey]；纯 SRT 传
+  /// null，包管线据此省略 audiobook 段、cue 走 uid 命名空间）。
+  Future<File> _packAudiobook({
+    required String identity,
+    required String srtBookUid,
+    required String? bookKey,
+  }) async {
     final Directory tmpDir =
         Directory.systemTemp.createTempSync('hibiki_audiobook_export');
-    final File out = File(p.join(tmpDir.path, '$bookKey.hibikiaudio'));
+    final File out = File(p.join(tmpDir.path, '$identity.hibikiaudio'));
     await _packages.exportAudioDatabasePackage(
-      bookKey: bookKey,
-      srtBookUid: srt.uid,
+      srtBookUid: srtBookUid,
       outputFile: out,
+      bookKey: bookKey,
     );
     return out;
   }
@@ -610,9 +659,11 @@ class AppModelLibraryHostService implements HibikiLibraryHostService {
   /// `Audiobooks` 行查询，不触发 [exportAudiobook] 的整包打包 zip I/O。与
   /// [putAudiobookPosition] 自身用的存在性闸门同一查询。
   @override
-  Future<bool> audiobookExists(String bookKey) async {
-    _assertSafeName(bookKey);
-    return await _db.getAudiobookByBookKey(bookKey) != null;
+  Future<bool> audiobookExists(String identity) async {
+    _assertSafeName(identity);
+    if (await _db.getAudiobookByBookKey(identity) != null) return true;
+    // 纯 SRT standalone：无 Audiobooks 行，按 uid 查 SrtBooks。
+    return await _db.getSrtBookByUid(identity) != null;
   }
 
   /// 把有声书包文件导入 host（解包写 DB + 音频文件）。
@@ -643,35 +694,47 @@ class AppModelLibraryHostService implements HibikiLibraryHostService {
     _assertSafeName(bookKey);
     await _runExclusive(() async {
       final AudiobookRow? ab = await _db.getAudiobookByBookKey(bookKey);
-      if (ab == null) return; // 幂等：不存在则静默跳过
+      if (ab != null) {
+        // 先取 audioRoot，再删 DB 行（磁盘清理在 DB 删除后，同 deleteBook 顺序）。
+        final String? audioRoot = ab.audioRoot;
 
-      // 先取 audioRoot，再删 DB 行（磁盘清理在 DB 删除后，同 deleteBook 顺序）。
-      final String? audioRoot = ab.audioRoot;
-
-      // 删除 SrtBooks 行（按 bookKey），其关联的 SrtBook 级别 audioCues 由事务处理。
-      // getSrtBookByBookKey 先拿 uid，再用 deleteSrtBookByUid 级联删 audioCue 行。
-      final SrtBookRow? srt = await _db.getSrtBookByBookKey(bookKey);
-      if (srt != null) {
-        await _db.deleteSrtBookByUid(srt.uid);
-      }
-
-      // 删除 Audiobooks 行（及其 audioCues 级联，via deleteAudiobookByBookKey）。
-      await _db.deleteAudiobookByBookKey(bookKey);
-
-      // 磁盘音频目录。TODO-935 ①A：仅删 app 内部持久根下的复制目录，绝不递归删
-      // 用户「引用导入」的原始外部目录（按路径是否在 <appDoc>/audiobooks 之外派生）。
-      if (audioRoot != null && audioRoot.isNotEmpty) {
-        final String persistRoot = await AudiobookStorage.audiobooksRootDir();
-        final bool referenced = AudiobookStorage.isReferencedPath(
-          filePath: audioRoot,
-          persistRoot: persistRoot,
-        );
-        if (!referenced) {
-          final Directory dir = Directory(audioRoot);
-          if (dir.existsSync()) await dir.delete(recursive: true);
+        // 删除 SrtBooks 行（按 bookKey），其关联的 SrtBook 级别 audioCues 由事务处理。
+        // getSrtBookByBookKey 先拿 uid，再用 deleteSrtBookByUid 级联删 audioCue 行。
+        final SrtBookRow? srt = await _db.getSrtBookByBookKey(bookKey);
+        if (srt != null) {
+          await _db.deleteSrtBookByUid(srt.uid);
         }
+
+        // 删除 Audiobooks 行（及其 audioCues 级联，via deleteAudiobookByBookKey）。
+        await _db.deleteAudiobookByBookKey(bookKey);
+
+        await _deleteAudioRootIfPersisted(audioRoot);
+        return;
       }
+
+      // 纯 SRT standalone：identity = uid，无 Audiobooks 行。按 uid 删 SrtBooks 行
+      // （级联 uid 命名空间的 audioCues）+ 其持久音频目录。
+      final SrtBookRow? srt = await _db.getSrtBookByUid(bookKey);
+      if (srt == null) return; // 幂等：都不存在则静默跳过
+      final String? audioRoot = srt.audioRoot;
+      await _db.deleteSrtBookByUid(srt.uid);
+      await _deleteAudioRootIfPersisted(audioRoot);
     });
+  }
+
+  /// 删除 [audioRoot] 磁盘目录，但仅当它在 app 内部持久根（<appDoc>/audiobooks）下
+  /// —— 绝不递归删用户「引用导入」的原始外部目录（TODO-935 ①A）。
+  Future<void> _deleteAudioRootIfPersisted(String? audioRoot) async {
+    if (audioRoot == null || audioRoot.isEmpty) return;
+    final String persistRoot = await AudiobookStorage.audiobooksRootDir();
+    final bool referenced = AudiobookStorage.isReferencedPath(
+      filePath: audioRoot,
+      persistRoot: persistRoot,
+    );
+    if (!referenced) {
+      final Directory dir = Directory(audioRoot);
+      if (dir.existsSync()) await dir.delete(recursive: true);
+    }
   }
 
   /// 读 host 端有声书 [bookKey] 的播放断点（BUG-471）。真相源是
@@ -706,8 +769,14 @@ class AppModelLibraryHostService implements HibikiLibraryHostService {
     int positionMs,
     int updatedAtMs,
   ) async {
-    // host 库不存在该有声书 → no-op（防任意 client 上报任意 bookKey 写脏 prefs）。
-    if (await _db.getAudiobookByBookKey(bookKey) == null) return;
+    // host 库不存在该有声书 → no-op（防任意 client 上报任意 key 写脏 prefs）。
+    // srt-backed 按 bookKey 查 Audiobooks；纯 SRT standalone 按 uid 查 SrtBooks。
+    // 进度 pref key = audiobook_pos_<identity>：standalone 的 identity=uid 恰为
+    // SrtBook 进度键，故写穿即写到正确命名空间。
+    if (await _db.getAudiobookByBookKey(bookKey) == null &&
+        await _db.getSrtBookByUid(bookKey) == null) {
+      return;
+    }
     final ({int positionMs, int updatedAtMs}) current =
         await getAudiobookPosition(bookKey);
     final ({int positionMs, int updatedAtMs}) winner =

--- a/hibiki/lib/src/sync/hibiki_library_host_service.dart
+++ b/hibiki/lib/src/sync/hibiki_library_host_service.dart
@@ -51,22 +51,48 @@ LocalAudioSyncDiff computeLocalAudioSyncDiff({
 
 // ── 有声书包 ──────────────────────────────────────────────────────────────────
 
-/// host 实时有声书的清单条目（键 = bookKey）。
+/// host 实时有声书的清单条目。
 ///
-/// [bookKey] 即 `sanitizeTtuFilename(title)`，在 Audiobooks/SrtBooks/AudioCues 表
-/// 中均以此为外键，跨设备稳定一致。[title] 可选，供显示用（允许 null）。
+/// 两类有声书统一走本 DTO：
+/// - **srt-backed**（EPUB 配对）：[bookKey] 非空（= `sanitizeTtuFilename(title)`），
+///   在 Audiobooks/SrtBooks/AudioCues 表中以 bookKey 为外键；[uid] 是其 SrtBook 的
+///   uid（新增，供 client 落地时定位）。
+/// - **纯 SRT（standalone）有声书**：无 EPUB、无 Audiobooks 行、[bookKey] 为空，
+///   身份只能靠 SrtBook 的 [uid]（cue/进度/持久目录全在 uid 命名空间）。旧枚举完全
+///   遗漏这类书，无法跨设备下载/同步。
+///
+/// [identity] 是传输/URL 身份键：srt-backed 取 bookKey（向后兼容旧 client/host），
+/// 纯 SRT 取 uid。host 端按此键先查 Audiobooks(bookKey) 再查 SrtBooks(uid) 解析。
+/// [title] 可选，供显示用（允许 null）。
 class RemoteAudiobookInfo {
-  const RemoteAudiobookInfo({required this.bookKey, this.title});
+  const RemoteAudiobookInfo({required this.bookKey, this.uid, this.title});
 
   final String bookKey;
+
+  /// SrtBook uid。纯 SRT 有声书（[bookKey] 空）的唯一身份；srt-backed 也带上供
+  /// client 落地定位。旧 host 不下发此字段 → fromJson 得 null（向后兼容）。
+  final String? uid;
+
   final String? title;
 
-  Map<String, Object?> toJson() =>
-      <String, Object?>{'bookKey': bookKey, 'title': title};
+  /// 传输/URL 身份键：srt-backed=bookKey；纯 SRT（bookKey 空）=uid。
+  String get identity => bookKey.isNotEmpty ? bookKey : (uid ?? '');
+
+  /// 纯 SRT（standalone）有声书：无 EPUB 配对、无 Audiobooks 行、bookKey 为空。
+  bool get isStandaloneSrt => bookKey.isEmpty;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+        'bookKey': bookKey,
+        if (uid != null && uid!.isNotEmpty) 'uid': uid,
+        'title': title,
+      };
 
   static RemoteAudiobookInfo fromJson(Map<String, Object?> json) =>
       RemoteAudiobookInfo(
         bookKey: json['bookKey']?.toString() ?? '',
+        uid: (json['uid']?.toString().isNotEmpty ?? false)
+            ? json['uid']!.toString()
+            : null,
         title: json['title']?.toString(),
       );
 }

--- a/hibiki/lib/src/sync/sync_asset_package_service.dart
+++ b/hibiki/lib/src/sync/sync_asset_package_service.dart
@@ -103,14 +103,30 @@ class SyncAssetPackageService {
     );
   }
 
+  /// 打包一本有声书为 `.hibikiaudio`。支持两类：
+  /// - **srt-backed**（EPUB 配对）：[bookKey] 非空、host 有 Audiobooks 行 → manifest
+  ///   带 `audiobook` 段、cue 走 bookKey 命名空间（原行为，逐字节不变）。
+  /// - **纯 SRT（standalone）有声书**：无 Audiobooks 行（[bookKey] 省略或空）→
+  ///   manifest `audiobook` 段为 null、资源仅取 SrtBook 自身音频/字幕/封面、cue 走
+  ///   **uid** 命名空间（SrtBook cue 键）。这样纯 SRT 有声书也能跨设备打包下载。
+  ///
+  /// [bookKey] 可省略：省略时从 [srtBookUid] 对应 SrtBook 的 bookKey 派生（standalone
+  /// 该 bookKey 为空 → 纯 SRT 分支）。
   Future<File> exportAudioDatabasePackage({
-    required String bookKey,
     required String srtBookUid,
     required File outputFile,
+    String? bookKey,
   }) async {
-    final AudiobookRow audiobook = (await _db.getAudiobookByBookKey(bookKey))!;
     final SrtBookRow srtBook = (await _db.getSrtBookByUid(srtBookUid))!;
-    final List<AudioCueRow> cues = await _db.getCuesForBook(bookKey);
+    final String effectiveBookKey =
+        (bookKey != null && bookKey.isNotEmpty) ? bookKey : srtBook.bookKey;
+    // 纯 SRT：无 Audiobooks 行（effectiveBookKey 为空则连查都不查）。
+    final AudiobookRow? audiobook = effectiveBookKey.isNotEmpty
+        ? await _db.getAudiobookByBookKey(effectiveBookKey)
+        : null;
+    // cue 命名空间：srt-backed=bookKey（Audiobook cue）；纯 SRT=uid（SrtBook cue）。
+    final String cueKey = audiobook != null ? effectiveBookKey : srtBookUid;
+    final List<AudioCueRow> cues = await _db.getCuesForBook(cueKey);
     // TODO-1165：SRT 书标签名（标签每设备本地，跨设备按名带进 manifest）。
     final List<BookTagRow> srtTags = await _db.getTagsForSrtBook(srtBook.id);
     final List<File> files = _audioPackageFiles(audiobook, srtBook);
@@ -130,7 +146,8 @@ class SyncAssetPackageService {
     final String manifestJson = jsonEncode(<String, Object?>{
       'schemaVersion': 1,
       'kind': 'audioDatabase',
-      'audiobook': _audiobookManifest(audiobook),
+      // 纯 SRT 有声书无 Audiobooks 行 → audiobook 段为 null，导入端据此走纯 SRT 分支。
+      'audiobook': audiobook != null ? _audiobookManifest(audiobook) : null,
       'srtBook': <String, Object?>{
         ..._srtBookManifest(srtBook),
         if (srtTags.isNotEmpty)
@@ -166,9 +183,27 @@ class SyncAssetPackageService {
     if (manifest['kind'] != 'audioDatabase') {
       throw FormatException('Unexpected package kind: ${manifest['kind']}');
     }
-    final Map<String, Object?> audiobook = _mapValue(manifest, 'audiobook');
+    // 纯 SRT 有声书包 audiobook 段为 null（standalone，无 Audiobooks 行）；
+    // srt-backed 包才有 audiobook 段。据此分流，纯 SRT 走 uid 身份专用分支。
+    final Object? rawAudiobook = manifest['audiobook'];
+    final Map<String, Object?>? audiobook =
+        rawAudiobook is Map ? _typedMap(rawAudiobook) : null;
     final Map<String, Object?> srtBook = _mapValue(manifest, 'srtBook');
     final Map<String, Object?> resources = _mapValue(manifest, 'resources');
+
+    if (audiobook == null) {
+      // 纯 SRT（standalone）有声书：bookKey 恒空、身份=uid、cue 走 uid 命名空间。
+      // bookKeyOverride 对 standalone 无意义（其 bookKey 必须保持空），此处忽略。
+      await _importStandaloneSrtPackage(
+        packageFile: packageFile,
+        audioDatabaseRoot: audioDatabaseRoot,
+        srtBook: srtBook,
+        resources: resources,
+        cues: _listValue(manifest, 'cues'),
+      );
+      return;
+    }
+
     final String bookKey =
         bookKeyOverride ?? _stringValue(audiobook, 'bookKey');
     // The on-disk directory name must be filesystem-safe: a bookKey (sanitized
@@ -255,6 +290,85 @@ class SyncAssetPackageService {
         final Map<String, Object?> cue = _typedMap(raw);
         return AudioCuesCompanion.insert(
           bookKey: bookKey,
+          chapterHref: _stringValue(cue, 'chapterHref'),
+          sentenceIndex: _intValue(cue, 'sentenceIndex'),
+          textFragmentId: _stringValue(cue, 'textFragmentId'),
+          cueText: _stringValue(cue, 'cueText'),
+          startMs: _intValue(cue, 'startMs'),
+          endMs: _intValue(cue, 'endMs'),
+          audioFileIndex: _intValue(cue, 'audioFileIndex'),
+        );
+      }).toList(),
+    );
+  }
+
+  /// 导入纯 SRT（standalone）有声书包：无 Audiobooks 行，身份=uid，bookKey 恒空。
+  /// 与 srt-backed 分支的差异：不 upsert Audiobooks 行（否则造孤儿脏行）、持久目录
+  /// 与 cue 命名空间均用 uid、音频/字幕/封面全取自 srtBook 段（无 audiobook 段）。
+  Future<void> _importStandaloneSrtPackage({
+    required File packageFile,
+    required Directory audioDatabaseRoot,
+    required Map<String, Object?> srtBook,
+    required Map<String, Object?> resources,
+    required List<Object?> cues,
+  }) async {
+    final String uid = _stringValue(srtBook, 'uid');
+    // standalone 无 bookKey，持久目录键统一用 uid（与 AudiobookStorage 一致）。
+    final Directory targetDir =
+        Directory(p.join(audioDatabaseRoot.path, _safeDirName(uid)));
+
+    await _extractResourcesInIsolate(
+      packagePath: packageFile.path,
+      targetDirPath: targetDir.path,
+      prefix: 'resources',
+    );
+
+    final List<String> audioPaths = _stringList(srtBook, 'audioPaths')
+        .map((String path) =>
+            p.join(targetDir.path, _resourceName(resources, path)))
+        .toList();
+
+    await _db.upsertSrtBook(SrtBooksCompanion.insert(
+      uid: uid,
+      title: _stringValue(srtBook, 'title'),
+      author: Value(_nullableString(srtBook, 'author')),
+      audioRoot: Value(targetDir.path),
+      audioPathsJson: Value(jsonEncode(audioPaths)),
+      srtPath: p.join(
+        targetDir.path,
+        _resourceName(resources, _stringValue(srtBook, 'srtPath')),
+      ),
+      coverPath: Value(_nullablePathIn(targetDir, resources, srtBook, 'coverPath')),
+      importedAt: _intValue(srtBook, 'importedAt'),
+      bookKey: const Value(''), // standalone：bookKey 恒空（纯 SRT 身份判据）。
+    ));
+
+    // 标签（manifest 按名带来，只增不删；缺 'tags' 键的旧包安全降级空列表）。
+    final Object? rawSrtTags = srtBook['tags'];
+    final List<String> srtTagNames = rawSrtTags is List
+        ? <String>[
+            for (final Object? t in rawSrtTags)
+              if (t != null && t.toString().isNotEmpty) t.toString(),
+          ]
+        : const <String>[];
+    if (srtTagNames.isNotEmpty) {
+      final SrtBookRow? importedSrt = await _db.getSrtBookByUid(uid);
+      if (importedSrt != null) {
+        for (final String name in srtTagNames) {
+          if (name.isEmpty) continue;
+          final int tagId = await _db.getOrCreateTagByName(name);
+          await _db.addTagToSrtBook(importedSrt.id, tagId);
+        }
+      }
+    }
+
+    // 纯 SRT cue 键 = uid（SrtBook cue 命名空间，见 SrtBookRepository.cuesFor）。
+    await _db.replaceCuesForBook(
+      uid,
+      cues.map((Object? raw) {
+        final Map<String, Object?> cue = _typedMap(raw);
+        return AudioCuesCompanion.insert(
+          bookKey: uid,
           chapterHref: _stringValue(cue, 'chapterHref'),
           sentenceIndex: _intValue(cue, 'sentenceIndex'),
           textFragmentId: _stringValue(cue, 'textFragmentId'),
@@ -396,10 +510,11 @@ class SyncAssetPackageService {
 /// `ttu-42`) pass through unchanged.
 String _safeDirName(String id) => id.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_');
 
-List<File> _audioPackageFiles(AudiobookRow audiobook, SrtBookRow srtBook) {
+List<File> _audioPackageFiles(AudiobookRow? audiobook, SrtBookRow srtBook) {
   final List<String> paths = <String>[
-    ..._decodeStringList(audiobook.audioPathsJson),
-    audiobook.alignmentPath,
+    // 纯 SRT 无 Audiobooks 行：不含 audiobook 音频/对齐文件，仅取 SrtBook 自身资源。
+    if (audiobook != null) ..._decodeStringList(audiobook.audioPathsJson),
+    if (audiobook != null) audiobook.alignmentPath,
     ..._decodeStringList(srtBook.audioPathsJson),
     srtBook.srtPath,
     if (srtBook.coverPath != null) srtBook.coverPath!,

--- a/hibiki/lib/src/sync/sync_compare_dialog.dart
+++ b/hibiki/lib/src/sync/sync_compare_dialog.dart
@@ -756,7 +756,9 @@ class _SyncCompareDialogState extends State<SyncCompareDialog> {
     // 按 title 找到该书，用其真实 bookKey 下载——不要按书名重算 ttu 文件名（BUG-414）。
     String? remoteBookKey;
     for (final RemoteAudiobookInfo a in remote) {
-      if (a.title == entry.title) {
+      // 只匹配 srt-backed（bookKey 非空）：本函数是给 EPUB 书补音频，纯 SRT
+      // standalone 项（bookKey 空、身份=uid）不参与，避免同名误匹配到空 bookKey。
+      if (a.bookKey.isNotEmpty && a.title == entry.title) {
         remoteBookKey = a.bookKey;
         break;
       }

--- a/hibiki/lib/src/sync/sync_orchestrator.dart
+++ b/hibiki/lib/src/sync/sync_orchestrator.dart
@@ -1632,8 +1632,13 @@ class SyncOrchestrator {
     final Set<String> localKeys = <String>{
       for (final AudiobookRow ab in localAudiobooks) ab.bookKey,
     };
+    // 纯 SRT（standalone）远端有声书（bookKey 空、身份=uid）**不进自动 union**：与
+    // 远端独有 EPUB 一样是「手动下载才落地」（TODO-1291 / 书架远端占位卡），自动
+    // sweep 只处理 srt-backed（bookKey 非空）有声书文件补拉，避免把独有 standalone
+    // 书自动灌进对端，也避免空 bookKey 污染 diff。
     final Set<String> remoteKeys = <String>{
-      for (final RemoteAudiobookInfo r in remoteAudiobooks) r.bookKey,
+      for (final RemoteAudiobookInfo r in remoteAudiobooks)
+        if (r.bookKey.isNotEmpty) r.bookKey,
     };
     // 本端已有 EPUB 的 bookKey 集合：Pull 只对「本端有书但缺音频」的远端项动作，
     // 避免落下无 EpubBooks 行可绑的孤儿有声书（importAudioDatabasePackage 不建书行）。

--- a/hibiki/test/sync/hibiki_library_host_service_audio_test.dart
+++ b/hibiki/test/sync/hibiki_library_host_service_audio_test.dart
@@ -217,6 +217,124 @@ void main() {
       expect(info.bookKey, '');
       expect(info.title, isNull);
     });
+
+    test('srt-backed：identity=bookKey、非 standalone', () {
+      const RemoteAudiobookInfo info =
+          RemoteAudiobookInfo(bookKey: 'ttu-1', uid: 'u1', title: 'T');
+      expect(info.identity, 'ttu-1');
+      expect(info.isStandaloneSrt, isFalse);
+      final RemoteAudiobookInfo decoded =
+          RemoteAudiobookInfo.fromJson(info.toJson());
+      expect(decoded.uid, 'u1');
+      expect(decoded.identity, 'ttu-1');
+    });
+
+    test('纯 SRT standalone：bookKey 空 → identity=uid、isStandaloneSrt', () {
+      const RemoteAudiobookInfo info =
+          RemoteAudiobookInfo(bookKey: '', uid: 'srt-uid-9', title: 'S');
+      expect(info.identity, 'srt-uid-9');
+      expect(info.isStandaloneSrt, isTrue);
+      final RemoteAudiobookInfo decoded =
+          RemoteAudiobookInfo.fromJson(info.toJson());
+      expect(decoded.bookKey, '');
+      expect(decoded.uid, 'srt-uid-9');
+      expect(decoded.identity, 'srt-uid-9');
+      expect(decoded.isStandaloneSrt, isTrue);
+    });
+  });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // 纯 SRT（standalone）有声书：枚举 + 身份解析导出
+  // ══════════════════════════════════════════════════════════════════════════
+
+  group('纯 SRT standalone 有声书', () {
+    late HibikiDatabase db;
+    late Directory temp;
+
+    setUp(() async {
+      db = _memDb();
+      temp = await Directory.systemTemp.createTemp('hibiki-standalone-svc-');
+    });
+
+    tearDown(() async {
+      await db.close();
+      await temp.delete(recursive: true);
+    });
+
+    Future<void> insertStandalone(String uid, String title) async {
+      final Directory audioDir = Directory(p.join(temp.path, uid));
+      audioDir.createSync(recursive: true);
+      final File track = File(p.join(audioDir.path, 'voice.mp3'))
+        ..writeAsStringSync('a');
+      final File subs = File(p.join(audioDir.path, 'subs.srt'))
+        ..writeAsStringSync('1\n00:00:00,000 --> 00:00:01,000\nx\n');
+      await db.upsertSrtBook(SrtBooksCompanion.insert(
+        uid: uid,
+        title: title,
+        audioRoot: Value(audioDir.path),
+        audioPathsJson: Value(jsonEncode(<String>[track.path])),
+        srtPath: subs.path,
+        importedAt: 1,
+        bookKey: const Value(''),
+      ));
+    }
+
+    test('listAudiobooks 同时枚举 srt-backed 与 standalone', () async {
+      await _insertAudiobook(
+        db: db,
+        bookKey: 'ttu-42',
+        audioDir: Directory(p.join(temp.path, 'ab')),
+      );
+      await insertStandalone('srt-standalone-1', '纯字幕书');
+
+      final AppModelLibraryHostService svc = _buildSvc(db: db);
+      final List<RemoteAudiobookInfo> list = await svc.listAudiobooks();
+      final Map<String, RemoteAudiobookInfo> byIdentity = <String,
+          RemoteAudiobookInfo>{for (final RemoteAudiobookInfo a in list) a.identity: a};
+
+      expect(byIdentity.keys, containsAll(<String>['ttu-42', 'srt-standalone-1']));
+      expect(byIdentity['ttu-42']!.isStandaloneSrt, isFalse);
+      final RemoteAudiobookInfo standalone = byIdentity['srt-standalone-1']!;
+      expect(standalone.isStandaloneSrt, isTrue);
+      expect(standalone.bookKey, '');
+      expect(standalone.uid, 'srt-standalone-1');
+      expect(standalone.title, '纯字幕书');
+    });
+
+    test('audiobookExists(uid) 对 standalone 为 true', () async {
+      await insertStandalone('srt-x', 'X');
+      final AppModelLibraryHostService svc = _buildSvc(db: db);
+      expect(await svc.audiobookExists('srt-x'), isTrue);
+      expect(await svc.audiobookExists('nonexistent'), isFalse);
+    });
+
+    test('exportAudiobook(uid) 打纯 SRT 包（无 audiobook 段）并可导入落 SrtBook',
+        () async {
+      await insertStandalone('srt-standalone-2', 'Standalone2');
+      final AppModelLibraryHostService svc = _buildSvc(db: db);
+
+      final File pkg = await svc.exportAudiobook('srt-standalone-2');
+      addTearDown(() {
+        try {
+          pkg.parent.deleteSync(recursive: true);
+        } catch (_) {}
+      });
+
+      final HibikiDatabase targetDb = _memDb();
+      addTearDown(targetDb.close);
+      final Directory targetAudio = Directory(p.join(temp.path, 'target'));
+      await SyncAssetPackageService(db: targetDb).importAudioDatabasePackage(
+        packageFile: pkg,
+        audioDatabaseRoot: targetAudio,
+        bookKeyOverride: 'srt-standalone-2', // server 会传 identity，须被忽略
+      );
+
+      expect(await targetDb.getAllAudiobooks(), isEmpty);
+      final SrtBookRow srt =
+          (await targetDb.getSrtBookByUid('srt-standalone-2'))!;
+      expect(srt.bookKey, '');
+      expect(srt.title, 'Standalone2');
+    });
   });
 
   // ══════════════════════════════════════════════════════════════════════════

--- a/hibiki/test/sync/sync_asset_package_service_test.dart
+++ b/hibiki/test/sync/sync_asset_package_service_test.dart
@@ -229,6 +229,109 @@ void main() {
       expect(srt.coverPath, p.join(targetAudio.path, 'ttu-42', 'cover.jpg'));
     });
 
+    test('standalone (pure SRT) audiobook round trips without an Audiobooks row',
+        () async {
+      // 纯 SRT（standalone）有声书：SrtBooks 行 bookKey 为空、无 Audiobooks 行，
+      // 身份=uid、cue 走 uid 命名空间。导出无 audiobook 段、导入不造孤儿 Audiobooks 行。
+      final Directory temp =
+          await Directory.systemTemp.createTemp('hibiki-audio-standalone-');
+      addTearDown(() => temp.delete(recursive: true));
+      final HibikiDatabase sourceDb = _testDb();
+      final HibikiDatabase targetDb = _testDb();
+      addTearDown(sourceDb.close);
+      addTearDown(targetDb.close);
+
+      final Directory sourceAudio =
+          Directory(p.join(temp.path, 'source-audio'));
+      await sourceAudio.create(recursive: true);
+      final File track = File(p.join(sourceAudio.path, 'voice.mp3'))
+        ..writeAsStringSync('standalone audio bytes');
+      final File subs = File(p.join(sourceAudio.path, 'subs.srt'))
+        ..writeAsStringSync('1\n00:00:00,000 --> 00:00:01,000\nこんにちは\n');
+      final File cover = File(p.join(sourceAudio.path, 'cover.png'))
+        ..writeAsStringSync('cover bytes');
+
+      // 无 Audiobooks 行；SrtBooks 行 bookKey 空。
+      await sourceDb.upsertSrtBook(SrtBooksCompanion.insert(
+        uid: 'srt-standalone-1',
+        title: 'Standalone SRT',
+        author: const Value('Voice Author'),
+        audioRoot: Value(sourceAudio.path),
+        audioPathsJson: Value(jsonEncode(<String>[track.path])),
+        srtPath: subs.path,
+        coverPath: Value(cover.path),
+        importedAt: 4242,
+        bookKey: const Value(''),
+      ));
+      // cue 走 uid 命名空间（SrtBook cue 键）。
+      await sourceDb.replaceCuesForBook(
+          'srt-standalone-1', <AudioCuesCompanion>[
+        AudioCuesCompanion.insert(
+          bookKey: 'srt-standalone-1',
+          chapterHref: 'srt',
+          sentenceIndex: 0,
+          textFragmentId: 'frag-0',
+          cueText: 'こんにちは',
+          startMs: 0,
+          endMs: 1000,
+          audioFileIndex: 0,
+        ),
+      ]);
+
+      // 不传 bookKey：从 SrtBook 派生（空）→ 纯 SRT 分支。
+      final File package = await SyncAssetPackageService(db: sourceDb)
+          .exportAudioDatabasePackage(
+        srtBookUid: 'srt-standalone-1',
+        outputFile: File(p.join(temp.path, 'standalone.hibikiaudio')),
+      );
+
+      // manifest 的 audiobook 段必须为 null（无 Audiobooks 行）。
+      final Archive archive =
+          ZipDecoder().decodeBytes(package.readAsBytesSync());
+      final ArchiveFile manifestFile = archive.findFile('manifest.json')!;
+      final Map<String, Object?> manifest =
+          (jsonDecode(utf8.decode(manifestFile.content as List<int>))
+              as Map<String, Object?>);
+      expect(manifest['audiobook'], isNull,
+          reason: '纯 SRT 包不带 audiobook 段');
+
+      final Directory targetAudio =
+          Directory(p.join(temp.path, 'target-audio'));
+      // 即便传 bookKeyOverride，纯 SRT 分支也必须忽略它（bookKey 恒空）。
+      await SyncAssetPackageService(db: targetDb).importAudioDatabasePackage(
+        packageFile: package,
+        audioDatabaseRoot: targetAudio,
+        bookKeyOverride: 'should-be-ignored',
+      );
+
+      // 关键：不得造出任何 Audiobooks 行。
+      expect(await targetDb.getAllAudiobooks(), isEmpty,
+          reason: '纯 SRT 导入不得造孤儿 Audiobooks 行');
+
+      final SrtBookRow srt =
+          (await targetDb.getSrtBookByUid('srt-standalone-1'))!;
+      expect(srt.bookKey, '', reason: 'standalone bookKey 恒空（忽略 override）');
+      expect(srt.title, 'Standalone SRT');
+      // 持久目录键 = uid。
+      expect(srt.srtPath,
+          p.join(targetAudio.path, 'srt-standalone-1', 'subs.srt'));
+      expect(srt.coverPath,
+          p.join(targetAudio.path, 'srt-standalone-1', 'cover.png'));
+      expect(jsonDecode(srt.audioPathsJson!) as List<dynamic>, <String>[
+        p.join(targetAudio.path, 'srt-standalone-1', 'voice.mp3'),
+      ]);
+      expect(
+          await File(p.join(targetAudio.path, 'srt-standalone-1', 'voice.mp3'))
+              .readAsString(),
+          'standalone audio bytes');
+
+      // cue 落在 uid 命名空间。
+      final List<AudioCueRow> cues =
+          await targetDb.getCuesForBook('srt-standalone-1');
+      expect(cues, hasLength(1));
+      expect(cues.single.cueText, 'こんにちは');
+    });
+
     test('large audio file survives STORE export + streaming import intact',
         () async {
       // 行为级证明 STORE 导出 + rawContent 流式导入对大文件往返字节一致。


### PR DESCRIPTION
## A. 书架合集不渲染（两处根因，非破坏性）
- **互联/远端**：后台合集专属同步（仅 `collectionsUpdated>0`）不触发书架刷新，且非响应式的 `_shelfMapsFuture` 只首帧懒加载一次。修：`refreshAfterSyncRun` 纳入 `collectionsUpdated` 触发 `refreshTab`；页面监听 `tabRefreshNotifier` 与下拉刷新时重载合集折叠映射。
- **云盘**：`CloudRemoteBookClient` 不下发 `collection`，远端书永不折进合集。修：用已同步的本地 `MediaCollectionItems`（`entryKey=sanitizeTtuFilename(title)`）回填折叠归属（无需给 client 塞 DB）。

## B. 纯 SRT（standalone）有声书下载（7 层）
纯 SRT 有声书（无 EPUB、无 Audiobooks 行、`bookKey` 空、身份=`uid`）此前每层被硬编码排除。统一身份模型：srt-backed 用 bookKey，纯 SRT 用 uid，经同一 `/api/library/audiobooks/<identity>` 路由，host 按 `bookKey→Audiobooks / uid→SrtBooks` 解析。srt-backed 路径逐字节不变（Never break userspace）。

1. **DTO** `RemoteAudiobookInfo`：加 `uid` + `identity` getter + `isStandaloneSrt`（向后兼容旧 host）。
2. **打包管线**：`audiobook` 段可空、cue 走 uid 命名空间、导入不造孤儿 Audiobooks 行、`bookKeyOverride` 对 standalone 忽略。
3. **host**：`listAudiobooks` 同时枚举 standalone；`exportAudiobook`/`audiobookExists`/`deleteAudiobook`/`putAudiobookPosition` 全按 identity 解析。
4. **server/client**：身份键透传，无需改动。
5. **书架**：新增纯 SRT 远端占位卡（耳机+云角标+下载），按 uid dedup，可折进已同步合集。
6. **自动 sweep + compare 对话框**：排除 standalone（manual-download-only，与 EPUB 独有书同策略 TODO-1291）。

## 验证
- `flutter analyze`（全包含 test）：No issues found。
- `flutter test`：新增纯 SRT 包 export/import 往返（断言无 Audiobooks 行 + bookKey 空 + cue 落 uid 命名空间）+ host 枚举/身份导出/existence 测试；相邻 sync audio 测试 79 项全绿。
- ⚠️ **待真机**：阅读器/导入/播放/书架类改动按项目规则需真实设备复测原始失败路径（书架合集渲染、纯 SRT 远端占位卡下载→落库→原地变本地卡），本 PR 尚未做设备验证。