### PR TITLE
fix(video): 字幕列表去重特效叠加ASS + 双语底部对白跨层重叠 (BUG-839/840)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 820 条。点号进各自文件。
+> 共 822 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-840](bugs/BUG-840-bilingual-bottom-overlap.md) | ✅ | ✅ | 双语底部对白跨层/边距重叠 |
+| [BUG-839](bugs/BUG-839-subtitle-list-effect-dup.md) | ✅ | ✅ | 字幕列表特效叠加ASS未去重 |
 | [BUG-838](bugs/BUG-838-video-subtitle-lookup-seek-steal.md) | ✅ | ✅ | 视频字幕点字查词被进度条隐形热区抢成seek跳走 |
 | [BUG-837](bugs/BUG-837-video-fullscreen-desktop-lock.md) | ✅ | ✅ | 桌面视频全屏独占锁死桌面无法切到其他软件 |
 | [BUG-836](bugs/BUG-836-video-ultra-anime4k-ul-windows-black.md) | ✅ | ✅ | 视频画质增强极高档(Anime4K UL)在 Windows ANGLE 后端黑屏 |

--- a/docs/bugs/BUG-839-subtitle-list-effect-dup.md
+++ b/docs/bugs/BUG-839-subtitle-list-effect-dup.md
@@ -1,0 +1,6 @@
+## BUG-839 · 字幕列表特效叠加ASS未去重
+- **报告**：2026-07-15（用户：截图 1:40 处 `ZH / JP / JP / ZH` 四行重复）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/video/video_subtitle_jump_panel.dart:422`（`all` 档 `List.generate(cues.length)` 全量渲染，整条 cue 链路无去重）。特效叠加 / 多层 ASS 用多条 `Dialogue` 事件渲染同一句可见文本（不同 layer/style/位置做描边、辉光、逐字变色特效），`AssParser.parseString`（`packages/hibiki_audio/lib/src/parsers/ass_parser.dart:271`）逐条产 `AudioCue`、`VideoPlayerController.setCues`（`video_player_controller.dart:1014`）只 sort 不 dedup，列表遂一句话出多行。
+- **[x] ① 已修复** — `video_subtitle_jump_panel.dart` 新增 `_dedupedRawIndexes`（按 `(startMs, text)` 折叠重复、保留首条代表行 + 建 raw→代表映射），三档过滤与计数 chip 全走去重集；当前播放句落在被折叠重复项时经 `_representativeRaw` 把高亮/自动滚动定位到代表行。画面 overlay 不走此路径，特效各层仍全渲染。提交 `4d4be72e9`。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_list_effect_dedup_test.dart`：`ZH/JP/JP/ZH` 折叠成 2 行；代表行仍能 seek 到真实 cue；当前句落在重复项时代表行不脱靶。
+- **备注**：双语（同时间不同文本）文本不同不折叠，日/中各占一行——与画面 overlay 的双语重叠是**另一个** bug（[[BUG-840]]，overlay 跨组避让）。

--- a/docs/bugs/BUG-840-bilingual-bottom-overlap.md
+++ b/docs/bugs/BUG-840-bilingual-bottom-overlap.md
@@ -1,0 +1,6 @@
+## BUG-840 · 双语底部对白跨层/边距重叠
+- **报告**：2026-07-15（用户：截图画面底部日文「クローゼットに押し込んだだけ…」与中文「不就是一股脑塞进衣柜里吗」糊在同一条基线）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/video/video_subtitle_overlay.dart` 的 `_positionKey`（`:L$layer` 后缀 + `:$ml:$mr`）把双语两条底部对白（日文一层 + 中文一层、或 MarginL/R 各异）拆成不同 `_positionKey` 组，各组独立 `Positioned.fill` 定位、又都被 `_paddingFor` 的 `max(bottomPadding, scaledMarginV)` 夹回同一底基线 → 叠印。既有 `_positionKey` 的 MarginV 折叠只覆盖「同 layer/margin、仅 MarginV 异」的双语（[[project_ass_blur_border_and_group_flicker_bug796_797]] 的 marginv 守卫），跨 Layer / 跨 MarginL/R 落在缺口外——组间**无全局碰撞避让**。
+- **[x] ① 已修复** — `video_subtitle_overlay.dart` 新增 `_mergeBottomBaselineGroups`：把**文本两两互异**的底部基线折叠组（无 \pos/\move、竖直锚=底部、MarginV 会被夹回基线）按水平锚点分桶合并进一个竖排堆叠组（libass 同位不同文本竖排避让），键归一为不含 Layer/MarginL/R 的底部基线桶。桶内出现重复文本（同句多层拷贝=卡拉OK特效层）则整桶不合并，各层仍同位叠画（[[project_ass_blur_border_and_group_flicker_bug796_797]] BUG-833 不回归）。提交 `4d4be72e9`。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_bilingual_cross_layer_overlap_test.dart`：跨 Layer（JP layer0 + CH layer1）竖排分行不叠印；跨 MarginL 竖排分行；同文本多层拷贝仍同位叠画一行。
+- **备注**：右侧字幕列表把双语显示成相邻两行是**正确**的（各占一行）；列表里同文本重复才折叠（[[BUG-839]]）。触发本 bug 的双语 `.ass` 用户已无留档，按「跨组底部避让 + 同文本不拆」的通用 libass 语义修，待真机 A/B 复测原始双语文件。

