### PR TITLE
fix(audiobook): 图片等待自动恢复尊重手动翻页 (BUG-890)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 866 条。点号进各自文件。
+> 共 867 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-890](bugs/BUG-890-paused-audio-follow-image-snap.md) | ✅ | ✅ | 暂停/图片等待时有声书跟随把阅读器拽回音频位置 |
 | [BUG-885](bugs/BUG-885-ext-shift-hover-miss.md) | 🚧 | 🚧 | 浏览器扩展 Shift 悬停查词约 80% 不弹（机器相关，本机未复现） |
 | [BUG-884](bugs/BUG-884-extension-lookup-compact-result.md) | ✅ | ✅ | 浏览器扩展查词响应重复携带原始词条导致冷链路慢 |
 | [BUG-883](bugs/BUG-883-extension-shadow-text-align.md) | ✅ | ✅ | 浏览器扩展弹窗继承宿主页居中对齐 |

--- a/docs/bugs/BUG-890-paused-audio-follow-image-snap.md
+++ b/docs/bugs/BUG-890-paused-audio-follow-image-snap.md
@@ -1,0 +1,40 @@
+## BUG-890 · 暂停/图片等待时有声书跟随把阅读器拽回音频位置
+- **报告**：2026-07-18（用户：）
+- **真实性**：✅ 真 bug（沿真实代码路径定位）。根因链见下。
+- **[x] ① 已修复** — 见下方修复
+- **[x] ② 已加自动化测试** — `hibiki/test/media/audiobook/image_pause_resume_manual_nav_test.dart`
+- **备注**：真机复测原始失败路径待做。
+
+### 现象
+开着「跟随音频」阅读带有声书的 EPUB，向前翻页想回看/预读时被拽回音频位置。用户观察：
+- 平常暂停时随便翻没问题；
+- 但**向前**跨过含插图的章（如 あとがき 前后必有一张图）时，被重置回“当前（音频）位置”；
+- “不是我触发的”，试几次才复现。
+
+### 根因
+不是普通暂停态。触发者是**图片等待**（`imagePauseSec>0`）的自动暂停+自动恢复：
+
+1. 播放中朗读跨过插图 → reader 的 `onImageDetected` → `AudiobookPlayerController.triggerImagePause()`
+   （`packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart:331`）暂停播放并 arm 一个
+   `imagePauseSec` 秒的定时器。用户此刻看到“音频停了”，以为可自由翻页。
+2. 用户在这几秒窗口内手动向前翻页 → `noteManualReaderNavigation()`（`:1173`）把
+   `_manualReaderOverrideCue = _currentCue`（图片那句），这枚一次性护栏本应让后续跟随保位不跳。
+3. 定时器到点：`triggerImagePause` 回调（`:336`）`_player.play()` 恢复播放后**无条件**调
+   `snapReaderToAudio()`（`:1208`）。`snapReaderToAudio` 会 `_manualReaderOverrideCue = null`（`:1212`）
+   清掉护栏 + 置 `_forceNextReveal` + `_maybeEmitCrossChapter(cue, bypassPlayGuard: true)`——于是把
+   reader 强行拽回音频所在章。用户手动翻到的位置被吃掉。
+
+对比：章内滚动跟随（`shouldRevealCurrentCue` `:1053`）已用 `_player.playing` 把关，跨章跟随/强制
+reveal 却只靠会被 `snapReaderToAudio` 清掉的一次性护栏——图片等待的自动恢复正好清掉它。
+
+### 修复
+图片等待的自动恢复**尊重手动导航**：若用户在暂停窗口内手动翻页离开，恢复播放时不再强制 snap，
+让跟随只在播放真正推进到**下一句**时经既有护栏自然接管（正是用户诉求）。
+
+- `triggerImagePause`：arm 定时器时清 `_readerMovedDuringImagePause=false`；回调里 `play()` 后仅当
+  未手动移动才 `snapReaderToAudio()`。
+- `noteManualReaderNavigation`：图片等待在途（`isImagePaused`）时置 `_readerMovedDuringImagePause=true`。
+- 纯决策 `shouldSnapAfterImagePauseResume(readerMovedDuringPause)` 抽出便于单测。
+- 生命周期各清点（`load`/`pause`/`play`/`dispose`）复位标志，杜绝泄漏。
+
+未手动移动的老用户路径（看完图→自动继续）行为不变。

