### PR TITLE
fix(video): BUG-861 恢复按住 Shift 连续切换查词

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 841 条。点号进各自文件。
+> 共 842 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-861](bugs/BUG-861-video-shift-hover-switch.md) | ✅ | ✅ | 视频按住Shift无法连续切换查词 |
 | [BUG-859](bugs/BUG-859-global-lookup-nested-popup-position.md) | ✅ | ✅ | 全局查词嵌套弹窗弹出位置不对 |
 | [BUG-858](bugs/BUG-858-anki-overwrite-sentence.md) | ✅ | ✅ | Anki 覆盖卡片只覆盖图片和语音，原文句子未覆盖 |
 | [BUG-857](bugs/BUG-857-horizontal-swipe-direction-not-flipped.md) | ✅ | ✅ | 横排滑动翻页方向未随书写方向翻转（和竖排一样，应与日语相反） |

--- a/docs/bugs/BUG-861-video-shift-hover-switch.md
+++ b/docs/bugs/BUG-861-video-shift-hover-switch.md
@@ -1,0 +1,28 @@
+## BUG-861 · 视频按住Shift无法连续切换查词
+- **报告**：2026-07-16（用户：）
+- **真实性**：✅ 真 bug — 根因 `hibiki/lib/src/pages/implementations/video_hibiki_page.dart`（查词浮层 dismiss barrier 缺 `onPointerHover` 转发）
+- **[x] ① 已修复** — `hibiki/lib/src/pages/implementations/video_hibiki_page.dart`（`_onDismissBarrierHover` + `_handleSubtitleHoverLookup` + barrier 外挂 `Listener(onPointerHover:)`）/ `video_hibiki/layout.part.dart`（`onCharHover` 走去重入口）
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/video_shift_hover_switch_static_test.dart`
+- **备注**：
+
+### 根因
+
+视频字幕查词与阅读器一样，桌面支持「按住 Shift 悬停字幕字符即查词」（TODO-756a）。首次悬停查词后弹出的查词浮层（`_buildPopupOverlay`）会在根 Overlay 铺一层**全屏 dismiss barrier**盖在字幕之上。
+
+- **阅读器**（`base_source_page.dart` / `reader_hibiki_page.dart:onDismissBarrierHover`）：barrier 外层挂了 `Listener(onPointerHover: onDismissBarrierHover)`——首弹后 barrier 盖住正文、WebView / 字幕自身收不到 hover 时，barrier 是**唯一**还能接 hover 的入口，按住 Shift 一路滑就反查命中字符 → `replaceStack` 无缝换词。
+- **视频**（`video_hibiki_page.dart:_buildPopupOverlay`）：barrier 只有一个 `GestureDetector`（处理 tap / 横拖关栈），**没有任何 `onPointerHover` 转发**。首弹后字幕盒自己的 `VideoSubtitleOverlay` `MouseRegion.onHover`（`_handleShiftHover`）被 barrier 遮住收不到 hover，于是「按住 Shift 连续切换查词」在**首弹之后彻底失效**——只能先关掉浮层、再悬停下一个词。
+
+### 修复（根因修复，非绕过）
+
+对齐阅读器，给视频 barrier 补上 hover 转发：
+
+1. barrier 的 `GestureDetector` 外层包 `Listener(onPointerHover: _onDismissBarrierHover)`（`_buildPopupOverlay`）。
+2. `_onDismissBarrierHover(PointerHoverEvent)`：门控与字幕盒 `_handleShiftHover` 一致（按住 Shift 或开「悬停即查词」）；8px 平方阈值节流（`barrierHoverThresholdPx`，与 `_kShiftHoverThresholdPx` 同构）；用已存在的 `_subtitleHitTester.hitTest`（全局坐标）反查命中字符；非嵌套 + 命中才换词（复用 `shouldSwitchWordOnBarrierTap` 门控，嵌套态换词会误替整栈）。
+3. `_handleSubtitleHoverLookup`：字幕盒 `onCharHover` 与 barrier hover 两条路径的**统一去重入口**——用「同句同 grapheme」短路，避免字符没被浮层遮住时两条 hover 路径同时命中导致同词双 `replaceStack` 闪烁 / 重复刷 FFI。`onCharTap`（点击查词）不经此入口，重复点同字仍照常重查。
+4. 关栈会话结束（`_popNestedPopupAt` stackEmpty）复位去重键，使关掉浮层后再次悬停同一字符能重查。
+
+### 验证
+
+- `flutter analyze` 干净。
+- `flutter test test/pages/video_shift_hover_switch_static_test.dart` 通过（源码接线守卫 + 门控纯函数）。
+- ⏳ 待真机（Windows 桌面，鼠标 + Shift）复测：首弹后按住 Shift 划过同句其它字符应连续换词、松开 Shift 停止。

--- a/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
@@ -324,11 +324,13 @@ extension _VideoLayout on _VideoHibikiPageState {
                         child: VideoSubtitleOverlay(
                           controller: controller,
                           onCharTap: _handleSubtitleLookupTap,
-                          // TODO-756a 桌面 Shift-鼠标悬停查词：与点击查词同链路
-                          // （[_handleSubtitleLookupTap] → [_lookupAt]，内部已 _immersiveAllowsLookup
+                          // TODO-756a 桌面 Shift-鼠标悬停查词：走去重入口 [_handleSubtitleHoverLookup]
+                          // →（[_handleSubtitleLookupTap] → [_lookupAt]，内部已 _immersiveAllowsLookup
                           // 门控），故按住 Shift 悬停字幕字符与点击该字符行为一致。移动端无 hover、
-                          // 自然不触发；节流由 VideoSubtitleOverlay 内部承载。
-                          onCharHover: _handleSubtitleLookupTap,
+                          // 自然不触发；节流由 VideoSubtitleOverlay 内部承载。BUG-861：与浮层 barrier
+                          // hover（[_onDismissBarrierHover]）共用同一「同句同 grapheme」去重键，避免
+                          // 字符未被浮层遮住时两条 hover 路径同时命中导致同词双查闪烁。
+                          onCharHover: _handleSubtitleHoverLookup,
                           // TODO-756b：开了“悬停即查词”则纯悬停（无需 Shift）即查词；
                           // 关闭退回 756a 的 Shift+悬停。视频与阅读器共享 instance。
                           hoverAutoLookupEnabled:

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -445,6 +445,11 @@ class VideoHibikiPage extends ConsumerStatefulWidget {
   }) =>
       topVisibleIndex <= 0 && hitSubtitle;
 
+  /// Shift-悬停在查词浮层 barrier 上「连续切换查词」的移动节流阈值（像素，BUG-861）。
+  /// 与字幕盒 [VideoSubtitleOverlay] 的 `_kShiftHoverThresholdPx` / 阅读器 barrier hover
+  /// 的 8px 同构：鼠标移动未超此阈值不重复查词，越过阈值 + 命中新字符才换词。
+  static const double barrierHoverThresholdPx = 8;
+
   /// 长按横向拖动连续调速的映射系数（TODO-338）：每 px 横向位移改变多少倍速。
   /// 200px ≈ 1.0x，故拖半屏（~600px）≈ ±3x，覆盖 [longPressDragMinSpeed]..
   /// [longPressDragMaxSpeed] 全程而手感不过敏。
@@ -3225,6 +3230,77 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     }
   }
 
+  /// Shift-悬停在 barrier 上「连续切换查词」的节流锚 + 去重键（TODO-756a，与阅读器
+  /// [ReaderHibikiPage.onDismissBarrierHover] 同语义）。[Offset.zero] / 空句 / -1 表示
+  /// 未进入（松开 Shift / 离开时复位），下次按 Shift 进入即触发。
+  Offset _barrierHoverLastPos = Offset.zero;
+  String _barrierHoverLastSentence = '';
+  int _barrierHoverLastGrapheme = -1;
+
+  /// 桌面 Shift-鼠标悬停在查词浮层 dismiss barrier 上「连续切换查词」（BUG-861，与阅读器
+  /// [ReaderHibikiPage.onDismissBarrierHover] 同语义）。
+  ///
+  /// 根因：首次查词打开浮层后，全屏 dismiss barrier（[_buildPopupOverlay]）盖在字幕之上，
+  /// 字幕盒自己的 [MouseRegion.onHover]（[VideoSubtitleOverlay] 的 `_handleShiftHover`）被
+  /// barrier 遮住收不到 hover——barrier 是此时**唯一**还能接 hover 的入口。阅读器早已在
+  /// barrier 外层挂 `Listener(onPointerHover: onDismissBarrierHover)` 转发换词，视频页此前
+  /// 只有 `GestureDetector`（无 hover 转发），故「按住 Shift 连续切换查词」在首弹后失效。
+  ///
+  /// 门控与字幕盒 `_handleShiftHover` 一致（TODO-756a/b）：按住 Shift 或开了「悬停即查词」
+  /// 才换词；8px 平方阈值节流（与 `_kShiftHoverThresholdPx` 同构）避免每像素抖动都查；
+  /// 命中同一字符（同句同 grapheme）短路去重，避免同词反复 `replaceStack` 闪烁 / 刷 FFI。
+  /// 换词经 [_handleSubtitleLookupTap] → [_lookupAt]（`replaceStack: true` 复用热槽无缝替换）。
+  void _onDismissBarrierHover(PointerHoverEvent event) {
+    if (!HardwareKeyboard.instance.isShiftPressed &&
+        !ReaderHibikiSource.instance.hoverAutoLookup) {
+      // 未按 Shift 且未开「悬停即查词」：复位节流锚 + 去重键，使下次按 Shift 进入即触发。
+      _barrierHoverLastPos = Offset.zero;
+      _barrierHoverLastSentence = '';
+      _barrierHoverLastGrapheme = -1;
+      return;
+    }
+    final double dx = event.position.dx - _barrierHoverLastPos.dx;
+    final double dy = event.position.dy - _barrierHoverLastPos.dy;
+    if (_barrierHoverLastPos != Offset.zero &&
+        dx * dx + dy * dy <
+            VideoHibikiPage.barrierHoverThresholdPx *
+                VideoHibikiPage.barrierHoverThresholdPx) {
+      return;
+    }
+    _barrierHoverLastPos = event.position;
+    // 命中反查复用与 barrier 点击换词（[_onDismissBarrierTap]）同一命中句柄，全局坐标契约
+    // 一致（[PointerHoverEvent.position] 已是全局坐标）。
+    final SubtitleCharHit? hit = _subtitleHitTester.hitTest(event.position);
+    // 非嵌套（仅顶层可见）且命中字幕字符才换词——与点 barrier 换词的
+    // [shouldSwitchWordOnBarrierTap] 同门控（嵌套态换词会误把整栈 replaceStack 替换掉）。
+    if (!VideoHibikiPage.shouldSwitchWordOnBarrierTap(
+      topVisibleIndex: _topVisiblePopupIndex,
+      hitSubtitle: hit != null,
+    )) {
+      return;
+    }
+    _handleSubtitleHoverLookup(hit!.sentence, hit.graphemeIndex, hit.charRect);
+  }
+
+  /// 悬停查词的统一去重入口（BUG-861）：字幕盒自己的 [MouseRegion]（`onCharHover` →
+  /// `_handleShiftHover`）与浮层 barrier（[_onDismissBarrierHover]）两条 hover 路径都汇聚
+  /// 到这里。首弹后 barrier 盖不住的字符可能被两条路径同时命中，用「同句同 grapheme」短路
+  /// 去重，保证一次移动只换一次词（否则同词双 `replaceStack` 会闪烁 / 重复刷 FFI）。点击查词
+  /// （`onCharTap` → [_handleSubtitleLookupTap]）不经此入口，故重复点同字仍照常重查。
+  void _handleSubtitleHoverLookup(
+    String sentence,
+    int graphemeIndex,
+    Rect charRect,
+  ) {
+    if (sentence == _barrierHoverLastSentence &&
+        graphemeIndex == _barrierHoverLastGrapheme) {
+      return;
+    }
+    _barrierHoverLastSentence = sentence;
+    _barrierHoverLastGrapheme = graphemeIndex;
+    _handleSubtitleLookupTap(sentence, graphemeIndex, charRect);
+  }
+
   /// BUG-094: seed one persistent, hidden warm popup slot on open so its
   /// [DictionaryPopupWebView] cold-loads popup.html/JS/CSS ONCE while idle and
   /// is reused warm for every lookup — no per-lookup cold-load (white flash) in
@@ -3316,6 +3392,10 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
       // 字 / 字幕条另一句切换查词走 _lookupAt(replaceStack)，栈不空，草稿不被清。
       _miningDraft.clear();
       _refocusVideo();
+      // BUG-861：查词会话结束，复位悬停切词去重键，使关掉浮层后再次悬停同一字符能重查。
+      _barrierHoverLastPos = Offset.zero;
+      _barrierHoverLastSentence = '';
+      _barrierHoverLastGrapheme = -1;
     }
   }
 
@@ -3407,29 +3487,35 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
                 // 并支持点同句另一字切换查词)。仅剩隐藏热槽时不拦，放行给视频。
                 if (_hasVisiblePopup || _popup.isSearchingUi)
                   Positioned.fill(
-                    child: GestureDetector(
-                      behavior: HitTestBehavior.translucent,
-                      // onTapUp（带坐标）而非 onTap：点到同句另一个字幕字符时切换查词
-                      // 并保持暂停，点其它区域才 dismiss + 恢复（见 _onDismissBarrierTap）。
-                      onTapUp: (TapUpDetails d) =>
-                          _onDismissBarrierTap(d.globalPosition),
-                      // TODO-1052：桌面对齐手机——在 barrier 上水平拖过阈关一层
-                      // （_popNestedPopupAt，逐层关）。仅当滑动关闭开关开启时挂横拖识别
-                      // （否则只 onTapUp，与旧行为一致）。竞技场天然分流：单击走 onTapUp、
-                      // 横拖走 onHorizontalDrag*，互斥不冲突（与 base_source_page 同范式）。
-                      onHorizontalDragStart:
-                          ReaderHibikiSource.instance.enableSwipeToClose
-                              ? _onDismissBarrierHorizontalDragStart
-                              : null,
-                      onHorizontalDragUpdate:
-                          ReaderHibikiSource.instance.enableSwipeToClose
-                              ? _onDismissBarrierHorizontalDragUpdate
-                              : null,
-                      onHorizontalDragEnd:
-                          ReaderHibikiSource.instance.enableSwipeToClose
-                              ? _onDismissBarrierHorizontalDragEnd
-                              : null,
-                      child: const ColoredBox(color: Colors.transparent),
+                    // BUG-861：barrier 外层挂 Listener 转发 hover——首弹后 barrier 盖住字幕，
+                    // 字幕盒 MouseRegion 收不到 hover，此处是「按住 Shift 连续切换查词」唯一
+                    // 还能接 hover 的入口（与 reader onDismissBarrierHover 同语义）。
+                    child: Listener(
+                      onPointerHover: _onDismissBarrierHover,
+                      child: GestureDetector(
+                        behavior: HitTestBehavior.translucent,
+                        // onTapUp（带坐标）而非 onTap：点到同句另一个字幕字符时切换查词
+                        // 并保持暂停，点其它区域才 dismiss + 恢复（见 _onDismissBarrierTap）。
+                        onTapUp: (TapUpDetails d) =>
+                            _onDismissBarrierTap(d.globalPosition),
+                        // TODO-1052：桌面对齐手机——在 barrier 上水平拖过阈关一层
+                        // （_popNestedPopupAt，逐层关）。仅当滑动关闭开关开启时挂横拖识别
+                        // （否则只 onTapUp，与旧行为一致）。竞技场天然分流：单击走 onTapUp、
+                        // 横拖走 onHorizontalDrag*，互斥不冲突（与 base_source_page 同范式）。
+                        onHorizontalDragStart:
+                            ReaderHibikiSource.instance.enableSwipeToClose
+                                ? _onDismissBarrierHorizontalDragStart
+                                : null,
+                        onHorizontalDragUpdate:
+                            ReaderHibikiSource.instance.enableSwipeToClose
+                                ? _onDismissBarrierHorizontalDragUpdate
+                                : null,
+                        onHorizontalDragEnd:
+                            ReaderHibikiSource.instance.enableSwipeToClose
+                                ? _onDismissBarrierHorizontalDragEnd
+                                : null,
+                        child: const ColoredBox(color: Colors.transparent),
+                      ),
                     ),
                   ),
                 // 搜索期加载占位卡（与书内同观感：就绪才显示真正浮层）。

--- a/hibiki/test/pages/video_shift_hover_switch_static_test.dart
+++ b/hibiki/test/pages/video_shift_hover_switch_static_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/video_hibiki_page.dart';
+
+import 'video_hibiki_page_source_corpus.dart';
+
+/// BUG-861：视频「按住 Shift 连续切换查词」在首弹后失效的修复守卫。
+///
+/// **根因**：首次悬停查词弹出的浮层在根 Overlay 铺一层全屏 dismiss barrier 盖在字幕之上，
+/// 字幕盒自己的 [MouseRegion.onHover]（`VideoSubtitleOverlay._handleShiftHover`）被遮住收不到
+/// hover。阅读器早在 barrier 外层挂 `Listener(onPointerHover: onDismissBarrierHover)` 转发换词，
+/// 视频页此前只有 `GestureDetector`（无 hover 转发），故首弹后无法再连续切换查词。
+///
+/// **修法**：barrier 外层挂 `Listener(onPointerHover: _onDismissBarrierHover)`；`_onDismissBarrierHover`
+/// 按住 Shift / 悬停即查词门控 + 8px 节流 + `_subtitleHitTester` 反查 + `shouldSwitchWordOnBarrierTap`
+/// 非嵌套门控 → `_handleSubtitleHoverLookup`（与字幕盒 `onCharHover` 共用的同句同 grapheme 去重
+/// 入口）→ `_handleSubtitleLookupTap`（`replaceStack` 换词）。
+///
+/// 浮层需真实平台视图，无法纯单测真实 hover→换词，故守两层：
+/// 1. 纯函数 [VideoHibikiPage.shouldSwitchWordOnBarrierTap] 门控（悬停切词复用同一判据）；
+/// 2. 源码接线守卫：barrier 挂 Listener.onPointerHover、`_onDismissBarrierHover` 门控/节流/去重
+///    入口、`onCharHover` 走去重入口、关栈复位去重键（防回归把这些环删掉 / 改回无 hover 转发）。
+void main() {
+  group('shouldSwitchWordOnBarrierTap — 悬停切词复用的非嵌套+命中门控', () {
+    test('非嵌套（仅顶层）+ 命中字幕字符 → 换词', () {
+      expect(
+        VideoHibikiPage.shouldSwitchWordOnBarrierTap(
+          topVisibleIndex: 0,
+          hitSubtitle: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('仅剩隐藏热槽（topVisibleIndex == -1）+ 命中 → 换词', () {
+      expect(
+        VideoHibikiPage.shouldSwitchWordOnBarrierTap(
+          topVisibleIndex: -1,
+          hitSubtitle: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('嵌套态（存在父层）→ 不换词（否则误替整栈）', () {
+      expect(
+        VideoHibikiPage.shouldSwitchWordOnBarrierTap(
+          topVisibleIndex: 1,
+          hitSubtitle: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('未命中字幕字符 → 不换词', () {
+      expect(
+        VideoHibikiPage.shouldSwitchWordOnBarrierTap(
+          topVisibleIndex: 0,
+          hitSubtitle: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('barrierHoverThresholdPx — 与字幕盒 8px 阈值同构', () {
+    test('阈值为 8px', () {
+      expect(VideoHibikiPage.barrierHoverThresholdPx, 8);
+    });
+  });
+
+  group('源码接线守卫', () {
+    final String page = readVideoHibikiSource();
+
+    test('dismiss barrier 外层挂 Listener 转发 hover 给 _onDismissBarrierHover', () {
+      final String overlay = _functionSource(
+        page,
+        'Widget _buildPopupOverlay(',
+        'Future<MinePopupResult> onMineEntry(',
+      );
+      // barrier 段：Listener(onPointerHover:) 包住 GestureDetector（有 onTapUp 的那层）。
+      expect(
+        overlay.contains('onPointerHover: _onDismissBarrierHover'),
+        isTrue,
+        reason: 'barrier 必须转发 onPointerHover，否则首弹后连续切换查词失效',
+      );
+      // Listener 必须在 barrier 的 GestureDetector 之外（先出现）。
+      expect(
+        overlay.indexOf('onPointerHover: _onDismissBarrierHover'),
+        lessThan(overlay.indexOf('onTapUp: (TapUpDetails d) =>')),
+        reason: 'Listener 应包在 barrier GestureDetector 外层',
+      );
+    });
+
+    test('_onDismissBarrierHover：门控 + 节流 + 反查 + 非嵌套门控 → 去重入口', () {
+      final String hover = _functionSource(
+        page,
+        'void _onDismissBarrierHover(PointerHoverEvent event) {',
+        'void _handleSubtitleHoverLookup(',
+      );
+      // 门控与字幕盒 _handleShiftHover 一致：按住 Shift 或开「悬停即查词」。
+      expect(
+          hover.contains('HardwareKeyboard.instance.isShiftPressed'), isTrue);
+      expect(
+        hover.contains('ReaderHibikiSource.instance.hoverAutoLookup'),
+        isTrue,
+      );
+      // 8px 平方阈值节流。
+      expect(
+        hover.contains('barrierHoverThresholdPx'),
+        isTrue,
+        reason: '必须 8px 节流，避免每像素抖动都查',
+      );
+      // 全局坐标反查复用字幕命中句柄。
+      expect(
+          hover.contains('_subtitleHitTester.hitTest(event.position)'), isTrue);
+      // 非嵌套 + 命中门控复用纯函数。
+      expect(
+        hover.contains('VideoHibikiPage.shouldSwitchWordOnBarrierTap('),
+        isTrue,
+      );
+      // 换词经统一去重入口。
+      expect(hover.contains('_handleSubtitleHoverLookup('), isTrue);
+    });
+
+    test('_handleSubtitleHoverLookup：同句同 grapheme 去重后转发查词', () {
+      final String funnel = _functionSource(
+        page,
+        'void _handleSubtitleHoverLookup(',
+        'void _onDismissBarrierTap(',
+      );
+      expect(
+        funnel.contains('_barrierHoverLastSentence') &&
+            funnel.contains('_barrierHoverLastGrapheme'),
+        isTrue,
+        reason: '两条 hover 路径共用同句同 grapheme 去重键',
+      );
+      expect(funnel.contains('_handleSubtitleLookupTap('), isTrue);
+    });
+
+    test('字幕盒 onCharHover 走去重入口（非直连 _handleSubtitleLookupTap）', () {
+      // layout.part.dart 在合并语料里；onCharHover 必须指向去重入口。
+      expect(
+        page.contains('onCharHover: _handleSubtitleHoverLookup'),
+        isTrue,
+        reason: 'onCharHover 直连 _handleSubtitleLookupTap 会与 barrier hover 双查同词',
+      );
+      // onCharTap（点击查词）仍直连，重复点同字要能重查。
+      expect(page.contains('onCharTap: _handleSubtitleLookupTap'), isTrue);
+    });
+
+    test('_popNestedPopupAt 关栈会话结束复位悬停去重键', () {
+      final String pop = _functionSource(
+        page,
+        'void _popNestedPopupAt(',
+        'Widget _buildNestedPopupLayer(',
+      );
+      expect(
+        pop.contains('_barrierHoverLastSentence = \'\'') &&
+            pop.contains('_barrierHoverLastGrapheme = -1'),
+        isTrue,
+        reason: '会话结束不复位则关掉浮层后再悬停同字符会被去重键挡住不重查',
+      );
+    });
+  });
+}
+
+/// 截取 [source] 中从 [start] 标记到 [end] 标记之间的源码片段（含 [start]、不含 [end]）。
+String _functionSource(String source, String start, String end) {
+  final int startIndex = source.indexOf(start);
+  expect(startIndex, isNonNegative, reason: 'Missing start marker: $start');
+  final int endIndex = source.indexOf(end, startIndex + start.length);
+  expect(endIndex, isNonNegative, reason: 'Missing end marker: $end');
+  return source.substring(startIndex, endIndex);
+}


### PR DESCRIPTION
## 问题
用户报「视频没办法按住 Shift 连续切换查词」。首次悬停查词成功后，无法再按住 Shift 划过同句其它字符切换查词。

## 根因
查词浮层弹出后，根 Overlay 铺一层全屏 dismiss barrier 盖在字幕之上，字幕盒自己的 `VideoSubtitleOverlay` `MouseRegion.onHover`（`_handleShiftHover`）被遮住收不到 hover。

阅读器早就在 barrier 外层挂了 `Listener(onPointerHover: onDismissBarrierHover)`——首弹后 barrier 是唯一还能接 hover 的入口，按住 Shift 一路滑就反查换词。**视频页的 barrier 只有 `GestureDetector`（处理 tap/横拖），没有任何 `onPointerHover` 转发**，故连续切换在首弹后彻底失效。

## 修复（对齐阅读器）
- `_buildPopupOverlay`：barrier 的 `GestureDetector` 外层包 `Listener(onPointerHover: _onDismissBarrierHover)`。
- `_onDismissBarrierHover`：门控与字幕盒 `_handleShiftHover` 一致（按住 Shift 或开「悬停即查词」）+ 8px 平方阈值节流 + `_subtitleHitTester` 全局反查 + `shouldSwitchWordOnBarrierTap` 非嵌套门控 → 换词。
- `_handleSubtitleHoverLookup`：字幕盒 `onCharHover` 与 barrier hover 两条路径统一「同句同 grapheme」去重入口，避免字符未被浮层遮住时双查同词闪烁；`onCharTap` 不经此入口，重复点同字仍重查。
- `_popNestedPopupAt` 关栈会话结束复位去重键。

## 验证
- `flutter analyze lib test` 干净。
- 新增 `test/pages/video_shift_hover_switch_static_test.dart`（门控纯函数 + 源码接线守卫）10 项通过；`bugs_per_file_guard` / `video_lookup_resume_static` 回归通过。
- ⏳ 待真机（Windows 桌面，鼠标 + Shift）复测原始失败路径。

docs/bugs/BUG-861。