### PR TITLE
Phase B app内弹窗拖拽冻结左上角（修「词靠右缘时从右下拖却从左上动」）

### DIFF
--- a/hibiki/lib/src/pages/base_source_page.dart
+++ b/hibiki/lib/src/pages/base_source_page.dart
@@ -479,11 +479,23 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
   /// / [popupMaxHeight] 用它临时覆盖偏好实时预览；null = 未拖，用已落库真值。松手清空。
   LookupSize? _popupResizePreview;
 
-  /// 拖把手起手：把当前偏好基准尺寸存入预览态（后续增量累积其上）。
+  /// Phase B 拖拽尺寸的**冻结原点**（2026-07-15）：拖右下把手时把弹窗左上角钉在拖拽起点，
+  /// 只往右下生长（否则贴词定位在词靠右时会把左缘往左推=「从右下拖却从左上动」）。持续到
+  /// 换词（选区变）或关窗；[_popupResizeAnchorSelection] 记它属于哪张卡（哪个选区）。
+  Offset? _popupResizeAnchorTopLeft;
+  Rect? _popupResizeAnchorSelection;
+
+  /// 顶层卡片本帧贴词算出的 rect / 选区缓存，供 [_onPopupResizeStart] 取当前左上角冻结。
+  Rect? _topPopupAnchoredRect;
+  Rect? _topPopupSelectionRect;
+
+  /// 拖把手起手：把当前偏好基准尺寸存入预览态（后续增量累积其上），并冻结顶层卡当前左上角。
   void _onPopupResizeStart() {
     setState(() {
       _popupResizePreview =
           LookupSize(appModel.popupMaxWidth, appModel.popupMaxHeight);
+      _popupResizeAnchorTopLeft = _topPopupAnchoredRect?.topLeft;
+      _popupResizeAnchorSelection = _topPopupSelectionRect;
     });
   }
 
@@ -514,10 +526,14 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
     }
   }
 
-  /// 拖拽被竞技场中途取消：丢弃预览态回到「读真值」，不落偏好。
+  /// 拖拽被竞技场中途取消：丢弃预览态回到「读真值」，不落偏好；一并撤销冻结原点（回贴词）。
   void _onPopupResizeCancel() {
     if (_popupResizePreview == null) return;
-    setState(() => _popupResizePreview = null);
+    setState(() {
+      _popupResizePreview = null;
+      _popupResizeAnchorTopLeft = null;
+      _popupResizeAnchorSelection = null;
+    });
   }
 
   Widget buildDictionary() {
@@ -643,6 +659,11 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
       screen,
       verticalWriting: _layerVerticalWriting(index),
     );
+    // Phase B 拖拽尺寸：缓存顶层卡当前 rect/选区，供 [_onPopupResizeStart] 冻结其左上角。
+    if (isTop) {
+      _topPopupSelectionRect = item.selectionRect;
+      _topPopupAnchoredRect = pos;
+    }
     final isDark = (appModel.overrideDictionaryTheme ?? theme).brightness ==
         Brightness.dark;
 
@@ -923,7 +944,7 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
     // 底部固定模式忽略选区放屏幕底部全宽面板。video 家族在 dictionary_page_mixin
     // 用同一个 [resolvePopupRect] 收口（不碰 video_hibiki_page）。reserve/padding/
     // verticalWriting 走本类 getter（子类可 override，如 reader 预留底栏）。
-    return resolvePopupRect(
+    final Rect anchored = resolvePopupRect(
       selectionRect: sel,
       screen: screen,
       bottomDocked: appModel.popupBottomDocked,
@@ -934,6 +955,19 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
       topReserve: popupTopReserve,
       verticalWriting: verticalWriting,
     );
+    // Phase B 拖拽尺寸（2026-07-15）：被拖的那张卡（选区匹配）冻结左上角，从右下生长，
+    // 消除「词靠右缘时贴词定位把左缘左移」的 bug。底部固定 dock 模式忽略选区、不冻结。
+    if (!appModel.popupBottomDocked &&
+        _popupResizeAnchorTopLeft != null &&
+        _popupResizeAnchorSelection == sel) {
+      return anchorPopupTopLeft(
+        anchored: anchored,
+        topLeft: _popupResizeAnchorTopLeft!,
+        screen: screen,
+        inset: popupPadding,
+      );
+    }
+    return anchored;
   }
 
   bool get dictionaryPopupShown => _hasVisiblePopup(_popup.entries);

