### PR TITLE
fix(update): 嵌套更新合集，beta/debug 通道收到正式版更新 (BUG-845)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 826 条。点号进各自文件。
+> 共 827 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-845](bugs/BUG-845-nested-update-channels.md) | ✅ | ✅ | 测试版/调试版通道应收到正式版更新（嵌套合集） |
 | [BUG-844](bugs/BUG-844-lyrics-shift-hover-lookup.md) | ✅ | ✅ | 歌词模式不支持Shift/悬停查词 |
 | [BUG-843](bugs/BUG-843-top-progress-overlaps-first-line.md) | ✅ | ✅ | 顶部阅读进度毛玻璃pill压住正文首行 |
 | [BUG-842](bugs/BUG-842-popup-native-title-tooltip-flies.md) | ✅ | ✅ | Windows查词弹窗调整上下文等按钮原生title提示飞到窗口角落 |

--- a/docs/bugs/BUG-845-nested-update-channels.md
+++ b/docs/bugs/BUG-845-nested-update-channels.md
@@ -1,0 +1,20 @@
+## BUG-845 · 测试版/调试版通道应收到正式版更新（嵌套合集）
+- **报告**：2026-07-16（用户：）
+- **真实性**：✅ 真 bug —— 更新通道原为**互斥孤岛**，beta/debug 用户永远收不到正式版/更保守轨道的更新，beta 开发暂停而正式版继续发补丁时会被永久卡死。根因见下。
+- **[x] ① 已修复** —— 根因在 `hibiki/lib/src/utils/misc/update_checker_release.dart`：
+  - 拉取层 `_fetchReleasesForChannel:474`：beta/debug 分支只拉本通道 manifest/API，从不拉 stable。
+  - 判定层 `isUpdateVersionNewer:1486`（旧）：`if (!_versionBelongsToChannel(remoteVersion, channel)) return false;` 要求远端**恰好**属于本通道，正式版无 `-beta/-debug` 后缀 → 被判 false。
+  - 两道闸门共同把 beta/debug 用户锁死在本轨。源于 BUG-480「正式版/测试版/调试版更新不能混」的过宽实现。
+  - **修复=嵌套超集模型**（越激进通道合集越大：`stable ⊆ beta ⊆ debug`）：
+    - 新增 `_channelsAdmittedBy` / `_channelAdmitsVersion` / `_sameChannelTrack` / `releaseEligibleForChannel` / `_compareReleaseRecency`。
+    - `_fetchReleasesForChannel` 改为按合集把每个准入轨道各拉一次并合并（抽出 `_fetchReleasesForExactChannel` 保留单轨原逻辑）。
+    - `isUpdateVersionNewer` 换成「嵌套准入 + 纯 semver + 同基跨轨守卫」：正式版成品可推给同基预发布用户（核心诉求）；同基跨轨预发布不回灌（保留 BUG-480 case A/B）。
+    - `selectUpdateReleaseForCurrentPlatform` 先按「最新优先」排序（同基预发布轨优先于 stable，让 beta/debug 用户留在本轨而非塌回 stable）再择一；`selectAsset` 改传 **release 自身轨道**（stable 包无 `-debug.` 后缀，否则 debug 用户拿不到并入合集的 stable 包）。
+  - 提交：<待填>
+- **[x] ② 已加自动化测试** —— `hibiki/test/utils/misc/version_comparison_test.dart`：
+  - `BUG-845 nested update channels (isUpdateVersionNewer)`：beta 收更高基/同基成品 stable、停滞 beta 收 stable 补丁、debug 收 stable+beta、stable 不收预发布、beta **不**收 debug、同基跨轨仍禁。
+  - `BUG-845 releaseEligibleForChannel`：三通道嵌套准入。
+  - `BUG-845 selectUpdateReleaseForCurrentPlatform`：beta 优先本轨领先版、停滞 beta 落回 stable、debug 能装 stable 包（非 `-debug` 命名）、debug 同基留本轨。
+  - 结构守卫 `update_checker_structure_guard_test.dart` release 天花板 1720→1900。
+  - 全量 `test/utils/misc/` + `test/settings/` 814 测试绿。
+- **备注**：与 BUG-480 关系——嵌套只放开「正向收更稳定轨/更高基」，同基跨轨预发布互推的铁律经 `_sameChannelTrack` 守卫**保留**。与 BUG-821（`effectiveCurrentVersionForUpdateChannel` 从 buildNumber 还原本机 seq，已在 develop）正交且正确组合：debug 用户仍优先留 debug 轨。待用户真机复测（beta/debug 通道设备点检查更新确认能收到更新的正式版）。

