### PR TITLE
fix(reader): 选区菜单补「收藏」项 (BUG-852)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 833 条。点号进各自文件。
+> 共 834 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-852](bugs/BUG-852-selection-menu-favorite.md) | ✅ | ✅ | 移动端选区菜单缺少收藏项 |
 | [BUG-851](bugs/BUG-851-dict-dark-usage-tag-washed.md) | ✅ | ✅ | ダークモードで辞書の使い方タグがライト背景のまま浮く |
 | [BUG-850](bugs/BUG-850-dict-ruby-hspacing-overlap.md) | ✅ | ✅ | 辞書例文の逐字ルビが横方向に重なる |
 | [BUG-849](bugs/BUG-849-reader-paginated-live-style.md) | ✅ | ✅ | 分页模式改字号/边距/主题不实时生效需重开书 |

--- a/docs/bugs/BUG-852-selection-menu-favorite.md
+++ b/docs/bugs/BUG-852-selection-menu-favorite.md
@@ -1,6 +1,6 @@
 ## BUG-852 · 移动端选区菜单缺少收藏项
 - **报告**：2026-07-16（用户：截图 手机长按选区，弹出菜单只有「搜索 / 复制」，缺「收藏」）
 - **真实性**：✅ 真 bug（功能缺口）。选区菜单构建点 `hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart` `_handleSelectionMenu`（移动端自绘拖选）与 `_showReaderTextContextMenu`（桌面原生选区右键）都只出「查词 / 复制 /（有音频时）导出片段」三项，从未接入 app 早有的收藏句子能力（`_toggleFavoriteSentence`，只在阅读器底栏 / 查词弹窗顶栏可达）。
-- **[x] ① 已修复** — 两条选区入口各补「收藏」菜单项（`value: 'favorite'` + 复用既有 i18n key `t.action_favorite`，图标 `Icons.star_border` 与底栏收藏按钮一致），并按选区类型正确填「查词状态」后复用同一后端 `_toggleFavoriteSentence`：移动端自绘选区经 `_fillLookupStateFromSelectionData(data, extractNativeImages: false)`（无原生选区）；桌面右键经 `_fillLookupStateFromNativeSelection()`（解析失败退回选中文本满足 currentSentence 非空契约）。提交：`7913c8bb1`。
+- **[x] ① 已修复** — 两条选区入口各补「收藏」菜单项（`value: 'favorite'` + 复用既有 i18n key `t.action_favorite`，图标 `Icons.star_border` 与底栏收藏按钮一致），并按选区类型正确填「查词状态」后复用同一后端 `_toggleFavoriteSentence`：移动端自绘选区经 `_fillLookupStateFromSelectionData(data, extractNativeImages: false)`（无原生选区）；桌面右键经 `_fillLookupStateFromNativeSelection()`（解析失败退回选中文本满足 currentSentence 非空契约）。提交：`c8253eed9`。
 - **[x] ② 已加自动化测试** — `hibiki/test/reader/reader_selection_favorite_menu_guard_test.dart`（源码扫描守卫，钉死两处菜单含 favorite 项 + switch 分支各自填状态后走 `_toggleFavoriteSentence`，且查词/复制老出口零回归；触屏 WebView 手势菜单只能真机跑，故与既有 `reader_mobile_selection_export_menu_guard` 同法用 Dart 源码扫描）。
 - **备注**：另一处用户反馈「手机没办法左右选择」（拖选区两端手柄拖不动）经查已在 develop `PR#150`（版本 1.2.0+780，`reader_selection_scripts.dart` `getCaretRange` 补 TEXT_NODE 快路守卫）修复；用户实机需更新到 ≥+780 才生效，非本 bug。若已 ≥+780 仍拖不动，另开真机诊断 bug。

