### PR TITLE
fix(reader): 移动端选区手柄真机拖不动 + 外观重设计 (BUG-765 续)

### DIFF
--- a/docs/bugs/BUG-765-reader-selection-handles-cannot-drag.md
+++ b/docs/bugs/BUG-765-reader-selection-handles-cannot-drag.md
@@ -4,3 +4,10 @@
 - **[x] ① 已修复** — `moveSelectionHandle` 在 hit-test 前把两个手柄临时 `pointer-events:none`、取字后还原（`savedStartPe`/`savedEndPe`），使手指坐标穿透到底下字符。全程仍只改 `this.selection` + CSS Custom Highlight，绝不碰原生选区（不复活 TODO-1279 双选区）。提交：cc6484e87
 - **[x] ② 已加自动化测试** — `hibiki/test/reader/reader_selection_handles_guard_test.dart` 补 `moveSelectionHandle` 在 hit-test 期间置 `pointer-events`='none' 再还原的守卫。
 - **备注**：真机验证待用户（长按拖选后，拖两端手柄能实时调整选区）。次因假设（Android 手势竞技场抢 fresh touchstart）未处理——主因单独即足以造成冻结，若真机仍有边缘拖动被抢再单列。
+
+### 复发续修（2026-07-15，用户真机反馈「还是拖不动」+「手柄难看」，竖排横排都有）
+- **真根因**：cc6484e87 的 `pointer-events:none` 修复押注「Android WebView 的 `caretPositionFromPoint` 尊重 pointer-events 从而看穿手柄」——真机不成立。`getCaretRange`（`reader_selection_scripts.dart` :472）在 `caretPositionFromPoint` 路径上**无条件早退**（`if (!pos) return null;` 后直接 `setStart` 返回），即便手柄已 `pointer-events:none`，部分 Android WebView 的 `caretPositionFromPoint` 仍把命中解析到手柄自身 / `documentElement`（ELEMENT_NODE）→ `getCharacterAtPoint` 见非文本节点返回 null → `moveSelectionHandle` 早退 → 选区永不更新 = 仍拖不动。`pointer-events` 那层是脆弱兼容层，不是根因。
+- **[x] ① 根因修复** — `getCaretRange` 改为**只在命中文本节点时才走 `caretPositionFromPoint` 快路**（`pos.offsetNode.nodeType === Node.TEXT_NODE`），命中非文本节点（遮挡的手柄 div）**不再早退**，落到已有的 `elementFromPoint`+最近字符几何兜底（对 `pointer-events:none` 稳定生效，扫描有界于底层文本块）。横竖排通吃。原 `pointer-events:none` 临时熄灭保留作双保险（让 `elementFromPoint` 解析到底层文本块而非手柄）。
+- **[x] ② 手柄外观重设计** — 去掉刺眼橙 `rgba(255,138,0,0.98)` + 双重发光 box-shadow（用户「难看」）。改：外层 32×32 透明触控盒（旧 24px→更好抓）承 `pointer-events:auto`+`touch-action:none`；内层 18px 实心圆钮，主题色 `var(--hoshi-sel-handle)`（`reader_content_styles.dart` 从主题 `linkColor` 下发 `:root` 变量，主题切换自动跟随）+ 白描边（任意背景可见）+ 单柔和阴影。`positionSelectionHandles` 加 8px 向外间隙让圆钮悬在选区外缘不压字。
+- **[x] ③ 自动化测试** — `reader_selection_handles_guard_test.dart` 补：`getCaretRange` 校验 `Node.TEXT_NODE` 且 `elementFromPoint` 兜底在 `caretPositionFromPoint` 之后可达（非早退）；手柄用 `var(--hoshi-sel-handle)` + 内层 `data-hoshi-sel-ball` 且移除旧橙色/发光。`reader_content_styles_test.dart` 补：注入 CSS 下发 `--hoshi-sel-handle`。提交：<pending>
+- **备注**：仍待用户真机复验（拖两端手柄实时调整选区 + 新外观），横排 / 竖排 vertical-rl 均需验。

--- a/hibiki/lib/src/reader/reader_content_styles.dart
+++ b/hibiki/lib/src/reader/reader_content_styles.dart
@@ -567,6 +567,11 @@ ruby rt, ruby rp {
     -webkit-touch-callout: none !important;
   }
 }
