### PR TITLE
feat(torrent): 内置 libtorrent 引擎 Windows 全链（阶段1b/2/3）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 33473 (1969 per locale)
+/// Strings: 33558 (1974 per locale)
 ///
-/// Built on 2026-07-18 at 15:29 UTC
+/// Built on 2026-07-18 at 17:34 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2650,6 +2650,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  String get video_setting_torrent_max_connections => 'Max connections';
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -7115,6 +7120,16 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -11653,6 +11668,16 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -16207,6 +16232,16 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -20772,6 +20807,16 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -25264,6 +25309,16 @@ class _StringsId extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -29804,6 +29859,16 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -34150,6 +34215,16 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -38499,6 +38574,16 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -43017,6 +43102,16 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -47550,6 +47645,16 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -52066,6 +52171,16 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -56527,6 +56642,16 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -61020,6 +61145,16 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -65500,6 +65635,16 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 // Path: <root>
@@ -69671,6 +69816,16 @@ class _StringsZhCn extends _StringsEn {
   String get video_setting_torrent_backend_qb => '外接 qBittorrent';
   @override
   String get video_setting_torrent_backend_embedded => '内置引擎（桌面）';
+  @override
+  String get video_setting_torrent_download_limit => '下载限速 (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => '上传限速 (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => '最大连接数';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = 不限';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = 引擎默认';
 }
 
 // Path: <root>
@@ -73939,6 +74094,16 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_setting_torrent_backend_embedded =>
       'Built-in engine (desktop)';
+  @override
+  String get video_setting_torrent_download_limit => 'Download limit (KB/s)';
+  @override
+  String get video_setting_torrent_upload_limit => 'Upload limit (KB/s)';
+  @override
+  String get video_setting_torrent_max_connections => 'Max connections';
+  @override
+  String get video_setting_torrent_limit_hint => '0 = unlimited';
+  @override
+  String get video_setting_torrent_connections_hint => '0 = engine default';
 }
 
 /// Flat map(s) containing all translations.
