### PR TITLE
fix(lookup): 剪贴板面板更新内容时把滚动复位到顶部

### DIFF
--- a/hibiki/assets/popup/global_lookup_host.js
+++ b/hibiki/assets/popup/global_lookup_host.js
@@ -1711,6 +1711,61 @@
     return frameSources.has(iframe) ? frameSources.get(iframe) : null;
   }
 
+  // 剪贴板面板：把 ROOT 帧的滚动位置复位到顶部。面板的 root iframe 是**复用**的
+  // （renderStack 只换 #entries-container innerHTML，iframe / 其滚动容器不重建），
+  // 故上一句被滚动过的 scrollTop 会跨渲染保留——一条更长的新剪贴板内容渲染进来时
+  // 停在旧偏移而非从头看。Dart 面板控制器在「剪贴板内容更新」路径（update /
+  // _showTextOnly，均 seed 新 root）渲染后调本函数，让新句总是从顶部开始。点句中字
+  // 重查（_lookupFromBanner）/ 关子卡（_rerender）不调，保留其滚动位置。
+  // 面板 iframe 直接加载 popup.html（无 content.js shadow，__hibikiRoot 为 null），
+  // 滚动落在 document 上；#entries-container 兜底（万一改用容器滚动）。no-op 当无
+  // root 帧 / 跨源守卫 / node harness。
+  function scrollRootToTop() {
+    var rootId = null;
+    frames.forEach(function (record, id) {
+      if (rootId === null) {
+        rootId = id;
+      }
+    });
+    var record = rootId !== null ? frames.get(rootId) : null;
+    if (!record) {
+      return;
+    }
+    var win = null;
+    var doc = null;
+    try {
+      win = record.iframe.contentWindow;
+      doc = record.iframe.contentDocument;
+    } catch (e) {
+      win = null;
+      doc = null;
+    }
+    try {
+      if (doc) {
+        if (doc.scrollingElement) {
+          doc.scrollingElement.scrollTop = 0;
+        }
+        if (doc.documentElement) {
+          doc.documentElement.scrollTop = 0;
+        }
+        if (doc.body) {
+          doc.body.scrollTop = 0;
+        }
+        var container = (typeof doc.getElementById === 'function')
+            ? doc.getElementById('entries-container')
+            : null;
+        if (container) {
+          container.scrollTop = 0;
+        }
+      }
+      if (win && typeof win.scrollTo === 'function') {
+        win.scrollTo(0, 0);
+      }
+    } catch (e) {
+      // no-op（跨源 / 未加载）。
+    }
+  }
+
   // TODO-1188 — the contentWindow of a frame record, or null when unavailable
   // (cross-origin guard / torn-down iframe / node harness).
   function frameWindowOf(record) {
@@ -1848,6 +1903,7 @@
     // spec 2026-07-10 — panel-mode hooks (no-ops in cascade mode).
     setPanelPinnedVisual: setPanelPinnedVisual,
     setPanelBlockCaptureVisual: setPanelBlockCaptureVisual,
+    scrollRootToTop: scrollRootToTop,
     _frames: frames,
     // TODO-1188 — exposed for the node bridge-routing harness only (never used to
     // drive behaviour): the live globalId -> {frameId, localId} route map.

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -210,7 +210,8 @@ class ClipboardPanelController {
         await _channel.raise(topmost: model.clipboardPanelPinned);
         if (seq != _updateSeq) return;
       }
-      await _renderPanel(model);
+      // 剪贴板内容更新：新句从顶部开始（复用 root iframe 的旧 scrollTop 会残留）。
+      await _renderPanel(model, resetRootScroll: true);
       glog('panel: updated "${request.text.length} chars" '
           'entries=${result.entries.length}');
     } catch (e, st) {
@@ -241,7 +242,8 @@ class ClipboardPanelController {
       await _channel.raise(topmost: model.clipboardPanelPinned);
       if (seq != _updateSeq) return;
     }
-    await _renderPanel(model);
+    // 剪贴板内容更新（纯文字态）：新句从顶部开始，与自动查词路径口径一致。
+    await _renderPanel(model, resetRootScroll: true);
     glog('panel: text-only "${text.length} chars" (auto-lookup off)');
   }
 
