### PR TITLE
fix(ci-debt): 修复develop长期红的4个守卫测试(log-upload注入等)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -805,6 +805,27 @@ jobs:
         elif [ ! -f "$dst" ]; then
           cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"
         fi
+    # Symmetric with the build job (BUG-290): every job that injects the
+    # google_oauth stub must also inject the log_upload stub so the symmetry
+    # guard (log_upload_workflow_injection_guard_test) stays green and a future
+    # platform job can never silently drop the injection. Harmless here (tests
+    # do not upload logs) - when the secret is unset it leaves the committed
+    # empty placeholder so nothing is exposed.
+    - name: Provide gitignored log upload secret stub
+      shell: bash
+      env:
+        LOG_UPLOAD_ENDPOINT: ${{ secrets.LOG_UPLOAD_ENDPOINT }}
+        LOG_UPLOAD_TOKEN: ${{ secrets.LOG_UPLOAD_TOKEN }}
+      run: |
+        dst=hibiki/lib/src/utils/misc/log_upload_secret.dart
+        if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
+          printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
+            "$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')" \
+            "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')" \
+            > "$dst"
+        elif [ ! -f "$dst" ]; then
+          cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
+        fi
 
     - name: Provide gitignored dandanplay secret stub
       shell: bash

--- a/hibiki/test/lookup/global_lookup_no_audio_hint_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_no_audio_hint_guard_test.dart
@@ -60,9 +60,19 @@ void main() {
 
   test('popup.css 定义 .audio-hint 与 .audio-button.audio-unavailable', () {
     final String css = read('assets/popup/popup.css');
-    expect(css.contains('.audio-hint {'), isTrue);
-    expect(css.contains('.audio-hint.visible {'), isTrue);
-    expect(css.contains('.audio-button.audio-unavailable {'), isTrue);
+    // 断言选择器已定义样式，但对「分组选择器」健壮：BUG-842 起 .audio-hint 与
+    // .hoshi-btn-tip 共用同一套视觉，CSS 写成 `.audio-hint,\n.hoshi-btn-tip {`，
+    // 旧的裸子串 `.audio-hint {` 不再匹配却仍然生效。这里改为匹配「选择器后紧跟
+    // `,`（分组）或 `{`（独立块），允许中间有空白」，既守住样式在位又不锁死写法。
+    bool definesSelector(String selector) => RegExp(
+          '${RegExp.escape(selector)}\\s*[,{]',
+        ).hasMatch(css);
+    expect(definesSelector('.audio-hint'), isTrue,
+        reason: '.audio-hint 必须作为选择器出现（可与 .hoshi-btn-tip 分组）');
+    expect(definesSelector('.audio-hint.visible'), isTrue,
+        reason: '.audio-hint.visible 必须定义可见态（可分组）');
+    expect(definesSelector('.audio-button.audio-unavailable'), isTrue,
+        reason: '.audio-button.audio-unavailable 静音态必须定义');
   });
 
   test('buildPopupSettingsJs 向两条 render 路径注入 i18nNoAudioAvailable', () {

--- a/hibiki/test/pages/popup_empty_entry_card_test.js
+++ b/hibiki/test/pages/popup_empty_entry_card_test.js
@@ -54,6 +54,14 @@ function makeElement(tag) {
       add(name) { this._set.add(name); },
       remove(name) { this._set.delete(name); },
       contains(name) { return this._set.has(name); },
+      // Standard DOMTokenList.toggle(name, force?) semantics: force===true adds,
+      // force===false removes, omitted flips. popup.js setMineState uses the
+      // two-arg force form for the open-anki button (TODO-1360).
+      toggle(name, force) {
+        const shouldHave = force === undefined ? !this._set.has(name) : !!force;
+        if (shouldHave) { this._set.add(name); } else { this._set.delete(name); }
+        return shouldHave;
+      },
     },
     get innerHTML() { return this._innerHTML; },
     set innerHTML(v) {

--- a/hibiki/test/utils/misc/popup_asset_behavior_test.js
+++ b/hibiki/test/utils/misc/popup_asset_behavior_test.js
@@ -29,6 +29,19 @@ class FakeClassList {
     this.values.delete(name);
     this.element.className = [...this.values].join(' ');
   }
+
+  // Standard DOMTokenList.toggle(name, force?): force===true adds, force===false
+  // removes, omitted flips. popup.js setMineState toggles 'open-anki-hidden' on
+  // the open-anki button via the two-arg force form (TODO-1360).
+  toggle(name, force) {
+    const shouldHave = force === undefined ? !this.values.has(name) : !!force;
+    if (shouldHave) {
+      this.add(name);
+    } else {
+      this.remove(name);
+    }
+    return shouldHave;
+  }
 }
 
 class FakeStyle {


### PR DESCRIPTION
## 背景
develop 上有 4 个守卫测试长期红，但它们不在 push-CI 单测门禁里跑（见 main.yml push 不跑单测），所以长期潜伏。本 PR 逐个根因修复。

## 逐测判据与修法

1. `test/build/log_upload_workflow_injection_guard_test.dart`（**真安全隐患，改源**）
   - 红因：release.yml 的 `tests` job 注入了 google_oauth stub 却漏注入 log_upload stub（`build` 发包 job 两者都有）。守卫 BUG-290：每个注入 google_oauth 的 job 必须对称注入 log_upload，否则将来加新平台 job 又会漏注入导致「上传日志」按钮因端点空永久隐藏。
   - 修法：给 `tests` job 补上对称的 log_upload 注入步骤（secret 未配置时回退入库空占位，不暴露端点）。**未弱化守卫**。

2. `test/pages/popup_empty_entry_card_test.js`（**守卫过时，改测**）
   - 红因：node mock DOM 的 classList 只实现 add/remove/contains，缺 `toggle`；popup.js:2181 `setMineState` 合法地用两参 `classList.toggle('open-anki-hidden', !isMined)`（TODO-1360，open-anki 按钮可见性）。
   - 修法：给 classList mock 补标准 `toggle(name, force)` 语义。

3. `test/pages/popup_mine_audio_fresh_resolve_static_test.dart`（**守卫过时，改测**）
   - 同 #2 根因：共享 harness `popup_asset_behavior_test.js` 的 `FakeClassList` 缺 `toggle`。补齐。

4. `test/lookup/global_lookup_no_audio_hint_guard_test.dart`（**守卫过时，改测**）
   - 红因：popup.css 断言用裸子串 `.audio-hint {`；BUG-842 起 `.audio-hint` 与 `.hoshi-btn-tip` 共用视觉，CSS 写成分组选择器 `.audio-hint,\n.hoshi-btn-tip {`，样式仍在位但裸子串不匹配。
   - 修法：断言改为「选择器后紧跟 `,` 或 `{`」的健壮匹配，容忍分组写法。

## log_upload 是否真隐患
是。#1 是真安全/功能隐患（release.yml tests job 漏对称注入），已改源修复且未放水守卫。其余 3 个是守卫本身随源码/CSS 合法演进而过时。

## 验证
- 4 个目标测试全绿（18 subtests）。
- `flutter analyze`：No issues found。
- 全量 `flutter test`：11713 passed / 3 skipped，唯一失败 `home_video_remote_download_register_test.dart` 与本 PR 无关（单跑全绿，全量并发下偶发 flake，非稳定红）。

## CI 缺口建议（不改 workflow，留给用户决策）
main.yml 的 push 触发不跑单元测试门禁，导致这类守卫测试长期潜伏红。建议在 push CI 增加一个轻量 `flutter test` 门禁（或至少跑 `test/build/`、`test/lookup/`、`test/pages/` 守卫子集），否则守卫失效无法在合并时暴露。此改动涉及发布 CI，需用户决策，本 PR 不动。

> 请勿自动合并 develop：由 integration owner gate 合并。
