### PR TITLE
fix(video): 远端不重拉+手机卡自适应+概览热力图+远端继续观看 (BUG-872/873 + 统计重设计 + #3)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 850 条。点号进各自文件。
+> 共 852 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-873](bugs/BUG-873-video-cards-too-large-on-phone.md) | ✅ | ✅ | 手机端视频卡片过大（窄屏只出 1 列铺满整屏） |
+| [BUG-872](bugs/BUG-872-remote-video-reload-on-return.md) | ✅ | ✅ | 互联远端视频看完返回即重拉列表 |
 | [BUG-869](bugs/BUG-869-fscx-line-level-squash.md) | ✅ | ✅ | 静态 \fscx/\fscy 被按行级「最后值生效」建模，句尾/前缀压扁标签把整行压扁 |
 | [BUG-868](bugs/BUG-868-reader-content-ready-timeout-pagination-wedge.md) | ✅ | ✅ | 开EPUB偶发卡住·内容就绪兜底超时漏复位导航态致翻页永久失效 |
 | [BUG-867](bugs/BUG-867-ass-fontname-gdi-fullname.md) | ✅ | ✅ | 装了字幕指定字体 hibiki 仍用回退字体（ASS Fontname=GDI 全名解析缺失） |

--- a/docs/bugs/BUG-872-remote-video-reload-on-return.md
+++ b/docs/bugs/BUG-872-remote-video-reload-on-return.md
@@ -1,0 +1,6 @@
+## BUG-872 · 互联远端视频看完返回即重拉列表
+- **报告**：2026-07-18（用户：）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/home_video_page.dart:221`（原 `_refresh()` 无条件 `_remoteFuture = _loadRemoteVideos()`）。从播放器返回走 `_open()`（`:1057` `_refresh()`）→ `_refresh` 连带重换远端 future → 远端那层 `FutureBuilder`（`:1662`）无缓存顶值，future 一换 `snapshot.data` 变 null → `_visibleRemoteVideos` 返回空 → 远端卡整片闪空重拉。远端清单不因本地播放而变，此重拉纯属多余（`_refresh` 自身注释也承认「切回 tab 不再隐式重拉远端，pull-to-refresh 才是显式刷新入口」，却在本地路径重拉了）。
+- **[x] ① 已修复** — 给 `_refresh({bool remote = false})` 加开关，默认只刷本地；仅 `_openManageSources`（改变远端来源）传 `remote: true`。远端显式刷新仍由下拉 `_pullToRefresh` 承担。提交见 PR。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/home_video_refresh_remote_guard_test.dart` 源码扫描守卫：`_refresh` 的远端重拉必须门控在 `remote` 之后，`_open` 返回后的刷新必须是本地 `_refresh()`（无 `remote: true`）。
+- **备注**：与 BUG-750/PR#53（切 tab keepAlive）不同源——那修的是 tab 切换销毁重建，本 bug 是从播放器返回的 `_refresh` 主动换 future。

