### PR TITLE
feat(video): 字幕对轴/延迟匹配加键盘快捷键 (Shift+A 打开对轴 / z·x 延迟±)

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 33728 (1984 per locale)
+/// Strings: 33779 (1987 per locale)
 ///
-/// Built on 2026-07-18 at 18:37 UTC
+/// Built on 2026-07-19 at 04:03 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2666,6 +2666,12 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get mining_audio_quality_standard => 'Standard';
   String get mining_audio_quality_high => 'High';
   String get mining_audio_quality_native => 'Native';
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -7162,6 +7168,15 @@ class _StringsAr extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -11731,6 +11746,15 @@ class _StringsDe extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -16316,6 +16340,15 @@ class _StringsEs extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -20912,6 +20945,15 @@ class _StringsFr extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -25435,6 +25477,15 @@ class _StringsId extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -30006,6 +30057,15 @@ class _StringsIt extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -34383,6 +34443,15 @@ class _StringsJa extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -38763,6 +38832,15 @@ class _StringsKo extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -43312,6 +43390,15 @@ class _StringsNl extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -47876,6 +47963,15 @@ class _StringsPtBr extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -52423,6 +52519,15 @@ class _StringsRu extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -56915,6 +57020,15 @@ class _StringsTh extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -61439,6 +61553,15 @@ class _StringsTr extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -65950,6 +66073,15 @@ class _StringsVi extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 // Path: <root>
@@ -70152,6 +70284,12 @@ class _StringsZhCn extends _StringsEn {
   String get mining_audio_quality_high => '高音质';
   @override
   String get mining_audio_quality_native => '原片';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase => '字幕延迟增大';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease => '字幕延迟减小';
+  @override
+  String get shortcut_action_video_open_subtitle_align => '打开字幕波形对轴';
 }
 
 // Path: <root>
@@ -74451,6 +74589,15 @@ class _StringsZhHk extends _StringsEn {
   String get mining_audio_quality_high => 'High';
   @override
   String get mining_audio_quality_native => 'Native';
+  @override
+  String get shortcut_action_video_subtitle_delay_increase =>
+      'Subtitle delay +';
+  @override
+  String get shortcut_action_video_subtitle_delay_decrease =>
+      'Subtitle delay −';
+  @override
+  String get shortcut_action_video_open_subtitle_align =>
+      'Open subtitle waveform align';
 }
 
 /// Flat map(s) containing all translations.
