### PR TITLE
fix(update): BUG-869 更新判据改按 release sequence「谁后用谁」，根治正式↔调试来回更新

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -67,6 +67,7 @@ jobs:
           INPUT_TAG_NAME: ${{ github.event.inputs.tag_name }}
           INPUT_RELEASE_NAME: ${{ github.event.inputs.release_name }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           set -euo pipefail
           VERSION=$(grep '^version:' hibiki/pubspec.yaml | sed 's/version: *//;s/+.*//')
@@ -84,6 +85,11 @@ jobs:
           PRERELEASE=true
           MAKE_LATEST=false
           PUBLISH_MANAGED_RELEASE=false
+          # BUG-869: manifest-only publish flag decoupled from
+          # PUBLISH_MANAGED_RELEASE (see release.yml) so the `release` event can
+          # emit latest-stable.json without re-touching the manual Release.
+          PUBLISH_MANIFEST=false
+          MANIFEST_CHANNEL=""
 
           case "$EVENT" in
             push)
@@ -122,12 +128,25 @@ jobs:
             release)
               CHANNEL=github-release
               TAG="${RELEASE_TAG_NAME:-${GITHUB_REF_NAME}}"
+              # BUG-869: a manually-published NON-prerelease Release IS the formal
+              # stable release → emit latest-stable.json (with releaseSequence) for
+              # in-China stable clients. Manifest-only; never touches the Release.
+              if [ "${RELEASE_IS_PRERELEASE}" = "false" ]; then
+                MANIFEST_CHANNEL=formal
+                PUBLISH_MANIFEST=true
+                PRERELEASE=false
+              fi
               ;;
             *)
               echo "::error title=Unsupported event::$EVENT is not a desktop release event."
               exit 1
               ;;
           esac
+
+          # BUG-869: push / workflow_dispatch unchanged — MANIFEST_CHANNEL follows
+          # CHANNEL and manifest publishes whenever the managed release does.
+          if [ -z "$MANIFEST_CHANNEL" ]; then MANIFEST_CHANNEL="$CHANNEL"; fi
+          if [ "$PUBLISH_MANAGED_RELEASE" = true ]; then PUBLISH_MANIFEST=true; fi
 
           BUILD_VERSION_NAME="$VERSION"
           case "$CHANNEL" in
@@ -182,6 +201,8 @@ jobs:
             echo "prerelease=$PRERELEASE"
             echo "make_latest=$MAKE_LATEST"
             echo "publish_managed_release=$PUBLISH_MANAGED_RELEASE"
+            echo "publish_manifest=$PUBLISH_MANIFEST"
+            echo "manifest_channel=$MANIFEST_CHANNEL"
             echo "build_version_name=$BUILD_VERSION_NAME"
             echo "release_sequence=$RELEASE_SEQUENCE"
             echo "body<<EOF"
@@ -637,12 +658,14 @@ jobs:
       # not cascade a run. Merges this platform's assets into any same-tag
       # manifest the Android workflow already pushed (concurrent, dedupe by name).
       - name: Publish mirror update manifest (desktop assets)
-        if: steps.channel.outputs.publish_managed_release == 'true'
+        # BUG-869: gate on publish_manifest + manifest_channel so the `release`
+        # event emits latest-stable.json without re-touching the manual Release.
+        if: steps.channel.outputs.publish_manifest == 'true'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          CHANNEL: ${{ steps.channel.outputs.channel }}
+          CHANNEL: ${{ steps.channel.outputs.manifest_channel }}
           TAG: ${{ steps.channel.outputs.tag }}
           # TODO-1049: manifest `tag` keeps the versioned/seq TAG for client
           # version comparison; asset URLs resolve under DOWNLOAD_TAG (the actual
@@ -679,6 +702,7 @@ jobs:
           INPUT_TAG_NAME: ${{ github.event.inputs.tag_name }}
           INPUT_RELEASE_NAME: ${{ github.event.inputs.release_name }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           set -euo pipefail
           VERSION=$(grep '^version:' hibiki/pubspec.yaml | sed 's/version: *//;s/+.*//')
@@ -696,6 +720,11 @@ jobs:
           PRERELEASE=true
           MAKE_LATEST=false
           PUBLISH_MANAGED_RELEASE=false
+          # BUG-869: manifest-only publish flag decoupled from
+          # PUBLISH_MANAGED_RELEASE (see release.yml) so the `release` event can
+          # emit latest-stable.json without re-touching the manual Release.
+          PUBLISH_MANIFEST=false
+          MANIFEST_CHANNEL=""
 
           case "$EVENT" in
             push)
@@ -734,6 +763,14 @@ jobs:
             release)
               CHANNEL=github-release
               TAG="${RELEASE_TAG_NAME:-${GITHUB_REF_NAME}}"
+              # BUG-869: a manually-published NON-prerelease Release IS the formal
+              # stable release → emit latest-stable.json (with releaseSequence) for
+              # in-China stable clients. Manifest-only; never touches the Release.
+              if [ "${RELEASE_IS_PRERELEASE}" = "false" ]; then
+                MANIFEST_CHANNEL=formal
+                PUBLISH_MANIFEST=true
+                PRERELEASE=false
+              fi
               ;;
             *)
               echo "::error title=Unsupported event::$EVENT is not an Apple release event."
@@ -785,6 +822,8 @@ jobs:
             echo "prerelease=$PRERELEASE"
             echo "make_latest=$MAKE_LATEST"
             echo "publish_managed_release=$PUBLISH_MANAGED_RELEASE"
+            echo "publish_manifest=$PUBLISH_MANIFEST"
+            echo "manifest_channel=$MANIFEST_CHANNEL"
             echo "build_version_name=$BUILD_VERSION_NAME"
             echo "release_sequence=$RELEASE_SEQUENCE"
             echo "body<<EOF"
@@ -1054,12 +1093,14 @@ jobs:
             hibiki/build/release-artifacts/hibiki-*-macos.zip
             hibiki/build/release-artifacts/hibiki-*-ios.ipa
       - name: Publish mirror update manifest (Apple assets)
-        if: steps.channel.outputs.publish_managed_release == 'true'
+        # BUG-869: gate on publish_manifest + manifest_channel so the `release`
+        # event emits latest-stable.json without re-touching the manual Release.
+        if: steps.channel.outputs.publish_manifest == 'true'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          CHANNEL: ${{ steps.channel.outputs.channel }}
+          CHANNEL: ${{ steps.channel.outputs.manifest_channel }}
           TAG: ${{ steps.channel.outputs.tag }}
           DOWNLOAD_TAG: ${{ steps.channel.outputs.publish_tag }}
           PRERELEASE: ${{ steps.channel.outputs.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
         INPUT_TAG_NAME: ${{ github.event.inputs.tag_name }}
         INPUT_RELEASE_NAME: ${{ github.event.inputs.release_name }}
         RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease }}
       run: |
         set -euo pipefail
         PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: *//')
@@ -124,6 +125,14 @@ jobs:
         BUILD_SPLIT_RELEASE_APK=false
         NEEDS_RELEASE_KEYSTORE=false
         PUBLISH_MANAGED_RELEASE=false
+        # BUG-869: manifest-only publish flag, decoupled from
+        # PUBLISH_MANAGED_RELEASE so the `release` event can emit
+        # latest-stable.json WITHOUT re-running the softprops managed-release
+        # create/upsert (which would touch the user's manually-created Release).
+        # MANIFEST_CHANNEL is the channel handed to publish_update_manifest.sh
+        # (debug|beta|formal) that decides the latest-<channel>.json filename.
+        PUBLISH_MANIFEST=false
+        MANIFEST_CHANNEL=""
 
         case "$EVENT" in
           push)
@@ -179,12 +188,29 @@ jobs:
             FILES="hibiki/build/release-artifacts/hibiki-*.apk"
             BUILD_SPLIT_RELEASE_APK=true
             NEEDS_RELEASE_KEYSTORE=true
+            # BUG-869: a manually-published, NON-prerelease GitHub Release IS the
+            # formal stable release. Emit latest-stable.json (with releaseSequence)
+            # so in-China stable clients can read the seq for "谁后用谁" comparison.
+            # This writes ONLY the data-file manifest; it never creates/modifies
+            # the Release (PUBLISH_MANAGED_RELEASE stays false). A manual PRERELEASE
+            # (beta via the UI) is left alone so it can never pollute stable.
+            if [ "${RELEASE_IS_PRERELEASE}" = "false" ]; then
+              MANIFEST_CHANNEL=formal
+              PUBLISH_MANIFEST=true
+              PRERELEASE=false
+            fi
             ;;
           *)
             echo "::error title=Unsupported event::$EVENT is not a release channel event."
             exit 1
             ;;
         esac
