### PR TITLE
i18n(扩展): 简化「安装浏览器扩展」完成横幅，去掉 Yomitan API/host/port/token 术语

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 32640 (1920 per locale)
 ///
-/// Built on 2026-07-16 at 12:21 UTC
+/// Built on 2026-07-17 at 12:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2208,7 +2208,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get browser_extension_step_pick_folder =>
       'Select the extension folder below (its path is already copied to your clipboard).';
   String get browser_extension_step_done_auto =>
-      'Done. Hibiki\'s Yomitan API server is now on and the extension is auto-configured to connect to it — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
   String get copied => 'Copied';
@@ -6274,7 +6274,7 @@ class _StringsAr extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -10706,7 +10706,7 @@ class _StringsDe extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -15154,7 +15154,7 @@ class _StringsEs extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -19613,7 +19613,7 @@ class _StringsFr extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -23999,7 +23999,7 @@ class _StringsId extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -28433,7 +28433,7 @@ class _StringsIt extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -32673,7 +32673,7 @@ class _StringsJa extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -36914,7 +36914,7 @@ class _StringsKo extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -41326,7 +41326,7 @@ class _StringsNl extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -45753,7 +45753,7 @@ class _StringsPtBr extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -50163,7 +50163,7 @@ class _StringsRu extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -54518,7 +54518,7 @@ class _StringsTh extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -58905,7 +58905,7 @@ class _StringsTr extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -63279,7 +63279,7 @@ class _StringsVi extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+      'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -67402,7 +67402,7 @@ class _StringsZhCn extends _StringsEn {
   String get browser_extension_step_pick_folder => '选择下方的扩展文件夹（其路径已复制到剪贴板）。';
   @override
   String get browser_extension_step_done_auto =>
-      '完成。已自动开启 Yomitan API 服务器，扩展已配置好连接本应用（查词 API，与设备互联/同步无关）——无需填写 host/端口/token。';
+      '完成。扩展已自动配置好，装好后会直接连上本应用查词，你不用手动填写任何设置。';
   @override
   String get browser_extension_enable_server_first =>
       '提示：请先在上方开启「Yomitan API 服务器」并设置 API 密钥，扩展才能被自动配置为可用连接。';
