### PR TITLE
feat(video): 波形对轴弹窗支持直接拖字幕条对轴

### DIFF
--- a/hibiki/lib/src/media/video/subtitle_waveform_align_panel.dart
+++ b/hibiki/lib/src/media/video/subtitle_waveform_align_panel.dart
@@ -363,8 +363,18 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
   static const double _minZoom = 0.25;
   static const double _maxZoom = 8.0;
 
-  /// 放大波形区高度（逻辑像素）。
-  static const double _waveHeight = 200.0;
+  /// 放大波形区高度（逻辑像素，可拖底部把手调节）。初值按屏高自适应（短屏起始更矮，够
+  /// 到下方缩放 +/-、字幕列表与调轴控件不必滚动整弹窗——用户反馈），随后由
+  /// [_buildResizeHandle] 竖直拖动在 [_minWaveHeight].._maxWaveHeight 间调节。
+  double _waveHeight = _defaultWaveHeight;
+
+  /// [_waveHeight] 初值（高屏封顶）与拖动上下界。
+  static const double _defaultWaveHeight = 200.0;
+  static const double _minWaveHeight = 96.0;
+  static const double _maxWaveHeight = 360.0;
+
+  /// 首帧按屏高自适应 [_waveHeight] 一次的守卫；用户拖动 / 旋转后不再被重置。
+  bool _waveHeightAdapted = false;
 
   /// 调轴细调滑条范围（正负 10 秒）与 clamp 上界（正负 600 秒），与
   /// [VideoQuickSettingsSheet] / VideoPlayerController 一致。
@@ -434,6 +444,18 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
         (_) => _onPositionTick(),
       );
     }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // 首帧按屏高自适应波形初始高度一次：短屏起始更矮，进弹窗即可够到下方缩放 +/-、字幕
+    // 列表与调轴控件，不必先把整弹窗滚到底（用户反馈）。用户拖底部把手后此守卫已置位，
+    // 之后旋转 / 键盘弹出等再触发本回调不会覆盖用户手动值。
+    if (_waveHeightAdapted) return;
+    _waveHeightAdapted = true;
+    final double screenH = MediaQuery.sizeOf(context).height;
+    _waveHeight = (screenH * 0.26).clamp(_minWaveHeight, _defaultWaveHeight);
   }
 
   void _onScroll() {
@@ -626,7 +648,7 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
           ),
           SizedBox(height: gap),
           _buildScrollableWaveform(cs),
-          SizedBox(height: gap / 2),
+          _buildResizeHandle(cs),
           _buildViewControls(cs),
           if (_displayCueIndices.isNotEmpty) ...<Widget>[
             SizedBox(height: gap),
@@ -826,6 +848,37 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
           ),
         );
       },
+    );
+  }
+
+  /// 波形区底部的高度调节把手（一条居中抓手 + 上下调整光标）。竖直拖动改 [_waveHeight]，
+  /// clamp 到 [_minWaveHeight].._maxWaveHeight。屏幕矮时把波形拖矮即可露出下方缩放 +/-、
+  /// 字幕列表与调轴控件，不必滚动整弹窗（用户反馈）；想看波形细节时也可拖高。
+  Widget _buildResizeHandle(ColorScheme cs) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeUpDown,
+      child: GestureDetector(
+        key: const ValueKey<String>('subtitle-waveform-resize-handle'),
+        behavior: HitTestBehavior.opaque,
+        onVerticalDragUpdate: (DragUpdateDetails details) {
+          setState(() {
+            _waveHeight = (_waveHeight + details.delta.dy)
+                .clamp(_minWaveHeight, _maxWaveHeight);
+          });
+        },
+        child: Container(
+          height: 22,
+          alignment: Alignment.center,
+          child: Container(
+            width: 44,
+            height: 5,
+            decoration: BoxDecoration(
+              color: cs.outlineVariant,
+              borderRadius: BorderRadius.circular(3),
+            ),
+          ),
+        ),
+      ),
     );
   }
 

