### PR TITLE
fix(popup): BUG-860 长URL链接换行，修复词典弹窗超链接出框

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 841 条。点号进各自文件。
+> 共 842 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-860](bugs/BUG-860-popup-link-overflow.md) | ✅ | ✅ | 查词弹窗长URL链接出框 |
 | [BUG-859](bugs/BUG-859-global-lookup-nested-popup-position.md) | ✅ | ✅ | 全局查词嵌套弹窗弹出位置不对 |
 | [BUG-858](bugs/BUG-858-anki-overwrite-sentence.md) | ✅ | ✅ | Anki 覆盖卡片只覆盖图片和语音，原文句子未覆盖 |
 | [BUG-857](bugs/BUG-857-horizontal-swipe-direction-not-flipped.md) | ✅ | ✅ | 横排滑动翻页方向未随书写方向翻转（和竖排一样，应与日语相反） |

--- a/docs/bugs/BUG-860-popup-link-overflow.md
+++ b/docs/bugs/BUG-860-popup-link-overflow.md
@@ -1,0 +1,6 @@
+## BUG-860 · 查词弹窗长URL链接出框
+- **报告**：2026-07-16（用户：截图）
+- **真实性**：✅ 真 bug。根因 `hibiki/assets/popup/popup.css` 的顶层 `a { color }` 规则只有颜色、**无任何断词规则**（原 `assets/popup/popup.css:561-563`）。词典条目里的超链接（`linkifyUrls` 把正文裸 URL 包成 `<a>`，见 `assets/popup/popup.js`；以及 Yomitan 结构化内容 `href` 节点）在默认 `white-space:normal` 下对无空格 URL 找不到断点。一条无空格长 URL（`itazuraneko.neocities.org/grammar/donnatoki/mainentries.html#わりに（は）`）撑大 `.glossary-group` 描边卡（`min-width:0` 的 1fr grid track，`assets/popup/popup.css` `.glossary-group`）的 min-content，视觉上突破右边界「出框」。
+- **[x] ① 已修复** — 在 popup.css 顶层 `a` 规则加 `overflow-wrap: anywhere;`（只在没有其它断点时才任意处折行，正常带空格文本不受影响；并缩小 min-content 使卡片不被撑宽；作用于全部 `<a>`，图片链接内无文本零副作用）。三镜像同步：`hibiki/assets/popup/popup.css` + `hibiki/assets/browser_extension/vendor/popup.css` + `tools/browser-extension/vendor/popup.css`，并重跑 `node tools/browser-extension/scripts/generate-content-css.mjs` 生成两份 `content.css`（byte-identical 已核 md5）。提交见本分支。
+- **[x] ② 已加自动化测试** — `hibiki/test/dictionary/popup_link_overflow_wrap_guard_test.dart`：断言三镜像 popup.css 的顶层 `a{}` 规则都含 `overflow-wrap:anywhere`（或等效 word-break），且两份 content.css 也继承该规则（防止漏跑生成脚本）。与 parity 守卫（`test/build/browser_extension_popup_parity_guard_test.dart`）一并通过。
+- **备注**：`overflow-wrap:anywhere` 优于 `word-break:break-all`——后者会对 CJK 正文强行逐字断行，前者只对「否则会溢出」的无断点内容生效，语义精确。真机验证待用户在查词弹窗打开含长 URL 参考链接的词条复测。

