### PR TITLE
fix(backup): 导出按功能类别剥离个人数据 + 配对 token 永不外泄 (BUG-812)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 793 条。点号进各自文件。
+> 共 794 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-812](bugs/BUG-812-backup-export-category-gating.md) | ✅ | ✅ | 导出未按功能类别剥离个人数据(收藏句/音频源路径/字体路径/sync开关/配对token泄漏) |
 | [BUG-811](bugs/BUG-811-remote-video-list-timeout-toast.md) | ✅ | ✅ | 远端视频清单超时把异常原文泄漏进 toast |
 | [BUG-810](bugs/BUG-810-backup-import-overlay-no-progress.md) | ✅ | ✅ | 备份导入复制阶段无进度条遮罩 |
 | [BUG-809](bugs/BUG-809-audiobook-clip-mjpeg-mov-size.md) | ✅ | ✅ | 有声书导出片段桌面仍用mjpeg/.mov无帧间压缩导致30秒200MB且非通用格式 |

--- a/docs/bugs/BUG-812-backup-export-category-gating.md
+++ b/docs/bugs/BUG-812-backup-export-category-gating.md
@@ -1,0 +1,12 @@
+## BUG-812 · 导出未按功能类别剥离个人数据(收藏句/音频源路径/字体路径/sync开关/配对token泄漏)
+- **报告**：2026-07-14（用户：分享备份给他人时，取消勾选的个人数据仍出现在导出 hibiki.db 里）
+- **真实性**：✅ 真 bug。用户备份 `backup_meta.json` 排除了 `settings` 等类别，但导出的 `hibiki.db` 仍明文残留：`hibiki_paired_peers`(peer_id + **token** + IP)、`favorite_sentences`(书名/章节/原句)、`local_audio_dbs`/`audio_source_configs`(绝对路径)、字体绝对路径、`sync_*` 开关、`sync_baselines`。
+  - 根因：`backup_service.dart` `settingsPrefPredicate` 把 `sync_*`/favorites/audio/font 键全列入「永久保留」，等于免除一切 gating；`favorite_sentences` 无任何 BackupCategory 归属故永不被剥；`hibiki_paired_peers`/`sync_baselines` 在整个 backup_service.dart 零引用，`_stripCredentials` 只扫 preferences 表，漏掉带 token 的独立表——尽管 HBK-AUDIT-012 注释宣称「已剥离凭据」，且 token 列 schema 明写「🔴 绝不进 sync/backup 明文导出」。
+- **[x] ① 已修复** — 每样数据挂回所属类别：
+  - `_stripCredentials` 增 `DELETE FROM _deviceLocalTables`（`hibiki_paired_peers`+`sync_baselines` 永远剥）；覆盖式导入新增 `_restoreDeviceLocalTablesFromBak` 从 bak 恢复本机行（两条 importSettings 子路径都覆盖）。
+  - `settingsPrefPredicate` 去掉 `NOT LIKE 'sync_%'` 例外 → sync 开关归 settings（导出剥离+导入回插共用谓词，天然对称）。
+  - 新增 `_stripExcludedContentRegistry`：favorites 跟 books、字体键跟 fonts、`local_audio_dbs`+`audio_source_configs`(按 `kind==localAudio` 条目筛，B) 跟 localAudio；新增 `_restoreExcludedContentRegistry` 覆盖式导入据 `meta.excludedCategories` 从 bak 保留本机。
+  - 恢复函数容错化（假/坏库 debugPrint 不阻断导入，仿 `_readDeviceLocalPrefs`）。
+  - 计划：`docs/superpowers/plans/2026-07-14-backup-export-category-gating.md`。提交见本分支/PR。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/backup_share_sanitization_test.dart`（11 例：导出剥离 token/baseline/favorites/fonts/audio(B)/sync 开关 + 覆盖导入保留本机 pairing/favorites + 全量迁移不变）；`hibiki/test/sync/backup_device_local_leak_guard_test.dart`（源码扫描守卫 `_stripCredentials` 覆盖两表）；更新 `backup_local_audio_portability_test.dart` 旧契约为新隐私契约。`flutter test test/sync/` 除 1 条预存无关失败(`sync_settings_visibility` auto-sync 门控，e6114bec1 引入，非本改动)外全绿。
+- **备注**：合并模式 `BackupMergeEngine` 已跳过 `sync_baselines`/`media_sources`/deviceLocalPrefKeys 且不碰 `hibiki_paired_peers`，加法式合并不受导出剥离影响；仅覆盖式导入需补对称。用户确认映射表 + `audio_source_configs` 选 B(按条目筛保留 remote)。契约变更：db-only 备份不勾 localAudio 时不再保留 `local_audio_dbs` 注册表（旧「runtime filename resolution」便利让位于隐私）。

--- a/hibiki/lib/src/sync/backup_service.dart
+++ b/hibiki/lib/src/sync/backup_service.dart
@@ -461,6 +461,23 @@ class BackupService {
   /// strip must never delete it.
   static const String _favoriteSentencesPrefKey = 'favorite_sentences';
 
+  /// Device-local tables that must NEVER travel in a shared backup and are
+  /// always restored from this device's pre-restore bak on an overwrite import
+  /// (BUG-812). Same philosophy as [SyncRepository.deviceLocalPrefKeys]:
+  ///   - `hibiki_paired_peers` — LAN pairing rows including the plaintext auth
+  ///     `token` (a live credential the HBK-AUDIT-012 pref-key sweep missed
+  ///     because it lives in its own table, not `preferences`).
+  ///   - `sync_baselines`      — per-asset incremental-sync causality; carrying
+  ///     it to another device corrupts later fork detection (mirrors why
+  ///     `_keyCollectionsBaselineMs` is device-local).
+  /// Neither is FK-targeted by a content table, so a wholesale DELETE / swap is
+  /// safe. The merge engine already skips both, so only the overwrite path needs
+  /// the restore.
+  static const List<String> _deviceLocalTables = <String>[
+    'hibiki_paired_peers',
+    'sync_baselines',
+  ];
+
   /// Content tables stripped from the exported DB copy when the `statistics`
   /// category is unticked (TODO-1193). None is FK-targeted by another content
   /// table, so a wholesale DELETE is safe.
@@ -491,11 +508,19 @@ class BackupService {
   /// EXCLUDES (preserves) the rows owned by other categories or that are
   /// content, so an "exclude settings" export never collaterally drops them:
   ///   - `audiobook_pos_*`         -> progress (the `progress` category)
-  ///   - `sync_*`                  -> device-local sync config (never travels)
-  ///   - `favorite_sentences`      -> favorites content (travels / merges)
-  ///   - `local_audio_dbs`         -> local-audio registry (`localAudio`)
-  ///   - `audio_source_configs`    -> audio-source config
-  ///   - font catalog + legacy font prefs -> font registry (`fonts`)
+  ///   - `favorite_sentences`      -> favorites content, gated on `books`
+  ///     (BUG-812, stripped/restored separately by the content-registry path)
+  ///   - `local_audio_dbs`         -> local-audio registry (`localAudio`, BUG-812)
+  ///   - `audio_source_configs`    -> audio-source config (`localAudio`, BUG-812)
+  ///   - font catalog + legacy font prefs -> font registry (`fonts`, BUG-812)
+  /// BUG-812: `sync_*` behaviour toggles ARE settings (see `sync_repository.dart`
+  /// — they are treated as user settings that travel), so they are NO LONGER
+  /// excepted here: unticking `settings` now strips them from the export and the
+  /// import restores them from bak. The device-local sync CONFIG / credentials
+  /// (`deviceLocalPrefKeys`) are handled out-of-band by `_stripCredentials`
+  /// (export) + `_applyPreservedConfig` (import, authoritative last word), so
+  /// letting this predicate also touch them on a settings-excluded restore is a
+  /// harmless no-op that `_applyPreservedConfig` overrides.
   /// Used SYMMETRICALLY by the export strip and the import preserve-from-bak so
   /// a `settings`-excluded backup and its restore never diverge.
   static final String settingsPrefPredicate = _buildSettingsPrefPredicate();
@@ -512,7 +537,6 @@ class BackupService {
         .map((String k) => "'${k.replaceAll("'", "''")}'")
         .join(', ');
     return "key NOT LIKE 'audiobook_pos_%' "
-        "AND key NOT LIKE 'sync_%' "
         'AND key NOT IN ($notIn)';
   }
 
@@ -922,6 +946,17 @@ class BackupService {
         );
       }
 
+      // BUG-812: content-registry preference rows follow their OWNING content
+      // category, not `settings` — strip favorites when `books` is unticked,
+      // the font registry when `fonts` is, and the local-audio registry (incl.
+      // the localAudio entries of `audio_source_configs`) when `localAudio` is.
+      await _stripExcludedContentRegistry(
+        tmpDir.path,
+        stripFavorites: !includeBooks,
+        stripFonts: !wants(BackupCategory.fonts),
+        stripLocalAudio: !wants(BackupCategory.localAudio),
+      );
+
       final books = await _db.getAllEpubBooks();
       final stats = await _db.getAllReadingStatistics();
       // The count reported to the import confirm dialog must reflect what is
@@ -1164,10 +1199,61 @@ class BackupService {
         " OR key LIKE 'sync_%private_key%'"
         " OR key = 'sync_desktop_credentials'",
       );
+      // BUG-812: device-local tables (LAN pairing token + sync baselines) live
+      // outside `preferences`, so the key sweeps above never touched them and a
+      // shared backup leaked the plaintext pairing `token`. Wipe them from the
+      // export copy unconditionally — they are meaningless (or harmful) on any
+      // other device and are restored from bak on an overwrite import.
+      for (final String table in _deviceLocalTables) {
+        await db.customStatement('DELETE FROM $table');
+      }
       await db.customStatement('VACUUM');
       await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
     } finally {
       await db.close();
+    }
+  }
+
+  /// Restores [_deviceLocalTables] from [bakPath] (this device's pre-import
+  /// snapshot) into the freshly-overwritten DB in [dbDirectory] (BUG-812). The
+  /// backup carries these tables EMPTY by design (`_stripCredentials`), so
+  /// without this the overwrite would wipe this device's LAN pairings and sync
+  /// baselines. Runs inline during import while both DBs are at the current
+  /// schema (bak is a copy of the live DB), so `SELECT *` columns align. No-op
+  /// (logged) if bak is gone.
+  static Future<void> _restoreDeviceLocalTablesFromBak(
+    String dbDirectory,
+    String bakPath,
+  ) async {
+    if (!File(bakPath).existsSync()) {
+      debugPrint('BackupService._restoreDeviceLocalTablesFromBak: '
+          'pre-restore.bak missing — local pairing/baselines could not be '
+          'preserved on import.');
+      return;
+    }
+    HibikiDatabase? db;
+    try {
+      db = HibikiDatabase(dbDirectory);
+      final String safeBak =
+          bakPath.replaceAll(r'\', '/').replaceAll("'", "''");
+      await db.customStatement("ATTACH DATABASE '$safeBak' AS devbak");
+      await db.transaction(() async {
+        for (final String t in _deviceLocalTables) {
+          await db!.customStatement('DELETE FROM $t');
+          await db.customStatement('INSERT INTO $t SELECT * FROM devbak.$t');
+        }
+      });
+      await db.customStatement('DETACH DATABASE devbak');
+      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+    } catch (e, st) {
+      // Best-effort preservation: a corrupt/unreadable imported DB must not
+      // abort the whole restore (the primary overwrite already landed).
+      debugPrint('BackupService._restoreDeviceLocalTablesFromBak failed: '
+          '$e\n$st');
+    } finally {
+      try {
+        await db?.close();
+      } catch (_) {/* db may have failed to open */}
     }
   }
 
@@ -1236,6 +1322,139 @@ class BackupService {
       await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
     } finally {
       await db.close();
+    }
+  }
+
+  /// BUG-812: strips the content-registry preference rows whose OWNING content
+  /// category the user unticked, from the standalone export DB copy. Each key is
+  /// governed by the feature it belongs to, NOT `settings`:
+  ///  - favorites (`favorite_sentences`)          -> `books`
+  ///  - font catalog + legacy font prefs          -> `fonts`
+  ///  - local-audio registry (`local_audio_dbs`)  -> `localAudio`
+  ///  - `audio_source_configs` localAudio entries -> `localAudio` (option B:
+  ///    only the `kind == 'localAudio'` entries carrying this device's absolute
+  ///    `.db` paths are dropped; remote audio-source entries are kept).
+  /// Mirrored on an overwrite import by [_restoreExcludedContentRegistry].
+  static Future<void> _stripExcludedContentRegistry(
+    String dbDirectory, {
+    required bool stripFavorites,
+    required bool stripFonts,
+    required bool stripLocalAudio,
+  }) async {
+    if (!stripFavorites && !stripFonts && !stripLocalAudio) return;
+    final HibikiDatabase db = HibikiDatabase(dbDirectory);
+    try {
+      if (stripFavorites) {
+        await db.customStatement(
+            "DELETE FROM preferences WHERE key = '$_favoriteSentencesPrefKey'");
+      }
+      if (stripFonts) {
+        for (final String k in <String>[
+          _fontCatalogPrefKey,
+          ..._legacyFontPrefKeys,
+        ]) {
+          await db.customStatement("DELETE FROM preferences WHERE key = '$k'");
+        }
+      }
+      if (stripLocalAudio) {
+        await db.customStatement(
+            "DELETE FROM preferences WHERE key = '$_localAudioDbsPrefKey'");
+        await _filterLocalAudioFromAudioSourceConfigs(db);
+      }
+      await db.customStatement('VACUUM');
+      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+    } finally {
+      await db.close();
+    }
+  }
+
+  /// Rewrites the `audio_source_configs` pref (BUG-812 option B): removes only
+  /// its `kind == 'localAudio'` entries (they carry this device's absolute `.db`
+  /// paths), keeping remote audio-source entries. Preserves the [PrefCodec] tag
+  /// on write. No-op if the pref is absent, unparseable, or has no local-audio
+  /// entry.
+  static Future<void> _filterLocalAudioFromAudioSourceConfigs(
+      HibikiDatabase db) async {
+    final rows = await db
+        .customSelect('SELECT value FROM preferences '
+            "WHERE key = '$_audioSourceConfigsPrefKey'")
+        .get();
+    if (rows.isEmpty) return;
+    final String? raw = rows.first.read<String?>('value');
+    if (raw == null) return;
+    final dynamic decoded = PrefCodec.decodeUntyped(raw);
+    if (decoded is! List) return;
+    final List<dynamic> kept = decoded
+        .where((dynamic e) => !(e is Map && e['kind'] == 'localAudio'))
+        .toList();
+    if (kept.length == decoded.length) return; // no local-audio entry to strip
+    if (kept.isEmpty) {
+      await db.customStatement('DELETE FROM preferences '
+          "WHERE key = '$_audioSourceConfigsPrefKey'");
+      return;
+    }
+    await db.customStatement(
+      'UPDATE preferences SET value = ? WHERE key = ?',
+      <Object?>[PrefCodec.encode(kept), _audioSourceConfigsPrefKey],
+    );
+  }
+
+  /// BUG-812: restores the content-registry preference rows from [bakPath] when
+  /// the backup EXCLUDED their owning category, so an overwrite import of a
+  /// books / fonts / localAudio-excluded backup never wipes this device's
+  /// favorites / font registry / local-audio registry to empty. Mirror of
+  /// [_stripExcludedContentRegistry]. `audio_source_configs` is restored whole
+  /// from bak (the device keeps its own audio setup when localAudio was
+  /// excluded), which subsumes the export-side B-filter. No-op (logged) if bak
+  /// is gone.
+  static Future<void> _restoreExcludedContentRegistry(
+    String dbDirectory,
+    String bakPath, {
+    required bool restoreFavorites,
+    required bool restoreFonts,
+    required bool restoreLocalAudio,
+  }) async {
+    final List<String> keys = <String>[
+      if (restoreFavorites) _favoriteSentencesPrefKey,
+      if (restoreFonts) ...<String>[
+        _fontCatalogPrefKey,
+        ..._legacyFontPrefKeys
+      ],
+      if (restoreLocalAudio) ...<String>[
+        _localAudioDbsPrefKey,
+        _audioSourceConfigsPrefKey,
+      ],
+    ];
+    if (keys.isEmpty) return;
+    if (!File(bakPath).existsSync()) {
+      debugPrint('BackupService._restoreExcludedContentRegistry: '
+          'pre-restore.bak missing — local favorites/fonts/audio registry could '
+          'not be preserved for a category-excluded backup.');
+      return;
+    }
+    HibikiDatabase? db;
+    try {
+      db = HibikiDatabase(dbDirectory);
+      final String safeBak =
+          bakPath.replaceAll(r'\', '/').replaceAll("'", "''");
+      final String inList =
+          keys.map((String k) => "'${k.replaceAll("'", "''")}'").join(', ');
+      await db.customStatement("ATTACH DATABASE '$safeBak' AS crbak");
+      await db.transaction(() async {
+        await db!
+            .customStatement('DELETE FROM preferences WHERE key IN ($inList)');
+        await db.customStatement('INSERT INTO preferences '
+            'SELECT * FROM crbak.preferences WHERE key IN ($inList)');
+      });
+      await db.customStatement('DETACH DATABASE crbak');
+      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+    } catch (e, st) {
+      debugPrint('BackupService._restoreExcludedContentRegistry failed: '
+          '$e\n$st');
+    } finally {
+      try {
+        await db?.close();
+      } catch (_) {/* db may have failed to open */}
     }
   }
 
@@ -1349,6 +1568,16 @@ class BackupService {
               false;
       final bool backupProfilesExcluded =
           meta?.excludedCategories.contains(BackupCategory.profiles.name) ??
+              false;
+      // BUG-812: content-registry prefs (favorites / fonts / local-audio) travel
+      // EMPTY when their owning category was unticked, so an overwrite import
+      // must preserve THIS device's rows from bak instead of wiping them.
+      final bool backupBooksExcluded =
+          meta?.excludedCategories.contains(BackupCategory.books.name) ?? false;
+      final bool backupFontsExcluded =
+          meta?.excludedCategories.contains(BackupCategory.fonts.name) ?? false;
+      final bool backupLocalAudioExcluded =
+          meta?.excludedCategories.contains(BackupCategory.localAudio.name) ??
               false;
 
       final String? dictionaryRestoreDirectory = dictionaryResourceDirectory;
@@ -1560,6 +1789,25 @@ class BackupService {
       } else if (haveCurrent) {
         // Keep this device's whole settings layer.
         await _restoreSettingsLayer(dbDirectory);
+      }
+
+      // 3a) BUG-812: the export wipes device-local tables (LAN pairing token +
+      //     sync baselines) unconditionally, so they arrive EMPTY. Restore this
+      //     device's rows from bak on any overwrite import (both importSettings
+      //     branches) — else the overwrite would wipe the device's pairings and
+      //     baselines. No-op on a fresh install (no bak).
+      if (haveCurrent) {
+        await _restoreDeviceLocalTablesFromBak(dbDirectory, bakPath);
+        // BUG-812: preserve THIS device's content-registry prefs from bak when
+        // the backup excluded their owning category (books/fonts/localAudio) —
+        // runs in both importSettings branches, mirroring the export strip.
+        await _restoreExcludedContentRegistry(
+          dbDirectory,
+          bakPath,
+          restoreFavorites: backupBooksExcluded,
+          restoreFonts: backupFontsExcluded,
+          restoreLocalAudio: backupLocalAudioExcluded,
+        );
       }
 
       // 3b) Rebase the imported DB's stored absolute paths (which point at the

--- a/hibiki/test/sync/backup_device_local_leak_guard_test.dart
+++ b/hibiki/test/sync/backup_device_local_leak_guard_test.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-812 regression guard (source scan): the LAN pairing `token` and sync
+/// baselines live in their OWN tables (`hibiki_paired_peers` / `sync_baselines`),
+/// which the `preferences`-key credential sweeps cannot reach. A future refactor
+/// that drops the table wipe from `_stripCredentials` would silently re-leak the
+/// plaintext pairing token into every shared backup. Lock the invariant in
+/// source: `_deviceLocalTables` must list both tables AND `_stripCredentials`
+/// must delete every device-local table.
+void main() {
+  test('_stripCredentials wipes the device-local pairing/baseline tables', () {
+    final File f = File('lib/src/sync/backup_service.dart');
+    expect(f.existsSync(), isTrue, reason: 'run from the hibiki/ package root');
+    final String s = f.readAsStringSync();
+
+    // The device-local table registry names both tables.
+    final int listStart = s.indexOf('_deviceLocalTables');
+    expect(listStart, greaterThan(-1),
+        reason: '_deviceLocalTables constant must exist');
+    final int listEnd = s.indexOf('];', listStart);
+    expect(listEnd, greaterThan(listStart));
+    final String listBody = s.substring(listStart, listEnd);
+    expect(listBody.contains("'hibiki_paired_peers'"), isTrue,
+        reason:
+            'pairing table (holds the plaintext token) must be device-local');
+    expect(listBody.contains("'sync_baselines'"), isTrue,
+        reason: 'sync baselines must be device-local');
+
+    // _stripCredentials must iterate the device-local tables and DELETE them,
+    // so the export copy carries neither the token nor the baselines.
+    final int stripStart = s.indexOf('_stripCredentials(String dbDirectory)');
+    expect(stripStart, greaterThan(-1), reason: '_stripCredentials must exist');
+    final int stripEnd = s.indexOf('static Future<void> _restore', stripStart);
+    expect(stripEnd, greaterThan(stripStart));
+    final String stripBody = s.substring(stripStart, stripEnd);
+    expect(
+      stripBody.contains('_deviceLocalTables') &&
+          stripBody.contains('DELETE FROM \$table'),
+      isTrue,
+      reason: '_stripCredentials must DELETE every _deviceLocalTables entry',
+    );
+  });
+}

--- a/hibiki/test/sync/backup_local_audio_portability_test.dart
+++ b/hibiki/test/sync/backup_local_audio_portability_test.dart
@@ -168,8 +168,8 @@ void main() {
     });
 
     test(
-        'a db-only backup (no localAudio category) leaves stored audio paths '
-        'untouched — playback relies on runtime filename resolution', () async {
+        'BUG-812: unticking localAudio strips the local_audio_dbs registry from '
+        'the export (paths are personal) — a fresh import has none', () async {
       final String srcDbDir = p.join(src.path, 'db');
       Directory(srcDbDir).createSync(recursive: true);
       final String laPath = p.join(srcDbDir, 'local_audio_333.db');
@@ -191,27 +191,25 @@ void main() {
       final BackupService service =
           BackupService(db: db, dbDirectory: srcDbDir, appVersion: '1.0.0');
       final String zip = p.join(src.path, 'books_only.zip');
+      // Empty set = every category unticked, including localAudio → the
+      // local-audio registry (which holds this device's absolute `.db` paths)
+      // must be stripped from the exported DB copy (BUG-812).
       await service.exportBackup(zip, categories: <BackupCategory>{});
       await db.close();
 
       final String dstDbDir = p.join(dst.path, 'db');
       Directory(dstDbDir).createSync(recursive: true);
+      // Fresh device (no current DB), so there is nothing to preserve from bak;
+      // the imported registry is simply absent.
       await BackupService.importBackupFiles(
           dbDirectory: dstDbDir, zipPath: zip);
 
       final HibikiDatabase restored = HibikiDatabase(dstDbDir);
       try {
         final Map<String, String> prefs = await restored.getAllPrefs();
-        final List<dynamic> dbs = jsonDecode(
-                PrefCodec.decode<String>(prefs['local_audio_dbs']!, '[]'))
-            as List<dynamic>;
-        final String path = (dbs.single as Map)['path'] as String;
-        // No files crossed over (localAudioRoot null), so import does NOT open
-        // the DB to rewrite prefs — the stored path stays as-is. Cross-machine
-        // playback of copies that DID travel is handled at bind time by
-        // LocalAudioManager.resolveInternalPath (filename resolution), covered
-        // by local_audio_manager_resolve_test.dart.
-        expect(path, laPath);
+        expect(prefs.containsKey('local_audio_dbs'), isFalse,
+            reason:
+                'localAudio unticked → registry paths never leave the device');
       } finally {
         await restored.close();
       }

--- a/hibiki/test/sync/backup_share_sanitization_test.dart
+++ b/hibiki/test/sync/backup_share_sanitization_test.dart
@@ -1,0 +1,318 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:drift/drift.dart' show Variable;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/backup_service.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+import 'temp_dir_cleanup.dart';
+
+/// BUG-812: a backup meant to be SHARED must not leak this device's personal
+/// data. Every personal item follows its OWNING feature category — untick the
+/// feature and its data disappears from the export — and the LAN pairing
+/// credential (`hibiki_paired_peers.token`) plus device-local sync baselines
+/// never travel at all. The overwrite import mirrors each strip by preserving
+/// THIS device's rows from bak, so a category-excluded backup never wipes them.
+void main() {
+  late Directory src;
+  late Directory work;
+
+  setUp(() async {
+    src = await Directory.systemTemp.createTemp('share_src_');
+    work = await Directory.systemTemp.createTemp('share_work_');
+  });
+  tearDown(() async {
+    for (final Directory d in <Directory>[src, work]) {
+      if (d.existsSync()) await cleanupTempDir(d);
+    }
+  });
+
+  Future<Archive> readZip(String zipPath) async {
+    final InputFileStream input = InputFileStream(zipPath);
+    try {
+      return ZipDecoder().decodeBuffer(input);
+    } finally {
+      await input.close();
+    }
+  }
+
+  int seq = 0;
+  Future<HibikiDatabase> openBackupDb(String zipPath) async {
+    final Archive archive = await readZip(zipPath);
+    final ArchiveFile dbFile = archive.findFile('hibiki.db')!;
+    final Directory dir = Directory(p.join(work.path, 'exdb${seq++}'))
+      ..createSync(recursive: true);
+    File(p.join(dir.path, 'hibiki.db'))
+        .writeAsBytesSync(dbFile.content as List<int>);
+    return HibikiDatabase(dir.path);
+  }
+
+  Future<int> tableCount(HibikiDatabase db, String table) async =>
+      (await db.customSelect('SELECT COUNT(*) c FROM $table').getSingle())
+          .data['c'] as int;
+
+  Future<int> prefCount(HibikiDatabase db, String key) async =>
+      (await db.customSelect('SELECT COUNT(*) c FROM preferences WHERE key = ?',
+              variables: <Variable<Object>>[Variable<String>(key)]).getSingle())
+          .data['c'] as int;
+
+  Future<String?> prefRaw(HibikiDatabase db, String key) async {
+    final rows = await db.customSelect(
+        'SELECT value v FROM preferences WHERE key = ?',
+        variables: <Variable<Object>>[Variable<String>(key)]).get();
+    if (rows.isEmpty) return null;
+    return rows.first.read<String?>('v');
+  }
+
+  /// Seeds an in-memory source device carrying every personal item, plus a
+  /// throwaway db dir the export copy is VACUUMed into.
+  Future<({BackupService service, HibikiDatabase db})> buildSensitiveSource(
+      {String favMarker = 'srcfav'}) async {
+    final String dbDir = p.join(src.path, 'db');
+    Directory(dbDir).createSync(recursive: true);
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    await db.insertEpubBook(EpubBooksCompanion.insert(
+      bookKey: 'Bk',
+      title: 'Bk',
+      epubPath: 'x',
+      extractDir: 'y',
+      chapterCount: 1,
+      chaptersJson: '["c"]',
+      importedAt: 0,
+    ));
+    // Device-local: LAN pairing (with plaintext token) + sync baseline.
+    await db.upsertPairedPeer(HibikiPairedPeersCompanion.insert(
+        peerId: 'peer-1', token: 'SECRET_PAIR_TOKEN', pairedAtMs: 1));
+    await db.into(db.syncBaselines).insert(SyncBaselinesCompanion.insert(
+        assetKey: 'Bk', dimension: 'progress', baseVersion: 7));
+    // Content-registry prefs, each owned by a content category.
+    await db.setPref(
+        'favorite_sentences',
+        jsonEncode(<Map<String, Object?>>[
+          <String, Object?>{'id': favMarker, 'text': 'a sentence'}
+        ]));
+    await db.setPref('src:reader_ttu:font_catalog',
+        jsonEncode(<String, Object?>{'version': 1, 'fonts': <Object?>[]}));
+    await db.setPref('src:reader_ttu:custom_fonts', jsonEncode(<Object?>[]));
+    await db.setPref(
+        'local_audio_dbs',
+        jsonEncode(<Map<String, Object?>>[
+          <String, Object?>{'path': r'D:\HIBIKI\support\local_audio_1.db'}
+        ]));
+    // Stored the way PreferencesRepository writes it: a PrefCodec `j:`-tagged
+    // JSON list, so the export-side B-filter can parse & filter its entries.
+    await db.setPref(
+      'audio_source_configs',
+      PrefCodec.encode(<Map<String, Object?>>[
+        <String, Object?>{
+          'kind': 'localAudio',
+          'path': r'D:\HIBIKI\support\local_audio_1.db',
+          'enabled': true,
+        },
+        <String, Object?>{
+          'kind': 'hibikiRemote',
+          'url': 'http://server.example/',
+          'enabled': true,
+        },
+      ]),
+    );
+    // Sync behaviour toggles (settings) — `b:`-tagged like the real app.
+    await db.setPref('sync_content_enabled', PrefCodec.encode(true));
+    await db.setPref('sync_auto_enabled', PrefCodec.encode(true));
+
+    final BackupService service =
+        BackupService(db: db, dbDirectory: dbDir, appVersion: '1.0.0');
+    return (service: service, db: db);
+  }
+
+  Set<BackupCategory> allExcept(BackupCategory c) =>
+      BackupCategory.values.toSet()..remove(c);
+
+  group('export sanitization', () {
+    test(
+        'device-local pairing token + sync baselines never travel (even with '
+        'all categories)', () async {
+      final built = await buildSensitiveSource();
+      final String zip = p.join(work.path, 'all.zip');
+      await built.service.exportBackup(zip); // null = every category
+      await built.db.close();
+
+      final HibikiDatabase ex = await openBackupDb(zip);
+      addTearDown(ex.close);
+      expect(await tableCount(ex, 'hibiki_paired_peers'), 0,
+          reason: 'LAN pairing token must never leave the device');
+      expect(await tableCount(ex, 'sync_baselines'), 0,
+          reason: 'sync baselines are device-local causality');
+    });
+
+    test('favorites follow books: unticking books strips favorite_sentences',
+        () async {
+      final built = await buildSensitiveSource();
+      final String zip = p.join(work.path, 'nobooks.zip');
+      await built.service
+          .exportBackup(zip, categories: allExcept(BackupCategory.books));
+      await built.db.close();
+
+      final HibikiDatabase ex = await openBackupDb(zip);
+      addTearDown(ex.close);
+      expect(await prefCount(ex, 'favorite_sentences'), 0);
+    });
+
+    test('favorites survive when books ticked', () async {
+      final built = await buildSensitiveSource();
+      final String zip = p.join(work.path, 'books.zip');
+      await built.service.exportBackup(zip,
+          categories: <BackupCategory>{BackupCategory.books});
+      await built.db.close();
+
+      final HibikiDatabase ex = await openBackupDb(zip);
+      addTearDown(ex.close);
+      expect(await prefCount(ex, 'favorite_sentences'), 1);
+    });
+
+    test('font registry follows fonts: unticking fonts strips catalog + legacy',
+        () async {
+      final built = await buildSensitiveSource();
+      final String zip = p.join(work.path, 'nofonts.zip');
+      await built.service
+          .exportBackup(zip, categories: allExcept(BackupCategory.fonts));
+      await built.db.close();
+
+      final HibikiDatabase ex = await openBackupDb(zip);
+      addTearDown(ex.close);
+      expect(await prefCount(ex, 'src:reader_ttu:font_catalog'), 0);
+      expect(await prefCount(ex, 'src:reader_ttu:custom_fonts'), 0);
+    });
+
+    test(
+        'local-audio registry follows localAudio; audio_source_configs keeps '
+        'only remote entries (option B)', () async {
+      final built = await buildSensitiveSource();
+      final String zip = p.join(work.path, 'noaudio.zip');
+      await built.service
+          .exportBackup(zip, categories: allExcept(BackupCategory.localAudio));
+      await built.db.close();
+
+      final HibikiDatabase ex = await openBackupDb(zip);
+      addTearDown(ex.close);
+      expect(await prefCount(ex, 'local_audio_dbs'), 0);
+      final String? raw = await prefRaw(ex, 'audio_source_configs');
+      expect(raw, isNotNull);
+      final dynamic decoded = PrefCodec.decodeUntyped(raw!);
+      expect(decoded, isA<List<dynamic>>());
+      final List<dynamic> entries = decoded as List<dynamic>;
+      expect(entries.length, 1, reason: 'only the remote entry survives');
+      expect((entries.single as Map)['kind'], 'hibikiRemote');
+    });
+
+    test('sync toggles follow settings: unticking settings strips them',
+        () async {
+      final built = await buildSensitiveSource();
+      final String zip = p.join(work.path, 'nosettings.zip');
+      await built.service
+          .exportBackup(zip, categories: allExcept(BackupCategory.settings));
+      await built.db.close();
+
+      final HibikiDatabase ex = await openBackupDb(zip);
+      addTearDown(ex.close);
+      expect(await prefCount(ex, 'sync_content_enabled'), 0);
+      expect(await prefCount(ex, 'sync_auto_enabled'), 0);
+    });
+
+    test('sync toggles survive when settings ticked', () async {
+      final built = await buildSensitiveSource();
+      final String zip = p.join(work.path, 'withsettings.zip');
+      await built.service.exportBackup(zip,
+          categories: <BackupCategory>{BackupCategory.settings});
+      await built.db.close();
+
+      final HibikiDatabase ex = await openBackupDb(zip);
+      addTearDown(ex.close);
+      expect(await prefCount(ex, 'sync_content_enabled'), 1);
+    });
+  });
+
+  group('overwrite import preserves this device (mirror of the strip)', () {
+    /// A source backup exported with [cats]; the source favorites are marked
+    /// 'srcfav' so a preserve test can tell them from the device's 'mine'.
+    Future<String> buildBackup(Set<BackupCategory>? cats) async {
+      final built = await buildSensitiveSource(favMarker: 'srcfav');
+      final String zip = p.join(work.path, 'src_${seq++}.zip');
+      await built.service.exportBackup(zip, categories: cats);
+      await built.db.close();
+      return zip;
+    }
+
+    /// Seeds an on-disk current device DB carrying its OWN pairing + favorites,
+    /// then overwrite-imports [zip]. Returns the re-opened current DB.
+    Future<HibikiDatabase> seedAndImport(String zip,
+        {required Set<BackupCategory> importCats}) async {
+      final String curDbDir = p.join(work.path, 'cur${seq++}', 'support');
+      Directory(curDbDir).createSync(recursive: true);
+      final HibikiDatabase cur0 = HibikiDatabase(curDbDir);
+      await cur0.upsertPairedPeer(HibikiPairedPeersCompanion.insert(
+          peerId: 'mydev', token: 'MY_DEVICE_TOKEN', pairedAtMs: 9));
+      await cur0.setPref(
+          'favorite_sentences',
+          jsonEncode(<Map<String, Object?>>[
+            <String, Object?>{'id': 'mine', 'text': 'my own sentence'}
+          ]));
+      await cur0.close();
+
+      await BackupService.importBackupFiles(
+        dbDirectory: curDbDir,
+        zipPath: zip,
+        importSettings: true,
+        categories: importCats,
+      );
+      return HibikiDatabase(curDbDir);
+    }
+
+    test(
+        'device pairing (token) survives an overwrite import of a normal '
+        'backup', () async {
+      final String zip = await buildBackup(null);
+      final HibikiDatabase cur =
+          await seedAndImport(zip, importCats: BackupCategory.values.toSet());
+      addTearDown(cur.close);
+      final rows = await cur
+          .customSelect('SELECT peer_id, token FROM hibiki_paired_peers')
+          .get();
+      expect(rows.length, 1);
+      expect(rows.single.read<String>('peer_id'), 'mydev');
+      expect(rows.single.read<String>('token'), 'MY_DEVICE_TOKEN',
+          reason: 'restored from this device bak, not the (empty) backup');
+    });
+
+    test('books-excluded backup does not wipe this device favorites', () async {
+      final String zip = await buildBackup(allExcept(BackupCategory.books));
+      final HibikiDatabase cur =
+          await seedAndImport(zip, importCats: BackupCategory.values.toSet());
+      addTearDown(cur.close);
+      final String? raw = await prefRaw(cur, 'favorite_sentences');
+      expect(raw, isNotNull);
+      expect(raw!.contains('mine'), isTrue,
+          reason: 'device favorites preserved from bak');
+      expect(raw.contains('srcfav'), isFalse,
+          reason: 'the excluded backup carried no favorites');
+    });
+
+    test(
+        'full backup (books ticked) overwrites favorites with the backup '
+        'copy (normal migration unchanged)', () async {
+      final String zip = await buildBackup(null);
+      final HibikiDatabase cur =
+          await seedAndImport(zip, importCats: BackupCategory.values.toSet());
+      addTearDown(cur.close);
+      final String? raw = await prefRaw(cur, 'favorite_sentences');
+      expect(raw, isNotNull);
+      expect(raw!.contains('srcfav'), isTrue,
+          reason: 'backup favorites win in overwrite when books included');
+    });
+  });
+}


### PR DESCRIPTION
## 背景
用户分享备份给他人时发现：即便在导出对话框取消勾选了 settings 等类别，导出的 `hibiki.db` 仍明文残留个人数据——尤其 `hibiki_paired_peers.token`（LAN 配对凭据，schema 明写「🔴 绝不进 sync/backup 明文导出」）、`favorite_sentences`（书名/章节/原句）、`local_audio_dbs`/`audio_source_configs`/字体的绝对路径、`sync_*` 开关、`sync_baselines`。

## 根因
`settingsPrefPredicate` 把 sync/favorites/audio/font 键全列入「永久保留」，免除一切 gating；`favorite_sentences` 无 BackupCategory 归属故永不被剥；`hibiki_paired_peers`/`sync_baselines` 全程零引用，`_stripCredentials` 只扫 preferences 表漏掉这两张独立表。

## 方案（每样数据挂回所属功能类别，取消勾选即剥离）
- **设备本地表**：`_stripCredentials` 无条件清空 `hibiki_paired_peers`(含 token) + `sync_baselines`；覆盖式导入 `_restoreDeviceLocalTablesFromBak` 从 bak 恢复本机行（两条 importSettings 子路径都覆盖）。
- **sync 开关 → settings**：`settingsPrefPredicate` 去掉 `NOT LIKE 'sync_%'` 例外（导出剥离 + 导入回插共用谓词，天然对称）。
- **favorites→books / 字体→fonts / 音频注册表→localAudio**：`_stripExcludedContentRegistry`；`audio_source_configs` 按 `kind==localAudio` 条目筛（保留 remote，选项 B）；`_restoreExcludedContentRegistry` 覆盖式导入据 `meta.excludedCategories` 从 bak 保留本机。
- 恢复函数容错化（假/坏库 debugPrint 不阻断导入）。

## 对称性 / 兼容
合并模式 `BackupMergeEngine` 已跳过 `sync_baselines`/`media_sources`/deviceLocalPrefKeys 且不碰 `hibiki_paired_peers`，加法式合并不受影响；仅覆盖式导入补对称。

## 契约变更
db-only 备份不勾 localAudio 时不再保留 `local_audio_dbs` 注册表（旧「runtime filename resolution」便利让位于隐私）。已更新 `backup_local_audio_portability_test`。

## 测试
- `test/sync/backup_share_sanitization_test.dart`（11 例：导出剥离 token/baseline/favorites/fonts/audio(B)/sync 开关 + 覆盖导入保留本机 pairing/favorites + 全量迁移不变）
- `test/sync/backup_device_local_leak_guard_test.dart`（源码扫描守卫）
- `flutter test test/sync/` 除 1 条**预存无关失败**（`sync_settings_visibility` auto-sync 门控，e6114bec1 引入）外全绿；`flutter analyze` 改动文件零问题。

BUG: docs/bugs/BUG-812-backup-export-category-gating.md
⚠️ 待真机验证导出/导入往返（模拟器或用户设备）。