### PR TITLE
fix(reader): BUG-843 顶部进度毛玻璃pill压住正文首行

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 824 条。点号进各自文件。
+> 共 825 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-843](bugs/BUG-843-top-progress-overlaps-first-line.md) | ✅ | ✅ | 顶部阅读进度毛玻璃pill压住正文首行 |
 | [BUG-842](bugs/BUG-842-popup-native-title-tooltip-flies.md) | ✅ | ✅ | Windows查词弹窗调整上下文等按钮原生title提示飞到窗口角落 |
 | [BUG-841](bugs/BUG-841-subtitle-list-effect-dup.md) | ✅ | ✅ | 字幕列表特效叠加ASS未去重 |
 | [BUG-840](bugs/BUG-840-bilingual-bottom-overlap.md) | ✅ | ✅ | 双语底部对白跨层/边距重叠 |

--- a/docs/bugs/BUG-843-top-progress-overlaps-first-line.md
+++ b/docs/bugs/BUG-843-top-progress-overlaps-first-line.md
@@ -1,0 +1,9 @@
+## BUG-843 · 顶部阅读进度毛玻璃pill压住正文首行
+- **报告**：2026-07-16（用户：顶部进度挡字，没开悬浮阅读进度，翻页模式，全端都有）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/reader_hibiki_page.dart:1360`（旧 `_infoStripHeight = _infoFontSize * 1.5`）与 `hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart:1779`（pill `EdgeInsets.symmetric(vertical: 3)`）。
+  - 顶部进度预留高走单一真相源 `topProgressReserve(infoStripHeight: _infoStripHeight)`（`reader_chrome_floating.dart:43`），挤压且显示时预留 `_infoStripHeight`；该预留经 JS `setChromeInsets` → CSS `--chrome-top-inset` 下压正文 padding-top，pill 则以 `Positioned(top: _stableTopInset)` 覆盖在预留区。铁律：pill 视觉高必须 ≤ 预留高，正文才不会被压。
+  - BUG-547 / TODO-1136（commit `41b945272`「悬浮阅读进度加毛玻璃背景」）给 pill 包了 `ClipRRect > BackdropFilter > Container(padding: vertical 3)`，pill 实高 = 文字行盒（真机字体约 14~16px）+ 上下 6px 内边距 ≈ 20~22px，**但该 commit 没同步上调 `_infoStripHeight`**（仍 18px）。于是挤压模式（未开悬浮进度、翻页/连续皆然）下 pill 高出预留 2~4px，盖住正文首行。纯布局常量失配，与平台/时序无关，故全端稳定复现。
+  - headless 测试字体（Ahem）行盒恰等字号、不溢出 em 盒，复现不出真机字体高度溢出（与本仓库多处「headless 测不出」同源）。
+- **[x] ① 已修复** — 把顶部进度的字号 / pill 内边距 / 预留高提到公共真相源 `reader_chrome_floating.dart`：`kTopProgressFontSize=12`、`kTopProgressPillVerticalPadding=3`、`kTopProgressStripHeight = kTopProgressFontSize*1.5 + 2*kTopProgressPillVerticalPadding = 24`。`reader_hibiki_page.dart` 的 `_infoFontSize`/`_infoStripHeight` 与 `chrome.part.dart` 的 pill 内边距均改引这些常量——pill 高与预留高从此共享同一批常量，杜绝再漂移。提交见下。
+- **[x] ② 已加自动化测试** — `hibiki/test/reader/reader_top_progress_reserve_test.dart`：确定性算术不变量守卫（预留高 ≥ 行盒估计 + pill 双边内边距、且确由字号与内边距推导）+ widget 实测 pill 高度 ≤ 预留。已硬验证：把预留退回旧值 18 时三处断言失败（`Expected ≥24, Actual 18`），还原即绿。
+- **备注**：悬浮态（`top_progress_floating` 开）预留恒 0、pill 浮在正文上自动收起属设计内，不受影响；本修复只影响挤压且显示进度时多下压 6px 正文区（正确代价）。caret/焦点环/弹窗避让均沿用同一 `_readerTopOffset`，随之一致，无破坏。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
@@ -1776,7 +1776,14 @@ extension _ReaderChrome on _ReaderHibikiPageState {
               filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
               child: Container(
                 color: frostedFill,
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                // TODO-975 铁律：pill 上下内边距与预留高 [_infoStripHeight]
+                // （= [kTopProgressStripHeight]）共享同一常量
+                // [kTopProgressPillVerticalPadding]，pill 实高绝不超预留（BUG-547
+                // 曾只加 padding 未同步预留 → 压住正文首行）。
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 8,
+                  vertical: kTopProgressPillVerticalPadding,
+                ),
                 child: Text(
                   '$_progressCurrentChars / $_progressTotalChars'
                   '  ${(ratio * 100).toStringAsFixed(2)}%',

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -1104,7 +1104,7 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   /// 走这个 getter，保证视觉高度与预留高度恒等。
   double get _readerChromeHeight => ReaderChromeScaler.scaledHeight(
       _readerChromeBaseHeight, _readerChromeScale);
-  static const double _infoFontSize = 12;
+  static const double _infoFontSize = kTopProgressFontSize;
 
   int? _progressCurrentChars;
   int? _progressTotalChars;
@@ -1356,8 +1356,11 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
       _progressTotalChars! > 0 &&
       ReaderHibikiSource.instance.showTopProgressBar;
 
-  /// 顶部进度信息条的自然高度（历史 `_infoFontSize * 1.5`）。
-  static const double _infoStripHeight = _infoFontSize * 1.5;
+  /// 顶部进度信息条的预留高（单一真相源 [kTopProgressStripHeight]）。历史值为裸
+  /// `_infoFontSize * 1.5`，未计入 BUG-547 毛玻璃 pill 后加的上下内边距，导致挤压模式
+  /// 下 pill 实高（文字行盒 + 6px 内边距）超出预留、压住正文首行；现改为共享
+  /// [kTopProgressStripHeight]（行盒估计 + pill 内边距）。
+  static const double _infoStripHeight = kTopProgressStripHeight;
 
   /// TODO-975 决策#2：顶部进度是否悬浮（点击唤出 + 自动收起 + 不占预留）。
   bool get _topProgressFloating =>

--- a/hibiki/lib/src/reader/reader_chrome_floating.dart
+++ b/hibiki/lib/src/reader/reader_chrome_floating.dart
@@ -33,6 +33,29 @@ int normalizeAutoHideChromeMillis(int value) {
 /// Default auto-hide duration: 3 seconds (TODO-975 decision #1).
 const int kDefaultAutoHideChromeMillis = 3000;
 
+/// Font size (logical px) of the top progress pill text (historical `12`).
+const double kTopProgressFontSize = 12;
+
+/// Vertical padding (logical px) on EACH side of the frosted pill's content,
+/// added by BUG-547 / TODO-1136 (the `EdgeInsets.symmetric(vertical: …)` in
+/// `_buildTopProgressBar`). Shared here so the reserved strip height below and
+/// the pill both read the SAME constant — the frosted layer added this padding
+/// but the old reserve never counted it, so the taller pill sat over the first
+/// body line in squeeze mode (BUG-470-adjacent overlap, all platforms).
+const double kTopProgressPillVerticalPadding = 3;
+
+/// Reserved strip height (logical px) for the top progress pill in squeeze mode.
+///
+/// Must be ≥ the pill's rendered height so the body text never sits under it
+/// (the 铁律 in this file's header). The pill's height = a text line box +
+/// [kTopProgressPillVerticalPadding] on both sides:
+///  * `kTopProgressFontSize * 1.5` is the historical line-box estimate (a real
+///    font's ascent+descent overflow the em box by ~1.17–1.4×; 1.5 keeps slack).
+///  * `+ 2 * kTopProgressPillVerticalPadding` counts the frosted pill padding
+///    that BUG-547 added but forgot to reserve for.
+const double kTopProgressStripHeight =
+    kTopProgressFontSize * 1.5 + 2 * kTopProgressPillVerticalPadding;
+
 /// Reserved height (logical px) for the top progress strip.
 ///
 ///  * Progress disabled / not yet measured (`showTopProgress == false`) -> 0,

--- a/hibiki/test/reader/reader_top_progress_reserve_test.dart
+++ b/hibiki/test/reader/reader_top_progress_reserve_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/reader/reader_chrome_floating.dart';
+
+/// BUG-843：翻页挤压模式下，顶部阅读进度的毛玻璃 pill 压住正文首行（全端复现、
+/// 未开悬浮进度）。
+///
+/// 根因：BUG-547 / TODO-1136 给 pill 加了 `EdgeInsets.symmetric(vertical: 3)` 毛玻璃
+/// 内边距（上下共 6px），但顶部进度的预留高 `_infoStripHeight` 仍是裸
+/// `_infoFontSize * 1.5`（18px），没把 pill 后加的内边距算进去。pill 实高 = 文字行盒
+/// （真机字体约 14~16px）+ 6px 内边距 ≈ 20~22px > 18px 预留，超出的部分盖住正文首行。
+/// 修复：预留高改为共享真相源 [kTopProgressStripHeight] = 行盒估计（font×1.5）+ 双边
+/// pill 内边距（2 × [kTopProgressPillVerticalPadding]）。
+///
+/// headless 测试字体（Ahem）的行盒恰等于字号、不溢出 em 盒，复现不出真机字体的高度
+/// 溢出，故用确定性算术不变量做主守卫；另配一个 widget 测量确认 pill 实测不超预留。
+void main() {
+  group('BUG-843 顶部进度预留必须容纳毛玻璃 pill', () {
+    test('预留高 ≥ 文字行盒估计 + pill 双边内边距（回收被漏计的毛玻璃 padding）', () {
+      // 铁律：pill 视觉高（行盒 + 双边内边距）绝不超预留高。旧值 18px 仅等于裸
+      // `font×1.5`、漏掉 6px 内边距，此断言下必然失败；修复后 24px 满足。
+      const double minReserve =
+          kTopProgressFontSize * 1.5 + 2 * kTopProgressPillVerticalPadding;
+      expect(
+        kTopProgressStripHeight,
+        greaterThanOrEqualTo(minReserve),
+        reason: '顶部进度预留高必须同时覆盖文字行盒和毛玻璃 pill 的上下内边距；'
+            '只要 pill 加了内边距而预留没跟着涨（BUG-843），此断言即失败',
+      );
+    });
+
+    test('单一真相源：预留高确由字号与 pill 内边距推导，pill 与预留不再各算各的', () {
+      // 若有人日后改 pill 内边距/字号而不同步预留，这三者的关系被打破即失败。
+      expect(
+        kTopProgressStripHeight,
+        kTopProgressFontSize * 1.5 + 2 * kTopProgressPillVerticalPadding,
+        reason: 'kTopProgressStripHeight 必须由 kTopProgressFontSize 与 '
+            'kTopProgressPillVerticalPadding 推导，杜绝两个不同源常量漂移',
+      );
+    });
+
+    testWidgets('实测 pill（毛玻璃内边距 + 进度文字）高度不超预留', (WidgetTester tester) async {
+      const Key pillKey = Key('bug843_pill_probe');
+      // 复刻 `_buildTopProgressBar` 里决定高度的子树：Container(上下内边距) > Text(字号)。
+      // 毛玻璃的 ClipRRect/BackdropFilter 不改高度，测量时省略。
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: Container(
+              key: pillKey,
+              padding: const EdgeInsets.symmetric(
+                horizontal: 8,
+                vertical: kTopProgressPillVerticalPadding,
+              ),
+              child: const Text(
+                '123456 / 999999  12.34%',
+                style: TextStyle(fontSize: kTopProgressFontSize),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final double pillHeight = tester.getSize(find.byKey(pillKey)).height;
+      expect(
+        pillHeight,
+        lessThanOrEqualTo(kTopProgressStripHeight),
+        reason: 'pill 实测高度（$pillHeight）不得超过顶部进度预留高'
+            '（$kTopProgressStripHeight），否则挤压模式下会压住正文首行',
+      );
+    });
+  });
+
+  test('kTopProgressStripHeight 是有限正值（防常量退化）', () {
+    expect(kTopProgressStripHeight.isFinite, isTrue);
+    expect(kTopProgressStripHeight, greaterThan(0));
+    // 显式钉住期望数值，防止无意改动悄悄回落：12×1.5 + 2×3 = 24。
+    expect(kTopProgressStripHeight, 24.0);
+  });
+}


### PR DESCRIPTION
## 问题
翻页挤压模式下（未开悬浮阅读进度、全端复现）顶部阅读进度的毛玻璃 pill 压住正文首行。

## 根因
BUG-547 / TODO-1136（`41b945272`）给顶部进度 pill 加了 `EdgeInsets.symmetric(vertical: 3)` 毛玻璃内边距（上下共 6px），但顶部进度的预留高 `_infoStripHeight` 仍是裸 `_infoFontSize * 1.5`（18px），**没把后加的内边距算进去**。pill 实高 = 文字行盒（真机字体约 14~16px）+ 6px 内边距 ≈ 20~22px > 18px 预留，超出部分盖住正文首行。纯布局常量失配，与平台/时序无关，故全端稳定复现。

## 修复
把字号 / pill 内边距 / 预留高提到公共真相源 `reader_chrome_floating.dart`：
- `kTopProgressFontSize=12` / `kTopProgressPillVerticalPadding=3`
- `kTopProgressStripHeight = kTopProgressFontSize*1.5 + 2*kTopProgressPillVerticalPadding = 24`

`reader_hibiki_page.dart` 的 `_infoFontSize`/`_infoStripHeight` 与 `chrome.part.dart` 的 pill 内边距均改引这些常量——pill 高与预留高共享同一批常量，杜绝再漂移。悬浮态预留恒 0 不受影响。

## 测试
新增 `test/reader/reader_top_progress_reserve_test.dart`：确定性算术不变量守卫（预留 ≥ 行盒估计 + pill 双边内边距）+ widget 实测 pill 高度 ≤ 预留。headless 字体（Ahem）行盒不溢出复现不出真机溢出，故主守卫用算术不变量。已硬验证：退回旧值 18 时三处断言失败（Expected ≥24, Actual 18），还原即绿。相邻 chrome/inset 守卫 23 测试全绿。

BUG 档案：`docs/bugs/BUG-843-top-progress-overlaps-first-line.md`

⚠️ 待真机复测原始失败路径（阅读器翻页、开顶部进度、关悬浮进度，确认正文首行不再被压）。