@@ -329,7 +331,12 @@ class ClipboardPanelController {
 
   /// 组栈渲染。screen/max 尺寸都以面板视口（CSS px）为边界：嵌套子卡的
   /// computeFrameRect 级联在面板内 clamp（spec §5），不再引用显示器工作区。
-  Future<void> _renderPanel(AppModel model) async {
+  /// [resetRootScroll]：仅「剪贴板内容更新」路径（[update] / [_showTextOnly]，均
+  /// seed 全新 root 帧）传 true——面板 root iframe 复用，其滚动容器的 scrollTop 会
+  /// 跨渲染保留，一条更长的新内容会停在旧偏移；渲染后调 host 的 scrollRootToTop 把
+  /// root 帧滚回顶部。点句中字重查 / 关子卡等原地更新传 false（保留当前滚动位置）。
+  Future<void> _renderPanel(AppModel model,
+      {bool resetRootScroll = false}) async {
     final BuildContext? ctx = model.navigatorKey.currentContext;
     if (ctx == null) return;
     final double viewportW = _panelRect.width;
@@ -403,7 +410,16 @@ class ClipboardPanelController {
     final String blockCaptureVisualJs = 'window.__globalLookupHost && '
         'window.__globalLookupHost.setPanelBlockCaptureVisual('
         '${model.clipboardPanelBlockCapture});';
-    await _channel.render('$script\n$pinVisualJs\n$blockCaptureVisualJs');
+    // 剪贴板内容更新（新 root）时把 root 帧滚回顶部：root iframe 复用，其滚动位置
+    // 会跨渲染保留，否则更长的新内容停在旧偏移而非从头看。并进同一渲染脚本（native
+    // pending_json_ 单槽缓存，独立脚本会互相覆盖）。原地更新（点字重查 / 关子卡）
+    // 不传，保留当前滚动位置。
+    final String scrollResetJs = resetRootScroll
+        ? '\nwindow.__globalLookupHost && '
+            'window.__globalLookupHost.scrollRootToTop();'
+        : '';
+    await _channel
+        .render('$script\n$pinVisualJs\n$blockCaptureVisualJs$scrollResetJs');
   }
 
   void _onJsMessage(Map<String, Object?> message) {

--- a/hibiki/test/lookup/clipboard_panel_controller_test.dart
+++ b/hibiki/test/lookup/clipboard_panel_controller_test.dart
@@ -234,6 +234,67 @@ void main() {
           reason: '手动查词必须清纯文字态，否则点词后释义被 sentenceOnly 摘掉');
     });
 
+    test('剪贴板内容更新（update / _showTextOnly）渲染后把 root 帧滚回顶部', () {
+      // root iframe 复用，其滚动容器 scrollTop 跨渲染保留，更长的新内容会停在旧
+      // 偏移。update / _showTextOnly（均 seed 新 root）必须以 resetRootScroll:true
+      // 渲染；_renderPanel 据此在渲染脚本追加 host 的 scrollRootToTop 调用。
+      final int renderFnAt =
+          controllerSrc.indexOf('Future<void> _renderPanel(');
+      expect(renderFnAt, greaterThan(0));
+      final int renderFnEnd = controllerSrc.indexOf('\n  }', renderFnAt);
+      final String renderBody =
+          controllerSrc.substring(renderFnAt, renderFnEnd);
+      expect(renderBody.contains('resetRootScroll'), isTrue,
+          reason: '_renderPanel 必须有 resetRootScroll 门控');
+      expect(
+        renderBody.contains('window.__globalLookupHost.scrollRootToTop();'),
+        isTrue,
+        reason: 'resetRootScroll 时渲染脚本必须调 host 的 scrollRootToTop',
+      );
+
+      // update 的自动查词分支以 resetRootScroll:true 渲染。
+      final int updAt = controllerSrc.indexOf('Future<void> update(');
+      final int updEnd = controllerSrc.indexOf('\n  }', updAt);
+      expect(
+        controllerSrc
+            .substring(updAt, updEnd)
+            .contains('_renderPanel(model, resetRootScroll: true)'),
+        isTrue,
+        reason: 'update 剪贴板内容更新必须复位滚动到顶部',
+      );
+
+      // _showTextOnly（关自动查词纯文字态）同样复位。
+      final int textAt = controllerSrc.indexOf('Future<void> _showTextOnly(');
+      final int textEnd = controllerSrc.indexOf('\n  }', textAt);
+      expect(
+        controllerSrc
+            .substring(textAt, textEnd)
+            .contains('_renderPanel(model, resetRootScroll: true)'),
+        isTrue,
+        reason: '纯文字态剪贴板更新同样复位滚动到顶部',
+      );
+
+      // 原地更新路径（点句中字重查 / 关子卡）不复位（保留当前滚动位置）。
+      final int bannerAt =
+          controllerSrc.indexOf('Future<void> _lookupFromBanner(');
+      final int bannerEnd = controllerSrc.indexOf('\n  }', bannerAt);
+      expect(
+        controllerSrc
+            .substring(bannerAt, bannerEnd)
+            .contains('resetRootScroll'),
+        isFalse,
+        reason: '点句中字重查是原地更新，不得复位滚动',
+      );
+
+      // host.js 暴露 scrollRootToTop（跨端契约）。
+      final String hostJs =
+          File('assets/popup/global_lookup_host.js').readAsStringSync();
+      expect(hostJs.contains('function scrollRootToTop('), isTrue,
+          reason: 'host 必须实现 scrollRootToTop');
+      expect(hostJs.contains('scrollRootToTop: scrollRootToTop,'), isTrue,
+          reason: 'host API 必须暴露 scrollRootToTop');
+    });
+
     test('dispatcher panel 分区调 ClipboardPanelController.update', () {
       expect(
         dispatcherSrc.contains('ClipboardPanelController.instance.update'),

--- a/hibiki/test/lookup/global_lookup_host_test.mjs
+++ b/hibiki/test/lookup/global_lookup_host_test.mjs
@@ -1892,4 +1892,40 @@ function flushTimers() {
     'BUG-859: panel mode never posts dismissPopupAt from the global hook');
 }
 
+// B3. 剪贴板面板：scrollRootToTop 把 ROOT 帧滚动位置复位到顶部（新剪贴板内容从
+//     头看，不残留上一句被滚动过的偏移）。root iframe 复用，其 document 滚动位置
+//     跨渲染保留，故 Dart 在 update / _showTextOnly 渲染后调此函数复位。
+{
+  const { host, document } = freshHost();
+  host.renderStack({
+    popups: [descriptor('panel-root', -1), descriptor('frame-1', 0)],
+    layoutMode: 'panel',
+  });
+  const shells = shellsOf(document);
+  const rootIframe = shells[0].children.find((c) => c.tagName === 'IFRAME');
+  const childIframe = shells[1].children.find((c) => c.tagName === 'IFRAME');
+  // 模拟用户把 root 卡与子卡都滚到中途。
+  rootIframe.contentDocument.documentElement.scrollTop = 300;
+  rootIframe.contentDocument.body.scrollTop = 300;
+  childIframe.contentDocument.documentElement.scrollTop = 150;
+  childIframe.contentDocument.body.scrollTop = 150;
+  assert.strictEqual(typeof host.scrollRootToTop, 'function',
+    'scrollRootToTop fn exposed');
+  host.scrollRootToTop();
+  assert.strictEqual(rootIframe.contentDocument.documentElement.scrollTop, 0,
+    '剪贴板更新：ROOT 帧 documentElement 滚回顶部');
+  assert.strictEqual(rootIframe.contentDocument.body.scrollTop, 0,
+    '剪贴板更新：ROOT 帧 body 滚回顶部');
+  // 只复位 root（第一个插入的帧）；子卡保留自身滚动（不是剪贴板内容）。
+  assert.strictEqual(childIframe.contentDocument.documentElement.scrollTop, 150,
+    '子帧滚动不被 scrollRootToTop 复位');
+}
+
+// B4. scrollRootToTop 无 root 帧 / 空栈时安全 no-op（不抛）。
+{
+  const { host } = freshHost();
+  assert.doesNotThrow(() => host.scrollRootToTop(),
+    'scrollRootToTop 空栈安全');
+}
+
 console.log('global_lookup_host_test: PASS');


### PR DESCRIPTION
## 问题
剪贴板查词面板（Windows 常驻面板）更新剪贴板内容时，滚动条停在上一句被滚动过的位置，而不是从顶部开始看。

## 根因
面板 root iframe 是**复用**的（`renderStack` 只替换 `#entries-container` 的 innerHTML，iframe 及其滚动容器不重建），所以上一句的 `scrollTop` 会跨渲染保留。一条更长的新剪贴板内容渲染进来时就停在旧偏移。

## 修复
- `global_lookup_host.js`：新增 `scrollRootToTop()`，把 ROOT 帧的 document 滚动（`scrollingElement`/`documentElement`/`body`，兜底 `#entries-container`）复位到顶部，并在 host API 暴露。
- `clipboard_panel_controller.dart`：`_renderPanel` 增加 `resetRootScroll` 门控；**剪贴板内容更新**路径（`update` / `_showTextOnly`，均 seed 全新 root）渲染后调 `scrollRootToTop`。点句中字重查（`_lookupFromBanner`）/ 关子卡（`_rerender`）等原地更新**不**复位，保留当前滚动位置。

## 测试
- `global_lookup_host_test.mjs`：新增 node harness 断言 `scrollRootToTop` 只复位 root 帧、子帧滚动不受影响、空栈安全 no-op。
- `clipboard_panel_controller_test.dart`：源码接线守卫——`update`/`_showTextOnly` 以 `resetRootScroll:true` 渲染、`_renderPanel` 追加 `scrollRootToTop` 调用、原地更新路径不复位、host 暴露该函数。
- `flutter analyze` 干净；`flutter test test/lookup/clipboard_panel_controller_test.dart`（25 passed）+ 相关 guard 测试通过；node harness PASS。

## 待验证
Windows 真机：复制长内容→滚到中途→再复制新内容，面板应从顶部显示。