@@ -78509,6 +78656,12 @@ extension on _StringsEn {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -82565,6 +82718,12 @@ extension on _StringsAr {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -86642,6 +86801,12 @@ extension on _StringsDe {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -90718,6 +90883,12 @@ extension on _StringsEs {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -94800,6 +94971,12 @@ extension on _StringsFr {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -98864,6 +99041,12 @@ extension on _StringsId {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -102943,6 +103126,12 @@ extension on _StringsIt {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -106984,6 +107173,12 @@ extension on _StringsJa {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -111029,6 +111224,12 @@ extension on _StringsKo {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -115101,6 +115302,12 @@ extension on _StringsNl {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -119170,6 +119377,12 @@ extension on _StringsPtBr {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -123244,6 +123457,12 @@ extension on _StringsRu {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -127302,6 +127521,12 @@ extension on _StringsTh {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -131369,6 +131594,12 @@ extension on _StringsTr {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -135431,6 +135662,12 @@ extension on _StringsVi {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }
@@ -139460,6 +139697,12 @@ extension on _StringsZhCn {
         return '高音质';
       case 'mining_audio_quality_native':
         return '原片';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return '字幕延迟增大';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return '字幕延迟减小';
+      case 'shortcut_action_video_open_subtitle_align':
+        return '打开字幕波形对轴';
       default:
         return null;
     }
@@ -143496,6 +143739,12 @@ extension on _StringsZhHk {
         return 'High';
       case 'mining_audio_quality_native':
         return 'Native';
+      case 'shortcut_action_video_subtitle_delay_increase':
+        return 'Subtitle delay +';
+      case 'shortcut_action_video_subtitle_delay_decrease':
+        return 'Subtitle delay −';
+      case 'shortcut_action_video_open_subtitle_align':
+        return 'Open subtitle waveform align';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "比特率越高越清晰，卡片体积也越大。",
   "mining_audio_quality_standard": "标准",
   "mining_audio_quality_high": "高音质",
-  "mining_audio_quality_native": "原片"
+  "mining_audio_quality_native": "原片",
+  "shortcut_action_video_subtitle_delay_increase": "字幕延迟增大",
+  "shortcut_action_video_subtitle_delay_decrease": "字幕延迟减小",
+  "shortcut_action_video_open_subtitle_align": "打开字幕波形对轴"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1982,5 +1982,8 @@
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native"
+  "mining_audio_quality_native": "Native",
+  "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
+  "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
 }

--- a/hibiki/lib/src/media/video/video_player_shortcuts.dart
+++ b/hibiki/lib/src/media/video/video_player_shortcuts.dart
@@ -35,6 +35,9 @@ class VideoPlayerShortcutActions {
     required this.replayPreviousSubtitle,
     required this.previousChapter,
     required this.nextChapter,
+    required this.openSubtitleAlign,
+    required this.subtitleDelayIncrease,
+    required this.subtitleDelayDecrease,
     required this.escape,
   });
 
@@ -84,6 +87,16 @@ class VideoPlayerShortcutActions {
   final VoidCallback previousChapter;
   final VoidCallback nextChapter;
 
+  /// 打开字幕波形对轴放大视图（用户请求，默认 Shift+A）：复用快速设置面板里的
+  /// SubtitleWaveformZoomView，一键从键盘直达埋得很深的「字幕调轴」。无字幕 / 无本地
+  /// 视频路径 / 移动端抽不到波形时降级弹提示、不弹窗。
+  final VoidCallback openSubtitleAlign;
+
+  /// 字幕延迟 +/-（用户请求，默认 z/x）：像 mpv 一样按固定步进整体平移字幕延迟，
+  /// 走现有 _setDelayMs 写穿 delayMs 落盘 + OSD 反馈。
+  final VoidCallback subtitleDelayIncrease;
+  final VoidCallback subtitleDelayDecrease;
+
   final VoidCallback escape;
 }
 
@@ -123,6 +136,9 @@ Map<ShortcutAction, VoidCallback> videoActionCallbacks(
     ShortcutAction.videoReplayPreviousSubtitle: actions.replayPreviousSubtitle,
     ShortcutAction.videoPreviousChapter: actions.previousChapter,
     ShortcutAction.videoNextChapter: actions.nextChapter,
+    ShortcutAction.videoOpenSubtitleAlign: actions.openSubtitleAlign,
+    ShortcutAction.videoSubtitleDelayIncrease: actions.subtitleDelayIncrease,
+    ShortcutAction.videoSubtitleDelayDecrease: actions.subtitleDelayDecrease,
     ShortcutAction.videoEscape: actions.escape,
   };
 }

--- a/hibiki/lib/src/pages/implementations/shortcut_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/shortcut_settings_page.dart
@@ -128,6 +128,12 @@ String _actionLabel(ShortcutAction action) {
       return t.shortcut_action_video_previous_chapter;
     case ShortcutAction.videoNextChapter:
       return t.shortcut_action_video_next_chapter;
+    case ShortcutAction.videoOpenSubtitleAlign:
+      return t.shortcut_action_video_open_subtitle_align;
+    case ShortcutAction.videoSubtitleDelayIncrease:
+      return t.shortcut_action_video_subtitle_delay_increase;
+    case ShortcutAction.videoSubtitleDelayDecrease:
+      return t.shortcut_action_video_subtitle_delay_decrease;
     case ShortcutAction.videoEscape:
       return t.shortcut_action_video_escape;
     case ShortcutAction.dpadUp:

--- a/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
@@ -1266,4 +1266,83 @@ extension _VideoSubtitle on _VideoHibikiPageState {
       ),
     );
   }
+
+  /// 字幕对轴/匹配快捷键（用户请求，默认 Shift+A）：从键盘一键弹波形对轴放大视图，
+  /// 免去「控制栏 tune → 快速设置面板 → 字幕调轴区 → 点入口」四级操作。逻辑与
+  /// [SubtitleWaveformAlignPanel] 的入口点击（懒抽波形 → 非空才弹 [SubtitleWaveformZoomView]）
+  /// 完全一致、零第二套状态：调轴仍经 [_setDelayMs] 写回权威 `_delayMs`，自动对轴复用
+  /// [_autoAlignSubtitle]，逐句试听 / 播放头 / 弹窗内快捷键与快速设置面板路径同源。
+  ///
+  /// 降级路径与面板入口同款：无 controller / 无字幕 cue / 无本地视频路径 / 抽波形返回空
+  /// （移动端拿不到逐帧行 / ffmpeg 不可用）时不弹窗，改弹 OSD 提示不可用（不崩不空白）。
+  Future<void> _openSubtitleWaveformAlign() async {
+    final VideoPlayerController? controller = _controller;
+    if (controller == null) return;
+    final List<AudioCue> cues = controller.cues;
+    final String? videoPath = controller.videoPath;
+    if (cues.isEmpty || videoPath == null || videoPath.isEmpty) {
+      _showOsd(t.video_subtitle_waveform_unavailable);
+      return;
+    }
+    final List<double> env = await _loadSubtitleWaveformEnvelope();
+    if (!mounted) return;
+    if (env.isEmpty) {
+      _showOsd(t.video_subtitle_waveform_unavailable);
+      return;
+    }
+    // 波形时间窗上界：与 extractAudioEnergyEnvelope 探测上界同源（前 N 分钟截断），
+    // 与 _SubtitleWaveformAlignPanelState._windowEndMs 同一算式，保证键盘直达路径与
+    // 面板入口路径画出的时间轴一致。
+    final int durationMs = controller.durationMs ?? 0;
+    final int windowEndMs =
+        (durationMs > 0 && durationMs < kSubtitleAutoAlignProbeLimitMs)
+            ? durationMs
+            : kSubtitleAutoAlignProbeLimitMs;
+    final bool canAutoAlign = cues.isNotEmpty && videoPath.isNotEmpty;
+    if (!context.mounted) return;
+    await showDialog<void>(
+      context: context,
+      useRootNavigator: true,
+      builder: (BuildContext _) => SubtitleWaveformZoomView(
+        rawEnvelope: env,
+        cues: cues,
+        windowEndMs: windowEndMs,
+        initialDelayMs: _delayMs,
+        onCommitDelay: _setDelayMs,
+        onAutoAlign: canAutoAlign ? _autoAlignSubtitle : null,
+        onPlayCue: (int startMs) async {
+          await controller.seekMs(startMs);
+          await controller.play();
+        },
+        isPlaying: () => controller.isPlaying,
+        onTogglePlayPause: () async {
+          await controller.togglePlayPause();
+        },
+        // 弹窗内复用视频页 registry 驱动的整表（尊重重映射）；排除会破坏弹窗自身的动作
+        // （Escape 关弹窗 / 全屏 / 打开字幕列表 / 沉浸锁 / 再次打开对轴弹窗——避免递归叠栈）。
+        keyboardShortcuts: buildVideoPlayerShortcutsFromRegistry(
+          appModel.shortcutRegistry,
+          _buildVideoShortcutActions(controller),
+          exclude: const <ShortcutAction>{
+            ShortcutAction.videoEscape,
+            ShortcutAction.videoToggleFullscreen,
+            ShortcutAction.videoToggleSubtitleList,
+            ShortcutAction.videoToggleImmersiveLock,
+            ShortcutAction.videoOpenSubtitleAlign,
+          },
+        ),
+        onSeek: (int ms) async {
+          await controller.seekMs(ms);
+        },
+        positionListenable: controller,
+        // positionMs 可空（未就绪）；与快速设置面板路径同用 -1 哨兵 = 不画播放头。
+        currentPositionMs: () => controller.positionMs ?? -1,
+      ),
+    );
+  }
 }
+
+/// 字幕延迟 +/- 快捷键（用户请求，默认 z/x）每次整体平移的步进（毫秒）。取 100ms
+/// = mpv 字幕延迟键 `z`/`x` 的 0.1s 惯例；与快速设置面板 ±50 / ±1000 步进正交（都经
+/// [_setDelayMs] 写穿同一权威 `_delayMs`）。
+const int _kSubtitleDelayNudgeMs = 100;

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -80,6 +80,7 @@ import 'package:hibiki/src/media/video/video_chapter_panel.dart';
 import 'package:hibiki/src/media/video/audio_energy_probe.dart';
 import 'package:hibiki/src/media/video/waveform_envelope_cache.dart';
 import 'package:hibiki/src/media/video/subtitle_auto_align.dart';
+import 'package:hibiki/src/media/video/subtitle_waveform_align_panel.dart';
 import 'package:hibiki/src/media/video/video_chapter_markers.dart';
 import 'package:hibiki/src/media/video/video_clip_exporter.dart';
 import 'package:hibiki/src/media/video/video_episode_panel.dart';
@@ -3806,6 +3807,18 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
         _pokeControlsVisible();
         unawaited(controller.nextChapter());
       }),
+      // 字幕对轴/匹配（用户请求）：Shift+A 一键弹波形对轴放大视图；z/x 整体平移字幕延迟
+      // ±_kSubtitleDelayNudgeMs（走 _setDelayMs 写穿 delayMs 落盘 + OSD）。都过沉浸门控，
+      // 与顶部快速设置面板同源、零第二套状态。
+      openSubtitleAlign: () => _runWhenImmersiveAllowsFullControls(
+        () => unawaited(_openSubtitleWaveformAlign()),
+      ),
+      subtitleDelayIncrease: () => _runWhenImmersiveAllowsFullControls(
+        () => unawaited(_setDelayMs(_delayMs + _kSubtitleDelayNudgeMs)),
+      ),
+      subtitleDelayDecrease: () => _runWhenImmersiveAllowsFullControls(
+        () => unawaited(_setDelayMs(_delayMs - _kSubtitleDelayNudgeMs)),
+      ),
       escape: () {
         if (_videoControlEditMode.value) {
           _hideVideoControlEditOverlay(revealControls: false);
@@ -5323,6 +5336,8 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
                 ShortcutAction.videoToggleFullscreen,
                 ShortcutAction.videoToggleSubtitleList,
                 ShortcutAction.videoToggleImmersiveLock,
+                // 对轴弹窗内再按「打开对轴」不叠第二层弹窗（与键盘直达路径一致）。
+                ShortcutAction.videoOpenSubtitleAlign,
               },
             ),
       // 点击字幕波形把播放头跳过去（seek 到该 x 对应的时间，不强制播放，保留当前播放态）。

--- a/hibiki/lib/src/shortcuts/shortcut_action.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_action.dart
@@ -153,6 +153,16 @@ enum ShortcutAction {
   videoCycleSubtitleObscure(
       ShortcutScope.video, 'video_cycle_subtitle_obscure'),
   videoToggleSubtitleHide(ShortcutScope.video, 'video_toggle_subtitle_hide'),
+  // 字幕对轴/匹配快捷键（用户请求）：把埋在快速设置面板深处的「字幕调轴」直接搬到
+  // 键盘。videoOpenSubtitleAlign 一键弹波形对轴放大视图（复用 SubtitleWaveformZoomView，
+  // 与面板入口同一逻辑、零第二套状态）；videoSubtitleDelayIncrease/Decrease 像 mpv 的
+  // z/x 一样按固定步进整体平移字幕延迟（走现有 _setDelayMs 写穿 delayMs 落盘）。三者都
+  // 在 video 独立 co-active 组内，默认键与既有视频键无冲突。
+  videoOpenSubtitleAlign(ShortcutScope.video, 'video_open_subtitle_align'),
+  videoSubtitleDelayIncrease(
+      ShortcutScope.video, 'video_subtitle_delay_increase'),
+  videoSubtitleDelayDecrease(
+      ShortcutScope.video, 'video_subtitle_delay_decrease'),
 
   // Gamepad（TODO-700 T6）：dpad 四向作为可绑触发键。默认各绑对应 dpad 键，执行体
   // = 通用方向焦点移动（与摇杆同效果，但摇杆固定走 onStickMove 通道、不经注册表，

--- a/hibiki/lib/src/shortcuts/shortcut_defaults.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_defaults.dart
@@ -336,6 +336,19 @@ class ShortcutDefaults {
     ShortcutAction.videoToggleSubtitleHide: _kb([
       _key(LogicalKeyboardKey.keyH),
     ]),
+    // 字幕对轴/匹配（用户请求）：打开波形对轴放大视图默认 Shift+A（A=Align，避开裸 A 的
+    // 回退 seek）；字幕延迟 -/+ 默认 z/x（mpv 经典字幕延迟键，每次 ±100ms=mpv 0.1s）。
+    // 三键在 video co-active 组内均未占用（裸 z/x、Shift+A 都是空闲位），无冲突。键盘-only
+    // （手柄不绑，与 videoToggleMute/videoSpeedUp 同范式）。
+    ShortcutAction.videoOpenSubtitleAlign: _kb([
+      _key(LogicalKeyboardKey.keyA, {ModifierKey.shift}),
+    ]),
+    ShortcutAction.videoSubtitleDelayDecrease: _kb([
+      _key(LogicalKeyboardKey.keyZ),
+    ]),
+    ShortcutAction.videoSubtitleDelayIncrease: _kb([
+      _key(LogicalKeyboardKey.keyX),
+    ]),
     // TODO-700 T6：dpad 四向可绑触发键。默认各绑对应 dpad 键；键盘留空（方向焦点
     // 移动由箭头键 / 摇杆负责，避免与各页面方向键语义重复）。执行体 = 通用方向焦点
     // 移动（gamepadMoveFocusInDirection），见 gamepad_service._dispatchButton。

--- a/hibiki/test/media/video/video_player_keyboard_static_test.dart
+++ b/hibiki/test/media/video/video_player_keyboard_static_test.dart
@@ -279,13 +279,42 @@ void main() {
               'Keyboard volume keys must not display volume in the top-left OSD.');
     });
 
-    test('subtitle sync is a settings control, not an arrow-key binding', () {
-      // TODO-060: subtitle sync moved to the settings panel row, committed via
-      // onSetDelay -> _setDelayMs; no arrow-key increment binding.
+    test('subtitle sync is both a settings control and a z/x key binding', () {
+      // TODO-060: subtitle sync is a settings panel row, committed via
+      // onSetDelay -> _setDelayMs. 用户请求（本轮）：额外把整体延迟平移绑到键盘
+      // z/x（mpv 惯例），每次 ±_kSubtitleDelayNudgeMs，走同一 _setDelayMs 写穿路径。
+      // 仍不绑到裸箭头键（箭头是 time seek，TODO-090），故与既有 seek 语义不冲突。
       expect(page.contains('onSetDelay: _setDelayMs'), isTrue);
       expect(page.contains('_setDelayMs'), isTrue);
-      expect(shortcuts.contains('_setDelayMs'), isFalse,
-          reason: 'subtitle sync is not bound to arrows, only in settings');
+      // 键盘默认：z = 减小字幕延迟、x = 增大（video co-active 组内无冲突）。
+      expect(
+          defaultHasKey(ShortcutAction.videoSubtitleDelayDecrease,
+              LogicalKeyboardKey.keyZ),
+          isTrue,
+          reason: 'z decreases subtitle delay (mpv-style)');
+      expect(
+          defaultHasKey(ShortcutAction.videoSubtitleDelayIncrease,
+              LogicalKeyboardKey.keyX),
+          isTrue,
+          reason: 'x increases subtitle delay (mpv-style)');
+      // 裸箭头仍不绑字幕延迟（保持 time seek 语义）。
+      expect(
+          defaultHasKey(ShortcutAction.videoSubtitleDelayDecrease,
+              LogicalKeyboardKey.arrowLeft),
+          isFalse,
+          reason: 'subtitle delay is not bound to bare arrows');
+      // 页面把两个动作接到 _setDelayMs(_delayMs ± step)，与设置面板同一写穿路径。
+      expect(page.contains('_setDelayMs(_delayMs + _kSubtitleDelayNudgeMs)'),
+          isTrue);
+      expect(page.contains('_setDelayMs(_delayMs - _kSubtitleDelayNudgeMs)'),
+          isTrue);
+      // action->callback 接线在 videoActionCallbacks 里。
+      expect(
+          shortcuts.contains(
+              'ShortcutAction.videoSubtitleDelayIncrease: '
+              'actions.subtitleDelayIncrease'),
+          isTrue);
+      // 仍不引入旧的被否决实现名。
       expect(page.contains('_adjustSubtitleOffset'), isFalse);
       expect(page.contains('_subtitleOffsetStepMs'), isFalse);
     });

--- a/hibiki/test/media/video/video_player_shortcuts_dispatch_test.dart
+++ b/hibiki/test/media/video/video_player_shortcuts_dispatch_test.dart
@@ -36,6 +36,9 @@ VideoPlayerShortcutActions _recordingVideoActions(List<String> log) {
     replayPreviousSubtitle: () => record('replayPreviousSubtitle'),
     previousChapter: () => record('previousChapter'),
     nextChapter: () => record('nextChapter'),
+    openSubtitleAlign: () => record('openSubtitleAlign'),
+    subtitleDelayIncrease: () => record('subtitleDelayIncrease'),
+    subtitleDelayDecrease: () => record('subtitleDelayDecrease'),
     escape: () => record('escape'),
   );
 }

--- a/hibiki/test/pages/video_fullscreen_gamepad_dispatch_test.dart
+++ b/hibiki/test/pages/video_fullscreen_gamepad_dispatch_test.dart
@@ -217,6 +217,9 @@ class _Rig {
       replayPreviousSubtitle: _noop,
       previousChapter: _noop,
       nextChapter: _noop,
+      openSubtitleAlign: _noop,
+      subtitleDelayIncrease: _noop,
+      subtitleDelayDecrease: _noop,
       escape: () {
         bump(ShortcutAction.videoEscape);
         if (state.fullscreenActive) {

--- a/hibiki/test/shortcuts/shortcut_load_order_test.dart
+++ b/hibiki/test/shortcuts/shortcut_load_order_test.dart
@@ -46,13 +46,14 @@ void main() {
   late HibikiDatabase db;
   late ReaderHibikiSource source;
 
-  // A non-default custom binding for a video action: KeyZ (no modifiers) mapped
+  // A non-default custom binding for a video action: KeyG (no modifiers) mapped
   // to "toggle play/pause", which defaults to Space/P/MediaPlayPause and never
-  // KeyZ. Resolving KeyZ in the video scope therefore proves the *custom* JSON
-  // was loaded, not the defaults.
+  // KeyG. Resolving KeyG in the video scope therefore proves the *custom* JSON
+  // was loaded, not the defaults. (KeyZ/KeyX are now default subtitle-delay
+  // bindings, so this sentinel deliberately uses a still-unbound key.)
   final String customJson = jsonEncode(<String, dynamic>{
     ShortcutAction.videoTogglePlayPause.key: <String, dynamic>{
-      'keyboard': <String>['KeyZ'],
+      'keyboard': <String>['KeyG'],
       'gamepad': <String>[],
       'mouse': <String>[],
     },
@@ -94,10 +95,10 @@ void main() {
     final HibikiShortcutRegistry registry = HibikiShortcutRegistry();
     await loadShortcutRegistry(registry, source, TargetPlatform.windows);
 
-    // Custom key KeyZ is NOT recognised — the registry only has defaults.
+    // Custom key KeyG is NOT recognised — the registry only has defaults.
     expect(
       registry.resolveKeyboard(
-        LogicalKeyboardKey.keyZ,
+        LogicalKeyboardKey.keyG,
         modifiers: const <ModifierKey>{},
         scope: ShortcutScope.video,
       ),
@@ -127,10 +128,10 @@ void main() {
     final HibikiShortcutRegistry registry = HibikiShortcutRegistry();
     await loadShortcutRegistry(registry, source, TargetPlatform.windows);
 
-    // The custom KeyZ binding for toggle-play-pause is now active.
+    // The custom KeyG binding for toggle-play-pause is now active.
     expect(
       registry.resolveKeyboard(
-        LogicalKeyboardKey.keyZ,
+        LogicalKeyboardKey.keyG,
         modifiers: const <ModifierKey>{},
         scope: ShortcutScope.video,
       ),

--- a/hibiki/test/shortcuts/video_shortcut_registry_test.dart
+++ b/hibiki/test/shortcuts/video_shortcut_registry_test.dart
@@ -39,6 +39,9 @@ VideoPlayerShortcutActions _recordingActions(List<String> log) {
     replayPreviousSubtitle: () => log.add('replayPreviousSubtitle'),
     previousChapter: () => log.add('previousChapter'),
     nextChapter: () => log.add('nextChapter'),
+    openSubtitleAlign: () => log.add('openSubtitleAlign'),
+    subtitleDelayIncrease: () => log.add('subtitleDelayIncrease'),
+    subtitleDelayDecrease: () => log.add('subtitleDelayDecrease'),
     escape: () => log.add('escape'),
   );
 }


### PR DESCRIPTION
## 背景
用户请求「调整匹配字幕快捷键 加一个」。字幕对轴/匹配功能此前只能经「控制栏 tune → 快速设置面板 → 字幕调轴区 → 点波形入口」四级操作触达，**零快捷键**。本轮把它搬到键盘。

用户选定（AskUserQuestion）：**① 打开波形对轴对话框** + **③ 微调字幕延迟 +/-**；默认键「按惯例定」。

## 改动
新增 3 个 `ShortcutScope.video` 可重映射快捷键动作（进 `HibikiShortcutRegistry`、可在快捷键设置页改键、带冲突检测），默认键在 video co-active 组内均未占用、无冲突、键盘-only：

| 动作 | 默认键 | 行为 |
|---|---|---|
| `videoOpenSubtitleAlign` | **Shift+A** | 一键弹波形对轴放大视图（复用 `SubtitleWaveformZoomView`，与快速设置面板入口同一逻辑、零第二套状态）；无字幕 / 无本地视频路径 / 抽不到波形时降级 OSD 提示、不弹窗 |
| `videoSubtitleDelayDecrease` | **z** | 字幕延迟整体 −100ms（mpv 惯例，走现有 `_setDelayMs` 写穿 `delayMs` 落盘 + OSD） |
| `videoSubtitleDelayIncrease` | **x** | 字幕延迟整体 +100ms |

落点：
- `shortcut_action.dart` 枚举 + `shortcut_defaults.dart` 三平台默认键
- `video_player_shortcuts.dart` `VideoPlayerShortcutActions` 三回调 + `videoActionCallbacks` 接线
- `video_hibiki_page.dart` `_buildVideoShortcutActions` 接线 + 步进常量 `_kSubtitleDelayNudgeMs`
- `subtitle.part.dart` 新增页面级 `_openSubtitleWaveformAlign()`（复刻面板入口懒抽波形 → 弹窗；对轴弹窗内 exclude `videoOpenSubtitleAlign` 防递归叠栈）
- `shortcut_settings_page.dart` 三个 `_actionLabel` 分支
- 3 个 i18n key（17 语言，经 `i18n_sync.dart` + `dart run slang` 生成）

## 测试
- `flutter analyze lib` 全绿
- `test/shortcuts/`、`test/i18n/`、`test/media/video/`（1577）全过
- 同步更新受影响测试：补三处 `VideoPlayerShortcutActions` 构造参数；`shortcut_load_order_test` 哨兵键 KeyZ→KeyG（z 现在是默认字幕延迟键）；按新事实重写 `video_player_keyboard_static_test` 的字幕同步键位守卫（现断言 z/x 绑定 + 裸箭头仍不绑）

## 待验证
真机复测：视频页 Shift+A 弹对轴对话框、z/x 平移字幕延迟并看 OSD；快捷键设置页可改这三个键。