@@ -71508,7 +71508,7 @@ class _StringsZhHk extends _StringsEn {
       'Select the extension folder below (its path is already copied to your clipboard).';
   @override
   String get browser_extension_step_done_auto =>
-      'Done. Hibiki\'s Yomitan API server is now on and the extension is auto-configured to connect to it — no host/port/token to fill in.';
+      '完成。擴充功能已自動設定好，裝好後會直接連上本應用查詞，你無需手動填寫任何設定。';
   @override
   String get browser_extension_enable_server_first =>
       'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
@@ -75518,7 +75518,7 @@ extension on _StringsEn {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. Hibiki\'s Yomitan API server is now on and the extension is auto-configured to connect to it — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -79444,7 +79444,7 @@ extension on _StringsAr {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -83391,7 +83391,7 @@ extension on _StringsDe {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -87337,7 +87337,7 @@ extension on _StringsEs {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -91289,7 +91289,7 @@ extension on _StringsFr {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -95223,7 +95223,7 @@ extension on _StringsId {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -99172,7 +99172,7 @@ extension on _StringsIt {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -103084,7 +103084,7 @@ extension on _StringsJa {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -106998,7 +106998,7 @@ extension on _StringsKo {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -110940,7 +110940,7 @@ extension on _StringsNl {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -114879,7 +114879,7 @@ extension on _StringsPtBr {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -118823,7 +118823,7 @@ extension on _StringsRu {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -122751,7 +122751,7 @@ extension on _StringsTh {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -126688,7 +126688,7 @@ extension on _StringsTr {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -130620,7 +130620,7 @@ extension on _StringsVi {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.';
+        return 'Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':
@@ -134522,7 +134522,7 @@ extension on _StringsZhCn {
       case 'browser_extension_step_pick_folder':
         return '选择下方的扩展文件夹（其路径已复制到剪贴板）。';
       case 'browser_extension_step_done_auto':
-        return '完成。已自动开启 Yomitan API 服务器，扩展已配置好连接本应用（查词 API，与设备互联/同步无关）——无需填写 host/端口/token。';
+        return '完成。扩展已自动配置好，装好后会直接连上本应用查词，你不用手动填写任何设置。';
       case 'browser_extension_enable_server_first':
         return '提示：请先在上方开启「Yomitan API 服务器」并设置 API 密钥，扩展才能被自动配置为可用连接。';
       case 'copied':
@@ -138427,7 +138427,7 @@ extension on _StringsZhHk {
       case 'browser_extension_step_pick_folder':
         return 'Select the extension folder below (its path is already copied to your clipboard).';
       case 'browser_extension_step_done_auto':
-        return 'Done. Hibiki\'s Yomitan API server is now on and the extension is auto-configured to connect to it — no host/port/token to fill in.';
+        return '完成。擴充功能已自動設定好，裝好後會直接連上本應用查詞，你無需手動填寫任何設定。';
       case 'browser_extension_enable_server_first':
         return 'Tip: enable "Yomitan API server" and set an API key above first, so the extension is auto-configured with a working connection.';
       case 'copied':

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. Hibiki's Yomitan API server is now on and the extension is auto-configured to connect to it — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. The extension is auto-configured to connect to this app — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "打开右上角的「开发者模式」开关。",
   "browser_extension_step_load_unpacked": "点击「加载已解压的扩展程序」。",
   "browser_extension_step_pick_folder": "选择下方的扩展文件夹（其路径已复制到剪贴板）。",
-  "browser_extension_step_done_auto": "完成。已自动开启 Yomitan API 服务器，扩展已配置好连接本应用（查词 API，与设备互联/同步无关）——无需填写 host/端口/token。",
+  "browser_extension_step_done_auto": "完成。扩展已自动配置好，装好后会直接连上本应用查词，你不用手动填写任何设置。",
   "browser_extension_enable_server_first": "提示：请先在上方开启「Yomitan API 服务器」并设置 API 密钥，扩展才能被自动配置为可用连接。",
   "copied": "已复制",
   "shortcut_action_global_toggle_fullscreen": "全屏切换",

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1625,7 +1625,7 @@
   "browser_extension_step_dev_mode": "Turn on \"Developer mode\" (toggle in the top-right corner).",
   "browser_extension_step_load_unpacked": "Click \"Load unpacked\".",
   "browser_extension_step_pick_folder": "Select the extension folder below (its path is already copied to your clipboard).",
-  "browser_extension_step_done_auto": "Done. Hibiki's Yomitan API server is now on and the extension is auto-configured to connect to it — no host/port/token to fill in.",
+  "browser_extension_step_done_auto": "完成。擴充功能已自動設定好，裝好後會直接連上本應用查詞，你無需手動填寫任何設定。",
   "browser_extension_enable_server_first": "Tip: enable \"Yomitan API server\" and set an API key above first, so the extension is auto-configured with a working connection.",
   "copied": "Copied",
   "shortcut_action_global_toggle_fullscreen": "Toggle fullscreen",


### PR DESCRIPTION
## 背景
用户反馈：设置里「安装浏览器扩展」对话框的完成横幅写着
> 完成。已自动开启 **Yomitan API 服务器**，扩展已配置好连接本应用（**查词 API，与设备互联/同步无关**）——无需填写 **host/端口/token**。

问题：
1. **术语劝退**——普通用户看不懂 `Yomitan API 服务器` / `host/端口/token`。
2. **『Yomitan』一词误导**——让人以为这和「导入 Yomitan 下载的词典」有关。其实这个开关只是给浏览器扩展提供查词通信口，跟词典导入毫无关系（Yomitan 格式词典的导入是另一个独立功能，走辞书导入界面）。

## 改动
把完成横幅（`browser_extension_step_done_auto`，横幅顶部 + 步骤5 两处复用）改成一句人话：
- zh-CN：`完成。扩展已自动配置好，装好后会直接连上本应用查词，你不用手动填写任何设置。`
- en：`Done. The extension is already set up to connect to Hibiki for lookups — nothing to fill in by hand.`
- 17 语言统一措辞；zh-HK 顺带从占位英文补成繁体中文。
- `dart run slang` 重新生成 `strings.g.dart`。

不动 `Yomitan API server` 开关本身的名字（它是真实协议名，供 yomitan-api 客户端识别），也不动未就绪态的提示（那条要指向该开关）。

## 验证
- `flutter test test/settings/browser_extension_install_dialog_test.dart test/i18n` → **25 passed**（ready/not-ready 横幅 + zh-CN mojibake 守卫均通过）。
- 各语言文件 diff 均为单行，无行末变换全行 churn。