### PR TITLE
fix(lyrics): 歌词模式支持Shift/悬停查词 (BUG-843)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 824 条。点号进各自文件。
+> 共 825 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-843](bugs/BUG-843-lyrics-shift-hover-lookup.md) | ✅ | ✅ | 歌词模式不支持Shift/悬停查词 |
 | [BUG-842](bugs/BUG-842-popup-native-title-tooltip-flies.md) | ✅ | ✅ | Windows查词弹窗调整上下文等按钮原生title提示飞到窗口角落 |
 | [BUG-841](bugs/BUG-841-subtitle-list-effect-dup.md) | ✅ | ✅ | 字幕列表特效叠加ASS未去重 |
 | [BUG-840](bugs/BUG-840-bilingual-bottom-overlap.md) | ✅ | ✅ | 双语底部对白跨层/边距重叠 |

--- a/docs/bugs/BUG-843-lyrics-shift-hover-lookup.md
+++ b/docs/bugs/BUG-843-lyrics-shift-hover-lookup.md
@@ -1,0 +1,9 @@
+## BUG-843 · 歌词模式不支持Shift/悬停查词
+- **报告**：2026-07-16（用户：）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart:2031-2063`（歌词页就绪分支只注入行级 caret 脚本，不注入正文 `_buildReaderSetupScript`）+ `hibiki/lib/src/media/audiobook/lyrics_mode_html.dart`（独立文档只挂 tap/pointer 点击查词，无 mousemove 悬停查词监听、无 `window.__hoverAutoLookup`）。正文的 Shift-悬停/纯悬停查词监听器只活在正文文档（`webview.part.dart:1214-1223`），歌词整页替换后彻底缺失 → 歌词模式只能点击查词，Shift-悬停与纯悬停自动查词全失效。附带 `lyrics_mode_html.dart` 的 `selectText` 重写只声明 `(x,y,maxLen)`、丢弃第 4 个 `fromHover` 实参，导致就算补上悬停也会命中空白误 fire `onTapEmpty`、同词悬停被 toggle。
+- **[x] ① 已修复** — 三处根因修复，提交见备注：
+  - `lyrics_mode_html.dart`：新增 `document` 上 `mousemove` 监听，镜像正文 `webview.part.dart` 语义（`e.shiftKey || window.__hoverAutoLookup` 门控 + 64px² 位移阈值 → `callHandler('onShiftHover', x, y)`）。Dart `onShiftHover` 已 `_selectTextAt(fromHover:true)`，在歌词文档命中被重写的 `selectText`（写 `__lyricsCueContext`），与点击查词同源。
+  - `lyrics_mode_html.dart`：`selectText` 重写改为 `function(x,y,maxLen,fromHover)` + `origSelectText.apply(this, arguments)` 原样透传 `fromHover`，悬停命中空白/同词不再误触发 `onTapEmpty`/toggle。
+  - `webview.part.dart`：歌词页就绪时调 `_applyHoverAutoLookupLive()` 下发 `window.__hoverAutoLookup` 初值，纯悬停查词从进入歌词那刻即生效（Shift-悬停不依赖此全局）。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/audiobook/lyrics_mode_html_test.dart` 新增 `BUG-843 hover lookup parity` group：断言生成 HTML 含 mousemove→onShiftHover 监听、Shift/hoverAutoLookup 门控、64px² 阈值、`selectText` 透传 `arguments`（不再硬编码 3 参调用）。
+- **备注**：Shift/悬停查词与点击查词都在歌词独立文档内经同一 `hoshiSelection.selectText` 管线，cue 元数据一致。拖选查词（选区手柄）是正文独立大功能，歌词模式按 cue 点/悬停查词，本次不纳入。提交哈希：见 PR。

--- a/hibiki/lib/src/media/audiobook/lyrics_mode_html.dart
+++ b/hibiki/lib/src/media/audiobook/lyrics_mode_html.dart
@@ -410,6 +410,24 @@ _lc.addEventListener('pointerup', function(e) {
   _lyTapEnd(e.clientX, e.clientY);
 }, {passive: false});
 
