### PR TITLE
fix: 审计 Low 弥散项批量根因修复 BUG-911~914（第二轮）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,14 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 890 条。点号进各自文件。
+> 共 894 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-914](bugs/BUG-914-remove-release-diagnostic-noise.md) | ✅ | ✅ | 发布版残留诊断日志/性能打点（查词·弹窗·按句同步热路径） |
+| [BUG-913](bugs/BUG-913-asymmetric-disposal-leak.md) | ✅ | ✅ | 常驻服务/Notifier/provider 未对称释放（泄漏） |
+| [BUG-912](bugs/BUG-912-state-not-reset-on-exception-path.md) | ✅ | ✅ | 异常/取消路径状态不复位（Windows 弹窗资产永久闩 + 长按缺 onLongPressCancel） |
+| [BUG-911](bugs/BUG-911-fail-open-swallow-add-logging.md) | ✅ | ✅ | fail-open 静默吞异常致线上不可诊断（补 ErrorLogService 日志） |
 | [BUG-909](bugs/BUG-909-remove-vertical-forensic-probes.md) | ✅ | ✅ | 移除发布版残留的竖排取证探针（TODO-792/753 系列 + 753-DIAG） |
 | [BUG-908](bugs/BUG-908-lan-sync-server-hardening.md) | ✅ | ✅ | LAN 局域网同步服务器健壮性欠账（token 膨胀 / PROPFIND 同步阻塞 / 写无互斥） |
 | [BUG-907](bugs/BUG-907-danmaku-layout-binary-and-isolate-parse.md) | ✅ | ✅ | 弹幕两项性能缺陷：布局每帧 O(N) 全量扫描 + 20MB sidecar 主 isolate 同步解析 |

--- a/docs/bugs/BUG-911-fail-open-swallow-add-logging.md
+++ b/docs/bugs/BUG-911-fail-open-swallow-add-logging.md
@@ -1,0 +1,26 @@
+## BUG-911 · fail-open 静默吞异常致线上不可诊断（补 ErrorLogService 日志）
+
+- **报告**：2026-07-19（审计复核）
+- **真实性**：✅ 真 bug（沿真实代码路径定位，四处 catch 确认无日志）。
+- **[x] ① 已修复** — 仅补日志，不改任何 fail-open 语义。
+- **[x] ② 已加自动化测试** — `hibiki/test/diagnostics/fail_open_logging_guard_test.dart`（源码扫描守卫，方法体切片锚点）。
+- **备注**：真机复测各失败路径的日志留痕待做。
+
+### 现象
+导出失败、Jimaku 搜索失败、视频观看统计写库失败、阅读统计/位置落盘失败等场景，异常被 catch 静默吞掉（继续降级 / 返回空 / fire-and-forget），线上无任何留痕，无法区分「真的没结果」与「出错了」。
+
+### 根因
+以下 catch 只降级不记日志（`ErrorLogService.instance.log(source, e, [stack])` 用户错误 / `.logDiagnostic(source, info)` 预期网络失败）：
+- `AppModel` yomitan 自启动 `app_model.dart:2049` `.catchError((Object _) {})` 空吞（邻居 startSyncServer 已记日志，唯此不一致）。
+- `collection_exporter.dart:917` `catch (_)` 只 `notify(导出失败)`，异常本体未进日志。
+- `jimaku_client.dart` `_searchEntries:259` / `listFiles:277` / `downloadFile:291` catch 返回空/null；解析兜底 `parseJimakuEntries:95` / `parseJimakuFiles:207` 亦然——搜索失败与「无字幕」不可区分。
+- `video_watch_tracker.dart` `_flush()` 整段 DB 写无 try/catch，由 `Timer.periodic(60s) → unawaited(_flush())` fire-and-forget 调用，异常未捕获静默丢弃。
+- `navigation.part.dart` `_flushReadingStats:1190` 只 `debugPrint`（release 不可见）；`_persistPosition` 的 `repo.save` 无 catch。
+
+### 修复
+只在 catch 补日志，**return/降级/fire-and-forget 语义全部不变**：
+- yomitan：`app_model.dart:2049` catchError 记 `ErrorLogService.instance.log('AppModel.startYomitanApiServer.autostart', e, s)`。
+- 导出：`collection_exporter.dart:920` 记 `log('collectionExport.saveOrShareExport', e, s)`，保留 notify。
+- Jimaku：5 处补 `logDiagnostic('JimakuClient.<method>', e)`（预期网络失败，不刷用户错误计数），仍返回空/null。
+- 观看统计：`video_watch_tracker.dart:_flush()` DB 写段包 try/catch，`:175` `log('VideoWatchTracker.flush', e, st)`，`_tickStart` 复位与早返回留 try 外、异常不冒泡不阻塞播放。
+- 阅读统计/位置：`navigation.part.dart:_flushReadingStats` catch 保留 debugPrint 并补 `log(...)`；`_persistPosition` 的 `repo.save` 包 catch 补 log（fail-open，下次 debounce/flush 重试）。

--- a/docs/bugs/BUG-912-state-not-reset-on-exception-path.md
+++ b/docs/bugs/BUG-912-state-not-reset-on-exception-path.md
@@ -1,0 +1,19 @@
+## BUG-912 · 异常/取消路径状态不复位（Windows 弹窗资产永久闩 + 长按缺 onLongPressCancel）
+
+- **报告**：2026-07-19（审计复核）
+- **真实性**：✅ 真 bug（#2/#3 沿真实代码路径定位）。#1 见备注。
+- **[x] ① 已修复** — #2 去进程级永久闩、#3 补 onLongPressCancel。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/popup_latch_and_longpress_guard_test.dart`（源码扫描守卫）。
+- **备注**：审计点名的 #1「temporarilyDisableStatusBarHiding 缺 finally」按当前代码**未能定位到该方法名/语义**——该标识符全仓不存在；最接近的 `openMedia` 沉浸设定本就是「持续隐藏到 closeMedia」的有意设计，且视频页等价路径 `_restoreSystemUiOnExit` 已有 dispose 还原 + `video_statusbar_immersive_guard_test` 守卫。按「不修臆想缺陷」原则，#1 标为**未定位/疑似已消解**，不武断改动核心媒体打开流程。
+
+### 现象
+- Windows 弹窗词典偶发永久降级到不可靠的 `file://` 加载：一次读盘异常后，之后整个进程再不尝试内联资产。
+- 有声书快捷设置里的 +/- 长按连触按钮：手指滑出取消（而非正常松手）时，数值持续狂涨/狂降不停。
+
+### 根因
+- **#2 Windows 资产永久闩** `dictionary_popup_webview.dart`：`static bool _inlineAssetsLoadFailed`，门控 `_ensureInlinePopupAssetsLoaded()` `if (_inlineCss != null || _inlineAssetsLoadFailed) return;`，catch 里 `_inlineAssetsLoadFailed = true`。该闩**只置位无复位**，一次瞬时读盘异常（文件锁/磁盘抖动）即进程级永久 true → 之后早退、内联资产永不重试。
+- **#3 长按 Timer 缺 cancel** `reader_quick_settings_sheet.dart` `_RepeatIconButtonState`：GestureDetector 只挂 `onLongPressStart(_start)`/`onLongPressEnd(_stop)`，**无 `onLongPressCancel`**。手势被取消（指针滑出/识别器被上层竞争夺走）时 `onLongPressEnd` 不必然回调，`_timer` 每 100ms 连触 `onPressed()` 直到 widget dispose。孪生实现 `video_hibiki_page.dart:6202` `_VideoRepeatGestureButton` 已正确挂 `onLongPressCancel: _stop`，此处漏了。
+
+### 修复
+- #2：删 `_inlineAssetsLoadFailed` 字段，门控收敛为 `if (_inlineCss != null) return;`（成功后 `_inlineCss` 非空已足以防重复读盘），catch 保留 `debugPrint` + `ErrorLogService.log`；失败后下次唤起自然重试，不再永久降级。
+- #3：`_RepeatIconButton` 的 GestureDetector 补 `onLongPressCancel: () => _stop()`，与视频页孪生对齐。

--- a/docs/bugs/BUG-913-asymmetric-disposal-leak.md
+++ b/docs/bugs/BUG-913-asymmetric-disposal-leak.md
@@ -1,0 +1,20 @@
+## BUG-913 · 常驻服务/Notifier/provider 未对称释放（泄漏）
+
+- **报告**：2026-07-19（审计复核）
+- **真实性**：✅ 真 bug（对照 initialise/dispose 确认只起未关）。
+- **[x] ① 已修复** — dispose 补关 4 个常驻服务 + 2 个 family 加 autoDispose + notifier 补 dispose。
+- **[x] ② 已加自动化测试** — `hibiki/test/models/app_model_audit_hardening_guard_test.dart`（dispose 体切片断言含 4 个 stop + syncServer dispose、两 family 含 `.autoDispose`）；base_source dispose 守卫在 `hibiki/test/lookup/dict_perf_probe_removal_guard_test.dart`。
+- **备注**：AppModel 无法在单测实例化，取源码扫描守卫为最强可落地层。
+
+### 现象
+退出/切换后台仍有后台 socket/WS 连接、轮询 Timer、HttpServer bind 常驻；长会话内查词越多，provider 实例只增不减，内存单调增长。
+
+### 根因
+- **`AppModel.dispose`（app_model.dart）漏关 4 个 initialise 起的常驻子系统**：LAN sync server（`syncServerController.startIfEnabled()` @2029）、texthooker（`TexthookerWsClientHost.instance.start` @2060）、yomitan（`startYomitanApiServer()` @2048）、anime 下载服务（`AnimeDownloadService..start()` @2072）。它们各自的 `stop()` 都存在，但 dispose 从未调用——纯只起未关泄漏。
+- **family provider 无界累积**：`quickActionColorProvider`（`FutureProvider.family`，:150）与 `visibleOnceProvider`（`StateProvider.family`，:168）key 为 `DictionaryEntry`，无 autoDispose，随查词单调增长（前者还缓存整份颜色 Map）。
+- **`_isSearchingNotifier`**（`base_source_page.dart:118` ValueNotifier）创建后从未 dispose，且被 `Listenable.merge` 挂监听，泄漏面更实。
+
+### 修复
+- `dispose()` 在 `super.dispose()` 之前、走现有 notifier/repo dispose 之前，补 fire-and-forget 停 4 个常驻服务：`unawaited(syncServerController.stop())` + `syncServerController.dispose()`（包 `if (_isInitialised)`，与现有 dictRepo 守卫一致）、`TexthookerWsClientHost.instance.stop()`（单例安全）、`unawaited(stopYomitanApiServer())`（null 安全）、`_animeDownloadService?.stop()`（其 stop 是同步 `void`，不 unawaited）。不动 initialise 启动逻辑。
+- 两 family 改 `.autoDispose.family`（弹窗内联颜色/一次性可见标记，弹窗关即应释放，autoDispose 语义正确）。reader Language family 有界，不动。
+- `base_source_page.dart` dispose 在 `super.dispose()` 前补 `_isSearchingNotifier.dispose()`。

