### PR TITLE
feat(torrent): 阶段1a libtorrent FFI walking skeleton (Windows)

### DIFF
--- a/native/hibiki_torrent/.gitignore
+++ b/native/hibiki_torrent/.gitignore
@@ -1,0 +1,2 @@
+# CMake / standalone build artifacts — never commit.
+build/

--- a/native/hibiki_torrent/CMakeLists.txt
+++ b/native/hibiki_torrent/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.16)
+cmake_policy(SET CMP0077 NEW)
+
+project(hibiki_torrent_ffi LANGUAGES CXX)
+
+# libtorrent 2.x 要求 C++17（或更高）。
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Linux/桌面共享库里链接静态依赖时用 PIC（与 hoshidicts 一致的姿态）。
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if(MSVC)
+  # UTF-8 源码/执行字符集，异常，屏蔽 min/max 宏；_WIN32_WINNT 给 Boost.Asio。
+  add_compile_options(/utf-8 /EHsc)
+  add_compile_definitions(NOMINMAX WIN32_LEAN_AND_MEAN _WIN32_WINNT=0x0601)
+endif()
+
+# libtorrent 由 vcpkg 提供（find_package config 模式）。上层构建需传入 vcpkg
+# 工具链文件（-DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake）
+# 与 triplet（x64-windows）。见本目录 README/harness。
+find_package(LibtorrentRasterbar CONFIG REQUIRED)
+
+add_library(hibiki_torrent_ffi SHARED
+    hibiki_torrent_ffi.cpp
+)
+
+target_include_directories(hibiki_torrent_ffi PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/hibiki_torrent_include
+)
+
+target_link_libraries(hibiki_torrent_ffi PRIVATE
+    LibtorrentRasterbar::torrent-rasterbar
+)
+
+# Windows：去掉 'lib' 前缀，DLL 名固定为 hibiki_torrent_ffi.dll（Dart 侧按此
+# DynamicLibrary.open）。
+if(WIN32)
+  set_target_properties(hibiki_torrent_ffi PROPERTIES
+      PREFIX ""
+      OUTPUT_NAME "hibiki_torrent_ffi"
+  )
+endif()
+
+if(APPLE)
+  set_target_properties(hibiki_torrent_ffi PROPERTIES
+      INSTALL_NAME_DIR "@rpath"
+      BUILD_WITH_INSTALL_NAME_DIR TRUE
+  )
+endif()