--- a/hibiki/lib/src/media/video/video_subtitle_jump_panel.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_jump_panel.dart
@@ -133,6 +133,18 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
   VideoSubtitleListFilter? _cachedFilter;
   List<int> _cachedVisibleIndexes = const <int>[];
   Map<int, int> _cachedVisibleIndexByRawIndex = const <int, int>{};
+
+  /// BUG-839：特效叠加 / 多层 ASS 用多条 Dialogue 事件渲染**同一句可见文本**（不同
+  /// layer / style / 位置做描边、辉光、逐字变色等特效），画面 overlay 有意全渲染各层
+  /// （TODO-1312），但字幕列表按 `(startMs, 文本)` 折叠这些重复，只保留首条**代表行**，
+  /// 一句话不再在列表里出现多行。双语（同时间、文本不同）文本不同不折叠，日/中各占一行。
+  /// [_cachedDedupIndexes] 是代表行的 raw 下标（升序，`setCues` 已排序）；
+  /// [_cachedRepresentativeByRaw] 把**每个** raw 下标（含被折叠的重复）映射到其代表行的
+  /// raw 下标，供当前播放句落在重复项时把高亮 / 自动滚动定位到那唯一渲染的代表行。
+  List<AudioCue>? _cachedDedupCues;
+  int _cachedDedupCuesLength = -1;
+  List<int> _cachedDedupIndexes = const <int>[];
+  Map<int, int> _cachedRepresentativeByRaw = const <int, int>{};
   List<AudioCue>? _cachedSelectedCues;
   int _cachedSelectedCuesLength = -1;
   int _cachedSelectedCount = 0;
@@ -212,7 +224,10 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
     super.initState();
     _lastControllerCueIndex = widget.controller.currentCueIndex;
     _lastSubtitleCuesLoading = widget.controller.isSubtitleCuesLoading;
-    final int initialRawIndex = widget.controller.currentCueIndex;
+    // BUG-839：当前句可能落在被折叠的重复项上——追踪其**代表行** raw（列表渲染的唯一行），
+    // 否则高亮 / 滚动定位不到（rowKey 按代表行 raw 挂）。
+    final int initialRawIndex =
+        _representativeRaw(widget.controller.currentCueIndex);
     _scrollTargetRawIndex =
         _isCurrentCueVisible(initialRawIndex) ? initialRawIndex : null;
     _retainRowKeyFor(_scrollTargetRawIndex);
@@ -232,10 +247,10 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
       _lastControllerCueIndex = widget.controller.currentCueIndex;
       _lastSubtitleCuesLoading = widget.controller.isSubtitleCuesLoading;
       _lastScrolledIndex = -1;
+      final int currentRep =
+          _representativeRaw(widget.controller.currentCueIndex);
       _scrollTargetRawIndex =
-          _isCurrentCueVisible(widget.controller.currentCueIndex)
-              ? widget.controller.currentCueIndex
-              : null;
+          _isCurrentCueVisible(currentRep) ? currentRep : null;
       _rowKeys.clear();
       _retainRowKeyFor(_scrollTargetRawIndex);
       _scheduleScrollToCurrentCue();
@@ -260,7 +275,9 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
     _lastControllerCueIndex = currentIndex;
     _lastSubtitleCuesLoading = cuesLoading;
     setState(() {
-      _scrollTargetRawIndex = currentIndex >= 0 ? currentIndex : null;
+      // BUG-839：追踪代表行 raw（当前句可能是被折叠的重复项）。
+      _scrollTargetRawIndex =
+          currentIndex >= 0 ? _representativeRaw(currentIndex) : null;
       _retainRowKeyFor(_scrollTargetRawIndex);
     });
     if (cueChanged) _scheduleScrollToCurrentCue();
