### PR TITLE
fix(reader): 挤压模式顶部进度不套毛玻璃 (BUG-886)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 866 条。点号进各自文件。
+> 共 867 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-886](bugs/BUG-886-top-progress-squeeze-frost.md) | ✅ | ✅ | 挤压模式顶部进度不应有毛玻璃且不应压住正文首行 |
 | [BUG-885](bugs/BUG-885-ext-shift-hover-miss.md) | 🚧 | 🚧 | 浏览器扩展 Shift 悬停查词约 80% 不弹（机器相关，本机未复现） |
 | [BUG-884](bugs/BUG-884-extension-lookup-compact-result.md) | ✅ | ✅ | 浏览器扩展查词响应重复携带原始词条导致冷链路慢 |
 | [BUG-883](bugs/BUG-883-extension-shadow-text-align.md) | ✅ | ✅ | 浏览器扩展弹窗继承宿主页居中对齐 |

--- a/docs/bugs/BUG-886-top-progress-squeeze-frost.md
+++ b/docs/bugs/BUG-886-top-progress-squeeze-frost.md
@@ -1,0 +1,6 @@
+## BUG-886 · 挤压模式顶部进度不应有毛玻璃且不应压住正文首行
+- **报告**：2026-07-18（用户：竖排、横线起笔字如「一」「ー」，顶部信息条模糊略盖正文首行；且未开悬浮顶部进度，本不该有背后模糊）
+- **真实性**：✅ 真 bug，根因 `hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart:1665`（`_buildTopProgressBar` 无条件套 `ClipRRect > BackdropFilter(ImageFilter.blur) > 半透明 Container` 毛玻璃）
+- **[x] ① 已修复** — 毛玻璃改为仅悬浮态绘制。单一真相源 `topProgressUsesFrostedGlass(floating:)`（`hibiki/lib/src/reader/reader_chrome_floating.dart`），挤压态返回 `false`：strip 已预留自身高度、正文被推到其下方，pill 落在预留区（正文空白顶边距 = 主题背景）之上，背后并无正文，毛玻璃既无意义又显出一块贴住正文首行的模糊矩形。挤压态改为纯文字（`Padding > Text`，无背景无模糊）；悬浮态维持毛玻璃提升可读性。提交：<pending>
+- **[x] ② 已加自动化测试** — `hibiki/test/reader/reader_top_progress_reserve_test.dart` 新增 group「BUG-886 顶部进度毛玻璃只在悬浮态出现」：`topProgressUsesFrostedGlass(floating:false)` 必 `false`、`floating:true` 必 `true`；一旦有人把毛玻璃改回无条件绘制即失败。
+- **备注**：与 BUG-843/BUG-547（预留高漏计 pill 内边距导致压住首行，已由 `kTopProgressStripHeight = font×1.5 + 2×padding = 24` 修复）同族但正交——843 修「预留 < pill 实高」的布局越界，886 修「挤压态根本不该有毛玻璃」的视觉噪声。两者叠加后挤压态既不越界也不显模糊。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
@@ -1629,12 +1629,14 @@ extension _ReaderChrome on _ReaderHibikiPageState {
     final Color infoColor = _themeTextColor();
     final String position = ReaderHibikiSource.instance.topProgressPosition;
 
-    // TODO-1136 / BUG-frosted：进度文字直接叠在正文上，浅色书/复杂背景下
-    //  看不清。在文字后面加一层毛玻璃（frosted glass）背景提升可读性——
-    //  经典配方（ClipRRect > BackdropFilter(ImageFilter.blur)
-    //  > 半透明 Container），背景色/文字色跟随当前主题
-    //  （_themeBackgroundColor / _themeTextColor），不硬编码。BackdropFilter 必须
-    //  在 ClipRRect 内限定到 pill 自身矩形，避免整页模糊。
+    // TODO-1136 / BUG-frosted：进度文字直接叠在正文上，浅色书/复杂背景下看不清，
+    //  在文字后面加一层毛玻璃（frosted glass）背景提升可读性——经典配方
+    //  （ClipRRect > BackdropFilter(ImageFilter.blur) > 半透明 Container），背景/文字
+    //  色跟随当前主题（_themeBackgroundColor / _themeTextColor），不硬编码。
+    //  BUG-886：毛玻璃只在**悬浮**模式有意义——那时进度真正浮在正文之上。挤压模式
+    //  下 strip 预留了自身高度、正文被推到其下方，pill 落在预留区（正文空白顶边距
+    //  = 主题背景）之上，背后并无正文，毛玻璃既无意义又会显出一块贴着正文首行的模糊
+    //  矩形（横线字如「一」「ー」尤为明显）。故 frostedFill 仅悬浮态使用。
     final Color frostedFill = _themeBackgroundColor()
         .withValues(alpha: _isReaderThemeDark ? 0.42 : 0.55);
 
@@ -1649,6 +1651,43 @@ extension _ReaderChrome on _ReaderHibikiPageState {
     //    (penetration guard).
     //  - No Focus/canRequestFocus wrapper: this stays a pure pointer surface and
     //    must never enter the focus-traversal pool (TODO-700 invariant).
+    final Text label = Text(
+      '$_progressCurrentChars / $_progressTotalChars'
+      '  ${(ratio * 100).toStringAsFixed(2)}%',
+      key: const ValueKey<String>('hoshi_progress'),
+      style: TextStyle(
+          fontSize: _ReaderHibikiPageState._infoFontSize, color: infoColor),
+      textAlign: readerTopProgressTextAlign(position),
+    );
+
+    // BUG-886：仅悬浮态套毛玻璃；挤压态是纯文字，无背景无模糊（见上方 frostedFill
+    //  注释）。两态纵向内边距同源 [kTopProgressPillVerticalPadding]，pill 实高不超
+    //  预留 [_infoStripHeight]（= [kTopProgressStripHeight]，BUG-547 已把预留同步含
+    //  该内边距），保证挤压态 pill 落在预留区内、绝不压住正文首行。
+    final Widget pill =
+        topProgressUsesFrostedGlass(floating: _topProgressFloating)
+            ? ClipRRect(
+                borderRadius: BorderRadius.circular(10),
+                child: BackdropFilter(
+                  filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+                  child: Container(
+                    color: frostedFill,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: kTopProgressPillVerticalPadding,
+                    ),
+                    child: label,
+                  ),
+                ),
+              )
+            : Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 8,
+                  vertical: kTopProgressPillVerticalPadding,
+                ),
+                child: label,
+              );
+
     return Positioned(
       top: _stableTopInset,
       left: 16,
@@ -1662,32 +1701,7 @@ extension _ReaderChrome on _ReaderHibikiPageState {
           onTap: _anyChromeFloating
               ? () => _handleFloatingChromeReveal()
               : _toggleChrome,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(10),
-            child: BackdropFilter(
-              filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-              child: Container(
-                color: frostedFill,
-                // TODO-975 铁律：pill 上下内边距与预留高 [_infoStripHeight]
-                // （= [kTopProgressStripHeight]）共享同一常量
-                // [kTopProgressPillVerticalPadding]，pill 实高绝不超预留（BUG-547
-                // 曾只加 padding 未同步预留 → 压住正文首行）。
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 8,
-                  vertical: kTopProgressPillVerticalPadding,
-                ),
-                child: Text(
-                  '$_progressCurrentChars / $_progressTotalChars'
-                  '  ${(ratio * 100).toStringAsFixed(2)}%',
-                  key: const ValueKey<String>('hoshi_progress'),
-                  style: TextStyle(
-                      fontSize: _ReaderHibikiPageState._infoFontSize,
-                      color: infoColor),
-                  textAlign: readerTopProgressTextAlign(position),
-                ),
-              ),
-            ),
-          ),
+          child: pill,
         ),
       ),
     );

