### PR TITLE
fix(video): 缺 ffprobe 不记错误日志 + 播放列表重扫对齐合集成员 (BUG-829/830)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 810 条。点号进各自文件。
+> 共 812 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-830](bugs/BUG-830-playlist-collection-not-reconciled.md) | ✅ | ✅ | m3u8播放列表增删视频后合集成员不更新 |
+| [BUG-829](bugs/BUG-829-ffprobe-missing-logged-as-error.md) | ✅ | ✅ | 内封字幕字体枚举缺 ffprobe 被当错误记日志 |
 | [BUG-828](bugs/BUG-828-backup-orphan-tables-leak.md) | ✅ | ✅ | 备份导出泄漏合集/标签/书架/搜索历史/删除墓碑等未受类别控制的孤儿表 |
 | [BUG-827](bugs/BUG-827-android-mine-cover-fileprovider.md) | ✅ | ✅ | 安卓阅读器制卡书籍封面缺失(FileProvider 未覆盖 app_flutter 解压目录) |
 | [BUG-826](bugs/BUG-826-popup-topbar-overlap-narrow.md) | ✅ | ✅ | 查词弹窗顶栏按钮窄宽时重叠 |

--- a/docs/bugs/BUG-829-ffprobe-missing-logged-as-error.md
+++ b/docs/bugs/BUG-829-ffprobe-missing-logged-as-error.md
@@ -1,0 +1,14 @@
+## BUG-829 · 内封字幕字体枚举缺 ffprobe 被当错误记日志
+- **报告**：2026-07-15（用户）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/video/subtitle_embedded_fonts.dart:260` `_enumerateFontAttachments`。
+- **[x] ① 已修复** — `hibiki/lib/src/media/video/subtitle_embedded_fonts.dart:260`
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/subtitle_embedded_fonts_test.dart`（`missing-ffprobe degrade` group）
+- **备注**：
+
+### 根因
+`_enumerateFontAttachments` 文档契约写「失败返回空列表」，但只处理了「ffprobe 跑起来但退出码非 0」（`!probe.isSuccess`）这一类失败，**没处理「ffprobe 二进制根本不存在」**。桌面 ffprobe 未随产物捆绑（`grep ffmpeg/ffprobe hibiki/windows/ ci/` 全空）也不在 PATH 时，`_backend.runProbe` → `_runCliFfprobe`（`ffmpeg_backend.dart:446`）解析成裸 `ffprobe`，`Process.start` 抛 `ProcessException`（`系统找不到指定的文件。`）并 `rethrow`，穿过无 try/catch 的 `_enumerateFontAttachments` 一路冒到 `loadForVideo` 的兜底 catch（`subtitle_embedded_fonts.dart:251`），被 `ErrorLogService.log('SubtitleEmbeddedFontLoader.loadForVideo', ...)` 当成**应用错误**刷进错误日志页——每开一个带内封字体的视频刷一条。
+
+内封字体是「有则更好」的可选增强（对齐 mpv/libass 的 attachment 字体），缺 ffprobe 是**预期降级**而非错误。
+
+### 修复
+在 `_enumerateFontAttachments` 就地 `try/catch (ProcessException)`，捕获「无 ffprobe 可执行」→ 返回空集，回退系统字体 fallback，不再上抛、不记错误日志。诚实兑现「失败返回空列表」的契约；真正意外错误（其余异常）仍会经 `loadForVideo` 兜底记录。

