### PR TITLE
feat(collections): 删除合集可选连同书/视频本体一起删

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39831 (2343 per locale)
+/// Strings: 39865 (2345 per locale)
 ///
-/// Built on 2026-07-14 at 15:02 UTC
+/// Built on 2026-07-14 at 16:18 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3110,6 +3110,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Couldn\'t load qualities for this video.';
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  String get delete_collection_also_books => 'Also delete the books in it';
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -8423,6 +8426,11 @@ class _StringsAr extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -13859,6 +13867,11 @@ class _StringsDe extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -19312,6 +19325,11 @@ class _StringsEs extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -24784,6 +24802,11 @@ class _StringsFr extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -30158,6 +30181,11 @@ class _StringsId extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -35593,6 +35621,11 @@ class _StringsIt extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -40753,6 +40786,11 @@ class _StringsJa extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -45918,6 +45956,11 @@ class _StringsKo extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -51321,6 +51364,11 @@ class _StringsNl extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -56747,6 +56795,11 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -62148,6 +62201,11 @@ class _StringsRu extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -67462,6 +67520,11 @@ class _StringsTh extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -72831,6 +72894,11 @@ class _StringsTr extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -78175,6 +78243,11 @@ class _StringsVi extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -83149,6 +83222,10 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       '启动比平常慢，可能在加载较大的书库或词典。请稍候，或点「重试」重新加载——你的数据是安全的，不会丢失。';
+  @override
+  String get delete_collection_also_books => '同时删除其中的书';
+  @override
+  String get delete_collection_also_videos => '同时删除其中的视频（保留你的原始视频文件）';
 }
 
 // Path: retrying_in
@@ -88211,6 +88288,11 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get loading_slow_message_mobile =>
       'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+  @override
+  String get delete_collection_also_books => 'Also delete the books in it';
+  @override
+  String get delete_collection_also_videos =>
+      'Also delete the videos (keeps your original video files)';
 }
 
 // Path: retrying_in
