### PR TITLE
fix(video): BUG-823 换集前 pause 旧 controller，消除过渡期双音轨

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 804 条。点号进各自文件。
+> 共 805 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-823](bugs/BUG-823-episode-switch-dualplay.md) | ✅ | ✅ | 切换剧集时上一个视频仍在播放（过渡期双音轨） |
 | [BUG-822](bugs/BUG-822-subtitle-group-order-padding-slide.md) | ✅ | ✅ | 换句时字幕组序翻转致避让 padding 动画重播（每句对白入场滑跳） |
 | [BUG-821](bugs/BUG-821-debug-update-check-plain-version.md) | ✅ | ✅ | beta/debug通道装无后缀X.Y.Z包永判已是最新 |
 | [BUG-820](bugs/BUG-820-ass-scale-letterbox-container.md) | ✅ | ✅ | ASS 字号/描边缩放基准误用播放器容器高（应为 fit:contain 视频内容矩形） |

--- a/docs/bugs/BUG-823-episode-switch-dualplay.md
+++ b/docs/bugs/BUG-823-episode-switch-dualplay.md
@@ -1,0 +1,6 @@
+## BUG-823 · 切换剧集时上一个视频仍在播放（过渡期双音轨）
+- **报告**：2026-07-15（用户：）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart:117-140`（`_switchEpisode` 本地分支）。本地播放列表每集是独立 `VideoBooks` 行 → 换集 = `pushReplacement` 到兄弟集单视频页。换集前只 `_persistPosition` 补记位置，**从不 pause/stop 旧 `_controller`**；旧页只有在 `dispose()`（`video_hibiki_page.dart:2889` 的 `_controller?.dispose()`）里才停播。而 Flutter `pushReplacement` 语义下，旧路由要等**新页入场过渡动画结束**才被移除并 dispose。过渡窗口内旧页 controller 仍在放音，新页 `_init` 已新建 player 并 autoPlay 起播（`video_player_controller.dart:1531`）→ **两条音轨短暂同响**，观感即「切集时上一个视频还在播」。仅本地播放列表换集受影响；远端换集（`_isRemote`）复用同一 player + `open()` 顶替旧媒体，天然不双开。
+- **[x] ① 已修复** — `episode.part.dart` 本地分支在 `navigator.pushReplacement` 之前插入 `await _controller?.pause();`，旧音轨在过渡动画开始前即刻静音，不再依赖延迟 dispose。远端分支已 `return`，不受影响。（commit：见提交哈希）
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/video_episode_switch_pause_guard_test.dart`（源码扫描守卫）：切 `_switchEpisode` 方法体，断言 ① `await _controller?.pause();` 出现在 `navigator.pushReplacement` 之前；② pause 落在 `_loadRemoteEpisode(... return` 之后（只属本地分支，不误伤远端）。撤掉 pause 或挪到 pushReplacement 之后即转红。
+- **备注**：视频页极重（media_kit / 原生 player），无法在 widget 测试里实例化 `VideoHibikiPage` 驱动真实换集，故取「源码扫描守卫」为最强可落地层。真机验证：本地多集播放列表连续换集，确认切集瞬间旧集音轨立即停、无双播叠音。

