### PR TITLE
fix(video): BUG-917 片段导出改 .mp4（copy+libx264 兜底）+ 桌面另存为

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 893 条。点号进各自文件。
+> 共 894 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-917](bugs/BUG-917-video-clip-mp4-muxer.md) | ✅ | ✅ | 视频片段导出 exit -22（捆绑 ffmpeg-min 无 matroska muxer，输出跟随源容器） |
 | [BUG-916](bugs/BUG-916-subtitle-list-shift-hover-offset.md) | ✅ | ✅ | 视频字幕列表Shift悬停查词偏左一格 |
 | [BUG-915](bugs/BUG-915-ass-user-scale-and-plain-off-mode.md) | ✅ | ✅ | 尊重字幕不能调字号；关闭尊重时 ASS 特效层叠印乱字 |
 | [BUG-910](bugs/BUG-910-video-subtitle-dismiss-halo-reloop.md) | ✅ | ✅ | 视频字幕查词点空白想关闭却重复查同一个词 |

--- a/docs/bugs/BUG-917-video-clip-mp4-muxer.md
+++ b/docs/bugs/BUG-917-video-clip-mp4-muxer.md
@@ -1,0 +1,15 @@
+## BUG-917 · 视频片段导出 exit -22（捆绑 ffmpeg-min 无 matroska muxer，输出跟随源容器）
+- **报告**：2026-07-19（用户：导出视频片段报 "Clip Export failed"，日志 `VideoClipExport ffmpeg exit -22 ... stderr=Error opening output files: Invalid argument`；且没有地方设置片段导出路径）
+- **真实性**：✅ 真 bug。根因在 `hibiki/lib/src/pages/implementations/video_hibiki/clip_export.part.dart:147`（`_clipExportOutputPath` 用 `p.extension(inputPath)` 让输出**跟随源容器**扩展名）+ ffmpeg-min build 契约（`tool/ffmpeg-min/build-ffmpeg-min.sh:60` 的 MUXERS 白名单 `gif,adts,image2,mjpeg,mov,mp4,srt,ass,webvtt,null` **没有 matroska/webm/avi/mpegts muxer**）。这是 BUG-460 的同源问题，当时只修了有声书音频路径，视频片段路径漏修。
+- **根因**：桌面捆绑的精简 ffmpeg 用 `--disable-everything` 构建。视频片段导出 `-c copy` 把输出写成**与源同扩展名**（多数番剧是 `.mkv`）→ ffmpeg 按 `.mkv` 自动选不存在的 matroska muxer → `Error opening output files: Invalid argument` → exit -22（EINVAL）。`.mp4` 源恰好能成功（mp4 muxer 在白名单里），故只有非 mp4 源（mkv/webm/avi/ts，即绝大多数）中招。
+  - build 脚本第 8/22/58 行早已为「片段导出 mp4」编入 `libx264` + `mp4` muxer（TODO-1257），但 Dart 端 `buildFfmpegVideoClipExportArgs` 仍写源容器 + `-c copy`，实现从未对齐 mp4 契约。
+  - 附带诉求：桌面端片段固定落 `getApplicationDocumentsDirectory()/video_clips/`，用户无法选导出位置。
+- **[x] ① 根因修复** — 提交 <PENDING>。
+  - `clip_export.part.dart`：删 `_clipExportOutputPath` 里「扩展名跟随源容器」逻辑，改 `_clipExportFileName` 恒生成 `<源名>_<起>-<止>.mp4`（`.mp4` 桌面 ffmpeg-min 能 mux + 任意播放器/浏览器通吃）。
+  - `video_clip_exporter.dart`：`exportVideoClipViaFfmpeg` 改「快路径 `-c copy` → 失败兜底重编码」两级：copy 成功（h264/hevc + aac 等）瞬时无损返回；copy 失败（源编码不入 mp4：vc1/wmv/dts/pcm…）自动用新增 `buildFfmpegVideoClipReencodeArgs`（`libx264 + aac -pix_fmt yuv420p -movflags +faststart`）重写同一个 `.mp4`。任何可解码源都不再 exit -22，代价（较慢/有损）只在快路径失败时付。
+  - 桌面新增「另存为」路径选择：`_resolveClipOutputPath` 桌面弹 `FilePicker.saveFile`（默认名 = 生成的 `.mp4` 名，`allowedExtensions:['mp4']`），`_ensureMp4Extension` 兜底用户删/换扩展名；取消 = 放弃导出（新 i18n key `video_clip_export_cancelled`）。移动端不变（落 app 目录后走系统分享）。
+- **[x] ② 自动化测试** — 提交 <PENDING>。
+  - `hibiki/test/media/video/video_clip_exporter_test.dart`：新增 `buildFfmpegVideoClipReencodeArgs`（libx264/aac/yuv420p/faststart/音频越界丢弃）与 `exportVideoClipViaFfmpeg`「copy 失败→reencode 成功」「两轮皆失败才 ffmpegFailed」两个行为测试（fake backend 按 args 含 `libx264` 区分两轮）。
+  - `hibiki/test/build/ffmpeg_min_clip_muxer_guard_test.dart`：源码扫描守卫——① build 白名单含 `mp4` 且**不含** `matroska` ② build `--enable-libx264` + ENCODERS 含 `libx264` ③ `clip_export.part.dart` 写 `.mp4` 且**不再**用 `p.extension(inputPath)` 取容器。
+  - `hibiki/test/pages/video_player_remote_uri_test.dart`：切源守卫锚点同步 `_clipExportOutputPath` → `_resolveClipOutputPath`（顺序不变量不动）。
+- **备注**：真机复测由验证代理执行——桌面对 `.mkv` 源导出应出可播 `.mp4`（快路径 copy）、能弹另存为选路径；对非 mp4 兼容编码源应自动重编码成功。桌面 ffmpeg-min 二进制若尚未随发布更新，重编码兜底依赖新 build 产物（libx264 已在白名单，属重编产物随发布更新范畴，同 BUG-460）。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 33915 (1995 per locale)
+/// Strings: 33932 (1996 per locale)
 ///
