### PR TITLE
fix(reader): BUG-867 内容就绪兜底超时补复位导航态，修复开EPUB偶发翻页永久失效

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 847 条。点号进各自文件。
+> 共 848 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-867](bugs/BUG-867-reader-content-ready-timeout-pagination-wedge.md) | ✅ | ✅ | 开EPUB偶发卡住·内容就绪兜底超时漏复位导航态致翻页永久失效 |
 | [BUG-866](bugs/BUG-866-reader-live-margin-theme-gate.md) | ✅ | ✅ | 阅读器余白/主题改完不实时生效须退出重进(样式重锚就绪门控静默丢CSS) |
 | [BUG-865](bugs/BUG-865-anki-popup-engine-missing-channel.md) | ✅ | ✅ | 外部查词面制卡 MissingPluginException 副engine未注册anki channel |
 | [BUG-864](bugs/BUG-864-gdrive-sync-transient-no-retry.md) | ✅ | ✅ | Google Drive 聚合同步瞬时网络超时不重试整轮放弃 |

--- a/docs/bugs/BUG-867-reader-content-ready-timeout-pagination-wedge.md
+++ b/docs/bugs/BUG-867-reader-content-ready-timeout-pagination-wedge.md
@@ -1,0 +1,10 @@
+## BUG-867 · 开EPUB偶发卡住·内容就绪兜底超时漏复位导航态致翻页永久失效
+
+- **报告**：2026-07-17（用户：）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart:41-58`（`_startContentReadyTimeout` 超时回调）+ `chrome.part.dart:39-40`（`_paginationInFlight` getter）。
+  - 内容就绪兜底看门狗 `_startContentReadyTimeout` 的超时回调只 `_rebuild(_readerContentReady = true)` 摘掉 loading 遮罩，**漏了复位** `_restoreInFlight` / `_isNavigatingToChapter` / `_restoreCompleter`。
+  - 当 `window.hoshiReader` 偶发不回 `onRestoreComplete`（`webview.part.dart` 的 `onRestoreComplete` / `_onRestoreComplete` 从不被触发）时，遮罩被兜底摘掉、书**看似打开**，但 `_paginationInFlight = _restoreInFlight || !_readerContentReady || _isNavigatingToChapter` 因前两项恒真而恒真 → `_paginate` / `onBoundarySwipe` 的翻页 tick 全被守卫吞掉 → **翻页永久失效、进度不保存**。
+  - 对比正常路径 `_onRestoreComplete`（navigation.part.dart:86-90）确实复位了这三者；兜底超时路径漏了。既有等待超时收尾 `_navigateToChapterAndWait`（navigation.part.dart:504-506）也证明这三者本该一起解开。
+- **[x] ① 已修复** — `navigation.part.dart` 超时回调在强制 `_readerContentReady = true` 的同一路径补 `_isNavigatingToChapter = false` + `_failNavigation()`（清 `_restoreInFlight`、`complete(false)` 并清空 `_restoreCompleter`，放行等待方），与 `_navigateToChapterAndWait` 的等待超时收尾同构。提交见本轮 commit。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/reader_content_ready_timeout_unwind_guard_static_test.dart`：源码语料守卫，断言超时回调体内同时含 `_readerContentReady = true` / `_isNavigatingToChapter = false` / `_failNavigation()`，且 `_failNavigation` helper 仍清 `_restoreInFlight` 并 complete/清空 completer。删掉任一复位即红。ReaderHibikiPage 过重（WebView + 音频 + 全 ProviderContainer）无法在 widget test 可靠拉起跑该超时回调，故落最强可落地的源码层（与 reader_* 一系列 *_static_test 同纪律）。
+- **备注**：根因分析由用户对着原始源码多次核对给出，本轮独立复核数据流后确认无误。修复不引入延迟/重试/吞异常，纯粹补齐兜底路径本该做的状态解锁。真机复测「反复开合同一 EPUB 直到触发兜底超时 toast，随后仍能翻页 + 退出重进进度保住」待用户在指定设备验证。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -47,6 +47,15 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
           _readerContentReady = true;
           _hasEverLoaded = true;
         });