--- a/hibiki/lib/src/reader/reader_chrome_floating.dart
+++ b/hibiki/lib/src/reader/reader_chrome_floating.dart
@@ -102,3 +102,17 @@ bool topProgressVisible({
   if (!floating) return true;
   return transientVisible;
 }
+
+/// Whether the top progress pill paints a frosted-glass (BackdropFilter blur +
+/// translucent fill) background behind its text — single source of truth for
+/// `_buildTopProgressBar`'s pill branch.
+///
+/// BUG-886: the frost only makes sense when [floating] — there the pill is a
+/// [Positioned] overlay genuinely on top of the body text, so a complex/light
+/// background needs the frost for legibility. In squeeze mode the strip reserves
+/// its own height and the body is pushed BELOW it, so the pill sits over the
+/// body's blank top margin (the theme background), not over text; a frost there
+/// is pointless and reads as a blurred rectangle hugging the first body line
+/// (worst on glyphs with a stroke at the very top, e.g. 「一」「ー」). So squeeze
+/// mode renders plain text with no blur and no fill.
+bool topProgressUsesFrostedGlass({required bool floating}) => floating;

--- a/hibiki/test/reader/reader_top_progress_reserve_test.dart
+++ b/hibiki/test/reader/reader_top_progress_reserve_test.dart
@@ -78,4 +78,21 @@ void main() {
     // 显式钉住期望数值，防止无意改动悄悄回落：12×1.5 + 2×3 = 24。
     expect(kTopProgressStripHeight, 24.0);
   });