--- a/native/hibiki_torrent/README.md
+++ b/native/hibiki_torrent/README.md
@@ -1,0 +1,85 @@
+# hibiki_torrent — 内置 libtorrent 引擎 C ABI bridge（阶段1a walking skeleton）
+
+番剧下载「内置 libtorrent 引擎」epic 的阶段1a：**有界** walking skeleton，只
+证明 `libtorrent 2.x 构建 → 自写 C ABI → ffigen/Dart FFI` 在 Windows 端到端
+打通，**不实现**磁力/元数据/下载管线（那是阶段1b）。
+
+选型（已定）：libtorrent 2.x（BSD-3）+ 自写 C ABI（不被 GPL/非 BSD 依赖传染）
++ Dart FFI + ffigen，照本仓库 `native/hoshidicts` 那套 C++ FFI 范式。
+
+## 结构
+
+```
+native/hibiki_torrent/
+  CMakeLists.txt                       # find_package(LibtorrentRasterbar) + SHARED lib
+  hibiki_torrent_ffi.cpp               # C ABI 实现
+  hibiki_torrent_include/
+    hibiki_torrent.h                   # C ABI 头（ffigen 入口）
+packages/hibiki_torrent/               # Dart 侧
+  ffigen.yaml                          # 从上面头文件生成绑定
+  lib/src/ffi/hibiki_torrent_bindings.dart   # 绑定
+  lib/src/embedded_torrent_engine.dart        # DynamicLibrary 薄封装
+  tool/version_harness.dart            # 端到端证明 harness
+  test/ffi_smoke_test.dart             # 冒烟测试（无库则 skip）
+```
+
+## C ABI（阶段1a 只这三个）
+
+- `const char* ht_libtorrent_version(void)` — libtorrent 版本串（静态存储，勿 free）
+- `void* ht_session_create(void)` — 建不监听端口的 session，空壳句柄
+- `void ht_session_destroy(void*)` — 销毁句柄
+
+## Windows 构建（standalone，不经 flutter windows runner）
+
+libtorrent 经 **vcpkg** 提供（本机验证过的获取路径）：
+
+```bash
+# 1) 装 libtorrent（一次性，约 20~40min，拉 boost + openssl 从源码编）
+export HTTPS_PROXY=http://127.0.0.1:34151 HTTP_PROXY=http://127.0.0.1:34151
+git clone https://github.com/microsoft/vcpkg <vcpkg>
+<vcpkg>/bootstrap-vcpkg.bat -disableMetrics
+<vcpkg>/vcpkg install libtorrent:x64-windows
+
+# 2) 配置 + 构建 bridge DLL
+cd native/hibiki_torrent
+cmake -B build -S . -A x64 \
+  -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake \
+  -DVCPKG_TARGET_TRIPLET=x64-windows
+cmake --build build --config Release
+# 产物：build/Release/hibiki_torrent_ffi.dll（+ vcpkg applocal 部署的
+# torrent-rasterbar/boost/openssl 依赖 DLL）
+```
+
+## 端到端证明
+
+```bash
+cd packages/hibiki_torrent && dart pub get
+dart run tool/version_harness.dart \
+  ../../native/hibiki_torrent/build/Release/hibiki_torrent_ffi.dll
+# 期望输出：libtorrent version: 2.0.x.0 / PASS
+```
+
+冒烟测试走 `HIBIKI_TORRENT_LIB` 环境变量指向 DLL；库不存在时整组 skip，
+CI/未构建环境不因缺 DLL 而红。
+
+## ffigen 重生成绑定
+
+`lib/src/ffi/hibiki_torrent_bindings.dart` 由 `ffigen.yaml` 对 `hibiki_torrent.h`
+生成。本机需装 LLVM/libclang：
+
+```bash
+cd packages/hibiki_torrent
+dart run ffigen --config ffigen.yaml
+```
+
+无 libclang 的机器上，已入库的手写绑定与 ffigen 对该 3 函数的输出等价。
+
+## 尚未做（阶段1b 及以后）
+
+- 未接进 `hibiki/windows/CMakeLists.txt` 的 flutter runner —— 接入前 `flutter
+  build windows` 不依赖 vcpkg/libtorrent，避免破坏未装 libtorrent 的构建环境。
+  1b 落地 `EmbeddedTorrentBackend` 时再决定「vcpkg 预装 vs FetchContent vs
+  vendored 预编译」的 app 集成方案。
+- 磁力/元数据/文件列表/顺序下载/边下边播 —— 阶段1b，实现
+  `hibiki/lib/src/media/torrent/torrent_backend.dart` 的 `TorrentBackend` 接口。
+```

--- a/native/hibiki_torrent/hibiki_torrent_ffi.cpp
+++ b/native/hibiki_torrent/hibiki_torrent_ffi.cpp
@@ -1,0 +1,42 @@
+// hibiki_torrent C ABI bridge implementation（阶段1a walking skeleton）。
+//
+// 只做工具链证明：暴露 libtorrent 版本串 + 空壳 session 生命周期。真正的
+// 磁力/元数据/文件优先级/边下边播在阶段1b实现 EmbeddedTorrentBackend 时再加。
+
+#include "hibiki_torrent.h"
+
+#include <libtorrent/session.hpp>
+#include <libtorrent/session_params.hpp>
+#include <libtorrent/settings_pack.hpp>
+#include <libtorrent/version.hpp>
+
+#include <utility>
+
+extern "C" {
+
+HT_EXPORT const char* ht_libtorrent_version(void) {
+  // lt::version() 返回指向静态存储的 C 字符串，跨 FFI 边界安全、无需释放。
+  return lt::version();
+}
+
+HT_EXPORT void* ht_session_create(void) {
+  try {
+    lt::settings_pack sp;
+    // 不绑定/监听任何端口，也不启用发现协议：walking skeleton 只验证
+    // session 能构造，不产生任何网络副作用（避免防火墙弹窗）。
+    sp.set_str(lt::settings_pack::listen_interfaces, "");
+    sp.set_bool(lt::settings_pack::enable_dht, false);
+    sp.set_bool(lt::settings_pack::enable_lsd, false);
+    sp.set_bool(lt::settings_pack::enable_upnp, false);
+    sp.set_bool(lt::settings_pack::enable_natpmp, false);
+    return new lt::session(std::move(sp));
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+HT_EXPORT void ht_session_destroy(void* session) {
+  delete static_cast<lt::session*>(session);
+}
+
+}  // extern "C"

--- a/native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h
+++ b/native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// hibiki_torrent — minimal C ABI bridge over libtorrent 2.x.
+//
+// 阶段1a walking skeleton：只导出证明工具链（libtorrent 构建 → C ABI →
+// Dart FFI）打通所需的最小面，不实现下载/磁力/元数据（那是阶段1b）。
+// C ABI 手写（不被 libtorrent 的 BSD 之外任何依赖传染），Dart 侧用 ffigen
+// 从本头文件生成绑定，与 hoshidicts 同一 FFI 范式。
+
+// ── Symbol export（与 hoshidicts platform.hpp 一致的做法）────────────
+#ifdef _WIN32
+#define HT_EXPORT __declspec(dllexport)
+#else
+#define HT_EXPORT __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// 返回 libtorrent 运行时版本串（如 "2.0.11.0"）。指向 libtorrent 内部静态
+// 存储，调用方**不得** free。
+HT_EXPORT const char* ht_libtorrent_version(void);
+
+// 创建一个不监听端口、不开 DHT/LSD/UPnP/NAT-PMP 的 libtorrent session，返回
+// 不透明句柄；失败返回 NULL。walking skeleton 只为证明 session 类真正链接进
+// 来，不承载任何下载语义。
+HT_EXPORT void* ht_session_create(void);
+
+// 销毁 ht_session_create 返回的句柄；传 NULL 为 no-op。
+HT_EXPORT void ht_session_destroy(void* session);
+
+#ifdef __cplusplus
+}
+#endif

--- a/packages/hibiki_torrent/ffigen.yaml
+++ b/packages/hibiki_torrent/ffigen.yaml
@@ -1,0 +1,21 @@
+# ffigen 配置：从 native/hibiki_torrent 的 C ABI 头文件生成 Dart FFI 绑定。
+# 生成命令（在本包目录下）：dart run ffigen --config ffigen.yaml
+# 需要本机装有 LLVM/libclang；若缺，绑定文件与本配置产物等价的手写版已入库
+# （lib/src/ffi/hibiki_torrent_bindings.dart 顶部有说明）。
+name: HibikiTorrentBindings
+description: Dart FFI bindings for the hibiki_torrent C ABI bridge over libtorrent.
+output: "lib/src/ffi/hibiki_torrent_bindings.dart"
+headers:
+  entry-points:
+    - "../../native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h"
+  include-directives:
+    - "**/hibiki_torrent.h"
+functions:
+  include:
+    - "ht_.*"
+preamble: |
+  // GENERATED / hand-mirrored — do not edit by hand except to re-run ffigen.
+  // ignore_for_file: always_specify_types, camel_case_types, non_constant_identifier_names
+comments:
+  style: any
+  length: full

--- a/packages/hibiki_torrent/lib/hibiki_torrent.dart
+++ b/packages/hibiki_torrent/lib/hibiki_torrent.dart
@@ -1,0 +1,5 @@
+/// hibiki_torrent — 内置 libtorrent 引擎的 FFI 绑定（阶段1a walking skeleton）。
+library;
+
+export 'src/embedded_torrent_engine.dart';
+export 'src/ffi/hibiki_torrent_bindings.dart';

--- a/packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart
+++ b/packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart
@@ -1,0 +1,52 @@
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+
+import 'ffi/hibiki_torrent_bindings.dart';
+
+/// 内置 libtorrent 引擎的 Dart 侧薄封装（阶段1a walking skeleton）。
+///
+/// 现在只暴露版本查询与 session 生命周期空壳，用于证明工具链打通；阶段1b
+/// 会在此之上实现 `TorrentBackend`（磁力/元数据/文件优先级/边下边播）。
+class EmbeddedTorrentEngine {
+  EmbeddedTorrentEngine._(this._bindings);
+
+  final HibikiTorrentBindings _bindings;
+
+  /// 加载本地原生库并构造引擎。[libraryPath] 显式指定 DLL/so/dylib 绝对路径
+  /// （standalone 构建产物或 harness 传入）；缺省按平台默认名从系统搜索路径找。
+  factory EmbeddedTorrentEngine.open({String? libraryPath}) {
+    final DynamicLibrary lib = libraryPath != null
+        ? DynamicLibrary.open(libraryPath)
+        : _openByPlatformDefault();
+    return EmbeddedTorrentEngine._(HibikiTorrentBindings(lib));
+  }
+
+  static DynamicLibrary _openByPlatformDefault() {
+    if (Platform.isWindows) return DynamicLibrary.open('hibiki_torrent_ffi.dll');
+    if (Platform.isMacOS) {
+      return DynamicLibrary.open('libhibiki_torrent_ffi.dylib');
+    }
+    if (Platform.isLinux || Platform.isAndroid) {
+      return DynamicLibrary.open('libhibiki_torrent_ffi.so');
+    }
+    if (Platform.isIOS) return DynamicLibrary.process();
+    throw UnsupportedError(
+        'hibiki_torrent: unsupported platform ${Platform.operatingSystem}');
+  }
+
+  /// libtorrent 运行时版本串（如 "2.0.11.0"）。
+  String libtorrentVersion() {
+    final Pointer<Char> p = _bindings.ht_libtorrent_version();
+    if (p == nullptr) return '';
+    return p.cast<Utf8>().toDartString();
+  }
+
+  /// 创建一个空壳 session 句柄；失败返回 [nullptr]。
+  Pointer<Void> createSession() => _bindings.ht_session_create();
+
+  /// 销毁 session 句柄（[nullptr] 为 no-op）。
+  void destroySession(Pointer<Void> session) =>
+      _bindings.ht_session_destroy(session);
+}

--- a/packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart
+++ b/packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart
@@ -1,0 +1,61 @@
+// GENERATED / hand-mirrored — do not edit by hand except to re-run ffigen.
+//
+// 本文件是 `ffigen.yaml` 对 native/hibiki_torrent/.../hibiki_torrent.h 的产物。
+// 本机装有 LLVM/libclang 时可 `dart run ffigen --config ffigen.yaml` 覆盖重生；
+// 内容与 ffigen 对该 3 函数 C ABI 的输出等价（单一 DynamicLibrary 构造 +
+// lookup 惰性字段），与仓库既有 hoshidicts FFI 手写范式一致。
+//
+// ignore_for_file: always_specify_types, camel_case_types, non_constant_identifier_names
+
+import 'dart:ffi' as ffi;
+
+/// Dart FFI bindings for the hibiki_torrent C ABI bridge over libtorrent.
+class HibikiTorrentBindings {
+  /// Holds the symbol lookup function.
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+      _lookup;
+
+  /// The symbols are looked up in [dynamicLibrary].
+  HibikiTorrentBindings(ffi.DynamicLibrary dynamicLibrary)
+      : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  HibikiTorrentBindings.fromLookup(
+    ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
+        lookup,
+  ) : _lookup = lookup;
+
+  /// 返回 libtorrent 运行时版本串（如 "2.0.11.0"）。指向 libtorrent 内部
+  /// 静态存储，调用方不得 free。
+  ffi.Pointer<ffi.Char> ht_libtorrent_version() {
+    return _ht_libtorrent_version();
+  }
+
+  late final _ht_libtorrent_versionPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
+          'ht_libtorrent_version');
+  late final _ht_libtorrent_version = _ht_libtorrent_versionPtr
+      .asFunction<ffi.Pointer<ffi.Char> Function()>();
+
+  /// 创建一个不监听端口的 libtorrent session，返回不透明句柄；失败返回 NULL。
+  ffi.Pointer<ffi.Void> ht_session_create() {
+    return _ht_session_create();
+  }
+
+  late final _ht_session_createPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Void> Function()>>(
+          'ht_session_create');
+  late final _ht_session_create =
+      _ht_session_createPtr.asFunction<ffi.Pointer<ffi.Void> Function()>();
+
+  /// 销毁 ht_session_create 返回的句柄；传 NULL 为 no-op。
+  void ht_session_destroy(ffi.Pointer<ffi.Void> session) {
+    return _ht_session_destroy(session);
+  }
+
+  late final _ht_session_destroyPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+          'ht_session_destroy');
+  late final _ht_session_destroy = _ht_session_destroyPtr
+      .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+}

--- a/packages/hibiki_torrent/pubspec.yaml
+++ b/packages/hibiki_torrent/pubspec.yaml
@@ -1,0 +1,16 @@
+name: hibiki_torrent
+description: >-
+  Embedded torrent engine (libtorrent 2.x) C ABI FFI bindings for Hibiki.
+  阶段1a walking skeleton：只证明 libtorrent 构建 → 自写 C ABI → Dart FFI
+  在桌面端打通，尚未实现下载管线。
+publish_to: none
+
+environment:
+  sdk: ">=3.5.0 <4.0.0"
+
+dependencies:
+  ffi: ^2.1.3
+
+dev_dependencies:
+  ffigen: ^13.0.0
+  test: ^1.24.0

--- a/packages/hibiki_torrent/test/ffi_smoke_test.dart
+++ b/packages/hibiki_torrent/test/ffi_smoke_test.dart
@@ -1,0 +1,49 @@
+// hibiki_torrent FFI 冒烟测试（阶段1a walking skeleton）。
+//
+// 经 DynamicLibrary 加载 native/hibiki_torrent 构建出的库，调
+// ht_libtorrent_version() 断言拿到非空版本串，并验证 session 生命周期。
+//
+// 库路径解析：环境变量 HIBIKI_TORRENT_LIB > 平台默认名（系统搜索路径）。
+// 库不存在时整组 skip —— CI/未构建环境不因缺 DLL 而红，符合仓库既有 FFI
+// 打包守卫「有则测、无则跳」的姿态。
+
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:hibiki_torrent/hibiki_torrent.dart';
+import 'package:test/test.dart';
+
+String? _resolveLibPath() {
+  final String? env = Platform.environment['HIBIKI_TORRENT_LIB'];
+  if (env != null && env.isNotEmpty) {
+    return File(env).existsSync() ? env : null;
+  }
+  return null; // fall back to platform-default open()
+}
+
+void main() {
+  final String? explicit = _resolveLibPath();
+
+  EmbeddedTorrentEngine? tryOpen() {
+    try {
+      return EmbeddedTorrentEngine.open(libraryPath: explicit);
+    } on ArgumentError {
+      return null; // DynamicLibrary.open 找不到库
+    }
+  }
+
+  final EmbeddedTorrentEngine? engine = tryOpen();
+
+  test('ht_libtorrent_version returns a non-empty semver-ish string', () {
+    final String version = engine!.libtorrentVersion();
+    expect(version, isNotEmpty);
+    // libtorrent 版本形如 "2.0.11.0"：至少含一个点。
+    expect(version, contains('.'));
+  }, skip: engine == null ? 'hibiki_torrent_ffi native lib not built' : null);
+
+  test('session create/destroy round-trips', () {
+    final Pointer<Void> session = engine!.createSession();
+    expect(session, isNot(equals(nullptr)));
+    engine.destroySession(session);
+  }, skip: engine == null ? 'hibiki_torrent_ffi native lib not built' : null);
+}

--- a/packages/hibiki_torrent/tool/version_harness.dart
+++ b/packages/hibiki_torrent/tool/version_harness.dart
@@ -1,0 +1,33 @@
+// 端到端工具链证明 harness（阶段1a）。
+//
+// 用法：dart run tool/version_harness.dart <hibiki_torrent_ffi.dll 绝对路径>
+// 缺省参数时按平台默认名从系统搜索路径加载。
+//
+// 经 DynamicLibrary 加载 native/hibiki_torrent 构建出的库 → 调
+// ht_libtorrent_version() 打印 libtorrent 真实版本号 → 建/销毁一个空壳
+// session。全部成功即证明 libtorrent 构建 → C ABI → Dart FFI 链路打通。
+
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:hibiki_torrent/hibiki_torrent.dart';
+
+void main(List<String> args) {
+  final String? path = args.isNotEmpty ? args.first : null;
+  final EmbeddedTorrentEngine engine =
+      EmbeddedTorrentEngine.open(libraryPath: path);
+
+  final String version = engine.libtorrentVersion();
+  stdout.writeln('libtorrent version: $version');
+  if (version.isEmpty) {
+    stderr.writeln('FAIL: empty version string');
+    exit(1);
+  }
+
+  final Pointer<Void> session = engine.createSession();
+  stdout.writeln('session handle: $session');
+  engine.destroySession(session);
+  stdout.writeln('session destroyed OK');
+
+  stdout.writeln('PASS: libtorrent -> C ABI -> Dart FFI walking skeleton');
+}


### PR DESCRIPTION
## 阶段1a：libtorrent FFI walking skeleton（有界里程碑1a）

番剧下载「内置 libtorrent 引擎」epic 的阶段1a。**有界** walking skeleton，只
证明 `libtorrent 2.x 构建 → 自写 C ABI → Dart FFI` 在 **Windows** 端到端打通，
**不实现**磁力/元数据/下载管线（阶段1b）。

### 端到端验证（PASS）
```
libtorrent version: 2.0.11.0
session handle: Pointer: address=0x...
session destroyed OK
PASS: libtorrent -> C ABI -> Dart FFI walking skeleton
```
`dart test` 冒烟测试 +2 全绿（version + session round-trip）。

### 选型与决定
- libtorrent 2.0.11（BSD-3）经 **vcpkg** `libtorrent:x64-windows`（拉 boost 1.91
  + openssl 3.6.3 从源码编，首次约 46min）。这是本机验证过的获取路径。
- 自写 C ABI（`ht_libtorrent_version` / `ht_session_create` / `ht_session_destroy`），
  不被 libtorrent 之外任何依赖传染，照 `native/hoshidicts` 的 C++ FFI 范式。
- Dart 侧 `ffigen.yaml` + 绑定 + `DynamicLibrary` 薄封装（`EmbeddedTorrentEngine`），
  是阶段1b `EmbeddedTorrentBackend` 的种子。

### 结构
- `native/hibiki_torrent/`：CMakeLists（find_package(LibtorrentRasterbar) + SHARED）
  + `hibiki_torrent_ffi.cpp` + `hibiki_torrent_include/hibiki_torrent.h` + README。
- `packages/hibiki_torrent/`：ffigen 配置、FFI 绑定、engine 封装、harness、冒烟测试。

### 边界（尚未做）
- **未接入 `hibiki/windows/CMakeLists.txt` 的 flutter runner** —— 接入前
  `flutter build windows` 不依赖 vcpkg/libtorrent，避免破坏未装 libtorrent 的
  构建环境（never break userspace）。1b 落地时再定 app 集成方案。
- 磁力/元数据/文件列表/顺序下载/边下边播 = 阶段1b，实现 `torrent_backend.dart`
  的 `TorrentBackend` 接口。

### 备注
- ffigen 需 libclang（本机未装 LLVM），入库绑定为与 ffigen 输出等价的手写版，
  README 记有重生成命令。