+        // BUG-867：兜底超时是「JS 侧 hoshiReader 迟迟不回 onRestoreComplete」时的最终解锁，
+        // 光翻 _readerContentReady 不够——_restoreInFlight / _isNavigatingToChapter /
+        // _restoreCompleter 仍悬空，_paginationInFlight（chrome.part.dart）恒真：遮罩摘掉、
+        // 书看似打开，但翻页永久被守卫吞掉、进度不再保存。这里连同解开导航态，与
+        // _navigateToChapterAndWait 的等待超时收尾（本文件 _restoreCompleter.future.timeout
+        // onTimeout）同构：清 _isNavigatingToChapter，_failNavigation 清 _restoreInFlight
+        // 并 complete(false)+清空 completer，让等待方立即返回而非各等各的 10s 超时。
+        _isNavigatingToChapter = false;
+        _failNavigation();
         // TODO-1229 第三次复诉：兜底超时也算内容就绪，消费 pending 并 stamp 冷却窗，
         // 避免惯性跨章后旗子悬空到下一次真实导航才被清（那会造成一次假冷却）。
         _noteChapterTurnSettledIfPending();

--- a/hibiki/test/pages/reader_content_ready_timeout_unwind_guard_static_test.dart
+++ b/hibiki/test/pages/reader_content_ready_timeout_unwind_guard_static_test.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-867 源码守卫：打开 EPUB 偶发「看似打开、翻页永久失效、进度不保存」。
+///
+/// 根因 = 内容就绪兜底看门狗 `_startContentReadyTimeout` 的超时回调只翻
+/// `_readerContentReady = true` 摘掉遮罩，却漏了复位导航态
+/// （`_restoreInFlight` / `_isNavigatingToChapter` / `_restoreCompleter`）。
+/// 当 `window.hoshiReader` 偶发不回 `onRestoreComplete` 时，这三者恒悬空 →
+/// `_paginationInFlight`（chrome.part.dart：`_restoreInFlight || !_readerContentReady
+/// || _isNavigatingToChapter`）恒真 → 翻页 tick 全被守卫吞掉、位置保存也停摆。
+///
+/// 修复 = 超时回调在强制置 `_readerContentReady = true` 的同一路径里，连同解开导航态：
+/// `_isNavigatingToChapter = false` + `_failNavigation()`（清 `_restoreInFlight`、
+/// complete(false) 并清空 `_restoreCompleter`），与 `_navigateToChapterAndWait` 的
+/// 等待超时收尾同构。
+///
+/// 守卫断言修复结构在位：①超时回调体内既有 `_readerContentReady = true` 又有
+/// `_isNavigatingToChapter = false` 与 `_failNavigation()`；②`_failNavigation` helper
+/// 本身仍清 `_restoreInFlight` 并 complete/清空 completer（防被掏空）。删掉任一即红。
+/// ReaderHibikiPage 过重（WebView + 音频 + 全 ProviderContainer），无法在 widget test
+/// 可靠拉起跑该超时回调，故落在最强可靠可落地的源码语料层（与 reader_* 一系列
+/// *_static_test 同纪律）。
+void main() {
+  String read(String rel) {
+    final File f = File(rel);
+    expect(f.existsSync(), isTrue, reason: '文件不存在：$rel');
+    return f.readAsStringSync().replaceAll('\r\n', '\n');
+  }
+
+  test('内容就绪兜底超时回调必须连同解开导航态（restore/navigate/completer）', () {
+    final String src = read(
+        'lib/src/pages/implementations/reader_hibiki/navigation.part.dart');
+
+    // 取 `_startContentReadyTimeout` 体到下一个方法 `_clearContentReadyTimeout` 之间，
+    // 保证断言只落在该超时回调上、不被文件别处的同名语句误判为通过。
+    final int start = src.indexOf('void _startContentReadyTimeout() {');
+    expect(start, greaterThan(-1), reason: '找不到 _startContentReadyTimeout');
+    final int end = src.indexOf('void _clearContentReadyTimeout() {', start);
+    expect(end, greaterThan(start),
+        reason: '找不到 _clearContentReadyTimeout（用于界定超时体范围）');
+    final String body = src.substring(start, end);
+
+    // ① 超时回调仍走「强制摘遮罩」这条路径。
+    expect(body.contains('_readerContentReady = true;'), isTrue,
+        reason: '超时回调应强制置内容就绪摘掉遮罩');
+
+    // ② 同一超时回调里必须解开导航态，否则 _paginationInFlight 恒真、翻页永久卡死。
+    expect(body.contains('_isNavigatingToChapter = false;'), isTrue,
+        reason: '超时回调必须清 _isNavigatingToChapter（否则 _paginationInFlight 恒真）');
+    expect(body.contains('_failNavigation();'), isTrue,
+        reason: '超时回调必须 _failNavigation 清 _restoreInFlight 并收尾 completer');
+
+    // ③ _failNavigation helper 自身仍复位 restoreInFlight 并 complete/清空 completer。
+    final int failStart = src.indexOf('void _failNavigation() {');
+    expect(failStart, greaterThan(-1), reason: '找不到 _failNavigation helper');
+    final int failEnd = src.indexOf('\n  }', failStart);
+    final String failBody = src.substring(failStart, failEnd);
+    expect(failBody.contains('_restoreInFlight = false;'), isTrue,
+        reason: '_failNavigation 必须清 _restoreInFlight');
+    expect(failBody.contains('_restoreCompleter!.complete(false);'), isTrue,
+        reason: '_failNavigation 必须完成挂起的 restore completer，放行等待方');
+    expect(failBody.contains('_restoreCompleter = null;'), isTrue,
+        reason: '_failNavigation 必须清空 _restoreCompleter');
+  });
+}


