### PR TITLE
fix(video): BUG-891 ASS 字号按 OS/2 win cell 换算 + 描边半径×2 对齐 mpv/libass

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 869 条。点号进各自文件。
+> 共 870 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-891](bugs/BUG-891-ass-size-outline-mpv-parity.md) | ✅ | ✅ | ASS 字幕字号偏小、描边偏细：cell 校准含 lineGap + 居中描边只显一半，与 mpv/libass 不齐 |
 | [BUG-890](bugs/BUG-890-paused-audio-follow-image-snap.md) | ✅ | ✅ | 暂停/图片等待时有声书跟随把阅读器拽回音频位置 |
 | [BUG-887](bugs/BUG-887-top-progress-squeeze-frost.md) | ✅ | ✅ | 挤压模式顶部进度不应有毛玻璃且不应压住正文首行 |
 | [BUG-886](bugs/BUG-886-collapse-header-center.md) | ✅ | ✅ | 折叠设置分组标题头文字与箭头未垂直居中 |

--- a/docs/bugs/BUG-891-ass-size-outline-mpv-parity.md
+++ b/docs/bugs/BUG-891-ass-size-outline-mpv-parity.md
@@ -1,0 +1,10 @@
+## BUG-891 · ASS 字幕字号偏小、描边偏细：cell 校准含 lineGap + 居中描边只显一半，与 mpv/libass 不齐
+- **报告**：2026-07-18（用户：同帧截图对比 mpv——对白行 Hibiki 比 mpv 小 ~20% 且描边更细；\pos 屏幕字两边一致 → 样式级错配非全局缩放错）
+- **真实性**：✅ 真 bug，两处根因：
+  1. **字号**：`video_subtitle_overlay.dart` 旧 `_assFontSizeToEm` 用 TextPainter **段落自然行高**当 cell 系数 k，但段落行高**含 hhea lineGap**（SkParagraph 把 leading 折进 ascent/descent，段落 API 剥不掉）。libass 语义（`ass_font.c::ass_face_set_size`：`mscale = hheaCell/winCell` + `FT_SIZE_REQUEST_TYPE_REAL_DIM` 按 hheaCell 定标，两处相消）是 **`em = Fontsize × upem / (usWinAscent+usWinDescent)`**（OS/2 win cell，无 lineGap）。实测本机字体表：Yu Gothic/Yu Mincho（Windows CJK 回退链首选）upem=2048、winCell=2636（1.287em）、lineGap=1024（0.5em）→ 旧近似 k≈1.6~1.79 vs libass 1.287，字号偏小 20~40%；MS Gothic（winCell=1.0、lineGap=0）恰好无差——所以「有的字幕对有的不对」。
+  2. **描边**：`_resolveStroke` 把 ASS `Outline`/`\bord`（libass `FT_Glyph_StrokeBorder` **向外扩的半径**，可见描边=完整半径）直接当 Flutter 居中 stroke 的 `strokeWidth`——内半边被上层 fill 盖住，可见只剩一半，恒比 mpv 细 50%。另 `Outline:0` 被 `clamp(0.5,…)` 下限强制成 0.5px 细边，mpv 则完全不画。
+- **[x] ① 已修复** — worktree-ass-size-outline-mpv-parity：
+  - 新增 `hibiki/lib/src/media/video/ass_font_metrics.dart`：sfnt（ttf/otf/ttc）`head`/`hhea`/`OS/2`/`name` 最小解析 + `AssFontCellIndex`（MKV 内嵌字体注册时同步喂入优先；懒惰后台 isolate 扫描系统字体目录，部分读取不整读大 TTC）；`cellPerEm = winCell/upem`（缺 OS/2 回退 hheaCell），与 libass 完全同源。
+  - `video_subtitle_overlay.dart`：`_cellPerEmFor` 先查真字体表（沿「显式家族→CJK 回退链」取 Skia 实际会用的第一个存在家族），表不可得才回退旧 TextPainter 近似；索引 `revision` bump 时清 k 缓存重绘自动校正。`assOutlineStrokeWidth`：半径×2 成居中 strokeWidth（可见宽=半径）、`Outline<=0` → 0 不画。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/ass_font_metrics_test.dart`（合成 sfnt/TTC：winCell 语义、hhea 回退、Yu Gothic 真实数值量级、索引优先级/大小写/revision）+ `hibiki/test/media/video/video_subtitle_ass_outline_width_test.dart`（Outline=2 → strokeWidth=半径×2；Outline=0 → 无描边层）；旧 `video_subtitle_letterbox_scale_test.dart` / `video_subtitle_overlay_markup_test.dart` 的描边断言同步更新为 ×2 语义。
+- **备注**：真表就绪前（扫描中/平台受限如 iOS 沙箱）字号先按旧近似渲染、就绪后同帧校正；测试环境（FlutterTest 字体）所有家族解析不到 → 不触发扫描、恒走近似，既有测试像素不变。字号索引按 family 级（不分字重面，同族各面 winCell 几乎一致）。`ScaledBorderAndShadow: no`（描边不随画面缩放，罕见）仍未特判。透明填充（\1a）下居中描边内半可见，与 libass 外扩环有细微差，可接受近似。

--- a/hibiki/lib/src/media/video/ass_font_metrics.dart
+++ b/hibiki/lib/src/media/video/ass_font_metrics.dart
@@ -1,0 +1,401 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+/// ASS 字号语义的**真字体表**实现（BUG-891，对照 libass `ass_font.c::ass_face_set_size`）。
+///
+/// libass/VSFilter 把 ASS `Fontsize` 解释为字体 **OS/2 win cell 高**（`usWinAscent +
+/// usWinDescent`，GDI 字符对齐盒）：先算 `mscale = hheaCell / winCell`，再以
+/// `FT_SIZE_REQUEST_TYPE_REAL_DIM`（按 hhea `Ascender - Descender` 定标）请求
+/// `Fontsize × mscale`——两处 hheaCell 相消，**净效果 `em = Fontsize × upem / winCell`**。
+/// 无 OS/2（或 winCell 无效）时 mscale=1，净效果 `em = Fontsize × upem / hheaCell`。
+///
+/// 此前渲染层用 [TextPainter] 实测段落自然行高当 cell（`_assFontSizeToEm` 旧近似），但
+/// 段落行高**含 hhea lineGap（leading）**：日文系统字体 lineGap 极大（Yu Gothic/Yu Mincho
+/// lineGap=0.5em，win cell 1.287em → 自然行高 ≈1.6~1.79em），把字算小 20%~40%，正是用户
+/// 报「字号比 mpv 小一截」的根因；MS Gothic（winCell=1.0、lineGap=0）恰好无差，故「有的
+/// 字幕对有的不对」。段落 API 无法剥离 leading（SkParagraph 把 leading 折进 ascent/descent），
+/// 根治只能像 libass 一样读真字体表——本文件提供 sfnt（ttf/otf/ttc）的 `head`/`hhea`/
+/// `OS/2`/`name` 最小解析，产出「family 名（小写）→ cell/em 系数」索引：
+/// - [AssFontCellIndex.registerFontBytes]：MKV 内嵌字体注册时同步喂入（字节已在内存，
+///   且正是 .ass 点名的字体，优先级最高）；
+/// - [AssFontCellIndex.ensureSystemScan]：懒惰后台 isolate 扫描各平台系统字体目录
+///   （部分读取，不整读大 TTC）；扫不到/平台受限（iOS 沙箱）时索引为空，渲染层回退
+///   旧 TextPainter 近似（诚实降级，行为与历史一致）。
+///
+/// 渲染层换算：`em = FontsizePx / cellPerEm`（`cellPerEm = winCell/upem`）。
+
+/// sfnt 表 tag 常量。
+const int _kTagTtcf = 0x74746366; // 'ttcf'
+const int _kTagOtto = 0x4F54544F; // 'OTTO'（CFF/OpenType）
+const int _kTagTrue = 0x74727565; // 'true'（旧 Mac TrueType）
+const int _kTagHead = 0x68656164; // 'head'
+const int _kTagHhea = 0x68686561; // 'hhea'
+const int _kTagOs2 = 0x4F532F32; // 'OS/2'
+const int _kTagName = 0x6E616D65; // 'name'
+
+/// 单个 sfnt face 的字号换算要素：声明的 family 名集合 + cell/em 系数。
+class SfntFaceCellMetrics {
+  const SfntFaceCellMetrics({required this.families, required this.cellPerEm});
+
+  /// name 表 nameID 1（Family）与 16（Typographic Family）的全部记录（含各语言本地化名，
+  /// 如「游ゴシック」），与 Skia/DirectWrite 家族解析口径一致。
+  final Set<String> families;
+
+  /// `cell / upem`：cell 优先 OS/2 `usWinAscent+usWinDescent`（libass/VSFilter 语义），
+  /// 缺 OS/2 / winCell 无效时回退 hhea `Ascender - Descender`。
+  final double cellPerEm;
+}
+
+/// 从 `head`/`hhea`/`OS/2` 表字节算 cell/em 系数（纯函数，libass `ass_face_set_size`
+/// 净语义）。表缺失 / 越界 / 结果超出合理区间（(0.5, 4.0)）返回 null（调用方回退近似）。
+double? cellPerEmFromTables({
+  required ByteData? head,
+  required ByteData? hhea,
+  ByteData? os2,
+}) {
+  if (head == null || head.lengthInBytes < 20) return null;
+  if (hhea == null || hhea.lengthInBytes < 8) return null;
+  final int upem = head.getUint16(18);
+  if (upem <= 0) return null;
+  // OS/2 usWinAscent(offset 74) + usWinDescent(offset 76)，均为无符号（规范如此）。
+  int cell = 0;
+  if (os2 != null && os2.lengthInBytes >= 78) {
+    cell = os2.getUint16(74) + os2.getUint16(76);
+  }
+  if (cell <= 0) {
+    // 无 OS/2：libass mscale=1，REAL_DIM 按 hhea cell 定标 → 净除数是 hheaCell。
+    cell = hhea.getInt16(4) - hhea.getInt16(6);
+  }
+  if (cell <= 0) return null;
+  final double k = cell / upem;
+  return (k > 0.5 && k < 4.0) ? k : null;
+}
+
+/// 从 `name` 表字节解析 family 名（nameID 1 / 16，各平台各语言记录都收）。
+/// 越界 / 非法记录静默跳过（诚实降级）。
+Set<String> familyNamesFromNameTable(ByteData? name) {
+  final Set<String> out = <String>{};
+  if (name == null || name.lengthInBytes < 6) return out;
+  final int count = name.getUint16(2);
+  final int stringStorage = name.getUint16(4);
+  for (int i = 0; i < count; i++) {
+    final int rec = 6 + i * 12;
+    if (rec + 12 > name.lengthInBytes) break;
+    final int platformId = name.getUint16(rec);
+    final int nameId = name.getUint16(rec + 6);
+    if (nameId != 1 && nameId != 16) continue;
+    final int strLen = name.getUint16(rec + 8);
+    final int strOff = stringStorage + name.getUint16(rec + 10);
+    if (strLen <= 0 || strOff + strLen > name.lengthInBytes) continue;
+    final String? decoded = _decodeNameString(platformId, name, strOff, strLen);
+    if (decoded != null && decoded.trim().isNotEmpty) out.add(decoded.trim());
+  }
+  return out;
+}
+
+/// name 记录解码：Windows(3)/Unicode(0) 为 UTF-16BE；Mac(1) 等按 Latin1 近似
+/// （ASCII 安全；日文 Mac 记录交给 UTF-16 记录兜底）。
+String? _decodeNameString(int platformId, ByteData data, int off, int len) {
+  try {
+    if (platformId == 3 || platformId == 0) {
+      if (len.isOdd) return null;
+      final StringBuffer sb = StringBuffer();
+      for (int i = 0; i + 1 < len; i += 2) {
+        sb.writeCharCode(
+            (data.getUint8(off + i) << 8) | data.getUint8(off + i + 1));
+      }
+      return sb.toString();
+    }
+    final StringBuffer sb = StringBuffer();
+    for (int i = 0; i < len; i++) {
+      sb.writeCharCode(data.getUint8(off + i));
+    }
+    return sb.toString();
+  } catch (_) {
+    return null;
+  }
+}
+
+/// 解析**内存中的** sfnt 字体字节（ttf/otf/ttc）为逐 face 的 [SfntFaceCellMetrics] 列表
+/// （纯函数，可单测；MKV 内嵌字体注册路径用）。非法/越界返回已解析到的部分，不抛。
+List<SfntFaceCellMetrics> parseSfntCellMetrics(Uint8List bytes) {
+  final List<SfntFaceCellMetrics> out = <SfntFaceCellMetrics>[];
+  try {
+    if (bytes.length < 12) return out;
+    final ByteData data = ByteData.sublistView(bytes);
+    final int tag = data.getUint32(0);
+    final List<int> faceOffsets = <int>[];
+    if (tag == _kTagTtcf) {
+      final int numFonts = data.getUint32(8);
+      if (numFonts <= 0 || numFonts > 64) return out;
+      for (int i = 0; i < numFonts; i++) {
+        final int offPos = 12 + i * 4;
+        if (offPos + 4 > bytes.length) break;
+        faceOffsets.add(data.getUint32(offPos));
+      }
+    } else if (tag == 0x00010000 || tag == _kTagOtto || tag == _kTagTrue) {
+      faceOffsets.add(0);
+    } else {
+      return out;
+    }
+    for (final int base in faceOffsets) {
+      final SfntFaceCellMetrics? face = _parseFaceFromBytes(data, base);
+      if (face != null) out.add(face);
+    }
+  } catch (_) {
+    // 非法字体：返回已解析到的部分。
+  }
+  return out;
+}
+
+/// 在整字体字节的 [base] 偏移处解析单 face（表目录 → head/hhea/OS/2/name → 要素）。
+SfntFaceCellMetrics? _parseFaceFromBytes(ByteData data, int base) {
+  final int length = data.lengthInBytes;
+  if (base < 0 || base + 12 > length) return null;
+  final int numTables = data.getUint16(base + 4);
+  if (numTables <= 0 || numTables > 512) return null;
+  ByteData? tableAt(int wantTag) {
+    for (int i = 0; i < numTables; i++) {
+      final int rec = base + 12 + i * 16;
+      if (rec + 16 > length) return null;
+      if (data.getUint32(rec) != wantTag) continue;
+      final int off = data.getUint32(rec + 8);
+      final int len = data.getUint32(rec + 12);
+      if (off < 0 || len <= 0 || off + len > length) return null;
+      return ByteData.sublistView(
+          data.buffer.asUint8List(data.offsetInBytes + off, len));
+    }
+    return null;
+  }
+
+  final double? cellPerEm = cellPerEmFromTables(
+    head: tableAt(_kTagHead),
+    hhea: tableAt(_kTagHhea),
+    os2: tableAt(_kTagOs2),
+  );
+  if (cellPerEm == null) return null;
+  final Set<String> families = familyNamesFromNameTable(tableAt(_kTagName));
+  if (families.isEmpty) return null;
+  return SfntFaceCellMetrics(families: families, cellPerEm: cellPerEm);
+}
+
+/// 各平台系统字体目录（存在性由扫描方判定；iOS 沙箱下不可读 → 空索引 → 渲染层回退近似）。
+List<String> systemFontDirectories() {
+  try {
+    if (Platform.isWindows) {
+      final String win = Platform.environment['WINDIR'] ?? r'C:\Windows';
+      final String? local = Platform.environment['LOCALAPPDATA'];
+      return <String>[
+        '$win\\Fonts',
+        if (local != null) '$local\\Microsoft\\Windows\\Fonts',
+      ];
+    }
+    if (Platform.isAndroid) {
+      return const <String>['/system/fonts', '/system/font', '/product/fonts'];
+    }
+    if (Platform.isMacOS) {
+      final String? home = Platform.environment['HOME'];
+      return <String>[
+        '/System/Library/Fonts',
+        '/System/Library/Fonts/Supplemental',
+        '/Library/Fonts',
+        if (home != null) '$home/Library/Fonts',
+      ];
+    }
+    if (Platform.isIOS) return const <String>['/System/Library/Fonts'];
+    if (Platform.isLinux) {
+      final String? home = Platform.environment['HOME'];
+      return <String>[
+        '/usr/share/fonts',
+        '/usr/local/share/fonts',
+        if (home != null) '$home/.local/share/fonts',
+        if (home != null) '$home/.fonts',
+      ];
+    }
+  } catch (_) {
+    // Platform 查询异常（测试特殊环境）：返回空。
+  }
+  return const <String>[];
+}
+
+/// isolate 入口：扫描 [dirs] 下全部字体文件，返回「family 名（小写）→ cellPerEm」映射。
+/// 部分读取（表目录 + 4 张小表），不把大 TTC 整读进内存。同名 family 先到先得
+/// （同族各字重面的 win cell 几乎一致，先到先得足够）。
+Future<Map<String, double>> scanSystemFontCellMetrics(List<String> dirs) async {
+  final Map<String, double> out = <String, double>{};
+  for (final String dir in dirs) {
+    try {
+      final Directory d = Directory(dir);
+      if (!d.existsSync()) continue;
+      await for (final FileSystemEntity e
+          in d.list(recursive: true, followLinks: false)) {
+        if (e is! File) continue;
+        final String lower = e.path.toLowerCase();
+        if (!lower.endsWith('.ttf') &&
+            !lower.endsWith('.otf') &&
+            !lower.endsWith('.ttc') &&
+            !lower.endsWith('.otc')) {
+          continue;
+        }
+        await _indexFontFile(e, out);
+      }
+    } catch (_) {
+      // 目录不可读（权限/沙箱）：跳过该目录。
+    }
+  }
+  return out;
+}
+
+/// 部分读取单个字体文件，把各 face 的 family→cellPerEm 并入 [out]（先到先得）。
+Future<void> _indexFontFile(File file, Map<String, double> out) async {
+  RandomAccessFile? raf;
+  try {
+    raf = await file.open();
+    final int fileLen = await raf.length();
+    Future<ByteData?> readAt(int off, int len) async {
+      if (off < 0 || len <= 0 || off + len > fileLen) return null;
+      await raf!.setPosition(off);
+      final Uint8List b = await raf.read(len);
+      return b.length == len ? ByteData.sublistView(b) : null;
+    }
+
+    final ByteData? header = await readAt(0, 12);
+    if (header == null) return;
+    final int tag = header.getUint32(0);
+    final List<int> faceOffsets = <int>[];
+    if (tag == _kTagTtcf) {
+      final int numFonts = header.getUint32(8);
+      if (numFonts <= 0 || numFonts > 64) return;
+      final ByteData? offs = await readAt(12, numFonts * 4);
+      if (offs == null) return;
+      for (int i = 0; i < numFonts; i++) {
+        faceOffsets.add(offs.getUint32(i * 4));
+      }
+    } else if (tag == 0x00010000 || tag == _kTagOtto || tag == _kTagTrue) {
+      faceOffsets.add(0);
+    } else {
+      return;
+    }
+
+    for (final int base in faceOffsets) {
+      final ByteData? dirHead = await readAt(base, 12);
+      if (dirHead == null) continue;
+      final int numTables = dirHead.getUint16(4);
+      if (numTables <= 0 || numTables > 512) continue;
+      final ByteData? dir = await readAt(base + 12, numTables * 16);
+      if (dir == null) continue;
+      Future<ByteData?> tableAt(int wantTag, {int maxLen = 1 << 20}) async {
+        for (int i = 0; i < numTables; i++) {
+          final int rec = i * 16;
+          if (dir.getUint32(rec) != wantTag) continue;
+          final int off = dir.getUint32(rec + 8);
+          final int len = dir.getUint32(rec + 12);
+          if (len <= 0 || len > maxLen) return null;
+          return readAt(off, len);
+        }
+        return null;
+      }
+
+      final double? cellPerEm = cellPerEmFromTables(
+        head: await tableAt(_kTagHead, maxLen: 1024),
+        hhea: await tableAt(_kTagHhea, maxLen: 1024),
+        os2: await tableAt(_kTagOs2, maxLen: 4096),
+      );
+      if (cellPerEm == null) continue;
+      final Set<String> families =
+          familyNamesFromNameTable(await tableAt(_kTagName));
+      for (final String family in families) {
+        out.putIfAbsent(family.toLowerCase(), () => cellPerEm);
+      }
+    }
+  } catch (_) {
+    // 单文件损坏/不可读：跳过。
+  } finally {
+    try {
+      await raf?.close();
+    } catch (_) {}
+  }
+}
+
+/// compute() 顶层入口（isolate 内跑全量系统扫描）。
+Future<Map<String, double>> _scanSystemFontsEntry(List<String> dirs) {
+  return scanSystemFontCellMetrics(dirs);
+}
+
+/// 进程级「family 名 → cell/em 系数」索引单例。
+///
+/// 双层：内嵌字体（[registerFontBytes]，MKV attachment——正是 .ass 点名的字体）优先于
+/// 系统扫描（[ensureSystemScan]，懒惰、一次、后台 isolate）。任一层更新都 bump
+/// [revision]，渲染层监听它清缓存重算（扫描完成前先用旧近似渲染，就绪后自动校正）。
+class AssFontCellIndex {
+  AssFontCellIndex._();
+
+  static final AssFontCellIndex instance = AssFontCellIndex._();
+
+  /// 索引内容代次；每次内嵌注册 / 系统扫描完成 +1。渲染层监听清 k 缓存。
+  final ValueNotifier<int> revision = ValueNotifier<int>(0);
+
+  final Map<String, double> _embedded = <String, double>{};
+  Map<String, double> _system = const <String, double>{};
+  bool _scanStarted = false;
+
+  /// 测试钩子：重置单例状态（系统扫描标记 / 两层映射 / revision）。
+  @visibleForTesting
+  void debugReset() {
+    _embedded.clear();
+    _system = const <String, double>{};
+    _scanStarted = false;
+    revision.value = 0;
+  }
+
+  /// 懒惰踢一次系统字体目录扫描（后台 isolate；幂等）。完成后 bump [revision]。
+  /// 失败静默（索引保持空，渲染层继续近似）。
+  void ensureSystemScan() {
+    if (_scanStarted) return;
+    _scanStarted = true;
+    final List<String> dirs = systemFontDirectories();
+    if (dirs.isEmpty) return;
+    compute(_scanSystemFontsEntry, dirs).then((Map<String, double> result) {
+      if (result.isEmpty) return;
+      _system = result;
+      revision.value++;
+    }).catchError((Object _) {
+      // isolate 失败：保持空索引。
+    });
+  }
+
+  /// 解析并登记一份内存字体（MKV 内嵌字体 / 用户自定义字体注册路径同步调用）。
+  /// [aliases]：调用方额外用来注册进 [FontLoader] 的家族别名（用户自定义字体常用
+  /// 自选名而非字体内部名），一并映射到首个 face 的系数。有新 family 时 bump
+  /// [revision]。解析失败静默。
+  void registerFontBytes(Uint8List bytes,
+      {Iterable<String> aliases = const <String>[]}) {
+    bool added = false;
+    double? firstCellPerEm;
+    for (final SfntFaceCellMetrics face in parseSfntCellMetrics(bytes)) {
+      firstCellPerEm ??= face.cellPerEm;
+      for (final String family in face.families) {
+        final String key = family.toLowerCase();
+        if (_embedded.containsKey(key)) continue;
+        _embedded[key] = face.cellPerEm;
+        added = true;
+      }
+    }
+    if (firstCellPerEm != null) {
+      for (final String alias in aliases) {
+        final String key = alias.toLowerCase();
+        if (key.isEmpty || _embedded.containsKey(key)) continue;
+        _embedded[key] = firstCellPerEm;
+        added = true;
+      }
+    }
+    if (added) revision.value++;
+  }
+
+  /// 查 [family]（大小写不敏感）的 cell/em 系数；内嵌层优先。未知返回 null。
+  double? cellPerEmOf(String family) {
+    final String key = family.toLowerCase();
+    return _embedded[key] ?? _system[key];
+  }
+}

