### PR TITLE
fix(anki): BUG-856 覆盖卡片整体替换字段，句子原文不再漏更新

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 837 条。点号进各自文件。
+> 共 838 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-856](bugs/BUG-856-anki-overwrite-sentence.md) | ✅ | ✅ | Anki 覆盖卡片只覆盖图片和语音，原文句子未覆盖 |
 | [BUG-855](bugs/BUG-855-ass-fontsize-em-vs-cell.md) | ✅ | ✅ | ASS Fontsize 被当 em 用，字号比 mpv 整体大一截 |
 | [BUG-854](bugs/BUG-854-selection-menu-favorite.md) | ✅ | ✅ | 移动端选区菜单缺少收藏项 |
 | [BUG-853](bugs/BUG-853-video-ime-space-pause.md) | ✅ | ✅ | 日语输入法激活时视频页按空格无法暂停 |

--- a/docs/bugs/BUG-856-anki-overwrite-sentence.md
+++ b/docs/bugs/BUG-856-anki-overwrite-sentence.md
@@ -1,0 +1,50 @@
+## BUG-856 · Anki 覆盖卡片只覆盖图片和语音，原文句子未覆盖
+- **报告**：2026-07-16（用户：）
+- **真实性**：✅ 真 bug。根因 `packages/hibiki_anki/lib/src/base_anki_repository.dart:340`（空值守卫被覆盖路径误用）。
+- **[x] ① 已修复** — commit 见下方；`base_anki_repository.dart` `buildMinedFields` 加 `keepEmpty`，两后端 `updateMinedNote` 走 `keepEmpty:true` + 守卫改「所有字段皆空白才拒绝」。
+- **[x] ② 已加自动化测试** — `packages/hibiki_anki/test/note_id_and_update_test.dart`（BUG-856 group，AnkiConnect）+ `packages/hibiki_anki/test/ankidroid_overwrite_test.dart`（AnkiDroid 空句清空）。
+- **备注**：
+
+### 根因（三方独立确认：主代理 + 2 个探索子代理）
+覆盖「已有卡片」走 `updateMinedNote` → `_renderMinedFields` → `buildMinedFields`。
+`base_anki_repository.dart:340` 的守卫 `if (value.trim().isNotEmpty) fields[entry.key] = value;`
+被**新建**与**覆盖**两条路径共用：
+- 新建：渲染为空的字段跳过 = 空字段，无害。
+- 覆盖：渲染为空的字段被跳过 → 字段名不进 map → 两后端 native `updateNoteFields`
+  「只覆盖给出的字段，未给出的保留旧值」→ 旧值**被静默保留**。
+
+`{sentence}`（`anki_models.dart:502-519`）只取自 `context.sentence`，而句子**从不随 popup
+制卡 payload 传递**（`hibiki/assets/popup/popup.js:1294-1310` 的 `buildMinePayload` 无
+`sentence` 键），只靠宿主**瞬时选区状态**（reader `currentMediaSource.currentSentence`、
+video `_lastLookupSentence`、overlay `sentenceContext`）。覆盖经「✓→异步查卡→操作面板→
+点击」或音量键导航后选区可能已清空 → 句子渲染空 → 被上面守卫丢弃 → 卡片旧句保留；
+而图片(`{card-image}`←书封/GIF)、句子音频(`{sentence-audio}`←cue 时间窗)来自与选区无关的
+独立存活状态，渲染非空 → 正常覆盖。故「只覆盖图片和语音、原文句子不覆盖」。
+
+各 surface 的 mine/update 在 Dart 层**对称**取/传句子，无漏传参数——这是同一份代码在
+两个时刻的不同运行态 + 覆盖误用新建的空值守卫。
+
+### 修复（用户选定语义：覆盖=整体替换，句子为空则随之清空）
+- `packages/hibiki_anki/lib/src/base_anki_repository.dart`：`buildMinedFields` 加
+  `bool keepEmpty=false`；`true` 时保留所有映射字段（含渲染为空的）。
+- `packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart` +
+  `.../ankidroid/anki_repository.dart`：`_renderMinedFields` 透传 `keepEmpty`；
+  `updateMinedNote` 传 `keepEmpty:true`，并把「拒绝清空」守卫从 `fields.isEmpty` 改成
+  `fields.values.every((v)=>v.trim().isEmpty)`（**所有**字段皆空白才拒绝清整卡；空映射
+  仍拒绝）。
+- 新建路径 `mineEntry` 不传 `keepEmpty`（默认 false），行为零变化（Never break userspace）。
+
+### 测试
+- `note_id_and_update_test.dart`「BUG-856」group（AnkiConnect）：覆盖写空 Sentence 字段
+  （清空陈旧句）/ 覆盖写新句 / 新建仍丢弃空 Sentence / 全空仍拒绝。
+- `ankidroid_overwrite_test.dart`：AnkiDroid 覆盖发送空 Sentence 字段以真正清空。
+- 消费侧 `hibiki/test/mining/immersion_mining_engine_test.dart` 14 项（含 updateMinedNote
+  路由）通过。
+- `flutter test`（hibiki_anki 全 170 项）通过；`flutter analyze` 仅 1 个**预先存在**、
+  与本次无关的 warning（`ankiconnect_commit_unknown_test.dart:8`）。
+
+### 真机复测清单（待用户验证）
+1. 视频页查词/字幕多选制卡 → 换句/选区清空后点绿 ✓↩ 或操作面板覆盖 → 卡片句子应更新
+   （句子非空覆盖为新句；句子为空则清空，不再残留旧句），图片/音频照常覆盖。
+2. 有声书/阅读器同上。
+3. 剪贴板/悬浮窗覆盖同上。

