### PR TITLE
fix(mining): 制卡ffmpeg失败摘要显示尾段真因而非version banner (BUG-834)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 815 条。点号进各自文件。
+> 共 816 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-834](bugs/BUG-834-ffmpeg-failure-summary-tail.md) | ✅ | ✅ | 制卡句子音频失败toast只显示ffmpeg版本banner看不到真因 |
 | [BUG-833](bugs/BUG-833-ass-karaoke-layers-stacked.md) | ✅ | ✅ | OP 多层卡拉 OK 同句三层被竖排堆叠成「三个字幕」 |
 | [BUG-832](bugs/BUG-832-backup-media-sources-dict-history-leak.md) | ✅ | ✅ | 备份导出泄漏 media_sources 本地路径与 dictionary_history 查词记录 |
 | [BUG-831](bugs/BUG-831-develop-md3-guard-red.md) | ✅ | ✅ | develop md3_static 守卫红:jimaku ListTile + collection-delete CheckboxListTile 2处既存违规 |

--- a/docs/bugs/BUG-834-ffmpeg-failure-summary-tail.md
+++ b/docs/bugs/BUG-834-ffmpeg-failure-summary-tail.md
@@ -1,0 +1,39 @@
+## BUG-834 · 制卡句子音频失败toast只显示ffmpeg版本banner看不到真因
+- **报告**：2026-07-15（用户：截图报「导出卡片失败：sentence audio export failed: ffmpeg exit 1」）
+- **真实性**：✅ 真 bug（诊断截断）。根因 `hibiki/lib/src/media/video/ffmpeg_backend.dart:83`（旧 `_summarizeFfmpegOutput` 从**头**截 500 字）。
+- **[x] ① 已修复** — 提交 `<pending>`
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/ffmpeg_backend_test.dart`（failureSummary surfaces the tail error line, not the leading banner）
+- **备注**：
+
+### 现象
+Android 阅读器/有声书划词制卡时 toast 弹「导出卡片失败：sentence audio export failed: ffmpeg exit 1; executable=ffmpeg-kit; attempted=ffmpeg-kit; stderr=ffmpeg version n6.0 ... configuration: --cross-prefix=... --prefix=/Users/shfaifsj/ffmpegkit-build/... 」——`stderr=` 后面**全是 ffmpeg 的 version + configuration banner**，在 configuration 中途被截断，用户和 in-app 日志都看不到 ffmpeg 到底为什么 exit 1。
+
+### 根因
+句子音频经 `TtsChannel.extractAudioSegment` → `extractAudioSegmentViaFfmpeg`（`desktop_audio_clipper.dart`）→ 移动端 `KitFfmpegBackend`（进程内 ffmpeg-kit）。失败时上报 `FfmpegRunResult.failureSummary`，其 stderr 部分由 `_summarizeFfmpegOutput` 生成：
+
+```dart
+final String oneLine = output.trim().replaceAll(RegExp(r'\s+'), ' ');
+return '${oneLine.substring(0, maxLength)}...';   // maxLength=500，从头截断
+```
+
+ffmpeg 的日志**开头恒是 banner**（`ffmpeg version` / `built with` / `configuration:` / `-i` 输入信息），`-hide_banner` 只去版本行不去 configuration。移动端自编 ffmpeg-kit 的 configuration 字符串极长（几百个 `--enable-*`），500 字全被它吃满，**真正的失败行（`Conversion failed!` / `Encoder not found` / `Invalid data` 等，在日志末尾）永远被截掉**。
+
+这与视频制卡 TODO-910 修过的完全是同一类问题——视频侧 OSD 早已改用 `extractFfmpegFailureReason`（从尾段扫真因行），但那个抽取器只在 `video_clip_exporter.dart` 里，**共享的 `FfmpegRunResult.failureSummary`（音频裁剪 + reader 制卡走这条）从未受益**，仍旧从头截断。
+
+### 修复
+把 `extractFfmpegFailureReason` 的正准实现搬到最底层 `ffmpeg_backend.dart`（与 `FfmpegRunResult` 同文件、无依赖），`video_clip_exporter.dart` 改为 `export ... show extractFfmpegFailureReason` 保持旧调用点/测试不变，`audiobook_clip_export.dart` 直接从 `ffmpeg_backend.dart` 取。`_summarizeFfmpegOutput` 改为：先 `extractFfmpegFailureReason(output)` 抽末尾真因行，抽不出才退化整段压平，再折单行限长。noise 过滤补上 `ffmpeg version` 前缀（旧版只滤 `built with`/`configuration:`/`lib`）。
+
+改动文件：
+- `hibiki/lib/src/media/video/ffmpeg_backend.dart`（+`extractFfmpegFailureReason`，`_summarizeFfmpegOutput` 改尾段抽取）
+- `hibiki/lib/src/media/video/video_clip_exporter.dart`（删本地重复定义，改 `export` 转口）
+- `hibiki/lib/src/media/audiobook/audiobook_clip_export.dart`（import 改从 ffmpeg_backend 直取）
+
+一处修复同时惠及：reader 划词制卡 toast、视频/有声书片段合成日志、桌面音频裁剪日志——全走同一个 `failureSummary`。
+
+### 验证
+- `flutter analyze`（全项目）无 issue。
+- `flutter test test/media test/build/ffmpeg_min_clip_muxer_guard_test.dart test/mining/immersion_mining_ffmpeg_integration_test.dart`：2605 passed / 2 skipped。
+- 新增守卫：超长 banner + 尾段 `Conversion failed!` 的日志，`failureSummary` 必含尾段真因、不含 `ffmpeg version` / `configuration:`。
+
+### 后续
+本修复解决的是「看不到真因」这一诊断截断根因。ffmpeg-kit 本次 exit 1 的**具体**原因（编码器/容器/输入解码）需用户在装了本修复的版本上复现，读新的（真因可见的）toast/日志再定位；届时可另开跟进。

--- a/docs/bugs/BUG-834-ffmpeg-failure-summary-tail.md
+++ b/docs/bugs/BUG-834-ffmpeg-failure-summary-tail.md
@@ -1,7 +1,7 @@
 ## BUG-834 · 制卡句子音频失败toast只显示ffmpeg版本banner看不到真因
 - **报告**：2026-07-15（用户：截图报「导出卡片失败：sentence audio export failed: ffmpeg exit 1」）
 - **真实性**：✅ 真 bug（诊断截断）。根因 `hibiki/lib/src/media/video/ffmpeg_backend.dart:83`（旧 `_summarizeFfmpegOutput` 从**头**截 500 字）。
-- **[x] ① 已修复** — 提交 `<pending>`
+- **[x] ① 已修复** — 提交 `4688c4a48`（PR #151）
 - **[x] ② 已加自动化测试** — `hibiki/test/media/video/ffmpeg_backend_test.dart`（failureSummary surfaces the tail error line, not the leading banner）
 - **备注**：
 

--- a/hibiki/lib/src/media/audiobook/audiobook_clip_export.dart
+++ b/hibiki/lib/src/media/audiobook/audiobook_clip_export.dart
@@ -3,9 +3,9 @@ import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:image/image.dart' as img;
+// BUG-834：extractFfmpegFailureReason 的正准实现在 ffmpeg_backend.dart（与
+// FfmpegBackend 同层），直接从这里取，不再经 video_clip_exporter 转口。
 import 'package:hibiki/src/media/video/ffmpeg_backend.dart';
-import 'package:hibiki/src/media/video/video_clip_exporter.dart'
-    show extractFfmpegFailureReason;
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 

--- a/hibiki/lib/src/media/video/ffmpeg_backend.dart
+++ b/hibiki/lib/src/media/video/ffmpeg_backend.dart
@@ -80,8 +80,89 @@ String _formatFfmpegReturnCode(int? returnCode) {
   return 'ffmpeg exit $returnCode';
 }
 
+/// 从 ffmpeg 日志里抽取「真正的失败原因行」，供 [FfmpegRunResult.failureSummary]
+/// 与失败 OSD 显示。
+///
+/// 根因（TODO-910 / BUG-834）：ffmpeg 的日志**开头恒是 banner**——version /
+/// `built with` / `configuration:` / 库版本，`-hide_banner` 只去版本行，`-i` 的
+/// 输入/流信息也在开头。真正的失败行（`Conversion failed!` /
+/// `Stream map '0:a:3' matches no streams` / `Could not open file` /
+/// `Invalid data found` / `Encoder ... not found` 等）出现在日志**末尾**。旧的
+/// [_summarizeFfmpegOutput] 从头截断 500 字 → 用户与日志只看到没用的 banner
+/// （移动端 ffmpeg-kit 的 configuration 极长，500 字全被 banner 吃满），真因永远
+/// 被截掉。本函数从尾段抽真因，让失败摘要可读。
+///
+/// 策略（从尾往头扫，跳过 banner/进度/Metadata 噪声行）：
+/// 1. 拆成非空行（去掉行内首尾空白）。
+/// 2. **优先**：自尾向首找第一条「含错误关键词」的行，返回它。
+/// 3. **退化**：无任何错误关键词行（如只有 banner），返回最后一条非噪声信息行
+///    （跳过 `Input #` / `Metadata:` / `Stream #` / `Duration:` / `ffmpeg version`
+///    / `built with` / `configuration:` / `lib*` 版本行 / 纯进度 `frame=` 等）；
+///    全是噪声则返回最后一条非空行。
+/// 4. 全空 → 空串（调用方据此不追加 detail）。
+String extractFfmpegFailureReason(String stderr) {
+  final List<String> lines = stderr
+      .split('\n')
+      .map((String l) => l.trim())
+      .where((String l) => l.isNotEmpty)
+      .toList();
+  if (lines.isEmpty) return '';
+
+  const List<String> errorMarkers = <String>[
+    'error',
+    'failed',
+    'invalid',
+    'could not',
+    'cannot',
+    'no such',
+    'matches no streams',
+    'unable',
+    'permission denied',
+    'not found',
+    'unsupported',
+    'unrecognized',
+    'unknown',
+    'does not contain',
+  ];
+  for (int i = lines.length - 1; i >= 0; i--) {
+    final String lower = lines[i].toLowerCase();
+    if (errorMarkers.any(lower.contains)) {
+      return lines[i];
+    }
+  }
+
+  // 退化：无错误关键词（典型是被截断的纯 banner）。返回最后一条非噪声信息行。
+  bool isNoise(String line) {
+    final String lower = line.toLowerCase();
+    return line.startsWith('Input #') ||
+        line.startsWith('Output #') ||
+        line.startsWith('Stream #') ||
+        line.startsWith('Metadata:') ||
+        line.startsWith('Duration:') ||
+        lower.startsWith('frame=') ||
+        lower.startsWith('size=') ||
+        lower.contains('encoder') ||
+        lower.startsWith('ffmpeg version') ||
+        lower.startsWith('built with') ||
+        lower.startsWith('configuration:') ||
+        lower.startsWith('lib');
+  }
+
+  for (int i = lines.length - 1; i >= 0; i--) {
+    if (!isNoise(lines[i])) return lines[i];
+  }
+  return lines.last;
+}
+
+/// 把 ffmpeg 日志压成一行给 [FfmpegRunResult.failureSummary] 显示。
+///
+/// BUG-834：不再从**头**截断（那永远是 banner，真因在尾段）。先用
+/// [extractFfmpegFailureReason] 抽出末尾的真因行；抽不出才退化到整段压平。再折成
+/// 单行并限长，避免超长 configuration 撑爆 toast。
 String _summarizeFfmpegOutput(String output) {
-  final String oneLine = output.trim().replaceAll(RegExp(r'\s+'), ' ');
+  final String reason = extractFfmpegFailureReason(output);
+  final String chosen = reason.isNotEmpty ? reason : output.trim();
+  final String oneLine = chosen.replaceAll(RegExp(r'\s+'), ' ').trim();
   const int maxLength = 500;
   if (oneLine.length <= maxLength) return oneLine;
   return '${oneLine.substring(0, maxLength)}...';

--- a/hibiki/lib/src/media/video/video_clip_exporter.dart
+++ b/hibiki/lib/src/media/video/video_clip_exporter.dart
@@ -3,6 +3,13 @@ import 'dart:io';
 import 'package:hibiki/src/media/video/ffmpeg_backend.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
 
+// BUG-834：`extractFfmpegFailureReason` 的正准实现搬到 ffmpeg_backend.dart（最底层、
+// 无依赖），供共享的 [FfmpegRunResult.failureSummary] 与音频/视频两路径统一复用。此处
+// 再导出，保持既有 `import '.../video_clip_exporter.dart' show extractFfmpegFailureReason`
+// 调用点与测试不变。
+export 'package:hibiki/src/media/video/ffmpeg_backend.dart'
+    show extractFfmpegFailureReason;
+
 enum VideoClipExportFailure {
   invalidRange,
   inputMissing,
@@ -175,78 +182,6 @@ Future<VideoClipExportResult> exportVideoClipViaFfmpeg({
       detail: e.toString(),
     );
   }
-}
-
-/// 纯函数：从 ffmpeg 的 stderr 里抽取「真正的失败原因行」，给失败 OSD 显示。
-///
-/// 根因（TODO-910）：ffmpeg 的 stderr 开头**恒是输入 banner**——
-/// `Input #0, matroska,webm, from '<path>': Metadata: encoder :...`
-/// （`-hide_banner` 只去版本 banner，不去 `-i` 的输入/流信息）。真正的失败行
-/// （`Conversion failed!` / `Stream map '0:a:3' matches no streams` /
-/// `Could not open file` / `Invalid data found` 等）出现在 stderr **末尾**。
-/// 旧 OSD 用 `substring(0, 160)` 从头截断 → 用户只看到没用的输入 banner，
-/// 看不到真因。本函数从尾段抽真因，让失败提示可读。
-///
-/// 策略（从尾往头扫，跳过 banner/进度/Metadata 噪声行）：
-/// 1. 把 stderr 拆成非空行（去掉行内首尾空白）。
-/// 2. **优先**：自尾向首找第一条「含错误关键词」的行
-///    （error / failed / invalid / could not / no such / matches no streams /
-///     unable / permission denied / not found），返回它。
-/// 3. **退化**：没有任何错误关键词行（如只有 banner），返回**最后一条非噪声行**
-///    （跳过 `Input #` / `Metadata:` / `Stream #` / `Duration:` / `encoder` /
-///     纯进度 `frame=...` 这类信息行）；若全是噪声，返回最后一条非空行。
-/// 4. 全空 → 空串（调用方据此不追加 detail）。
-String extractFfmpegFailureReason(String stderr) {
-  final List<String> lines = stderr
-      .split('\n')
-      .map((String l) => l.trim())
-      .where((String l) => l.isNotEmpty)
-      .toList();
-  if (lines.isEmpty) return '';
-
-  const List<String> errorMarkers = <String>[
-    'error',
-    'failed',
-    'invalid',
-    'could not',
-    'cannot',
-    'no such',
-    'matches no streams',
-    'unable',
-    'permission denied',
-    'not found',
-    'unsupported',
-    'unrecognized',
-    'unknown',
-    'does not contain',
-  ];
-  for (int i = lines.length - 1; i >= 0; i--) {
-    final String lower = lines[i].toLowerCase();
-    if (errorMarkers.any(lower.contains)) {
-      return lines[i];
-    }
-  }
-
-  // 退化：无错误关键词（典型是被截断的纯 banner）。返回最后一条非噪声信息行。
-  bool isNoise(String line) {
-    final String lower = line.toLowerCase();
-    return line.startsWith('Input #') ||
-        line.startsWith('Output #') ||
-        line.startsWith('Stream #') ||
-        line.startsWith('Metadata:') ||
-        line.startsWith('Duration:') ||
-        lower.startsWith('frame=') ||
-        lower.startsWith('size=') ||
-        lower.contains('encoder') ||
-        lower.startsWith('built with') ||
-        lower.startsWith('configuration:') ||
-        lower.startsWith('lib');
-  }
-
-  for (int i = lines.length - 1; i >= 0; i--) {
-    if (!isNoise(lines[i])) return lines[i];
-  }
-  return lines.last;
 }
 
 void _deleteIfPresent(File file) {

--- a/hibiki/test/media/video/ffmpeg_backend_test.dart
+++ b/hibiki/test/media/video/ffmpeg_backend_test.dart
@@ -44,6 +44,51 @@ void main() {
           result.failureSummary, contains(r'C:\Hibiki\ffmpeg.exe -> ffmpeg'));
       expect(result.failureSummary, contains('The application was unable'));
     });
