### PR TITLE
fix(settings): BUG-886 折叠分组标题头与箭头垂直居中

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 866 条。点号进各自文件。
+> 共 867 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-886](bugs/BUG-886-collapse-header-center.md) | ✅ | ✅ | 折叠设置分组标题头文字与箭头未垂直居中 |
 | [BUG-885](bugs/BUG-885-ext-shift-hover-miss.md) | 🚧 | 🚧 | 浏览器扩展 Shift 悬停查词约 80% 不弹（机器相关，本机未复现） |
 | [BUG-884](bugs/BUG-884-extension-lookup-compact-result.md) | ✅ | ✅ | 浏览器扩展查词响应重复携带原始词条导致冷链路慢 |
 | [BUG-883](bugs/BUG-883-extension-shadow-text-align.md) | ✅ | ✅ | 浏览器扩展弹窗继承宿主页居中对齐 |

--- a/docs/bugs/BUG-886-collapse-header-center.md
+++ b/docs/bugs/BUG-886-collapse-header-center.md
@@ -1,0 +1,6 @@
+## BUG-886 · 折叠设置分组标题头文字与箭头未垂直居中
+- **报告**：2026-07-18（用户：）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/utils/components/settings_shared.dart:196`（PR#209 合入的可折叠 section 标题头）。`AdaptiveSettingsSurface._buildContainedTitle` 直接复用「行上方小标题」的上重下轻 padding `fromLTRB(12, 10, 12, 4)`（上10/下4）来渲染折叠头 label；折叠头那一行里 chevron 按 Row 默认 `crossAxisAlignment.center` 垂直居中，导致标题文字比 chevron 低约 3px，视觉上没居中。
+- **[x] ① 已修复** — `settings_shared.dart:_buildContainedTitle` 增加 `interactive = onTitleTap != null` 判定：折叠头（可点整头）用上下对称 padding（Material `fromLTRB(12, 10, 12, 10)` / Cupertino `fromLTRB(16, 10, 16, 10)`），标题与 chevron 共享同一垂直中线；静态内嵌小标题（`onTitleTap == null`）保持上重下轻贴住下方设置行，行为不变。提交：<待填>
+- **[x] ② 已加自动化测试** — `hibiki/test/widgets/settings_shared_test.dart`：`collapsible section header title is vertically centered with its chevron (BUG-886)`，构建 `collapsible: true` 的 `AdaptiveSettingsSection`，断言标题文字与 `Icons.expand_more` 的垂直中心差 < 1.5px。已验：还原修复后该测试失败（差约 3px），修复后通过。
+- **备注**：同批用户反馈的「互联与同步后端不冲突」（互联从单一 `SyncBackendType` 解耦）是独立架构改动，另立 PR 根修，不在本 bug 范围。

--- a/hibiki/lib/src/utils/components/settings_shared.dart
+++ b/hibiki/lib/src/utils/components/settings_shared.dart
@@ -180,9 +180,17 @@ class AdaptiveSettingsSurface extends StatelessWidget {
     HibikiDesignTokens tokens,
     bool cupertino,
   ) {
+    // 折叠头（onTitleTap != null）是带尾随箭头的可点整头：箭头在 Row 里按
+    // crossAxisAlignment.center 垂直居中，标题必须用上下对称 padding 才能与箭头
+    // 在同一垂直中线上（否则上重下轻的标签 padding 会让标题比箭头低几像素）。
+    // 静态内嵌小标题（onTitleTap == null）是行上方的标签，保持上重下轻贴住下方
+    // 设置行，行为不变。
+    final bool interactive = onTitleTap != null;
     final Widget label = cupertino
         ? Padding(
-            padding: const EdgeInsets.fromLTRB(16, 10, 16, 4),
+            padding: interactive
+                ? const EdgeInsets.fromLTRB(16, 10, 16, 10)
+                : const EdgeInsets.fromLTRB(16, 10, 16, 4),
             child: Text(
               title!.toUpperCase(),
               style: tokens.type.metadata.copyWith(
@@ -193,10 +201,12 @@ class AdaptiveSettingsSurface extends StatelessWidget {
           )
         : SettingsSectionHeader(
             title!,
-            padding: const EdgeInsets.fromLTRB(12, 10, 12, 4),
+            padding: interactive
+                ? const EdgeInsets.fromLTRB(12, 10, 12, 10)
+                : const EdgeInsets.fromLTRB(12, 10, 12, 4),
           );
 
-    if (onTitleTap == null) return label;
+    if (!interactive) return label;
 
     // 折叠头：标题 + 尾随箭头拼成整头，整头可点、可焦点驱动展开/收起。焦点驱动走
     // 与设置行一致的 _SettingsRowFocusTarget（Enter/手柄 A 触发 Activate），保证纯

--- a/hibiki/test/widgets/settings_shared_test.dart
+++ b/hibiki/test/widgets/settings_shared_test.dart
@@ -803,4 +803,46 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.widgetWithText(MenuItemButton, 'Work'), findsNothing);
   });
+
+  testWidgets(
+      'collapsible section header title is vertically centered with its chevron '
+      '(BUG-886)', (tester) async {
+    // Regression guard (BUG-886): the collapsible header reused the label-above-
+    // rows padding (top-heavy 10/4), so the title text sat ~3px below the chevron
+    // (which is center-aligned in the header Row). The interactive header must use
+    // symmetric vertical padding so title and chevron share one vertical center.
+    await tester.pumpWidget(
+      _buildHarness(
+        platform: TargetPlatform.android,
+        child: Scaffold(
+          body: AdaptiveSettingsSection(
+            title: 'Local backup',
+            titlePlacement: SettingsSectionTitlePlacement.inside,
+            collapsible: true,
+            children: [
+              AdaptiveSettingsSwitchRow(
+                title: 'Highlight on tap',
+                value: true,
+                onChanged: (_) {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    // The collapsible header renders the folding chevron alongside the title.
+    expect(find.byIcon(Icons.expand_more), findsOneWidget);
+    final double titleCenter = tester.getCenter(find.text('Local backup')).dy;
+    final double chevronCenter =
+        tester.getCenter(find.byIcon(Icons.expand_more)).dy;
+    expect(
+      (titleCenter - chevronCenter).abs(),
+      lessThan(1.5),
+      reason:
+          'collapsible header title and chevron must be on the same vertical '
+          'center; a top-heavy label padding would drop the title below it',
+    );
+  });
 }


### PR DESCRIPTION
## 问题
可折叠设置分组的标题头(如「本地备份」「数据存储位置」)标题文字比右侧下拉箭头低约 3px,视觉上没居中。

## 根因
`AdaptiveSettingsSurface._buildContainedTitle`(settings_shared.dart)直接复用「行上方小标题」的上重下轻 padding `fromLTRB(12, 10, 12, 4)` 渲染折叠头 label;折叠头 Row 里箭头按默认 `crossAxisAlignment.center` 垂直居中,两者不在同一垂直中线。

## 修复
增加 `interactive = onTitleTap != null` 判定:可点整头(折叠头)用上下对称 padding(Material `12,10,12,10` / Cupertino `16,10,16,10`),标题与箭头共享同一垂直中线;静态内嵌小标题保持贴住下方设置行的原行为不变。

## 测试
`test/widgets/settings_shared_test.dart` 新增守卫:构建 `collapsible: true` 分组,断言标题文字与 `Icons.expand_more` 垂直中心差 < 1.5px。已验:还原修复该测试失败(差约 3px),修复后通过。全量 `flutter analyze` 干净;`test/settings` + `settings_shared_test` 共 291 passed。

BUG: docs/bugs/BUG-886-collapse-header-center.md

> 注:同批用户反馈的「互联与同步后端不冲突」(互联从单一 SyncBackendType 解耦)是独立架构改动,另立 PR 根修。