--- a/hibiki/lib/src/media/video/subtitle_waveform_align_panel.dart
+++ b/hibiki/lib/src/media/video/subtitle_waveform_align_panel.dart
@@ -253,11 +253,13 @@ class _SubtitleWaveformAlignPanelState
 /// 弹出（showDialog）。
 ///
 /// **交互模型（平移查看 vs 调轴，物理分离、永不冲突）**：
-/// - **横向拖动波形 = 平移查看**：波形按固定像素密度铺开在一条可横向滚动的时间轴上，
-///   拖动 / 滚轮平移查看不同时间段（默认只抽了前 N 分钟）。可用缩放按钮改密度看细节。
-/// - **调轴 = 底部专用控件条**：滑条（细调）/ 步进 / 归零 / 数值输入，改动经 [onCommitDelay]
-///   写回上方权威 `_delayMs`（同源、零第二套状态）。波形上的 cue 线随之**实时平移**——
-///   用户滚到有语音的段落，拖底部滑条让 cue 线对齐波形峰值即完成对轴。
+/// - **横向拖动上方波形区 = 平移查看**：波形按固定像素密度铺开在一条可横向滚动的时间轴
+///   上，拖动 / 滚轮平移查看不同时间段（默认只抽了前 N 分钟）。可用缩放按钮改密度看细节。
+/// - **横向拖动波形下方的字幕条 = 直接对轴**：抓住字幕块沿时间轴左右滑，把它对到语音波峰
+///   即完成对轴（整体延迟平移，cue 线 / 字幕块 / 列表实时跟手，松手落盘）。这与上一条的
+///   平移查看落在不同 widget、不同拖动手势上，永不冲突——省得为了 ±50ms 滚到底用控件条。
+/// - **调轴控件条（细调兜底）**：滑条 / 步进 / 归零 / 数值输入，改动经 [onCommitDelay]
+///   写回上方权威 `_delayMs`（同源、零第二套状态），与拖字幕条对轴同一个延迟值。
 ///
 /// 两类操作作用在不同 widget（波形区 = 滚动手势；控件条 = 独立控件），故横向拖查看永不
 /// 误触调轴，反之亦然。
@@ -335,8 +337,12 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
   /// 本地权威延迟（毫秒，乐观更新）。改动经 [_commit] 写回上方 `_delayMs`。
   late int _delayMs = widget.initialDelayMs;
 
-  /// 拖动滑条时的临时预览值（松手才 [_commit] 落盘）。null = 未拖动。
+  /// 拖动滑条 / 波形上拖字幕条时的临时预览值（松手才 [_commit] 落盘）。null = 未拖动。
   int? _dragMs;
+
+  /// 直接在波形上横拖字幕条对轴时的精确累计延迟（毫秒，含小数）。落 [_dragMs]（取整）前
+  /// 保留亚像素精度，避免每帧小位移取整丢步。null = 未在拖字幕条。
+  double? _cueDragMsPrecise;
 
   /// TODO-1316：波形对轴视图内自动对轴进行中；true 时按钮切 spinner 并禁用（防重入）。
   bool _autoAligning = false;
@@ -363,18 +369,8 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
   static const double _minZoom = 0.25;
   static const double _maxZoom = 8.0;
 