--- a/docs/bugs/BUG-914-remove-release-diagnostic-noise.md
+++ b/docs/bugs/BUG-914-remove-release-diagnostic-noise.md
@@ -1,0 +1,25 @@
+## BUG-914 · 发布版残留诊断日志/性能打点（查词·弹窗·按句同步热路径）
+
+- **报告**：2026-07-19（审计复核）
+- **真实性**：✅ 真问题（裸 `debugPrint`/`print`/`Stopwatch` 落在按句/按查词热路径，`debugPrint` release 不剥离）。
+- **[x] ① 已清理** — 移除探针簇 + 收敛因探针而生的死代码。
+- **[x] ② 已加自动化测试** — 源码扫描守卫：`hibiki/test/lookup/dict_perf_probe_removal_guard_test.dart`、`hibiki/test/media/audiobook/audiobook_probe_removal_guard_test.dart`、`hibiki/test/pages/popup_latch_and_longpress_guard_test.dart`、`hibiki/test/models/app_model_audit_hardening_guard_test.dart`。
+- **备注**：竖排 `[792-*]`/`[753-DIAG]` 探针已由 BUG-902 单独移除，不在本条。`integration_test/lookup_latency_perf_itest.dart` 的 latency 探针是有意的性能测试，保留。
+
+### 现象
+release 构建下每次查词 / 每次弹窗推送 / 播放期每句高亮都打印 `[dict-perf]` / `[popup-perf]` / `[video-lookup]` / `[hibiki-autoread]` / `[sasayaki-hl]` / `[hibiki-crossChapter]` trace，污染日志、吃 UI 线程。
+
+### 根因
+一簇取证已完成的临时性能探针散落在最热路径上、无 `kDebugMode` 门控：
+- 查词核心 `app_model.dart`：`normalizeSearchTerm` 三段 Stopwatch + `searchDictionary` 6 处 `[dict-perf]` debugPrint；探针耦合出一个 `NormalizedSearchTerm` record（三个 `*Micros` 字段纯为打点）。
+- FFI `hoshidicts.dart` `[dict-perf] native call/convert`；历史落库 `dictionary_repository.dart` `[dict-perf] persistHistory`。
+- 弹窗/结果 UI：`base_source_page.dart`、`dictionary_page_mixin.dart`、`popup_dictionary_page.dart`（`[popup-perf]`）、`dictionary_popup_webview.dart`（`[dict-perf] evaluateJavascript`）、`video_hibiki/lookup_favorite.part.dart`（`[video-lookup]`）。
+- autoread `lookup_audio_playback.dart` `[hibiki-autoread]`。
+- 按句同步 `audiobook_bridge.dart`（`[sasayaki-hl]` 逐 cue）、`audiobook_controller.dart`（`[hibiki-crossChapter]` print）。
+
+### 修复
+逐个核实为纯观测（无副作用）后移除 debugPrint/print/Stopwatch 及调用点，并收敛因探针而生的死代码：
+- `NormalizedSearchTerm` typedef 删除，`normalizeSearchTerm` 返回类型收敛为 `String`（保留 emoji/标点/surrogate 清洗逻辑本身），同步改调用点与 `app_model_search_pure_logic_test.dart`。
+- `audiobook_controller.dart` 删打点后 `_maybeEmitCrossChapter` 的 `quiet` 参数变死 plumbing，一并移除（签名/调用点/空 if 包裹）。
+- `lookup_audio_playback.dart` 删打点后 `flutter/foundation.dart` import 与 `ok`/`sources` 局部变量变死，一并清理。
+- 保留：catch 里的错误日志、`[Hibiki] init:` 一次性启动日志、ErrorLogService 管道、参与控制流的功能性 Stopwatch。

--- a/hibiki/lib/src/media/audiobook/audiobook_bridge.dart
+++ b/hibiki/lib/src/media/audiobook/audiobook_bridge.dart
@@ -456,9 +456,6 @@ window.__hoshiAnnotate = function(chapterHref) {
     // 的 textFragmentId='[data-cue-id=...]'）走普通 __hoshiHighlight，完全不碰
     // sasayaki 高亮系统——即使 setup 期建了 range 也不会激活 ::highlight。
     // TODO-724：pauseEnabled = imagePauseSec>0；仅它为真时跨图才滚到插图。
-    debugPrint('[sasayaki-hl] highlight raw="$raw" '
-        'frag=${frag == null ? "NULL->__hoshiHighlight(non-sasayaki)" : "sasayaki"} '
-        'reveal=$reveal pauseEnabled=$pauseEnabled');
     if (frag != null) {
       await controller.evaluateJavascript(
         source: 'if(typeof __hoshiHighlightSasayakiCueById!=="undefined")'
@@ -556,9 +553,6 @@ window.__hoshiAnnotate = function(chapterHref) {
     final List<Map<String, dynamic>> payload =
         buildSasayakiPayload(cues, sectionIndex);
     if (payload.isEmpty) {
-      // BUG-366/TODO-630 诊断：payload 空 → JS __hoshiApplySasayakiCues 不被调用。
-      debugPrint('[sasayaki-hl] applySasayakiCues section=$sectionIndex '
-          'EMPTY payload (cues=${cues.length}) -> JS not invoked');
       return;
     }
     final String json = jsonEncode(payload);

--- a/hibiki/lib/src/media/audiobook/reader_quick_settings_sheet.dart
+++ b/hibiki/lib/src/media/audiobook/reader_quick_settings_sheet.dart
@@ -2013,6 +2013,11 @@ class _RepeatIconButtonState extends State<_RepeatIconButton> {
     return GestureDetector(
       onLongPressStart: (_) => _start(),
       onLongPressEnd: (_) => _stop(),
+      // BUG-912 #3：手势被取消（指针滑出 / 识别器被上层夺走）而非正常 End 时，
+      // onLongPressEnd 不必然回调；不补 cancel 的话 _timer 会持续每 100ms 连触
+      // widget.onPressed()（数值狂涨 / 狂降）直到 dispose。与 video_hibiki_page.dart
+      // 的 _VideoRepeatGestureButton 对齐。
+      onLongPressCancel: () => _stop(),
       child: HibikiIconButton(
         icon: widget.icon,
         size: 18,

--- a/hibiki/lib/src/media/video/jimaku_client.dart
+++ b/hibiki/lib/src/media/video/jimaku_client.dart
@@ -3,6 +3,8 @@ import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 
+import 'package:hibiki/src/utils/misc/error_log_service.dart';
+
 import 'package:hibiki/src/media/video/video_filename_parser.dart';
 
 /// Jimaku（jimaku.cc）字幕条目：一个番剧/作品。
@@ -88,7 +90,10 @@ List<JimakuEntry> parseJimakuEntries(String body) {
       ));
     }
     return out;
-  } catch (_) {
+  } catch (e) {
+    // fail-open：解析失败返回空列表（同旧行为），补 diagnostic 便于排障。
+    ErrorLogService.instance
+        .logDiagnostic('JimakuClient.parseJimakuEntries', e);
     return const <JimakuEntry>[];
   }
 }
@@ -198,7 +203,9 @@ List<JimakuFile> parseJimakuFiles(String body) {
       ));
     }
     return out;
-  } catch (_) {
+  } catch (e) {
+    // fail-open：解析失败返回空列表（同旧行为），补 diagnostic 便于排障。
+    ErrorLogService.instance.logDiagnostic('JimakuClient.parseJimakuFiles', e);
     return const <JimakuFile>[];
   }
 }
@@ -248,7 +255,9 @@ class JimakuClient {
       final http.Response res = await _client.get(uri, headers: _headers);
       if (res.statusCode != 200) return const <JimakuEntry>[];
       return parseJimakuEntries(res.body);
-    } catch (_) {
+    } catch (e) {
+      // fail-open：预期可失败的网络路径，返回空列表（同旧行为），补 diagnostic。
+      ErrorLogService.instance.logDiagnostic('JimakuClient.searchEntries', e);
       return const <JimakuEntry>[];
     }
   }
@@ -264,7 +273,9 @@ class JimakuClient {
       final http.Response res = await _client.get(uri, headers: _headers);
       if (res.statusCode != 200) return const <JimakuFile>[];
       return parseJimakuFiles(res.body);
-    } catch (_) {
+    } catch (e) {
+      // fail-open：预期可失败的网络路径，返回空列表（同旧行为），补 diagnostic。
+      ErrorLogService.instance.logDiagnostic('JimakuClient.listFiles', e);
       return const <JimakuFile>[];
     }
   }