@@ -77966,6 +78131,16 @@ extension on _StringsEn {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -81991,6 +82166,16 @@ extension on _StringsAr {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -86037,6 +86222,16 @@ extension on _StringsDe {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -90082,6 +90277,16 @@ extension on _StringsEs {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -94133,6 +94338,16 @@ extension on _StringsFr {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -98166,6 +98381,16 @@ extension on _StringsId {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -102214,6 +102439,16 @@ extension on _StringsIt {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -106224,6 +106459,16 @@ extension on _StringsJa {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -110238,6 +110483,16 @@ extension on _StringsKo {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -114279,6 +114534,16 @@ extension on _StringsNl {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -118317,6 +118582,16 @@ extension on _StringsPtBr {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -122360,6 +122635,16 @@ extension on _StringsRu {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -126387,6 +126672,16 @@ extension on _StringsTh {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -130423,6 +130718,16 @@ extension on _StringsTr {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -134454,6 +134759,16 @@ extension on _StringsVi {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }
@@ -138453,6 +138768,16 @@ extension on _StringsZhCn {
         return '外接 qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return '内置引擎（桌面）';
+      case 'video_setting_torrent_download_limit':
+        return '下载限速 (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return '上传限速 (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return '最大连接数';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = 不限';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = 引擎默认';
       default:
         return null;
     }
@@ -142458,6 +142783,16 @@ extension on _StringsZhHk {
         return 'External qBittorrent';
       case 'video_setting_torrent_backend_embedded':
         return 'Built-in engine (desktop)';
+      case 'video_setting_torrent_download_limit':
+        return 'Download limit (KB/s)';
+      case 'video_setting_torrent_upload_limit':
+        return 'Upload limit (KB/s)';
+      case 'video_setting_torrent_max_connections':
+        return 'Max connections';
+      case 'video_setting_torrent_limit_hint':
+        return '0 = unlimited';
+      case 'video_setting_torrent_connections_hint':
+        return '0 = engine default';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 33422 (1966 per locale)
+/// Strings: 33473 (1969 per locale)
 ///
-/// Built on 2026-07-18 at 04:25 UTC
+/// Built on 2026-07-18 at 15:29 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2646,6 +2646,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Controls whether Hibiki stays above other windows';
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  String get video_setting_torrent_backend => 'Download backend';
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -7104,6 +7108,13 @@ class _StringsAr extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -11635,6 +11646,13 @@ class _StringsDe extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -16182,6 +16200,13 @@ class _StringsEs extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -20740,6 +20765,13 @@ class _StringsFr extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -25225,6 +25257,13 @@ class _StringsId extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -29758,6 +29797,13 @@ class _StringsIt extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -34097,6 +34143,13 @@ class _StringsJa extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -38439,6 +38492,13 @@ class _StringsKo extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -42950,6 +43010,13 @@ class _StringsNl extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -47476,6 +47543,13 @@ class _StringsPtBr extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -51985,6 +52059,13 @@ class _StringsRu extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -56439,6 +56520,13 @@ class _StringsTh extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -60925,6 +61013,13 @@ class _StringsTr extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -65398,6 +65493,13 @@ class _StringsVi extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 // Path: <root>
@@ -69563,6 +69665,12 @@ class _StringsZhCn extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       '端口 ${port} 正被 Yomitan API 占用。请先在 Yomitan 高级设置中关闭 Yomitan API，再回 Hibiki 开启 Yomitan API 服务器。';
+  @override
+  String get video_setting_torrent_backend => '下载后端';
+  @override
+  String get video_setting_torrent_backend_qb => '外接 qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded => '内置引擎（桌面）';
 }
 
 // Path: <root>
@@ -73824,6 +73932,13 @@ class _StringsZhHk extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String get video_setting_torrent_backend => 'Download backend';
+  @override
+  String get video_setting_torrent_backend_qb => 'External qBittorrent';
+  @override
+  String get video_setting_torrent_backend_embedded =>
+      'Built-in engine (desktop)';
 }
 
 /// Flat map(s) containing all translations.
@@ -77845,6 +77960,12 @@ extension on _StringsEn {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -81864,6 +81985,12 @@ extension on _StringsAr {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -85904,6 +86031,12 @@ extension on _StringsDe {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -89943,6 +90076,12 @@ extension on _StringsEs {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -93988,6 +94127,12 @@ extension on _StringsFr {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -98015,6 +98160,12 @@ extension on _StringsId {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -102057,6 +102208,12 @@ extension on _StringsIt {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -106061,6 +106218,12 @@ extension on _StringsJa {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -110069,6 +110232,12 @@ extension on _StringsKo {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -114104,6 +114273,12 @@ extension on _StringsNl {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -118136,6 +118311,12 @@ extension on _StringsPtBr {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -122173,6 +122354,12 @@ extension on _StringsRu {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -126194,6 +126381,12 @@ extension on _StringsTh {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -130224,6 +130417,12 @@ extension on _StringsTr {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -134249,6 +134448,12 @@ extension on _StringsVi {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }
@@ -138242,6 +138447,12 @@ extension on _StringsZhCn {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             '端口 ${port} 正被 Yomitan API 占用。请先在 Yomitan 高级设置中关闭 Yomitan API，再回 Hibiki 开启 Yomitan API 服务器。';
+      case 'video_setting_torrent_backend':
+        return '下载后端';
+      case 'video_setting_torrent_backend_qb':
+        return '外接 qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return '内置引擎（桌面）';
       default:
         return null;
     }
@@ -142241,6 +142452,12 @@ extension on _StringsZhHk {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'video_setting_torrent_backend':
+        return 'Download backend';
+      case 'video_setting_torrent_backend_qb':
+        return 'External qBittorrent';
+      case 'video_setting_torrent_backend_embedded':
+        return 'Built-in engine (desktop)';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "端口 $port 正被 Yomitan API 占用。请先在 Yomitan 高级设置中关闭 Yomitan API，再回 Hibiki 开启 Yomitan API 服务器。",
   "video_setting_torrent_backend": "下载后端",
   "video_setting_torrent_backend_qb": "外接 qBittorrent",
-  "video_setting_torrent_backend_embedded": "内置引擎（桌面）"
+  "video_setting_torrent_backend_embedded": "内置引擎（桌面）",
+  "video_setting_torrent_download_limit": "下载限速 (KB/s)",
+  "video_setting_torrent_upload_limit": "上传限速 (KB/s)",
+  "video_setting_torrent_max_connections": "最大连接数",
+  "video_setting_torrent_limit_hint": "0 = 不限",
+  "video_setting_torrent_connections_hint": "0 = 引擎默认"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "暂不可提前入库（元数据未就绪或连接失败），稍后再试",
   "interconnect_section_related": "远端内容与查词",
   "desktop_clipboard_window_mode_hint": "控制 Hibiki 是否保持在其他窗口上方",
-  "browser_extension_yomitan_port_conflict": "端口 $port 正被 Yomitan API 占用。请先在 Yomitan 高级设置中关闭 Yomitan API，再回 Hibiki 开启 Yomitan API 服务器。"
+  "browser_extension_yomitan_port_conflict": "端口 $port 正被 Yomitan API 占用。请先在 Yomitan 高级设置中关闭 Yomitan API，再回 Hibiki 开启 Yomitan API 服务器。",
+  "video_setting_torrent_backend": "下载后端",
+  "video_setting_torrent_backend_qb": "外接 qBittorrent",
+  "video_setting_torrent_backend_embedded": "内置引擎（桌面）"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1967,5 +1967,10 @@
   "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
-  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
+  "video_setting_torrent_download_limit": "Download limit (KB/s)",
+  "video_setting_torrent_upload_limit": "Upload limit (KB/s)",
+  "video_setting_torrent_max_connections": "Max connections",
+  "video_setting_torrent_limit_hint": "0 = unlimited",
+  "video_setting_torrent_connections_hint": "0 = engine default"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1964,5 +1964,8 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "video_setting_torrent_backend": "Download backend",
+  "video_setting_torrent_backend_qb": "External qBittorrent",
+  "video_setting_torrent_backend_embedded": "Built-in engine (desktop)"
 }

--- a/hibiki/lib/src/media/torrent/anime_download_config.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_config.dart
@@ -13,6 +13,9 @@ class QbConnectionConfig {
     this.username = '',
     this.password = '',
     this.category = 'hibiki',
+    this.downloadLimitKbps = 0,
+    this.uploadLimitKbps = 0,
+    this.maxConnections = 0,
   });
 
   /// 本应用管理的下载在 qBittorrent 里归入的默认分类名。
@@ -40,6 +43,15 @@ class QbConnectionConfig {
   /// 下载归入的 qBittorrent 分类（列种子时也按此过滤，默认 [defaultCategory]）。
   final String category;
 
+  /// 内置引擎全局下载限速（KB/s，0 = 不限）。外接 qb 忽略（qb 自有设置）。
+  final int downloadLimitKbps;
+
+  /// 内置引擎全局上传限速（KB/s，0 = 不限）。
+  final int uploadLimitKbps;
+
+  /// 内置引擎全局最大连接数（0 = 引擎默认）。
+  final int maxConnections;
+
   /// 是否已配置（[baseUrl] 非空）；未配置时下载入队与完成监听均不动作。
   bool get isConfigured =>
       backend == backendEmbedded || baseUrl.trim().isNotEmpty;
@@ -50,6 +62,9 @@ class QbConnectionConfig {
     String? username,
     String? password,
     String? category,
+    int? downloadLimitKbps,
+    int? uploadLimitKbps,
+    int? maxConnections,
   }) {
     return QbConnectionConfig(
       backend: backend ?? this.backend,
@@ -57,8 +72,17 @@ class QbConnectionConfig {
       username: username ?? this.username,
       password: password ?? this.password,
       category: category ?? this.category,
+      downloadLimitKbps: downloadLimitKbps ?? this.downloadLimitKbps,
+      uploadLimitKbps: uploadLimitKbps ?? this.uploadLimitKbps,
+      maxConnections: maxConnections ?? this.maxConnections,
     );
   }
+}
+
+/// JSON 数字字段容错解析为非负 int（null/非数/负数 → 0）。
+int _nonNegInt(Object? value) {
+  final int n = value is num ? value.toInt() : 0;
+  return n < 0 ? 0 : n;
 }
 
 /// 解析偏好里存的 JSON 字符串为 [QbConnectionConfig]。纯函数，容错：
@@ -81,6 +105,9 @@ QbConnectionConfig? decodeQbConnectionConfig(String raw) {
       category: category is String && category.isNotEmpty
           ? category
           : QbConnectionConfig.defaultCategory,
+      downloadLimitKbps: _nonNegInt(json['downloadLimitKbps']),
+      uploadLimitKbps: _nonNegInt(json['uploadLimitKbps']),
+      maxConnections: _nonNegInt(json['maxConnections']),
     );
   } catch (_) {
     return null;
@@ -96,5 +123,8 @@ String encodeQbConnectionConfig(QbConnectionConfig config) {
     'username': config.username,
     'password': config.password,
     'category': config.category,
+    'downloadLimitKbps': config.downloadLimitKbps,
+    'uploadLimitKbps': config.uploadLimitKbps,
+    'maxConnections': config.maxConnections,
   });
 }

--- a/hibiki/lib/src/media/torrent/anime_download_config.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_config.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 /// 字符串，解析在消费端做。
 class QbConnectionConfig {
   const QbConnectionConfig({
+    this.backend = backendQbittorrent,
     this.baseUrl = '',
     this.username = '',
     this.password = '',
@@ -16,6 +17,16 @@ class QbConnectionConfig {
 
   /// 本应用管理的下载在 qBittorrent 里归入的默认分类名。
   static const String defaultCategory = 'hibiki';
+
+  /// 后端标识：外接 qBittorrent WebUI。
+  static const String backendQbittorrent = 'qbittorrent';
+
+  /// 后端标识：内置 libtorrent 引擎（桌面；见 EmbeddedTorrentHost）。
+  static const String backendEmbedded = 'embedded';
+
+  /// 下载后端（[backendQbittorrent] / [backendEmbedded]）。历史配置无此
+  /// 字段时回退 qb（向后兼容：既有用户行为不变）。
+  final String backend;
 
   /// WebUI 地址（如 `http://127.0.0.1:8080`）；空 = 未配置。
   final String baseUrl;
@@ -30,15 +41,18 @@ class QbConnectionConfig {
   final String category;
 
   /// 是否已配置（[baseUrl] 非空）；未配置时下载入队与完成监听均不动作。
-  bool get isConfigured => baseUrl.trim().isNotEmpty;
+  bool get isConfigured =>
+      backend == backendEmbedded || baseUrl.trim().isNotEmpty;
 
   QbConnectionConfig copyWith({
+    String? backend,
     String? baseUrl,
     String? username,
     String? password,
     String? category,
   }) {
     return QbConnectionConfig(
+      backend: backend ?? this.backend,
       baseUrl: baseUrl ?? this.baseUrl,
       username: username ?? this.username,
       password: password ?? this.password,
@@ -56,7 +70,11 @@ QbConnectionConfig? decodeQbConnectionConfig(String raw) {
     final dynamic json = jsonDecode(raw);
     if (json is! Map) return null;
     final dynamic category = json['category'];
+    final dynamic backend = json['backend'];
     return QbConnectionConfig(
+      backend: backend == QbConnectionConfig.backendEmbedded
+          ? QbConnectionConfig.backendEmbedded
+          : QbConnectionConfig.backendQbittorrent,
       baseUrl: json['baseUrl'] is String ? json['baseUrl'] as String : '',
       username: json['username'] is String ? json['username'] as String : '',
       password: json['password'] is String ? json['password'] as String : '',
@@ -73,6 +91,7 @@ QbConnectionConfig? decodeQbConnectionConfig(String raw) {
 /// 互逆）。纯函数。
 String encodeQbConnectionConfig(QbConnectionConfig config) {
   return jsonEncode(<String, dynamic>{
+    'backend': config.backend,
     'baseUrl': config.baseUrl,
     'username': config.username,
     'password': config.password,

--- a/hibiki/lib/src/media/torrent/anime_download_service.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_service.dart
@@ -106,10 +106,12 @@ class AnimeDownloadService {
       List<String> videoAbsolutePaths,
     ) importer,
     TorrentBackend Function(QbConnectionConfig config)? backendFactory,
+    void Function()? onTick,
     this.interval = const Duration(seconds: 20),
   })  : _configProvider = configProvider,
         _importer = importer,
-        _backendFactory = backendFactory ?? _defaultBackendFactory;
+        _backendFactory = backendFactory ?? _defaultBackendFactory,
+        _onTick = onTick;
 
   /// 种子在后端里消失（用户手动删除）后，计划保留等待的时长；
   /// 超过（按 [AnimeDownloadPlan.createdAtMs] 判断）标 failed。
@@ -131,6 +133,10 @@ class AnimeDownloadService {
     List<String> videoAbsolutePaths,
   ) _importer;
   final TorrentBackend Function(QbConnectionConfig config) _backendFactory;
+
+  /// 每 tick 起始（早于「无 pending 计划则跳过」判断）无条件跑一次的钩子；
+  /// 内置引擎接反吸血扫描（种子做种期仍需封吸血 peer，不能被 pending 门控）。
+  final void Function()? _onTick;
   final Duration interval;
 
   Timer? _timer;
@@ -214,6 +220,9 @@ class AnimeDownloadService {
   }
 
   Future<void> _tickOnce() async {
+    // 反吸血等后端维护钩子先跑：与是否有等待入库的计划无关（做种期也要封）。
+    _onTick?.call();
+
     final QbConnectionConfig? config = _configProvider();
     if (config == null || !config.isConfigured) return;
 

--- a/hibiki/lib/src/media/torrent/embedded_torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/embedded_torrent_backend.dart
@@ -20,11 +20,18 @@ class EmbeddedTorrentBackend implements TorrentBackend {
   EmbeddedTorrentBackend({
     required EmbeddedTorrentSession session,
     required String baseSavePath,
+    bool closesSession = true,
   })  : _session = session,
-        _baseSavePath = baseSavePath;
+        _baseSavePath = baseSavePath,
+        _closesSession = closesSession;
 
   final EmbeddedTorrentSession _session;
   final String _baseSavePath;
+
+  /// close() 是否真的销毁底层 session。standalone/测试用途持有自己的
+  /// session → true；app 侧 [EmbeddedTorrentHost] 派发的短命适配器共享
+  /// 常驻 session → false（每 tick 建/关适配器不能连累会话）。
+  final bool _closesSession;
 
   /// 已添加但 firstLastPiecePrio 尚未应用成功（等元数据）的种子。
   final Set<String> _pendingFirstLast = <String>{};
@@ -107,7 +114,9 @@ class EmbeddedTorrentBackend implements TorrentBackend {
   }
 
   @override
-  void close() => _session.close();
+  void close() {
+    if (_closesSession) _session.close();
+  }
 
   String _categoryPath(String category) => p.join(_baseSavePath, category);
 

--- a/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
+++ b/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
@@ -1,0 +1,157 @@
+import 'dart:io';
+
+import 'package:hibiki/src/media/torrent/anti_leech.dart';
+import 'package:hibiki/src/media/torrent/embedded_torrent_backend.dart';
+import 'package:hibiki_torrent/hibiki_torrent.dart';
+
+/// 内置 libtorrent 引擎的 app 侧宿主：拥有**常驻**引擎 + 单个 session
+/// （所有内置下载共享），按需派发短命 [EmbeddedTorrentBackend] 适配器给
+/// `AnimeDownloadService` 的每 tick 用（适配器 close 不连累会话）。
+///
+/// 生命周期：app 启动时（桌面、且用户选内置后端）`open` 一次，AppModel
+/// 释放时 `dispose`。DLL 加载失败（未构建/缺依赖）返回 null，上层回退外接
+/// qb 或静默不动作，绝不 crash 启动流程。
+///
+/// 反吸血：持有全局单例 [AntiLeechEngine]（共享连坐段），`sweepAntiLeech`
+/// 每次把所有种子的 peer 喂进引擎判定，新增封段全量重建 libtorrent
+/// ip_filter（见 [project_libtorrent_phase1b_pr227] 的阶段3 接线）。
+class EmbeddedTorrentHost {
+  EmbeddedTorrentHost._({
+    required EmbeddedTorrentEngine engine,
+    required EmbeddedTorrentSession session,
+    required String baseSavePath,
+    required int Function() clockMs,
+  })  : _engine = engine,
+        _session = session,
+        _baseSavePath = baseSavePath,
+        _clockMs = clockMs;
+
+  final EmbeddedTorrentEngine _engine;
+  final EmbeddedTorrentSession _session;
+  final String _baseSavePath;
+  final int Function() _clockMs;
+
+  /// 全局反吸血引擎（共享连坐段，见 anti_leech.dart 类 doc 建议）。
+  final AntiLeechEngine _antiLeech = AntiLeechEngine();
+
+  /// 当前 ip_filter 里的封段快照（避免无变化时重复 set_ip_filter）。
+  Set<String> _appliedBans = <String>{};
+
+  /// 底层引擎版本串（诊断/probe 用）。
+  String get libtorrentVersion => _engine.libtorrentVersion();
+
+  /// 打开宿主。[libraryPath] 显式 DLL 路径（缺省按平台默认名搜系统路径）；
+  /// [baseSavePath] 内置下载根目录；[listenInterfaces] 监听接口（桌面默认
+  /// 全网 6881，端口占用时 libtorrent 自行回退）；[clockMs] 单调毫秒时钟
+  /// 注入（反吸血引擎判定基准，测试可注入假时钟）。
+  /// 任何失败（DLL 加载 / session 创建）返回 null。
+  static EmbeddedTorrentHost? open({
+    String? libraryPath,
+    required String baseSavePath,
+    String listenInterfaces = '0.0.0.0:6881',
+    bool enableDht = true,
+    int Function()? clockMs,
+  }) {
+    EmbeddedTorrentEngine engine;
+    try {
+      engine = EmbeddedTorrentEngine.open(libraryPath: libraryPath);
+    } on ArgumentError {
+      return null; // DLL 缺失/未构建
+    } on Object {
+      return null;
+    }
+    final EmbeddedTorrentSession? session = EmbeddedTorrentSession.open(
+      engine,
+      listenInterfaces: listenInterfaces,
+      enableDht: enableDht,
+    );
+    if (session == null) return null;
+    return EmbeddedTorrentHost._(
+      engine: engine,
+      session: session,
+      baseSavePath: baseSavePath,
+      clockMs: clockMs ?? _defaultClockMs,
+    );
+  }
+
+  static int _defaultClockMs() => DateTime.now().millisecondsSinceEpoch;
+
+  /// 派发一个短命后端适配器（共享常驻 session；其 close 不销毁会话）。
+  /// 供 `AnimeDownloadService.backendFactory` 每 tick 调用。
+  EmbeddedTorrentBackend backendView() {
+    return EmbeddedTorrentBackend(
+      session: _session,
+      baseSavePath: _baseSavePath,
+      closesSession: false,
+    );
+  }
+
+  /// 反吸血扫描：遍历所有种子的 peer，喂进 [AntiLeechEngine] 判定，
+  /// 若封段集较上次有变化则全量重建 libtorrent ip_filter。返回本轮新增
+  /// 封禁的 peer 数（诊断用）。异常静默吞（不打断下载轮询）。
+  int sweepAntiLeech() {
+    try {
+      final int nowMs = _clockMs();
+      int newlyBanned = 0;
+      for (final HtTorrentStatus t in _session.listTorrents()) {
+        final List<HtPeerInfo>? peers = _session.torrentPeers(t.id);
+        if (peers == null || peers.isEmpty) continue;
+        final TorrentContext ctx = TorrentContext(
+          infoHash: t.id,
+          totalSize: t.total,
+          completedSize: t.done,
+          isSeeding: t.isSeeding,
+        );
+        final List<PeerSnapshot> snapshots = <PeerSnapshot>[
+          for (final HtPeerInfo pi in peers)
+            PeerSnapshot(
+              ip: pi.ip,
+              peerId: pi.peerId,
+              client: pi.client,
+              reportedProgress: pi.progress,
+              totalUpload: pi.totalUpload,
+              uploadSpeed: pi.upSpeed,
+              peerInterested: pi.remoteInterested,
+            ),
+        ];
+        final Map<String, BanVerdict> verdicts =
+            _antiLeech.evaluate(snapshots, ctx, nowMs: nowMs);
+        newlyBanned += verdicts.values.where((BanVerdict v) => v.banned).length;
+      }
+      final Set<String> bans = _antiLeech.bannedCidrs;
+      if (!_setEquals(bans, _appliedBans)) {
+        if (_session.applyIpFilter(bans)) {
+          _appliedBans = Set<String>.from(bans);
+        }
+      }
+      return newlyBanned;
+    } on Object {
+      return 0;
+    }
+  }
+
+  static bool _setEquals(Set<String> a, Set<String> b) {
+    if (a.length != b.length) return false;
+    for (final String e in a) {
+      if (!b.contains(e)) return false;
+    }
+    return true;
+  }
+
+  /// 释放常驻 session（app 退出时）。
+  void dispose() {
+    _session.close();
+  }
+}
+
+/// 平台默认内置 DLL 路径解析：flutter runner 把 native 依赖放在可执行文件
+/// 旁（Windows）。阶段2 未接进 windows runner 前，这里返回 null 让
+/// [EmbeddedTorrentHost.open] 走系统搜索路径（或由调用方显式传 libraryPath）。
+String? defaultEmbeddedTorrentLibraryPath() {
+  if (Platform.isWindows) {
+    // runner 集成后 DLL 与 hibiki.exe 同目录，DynamicLibrary 按名即可命中；
+    // 此处不硬编码 build 产物路径（那是 standalone 测试的事）。
+    return null;
+  }
+  return null;
+}

--- a/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
+++ b/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
@@ -76,6 +76,21 @@ class EmbeddedTorrentHost {
 
   static int _defaultClockMs() => DateTime.now().millisecondsSinceEpoch;
 
+  /// 应用用户可调的全局资源限制（速率 + 连接数）。[downloadKbps]/[uploadKbps]
+  /// 单位 KB/s（0 = 不限），[maxConnections]（0 = 引擎默认）。config 变更时
+  /// 由 AppModel 调用，即时生效。
+  bool applyLimits({
+    int downloadKbps = 0,
+    int uploadKbps = 0,
+    int maxConnections = 0,
+  }) {
+    return _session.applyLimits(
+      downloadBps: downloadKbps > 0 ? downloadKbps * 1024 : 0,
+      uploadBps: uploadKbps > 0 ? uploadKbps * 1024 : 0,
+      connectionsLimit: maxConnections,
+    );
+  }
+
   /// 派发一个短命后端适配器（共享常驻 session；其 close 不销毁会话）。
   /// 供 `AnimeDownloadService.backendFactory` 每 tick 调用。
   EmbeddedTorrentBackend backendView() {

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -2730,8 +2730,22 @@ class AppModel with ChangeNotifier {
   /// qBittorrent WebUI 连接配置（番剧下载）；null = 未配置未启用。
   QbConnectionConfig? get qbConnectionConfig => prefsRepo.qbConnectionConfig;
 
-  Future<void> setQbConnectionConfig(QbConnectionConfig? config) =>
-      prefsRepo.setQbConnectionConfig(config);
+  Future<void> setQbConnectionConfig(QbConnectionConfig? config) async {
+    await prefsRepo.setQbConnectionConfig(config);
+    // 内置引擎资源限制即时生效（用户在设置里改限速/连接数后不必重启）。
+    _applyEmbeddedTorrentLimits(config);
+  }
+
+  /// 把配置里的内置引擎资源限制应用到常驻宿主（宿主不存在则 no-op）。
+  void _applyEmbeddedTorrentLimits(QbConnectionConfig? config) {
+    final EmbeddedTorrentHost? host = _embeddedTorrentHost;
+    if (host == null || config == null) return;
+    host.applyLimits(
+      downloadKbps: config.downloadLimitKbps,
+      uploadKbps: config.uploadLimitKbps,
+      maxConnections: config.maxConnections,
+    );
+  }
 
   /// 番剧下载：计划存储（选种对话框写计划/暂存字幕，与完成监听服务共用同一实例）。
   AnimeDownloadPlanStore? _animeDownloadPlanStore;
@@ -2762,6 +2776,8 @@ class AppModel with ChangeNotifier {
       _embeddedTorrentHost = EmbeddedTorrentHost.open(
         baseSavePath: path.join(baseDir.path, 'content'),
       );
+      // 启动即把已保存的资源限制铺到宿主（不必等用户改设置）。
+      _applyEmbeddedTorrentLimits(prefsRepo.qbConnectionConfig);
     }
 
     _animeDownloadService = AnimeDownloadService(

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -42,6 +42,10 @@ import 'package:hibiki/src/models/dictionary_repository.dart';
 import 'package:hibiki/src/models/media_history_repository.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/media/torrent/anime_download_config.dart';
+import 'package:hibiki/src/media/torrent/embedded_torrent_host.dart';
+import 'package:hibiki/src/media/torrent/qb_torrent_backend.dart';
+import 'package:hibiki/src/media/torrent/qbittorrent_client.dart';
+import 'package:hibiki/src/media/torrent/torrent_backend.dart';
 import 'package:hibiki/src/media/torrent/anime_download_importer.dart';
 import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
 import 'package:hibiki/src/media/torrent/anime_download_service.dart';
@@ -2737,6 +2741,11 @@ class AppModel with ChangeNotifier {
   AnimeDownloadService? _animeDownloadService;
   AnimeDownloadService? get animeDownloadService => _animeDownloadService;
 
+  /// 内置 libtorrent 下载宿主（桌面且用户选内置后端时懒建；DLL 缺失/加载
+  /// 失败为 null，服务回退外接 qb）。app 释放时 dispose。
+  EmbeddedTorrentHost? _embeddedTorrentHost;
+  EmbeddedTorrentHost? get embeddedTorrentHost => _embeddedTorrentHost;
+
   /// 启动番剧下载完成监听。幂等（重复调用不重建）；失败由调用方记日志，不破坏 init。
   Future<void> startAnimeDownloadService() async {
     if (_animeDownloadService != null) return;
@@ -2745,12 +2754,42 @@ class AppModel with ChangeNotifier {
     final AnimeDownloadPlanStore store =
         AnimeDownloadPlanStore(baseDir: baseDir);
     _animeDownloadPlanStore = store;
+
+    // 内置引擎宿主：仅桌面（Android/iOS 阶段4/5 再定），且下载根目录就在
+    // 计划目录旁的 `content/` 子目录（分类再往下分）。DLL 未随包/未构建时
+    // open 返回 null，工厂自然回退 qb。
+    if (_supportsEmbeddedTorrent()) {
+      _embeddedTorrentHost = EmbeddedTorrentHost.open(
+        baseSavePath: path.join(baseDir.path, 'content'),
+      );
+    }
+
     _animeDownloadService = AnimeDownloadService(
       store: store,
       configProvider: () => prefsRepo.qbConnectionConfig,
       importer: buildAnimeDownloadImporter(database),
+      backendFactory: _torrentBackendFor,
+      onTick: () => _embeddedTorrentHost?.sweepAntiLeech(),
     )..start();
   }
+
+  /// 后端选择：配置选内置且宿主可用 → 内置引擎的共享 session 视图；否则
+  /// 外接 qBittorrent（默认 / 内置不可用时的回退）。
+  TorrentBackend _torrentBackendFor(QbConnectionConfig config) {
+    final EmbeddedTorrentHost? host = _embeddedTorrentHost;
+    if (config.backend == QbConnectionConfig.backendEmbedded && host != null) {
+      return host.backendView();
+    }
+    return QbTorrentBackend(QBittorrentClient(
+      baseUrl: config.baseUrl,
+      username: config.username,
+      password: config.password,
+    ));
+  }
+
+  /// 内置 libtorrent 支持的平台：桌面（Windows 先行；mac/Linux 阶段4）。
+  bool _supportsEmbeddedTorrent() =>
+      Platform.isWindows || Platform.isMacOS || Platform.isLinux;
 
   /// 每系列记住的 Jimaku 字幕语言偏好（TODO-674）。
   Map<String, String> get jimakuPreferredLanguages =>
@@ -4029,6 +4068,9 @@ class AppModel with ChangeNotifier {
     }
     _remoteLookupHttpClient?.close();
     _remoteLookupHttpClient = null;
+    _animeDownloadService?.stop();
+    _embeddedTorrentHost?.dispose();
+    _embeddedTorrentHost = null;
     super.dispose();
   }
 

--- a/hibiki/lib/src/settings/settings_schema_video.dart
+++ b/hibiki/lib/src/settings/settings_schema_video.dart
@@ -790,6 +790,23 @@ SettingsDestination buildVideoDestination() {
             id: 'video.anime_download.qb_category',
             builder: _buildQbCategoryField,
           ),
+          // 内置引擎资源限制（仅内置后端显示；外接 qb 有自己的设置）。
+          // 均为数字输入，0 = 不限；改动即时应用到常驻引擎会话。
+          SettingsCustomItem(
+            id: 'video.anime_download.embedded_download_limit',
+            visible: _embeddedBackendSelected,
+            builder: _buildEmbeddedDownloadLimitField,
+          ),
+          SettingsCustomItem(
+            id: 'video.anime_download.embedded_upload_limit',
+            visible: _embeddedBackendSelected,
+            builder: _buildEmbeddedUploadLimitField,
+          ),
+          SettingsCustomItem(
+            id: 'video.anime_download.embedded_max_connections',
+            visible: _embeddedBackendSelected,
+            builder: _buildEmbeddedMaxConnectionsField,
+          ),
         ],
       ),
     ],
@@ -803,6 +820,79 @@ bool _qbBackendSelected(SettingsContext settingsContext) {
       settingsContext.appModel.qbConnectionConfig;
   return (config?.backend ?? QbConnectionConfig.backendQbittorrent) ==
       QbConnectionConfig.backendQbittorrent;
+}
+
+/// 当前是否选内置 libtorrent 引擎后端（决定内置引擎资源限制字段是否显示）。
+bool _embeddedBackendSelected(SettingsContext settingsContext) {
+  final QbConnectionConfig? config =
+      settingsContext.appModel.qbConnectionConfig;
+  return config?.backend == QbConnectionConfig.backendEmbedded;
+}
+
+/// 把限制字段的文本输入解析为非负整数（空/非数/负数 → 0 = 不限）。
+int _parseNonNegLimit(String value) {
+  final int n = int.tryParse(value.trim()) ?? 0;
+  return n < 0 ? 0 : n;
+}
+
+Widget _buildEmbeddedDownloadLimitField(SettingsContext settingsContext) {
+  final QbConnectionConfig? config =
+      settingsContext.appModel.qbConnectionConfig;
+  final int current = config?.downloadLimitKbps ?? 0;
+  return SettingsSecretField(
+    title: t.video_setting_torrent_download_limit,
+    icon: Icons.south_outlined,
+    initialValue: current == 0 ? '' : '$current',
+    keyboardType: TextInputType.number,
+    hintText: t.video_setting_torrent_limit_hint,
+    onChanged: (String value) async {
+      await _commitQbConfig(
+        settingsContext,
+        (QbConnectionConfig c) =>
+            c.copyWith(downloadLimitKbps: _parseNonNegLimit(value)),
+      );
+    },
+  );
+}
+
+Widget _buildEmbeddedUploadLimitField(SettingsContext settingsContext) {
+  final QbConnectionConfig? config =
+      settingsContext.appModel.qbConnectionConfig;
+  final int current = config?.uploadLimitKbps ?? 0;
+  return SettingsSecretField(
+    title: t.video_setting_torrent_upload_limit,
+    icon: Icons.north_outlined,
+    initialValue: current == 0 ? '' : '$current',
+    keyboardType: TextInputType.number,
+    hintText: t.video_setting_torrent_limit_hint,
+    onChanged: (String value) async {
+      await _commitQbConfig(
+        settingsContext,
+        (QbConnectionConfig c) =>
+            c.copyWith(uploadLimitKbps: _parseNonNegLimit(value)),
+      );
+    },
+  );
+}
+
+Widget _buildEmbeddedMaxConnectionsField(SettingsContext settingsContext) {
+  final QbConnectionConfig? config =
+      settingsContext.appModel.qbConnectionConfig;
+  final int current = config?.maxConnections ?? 0;
+  return SettingsSecretField(
+    title: t.video_setting_torrent_max_connections,
+    icon: Icons.lan_outlined,
+    initialValue: current == 0 ? '' : '$current',
+    keyboardType: TextInputType.number,
+    hintText: t.video_setting_torrent_connections_hint,
+    onChanged: (String value) async {
+      await _commitQbConfig(
+        settingsContext,
+        (QbConnectionConfig c) =>
+            c.copyWith(maxConnections: _parseNonNegLimit(value)),
+      );
+    },
+  );
 }
 
 /// 读改写 qbConnectionConfig（纯 pref）：取当前（null 视为空配置）→ [mutate] → 落盘。

--- a/hibiki/lib/src/settings/settings_schema_video.dart
+++ b/hibiki/lib/src/settings/settings_schema_video.dart
@@ -743,18 +743,47 @@ SettingsDestination buildVideoDestination() {
       SettingsSection(
         title: t.section_video_anime_download,
         items: <SettingsItem>[
-          // 番剧下载走外部 qBittorrent 实例（WebUI API），Hibiki 不内嵌 BT 引擎。
-          // 四项都是纯 pref（一个 JSON 配置），URL 留空 = 功能未启用。
+          // 后端二选一：外接 qBittorrent（全平台）或内置 libtorrent 引擎
+          // （桌面）。选内置时下面的 qb 连接字段隐藏（内置无需连接参数）。
+          SettingsSegmentedItem<String>(
+            id: 'video.anime_download.backend',
+            title: t.video_setting_torrent_backend,
+            icon: Icons.dns_outlined,
+            options: <SettingsSegmentOption<String>>[
+              SettingsSegmentOption<String>(
+                value: QbConnectionConfig.backendQbittorrent,
+                label: t.video_setting_torrent_backend_qb,
+              ),
+              SettingsSegmentOption<String>(
+                value: QbConnectionConfig.backendEmbedded,
+                label: t.video_setting_torrent_backend_embedded,
+              ),
+            ],
+            selected: (SettingsContext settingsContext) =>
+                settingsContext.appModel.qbConnectionConfig?.backend ??
+                QbConnectionConfig.backendQbittorrent,
+            onChanged: (SettingsContext settingsContext, String backend) async {
+              await _commitQbConfig(
+                settingsContext,
+                (QbConnectionConfig c) => c.copyWith(backend: backend),
+              );
+            },
+          ),
+          // qb 连接字段（内置引擎时隐藏）：纯 pref（一个 JSON 配置），
+          // URL 留空 = 外接后端未启用。
           SettingsCustomItem(
             id: 'video.anime_download.qb_url',
+            visible: _qbBackendSelected,
             builder: _buildQbUrlField,
           ),
           SettingsCustomItem(
             id: 'video.anime_download.qb_username',
+            visible: _qbBackendSelected,
             builder: _buildQbUsernameField,
           ),
           SettingsCustomItem(
             id: 'video.anime_download.qb_password',
+            visible: _qbBackendSelected,
             builder: _buildQbPasswordField,
           ),
           SettingsCustomItem(
@@ -765,6 +794,15 @@ SettingsDestination buildVideoDestination() {
       ),
     ],
   );
+}
+
+/// 当前是否选外接 qBittorrent 后端（决定 qb 连接字段是否显示）。历史配置
+/// 无 backend 字段回退 qb（既有用户看得见连接字段，行为不变）。
+bool _qbBackendSelected(SettingsContext settingsContext) {
+  final QbConnectionConfig? config =
+      settingsContext.appModel.qbConnectionConfig;
+  return (config?.backend ?? QbConnectionConfig.backendQbittorrent) ==
+      QbConnectionConfig.backendQbittorrent;
 }
 
 /// 读改写 qbConnectionConfig（纯 pref）：取当前（null 视为空配置）→ [mutate] → 落盘。

--- a/hibiki/test/media/torrent/anime_download_config_backend_test.dart
+++ b/hibiki/test/media/torrent/anime_download_config_backend_test.dart
@@ -49,6 +49,52 @@ void main() {
     expect(qbSet.isConfigured, isTrue);
   });
 
+  test('rate/connection limits round-trip and default to 0 (unlimited)', () {
+    const QbConnectionConfig defaults = QbConnectionConfig();
+    expect(defaults.downloadLimitKbps, 0);
+    expect(defaults.uploadLimitKbps, 0);
+    expect(defaults.maxConnections, 0);
+
+    const QbConnectionConfig limited = QbConnectionConfig(
+      backend: QbConnectionConfig.backendEmbedded,
+      downloadLimitKbps: 2048,
+      uploadLimitKbps: 512,
+      maxConnections: 100,
+    );
+    final QbConnectionConfig decoded =
+        decodeQbConnectionConfig(encodeQbConnectionConfig(limited))!;
+    expect(decoded.downloadLimitKbps, 2048);
+    expect(decoded.uploadLimitKbps, 512);
+    expect(decoded.maxConnections, 100);
+  });
+
+  test('legacy JSON without limit fields decodes to 0', () {
+    final QbConnectionConfig decoded =
+        decodeQbConnectionConfig('{"backend":"embedded"}')!;
+    expect(decoded.downloadLimitKbps, 0);
+    expect(decoded.uploadLimitKbps, 0);
+    expect(decoded.maxConnections, 0);
+  });
+
+  test('negative/garbage limit values clamp to 0', () {
+    final QbConnectionConfig decoded = decodeQbConnectionConfig(
+        '{"downloadLimitKbps":-5,"uploadLimitKbps":"x","maxConnections":-1}')!;
+    expect(decoded.downloadLimitKbps, 0);
+    expect(decoded.uploadLimitKbps, 0);
+    expect(decoded.maxConnections, 0);
+  });
+
+  test('copyWith preserves limits when not overridden', () {
+    const QbConnectionConfig base = QbConnectionConfig(
+      downloadLimitKbps: 1000,
+      maxConnections: 50,
+    );
+    final QbConnectionConfig next = base.copyWith(uploadLimitKbps: 200);
+    expect(next.downloadLimitKbps, 1000);
+    expect(next.uploadLimitKbps, 200);
+    expect(next.maxConnections, 50);
+  });
+
   test('copyWith preserves backend when not overridden', () {
     const QbConnectionConfig base =
         QbConnectionConfig(backend: QbConnectionConfig.backendEmbedded);

--- a/hibiki/test/media/torrent/anime_download_config_backend_test.dart
+++ b/hibiki/test/media/torrent/anime_download_config_backend_test.dart
@@ -1,0 +1,61 @@
+// 阶段2：QbConnectionConfig 的 backend 字段 codec / 向后兼容 / isConfigured。
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/torrent/anime_download_config.dart';
+
+void main() {
+  test('backend defaults to qbittorrent', () {
+    const QbConnectionConfig config = QbConnectionConfig();
+    expect(config.backend, QbConnectionConfig.backendQbittorrent);
+  });
+
+  test('legacy JSON without backend field decodes as qbittorrent', () {
+    // 阶段1 之前写下的配置没有 backend 字段：向后兼容回退 qb。
+    final QbConnectionConfig? config = decodeQbConnectionConfig(
+        '{"baseUrl":"http://127.0.0.1:8080","username":"u","password":"p"}');
+    expect(config, isNotNull);
+    expect(config!.backend, QbConnectionConfig.backendQbittorrent);
+    expect(config.baseUrl, 'http://127.0.0.1:8080');
+  });
+
+  test('embedded backend round-trips through encode/decode', () {
+    const QbConnectionConfig original = QbConnectionConfig(
+      backend: QbConnectionConfig.backendEmbedded,
+      category: 'hibiki-anime',
+    );
+    final QbConnectionConfig? decoded =
+        decodeQbConnectionConfig(encodeQbConnectionConfig(original));
+    expect(decoded, isNotNull);
+    expect(decoded!.backend, QbConnectionConfig.backendEmbedded);
+    expect(decoded.category, 'hibiki-anime');
+  });
+
+  test('unknown backend value falls back to qbittorrent', () {
+    final QbConnectionConfig? config =
+        decodeQbConnectionConfig('{"backend":"bogus","baseUrl":"x"}');
+    expect(config!.backend, QbConnectionConfig.backendQbittorrent);
+  });
+
+  test('isConfigured: embedded needs no url, qb needs a url', () {
+    // 内置引擎无连接参数：恒已配置。
+    const QbConnectionConfig embedded =
+        QbConnectionConfig(backend: QbConnectionConfig.backendEmbedded);
+    expect(embedded.isConfigured, isTrue);
+    // 外接 qb：URL 空 = 未配置。
+    const QbConnectionConfig qbEmpty = QbConnectionConfig();
+    expect(qbEmpty.isConfigured, isFalse);
+    const QbConnectionConfig qbSet =
+        QbConnectionConfig(baseUrl: 'http://127.0.0.1:8080');
+    expect(qbSet.isConfigured, isTrue);
+  });
+
+  test('copyWith preserves backend when not overridden', () {
+    const QbConnectionConfig base =
+        QbConnectionConfig(backend: QbConnectionConfig.backendEmbedded);
+    final QbConnectionConfig next = base.copyWith(category: 'x');
+    expect(next.backend, QbConnectionConfig.backendEmbedded);
+    final QbConnectionConfig switched =
+        base.copyWith(backend: QbConnectionConfig.backendQbittorrent);
+    expect(switched.backend, QbConnectionConfig.backendQbittorrent);
+  });
+}

--- a/hibiki/test/media/torrent/embedded_torrent_host_test.dart
+++ b/hibiki/test/media/torrent/embedded_torrent_host_test.dart
@@ -1,0 +1,98 @@
+// 阶段2/3：EmbeddedTorrentHost 宿主接线验证——常驻 session 派发短命后端
+// 视图（视图 close 不连累会话）、反吸血 sweep 遍历 peer 不抛、libtorrent 版本。
+//
+// 下载源 LocalSeedRig（127.0.0.1 本地做种，零外网）。缺 DLL 整组 skip。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/torrent/embedded_torrent_backend.dart';
+import 'package:hibiki/src/media/torrent/embedded_torrent_host.dart';
+import 'package:hibiki/src/media/torrent/torrent_backend.dart';
+import 'package:hibiki_torrent/hibiki_torrent.dart';
+import 'package:hibiki_torrent/testing.dart';
+import 'package:path/path.dart' as p;
+
+String? _resolveLibPath() {
+  final String? env = Platform.environment['HIBIKI_TORRENT_LIB'];
+  if (env != null && env.isNotEmpty) {
+    return File(env).existsSync() ? env : null;
+  }
+  return null;
+}
+
+void main() {
+  final String? libPath = _resolveLibPath();
+  final String? skip =
+      libPath == null ? 'hibiki_torrent_ffi native lib not built' : null;
+
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('ht_host_');
+  });
+
+  tearDown(() {
+    try {
+      tempDir.deleteSync(recursive: true);
+    } on FileSystemException {
+      // Windows 偶发句柄未释放；留给系统清理。
+    }
+  });
+
+  test(
+    'host opens, hands out shared-session backend views, sweeps peers',
+    () async {
+      // 用非监听引擎给 rig 做种，另用 host 拿真实下载 session。
+      final EmbeddedTorrentEngine rigEngine =
+          EmbeddedTorrentEngine.open(libraryPath: libPath!);
+      final LocalSeedRig rig = await LocalSeedRig.start(
+          engine: rigEngine, workDir: tempDir, contentBytes: 1024 * 1024);
+      addTearDown(rig.dispose);
+
+      // host：监听回环（出站连接需要 listen socket），无 DHT（确定性）。
+      final EmbeddedTorrentHost? host = EmbeddedTorrentHost.open(
+        libraryPath: libPath,
+        baseSavePath: p.join(tempDir.path, 'content'),
+        listenInterfaces: '127.0.0.1:0',
+        enableDht: false,
+        clockMs: () => _fakeClock,
+      );
+      expect(host, isNotNull);
+      addTearDown(host!.dispose);
+
+      expect(host.libtorrentVersion, startsWith('2.'));
+
+      // backendView 是 TorrentBackend；其 close 不能销毁常驻 session。
+      final TorrentBackend view1 = host.backendView();
+      expect(view1, isA<EmbeddedTorrentBackend>());
+      expect(await view1.probeConnection(), startsWith('libtorrent 2.'));
+      expect(await view1.prepareCategory('hibiki-anime'), isTrue);
+      expect(
+        await view1.addTorrent(rig.magnetUri,
+            category: 'hibiki-anime', sequential: true),
+        isTrue,
+      );
+      view1.close(); // 关视图……
+
+      // ……第二个视图仍能操作同一 session（证明会话没被 view1.close 销毁）。
+      final TorrentBackend view2 = host.backendView();
+      final List<TorrentSnapshot> listed =
+          await view2.listTorrents(category: 'hibiki-anime');
+      expect(listed, hasLength(1));
+      expect(listed.single.hash, rig.infoHash);
+
+      // 反吸血 sweep：遍历种子（此处 1 个、无已连 peer）→ torrentPeers 空
+      // → evaluate 空 → 无新封段。全程不抛，返回 0（无新封禁）。多跑几轮
+      // 幂等（不会因重复 applyIpFilter 报错）。
+      expect(host.sweepAntiLeech(), 0);
+      expect(host.sweepAntiLeech(), 0);
+      expect(host.sweepAntiLeech(), 0);
+    },
+    skip: skip,
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+}
+
+// 反吸血引擎的判定基准时钟（注入固定值；本测试不依赖时间推进）。
+const int _fakeClock = 1000000;

--- a/hibiki/test/media/torrent/embedded_torrent_host_test.dart
+++ b/hibiki/test/media/torrent/embedded_torrent_host_test.dart
@@ -88,6 +88,14 @@ void main() {
       expect(host.sweepAntiLeech(), 0);
       expect(host.sweepAntiLeech(), 0);
       expect(host.sweepAntiLeech(), 0);
+
+      // 用户可调资源限制：全设 / 全 0（不限）/ 只设连接数，均应用成功不抛。
+      expect(
+          host.applyLimits(
+              downloadKbps: 2048, uploadKbps: 512, maxConnections: 100),
+          isTrue);
+      expect(host.applyLimits(), isTrue);
+      expect(host.applyLimits(maxConnections: 50), isTrue);
     },
     skip: skip,
     timeout: const Timeout(Duration(minutes: 2)),

--- a/hibiki/windows/CMakeLists.txt
+++ b/hibiki/windows/CMakeLists.txt
@@ -103,6 +103,27 @@ endif()
 install(TARGETS hoshidicts_ffi RUNTIME DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
   COMPONENT Runtime)
 
+# === 内置 libtorrent 引擎（可选，vendored 预编译）===
+# hibiki_torrent 依赖 libtorrent+boost+openssl（vcpkg 首次源码编译约 40min），
+# 不能强制每台构建机装 vcpkg。故采用 vendored 预编译：由
+# native/hibiki_torrent/build_windows_dll.ps1 事先产出 4 个 DLL 到
+# prebuilt/windows-x64/，这里「有则拷、无则跳」——目录不存在时 flutter build
+# windows 照常成功，app 运行期 DLL 缺失自动回退外接 qb（见 EmbeddedTorrentHost）。
+set(HIBIKI_TORRENT_PREBUILT_DIR
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../native/hibiki_torrent/prebuilt/windows-x64")
+set(HIBIKI_TORRENT_DLLS
+  "hibiki_torrent_ffi.dll"
+  "torrent-rasterbar.dll"
+  "libssl-3-x64.dll"
+  "libcrypto-3-x64.dll")
+foreach(_dll ${HIBIKI_TORRENT_DLLS})
+  set(_dll_path "${HIBIKI_TORRENT_PREBUILT_DIR}/${_dll}")
+  if(EXISTS "${_dll_path}")
+    install(FILES "${_dll_path}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+      COMPONENT Runtime)
+  endif()
+endforeach()
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")

--- a/native/hibiki_torrent/.gitignore
+++ b/native/hibiki_torrent/.gitignore
@@ -1,2 +1,6 @@
 # CMake / standalone build artifacts — never commit.
 build/
+
+# Vendored prebuilt runtime DLLs（由 build_windows_dll.ps1 产出，~11MB）——
+# 不入库（repo 不放二进制），由构建/发布流程各自现产或从 release 拉取。
+prebuilt/

--- a/native/hibiki_torrent/README.md
+++ b/native/hibiki_torrent/README.md
@@ -100,13 +100,31 @@ dart run ffigen --config ffigen.yaml
 
 无 libclang 的机器上，已入库的手写绑定与 ffigen 输出等价。
 
-## 尚未做（阶段2 及以后）
+## 阶段2/3 已接线（app 侧）
+
+- **后端选择**：`QbConnectionConfig` 加 `backend` 字段（`qbittorrent` /
+  `embedded`；历史配置无此字段回退 qb）。设置→视频→番剧下载新增后端二选一
+  分段控件，选内置时隐藏 qb 连接字段。
+- **`EmbeddedTorrentBackend implements TorrentBackend`**：分类=保存子目录、
+  magnet/.torrent 文件（http URL 拒绝）、firstLastPiecePrio 在 listTorrents
+  轮询期补应用。`closesSession` 区分 standalone（自持会话）与 app 共享会话。
+- **`EmbeddedTorrentHost`**（app 侧宿主）：拥有常驻引擎 + 单 session，派发
+  短命 `backendView()` 给 `AnimeDownloadService` 每 tick 用（视图 close 不
+  连累会话）。桌面且 DLL 可用时 `AppModel.startAnimeDownloadService` 懒建，
+  DLL 缺失回退 qb。
+- **反吸血（阶段3）**：`ht_torrent_peers` 导出 peer_info、`ht_apply_ip_filter`
+  执行封禁；`EmbeddedTorrentHost.sweepAntiLeech` 每 tick 把所有种子 peer 喂
+  `AntiLeechEngine`，新增封段全量重建 libtorrent ip_filter。服务 tick 加
+  `onTick` 钩子（早于 pending 门控，做种期也封）。ip_filter 生效性有测试
+  验证（封回环段 → 元数据死等；清空 → 秒连）。
+
+## 尚未做（阶段4 及以后）
 
 - 未接进 `hibiki/windows/CMakeLists.txt` 的 flutter runner —— 接入前
-  `flutter build windows` 不依赖 vcpkg/libtorrent。阶段2 接
-  `AnimeDownloadService.backendFactory` 全链时一并决定「vcpkg 预装 vs
-  FetchContent vs vendored 预编译」的 app 集成与 DLL 随包方案。
+  `flutter build windows` 不依赖 vcpkg/libtorrent。阶段4 一并决定「vcpkg
+  预装 vs FetchContent vs vendored 预编译」的 app 集成 + DLL 随包方案。
 - http(s) .torrent URL 下载（内置引擎侧 magnet-only；Nyaa 链路产 magnet）。
-- 反吸血接线（阶段3）：native 补 peer_info 导出，喂 `AntiLeechEngine`，
-  `BanVerdict` 翻成 libtorrent `ip_filter`。
 - 多平台（Android/macOS/Linux）+ CI 依赖获取策略（阶段4）。
+- 反吸血的真实吸血 peer 触发（PCB 进度作弊需伪造进度的 peer；本地 rig 的
+  做种者诚实，自动化只验 ip_filter 执行力 + peer_info 导出 + sweep 不误封，
+  真封禁触发留真机/阶段4）。

--- a/native/hibiki_torrent/README.md
+++ b/native/hibiki_torrent/README.md
@@ -143,6 +143,23 @@ flutter windows 构建也不便注入 vcpkg 工具链文件。故：
 `build_windows_dll.ps1`（需缓存 vcpkg libtorrent，避免每次 40min），或从
 预先发布的 release 资产下载这 4 个 DLL 放进 `prebuilt/windows-x64/`。
 
+## 用户可调资源限制（速率 + 连接数）
+
+`QbConnectionConfig` 加 `downloadLimitKbps` / `uploadLimitKbps`（KB/s，0=不限）
++ `maxConnections`（0=引擎默认）；设置→视频→番剧下载在**选内置引擎时**显示
+三个数字输入。native `ht_apply_limits(download_bps, upload_bps,
+connections_limit)` 一次应用（`connections_limit<=0` 保持 libtorrent 默认，
+不会把"不限"误设成禁连）。`EmbeddedTorrentHost.applyLimits`（KB/s→bps）在
+宿主创建时铺一次、用户改设置时即时重应用（`AppModel.setQbConnectionConfig`）。
+
+## 为什么不支持 wss:// tracker
+
+libtorrent 2.x **无 WebSocket/WebRTC/WebTorrent tracker 能力**（头文件里
+`websocket`/`wss` 零命中）。wss 是浏览器 WebTorrent（WebRTC data channel）
+生态，给 libtorrent 加它等于塞进整套 WebRTC 栈，是另一个量级的项目。番剧
+种子（Nyaa）用标准 `udp://`/`http://` tracker + DHT，不依赖 wss——所以这
+不是"用户用不了"的短板。真实下载走标准 tracker + DHT 即可。
+
 ## 尚未做（多平台 + 真机）
 
 - **多平台**（Android/macOS/Linux）：同样走 vendored 预编译 + 各 runner

--- a/native/hibiki_torrent/README.md
+++ b/native/hibiki_torrent/README.md
@@ -118,13 +118,37 @@ dart run ffigen --config ffigen.yaml
   `onTick` 钩子（早于 pending 门控，做种期也封）。ip_filter 生效性有测试
   验证（封回环段 → 元数据死等；清空 → 秒连）。
 
-## 尚未做（阶段4 及以后）
+## 阶段4 — Windows DLL 随包（已接 flutter runner）
 
-- 未接进 `hibiki/windows/CMakeLists.txt` 的 flutter runner —— 接入前
-  `flutter build windows` 不依赖 vcpkg/libtorrent。阶段4 一并决定「vcpkg
-  预装 vs FetchContent vs vendored 预编译」的 app 集成 + DLL 随包方案。
+**分布决策：vendored 预编译**（在「vcpkg 预装 / FetchContent 现编 / vendored
+预编译」三选一里选它）。理由：libtorrent 经 vcpkg 首次源码编译约 40min
+（boost+openssl+libtorrent），不能强制每台构建机 / CI 都装 vcpkg 并现编；
+flutter windows 构建也不便注入 vcpkg 工具链文件。故：
+
+1. **产出**：`native/hibiki_torrent/build_windows_dll.ps1 -VcpkgRoot <vcpkg>`
+   编 bridge 并把 4 个运行时 DLL（`hibiki_torrent_ffi` + `torrent-rasterbar`
+   + `libssl-3-x64` + `libcrypto-3-x64`，共 ~11MB）收拢到
+   `prebuilt/windows-x64/`（git 忽略，不入库——repo 不放二进制，构建/发布
+   流程各自现产或从 release 拉取）。
+2. **随包**：`hibiki/windows/CMakeLists.txt` 在 hoshidicts 之后加了
+   **copy-if-present** 块——`prebuilt/windows-x64/*.dll` 存在则 `install` 到
+   `hibiki.exe` 旁，不存在则跳过。因此 `flutter build windows` **不依赖
+   vcpkg/libtorrent**：没跑过产出脚本的机器照常构建，只是 app 运行期
+   `EmbeddedTorrentHost.open` 因 DLL 缺失返回 null → 自动回退外接 qb。
+3. **加载**：`EmbeddedTorrentEngine._openByPlatformDefault` 用
+   `DynamicLibrary.open('hibiki_torrent_ffi.dll')`，DLL 与 exe 同目录即命中；
+   运行时依赖（torrent-rasterbar/ssl/crypto）也在同目录，被隐式加载。
+
+发布流程接入：CI/release workflow 在打 Windows 包前跑一次
+`build_windows_dll.ps1`（需缓存 vcpkg libtorrent，避免每次 40min），或从
+预先发布的 release 资产下载这 4 个 DLL 放进 `prebuilt/windows-x64/`。
+
+## 尚未做（多平台 + 真机）
+
+- **多平台**（Android/macOS/Linux）：同样走 vendored 预编译 + 各 runner
+  CMake 的 copy-if-present，但需对应工具链编 libtorrent（Android NDK /
+  Xcode / gcc），未在本机验证，另起 job。
 - http(s) .torrent URL 下载（内置引擎侧 magnet-only；Nyaa 链路产 magnet）。
-- 多平台（Android/macOS/Linux）+ CI 依赖获取策略（阶段4）。
 - 反吸血的真实吸血 peer 触发（PCB 进度作弊需伪造进度的 peer；本地 rig 的
   做种者诚实，自动化只验 ip_filter 执行力 + peer_info 导出 + sweep 不误封，
-  真封禁触发留真机/阶段4）。
+  真封禁触发留真机）。

--- a/native/hibiki_torrent/build_windows_dll.ps1
+++ b/native/hibiki_torrent/build_windows_dll.ps1
@@ -1,0 +1,65 @@
+﻿# 构建内置 libtorrent 引擎的 Windows DLL 并把运行时依赖收拢到
+# prebuilt/windows-x64/ 供 flutter windows runner 随包（见 hibiki/windows/
+# CMakeLists.txt 的 copy-if-present 集成）。
+#
+# 为什么不在 flutter build 时现编：libtorrent 经 vcpkg 首次源码编译约 40min
+# （boost+openssl+libtorrent），CI/多数开发机不该被迫装 vcpkg。故本脚本单独
+# 产出 4 个 DLL（bridge + torrent-rasterbar + ssl + crypto），flutter windows
+# 构建只做「有则拷、无则跳」，不依赖 vcpkg（阶段4 决策：vendored 预编译）。
+#
+# 用法（需先 vcpkg install libtorrent:x64-windows）：
+#   pwsh -File native/hibiki_torrent/build_windows_dll.ps1 -VcpkgRoot D:\APP\vcpkg
+# 产物：native/hibiki_torrent/prebuilt/windows-x64/*.dll（git 忽略，不入库）
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$VcpkgRoot,
+
+    [string]$Triplet = "x64-windows",
+
+    [string]$Config = "Release"
+)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$buildDir = Join-Path $scriptDir "build"
+$outDir = Join-Path $scriptDir "prebuilt\windows-x64"
+
+$toolchain = Join-Path $VcpkgRoot "scripts\buildsystems\vcpkg.cmake"
+if (-not (Test-Path $toolchain)) {
+    throw "vcpkg toolchain not found: $toolchain (装好 vcpkg 并传 -VcpkgRoot)"
+}
+
+Write-Host "==> CMake configure ($Triplet)"
+cmake -B $buildDir -S $scriptDir -A x64 `
+    "-DCMAKE_TOOLCHAIN_FILE=$toolchain" `
+    "-DVCPKG_TARGET_TRIPLET=$Triplet"
+if ($LASTEXITCODE -ne 0) { throw "cmake configure failed" }
+
+Write-Host "==> CMake build ($Config)"
+cmake --build $buildDir --config $Config
+if ($LASTEXITCODE -ne 0) { throw "cmake build failed" }
+
+$releaseDir = Join-Path $buildDir $Config
+# bridge DLL + vcpkg applocal 部署的运行时依赖（torrent-rasterbar / ssl /
+# crypto）都在 Release 目录里；全量收拢，缺一不可（DynamicLibrary 预载靠它们）。
+$required = @(
+    "hibiki_torrent_ffi.dll",
+    "torrent-rasterbar.dll",
+    "libssl-3-x64.dll",
+    "libcrypto-3-x64.dll"
+)
+
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+foreach ($dll in $required) {
+    $src = Join-Path $releaseDir $dll
+    if (-not (Test-Path $src)) {
+        throw "缺少构建产物 $dll（$src）——检查 vcpkg libtorrent 是否装全"
+    }
+    Copy-Item $src (Join-Path $outDir $dll) -Force
+    Write-Host "  copied $dll"
+}
+
+Write-Host "==> Done. Prebuilt DLLs in: $outDir"
+Write-Host "    flutter build windows 会自动把它们拷到 hibiki.exe 旁（见 windows/CMakeLists.txt）。"

--- a/native/hibiki_torrent/hibiki_torrent_ffi.cpp
+++ b/native/hibiki_torrent/hibiki_torrent_ffi.cpp
@@ -240,6 +240,27 @@ HT_EXPORT int ht_session_set_rate_limits(void* session, int download_bps,
   }
 }
 
+HT_EXPORT int ht_apply_limits(void* session, int download_bps, int upload_bps,
+                              int connections_limit) {
+  if (session == nullptr) return 0;
+  try {
+    lt::settings_pack sp;
+    sp.set_int(lt::settings_pack::download_rate_limit,
+               download_bps > 0 ? download_bps : 0);
+    sp.set_int(lt::settings_pack::upload_rate_limit,
+               upload_bps > 0 ? upload_bps : 0);
+    // <=0 时不动 connections_limit（保持 libtorrent 默认），避免把用户
+    // "不限"误设成 0（0 会禁止所有连接）。
+    if (connections_limit > 0) {
+      sp.set_int(lt::settings_pack::connections_limit, connections_limit);
+    }
+    as_session(session)->apply_settings(std::move(sp));
+    return 1;
+  } catch (...) {
+    return 0;
+  }
+}
+
 HT_EXPORT char* ht_add_magnet(void* session, const char* magnet_uri,
                               const char* save_path, int sequential) {
   if (session == nullptr) return json_error("session is null");

--- a/native/hibiki_torrent/hibiki_torrent_ffi.cpp
+++ b/native/hibiki_torrent/hibiki_torrent_ffi.cpp
@@ -16,6 +16,7 @@
 #include <libtorrent/create_torrent.hpp>
 #include <libtorrent/download_priority.hpp>
 #include <libtorrent/error_code.hpp>
+#include <libtorrent/ip_filter.hpp>
 #include <libtorrent/magnet_uri.hpp>
 #include <libtorrent/session.hpp>
 #include <libtorrent/session_params.hpp>
@@ -26,6 +27,7 @@
 #include <libtorrent/torrent_status.hpp>
 #include <libtorrent/version.hpp>
 
+#include <cctype>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -494,6 +496,138 @@ HT_EXPORT int ht_apply_first_last_priority(void* session,
     return 1;
   } catch (...) {
     return -1;
+  }
+}
+
+HT_EXPORT char* ht_torrent_peers(void* session, const char* info_hash) {
+  if (session == nullptr) return json_error("session is null");
+  try {
+    lt::torrent_handle h = find_torrent(as_session(session), info_hash);
+    if (!h.is_valid()) return json_error("torrent not found");
+    std::vector<lt::peer_info> peers;
+    h.get_peer_info(peers);
+    std::string out = "{\"ok\":true,\"peers\":[";
+    bool first = true;
+    for (const lt::peer_info& pi : peers) {
+      if (!first) out += ',';
+      first = false;
+      out += '{';
+      append_json_str_field(out, "ip", pi.ip.address().to_string());
+      out += ",\"port\":" + std::to_string(pi.ip.port()) + ',';
+      // peer_id：20 字节，前 8 字节常是 ASCII 客户端指纹（如 "-XL0012-"）；
+      // 不可打印字节转 '.'，黑名单前缀匹配仍成立。
+      std::string pid;
+      pid.reserve(20);
+      for (const char byte : pi.pid) {
+        const unsigned char b = static_cast<unsigned char>(byte);
+        pid += (b >= 0x20 && b < 0x7f) ? char(b) : '.';
+      }
+      append_json_str_field(out, "peer_id", pid);
+      out += ',';
+      append_json_str_field(out, "client", pi.client);
+      out += ",\"progress\":" + std::to_string(pi.progress);
+      out += ",\"total_upload\":" + std::to_string(pi.total_upload);
+      out += ",\"total_download\":" + std::to_string(pi.total_download);
+      out += ",\"up_speed\":" + std::to_string(pi.up_speed);
+      out += ",\"down_speed\":" + std::to_string(pi.down_speed);
+      out += std::string(",\"remote_interested\":") +
+             (bool(pi.flags & lt::peer_info::remote_interested) ? "true"
+                                                                : "false");
+      out += '}';
+    }
+    out += "]}";
+    return dup_string(out);
+  } catch (const std::exception& e) {
+    return json_error(e.what());
+  } catch (...) {
+    return json_error("unknown error in ht_torrent_peers");
+  }
+}
+
+namespace {
+
+// "a.b.c.d/nn" / "x::y/nn" → 该 CIDR 段的 [first, last] 地址对；解析失败
+// 返回 false。前缀缺省当 /32（v4）或 /128（v6）单地址。
+bool cidr_range(const std::string& cidr, lt::address& first,
+                lt::address& last) {
+  std::string ip = cidr;
+  int prefix = -1;
+  const std::size_t slash = cidr.rfind('/');
+  if (slash != std::string::npos) {
+    ip = cidr.substr(0, slash);
+    try {
+      prefix = std::stoi(cidr.substr(slash + 1));
+    } catch (...) {
+      return false;
+    }
+  }
+  lt::error_code ec;
+  const lt::address addr = lt::make_address(ip, ec);
+  if (ec) return false;
+  if (addr.is_v4()) {
+    if (prefix < 0 || prefix > 32) prefix = 32;
+    const std::uint32_t base = addr.to_v4().to_uint();
+    const std::uint32_t mask =
+        prefix == 0 ? 0u : ~std::uint32_t(0) << (32 - prefix);
+    first = boost::asio::ip::address_v4(base & mask);
+    last = boost::asio::ip::address_v4((base & mask) | ~mask);
+    return true;
+  }
+  if (prefix < 0 || prefix > 128) prefix = 128;
+  auto bytes_first = addr.to_v6().to_bytes();
+  auto bytes_last = bytes_first;
+  for (int i = 0; i < 16; ++i) {
+    const int bit_start = i * 8;
+    if (prefix <= bit_start) {
+      bytes_first[std::size_t(i)] = 0x00;
+      bytes_last[std::size_t(i)] = 0xff;
+    } else if (prefix < bit_start + 8) {
+      const unsigned char mask =
+          static_cast<unsigned char>(0xff << (bit_start + 8 - prefix));
+      bytes_first[std::size_t(i)] &= mask;
+      bytes_last[std::size_t(i)] |= static_cast<unsigned char>(~mask);
+    }
+  }
+  first = boost::asio::ip::address_v6(bytes_first);
+  last = boost::asio::ip::address_v6(bytes_last);
+  return true;
+}
+
+}  // namespace
+
+HT_EXPORT int ht_apply_ip_filter(void* session, const char* cidrs) {
+  if (session == nullptr) return 0;
+  try {
+    lt::ip_filter filter;
+    if (cidrs != nullptr) {
+      const std::string all(cidrs);
+      std::size_t pos = 0;
+      while (pos <= all.size()) {
+        std::size_t end = all.find('\n', pos);
+        if (end == std::string::npos) end = all.size();
+        std::string line = all.substr(pos, end - pos);
+        // 去首尾空白（含 \r）。
+        while (!line.empty() && std::isspace(
+                                    static_cast<unsigned char>(line.back()))) {
+          line.pop_back();
+        }
+        while (!line.empty() && std::isspace(static_cast<unsigned char>(
+                                    line.front()))) {
+          line.erase(line.begin());
+        }
+        if (!line.empty()) {
+          lt::address first, last;
+          if (cidr_range(line, first, last)) {
+            filter.add_rule(first, last, lt::ip_filter::blocked);
+          }
+        }
+        pos = end + 1;
+      }
+    }
+    as_session(session)->set_ip_filter(filter);
+    return 1;
+  } catch (...) {
+    return 0;
   }
 }
 

--- a/native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h
+++ b/native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h
@@ -51,6 +51,14 @@ HT_EXPORT int ht_session_listen_port(void* session);
 HT_EXPORT int ht_session_set_rate_limits(void* session, int download_bps,
                                          int upload_bps);
 
+// 一次设全局资源限制（用户可调，控制内置引擎占用）：
+// [download_bps]/[upload_bps] 速率上限（字节/秒，<=0 = 不限）；
+// [connections_limit] 全局最大连接数（<=0 = 保持 libtorrent 默认）。
+// 返回 1 成功、0 失败。（速率部分与 ht_session_set_rate_limits 等价，这里
+// 合成一个入口让 app 从配置一次性应用。）
+HT_EXPORT int ht_apply_limits(void* session, int download_bps, int upload_bps,
+                              int connections_limit);
+
 // 添加磁力链接，落盘到 [save_path]；[sequential] 非 0 开顺序下载。
 // 成功 {"ok":true,"id":"<infohash>"}；失败 {"ok":false,"error":"..."}。
 // 重复添加同一种子返回已有种子的 id（ok:true）。

--- a/native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h
+++ b/native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h
@@ -5,6 +5,7 @@
 // 阶段1b：真实下载管线（磁力 → 元数据 → 顺序下载 → 进度 → 完成）+ 本地
 // 做种/测试支撑（make_torrent / connect_peer）+ 边下边播原语
 // （sequential + set_piece_deadline + 首尾 piece 提优）。
+// 阶段3：反吸血支撑（torrent_peers 导出 peer_info、apply_ip_filter 执行封禁）。
 // C ABI 手写（不被 libtorrent 的 BSD 之外任何依赖传染），Dart 侧用 ffigen
 // 从本头文件生成绑定，与 hoshidicts 同一 FFI 范式。
 //
@@ -100,6 +101,19 @@ HT_EXPORT int ht_set_piece_deadline(void* session, const char* info_hash,
 // 返回 1 = 已应用、0 = 元数据未就绪（稍后重试）、-1 = 种子不存在。
 HT_EXPORT int ht_apply_first_last_priority(void* session,
                                            const char* info_hash);
+
+// 某种子当前连接的 peer 列表（反吸血判定输入）：
+// {"ok":true,"peers":[{"ip","port","peer_id"(20 字节可打印化，不可打印字节
+// 转 '.'),"client","progress"(peer 自报 0~1，可伪造),"total_upload"(我实际
+// 喂给该 peer 的字节，可信),"total_download","up_speed","down_speed",
+// "remote_interested"}]}
+HT_EXPORT char* ht_torrent_peers(void* session, const char* info_hash);
+
+// 用 CIDR 列表整体重建 session 的 ip_filter（换行分隔，如
+// "1.2.3.0/24\n5.6.7.8/32"；空串 = 清空）。已连接的命中 peer 会被断开，
+// 新连接直接拒绝。封禁真相源在 Dart 侧 AntiLeechEngine（bannedCidrs），
+// 每次全量重建消除增量同步状态。1 成功 0 失败。
+HT_EXPORT int ht_apply_ip_filter(void* session, const char* cidrs);
 
 // 移除种子；[delete_files] 非 0 连已下载数据一起删。1 成功 0 失败。
 HT_EXPORT int ht_remove_torrent(void* session, const char* info_hash,

--- a/packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart
+++ b/packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart
@@ -263,6 +263,55 @@ class HtPieceMap {
   int get haveCount => have.codeUnits.where((int c) => c == 0x31).length;
 }
 
+/// 某种子当前连接的单个 peer（反吸血判定输入）。
+class HtPeerInfo {
+  const HtPeerInfo({
+    required this.ip,
+    required this.port,
+    required this.peerId,
+    required this.client,
+    required this.progress,
+    required this.totalUpload,
+    required this.totalDownload,
+    required this.upSpeed,
+    required this.downSpeed,
+    required this.remoteInterested,
+  });
+
+  final String ip;
+  final int port;
+
+  /// 20 字节 peer_id 的可打印化（不可打印字节转 '.'；前 8 字节常是
+  /// "-XL0012-" 式客户端指纹）。
+  final String peerId;
+  final String client;
+
+  /// peer 自报进度 0~1（可伪造）。
+  final double progress;
+
+  /// 我实际喂给该 peer 的字节（可信，PCB 判定依据）。
+  final int totalUpload;
+  final int totalDownload;
+  final int upSpeed;
+  final int downSpeed;
+  final bool remoteInterested;
+
+  factory HtPeerInfo._fromJson(Map<String, dynamic> json) {
+    return HtPeerInfo(
+      ip: json['ip'] as String? ?? '',
+      port: (json['port'] as num?)?.toInt() ?? 0,
+      peerId: json['peer_id'] as String? ?? '',
+      client: json['client'] as String? ?? '',
+      progress: (json['progress'] as num?)?.toDouble() ?? 0.0,
+      totalUpload: (json['total_upload'] as num?)?.toInt() ?? 0,
+      totalDownload: (json['total_download'] as num?)?.toInt() ?? 0,
+      upSpeed: (json['up_speed'] as num?)?.toInt() ?? 0,
+      downSpeed: (json['down_speed'] as num?)?.toInt() ?? 0,
+      remoteInterested: json['remote_interested'] == true,
+    );
+  }
+}
+
 /// 单个 piece 完成事件（发生序）。
 class HtPieceEvent {
   const HtPieceEvent({required this.id, required this.piece});
@@ -442,6 +491,37 @@ class EmbeddedTorrentSession {
       return _b.ht_apply_first_last_priority(_session, id);
     } finally {
       malloc.free(id);
+    }
+  }
+
+  /// 某种子当前连接的 peer 列表；种子不存在返回 null。
+  List<HtPeerInfo>? torrentPeers(String infoHash) {
+    if (isClosed) return null;
+    final Pointer<Char> id = infoHash.toNativeUtf8().cast<Char>();
+    try {
+      final Object? json =
+          _engine._consumeJson(_b.ht_torrent_peers(_session, id));
+      if (json is! Map<String, dynamic> || json['ok'] != true) return null;
+      final Object? peers = json['peers'];
+      if (peers is! List) return null;
+      return peers
+          .whereType<Map<String, dynamic>>()
+          .map(HtPeerInfo._fromJson)
+          .toList(growable: false);
+    } finally {
+      malloc.free(id);
+    }
+  }
+
+  /// 用 CIDR 列表整体重建 session 的 ip_filter（空列表 = 清空）。已连接的
+  /// 命中 peer 会被断开，新连接直接拒绝。
+  bool applyIpFilter(Iterable<String> cidrs) {
+    if (isClosed) return false;
+    final Pointer<Char> joined = cidrs.join('\n').toNativeUtf8().cast<Char>();
+    try {
+      return _b.ht_apply_ip_filter(_session, joined) == 1;
+    } finally {
+      malloc.free(joined);
     }
   }
 

--- a/packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart
+++ b/packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart
@@ -360,6 +360,19 @@ class EmbeddedTorrentSession {
     return _b.ht_session_set_rate_limits(_session, downloadBps, uploadBps) == 1;
   }
 
+  /// 一次设全局资源限制（用户可调）：速率上限（字节/秒，<=0 不限）+ 全局最大
+  /// 连接数（<=0 保持 libtorrent 默认）。
+  bool applyLimits({
+    int downloadBps = 0,
+    int uploadBps = 0,
+    int connectionsLimit = 0,
+  }) {
+    if (isClosed) return false;
+    return _b.ht_apply_limits(
+            _session, downloadBps, uploadBps, connectionsLimit) ==
+        1;
+  }
+
   /// 添加磁力链接。
   HtAddResult addMagnet(
     String magnetUri, {

--- a/packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart
+++ b/packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart
@@ -90,6 +90,24 @@ class HibikiTorrentBindings {
   late final _ht_session_set_rate_limits = _ht_session_set_rate_limitsPtr
       .asFunction<int Function(ffi.Pointer<ffi.Void>, int, int)>();
 
+  /// 一次设全局资源限制（速率 bps + 连接数）。1 成功 0 失败。
+  int ht_apply_limits(
+    ffi.Pointer<ffi.Void> session,
+    int download_bps,
+    int upload_bps,
+    int connections_limit,
+  ) {
+    return _ht_apply_limits(
+        session, download_bps, upload_bps, connections_limit);
+  }
+
+  late final _ht_apply_limitsPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Int, ffi.Int,
+              ffi.Int)>>('ht_apply_limits');
+  late final _ht_apply_limits = _ht_apply_limitsPtr
+      .asFunction<int Function(ffi.Pointer<ffi.Void>, int, int, int)>();
+
   /// 添加磁力；返回 malloc JSON（ht_free_string 释放）。
   ffi.Pointer<ffi.Char> ht_add_magnet(
     ffi.Pointer<ffi.Void> session,

--- a/packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart
+++ b/packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart
@@ -254,6 +254,37 @@ class HibikiTorrentBindings {
   late final _ht_apply_first_last_priority = _ht_apply_first_last_priorityPtr
       .asFunction<int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>();
 
+  /// 某种子当前连接的 peer 列表；返回 malloc JSON（ht_free_string 释放）。
+  ffi.Pointer<ffi.Char> ht_torrent_peers(
+    ffi.Pointer<ffi.Void> session,
+    ffi.Pointer<ffi.Char> info_hash,
+  ) {
+    return _ht_torrent_peers(session, info_hash);
+  }
+
+  late final _ht_torrent_peersPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Char>)>>('ht_torrent_peers');
+  late final _ht_torrent_peers = _ht_torrent_peersPtr.asFunction<
+      ffi.Pointer<ffi.Char> Function(
+          ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>();
+
+  /// 用换行分隔的 CIDR 列表整体重建 ip_filter。1 成功 0 失败。
+  int ht_apply_ip_filter(
+    ffi.Pointer<ffi.Void> session,
+    ffi.Pointer<ffi.Char> cidrs,
+  ) {
+    return _ht_apply_ip_filter(session, cidrs);
+  }
+
+  late final _ht_apply_ip_filterPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Char>)>>('ht_apply_ip_filter');
+  late final _ht_apply_ip_filter = _ht_apply_ip_filterPtr
+      .asFunction<int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>();
+
   /// 移除种子。1 成功 0 失败。
   int ht_remove_torrent(
     ffi.Pointer<ffi.Void> session,

--- a/packages/hibiki_torrent/test/embedded_pipeline_test.dart
+++ b/packages/hibiki_torrent/test/embedded_pipeline_test.dart
@@ -205,4 +205,70 @@ void main() {
     expect(session.setRateLimits(downloadBps: 1024 * 1024), isTrue);
     expect(session.setRateLimits(), isTrue);
   }, skip: skip);
+
+  test(
+    'ip_filter blocks the seeder, then clearing it lets the download start',
+    () async {
+      final LocalSeedRig rig = await LocalSeedRig.start(
+          engine: engine!, workDir: tempDir, contentBytes: 1024 * 1024);
+      addTearDown(rig.dispose);
+
+      final EmbeddedTorrentSession? leecher =
+          EmbeddedTorrentSession.open(engine, listenInterfaces: '127.0.0.1:0');
+      addTearDown(leecher!.close);
+      // 限速让 1MiB 传输持续若干秒，peer 不会秒完即断——保证下面观察到它。
+      leecher.setRateLimits(downloadBps: 64 * 1024);
+
+      // 先封整个回环段：随后 connect_peer 到做种者应被 ip_filter 拒绝，
+      // 30×0.1s 窗口内拿不到元数据（若不生效，1MiB 本地传输早该几百 ms 完成）。
+      expect(leecher.applyIpFilter(<String>['127.0.0.0/8']), isTrue);
+      final HtAddResult added = leecher.addMagnet(rig.magnetUri,
+          savePath: '${tempDir.path}/dl', sequential: true);
+      expect(added.ok, isTrue);
+      for (int i = 0; i < 30; i++) {
+        leecher.connectPeer(rig.infoHash, '127.0.0.1', rig.seederPort);
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      }
+      expect(
+        leecher.listTorrents().single.hasMetadata,
+        isFalse,
+        reason: 'ip_filter should have blocked the only available peer',
+      );
+
+      // 清空过滤器后同一 peer 应可连上并拿到元数据。
+      expect(leecher.applyIpFilter(const <String>[]), isTrue);
+      await _pollUntil(
+        () => leecher.listTorrents().single.hasMetadata,
+        timeout: const Duration(seconds: 30),
+        what: 'metadata after clearing ip_filter',
+        onTick: () =>
+            leecher.connectPeer(rig.infoHash, '127.0.0.1', rig.seederPort),
+      );
+
+      // 连上后 peer 列表应 surface 做种者（反吸血判定输入）。限速 64KiB/s 让
+      // 1MiB 传输持续约 16s，peer 全程连着——把 peer 观察绑在真实传输窗口上
+      // 而非独立竞态：推进到进度过半期间，做种者应至少出现一次且喂过字节。
+      int maxSeenDownload = 0;
+      await _pollUntil(
+        () {
+          for (final HtPeerInfo pr
+              in leecher.torrentPeers(rig.infoHash) ?? const <HtPeerInfo>[]) {
+            if (pr.ip == '127.0.0.1' && pr.totalDownload > maxSeenDownload) {
+              maxSeenDownload = pr.totalDownload;
+            }
+          }
+          return leecher.listTorrents().single.progress >= 0.5;
+        },
+        timeout: const Duration(seconds: 60),
+        what: 'download to reach 50% (peer feeding bytes)',
+        onTick: () =>
+            leecher.connectPeer(rig.infoHash, '127.0.0.1', rig.seederPort),
+      );
+      // 做种者在传输窗口内出现过并给我们喂了字节。
+      expect(maxSeenDownload, greaterThan(0),
+          reason: 'seeder peer must surface in peer_info with bytes fed to us');
+    },
+    skip: skip,
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
 }

--- a/packages/hibiki_torrent/test/embedded_pipeline_test.dart
+++ b/packages/hibiki_torrent/test/embedded_pipeline_test.dart
@@ -206,6 +206,23 @@ void main() {
     expect(session.setRateLimits(), isTrue);
   }, skip: skip);
 
+  test('applyLimits (rate + connections) round-trips', () {
+    final EmbeddedTorrentSession? session =
+        EmbeddedTorrentSession.open(engine!);
+    addTearDown(session!.close);
+    // 全设。
+    expect(
+        session.applyLimits(
+            downloadBps: 2 * 1024 * 1024,
+            uploadBps: 512 * 1024,
+            connectionsLimit: 100),
+        isTrue);
+    // 全 0 = 不限，也应成功（connections<=0 保持默认，不误设成禁连）。
+    expect(session.applyLimits(), isTrue);
+    // 只设连接数。
+    expect(session.applyLimits(connectionsLimit: 50), isTrue);
+  }, skip: skip);
+
   test(
     'ip_filter blocks the seeder, then clearing it lets the download start',
     () async {


### PR DESCRIPTION
TODO-1649 内置 libtorrent 引擎 · 阶段1b（1a 骨架 PR#213 已合）。

## 做了什么
- **C ABI 真实下载管线**（`native/hibiki_torrent`）：磁力/.torrent 添加、`make_torrent`（本地做种/测试）、`connect_peer`、种子/文件/piece 位图查询、`poll_piece_events`（piece 完成序）、`set_piece_deadline` + `apply_first_last_priority`（边下边播原语）、移除、限速。`ht_session_create` 改带 listen_interfaces + DHT 参数（空 = 1a 空壳语义，冒烟测试不变）。C 层零自有状态，出参 malloc JSON（手写转义，无第三方依赖，不引 GPL 传染）。
- **Dart**：绑定手扩（ffigen 等价风格）+ `EmbeddedTorrentSession` 高层封装 + `LocalSeedRig`（127.0.0.1 本地做种测试脚手架，确定性零外网）。
- **app**：`EmbeddedTorrentBackend implements TorrentBackend` —— 分类=保存子目录（目录即真相）、magnet/.torrent 文件（http URL 明确拒绝，Nyaa 链路产 magnet）、firstLastPiecePrio 在 listTorrents 轮询期补应用（libtorrent 无 add 期开关）。

## 验证（全绿）
- `packages/hibiki_torrent`: `dart test` 5/5 —— 端到端管线：**磁力 → 元数据 → 顺序下载 → 完成 → 下载字节与做种源逐字节相等 → piece 完成序验证顺序性（剔除首尾提优后递增占比 >0.8）**，8MiB 本地 rig ~1s 跑完
- `hibiki`: `flutter test test/media/torrent/embedded_torrent_backend_test.dart` 1/1 —— TorrentBackend 契约（probe/分类目录/过滤/isComplete/listFiles 映射）
- `flutter analyze`（app 全量）+ `dart analyze`（包）均 0 issue
- 缺 DLL 环境测试整组 skip，CI 不红（`flutter build windows` 不依赖 vcpkg）

## 踩坑已记 README
1. libtorrent **出站连接绑定 listen socket**，不监听的 session 连不出任何 peer（曾致元数据死等）
2. add 默认旗标带 `paused`，起始瞬间丢 `connect_peer` 且本地无 DHT/tracker 无从再发现 → bridge add 即启动
3. Windows `DynamicLibrary.open` 不搜目标 DLL 所在目录的依赖 → 引擎预载同目录 vcpkg applocal 依赖

## 真机验收
- `dart run tool/download_harness.dart <dll> "<magnet>" <saveDir>`（DHT 开、顺序下载、逐秒进度）用真实磁力冒烟；边下边播全链（选种→入库→播放）是阶段2 接 `backendFactory` 的事
- 构建：vcpkg（`D:\APP\vcpkg`）+ `cmake --build build --config Release`，见 README

## 后续（TODO-1649）
阶段2 接进全链 + app 集成/DLL 随包方案；阶段3 反吸血接线（补 peer_info 导出喂 AntiLeechEngine）；阶段4 多平台+CI 依赖策略。