+// ── BUG-843: 桌面 Shift-悬停 / 纯悬停查词 ──
+// 歌词是独立文档，正文 setup 脚本（含 mousemove→onShiftHover 与 window.__hoverAutoLookup）
+// 不注入到这里，导致歌词模式此前完全不支持悬停查词（只有点击查词）。这里镜像正文
+// webview.part.dart 的 mousemove 监听：Shift 按住或开了「悬停即查词」开关时，鼠标越过
+// 8px 门限即回 Dart onShiftHover（→ _selectTextAt(fromHover:true)，命中被重写的
+// selectText 写入 cue 元数据、同源查词管线）。命中空白/同词由 selectText 的 fromHover
+// 短路处理，不闪不叠层。__hoverAutoLookup 初值由 Dart 在歌词页就绪时下发。
+var _shiftHoverLastX = -1, _shiftHoverLastY = -1;
+document.addEventListener('mousemove', function(e) {
+  if (!e.shiftKey && !window.__hoverAutoLookup) { _shiftHoverLastX = -1; _shiftHoverLastY = -1; return; }
+  var dx = e.clientX - _shiftHoverLastX, dy = e.clientY - _shiftHoverLastY;
+  if (dx * dx + dy * dy < 64) return;
+  _shiftHoverLastX = e.clientX; _shiftHoverLastY = e.clientY;
+  if (window.flutter_inappwebview) {
+    window.flutter_inappwebview.callHandler('onShiftHover', e.clientX, e.clientY);
+  }
+}, {passive: true});
+
 // ── 中键点句 → seek 到该 cue 并播放（标准 click 不触发中键，单列 mousedown）──
 _lc.addEventListener('mousedown', function(e) {
   if (e.button === 0) return;
@@ -424,7 +442,12 @@ _lc.addEventListener('mousedown', function(e) {
 // ── 歌词模式：覆写 selection 回调，附加 cue 元数据 ──
 (function() {
   var origSelectText = window.hoshiSelection.selectText;
-  window.hoshiSelection.selectText = function(x, y, maxLen) {
+  // BUG-843: 必须透传全部实参（含第 4 个 fromHover）。旧重写只声明 (x,y,maxLen)、
+  // 只转发 3 参，把 Shift-悬停/纯悬停查词路径（selectInvocation 传 fromHover=true）
+  // 的 fromHover 吞成 undefined → origSelectText 当成真点击：命中空白误 fire
+  // onTapEmpty（关弹窗/唤底栏闪烁）、同词再悬停被 toggle 掉选区。用 apply 原样转发
+  // 整个 arguments，语义与正文选区完全一致。
+  window.hoshiSelection.selectText = function(x, y, maxLen, fromHover) {
     var hitEl = document.elementFromPoint(x, y);
     var cueEl = hitEl ? hitEl.closest('.cue') : null;
     if (cueEl) {
@@ -435,7 +458,7 @@ _lc.addEventListener('mousedown', function(e) {
     } else {
       window.__lyricsCueContext = null;
     }
-    return origSelectText.call(window.hoshiSelection, x, y, maxLen);
+    return origSelectText.apply(window.hoshiSelection, arguments);
   };
 })();
 

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -2054,6 +2054,11 @@ extension _ReaderWebView on _ReaderHibikiPageState {
       }
       _onCueChanged();
       await _applyLyricsFavorites();
+      // BUG-843: 歌词是独立文档，正文 setup 脚本（下发 window.__hoverAutoLookup 初值）
+      // 不在此分支注入。歌词页的 mousemove 悬停查词监听据此全局跳过 Shift 门控（纯悬停即
+      // 查词），必须在页面就绪时把当前开关值同步进新文档，否则纯悬停查词要等一次设置热更
+      // 才生效。Shift-悬停不依赖此全局（监听器直接读 e.shiftKey），本行只补齐纯悬停路径。
+      if (mounted) await _applyHoverAutoLookupLive();
       // BUG-767: 此前（BUG-755）在歌词页就绪即强夺阅读焦点，想让 ESC 从进入那刻就能退。
       // 但桌面 loadData 后强夺 Flutter 焦点会把原生 WebView2 顶焦、重置其滚动到顶
       // （→ 高亮看似回第一句），并与页面自身抢焦点抖动；一旦叠加重载路径每次 loadData

--- a/hibiki/test/media/audiobook/lyrics_mode_html_test.dart
+++ b/hibiki/test/media/audiobook/lyrics_mode_html_test.dart
@@ -278,6 +278,68 @@ void main() {
         expect(html, contains('__lyricsFitCues()'));
       });
     });
+
+    // BUG-843: 歌词是独立文档，正文 setup 脚本（含 mousemove→onShiftHover 与
+    // window.__hoverAutoLookup）不注入到这里，导致歌词模式此前完全不支持悬停查词，
+    // 只能点击查词。这里守卫悬停查词监听已镜像正文语义、且 selectText 重写透传
+    // fromHover（否则悬停命中空白误 fire onTapEmpty、同词悬停被 toggle）。
+    group('shift / auto hover lookup parity (BUG-843)', () {
+      String buildHtml() {
+        return LyricsModeHtml.generate(
+          cues: <AudioCue>[_cue(0), _cue(1)],
+          currentIndex: 0,
+          backgroundColor: 'rgba(255,255,255,1.00)',
+          textColor: 'rgba(0,0,0,1.00)',
+          accentColor: 'rgba(255,220,0,1.00)',
+          fontSize: 20,
+        );
+      }
+
+      test('ships a document mousemove listener that fires onShiftHover', () {
+        final String html = buildHtml();
+        // Hover lookup must live in the lyrics document itself (the reader setup
+        // script is not injected here), mirroring webview.part.dart's listener.
+        expect(html, contains("document.addEventListener('mousemove'"));
+        expect(
+          html,
+          contains("window.flutter_inappwebview.callHandler('onShiftHover'"),
+        );
+      });
+
+      test('hover is gated on Shift or the __hoverAutoLookup toggle', () {
+        final String html = buildHtml();
+        // Same gate as the reader body: Shift held OR the "hover to look up"
+        // setting on; neither → reset the throttle anchor and bail.
+        expect(
+          html,
+          contains('!e.shiftKey && !window.__hoverAutoLookup'),
+        );
+      });
+
+      test('hover honours the 8px (64 px^2) movement throttle', () {
+        final String html = buildHtml();
+        // Identical movement threshold to the reader body so a stationary cursor
+        // does not re-fire a lookup every mousemove.
+        expect(html, contains('dx * dx + dy * dy < 64'));
+      });
+
+      test('selectText override forwards fromHover (all args, not just 3)', () {
+        final String html = buildHtml();
+        // The override must pass the 4th fromHover arg through, otherwise a hover
+        // over blank space fires onTapEmpty and a same-word re-hover toggles the
+        // selection off. Forward the whole arguments object.
+        expect(
+          html,
+          contains('origSelectText.apply(window.hoshiSelection, arguments)'),
+        );
+        // The broken 3-arg forwarding must be gone.
+        expect(
+          html,
+          isNot(contains(
+              'origSelectText.call(window.hoshiSelection, x, y, maxLen)')),
+        );
+      });
+    });
   });
 }
 


### PR DESCRIPTION
## 根因
歌词模式用 `LyricsModeHtml` 整页替换文档。正文的 Shift-悬停/纯悬停查词监听器（`webview.part.dart:1214-1223` 的 mousemove→`onShiftHover`）与 `window.__hoverAutoLookup` 全局只活在正文文档；歌词页就绪分支（`webview.part.dart:2031-2063`）只注入行级 caret 脚本，**从未安装悬停查词监听、也不下发 `__hoverAutoLookup`**。歌词独立文档（`lyrics_mode_html.dart`）只挂 tap/pointer 点击查词。→ 歌词模式只能点击查词，Shift-悬停与纯悬停自动查词全失效。

附带 bug：`selectText` 重写只声明 `(x,y,maxLen)`、丢弃第 4 个 `fromHover` 实参，导致就算补上悬停也会命中空白误 fire `onTapEmpty`、同词悬停被 toggle。

## 修复（镜像正文，最小改动）
1. `lyrics_mode_html.dart`：新增 `document` mousemove 监听，语义与正文逐字节一致（`e.shiftKey || __hoverAutoLookup` 门控 + 64px² 阈值 → `onShiftHover`）。Dart `onShiftHover` 已 `_selectTextAt(fromHover:true)`，在歌词文档命中重写的 `selectText`（写 `__lyricsCueContext`），与点击查词同源。
2. `lyrics_mode_html.dart`：`selectText` 重写改 `function(x,y,maxLen,fromHover)` + `origSelectText.apply(this, arguments)` 透传全部实参。
3. `webview.part.dart`：歌词页就绪调 `_applyHoverAutoLookupLive()` 下发 `__hoverAutoLookup` 初值，纯悬停查词从进入那刻即生效（Shift-悬停不依赖此全局）。

## 测试
`test/media/audiobook/lyrics_mode_html_test.dart` 新增 `BUG-843 hover lookup parity` group（4 断言：mousemove→onShiftHover、Shift/hoverAutoLookup 门控、64px² 阈值、selectText 透传 arguments）。全套 18 项通过；`flutter analyze` 干净；caret 相邻测试无回归。

## 待验
真机（Windows 离屏 / Android）复测歌词模式下 Shift+鼠标悬停即查词、开启「悬停即查词」后纯悬停查词、连续换词与命中空白不闪。拖选查词是正文独立大功能，本次不纳入。