### PR TITLE
fix(collections): 标签拖到合集行头即打标签（补合集级 DragTarget，BUG-894）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 869 条。点号进各自文件。
+> 共 870 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-894](bugs/BUG-894-collection-tag-drop-target.md) | ✅ | ✅ | 标签拖到合集行头无接收（合集打标签仅详情页按钮入口） |
 | [BUG-890](bugs/BUG-890-paused-audio-follow-image-snap.md) | ✅ | ✅ | 暂停/图片等待时有声书跟随把阅读器拽回音频位置 |
 | [BUG-887](bugs/BUG-887-top-progress-squeeze-frost.md) | ✅ | ✅ | 挤压模式顶部进度不应有毛玻璃且不应压住正文首行 |
 | [BUG-886](bugs/BUG-886-collapse-header-center.md) | ✅ | ✅ | 折叠设置分组标题头文字与箭头未垂直居中 |

--- a/docs/bugs/BUG-894-collection-tag-drop-target.md
+++ b/docs/bugs/BUG-894-collection-tag-drop-target.md
@@ -10,8 +10,8 @@
   - 视频页 `_addTagToVideoCollection`（`home_video_page.dart`）：查 `getTagsForCollection` 去重 → `addTagToCollection` → 失效 `filteredCollectionIdsProvider` → toast。
   - 书架页 `_addTagToCollection`（`reader_hibiki_history_page.dart`）：同上（不复用 `_addTagToMedia`，其「已存在」提示固定为 `tag_already_on_book`，合集文案不对）。
   - 新增 i18n `tag_added_to_collection` / `tag_already_on_collection`（`tool/i18n_sync.dart --add`，17 语言，`dart run slang` 重生成）。
-  - 提交：f0ad59aa4
+  - 提交：80a68e84d
 
-- **[x] ② 已加自动化测试** — `hibiki/test/widgets/collection_shelf_row_tag_drop_test.dart`：pump `CollectionShelfRow` + `Draggable<BookTagRow>`，把标签拖到行头断言 `onTagDropped` 收到该 `BookTagRow`；并断言 `onTagDropped: null` 时行头不是 `DragTarget`（回归守卫：防止调用点漏传接线又退回静默）。提交：f0ad59aa4
+- **[x] ② 已加自动化测试** — `hibiki/test/media/collection_shelf_row_tag_drop_test.dart`：pump `CollectionShelfRow` + `Draggable<BookTagRow>`，把标签拖到行头断言 `onTagDropped` 收到该 `BookTagRow`；并断言 `onTagDropped: null` 时行头不是 `DragTarget`（回归守卫：防止调用点漏传接线又退回静默）。提交：80a68e84d
 
 - **备注**：合集打标签的持久化/同步（`CollectionSyncEngine` 并集透传、备份合并 `_mergeCollectionTags`）与详情页展示均由 PR#128 提供，本修复仅补「拖放」这条交互入口，与已有「详情页 AppBar 按钮」入口等价。真机验收：视频/书架合集行头拖标签→toast→穿 DB（详情页标签行可见）、标签栏过滤合集卡显隐、重复拖同标签提示「已在此合集上」、回归普通书/视频/成员卡拖标签仍有效。