--- a/hibiki/test/media/audiobook/image_pause_resume_manual_nav_test.dart
+++ b/hibiki/test/media/audiobook/image_pause_resume_manual_nav_test.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+/// BUG-890：开着「跟随音频」+「图片等待」阅读有声书，朗读跨过插图时图片等待自动
+/// 暂停几秒。用户在这几秒窗口内手动向前翻页（想预读/跨过 あとがき 的插图章），
+/// 图片等待到点自动恢复播放时，旧逻辑无条件 `snapReaderToAudio()` —— 它清掉
+/// `_manualReaderOverrideCue` 护栏并 `_maybeEmitCrossChapter(bypassPlayGuard:true)`，
+/// 把 reader 强行拽回音频所在章，吃掉用户手动翻到的位置。
+///
+/// 根因：跨章跟随/强制 reveal 未像章内滚动（`shouldRevealCurrentCue` 有 playing 门控）
+/// 那样受控，只靠会被 `snapReaderToAudio` 清空的一次性护栏；图片等待的自动恢复正好
+/// 清掉它。
+///
+/// 修复：图片等待自动恢复尊重手动导航——窗口内手动翻页离开则不强制 snap，让跟随只
+/// 在播放推进到下一句时经既有护栏自然接管（正是用户诉求）。
+void main() {
+  group('BUG-890 图片等待自动恢复的 snap 决策（纯谓词）', () {
+    test('窗口内未手动翻页 → 恢复时仍 snap 回音频位（老行为不变）', () {
+      expect(
+        AudiobookPlayerController.shouldSnapAfterImagePauseResume(
+          readerMovedDuringPause: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('窗口内手动翻页离开插图那句 → 恢复时不 snap（保住用户手动位置）', () {
+      expect(
+        AudiobookPlayerController.shouldSnapAfterImagePauseResume(
+          readerMovedDuringPause: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('BUG-890 源码守卫：接线不能被回退', () {
+    final String source = File(
+            '../packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart')
+        .readAsStringSync();
+
+    test('图片等待窗口内手动翻页会置标志', () {
+      expect(
+        source,
+        contains(
+            'if (isImagePaused) {\n      _readerMovedDuringImagePause = true;'),
+        reason: 'noteManualReaderNavigation 必须在图片等待在途时记录用户已手动离开。',
+      );
+    });
+
+    test('图片等待自动恢复经 shouldSnapAfterImagePauseResume 门控 snap', () {
+      expect(
+        source,
+        contains('if (shouldSnapAfterImagePauseResume('),
+        reason: 'triggerImagePause 定时器恢复播放后必须用该谓词门控 snapReaderToAudio，'
+            '不能无条件 snap。',
+      );
+    });
+
+    test('标志在生命周期各点复位，杜绝泄漏', () {
+      // arm 定时器时复位
+      expect(
+        source,
+        contains(
+            '_readerMovedDuringImagePause = false;\n    unawaited(_player.pause());'),
+        reason: 'triggerImagePause arm 时必须复位标志。',
+      );
+      // arm / load / pause 至少三处复位标志（String 实现 Pattern，allMatches 为原生）
+      expect(
+        '_readerMovedDuringImagePause = false;'.allMatches(source).length >= 3,
+        isTrue,
+        reason: 'arm / load / pause 至少三处复位标志，防止跨轮泄漏。',
+      );
+    });
+  });
+}

--- a/packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart
+++ b/packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart
@@ -317,6 +317,21 @@ class AudiobookPlayerController extends ChangeNotifier {
   /// 当前是否处于图片暂停等待中。
   bool get isImagePaused => _imagePauseTimer?.isActive ?? false;
 
+  /// BUG-890：图片等待（自动暂停）窗口内用户是否手动翻页离开了插图那句。
+  /// 图片等待到点自动恢复播放时，若为真则**不**强制把 reader 拽回音频位
+  /// （否则把用户手动翻到的位置吃掉）——让跟随只在播放推进到下一句时经
+  /// [_manualReaderOverrideCue] 护栏自然接管。由 [noteManualReaderNavigation]
+  /// 在 [isImagePaused] 期间置真，定时器回调消费后复位，生命周期各点复位防泄漏。
+  bool _readerMovedDuringImagePause = false;
+
+  /// 纯决策：图片等待自动恢复播放时是否应把 reader 强制 snap 回音频位。
+  /// 用户在暂停窗口内手动翻页离开（[readerMovedDuringPause] 为真）→ 不 snap。
+  @visibleForTesting
+  static bool shouldSnapAfterImagePauseResume({
+    required bool readerMovedDuringPause,
+  }) =>
+      !readerMovedDuringPause;
+
   void setImagePauseSec(int sec) {
     final int clamped = sec.clamp(0, 15);
     if (imagePauseSec.value == clamped) return;
@@ -332,15 +347,27 @@ class AudiobookPlayerController extends ChangeNotifier {
     final int sec = imagePauseSec.value;
     if (sec <= 0 || !_player.playing) return;
     _imagePauseTimer?.cancel();
+    // BUG-890：新一轮图片等待开始，复位“窗口内是否手动翻页”标志。
+    _readerMovedDuringImagePause = false;
     unawaited(_player.pause());
     _imagePauseTimer = Timer(Duration(seconds: sec), () {
       _imagePauseTimer = null;
+      // BUG-890：消费并复位标志（无论下面是否恢复都清，防泄漏到下一轮）。
+      final bool readerMoved = _readerMovedDuringImagePause;
+      _readerMovedDuringImagePause = false;
       if (!_player.playing) {
         unawaited(_player.play());
         // 暂停时视口停在插图上；恢复后把视口拉回当前 cue（插图后那句），
         // 让 reader 的 _onCueChanged 以 forceReveal 续上 audio-follow（snapReaderToAudio
         // 内部会 notifyListeners）。
-        snapReaderToAudio();
+        // BUG-890：但若用户在这几秒暂停窗口内已手动翻页离开插图那句，则不强制
+        // snap——否则把用户手动翻到的位置吃掉。既有 _manualReaderOverrideCue 护栏
+        // 会让恢复后“同一句”期间保位不跳，跟随只在播放推进到下一句时自然接管。
+        if (shouldSnapAfterImagePauseResume(
+          readerMovedDuringPause: readerMoved,
+        )) {
+          snapReaderToAudio();
+        }
       }
     });
     notifyListeners();
@@ -507,6 +534,7 @@ class AudiobookPlayerController extends ChangeNotifier {
     _imagePauseTimer = null;
     _hasPlayedOnce = false;
     _forceNextReveal = false;
+    _readerMovedDuringImagePause = false;
     _chapterTransition = false;
     _imageChapterPauseActive = false;
 
@@ -702,9 +730,11 @@ class AudiobookPlayerController extends ChangeNotifier {
     _manualReaderOverrideCue = null;
     // 用户在图片自动暂停窗口内手动播放：取消待恢复计时器并把视口从插图拉回当前
     // cue（否则计时器到点见已在播放而跳过 snap，视口卡在插图上直到下次 cue 推进）。
+    // 手动按播放是显式“继续听书”手势，仍 snap；只复位 BUG-890 的窗口内翻页标志。
     if (_imagePauseTimer != null) {
       _imagePauseTimer!.cancel();
       _imagePauseTimer = null;
+      _readerMovedDuringImagePause = false;
       snapReaderToAudio();
     }
     unawaited(_player.play());
@@ -713,6 +743,7 @@ class AudiobookPlayerController extends ChangeNotifier {
   Future<void> pause() async {
     _imagePauseTimer?.cancel();
     _imagePauseTimer = null;
+    _readerMovedDuringImagePause = false;
     _resumeMainAfterClip = false;
     await _player.pause();
     _maybeSavePosition(force: true);
@@ -1194,6 +1225,11 @@ class AudiobookPlayerController extends ChangeNotifier {
   void noteManualReaderNavigation() {
     _chapterTransition = false;
     _manualReaderOverrideCue = _currentCue;
+    // BUG-890：图片等待自动暂停窗口内的手动翻页 → 标记为“用户已离开插图那句”，
+    // 图片等待到点恢复时据此不强制 snap 回音频位（见 triggerImagePause）。
+    if (isImagePaused) {
+      _readerMovedDuringImagePause = true;
+    }
   }
 
   /// 翻转 Follow audio 开关并经 [onFollowAudioPersist] 落 Hive。相同值调用


### PR DESCRIPTION
## 现象
开着「跟随音频」阅读带有声书的 EPUB，向前翻页想回看/预读时被拽回音频位置——尤其向前跨过含插图的章（如 あとがき 前后必有一张图）时，被重置回音频位。用户：`不是我触发的`，试几次才复现。

## 根因
触发者是**图片等待**（`imagePauseSec>0`）的自动暂停+自动恢复，不是普通暂停态：
1. 播放中朗读跨过插图 → `triggerImagePause()` 自动暂停并 arm 定时器（用户看到`音频停了`，以为可自由翻页）。
2. 用户在这几秒窗口内手动向前翻页 → `noteManualReaderNavigation()` 设一次性护栏 `_manualReaderOverrideCue`。
3. 定时器到点：`play()` 恢复播放后**无条件** `snapReaderToAudio()` —— 它清掉护栏 + `_maybeEmitCrossChapter(bypassPlayGuard:true)`，把 reader 强行拽回音频所在章，吃掉用户手动翻到的位置。

对比：章内滚动跟随（`shouldRevealCurrentCue`）已用 `_player.playing` 门控，跨章跟随/强制 reveal 却只靠会被 `snapReaderToAudio` 清掉的一次性护栏——图片等待自动恢复正好清掉它。

## 修复
图片等待自动恢复**尊重手动导航**：窗口内手动翻页离开则恢复时不强制 snap，让跟随只在播放推进到**下一句**时经既有护栏自然接管（正是用户诉求：`sync should only trigger when playback moves to the next sentence`）。未手动移动的老用户路径（看完图→自动继续）行为不变；显式手势（按播放/开跟随/点句子）仍跳。

- `triggerImagePause`：arm 时复位标志；回调经纯谓词 `shouldSnapAfterImagePauseResume` 门控 snap。
- `noteManualReaderNavigation`：`isImagePaused` 期间置 `_readerMovedDuringImagePause=true`。
- `load`/`pause`/`play` 各复位标志防泄漏。

## 测试
- `hibiki/test/media/audiobook/image_pause_resume_manual_nav_test.dart`：纯谓词 2 例 + 源码守卫 3 例，全绿。
- `flutter test test/media/audiobook/` 全套 794 例通过，无回归。
- `flutter analyze` 变更文件 0 issue。

⚠️ **真机复测原始失败路径待做**（EPUB+有声书+图片等待开，向前跨 あとがき 插图章）。