--- a/hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart
@@ -126,6 +126,12 @@ extension _VideoEpisode on _VideoHibikiPageState {
     if (curPos != null) {
       await _persistPosition(widget.bookUid, curPos);
     }
+    // BUG-823：本地换集用 pushReplacement，Flutter 语义下旧路由要等新页入场过渡动画
+    // 结束才被移除并 dispose（旧页 dispose 里才 _controller?.dispose() 停播）。过渡窗口
+    // 内旧页 controller 仍在放音，而新页 _init 已新建 player 并 autoPlay 起播 → 两条音轨
+    // 短暂同响（观感：切集时上一个视频还在播）。换集前先 pause 旧播放器，音轨即刻静音，
+    // 不再依赖延迟 dispose。远端换集复用同一 player + open() 顶替，天然不双开，故只本地分支处理。
+    await _controller?.pause();
     if (!context.mounted) return;
     await navigator.pushReplacement<void, void>(
       adaptivePageRoute<void>(

--- a/hibiki/test/pages/video_episode_switch_pause_guard_test.dart
+++ b/hibiki/test/pages/video_episode_switch_pause_guard_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-823 守卫：本地换集前必须先 pause 旧 controller，杜绝过渡期双音轨。
+///
+/// 本地播放列表换集走 `pushReplacement` 到兄弟集单视频页。Flutter 语义下旧路由要等
+/// 新页入场过渡动画结束才被移除并 `dispose`（旧页 dispose 里才 `_controller?.dispose()`
+/// 停播）。过渡窗口内旧页 controller 仍在放音，而新页 `_init` 已新建 player 并 autoPlay
+/// 起播 → 两条音轨短暂同响（观感：切集时上一个视频还在播）。
+///
+/// 修复：本地分支在 `pushReplacement` 前 `await _controller?.pause()`，音轨即刻静音，
+/// 不再依赖延迟 dispose。远端换集复用同一 player + open() 顶替，天然不双开，故只本地
+/// 分支处理。撤掉这个 pause 或把它挪到 pushReplacement 之后即转红。
+void main() {
+  final File episodePart =
+      File('lib/src/pages/implementations/video_hibiki/episode.part.dart');
+
+  late String switchBody;
+
+  setUpAll(() {
+    expect(episodePart.existsSync(), isTrue);
+    final String src = episodePart.readAsStringSync().replaceAll('\r\n', '\n');
+    final int start = src.indexOf('Future<void> _switchEpisode(');
+    expect(start, isNonNegative, reason: '找不到 _switchEpisode 方法');
+    // 方法体终点锚：下一个 `\n  /// ` 文档注释（_showEpisodeList 前）。
+    final int end = src.indexOf('\n  /// ', start);
+    expect(end, greaterThan(start), reason: '找不到 _switchEpisode 方法体终点');
+    switchBody = src.substring(start, end);
+  });
+
+  test('local episode switch pauses old controller before pushReplacement', () {
+    final int pauseIdx = switchBody.indexOf('await _controller?.pause();');
+    final int pushIdx = switchBody.indexOf('navigator.pushReplacement');
+    expect(pushIdx, isNonNegative, reason: '本地换集应走 pushReplacement');
+    expect(pauseIdx, isNonNegative,
+        reason: '换集前必须 await _controller?.pause() 停旧音轨（BUG-823）');
+    expect(pauseIdx, lessThan(pushIdx),
+        reason: 'pause 必须在 pushReplacement 之前，否则过渡期旧音轨仍在放');
+  });
+
+  test('pause sits in the local branch, after the remote early return', () {
+    // 远端分支复用同一 player，靠 open() 顶替天然不双开；pause 只属本地分支，必须落在
+    // `_loadRemoteEpisode(... return;` 之后，避免误伤远端换流路径。
+    final int remoteReturnIdx =
+        switchBody.indexOf('_loadRemoteEpisode(index, startIntent: intent)');
+    final int pauseIdx = switchBody.indexOf('await _controller?.pause();');
+    expect(remoteReturnIdx, isNonNegative, reason: '远端分支应走 _loadRemoteEpisode');
+    expect(pauseIdx, greaterThan(remoteReturnIdx),
+        reason: 'pause 必须在远端早退之后，只作用于本地换集分支');
+  });
+}


### PR DESCRIPTION
## 现象
切换剧集时，上一个视频可能还在播（旧集音轨没停、与新集叠音）。仅本地播放列表换集出现。

## 根因
本地每集是独立 `VideoBooks` 行 → 换集 = `pushReplacement` 到兄弟集单视频页（`episode.part.dart:117-140` `_switchEpisode` 本地分支）。换集前只 `_persistPosition` 补记位置，**从不 pause/stop 旧 `_controller`**；旧页只在 `dispose()`（`video_hibiki_page.dart:2889`）里才停播。而 Flutter `pushReplacement` 语义下旧路由要等新页入场过渡动画结束才被移除并 dispose——过渡窗口内旧页 controller 仍放音，新页 `_init` 已新建 player 并 autoPlay 起播 → 两条音轨短暂同响。远端换集（`_isRemote`）复用同一 player + `open()` 顶替旧媒体，天然不双开。

## 修复
本地分支在 `navigator.pushReplacement` 之前插入 `await _controller?.pause();`，旧音轨在过渡动画开始前即刻静音，不再依赖延迟 dispose。远端分支已 `return`，不受影响。

## 测试
- 新增源码扫描守卫 `hibiki/test/pages/video_episode_switch_pause_guard_test.dart`：断言 pause 落在 `pushReplacement` 之前、`_loadRemoteEpisode(... return` 之后（只属本地分支）。撤掉或挪位即转红。
- 视频页极重（media_kit 原生 player）无法 widget 测试实例化，源码守卫为最强可落地层。
- `flutter analyze` 干净；相关换集/自动连播/bugs per-file 守卫全绿（14 项）。

## 待验
真机：本地多集播放列表连续换集，确认切集瞬间旧集音轨立即停、无双播叠音。

BUG-823