### PR TITLE
fix(video): BUG-839 全屏连播换集漏栈致ESC逐层回退

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 820 条。点号进各自文件。
+> 共 821 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-839](bugs/BUG-839-fullscreen-autoplay-esc-stack.md) | 🚧 | 🚧 | 全屏连播换集漏栈致ESC逐层回退 |
 | [BUG-838](bugs/BUG-838-video-subtitle-lookup-seek-steal.md) | ✅ | ✅ | 视频字幕点字查词被进度条隐形热区抢成seek跳走 |
 | [BUG-837](bugs/BUG-837-video-fullscreen-desktop-lock.md) | ✅ | ✅ | 桌面视频全屏独占锁死桌面无法切到其他软件 |
 | [BUG-836](bugs/BUG-836-video-ultra-anime4k-ul-windows-black.md) | ✅ | ✅ | 视频画质增强极高档(Anime4K UL)在 Windows ANGLE 后端黑屏 |

--- a/docs/bugs/BUG-839-fullscreen-autoplay-esc-stack.md
+++ b/docs/bugs/BUG-839-fullscreen-autoplay-esc-stack.md
@@ -1,0 +1,40 @@
+## BUG-839 · 全屏连播换集漏栈致ESC逐层回退
+
+- **报告**：2026-07-15（用户：全屏看本地视频，连播下一集后按 ESC 回到上一集而非退出；连播 N 集要按 N 次 ESC）
+- **真实性**：✅ 真 bug（仅桌面全屏下复现）。根因 `hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart:130`
+- **[x] ① 已修复** — 见下「根因 + 修复」（分支 `worktree-fix-fullscreen-autoplay-esc-stack`）
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/video_fullscreen_switch_flatten_guard_test.dart`（源码守卫：本地换集 pushReplacement 前必先退全屏路由）；提交 `<pending>`
+- **备注**：窗口模式不复现；远端播放列表原地换流不受影响。
+
+### 根因
+
+连播链路（全在 `video_hibiki/episode.part.dart`）：
+`_handlePlaybackCompleted`(:18) → 5s 倒计时(:40) → `_runAutoAdvance`(:72) → `_switchEpisode`(:94)
+→ 本地分支 `navigator.pushReplacement(...)`(:130)。
+
+`pushReplacement` 的语义是**替换该 navigator 的栈顶路由**，而非「替换本集页」。全 app 只有一个 root
+navigator（`hibiki/lib/src/models/app_model.dart:525`，home 无嵌套 Navigator），视频页与全屏路由同栈：
+
+- **窗口播放**：栈顶就是剧集页，`pushReplacement` 正确替换本集 → 栈平，ESC 一次退出。**不复现**。
+- **全屏播放**：进全屏时 app 往 root navigator **压了独立全屏路由**（`video_hibiki/fullscreen.part.dart:177`
+  `rootNavigator: true`）。此刻栈 = `[书架, 第N集页, 全屏路由]`。连播触发 `pushReplacement` → 替换掉
+  **栈顶的全屏路由**、把第N+1集页 push 上来 → 栈变 `[书架, 第N集页, 第N+1集页]`，**旧集页漏在下面**。
+  ESC 只 `nav.pop()` 一层（`video_hibiki_page.dart:3423`）→ 回到旧集页而非退出。`_switchEpisode` 全程
+  未与全屏路由协调，是漏栈的根。
+
+引入提交 `07a1f9dee`（Phase 3 pushReplacement 低风险架构）——低风险架构未覆盖「全屏时栈顶不是剧集页」。
+
+### 修复
+
+`episode.part.dart` 本地换集分支：
+1. `pushReplacement` 前若在全屏路由（`_videoFullscreenRoute != null`），先经既有汇聚点
+   `_exitVideoFullscreen(_videoControlsContext)` 退全屏路由，让剧集页回到栈顶 → `pushReplacement`
+   正确替换本集页（栈恒平）。
+2. 记录 `wasFullscreen`，给新页 `VideoHibikiPage.neutralized(initialFullscreen: wasFullscreen)`；
+   新页 `_promoteVideoReady`(:1608) 首帧就绪后若 `initialFullscreen && 桌面` 重进全屏 → 连播保持全屏沉浸。
+3. 窗口模式（`wasFullscreen=false`）走原路径零变化；远端原地换流不受影响。
+
+### 验证
+
+- `flutter analyze`（lib+test）clean、`flutter test`
+- Windows 离屏真机：全屏连播 → ESC 一次退出到书架 + 下一集仍全屏

--- a/hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart
@@ -120,6 +120,18 @@ extension _VideoEpisode on _VideoHibikiPageState {
     // （tick 只整秒写，补这一下避免丢尾部几百 ms）；新页 _init 从该集行 lastPositionMs 续播。
     final String? targetUid = _episodes[index].bookUid;
     if (targetUid == null) return;
+    // BUG-839：全屏播放时 app 全屏路由压在剧集页之上（fullscreen.part.dart 推到 root
+    // navigator）。若不先退，下面的 pushReplacement 会替换掉栈顶的**全屏路由**、把本集页
+    // 漏在栈里 → 每连播一集就残留一层、ESC 需逐层退。故换集前先经既有汇聚点退全屏路由，
+    // 让剧集页回到栈顶，pushReplacement 才正确替换本集页（栈恒平、ESC 一次退出）；并记
+    // wasFullscreen，给新页 initialFullscreen 让其就绪后重进全屏，保持连播全屏沉浸。
+    final BuildContext? fsCtx = _videoControlsContext;
+    final bool wasFullscreen =
+        fsCtx != null && fsCtx.mounted && isFullscreen(fsCtx);
+    if (fsCtx != null && wasFullscreen) {
+      await _exitVideoFullscreen(fsCtx);
+      if (!context.mounted) return;
+    }
     // 捕获 NavigatorState（在 await 前），避免跨 async gap 用 context。
     final NavigatorState navigator = Navigator.of(context);
     final int? curPos = _controller?.positionMs;
@@ -140,6 +152,7 @@ extension _VideoEpisode on _VideoHibikiPageState {
           bookUid: targetUid,
           repo: widget.repo,
           playlistCollectionId: widget.playlistCollectionId,
+          initialFullscreen: wasFullscreen,
         ),
       ),
     );

--- a/hibiki/lib/src/pages/implementations/video_hibiki/fullscreen.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/fullscreen.part.dart
@@ -45,6 +45,41 @@ extension _VideoFullscreen on _VideoHibikiPageState {
         : _pushNeutralizedVideoFullscreen(context);
   }
 
+  /// BUG-839：从全屏页连播/换集而来的新页（[VideoHibikiPage.initialFullscreen]）在首帧
+  /// 就绪后自动重进全屏路由，保持连播全屏沉浸不被换集打断。
+  ///
+  /// 换集本地分支（[_VideoEpisode._switchEpisode]）先退旧页全屏路由再 `pushReplacement`
+  /// 到本集页（否则 `pushReplacement` 会误替换栈顶全屏路由、漏栈旧集页，致 ESC 逐层退）；
+  /// 新页则由本方法在就绪后重进全屏，端到端观感 = 换集全程全屏、ESC 一次退出。
+  ///
+  /// 一次性（[_didInitialFullscreen]）；仅桌面（移动端无全屏路由，[_pushNeutralizedVideoFullscreen]
+  /// 本就 no-op）。controls 首建帧才设 [_videoControlsContext]、可能晚于就绪帧，故 context
+  /// 未就绪时逐帧重试，带上限（失败/缺失态或超时放弃，杜绝死循环）。两条就绪路径
+  /// （快路径直接翻真 / 慢路径 [_promoteVideoReady]）都调它，一次性闸门去重。
+  void _scheduleInitialFullscreenIfNeeded() {
+    if (_didInitialFullscreen) return;
+    if (!widget.initialFullscreen || isMobilePlatform) {
+      _didInitialFullscreen = true;
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_didInitialFullscreen || !mounted) return;
+      // 失败/缺失态 controls 永不建 → context 永为 null；超时兜底防逐帧死循环。
+      if (_failed || _missingResource || _initialFullscreenRetries > 30) {
+        _didInitialFullscreen = true;
+        return;
+      }
+      final BuildContext? ctx = _videoControlsContext;
+      if (ctx == null || !ctx.mounted) {
+        _initialFullscreenRetries++;
+        _scheduleInitialFullscreenIfNeeded();
+        return;
+      }
+      _didInitialFullscreen = true;
+      if (!isFullscreen(ctx)) unawaited(_pushNeutralizedVideoFullscreen(ctx));
+    });
+  }
+
   Future<void> _pushNeutralizedVideoFullscreen(BuildContext context) async {
     if (_videoFullscreenTransitioning || isFullscreen(context)) return;
     if (!context.mounted) return;

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -333,6 +333,7 @@ class VideoHibikiPage extends ConsumerStatefulWidget {
     this.initialCueStartMs,
     this.initialEpisodeIndex,
     this.initialSubtitleListVisible = false,
+    this.initialFullscreen = false,
     super.key,
   })  : remoteInfo = null,
         remoteClient = null;
@@ -348,6 +349,7 @@ class VideoHibikiPage extends ConsumerStatefulWidget {
   })  : bookUid = info.id,
         remoteInfo = info,
         remoteClient = client,
+        initialFullscreen = false,
         playlistCollectionId = null;
 
   final String bookUid;
@@ -362,6 +364,11 @@ class VideoHibikiPage extends ConsumerStatefulWidget {
   final int? initialCueStartMs;
   final int? initialEpisodeIndex;
   final bool initialSubtitleListVisible;
+
+  /// BUG-839：作为「从全屏页连播/换集而来」的新页打开——首帧就绪后自动重进全屏路由，
+  /// 保持连播全屏沉浸不被换集打断。仅本地 pushReplacement 换集在换集前处于全屏时置真
+  /// （见 [_VideoEpisode._switchEpisode]）；首开 / 远端恒 false。
+  final bool initialFullscreen;
 
   /// 打开视频播放页的**唯一入口**：在路由层用 [HibikiAppUiScaleNeutralizer] 把整页中和
   /// （与阅读器 [ReaderHibikiSource.buildLaunchPage] 同范式）。
@@ -378,6 +385,7 @@ class VideoHibikiPage extends ConsumerStatefulWidget {
     int? initialCueStartMs,
     int? initialEpisodeIndex,
     bool initialSubtitleListVisible = false,
+    bool initialFullscreen = false,
   }) =>
       HibikiAppUiScaleNeutralizer(
         child: VideoHibikiPage(
@@ -387,6 +395,7 @@ class VideoHibikiPage extends ConsumerStatefulWidget {
           initialCueStartMs: initialCueStartMs,
           initialEpisodeIndex: initialEpisodeIndex,
           initialSubtitleListVisible: initialSubtitleListVisible,
+          initialFullscreen: initialFullscreen,
         ),
       );
 
@@ -1174,6 +1183,13 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// 对话框/遮罩压住（`isCurrent`），避免切窗返回时抢走全屏内对话框的焦点。
   PageRoute<void>? _videoFullscreenRoute;
 
+  /// BUG-839：`initialFullscreen` 新页「首帧就绪后重进全屏」的一次性闸门 + 有界重试计数。
+  /// controls 首建帧（设 [_videoControlsContext]）可能晚于就绪帧，故就绪后逐帧重试到
+  /// context 可用再进全屏；失败/缺失态或超过上限则放弃，避免死循环（见
+  /// [_scheduleInitialFullscreenIfNeeded]）。
+  bool _didInitialFullscreen = false;
+  int _initialFullscreenRetries = 0;
+
   /// 观看统计采集器（观看时长 + 字幕字数 + 完成标记）；首次 load 建，dispose 释放。
   VideoWatchTracker? _watchTracker;
 
@@ -1641,6 +1657,8 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     _controller?.removeListener(_promoteVideoReadyOnFirstFrame);
     if (!mounted) return;
     setState(() => _videoReadyToShow = true);
+    // BUG-839：慢路径就绪后触发「换集保持全屏」的重进全屏（仅 initialFullscreen 新页生效）。
+    _scheduleInitialFullscreenIfNeeded();
   }
 
   Future<void> _init() async {
@@ -2536,6 +2554,11 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
         _videoReadyToShow = controller.isReadyForFirstPaint;
       }
     });
+    // BUG-839：快路径（本地文件 load 即出画）就绪后触发「换集保持全屏」的重进全屏
+    // （仅 initialFullscreen 新页生效；慢路径由 [_promoteVideoReady] 触发）。
+    if (isInitialVideoOpen && _videoReadyToShow) {
+      _scheduleInitialFullscreenIfNeeded();
+    }
     if (isInitialVideoOpen && !_videoReadyToShow) {
       // load() 已返回但首帧尚未解码出画：进入「准备」阶段，页级加载态保持到首帧
       // 就绪，而非立刻把画面让给 media_kit 触发第二个缓冲圈（TODO-1276）。

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+786
+version: 1.2.0+787
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/video_fullscreen_switch_flatten_guard_test.dart
+++ b/hibiki/test/pages/video_fullscreen_switch_flatten_guard_test.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-839 守卫：全屏下连播/换集不得漏栈旧集页（否则 ESC 需逐层退）。
+///
+/// 根因：全屏播放时 app 全屏路由被推到 **root navigator**（`fullscreen.part.dart` 的
+/// `_pushNeutralizedVideoFullscreen`，`rootNavigator: true`），压在剧集页之上。本地换集
+/// 走 `navigator.pushReplacement`——它替换的是该 navigator 的**栈顶路由**。若换集前不先退
+/// 全屏路由，`pushReplacement` 会替换掉栈顶的全屏路由、把本集页漏在栈里，每连播一集残留
+/// 一层 → 按 ESC 一层层回退而非退出。
+///
+/// 修复不变量：
+/// ① `_switchEpisode` 本地分支在 `pushReplacement` **之前**先 `_exitVideoFullscreen`
+///    退全屏路由，让剧集页回到栈顶，pushReplacement 正确替换本集（栈恒平、ESC 一次退出）；
+///    并把换集前是否全屏（`wasFullscreen`）透传给新页 `initialFullscreen`。
+/// ② `VideoHibikiPage` / `neutralized` 承载 `initialFullscreen` 字段；新页首帧就绪后经
+///    `_scheduleInitialFullscreenIfNeeded` 重进全屏（快/慢两条就绪路径都触发），保持连播
+///    全屏沉浸。
+///
+/// 撤掉任一环（去掉换集前退全屏、把 exit 挪到 push 之后、断开 initialFullscreen 透传/重进）
+/// 即转红。行为级复现需 media_kit + 全屏路由 + 真 navigator 栈，故守在最强可落地的源码层。
+void main() {
+  final File episodePart =
+      File('lib/src/pages/implementations/video_hibiki/episode.part.dart');
+  final File fullscreenPart =
+      File('lib/src/pages/implementations/video_hibiki/fullscreen.part.dart');
+  final File pageFile =
+      File('lib/src/pages/implementations/video_hibiki_page.dart');
+
+  late String switchBody;
+  late String fullscreenSrc;
+  late String pageSrc;
+
+  setUpAll(() {
+    for (final File f in <File>[episodePart, fullscreenPart, pageFile]) {
+      expect(f.existsSync(), isTrue, reason: '缺文件 ${f.path}');
+    }
+    final String episodeSrc =
+        episodePart.readAsStringSync().replaceAll('\r\n', '\n');
+    final int start = episodeSrc.indexOf('Future<void> _switchEpisode(');
+    expect(start, isNonNegative, reason: '找不到 _switchEpisode 方法');
+    // 方法体终点锚：下一个 `\n  /// ` 文档注释（_showEpisodeList 前）。
+    final int end = episodeSrc.indexOf('\n  /// ', start);
+    expect(end, greaterThan(start), reason: '找不到 _switchEpisode 方法体终点');
+    switchBody = episodeSrc.substring(start, end);
+
+    fullscreenSrc = fullscreenPart.readAsStringSync().replaceAll('\r\n', '\n');
+    pageSrc = pageFile.readAsStringSync().replaceAll('\r\n', '\n');
+  });
+
+  test('换集本地分支：pushReplacement 前先退全屏路由', () {
+    final int exitIdx = switchBody.indexOf('_exitVideoFullscreen(');
+    final int pushIdx = switchBody.indexOf('navigator.pushReplacement');
+    expect(pushIdx, isNonNegative, reason: '本地换集应走 pushReplacement');
+    expect(exitIdx, isNonNegative,
+        reason: '换集前必须先 _exitVideoFullscreen 退全屏路由（BUG-839）');
+    expect(exitIdx, lessThan(pushIdx),
+        reason: '退全屏必须在 pushReplacement 之前，否则会误替换栈顶全屏路由、漏栈旧集页');
+  });
+
+  test('退全屏只作用于本地分支（在远端早退之后）', () {
+    final int remoteReturnIdx =
+        switchBody.indexOf('_loadRemoteEpisode(index, startIntent: intent)');
+    final int exitIdx = switchBody.indexOf('_exitVideoFullscreen(');
+    expect(remoteReturnIdx, isNonNegative, reason: '远端分支应走 _loadRemoteEpisode');
+    expect(exitIdx, greaterThan(remoteReturnIdx),
+        reason: '退全屏必须在远端早退之后，只作用于本地换集分支（远端原地换流不压栈）');
+  });
+
+  test('换集把换集前全屏态透传给新页 initialFullscreen', () {
+    expect(switchBody.contains('wasFullscreen'), isTrue,
+        reason: '换集应捕获换集前是否全屏（wasFullscreen）');
+    expect(switchBody.contains('initialFullscreen: wasFullscreen'), isTrue,
+        reason: '新页 neutralized 必须收到 initialFullscreen: wasFullscreen，才能重进全屏');
+  });
+
+  test('VideoHibikiPage / neutralized 承载 initialFullscreen 字段并透传', () {
+    expect(pageSrc.contains('final bool initialFullscreen;'), isTrue,
+        reason: 'VideoHibikiPage 应有 initialFullscreen 字段');
+    expect(pageSrc.contains('this.initialFullscreen = false'), isTrue,
+        reason: '默认构造器应默认 initialFullscreen=false（首开不自动全屏）');
+    // neutralized 工厂必须把入参透传给构造器，否则换集标志到不了新页 State。
+    expect(pageSrc.contains('bool initialFullscreen = false'), isTrue,
+        reason: 'neutralized 工厂应有 initialFullscreen 形参');
+    expect(pageSrc.contains('initialFullscreen: initialFullscreen'), isTrue,
+        reason: 'neutralized 必须把 initialFullscreen 透传给 VideoHibikiPage');
+  });
+
+  test('新页首帧就绪的两条路径都触发重进全屏', () {
+    // 慢路径 [_promoteVideoReady] 与快路径（isInitialVideoOpen 直接翻真）都必须调
+    // _scheduleInitialFullscreenIfNeeded，否则本地文件（快路径）换集不会重进全屏。
+    final int scheduleCalls =
+        '_scheduleInitialFullscreenIfNeeded()'.allMatches(pageSrc).length;
+    expect(scheduleCalls, greaterThanOrEqualTo(2),
+        reason: '快/慢两条就绪路径都要触发重进全屏（至少 2 处调用）');
+  });
+
+  test('重进全屏方法存在且一次性、带上限防死循环', () {
+    expect(fullscreenSrc.contains('void _scheduleInitialFullscreenIfNeeded()'),
+        isTrue,
+        reason: '应在 fullscreen 域定义 _scheduleInitialFullscreenIfNeeded');
+    expect(fullscreenSrc.contains('_didInitialFullscreen'), isTrue,
+        reason: '重进全屏必须一次性（_didInitialFullscreen 闸门）');
+    expect(fullscreenSrc.contains('_initialFullscreenRetries'), isTrue,
+        reason: 'controls 未就绪时的重试必须有上限（_initialFullscreenRetries），杜绝死循环');
+    expect(fullscreenSrc.contains('_pushNeutralizedVideoFullscreen('), isTrue,
+        reason: '就绪后应经 _pushNeutralizedVideoFullscreen 重进全屏路由');
+  });
+}