-  /// 放大波形区高度（逻辑像素，可拖底部把手调节）。初值按屏高自适应（短屏起始更矮，够
-  /// 到下方缩放 +/-、字幕列表与调轴控件不必滚动整弹窗——用户反馈），随后由
-  /// [_buildResizeHandle] 竖直拖动在 [_minWaveHeight].._maxWaveHeight 间调节。
-  double _waveHeight = _defaultWaveHeight;
-
-  /// [_waveHeight] 初值（高屏封顶）与拖动上下界。
-  static const double _defaultWaveHeight = 200.0;
-  static const double _minWaveHeight = 96.0;
-  static const double _maxWaveHeight = 360.0;
-
-  /// 首帧按屏高自适应 [_waveHeight] 一次的守卫；用户拖动 / 旋转后不再被重置。
-  bool _waveHeightAdapted = false;
+  /// 放大波形区高度（逻辑像素）。
+  static const double _waveHeight = 200.0;
 
   /// 调轴细调滑条范围（正负 10 秒）与 clamp 上界（正负 600 秒），与
   /// [VideoQuickSettingsSheet] / VideoPlayerController 一致。
@@ -444,18 +440,6 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
         (_) => _onPositionTick(),
       );
     }
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    // 首帧按屏高自适应波形初始高度一次：短屏起始更矮，进弹窗即可够到下方缩放 +/-、字幕
-    // 列表与调轴控件，不必先把整弹窗滚到底（用户反馈）。用户拖底部把手后此守卫已置位，
-    // 之后旋转 / 键盘弹出等再触发本回调不会覆盖用户手动值。
-    if (_waveHeightAdapted) return;
-    _waveHeightAdapted = true;
-    final double screenH = MediaQuery.sizeOf(context).height;
-    _waveHeight = (screenH * 0.26).clamp(_minWaveHeight, _defaultWaveHeight);
   }
 
   void _onScroll() {
@@ -648,7 +632,7 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
           ),
           SizedBox(height: gap),
           _buildScrollableWaveform(cs),
-          _buildResizeHandle(cs),
+          SizedBox(height: gap / 2),
           _buildViewControls(cs),
           if (_displayCueIndices.isNotEmpty) ...<Widget>[
             SizedBox(height: gap),
@@ -851,37 +835,6 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
     );
   }
 