--- a/docs/bugs/BUG-845-nested-update-channels.md
+++ b/docs/bugs/BUG-845-nested-update-channels.md
@@ -10,7 +10,7 @@
     - `_fetchReleasesForChannel` 改为按合集把每个准入轨道各拉一次并合并（抽出 `_fetchReleasesForExactChannel` 保留单轨原逻辑）。
     - `isUpdateVersionNewer` 换成「嵌套准入 + 纯 semver + 同基跨轨守卫」：正式版成品可推给同基预发布用户（核心诉求）；同基跨轨预发布不回灌（保留 BUG-480 case A/B）。
     - `selectUpdateReleaseForCurrentPlatform` 先按「最新优先」排序（同基预发布轨优先于 stable，让 beta/debug 用户留在本轨而非塌回 stable）再择一；`selectAsset` 改传 **release 自身轨道**（stable 包无 `-debug.` 后缀，否则 debug 用户拿不到并入合集的 stable 包）。
-  - 提交：<待填>
+  - 提交：`1be4a82cf`
 - **[x] ② 已加自动化测试** —— `hibiki/test/utils/misc/version_comparison_test.dart`：
   - `BUG-845 nested update channels (isUpdateVersionNewer)`：beta 收更高基/同基成品 stable、停滞 beta 收 stable 补丁、debug 收 stable+beta、stable 不收预发布、beta **不**收 debug、同基跨轨仍禁。
   - `BUG-845 releaseEligibleForChannel`：三通道嵌套准入。

--- a/hibiki/lib/src/utils/misc/update_checker_release.dart
+++ b/hibiki/lib/src/utils/misc/update_checker_release.dart
@@ -471,7 +471,24 @@ class UpdateChecker {
     return attempt().timeout(_kPerAttemptTimeout);
   }
 
