### PR TITLE
fix(startup): 数据根不可达/看门狗重试致「数据全空」观感 (BUG-815)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 796 条。点号进各自文件。
+> 共 797 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-815](bugs/BUG-815-init-retry-race.md) | ✅ | ✅ | 看门狗重试与在飞初始化竞态致数据全空(移动端) |
 | [BUG-814](bugs/BUG-814-interconnect-video-list-empty.md) | ✅ | ✅ | 互联开启后手机视频列表为空(host listVideos 每视频串行 ffmpeg 探测超过 client 15s 超时) |
 | [BUG-813](bugs/BUG-813-interconnect-download-no-reading-progress.md) | ✅ | ✅ | 互联手动下载远端书不带回阅读记录(阅读进度/有声书断点) |
 | [BUG-812](bugs/BUG-812-interconnect-audiobook-not-in-collection.md) | ✅ | ✅ | 互联开启后手机上有声书不进合集(host listBooks 只用 epub\|bookKey 查归属，漏 srt-backed 有声书的 srt\|uid 成员键) |

--- a/docs/bugs/BUG-815-init-retry-race.md
+++ b/docs/bugs/BUG-815-init-retry-race.md
@@ -1,0 +1,17 @@
+## BUG-815 · 看门狗重试与在飞初始化竞态致数据全空(移动端)
+- **报告**：2026-07-14（用户：截图「启动耗时超出预期」页）
+- **真实性**：✅ 真 bug。手机上从没设自定义数据位置，可看门狗逃生页仍弹出、点「重试」后主页**数据全空**、重启 app 即恢复——数据没真丢，是**并发双初始化打烂了可见状态**。
+  - 根因数据流：
+    1. `hibiki/lib/main.dart:344` 冷启动 `await appModel.initialise()`。慢冷启动（首启 / 慢存储 / 大库）下这个 init 只是**慢**、并未 hang。
+    2. `hibiki/lib/main.dart:1309`+ 的 20s 加载看门狗（BUG-572/TODO-1260 引入）纯粹是 UI 逃生口——**不取消**那个在飞的 init。超 20s 翻 `_loadingTimedOut` 显示逃生页。
+    3. 用户点「重试」→ `onRetry`（`hibiki/lib/main.dart:1327`+）调 `appModel.retryInitialise()`。修复前 `hibiki/lib/src/models/app_model.dart` 的 `retryInitialise()` **无任何 in-flight 守卫**：`_databaseOpened==true` 时直接 `await _database.close()` 关掉**首个 init 正在用的 DB**，再 `await initialise()` 起**第二个并发 init**。
+    4. 两个 init 抢同一批可变字段（`_database` / `_prefsRepo` / `dictRepo` / `_isInitialised`），谁先 `notifyListeners()` 就用谁半加载的 repo → 主页渲染空数据。重启是单次干净 init → 数据回来。
+  - 连带文案错误：`hibiki/lib/src/storage/app_paths.dart:90` `_resolveDataRoot()` 在 `!isDesktopPlatform` 时**直接 return null**——自定义数据根 + 2s 超时回退**是纯桌面逻辑**，移动端 documents/support 恒走 `path_provider` 默认路径。故看门狗文案「数据存储位置设在未连接网络盘 / 用默认位置启动」（`loading_slow_message`）在手机上既不适用又吓人（重试根本不换位置）。
+- **[x] ① 已修复** — 两道结构不变量让「并发双 init」根本不可能 + 移动端文案（分支 `worktree-bug-init-retry-race`）：
+  1. `hibiki/lib/src/models/app_model.dart`：公开 `initialise()` 改为**带 in-flight 守卫的同步包装**（新增字段 `_initInFlight`）——已有 run 在飞时复用同一 future，绝不起第二个；真正的一次性 init 体搬到 `_initialiseOnce()`（内部 catch，永不 rethrow，完成后 `whenComplete` 清 `_initInFlight`，故 error 后的干净重起仍可用）。
+  2. `hibiki/lib/src/models/app_model.dart` `retryInitialise()`：在 `_database.close()` 教条式拆卸**之前**先检查 `_initInFlight`，在飞就 `await` 它并 `return`——init 在飞=慢启动而非 hang，await 即可（成功出数据 / 失败落 `_initError`），**绝不关它正在用的 DB**。
+  3. `hibiki/lib/src/startup/loading_watchdog_view.dart` + i18n key `loading_slow_message_mobile`（17 语言，经 `tool/i18n_sync.dart --add` + `dart run slang`）：移动端（`defaultTargetPlatform` android/iOS，或显式 `isMobile`）改显不提「默认位置」的安心文案；桌面保留掉线盘解释。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/models/app_model_init_retry_race_guard_test.dart`：源码扫描守卫（沿 BUG-207 范式，~2900 行 init 序列无法在 host 单测真实驱动）——钉住 ①公开 `initialise()` 是带 `_initInFlight` 守卫的同步包装、init 体在 `_initialiseOnce()`；②`retryInitialise()` 的 `_initInFlight` 短路 + `return;` 必须早于 `_database.close()`。撤修复任一 → 守卫红。
+  - `hibiki/test/startup/loading_watchdog_view_test.dart`：新增移动端文案用例（`isMobile:true` 显 `loading_slow_message_mobile`、不含桌面 `loading_slow_message`），桌面用例改 `isMobile:false`。
+- **备注**：`flutter analyze`（4 改动文件）+ `flutter test`（view 5 / guard 2 / i18n+md3 77）全绿。**待真机验收**：手机上人为拖慢冷启动触发 20s 看门狗（大库 / 慢存储），点「重试」应**照常出全量数据**（不再空），文案不再提「默认位置」。与本地不入库的 `docs/REGRESSION_BUGS.md` 区分。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39814 (2342 per locale)
+/// Strings: 39831 (2343 per locale)
 ///
-/// Built on 2026-07-14 at 13:08 UTC
+/// Built on 2026-07-14 at 15:02 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3108,6 +3108,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_quality_loading => 'Loading available qualities…';
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -8418,6 +8420,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -13851,6 +13856,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -19301,6 +19309,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -24770,6 +24781,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -30141,6 +30155,9 @@ class _StringsId extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -35573,6 +35590,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -40730,6 +40750,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -45892,6 +45915,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -51292,6 +51318,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -56715,6 +56744,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -62113,6 +62145,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -67424,6 +67459,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -72790,6 +72828,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -78131,6 +78172,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -83102,6 +83146,9 @@ class _StringsZhCn extends _StringsEn {
   String get video_quality_loading => '正在获取可选画质…';
   @override
   String get video_quality_load_failed => '无法获取该视频的画质档。';
+  @override
+  String get loading_slow_message_mobile =>
+      '启动比平常慢，可能在加载较大的书库或词典。请稍候，或点「重试」重新加载——你的数据是安全的，不会丢失。';
 }
 
 // Path: retrying_in
@@ -88161,6 +88208,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_quality_load_failed =>
       'Couldn\'t load qualities for this video.';
+  @override
+  String get loading_slow_message_mobile =>
+      'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
 }
 
 // Path: retrying_in
@@ -92989,6 +93039,8 @@ extension on _StringsEn {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -97777,6 +97829,8 @@ extension on _StringsAr {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -102587,6 +102641,8 @@ extension on _StringsDe {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -107395,6 +107451,8 @@ extension on _StringsEs {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -112210,6 +112268,8 @@ extension on _StringsFr {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -117005,6 +117065,8 @@ extension on _StringsId {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -121817,6 +121879,8 @@ extension on _StringsIt {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -126586,6 +126650,8 @@ extension on _StringsJa {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -131359,6 +131425,8 @@ extension on _StringsKo {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -136164,6 +136232,8 @@ extension on _StringsNl {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -140966,6 +141036,8 @@ extension on _StringsPtBr {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -145772,6 +145844,8 @@ extension on _StringsRu {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -150560,6 +150634,8 @@ extension on _StringsTh {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -155357,6 +155433,8 @@ extension on _StringsTr {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -160148,6 +160226,8 @@ extension on _StringsVi {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }
@@ -164903,6 +164983,8 @@ extension on _StringsZhCn {
         return '正在获取可选画质…';
       case 'video_quality_load_failed':
         return '无法获取该视频的画质档。';
+      case 'loading_slow_message_mobile':
+        return '启动比平常慢，可能在加载较大的书库或词典。请稍候，或点「重试」重新加载——你的数据是安全的，不会丢失。';
       default:
         return null;
     }
@@ -169664,6 +169746,8 @@ extension on _StringsZhHk {
         return 'Loading available qualities…';
       case 'video_quality_load_failed':
         return 'Couldn\'t load qualities for this video.';
+      case 'loading_slow_message_mobile':
+        return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "重试",
   "video_load_failed_back": "返回",
   "video_quality_loading": "正在获取可选画质…",
-  "video_quality_load_failed": "无法获取该视频的画质档。"
+  "video_quality_load_failed": "无法获取该视频的画质档。",
+  "loading_slow_message_mobile": "启动比平常慢，可能在加载较大的书库或词典。请稍候，或点「重试」重新加载——你的数据是安全的，不会丢失。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2348,5 +2348,6 @@
   "video_load_failed_retry": "Retry",
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
-  "video_quality_load_failed": "Couldn't load qualities for this video."
+  "video_quality_load_failed": "Couldn't load qualities for this video.",
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
 }

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -709,6 +709,12 @@ class AppModel with ChangeNotifier {
   bool get isInitialised => _isInitialised;
   bool _isInitialised = false;
 
+  /// BUG-815: the currently-running [_initialiseOnce] future, or null when no
+  /// init is in flight. [initialise] uses it to serialise concurrent callers so
+  /// a second init can never race the first over the shared [_database] /
+  /// repositories / [_isInitialised]. Cleared when the in-flight run completes.
+  Future<void>? _initInFlight;
+
   /// Non-null if [initialise] threw; UI should display this instead of spinning.
   String? get initError => _initError;
   String? _initError;
@@ -732,6 +738,21 @@ class AppModel with ChangeNotifier {
 
   /// Clears the error state and re-runs [initialise].
   Future<void> retryInitialise() async {
+    // BUG-815: if an init started by main() is still IN FLIGHT — a slow cold
+    // start that merely tripped the 20s loading watchdog, NOT a hang — do NOT
+    // tear down / re-open the DB below. Closing [_database] out from under the
+    // running init and spawning a SECOND concurrent init races them over the
+    // shared _database / repositories / _isInitialised and surfaces as "all data
+    // empty" on the home screen (mobile has no custom data root, so restarting —
+    // a single clean init — restores everything). Await the in-flight attempt
+    // instead: it completes (data appears) or sets _initError (whose own Retry
+    // then runs cleanly, because [initialise]'s whenComplete has cleared
+    // _initInFlight by that point).
+    final Future<void>? inFlight = _initInFlight;
+    if (inFlight != null) {
+      await inFlight;
+      return;
+    }
     // A previous attempt may have partially initialised resources. Tear down
     // the ones that would otherwise leak or double-register before re-running
     // (the late fields below are reassigned by initialise()).
@@ -1805,7 +1826,29 @@ class AppModel with ChangeNotifier {
     _databaseDirectory = _appPaths.supportRoot;
   }
 
-  Future<void> initialise() async {
+  /// Public entry point for app initialisation.
+  ///
+  /// BUG-815: serialises initialisation. If a run is already in flight (e.g. the
+  /// loading-watchdog Retry firing while main()'s init is still going on a slow
+  /// cold start), concurrent callers share that single run instead of starting a
+  /// SECOND init that races the first over [_database] / repositories /
+  /// [_isInitialised]. Once the run completes — success OR [_initError] (the body
+  /// catches internally and never rethrows, so this future always resolves
+  /// normally) — the guard clears, so a genuine retry-after-error still starts a
+  /// fresh attempt.
+  Future<void> initialise() {
+    final Future<void>? existing = _initInFlight;
+    if (existing != null) return existing;
+    final Future<void> run = _initialiseOnce();
+    _initInFlight = run;
+    return run.whenComplete(() {
+      if (identical(_initInFlight, run)) _initInFlight = null;
+    });
+  }
+
+  /// One-shot initialisation body. Never call directly — always go through
+  /// [initialise] so the in-flight guard holds.
+  Future<void> _initialiseOnce() async {
     try {
       debugPrint('[Hibiki] init: PackageInfo + DeviceInfo');
 

--- a/hibiki/lib/src/startup/loading_watchdog_view.dart
+++ b/hibiki/lib/src/startup/loading_watchdog_view.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/material.dart';
 
 import 'package:hibiki/utils.dart' show t;
@@ -20,6 +21,7 @@ class LoadingWatchdogView extends StatelessWidget {
     required this.timedOut,
     required this.colorScheme,
     required this.onRetry,
+    this.isMobile,
   });
 
   /// 是否已超过看门狗时限仍未初始化完成（true 显示逃生 UI，false 显示转圈）。
@@ -31,6 +33,10 @@ class LoadingWatchdogView extends StatelessWidget {
   /// 用户点「重试」的回调（由 State 复位看门狗并调 `retryInitialise`）。
   final VoidCallback onRetry;
 
+  /// BUG-815：是否移动端（决定超时说明文案）。null 时按 [defaultTargetPlatform]
+  /// 解析（生产默认）；测试可显式传值断言桌面 / 移动两套文案。
+  final bool? isMobile;
+
   @override
   Widget build(BuildContext context) {
     if (!timedOut) {
@@ -38,6 +44,14 @@ class LoadingWatchdogView extends StatelessWidget {
         child: CircularProgressIndicator(color: colorScheme.primary),
       );
     }
+    // BUG-815: the desktop copy explains the dropped custom-drive data root +
+    // "start with the default location" escape. On mobile there is NO custom
+    // data root (AppPaths._resolveDataRoot returns null off desktop), so that
+    // wording is both irrelevant and alarming — Retry never changes any location
+    // there. Pick a mobile-appropriate copy that reassures the data is safe.
+    final bool mobile = isMobile ??
+        (defaultTargetPlatform == TargetPlatform.android ||
+            defaultTargetPlatform == TargetPlatform.iOS);
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(24),
@@ -57,7 +71,7 @@ class LoadingWatchdogView extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             Text(
-              t.loading_slow_message,
+              mobile ? t.loading_slow_message_mobile : t.loading_slow_message,
               style: TextStyle(
                 fontSize: 13,
                 color: colorScheme.onSurfaceVariant,

--- a/hibiki/test/models/app_model_init_retry_race_guard_test.dart
+++ b/hibiki/test/models/app_model_init_retry_race_guard_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 源码守卫（BUG-815）：看门狗「重试」与在飞的首个初始化并发竞态 → 数据全空。
+///
+/// 根因数据流——`main()` 冷启动 `await appModel.initialise()`。慢冷启动（首启 / 慢
+/// 存储 / 大库）下这个 init 只是**慢**、并未 hang，20s 后触发加载看门狗逃生 UI。用户
+/// 点「重试」→ `retryInitialise()`。修复前它**无任何 in-flight 守卫**：`_databaseOpened`
+/// 为真时直接 `await _database.close()` 关掉**首个 init 正在用的 DB**，再 `initialise()`
+/// 起**第二个并发 init**。两个 init 抢同一批可变字段（`_database` / repositories /
+/// `_isInitialised`），谁先 `notifyListeners()` 就用谁半加载的 repo → 主页渲染空数据。
+/// 重启（单次干净 init）即恢复，证明数据没真丢，是并发初始化打烂了可见状态。
+///
+/// 修复——两道结构不变量，让「并发双 init」根本不可能：
+///   1. 公开 `initialise()` 改为**带 in-flight 守卫的同步包装**：已有 run 在飞时复用同
+///      一 future，绝不起第二个；真正的一次性 init 体搬到 `_initialiseOnce()`。
+///   2. `retryInitialise()` 在 `_database.close()` 教条式拆卸**之前**先检查 `_initInFlight`
+///      并 `return`：init 在飞 = 慢启动而非 hang，await 它即可（成功出数据 / 失败落
+///      `_initError`，其自身 Retry 那时 `_initInFlight` 已清可干净重起），绝不关它在用的 DB。
+///
+/// 这段 ~2900 行的初始化序列无法在 host 单测里真实驱动（要打开真 DB、注册全部媒体源、
+/// 跑搜索预热、平台通道等），故沿用 BUG-207 的源码扫描守卫范式钉住上述结构不被回退。
+/// 配套 widget 测试 test/startup/loading_watchdog_view_test.dart 覆盖移动端文案分支。
+void main() {
+  final String src = File('lib/src/models/app_model.dart').readAsStringSync();
+
+  test('公开 initialise() 是带 in-flight 守卫的包装，init 体在 _initialiseOnce() (BUG-815)',
+      () {
+    // 公开入口必须是同步返回的守卫包装（`Future<void> initialise() {`，非 async），
+    // 而不是直接把 ~2900 行 init 体挂在 initialise() 上（那样无法串行化并发调用）。
+    final int wrapIdx = src.indexOf('Future<void> initialise() {');
+    expect(
+      wrapIdx,
+      greaterThanOrEqualTo(0),
+      reason:
+          'initialise() 必须是带 in-flight 守卫的同步包装（Future<void> initialise() {）——'
+          '被改回 `initialise() async { try {…}` 会失去串行化，重试可再起并发 init。',
+    );
+
+    // 真正的一次性 init 体搬到 _initialiseOnce()。
+    final int onceIdx = src.indexOf('Future<void> _initialiseOnce() async {');
+    expect(
+      onceIdx,
+      greaterThan(wrapIdx),
+      reason: 'init 体必须在 _initialiseOnce() 内，由 initialise() 经守卫调用。',
+    );
+
+    // 守卫包装体必须引用 _initInFlight（复用在飞 run 的证据）。
+    final String wrapperBody = src.substring(wrapIdx, onceIdx);
+    expect(
+      wrapperBody.contains('_initInFlight'),
+      isTrue,
+      reason: 'initialise() 包装必须用 _initInFlight 串行化并发调用（复用在飞 future）。',
+    );
+  });
+
+  test('retryInitialise() 在 _database.close() 之前先短路在飞 init (BUG-815)', () {
+    final int retryIdx = src.indexOf('Future<void> retryInitialise() async {');
+    expect(retryIdx, greaterThanOrEqualTo(0),
+        reason: '找不到 retryInitialise() —— 被改名/删除？');
+
+    // 只在 retryInitialise 方法窗口内比较（方法约 ~45 行；1600 字符足够覆盖，且其后
+    // 的成员 cacheManager getter 等不含 _database.close()）。
+    final int windowEnd =
+        (retryIdx + 1600) < src.length ? retryIdx + 1600 : src.length;
+    final String retryRegion = src.substring(retryIdx, windowEnd);
+
+    final int inFlightCheckIdx = retryRegion.indexOf('_initInFlight');
+    final int closeIdx = retryRegion.indexOf('_database.close()');
+
+    expect(inFlightCheckIdx, greaterThanOrEqualTo(0),
+        reason: 'retryInitialise() 必须先检查 _initInFlight（在飞 init 短路）。');
+    expect(closeIdx, greaterThanOrEqualTo(0),
+        reason: 'retryInitialise() 仍应保留 error 后的干净重起（_database.close()）。');
+
+    // 关键不变量：in-flight 检查必须早于 _database.close()。否则慢启动下重试会关掉
+    // 首个在飞 init 正在用的 DB，并起第二个并发 init → 数据全空（BUG-815 症状）。
+    expect(
+      inFlightCheckIdx < closeIdx,
+      isTrue,
+      reason: 'BUG-815 回归：retryInitialise() 在 _database.close() 之前必须先短路在飞 init，'
+          '否则会关掉在飞 init 正在用的 DB → 并发双初始化 → 主页数据全空。',
+    );
+
+    // 加固：短路后必须真的 return（不落到下面的拆卸+重跑），否则形同虚设。
+    final String beforeClose = retryRegion.substring(0, closeIdx);
+    expect(
+      beforeClose.contains('return;'),
+      isTrue,
+      reason: 'in-flight 短路后必须 `return;`，不得继续走 _database.close() 拆卸路径。',
+    );
+  });
+}

--- a/hibiki/test/startup/loading_watchdog_view_test.dart
+++ b/hibiki/test/startup/loading_watchdog_view_test.dart
@@ -24,12 +24,13 @@ void main() {
     expect(find.text(t.loading_slow_title), findsNothing);
   });
 
-  testWidgets('超时 → 显示说明 + 重试按钮（逃生口出现）', (WidgetTester tester) async {
+  testWidgets('超时(桌面) → 显示掉线盘说明 + 重试按钮（逃生口出现）', (WidgetTester tester) async {
     bool retried = false;
     await tester.pumpWidget(wrap(LoadingWatchdogView(
       timedOut: true,
       colorScheme: cs,
       onRetry: () => retried = true,
+      isMobile: false,
     )));
 
     expect(find.byType(CircularProgressIndicator), findsNothing,
@@ -41,5 +42,25 @@ void main() {
     await tester.tap(find.text(t.retry));
     await tester.pump();
     expect(retried, isTrue, reason: '点重试须触发 onRetry（复位看门狗 + retryInitialise）');
+  });
+
+  // BUG-815：移动端没有自定义数据根（AppPaths._resolveDataRoot 非桌面恒 null），
+  // 桌面那套「数据存储位置设在未连接网络盘 / 用默认位置启动」文案在手机上既不适用
+  // 又吓人（重试根本不换位置）。移动端必须改显不提「默认位置」的安心文案。
+  testWidgets('超时(移动端) → 显示移动端安心文案，不含桌面『默认位置』说明 (BUG-815)',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(wrap(LoadingWatchdogView(
+      timedOut: true,
+      colorScheme: cs,
+      onRetry: () {},
+      isMobile: true,
+    )));
+
+    expect(find.text(t.loading_slow_title), findsOneWidget);
+    expect(find.text(t.loading_slow_message_mobile), findsOneWidget,
+        reason: '移动端须显示 loading_slow_message_mobile');
+    expect(find.text(t.loading_slow_message), findsNothing,
+        reason: '移动端不得再显示桌面掉线盘 / 默认位置文案');
+    expect(find.text(t.retry), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 问题（用户报）
- 手机:「启动耗时超出预期」逃生页点「重试」后主页**数据全空**、重启即恢复(手机从没设自定义数据位置)。
- 电脑:同样「数据全空」,追报「我数据正常在,你给我弄没了」。

## 真相:数据从未真丢(已核实)
桌面 `flutter.data_root=D:\APP\HIBIKI_date`,真库 `hibiki.db` 27MB 干净关闭,默认位置无残留空库。两条独立根因都只是**把空当真数据显示**。

## 根因
- **桌面(主)**:`app_paths.dart` `_resolveDataRoot()` 对自定义数据根做 2s 存在性探测,盘一慢(休眠/杀软/高负载)误判不可用 → **静默退回 `path_provider` 默认空位置**打开 → 满屏全空(真库原封不动在原盘),甚至可能在空态写错位置。是 BUG-572 兜底"能开就行"的设计副作用。
- **移动(次)**:慢冷启动 >20s 触发看门狗(不取消在飞 init),点「重试」→ `retryInitialise()` 无 in-flight 守卫,关掉在飞 init 正用的 DB 再起第二个并发 init → 半加载 repo 渲染空。

## 修复
- **桌面**:`resolve()` 预检——配置了自定义根但探测不可达时**抛 `DataRootUnavailableException`,绝不静默开空默认库**;`main.dart` 裸 loading 分支前渲染「数据位置未响应」逃生屏:默认「重试」(盘醒了用回真库) + **显式**「仍用默认位置启动」(`forceDefaultRootForSession`,仅本次进程、不动配置与原盘数据)。i18n 三 key(17 语言)。用户定调「保留逃生口但写清楚」。
- **移动**:`initialise()` 加 `_initInFlight` 守卫(复用在飞 future,绝不起第二个)+ `retryInitialise` 先短路在飞 init(绝不关它正用的 DB);看门狗文案移动端不再提「默认位置」。

## 测试
`app_paths_data_root_timeout_test`(契约改为抛异常 + force 回退 + 无自定义根不抛 + 源码守卫)、`data_root_unavailable_escape_guard_test`(逃生屏/双按钮/接线)、`app_model_init_retry_race_guard_test`(竞态不变量)、`loading_watchdog_view_test`(移动端文案)。`flutter analyze`(8) + `flutter test`(89) 全绿。

## ⚠️ 待真机验收
①桌面数据位置设可断开盘、断开冷启动 → 见「数据位置未响应」屏(不再全空/不再静默默认),接回盘「重试」数据回来;显式点默认→空态、原盘不动、下次自动用回。②手机拖慢冷启动触发看门狗「重试」→ 照常出全量数据。