-  /// 波形区底部的高度调节把手（一条居中抓手 + 上下调整光标）。竖直拖动改 [_waveHeight]，
-  /// clamp 到 [_minWaveHeight].._maxWaveHeight。屏幕矮时把波形拖矮即可露出下方缩放 +/-、
-  /// 字幕列表与调轴控件，不必滚动整弹窗（用户反馈）；想看波形细节时也可拖高。
-  Widget _buildResizeHandle(ColorScheme cs) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.resizeUpDown,
-      child: GestureDetector(
-        key: const ValueKey<String>('subtitle-waveform-resize-handle'),
-        behavior: HitTestBehavior.opaque,
-        onVerticalDragUpdate: (DragUpdateDetails details) {
-          setState(() {
-            _waveHeight = (_waveHeight + details.delta.dy)
-                .clamp(_minWaveHeight, _maxWaveHeight);
-          });
-        },
-        child: Container(
-          height: 22,
-          alignment: Alignment.center,
-          child: Container(
-            width: 44,
-            height: 5,
-            decoration: BoxDecoration(
-              color: cs.outlineVariant,
-              borderRadius: BorderRadius.circular(3),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
   /// TODO-1244：波形下方的 cue 文本条。每句按时间位置（[AudioCue.startMs]/[endMs] 叠加
   /// [delayMs]）铺在时间轴上，宽度 = 该句时长像素（下限 [_minChipWidth]）。视口外裁剪
   /// （[_cullMarginPx] 余量）把上墙片段压到可见的几十个，密集字幕滚动/拖延迟不卡。
@@ -933,10 +886,48 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
         child: _buildCueChip(theme, cs, cue, text, delayMs),
       ));
     }
-    return SizedBox(
+    final Widget stripBody = SizedBox(
       width: contentWidth,
       height: _stripHeight,
       child: Stack(clipBehavior: Clip.hardEdge, children: chips),
+    );
+    // 直接在波形上横拖底部字幕条对轴（用户反馈：不想滚到底用 +/-）：横向拖 = 平移整体
+    // 延迟，波形上的 cue 线 / 字幕块 / 下方字幕列表高亮随之实时移动，松手 [_commit] 落盘并
+    // 实时生效——与「拖上方波形区 = 平移查看时间轴」物理分离（不同 widget、不同拖动手势），
+    // 永不冲突。只在可调轴（[SubtitleWaveformZoomView.onCommitDelay] 非空）且时间窗有效时挂。
+    if (widget.onCommitDelay == null ||
+        widget.windowEndMs <= 0 ||
+        contentWidth <= 0) {
+      return stripBody;
+    }
+    // 像素↔毫秒：整条时间轴 windowEndMs 铺在 contentWidth 上，1 逻辑像素 = 该毫秒数。
+    final double msPerPx = widget.windowEndMs / contentWidth;
+    return MouseRegion(
+      cursor: SystemMouseCursors.grab,
+      child: GestureDetector(
+        key: const ValueKey<String>('subtitle-waveform-cue-strip'),
+        behavior: HitTestBehavior.opaque,
+        onHorizontalDragStart: (DragStartDetails _) {
+          _cueDragMsPrecise = (_dragMs ?? _delayMs).toDouble();
+          setState(() => _dragMs = _dragMs ?? _delayMs);
+        },
+        onHorizontalDragUpdate: (DragUpdateDetails details) {
+          // 向右拖字幕块 → 字幕出现更晚（延迟增大）；块跟手移动。
+          final double base = _cueDragMsPrecise ?? _delayMs.toDouble();
+          final double next = base + details.delta.dx * msPerPx;
+          _cueDragMsPrecise = next;
+          setState(
+              () => _dragMs = next.round().clamp(-_clampMs, _clampMs).toInt());
+        },
+        onHorizontalDragEnd: (DragEndDetails _) {
+          final int? preview = _dragMs;
+          _cueDragMsPrecise = null;
+          if (preview == null) return;
+          setState(() => _dragMs = null);
+          _commit(preview);
+        },
+        child: stripBody,
+      ),
     );
   }
 

--- a/hibiki/test/media/video/subtitle_waveform_align_panel_test.dart
+++ b/hibiki/test/media/video/subtitle_waveform_align_panel_test.dart
@@ -72,6 +72,19 @@ SubtitleWaveformPainter _zoomPainter(WidgetTester tester) {
   return paint.painter! as SubtitleWaveformPainter;
 }
 
+/// 波形 [CustomPaint] 的高度（= 当前 _waveHeight）。拖调节把手后应随之变化。
+double _waveHeight(WidgetTester tester) {
+  final CustomPaint paint = tester
+      .widgetList<CustomPaint>(find.descendant(
+        of: find.byType(SubtitleWaveformZoomView),
+        matching: find.byType(CustomPaint),
+      ))
+      .firstWhere((CustomPaint w) => w.painter is SubtitleWaveformPainter);
+  return paint.size.height;
+}
+
+const Key _resizeKey = ValueKey<String>('subtitle-waveform-resize-handle');
+
 const Key _openKey = ValueKey<String>('subtitle-waveform-open-button');
 
 /// TODO-1315: tapping the entry lazily probes then opens the zoom dialog.
@@ -528,5 +541,39 @@ void main() {
     expect(seeks, hasLength(1));
     expect(seeks.single, inInclusiveRange(0, 60000));
     expect(seeks.single, lessThan(1000)); // 近左缘 → 时间很小
+  });
+
+  testWidgets('resize handle: dragging up shrinks the waveform height',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_host(
+      cues: <AudioCue>[_cue(1000, 2000, text: 'ohayou')],
+      loadWaveform: () async => <double>[-60, -20, -40, -10, -30, -5],
+    ));
+    await tester.pumpAndSettle();
+    await _openZoom(tester);
+    expect(find.byKey(_resizeKey), findsOneWidget);
+    final double before = _waveHeight(tester);
+    // 向上拖把手 → 波形变矮（露出下方控件，短屏不必滚整弹窗）。
+    await tester.drag(find.byKey(_resizeKey), const Offset(0, -80));
+    await tester.pumpAndSettle();
+    final double after = _waveHeight(tester);
+    expect(after, lessThan(before));
+    expect(after, greaterThanOrEqualTo(96.0)); // 不低于 _minWaveHeight
+  });
+
+  testWidgets('resize handle: dragging down grows the waveform height',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_host(
+      cues: <AudioCue>[_cue(1000, 2000, text: 'ohayou')],
+      loadWaveform: () async => <double>[-60, -20, -40, -10, -30, -5],
+    ));
+    await tester.pumpAndSettle();
+    await _openZoom(tester);
+    final double before = _waveHeight(tester);
+    await tester.drag(find.byKey(_resizeKey), const Offset(0, 120));
+    await tester.pumpAndSettle();
+    final double after = _waveHeight(tester);
+    expect(after, greaterThan(before));
+    expect(after, lessThanOrEqualTo(360.0)); // 不高于 _maxWaveHeight
   });
 }