--- a/hibiki/assets/browser_extension/vendor/content.css
+++ b/hibiki/assets/browser_extension/vendor/content.css
@@ -523,6 +523,11 @@
 
 :where(#entries-container) a {
     color: var(--primary-color);
+    /* BUG: 无空格的长 URL（linkify 的裸链接 / 结构化内容 href）在 .glossary-group
+       描边卡里找不到断点，把 min-width:0 的 grid track 撑出右边界「出框」。
+       overflow-wrap:anywhere 只在没有其它断点时才任意处折行（正常带空格文本不受影响），
+       并缩小 min-content 使卡片不被撑宽。作用于全部 <a>（图片链接内无文本，零副作用）。 */
+    overflow-wrap: anywhere;
 }
 
 .gloss-image-container {

--- a/hibiki/assets/browser_extension/vendor/popup.css
+++ b/hibiki/assets/browser_extension/vendor/popup.css
@@ -560,6 +560,11 @@ hr {
 
 a {
     color: var(--primary-color);
+    /* BUG: 无空格的长 URL（linkify 的裸链接 / 结构化内容 href）在 .glossary-group
+       描边卡里找不到断点，把 min-width:0 的 grid track 撑出右边界「出框」。
+       overflow-wrap:anywhere 只在没有其它断点时才任意处折行（正常带空格文本不受影响），
+       并缩小 min-content 使卡片不被撑宽。作用于全部 <a>（图片链接内无文本，零副作用）。 */
+    overflow-wrap: anywhere;
 }
 
 .gloss-image-container {

--- a/hibiki/assets/popup/popup.css
+++ b/hibiki/assets/popup/popup.css
@@ -560,6 +560,11 @@ hr {
 
 a {
     color: var(--primary-color);
+    /* BUG: 无空格的长 URL（linkify 的裸链接 / 结构化内容 href）在 .glossary-group
+       描边卡里找不到断点，把 min-width:0 的 grid track 撑出右边界「出框」。
+       overflow-wrap:anywhere 只在没有其它断点时才任意处折行（正常带空格文本不受影响），
+       并缩小 min-content 使卡片不被撑宽。作用于全部 <a>（图片链接内无文本，零副作用）。 */
+    overflow-wrap: anywhere;
 }
 
 .gloss-image-container {

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+817
+version: 1.2.0+818
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/dictionary/popup_link_overflow_wrap_guard_test.dart
+++ b/hibiki/test/dictionary/popup_link_overflow_wrap_guard_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 守卫（BUG-860）：查词弹窗里的超链接 `<a>` 必须能对无空格长 URL 断行，
+/// 否则 linkify 的裸链接 / 结构化内容 href（如
+/// `itazuraneko.neocities.org/grammar/...#わりに（は）`）在 `.glossary-group`
+/// 描边卡（`min-width:0` 的 grid track）里找不到断点，会把卡片撑出右边界「出框」。
+///
+/// 根因：`popup.css` 的 `a { color }` 规则原来只有颜色、无任何断词规则，
+/// 默认 `white-space:normal` 对无空格 URL 找不到断点。修复是在该规则加
+/// `overflow-wrap: anywhere`（只在没有其它断点时才任意处折行，正常带空格
+/// 文本不受影响，且缩小 min-content 使卡片不被撑宽）。
+///
+/// 三镜像铁律：popup.css 是查词弹窗真值源，改动必须同步到浏览器扩展两份
+/// vendored 镜像，本守卫对三处都断言，防止有人漏改或回退某一份。
+void main() {
+  String read(String p) => File(p).readAsStringSync();
+
+  /// 提取 popup.css 里顶层 `a { ... }` 规则块（截图问题的裸链接与结构化 href
+  /// 都是普通 `<a>`，样式都由这条根规则兜底）。
+  String extractBaseAnchorRule(String css) {
+    final Match? m =
+        RegExp(r'(?:^|\n)a\s*\{([^}]*)\}', multiLine: true).firstMatch(css);
+    expect(m, isNotNull, reason: 'popup.css 应有顶层 a { } 规则');
+    return m!.group(1)!;
+  }
+
+  const List<String> cssMirrors = <String>[
+    'assets/popup/popup.css',
+    'assets/browser_extension/vendor/popup.css',
+    '../tools/browser-extension/vendor/popup.css',
+  ];
+
+  test('三镜像 popup.css 的顶层 a 规则都带 overflow-wrap，能给长 URL 断行', () {
+    for (final String path in cssMirrors) {
+      final String rule = extractBaseAnchorRule(read(path));
+      expect(
+        RegExp(r'overflow-wrap:\s*anywhere').hasMatch(rule) ||
+            RegExp(r'word-break:\s*break-(all|word)').hasMatch(rule),
+        isTrue,
+        reason: '$path 的 a{} 规则应含 overflow-wrap:anywhere（或等效断词），'
+            '否则无空格长 URL 会撑破 .glossary-group 卡片（BUG-860 回归）',
+      );
+    }
+  });
+
+  test('扩展注入用的 content.css 也继承了 a 的断词规则', () {
+    // content.css 由 popup.css 经 generate-content-css.mjs 生成，类规则原样保留，
+    // 所以断词规则应一并出现（防止只改 popup.css 忘了重新生成 content.css）。
+    for (final String path in <String>[
+      'assets/browser_extension/vendor/content.css',
+      '../tools/browser-extension/vendor/content.css',
+    ]) {
+      final String css = read(path);
+      expect(css, contains('overflow-wrap: anywhere'),
+          reason: '$path 应含 a 的 overflow-wrap 断词规则（重跑 generate-content-css.mjs）');
+    }
+  });
+}

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -523,6 +523,11 @@
 
 :where(#entries-container) a {
     color: var(--primary-color);
+    /* BUG: 无空格的长 URL（linkify 的裸链接 / 结构化内容 href）在 .glossary-group
+       描边卡里找不到断点，把 min-width:0 的 grid track 撑出右边界「出框」。
+       overflow-wrap:anywhere 只在没有其它断点时才任意处折行（正常带空格文本不受影响），
+       并缩小 min-content 使卡片不被撑宽。作用于全部 <a>（图片链接内无文本，零副作用）。 */
+    overflow-wrap: anywhere;
 }
 
 .gloss-image-container {

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -560,6 +560,11 @@ hr {
 
 a {
     color: var(--primary-color);
+    /* BUG: 无空格的长 URL（linkify 的裸链接 / 结构化内容 href）在 .glossary-group
+       描边卡里找不到断点，把 min-width:0 的 grid track 撑出右边界「出框」。
+       overflow-wrap:anywhere 只在没有其它断点时才任意处折行（正常带空格文本不受影响），
+       并缩小 min-content 使卡片不被撑宽。作用于全部 <a>（图片链接内无文本，零副作用）。 */
+    overflow-wrap: anywhere;
 }
 
 .gloss-image-container {


### PR DESCRIPTION
## 问题
截图：查词弹窗词条里的长参考链接（`itazuraneko.neocities.org/grammar/donnatoki/mainentries.html#わりに（は）`）没有换行，突破 `.glossary-group` 描边卡右边界「出框」。

## 根因
`popup.css` 顶层 `a { color }` 规则**无任何断词规则**。词条里的超链接——`linkifyUrls` 把正文裸 URL 包成 `<a>`，以及 Yomitan 结构化内容 `href` 节点——在默认 `white-space:normal` 下对无空格 URL 找不到断点，撑大 `.glossary-group`（`min-width:0` 的 1fr grid track）的 min-content，视觉上出框。

## 修复
顶层 `a` 规则加 `overflow-wrap: anywhere;`：只在没有其它断点时才任意处折行（正常带空格文本不受影响），并缩小 min-content 使卡片不被撑宽。作用于全部 `<a>`（图片链接内无文本，零副作用）。优于 `word-break:break-all`（后者会对 CJK 正文强行逐字断行）。

三镜像同步 + 重生成 content.css：
- `hibiki/assets/popup/popup.css`（真值源）
- `hibiki/assets/browser_extension/vendor/popup.css`
- `tools/browser-extension/vendor/popup.css`
- 两份 `content.css` 由 `generate-content-css.mjs` 重新生成（md5 已核 byte-identical）

## 测试
- 新增 `hibiki/test/dictionary/popup_link_overflow_wrap_guard_test.dart`：断言三镜像 `a{}` 含 `overflow-wrap`，两份 content.css 继承该规则。
- 既有 parity / 语义 / radius 守卫一并通过（`flutter test` 4 文件全绿）。

## 遗留
真机验证待用户在查词弹窗打开含长 URL 参考链接的词条复测。

BUG-860 · `docs/bugs/BUG-860-popup-link-overflow.md`