### PR TITLE
fix(anki): BUG-825 安卓阅读器制卡书籍封面缺失 (FileProvider 未覆盖 app_flutter)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 806 条。点号进各自文件。
+> 共 807 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-825](bugs/BUG-825-android-mine-cover-fileprovider.md) | ✅ | ✅ | 安卓阅读器制卡书籍封面缺失(FileProvider 未覆盖 app_flutter 解压目录) |
 | [BUG-824](bugs/BUG-824-ankidroid-mine-permission-prompt.md) | ✅ | ✅ | AnkiDroid 权限未授予制卡失败无明显提醒 |
 | [BUG-823](bugs/BUG-823-episode-switch-dualplay.md) | ✅ | ✅ | 切换剧集时上一个视频仍在播放（过渡期双音轨） |
 | [BUG-822](bugs/BUG-822-subtitle-group-order-padding-slide.md) | ✅ | ✅ | 换句时字幕组序翻转致避让 padding 动画重播（每句对白入场滑跳） |

--- a/docs/bugs/BUG-825-android-mine-cover-fileprovider.md
+++ b/docs/bugs/BUG-825-android-mine-cover-fileprovider.md
@@ -1,0 +1,17 @@
+## BUG-825 · 安卓阅读器制卡书籍封面缺失(FileProvider 未覆盖 app_flutter 解压目录)
+- **报告**：2026-07-15（用户：手机制卡少了书籍封面，卡片 `Picture` 字段是空的；电脑制卡有封面）
+- **真实性**：✅ **真 bug**。沿真实代码路径复核（develop 设备构建 `d50148f` 1.2.0+750 已含 BUG-703 封面路径修复）：
+  - 制卡封面**解析正确、非空**——`hibiki/lib/src/pages/implementations/reader_hibiki/mining.part.dart:38` 用 `ReaderHibikiSource.resolveCoverFilePath` 解析到解压目录里的真实封面文件（与书架同一解析器，用户确认书架封面正常）。
+  - 卡片图字段走 `{card-image}`（Lapis 预设 `packages/hibiki_anki/lib/src/lapis_note_type.dart:71` `'Picture': '{card-image}'`），渲染读 `context.coverPath`。
+  - **根因在 AnkiDroid 落媒体那一步**：`hibiki/android/app/src/main/java/app/hibiki/reader/AnkiChannelHandler.java:283` `FileProvider.getUriForFile(file)` 只能服务 `provider_paths.xml` 声明过的根（`code_cache`/`files`/`cache`/`external*`）。句子音频/视频封面/词典媒体都先写进 Dart `Directory.systemTemp`（=Android `code_cache`）再交 AnkiDroid，故能被服务；**唯独书籍封面**直接把 EPUB 解压目录路径喂 FileProvider——解压目录 base 是 `getApplicationDocumentsDirectory()` = `/data/data/<pkg>/app_flutter`（`files` 的兄弟目录，**不在任何配置根下**）→ `getUriForFile` 抛 `IllegalArgumentException「Failed to find configured root」`，被 `packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart` 的 `_addMediaFile` catch 吞掉 → 返回 null → coverRef=null → `{card-image}` 恒空。
+  - 平台面：仅 **AnkiDroid（手机）** 中招；桌面 **AnkiConnect** 走 HTTP 传字节、书架 Flutter 直接读文件，都不经 FileProvider → 电脑/书架正常。默认数据根即触发（无需自定义位置）。
+  - 与已修的 BUG-703 区分：BUG-703 是封面**路径解析**大小写不对称（已修）；本 bug 是解析出的封面路径**落 AnkiDroid 媒体**时被 FileProvider 拒。
+- **[x] ① 已修复** — `packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart`：新增收口 `_stageForMediaProvider(filePath, preferredName)`，`_addMediaFile` 在进原生前调用它——源文件若不在 `code_cache`（`Directory.systemTemp`）下就先复制进 FileProvider 覆盖的 `anki-media` 缓存目录，再把副本路径交给原生 `addFileToMedia`。这样**每一种**交给 AnkiDroid 的媒体都落在声明过的根里；已在 temp 下的媒体（句子音频等）原样返回，零行为改动、不多余复制。（提交哈希见 git log / 本分支。）
+- **[x] ② 已加自动化测试** — `packages/hibiki_anki/test/ankidroid_cover_fileprovider_stage_test.dart`（3 例，全绿）：
+  1. 行为端到端（mock `app.hibiki.reader/anki` 通道）：封面源在 `systemTemp` 之外（模拟 `app_flutter` 解压目录）时，`mineEntry` 提交给原生 `addFileToMedia` 的 `filename` 必须被搬进 `systemTemp`(=code_cache) 下、且副本真实存在、字节一致——回归即变红。
+  2. 无回归：封面源已在 `systemTemp` 下时原样提交，不多余复制。
+  3. 源码接线守卫：`_addMediaFile` 必经 `_stageForMediaProvider`，且提交 `stagedPath` 而非裸 `filePath`（一旦改回 `'filename': filePath` 立即变红）。
+  - 全量 `flutter analyze`（改动文件）No issues；`packages/hibiki_anki` 整包 165 例全绿。
+- **备注**：
+  - **Android 真机验证门未过**：修复在 Dart 侧收口，逻辑清晰且 CI 端到端守卫已覆盖「非 code_cache 源被搬进 code_cache」这一根因判据；但未在真机制卡目视封面出现（本机安卓真机在线但为 release 不可 debug 构建，需另装含本修复的构建才能肉眼复测原始失败路径）。待有含修复的构建时补真机复测。
+  - 顺带受益：`_addRemoteAudio` 的 localFile 分支等任何「从任意本地路径取媒体交 AnkiDroid」的场景，此后都不会再被 FileProvider 拒（同一收口）。

