### PR TITLE
fix(video): BUG-824 点视频进度条被误判成点字幕触发查词

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 804 条。点号进各自文件。
+> 共 805 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-824](bugs/BUG-824-subtitle-hit-seekbar.md) | ✅ | ✅ | 点视频进度条被误判成点字幕触发查词 |
 | [BUG-822](bugs/BUG-822-subtitle-group-order-padding-slide.md) | ✅ | ✅ | 换句时字幕组序翻转致避让 padding 动画重播（每句对白入场滑跳） |
 | [BUG-821](bugs/BUG-821-debug-update-check-plain-version.md) | ✅ | ✅ | beta/debug通道装无后缀X.Y.Z包永判已是最新 |
 | [BUG-820](bugs/BUG-820-ass-scale-letterbox-container.md) | ✅ | ✅ | ASS 字号/描边缩放基准误用播放器容器高（应为 fit:contain 视频内容矩形） |

--- a/docs/bugs/BUG-824-subtitle-hit-seekbar.md
+++ b/docs/bugs/BUG-824-subtitle-hit-seekbar.md
@@ -1,0 +1,12 @@
+## BUG-824 · 点视频进度条被误判成点字幕触发查词
+
+- **报告**：2026-07-15（用户：）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/video/video_subtitle_overlay.dart:47`（`resolveSubtitleCharHit` 的最近字符兜底容差各向同性）。
+  - 视频页字幕层 `VideoSubtitleOverlay`（`layout.part.dart:323`）盖在 media_kit 控制条/进度条（`layout.part.dart:257`）**之上**，是同一 `Stack` 的最顶层，最先被 hit-test。
+  - 字幕字符 tap 识别器 `_SubtitleCharTapRecognizer.isPointerAllowed` 只要 `_hitEntryIndexAt(pos) >= 0` 就收下指针、赢竞技场并 reject media_kit 的 onTap（`video_subtitle_overlay.dart:1535-1547`）。
+  - 命中内核 `resolveSubtitleCharHit` 第二段「最近字符兜底」用**各向同性**欧氏距离，容差 `clamp(charWidth/2, 10px, ∞)`（36px 字幕半字宽≈18px）。这个容差本为水平「字缝/描边外缘」miss 兜底（TODO-916/971，字缝是水平方向），却被写成各向同性，**垂直向下**也放出 ~18px 裙边。
+  - 避让逻辑 `_paddingFor` + `videoSubtitleControlsReserve` 故意把控制条可见时的字幕底缘停在「进度条轨道上缘 + 一点点呼吸间距」（`video_subtitle_style.dart:66-87`），底行字符矩形下缘紧贴进度条。于是向下的 18px 裙边恰好盖住进度条轨道顶部一条带。
+  - 用户 **tap（非拖动）**这条带时 → 顶层字幕识别器赢竞技场 → `_handleSubtitleLookupTap` → `_lookupAt` 暂停视频（`_pausedForLookup=true; controller.pause()`）+ 弹查词浮层，seek 被吞（`lookup_favorite.part.dart:49-51`）。拖动 seek 因超 slop 后由 media_kit 的 horizontal-drag 识别器赢过 tap，不受影响——与「点进度条」的描述吻合。
+- **[x] ① 已修复** — 把 `resolveSubtitleCharHit` 的兜底容差从各向同性圆改成**方向感知椭圆**：水平半轴保持 `clamp(半字宽, minTolerance=10px, ∞)`（保 TODO-916/971 字缝兜底），垂直半轴收紧到描边级 `edgeTolerance=6px`（覆盖默认软阴影半径 3px + 手指余量），判据 `(dx/tolX)² + (dy/tolY)² ≤ 1`。向下不再放半字宽裙边，tap 穿透到 media_kit 进度条正常 seek。`hibiki/lib/src/media/video/video_subtitle_overlay.dart:47`。提交：`<待填>`。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/subtitle_char_hit_tolerance_test.dart` 新增 `BUG-824：垂直兜底容差是描边级` 用例：36px 宽字符正下方 12/15px 的点须 miss（旧 18px 裙边会误命中），且水平半字宽兜底、垂直描边上下缘兜底不回归。8 项全过。提交：`<待填>`。
+- **备注**：与 memory 中 BUG-823（切换剧集双音轨 PR#138 草稿）避免撞号，本条用 824。修复仅动一处纯函数，页面/竞技场层叠逻辑不变；待真机在视频播放页 tap 进度条复测「seek 生效、不弹查词」。

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -39,11 +39,19 @@ class VideoSubtitleHitTester {
 /// TODO-916 症状④：字幕字符之间有 [Wrap] 间隙 + 描边层不计入命中盒，落在字缝/描边
 /// 外缘的点用「精确 [Rect.contains]」会全 miss、查不到词。两段判据消除 miss：
 /// 1. 先精确包含：命中第一个 `contains(point)` 的字符（旧行为，零容差时等价）。
-/// 2. 未命中则取**距点击点最近**的字符，且仅当该距离在合理阈值内才采纳——阈值取该候选
-///    字符的半个宽度（再夹一个最小值 [minTolerance]，防极窄字符阈值过小），保证只在字缝/
-///    描边一字之内兜底，不会跨到隔壁字符或远处误命中。
+/// 2. 未命中则取**距点击点最近**的字符，且仅当该点落在该字符的兜底容差区内才采纳。
 ///
-/// [Rect.zero]（无 RenderBox 的字符）跳过。无任何有效矩形或全部超阈值时返回 -1。
+/// 容差**方向感知**（BUG-824）：字缝在**水平**方向（同一行字符间的 [Wrap] 间隙），
+/// 描边只是四周薄薄一圈。故容差用椭圆而非各向同性圆——
+/// - 水平半轴 [minTolerance]/半字宽取大：跨字缝兜底（TODO-916/971，36px 字半字宽≈18px）；
+/// - 垂直半轴 [edgeTolerance] 只放描边级几像素：字身外上下只需覆盖描边外缘。
+///
+/// 旧实现用各向同性容差 `clamp(半字宽, 10px, ∞)`，把**水平**半字宽（≈18px）原样用到
+/// **垂直向下**，会向下溢出盖住紧贴字幕下方的视频进度条（seek bar）——用户 tap 进度条
+/// 顶部一条带时被顶层字幕识别器赢走竞技场，暂停视频 + 弹查词、seek 被吞（BUG-824）。
+/// 垂直方向本就不该放半字宽的裙边。
+///
+/// [Rect.zero]（无 RenderBox 的字符）跳过。无任何有效矩形或全部超容差时返回 -1。
 @visibleForTesting
 int resolveSubtitleCharHit(
   List<Rect> charRects,
@@ -51,6 +59,9 @@ int resolveSubtitleCharHit(
   // TODO-971：手指比 6px 宽，旧 6.0 下手机字幕点词常落在字缝/描边外缘 miss。
   // 放宽到 10.0，字缝/描边一字之内更易兜底命中（仍夹半字宽，不跨到隔壁字）。
   double minTolerance = 10.0,
+  // BUG-824：垂直兜底半轴。字身外上下只需覆盖描边外缘（默认软阴影半径 3px + 手指余量），
+  // 远小于水平半字宽——避免向下溢出到紧贴字幕下方的进度条轨道。
+  double edgeTolerance = 6.0,
 }) {
   // 第一段：精确包含。
   for (int i = 0; i < charRects.length; i++) {
@@ -58,7 +69,7 @@ int resolveSubtitleCharHit(
     if (r == Rect.zero) continue;
     if (r.contains(point)) return i;
   }
-  // 第二段：最近字符兜底（在该字符半字宽 / [minTolerance] 容差内）。
+  // 第二段：最近字符兜底（在该字符的方向感知椭圆容差区内）。
   int bestIndex = -1;
   double bestDistance = double.infinity;
   for (int i = 0; i < charRects.length; i++) {
@@ -66,11 +77,15 @@ int resolveSubtitleCharHit(
     if (r == Rect.zero) continue;
     final double dx = (point.dx.clamp(r.left, r.right)) - point.dx;
     final double dy = (point.dy.clamp(r.top, r.bottom)) - point.dy;
+    // 用欧氏距离在多个候选里选**最近**的（水平相邻字符的取舍与旧行为一致）。
     final double distance = (dx * dx + dy * dy);
     if (distance >= bestDistance) continue;
-    final double tolerance =
+    // 椭圆判据：水平半轴放宽跨字缝、垂直半轴收紧只覆盖描边（BUG-824）。
+    final double toleranceX =
         (r.width / 2).clamp(minTolerance, double.infinity).toDouble();
-    if (distance <= tolerance * tolerance) {
+    final double nx = dx / toleranceX;
+    final double ny = dy / edgeTolerance;
+    if (nx * nx + ny * ny <= 1.0) {
       bestDistance = distance;
       bestIndex = i;
     }

--- a/hibiki/test/media/video/subtitle_char_hit_tolerance_test.dart
+++ b/hibiki/test/media/video/subtitle_char_hit_tolerance_test.dart
@@ -29,15 +29,36 @@ void main() {
   });
 
   test('描边外缘垂直方向小幅 miss：在容差内兜底', () {
-    // 字符 0 顶 y=0，点 y=-3（描边上缘外 3px，水平在字符内 x=5）→ 容差内命中 0。
+    // 字符 0 顶 y=0，点 y=-3（描边上缘外 3px，水平在字符内 x=5）→ 垂直容差内命中 0。
     expect(resolveSubtitleCharHit(row(), const Offset(5, -3)), 0);
+    // 字符 0 底 y=20，点 y=23（描边下缘外 3px）→ 垂直容差内命中 0。
+    expect(resolveSubtitleCharHit(row(), const Offset(5, 23)), 0);
   });
 
   test('超出容差：返回 -1（不误命中远处字符）', () {
     // x=50 远在所有字符右侧 > 半字宽 → miss。
     expect(resolveSubtitleCharHit(row(), const Offset(50, 10)), -1);
-    // y=40 远在下方 > 容差（min 6px）→ miss。
+    // y=40 远在下方 > 垂直容差 → miss。
     expect(resolveSubtitleCharHit(row(), const Offset(5, 40)), -1);
+  });
+
+  test('BUG-824：垂直兜底容差是描边级，不放半字宽裙边溢出到进度条', () {
+    // 真实场景：36px 字幕（宽≈36），底行字符紧贴其下方的视频进度条轨道。旧各向同性容差
+    // = clamp(半字宽=18, 10, ∞) = 18px，向下也放 18px 裙边 → tap 落在字符正下方 12~15px
+    // （已在进度条轨道顶部一条带）被误判成点字符、暂停视频弹查词、seek 被吞。
+    final List<Rect> wide = <Rect>[const Rect.fromLTWH(0, 0, 36, 40)];
+    // 字符底 y=40。正下方 15px（y=55，水平在字符内 x=18）：旧 18px 裙边会误命中，
+    // 现垂直容差 6px → 必须 miss，让 tap 穿透到 media_kit 进度条 seek。
+    expect(
+      resolveSubtitleCharHit(wide, const Offset(18, 55)),
+      -1,
+      reason: 'BUG-824：字符正下方 15px 不得被误判命中（否则点进度条→暂停+查词）',
+    );
+    // 正下方 12px（y=52）同样 miss（仍在轨道带内）。
+    expect(resolveSubtitleCharHit(wide, const Offset(18, 52)), -1);
+    // 对照：水平方向半字宽（18px）兜底不受影响——字符右缘外 12px（x=48）仍命中，
+    // 证明只收紧了垂直、没伤水平字缝兜底（TODO-916/971）。
+    expect(resolveSubtitleCharHit(wide, const Offset(48, 20)), 0);
   });
 
   test('Rect.zero（无 RenderBox 的字符）被跳过', () {


### PR DESCRIPTION
## 问题
视频播放页 tap 进度条（seek bar）时被误判成点击字幕字符，暂停视频并弹出查词浮层，seek 被吞掉。仅 tap-to-seek 复发，拖动 seek 不受影响。

## 根因
字幕层 `VideoSubtitleOverlay` 在 media_kit 控制条/进度条**之上**（同一 Stack 最顶层），最先被 hit-test。字幕字符命中的「最近字符兜底」纯函数 `resolveSubtitleCharHit` 用**各向同性**欧氏容差 `clamp(charWidth/2, 10px, ∞)`（36px 字幕半字宽≈18px）。该容差本为**水平**字缝/描边外缘 miss 兜底（TODO-916/971），却被各向同性地用到**垂直向下**，放出 ~18px 裙边。避让逻辑把字幕底缘停在进度条轨道上缘上方一点，于是向下裙边恰好盖住进度条顶部一条带 → 顶层字幕识别器赢竞技场、reject media_kit 的 onTap → 暂停 + 查词。

## 修复
把兜底容差从各向同性圆改成**方向感知椭圆**：
- 水平半轴保持 `clamp(半字宽, minTolerance=10px, ∞)`（保字缝兜底不回归）
- 垂直半轴收紧到描边级 `edgeTolerance=6px`（覆盖默认软阴影半径 3px + 手指余量）
- 判据 `(dx/tolX)² + (dy/tolY)² ≤ 1`

向下不再放半字宽裙边，tap 穿透到 media_kit 进度条正常 seek。只动一处纯函数，页面/竞技场层叠逻辑不变。

## 测试
`test/media/video/subtitle_char_hit_tolerance_test.dart` 新增 `BUG-824` 守卫：36px 宽字符正下方 12/15px 的点须 miss（旧 18px 裙边会误命中），水平字缝兜底 + 垂直描边上下缘兜底不回归。8 项全过；`flutter analyze` 干净。

## 待验
真机在视频播放页 tap 进度条复测「seek 生效、不弹查词」。

跟踪：`docs/bugs/BUG-824-subtitle-hit-seekbar.md`