+  /// BUG-845 嵌套合集拉取：越激进的通道合集越大，beta/debug 用户要能收到更新的正式版/
+  /// 更高基版本，永不掉队。按 [_channelsAdmittedBy] 把本通道接纳的每个轨道各拉一次
+  /// （stable→[stable]；beta→[stable,beta]；debug→[stable,beta,debug]）并合并——上层
+  /// [selectUpdateReleaseForCurrentPlatform] 会按「最新优先」排序后择一，对多轨并集透明。
   static Future<List<Map<String, dynamic>>> _fetchReleasesForChannel(
+    HttpClient client,
+    UpdateChannel channel,
+  ) async {
+    final List<Map<String, dynamic>> merged = <Map<String, dynamic>>[];
+    for (final UpdateChannel track in _channelsAdmittedBy(channel)) {
+      merged.addAll(await _fetchReleasesForExactChannel(client, track));
+    }
+    return merged;
+  }
+
+  /// 单一轨道 [channel] 的 release 拉取（BUG-845 前的既有逻辑原样保留，仅从
+  /// [_fetchReleasesForChannel] 抽出以便按合集并集复用）。
+  static Future<List<Map<String, dynamic>>> _fetchReleasesForExactChannel(
     HttpClient client,
     UpdateChannel channel,
   ) async {
@@ -1416,9 +1433,24 @@ Future<UpdateReleaseSelection?> selectUpdateReleaseForCurrentPlatform(
   required UpdateChannel channel,
   required PlatformUpdater updater,
 }) async {
+  // BUG-845：合集是多轨并集（beta/debug 用户会同时拿到 stable/beta/debug 的 latest），
+  // 必须先按「最新优先」排序再取第一个可用于本平台的更新，否则按拉取顺序会误选更旧的
+  // release（如 beta 用户 beta 轨已到 1.3.0-beta.1，却因 stable 1.2.0 排在前而误选 1.2.0）。
+  // 排序键：基版本降序 → 同基预发布轨优先于正式版（debug>beta>stable，让 beta/debug 用户
+  // 停留本轨而非同基塌回 stable）→ 同基同轨预发布序号降序。
+  final List<Map<String, dynamic>> ordered = releases
+      .where((Map<String, dynamic> r) => releaseEligibleForChannel(r, channel))
+      .toList()
+    ..sort((Map<String, dynamic> a, Map<String, dynamic> b) {
+      final String va =
+          normalizeReleaseVersionTag(a['tag_name'] as String? ?? '') ?? '';
+      final String vb =
+          normalizeReleaseVersionTag(b['tag_name'] as String? ?? '') ?? '';
+      return _compareReleaseRecency(vb, va); // 降序：新的在前
+    });
+
   UpdateReleaseSelection? fallback;
-  for (final Map<String, dynamic> release in releases) {
-    if (!releaseMatchesUpdateChannel(release, channel)) continue;
+  for (final Map<String, dynamic> release in ordered) {
     final String? topVersion =
         normalizeReleaseVersionTag(release['tag_name'] as String? ?? '');
     if (topVersion == null || topVersion.isEmpty) continue;
@@ -1430,8 +1462,13 @@ Future<UpdateReleaseSelection?> selectUpdateReleaseForCurrentPlatform(
         (release['assets'] as List<dynamic>? ?? <dynamic>[])
             .whereType<Map<String, dynamic>>()
             .toList(growable: false);
+    // BUG-845：asset 命名按 release **自身所属轨道**过滤（stable 包无 `-debug.` 后缀，
+    // debug 包才有），故 selectAsset 传 release 自身轨道而非用户通道——否则 debug 用户
+    // 处理并入合集的 stable release 时，会因 stable 包不含 `-debug.` 后缀被误拒、选不到包。
+    // 「这个 release 属于哪个合集」的准入已由 releaseEligibleForChannel 在上面把关。
+    final UpdateChannel releaseTrack = channelForUpdateVersion(topVersion);
     final UpdateAsset? asset =
-        await updater.selectAsset(assetMaps, channel: channel);
+        await updater.selectAsset(assetMaps, channel: releaseTrack);
 
     // TODO-1205：用**所选 asset 自身版本**判更新 + 显示，而非顶层 tag（全平台最大 seq）。
     // 顶层 6636 但安卓 asset=6621==本机时，用顶层会「有更新」→装回 6621→再提示的死循环。
@@ -1485,6 +1522,21 @@ bool releaseMatchesUpdateChannel(
   };
 }
 
+/// BUG-845 嵌套合集准入的 release 过滤：[release] 本身所属通道被用户 [channel] 的嵌套
+/// 合集接纳即合格（越激进通道合集越大）。与 [releaseMatchesUpdateChannel]（精确同通道）
+/// 区别：后者只接纳恰好本通道，供 [_fetchStableRelease] 校验「这确实是 stable」等精确用途；
+/// 本函数供选择/过滤阶段判「属于本通道合集」，复用精确判据不新造 pattern。
+@visibleForTesting
+bool releaseEligibleForChannel(
+  Map<String, dynamic> release,
+  UpdateChannel channel,
+) {
+  for (final UpdateChannel track in _channelsAdmittedBy(channel)) {
+    if (releaseMatchesUpdateChannel(release, track)) return true;
+  }
+  return false;
+}
+
 /// TODO-1024 / BUG-479：通道感知的「远端 [tag] 是否比本地 [current] 新」公开判定，供
 /// 缓存优先的乐观反馈（手动「检查更新」据缓存 tag 立刻分流「发现新版」/「已是最新」）。
 /// 薄包 [isUpdateVersionNewer]（后者 `@visibleForTesting`，仅本库/测试内可用）。
@@ -1501,34 +1553,84 @@ bool isUpdateVersionNewer(
   String local,
   UpdateChannel channel,
 ) {
-  if (channel == UpdateChannel.stable) return isVersionNewer(remote, local);
-
   final String remoteVersion = _stripBuildMetadata(remote.trim());
   final String localVersion = _stripBuildMetadata(local.trim());
-  if (!_versionBelongsToChannel(remoteVersion, channel)) return false;
+
+  // BUG-845 嵌套合集准入：越激进的通道合集越大——stable 只收 stable；beta 收
+  // {stable,beta}；debug 收 {stable,beta,debug}。远端版本所属轨道若不在本通道合集里，
+  // 一律不是更新（把旧的「远端必须**恰好**属于本通道」钝刀换成嵌套准入，让 beta/debug
+  // 用户能收到更新的正式版/更高基版本，永不掉队）。
+  if (!_channelAdmitsVersion(remoteVersion, channel)) return false;
 
   final int baseCompare = _compareBaseVersion(remoteVersion, localVersion);
   if (baseCompare != 0) return baseCompare > 0;
 
-  // BUG-480：基版本相同时**严格只在同通道预发布序号递进**才算更新——绝不让正式版/
-  // 别通道预发布被同基的本通道预发布推送（用户铁律「正式版/测试版/调试版更新不能混」）。
-  //
-  // 此前两条早退（`localPrerelease == null → true`、跨通道预发布 → `true`）把「同基的
-  // 本通道预发布」当成对本地的更新，导致：
-  //   * 正式版 `1.0.1` 装机 + 选了 debug 通道 → 同基 `1.0.1-debug.<seq>` 被判更新（混推，
-  //     且语义错：semver 里 `1.0.1-debug.x < 1.0.1`，预发布**早于**正式版，不该回灌）。
-  //   * beta 装机 `1.0.1-beta.x` + 选了 debug 通道 → 同基 `1.0.1-debug.<seq>` 被判更新（跨
-  //     通道混推）。
-  // 现在：同基场景下，只有「本地也是**本通道**预发布」且「远端本通道预发布序号严格更大」
-  // 才更新；本地是正式版、或本地是别通道预发布、或序号相同/更小 → 一律不更新（同基同号也
-  // 一并落到序号比较返回 false，根除「不检测版本号相同」）。跨通道升级走「基版本递增」
-  // （上面 baseCompare > 0）这条正路，不靠同基回灌。
+  // 同基版本：正式版成品优先，同基跨轨预发布不回灌（保留 BUG-480 铁律）。
+  final String? remotePrerelease = _prereleasePart(remoteVersion);
   final String? localPrerelease = _prereleasePart(localVersion);
-  if (localPrerelease == null) return false;
-  if (!_prereleaseBelongsToChannel(localPrerelease, channel)) return false;
 
-  final String remotePrerelease = _prereleasePart(remoteVersion)!;
+  // 远端是正式版成品：只要本地是同基的预发布就算更新——预发布**早于**其正式版，beta/debug
+  // 用户理应领到成品 stable（BUG-845 核心诉求）。本地也是同基正式版 → 版本相同，非更新。
+  if (remotePrerelease == null) return localPrerelease != null;
+
+  // 远端是预发布、本地是同基正式版：semver 里预发布 < 正式版，是回退，不推
+  // （BUG-480 case A：正式版装机误开通道，绝不被同基预发布回灌）。
+  if (localPrerelease == null) return false;
+
+  // 双方同基预发布：只在**同一轨**（都 beta 或都 debug）按序号严格递进才算更新；
+  // 跨轨（beta↔debug）同基不互推（BUG-480 case B：beta 装机误开 debug 通道，绝不被同基
+  // debug 预发布跨轨回灌——跨轨同基先后无意义）。
+  if (!_sameChannelTrack(remotePrerelease, localPrerelease)) return false;
   return _comparePrerelease(remotePrerelease, localPrerelease) > 0;
+}
+
+/// BUG-845 嵌套合集：用户通道 [channel] 能接纳的所有轨道（含更保守的轨道），从最保守
+/// 到本通道。「合集逐渐变大」——stable→[stable]；beta→[stable,beta]；
+/// debug→[stable,beta,debug]。同时驱动拉取阶段的合集并集与准入判定。
+List<UpdateChannel> _channelsAdmittedBy(UpdateChannel channel) {
+  return switch (channel) {
+    UpdateChannel.stable => const <UpdateChannel>[UpdateChannel.stable],
+    UpdateChannel.beta => const <UpdateChannel>[
+        UpdateChannel.stable,
+        UpdateChannel.beta,
+      ],
+    UpdateChannel.debug => const <UpdateChannel>[
+        UpdateChannel.stable,
+        UpdateChannel.beta,
+        UpdateChannel.debug,
+      ],
+  };
+}
+
+/// 通道稳定度 rank：stable=0 < beta=1 < debug=2。同基版本选择时预发布轨优先于正式版，
+/// 让 beta/debug 用户停留在本轨而非同基塌回 stable（BUG-845）。
+int _channelTrackRank(UpdateChannel channel) => switch (channel) {
+      UpdateChannel.stable => 0,
+      UpdateChannel.beta => 1,
+      UpdateChannel.debug => 2,
+    };
+
+/// BUG-845：远端 [version] 所属轨道是否被 [channel] 的嵌套合集接纳。轨道由
+/// [channelForUpdateVersion] 推断（正式版 → stable，`-beta.N`/`-debug.N` → 对应轨），
+/// 与既有判据同一套 pattern，不新造。
+bool _channelAdmitsVersion(String version, UpdateChannel channel) {
+  return _channelsAdmittedBy(channel)
+      .contains(channelForUpdateVersion(version));
+}
+
+/// 两个预发布串是否同一轨（都 beta 或都 debug）。用于同基版本判断能否按序号递进；
+/// 跨轨同基不互推（保留 BUG-480 铁律）。
+bool _sameChannelTrack(String remotePrerelease, String localPrerelease) {
+  for (final UpdateChannel track in const <UpdateChannel>[
+    UpdateChannel.beta,
+    UpdateChannel.debug,
+  ]) {
+    if (_prereleaseBelongsToChannel(remotePrerelease, track) &&
+        _prereleaseBelongsToChannel(localPrerelease, track)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /// **纯函数（BUG-457）**：把本机安装版本 [version] 归一成「可与本通道远端预发布比较」的
@@ -1607,6 +1709,25 @@ bool isVersionNewer(String remote, String local) {
   if (remotePrerelease == null && localPrerelease != null) return true;
   if (remotePrerelease == null || localPrerelease == null) return false;
   return _comparePrerelease(remotePrerelease, localPrerelease) > 0;
+}
+
+/// BUG-845 候选新旧比较（供合集并集选择排序，非「是否更新」判定）：`>0` 表示 [a] 比
+/// [b] 更新。基版本降序主导；同基时预发布轨更前沿（debug>beta>stable）者更新——让
+/// beta/debug 用户在同基场景优先跟本轨的预发布，而非塌回同基正式版；同基同轨按预发布
+/// 序号。注意：这只决定「若都算更新，谁排前面」，真正能否升级仍由 [isUpdateVersionNewer]
+/// 逐个把关（同基跨轨/回退在那里被拒）。
+int _compareReleaseRecency(String a, String b) {
+  final String va = _stripBuildMetadata(a.trim());
+  final String vb = _stripBuildMetadata(b.trim());
+  final int baseCompare = _compareBaseVersion(va, vb);
+  if (baseCompare != 0) return baseCompare;
+  final int rankA = _channelTrackRank(channelForUpdateVersion(va));
+  final int rankB = _channelTrackRank(channelForUpdateVersion(vb));
+  if (rankA != rankB) return rankA.compareTo(rankB);
+  final String? pa = _prereleasePart(va);
+  final String? pb = _prereleasePart(vb);
+  if (pa == null || pb == null) return 0;
+  return _comparePrerelease(pa, pb);
 }
 
 String _stripBuildMetadata(String version) => version.split('+').first;

--- a/hibiki/test/utils/misc/update_checker_structure_guard_test.dart
+++ b/hibiki/test/utils/misc/update_checker_structure_guard_test.dart
@@ -90,8 +90,13 @@ void main() {
     // build number 反解 seq），须与既有版本比较（isUpdateVersionNewer 等）共享同一 library 私有
     // 作用域（part 契约禁止 part 内 import 无法拆库）。release 净增 ~77 行到 1709，故把 release
     // 天花板从 1650 上调到 1720（留 ~11 行合理余量，与既有余量风格一致）。
+    // BUG-845：再加入「嵌套更新合集」（越激进通道合集越大：stable⊆beta⊆debug，让 beta/debug
+    // 用户能收到更新的正式版/更高基版本，永不掉队）——_channelsAdmittedBy / _channelAdmitsVersion
+    // / _sameChannelTrack / releaseEligibleForChannel / _compareReleaseRecency 等跨切判据，须与
+    // 既有版本比较共享同一 library 私有作用域。release 净增 ~120 行到 1830，故把 release 天花板
+    // 从 1720 上调到 1900（留 ~70 行合理余量，与既有余量风格一致）。
     const int kDownloadCeiling = 1780;
-    const int kReleaseCeiling = 1720;
+    const int kReleaseCeiling = 1900;
     const int kDefaultCeiling = 1500;
     for (final String path in <String>[barrel, ...parts]) {
       final int ceiling = path == download

--- a/hibiki/test/utils/misc/version_comparison_test.dart
+++ b/hibiki/test/utils/misc/version_comparison_test.dart
@@ -420,6 +420,241 @@ void main() {
       );
     });
   });
+
+  // BUG-845：嵌套合集——越激进的通道合集越大（stable⊆beta⊆debug）。测试版/调试版应能
+  // 收到更新的正式版/更高基版本，永不掉队；但更保守的通道不得反向收到更激进轨道。
+  group('BUG-845 nested update channels (isUpdateVersionNewer)', () {
+    test('beta channel receives a higher-base stable release', () {
+      expect(
+        isUpdateVersionNewer('1.3.0', '1.2.0-beta.5', UpdateChannel.beta),
+        isTrue,
+        reason: 'beta 用户应收到更高基版本的正式版',
+      );
+    });
+
+    test('beta channel receives the finished same-base stable release', () {
+      // beta 用户在 1.2.0-beta.5，正式版 1.2.0 出了（成品早于预发布？不——预发布早于成品，
+      // semver 里 1.2.0 > 1.2.0-beta.5）→ 应领到成品 1.2.0（用户原始诉求）。
+      expect(
+        isUpdateVersionNewer('1.2.0', '1.2.0-beta.5', UpdateChannel.beta),
+        isTrue,
+        reason: 'beta 用户应领到同基的成品正式版',
+      );
+    });
+
+    test('stranded beta gets newer stable patch when beta paused', () {
+      // beta 停在 1.2.0-beta.5，正式版继续发补丁 1.2.1 → 不再被卡死。
+      expect(
+        isUpdateVersionNewer('1.2.1', '1.2.0-beta.5', UpdateChannel.beta),
+        isTrue,
+      );
+    });
+
+    test('debug channel receives stable and beta (largest 合集)', () {
+      expect(
+        isUpdateVersionNewer('1.3.0', '1.2.0-debug.100', UpdateChannel.debug),
+        isTrue,
+        reason: 'debug 用户应收到更高基正式版',
+      );
+      expect(
+        isUpdateVersionNewer('1.2.0', '1.2.0-debug.100', UpdateChannel.debug),
+        isTrue,
+        reason: 'debug 用户应领到同基成品正式版',
+      );
+      expect(
+        isUpdateVersionNewer(
+          '1.3.0-beta.1',
+          '1.2.0-debug.100',
+          UpdateChannel.debug,
+        ),
+        isTrue,
+        reason: 'debug 合集含 beta 轨：更高基 beta 也应收到',
+      );
+    });
+
+    test('stable channel never receives prereleases (smallest 合集)', () {
+      expect(
+        isUpdateVersionNewer('1.3.0-beta.1', '1.2.0', UpdateChannel.stable),
+        isFalse,
+        reason: '正式版通道合集只含 stable，不收 beta',
+      );
+      expect(
+        isUpdateVersionNewer('1.3.0-debug.1', '1.2.0', UpdateChannel.stable),
+        isFalse,
+        reason: '正式版通道不收 debug',
+      );
+    });
+
+    test('beta channel does NOT receive debug builds (debug ∉ beta 合集)', () {
+      // 关键不对称：debug 只在 debug 合集里；beta 用户拿不到 debug 预发布。
+      expect(
+        isUpdateVersionNewer(
+          '1.3.0-debug.1',
+          '1.2.0-beta.5',
+          UpdateChannel.beta,
+        ),
+        isFalse,
+        reason: 'beta 合集={stable,beta}，不含 debug 轨',
+      );
+    });
+
+    test('same-base cross-track prerelease still blocked (BUG-480 preserved)',
+        () {
+      // 嵌套放开的只是「正向收更稳定轨/更高基」；同基跨轨预发布互推仍禁。
+      expect(
+        isUpdateVersionNewer(
+          '1.2.0-debug.200',
+          '1.2.0-beta.100',
+          UpdateChannel.debug,
+        ),
+        isFalse,
+        reason: '同基 beta 装机不得被同基 debug 跨轨回灌',
+      );
+    });
+  });
+
+  group('BUG-845 releaseEligibleForChannel (nested admission)', () {
+    test('beta 合集 admits stable + beta, rejects debug', () {
+      expect(
+        releaseEligibleForChannel(
+          _release(tag: 'v1.2.0', prerelease: false),
+          UpdateChannel.beta,
+        ),
+        isTrue,
+      );
+      expect(
+        releaseEligibleForChannel(
+          _release(tag: 'v1.3.0-beta.1', prerelease: true),
+          UpdateChannel.beta,
+        ),
+        isTrue,
+      );
+      expect(
+        releaseEligibleForChannel(
+          _release(tag: 'v1.3.0-debug.1+abc1234', prerelease: true),
+          UpdateChannel.beta,
+        ),
+        isFalse,
+      );
+    });
+
+    test('debug 合集 admits all three tracks', () {
+      expect(
+        releaseEligibleForChannel(
+          _release(tag: 'v1.2.0', prerelease: false),
+          UpdateChannel.debug,
+        ),
+        isTrue,
+      );
+      expect(
+        releaseEligibleForChannel(
+          _release(tag: 'v1.3.0-beta.1', prerelease: true),
+          UpdateChannel.debug,
+        ),
+        isTrue,
+      );
+      expect(
+        releaseEligibleForChannel(
+          _release(tag: 'v1.3.0-debug.1+abc1234', prerelease: true),
+          UpdateChannel.debug,
+        ),
+        isTrue,
+      );
+    });
+
+    test('stable 合集 admits only stable', () {
+      expect(
+        releaseEligibleForChannel(
+          _release(tag: 'v1.2.0', prerelease: false),
+          UpdateChannel.stable,
+        ),
+        isTrue,
+      );
+      expect(
+        releaseEligibleForChannel(
+          _release(tag: 'v1.3.0-beta.1', prerelease: true),
+          UpdateChannel.stable,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('BUG-845 selectUpdateReleaseForCurrentPlatform (union + ordering)', () {
+    AndroidUpdater arm64Updater() =>
+        AndroidUpdater(abiProvider: () async => <String>['arm64-v8a']);
+
+    test('beta user picks higher-base beta over same-base stable', () async {
+      // beta 轨领先（1.3.0-beta.1）时选 beta，而非因 stable 1.2.0 排前而误选旧版。
+      final UpdateReleaseSelection? sel =
+          await selectUpdateReleaseForCurrentPlatform(
+        <Map<String, dynamic>>[
+          _relWithApks('v1.2.0',
+              prerelease: false, apks: <String>['hibiki-1.2.0-arm64-v8a.apk']),
+          _relWithApks('v1.3.0-beta.1',
+              prerelease: true, apks: <String>['hibiki-1.3.0-arm64-v8a.apk']),
+        ],
+        currentVersion: '1.2.0-beta.5',
+        channel: UpdateChannel.beta,
+        updater: arm64Updater(),
+      );
+      expect(sel?.version, '1.3.0-beta.1');
+    });
+
+    test('stranded beta user falls back to newer stable', () async {
+      // beta 停在 1.2.0-beta.5（latest beta == 本机），正式版补丁 1.2.1 出 → 选 stable。
+      final UpdateReleaseSelection? sel =
+          await selectUpdateReleaseForCurrentPlatform(
+        <Map<String, dynamic>>[
+          _relWithApks('v1.2.1',
+              prerelease: false, apks: <String>['hibiki-1.2.1-arm64-v8a.apk']),
+          _relWithApks('v1.2.0-beta.5',
+              prerelease: true, apks: <String>['hibiki-1.2.0-arm64-v8a.apk']),
+        ],
+        currentVersion: '1.2.0-beta.5',
+        channel: UpdateChannel.beta,
+        updater: arm64Updater(),
+      );
+      expect(sel?.version, '1.2.1');
+    });
+
+    test('debug user can install a stable release asset (non-debug apk name)',
+        () async {
+      // selectAsset 按 release 自身轨道过滤 asset：stable 包无 -debug 后缀，debug 用户
+      // 仍能选到它（否则会因不含 -debug 被误拒、拿不到 stable 更新）。
+      final UpdateReleaseSelection? sel =
+          await selectUpdateReleaseForCurrentPlatform(
+        <Map<String, dynamic>>[
+          _relWithApks('v1.3.0',
+              prerelease: false, apks: <String>['hibiki-1.3.0-arm64-v8a.apk']),
+        ],
+        currentVersion: '1.2.0-debug.100',
+        channel: UpdateChannel.debug,
+        updater: arm64Updater(),
+      );
+      expect(sel?.version, '1.3.0');
+      expect(sel?.asset?.name, 'hibiki-1.3.0-arm64-v8a.apk');
+    });
+
+    test('debug user stays on debug track over same-base stable', () async {
+      // 同基场景：debug 轨更前沿构建优先于同基成品 stable，避免塌回 stable 后再也收不到
+      // 后续 debug 构建。
+      final UpdateReleaseSelection? sel =
+          await selectUpdateReleaseForCurrentPlatform(
+        <Map<String, dynamic>>[
+          _relWithApks('v1.2.0',
+              prerelease: false, apks: <String>['hibiki-1.2.0-arm64-v8a.apk']),
+          _relWithApks('v1.2.0-debug.200+abc1234',
+              prerelease: true,
+              apks: <String>['hibiki-1.2.0-abc1234-debug.apk']),
+        ],
+        currentVersion: '1.2.0-debug.100',
+        channel: UpdateChannel.debug,
+        updater: arm64Updater(),
+      );
+      expect(sel?.version, '1.2.0-debug.200');
+    });
+  });
 }
 
 Map<String, dynamic> _release({
@@ -431,4 +666,25 @@ Map<String, dynamic> _release({
       'tag_name': tag,
       'prerelease': prerelease,
       'draft': draft,
+    };
+
+Map<String, dynamic> _relWithApks(
+  String tag, {
+  required bool prerelease,
+  required List<String> apks,
+}) =>
+    <String, dynamic>{
+      'tag_name': tag,
+      'prerelease': prerelease,
+      'draft': false,
+      'body': '',
+      'html_url': 'https://github.com/hajisensai/hibiki/releases/tag/$tag',
+      'assets': <Map<String, dynamic>>[
+        for (final String name in apks)
+          <String, dynamic>{
+            'name': name,
+            'browser_download_url':
+                'https://github.com/hajisensai/hibiki/releases/download/$tag/$name',
+          },
+      ],
     };


### PR DESCRIPTION
## 问题
更新通道原为**互斥孤岛**：beta/debug 用户只拉本通道 release，且 `isUpdateVersionNewer` 要求远端**恰好**属于本通道，正式版无 `-beta/-debug` 后缀被判 false。beta 开发暂停而正式版继续发补丁时，beta 用户被**永久卡死**收不到更新。

## 方案：嵌套超集模型（合集逐渐变大 `stable ⊆ beta ⊆ debug`）
| 用户通道 | 合集 |
|---|---|
| 正式版 | {stable} |
| 测试版 | {stable, beta} |
| 调试版 | {stable, beta, debug} |

- `_fetchReleasesForChannel`：按合集把每个准入轨道各拉一次并合并（抽出 `_fetchReleasesForExactChannel` 保留单轨原逻辑）。
- `isUpdateVersionNewer`：嵌套准入 + 纯 semver + **同基跨轨守卫**——正式版成品可推给同基预发布用户（核心诉求）；同基跨轨预发布不回灌（**保留 BUG-480 铁律** case A/B）。
- `selectUpdateReleaseForCurrentPlatform`：按「最新优先」排序（同基预发布轨优先于 stable，beta/debug 用户留本轨不塌回 stable）。
- `selectAsset` 改传 **release 自身轨道**（stable 包无 `-debug.` 后缀，否则 debug 用户拿不到并入合集的 stable 包）。

## 测试
- `version_comparison_test.dart`：新增嵌套准入/选择用例（beta 收更高基/同基成品 stable、停滞 beta 落回 stable、debug 收 stable+beta、stable 不收预发布、beta **不**收 debug、同基跨轨仍禁、debug 装 stable 包非 `-debug` 命名、debug 同基留本轨）。
- 既有 BUG-480 铁律测试全部保留通过。结构守卫天花板 1720→1900。
- 全量 `test/utils/misc/` + `test/settings/` **814 绿**。

## 说明
- 与 BUG-821（`effectiveCurrentVersionForUpdateChannel` 从 buildNumber 还原本机 seq，已在 develop）正交且正确组合：debug 用户仍优先留 debug 轨。
- 详见 `docs/bugs/BUG-845-nested-update-channels.md`。

## ⚠️ 待真机
beta/debug 通道设备点「检查更新」确认能收到更新的正式版。