+/* BUG-765 续：移动端选区起止手柄的强调色跟随主题。reader_selection_scripts.dart 里
+   自绘的起/止手柄用 var(--hoshi-sel-handle) 引用本变量；主题切换重注入本 CSS 时手柄
+   颜色自动更新，无需 JS 感知主题。用主题 linkColor（各主题的饱和强调色）而非查词高亮
+   色（0.35 低透明 tint，太淡不适合实心抓手）。 */
+:root { --hoshi-sel-handle: ${linkColor ?? colors.linkColor}; }
 /* BUG-125：查词高亮用不透明色（见 selectionOpaque 注释）。JS 侧给该 Highlight 设
    priority=1，使其叠在音频(sasayaki, 默认 priority=0)之上 → 重叠处只显示这一层。 */
 ::highlight(hoshi-selection) {

--- a/hibiki/lib/src/reader/reader_selection_scripts.dart
+++ b/hibiki/lib/src/reader/reader_selection_scripts.dart
@@ -470,13 +470,25 @@ window.hoshiSelection = {
     return dx * dx + dy * dy;
   },
   getCaretRange: function(x, y) {
+    // BUG-765 续修：`caretPositionFromPoint` 命中「非文本 / 振假名」节点时**不再早退**，
+    // 落到下面的 `elementFromPoint`+最近字符几何兜底。根因：拖选区手柄时手指压在手柄
+    // div 上，即便 `moveSelectionHandle` 已把手柄 `pointer-events:none`，部分 Android
+    // WebView 的 `caretPositionFromPoint` 仍把命中解析到手柄自身 / documentElement
+    // （ELEMENT_NODE）→ getCharacterAtPoint 返回 null → 手柄冻结拖不动。旧代码押注
+    // 「caretPositionFromPoint 尊重 pointer-events」这一脆弱假设，真机不成立。现在只在
+    // 拿到可用文本节点时才走快路，否则统一落到 elementFromPoint（对 pointer-events:none
+    // 稳定生效）解析出的底层文本块里做有界的最近字符扫描，横竖排通吃。
     if (document.caretPositionFromPoint) {
       var pos = document.caretPositionFromPoint(x, y);
-      if (!pos) return null;
-      var range = document.createRange();
-      range.setStart(pos.offsetNode, pos.offset);
-      range.collapse(true);
-      return range;
+      // 命中文本节点走快路（振假名文本仍返回，由 getCharacterAtPoint 自己 reject，
+      // 保持「点振假名不查词」老行为）；命中非文本节点（遮挡的手柄 div /
+      // documentElement）则**不早退**，继续走下面的几何兜底。
+      if (pos && pos.offsetNode && pos.offsetNode.nodeType === Node.TEXT_NODE) {
+        var caretRange = document.createRange();
+        caretRange.setStart(pos.offsetNode, pos.offset);
+        caretRange.collapse(true);
+        return caretRange;
+      }
     }
     var element = document.elementFromPoint(x, y);
     if (!element) return null;
@@ -1295,11 +1307,24 @@ window.hoshiSelection = {
         el = document.createElement('div');
         el.id = 'hoshi-sel-handle-' + which;
         el.setAttribute('data-hoshi-sel-handle', which);
-        el.style.cssText = 'position:fixed;z-index:2147483645;width:24px;height:24px;' +
-          'margin-left:-12px;margin-top:-12px;border-radius:50%;' +
-          'background:rgba(255,138,0,0.98);' +
-          'box-shadow:0 0 0 2px rgba(0,0,0,0.28),0 0 4px rgba(255,138,0,0.9);' +
-          'pointer-events:auto;touch-action:none;display:none;box-sizing:border-box;';
+        // BUG-765 续：外层是 32×32 透明触控盒（比旧 24px 大，改善抓取；不取更大是因为
+        // 1~2 字 CJK 短选区两端相距仅约一个字宽，触控盒过大会几乎完全重叠、反而遮住起
+        // 手柄）。命中区大、视觉小；pointer-events:auto + touch-action:none 让它吃掉浏览器
+        // 滚动手势并可拖。视觉抓手是内层 18px 实心圆钮，用主题色 var(--hoshi-sel-handle)
+        // （reader CSS 从 linkColor 下发，随主题变）+ 白描边（任意背景都可见）+ 单柔和阴
+        // 影，去掉旧的刺眼橙色 + 双重发光 box-shadow（用户投诉「难看」）。
+        el.style.cssText = 'position:fixed;z-index:2147483645;width:32px;height:32px;' +
+          'margin-left:-16px;margin-top:-16px;box-sizing:border-box;' +
+          'background:transparent;border:0;' +
+          'pointer-events:auto;touch-action:none;display:none;';
+        var ball = document.createElement('div');
+        ball.setAttribute('data-hoshi-sel-ball', which);
+        ball.style.cssText = 'position:absolute;left:50%;top:50%;width:18px;height:18px;' +
+          'margin-left:-9px;margin-top:-9px;border-radius:50%;box-sizing:border-box;' +
+          'background:var(--hoshi-sel-handle, #3a5fad);' +
+          'border:2px solid rgba(255,255,255,0.95);' +
+          'box-shadow:0 1px 4px rgba(0,0,0,0.35);pointer-events:none;';
+        el.appendChild(ball);
         document.documentElement.appendChild(el);
         self._wireHandle(el, which);
       }
@@ -1395,20 +1420,22 @@ window.hoshiSelection = {
     var sRect = this._glyphRect(eps.startNode, eps.startOffset);
     var eRect = this._glyphRect(eps.endNode, eps.endOffset);
     var sx, sy, ex, ey;
+    // 圆钮离开文字的间隙（约半个钮），让抓手悬在选区外缘、不压住字。
+    var GAP = 8;
     if (vertical) {
       // vertical-rl: reading runs top->bottom, columns right->left. Start grip
       // above the first glyph, end grip below the last glyph.
       sx = sRect.left + sRect.width / 2;
-      sy = sRect.top;
+      sy = sRect.top - GAP;
       ex = eRect.left + eRect.width / 2;
-      ey = eRect.bottom;
+      ey = eRect.bottom + GAP;
     } else {
       // horizontal: start grip at the lower-left of the first glyph, end grip at
       // the lower-right of the last glyph (below the baseline).
       sx = sRect.left;
-      sy = sRect.bottom;
+      sy = sRect.bottom + GAP;
       ex = eRect.right;
-      ey = eRect.bottom;
+      ey = eRect.bottom + GAP;
     }
     handles.start.style.left = sx + 'px';
     handles.start.style.top = sy + 'px';

--- a/hibiki/test/reader/reader_content_styles_test.dart
+++ b/hibiki/test/reader/reader_content_styles_test.dart
@@ -61,6 +61,13 @@ void main() {
     test('contains light theme background by default', () {
       expect(css, contains('#fff'));
     });
+
+    test('BUG-765 续：下发选区手柄主题色变量 --hoshi-sel-handle', () {
+      // 移动端自绘选区起/止手柄用 var(--hoshi-sel-handle) 上色，须由本 CSS 从主题
+      // linkColor 下发，主题切换重注入时手柄自动跟随。
+      expect(css, contains('--hoshi-sel-handle:'),
+          reason: '注入 CSS 必须定义 --hoshi-sel-handle 供手柄引用');
+    });
   });
 
   group('ReaderContentStyles.css theme overrides', () {

--- a/hibiki/test/reader/reader_selection_handles_guard_test.dart
+++ b/hibiki/test/reader/reader_selection_handles_guard_test.dart
@@ -174,4 +174,41 @@ void main() {
           reason: '长按 arm 白名单必须排除起止手柄元素');
     });
   });
