### PR TITLE
fix(lyrics): BUG-852 听力沉浸模糊盖全部句，不再暴露前后文

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 833 条。点号进各自文件。
+> 共 834 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-852](bugs/BUG-852-lyrics-blur-exposes-context.md) | ✅ | ✅ | 歌词模式模糊只盖当前句，前后文暴露 |
 | [BUG-851](bugs/BUG-851-dict-dark-usage-tag-washed.md) | ✅ | ✅ | ダークモードで辞書の使い方タグがライト背景のまま浮く |
 | [BUG-850](bugs/BUG-850-dict-ruby-hspacing-overlap.md) | ✅ | ✅ | 辞書例文の逐字ルビが横方向に重なる |
 | [BUG-849](bugs/BUG-849-reader-paginated-live-style.md) | ✅ | ✅ | 分页模式改字号/边距/主题不实时生效需重开书 |

--- a/docs/bugs/BUG-852-lyrics-blur-exposes-context.md
+++ b/docs/bugs/BUG-852-lyrics-blur-exposes-context.md
@@ -1,0 +1,6 @@
+## BUG-852 · 歌词模式模糊只盖当前句，前后文暴露
+- **报告**：2026-07-16（用户：）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/audiobook/lyrics_mode_html.dart:143`——听力沉浸模糊（TODO-908）的 CSS 门控写成 `body.lyrics-blur .cue.current { filter: blur(8px) }`，只盖当前句；前后文 `.cue` / `.cue.near-*` 无 filter，照样清晰可读、可预读，沉浸模糊语义（整篇不可预读）失效。显形选择器 `.cue.current:hover` / `.cue.current.revealed` 同样只对当前句生效。
+- **[x] ① 已修复** — 把 blur 门控从 `.cue.current` 放宽到整个 `.cue`（`body.lyrics-blur .cue { filter: blur(8px) }`），显形选择器同步改成 `.cue:hover` / `.cue.revealed`，逐句 hover / 点击才显形。运行时开关 `__lyricsSetBlur` 仍只翻 `body.lyrics-blur` class（`.revealed` 显形逻辑本就按任意 `.cue` 走，无需改）。提交：见 PR。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/audiobook/lyrics_mode_html_test.dart` 新增 group `BUG-852 listening blur hides all cues (not just current)`：断言 blur filter 挂在 `body.lyrics-blur .cue`、显形选择器为 `.cue:hover` / `.cue.revealed`，并回归守卫旧的 `body.lyrics-blur .cue.current {` 门控不得再出现。
+- **备注**：模糊维度与 writing-mode 正交，只作用 `.cue`，不碰 TODO-907 轴 CSS；`__lyricsUpdateStyle` 的 cssRules 遍历按精确 selectorText 匹配（`.cue` / `.cue.current`），不与放宽后的 `body.lyrics-blur .cue` 复合选择器冲突。

