### PR TITLE
fix(video,sync): 内嵌字幕毒轨逐轨回退(BUG-863) + Drive 瞬时超时重试(BUG-864)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 842 条。点号进各自文件。
+> 共 844 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-864](bugs/BUG-864-gdrive-sync-transient-no-retry.md) | ✅ | ✅ | Google Drive 聚合同步瞬时网络超时不重试整轮放弃 |
+| [BUG-863](bugs/BUG-863-embedded-sub-poison-track.md) | ✅ | ✅ | 内嵌字幕单遍抽取被一条毒轨整批击穿 |
 | [BUG-860](bugs/BUG-860-popup-link-overflow.md) | ✅ | ✅ | 查词弹窗长URL链接出框 |
 | [BUG-859](bugs/BUG-859-global-lookup-nested-popup-position.md) | ✅ | ✅ | 全局查词嵌套弹窗弹出位置不对 |
 | [BUG-858](bugs/BUG-858-anki-overwrite-sentence.md) | ✅ | ✅ | Anki 覆盖卡片只覆盖图片和语音，原文句子未覆盖 |

--- a/docs/bugs/BUG-863-embedded-sub-poison-track.md
+++ b/docs/bugs/BUG-863-embedded-sub-poison-track.md
@@ -1,0 +1,13 @@
+## BUG-863 · 内嵌字幕单遍抽取被一条毒轨整批击穿
+
+> 原以工具自动取号建为 BUG-861，与并发分支 PR#190（Shift 悬停连续查词）撞号，改号为 863。
+
+- **报告**：2026-07-16（用户：运行日志 `extractEmbeddedSubtitlesViaFfmpeg` ffmpeg exit -22）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/utils/misc/desktop_audio_clipper.dart:1041`（单遍多轨命令）+ `hibiki/lib/src/media/video/video_subtitle_source.dart:261`（`subtitleFormatForCodec` fail-open）。
+  - 抽取走单遍多轨命令 `-y -i in -map 0:s:0 out0 -map 0:s:1 out1 …`（BUG-104 优化，整容器只读一遍）。
+  - `subtitleFormatForCodec` fail-open：未知/非图形 codec 一律当文本 → `.srt`，赌「顶多这一轨失败」。
+  - 但 ffmpeg 在写任何数据包**之前**先初始化所有输出编码器。只要有一条文本类 codec（如 `eia_608`/字幕 caption）在 output-open 阶段无法转码，整条命令直接 `AVERROR(EINVAL) = -22`，打印 `Error opening output files: Invalid argument`，**一个包都没写** → `written` 为空 → 整批全丢，连同容器里正常的 `ass`/`srt` 轨一起没了。这是「明明有字幕、切内封却一条都出不来」的静默失败根源。
+  - 1045 行原注释「一个坏轨仍能让其它轨写出」的假设只在**写包阶段**失败时成立；output-open 阶段的 EINVAL 发生在写包之前，击穿该兜底。
+- **[x] ① 已修复** — `desktop_audio_clipper.dart` `extractEmbeddedSubtitlesViaFfmpeg`：单遍 `written.length < outputs.length` 时对每条仍缺失的轨用 `buildFfmpegSubtitleArgs` 逐轨重抽（沿用同一 size-scaled `timeout`，非单片 30s），毒轨只损失自己；单遍全成功零开销不进回退。（提交见 PR）
+- **[x] ② 已加自动化测试** — `hibiki/test/utils/desktop_audio_clipper_test.dart` 新增组「毒轨逐轨回退 (BUG-863)」：注入 `_FakePoisonFfmpegBackend`（模拟 output-open 整批 EINVAL），断言 3 轨含毒轨 1 时结果为 `{0,2}`（好轨保住、毒轨只损失自己）、单遍 + 3 条逐轨共 4 趟；另断言无毒轨时单遍成功不触发回退（零开销）。
+- **备注**：日志同批还有一条 Google Drive 同步瞬时超时不重试，另见 BUG-864。

--- a/docs/bugs/BUG-864-gdrive-sync-transient-no-retry.md
+++ b/docs/bugs/BUG-864-gdrive-sync-transient-no-retry.md
@@ -1,0 +1,14 @@
+## BUG-864 · Google Drive 聚合同步瞬时网络超时不重试整轮放弃
+
+> 原以工具自动取号建为 BUG-862，为与同批 BUG-863 保持连号并避开并发分支占用，改号为 864。
+
+- **报告**：2026-07-16（用户：运行日志 `SyncRunReport.errors` `aggregate sync: ClientException with SocketException 信号灯超时 errno=121 www.googleapis.com`；用户明确要求「应该继续或重试，而不是完全放弃」）
+- **真实性**：✅ 真 bug。
+  - `GoogleDriveHandler._call`（`hibiki/lib/src/sync/google_drive_handler.dart:125`）只对 401 做单次刷新重试；瞬时 `SocketException`/超时既不是 `DetailedApiRequestError` 也非 unauthorized，走 `rethrow` 原样抛出。
+  - `GoogleDriveSyncBackend._wrapErrors`（`google_drive_sync_backend.dart:36`）只 `on GoogleDriveError` / `on GoogleDriveAuthError`，接不住裸 `SocketException` → 未分类穿透。
+  - `SyncOrchestrator._syncAggregate`（`sync_orchestrator.dart:456`）裸 `catch (e)` 把它记进 `report.errors` 后**整轮聚合合并+上传直接放弃**，零重试。`AggregateSyncService.sync` 里 `ensureNamespace`/`listChildren`/`putJsonAsset` 均无保护，一次瞬时超时即中断整轮。
+- **[x] ① 已修复** — 在唯一咽喉 `_call` 外包有界退避重试：
+  - 新增 `hibiki/lib/src/sync/sync_transient_error.dart`：`isTransientSyncError(Object)`（复用 `sync_error_messages.dart` 的 timeout/network 子串分类 + `SocketException`/`TimeoutException`/`HttpException` 类型；auth/scope/4xx 明确判非瞬时不重试）+ `retryTransientSync<T>`（默认 4 次、线性退避 400ms*attempt、`sleep` 可注入、永久错误立即抛不浪费预算）。
+  - `_call` 拆出 `_callOnce`（保留原 401 刷新逻辑），`_call = retryTransientSync(() => _callOnce(fn))`。因所有 Drive op 都经 `_call`，聚合同步的 list/ensure/put 以及全部书/词典操作一并获得瞬时重试；重试 op 均幂等（overwrite-by-name / 幂等 list/ensure），重复安全。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/sync_transient_error_test.dart`：`isTransientSyncError` 对日志原文（信号灯超时/errno121）、网络子串族判 true，对 insufficient_scope/401/invalid_grant/not-found 判 false；`retryTransientSync` 断言瞬时失败重试到成功（并按线性退避 sleep）、穷尽 maxAttempts 后抛最后一个错、永久错误一次即抛、首次成功不 sleep（零开销）。
+- **备注**：同批日志另一条 ffmpeg 内嵌字幕毒轨见 BUG-863。第一条日志本身是本机代理 fake-ip 把 googleapis 解析成假 IP 导致的真实网络超时（环境），但「一次超时就放弃整轮」是代码缺陷，本条修复的是后者。

