### PR TITLE
fix(dictionary): remove residual inline gaiji spacing

### DIFF
--- a/docs/bugs/BUG-803-inline-gaiji-width.md
+++ b/docs/bugs/BUG-803-inline-gaiji-width.md
@@ -1,17 +1,18 @@
 ## BUG-803 · 词典行内外字图标撑开相邻链接
 
-- **报告**：2026-07-14（用户截图：明镜国語辞典第三版「以外」释义中的「以内」链接被推到右侧）。
+- **报告**：2026-07-14（用户两次截图：明镜国語辞典第三版「以外」释义中的「以内」链接被推到右侧；首修去掉 15em 宽度后仍残留 2em 空白）。
 - **真实性**：✅ 真 bug。沿用户本机真实词典数据解析到该行由无尺寸 SVG 外字
   `gaiji/対義語.svg` 和紧随其后的「以内」交叉引用组成；词典 `styles.css` 对外字容器声明
   `width: 15em !important; margin-inline-end: 2em`。渲染器在
   `hibiki/assets/popup/popup.js:1049-1054` 虽把无尺寸 SVG 识别为 1.2em 行内图标，但原来的
-  普通内联 `width:auto` 无法胜过词典的 `!important`，容器被撑到约 15em，链接随之右移。
+  普通内联 `width:auto` 无法胜过词典的 `!important`，容器被撑到约 15em；首修仅锁定宽度后，词典的 `margin-inline-end:2em` 仍留下约 40px 空白。
 - **[x] ① 已修复** — 仅对带 `gaiji` 结构化标记的无尺寸 SVG，把渲染器已经选定的
-  `width:auto` 提升为内联 important，守住“行内字形”的尺寸契约；普通图片、显式尺寸 SVG
+  `width:auto` 提升为内联 important，并把 `margin-inline-end` 锁为 `0!important`，完整守住“行内字形”的尺寸契约；普通图片、显式尺寸 SVG
   和词典其余自定义样式保持原行为。三份 popup JS 镜像同步更新（本提交）。
 - **[x] ② 已加自动化与真实引擎测试** —
   `hibiki/test/utils/misc/popup_asset_behavior_test.js` 锁定外字宽度优先级，并覆盖现有图片行为；
   `hibiki/integration_test/desktop_reader_css_dom_test.dart` 在真实 Windows WebView2 中加载生产