--- a/docs/bugs/BUG-852-selection-menu-favorite.md
+++ b/docs/bugs/BUG-852-selection-menu-favorite.md
@@ -1,0 +1,6 @@
+## BUG-852 · 移动端选区菜单缺少收藏项
+- **报告**：2026-07-16（用户：截图 手机长按选区，弹出菜单只有「搜索 / 复制」，缺「收藏」）
+- **真实性**：✅ 真 bug（功能缺口）。选区菜单构建点 `hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart` `_handleSelectionMenu`（移动端自绘拖选）与 `_showReaderTextContextMenu`（桌面原生选区右键）都只出「查词 / 复制 /（有音频时）导出片段」三项，从未接入 app 早有的收藏句子能力（`_toggleFavoriteSentence`，只在阅读器底栏 / 查词弹窗顶栏可达）。
+- **[x] ① 已修复** — 两条选区入口各补「收藏」菜单项（`value: 'favorite'` + 复用既有 i18n key `t.action_favorite`，图标 `Icons.star_border` 与底栏收藏按钮一致），并按选区类型正确填「查词状态」后复用同一后端 `_toggleFavoriteSentence`：移动端自绘选区经 `_fillLookupStateFromSelectionData(data, extractNativeImages: false)`（无原生选区）；桌面右键经 `_fillLookupStateFromNativeSelection()`（解析失败退回选中文本满足 currentSentence 非空契约）。提交：`7913c8bb1`。
+- **[x] ② 已加自动化测试** — `hibiki/test/reader/reader_selection_favorite_menu_guard_test.dart`（源码扫描守卫，钉死两处菜单含 favorite 项 + switch 分支各自填状态后走 `_toggleFavoriteSentence`，且查词/复制老出口零回归；触屏 WebView 手势菜单只能真机跑，故与既有 `reader_mobile_selection_export_menu_guard` 同法用 Dart 源码扫描）。
+- **备注**：另一处用户反馈「手机没办法左右选择」（拖选区两端手柄拖不动）经查已在 develop `PR#150`（版本 1.2.0+780，`reader_selection_scripts.dart` `getCaretRange` 补 TEXT_NODE 快路守卫）修复；用户实机需更新到 ≥+780 才生效，非本 bug。若已 ≥+780 仍拖不动，另开真机诊断 bug。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
@@ -293,6 +293,23 @@ extension _ReaderChrome on _ReaderHibikiPageState {
           ],
         ),
       ),
+      // BUG-852：选区菜单补「收藏」——与桌面底栏 / 查词弹窗顶栏的收藏句子
+      // （`_toggleFavoriteSentence`）同一后端，仅入口不同。触屏从不建原生选区
+      // （TODO-1279），旧菜单只有查词 / 复制 / 导出，无从收藏当前句；此项填平缺口。
+      PopupMenuItem<String>(
+        value: 'favorite',
+        height: kMinInteractiveDimension * menuScale,
+        padding: EdgeInsets.symmetric(horizontal: 16.0 * menuScale),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(Icons.star_border, size: 18.0 * menuScale),
+            SizedBox(width: 12.0 * menuScale),
+            Text(t.action_favorite,
+                style: TextStyle(fontSize: 14.0 * menuScale)),
+          ],
+        ),
+      ),
       if (hasAudio)
         PopupMenuItem<String>(
           value: 'export',
@@ -351,6 +368,20 @@ extension _ReaderChrome on _ReaderHibikiPageState {
       case 'copy':
         await Clipboard.setData(ClipboardData(text: selectedText));
         HibikiToast.show(msg: t.copied_to_clipboard);
+        return;
+      case 'favorite':
+        // BUG-852：右键收藏也走「原生选区 → 查词状态」补写（与 search 同源），确保
+        // _toggleFavoriteSentence 读到的 currentSentence / 句级区间非空；解析失败退回
+        // 选中文本本身满足非空契约。
+        final ReaderSelectionData? favSel =
+            await _fillLookupStateFromNativeSelection();
+        if (!mounted) return;
+        if (favSel == null) {
+          appModel.currentMediaSource?.setCurrentSentence(
+            selection: HibikiTextSelection(text: selectedText),
+          );
+        }
+        await _toggleFavoriteSentence();
         return;
       case 'export':
         await _exportAudiobookClipFromSelection();
@@ -424,6 +455,23 @@ extension _ReaderChrome on _ReaderHibikiPageState {
           ],
         ),
       ),
