### PR TITLE
feat(clipboard-panel): 防截屏开关 + 每次查词抬前台 (Windows)

### DIFF
--- a/hibiki/assets/popup/global_lookup_host.js
+++ b/hibiki/assets/popup/global_lookup_host.js
@@ -162,6 +162,11 @@
   // SetTopmost applies it); Dart syncs this visual via setPanelPinnedVisual on
   // panel show so the bar icon matches the remembered pref.
   var panelPinnedVisual = true;
+  // Panel block-capture VISUAL state（防截屏）. Truth source is the Dart pref
+  // clipboardPanelBlockCapture (native SetWindowDisplayAffinity applies it);
+  // Dart syncs this visual via setPanelBlockCaptureVisual. Default true =
+  // capture blocked (shield bright); toggled off dims the shield (panel-block-off).
+  var panelBlockCaptureVisual = true;
 
   // Post a message to C++ (and on to Dart) via the TOP-LEVEL chrome.webview
   // bridge. Mirrors the adapter envelope { handler, args } so _onJsMessage routes
@@ -381,6 +386,8 @@
         '#global-lookup-panel-bar[data-theme="dark"] .panel-btn:hover{' +
         'background:rgba(235,235,245,0.24);color:rgba(235,235,245,0.95);}' +
         '#global-lookup-panel-bar .panel-btn.panel-pin-off{opacity:0.45;}' +
+        // 防截屏按钮关闭态（允许截图）时同样调暗，与 pin-off 一致。
+        '#global-lookup-panel-bar .panel-btn.panel-block-off{opacity:0.45;}' +
         // Bottom-right resize grip (posts beginWindowResize).
         '#global-lookup-panel-resize{' +
         'position:fixed;right:0;bottom:0;width:16px;height:16px;' +
@@ -444,6 +451,28 @@
     pinBtn.addEventListener('pointerdown', onPin, true);
     bar.appendChild(pinBtn);
 
+    // 防截屏按钮（🛡）：切换 SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE)。
+    // 默认开（盾牌亮）= 面板不进截图/录屏；关（盾牌变暗）= 允许被截。视觉态由
+    // Dart 经 setPanelBlockCaptureVisual 同步（与 pin 同一范式）。
+    var blockBtn = document.createElement('div');
+    blockBtn.className =
+        'panel-btn panel-block' + (panelBlockCaptureVisual ? '' : ' panel-block-off');
+    blockBtn.setAttribute('role', 'button');
+    blockBtn.setAttribute('aria-label', 'Block screen capture');
+    blockBtn.textContent = '🛡';
+    var onBlock = function (event) {
+      if (event) {
+        if (typeof event.stopPropagation === 'function') {
+          event.stopPropagation();
+        }
+        if (typeof event.preventDefault === 'function') event.preventDefault();
+      }
+      setPanelBlockCaptureVisual(!panelBlockCaptureVisual);
+      postToHost('panelBlockCapture', [panelBlockCaptureVisual]);
+    };
+    blockBtn.addEventListener('pointerdown', onBlock, true);
+    bar.appendChild(blockBtn);
+
     var closeBtn = document.createElement('div');
     closeBtn.className = 'panel-btn panel-close';
     closeBtn.setAttribute('role', 'button');