+
+        # BUG-869: push / workflow_dispatch keep existing behavior — MANIFEST_CHANNEL
+        # follows CHANNEL (debug|beta|formal) and the manifest publishes whenever the
+        # managed release does. Only the `release` event opts in above independently.
+        if [ -z "$MANIFEST_CHANNEL" ]; then MANIFEST_CHANNEL="$CHANNEL"; fi
+        if [ "$PUBLISH_MANAGED_RELEASE" = true ]; then PUBLISH_MANIFEST=true; fi
 
         BUILD_VERSION_NAME="${TAG#v}"
         BUILD_VERSION_NAME="${BUILD_VERSION_NAME%%+*}"
@@ -241,6 +267,8 @@ jobs:
           echo "android_build_number=$ANDROID_BUILD_NUMBER"
           echo "release_sequence=$RELEASE_SEQUENCE"
           echo "publish_managed_release=$PUBLISH_MANAGED_RELEASE"
+          echo "publish_manifest=$PUBLISH_MANIFEST"
+          echo "manifest_channel=$MANIFEST_CHANNEL"
           echo "files=$FILES"
           echo "body<<EOF"
           echo "$BODY"
@@ -715,12 +743,15 @@ jobs:
     # absent from this workflow's push trigger (main/develop only) so it does
     # not cascade a run.
     - name: Publish mirror update manifest (Android assets)
-      if: steps.channel.outputs.publish_managed_release == 'true'
+      # BUG-869: gate on publish_manifest (decoupled from publish_managed_release)
+      # and use manifest_channel so the `release` event emits latest-stable.json
+      # without re-touching the manually-created Release.
+      if: steps.channel.outputs.publish_manifest == 'true'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
-        CHANNEL: ${{ steps.channel.outputs.channel }}
+        CHANNEL: ${{ steps.channel.outputs.manifest_channel }}
         TAG: ${{ steps.channel.outputs.tag }}
         # TODO-1049: manifest `tag` keeps the versioned/seq TAG for client
         # version comparison; asset URLs resolve under DOWNLOAD_TAG (the actual

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 849 条。点号进各自文件。
+> 共 850 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-869](bugs/BUG-869-update-channel-pingpong.md) | ✅ | ✅ | 调试版与正式版来回更新 |
 | [BUG-868](bugs/BUG-868-reader-content-ready-timeout-pagination-wedge.md) | ✅ | ✅ | 开EPUB偶发卡住·内容就绪兜底超时漏复位导航态致翻页永久失效 |
 | [BUG-867](bugs/BUG-867-ass-fontname-gdi-fullname.md) | ✅ | ✅ | 装了字幕指定字体 hibiki 仍用回退字体（ASS Fontname=GDI 全名解析缺失） |
 | [BUG-866](bugs/BUG-866-reader-live-margin-theme-gate.md) | ✅ | ✅ | 阅读器余白/主题改完不实时生效须退出重进(样式重锚就绪门控静默丢CSS) |

--- a/docs/bugs/BUG-869-update-channel-pingpong.md
+++ b/docs/bugs/BUG-869-update-channel-pingpong.md
@@ -1,0 +1,16 @@
+## BUG-869 · 调试版与正式版来回更新
+
+- **报告**：2026-07-17（用户：调试版本会互相更新到正式、调试版，来回更新）
+- **真实性**：✅ 真 bug。仅影响 beta/debug 通道用户（stable 通道合集只含 stable，见不到预发布，不受影响）。根因是同基版本跨轨判定自相矛盾，`hibiki/lib/src/utils/misc/update_checker_release.dart`：
+  - **方向①**（BUG-846）`isUpdateVersionNewer` 同基分支 `if (remotePrerelease == null) return localPrerelease != null;`：装着 `1.2.0-debug.7920` 的用户被判「同基正式版 `1.2.0` 是更新」（semver 里正式版 > 同基预发布）→ 升到正式版。
+  - **方向②**（BUG-457/821）`effectiveCurrentVersionForUpdateChannel` 把无后缀的正式版安装 `1.2.0` + versionCode **伪造成** `1.2.0-debug.<正式版seq>` → 远端 `1.2.0-debug.7920`（seq 7920 > 正式版 seq）又被判更新 → 装回调试版 → 回到方向①，无限来回。
+  - 两方向各自被测试断言为「正确」，但合起来就是乒乓；`_compareReleaseRecency` 排序「预发布轨优先」与判据「正式版优先」也互相矛盾，无收敛守卫。
+  - 关键事实：CI 出的 beta/debug 包 versionName **本就带** `-debug.<seq>` 后缀（`release.yml` 的 `--build-name`），只有正式版是纯 `X.Y.Z`。所以那个「无后缀就当预发布还原」的伪造在生产里几乎只命中真正的正式版安装，硬把它标成预发布轨。
+- **[x] ① 已修复** — 根因修复：更新判据改为用户指定的「谁后构建谁赢」——按 release sequence（`git rev-list --count HEAD`，三通道同一把尺）做 `(基版本, 序号)` 全序比较，唯一最大值即目标，天然无来回。`update_checker_release.dart`：
+  - `isUpdateVersionNewer` 同基分支改为按 seq 比（`_releaseSeqOf`：预发布串尾号 / manifest 顶层 releaseSequence / versionCode 反解）；两侧 seq 已知比先后，任一未知则保守不更新（同基不 churn）。删除 semver「正式版>预发布」与 `_sameChannelTrack`/`_channelTrackRank` 分支。
+  - `effectiveCurrentVersionForUpdateChannel`（伪造串，病根）删除，换成 `currentReleaseSequence`（只提取本机序号、**不改轨道标签**），经 `scheduleCheck`/`_check`/`selectUpdateReleaseForCurrentPlatform` 透传。
+  - 正式版通道也读 `latest-stable.json`（CI 早已发布，顶层带 `releaseSequence`）拿正式版序号；`buildReleaseFromManifest` 透出顶层 `releaseSequence`；`manifestUrlsForChannel(stable)` / `kStableManifestUrl` 接线；读不到（手动 GitHub Release 未发 manifest）回退 302，同基保守。
+  - `_compareReleaseRecency` 排序改按同一 seq，消除排序/判据不一致。
+  - 提交哈希：见本分支 commit（fix(update): BUG-869 …）。
+- **[x] ② 已加自动化测试** — `hibiki/test/utils/misc/version_comparison_test.dart`：新增 `currentReleaseSequence + 谁后用谁 乒乓根治` 组（序号提取 + 同基「谁后用谁」双向 + 序号未知保守）+ 选择器级**乒乓收敛守卫**（装 stable 升到更晚 debug；装 debug 后不被同基更早正式版拉回→ 返 null 收敛）；跨轨同基/BUG-846 同基断言按新序号语义重写。`hibiki/test/utils/misc/update_checker_manifest_test.dart`：stable 走 manifest + `buildReleaseFromManifest` 透出顶层 `releaseSequence` 守卫。`test/utils/misc/` + `test/settings/` 全绿（812+）。
+- **备注**：CI 加固——让手动 GitHub Release 发正式版时也产出 `latest-stable.json`（覆盖 302 无序号边界），随本 PR 一并做。行为变更：同基跨轨在「谁后用谁」下按序号比（放宽 BUG-480 case B 的跨轨互斥，合集门仍保证 beta 用户看不到 debug 轨）。待真机验收：beta/debug 设备连续「检查更新」确认收敛、不再正式↔调试来回。

