### PR TITLE
移除诊断页「关闭 Impeller」实验开关

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39865 (2345 per locale)
+/// Strings: 39831 (2343 per locale)
 ///
-/// Built on 2026-07-16 at 03:45 UTC
+/// Built on 2026-07-16 at 04:22 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2843,10 +2843,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get media_source_network_label_optional => 'Display name (optional)';
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
   String get render_restart_required => 'Takes effect after restarting the app';
   String get handlebar_card_image => 'Card Image (Cover / GIF)';
   String get video_subtitle_youtube_captions => 'YouTube captions';
@@ -7957,12 +7953,6 @@ class _StringsAr extends _StringsEn {
   @override
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
-  @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
   @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
@@ -13400,12 +13390,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
-  @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
   @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
@@ -18862,12 +18846,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
-  @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
   @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
@@ -24344,12 +24322,6 @@ class _StringsFr extends _StringsEn {
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
   @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
-  @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
   String get handlebar_card_image => 'Card Image (Cover / GIF)';
@@ -29726,12 +29698,6 @@ class _StringsId extends _StringsEn {
   @override
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
-  @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
   @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
@@ -35171,12 +35137,6 @@ class _StringsIt extends _StringsEn {
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
   @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
-  @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
   String get handlebar_card_image => 'Card Image (Cover / GIF)';
@@ -40342,12 +40302,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
-  @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
   @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
@@ -45515,12 +45469,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
-  @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
   @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
@@ -50925,12 +50873,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
-  @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
   @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
@@ -56361,12 +56303,6 @@ class _StringsPtBr extends _StringsEn {
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
   @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
-  @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
   String get handlebar_card_image => 'Card Image (Cover / GIF)';
@@ -61771,12 +61707,6 @@ class _StringsRu extends _StringsEn {
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
   @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
-  @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
   String get handlebar_card_image => 'Card Image (Cover / GIF)';
@@ -67095,12 +67025,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
-  @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
   @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
@@ -72472,12 +72396,6 @@ class _StringsTr extends _StringsEn {
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
   @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
-  @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
   String get handlebar_card_image => 'Card Image (Cover / GIF)';
@@ -77825,12 +77743,6 @@ class _StringsVi extends _StringsEn {
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
   @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
-  @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
   String get handlebar_card_image => 'Card Image (Cover / GIF)';
@@ -82849,11 +82761,6 @@ class _StringsZhCn extends _StringsEn {
   String get media_source_network_label_optional => '显示名（可选）';
   @override
   String get media_source_network_missing_fields => '请填写主机、用户名、远端路径，以及密码或私钥';
-  @override
-  String get render_impeller_disable_toggle => '关闭 Impeller（改用 Skia 渲染）';
-  @override
-  String get render_impeller_disable_hint =>
-      '改用 Skia 渲染后端。视频能播放但画面恒黑时可尝试；重启 App 后生效。';
   @override
   String get render_restart_required => '重启 App 后生效';
   @override
@@ -87880,12 +87787,6 @@ class _StringsZhHk extends _StringsEn {
   String get media_source_network_missing_fields =>
       'Enter host, username, remote path, and a password or key';
   @override
-  String get render_impeller_disable_toggle =>
-      'Disable Impeller (use Skia renderer)';
-  @override
-  String get render_impeller_disable_hint =>
-      'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
-  @override
   String get render_restart_required => 'Takes effect after restarting the app';
   @override
   String get handlebar_card_image => 'Card Image (Cover / GIF)';
@@ -92772,10 +92673,6 @@ extension on _StringsEn {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -97567,10 +97464,6 @@ extension on _StringsAr {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -102384,10 +102277,6 @@ extension on _StringsDe {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -107199,10 +107088,6 @@ extension on _StringsEs {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -112021,10 +111906,6 @@ extension on _StringsFr {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -116823,10 +116704,6 @@ extension on _StringsId {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -121642,10 +121519,6 @@ extension on _StringsIt {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -126419,10 +126292,6 @@ extension on _StringsJa {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -131198,10 +131067,6 @@ extension on _StringsKo {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -136010,10 +135875,6 @@ extension on _StringsNl {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -140819,10 +140680,6 @@ extension on _StringsPtBr {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -145632,10 +145489,6 @@ extension on _StringsRu {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -150427,10 +150280,6 @@ extension on _StringsTh {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -155231,10 +155080,6 @@ extension on _StringsTr {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -160029,10 +159874,6 @@ extension on _StringsVi {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':
@@ -164793,10 +164634,6 @@ extension on _StringsZhCn {
         return '显示名（可选）';
       case 'media_source_network_missing_fields':
         return '请填写主机、用户名、远端路径，以及密码或私钥';
-      case 'render_impeller_disable_toggle':
-        return '关闭 Impeller（改用 Skia 渲染）';
-      case 'render_impeller_disable_hint':
-        return '改用 Skia 渲染后端。视频能播放但画面恒黑时可尝试；重启 App 后生效。';
       case 'render_restart_required':
         return '重启 App 后生效';
       case 'handlebar_card_image':
@@ -169560,10 +169397,6 @@ extension on _StringsZhHk {
         return 'Display name (optional)';
       case 'media_source_network_missing_fields':
         return 'Enter host, username, remote path, and a password or key';
-      case 'render_impeller_disable_toggle':
-        return 'Disable Impeller (use Skia renderer)';
-      case 'render_impeller_disable_hint':
-        return 'Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.';
       case 'render_restart_required':
         return 'Takes effect after restarting the app';
       case 'handlebar_card_image':

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "远端路径",
   "media_source_network_label_optional": "显示名（可选）",
   "media_source_network_missing_fields": "请填写主机、用户名、远端路径，以及密码或私钥",
-  "render_impeller_disable_toggle": "关闭 Impeller（改用 Skia 渲染）",
-  "render_impeller_disable_hint": "改用 Skia 渲染后端。视频能播放但画面恒黑时可尝试；重启 App 后生效。",
   "render_restart_required": "重启 App 后生效",
   "handlebar_card_image": "卡片图片（封面 / 视频 GIF）",
   "video_subtitle_youtube_captions": "YouTube 字幕",

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2144,8 +2144,6 @@
   "media_source_network_remote_path": "Remote path",
   "media_source_network_label_optional": "Display name (optional)",
   "media_source_network_missing_fields": "Enter host, username, remote path, and a password or key",
-  "render_impeller_disable_toggle": "Disable Impeller (use Skia renderer)",
-  "render_impeller_disable_hint": "Falls back to the Skia renderer. Try this if a video plays but the screen stays black; takes effect after restarting the app.",
   "render_restart_required": "Takes effect after restarting the app",
   "handlebar_card_image": "Card Image (Cover / GIF)",
   "video_subtitle_youtube_captions": "YouTube captions",

--- a/hibiki/lib/src/settings/settings_schema_system.dart
+++ b/hibiki/lib/src/settings/settings_schema_system.dart
@@ -216,30 +216,6 @@ SettingsDestination buildSystemDestination() {
                 DebugLogService.instance.entries.isNotEmpty,
             builder: (_) => const DebugLogPage(),
           ),
-          // TODO-1232 A3：关闭 Impeller（改用 Skia 渲染）实验开关。仅 Android 有效
-          // （Impeller shell arg 由 MainActivity 在下次启动注入），故 Android-only。
-          // 用来自证 realme 8「视频能播但恒黑」是否为 Impeller/Mali 合成层问题：
-          // 关掉后若不黑＝坐实，据此根治。全局默认仍是 Impeller，本开关只在用户
-          // 主动打开时于**下次启动**翻转，属产品安全的试验路径（非默认全局关）。
-          SettingsSwitchItem(
-            id: 'diagnostics.disable_impeller',
-            title: t.render_impeller_disable_toggle,
-            subtitle:
-                t.render_impeller_disable_hint + t.settings_experimental_suffix,
-            icon: Icons.animation_outlined,
-            // 仅在 native 渲染后端 channel 已接线处显示（当前 = Android，见
-            // RenderBackendService.init）；非 Android channel 缺失即隐藏。
-            visible: (_) => RenderBackendService.instance.isSupported,
-            value: (_) => RenderBackendService.instance.impellerDisabled,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              final bool ok = await RenderBackendService.instance
-                  .setImpellerDisabled(value);
-              settingsContext.refresh();
-              if (ok) {
-                HibikiToast.show(msg: t.render_restart_required);
-              }
-            },
-          ),
         ],
       ),
     ],


### PR DESCRIPTION
## 改动
删除 设置 → 诊断 分区的 `diagnostics.disable_impeller` 开关（文案「关闭 Impeller（改用 Skia 渲染）」）及其两个 i18n key `render_impeller_disable_toggle` / `render_impeller_disable_hint`（17 语言经 i18n_sync 同步删除 + 重新生成 strings.g.dart）。

## 保留（未动）
- 视频设置面板「画面全黑？切换渲染器（Skia）」降级入口 `video_render_skia_fix_*` / `_switchToSkiaAndRestart`
- `RenderBackendService`（该入口仍依赖）
- Android native 默认保持 Impeller 守卫；`render_restart_required` 仍被上述入口使用

## 验证
- 42 个源码扫描守卫测试通过（含 impeller_default_guard、settings schema guards）
- 18 个 i18n 完整性测试通过（每语言 100% 覆盖、无孤儿 key）
- flutter analyze 干净（生成文件 warning 被 CI `**.g.dart` 排除）
- 需 sqlite native-assets 的 3 个测试因本机网络下载失败未跑成，但均不引用被删开关