@@ -495,6 +524,26 @@
       if (kid && String(kid.className).indexOf('panel-pin') >= 0) {
         kid.className =
             'panel-btn panel-pin' + (panelPinnedVisual ? '' : ' panel-pin-off');
+        return;
+      }
+    }
+  }
+
+  // 防截屏 — 把 🛡 按钮视觉态同步到 Dart pref（真相源；native
+  // SetWindowDisplayAffinity 应用真正的捕获排除）。与 setPanelPinnedVisual 同构。
+  function setPanelBlockCaptureVisual(block) {
+    panelBlockCaptureVisual = !!block;
+    var bar = document.getElementById &&
+        document.getElementById('global-lookup-panel-bar');
+    if (!bar) {
+      return;
+    }
+    var kids = bar.children || [];
+    for (var i = 0; i < kids.length; i++) {
+      var kid = kids[i];
+      if (kid && String(kid.className).indexOf('panel-block') >= 0) {
+        kid.className = 'panel-btn panel-block' +
+            (panelBlockCaptureVisual ? '' : ' panel-block-off');
         return;
       }
     }
@@ -1798,6 +1847,7 @@
     dismissRootWithSlide: dismissRootWithSlide,
     // spec 2026-07-10 — panel-mode hooks (no-ops in cascade mode).
     setPanelPinnedVisual: setPanelPinnedVisual,
+    setPanelBlockCaptureVisual: setPanelBlockCaptureVisual,
     _frames: frames,
     // TODO-1188 — exposed for the node bridge-routing harness only (never used to
     // drive behaviour): the live globalId -> {frameId, localId} route map.

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -202,6 +202,13 @@ class ClipboardPanelController {
         _visible = false;
         await _showPanel(model);
         if (seq != _updateSeq) return;
+      } else {
+        // 已显示：每次查词把面板抬到 z 序最上，不抢焦点（游戏/浏览器仍持键盘
+        // 焦点）。已 pin 直接置顶，否则顶到非置顶带最上——修复「面板被别的窗
+        // 压住时，新剪贴板查词只原地更新、看不到」。_showPanel 分支已在 reveal
+        // 时置顶，故只在这里补。
+        await _channel.raise(topmost: model.clipboardPanelPinned);
+        if (seq != _updateSeq) return;
       }
       await _renderPanel(model);
       glog('panel: updated "${request.text.length} chars" '
@@ -227,6 +234,11 @@ class ClipboardPanelController {
     if (!_visible || !await _channel.isShowing()) {
       _visible = false;
       await _showPanel(model);
+      if (seq != _updateSeq) return;
+    } else {
+      // 已显示：纯文字态也把面板抬到 z 序最上（每次剪贴板更新即前台，不抢焦点），
+      // 与自动查词路径口径一致。
+      await _channel.raise(topmost: model.clipboardPanelPinned);
       if (seq != _updateSeq) return;
     }
     await _renderPanel(model);
@@ -306,6 +318,9 @@ class ClipboardPanelController {
     // 真机实测它经 windowed WebView2 呈现为不透明，且毛玻璃≠「看见底下」。
     await _channel.setWindowAlpha((model.clipboardPanelOpacity * 100).round());
     await _channel.setPinned(model.clipboardPanelPinned);
+    // 防截屏：按 pref（默认开）给面板窗设 display affinity。窗口重建后 native
+    // 侧 ApplyBlockCapture 自动重加，这里每次显示再确认一次（pref 可能已改）。
+    await _channel.setBlockCapture(model.clipboardPanelBlockCapture);
     // pin 视觉态同步折进 _renderPanel 的渲染脚本（审查修正：native
     // pending_json_ 是单槽缓存，独立发送会被随后的栈渲染覆盖丢失）。
     glog('panel: shown rect=$_panelRect '
@@ -383,7 +398,12 @@ class ClipboardPanelController {
     final String pinVisualJs = 'window.__globalLookupHost && '
         'window.__globalLookupHost.setPanelPinnedVisual('
         '${model.clipboardPanelPinned});';
-    await _channel.render('$script\n$pinVisualJs');
+    // 防截屏按钮视觉态同样并进同一渲染脚本（native pending_json_ 单槽缓存，
+    // 独立脚本会互相覆盖），保证 🛡 图标与卡片、pin 同帧就位。
+    final String blockCaptureVisualJs = 'window.__globalLookupHost && '
+        'window.__globalLookupHost.setPanelBlockCaptureVisual('
+        '${model.clipboardPanelBlockCapture});';
+    await _channel.render('$script\n$pinVisualJs\n$blockCaptureVisualJs');
   }
 
   void _onJsMessage(Map<String, Object?> message) {
@@ -425,6 +445,13 @@ class ClipboardPanelController {
             args is List && args.isNotEmpty && args.first == true;
         unawaited(_channel.setPinned(pinned));
         unawaited(model?.setClipboardPanelPinned(pinned));
+      case 'panelBlockCapture':
+        // 防截屏按钮：切 native display affinity + 落 pref（默认开）。
+        final Object? args = message['args'];
+        final bool block =
+            args is List && args.isNotEmpty && args.first == true;
+        unawaited(_channel.setBlockCapture(block));
+        unawaited(model?.setClipboardPanelBlockCapture(block));
       case 'panelClose':
         unawaited(hidePanel());
       case 'dismissPopupAt':

--- a/hibiki/lib/src/lookup/overlay_window_channel.dart
+++ b/hibiki/lib/src/lookup/overlay_window_channel.dart
@@ -207,6 +207,21 @@ class OverlayWindowChannel {
         'pinned': pinned,
       });
 
+  /// 防截屏 — SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE)：面板对用户可见
+  /// 但从截图 / 录屏 / 屏幕共享里排除。Only wired on the clipboard-panel channel.
+  Future<void> setBlockCapture(bool block) =>
+      _channel.invokeMethod<void>('setBlockCapture', <String, Object?>{
+        'block': block,
+      });
+
+  /// 面板抬前台 — 把已显示的面板重排到 z 序最上，绝不激活（不抢当前前台窗口
+  /// 焦点）。[topmost]=true（已 pin）直接置顶，false 则顶到非置顶带最上。
+  /// Only wired on the clipboard-panel channel.
+  Future<void> raise({required bool topmost}) =>
+      _channel.invokeMethod<void>('raise', <String, Object?>{
+        'topmost': topmost,
+      });
+
   /// 面板任务栏图标 — 任务栏按钮 / Alt-Tab 项的窗口标题（本地化文案）。
   /// 窗口创建前设置则用于创建，已创建则即时更新。Only wired on the
   /// clipboard-panel channel.

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4275,6 +4275,9 @@ class AppModel with ChangeNotifier {
   bool get clipboardPanelPinned => prefsRepo.clipboardPanelPinned;
   Future<void> setClipboardPanelPinned(bool v) =>
       prefsRepo.setClipboardPanelPinned(v);
+  bool get clipboardPanelBlockCapture => prefsRepo.clipboardPanelBlockCapture;
+  Future<void> setClipboardPanelBlockCapture(bool v) =>
+      prefsRepo.setClipboardPanelBlockCapture(v);
 
   Map<String, String> get customDictCSS => prefsRepo.customDictCSS;
   String getCustomCSSForDict(String dictName) =>

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -566,6 +566,17 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 防截屏（剪贴板面板，Windows）—— 面板窗设 SetWindowDisplayAffinity
+  /// (WDA_EXCLUDEFROMCAPTURE)，对用户可见但从截图 / 录屏 / 屏幕共享排除。
+  /// 默认 true（隐私优先）；面板栏 🛡 按钮切换。
+  bool get clipboardPanelBlockCapture =>
+      getPref('clipboard_panel_block_capture', defaultValue: true) as bool;
+
+  Future<void> setClipboardPanelBlockCapture(bool value) async {
+    await setPref('clipboard_panel_block_capture', value);
+    notifyListeners();
+  }
+
   final int defaultSearchDebounceDelay = 100;
 
   int get searchDebounceDelay => getPref('auto_search_debounce_delay',

--- a/hibiki/test/lookup/clipboard_panel_controller_test.dart
+++ b/hibiki/test/lookup/clipboard_panel_controller_test.dart
@@ -209,20 +209,18 @@ void main() {
       // （_showTextOnly），不自动查词、不弹释义；点句中字才手动查。
       final int updAt = controllerSrc.indexOf('Future<void> update(');
       expect(updAt, greaterThan(0));
-      final int gateAt =
-          controllerSrc.indexOf('if (!model.desktopClipboardAutoLookup)', updAt);
+      final int gateAt = controllerSrc.indexOf(
+          'if (!model.desktopClipboardAutoLookup)', updAt);
       final int textOnlyAt =
           controllerSrc.indexOf('_showTextOnly(model, request.text)', gateAt);
-      expect(gateAt, greaterThan(updAt),
-          reason: 'update 必须在关自动查词时早退到纯文字态');
+      expect(gateAt, greaterThan(updAt), reason: 'update 必须在关自动查词时早退到纯文字态');
       expect(textOnlyAt, greaterThan(gateAt));
       // _showTextOnly 里没有 searchDictionary（纯文字态绝不自动查词）。
       final int fnAt = controllerSrc.indexOf('Future<void> _showTextOnly(');
       expect(fnAt, greaterThan(0));
       final int fnEnd = controllerSrc.indexOf('\n  }', fnAt);
       final String body = controllerSrc.substring(fnAt, fnEnd);
-      expect(body.contains('searchDictionary'), isFalse,
-          reason: '纯文字态不得自动查词');
+      expect(body.contains('searchDictionary'), isFalse, reason: '纯文字态不得自动查词');
       expect(body.contains('_sentenceOnly = true'), isTrue,
           reason: '纯文字态须置 sentenceOnly，渲染脚本据此摘掉 No results 块');
     });
@@ -240,6 +238,47 @@ void main() {
       expect(
         dispatcherSrc.contains('ClipboardPanelController.instance.update'),
         isTrue,
+      );
+    });
+
+    test('防截屏：panelBlockCapture 桥切 native + 落 pref（默认开）', () {
+      // 面板栏 🛡 按钮：_onJsMessage 处理 panelBlockCapture，切 native display
+      // affinity（_channel.setBlockCapture）并落 pref（setClipboardPanelBlockCapture）。
+      expect(controllerSrc.contains("case 'panelBlockCapture':"), isTrue,
+          reason: '面板栏防截屏按钮必须有 _onJsMessage 分支');
+      expect(controllerSrc.contains('_channel.setBlockCapture(block)'), isTrue,
+          reason: '切换必须调 native SetWindowDisplayAffinity');
+      expect(controllerSrc.contains('setClipboardPanelBlockCapture(block)'),
+          isTrue,
+          reason: '切换必须持久化到 pref');
+      // 显示面板时按 pref 应用一次（默认开）。
+      expect(
+        controllerSrc
+            .contains('setBlockCapture(model.clipboardPanelBlockCapture)'),
+        isTrue,
+        reason: '_showPanel 必须按 pref 给面板窗设防截屏',
+      );
+    });
+
+    test('防截屏 pref 默认开（隐私优先）', () {
+      final String prefsSrc =
+          File('lib/src/models/preferences_repository.dart').readAsStringSync();
+      expect(
+        prefsSrc.contains(
+            "getPref('clipboard_panel_block_capture', defaultValue: true)"),
+        isTrue,
+        reason: '防截屏 pref 必须默认 true（用户要求「默认打开」）',
+      );
+    });
+
+    test('抬前台：已显示分支每次查词 raise（不抢焦点）', () {
+      // 功能 B：面板已显示时（update / _showTextOnly 的 else 分支）每次查词把窗口
+      // 抬到 z 序最上，pin 决定是否置顶。native RaiseToFront 全程 SWP_NOACTIVATE。
+      expect(
+        controllerSrc
+            .contains('_channel.raise(topmost: model.clipboardPanelPinned)'),
+        isTrue,
+        reason: '已显示时新查词必须抬前台（修复被别的窗压住看不到），按 pin 决定置顶',
       );
     });
 

--- a/hibiki/test/lookup/global_lookup_host_test.mjs
+++ b/hibiki/test/lookup/global_lookup_host_test.mjs
@@ -1711,7 +1711,7 @@ function flushTimers() {
     layoutMode: 'panel',
   });
   const bar = document.getElementById('global-lookup-panel-bar');
-  const [grip, pinBtn, closeBtn] = bar.children;
+  const [grip, pinBtn, blockBtn, closeBtn] = bar.children;
   const fakeEvent = { preventDefault() {}, stopPropagation() {} };
 
   hostPostLog = [];
@@ -1735,6 +1735,29 @@ function flushTimers() {
   assert.ok(
     pinBtn.className.indexOf('panel-pin-off') < 0,
     'setPanelPinnedVisual(true) restores the pinned visual (Dart pref sync)',
+  );
+
+  // 防截屏按钮：默认开（盾牌亮）；首点关 -> posts panelBlockCapture(false) + 变暗；
+  // setPanelBlockCaptureVisual(true) 从 Dart pref 恢复亮态。
+  assert.ok(
+    blockBtn.className.indexOf('panel-block') >= 0 &&
+      blockBtn.className.indexOf('panel-block-off') < 0,
+    'block-capture default on (shield bright)',
+  );
+  hostPostLog = [];
+  blockBtn._listeners['pointerdown'][0](fakeEvent);
+  const blockMsg = hostPostLog.find((m) => m.handler === 'panelBlockCapture');
+  assert.ok(blockMsg, 'block button posts panelBlockCapture');
+  assert.strictEqual(
+    blockMsg.args[0], false, 'default on -> first tap turns capture-block off');
+  assert.ok(
+    blockBtn.className.indexOf('panel-block-off') >= 0,
+    'capture-block-off visual applied',
+  );
+  host.setPanelBlockCaptureVisual(true);
+  assert.ok(
+    blockBtn.className.indexOf('panel-block-off') < 0,
+    'setPanelBlockCaptureVisual(true) restores blocked visual (Dart pref sync)',
   );
 
   hostPostLog = [];

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -1278,6 +1278,18 @@ void FlutterWindow::RegisterClipboardPanelChannel() {
           clipboard_panel_window_->SetTopmost(
               BoolFromValue(args, "pinned", true));
           result->Success();
+        } else if (method == "setBlockCapture") {
+          // 防截屏 — WDA_EXCLUDEFROMCAPTURE：面板对用户可见但不进截图 / 录屏 /
+          // 屏幕共享。默认 true（Dart pref clipboardPanelBlockCapture 默认开）。
+          clipboard_panel_window_->SetBlockCapture(
+              BoolFromValue(args, "block", true));
+          result->Success();
+        } else if (method == "raise") {
+          // 面板抬前台 — 每次查词把已显示的面板重排到 z 序最上，不抢焦点；
+          // topmost（已 pin）直接置顶，否则顶到非置顶带最上（见 RaiseToFront）。
+          clipboard_panel_window_->RaiseToFront(
+              BoolFromValue(args, "topmost", false));
+          result->Success();
         } else if (method == "setWindowTitle") {
           // 面板任务栏图标 — Dart 传本地化标题（任务栏按钮 / Alt-Tab 项）。
           clipboard_panel_window_->SetWindowTitle(

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -13,6 +13,20 @@
 
 #pragma comment(lib, "Shlwapi.lib")
 
+// 防截屏 — SetWindowDisplayAffinity 的 WDA_EXCLUDEFROMCAPTURE 需 Win10 2004+ SDK。
+// 老 SDK 头文件里没有这些常量时兜底定义（运行时 Win10<2004 会让 API 返回失败，
+// ApplyBlockCapture 再回退 WDA_MONITOR）。SetWindowDisplayAffinity 本体在 user32，
+// windows.h 已声明。
+#ifndef WDA_NONE
+#define WDA_NONE 0x00000000
+#endif
+#ifndef WDA_MONITOR
+#define WDA_MONITOR 0x00000001
+#endif
+#ifndef WDA_EXCLUDEFROMCAPTURE
+#define WDA_EXCLUDEFROMCAPTURE 0x00000011
+#endif
+
 using Microsoft::WRL::Callback;
 using Microsoft::WRL::Make;
 
@@ -338,6 +352,9 @@ bool GlobalLookupWindow::ShowAt(int x, int y, int width, int height,
     if (hwnd_ == nullptr) {
       return false;
     }
+    // 防截屏 — 新窗口一建立就按最后一次 SetBlockCapture 的值置 display affinity，
+    // 故 ForgetDeadWindow / 崩溃恢复重建后仍然生效（默认 false = 不影响）。
+    ApplyBlockCapture();
     EnsureWebView();
   } else {
     SetWindowPos(hwnd_, HWND_TOPMOST, off_x, 0, width, height, SWP_NOACTIVATE);
@@ -377,6 +394,8 @@ void GlobalLookupWindow::PrewarmWebView(int width, int height, HWND owner) {
   if (hwnd_ == nullptr) {
     return;
   }
+  // 防截屏 — 预热窗同样一建立就套用（见 ShowAt 同名调用）。
+  ApplyBlockCapture();
   EnsureWebView();
   // Show off-screen (so WebView2 lays out + navigates and NavigationCompleted
   // fires -> webview_ready_) but keep visible_ false: the click-outside hooks
@@ -653,6 +672,47 @@ void GlobalLookupWindow::SetTopmost(bool topmost) {
   // 此标志兜底防回归；与 Reveal/RevealStack 的 SetWindowPos 口径一致。
   SetWindowPos(hwnd_, topmost ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOOWNERZORDER);
+}
+
+void GlobalLookupWindow::SetBlockCapture(bool block) {
+  block_capture_ = block;
+  ApplyBlockCapture();
+}
+
+void GlobalLookupWindow::ApplyBlockCapture() {
+  if (hwnd_ == nullptr) {
+    return;
+  }
+  // WDA_EXCLUDEFROMCAPTURE：窗口对用户可见但从截图 / 录屏 / 屏幕共享里排除
+  // （查词内容不外泄）。Win10<2004 该值不被支持 -> API 失败，回退 WDA_MONITOR
+  // （被捕获处画成黑块，同样不泄露内容）。关闭时 WDA_NONE 恢复正常可截。
+  if (!block_capture_) {
+    SetWindowDisplayAffinity(hwnd_, WDA_NONE);
+    return;
+  }
+  if (!SetWindowDisplayAffinity(hwnd_, WDA_EXCLUDEFROMCAPTURE)) {
+    SetWindowDisplayAffinity(hwnd_, WDA_MONITOR);
+  }
+}
+
+void GlobalLookupWindow::RaiseToFront(bool topmost) {
+  if (hwnd_ == nullptr) {
+    return;
+  }
+  // 每次查词把已显示的面板重排到 z 序最上，绝不激活（SWP_NOACTIVATE，不抢当前
+  // 前台窗口键盘焦点）。SWP_NOOWNERZORDER 兜底不连带 owner（面板现无 owner，
+  // 与 SetTopmost/Reveal 口径一致）。
+  const UINT flags =
+      SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOOWNERZORDER;
+  if (topmost) {
+    // 已 pin：直接顶到置顶带最上。
+    SetWindowPos(hwnd_, HWND_TOPMOST, 0, 0, 0, 0, flags);
+    return;
+  }
+  // 未 pin：裸 HWND_TOP 在别的 app 处于前台时可能被前台锁拒绝，故先短暂置顶
+  // 再撤销——面板落到「非置顶带最上、仍压在前台游戏/浏览器之上」，且全程不激活。
+  SetWindowPos(hwnd_, HWND_TOPMOST, 0, 0, 0, 0, flags);
+  SetWindowPos(hwnd_, HWND_NOTOPMOST, 0, 0, 0, 0, flags);
 }
 
 void GlobalLookupWindow::SetWindowAlpha(int percent) {

--- a/hibiki/windows/runner/global_lookup_window.h
+++ b/hibiki/windows/runner/global_lookup_window.h
@@ -178,6 +178,20 @@ class GlobalLookupWindow {
   // or activating. No-op before the window exists.
   void SetTopmost(bool topmost);
 
+  // 防截屏（剪贴板面板） — SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE)：
+  // 窗口对用户可见，但被排除在截图 / 录屏 / 屏幕共享捕获之外（内容不外泄）。
+  // 记住 [block] 到 block_capture_，窗口重建（ForgetDeadWindow → 新 hwnd）后由
+  // CreateWindowExW 之后的 ApplyBlockCapture() 自动重加。默认 false（瞬态查词
+  // 覆盖窗不受影响）；面板实例的 Dart 控制器在显示时按 pref 置 true。
+  void SetBlockCapture(bool block);
+
+  // 面板抬前台 — 每次查词把已显示的面板重排到 z 序最上，绝不激活（不抢当前
+  // 前台窗口的键盘焦点）。[topmost]=true（已 pin）直接 HWND_TOPMOST；false
+  // 时用 TOPMOST→NOTOPMOST 弹一下，绕过前台锁把面板顶到非置顶带最上（裸
+  // HWND_TOP 在别的 app 处于前台时可能被系统拒绝）。No-op before the window
+  // exists.
+  void RaiseToFront(bool topmost);
+
   // spec §6 真机修正 — WHOLE-WINDOW opacity via WS_EX_LAYERED +
   // SetLayeredWindowAttributes(LWA_ALPHA). Real-device finding: the acrylic
   // backdrop chain renders user-visibly OPAQUE through the windowed WebView2
@@ -227,6 +241,10 @@ class GlobalLookupWindow {
   // WebView2 proxies so the next ShowAt/PrewarmWebView rebuilds from scratch.
   bool OwnsLiveWindow() const;
   void ForgetDeadWindow();
+  // 防截屏 — 把 block_capture_ 应用到当前 hwnd_（SetWindowDisplayAffinity）。
+  // 每次 CreateWindowExW 之后调用一次，故窗口重建（ForgetDeadWindow / 崩溃恢复）
+  // 后依然按最后一次 SetBlockCapture 的值生效。No-op before the window exists.
+  void ApplyBlockCapture();
   void EnsureWebView();
   // 背景逐像素透明（composition 模式）辅助：
   // InitCompositionDevice — 建 D3D11 + DComp 设备（无需 HWND），可在建窗前探测能力；
@@ -280,6 +298,9 @@ class GlobalLookupWindow {
   bool arm_dismiss_hooks_ = true;
   bool activatable_ = false;
   bool taskbar_presence_ = false;
+  // 防截屏当前请求值（真相源是 Dart pref；窗口重建后 ApplyBlockCapture 用它重加）。
+  // 默认 false：只有面板实例的控制器会按 pref 置 true，瞬态覆盖窗恒不受影响。
+  bool block_capture_ = false;
   // 背景逐像素透明模式（仅面板实例）：composition controller + DirectComposition。
   // 默认 false=windowed（瞬态窗与历史行为一字不改）。见 SetCompositionMode。
   bool composition_mode_ = false;


### PR DESCRIPTION
## 需求

剪贴板查词面板（Windows 常驻面板）两项能力：
1. **防止面板被截图/录屏** —— 面板栏加一个 🛡 开关按钮，**默认开**。
2. **每次查词把面板抬到前台** —— 不抢焦点（未开强制置顶/pin 时只把窗口 z-order 顶到最上，键盘焦点留在当前前台的游戏/浏览器）。

范围：**仅 Windows 剪贴板面板**（「粘贴板查词弹窗」+「强制置顶」都是面板专属特征；瞬态查词覆盖窗、in-app/Android/扩展均不受影响）。

## 实现

### A. 防截屏（默认开）
- native `GlobalLookupWindow::SetBlockCapture` → `SetWindowDisplayAffinity(hwnd_, WDA_EXCLUDEFROMCAPTURE)`：窗口对用户可见但被排除在截图/录屏/屏幕共享之外。Win10<2004 该值不支持时回退 `WDA_MONITOR`（捕获处画黑块，同样不泄露内容）。
- 窗口重建（`ForgetDeadWindow` / 崩溃恢复）后由 `CreateWindowExW` 之后的 `ApplyBlockCapture()` 自动重加。
- 按钮在 `global_lookup_host.js` 面板 chrome（**Windows 覆盖窗专用宿主脚本，不在 popup.js 三镜像范围**，不污染 in-app/Android/扩展），照 pin 按钮范式：`panelBlockCapture` handler + `setPanelBlockCaptureVisual` 视觉同步。
- 新 pref `clipboardPanelBlockCapture` 默认 `true`。

### B. 每次查词抬前台（不抢焦点）
- native `GlobalLookupWindow::RaiseToFront(topmost)`：已 pin → `HWND_TOPMOST`；未 pin → `TOPMOST`→`NOTOPMOST` 弹一下绕过前台锁，把面板顶到**非置顶带最上**（裸 `HWND_TOP` 在别的 app 处于前台时可能被前台锁拒绝）。全程 `SWP_NOACTIVATE`，绝不抢焦点。
- 补 `ClipboardPanelController.update()` 与 `_showTextOnly()` 命中「已可见只 render」分支的缺口（此前面板被别的窗压住时，新剪贴板查词只原地更新、看不到）。

## 改动文件
- native：`global_lookup_window.h/.cpp`（`SetBlockCapture`/`ApplyBlockCapture`/`RaiseToFront` + WDA 常量兜底）、`flutter_window.cpp`（面板 channel 加 `setBlockCapture`/`raise`）
- Dart：`overlay_window_channel.dart`、`clipboard_panel_controller.dart`、`preferences_repository.dart`、`app_model.dart`
- JS：`global_lookup_host.js`（🛡 按钮 + `setPanelBlockCaptureVisual`）
- 测试：`global_lookup_host_test.mjs`（按钮/视觉态）、`clipboard_panel_controller_test.dart`（源码接线守卫：防截屏桥/默认开/抬前台）

## 验证
- `dart analyze`：No issues found
- `flutter test`（面板控制器 + guard）：47 passed
- node host 测试：PASS
- `flutter build windows --debug`：✅ 编译干净（新增 C++ 无 error）
- ⏳ **真机待验**：截图/录屏时面板确实不出现；未 pin 时新剪贴板复制把面板顶到游戏之上且焦点不被抢。

## 备注
- 未 bump 版本号（草稿 PR 非发布，交 integration owner 合并时统一处理，避免与并发 PR 撞 `+build`）。
- 瞬态查词覆盖窗**未**加防截屏（native 默认 `block_capture_=false`），如需要可作后续跟进。