### PR TITLE
fix(reader): 手机滑动翻页灵敏度 + 横排方向 (BUG-854/855)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 834 条。点号进各自文件。
+> 共 836 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-855](bugs/BUG-855-horizontal-swipe-direction-not-flipped.md) | ✅ | ✅ | 横排滑动翻页方向未随书写方向翻转（和竖排一样，应与日语相反） |
+| [BUG-854](bugs/BUG-854-mobile-swipe-insensitive-lookup.md) | ✅ | ✅ | 手机滑动翻页迟钝且短滑误触查词 |
 | [BUG-852](bugs/BUG-852-lyrics-blur-exposes-context.md) | ✅ | ✅ | 歌词模式模糊只盖当前句，前后文暴露 |
 | [BUG-851](bugs/BUG-851-dict-dark-usage-tag-washed.md) | ✅ | ✅ | ダークモードで辞書の使い方タグがライト背景のまま浮く |
 | [BUG-850](bugs/BUG-850-dict-ruby-hspacing-overlap.md) | ✅ | ✅ | 辞書例文の逐字ルビが横方向に重なる |

--- a/docs/bugs/BUG-854-mobile-swipe-insensitive-lookup.md
+++ b/docs/bugs/BUG-854-mobile-swipe-insensitive-lookup.md
@@ -1,0 +1,11 @@
+## BUG-854 · 手机滑动翻页迟钝且短滑误触查词
+- **报告**：2026-07-16（用户：qqbotxiaoxiao）
+- **真实性**：✅ 真 bug — 根因 `hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart:844,851`（旧 `_gestureEnd` 把查词框上界直接取成翻页距离阈值 `$swipeDistThreshold`=72px），阈值本身在 `hibiki/lib/src/reader/reader_settings.dart:411-412`（`baseSwipeDistPx=72 / baseSwipeFastDistPx=36`）。
+- **[x] ① 已修复** — 提交 <PENDING>
+  - 根因：分页触摸 `_gestureEnd` 里「翻页」与「查词」共用同一个 72px：翻页需 `absDx≥72`（或快滑 `≥36 且 900px/s`），而查词分支是 `absDx<72 && absDy<72`。两个 72 相同 → **没有死区**：① 72px 在手机上太长 → 「要滑很长才翻」；② 任何够不到 72 的横滑（如 50px）落进查词分支 → 「翻短了会查词」。
+  - 修复：
+    - 降低默认翻页距离阈值（`reader_settings.dart`）`baseSwipeDistPx 72→44`、`baseSwipeFastDistPx 36→22`（「轻快」档，灵敏度系数仍可上调回旧手感）。
+    - 新增固定「原地轻点」半径常量 `ReaderSettings.tapSlopPx=28`（**不随灵敏度缩放**），注入为 `$tapSlop`。
+    - `_gestureEnd` 查词分支由 `absDx<$swipeDistThreshold && absDy<$swipeDistThreshold` 改为 `absDx<=$tapSlop && absDy<=$tapSlop`：只有两轴 ≤28px 的原地轻点才查词；横向主导、超 28px 却够不到翻页阈值的短滑落到两分支之外 → **空操作**（既不翻页也不查词），切断短滑误查词。TODO-971 慢点词由「去掉 500ms 时限」保住（保留），不靠 72px 大框（副作用，回收）。
+- **[x] ② 已加自动化测试** — `hibiki/test/reader/reader_paged_touch_swipe_behavior_test.js`（新增可控时钟建模速度：慢 30px 横滑=死区无查词、快 30px flick=翻页、小 25px 点=查词；vertical drag 死区）+ `hibiki/test/reader/swipe_page_turn_sensitivity_test.dart`（阈值 44/22 及缩放 + `tapSlopPx==28` 守卫）。
+- **备注**：触摸「手感」需用户真机复测；单测/harness 只锁逻辑判据。与 [[BUG-855]]（横排滑动方向）同 PR、同一次真机验证。