@@ -278,10 +295,12 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
 
   void _scrollToCurrentCueIfNeeded() {
     if (!_autoScroll) return;
-    final int currentIndex = widget.controller.currentCueIndex;
+    final int rawIndex = widget.controller.currentCueIndex;
     final List<AudioCue> cues = widget.controller.cues;
-    if (currentIndex < 0 || currentIndex >= cues.length) return;
+    if (rawIndex < 0 || rawIndex >= cues.length) return;
     final List<int> visibleIndexes = _visibleCueIndexes(cues);
+    // BUG-839：当前句若是被折叠的重复项，定位到其代表行（列表渲染的唯一行、rowKey 所在）。
+    final int currentIndex = _representativeRaw(rawIndex);
     final int visibleIndex =
         _visibleIndexForRawIndex(currentIndex, visibleIndexes);
     if (visibleIndex < 0 || visibleIndex == _lastScrolledIndex) return;
@@ -378,9 +397,10 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
         _cachedSelectedCuesLength == cues.length) {
       return _cachedSelectedCount;
     }
+    // BUG-839：只数去重后的代表行，与 selected 档实际渲染的行一一对应。
     int count = 0;
-    for (final AudioCue cue in cues) {
-      if (_isCueSelectedForCard(cue)) count++;
+    for (final int i in _dedupedRawIndexes(cues)) {
+      if (_isCueSelectedForCard(cues[i])) count++;
     }
     _cachedSelectedCues = cues;
     _cachedSelectedCuesLength = cues.length;
@@ -393,11 +413,51 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
   /// 谓词，故数量与列表完全一致。这是已删的「本集收藏」面板顶部计数 header 的归宿：收藏
   /// 统计并入字幕列表收藏档。
   int _favoriteCueCount(List<AudioCue> cues) {
+    // BUG-839：只数去重后的代表行，与 favorites 档实际渲染的行一一对应。
     int count = 0;
-    for (final AudioCue cue in cues) {
-      if (widget.isCueFavorited(cue)) count++;
+    for (final int i in _dedupedRawIndexes(cues)) {
+      if (widget.isCueFavorited(cues[i])) count++;
     }
     return count;
+  }
+
+  /// BUG-839：按 `(startMs, 文本)` 折叠重复 cue，返回代表行 raw 下标（升序）并同步
+  /// 刷新 [_cachedRepresentativeByRaw]（每个 raw → 其代表行 raw）。按 cues 身份 + 长度
+  /// 记忆化（`setCues` 换列表即失效；[_clearCueCaches] 亦清）。特效叠加 / 多层同句拷贝
+  /// 同 start 同文本 → 折叠成一行；双语文本不同 → 各自保留。
+  List<int> _dedupedRawIndexes(List<AudioCue> cues) {
+    if (identical(_cachedDedupCues, cues) &&
+        _cachedDedupCuesLength == cues.length) {
+      return _cachedDedupIndexes;
+    }
+    final List<int> reps = <int>[];
+    final Map<String, int> firstByKey = <String, int>{};
+    final Map<int, int> repByRaw = <int, int>{};
+    for (int i = 0; i < cues.length; i++) {
+      final AudioCue cue = cues[i];
+      final String key = '${cue.startMs} ${cue.text}';
+      final int? rep = firstByKey[key];
+      if (rep == null) {
+        firstByKey[key] = i;
+        repByRaw[i] = i;
+        reps.add(i);
+      } else {
+        repByRaw[i] = rep;
+      }
+    }
+    _cachedDedupCues = cues;
+    _cachedDedupCuesLength = cues.length;
+    _cachedDedupIndexes = reps;
+    _cachedRepresentativeByRaw = repByRaw;
+    return reps;
+  }
+
+  /// 把任意 raw 下标（可能是被折叠的重复项）映射到其代表行 raw 下标（BUG-839）。当前
+  /// 播放句落在重复拷贝上时，用它把高亮 / 自动滚动定位到唯一渲染的代表行。
+  int _representativeRaw(int rawIndex) {
+    if (rawIndex < 0) return rawIndex;
+    _dedupedRawIndexes(widget.controller.cues);
+    return _cachedRepresentativeByRaw[rawIndex] ?? rawIndex;
   }
 
   List<int> _visibleCueIndexes(List<AudioCue> cues) {
@@ -417,21 +477,24 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
         _cachedFilter == _filter) {
       return _cachedVisibleIndexes;
     }
+    // BUG-839：三档都以**去重后**的代表行为基（特效叠加同句拷贝只出一行）；收藏 / 已选
+    // 再在代表行上过滤，计数 chip 走同一去重集合（[_favoriteCueCount] / [_selectedCueCount]）
+    // 故数量与列表一致。
+    final List<int> base = _dedupedRawIndexes(cues);
     late final List<int> indexes;
     switch (_filter) {
       case VideoSubtitleListFilter.all:
-        indexes =
-            List<int>.generate(cues.length, (int i) => i, growable: false);
+        indexes = base;
         break;
       case VideoSubtitleListFilter.favorites:
         indexes = <int>[
-          for (int i = 0; i < cues.length; i++)
+          for (final int i in base)
             if (widget.isCueFavorited(cues[i])) i,
         ];
         break;
       case VideoSubtitleListFilter.selected:
         indexes = <int>[
-          for (int i = 0; i < cues.length; i++)
+          for (final int i in base)
             if (_isCueSelectedForCard(cues[i])) i,
         ];
         break;
@@ -451,10 +514,10 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
   }
 
   int _visibleIndexForRawIndex(int rawIndex, List<int> visibleIndexes) {
-    if (_filter == VideoSubtitleListFilter.all) {
-      return rawIndex >= 0 && rawIndex < visibleIndexes.length ? rawIndex : -1;
-    }
-    return _cachedVisibleIndexByRawIndex[rawIndex] ?? -1;
+    // BUG-839：去重后 `all` 档不再是恒等映射（重复项被折叠、raw 下标有跳空），三档统一走
+    // raw→代表行→可见位置映射；当前句落在被折叠的重复项时，定位到其代表行。
+    final int rep = _cachedRepresentativeByRaw[rawIndex] ?? rawIndex;
+    return _cachedVisibleIndexByRawIndex[rep] ?? -1;
   }
 
   bool _isCurrentCueVisible(int rawIndex) {
@@ -491,6 +554,10 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
     _cachedSelectedCues = null;
     _cachedSelectedCuesLength = -1;
     _cachedSelectedCount = 0;
+    _cachedDedupCues = null;
+    _cachedDedupCuesLength = -1;
+    _cachedDedupIndexes = const <int>[];
+    _cachedRepresentativeByRaw = const <int, int>{};
   }
 
   void _retainRowKeyFor(int? rawIndex) {
@@ -513,7 +580,10 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
     final ColorScheme cs = widget.colorScheme;
     final List<AudioCue> cues = widget.controller.cues;
     final List<int> visibleIndexes = _visibleCueIndexes(cues);
-    final int currentIndex = widget.controller.currentCueIndex;
+    // BUG-839：当前句可能是被折叠的重复项——映射到其代表行 raw（列表渲染的唯一行）供高亮
+    // 与 rowKey 保留，否则当前句落在重复拷贝时整行都不高亮。
+    final int currentIndex =
+        _representativeRaw(widget.controller.currentCueIndex);
     _retainRowKeyFor(currentIndex >= 0 ? currentIndex : _scrollTargetRawIndex);
     final bool showLoading =
         cues.isEmpty && widget.controller.isSubtitleCuesLoading;

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -676,6 +676,14 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
         order.add((key, group));
       }
     }
+    // BUG-840：跨组底部碰撞避让。`_positionKey` 把底部基线折叠组（渲染在同一
+    // `max(bottomPadding, ...)` 基线）还按 Layer / MarginL/R 拆成多组时，双语对白（日文一
+    // 层 + 中文一层、或水平边距各异）会各自成组、又都锚到同一底基线 → 叠印糊字。libass 语义：
+    // 同位不同文本的底部事件竖排避让、不叠印。修复：把**文本两两互异**的底部基线折叠组合并进
+    // 一个堆叠组（竖排分行）；同文本的多层拷贝（卡拉OK特效层，BUG-833，通常 \pos / 顶部锚点，
+    // 不落底部基线桶）不合并，仍各自成组同位叠画出特效。
+    final List<(String, List<AudioCue>)> grouped =
+        _mergeBottomBaselineGroups(order);
     // 组内按 MarginV 升序稳定排序：折进同一基线桶的底部双语（JP MarginV=4 + CH MarginV=30）
     // 竖排堆叠时，MarginV 小的贴锚点（底部锚组 slot0 在底）、大的在上，复现 libass「MarginV
     // 越大离底越远」的相对次序，不再依赖字幕文件里 JP/CH 的书写先后（本 BUG 的次序保证）。
@@ -686,7 +694,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
       return (mv == null || mv <= 0) ? 0 : mv;
     }
 
