### PR TITLE
feat(torrent): 反吸血判定引擎纯 Dart 核心（复刻 PeerBanHelper 规则）

### DIFF
--- a/hibiki/lib/src/media/torrent/anti_leech.dart
+++ b/hibiki/lib/src/media/torrent/anti_leech.dart
@@ -1,0 +1,424 @@
+import 'dart:math' as math;
+
+/// 反吸血判定引擎的纯 Dart 核心（复刻 PeerBanHelper 的规则语义）。
+///
+/// 定位：将来内置 libtorrent 引擎的反吸血层的**纯逻辑核心**。本文件不碰
+/// libtorrent、不碰网络、不执行封禁——只做判定：输入一批抽象 peer 快照
+/// （[PeerSnapshot]）+ 种子上下文（[TorrentContext]），输出每个 peer 的
+/// [BanVerdict]（该不该封 / 封哪个 CIDR 段 / 原因）。native 引擎负责把
+/// libtorrent `peer_info` 映射成 [PeerSnapshot]，再把 [BanVerdict] 翻译成
+/// libtorrent `ip_filter`。
+///
+/// 核心洞察（进度作弊检测，PCB）：「我实际喂给这个 peer 多少字节」
+/// （[PeerSnapshot.totalUpload]，可信）对「peer 自报进度」
+/// （[PeerSnapshot.reportedProgress]，可伪造），对不上就是吸血。
+///
+/// 零外部依赖；所有时间经 `nowMs` 参数注入，绝不内部调 `DateTime.now()`。
+
+/// peer 快照（libtorrent `peer_info` 的中性子集；native 引擎映射后喂入）。
+class PeerSnapshot {
+  const PeerSnapshot({
+    required this.ip,
+    required this.peerId,
+    required this.client,
+    required this.reportedProgress,
+    required this.totalUpload,
+    this.uploadSpeed = 0,
+    this.peerInterested = true,
+  });
+
+  /// 如 `'1.2.3.4'`（IPv4）或 `'2001:db8::1'`（IPv6）。
+  final String ip;
+
+  /// 20 字节 peer_id 的可读形式，如 `'-XL0012-abcdef...'`。
+  final String peerId;
+
+  /// 客户端名，如 `'Xunlei 0.0.1.2'` / `'qBittorrent 4.6.5'`。
+  final String client;
+
+  /// 0..1，peer 自报进度（可作弊）。
+  final double reportedProgress;
+
+  /// 本连接我实际上传给它的字节（可信，反吸血基准）。
+  final int totalUpload;
+
+  /// 当前上传速率 B/s（预留字段，当前规则未使用）。
+  final int uploadSpeed;
+
+  /// peer 是否 interested（在问我要数据；预留字段，当前规则未使用）。
+  final bool peerInterested;
+}
+
+/// 种子上下文。
+class TorrentContext {
+  const TorrentContext({
+    required this.infoHash,
+    required this.totalSize,
+    this.completedSize,
+    this.isSeeding = false,
+  });
+
+  final String infoHash;
+
+  /// 种子总字节。
+  final int totalSize;
+
+  /// 未完成任务时用它做 excessive 比较（null 用 [totalSize]）。
+  final int? completedSize;
+
+  final bool isSeeding;
+}
+
+/// 封禁原因。
+enum BanReason {
+  /// PCB differenceTest：实喂进度比自报进度高出阈值 = 谎报低进度骗上传。
+  progressCheat,
+
+  /// PCB：自报进度倒退超阈值。
+  progressRewind,
+
+  /// PCB：单 peer 从我这下走的量超种子数倍 = PCDN 回源/过量白嫖。
+  excessiveDownload,
+
+  /// peer_id 前缀黑名单命中。
+  peerIdBlacklist,
+
+  /// 客户端名关键词黑名单命中。
+  clientBlacklist,
+
+  /// 迅雷特例：做种时不让迅雷白嫖（不做种时迅雷可能是正常下载者，放行）。
+  xunleiSeeding,
+
+  /// 多拨/PCDN：同段同种子连接数超容忍值。
+  multiDialing,
+
+  /// 连坐：IP 落在已封 CIDR 段内。
+  autoRangeBan,
+}
+
+/// 判定结果。[banned]=false 时其余字段忽略。
+class BanVerdict {
+  const BanVerdict.allow()
+      : banned = false,
+        reason = null,
+        cidr = null,
+        banDurationMs = null;
+
+  const BanVerdict.ban(this.reason, {this.cidr, this.banDurationMs})
+      : banned = true;
+
+  final bool banned;
+  final BanReason? reason;
+
+  /// 连坐/多拨时要封的段（如 `'1.2.3.0/24'`）；单 IP 封时 null（=封该
+  /// peer.ip）。
+  final String? cidr;
+
+  /// 封禁时长；null=用默认长封。
+  final int? banDurationMs;
+}
+
+/// 阈值配置。
+///
+/// 默认值是贴 PeerBanHelper 语义的合理默认，**非**从 PBH 源码逐字抄的官方
+/// 精确值；默认值待真机调优/对齐 PBH 上游。
+class AntiLeechConfig {
+  const AntiLeechConfig({
+    this.maxProgressDifference = 0.08,
+    this.progressRewindThreshold = 0.05,
+    this.excessiveThreshold = 3.0,
+    this.handshakeGraceMs = 60000,
+    this.minTorrentSizeForPcb = 20 * 1024 * 1024,
+    this.ipv4PrefixLength = 24,
+    this.ipv6PrefixLength = 60,
+    this.multiDialTolerance = 8,
+    this.peerIdBlacklistPrefixes = const <String>[
+      '-XL',
+      '-SD',
+      '-XF',
+      '-DL',
+      '-BN',
+      '-DT',
+      '-QD',
+    ],
+    this.clientNameKeywords = const <String>[
+      'xunlei',
+      'thunder',
+      'qqdownload',
+      'xfplay',
+      'dandanplay',
+      'offline',
+    ],
+  });
+
+  /// computedProgress 比自报高出这么多即作弊。
+  final double maxProgressDifference;
+
+  /// 进度倒退超此值即作弊。
+  final double progressRewindThreshold;
+
+  /// 单 peer 上传量超种子大小这么多倍即过量。
+  final double excessiveThreshold;
+
+  /// 首见后宽限窗口（毫秒），避 bitfield 未就绪误判。
+  final int handshakeGraceMs;
+
+  /// 小于此大小（字节）的种子不做 PCB（小文件噪声大）。
+  final int minTorrentSizeForPcb;
+
+  /// 连坐/多拨用的 IPv4 段前缀位数。
+  final int ipv4PrefixLength;
+
+  /// 连坐/多拨用的 IPv6 段前缀位数。
+  final int ipv6PrefixLength;
+
+  /// 同段同种子容忍的连接数，超即多拨。
+  final int multiDialTolerance;
+
+  /// peer_id 前缀黑名单。
+  final List<String> peerIdBlacklistPrefixes;
+
+  /// 客户端名关键词黑名单（小写子串匹配）。
+  final List<String> clientNameKeywords;
+}
+
+/// 解析 IP 字符串为字节列表（IPv4 → 4 字节，IPv6 → 16 字节）。纯函数，
+/// 容错：非法输入返回 null。
+List<int>? _tryParseIpBytes(String ip) {
+  if (ip.contains(':')) {
+    try {
+      return Uri.parseIPv6Address(ip);
+    } on FormatException {
+      return null;
+    }
+  }
+  final List<String> parts = ip.split('.');
+  if (parts.length != 4) return null;
+  final List<int> bytes = <int>[];
+  for (final String part in parts) {
+    // 只接受 1~3 位纯数字（拒绝空段 / '+1' / 前置符号）。
+    if (!RegExp(r'^\d{1,3}$').hasMatch(part)) return null;
+    final int value = int.parse(part);
+    if (value > 255) return null;
+    bytes.add(value);
+  }
+  return bytes;
+}
+
+/// 把 [bytes] 保留前 [prefixBits] 位、其余清零（就地修改）。
+void _maskBytes(List<int> bytes, int prefixBits) {
+  final int fullBytes = prefixBits ~/ 8;
+  final int remBits = prefixBits % 8;
+  for (int i = fullBytes; i < bytes.length; i++) {
+    if (i == fullBytes && remBits != 0) {
+      bytes[i] &= (0xFF << (8 - remBits)) & 0xFF;
+    } else {
+      bytes[i] = 0;
+    }
+  }
+}
+
+/// 算 IP 所属 CIDR 段，如 `cidrOf('1.2.3.4')` → `'1.2.3.0/24'`。纯函数。
+///
+/// IPv4 用 [ipv4Prefix] 位掩码；IPv6 用 [ipv6Prefix] 位掩码（输出为不压缩的
+/// 8 组十六进制形式，如 `'2001:db8:0:0:0:0:0:0/60'`）。容错：非法 IPv4
+/// 返回 `'$ip/32'`；非法 IPv6（含 `:` 但解析失败）原样返回。
+String cidrOf(String ip, {int ipv4Prefix = 24, int ipv6Prefix = 60}) {
+  final List<int>? bytes = _tryParseIpBytes(ip);
+  if (ip.contains(':')) {
+    if (bytes == null || bytes.length != 16) return ip;
+    final int prefix =
+        ipv6Prefix < 0 ? 0 : (ipv6Prefix > 128 ? 128 : ipv6Prefix);
+    _maskBytes(bytes, prefix);
+    final StringBuffer buffer = StringBuffer();
+    for (int i = 0; i < 8; i++) {
+      if (i > 0) buffer.write(':');
+      buffer.write(((bytes[i * 2] << 8) | bytes[i * 2 + 1]).toRadixString(16));
+    }
+    return '$buffer/$prefix';
+  }
+  if (bytes == null) return '$ip/32';
+  final int prefix = ipv4Prefix < 0 ? 0 : (ipv4Prefix > 32 ? 32 : ipv4Prefix);
+  _maskBytes(bytes, prefix);
+  return '${bytes.join('.')}/$prefix';
+}
+
+/// 判 IP 是否落在 CIDR 段内（前缀位比较，IPv4/IPv6 都支持）。纯函数，
+/// 容错：cidr 无 `/`（[cidrOf] 的 IPv6 非法回退产物）退化为精确串比较；
+/// 前缀非法、地址非法或地址族不匹配返回 false。
+bool ipInCidr(String ip, String cidr) {
+  final int slash = cidr.lastIndexOf('/');
+  if (slash < 0) return ip == cidr;
+  final int? prefix = int.tryParse(cidr.substring(slash + 1));
+  if (prefix == null || prefix < 0) return false;
+  final List<int>? ipBytes = _tryParseIpBytes(ip);
+  final List<int>? netBytes = _tryParseIpBytes(cidr.substring(0, slash));
+  if (ipBytes == null || netBytes == null) return false;
+  if (ipBytes.length != netBytes.length) return false;
+  if (prefix > ipBytes.length * 8) return false;
+  final int fullBytes = prefix ~/ 8;
+  for (int i = 0; i < fullBytes; i++) {
+    if (ipBytes[i] != netBytes[i]) return false;
+  }
+  final int remBits = prefix % 8;
+  if (remBits != 0) {
+    final int mask = (0xFF << (8 - remBits)) & 0xFF;
+    if ((ipBytes[fullBytes] & mask) != (netBytes[fullBytes] & mask)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// 反吸血判定引擎（有状态：跨 [evaluate] 调用累积峰值/首见/进度/封段）。
+///
+/// 规则顺序（每 peer 走一遍，第一个命中就 ban 并短路）：
+/// ① AutoRangeBan 连坐 → ② PeerId/ClientName 黑名单（含迅雷做种特例）→
+/// ③ MultiDialing 多拨 → ④ ProgressCheatBlocker（PCB，最后做：最贵且要过
+/// 宽限窗口）。任何新 ban 都把该 IP 的 CIDR 段登记进连坐源。
+class AntiLeechEngine {
+  AntiLeechEngine({this.config = const AntiLeechConfig()});
+
+  final AntiLeechConfig config;
+
+  /// 每 IP 见过的 `totalUpload` 峰值（抗断连重置——peer 断连重连后
+  /// totalUpload 归零，但我们记得峰值）。
+  final Map<String, int> _peakUpload = <String, int>{};
+
+  /// 每 IP 首见时刻（宽限窗口基准）。
+  final Map<String, int> _firstSeenMs = <String, int>{};
+
+  /// 每 IP 上次自报进度（progressRewind 基准）。
+  final Map<String, double> _lastProgress = <String, double>{};
+
+  /// 已封段（AutoRangeBan 连坐源）。
+  final Set<String> _bannedCidrs = <String>{};
+
+  /// `infoHash@cidr` → 该段该种子见过的 IP 集（MultiDialing 计数）。
+  final Map<String, Set<String>> _torrentSegmentIps = <String, Set<String>>{};
+
+  /// 当前已封段的只读视图（native 层可据此重建 ip_filter）。
+  Set<String> get bannedCidrs => Set<String>.unmodifiable(_bannedCidrs);
+
+  /// 对一批 peer 快照做判定，返回 `ip → 判定` 映射。
+  ///
+  /// [nowMs] 由调用方注入（单调毫秒时钟），引擎内部绝不取真实时间。
+  /// 每个新 ban 的 IP 的 CIDR 段立即加入连坐源，因此同一批里排在后面的
+  /// 同段 peer 会直接命中 AutoRangeBan。
+  Map<String, BanVerdict> evaluate(
+    List<PeerSnapshot> peers,
+    TorrentContext ctx, {
+    required int nowMs,
+  }) {
+    final Map<String, BanVerdict> out = <String, BanVerdict>{};
+    for (final PeerSnapshot peer in peers) {
+      final BanVerdict verdict = _evaluatePeer(peer, ctx, nowMs);
+      if (verdict.banned) {
+        _bannedCidrs.add(verdict.cidr ?? _segmentOf(peer.ip));
+      }
+      out[peer.ip] = verdict;
+    }
+    return out;
+  }
+
+  /// 单 peer 判定（规则顺序见类 doc）。
+  BanVerdict _evaluatePeer(PeerSnapshot peer, TorrentContext ctx, int nowMs) {
+    // ① AutoRangeBan（连坐，先查）：IP 落在任一已封段直接 ban。
+    for (final String cidr in _bannedCidrs) {
+      if (ipInCidr(peer.ip, cidr)) {
+        return BanVerdict.ban(BanReason.autoRangeBan, cidr: cidr);
+      }
+    }
+
+    // ② PeerId/ClientName 黑名单 + 迅雷特例。
+    final String clientLower = peer.client.toLowerCase();
+    final bool isXunlei = peer.peerId.startsWith('-XL') ||
+        clientLower.startsWith('xunlei') ||
+        clientLower.startsWith('thunder');
+    if (isXunlei) {
+      // 迅雷特例：仅做种时 ban（不做种时迅雷可能是正常下载者），不做种
+      // 则跳过黑名单继续走后续规则。
+      if (ctx.isSeeding) {
+        return const BanVerdict.ban(BanReason.xunleiSeeding);
+      }
+    } else {
+      for (final String prefix in config.peerIdBlacklistPrefixes) {
+        if (peer.peerId.startsWith(prefix)) {
+          return const BanVerdict.ban(BanReason.peerIdBlacklist);
+        }
+      }
+      for (final String keyword in config.clientNameKeywords) {
+        if (clientLower.contains(keyword)) {
+          return const BanVerdict.ban(BanReason.clientBlacklist);
+        }
+      }
+    }
+
+    // ③ MultiDialingBlocker（多拨/PCDN）：同段同种子 IP 数超容忍值封段。
+    final String segment = _segmentOf(peer.ip);
+    final Set<String> segmentIps = _torrentSegmentIps.putIfAbsent(
+        '${ctx.infoHash}@$segment', () => <String>{})
+      ..add(peer.ip);
+    if (segmentIps.length > config.multiDialTolerance) {
+      return BanVerdict.ban(BanReason.multiDialing, cidr: segment);
+    }
+
+    // ④ ProgressCheatBlocker（PCB 核心）。
+    return _evaluatePcb(peer, ctx, nowMs);
+  }
+
+  /// PCB：differenceTest → progressRewind → excessiveDownload。
+  BanVerdict _evaluatePcb(PeerSnapshot peer, TorrentContext ctx, int nowMs) {
+    final int firstSeen = _firstSeenMs.putIfAbsent(peer.ip, () => nowMs);
+    // 峰值抗断连：断连重连后 totalUpload 归零，按历史峰值判。
+    final int computedUploaded =
+        math.max(peer.totalUpload, _peakUpload[peer.ip] ?? 0);
+    _peakUpload[peer.ip] = computedUploaded;
+
+    // 宽限窗口：只更新状态不判定，避 bitfield 未就绪误封。
+    if (nowMs - firstSeen < config.handshakeGraceMs) {
+      _lastProgress[peer.ip] = peer.reportedProgress;
+      return const BanVerdict.allow();
+    }
+    // 小种子噪声大，跳过 PCB。
+    if (ctx.totalSize <= 0 || ctx.totalSize < config.minTorrentSizeForPcb) {
+      return const BanVerdict.allow();
+    }
+    // 没喂出过任何字节（含峰值）就无从判「喂了却自报低」。
+    if (computedUploaded == 0) {
+      _lastProgress[peer.ip] = peer.reportedProgress;
+      return const BanVerdict.allow();
+    }
+
+    // differenceTest：我喂给你的量对应的进度，比你自报的高出一大截 =
+    // 你谎报低进度骗我持续上传。
+    final double computedProgress =
+        math.min(1.0, computedUploaded / ctx.totalSize);
+    if (computedProgress - peer.reportedProgress >
+        config.maxProgressDifference) {
+      return const BanVerdict.ban(BanReason.progressCheat);
+    }
+
+    // progressRewind：自报进度倒退超阈值。
+    final double? lastProgress = _lastProgress[peer.ip];
+    _lastProgress[peer.ip] = peer.reportedProgress;
+    if (lastProgress != null &&
+        lastProgress - peer.reportedProgress > config.progressRewindThreshold) {
+      return const BanVerdict.ban(BanReason.progressRewind);
+    }
+
+    // excessiveDownload：单 peer 下走的量超整个种子数倍 = PCDN 回源。
+    final int refSize = ctx.completedSize ?? ctx.totalSize;
+    if (refSize > 0 && computedUploaded > refSize * config.excessiveThreshold) {
+      return const BanVerdict.ban(BanReason.excessiveDownload);
+    }
+    return const BanVerdict.allow();
+  }
+
+  /// 按配置前缀算 IP 所属段。
+  String _segmentOf(String ip) => cidrOf(
+        ip,
+        ipv4Prefix: config.ipv4PrefixLength,
+        ipv6Prefix: config.ipv6PrefixLength,
+      );
+}

--- a/hibiki/test/torrent/anti_leech_test.dart
+++ b/hibiki/test/torrent/anti_leech_test.dart
@@ -1,0 +1,435 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/torrent/anti_leech.dart';
+
+const int kMiB = 1024 * 1024;
+
+/// 造 peer 快照；默认是一个正常 qBittorrent peer。
+PeerSnapshot peer({
+  String ip = '1.2.3.4',
+  String peerId = '-qB4650-0123456789ab',
+  String client = 'qBittorrent 4.6.5',
+  double reportedProgress = 0,
+  int totalUpload = 0,
+}) {
+  return PeerSnapshot(
+    ip: ip,
+    peerId: peerId,
+    client: client,
+    reportedProgress: reportedProgress,
+    totalUpload: totalUpload,
+  );
+}
+
+/// 造种子上下文；默认 100 MiB、非做种（超过默认 PCB 最小种子大小）。
+TorrentContext ctx({
+  String infoHash = 'hash-a',
+  int totalSize = 100 * kMiB,
+  int? completedSize,
+  bool isSeeding = false,
+}) {
+  return TorrentContext(
+    infoHash: infoHash,
+    totalSize: totalSize,
+    completedSize: completedSize,
+    isSeeding: isSeeding,
+  );
+}
+
+void main() {
+  group('cidrOf', () {
+    test('IPv4 默认 /24', () {
+      expect(cidrOf('1.2.3.4'), '1.2.3.0/24');
+      expect(cidrOf('10.0.0.255'), '10.0.0.0/24');
+    });
+
+    test('IPv4 自定义前缀', () {
+      expect(cidrOf('1.2.3.4', ipv4Prefix: 16), '1.2.0.0/16');
+      expect(cidrOf('1.2.3.4', ipv4Prefix: 32), '1.2.3.4/32');
+    });
+
+    test('IPv6 默认 /60（非整字节掩码）', () {
+      // /60 = 前 7 字节 + 第 8 字节高 4 位：0xf5 → 0xf0。
+      expect(
+        cidrOf('2001:db8:aaaa:bbf5::1'),
+        '2001:db8:aaaa:bbf0:0:0:0:0/60',
+      );
+    });
+
+    test('IPv6 自定义前缀 /64', () {
+      expect(
+        cidrOf('2001:db8:aaaa:bbf5::1', ipv6Prefix: 64),
+        '2001:db8:aaaa:bbf5:0:0:0:0/64',
+      );
+    });
+
+    test('非法 IPv4 返回 ip/32', () {
+      expect(cidrOf('foo.bar'), 'foo.bar/32');
+      expect(cidrOf('1.2.3.999'), '1.2.3.999/32');
+      expect(cidrOf('1.2.3'), '1.2.3/32');
+    });
+
+    test('非法 IPv6 原样返回', () {
+      expect(cidrOf('zz::1'), 'zz::1');
+    });
+  });
+
+  group('ipInCidr', () {
+    test('IPv4 /24 边界内外', () {
+      expect(ipInCidr('1.2.3.99', '1.2.3.0/24'), isTrue);
+      expect(ipInCidr('1.2.3.255', '1.2.3.0/24'), isTrue);
+      expect(ipInCidr('1.2.4.0', '1.2.3.0/24'), isFalse);
+      expect(ipInCidr('2.2.3.4', '1.2.3.0/24'), isFalse);
+    });
+
+    test('前缀 0 匹配一切 IPv4', () {
+      expect(ipInCidr('9.9.9.9', '0.0.0.0/0'), isTrue);
+    });
+
+    test('IPv6 /60 边界内外', () {
+      const String cidr = '2001:db8:aaaa:bbf0:0:0:0:0/60';
+      expect(ipInCidr('2001:db8:aaaa:bbf5::9', cidr), isTrue);
+      expect(ipInCidr('2001:db8:aaaa:bbe0::9', cidr), isFalse);
+      expect(ipInCidr('2001:db8:aaab:bbf0::9', cidr), isFalse);
+    });
+
+    test('地址族不匹配返回 false', () {
+      expect(ipInCidr('::1', '1.2.3.0/24'), isFalse);
+      expect(ipInCidr('1.2.3.4', '2001:db8:0:0:0:0:0:0/60'), isFalse);
+    });
+
+    test('非法输入容错', () {
+      expect(ipInCidr('1.2.3.4', 'garbage/24'), isFalse);
+      expect(ipInCidr('not-an-ip', '1.2.3.0/24'), isFalse);
+      expect(ipInCidr('1.2.3.4', '1.2.3.0/abc'), isFalse);
+      expect(ipInCidr('1.2.3.4', '1.2.3.0/40'), isFalse);
+      // 无 `/` 的 cidr（IPv6 非法回退产物）退化为精确串比较。
+      expect(ipInCidr('zz::1', 'zz::1'), isTrue);
+      expect(ipInCidr('zz::2', 'zz::1'), isFalse);
+    });
+  });
+
+  group('PCB 进度作弊检测', () {
+    late AntiLeechEngine engine;
+
+    setUp(() => engine = AntiLeechEngine());
+
+    // 默认宽限 60000ms：t0 首见（宽限内），t1 已出宽限。
+    const int t0 = 1000;
+    const int t1 = t0 + 60000;
+
+    test('differenceTest：喂出 50% 却自报 5% → ban', () {
+      final PeerSnapshot p =
+          peer(totalUpload: 50 * kMiB, reportedProgress: 0.05);
+      // 首轮在宽限窗口内 → allow。
+      final Map<String, BanVerdict> r0 =
+          engine.evaluate(<PeerSnapshot>[p], ctx(), nowMs: t0);
+      expect(r0['1.2.3.4']!.banned, isFalse);
+      // 出宽限后 → ban(progressCheat)。
+      final Map<String, BanVerdict> r1 =
+          engine.evaluate(<PeerSnapshot>[p], ctx(), nowMs: t1);
+      expect(r1['1.2.3.4']!.banned, isTrue);
+      expect(r1['1.2.3.4']!.reason, BanReason.progressCheat);
+      expect(r1['1.2.3.4']!.cidr, isNull);
+    });
+
+    test('自报与计算一致 → allow', () {
+      final PeerSnapshot p =
+          peer(totalUpload: 50 * kMiB, reportedProgress: 0.5);
+      engine.evaluate(<PeerSnapshot>[p], ctx(), nowMs: t0);
+      final Map<String, BanVerdict> r =
+          engine.evaluate(<PeerSnapshot>[p], ctx(), nowMs: t1);
+      expect(r['1.2.3.4']!.banned, isFalse);
+    });
+
+    test('宽限窗口内即使作弊数值也 allow', () {
+      final PeerSnapshot p =
+          peer(totalUpload: 50 * kMiB, reportedProgress: 0.05);
+      final Map<String, BanVerdict> r0 =
+          engine.evaluate(<PeerSnapshot>[p], ctx(), nowMs: t0);
+      expect(r0['1.2.3.4']!.banned, isFalse);
+      // 仍在窗口内（差 1ms 到期）。
+      final Map<String, BanVerdict> r1 =
+          engine.evaluate(<PeerSnapshot>[p], ctx(), nowMs: t1 - 1);
+      expect(r1['1.2.3.4']!.banned, isFalse);
+    });
+
+    test('totalUpload==0 且无峰值 → allow（无从判定）', () {
+      final PeerSnapshot p = peer(totalUpload: 0, reportedProgress: 0);
+      engine.evaluate(<PeerSnapshot>[p], ctx(), nowMs: t0);
+      final Map<String, BanVerdict> r =
+          engine.evaluate(<PeerSnapshot>[p], ctx(), nowMs: t1);
+      expect(r['1.2.3.4']!.banned, isFalse);
+    });
+
+    test('小种子跳过 PCB', () {
+      final TorrentContext small = ctx(totalSize: 10 * kMiB);
+      final PeerSnapshot p = peer(totalUpload: 5 * kMiB, reportedProgress: 0);
+      engine.evaluate(<PeerSnapshot>[p], small, nowMs: t0);
+      final Map<String, BanVerdict> r =
+          engine.evaluate(<PeerSnapshot>[p], small, nowMs: t1);
+      expect(r['1.2.3.4']!.banned, isFalse);
+    });
+
+    test('progressRewind：进度从 0.6 退到 0.5 → ban', () {
+      // 宽限轮登记 lastProgress=0.6（上传量小，differenceTest 不触发）。
+      engine.evaluate(
+        <PeerSnapshot>[peer(totalUpload: kMiB, reportedProgress: 0.6)],
+        ctx(),
+        nowMs: t0,
+      );
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[peer(totalUpload: kMiB, reportedProgress: 0.5)],
+        ctx(),
+        nowMs: t1,
+      );
+      expect(r['1.2.3.4']!.banned, isTrue);
+      expect(r['1.2.3.4']!.reason, BanReason.progressRewind);
+    });
+
+    test('小幅进度回落不超阈值 → allow', () {
+      engine.evaluate(
+        <PeerSnapshot>[peer(totalUpload: kMiB, reportedProgress: 0.6)],
+        ctx(),
+        nowMs: t0,
+      );
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[peer(totalUpload: kMiB, reportedProgress: 0.57)],
+        ctx(),
+        nowMs: t1,
+      );
+      expect(r['1.2.3.4']!.banned, isFalse);
+    });
+
+    test('excessiveDownload：单 peer 上传 3.5x 种子 → ban', () {
+      final PeerSnapshot p =
+          peer(totalUpload: 350 * kMiB, reportedProgress: 1.0);
+      engine.evaluate(<PeerSnapshot>[p], ctx(), nowMs: t0);
+      final Map<String, BanVerdict> r =
+          engine.evaluate(<PeerSnapshot>[p], ctx(), nowMs: t1);
+      expect(r['1.2.3.4']!.banned, isTrue);
+      expect(r['1.2.3.4']!.reason, BanReason.excessiveDownload);
+    });
+
+    test('excessiveDownload：未完成任务用 completedSize 做基准', () {
+      // completedSize=50MiB，上传 160MiB > 50*3=150MiB → ban；
+      // 若按 totalSize=100MiB 则 160 < 300 不会 ban。
+      final TorrentContext partial = ctx(completedSize: 50 * kMiB);
+      final PeerSnapshot p =
+          peer(totalUpload: 160 * kMiB, reportedProgress: 1.0);
+      engine.evaluate(<PeerSnapshot>[p], partial, nowMs: t0);
+      final Map<String, BanVerdict> r =
+          engine.evaluate(<PeerSnapshot>[p], partial, nowMs: t1);
+      expect(r['1.2.3.4']!.banned, isTrue);
+      expect(r['1.2.3.4']!.reason, BanReason.excessiveDownload);
+    });
+
+    test('峰值抗断连：断连重连 totalUpload 归零仍按峰值判 → 仍 ban', () {
+      // 首轮建峰值 50MiB（自报一致，宽限内也不会 ban）。
+      engine.evaluate(
+        <PeerSnapshot>[peer(totalUpload: 50 * kMiB, reportedProgress: 0.5)],
+        ctx(),
+        nowMs: t0,
+      );
+      // 断连重连：totalUpload=0、自报 0.05 → computedUploaded 按峰值 50MiB，
+      // computedProgress 0.5 - 0.05 = 0.45 > 0.08 → ban。
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[peer(totalUpload: 0, reportedProgress: 0.05)],
+        ctx(),
+        nowMs: t1,
+      );
+      expect(r['1.2.3.4']!.banned, isTrue);
+      expect(r['1.2.3.4']!.reason, BanReason.progressCheat);
+    });
+  });
+
+  group('PeerId/ClientName 黑名单', () {
+    late AntiLeechEngine engine;
+
+    setUp(() => engine = AntiLeechEngine());
+
+    test('迅雷 peerId 做种时 → ban(xunleiSeeding)', () {
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[peer(peerId: '-XL0012-abcdefabcdef')],
+        ctx(isSeeding: true),
+        nowMs: 0,
+      );
+      expect(r['1.2.3.4']!.banned, isTrue);
+      expect(r['1.2.3.4']!.reason, BanReason.xunleiSeeding);
+    });
+
+    test('迅雷 peerId 非做种 → allow（可能是正常下载者）', () {
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[peer(peerId: '-XL0012-abcdefabcdef')],
+        ctx(isSeeding: false),
+        nowMs: 0,
+      );
+      expect(r['1.2.3.4']!.banned, isFalse);
+    });
+
+    test('client 以 thunder 开头也走迅雷特例', () {
+      final PeerSnapshot p = peer(client: 'Thunder 11.3.1');
+      expect(
+        engine.evaluate(<PeerSnapshot>[p], ctx(isSeeding: false),
+            nowMs: 0)['1.2.3.4']!.banned,
+        isFalse,
+      );
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[peer(ip: '1.2.4.4', client: 'Thunder 11.3.1')],
+        ctx(isSeeding: true),
+        nowMs: 0,
+      );
+      expect(r['1.2.4.4']!.reason, BanReason.xunleiSeeding);
+    });
+
+    test('非迅雷 peerId 前缀 -SD 直接 ban（与做种无关）', () {
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[peer(peerId: '-SD0100-abcdefabcdef')],
+        ctx(isSeeding: false),
+        nowMs: 0,
+      );
+      expect(r['1.2.3.4']!.banned, isTrue);
+      expect(r['1.2.3.4']!.reason, BanReason.peerIdBlacklist);
+    });
+
+    test('client 含 thunder（非开头）→ ban(clientBlacklist)', () {
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[peer(client: 'Fake thunder mod')],
+        ctx(isSeeding: false),
+        nowMs: 0,
+      );
+      expect(r['1.2.3.4']!.banned, isTrue);
+      expect(r['1.2.3.4']!.reason, BanReason.clientBlacklist);
+    });
+
+    test('正常客户端 → allow', () {
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[peer()],
+        ctx(isSeeding: true),
+        nowMs: 0,
+      );
+      expect(r['1.2.3.4']!.banned, isFalse);
+    });
+  });
+
+  group('MultiDialing 多拨', () {
+    late AntiLeechEngine engine;
+
+    setUp(() => engine = AntiLeechEngine());
+
+    test('同 /24 同种子第 9 个 IP（超容忍 8）→ ban 段，同轮后续同段连坐', () {
+      final List<PeerSnapshot> peers = <PeerSnapshot>[
+        for (int i = 1; i <= 10; i++) peer(ip: '1.2.3.$i'),
+      ];
+      final Map<String, BanVerdict> r = engine.evaluate(peers, ctx(), nowMs: 0);
+      for (int i = 1; i <= 8; i++) {
+        expect(r['1.2.3.$i']!.banned, isFalse, reason: 'ip 1.2.3.$i');
+      }
+      expect(r['1.2.3.9']!.banned, isTrue);
+      expect(r['1.2.3.9']!.reason, BanReason.multiDialing);
+      expect(r['1.2.3.9']!.cidr, '1.2.3.0/24');
+      // 第 10 个：段已进连坐源 → autoRangeBan。
+      expect(r['1.2.3.10']!.reason, BanReason.autoRangeBan);
+    });
+
+    test('计数跨 evaluate 轮累积', () {
+      engine.evaluate(
+        <PeerSnapshot>[for (int i = 1; i <= 5; i++) peer(ip: '7.7.7.$i')],
+        ctx(),
+        nowMs: 0,
+      );
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[for (int i = 6; i <= 9; i++) peer(ip: '7.7.7.$i')],
+        ctx(),
+        nowMs: 1000,
+      );
+      expect(r['7.7.7.8']!.banned, isFalse);
+      expect(r['7.7.7.9']!.reason, BanReason.multiDialing);
+    });
+
+    test('不同种子的同段连接不互相计数', () {
+      final List<PeerSnapshot> five = <PeerSnapshot>[
+        for (int i = 1; i <= 5; i++) peer(ip: '8.8.8.$i'),
+      ];
+      final Map<String, BanVerdict> rA =
+          engine.evaluate(five, ctx(infoHash: 'hash-a'), nowMs: 0);
+      final Map<String, BanVerdict> rB =
+          engine.evaluate(five, ctx(infoHash: 'hash-b'), nowMs: 0);
+      expect(rA.values.every((BanVerdict v) => !v.banned), isTrue);
+      expect(rB.values.every((BanVerdict v) => !v.banned), isTrue);
+    });
+  });
+
+  group('AutoRangeBan 连坐与规则短路顺序', () {
+    late AntiLeechEngine engine;
+
+    setUp(() => engine = AntiLeechEngine());
+
+    test('一个 IP 被 PCB ban 后，同 /24 另一 IP 下轮直接连坐', () {
+      final PeerSnapshot cheat =
+          peer(ip: '1.2.3.4', totalUpload: 50 * kMiB, reportedProgress: 0.05);
+      engine.evaluate(<PeerSnapshot>[cheat], ctx(), nowMs: 0);
+      final Map<String, BanVerdict> r1 =
+          engine.evaluate(<PeerSnapshot>[cheat], ctx(), nowMs: 60000);
+      expect(r1['1.2.3.4']!.reason, BanReason.progressCheat);
+      expect(engine.bannedCidrs, contains('1.2.3.0/24'));
+
+      final Map<String, BanVerdict> r2 = engine.evaluate(
+        <PeerSnapshot>[peer(ip: '1.2.3.5')],
+        ctx(),
+        nowMs: 61000,
+      );
+      expect(r2['1.2.3.5']!.banned, isTrue);
+      expect(r2['1.2.3.5']!.reason, BanReason.autoRangeBan);
+      expect(r2['1.2.3.5']!.cidr, '1.2.3.0/24');
+    });
+
+    test('连坐优先于黑名单：同段黑名单 peer 报 autoRangeBan', () {
+      // 先用黑名单 ban 登记 9.9.9.0/24。
+      engine.evaluate(
+        <PeerSnapshot>[peer(ip: '9.9.9.1', peerId: '-SD0100-abcdefabcdef')],
+        ctx(),
+        nowMs: 0,
+      );
+      // 同段另一个黑名单 peer：规则 ① 先命中。
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[peer(ip: '9.9.9.2', peerId: '-SD0100-abcdefabcdef')],
+        ctx(),
+        nowMs: 1000,
+      );
+      expect(r['9.9.9.2']!.reason, BanReason.autoRangeBan);
+    });
+
+    test('黑名单优先于 PCB 且不受宽限窗口保护', () {
+      // 首见即判（PCB 此时还在宽限窗口内）。
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[
+          peer(
+            peerId: '-SD0100-abcdefabcdef',
+            totalUpload: 50 * kMiB,
+            reportedProgress: 0.05,
+          ),
+        ],
+        ctx(),
+        nowMs: 0,
+      );
+      expect(r['1.2.3.4']!.reason, BanReason.peerIdBlacklist);
+    });
+
+    test('IPv6 peer 被 ban 后同 /60 段连坐', () {
+      engine.evaluate(
+        <PeerSnapshot>[
+          peer(ip: '2001:db8:aaaa:bbf5::1', peerId: '-SD0100-abcdefabcdef'),
+        ],
+        ctx(),
+        nowMs: 0,
+      );
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[peer(ip: '2001:db8:aaaa:bbf9::2')],
+        ctx(),
+        nowMs: 1000,
+      );
+      expect(r['2001:db8:aaaa:bbf9::2']!.reason, BanReason.autoRangeBan);
+      expect(r['2001:db8:aaaa:bbf9::2']!.cidr, '2001:db8:aaaa:bbf0:0:0:0:0/60');
+    });
+  });
+}


