### PR TITLE
docs: 清理 OneDrive 引用（教程链接+README 镜像）并加词典/音频教程提醒

### DIFF
--- a/docs/user-guide.ar.md
+++ b/docs/user-guide.ar.md
@@ -24,7 +24,7 @@ https://github.com/hajisensai/hibiki/releases/latest
 
 ### 1. استيراد القواميس المُوصى بها والصوت المحلي (يُوصى به بشدة للمبتدئين!!! · اختياري)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 داخل التطبيق: الإعدادات -> المزامنة والنسخ الاحتياطي -> اضغط على **استيراد نسخة احتياطية**.
 

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -24,7 +24,7 @@ Android: Wähle **arm64**. Windows: Wähle die **.exe**-Datei.
 
 ### 1. Empfohlene Wörterbücher und lokales Audio importieren (Sehr empfehlenswert für Einsteiger!!! · optional)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 In der App: Einstellungen -> Synchronisierung & Sicherung -> tippe auf **Sicherung importieren**.
 

--- a/docs/user-guide.es.md
+++ b/docs/user-guide.es.md
@@ -24,7 +24,7 @@ Android: elige **arm64**. Windows: elige el archivo **.exe**.
 
 ### 1. Importar los diccionarios recomendados y el audio local (Muy recomendado para principiantes!!! · opcional)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 En la aplicación: Ajustes -> Sincronización y copia de seguridad -> toca **Importar copia de seguridad**.
 

--- a/docs/user-guide.fr.md
+++ b/docs/user-guide.fr.md
@@ -24,7 +24,7 @@ Android : choisissez **arm64**. Windows : choisissez le fichier **.exe**.
 
 ### 1. Importer les dictionnaires recommandés et l'audio local (Fortement recommandé pour les débutants!!! · facultatif)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 Dans l'application : Paramètres -> Synchronisation et sauvegarde -> appuyez sur **Importer une sauvegarde**.
 

--- a/docs/user-guide.id.md
+++ b/docs/user-guide.id.md
@@ -24,7 +24,7 @@ Android: pilih **arm64**. Windows: pilih berkas **.exe**.
 
 ### 1. Mengimpor kamus yang direkomendasikan dan audio lokal (Sangat direkomendasikan untuk pemula!!! · opsional)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 Di dalam aplikasi: Pengaturan -> Sinkronisasi & Cadangan -> ketuk **Impor Cadangan**.
 

--- a/docs/user-guide.it.md
+++ b/docs/user-guide.it.md
@@ -24,7 +24,7 @@ Android: scegli **arm64**. Windows: scegli il file **.exe**.
 
 ### 1. Importare i dizionari consigliati e l'audio locale (Altamente consigliato per i principianti!!! · facoltativo)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 Nell'app: Impostazioni -> Sincronizzazione e backup -> tocca **Importa backup**.
 

--- a/docs/user-guide.ja.md
+++ b/docs/user-guide.ja.md
@@ -24,7 +24,7 @@ Android：**arm64** を選んでください。Windows：**.exe** ファイル�
 
 ### 1. 推奨辞書とローカル音声をインポートする（初心者に強くおすすめ！！！・任意）
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 アプリ内で：設定 -> 同期とバックアップ -> **バックアップをインポート** をタップします。
 

--- a/docs/user-guide.ko.md
+++ b/docs/user-guide.ko.md
@@ -24,7 +24,7 @@ Android: **arm64**를 선택하세요. Windows: **.exe** 파일을 선택하세�
 
 ### 1. 추천 사전과 로컬 오디오 가져오기(초보자에게 강력 추천!!! · 선택 사항)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 앱에서: 설정 -> 동기화 및 백업 -> **백업 가져오기**를 탭합니다.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -28,7 +28,7 @@ Android: choose **arm64**. Windows: choose the **.exe** file.
 
 ### 1. Import recommended dictionaries and local audio (Highly recommended for beginners!!! · optional)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 In the app: Settings -> Sync & Backup -> tap **Import Backup**.
 

--- a/docs/user-guide.nl.md
+++ b/docs/user-guide.nl.md
@@ -24,7 +24,7 @@ Android: kies **arm64**. Windows: kies het **.exe**-bestand.
 
 ### 1. Aanbevolen woordenboeken en lokale audio importeren (Sterk aanbevolen voor beginners!!! · optioneel)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 In de app: Instellingen -> Synchronisatie en back-up -> tik op **Back-up importeren**.
 

--- a/docs/user-guide.pt-BR.md
+++ b/docs/user-guide.pt-BR.md
@@ -24,7 +24,7 @@ Android: escolha **arm64**. Windows: escolha o arquivo **.exe**.
 
 ### 1. Importar os dicionários recomendados e o áudio local (Altamente recomendado para iniciantes!!! · opcional)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 No aplicativo: Configurações -> Sincronização e backup -> toque em **Importar backup**.
 