--- a/hibiki/lib/src/media/video/subtitle_embedded_fonts.dart
+++ b/hibiki/lib/src/media/video/subtitle_embedded_fonts.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show FontLoader;
+import 'package:hibiki/src/media/video/ass_font_metrics.dart';
 import 'package:hibiki/src/media/video/ffmpeg_backend.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:path/path.dart' as p;
@@ -325,6 +326,9 @@ class SubtitleEmbeddedFontLoader {
     final Uint8List bytes = await file.readAsBytes();
     final Set<String> names = parseSfntFamilyNames(bytes);
     if (names.isEmpty) return;
+    // BUG-891：同步喂进字号换算索引（OS/2 win cell 语义）——内嵌字体正是 .ass 点名的
+    // 字体，其 cell/em 系数优先于系统扫描，overlay 字号与 mpv/libass 同源。
+    AssFontCellIndex.instance.registerFontBytes(bytes);
     for (final String family in names) {
       families.add(family);
       if (_registeredFamilies.contains(family)) continue;

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -10,6 +10,7 @@ import 'package:flutter/rendering.dart'
 import 'package:flutter/scheduler.dart' show Ticker;
 import 'package:flutter/services.dart' show HardwareKeyboard;
 
+import 'package:hibiki/src/media/video/ass_font_metrics.dart';
 import 'package:hibiki/src/media/video/subtitle_pos_mapping.dart';
 import 'package:hibiki/src/media/video/video_player_controller.dart';
 import 'package:hibiki/src/media/video/video_subtitle_style.dart';
@@ -100,6 +101,17 @@ int resolveSubtitleCharHit(
 /// `\blur 值 × (显示/PlayRes 缩放) × blur_radius_scale`。**ASS 的 `\blur` 数值不是直接的高斯
 /// sigma**——少了这个因子就比 mpv/libass 明显偏糊（约 1/0.8493 ≈ 1.18×）。
 final double kLibassBlurRadiusScale = 2 / math.sqrt(math.log(256));
+
+/// 把 ASS `Outline`/`\bord`（**向外扩的描边半径**，已按 PlayRes 缩放成逻辑像素）换算成
+/// Flutter 居中 stroke 的 `strokeWidth`（BUG-891）：libass 用 FreeType stroker 沿字形
+/// 轮廓**向外**描 [outlinePx] 半径（`FT_Glyph_StrokeBorder`，可见描边=完整半径）；
+/// Flutter `PaintingStyle.stroke` 沿轮廓**居中**描，内半边被上层 fill 盖住，可见只剩
+/// `strokeWidth/2`——必须 ×2 才与 mpv/libass 同宽（旧实现直接把半径当 strokeWidth，
+/// 描边恒比 mpv 细一半，用户报「描边偏细」）。<=0（含 `Outline:0` 明示无描边）返回 0
+/// （不画描边层——旧实现被 `clamp(0.5,…)` 强制成 0.5px 细边，mpv 则完全不画）。
+@visibleForTesting
+double assOutlineStrokeWidth(double outlinePx) =>
+    outlinePx <= 0 ? 0 : outlinePx * 2;
 
 /// 把 ASS `\blur` 值 [blurValue] 换算成 Flutter 高斯模糊 sigma（逻辑像素），对齐 libass/mpv：
 /// `sigma = blurValue × [assFontScale]（显示区高 / PlayResY）× [kLibassBlurRadiusScale]`，
@@ -468,6 +480,9 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   @override
   void initState() {
     super.initState();
+    // BUG-891：字体表索引（内嵌字体注册 / 系统扫描完成）更新时，k=cell/em 缓存里可能
+    // 还存着索引就绪前的 TextPainter 近似值——清缓存重算并重绘，使字号自动校正到真表值。
+    AssFontCellIndex.instance.revision.addListener(_onFontMetricsRevision);
     _fadeTicker = createTicker((_) {
       // 每帧强制重建：build 里按最新播放位置重算各 cue 的 fade 不透明度（值来自
       // controller，不在此保存，故空 setState 足矣）。
@@ -475,8 +490,16 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     });
   }
 
+  /// 字体表索引代次变化（BUG-891）：清依赖字号的缓存并重绘（见 [initState] 注释）。
+  void _onFontMetricsRevision() {
+    _fontCellFactorCache.clear();
+    _charSizeCache.clear();
+    if (mounted) setState(() {});
+  }
+
   @override
   void dispose() {
+    AssFontCellIndex.instance.revision.removeListener(_onFontMetricsRevision);
     // 停并释放 ticker：SingleTickerProviderStateMixin.dispose 会断言 ticker 不再 active，
     // 故必须在 super.dispose 之前 dispose 掉它（dispose 内部会取消在途 tick）。
     _fadeTicker?.dispose();
@@ -1529,9 +1552,19 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
             from + (tr.bordTo! - from) * tr.progressAt(elapsedMs, durMs);
       }
     }
-    final double outlineWidth = outlineWidthAss != null
-        ? (outlineWidthAss * _assFontScale(markup)).clamp(0.5, 24.0).toDouble()
-        : baseWidth;
+    // BUG-891：ASS 值是「向外扩的半径」——缩放夹范围后经 [assOutlineStrokeWidth] ×2 成
+    // 居中 strokeWidth（可见宽=半径，与 mpv 对齐）；Outline<=0 明示无描边 → 0（不再被
+    // clamp 下限强制成 0.5px 细边）。回退用户统一宽（baseWidth，历史居中语义）不变换。
+    final double outlineWidth;
+    if (outlineWidthAss == null) {
+      outlineWidth = baseWidth;
+    } else if (outlineWidthAss <= 0) {
+      outlineWidth = 0;
+    } else {
+      outlineWidth = assOutlineStrokeWidth(
+        (outlineWidthAss * _assFontScale(markup)).clamp(0.5, 24.0).toDouble(),
+      );
+    }
     return (
       outlineArgb != null ? Color(outlineArgb) : baseColor,
       outlineWidth,
@@ -1816,36 +1849,57 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     return (family: fam, weight: w);
   }
 
-  /// libass/VSFilter 的字号语义（`FT_SIZE_REQUEST_TYPE_REAL_DIM`）：ASS `Fontsize`
-  /// 等于字体**上升部+下降部（cell 高）**，不是 em；Flutter `TextStyle.fontSize` 是
-  /// em。常见 CJK 字体 cell≈1.1~1.25 em——直接把 Fontsize 当 em 用会比 mpv 整体大
-  /// 一截（用户报「字号比 mpv 大/小一截、各布局都有」的根因）。本方法用 [TextPainter]
-  /// 实测「目标字体+回退链」在指定字重/斜体下的自然行高系数 k=cell/em（不设 height
-  /// 覆盖=字体自然度量），返回 em' = px/k，使渲染 cell 高 == ASS 请求的 Fontsize。
-  /// 结果按 (family|weight|italic) 缓存；测试字体（FlutterTest）k=1.0，既有测试像素
-  /// 不变。异常度量（k∉(0.5,2.0)）回退 1.0 不校准。
+  /// libass/VSFilter 的字号语义（`ass_face_set_size` + `FT_SIZE_REQUEST_TYPE_REAL_DIM`）：
+  /// ASS `Fontsize` 等于字体 **OS/2 win cell 高**（`usWinAscent+usWinDescent`，净效果
+  /// `em = Fontsize × upem / winCell`，推导见 [AssFontCellIndex] 文件头），不是 em；
+  /// Flutter `TextStyle.fontSize` 是 em，故换算 em' = px / k（k=cell/em）。
+  /// 结果按 (family|weight|italic) 缓存；真相源见 [_cellPerEmFor]。
   double _assFontSizeToEm(
       double px, String? family, FontWeight weight, bool italic) {
     final String key = '${family ?? ''}|${weight.index}|${italic ? 1 : 0}';
-    final double k = _fontCellFactorCache.putIfAbsent(key, () {
-      final TextPainter tp = TextPainter(
-        text: TextSpan(
-          text: 'Ｍぽ',
-          style: TextStyle(
-            fontSize: 100,
-            fontFamily: family,
-            fontFamilyFallback: _kSubtitleCjkFallback,
-            fontWeight: weight,
-            fontStyle: italic ? FontStyle.italic : FontStyle.normal,
-          ),
-        ),
-        textDirection: TextDirection.ltr,
-      )..layout();
-      final double factor = tp.height / 100.0;
-      tp.dispose();
-      return (factor.isFinite && factor > 0.5 && factor < 2.0) ? factor : 1.0;
-    });
+    final double k = _fontCellFactorCache.putIfAbsent(
+        key, () => _cellPerEmFor(family, weight, italic));
     return px / k;
+  }
+
+  /// k=cell/em 的真相源（BUG-891 根修）：
+  ///
+  /// ① **真字体表**：沿「显式家族 → CJK 回退链」找 Skia 实际会解析到的第一个存在家族，
+  ///   查 [AssFontCellIndex]（MKV 内嵌字体 + 系统字体目录扫描）的 `winCell/upem`——与
+  ///   libass 完全同源。只对第一个真实存在的家族查表（后续家族不会被用来渲染）；同时
+  ///   懒惰踢一次系统扫描（测试环境所有家族都解析不到 → 不踢、恒走 ②，既有测试像素不变）。
+  /// ② **TextPainter 行高近似**（仅兜底：扫描未就绪 / 平台受限 / 家族无表）：实测段落
+  ///   自然行高当 cell。注意它**含 hhea lineGap**：日文系统字体 lineGap 极大（Yu Gothic
+  ///   lineGap=0.5em、winCell=1.287em → 行高 ≈1.79em），把字算小 20%~40%，正是「字号比
+  ///   mpv 小一截」的旧病根——真表就绪后 [AssFontCellIndex.revision] bump → 清缓存重算，
+  ///   自动校正到 ①。异常度量（k∉(0.5,2.0)）回退 1.0 不校准。
+  double _cellPerEmFor(String? family, FontWeight weight, bool italic) {
+    for (final String candidate in <String>[
+      if (family != null && family.isNotEmpty) family,
+      ..._kSubtitleCjkFallback,
+    ]) {
+      if (!_fontFamilyExists(candidate)) continue;
+      AssFontCellIndex.instance.ensureSystemScan();
+      final double? k = AssFontCellIndex.instance.cellPerEmOf(candidate);
+      if (k != null) return k;
+      break; // Skia 会用它渲染但表未就绪/未收录 → 落到 ② 近似。
+    }
+    final TextPainter tp = TextPainter(
+      text: TextSpan(
+        text: 'Ｍぽ',
+        style: TextStyle(
+          fontSize: 100,
+          fontFamily: family,
+          fontFamilyFallback: _kSubtitleCjkFallback,
+          fontWeight: weight,
+          fontStyle: italic ? FontStyle.italic : FontStyle.normal,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    final double factor = tp.height / 100.0;
+    tp.dispose();
+    return (factor.isFinite && factor > 0.5 && factor < 2.0) ? factor : 1.0;
   }
 
   /// 缩放后的 ASS 字号夹到合理范围：下限 8px、上限 = 显示区高的 40%（防 PlayResY 缺失 /

--- a/hibiki/lib/src/models/app_font_loader.dart
+++ b/hibiki/lib/src/models/app_font_loader.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/services.dart' show FontLoader;
+import 'package:hibiki/src/media/video/ass_font_metrics.dart';
 import 'package:hibiki/src/models/font_decoder.dart';
 import 'package:hibiki/src/models/woff2_decoder.dart';
 import 'package:hibiki/src/reader/reader_settings.dart'
@@ -88,6 +89,11 @@ class AppFontLoader {
                 .asByteData(bytes.offsetInBytes, bytes.lengthInBytes)));
           await loader.load();
           _loadedFamilies.add(family);
+          // BUG-891：自定义字体不在系统字体目录（扫描不到），把字节同步喂进 ASS 字号
+          // 换算索引（OS/2 win cell 语义），别名=本处注册的家族名——视频字幕用自定义
+          // 字体时字号也与 mpv/libass 同源。
+          AssFontCellIndex.instance
+              .registerFontBytes(bytes, aliases: <String>[family]);
         } catch (e, stack) {
           ErrorLogService.instance
               .log('AppFontLoader.resolveAndLoad', e, stack);

--- a/hibiki/test/media/video/ass_font_metrics_test.dart
+++ b/hibiki/test/media/video/ass_font_metrics_test.dart
@@ -1,0 +1,211 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/ass_font_metrics.dart';
+
+/// BUG-891：ASS 字号的 libass `ass_face_set_size` 语义（`em = Fontsize × upem / winCell`）
+/// 守卫——sfnt 表解析、TTC 多 face、OS/2 缺失回退 hhea、索引优先级与大小写。
+
+/// 组一个最小 sfnt 单 face 字体（head + hhea + [OS/2] + name）。
+Uint8List _buildFace({
+  int upem = 1000,
+  int hheaAsc = 800,
+  int hheaDesc = -200,
+  int? winAsc = 1100,
+  int? winDesc = 300,
+  String family = 'TestFam',
+}) {
+  final bool hasOs2 = winAsc != null && winDesc != null;
+
+  final Uint8List head = Uint8List(54);
+  ByteData.sublistView(head).setUint16(18, upem);
+
+  final Uint8List hhea = Uint8List(36);
+  ByteData.sublistView(hhea)
+    ..setInt16(4, hheaAsc)
+    ..setInt16(6, hheaDesc);
+
+  Uint8List? os2;
+  if (hasOs2) {
+    os2 = Uint8List(96);
+    ByteData.sublistView(os2)
+      ..setUint16(74, winAsc)
+      ..setUint16(76, winDesc);
+  }
+
+  // name 表：format 0，一条 Windows(3) Unicode nameID=1 记录，UTF-16BE。
+  final List<int> famUtf16 = <int>[];
+  for (final int cu in family.codeUnits) {
+    famUtf16
+      ..add((cu >> 8) & 0xFF)
+      ..add(cu & 0xFF);
+  }
+  final Uint8List name = Uint8List(6 + 12 + famUtf16.length);
+  final ByteData nd = ByteData.sublistView(name);
+  nd
+    ..setUint16(0, 0) // format
+    ..setUint16(2, 1) // count
+    ..setUint16(4, 6 + 12) // string storage offset
+    ..setUint16(6, 3) // platformID Windows
+    ..setUint16(8, 1) // encodingID
+    ..setUint16(10, 0x409) // languageID
+    ..setUint16(12, 1) // nameID Family
+    ..setUint16(14, famUtf16.length)
+    ..setUint16(16, 0);
+  name.setRange(6 + 12, name.length, famUtf16);
+
+  final List<(String, Uint8List)> tables = <(String, Uint8List)>[
+    ('head', head),
+    ('hhea', hhea),
+    if (os2 != null) ('OS/2', os2),
+    ('name', name),
+  ];
+  final int numTables = tables.length;
+  final int dirLen = 12 + numTables * 16;
+  int total = dirLen;
+  for (final (String, Uint8List) t in tables) {
+    total += t.$2.length;
+  }
+  final Uint8List out = Uint8List(total);
+  final ByteData od = ByteData.sublistView(out);
+  od
+    ..setUint32(0, 0x00010000)
+    ..setUint16(4, numTables);
+  int offset = dirLen;
+  for (int i = 0; i < numTables; i++) {
+    final (String tag, Uint8List body) = tables[i];
+    final int rec = 12 + i * 16;
+    od
+      ..setUint32(
+          rec,
+          (tag.codeUnitAt(0) << 24) |
+              (tag.codeUnitAt(1) << 16) |
+              (tag.codeUnitAt(2) << 8) |
+              tag.codeUnitAt(3))
+      ..setUint32(rec + 8, offset)
+      ..setUint32(rec + 12, body.length);
+    out.setRange(offset, offset + body.length, body);
+    offset += body.length;
+  }
+  return out;
+}
+
+/// 把若干单 face 字体包成 TTC 容器。
+Uint8List _wrapTtc(List<Uint8List> faces) {
+  final int headerLen = 12 + faces.length * 4;
+  int total = headerLen;
+  for (final Uint8List f in faces) {
+    total += f.length;
+  }
+  final Uint8List out = Uint8List(total);
+  final ByteData od = ByteData.sublistView(out);
+  od
+    ..setUint32(0, 0x74746366) // 'ttcf'
+    ..setUint32(8, faces.length);
+  int offset = headerLen;
+  for (int i = 0; i < faces.length; i++) {
+    od.setUint32(12 + i * 4, offset);
+    out.setRange(offset, offset + faces[i].length, faces[i]);
+    // 真 TTC 的表偏移是**文件绝对偏移**：把单 face 的局部表偏移平移到绝对位置。
+    final ByteData fd =
+        ByteData.sublistView(out, offset, offset + faces[i].length);
+    final int numTables = fd.getUint16(4);
+    for (int t = 0; t < numTables; t++) {
+      final int rec = 12 + t * 16;
+      fd.setUint32(rec + 8, fd.getUint32(rec + 8) + offset);
+    }
+    offset += faces[i].length;
+  }
+  return out;
+}
+
+void main() {
+  test('单 face：cellPerEm = (usWinAscent+usWinDescent)/upem（libass 语义）', () {
+    final List<SfntFaceCellMetrics> faces = parseSfntCellMetrics(
+        _buildFace(upem: 1000, winAsc: 1100, winDesc: 300));
+    expect(faces, hasLength(1));
+    expect(faces.single.families, contains('TestFam'));
+    expect(faces.single.cellPerEm, closeTo(1.4, 1e-9));
+  });
+
+  test('无 OS/2：回退 hhea Ascender-Descender（libass mscale=1 分支）', () {
+    final List<SfntFaceCellMetrics> faces = parseSfntCellMetrics(_buildFace(
+        upem: 2048,
+        hheaAsc: 1802,
+        hheaDesc: -246,
+        winAsc: null,
+        winDesc: null));
+    expect(faces, hasLength(1));
+    expect(faces.single.cellPerEm, closeTo(2048 / 2048, 1e-9));
+  });
+
+  test('真实字体数值：Yu Gothic winCell 1.287em（BUG-891 病根量级）', () {
+    // Yu Gothic：upem=2048 winAsc=... 合计 2636 → cellPerEm≈1.287（lineGap=1024 不参与，
+    // 旧 TextPainter 行高近似会把它算进去得 ≈1.79——字号偏小 20%~40% 的根因）。
+    final List<SfntFaceCellMetrics> faces = parseSfntCellMetrics(_buildFace(
+        upem: 2048, hheaAsc: 1802, hheaDesc: -455, winAsc: 2000, winDesc: 636));
+    expect(faces.single.cellPerEm, closeTo(2636 / 2048, 1e-9));
+  });
+
+  test('TTC：逐 face 解析、family 各归各', () {
+    final Uint8List ttc = _wrapTtc(<Uint8List>[
+      _buildFace(family: 'FamA', winAsc: 1000, winDesc: 0),
+      _buildFace(family: 'FamB', winAsc: 1200, winDesc: 300),
+    ]);
+    final List<SfntFaceCellMetrics> faces = parseSfntCellMetrics(ttc);
+    expect(faces, hasLength(2));
+    expect(faces[0].families, contains('FamA'));
+    expect(faces[0].cellPerEm, closeTo(1.0, 1e-9));
+    expect(faces[1].families, contains('FamB'));
+    expect(faces[1].cellPerEm, closeTo(1.5, 1e-9));
+  });
+
+  test('垃圾字节 / 越界不抛，返回空', () {
+    expect(parseSfntCellMetrics(Uint8List(0)), isEmpty);
+    expect(parseSfntCellMetrics(Uint8List.fromList(List<int>.filled(64, 0xAB))),
+        isEmpty);
+  });
+
+  test('cellPerEmFromTables：异常区间（k<=0.5 或 >=4.0）返回 null', () {
+    final Uint8List head = Uint8List(54);
+    ByteData.sublistView(head).setUint16(18, 1000);
+    final Uint8List hhea = Uint8List(36);
+    ByteData.sublistView(hhea)
+      ..setInt16(4, 100)
+      ..setInt16(6, 0); // cell=100 → k=0.1 越界
+    expect(
+        cellPerEmFromTables(
+            head: ByteData.sublistView(head), hhea: ByteData.sublistView(hhea)),
+        isNull);
+  });
+
+  test('索引：大小写不敏感、内嵌先到先得、revision 递增', () {
+    final AssFontCellIndex index = AssFontCellIndex.instance;
+    index.debugReset();
+    expect(index.revision.value, 0);
+    index.registerFontBytes(
+        _buildFace(family: 'TestFam', winAsc: 1100, winDesc: 300));
+    expect(index.revision.value, 1);
+    expect(index.cellPerEmOf('testfam'), closeTo(1.4, 1e-9));
+    expect(index.cellPerEmOf('TESTFAM'), closeTo(1.4, 1e-9));
+    // 同名再注册（不同数值）不覆盖（先到先得），revision 不再涨。
+    index.registerFontBytes(
+        _buildFace(family: 'TestFam', winAsc: 2000, winDesc: 0));
+    expect(index.revision.value, 1);
+    expect(index.cellPerEmOf('testfam'), closeTo(1.4, 1e-9));
+    expect(index.cellPerEmOf('nosuch'), isNull);
+    index.debugReset();
+  });
+
+  test('索引：aliases 把调用方注册名映射到首 face 系数（自定义字体路径）', () {
+    final AssFontCellIndex index = AssFontCellIndex.instance;
+    index.debugReset();
+    index.registerFontBytes(
+      _buildFace(family: 'InternalName', winAsc: 1100, winDesc: 300),
+      aliases: const <String>['My Custom Font'],
+    );
+    expect(index.cellPerEmOf('my custom font'), closeTo(1.4, 1e-9));
+    expect(index.cellPerEmOf('internalname'), closeTo(1.4, 1e-9));
+    index.debugReset();
+  });
+}

--- a/hibiki/test/media/video/video_subtitle_ass_outline_width_test.dart
+++ b/hibiki/test/media/video/video_subtitle_ass_outline_width_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_player_controller.dart';
+import 'package:hibiki/src/media/video/video_subtitle_overlay.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+/// BUG-891 描边宽守卫：ASS `Outline`/`\bord` 是**向外扩的半径**（libass
+/// `FT_Glyph_StrokeBorder`），Flutter 居中 stroke 可见只剩一半——渲染必须 ×2；
+/// `Outline:0` 明示无描边时不得被 clamp 下限画出 0.5px 细边（mpv 完全不画）。
+const String _kAssHead = r'''
+[Script Info]
+PlayResX: 1920
+PlayResY: 1080
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Bord2,Arial,60,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,2,10,10,20,1
+Style: Bord0,Arial,60,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,0,0,2,10,10,20,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+''';
+
+List<AudioCue> _parse(String dialogue) =>
+    AssParser.parseString(content: '$_kAssHead$dialogue\n', bookKey: 'bord');
+
+Future<void> _pump(WidgetTester tester, List<AudioCue> cues) async {
+  final VideoPlayerController c = VideoPlayerController();
+  addTearDown(c.dispose);
+  c.setCues(cues);
+  c.debugSetPositionForTesting(500);
+  c.debugUpdateCueForPosition(500);
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: VideoSubtitleOverlay(controller: c, respectAssStyle: true),
+    ),
+  ));
+  await tester.pump();
+}
+
+Iterable<Text> _strokeTexts(WidgetTester tester, String ch) => tester
+    .widgetList<Text>(find.text(ch))
+    .where((Text t) => t.style?.foreground != null);
+
+void main() {
+  test('assOutlineStrokeWidth：半径 ×2 成居中 strokeWidth；<=0 无描边', () {
+    expect(assOutlineStrokeWidth(3), 6);
+    expect(assOutlineStrokeWidth(0.5), 1);
+    expect(assOutlineStrokeWidth(0), 0);
+    expect(assOutlineStrokeWidth(-1), 0);
+  });
+
+  testWidgets('Outline=2：stroke 层 strokeWidth = 2×(2×显示高/PlayResY)（半径×2）',
+      (WidgetTester tester) async {
+    await _pump(
+        tester, _parse(r'Dialogue: 0,0:00:00.00,0:00:02.00,Bord2,,0,0,0,,あ'));
+    final Iterable<Text> strokes = _strokeTexts(tester, 'あ');
+    expect(strokes, isNotEmpty, reason: 'Outline=2 必须有描边层');
+    // 测试面 600 高、无视频分辨率 → assFontScale = 600/1080；半径 = 2×600/1080，
+    // 可见宽须与 mpv 同 = 半径 → 居中 strokeWidth = 半径×2。
+    const double expected = (2 * 600 / 1080) * 2;
+    expect(
+        strokes.first.style!.foreground!.strokeWidth, closeTo(expected, 0.01));
+  });
+
+  testWidgets('Outline=0：不画描边层（不被 clamp 下限强制成 0.5px 细边）',
+      (WidgetTester tester) async {
+    await _pump(
+        tester, _parse(r'Dialogue: 0,0:00:00.00,0:00:02.00,Bord0,,0,0,0,,あ'));
+    expect(_strokeTexts(tester, 'あ'), isEmpty,
+        reason: 'Outline:0 明示无描边，mpv/libass 完全不画');
+  });
+}

--- a/hibiki/test/media/video/video_subtitle_letterbox_scale_test.dart
+++ b/hibiki/test/media/video/video_subtitle_letterbox_scale_test.dart
@@ -73,8 +73,9 @@ void main() {
     // 内容矩形高 = 640×(1080/1920) = 360 → 字号 65×360/1080 = 21.67，
     // 而非容器基准的 65×640/1080 = 38.5（偏大 78%）。
     expect(_fill(tester).style?.fontSize, closeTo(65 * 360 / 1080, 0.01));
+    // BUG-891：ASS Outline 是向外扩的半径，居中 stroke 需 ×2 才与 mpv 同可见宽。
     expect(_stroke(tester).style?.foreground?.strokeWidth,
-        closeTo(2.5 * 360 / 1080, 0.01));
+        closeTo(2.5 * 360 / 1080 * 2, 0.01));
   });
 
   testWidgets(

--- a/hibiki/test/media/video/video_subtitle_overlay_markup_test.dart
+++ b/hibiki/test/media/video/video_subtitle_overlay_markup_test.dart
@@ -378,7 +378,8 @@ void main() {
     ));
     await pumpOverlay(tester, cue, respect: true, height: 360);
     final Text stroke = strokeOf(tester, 'X');