--- a/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
@@ -711,9 +711,11 @@ class AnkiRepository extends BaseAnkiRepository {
   Future<String?> _addMediaFile(
       String filePath, String preferredName, String mimeType) async {
     try {
+      final String stagedPath =
+          await _stageForMediaProvider(filePath, preferredName);
       final result =
           await _channel.invokeMethod('addFileToMedia', <String, dynamic>{
-        'filename': filePath,
+        'filename': stagedPath,
         'preferredName': preferredName,
         'mimeType': mimeType,
       });
@@ -722,6 +724,35 @@ class AnkiRepository extends BaseAnkiRepository {
       debugPrint('AnkiRepository._addMediaFile $preferredName: $e\n$stack');
       return null;
     }
+  }
+
+  /// BUG-825：把要交给 AnkiDroid 的媒体文件搬进 FileProvider 覆盖得到的根，再返回其
+  /// 路径。AnkiDroid 通过原生 `FileProvider.getUriForFile` 摄取媒体，而 FileProvider
+  /// 只能服务 `provider_paths.xml` 声明过的根（code_cache / files / cache / external*）。
+  /// Dart 的 [Directory.systemTemp] 解析到 app 的 `code_cache`，所以已经写在那里的媒体
+  /// （句子音频 `hibiki_mine_sentence_audio_*`、词典媒体、下载音频、视频制卡封面）都能被
+  /// FileProvider 服务。但**书籍封面**是直接从 EPUB 解压目录取的——解压目录 base 是
+  /// `getApplicationDocumentsDirectory()` = `/data/data/<pkg>/app_flutter`（`files` 的
+  /// 兄弟目录，**不在任何配置根下**）。对该路径调用 `getUriForFile` 会抛
+  /// `IllegalArgumentException「Failed to find configured root」`，被 [_addMediaFile]
+  /// 的 catch 吞掉 → 返回 null → `{card-image}` 恒空（仅 AnkiDroid；AnkiConnect 走 HTTP
+  /// 传字节、书架直接读文件，都不经 FileProvider，故电脑/书架正常）。
+  ///
+  /// 根因修复：源文件若不在 `code_cache`（[Directory.systemTemp]）下，就先 copy 进
+  /// FileProvider 覆盖的 `anki-media` 缓存目录，让**每一种**交给 AnkiDroid 的媒体都落在
+  /// 声明过的根里。已在 temp 下的媒体原样返回（零行为改动、不多余复制）。
+  Future<String> _stageForMediaProvider(
+      String filePath, String preferredName) async {
+    final String tempRoot = Directory.systemTemp.path;
+    if (filePath == tempRoot ||
+        filePath.startsWith('$tempRoot${Platform.pathSeparator}') ||
+        filePath.startsWith('$tempRoot/')) {
+      return filePath;
+    }
+    final Directory cacheDir = await _mediaCacheDir();
+    final File dest = File('${cacheDir.path}/$preferredName');
+    await File(filePath).copy(dest.path);
+    return dest.path;
   }
 
   Future<Directory> _mediaCacheDir() async {

--- a/packages/hibiki_anki/test/ankidroid_cover_fileprovider_stage_test.dart
+++ b/packages/hibiki_anki/test/ankidroid_cover_fileprovider_stage_test.dart
@@ -1,0 +1,177 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+/// BUG-825 回归守卫：安卓阅读器制卡书籍封面缺失。
+///
+/// 根因：AnkiDroid 经原生 `FileProvider.getUriForFile` 摄取媒体，FileProvider 只服务
+/// `provider_paths.xml` 声明过的根（code_cache/files/cache/external*）。句子音频/视频封面/
+/// 词典媒体都先落在 Dart 的 [Directory.systemTemp]（=Android code_cache）下，故能被服务；
+/// 唯独**书籍封面**直接从 EPUB 解压目录取——解压目录 base 是
+/// `getApplicationDocumentsDirectory()` = `/data/data/<pkg>/app_flutter`（不在任何配置根
+/// 下），`getUriForFile` 抛「Failed to find configured root」被吞掉 → coverRef=null →
+/// `{card-image}` 恒空（仅 AnkiDroid；AnkiConnect 传字节、书架直接读文件，都正常）。
+///
+/// 修复：[AnkiRepository] 把交给 AnkiDroid 的媒体在进原生前，若源不在 code_cache
+/// （[Directory.systemTemp]）下就先复制进 FileProvider 覆盖的 `anki-media` 缓存。
+class _ConfiguredAnkiRepository extends AnkiRepository {
+  _ConfiguredAnkiRepository(this.settings);
+
+  final AnkiSettings settings;
+
+  @override
+  Future<AnkiSettings> loadSettings() async => settings;
+}
+
+const AnkiSettings _settings = AnkiSettings(
+  selectedDeckId: 1,
+  selectedNoteTypeId: 2,
+  availableDecks: <AnkiDeck>[AnkiDeck(id: 1, name: 'Mining')],
+  availableNoteTypes: <AnkiNoteType>[
+    AnkiNoteType(
+      id: 2,
+      name: 'Hibiki',
+      fields: <String>['Expression', 'Picture'],
+    ),
+  ],
+  fieldMappings: <String, String>{
+    'Expression': '{expression}',
+    'Picture': '{card-image}',
+  },
+  allowDupes: true,
+);
+
+// 最小合法 JPEG（SOI + APP0 + EOI），让封面被识别成 .jpg。
+final List<int> _jpegBytes = <int>[
+  0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, //
+  0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, //
+  0x01, 0x00, 0x00, 0x01, 0x00, 0x01, //
+  0x00, 0x00, 0xFF, 0xD9,
+];
+
+const String _payload = '{"expression":"言葉"}';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const MethodChannel channel = MethodChannel('app.hibiki.reader/anki');
+
+  late List<Map<String, String>> mediaCalls; // {preferredName, filename}
+
+  setUp(() {
+    mediaCalls = <Map<String, String>>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      switch (call.method) {
+        case 'requestAnkidroidPermissions':
+          return true;
+        case 'addFileToMedia':
+          final args = Map<String, dynamic>.from(call.arguments as Map);
+          mediaCalls.add(<String, String>{
+            'preferredName': args['preferredName'] as String,
+            'filename': args['filename'] as String,
+          });
+          // 原生实现回传媒体在 collection 内的真实文件名；这里回 preferredName 足够。
+          return args['preferredName'] as String;
+        case 'addNote':
+          return true;
+        default:
+          fail('Unexpected AnkiDroid channel call: ${call.method}');
+      }
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  Map<String, String> _coverCall() => mediaCalls.firstWhere(
+        (Map<String, String> c) =>
+            c['preferredName']!.startsWith('hibiki_cover_'),
+        orElse: () => fail('制卡没有向 AnkiDroid 提交封面媒体（addFileToMedia 未收到 cover）'),
+      );
+
+  group('BUG-825 book cover FileProvider staging (AnkiDroid)', () {
+    test(
+        '封面源在 code_cache(systemTemp) 之外(模拟 app_flutter 解压目录) → 被搬进 anki-media 缓存',
+        () async {
+      // 造一个不在 systemTemp 下的“解压目录”封面（真实 bug：app_flutter 不在配置根内）。
+      final Directory outside = Directory(
+          '${Directory.current.path}/.dart_tool/hibiki_bug825_extract');
+      outside.createSync(recursive: true);
+      addTearDown(() {
+        if (outside.existsSync()) outside.deleteSync(recursive: true);
+      });
+      final File cover = File('${outside.path}/Cover.jpg')
+        ..writeAsBytesSync(_jpegBytes);
+      // 前置断言：这个源确实不在 systemTemp 下（否则本测无意义）。
+      expect(cover.path.startsWith(Directory.systemTemp.path), isFalse);
+
+      final MineOutcome outcome =
+          await _ConfiguredAnkiRepository(_settings).mineEntry(
+        rawPayloadJson: _payload,
+        context: AnkiMiningContext(
+          sentence: 'これは言葉です。',
+          coverPath: cover.path,
+          source: AnkiMiningSource.book,
+        ),
+      );
+      expect(outcome.result, MineResult.success);
+
+      final String stagedPath = _coverCall()['filename']!;
+      // 交给原生 FileProvider 的路径必须落在 systemTemp(=code_cache) 下，而不是原
+      // app_flutter 解压路径——否则 getUriForFile 抛「Failed to find configured root」。
+      expect(
+        stagedPath.startsWith(Directory.systemTemp.path),
+        isTrue,
+        reason: '封面必须被搬进 FileProvider 覆盖的 code_cache 缓存，'
+            '实际 filename=$stagedPath',
+      );
+      expect(stagedPath, isNot(cover.path));
+      // 搬进去的副本必须真实存在且内容一致（原生要读它）。
+      final File staged = File(stagedPath);
+      expect(staged.existsSync(), isTrue);
+      expect(staged.readAsBytesSync(), _jpegBytes);
+    });
+
+    test('封面源已在 code_cache(systemTemp) 下 → 原样提交，不多余复制(无回归)', () async {
+      final Directory inside =
+          Directory.systemTemp.createTempSync('hibiki_bug825_incache');
+      addTearDown(() {
+        if (inside.existsSync()) inside.deleteSync(recursive: true);
+      });
+      final File cover = File('${inside.path}/cover.jpg')
+        ..writeAsBytesSync(_jpegBytes);
+      expect(cover.path.startsWith(Directory.systemTemp.path), isTrue);
+
+      final MineOutcome outcome =
+          await _ConfiguredAnkiRepository(_settings).mineEntry(
+        rawPayloadJson: _payload,
+        context: AnkiMiningContext(
+          sentence: 'これは言葉です。',
+          coverPath: cover.path,
+          source: AnkiMiningSource.book,
+        ),
+      );
+      expect(outcome.result, MineResult.success);
+      expect(_coverCall()['filename'], cover.path,
+          reason: '已在 code_cache 下的媒体不应被重复复制，路径应原样传给原生');
+    });
+
+    test('源码接线守卫：_addMediaFile 必经 _stageForMediaProvider，禁止裸传 filePath', () {
+      final File src = File('lib/src/ankidroid/anki_repository.dart');
+      expect(src.existsSync(), isTrue,
+          reason: '测试须在 packages/hibiki_anki 目录下运行');
+      final String code = src.readAsStringSync();
+      expect(code.contains('_stageForMediaProvider'), isTrue,
+          reason: '暂存到 FileProvider 覆盖根的收口函数必须存在');
+      // 交给原生的 filename 必须是 staged 路径，不能回退成裸 filePath（BUG-825 回归）。
+      expect(code.contains("'filename': stagedPath"), isTrue,
+          reason: 'addFileToMedia 必须提交 stagedPath');
+      expect(code.contains("'filename': filePath"), isFalse,
+          reason: '一旦改回裸 filePath，app_flutter 封面又会被 FileProvider 拒');
+    });
+  });
+}


### PR DESCRIPTION
## 现象
手机制卡卡片 `Picture` 字段(书籍封面)是空的;电脑制卡有封面。

## 根因(经真实代码路径闭环)
- 制卡封面**解析正确**(`mining.part.dart:38` `resolveCoverFilePath`,与书架同源;用户确认书架封面正常)。
- AnkiDroid 经原生 `FileProvider.getUriForFile`(`AnkiChannelHandler.java:283`)摄取媒体,FileProvider 只服务 `provider_paths.xml` 声明过的根(code_cache/files/cache/external*)。
- 句子音频/视频封面/词典媒体都先落 `systemTemp`(=code_cache)故正常;**唯独书籍封面**直接把 EPUB 解压目录路径喂 FileProvider——解压目录 base 是 `getApplicationDocumentsDirectory()` = `/data/data/<pkg>/app_flutter`(`files` 的兄弟,不在任何配置根下)→ 抛 `Failed to find configured root` 被 `_addMediaFile` catch 吞 → coverRef=null → `{card-image}` 空。
- 仅 AnkiDroid 中招;桌面 AnkiConnect 传字节、书架直接读文件都不经 FileProvider → 电脑/书架正常。默认数据根即触发。
- 与已修 BUG-703(封面路径大小写解析)区分:那是解析,这是落媒体被 FileProvider 拒。

## 修复
`_addMediaFile` 进原生前经新增 `_stageForMediaProvider`:源不在 code_cache(systemTemp)下就先复制进 FileProvider 覆盖的 `anki-media` 缓存再交原生。每种交给 AnkiDroid 的媒体都落在声明根内;已在 temp 下的媒体原样返回(零行为改动)。

## 测试
`packages/hibiki_anki/test/ankidroid_cover_fileprovider_stage_test.dart`(3例):行为端到端(temp 外源被搬进 code_cache 且副本存在/字节一致)+ 无回归(temp 内源原样)+ 源码接线守卫。`flutter analyze` 干净;hibiki_anki 整包 165 例全绿。

## 待办
⚠️ **安卓真机目视验证门未过**:修复在 Dart 侧收口、CI 端到端守卫已覆盖根因判据,但未在真机制卡肉眼确认封面出现(本机真机为 release 不可 debug 构建,需另装含本修复的构建)。详见 `docs/bugs/BUG-825-*.md`。