+
+    // BUG-834：Android 制卡句子音频（ffmpeg-kit）失败时，toast/日志只显示 ffmpeg
+    // version + configuration banner，真因（末尾的 Error/Invalid/... 行）被从头截
+    // 断吃掉。failureSummary 必须从**尾段**抽真因，而不是从头截 500 字。
+    test('failureSummary surfaces the tail error line, not the leading banner',
+        () {
+      // 复刻移动端 ffmpeg-kit n6.0 日志：超长 banner 在前（configuration 独占 >500
+      // 字），真正的失败行在末尾。旧实现从头截 500 字 → 永远只剩 banner。
+      final String longConfig = 'configuration: '
+          '${List<String>.filled(60, '--enable-decoder=some_long_name').join(' ')}';
+      final String output = <String>[
+        'ffmpeg version n6.0 Copyright (c) 2000-2023 the FFmpeg developers',
+        'built with Android (9352603, based on r450784d1) clang version 14.0.7',
+        longConfig,
+        "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '/data/user/0/app/cache/book.m4b':",
+        '  Duration: 00:03:12.00, start: 0.000000, bitrate: 128 kb/s',
+        '  Stream #0:0(und): Audio: aac (LC), 44100 Hz, stereo, fltp, 128 kb/s',
+        '[aac @ 0x7f] Error while opening encoder - maybe incorrect parameters',
+        'Conversion failed!',
+      ].join('\n');
+
+      final FfmpegRunResult result = FfmpegRunResult(
+        returnCode: 1,
+        output: output,
+        executable: 'ffmpeg-kit',
+        attemptedExecutables: const <String>['ffmpeg-kit'],
+      );
+
+      final String summary = result.failureSummary;
+      // 真因（尾段错误行）必须出现——从尾向首取第一条含错误关键词的行
+      // （'Conversion failed!' 命中 'failed'），而非开头 banner。
+      expect(summary, contains('Conversion failed!'),
+          reason: 'The real ffmpeg failure line (tail) must survive '
+              'summarization instead of the leading banner.');
+      // banner（version 行）不得成为唯一显示内容——旧的从头截断正是只剩它。
+      expect(summary.contains('ffmpeg version n6.0'), isFalse,
+          reason: 'The leading version banner must not crowd out the real '
+              'error (old head-truncation showed only the banner).');
+      expect(summary.contains('configuration:'), isFalse,
+          reason: 'The long configuration banner must not be surfaced instead '
+              'of the tail error (BUG-834).');
+      // 仍带执行上下文。
+      expect(summary, contains('executable=ffmpeg-kit'));
+      expect(summary, contains('ffmpeg exit 1'));
+    });
   });
 
   group('resolveFfmpegBackend', () {


### PR DESCRIPTION
## 现象
用户截图：Android 划词制卡弹「导出卡片失败：sentence audio export failed: ffmpeg exit 1; executable=ffmpeg-kit; ... stderr=ffmpeg version n6.0 ... configuration: --cross-prefix=...」——`stderr=` 后全是 ffmpeg 的 version+configuration banner，在中途被截断，真正的失败原因看不到。

## 根因
句子音频失败上报 `FfmpegRunResult.failureSummary`，其 stderr 部分由 `_summarizeFfmpegOutput` 从**头**截 500 字。ffmpeg 日志开头恒是 banner（version/built with/configuration/输入信息），移动端自编 ffmpeg-kit 的 configuration 极长，500 字全被它吃满，**末尾的真因行（`Conversion failed!` / `Encoder not found` / `Invalid data`）永远被截掉**。

视频制卡 TODO-910 早已用 `extractFfmpegFailureReason`（从尾段扫真因）修过同类问题，但那个抽取器只在 `video_clip_exporter.dart`，**共享的 `failureSummary`（音频裁剪 + reader 制卡走这条）从未受益**。

## 修复
- 把 `extractFfmpegFailureReason` 正准实现搬到最底层 `ffmpeg_backend.dart`（与 `FfmpegRunResult` 同文件）。
- `video_clip_exporter.dart` 改 `export ... show` 转口，`audiobook_clip_export.dart` 直接从 ffmpeg_backend 取（旧调用点/测试不变）。
- `_summarizeFfmpegOutput` 改为先抽末尾真因行、抽不出才退化，noise 过滤补 `ffmpeg version` 前缀。
- 一处修复惠及 reader 划词制卡 toast + 视频/有声书合成日志 + 桌面音频裁剪日志（同走 failureSummary）。

## 验证
- `flutter analyze`（全项目）No issues。
- `flutter test test/media test/build/ffmpeg_min_clip_muxer_guard_test.dart test/mining/immersion_mining_ffmpeg_integration_test.dart`：2605 passed / 2 skipped。
- 新增守卫 `test/media/video/ffmpeg_backend_test.dart`：超长 banner + 尾段 `Conversion failed!`，`failureSummary` 必含尾段真因、不含 `ffmpeg version`/`configuration:`。

## 后续
本修复解决「看不到真因」的诊断截断。ffmpeg-kit 本次 exit 1 的**具体**原因需用户在装了本修复的版本上复现、读新的（真因可见的）toast/日志再定位。

BUG-834 详情见 `docs/bugs/BUG-834-ffmpeg-failure-summary-tail.md`。