### PR TITLE
fix(audiobook): BUG-872 歌词模式重开书恢复当前行而非跳回开头

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 850 条。点号进各自文件。
+> 共 851 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-872](bugs/BUG-872-lyrics-restore-position.md) | ✅ | ✅ | 歌词模式重开书高亮跳回开头 |
 | [BUG-869](bugs/BUG-869-fscx-line-level-squash.md) | ✅ | ✅ | 静态 \fscx/\fscy 被按行级「最后值生效」建模，句尾/前缀压扁标签把整行压扁 |
 | [BUG-868](bugs/BUG-868-reader-content-ready-timeout-pagination-wedge.md) | ✅ | ✅ | 开EPUB偶发卡住·内容就绪兜底超时漏复位导航态致翻页永久失效 |
 | [BUG-867](bugs/BUG-867-ass-fontname-gdi-fullname.md) | ✅ | ✅ | 装了字幕指定字体 hibiki 仍用回退字体（ASS Fontname=GDI 全名解析缺失） |

--- a/docs/bugs/BUG-872-lyrics-restore-position.md
+++ b/docs/bugs/BUG-872-lyrics-restore-position.md
@@ -1,0 +1,6 @@
+## BUG-872 · 歌词模式重开书高亮跳回开头
+- **报告**：2026-07-18（用户：）
+- **真实性**：✅ 真 bug。根因 `packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart:463`（`load()` seek 到保存位置后未重算 `_currentCue`）＋ `hibiki/lib/src/pages/implementations/reader_hibiki/lyrics.part.dart:113` 歌词窗口用依赖 `_currentCue` 的 `allBookCueIdx`。
+- **[x] ① 已修复** — `load()` 恢复位置后 `_currentCue` 仍为 null（只由 125ms 播放 tick 的 `_updateCurrentCue` 填充，且 `idx<0` 裸 return），故重开书暂停态下 `allBookCueIdx == -1`；歌词窗 `LyricsCueWindow.select` 把 -1 clamp 成 0 = 跳回第一句，播放首个 tick 后才跳到正确行。播放器**位置**已正确恢复到 `savedMs`，`cueAtCurrentPositionInBook()` 立即可算出正确 cue（悬浮字幕 `displayCueForFloatingLyric` 早已用同款位置重算法回避这坑）。修复：新增位置驱动的 `allBookCueIdxAtPosition`（live cue 优先，null 时按播放器当前位置重算），歌词入场索引与窗口选择改用它。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/audiobook/lyrics_restore_position_test.dart`：用 fake just_audio 平台以保存位置 `positionMs` load（暂停态、无播放 tick），断言 `allBookCueIdx == -1`（bug 前置条件：`_currentCue` 未填充）而 `allBookCueIdxAtPosition` 返回该位置对应 cue 的正确 allBook 索引。
+- **备注**：与 in-flight PR#205（BUG-870/871 触控板滚动）避号，改用 872。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/lyrics.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/lyrics.part.dart
@@ -110,9 +110,12 @@ extension _ReaderLyrics on _ReaderHibikiPageState {
           _audiobookController!.setChapterCues(allCues);
         }
         _lyricsEntryChapter = _currentChapter;
+        // BUG-872：用 allBookCueIdxAtPosition（位置优先）而非 allBookCueIdx，
+        // 重开书暂停态下 _currentCue 尚未被播放 tick 填充，allBookCueIdx==-1 会
+        // 把入场高亮 clamp 回第一句；按已恢复的播放器位置取正确 cue。
         _lyricsEntryCueIndex =
             _audiobookController!.allBookCuesSnapshot.isNotEmpty
-                ? _audiobookController!.allBookCueIdx
+                ? _audiobookController!.allBookCueIdxAtPosition
                 : _audiobookController!.currentCueIdx;
         await _loadLyricsPage();
         await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -140,8 +143,11 @@ extension _ReaderLyrics on _ReaderHibikiPageState {
     final LyricsCueWindow cueWindow = LyricsCueWindow.select(
       allBookCues: ctrl.allBookCuesSnapshot,
       chapterCues: ctrl.chapterCuesSnapshot,
-      allBookIndex:
-          ctrl.allBookCueIdx >= 0 ? ctrl.allBookCueIdx : _lyricsEntryCueIndex,
+      // BUG-872：allBookCueIdxAtPosition 在 _currentCue 未填充时按播放器位置回退，
+      // 重开书恢复歌词页时窗口锚到已恢复的当前句而非第一句。
+      allBookIndex: ctrl.allBookCueIdxAtPosition >= 0
+          ? ctrl.allBookCueIdxAtPosition
+          : _lyricsEntryCueIndex,
       chapterIndex:
           ctrl.currentCueIdx >= 0 ? ctrl.currentCueIdx : _lyricsEntryCueIndex,
     );

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -1502,8 +1502,10 @@ extension _ReaderWebView on _ReaderHibikiPageState {
             _audiobookController!.setChapterCues(allCues);
           }
           _lyricsEntryChapter = _currentChapter;
+          // BUG-872：位置优先索引，避免暂停态重建时 _currentCue 未填充导致
+          // 入场高亮 clamp 回第一句。
           _lyricsEntryCueIndex = allCues.isNotEmpty
-              ? _audiobookController!.allBookCueIdx
+              ? _audiobookController!.allBookCueIdxAtPosition
               : _audiobookController!.currentCueIdx;
           _loadLyricsPage();
         } else {

--- a/hibiki/test/media/audiobook/lyrics_restore_position_test.dart
+++ b/hibiki/test/media/audiobook/lyrics_restore_position_test.dart
@@ -1,0 +1,257 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+import 'package:just_audio_platform_interface/just_audio_platform_interface.dart';
+
+// BUG-872 contract guard — 歌词模式重开书高亮跳回开头。
+//
+// Root cause: AudiobookPlayerController.load() seeks the player to the saved
+// position but leaves the derived _currentCue stale. _currentCue is only set by
+// the 125ms playback tick (_updateCurrentCue), and load() commonly emits a
+// transient posMs~=0 first, so on a paused reopen _currentCue lands on the
+// FIRST cue (allBookCueIdx == 0). The old lyrics window read allBookCueIdx
+// directly, so it opened on line 0; the first real play tick then jumped to the
+// correct line — exactly the reported symptom.
+//
+// The player *position* is restored correctly to savedMs, so
+// cueAtCurrentPositionInBook() is the authoritative source at restore time. The
+// fix adds allBookCueIdxAtPosition (purely position-driven, independent of the
+// tick-updated _currentCue) and points the lyrics window at it.
+//
+// This guard pins the controller contract: after loading to a saved position
+// while paused, allBookCueIdxAtPosition resolves to the cue spanning that
+// position (not the stale line-0 that allBookCueIdx reports).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  AudioCue cue(int startMs) => AudioCue()
+    ..id = startMs
+    ..bookKey = 'book'
+    ..chapterHref = 'chapter'
+    ..sentenceIndex = startMs ~/ 1000
+    ..textFragmentId = 'cue-$startMs'
+    ..text = 'cue $startMs'
+    ..startMs = startMs
+    ..endMs = startMs + 1000
+    ..audioFileIndex = 0;
+
+  Audiobook ab(String key) => Audiobook()
+    ..bookKey = key
+    ..audioPaths = const <String>[]
+    ..audioRoot = null
+    ..alignmentFormat = 'srt'
+    ..alignmentPath = '';
+
+  File makeFile(String name) {
+    final File f = File('${Directory.systemTemp.path}/$name');
+    if (!f.existsSync()) f.writeAsBytesSync(const <int>[0]);
+    addTearDown(() {
+      if (f.existsSync()) f.deleteSync();
+    });
+    return f;
+  }
+
+  void installPlatform() {
+    const MethodChannel sessionCh =
+        MethodChannel('com.ryanheise.audio_session');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(sessionCh, (_) async => null);
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(sessionCh, null);
+    });
+    final JustAudioPlatform prev = JustAudioPlatform.instance;
+    JustAudioPlatform.instance = _FakePlatform();
+    addTearDown(() => JustAudioPlatform.instance = prev);
+  }
+
+  Future<AudiobookPlayerController> loadedAt({
+    required int positionMs,
+    required List<AudioCue> cues,
+    required String audioName,
+  }) async {
+    installPlatform();
+    final AudiobookPlayerController controller = AudiobookPlayerController();
+    addTearDown(controller.dispose);
+    controller.setAllBookCues(cues);
+    controller.setChapterCues(cues);
+    await controller.load(
+      audiobook: ab('a'),
+      audioFiles: <File>[makeFile(audioName)],
+      initialPositionMs: positionMs,
+    );
+    return controller;
+  }
+
+  test(
+    'reopen at a saved position: allBookCueIdxAtPosition resolves the current '
+    'line even though the live index is a stale line-0',
+    () async {
+      final AudiobookPlayerController controller = await loadedAt(
+        positionMs: 1000,
+        cues: <AudioCue>[cue(0), cue(1000), cue(2000)],
+        audioName: 'hibiki-lyrics-restore-1.mp3',
+      );
+
+      // Bug precondition: the live index is NOT the saved line. A load-time
+      // transient (or an absent play tick) leaves _currentCue on the first cue
+      // (or unset), so allBookCueIdx cannot be trusted for the restore anchor.
+      expect(controller.allBookCueIdx, isNot(1),
+          reason: 'the tick-updated live index does not reflect the restored '
+              'position yet — this is why the old window jumped to the start');
+
+      // Fix: the position-driven getter reads the restored player position and
+      // maps it to the cue spanning it (cue(1000) at index 1).
+      expect(controller.allBookCueIdxAtPosition, 1,
+          reason: 'the saved position 1000ms falls inside cue(1000), whose '
+              'all-book index is 1 — the line the lyrics page must open on');
+    },
+  );
+
+  test(
+    'reopen at position 0: window anchors to the first line',
+    () async {
+      final AudiobookPlayerController controller = await loadedAt(
+        positionMs: 0,
+        cues: <AudioCue>[cue(0), cue(1000), cue(2000)],
+        audioName: 'hibiki-lyrics-restore-0.mp3',
+      );
+      expect(controller.allBookCueIdxAtPosition, 0,
+          reason: 'position 0 is inside cue(0), index 0');
+    },
+  );
+
+  test(
+    'reopen deep into the book: window anchors to the matching line',
+    () async {
+      final AudiobookPlayerController controller = await loadedAt(
+        positionMs: 2500,
+        cues: <AudioCue>[cue(0), cue(1000), cue(2000)],
+        audioName: 'hibiki-lyrics-restore-2.mp3',
+      );
+      expect(controller.allBookCueIdxAtPosition, 2,
+          reason: 'position 2500ms falls inside cue(2000) (2000..3000), '
+              'all-book index 2');
+    },
+  );
+}
+
+class _FakePlatform extends JustAudioPlatform {
+  _FakePlayer? player;
+  @override
+  Future<AudioPlayerPlatform> init(InitRequest request) async {
+    player = _FakePlayer(request.id);
+    return player!;
+  }
+
+  @override
+  Future<DisposePlayerResponse> disposePlayer(
+      DisposePlayerRequest request) async {
+    await player?.dispose(DisposeRequest());
+    return DisposePlayerResponse();
+  }
+
+  @override
+  Future<DisposeAllPlayersResponse> disposeAllPlayers(
+      DisposeAllPlayersRequest request) async {
+    await player?.dispose(DisposeRequest());
+    return DisposeAllPlayersResponse();
+  }
+}
+
+class _FakePlayer extends AudioPlayerPlatform {
+  _FakePlayer(super.id);
+  final StreamController<PlaybackEventMessage> _events =
+      StreamController<PlaybackEventMessage>.broadcast();
+
+  void emit(int ms, ProcessingStateMessage state, {required bool playing}) {
+    _events.add(PlaybackEventMessage(
+      processingState: state,
+      updateTime: DateTime.now(),
+      updatePosition: Duration(milliseconds: ms),
+      bufferedPosition: Duration(milliseconds: ms),
+      duration: const Duration(seconds: 100),
+      icyMetadata: null,
+      currentIndex: 0,
+      androidAudioSessionId: null,
+    ));
+  }
+
+  @override
+  Stream<PlaybackEventMessage> get playbackEventMessageStream => _events.stream;
+
+  @override
+  Future<LoadResponse> load(LoadRequest request) async {
+    emit(request.initialPosition?.inMilliseconds ?? 0,
+        ProcessingStateMessage.ready,
+        playing: false);
+    return LoadResponse(duration: const Duration(seconds: 100));
+  }
+
+  @override
+  Future<PauseResponse> pause(PauseRequest request) async => PauseResponse();
+  @override
+  Future<PlayResponse> play(PlayRequest request) async => PlayResponse();
+  @override
+  Future<SeekResponse> seek(SeekRequest request) async {
+    emit(request.position?.inMilliseconds ?? 0, ProcessingStateMessage.ready,
+        playing: false);
+    return SeekResponse();
+  }
+
+  @override
+  Future<SetAndroidAudioAttributesResponse> setAndroidAudioAttributes(
+          SetAndroidAudioAttributesRequest request) async =>
+      SetAndroidAudioAttributesResponse();
+  @override
+  Future<SetAutomaticallyWaitsToMinimizeStallingResponse>
+      setAutomaticallyWaitsToMinimizeStalling(
+              SetAutomaticallyWaitsToMinimizeStallingRequest request) async =>
+          SetAutomaticallyWaitsToMinimizeStallingResponse();
+  @override
+  Future<SetCanUseNetworkResourcesForLiveStreamingWhilePausedResponse>
+      setCanUseNetworkResourcesForLiveStreamingWhilePaused(
+              SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest
+                  request) async =>
+          SetCanUseNetworkResourcesForLiveStreamingWhilePausedResponse();
+  @override
+  Future<SetLoopModeResponse> setLoopMode(SetLoopModeRequest request) async =>
+      SetLoopModeResponse();
+  @override
+  Future<SetPitchResponse> setPitch(SetPitchRequest request) async =>
+      SetPitchResponse();
+  @override
+  Future<SetPreferredPeakBitRateResponse> setPreferredPeakBitRate(
+          SetPreferredPeakBitRateRequest request) async =>
+      SetPreferredPeakBitRateResponse();
+  @override
+  Future<SetShuffleModeResponse> setShuffleMode(
+          SetShuffleModeRequest request) async =>
+      SetShuffleModeResponse();
+  @override
+  Future<SetShuffleOrderResponse> setShuffleOrder(
+          SetShuffleOrderRequest request) async =>
+      SetShuffleOrderResponse();
+  @override
+  Future<SetSkipSilenceResponse> setSkipSilence(
+          SetSkipSilenceRequest request) async =>
+      SetSkipSilenceResponse();
+  @override
+  Future<SetSpeedResponse> setSpeed(SetSpeedRequest request) async =>
+      SetSpeedResponse();
+  @override
+  Future<SetVolumeResponse> setVolume(SetVolumeRequest request) async =>
+      SetVolumeResponse();
+  @override
+  Future<SetWebCrossOriginResponse> setWebCrossOrigin(
+          SetWebCrossOriginRequest request) async =>
+      SetWebCrossOriginResponse();
+  @override
+  Future<DisposeResponse> dispose(DisposeRequest request) async {
+    if (!_events.isClosed) await _events.close();
+    return DisposeResponse();
+  }
+}

--- a/packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart
+++ b/packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart
@@ -175,6 +175,27 @@ class AudiobookPlayerController extends ChangeNotifier {
     return _allBookCueIndex(allBookCues: _allBookCues, currentCue: cue);
   }
 
+  /// [allBookCueIdx] 的「位置驱动」变体：直接按 [_player] 当前位置实时重算的
+  /// cue（[cueAtCurrentPositionInBook]）映射到 allBook 索引，**不依赖**
+  /// [_currentCue]。
+  ///
+  /// BUG-872：重开书时 [load] 已把播放器 seek 回保存位置，但 [_currentCue] 由
+  /// 125ms 播放 tick（[_updateCurrentCue]）填充，且 load 期常先吐一条 posMs≈0 的
+  /// 瞬态把 [_currentCue] 定成首句（[allBookCueIdx]==0）——歌词模式入场直接用它
+  /// 就高亮跳回第一句，等首个真实 tick 才跳到正确行。播放器**位置**已恢复到
+  /// `savedMs`，故按位置重算才是权威（[cueAtCurrentPositionInBook] 内部在位置
+  /// 无命中时仍回退 [_currentCue]）。歌词入场 / 恢复用本 getter，一次性锚定，
+  /// 与悬浮字幕 [displayCueForFloatingLyric] 同源回避 tick 依赖。
+  int get allBookCueIdxAtPosition {
+    final AudioCue? cue = cueAtCurrentPositionInBook();
+    if (cue == null || _allBookCues.isEmpty) return -1;
+    final int? id = cue.id;
+    if (id != null) {
+      return _allBookCueIdToIndex[id] ?? -1;
+    }
+    return _allBookCueIndex(allBookCues: _allBookCues, currentCue: cue);
+  }
+
   // ── PR8b: Follow audio ────────────────────────────────────────────────────
 
   /// 持久化后的 Follow audio 开关。UI 监听这个 ValueNotifier 切换磁铁图标。


### PR DESCRIPTION
## 问题
用户报告：在歌词模式播放一段音频后，退出书籍再重新打开，歌词高亮不显示当前播放位置而是**跳回最开头**；一旦开始播放，下一句起位置才更新并显示正确行。与之前是否在歌词模式无关。

## 根因
`AudiobookPlayerController.load()` 重开书时已把播放器 seek 回保存位置，但派生的 `_currentCue` 仍是过期值——它只由 125ms 播放 tick（`_updateCurrentCue`，且 `idx<0` 裸 return）填充，且 load 期常先吐一条 `posMs≈0` 的瞬态把 `_currentCue` 定成**首句**（`allBookCueIdx==0`）。歌词模式入场（`lyrics.part.dart` / `webview.part.dart`）直接读 `allBookCueIdx`，于是 `LyricsCueWindow.select` 锚到第 0 句；首个真实 tick 后才跳到正确行。

播放器**位置**已正确恢复到 `savedMs`，`cueAtCurrentPositionInBook()` 才是恢复时刻的权威源（悬浮字幕 `displayCueForFloatingLyric` 早已用同款位置重算法回避这个 tick 依赖）。

## 修复
- 新增 `AudiobookPlayerController.allBookCueIdxAtPosition`：纯位置驱动，按 `cueAtCurrentPositionInBook()` 从已恢复的播放器位置映射 allBook 索引，不依赖 tick 更新的 `_currentCue`（位置无命中时内部仍回退 `_currentCue`）。
- 歌词入场索引（`_lyricsEntryCueIndex`）与窗口选择（`_loadLyricsPage` 的 `allBookIndex`）改用该 getter；`webview.part.dart` 的暂停态重建路径同改。

## 测试
`hibiki/test/media/audiobook/lyrics_restore_position_test.dart`（用 fake just_audio 平台）：以保存位置 `positionMs` load（暂停、无播放 tick），断言 `allBookCueIdxAtPosition` 命中该位置对应 cue，而 `allBookCueIdx` 仍是过期首句。3 用例（位置 0 / 1000 / 2500）全绿。

## 验证
- `flutter analyze`（改动文件 + 控制器）：No issues。
- `flutter test test/media/audiobook/`：789 全绿（含新增 3）。
- ⚠️ 待真机复测：安卓/桌面真机重开歌词模式书目视高亮落在当前句。

`docs/bugs/BUG-872-lyrics-restore-position.md`