### PR TITLE
docs(readme): hero 三链接改醒目徽章按钮（带图标）

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@
 
 **English** | [简体中文](README.zh-CN.md) | [繁體中文](docs/readme/README.zh-Hant.md) | [日本語](docs/readme/README.ja.md) | [한국어](docs/readme/README.ko.md) | [Español](docs/readme/README.es.md) | [Français](docs/readme/README.fr.md) | [Deutsch](docs/readme/README.de.md) | [Português](docs/readme/README.pt-BR.md) | [Русский](docs/readme/README.ru.md) | [Tiếng Việt](docs/readme/README.vi.md) | [ภาษาไทย](docs/readme/README.th.md) | [Bahasa Indonesia](docs/readme/README.id.md) | [Italiano](docs/readme/README.it.md) | [Nederlands](docs/readme/README.nl.md) | [Türkçe](docs/readme/README.tr.md) | [العربية](docs/readme/README.ar.md)
 
-[User Guide](docs/user-guide.md) | [Download Latest](https://github.com/hajisensai/hibiki/releases) | [Join our Discord](https://discord.gg/WhjwyGmm7f)
+[![User Guide](https://img.shields.io/badge/%F0%9F%93%96%20User%20Guide-0969DA?style=for-the-badge)](docs/user-guide.md)
+
+[![Download Latest](https://img.shields.io/badge/%E2%AC%87%20Download%20Latest-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Join our Discord](https://img.shields.io/badge/Join%20our%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **Watch what you want to watch, and pick up the language along the way.**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,10 @@
 
 [English](README.md) | **简体中文** | [繁體中文](docs/readme/README.zh-Hant.md) | [日本語](docs/readme/README.ja.md) | [한국어](docs/readme/README.ko.md) | [Español](docs/readme/README.es.md) | [Français](docs/readme/README.fr.md) | [Deutsch](docs/readme/README.de.md) | [Português](docs/readme/README.pt-BR.md) | [Русский](docs/readme/README.ru.md) | [Tiếng Việt](docs/readme/README.vi.md) | [ภาษาไทย](docs/readme/README.th.md) | [Bahasa Indonesia](docs/readme/README.id.md) | [Italiano](docs/readme/README.it.md) | [Nederlands](docs/readme/README.nl.md) | [Türkçe](docs/readme/README.tr.md) | [العربية](docs/readme/README.ar.md)
 
-[使用文档](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [下载最新版本](https://github.com/hajisensai/hibiki/releases) | [加入 Discord 社区](https://discord.gg/WhjwyGmm7f)
+[![使用文档](https://img.shields.io/badge/%F0%9F%93%96%20%E4%BD%BF%E7%94%A8%E6%96%87%E6%A1%A3-0969DA?style=for-the-badge)](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb)
+
+[![下载最新版本](https://img.shields.io/badge/%E2%AC%87%20%E4%B8%8B%E8%BD%BD%E6%9C%80%E6%96%B0%E7%89%88%E6%9C%AC-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![加入 Discord 社区](https://img.shields.io/badge/%E5%8A%A0%E5%85%A5%20Discord%20%E7%A4%BE%E5%8C%BA-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **看你想看的，语言顺手就学会了。**
 

--- a/docs/readme/README.ar.md
+++ b/docs/readme/README.ar.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | **العربية**
 
-[دليل المستخدم](../user-guide.ar.md) | [تنزيل أحدث إصدار](https://github.com/hajisensai/hibiki/releases)
+[![دليل المستخدم](https://img.shields.io/badge/%F0%9F%93%96%20%D8%AF%D9%84%D9%8A%D9%84%20%D8%A7%D9%84%D9%85%D8%B3%D8%AA%D8%AE%D8%AF%D9%85-0969DA?style=for-the-badge)](../user-guide.ar.md)
+
+[![تنزيل أحدث إصدار](https://img.shields.io/badge/%E2%AC%87%20%D8%AA%D9%86%D8%B2%D9%8A%D9%84%20%D8%A3%D8%AD%D8%AF%D8%AB%20%D8%A5%D8%B5%D8%AF%D8%A7%D8%B1-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![انضم إلى Discord](https://img.shields.io/badge/%D8%A7%D9%86%D8%B6%D9%85%20%D8%A5%D9%84%D9%89%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **شاهِد ما تحبّ مشاهدته، وستتعلّم اللغة في الطريق.**
 

--- a/docs/readme/README.de.md
+++ b/docs/readme/README.de.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | **Deutsch** | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[Benutzerhandbuch](../user-guide.de.md) | [Neueste Version herunterladen](https://github.com/hajisensai/hibiki/releases)
+[![Benutzerhandbuch](https://img.shields.io/badge/%F0%9F%93%96%20Benutzerhandbuch-0969DA?style=for-the-badge)](../user-guide.de.md)
+
+[![Neueste Version herunterladen](https://img.shields.io/badge/%E2%AC%87%20Neueste%20Version%20herunterladen-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Discord beitreten](https://img.shields.io/badge/Discord%20beitreten-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **Schau, was du sehen willst — und lern die Sprache ganz nebenbei.**
 

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | **Español** | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[Guía de usuario](../user-guide.es.md) | [Descargar la última versión](https://github.com/hajisensai/hibiki/releases)
+[![Guía de usuario](https://img.shields.io/badge/%F0%9F%93%96%20Gu%C3%ADa%20de%20usuario-0969DA?style=for-the-badge)](../user-guide.es.md)
+
+[![Descargar la última versión](https://img.shields.io/badge/%E2%AC%87%20Descargar%20la%20%C3%BAltima%20versi%C3%B3n-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Únete a Discord](https://img.shields.io/badge/%C3%9Anete%20a%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **Mira lo que quieras mirar y aprende el idioma sobre la marcha.**
 

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | **Français** | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[Guide d'utilisation](../user-guide.fr.md) | [Télécharger la dernière version](https://github.com/hajisensai/hibiki/releases)
+[![Guide d'utilisation](https://img.shields.io/badge/%F0%9F%93%96%20Guide%20d%27utilisation-0969DA?style=for-the-badge)](../user-guide.fr.md)
+
+[![Télécharger la dernière version](https://img.shields.io/badge/%E2%AC%87%20T%C3%A9l%C3%A9charger%20la%20derni%C3%A8re%20version-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Rejoindre le Discord](https://img.shields.io/badge/Rejoindre%20le%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **Regardez ce que vous avez envie de regarder, et la langue vient toute seule.**
 

--- a/docs/readme/README.id.md
+++ b/docs/readme/README.id.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | **Bahasa Indonesia** | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[Panduan Pengguna](../user-guide.id.md) | [Unduh versi terbaru](https://github.com/hajisensai/hibiki/releases)
+[![Panduan Pengguna](https://img.shields.io/badge/%F0%9F%93%96%20Panduan%20Pengguna-0969DA?style=for-the-badge)](../user-guide.id.md)
+
+[![Unduh versi terbaru](https://img.shields.io/badge/%E2%AC%87%20Unduh%20versi%20terbaru-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Gabung Discord](https://img.shields.io/badge/Gabung%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **Tonton apa yang ingin kamu tonton, lalu bahasanya ikut terkuasai.**
 

--- a/docs/readme/README.it.md
+++ b/docs/readme/README.it.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | **Italiano** | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[Guida utente](../user-guide.it.md) | [Scarica l'ultima versione](https://github.com/hajisensai/hibiki/releases)
+[![Guida utente](https://img.shields.io/badge/%F0%9F%93%96%20Guida%20utente-0969DA?style=for-the-badge)](../user-guide.it.md)
+
+[![Scarica l'ultima versione](https://img.shields.io/badge/%E2%AC%87%20Scarica%20l%27ultima%20versione-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Unisciti a Discord](https://img.shields.io/badge/Unisciti%20a%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **Guarda ciò che ti va di guardare e impara la lingua lungo il cammino.**
 

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | **日本語** | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[使い方ガイド](../user-guide.ja.md) | [最新版をダウンロード](https://github.com/hajisensai/hibiki/releases)
+[![使い方ガイド](https://img.shields.io/badge/%F0%9F%93%96%20%E4%BD%BF%E3%81%84%E6%96%B9%E3%82%AC%E3%82%A4%E3%83%89-0969DA?style=for-the-badge)](../user-guide.ja.md)
+
+[![最新版をダウンロード](https://img.shields.io/badge/%E2%AC%87%20%E6%9C%80%E6%96%B0%E7%89%88%E3%82%92%E3%83%80%E3%82%A6%E3%83%B3%E3%83%AD%E3%83%BC%E3%83%89-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Discord に参加](https://img.shields.io/badge/Discord%20%E3%81%AB%E5%8F%82%E5%8A%A0-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **観たいものを観ているうちに、ことばが手に入る。**
 

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | **한국어** | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[사용 설명서](../user-guide.ko.md) | [최신 버전 다운로드](https://github.com/hajisensai/hibiki/releases)
+[![사용 설명서](https://img.shields.io/badge/%F0%9F%93%96%20%EC%82%AC%EC%9A%A9%20%EC%84%A4%EB%AA%85%EC%84%9C-0969DA?style=for-the-badge)](../user-guide.ko.md)
+
+[![최신 버전 다운로드](https://img.shields.io/badge/%E2%AC%87%20%EC%B5%9C%EC%8B%A0%20%EB%B2%84%EC%A0%84%20%EB%8B%A4%EC%9A%B4%EB%A1%9C%EB%93%9C-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Discord 참여](https://img.shields.io/badge/Discord%20%EC%B0%B8%EC%97%AC-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **보고 싶은 걸 보다 보면, 언어는 자연스럽게 따라옵니다.**
 

--- a/docs/readme/README.nl.md
+++ b/docs/readme/README.nl.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | **Nederlands** | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[Gebruikershandleiding](../user-guide.nl.md) | [Nieuwste versie downloaden](https://github.com/hajisensai/hibiki/releases)
+[![Gebruikershandleiding](https://img.shields.io/badge/%F0%9F%93%96%20Gebruikershandleiding-0969DA?style=for-the-badge)](../user-guide.nl.md)
+
+[![Nieuwste versie downloaden](https://img.shields.io/badge/%E2%AC%87%20Nieuwste%20versie%20downloaden-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Word lid van Discord](https://img.shields.io/badge/Word%20lid%20van%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **Kijk waar je zin in hebt en pik de taal onderweg op.**
 

--- a/docs/readme/README.pt-BR.md
+++ b/docs/readme/README.pt-BR.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | **Português** | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[Guia do usuário](../user-guide.pt-BR.md) | [Baixar a versão mais recente](https://github.com/hajisensai/hibiki/releases)
+[![Guia do usuário](https://img.shields.io/badge/%F0%9F%93%96%20Guia%20do%20usu%C3%A1rio-0969DA?style=for-the-badge)](../user-guide.pt-BR.md)
+
+[![Baixar a versão mais recente](https://img.shields.io/badge/%E2%AC%87%20Baixar%20a%20vers%C3%A3o%20mais%20recente-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Entrar no Discord](https://img.shields.io/badge/Entrar%20no%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **Assista ao que você quer assistir e aprenda o idioma no caminho.**
 

--- a/docs/readme/README.ru.md
+++ b/docs/readme/README.ru.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | **Русский** | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[Руководство пользователя](../user-guide.ru.md) | [Скачать последнюю версию](https://github.com/hajisensai/hibiki/releases)
+[![Руководство пользователя](https://img.shields.io/badge/%F0%9F%93%96%20%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE%20%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8F-0969DA?style=for-the-badge)](../user-guide.ru.md)
+
+[![Скачать последнюю версию](https://img.shields.io/badge/%E2%AC%87%20%D0%A1%D0%BA%D0%B0%D1%87%D0%B0%D1%82%D1%8C%20%D0%BF%D0%BE%D1%81%D0%BB%D0%B5%D0%B4%D0%BD%D1%8E%D1%8E%20%D0%B2%D0%B5%D1%80%D1%81%D0%B8%D1%8E-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Присоединиться к Discord](https://img.shields.io/badge/%D0%9F%D1%80%D0%B8%D1%81%D0%BE%D0%B5%D0%B4%D0%B8%D0%BD%D0%B8%D1%82%D1%8C%D1%81%D1%8F%20%D0%BA%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **Смотрите то, что хочется, — и язык подтянется сам собой.**
 

--- a/docs/readme/README.th.md
+++ b/docs/readme/README.th.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | **ภาษาไทย** | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[คู่มือผู้ใช้](../user-guide.th.md) | [ดาวน์โหลดเวอร์ชันล่าสุด](https://github.com/hajisensai/hibiki/releases)
+[![คู่มือผู้ใช้](https://img.shields.io/badge/%F0%9F%93%96%20%E0%B8%84%E0%B8%B9%E0%B9%88%E0%B8%A1%E0%B8%B7%E0%B8%AD%E0%B8%9C%E0%B8%B9%E0%B9%89%E0%B9%83%E0%B8%8A%E0%B9%89-0969DA?style=for-the-badge)](../user-guide.th.md)
+
+[![ดาวน์โหลดเวอร์ชันล่าสุด](https://img.shields.io/badge/%E2%AC%87%20%E0%B8%94%E0%B8%B2%E0%B8%A7%E0%B8%99%E0%B9%8C%E0%B9%82%E0%B8%AB%E0%B8%A5%E0%B8%94%E0%B9%80%E0%B8%A7%E0%B8%AD%E0%B8%A3%E0%B9%8C%E0%B8%8A%E0%B8%B1%E0%B8%99%E0%B8%A5%E0%B9%88%E0%B8%B2%E0%B8%AA%E0%B8%B8%E0%B8%94-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![เข้าร่วม Discord](https://img.shields.io/badge/%E0%B9%80%E0%B8%82%E0%B9%89%E0%B8%B2%E0%B8%A3%E0%B9%88%E0%B8%A7%E0%B8%A1%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **ดูสิ่งที่อยากดู แล้วเรียนรู้ภาษาไปในตัว**
 

--- a/docs/readme/README.tr.md
+++ b/docs/readme/README.tr.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | **Türkçe** | [العربية](README.ar.md)
 
-[Kullanım Kılavuzu](../user-guide.tr.md) | [En son sürümü indir](https://github.com/hajisensai/hibiki/releases)
+[![Kullanım Kılavuzu](https://img.shields.io/badge/%F0%9F%93%96%20Kullan%C4%B1m%20K%C4%B1lavuzu-0969DA?style=for-the-badge)](../user-guide.tr.md)
+
+[![En son sürümü indir](https://img.shields.io/badge/%E2%AC%87%20En%20son%20s%C3%BCr%C3%BCm%C3%BC%20indir-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Discord'a katıl](https://img.shields.io/badge/Discord%27a%20kat%C4%B1l-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **İzlemek istediğini izle, dili de yol üstünde kap.**
 

--- a/docs/readme/README.vi.md
+++ b/docs/readme/README.vi.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | **Tiếng Việt** | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[Hướng dẫn sử dụng](../user-guide.vi.md) | [Tải bản mới nhất](https://github.com/hajisensai/hibiki/releases)
+[![Hướng dẫn sử dụng](https://img.shields.io/badge/%F0%9F%93%96%20H%C6%B0%E1%BB%9Bng%20d%E1%BA%ABn%20s%E1%BB%AD%20d%E1%BB%A5ng-0969DA?style=for-the-badge)](../user-guide.vi.md)
+
+[![Tải bản mới nhất](https://img.shields.io/badge/%E2%AC%87%20T%E1%BA%A3i%20b%E1%BA%A3n%20m%E1%BB%9Bi%20nh%E1%BA%A5t-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![Tham gia Discord](https://img.shields.io/badge/Tham%20gia%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **Xem thứ bạn muốn xem, rồi tự nhiên học được ngôn ngữ.**
 

--- a/docs/readme/README.zh-Hant.md
+++ b/docs/readme/README.zh-Hant.md
@@ -10,7 +10,10 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | **繁體中文** | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[使用文件](../user-guide.zh-Hant.md) | [下載最新版本](https://github.com/hajisensai/hibiki/releases)
+[![使用文件](https://img.shields.io/badge/%F0%9F%93%96%20%E4%BD%BF%E7%94%A8%E6%96%87%E4%BB%B6-0969DA?style=for-the-badge)](../user-guide.zh-Hant.md)
+
+[![下載最新版本](https://img.shields.io/badge/%E2%AC%87%20%E4%B8%8B%E8%BC%89%E6%9C%80%E6%96%B0%E7%89%88%E6%9C%AC-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
+[![加入 Discord 社群](https://img.shields.io/badge/%E5%8A%A0%E5%85%A5%20Discord%20%E7%A4%BE%E7%BE%A4-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
 
 > **看你想看的，語言順手就學會了。**
 


### PR DESCRIPTION
让顶部 User Guide / Download Latest / Join Discord 更容易被看见。

## 改动
- README.md / README.zh-CN.md：hero 里那行灰色纯文字链接 → shields `for-the-badge` 徽章按钮（带图标）。
- 布局：**📖 User Guide 单独上排**；第二排 **⬇ Download Latest**（下载箭头图标）+ **Discord**（品牌图标·5865F2）。
- 蓝(0969DA)/绿(2EA44F)/紫(5865F2)三色区分。徽章走 GitHub camo，仓库本来就用 shields 徽章，风格一致。

## 未改
- 15 个 `docs/readme/*.md` 语言变体（头部只有 Guide|Download 两个链接、无 Discord）暂未改，待确认是否同步。