@@ -276,7 +287,9 @@ class JimakuClient {
           await _client.get(Uri.parse(fileUrl), headers: _headers);
       if (res.statusCode != 200) return null;
       return res.bodyBytes;
-    } catch (_) {
+    } catch (e) {
+      // fail-open：预期可失败的网络路径，返回 null（同旧行为），补 diagnostic。
+      ErrorLogService.instance.logDiagnostic('JimakuClient.downloadFile', e);
       return null;
     }
   }

--- a/hibiki/lib/src/media/video/video_watch_tracker.dart
+++ b/hibiki/lib/src/media/video/video_watch_tracker.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:hibiki/src/media/video/video_playback_source.dart';
+import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki/src/utils/misc/hibiki_time_format.dart';
 
 /// 完成判定纯函数：进度 ≥ 90% 且尚未完成、且时长已知。
@@ -150,21 +151,28 @@ class VideoWatchTracker {
     _tickStart = now;
     if (s == null || start == null) return;
 
-    // 仅在连续前台播放窗口内累加：[isContinuousWatchGap] 过滤异常大间隔（后台挂起 /
-    // 系统睡眠 / 长 GC 停顿致定时器跨越非播放窗口），整窗丢弃而非凭空计入观看时长，
-    // 并保证 [splitWatchTime] 输入恒 ≤ kMaxWatchGap（单次至多跨一个边界）。
-    if (s.isPlaying && isContinuousWatchGap(start, now)) {
-      for (final (String dateKey, int hour, int ms)
-          in splitWatchTime(start, now)) {
-        await _addHourly?.call(dateKey, hour, ms);
-        // 逐桶配各自 dateKey：跨午夜正确归两天。
-        await _addStat(title, dateKey, 0, ms);
+    // 周期 tick 经 `unawaited(_flush())` fire-and-forget 调用，DB 写异常无处捕获会被
+    // 静默丢弃且线上不可诊断。整段 DB 写包 try/catch：fail-open（异常不冒泡、不阻塞
+    // 播放，仅丢本次统计增量），并补 ErrorLogService.log 使其可诊断。
+    try {
+      // 仅在连续前台播放窗口内累加：[isContinuousWatchGap] 过滤异常大间隔（后台挂起 /
+      // 系统睡眠 / 长 GC 停顿致定时器跨越非播放窗口），整窗丢弃而非凭空计入观看时长，
+      // 并保证 [splitWatchTime] 输入恒 ≤ kMaxWatchGap（单次至多跨一个边界）。
+      if (s.isPlaying && isContinuousWatchGap(start, now)) {
+        for (final (String dateKey, int hour, int ms)
+            in splitWatchTime(start, now)) {
+          await _addHourly?.call(dateKey, hour, ms);
+          // 逐桶配各自 dateKey：跨午夜正确归两天。
+          await _addStat(title, dateKey, 0, ms);
+        }
       }
-    }
 
-    if (shouldMarkCompleted(s.positionMs, s.durationMs, _completed)) {
-      _completed = true;
-      await _markCompleted(bookUid);
+      if (shouldMarkCompleted(s.positionMs, s.durationMs, _completed)) {
+        _completed = true;
+        await _markCompleted(bookUid);
+      }
+    } catch (e, st) {
+      ErrorLogService.instance.log('VideoWatchTracker.flush', e, st);
     }
   }
 }

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -147,9 +147,8 @@ final appProvider = ChangeNotifierProvider<AppModel>((ref) {
 });
 
 /// Provides color for all quick actions.
-final quickActionColorProvider =
-    FutureProvider.family<Map<String, Color?>, DictionaryEntry>(
-        (ref, entry) async {
+final quickActionColorProvider = FutureProvider.autoDispose
+    .family<Map<String, Color?>, DictionaryEntry>((ref, entry) async {
   AppModel appModel = ref.watch(appProvider);
   // Key each color to its action's uniqueKey in a single pass; a positional
   // colors[i] join would silently mismap if iteration order ever diverged.
@@ -165,8 +164,8 @@ final quickActionColorProvider =
 });
 
 /// A global [Provider] for maintaining visible once state.
-final visibleOnceProvider =
-    StateProvider.family<bool, DictionaryEntry>((ref, entry) => false);
+final visibleOnceProvider = StateProvider.autoDispose
+    .family<bool, DictionaryEntry>((ref, entry) => false);
 
 /// A global [Provider] for listening to search term changes in PIP mode.
 final pipSearchTermProvider = StateProvider<String>((ref) => '');
@@ -257,26 +256,14 @@ typedef DictPathEntry = ({
   return (term: term, freq: freq, pitch: pitch, kanji: kanji);
 }
 
-/// [normalizeSearchTerm] 的返回：清洗后的查询串 + 三步替换各自的微秒耗时，供
-/// `[dict-perf]` 打点逐字段读取（耗时本身是可观测性数据，不影响查询结果）。
-typedef NormalizedSearchTerm = ({
-  String term,
-  int emojiMicros,
-  int punctMicros,
-  int surrogateMicros,
-});
-
 /// 词典查询前的查询串清洗单一真相：换行折空格 → emoji 去除 → 首尾标点/符号剥离 →
-/// 孤立代理项替换。此前 4 步 replaceAll 散在 [AppModel.searchDictionary] 内、与多个
-/// Stopwatch 打点交织，无法单测（依赖整页 AppModel + FFI）。纯逻辑（输入→输出确定）
-/// 凿到这里，原调用处仍用 `swPreprocess` 包住总计时、用返回的子计时拼出逐字不变的
-/// `[dict-perf] preprocess` 打点。换行折叠是无条件首步（无独立计时），emoji/punct/
-/// surrogate 三步各自计时随结果返回。
+/// 孤立代理项替换。此前 4 步 replaceAll 散在 [AppModel.searchDictionary] 内，无法单测
+/// （依赖整页 AppModel + FFI）。纯逻辑（输入→输出确定）凿到这里，返回清洗后的查询串。
 ///
 /// 替换契约逐字不变（变=查询语义/缓存键漂移）：`\n`→`' '`、[emojiRegex]→`' '`、
 /// [punctuationRegex]→`''`、[loneSurrogateRegex]→`' '`，顺序固定。
 @visibleForTesting
-NormalizedSearchTerm normalizeSearchTerm(
+String normalizeSearchTerm(
   String searchTerm, {
   required RegExp emojiRegex,
   required RegExp punctuationRegex,
@@ -289,25 +276,10 @@ NormalizedSearchTerm normalizeSearchTerm(
     searchTerm = searchTerm.characters.take(kMaxLookupInputChars).toString();
   }
   searchTerm = searchTerm.replaceAll('\n', ' ');
-
-  final swEmoji = Stopwatch()..start();
   searchTerm = searchTerm.replaceAll(emojiRegex, ' ');
-  swEmoji.stop();
-
-  final swPunct = Stopwatch()..start();
   searchTerm = searchTerm.replaceAll(punctuationRegex, '');
-  swPunct.stop();
-
-  final swSurrogate = Stopwatch()..start();
   searchTerm = searchTerm.replaceAll(loneSurrogateRegex, ' ');
-  swSurrogate.stop();
-
-  return (
-    term: searchTerm,
-    emojiMicros: swEmoji.elapsedMicroseconds,
-    punctMicros: swPunct.elapsedMicroseconds,
-    surrogateMicros: swSurrogate.elapsedMicroseconds,
-  );
+  return searchTerm;
 }
 
 /// [normalizeSearchTerm] 在查词前用 [punctuationRegex]（`^[\p{P}\p{S}]+|[\p{P}\p{S}]+$`）
@@ -2046,7 +2018,12 @@ class AppModel with ChangeNotifier {
         ErrorLogService.instance.log('AppModel.startSyncServer', e, s);
       }));
       if (yomitanApiServerEnabled) {
-        unawaited(startYomitanApiServer().catchError((Object _) {}));
+        // fail-open：自启动失败绝不阻塞 init、不改开关语义，但必须留痕（BUG-911），
+        // 与邻居 startSyncServer / refreshBrowserExtensionCopy 一致记日志，避免静默吞异常。
+        unawaited(startYomitanApiServer().catchError((Object e, StackTrace s) {
+          ErrorLogService.instance
+              .log('AppModel.startYomitanApiServer.autostart', e, s);
+        }));
       }
       // BUG-726：桌面端启动时把 <appSupport> 下已解压的浏览器扩展副本刷新到当前内置版本
       // （只在用户装过扩展、指纹不一致时重解压；没装过不落盘）。此前该副本只在手动跑
@@ -3101,23 +3078,12 @@ class AppModel with ChangeNotifier {
     bool useCache = true,
     bool allowRemoteLookup = true,
   }) async {
-    final swTotal = Stopwatch()..start();
-    final swPreprocess = Stopwatch()..start();
-
-    final NormalizedSearchTerm normalized = normalizeSearchTerm(
+    searchTerm = normalizeSearchTerm(
       searchTerm,
       emojiRegex: _emojiRegex,
       punctuationRegex: _punctuationRegex,
       loneSurrogateRegex: _loneSurrogateRegex,
     );
-    searchTerm = normalized.term;
-
-    swPreprocess.stop();
-    debugPrint('[dict-perf] preprocess: ${swPreprocess.elapsedMilliseconds}ms '
-        '(emoji=${normalized.emojiMicros}µs '
-        'punct=${normalized.punctMicros}µs '
-        'surrogate=${normalized.surrogateMicros}µs) '
-        '"$searchTerm"');
 
     if (searchTerm.trim().isEmpty) {
       return DictionarySearchResult(searchTerm: searchTerm);
@@ -3145,8 +3111,6 @@ class AppModel with ChangeNotifier {
 
     final cached = dictRepo.getCachedSearch(cacheKey);
     if (useCache && cached != null) {
-      swTotal.stop();
-      debugPrint('[dict-perf] cache HIT: ${swTotal.elapsedMilliseconds}ms');
       return cached;
     }
 
@@ -3166,7 +3130,6 @@ class AppModel with ChangeNotifier {
     DictionarySearchResult? result;
 
     if (ffiResults != null) {
-      final swBuild = Stopwatch()..start();
       result = buildResultFromLookup(
         searchTerm: searchTerm,
         results: ffiResults,
@@ -3182,11 +3145,7 @@ class AppModel with ChangeNotifier {
         maximumTerms: effectiveMaxTerms,
       );
       result = result.withKanjiResults(kanjiResults);
-      swBuild.stop();
-      debugPrint(
-          '[dict-perf] FFI cache HIT, buildResult+popupJson: ${swBuild.elapsedMilliseconds}ms entries=${result.entries.length}');
     } else {
-      final swLookup = Stopwatch()..start();
       ffiResults = HoshiDicts.instance.lookup(
         searchTerm,
         maxResults: maximumDictionarySearchResults,
@@ -3206,14 +3165,7 @@ class AppModel with ChangeNotifier {
         );
         result = result.withKanjiResults(kanjiResults);
       }
-      swLookup.stop();
-      debugPrint(
-          '[dict-perf] FFI lookup + build + popupJson: ${swLookup.elapsedMilliseconds}ms entries=${result?.entries.length ?? 0}');
     }
-
-    swTotal.stop();
-    debugPrint(
-        '[dict-perf] searchDictionary total: ${swTotal.elapsedMilliseconds}ms');
 
     if (result != null && result.entries.isNotEmpty) {
       dictRepo.cacheSearchResult(cacheKey, result);
@@ -4006,6 +3958,20 @@ class AppModel with ChangeNotifier {
 
   @override
   void dispose() {
+    // BUG-913：对称释放 initialise() 起的 4 个 app-wide 常驻子系统。dispose 是同步的、
+    // 这些 stop 多为 Future → fire-and-forget（unawaited）；先停常驻服务，再走现有
+    // notifier/repo dispose，最后 super.dispose()。
+    if (_isInitialised) {
+      // syncServerController 是 late final 带初始化器（读即构造）：仅在已 init（即已被
+      // startIfEnabled 构造）时读它，避免「从未 init 却只为销毁而构造」。它既是常驻
+      // 服务又是 ChangeNotifier，故 stop() 后还需 dispose()。
+      unawaited(syncServerController.stop());
+      syncServerController.dispose();
+    }
+    // 其余三个 stop 都 null 安全 / 单例安全，未启动也可调，无需 _isInitialised 守卫。
+    unawaited(TexthookerWsClientHost.instance.stop());
+    unawaited(stopYomitanApiServer());
+    _animeDownloadService?.stop();
     _prefsRepo?.removeListener(notifyListeners);
     if (_themeListenerAdded) {
       themeNotifier.removeListener(notifyListeners);

--- a/hibiki/lib/src/models/dictionary_repository.dart
+++ b/hibiki/lib/src/models/dictionary_repository.dart
@@ -324,7 +324,6 @@ class DictionaryRepository {
 
   Future<void> _flushDictionaryHistory() async {
     _cancelPendingHistoryPersist();
-    final swPersist = Stopwatch()..start();
     final items = <DictionaryHistoryCompanion>[];
     for (int i = 0; i < _dictionaryHistoryResults.length; i++) {
       final DictionarySearchResult r = _dictionaryHistoryResults[i];
@@ -333,13 +332,9 @@ class DictionaryRepository {
         resultJson: _historyJsonMemo[r] ??= r.toJson(),
       ));
     }
-    final swSerialize = swPersist.elapsedMilliseconds;
     // 序列化段与上面的取消/快照在同一同步区间内完成；此后 clear 等竞态由
     // drift 单连接 FIFO 保序（本次写先入队，后续 clear 的 DELETE 后到后赢）。
     await _db.replaceAllDictionaryHistory(items);
-    swPersist.stop();
-    debugPrint(
-        '[dict-perf] persistHistory: serialize=${swSerialize}ms dbWrite=${swPersist.elapsedMilliseconds - swSerialize}ms total=${swPersist.elapsedMilliseconds}ms items=${items.length}');
   }
 
   /// Release in-memory caches. Replaces the inherited ChangeNotifier.dispose

--- a/hibiki/lib/src/pages/base_source_page.dart
+++ b/hibiki/lib/src/pages/base_source_page.dart
@@ -101,6 +101,7 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
     _visibleRenderFailsafeTimer?.cancel();
     // TODO-058：controller 现持有挂起层兜底 Timer，作为其所有者必须 dispose 取消，防泄漏。
     _popup.dispose();
+    _isSearchingNotifier.dispose();
     super.dispose();
   }
 
@@ -213,7 +214,6 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
     final gen = ++_searchGeneration;
     _pendingSelectionRect = selectionRect;
     _deferredPopupItem = null;
-    final swTotal = Stopwatch()..start();
 
     try {
       if (!deferDisplay) {
@@ -227,8 +227,6 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
       );
 
       if (_searchGeneration != gen) return 0;
-
-      final msAfterSearch = swTotal.elapsedMilliseconds;
 
       appModel.addToDictionaryHistory(result: dictionaryResult);
 
@@ -273,9 +271,6 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
         _popup.markPendingReveal(item);
       }
 
-      debugPrint(
-          '[dict-perf] searchDictionaryResult: search=${msAfterSearch}ms pushPopup=${swTotal.elapsedMilliseconds}ms "$searchTerm"');
-
       final int highlightCount = lookupHighlightCharCount(
         result: dictionaryResult,
         searchTerm: searchTerm,
@@ -283,8 +278,6 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
       );
 
       final bool arEnabled = ReaderHibikiSource.instance.autoReadOnLookup;
-      debugPrint(
-          '[hibiki-autoread] autoReadOnLookup=$arEnabled entries=${dictionaryResult.entries.length}');
       if (arEnabled && dictionaryResult.entries.isNotEmpty) {
         final entry = dictionaryResult.entries.first;
         final expression = entry.word;

--- a/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -736,7 +736,6 @@ mixin DictionaryPageMixin {
   }) async {
     final String trimmed = query.trim();
     if (trimmed.isEmpty) return 0;
-    final Stopwatch swPush = Stopwatch()..start();
     final int maxTerms = mixinAppModel.maximumTerms;
     final Rect rect = fallbackSelectionRect(selectionRect);
     final DictionaryPopupEntry entry = controller.beginTop(
@@ -764,9 +763,6 @@ mixin DictionaryPageMixin {
         searchWithWildcards: true,
         overrideMaximumTerms: maxTerms,
       );
-      debugPrint('[dict-perf] pushNestedPopup search done in '
-          '${swPush.elapsedMilliseconds}ms reuseWarm=$reuseWarmSlot '
-          'entries=${result.entries.length} "$trimmed"');
       if (mounted && controller.entries.contains(entry)) {
         setState(() {
           controller.fillResult(

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -810,7 +810,6 @@ JSON.stringify((function(){
           window.resetSelectedDictionaries();
           window.renderPopup();
         ''';
-    final swInject = Stopwatch()..start();
     _controller!.evaluateJavascript(source: '''
       ${staticChanged ? staticSettingsJs : ''}
       $entriesJs
@@ -852,11 +851,7 @@ JSON.stringify((function(){
       };
       $beforeRenderJs
       ${needsScrollCheck ? _scrollCheckJs : ""}
-    ''').then((_) {
-      swInject.stop();
-      debugPrint(
-          '[dict-perf] evaluateJavascript: ${swInject.elapsedMilliseconds}ms');
-    });
+    ''');
   }
 
   /// Ensures the current [widget.result] is (or will be) rendered in the WebView.
@@ -901,20 +896,21 @@ JSON.stringify((function(){
   static String? _inlineDictMediaJs;
   static String? _inlineSelectionJs;
   static String? _inlinePopupJs;
-  static bool _inlineAssetsLoadFailed = false;
 
   static bool get _shouldInlinePopupAssets =>
       isWindowsPlatform || defaultTargetPlatform == TargetPlatform.iOS;
 
   static void _ensureInlinePopupAssetsLoaded() {
-    if (_inlineCss != null || _inlineAssetsLoadFailed) return;
+    // BUG-912 #2：成功后 _inlineCss 非空即可防重复读盘；不再用进程级
+    // 永久失败闩——一次瞬时读盘异常（文件锁 / 磁盘抖动）不该把内联资产
+    // 永久降级到不可靠的 file:// 路径，失败时下次唤起自然重试。
+    if (_inlineCss != null) return;
     try {
       _inlineCss = _readPopupAsset('popup.css');
       _inlineDictMediaJs = _readPopupAsset('dict-media.js');
       _inlineSelectionJs = _readPopupAsset('selection.js');
       _inlinePopupJs = _readPopupAsset('popup.js');
     } catch (e, stack) {
-      _inlineAssetsLoadFailed = true;
       debugPrint('[PopupWebView] Popup asset inlining failed, '
           'falling back to file:// URL loading: $e');
       ErrorLogService.instance

--- a/hibiki/lib/src/pages/implementations/popup_dictionary_page.dart
+++ b/hibiki/lib/src/pages/implementations/popup_dictionary_page.dart
@@ -66,7 +66,6 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
     onLookupStackDepthChanged: recordLookupStackDepth,
   );
   final GlobalKey _resultStackKey = GlobalKey();
-  final Stopwatch _startupStopwatch = Stopwatch()..start();
   bool _isClosing = false;
   String _sourceLookupText = '';
 
@@ -96,7 +95,6 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
     // TODO-1204：接线查词计数（每次查词 +1 → lookup_mining_counters）。
     attachLookupCounter(_popup);
     _sourceLookupText = widget.searchTerm.trim();
-    debugPrint('[popup-perf] init search="${widget.searchTerm}"');
     // TODO-951 症状C：开页 seed 一个常驻隐藏热槽，弹窗 WebView 冷加载一次后全程复用
     // （与 reader/video/首页查词同范式），消除「每次查词重建 WebView 露白屏一瞬」。
     // appModel 未初始化时 seedWarmSlot 内部据 lowMemory 早退前先设真值；此处与首页
@@ -167,8 +165,6 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
   }) async {
     final String trimmed = query.trim();
     if (trimmed.isEmpty) return;
-    debugPrint('[popup-perf] search start "$trimmed" '
-        '${_startupStopwatch.elapsedMilliseconds}ms');
     if (_searchController.text != trimmed) {
       _searchController.text = trimmed;
       _searchController.selection = TextSelection.collapsed(
@@ -187,8 +183,6 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
       // DictionaryPopupLayer 的加载盖板兜住——不走「搜索期隐藏 + anchored 占位卡」。
       revealWhileSearching: true,
     );
-    debugPrint('[popup-perf] ffi done "$trimmed" '
-        '${_startupStopwatch.elapsedMilliseconds}ms');
   }
 
   void _popAt(int index) {
@@ -471,8 +465,6 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
       onClose: isBase ? null : () => _popAt(index),
       onBack: null,
       onRendered: () {
-        debugPrint('[popup-perf] render "${entry.searchTerm}" '
-            '${_startupStopwatch.elapsedMilliseconds}ms');
         if (_popup.revealRendered(entry) && mounted) setState(() {});
       },
       // TODO-951 症状A：点**本层卡片本体的空白区**（popup.js 在 __hasChildPopup 为真时

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -1021,18 +1021,23 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
         'section=$section normOffset=$normOffset charOffset=$charOffset');
     final ReaderPositionRepository repo =
         ReaderPositionRepository(appModel.database);
-    await repo.save(
-      bookKey: widget.bookKey,
-      sectionIndex: section,
-      normCharOffset: normOffset,
-      // BUG-162: >=0 写精确锚（char_offset 列）。<0（WebView 当帧算不出精确偏移）
-      // 传 null → ReaderPositionRepository.save 在同 section 保留既有精确锚、仅跨
-      // section 失效。BUG-285 回归：TODO-265 误改成直接传 -1，使 _refreshProgress /
-      // _syncPositionFromWebViewProgress 在重排或竖排边缘拿到 -1 时把同 section 的
-      // 精确锚覆盖成 -1 → 恢复/有声书跨章重锚退化成「章首分数」（章节粒度），不再
-      // 逐句跟随。还原 null 守卫，把同/跨 section 的取舍交回 repo.save。
-      charOffset: charOffset >= 0 ? charOffset : null,
-    );
+    try {
+      await repo.save(
+        bookKey: widget.bookKey,
+        sectionIndex: section,
+        normCharOffset: normOffset,
+        // BUG-162: >=0 写精确锚（char_offset 列）。<0（WebView 当帧算不出精确偏移）
+        // 传 null → ReaderPositionRepository.save 在同 section 保留既有精确锚、仅跨
+        // section 失效。BUG-285 回归：TODO-265 误改成直接传 -1，使 _refreshProgress /
+        // _syncPositionFromWebViewProgress 在重排或竖排边缘拿到 -1 时把同 section 的
+        // 精确锚覆盖成 -1 → 恢复/有声书跨章重锚退化成「章首分数」（章节粒度），不再
+        // 逐句跟随。还原 null 守卫，把同/跨 section 的取舍交回 repo.save。
+        charOffset: charOffset >= 0 ? charOffset : null,
+      );
+    } catch (e, stack) {
+      // fail-open：本次位置未落盘（后续 debounce/flush 会重试），补日志便于诊断。
+      ErrorLogService.instance.log('ReaderHibiki._persistPosition', e, stack);
+    }
 
     // 读到全书末尾（最后一章 + 章内进度到末尾）→ 自动写「已读完」时间戳。
     // markEpubBookCompletedIfUnset 幂等（仅 completed_at IS NULL 时写），不刷新时间戳、
@@ -1192,8 +1197,11 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
         charsRead: charsRead,
         timeMs: elapsedMs,
       );
-    } catch (e) {
+    } catch (e, stack) {
+      // fail-open：本次统计增量丢弃（计数器已清零，不会重复累加），补 debugPrint +
+      // ErrorLogService.log 使 DB 写异常线上可诊断。
       debugPrint('[ReaderHibiki] stats flush error: $e');
+      ErrorLogService.instance.log('ReaderHibiki._flushReadingStats', e, stack);
     }
   }
 }

--- a/hibiki/lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart
@@ -36,9 +36,7 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
   ) async {
     final VideoPlayerController? controller = _controller;
     if (controller == null) return;
-    final Stopwatch swLookup = Stopwatch()..start();
     final String term = subtitleLookupTerm(sentence, graphemeIndex);
-    debugPrint('[video-lookup] tap idx=$graphemeIndex term="$term"');
     // 先判空再暂停：空词不弹浮层，不能暂停后无浮层可关→恢复路径永不触发（卡暂停）。
     if (term.isEmpty) return;
     // 仅当视频正在播放才暂停并标记，浮层全关后据此恢复（BUG-072）。查词前本就
@@ -72,9 +70,6 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
       replaceStack: true,
       reuseWarmSlot: true,
       autoRead: true,
-    );
-    debugPrint(
-      '[video-lookup] popup ready in ${swLookup.elapsedMilliseconds}ms term="$term"',
     );
     // 刷新查词浮层顶部收藏星标：判定当前字幕句是否已收藏（异步，不阻塞弹窗）。
     unawaited(_refreshVideoSentenceFavorite());

--- a/hibiki/lib/src/utils/misc/collection_exporter.dart
+++ b/hibiki/lib/src/utils/misc/collection_exporter.dart
@@ -5,6 +5,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki/src/utils/misc/hibiki_share.dart';
 import 'package:hibiki/src/utils/misc/hibiki_time_format.dart';
 
@@ -914,7 +915,9 @@ Future<void> saveOrShareExport({
         subject: subject,
       );
     }
-  } catch (_) {
+  } catch (e, s) {
+    // fail-open：保留 notify 提示用户导出失败；补 ErrorLogService.log 便于线上诊断。
+    ErrorLogService.instance.log('collectionExport.saveOrShareExport', e, s);
     notify(t.collection_export_failed);
   } finally {
     if (_isDesktop && tmp != null) {

--- a/hibiki/lib/src/utils/misc/lookup_audio_playback.dart
+++ b/hibiki/lib/src/utils/misc/lookup_audio_playback.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/utils/misc/tts_channel.dart';
@@ -19,16 +18,14 @@ Future<void> playLookupAudio(
 ) async {
   final String? url =
       await resolveLookupAudioUrl(appModel, expression, reading);
-  debugPrint('[hibiki-autoread] resolved url=$url');
   if (url == null || url.isEmpty) return;
 
   // Plays remote URLs and local file paths uniformly, including Windows
   // drive-letter paths (BUG-046).
-  final bool ok = await TtsChannel.instance.playAudioRef(
+  await TtsChannel.instance.playAudioRef(
     url,
     volume: ReaderHibikiSource.instance.lookupAudioVolumeGain,
   );
-  debugPrint('[hibiki-autoread] play ok=$ok');
 }
 
 /// Resolves (but does not play) the configured-source audio URL/path for
@@ -40,9 +37,6 @@ Future<String?> resolveLookupAudioUrl(
   String expression,
   String reading,
 ) async {
-  final sources = appModel.enabledAudioSources;
-  debugPrint(
-      '[hibiki-autoread] "$expression" reading="$reading" sources=${sources.length}');
   final WordAudioResolver resolver = WordAudioResolver(
     queryLocalAudio: (expression, reading) async {
       try {
@@ -50,8 +44,6 @@ Future<String?> resolveLookupAudioUrl(
             .queryLocalAudio(expression, reading)
             .timeout(const Duration(milliseconds: 500));
       } on TimeoutException {
-        debugPrint(
-            '[hibiki-autoread] queryLocalAudio timed out for "$expression"');
         return null;
       }
     },
@@ -61,8 +53,6 @@ Future<String?> resolveLookupAudioUrl(
             .queryLocalAudio(expression, reading, dbIndex: dbIndex)
             .timeout(const Duration(milliseconds: 500));
       } on TimeoutException {
-        debugPrint(
-            '[hibiki-autoread] queryLocalAudio timed out for "$expression"');
         return null;
       }
     },

--- a/hibiki/test/diagnostics/fail_open_logging_guard_test.dart
+++ b/hibiki/test/diagnostics/fail_open_logging_guard_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-911 守卫：fail-open 的 catch 静默吞异常致线上不可诊断。
+///
+/// 这批修复**不改 fail-open 语义**（继续吞 / 继续降级 / 继续返回空 / 继续 fire-and-forget），
+/// 只在原本静默的 catch / 未捕获的 DB 写路径补 ErrorLogService.log（用户可见错误、计数落盘）
+/// 或 ErrorLogService.logDiagnostic（预期网络失败、不计数）。
+///
+/// 本守卫用**方法体切片**（按方法名锚点，不用裸行号）钉住每个补日志点仍在其对应方法体内，
+/// 未来有人把日志删掉会变红。
+void main() {
+  String libFile(String relative) =>
+      File(relative).readAsStringSync().replaceAll('\r\n', '\n');
+
+  /// 按 [signature]（以起始 `(` 结尾，如 `_flush(`）截出函数体：先配平参数列表的圆括号
+  /// （命名参数的 `{...}` 不能当函数体大括号），再从参数列表后的第一个 `{` 起配平大括号。
+  String fnBody(String src, String signature) {
+    final int start = src.indexOf(signature);
+    expect(start, greaterThanOrEqualTo(0),
+        reason: '函数 $signature 必须存在（结构守卫锚点）。');
+    int i = start + signature.length - 1; // 指向起始 '('
+    expect(src[i], '(', reason: 'signature 必须以 "(" 结尾。');
+    int paren = 0;
+    for (; i < src.length; i++) {
+      final String ch = src[i];
+      if (ch == '(') paren++;
+      if (ch == ')') {
+        paren--;
+        if (paren == 0) break;
+      }
+    }
+    final int bodyStart = src.indexOf('{', i);
+    expect(bodyStart, greaterThanOrEqualTo(0),
+        reason: '函数 $signature 参数列表后必须有函数体 "{"。');
+    int depth = 0;
+    for (i = bodyStart; i < src.length; i++) {
+      final String ch = src[i];
+      if (ch == '{') depth++;
+      if (ch == '}') {
+        depth--;
+        if (depth == 0) return src.substring(bodyStart, i + 1);
+      }
+    }
+    fail('函数 $signature 大括号不配平，无法截出函数体。');
+  }
+
+  // 容忍 dart format 把 ErrorLogService.instance.log( 折行成
+  // ErrorLogService.instance 换行后 .log(，用正则匹配中间任意空白。
+  final RegExp logRe = RegExp(r'ErrorLogService\.instance\s*\.log\(');
+  final RegExp diagRe =
+      RegExp(r'ErrorLogService\.instance\s*\.logDiagnostic\(');
+
+  group('collection_exporter.saveOrShareExport fail-open 补 log', () {
+    test('catch 仍走 notify 且补 ErrorLogService.log', () {
+      final String src = libFile('lib/src/utils/misc/collection_exporter.dart');
+      final String body = fnBody(src, 'Future<void> saveOrShareExport(');
+      expect(body, contains('collectionExport.saveOrShareExport'),
+          reason:
+              'saveOrShareExport 的 catch 必须补 ErrorLogService.log（source tag）。');
+      expect(logRe.hasMatch(body), isTrue,
+          reason: 'saveOrShareExport 方法体内必须有 ErrorLogService.instance.log 调用。');
+      // fail-open 未变：仍向用户提示导出失败。
+      expect(body, contains('notify(t.collection_export_failed)'),
+          reason: 'fail-open 语义未变：catch 仍 notify 用户导出失败。');
+    });
+  });
+
+  group('jimaku_client 预期网络失败路径补 logDiagnostic', () {
+    late String src;
+    setUpAll(() => src = libFile('lib/src/media/video/jimaku_client.dart'));
+
+    test('_searchEntries catch 补 diagnostic 且仍返回空列表', () {
+      final String body =
+          fnBody(src, 'Future<List<JimakuEntry>> _searchEntries(');
+      expect(body, contains('JimakuClient.searchEntries'));
+      expect(diagRe.hasMatch(body), isTrue);
+      expect(body, contains('return const <JimakuEntry>[];'),
+          reason: 'fail-open 未变：仍返回空列表。');
+    });
+
+    test('listFiles catch 补 diagnostic 且仍返回空列表', () {
+      final String body = fnBody(src, 'Future<List<JimakuFile>> listFiles(');
+      expect(body, contains('JimakuClient.listFiles'));
+      expect(diagRe.hasMatch(body), isTrue);
+      expect(body, contains('return const <JimakuFile>[];'),
+          reason: 'fail-open 未变：仍返回空列表。');
+    });
+
+    test('downloadFile catch 补 diagnostic 且仍返回 null', () {
+      final String body = fnBody(src, 'Future<Uint8List?> downloadFile(');
+      expect(body, contains('JimakuClient.downloadFile'));
+      expect(diagRe.hasMatch(body), isTrue);
+      expect(body, contains('return null;'), reason: 'fail-open 未变：仍返回 null。');
+    });
+
+    test('纯解析兜底也补 diagnostic', () {
+      expect(src, contains('JimakuClient.parseJimakuEntries'));
+      expect(src, contains('JimakuClient.parseJimakuFiles'));
+    });
+  });
+
+  group('video_watch_tracker._flush fire-and-forget 补 log', () {
+    test('_flush 的 DB 写包 try/catch 并补 ErrorLogService.log', () {
+      final String src =
+          libFile('lib/src/media/video/video_watch_tracker.dart');
+      final String body = fnBody(src, 'Future<void> _flush(');
+      expect(body, contains('VideoWatchTracker.flush'),
+          reason: '_flush 的 DB 写异常必须补 ErrorLogService.log（source tag）。');
+      expect(logRe.hasMatch(body), isTrue,
+          reason: '_flush 方法体内必须有 ErrorLogService.instance.log 调用。');
+      // fail-open 未变：仍是 unawaited fire-and-forget（异常不冒泡阻塞播放）。
+      expect(src, contains('unawaited(_flush())'),
+          reason: 'fail-open 未变：周期 tick 仍 fire-and-forget。');
+    });
+  });
+
+  group('reader navigation 阅读统计 / 位置落盘补 log', () {
+    late String src;
+    setUpAll(() => src = libFile(
+        'lib/src/pages/implementations/reader_hibiki/navigation.part.dart'));
+
+    test('_flushReadingStats catch 保留 debugPrint 且补 ErrorLogService.log', () {
+      final String body = fnBody(src, 'Future<void> _flushReadingStats(');
+      expect(body, contains('ReaderHibiki._flushReadingStats'));
+      expect(logRe.hasMatch(body), isTrue);
+      expect(body, contains("debugPrint('[ReaderHibiki] stats flush error"),
+          reason: 'fail-open 未变：保留原 debugPrint。');
+    });
+
+    test('_persistPosition 的 repo.save 包 catch 并补 ErrorLogService.log', () {
+      final String body = fnBody(src, 'Future<void> _persistPosition(');
+      expect(body, contains('ReaderHibiki._persistPosition'));
+      expect(logRe.hasMatch(body), isTrue);
+    });
+  });
+}

--- a/hibiki/test/lookup/dict_perf_probe_removal_guard_test.dart
+++ b/hibiki/test/lookup/dict_perf_probe_removal_guard_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 源码扫描守卫（BUG-914 + BUG-913）。
+///
+/// BUG-914：查词/弹窗热路径此前散落着发布版也不会被剥离的裸计时探针
+/// （`[dict-perf]` / `[popup-perf]` / `[video-lookup]` / `[hibiki-autoread]`
+/// 的 `debugPrint` + `Stopwatch`）。这些每次查词/每帧渲染都打点，是 release
+/// 噪声与微小开销。移除后用源码文本断言防回归（探针散在私有 State / FFI 热
+/// 路径，无法用 widget 测试直接触达）。
+///
+/// BUG-913：`base_source_page.dart` 的 `_isSearchingNotifier`（ValueNotifier）
+/// 创建了却没在 `dispose()` 释放，泄漏监听器。断言 dispose 已补 dispose 调用。
+void main() {
+  String read(String path) => File(path).readAsStringSync();
+
+  // hibiki 包内相对路径（flutter test 以包根为 cwd）。
+  const String repositoryPath = 'lib/src/models/dictionary_repository.dart';
+  const String baseSourcePagePath = 'lib/src/pages/base_source_page.dart';
+  const String mixinPath =
+      'lib/src/pages/implementations/dictionary_page_mixin.dart';
+  const String popupPagePath =
+      'lib/src/pages/implementations/popup_dictionary_page.dart';
+  const String lookupFavoritePath =
+      'lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart';
+  const String lookupAudioPath =
+      'lib/src/utils/misc/lookup_audio_playback.dart';
+  // 词典 FFI 引擎在同工作区的兄弟包。
+  const String hoshidictsPath =
+      '../packages/hibiki_dictionary/lib/src/engine/hoshidicts.dart';
+
+  // (文件, 该文件不应再出现的探针标记)。
+  const Map<String, List<String>> probeMarkers = <String, List<String>>{
+    repositoryPath: <String>['[dict-perf]'],
+    baseSourcePagePath: <String>['[dict-perf]', '[hibiki-autoread]'],
+    mixinPath: <String>['[dict-perf]'],
+    popupPagePath: <String>['[popup-perf]'],
+    lookupFavoritePath: <String>['[video-lookup]'],
+    lookupAudioPath: <String>['[hibiki-autoread]'],
+    hoshidictsPath: <String>['[dict-perf]'],
+  };
+
+  probeMarkers.forEach((String path, List<String> markers) {
+    test('BUG-914：$path 不再含热路径计时探针', () {
+      final String src = read(path);
+      for (final String marker in markers) {
+        expect(
+          src.contains(marker),
+          isFalse,
+          reason: '$path 不应再有 $marker 探针（release 噪声 + 微开销，BUG-914）',
+        );
+      }
+    });
+  });
+
+  test('BUG-913：base_source_page.dispose 释放 _isSearchingNotifier', () {
+    final String src = read(baseSourcePagePath);
+    expect(
+      src.contains('_isSearchingNotifier.dispose()'),
+      isTrue,
+      reason: '$baseSourcePagePath 的 dispose() 必须释放 _isSearchingNotifier，'
+          '否则 ValueNotifier 监听器泄漏（BUG-913）',
+    );
+  });
+}

--- a/hibiki/test/media/audiobook/audiobook_probe_removal_guard_test.dart
+++ b/hibiki/test/media/audiobook/audiobook_probe_removal_guard_test.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-914：移除有声书按句同步/高亮热路径的发布版诊断噪声后，锁住这两处
+/// 打点不再回归。测试从 `hibiki/` 工作目录运行：
+/// - 桥接文件在本包内（`lib/src/media/audiobook/audiobook_bridge.dart`），
+///   曾在播放期逐 cue 打 `[sasayaki-hl]`（highlight raw / applySasayakiCues
+///   EMPTY payload）。
+/// - 控制器在 `hibiki_audio` 包（`../packages/hibiki_audio/lib/src/audiobook/
+///   audiobook_controller.dart`），曾在 `_maybeEmitCrossChapter` 按句同步热
+///   路径打 `[hibiki-crossChapter]`（blocked / cueSec）。
+void main() {
+  String readSource(String relativePath) {
+    final File file = File(relativePath);
+    expect(file.existsSync(), isTrue,
+        reason: 'expected source at ${file.absolute.path}');
+    return file.readAsStringSync();
+  }
+
+  test('audiobook bridge no longer emits [sasayaki-hl] playback probes', () {
+    final String source =
+        readSource('lib/src/media/audiobook/audiobook_bridge.dart');
+    expect(source, isNot(contains('[sasayaki-hl]')),
+        reason: 'BUG-914: 播放期逐句高亮的 [sasayaki-hl] 诊断打点必须移除，'
+            '避免发布版热路径噪声');
+  });
+
+  test('audiobook controller no longer emits [hibiki-crossChapter] probes', () {
+    final String source = readSource(
+        '../packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart');
+    expect(source, isNot(contains('[hibiki-crossChapter]')),
+        reason: 'BUG-914: _maybeEmitCrossChapter 按句同步热路径的 '
+            '[hibiki-crossChapter] print 必须移除');
+  });
+}

--- a/hibiki/test/models/app_model_audit_hardening_guard_test.dart
+++ b/hibiki/test/models/app_model_audit_hardening_guard_test.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// AppModel 审计加固源码守卫（BUG-911 / BUG-913 / BUG-914）。
+///
+/// AppModel 太大、依赖整页初始化 + Drift + FFI，无法在单测里实例化并驱动
+/// dispose()/searchDictionary() 的真实路径，故这里用源码扫描守卫锁住三簇加固不回归。
+/// 测试从 `hibiki/` 工作目录运行，读 `lib/src/models/app_model.dart`。
+void main() {
+  final File file = File('lib/src/models/app_model.dart');
+  late final String source;
+
+  setUpAll(() {
+    expect(file.existsSync(), isTrue,
+        reason: 'expected source at ${file.absolute.path}');
+    source = file.readAsStringSync();
+  });
+
+  /// 截取 `void dispose() { ... super.dispose(); }` 的方法体，避免把 closeForPopup
+  /// 等其它清理逻辑误当成 dispose 内容。
+  String disposeBody(String src) {
+    const String marker = 'void dispose() {';
+    final int start = src.indexOf(marker);
+    expect(start, greaterThanOrEqualTo(0), reason: 'AppModel.dispose() 声明必须存在');
+    final int superIdx = src.indexOf('super.dispose();', start);
+    expect(superIdx, greaterThan(start),
+        reason: 'dispose() 必须以 super.dispose() 收尾');
+    return src.substring(start, superIdx);
+  }
+
+  group('BUG-913 dispose 对称释放 4 个常驻子系统', () {
+    test('LAN sync server 在 dispose 内被 stop', () {
+      expect(disposeBody(source), contains('syncServerController.stop()'),
+          reason: 'initialise 起的 LAN sync server 必须在 dispose 关停');
+    });
+
+    test('sync server ChangeNotifier 在 dispose 内被 dispose', () {
+      expect(disposeBody(source), contains('syncServerController.dispose()'),
+          reason: 'syncServerController 是 ChangeNotifier，stop 后还需 dispose');
+    });
+
+    test('texthooker 在 dispose 内被 stop', () {
+      expect(disposeBody(source),
+          contains('TexthookerWsClientHost.instance.stop()'),
+          reason: 'initialise 起的 texthooker host 必须在 dispose 关停');
+    });
+
+    test('yomitan api server 在 dispose 内被 stop', () {
+      expect(disposeBody(source), contains('stopYomitanApiServer()'),
+          reason: 'initialise 起的 yomitan-api server 必须在 dispose 关停');
+    });
+
+    test('anime 下载服务在 dispose 内被 stop', () {
+      expect(disposeBody(source), contains('_animeDownloadService?.stop()'),
+          reason: 'initialise 起的番剧下载服务必须在 dispose 关停');
+    });
+  });
+
+  group('BUG-913 弹窗内联 family provider autoDispose 化', () {
+    // 剥离所有空白后匹配：dart format 会把 `.autoDispose` 与 `.family<...>`
+    // 折成两行，精确单行子串会误判，故对无空白视图断言。`source` 是 late（setUpAll
+    // 赋值），故 noWs 必须在 test 体内计算，不能放组级（收集期 source 未初始化）。
+    test('quickActionColorProvider 声明含 autoDispose', () {
+      expect(
+          source.replaceAll(RegExp(r'\s+'), ''),
+          contains(
+              'FutureProvider.autoDispose.family<Map<String,Color?>,DictionaryEntry>'),
+          reason: '弹窗内联颜色 family 随查词单调增长，须 autoDispose（弹窗关即释放）');
+    });
+
+    test('visibleOnceProvider 声明含 autoDispose', () {
+      expect(source.replaceAll(RegExp(r'\s+'), ''),
+          contains('StateProvider.autoDispose.family<bool,DictionaryEntry>'),
+          reason: '一次性可见标记 family 随查词单调增长，须 autoDispose（弹窗关即释放）');
+    });
+  });
+
+  group('BUG-914 移除查词热路径 [dict-perf] 性能探针', () {
+    test('app_model.dart 不再出现 [dict-perf]', () {
+      expect(source, isNot(contains('[dict-perf]')),
+          reason: 'searchDictionary 每次查词必跑，发布版不得留 [dict-perf] 打点');
+    });
+  });
+
+  group('BUG-911 yomitan 自启动 fail-open 补日志', () {
+    test('自启动 catchError 不再是空吞', () {
+      expect(source,
+          isNot(contains('startYomitanApiServer().catchError((Object _) {})')),
+          reason: 'BUG-911：空 catchError 静默吞异常必须移除');
+    });
+
+    test('自启动失败经 ErrorLogService 留痕', () {
+      expect(source, contains('AppModel.startYomitanApiServer.autostart'),
+          reason: 'fail-open 保持不变，但失败须记日志（与邻居 startSyncServer 一致）');
+    });
+  });
+}

--- a/hibiki/test/models/app_model_search_pure_logic_test.dart
+++ b/hibiki/test/models/app_model_search_pure_logic_test.dart
@@ -26,7 +26,7 @@ void main() {
         emojiRegex: emojiRegex,
         punctuationRegex: punctuationRegex,
         loneSurrogateRegex: loneSurrogateRegex,
-      ).term;
+      );
 
   void expectEquivalent(String input) {
     expect(normalize(input), legacyNormalize(input),
@@ -102,18 +102,6 @@ void main() {
       const String input = '。図書\n\u{1F600}館\uD800！';
       expect(normalize(input), legacyNormalize(input));
       expectEquivalent(input);
-    });
-
-    test('micro timing fields non-negative (observability passthrough)', () {
-      final result = normalizeSearchTerm(
-        '図書\n\u{1F600}館',
-        emojiRegex: emojiRegex,
-        punctuationRegex: punctuationRegex,
-        loneSurrogateRegex: loneSurrogateRegex,
-      );
-      expect(result.emojiMicros, greaterThanOrEqualTo(0));
-      expect(result.punctMicros, greaterThanOrEqualTo(0));
-      expect(result.surrogateMicros, greaterThanOrEqualTo(0));
     });
   });
 

--- a/hibiki/test/pages/popup_latch_and_longpress_guard_test.dart
+++ b/hibiki/test/pages/popup_latch_and_longpress_guard_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 源码扫描守卫（BUG-912 #2 / #3 / BUG-914）。
+///
+/// 三条独立回归防护，都用源码文本断言（涉及私有 State / 静态字段，
+/// 无法用 widget 测试直接触达）：
+///
+/// 1. BUG-912 #2：`dictionary_popup_webview.dart` 不得再有进程级
+///    `_inlineAssetsLoadFailed` 永久失败闩。Windows/iOS 内联资产路径下，
+///    一次瞬时读盘异常（文件锁 / 磁盘抖动）不该把整进程永久降级到不可靠
+///    的 file:// 路径；成功后 `_inlineCss != null` 已能防重复读盘。
+/// 2. BUG-914：同文件不得再有 `[dict-perf]` 热路径打点探针。
+/// 3. BUG-912 #3：`reader_quick_settings_sheet.dart` 的 `_RepeatIconButton`
+///    长按手势必须挂 `onLongPressCancel`，否则手势被取消（指针滑出 /
+///    识别器被夺走）时 `_timer` 会持续连触直到 dispose。
+void main() {
+  String read(String path) => File(path).readAsStringSync();
+
+  const String popupWebviewPath =
+      'lib/src/pages/implementations/dictionary_popup_webview.dart';
+  const String quickSettingsPath =
+      'lib/src/media/audiobook/reader_quick_settings_sheet.dart';
+
+  test('BUG-912 #2：弹窗内联资产不再有进程级永久失败闩', () {
+    final String src = read(popupWebviewPath);
+    expect(
+      src.contains('_inlineAssetsLoadFailed'),
+      isFalse,
+      reason: '$popupWebviewPath 不应再有 _inlineAssetsLoadFailed 永久闩'
+          '（一次瞬时读盘异常会把内联资产永久降级到 file://，无复位路径）',
+    );
+    // 门控只判 _inlineCss 非空即可防重复读盘；断言不含永久失败闩条件。
+    final Match? gate = RegExp(
+      r'if\s*\(\s*_inlineCss\s*!=\s*null([^)]*)\)\s*return;',
+    ).firstMatch(src);
+    expect(gate, isNotNull,
+        reason: '应保留 `if (_inlineCss != null) return;` 防重复读盘守卫');
+    expect(
+      gate!.group(1)!.contains('Failed') || gate.group(1)!.contains('||'),
+      isFalse,
+      reason: '内联资产门控不应再叠加永久失败闩条件（BUG-912 #2）',
+    );
+  });
+
+  test('BUG-914：弹窗注入热路径不再有 [dict-perf] 计时探针', () {
+    final String src = read(popupWebviewPath);
+    expect(
+      src.contains('[dict-perf]'),
+      isFalse,
+      reason: '$popupWebviewPath 不应再有 [dict-perf] 打点（热路径噪声，BUG-914）',
+    );
+    expect(
+      src.contains('swInject'),
+      isFalse,
+      reason: '$popupWebviewPath 不应再有 swInject 计时 Stopwatch（死变量，BUG-914）',
+    );
+  });
+
+  test('BUG-912 #3：_RepeatIconButton 长按手势挂 onLongPressCancel', () {
+    final String src = read(quickSettingsPath);
+    final int classIdx = src.indexOf('class _RepeatIconButtonState');
+    expect(classIdx, greaterThanOrEqualTo(0),
+        reason: '$quickSettingsPath 应存在 _RepeatIconButtonState');
+    final int buildIdx = src.indexOf('GestureDetector', classIdx);
+    expect(buildIdx, greaterThanOrEqualTo(0),
+        reason: '_RepeatIconButtonState.build 应有 GestureDetector');
+    // 截取该 GestureDetector 到其 child 之间的构造参数块。
+    final String body = src.substring(
+        buildIdx, classIdx + 1600 < src.length ? classIdx + 1600 : src.length);
+    expect(
+      body.contains('onLongPressCancel'),
+      isTrue,
+      reason: '_RepeatIconButton 的 GestureDetector 必须挂 onLongPressCancel，'
+          '否则手势被取消时 _timer 持续连触（BUG-912 #3）',
+    );
+  });
+}

--- a/packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart
+++ b/packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart
@@ -1099,12 +1099,12 @@ class AudiobookPlayerController extends ChangeNotifier {
       // !_hasPlayedOnce（本会话首次「从本句播放」）/ restore-in-flight 等守卫
       // 被挡，文字停在原章；之后 cue 一直不变就走这条裸 return、永不再做跨章
       // 检查 → 要用户再点一次才跟过去。在「正在跟随播放」（playing 且非
-      // playCueOnce 单句试听）时补一次安静（不打印）的跨章检查，让文字收敛到
+      // playCueOnce 单句试听）时补一次跨章检查，让文字收敛到
       // 当前 cue 所属章。_maybeEmitCrossChapter 同章早退（已同步时 no-op）、
       // 跳章期间 _chapterTransition 守卫挡住后续 tick，不会 per-tick 抖动；
       // 暂停态不补检查，避免覆盖用户手动翻页。
       if (_player.playing && _stopAtPositionMs == null) {
-        _maybeEmitCrossChapter(cue, quiet: true);
+        _maybeEmitCrossChapter(cue);
       }
       if (forceNotify) {
         notifyListeners();
@@ -1164,13 +1164,8 @@ class AudiobookPlayerController extends ChangeNotifier {
   ///
   /// SMIL/JSON 等非 sasayaki 路径 cue 的 textFragmentId 解码返回 null，
   /// 自然跳过这套逻辑（它们没有跨章同步概念）。
-  void _maybeEmitCrossChapter(AudioCue? cue,
-      {bool bypassPlayGuard = false, bool quiet = false}) {
+  void _maybeEmitCrossChapter(AudioCue? cue, {bool bypassPlayGuard = false}) {
     if (_chapterTransition) {
-      if (!quiet) {
-        // ignore: avoid_print
-        print('[hibiki-crossChapter] blocked: _chapterTransition=true');
-      }
       return;
     }
     if (cue == null) return;
@@ -1180,11 +1175,6 @@ class AudiobookPlayerController extends ChangeNotifier {
     if (frag == null) return;
     final int cueSec = frag.sectionIndex;
     final int currentSec = getCurrentReaderSection?.call() ?? -1;
-    if (!quiet) {
-      // ignore: avoid_print
-      print(
-          '[hibiki-crossChapter] cueSec=$cueSec currentSec=$currentSec follow=${followAudio.value} played=$_hasPlayedOnce');
-    }
     if (!shouldCrossChapterForTesting(
       cueSec: cueSec,
       currentSec: currentSec,

--- a/packages/hibiki_dictionary/lib/src/engine/hoshidicts.dart
+++ b/packages/hibiki_dictionary/lib/src/engine/hoshidicts.dart
@@ -557,16 +557,11 @@ class HoshiDicts {
   }) {
     final tp = text.toNativeUtf8(allocator: calloc);
     try {
-      final swNative = Stopwatch()..start();
       final r = _bindings!.lookup(_handle!, tp, maxResults, scanLength);
-      swNative.stop();
-      debugPrint(
-          '[dict-perf]     native call: ${swNative.elapsedMicroseconds}µs count=${r.count}');
 
       final rPtr = calloc<FfiLookupResults>();
       rPtr.ref = r;
       try {
-        final swConvert = Stopwatch()..start();
         final results = <HoshiLookupResult>[];
         for (int i = 0; i < r.count; i++) {
           final src = r.results[i];
@@ -585,9 +580,6 @@ class HoshiDicts {
             preprocessorSteps: src.preprocessorSteps,
           ));
         }
-        swConvert.stop();
-        debugPrint(
-            '[dict-perf]     ffi→dart convert: ${swConvert.elapsedMicroseconds}µs');
         return results;
       } finally {
         _bindings!.freeLookupResults(rPtr);


### PR DESCRIPTION
## 背景
接续已合并的 PR#241（审计 High/Medium，BUG-896~902 → 合并时 renumber 为 903~909）。本 PR 处理审计 **Low 弥散项**——散落 print 打点 / fail-open 吞异常无日志 / 异常路径状态不复位 / 常驻服务不对称释放。已基于最新 `develop` rebase（含 PR#240/#241）。

## 修复清单（一 BUG 一文件，见 `docs/bugs/`）
| BUG | 缺陷 | 根因修复 | 测试 |
|---|---|---|---|
| 911 | fail-open catch 静默吞异常致线上不可诊断 | yomitan 自启 / 集合导出 / Jimaku 搜索 / 观看统计周期写 / 阅读统计落盘 5 处补 `ErrorLogService.log\|logDiagnostic`，**不改 fail-open 语义** | 源码扫描守卫（方法体切片，钉住补日志且语义未变） |
| 912 | 异常/取消路径状态不复位 | 删 Windows 弹窗资产进程级永久闩（门控收敛 `_inlineCss!=null`，失败下次重试）；有声书 +/- 长按补 `onLongPressCancel`（对齐视频页孪生） | 源码扫描守卫 |
| 913 | 常驻服务/Notifier/provider 未对称释放（泄漏） | `AppModel.dispose` 补关 LAN sync/texthooker/yomitan/anime 下载服务 4 个常驻子系统；两 family 加 `.autoDispose`；`base_source_page` 补 `_isSearchingNotifier.dispose()` | dispose 体切片断言 + family autoDispose 断言 |
| 914 | 发布版残留诊断打点（查词/弹窗/按句同步热路径） | 移除 `[dict-perf]`/`[popup-perf]`/`[video-lookup]`/`[hibiki-autoread]`/`[sasayaki-hl]`/`[hibiki-crossChapter]` 探针簇（11 文件）；收敛 `NormalizedSearchTerm→String`、删死 `quiet` 参数/死 import | 源码扫描守卫（各文件无对应标记） |

## 说明
- 审计点名的「temporarilyDisableStatusBarHiding 缺 finally」按当前代码**全仓无此符号**、疑似已消解（最接近的 `openMedia` 沉浸是「持续到 closeMedia」的有意设计、视频页已有对称还原+守卫），按「不修臆想缺陷」原则跳过，见 BUG-912 备注。
- BUG 号取 **911~914**：避让 PR#241 合并后占用的 903~909 与并发 PR#242 的 910。
- 竖排取证探针 `[792-*]`/`[753-DIAG]` 已在 PR#241 的 BUG-902 移除，不在本 PR。

## 验证
- `flutter analyze`：hibiki / hibiki_audio / hibiki_dictionary 全 `No issues found`。
- `flutter test`：本轮 6 个守卫/纯逻辑测试全绿（63 条）；rebase 合并涉及的 `navigation.part.dart`（位置落盘 + 末章自动完成两特性并存）、`app_model`、`audiobook_controller` 回归全绿（cross-chapter / epub_completed / reader_positions）。sqlite3 native 经本机 proxy 下载。
- **待真机**：各 fail-open 失败路径的日志留痕、Windows 弹窗资产重试、有声书长按取消、dispose 常驻服务实际关停需真机复测。