-    for (final (String, List<AudioCue>) entry in order) {
+    for (final (String, List<AudioCue>) entry in grouped) {
       final List<AudioCue> group = entry.$2;
       if (group.length < 2) continue;
       // 稳定排序（List.sort 非稳定）：以原始下标做 tie-break，保证同 MarginV 保持发现次序。
@@ -696,7 +704,87 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
         return c != 0 ? c : byIndex.indexOf(a).compareTo(byIndex.indexOf(b));
       });
     }
-    return order;
+    return grouped;
+  }
+
+  /// BUG-840：把**文本两两互异**的底部基线折叠组合并进一个堆叠组（跨组底部碰撞避让）。
+  ///
+  /// 「底部基线折叠」= 无 \pos / \move、竖直锚点=底部、且 MarginV 会被 [_paddingFor] 的
+  /// `max(bottomPadding, scaledMarginV)` 夹回同一底基线（MarginV 空 / <=0 / <= bottomPadding）。
+  /// 这些组全部渲染在同一 y——双语对白（日文层 + 中文层、或 MarginL/R 各异）被
+  /// [_positionKey] 按 Layer / 水平边距拆成多组时会叠印糊字。按**水平锚点**分桶（左/中/右对齐
+  /// 各成一栏，不横向混排），桶内若全部文本互异（双语 / 多行不同翻译）→ 合并成一个竖排堆叠组，
+  /// 键归一为不含 Layer / MarginL/R 的底部基线桶（跨帧稳定，[_syncGroupSlots] 槽位身份不漂移）。
+  /// 桶内出现重复文本（同句多层拷贝=卡拉OK特效层，应同位叠画不拆行）则整桶不合并，保持
+  /// [_positionKey] 原分组（各层同位叠画，BUG-833 不回归）。非底部 / 带显式位置的组原样保留。
+  List<(String, List<AudioCue>)> _mergeBottomBaselineGroups(
+    List<(String, List<AudioCue>)> order,
+  ) {
+    bool isBottomBaselineFolded(AudioCue cue) {
+      final SubtitleMarkup? m = cue.markup;
+      if (m == null) return true; // 纯 SRT / 无 markup：底部居中、无 MarginV → 折叠
+      if (m.posFraction != null) return false;
+      if (widget.respectAssStyle && m.move != null) return false;
+      final SubtitleVAlign v = m.anchor?.vertical ?? SubtitleVAlign.bottom;
+      if (v != SubtitleVAlign.bottom) return false;
+      final double? mv = m.cueStyle?.marginV;
+      if (mv == null || mv <= 0) return true;
+      return mv <= widget.bottomPadding;
+    }
+
+    // 按水平锚点分桶收集底部基线折叠组的 order 下标（组内 cue 同键、同折叠态，取代表判断）。
+    final Map<int, List<int>> bucketsByAh = <int, List<int>>{};
+    for (int i = 0; i < order.length; i++) {
+      final AudioCue rep = order[i].$2.first;
+      if (!isBottomBaselineFolded(rep)) continue;
+      final int ah =
+          (rep.markup?.anchor?.horizontal ?? SubtitleHAlign.center).index;
+      (bucketsByAh[ah] ??= <int>[]).add(i);
+    }
+
+    // 需合并的桶：>=2 组且桶内文本两两互异。keepInto[drop]=keep（首组），mergedCues[keep]=并集。
+    final Map<int, int> dropInto = <int, int>{};
+    final Map<int, List<AudioCue>> mergedCues = <int, List<AudioCue>>{};
+    final Map<int, int> mergedAh = <int, int>{};
+    bucketsByAh.forEach((int ah, List<int> idxs) {
+      if (idxs.length < 2) return;
+      final Set<String> seen = <String>{};
+      bool distinct = true;
+      for (final int i in idxs) {
+        for (final AudioCue cue in order[i].$2) {
+          if (!seen.add(cue.text)) {
+            distinct = false;
+            break;
+          }
+        }
+        if (!distinct) break;
+      }
+      if (!distinct) return;
+      final int keep = idxs.first;
+      final List<AudioCue> union = <AudioCue>[];
+      for (final int i in idxs) {
+        union.addAll(order[i].$2);
+        if (i != keep) dropInto[i] = keep;
+      }
+      mergedCues[keep] = union;
+      mergedAh[keep] = ah;
+    });
+    if (dropInto.isEmpty) return order;
+
+    // 重建 order：keep 位置换成合并组（键归一），drop 位置跳过，其余原样、保持发现顺序。
+    final List<(String, List<AudioCue>)> out = <(String, List<AudioCue>)>[];
+    for (int i = 0; i < order.length; i++) {
+      if (dropInto.containsKey(i)) continue;
+      final List<AudioCue>? union = mergedCues[i];
+      if (union != null) {
+        final String key =
+            'a:${SubtitleVAlign.bottom.index}:${mergedAh[i]}:-1:-1:-1';
+        out.add((key, union));
+      } else {
+        out.add(order[i]);
+      }
+    }
+    return out;
   }
 
   /// 一条 cue 的「有效定位」分组键（TODO-1341）：有 \pos 时按分数（+ 锚点），否则按锚点