--- a/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -546,6 +546,7 @@ class AnkiConnectRepository extends BaseAnkiRepository {
     required AnkiSettings settings,
     required AnkiMiningPayload payload,
     required AnkiMiningContext context,
+    bool keepEmpty = false,
   }) async {
     final List<Future<dynamic>> mediaFutures = <Future<dynamic>>[
       context.coverPath != null
@@ -608,6 +609,7 @@ class AnkiConnectRepository extends BaseAnkiRepository {
         payload: mediaPayload,
         context: mediaContext,
         dictionaryMediaTags: dictionaryMediaTags,
+        keepEmpty: keepEmpty,
       ),
       audioWarning: remoteAudio.failureReason,
     );
@@ -620,7 +622,10 @@ class AnkiConnectRepository extends BaseAnkiRepository {
   /// 按 id 覆盖。与 [mineEntry] 一样保证**返回** [MineOutcome] 而非抛出（供调用方
   /// 统一 switch 处理 toast/UI）。不新增卡片、不改 tag、不查重（更新语义）。
   ///
-  /// 渲染出的 fields 为空（什么都没渲染出来）时拒绝更新，避免把已有卡片清空。
+  /// BUG-856：覆盖=整体替换。keepEmpty 令 [_renderMinedFields] 保留所有映射字段
+  /// （含渲染为空的），使 `updateNoteFields` 真正按 id 替换每个映射字段（句子瞬时选区
+  /// 为空时随之清空，不再静默保留旧句）。仅当**所有**字段渲染皆空白时拒绝——那是
+  /// 「没有任何字段映射命中」会清空整卡，才拒绝；部分字段有内容时照常整体替换。
   @override
   Future<MineOutcome> updateMinedNote({
     required int noteId,
@@ -649,11 +654,13 @@ class AnkiConnectRepository extends BaseAnkiRepository {
         settings: settings,
         payload: payload,
         context: context,
+        keepEmpty: true,
       );
       final Map<String, String> fields = rendered.fields;
 
-      // 渲染为空说明没有任何字段映射命中，更新会把已有卡片清空——拒绝。
-      if (fields.isEmpty) {
+      // 所有映射字段渲染皆空白（含无字段映射）说明会把整卡清空——拒绝。部分字段
+      // 有内容时按覆盖语义整体替换（空字段随之清空，Never break userspace 见 BUG-856）。
+      if (fields.values.every((String v) => v.trim().isEmpty)) {
         return MineOutcome.failure(
           'All fields are empty — refusing to clear an existing card. '
           'Check your note type field mappings.',

--- a/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
@@ -298,6 +298,7 @@ class AnkiRepository extends BaseAnkiRepository {
     required AnkiSettings settings,
     required AnkiMiningPayload payload,
     required AnkiMiningContext context,
+    bool keepEmpty = false,
   }) async {
     final List<Future<dynamic>> mediaFutures = <Future<dynamic>>[
       context.coverPath != null
@@ -354,6 +355,7 @@ class AnkiRepository extends BaseAnkiRepository {
         payload: mediaPayload,
         context: mediaContext,
         dictionaryMediaTags: dictionaryMediaTags,
+        keepEmpty: keepEmpty,
       ),
       audioWarning: remoteAudio.failureReason,
     );
@@ -367,7 +369,10 @@ class AnkiRepository extends BaseAnkiRepository {
   /// 保证**返回** [MineOutcome] 而非抛出（供调用方统一 switch 处理 toast/UI）。
   /// 不新增卡片、不改 tag、不查重（更新语义）——与 AnkiConnect 后端对称。
   ///
-  /// 渲染出的 fields 为空（什么都没渲染出来）时拒绝更新，避免把已有卡片清空。
+  /// BUG-856：覆盖=整体替换。keepEmpty 保留所有映射字段（含渲染为空的）。native
+  /// `updateNoteFields` 只覆盖给出的字段——不发空字段则句子瞬时选区为空时旧句被静默
+  /// 保留（表现为「只覆盖图片和语音」），故发送空值以真正清空。仅当所有字段皆空白时
+  /// 拒绝（会清空整卡），部分有内容时照常整体替换。
   @override
   Future<MineOutcome> updateMinedNote({
     required int noteId,
@@ -394,11 +399,13 @@ class AnkiRepository extends BaseAnkiRepository {
         settings: settings,
         payload: payload,
         context: context,
+        keepEmpty: true,
       );
       final Map<String, String> fields = rendered.fields;
 
-      // 渲染为空说明没有任何字段映射命中，更新会把已有卡片清空——拒绝。
-      if (fields.isEmpty) {
+      // 所有映射字段渲染皆空白（含无字段映射）说明会把整卡清空——拒绝。部分字段
+      // 有内容时按覆盖语义整体替换（空字段随之清空，见 BUG-856）。
+      if (fields.values.every((String v) => v.trim().isEmpty)) {
         return MineOutcome.failure(
           'All fields are empty — refusing to clear an existing card. '
           'Check your note type field mappings.',

--- a/packages/hibiki_anki/lib/src/base_anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/base_anki_repository.dart
@@ -323,12 +323,21 @@ abstract class BaseAnkiRepository {
 
   /// 按 [fieldMappings] 渲染卡片字段：模板渲染 → 替换词典媒体占位符 → HTML 规范化。
   /// 两 backend 共用同一逻辑（原先在两个 repo 各有一份 byte 级重复实现）。
+  ///
+  /// BUG-856：[keepEmpty] 区分「新建」与「覆盖」语义。
+  /// - 新建（默认 false）：渲染为空的字段直接跳过——新卡该字段本就空白，无意义。
+  /// - 覆盖（true）：**保留所有映射字段**（含渲染为空的），使 `updateNoteFields`
+  ///   按 id 真正整体替换。否则句子（`{sentence}` 取瞬时选区状态，覆盖那刻可能已空）
+  ///   会被这里过滤掉、字段名不进 map，两后端 native 都「未给出的字段保留旧值」，
+  ///   表现为「只覆盖图片和语音、原文句子不更新」。用户选定语义：覆盖=整体替换，
+  ///   句子为空则随之清空（`updateMinedNote` 另有「全部字段皆空 → 拒绝清整卡」总守卫）。
   @protected
   Map<String, String> buildMinedFields({
     required Map<String, String> fieldMappings,
     required AnkiMiningPayload payload,
     required AnkiMiningContext context,
     required Map<String, String> dictionaryMediaTags,
+    bool keepEmpty = false,
   }) {
     final fields = <String, String>{};
     for (final entry in fieldMappings.entries) {
@@ -337,7 +346,7 @@ abstract class BaseAnkiRepository {
         value = value.replaceAll(mediaEntry.key, mediaEntry.value);
       }
       value = normalizeAnkiDictionaryHtml(value);
-      if (value.trim().isNotEmpty) {
+      if (keepEmpty || value.trim().isNotEmpty) {
         fields[entry.key] = value;
       }
     }

--- a/packages/hibiki_anki/test/ankidroid_overwrite_test.dart
+++ b/packages/hibiki_anki/test/ankidroid_overwrite_test.dart
@@ -161,6 +161,39 @@ void main() {
       expect(fieldValues['Reading'], 'べんきょう');
     });
 
+    // BUG-856: AnkiDroid native updateNoteFields only overwrites the fields it
+    // is GIVEN (unlisted fields keep their old value). So to make "覆盖" a true
+    // integral replace, an empty {sentence} render must still be SENT (empty),
+    // not dropped — otherwise a stale sentence survives while image/audio update.
+    test('overwrite sends an empty Sentence field to clear a stale sentence',
+        () async {
+      final calls = <MethodCall>[];
+      _mockChannel(calls, (call) async {
+        if (call.method == 'updateNoteFields') return null;
+        fail('unexpected channel call: ${call.method}');
+      });
+
+      final repo = _ConfiguredAnkiRepository(_settings().copyWith(
+        fieldMappings: const <String, String>{
+          'Expression': '{expression}',
+          'Sentence': '{sentence}',
+        },
+      ));
+      final outcome = await repo.updateMinedNote(
+        noteId: 42,
+        rawPayloadJson: _payload,
+        context: const AnkiMiningContext(sentence: ''),
+      );
+
+      expect(outcome.result, MineResult.success);
+      final args = Map<String, dynamic>.from(calls.single.arguments as Map);
+      final fieldValues = Map<String, String>.from(args['fieldValues'] as Map);
+      expect(fieldValues['Expression'], '勉強');
+      expect(fieldValues.containsKey('Sentence'), isTrue,
+          reason: 'must send the empty Sentence so native clears it');
+      expect(fieldValues['Sentence'], '');
+    });
+
     test('empty render is refused (does not clear the existing card)',
         () async {
       final calls = <MethodCall>[];

--- a/packages/hibiki_anki/test/note_id_and_update_test.dart
+++ b/packages/hibiki_anki/test/note_id_and_update_test.dart
@@ -24,6 +24,9 @@ class _RecordingService extends AnkiConnectService {
   final List<String> storedFilenames = <String>[];
   final List<({int noteId, Map<String, String> fields})> updateCalls =
       <({int noteId, Map<String, String> fields})>[];
+  // BUG-856: capture the fields addNote received so tests can assert the
+  // new-card render still DROPS empty fields (keepEmpty=false, unchanged).
+  final List<Map<String, String>> addNoteCalls = <Map<String, String>>[];
 
   @override
   Future<void> storeMediaFile({
@@ -42,8 +45,10 @@ class _RecordingService extends AnkiConnectService {
     List<String>? tags,
     Map<String, String>? mediaFiles,
     bool allowDuplicate = false,
-  }) async =>
-      addNoteId;
+  }) async {
+    addNoteCalls.add(Map<String, String>.from(fields));
+    return addNoteId;
+  }
 
   @override
   Future<bool> isDuplicate({
@@ -295,6 +300,111 @@ void main() {
       );
 
       expect(outcome.result, MineResult.error);
+      expect(service.updateCalls, isEmpty);
+    });
+  });
+
+  // BUG-856: overwrite must integral-replace every mapped field, including a
+  // {sentence} field that renders empty (stale-selection at overwrite time).
+  // Old code dropped empty fields on overwrite → sentence silently preserved,
+  // so "只覆盖图片和语音、原文不覆盖". New: overwrite keeps empty fields (clears
+  // the stale sentence), while NEW cards (mineEntry) still drop empties.
+  group('BUG-856: overwrite integral-replaces mapped fields', () {
+    AnkiSettings settingsWithSentence() => const AnkiSettings(
+          selectedDeckId: 1,
+          selectedNoteTypeId: 2,
+          availableDecks: <AnkiDeck>[AnkiDeck(id: 1, name: 'Mining')],
+          availableNoteTypes: <AnkiNoteType>[
+            AnkiNoteType(
+                id: 2,
+                name: 'Hibiki',
+                fields: <String>['Expression', 'Sentence']),
+          ],
+          fieldMappings: <String, String>{
+            'Expression': '{expression}',
+            'Sentence': '{sentence}',
+          },
+          allowDupes: true,
+        );
+
+    test('overwrite writes an empty Sentence field to clear a stale sentence',
+        () async {
+      final service = _RecordingService();
+      final repo =
+          _ConfiguredRepo(service: service, settings: settingsWithSentence());
+
+      // Overwrite when the live selection sentence is gone (context.sentence '').
+      final MineOutcome outcome = await repo.updateMinedNote(
+        noteId: 5,
+        rawPayloadJson: _payload,
+        context: const AnkiMiningContext(sentence: ''),
+      );
+
+      expect(outcome.result, MineResult.success);
+      expect(service.updateCalls, hasLength(1));
+      final Map<String, String> fields = service.updateCalls.single.fields;
+      // Expression still overwrites; Sentence is PRESENT-but-empty (cleared),
+      // not silently dropped/preserved.
+      expect(fields['Expression'], '勉強');
+      expect(fields.containsKey('Sentence'), isTrue,
+          reason: 'overwrite must send the Sentence field so it is replaced');
+      expect(fields['Sentence'], '');
+    });
+
+    test('overwrite writes the new non-empty sentence', () async {
+      final service = _RecordingService();
+      final repo =
+          _ConfiguredRepo(service: service, settings: settingsWithSentence());
+
+      final MineOutcome outcome = await repo.updateMinedNote(
+        noteId: 5,
+        rawPayloadJson: _payload,
+        context: const AnkiMiningContext(sentence: '新しい例文'),
+      );
+
+      expect(outcome.result, MineResult.success);
+      expect(service.updateCalls.single.fields['Sentence'], '新しい例文');
+    });
+
+    test('new-card mineEntry still DROPS an empty Sentence field (unchanged)',
+        () async {
+      final service = _RecordingService();
+      final repo =
+          _ConfiguredRepo(service: service, settings: settingsWithSentence());
+
+      final MineOutcome outcome = await repo.mineEntry(
+        rawPayloadJson: _payload,
+        context: const AnkiMiningContext(sentence: ''),
+      );
+
+      expect(outcome.result, MineResult.success);
+      expect(service.addNoteCalls, hasLength(1));
+      final Map<String, String> fields = service.addNoteCalls.single;
+      expect(fields['Expression'], '勉強');
+      expect(fields.containsKey('Sentence'), isFalse,
+          reason: 'new cards drop empty fields — keepEmpty=false unchanged');
+    });
+
+    test('overwrite still refused when ALL mapped fields render empty',
+        () async {
+      final service = _RecordingService();
+      // Only a Sentence mapping; empty sentence → the whole render is blank →
+      // refuse (would wipe the entire card), same guard as before.
+      final repo = _ConfiguredRepo(
+        service: service,
+        settings: settingsWithSentence().copyWith(
+          fieldMappings: const <String, String>{'Sentence': '{sentence}'},
+        ),
+      );
+
+      final MineOutcome outcome = await repo.updateMinedNote(
+        noteId: 5,
+        rawPayloadJson: '{"expression":"","reading":""}',
+        context: const AnkiMiningContext(sentence: ''),
+      );
+
+      expect(outcome.result, MineResult.error);
+      expect(outcome.errorDetail, contains('empty'));
       expect(service.updateCalls, isEmpty);
     });
   });


### PR DESCRIPTION
## 问题
用户报：制卡「覆盖已有卡片」时只覆盖了图片和语音，原文句子没有被覆盖更新。

## 根因（主代理 + 2 个探索子代理三方确认）
覆盖走 `updateMinedNote` → `buildMinedFields`，其空值守卫
`base_anki_repository.dart:340`（`value.trim().isNotEmpty`）被**新建**和**覆盖**共用。
对覆盖它意味着「渲染为空的字段被跳过 = 两后端 native `updateNoteFields` 保留旧值」。

`{sentence}` 只取自宿主**瞬时选区状态**（`anki_models.dart:502-519`），且句子**从不随
popup 制卡 payload 传递**（`popup.js:buildMinePayload` 无 `sentence` 键）。覆盖经
「✓→异步查卡→操作面板→点击」或音量键导航后选区已清空 → 句子渲染空 → 被守卫丢弃 →
旧句保留；而图片(书封/GIF)、句子音频(cue 时间窗)来自与选区无关的独立存活状态、渲染
非空 → 正常覆盖。故「只覆盖图片和语音、原文句子不覆盖」。

各 surface mine/update 在 Dart 层对称传句子，无漏传参数——是覆盖误用新建的空值守卫。

## 修复（用户选定语义：覆盖=整体替换，句子为空则清空）
- `buildMinedFields` 加 `keepEmpty`；覆盖路径 `keepEmpty:true` 保留所有映射字段（含空）。
- 两后端（AnkiConnect/AnkiDroid）`updateMinedNote` 走 `keepEmpty:true`，守卫从
  `fields.isEmpty` 改成「所有字段皆空白才拒绝」（仍防清整卡）。
- `mineEntry` 默认 `keepEmpty=false`，**新建行为零变化**（Never break userspace）。

## 测试
- `note_id_and_update_test.dart` BUG-856 group（AnkiConnect）：覆盖清空陈旧句 / 覆盖写
  新句 / 新建仍丢空 Sentence / 全空仍拒绝。
- `ankidroid_overwrite_test.dart`：AnkiDroid 覆盖发送空 Sentence 以真正清空。
- `hibiki_anki` 全 170 项 + 消费侧 `immersion_mining_engine_test`（14）通过；
  analyze 仅 1 个预先存在无关 warning。

## 待真机复测
视频/有声书/剪贴板覆盖：句子非空→更新为新句；句子为空→清空不残留旧句；图片音频照常覆盖。

见 `docs/bugs/BUG-856-anki-overwrite-sentence.md`。