### PR TITLE
fix(video): BUG-837 桌面视频全屏改非独占，修复锁死桌面无法切软件

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 818 条。点号进各自文件。
+> 共 819 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-837](bugs/BUG-837-video-fullscreen-desktop-lock.md) | ✅ | ✅ | 桌面视频全屏独占锁死桌面无法切到其他软件 |
 | [BUG-836](bugs/BUG-836-video-ultra-anime4k-ul-windows-black.md) | ✅ | ✅ | 视频画质增强极高档(Anime4K UL)在 Windows ANGLE 后端黑屏 |
 | [BUG-835](bugs/BUG-835-ffmpeg-failure-summary-tail.md) | ✅ | ✅ | 制卡句子音频失败toast只显示ffmpeg版本banner看不到真因 |
 | [BUG-834](bugs/BUG-834-remote-card-timer-leak.md) | ✅ | ✅ | HomeVideoPage的videoBooks watch订阅dispose取消时遗留drift缓存保留Timer致isolate不退出+CI全量单测挂死60min |

--- a/docs/bugs/BUG-837-video-fullscreen-desktop-lock.md
+++ b/docs/bugs/BUG-837-video-fullscreen-desktop-lock.md
@@ -1,0 +1,8 @@
+## BUG-837 · 桌面视频全屏独占锁死桌面无法切到其他软件
+- **报告**：2026-07-15（用户：双屏 Windows）
+- **真实性**：✅ 真 bug — 根因 `third_party/media_kit_video/windows/utils.cc:44-49`（`Utils::EnterNativeFullscreen`）。
+- **现象**：桌面进视频全屏后，桌面点不开其他软件、只有任务栏能动、窗口最小化也不行，必须 Win+D（显示桌面）或退出视频才能操作其他软件；双屏。
+- **根因**：桌面视频全屏走 media_kit 上游 `EnterNativeFullscreen`：把主窗口 `style & ~WS_OVERLAPPEDWINDOW` 变无边框、`SetWindowPos(HWND_TOP, rcMonitor…)` 精确铺满整块显示器。Flutter/ANGLE 的无边框窗口精确等于显示器矩形 + 顶层 → 被 Windows/DWM 提升为**独占式全屏（Fullscreen Optimization / 独占 MPO flip）**，z-order 被霸占：其他窗口浮不上来（只有系统置顶的任务栏可点）、Alt+Tab/任务栏切不走、双屏另一屏受牵连，只能 Win+D 强制最小化一切或退出视频还原样式才解锁。排除了「窗口置顶」路径——读用户生产库 `desktop_clipboard_window_mode = normal`，主窗从不带 `WS_EX_TOPMOST`。
+- **[x] ① 已修复** — `third_party/media_kit_video/windows/utils.cc` `EnterNativeFullscreen`：① 落点改 `HWND_NOTOPMOST`（非置顶层 + 清除遗留 always-on-top，让被激活的其他窗口能覆盖本窗口）；② 窗口高度 `monitor_height + 1`（比显示器高 1px，底边落屏外，使客户区不再精确等于显示器矩形 → DWM 不再判独占全屏、恢复普通合成、窗口可被覆盖/切走；多出 1px 在屏外不可见，视觉仍铺满）。不动 `WS_OVERLAPPEDWINDOW` 全屏状态机（`ExitNativeFullscreen`/`WM_NCCALCSIZE` 依赖它）。提交：<pending>。
+- **[x] ② 已加自动化测试** — `hibiki/test/build/video_fullscreen_no_exclusive_guard_test.dart`（源码扫描守卫：`EnterNativeFullscreen` 段必含 `HWND_NOTOPMOST` 且不含 `HWND_TOP,`、必含 `monitor_height + 1`；原生窗口无法在 host 跑，守卫防 re-vendor/重构静默回归）。
+- **备注**：z-order/DWM 独占行为**必须在双屏真机复测**——修复逻辑正确但 FSO/独占合成只有真机能最终验证；当前后台会话单屏 + 沙箱跑不了 GUI 前台切换，复现不了。真机验证点：进视频全屏后 Alt+Tab / 点任务栏能正常切到其他软件、双屏另一屏可用、退出全屏窗口正常还原。若仍锁死需迭代 FSO 规避手段。

--- a/hibiki/test/build/video_fullscreen_no_exclusive_guard_test.dart
+++ b/hibiki/test/build/video_fullscreen_no_exclusive_guard_test.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Source-scan guard for BUG-837: desktop video fullscreen must NOT become a
+/// DWM exclusive fullscreen (Fullscreen Optimization / exclusive MPO flip).
+///
+/// media_kit's upstream [Utils::EnterNativeFullscreen] makes the borderless
+/// main window fill the monitor rect exactly and lands it at HWND_TOP. On
+/// Windows that gets promoted to exclusive fullscreen: the window seizes the
+/// z-order, so the user can no longer Alt+Tab / click the taskbar to reach
+/// other apps (the second monitor is dragged along too) — only Win+D or exiting
+/// the video releases it. The native window cannot run on the test host, so
+/// this guard pins the two load-bearing bits of the fix inside the vendored
+/// utils.cc so a `pub get` re-vendor or refactor cannot silently regress it.
+void main() {
+  late String enterBody;
+
+  setUpAll(() {
+    final String cpp =
+        File('../third_party/media_kit_video/windows/utils.cc')
+            .readAsStringSync();
+    final int enter = cpp.indexOf('void Utils::EnterNativeFullscreen');
+    final int exit = cpp.indexOf('void Utils::ExitNativeFullscreen');
+    expect(enter, greaterThanOrEqualTo(0),
+        reason: 'EnterNativeFullscreen must exist in vendored utils.cc');
+    expect(exit, greaterThan(enter),
+        reason: 'ExitNativeFullscreen must follow EnterNativeFullscreen');
+    enterBody = cpp.substring(enter, exit);
+  });
+
+  group('BUG-837 desktop video fullscreen is non-exclusive', () {
+    test('window lands non-topmost so other apps can cover it', () {
+      // Must place the fullscreen window on the non-topmost band and clear any
+      // leftover always-on-top, so an activated app can rise above it.
+      expect(enterBody.contains('HWND_NOTOPMOST'), isTrue,
+          reason: 'Fullscreen window must be forced non-topmost (BUG-837).');
+      expect(enterBody.contains('HWND_TOP,'), isFalse,
+          reason:
+              'HWND_TOP re-introduces exclusive-fullscreen z-order seizure.');
+    });
+
+    test('client rect is not an exact monitor cover (breaks exclusive flip)',
+        () {
+      // One pixel taller than the monitor keeps the window off the DWM
+      // exclusive-fullscreen path; the extra pixel is off-screen and invisible.
+      expect(enterBody.contains('monitor_height + 1'), isTrue,
+          reason:
+              'Fullscreen height must differ from the monitor rect so DWM does '
+              'not promote it to an exclusive flip (BUG-837).');
+    });
+  });
+}

