### PR TITLE
feat(settings): 应用内查看更新日志

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39797 (2341 per locale)
+/// Strings: 39865 (2345 per locale)
 ///
-/// Built on 2026-07-15 at 15:20 UTC
+/// Built on 2026-07-16 at 03:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3112,6 +3112,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
           {required Object done, required Object total}) =>
       'Subtitles fetched: ${done}/${total}';
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  String get settings_view_changelog => 'View changelog';
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  String get changelog_open_releases => 'Open releases page';
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -8425,6 +8430,15 @@ class _StringsAr extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -13861,6 +13875,15 @@ class _StringsDe extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -19314,6 +19337,15 @@ class _StringsEs extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -24786,6 +24818,15 @@ class _StringsFr extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -30160,6 +30201,15 @@ class _StringsId extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -35595,6 +35645,15 @@ class _StringsIt extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -40755,6 +40814,15 @@ class _StringsJa extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -45920,6 +45988,15 @@ class _StringsKo extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -51323,6 +51400,15 @@ class _StringsNl extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -56749,6 +56835,15 @@ class _StringsPtBr extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -62150,6 +62245,15 @@ class _StringsRu extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -67464,6 +67568,15 @@ class _StringsTh extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -72833,6 +72946,15 @@ class _StringsTr extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -78177,6 +78299,15 @@ class _StringsVi extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -83150,6 +83281,14 @@ class _StringsZhCn extends _StringsEn {
       '字幕已获取：${done}/${total}';
   @override
   String get anki_open_no_card => '在 Anki 中没有找到这个词的卡片。';
+  @override
+  String get settings_view_changelog => '查看更新日志';
+  @override
+  String get changelog_empty => '未获取到更新日志，请检查网络或代理设置。';
+  @override
+  String get changelog_open_releases => '打开发布页';
+  @override
+  String get changelog_prerelease => '预发布';
 }
 
 // Path: retrying_in
@@ -88212,6 +88351,15 @@ class _StringsZhHk extends _StringsEn {
       'Subtitles fetched: ${done}/${total}';
   @override
   String get anki_open_no_card => 'No card found for this word in Anki.';
+  @override
+  String get settings_view_changelog => 'View changelog';
+  @override
+  String get changelog_empty =>
+      'No changelog found. Check your network or proxy settings.';
+  @override
+  String get changelog_open_releases => 'Open releases page';
+  @override
+  String get changelog_prerelease => 'Prerelease';
 }
 
 // Path: retrying_in