--- a/hibiki/test/media/video/video_subtitle_bilingual_cross_layer_overlap_test.dart
+++ b/hibiki/test/media/video/video_subtitle_bilingual_cross_layer_overlap_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_player_controller.dart';
+import 'package:hibiki/src/media/video/video_subtitle_overlay.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+/// BUG-840 守卫：双语底部对白（日文 + 中文，同为底部锚点、时间重叠，但 `_positionKey` 因
+/// **ASS Layer 不同**或 **MarginL/R 不同**把两条拆成两组）不得叠印糊字。libass 语义：同位
+/// 不同文本的底部事件竖排避让；同文本的多层拷贝（卡拉OK特效层）才同位叠画。
+///
+/// 修复前：JP layer0 + CH layer1（都 \an2 底部、MarginV 小）→ 两组各自定位却落在同一
+/// `max(bottomPadding, ...)` 基线 → 叠印。修复：文本互异的底部基线折叠组合并成一个堆叠组
+/// （竖排分行）；同文本的仍分组同位叠画。
+AudioCue _bottomCue(
+  String text, {
+  double marginV = 0,
+  double marginL = 0,
+  int layer = 0,
+  required double fontSizePx,
+}) {
+  final SubtitleCueStyle style = SubtitleCueStyle(
+    fontSizePx: fontSizePx,
+    primaryColorArgb: 0xFFFFFFFF,
+    anchor: const SubtitleAnchor(SubtitleVAlign.bottom, SubtitleHAlign.center),
+    marginV: marginV,
+    marginL: marginL,
+  );
+  return AudioCue()
+    ..bookKey = 'b'
+    ..chapterHref = 'c'
+    ..sentenceIndex = 0
+    ..textFragmentId = ''
+    ..text = text
+    ..markup = SubtitleMarkup(
+      plainText: text,
+      spans: const <SubtitleSpan>[],
+      anchor:
+          const SubtitleAnchor(SubtitleVAlign.bottom, SubtitleHAlign.center),
+      cueStyle: style,
+      playResY: 720, // 显示区 720 / PlayResY 720 → 缩放 1.0。
+      layer: layer,
+    )
+    ..startMs = 0
+    ..endMs = 5000;
+}
+
+Rect _fillRect(WidgetTester tester, String ch) {
+  final Finder fill = find.byWidgetPredicate(
+      (Widget w) => w is Text && w.data == ch && w.style?.foreground == null);
+  return tester.getRect(fill.first);
+}
+
+Set<String> _fillTops(WidgetTester tester, String ch) {
+  final Finder fill = find.byWidgetPredicate(
+      (Widget w) => w is Text && w.data == ch && w.style?.foreground == null);
+  return <String>{
+    for (final Element e in fill.evaluate())
+      tester
+          .getRect(find.byElementPredicate((Element x) => x == e))
+          .top
+          .toStringAsFixed(1),
+  };
+}
+
+Future<void> _pumpOverlay(WidgetTester tester, VideoPlayerController c) async {
+  tester.view.physicalSize = const Size(1280, 720);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 1280,
+        height: 720,
+        child: VideoSubtitleOverlay(controller: c, respectAssStyle: true),
+      ),
+    ),
+  ));
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('双语底部对白跨 Layer（JP layer0 + CH layer1）竖排分行、不叠印',
+      (WidgetTester tester) async {
+    final VideoPlayerController c = VideoPlayerController();
+    addTearDown(c.dispose);
+    // 日文贴底一层、中文另一层，都 \an2、MarginV 小（都 < bottomPadding=75）。
+    final AudioCue jp = _bottomCue('日', marginV: 4, layer: 0, fontSizePx: 35);
+    final AudioCue ch = _bottomCue('中', marginV: 4, layer: 1, fontSizePx: 35);
+    c.setCues(<AudioCue>[jp, ch]);
+    c.debugUpdateCueForPosition(1000);
+    expect(c.activeCues.length, 2);
+
+    await _pumpOverlay(tester, c);
+
+    final Rect jpRect = _fillRect(tester, '日');
+    final Rect chRect = _fillRect(tester, '中');
+    // 两条竖直不重叠（修复前跨 Layer 拆组、共基线叠印）。
+    expect(chRect.bottom, lessThanOrEqualTo(jpRect.top + 0.5),
+        reason: '中(上) 底缘应在 日(下) 顶缘之上，两条分离不叠印');
+  });
+
+  testWidgets('双语底部对白跨 MarginL（水平边距不同、同为中心锚）竖排分行、不叠印',
+      (WidgetTester tester) async {
+    final VideoPlayerController c = VideoPlayerController();
+    addTearDown(c.dispose);
+    final AudioCue jp = _bottomCue('日', marginV: 4, marginL: 0, fontSizePx: 35);
+    final AudioCue ch =
+        _bottomCue('中', marginV: 4, marginL: 40, fontSizePx: 35);
+    c.setCues(<AudioCue>[jp, ch]);
+    c.debugUpdateCueForPosition(1000);
+    await _pumpOverlay(tester, c);
+
+    final Rect jpRect = _fillRect(tester, '日');
+    final Rect chRect = _fillRect(tester, '中');
+    expect(chRect.bottom, lessThanOrEqualTo(jpRect.top + 0.5),
+        reason: 'MarginL 各异的底部双语也应竖排避让');
+  });
+
+  testWidgets('同文本多层拷贝（卡拉OK特效层）在底部基线仍同位叠画、不被误拆成两行',
+      (WidgetTester tester) async {
+    final VideoPlayerController c = VideoPlayerController();
+    addTearDown(c.dispose);
+    // 同句 'め' 拆两层（光晕层 + 主文字层），都 \an2 底部——应同位叠画成一行特效。
+    final AudioCue glow = _bottomCue('め', marginV: 4, layer: 3, fontSizePx: 40);
+    final AudioCue main = _bottomCue('め', marginV: 4, layer: 4, fontSizePx: 40);
+    c.setCues(<AudioCue>[glow, main]);
+    c.debugUpdateCueForPosition(1000);
+    await _pumpOverlay(tester, c);
+
+    // 两份 'め' 拷贝必须同位叠画（同 top），不得因合并逻辑被竖排成两行。
+    expect(_fillTops(tester, 'め'), hasLength(1),
+        reason: '同文本的多层拷贝必须同位叠画成一行（BUG-833 不回归）');
+  });
+}

