### PR TITLE
feat(tags): 标签行长按/右键上下文菜单，补齐删除入口

### DIFF
--- a/hibiki/lib/src/pages/implementations/tag_management_page.dart
+++ b/hibiki/lib/src/pages/implementations/tag_management_page.dart
@@ -23,6 +23,9 @@ const List<int> kTagPresetColors = [
   0xFF78909C, // blue grey
 ];
 
+/// 标签行长按 / 右键上下文菜单的动作。
+enum _TagMenuAction { edit, delete }
+
 class TagManagementPage extends ConsumerStatefulWidget {
   const TagManagementPage({super.key});
 
@@ -98,6 +101,58 @@ class _TagManagementPageState extends ConsumerState<TagManagementPage> {
       rethrow;
     }
     await _reload();
+  }
+
+  /// 长按（原地松手）/ 右键弹出上下文菜单：编辑 + 删除。照仓库既有卡片长按菜单
+  /// 范式（[_showMemberMenu] 的 showMenu + Overlay.globalToLocal 换算）。桌面端鼠标
+  /// 既无 swipe 又无 gamepad，删除此前无入口——本菜单补齐，同时保留 tap→编辑、
+  /// swipe→删除、gamepad X→删除。
+  Future<void> _showTagMenu(BookTagRow tag, Offset globalPosition) async {
+    final RenderObject? overlay =
+        Overlay.of(context).context.findRenderObject();
+    if (overlay is! RenderBox) return;
+    // 与 media_collection_grid_detail_page 同理：globalPosition 是真实视口坐标，
+    // 需经 Overlay 的 RenderBox 换算到根 Navigator Overlay 坐标系，界面缩放≠100%
+    // 时才不偏移（scale=1 时为单位阵，逐像素等价）。
+    final Offset anchor = overlay.globalToLocal(globalPosition);
+    final RelativeRect position = RelativeRect.fromRect(
+      Rect.fromPoints(anchor, anchor),
+      Offset.zero & overlay.size,
+    );
+    final ColorScheme scheme = Theme.of(context).colorScheme;
+    final _TagMenuAction? action = await showMenu<_TagMenuAction>(
+      context: context,
+      position: position,
+      items: <PopupMenuEntry<_TagMenuAction>>[
+        PopupMenuItem<_TagMenuAction>(
+          value: _TagMenuAction.edit,
+          child: Row(
+            children: <Widget>[
+              const Icon(Icons.edit_outlined, size: 20),
+              const SizedBox(width: 12),
+              Text(t.dialog_edit),
+            ],
+          ),
+        ),
+        PopupMenuItem<_TagMenuAction>(
+          value: _TagMenuAction.delete,
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.delete_outline, size: 20, color: scheme.error),
+              const SizedBox(width: 12),
+              Text(t.dialog_delete, style: TextStyle(color: scheme.error)),
+            ],
+          ),
+        ),
+      ],
+    );
+    if (!mounted || action == null) return;
+    switch (action) {
+      case _TagMenuAction.edit:
+        await _editTag(tag);
+      case _TagMenuAction.delete:
+        await _deleteTag(tag);
+    }
   }
 
   Future<void> _deleteTag(BookTagRow tag) async {
@@ -211,14 +266,21 @@ class _TagManagementPageState extends ConsumerState<TagManagementPage> {
                         },
                       ),
                     },
-                    child: HibikiListItem(
-                      leading: CircleAvatar(
-                        backgroundColor: Color(tag.colorValue),
-                        radius: 14,
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.translucent,
+                      onLongPressStart: (LongPressStartDetails d) =>
+                          _showTagMenu(tag, d.globalPosition),
+                      onSecondaryTapDown: (TapDownDetails d) =>
+                          _showTagMenu(tag, d.globalPosition),
+                      child: HibikiListItem(
+                        leading: CircleAvatar(
+                          backgroundColor: Color(tag.colorValue),
+                          radius: 14,
+                        ),
+                        title: Text(tag.name),
+                        trailing: Text(t.tag_book_count(count: count)),
+                        onTap: () => _editTag(tag),
                       ),
-                      title: Text(tag.name),
-                      trailing: Text(t.tag_book_count(count: count)),
-                      onTap: () => _editTag(tag),
                     ),
                   ),
                 );