--- a/docs/bugs/BUG-855-horizontal-swipe-direction-not-flipped.md
+++ b/docs/bugs/BUG-855-horizontal-swipe-direction-not-flipped.md
@@ -1,0 +1,8 @@
+## BUG-855 · 横排滑动翻页方向未随书写方向翻转（和竖排一样，应与日语相反）
+- **报告**：2026-07-16（用户：qqbotxiaoxiao）
+- **真实性**：✅ 真 bug — 根因 `hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart` 的 `onSwipe` handler（旧代码只用 `invertSwipeDirection` 映射 `'left'/'right'`→forward/backward，不读书写方向）。对照：键盘方向键早已在 `hibiki/lib/src/shortcuts/reader_space_override.dart:80` 用 `leftIsForward = rtl ^ reverse` 按书写方向翻转，滑动路径漏了。
+- **[x] ① 已修复** — 提交 <PENDING>
+  - 根因：触摸/鼠标滑动翻页方向此前只看 `invertSwipeDirection`（默认 true，为竖排 vertical-rl 调），横排 `horizontal-tb` 复用同一套映射 → 横排「下一页」方向与竖排相同（错），本该相反：竖排 RTL 下一页在左，横排 LTR 下一页在右。
+  - 修复：新增纯谓词 `swipeLeftIsForward({invert, rtl}) => invert ^ rtl`（`reader_space_override.dart`），与键盘 `rtl ^ reverse` 同构；`onSwipe` handler 改用它算 `leftIsForward`，`_isRtlReading` 传入。四象限：竖排默认(rtl=T,invert=T)→false（右滑前进，**与历史一致，不破坏手感**）；横排默认(rtl=F,invert=T)→true（左滑前进，LTR 下一页在右）。
+- **[x] ② 已加自动化测试** — `hibiki/test/reader/swipe_page_turn_direction_test.dart`（锁 `swipeLeftIsForward` 四象限：横竖排恒相反、竖排默认不变、invert 开关整体取反）。
+- **备注**：真机需在横排模式复测滑动方向；竖排行为不变（回归风险低）。与 [[BUG-854]] 同 PR、同一次真机验证。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -458,12 +458,14 @@ extension _ReaderWebView on _ReaderHibikiPageState {
 
   String _buildReaderSetupScript({String? sasayakiCuesJson}) {
     final ReaderSettings s = _settings!;
-    // TODO-113: 滑动翻页距离阈值随灵敏度系数缩放。基础值 72px（纯距离触发）/ 36px
-    // （配合速度的快速短滑触发），系数 1.0 = 原手感，越大越迟钝（需滑得更远）。
+    // TODO-113: 滑动翻页距离阈值随灵敏度系数缩放。基础值 44px（纯距离触发）/ 22px
+    // （配合速度的快速短滑触发），系数 1.0 = 默认「轻快」手感，越大越迟钝（需滑得更远）。
     final ({int dist, int fastDist}) swipeThresholds =
         ReaderSettings.swipePageTurnDistThresholds(s.swipePageTurnSensitivity);
     final int swipeDistThreshold = swipeThresholds.dist;
     final int swipeFastDistThreshold = swipeThresholds.fastDist;
+    // 查词「原地轻点」半径（固定，不随灵敏度缩放）：与翻页距离阈值解耦，杜绝短滑误查词。
+    const int tapSlop = ReaderSettings.tapSlopPx;
     // BUG-239: 连续模式靠原生滚动（滚动轴 = 书写轴），章间切换走边界手势 IIFE。
     // _gestureEnd 的 onSwipe（90% 整屏跳页）只在分页模式有意义；连续模式回传会与
     // 原生滚动产生轴向冲突，故注入 continuousMode 标志在 _gestureEnd 内门控。
@@ -846,14 +848,13 @@ extension _ReaderWebView on _ReaderHibikiPageState {
       } else {
         window.flutter_inappwebview.callHandler('onSwipe', 'right');
       }
-    } else if (absDx < $swipeDistThreshold && absDy < $swipeDistThreshold) {
-      // TODO-971: 消除「20~72px 漂移既不算 tap 也不算 swipe」的死区。旧判据
-      // `absDx<20 && absDy<20 && elapsed<500` 把稳而慢 / 略有漂移的点词手势整个丢
-      // 掉（用户报「单词难点中」）。把 tap 上界从 20px 放宽到 swipe 距离阈值
-      // （$swipeDistThreshold），并去掉 500ms 时限：在「翻页阈值」以内的非翻页手势
-      // 一律当点击查词。仍保留 swipe 阈值上界，使连续模式的整页竖向滚动拖拽（dy 远
-      // 超阈值）不会被误判成 tap 触发查词（保留原 20px 时「大拖拽不查词」的语义、
-      // 只是把可点击区从 20px 扩到 72px）。
+    } else if (absDx <= $tapSlop && absDy <= $tapSlop) {
+      // BUG-手机翻短了会查词：查词框与翻页距离阈值**解耦**。旧判据把上界取成
+      // swipe 距离阈值（72px），于是任何够不到翻页阈值的横滑（如 50px）都落进这里被
+      // 当成点词。改成固定的「原地轻点」半径 $tapSlop（28px，两轴各 ≤）：只有真正
+      // 原地轻点才查词；横向主导、超出此半径却够不到翻页阈值的短滑落到本 if 之外
+      // → **空操作**（既不翻页也不查词），彻底切断短滑误查词。TODO-971 真正治好慢
+      // 点词的是去掉 500ms 时限（保留），不是把框放大到 72（那步是副作用，现回收）。
       var tapEl = document.elementFromPoint(x, y);
       if (_hoshiRevealBlurredImage(tapEl)) {
         if (e && e.preventDefault) e.preventDefault();
@@ -1690,14 +1691,22 @@ extension _ReaderWebView on _ReaderHibikiPageState {
             final String dir = args[0] as String;
             final bool invert =
                 ReaderHibikiSource.instance.invertSwipeDirection;
+            // BUG-横排滑动翻页方向不随书写方向翻转：滑动/鼠标拖动翻页此前只看
+            // invertSwipeDirection 开关，不看书写方向，横排与竖排共用同一套映射。
+            // 键盘方向键早已用 `leftIsForward = rtl ^ reverse` 按书写方向翻转
+            // （resolveReaderArrowPageTurn），滑动却漏了。改用同构的纯谓词
+            // swipeLeftIsForward(invert ^ rtl)：竖排(rtl=true)默认手感不变，横排
+            // (rtl=false)整体反转——向左滑=前进（LTR 下一页在右，推内容向左露出）。
+            final bool leftIsForward =
+                swipeLeftIsForward(invert: invert, rtl: _isRtlReading);
             if (dir == 'left') {
-              _paginate(invert
-                  ? ReaderNavigationDirection.backward
-                  : ReaderNavigationDirection.forward);
-            } else if (dir == 'right') {
-              _paginate(invert
+              _paginate(leftIsForward
                   ? ReaderNavigationDirection.forward
                   : ReaderNavigationDirection.backward);
+            } else if (dir == 'right') {
+              _paginate(leftIsForward
+                  ? ReaderNavigationDirection.backward
+                  : ReaderNavigationDirection.forward);
             }
           },
         );

--- a/hibiki/lib/src/reader/reader_settings.dart
+++ b/hibiki/lib/src/reader/reader_settings.dart
@@ -394,7 +394,7 @@ class ReaderSettings {
 
   /// 翻页滑动灵敏度系数（TODO-113）。1.0 = 默认手感；<1 更灵敏（更短的滑动即可
   /// 翻页），>1 更迟钝（需滑得更远）。系数缩放 JS 端 `_gestureEnd` 的基础距离阈值
-  /// （72px / 快速短滑 36px），见 reader_hibiki_page.dart `_buildReaderSetupScript`。
+  /// （44px / 快速短滑 22px），见 reader_hibiki_page.dart `_buildReaderSetupScript`。
   static double normalizeSwipePageTurnSensitivity(num value) =>
       value.toDouble().clamp(0.3, 2.0).toDouble();
 
@@ -406,10 +406,24 @@ class ReaderSettings {
         normalizeSwipePageTurnSensitivity(v),
       );
 
-  /// 基础滑动翻页距离阈值（px）：纯距离触发 [baseDistPx]，配合速度的快速短滑触发
-  /// [baseFastDistPx]。系数 1.0 时与旧硬编码值一致（72 / 36）。
-  static const int baseSwipeDistPx = 72;
-  static const int baseSwipeFastDistPx = 36;
+  /// 基础滑动翻页距离阈值（px）：纯距离触发 [baseSwipeDistPx]，配合速度的快速短滑
+  /// 触发 [baseSwipeFastDistPx]。系数 1.0 = 默认手感（44 / 22）。
+  ///
+  /// BUG-手机翻页迟钝：旧默认 72 / 36 是照桌面鼠标手感定的，手机上「要滑很长才翻」。
+  /// 降到 44 / 22（「轻快」档），正常一滑即翻；灵敏度系数仍可上调回旧手感（系数≈1.6
+  /// → 70 / 35）。
+  static const int baseSwipeDistPx = 44;
+  static const int baseSwipeFastDistPx = 22;
+
+  /// 查词「原地轻点」判定半径（px，两轴各 ≤ 此值才算点击查词）。**固定值、不随灵敏度
+  /// 系数缩放**——它是「点」与「滑」的形状判据，不是翻页距离。
+  ///
+  /// BUG-手机翻短了会查词：旧实现把查词框上界直接取成翻页距离阈值（72px），于是任何
+  /// 够不到翻页阈值的横滑都落进查词分支被当成点词。解耦后：只有两轴位移都 ≤ 28px 的
+  /// 原地轻点才查词；横向主导、超过此半径但够不到翻页阈值的短滑一律**空操作**（既不
+  /// 翻页也不查词），彻底切断「短滑误查词」。TODO-971 真正治好慢点词靠的是去掉 500ms
+  /// 时限（保留），不是把框放大到 72（那是副作用）。
+  static const int tapSlopPx = 28;
 
   /// 把灵敏度系数 [sensitivity] 解析成 JS `_gestureEnd` 用的两个距离阈值（px）。
   /// 系数越大阈值越大（越迟钝，需滑得更远）；越小越灵敏。这是 reader 注入脚本与

--- a/hibiki/lib/src/shortcuts/reader_space_override.dart
+++ b/hibiki/lib/src/shortcuts/reader_space_override.dart
@@ -97,6 +97,22 @@ ShortcutAction? resolveReaderArrowPageTurn({
   return null;
 }
 
+/// 触摸 / 鼠标滑动翻页方向必须跟随书写方向（横排 LTR 与竖排 vertical-rl 相反），
+/// 与键盘方向键 [resolveReaderArrowPageTurn] 的 `leftIsForward = rtl ^ reverse` 同构。
+///
+/// 返回「向左滑（`onSwipe('left')`，手指 dx<0）是否 = 前进」。
+/// - [invert] = 用户 `invertSwipeDirection` 开关（默认 true）。
+/// - [rtl] = 竖排 vertical-rl（日文默认，`_isRtlReading`）。
+///
+/// `invert ^ rtl` 的四象限：
+/// - 竖排默认(rtl=T, invert=T) → false：右滑前进（**与历史行为一致**，不破坏既有手感）。
+/// - 横排默认(rtl=F, invert=T) → true：左滑前进（LTR 下一页在右，推内容向左露出=前进）。
+///
+/// 此前滑动路径只用 [invert] 不看书写方向，横排与竖排共用同一套映射（横排方向反了）；
+/// 键盘路径早已翻转，滑动漏了，本谓词补齐。
+bool swipeLeftIsForward({required bool invert, required bool rtl}) =>
+    invert ^ rtl;
+
 /// 桌面 Windows 阅读器「Ctrl+C 复制选中文字」止血兼容层（BUG-402）。
 ///
 /// 根因：Windows 端 WebView 走 WebView2 合成模式，fork 的

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+804
+version: 1.2.0+805
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/reader/reader_paged_touch_swipe_behavior_test.js
+++ b/hibiki/test/reader/reader_paged_touch_swipe_behavior_test.js
@@ -65,6 +65,16 @@ function makeHarness(continuousMode) {
   const taps = [];
   let currentDispatch = null;
 
+  // Controllable clock so tests can model gesture DURATION (hence velocity):
+  // _gestureEnd computes `velocity = absDx / elapsed * 1000`. With the real Date
+  // every synchronous dispatch has elapsed≈0 → velocity≈infinity, which would
+  // make the fast-swipe path fire for any absDx>=fastDist and make a "slow short
+  // drag = dead zone" case untestable. advance(ms) between touchstart and
+  // touchend sets `elapsed`, so a slow drift stays below the 900px/s fast gate.
+  let clockMs = 1000;
+  function FakeDate() {}
+  FakeDate.now = function () { return clockMs; };
+
   const body = { writingMode: 'horizontal-tb' };
   const fakeElement = {
     tagName: 'P',
@@ -123,7 +133,7 @@ function makeHarness(continuousMode) {
 
   const sandbox = {
     Node: { TEXT_NODE: 3 },
-    Date,
+    Date: FakeDate,
     Math,
     URL,
     document: documentObj,
@@ -142,8 +152,9 @@ function makeHarness(continuousMode) {
     .replace(/\$vnMode/g, 'false')
     .replace(/\$vnClickAdvance/g, 'false')
     .replace(/\$hoverAutoLookup/g, 'false')
-    .replace(/\$swipeDistThreshold/g, '72')
-    .replace(/\$swipeFastDistThreshold/g, '36')
+    .replace(/\$swipeDistThreshold/g, '44')
+    .replace(/\$swipeFastDistThreshold/g, '22')
+    .replace(/\$tapSlop/g, '28')
     // BUG-712 ①: the tap-gate mirror line
     // `window.__hoshiTapGate = { chrome: $_showChrome, lookup:
     // ${ReaderHibikiSource.instance.highlightOnTap}, maxLen: 400 };` is emitted
@@ -167,7 +178,9 @@ function makeHarness(continuousMode) {
     }
   }
 
-  return { dispatch, swipes, taps };
+  function advance(ms) { clockMs += ms; }
+
+  return { dispatch, swipes, taps, advance };
 }
 
 function pointerEvt(type, x, y, button, buttons) {
@@ -197,7 +210,7 @@ function touchEvt(x, y) {
   h.dispatch('touchstart', touchEvt(200, 300));
   h.dispatch('pointermove', pointerEvt('touch', 150, 300, -1, 1));
   h.dispatch('pointermove', pointerEvt('touch', 80, 300, -1, 1));
-  h.dispatch('touchend', touchEvt(80, 300)); // dx = -120 (> 72)
+  h.dispatch('touchend', touchEvt(80, 300)); // dx = -120 (> 44)
   h.dispatch('pointerup', pointerEvt('touch', 80, 300, 0, 0));
   // The page turn must come from the touchend path; pointerup must stay silent.
   // Reverting the fix makes touchend emit nothing (swipe lost to the pointer
@@ -250,42 +263,41 @@ function touchEvt(x, y) {
   );
 })();
 
-// TODO-971: PAGED mode, a 30px drift (below the 72px swipe threshold but above
-// the old 20px tap upper-bound) must be treated as a TAP, not silently dropped.
-// Pre-fix `_gestureEnd` had `else if (absDx < 20 && absDy < 20 && elapsed < 500)`
-// for the tap branch, so a 20~72px drift hit neither swipe nor tap -> the word
-// lookup was lost ("单词点不中"). The fix drops the 20px /
-// 500ms gate: anything that did NOT trigger a page swipe is a tap.
+// BUG-手机翻短了会查词: PAGED mode, a SLOW ~30px horizontal drift is a short,
+// under-powered swipe -- it must be a DEAD ZONE (no page turn, and crucially NO
+// word lookup). dx=30 is beyond the 28px tap-slop (so not a tap) yet below the
+// 44px pure-distance swipe threshold, and the slow duration keeps velocity under
+// the 900px/s fast gate. Pre-fix the tap box == the 72px swipe threshold, so this
+// fell into the tap branch and fired a spurious lookup ("翻短了会查词").
 (function () {
   const h = makeHarness(false);
   h.dispatch('pointerdown', pointerEvt('touch', 200, 300, 0, 1));
   h.dispatch('touchstart', touchEvt(200, 300));
+  h.advance(300); // slow drift: velocity = 30/300*1000 = 100px/s (< 900)
   h.dispatch('pointermove', pointerEvt('touch', 215, 305, -1, 1));
-  h.dispatch('touchend', touchEvt(230, 308)); // dx = +30 (>20, <72), dy = +8
+  h.dispatch('touchend', touchEvt(230, 308)); // dx = +30 (>28 slop, <44 dist), dy = +8
   h.dispatch('pointerup', pointerEvt('touch', 230, 308, 0, 0));
   assert.deepStrictEqual(
     h.swipes, [],
-    'a 30px drift must NOT page-turn (below swipe threshold); got '
+    'a slow 30px horizontal drift must NOT page-turn (below swipe distance); got '
       + JSON.stringify(h.swipes),
   );
   assert.deepStrictEqual(
-    h.taps, [230],
-    'a 30px drift (no swipe) must be treated as a tap, not dropped; got '
-      + JSON.stringify(h.taps),
+    h.taps, [],
+    'a slow 30px horizontal drift must be a DEAD ZONE, never a word lookup '
+      + '(fixes 翻短了会查词); got ' + JSON.stringify(h.taps),
   );
 })();
 
-// TODO-971 guard: a LARGE vertical drag (dy=120, above the 72px swipe distance)
-// is a scroll/drag gesture, NOT a tap. The fix caps the tap window at the swipe
-// distance threshold so continuous-mode scroll drags don't fire a spurious word
-// lookup. (Vertical-dominant means absDx<absDy so the swipe branch never fires;
-// without the cap this would wrongly emit onTap.)
+// A LARGE vertical drag (dy=120) is a scroll/drag gesture, NOT a tap: absDy
+// exceeds the 28px tap-slop so the tap branch is skipped, and absDx<absDy keeps
+// the swipe branch off -> dead zone, no spurious lookup.
 (function () {
   const h = makeHarness(false);
   h.dispatch('pointerdown', pointerEvt('touch', 200, 300, 0, 1));
   h.dispatch('touchstart', touchEvt(200, 300));
   h.dispatch('pointermove', pointerEvt('touch', 205, 240, -1, 1));
-  h.dispatch('touchend', touchEvt(208, 180)); // dx = +8, dy = -120 (>72)
+  h.dispatch('touchend', touchEvt(208, 180)); // dx = +8, dy = -120 (>28 slop)
   h.dispatch('pointerup', pointerEvt('touch', 208, 180, 0, 0));
   assert.deepStrictEqual(
     h.swipes, [], 'a vertical drag must not page-turn; got '
@@ -293,7 +305,45 @@ function touchEvt(x, y) {
   );
   assert.deepStrictEqual(
     h.taps, [],
-    'a large (>72px) drag is a scroll, not a tap; must NOT emit onTap; got '
+    'a large vertical drag is a scroll, not a tap; must NOT emit onTap; got '
+      + JSON.stringify(h.taps),
+  );
+})();
+
+// BUG-手机翻页迟钝: a FAST short flick (dx=30 over 20ms -> 1500px/s) must turn the
+// page via the fast-swipe gate (absDx>=22 fastDist AND velocity>=900), so users
+// no longer have to drag a long way. dx=30 is below the 44px pure-distance
+// threshold; only the fast path makes it a page turn.
+(function () {
+  const h = makeHarness(false);
+  h.dispatch('pointerdown', pointerEvt('touch', 200, 300, 0, 1));
+  h.dispatch('touchstart', touchEvt(200, 300));
+  h.advance(20); // fast flick: velocity = 30/20*1000 = 1500px/s (>= 900)
+  h.dispatch('pointermove', pointerEvt('touch', 185, 300, -1, 1));
+  h.dispatch('touchend', touchEvt(170, 300)); // dx = -30 (leftward), dy = 0
+  h.dispatch('pointerup', pointerEvt('touch', 170, 300, 0, 0));
+  assert.deepStrictEqual(
+    h.swipes, ['left@touchend'],
+    'a fast 30px flick must page-turn via the fast gate; got '
+      + JSON.stringify(h.swipes),
+  );
+})();
+
+// A small horizontal tap (dx=25, within the 28px slop) is still a word lookup:
+// the tap box stays generous enough for normal finger jitter, so on-text tapping
+// keeps working (the TODO-971 "单词点不中" concern is preserved by the removed
+// 500ms time gate, not by a 72px box).
+(function () {
+  const h = makeHarness(false);
+  h.dispatch('pointerdown', pointerEvt('touch', 200, 300, 0, 1));
+  h.dispatch('touchstart', touchEvt(200, 300));
+  h.advance(300); // slow, so the fast-swipe gate never fires
+  h.dispatch('touchend', touchEvt(225, 306)); // dx = +25 (<=28 slop), dy = +6
+  h.dispatch('pointerup', pointerEvt('touch', 225, 306, 0, 0));
+  assert.deepStrictEqual(h.swipes, [], 'a small tap must not page-turn');
+  assert.deepStrictEqual(
+    h.taps, [225],
+    'a small (<=28px) horizontal tap must still report onTap (word lookup); got '
       + JSON.stringify(h.taps),
   );
 })();

--- a/hibiki/test/reader/swipe_page_turn_direction_test.dart
+++ b/hibiki/test/reader/swipe_page_turn_direction_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/shortcuts/reader_space_override.dart';
+
+/// BUG-横排滑动翻页方向不随书写方向翻转：滑动 / 鼠标拖动翻页方向此前只看
+/// `invertSwipeDirection` 开关，横排与竖排共用同一套映射（横排方向反了）。键盘方向
+/// 键早已用 `leftIsForward = rtl ^ reverse` 翻转，滑动漏了。本测试锁住补齐后的纯谓词
+/// [swipeLeftIsForward]（`invert ^ rtl`）：横排与竖排相反，且竖排默认手感不变。
+void main() {
+  group('swipeLeftIsForward: 横排与竖排方向必须相反', () {
+    test('竖排默认(rtl=T, invert=T) → 左滑=后退（与历史行为一致，不破坏手感）', () {
+      expect(swipeLeftIsForward(invert: true, rtl: true), isFalse);
+    });
+
+    test('横排默认(rtl=F, invert=T) → 左滑=前进（相对竖排反转）', () {
+      expect(swipeLeftIsForward(invert: true, rtl: false), isTrue);
+    });
+
+    test('同一 invert 下，横排与竖排的「左滑是否前进」恒相反', () {
+      for (final bool invert in <bool>[true, false]) {
+        expect(
+          swipeLeftIsForward(invert: invert, rtl: true),
+          isNot(swipeLeftIsForward(invert: invert, rtl: false)),
+          reason: 'invert=$invert 时横排/竖排方向必须相反',
+        );
+      }
+    });
+
+    test('invertSwipeDirection 开关在任一书写方向下都整体取反', () {
+      for (final bool rtl in <bool>[true, false]) {
+        expect(
+          swipeLeftIsForward(invert: true, rtl: rtl),
+          isNot(swipeLeftIsForward(invert: false, rtl: rtl)),
+          reason: 'rtl=$rtl 时 invert 开关必须整体反转左右语义',
+        );
+      }
+    });
+  });
+}

--- a/hibiki/test/reader/swipe_page_turn_sensitivity_test.dart
+++ b/hibiki/test/reader/swipe_page_turn_sensitivity_test.dart
@@ -5,7 +5,7 @@ import 'package:hibiki/src/reader/reader_settings.dart';
 
 /// TODO-113: 翻页滑动灵敏度系数的持久化 + 阈值生效守卫。
 ///
-/// 系数缩放 JS `_gestureEnd` 的距离阈值（基础 72px / 快速短滑 36px）。reader 注入
+/// 系数缩放 JS `_gestureEnd` 的距离阈值（基础 44px / 快速短滑 22px）。reader 注入
 /// 脚本 `reader_hibiki_page._buildReaderSetupScript` 与本测试共用纯函数
 /// [ReaderSettings.swipePageTurnDistThresholds]，所以「改系数 → 阈值变」在 UI 与 JS
 /// 两侧一致；真正的触摸翻页手感走 WebView，归设备集成验证。
@@ -51,11 +51,11 @@ void main() {
   });
 
   group('swipePageTurnDistThresholds (the JS-injected effect)', () {
-    test('sensitivity 1.0 reproduces the legacy hard-coded 72 / 36', () {
+    test('sensitivity 1.0 is the default light 44 / 22', () {
       final ({int dist, int fastDist}) t =
           ReaderSettings.swipePageTurnDistThresholds(1.0);
-      expect(t.dist, 72);
-      expect(t.fastDist, 36);
+      expect(t.dist, 44);
+      expect(t.fastDist, 22);
     });
 
     test('higher sensitivity raises both thresholds (more deliberate swipe)',
@@ -66,17 +66,22 @@ void main() {
           ReaderSettings.swipePageTurnDistThresholds(2.0);
       expect(high.dist, greaterThan(low.dist));
       expect(high.fastDist, greaterThan(low.fastDist));
-      expect(high.dist, 144);
-      expect(high.fastDist, 72);
+      expect(high.dist, 88);
+      expect(high.fastDist, 44);
     });
 
     test('lower sensitivity lowers both thresholds (more sensitive swipe)', () {
       final ({int dist, int fastDist}) t =
           ReaderSettings.swipePageTurnDistThresholds(0.5);
-      expect(t.dist, lessThan(72));
-      expect(t.fastDist, lessThan(36));
-      expect(t.dist, 36);
-      expect(t.fastDist, 18);
+      expect(t.dist, lessThan(44));
+      expect(t.fastDist, lessThan(22));
+      expect(t.dist, 22);
+      expect(t.fastDist, 11);
+    });
+
+    test('tapSlopPx is a fixed 28 and NOT scaled by sensitivity', () {
+      // 查词半径与翻页距离阈值解耦：无论灵敏度怎么调，原地轻点判定恒为 28px。
+      expect(ReaderSettings.tapSlopPx, 28);
     });
   });
 }


### PR DESCRIPTION
## 背景（用户报）
1. **横排翻页方向和竖排一样，应与日语相反**（BUG-855）
2. **手机翻页很不灵敏，要滑很长；翻短了甚至会查词**（BUG-854）

## 根因
两处都在阅读器分页滑动路径，且都源于「缺了键盘路径早已有的处理」：

- **BUG-854**：`_gestureEnd` 里「翻页」判定 (`absDx≥72`) 与「查词」判定 (`absDx<72 && absDy<72`) **共用同一个 72px**，中间没有死区。→ ① 72px 手机上太长；② 任何够不到 72 的横滑落进查词分支被当成点词。
- **BUG-855**：`onSwipe` handler 只用 `invertSwipeDirection` 映射方向，**不看书写方向**，横排与竖排共用同一套。键盘方向键早已用 `leftIsForward = rtl ^ reverse` 翻转（`resolveReaderArrowPageTurn`），滑动漏了。

## 修复
- 翻页基础阈值 `72/36 → 44/22`（「轻快」默认，用户选定；灵敏度系数仍可上调回旧手感）。
- 新增固定「原地轻点」半径 `ReaderSettings.tapSlopPx = 28`（**不随灵敏度缩放**），查词分支解耦为 `两轴 ≤28px`；横向主导、超 28px 却够不到翻页阈值的短滑 → **空操作**（既不翻页也不查词），切断短滑误查词。
- 新增纯谓词 `swipeLeftIsForward(invert ^ rtl)`（与键盘 `rtl ^ reverse` 同构），`onSwipe` 改用它：**竖排默认手感不变**（右滑前进），**横排整体反转**（左滑前进，LTR 下一页在右）。

## 测试
- `reader_paged_touch_swipe_behavior_test.js`：引入可控时钟建模手势速度——慢 30px 横滑=死区无查词、快 30px flick=翻页、小 25px 点=查词、竖向拖动=死区。
- `swipe_page_turn_sensitivity_test.dart`：阈值 44/22 及缩放，新增 `tapSlopPx==28` 守卫。
- 新增 `swipe_page_turn_direction_test.dart`：锁 `swipeLeftIsForward` 四象限（横竖排恒相反、竖排默认不变、invert 整体取反）。
- `flutter analyze` 全量 0 issue；上述测试 + per-file bug 守卫全绿。

## 待真机
触摸「手感」和横排方向属物理手势，单测只锁逻辑判据；**需用户在手机上复测**：横排滑动方向是否正确、短滑不再误查词、正常一滑即翻、竖排行为不变。