--- a/docs/bugs/BUG-830-playlist-collection-not-reconciled.md
+++ b/docs/bugs/BUG-830-playlist-collection-not-reconciled.md
@@ -1,0 +1,21 @@
+## BUG-830 · m3u8播放列表增删视频后合集成员不更新
+- **报告**：2026-07-15（用户）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/source/media_source_scanner.dart:625`（旧 `_importPlaylists`）。
+- **[x] ① 已修复** — `hibiki/lib/src/media/source/media_source_scanner.dart`（`_importPlaylists` 重扫改 reconcile）+ `hibiki/lib/src/media/video/video_book_repository.dart`（新增 `reconcileSplitPlaylist`）
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_import_split_playlist_test.dart`（`reconcileSplitPlaylist` group 三例）+ `hibiki/test/media/source/media_source_scanner_test.dart`（source guard 更新为 reconcile 契约）
+- **备注**：
+
+### 根因
+统一合集 Phase 2 里，一个 m3u8 清单 = N 条独立 `VideoBooks` 行 + 一个 `MediaCollections(collectionType='playlist')`，成员走 `MediaCollectionItems`。`_importPlaylists` 用「同名 playlist 合集是否已存在」判重（合集名 = m3u8 basename），命中即 `if (existingPlaylistNames.contains(collectionName)) continue;`（旧 `media_source_scanner.dart:625`）——**只要合集已存在就整体跳过，连清单都不读**，从不把清单和 `MediaCollectionItems` 做差异比对。于是磁盘上编辑 m3u8 增删某集后，成员表永远停在首次导入那一刻的快照，剧集面板/合集详情显示旧成员。
+
+初衷是「编辑集路径重扫仍幂等、不产生 X (2) 重复」（TODO-1237 ②），但把「幂等」错误地实现成了「存在即整体跳过」，而非「存在则以清单为准对齐成员」。
+
+### 修复
+- 新增 `VideoBookRepository.reconcileSplitPlaylist(collectionId, entries)`：以清单为准、按集的**稳定基身份** `coreSingleVideoBookUid`（取文件名去扩展名、与目录/绝对路径无关）对齐成员——
+  - 清单有、成员没有的基身份 → 建 VideoBook + `addToCollection`；
+  - 成员有、清单已删的基身份 → 只 `removeFromCollection` 解绑，**保留 VideoBook 本体**（不丢观看进度，非破坏性）。
+  - 先加后删，避免整批替换时合集瞬时空掉被「移空自删」误删。已在清单里的集不重跑 `importSplitPlaylist`（避免撞 uid 加后缀造重复行）。
+- `_importPlaylists` 重扫逻辑：把「同名即 `continue` 跳过」改为「首导不存在 → `importSplitPlaylist`；已存在 → `reconcileSplitPlaylist` 对齐成员」，并把去重键从 `Set<String>` 名集改成 `Map<String,int>` 名→合集 id。
+
+### 为何按「基身份」而非完整路径匹配
+`coreSingleVideoBookUid` 是 basename 派生、与路径无关。同一集换目录（相对→绝对 / 移动文件夹）基身份不变，判为「未变」不增删，不误制孤儿行——保住重扫 relocation 幂等契约（守卫 `media_source_scanner_test` 的 `re-scan after manifest episode paths change` 用例）。真正的增删（不同 basename 的集）才触发成员同步。