--- a/hibiki/test/media/video/subtitle_waveform_align_panel_test.dart
+++ b/hibiki/test/media/video/subtitle_waveform_align_panel_test.dart
@@ -72,18 +72,8 @@ SubtitleWaveformPainter _zoomPainter(WidgetTester tester) {
   return paint.painter! as SubtitleWaveformPainter;
 }
 
-/// 波形 [CustomPaint] 的高度（= 当前 _waveHeight）。拖调节把手后应随之变化。
-double _waveHeight(WidgetTester tester) {
-  final CustomPaint paint = tester
-      .widgetList<CustomPaint>(find.descendant(
-        of: find.byType(SubtitleWaveformZoomView),
-        matching: find.byType(CustomPaint),
-      ))
-      .firstWhere((CustomPaint w) => w.painter is SubtitleWaveformPainter);
-  return paint.size.height;
-}
-
-const Key _resizeKey = ValueKey<String>('subtitle-waveform-resize-handle');
+const Key _stripKey = ValueKey<String>('subtitle-waveform-cue-strip');
+const Key _hscrollKey = ValueKey<String>('subtitle-waveform-hscroll');
 
 const Key _openKey = ValueKey<String>('subtitle-waveform-open-button');
 
@@ -543,25 +533,36 @@ void main() {
     expect(seeks.single, lessThan(1000)); // 近左缘 → 时间很小
   });
 