@@ -93041,6 +93123,10 @@ extension on _StringsEn {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -97831,6 +97917,10 @@ extension on _StringsAr {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -102643,6 +102733,10 @@ extension on _StringsDe {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -107453,6 +107547,10 @@ extension on _StringsEs {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -112270,6 +112368,10 @@ extension on _StringsFr {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -117067,6 +117169,10 @@ extension on _StringsId {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -121881,6 +121987,10 @@ extension on _StringsIt {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -126652,6 +126762,10 @@ extension on _StringsJa {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -131427,6 +131541,10 @@ extension on _StringsKo {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -136234,6 +136352,10 @@ extension on _StringsNl {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -141038,6 +141160,10 @@ extension on _StringsPtBr {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -145846,6 +145972,10 @@ extension on _StringsRu {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -150636,6 +150766,10 @@ extension on _StringsTh {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -155435,6 +155569,10 @@ extension on _StringsTr {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -160228,6 +160366,10 @@ extension on _StringsVi {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }
@@ -164985,6 +165127,10 @@ extension on _StringsZhCn {
         return '无法获取该视频的画质档。';
       case 'loading_slow_message_mobile':
         return '启动比平常慢，可能在加载较大的书库或词典。请稍候，或点「重试」重新加载——你的数据是安全的，不会丢失。';
+      case 'delete_collection_also_books':
+        return '同时删除其中的书';
+      case 'delete_collection_also_videos':
+        return '同时删除其中的视频（保留你的原始视频文件）';
       default:
         return null;
     }
@@ -169748,6 +169894,10 @@ extension on _StringsZhHk {
         return 'Couldn\'t load qualities for this video.';
       case 'loading_slow_message_mobile':
         return 'Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won\'t be lost.';
+      case 'delete_collection_also_books':
+        return 'Also delete the books in it';
+      case 'delete_collection_also_videos':
+        return 'Also delete the videos (keeps your original video files)';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "返回",
   "video_quality_loading": "正在获取可选画质…",
   "video_quality_load_failed": "无法获取该视频的画质档。",
-  "loading_slow_message_mobile": "启动比平常慢，可能在加载较大的书库或词典。请稍候，或点「重试」重新加载——你的数据是安全的，不会丢失。"
+  "loading_slow_message_mobile": "启动比平常慢，可能在加载较大的书库或词典。请稍候，或点「重试」重新加载——你的数据是安全的，不会丢失。",
+  "delete_collection_also_books": "同时删除其中的书",
+  "delete_collection_also_videos": "同时删除其中的视频（保留你的原始视频文件）"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2349,5 +2349,7 @@
   "video_load_failed_back": "Back",
   "video_quality_loading": "Loading available qualities…",
   "video_quality_load_failed": "Couldn't load qualities for this video.",
-  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost."
+  "loading_slow_message_mobile": "Startup is taking longer than usual — Hibiki may be loading a large library or dictionaries. Please wait a moment, or tap Retry to reload. Your data is safe and won't be lost.",
+  "delete_collection_also_books": "Also delete the books in it",
+  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)"
 }

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -2611,6 +2611,20 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
           onOpenEpisode: (VideoBookRow ep) =>
               _open(ep, playlistCollectionId: collection.id),
           onChanged: _refresh,
+          // 「连同视频一起删」：逐集删视频 DB 行 + app 拥有副本（封面/字幕），保留用户
+          // 原始视频文件；逐集不 VACUUM，循环后一次性 compact（避免逐集 VACUUM）。
+          // 复用批量删除同一纪律（_batchDeleteConfirm）。
+          onDeleteMembersMedia: (List<VideoBookRow> members) async {
+            for (final VideoBookRow ep in members) {
+              await repo.deleteVideoBookAndReclaimAssets(
+                ep.bookUid,
+                compactDatabase: false,
+              );
+            }
+            if (members.isNotEmpty) {
+              await repo.compactAfterVideoDeleteBestEffort();
+            }
+          },
         ),
       ),
     );

--- a/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -22,6 +22,7 @@ class MediaCollectionDetailPage extends StatefulWidget {
     required this.loadMembers,
     required this.onOpenEpisode,
     required this.onChanged,
+    this.onDeleteMembersMedia,
     super.key,
   });
 
@@ -36,6 +37,12 @@ class MediaCollectionDetailPage extends StatefulWidget {
 
   /// 改名 / 删除后刷新库页。
   final VoidCallback onChanged;
+
+  /// 「删除合集」时可选连同各集视频本体一起删（默认不删，保持只解链语义）。
+  /// 调用方（持 [VideoBookRepository]）注入：按 [VideoBookRow] 删视频 DB 行 +
+  /// app 拥有副本（封面/字幕），**保留用户原始视频文件**（导入时只存路径从不复制）。
+  /// null = 详情页不提供该选项（确认框不显示复选框），退回纯解链删除。
+  final Future<void> Function(List<VideoBookRow> members)? onDeleteMembersMedia;
 
   @override
   State<MediaCollectionDetailPage> createState() =>
@@ -239,27 +246,56 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
   }
 
   Future<void> _delete() async {
+    // 仅当调用方注入了删本体回调、且合集当前有成员时，才给用户「连同视频一起删」
+    // 选项；否则退回纯解链删除（老行为，零变化）。
+    final bool canDeleteMembers =
+        widget.onDeleteMembersMedia != null && _members.isNotEmpty;
+    bool alsoDeleteMembers = false;
     final bool? ok = await showAppDialog<bool>(
       context: context,
-      builder: (BuildContext ctx) => AlertDialog(
-        title: Text(t.delete_collection),
-        content: Text(t.delete_collection_confirm),
-        actions: <Widget>[
-          adaptiveDialogAction(
-            context: ctx,
-            onPressed: () => Navigator.pop(ctx, false),
-            child: Text(t.dialog_cancel),
+      builder: (BuildContext ctx) => StatefulBuilder(
+        builder: (BuildContext ctx, StateSetter setLocal) => AlertDialog(
+          title: Text(t.delete_collection),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(t.delete_collection_confirm),
+              if (canDeleteMembers) ...<Widget>[
+                const SizedBox(height: 8),
+                CheckboxListTile(
+                  value: alsoDeleteMembers,
+                  onChanged: (bool? v) =>
+                      setLocal(() => alsoDeleteMembers = v ?? false),
+                  contentPadding: EdgeInsets.zero,
+                  controlAffinity: ListTileControlAffinity.leading,
+                  title: Text(t.delete_collection_also_videos),
+                ),
+              ],
+            ],
           ),
-          adaptiveDialogAction(
-            context: ctx,
-            isDestructiveAction: true,
-            onPressed: () => Navigator.pop(ctx, true),
-            child: Text(t.delete_collection),
-          ),
-        ],
+          actions: <Widget>[
+            adaptiveDialogAction(
+              context: ctx,
+              onPressed: () => Navigator.pop(ctx, false),
+              child: Text(t.dialog_cancel),
+            ),
+            adaptiveDialogAction(
+              context: ctx,
+              isDestructiveAction: true,
+              onPressed: () => Navigator.pop(ctx, true),
+              child: Text(t.delete_collection),
+            ),
+          ],
+        ),
       ),
     );
     if (ok != true) return;
+    // 先删各集视频本体（DB 行 + 封面/字幕副本），再解散容器。删视频会连带清各合集
+    // 引用行并自删空合集，故随后的 deleteMediaCollection 多为幂等收尾（写合集级墓碑）。
+    if (alsoDeleteMembers && widget.onDeleteMembersMedia != null) {
+      await widget.onDeleteMembersMedia!(List<VideoBookRow>.of(_members));
+    }
     await widget.database.deleteMediaCollection(widget.collection.id);
     if (!mounted) return;
     widget.onChanged();

--- a/hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart
@@ -23,6 +23,7 @@ class MediaCollectionGridDetailPage extends StatefulWidget {
     required this.memberCardBuilder,
     required this.onChanged,
     this.onOpenMember,
+    this.onDeleteMembersMedia,
     super.key,
   });
 
@@ -50,6 +51,13 @@ class MediaCollectionGridDetailPage extends StatefulWidget {
 
   /// 改名 / 删除 / 移出成员后刷新书架。
   final VoidCallback onChanged;
+
+  /// 「删除合集」时可选连同成员本体一起删（默认不删，保持只解链语义）。调用方
+  /// （持 AppModel + [ReaderHibikiSource] / [VideoBookRepository]）注入：按每个成员
+  /// (mediaType, entryKey) 删底层书/有声书/视频本体 + 磁盘副本，并释放空间。
+  /// null = 详情页不提供该选项（确认框不显示复选框），退回纯解链删除。
+  final Future<void> Function(List<MediaCollectionItemRow> members)?
+      onDeleteMembersMedia;
 
   @override
   State<MediaCollectionGridDetailPage> createState() =>
@@ -205,27 +213,57 @@ class _MediaCollectionGridDetailPageState
   }
 
   Future<void> _delete() async {
+    // 仅当调用方注入了删本体回调、且合集当前有成员时，才给用户「连同书一起删」
+    // 选项；否则退回纯解链删除（老行为，零变化）。
+    final bool canDeleteMembers =
+        widget.onDeleteMembersMedia != null && _rows.isNotEmpty;
+    bool alsoDeleteMembers = false;
     final bool? ok = await showAppDialog<bool>(
       context: context,
-      builder: (BuildContext ctx) => AlertDialog(
-        title: Text(t.delete_collection),
-        content: Text(t.delete_collection_confirm),
-        actions: <Widget>[
-          adaptiveDialogAction(
-            context: ctx,
-            onPressed: () => Navigator.pop(ctx, false),
-            child: Text(t.dialog_cancel),
+      builder: (BuildContext ctx) => StatefulBuilder(
+        builder: (BuildContext ctx, StateSetter setLocal) => AlertDialog(
+          title: Text(t.delete_collection),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(t.delete_collection_confirm),
+              if (canDeleteMembers) ...<Widget>[
+                const SizedBox(height: 8),
+                CheckboxListTile(
+                  value: alsoDeleteMembers,
+                  onChanged: (bool? v) =>
+                      setLocal(() => alsoDeleteMembers = v ?? false),
+                  contentPadding: EdgeInsets.zero,
+                  controlAffinity: ListTileControlAffinity.leading,
+                  title: Text(t.delete_collection_also_books),
+                ),
+              ],
+            ],
           ),
-          adaptiveDialogAction(
-            context: ctx,
-            isDestructiveAction: true,
-            onPressed: () => Navigator.pop(ctx, true),
-            child: Text(t.delete_collection),
-          ),
-        ],
+          actions: <Widget>[
+            adaptiveDialogAction(
+              context: ctx,
+              onPressed: () => Navigator.pop(ctx, false),
+              child: Text(t.dialog_cancel),
+            ),
+            adaptiveDialogAction(
+              context: ctx,
+              isDestructiveAction: true,
+              onPressed: () => Navigator.pop(ctx, true),
+              child: Text(t.delete_collection),
+            ),
+          ],
+        ),
       ),
     );
     if (ok != true) return;
+    // 先删成员本体（书/有声书/视频 DB 行 + 磁盘副本），再解散容器。删书不动合集引用
+    // 行，故随后的 deleteMediaCollection 负责清掉残留引用 + 写合集级墓碑。
+    if (alsoDeleteMembers && widget.onDeleteMembersMedia != null) {
+      await widget
+          .onDeleteMembersMedia!(List<MediaCollectionItemRow>.of(_rows));
+    }
     await widget.database.deleteMediaCollection(widget.collection.id);
     if (!mounted) return;
     widget.onChanged();

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -1466,9 +1466,52 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             _shelfMapsFuture = _loadShelfMaps();
             if (mounted) setState(() {});
           },
+          onDeleteMembersMedia: _deleteCollectionMembersMedia,
         ),
       ),
     );
+  }
+
+  /// 「删除合集」时连同成员本体一起删：按 (mediaType, entryKey) 分派到删书/删视频。
+  /// 复用批量删除同一分派纪律（[_batchDeleteConfirm]）——epub 直接删；srt 先 findByUid
+  /// 拿 bookKey 删本体再删 srt 行；video 逐个删并末尾一次 compact。删书本身各自 VACUUM。
+  Future<void> _deleteCollectionMembersMedia(
+    List<MediaCollectionItemRow> members,
+  ) async {
+    bool anyVideo = false;
+    for (final MediaCollectionItemRow m in members) {
+      switch (m.mediaType) {
+        case 'epub':
+          await ReaderHibikiSource.instance.deleteBook(
+            db: appModel.database,
+            bookKey: m.entryKey,
+            appModel: appModel,
+          );
+        case 'srt':
+          final SrtBookRepository repo = SrtBookRepository(appModel.database);
+          final SrtBook? book = await repo.findByUid(m.entryKey);
+          if (book != null) {
+            if (book.bookKey.isNotEmpty) {
+              await ReaderHibikiSource.instance.deleteBook(
+                db: appModel.database,
+                bookKey: book.bookKey,
+                appModel: appModel,
+              );
+            }
+            await repo.delete(m.entryKey);
+          }
+        case 'video':
+          // 混合合集里若混入视频成员：删视频 DB 行 + app 拥有副本，保留原始视频文件。
+          await _videoRepo.deleteVideoBookAndReclaimAssets(
+            m.entryKey,
+            compactDatabase: false,
+          );
+          anyVideo = true;
+      }
+    }
+    if (anyVideo) {
+      await _videoRepo.compactAfterVideoDeleteBestEffort();
+    }
   }
 
   /// 系列详情页按成员行渲染卡片：epub → 经书架 provider 找 MediaItem；srt → 经 uid

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+756
+version: 1.2.0+757
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/media_collection_grid_detail_page_test.dart
+++ b/hibiki/test/pages/media_collection_grid_detail_page_test.dart
@@ -241,4 +241,87 @@ void main() {
         <String>['k1', 'k3'],
         reason: '注入的移出回调应真把 k2 从合集移除（removeFromCollection）');
   });
+
+  // ── 「删除合集」连同成员本体一起删（复选框，默认不删=只解链老行为）───────────
+  Widget wrapPageWithDelete(
+    MediaCollectionRow col,
+    HibikiDatabase db, {
+    Future<void> Function(List<MediaCollectionItemRow> members)?
+        onDeleteMembersMedia,
+  }) =>
+      TranslationProvider(
+        child: MaterialApp(
+          home: MediaCollectionGridDetailPage(
+            database: db,
+            collection: col,
+            memberCardBuilder: cardBuilder,
+            onChanged: () {},
+            onDeleteMembersMedia: onDeleteMembersMedia,
+          ),
+        ),
+      );
+
+  testWidgets('删除合集：未注入删本体回调 → 弹窗无复选框，仅解散容器（老行为零变化）',
+      (WidgetTester tester) async {
+    final ({HibikiDatabase db, MediaCollectionRow col}) s = await seed();
+    await tester.pumpWidget(wrapPage(s.col, s.db)); // 不传 onDeleteMembersMedia
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip(t.delete_collection));
+    await tester.pumpAndSettle();
+    expect(find.text(t.delete_collection_also_books), findsNothing,
+        reason: '无删本体回调时不应出现「同时删除其中的书」复选框');
+
+    await tester.tap(find.text(t.delete_collection).last); // 确认删除
+    await tester.pumpAndSettle();
+    expect(await s.db.getMediaCollectionById(s.col.id), isNull,
+        reason: '删合集仍只解散容器（deleteMediaCollection）');
+  });
+
+  testWidgets('删除合集：复选框默认不勾 → 回调不触发，只解散容器', (WidgetTester tester) async {
+    final ({HibikiDatabase db, MediaCollectionRow col}) s = await seed();
+    final List<MediaCollectionItemRow> passed = <MediaCollectionItemRow>[];
+    await tester.pumpWidget(wrapPageWithDelete(
+      s.col,
+      s.db,
+      onDeleteMembersMedia: (List<MediaCollectionItemRow> members) async =>
+          passed.addAll(members),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip(t.delete_collection));
+    await tester.pumpAndSettle();
+    expect(find.text(t.delete_collection_also_books), findsOneWidget,
+        reason: '注入删本体回调后应出现复选框');
+
+    await tester.tap(find.text(t.delete_collection).last); // 不勾直接删
+    await tester.pumpAndSettle();
+    expect(passed, isEmpty, reason: '未勾选复选框不应删成员本体');
+    expect(await s.db.getMediaCollectionById(s.col.id), isNull);
+  });
+
+  testWidgets('删除合集：勾选「同时删除其中的书」→ 回调收到全部成员再解散容器', (WidgetTester tester) async {
+    final ({HibikiDatabase db, MediaCollectionRow col}) s = await seed();
+    final List<String> passed = <String>[];
+    await tester.pumpWidget(wrapPageWithDelete(
+      s.col,
+      s.db,
+      onDeleteMembersMedia: (List<MediaCollectionItemRow> members) async =>
+          passed.addAll(members.map(
+              (MediaCollectionItemRow r) => '${r.mediaType}|${r.entryKey}')),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip(t.delete_collection));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.delete_collection_also_books)); // 勾选
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.delete_collection).last); // 确认删除
+    await tester.pumpAndSettle();
+
+    expect(passed, <String>['epub|k1', 'epub|k2', 'epub|k3'],
+        reason: '勾选后应把全部成员按 (mediaType,entryKey) 传给删本体回调');
+    expect(await s.db.getMediaCollectionById(s.col.id), isNull,
+        reason: '删成员本体后仍解散容器');
+  });
 }