--- a/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -145,7 +145,7 @@ mixin DictionaryPageMixin {
     // 家族（video/首页/texthooker）不预留 reserve、不竖排避让（全用默认），盒子尺寸
     // 随界面大小放大（同 base 的 popupMaxWidth/Height）。Phase B 拖把手时用预览态
     // [_popupResizePreview] 临时覆盖偏好实时预览（松手落库，见 [_onMixinPopupResizeEnd]）。
-    return resolvePopupRect(
+    final Rect anchored = resolvePopupRect(
       selectionRect: selectionRect,
       screen: screen,
       bottomDocked: mixinAppModel.popupBottomDocked,
@@ -154,19 +154,43 @@ mixin DictionaryPageMixin {
       maxHeight: (_popupResizePreview?.height ?? mixinAppModel.popupMaxHeight) *
           mixinAppModel.appUiScale,
     );
+    // Phase B 拖拽尺寸（2026-07-15）：被拖的那张卡（选区匹配）冻结左上角，从右下生长，
+    // 消除「词靠右缘时贴词定位把左缘左移」的 bug（同 base_source_page）。dock 模式不冻结。
+    if (!mixinAppModel.popupBottomDocked &&
+        _popupResizeAnchorTopLeft != null &&
+        _popupResizeAnchorSelection == selectionRect) {
+      return anchorPopupTopLeft(
+        anchored: anchored,
+        topLeft: _popupResizeAnchorTopLeft!,
+        screen: screen,
+        inset: 6.0,
+      );
+    }
+    return anchored;
   }
 
   /// Phase B 尺寸拖拽的预览态（基准逻辑像素，未缩放）。非空 = 正在拖右下角把手；
   /// null = 未拖，用已落库真值。reader 家族的对应态在 [BaseSourcePageState]。
   LookupSize? _popupResizePreview;
 
-  /// 拖把手起手：存当前偏好基准尺寸为预览起点。
+  /// Phase B 拖拽尺寸的**冻结原点**（2026-07-15，同 base_source_page）：拖右下把手时把
+  /// 弹窗左上角钉在拖拽起点、只往右下生长，持续到换词/关窗。[_popupResizeAnchorSelection]
+  /// 记它属于哪张卡；[_topPopupAnchoredRect]/[_topPopupSelectionRect] 是供起手取当前左上角
+  /// 的顶层卡缓存。
+  Offset? _popupResizeAnchorTopLeft;
+  Rect? _popupResizeAnchorSelection;
+  Rect? _topPopupAnchoredRect;
+  Rect? _topPopupSelectionRect;
+
+  /// 拖把手起手：存当前偏好基准尺寸为预览起点，并冻结顶层卡当前左上角。
   void _onMixinPopupResizeStart() {
     setState(() {
       _popupResizePreview = LookupSize(
         mixinAppModel.popupMaxWidth,
         mixinAppModel.popupMaxHeight,
       );
+      _popupResizeAnchorTopLeft = _topPopupAnchoredRect?.topLeft;
+      _popupResizeAnchorSelection = _topPopupSelectionRect;
     });
   }
 
@@ -196,10 +220,14 @@ mixin DictionaryPageMixin {
     }
   }
 
-  /// 拖拽被竞技场中途取消：丢弃预览态回到「读真值」，不落偏好。
+  /// 拖拽被竞技场中途取消：丢弃预览态回到「读真值」，不落偏好；一并撤销冻结原点（回贴词）。
   void _onMixinPopupResizeCancel() {
     if (_popupResizePreview == null) return;
-    setState(() => _popupResizePreview = null);
+    setState(() {
+      _popupResizePreview = null;
+      _popupResizeAnchorTopLeft = null;
+      _popupResizeAnchorSelection = null;
+    });
   }
 
   /// Mines the current dictionary entry to Anki.
@@ -502,6 +530,11 @@ mixin DictionaryPageMixin {
   }) {
     final DictionaryPopupEntry entry = controller.entries[index];
     final Rect pos = _calcMixinPopupPosition(entry.selectionRect, screen);
+    // Phase B 拖拽尺寸：缓存顶层卡当前 rect/选区，供 [_onMixinPopupResizeStart] 冻结左上角。
+    if (index == controller.entries.length - 1) {
+      _topPopupSelectionRect = entry.selectionRect;
+      _topPopupAnchoredRect = pos;
+    }
     final bool isDark =
         (mixinAppModel.overrideDictionaryTheme ?? mixinTheme).brightness ==
             Brightness.dark;

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -228,6 +228,34 @@ Rect resolvePopupRect({
   );
 }
 
+/// Phase B 拖拽尺寸（2026-07-15）— 把贴词算出的 [anchored] rect 的**原点钉回**
+/// [topLeft]（拖拽起始时那张卡的左上角），只保留其尺寸并夹住不越出屏幕（右下不出界）。
+///
+/// 根因：[calcPopupPosition] 在词靠右缘（横排）或词在右侧（竖排）时，弹窗左缘由
+/// 「词位置 − 宽度」推出（右缘锚在词），故宽度一变大 left 就左移。用户拖**右下**把手时
+/// 期望「左上不动、右下生长」（标准 resize），左移就成了「从右下拖却从左上动」的 bug。
+/// 拖拽期间及被拖的这张卡后续渲染都用本函数把原点冻结在拖拽起点——消除该特殊情况，且
+/// 松手不回跳（尺寸落偏好后同一选区仍读冻结原点，直到换词/关窗）。
+///
+/// [inset] = 屏幕边距（popupPadding）。尺寸取 [anchored] 的（已按当前 max/预览 + 屏幕
+/// clamp），再从冻结原点二次夹住确保右/下不出屏。
+Rect anchorPopupTopLeft({
+  required Rect anchored,
+  required Offset topLeft,
+  required Size screen,
+  required double inset,
+}) {
+  final double maxLeft = (screen.width - inset).clamp(0.0, screen.width);
+  final double maxTop = (screen.height - inset).clamp(0.0, screen.height);
+  final double left = topLeft.dx.clamp(inset.clamp(0.0, maxLeft), maxLeft);
+  final double top = topLeft.dy.clamp(inset.clamp(0.0, maxTop), maxTop);
+  final double width = anchored.width
+      .clamp(0.0, (screen.width - inset - left).clamp(0.0, screen.width));
+  final double height = anchored.height
+      .clamp(0.0, (screen.height - inset - top).clamp(0.0, screen.height));
+  return Rect.fromLTWH(left, top, width, height);
+}
+
 /// 把一个弹窗层 [child] 按 [pos] 摆放；隐藏层（[visible]=false，即 BUG-094 常驻热槽 /
 /// TODO-058 挂起冷层）停到屏幕右外侧 `(screen.width + 8, 0)` 继续预热。
 ///

--- a/hibiki/test/pages/dictionary_popup_layer_test.dart
+++ b/hibiki/test/pages/dictionary_popup_layer_test.dart
@@ -480,4 +480,65 @@ void main() {
       expect(docked.width.isFinite && docked.height.isFinite, isTrue);
     });
   });
