### PR TITLE
fix(ui): 组合成系列图标区分收藏夹 + HibikiIconButton 显示 tooltip (BUG-804)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 785 条。点号进各自文件。
+> 共 786 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-804](bugs/BUG-804-multiselect-combine-icon-tooltip.md) | ✅ | ✅ | 多选栏组合成系列图标与收藏夹雷同且无tooltip |
 | [BUG-803](bugs/BUG-803-inline-gaiji-width.md) | ✅ | ✅ | 词典行内外字图标撑开相邻链接 |
 | [BUG-802](bugs/BUG-802-popup-copy-search-selection.md) | ✅ | ✅ | 查词弹窗选中后复制/搜索无效 |
 | [BUG-801](bugs/BUG-801-android-native-subtitleview-duplicate.md) | ✅ | ✅ | 安卓视频原生SubtitleView与可点浮层字幕重复(控制条显示时上下两条) |

--- a/docs/bugs/BUG-804-multiselect-combine-icon-tooltip.md
+++ b/docs/bugs/BUG-804-multiselect-combine-icon-tooltip.md
@@ -1,0 +1,14 @@
+## BUG-804 · 多选栏组合成系列图标与收藏夹雷同且无tooltip
+- **报告**：2026-07-14（用户：）
+- **真实性**：✅ 真 bug。两处独立缺陷叠加：
+  - **图标雷同**：多选（批量）操作栏的「组合成系列」按钮与页头「收藏夹」入口、合集卡叠层角标共用同一 `Icons.collections_bookmark_outlined`，肉眼无法区分。
+    - `hibiki/lib/src/pages/implementations/home_video_page.dart:2846`（组合成系列，旧值 `collections_bookmark_outlined`）
+    - `hibiki/lib/src/pages/implementations/reader_history/books.part.dart:382`（书架同款组合按钮，旧值同上）
+    - 对照入口：`home_video_page.dart:2388`（收藏夹 `t.collections`，保留 `collections_bookmark_outlined`）
+  - **无 tooltip**：`HibikiIconButton` 收到 `tooltip:` 后只喂给 `Semantics(label:)`（无障碍），从不生成 Material `Tooltip`，纯图标按钮悬停 / 长按无可见说明。
+    - 根因 `hibiki/lib/src/utils/components/hibiki_icon_button.dart`（原 260 / 292 行两处纯图标 return 只包 `Semantics`，无 `Tooltip`）
+- **[x] ① 已修复** — commit（见下）：
+  - 图标差异化：`home_video_page.dart` 与 `books.part.dart` 的组合按钮改用 `Icons.playlist_add`，与收藏夹的 `collections_bookmark_outlined` 区分（二者语义无关）。
+  - Tooltip：`hibiki_icon_button.dart` 新增 `_withTooltip()`，两条纯图标 return（宽点击区 / 普通图标）用 Material `Tooltip` 包裹（空 tooltip 不包裹，避免空浮层）；带可见文字的药丸形态无需再弹，不变。
+- **[x] ② 已加自动化测试** — `hibiki/test/widgets/hibiki_icon_button_test.dart`：新增 3 例——纯图标按钮包 Material `Tooltip` 且 message 正确、宽点击区同样包 `Tooltip`、空 tooltip 不生成 `Tooltip`。守住「纯图标按钮必有可见说明」这一系统性根因。
+- **备注**：图标雷同是一行视觉选择、无独立行为可 widget 断言（批量栏 widget 测试依赖 DB/native_assets，本机 native_assets 有 DLL 锁问题不稳定），故以 `HibikiIconButton` 的 Tooltip 生成守卫为主。核心改动经 `flutter analyze`（clean）+ 上述 3 例 + 既有 `HibikiIconButton` 点击/焦点/golden 测试验证；`Tooltip` 在 `dispose()` 内自取消定时器，不引入「tree 释放后 timer pending」。批量栏页级测试（含 DB）待真机 / CI 复测。

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -2843,7 +2843,9 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
                 key: const ValueKey<String>('home_video_batch_combine'),
                 enabled: canCombine,
                 onTap: _batchCombineIntoSeries,
-                icon: Icons.collections_bookmark_outlined,
+                // 组合成系列用 playlist_add，与页头「收藏夹」入口的
+                // collections_bookmark_outlined 区分开（二者语义无关，避免同图标歧义）。
+                icon: Icons.playlist_add,
                 tooltip: t.combine_into_series,
               ),
               SizedBox(width: tokens.spacing.gap / 2),

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -379,7 +379,9 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
                 key: const ValueKey<String>('reader_shelf_batch_combine'),
                 enabled: canCombine,
                 onTap: _batchCombineIntoSeries,
