### PR TITLE
fix(sync): BUG-845 WebDAV folderId 缺尾斜杠致进度溢出根目录并删对端副本

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 826 条。点号进各自文件。
+> 共 827 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-845](bugs/BUG-845-webdav-folder-slash-spill.md) | ✅ | ✅ | WebDAV book folderId 缺尾斜杠致进度文件溢出根目录并删除对端 in-folder 副本 |
 | [BUG-844](bugs/BUG-844-lyrics-shift-hover-lookup.md) | ✅ | ✅ | 歌词模式不支持Shift/悬停查词 |
 | [BUG-843](bugs/BUG-843-top-progress-overlaps-first-line.md) | ✅ | ✅ | 顶部阅读进度毛玻璃pill压住正文首行 |
 | [BUG-842](bugs/BUG-842-popup-native-title-tooltip-flies.md) | ✅ | ✅ | Windows查词弹窗调整上下文等按钮原生title提示飞到窗口角落 |

--- a/docs/bugs/BUG-845-webdav-folder-slash-spill.md
+++ b/docs/bugs/BUG-845-webdav-folder-slash-spill.md
@@ -1,0 +1,34 @@
+## BUG-845 · WebDAV book folderId 缺尾斜杠致进度文件溢出根目录并删除对端 in-folder 副本
+
+- **报告**：2026-07-16（用户复报：「webdav 同步数据，手机端这本书还是坏的会同步到文件外，依旧会把平板端这本书正常同步到文件夹内的文件给清掉」，附真机截图 `hibiki-data/屍人荘の殺人`）。BUG-619 / BUG-653（TODO-1329/1340）修过「空 title 溢出」，用户复报仍溢出且删对端。
+- **真实性**：✅ 真 bug，且是 BUG-619/653 未覆盖的**另一条溢出源**。截图关键新信号：溢出文件名是 `屍人荘の殺人audioBook_1_6_<ts>_<pos>.json`（**书名前缀 + audioBook 名连体**，97 B，时间戳每次变、堆多份），不是 BUG-619 的裸 `audioBook_1_6_*`。
+
+### 根因
+
+路径式后端把 per-book folderId 当**裸路径前缀**用：子文件地址 = `folderId + Uri.encodeComponent(fileName)`，**不插分隔符**（`webdav_ops.dart:222` `uploadJson`；`webdav_sync_backend.dart:216` `uploadContentFile` / `:269` `findContentFile`）。所以 folderId **必须以 `/` 结尾**，否则 `folderId + fileName` 会把两者**粘连**成书文件夹的兄弟：`<root>/屍人荘の殺人` + `audioBook_1_6_….json` → `<root>/屍人荘の殺人audioBook_1_6_….json`，文件落到**同步根**、书名黏在文件名前。
+
+`ensureBookFolder` 在**创建**文件夹时拼的是带尾斜杠的 `<root>/<sanitized>/`（`webdav_sync_backend.dart:109`），但 folderId 还有另外两条**不带斜杠**的入缓存路径：
+- `cacheBookFolderIds(listBooks(...))`（`webdav_sync_backend.dart:301`）：`listBooks` 存 `DriveFile(id: e.href)`（`:93`），href 来自 PROPFIND；**部分 WebDAV 服务器（坚果云 / Nutstore 等）对 collection href 不带尾斜杠**。调用点在同步比较弹窗 `sync_compare_dialog.dart:167` / 远端书客户端 `cloud_remote_book_client.dart:65`。
+- `restoreCache(getFolderCache())`（`webdav_sync_backend.dart:283` ← `sync_manager.dart:_restoreDriveCache`）：无尾斜杠的 id 经 `sync_repository.dart:139 setFolderCache`（jsonEncode 原样入 `preferences.sync_folder_cache`）**往返持久化**，重启后再灌回。
+
+`ensureBookFolder` 命中缓存时**原样返回**缓存值（`webdav_sync_backend.dart:105-107`），没规范化。于是 folderId 无尾斜杠 → 每次导出：
+1. `updateAudioBookFile`（`:195`）先 `uploadJson(folderId, fileName)` 把新 audioBook 写到 `<root>/屍人荘の殺人audioBook_….json`（**根 · 连体名 · 错位**）；
+2. 再 `deleteFile(fileId)`，而 `fileId` 来自 `listSyncFiles(folderId)`（`sync_manager.dart:280`）在书文件夹内拾到的**对端（平板）正常 in-folder 副本**——PROPFIND 不带尾斜杠也能解析该 collection，照样列出并删。
+→ 净效果：**对端 in-folder 正常文件被删，根目录多一份连体孤儿**；audioBook 名带 `DateTime.now()` 每次变 + `findSyncFileByPrefix` 单文件去重 → 根里连体孤儿**堆多份**（「丢很多份」）。互联后端 `HibikiClientSyncBackend`（复用 `WebDavOps` 同款连体 concat）结构同型（其 server 通常回带斜杠 href，暴露面较低）。其余后端安全：ftp/sftp/dropbox 用显式 `/` 分隔、onedrive/google_drive 用不可变 item id + parent 引用，均不做裸路径粘连。
+
+- 既有 `pruneRootSpill`（BUG-653）用 `isTtuPerBookFileName`**先头锚 `^audioBook_1_6_`**，**匹配不到**书名前缀的 `屍人荘の殺人audioBook_1_6_…`，历史残留永不清。
+
+### 修复
+
+- **[x] ① 已修复** — 分支 `worktree-webdav-folder-slash-spill`（commit 见末）。防御纵深，令不变量「缓存里每个 folderId 都以 `/` 结尾」**由构造保证**：
+  1. 新增单一归一函数 `ensureFolderIdTrailingSlash(folderId)`（`sync_backend.dart`）：缺尾斜杠则补。
+  2. `WebDavSyncBackend` + `HibikiClientSyncBackend` 三处入缓存点全归一：`cacheBookFolderIds`（服务器 href 入口）、`restoreCache`（毒持久化 id 入口，**顺带自愈老用户已污染的 `sync_folder_cache`**，含 rootFolderId）、`ensureBookFolder` 命中缓存的返回值（兜底）。`evictFolderId` 比较入参也先归一，避免尾斜杠差异漏逐出。写入源头（`updateAudioBookFile`/`uploadContentFile`）不再可能收到无斜杠 folderId → 不再溢出、不再误删对端 in-folder 副本。
+  3. 残留自愈：`ttu_filename.dart` 的 spill 谓词 `_ttuPerBookFilePattern` 去掉先头锚 `^`（改 `(?:progress|statistics|audioBook|cover)_1_6[._]` 任意位置匹配），令 `pruneRootSpill` 同时清掉裸（BUG-619）与**书名前缀**（本 bug）两形态的根残留；`type_1_6[._]` 标记足够特异，只 Hibiki per-book 文件带它，且调用方仍要求「非文件夹的根直接子项」（`sync_orchestrator.dart:1999` `e.isFolder` 守卫在前），书文件夹/保留 namespace 绝不误删。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/sync/sync_folder_id_slash_test.dart`（新）：`ensureFolderIdTrailingSlash` 纯函数；`WebDavSyncBackend` / `HibikiClientSyncBackend` 用无斜杠 href 喂 `cacheBookFolderIds` / `restoreCache` → `cachedFolderIds` / `cachedRootFolderId` 均带尾斜杠；`ensureBookFolder` 命中缓存返回带斜杠，且模拟 `folderId + audioBookFileName(...)` 落在书文件夹**内**（含 `/audioBook_`）、**不**粘连成 `屍人荘の殺人audioBook_`（根溢出）。
+  - `hibiki/test/sync/sync_root_spill_prune_test.dart`（扩）：谓词组加书名前缀四型命中 + 近似负例（`屍人荘の殺人progression.json` 仍 false）；新增 `pruneRootSpill` 用例：书文件夹完好，根里多份书名前缀 audioBook + cover 全清（`rootSpillFilesRemoved==3`）、in-folder 合法文件不动。既有 BUG-619 裸溢出用例 + TODO-1346 文件夹/本地 DB 安全守卫全绿（去锚不改其判定）。
+  - `flutter analyze` 5 个改动 lib 文件 0 issue；`flutter test test/sync/sync_folder_id_slash_test.dart test/sync/sync_root_spill_prune_test.dart test/sync/ttu_filename_test.dart` 38 例全绿。
+
+- **备注**：
+  - **待真机双设备验收（用户 WebDAV/坚果云）**：手机 + 平板同账户 → 触发有声书进度同步 → 云盘文件浏览器确认：`hibiki-data/` 根下不再新增 `<书名>audioBook_1_6_*` 连体文件；书文件夹 `hibiki-data/屍人荘の殺人/` 内 `audioBook_*.json` 正常更新且**不再被对端删**；已升级到本包并跑过一次同步后，历史根残留（含连体多份）被 `pruneRootSpill` 清空。
+  - `test/sync/sync_settings_visibility_test.dart` 的 `auto-sync is gated on the hosting role` 一例在**本分支 base（develop `bb66190c3`）即失败**（`sync.content` gating，与本改动无关，已 stash 本改动复核确认），非本次引入。

--- a/hibiki/lib/src/sync/hibiki_client_sync_backend.dart
+++ b/hibiki/lib/src/sync/hibiki_client_sync_backend.dart
@@ -302,7 +302,8 @@ class HibikiClientSyncBackend extends SyncBackend
     final sanitized = requireBookFolderName(bookTitle);
 
     if (_titleToFolderId.containsKey(sanitized)) {
-      return _titleToFolderId[sanitized]!;
+      // Normalize a possibly slash-less cached href on return (BUG-845).
+      return ensureFolderIdTrailingSlash(_titleToFolderId[sanitized]!);
     }
 
     final path = '$rootFolderId${Uri.encodeComponent(sanitized)}/';
@@ -487,9 +488,15 @@ class HibikiClientSyncBackend extends SyncBackend
     String? rootFolderId,
     Map<String, String>? titleToFolderId,
   }) {
-    _rootFolderId = rootFolderId;
+    // Heal slash-less persisted ids on load so every cached folderId ends with
+    // `/` (BUG-845): `folderId + fileName` must never spill into the root.
+    _rootFolderId = rootFolderId == null
+        ? null
+        : ensureFolderIdTrailingSlash(rootFolderId);
     if (titleToFolderId != null) {
-      _titleToFolderId.addAll(titleToFolderId);
+      titleToFolderId.forEach((title, id) {
+        _titleToFolderId[title] = ensureFolderIdTrailingSlash(id);
+      });
     }
   }
 
@@ -502,7 +509,10 @@ class HibikiClientSyncBackend extends SyncBackend
   @override
   void cacheBookFolderIds(List<DriveFile> folders) {
     for (final f in folders) {
-      _titleToFolderId[f.name] = f.id;
+      // DriveFile.id = the server's collection href; normalize the trailing
+      // slash before caching so a later `folderId + fileName` write cannot spill
+      // into the root (BUG-845).
+      _titleToFolderId[f.name] = ensureFolderIdTrailingSlash(f.id);
     }
   }
 
@@ -510,7 +520,9 @@ class HibikiClientSyncBackend extends SyncBackend
   void evictFolderId(String folderId) {
     // 按值反查逐出书名→folderId 缓存里指向 [folderId] 的条目，消除删书后陈旧态
     // （BUG-202）。路径式后端的 folderId 是按名派生的路径，逐出仍是廉价正确性。
-    _titleToFolderId.removeWhere((_, id) => id == folderId);
+    // 缓存值已统一带尾斜杠（BUG-845），入参也归一后再比。
+    final normalized = ensureFolderIdTrailingSlash(folderId);
+    _titleToFolderId.removeWhere((_, id) => id == normalized);
   }
 
   // ── SyncAssetStore ────────────────────────────────────────────────

--- a/hibiki/lib/src/sync/sync_backend.dart
+++ b/hibiki/lib/src/sync/sync_backend.dart
@@ -64,6 +64,24 @@ String requireBookFolderName(String bookTitle) {
   return name;
 }
 
+/// Path-style backends (WebDAV, Hibiki interconnect) use a book/namespace
+/// folderId as a bare path PREFIX: a child is addressed as `folderId + name`
+/// with NO separator inserted (see `WebDavOps.uploadJson`). The prefix therefore
+/// MUST end with `/`, or `folderId + fileName` fuses the two into a sibling of
+/// the folder — `<root>/<title>audioBook_1_6_….json` lands directly in the sync
+/// root with the title glued to the file name instead of inside
+/// `<root>/<title>/` (BUG-845, a re-report of BUG-619 / BUG-653's spill).
+///
+/// `ensureBookFolder` appends the slash when it CREATES a folder, but folder ids
+/// also enter the cache from server PROPFIND hrefs
+/// (`cacheBookFolderIds` / `restoreCache`), and some WebDAV servers (e.g.
+/// Nutstore / 坚果云) return collection hrefs WITHOUT a trailing slash. Run every
+/// such id through this before caching or returning it so the invariant "a
+/// cached folderId ends with `/`" holds by construction — and any already
+/// poisoned persisted cache self-heals the next time it is loaded.
+String ensureFolderIdTrailingSlash(String folderId) =>
+    folderId.endsWith('/') ? folderId : '$folderId/';
+
 abstract class SyncBackend implements SyncAssetStore {
   // ── Auth ──────────────────────────────────────────────────────────
 

--- a/hibiki/lib/src/sync/ttu_filename.dart
+++ b/hibiki/lib/src/sync/ttu_filename.dart
@@ -35,22 +35,31 @@ String progressFileName(int timestampMs, double progress) =>
 String audioBookFileName(int timestampMs, double positionSec) =>
     'audioBook_1_6_${timestampMs}_$positionSec.json';
 
-/// The ッツ per-book file names that legitimately live ONLY inside a book's
-/// folder (`<root>/<sanitizedTitle>/`): the churning progress / statistics /
-/// audioBook JSON plus the book cover. Every one starts with its type followed
-/// by the `_1_6` schema marker, then `_` (JSON) or `.` (cover extension).
+/// The ッツ per-book files that legitimately live ONLY inside a book's folder
+/// (`<root>/<sanitizedTitle>/`): the churning progress / statistics / audioBook
+/// JSON plus the book cover. Each carries its type followed by the `_1_6` schema
+/// marker, then `_` (JSON) or `.` (cover extension).
 ///
-/// A file matching this pattern sitting as a *direct child of the sync root* is
-/// spill: the old empty-title `ensureBookFolder('')` collapsed `<root>/<''>/`
-/// onto the root itself, scattering these files next to real book folders
-/// (BUG-619 / TODO-1329 stopped the source). Because their timestamp filenames
-/// churn every export and the single-file `findSyncFileByPrefix` dedup only
-/// ever tracks one, spilled copies pile up into many (`丢很多份`, TODO-1340).
-/// Used to detect and sweep that residue — callers MUST additionally require the
-/// entry to be a non-folder direct child of the root (a book's own folder may be
-/// named anything, so name alone is not enough).
+/// A file whose name CONTAINS this marker sitting as a *direct child of the sync
+/// root* is spill in one of two shapes seen in the wild:
+///  - **bare** `audioBook_1_6_….json` — the old empty-title `ensureBookFolder('')`
+///    collapsed `<root>/<''>/` onto the root itself (BUG-619 / TODO-1329 stopped
+///    that source);
+///  - **title-prefixed** `<title>audioBook_1_6_….json` — a book folderId cached
+///    WITHOUT its trailing slash made `folderId + fileName` fuse into
+///    `<root>/<title>audioBook_…` (BUG-845; the write source is now fixed at
+///    `ensureFolderIdTrailingSlash`).
+///
+/// Both are orphaned spill; their timestamp filenames churn every export and the
+/// single-file `findSyncFileByPrefix` dedup only tracks one, so copies pile up
+/// into many (`丢很多份`, TODO-1340). The `type_1_6[._]` marker is specific
+/// enough that only Hibiki's per-book files carry it, so the pattern is matched
+/// ANYWHERE in the name (not just anchored) to also catch the title-prefixed
+/// shape. Used to detect and sweep that residue — callers MUST additionally
+/// require the entry to be a non-folder direct child of the root (a book's own
+/// folder may be named anything, so name alone is not enough).
 final RegExp _ttuPerBookFilePattern =
-    RegExp(r'^(?:progress|statistics|audioBook|cover)_1_6[._]');
+    RegExp(r'(?:progress|statistics|audioBook|cover)_1_6[._]');
 
 bool isTtuPerBookFileName(String fileName) =>
     _ttuPerBookFilePattern.hasMatch(fileName);

--- a/hibiki/lib/src/sync/webdav_sync_backend.dart
+++ b/hibiki/lib/src/sync/webdav_sync_backend.dart
@@ -103,7 +103,11 @@ class WebDavSyncBackend extends SyncBackend {
     final sanitized = requireBookFolderName(bookTitle);
 
     if (_titleToFolderId.containsKey(sanitized)) {
-      return _titleToFolderId[sanitized]!;
+      // A cached id may have entered slash-less from a server PROPFIND href
+      // (some WebDAV servers omit the trailing slash on collection hrefs).
+      // Normalize on return so `folderId + fileName` never fuses the file into
+      // the root as `<title>audioBook_…` (BUG-845).
+      return ensureFolderIdTrailingSlash(_titleToFolderId[sanitized]!);
     }
 
     final path = '$rootFolderId${Uri.encodeComponent(sanitized)}/';
@@ -285,9 +289,15 @@ class WebDavSyncBackend extends SyncBackend {
     String? rootFolderId,
     Map<String, String>? titleToFolderId,
   }) {
-    _rootFolderId = rootFolderId;
+    // Persisted ids may have been stored slash-less (from a server href); heal
+    // them on load so every cached folderId ends with `/` (BUG-845).
+    _rootFolderId = rootFolderId == null
+        ? null
+        : ensureFolderIdTrailingSlash(rootFolderId);
     if (titleToFolderId != null) {
-      _titleToFolderId.addAll(titleToFolderId);
+      titleToFolderId.forEach((title, id) {
+        _titleToFolderId[title] = ensureFolderIdTrailingSlash(id);
+      });
     }
   }
 
@@ -300,7 +310,11 @@ class WebDavSyncBackend extends SyncBackend {
   @override
   void cacheBookFolderIds(List<DriveFile> folders) {
     for (final f in folders) {
-      _titleToFolderId[f.name] = f.id;
+      // listBooks maps DriveFile.id = the server's collection href, which some
+      // WebDAV servers return WITHOUT a trailing slash. Normalize before caching
+      // so a later `folderId + fileName` write cannot spill into the root
+      // (BUG-845).
+      _titleToFolderId[f.name] = ensureFolderIdTrailingSlash(f.id);
     }
   }
 
@@ -308,7 +322,9 @@ class WebDavSyncBackend extends SyncBackend {
   void evictFolderId(String folderId) {
     // 按值反查逐出书名→folderId 缓存里指向 [folderId] 的条目，消除删书后陈旧态
     // （BUG-202）。路径式后端的 folderId 是按名派生的路径，逐出仍是廉价正确性。
-    _titleToFolderId.removeWhere((_, id) => id == folderId);
+    // 缓存值已统一规范化为带尾斜杠（BUG-845），入参也归一后再比，避免尾斜杠差异漏逐出。
+    final normalized = ensureFolderIdTrailingSlash(folderId);
+    _titleToFolderId.removeWhere((_, id) => id == normalized);
   }
 
   // ── SyncAssetStore ────────────────────────────────────────────────

--- a/hibiki/test/sync/sync_folder_id_slash_test.dart
+++ b/hibiki/test/sync/sync_folder_id_slash_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/hibiki_client_sync_backend.dart';
+import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/ttu_filename.dart';
+import 'package:hibiki/src/sync/ttu_models.dart';
+import 'package:hibiki/src/sync/webdav_sync_backend.dart';
+
+// BUG-845: a path-style backend addresses a child file as `folderId + fileName`
+// with NO separator (see WebDavOps.uploadJson). A per-book folderId therefore
+// MUST end with `/`. `ensureBookFolder` appends it when it CREATES a folder, but
+// ids also enter the cache from server PROPFIND hrefs
+// (cacheBookFolderIds / restoreCache), and some WebDAV servers (Nutstore/坚果云)
+// return collection hrefs WITHOUT a trailing slash. A slash-less cached id made
+// `folderId + audioBookFileName(...)` fuse into `<root>/<title>audioBook_…` —
+// spilling the file into the sync ROOT with the title glued to the file name,
+// while updateAudioBookFile deleted the correct in-folder copy. These tests pin
+// the invariant "every cached folderId ends with `/`", enforced at
+// `ensureFolderIdTrailingSlash` on every cache-population site.
+
+/// A slash-less collection href, exactly as a Nutstore-style server returns it.
+const String _rootId = 'https://dav.example.com/hibiki-data/';
+const String _slashlessBookHref = 'https://dav.example.com/hibiki-data/屍人荘の殺人';
+
+void main() {
+  group('ensureFolderIdTrailingSlash', () {
+    test('appends a missing slash and leaves an existing one', () {
+      expect(ensureFolderIdTrailingSlash(_slashlessBookHref), '$_slashlessBookHref/');
+      expect(ensureFolderIdTrailingSlash('$_slashlessBookHref/'),
+          '$_slashlessBookHref/');
+    });
+  });
+
+  group('WebDavSyncBackend folderId trailing-slash invariant', () {
+    final WebDavSyncBackend backend = WebDavSyncBackend.instance;
+    setUp(backend.clearCache);
+    tearDown(backend.clearCache);
+
+    test('cacheBookFolderIds normalizes a slash-less server href', () {
+      backend.cacheBookFolderIds(
+          const [DriveFile(id: _slashlessBookHref, name: '屍人荘の殺人')]);
+      expect(backend.cachedFolderIds['屍人荘の殺人'], '$_slashlessBookHref/');
+    });
+
+    test('restoreCache heals a slash-less persisted id and root id', () {
+      backend.restoreCache(
+        rootFolderId: 'https://dav.example.com/hibiki-data',
+        titleToFolderId: const {'屍人荘の殺人': _slashlessBookHref},
+      );
+      expect(backend.cachedRootFolderId, 'https://dav.example.com/hibiki-data/');
+      expect(backend.cachedFolderIds['屍人荘の殺人'], '$_slashlessBookHref/');
+    });
+
+    test(
+        'ensureBookFolder cache-hit returns a slashed id so the write lands '
+        'in-folder, not fused into the root', () async {
+      // Seed the cache the way a compare/list flow does — with a raw href.
+      backend.cacheBookFolderIds(
+          const [DriveFile(id: _slashlessBookHref, name: '屍人荘の殺人')]);
+
+      final String folderId = await backend.ensureBookFolder(
+        bookTitle: '屍人荘の殺人',
+        rootFolderId: _rootId,
+      );
+      expect(folderId, endsWith('/'),
+          reason: 'a folderId used as a bare path prefix must end with `/`');
+
+      // Reproduce WebDavOps.uploadJson's join (Uri.encodeComponent adds no
+      // slashes, so a plain concat models the path shape).
+      final String fileName = audioBookFileName(1705944232500, 123.45);
+      final String writePath = '$folderId$fileName';
+      expect(writePath, endsWith('/$fileName'),
+          reason: 'the file must be a CHILD of the book folder');
+      expect(writePath.contains('屍人荘の殺人$fileName'), isFalse,
+          reason: 'the title must not fuse onto the file name (root spill)');
+    });
+  });
+
+  group('HibikiClientSyncBackend folderId trailing-slash invariant', () {
+    final HibikiClientSyncBackend backend = HibikiClientSyncBackend.instance;
+    setUp(backend.clearCache);
+    tearDown(backend.clearCache);
+
+    test('cacheBookFolderIds + ensureBookFolder cache-hit stay slashed',
+        () async {
+      backend.cacheBookFolderIds(
+          const [DriveFile(id: _slashlessBookHref, name: '屍人荘の殺人')]);
+      expect(backend.cachedFolderIds['屍人荘の殺人'], '$_slashlessBookHref/');
+
+      final String folderId = await backend.ensureBookFolder(
+        bookTitle: '屍人荘の殺人',
+        rootFolderId: _rootId,
+      );
+      expect(folderId, endsWith('/'));
+    });
+
+    test('restoreCache heals slash-less persisted ids', () {
+      backend.restoreCache(
+        rootFolderId: 'https://dav.example.com/hibiki-data',
+        titleToFolderId: const {'屍人荘の殺人': _slashlessBookHref},
+      );
+      expect(backend.cachedRootFolderId, 'https://dav.example.com/hibiki-data/');
+      expect(backend.cachedFolderIds['屍人荘の殺人'], '$_slashlessBookHref/');
+    });
+  });
+}

--- a/hibiki/test/sync/sync_root_spill_prune_test.dart
+++ b/hibiki/test/sync/sync_root_spill_prune_test.dart
@@ -53,6 +53,22 @@ void main() {
       expect(isTtuPerBookFileName('progress_2_0_x.json'), isFalse);
       expect(isTtuPerBookFileName('progression.json'), isFalse);
     });
+
+    test('matches title-PREFIXED spill (slash-less folderId fusion, BUG-845)',
+        () {
+      // A book folderId cached without its trailing slash fuses the file name
+      // onto the title: `<root>/屍人荘の殺人` + `audioBook_1_6_….json` becomes a
+      // root-level `屍人荘の殺人audioBook_1_6_….json`. The marker is matched
+      // anywhere in the name, so these are swept too.
+      expect(isTtuPerBookFileName('屍人荘の殺人$_spilledAudioBook'), isTrue);
+      expect(isTtuPerBookFileName('屍人荘の殺人$_spilledProgress'), isTrue);
+      expect(isTtuPerBookFileName('屍人荘の殺人$_spilledStatistics'), isTrue);
+      expect(isTtuPerBookFileName('屍人荘の殺人$_spilledCover'), isTrue);
+      // A title with punctuation still fuses and is still caught.
+      expect(isTtuPerBookFileName('A B.C!cover_1_6.png'), isTrue);
+      // But a bare title with no fused marker is still safe.
+      expect(isTtuPerBookFileName('屍人荘の殺人progression.json'), isFalse);
+    });
   });
 
   group('SyncOrchestrator.pruneRootSpill', () {
@@ -135,6 +151,55 @@ void main() {
           await store.findAsset('root/屍人荘の殺人', _spilledProgress);
       expect(nested, isNotNull,
           reason: 'a per-book file inside its own folder is legitimate');
+    });
+
+    test('sweeps title-PREFIXED spill while keeping the book folder (BUG-845)',
+        () async {
+      final FakeAssetStore store = FakeAssetStore();
+      final HibikiDatabase db = _memDb();
+      addTearDown(db.close);
+
+      // The book folder is intact; the slash-less folderId fusion left several
+      // churned title-prefixed audioBook copies as direct root children.
+      await store.ensureFolder('root', '屍人荘の殺人');
+      await seedFile(store, 'root/屍人荘の殺人', _spilledAudioBook);
+      await seedFile(store, 'root', '屍人荘の殺人$_spilledAudioBook');
+      await seedFile(store, 'root',
+          '屍人荘の殺人audioBook_1_6_1700000009999_43.5.json');
+      await seedFile(store, 'root', '屍人荘の殺人$_spilledCover');
+
+      final Directory tmp = Directory('${work.path}/tmp')..createSync();
+      final SyncOrchestrator orchestrator = SyncOrchestrator(
+        db: db,
+        backend: FakeSyncBackend(store),
+        dictionaryResourceRoot: tmp,
+        audioDatabaseRoot: tmp,
+        tempDir: tmp,
+        syncStats: false,
+        syncAudioBookPosition: false,
+        syncContent: false,
+        syncAudioBookFiles: false,
+        syncDictionary: false,
+        syncLocalAudio: false,
+      );
+
+      final SyncRunReport report = SyncRunReport();
+      await orchestrator.pruneRootSpill('root', report);
+
+      expect(report.rootSpillFilesRemoved, 3,
+          reason: 'every title-prefixed root spill copy is swept');
+      expect(report.errors, isEmpty);
+
+      final Set<String> rootNames = (await store.listChildren('root'))
+          .map((AssetEntry e) => e.name)
+          .toSet();
+      // The book folder survives; no title-prefixed spill remains at root.
+      expect(rootNames, contains('屍人荘の殺人'));
+      expect(rootNames.any(isTtuPerBookFileName), isFalse);
+      // The legitimate in-folder file is untouched.
+      final AssetEntry? nested =
+          await store.findAsset('root/屍人荘の殺人', _spilledAudioBook);
+      expect(nested, isNotNull);
     });
 
     test('clean root is a no-op (idempotent)', () async {


### PR DESCRIPTION
## 症状（用户复报 · WebDAV/坚果云）
手机端有声书进度文件同步到「文件夹外」（`hibiki-data/` 根），且把平板端正常同步进书文件夹内的文件清掉；根里堆多份 `屍人荘の殺人audioBook_1_6_<ts>_<pos>.json`（书名前缀+audioBook 连体，97 B）。BUG-619/653 修过「空 title 溢出」，这是**另一条溢出源**。

## 根因
路径式后端子文件地址 = `folderId + fileName`（**无分隔符**，`webdav_ops.dart:222`），故 folderId **必须带尾斜杠**。`ensureBookFolder` 创建时带斜杠，但 folderId 还从 `cacheBookFolderIds`（`listBooks` 的 PROPFIND href）和 `restoreCache`（持久化 `sync_folder_cache`）入缓存——**坚果云等对 collection href 不带尾斜杠**，且命中缓存时原样返回。于是：
1. `uploadJson(folderId, fileName)` 把新 audioBook 写成 `<root>/屍人荘の殺人audioBook_….json`（根·连体·错位）；
2. `updateAudioBookFile` 再删 `listSyncFiles(folder)` 拾到的**对端 in-folder 正常副本**。
churn 名 + 单文件去重 → 根里连体孤儿堆多份（丢很多份）。互联后端 `HibikiClientSyncBackend` 同型。其余后端（ftp/sftp/dropbox 显式 `/`；onedrive/gdrive 不可变 id）安全。
既有 `pruneRootSpill` 用先头锚 `^audioBook_1_6_`，**清不掉**书名前缀残留。

## 修复
- 新增 `ensureFolderIdTrailingSlash`（`sync_backend.dart`），在 WebDav/HibikiClient 三处入缓存点（`cacheBookFolderIds`/`restoreCache`/`ensureBookFolder` 命中返回）归一，令「缓存 folderId 恒带尾斜杠」由构造保证；`restoreCache` 顺带**自愈老用户已污染的持久化缓存**；`evictFolderId` 比较也归一。
- spill 谓词去先头锚（任意位置匹配 `type_1_6[._]`），令 `pruneRootSpill` 同清裸 + 书名前缀两形态残留；`isFolder` 守卫在前，书文件夹/保留 namespace 不误删。

## 测试
- 新 `test/sync/sync_folder_id_slash_test.dart`：纯函数 + 两后端 cache 归一 + 命中返回带斜杠 + 模拟写入落书文件夹内不粘连。
- 扩 `test/sync/sync_root_spill_prune_test.dart`：书名前缀谓词命中/负例 + 掃除用例。
- `flutter analyze` 5 改动文件 0 issue；`flutter test test/sync/{sync_folder_id_slash,sync_root_spill_prune,ttu_filename}_test.dart` 38 例全绿。

## 待验收
真机双设备（WebDAV/坚果云）：进度不再溢出根、书文件夹内文件不被对端删、历史根残留经一次同步被清。

注：`test/sync/sync_settings_visibility_test.dart` 一例在本分支 base（develop `bb66190c3`）即失败（`sync.content` gating，与本改动无关，已 stash 复核）。