### PR TITLE
feat(clipboard): 透明文字窗 Luna 式 hover 工具栏（移动把手+锁定+一键透明）

### DIFF
--- a/hibiki/lib/src/lookup/clipboard_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_text_overlay_controller.dart
@@ -21,6 +21,18 @@ int clipboardTextWindowBgColor(double opacity) {
   return alpha << 24;
 }
 
+/// 「一键透明」按钮的下一档背景不透明度（Luna #7 语义，纯函数便于单测）：当前有
+/// 底色（>0）→ 切到 0（纯透明）；当前已是 0 → 恢复上一档非 0 值 [lastNonZero]，
+/// 从没设过则用 [fallback]。
+double toggledTextWindowBgOpacity({
+  required double current,
+  required double lastNonZero,
+  double fallback = 0.35,
+}) {
+  if (current > 0.0) return 0.0;
+  return lastNonZero > 0.0 ? lastNonZero : fallback;
+}
+
 class ClipboardTextOverlayController {
   ClipboardTextOverlayController._();
   static final ClipboardTextOverlayController instance =
@@ -29,17 +41,26 @@ class ClipboardTextOverlayController {
   /// native 后端仅 Windows（复用 FloatingLyricWindow layered 窗）。
   static bool get isSupported => Platform.isWindows;
 
+  /// 一键透明按钮从「透明」切回时用的默认背景不透明度（用户从没设过非 0 值时）。
+  static const double _defaultBackdropOpacity = 0.35;
+
   AppModel? _appModel;
   bool _started = false;
   bool _visible = false;
 
-  /// main.dart 桌面块启动一次（幂等）：接线 native 点字回调。窗口到首个
+  /// 一键透明按钮记住的上一档非 0 背景不透明度，供从 0 切回时恢复。
+  double _lastNonZeroBgOpacity = _defaultBackdropOpacity;
+
+  /// main.dart 桌面块启动一次（幂等）：接线 native 点字 + 一键透明回调。窗口到首个
   /// textWindow 分区请求才真正显示。
   Future<void> start({required AppModel appModel}) async {
     if (!isSupported || _started) return;
     _started = true;
     _appModel = appModel;
-    ClipboardTextOverlayChannel.setEventHandlers(onLookupText: _onLookup);
+    ClipboardTextOverlayChannel.setEventHandlers(
+      onLookupText: _onLookup,
+      onToggleTransparency: _onToggleTransparency,
+    );
   }
 
   /// 剪贴板请求入口（dispatcher 的 textWindow 分区）：显示透明窗并推入文本。
@@ -63,6 +84,23 @@ class ClipboardTextOverlayController {
       bgColor: _bgColor(),
       textColor: _textColor(),
     );
+  }
+
+  /// 顶栏「一键透明」按钮（Luna #7 语义）：在「当前背景不透明度」与「0（纯透明）」
+  /// 间切换，记住上一档非 0 值供切回；切到 0 之外时更新记忆。写穿 pref 让设置滑杆
+  /// 同步，并即时重刷窗口。
+  Future<void> _onToggleTransparency() async {
+    final AppModel? model = _appModel;
+    if (model == null) return;
+    final double current = model.clipboardTextWindowBgOpacity;
+    if (current > 0.0) _lastNonZeroBgOpacity = current;
+    final double next = toggledTextWindowBgOpacity(
+      current: current,
+      lastNonZero: _lastNonZeroBgOpacity,
+      fallback: _defaultBackdropOpacity,
+    );
+    await model.setClipboardTextWindowBgOpacity(next);
+    await refreshStyle();
   }
 
   /// 切走去向 / 关剪贴板监听时收起窗口（不留孤儿透明窗）。

--- a/hibiki/lib/src/platform/clipboard_text_overlay_channel.dart
+++ b/hibiki/lib/src/platform/clipboard_text_overlay_channel.dart
@@ -6,6 +6,7 @@ import 'package:hibiki/src/platform/floating_overlay_channel.dart';
 import 'package:hibiki/src/utils/misc/channel_constants.dart';
 
 typedef ClipboardTextLookupHandler = void Function(String text, int index);
+typedef ClipboardTextTransparencyHandler = void Function();
 
 /// 真透明剪切板文字窗的 MethodChannel 绑定（Windows-only）。
 ///
@@ -30,33 +31,47 @@ class ClipboardTextOverlayChannel extends FloatingOverlayChannel {
   bool get isSupported => platformOverride ?? Platform.isWindows;
 
   static ClipboardTextLookupHandler? _onLookupText;
+  static ClipboardTextTransparencyHandler? _onToggleTransparency;
 
-  static void setEventHandlers({ClipboardTextLookupHandler? onLookupText}) {
+  static void setEventHandlers({
+    ClipboardTextLookupHandler? onLookupText,
+    ClipboardTextTransparencyHandler? onToggleTransparency,
+  }) {
     _onLookupText = onLookupText;
+    _onToggleTransparency = onToggleTransparency;
     _instance.channel.setMethodCallHandler(_handleNativeCall);
   }
 
   static void clearEventHandlers() {
     _onLookupText = null;
+    _onToggleTransparency = null;
     _instance.channel.setMethodCallHandler(null);
   }
 
   static Future<void> _handleNativeCall(MethodCall call) async {
-    if (call.method != 'lookupText') return;
-    final Object? args = call.arguments;
-    String text = '';
-    int index = 0;
-    if (args is Map) {
-      text = args['text']?.toString() ?? '';
-      final Object? indexValue = args['index'];
-      if (indexValue is int) {
-        index = indexValue;
-      } else if (indexValue is num) {
-        index = indexValue.toInt();
-      }
-    }
-    if (text.trim().isNotEmpty) {
-      _onLookupText?.call(text, index);
+    switch (call.method) {
+      case 'lookupText':
+        final Object? args = call.arguments;
+        String text = '';
+        int index = 0;
+        if (args is Map) {
+          text = args['text']?.toString() ?? '';
+          final Object? indexValue = args['index'];
+          if (indexValue is int) {
+            index = indexValue;
+          } else if (indexValue is num) {
+            index = indexValue.toInt();
+          }
+        }
+        if (text.trim().isNotEmpty) {
+          _onLookupText?.call(text, index);
+        }
+        break;
+      case 'toggleTransparency':
+        _onToggleTransparency?.call();
+        break;
+      default:
+        break;
     }
   }
 

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+760
+version: 1.2.0+761
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/lookup/clipboard_text_overlay_channel_test.dart
+++ b/hibiki/test/lookup/clipboard_text_overlay_channel_test.dart
@@ -48,6 +48,30 @@ void main() {
     });
   });
 
+  group('toggledTextWindowBgOpacity（一键透明 0↔上一档）', () {
+    test('有底色 → 切到 0', () {
+      expect(
+        toggledTextWindowBgOpacity(current: 0.35, lastNonZero: 0.35),
+        0.0,
+      );
+    });
+
+    test('已 0 → 恢复上一档非 0', () {
+      expect(
+        toggledTextWindowBgOpacity(current: 0.0, lastNonZero: 0.6),
+        0.6,
+      );
+    });
+
+    test('已 0 且从没设过 → 用 fallback', () {
+      expect(
+        toggledTextWindowBgOpacity(
+            current: 0.0, lastNonZero: 0.0, fallback: 0.35),
+        0.35,
+      );
+    });
+  });
+
   group('ClipboardTextOverlayChannel native events', () {
     test('点字事件转发 text + index', () async {
       String? text;
@@ -80,6 +104,17 @@ void main() {
       });
 
       expect(fired, isFalse);
+    });
+
+    test('一键透明事件转发（顶栏透明按钮）', () async {
+      int fired = 0;
+      ClipboardTextOverlayChannel.setEventHandlers(
+        onToggleTransparency: () => fired++,
+      );
+
+      await invokeFromNative('toggleTransparency');
+
+      expect(fired, 1);
     });
   });
 

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -46,6 +46,20 @@ constexpr float kBaseStripHeightForFontDip = 96.0f;
 // hit areas can never drift from what is drawn.
 constexpr int kControlSlotCount = 5;
 