+
+  group('BUG-886 顶部进度毛玻璃只在悬浮态出现', () {
+    test('挤压态（未开悬浮进度）不套毛玻璃', () {
+      // 用户报告：没开悬浮顶部进度，pill 背后却有一层模糊贴住正文首行。挤压态 pill
+      // 落在预留区（正文空白顶边距 = 主题背景）上，背后没有正文，毛玻璃无意义。
+      expect(
+        topProgressUsesFrostedGlass(floating: false),
+        isFalse,
+        reason: '挤压模式顶部进度必须是纯文字、无 BackdropFilter 模糊；'
+            '一旦有人把毛玻璃改回无条件绘制（BUG-886 回归），此断言即失败',
+      );
+    });
+
+    test('悬浮态才套毛玻璃（浮在正文之上需提升可读性）', () {
+      expect(topProgressUsesFrostedGlass(floating: true), isTrue);
+    });
+  });
 }


### PR DESCRIPTION
## 问题
竖排、横线起笔字（「一」「ー」）下，顶部阅读进度信息条背后的毛玻璃略盖住正文首行；且用户**未开悬浮顶部进度**，本不该有背后模糊。

## 根因
`_buildTopProgressBar`（`chrome.part.dart`）**无条件**给进度 pill 套 `ClipRRect > BackdropFilter(ImageFilter.blur) > 半透明 Container` 毛玻璃。毛玻璃只在**悬浮**态有意义——那时 pill 真正浮在正文之上。挤压态 strip 已预留自身高度、正文被推到其下方，pill 落在预留区（正文空白顶边距 = 主题背景）之上，背后并无正文，毛玻璃既无意义又显出一块贴住正文首行的模糊矩形。

## 修复
- 新增单一真相源纯函数 `topProgressUsesFrostedGlass(floating:)`（`reader_chrome_floating.dart`）：挤压态 `false`、悬浮态 `true`。
- `_buildTopProgressBar` 据此分支：悬浮态维持毛玻璃提升可读性；挤压态改为纯文字（`Padding > Text`，无背景无模糊）。两态纵向内边距同源，pill 实高不超预留（BUG-547/843 已修的预留=24 不变）。

## 测试
`test/reader/reader_top_progress_reserve_test.dart` 新增 BUG-886 group：`floating:false`→无毛玻璃、`floating:true`→有毛玻璃。全 6 用例通过；`flutter analyze` 三文件 0 issue。

## 验证状态
- [x] flutter analyze / flutter test 通过
- [ ] 真机复测竖排横线起笔字 + 关闭悬浮进度（待真机验收）

与 BUG-843/547（预留漏计 pill 内边距 → 越界压首行）同族但正交。