-/// Built on 2026-07-19 at 05:13 UTC
+/// Built on 2026-07-19 at 05:49 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2681,6 +2681,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Subtitle delay −';
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -7203,6 +7204,8 @@ class _StringsAr extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -11798,6 +11801,8 @@ class _StringsDe extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -16409,6 +16414,8 @@ class _StringsEs extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -21031,6 +21038,8 @@ class _StringsFr extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -25580,6 +25589,8 @@ class _StringsId extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -30177,6 +30188,8 @@ class _StringsIt extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -34580,6 +34593,8 @@ class _StringsJa extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -38986,6 +39001,8 @@ class _StringsKo extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -43561,6 +43578,8 @@ class _StringsNl extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -48151,6 +48170,8 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -52724,6 +52745,8 @@ class _StringsRu extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -57242,6 +57265,8 @@ class _StringsTh extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -61792,6 +61817,8 @@ class _StringsTr extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -66329,6 +66356,8 @@ class _StringsVi extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 // Path: <root>
@@ -70553,6 +70582,8 @@ class _StringsZhCn extends _StringsEn {
   String get shortcut_action_video_subtitle_delay_decrease => '字幕延迟减小';
   @override
   String get shortcut_action_video_open_subtitle_align => '打开字幕波形对轴';
+  @override
+  String get video_clip_export_cancelled => '已取消片段导出';
 }
 
 // Path: <root>
@@ -74878,6 +74909,8 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get shortcut_action_video_open_subtitle_align =>
       'Open subtitle waveform align';
+  @override
+  String get video_clip_export_cancelled => 'Clip export cancelled';
 }
 
 /// Flat map(s) containing all translations.