### PR DESCRIPTION
## 需求
删除合集时应能选择「把其中的书/视频也一起删了」——不只是解散分组。

## 现状
两个合集详情页（书架 `MediaCollectionGridDetailPage` / 视频 `MediaCollectionDetailPage`）删合集只调 `deleteMediaCollection`——**只删分组容器 + 成员引用行，不碰书/视频本体**（Jellyfin 删 BoxSet 不删 LinkedChild 语义）。

## 改动
删除确认框加一个「同时删除其中的书/视频」**复选框**（默认不勾 = 保持只解散的老行为，向后兼容）。勾选后遍历成员按 `mediaType` 分派到现成的删本体路径：

- `epub` → `ReaderHibikiSource.deleteBook`（删解压副本 + 相关行 + VACUUM）
- `srt` → `findByUid` → `deleteBook(bookKey)` + `repo.delete(uid)`
- `video` → `deleteVideoBookAndReclaimAssets`（末尾一次 `compact`）

**删除边界**（确认框文案已说明）：
- 书 = 删 Hibiki 导入时解压出来的副本，**释放磁盘空间**（不动用户原始 .epub）
- 视频 = 删 DB 记录 + 封面/字幕副本，**保留用户原始视频文件**（导入只存路径从不复制）

两个详情页加可选回调 `onDeleteMembersMedia`，由已持 `ReaderHibikiSource`/`VideoBookRepository` 的父页面注入删本体分派；详情页只负责 UI + 遍历，顺序是**先删成员本体 → 再 `deleteMediaCollection` 解散容器**。

## 测试
- `test/pages/media_collection_grid_detail_page_test.dart` 加 3 例：无回调时无复选框（老行为零变化）/ 不勾只解散不删本体 / 勾选后回调收到全部成员再解散。全绿。
- i18n 加 2 key（`i18n_sync.dart`，17 语言齐全）；i18n 完整性测试通过。
- `flutter analyze` 4 个改动文件零问题。

## 待验收
⚠️ 未真机验收：需在真实设备上删一个含书/含视频的合集，勾选复选框，确认书/视频真的从库里消失、空间释放（书）、原始视频文件保留（视频）。