### PR TITLE
perf(reader): 阅读设置抽屉滚动加 RepaintBoundary 消除每帧重绘

### DIFF
--- a/hibiki/lib/src/settings/master_detail_settings_sheet.dart
+++ b/hibiki/lib/src/settings/master_detail_settings_sheet.dart
@@ -159,10 +159,19 @@ class HibikiMasterDetailSettingsSheet extends StatelessWidget {
             return SingleChildScrollView(
               key: narrowKey(),
               padding: narrowPadding(context, constraints),
-              child: AnimatedSize(
-                duration: const Duration(milliseconds: 200),
-                alignment: Alignment.topCenter,
-                child: narrowChild(context, constraints),
+              // 滚动性能：窄窗（含手机 bottom sheet）用一个非懒的
+              // SingleChildScrollView + Column（BUG-037/042 刻意非懒，保证滚动
+              // 范围恒定）。但 SingleChildScrollView 滚动时会重绘整棵子树，正文里
+              // 未加 RepaintBoundary 的 CustomPaint（如主题色卡 HibikiSchemeSwatch
+              // 的 SchemeDiagonalPainter）每帧都会重跑 paint() → 滚动掉帧。这里把
+              // 整块正文包一层 RepaintBoundary：正文只栅格化一次进缓存层，滚动仅
+              // 按偏移合成该层、不再重绘子树。不改布局/滚动语义，纯合成优化。
+              child: RepaintBoundary(
+                child: AnimatedSize(
+                  duration: const Duration(milliseconds: 200),
+                  alignment: Alignment.topCenter,
+                  child: narrowChild(context, constraints),
+                ),
               ),
             );
           },

--- a/hibiki/lib/src/utils/components/hibiki_material_components.dart
+++ b/hibiki/lib/src/utils/components/hibiki_material_components.dart
@@ -1447,7 +1447,12 @@ class HibikiSchemeSwatch extends StatelessWidget {
       ),
       child: ClipRRect(
         borderRadius: tokens.radii.chipRadius,
-        child: CustomPaint(
+        // 滚动性能：色卡常摆在非懒的 Wrap/Column（如阅读设置抽屉的主题选择器、
+        // buildThemeSelector 的 Wrap）里。父级 SingleChildScrollView 滚动时会重绘
+        // 整棵子树，令 SchemeDiagonalPainter.paint() 每帧重跑 → 掉帧。给画布包一层
+        // RepaintBoundary，让每张色卡各自栅格化进缓存层，滚动只合成、不重绘。
+        child: RepaintBoundary(
+          child: CustomPaint(
           // TODO-1320: pin the painting surface to the card size. A childless
           // CustomPaint with the default `size: Size.zero` collapses to zero
           // under the LOOSE constraints the parent AnimatedContainer hands down
@@ -1482,6 +1487,7 @@ class HibikiSchemeSwatch extends StatelessWidget {
                     child: badge,
                   ),
                 ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## 问题
书里打开「阅读设置」抽屉后，**上下滚动卡/掉帧**（用户反馈「刷新率很低」）。

## 根因
手机窄窗抽屉用非懒的 `SingleChildScrollView + Column`（`master_detail_settings_sheet.dart`；BUG-037/042 刻意非懒以保证滚动范围恒定、不可改懒加载）。而 `SingleChildScrollView` 滚动时**会重绘整棵子树**。正文里的主题色卡 `HibikiSchemeSwatch` 的 `CustomPaint(SchemeDiagonalPainter)`（对角三角形 + 「文」字形 + 圆点）**没有 RepaintBoundary**，于是每个滚动帧都重跑其 `paint()` → 掉帧。（schema 设置行走嵌套 `ListView.builder`，本已带 per-item RepaintBoundary；色卡在 `Wrap` 里漏了。）

## 改动（纯合成优化，零布局/行为/绘制结果变化）
- `master_detail_settings_sheet.dart`：窄窗滚动正文整体包一层 `RepaintBoundary` → 正文只栅格化一次进缓存层，滚动仅按偏移合成、不再重绘子树。
- `hibiki_material_components.dart`：`HibikiSchemeSwatch` 的 `CustomPaint` 各自包 `RepaintBoundary` 兜底，任何非懒容器里的色卡都缓存（惠及宽窗/其它滚动）。

## 验证
- `flutter analyze` 干净；debug APK 构建通过；模拟器启动无崩溃。
- 外观页主题色卡渲染正确（对角预览 / 选中环 / 自定义「+」全部正常，见附图）——确认 RepaintBoundary 包裹未改绘制结果。
- ⚠️ **滚动流畅度实效需真机 + 真实书籍复测**：模拟器软件 GPU（SwiftShader）不代表真机手感，且当前模拟器库为空、无法驱动书内抽屉。

## 备注
与之前误判「设备刷新率」的 PR #182 无关，#182 已关闭。