### PR TITLE
fix(reader): 混合布局书文本×插画错配 spread 致合并插图失效 (BUG-817)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 798 条。点号进各自文件。
+> 共 799 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-817](bugs/BUG-817-merge-text-image-spread-mispair.md) | ✅ | ✅ | 自动跨页把文本章与固定布局插画章错配成spread导致合并插图失效 |
 | [BUG-816](bugs/BUG-816-backup-export-category-gating.md) | ✅ | ✅ | 导出未按功能类别剥离个人数据(收藏句/音频源路径/字体路径/sync开关/配对token泄漏) |
 | [BUG-815](bugs/BUG-815-init-retry-race.md) | ✅ | ✅ | 看门狗重试与在飞初始化竞态致数据全空(移动端) |
 | [BUG-814](bugs/BUG-814-interconnect-video-list-empty.md) | ✅ | ✅ | 互联开启后手机视频列表为空(host listVideos 每视频串行 ffmpeg 探测超过 client 15s 超时) |

--- a/docs/bugs/BUG-817-merge-text-image-spread-mispair.md
+++ b/docs/bugs/BUG-817-merge-text-image-spread-mispair.md
@@ -1,0 +1,45 @@
+## BUG-817 · 自动跨页把文本章与固定布局插画章错配成spread导致合并插图失效
+
+- **报告**：2026-07-15（用户：安達としまむら2 手机复现「开启『将插图页并入正文』不生效 + 翻不回去那张插画页」）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/epub/epub_spread_map.dart:250`（`_shouldPairAuto` 的 OPF `_isSpreadPair` 规则未要求两页都是纯图片页）。
+- **[x] ① 已修复** — `epub_spread_map.dart:249-258`：OPF page-spread 配对规则加 `book.isImageOnlyChapter(i) && book.isImageOnlyChapter(i+1)` 约束（与下方 rendition:spread / edge-match 规则对齐）。提交见分支 `worktree-reader-merge-spread-mispair`。
+- **[x] ② 已加自动化测试** — `hibiki/test/epub/epub_spread_map_test.dart` 新增 `BUG-817: OPF page-spread must NOT pair a reflowable text page with a fixed-layout illustration page`（TDD：撤修复即 `Expected false / Actual true` 失败，含修复后 20 项全绿）。
+
+### 根因
+
+`安達としまむら2`（電撃文庫）是**混合布局**书：正文章是 reflowable（`book-style.css`，如 p-009/p-011），插页插画是固定布局 SVG 页（`fixed-layout-jp.css` + `<svg><image xlink:href="../image/tNNN.jpg"/></svg>`，如 p-010，正文≈0 字符）。其 OPF spine 给**reflowable 文本章**也打了 `page-spread-right`，紧随的固定布局插画章打 `page-spread-left`：
+
+```
+p-009  page-spread-right                              （reflowable 正文 3346 字）
+p-010  rendition:layout-pre-paginated page-spread-left（SVG 插画 t004.jpg，正文≈0）
+p-011  （无 spread 属性）                              （reflowable 正文 クリスマス）
+```
+
+`spreadMode='auto'` 下，`_shouldPairAuto` 第一条规则 `_isSpreadPair(a.spreadProperty, b.spreadProperty)`（`epub_spread_map.dart:250` 旧码）**只看 OPF page-spread 属性、不校验两页是否都是纯图片页**，于是把**文本章 p-009 与插画章 p-010 配成畸形「文本+图」spread**。`_mergeImageEntries` 的 `isLeadingImage` 要求 `!entry.isSpread`（`:213`），被 spread 消费的 p-010 不再是「前导单图」→ **merge 永远吸收不到它**（「配对赢过合并」把插画配给了错误的邻居）。表现：
+
+- **功能①**：「将插图页并入正文」对 p-010 完全无效——它既没内联进 p-011，又卡在文本+图 spread 里（滚动模式下图不渲染）→ 用户「没生效」。
+- 被吸收章目录/翻页隐藏由 spread 抢占导致 p-010 无独立可达虚拟页 → 用户「翻不回去那张插画页」。
+- **功能②（下游）**：音频跨章 `_pauseThroughImageOnlyChapters` 对 p-010 调 `_resolveNavChapter`，因 p-010 未被吸收（在 spread 内）返回自身 → 导航到该畸形 spread 后 `_currentChapter` 停在 p-009 而非 p-011 → `_onCueChanged` 每 tick 命中 `frag.sectionIndex != _currentChapter` 早退（只高亮不 reveal）→「暂停结束后高亮跟、页面不滚」；手动重开跟随经 `snapReaderToAudio → _maybeEmitCrossChapter` 重新对齐到 p-011 才恢复。修复①后 `_resolveNavChapter(p-010)=p-011`，音频路径直接对齐 p-011，功能② 预期随之恢复（待真机复测确认）。
+
+对照：同函数 `rendition:spread`（`:253-256`）与 edge-match（`:261-264`）规则**早已**要求两页都 `isImageOnlyChapter`，唯独 OPF 规则漏了——本修复补齐这个不对称。
+
+### 修复
+
+`_shouldPairAuto` OPF 规则改为：
+```dart
+if (_isSpreadPair(a.spreadProperty, b.spreadProperty) &&
+    book.isImageOnlyChapter(i) &&
+    book.isImageOnlyChapter(i + 1)) {
+  return true;
+}
+```
+真正的两页插画跨页（两页都 image-only）仍正常配对，无回归（既有「spread pairing wins over merge」测试用两张图，仍绿）。
+
+### 验证
+
+- `flutter test test/epub/` + merged_image 相关：213 项全绿。
+- `flutter analyze`：无 issue。
+- TDD 红检：`git stash` 撤 lib 修复后 BUG-817 测试 `Expected false / Actual true` 失败。
+- **待真机/离屏合成 EPUB 复测**：开合并后 p-010 插画内联到 p-011 顶部可见；有声书跨该插画跟随不失效。**不得用本 dev 构建覆盖用户 release 1.2.0**（schema 更新 → 降级 DROP 毁库红线），真机验证用合成同构 EPUB 或等 CI 出新版。
+
+- **备注**：修复只动 `_shouldPairAuto` 一处判据，影响面 = 混合布局书里被 OPF 错误标注 spread 的文本×图边界。功能② 的独立复测跟进另记。

--- a/hibiki/lib/src/epub/epub_spread_map.dart
+++ b/hibiki/lib/src/epub/epub_spread_map.dart
@@ -246,8 +246,19 @@ class EpubSpreadMap {
     final EpubChapter a = book.chapters[i];
     final EpubChapter b = book.chapters[i + 1];
 
-    // OPF metadata: explicit left+right pair.
-    if (_isSpreadPair(a.spreadProperty, b.spreadProperty)) return true;
+    // OPF metadata: explicit left+right pair — but only between two fixed-layout
+    // illustration pages. BUG-817: hybrid books (e.g. 電撃文庫 light novels) also
+    // stamp page-spread-left/right on *reflowable text* pages; pairing a text page
+    // with the following fixed-layout illustration page swallowed the image into a
+    // nonsensical text|image spread, which then acted as a merge barrier so the
+    // illustration was never absorbed into the prose ("将插图页并入正文" no-op, the
+    // picture vanishing entirely). Require both image-only, matching the two rules
+    // below, so only genuine two-page illustration spreads pair.
+    if (_isSpreadPair(a.spreadProperty, b.spreadProperty) &&
+        book.isImageOnlyChapter(i) &&
+        book.isImageOnlyChapter(i + 1)) {
+      return true;
+    }
 
     // Book-level rendition:spread with image-only chapters.
     if (book.renditionSpread != null &&

--- a/hibiki/test/epub/epub_spread_map_test.dart
+++ b/hibiki/test/epub/epub_spread_map_test.dart
@@ -430,6 +430,47 @@ void main() {
       });
 
       test(
+          'BUG-817: OPF page-spread must NOT pair a reflowable text page with a '
+          'fixed-layout illustration page (hybrid book), or the illustration is '
+          'consumed by a bogus text|image spread and merge can never absorb it',
+          () {
+        // Real repro from 安達としまむら2 (電撃文庫 hybrid layout): reflowable
+        // text chapters carry OPF page-spread-right, and the fixed-layout SVG
+        // insert illustration that follows carries page-spread-left. The old
+        // `_isSpreadPair` rule paired them on OPF metadata alone → the image was
+        // swallowed into a nonsensical text|image spread, `isAbsorbedImageChapter`
+        // stayed false, and "将插图页并入正文" silently did nothing (the picture
+        // vanished: no standalone page, no inline injection). Pairing must require
+        // BOTH pages be image-only, exactly like the rendition:spread rule.
+        //   ch0 text(right), ch1 image(left), ch2 text — p-009/p-010/p-011.
+        final EpubBook book = _makeBook(
+          count: 3,
+          imageOnly: <bool>[false, true, false],
+          spreadProps: <String?>[
+            'page-spread-right',
+            'page-spread-left',
+            null,
+          ],
+        );
+        final EpubSpreadMap map = EpubSpreadMap.build(
+          book: book,
+          spreadMode: 'auto',
+          spreadDirection: 'rtl',
+          mergeImagePages: true,
+        );
+        // The text page is never spread-paired with the image.
+        expect(map.entryAt(map.virtualPageForChapter(0)).isSpread, isFalse,
+            reason: '文本章不得与插画章配成 spread');
+        // The illustration is absorbed into the following text chapter's top.
+        expect(map.isAbsorbedImageChapter(1), isTrue,
+            reason: '插画应被 merge 吸收进后随正文，而非被 spread 消费');
+        expect(map.mergedImagesForChapter(2), <int>[1]);
+        // Pages collapse to [ch0 text], [ch2 text + inline img1].
+        expect(map.length, 2);
+        expect(map.entryAt(1).chapterIndex, 2);
+      });
+
+      test(
           'merge folds each leading image run into the next text chapter '
           '(TODO-1174)', () {
         // text, img, img, text, img, text


### PR DESCRIPTION
## 根因
`安達としまむら2`(電撃文庫)是混合布局书:reflowable 正文章 + 固定布局 SVG 插画页。其 OPF spine 给**文本章**也打了 `page-spread-right`,紧随的固定布局插画章打 `page-spread-left`。

`spreadMode='auto'` 下 `_shouldPairAuto` 的 OPF 规则 `_isSpreadPair`(`epub_spread_map.dart:250` 旧码)**只看 OPF 属性、不校验两页都是纯图片页**,把**文本章 p-009 与插画章 p-010 配成畸形『文本+图』spread**。`_mergeImageEntries` 的 `isLeadingImage` 要求 `!entry.isSpread`,被 spread 消费的 p-010 不再是前导单图 → **merge 永远吸收不到它**。

- **功能①**:「将插图页并入正文」对该插画无效,且卡在 spread 里滚动模式不渲染 → 用户「没生效」+「翻不回去那张插画页」。
- **功能②(下游)**:音频跨章 `_pauseThroughImageOnlyChapters` 对 p-010 `_resolveNavChapter` 返回自身(未吸收)→ 导航到畸形 spread 后 `_currentChapter` 停在 p-009 ≠ cue.section(p-011)→ `_onCueChanged` 早退只高亮不 reveal → 暂停结束后高亮跟、页面不滚;手动重开跟随经 `snapReaderToAudio` 重对齐才恢复。修复①后 `_resolveNavChapter(p-010)=p-011`,预期随之恢复(待真机复测)。

对照:同函数 rendition:spread / edge-match 规则**早已**要求两页都 image-only,唯独 OPF 规则漏了——本 PR 补齐不对称。

## 修复
`_shouldPairAuto` OPF 规则加 `isImageOnlyChapter(i) && isImageOnlyChapter(i+1)`。真正两页插画跨页(都 image-only)仍配对,无回归。

## 测试
- TDD:`test/epub/epub_spread_map_test.dart` 新增 BUG-817 复现测试(撤修复即 `Expected false / Actual true` 失败)。
- `flutter test test/epub/` + merged_image:213 项全绿;`flutter analyze`:无 issue。

## 待验(真机/离屏,禁用 dev 构建覆盖用户 release 1.2.0)
- [ ] 开合并后插画内联到后随正文顶部可见
- [ ] 有声书跨该插画跟随不失效(功能②)

见 `docs/bugs/BUG-817-merge-text-image-spread-mispair.md`。