--- a/docs/bugs/BUG-894-collection-tag-drop-target.md
+++ b/docs/bugs/BUG-894-collection-tag-drop-target.md
@@ -1,0 +1,17 @@
+## BUG-894 · 标签拖到合集行头无接收（合集打标签仅详情页按钮入口）
+
+- **报告**：2026-07-19（用户：标签拖到合集上没反应，但应该可以给合集打标签）
+- **真实性**：✅ 真 bug（交互缺口）。PR#128（已合 develop）落地了「合集打标签」的数据层（`CollectionTagMappings` 表 + `addTagToCollection`/`getTagsForCollection`/`removeTagFromCollection`，`packages/hibiki_core/lib/src/database/database.dart:4054-4083`）与详情页 AppBar 打标签按钮（`tag_picker_page.dart:62` 的 `collectionId` 分派），但**没有实现「把标签拖到合集上」这个手势**：
+  - 标签是 `LongPressDraggable<BookTagRow>`（`tag_filter_bar.dart:136`）。
+  - 书/视频/SRT 卡外包 `BookDragTarget`（`book_drag_target.dart:33`，`DragTarget<BookTagRow>` → `onTagDropped` → `addTagToBook`/`addTagToVideoBook`/`addTagToSrtBook`），所以拖到书卡有效。
+  - 合集行 `CollectionShelfRow`（`hibiki/lib/src/media/collections/collection_shelf_row.dart`）**根因**：既不是 `DragTarget`，两个调用点（`home_video_page.dart` 的 `_buildVideoCollectionRow`、`reader_hibiki_history_page.dart` 的 `_buildShelfCollectionRow`）也没把它包进 `BookDragTarget`。标签落在合集行头上无处接收 → 静默无反应。合集内的成员卡各自仍是书级 `DragTarget`（拖到某集=给那本书打标签），缺的是**合集级** drop target。
+
+- **[x] ① 已修复** — 在 `CollectionShelfRow` 加可选 `onTagDropped`（`hibiki/lib/src/media/collections/collection_shelf_row.dart`）：非 null 时把**行头**包一层 `DragTarget<BookTagRow>`（`_wrapTagDropTarget`，与 `BookDragTarget` 视觉同源、适配行头形状，拖入时高亮边框 + 末端 `new_label` 图标；`IgnorePointer` overlay 不吞点击/焦点）。行头区与成员卡区在 `Column` 里不重叠，语义清晰。两个调用点接线合集级打标签：
+  - 视频页 `_addTagToVideoCollection`（`home_video_page.dart`）：查 `getTagsForCollection` 去重 → `addTagToCollection` → 失效 `filteredCollectionIdsProvider` → toast。
+  - 书架页 `_addTagToCollection`（`reader_hibiki_history_page.dart`）：同上（不复用 `_addTagToMedia`，其「已存在」提示固定为 `tag_already_on_book`，合集文案不对）。
+  - 新增 i18n `tag_added_to_collection` / `tag_already_on_collection`（`tool/i18n_sync.dart --add`，17 语言，`dart run slang` 重生成）。
+  - 提交：f0ad59aa4
+
+- **[x] ② 已加自动化测试** — `hibiki/test/widgets/collection_shelf_row_tag_drop_test.dart`：pump `CollectionShelfRow` + `Draggable<BookTagRow>`，把标签拖到行头断言 `onTagDropped` 收到该 `BookTagRow`；并断言 `onTagDropped: null` 时行头不是 `DragTarget`（回归守卫：防止调用点漏传接线又退回静默）。提交：f0ad59aa4
+
+- **备注**：合集打标签的持久化/同步（`CollectionSyncEngine` 并集透传、备份合并 `_mergeCollectionTags`）与详情页展示均由 PR#128 提供，本修复仅补「拖放」这条交互入口，与已有「详情页 AppBar 按钮」入口等价。真机验收：视频/书架合集行头拖标签→toast→穿 DB（详情页标签行可见）、标签栏过滤合集卡显隐、重复拖同标签提示「已在此合集上」、回归普通书/视频/成员卡拖标签仍有效。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 33422 (1966 per locale)
+/// Strings: 33456 (1968 per locale)
 ///
-/// Built on 2026-07-18 at 04:25 UTC
+/// Built on 2026-07-18 at 16:08 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2646,6 +2646,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Controls whether Hibiki stays above other windows';
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -7104,6 +7108,12 @@ class _StringsAr extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -11635,6 +11645,12 @@ class _StringsDe extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -16182,6 +16198,12 @@ class _StringsEs extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -20740,6 +20762,12 @@ class _StringsFr extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -25225,6 +25253,12 @@ class _StringsId extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -29758,6 +29792,12 @@ class _StringsIt extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -34097,6 +34137,12 @@ class _StringsJa extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -38439,6 +38485,12 @@ class _StringsKo extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -42950,6 +43002,12 @@ class _StringsNl extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -47476,6 +47534,12 @@ class _StringsPtBr extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -51985,6 +52049,12 @@ class _StringsRu extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -56439,6 +56509,12 @@ class _StringsTh extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -60925,6 +61001,12 @@ class _StringsTr extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -65398,6 +65480,12 @@ class _StringsVi extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 // Path: <root>
@@ -69563,6 +69651,12 @@ class _StringsZhCn extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       '端口 ${port} 正被 Yomitan API 占用。请先在 Yomitan 高级设置中关闭 Yomitan API，再回 Hibiki 开启 Yomitan API 服务器。';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      '标签「${name}」已添加到合集。';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      '标签「${name}」已在此合集上。';
 }
 
 // Path: <root>
