### PR TITLE
fix(anki): BUG-865 副engine注册anki channel，修复外部查词面制卡MissingPluginException

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 845 条。点号进各自文件。
+> 共 846 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-865](bugs/BUG-865-anki-popup-engine-missing-channel.md) | ✅ | ✅ | 外部查词面制卡 MissingPluginException 副engine未注册anki channel |
 | [BUG-864](bugs/BUG-864-gdrive-sync-transient-no-retry.md) | ✅ | ✅ | Google Drive 聚合同步瞬时网络超时不重试整轮放弃 |
 | [BUG-863](bugs/BUG-863-embedded-sub-poison-track.md) | ✅ | ✅ | 内嵌字幕单遍抽取被一条毒轨整批击穿 |
 | [BUG-861](bugs/BUG-861-video-shift-hover-switch.md) | ✅ | ✅ | 视频按住Shift无法连续切换查词 |

--- a/docs/bugs/BUG-865-anki-popup-engine-missing-channel.md
+++ b/docs/bugs/BUG-865-anki-popup-engine-missing-channel.md
@@ -1,0 +1,12 @@
+## BUG-865 · 外部查词面制卡 MissingPluginException 副engine未注册anki channel
+- **报告**：2026-07-16（用户：截图 toast「导出卡片失败：AnkiDroid: unexpected error: MissingPluginException(No imple...」）
+- **真实性**：✅ 真 bug。根因 `hibiki/android/app/src/main/java/app/hibiki/reader/PopupEngineHolder.kt:90` — 副 FlutterEngine（`popupMain`）只调 `FloatingDictPluginRegistrant.registerWith(engine)` 注册插件 + `/popup` channel，**未注册** `app.hibiki.reader/anki` MethodChannel（唯一注册在 `MainActivity.configureFlutterEngine` → `AnkiChannelHandler.register`，`MainActivity.java:475`）。
+  - 数据流：app 外查词面（剪贴板 / 悬浮 / 选区弹窗 = `PopupDictionaryPage`，跑在 popupMain 副 engine）点「＋」制卡 → `AnkiRepository._mineEntryInner` → `_channel.invokeMethod('addNote')`（`packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart`）→ 该 engine 上 channel 无 handler → 抛 `MissingPluginException`。`MissingPluginException` 不是 `PlatformException` 子类，逃过 addNote 内层 `on PlatformException` catch，命中 `mineEntry` 外层 `catch (e)` → 包成 `'AnkiDroid: unexpected error: $e'` → `error_log_service.dart` 拼成「导出卡片失败：…」toast。
+  - 诱因：BUG-774（`7a0e83b3c`）解禁了 app 外查词面上原被 CSS 隐藏的制卡「＋」按钮，使这条路径首次可达。
+- **[x] ① 已修复** — 让 anki channel 在副 engine 也注册。`AnkiChannelHandler` 里唯一真正需要 `Activity` 的只有运行时权限弹窗（`ActivityCompat.requestPermissions`），其余全部 `Context` 即可（`AnkiDroidHelper` 内部已 `getApplicationContext()`；`AddContentApi`/`FileProvider`/`grantUriPermission`/`getContentResolver`/`startActivity(NEW_TASK)` 均 Context）。
+  - `AnkiChannelHandler.java`：新增 `AnkiChannelHandler(@NonNull Context, @Nullable Activity)` 构造器（存 `applicationContext` + 可空 `activity`），旧 `AnkiChannelHandler(Activity)` 委托 `this(activity, activity)`（主 engine 不变）；把 lambda/helper 里 `activity.*` 全改 `context.*`；`requirePermission` 与 `requestAnkidroidPermissions` 对 `activity==null` 优雅降级（不弹框，回 `PERMISSION_DENIED`，避免 NPE）。
+  - `FloatingDictPluginRegistrant.registerWith(FlutterEngine, Context)`：新增 Context 参数，注册 `new AnkiChannelHandler(context, null)`。
+  - `PopupEngineHolder.ensureEngine`：调 `registerWith(engine, context.applicationContext)`。
+  - 提交：（见 PR）
+- **[x] ② 已加自动化测试** — `hibiki/test/android/anki_popup_engine_channel_guard_test.dart`：源码扫描守卫，断言 ①`FloatingDictPluginRegistrant.registerWith` 带 Context 参数且注册 `AnkiChannelHandler`、②`PopupEngineHolder` 向 registrant 传 context、③`AnkiChannelHandler` 有 `(Context, @Nullable Activity)` 构造器且对 `activity==null` 权限降级。真机 channel 注册跑原生层测不了，守注册机制防回归。
+- **备注**：与 BUG-146（popup 副 engine registrant 缺 dev 插件）同类；与 BUG-390（WebView 半销毁 evaluateJavascript per-instance channel 被摘）无关。真机需在 Android 上从剪贴板/悬浮/选区弹窗制卡验证不再 toast MissingPluginException、卡片真入 AnkiDroid。

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/AnkiChannelHandler.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/AnkiChannelHandler.java
@@ -3,6 +3,7 @@ package app.hibiki.reader;
 import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentValues;
+import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -10,6 +11,7 @@ import android.os.Handler;
 import android.os.Looper;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.content.FileProvider;
 
 import com.ichi2.anki.FlashCardsContract;
@@ -33,12 +35,33 @@ public class AnkiChannelHandler {
     private static final String CHANNEL = ChannelNames.ANKI;
     private static final int AD_PERM_REQUEST = 0;
 
+    // BUG-865：AnkiDroid ContentProvider 访问是「进程 + 权限」作用域，只需 Context
+    // （AnkiDroidHelper 内部已 getApplicationContext()、AddContentApi/FileProvider/
+    // grantUriPermission/getContentResolver/startActivity(NEW_TASK) 均 Context 即可）。
+    // 唯一真正需要 Activity 的是运行时权限弹窗 ActivityCompat.requestPermissions；
+    // 副 FlutterEngine（popupMain/PopupEngineHolder）无 Activity，此时 activity=null，
+    // 权限路径优雅降级（返回 PERMISSION_DENIED，不 NPE），制卡权限已在主 app 授予。
+    private final Context context;
+    @Nullable
     private final Activity activity;
     private final AnkiDroidHelper ankiDroid;
 
+    /** 主 engine（MainActivity）用：Activity 既作 Context 又能弹权限。 */
     public AnkiChannelHandler(Activity activity) {
+        this(activity, activity);
+    }
+
+    /**
+     * BUG-865：副 engine（popupMain）用 applicationContext 注册，activity 传 null。
+     *
+     * @param context  用于 ContentProvider / FileProvider 的 Context（内部取
+     *                 applicationContext，避免暖 engine 持有 Activity 泄漏）。
+     * @param activity 运行时权限弹窗宿主；无 Activity（副 engine/服务）时传 null。
+     */
+    public AnkiChannelHandler(@NonNull Context context, @Nullable Activity activity) {
+        this.context = context.getApplicationContext();
         this.activity = activity;
-        this.ankiDroid = new AnkiDroidHelper(activity);
+        this.ankiDroid = new AnkiDroidHelper(this.context);
     }
 
     public void register(@NonNull FlutterEngine engine) {
@@ -55,7 +78,7 @@ public class AnkiChannelHandler {
                 final String filename = call.argument("filename");
                 final String preferredName = call.argument("preferredName");
                 final String mimeType = call.argument("mimeType");
-                final AddContentApi api = new AddContentApi(activity);
+                final AddContentApi api = new AddContentApi(context);
                 final ArrayList<String> noteTypeFields = call.argument("noteTypeFields");
                 final String noteTypeName = call.argument("noteTypeName");
                 final String cardName = call.argument("cardName");
@@ -269,7 +292,9 @@ public class AnkiChannelHandler {
                         }
                         break;
                     case "requestAnkidroidPermissions":
-                        if (ankiDroid.shouldRequestPermission()) {
+                        // BUG-865：副 engine（activity==null）无法弹系统权限框，静默跳过；
+                        // 权限须在主 app 授予。仍回 success(true) 保持契约不变。
+                        if (activity != null && ankiDroid.shouldRequestPermission()) {
                             ankiDroid.requestPermission(activity, AD_PERM_REQUEST);
                         }
                         result.success(true);
@@ -295,15 +320,15 @@ public class AnkiChannelHandler {
                         // IllegalArgumentException「Failed to find configured root」，SVG 外字
                         // 制卡断裂。
                         Uri fileUri = FileProvider.getUriForFile(
-                            activity, BuildConfig.APPLICATION_ID + ".provider", file);
-                        activity.grantUriPermission("com.ichi2.anki", fileUri,
+                            context, BuildConfig.APPLICATION_ID + ".provider", file);
+                        context.grantUriPermission("com.ichi2.anki", fileUri,
                             Intent.FLAG_GRANT_READ_URI_PERMISSION);
                         ContentValues contentValues = new ContentValues();
                         contentValues.put(FlashCardsContract.AnkiMedia.FILE_URI,
                             fileUri.toString());
                         contentValues.put(FlashCardsContract.AnkiMedia.PREFERRED_NAME,
                             preferredName);
-                        ContentResolver contentResolver = activity.getContentResolver();
+                        ContentResolver contentResolver = context.getContentResolver();
                         Uri returnUri = contentResolver.insert(
                             FlashCardsContract.AnkiMedia.CONTENT_URI, contentValues);
                         if (returnUri == null || returnUri.getPath() == null) {
@@ -341,7 +366,11 @@ public class AnkiChannelHandler {
 
     private boolean requirePermission(MethodChannel.Result result) {
         if (ankiDroid.shouldRequestPermission()) {
-            ankiDroid.requestPermission(activity, AD_PERM_REQUEST);
+            // BUG-865：副 engine（activity==null）不能弹系统权限框，只回错误让 Dart
+            // 层提示「去主 app 授予 AnkiDroid 权限」，避免 ActivityCompat 对 null NPE。
+            if (activity != null) {
+                ankiDroid.requestPermission(activity, AD_PERM_REQUEST);
+            }
             result.error("PERMISSION_DENIED",
                 "AnkiDroid permission not granted. Please grant and retry.",
                 null);
@@ -363,7 +392,7 @@ public class AnkiChannelHandler {
      */
     private Long addNote(String model, String deck,
                          ArrayList<String> fields, ArrayList<String> tags) {
-        final AddContentApi api = new AddContentApi(activity);
+        final AddContentApi api = new AddContentApi(context);
 
         long deckId;
         Long existingDeck = ankiDroid.findDeckIdByName(deck);
@@ -404,7 +433,7 @@ public class AnkiChannelHandler {
      *         {@code null} if the note no longer exists / its model is gone.
      */
     private Map<String, String> notesInfo(long noteId) {
-        final AddContentApi api = new AddContentApi(activity);
+        final AddContentApi api = new AddContentApi(context);
         NoteInfo note = api.getNote(noteId);
         if (note == null) {
             return null;
@@ -435,7 +464,7 @@ public class AnkiChannelHandler {
      *         note / its model cannot be found or AnkiDroid refused the update.
      */
     private String updateNoteFields(long noteId, Map<String, String> fieldValues) {
-        final AddContentApi api = new AddContentApi(activity);
+        final AddContentApi api = new AddContentApi(context);
         NoteInfo note = api.getNote(noteId);
         if (note == null) {
             return "Note not found: " + noteId;
@@ -485,7 +514,7 @@ public class AnkiChannelHandler {
      * the note does not exist or the provider yields no row.
      */
     private Long modelIdForNote(long noteId) {
-        ContentResolver resolver = activity.getContentResolver();
+        ContentResolver resolver = context.getContentResolver();
         Uri noteUri = Uri.withAppendedPath(
             FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
         try (Cursor cursor = resolver.query(
@@ -506,7 +535,7 @@ public class AnkiChannelHandler {
     private boolean checkForDuplicates(ArrayList<String> models, String key,
                                        String reading,
                                        ArrayList<Integer> readingFieldIndices) {
-        final AddContentApi api = new AddContentApi(activity);
+        final AddContentApi api = new AddContentApi(context);
         for (int i = 0; i < models.size(); i++) {
             String model = models.get(i);
             Long mid = ankiDroid.findModelIdByName(model, 1);
@@ -546,7 +575,7 @@ public class AnkiChannelHandler {
     private List<Map<String, Object>> findNotesByContent(
             ArrayList<String> models, String key, String reading,
             ArrayList<Integer> readingFieldIndices) {
-        final AddContentApi api = new AddContentApi(activity);
+        final AddContentApi api = new AddContentApi(context);
         // De-dup by note id across models (a card matches at most one model, but
         // guard anyway), then sort newest-first.
         final LinkedHashMap<Long, String> byId = new LinkedHashMap<>();
@@ -597,17 +626,17 @@ public class AnkiChannelHandler {
             FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
         Intent intent = new Intent(Intent.ACTION_VIEW, noteUri);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        if (intent.resolveActivity(activity.getPackageManager()) == null) {
+        if (intent.resolveActivity(context.getPackageManager()) == null) {
             return false;
         }
-        activity.startActivity(intent);
+        context.startActivity(intent);
         return true;
     }
 
     private void createNoteType(String name, ArrayList<String> fields,
                                 String cardName, String front, String back,
                                 String css) {
-        final AddContentApi api = new AddContentApi(activity);
+        final AddContentApi api = new AddContentApi(context);
         // Idempotent: a model with this name + field count already exists.
         if (ankiDroid.findModelIdByName(name, fields.size()) != null) return;
         api.addNewCustomModel(

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/FloatingDictPluginRegistrant.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/FloatingDictPluginRegistrant.java
@@ -1,5 +1,7 @@
 package app.hibiki.reader;
 
+import android.content.Context;
+
 import androidx.annotation.NonNull;
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterEngine;
@@ -9,7 +11,19 @@ final class FloatingDictPluginRegistrant {
 
     private FloatingDictPluginRegistrant() {}
 
-    static void registerWith(@NonNull FlutterEngine flutterEngine) {
+    static void registerWith(@NonNull FlutterEngine flutterEngine, @NonNull Context context) {
+        // BUG-865：副 FlutterEngine（popupMain）上的制卡走 AnkiRepository 的
+        // `app.hibiki.reader/anki` MethodChannel。该 channel 原先只在 MainActivity 的主
+        // engine 注册，副 engine 未注册 → app 外查词面（剪贴板/悬浮/选区弹窗）制卡时
+        // invokeMethod('addNote') 抛 MissingPluginException，toast 显示「导出卡片失败：
+        // AnkiDroid: unexpected error: MissingPluginException(...)」。这里用
+        // applicationContext（activity=null）补注册：ContentProvider 制卡是进程+权限
+        // 作用域，Context 足够；权限弹窗须在主 app 完成（见 AnkiChannelHandler）。
+        try {
+            new AnkiChannelHandler(context, null).register(flutterEngine);
+        } catch (Exception e) {
+            Log.e(TAG, "Error registering anki channel", e);
+        }
         try {
             flutterEngine.getPlugins().add(
                 new dev.fluttercommunity.plus.device_info.DeviceInfoPlusPlugin());

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/PopupEngineHolder.kt
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/PopupEngineHolder.kt
@@ -87,7 +87,9 @@ object PopupEngineHolder {
         if (cache.get(ENGINE_ID) != null) return false
 
         val engine = FlutterEngine(context.applicationContext, null, false)
-        FloatingDictPluginRegistrant.registerWith(engine)
+        // BUG-865：传 applicationContext 让 registrant 也注册 anki channel，使 popupMain
+        // 副 engine 上的 app 外查词面制卡不再抛 MissingPluginException。
+        FloatingDictPluginRegistrant.registerWith(engine, context.applicationContext)
 
         val ch = MethodChannel(engine.dartExecutor.binaryMessenger, ChannelNames.POPUP)
         ch.setMethodCallHandler { call, result ->

--- a/hibiki/test/android/anki_popup_engine_channel_guard_test.dart
+++ b/hibiki/test/android/anki_popup_engine_channel_guard_test.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-865 source-scan guard: app 外查词面（剪贴板 / 悬浮 / 选区弹窗）的制卡跑在
+/// `popupMain` 副 FlutterEngine（`PopupEngineHolder`）里。AnkiDroid 制卡走
+/// `AnkiRepository` 的 `app.hibiki.reader/anki` MethodChannel，而该 channel 原先只在
+/// `MainActivity.configureFlutterEngine` 的主 engine 注册。副 engine 未注册 →
+/// `invokeMethod('addNote')` 抛 `MissingPluginException`，被 `mineEntry` 外层 catch
+/// 包成 toast「导出卡片失败：AnkiDroid: unexpected error: MissingPluginException(...)」。
+/// 诱因是 BUG-774 解禁了 app 外查词面的制卡「＋」按钮。
+///
+/// 根因修复：副 engine 的唯一插件注册点 `FloatingDictPluginRegistrant.registerWith`
+/// 接收一个 `Context`，并用 `applicationContext` 注册一份
+/// `new AnkiChannelHandler(context, null)`（AnkiDroid ContentProvider 制卡是进程+权限
+/// 作用域，Context 足够；权限弹窗须在主 app 完成，故 activity 传 null）。
+///
+/// 真机 MethodChannel 注册跑在 Android 原生层（这里跑不了），故守 *注册机制*：若
+/// registrant 不再注册 anki channel、或 `PopupEngineHolder` 不再向 registrant 传
+/// Context，副 engine 制卡会再次抛 MissingPluginException，本测试转红。
+void main() {
+  // Tests run with CWD = `hibiki/`.
+  final File registrant = File(
+    'android/app/src/main/java/app/hibiki/reader/FloatingDictPluginRegistrant.java',
+  );
+  final File popupEngine = File(
+    'android/app/src/main/java/app/hibiki/reader/PopupEngineHolder.kt',
+  );
+  final File ankiHandler = File(
+    'android/app/src/main/java/app/hibiki/reader/AnkiChannelHandler.java',
+  );
+
+  test('secondary-engine files exist', () {
+    expect(registrant.existsSync(), isTrue);
+    expect(popupEngine.existsSync(), isTrue);
+    expect(ankiHandler.existsSync(), isTrue);
+  });
+
+  test('FloatingDictPluginRegistrant registers the anki channel', () {
+    final String src = registrant.readAsStringSync();
+    final String compact = src.replaceAll(RegExp(r'\s+'), ' ');
+
+    // registerWith 必须接收一个 Context（供 anki channel 用 applicationContext 注册）。
+    expect(
+      RegExp(r'registerWith\([^)]*FlutterEngine[^)]*Context[^)]*\)')
+          .hasMatch(compact),
+      isTrue,
+      reason: 'BUG-865: registerWith 必须带 Context 参数，否则无法在副 engine 注册 '
+          'anki channel（AnkiChannelHandler 需要 Context）。',
+    );
+
+    // 必须在此注册 AnkiChannelHandler，否则 popupMain 副 engine 制卡抛
+    // MissingPluginException。
+    expect(
+      RegExp(r'new\s+AnkiChannelHandler\([^)]*\)\s*\.register\(')
+          .hasMatch(compact),
+      isTrue,
+      reason: 'BUG-865: 副 engine 必须注册 app.hibiki.reader/anki channel，'
+          '否则 app 外查词面制卡 invokeMethod(addNote) 抛 MissingPluginException。',
+    );
+  });
+
+  test('PopupEngineHolder passes a Context into the registrant', () {
+    final String src = popupEngine.readAsStringSync();
+    final String compact = src.replaceAll(RegExp(r'\s+'), ' ');
+
+    expect(
+      RegExp(r'FloatingDictPluginRegistrant\.registerWith\([^)]*context[^)]*\)')
+          .hasMatch(compact),
+      isTrue,
+      reason: 'BUG-865: PopupEngineHolder 必须把 Context（applicationContext）传给 '
+          'registerWith，否则 anki channel 无法在 popupMain 副 engine 注册。',
+    );
+  });
+
+  test('AnkiChannelHandler has a Context-based constructor for the sub-engine',
+      () {
+    final String src = ankiHandler.readAsStringSync();
+    final String compact = src.replaceAll(RegExp(r'\s+'), ' ');
+
+    // 构造器必须能接受 (Context, @Nullable Activity)，让副 engine 用 applicationContext
+    // 注册且 activity 传 null（ContentProvider 制卡只需 Context）。
+    expect(
+      RegExp(r'AnkiChannelHandler\(\s*@NonNull\s+Context\s+context,\s*@Nullable\s+Activity\s+activity\s*\)')
+          .hasMatch(compact),
+      isTrue,
+      reason: 'BUG-865: AnkiChannelHandler 需要一个 (Context, @Nullable Activity) '
+          '构造器；否则副 engine 无 Activity 时无法注册 anki channel。',
+    );
+
+    // 权限弹窗路径必须对 activity==null 优雅降级（不能对 null 调 requestPermission）。
+    expect(
+      compact.contains('if (activity != null)'),
+      isTrue,
+      reason: 'BUG-865: activity==null（副 engine）时权限弹窗须跳过，否则 '
+          'ActivityCompat.requestPermissions 对 null NPE。',
+    );
+  });
+}


### PR DESCRIPTION
## 现象
用户截图：从 app 外查词面（剪贴板 / 悬浮 / 选区弹窗）弹出的词典里点制卡「＋」，toast 报
`导出卡片失败：AnkiDroid: unexpected error: MissingPluginException(No imple...`。

## 根因
外部查词面 `PopupDictionaryPage` 跑在 `popupMain` **副 FlutterEngine**（`PopupEngineHolder`）里。
AnkiDroid 制卡走 `AnkiRepository` 的 `app.hibiki.reader/anki` MethodChannel，而该 channel
**只在 `MainActivity.configureFlutterEngine` 的主 engine 注册**，副 engine 只注册了
`FloatingDictPluginRegistrant` 插件 + `/popup` channel。于是副 engine 上
`invokeMethod('addNote')` 命中无 handler 的 channel → `MissingPluginException`。它不是
`PlatformException` 子类，逃过 `addNote` 内层 catch，命中 `mineEntry` 外层 `catch (e)` →
包成 toast。诱因是 **BUG-774**（`7a0e83b3c`）解禁了外部查词面上原被 CSS 隐藏的制卡按钮。

## 修复
`AnkiChannelHandler` 里唯一真正需要 `Activity` 的只有运行时权限弹窗
（`ActivityCompat.requestPermissions`），其余全部 `Context` 即可（`AnkiDroidHelper` 内部已
`getApplicationContext()`；`AddContentApi`/`FileProvider`/`grantUriPermission`/
`getContentResolver`/`startActivity(NEW_TASK)` 均 Context）。

- `AnkiChannelHandler.java`：新增 `(Context, @Nullable Activity)` 构造器（存 applicationContext
  + 可空 activity），旧 `(Activity)` 委托 `this(activity, activity)`（主 engine 行为不变）；
  lambda/helper 里 `activity.*` 全改 `context.*`；`requirePermission` /
  `requestAnkidroidPermissions` 对 `activity==null` 优雅降级（不弹框、回 `PERMISSION_DENIED`，
  避免对 null NPE）。
- `FloatingDictPluginRegistrant.registerWith(FlutterEngine, Context)`：新增 Context 参数，
  用 `new AnkiChannelHandler(context, null)` 注册 anki channel（副 engine 唯一注册点，未来任何
  用该 registrant 的副 engine 都自动获得 anki channel）。
- `PopupEngineHolder.ensureEngine`：`registerWith(engine, context.applicationContext)`。

暖 engine 用 applicationContext 而非 Activity，避免持有 Activity 泄漏。

## 测试
- `hibiki/test/android/anki_popup_engine_channel_guard_test.dart` 源码扫描守卫（4 断言全过）：
  registrant 带 Context 参数且注册 AnkiChannelHandler / PopupEngineHolder 传 context /
  AnkiChannelHandler 有 (Context,@Nullable Activity) 构造器且对 activity==null 权限降级。
- `gradlew :app:compileDebugJavaWithJavac :app:compileDebugKotlin` → **BUILD SUCCESSFUL**。

## 版本
未 bump `+build`，留给 integration owner 落地时统一处理（避免并发 PR 冲突）。

## 真机验证（待办）
Android 上从剪贴板 / 悬浮 / 选区弹窗制卡，确认不再 toast MissingPluginException 且卡片真入
AnkiDroid；顺带验证外字 SVG 媒体（addFileToMedia）在副 engine 也能附卡。

BUG 文档：`docs/bugs/BUG-865-anki-popup-engine-missing-channel.md`