--- a/hibiki/lib/src/sync/google_drive_handler.dart
+++ b/hibiki/lib/src/sync/google_drive_handler.dart
@@ -8,6 +8,7 @@ import 'package:googleapis_auth/googleapis_auth.dart' as auth;
 import 'package:hibiki/src/sync/google_drive_auth.dart';
 import 'package:hibiki/src/sync/sync_asset_store.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/sync_transient_error.dart';
 import 'package:hibiki/src/sync/sync_utils.dart';
 import 'package:hibiki/src/sync/ttu_filename.dart';
 import 'package:hibiki/src/sync/ttu_models.dart';
@@ -122,7 +123,19 @@ class GoogleDriveHandler {
     return _cachedApi!;
   }
 
-  Future<T> _call<T>(Future<T> Function(drive.DriveApi api) fn) async {
+  /// Every Drive request funnels through here. Wraps [_callOnce] (which owns the
+  /// auth-refresh single retry) in a bounded transient-error retry-with-backoff:
+  /// a `SocketException` / timeout (信号灯超时) on any op — folder ensure, list,
+  /// JSON download, overwrite-by-name upload — recovers in place instead of
+  /// throwing raw past `_wrapErrors` and abandoning the whole sync round with
+  /// zero retries (BUG-864). Permanent errors (auth / scope / 4xx) are not
+  /// transient, so [retryTransientSync] re-throws them immediately without
+  /// burning attempts; the retried ops are all idempotent so a repeat is safe.
+  Future<T> _call<T>(Future<T> Function(drive.DriveApi api) fn) {
+    return retryTransientSync<T>(() => _callOnce<T>(fn));
+  }
+
+  Future<T> _callOnce<T>(Future<T> Function(drive.DriveApi api) fn) async {
     try {
       return await fn(await _api());
     } on GoogleDriveAuthError {

--- a/hibiki/lib/src/sync/sync_transient_error.dart
+++ b/hibiki/lib/src/sync/sync_transient_error.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+import 'dart:io';
+
+/// Whether [error] is a **transient** network/timeout failure a bounded
+/// retry-with-backoff can recover from, as opposed to a permanent one (auth,
+/// permission, not-found, malformed request).
+///
+/// Mirrors the substring taxonomy `sync_error_messages.dart` already trusts for
+/// its "timeout" / "network" clauses, plus the concrete `dart:io` exception
+/// types. Auth / scope / other permanent failures are explicitly NOT transient:
+/// they have their own refresh / re-consent handling and must never be silently
+/// retried (a hard sign-in-expired would just burn every attempt then fail the
+/// same way). This is the missing classifier behind BUG-864 — a Google Drive
+/// `SocketException` (信号灯超时 / errno 121) arrived unclassified and abandoned
+/// the whole aggregate sync round with zero retries.
+bool isTransientSyncError(Object error) {
+  if (error is SocketException) return true;
+  if (error is TimeoutException) return true;
+  if (error is HttpException) return true;
+  final String l = error.toString().toLowerCase();
+  // Permanent auth/permission failures: never retry (own handling path). Checked
+  // first so a message that happens to also mention a socket cannot smuggle an
+  // auth error into the retry loop.
+  if (l.contains('insufficient_scope') ||
+      l.contains('unauthorized') ||
+      l.contains('invalid_grant') ||
+      l.contains('403') && l.contains('insufficient')) {
+    return false;
+  }
+  const List<String> transientMarkers = <String>[
+    'timed out',
+    'timeout',
+    '信号灯超时', // Windows ERROR_SEM_TIMEOUT
+    'errno = 121', // ERROR_SEM_TIMEOUT
+    'errno = 110', // ETIMEDOUT
+    'socketexception',
+    'clientexception',
+    'handshakeexception',
+    'failed host lookup',
+    'connection refused',
+    'connection closed',
+    'connection reset',
+    'connection abort', // "software caused connection abort"
+    'network is unreachable',
+  ];
+  for (final String marker in transientMarkers) {
+    if (l.contains(marker)) return true;
+  }
+  return false;
+}
+
+/// Runs [op], retrying up to [maxAttempts] **total** attempts while the thrown
+/// error passes [isTransient] (default [isTransientSyncError]). Waits
+/// `backoff * attempt` (linear backoff) between tries; [sleep] is injectable so
+/// tests run without real delay.
+///
+/// Re-throws the last error the moment attempts are exhausted OR the error is
+/// non-transient, so a permanent failure surfaces immediately instead of
+/// wasting the whole retry budget. The retried [op] must be idempotent — every
+/// caller here is (Drive folder ensure / list / download / overwrite-by-name
+/// upload), so a repeated attempt after a partial network blip is safe.
+Future<T> retryTransientSync<T>(
+  Future<T> Function() op, {
+  int maxAttempts = 4,
+  Duration backoff = const Duration(milliseconds: 400),
+  bool Function(Object error) isTransient = isTransientSyncError,
+  Future<void> Function(Duration delay)? sleep,
+}) async {
+  assert(maxAttempts >= 1, 'maxAttempts must be at least 1');
+  final Future<void> Function(Duration delay) doSleep =
+      sleep ?? (Duration delay) => Future<void>.delayed(delay);
+  int attempt = 0;
+  while (true) {
+    attempt++;
+    try {
+      return await op();
+    } catch (error) {
+      if (attempt >= maxAttempts || !isTransient(error)) rethrow;
+      await doSleep(backoff * attempt);
+    }
+  }
+}

--- a/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
+++ b/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
@@ -1020,7 +1020,11 @@ List<String> buildFfmpegMultiSubtitleArgs({
 /// pass (see [buildFfmpegMultiSubtitleArgs]). Returns the subset of [outputs]
 /// actually written (file exists and non-empty); a partially-failed batch (one
 /// corrupt track) still yields the tracks that succeeded rather than dropping
-/// everything.
+/// everything. When the single pass produces fewer tracks than requested — the
+/// worst case being an output-open `AVERROR(EINVAL)` (exit -22) that a single
+/// un-encodable track triggers, aborting the batch before ANY track is written —
+/// each still-missing track is re-demuxed on its own so one poison track only
+/// loses itself instead of poisoning every good track in the container.
 ///
 /// [timeout] bounds a hung demux. Unlike single-clip encodes, the read time of a
 /// big interleaved container grows with its size, so callers pass a size-scaled
@@ -1055,6 +1059,44 @@ Future<Map<int, String>> extractEmbeddedSubtitlesViaFfmpeg({
         } catch (_) {}
       }
     });
+    // Per-track fallback for tracks the single pass did NOT produce. ffmpeg
+    // initialises EVERY output encoder before writing any packet, so a single
+    // text-classified track whose codec it cannot transcode to the target muxer
+    // (e.g. a caption stream fail-opened to `.srt` by subtitleFormatForCodec)
+    // aborts the WHOLE single pass at output-open (`AVERROR(EINVAL)`, exit -22,
+    // "Error opening output files: Invalid argument") BEFORE anything lands —
+    // poisoning every good track in the batch. Re-demux each still-missing track
+    // on its own so a poison track only loses itself; a genuinely un-encodable
+    // track stays missing (graceful no-subtitle for that one track only). Reuses
+    // the same size-scaled [timeout] as the batch (NOT the single-clip 30s) so a
+    // large interleaved container does not spuriously time out on the retry. A
+    // fully-successful single pass leaves written.length == outputs.length, so
+    // this loop never runs (zero overhead on the common path). Gated on a
+    // non-null returnCode: a timed-out batch (returnCode == null) means the
+    // demux is too slow (IO contention), so per-track retries would just
+    // multiply that one timeout into N — the poison-track case that this
+    // fallback targets always returns a real exit code (-22), fast.
+    if (result.returnCode != null && written.length < outputs.length) {
+      for (final MapEntry<int, String> entry in outputs.entries) {
+        if (written.containsKey(entry.key)) continue;
+        final FfmpegRunResult single = await _runFfmpeg(
+          buildFfmpegSubtitleArgs(
+            inputPath: inputPath,
+            streamIndex: entry.key,
+            outputPath: entry.value,
+          ),
+          timeout,
+        );
+        final File f = File(entry.value);
+        if (single.returnCode == 0 && f.existsSync() && f.lengthSync() > 0) {
+          written[entry.key] = entry.value;
+        } else if (f.existsSync()) {
+          try {
+            f.deleteSync();
+          } catch (_) {}
+        }
+      }
+    }
     if (written.isEmpty) {
       _reportFfmpegFailure(
         'extractEmbeddedSubtitlesViaFfmpeg',

--- a/hibiki/test/sync/sync_transient_error_test.dart
+++ b/hibiki/test/sync/sync_transient_error_test.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/sync_transient_error.dart';
+
+void main() {
+  group('isTransientSyncError (BUG-864)', () {
+    test('true for concrete dart:io transient exception types', () {
+      expect(isTransientSyncError(const SocketException('boom')), isTrue);
+      expect(isTransientSyncError(TimeoutException('slow')), isTrue);
+      expect(isTransientSyncError(const HttpException('reset')), isTrue);
+    });
+
+    test('true for the reported Windows semaphore-timeout SocketException', () {
+      // The exact shape from the log: ClientException wrapping a SocketException
+      // 信号灯超时 / errno 121 against www.googleapis.com.
+      const String reported = 'ClientException with SocketException: 信号灯超时时间已到 '
+          '(OS Error: 信号灯超时时间已到, errno = 121), '
+          'address = www.googleapis.com, port = 2011';
+      expect(isTransientSyncError(reported), isTrue);
+    });
+
+    test('true for the network/timeout substring taxonomy', () {
+      for (final String s in <String>[
+        'SocketException: Connection reset by peer',
+        'Connection closed before full header was received',
+        'Connection refused',
+        'Failed host lookup: www.googleapis.com',
+        'Operation timed out',
+        'errno = 110',
+        'HandshakeException: ...',
+        'Network is unreachable',
+      ]) {
+        expect(isTransientSyncError(s), isTrue, reason: s);
+      }
+    });
+
+    test('false for permanent auth / permission / not-found errors', () {
+      expect(isTransientSyncError('insufficient_scope: re-consent required'),
+          isFalse);
+      expect(isTransientSyncError('401 unauthorized'), isFalse);
+      expect(isTransientSyncError('invalid_grant'), isFalse);
+      expect(isTransientSyncError('403 insufficientPermissions'), isFalse);
+      expect(isTransientSyncError('File not found'), isFalse);
+      expect(isTransientSyncError('Some unrelated failure'), isFalse);
+    });
+  });
+
+  group('retryTransientSync (BUG-864)', () {
+    test('retries a transient failure then succeeds, backing off each attempt',
+        () async {
+      int calls = 0;
+      final List<Duration> slept = <Duration>[];
+      final String result = await retryTransientSync<String>(
+        () async {
+          calls++;
+          if (calls < 3) throw const SocketException('blip');
+          return 'ok';
+        },
+        backoff: const Duration(milliseconds: 10),
+        sleep: (Duration d) async => slept.add(d),
+      );
+      expect(result, 'ok');
+      expect(calls, 3, reason: '两次瞬时失败 + 第三次成功');
+      // 线性退避：backoff*1, backoff*2。
+      expect(slept, <Duration>[
+        const Duration(milliseconds: 10),
+        const Duration(milliseconds: 20),
+      ]);
+    });
+
+    test('gives up after maxAttempts and rethrows the last transient error',
+        () async {
+      int calls = 0;
+      await expectLater(
+        retryTransientSync<void>(
+          () async {
+            calls++;
+            throw const SocketException('always');
+          },
+          maxAttempts: 3,
+          sleep: (Duration d) async {},
+        ),
+        throwsA(isA<SocketException>()),
+      );
+      expect(calls, 3, reason: '穷尽 maxAttempts 次');
+    });
+
+    test('does NOT retry a non-transient error — rethrows on first attempt',
+        () async {
+      int calls = 0;
+      await expectLater(
+        retryTransientSync<void>(
+          () async {
+            calls++;
+            throw StateError('permanent');
+          },
+          sleep: (Duration d) async {},
+        ),
+        throwsA(isA<StateError>()),
+      );
+      expect(calls, 1, reason: '永久错误立即抛出，不浪费重试');
+    });
+
+    test('a first-attempt success never sleeps (common path zero overhead)',
+        () async {
+      int calls = 0;
+      bool slept = false;
+      final int result = await retryTransientSync<int>(
+        () async {
+          calls++;
+          return 42;
+        },
+        sleep: (Duration d) async => slept = true,
+      );
+      expect(result, 42);
+      expect(calls, 1);
+      expect(slept, isFalse);
+    });
+  });
+}

--- a/hibiki/test/utils/desktop_audio_clipper_test.dart
+++ b/hibiki/test/utils/desktop_audio_clipper_test.dart
@@ -980,6 +980,67 @@ void main() {
     });
   });
 
+  group('extractEmbeddedSubtitlesViaFfmpeg 毒轨逐轨回退 (BUG-863)', () {
+    tearDown(() => ffmpeg.setFfmpegBackendForTesting(null));
+
+    test('单遍被一条 output-open 毒轨整批击穿时，逐轨回退保住其余好轨', () async {
+      final Directory dir =
+          Directory.systemTemp.createTempSync('hibiki_poison_test');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final String video = '${dir.path}/in.mkv';
+      // 只需存在（extractEmbeddedSubtitlesViaFfmpeg 用 existsSync 门控输入）。
+      File(video).writeAsStringSync('fake-container');
+      final _FakePoisonFfmpegBackend fake =
+          _FakePoisonFfmpegBackend(poisonIndex: 1);
+      ffmpeg.setFfmpegBackendForTesting(fake);
+
+      final Map<int, String> outputs = <int, String>{
+        0: '${dir.path}/sub_0.srt',
+        1: '${dir.path}/sub_1.srt', // 毒轨：ffmpeg 在 output-open 阶段 EINVAL
+        2: '${dir.path}/sub_2.ass',
+      };
+      final Map<int, String> written = await extractEmbeddedSubtitlesViaFfmpeg(
+        inputPath: video,
+        outputs: outputs,
+      );
+
+      // 好轨 0/2 保住；毒轨 1 只损失自己（不再整批 0 条）。
+      expect(written.keys.toSet(), <int>{0, 2});
+      expect(File(outputs[0]!).existsSync(), isTrue);
+      expect(File(outputs[2]!).existsSync(), isTrue);
+      expect(File(outputs[1]!).existsSync(), isFalse);
+
+      // 第一趟单遍全轨（含毒轨→整批失败），随后对 3 条缺失轨各跑一次逐轨。
+      expect(fake.passes.first.keys.toSet(), <int>{0, 1, 2},
+          reason: '第一趟必须是单遍全轨');
+      expect(fake.passes.length, 4, reason: '单遍 + 3 条逐轨回退');
+      for (final Map<int, String> p in fake.passes.skip(1)) {
+        expect(p.length, 1, reason: '回退每趟只抽一条轨');
+      }
+    });
+
+    test('单遍全部成功时不触发逐轨回退（common path 零开销）', () async {
+      final Directory dir =
+          Directory.systemTemp.createTempSync('hibiki_clean_test');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final String video = '${dir.path}/in.mkv';
+      File(video).writeAsStringSync('fake-container');
+      final _FakePoisonFfmpegBackend fake =
+          _FakePoisonFfmpegBackend(poisonIndex: -1); // 无毒轨
+      ffmpeg.setFfmpegBackendForTesting(fake);
+
+      final Map<int, String> written = await extractEmbeddedSubtitlesViaFfmpeg(
+        inputPath: video,
+        outputs: <int, String>{
+          0: '${dir.path}/s0.srt',
+          1: '${dir.path}/s1.srt',
+        },
+      );
+      expect(written.keys.toSet(), <int>{0, 1});
+      expect(fake.passes.length, 1, reason: '单遍成功 → 不跑逐轨回退');
+    });
+  });
+
   group('extractEmbeddedCoverViaFfmpeg', () {
     test('returns null when the audio file does not exist', () async {
       expect(
@@ -1148,4 +1209,59 @@ class _InvalidBundledThenPathFfmpegBackend implements ffmpeg.FfmpegBackend {
     Duration timeout,
   ) async =>
       const ffmpeg.FfmpegRunResult(returnCode: 0, output: '{"format":{}}');
+}
+
+/// Simulates the BUG-863 defect: ffmpeg initialises EVERY output encoder before
+/// writing any packet, so a demux pass that includes a track whose codec it
+/// cannot transcode ([poisonIndex]) aborts at output-open with EINVAL (-22) and
+/// writes NOTHING (all-or-nothing). A pass WITHOUT the poison track demuxes every
+/// requested track to a non-empty file. [passes] records the `0:s:N`→outputPath
+/// map of each invocation so a test can assert the single pass ran first, then
+/// per-track fallback for the still-missing tracks.
+class _FakePoisonFfmpegBackend implements ffmpeg.FfmpegBackend {
+  _FakePoisonFfmpegBackend({required this.poisonIndex});
+
+  final int poisonIndex;
+  final List<Map<int, String>> passes = <Map<int, String>>[];
+
+  Map<int, String> _parseMaps(List<String> args) {
+    final Map<int, String> map = <int, String>{};
+    final RegExp mapPattern = RegExp(r'^0:s:(\d+)$');
+    for (int i = 0; i + 2 < args.length; i++) {
+      if (args[i] != '-map') continue;
+      final RegExpMatch? m = mapPattern.firstMatch(args[i + 1]);
+      if (m == null) continue;
+      map[int.parse(m.group(1)!)] = args[i + 2];
+    }
+    return map;
+  }
+
+  @override
+  Future<ffmpeg.FfmpegRunResult> run(
+    List<String> args,
+    Duration timeout,
+  ) async {
+    final Map<int, String> pass = _parseMaps(args);
+    passes.add(pass);
+    if (pass.containsKey(poisonIndex)) {
+      // Output-open abort: batch dies before any packet lands.
+      return const ffmpeg.FfmpegRunResult(
+        returnCode: -22,
+        output: 'Error opening output files: Invalid argument',
+      );
+    }
+    pass.forEach((int idx, String out) {
+      File(out)
+        ..createSync(recursive: true)
+        ..writeAsStringSync('1\n00:00:00,000 --> 00:00:01,000\nx\n');
+    });
+    return const ffmpeg.FfmpegRunResult(returnCode: 0, output: '');
+  }
+
+  @override
+  Future<ffmpeg.FfmpegRunResult> runProbe(
+    List<String> args,
+    Duration timeout,
+  ) async =>
+      throw UnimplementedError('runProbe not used by subtitle extraction');
 }


### PR DESCRIPTION
运行日志 triage 出两个真 bug，各做根因修复 + 最强可落地层自动化测试。

## BUG-863 · 内嵌字幕单遍抽取被一条毒轨整批击穿
- **根因**：`extractEmbeddedSubtitlesViaFfmpeg` 走单遍多轨命令 `-y -i in -map 0:s:0 out0 -map 0:s:1 out1 …`（BUG-104 优化）。ffmpeg 在写任何数据包前先初始化全部输出编码器，只要有一条被 `subtitleFormatForCodec` fail-open 成 `.srt` 但无法转码的文本轨（如 caption），整条命令在 output-open 阶段直接 `AVERROR(EINVAL) = -22`（`Error opening output files: Invalid argument`），**一个包都没写** → `written` 空 → 整批全丢，连正常 ass/srt 轨一起没。
- **修复**：单遍 `written.length < outputs.length` 且批 `returnCode != null`（超时批不回退，避免把一次超时放大成 N 次）时，对每条缺失轨用 `buildFfmpegSubtitleArgs` 逐轨重抽（沿用同一 size-scaled 超时）。毒轨只损失自己；单遍全成功零开销。
- **测试**：`desktop_audio_clipper_test.dart` 注入 `_FakePoisonFfmpegBackend` 模拟 output-open 整批 EINVAL，断言 3 轨含毒轨时结果 `{0,2}`、单遍+3逐轨=4 趟；无毒轨时单遍成功不回退。

## BUG-864 · Google Drive 聚合同步瞬时超时不重试整轮放弃
- **根因**：`GoogleDriveHandler._call` 只对 401 重试；瞬时 `SocketException`/超时（信号灯超时 errno121）裸抛，穿透 `_wrapErrors`（只 catch GoogleDriveError），`SyncOrchestrator._syncAggregate` 裸 catch 记 `report.errors` 后**整轮放弃**，零重试。
- **修复**：新增 `sync_transient_error.dart`——`isTransientSyncError`（复用 sync_error_messages 的 timeout/network 子串分类 + dart:io 异常类型；auth/scope/4xx 判非瞬时）+ `retryTransientSync`（默认 4 次线性退避 400ms*attempt，sleep 可注入，永久错立即抛）。`_call` 拆 `_callOnce`（保留 401 逻辑）后外包重试，覆盖全部 Drive 幂等操作（聚合 list/ensure/put + 书/词典）。
- **测试**：`sync_transient_error_test.dart` 覆盖判定分类（含日志原文信号灯超时）+ 重试到成功/退避/穷尽即抛/不重试永久错/首次成功零 sleep。

## 验证
- `flutter analyze`：No issues found。
- 两处新增/改动测试全绿（clipper 43、sync helper 8）。
- ⚠️ 预存在失败（**非本 PR 引入**）：`test/sync/sync_settings_visibility_test.dart` 的 `buildSyncBackupDestination … sync.content` gating，基底 origin/develop 已失败，本 PR 未碰 sync_settings_schema。
- 未 bump `pubspec.yaml`（draft PR 未发布，版本由 integration owner 合并时定）。
- 真机复测原始失败路径（切内封字幕 / Drive 同步）留给验收。