### PR TITLE
fix(reader): 请求高刷新率 (Android display mode + iOS ProMotion)

### DIFF
--- a/hibiki/android/app/src/main/java/app/hibiki/reader/MainActivity.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/MainActivity.java
@@ -134,6 +134,45 @@ public class MainActivity extends AudioServiceActivity {
         super.onCreate(savedInstanceState);
 
         disableSystemFocusHighlight();
+        requestHighestRefreshRate();
+    }
+
+    // 主动向系统请求本窗口的最高刷新率显示模式。Flutter/WebView 阅读器本身不会
+    // 请求高刷，很多机型（尤其自适应刷新/省电策略下）会把没表态的第三方 App 钉在
+    // 60Hz 甚至更低，读书时整屏明显掉刷新率。这里在 getSupportedModes() 里挑一个
+    // 与当前分辨率相同、刷新率最高的模式，写进 window.preferredDisplayModeId（等价
+    // 于 flutter_displaymode 的原生做法，但不引入依赖）。只声明偏好、交由系统调度；
+    // 拿不到 / 无更高模式 / 任意异常都安全退化为系统默认，never break userspace。
+    private void requestHighestRefreshRate() {
+        try {
+            android.view.Display display;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                display = getDisplay();
+            } else {
+                display = getWindowManager().getDefaultDisplay();
+            }
+            if (display == null) return;
+            android.view.Display.Mode current = display.getMode();
+            android.view.Display.Mode[] modes = display.getSupportedModes();
+            if (modes == null || modes.length == 0) return;
+            int bestModeId = 0;
+            float bestRate = current.getRefreshRate();
+            for (android.view.Display.Mode mode : modes) {
+                // 只在与当前分辨率一致的模式里挑，避免顺带改了分辨率。
+                if (mode.getPhysicalWidth() == current.getPhysicalWidth()
+                        && mode.getPhysicalHeight() == current.getPhysicalHeight()
+                        && mode.getRefreshRate() > bestRate + 1f) {
+                    bestRate = mode.getRefreshRate();
+                    bestModeId = mode.getModeId();
+                }
+            }
+            if (bestModeId == 0) return; // 当前已是最高刷新率模式。
+            WindowManager.LayoutParams lp = getWindow().getAttributes();
+            lp.preferredDisplayModeId = bestModeId;
+            getWindow().setAttributes(lp);
+        } catch (Exception e) {
+            android.util.Log.w("hibiki-refresh", "request high refresh rate failed", e);
+        }
     }
 
     // BUG-195: On API 26+ every View defaults to defaultFocusHighlightEnabled=true,

--- a/hibiki/ios/Runner/Info.plist
+++ b/hibiki/ios/Runner/Info.plist
@@ -59,9 +59,12 @@
 		<false/>
 		<key>UIStatusBarHidden</key>
 		<false/>
-			<key>CADisableMinimumFrameDurationOnPhone</key>
-			<false/>
-			<key>UIApplicationSceneManifest</key>
+		<!-- 解放 ProMotion 120Hz：置 false（或缺省）时 CoreAnimation 把 Flutter
+		     渲染钉在 60fps 上限，读书/滚动在 120Hz 机型上明显掉刷新率。true =
+		     允许高于 60fps 的帧率，交由系统按内容需求调度。 -->
+		<key>CADisableMinimumFrameDurationOnPhone</key>
+		<true/>
+		<key>UIApplicationSceneManifest</key>
 			<dict>
 				<key>UIApplicationSupportsMultipleScenes</key>
 				<false/>


### PR DESCRIPTION
## 问题
用户反馈「书籍里面的阅读设置，刷新率明显只有 30 左右」——读书时整屏刷新率很低。

排查确认阅读设置里**没有**任何叫「刷新率」的选项；真因是 **App 从不向系统请求高刷**：
- Android `MainActivity` 未设 `preferredDisplayModeId`，也无 `flutter_displaymode` 依赖。很多机型在自适应刷新/省电策略下会把没表态的第三方 App 钉在 60Hz 甚至更低。
- iOS `Info.plist` 的 `CADisableMinimumFrameDurationOnPhone` 为 `false`，CoreAnimation 把 Flutter 渲染钉在 60fps 上限（ProMotion 机型无法上 120Hz）。

## 改动
- **Android** (`MainActivity.onCreate`)：新增 `requestHighestRefreshRate()`，在 `display.getSupportedModes()` 里挑与当前分辨率一致、刷新率最高的 `Display.Mode`，写进 `window.preferredDisplayModeId`（等价 flutter_displaymode 的原生做法，不引入依赖）。拿不到 display / 无更高模式 / 任意异常都安全退化为系统默认，never break userspace。
- **iOS** (`Info.plist`)：`CADisableMinimumFrameDurationOnPhone` 置 `true`，解放 ProMotion 120Hz。
- Desktop（Windows/macOS/Linux）按显示器刷新渲染，非表示模式问题；若桌面也 30fps 则是 WebView 合成吞吐（另案），本 PR 不涉及。

## 验证
- `flutter build apk --debug` 通过，Java 编译干净。
- 模拟器（emulator-5554，单 60Hz 模式）安装启动无崩溃、无 FATAL；`supportedModes` 只有 60Hz → 代码 `bestModeId=0` 安全 no-op，符合设计。
- ⚠️ **高刷实效需在真实 120Hz 机型复测**：模拟器无高刷模式，无法验证 30→高刷的改善。请在真机进 App 读书后用 `adb shell dumpsys display | grep RenderFrameRate` 或系统开发者选项「显示刷新率」确认已升到面板最高刷。