### PR TITLE
fix(perf): 查词弹窗/悬浮窗请求系统最高刷新率，修复滚动帧率锁 60Hz

### DIFF
--- a/hibiki/android/app/src/main/java/app/hibiki/reader/BaseFloatingService.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/BaseFloatingService.java
@@ -243,6 +243,10 @@ public abstract class BaseFloatingService extends Service {
                         | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
                 PixelFormat.TRANSLUCENT);
         lp.gravity = Gravity.TOP | Gravity.START;
+        // 悬浮查词 / 悬浮歌词 overlay 窗默认不请求高刷，滚动 / 逐行滑动被系统压到
+        // 60Hz。addView 前给 LayoutParams 声明最高刷模式偏好（FloatingLyricService
+        // 覆写了本方法但会 super 调用，故一并覆盖；FloatingDictService 自建 lp 需单独接）。
+        HighRefreshRate.applyToLayoutParams(lp, windowManager);
         return lp;
     }
 

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/FloatingDictService.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/FloatingDictService.java
@@ -150,6 +150,8 @@ public class FloatingDictService extends BaseFloatingService {
                         | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
                 PixelFormat.TRANSLUCENT);
         lp.gravity = Gravity.TOP | Gravity.START;
+        // 本方法完全自建 lp、不调 super，故需单独请求高刷（与 BaseFloatingService 同款）。
+        HighRefreshRate.applyToLayoutParams(lp, windowManager);
         return lp;
     }
 

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/HighRefreshRate.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/HighRefreshRate.java
@@ -1,0 +1,92 @@
+package app.hibiki.reader;
+
+import android.app.Activity;
+import android.os.Build;
+import android.util.Log;
+import android.view.Display;
+import android.view.Window;
+import android.view.WindowManager;
+
+/**
+ * 让本 App 的每个原生窗口主动向系统请求「与当前分辨率相同、刷新率最高」的
+ * {@link Display.Mode}。Flutter/WebView 本身从不请求高刷，很多机型在自适应刷新 /
+ * 省电策略下会把没表态的第三方 App 钉在 60Hz 甚至更低——阅读器主窗口、查词弹窗
+ * （{@code PopupDictFlutterActivity}，独立 {@code :popup} 进程、独立 window，绝不
+ * 继承 MainActivity 的偏好）、悬浮查词 / 悬浮歌词窗整屏明显掉刷新率。
+ *
+ * <p>这里只声明偏好（{@code preferredDisplayModeId}），由系统调度；拿不到 display /
+ * 无更高模式 / 任意异常都安全退化为系统默认，never break userspace。等价于
+ * flutter_displaymode 的原生做法，但不引入依赖。
+ *
+ * <p>覆盖两种窗口形态各一个入口：Activity 主窗口走 {@link #applyToActivity(Activity)}
+ * （改 {@code window.attributes}）；悬浮窗 overlay 走
+ * {@link #applyToLayoutParams(WindowManager.LayoutParams, WindowManager)}（在
+ * {@code addView} 之前改 {@link WindowManager.LayoutParams}）。
+ */
+public final class HighRefreshRate {
+    private static final String TAG = "hibiki-refresh";
+
+    private HighRefreshRate() {}
+
+    /**
+     * 在 {@code display} 支持的所有模式里挑一个与当前分辨率一致、刷新率严格更高
+     * （+1f 容差抗浮点抖动）的模式，返回其 {@code modeId}；当前已是最高刷 / 无可用
+     * 模式 / {@code display} 为空时返回 0（= 不表态，系统默认）。
+     *
+     * @param display 目标窗口所在的显示器，可为 null。
+     * @return 目标 {@code Display.Mode} 的 id，或 0 表示不改。
+     */
+    public static int bestModeId(Display display) {
+        if (display == null) return 0;
+        Display.Mode current = display.getMode();
+        Display.Mode[] modes = display.getSupportedModes();
+        if (current == null || modes == null || modes.length == 0) return 0;
+        int bestModeId = 0;
+        float bestRate = current.getRefreshRate();
+        for (Display.Mode mode : modes) {
+            // 只在与当前分辨率一致的模式里挑，避免顺带改了分辨率。
+            if (mode.getPhysicalWidth() == current.getPhysicalWidth()
+                    && mode.getPhysicalHeight() == current.getPhysicalHeight()
+                    && mode.getRefreshRate() > bestRate + 1f) {
+                bestRate = mode.getRefreshRate();
+                bestModeId = mode.getModeId();
+            }
+        }
+        return bestModeId;
+    }
+
+    /** 给 Activity 主窗口请求最高刷新率。须在 {@code super.onCreate} 之后调用。安全 no-op 退化。 */
+    public static void applyToActivity(Activity activity) {
+        if (activity == null) return;
+        try {
+            Display display = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+                    ? activity.getDisplay()
+                    : activity.getWindowManager().getDefaultDisplay();
+            int modeId = bestModeId(display);
+            if (modeId == 0) return;
+            Window window = activity.getWindow();
+            if (window == null) return;
+            WindowManager.LayoutParams lp = window.getAttributes();
+            lp.preferredDisplayModeId = modeId;
+            window.setAttributes(lp);
+        } catch (Exception e) {
+            Log.w(TAG, "request high refresh rate (activity) failed", e);
+        }
+    }
+
+    /**
+     * 给悬浮窗 overlay 的 {@link WindowManager.LayoutParams} 请求最高刷新率。须在
+     * {@code windowManager.addView(view, lp)} 之前调用，用该 overlay 的
+     * {@link WindowManager} 解析所在 display。安全 no-op 退化。
+     */
+    public static void applyToLayoutParams(WindowManager.LayoutParams lp, WindowManager wm) {
+        if (lp == null || wm == null) return;
+        try {
+            int modeId = bestModeId(wm.getDefaultDisplay());
+            if (modeId == 0) return;
+            lp.preferredDisplayModeId = modeId;
+        } catch (Exception e) {
+            Log.w(TAG, "request high refresh rate (overlay) failed", e);
+        }
+    }
+}

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/MainActivity.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/MainActivity.java
@@ -134,45 +134,9 @@ public class MainActivity extends AudioServiceActivity {
         super.onCreate(savedInstanceState);
 
         disableSystemFocusHighlight();
-        requestHighestRefreshRate();
-    }
-
-    // 主动向系统请求本窗口的最高刷新率显示模式。Flutter/WebView 阅读器本身不会
-    // 请求高刷，很多机型（尤其自适应刷新/省电策略下）会把没表态的第三方 App 钉在
-    // 60Hz 甚至更低，读书时整屏明显掉刷新率。这里在 getSupportedModes() 里挑一个
-    // 与当前分辨率相同、刷新率最高的模式，写进 window.preferredDisplayModeId（等价
-    // 于 flutter_displaymode 的原生做法，但不引入依赖）。只声明偏好、交由系统调度；
-    // 拿不到 / 无更高模式 / 任意异常都安全退化为系统默认，never break userspace。
-    private void requestHighestRefreshRate() {
-        try {
-            android.view.Display display;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                display = getDisplay();
-            } else {
-                display = getWindowManager().getDefaultDisplay();
-            }
-            if (display == null) return;
-            android.view.Display.Mode current = display.getMode();
-            android.view.Display.Mode[] modes = display.getSupportedModes();
-            if (modes == null || modes.length == 0) return;
-            int bestModeId = 0;
-            float bestRate = current.getRefreshRate();
-            for (android.view.Display.Mode mode : modes) {
-                // 只在与当前分辨率一致的模式里挑，避免顺带改了分辨率。
-                if (mode.getPhysicalWidth() == current.getPhysicalWidth()
-                        && mode.getPhysicalHeight() == current.getPhysicalHeight()
-                        && mode.getRefreshRate() > bestRate + 1f) {
-                    bestRate = mode.getRefreshRate();
-                    bestModeId = mode.getModeId();
-                }
-            }
-            if (bestModeId == 0) return; // 当前已是最高刷新率模式。
-            WindowManager.LayoutParams lp = getWindow().getAttributes();
-            lp.preferredDisplayModeId = bestModeId;
-            getWindow().setAttributes(lp);
-        } catch (Exception e) {
-            android.util.Log.w("hibiki-refresh", "request high refresh rate failed", e);
-        }
+        // 阅读器主窗口请求系统最高刷新率（收敛到共享 HighRefreshRate，与查词弹窗
+        // PopupDictFlutterActivity / 悬浮窗共用同一实现，见 HighRefreshRate.java）。
+        HighRefreshRate.applyToActivity(this);
     }
 
     // BUG-195: On API 26+ every View defaults to defaultFocusHighlightEnabled=true,

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/PopupDictFlutterActivity.kt
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/PopupDictFlutterActivity.kt
@@ -90,6 +90,9 @@ class PopupDictFlutterActivity : FlutterActivity() {
         engineWasCold = PopupEngineHolder.ensureEngine(this)
         PopupEngineHolder.setOnFinish { runOnUiThread { finish() } }
         super.onCreate(savedInstanceState)
+        // 查词弹窗是独立 :popup 进程、独立 window，绝不继承 MainActivity 的高刷偏好；
+        // 不主动请求就被系统按默认策略压到 60Hz，滚动列表明显卡顿。安全 no-op 退化。
+        HighRefreshRate.applyToActivity(this)
         if (!engineWasCold) {
             // Warm reuse: Dart is already mounted and won't re-poll
             // getInitialProcessText, so push the new term explicitly.

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+839
+version: 1.2.0+840
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"


### PR DESCRIPTION
## 症状
用户报「查词弹窗滚轮上下滑动帧率很低卡卡的」，要求帧率跟随系统、不要强行封顶。

## 根因（已 git 亲验）
- `develop` 上 **MainActivity（阅读器主窗口）已请求高刷**（`requestHighestRefreshRate`）→ 所以书籍阅读正常。
- 但 **查词弹窗 `PopupDictFlutterActivity` 是独立 `:popup` 进程、独立 window，绝不继承主窗口的 `preferredDisplayModeId`** → 被系统按默认策略（自适应刷新/省电）压到 60Hz，滚动列表明显卡顿。悬浮查词/悬浮歌词 overlay 窗同样从不请求高刷。
- 对照：阅读器与弹窗都是「逐 wheel 事件离散 scrollBy」，但阅读器有高刷=正常，弹窗无高刷=卡——**差别只在刷新率，不在滚动逻辑**。故不改 popup.js 那套精调+重守卫的滚轮逻辑（避免无谓回归）。
- Dart 侧无任何显式 fps 封顶（全仓 `fps`/`framerate` 命中均为音频/GIF/视频导出）。

## 改动（Android 原生）
- 新增共享 `HighRefreshRate` helper：**Activity 主窗口** + **overlay LayoutParams** 两个入口，在 `getSupportedModes()` 里挑与当前分辨率一致、刷新率最高的 `Display.Mode` 写进 `preferredDisplayModeId`；拿不到/无更高模式/异常一律安全退化为系统默认，never break userspace。
- `MainActivity` 内联实现收敛到 helper（单一真相源，去重 ~40 行）。
- `PopupDictFlutterActivity.onCreate`（查词弹窗）+ `BaseFloatingService.createLayoutParams`（覆盖 `FloatingLyricService`，其 super 调用继承）+ `FloatingDictService.createLayoutParams`（自建 lp，单独接）各接入。
- iOS Release 已由构建脚本解放 ProMotion（`CADisableMinimumFrameDurationOnPhone`），桌面跟随系统合成器，均无需改。

## 验证
- `flutter build apk --debug` 通过（无错误，仅既有 deprecation 警告）。
- ⚠️ **待 120Hz 真机复测**：本机当前无设备连接；模拟器单 60Hz 模式只能验证安全 no-op、不代表高刷手感。

## 其余审计发现（不在本 PR，供后续按真机测量定优先级）
- popup.js 逐事件离散 scrollBy（正常网页行为，高刷后应与阅读器同样顺滑）。
- Flutter 隐式掉帧清单：查词弹窗滑动关窗每帧重建整树+Opacity saveLayer、结果列表 cacheExtent≈无限；主题色卡/统计图 CustomPaint 缺 RepaintBoundary（PR#187 范式）；弹幕层每帧整树 rebuild。建议真机测帧率后再按需修。