### PR TITLE
docs: 更新推荐词典/本地音频 Google Drive 链接 + 导入标题加小白推荐强调

### DIFF
--- a/docs/user-guide.ar.md
+++ b/docs/user-guide.ar.md
@@ -22,9 +22,9 @@ https://github.com/hajisensai/hibiki/releases/latest
 
 ## دليل الإعداد
 
-### 1. استيراد القواميس المُوصى بها والصوت المحلي (اختياري)
+### 1. استيراد القواميس المُوصى بها والصوت المحلي (يُوصى به بشدة للمبتدئين!!! · اختياري)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 داخل التطبيق: الإعدادات -> المزامنة والنسخ الاحتياطي -> اضغط على **استيراد نسخة احتياطية**.
 

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -22,9 +22,9 @@ Android: Wähle **arm64**. Windows: Wähle die **.exe**-Datei.
 
 ## Einrichtungs-Tutorial
 
-### 1. Empfohlene Wörterbücher und lokales Audio importieren (optional)
+### 1. Empfohlene Wörterbücher und lokales Audio importieren (Sehr empfehlenswert für Einsteiger!!! · optional)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 In der App: Einstellungen -> Synchronisierung & Sicherung -> tippe auf **Sicherung importieren**.
 

--- a/docs/user-guide.es.md
+++ b/docs/user-guide.es.md
@@ -22,9 +22,9 @@ Android: elige **arm64**. Windows: elige el archivo **.exe**.
 
 ## Tutorial de configuración
 
-### 1. Importar los diccionarios recomendados y el audio local (opcional)
+### 1. Importar los diccionarios recomendados y el audio local (Muy recomendado para principiantes!!! · opcional)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 En la aplicación: Ajustes -> Sincronización y copia de seguridad -> toca **Importar copia de seguridad**.
 

--- a/docs/user-guide.fr.md
+++ b/docs/user-guide.fr.md
@@ -22,9 +22,9 @@ Android : choisissez **arm64**. Windows : choisissez le fichier **.exe**.
 
 ## Tutoriel de configuration
 
-### 1. Importer les dictionnaires recommandés et l'audio local (facultatif)
+### 1. Importer les dictionnaires recommandés et l'audio local (Fortement recommandé pour les débutants!!! · facultatif)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 Dans l'application : Paramètres -> Synchronisation et sauvegarde -> appuyez sur **Importer une sauvegarde**.
 

--- a/docs/user-guide.id.md
+++ b/docs/user-guide.id.md
@@ -22,9 +22,9 @@ Android: pilih **arm64**. Windows: pilih berkas **.exe**.
 
 ## Tutorial Konfigurasi
 
-### 1. Mengimpor kamus yang direkomendasikan dan audio lokal (opsional)
+### 1. Mengimpor kamus yang direkomendasikan dan audio lokal (Sangat direkomendasikan untuk pemula!!! · opsional)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 Di dalam aplikasi: Pengaturan -> Sinkronisasi & Cadangan -> ketuk **Impor Cadangan**.
 

--- a/docs/user-guide.it.md
+++ b/docs/user-guide.it.md
@@ -22,9 +22,9 @@ Android: scegli **arm64**. Windows: scegli il file **.exe**.
 
 ## Tutorial di configurazione
 
-### 1. Importare i dizionari consigliati e l'audio locale (facoltativo)
+### 1. Importare i dizionari consigliati e l'audio locale (Altamente consigliato per i principianti!!! · facoltativo)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 Nell'app: Impostazioni -> Sincronizzazione e backup -> tocca **Importa backup**.
 

--- a/docs/user-guide.ja.md
+++ b/docs/user-guide.ja.md
@@ -22,9 +22,9 @@ Android：**arm64** を選んでください。Windows：**.exe** ファイル�
 
 ## 設定チュートリアル
 
-### 1. 推奨辞書とローカル音声をインポートする（任意）
+### 1. 推奨辞書とローカル音声をインポートする（初心者に強くおすすめ！！！・任意）
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 アプリ内で：設定 -> 同期とバックアップ -> **バックアップをインポート** をタップします。
 

--- a/docs/user-guide.ko.md
+++ b/docs/user-guide.ko.md
@@ -22,9 +22,9 @@ Android: **arm64**를 선택하세요. Windows: **.exe** 파일을 선택하세�
 
 ## 설정 튜토리얼
 
-### 1. 추천 사전과 로컬 오디오 가져오기(선택 사항)
+### 1. 추천 사전과 로컬 오디오 가져오기(초보자에게 강력 추천!!! · 선택 사항)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 앱에서: 설정 -> 동기화 및 백업 -> **백업 가져오기**를 탭합니다.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -26,9 +26,9 @@ Android: choose **arm64**. Windows: choose the **.exe** file.
 
 ## Configuration Tutorial
 
-### 1. Import recommended dictionaries and local audio (optional)
+### 1. Import recommended dictionaries and local audio (Highly recommended for beginners!!! · optional)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 In the app: Settings -> Sync & Backup -> tap **Import Backup**.
 

--- a/docs/user-guide.nl.md
+++ b/docs/user-guide.nl.md
@@ -22,9 +22,9 @@ Android: kies **arm64**. Windows: kies het **.exe**-bestand.
 
 ## Configuratiehandleiding
 
-### 1. Aanbevolen woordenboeken en lokale audio importeren (optioneel)
+### 1. Aanbevolen woordenboeken en lokale audio importeren (Sterk aanbevolen voor beginners!!! · optioneel)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 In de app: Instellingen -> Synchronisatie en back-up -> tik op **Back-up importeren**.
 