@@ -93039,6 +93187,14 @@ extension on _StringsEn {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -97826,6 +97982,14 @@ extension on _StringsAr {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -102635,6 +102799,14 @@ extension on _StringsDe {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -107442,6 +107614,14 @@ extension on _StringsEs {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -112256,6 +112436,14 @@ extension on _StringsFr {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -117050,6 +117238,14 @@ extension on _StringsId {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -121861,6 +122057,14 @@ extension on _StringsIt {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -126629,6 +126833,14 @@ extension on _StringsJa {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -131401,6 +131613,14 @@ extension on _StringsKo {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -136205,6 +136425,14 @@ extension on _StringsNl {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -141006,6 +141234,14 @@ extension on _StringsPtBr {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -145811,6 +146047,14 @@ extension on _StringsRu {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -150598,6 +150842,14 @@ extension on _StringsTh {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -155394,6 +155646,14 @@ extension on _StringsTr {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -160184,6 +160444,14 @@ extension on _StringsVi {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }
@@ -164938,6 +165206,14 @@ extension on _StringsZhCn {
             '字幕已获取：${done}/${total}';
       case 'anki_open_no_card':
         return '在 Anki 中没有找到这个词的卡片。';
+      case 'settings_view_changelog':
+        return '查看更新日志';
+      case 'changelog_empty':
+        return '未获取到更新日志，请检查网络或代理设置。';
+      case 'changelog_open_releases':
+        return '打开发布页';
+      case 'changelog_prerelease':
+        return '预发布';
       default:
         return null;
     }
@@ -169698,6 +169974,14 @@ extension on _StringsZhHk {
             'Subtitles fetched: ${done}/${total}';
       case 'anki_open_no_card':
         return 'No card found for this word in Anki.';
+      case 'settings_view_changelog':
+        return 'View changelog';
+      case 'changelog_empty':
+        return 'No changelog found. Check your network or proxy settings.';
+      case 'changelog_open_releases':
+        return 'Open releases page';
+      case 'changelog_prerelease':
+        return 'Prerelease';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "为合集获取字幕",
   "video_jimaku_batch_download": "下载全部",
   "video_jimaku_batch_done": "字幕已获取：$done/$total",
-  "anki_open_no_card": "在 Anki 中没有找到这个词的卡片。"
+  "anki_open_no_card": "在 Anki 中没有找到这个词的卡片。",
+  "settings_view_changelog": "查看更新日志",
+  "changelog_empty": "未获取到更新日志，请检查网络或代理设置。",
+  "changelog_open_releases": "打开发布页",
+  "changelog_prerelease": "预发布"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2347,5 +2347,9 @@
   "video_jimaku_batch_title": "Fetch subtitles for collection",
   "video_jimaku_batch_download": "Download all",
   "video_jimaku_batch_done": "Subtitles fetched: $done/$total",
-  "anki_open_no_card": "No card found for this word in Anki."
+  "anki_open_no_card": "No card found for this word in Anki.",
+  "settings_view_changelog": "View changelog",
+  "changelog_empty": "No changelog found. Check your network or proxy settings.",
+  "changelog_open_releases": "Open releases page",
+  "changelog_prerelease": "Prerelease"
 }

--- a/hibiki/lib/pages.dart
+++ b/hibiki/lib/pages.dart
@@ -30,6 +30,7 @@ export 'src/pages/implementations/media_sources_dialog.dart';
 export 'src/pages/implementations/audio_recorder_page.dart';
 export 'src/pages/implementations/switch_settings_page.dart';
 export 'src/pages/implementations/media_item_edit_dialog_page.dart';
+export 'src/pages/implementations/changelog_page.dart';
 export 'src/pages/implementations/crash_dump_page.dart';
 export 'src/pages/implementations/error_log_page.dart';
 export 'src/pages/implementations/debug_log_page.dart';

--- a/hibiki/lib/src/pages/implementations/changelog_page.dart
+++ b/hibiki/lib/src/pages/implementations/changelog_page.dart
@@ -1,0 +1,274 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'package:hibiki/utils.dart';
+
+/// 「查看更新日志」页（TODO-1310）：应用内在线拉取本仓库全部 GitHub releases，
+/// 用 Markdown 渲染每个版本的发布说明（版本号 / 发布日期 / 预发布标记 / 正文）。
+///
+/// 数据经 [fetchAllGitHubReleases] 拉取，复用「检查更新」同一套镜像回退 + 代理注入
+/// + 超时管线。`api.github.com` 列表 API 无镜像/302 逃生口（见该函数注释），纯 GFW
+/// 无代理会拿到空列表——空态给「打开发布页」逃生口。
+///
+/// [customProxy] 由设置页透传（`appModel.updateCustomProxy`），与检查更新同源。
+class ChangelogPage extends StatefulWidget {
+  const ChangelogPage({
+    super.key,
+    this.customProxy = '',
+    this.initialReleases,
+  });
+
+  final String customProxy;
+
+  /// 测试注入口：非 null 时跳过网络拉取，直接以给定列表渲染（widget 测试无法也不该
+  /// 打真实 GitHub API）。生产路径恒为 null，走 [UpdateChecker.fetchAllReleases]。
+  @visibleForTesting
+  final List<Map<String, dynamic>>? initialReleases;
+
+  @override
+  State<ChangelogPage> createState() => _ChangelogPageState();
+}
+
+class _ChangelogPageState extends State<ChangelogPage> {
+  bool _loading = true;
+  List<Map<String, dynamic>> _releases = const <Map<String, dynamic>>[];
+
+  static const String _releasesPageUrl =
+      'https://github.com/$kGitHubRepo/releases';
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.initialReleases != null) {
+      _releases = widget.initialReleases!;
+      _loading = false;
+      return;
+    }
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final List<Map<String, dynamic>> releases =
+        await fetchAllGitHubReleases(customProxy: widget.customProxy);
+    if (!mounted) return;
+    setState(() {
+      _releases = releases;
+      _loading = false;
+    });
+  }
+
+  Future<void> _openReleasesPage() async {
+    await launchUrl(
+      Uri.parse(_releasesPageUrl),
+      mode: LaunchMode.externalApplication,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return HibikiPageScaffold(
+      title: t.settings_view_changelog,
+      actions: <Widget>[
+        HibikiIconButton(
+          icon: Icons.open_in_new_outlined,
+          tooltip: t.changelog_open_releases,
+          onTap: _openReleasesPage,
+        ),
+        HibikiIconButton(
+          icon: Icons.refresh,
+          tooltip: t.refresh,
+          onTap: _loading ? null : _load,
+        ),
+      ],
+      body: _buildBody(context),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_releases.isEmpty) {
+      return _ChangelogEmptyState(
+        onRetry: _load,
+        onOpenReleases: _openReleasesPage,
+      );
+    }
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return ListView.builder(
+      padding: EdgeInsets.all(tokens.spacing.gap),
+      itemCount: _releases.length,
+      itemBuilder: (BuildContext context, int index) {
+        return Padding(
+          padding: EdgeInsets.only(bottom: tokens.spacing.gap),
+          child: _ReleaseCard(release: _releases[index]),
+        );
+      },
+    );
+  }
+}
+
+/// 空态 / 拉取失败：给「重试」与「打开发布页」两个逃生口。
+class _ChangelogEmptyState extends StatelessWidget {
+  const _ChangelogEmptyState({
+    required this.onRetry,
+    required this.onOpenReleases,
+  });
+
+  final VoidCallback onRetry;
+  final VoidCallback onOpenReleases;
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.all(tokens.spacing.card),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.cloud_off_outlined,
+              size: 48,
+              color: Theme.of(context).colorScheme.outline,
+            ),
+            SizedBox(height: tokens.spacing.gap),
+            Text(
+              t.changelog_empty,
+              textAlign: TextAlign.center,
+              style: tokens.type.listSubtitle,
+            ),
+            SizedBox(height: tokens.spacing.card),
+            Wrap(
+              alignment: WrapAlignment.center,
+              spacing: tokens.spacing.gap,
+              runSpacing: tokens.spacing.gap,
+              children: <Widget>[
+                OutlinedButton.icon(
+                  onPressed: onRetry,
+                  icon: const Icon(Icons.refresh),
+                  label: Text(t.retry),
+                ),
+                FilledButton.icon(
+                  onPressed: onOpenReleases,
+                  icon: const Icon(Icons.open_in_new_outlined),
+                  label: Text(t.changelog_open_releases),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 单个版本卡片：版本号 + 通道徽标 + 发布日期 + Markdown 正文。
+class _ReleaseCard extends StatelessWidget {
+  const _ReleaseCard({required this.release});
+
+  final Map<String, dynamic> release;
+
+  /// 发布日期取 `published_at`（ISO8601）的日期段（`YYYY-MM-DD`）；缺失返空串。
+  String get _publishedDate {
+    final Object? raw = release['published_at'];
+    if (raw is! String || raw.isEmpty) return '';
+    final int tIndex = raw.indexOf('T');
+    return tIndex > 0 ? raw.substring(0, tIndex) : raw;
+  }
+
+  /// 是否预发布：直接读 GitHub `prerelease` 字段（beta/debug 通道对"看更新日志"
+  /// 的用户无区分意义，统一显示一个「预发布」徽标即可，不引入内部通道推断逻辑）。
+  bool get _isPrerelease => release['prerelease'] == true;
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final ThemeData theme = Theme.of(context);
+    final Object? tagName = release['tag_name'];
+    final String title =
+        tagName is String && tagName.isNotEmpty ? tagName : '—';
+    final Object? bodyRaw = release['body'];
+    final String body = bodyRaw is String ? bodyRaw.trim() : '';
+    final String date = _publishedDate;
+
+    return HibikiCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Flexible(
+                child: Text(
+                  title,
+                  style: theme.textTheme.titleMedium,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (_isPrerelease) ...<Widget>[
+                SizedBox(width: tokens.spacing.gap / 2),
+                _ChannelBadge(label: t.changelog_prerelease),
+              ],
+            ],
+          ),
+          if (date.isNotEmpty) ...<Widget>[
+            SizedBox(height: tokens.spacing.gap / 4),
+            Text(date, style: tokens.type.metadata),
+          ],
+          if (body.isNotEmpty) ...<Widget>[
+            SizedBox(height: tokens.spacing.gap),
+            MarkdownBody(
+              data: body,
+              selectable: true,
+              // TODO-966: flutter_markdown 0.6.23 在 selectable 时会无条件解引用
+              // onSelectionChanged!，不传则选中文本即崩；补空回调保留可选能力
+              // （与 UpdateAvailableDialog 同一约定）。
+              onSelectionChanged: (String? text, TextSelection selection,
+                  SelectionChangedCause? cause) {},
+              onTapLink: (_, String? href, __) {
+                if (href == null) return;
+                launchUrl(
+                  Uri.parse(href),
+                  mode: LaunchMode.externalApplication,
+                );
+              },
+              styleSheet: MarkdownStyleSheet.fromTheme(theme).copyWith(
+                p: tokens.type.listSubtitle,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ChannelBadge extends StatelessWidget {
+  const _ChannelBadge({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final ColorScheme scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: tokens.spacing.gap / 2,
+        vertical: tokens.spacing.gap / 4,
+      ),
+      decoration: BoxDecoration(
+        color: scheme.secondaryContainer,
+        borderRadius: tokens.radii.chipRadius,
+      ),
+      child: Text(
+        label,
+        style: tokens.type.metadata.copyWith(
+          color: scheme.onSecondaryContainer,
+        ),
+      ),
+    );
+  }
+}

--- a/hibiki/lib/src/settings/settings_schema_system.dart
+++ b/hibiki/lib/src/settings/settings_schema_system.dart
@@ -62,6 +62,22 @@ SettingsDestination buildSystemDestination() {
             icon: Icons.system_update_outlined,
             onTap: _checkUpdateNow,
           ),
+          // TODO-1310：应用内查看更新日志。推 ChangelogPage，在线拉本仓库 GitHub
+          // releases 列表并用 Markdown 渲染各版本说明；customProxy 透传设置里现有的
+          // 更新代理项，与「立即检查更新」同源。
+          SettingsNavigationItem(
+            id: 'system.view_changelog',
+            title: t.settings_view_changelog,
+            icon: Icons.history_outlined,
+            onTap: (SettingsContext settingsContext) async {
+              await pushSettingsPage(
+                settingsContext,
+                (_) => ChangelogPage(
+                  customProxy: settingsContext.appModel.updateCustomProxy,
+                ),
+              );
+            },
+          ),
           SettingsSwitchItem(
             id: 'system.update_never_remind',
             title: t.update_never_remind,

--- a/hibiki/lib/src/utils/misc/update_checker_net.dart
+++ b/hibiki/lib/src/utils/misc/update_checker_net.dart
@@ -780,3 +780,52 @@ UpdateDownloadAttemptFailure? selectRepresentativeDownloadFailure(
   }
   return failures.first;
 }
+
+/// 「更新日志」页数据源（TODO-1310，应用内查看历史发布说明）：拉取本仓库全部
+/// GitHub releases（含各版本 `tag_name` / `published_at` / Markdown `body` /
+/// `prerelease` 标记 / `html_url`），复用与「检查更新」完全相同的私有 HTTP 管线
+/// （[UpdateChecker._httpGetStringFromGitHubRepos]）——自动继承多镜像回退、系统/自定义
+/// 代理注入（[applyUpdateProxy]）、每候选整体超时、`kGitHubRepoFallbacks` 旧库回退。
+/// `draft` 草稿被过滤（未发布，用户不该看到）。
+///
+/// ⚠️ `api.github.com/.../releases` 列表 API 经任何公共 gh 代理都会 403（BUG-292），
+/// 且无 302 网页等价物，故纯 GFW 无代理环境会拿到空列表；网络/解析异常同样收敛为
+/// 空列表（记诊断日志、不抛）。返回空列表对 UI 一律等价于「无数据」，调用方给
+/// 「拉取失败/请检查网络或代理」空态并提供「打开发布页」逃生口即可。
+Future<List<Map<String, dynamic>>> fetchAllGitHubReleases({
+  String customProxy = '',
+  int perPage = 30,
+}) async {
+  final HttpClient client = HttpClient()
+    ..connectionTimeout = const Duration(seconds: 10);
+  try {
+    await applyUpdateProxy(client, userProxy: customProxy);
+    final String? body = await UpdateChecker._httpGetStringFromGitHubRepos(
+      client,
+      (String repo) =>
+          'https://api.github.com/repos/$repo/releases?per_page=$perPage',
+      headers: const <String, String>{'Accept': 'application/vnd.github+json'},
+    );
+    if (body == null) return const <Map<String, dynamic>>[];
+    return parseGitHubReleasesResponse(body);
+  } catch (e, stack) {
+    ErrorLogService.instance.log('fetchAllGitHubReleases', e, stack);
+    return const <Map<String, dynamic>>[];
+  } finally {
+    client.close();
+  }
+}
+
+/// 解析 GitHub `releases` 列表 API 响应体（[fetchAllGitHubReleases] 的纯解析核心，
+/// 抽出便于单测）：期望顶层是 release 对象数组，逐元素保留 `Map`、过滤 `draft==true`
+/// 的草稿；顶层非数组（如错误对象 `{"message":...}`）返回空列表。**不吞 JSON 语法
+/// 错误**——`jsonDecode` 抛出交由调用方的 try 收敛为空列表并记日志。
+@visibleForTesting
+List<Map<String, dynamic>> parseGitHubReleasesResponse(String body) {
+  final dynamic decoded = jsonDecode(body);
+  if (decoded is! List) return const <Map<String, dynamic>>[];
+  return decoded
+      .whereType<Map<String, dynamic>>()
+      .where((Map<String, dynamic> release) => release['draft'] != true)
+      .toList(growable: false);
+}

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+794
+version: 1.2.0+795
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/changelog_page_test.dart
+++ b/hibiki/test/pages/changelog_page_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/pages.dart';
+import 'package:hibiki/utils.dart';
+
+/// TODO-1310：「查看更新日志」页渲染守卫。通过 `initialReleases` 注入口绕开网络，
+/// 验证：① 列表态渲染版本号/日期/预发布徽标/Markdown 正文；② 空态给出提示文案与
+/// 「重试」「打开发布页」两个逃生口。
+void main() {
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+  });
+
+  Widget wrap(Widget home) {
+    return TranslationProvider(
+      child: MaterialApp(home: home),
+    );
+  }
+
+  testWidgets('列表态渲染版本号、日期、预发布徽标与正文', (WidgetTester tester) async {
+    await tester.pumpWidget(wrap(
+      ChangelogPage(
+        initialReleases: const <Map<String, dynamic>>[
+          <String, dynamic>{
+            'tag_name': 'v1.2.0',
+            'published_at': '2026-07-10T08:00:00Z',
+            'prerelease': false,
+            'body': 'Stable release notes body',
+          },
+          <String, dynamic>{
+            'tag_name': 'v1.3.0-beta.1',
+            'published_at': '2026-07-15T09:30:00Z',
+            'prerelease': true,
+            'body': 'Beta notes',
+          },
+        ],
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // 版本号
+    expect(find.text('v1.2.0'), findsOneWidget);
+    expect(find.text('v1.3.0-beta.1'), findsOneWidget);
+    // 发布日期（取 ISO8601 的日期段）
+    expect(find.text('2026-07-10'), findsOneWidget);
+    expect(find.text('2026-07-15'), findsOneWidget);
+    // 预发布徽标：仅 beta 那条有，stable 无 → 恰好一个
+    expect(find.text(t.changelog_prerelease), findsOneWidget);
+    // Markdown 正文（RichText）
+    expect(
+      find.textContaining('Stable release notes body', findRichText: true),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('空列表渲染空态与两个逃生口', (WidgetTester tester) async {
+    await tester.pumpWidget(wrap(
+      const ChangelogPage(initialReleases: <Map<String, dynamic>>[]),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.changelog_empty), findsOneWidget);
+    expect(find.text(t.retry), findsOneWidget);
+    // 空态里的「打开发布页」按钮 + 顶栏图标 tooltip 同文案 → 至少一个
+    expect(find.text(t.changelog_open_releases), findsWidgets);
+    // 未注入网络时不应转圈（initialReleases 非 null 即跳过加载）
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+}

--- a/hibiki/test/utils/misc/update_checker_all_releases_parse_test.dart
+++ b/hibiki/test/utils/misc/update_checker_all_releases_parse_test.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/utils/misc/update_checker.dart';
+
+/// TODO-1310：`fetchAllGitHubReleases` 的纯解析核心 [parseGitHubReleasesResponse]
+/// 守卫——「查看更新日志」页依赖它把 GitHub `releases` 列表 API 响应体转成
+/// release map 列表，过滤草稿、拒绝非数组。
+void main() {
+  group('parseGitHubReleasesResponse', () {
+    test('保留已发布 release 并按原顺序返回', () {
+      final String body = jsonEncode(<Map<String, dynamic>>[
+        <String, dynamic>{
+          'tag_name': 'v1.2.0',
+          'body': '## 新增\n- 更新日志页',
+          'prerelease': false,
+          'draft': false,
+        },
+        <String, dynamic>{
+          'tag_name': 'v1.1.0',
+          'body': '修复若干问题',
+          'prerelease': false,
+          'draft': false,
+        },
+      ]);
+
+      final List<Map<String, dynamic>> releases =
+          parseGitHubReleasesResponse(body);
+
+      expect(releases, hasLength(2));
+      expect(releases[0]['tag_name'], 'v1.2.0');
+      expect(releases[1]['tag_name'], 'v1.1.0');
+    });
+
+    test('过滤 draft==true 的草稿', () {
+      final String body = jsonEncode(<Map<String, dynamic>>[
+        <String, dynamic>{'tag_name': 'v2.0.0-wip', 'draft': true},
+        <String, dynamic>{'tag_name': 'v1.9.0', 'draft': false},
+        <String, dynamic>{'tag_name': 'v1.8.0'},
+      ]);
+
+      final List<Map<String, dynamic>> releases =
+          parseGitHubReleasesResponse(body);
+
+      expect(releases.map((Map<String, dynamic> r) => r['tag_name']),
+          <String>['v1.9.0', 'v1.8.0']);
+    });
+
+    test('顶层非数组（如错误对象）返回空列表', () {
+      final String body =
+          jsonEncode(<String, dynamic>{'message': 'API rate limit exceeded'});
+
+      expect(parseGitHubReleasesResponse(body), isEmpty);
+    });
+
+    test('数组内非对象元素被剔除', () {
+      final String body = jsonEncode(<dynamic>[
+        'not-an-object',
+        42,
+        <String, dynamic>{'tag_name': 'v1.0.0', 'draft': false},
+      ]);
+
+      final List<Map<String, dynamic>> releases =
+          parseGitHubReleasesResponse(body);
+
+      expect(releases, hasLength(1));
+      expect(releases.single['tag_name'], 'v1.0.0');
+    });
+
+    test('空数组返回空列表', () {
+      expect(parseGitHubReleasesResponse('[]'), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## 需求
设置里新增「查看更新日志」入口。

## 方案
设置 → 系统 → 更新 分区新增 `查看更新日志` 导航项，推 `ChangelogPage`：应用内在线拉取本仓库全部 GitHub releases，用 Markdown 渲染每个版本的发布说明（版本号 / 发布日期 / 预发布徽标 / 正文）。

## 实现要点
- **数据源** `fetchAllGitHubReleases`（落在 `update_checker_net.dart` 纯网络层）复用「检查更新」既有私有 HTTP 管线 `UpdateChecker._httpGetStringFromGitHubRepos`——自动继承多镜像回退、`applyUpdateProxy` 系统/自定义代理注入、每候选整体超时、`kGitHubRepoFallbacks` 旧库回退；`customProxy` 透传设置里现有更新代理项，与「立即检查更新」同源。
- **纯解析核心** `parseGitHubReleasesResponse` 抽出便于单测：过滤 `draft`、拒绝非数组、剔除非对象元素。
- 两函数放 net.dart 而非 release.dart，避让 release.dart 的 1720 行可维护性守卫。
- **空态**：`api.github.com/.../releases` 列表 API 经任何公共 gh 代理必 403（BUG-292）且无 302 逃生口，纯 GFW 无代理会拿到空列表——空态给「重试」+「打开发布页」两个逃生口。
- 预发布徽标只按 `prerelease` 字段显示统一「预发布」标签（不引入内部通道推断 / 不用 @visibleForTesting 成员），radius 走 `tokens.radii.chipRadius` 过 MD3 静态守卫。
- 新增 i18n key（17 语言，经 `i18n_sync.dart`）：`settings_view_changelog` / `changelog_empty` / `changelog_open_releases` / `changelog_prerelease`。

## 测试
- `update_checker_all_releases_parse_test.dart`：解析核心 6 例（保序 / 过滤草稿 / 非数组 / 剔非对象 / 空数组）。
- `changelog_page_test.dart`：`initialReleases` 注入口绕开网络，验证列表态（版本号/日期/预发布徽标/Markdown 正文）+ 空态（提示文案 + 两逃生口 + 不转圈）。
- `flutter analyze` 全绿；结构守卫 / MD3 静态守卫 / i18n 完整性 / 全部 559 个 update_checker 测试通过。

## 真机验证待办
- [ ] 有网/有代理环境点入口，确认拉到 releases 列表并正确渲染 Markdown、外链点击外跳。
- [ ] 无网/无代理确认落空态且「打开发布页」逃生口可用。
- [ ] 五平台入口可见性（受 `platformSupportsUpdateCheck()` 网关）。

bump `1.2.0+795`。