### PR TITLE
fix(video): BUG-910 字幕查词点空白想关闭却重复查同一个词

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 890 条。点号进各自文件。
+> 共 891 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-910](bugs/BUG-910-video-subtitle-dismiss-halo-reloop.md) | ✅ | ✅ | 视频字幕查词点空白想关闭却重复查同一个词 |
 | [BUG-909](bugs/BUG-909-remove-vertical-forensic-probes.md) | ✅ | ✅ | 移除发布版残留的竖排取证探针（TODO-792/753 系列 + 753-DIAG） |
 | [BUG-908](bugs/BUG-908-lan-sync-server-hardening.md) | ✅ | ✅ | LAN 局域网同步服务器健壮性欠账（token 膨胀 / PROPFIND 同步阻塞 / 写无互斥） |
 | [BUG-907](bugs/BUG-907-danmaku-layout-binary-and-isolate-parse.md) | ✅ | ✅ | 弹幕两项性能缺陷：布局每帧 O(N) 全量扫描 + 20MB sidecar 主 isolate 同步解析 |

--- a/docs/bugs/BUG-910-video-subtitle-dismiss-halo-reloop.md
+++ b/docs/bugs/BUG-910-video-subtitle-dismiss-halo-reloop.md
@@ -1,0 +1,18 @@
+## BUG-910 · 视频字幕查词点空白想关闭却重复查同一个词
+
+- **报告**：2026-07-19（用户：）
+- **现象**：视频播放时点画面底部内嵌字幕某字查词 → 弹词典浮层（正常）。想点浮层外**空白处**关掉浮层继续看视频，却**反复重查同一句里的词**，关不掉。用户强调点的是**空白**、不是字、不是同一个词区域。
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/video_hibiki_page.dart` `_onDismissBarrierTap`（原 `final SubtitleCharHit? hit = _subtitleHitTester.hitTest(globalPos);`）。
+  - 查词浮层打开时根 Overlay 铺全屏 dismiss barrier，点浮层外先进 `_onDismissBarrierTap` → `_subtitleHitTester.hitTest(globalPos)` 反查是否点到底部字幕字符，命中即 `shouldSwitchWordOnBarrierTap`（非嵌套 `topVisibleIndex<=0 && hitSubtitle`）→ `_handleSubtitleLookupTap` → `_lookupAt(replaceStack:true)` 重查、保持暂停、浮层不关。
+  - 关键：命中反查复用**查词用的胖手指裙边容差** `resolveSubtitleCharHit`（`video_subtitle_overlay.dart`，TODO-971 水平半字宽 ≈18px + BUG-825 描边级垂直边）。这套 halo 本服务「点小字好点中」，但 barrier 判「关闭 vs 切词」也吃它 → 字幕行周围约 18px 的**空白**被误判成「命中字幕」→ 把「点空白想关闭」当成「切词重查」。查词已暂停（`_lookupAt` 置 `_pausedForLookup=true; controller.pause()`），字幕**冻结**在屏，用户在字幕行附近空白反复点 → 反复落进 halo → 反复重查同一句 = 死循环。
+  - 佐证：BUG-410 备注原话「位置相关、间歇（落字幕上复现，**落纯空白正常**）」——当初 barrier 命中判定还是精确容差，点纯空白能正常关；TODO-916/971 放宽容差后 barrier 继承了 halo，「落纯空白正常」被打破，退化成本 bug。桌面悬停换词（`_onDismissBarrierHover`）、Shift 查词（`_triggerShiftLookupAtLastPointer`）是查词意图，仍应用宽容差，不受影响。
+- **[x] ① 已修复** — 解耦「查词命中」与「barrier 关闭判定」，让 barrier 只在点**落在字形矩形内**才算命中：
+  - `resolveSubtitleCharHit`（`video_subtitle_overlay.dart`）加 `bool exactOnly=false`：为 true 时只跑第一段精确 `Rect.contains`、**跳过**第二段裙边兜底容差，字形外一律返回 -1。默认 false，查词/悬停命中语义完全不变。
+  - `VideoSubtitleHitTester.hitTest` / 绑定实现 `_charHitTest` / `_hitEntryIndexAt` 透传 `exactOnly`。
+  - `_onDismissBarrierTap` 改 `_subtitleHitTester.hitTest(globalPos, exactOnly: true)`：点字幕行周围空白 halo → 命中为空 → 落到 `_popNestedPopupAt(0)` 关整栈 + 恢复播放（`shouldResumeAfterLookupDismiss`）；点在字形上仍切词（TODO-758 不回归）；嵌套门控 `shouldSwitchWordOnBarrierTap`（BUG-410）不动；查词胖手指容差（TODO-971）不动。恢复了 BUG-410 备注承诺的「落纯空白正常」。
+  - 仅动 barrier **tap** 一处；hover 换词（`_onDismissBarrierHover:3327`）、Shift 查词（`_triggerShiftLookupAtLastPointer:1243`）仍走宽容差。字幕列表侧栏兜底（`_subtitleListHitTester`）不在本 bug 路径，未改。
+  - 提交哈希：（见分支 `worktree-bug-video-subtitle-dismiss-halo` / 本 PR）。
+- **[x] ② 已加自动化测试** — 纯函数行为测试，扩展 `hibiki/test/media/video/subtitle_char_hit_tolerance_test.dart`：
+  - `group('BUG-910：exactOnly ...')`：点落字形内 exactOnly 仍命中（切词保留）；字缝 / 描边 halo / 字幕行水平右缘 12px 空白在**默认宽容差命中、exactOnly 下必 -1**（对照断言两路，撤 `exactOnly` 分支即转红）。
+  - 现有 8 项容差用例（TODO-916/971/BUG-825）不变，证明查词命中语义零回归。
+- **备注**：barrier 真实点击坐标命中底部字幕是渲染几何产物，widget 测试照不到几何；关闭 vs 切词的判据（exactOnly 命中语义）已由纯函数在 Dart 层覆盖。最终交互（查词→点字幕行周围空白→浮层关闭+续播；点在字上→切词）留真机/模拟器焦点驱动复测一次。

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -29,12 +29,16 @@ typedef SubtitleCharHit = ({String sentence, int graphemeIndex, Rect charRect});
 /// 点击 → 点同句第二个词只会关栈+恢复播放，查不了第二个词。让 barrier 先用本句柄反查
 /// 是否点到了字幕字符，是则切换查词（保持暂停），否则才 dismiss。
 class VideoSubtitleHitTester {
-  SubtitleCharHit? Function(Offset globalPos)? _impl;
+  SubtitleCharHit? Function(Offset globalPos, {bool exactOnly})? _impl;
 
-  void bindHitTest(SubtitleCharHit? Function(Offset globalPos) impl) =>
+  void bindHitTest(
+          SubtitleCharHit? Function(Offset globalPos, {bool exactOnly}) impl) =>
       _impl = impl;
 
-  SubtitleCharHit? hitTest(Offset globalPos) => _impl?.call(globalPos);
+  /// [exactOnly]（BUG-910）：为 true 时只在点落在字形矩形内才命中，跳过手指友好的裙边
+  /// 容差——查词浮层 dismiss barrier 用它区分「点空白想关闭」与「点字上想切词」。
+  SubtitleCharHit? hitTest(Offset globalPos, {bool exactOnly = false}) =>
+      _impl?.call(globalPos, exactOnly: exactOnly);
 }
 
 /// 按全局坐标在一组字符屏幕矩形里反查命中的字符下标（纯函数，可测）。
@@ -54,6 +58,13 @@ class VideoSubtitleHitTester {
 /// 顶部一条带时被顶层字幕识别器赢走竞技场，暂停视频 + 弹查词、seek 被吞（BUG-825）。
 /// 垂直方向本就不该放半字宽的裙边。
 ///
+/// [exactOnly] 为 true 时**只跑精确包含**、跳过第二段兜底容差（BUG-910）：查词/悬停要
+/// 手指友好的宽容差（默认 false），但查词浮层的 dismiss barrier 判「关闭 vs 切词」不能用
+/// 这套 halo——字幕行周围约 18px 水平裙边被吃成「命中字幕」会把「点空白想关闭」误判成
+/// 「切词重查」，暂停冻结字幕下反复重查同一句。barrier 用 [exactOnly]=true 只在点**落在
+/// 字形矩形内**才算切词，落 halo 空白照常 dismiss+续播（恢复 BUG-410 备注承诺的「落纯
+/// 空白正常」，同时不动查词的宽容差）。
+///
 /// [Rect.zero]（无 RenderBox 的字符）跳过。无任何有效矩形或全部超容差时返回 -1。
 @visibleForTesting
 int resolveSubtitleCharHit(
@@ -65,6 +76,8 @@ int resolveSubtitleCharHit(
   // BUG-825：垂直兜底半轴。字身外上下只需覆盖描边外缘（默认软阴影半径 3px + 手指余量），
   // 远小于水平半字宽——避免向下溢出到紧贴字幕下方的进度条轨道。
   double edgeTolerance = 6.0,
+  // BUG-910：仅精确包含，跳过第二段裙边容差（barrier 关闭判定用）。
+  bool exactOnly = false,
 }) {
   // 第一段：精确包含。
   for (int i = 0; i < charRects.length; i++) {
@@ -72,6 +85,8 @@ int resolveSubtitleCharHit(
     if (r == Rect.zero) continue;
     if (r.contains(point)) return i;
   }
+  // exactOnly：不跑裙边兜底——点在字形外一律 miss（barrier 据此 dismiss，不误判切词）。
+  if (exactOnly) return -1;
   // 第二段：最近字符兜底（在该字符的方向感知椭圆容差区内）。
   int bestIndex = -1;
   double bestDistance = double.infinity;
@@ -396,20 +411,20 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// 活动集）里反查命中的登记表下标；模糊层字符按 [Rect.zero] 跳过（不参与命中，与点击
   /// 行为一致：模糊时不查词）。无命中返回 -1。是 [_charHitTest] / 竞技场门控 / 悬停查词
   /// 的共享命中内核。
-  int _hitEntryIndexAt(Offset globalPos) {
+  int _hitEntryIndexAt(Offset globalPos, {bool exactOnly = false}) {
     if (_charEntries.isEmpty) return -1;
     final List<Rect> rects = <Rect>[
       for (final _SubtitleCharEntry e in _charEntries)
         e.blurred ? Rect.zero : _globalRectOf(e.context),
     ];
-    return resolveSubtitleCharHit(rects, globalPos);
+    return resolveSubtitleCharHit(rects, globalPos, exactOnly: exactOnly);
   }
 
   /// 按全局坐标反查命中的字幕字符，返回其**所属整条 cue 文本** + 该 cue 内 grapheme 下标
   /// + 字符全局矩形。模糊 / 空 / 无命中返回 null。供 [VideoSubtitleHitTester] 绑定，
   /// 二维登记后点主字幕 / 副字幕 / 重叠某条都能查到正确的整句（TODO-1312）。
-  SubtitleCharHit? _charHitTest(Offset globalPos) {
-    final int i = _hitEntryIndexAt(globalPos);
+  SubtitleCharHit? _charHitTest(Offset globalPos, {bool exactOnly = false}) {
+    final int i = _hitEntryIndexAt(globalPos, exactOnly: exactOnly);
     if (i < 0) return null;
     final _SubtitleCharEntry e = _charEntries[i];
     return (

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -3404,7 +3404,15 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     // 单层查词点同句另一个字符切换查词是合理交互。嵌套态（存在父层）下底部字幕仍清晰渲染、
     // 其字符矩形持续绑定，点第 2+ 个窗外面常落在字幕文字上；若仍走反查会 replaceStack 把整栈
     // 替换掉（顶层窗没关而是被换成新词）。故仅当 [shouldSwitchWordOnBarrierTap] 为真才反查。
-    final SubtitleCharHit? hit = _subtitleHitTester.hitTest(globalPos);
+    //
+    // BUG-910：反查用 `exactOnly: true`（只在点**落在字形矩形内**才算命中）。查词的胖手指裙边
+    // 容差（TODO-971 半字宽 ≈18px + BUG-825 描边级垂直边）本服务「点小字好点中」，但 barrier
+    // 判「关闭 vs 切词」若也吃这套 halo，字幕行周围约 18px 空白会被误判成「命中字幕」→ 把「点
+    // 空白想关闭继续看」当成「切词重查」，暂停冻结字幕下反复重查同一句（用户报「点空白一直
+    // 重复查一个词」）。exactOnly 让空白 halo 落回 dismiss+续播（恢复 BUG-410 备注承诺的「落
+    // 纯空白正常」），点在字上仍切词。悬停换词 / Shift 查词是查词意图，仍用宽容差（不改）。
+    final SubtitleCharHit? hit =
+        _subtitleHitTester.hitTest(globalPos, exactOnly: true);
     if (VideoHibikiPage.shouldSwitchWordOnBarrierTap(
       topVisibleIndex: _topVisiblePopupIndex,
       hitSubtitle: hit != null,

--- a/hibiki/test/media/video/subtitle_char_hit_tolerance_test.dart
+++ b/hibiki/test/media/video/subtitle_char_hit_tolerance_test.dart
@@ -74,6 +74,52 @@ void main() {
     expect(resolveSubtitleCharHit(<Rect>[], const Offset(5, 10)), -1);
   });
 
+  group('BUG-910：exactOnly（barrier 关闭判定用，跳过裙边兜底）', () {
+    test('exactOnly：点落在字形内仍命中（切词意图保留）', () {
+      // 字上 x=5 正落在字符 0 矩形内 → exactOnly 也命中（点字仍切词，TODO-758 不回归）。
+      expect(
+        resolveSubtitleCharHit(row(), const Offset(5, 10), exactOnly: true),
+        0,
+      );
+      expect(
+        resolveSubtitleCharHit(row(), const Offset(19, 10), exactOnly: true),
+        1,
+      );
+    });
+
+    test('exactOnly：字缝/描边 halo 一律 miss（点空白 → dismiss，不误判切词）', () {
+      // 字缝 x=12（宽容差下会兜底命中相邻字符）：exactOnly 下必须 -1 → barrier 走 dismiss。
+      expect(resolveSubtitleCharHit(row(), const Offset(12, 10)), anyOf(0, 1),
+          reason: '对照：默认宽容差字缝会兜底命中');
+      expect(
+        resolveSubtitleCharHit(row(), const Offset(12, 10), exactOnly: true),
+        -1,
+        reason: 'exactOnly：字缝空白不命中，barrier 应 dismiss 而非切词重查',
+      );
+      // 字符 0 上缘外 3px（默认垂直容差内会命中）：exactOnly 下 miss。
+      expect(resolveSubtitleCharHit(row(), const Offset(5, -3)), 0,
+          reason: '对照：默认容差描边外缘会兜底命中');
+      expect(
+        resolveSubtitleCharHit(row(), const Offset(5, -3), exactOnly: true),
+        -1,
+        reason: 'exactOnly：字身外描边 halo 不命中',
+      );
+    });
+
+    test('BUG-910 核心：字幕行水平裙边 halo 空白 exactOnly 必 miss', () {
+      // 36px 字幕单字，右缘外 12px（x=48）在默认水平半字宽兜底内会命中（用户误以为点的是
+      // 空白，却被吃成命中→切词重查死循环）。exactOnly 下 miss → barrier dismiss+续播。
+      final List<Rect> wide = <Rect>[const Rect.fromLTWH(0, 0, 36, 40)];
+      expect(resolveSubtitleCharHit(wide, const Offset(48, 20)), 0,
+          reason: '对照：默认宽容差右缘 12px halo 会误命中');
+      expect(
+        resolveSubtitleCharHit(wide, const Offset(48, 20), exactOnly: true),
+        -1,
+        reason: 'BUG-910：字幕行右侧空白 halo exactOnly 必 miss，barrier 才会关闭续播',
+      );
+    });
+  });
+
   test('TODO-971：默认容差 ≥ 10（手指比 6px 宽，放宽兜底命中）', () {
     // 极窄字符（width=4 → 半字宽=2）下，默认 minTolerance 决定实际容差。手指比 6px
     // 宽，旧 6.0 仍偏小，手机字幕点词常 miss。默认放宽到 ≥ 10：距字符 9px 的点必须

--- a/hibiki/test/media/video/video_player_keyboard_static_test.dart
+++ b/hibiki/test/media/video/video_player_keyboard_static_test.dart
@@ -375,10 +375,14 @@ void main() {
       ).firstMatch(page);
       expect(body, isNotNull, reason: 'cannot find _onDismissBarrierTap body');
       final String b = body!.group(1)!;
-      final int hitAt = b.indexOf('_subtitleHitTester.hitTest(globalPos)');
+      // BUG-910：barrier 关闭判定用 exactOnly:true（跳过查词裙边容差），点字幕行周围空白
+      // halo 不误判成切词重查。查词/悬停仍用宽容差（不在本方法体）。
+      final int hitAt =
+          b.indexOf('_subtitleHitTester.hitTest(globalPos, exactOnly: true)');
       final int handlerAt = b.indexOf('_handleSubtitleLookupTap(');
       final int popAt = b.indexOf('_popNestedPopupAt(0)');
-      expect(hitAt, greaterThanOrEqualTo(0), reason: 'hit-test the char first');
+      expect(hitAt, greaterThanOrEqualTo(0),
+          reason: 'hit-test the char first with exactOnly (BUG-910)');
       expect(handlerAt, greaterThan(hitAt),
           reason: 'on hit, switch lookup through the lookup gate handler');
       expect(popAt, greaterThan(handlerAt),


### PR DESCRIPTION
## 现象
视频播放点画面底部字幕某字查词→弹浮层。想点浮层外**空白**关掉继续看，却**反复重查同一句里的词**，关不掉。用户强调点的是空白、不是字。

## 根因（✅ 真 bug）
查词浮层的全屏 dismiss barrier `_onDismissBarrierTap` 反查是否点到字幕字符时，**复用了查词用的胖手指裙边容差** `resolveSubtitleCharHit`（TODO-971 水平半字宽≈18px + BUG-825 描边级垂直边）。这套 halo 本服务「点小字好点中」，但 barrier 判「关闭 vs 切词」也吃它 → 字幕行周围约 18px 的**空白**被误判成命中字幕 → `shouldSwitchWordOnBarrierTap`（非嵌套）→ `_lookupAt(replaceStack)` 重查、保持暂停。查词已暂停冻结字幕在屏，用户在字幕行附近空白反复点 → 反复落 halo → 反复重查同一句 = 死循环。

佐证：BUG-410 备注原话「落纯空白正常」——当初 barrier 判定还是精确容差；TODO-916/971 放宽容差后 barrier 继承 halo，「落纯空白正常」被打破。

## 修复（解耦查词命中与 barrier 关闭判定）
- `resolveSubtitleCharHit` 加 `exactOnly`：为 true 只跑精确 `Rect.contains`、跳过裙边兜底，字形外一律 miss。默认 false，查词/悬停命中语义零变化。
- `VideoSubtitleHitTester.hitTest`/`_charHitTest`/`_hitEntryIndexAt` 透传 `exactOnly`。
- `_onDismissBarrierTap` 用 `exactOnly:true`：空白 halo→dismiss+续播（恢复 BUG-410 承诺的落纯空白正常），点字上仍切词（TODO-758 不回归），嵌套门控（BUG-410）/查词容差（TODO-971）不动。
- 仅动 barrier **tap** 一处；hover 换词、Shift 查词仍宽容差。

## 测试
- `subtitle_char_hit_tolerance_test.dart` 加 `exactOnly` 组：点字形内仍命中；字缝/描边/字幕行水平 halo 空白在默认宽容差命中、exactOnly 必 -1（对照两路）。
- 更新 `video_player_keyboard_static_test.dart` 守卫断言 barrier 用 `exactOnly:true`。
- `flutter analyze` 3 文件 0 issue；`test/media/video/` 全绿（1580 pass / 2 skip）。

## 🔴 待真机
留真机/模拟器焦点驱动复测：查词→点字幕行周围空白→浮层关闭+续播；点在字上→切词。