--- a/hibiki/lib/src/media/audiobook/lyrics_mode_html.dart
+++ b/hibiki/lib/src/media/audiobook/lyrics_mode_html.dart
@@ -61,9 +61,9 @@ class LyricsModeHtml {
             'calc(45vh + ${marginBottom}vh) ${marginRight > 0 ? marginRight : 2.5}vw;';
     // JS 端轴标记：true=竖排横滚（用 scrollBy 增量绕开 vertical-rl 负向 scrollX）。
     final String verticalJs = vertical ? 'true' : 'false';
-    // TODO-908：听力沉浸模糊。blur=true 时给 body 挂 `lyrics-blur` class，CSS 只对
-    // 当前句（.cue.current）盖 8px 高斯模糊；hover 或点击（.revealed）显形。模糊维度
-    // 与 writing-mode 正交——blur CSS 只作用在 cue 元素上，与轴/竖排无关。
+    // TODO-908 / BUG-852：听力沉浸模糊。blur=true 时给 body 挂 `lyrics-blur` class，CSS
+    // 对**所有**句（.cue）盖 8px 高斯模糊；单独 hover 或点击（.revealed）才显形。模糊
+    // 维度与 writing-mode 正交——blur CSS 只作用在 cue 元素上，与轴/竖排无关。
     final String blurBodyClass = blur ? ' class="lyrics-blur"' : '';
 
     return '''
@@ -137,16 +137,18 @@ body { font-family: "Noto Serif JP", "Noto Sans JP", serif; }
 .cue.near-1 { opacity: 0.55; transform: scale(1.05); }
 .cue.near-2 { opacity: 0.35; }
 .cue.near-3 { opacity: 0.25; }
-/* TODO-908: 听力沉浸模糊 —— body.lyrics-blur 时只对当前句盖 8px 高斯模糊，
-   hover 或点击显形（.revealed）。与视频字幕的 ImageFilter.blur(sigma:8) 等价。
-   仅作用 .cue（与 writing-mode 正交，不碰 TODO-907 轴 CSS）。 */
-body.lyrics-blur .cue.current {
+/* TODO-908 / BUG-852: 听力沉浸模糊 —— body.lyrics-blur 时对**所有**句（.cue，含
+   当前句与前后文 near-*）盖 8px 高斯模糊；单独 hover 或点击（.revealed）才显形。
+   之前只盖 .cue.current，前后文照样能读、可预读，沉浸失效——听力模糊的语义是整篇
+   不可预读，必须盖全部 cue。与视频字幕的 ImageFilter.blur(sigma:8) 等价。仅作用
+   .cue（与 writing-mode 正交，不碰 TODO-907 轴 CSS）。 */
+body.lyrics-blur .cue {
   filter: blur(8px);
   transition: filter 0.2s ease-out, opacity 0.35s ease-out,
       transform 0.3s ease-out, color 0.3s ease-out;
 }
-body.lyrics-blur .cue.current:hover,
-body.lyrics-blur .cue.current.revealed {
+body.lyrics-blur .cue:hover,
+body.lyrics-blur .cue.revealed {
   filter: blur(0);
 }
 ::highlight(hoshi-selection) {
@@ -521,8 +523,8 @@ window.__lyricsUpdateStyle = function(bgColor, textColor, accentColor, fontSize,
   __lyricsFitCues();
 };
 
-// ── 实时模糊开关（TODO-908，仿 __lyricsUpdateStyle，不重建整页） ──
-// on=true 给 body 挂 lyrics-blur（CSS 只模糊当前句，hover/点击显形）；off 摘掉并
+// ── 实时模糊开关（TODO-908 / BUG-852，仿 __lyricsUpdateStyle，不重建整页） ──
+// on=true 给 body 挂 lyrics-blur（CSS 模糊所有句，逐句 hover/点击显形）；off 摘掉并
 // 清掉所有遗留的 .revealed，回到无模糊态。
 window.__lyricsSetBlur = function(on) {
   if (on) {

--- a/hibiki/test/media/audiobook/lyrics_mode_html_test.dart
+++ b/hibiki/test/media/audiobook/lyrics_mode_html_test.dart
@@ -340,6 +340,56 @@ void main() {
         );
       });
     });
+
+    // BUG-852: 听力沉浸模糊只盖 .cue.current，前后文（.cue.near-* 与远处 .cue）照样
+    // 清晰可读、可预读，沉浸失效。修复=把 blur 门控从 .cue.current 放宽到整个 .cue，
+    // 逐句 hover / 点击（.revealed）才显形，与视频字幕整篇遮罩语义一致。
+    group('BUG-852 listening blur hides all cues (not just current)', () {
+      String buildBlurHtml() => LyricsModeHtml.generate(
+            cues: <AudioCue>[_cue(0), _cue(1), _cue(2), _cue(3), _cue(4)],
+            currentIndex: 2,
+            backgroundColor: 'rgba(255,255,255,1.00)',
+            textColor: 'rgba(0,0,0,1.00)',
+            accentColor: 'rgba(255,220,0,1.00)',
+            fontSize: 20,
+            blur: true,
+          );
+
+      test('blur filter is gated on all .cue, not .cue.current only', () {
+        final String html = buildBlurHtml();
+
+        // The blur must be applied through `body.lyrics-blur .cue { ... }` so it
+        // covers the current cue AND all preceding/following cues.
+        final String blurRule = _cssBlock(html, 'body.lyrics-blur .cue {');
+        expect(blurRule, contains('filter: blur(8px)'));
+
+        // Regression guard: the blur must NOT be re-narrowed to only the current
+        // cue — that was the bug (前后文暴露).
+        expect(html, isNot(contains('body.lyrics-blur .cue.current {')));
+        expect(
+          html,
+          isNot(contains('body.lyrics-blur .cue.current:hover')),
+        );
+      });
+
+      test('any cue reveals (unblurs) on hover or .revealed, not current-only',
+          () {
+        final String html = buildBlurHtml();
+
+        // Reveal selectors must match any cue, so tapping/hovering a non-current
+        // (前后文) line unblurs it just like the current line.
+        expect(html, contains('body.lyrics-blur .cue:hover'));
+        expect(html, contains('body.lyrics-blur .cue.revealed'));
+      });
+
+      test('runtime blur toggle still only flips the body class', () {
+        final String html = buildBlurHtml();
+        // The live toggle drives blur purely via the body.lyrics-blur class, so
+        // the broadened CSS selector governs which cues blur — no per-cue JS.
+        expect(html, contains("document.body.classList.add('lyrics-blur')"));
+        expect(html, contains("document.body.classList.remove('lyrics-blur')"));
+      });
+    });
   });
 }
 


### PR DESCRIPTION
## 问题
歌词模式「听力沉浸模糊」只对当前句（`.cue.current`）盖 8px 高斯模糊，前后文（`.cue.near-*` 与远处 `.cue`）无 filter、清晰可读且可预读——沉浸模糊语义（整篇不可预读）失效。见用户截图：中间当前句被模糊，上下文全部暴露。

## 根因
`hibiki/lib/src/media/audiobook/lyrics_mode_html.dart:143` 的 CSS 门控写成 `body.lyrics-blur .cue.current { filter: blur(8px) }`，只命中当前句；显形选择器 `.cue.current:hover` / `.cue.current.revealed` 同样只对当前句生效。

## 修复
- blur 门控从 `.cue.current` 放宽到整个 `.cue`（`body.lyrics-blur .cue`），盖当前句 + 前后文全部。
- 显形选择器同步改成 `.cue:hover` / `.cue.revealed`，逐句 hover / 点击才显形，与视频字幕整篇遮罩语义一致。
- 运行时开关 `__lyricsSetBlur` 仍只翻 `body.lyrics-blur` class（`.revealed` 显形逻辑本就按任意 `.cue` 走，无需改）。
- 与 writing-mode 正交，只作用 `.cue`，不碰 TODO-907 轴 CSS。

## 测试
`hibiki/test/media/audiobook/lyrics_mode_html_test.dart` 新增 group `BUG-852 ...`：断言 blur filter 挂 `body.lyrics-blur .cue`、显形选择器为 `.cue:hover` / `.cue.revealed`，并回归守卫旧 `body.lyrics-blur .cue.current {` 门控不得再出现。全 21 测试通过；`flutter analyze` 干净。

## 待验证
真机/离屏歌词模式开模糊，确认前后文也被盖、逐句点击可单独显形。