### PR TITLE
fix(video): 字幕列表Shift悬停/点字查词偏左一格 (BUG-910)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 890 条。点号进各自文件。
+> 共 891 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-910](bugs/BUG-910-subtitle-list-shift-hover-offset.md) | ✅ | ✅ | 视频字幕列表Shift悬停查词偏左一格 |
 | [BUG-909](bugs/BUG-909-remove-vertical-forensic-probes.md) | ✅ | ✅ | 移除发布版残留的竖排取证探针（TODO-792/753 系列 + 753-DIAG） |
 | [BUG-908](bugs/BUG-908-lan-sync-server-hardening.md) | ✅ | ✅ | LAN 局域网同步服务器健壮性欠账（token 膨胀 / PROPFIND 同步阻塞 / 写无互斥） |
 | [BUG-907](bugs/BUG-907-danmaku-layout-binary-and-isolate-parse.md) | ✅ | ✅ | 弹幕两项性能缺陷：布局每帧 O(N) 全量扫描 + 20MB sidecar 主 isolate 同步解析 |

--- a/docs/bugs/BUG-910-subtitle-list-shift-hover-offset.md
+++ b/docs/bugs/BUG-910-subtitle-list-shift-hover-offset.md
@@ -1,0 +1,8 @@
+## BUG-910 · 视频字幕列表Shift悬停查词偏左一格
+- **报告**：2026-07-19（用户：录屏 `Hibiki 2026-07-19 03-02-42.mp4`）
+- **真实性**：✅ 真 bug。录屏在字幕列表面板 Shift 悬停 / 点字查词，句「もみじは私の護衛ね 人多いし…」逐字验证：指向「護」查出「の」、指向「ね」查出「衛」、指向「衛」查出「護衛」——命中系统性**偏左一格**（多帧一致，光标静止时也偏，非 lag）。根因 `hibiki/lib/src/media/video/video_subtitle_jump_panel.dart:157`（旧 `subtitleGraphemeIndexForOffset`）。
+- **[x] ① 已修复** — 根因：tap 的 `hitAt` 与 hover/barrier 的 `subtitleListCharHitFromParagraph` 都走 `TextPainter/RenderParagraph.getPositionForOffset(point).offset` 取 caret 边界，再经 `subtitleGraphemeIndexForOffset` 映射回字下标。`getPositionForOffset` 把某字**左半格与右半格的点塌陷到同一条 caret 边界**（点在字 i 左半 → 返回 `starts[i]`，即字 i 与 i-1 之间的边界），仅凭偏移量无法区分点落在边界哪侧；旧映射的 `if (offset <= starts[i]) return i-1` 又把边界**一律归左字**。叠加命中盒 `inflate(height*0.5)` 的半字格容差，把左邻字的盒撑进本字、坐实偏左命中。修复：丢弃 caret 偏移这层，新增纯函数 `resolveSubtitleListGraphemeHit`——对**每个 grapheme 的真实渲染盒**（`BoxHeightStyle.max` 覆盖行距 leading）对**真实像素点**做几何命中（先 `Rect.contains` 后半字宽最近兜底）。两条命中 helper 同源改用它，删掉 `subtitleGraphemeIndexForOffset`。提交：<待填>。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/media/video/video_subtitle_jump_panel_hit_tester_test.dart`：纯函数 `resolveSubtitleListGraphemeHit` 用合成矩形钉死「点某字**左半格**必命中该字本身、不偏左」+ 边界归右字 + 半字宽容差兜底 + 空盒跳过。
+  - `hibiki/test/media/video/video_subtitle_jump_panel_test.dart`：`BUG-910` widget 回归——tap 全角字「う」的**左 1/4** 处必查「う」（旧实现查左邻「い」）；两条 source guard 钉死 tap / hover / barrier 三路命中均走 `resolveSubtitleListGraphemeHit`、不得回落 `getPositionForOffset(`。
+- **备注**：既有 widget 测试全部叩字符**中心**——中心点被 `getPositionForOffset` 丸到字**末尾**边界、旧映射偶然返回正确下标，故这条偏左 bug 一直躲过绿门。新增左半格用例正是补这个盲区。命中盒 `BoxHeightStyle.max`（BUG-879 覆盖行距 leading，「点了不出词」的一半病因）保留，未回退。

--- a/hibiki/lib/src/media/video/video_subtitle_jump_panel.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_jump_panel.dart
@@ -33,6 +33,51 @@ double subtitleTimestampColumnWidth(double effectiveFontSize, bool hasHours) {
   return scaled < floor ? floor : scaled;
 }
 
+/// 按局部坐标在一行字幕的 grapheme 屏幕矩形里反查命中的字下标（纯函数，可测）。
+///
+/// BUG-910：旧实现走 `TextPainter.getPositionForOffset(point).offset` 取 caret 边界、
+/// 再映射回字下标。但 `getPositionForOffset` 把某字**左半格与右半格的点塌陷到同一条 caret
+/// 边界**（点在字 i 左半 → 返回 `starts[i]`，即字 i 与 i-1 之间的边界），单凭这个偏移量
+/// 无法区分点落在边界哪一侧；旧 `graphemeIndexForOffset` 又把边界一律归给**左边**那个字
+/// （`offset <= starts[i]` 返回 `i-1`），于是指向某字左半时系统性查到**左边一个字**
+/// （视频里指「護」查出「の」、指「ね」查出「衛」）。
+///
+/// 根治：丢弃 caret 偏移这一层，直接用**真实像素点**做几何命中——
+/// 1. 先取包含点的字（[Rect.contains] 含左/上边、排右/下边，故落在两字边界的点归**右侧**
+///    那个字，与「指向某字起笔」的直觉一致）。
+/// 2. miss 则取欧氏距离最近、且在半字宽 / [minTolerance] 容差内的字（兜底 [Wrap] 字缝、
+///    换行首尾的空隙）。垂直用 clamp 距离参与，避免把点归到相邻行的远字。
+///
+/// 空矩形（零宽组合字符等）跳过。无有效矩形或全部超容差返回 -1。
+@visibleForTesting
+int resolveSubtitleListGraphemeHit(
+  List<Rect> graphemeRects,
+  Offset point, {
+  double minTolerance = 4.0,
+}) {
+  for (int i = 0; i < graphemeRects.length; i++) {
+    final Rect r = graphemeRects[i];
+    if (r.isEmpty) continue;
+    if (r.contains(point)) return i;
+  }
+  int bestIndex = -1;
+  double bestDistance = double.infinity;
+  for (int i = 0; i < graphemeRects.length; i++) {
+    final Rect r = graphemeRects[i];
+    if (r.isEmpty) continue;
+    final double dx = point.dx.clamp(r.left, r.right) - point.dx;
+    final double dy = point.dy.clamp(r.top, r.bottom) - point.dy;
+    final double distance = dx * dx + dy * dy;
+    if (distance >= bestDistance) continue;
+    final double tolerance = (r.width / 2).clamp(minTolerance, double.infinity);
+    if (distance <= tolerance * tolerance) {
+      bestDistance = distance;
+      bestIndex = i;
+    }
+  }
+  return bestIndex;
+}
+
 /// 字幕列表行字号缩放档位（BUG-878）。原上限只到 1.3×，用户反馈「字号拉到最大才够用、
 /// 上限不够」，向上扩到 2.0×（1.5 / 1.75 / 2.0 三档）。默认档 [_kDefaultFontScaleIndex]=1
 /// （1.0×）。数组扩容后旧持久化下标仍安全（seed / [_stepFont] 都 clamp 到数组范围）。
@@ -106,22 +151,6 @@ List<int> subtitleGraphemeEndOffsets(String text) {
   return ends;
 }
 
-/// 把 UTF-16 [offset] 映射到 grapheme 下标：落在某 grapheme 区间内即命中该 grapheme，
-/// 落在起点前归第一个、越界归最后一个。[starts]/[ends] 为同源 grapheme 偏移表。
-@visibleForTesting
-int subtitleGraphemeIndexForOffset(
-  int offset,
-  List<int> starts,
-  List<int> ends,
-) {
-  if (starts.isEmpty) return -1;
-  for (int i = 0; i < starts.length; i++) {
-    if (offset <= starts[i]) return i == 0 ? 0 : i - 1;
-    if (offset <= ends[i]) return i;
-  }
-  return starts.length - 1;
-}
-
 Rect _subtitleUnionBoxes(List<TextBox> boxes) {
   if (boxes.isEmpty) return Rect.zero;
   Rect rect = boxes.first.toRect();
@@ -147,26 +176,26 @@ SubtitleListCharHit? subtitleListCharHitFromParagraph(
   final List<int> starts = subtitleGraphemeStartOffsets(text);
   if (starts.isEmpty) return null;
   final List<int> ends = subtitleGraphemeEndOffsets(text);
-  final int offset = paragraph.getPositionForOffset(localPosition).offset;
+  // BUG-910：对**每个 grapheme 的真实渲染盒**做几何命中，不再走 getPositionForOffset 的
+  // caret 边界（后者把某字左右半格塌陷到同一边界、无法区分点在哪侧 → 旧实现系统性偏左一格）。
+  // BUG-879：盒用 BoxHeightStyle.max 覆盖整行视觉格（含 1.25 行高的 leading），点在行距里
+  // 也落在盒内命中，不退 seek。
+  final List<Rect> rects = <Rect>[
+    for (int i = 0; i < starts.length; i++)
+      _subtitleUnionBoxes(
+        paragraph.getBoxesForSelection(
+          TextSelection(baseOffset: starts[i], extentOffset: ends[i]),
+          boxHeightStyle: BoxHeightStyle.max,
+        ),
+      ),
+  ];
   final int graphemeIndex =
-      subtitleGraphemeIndexForOffset(offset, starts, ends);
+      resolveSubtitleListGraphemeHit(rects, localPosition);
   if (graphemeIndex < 0) return null;
-  final int start = starts[graphemeIndex];
-  final int end = ends[graphemeIndex];
-  Rect localRect = _subtitleUnionBoxes(
-    paragraph.getBoxesForSelection(
-      TextSelection(baseOffset: start, extentOffset: end),
-      // BUG-879：盒覆盖整行视觉格（含行距 leading），默认 tight 只贴字形、点在 1.25 行高的
-      // 上下 leading 里就落空 → 退 seek（「点了不出词」的一半病因）。
-      boxHeightStyle: BoxHeightStyle.max,
-    ),
-  );
-  if (localRect.isEmpty) return null;
+  Rect localRect = rects[graphemeIndex];
   if (!localRect.contains(localPosition)) {
-    // BUG-879：容差从 1px 放宽到半个字格（≈ 行高一半，CJK 方块字 ≈ 半字宽），与画面字幕
-    // resolveSubtitleCharHit 的半字宽字缝兜底同量级——点在字缝 / 行距上仍命中最近字符。
-    final double tol = localRect.height * 0.5;
-    if (!localRect.inflate(tol).contains(localPosition)) return null;
+    // 字缝 / 行距上的兜底命中：把返回盒扩到含点，保证 charRect 始终含指针（浮层锚点、
+    // barrier 反查的 contains 判定不落空）。
     localRect = localRect.expandToInclude(
       Rect.fromCenter(center: localPosition, width: 1, height: 1),
     );
@@ -1252,8 +1281,8 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
           required Offset localPosition,
           required Offset globalPosition,
         }) {
-          // BUG-874：grapheme 映射 / 选区盒并集用顶层纯 helper（与 barrier 反查
-          // [subtitleListCharHitFromParagraph] 同源），此处仅 caret 兜底沿用 TextPainter。
+          // BUG-874：grapheme 偏移表用顶层纯 helper（与 barrier 反查
+          // [subtitleListCharHitFromParagraph] 同源）。
           final List<int> starts = subtitleGraphemeStartOffsets(cue.text);
           final List<int> ends = subtitleGraphemeEndOffsets(cue.text);
           if (starts.isEmpty) return null;
@@ -1267,43 +1296,28 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
           );
           try {
             painter.layout(maxWidth: maxWidth);
-            final int offset =
-                painter.getPositionForOffset(localPosition).offset;
+            // BUG-910：与 barrier / hover 反查同款——对每个 grapheme 的真实渲染盒做几何命中，
+            // 不再走 getPositionForOffset 的 caret 边界（会把某字左右半格塌陷到同一边界、
+            // 系统性偏左一格）。BUG-879：BoxHeightStyle.max 覆盖整行视觉格，点在行距里也命中。
+            final List<Rect> rects = <Rect>[
+              for (int i = 0; i < starts.length; i++)
+                _subtitleUnionBoxes(
+                  painter.getBoxesForSelection(
+                    TextSelection(baseOffset: starts[i], extentOffset: ends[i]),
+                    boxHeightStyle: BoxHeightStyle.max,
+                  ),
+                ),
+            ];
             final int graphemeIndex =
-                subtitleGraphemeIndexForOffset(offset, starts, ends);
+                resolveSubtitleListGraphemeHit(rects, localPosition);
             if (graphemeIndex < 0) return null;
-            final int start = starts[graphemeIndex];
-            final int end = ends[graphemeIndex];
-            Rect localRect = _subtitleUnionBoxes(
-              painter.getBoxesForSelection(
-                TextSelection(baseOffset: start, extentOffset: end),
-                // BUG-879：盒覆盖整行视觉格（含 1.25 行高的 leading），与 barrier 反查
-                // [subtitleListCharHitFromParagraph] 同款，消除点在行距/字缝落空退 seek。
-                boxHeightStyle: BoxHeightStyle.max,
-              ),
-            );
-            if (localRect.isEmpty) {
-              final Offset caretOffset = painter.getOffsetForCaret(
-                TextPosition(offset: start),
-                Rect.fromLTWH(0, 0, 1, painter.preferredLineHeight),
-              );
-              localRect = Rect.fromLTWH(
-                caretOffset.dx,
-                caretOffset.dy,
-                1,
-                painter.preferredLineHeight,
-              );
-            }
+            Rect localRect = rects[graphemeIndex];
             if (!localRect.contains(localPosition)) {
-              // BUG-879：容差 1px→半字格（≈ 行高一半，CJK ≈ 半字宽），与画面字幕
-              // resolveSubtitleCharHit 的半字宽字缝兜底同量级，点字缝仍命中最近字符。
-              final double tol = localRect.height * 0.5;
-              if (!localRect.inflate(tol).contains(localPosition)) return null;
+              // 字缝 / 行距兜底命中：扩盒含点，保证 charRect 始终含指针。
               localRect = localRect.expandToInclude(
                 Rect.fromCenter(center: localPosition, width: 1, height: 1),
               );
             }
-            if (localRect.isEmpty) return null;
             final Offset globalOrigin = globalPosition - localPosition;
             return (
               graphemeIndex: graphemeIndex,

--- a/hibiki/test/media/video/video_subtitle_jump_panel_hit_tester_test.dart
+++ b/hibiki/test/media/video/video_subtitle_jump_panel_hit_tester_test.dart
@@ -97,19 +97,57 @@ void main() {
         expect(starts[i], ends[i - 1]);
       }
     });
+  });
 
-    test('offset maps back to the containing grapheme index', () {
-      const String text = 'a👩‍💻b';
-      final List<int> starts = subtitleGraphemeStartOffsets(text);
-      final List<int> ends = subtitleGraphemeEndOffsets(text);
-      expect(subtitleGraphemeIndexForOffset(0, starts, ends), 0);
-      // 落在中间 ZWJ 表情内部任一 UTF-16 偏移都归第 2 个 grapheme（下标 1）。
-      expect(subtitleGraphemeIndexForOffset(2, starts, ends), 1);
-      expect(subtitleGraphemeIndexForOffset(ends.last, starts, ends), 2);
+  // BUG-910：字幕列表 Shift-悬停 / tap 查词系统性「偏左一格」——指向「護」查出「の」、
+  // 指「ね」查出「衛」。病根是旧命中走 getPositionForOffset 的 caret 边界：点落在某字**左
+  // 半格**时返回该字左边界（= 与左邻字之间的边界），旧映射又把边界一律归**左**字。改由
+  // resolveSubtitleListGraphemeHit 对**每个字的真实渲染盒**做几何命中（先 contains 后半字宽
+  // 最近），对真实像素点判定、不再塌陷左右半格。下面用合成矩形钉死这条纯函数判定。
+  group('resolveSubtitleListGraphemeHit (BUG-910 几何命中，不偏左)', () {
+    // 三个连续方块字：[0,30) [30,60) [60,90)，行高 40。
+    final List<Rect> rects = <Rect>[
+      const Rect.fromLTWH(0, 0, 30, 40),
+      const Rect.fromLTWH(30, 0, 30, 40),
+      const Rect.fromLTWH(60, 0, 30, 40),
+    ];
+
+    test('点在字内 → 该字（含左半格，回归病根）', () {
+      // 中间字**左半格** x=35：旧实现查到左邻字（下标 0），几何命中返回本字（下标 1）。
+      expect(resolveSubtitleListGraphemeHit(rects, const Offset(35, 20)), 1,
+          reason: '指向某字左半格必须命中该字本身，不偏左一格');
+      // 中间字右半格 x=55 同样命中本字。
+      expect(resolveSubtitleListGraphemeHit(rects, const Offset(55, 20)), 1);
+      // 首字左端、末字右端。
+      expect(resolveSubtitleListGraphemeHit(rects, const Offset(2, 20)), 0);
+      expect(resolveSubtitleListGraphemeHit(rects, const Offset(88, 20)), 2);
     });
 
-    test('empty text → -1', () {
-      expect(subtitleGraphemeIndexForOffset(0, <int>[], <int>[]), -1);
+    test('两字边界点归右侧字（Rect.contains 含左边、排右边）', () {
+      expect(resolveSubtitleListGraphemeHit(rects, const Offset(30, 20)), 1);
+      expect(resolveSubtitleListGraphemeHit(rects, const Offset(60, 20)), 2);
+    });
+
+    test('字缝 / 越界：半字宽容差内取最近，超出返回 -1', () {
+      // 右端外 10px（< 半字宽 15）→ 命中末字。
+      expect(resolveSubtitleListGraphemeHit(rects, const Offset(100, 20)), 2);
+      // 远在右侧（> 半字宽）→ 无命中。
+      expect(resolveSubtitleListGraphemeHit(rects, const Offset(140, 20)), -1);
+    });
+
+    test('空矩形跳过；全空 → -1', () {
+      expect(
+        resolveSubtitleListGraphemeHit(
+          <Rect>[Rect.zero, const Rect.fromLTWH(30, 0, 30, 40)],
+          const Offset(40, 20),
+        ),
+        1,
+      );
+      expect(
+          resolveSubtitleListGraphemeHit(
+              <Rect>[Rect.zero, Rect.zero], const Offset(5, 5)),
+          -1);
+      expect(resolveSubtitleListGraphemeHit(<Rect>[], const Offset(5, 5)), -1);
     });
   });
 

--- a/hibiki/test/media/video/video_subtitle_jump_panel_test.dart
+++ b/hibiki/test/media/video/video_subtitle_jump_panel_test.dart
@@ -85,6 +85,51 @@ Rect _unionRects(Iterable<Rect> rects) {
   );
 }
 
+/// 同 [_tapPointForGrapheme]，但取目标字的**左 1/4** 处（而非中心）。BUG-910：中心点会被
+/// getPositionForOffset 丸到字的**末尾**边界、旧命中偶然对；左半格才暴露「偏左一格」病根。
+({Offset tapPoint, int graphemeIndex}) _leftPortionPointForGrapheme(
+  WidgetTester tester,
+  String sentence,
+  String targetGrapheme,
+) {
+  final Finder textFinder = find.text(sentence, findRichText: true);
+  expect(textFinder, findsOneWidget);
+  final BuildContext context = tester.element(textFinder);
+  final RichText richText = tester.widget<RichText>(textFinder);
+  final RenderBox textBox = tester.renderObject<RenderBox>(textFinder);
+  final List<String> graphemes = sentence.characters.toList(growable: false);
+  final int targetIndex = graphemes.indexOf(targetGrapheme);
+  expect(targetIndex, greaterThanOrEqualTo(0), reason: targetGrapheme);
+  int startOffset = 0;
+  for (int i = 0; i < targetIndex; i++) {
+    startOffset += graphemes[i].length;
+  }
+  final int endOffset = startOffset + graphemes[targetIndex].length;
+  final TextPainter painter = TextPainter(
+    text: richText.text,
+    textAlign: TextAlign.start,
+    textDirection: Directionality.of(context),
+    textScaler: MediaQuery.textScalerOf(context),
+    maxLines: null,
+    ellipsis: null,
+  )..layout(maxWidth: textBox.size.width);
+  final Rect targetRect = _unionRects(
+    painter
+        .getBoxesForSelection(
+          TextSelection(baseOffset: startOffset, extentOffset: endOffset),
+        )
+        .map((TextBox box) => box.toRect()),
+  );
+  painter.dispose();
+  expect(targetRect, isNot(Rect.zero));
+  final Offset leftPortion =
+      Offset(targetRect.left + targetRect.width * 0.25, targetRect.center.dy);
+  return (
+    tapPoint: textBox.localToGlobal(leftPortion),
+    graphemeIndex: targetIndex,
+  );
+}
+
 int _builtCueTextWidgetCount(WidgetTester tester) {
   return tester.allWidgets.where((Widget widget) {
     if (widget is Text) {
@@ -769,8 +814,12 @@ void main() {
           reason: 'per-character BuildContext capture must stay removed');
       expect(body, contains('RichText('));
       expect(body, contains('TextPainter('));
-      expect(body, contains('getPositionForOffset'));
       expect(body, contains('getBoxesForSelection'));
+      // BUG-910：命中走 grapheme 真实盒的几何反查，不再用 getPositionForOffset 的 caret
+      // 边界（会把某字左右半格塌陷到同一边界、系统性偏左一格）。
+      expect(body, contains('resolveSubtitleListGraphemeHit'));
+      expect(body, isNot(contains('getPositionForOffset(')),
+          reason: 'BUG-910：tap 命中不得再回落 caret 偏移映射');
       expect(body, contains('MediaQuery.textScalerOf(context)'));
       expect(body, contains('Directionality.of(context)'));
       expect(body, contains('constraints.maxWidth'));
@@ -886,6 +935,39 @@ void main() {
       expect(lookupRect!.contains(tapPoint), isTrue,
           reason: 'returned global charRect must contain the actual tap point');
       expect(seeked, isNull, reason: 'tapping text must look up, not seek');
+    });
+
+    testWidgets(
+        'BUG-910: tapping a character\'s LEFT portion looks up THAT character, '
+        'not the one to its left', (WidgetTester tester) async {
+      final VideoPlayerController controller = VideoPlayerController();
+      addTearDown(controller.dispose);
+      // 全角方块字（视频里的真实场景：の護衛ね…），字宽足够、左半格明显。
+      const String sentence = 'あいうえお';
+      controller.setCues(<AudioCue>[_cue(0, 0, 1000, sentence)]);
+      int? lookupIndex;
+
+      await tester.pumpWidget(_wrap(VideoSubtitleJumpPanel(
+        controller: controller,
+        onTapCue: (_) {},
+        onLookupCue: (AudioCue _, int i, Rect __) => lookupIndex = i,
+        onCopyCue: (_) {},
+        onFavoriteCue: (_) async {},
+        isCueFavorited: (_) => false,
+        onClose: () {},
+        colorScheme: const ColorScheme.dark(),
+        title: 'Subtitle list',
+        emptyHint: 'empty',
+      )));
+
+      // 点「う」（下标 2）的左 1/4 处：旧实现（caret 偏移映射）会查到「い」（下标 1）。
+      final ({int graphemeIndex, Offset tapPoint}) target =
+          _leftPortionPointForGrapheme(tester, sentence, 'う');
+      await tester.tapAt(target.tapPoint);
+      await tester.pump();
+
+      expect(lookupIndex, target.graphemeIndex,
+          reason: '指向某字左半格必须查该字（BUG-910：原本偏左一格查到左邻字）');
     });
 
     testWidgets(
@@ -1548,10 +1630,12 @@ void main() {
           reason: 'hover 查词门控需读 Shift 键状态');
     });
 
-    // Source guard（BUG-879：「点了不出词」的命中收窄病因）：列表命中盒用 BoxHeightStyle.max
-    // 覆盖整行视觉格 + 半字格容差（`height * 0.5`），tap / hover / barrier 四路共用的两个
-    // 命中 helper 都必须放宽，否则点在行距/字缝落空退 seek。撤修复（回 1px / tight）→ 红。
-    test('BUG-879 source guard: list char hit uses forgiving box + tolerance',
+    // Source guard（BUG-879 命中收窄 + BUG-910 偏左一格）：tap / hover / barrier 三路共用的
+    // 两个命中 helper 都必须①用 BoxHeightStyle.max 覆盖整行视觉格（点在行距 leading 不落空
+    // 退 seek），②走 grapheme 真实盒的几何反查 resolveSubtitleListGraphemeHit（不再用
+    // getPositionForOffset 的 caret 边界，否则某字左半格查到左边一个字）。撤任一 → 红。
+    test(
+        'BUG-879/910 source guard: list char hit uses forgiving box + geometry',
         () {
       final String source =
           File('lib/src/media/video/video_subtitle_jump_panel.dart')
@@ -1564,9 +1648,10 @@ void main() {
       );
       expect(paraHit, contains('BoxHeightStyle.max'),
           reason: 'RenderParagraph 反查须用 BoxHeightStyle.max 覆盖行距 leading');
-      expect(paraHit, contains('localRect.height * 0.5'),
-          reason: '容差须放宽到半字格（不再 1px），点字缝仍命中');
-      expect(paraHit, isNot(contains('inflate(1)')), reason: '旧 1px 容差必须已移除');
+      expect(paraHit, contains('resolveSubtitleListGraphemeHit'),
+          reason: 'BUG-910：须用 grapheme 真实盒几何反查');
+      expect(paraHit, isNot(contains('getPositionForOffset(')),
+          reason: 'BUG-910：不得再用 caret 偏移映射（偏左一格病根）');
       // tap 路径的 TextPainter 反查。
       final String tapHit = _sourceBetween(
         source,
@@ -1575,8 +1660,10 @@ void main() {
       );
       expect(tapHit, contains('BoxHeightStyle.max'),
           reason: 'tap 命中也须用 BoxHeightStyle.max');
-      expect(tapHit, contains('localRect.height * 0.5'),
-          reason: 'tap 容差同样放宽到半字格');
+      expect(tapHit, contains('resolveSubtitleListGraphemeHit'),
+          reason: 'BUG-910：tap 命中同走 grapheme 真实盒几何反查');
+      expect(tapHit, isNot(contains('getPositionForOffset(')),
+          reason: 'BUG-910：tap 命中不得再用 caret 偏移映射');
     });
   });
 


### PR DESCRIPTION
## 症状
用户录屏（`Hibiki 2026-07-19 03-02-42.mp4`）：视频右侧字幕列表面板 Shift 悬停 / 点字查词，句「もみじは私の護衛ね 人多いし…」逐字验证——指向「護」查出「の」、指「ね」查出「衛」、指「衛」查出「護衛」，命中系统性**偏左一格**（多帧一致，光标静止也偏，非 lag）。

## 根因
tap 的 `hitAt` 与 hover/barrier 的 `subtitleListCharHitFromParagraph` 都走 `getPositionForOffset(point).offset` 取 caret 边界，再经 `subtitleGraphemeIndexForOffset` 映射回字下标。`getPositionForOffset` 把某字**左半格与右半格的点塌陷到同一条 caret 边界**（点在字 i 左半 → 返回 `starts[i]`，即 i 与 i-1 之间的边界），仅凭偏移无法区分点落在哪侧；旧映射 `if (offset <= starts[i]) return i-1` 又把边界**一律归左字**，叠加命中盒 `inflate(height*0.5)` 半字格容差坐实偏左命中。

## 修复
丢弃 caret 偏移这层，新增纯函数 `resolveSubtitleListGraphemeHit`——对**每个 grapheme 的真实渲染盒**（`BoxHeightStyle.max` 保留 BUG-879 覆盖行距 leading）对**真实像素点**做几何命中（先 `Rect.contains` 后半字宽最近兜底）。tap/hover/barrier 三路命中同源改用它，删除病根 `subtitleGraphemeIndexForOffset`。

## 测试（②）
- `video_subtitle_jump_panel_hit_tester_test.dart`：纯函数用合成矩形钉死「点某字**左半格**必命中该字本身、不偏左」+ 边界归右字 + 半字宽容差 + 空盒跳过。
- `video_subtitle_jump_panel_test.dart`：widget 回归——tap 全角字左 1/4 处必查该字（旧实现查左邻）；两条 source guard 钉死三路均走 `resolveSubtitleListGraphemeHit`、不得回落 `getPositionForOffset(`。
- 既有测试全叩字符**中心**（中心被丸到末尾边界、旧映射偶然对）故一直躲过绿门，新增左半格用例补盲区。

## 验证
- `flutter analyze`（3 文件）No issues。
- `flutter test test/media/video/` 全绿（1580 passed / 2 skipped），含新增 BUG-910 用例与既有 BUG-879 hover。
- 未真机复测（draft 待真机验收）。