--- a/docs/bugs/BUG-873-video-cards-too-large-on-phone.md
+++ b/docs/bugs/BUG-873-video-cards-too-large-on-phone.md
@@ -1,0 +1,6 @@
+## BUG-873 · 手机端视频卡片过大（窄屏只出 1 列铺满整屏）
+- **报告**：2026-07-18（用户：）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/home_video_page.dart:1694`（原 `unifiedShelfCardLayout(..., targetWidth: 240)` 硬编码）。手机竖屏可用宽≈380dp 时 `columns = floor((380+12)/(240+12)) = 1` → 卡片被拉满整屏宽。而书架页早已用响应式 `readerShelfGridExtentForWidth`（手机<600→150），视频页与之不一致。附带：卡高 `mainAxisExtent`/`rowHeight` 硬编码 218（只在 240 宽才对），窄卡会残留封面上下留白。
+- **[x] ① 已修复** — targetWidth 改用书架同款 `readerShelfGridExtentForWidth(constraints.maxWidth)`（手机出≥2 列）；卡高改成随卡宽按 16:9 联动的 `_videoCardExtent(cardWidth) = cardWidth*9/16 + 83`（cardWidth=240 时回落到旧的 218，向后兼容），散卡网格与合集横排行共用。提交见 PR。
+- **[x] ② 已加自动化测试** — `hibiki/test/utils/misc/platform_layout_test.dart` 新增 group：手机宽（≤599）+ `readerShelfGridExtentForWidth` 目标宽经 `unifiedShelfCardLayout` 必得 ≥2 列（守卫「回到硬编码 240 → 1 列」的回归）。
+- **备注**：`unifiedShelfCardLayout` 被散卡网格与合集横排行成员卡共用，故两处逐像素同尺寸。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 32895 (1935 per locale)
+/// Strings: 32929 (1937 per locale)
 ///
-/// Built on 2026-07-17 at 10:58 UTC
+/// Built on 2026-07-17 at 17:13 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2612,6 +2612,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Connection & server settings are in the Hibiki Interconnect category';
   String get settings_search_hint => 'Search settings';
   String get settings_search_no_results => 'No matching settings';
+  String get reading_activity => 'Reading activity';
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -7005,6 +7007,10 @@ class _StringsAr extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -11471,6 +11477,10 @@ class _StringsDe extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -15953,6 +15963,10 @@ class _StringsEs extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -20446,6 +20460,10 @@ class _StringsFr extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -24866,6 +24884,10 @@ class _StringsId extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -29334,6 +29356,10 @@ class _StringsIt extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -33607,6 +33633,10 @@ class _StringsJa extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -37883,6 +37913,10 @@ class _StringsKo extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -42329,6 +42363,10 @@ class _StringsNl extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -46790,6 +46828,10 @@ class _StringsPtBr extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -51234,6 +51276,10 @@ class _StringsRu extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -55623,6 +55669,10 @@ class _StringsTh extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -60044,6 +60094,10 @@ class _StringsTr extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -64452,6 +64506,10 @@ class _StringsVi extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 // Path: <root>
@@ -68553,6 +68611,10 @@ class _StringsZhCn extends _StringsEn {
   String get settings_search_hint => '搜索设置';
   @override
   String get settings_search_no_results => '没有匹配的设置项';
+  @override
+  String get reading_activity => '阅读活动';
+  @override
+  String get video_watch_activity => '观看活动';
 }
 
 // Path: <root>
@@ -72745,6 +72807,10 @@ class _StringsZhHk extends _StringsEn {
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
+  @override
+  String get reading_activity => 'Reading activity';
+  @override
+  String get video_watch_activity => 'Watch activity';
 }
 
 /// Flat map(s) containing all translations.
@@ -76703,6 +76769,10 @@ extension on _StringsEn {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -80659,6 +80729,10 @@ extension on _StringsAr {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -84636,6 +84710,10 @@ extension on _StringsDe {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -88612,6 +88690,10 @@ extension on _StringsEs {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -92594,6 +92676,10 @@ extension on _StringsFr {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -96558,6 +96644,10 @@ extension on _StringsId {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -100537,6 +100627,10 @@ extension on _StringsIt {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -104478,6 +104572,10 @@ extension on _StringsJa {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -108423,6 +108521,10 @@ extension on _StringsKo {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -112395,6 +112497,10 @@ extension on _StringsNl {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -116364,6 +116470,10 @@ extension on _StringsPtBr {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -120338,6 +120448,10 @@ extension on _StringsRu {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -124296,6 +124410,10 @@ extension on _StringsTh {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -128263,6 +128381,10 @@ extension on _StringsTr {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -132225,6 +132347,10 @@ extension on _StringsVi {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }
@@ -136155,6 +136281,10 @@ extension on _StringsZhCn {
         return '搜索设置';
       case 'settings_search_no_results':
         return '没有匹配的设置项';
+      case 'reading_activity':
+        return '阅读活动';
+      case 'video_watch_activity':
+        return '观看活动';
       default:
         return null;
     }
@@ -140091,6 +140221,10 @@ extension on _StringsZhHk {
         return 'Search settings';
       case 'settings_search_no_results':
         return 'No matching settings';
+      case 'reading_activity':
+        return 'Reading activity';
+      case 'video_watch_activity':
+        return 'Watch activity';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "连接到其他设备",
   "interconnect_moved_note": "互联连接与本机服务器设置在「Hibiki 互联」分类",
   "settings_search_hint": "搜索设置",
-  "settings_search_no_results": "没有匹配的设置项"
+  "settings_search_no_results": "没有匹配的设置项",
+  "reading_activity": "阅读活动",
+  "video_watch_activity": "观看活动"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1933,5 +1933,7 @@
   "interconnect_section_client": "Connect to other devices",
   "interconnect_moved_note": "Connection & server settings are in the Hibiki Interconnect category",
   "settings_search_hint": "Search settings",
-  "settings_search_no_results": "No matching settings"
+  "settings_search_no_results": "No matching settings",
+  "reading_activity": "Reading activity",
+  "video_watch_activity": "Watch activity"
 }

--- a/hibiki/lib/src/media/video/video_library_overview.dart
+++ b/hibiki/lib/src/media/video/video_library_overview.dart
@@ -181,6 +181,43 @@ int _heroRank(
   return b.bookUid.compareTo(a.bookUid);
 }
 
+/// 远端「继续观看」候选的最小投影（页面从 `RemoteVideoInfo` 映射；测试直接构造）。
+class RemoteContinueEntry {
+  const RemoteContinueEntry({
+    required this.id,
+    required this.positionMs,
+    required this.completed,
+    required this.updatedAtMs,
+  });
+
+  final String id;
+
+  /// host 端记录的断点（毫秒，0=从头）。
+  final int positionMs;
+
+  /// 是否看完（页面由 positionMs / durationMs 派生——远端无 completed 列）。
+  final bool completed;
+
+  /// host 端断点最后更新时间（epoch 毫秒，0=无记录）。用于跨候选/跨本地排序。
+  final int updatedAtMs;
+}
+
+/// 纯函数：从远端视频投影里挑「继续观看」候选——有断点（positionMs>0）、未看完，
+/// 按 [RemoteContinueEntry.updatedAtMs]（host 端上次播放时间戳）最新者。无则 null。
+///
+/// 纯流播远端视频无本地进度行，故不进 [computeVideoLibraryOverview] 的本地 hero
+/// 推导（其合集 Next-Up 逻辑按本地 uid 键控）；本函数独立挑远端候选，页面层再按
+/// 时间戳与本地 hero 比较取胜者，让「继续观看」也覆盖互联远端视频（用户反馈）。
+RemoteContinueEntry? pickRemoteContinueEntry(
+    List<RemoteContinueEntry> entries) {
+  RemoteContinueEntry? best;
+  for (final RemoteContinueEntry e in entries) {
+    if (e.completed || e.positionMs <= 0) continue;
+    if (best == null || e.updatedAtMs > best.updatedAtMs) best = e;
+  }
+  return best;
+}
+
 /// 毫秒 → `m:ss` / `h:mm:ss`（视频「已看至」外显）。委托 [HibikiTimeFormat.clock]。
 String formatVideoPosition(int positionMs) =>
     HibikiTimeFormat.clock(Duration(milliseconds: positionMs));

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -214,11 +214,16 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     if (mounted) _refresh();
   }
 
-  void _refresh() {
+  /// 刷新库页。默认只刷**本地**（书架列表 + 分组映射 + 封面自愈）；远端互联清单
+  /// 不因本地播放/导入/标签变化而改变，故不重拉，避免「看完视频返回→远端卡整片闪空
+  /// 重新加载」（远端那层 FutureBuilder 无缓存顶值，future 一换即清空重拉）。
+  /// 只有真正改变远端来源的路径（[_openManageSources]）才传 `remote: true` 重拉清单；
+  /// 用户主动刷新走下拉 [_pullToRefresh]。
+  void _refresh({bool remote = false}) {
     setState(() {
       // TODO-1255：书架展示走 listForShelf（自愈数据根迁移遗弃的封面路径）。
       _future = widget.repo.listForShelf();
-      _remoteFuture = _loadRemoteVideos();
+      if (remote) _remoteFuture = _loadRemoteVideos();
     });
     _loadLibraryMaps();
     _maybeBackfillCovers();
@@ -709,7 +714,8 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
       context: context,
       builder: (_) => const MediaSourcesDialog(mediaKind: 'video'),
     );
-    if (mounted) _refresh();
+    // 管理互联源可能新增/切换/移除远端 host，远端清单需重拉。
+    if (mounted) _refresh(remote: true);
   }
 
   /// 拖放到视频 tab 时的处理：分类文件 → 局部坐标转屏幕坐标命中卡片 → 决策意图。
@@ -1681,11 +1687,15 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
                 builder: (BuildContext context, BoxConstraints constraints) {
                   final HibikiDesignTokens tokens =
                       HibikiDesignTokens.of(context);
+                  // 卡目标宽与书架同源（[readerShelfGridExtentForWidth]）：手机窄屏
+                  // （宽<600）用 150 → 至少 2 列，不再「1 列铺满整屏、卡片过大」；宽屏
+                  // 按断点收敛列数。此前硬编码 240 使手机可用宽≈380 时 floor 出 1 列。
                   final ({int columns, double cardWidth}) cardLayout =
                       unifiedShelfCardLayout(
                     availableWidth:
                         constraints.maxWidth - tokens.spacing.card * 2,
-                    targetWidth: 240,
+                    targetWidth:
+                        readerShelfGridExtentForWidth(constraints.maxWidth),
                   );
                   return CustomScrollView(
                     physics: const AlwaysScrollableScrollPhysics(),
@@ -2188,10 +2198,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         title: collection.name,
         countLabel: t.video_playlist_episodes(count: memberCount),
         itemCount: memberCount,
-        // 与散卡网格 cell 同宽同高（unifiedShelfCardLayout；218 = 封面区 + 标题 +
-        // Phase D 观看进度行）。
+        // 与散卡网格 cell 同宽同高（unifiedShelfCardLayout + _videoCardExtent：
+        // 16:9 封面 + 标题 + Phase D 观看进度行，随卡宽联动）。
         itemWidth: cardLayout.cardWidth,
-        rowHeight: 218,
+        rowHeight: _videoCardExtent(cardLayout.cardWidth),
         initialIndex: continueIdx,
         headerFocusId: HibikiFocusId('home-video-collection-${collection.id}'),
         onOpenDetail: () => _openCollectionDetail(collection),
@@ -2576,6 +2586,16 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   /// 连续散视频段落的 [SliverGrid]（TODO-654：随主 [CustomScrollView] 滚动；
   /// 网格 delegate 与远端区一致）。UI v2 Phase C 后合集不再进网格（渲染成全宽
   /// 横排行），本网格只装散视频单卡。
+  /// 视频卡总高 = 16:9 封面高（[cardWidth] × 9/16）+ 文字块（标题 2 行 + 观看进度行
+  /// + 内边距）。文字块 [_kVideoCardTextBlock] = 83，在 cardWidth=240 时回到旧的固定
+  /// 218，向后兼容；卡变窄时封面等比缩，不再出现固定卡高下的封面上下留白。散卡网格
+  /// [mainAxisExtent] 与合集横排行 [CollectionShelfRow.rowHeight] 共用此高，保持逐像素同尺寸。
+  static double _videoCardExtent(double cardWidth) =>
+      cardWidth * 9 / 16 + _kVideoCardTextBlock;
+
+  /// 视频卡封面下方文字块的固定高度（标题 2 行 + 观看进度行 + 内边距）。
+  static const double _kVideoCardTextBlock = 83;
+
   Widget _buildLooseVideoGridSliver(
     List<_VideoLooseCard> loose,
     EdgeInsetsGeometry padding,
@@ -2585,11 +2605,11 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
       padding: padding,
       sliver: SliverGrid.builder(
         // FixedCrossAxisCount + 统一卡宽（unifiedShelfCardLayout）：散卡 cell 与
-        // 合集横排行成员卡逐像素同尺寸（用户实报合集卡大一截）。
-        // mainAxisExtent 218 = 封面区 + 标题 + Phase D 观看进度行。
+        // 合集横排行成员卡逐像素同尺寸（用户实报合集卡大一截）。卡高随卡宽按
+        // 16:9 封面联动（_videoCardExtent），窄卡不再残留固定 218 的封面上下留白。
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: cardLayout.columns,
-          mainAxisExtent: 218,
+          mainAxisExtent: _videoCardExtent(cardLayout.cardWidth),
           crossAxisSpacing: 12,
           mainAxisSpacing: 12,
         ),

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -1715,8 +1715,14 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
                       // UI v2 Phase B：顶部「继续观看 hero + 媒体库概览」条（用户拍板：
                       // mockup 顶排的收藏筛选换成统计）。空库隐藏；统计按未过滤全量
                       // [all] 描述整库，不随标签筛选变。
-                      if (all.isNotEmpty)
-                        SliverToBoxAdapter(child: _buildOverviewSection(all)),
+                      // 本地库非空恒显示概览（活动热力图）；本地空时仅当存在远端
+                      // 续播候选（有断点未看完）才显示——否则「连了远端但没在看任何
+                      // 视频」不该凭空冒出一张空概览（也避免挤走远端卡的可点区域）。
+                      if (all.isNotEmpty ||
+                          _hasRemoteResumeCandidate(remoteVideos))
+                        SliverToBoxAdapter(
+                          child: _buildOverviewSection(all, remoteVideos),
+                        ),
                       ..._buildLocalVideoSlivers(
                           all, ordered, remoteVideos, cardLayout),
                     ],
@@ -1736,7 +1742,31 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   /// watch-stats → importedAt 回退）。右侧不再是「总数/未完成/近7天导入」三格状态
   /// 计数（用户反馈：那是状态非统计），改成 GitHub 式观看时长热力图（[_watchMsByDay]，
   /// 整卡点开完整视频统计页）。宽 ≥720 并排、窄屏纵向堆叠；无 hero 候选时只渲染热力图。
-  Widget _buildOverviewSection(List<VideoBookRow> all) {
+  /// 远端视频 → [RemoteContinueEntry] 投影（completed 由 positionMs/durationMs
+  /// 派生，远端无 completed 列）。概览 gate 与 hero 选取共用，单一真值不重复派生。
+  List<RemoteContinueEntry> _remoteContinueEntries(
+    List<RemoteVideoInfo> remoteVideos,
+  ) =>
+      <RemoteContinueEntry>[
+        for (final RemoteVideoInfo v in remoteVideos)
+          RemoteContinueEntry(
+            id: v.id,
+            positionMs: v.positionMs,
+            completed: v.durationMs != null &&
+                v.durationMs! > 0 &&
+                v.positionMs >= (v.durationMs! * 0.9),
+            updatedAtMs: v.positionUpdatedAtMs,
+          ),
+      ];
+
+  /// 是否存在远端续播候选（有断点未看完）。本地库空时用它 gate 概览显隐。
+  bool _hasRemoteResumeCandidate(List<RemoteVideoInfo> remoteVideos) =>
+      pickRemoteContinueEntry(_remoteContinueEntries(remoteVideos)) != null;
+
+  Widget _buildOverviewSection(
+    List<VideoBookRow> all,
+    List<RemoteVideoInfo> remoteVideos,
+  ) {
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     final VideoLibraryOverview overview = computeVideoLibraryOverview(
       entries: <VideoOverviewEntry>[
@@ -1780,9 +1810,26 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         }
       }
     }
+    // #3：远端/互联视频也进「继续观看」。纯流播远端无本地进度行，独立挑候选
+    // （[pickRemoteContinueEntry]：有断点未看完、host 端断点时间戳最新），再与本地
+    // hero 按时间戳比较——远端更近（或本地无 hero）则 hero 换成远端卡（点击 _openRemote）。
+    final RemoteContinueEntry? remoteBest =
+        pickRemoteContinueEntry(_remoteContinueEntries(remoteVideos));
+    final int? localWatchedMs =
+        overview.heroLastWatched?.millisecondsSinceEpoch;
+    final bool remoteWins = remoteBest != null &&
+        (hero == null ||
+            localWatchedMs == null ||
+            remoteBest.updatedAtMs > localWatchedMs);
     final Widget stats = _buildWatchHeatmapCard(tokens);
-    final Widget? heroCard =
-        hero == null ? null : _buildContinueHero(hero, overview, tokens);
+    Widget? heroCard;
+    if (remoteWins) {
+      final RemoteVideoInfo rv =
+          remoteVideos.firstWhere((RemoteVideoInfo v) => v.id == remoteBest.id);
+      heroCard = _buildContinueHeroRemote(rv, tokens);
+    } else if (hero != null) {
+      heroCard = _buildContinueHero(hero, overview, tokens);
+    }
     return Padding(
       padding: EdgeInsets.fromLTRB(
         tokens.spacing.card,
@@ -1864,6 +1911,71 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
                 SizedBox(height: tokens.spacing.gap / 2),
                 Text(
                   hero.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: tokens.type.listTitle,
+                ),
+                SizedBox(height: tokens.spacing.gap / 2),
+                Text(
+                  metadata.join(' · '),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: tokens.type.metadata,
+                ),
+              ],
+            ),
+          ),
+          SizedBox(width: tokens.spacing.gap),
+          Icon(
+            Icons.play_circle_filled,
+            size: 36,
+            color: tokens.surfaces.primary,
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 远端「继续观看」hero 卡（#3）：与本地 [_buildContinueHero] 同形态，但封面走
+  /// 远端封面 [_buildRemoteVideoCover]、进度取 host 端 [RemoteVideoInfo.positionMs] /
+  /// [RemoteVideoInfo.positionUpdatedAtMs]，整卡点击走远端流播 [_openRemote]。
+  Widget _buildContinueHeroRemote(
+    RemoteVideoInfo video,
+    HibikiDesignTokens tokens,
+  ) {
+    final DateTime? watched = video.positionUpdatedAtMs > 0
+        ? DateTime.fromMillisecondsSinceEpoch(video.positionUpdatedAtMs)
+        : null;
+    final List<String> metadata = <String>[
+      t.video_watched_up_to(time: formatVideoPosition(video.positionMs)),
+      if (watched != null)
+        t.video_last_watched(date: _formatOverviewDate(watched)),
+    ];
+    return HibikiCard(
+      key: ValueKey<String>('home_video_continue_hero_remote_${video.id}'),
+      focusId: const HibikiFocusId('home-video-continue-hero'),
+      onTap: () => _openRemote(video),
+      child: Row(
+        children: <Widget>[
+          ClipRRect(
+            borderRadius: HibikiBorderRadius.card,
+            child: SizedBox(
+              width: 148,
+              height: 84,
+              child: _buildRemoteVideoCover(video),
+            ),
+          ),
+          SizedBox(width: tokens.spacing.gap + 4),
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(t.video_continue_watching,
+                    style: tokens.type.sectionLabel),
+                SizedBox(height: tokens.spacing.gap / 2),
+                Text(
+                  video.title,
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                   style: tokens.type.listTitle,

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -53,6 +53,7 @@ import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/src/sync/video_manifest.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki/src/utils/components/batch_tag_dialog_frame.dart';
+import 'package:hibiki/src/utils/components/stat_contribution_heatmap.dart';
 import 'package:hibiki/src/pages/implementations/collection_name_dialog.dart';
 import 'package:hibiki/src/media/video/video_filename_parser.dart';
 import 'package:hibiki/src/utils/misc/shelf_ordering.dart';
@@ -170,6 +171,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   /// NULL-uid 行按 title 回退。与 [_loadLibraryMaps] 同批预取。
   Map<String, DateTime> _watchAtByUid = const <String, DateTime>{};
   Map<String, DateTime> _legacyWatchAtByTitle = const <String, DateTime>{};
+
+  /// 每日观看时长（dateKey → 毫秒之和），驱动顶部概览的观看热力图（GitHub 式）。
+  /// 与 [_watchAtByUid] 同批从 watch-stats 全量行聚合（[_loadLibraryMaps]）。
+  Map<String, int> _watchMsByDay = const <String, int>{};
 
   @override
   void initState() {
@@ -295,6 +300,12 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
           if (r.bookUid == null) (r.title, r.lastModified),
       ],
     );
+    // 每日观看时长聚合（dateKey → sum watchTimeMs），供顶部观看热力图。同一批
+    // watchRows 复用，不再单独查库。
+    final Map<String, int> watchMsByDay = <String, int>{};
+    for (final VideoWatchStatisticRow r in watchRows) {
+      watchMsByDay[r.dateKey] = (watchMsByDay[r.dateKey] ?? 0) + r.watchTimeMs;
+    }
     if (mounted) {
       setState(() {
         _sortMode = sortMode;
@@ -305,6 +316,7 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         _primaryCollectionByEntry = primaryMap;
         _watchAtByUid = watchByUid;
         _legacyWatchAtByTitle = legacyByTitle;
+        _watchMsByDay = watchMsByDay;
       });
     }
   }
@@ -1718,12 +1730,12 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     );
   }
 
-  /// UI v2 Phase B：顶部概览条 =「继续观看 hero」+「媒体库概览」统计。
+  /// UI v2 Phase B：顶部概览条 =「继续观看 hero」+「观看活动热力图」。
   ///
-  /// 数据全部内存推导（[computeVideoLibraryOverview]）：hero = 有痕迹未看完中
-  /// 最近看过的一条（watch-stats → importedAt 回退）；统计 = 总数 / 未完成 /
-  /// 近 7 天导入。**不显示百分比**（VideoBooks 无总时长列，不造假）。宽 ≥720
-  /// 并排、窄屏纵向堆叠；无 hero 候选时只渲染统计。
+  /// hero = 有痕迹未看完中最近看过的一条（[computeVideoLibraryOverview]，
+  /// watch-stats → importedAt 回退）。右侧不再是「总数/未完成/近7天导入」三格状态
+  /// 计数（用户反馈：那是状态非统计），改成 GitHub 式观看时长热力图（[_watchMsByDay]，
+  /// 整卡点开完整视频统计页）。宽 ≥720 并排、窄屏纵向堆叠；无 hero 候选时只渲染热力图。
   Widget _buildOverviewSection(List<VideoBookRow> all) {
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     final VideoLibraryOverview overview = computeVideoLibraryOverview(
@@ -1768,7 +1780,7 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         }
       }
     }
-    final Widget stats = _buildOverviewStats(overview, tokens);
+    final Widget stats = _buildWatchHeatmapCard(tokens);
     final Widget? heroCard =
         hero == null ? null : _buildContinueHero(hero, overview, tokens);
     return Padding(
@@ -1877,11 +1889,14 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     );
   }
 
-  /// 媒体库概览统计：总数 / 未完成 / 近 7 天导入 三格。
-  Widget _buildOverviewStats(
-    VideoLibraryOverview overview,
-    HibikiDesignTokens tokens,
-  ) {
+  /// 顶部观看活动热力图卡（GitHub 式贡献图）：按每日观看时长 [_watchMsByDay] 铺
+  /// 最近数周方格，整卡可点开完整视频统计页。取代旧的「总数/未完成/近7天导入」三格
+  /// 状态计数——那是状态而非统计（用户反馈），热力图直观展示观看活跃度。
+  Widget _buildWatchHeatmapCard(HibikiDesignTokens tokens) {
+    final StatHeatmapModel model = buildStatHeatmap(
+      valueByDateKey: _watchMsByDay,
+      now: DateTime.now(),
+    );
     return DecoratedBox(
       decoration: ShapeDecoration(
         color: tokens.surfaces.group,
@@ -1896,56 +1911,17 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Text(t.video_library_overview, style: tokens.type.sectionLabel),
+            Text(t.video_watch_activity, style: tokens.type.sectionLabel),
             SizedBox(height: tokens.spacing.gap),
-            Row(
-              children: <Widget>[
-                Expanded(
-                  child: _buildOverviewStatCell(
-                    t.video_stat_total_videos,
-                    overview.total,
-                    tokens,
-                  ),
-                ),
-                Expanded(
-                  child: _buildOverviewStatCell(
-                    t.video_stat_unfinished,
-                    overview.unfinished,
-                    tokens,
-                  ),
-                ),
-                Expanded(
-                  child: _buildOverviewStatCell(
-                    t.video_stat_recent_imports,
-                    overview.recentImports,
-                    tokens,
-                  ),
-                ),
-              ],
+            StatContributionHeatmap(
+              model: model,
+              baseColor: tokens.surfaces.primary,
+              emptyColor: tokens.surfaces.card,
+              onTap: _openStatistics,
             ),
           ],
         ),
       ),
-    );
-  }
-
-  Widget _buildOverviewStatCell(
-    String label,
-    int value,
-    HibikiDesignTokens tokens,
-  ) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        Text('$value', style: tokens.type.pageTitle),
-        SizedBox(height: tokens.spacing.gap / 2),
-        Text(
-          label,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: tokens.type.metadata,
-        ),
-      ],
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -11,6 +11,7 @@ import 'package:hibiki/media.dart';
 import 'package:hibiki/pages.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki/src/epub/epub_importer.dart';
+import 'package:hibiki/src/utils/components/stat_contribution_heatmap.dart';
 import 'package:hibiki/src/media/audiobook/audiobook_import_dialog.dart';
 import 'package:hibiki/src/media/audiobook/book_import_dialog.dart';
 import 'package:hibiki/src/media/drag_drop/card_drop_registry.dart';
@@ -203,6 +204,10 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
   Map<int, MediaCollectionRow> _collectionsById =
       const <int, MediaCollectionRow>{};
   Map<String, int> _primaryCollectionByEntry = const <String, int>{};
+
+  /// 每日阅读字数（dateKey → charactersRead 之和），驱动顶部概览的阅读热力图
+  /// （GitHub 式）。与折叠映射同批 [_loadShelfMaps] 预取。
+  Map<String, int> _readingCharsByDay = const <String, int>{};
   RemoteBookClient? _remoteBookClient;
 
   /// 正在下载中的远端书（key = book.title）。值为进度分数 0..1；收到首个
@@ -523,6 +528,15 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     _epubImportedAtByKey = <String, int>{
       for (final EpubBookRow r in epubRows) r.bookKey: r.importedAt,
     };
+    // 每日阅读字数聚合（dateKey → sum charactersRead），供顶部阅读热力图。
+    final List<ReadingStatisticRow> readingRows =
+        await appModel.database.getAllReadingStatistics();
+    final Map<String, int> readingCharsByDay = <String, int>{};
+    for (final ReadingStatisticRow r in readingRows) {
+      readingCharsByDay[r.dateKey] =
+          (readingCharsByDay[r.dateKey] ?? 0) + r.charactersRead;
+    }
+    _readingCharsByDay = readingCharsByDay;
     _memberSortIndex = memberSortIndex;
     _collectionsById = <int, MediaCollectionRow>{
       for (final MediaCollectionRow c in collections) c.id: c,
@@ -750,12 +764,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
       (MediaItem item) =>
           _lastReadAtByBookKey[_parseBookKey(item.mediaIdentifier)] ?? 0,
     );
-    final Widget stats = _buildShelfOverviewStats(
-      total: libraryTotal,
-      reading: tally.reading,
-      finished: tally.finished,
-      tokens: tokens,
-    );
+    final Widget stats = _buildReadingHeatmapCard(tokens);
     final Widget? heroCard =
         hero == null ? null : _buildContinueReadingHero(hero, tokens);
     return Padding(
@@ -862,28 +871,14 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     );
   }
 
-  /// 书库概览统计三格：总数 / 在读 / 读完。
-  Widget _buildShelfOverviewStats({
-    required int total,
-    required int reading,
-    required int finished,
-    required HibikiDesignTokens tokens,
-  }) {
-    Widget cell(String label, int value) => Expanded(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Text('$value', style: tokens.type.pageTitle),
-              SizedBox(height: tokens.spacing.gap / 2),
-              Text(
-                label,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: tokens.type.metadata,
-              ),
-            ],
-          ),
-        );
+  /// 顶部阅读活动热力图卡（GitHub 式贡献图）：按每日阅读字数 [_readingCharsByDay]
+  /// 铺最近数周方格，整卡可点开完整阅读统计页。取代旧的「总数/在读/读完」三格状态
+  /// 计数——那是状态而非统计（用户反馈），热力图直观展示阅读活跃度。
+  Widget _buildReadingHeatmapCard(HibikiDesignTokens tokens) {
+    final StatHeatmapModel model = buildStatHeatmap(
+      valueByDateKey: _readingCharsByDay,
+      now: DateTime.now(),
+    );
     return DecoratedBox(
       decoration: ShapeDecoration(
         color: tokens.surfaces.group,
@@ -898,14 +893,13 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Text(t.book_library_overview, style: tokens.type.sectionLabel),
+            Text(t.reading_activity, style: tokens.type.sectionLabel),
             SizedBox(height: tokens.spacing.gap),
-            Row(
-              children: <Widget>[
-                cell(t.video_stat_total_videos, total),
-                cell(t.shelf_stat_reading, reading),
-                cell(t.video_stat_completed, finished),
-              ],
+            StatContributionHeatmap(
+              model: model,
+              baseColor: tokens.surfaces.primary,
+              emptyColor: tokens.surfaces.card,
+              onTap: _openReadingStatistics,
             ),
           ],
         ),

--- a/hibiki/lib/src/utils/components/stat_contribution_heatmap.dart
+++ b/hibiki/lib/src/utils/components/stat_contribution_heatmap.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+import 'package:hibiki/src/pages/implementations/stat_activity.dart';
+
+/// GitHub 式「贡献热力图」的一天格子：日期键 + 当日活动值 + 强度等级。
+///
+/// [dateKey] 为 null 表示占位格（当前周里今天之后的未来日，不落在窗口内），渲染成
+/// 透明/无色，仅用于把最后一列补齐 7 行。真实日 [dateKey] 形如 `2026-06-07`，与
+/// DB 统计行同格式（[statDateKey]）。
+class StatHeatmapCell {
+  const StatHeatmapCell({
+    required this.dateKey,
+    required this.value,
+    required this.level,
+  });
+
+  final String? dateKey;
+  final int value;
+
+  /// 强度等级 0..4（0 = 无活动；4 = 最活跃）。用于映射到颜色深浅。
+  final int level;
+}
+
+/// 贡献热力图模型：按「周」分列（[weeks]，每列自上而下 周一..周日 共 7 天），
+/// 末列含今天。纯数据，供 [StatContributionHeatmap] 渲染、可单测。
+class StatHeatmapModel {
+  const StatHeatmapModel({required this.weeks, required this.maxValue});
+
+  /// 列表，每列 7 个 [StatHeatmapCell]（周一在上、周日在下）。
+  final List<List<StatHeatmapCell>> weeks;
+
+  /// 窗口内单日最大活动值（0 表示全窗口无活动）。用于等级分桶的分母。
+  final int maxValue;
+}
+
+/// 纯函数：把「日期键→活动值」映射构造成最近 [weeks] 周的贡献热力图模型。
+///
+/// - 以 [now] 所在周的周一为末列起点，向前取 [weeks] 列（每列周一..周日）。
+/// - 每天的值取自 [valueByDateKey]（缺省 0）。
+/// - 今天之后的未来日（末列里 > 今天的格子）为占位格（dateKey=null，level=0）。
+/// - 等级：value==0→0；否则按占 [StatHeatmapModel.maxValue] 的比例分 1..4 四档
+///   （>0 至少 1 档，满值 4 档），空窗口（maxValue==0）全为 0。
+StatHeatmapModel buildStatHeatmap({
+  required Map<String, int> valueByDateKey,
+  required DateTime now,
+  int weeks = 17,
+}) {
+  final DateTime today = DateTime(now.year, now.month, now.day);
+  // 本周周一（DateTime.weekday: 周一=1..周日=7）。
+  final DateTime thisMonday =
+      today.subtract(Duration(days: today.weekday - DateTime.monday));
+  final DateTime firstMonday =
+      thisMonday.subtract(Duration(days: (weeks - 1) * 7));
+
+  int maxValue = 0;
+  final List<List<({String? dateKey, int value, DateTime day})>> raw =
+      <List<({String? dateKey, int value, DateTime day})>>[];
+  for (int w = 0; w < weeks; w++) {
+    final List<({String? dateKey, int value, DateTime day})> col =
+        <({String? dateKey, int value, DateTime day})>[];
+    for (int d = 0; d < 7; d++) {
+      final DateTime day = firstMonday.add(Duration(days: w * 7 + d));
+      if (day.isAfter(today)) {
+        col.add((dateKey: null, value: 0, day: day));
+        continue;
+      }
+      final String key = statDateKey(day);
+      final int value = valueByDateKey[key] ?? 0;
+      if (value > maxValue) maxValue = value;
+      col.add((dateKey: key, value: value, day: day));
+    }
+    raw.add(col);
+  }
+
+  int levelOf(int value) {
+    if (value <= 0 || maxValue <= 0) return 0;
+    // 比例分桶：(0,0.25]→1, (0.25,0.5]→2, (0.5,0.75]→3, (0.75,1]→4。
+    final double frac = value / maxValue;
+    if (frac > 0.75) return 4;
+    if (frac > 0.5) return 3;
+    if (frac > 0.25) return 2;
+    return 1;
+  }
+
+  final List<List<StatHeatmapCell>> cols = <List<StatHeatmapCell>>[
+    for (final List<({String? dateKey, int value, DateTime day})> col in raw)
+      <StatHeatmapCell>[
+        for (final ({String? dateKey, int value, DateTime day}) c in col)
+          StatHeatmapCell(
+            dateKey: c.dateKey,
+            value: c.value,
+            level: c.dateKey == null ? 0 : levelOf(c.value),
+          ),
+      ],
+  ];
+  return StatHeatmapModel(weeks: cols, maxValue: maxValue);
+}
+
+/// GitHub 式贡献热力图组件：自适应可用宽度铺 [StatHeatmapModel.weeks] 列小方格，
+/// 颜色由 [baseColor] 按等级 0..4 加深。整块可 [onTap]（打开完整统计页）。
+///
+/// 用 [CustomPaint]（含 [RepaintBoundary]）一次绘制所有格子，避免上百个 widget 参与
+/// 布局/重绘（与阅读设置抽屉色卡缺 RepaintBoundary 卡顿同类考量）。
+class StatContributionHeatmap extends StatelessWidget {
+  const StatContributionHeatmap({
+    required this.model,
+    required this.baseColor,
+    required this.emptyColor,
+    super.key,
+    this.onTap,
+    this.cell = 12,
+    this.spacing = 3,
+  });
+
+  final StatHeatmapModel model;
+  final Color baseColor;
+
+  /// level 0（无活动）格子的底色（通常取一个很浅的中性色）。
+  final Color emptyColor;
+  final VoidCallback? onTap;
+
+  /// 单格边长（逻辑像素，自然尺寸）。实际渲染由外层 [FittedBox] 按可用宽度等比
+  /// 缩小（不放大），故这是「上限」尺寸。
+  final double cell;
+  final double spacing;
+
+  @override
+  Widget build(BuildContext context) {
+    final int cols = model.weeks.length;
+    if (cols == 0) return const SizedBox.shrink();
+    // 固定自然尺寸（不依赖 LayoutBuilder——本组件会被放进 IntrinsicHeight 的概览条
+    // 里，而 LayoutBuilder 不支持 intrinsic 测量会抛异常）。宽度不足时由 FittedBox
+    // 等比缩小，宽屏保持自然尺寸左对齐。
+    final double natW = cols * cell + (cols - 1) * spacing;
+    final double natH = 7 * cell + 6 * spacing;
+    Widget content = FittedBox(
+      fit: BoxFit.scaleDown,
+      alignment: Alignment.centerLeft,
+      child: SizedBox(
+        width: natW,
+        height: natH,
+        child: RepaintBoundary(
+          child: CustomPaint(
+            painter: _HeatmapPainter(
+              model: model,
+              baseColor: baseColor,
+              emptyColor: emptyColor,
+              cell: cell,
+              spacing: spacing,
+            ),
+          ),
+        ),
+      ),
+    );
+    if (onTap != null) {
+      content = InkWell(
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(Radius.circular(12)),
+        child: content,
+      );
+    }
+    return content;
+  }
+}
+
+class _HeatmapPainter extends CustomPainter {
+  _HeatmapPainter({
+    required this.model,
+    required this.baseColor,
+    required this.emptyColor,
+    required this.cell,
+    required this.spacing,
+  });
+
+  final StatHeatmapModel model;
+  final Color baseColor;
+  final Color emptyColor;
+  final double cell;
+  final double spacing;
+
+  /// 等级 0..4 → 颜色。0 用 [emptyColor]；1..4 用 [baseColor] 按不透明度加深。
+  Color _colorFor(int level) {
+    switch (level) {
+      case 0:
+        return emptyColor;
+      case 1:
+        return baseColor.withValues(alpha: 0.35);
+      case 2:
+        return baseColor.withValues(alpha: 0.55);
+      case 3:
+        return baseColor.withValues(alpha: 0.78);
+      default:
+        return baseColor;
+    }
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint paint = Paint()..style = PaintingStyle.fill;
+    final Radius radius = Radius.circular(cell * 0.25);
+    for (int w = 0; w < model.weeks.length; w++) {
+      final List<StatHeatmapCell> col = model.weeks[w];
+      final double x = w * (cell + spacing);
+      for (int d = 0; d < col.length; d++) {
+        final StatHeatmapCell c = col[d];
+        // 占位格（未来日）不绘制，留白。
+        if (c.dateKey == null) continue;
+        final double y = d * (cell + spacing);
+        paint.color = _colorFor(c.level);
+        canvas.drawRRect(
+          RRect.fromRectAndRadius(
+            Rect.fromLTWH(x, y, cell, cell),
+            radius,
+          ),
+          paint,
+        );
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_HeatmapPainter old) =>
+      old.model != model ||
+      old.baseColor != baseColor ||
+      old.emptyColor != emptyColor ||
+      old.cell != cell ||
+      old.spacing != spacing;
+}

--- a/hibiki/test/media/video_library_overview_test.dart
+++ b/hibiki/test/media/video_library_overview_test.dart
@@ -245,4 +245,54 @@ void main() {
     expect(m['A'], DateTime(2026, 3, 1));
     expect(m.containsKey('B'), isFalse);
   });
+
+  group('pickRemoteContinueEntry (#3 远端继续观看)', () {
+    RemoteContinueEntry rc(
+      String id, {
+      int positionMs = 0,
+      bool completed = false,
+      int updatedAtMs = 0,
+    }) =>
+        RemoteContinueEntry(
+          id: id,
+          positionMs: positionMs,
+          completed: completed,
+          updatedAtMs: updatedAtMs,
+        );
+
+    test('空列表 → null', () {
+      expect(pickRemoteContinueEntry(const <RemoteContinueEntry>[]), isNull);
+    });
+
+    test('无断点 / 已看完的都排除', () {
+      expect(
+        pickRemoteContinueEntry(<RemoteContinueEntry>[
+          rc('a', positionMs: 0, updatedAtMs: 100), // 无断点
+          rc('b', positionMs: 500, completed: true, updatedAtMs: 200), // 已看完
+        ]),
+        isNull,
+      );
+    });
+
+    test('有断点未看完中取 updatedAtMs 最新者', () {
+      final RemoteContinueEntry? best = pickRemoteContinueEntry(
+        <RemoteContinueEntry>[
+          rc('old', positionMs: 100, updatedAtMs: 1000),
+          rc('newest', positionMs: 200, updatedAtMs: 3000),
+          rc('mid', positionMs: 300, updatedAtMs: 2000),
+        ],
+      );
+      expect(best?.id, 'newest');
+    });
+
+    test('updatedAtMs 全 0（host 未记时间戳）仍取第一个有断点未看完的', () {
+      final RemoteContinueEntry? best = pickRemoteContinueEntry(
+        <RemoteContinueEntry>[
+          rc('a', positionMs: 100),
+          rc('b', positionMs: 200),
+        ],
+      );
+      expect(best?.id, 'a');
+    });
+  });
 }

--- a/hibiki/test/pages/home_video_overview_wide_test.dart
+++ b/hibiki/test/pages/home_video_overview_wide_test.dart
@@ -14,6 +14,7 @@ import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/home_video_page.dart';
 import 'package:hibiki/src/platform/platform_providers.dart';
 import 'package:hibiki/src/platform/platform_services.dart';
+import 'package:hibiki/src/utils/components/stat_contribution_heatmap.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -24,7 +25,7 @@ import '../helpers/test_platform_services.dart';
 /// 顶部概览条宽窗分支曾用裸 Row(crossAxisAlignment: stretch)——它在
 /// SliverToBoxAdapter 的无界高度下强制子项无限高，首帧即抛
 /// `BoxConstraints forces an infinite height`。修复 = IntrinsicHeight 收界。
-/// 本测试锁死：宽窗 + hero 候选渲染不抛、且 hero 与统计三格真实可见。
+/// 本测试锁死：宽窗 + hero 候选渲染不抛、且 hero 与观看活动热力图真实可见。
 void main() {
   final TestWidgetsFlutterBinding binding =
       TestWidgetsFlutterBinding.ensureInitialized();
@@ -105,8 +106,9 @@ void main() {
 
     expect(tester.takeException(), isNull);
     expect(find.text(t.video_continue_watching), findsOneWidget);
-    expect(find.text(t.video_library_overview), findsOneWidget);
-    expect(find.text(t.video_stat_unfinished), findsOneWidget);
+    // 概览右侧改为「观看活动」热力图（取代旧的总数/未完成/近7天三格）。
+    expect(find.text(t.video_watch_activity), findsOneWidget);
+    expect(find.byType(StatContributionHeatmap), findsOneWidget);
   });
 
   testWidgets('窄窗 + 续看候选：纵向堆叠分支同样不抛', (WidgetTester tester) async {

--- a/hibiki/test/pages/home_video_refresh_remote_guard_test.dart
+++ b/hibiki/test/pages/home_video_refresh_remote_guard_test.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 根因守卫（BUG-872：互联远端视频看完返回即重拉列表）。
+///
+/// 症状——连远端视频，点进去看一段（>0 秒）再返回，远端视频卡整片闪空、重新联网
+/// 拉取。真根因：从播放器返回走 `_open()` → `_refresh()`，而旧 `_refresh()` 无条件
+/// `_remoteFuture = _loadRemoteVideos()` 连带重换远端 future；远端那层 FutureBuilder
+/// 无缓存顶值，future 一换 snapshot.data 归 null → 远端卡清空重拉。远端清单不因本地
+/// 播放而变，此重拉纯属多余。
+///
+/// 修复——`_refresh({bool remote = false})` 默认只刷本地；只有真正改变远端来源的
+/// `_openManageSources` 传 `remote: true`；远端显式刷新仍由下拉 `_pullToRefresh` 承担。
+///
+/// HomeVideoPage 运行时表面在 headless 测试里无法稳定挂载（AppModel 未初始化），故
+/// 这里用源码扫描锁住不变式：`_refresh` 的远端重拉必须门控在 `remote` 之后，且从
+/// 播放器返回的刷新是本地 `_refresh()`（不带 `remote: true`）。
+void main() {
+  final String src = File(
+    'lib/src/pages/implementations/home_video_page.dart',
+  ).readAsStringSync();
+
+  test('_refresh 带 remote 开关且默认关（本地刷新不重拉远端）', () {
+    expect(
+      src.contains('void _refresh({bool remote = false})'),
+      isTrue,
+      reason: '_refresh 必须有 remote 开关且默认 false，避免本地刷新连带重拉远端',
+    );
+  });
+
+  test('_refresh 内远端重拉必须门控在 remote 之后', () {
+    final int start = src.indexOf('void _refresh({bool remote = false})');
+    expect(start, isNonNegative);
+    // 截取 _refresh 方法体（到下一个方法/文档注释起始）。
+    final int bodyEnd = src.indexOf('/// 下拉刷新', start);
+    expect(bodyEnd, greaterThan(start),
+        reason: '_refresh 方法体后应紧接 _pullToRefresh 文档注释');
+    final String body = src.substring(start, bodyEnd);
+    expect(
+      body.contains('if (remote) _remoteFuture = _loadRemoteVideos();'),
+      isTrue,
+      reason: '_refresh 里远端重拉必须门控在 remote 之后（默认路径不重拉）',
+    );
+    // 断言方法体里没有无条件（未门控）的远端重拉。
+    expect(
+      body.contains('\n      _remoteFuture = _loadRemoteVideos();'),
+      isFalse,
+      reason: '_refresh 不得有无条件的 _remoteFuture 重换（回归即恢复闪空重拉）',
+    );
+  });
+
+  test('从播放器返回后的刷新是本地 _refresh()（不带 remote）', () {
+    // _open() 返回后刷新继续观看 hero / 进度，只需本地。
+    expect(
+      src.contains('从播放器返回后刷新'),
+      isTrue,
+      reason: '_open 返回后应有本地刷新注释锚点',
+    );
+    final int anchor = src.indexOf('从播放器返回后刷新');
+    final String tail = src.substring(anchor, anchor + 300);
+    expect(
+      tail.contains('if (mounted) _refresh();'),
+      isTrue,
+      reason: '播放器返回只刷本地，不得传 remote: true',
+    );
+    expect(
+      tail.contains('_refresh(remote: true)'),
+      isFalse,
+      reason: '播放器返回不得重拉远端清单',
+    );
+  });
+
+  test('只有 _openManageSources 传 remote: true（改变远端来源才重拉）', () {
+    expect(
+      src.contains('if (mounted) _refresh(remote: true);'),
+      isTrue,
+      reason: '管理互联源后必须重拉远端清单（remote: true）',
+    );
+    // 全文件里 remote: true 的刷新调用应恰好 1 处（仅管理源）。
+    final int count =
+        RegExp(r'_refresh\(remote: true\)').allMatches(src).length;
+    expect(count, 1, reason: '当前仅管理互联源需要 remote: true 刷新');
+  });
+}

--- a/hibiki/test/utils/misc/platform_layout_test.dart
+++ b/hibiki/test/utils/misc/platform_layout_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
 import 'package:hibiki/src/utils/misc/platform_utils.dart';
 
 void main() {
@@ -365,5 +366,52 @@ void main() {
         expect(tester.getTopLeft(find.byKey(childKey)).dy, 0);
       },
     );
+  });
+
+  group('video shelf card layout (BUG-873)', () {
+    // 手机窄屏视频卡不得再退化成「1 列铺满整屏」。视频页 targetWidth 从硬编码 240
+    // 改成书架同款响应式 readerShelfGridExtentForWidth，必须让手机（宽<600）出 ≥2 列。
+    // 卡宽内边距按视频页构建：availableWidth = maxWidth - tokens.spacing.card*2。
+    // 这里用保守的 12*2 内边距（tokens.spacing.card 实际 16，减得更多列数只会更多，
+    // 用 12 是列数下界的安全估计）。
+    double phoneAvailable(double maxWidth) => maxWidth - 12 * 2;
+
+    test('regression: hardcoded targetWidth 240 yielded 1 column on phone', () {
+      // 复现旧行为：手机可用宽下 240 目标宽只算出 1 列（铺满整屏 = 卡片过大）。
+      final layout = unifiedShelfCardLayout(
+        availableWidth: phoneAvailable(384),
+        targetWidth: 240,
+      );
+      expect(layout.columns, 1, reason: '旧硬编码 240 在手机窄屏退化为 1 列');
+    });
+
+    test('responsive target gives >=2 columns across phone widths', () {
+      for (final double w in <double>[360, 384, 393, 412, 480, 599]) {
+        final layout = unifiedShelfCardLayout(
+          availableWidth: phoneAvailable(w),
+          targetWidth: readerShelfGridExtentForWidth(w),
+        );
+        expect(
+          layout.columns,
+          greaterThanOrEqualTo(2),
+          reason: '手机宽 $w 应出至少 2 列（targetWidth='
+              '${readerShelfGridExtentForWidth(w)}）',
+        );
+      }
+    });
+
+    test('wide screens still collapse to comfortable multi-column', () {
+      // 宽屏不受影响：仍按断点收敛列数（不会因目标宽变小而爆出过多超小卡）。
+      final tablet = unifiedShelfCardLayout(
+        availableWidth: phoneAvailable(840),
+        targetWidth: readerShelfGridExtentForWidth(840),
+      );
+      expect(tablet.columns, greaterThanOrEqualTo(3));
+      final desktop = unifiedShelfCardLayout(
+        availableWidth: phoneAvailable(1440),
+        targetWidth: readerShelfGridExtentForWidth(1440),
+      );
+      expect(desktop.columns, greaterThanOrEqualTo(5));
+    });
   });
 }

--- a/hibiki/test/widgets/stat_contribution_heatmap_test.dart
+++ b/hibiki/test/widgets/stat_contribution_heatmap_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/stat_activity.dart';
+import 'package:hibiki/src/utils/components/stat_contribution_heatmap.dart';
+
+/// 贡献热力图纯模型 [buildStatHeatmap] 的单测：窗口/周对齐、等级分桶、未来日占位。
+void main() {
+  group('buildStatHeatmap', () {
+    // 固定「现在」= 2026-07-15（周三），避免依赖真实时钟。
+    final DateTime now = DateTime(2026, 7, 15, 10, 30);
+
+    test('列数 = weeks，每列 7 天（周一..周日）', () {
+      final StatHeatmapModel m = buildStatHeatmap(
+        valueByDateKey: const <String, int>{},
+        now: now,
+        weeks: 10,
+      );
+      expect(m.weeks.length, 10);
+      for (final List<StatHeatmapCell> col in m.weeks) {
+        expect(col.length, 7);
+      }
+      expect(m.maxValue, 0);
+    });
+
+    test('空数据全为 level 0', () {
+      final StatHeatmapModel m = buildStatHeatmap(
+        valueByDateKey: const <String, int>{},
+        now: now,
+        weeks: 4,
+      );
+      for (final List<StatHeatmapCell> col in m.weeks) {
+        for (final StatHeatmapCell c in col) {
+          expect(c.level, 0);
+        }
+      }
+    });
+
+    test('末列今天之后是未来占位格（dateKey=null, level 0）', () {
+      final StatHeatmapModel m = buildStatHeatmap(
+        valueByDateKey: const <String, int>{},
+        now: now,
+        weeks: 3,
+      );
+      final List<StatHeatmapCell> lastCol = m.weeks.last;
+      // 2026-07-15 是周三（weekday=3）→ 周一..周三是过去/今天（非 null），
+      // 周四..周日是未来（null 占位）。
+      expect(lastCol[0].dateKey, isNotNull); // 周一
+      expect(lastCol[2].dateKey, isNotNull); // 周三=今天
+      expect(lastCol[3].dateKey, isNull); // 周四=未来
+      expect(lastCol[6].dateKey, isNull); // 周日=未来
+    });
+
+    test('今天的值落进末列对应行并计入 maxValue', () {
+      final String todayKey = statDateKey(DateTime(2026, 7, 15));
+      final StatHeatmapModel m = buildStatHeatmap(
+        valueByDateKey: <String, int>{todayKey: 5000},
+        now: now,
+        weeks: 3,
+      );
+      expect(m.maxValue, 5000);
+      final StatHeatmapCell todayCell = m.weeks.last[2]; // 周三
+      expect(todayCell.dateKey, todayKey);
+      expect(todayCell.value, 5000);
+      expect(todayCell.level, 4); // 唯一非零值 = 满值 → 最高档
+    });
+
+    test('等级按占 maxValue 比例分 1..4 四档', () {
+      // 四天不同强度：max=100 → 10%→1, 40%→2, 60%→3, 100%→4。
+      final DateTime d1 = DateTime(2026, 7, 13); // 周一
+      final DateTime d2 = DateTime(2026, 7, 14); // 周二
+      final DateTime d3 = DateTime(2026, 7, 15); // 周三=今天
+      final DateTime d0 = DateTime(2026, 7, 12); // 上周日
+      final StatHeatmapModel m = buildStatHeatmap(
+        valueByDateKey: <String, int>{
+          statDateKey(d0): 100,
+          statDateKey(d1): 10,
+          statDateKey(d2): 40,
+          statDateKey(d3): 60,
+        },
+        now: now,
+        weeks: 3,
+      );
+      expect(m.maxValue, 100);
+      int levelForKey(String key) {
+        for (final List<StatHeatmapCell> col in m.weeks) {
+          for (final StatHeatmapCell c in col) {
+            if (c.dateKey == key) return c.level;
+          }
+        }
+        fail('key $key not found in window');
+      }
+
+      expect(levelForKey(statDateKey(d0)), 4); // 100%
+      expect(levelForKey(statDateKey(d1)), 1); // 10%
+      expect(levelForKey(statDateKey(d2)), 2); // 40%
+      expect(levelForKey(statDateKey(d3)), 3); // 60%
+    });
+
+    test('窗口外的旧日期不影响（只取最近 weeks 周）', () {
+      // 20 周前的一天不应出现在 4 周窗口里。
+      final String ancient = statDateKey(DateTime(2026, 2, 1));
+      final StatHeatmapModel m = buildStatHeatmap(
+        valueByDateKey: <String, int>{ancient: 9999},
+        now: now,
+        weeks: 4,
+      );
+      expect(m.maxValue, 0); // 窗口内无数据
+      for (final List<StatHeatmapCell> col in m.weeks) {
+        for (final StatHeatmapCell c in col) {
+          expect(c.dateKey == ancient, isFalse);
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
用户反馈的互联视频四点，全部落地：

## ① 远端视频看完返回即重拉列表（BUG-872）✅
根因：`_open()` 返回走 `_refresh()`，旧 `_refresh` 无条件重换 `_remoteFuture` 发远端网络请求；远端 `FutureBuilder` 无缓存顶值 → 闪空重拉。修复：`_refresh({bool remote=false})` 默认只刷本地，仅 `_openManageSources` 传 `remote:true`。

## ② 手机端视频卡片过大（BUG-873）✅
根因：`unifiedShelfCardLayout(targetWidth:240)` 硬编码，手机窄屏只算 1 列铺满。修复：改用书架同款响应式 `readerShelfGridExtentForWidth`（手机<600→150 出≥2列）；卡高随卡宽按 16:9 联动 `_videoCardExtent`（240宽=218向后兼容）。

## ④ 概览条改统计（用户拍板：GitHub 式热力图）✅
「总数/在读/已完成」「总数/未完成/近7天导入」是状态非统计。改成各自的活动热力图：
- 书架页顶部 → 阅读活动热力图（每日阅读字数）
- 视频页顶部 → 观看活动热力图（每日观看时长）
- 整块点击打开对应完整统计页
- 新增 `StatContributionHeatmap`（纯模型 + FittedBox 自适应 CustomPaint，避开 IntrinsicHeight 下 LayoutBuilder 抛异常）

## ③ 继续观看含远端 ✅
本地续播 hero 只认本地进度，纯流播远端结构性进不了。修复：新增纯函数 `pickRemoteContinueEntry`（不动已测的 `computeVideoLibraryOverview`），页面层按 host 端 `positionUpdatedAtMs` 与本地 hero 的 `heroLastWatched` 比较取胜者，远端胜则渲染 `_buildContinueHeroRemote`（远端封面 + host 断点，点击 `_openRemote` 流播）。本地空但有远端续播候选时也显示概览。

## 测试
- `home_video_refresh_remote_guard_test`（#1 源码守卫）
- `platform_layout_test` 新增 group（#2 手机≥2列守卫）
- `stat_contribution_heatmap_test`（#4 热力图纯模型 6 项）+ 更新概览宽屏守卫
- `video_library_overview_test` 新增 `pickRemoteContinueEntry` 4 项（#3）
- 全量 `flutter analyze` No issues；media/widgets/utils 3567 项 + pages 相关全绿
- (注：test/pages 有 2 个 popup JS 桩测试红是**基底落后 origin/develop** 的继承失败，上游 popup.js 已修，与本 PR 无关)

## 待真机
UI 改动（卡片大小、热力图、远端返回不闪、远端续播卡）最终视觉/交互需真机验收。

🤖 Generated with [Claude Code](https://claude.com/claude-code)