-  testWidgets('resize handle: dragging up shrinks the waveform height',
+  testWidgets(
+      'cue strip drag: sliding the subtitle strip right commits a larger delay',
       (WidgetTester tester) async {
+    final List<int> committed = <int>[];
     await tester.pumpWidget(_host(
-      cues: <AudioCue>[_cue(1000, 2000, text: 'ohayou')],
-      loadWaveform: () async => <double>[-60, -20, -40, -10, -30, -5],
+      cues: <AudioCue>[
+        _cue(1000, 2000, text: 'ohayou'),
+        _cue(30000, 31000, text: 'konbanwa'),
+      ],
+      loadWaveform: () async => <double>[-60, -20, -40, -10, -30, -5, -50, -12],
+      onCommitDelay: (int ms) async => committed.add(ms),
     ));
     await tester.pumpAndSettle();
     await _openZoom(tester);
-    expect(find.byKey(_resizeKey), findsOneWidget);
-    final double before = _waveHeight(tester);
-    // 向上拖把手 → 波形变矮（露出下方控件，短屏不必滚整弹窗）。
-    await tester.drag(find.byKey(_resizeKey), const Offset(0, -80));
+    expect(_zoomPainter(tester).previewDelayMs, 0);
+    expect(find.byKey(_stripKey), findsOneWidget);
+    // 字幕条铺满整条时间轴、宽超视口，其几何中心在视口外；改用视口内、落在底部字幕条
+    // 高度上的点起拖（波形容器上部是波形区、底部 56px 是字幕条）。
+    final Rect box = tester.getRect(find.byKey(_hscrollKey));
+    final Offset start = Offset(box.left + 60, box.bottom - 18);
+    await tester.dragFrom(start, const Offset(140, 0));
     await tester.pumpAndSettle();
-    final double after = _waveHeight(tester);
-    expect(after, lessThan(before));
-    expect(after, greaterThanOrEqualTo(96.0)); // 不低于 _minWaveHeight
+    // 向右拖字幕块 → 延迟增大（正），松手落盘一次。
+    expect(committed, hasLength(1));
+    expect(committed.single, greaterThan(0));
+    expect(_zoomPainter(tester).previewDelayMs, committed.single);
   });
 
-  testWidgets('resize handle: dragging down grows the waveform height',
+  testWidgets(
+      'cue strip drag: read-only (no onCommitDelay) => no align-drag gesture',
       (WidgetTester tester) async {
     await tester.pumpWidget(_host(
       cues: <AudioCue>[_cue(1000, 2000, text: 'ohayou')],
@@ -569,11 +570,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
     await _openZoom(tester);
-    final double before = _waveHeight(tester);
-    await tester.drag(find.byKey(_resizeKey), const Offset(0, 120));
-    await tester.pumpAndSettle();
-    final double after = _waveHeight(tester);
-    expect(after, greaterThan(before));
-    expect(after, lessThanOrEqualTo(360.0)); // 不高于 _maxWaveHeight
+    // 无 onCommitDelay：字幕条只读，不挂对轴拖动手势（key 不存在）。
+    expect(find.byKey(_stripKey), findsNothing);
   });
 }


### PR DESCRIPTION
## 诉求（用户反馈 + 澄清）
在「波形对轴」弹窗里想**直接抓住波形下方那条字幕块、沿时间轴左右滑，把它对到语音波峰**即完成对轴——而不是把弹窗滚到底、用 `+/-` / 滑条一点点挪。

> 首版一度做成「拖底部把手调波形框高度」，方向理解错，已在本 PR 内撤回。

## 修复
- 波形下方的字幕条（`_buildCueStrip`）包一层**横向拖动手势**（`key: subtitle-waveform-cue-strip`，`grab` 光标）：
  - 横向拖 = 平移**整体延迟**；像素↔毫秒按 `windowEndMs / contentWidth` 换算，`_cueDragMsPrecise` 累计亚像素精度避免每帧取整丢步。
  - 拖动中走 `_dragMs` 预览：波形上的 cue 线、字幕块、下方字幕列表高亮**实时跟手**；松手 `_commit` 落盘并实时生效（与滑条 / 步进 / 自动对轴同一个 `_delayMs`，零第二套状态）。
  - 仅 `onCommitDelay` 非空（可调轴）时挂手势；只读时字幕条不可拖。
- 与「拖**上方波形区** = 平移查看时间轴」落在不同 widget、不同拖动手势上，**永不冲突**；实测子手势在手势竞技场胜过弹窗横向滚动（拖字幕条不会被滚动吞）。
- 底部滑条 / 步进 / 数值输入作为**细调兜底**保留，不删。无新增 i18n / 持久化字段。

## 测试
- 新增 2 条 widget 测试：拖字幕条向右 → 落盘一个更大的正延迟且 `previewDelayMs` 同步；只读（无 `onCommitDelay`）→ 字幕条不挂对轴手势。
- 既有「拖波形区不改延迟」等全部保留。`flutter test` 该文件 **23** 条全过，`flutter analyze` 两文件 No issues。

## 待真机验收
- 打开「波形对轴」，抓住波形下方字幕块横向拖动：字幕块 / cue 线 / 列表跟手移动，松手后字幕延迟按拖动量更新、实时生效；触屏与鼠标皆可。拖上方波形区仍为平移查看、互不干扰。