@@ -73824,6 +73918,12 @@ class _StringsZhHk extends _StringsEn {
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
       'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+  @override
+  String tag_added_to_collection({required Object name}) =>
+      'Tag ${name} added to collection.';
+  @override
+  String tag_already_on_collection({required Object name}) =>
+      'Tag ${name} is already on this collection.';
 }
 
 /// Flat map(s) containing all translations.
@@ -77845,6 +77945,11 @@ extension on _StringsEn {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -81864,6 +81969,11 @@ extension on _StringsAr {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -85904,6 +86014,11 @@ extension on _StringsDe {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -89943,6 +90058,11 @@ extension on _StringsEs {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -93988,6 +94108,11 @@ extension on _StringsFr {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -98015,6 +98140,11 @@ extension on _StringsId {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -102057,6 +102187,11 @@ extension on _StringsIt {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -106061,6 +106196,11 @@ extension on _StringsJa {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -110069,6 +110209,11 @@ extension on _StringsKo {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -114104,6 +114249,11 @@ extension on _StringsNl {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -118136,6 +118286,11 @@ extension on _StringsPtBr {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -122173,6 +122328,11 @@ extension on _StringsRu {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -126194,6 +126354,11 @@ extension on _StringsTh {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -130224,6 +130389,11 @@ extension on _StringsTr {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -134249,6 +134419,11 @@ extension on _StringsVi {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }
@@ -138242,6 +138417,10 @@ extension on _StringsZhCn {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             '端口 ${port} 正被 Yomitan API 占用。请先在 Yomitan 高级设置中关闭 Yomitan API，再回 Hibiki 开启 Yomitan API 服务器。';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => '标签「${name}」已添加到合集。';
+      case 'tag_already_on_collection':
+        return ({required Object name}) => '标签「${name}」已在此合集上。';
       default:
         return null;
     }
@@ -142241,6 +142420,11 @@ extension on _StringsZhHk {
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
             'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      case 'tag_added_to_collection':
+        return ({required Object name}) => 'Tag ${name} added to collection.';
+      case 'tag_already_on_collection':
+        return ({required Object name}) =>
+            'Tag ${name} is already on this collection.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "暂不可提前入库（元数据未就绪或连接失败），稍后再试",
   "interconnect_section_related": "远端内容与查词",
   "desktop_clipboard_window_mode_hint": "控制 Hibiki 是否保持在其他窗口上方",
-  "browser_extension_yomitan_port_conflict": "端口 $port 正被 Yomitan API 占用。请先在 Yomitan 高级设置中关闭 Yomitan API，再回 Hibiki 开启 Yomitan API 服务器。"
+  "browser_extension_yomitan_port_conflict": "端口 $port 正被 Yomitan API 占用。请先在 Yomitan 高级设置中关闭 Yomitan API，再回 Hibiki 开启 Yomitan API 服务器。",
+  "tag_added_to_collection": "标签「$name」已添加到合集。",
+  "tag_already_on_collection": "标签「$name」已在此合集上。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1964,5 +1964,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki."
+  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "tag_added_to_collection": "Tag $name added to collection.",
+  "tag_already_on_collection": "Tag $name is already on this collection."
 }

--- a/hibiki/lib/src/media/collections/collection_shelf_row.dart
+++ b/hibiki/lib/src/media/collections/collection_shelf_row.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:hibiki_core/hibiki_core.dart';
 
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
 import 'package:hibiki/src/focus/hibiki_focus_target.dart';
@@ -32,6 +33,7 @@ class CollectionShelfRow extends StatefulWidget {
     this.onToggleCollapsed,
     this.selectionCheckbox,
     this.onToggleSelected,
+    this.onTagDropped,
     super.key,
   });
 
@@ -82,12 +84,21 @@ class CollectionShelfRow extends StatefulWidget {
   /// [onOpenDetail]。null（默认）时行头点击维持进详情。
   final VoidCallback? onToggleSelected;
 
+  /// 把标签拖到**行头**上 = 给整个合集打标签（与书/视频卡的 [BookDragTarget] 拖放
+  /// 手势一致；成员卡区各成员卡自带书级 drop target，与行头区不重叠）。null（默认）时
+  /// 行头不接收拖放。合集详情页 AppBar 的打标签按钮是另一条等价入口。
+  final void Function(BookTagRow tag)? onTagDropped;
+
   @override
   State<CollectionShelfRow> createState() => _CollectionShelfRowState();
 }
 
 class _CollectionShelfRowState extends State<CollectionShelfRow> {
   late final ScrollController _controller;
+
+  /// 行头正被标签拖放悬停（画高亮边框反馈）。仅 [CollectionShelfRow.onTagDropped]
+  /// 非 null 时有意义。
+  bool _tagHovering = false;
 
   @override
   void initState() {
@@ -230,8 +241,9 @@ class _CollectionShelfRowState extends State<CollectionShelfRow> {
       ),
     );
     final HibikiFocusId? focusId = widget.headerFocusId;
+    Widget result = header;
     if (focusId != null && HibikiFocusRoot.maybeControllerOf(context) != null) {
-      return Actions(
+      result = Actions(
         actions: <Type, Action<Intent>>{
           ActivateIntent: CallbackAction<ActivateIntent>(
             onInvoke: (_) {
@@ -243,7 +255,77 @@ class _CollectionShelfRowState extends State<CollectionShelfRow> {
         child: HibikiFocusTarget(id: focusId, child: header),
       );
     }
-    return header;
+    // 把标签拖到行头 = 给整个合集打标签。DragTarget 包在最外层（含焦点包裹），
+    // 整个行头区域都是 drop 区；仅拖拽时接收 [BookTagRow]，普通点击/焦点不受影响。
+    final void Function(BookTagRow tag)? onTagDropped = widget.onTagDropped;
+    if (onTagDropped != null) {
+      result = _wrapTagDropTarget(context, tokens, result, onTagDropped);
+    }
+    return result;
+  }
+
+  /// 用 [DragTarget] 包住行头 [child]：拖入标签时画高亮边框反馈，落下时回调
+  /// [onTagDropped]（给整个合集打标签）。与 `BookDragTarget` 的书级拖放视觉同源，
+  /// 但适配行头形状（末端小图标而非居中大图标）。
+  Widget _wrapTagDropTarget(
+    BuildContext context,
+    HibikiDesignTokens tokens,
+    Widget child,
+    void Function(BookTagRow tag) onTagDropped,
+  ) {
+    final Color hoverColor = tokens.surfaces.primary;
+    return DragTarget<BookTagRow>(
+      onWillAcceptWithDetails: (_) => true,
+      onAcceptWithDetails: (DragTargetDetails<BookTagRow> details) {
+        setState(() => _tagHovering = false);
+        onTagDropped(details.data);
+      },
+      onMove: (_) {
+        if (!_tagHovering) setState(() => _tagHovering = true);
+      },
+      onLeave: (_) {
+        if (_tagHovering) setState(() => _tagHovering = false);
+      },
+      builder: (
+        BuildContext context,
+        List<BookTagRow?> candidateData,
+        List<dynamic> rejectedData,
+      ) {
+        return Stack(
+          children: <Widget>[
+            child,
+            if (_tagHovering)
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: hoverColor.withValues(alpha: 0.18),
+                      borderRadius: tokens.radii.controlRadius,
+                      border: Border.all(
+                        color: hoverColor,
+                        width: tokens.spacing.gap / 4,
+                      ),
+                    ),
+                    child: Align(
+                      alignment: AlignmentDirectional.centerEnd,
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: tokens.spacing.gap,
+                        ),
+                        child: Icon(
+                          Icons.new_label_outlined,
+                          color: hoverColor,
+                          size: 20,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
   }
 }
 

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -1506,6 +1506,26 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     }
   }
 
+  /// 把标签拖到合集行头 = 给整个合集打标签（`CollectionShelfRow.onTagDropped`）。
+  /// `addTagToCollection` 本身幂等（INSERT OR IGNORE），这里先查现有标签给「已存在」
+  /// 提示，避免静默无反馈；成功后失效 [filteredCollectionIdsProvider] 让标签过滤下
+  /// 合集卡显隐立即刷新（详情页标签行走 FutureBuilder，重进即新）。
+  Future<void> _addTagToVideoCollection(
+      int collectionId, BookTagRow tag) async {
+    final HibikiDatabase db = ref.read(appProvider).database;
+    final List<BookTagRow> existing =
+        await db.getTagsForCollection(collectionId);
+    if (existing.any((BookTagRow t) => t.id == tag.id)) {
+      HibikiToast.show(msg: t.tag_already_on_collection(name: tag.name));
+      return;
+    }
+    await db.addTagToCollection(collectionId, tag.id);
+    ref.invalidate(filteredCollectionIdsProvider);
+    if (mounted) {
+      HibikiToast.show(msg: t.tag_added_to_collection(name: tag.name));
+    }
+  }
+
   /// 设置封面：选图 → 经共享 [setVideoCoverFromPickedFile]（拷盘 + 驱逐旧缓存 +
   /// 落库）→ 刷新。与书架视频卡的换封面共用同一入口，封面与自动截图同目录。
   Future<void> _pickCover(VideoBookRow book) async {
@@ -2223,6 +2243,9 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         onToggleSelected: _selectionMode
             ? () => _toggleCollectionSelection(collection.id)
             : null,
+        // 拖标签到行头 = 给整个合集打标签（与散卡书级拖放一致）。
+        onTagDropped: (BookTagRow tag) =>
+            _addTagToVideoCollection(collection.id, tag),
         itemBuilder: (BuildContext _, int i) {
           final _VideoSlot slot = group.items[i].payload;
           final VideoBookRow? local = slot.local;

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -695,6 +695,25 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     );
   }
 
+  /// 把标签拖到书架合集行头 = 给整个合集打标签（`CollectionShelfRow.onTagDropped`）。
+  /// 不复用 [_addTagToMedia]：它的「已存在」提示固定是 `tag_already_on_book`，对合集
+  /// 文案不对。`addTagToCollection` 幂等，这里先查现有标签给合集专属提示，成功后失效
+  /// [filteredCollectionIdsProvider] 让标签过滤下合集卡显隐立即刷新。
+  Future<void> _addTagToCollection(int collectionId, BookTagRow tag) async {
+    final HibikiDatabase db = ref.read(appProvider).database;
+    final List<BookTagRow> existing =
+        await db.getTagsForCollection(collectionId);
+    if (existing.any((BookTagRow t) => t.id == tag.id)) {
+      HibikiToast.show(msg: t.tag_already_on_collection(name: tag.name));
+      return;
+    }
+    await db.addTagToCollection(collectionId, tag.id);
+    ref.invalidate(filteredCollectionIdsProvider);
+    if (mounted) {
+      HibikiToast.show(msg: t.tag_added_to_collection(name: tag.name));
+    }
+  }
+
   /// 某媒体卡上挂的标签列：标签 map 为空 / 该 key 无标签都返回 null，否则渲染
   /// [_adaptiveTagColumn]。三种媒体（epub/srt/video）只差「watch 哪个标签 provider +
   /// key 类型」，故各 caller 自己 `ref.watch(provider).valueOrNull`（保响应式订阅）后
@@ -1303,6 +1322,9 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
         onToggleSelected: _selectionMode
             ? () => _toggleCollectionSelection(collection.id)
             : null,
+        // 拖标签到行头 = 给整个合集打标签（与散书书级拖放一致）。
+        onTagDropped: (BookTagRow tag) =>
+            _addTagToCollection(collection.id, tag),
         itemBuilder: (BuildContext _, int i) => _buildShelfMemberCard(
           group.items[i].payload,
           epubCoverUrisByBookKey,

--- a/hibiki/test/media/collection_shelf_row_tag_drop_test.dart
+++ b/hibiki/test/media/collection_shelf_row_tag_drop_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
+
+/// BUG-894：把标签拖到合集**行头** = 给整个合集打标签（与书/视频卡的书级拖放一致）。
+/// 根因是合集行既非 `DragTarget` 也未被调用点包进 `BookDragTarget`，标签落上去静默无
+/// 反应。这里守卫「行头拖放接收」这条交互：拖入触发回调、漏接线（onTagDropped=null）
+/// 时不建 DragTarget（防止再次退回静默）。纯 `BookTagRow` data class，不开 DB。
+void main() {
+  const BookTagRow tag = BookTagRow(
+    id: 7,
+    name: 'お気に入り',
+    colorValue: 0xFF2196F3,
+    sortOrder: 0,
+    createdAt: 0,
+  );
+
+  Future<void> pump(WidgetTester tester, CollectionShelfRow row) async {
+    tester.view.physicalSize = const Size(800, 600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          // 非滚动 Column（不用 ListView）：避免外层竖直滚动手势与 Draggable 的拖拽
+          // 识别器在手势竞技场抢赢，导致 moveBy 被当滚动吞掉、拖拽根本没启动。
+          body: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              // 拖动源：一个携带 [tag] 的普通 Draggable（真 app 里是标签栏的
+              // LongPressDraggable<BookTagRow>，此处简化手势，payload 类型一致即可）。
+              Draggable<BookTagRow>(
+                data: tag,
+                feedback: const SizedBox(
+                  key: ValueKey<String>('tag_feedback'),
+                  width: 40,
+                  height: 20,
+                ),
+                // 有颜色的 Container 才参与命中测试（裸 SizedBox 透明，指针按下命中
+                // 不到 Draggable 的 Listener，拖拽根本不会启动）。
+                child: Container(
+                  key: const ValueKey<String>('tag_handle'),
+                  width: 40,
+                  height: 20,
+                  color: const Color(0xFF2196F3),
+                ),
+              ),
+              row,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  CollectionShelfRow buildRow({void Function(BookTagRow tag)? onTagDropped}) =>
+      CollectionShelfRow(
+        title: 'コレクション',
+        countLabel: '3',
+        itemCount: 1,
+        itemWidth: 200,
+        rowHeight: 160,
+        onOpenDetail: () {},
+        onTagDropped: onTagDropped,
+        itemBuilder: (BuildContext _, int __) => const Text('EP0'),
+      );
+
+  testWidgets('把标签拖到合集行头触发 onTagDropped（合集级打标签入口）',
+      (WidgetTester tester) async {
+    BookTagRow? dropped;
+    await pump(tester, buildRow(onTagDropped: (BookTagRow t) => dropped = t));
+
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const ValueKey<String>('tag_handle'))),
+    );
+    await tester.pump();
+    // 先小步移动启动拖拽（Draggable 的 recognizer 需一次超过 slop 的移动才 onStart），
+    // 再落到行头标题上（行头区被 DragTarget 包裹）。
+    await gesture.moveBy(const Offset(0, 30));
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey<String>('tag_feedback')),
+      findsOneWidget,
+      reason: '拖拽应已启动（feedback 出现）',
+    );
+    await gesture.moveTo(tester.getCenter(find.text('コレクション')));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(dropped, isNotNull, reason: '行头必须接收标签拖放');
+    expect(dropped!.id, tag.id, reason: '回调必须收到被拖的那个 BookTagRow');
+  });
+
+  testWidgets('onTagDropped 非 null 时行头是 DragTarget<BookTagRow>',
+      (WidgetTester tester) async {
+    await pump(tester, buildRow(onTagDropped: (_) {}));
+    expect(find.byType(DragTarget<BookTagRow>), findsOneWidget);
+  });
+
+  testWidgets('onTagDropped 为 null 时行头不建 DragTarget（守卫调用点漏接线又退回静默）',
+      (WidgetTester tester) async {
+    await pump(tester, buildRow(onTagDropped: null));
+    expect(find.byType(DragTarget<BookTagRow>), findsNothing);
+  });
+}


### PR DESCRIPTION
## 问题
用户报：标签拖到合集上没反应，但应该能给合集打标签。

## 根因
PR#128 落地了合集打标签的**数据层**（`CollectionTagMappings` 表 + `addTagToCollection`）与**详情页 AppBar 按钮**入口，但漏了「把标签**拖到**合集上」这个手势——合集行 `CollectionShelfRow` 既不是 `DragTarget`，两个调用点（`home_video_page` / `reader_hibiki_history_page`）也没把它包进 `BookDragTarget`。标签落在合集行头上无处接收 → 静默无反应（书/视频卡靠 `BookDragTarget` 拖放有效）。

## 修复
- `CollectionShelfRow` 加可选 `onTagDropped`：行头包一层 `DragTarget<BookTagRow>`（`_wrapTagDropTarget`，与 `BookDragTarget` 视觉同源、适配行头形状；`IgnorePointer` overlay 不吞点击/焦点）。行头区与成员卡区不重叠——成员卡各自仍是**书级** drop target（拖到某集=给那本书打标签），行头是新增的**合集级** target。
- 视频页 `_addTagToVideoCollection` / 书架页 `_addTagToCollection`：查 `getTagsForCollection` 去重 → `addTagToCollection` → 失效 `filteredCollectionIdsProvider` → toast。
- i18n 新增 `tag_added_to_collection` / `tag_already_on_collection`（17 语言）。

## 测试
- `collection_shelf_row_tag_drop_test.dart`：拖标签到行头触发回调 + 漏接线守卫（`onTagDropped=null` 时不建 DragTarget）。3 绿。
- 受影响 CollectionShelfRow 测试 11 绿（向后兼容，加的是可选参数）。
- 全量 `flutter analyze` 0 issue。

## 真机验收（待）
视频/书架合集行头拖标签 → toast → 穿 DB（详情页标签行可见）、标签栏过滤合集卡显隐、重复拖同标签提示「已在此合集上」、回归普通书/视频/成员卡拖标签仍有效。

BUG-894。与已有「详情页 AppBar 打标签按钮」入口等价。