-  `dict-media.js`、`popup.js`、`popup.css` 和明镜原样的 15em 规则。实测图标宽度 24px、
-  「以内」距行首 64px、内联优先级为 important，目标内全部通过。
+  `dict-media.js`、`popup.js`、`popup.css` 和明镜原样的 15em/2em 规则。实测图标宽度 24px、
+  「以内」偏移 24px、与图标右缘间距 0px、计算外边距 0px，宽度与外边距优先级均为
+  important；直接几何断言避免宽松阈值再次漏掉残余空白。
 - **备注**：Windows 隔离测试使用独立测试根，与用户运行中的 Hibiki、用户词典数据完全隔离。

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -1051,6 +1051,7 @@ function createDefinitionImage(data, dictionary, exporting = false) {
         const isGaiji = nodeData?.class === 'gaiji' || Object.prototype.hasOwnProperty.call(nodeData || {}, 'gaiji');
         if (isGaiji) {
             imageContainer.style.setProperty('width', 'auto', 'important');
+            imageContainer.style.setProperty('margin-inline-end', '0', 'important');
         }
         imageContainer.style.minWidth = '1.2em';
         imageContainer.style.height = '1.2em';

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -1051,6 +1051,7 @@ function createDefinitionImage(data, dictionary, exporting = false) {
         const isGaiji = nodeData?.class === 'gaiji' || Object.prototype.hasOwnProperty.call(nodeData || {}, 'gaiji');
         if (isGaiji) {
             imageContainer.style.setProperty('width', 'auto', 'important');
+            imageContainer.style.setProperty('margin-inline-end', '0', 'important');
         }
         imageContainer.style.minWidth = '1.2em';
         imageContainer.style.height = '1.2em';

--- a/hibiki/integration_test/desktop_reader_css_dom_test.dart
+++ b/hibiki/integration_test/desktop_reader_css_dom_test.dart
@@ -108,8 +108,8 @@ void main() {
   });
 
   testWidgets(
-      'BUG-803: dimensionless inline gaiji ignores a dictionary 15em important '
-      'width in the live WebView engine', (WidgetTester tester) async {
+      'BUG-803: dimensionless inline gaiji ignores dictionary 15em width and '
+      '2em end margin in the live WebView engine', (WidgetTester tester) async {
     final String popupJs = await rootBundle.loadString('assets/popup/popup.js');
     final String popupCss =
         await rootBundle.loadString('assets/popup/popup.css');
@@ -189,8 +189,13 @@ void main() {
         return JSON.stringify({
           imageWidth: imageRect.width,
           referenceOffset: referenceRect.left - rowRect.left,
+          referenceGap: referenceRect.left - imageRect.right,
           computedWidth: getComputedStyle(imageContainer).width,
-          inlinePriority: imageContainer.style.getPropertyPriority('width')
+          computedMarginInlineEnd:
+            getComputedStyle(imageContainer).marginInlineEnd,
+          inlinePriority: imageContainer.style.getPropertyPriority('width'),
+          marginPriority:
+            imageContainer.style.getPropertyPriority('margin-inline-end')
         });
         } catch (error) {
           return JSON.stringify({
@@ -212,10 +217,16 @@ void main() {
     final double imageWidth = (geometry['imageWidth'] as num).toDouble();
     final double referenceOffset =
         (geometry['referenceOffset'] as num).toDouble();
+    final double referenceGap = (geometry['referenceGap'] as num).toDouble();
     expect(geometry['inlinePriority'], 'important');
+    expect(geometry['marginPriority'], 'important');
+    expect(geometry['computedMarginInlineEnd'], '0px');
     expect(imageWidth, lessThan(40),
         reason: '20px text should keep the inline gaiji near 1.2em, not 15em');
-    expect(referenceOffset, lessThan(100),
+    expect(referenceOffset, lessThan(40),
         reason: 'the adjacent 以内 link must remain next to the gaiji label');
+    expect(referenceGap.abs(), lessThan(1),
+        reason:
+            'dictionary margin-inline-end must not leave a gap after gaiji');
   });
 }

--- a/hibiki/test/utils/misc/popup_asset_behavior_test.js
+++ b/hibiki/test/utils/misc/popup_asset_behavior_test.js
@@ -468,10 +468,10 @@ function testExplicitContentImageDimensionsDefaultToPixelUnits() {
 }
 
 // BUG-803: Meikyo's structured-content CSS assigns `width: 15em !important`
-// to a dimensionless SVG gaiji container. The renderer identifies that image as
-// an inline glyph, so its intrinsic width must win the author stylesheet's
-// important declaration or the following antonym link is pushed far right.
-function testDimensionlessGaijiSvgLocksItsInlineWidth() {
+// and `margin-inline-end: 2em` to a dimensionless SVG gaiji container. The
+// renderer identifies that image as an inline glyph, so both layout dimensions
+// must stay renderer-owned or the following antonym link is pushed right.
+function testDimensionlessGaijiSvgLocksItsInlineMetrics() {
   const context = loadPopup();
   const node = context.createDefinitionImage(
     {
@@ -498,6 +498,16 @@ function testDimensionlessGaijiSvgLocksItsInlineWidth() {
     container.style.getPropertyPriority('width'),
     'important',
     'inline gaiji width must outrank dictionary CSS such as width:15em!important',
+  );
+  assert.equal(
+    container.style['margin-inline-end'],
+    '0',
+    'inline gaiji must neutralize dictionary spacing such as margin-inline-end:2em',
+  );
+  assert.equal(
+    container.style.getPropertyPriority('margin-inline-end'),
+    'important',
+    'inline gaiji spacing must remain renderer-owned',
   );
 }
 
@@ -1831,7 +1841,7 @@ testSanseidoEmAccentImageStaysInlineAndPointsAtDictionaryMedia();
 testGlossImageScrollWrapperIsInline();
 testLargeRasterImagesMarkedAsEmUseNaturalWidthAfterLoad();
 testExplicitContentImageDimensionsDefaultToPixelUnits();
-testDimensionlessGaijiSvgLocksItsInlineWidth();
+testDimensionlessGaijiSvgLocksItsInlineMetrics();
 testPixelImagesWithBadDeclaredAspectUseNaturalWidthAfterLoad();
 testTappingDefinitionImageOpensLightbox();
 testTapOnGlossaryTextSelectsWord();

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -1051,6 +1051,7 @@ function createDefinitionImage(data, dictionary, exporting = false) {
         const isGaiji = nodeData?.class === 'gaiji' || Object.prototype.hasOwnProperty.call(nodeData || {}, 'gaiji');
         if (isGaiji) {
             imageContainer.style.setProperty('width', 'auto', 'important');
+            imageContainer.style.setProperty('margin-inline-end', '0', 'important');
         }
         imageContainer.style.minWidth = '1.2em';
         imageContainer.style.height = '1.2em';


### PR DESCRIPTION
## What changed

- Follow up merged PR #108 by neutralizing Meikyo's remaining `margin-inline-end: 2em` on dimensionless gaiji SVGs.
- Keep width and trailing spacing renderer-owned only for structured gaiji; explicitly sized media and ordinary images remain unchanged.
- Strengthen the regression from a loose `<100px` offset to direct link-to-icon gap geometry.
- Keep all three `popup.js` mirrors byte-identical and update BUG-803 with the second screenshot/root cause.

## Why a follow-up

PR #108 correctly removed the dictionary's `width: 15em !important`, but its WebView2 assertion accepted the resulting 64px offset. The second screenshot showed the residual problem: the 24px icon was fixed, while `margin-inline-end: 2em` still left roughly 40px before `以内`.

## Validation

- TDD red: before the production change, the new JS assertion failed with `actual: undefined, expected: '0'`
- `node test/utils/misc/popup_asset_behavior_test.js` — passed
- `flutter test --no-pub test/build/browser_extension_popup_parity_guard_test.dart` — 13/13 passed
- `tool/run_windows_itest.ps1 -RunId bug803-inline-gaiji-gap-latest integration_test/desktop_reader_css_dom_test.dart` — 2/2 passed on latest `origin/develop`
  - gaiji width: 24px
  - `以内` offset: 24px
  - link-to-gaiji gap: 0px
  - computed end margin: 0px
  - width and margin priorities: `important`
- `dart run tool/bug.dart check` — passed; 785 unique, synchronized entries
- `dart format .` — ran; target Dart test formatted, unrelated baseline formatting diffs excluded

## Known baseline test issue

The full Flutter suite attempt from PR #108 hit the unrelated existing hang in `test/pages/home_video_remote_collection_membership_test.dart`; an isolated rerun also hung. This follow-up has no overlap with that file, and all rendering-specific checks above pass on the latest base.