-                icon: Icons.collections_bookmark_outlined,
+                // 组合成系列用 playlist_add，与页头「收藏夹」入口的
+                // collections_bookmark_outlined 区分开（二者语义无关，避免同图标歧义）。
+                icon: Icons.playlist_add,
                 tooltip: t.combine_into_series,
               ),
               SizedBox(width: tokens.spacing.gap / 2),

--- a/hibiki/lib/src/utils/components/hibiki_icon_button.dart
+++ b/hibiki/lib/src/utils/components/hibiki_icon_button.dart
@@ -257,7 +257,7 @@ class _HibikiIconButtonState extends State<HibikiIconButton> {
           onPressed: enabled ? _handleTap : null,
         ),
       );
-      return _focusable(context, button);
+      return _focusable(context, _withTooltip(button));
     }
 
     Widget touchTarget = ColoredBox(
@@ -289,7 +289,16 @@ class _HibikiIconButtonState extends State<HibikiIconButton> {
         child: touchTarget,
       ),
     );
-    return _focusable(context, button);
+    return _focusable(context, _withTooltip(button));
+  }
+
+  /// 纯图标按钮（无可见文字）用 Material [Tooltip] 包裹，让鼠标悬停 / 长按能弹出
+  /// 用途说明——原先 [tooltip] 只喂给 [Semantics.label]（无障碍），屏幕上不可见，
+  /// 导致批量操作栏等纯图标按钮「放上去没说明」。带可见文字的药丸形态无需再弹，
+  /// 故不走此路径。空 [tooltip] 不包裹，避免弹出空浮层。
+  Widget _withTooltip(Widget child) {
+    if (widget.tooltip.isEmpty) return child;
+    return Tooltip(message: widget.tooltip, child: child);
   }
 
   Widget _focusable(BuildContext context, Widget button) {

--- a/hibiki/test/widgets/hibiki_icon_button_test.dart
+++ b/hibiki/test/widgets/hibiki_icon_button_test.dart
@@ -96,6 +96,49 @@ void main() {
       expect(find.byType(IconButton), findsOneWidget);
     });
 
+    // BUG-804：纯图标按钮（如批量操作栏）以前只把 tooltip 喂给 Semantics，屏幕上
+    // 悬停不弹说明。现用 Material [Tooltip] 包裹，鼠标悬停 / 长按可见用途。
+    testWidgets('plain icon button wraps in a Material Tooltip',
+        (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        HibikiIconButton(
+          icon: Icons.playlist_add,
+          tooltip: 'Combine',
+          onTap: () {},
+        ),
+      ));
+
+      final Tooltip tip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tip.message, 'Combine');
+    });
+
+    testWidgets('wide tap area icon button also wraps in a Material Tooltip',
+        (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        const HibikiIconButton(
+          icon: Icons.settings,
+          tooltip: 'Settings',
+          isWideTapArea: true,
+        ),
+      ));
+
+      final Tooltip tip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tip.message, 'Settings');
+    });
+
+    testWidgets('empty tooltip adds no Tooltip wrapper (no empty hover box)',
+        (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        HibikiIconButton(
+          icon: Icons.add,
+          tooltip: '',
+          onTap: () {},
+        ),
+      ));
+
+      expect(find.byType(Tooltip), findsNothing);
+    });
+
     testWidgets('registers with the focus root and activates on Enter',
         (tester) async {
       bool tapped = false;


### PR DESCRIPTION
## 问题（用户报告）
多选（批量）操作栏里有个图标与页头「收藏夹」入口**长得一模一样**，且鼠标悬停**没有说明**。

两个独立根因叠加：
1. **图标雷同**：批量栏「组合成系列」按钮与「收藏夹」入口、合集卡叠层角标共用同一 `Icons.collections_bookmark_outlined`。用户看到的那个其实是「组合成系列」，不是收藏夹。
2. **无 tooltip**：`HibikiIconButton` 收到 `tooltip:` 只喂给 `Semantics(label:)`（无障碍），从不生成 Material `Tooltip`，纯图标按钮悬停/长按无可见说明。

## 改动
- 批量栏「组合成系列」改用 `Icons.playlist_add`（video + reader shelf 两处），与收藏夹区分。
- `HibikiIconButton` 新增 `_withTooltip()`：两条纯图标 return 用 Material `Tooltip` 包裹（空 tooltip 不包裹）；带可见文字的药丸形态不变。

## 验证
- `flutter analyze`（全量）clean。
- `hibiki_icon_button_test.dart` 新增 3 例（纯图标/宽点击区包 Tooltip、空 tooltip 不包）+ 既有点击/焦点/golden 全绿（golden 无像素变化 → 无视觉回归）。
- `Tooltip` 在 dispose 内自取消定时器，不引入 timer-pending。
- 批量栏页级测试依赖 DB/native_assets，本机 native_assets 有 DLL 锁问题不稳定，待 CI/真机复测。

BUG-804（docs/bugs/BUG-804-multiselect-combine-icon-tooltip.md）。