+
+  group('BUG-765 续修：getCaretRange caretPositionFromPoint 命中非文本节点不早退', () {
+    test('caretPositionFromPoint 仅在文本节点走快路，非文本落几何兜底', () {
+      final String body = _between(
+          js, 'getCaretRange: function', 'getCharacterAtPoint: function');
+      // 命中判据必须校验 TEXT_NODE（旧代码 if(!pos) return 无条件早退，押注
+      // caretPositionFromPoint 尊重 pointer-events，真机不成立 → 拖手柄冻结）。
+      expect(body, contains('nodeType === Node.TEXT_NODE'),
+          reason: 'caretPositionFromPoint 结果必须校验是文本节点才走快路');
+      // 非文本节点（遮挡的手柄 div / documentElement）不得早退，必须落到下方
+      // elementFromPoint + 最近字符几何兜底（对 pointer-events:none 稳定生效）。
+      final int caretIdx = body.indexOf('caretPositionFromPoint');
+      final int fallbackIdx = body.indexOf('elementFromPoint');
+      expect(caretIdx, greaterThanOrEqualTo(0));
+      expect(fallbackIdx, greaterThan(caretIdx),
+          reason: 'elementFromPoint 几何兜底必须在 caretPositionFromPoint 之后可达（非早退）');
+      // 不得再有「拿到 pos 就无条件 setStart 返回」的旧早退。
+      expect(body, isNot(contains('if (!pos) return null;')),
+          reason: '旧无条件早退必须移除，改为 TEXT_NODE 校验 + 兜底');
+    });
+  });
+
+  group('BUG-765 续修：手柄外观（主题色 + 触控盒 + 内层圆钮，去刺眼橙）', () {
+    test('手柄用主题变量 var(--hoshi-sel-handle) 上色，不再硬编码刺眼橙 + 发光', () {
+      final String body = _between(
+          js, 'ensureSelectionHandles: function', '_wireHandle: function');
+      expect(body, contains('var(--hoshi-sel-handle'),
+          reason: '圆钮颜色须走主题变量（reader CSS 从 linkColor 下发，随主题变）');
+      // 内层实心圆钮存在（外层是透明触控盒）。
+      expect(body, contains("'data-hoshi-sel-ball'"), reason: '须有内层视觉圆钮元素');
+      // 旧刺眼橙 + 双重发光 box-shadow 必须移除。
+      expect(body, isNot(contains('rgba(255,138,0,0.98)')),
+          reason: '旧刺眼橙背景必须移除');
+      expect(body, isNot(contains('0 0 4px rgba(255,138,0,0.9)')),
+          reason: '旧橙色发光 box-shadow 必须移除');
+    });
+  });
 }


