### PR TITLE
fix(video): BUG-903 尊重模式加 sub-scale 字号倍率；关闭尊重改纯字幕模式

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 870 条。点号进各自文件。
+> 共 871 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-903](bugs/BUG-903-ass-user-scale-and-plain-off-mode.md) | ✅ | ✅ | 尊重字幕不能调字号；关闭尊重时 ASS 特效层叠印乱字 |
 | [BUG-891](bugs/BUG-891-ass-size-outline-mpv-parity.md) | ✅ | ✅ | ASS 字幕字号偏小、描边偏细：cell 校准含 lineGap + 居中描边只显一半，与 mpv/libass 不齐 |
 | [BUG-890](bugs/BUG-890-paused-audio-follow-image-snap.md) | ✅ | ✅ | 暂停/图片等待时有声书跟随把阅读器拽回音频位置 |
 | [BUG-887](bugs/BUG-887-top-progress-squeeze-frost.md) | ✅ | ✅ | 挤压模式顶部进度不应有毛玻璃且不应压住正文首行 |

--- a/docs/bugs/BUG-903-ass-user-scale-and-plain-off-mode.md
+++ b/docs/bugs/BUG-903-ass-user-scale-and-plain-off-mode.md
@@ -1,0 +1,10 @@
+## BUG-903 · 尊重字幕不能调字号；关闭尊重时 ASS 特效层叠印乱字
+- **报告**：2026-07-19（用户：截图为关闭「尊重字幕自带样式」后一行对白与特效层同位叠印成乱字；而开着尊重时字号滑块无效，「尊重字幕又不能调节大小」——用户被迫二选一）
+- **真实性**：✅ 真 bug，两处根因（`hibiki/lib/src/media/video/video_subtitle_overlay.dart`）：
+  1. **尊重模式字号不可调**：`_styleForGrapheme` 里 `cueFontPx != null` 时字号完全由 ASS 值换算，`widget.fontSize`（用户滑块）只在无 ASS 字号时作回退——滑块对 ASS 字幕零作用，没有 mpv `sub-scale` 那样的用户倍率通道。
+  2. **关闭尊重叠印乱字**：respectAssStyle 关时**样式**统一但**位置不统一**——`_posScreen`/`_positionKey` 的 \pos/\an/Layer/MarginV 不受 respect 门控，而 \1a 透明填充、\fscx 缩放、字号、动画全被忽略。KFX/多层特效字幕（一句拆成多条同时事件、依赖透明层/逐段样式区分）被渲染成多份**裸文本**按作者坐标叠画 → 同位叠印乱字（用户截图）。半吊子「样式不尊重、位置却尊重」语义即病根。
+- **[x] ① 已修复** — worktree-ass-size-outline-mpv-parity（叠加在 BUG-891 之上）：
+  - 尊重模式：新增 `VideoSubtitleOverlay.assUserFontScale`（mpv `sub-scale` 语义）——ASS 字号换算出 em 后乘该倍率；页面（`layout.part.dart`）传 `用户字号基准 / 默认 36`，默认 =1.0 完全按作者字号（mpv 平价基线不变），滑块±即整体缩放。只缩文字，不缩描边/阴影/字间距/边距；不含屏幕自适应因子（ASS 路径已按显示区几何缩放，叠加会双重放大）。
+  - 关闭尊重 = **纯字幕模式**（asbplayer 语义）：位置/层/边距语义整体归零——全部 cue 折进一个底部组（副字幕仍置顶），`_uniqueByText` 按文本去重（特效层拷贝只渲染一条），文本互异的竖排堆叠不叠印；`_positionCueGroup` 的 `ownMarkup` 按 respect 门控置 null，下游 \pos/\an/margins 全走「无位置信息」分支，零特例。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_ass_user_scale_plain_mode_test.dart`：①默认 1.0 基线不变 / 1.5× 只放大文字不动描边；②纯字幕模式同文本多层去重、\pos 顶部招牌落底部堆叠不叠印、respect 开时 \pos 不回归。旧断言依「定位属尊重语义」更新：`video_subtitle_dual_position_test.dart` / `video_subtitle_overlay_markup_test.dart` 的 \an 定位测试改显式 `respectAssStyle: true`。
+- **备注**：行为变化（有意）：respectAssStyle 关时 \an8 顶部歌词/\pos 招牌不再按自带位置渲染，一律底部堆叠（开关默认开，关=明确选择统一简洁外观）。用户「调大小」诉求在尊重模式下由倍率满足，无需再关尊重。

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -158,6 +158,7 @@ class VideoSubtitleOverlay extends StatefulWidget {
     this.controlsBottomReserve = kVideoControlsBottomReserve,
     this.fontFamily,
     this.respectAssStyle = false,
+    this.assUserFontScale = 1.0,
     super.key,
   });
 
@@ -261,6 +262,16 @@ class VideoSubtitleOverlay extends StatefulWidget {
   /// 外观像素级一致（仅行内 \i \b \u \s \c \fs 这些旧就支持的 span 样式照旧生效——那是本开关
   /// 出现前既有行为、不受影响）。
   final bool respectAssStyle;
+
+  /// 尊重 .ass 模式下的**用户字号倍率**（mpv `sub-scale` 同语义，BUG-903）。
+  ///
+  /// 此前 [respectAssStyle] 开时 ASS 绝对字号完全接管、[fontSize] 滑块失效——用户要调
+  /// 大小只能关掉尊重开关（又会失去自带样式，特效字幕塌成叠印乱字）。本倍率乘在 ASS
+  /// 字号换算出的 em 上：页面传「用户字号基准 / 默认 36」，默认基准时 =1.0（完全按作者
+  /// 字号，mpv 平价基线不变），滑块±即整体缩放。只乘字号，不乘描边/阴影/字间距/边距
+  /// （对齐 mpv `sub-scale` 只缩文字的语义）；不含屏幕自适应因子（ASS 路径已按显示区
+  /// 几何缩放，再叠屏幕因子会双重放大）。respectAssStyle 关时不参与（[fontSize] 直用）。
+  final double assUserFontScale;
 
   /// 听力沉浸「模糊态」的高斯模糊 sigma（逻辑像素）。以前是硬编码 8——一个只对默认字号
   /// 36 勉强够用的绝对值（8/36≈0.22×字宽），用户把字幕字号调大后同样的 8px 相对字形就
@@ -642,8 +653,14 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
         // 的 cue 归一堆叠、不同位置各自成组独立定位。副字幕不再被无条件塞进一个顶部盒：带显式
         // 位置（\pos 或 \an，即 ASS 副字幕）的组遵自带位置；纯 SRT 副字幕（anchor / pos 皆空）
         // 无位置信息才在 [_positionCueGroup] 里回退置顶（翻译参考，避让主字幕底部）。
-        final List<(String, List<AudioCue>)> groups =
-            _groupMainCuesByPosition(cues);
+        //
+        // respectAssStyle 关 = **纯字幕模式**（asbplayer 语义，BUG-903）：不但样式统一，
+        // 位置/层/边距也统一——全部 cue 折进**一个**底部组（副字幕仍置顶），并按文本去重
+        // （KFX/多层特效把一句拆成多条同时事件，样式被统一后只剩裸文本拷贝，同位叠印成
+        // 乱字——正是「样式不尊重、位置却尊重」的半吊子语义的病根；文本互异的堆叠分行）。
+        final List<(String, List<AudioCue>)> groups = widget.respectAssStyle
+            ? _groupMainCuesByPosition(cues)
+            : <(String, List<AudioCue>)>[('plain', _uniqueByText(cues))];
 
         final List<(String, Widget)> positioned = <(String, Widget)>[
           for (final (String key, List<AudioCue> group) in groups)
@@ -702,6 +719,17 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
       clipper: _AssClipClipper(clip: clip, videoW: videoW, videoH: videoH),
       child: child,
     );
+  }
+
+  /// 纯字幕模式（respectAssStyle 关，BUG-903）：按 `text` 去重、保留发现顺序。KFX/
+  /// 多层卡拉 OK 的同句多层拷贝（样式统一后内容全同）只渲染一条；文本互异的保留（由
+  /// 单组竖排堆叠、不叠印）。respectAssStyle 开不走本路径（层语义由分组键承载）。
+  List<AudioCue> _uniqueByText(List<AudioCue> cues) {
+    final Set<String> seen = <String>{};
+    return <AudioCue>[
+      for (final AudioCue cue in cues)
+        if (seen.add(cue.text)) cue,
+    ];
   }
 
   /// TODO-1341：把主字幕活动集按「有效定位」（\pos 分数 + 锚点，或纯锚点）分组，保留发现
@@ -951,7 +979,11 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     // （\pos 或 \an，即 ASS 副字幕）遵其自带位置（各遵自带位置，消除「副字幕总被拽到顶部」的
     // 降级）；纯 SRT 副字幕（anchor / pos 皆空、无位置信息）才回退强制置顶（翻译参考，避让主
     // 字幕底部，与历史一致）。
-    final SubtitleMarkup? ownMarkup = cues.first.markup;
+    // 纯字幕模式（respectAssStyle 关，BUG-903）：位置语义整体归零——\pos / \an / MarginV /
+    // \move 全不参与，主字幕恒底部居中基线、副字幕恒置顶（asbplayer 语义）。ownMarkup 置
+    // null 让下游 ownPos / ownAnchor / posMarkup / margins 全走「无位置信息」分支，零特例。
+    final SubtitleMarkup? ownMarkup =
+        widget.respectAssStyle ? cues.first.markup : null;
     // 副字幕默认置顶（翻译参考，避让主字幕底部对白）；但若它自带**非底部**位置——\pos，或
     // \an 顶部 / 中部（作者本就把它放在别处，如顶部歌词 / 招牌 / 中部注释）——则遵其自带位置，
     // 不再硬拽到顶（消除「副字幕总被降级到顶部」）。自带底部 / 无位置的副字幕（纯 SRT、\an2
@@ -1625,10 +1657,12 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
             : _fontWeight(widget.fontWeight));
     final bool baseItalic = respect && (cue?.italic ?? false);
     // ASS 字号 → em：先按 PlayRes 占比缩放，再按字体 cell/em 系数校准
-    // （libass REAL_DIM 语义，见 [_assFontSizeToEm]），最后夹上限。
+    // （libass REAL_DIM 语义，见 [_assFontSizeToEm]），再乘用户字号倍率
+    // （[VideoSubtitleOverlay.assUserFontScale]，mpv sub-scale 语义，BUG-903），最后夹上限。
     final double baseFontSize = cueFontPx != null
-        ? _scaleAssFontSize(_assFontSizeToEm(
-            cueFontPx * assFontScale, baseFontFamily, baseWeight, baseItalic))
+        ? _scaleAssFontSize(_assFontSizeToEm(cueFontPx * assFontScale,
+                baseFontFamily, baseWeight, baseItalic) *
+            widget.assUserFontScale)
         : widget.fontSize;
 
     final TextStyle base = TextStyle(
@@ -1691,10 +1725,11 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
       fontSize: span.fontSizePx != null
           ? (respect
               ? _scaleAssFontSize(_assFontSizeToEm(
-                  span.fontSizePx! * assFontScale,
-                  spanFontFamily ?? baseFontFamily,
-                  span.bold ? FontWeight.bold : baseWeight,
-                  span.italic || baseItalic))
+                      span.fontSizePx! * assFontScale,
+                      spanFontFamily ?? baseFontFamily,
+                      span.bold ? FontWeight.bold : baseWeight,
+                      span.italic || baseItalic) *
+                  widget.assUserFontScale)
               : span.fontSizePx!)
           : base.fontSize,
       decoration: decos.isEmpty ? null : TextDecoration.combine(decos),

--- a/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
@@ -397,6 +397,12 @@ extension _VideoLayout on _VideoHibikiPageState {
                           // TODO-1105：尊重 .ass 自带样式（字体/主色/描边/阴影）。开关默认开；
                           // 关时 overlay 全走上面的统一样式，外观与历史像素级一致。
                           respectAssStyle: appModel.videoRespectAssStyle,
+                          // BUG-903：尊重模式下用户字号滑块=ASS 字号的整体倍率（mpv
+                          // sub-scale 语义）。用**用户基准/默认 36**而非上面已乘屏幕因子的
+                          // fontSize——ASS 路径按显示区几何缩放已与 mpv 同源，再叠屏幕
+                          // 因子会双重放大；默认基准 36 → 1.0 = 完全按作者字号。
+                          assUserFontScale: _subtitleStyle.fontSize /
+                              VideoSubtitleStyle.defaults.fontSize,
                         ),
                       ),
                       _buildOsdOverlay(),

--- a/hibiki/test/media/video/video_subtitle_ass_user_scale_plain_mode_test.dart
+++ b/hibiki/test/media/video/video_subtitle_ass_user_scale_plain_mode_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_player_controller.dart';
+import 'package:hibiki/src/media/video/video_subtitle_overlay.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+/// BUG-903 守卫：
+/// ① 尊重 .ass 模式下用户字号滑块 = ASS 字号的整体倍率（mpv `sub-scale` 语义，
+///   [VideoSubtitleOverlay.assUserFontScale]）；默认 1.0 完全按作者字号（mpv 平价基线）。
+/// ② respectAssStyle 关 = 纯字幕模式（asbplayer 语义）：\pos/\an/层/边距全不参与——主
+///   字幕恒底部居中、同文本多层拷贝（KFX 特效层）去重只渲染一条、文本互异的竖排堆叠。
+///   旧行为「样式不尊重、位置却尊重」把特效层渲染成同位叠印乱字（用户截图）。
+const String _kAssHead = r'''
+[Script Info]
+PlayResX: 1280
+PlayResY: 720
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: D,Arial,48,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,2,10,10,20,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+''';
+
+List<AudioCue> _parse(String dialogues) =>
+    AssParser.parseString(content: '$_kAssHead$dialogues\n', bookKey: 'sc');
+
+Future<VideoPlayerController> _pump(
+  WidgetTester tester,
+  List<AudioCue> cues, {
+  required bool respect,
+  double assUserFontScale = 1.0,
+}) async {
+  final VideoPlayerController c = VideoPlayerController();
+  addTearDown(c.dispose);
+  // 视频分辨率与测试面同比（800×600 vs 1280×720 皆 4:3? 否）：给 \pos 映射用；
+  // 16:9 内容在 800×600 面上 letterbox，位置断言只看相对关系不钉像素。
+  c.debugVideoWidthOverride = 1280;
+  c.debugVideoHeightOverride = 720;
+  c.setCues(cues);
+  c.debugSetPositionForTesting(500);
+  c.debugUpdateCueForPosition(500);
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: VideoSubtitleOverlay(
+        controller: c,
+        respectAssStyle: respect,
+        assUserFontScale: assUserFontScale,
+      ),
+    ),
+  ));
+  await tester.pump();
+  return c;
+}
+
+Text _fill(WidgetTester tester, String ch) => tester
+    .widgetList<Text>(find.text(ch))
+    .firstWhere((Text t) => t.style?.foreground == null);
+
+void main() {
+  group('① assUserFontScale（mpv sub-scale 语义）', () {
+    testWidgets('默认 1.0：ASS 字号按显示几何缩放，完全按作者字号（基线不变）',
+        (WidgetTester tester) async {
+      await _pump(
+          tester, _parse(r'Dialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,あ'),
+          respect: true);
+      // 视频内容矩形高 = 800×(720/1280)=450 → 48×450/720 = 30（测试环境无真字体表，
+      // cell 系数 1.0）。
+      expect(_fill(tester, 'あ').style?.fontSize, closeTo(30, 0.01));
+    });
+
+    testWidgets('1.5 倍：ASS 字号整体放大 1.5×；描边不随之缩放（sub-scale 只缩文字）',
+        (WidgetTester tester) async {
+      await _pump(
+          tester, _parse(r'Dialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,あ'),
+          respect: true, assUserFontScale: 1.5);
+      expect(_fill(tester, 'あ').style?.fontSize, closeTo(45, 0.01));
+      // 描边宽不乘用户倍率：Outline=2 → 半径 2×450/720=1.25 → strokeWidth ×2 = 2.5。
+      final Text stroke = tester
+          .widgetList<Text>(find.text('あ'))
+          .firstWhere((Text t) => t.style?.foreground != null);
+      expect(stroke.style!.foreground!.strokeWidth, closeTo(2.5, 0.01));
+    });
+  });
+
+  group('② respectAssStyle 关 = 纯字幕模式（asbplayer 语义）', () {
+    testWidgets('同文本多层拷贝（KFX 特效层）去重：只渲染一条', (WidgetTester tester) async {
+      await _pump(
+          tester,
+          _parse('Dialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,'
+              r'{\pos(400,300)}重'
+              '\nDialogue: 1,0:00:00.00,0:00:02.00,D,,0,0,0,,'
+              r'{\pos(400,300)\1a&HFF&}重'),
+          respect: false);
+      // 纯字幕模式：同文本两层只渲染一条（respect 开时两层各 stroke+fill 同位叠画）。
+      expect(find.text('重'), findsOneWidget);
+    });
+
+    testWidgets(r'\pos 顶部招牌 + 底部对白：位置语义归零，都落底部堆叠、不叠印',
+        (WidgetTester tester) async {
+      await _pump(
+          tester,
+          _parse('Dialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,'
+              r'{\pos(200,50)}甲'
+              '\nDialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,乙'),
+          respect: false);
+      final Rect a = tester.getRect(find.text('甲'));
+      final Rect b = tester.getRect(find.text('乙'));
+      // \pos(200,50)（顶部）被忽略：两条都在测试面下半部（600 高 → dy>300）。
+      expect(a.top, greaterThan(300), reason: '纯字幕模式忽略 \\pos，恒底部');
+      expect(b.top, greaterThan(300));
+      // 竖排堆叠、不叠印（矩形不相交）。
+      expect(a.intersect(b).isEmpty, isTrue, reason: '文本互异的同时字幕必须分行堆叠，不得同位叠印');
+    });
+
+    testWidgets('respect 开：\\pos 招牌仍按自带位置（本修复不回归 ON 路径）',
+        (WidgetTester tester) async {
+      await _pump(
+          tester,
+          _parse('Dialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,'
+              r'{\pos(200,50)}甲'
+              '\nDialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,乙'),
+          respect: true);
+      // respect 开时每字符渲染 stroke+fill 两层 Text（同位），取 first 即可。
+      final Rect a = tester.getRect(find.text('甲').first);
+      final Rect b = tester.getRect(find.text('乙').first);
+      // \pos y=50/720 → 上半部；对白仍底部。
+      expect(a.top, lessThan(300), reason: 'respect 开时 \\pos 顶部招牌在上半部');
+      expect(b.top, greaterThan(300));
+    });
+  });
+}

--- a/hibiki/test/media/video/video_subtitle_dual_position_test.dart
+++ b/hibiki/test/media/video/video_subtitle_dual_position_test.dart
@@ -70,11 +70,13 @@ void main() {
       expect(c.activeCues.map((AudioCue e) => e.text).toList(),
           <String>['上', '下']);
 
-      await _pump(tester, VideoSubtitleOverlay(controller: c));
+      // BUG-903：ASS 定位现属「尊重 .ass」语义（respectAssStyle 关=纯字幕模式恒底部）。
+      await _pump(
+          tester, VideoSubtitleOverlay(controller: c, respectAssStyle: true));
 
-      // 默认统一外观：每字单层 Text（Niratan 软投影），两条都在屏 → 各 1 个。
-      expect(find.text('上'), findsOneWidget);
-      expect(find.text('下'), findsOneWidget);
+      // 尊重 .ass（BUG-903 起定位属尊重语义）：每字 stroke+fill 两层 Text → 各 2 个。
+      expect(find.text('上'), findsNWidgets(2));
+      expect(find.text('下'), findsNWidgets(2));
 
       final Rect overlayRect =
           tester.getRect(find.byType(VideoSubtitleOverlay));
@@ -101,7 +103,9 @@ void main() {
 
       // 位置 2500：currentCue 为其一。
       c.debugUpdateCueForPosition(2500);
-      await _pump(tester, VideoSubtitleOverlay(controller: c));
+      // BUG-903：ASS 定位现属「尊重 .ass」语义（respectAssStyle 关=纯字幕模式恒底部）。
+      await _pump(
+          tester, VideoSubtitleOverlay(controller: c, respectAssStyle: true));
       final Rect r1 = tester.getRect(find.byType(VideoSubtitleOverlay));
       final double top1 = tester.getCenter(find.text('上').first).dy;
       final double bottom1 = tester.getCenter(find.text('下').first).dy;
@@ -165,7 +169,9 @@ void main() {
             start: 2000, end: 8000),
       ]);
       c.debugUpdateCueForPosition(3000);
-      await _pump(tester, VideoSubtitleOverlay(controller: c));
+      // BUG-903：ASS 定位现属「尊重 .ass」语义（respectAssStyle 关=纯字幕模式恒底部）。
+      await _pump(
+          tester, VideoSubtitleOverlay(controller: c, respectAssStyle: true));
       final Rect overlayRect =
           tester.getRect(find.byType(VideoSubtitleOverlay));
       expect(tester.getCenter(find.text('一').first).dy,

--- a/hibiki/test/media/video/video_subtitle_overlay_markup_test.dart
+++ b/hibiki/test/media/video/video_subtitle_overlay_markup_test.dart
@@ -35,6 +35,8 @@ void main() {
       home: Scaffold(
         body: VideoSubtitleOverlay(
           controller: c,
+          // BUG-903：\an 定位现属「尊重 .ass」语义（关=纯字幕模式恒底部堆叠）。
+          respectAssStyle: true,
           onCharTap: (String s, int i, Rect r) {
             tappedSentence = s;
             tappedIndex = i;


### PR DESCRIPTION
跟进 PR#233（BUG-891，已合并）。用户复诉：**开着「尊重字幕自带样式」不能调字号；关掉又叠印乱字**（截图：一行对白与特效层同位叠印）——被迫二选一。

## 根因
1. **尊重模式字号不可调**：`_styleForGrapheme` 里 ASS 字号完全接管，用户 fontSize 滑块只在无 ASS 字号时作回退——没有 mpv `sub-scale` 那样的用户倍率通道。
2. **关闭尊重叠印乱字**：respect 关时**样式统一但位置不统一**——\pos/\an/Layer/MarginV 不受门控，而 \1a 透明填充、\fscx、字号、动画全被忽略。KFX/多层特效字幕（一句拆多条同时事件、靠透明层区分）被渲染成多份裸文本按作者坐标叠画 → 叠印乱字。半吊子语义即病根。

## 修复（commit 0886c2bd6）
- **尊重开**：新增 `VideoSubtitleOverlay.assUserFontScale`（mpv `sub-scale` 语义）——ASS 字号换算 em 后乘倍率；页面传 `用户字号基准/默认36`，默认 =1.0 完全按作者字号（mpv 平价基线不变）。只缩文字不缩描边/阴影/边距；不叠屏幕自适应因子（防双重放大）。
- **尊重关 = 纯字幕模式**（asbplayer 语义，行为变化·有意）：位置/层/边距语义归零——全部 cue 底部堆叠（副字幕仍置顶）+ 按文本去重（特效层拷贝只渲染一条）。\an8/\pos 定位现属「尊重」语义（开关默认开，关=明确选择统一简洁外观）。

## 测试
- 新 `video_subtitle_ass_user_scale_plain_mode_test.dart`：倍率默认基线不变 / 1.5× 只缩文字不动描边 / 同文本多层去重 / \pos 顶部招牌落底堆叠不叠印 / respect 开 \pos 不回归。
- `dual_position` / `overlay_markup` 的 \an 定位测试改显式 `respectAssStyle: true`（语义迁移）。
- 全量 flutter test **11820 过**（唯一失败 `home_video_remote_download_register_test` 在干净基底同样失败，环境性既有问题）；`flutter analyze` 0 issue。

## 待真机
- 尊重开：字号滑块拖动 → ASS 字幕整体缩放，默认 36 时与 mpv 一致。
- 尊重关：用户截图那集特效字幕 → 不再叠印（底部堆叠去重）。
- 备注：bug 号按撞号纪律 892→903（PR#231 已占 892/893，在途占到 902）。