+
+  group('Phase B 拖拽尺寸冻结原点（anchorPopupTopLeft，2026-07-15）', () {
+    const Size screen = Size(1000, 800);
+    // 词靠右缘：横排贴词定位会把 left 推成 (screen - width - inset)，宽度一变大就左移。
+    const Rect selRight = Rect.fromLTWH(900, 400, 20, 20);
+
+    test('bug 复现：词靠右缘时 maxWidth 变大 → 贴词定位左上角左移', () {
+      final Rect small = calcPopupPosition(
+          selectionRect: selRight, screen: screen, maxWidth: 300);
+      final Rect big = calcPopupPosition(
+          selectionRect: selRight, screen: screen, maxWidth: 600);
+      expect(big.left, lessThan(small.left),
+          reason: '宽度变大时左上角左移——用户报「从右下拖却从左上动」的根源');
+    });
+
+    test('anchorPopupTopLeft 钉死左上角、保留 anchored 尺寸', () {
+      final Rect r = anchorPopupTopLeft(
+        anchored: const Rect.fromLTWH(400, 300, 500, 400),
+        topLeft: const Offset(120, 90),
+        screen: screen,
+        inset: 6,
+      );
+      expect(r.topLeft, const Offset(120, 90));
+      expect(r.width, 500);
+      expect(r.height, 400);
+    });
+
+    test('修复：冻结原点后宽度增大只往右长、左上不动', () {
+      const Offset frozen = Offset(600, 200); // 拖拽起始左上角
+      final Rect small = anchorPopupTopLeft(
+        anchored: calcPopupPosition(
+            selectionRect: selRight, screen: screen, maxWidth: 300),
+        topLeft: frozen,
+        screen: screen,
+        inset: 6,
+      );
+      final Rect big = anchorPopupTopLeft(
+        anchored: calcPopupPosition(
+            selectionRect: selRight, screen: screen, maxWidth: 600),
+        topLeft: frozen,
+        screen: screen,
+        inset: 6,
+      );
+      expect(small.left, big.left, reason: '左上角冻结不动');
+      expect(small.top, big.top);
+      expect(big.width, greaterThan(small.width), reason: '只往右下生长');
+    });
+
+    test('anchorPopupTopLeft 夹住右下不越出屏幕', () {
+      final Rect r = anchorPopupTopLeft(
+        anchored: const Rect.fromLTWH(0, 0, 900, 700),
+        topLeft: const Offset(700, 500),
+        screen: screen,
+        inset: 6,
+      );
+      expect(r.left, 700);
+      expect(r.top, 500);
+      expect(r.right, lessThanOrEqualTo(994.001));
+      expect(r.bottom, lessThanOrEqualTo(794.001));
+    });
+  });
 }


