### PR TITLE
查词弹窗尺寸 Phase C/D 真机修复（覆盖窗乱跳=增量折算 / 扩展拖拽关窗=popup.js 豁免 grip）

### DIFF
--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -3616,6 +3616,10 @@ document.addEventListener('click', (e) => {
     }
 
     const _t0 = __hibikiEventTarget(e); const target = _t0?.nodeType === Node.TEXT_NODE ? _t0.parentElement : _t0;
+    // 弹窗尺寸拖拽把手（浏览器扩展 Phase D）是宿主页 body 顶层兄弟 #hibiki-popup-resize-grip，
+    // 不在任何弹窗内部选择器内，点/拖它会落到本函数末尾的 tapOutside 关窗（用户报「拖动关窗」）。
+    // 这里显式豁免：点/拖把手绝不关窗。app 内弹窗文档里无此元素，closest 永不命中 → no-op。
+    if (target?.closest?.('#hibiki-popup-resize-grip')) return;
     // TODO-1189 — audio/mine/favorite are per-entry action buttons; a click on any
     // of them must NEVER reach the document dismiss path. .favorite-button was
     // missing here, so tapping ☆ on a PARENT card fell through to the .entry

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -3616,6 +3616,10 @@ document.addEventListener('click', (e) => {
     }
 
     const _t0 = __hibikiEventTarget(e); const target = _t0?.nodeType === Node.TEXT_NODE ? _t0.parentElement : _t0;
+    // 弹窗尺寸拖拽把手（浏览器扩展 Phase D）是宿主页 body 顶层兄弟 #hibiki-popup-resize-grip，
+    // 不在任何弹窗内部选择器内，点/拖它会落到本函数末尾的 tapOutside 关窗（用户报「拖动关窗」）。
+    // 这里显式豁免：点/拖把手绝不关窗。app 内弹窗文档里无此元素，closest 永不命中 → no-op。
+    if (target?.closest?.('#hibiki-popup-resize-grip')) return;
     // TODO-1189 — audio/mine/favorite are per-entry action buttons; a click on any
     // of them must NEVER reach the document dismiss path. .favorite-button was
     // missing here, so tapping ☆ on a PARENT card fell through to the .entry

--- a/hibiki/lib/src/lookup/effective_lookup_size.dart
+++ b/hibiki/lib/src/lookup/effective_lookup_size.dart
@@ -80,24 +80,26 @@ LookupSize resolveDraggedLookupSize({
   return LookupSize(width, height);
 }
 
-/// Phase C（2026-07-13）— 「app 外瞬态覆盖查词窗」被拖角调整尺寸后，native 模态
-/// size 循环结束回报**最终窗口物理像素**尺寸，本函数把它倒推回 overlay 场景的
-/// 「基准（未缩放）最大宽高」并 clamp。app 内拖拽写 [resolveDraggedLookupSize]（增量
-/// 折算），覆盖窗走这里（绝对窗口尺寸折算）——两者都不引入第二套「固定尺寸」概念，
-/// 只是把同一「最大宽高」真值换一种输入编辑。
+/// Phase C（2026-07-14 修订）— 「app 外瞬态覆盖查词窗」被拖角调整尺寸，用**增量**折算。
 ///
-/// 正向链（controller 算窗口物理尺寸，见 global_lookup_controller）：
-/// `cardW = overlayEffective.width × appUiScale`，再 `× dpr` 传 native 建窗，
-/// 故单卡窗口物理宽 ≈ `overlayLogicalW × uiScale × dpr`。倒推即：
-/// `overlayLogicalW = 窗口物理宽 / dpr / uiScale`。
+/// 关键：瞬态覆盖窗因 reserve-to-edge 级联余量恒比可见卡片大一截（那段被 region 裁掉
+/// 不可见），故**绝对窗口尺寸不能直接当卡片尺寸倒推**——会把余量算进去，折算出的
+/// overlay 尺寸系统性暴涨（常顶到上限/工作区），卡片爆炸放大并被甩到工作区角（用户报
+/// 的「乱跳」根因）。native 回报拖拽**起始与结束**的窗口物理尺寸，本函数用二者之差
+/// （恒定余量在相减中抵消，与余量的具体值/方向无关）折算回 overlay 场景「基准（未缩放）
+/// 最大宽高」的增量，叠加到当前值：
+///   `new = clamp(current + (physEnd - physStart) / dpr / uiScale)`
 ///
-/// [dpr] / [uiScale] 非正时按 1 兜底（不除零、不反向缩放）。结果先**下取整**到整
-/// 逻辑像素（避免一次拖拽因四舍五入把值顶上去 / 多次往返累积漂移），再 clamp 到
-/// [kLookupPopupMinWidth]..[kLookupPopupMaxHeight]——与滑杆同一 min/max 单一同源。
-/// 纯函数（含 dpr、uiScale、下取整、clamp 边界），直接单测。
-LookupSize resolveOverlayResizeFromWindow({
-  required double windowPhysicalWidth,
-  required double windowPhysicalHeight,
+/// 正向链：`cardW = overlayLogicalW × uiScale`，再 `× dpr` 传 native 建窗；故窗口物理
+/// 增量 `Δphys = ΔoverlayLogicalW × uiScale × dpr`，倒推 `ΔoverlayLogicalW = Δphys /
+/// dpr / uiScale`。[dpr]/[uiScale] 非正按 1 兜底（不除零、不反向）。与滑杆同一 min/max
+/// 单一同源。不下取整——增量模型每次独立于真实起始尺寸，flooring 会在多次拖拽累积下漂。
+/// 纯函数，直接单测。
+LookupSize resolveOverlayResizeFromDelta({
+  required double currentWidth,
+  required double currentHeight,
+  required double deltaPhysWidth,
+  required double deltaPhysHeight,
   required double dpr,
   required double uiScale,
   double minWidth = kLookupPopupMinWidth,
@@ -108,10 +110,9 @@ LookupSize resolveOverlayResizeFromWindow({
   final double d = dpr > 0 ? dpr : 1.0;
   final double s = uiScale > 0 ? uiScale : 1.0;
   final double width =
-      (windowPhysicalWidth / d / s).floorToDouble().clamp(minWidth, maxWidth);
-  final double height = (windowPhysicalHeight / d / s)
-      .floorToDouble()
-      .clamp(minHeight, maxHeight);
+      (currentWidth + deltaPhysWidth / d / s).clamp(minWidth, maxWidth);
+  final double height =
+      (currentHeight + deltaPhysHeight / d / s).clamp(minHeight, maxHeight);
   return LookupSize(width, height);
 }
 

--- a/hibiki/lib/src/lookup/global_lookup_controller.dart
+++ b/hibiki/lib/src/lookup/global_lookup_controller.dart
@@ -695,20 +695,29 @@ class GlobalLookupController {
     if (model == null) {
       return;
     }
+    // native（WM_EXITSIZEMOVE）回报 args=[left, top, width, height, startW, startH]
+    // 均为**窗口物理 px**：[2][3] 是拖拽结束尺寸、[4][5] 是拖拽起始尺寸。要 6 个字段——
+    // 只有真的拖过 grip 才有起始尺寸；用「结束−起始」增量折算抵消恒定级联余量（见
+    // [resolveOverlayResizeFromDelta]），绝不用绝对窗口尺寸倒推（会把余量算进去→暴涨乱跳）。
     final Object? args = message['args'];
-    if (args is! List || args.length < 4) {
+    if (args is! List || args.length < 6) {
       return;
     }
     double num2(Object? v) => (v is num) ? v.toDouble() : 0;
     final double physW = num2(args[2]);
     final double physH = num2(args[3]);
-    if (physW <= 0 || physH <= 0) {
+    final double startW = num2(args[4]);
+    final double startH = num2(args[5]);
+    if (physW <= 0 || physH <= 0 || startW <= 0 || startH <= 0) {
       return;
     }
     final double dpr = _devicePixelRatio();
-    final LookupSize size = resolveOverlayResizeFromWindow(
-      windowPhysicalWidth: physW,
-      windowPhysicalHeight: physH,
+    final LookupSize current = model.overlayLookupEffectiveSize;
+    final LookupSize size = resolveOverlayResizeFromDelta(
+      currentWidth: current.width,
+      currentHeight: current.height,
+      deltaPhysWidth: physW - startW,
+      deltaPhysHeight: physH - startH,
       dpr: dpr,
       uiScale: model.appUiScale,
     );

--- a/hibiki/test/lookup/effective_lookup_size_test.dart
+++ b/hibiki/test/lookup/effective_lookup_size_test.dart
@@ -71,52 +71,64 @@ void main() {
       expect(independent(2000, 1600), const LookupSize(640, 480));
     });
 
-    test('resolveOverlayResizeFromWindow — 覆盖窗拖角倒推 + 解锁真值', () {
-      // 正向：cardW = overlayLogicalW × uiScale，窗口物理宽 = cardW × dpr。
-      // 取 overlayLogicalW=600, uiScale=1.25, dpr=1.5 → 物理宽 = 600×1.25×1.5 = 1125。
-      final LookupSize size = resolveOverlayResizeFromWindow(
-        windowPhysicalWidth: 1125,
-        windowPhysicalHeight: 900, // 480×1.25×1.5 = 900 → 逻辑高 480
+    test('resolveOverlayResizeFromDelta — 增量折算叠加到当前值', () {
+      // 拖大：物理增量 +Δ → 逻辑增量 = Δ/dpr/uiScale。
+      // current=600, Δphys=+450, dpr=1.5, uiScale=1.25 → +450/1.5/1.25 = +240 → 840。
+      final LookupSize size = resolveOverlayResizeFromDelta(
+        currentWidth: 600,
+        currentHeight: 480,
+        deltaPhysWidth: 450,
+        deltaPhysHeight: -180, // -180/1.5/1.25 = -96 → 480-96 = 384
         dpr: 1.5,
         uiScale: 1.25,
       );
-      expect(size, const LookupSize(600, 480));
+      expect(size, const LookupSize(840, 384));
     });
 
-    test('resolveOverlayResizeFromWindow — dpr/uiScale 非正按 1 兜底（不除零）', () {
-      final LookupSize size = resolveOverlayResizeFromWindow(
-        windowPhysicalWidth: 800,
-        windowPhysicalHeight: 600,
+    test('resolveOverlayResizeFromDelta — 恒定级联余量在相减中抵消（150% 例）', () {
+      // 关键：不管起始窗口比卡片大多少（reserve-to-edge 余量），只要用「结束−起始」增量，
+      // 余量作为常量被减掉。仅拖动那段 Δphys 决定尺寸变化——150% 下也精确。
+      const double uiScale = 1.5, dpr = 1.5;
+      // 用户把窗口物理宽拖大 90px（= 逻辑 90/1.5/1.5 = 40）。
+      final LookupSize size = resolveOverlayResizeFromDelta(
+        currentWidth: 400,
+        currentHeight: 360,
+        deltaPhysWidth: 90,
+        deltaPhysHeight: 0,
+        dpr: dpr,
+        uiScale: uiScale,
+      );
+      expect(size, const LookupSize(440, 360));
+    });
+
+    test('resolveOverlayResizeFromDelta — dpr/uiScale 非正按 1 兜底（不除零）', () {
+      final LookupSize size = resolveOverlayResizeFromDelta(
+        currentWidth: 500,
+        currentHeight: 400,
+        deltaPhysWidth: 100,
+        deltaPhysHeight: -50,
         dpr: 0,
         uiScale: -1,
       );
-      expect(size, const LookupSize(800, 600));
+      expect(size, const LookupSize(600, 350));
     });
 
-    test('resolveOverlayResizeFromWindow — 下取整到整逻辑像素', () {
-      // 900.9 / 1 / 1 = 900.9 → floor 900；700.2 → 700。
-      final LookupSize size = resolveOverlayResizeFromWindow(
-        windowPhysicalWidth: 900.9,
-        windowPhysicalHeight: 700.2,
-        dpr: 1,
-        uiScale: 1,
-      );
-      expect(size, const LookupSize(900, 700));
-    });
-
-    test('resolveOverlayResizeFromWindow — clamp 到滑杆同源 min/max', () {
-      // 过小 → 夹到 (250,200)；过大 → 夹到 (2000,1600)。
-      final LookupSize tiny = resolveOverlayResizeFromWindow(
-        windowPhysicalWidth: 10,
-        windowPhysicalHeight: 10,
+    test('resolveOverlayResizeFromDelta — clamp 到滑杆同源 min/max', () {
+      final LookupSize tiny = resolveOverlayResizeFromDelta(
+        currentWidth: 260,
+        currentHeight: 210,
+        deltaPhysWidth: -9999,
+        deltaPhysHeight: -9999,
         dpr: 1,
         uiScale: 1,
       );
       expect(
           tiny, const LookupSize(kLookupPopupMinWidth, kLookupPopupMinHeight));
-      final LookupSize huge = resolveOverlayResizeFromWindow(
-        windowPhysicalWidth: 99999,
-        windowPhysicalHeight: 99999,
+      final LookupSize huge = resolveOverlayResizeFromDelta(
+        currentWidth: 1900,
+        currentHeight: 1500,
+        deltaPhysWidth: 9999,
+        deltaPhysHeight: 9999,
         dpr: 1,
         uiScale: 1,
       );
@@ -124,12 +136,14 @@ void main() {
           huge, const LookupSize(kLookupPopupMaxWidth, kLookupPopupMaxHeight));
     });
 
-    test('resolveOverlayResizeFromWindow — 拖出的尺寸即解锁独立键的写入值', () {
-      // 语义验证：倒推值直接作为 overlayLookupMaxWidth/Height 写入，effective 在
+    test('resolveOverlayResizeFromDelta — 拖出的尺寸即解锁独立键的写入值', () {
+      // 语义验证：增量折算后的值直接作为 overlayLookupMaxWidth/Height 写入，effective 在
       // independent=true 下即读它——拖拽与滑杆写同一真值。
-      final LookupSize dragged = resolveOverlayResizeFromWindow(
-        windowPhysicalWidth: 1400,
-        windowPhysicalHeight: 1000,
+      final LookupSize dragged = resolveOverlayResizeFromDelta(
+        currentWidth: 400,
+        currentHeight: 360,
+        deltaPhysWidth: 600, // /2/1 = +300 → 700
+        deltaPhysHeight: 280, // /2/1 = +140 → 500
         dpr: 2,
         uiScale: 1,
       );

--- a/hibiki/test/lookup/overlay_resize_wiring_guard_test.dart
+++ b/hibiki/test/lookup/overlay_resize_wiring_guard_test.dart
@@ -33,8 +33,8 @@ void main() {
       final String src = file.readAsStringSync();
       expect(src.contains("handler == 'windowMoved'"), isTrue,
           reason: 'overlay 未接 windowMoved 回报——拖完不落库');
-      expect(src.contains('resolveOverlayResizeFromWindow'), isTrue,
-          reason: '倒推未走同源纯函数');
+      expect(src.contains('resolveOverlayResizeFromDelta'), isTrue,
+          reason: '倒推未走同源纯函数（增量折算）');
       expect(src.contains('setOverlayLookupIndependentSize'), isTrue,
           reason: '拖动未解锁 overlay 独立尺寸');
       expect(src.contains('setOverlayLookupMaxWidth'), isTrue);

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -1437,6 +1437,16 @@ LRESULT GlobalLookupWindow::HandleMessage(UINT message, WPARAM wparam,
       // 窗口区域，裁剪区不随窗口增大 → 拖拽看不到窗口变大；置 resizing_ 并立即重算区域，
       // 拖拽期间改用整窗区域（见 ApplyRoundedRegion）。面板实例区域本就是整窗，此为 no-op。
       resizing_ = true;
+      // Phase C（2026-07-14）— 记下拖拽起始的真实窗口物理尺寸；WM_EXITSIZEMOVE 一并回报，
+      // Dart 用「结束−起始」增量折算（抵消恒定级联余量）。GetWindowRect 是拖拽前实际尺寸，
+      // 比 Dart 侧 last-sent（可能被 clamp）可靠。
+      if (hwnd_ != nullptr) {
+        RECT sr{};
+        if (GetWindowRect(hwnd_, &sr)) {
+          resize_start_w_ = sr.right - sr.left;
+          resize_start_h_ = sr.bottom - sr.top;
+        }
+      }
       ApplyRoundedRegion();
       return 0;
     case WM_EXITSIZEMOVE: {
@@ -1450,10 +1460,14 @@ LRESULT GlobalLookupWindow::HandleMessage(UINT message, WPARAM wparam,
       if (message_cb_ && hwnd_ != nullptr) {
         RECT r{};
         GetWindowRect(hwnd_, &r);
+        // Phase C（2026-07-14）— 追加拖拽起始尺寸 [startW, startH]，Dart 用「结束−起始」
+        // 增量折算 overlay 尺寸（面板实例读 [0..3] 绝对 rect，忽略 [4][5]，向后兼容）。
         message_cb_(std::string("{\"handler\":\"windowMoved\",\"args\":[") +
                     std::to_string(r.left) + "," + std::to_string(r.top) +
                     "," + std::to_string(r.right - r.left) + "," +
-                    std::to_string(r.bottom - r.top) + "]}");
+                    std::to_string(r.bottom - r.top) + "," +
+                    std::to_string(resize_start_w_) + "," +
+                    std::to_string(resize_start_h_) + "]}");
       }
       return 0;
     }

--- a/hibiki/windows/runner/global_lookup_window.h
+++ b/hibiki/windows/runner/global_lookup_window.h
@@ -243,6 +243,12 @@ class GlobalLookupWindow {
   // 变大；resize 期间 ApplyRoundedRegion 改用整窗区域，让窗口可见地随拖拽增长，结束
   // 复原 shell 裁剪。面板实例 shell_rects_css_ 为空，此标志对它无副作用。
   bool resizing_ = false;
+  // Phase C（2026-07-14）— 拖拽起始（WM_ENTERSIZEMOVE 那刻）的窗口物理尺寸。瞬态覆盖
+  // 窗恒比可见卡片大一截（reserve-to-edge 级联余量），故 WM_EXITSIZEMOVE 回报「起始+结束」
+  // 两个尺寸，Dart 用二者之差（恒定余量抵消）折算 overlay 增量——绝对窗口尺寸会把余量算
+  // 进去导致尺寸暴涨/卡片甩边（乱跳）。0 = 未在拖拽。
+  int resize_start_w_ = 0;
+  int resize_start_h_ = 0;
   // spec 2026-07-10 — panel-instance data knobs (defaults == the historical
   // lookup-overlay behaviour, so the first instance is byte-for-byte unchanged).
   bool arm_dismiss_hooks_ = true;

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -3616,6 +3616,10 @@ document.addEventListener('click', (e) => {
     }
 
     const _t0 = __hibikiEventTarget(e); const target = _t0?.nodeType === Node.TEXT_NODE ? _t0.parentElement : _t0;
+    // 弹窗尺寸拖拽把手（浏览器扩展 Phase D）是宿主页 body 顶层兄弟 #hibiki-popup-resize-grip，
+    // 不在任何弹窗内部选择器内，点/拖它会落到本函数末尾的 tapOutside 关窗（用户报「拖动关窗」）。
+    // 这里显式豁免：点/拖把手绝不关窗。app 内弹窗文档里无此元素，closest 永不命中 → no-op。
+    if (target?.closest?.('#hibiki-popup-resize-grip')) return;
     // TODO-1189 — audio/mine/favorite are per-entry action buttons; a click on any
     // of them must NEVER reach the document dismiss path. .favorite-button was
     // missing here, so tapping ☆ on a PARENT card fell through to the .entry


### PR DESCRIPTION
查词弹窗尺寸 Phase C/D 的**真机 bug 修复**（接已合入 develop 的 C+D 与松手即时填充）。用户真机（界面缩放 **150%**）反馈：Phase C 覆盖窗拖拽**乱跳**、Phase D 扩展拖拽**把弹窗关掉**。

## 1. Phase D 拖 resize 把手不再关窗（f1ed886e0）
**根因**：弹窗有两条「点外关闭」路径，原实现只给 content.js 的 mousedown 加了 grip 豁免；真正关窗的是 shadow 内 **popup.js 的 click→tapOutside**（grip 是宿主页 body 顶层兄弟，命中不了任何弹窗内部选择器 → 判为点外 → 关）。
**修**：popup.js click handler 按 `#hibiki-popup-resize-grip` 豁免（三镜像同步；app 内文档无此元素 → no-op）。

## 2. Phase C 覆盖窗 resize 改增量折算，修尺寸暴涨/乱跳（7ca0de08f）
**根因**：`_onOverlayResized` 把 `GetWindowRect` 的**整窗**尺寸当卡片尺寸倒推，但瞬态覆盖窗因 reserve-to-edge 级联余量恒比可见卡片大一截（那段被 region 裁掉不可见）→ 折算尺寸系统性暴涨（常顶到 2000×1600/工作区）→ 松手即时填充立即套用 → 卡片爆炸放大 + `computeRootShellOffset` 把根卡甩到工作区角 = **乱跳**。折算数学在 150% 下本身对称，错的是**输入**（整窗含余量）。
**修**：改**增量**折算——native 在 `WM_ENTERSIZEMOVE` 抓拖拽起始的真实窗口物理尺寸、`WM_EXITSIZEMOVE` 一并回报「起止两尺寸」，Dart 用二者之差（恒定余量在相减中抵消，与余量值/方向无关）折算 overlay 增量叠加到当前值：`new = clamp(current + (physEnd − physStart)/dpr/uiScale)`。size 不再暴涨 → 不再甩边/乱跳，150% 下 1:1 跟手。

## 验证
- `flutter analyze` 干净；overlay resize guard + 增量折算纯函数（含 150% 例、余量抵消、clamp、dpr/uiScale 非正兜底、拖出即写入真值）21/21 通过；扩展三镜像 parity guard + node placement 12/12 通过；三镜像字节一致。
- **Phase C 的 C++ 改动已 `flutter build windows --debug` 编译通过**（`√ Built hibiki.exe`）。

## 待真机复测
- Windows 覆盖窗：拖 grip 尺寸随手 1:1（150% 下不暴涨/不甩边）、松手即时填充、下次查词沿用。**残留待观察**：拖得比内容高时高度按内容封顶（「最大高度」语义，宽度填满）；`WM_EXITSIZEMOVE` 先复原旧卡矩形再重排新 shellRects 理论上有 1 帧区域两跳——真机若仍见闪烁再做区域延迟复原。
- Chrome/Edge：扩展拖 grip 不再关窗、尺寸经 bridge 回写、下次查词沿用。