--- a/hibiki/lib/src/settings/settings_schema_system.dart
+++ b/hibiki/lib/src/settings/settings_schema_system.dart
@@ -243,12 +243,12 @@ Future<void> _checkUpdateNow(SettingsContext settingsContext) async {
   final String currentBuildNumber =
       settingsContext.appModel.packageInfo.buildNumber;
   final UpdateChannel channel = _channelFromSettings(settingsContext);
-  // BUG-457：缓存乐观比较也用还原后的版本，否则 beta/debug 通道装无后缀 `X.Y.Z` release
-  // 包时，缓存路径同样把同基预发布误判「已是最新」（与网络路径 scheduleCheck 内部还原一致）。
-  final String comparableVersion = effectiveCurrentVersionForUpdateChannel(
+  // BUG-846「谁后用谁」：缓存乐观比较用本机 release sequence（无后缀 `X.Y.Z` 正式版包 /
+  // beta/debug 包都能取到），与网络路径 scheduleCheck 同源。远端 seq 从缓存的 latestTag 串
+  // 自取（beta/debug 带尾号；正式版无 → 保守走基版本比较，网络刷新随后收口）。
+  final int? currentReleaseSeq = currentReleaseSequence(
     version: currentVersion,
     buildNumber: currentBuildNumber,
-    channel: channel,
   );
   final UpdateCheckCacheEntry? cached = cachedEntryForChannel(
     settingsContext.appModel.updateCheckCache,
@@ -256,7 +256,8 @@ Future<void> _checkUpdateNow(SettingsContext settingsContext) async {
   );
   if (cached != null) {
     final bool newer = updateTagIsNewerThanCurrent(
-        cached.latestTag, comparableVersion, channel);
+        cached.latestTag, currentVersion, channel,
+        localSeq: currentReleaseSeq);
     HibikiToast.show(
       msg: newer
           ? t.update_cached_newer(version: cached.latestTag)

--- a/hibiki/lib/src/utils/misc/update_checker_release.dart
+++ b/hibiki/lib/src/utils/misc/update_checker_release.dart
@@ -83,17 +83,18 @@ class UpdateChecker {
         : betaChannel
             ? UpdateChannel.beta
             : UpdateChannel.stable;
-    // BUG-457：把无后缀的本机版本按通道 + buildNumber 还原成可比的预发布版本；stable 或
-    // 本机已带本通道后缀时原样返回（纯函数，见 effectiveCurrentVersionForUpdateChannel）。
-    final String comparableCurrentVersion =
-        effectiveCurrentVersionForUpdateChannel(
+    // BUG-846「谁后用谁」：算出本机 release sequence（beta/debug 版本串已带 `-<channel>.<seq>`
+    // 直接取；无后缀 `X.Y.Z`（正式版包 / 本地 build）用平台构建号反解），透到比较层做跨轨
+    // 序号全序比较。**不再**把本机版本伪造成 `<base>-<channel>.<seq>` 串——那会把真正的正式版
+    // 安装误标成预发布轨，触发正式↔调试来回更新（BUG-846 乒乓根因）。
+    final int? currentReleaseSeq = currentReleaseSequence(
       version: currentVersion,
       buildNumber: currentBuildNumber,
-      channel: channel,
     );
     final Completer<void> completer = Completer<void>();
     SchedulerBinding.instance.addPostFrameCallback((_) {
-      _check(context, comparableCurrentVersion,
+      _check(context, currentVersion,
+              currentReleaseSeq: currentReleaseSeq,
               neverRemind: neverRemind,
               autoInstall: autoInstall,
               channel: channel,
@@ -226,6 +227,8 @@ class UpdateChecker {
   static Future<void> _check(
     BuildContext context,
     String currentVersion, {
+    // BUG-846「谁后用谁」：本机 release sequence（跨轨全序比较用）。null = 取不到（同基保守）。
+    int? currentReleaseSeq,
     bool neverRemind = false,
     bool autoInstall = false,
     UpdateChannel channel = UpdateChannel.stable,
@@ -271,6 +274,7 @@ class UpdateChecker {
           await selectUpdateReleaseForCurrentPlatform(
         releases,
         currentVersion: currentVersion,
+        currentReleaseSeq: currentReleaseSeq,
         channel: channel,
         updater: updater,
       );
@@ -309,7 +313,11 @@ class UpdateChecker {
       }
 
       // selection 非空即已按 asset 版本判定为「比本机新」；这里保留防御性再判一次。
-      if (!isUpdateVersionNewer(version, currentVersion, channel)) {
+      // BUG-846：远端 seq 用所选 release 顶层 releaseSequence（正式版无预发布串靠它），
+      // 本机 seq 用透传下来的 currentReleaseSeq，与选择阶段同源。
+      if (!isUpdateVersionNewer(version, currentVersion, channel,
+          remoteSeq: json['releaseSequence'] as int?,
+          localSeq: currentReleaseSeq)) {
         // 已是最新（TODO-898）。
         onUpToDate?.call();
         return;
@@ -493,6 +501,16 @@ class UpdateChecker {
     UpdateChannel channel,
   ) async {
     if (channel == UpdateChannel.stable) {
+      // BUG-846「谁后用谁」：正式版**优先**读 `latest-stable.json` 镜像清单——它顶层带
+      // `releaseSequence`（CI `merge_update_manifest.py` 写入），是客户端唯一能拿到正式版
+      // release sequence 的来源，据此才能与同基预发布按「谁后构建谁赢」比较。**回退**到原
+      // 302 跳转 / API 直连（拿不到 seq，同基保守不 churn）。手动 GitHub Release 未发 manifest
+      // 时自然走回退，fail-open。
+      final Map<String, dynamic>? manifestRelease =
+          await _fetchChannelReleaseFromManifest(client, channel);
+      if (manifestRelease != null) {
+        return <Map<String, dynamic>>[manifestRelease];
+      }
       final Map<String, dynamic>? release = await _fetchStableRelease(client);
       return release == null
           ? const <Map<String, dynamic>>[]
@@ -1068,10 +1086,14 @@ class UpdateChecker {
       final UpdateChannel channel = channelForUpdateVersion(version);
       final List<Map<String, dynamic>> releases =
           await _fetchReleasesForChannel(client, channel);
+      // BUG-846：重取仅为换同版本的新下载 URL；本机 seq 从下载目标 [version] 串自取
+      // （预发布串自带 seq；正式版无 buildNumber 上下文 → null → 同基保守，不影响换 URL）。
       final UpdateReleaseSelection? selection =
           await selectUpdateReleaseForCurrentPlatform(
         releases,
         currentVersion: version,
+        currentReleaseSeq:
+            currentReleaseSequence(version: version, buildNumber: null),
         channel: channel,
         updater: updater,
       );
@@ -1303,12 +1325,21 @@ const String kDebugManifestUrl =
 const String kLegacyDebugManifestUrl =
     'https://raw.githubusercontent.com/$kLegacyGitHubRepo/update-manifest/latest-debug.json';
 
+/// stable 通道镜像清单（BUG-846「谁后用谁」）。CI `publish_update_manifest.sh` 的 formal 分支
+/// 已生成 `latest-stable.json`（`merge_update_manifest.py` 写顶层 `releaseSequence`）。客户端读它
+/// 才能拿到正式版 release sequence，与同基预发布按「谁后构建谁赢」比较；读不到（手动 GitHub
+/// Release 未发 manifest）则回退 302 跳转（无 seq，同基保守不 churn）。与 beta/debug 同构。
+const String kStableManifestUrl =
+    'https://raw.githubusercontent.com/$kGitHubRepo/update-manifest/latest-stable.json';
+const String kLegacyStableManifestUrl =
+    'https://raw.githubusercontent.com/$kLegacyGitHubRepo/update-manifest/latest-stable.json';
+
 /// CI 生成镜像清单时识别的 schema 版本（TODO-705）。客户端只认该版本；
 /// 未来结构不兼容的变更递增该号，旧客户端不识别则安全回退 API 直连。
 const int kUpdateManifestSchemaVersion = 1;
 
-/// **纯函数**：按通道返回镜像清单 URL（TODO-705）。beta/debug 有 manifest；
-/// stable 走 302 跳转、不走 manifest（返 null）。
+/// **纯函数**：按通道返回镜像清单 URL（TODO-705 / BUG-846）。三通道均有 manifest
+/// （stable 读它拿正式版 seq；读不到再回退 302）。
 @visibleForTesting
 String? manifestUrlForChannel(UpdateChannel channel) {
   final Map<String, String> urls = manifestUrlsForChannel(channel);
@@ -1327,7 +1358,10 @@ Map<String, String> manifestUrlsForChannel(UpdateChannel channel) {
         kGitHubRepo: kDebugManifestUrl,
         kLegacyGitHubRepo: kLegacyDebugManifestUrl,
       },
-    UpdateChannel.stable => const <String, String>{},
+    UpdateChannel.stable => const <String, String>{
+        kGitHubRepo: kStableManifestUrl,
+        kLegacyGitHubRepo: kLegacyStableManifestUrl,
+      },
   };
 }
 
@@ -1372,6 +1406,9 @@ Map<String, dynamic>? buildReleaseFromManifest(
   final String body0 =
       decoded['notes'] is String ? decoded['notes'] as String : '';
   final bool prerelease = decoded['prerelease'] == true;
+  // TODO-1205 / BUG-846：透传顶层 `releaseSequence`（CI `merge_update_manifest.py` 写的
+  // 全平台最大 seq）。正式版无预发布串带不了 seq，跨轨「谁后用谁」比较全靠它。
+  final Object? topReleaseSeq = decoded['releaseSequence'];
 
   final List<Map<String, dynamic>> assets = <Map<String, dynamic>>[];
   final Object? assetsRaw = decoded['assets'];
@@ -1412,6 +1449,7 @@ Map<String, dynamic>? buildReleaseFromManifest(
     'draft': false,
     'body': body0,
     'html_url': '${stableReleasesHtmlUrlForRepo(repo)}/tag/$tag',
+    if (topReleaseSeq is int) 'releaseSequence': topReleaseSeq,
     'assets': assets,
   };
 }
@@ -1430,14 +1468,17 @@ class _StableRedirectTag {
 Future<UpdateReleaseSelection?> selectUpdateReleaseForCurrentPlatform(
   List<Map<String, dynamic>> releases, {
   required String currentVersion,
+  // BUG-846「谁后用谁」：本机 release sequence（跨轨全序比较用）。null = 取不到（同基保守）。
+  int? currentReleaseSeq,
   required UpdateChannel channel,
   required PlatformUpdater updater,
 }) async {
   // BUG-846：合集是多轨并集（beta/debug 用户会同时拿到 stable/beta/debug 的 latest），
   // 必须先按「最新优先」排序再取第一个可用于本平台的更新，否则按拉取顺序会误选更旧的
   // release（如 beta 用户 beta 轨已到 1.3.0-beta.1，却因 stable 1.2.0 排在前而误选 1.2.0）。
-  // 排序键：基版本降序 → 同基预发布轨优先于正式版（debug>beta>stable，让 beta/debug 用户
-  // 停留本轨而非同基塌回 stable）→ 同基同轨预发布序号降序。
+  // 排序键=「谁后构建谁赢」：基版本降序 → 同基按 release sequence 降序（三通道同尺，正式版
+  // seq 从 manifest 顶层 releaseSequence 取，预发布 seq 即版本串尾号）。与 isUpdateVersionNewer
+  // 同尺，消除「排序偏预发布轨 vs 判据偏正式版」不一致这个乒乓根源。
   final List<Map<String, dynamic>> ordered = releases
       .where((Map<String, dynamic> r) => releaseEligibleForChannel(r, channel))
       .toList()
@@ -1446,7 +1487,10 @@ Future<UpdateReleaseSelection?> selectUpdateReleaseForCurrentPlatform(
           normalizeReleaseVersionTag(a['tag_name'] as String? ?? '') ?? '';
       final String vb =
           normalizeReleaseVersionTag(b['tag_name'] as String? ?? '') ?? '';
-      return _compareReleaseRecency(vb, va); // 降序：新的在前
+      // 降序：新的在前。seq 从各自 release map 顶层取（正式版 302 回退无 → null）。
+      return _compareReleaseRecency(vb, va,
+          seqA: b['releaseSequence'] as int?,
+          seqB: a['releaseSequence'] as int?);
     });
 
   UpdateReleaseSelection? fallback;
@@ -1456,7 +1500,12 @@ Future<UpdateReleaseSelection?> selectUpdateReleaseForCurrentPlatform(
     if (topVersion == null || topVersion.isEmpty) continue;
     // 粗过滤：顶层 tag 是全平台最大 seq（TODO-1173），连它都不比本机新，
     // 本 release 对任何平台都无更新。保留这层既避开 up-to-date 时多余的 selectAsset。
-    if (!isUpdateVersionNewer(topVersion, currentVersion, channel)) continue;
+    // BUG-846：远端 seq 用本 release 顶层 releaseSequence（正式版无预发布串靠它）。
+    if (!isUpdateVersionNewer(topVersion, currentVersion, channel,
+        remoteSeq: release['releaseSequence'] as int?,
+        localSeq: currentReleaseSeq)) {
+      continue;
+    }
 
     final List<Map<String, dynamic>> assetMaps =
         (release['assets'] as List<dynamic>? ?? <dynamic>[])
@@ -1477,7 +1526,9 @@ Future<UpdateReleaseSelection?> selectUpdateReleaseForCurrentPlatform(
         asset == null ? null : normalizeReleaseVersionTag(asset.version ?? '');
     final String effectiveVersion = assetVersion ?? topVersion;
     if (asset != null &&
-        !isUpdateVersionNewer(effectiveVersion, currentVersion, channel)) {
+        !isUpdateVersionNewer(effectiveVersion, currentVersion, channel,
+            remoteSeq: release['releaseSequence'] as int?,
+            localSeq: currentReleaseSeq)) {
       // 顶层更新但本平台 asset 已是本机版本（或更旧）→ 对本机不是更新，跳过。
       continue;
     }
@@ -1543,45 +1594,59 @@ bool releaseEligibleForChannel(
 bool updateTagIsNewerThanCurrent(
   String tag,
   String current,
-  UpdateChannel channel,
-) =>
-    isUpdateVersionNewer(tag, current, channel);
+  UpdateChannel channel, {
+  int? remoteSeq,
+  int? localSeq,
+}) =>
+    isUpdateVersionNewer(tag, current, channel,
+        remoteSeq: remoteSeq, localSeq: localSeq);
+
+/// **纯函数**：取版本的 release sequence（= `git rev-list --count HEAD`，三通道同一把尺）。
+/// 预发布串 `-beta.<seq>` / `-debug.<seq>` 的尾段数字**就是** seq（CI `TAG=v${VERSION}-<ch>.${SEQ}`）；
+/// 正式版无预发布段，seq 由 [explicitSeq]（manifest 顶层 `releaseSequence` / 本机 versionCode 反解）
+/// 提供。都取不到 → null（同基无法判先后 → 调用方保守不更新，绝不 churn）。
+int? _releaseSeqOf(String version, int? explicitSeq) {
+  final String? pre = _prereleasePart(_stripBuildMetadata(version));
+  if (pre != null) {
+    final int? seq = int.tryParse(pre.split('.').last);
+    if (seq != null) return seq;
+  }
+  return explicitSeq;
+}
 
 @visibleForTesting
 bool isUpdateVersionNewer(
   String remote,
   String local,
-  UpdateChannel channel,
-) {
+  UpdateChannel channel, {
+  // BUG-846「谁后用谁」：跨轨全序比较用的 release sequence。远端正式版无预发布串带不了 seq，
+  // 靠 [remoteSeq]（manifest 顶层）；本机正式版靠 [localSeq]（versionCode 反解）。预发布串自带。
+  int? remoteSeq,
+  int? localSeq,
+}) {
   final String remoteVersion = _stripBuildMetadata(remote.trim());
   final String localVersion = _stripBuildMetadata(local.trim());
 
   // BUG-846 嵌套合集准入：越激进的通道合集越大——stable 只收 stable；beta 收
   // {stable,beta}；debug 收 {stable,beta,debug}。远端版本所属轨道若不在本通道合集里，
-  // 一律不是更新（把旧的「远端必须**恰好**属于本通道」钝刀换成嵌套准入，让 beta/debug
-  // 用户能收到更新的正式版/更高基版本，永不掉队）。
+  // 一律不是更新（让 beta/debug 用户能收到更新的正式版/更高基版本，永不掉队）。
   if (!_channelAdmitsVersion(remoteVersion, channel)) return false;
 
+  // 基版本不同：高基永远更新（pubspec 基版本随 commit 单调递增，高基=更晚构建）。
   final int baseCompare = _compareBaseVersion(remoteVersion, localVersion);
   if (baseCompare != 0) return baseCompare > 0;
 
-  // 同基版本：正式版成品优先，同基跨轨预发布不回灌（保留 BUG-480 铁律）。
-  final String? remotePrerelease = _prereleasePart(remoteVersion);
-  final String? localPrerelease = _prereleasePart(localVersion);
+  // 同基：按 release sequence「谁后构建谁赢」（BUG-846 正式↔调试来回更新根治）。序号跨三
+  // 通道同尺（都是 git rev-list --count HEAD），故正式版/beta/debug 同基可直接比先后，不再
+  // 用 semver 的「正式版>预发布」——那与「预发布轨更晚构建」矛盾，正是乒乓根源。
+  final int? rSeq = _releaseSeqOf(remoteVersion, remoteSeq);
+  final int? lSeq = _releaseSeqOf(localVersion, localSeq);
+  if (rSeq != null && lSeq != null) return rSeq > lSeq;
 
-  // 远端是正式版成品：只要本地是同基的预发布就算更新——预发布**早于**其正式版，beta/debug
-  // 用户理应领到成品 stable（BUG-846 核心诉求）。本地也是同基正式版 → 版本相同，非更新。
-  if (remotePrerelease == null) return localPrerelease != null;
-
-  // 远端是预发布、本地是同基正式版：semver 里预发布 < 正式版，是回退，不推
-  // （BUG-480 case A：正式版装机误开通道，绝不被同基预发布回灌）。
-  if (localPrerelease == null) return false;
-
-  // 双方同基预发布：只在**同一轨**（都 beta 或都 debug）按序号严格递进才算更新；
-  // 跨轨（beta↔debug）同基不互推（BUG-480 case B：beta 装机误开 debug 通道，绝不被同基
-  // debug 预发布跨轨回灌——跨轨同基先后无意义）。
-  if (!_sameChannelTrack(remotePrerelease, localPrerelease)) return false;
-  return _comparePrerelease(remotePrerelease, localPrerelease) > 0;
+  // 任一侧序号未知（如正式版仅走 302 拿不到 seq，或本机构建号缺失）：同基无法判先后 →
+  // 保守不更新。绝不在无法证实「远端更晚」时把用户在同基的两个轨道间来回推；等基版本上升
+  // （上面 baseCompare>0）再更新。fail-open：不误升。
+  return false;
 }
 
 /// BUG-846 嵌套合集：用户通道 [channel] 能接纳的所有轨道（含更保守的轨道），从最保守
@@ -1602,14 +1667,6 @@ List<UpdateChannel> _channelsAdmittedBy(UpdateChannel channel) {
   };
 }
 
-/// 通道稳定度 rank：stable=0 < beta=1 < debug=2。同基版本选择时预发布轨优先于正式版，
-/// 让 beta/debug 用户停留在本轨而非同基塌回 stable（BUG-846）。
-int _channelTrackRank(UpdateChannel channel) => switch (channel) {
-      UpdateChannel.stable => 0,
-      UpdateChannel.beta => 1,
-      UpdateChannel.debug => 2,
-    };
-
 /// BUG-846：远端 [version] 所属轨道是否被 [channel] 的嵌套合集接纳。轨道由
 /// [channelForUpdateVersion] 推断（正式版 → stable，`-beta.N`/`-debug.N` → 对应轨），
 /// 与既有判据同一套 pattern，不新造。
@@ -1618,62 +1675,25 @@ bool _channelAdmitsVersion(String version, UpdateChannel channel) {
       .contains(channelForUpdateVersion(version));
 }
 
-/// 两个预发布串是否同一轨（都 beta 或都 debug）。用于同基版本判断能否按序号递进；
-/// 跨轨同基不互推（保留 BUG-480 铁律）。
-bool _sameChannelTrack(String remotePrerelease, String localPrerelease) {
-  for (final UpdateChannel track in const <UpdateChannel>[
-    UpdateChannel.beta,
-    UpdateChannel.debug,
-  ]) {
-    if (_prereleaseBelongsToChannel(remotePrerelease, track) &&
-        _prereleaseBelongsToChannel(localPrerelease, track)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/// **纯函数（BUG-457）**：把本机安装版本 [version] 归一成「可与本通道远端预发布比较」的
-/// 版本串。
+/// **纯函数（BUG-846「谁后用谁」）**：本机安装版本的 release sequence，供跨轨全序比较。
 ///
-/// 根因：beta/debug 通道的远端版本形如 `1.2.0-debug.7920`（预发布），而本机若装的是无后缀
-/// `1.2.0`（本地 `flutter build` 出的 release 包 versionName 直接取 pubspec 基版本），在 semver
-/// 里 `1.2.0-debug.7920 < 1.2.0`（预发布早于正式版）+ [isUpdateVersionNewer] 的「同基需本机
-/// 也是本通道预发布」判据 → 永远判「已是最新」，同基预发布更新永远推不动（用户报「点检查
-/// 更新说最新，实际不是」）。
+/// beta/debug 包版本串已带 `-<channel>.<seq>` → 直接取尾号；无后缀 `X.Y.Z`（正式版包 / 本地
+/// `flutter build`）→ 用平台构建号 [buildNumber]（Android versionCode / 桌面 raw build number）
+/// 反解（[_releaseSequenceFromPlatformBuildNumber]）。取不到 → null（同基无法判先后 → 保守）。
 ///
-/// 修复：本机 versionName 无预发布段时，用平台构建号 [buildNumber] 还原 release sequence，
-/// 重建成 `<base>-<channel>.<seq>` 再参与比较。这样 `1.2.0`（seq 7863）→ `1.2.0-debug.7863`，
-/// 远端 `1.2.0-debug.7920` 正确判为更新。
-///
-/// 不改变以下路径（原样返回归一后的 [version]）：
-/// * stable 通道（正式版比较不涉及预发布还原）。
-/// * 本机 versionName 已带本通道后缀（CI 构建 `1.2.0-debug.7863`，无需还原）。
-/// * 本机带**别通道**预发布后缀 / [buildNumber] 缺失或不可解析（fail-open，绝不误升）。
+/// **不再**把无后缀正式版伪造成 `<base>-<channel>.<seq>` 串（旧 `effectiveCurrentVersionFor…`
+/// 的做法）——那会把真正的正式版安装误标成本通道预发布轨，触发正式↔调试来回更新（BUG-846
+/// 乒乓根因）。现在只提取序号、不改轨道标签，正式版仍是正式版。
 ///
 /// 生产调用点：[scheduleCheck] 内部（网络路径）+ 设置页手动检查的缓存乐观比较路径。
-String effectiveCurrentVersionForUpdateChannel({
+int? currentReleaseSequence({
   required String version,
   required String? buildNumber,
-  required UpdateChannel channel,
 }) {
-  final String normalized = _stripBuildMetadata(version.trim());
-  if (channel == UpdateChannel.stable) return normalized;
-  // 已经带本通道后缀（CI 预发布包）→ 直接比较，不重建。
-  if (_versionBelongsToChannel(normalized, channel)) return normalized;
-  // 带别通道预发布后缀（如 stable 通道装 beta 包混用）→ 不猜，交由既有严格判据处理。
-  if (_prereleasePart(normalized) != null) return normalized;
-
-  final int? releaseSequence =
-      _releaseSequenceFromPlatformBuildNumber(buildNumber);
-  if (releaseSequence == null) return normalized;
-
-  final String channelName = switch (channel) {
-    UpdateChannel.beta => 'beta',
-    UpdateChannel.debug => 'debug',
-    UpdateChannel.stable => throw StateError('stable handled above'),
-  };
-  return '${_basePart(normalized)}-$channelName.$releaseSequence';
+  return _releaseSeqOf(
+    _stripBuildMetadata(version.trim()),
+    _releaseSequenceFromPlatformBuildNumber(buildNumber),
+  );
 }
 
 /// **纯函数（BUG-457）**：从平台构建号还原 CI release sequence（= `git rev-list --count HEAD`）。
@@ -1711,23 +1731,20 @@ bool isVersionNewer(String remote, String local) {
   return _comparePrerelease(remotePrerelease, localPrerelease) > 0;
 }
 
-/// BUG-846 候选新旧比较（供合集并集选择排序，非「是否更新」判定）：`>0` 表示 [a] 比
-/// [b] 更新。基版本降序主导；同基时预发布轨更前沿（debug>beta>stable）者更新——让
-/// beta/debug 用户在同基场景优先跟本轨的预发布，而非塌回同基正式版；同基同轨按预发布
-/// 序号。注意：这只决定「若都算更新，谁排前面」，真正能否升级仍由 [isUpdateVersionNewer]
-/// 逐个把关（同基跨轨/回退在那里被拒）。
-int _compareReleaseRecency(String a, String b) {
+/// BUG-846「谁后用谁」候选新旧比较（供合集并集选择排序，非「是否更新」判定）：`>0` 表示
+/// [a] 比 [b] 更新。基版本降序主导；同基按 release sequence（`git rev-list --count HEAD`，三
+/// 通道同尺）降序——正式版 seq 由 [seqA]/[seqB]（manifest 顶层 releaseSequence）提供，预发布
+/// seq 即版本串尾号。序号缺失（正式版 302 回退无 seq）→ 同基视为并列（稳定排序保原序）。
+/// 与 [isUpdateVersionNewer] 同尺，消除「排序偏预发布轨 vs 判据偏正式版」不一致这个乒乓根源。
+int _compareReleaseRecency(String a, String b, {int? seqA, int? seqB}) {
   final String va = _stripBuildMetadata(a.trim());
   final String vb = _stripBuildMetadata(b.trim());
   final int baseCompare = _compareBaseVersion(va, vb);
   if (baseCompare != 0) return baseCompare;
-  final int rankA = _channelTrackRank(channelForUpdateVersion(va));
-  final int rankB = _channelTrackRank(channelForUpdateVersion(vb));
-  if (rankA != rankB) return rankA.compareTo(rankB);
-  final String? pa = _prereleasePart(va);
-  final String? pb = _prereleasePart(vb);
-  if (pa == null || pb == null) return 0;
-  return _comparePrerelease(pa, pb);
+  final int? ra = _releaseSeqOf(va, seqA);
+  final int? rb = _releaseSeqOf(vb, seqB);
+  if (ra != null && rb != null) return ra.compareTo(rb);
+  return 0;
 }
 
 String _stripBuildMetadata(String version) => version.split('+').first;
@@ -1794,15 +1811,6 @@ bool _releaseTagMatchesChannel(String tag, UpdateChannel channel) {
   return switch (channel) {
     UpdateChannel.beta => _kBetaReleaseTagPattern.hasMatch(normalized),
     UpdateChannel.debug => _kDebugReleaseTagPattern.hasMatch(normalized),
-    UpdateChannel.stable => false,
-  };
-}
-
-bool _prereleaseBelongsToChannel(String prerelease, UpdateChannel channel) {
-  final String normalized = prerelease.trim();
-  return switch (channel) {
-    UpdateChannel.beta => _kBetaVersionPattern.hasMatch('0.0.0-$normalized'),
-    UpdateChannel.debug => _kDebugVersionPattern.hasMatch('0.0.0-$normalized'),
     UpdateChannel.stable => false,
   };
 }

--- a/hibiki/test/utils/misc/update_checker_manifest_test.dart
+++ b/hibiki/test/utils/misc/update_checker_manifest_test.dart
@@ -14,6 +14,7 @@ String _manifestJson({
   String channel = 'beta',
   bool prerelease = true,
   String notes = 'Beta build notes',
+  int? releaseSequence,
   List<Map<String, dynamic>>? assets,
 }) {
   return jsonEncode(<String, dynamic>{
@@ -23,6 +24,7 @@ String _manifestJson({
     'channel': channel,
     'prerelease': prerelease,
     'notes': notes,
+    if (releaseSequence != null) 'releaseSequence': releaseSequence,
     'assets': assets ??
         <Map<String, dynamic>>[
           <String, dynamic>{
@@ -78,8 +80,23 @@ void main() {
       );
     });
 
-    test('stable does not use a manifest (302 path), returns null', () {
-      expect(manifestUrlForChannel(UpdateChannel.stable), isNull);
+    test('stable now uses latest-stable.json manifest (BUG-846 谁后用谁)', () {
+      // BUG-846：stable 也读 manifest 拿正式版 releaseSequence（跨轨序号比较用）；读不到
+      // 才回退 302。故 manifestUrlForChannel(stable) 不再返 null。
+      expect(manifestUrlForChannel(UpdateChannel.stable), kStableManifestUrl);
+      expect(
+        kStableManifestUrl,
+        'https://raw.githubusercontent.com/hajisensai/hibiki/update-manifest/latest-stable.json',
+      );
+      expect(
+        manifestUrlsForChannel(UpdateChannel.stable),
+        const <String, String>{
+          'hajisensai/hibiki':
+              'https://raw.githubusercontent.com/hajisensai/hibiki/update-manifest/latest-stable.json',
+          'hdjsadgfwtg/hibiki':
+              'https://raw.githubusercontent.com/hdjsadgfwtg/hibiki/update-manifest/latest-stable.json',
+        },
+      );
     });
   });
 
@@ -113,6 +130,35 @@ void main() {
       final Map<String, dynamic> release =
           buildReleaseFromManifest(_manifestJson())!;
       expect(releaseMatchesUpdateChannel(release, UpdateChannel.beta), isTrue);
+    });
+
+    test('BUG-846: top-level releaseSequence is surfaced for 谁后用谁', () {
+      // stable manifest（tag 无预发布串带不了 seq）靠顶层 releaseSequence 提供跨轨比较序号。
+      final Map<String, dynamic> release = buildReleaseFromManifest(
+        _manifestJson(
+          tag: 'v1.2.0',
+          version: '1.2.0',
+          channel: 'formal',
+          prerelease: false,
+          releaseSequence: 7850,
+          assets: <Map<String, dynamic>>[
+            <String, dynamic>{
+              'name': 'hibiki-1.2.0-arm64-v8a.apk',
+              'browser_download_url':
+                  'https://github.com/hajisensai/hibiki/releases/download/v1.2.0/hibiki-1.2.0-arm64-v8a.apk',
+            },
+          ],
+        ),
+      )!;
+      expect(release['releaseSequence'], 7850);
+      expect(
+          releaseMatchesUpdateChannel(release, UpdateChannel.stable), isTrue);
+    });
+
+    test('BUG-846: absent releaseSequence leaves the key unset (302 保守)', () {
+      final Map<String, dynamic> release =
+          buildReleaseFromManifest(_manifestJson())!;
+      expect(release.containsKey('releaseSequence'), isFalse);
     });
 
     test('legacy manifest source keeps legacy release page fallback', () {

--- a/hibiki/test/utils/misc/version_comparison_test.dart
+++ b/hibiki/test/utils/misc/version_comparison_test.dart
@@ -81,28 +81,43 @@ void main() {
       );
     });
 
-    test('BUG-480 debug channel does NOT push onto same-base beta install', () {
-      // beta 装机 1.0.1-beta.x + 选 debug 通道 → 同基 debug 预发布**不跨通道推送**。
+    test('BUG-846 谁后用谁: debug channel takes newer-seq debug over beta build',
+        () {
+      // 用户新判据「谁后构建谁赢」：同基跨轨按 release sequence 比先后（seq 三通道同尺）。
+      // debug 通道用户装着 beta.300，远端 debug.412 序号更大=构建更晚 → 应更新（合集门天然
+      // 限制：只有 debug 通道能看到 debug 轨，不会误推给 beta/stable 用户）。
       expect(
         isUpdateVersionNewer(
           '0.5.1-debug.412',
           '0.5.1-beta.300',
           UpdateChannel.debug,
         ),
+        isTrue,
+        reason: 'debug.412 比 beta.300 构建更晚（谁后用谁）',
+      );
+      // 反向：装着 debug.412，远端 beta.300 序号更小=更早 → 不更新。
+      expect(
+        isUpdateVersionNewer(
+          '0.5.1-beta.300',
+          '0.5.1-debug.412',
+          UpdateChannel.debug,
+        ),
         isFalse,
-        reason: 'beta 装机不得被同基 debug 预发布跨通道推送',
+        reason: 'beta.300 比 debug.412 更早，不回退',
       );
     });
 
-    test('BUG-480 beta channel does NOT push onto same-base debug install', () {
+    test('BUG-846 谁后用谁: beta channel takes newer-seq beta over debug build',
+        () {
+      // beta 通道用户装着 debug.300（历史遗留），远端 beta.412 更晚 → 更新到 beta 头。
       expect(
         isUpdateVersionNewer(
           '0.5.1-beta.412',
           '0.5.1-debug.300',
           UpdateChannel.beta,
         ),
-        isFalse,
-        reason: 'debug 装机不得被同基 beta 预发布跨通道推送',
+        isTrue,
+        reason: 'beta.412 比 debug.300 构建更晚（谁后用谁）',
       );
     });
 
@@ -296,127 +311,103 @@ void main() {
     });
   });
 
-  group('effectiveCurrentVersionForUpdateChannel (BUG-457)', () {
-    test(
-        'debug channel: plain X.Y.Z release restores seq from Android '
-        'versionCode and detects newer debug build', () {
-      // 复现用户设备：versionName=1.2.0（本地 release 包无 -debug 后缀），
-      // versionCode=1000786300 → seq 7863；远端 debug 1.2.0-debug.7920 必须判为更新。
-      final String effective = effectiveCurrentVersionForUpdateChannel(
-        version: '1.2.0',
-        buildNumber: '1000786300',
-        channel: UpdateChannel.debug,
-      );
-      expect(effective, '1.2.0-debug.7863');
+  group('currentReleaseSequence + 谁后用谁 乒乓根治 (BUG-846)', () {
+    test('Android versionCode decodes to the release sequence', () {
+      // 正式版包无 -debug 后缀：versionCode 1e9 + 100*7863 = 1000786300 → seq 7863。
       expect(
-        isUpdateVersionNewer(
-            '1.2.0-debug.7920', effective, UpdateChannel.debug),
-        isTrue,
-        reason: 'installed debug seq 7863 must see debug 7920 as an update',
+        currentReleaseSequence(version: '1.2.0', buildNumber: '1000786300'),
+        7863,
       );
     });
 
-    test('debug channel: same installed seq is not re-offered', () {
-      final String effective = effectiveCurrentVersionForUpdateChannel(
-        version: '1.2.0',
-        buildNumber: '1000792000',
-        channel: UpdateChannel.debug,
-      );
-      expect(effective, '1.2.0-debug.7920');
+    test('desktop raw build number is the release sequence', () {
       expect(
-        isUpdateVersionNewer(
-            '1.2.0-debug.7920', effective, UpdateChannel.debug),
-        isFalse,
+        currentReleaseSequence(version: '1.0.1', buildNumber: '6095'),
+        6095,
       );
     });
 
-    test('desktop build number (raw seq) restores installed beta sequence', () {
+    test('Android ABI offset is stripped from the release sequence', () {
+      // 1e9 + 100*6095 + 2(abi offset) = 1000609502 → seq 6095。
       expect(
-        effectiveCurrentVersionForUpdateChannel(
-          version: '1.0.1',
-          buildNumber: '6095',
-          channel: UpdateChannel.beta,
-        ),
-        '1.0.1-beta.6095',
-      );
-      expect(
-        isUpdateVersionNewer(
-          '1.0.1-beta.6095',
-          effectiveCurrentVersionForUpdateChannel(
-            version: '1.0.1',
-            buildNumber: '6095',
-            channel: UpdateChannel.beta,
-          ),
-          UpdateChannel.beta,
-        ),
-        isFalse,
-        reason: 'installed beta 6095 must not prompt for beta 6095 again',
+        currentReleaseSequence(version: '1.0.1', buildNumber: '1000609502'),
+        6095,
       );
     });
 
-    test('Android ABI versionCode offset is decoded to the release sequence',
+    test('prerelease suffix seq wins over build number (no fabrication)', () {
+      // 版本串已带 -debug.7863 → 直接取尾号（不看 buildNumber），且**不改轨道标签**。
+      expect(
+        currentReleaseSequence(
+            version: '1.2.0-debug.7863', buildNumber: '1000792000'),
+        7863,
+      );
+      expect(
+        currentReleaseSequence(version: '1.0.1-beta.6095', buildNumber: null),
+        6095,
+      );
+      // +build 元数据不影响。
+      expect(
+        currentReleaseSequence(version: '1.2.0+723', buildNumber: '1000786300'),
+        7863,
+      );
+    });
+
+    test('missing/unparseable build number → null (conservative, no churn)',
         () {
-      // 1e9 + 100*6095 + 2(abi offset) = 1000609502
       expect(
-        effectiveCurrentVersionForUpdateChannel(
-          version: '1.0.1',
-          buildNumber: '1000609502',
-          channel: UpdateChannel.beta,
-        ),
-        '1.0.1-beta.6095',
+          currentReleaseSequence(version: '1.2.0', buildNumber: null), isNull);
+      expect(
+        currentReleaseSequence(version: '1.2.0', buildNumber: 'not-a-number'),
+        isNull,
       );
     });
 
-    test('stable channel returns normalized version unchanged', () {
+    test(
+        'debug user on plain stable 1.2.0: pushed to debug only if debug is later',
+        () {
+      // 装了正式版 1.2.0（seq 由 versionCode 反解为 7863），debug 通道。
+      final int? localSeq =
+          currentReleaseSequence(version: '1.2.0', buildNumber: '1000786300');
+      expect(localSeq, 7863);
+      // 远端 debug.7920 更晚 → 更新（谁后用谁）。
       expect(
-        effectiveCurrentVersionForUpdateChannel(
-          version: '1.2.0+723',
-          buildNumber: '1000786300',
-          channel: UpdateChannel.stable,
-        ),
-        '1.2.0',
+        isUpdateVersionNewer('1.2.0-debug.7920', '1.2.0', UpdateChannel.debug,
+            localSeq: localSeq),
+        isTrue,
+        reason: 'debug.7920 比本机正式版 seq 7863 更晚',
+      );
+      // 若本机正式版 seq 更大（正式版是最后构建，如 8000 > 7920）→ 不回退到 debug。
+      expect(
+        isUpdateVersionNewer('1.2.0-debug.7920', '1.2.0', UpdateChannel.debug,
+            localSeq: 8000),
+        isFalse,
+        reason: '正式版 seq 8000 比 debug.7920 更晚，绝不回退（消除来回更新）',
       );
     });
 
-    test('version already carrying channel suffix is left untouched', () {
+    test(
+        'debug user on debug.7920: not dragged back to earlier-seq same-base stable',
+        () {
+      // 装了 debug.7920，远端同基正式版 seq 更早（7800）→ 不推（谁后用谁，禁回退）。
       expect(
-        effectiveCurrentVersionForUpdateChannel(
-          version: '1.2.0-debug.7863',
-          buildNumber: '1000786300',
-          channel: UpdateChannel.debug,
-        ),
-        '1.2.0-debug.7863',
+        isUpdateVersionNewer('1.2.0', '1.2.0-debug.7920', UpdateChannel.debug,
+            remoteSeq: 7800),
+        isFalse,
+        reason: '同基正式版 seq 7800 比本机 debug.7920 更早，不回退',
       );
-    });
-
-    test('missing/unparseable build number fails open (no restore)', () {
+      // 正式版更晚（7950 > 7920）→ 推正式版（谁后用谁：正式版是最后构建的）。
       expect(
-        effectiveCurrentVersionForUpdateChannel(
-          version: '1.2.0',
-          buildNumber: null,
-          channel: UpdateChannel.debug,
-        ),
-        '1.2.0',
+        isUpdateVersionNewer('1.2.0', '1.2.0-debug.7920', UpdateChannel.debug,
+            remoteSeq: 7950),
+        isTrue,
+        reason: '同基正式版 seq 7950 比 debug.7920 更晚，应升到正式版',
       );
+      // 正式版 seq 未知（302 回退拿不到）→ 保守不推，同基绝不 churn。
       expect(
-        effectiveCurrentVersionForUpdateChannel(
-          version: '1.2.0',
-          buildNumber: 'not-a-number',
-          channel: UpdateChannel.debug,
-        ),
-        '1.2.0',
-      );
-    });
-
-    test('foreign-channel prerelease suffix is not rewritten', () {
-      // 本机装 beta 包但切到 debug 通道 → 不猜，交由既有严格判据（不还原）。
-      expect(
-        effectiveCurrentVersionForUpdateChannel(
-          version: '1.2.0-beta.10',
-          buildNumber: '1000786300',
-          channel: UpdateChannel.debug,
-        ),
-        '1.2.0-beta.10',
+        isUpdateVersionNewer('1.2.0', '1.2.0-debug.7920', UpdateChannel.debug),
+        isFalse,
+        reason: '正式版 seq 未知时同基保守不推',
       );
     });
   });
@@ -432,13 +423,21 @@ void main() {
       );
     });
 
-    test('beta channel receives the finished same-base stable release', () {
-      // beta 用户在 1.2.0-beta.5，正式版 1.2.0 出了（成品早于预发布？不——预发布早于成品，
-      // semver 里 1.2.0 > 1.2.0-beta.5）→ 应领到成品 1.2.0（用户原始诉求）。
+    test('beta channel receives the finished same-base stable when it is later',
+        () {
+      // beta 用户在 1.2.0-beta.5，同基正式版 1.2.0 出了。谁后用谁：仅当正式版 seq 更大
+      // （构建更晚，如 seq 20 > 5）才领到——正式版一般在 beta 之后收尾。
+      expect(
+        isUpdateVersionNewer('1.2.0', '1.2.0-beta.5', UpdateChannel.beta,
+            remoteSeq: 20),
+        isTrue,
+        reason: 'beta 用户应领到同基但构建更晚的成品正式版',
+      );
+      // 正式版 seq 未知（302 无 manifest）→ 同基保守不推（等更高基或 manifest 提供 seq）。
       expect(
         isUpdateVersionNewer('1.2.0', '1.2.0-beta.5', UpdateChannel.beta),
-        isTrue,
-        reason: 'beta 用户应领到同基的成品正式版',
+        isFalse,
+        reason: '正式版 seq 未知时同基不 churn',
       );
     });
 
@@ -457,9 +456,10 @@ void main() {
         reason: 'debug 用户应收到更高基正式版',
       );
       expect(
-        isUpdateVersionNewer('1.2.0', '1.2.0-debug.100', UpdateChannel.debug),
+        isUpdateVersionNewer('1.2.0', '1.2.0-debug.100', UpdateChannel.debug,
+            remoteSeq: 150),
         isTrue,
-        reason: 'debug 用户应领到同基成品正式版',
+        reason: 'debug 用户应领到同基但构建更晚(seq 150>100)的正式版',
       );
       expect(
         isUpdateVersionNewer(
@@ -498,17 +498,27 @@ void main() {
       );
     });
 
-    test('same-base cross-track prerelease still blocked (BUG-480 preserved)',
-        () {
-      // 嵌套放开的只是「正向收更稳定轨/更高基」；同基跨轨预发布互推仍禁。
+    test('same-base cross-track compares by seq (谁后用谁, BUG-846)', () {
+      // 谁后用谁：debug 通道用户装着 beta.100，同基 debug.200 序号更大=构建更晚 → 更新。
+      // 合集门保证只有 debug 通道能看到 debug 轨（beta/stable 用户不受影响）。
       expect(
         isUpdateVersionNewer(
           '1.2.0-debug.200',
           '1.2.0-beta.100',
           UpdateChannel.debug,
         ),
+        isTrue,
+        reason: 'debug.200 比 beta.100 构建更晚',
+      );
+      // 反向更早不推。
+      expect(
+        isUpdateVersionNewer(
+          '1.2.0-beta.100',
+          '1.2.0-debug.200',
+          UpdateChannel.debug,
+        ),
         isFalse,
-        reason: '同基 beta 装机不得被同基 debug 跨轨回灌',
+        reason: 'beta.100 比 debug.200 更早，不回退',
       );
     });
   });
@@ -654,6 +664,52 @@ void main() {
       );
       expect(sel?.version, '1.2.0-debug.200');
     });
+
+    test('BUG-846 乒乓收敛: debug user on stable 1.2.0 升到更晚的 debug.200', () async {
+      // 装了正式版 1.2.0（本机 seq 150 由 currentReleaseSeq 提供），合集含同基 debug.200。
+      // 谁后用谁：debug.200 更晚 → 升上去。
+      final UpdateReleaseSelection? sel =
+          await selectUpdateReleaseForCurrentPlatform(
+        <Map<String, dynamic>>[
+          _relWithApks('v1.2.0',
+              prerelease: false,
+              apks: <String>['hibiki-1.2.0-arm64-v8a.apk'],
+              releaseSequence: 150),
+          _relWithApks('v1.2.0-debug.200+abc1234',
+              prerelease: true,
+              apks: <String>['hibiki-1.2.0-abc1234-debug.apk'],
+              releaseSequence: 200),
+        ],
+        currentVersion: '1.2.0',
+        currentReleaseSeq: 150,
+        channel: UpdateChannel.debug,
+        updater: arm64Updater(),
+      );
+      expect(sel?.version, '1.2.0-debug.200');
+    });
+
+    test('BUG-846 乒乓收敛: debug user on debug.200 不再被同基更早正式版拉回', () async {
+      // 装了 debug.200（本机 seq 200），合集含同基正式版 seq 150（更早）。谁后用谁：不推
+      // 任何东西（正式版更早、debug 即本机）→ 收敛，绝不来回更新。
+      final UpdateReleaseSelection? sel =
+          await selectUpdateReleaseForCurrentPlatform(
+        <Map<String, dynamic>>[
+          _relWithApks('v1.2.0',
+              prerelease: false,
+              apks: <String>['hibiki-1.2.0-arm64-v8a.apk'],
+              releaseSequence: 150),
+          _relWithApks('v1.2.0-debug.200+abc1234',
+              prerelease: true,
+              apks: <String>['hibiki-1.2.0-abc1234-debug.apk'],
+              releaseSequence: 200),
+        ],
+        currentVersion: '1.2.0-debug.200',
+        currentReleaseSeq: 200,
+        channel: UpdateChannel.debug,
+        updater: arm64Updater(),
+      );
+      expect(sel, isNull, reason: '已在合集最新（seq 200），不再提示更新');
+    });
   });
 }
 
@@ -672,6 +728,7 @@ Map<String, dynamic> _relWithApks(
   String tag, {
   required bool prerelease,
   required List<String> apks,
+  int? releaseSequence,
 }) =>
     <String, dynamic>{
       'tag_name': tag,
@@ -679,6 +736,7 @@ Map<String, dynamic> _relWithApks(
       'draft': false,
       'body': '',
       'html_url': 'https://github.com/hajisensai/hibiki/releases/tag/$tag',
+      if (releaseSequence != null) 'releaseSequence': releaseSequence,
       'assets': <Map<String, dynamic>>[
         for (final String name in apks)
           <String, dynamic>{


### PR DESCRIPTION
## 问题
用户报「调试版本会互相更新到正式、调试版，来回更新」。仅影响 beta/debug 通道用户。

## 根因（`hibiki/lib/src/utils/misc/update_checker_release.dart`）
同基版本跨轨判定**自相矛盾**导致乒乓：
- 方向①（BUG-846）`isUpdateVersionNewer` 同基分支 semver「正式版 > 同基预发布」→ debug 用户被推去同基正式版；
- 方向②（BUG-457/821）`effectiveCurrentVersionForUpdateChannel` 把无后缀正式版安装**伪造成** `1.2.0-debug.<正式版seq>` → 又被判 debug 是更新 → 装回 debug → 无限来回；
- `_compareReleaseRecency` 排序「预发布轨优先」与判据「正式版优先」再互相矛盾，且无收敛守卫。

## 修复：按 release sequence「谁后构建谁赢」（用户指定语义）
序号（`git rev-list --count HEAD`）三通道同尺，`(基版本, 序号)` 全序比较有唯一最大值 → 天然收敛。
- `isUpdateVersionNewer` 同基分支改按 seq 比（`_releaseSeqOf`：预发布串尾号 / manifest 顶层 releaseSequence / versionCode 反解）；两侧 seq 已知比先后，任一未知则**保守不更新**（同基不 churn）。
- 删 `effectiveCurrentVersionForUpdateChannel`（伪造串，病根），换 `currentReleaseSequence`（只取序号、不改轨道标签），经 scheduleCheck/_check/select 透传。
- 正式版通道读 `latest-stable.json`（CI 早已发布，顶层带 releaseSequence）拿正式版序号；`buildReleaseFromManifest` 透出顶层 seq；读不到回退 302（同基保守）。
- `_compareReleaseRecency` 排序改同一 seq，消除排序/判据不一致。

## CI 加固（f580baa30）
让**手动 GitHub Release** 发正式版时也产出 `latest-stable.json`（覆盖 302 无序号边界）。新增独立 `publish_manifest`/`manifest_channel`（与 `publish_managed_release` 解耦，**绝不**二次改用户手动建的 Release，**绝不**让 push 产出正式 manifest），非预发布 Release → formal manifest + prerelease=false。push/workflow_dispatch 行为零变化。`check_release_policy.ps1` 通过。

## 行为变更
同基跨轨在「谁后用谁」下按序号比（放宽 BUG-480 case B 跨轨互斥；合集门仍保证 beta 用户看不到 debug 轨）。

## 测试
- `version_comparison_test.dart`：新增「谁后用谁」双向 + **乒乓收敛守卫**（装 stable 升到更晚 debug；装 debug 后不被同基更早正式版拉回→返 null 收敛）；旧 BUG-846/480 同基断言按序号语义重写。
- `update_checker_manifest_test.dart`：stable 走 manifest + 顶层 releaseSequence 透出守卫。
- `test/utils/misc` + `test/settings` 全绿（812+）；`flutter analyze` 净；策略守卫 EXIT=0。

## 待真机验收
beta/debug 设备连续「检查更新」确认收敛、不再正式↔调试来回。

BUG 记录：`docs/bugs/BUG-869-update-channel-pingpong.md`