+// Text-only clipboard window (Luna-style hover toolbar). A thin top strip is
+// ALWAYS a mouse catch (drawn at ~2% alpha across the full width) so the fully
+// transparent window can always be grabbed to move + can reveal its toolbar,
+// while the body below stays truly transparent (click-through to the game). At
+// rest only a small centre grip pill hints the handle; on hover the strip
+// brightens and the lock + one-click-transparency buttons appear. Text-only
+// hit-testing / drawing derive geometry from these so the hit areas can never
+// drift from what is drawn.
+constexpr float kTextGripWidthDip = 40.0f;
+constexpr float kTextGripHeightDip = 4.0f;
+constexpr float kTextGripTopDip = 9.0f;
+constexpr float kTextStripRestAlpha = 0.02f;   // near-invisible, still catchable
+constexpr float kTextStripHoverAlpha = 0.55f;  // visible toolbar band on hover
+
 // ARGB (0xAARRGGBB) -> D2D1_COLOR_F (straight alpha).
 D2D1_COLOR_F ColorFromArgb(uint32_t argb) {
   const float a = ((argb >> 24) & 0xFF) / 255.0f;
@@ -659,14 +673,13 @@ void FloatingLyricWindow::Render() {
   const float pad = ScaleForDpi(kHorizontalPaddingDip);
   const float controls_h =
       ScaleForDpi(kButtonSizeDip) + ScaleForDpi(kControlsTopDip);
-  // Text-only mode has no controls row: the text uses the full window height
-  // (centred), so the clipboard string is never pushed down under a phantom
-  // button strip. The audiobook strip keeps reserving controls_h at the top.
-  const float text_top = text_only_ ? pad : controls_h;
+  // Both modes reserve controls_h at the top: the lyric strip for its transport
+  // row, the text-only clipboard window for its thin Luna-style hover toolbar
+  // (the text sits below the strip so the toolbar never overlaps it).
   text_rect_.left = pad;
-  text_rect_.top = text_top;
+  text_rect_.top = controls_h;
   text_rect_.width = std::max(1.0f, width - pad * 2);
-  text_rect_.height = std::max(1.0f, height - text_top - pad * 0.5f);
+  text_rect_.height = std::max(1.0f, height - controls_h - pad * 0.5f);
 
   if (text_format_ != nullptr && !text_.empty()) {
     if (text_layout_ == nullptr) {
@@ -741,10 +754,81 @@ void FloatingLyricWindow::Render() {
     }
   }
 
-  // Text-only clipboard window draws no transport / lock / close buttons and no
-  // resize grip — only the draggable, tappable text. Skip the whole controls +
-  // grip block; ControlActionAt() / ResizeGripContains() short-circuit to match.
-  if (!text_only_) {
+  if (text_only_) {
+    // Luna-style hover toolbar for the transparent clipboard window: a thin top
+    // strip that is ALWAYS a mouse catch (so the transparent window can be
+    // grabbed to move + can reveal its controls), showing only a grip hint at
+    // rest and the lock + one-click-transparency buttons on hover. Geometry
+    // mirrors ControlActionAt(text_only_) exactly.
+    const float t_btn = ScaleForDpi(kButtonSizeDip);
+    const float t_pad = ScaleForDpi(kHorizontalPaddingDip);
+    const float t_gap = ScaleForDpi(kButtonGapDip);
+    const float t_top = ScaleForDpi(kControlsTopDip);
+    const float strip_h = t_top + t_btn;
+
+    // Full-width strip background: near-invisible at rest (still catches the
+    // mouse so the top edge is always grabbable), a visible band on hover so the
+    // whole strip stays catchable while sliding across to the buttons.
+    Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> strip_bg;
+    render_target_->CreateSolidColorBrush(ColorFromArgb(style_.bg_color | 0xFF000000),
+                                          strip_bg.GetAddressOf());
+    strip_bg->SetOpacity(hovered_ ? kTextStripHoverAlpha : kTextStripRestAlpha);
+    D2D1_ROUNDED_RECT strip_rect = D2D1::RoundedRect(
+        D2D1::RectF(0, 0, static_cast<float>(width), strip_h),
+        ScaleForDpi(6), ScaleForDpi(6));
+    render_target_->FillRoundedRectangle(strip_rect, strip_bg.Get());
+
+    // Centre grip pill — the visible move handle (brighter on hover).
+    const float grip_w = ScaleForDpi(kTextGripWidthDip);
+    const float grip_h = ScaleForDpi(kTextGripHeightDip);
+    const float grip_x = (width - grip_w) / 2.0f;
+    const float grip_y = ScaleForDpi(kTextGripTopDip);
+    Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> grip_brush;
+    render_target_->CreateSolidColorBrush(ColorFromArgb(style_.text_color),
+                                          grip_brush.GetAddressOf());
+    grip_brush->SetOpacity(hovered_ ? 0.9f : 0.28f);
+    D2D1_ROUNDED_RECT grip_rect = D2D1::RoundedRect(
+        D2D1::RectF(grip_x, grip_y, grip_x + grip_w, grip_y + grip_h),
+        grip_h / 2.0f, grip_h / 2.0f);
+    render_target_->FillRoundedRectangle(grip_rect, grip_brush.Get());
+
+    // Lock + one-click-transparency buttons appear only on hover, right-aligned
+    // (transparency then lock). Their hit areas in ControlActionAt() are gated
+    // on hovered_ too, so a click can never hit an invisible button.
+    if (hovered_) {
+      Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> tb_bg;
+      Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> tb_fg;
+      Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> tb_active;
+      render_target_->CreateSolidColorBrush(ColorFromArgb(style_.button_bg_color),
+                                            tb_bg.GetAddressOf());
+      render_target_->CreateSolidColorBrush(ColorFromArgb(style_.button_text_color),
+                                            tb_fg.GetAddressOf());
+      render_target_->CreateSolidColorBrush(ColorFromArgb(style_.active_color),
+                                            tb_active.GetAddressOf());
+      const float lock_x = width - t_pad - t_btn;
+      const float trans_x = lock_x - t_gap - t_btn;
+      auto draw_tbtn = [&](float bx, const wchar_t* glyph, bool active) {
+        D2D1_ROUNDED_RECT br = D2D1::RoundedRect(
+            D2D1::RectF(bx, t_top, bx + t_btn, t_top + t_btn), ScaleForDpi(6),
+            ScaleForDpi(6));
+        render_target_->FillRoundedRectangle(br, tb_bg.Get());
+        Microsoft::WRL::ComPtr<IDWriteTextFormat> glyph_fmt;
+        dwrite_factory_->CreateTextFormat(
+            L"Segoe UI Symbol", nullptr, DWRITE_FONT_WEIGHT_NORMAL,
+            DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL, t_btn * 0.5f,
+            L"", glyph_fmt.GetAddressOf());
+        if (glyph_fmt != nullptr) {
+          glyph_fmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+          glyph_fmt->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+          render_target_->DrawTextW(glyph, GlyphLength(glyph), glyph_fmt.Get(),
+                                    D2D1::RectF(bx, t_top, bx + t_btn, t_top + t_btn),
+                                    active ? tb_active.Get() : tb_fg.Get());
+        }
+      };
+      draw_tbtn(trans_x, L"◐", false);  // one-click background transparency
+      draw_tbtn(lock_x, locked_ ? L"\U0001F512" : L"\U0001F513", locked_);  // lock
+    }
+  } else {
   // Controls row (only fully visible while hovered, like QQ Music). The hit
   // areas in ControlActionAt() stay live regardless so a deliberate click on a
   // half-faded button still works.
@@ -814,7 +898,7 @@ void FloatingLyricWindow::Render() {
           D2D1::Point2F(width - 2.0f, height - off), grip_brush.Get(), stroke);
     }
   }
-  }  // if (!text_only_)
+  }  // else (lyric transport controls)
 
   HRESULT hr = render_target_->EndDraw();
   if (hr == D2DERR_RECREATE_TARGET) {
@@ -841,9 +925,32 @@ void FloatingLyricWindow::Render() {
 }
 
 std::string FloatingLyricWindow::ControlActionAt(float x, float y) {
-  // Text-only clipboard window has no control buttons, so no client point is
-  // ever a control hit — every press falls through to the drag / lookup path.
   if (text_only_) {
+    // Text-only Luna toolbar: only the lock + one-click-transparency buttons are
+    // control hits, and only while hovered (they are invisible otherwise, so a
+    // click must never land on a phantom button). The grip / empty strip returns
+    // empty so a press there becomes a window drag — geometry mirrors Render().
+    if (!hovered_) {
+      return std::string();
+    }
+    RECT rc;
+    GetClientRect(hwnd_, &rc);
+    const float width = static_cast<float>(rc.right - rc.left);
+    const float btn = ScaleForDpi(kButtonSizeDip);
+    const float gap = ScaleForDpi(kButtonGapDip);
+    const float pad = ScaleForDpi(kHorizontalPaddingDip);
+    const float ctrl_top = ScaleForDpi(kControlsTopDip);
+    if (y < ctrl_top || y > ctrl_top + btn) {
+      return std::string();
+    }
+    const float lock_x = width - pad - btn;
+    const float trans_x = lock_x - gap - btn;
+    if (x >= lock_x && x <= lock_x + btn) {
+      return "lock";
+    }
+    if (x >= trans_x && x <= trans_x + btn) {
+      return "toggleTransparency";
+    }
     return std::string();
   }
   RECT rc;

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -816,8 +816,6 @@ void FlutterWindow::RegisterClipboardTextChannel() {
           "app.hibiki.reader/clipboard_text",
           &flutter::StandardMethodCodec::GetInstance());
 
-  // Only the word-lookup tap is wired: text-only mode never emits control / lock
-  // events (ControlActionAt short-circuits), so those callbacks are unnecessary.
   clipboard_text_window_->SetLookupCallback(
       [this](const std::string& text, int char_index) {
         flutter::EncodableMap map{
@@ -828,6 +826,14 @@ void FlutterWindow::RegisterClipboardTextChannel() {
         clipboard_text_channel_->InvokeMethod(
             "lookupText",
             std::make_unique<flutter::EncodableValue>(std::move(map)));
+      });
+  // The only control action the text-only toolbar emits is "toggleTransparency"
+  // (the lock button toggles the drag lock natively). Forward it to Dart so the
+  // controller can flip the background-opacity pref (one-click transparency).
+  clipboard_text_window_->SetControlCallback(
+      [this](const std::string& action) {
+        clipboard_text_channel_->InvokeMethod(
+            action, std::make_unique<flutter::EncodableValue>());
       });
 
   clipboard_text_channel_->SetMethodCallHandler(


### PR DESCRIPTION
## 背景
透明剪切板文字窗本体（Plan B 复用 FloatingLyricWindow）+ 文字色跟随主题已随原 PR #115 落入 develop。但本 commit（Luna 式 hover 工具栏）是在 PR #115 合并/关闭**之后**才 push 的，未随之落地——本 PR 把它单独摘到当前 develop 上。

## 内容（用户「怎么移动这个 / 看看 luna 怎么做的」）
参考 LunaTranslator：全透明窗靠「始终可抓的顶栏区域 + hover 才亮」解决怎么移动。
- **native(text-only)**：顶部一条细工具栏带始终以 ~2% alpha 铺满（捕获鼠标、近乎不可见），静止只露居中小把手 pill；hover 时整条带变亮（0.55）+ 右侧浮现「一键透明 ◐」「锁定 🔒」两个按钮（带内连续可抓，能滑到按钮不掉 hover）。正文区仍真透明（点击穿透游戏）+ 文字实心。
- **移动**：抓顶栏（始终可抓）或抓文字拖。
- **锁定**：native toggle `locked_`（禁拖，转瞬态）。
- **一键透明**：control 回调 → 通道 `toggleTransparency` → controller 在「当前背景不透明度 ↔ 0」间切换、记住上一档非 0 值（默认 0.35）、写穿 pref（Luna #7 语义）。纯函数 `toggledTextWindowBgOpacity` 单测覆盖。

## 验证
- `flutter analyze` clean（当前 develop 基底）；channel/toggle 测试绿；**Windows debug 构建通过**（native 无本文件警告/错误）。
- ⚠️ **待真机**：hover 工具栏浮现 + 逐像素透明的视觉与手感证据需真实 Windows + 游戏复验。

## 关键洞察
UpdateLayeredWindow 逐像素 hit-test：alpha=0 才穿透、alpha≥1 就捕获 → 2% 铺底 = 看不见但可抓；全透明 hover 浮现工具栏必须整条带连续可抓（离散不透明岛之间的透明间隙会掉 hover）。