### PR DESCRIPTION
## 根因
内容就绪兜底看门狗 `_startContentReadyTimeout` 的超时回调（`navigation.part.dart:41-58`）只 `_rebuild(_readerContentReady = true)` 摘掉 loading 遮罩，**漏了复位** `_restoreInFlight` / `_isNavigatingToChapter` / `_restoreCompleter`。

当 `window.hoshiReader` 偶发不回 `onRestoreComplete` 时，遮罩被兜底摘掉、书**看似打开**，但 `_paginationInFlight = _restoreInFlight || !_readerContentReady || _isNavigatingToChapter`（`chrome.part.dart:39-40`）因前两项恒真而恒真 → 翻页 tick 全被守卫吞掉 → **翻页永久失效、进度不保存**。

正常路径 `_onRestoreComplete`（navigation.part.dart:86-90）本就复位这三者；等待超时收尾 `_navigateToChapterAndWait`（navigation.part.dart:504-506）也一起解开。唯独兜底超时路径漏了。

## 修复
超时回调在强制 `_readerContentReady = true` 的同一路径补 `_isNavigatingToChapter = false` + `_failNavigation()`（清 `_restoreInFlight`、`complete(false)` 并清空 `_restoreCompleter`，放行等待方），与既有等待超时收尾同构。纯补齐兜底路径本该做的状态解锁，不引入延迟/重试/吞异常。

## 测试
新增 `hibiki/test/pages/reader_content_ready_timeout_unwind_guard_static_test.dart` 源码守卫：断言超时回调体内同时含三处复位、且 `_failNavigation` helper 未被掏空。删掉任一复位即红。ReaderHibikiPage 过重无法在 widget test 拉起跑该超时回调，故落最强可落地的源码层（reader_* *_static_test 同纪律）。

- `flutter analyze`（改动文件）：No issues found
- 新守卫 + 相邻 `reader_init_hang_recovery` / `chapter_jump_pagination_in_flight` / `bugs_per_file` 守卫：全绿

## 待办
真机复测「反复开合同一 EPUB 直到触发兜底超时 toast，随后仍能翻页 + 退出重进进度保住」待用户在指定设备验证。

BUG 记录：`docs/bugs/BUG-867-reader-content-ready-timeout-pagination-wedge.md`