### PR TITLE
fix(lookup): 桌面查词浮窗顶部控制栏浅色下看清 + 卡片不透明 (BUG-819/818)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 799 条。点号进各自文件。
+> 共 800 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-818](bugs/BUG-818-popup-surface-translucent-wallpaper.md) | ✅ | ✅ | 查词浮窗卡片背景半透明透出壁纸浅色下看不清 |
 | [BUG-817](bugs/BUG-817-merge-text-image-spread-mispair.md) | ✅ | ✅ | 自动跨页把文本章与固定布局插画章错配成spread导致合并插图失效 |
 | [BUG-816](bugs/BUG-816-backup-export-category-gating.md) | ✅ | ✅ | 导出未按功能类别剥离个人数据(收藏句/音频源路径/字体路径/sync开关/配对token泄漏) |
 | [BUG-815](bugs/BUG-815-init-retry-race.md) | ✅ | ✅ | 看门狗重试与在飞初始化竞态致数据全空(移动端) |

--- a/docs/bugs/BUG-818-popup-surface-translucent-wallpaper.md
+++ b/docs/bugs/BUG-818-popup-surface-translucent-wallpaper.md
@@ -1,0 +1,24 @@
+## BUG-818 · 查词浮窗卡片背景半透明透出壁纸浅色下看不清
+- **报告**：2026-07-15（用户：）
+- **真实性**：✅ 真 bug — 根因 `hibiki/lib/src/pages/implementations/popup_dictionary_page.dart:330`
+- **[x] ① 已修复** — 见 `hibiki/lib/src/pages/implementations/popup_dictionary_page.dart:330`
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/popup_surface_opaque_guard_test.dart`（源码扫描守卫）
+- **备注**：
+
+### 根因
+独立查词浮窗（`hibiki/lib/popup_main.dart` 宿主 `PopupDictionaryPage`）跑在**完全透明的浮动窗**里（`popup_main.dart` 各分支 `Scaffold backgroundColor: Colors.transparent`，为圆角+阴影）。浮窗内唯一的背景是 `_buildCard` 里的 `HibikiPopupSurface`，其色 `= appModel.overrideDictionaryColor ?? tokens.surfaces.page`。
+
+- `tokens.surfaces.page = scheme.surface`（`hibiki/lib/src/utils/components/hibiki_design_tokens.dart:148`），默认不透明。
+- 但 `overrideDictionaryColor` 由阅读器主题背景灌入：`_syncDictionaryTheme` → `setOverrideDictionaryColor(bg)`，`bg = _themeBackgroundColor() = _readerThemeColors.bg`（`reader_hibiki/chrome.part.dart:1930/1887`）。某些预设/自定义阅读器主题的背景色**带 alpha**（同文件 1746 行的 frosted 逻辑也印证 bg 可被赋透明度语义）。
+
+app 内查词时浮窗背后是不透明阅读页，半透明卡片看着正常；到了独立浮窗（窗口透明），半透明卡片直接透出**桌面壁纸**，浅色壁纸下文字/边界发虚看不清。属**上下文不匹配**：同一颜色在实心页面 vs 透明浮窗上行为不同。
+
+### 修复
+`popup_dictionary_page.dart:330` 浮窗卡片色强制补满 alpha：
+```dart
+color: (appModel.overrideDictionaryColor ?? tokens.surfaces.page).withValues(alpha: 1.0),
+```
+浮窗卡片是透明窗上唯一背景层，理应恒不透明——消除“卡片可能半透明”这一特殊情况。主题色本就不透明时该调用是 no-op，零破坏（app 内不受影响）。
+
+### 测试
+`hibiki/test/pages/popup_surface_opaque_guard_test.dart`：源码扫描守卫，断言浮窗卡片 `HibikiPopupSurface(color: ...)` 那行对 `overrideDictionaryColor ?? tokens.surfaces.page` 施加了 `.withValues(alpha: 1.0)`，防止未来重构重新引入透明浮窗透壁纸。

--- a/hibiki/lib/src/pages/implementations/popup_dictionary_page.dart
+++ b/hibiki/lib/src/pages/implementations/popup_dictionary_page.dart
@@ -327,7 +327,8 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
 
   Widget _buildCard(HibikiDesignTokens tokens) {
     final Widget card = HibikiPopupSurface(
-      color: appModel.overrideDictionaryColor ?? tokens.surfaces.page,
+      color: (appModel.overrideDictionaryColor ?? tokens.surfaces.page)
+          .withValues(alpha: 1.0),
       child: Column(
         children: [
           // TODO-951 症状B：关闭是「结果」，滑动只是其中一种「触发行为」，二者解耦。

--- a/hibiki/test/pages/popup_surface_opaque_guard_test.dart
+++ b/hibiki/test/pages/popup_surface_opaque_guard_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 源码扫描守卫（BUG-818）：独立查词浮窗（`lib/popup_main.dart` 宿主 `PopupDictionaryPage`）
+/// 跑在**完全透明的浮动窗**里（圆角+阴影靠内部卡片画），窗内唯一背景是 `_buildCard` 的
+/// `HibikiPopupSurface`。其色 `appModel.overrideDictionaryColor ?? tokens.surfaces.page`
+/// 会灌入阅读器主题背景色（`_syncDictionaryTheme`），某些预设/自定义主题背景**带 alpha**；
+/// 在透明浮窗上半透明卡片直接透出**桌面壁纸**，浅色壁纸下文字/边界看不清。
+///
+/// 修复把该卡片色强制补满 alpha（`.withValues(alpha: 1.0)`）。浮窗卡片是透明窗上唯一背景层，
+/// 理应恒不透明——app 内背后是不透明阅读页不受影响，no-op。此守卫锁死不变式，防重构去掉
+/// alpha 补齐又让透明主题色透出宿主壁纸（无法用 flutter test 直接驱动独立浮窗宿主窗，故源码扫描）。
+void main() {
+  final File page = File(
+    'lib/src/pages/implementations/popup_dictionary_page.dart',
+  );
+
+  late final String flat;
+
+  setUpAll(() {
+    expect(page.existsSync(), isTrue,
+        reason: 'popup_dictionary_page.dart 应存在: ${page.path}');
+    // 去空白后匹配，抗 dart format 换行。
+    flat = page.readAsStringSync().replaceAll(RegExp(r'\s+'), '');
+  });
+
+  group('BUG-818 查词浮窗卡片背景恒不透明', () {
+    test('_buildCard 的 HibikiPopupSurface color 对主题色补满 alpha=1.0', () {
+      expect(
+        flat.contains(
+          'color:(appModel.overrideDictionaryColor??tokens.surfaces.page)'
+          '.withValues(alpha:1.0),',
+        ),
+        isTrue,
+        reason: '浮窗卡片是透明窗上唯一背景层，须强制不透明，'
+            '否则带 alpha 的阅读器主题色会透出桌面壁纸（BUG-818）',
+      );
+    });
+
+    test('未包裹的半透明形状不得复现（防回归）', () {
+      expect(
+        flat.contains(
+          'color:appModel.overrideDictionaryColor??tokens.surfaces.page,',
+        ),
+        isFalse,
+        reason: '旧的直接用主题色（可能带 alpha）的形状不得复现——那会让浮窗透出壁纸',
+      );
+    });
+  });
+}


### PR DESCRIPTION
用户报：桌面查词浮窗**顶部带图钉📌/关闭×的控制栏**在浅色壁纸下基本看不清。

## BUG-819（用户实际所指，主修复）— 控制栏浅色对比太低
顶部控制条 `#global-lookup-panel-bar`（拖拽 grip + 置顶图钉 + 关闭）由 `assets/popup/global_lookup_host.js` 注入。浅色变体取值过淡：栏底 0.10、按钮芯片 0.16、图标 0.75，未置顶图钉再 opacity:0.45——浅色上整条糊没。

修复：只上调浅色变体对比（深色变体 BUG-768 不动）：栏底 0.10→0.18、芯片 0.16→0.30、图标 0.75→0.92、hover 0.28/0.95→0.42/1、pin-off 0.45→0.62。守卫测试 `lookup_panel_bar_contrast_guard_test.dart`。

## BUG-818（同截图相邻问题，一并修）— 卡片半透明透壁纸
浮窗窗口透明，卡片色继承阅读器主题背景，某些主题带 alpha → 透出桌面壁纸。`popup_dictionary_page.dart:330` 卡片色强制 `.withValues(alpha: 1.0)`（不透明时 no-op）。守卫测试 `popup_surface_opaque_guard_test.dart`。

## 验证
两个源码扫描守卫测试均通过；flutter analyze 改动 Dart 文件 No issues。bug 记录 docs/bugs/BUG-819、BUG-818。

## 待真机
桌面 Windows 全局查词浮窗浅色壁纸下确认顶部图钉/关闭控制栏清晰可见；卡片不再透出壁纸。