--- a/docs/user-guide.ru.md
+++ b/docs/user-guide.ru.md
@@ -24,7 +24,7 @@ Android: выберите **arm64**. Windows: выберите файл **.exe**
 
 ### 1. Импорт рекомендуемых словарей и локального аудио (Настоятельно рекомендуется новичкам!!! · необязательно)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 В приложении: Настройки -> Синхронизация и резервное копирование -> нажмите **Импортировать резервную копию**.
 

--- a/docs/user-guide.th.md
+++ b/docs/user-guide.th.md
@@ -24,7 +24,7 @@ Android: เลือก **arm64** Windows: เลือกไฟล์ **.exe**
 
 ### 1. นำเข้าพจนานุกรมที่แนะนำและไฟล์เสียงในเครื่อง (แนะนำอย่างยิ่งสำหรับมือใหม่!!! · ไม่บังคับ)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 ในแอป: การตั้งค่า -> ซิงค์และสำรองข้อมูล -> แตะ **นำเข้าข้อมูลสำรอง**
 

--- a/docs/user-guide.tr.md
+++ b/docs/user-guide.tr.md
@@ -24,7 +24,7 @@ Android: **arm64** seçin. Windows: **.exe** dosyasını seçin.
 
 ### 1. Önerilen sözlükleri ve yerel sesi içe aktarma (Yeni başlayanlara şiddetle önerilir!!! · isteğe bağlı)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 Uygulamada: Ayarlar -> Eşitleme ve Yedekleme -> **Yedeği İçe Aktar** öğesine dokunun.
 

--- a/docs/user-guide.vi.md
+++ b/docs/user-guide.vi.md
@@ -24,7 +24,7 @@ Android: chọn **arm64**. Windows: chọn tệp **.exe**.
 
 ### 1. Nhập các từ điển được đề xuất và âm thanh cục bộ (Rất khuyến khích cho người mới!!! · tùy chọn)
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 Trong ứng dụng: Cài đặt -> Đồng bộ & Sao lưu -> nhấn **Nhập bản sao lưu**.
 

--- a/docs/user-guide.zh-Hant.md
+++ b/docs/user-guide.zh-Hant.md
@@ -24,7 +24,7 @@ Android：選擇 **arm64**。Windows：選擇 **.exe** 檔案。
 
 ### 1. 匯入推薦詞典與本機音訊（極其推薦新手使用此方法！！！可選）
 
-[OneDrive](https://summersaltsea-my.sharepoint.com/:u:/g/personal/nonoka_summersaltsea_onmicrosoft_com/IQD1h7CwWz1hToQOwU1sNhBXAZi0td87k0EHDKMyJZMJyJc?e=5ah1Jn) / [Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
+[Google Drive](https://drive.google.com/file/d/19WIDymw87t7Ra_h-Vny6qRe7kBKBs2G0/view?usp=sharing)
 
 在 App 中：設定 -> 同步與備份 -> 點擊 **匯入備份**。
 


### PR DESCRIPTION
承接已合并的 PR #156，把 OneDrive 相关引用清理干净，并在 README 加词典/音频导入教程的入口。

## 改动
1. **User Guide（16 语言 `docs/user-guide*.md`）**：教程行去掉 `[OneDrive](…) / ` 前缀，只留新备份 Google Drive 链接。
2. **README.md / README.zh-CN.md**：删除 OneDrive **下载镜像**（头部链接、安装段落、说明注释共 3 处/文件）。`OneDrive` 作为同步后端/隐私说明的正常提及**保留**。
3. **README 加教程入口**：安装段加一句 callout 指向 User Guide + 一张可点缩略图（`import-backup.png`, 360px）跳到「导入推荐词典和音频」教程。**不搬教程正文**，单一真相源留在 User Guide，避免两份文档漂移。

## 背景（OneDrive 为何全删）
用户提供的 OneDrive 链接均需登录（`:u:/r/…`、文件夹 `onedrive.aspx?id=…` 匿名访问都 302 到 `login.microsoftonline.com`）；唯一匿名可用的旧 `:u:/g/…?e=5ah1Jn` 经 GUID 比对指向旧备份。用户遂决定弃用 OneDrive、只留 Google Drive。

## 验证
- `git diff --check` 干净
- READMEs 中 OneDrive 镜像 share 链接归 0；`docs` 中 OneDrive 旧 ID 归 0、GD 新 ID 16 处
- 缩略图 `docs/static-assets/user-guide/import-backup.png` 存在