### PR TITLE
feat(stats): 首页活动热力图加翻页与每日数值查看

### DIFF
--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -54,6 +54,7 @@ import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/src/sync/video_manifest.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki/src/utils/components/batch_tag_dialog_frame.dart';
+import 'package:hibiki/src/pages/implementations/stat_shared.dart';
 import 'package:hibiki/src/utils/components/stat_contribution_heatmap.dart';
 import 'package:hibiki/src/pages/implementations/collection_name_dialog.dart';
 import 'package:hibiki/src/media/video/video_filename_parser.dart';
@@ -2036,13 +2037,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   }
 
   /// 顶部观看活动热力图卡（GitHub 式贡献图）：按每日观看时长 [_watchMsByDay] 铺
-  /// 最近数周方格，整卡可点开完整视频统计页。取代旧的「总数/未完成/近7天导入」三格
-  /// 状态计数——那是状态而非统计（用户反馈），热力图直观展示观看活跃度。
+  /// 数周方格。可点**标题**打开完整视频统计页；点某天格子弹气泡看当日观看时长；
+  /// 数据超首屏时热力图右上出现翻页箭头看更早历史。取代旧的「总数/未完成/近7天
+  /// 导入」三格状态计数——那是状态而非统计（用户反馈），热力图直观展示观看活跃度。
   Widget _buildWatchHeatmapCard(HibikiDesignTokens tokens) {
-    final StatHeatmapModel model = buildStatHeatmap(
-      valueByDateKey: _watchMsByDay,
-      now: DateTime.now(),
-    );
     return DecoratedBox(
       decoration: ShapeDecoration(
         color: tokens.surfaces.group,
@@ -2057,13 +2055,47 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Text(t.video_watch_activity, style: tokens.type.sectionLabel),
+            _buildStatHeatmapTitle(
+              tokens,
+              t.video_watch_activity,
+              _openStatistics,
+            ),
             SizedBox(height: tokens.spacing.gap),
             StatContributionHeatmap(
-              model: model,
+              valueByDateKey: _watchMsByDay,
+              now: DateTime.now(),
               baseColor: tokens.surfaces.primary,
               emptyColor: tokens.surfaces.card,
-              onTap: _openStatistics,
+              valueLabel: (String dateKey, int ms) =>
+                  '${formatStatHeatmapDay(dateKey)} · ${formatStatTime(ms)}',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 热力图卡可点标题：文字 + 尾随小箭头，点击打开对应统计页（取代旧的整卡 onTap，
+  /// 好把格子点击让给「查看每日数值」）。
+  Widget _buildStatHeatmapTitle(
+    HibikiDesignTokens tokens,
+    String label,
+    VoidCallback onOpen,
+  ) {
+    return InkWell(
+      onTap: onOpen,
+      borderRadius: const BorderRadius.all(Radius.circular(8)),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(label, style: tokens.type.sectionLabel),
+            const SizedBox(width: 2),
+            Icon(
+              Icons.chevron_right,
+              size: 16,
+              color: tokens.type.sectionLabel.color,
             ),
           ],
         ),

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -11,6 +11,7 @@ import 'package:hibiki/media.dart';
 import 'package:hibiki/pages.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki/src/epub/epub_importer.dart';
+import 'package:hibiki/src/pages/implementations/stat_shared.dart';
 import 'package:hibiki/src/utils/components/stat_contribution_heatmap.dart';
 import 'package:hibiki/src/media/audiobook/audiobook_import_dialog.dart';
 import 'package:hibiki/src/media/audiobook/book_import_dialog.dart';
@@ -902,13 +903,10 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
   }
 
   /// 顶部阅读活动热力图卡（GitHub 式贡献图）：按每日阅读字数 [_readingCharsByDay]
-  /// 铺最近数周方格，整卡可点开完整阅读统计页。取代旧的「总数/在读/读完」三格状态
-  /// 计数——那是状态而非统计（用户反馈），热力图直观展示阅读活跃度。
+  /// 铺数周方格。可点**标题**打开完整阅读统计页；点某天格子弹气泡看当日阅读字数；
+  /// 数据超首屏时热力图右上出现翻页箭头看更早历史。取代旧的「总数/在读/读完」三格
+  /// 状态计数——那是状态而非统计（用户反馈），热力图直观展示阅读活跃度。
   Widget _buildReadingHeatmapCard(HibikiDesignTokens tokens) {
-    final StatHeatmapModel model = buildStatHeatmap(
-      valueByDateKey: _readingCharsByDay,
-      now: DateTime.now(),
-    );
     return DecoratedBox(
       decoration: ShapeDecoration(
         color: tokens.surfaces.group,
@@ -923,13 +921,47 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Text(t.reading_activity, style: tokens.type.sectionLabel),
+            _buildStatHeatmapTitle(
+              tokens,
+              t.reading_activity,
+              _openReadingStatistics,
+            ),
             SizedBox(height: tokens.spacing.gap),
             StatContributionHeatmap(
-              model: model,
+              valueByDateKey: _readingCharsByDay,
+              now: DateTime.now(),
               baseColor: tokens.surfaces.primary,
               emptyColor: tokens.surfaces.card,
-              onTap: _openReadingStatistics,
+              valueLabel: (String dateKey, int chars) =>
+                  '${formatStatHeatmapDay(dateKey)} · ${formatStatChars(chars)}',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 热力图卡可点标题：文字 + 尾随小箭头，点击打开对应统计页（取代旧的整卡 onTap，
+  /// 好把格子点击让给「查看每日数值」）。
+  Widget _buildStatHeatmapTitle(
+    HibikiDesignTokens tokens,
+    String label,
+    VoidCallback onOpen,
+  ) {
+    return InkWell(
+      onTap: onOpen,
+      borderRadius: const BorderRadius.all(Radius.circular(8)),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(label, style: tokens.type.sectionLabel),
+            const SizedBox(width: 2),
+            Icon(
+              Icons.chevron_right,
+              size: 16,
+              color: tokens.type.sectionLabel.color,
             ),
           ],
         ),

--- a/hibiki/lib/src/pages/implementations/stat_shared.dart
+++ b/hibiki/lib/src/pages/implementations/stat_shared.dart
@@ -46,6 +46,26 @@ String formatStatTime(int ms) {
   return t.stat_format_hours_minutes(h: h, m: m);
 }
 
+/// 统计页字数外显：≥1 万套「万」文案（保留 1 位小数），否则整数字文案。
+/// 与阅读统计页原私有 `_formatChars` 同口径，供热力图气泡等复用（机械去重）。
+String formatStatChars(int chars) {
+  if (chars >= 10000) {
+    return t.stat_format_chars_wan(n: (chars / 10000).toStringAsFixed(1));
+  }
+  return t.stat_format_chars(n: chars);
+}
+
+/// 热力图气泡日期标签：`M-dd`；跨年补年份成 `Y-M-dd`。[dateKey] 形如 `2026-07-18`
+/// （[statDateKey] 格式）；无法解析时原样返回。
+String formatStatHeatmapDay(String dateKey) {
+  final DateTime? d = DateTime.tryParse(dateKey);
+  if (d == null) return dateKey;
+  final DateTime now = DateTime.now();
+  final String dd = d.day.toString().padLeft(2, '0');
+  if (d.year == now.year) return '${d.month}-$dd';
+  return '${d.year}-${d.month}-$dd';
+}
+
 /// 「今日按小时」柱状图区块（标题 + [StatHourlyChartPainter] 画布）。
 /// [hourlyMs] 为 0-23 每小时的毫秒值。
 Widget buildStatHourlyChartSection(BuildContext context, List<int> hourlyMs) {

--- a/hibiki/lib/src/utils/components/stat_contribution_heatmap.dart
+++ b/hibiki/lib/src/utils/components/stat_contribution_heatmap.dart
@@ -32,24 +32,31 @@ class StatHeatmapModel {
   final int maxValue;
 }
 
-/// 纯函数：把「日期键→活动值」映射构造成最近 [weeks] 周的贡献热力图模型。
+/// 纯函数：把「日期键→活动值」映射构造成一段 [weeks] 周的贡献热力图模型。
 ///
-/// - 以 [now] 所在周的周一为末列起点，向前取 [weeks] 列（每列周一..周日）。
+/// - [weekOffset]（单位=周，≥0）把窗口整体向前平移看历史：0 = 末列为本周（含今天）；
+///   正值 = 末列往前推 [weekOffset] 周，此时窗口全在过去，无未来占位格。
+/// - 以（本周周一 − [weekOffset] 周）为末列起点，向前取 [weeks] 列（每列周一..周日）。
 /// - 每天的值取自 [valueByDateKey]（缺省 0）。
-/// - 今天之后的未来日（末列里 > 今天的格子）为占位格（dateKey=null，level=0）。
+/// - 今天之后的未来日（仅 [weekOffset]==0 的末列里 > 今天的格子）为占位格
+///   （dateKey=null，level=0）。
 /// - 等级：value==0→0；否则按占 [StatHeatmapModel.maxValue] 的比例分 1..4 四档
 ///   （>0 至少 1 档，满值 4 档），空窗口（maxValue==0）全为 0。
 StatHeatmapModel buildStatHeatmap({
   required Map<String, int> valueByDateKey,
   required DateTime now,
   int weeks = 17,
+  int weekOffset = 0,
 }) {
   final DateTime today = DateTime(now.year, now.month, now.day);
   // 本周周一（DateTime.weekday: 周一=1..周日=7）。
   final DateTime thisMonday =
       today.subtract(Duration(days: today.weekday - DateTime.monday));
+  // 窗口末列的周一：翻页时整体向前平移 weekOffset 周。
+  final DateTime anchorMonday =
+      thisMonday.subtract(Duration(days: weekOffset * 7));
   final DateTime firstMonday =
-      thisMonday.subtract(Duration(days: (weeks - 1) * 7));
+      anchorMonday.subtract(Duration(days: (weeks - 1) * 7));
 
   int maxValue = 0;
   final List<List<({String? dateKey, int value, DateTime day})>> raw =
@@ -95,28 +102,94 @@ StatHeatmapModel buildStatHeatmap({
   return StatHeatmapModel(weeks: cols, maxValue: maxValue);
 }
 
-/// GitHub 式贡献热力图组件：自适应可用宽度铺 [StatHeatmapModel.weeks] 列小方格，
-/// 颜色由 [baseColor] 按等级 0..4 加深。整块可 [onTap]（打开完整统计页）。
+/// 纯函数：以 [weeks] 周为翻页步长，能向前翻到的最深 [buildStatHeatmap] `weekOffset`
+/// （单位=周，总是 [weeks] 的整数倍）。返回值 = 「含最早数据那一周」所在页的
+/// weekOffset；无数据或数据都落在首屏（第 0 页）时返回 0（此时无需翻页箭头）。
+int maxHeatmapPageOffset({
+  required Map<String, int> valueByDateKey,
+  required DateTime now,
+  int weeks = 17,
+}) {
+  if (valueByDateKey.isEmpty || weeks <= 0) return 0;
+  String? minKey;
+  for (final String k in valueByDateKey.keys) {
+    if (minKey == null || k.compareTo(minKey) < 0) minKey = k;
+  }
+  final DateTime? earliest = DateTime.tryParse(minKey!);
+  if (earliest == null) return 0;
+  final DateTime earliestDay =
+      DateTime(earliest.year, earliest.month, earliest.day);
+  final DateTime today = DateTime(now.year, now.month, now.day);
+  final DateTime thisMonday =
+      today.subtract(Duration(days: today.weekday - DateTime.monday));
+  final DateTime earliestMonday = earliestDay
+      .subtract(Duration(days: earliestDay.weekday - DateTime.monday));
+  if (!earliestMonday.isBefore(thisMonday)) return 0;
+  // 用小时/168 四舍五入求周数，规避 DST 让 inDays 少算 1 天。
+  final int weeksBack =
+      (thisMonday.difference(earliestMonday).inHours + 84) ~/ 168;
+  final int pages = weeksBack ~/ weeks;
+  return pages * weeks;
+}
+
+/// 纯函数：把热力图局部坐标 [local]（自然坐标系，未经 [FittedBox] 缩放）反算成
+/// 命中的 (列, 行)。落在格子间隙或越界时返回 null；行固定 0..6（周一..周日）。
+({int col, int row})? hitStatHeatmapCell(
+  Offset local, {
+  required double cell,
+  required double spacing,
+  required int cols,
+}) {
+  if (local.dx < 0 || local.dy < 0) return null;
+  final double step = cell + spacing;
+  final int col = local.dx ~/ step;
+  final int row = local.dy ~/ step;
+  if (col < 0 || col >= cols || row < 0 || row >= 7) return null;
+  // 落在格子内部而非右/下侧间隙。
+  if (local.dx - col * step > cell) return null;
+  if (local.dy - row * step > cell) return null;
+  return (col: col, row: row);
+}
+
+/// GitHub 式贡献热力图组件：自适应可用宽度铺 [weeks] 列小方格，颜色由 [baseColor]
+/// 按等级 0..4 加深。
+///
+/// 交互（无整块打开统计页的 onTap——打开统计移到外层可点标题）：
+/// - **翻页**：数据超出首屏（[maxHeatmapPageOffset] > 0）时，顶部行右侧出现 ←/→
+///   箭头，←=看更早一屏、→=回到更近一屏，到边界自动禁用。
+/// - **每日数值**：点某天格子在顶部行左侧弹气泡显示当天日期+数值（[valueLabel]
+///   由外层给格式化器：视频=观看时长 / 阅读=字数）；再点同格或点空白收起。
 ///
 /// 用 [CustomPaint]（含 [RepaintBoundary]）一次绘制所有格子，避免上百个 widget 参与
 /// 布局/重绘（与阅读设置抽屉色卡缺 RepaintBoundary 卡顿同类考量）。
-class StatContributionHeatmap extends StatelessWidget {
+class StatContributionHeatmap extends StatefulWidget {
   const StatContributionHeatmap({
-    required this.model,
+    required this.valueByDateKey,
+    required this.now,
     required this.baseColor,
     required this.emptyColor,
+    required this.valueLabel,
     super.key,
-    this.onTap,
+    this.weeks = 17,
     this.cell = 12,
     this.spacing = 3,
   });
 
-  final StatHeatmapModel model;
+  /// 日期键（`2026-06-07`）→ 当日活动值（视频=观看毫秒 / 阅读=字数）的全量映射。
+  final Map<String, int> valueByDateKey;
+
+  /// 「现在」（构造窗口用；末屏末列含今天）。
+  final DateTime now;
   final Color baseColor;
 
   /// level 0（无活动）格子的底色（通常取一个很浅的中性色）。
   final Color emptyColor;
-  final VoidCallback? onTap;
+
+  /// 选中某天时气泡文案的格式化器：入参为 (dateKey, 当日值)，返回完整气泡文本。
+  final String Function(String dateKey, int value) valueLabel;
+
+  /// 每屏列数（周数），也是翻页步长。
+  final int weeks;
 
   /// 单格边长（逻辑像素，自然尺寸）。实际渲染由外层 [FittedBox] 按可用宽度等比
   /// 缩小（不放大），故这是「上限」尺寸。
@@ -124,17 +197,157 @@ class StatContributionHeatmap extends StatelessWidget {
   final double spacing;
 
   @override
+  State<StatContributionHeatmap> createState() =>
+      _StatContributionHeatmapState();
+}
+
+class _StatContributionHeatmapState extends State<StatContributionHeatmap> {
+  /// 当前翻页偏移（单位=周，0=最近一屏；每翻一页 ± [StatContributionHeatmap.weeks]）。
+  int _pageOffset = 0;
+
+  /// 当前选中格子的日期键（null=未选中，不显示气泡）。
+  String? _selectedDateKey;
+
+  static const double _headerHeight = 22;
+
+  /// 翻页：[dir] > 0 看更早、< 0 回更近；步长 = weeks 周，clamp 到 [0, maxOffset]。
+  /// 翻页后清除选中（原选中日已不在视野）。
+  void _page(int dir, int maxOffset) {
+    final int next =
+        (_pageOffset + dir * widget.weeks).clamp(0, maxOffset).toInt();
+    if (next == _pageOffset) return;
+    setState(() {
+      _pageOffset = next;
+      _selectedDateKey = null;
+    });
+  }
+
+  void _onTapGrid(Offset local, StatHeatmapModel model) {
+    final ({int col, int row})? hit = hitStatHeatmapCell(
+      local,
+      cell: widget.cell,
+      spacing: widget.spacing,
+      cols: model.weeks.length,
+    );
+    String? next;
+    if (hit != null) {
+      // 占位格（未来日）dateKey 为 null → 视作点空白，收起气泡。
+      next = model.weeks[hit.col][hit.row].dateKey;
+    }
+    setState(() {
+      // 再点同一格 → 收起。
+      _selectedDateKey = (next == _selectedDateKey) ? null : next;
+    });
+  }
+
+  Widget _arrow(
+    IconData icon,
+    bool enabled,
+    VoidCallback onTap,
+    Color activeColor,
+    Color disabledColor,
+  ) {
+    return SizedBox(
+      width: 26,
+      height: _headerHeight,
+      child: InkResponse(
+        radius: 16,
+        onTap: enabled ? onTap : null,
+        child: Icon(
+          icon,
+          size: 18,
+          color: enabled ? activeColor : disabledColor,
+        ),
+      ),
+    );
+  }
+
+  Widget _bubbleChip(ThemeData theme, String text) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: const BorderRadius.all(Radius.circular(10)),
+      ),
+      child: Text(
+        text,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.labelMedium?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(ThemeData theme, int offset, int maxOffset) {
+    final bool showArrows = maxOffset > 0;
+    final String? sel = _selectedDateKey;
+    final String? bubble = sel == null
+        ? null
+        : widget.valueLabel(sel, widget.valueByDateKey[sel] ?? 0);
+    return SizedBox(
+      height: _headerHeight,
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: bubble == null
+                ? const SizedBox.shrink()
+                : Align(
+                    alignment: Alignment.centerLeft,
+                    child: _bubbleChip(theme, bubble),
+                  ),
+          ),
+          if (showArrows) ...<Widget>[
+            _arrow(
+              Icons.chevron_left,
+              offset < maxOffset,
+              () => _page(1, maxOffset),
+              theme.colorScheme.onSurfaceVariant,
+              theme.disabledColor,
+            ),
+            _arrow(
+              Icons.chevron_right,
+              offset > 0,
+              () => _page(-1, maxOffset),
+              theme.colorScheme.onSurfaceVariant,
+              theme.disabledColor,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final int maxOffset = maxHeatmapPageOffset(
+      valueByDateKey: widget.valueByDateKey,
+      now: widget.now,
+      weeks: widget.weeks,
+    );
+    // 数据缩水（如切换来源/删除）后把越界的偏移收回合法范围。
+    final int offset = _pageOffset.clamp(0, maxOffset).toInt();
+    if (offset != _pageOffset) _pageOffset = offset;
+
+    final StatHeatmapModel model = buildStatHeatmap(
+      valueByDateKey: widget.valueByDateKey,
+      now: widget.now,
+      weeks: widget.weeks,
+      weekOffset: offset,
+    );
     final int cols = model.weeks.length;
     if (cols == 0) return const SizedBox.shrink();
+
     // 固定自然尺寸（不依赖 LayoutBuilder——本组件会被放进 IntrinsicHeight 的概览条
     // 里，而 LayoutBuilder 不支持 intrinsic 测量会抛异常）。宽度不足时由 FittedBox
     // 等比缩小，宽屏保持自然尺寸左对齐。
-    final double natW = cols * cell + (cols - 1) * spacing;
-    final double natH = 7 * cell + 6 * spacing;
-    Widget content = FittedBox(
-      fit: BoxFit.scaleDown,
-      alignment: Alignment.centerLeft,
+    final double natW = cols * widget.cell + (cols - 1) * widget.spacing;
+    final double natH = 7 * widget.cell + 6 * widget.spacing;
+    final Widget grid = GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTapUp: (TapUpDetails d) => _onTapGrid(d.localPosition, model),
       child: SizedBox(
         width: natW,
         height: natH,
@@ -142,23 +355,31 @@ class StatContributionHeatmap extends StatelessWidget {
           child: CustomPaint(
             painter: _HeatmapPainter(
               model: model,
-              baseColor: baseColor,
-              emptyColor: emptyColor,
-              cell: cell,
-              spacing: spacing,
+              baseColor: widget.baseColor,
+              emptyColor: widget.emptyColor,
+              cell: widget.cell,
+              spacing: widget.spacing,
+              selectedDateKey: _selectedDateKey,
+              selectedBorderColor: theme.colorScheme.onSurface,
             ),
           ),
         ),
       ),
     );
-    if (onTap != null) {
-      content = InkWell(
-        onTap: onTap,
-        borderRadius: const BorderRadius.all(Radius.circular(12)),
-        child: content,
-      );
-    }
-    return content;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        _buildHeader(theme, offset, maxOffset),
+        SizedBox(height: widget.spacing * 2),
+        FittedBox(
+          fit: BoxFit.scaleDown,
+          alignment: Alignment.centerLeft,
+          child: grid,
+        ),
+      ],
+    );
   }
 }
 
@@ -169,6 +390,8 @@ class _HeatmapPainter extends CustomPainter {
     required this.emptyColor,
     required this.cell,
     required this.spacing,
+    required this.selectedDateKey,
+    required this.selectedBorderColor,
   });
 
   final StatHeatmapModel model;
@@ -176,6 +399,8 @@ class _HeatmapPainter extends CustomPainter {
   final Color emptyColor;
   final double cell;
   final double spacing;
+  final String? selectedDateKey;
+  final Color selectedBorderColor;
 
   /// 等级 0..4 → 颜色。0 用 [emptyColor]；1..4 用 [baseColor] 按不透明度加深。
   Color _colorFor(int level) {
@@ -196,7 +421,12 @@ class _HeatmapPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final Paint paint = Paint()..style = PaintingStyle.fill;
+    final Paint border = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5
+      ..color = selectedBorderColor;
     final Radius radius = Radius.circular(cell * 0.25);
+    Rect? selectedRect;
     for (int w = 0; w < model.weeks.length; w++) {
       final List<StatHeatmapCell> col = model.weeks[w];
       final double x = w * (cell + spacing);
@@ -205,15 +435,20 @@ class _HeatmapPainter extends CustomPainter {
         // 占位格（未来日）不绘制，留白。
         if (c.dateKey == null) continue;
         final double y = d * (cell + spacing);
+        final Rect rect = Rect.fromLTWH(x, y, cell, cell);
         paint.color = _colorFor(c.level);
-        canvas.drawRRect(
-          RRect.fromRectAndRadius(
-            Rect.fromLTWH(x, y, cell, cell),
-            radius,
-          ),
-          paint,
-        );
+        canvas.drawRRect(RRect.fromRectAndRadius(rect, radius), paint);
+        if (selectedDateKey != null && c.dateKey == selectedDateKey) {
+          selectedRect = rect;
+        }
       }
+    }
+    // 选中格描边画在最后，避免被相邻格覆盖。
+    if (selectedRect != null) {
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(selectedRect.inflate(0.5), radius),
+        border,
+      );
     }
   }
 
@@ -223,5 +458,7 @@ class _HeatmapPainter extends CustomPainter {
       old.baseColor != baseColor ||
       old.emptyColor != emptyColor ||
       old.cell != cell ||
-      old.spacing != spacing;
+      old.spacing != spacing ||
+      old.selectedDateKey != selectedDateKey ||
+      old.selectedBorderColor != selectedBorderColor;
 }

--- a/hibiki/test/widgets/stat_contribution_heatmap_test.dart
+++ b/hibiki/test/widgets/stat_contribution_heatmap_test.dart
@@ -2,7 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/pages/implementations/stat_activity.dart';
 import 'package:hibiki/src/utils/components/stat_contribution_heatmap.dart';
 
-/// 贡献热力图纯模型 [buildStatHeatmap] 的单测：窗口/周对齐、等级分桶、未来日占位。
+/// 贡献热力图纯模型 [buildStatHeatmap] 的单测：窗口/周对齐、等级分桶、未来日占位，
+/// 以及翻页偏移 [maxHeatmapPageOffset]、格子命中 [hitStatHeatmapCell]。
 void main() {
   group('buildStatHeatmap', () {
     // 固定「现在」= 2026-07-15（周三），避免依赖真实时钟。
@@ -109,6 +110,150 @@ void main() {
           expect(c.dateKey == ancient, isFalse);
         }
       }
+    });
+
+    test('weekOffset 把窗口整体前移一屏：末列不再含今天、无未来占位', () {
+      // now=2026-07-15（周三）。offset=0 时末列含今天且有未来占位；
+      // offset=weeks(=3) 时窗口整体前移 3 周，全为过去日、无 null 占位。
+      final StatHeatmapModel m = buildStatHeatmap(
+        valueByDateKey: const <String, int>{},
+        now: now,
+        weeks: 3,
+        weekOffset: 3,
+      );
+      final String todayKey = statDateKey(DateTime(2026, 7, 15));
+      for (final List<StatHeatmapCell> col in m.weeks) {
+        for (final StatHeatmapCell c in col) {
+          expect(c.dateKey, isNotNull); // 全在过去 → 无未来占位
+          expect(c.dateKey == todayKey, isFalse); // 今天不在此屏
+        }
+      }
+      // 前移一屏后，前一屏（offset=0）的旧日落进本屏：末列末行=前移窗口的末周日。
+      final StatHeatmapModel prev = buildStatHeatmap(
+        valueByDateKey: const <String, int>{},
+        now: now,
+        weeks: 3,
+      );
+      // offset=3 屏的末列周一 = offset=0 屏首列周一往前推 0（相邻拼接），二者不重叠。
+      final String prevFirstMonday = prev.weeks.first[0].dateKey!;
+      final String offFirstMonday = m.weeks.first[0].dateKey!;
+      expect(offFirstMonday.compareTo(prevFirstMonday) < 0, isTrue);
+    });
+  });
+
+  group('maxHeatmapPageOffset', () {
+    final DateTime now = DateTime(2026, 7, 15, 10, 30); // 周三
+
+    test('空数据 → 0（无翻页）', () {
+      expect(
+        maxHeatmapPageOffset(
+          valueByDateKey: const <String, int>{},
+          now: now,
+          weeks: 17,
+        ),
+        0,
+      );
+    });
+
+    test('数据都在首屏内 → 0', () {
+      // 2 周前的一天，weeks=17 首屏足以覆盖 → 无需翻页。
+      final String k = statDateKey(DateTime(2026, 7, 1));
+      expect(
+        maxHeatmapPageOffset(
+          valueByDateKey: <String, int>{k: 100},
+          now: now,
+          weeks: 17,
+        ),
+        0,
+      );
+    });
+
+    test('最早数据超出一屏 → 返回 weeks 的整数倍', () {
+      // weeks=4（一屏 4 周）。最早数据约 10 周前 → weeksBack≈10 → pages=2 → 8。
+      final String k = statDateKey(DateTime(2026, 5, 6)); // 距 7-15 约 10 周
+      final int off = maxHeatmapPageOffset(
+        valueByDateKey: <String, int>{k: 5},
+        now: now,
+        weeks: 4,
+      );
+      expect(off % 4, 0);
+      expect(off, greaterThan(0));
+      // 该偏移的窗口应真的含最早数据周（不早于最早周、覆盖到它）。
+      final StatHeatmapModel m = buildStatHeatmap(
+        valueByDateKey: <String, int>{k: 5},
+        now: now,
+        weeks: 4,
+        weekOffset: off,
+      );
+      bool found = false;
+      for (final List<StatHeatmapCell> col in m.weeks) {
+        for (final StatHeatmapCell c in col) {
+          if (c.dateKey == k) found = true;
+        }
+      }
+      expect(found, isTrue);
+    });
+  });
+
+  group('hitStatHeatmapCell', () {
+    const double cell = 12;
+    const double spacing = 3;
+    const double step = cell + spacing; // 15
+
+    test('格子内部命中对应 (列,行)', () {
+      // 第 2 列(索引1) 第 3 行(索引2) 的中心 ≈ (1*15+6, 2*15+6)=(21,36)。
+      final ({int col, int row})? hit = hitStatHeatmapCell(
+        const Offset(21, 36),
+        cell: cell,
+        spacing: spacing,
+        cols: 5,
+      );
+      expect(hit, isNotNull);
+      expect(hit!.col, 1);
+      expect(hit.row, 2);
+    });
+
+    test('落在格子间隙 → null', () {
+      // x=13 落在第 0 列格子(0..12)右侧的 spacing 间隙(12..15)。
+      expect(
+        hitStatHeatmapCell(
+          const Offset(13, 6),
+          cell: cell,
+          spacing: spacing,
+          cols: 5,
+        ),
+        isNull,
+      );
+    });
+
+    test('越界（列 >= cols 或 行 >= 7 或负）→ null', () {
+      expect(
+        hitStatHeatmapCell(
+          const Offset(5 * step + 1, 6),
+          cell: cell,
+          spacing: spacing,
+          cols: 5,
+        ),
+        isNull,
+      );
+      expect(
+        hitStatHeatmapCell(
+          const Offset(6, 7 * step + 1),
+          cell: cell,
+          spacing: spacing,
+          cols: 5,
+        ),
+        isNull,
+      );
+      expect(
+        hitStatHeatmapCell(
+          const Offset(-1, 6),
+          cell: cell,
+          spacing: spacing,
+          cols: 5,
+        ),
+        isNull,
+      );
     });
   });
 }


### PR DESCRIPTION
## 需求
首页格子图（GitHub 式活动热力图）：**① 超长时加翻页 ② 加每日观看量查看**。经与用户确认：左右箭头翻页 / 点格子弹气泡+标题进统计页 / 观看+阅读两个热力图对称加。

## 改动
- `StatContributionHeatmap` 改 StatefulWidget：内部管翻页偏移（周窗口）+ 选中格。API 从收 `model` 改收 `valueByDateKey`+`now`+`valueLabel`（父层给格式化器：视频=观看时长 / 阅读=字数）。
- **翻页**：数据超首屏（`maxHeatmapPageOffset>0`）时热力图上方右侧出现 ←/→，←=看更早一屏、→=回更近一屏，到边界禁用；`buildStatHeatmap` 加 `weekOffset` 平移窗口。
- **每日数值**：点某天格子上方左侧弹气泡（`07-18 · 42分钟`/`3200字`），选中格描边；再点同格或空白收起。命中用纯函数 `hitStatHeatmapCell`（GestureDetector 放 FittedBox 内层用自然坐标，规避缩放）。
- **打开统计页**入口从整卡 `onTap` 移到可点**标题**（尾随小箭头），把格子点击让给查看数值。
- `stat_shared` 新增 `formatStatChars` / `formatStatHeatmapDay` 供气泡复用。
- 两处调用（`home_video_page` 观看 / `reader_hibiki_history_page` 阅读）对称更新。

## 验证
- `flutter analyze` 全绿（0 issue）。
- `flutter test`：热力图单测 13 例（新增 weekOffset / maxHeatmapPageOffset / hitStatHeatmapCell）+ 宽窗守卫 2 例，全过。
- ⚠️ **待真机**：概览条布局/触屏点格子/翻页交互需真实设备复测（Android 模拟器 + Windows 离屏）。