@@ -78958,6 +78991,8 @@ extension on _StringsEn {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -83036,6 +83071,8 @@ extension on _StringsAr {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -87135,6 +87172,8 @@ extension on _StringsDe {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -91233,6 +91272,8 @@ extension on _StringsEs {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -95337,6 +95378,8 @@ extension on _StringsFr {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -99423,6 +99466,8 @@ extension on _StringsId {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -103524,6 +103569,8 @@ extension on _StringsIt {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -107587,6 +107634,8 @@ extension on _StringsJa {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -111654,6 +111703,8 @@ extension on _StringsKo {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -115748,6 +115799,8 @@ extension on _StringsNl {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -119839,6 +119892,8 @@ extension on _StringsPtBr {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -123935,6 +123990,8 @@ extension on _StringsRu {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -128015,6 +128072,8 @@ extension on _StringsTh {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -132104,6 +132163,8 @@ extension on _StringsTr {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -136188,6 +136249,8 @@ extension on _StringsVi {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }
@@ -140239,6 +140302,8 @@ extension on _StringsZhCn {
         return '字幕延迟减小';
       case 'shortcut_action_video_open_subtitle_align':
         return '打开字幕波形对轴';
+      case 'video_clip_export_cancelled':
+        return '已取消片段导出';
       default:
         return null;
     }
@@ -144297,6 +144362,8 @@ extension on _StringsZhHk {
         return 'Subtitle delay −';
       case 'shortcut_action_video_open_subtitle_align':
         return 'Open subtitle waveform align';
+      case 'video_clip_export_cancelled':
+        return 'Clip export cancelled';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = 引擎默认",
   "shortcut_action_video_subtitle_delay_increase": "字幕延迟增大",
   "shortcut_action_video_subtitle_delay_decrease": "字幕延迟减小",
-  "shortcut_action_video_open_subtitle_align": "打开字幕波形对轴"
+  "shortcut_action_video_open_subtitle_align": "打开字幕波形对轴",
+  "video_clip_export_cancelled": "已取消片段导出"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1993,5 +1993,6 @@
   "video_setting_torrent_connections_hint": "0 = engine default",
   "shortcut_action_video_subtitle_delay_increase": "Subtitle delay +",
   "shortcut_action_video_subtitle_delay_decrease": "Subtitle delay −",
-  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align"
+  "shortcut_action_video_open_subtitle_align": "Open subtitle waveform align",
+  "video_clip_export_cancelled": "Clip export cancelled"
 }

--- a/hibiki/lib/src/media/video/video_clip_exporter.dart
+++ b/hibiki/lib/src/media/video/video_clip_exporter.dart
@@ -82,6 +82,68 @@ List<String> buildFfmpegVideoClipExportArgs({
   ];
 }
 
+/// 纯函数：拼「重编码」裁剪命令（libx264 视频 + aac 音频 → mp4）。
+///
+/// 当 [buildFfmpegVideoClipExportArgs] 的 `-c copy` 因源编码装不进 mp4 容器而失败
+/// （vc1/wmv/mpeg2/rv/theora 视频、dts/truehd/pcm 音频等，或流复制不兼容）时用它兜底。
+/// 桌面精简 ffmpeg（`tool/ffmpeg-min`）为此专门编入 libx264（`--enable-gpl`，TODO-1257），
+/// mp4 muxer 也在白名单里；重编码后任何可解码的源都能落成通用可播的 .mp4，杜绝
+/// 「输出跟随源容器 → matroska/webm muxer 缺失 → exit -22 EINVAL」（BUG-917/460）。
+///
+/// `-pix_fmt yuv420p` 把 10-bit / 4:2:2 等源统一降到 8-bit 4:2:0（浏览器/播放器通吃）；
+/// `-movflags +faststart` 把 moov 前移便于边下边播。音频选择沿用与 copy 路径同一套
+/// [resolveAudioMapIndex] 边界判定（越界回退默认轨，尾随 `?` 兜底，BUG-345）。
+List<String> buildFfmpegVideoClipReencodeArgs({
+  required String inputPath,
+  required int startMs,
+  required int endMs,
+  required String outputPath,
+  int? audioStreamIndex,
+  int? audioStreamCount,
+}) {
+  final double startSeconds = startMs / 1000.0;
+  final double durationSeconds = (endMs - startMs) / 1000.0;
+  final int? explicitAudio = resolveAudioMapIndex(
+    audioStreamIndex: audioStreamIndex,
+    audioStreamCount: audioStreamCount,
+  );
+  return <String>[
+    '-hide_banner',
+    '-y',
+    '-ss',
+    startSeconds.toStringAsFixed(3),
+    '-t',
+    durationSeconds.toStringAsFixed(3),
+    '-i',
+    inputPath,
+    if (explicitAudio != null) ...<String>[
+      '-map',
+      '0:v:0',
+      '-map',
+      '0:a:$explicitAudio?',
+    ],
+    '-sn',
+    '-dn',
+    '-c:v',
+    'libx264',
+    '-preset',
+    'veryfast',
+    '-crf',
+    '20',
+    '-pix_fmt',
+    'yuv420p',
+    '-c:a',
+    'aac',
+    '-b:a',
+    '192k',
+    '-avoid_negative_ts',
+    'make_zero',
+    '-movflags',
+    '+faststart',
+    outputPath,
+  ];
+}
+
 /// 纯函数：把请求的 [audioStreamIndex] 归一成「实际拼进 `-map 0:a:N` 的下标」，
 /// 否则返回 null（不加 `-map`，用 ffmpeg 默认音频选择）。两条 ffmpeg 裁剪路径
 /// （视频片段导出 / 桌面音频裁剪）共用这套边界判定（BUG-345）。
@@ -129,8 +191,14 @@ Future<VideoClipExportResult> exportVideoClipViaFfmpeg({
 
   try {
     output.parent.createSync(recursive: true);
-    final FfmpegRunResult result =
-        await (backend ?? resolveFfmpegBackend()).run(
+    final FfmpegBackend resolved = backend ?? resolveFfmpegBackend();
+    bool produced(FfmpegRunResult r) =>
+        r.isSuccess && output.existsSync() && output.lengthSync() > 0;
+
+    // 快路径：`-c copy`（瞬时、无损）。多数 h264/hevc + aac 源直接成功。输出恒
+    // `.mp4`（由调用方决定的 outputPath；见 BUG-917：绝不再跟随源容器扩展名，
+    // 否则 mkv/webm 源会选中 ffmpeg-min 白名单里不存在的 matroska muxer → exit -22）。
+    final FfmpegRunResult copyResult = await resolved.run(
       buildFfmpegVideoClipExportArgs(
         inputPath: inputPath,
         startMs: startMs,
@@ -141,24 +209,47 @@ Future<VideoClipExportResult> exportVideoClipViaFfmpeg({
       ),
       timeout,
     );
-    if (result.isSuccess && output.existsSync() && output.lengthSync() > 0) {
+    if (produced(copyResult)) {
       return VideoClipExportResult.success(outputPath);
     }
     _deleteIfPresent(output);
-    if (result.isSuccess) {
+
+    // 兜底：源编码装不进 mp4（vc1/wmv/dts/pcm… 或流复制不兼容）导致 copy 失败时，
+    // 重编码为 libx264 + aac 再写同一个 .mp4（桌面 ffmpeg-min 专为此编入 libx264，
+    // TODO-1257）。这样任何可解码的源都不再 exit -22（BUG-917），代价是较慢/有损，
+    // 只在快路径失败时才付。
+    final FfmpegRunResult reencodeResult = await resolved.run(
+      buildFfmpegVideoClipReencodeArgs(
+        inputPath: inputPath,
+        startMs: startMs,
+        endMs: endMs,
+        outputPath: outputPath,
+        audioStreamIndex: audioStreamIndex,
+        audioStreamCount: audioStreamCount,
+      ),
+      timeout,
+    );
+    if (produced(reencodeResult)) {
+      return VideoClipExportResult.success(outputPath);
+    }
+    _deleteIfPresent(output);
+    if (reencodeResult.isSuccess) {
       return const VideoClipExportResult.failure(
         VideoClipExportFailure.outputMissing,
       );
     }
-    // C 修（BUG-345）：把 ffmpeg 真实失败原因（退出码 + stderr）写进错误日志，
-    // 与 desktop_audio_clipper 的 _reportFfmpegFailure 对齐——否则失败是黑盒，
-    // 真机只看到一句固定文案，看不到「Stream map matches no streams」。
-    ErrorLogService.instance.log('VideoClipExport', result.failureSummary);
-    // TODO-910：detail 回传 stderr **尾段**抽出的真因行，而非全量 stderr。
-    // ffmpeg stderr 开头恒是 `Input #0, ...: Metadata: encoder :...` 输入 banner，
-    // 真正的失败行（Conversion failed / matches no streams / Could not open ...）
-    // 出现在末尾；调用方用它拼 OSD 时绝不能从头截断，否则只显示 banner。
-    final String reason = extractFfmpegFailureReason(result.output);
+    // C 修（BUG-345）：把两轮 ffmpeg 的真实失败原因（退出码 + stderr）写进错误日志，
+    // 与 desktop_audio_clipper 的 _reportFfmpegFailure 对齐——否则失败是黑盒，真机只
+    // 看到一句固定文案，看不到「Stream map matches no streams」/「Invalid argument」。
+    ErrorLogService.instance
+        .log('VideoClipExport', 'stream-copy: ${copyResult.failureSummary}');
+    ErrorLogService.instance
+        .log('VideoClipExport', 'reencode: ${reencodeResult.failureSummary}');
+    // TODO-910：detail 回传 stderr **尾段**抽出的真因行（重编码轮，最终失败原因），
+    // 而非全量 stderr。ffmpeg stderr 开头恒是 `Input #0, ...: Metadata: encoder :...`
+    // 输入 banner，真正的失败行（Conversion failed / matches no streams / Could not
+    // open ...）出现在末尾；调用方拼 OSD 时绝不能从头截断，否则只显示 banner。
+    final String reason = extractFfmpegFailureReason(reencodeResult.output);
     return VideoClipExportResult.failure(
       VideoClipExportFailure.ffmpegFailed,
       detail: reason.isEmpty ? null : reason,

--- a/hibiki/lib/src/pages/implementations/video_hibiki/clip_export.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/clip_export.part.dart
@@ -58,21 +58,31 @@ extension _VideoClipExport on _VideoHibikiPageState {
     final int generation = _clipExportGeneration;
     final int? audioStreamIndex = _clipExportStartAudioStreamIndex;
     final int? audioStreamCount = _clipExportStartAudioStreamCount;
-    final String outputPath = await _clipExportOutputPath(
+    // 桌面弹「另存为」让用户自选目录/文件名（BUG-917 用户诉求「没法设导出路径」），
+    // 移动端落 app 文档目录后走系统分享。dialog 是异步阻塞 UI，返回后需重核
+    // mounted / generation（用户可能中途换源）。取消对话框视为放弃本次导出。
+    final String defaultName = _clipExportFileName(
       inputPath: startPath,
       startMs: startMs,
       endMs: endMs,
     );
-    if (!mounted) {
-      await _deleteClipOutput(outputPath);
+    final bool isDesktop =
+        Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+    final String? outputPath = await _resolveClipOutputPath(
+      defaultName: defaultName,
+      isDesktop: isDesktop,
+    );
+    if (!mounted) return;
+    if (outputPath == null) {
+      // 桌面用户取消了「另存为」——此刻尚未产出任何文件，直接清状态收场。
+      _rebuild(_clearClipExportState);
+      _showOsd(t.video_clip_export_cancelled);
+      _refocusVideo();
       return;
     }
     if (generation != _clipExportGeneration || _currentVideoPath != startPath) {
-      await _deleteClipOutput(outputPath);
-      if (mounted) {
-        _rebuild(_clearClipExportState);
-        _showOsd(t.video_clip_export_source_changed);
-      }
+      _rebuild(_clearClipExportState);
+      _showOsd(t.video_clip_export_source_changed);
       return;
     }
     _rebuild(() => _clipExporting = true);
@@ -135,21 +145,49 @@ extension _VideoClipExport on _VideoHibikiPageState {
     _clipExportStartAudioStreamCount = null;
   }
 
-  Future<String> _clipExportOutputPath({
+  /// 片段导出的默认文件名：`<源名>_<起>-<止>.mp4`。扩展名恒 `.mp4`——绝不再跟随
+  /// 源容器（BUG-917：mkv/webm/avi/ts 源会让 ffmpeg 选中桌面精简 ffmpeg 白名单里
+  /// 不存在的 matroska/webm muxer → exit -22 EINVAL）。mp4 桌面 ffmpeg-min 能 mux，
+  /// 且任意播放器/浏览器通吃。
+  String _clipExportFileName({
     required String inputPath,
     required int startMs,
     required int endMs,
-  }) async {
-    final Directory docs = await getApplicationDocumentsDirectory();
-    final Directory dir = Directory(p.join(docs.path, 'video_clips'));
+  }) {
     final String rawStem = _safeFileName(p.basenameWithoutExtension(inputPath));
     final String stem = rawStem.isEmpty ? 'video' : rawStem;
-    final String ext = p.extension(inputPath).isEmpty
-        ? '.mkv'
-        : p.extension(inputPath).toLowerCase();
-    final String name =
-        '${stem}_${_clipExportTimeToken(startMs)}-${_clipExportTimeToken(endMs)}$ext';
-    return p.join(dir.path, name);
+    return '${stem}_${_clipExportTimeToken(startMs)}-'
+        '${_clipExportTimeToken(endMs)}.mp4';
+  }
+
+  /// 决定片段导出目标路径：桌面弹「另存为」让用户选目录/文件名（取消返回 null），
+  /// 移动端落 app 文档目录 `video_clips/`（随后走系统分享）。输出恒 `.mp4`。
+  Future<String?> _resolveClipOutputPath({
+    required String defaultName,
+    required bool isDesktop,
+  }) async {
+    if (isDesktop) {
+      final String? picked = await FilePicker.platform.saveFile(
+        dialogTitle: t.video_clip_export,
+        fileName: defaultName,
+        type: FileType.custom,
+        allowedExtensions: <String>['mp4'],
+      );
+      if (picked == null) return null;
+      return _ensureMp4Extension(picked);
+    }
+    final Directory docs = await getApplicationDocumentsDirectory();
+    final Directory dir = Directory(p.join(docs.path, 'video_clips'));
+    return p.join(dir.path, defaultName);
+  }
+
+  /// 保证路径以 `.mp4` 结尾：用户在「另存为」里删/换了扩展名时补回，否则 ffmpeg 又
+  /// 按扩展名挑 muxer，退回 BUG-917（选中缺失的 matroska/mkv muxer → exit -22）。
+  String _ensureMp4Extension(String path) {
+    if (p.extension(path).toLowerCase() == '.mp4') return path;
+    return p.extension(path).isEmpty
+        ? '$path.mp4'
+        : '${p.withoutExtension(path)}.mp4';
   }
 
   String _clipExportTimeToken(int ms) {

--- a/hibiki/test/build/ffmpeg_min_clip_muxer_guard_test.dart
+++ b/hibiki/test/build/ffmpeg_min_clip_muxer_guard_test.dart
@@ -55,6 +55,48 @@ void main() {
         reason: 'muxing ADTS AAC into a .mov requires the aac_adtstoasc bsf.');
   });
 
+  test('ffmpeg-min build whitelist enables the mp4 muxer for video clips', () {
+    // BUG-917: video clip export writes .mp4 (was: the source container). The
+    // bundled ffmpeg-min has NO matroska/webm/avi/mpegts muxer, so following the
+    // source extension (mkv/webm/…) auto-selected an absent muxer → exit -22.
+    final String script = workspaceFile('tool/ffmpeg-min/build-ffmpeg-min.sh');
+    final RegExp muxers = RegExp(r'^MUXERS="([^"]*)"', multiLine: true);
+    final List<String> list = muxers.firstMatch(script)!.group(1)!.split(',');
+    expect(list, contains('mp4'),
+        reason: 'video clip export targets .mp4 (h264/hevc copy or libx264 '
+            're-encode); without the mp4 muxer it exits -22. BUG-917.');
+    expect(list, isNot(contains('matroska')),
+        reason: 'ffmpeg-min has no matroska muxer — proof the clip export must '
+            'NOT follow a .mkv source extension. BUG-917.');
+  });
+
+  test('ffmpeg-min build enables libx264 for the clip re-encode fallback', () {
+    // The copy→re-encode fallback (BUG-917) needs libx264; the build turns it on
+    // via --enable-gpl --enable-libx264 (TODO-1257).
+    final String script = workspaceFile('tool/ffmpeg-min/build-ffmpeg-min.sh');
+    expect(script, contains('--enable-libx264'),
+        reason: 'clip re-encode fallback muxes libx264 into .mp4. BUG-917.');
+    final String encoders = RegExp(r'^ENCODERS="([^"]*)"', multiLine: true)
+        .firstMatch(script)!
+        .group(1)!;
+    expect(encoders.split(','), contains('libx264'));
+  });
+
+  test('video clip export names the output .mp4, never the source container',
+      () {
+    // Source-scan guard: the clip export path must build a .mp4 filename and
+    // must not derive the extension from the input path (BUG-917 regression).
+    final String clip = libFile(
+      'lib/src/pages/implementations/video_hibiki/clip_export.part.dart',
+    );
+    expect(clip.contains(".mp4'"), isTrue,
+        reason: 'clip export must write .mp4 (ffmpeg-min muxable + universal). '
+            'BUG-917.');
+    expect(clip.contains('p.extension(inputPath)'), isFalse,
+        reason: 'clip output extension must NOT follow the source container — '
+            'mkv/webm/avi/ts have no muxer in ffmpeg-min → exit -22. BUG-917.');
+  });
+
   test('audiobook clip pipeline emits .aac audio, never .m4a/.mp4', () {
     final String pipeline = libFile(
       'lib/src/pages/implementations/reader_hibiki/audiobook.part.dart',

--- a/hibiki/test/media/video/video_clip_exporter_test.dart
+++ b/hibiki/test/media/video/video_clip_exporter_test.dart
@@ -105,7 +105,126 @@ void main() {
     });
   });
 
+  group('buildFfmpegVideoClipReencodeArgs (BUG-917 fallback)', () {
+    test('re-encodes to libx264 + aac and always targets the given .mp4', () {
+      final List<String> args = buildFfmpegVideoClipReencodeArgs(
+        inputPath: '/video/source.mkv',
+        startMs: 1000,
+        endMs: 3000,
+        outputPath: '/out/clip.mp4',
+        audioStreamIndex: 1,
+      );
+
+      // libx264 + mp4 muxer are exactly what tool/ffmpeg-min provisioned for
+      // clip export (TODO-1257); this path guarantees a muxable container even
+      // when -c copy can't hold the source codecs.
+      expect(
+          args,
+          containsAllInOrder(<String>[
+            '-i',
+            '/video/source.mkv',
+            '-map',
+            '0:v:0',
+            '-map',
+            '0:a:1?',
+            '-sn',
+            '-dn',
+            '-c:v',
+            'libx264',
+          ]));
+      expect(args, containsAllInOrder(<String>['-c:a', 'aac']));
+      expect(args, containsAllInOrder(<String>['-pix_fmt', 'yuv420p']));
+      expect(args, containsAllInOrder(<String>['-movflags', '+faststart']));
+      expect(args.last, '/out/clip.mp4');
+      // Never a raw stream copy on this path.
+      expect(args.contains('copy'), isFalse);
+    });
+
+    test('honours the same audio out-of-range drop as the copy path', () {
+      final List<String> args = buildFfmpegVideoClipReencodeArgs(
+        inputPath: '/video/source.mkv',
+        startMs: 0,
+        endMs: 1000,
+        outputPath: '/out/clip.mp4',
+        audioStreamIndex: 2,
+        audioStreamCount: 2,
+      );
+      expect(args.contains('-map'), isFalse);
+      expect(args.any((String a) => a.startsWith('0:a:')), isFalse);
+    });
+  });
+
   group('exportVideoClipViaFfmpeg', () {
+    test(
+        'falls back to re-encode when stream-copy fails, then succeeds '
+        '(BUG-917)', () async {
+      // Root cause: the bundled ffmpeg-min can only mux mp4/mov for video+audio.
+      // When -c copy into .mp4 fails (codec not mp4-compatible), the exporter
+      // must retry with libx264 + aac rather than surfacing exit -22.
+      final Directory dir =
+          Directory.systemTemp.createTempSync('hibiki_clip_export_fallback');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final File input = File('${dir.path}/source.mkv')
+        ..writeAsBytesSync(<int>[1]);
+      final File output = File('${dir.path}/clip.mp4');
+      final _FakeFfmpegBackend backend = _FakeFfmpegBackend(
+        onRun: (List<String> args) {
+          final bool isReencode = args.contains('libx264');
+          if (isReencode) {
+            output.writeAsBytesSync(<int>[9, 8, 7]);
+            return const FfmpegRunResult(returnCode: 0, output: 'ok');
+          }
+          // Stream-copy path fails the way an mkv-into-a-missing-muxer would.
+          return const FfmpegRunResult(
+            returnCode: 1,
+            output: 'Error opening output files: Invalid argument',
+          );
+        },
+      );
+
+      final VideoClipExportResult result = await exportVideoClipViaFfmpeg(
+        inputPath: input.path,
+        startMs: 0,
+        endMs: 2000,
+        outputPath: output.path,
+        backend: backend,
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(result.outputPath, output.path);
+      // Both attempts ran: first stream-copy, then the libx264 fallback.
+      expect(backend.calls.length, 2);
+      expect(backend.calls.first.contains('copy'), isTrue);
+      expect(backend.calls[1].contains('libx264'), isTrue);
+      expect(output.existsSync(), isTrue);
+    });
+
+    test('reports ffmpegFailed only when BOTH copy and re-encode fail',
+        () async {
+      final Directory dir =
+          Directory.systemTemp.createTempSync('hibiki_clip_export_bothfail');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final File input = File('${dir.path}/source.mkv')
+        ..writeAsBytesSync(<int>[1]);
+      final File output = File('${dir.path}/clip.mp4');
+      final _FakeFfmpegBackend backend = _FakeFfmpegBackend(
+        onRun: (List<String> args) =>
+            const FfmpegRunResult(returnCode: 1, output: 'boom'),
+      );
+
+      final VideoClipExportResult result = await exportVideoClipViaFfmpeg(
+        inputPath: input.path,
+        startMs: 0,
+        endMs: 1000,
+        outputPath: output.path,
+        backend: backend,
+      );
+
+      expect(result.failure, VideoClipExportFailure.ffmpegFailed);
+      expect(backend.calls.length, 2);
+      expect(output.existsSync(), isFalse);
+    });
+
     test('rejects invalid ranges without running ffmpeg and removes leftovers',
         () async {
       final Directory dir =

--- a/hibiki/test/pages/video_player_remote_uri_test.dart
+++ b/hibiki/test/pages/video_player_remote_uri_test.dart
@@ -36,8 +36,8 @@ void main() {
       final int end = page.indexOf('Future<void> _saveScreenshot(', idx);
       final String body = page.substring(idx, end);
 
-      final int outputPathAwait =
-          body.indexOf('final String outputPath = await _clipExportOutputPath');
+      final int outputPathAwait = body
+          .indexOf('final String? outputPath = await _resolveClipOutputPath');
       final int preStartGuard = body.indexOf(
         'generation != _clipExportGeneration || _currentVideoPath != startPath',
         outputPathAwait,


### PR DESCRIPTION
## 问题（用户报告）

导出视频片段报 `Clip Export failed`，日志：
```
VideoClipExport ffmpeg exit -22; ... stderr=Error opening output files: Invalid argument
```
且桌面端无处设置片段导出路径。

## 根因

桌面捆绑的精简 ffmpeg（`tool/ffmpeg-min`，`--disable-everything`）muxer 白名单为
`gif,adts,image2,mjpeg,mov,mp4,srt,ass,webvtt,null` —— **无 matroska/webm/avi/mpegts**。
而 `_clipExportOutputPath` 用 `p.extension(inputPath)` 让输出**跟随源容器**扩展名，多数番剧是
`.mkv` → ffmpeg 按 `.mkv` 自动选不存在的 matroska muxer → `Invalid argument` → exit -22（EINVAL）。
`.mp4` 源恰好能成，故只有非 mp4 源中招。这是 BUG-460 的同源问题，当时只修有声书音频路径，视频片段路径漏修。
build 脚本第 8/22/58 行早为「片段导出 mp4」编入 `libx264`+`mp4` muxer（TODO-1257），但 Dart 端实现从未对齐。

## 修复

1. **输出恒 `.mp4`**（ffmpeg-min 可 mux + 任意播放器/浏览器通吃），删「扩展名跟随源容器」。
2. **`exportVideoClipViaFfmpeg` 两级**：快路径 `-c copy`（瞬时无损，h264/hevc+aac 直接成）；失败兜底
   新增 `buildFfmpegVideoClipReencodeArgs`（`libx264 + aac -pix_fmt yuv420p -movflags +faststart`）
   重写同一 `.mp4`。任何可解码源不再 exit -22，代价（较慢/有损）只在快路径失败时付。
3. **桌面另存为**：`_resolveClipOutputPath` 弹 `FilePicker.saveFile`（默认名 `.mp4`），
   `_ensureMp4Extension` 兜底删/换扩展名；取消 = 放弃（新 i18n key `video_clip_export_cancelled`）。移动端不变。

## 测试

- `video_clip_exporter_test.dart`：reencode args + `copy 失败→reencode 成功` + `两轮皆失败才 ffmpegFailed`。
- `ffmpeg_min_clip_muxer_guard_test.dart`：源码扫描守卫（build 含 `mp4`/`libx264`、不含 `matroska`；part 写 `.mp4` 且不再取源扩展名）。
- `video_player_remote_uri_test.dart`：切源守卫锚点同步。
- 全量 `flutter analyze` 无问题；`test/media/video` `test/build` `test/i18n` 1770 通过。

## 待真机

桌面对 `.mkv` 源导出应出可播 `.mp4`（快路径 copy）、能弹另存为选路径；非 mp4 兼容编码源应自动重编码成功。
重编码兜底依赖含 `libx264` 的 ffmpeg-min 二进制随发布更新（同 BUG-460 契约）。

Fixes BUG-917.