+      // BUG-852：选区菜单补「收藏」——与桌面底栏 / 查词弹窗顶栏的收藏句子
+      // （`_toggleFavoriteSentence`）同一后端，仅入口不同。触屏从不建原生选区
+      // （TODO-1279），旧菜单只有查词 / 复制 / 导出，无从收藏当前句；此项填平缺口。
+      PopupMenuItem<String>(
+        value: 'favorite',
+        height: kMinInteractiveDimension * menuScale,
+        padding: EdgeInsets.symmetric(horizontal: 16.0 * menuScale),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(Icons.star_border, size: 18.0 * menuScale),
+            SizedBox(width: 12.0 * menuScale),
+            Text(t.action_favorite,
+                style: TextStyle(fontSize: 14.0 * menuScale)),
+          ],
+        ),
+      ),
       if (hasAudio)
         PopupMenuItem<String>(
           value: 'export',
@@ -469,6 +517,15 @@ extension _ReaderChrome on _ReaderHibikiPageState {
       case 'copy':
         await Clipboard.setData(ClipboardData(text: data.text));
         HibikiToast.show(msg: t.copied_to_clipboard);
+        await _clearReaderAppSelection();
+        return;
+      case 'favorite':
+        // BUG-852：拖选是 app 自绘选区（无原生选区），从菜单 payload 填查词状态
+        // （currentSentence 非空契约 + 句级区间），与「导出片段」共用
+        // _fillLookupStateFromSelectionData，再走既有收藏句子后端；收藏完清掉选区高亮。
+        await _fillLookupStateFromSelectionData(data,
+            extractNativeImages: false);
+        await _toggleFavoriteSentence();
         await _clearReaderAppSelection();
         return;
       case 'export':

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+802
+version: 1.2.0+803
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/reader/reader_selection_favorite_menu_guard_test.dart
+++ b/hibiki/test/reader/reader_selection_favorite_menu_guard_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-852：阅读器选区菜单补「收藏」守卫。
+///
+/// 用户实机反馈手机选区菜单只有「查词 / 复制」，缺「收藏」——app 早有收藏句子能力
+/// （`_toggleFavoriteSentence`，桌面底栏 / 查词弹窗顶栏用），但选区菜单从没接进去。
+/// 触屏拖选是 **app 自绘选区**（`_handleSelectionMenu`），桌面是 **原生选区右键**
+/// （`_showReaderTextContextMenu`），两条选区入口此前都无收藏项。本守卫钉死两处都补上
+/// 「收藏」，且各自按选区类型正确填「查词状态」（`currentSentence` / 句级区间非空契约）
+/// 后复用同一后端 `_toggleFavoriteSentence`：
+///   ① 手机拖选菜单：`value: 'favorite'` + `t.action_favorite`，switch 分支经
+///      `_fillLookupStateFromSelectionData(..., extractNativeImages: false)`（无原生选区）
+///      填状态后 `_toggleFavoriteSentence()`；
+///   ② 桌面右键菜单：同项，switch 分支经 `_fillLookupStateFromNativeSelection()`
+///      （原生选区）填状态后 `_toggleFavoriteSentence()`；
+///   ③ 查词 / 复制两条老出口零回归。
+///
+/// 真机触屏 WebView 才能跑真手势 + 菜单，故用 Dart 源码扫描钉死契约（与既有
+/// reader_mobile_selection_export_menu_guard 同法）。
+String _between(String src, String startMarker, String endMarker) {
+  final int start = src.indexOf(startMarker);
+  final int end = src.indexOf(endMarker, start + startMarker.length);
+  expect(start, greaterThanOrEqualTo(0), reason: '找不到 $startMarker');
+  expect(end, greaterThan(start), reason: '找不到 $endMarker（在 $startMarker 之后）');
+  return src.substring(start, end);
+}
+
+void main() {
+  final String chrome =
+      File('lib/src/pages/implementations/reader_hibiki/chrome.part.dart')
+          .readAsStringSync();
+
+  String selectionMenuBody() => _between(
+      chrome,
+      'Future<void> _handleSelectionMenu(',
+      'Future<void> _clearReaderAppSelection(');
+  String desktopMenuBody() => _between(
+      chrome,
+      'Future<void> _showReaderTextContextMenu(',
+      'Future<void> _handleSelectionMenu(');
+
+  group('① 手机拖选菜单补「收藏」（自绘选区，无原生选区）', () {
+    test('菜单项含 favorite + 复用 action_favorite i18n key', () {
+      final String body = selectionMenuBody();
+      expect(body, contains("value: 'favorite'"), reason: '缺「收藏」菜单项');
+      expect(body, contains('t.action_favorite'),
+          reason: '收藏项必须复用既有 action_favorite i18n key（勿新增重复 key）');
+      // 查词 / 复制两条老出口仍在（共存，不回退）。
+      expect(body, contains('t.search'));
+      expect(body, contains('t.copy'));
+    });
+
+    test('switch favorite 分支从自绘选区 payload 填状态后走收藏后端', () {
+      // 折叠空白，容忍 dart format 把长调用换行折行（断言不依赖具体换行）。
+      final String body = selectionMenuBody().replaceAll(RegExp(r'\s+'), ' ');
+      expect(body, contains("case 'favorite':"));
+      expect(
+          body,
+          contains(
+              '_fillLookupStateFromSelectionData(data, extractNativeImages: false)'),
+          reason: '触屏自绘选区无原生选区，须从 payload 填 currentSentence / 句级区间');
+      expect(body, contains('_toggleFavoriteSentence()'),
+          reason: '收藏必须复用桌面同一后端 _toggleFavoriteSentence');
+      expect(body, contains('_clearReaderAppSelection()'),
+          reason: '收藏完清掉 app 选区高亮');
+    });
+  });
+
+  group('② 桌面右键菜单补「收藏」（原生选区）', () {
+    test('菜单项含 favorite + 复用 action_favorite i18n key', () {
+      final String body = desktopMenuBody();
+      expect(body, contains("value: 'favorite'"), reason: '桌面右键缺「收藏」菜单项');
+      expect(body, contains('t.action_favorite'));
+      // 门控与老三项一致：桌面右键仅 Windows。
+      expect(body, contains('isWindowsPlatform'), reason: '桌面右键菜单门控不得回退');
+    });
+
+    test('switch favorite 分支从原生选区填状态后走收藏后端', () {
+      final String body = desktopMenuBody();
+      expect(body, contains("case 'favorite':"));
+      expect(body, contains('_fillLookupStateFromNativeSelection()'),
+          reason: '桌面走原生选区路径填 currentSentence（与 search 同源）');
+      expect(body, contains('_toggleFavoriteSentence()'),
+          reason: '收藏必须复用桌面同一后端 _toggleFavoriteSentence');
+    });
+  });
+}


### PR DESCRIPTION
## 用户报告
手机长按选区弹出的菜单只有「搜索 / 复制」，缺「收藏」（截图）。另反馈「手机没办法左右选择」。

## 根因
- **收藏缺口（本 PR 修）**：选区菜单构建点 `chrome.part.dart` 的 `_handleSelectionMenu`（移动端自绘拖选）与 `_showReaderTextContextMenu`（桌面原生选区右键）都只出「查词 / 复制 /（有音频）导出片段」，从未接入 app 早有的收藏句子能力 `_toggleFavoriteSentence`（此前只在阅读器底栏 / 查词弹窗顶栏可达）。
- **左右选择（无需改动）**：拖选区两端手柄拖不动已在 develop PR#150（1.2.0+780，`getCaretRange` 补 TEXT_NODE 快路守卫）修复；用户实机需更新到 ≥+780 才生效。

## 改动
两条选区入口各补「收藏」菜单项（复用既有 i18n key `t.action_favorite`，图标 `Icons.star_border` 与底栏收藏按钮一致），按选区类型正确填「查词状态」后复用同一后端 `_toggleFavoriteSentence`：
- 移动端自绘选区 → `_fillLookupStateFromSelectionData(data, extractNativeImages: false)`（无原生选区）
- 桌面右键 → `_fillLookupStateFromNativeSelection()`（解析失败退回选中文本满足 currentSentence 非空契约）

查词 / 复制 / 导出老出口零回归。

## 测试
- 新增源码扫描守卫 `hibiki/test/reader/reader_selection_favorite_menu_guard_test.dart`（4 test 全绿）：钉死两处菜单含 favorite 项 + switch 分支各自填状态后走 `_toggleFavoriteSentence`。触屏 WebView 手势菜单只能真机跑，故与既有 `reader_mobile_selection_export_menu_guard` 同法用源码扫描。
- 回归：选区/收藏相关既有守卫共 47 test 全绿；`flutter analyze` 0 issue；bugs per-file guard 绿。
- **待真机复验**：手机长按拖选 → 菜单点「收藏」→ 句子进收藏夹（toast「已收藏」）。

bump 1.2.0+803。