### PR TITLE
fix(reader): 批量管理标签三段横排单行

### DIFF
--- a/hibiki/lib/src/pages/implementations/reader_history/dialogs.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/dialogs.part.dart
@@ -527,8 +527,14 @@ class _BatchTagIntentRow extends StatelessWidget {
     final Color keepColor = colors.onSurfaceVariant;
 
     Widget segmentLabel(String text, _BatchTagIntent intent, Color color) {
+      // 三段共享一行、每段仅得 ~90dp（手机窄弹窗），双字标签必须锁死单行，
+      // 否则 SegmentedButton 会把「保持」竖排成「保/持」（原缺陷）。softWrap
+      // 关掉后文字一律横排；配合下方 Expanded 铺满行宽 + 收紧内边距保证放得下。
       return Text(
         text,
+        maxLines: 1,
+        softWrap: false,
+        overflow: TextOverflow.visible,
         style: TextStyle(
           fontSize: 12,
           color: selected == intent ? color : null,
@@ -536,77 +542,81 @@ class _BatchTagIntentRow extends StatelessWidget {
       );
     }
 
+    // 收紧每段横向内边距（默认 ~12dp/侧太宽，在窄弹窗里把 icon+双字挤到换行）。
+    // 只在本弹窗局部覆盖，不动全局 kSettingsSegmentedStyle。
+    final ButtonStyle segmentedStyle = kSettingsSegmentedStyle.copyWith(
+      padding: const WidgetStatePropertyAll<EdgeInsetsGeometry>(
+        EdgeInsets.symmetric(horizontal: 6),
+      ),
+    );
+
     return AdaptiveSettingsRow(
       title: tag.name,
       icon: cupertino ? CupertinoIcons.tag : Icons.sell_outlined,
       controlBelow: true,
-      trailing: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 300),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            DecoratedBox(
-              decoration: BoxDecoration(
-                color: tagColor,
-                shape: BoxShape.circle,
-              ),
-              child: const SizedBox(width: 12, height: 12),
+      // controlBelow 下 trailing 独占整行；用 Expanded 让三段铺满行宽（不再被
+      // mainAxisSize.min + maxWidth:300 挤到 ~270 触发压缩换行）。
+      trailing: Row(
+        children: [
+          DecoratedBox(
+            decoration: BoxDecoration(
+              color: tagColor,
+              shape: BoxShape.circle,
             ),
-            SizedBox(width: tokens.spacing.gap + tokens.spacing.gap / 2),
-            Flexible(
-              child: adaptiveSegmentedButton<_BatchTagIntent>(
-                context: context,
-                segments: [
-                  ButtonSegment<_BatchTagIntent>(
-                    value: _BatchTagIntent.keep,
-                    tooltip: t.batch_tag_keep,
-                    label: segmentLabel(
-                        t.batch_tag_keep, _BatchTagIntent.keep, keepColor),
-                    icon: Icon(
-                      cupertino
-                          ? CupertinoIcons.minus_circle
-                          : Icons.remove_circle_outline,
-                      size: 16,
-                      color:
-                          selected == _BatchTagIntent.keep ? keepColor : null,
-                    ),
+            child: const SizedBox(width: 12, height: 12),
+          ),
+          SizedBox(width: tokens.spacing.gap + tokens.spacing.gap / 2),
+          Expanded(
+            child: adaptiveSegmentedButton<_BatchTagIntent>(
+              context: context,
+              segments: [
+                ButtonSegment<_BatchTagIntent>(
+                  value: _BatchTagIntent.keep,
+                  tooltip: t.batch_tag_keep,
+                  label: segmentLabel(
+                      t.batch_tag_keep, _BatchTagIntent.keep, keepColor),
+                  icon: Icon(
+                    cupertino
+                        ? CupertinoIcons.minus_circle
+                        : Icons.remove_circle_outline,
+                    size: 16,
+                    color: selected == _BatchTagIntent.keep ? keepColor : null,
                   ),
-                  ButtonSegment<_BatchTagIntent>(
-                    value: _BatchTagIntent.add,
-                    tooltip: t.batch_tag_add,
-                    label: segmentLabel(
-                        t.batch_tag_add, _BatchTagIntent.add, addColor),
-                    icon: Icon(
-                      cupertino ? CupertinoIcons.add_circled : Icons.add_circle,
-                      size: 16,
-                      color: selected == _BatchTagIntent.add ? addColor : null,
-                    ),
+                ),
+                ButtonSegment<_BatchTagIntent>(
+                  value: _BatchTagIntent.add,
+                  tooltip: t.batch_tag_add,
+                  label: segmentLabel(
+                      t.batch_tag_add, _BatchTagIntent.add, addColor),
+                  icon: Icon(
+                    cupertino ? CupertinoIcons.add_circled : Icons.add_circle,
+                    size: 16,
+                    color: selected == _BatchTagIntent.add ? addColor : null,
                   ),
-                  ButtonSegment<_BatchTagIntent>(
-                    value: _BatchTagIntent.remove,
-                    tooltip: t.batch_tag_remove,
-                    label: segmentLabel(t.batch_tag_remove,
-                        _BatchTagIntent.remove, removeColor),
-                    icon: Icon(
-                      cupertino
-                          ? CupertinoIcons.minus_circle_fill
-                          : Icons.do_not_disturb_on,
-                      size: 16,
-                      color: selected == _BatchTagIntent.remove
-                          ? removeColor
-                          : null,
-                    ),
+                ),
+                ButtonSegment<_BatchTagIntent>(
+                  value: _BatchTagIntent.remove,
+                  tooltip: t.batch_tag_remove,
+                  label: segmentLabel(
+                      t.batch_tag_remove, _BatchTagIntent.remove, removeColor),
+                  icon: Icon(
+                    cupertino
+                        ? CupertinoIcons.minus_circle_fill
+                        : Icons.do_not_disturb_on,
+                    size: 16,
+                    color:
+                        selected == _BatchTagIntent.remove ? removeColor : null,
                   ),
-                ],
-                selected: {selected},
-                onSelectionChanged: (values) {
-                  if (values.isNotEmpty) onChanged(values.first);
-                },
-                style: kSettingsSegmentedStyle,
-              ),
+                ),
+              ],
+              selected: {selected},
+              onSelectionChanged: (values) {
+                if (values.isNotEmpty) onChanged(values.first);
+              },
+              style: segmentedStyle,
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/hibiki/test/pages/batch_tag_intent_segments_test.dart
+++ b/hibiki/test/pages/batch_tag_intent_segments_test.dart
@@ -87,6 +87,43 @@ void main() {
     expect(removeLabel.style?.color, errorColor, reason: '红色应扩到整段（含文字标签），不只图标');
   });
 
+  testWidgets('窄弹窗宽度下三段文字横排单行（不再竖排成「保/持」且不溢出）', (
+    WidgetTester tester,
+  ) async {
+    // 复刻手机窄弹窗：正文可用宽度 ~300dp。修复前三段被 mainAxisSize.min +
+    // maxWidth:300 压到 ~270，双字标签竖排换行；修复后铺满行宽 + 单行锁定。
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: 300,
+                child: buildBatchTagIntentRowForTesting(tag: tag()),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 无 RenderFlex overflow / 布局异常。
+    expect(tester.takeException(), isNull);
+
+    // 每个语义标签都锁死单行、关闭软换行——从根上杜绝「保/持」竖排。
+    for (final String label in <String>[
+      t.batch_tag_keep,
+      t.batch_tag_add,
+      t.batch_tag_remove,
+    ]) {
+      final Text widget = tester.widget<Text>(find.text(label));
+      expect(widget.maxLines, 1, reason: '$label 应单行');
+      expect(widget.softWrap, isFalse, reason: '$label 应关闭软换行（横排不竖排）');
+    }
+  });
+
   test('源码守卫：三段不再用同款横杠且 remove 文字也染错误红', () {
     final String src = readReaderHistorySource();
 


### PR DESCRIPTION
## 问题
「批量管理标签」弹窗里每个标签的三段控件（保持/添加/移除），在手机窄弹窗下双字标签被压成竖排（保/持、添/加、移/除），观感像坏了。

## 根因
`_BatchTagIntentRow` 的 trailing 在 `controlBelow` 列布局里是 `ConstrainedBox(maxWidth:300) > Row(mainAxisSize.min) > Flexible(三段)`。min-size Row 只把 ~270dp 松约束丢给三段，低于「icon+2 汉字」自然宽度 → 每段被压缩 → `Text` 自动换行竖排。

## 修复（三处协同，保留 TODO-308 图标/颜色守卫）
1. 去掉 `mainAxisSize.min` + `ConstrainedBox(300)`，三段包进 `Expanded` 铺满整行宽。
2. 局部 `ButtonStyle` 收紧每段横向内边距（12→6dp/侧），不动全局 `kSettingsSegmentedStyle`。
3. 段标签 `Text` 设 `maxLines:1, softWrap:false`，从根上禁止竖排。

## 测试
- `test/pages/batch_tag_intent_segments_test.dart` 新增窄宽（300dp）守卫：断言无 RenderFlex overflow + 三段标签单行/关软换行。
- 5 项全绿；`flutter analyze` 干净。
- ⚠️ 待真机复测原始失败路径（书架多选 → 标签图标 → 弹窗）。