--- a/third_party/media_kit_video/windows/utils.cc
+++ b/third_party/media_kit_video/windows/utils.cc
@@ -42,10 +42,20 @@ void Utils::EnterNativeFullscreen(HWND window) {
     ::GetMonitorInfo(::MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST),
                      &monitor);
     ::SetWindowLongPtr(window, GWL_STYLE, style & ~WS_OVERLAPPEDWINDOW);
-    ::SetWindowPos(window, HWND_TOP, monitor.rcMonitor.left,
-                   monitor.rcMonitor.top,
-                   monitor.rcMonitor.right - monitor.rcMonitor.left,
-                   monitor.rcMonitor.bottom - monitor.rcMonitor.top,
+    // Hibiki BUG(桌面视频全屏锁死桌面)：媒体窗口全屏必须保持“可切走的窗口化
+    // 全屏”，绝不能变成 DWM 独占式全屏（Fullscreen Optimization / 独占 MPO
+    // flip）。上游默认把无边框窗口精确铺满整块显示器（rcMonitor）并落 HWND_TOP，
+    // 这会被 DWM 提升为独占全屏：z-order 被霸占，用户无法 Alt+Tab / 点任务栏切到
+    // 其他软件、双屏另一屏被牵连，只能靠 Win+D 或退出视频才能解锁。两处根因修复：
+    //  1) 用 HWND_NOTOPMOST 显式落在非置顶层，清除任何遗留的 always-on-top，
+    //     保证被激活的其他窗口能覆盖到本窗口之上。
+    //  2) 窗口高度比显示器多 1px（底边落在显示器外），使窗口客户区不再精确等于
+    //     显示器矩形——DWM 据此不再判定为独占全屏，恢复普通合成，窗口可被正常
+    //     覆盖/切走。多出的 1px 在屏幕外不可见，视觉仍铺满整屏。
+    const int monitor_width = monitor.rcMonitor.right - monitor.rcMonitor.left;
+    const int monitor_height = monitor.rcMonitor.bottom - monitor.rcMonitor.top;
+    ::SetWindowPos(window, HWND_NOTOPMOST, monitor.rcMonitor.left,
+                   monitor.rcMonitor.top, monitor_width, monitor_height + 1,
                    SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
   }
 }


### PR DESCRIPTION
## 现象
双屏 Windows：桌面进视频全屏后，桌面点不开其他软件、只有任务栏能动、最小化也不行，必须 Win+D 或退出视频才能操作其他软件。

## 根因（`third_party/media_kit_video/windows/utils.cc:44-49`）
media_kit 上游 `EnterNativeFullscreen` 把无边框主窗口**精确铺满整块显示器**（`rcMonitor`）且落 `HWND_TOP`。Flutter/ANGLE 无边框窗口精确等于显示器矩形 + 顶层 → 被 Windows/DWM 提升为**独占式全屏（Fullscreen Optimization / 独占 MPO flip）**，z-order 被霸占：其他窗口浮不上来、Alt+Tab/任务栏切不走、双屏另一屏受牵连，只能 Win+D 或退出视频解锁。

已排除「窗口置顶」路径：读用户生产库 `desktop_clipboard_window_mode = normal`，主窗从不带 `WS_EX_TOPMOST`。

## 修复
`EnterNativeFullscreen` 两处根因修复，不动 `WS_OVERLAPPEDWINDOW` 全屏状态机：
1. 落点 `HWND_TOP` → `HWND_NOTOPMOST`（非置顶层 + 清遗留 always-on-top，让激活的其他窗口能覆盖）。
2. 窗口高度 `monitor_height + 1`（比显示器高 1px、底边落屏外，客户区不再精确等于显示器矩形）→ DWM 不再判独占全屏、恢复普通合成、窗口可被覆盖/切走；多出 1px 屏外不可见，视觉仍铺满。

## 测试
- 源码守卫 `hibiki/test/build/video_fullscreen_no_exclusive_guard_test.dart`（2/2 通过）：钉住 `HWND_NOTOPMOST` + 非精确覆盖，防 re-vendor/重构静默回归。
- `flutter analyze` 无问题。

## ⚠️ 待验证
z-order/DWM 独占行为**必须在双屏真机复测**——诊断会话是单屏 + 沙箱跑不了 GUI 前台切换，复现不了。真机验证点：进视频全屏后 Alt+Tab / 点任务栏能切到其他软件、双屏另一屏可用、退出全屏正常还原。若仍锁死需迭代 FSO 规避手段。