--- a/docs/user-guide.pt-BR.md
+++ b/docs/user-guide.pt-BR.md
@@ -22,9 +22,9 @@ Android: escolha **arm64**. Windows: escolha o arquivo **.exe**.
 
 ## Tutorial de configuração
 
-### 1. Importar os dicionários recomendados e o áudio local (opcional)
+### 1. Importar os dicionários recomendados e o áudio local (Altamente recomendado para iniciantes!!! · opcional)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 No aplicativo: Configurações -> Sincronização e backup -> toque em **Importar backup**.
 

--- a/docs/user-guide.ru.md
+++ b/docs/user-guide.ru.md
@@ -22,9 +22,9 @@ Android: выберите **arm64**. Windows: выберите файл **.exe**
 
 ## Руководство по настройке
 
-### 1. Импорт рекомендуемых словарей и локального аудио (необязательно)
+### 1. Импорт рекомендуемых словарей и локального аудио (Настоятельно рекомендуется новичкам!!! · необязательно)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 В приложении: Настройки -> Синхронизация и резервное копирование -> нажмите **Импортировать резервную копию**.
 

--- a/docs/user-guide.th.md
+++ b/docs/user-guide.th.md
@@ -22,9 +22,9 @@ Android: เลือก **arm64** Windows: เลือกไฟล์ **.exe**
 
 ## บทแนะนำการตั้งค่า
 
-### 1. นำเข้าพจนานุกรมที่แนะนำและไฟล์เสียงในเครื่อง (ไม่บังคับ)
+### 1. นำเข้าพจนานุกรมที่แนะนำและไฟล์เสียงในเครื่อง (แนะนำอย่างยิ่งสำหรับมือใหม่!!! · ไม่บังคับ)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 ในแอป: การตั้งค่า -> ซิงค์และสำรองข้อมูล -> แตะ **นำเข้าข้อมูลสำรอง**
 

--- a/docs/user-guide.tr.md
+++ b/docs/user-guide.tr.md
@@ -22,9 +22,9 @@ Android: **arm64** seçin. Windows: **.exe** dosyasını seçin.
 
 ## Yapılandırma Eğitimi
 
-### 1. Önerilen sözlükleri ve yerel sesi içe aktarma (isteğe bağlı)
+### 1. Önerilen sözlükleri ve yerel sesi içe aktarma (Yeni başlayanlara şiddetle önerilir!!! · isteğe bağlı)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 Uygulamada: Ayarlar -> Eşitleme ve Yedekleme -> **Yedeği İçe Aktar** öğesine dokunun.
 

--- a/docs/user-guide.vi.md
+++ b/docs/user-guide.vi.md
@@ -22,9 +22,9 @@ Android: chọn **arm64**. Windows: chọn tệp **.exe**.
 
 ## Hướng dẫn cấu hình
 
-### 1. Nhập các từ điển được đề xuất và âm thanh cục bộ (tùy chọn)
+### 1. Nhập các từ điển được đề xuất và âm thanh cục bộ (Rất khuyến khích cho người mới!!! · tùy chọn)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 Trong ứng dụng: Cài đặt -> Đồng bộ & Sao lưu -> nhấn **Nhập bản sao lưu**.
 

--- a/docs/user-guide.zh-Hant.md
+++ b/docs/user-guide.zh-Hant.md
@@ -22,9 +22,9 @@ Android：選擇 **arm64**。Windows：選擇 **.exe** 檔案。
 
 ## 設定教學
 
-### 1. 匯入推薦詞典與本機音訊（可選）
+### 1. 匯入推薦詞典與本機音訊（極其推薦新手使用此方法！！！可選）
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6/view?usp=sharing)
+[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 在 App 中：設定 -> 同步與備份 -> 點擊 **匯入備份**。
 


### PR DESCRIPTION
## 改动
教程「导入推荐词典及本地音频（可选）」章节：

1. **标题追加强调**：`（可选）` → `（极其推荐小白使用此方法！！！可选）`，16 个语言版本同步翻译（`docs/user-guide.*.md`）。
2. **Google Drive 链接更新**：旧备份 `1Xz5WdoLCEaTLHXpTtHBwxjJGMgKQA0B6` → 新备份 `19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0`（已验证匿名可下载）。

## ⚠️ OneDrive 链接暂未改（待补）
用户提供的 OneDrive 链接是 `download.aspx?...&tempauth=…` **临时下载链接**，内嵌 token `exp≈2026-07-15` 当天失效，不能进文档。

对旧共享链接 `IQD1h7Cw…?e=5ah1Jn` 做了核验：
- 匿名可访问（HTTP 200），但解码其分享 ID 得到的 item GUID = `0198b4b5…`，与新备份 UniqueId `9cdc7863-dc82-4b8d-add7-a38b1b49d8a9` **不一致** → 旧链接指向的是旧备份。
- 无 tempauth 的 `download.aspx?UniqueId=9cdc7863…` 匿名访问返回 **403**，不能直接用。

正规匿名分享链接（`…/:u:/g/personal/…?e=…` 形式）只能由文件所有者在 OneDrive 网页点「共享 → 复制链接（任何人）」生成，无法程序化伪造。**等所有者提供该链接后在本 PR 追加一次提交更新 OneDrive 侧。**

## 状态
Draft —— OneDrive 链接补齐前请勿合并。