--- a/hibiki/lib/src/media/source/media_source_scanner.dart
+++ b/hibiki/lib/src/media/source/media_source_scanner.dart
@@ -605,13 +605,15 @@ class MediaSourceScanner {
   ) async {
     if (plan.playlists.isEmpty) return 0;
 
-    // 统一合集：拆集后无单条 playlist 行 → 按「同名 playlist 合集是否已存在」判重。
-    // 合集名 = m3u8 basename（与旧 playlistBookUid 同为 basename 派生，去重/同名碰撞
-    // 行为一致），且**不随 manifest 内集路径编辑而变** → 编辑集路径重扫仍幂等，不产生
-    // X (2) 重复（TODO-1237 ②）。在读/解析前判重，未变的文件夹重扫无 per-playlist IO。
-    final Set<String> existingPlaylistNames = <String>{
+    // 统一合集：拆集后无单条 playlist 行 → 用「同名 playlist 合集是否已存在」区分
+    // 首次导入 vs 重扫。合集名 = m3u8 basename（**不随 manifest 内集路径编辑而变** →
+    // 编辑集路径重扫仍幂等，不产生 X (2) 重复，TODO-1237 ②）。首导（不存在）走
+    // importSplitPlaylist；已存在走 reconcileSplitPlaylist 把成员对齐到当前清单
+    // （BUG-830：磁盘上编辑 m3u8 增删某集后合集成员永不更新）。故必须逐个解析清单
+    // （不再「同名即整体跳过」），per-playlist 多读一个小文本清单的开销可接受。
+    final Map<String, int> existingPlaylistIds = <String, int>{
       for (final MediaCollectionRow c in await _db.getAllMediaCollections())
-        if (c.collectionType == 'playlist') c.name,
+        if (c.collectionType == 'playlist') c.name: c.id,
     };
 
     // Temp dir only used by non-local transports (copyToLocal downloads here);
@@ -622,7 +624,6 @@ class MediaSourceScanner {
       for (final ScanPlaylistItem item in plan.playlists) {
         final String collectionName =
             p.basenameWithoutExtension(item.playlistPath);
-        if (existingPlaylistNames.contains(collectionName)) continue;
 
         playlistTmp ??= Directory.systemTemp.createTempSync('m1c_scan_pls_');
         final String localM3u8 =
@@ -634,8 +635,21 @@ class MediaSourceScanner {
         final String baseDir = p.dirname(item.playlistPath);
         final List<PlaylistEntry> entries =
             parseM3u8(content: content, baseDir: baseDir);
-        if (entries.isEmpty) continue; // empty / not a playlist: skip silently.
-        existingPlaylistNames.add(collectionName);
+        // 空 / 不可解析清单：跳过（不当成「清单变空 → 清光成员」，避免读盘瞬时失败
+        // 误删已存在合集，保守降级）。
+        if (entries.isEmpty) continue;
+
+        final int? existingId = existingPlaylistIds[collectionName];
+        if (existingId != null) {
+          // 已存在同名 playlist 合集：以当前清单为准对齐成员（增删差异），不重导、
+          // 不计入「新增合集数」；封面首导时已抽，无需重抽。
+          await _videoRepo.reconcileSplitPlaylist(
+            collectionId: existingId,
+            entries: entries,
+            sourceId: sourceId,
+          );
+          continue;
+        }
 
         final ({int collectionId, List<String> episodeUids}) result =
             await _videoRepo.importSplitPlaylist(
@@ -643,6 +657,8 @@ class MediaSourceScanner {
           entries: entries,
           sourceId: sourceId,
         );
+        // 记入 map：同一次扫描里遇到第二个同名清单时走 reconcile，不再重导致重复。
+        existingPlaylistIds[collectionName] = result.collectionId;
 
         // TODO-1237 ①: cover from the first USABLE episode (local ffmpeg only),
         // applied to the first episode row; mobile / any failure -> null cover,

--- a/hibiki/lib/src/media/video/subtitle_embedded_fonts.dart
+++ b/hibiki/lib/src/media/video/subtitle_embedded_fonts.dart
@@ -257,19 +257,33 @@ class SubtitleEmbeddedFontLoader {
   }
 
   /// ffprobe 枚举字体附件流（JSON）。失败返回空列表。
+  ///
+  /// 「失败」含两类，都必须诚实降级为空集、绝不上抛：① ffprobe 跑起来了但退出码非 0
+  /// （`!isSuccess`）；② ffprobe 二进制**根本不存在**（未随桌面产物捆绑且不在 PATH）——
+  /// 此时 [FfmpegBackend.runProbe] 底层 `Process.start` 抛 [ProcessException] 冒上来。
+  /// 内封字体是「有则更好」的可选增强（对齐 mpv/libass 的 attachment 字体），缺 ffprobe
+  /// 是**预期降级**而非应用错误；若放任 [ProcessException] 穿到 [loadForVideo] 的兜底
+  /// catch，会被当成「报错」刷进 [ErrorLogService]（每开一个带内封字体的视频刷一条），
+  /// 与本方法「失败返回空列表」的契约相悖。故在此就地兜住，回退系统字体 fallback。
   Future<List<EmbeddedFontAttachment>> _enumerateFontAttachments(
     String videoPath,
   ) async {
-    final FfmpegRunResult probe = await _backend.runProbe(
-      <String>[
-        '-v', 'quiet',
-        '-print_format', 'json',
-        '-show_streams',
-        '-select_streams', 't', // 只列附件流。
-        videoPath,
-      ],
-      _probeTimeout,
-    );
+    final FfmpegRunResult probe;
+    try {
+      probe = await _backend.runProbe(
+        <String>[
+          '-v', 'quiet',
+          '-print_format', 'json',
+          '-show_streams',
+          '-select_streams', 't', // 只列附件流。
+          videoPath,
+        ],
+        _probeTimeout,
+      );
+    } on ProcessException {
+      // 无 ffprobe 可执行（未捆绑 + 不在 PATH）：预期降级，非错误，不记日志。
+      return const <EmbeddedFontAttachment>[];
+    }
     if (!probe.isSuccess) return const <EmbeddedFontAttachment>[];
     return parseFfprobeFontAttachments(probe.output);
   }

--- a/hibiki/lib/src/media/video/video_book_repository.dart
+++ b/hibiki/lib/src/media/video/video_book_repository.dart
@@ -98,6 +98,82 @@ class VideoBookRepository {
     return (collectionId: collectionId, episodeUids: epUids);
   }
 
+  /// 统一合集：把**已存在**的 playlist 合集 [collectionId] 的成员对齐到当前 m3u8 清单
+  /// [entries]（增删差异同步）。补 [importSplitPlaylist] 只在首次导入落库、之后再没有
+  /// 任何路径拿「当前清单」对账成员表的缺口（BUG-830：磁盘上编辑 m3u8 增删某集后，
+  /// 合集成员永不更新）。
+  ///
+  /// 对齐以**清单为准**、按集的**稳定基身份** [coreSingleVideoBookUid]（取文件名去
+  /// 扩展名、与目录/绝对路径无关，见 hibiki_core `video_book_uid`）匹配，**不是**按
+  /// 完整 `videoPath`：同一集换目录（相对路径改绝对 / 移动文件夹）基身份不变 → 判为
+  /// 「未变」不增删、不误制孤儿行（对齐首导 uid 派生规则与重扫 relocation 幂等契约）。
+  /// - 清单有、成员没有的基身份 → 建独立 VideoBook 行（uid 同 [importSplitPlaylist] 去重）
+  ///   + `addToCollection`；
+  /// - 成员有、清单已删的基身份 → **只 `removeFromCollection` 解绑，不删 VideoBook 本体**
+  ///   （保留其观看进度；条目脱离合集后作为独立视频存在，非破坏性）。
+  ///
+  /// 先加后删：整批替换时先加新集让合集非空，再删旧集，绝不让合集瞬时空掉被
+  /// [HibikiDatabase.removeFromCollection] 的「移空自删」误删。已在清单里的集不重建
+  /// （不重跑 [importSplitPlaylist]，避免 [coreUniqueVideoBookUid] 撞已存在 uid 加后缀
+  /// 造重复行——这正是重扫从前整体跳过的原因）。返回 (新增, 移除) 计数。
+  Future<({int added, int removed})> reconcileSplitPlaylist({
+    required int collectionId,
+    required List<PlaylistEntry> entries,
+    int? sourceId,
+  }) async {
+    // 当前成员 bookUid → 其稳定基身份（用于与清单按基身份对齐）。
+    final List<MediaCollectionItemRow> items =
+        await _db.getCollectionItems(collectionId);
+    final Map<String, String> memberBaseByUid = <String, String>{};
+    for (final MediaCollectionItemRow item in items) {
+      if (item.mediaType != 'video') continue;
+      final VideoBookRow? row = await _db.getVideoBookByBookUid(item.entryKey);
+      if (row != null) {
+        memberBaseByUid[item.entryKey] = coreSingleVideoBookUid(row.videoPath);
+      }
+    }
+    final Set<String> memberBases = memberBaseByUid.values.toSet();
+    final Set<String> manifestBases = entries
+        .map((PlaylistEntry e) => coreSingleVideoBookUid(e.path))
+        .toSet();
+
+    int added = 0;
+    int removed = 0;
+    final Set<String> taken =
+        (await listAll()).map((VideoBookRow r) => r.bookUid).toSet();
+    await _db.transaction(() async {
+      // 先加：清单有、成员没有的基身份。
+      for (final PlaylistEntry e in entries) {
+        final String base = coreSingleVideoBookUid(e.path);
+        if (memberBases.contains(base)) continue;
+        final String uid = coreUniqueVideoBookUid(base, taken);
+        taken.add(uid);
+        await saveVideoBook(
+          VideoBooksCompanion(
+            bookUid: Value(uid),
+            title: Value(e.title.isNotEmpty
+                ? e.title
+                : p.basenameWithoutExtension(e.path)),
+            videoPath: Value(e.path),
+            lastPositionMs: Value(e.positionMs),
+            embeddedSubtitleTrack: const Value<int?>(0),
+            importedAt: Value(DateTime.now()),
+          ),
+          sourceId: sourceId,
+        );
+        await _db.addToCollection(collectionId, 'video', uid);
+        added++;
+      }
+      // 后删：成员有、清单已删的基身份（只解绑，保留 VideoBook 本体）。
+      for (final MapEntry<String, String> m in memberBaseByUid.entries) {
+        if (manifestBases.contains(m.value)) continue;
+        await _db.removeFromCollection(collectionId, 'video', m.key);
+        removed++;
+      }
+    });
+    return (added: added, removed: removed);
+  }
+
   Future<VideoBookRow?> getByBookUid(String bookUid) =>
       _db.getVideoBookByBookUid(bookUid);
 

--- a/hibiki/test/media/source/media_source_scanner_test.dart
+++ b/hibiki/test/media/source/media_source_scanner_test.dart
@@ -768,15 +768,18 @@ sub_b/ep2.mp4
     // reintroduce X (2) single-video folder-scan duplicates.
     expect(src.contains('existingPaths.add(normalizeVideoPath'), isTrue,
         reason: 'single-video scan must skip already-imported physical paths');
-    // TODO-1237 ② / 统一合集 Phase 2: _importPlaylists dedups by the STABLE
-    // playlist COLLECTION name (m3u8 basename), skipping an already-imported
-    // manifest instead of suffixing an X (2) duplicate. Guard the name-skip
-    // wiring so a future edit can't regress to a volatile first-episode-path key.
-    expect(
-        src.contains(
-            'if (existingPlaylistNames.contains(collectionName)) continue;'),
-        isTrue,
-        reason: 'playlist scan must skip an already-imported collection name');
+    // TODO-1237 ② / 统一合集 Phase 2 / BUG-830: _importPlaylists keys on the
+    // STABLE playlist COLLECTION name (m3u8 basename). First import splits into
+    // per-episode rows + a collection; a re-scan of an ALREADY-imported manifest
+    // RECONCILES its members to the current manifest (add/remove diff) instead of
+    // suffixing an X (2) duplicate. Guard the name-keyed collection map + the
+    // reconcile wiring so a future edit can neither regress to a volatile
+    // first-episode-path key nor drop the member-sync that BUG-830 restored.
+    expect(src.contains('existingPlaylistIds[collectionName]'), isTrue,
+        reason: 'playlist scan must key dedup by stable collection name');
+    expect(src.contains('reconcileSplitPlaylist('), isTrue,
+        reason: 'a re-scanned existing playlist must reconcile members to the '
+            'current manifest (BUG-830), not silently skip');
     expect(src.contains('importSplitPlaylist('), isTrue,
         reason:
             'playlist scan must split into per-episode rows + a collection');

--- a/hibiki/test/media/video/subtitle_embedded_fonts_test.dart
+++ b/hibiki/test/media/video/subtitle_embedded_fonts_test.dart
@@ -1,7 +1,24 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/ffmpeg_backend.dart';
 import 'package:hibiki/src/media/video/subtitle_embedded_fonts.dart';
+import 'package:hibiki/src/utils/misc/error_log_service.dart';
+import 'package:path/path.dart' as p;
+
+/// BUG-829：模拟「ffprobe 二进制根本不存在」——[CliFfmpegBackend] 底层 `Process.start`
+/// 会抛 [ProcessException]（`系统找不到指定的文件。`）。用于验证枚举附件时被就地兜住、
+/// 降级空集且不刷错误日志。
+class _MissingFfprobeBackend implements FfmpegBackend {
+  @override
+  Future<FfmpegRunResult> run(List<String> args, Duration timeout) async =>
+      throw const ProcessException('ffmpeg', <String>[]);
+
+  @override
+  Future<FfmpegRunResult> runProbe(List<String> args, Duration timeout) async =>
+      throw const ProcessException('ffprobe', <String>[], '系统找不到指定的文件。', 2);
+}
 
 void _u16(List<int> out, int v) {
   out.add((v >> 8) & 0xFF);
@@ -110,6 +127,40 @@ void main() {
       expect(parseFfprobeFontAttachments('not json'), isEmpty);
       expect(parseFfprobeFontAttachments('{"streams":[]}'), isEmpty);
       expect(parseFfprobeFontAttachments('{"foo":1}'), isEmpty);
+    });
+  });
+
+  group('SubtitleEmbeddedFontLoader missing-ffprobe degrade (BUG-829)', () {
+    test('缺 ffprobe（ProcessException）时降级空集且不刷错误日志', () async {
+      final Directory dir =
+          Directory.systemTemp.createTempSync('hibiki_embfont_');
+      addTearDown(() {
+        try {
+          dir.deleteSync(recursive: true);
+        } catch (_) {}
+      });
+      // loadForVideo 要求本地文件存在才会去枚举附件。
+      final File video = File(p.join(dir.path, 'clip.mkv'))
+        ..writeAsBytesSync(<int>[0]);
+
+      final int before = ErrorLogService.instance.entries.length;
+
+      final SubtitleEmbeddedFontLoader loader =
+          SubtitleEmbeddedFontLoader(backend: _MissingFfprobeBackend());
+      final Set<String> families = await loader.loadForVideo(video.path);
+
+      // 无 ffprobe → 无附件 → 空集，回退系统字体 fallback（不崩）。
+      expect(families, isEmpty);
+
+      // 关键回归：缺 ffprobe 二进制是预期降级，绝不作为「错误」刷进 ErrorLogService。
+      final List<ErrorLogEntry> entries = ErrorLogService.instance.entries;
+      expect(entries.length, before, reason: '缺 ffprobe 不应新增任何错误日志条目');
+      expect(
+        entries.where((ErrorLogEntry e) =>
+            e.source == 'SubtitleEmbeddedFontLoader.loadForVideo'),
+        isEmpty,
+        reason: 'loadForVideo 不应把「无 ffprobe」记成错误',
+      );
     });
   });
 }

--- a/hibiki/test/media/video/video_import_split_playlist_test.dart
+++ b/hibiki/test/media/video/video_import_split_playlist_test.dart
@@ -80,4 +80,109 @@ void main() {
     expect(await db.getMediaCollectionById(result.collectionId), isNull,
         reason: '移空后 playlist 合集自删');
   });
+
+  group('reconcileSplitPlaylist：重扫按清单对齐成员（BUG-830）', () {
+    /// 取合集当前成员对应的 videoPath 集（成员引用 bookUid → VideoBook.videoPath）。
+    Future<Set<String>> memberPaths(
+        HibikiDatabase db, VideoBookRepository repo, int collectionId) async {
+      final Set<String> out = <String>{};
+      for (final MediaCollectionItemRow m
+          in await db.getCollectionItems(collectionId)) {
+        final VideoBookRow? row = await repo.getByBookUid(m.entryKey);
+        if (row != null) out.add(row.videoPath);
+      }
+      return out;
+    }
+
+    test('清单增删某集 → 合集成员随之增删（只解绑不删本体）', () async {
+      final HibikiDatabase db = _memDb();
+      addTearDown(db.close);
+      final VideoBookRepository repo = VideoBookRepository(db);
+
+      final ({int collectionId, List<String> episodeUids}) result =
+          await repo.importSplitPlaylist(
+        collectionName: 'Show',
+        entries: const <PlaylistEntry>[
+          PlaylistEntry(title: 'E1', path: '/v/Show E01.mkv'),
+          PlaylistEntry(title: 'E2', path: '/v/Show E02.mkv'),
+        ],
+      );
+
+      // 磁盘上编辑 m3u8：删 E01、留 E02、加 E03。
+      final ({int added, int removed}) recon =
+          await repo.reconcileSplitPlaylist(
+        collectionId: result.collectionId,
+        entries: const <PlaylistEntry>[
+          PlaylistEntry(title: 'E2', path: '/v/Show E02.mkv'),
+          PlaylistEntry(title: 'E3', path: '/v/Show E03.mkv'),
+        ],
+      );
+      expect(recon.added, 1);
+      expect(recon.removed, 1);
+
+      expect(await memberPaths(db, repo, result.collectionId),
+          <String>{'/v/Show E02.mkv', '/v/Show E03.mkv'});
+
+      // 移出清单的 E01 只解绑，VideoBook 本体保留（保观看进度，非破坏性）。
+      expect(await repo.getByBookUid('video/Show E01'), isNotNull,
+          reason: '移出清单的集只 removeFromCollection，不删 VideoBook 本体');
+      // 未变的 E02 不重建、E03 只新建一条 → 总 3 本（E01 保留 + E02 + E03）。
+      expect((await repo.listAll()).length, 3);
+    });
+
+    test('清单未变 → 幂等零改动，不产生重复 VideoBook', () async {
+      final HibikiDatabase db = _memDb();
+      addTearDown(db.close);
+      final VideoBookRepository repo = VideoBookRepository(db);
+
+      const List<PlaylistEntry> entries = <PlaylistEntry>[
+        PlaylistEntry(title: 'E1', path: '/v/a.mkv'),
+        PlaylistEntry(title: 'E2', path: '/v/b.mkv'),
+      ];
+      final ({int collectionId, List<String> episodeUids}) result = await repo
+          .importSplitPlaylist(collectionName: 'Show', entries: entries);
+
+      final ({int added, int removed}) recon =
+          await repo.reconcileSplitPlaylist(
+              collectionId: result.collectionId, entries: entries);
+      expect(recon.added, 0);
+      expect(recon.removed, 0);
+      // 未变集不重跑 importSplitPlaylist → 不撞 uid 加后缀造重复行（旧代码整体跳过之因）。
+      expect((await repo.listAll()).length, 2);
+      expect(await memberPaths(db, repo, result.collectionId),
+          <String>{'/v/a.mkv', '/v/b.mkv'});
+    });
+
+    test('整批替换清单 → 先加后删，合集不被移空自删', () async {
+      final HibikiDatabase db = _memDb();
+      addTearDown(db.close);
+      final VideoBookRepository repo = VideoBookRepository(db);
+
+      final ({int collectionId, List<String> episodeUids}) result =
+          await repo.importSplitPlaylist(
+        collectionName: 'Show',
+        entries: const <PlaylistEntry>[
+          PlaylistEntry(title: 'E1', path: '/v/a.mkv'),
+          PlaylistEntry(title: 'E2', path: '/v/b.mkv'),
+        ],
+      );
+
+      final ({int added, int removed}) recon =
+          await repo.reconcileSplitPlaylist(
+        collectionId: result.collectionId,
+        entries: const <PlaylistEntry>[
+          PlaylistEntry(title: 'E3', path: '/v/c.mkv'),
+          PlaylistEntry(title: 'E4', path: '/v/d.mkv'),
+        ],
+      );
+      expect(recon.added, 2);
+      expect(recon.removed, 2);
+
+      // 先加新集让合集非空、再删旧集 → 合集绝不瞬时空掉被「移空自删」误删。
+      expect(await db.getMediaCollectionById(result.collectionId), isNotNull,
+          reason: '先加后删，整批替换不误删合集');
+      expect(await memberPaths(db, repo, result.collectionId),
+          <String>{'/v/c.mkv', '/v/d.mkv'});
+    });
+  });
 }


### PR DESCRIPTION
## 两个视频子系统真 bug（用户报告）

### BUG-829 · 内封字幕字体枚举缺 ffprobe 被当错误刷进错误日志
- **根因**：`subtitle_embedded_fonts.dart` 的 `_enumerateFontAttachments` 文档写「失败返回空列表」，但只处理「ffprobe 退出码非 0」，没处理「ffprobe 二进制根本不存在」。桌面 ffprobe 未随产物捆绑（`grep ffmpeg/ffprobe hibiki/windows/ ci/` 全空）也不在 PATH 时，`Process.start` 抛 `ProcessException` 一路冒到 `loadForVideo` 兜底 catch，被 `ErrorLogService` 当**应用错误**记录——每开一个带内封字体的视频刷一条。
- **修复**：就地 `catch (ProcessException)` → 返回空集，回退系统字体 fallback。缺可选外部工具是**预期降级**而非错误。

### BUG-830 · m3u8 播放列表增删视频后合集成员不更新
- **根因**：`_importPlaylists` 对已存在同名 playlist 合集整体 `continue` 跳过（连清单都不读），从不把 m3u8 清单与 `MediaCollectionItems` 差异比对 → 磁盘上编辑清单增删集后，成员表永远停在首导快照。
- **修复**：新增 `VideoBookRepository.reconcileSplitPlaylist`，按集**稳定基身份** `coreSingleVideoBookUid`（basename 派生、与路径无关）对齐成员：清单有成员无→建行+addToCollection；成员有清单无→只 `removeFromCollection` 解绑（**保留 VideoBook 本体，不丢观看进度**）；先加后删防合集移空自删。重扫改为「首导 `importSplitPlaylist` / 已存在 `reconcile`」。
- **relocation 幂等**：换目录但同 basename 的集基身份不变 → 判「未变」不增删、不制孤儿行，保住旧的「不产生 X(2) 重复」契约（原 relocation 守卫测试无需改动即通过）。

## 决策/假设
- 从清单移出的集**只解绑不删本体**（保守、非破坏性；条目脱离合集后作为独立视频存在）。
- 空/不可解析清单跳过（不当成「清空成员」，避免读盘瞬时失败误删合集）。

## 验证
- `flutter analyze`（改动文件）：No issues found。
- `flutter test`：`subtitle_embedded_fonts_test.dart` / `video_import_split_playlist_test.dart`（+3 reconcile 例）/ `media_source_scanner_test.dart`（guard 更新为 reconcile 契约、relocation 例仍绿）全通过。
- ⚠️ **待真机**：桌面重扫真实 m3u8 增删集后合集/剧集面板刷新 + 打开带内封字体视频不再刷错误日志。

BUG-829 `docs/bugs/BUG-829-*.md` / BUG-830 `docs/bugs/BUG-830-*.md`。