--- a/hibiki/test/pages/tag_management_context_menu_source_guard_test.dart
+++ b/hibiki/test/pages/tag_management_context_menu_source_guard_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 源码守卫：锁定「标签管理页每行长按 + 右键弹上下文菜单（编辑 + 删除）」，防止
+/// 回归到桌面端鼠标无删除入口（此前删除仅 swipe / gamepad X，鼠标只能 tap→编辑）。
+///
+/// 用源码扫描而非整页 widget pump：[TagManagementPage] 依赖完整 AppModel + DB，
+/// 整页启动成本高且脆弱；这里的不变式（长按 / 右键指向同一菜单构建器、菜单同时含
+/// 编辑与删除动作）正是用户报的「只能编辑不能删除」的精确反面，源码扫描足以守住。
+String _read(String relative) {
+  final File f = File(relative);
+  if (!f.existsSync()) {
+    throw StateError(
+        'missing source: $relative (cwd=${Directory.current.path})');
+  }
+  return f.readAsStringSync();
+}
+
+String _methodBody(String source, String signature) {
+  final int start = source.indexOf(signature);
+  if (start < 0) {
+    throw StateError('missing method signature: $signature');
+  }
+  final int bodyStart = source.indexOf('{', start);
+  if (bodyStart < 0) {
+    throw StateError('missing method body: $signature');
+  }
+  int depth = 0;
+  for (int i = bodyStart; i < source.length; i++) {
+    final String ch = source[i];
+    if (ch == '{') depth++;
+    if (ch == '}') {
+      depth--;
+      if (depth == 0) return source.substring(start, i + 1);
+    }
+  }
+  throw StateError('unterminated method body: $signature');
+}
+
+void main() {
+  final String src =
+      _read('lib/src/pages/implementations/tag_management_page.dart');
+
+  group('标签管理页长按 / 右键上下文菜单', () {
+    test('标签行同时绑定长按与右键，都指向 _showTagMenu', () {
+      expect(src.contains('onLongPressStart:'), isTrue,
+          reason: '长按必须弹菜单');
+      expect(src.contains('onSecondaryTapDown:'), isTrue,
+          reason: '右键必须弹菜单');
+      // 两个触发器都换算真实坐标喂给同一菜单构建器。
+      expect(src.contains('_showTagMenu(tag, d.globalPosition)'), isTrue,
+          reason: '长按 / 右键共用同一菜单入口');
+    });
+
+    test('菜单同时提供编辑与删除动作', () {
+      final String menuBody = _methodBody(
+        src,
+        'Future<void> _showTagMenu(BookTagRow tag, Offset globalPosition)',
+      );
+      expect(menuBody.contains('_TagMenuAction.edit'), isTrue);
+      expect(menuBody.contains('_TagMenuAction.delete'), isTrue);
+      expect(menuBody.contains('_editTag(tag)'), isTrue,
+          reason: '编辑动作接回既有 _editTag');
+      expect(menuBody.contains('_deleteTag(tag)'), isTrue,
+          reason: '删除动作接回既有 _deleteTag（含确认弹窗）');
+    });
+
+    test('tap 仍是快捷编辑，删除既有 swipe / gamepad 入口保留', () {
+      expect(src.contains('onTap: () => _editTag(tag)'), isTrue,
+          reason: 'tap→编辑保持不变（向后兼容）');
+      // swipe 删除与 gamepad X 删除的既有入口不得被本次改动移除。
+      expect(src.contains('confirmDismiss:'), isTrue,
+          reason: 'swipe 删除入口保留');
+      expect(src.contains('GamepadButton.x'), isTrue,
+          reason: 'gamepad X 删除入口保留');
+    });
+  });
+}


### PR DESCRIPTION
## 问题
标签管理页此前只能 tap→编辑，删除仅通过 swipe 或 gamepad X。桌面端鼠标既无 swipe 又无手柄，实际上**无法删除标签**（用户报告：只能编辑不能删除）。

## 修复
- 每个标签行包一层 `GestureDetector`：**长按**（`onLongPressStart`）与**右键**（`onSecondaryTapDown`）都弹出同一上下文菜单（编辑 + 删除）。
- 菜单复用既有 `_editTag` / `_deleteTag`（删除仍走 `TagDeleteConfirmationDialog` 确认弹窗），未新写删除逻辑。
- 照 `media_collection_grid_detail_page._showMemberMenu` 的 `showMenu` + `Overlay.globalToLocal` 坐标换算范式，界面缩放≠100% 时菜单不偏移。
- **向后兼容**：tap→编辑、swipe→删除、gamepad X→删除全部保留。
- 无新增 i18n key（复用 `dialog_edit` / `dialog_delete`）。

## 测试
- 新增源码守卫 `test/pages/tag_management_context_menu_source_guard_test.dart`（3 项，锁定长按+右键共用菜单入口、菜单含编辑+删除、既有入口保留）——全绿。
- `flutter analyze` 目标文件 0 issue。

## 待真机
桌面端右键 / 移动端长按弹菜单并删除标签的真机验收待补。