### PR DESCRIPTION
## 背景
用户真机反馈：手机长按选区后**左右两端手柄还是拖不动**（cc6484e87 的修复真机未生效），且**手柄难看**；横排竖排都有。

## 真根因
cc6484e87 的 `pointer-events:none` 押注「Android WebView 的 `caretPositionFromPoint` 尊重 pointer-events 从而看穿手柄」——真机不成立。`getCaretRange`（`reader_selection_scripts.dart`）在 `caretPositionFromPoint` 路径**无条件早退**：即便手柄已 `pointer-events:none`，部分 Android WebView 的 `caretPositionFromPoint` 仍把命中解析到手柄自身 / `documentElement`（ELEMENT_NODE）→ `getCharacterAtPoint` 见非文本节点返回 null → `moveSelectionHandle` 早退 → 选区永不更新 = 仍拖不动。`pointer-events` 那层只是脆弱兼容层。

## 修复
- **根因**：`getCaretRange` 只在命中**文本节点**（`nodeType===TEXT_NODE`）时才走 `caretPositionFromPoint` 快路；命中非文本节点**不早退**，落到已有的 `elementFromPoint`+最近字符几何兜底（对 `pointer-events:none` 稳定生效，扫描有界于底层文本块）。横竖排通吃。`pointer-events:none` 临时熄灭保留作双保险。
- **外观**：去掉刺眼橙 `rgba(255,138,0,0.98)`+双重发光。外层 32×32 透明触控盒（旧 24px→更好抓）+ 内层 18px 实心圆钮，主题色 `var(--hoshi-sel-handle)`（`reader_content_styles.dart` 从主题 `linkColor` 下发 `:root` 变量，随主题自动变）+ 白描边 + 单柔和阴影；`positionSelectionHandles` 加 8px 向外间隙让圆钮悬在选区外缘不压字。

## 测试
- `reader_selection_handles_guard_test.dart`：新增 `getCaretRange` TEXT_NODE 校验 + `elementFromPoint` 兜底可达（非早退）；手柄用 `var(--hoshi-sel-handle)` + 内层 `data-hoshi-sel-ball`、移除旧橙色/发光。
- `reader_content_styles_test.dart`：注入 CSS 下发 `--hoshi-sel-handle`。
- `flutter test test/reader/`：**1065 全绿**；`flutter analyze` 改动文件 0 issue；`dart format` 已跑；注入 JS 经 `node --check` 语法校验通过。

## 待验
触屏拖拽无法用焦点驱动集成测试自动复现，**待用户真机复验**：横排 / 竖排 vertical-rl 下长按拖选后拖两端手柄能实时调整选区 + 新外观。