### PR DESCRIPTION
Phase B app 内查词卡拖拽的真机 bug 修复。用户真机反馈：**弹窗在左、被查高亮词在右时，拖右下角把手，弹窗却从左上角动**（左上角没固定、长错方向）。

## 根因
app 内查词卡贴着被查词定位（`calcPopupPosition`）。词靠**右缘**（横排）或词在右侧（竖排）时，弹窗左缘由「词位置 − 宽度」推出（**右缘锚在词**）——所以拖动把手改宽度时，宽度一变大 `left` 就左移 = 「从右下拖却从左上动」。用户拖**右下**把手期望的是标准 resize：左上固定、右下生长。

## 修（Phase B，纯 Flutter 全平台，本机可 widget 测试）
新增纯函数 `anchorPopupTopLeft`：拖动时**冻结拖拽起始那张卡的左上角**，只保留尺寸并夹住右下不越出屏幕；对被拖的这张卡（选区匹配）**持续冻结**——拖拽期间不左移、松手落偏好后同一张卡仍读冻结原点（不回跳），换词（选区变）或关窗自动回到贴词定位。两宿主（reader/有声书/独立查词页 `base_source_page` + video/首页/texthooker `dictionary_page_mixin`）对称接线。dock 底部固定模式不冻结。

## 验证
- `flutter analyze` 干净。
- `dictionary_popup_layer_test` 新增 4 例（**bug 复现**：词靠右缘 maxWidth 变大→贴词定位左上角左移；**修复**：冻结原点后宽度增大只往右下长、左上不动；钉死左上角；右下不越屏）——全组 44/44 通过。
- 宿主回归：base_source_page hot/warm/nested popup + home/video lookup overlay 等 24 例通过（冻结仅在拖拽激活时生效，其余照常贴词，无回归）。

## 待真机复测
Windows/Android：弹窗在左、词在右时拖右下把手 → 左上角不动、只往右下长；松手不回跳；换词后回到贴词定位。