### PR DESCRIPTION
## 反吸血判定引擎（纯 Dart 核心，复刻 PeerBanHelper）

内置 libtorrent 下载引擎的地基之一（阶段0 `TorrentBackend` 接口抽象已随 PR #204 进 develop）。这是**反吸血的纯逻辑核心**——把 PeerBanHelper 的规则复刻成纯函数，**不碰 libtorrent、不碰网络、不执行封禁**，只做判定。将来 native libtorrent 引擎把 `peer_info` 映射成 `PeerSnapshot` 喂进来，把 `BanVerdict` 翻成 libtorrent `ip_filter`。

### 核心：进度作弊检测（PCB）
PBH 反吸血的心脏——**「我实际喂给这个 peer 多少字节」（`totalUpload`，可信）对「peer 自报进度」（`reportedProgress`，可伪造），对不上就是吸血。**
- `computedUploaded = max(totalUpload, 历史峰值)`：抗断连重置（peer 断连重连后计数归零，仍按峰值判）
- 差异测试：`computedProgress - reportedProgress > 阈值` → 封（谎报低进度骗持续上传）
- 进度倒退、过量下载（单 peer 下走量超种子数倍 = PCDN 回源）
- 握手宽限窗口：首见后 N 秒 / bitfield 未就绪不判，避免误封

### 其余规则（短路顺序：连坐 → 黑名单 → 多拨 → PCB）
- peer_id / 客户端名黑名单（迅雷特例：做种时才封，不做种放行）
- MultiDialing 多拨/PCDN（同网段同种子连接数超阈值封段）
- AutoRangeBan 连坐（封一个 IP，同 CIDR 新 peer 连坐）

### 说明
- 阈值默认贴 PBH 语义、非官方精确值，doc 注明待真机调优。
- 时间全经 `nowMs` 注入（零 `DateTime.now()`，确定性单测）。
- 34 用例覆盖全部规则分支；`test/torrent/` 全量 129 用例绿；`flutter analyze` 零问题。

完整多阶段路线（native bridge 待另起 job）见项目看板 TODO-1649。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