### PR DESCRIPTION
## 现象
全屏播放本地视频，连播下一集后按 ESC 回到上一集而非退出；连播 N 集要按 N 次 ESC。**仅桌面全屏下复现**，窗口模式正常。

## 根因
全屏播放时 app 全屏路由被推到 **root navigator**（`fullscreen.part.dart` `_pushNeutralizedVideoFullscreen`，`rootNavigator: true`），压在剧集页之上。本地换集 `_switchEpisode`（`episode.part.dart`）走 `navigator.pushReplacement`——它替换的是该 navigator 的**栈顶路由**。换集前不先退全屏，`pushReplacement` 就替换掉栈顶的全屏路由、把本集页漏在栈里，每连播一集残留一层 → ESC（`_handleBackOrExit` 只 pop 一层）逐层回退。

引入提交 `07a1f9dee`（Phase 3 pushReplacement 低风险架构）未覆盖「全屏时栈顶不是剧集页」。

## 修复
- `_switchEpisode` 本地分支 `pushReplacement` 前，若在全屏路由先经既有汇聚点 `_exitVideoFullscreen` 退全屏，让剧集页回到栈顶 → `pushReplacement` 正确替换本集（栈恒平、ESC 一次退出）。
- 记 `wasFullscreen` 透传新页 `initialFullscreen`；新页首帧就绪（快/慢两条 ready 路径都触发）后经 `_scheduleInitialFullscreenIfNeeded` 重进全屏，**连播保持全屏沉浸**（一次性闸门 + 有界重试防死循环）。
- 窗口模式（`wasFullscreen=false`）与远端原地换流**零行为变化**。

## 测试
- 新守卫 `test/pages/video_fullscreen_switch_flatten_guard_test.dart`（6 例）：换集先退全屏再 push、只作用本地分支、`initialFullscreen` 透传、双 ready 路径触发重进、重进方法一次性带上限。
- `flutter analyze` 干净；相邻视频/全屏/换集守卫 43 例全绿。

## 待验证（铁律）
⚠️ 桌面真机复测：全屏连播 → **ESC 一次退出到书架** + **下一集仍全屏**。行为级自动化难覆盖（需 media_kit + 全屏路由 + 真 navigator 栈 + 连播倒计时），故守在源码层，端到端仍需真机确认。

BUG 详情：`docs/bugs/BUG-839-fullscreen-autoplay-esc-stack.md`