-    expect(stroke.style?.foreground?.strokeWidth, 2.0); // 4 * 360/720
+    // BUG-891：半径 4×360/720=2 → 居中 strokeWidth ×2 = 4（可见描边=半径，对齐 mpv）。
+    expect(stroke.style?.foreground?.strokeWidth, 4.0); // (4 * 360/720) * 2
     expect(stroke.style?.foreground?.color, const Color(0xFF0000FF));
   });
 
@@ -391,7 +392,8 @@ void main() {
       cueStyle: SubtitleCueStyle(outlineWidthPx: 4),
     ));
     await pumpOverlay(tester, cue, respect: true, height: 360);
-    expect(strokeOf(tester, 'X').style?.foreground?.strokeWidth, 4.0);
+    // BUG-891：裸半径 4 → 居中 strokeWidth ×2 = 8（无 PlayResY 不缩放，仅 ×2 换算）。
+    expect(strokeOf(tester, 'X').style?.foreground?.strokeWidth, 8.0);
   });
 
   testWidgets(


### PR DESCRIPTION
## 症状（用户同帧截图对比 mpv）
- 对白行字号比 mpv 小 ~20%（且随字体不同时对时错），描边比 mpv 细
- \pos 屏幕字两边一致 → 样式级错配，非全局缩放错

## 根因
1. **字号**：`_assFontSizeToEm` 用 TextPainter 段落自然行高当 cell 系数，但段落行高**含 hhea lineGap**（SkParagraph 把 leading 折进 ascent/descent，段落 API 剥不掉）。libass 语义（`ass_font.c::ass_face_set_size`：mscale=hheaCell/winCell + REAL_DIM 按 hheaCell 定标，相消）= **em = Fontsize × upem / (usWinAscent+usWinDescent)**。实测本机字体表：Yu Gothic（Windows CJK 回退首选）winCell=1.287em、lineGap=0.5em → 旧近似 k≈1.79 vs libass 1.287，偏小 20~40%；MS Gothic（winCell=1.0、lineGap=0）恰好无差——「有的对有的不对」。
2. **描边**：ASS `Outline`/`\bord` 是 libass `FT_Glyph_StrokeBorder` **向外扩的半径**（可见描边=完整半径）；旧代码把它直接当 Flutter 居中 stroke 的 strokeWidth，内半被 fill 盖住，可见恒只剩一半。另 `Outline:0` 被 clamp 下限强制成 0.5px 细边（mpv 完全不画）。

## 修复
- 新增 `ass_font_metrics.dart`：sfnt（ttf/otf/ttc）head/hhea/OS\/2/name 最小解析 + `AssFontCellIndex`（三路喂入：MKV 内嵌字体注册、用户自定义字体注册（alias）、系统字体目录懒惰后台 isolate 扫描——部分读取不整读大 TTC）。实测本机 340 family 约 1s 扫完，`yu gothic→1.2871`、`游ゴシック→1.2871`（本地化名命中）、`meiryo→1.5`、`ms gothic→1.0`，与 Python 逐表解析 ground truth 一致。
- overlay `_cellPerEmFor`：沿「显式家族→CJK 回退链」取 Skia 实际会用的第一个存在家族查真表；表不可得（扫描中/iOS 沙箱/测试环境）回退旧 TextPainter 近似，索引 revision bump 后清缓存自动校正。
- `assOutlineStrokeWidth`：半径×2 成居中 strokeWidth；Outline≤0 → 不画描边层。

## 测试
- 新增 `ass_font_metrics_test.dart`（合成 sfnt/TTC：winCell 语义、hhea 回退、Yu Gothic 量级、索引 alias/大小写/revision）+ `video_subtitle_ass_outline_width_test.dart`（Outline=2→×2、Outline=0→无描边层）
- 旧描边断言（letterbox_scale / overlay_markup）同步更新为 ×2 语义
- 全量 `flutter analyze` 0 issue；全量 `flutter test` 11814 过、唯一失败 `home_video_remote_download_register_test.dart` 在干净基底同样失败（环境相关既有失败，与本改动无关）

## 待真机
- Windows/Android 开同一集对照 mpv：对白行字号/描边宽应与 mpv 一致（尤其 Fontname 未安装回退 Yu Gothic 的场景）
- 带内嵌字体的 MKV：注册后字号立即校正
- 备注：`ScaledBorderAndShadow: no`（罕见）未特判；\1a 透明填充下居中描边内半可见与 libass 有细微差（记录在 BUG-891 备注）