--- a/hibiki/test/media/video/video_subtitle_list_effect_dedup_test.dart
+++ b/hibiki/test/media/video/video_subtitle_list_effect_dedup_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hibiki/src/media/video/video_player_controller.dart';
+import 'package:hibiki/src/media/video/video_subtitle_jump_panel.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+/// BUG-839 守卫：特效叠加 / 多层 ASS 用多条 Dialogue 事件渲染**同一句可见文本**（不同
+/// layer / style / 位置做描边、辉光、逐字变色特效），字幕列表必须按 `(startMs, 文本)` 折叠
+/// 这些重复、一句话只出一行；双语（同时间不同文本）文本不同不折叠，各占一行。画面 overlay
+/// 仍全渲染各层特效（不走列表这条路径）。
+AudioCue _cue(int sentence, int startMs, String text) => AudioCue()
+  ..bookKey = 'video/1'
+  ..chapterHref = 'video://default'
+  ..sentenceIndex = sentence
+  ..textFragmentId = ''
+  ..text = text
+  ..startMs = startMs
+  ..endMs = startMs + 2000
+  ..audioFileIndex = 0;
+
+Widget _wrap(Widget child) => MaterialApp(
+      home: Scaffold(body: Stack(children: <Widget>[child])),
+    );
+
+int _rowCount(WidgetTester tester) =>
+    tester.widgetList<Text>(find.byType(Text)).where((Text w) {
+      final String? d = w.data;
+      return d == 'CH line' || d == 'JP line';
+    }).length;
+
+void main() {
+  testWidgets('特效叠加重复行（同 start 同文本 ×2）在列表里折叠成一行；双语文本不同各占一行',
+      (WidgetTester tester) async {
+    final VideoPlayerController controller = VideoPlayerController();
+    addTearDown(controller.dispose);
+    // 复现第一张图：1:40 处 ZH / JP / JP / ZH —— 每语言各被特效层复制一遍。
+    const int t = 100000; // 1:40
+    controller.setCues(<AudioCue>[
+      _cue(0, t, 'CH line'),
+      _cue(1, t, 'JP line'),
+      _cue(2, t, 'JP line'),
+      _cue(3, t, 'CH line'),
+    ]);
+
+    await tester.pumpWidget(_wrap(VideoSubtitleJumpPanel(
+      controller: controller,
+      onTapCue: (_) {},
+      onClose: () {},
+      onCopyCue: (_) {},
+      onFavoriteCue: (_) async {},
+      isCueFavorited: (_) => false,
+      colorScheme: const ColorScheme.dark(),
+      title: 'Subtitle list',
+      emptyHint: 'empty',
+    )));
+
+    // 各文本只渲染一行（折叠前是各 2 行）。
+    expect(find.text('CH line'), findsOneWidget);
+    expect(find.text('JP line'), findsOneWidget);
+    expect(_rowCount(tester), 2, reason: '4 条特效重复应折叠成 2 行');
+  });
+
+  testWidgets('点折叠后的代表行仍能 seek 到真实 cue', (WidgetTester tester) async {
+    final VideoPlayerController controller = VideoPlayerController();
+    addTearDown(controller.dispose);
+    const int t = 100000;
+    controller.setCues(<AudioCue>[
+      _cue(0, t, 'CH line'),
+      _cue(1, t, 'JP line'),
+      _cue(2, t, 'JP line'),
+      _cue(3, t, 'CH line'),
+    ]);
+    AudioCue? tapped;
+
+    await tester.pumpWidget(_wrap(VideoSubtitleJumpPanel(
+      controller: controller,
+      onTapCue: (AudioCue cue) => tapped = cue,
+      onClose: () {},
+      onCopyCue: (_) {},
+      onFavoriteCue: (_) async {},
+      isCueFavorited: (_) => false,
+      colorScheme: const ColorScheme.dark(),
+      title: 'Subtitle list',
+      emptyHint: 'empty',
+    )));
+
+    await tester.tap(find.text('JP line'));
+    await tester.pump();
+    expect(tapped, isNotNull);
+    expect(tapped!.text, 'JP line');
+    expect(tapped!.startMs, t);
+  });
+
+  testWidgets('当前播放句落在被折叠的重复项时，代表行仍高亮（不脱靶）', (WidgetTester tester) async {
+    final VideoPlayerController controller = VideoPlayerController();
+    addTearDown(controller.dispose);
+    const int t = 100000;
+    controller.setCues(<AudioCue>[
+      _cue(0, t, 'CH line'),
+      _cue(1, t, 'JP line'),
+      _cue(2, t, 'JP line'), // 重复：被折叠，raw=2
+      _cue(3, t, 'CH line'),
+    ]);
+    // 让当前句定位到重叠区（多条同刻活跃，currentCueIndex 可能取到重复项）。
+    controller.debugUpdateCueForPosition(t + 500);
+
+    await tester.pumpWidget(_wrap(VideoSubtitleJumpPanel(
+      controller: controller,
+      onTapCue: (_) {},
+      onClose: () {},
+      onCopyCue: (_) {},
+      onFavoriteCue: (_) async {},
+      isCueFavorited: (_) => false,
+      colorScheme: const ColorScheme.dark(),
+      title: 'Subtitle list',
+      emptyHint: 'empty',
+    )));
+    await tester.pump();
+
+    // 列表仍是 2 行、无异常（渲染不因当前句是重复项而崩）。
+    expect(_rowCount(tester), 2);
+    expect(find.text('CH line'), findsOneWidget);
+    expect(find.text('JP line'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
两个 ASS 字幕 bug（用户报，含截图）。

## BUG-839 · 字幕列表特效叠加未去重
特效/多层 ASS 用多条 `Dialogue` 事件渲染同一句可见文本（不同 layer/style/位置做描边、辉光、逐字变色），字幕列表遂一句话出多行（截图 1:40 处 `ZH/JP/JP/ZH`）。
- 根因：`video_subtitle_jump_panel.dart` `all` 档全量渲染 `cues`，整条 cue 链路无去重。
- 修复：列表按 `(startMs, 文本)` 折叠重复、只保留代表行；三档过滤+计数 chip 同源；当前句落在被折叠重复项时经 `_representativeRaw` 把高亮/自动滚动定位到代表行。**overlay 不走此路径**，特效各层仍全渲染。
- 双语（不同文本）不折叠，日/中各占一行。

## BUG-840 · 双语底部对白跨层/边距重叠
双语底部对白（日文层 + 中文层、或 MarginL/R 各异）被 `_positionKey` 按 Layer/边距拆成多组、又都被 `max(bottomPadding, ...)` 夹回同一底基线 → 叠印糊字（截图红箭头）。既有 MarginV 折叠守卫只覆盖「同 layer/margin」双语，跨 Layer/MarginL-R 落在缺口外，组间无全局碰撞避让。
- 修复：新增 `_mergeBottomBaselineGroups`——文本两两互异的底部基线折叠组按水平锚点分桶合并成竖排堆叠组（libass 同位不同文本竖排避让）；同文本多层拷贝（卡拉OK特效层）不合并、各层仍同位叠画（BUG-833 不回归）。

## 测试
- `video_subtitle_list_effect_dedup_test.dart`（3）+ `video_subtitle_bilingual_cross_layer_overlap_test.dart`（3，含卡拉OK同位守卫）。
- 全量 `test/media/video` 1536 通过、无回归；`flutter analyze` 干净。

## 待真机
触发 BUG-840 的双语 `.ass` 用户已无留档，按通用 libass 语义修（跨组底部避让 + 同文本不拆），待真机 A/B 复测原始双语文件。