### PR TITLE
fix(mining): BUG-918 句子上下文对话框横屏塌陷只剩选项

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 894 条。点号进各自文件。
+> 共 895 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-918](bugs/BUG-918-scm-landscape-sentence-collapsed.md) | ✅ | ✅ | 制卡·选择句子上下文对话框横屏塌陷只剩选项看不见句子 |
 | [BUG-917](bugs/BUG-917-video-clip-mp4-muxer.md) | ✅ | ✅ | 视频片段导出 exit -22（捆绑 ffmpeg-min 无 matroska muxer，输出跟随源容器） |
 | [BUG-916](bugs/BUG-916-subtitle-list-shift-hover-offset.md) | ✅ | ✅ | 视频字幕列表Shift悬停查词偏左一格 |
 | [BUG-915](bugs/BUG-915-ass-user-scale-and-plain-off-mode.md) | ✅ | ✅ | 尊重字幕不能调字号；关闭尊重时 ASS 特效层叠印乱字 |

--- a/docs/bugs/BUG-918-scm-landscape-sentence-collapsed.md
+++ b/docs/bugs/BUG-918-scm-landscape-sentence-collapsed.md
@@ -1,0 +1,6 @@
+## BUG-918 · 制卡·选择句子上下文对话框横屏塌陷只剩选项看不见句子
+- **报告**：2026-07-19（用户：qqbotxiaoxiao，原话「手机上看不见句子，只有选项。这个选项占位太大了也」，附横屏截图）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/sentence_context_dialog.dart:326`（原 `Flexible(SingleChildScrollView(...))`）。`SentenceContextDialog` 的 `AlertDialog` 正文是 `Column(mainAxisSize: min)`，句子预览卡放在 `Flexible(SingleChildScrollView)` 里、下面跟固定的计数区/±按钮 Row（四颗 `OutlinedButton.icon`）。**横屏矮窗**（用户截图 780×360 逻辑）竖向空间不足时，`Flexible`（loose fit）把全部剩余空间让给固定兄弟 → 滚动区塌成 **0 高**，句子预览整段消失、只剩计数 + 选项按钮，同时 RenderFlex 底部溢出 23px。复现：无头 widget 测试在 780×360 下量到 `SingleChildScrollView` = `Size(600, 0)` + `A RenderFlex overflowed by 23 pixels`。竖屏 360×780 空间够、不塌陷，所以只在横屏（用户当时横屏阅读）暴露。
+- **[x] ① 已修复** — 改为 `AlertDialog(scrollable: true)` + 正文直接铺卡（`...spacedCards`），删掉内层 `Flexible`/`SingleChildScrollView`：整个对话框正文统一滚动，任何朝向/尺寸下句子预览都保有真实高度、按需滚动，不再塌陷也不溢出。附带收紧四颗 ±按钮（`VisualDensity.compact` + 收敛 padding/minSize + `shrinkWrap` tapTarget）回应「选项占位太大」，给句子预览让出竖向空间。提交：见下。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/sentence_context_dialog_landscape_guard_test.dart`：横屏 780×360 + 竖屏 360×780 两向下断言「无 RenderFlex 溢出 + 当前句真正渲染出可见高度（`getRect().height > 4`）+ 句顶落在屏内」。修复前横屏用例因塌成 0 高 + 溢出必失败。原 `sentence_context_dialog_widget_test.dart` 行为用例（当前句/计数/词高亮/后加一句整体替换/确认/取消还原）全绿。
+- **备注**：真机验证待用户（手机横屏 reader/有声书/视频点「调整上下文」，句子预览可见、按钮不占满、增减上下文 + 确认制卡正常）。

--- a/hibiki/lib/src/pages/implementations/sentence_context_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/sentence_context_dialog.dart
@@ -244,6 +244,8 @@ class _SentenceContextDialogState extends State<SentenceContextDialog> {
   }
 
   /// ±上下文按钮：图标（−/+）+ 文案的描边按钮。保持 [OutlinedButton] 语义。
+  /// 收紧到 compact 视觉密度 + 收敛内边距/最小尺寸——横屏矮窗里四颗按钮占位太重
+  /// （用户报「这个选项占位太大」），压扁后给句子预览让出竖向空间。
   Widget _adjustButton({
     required IconData icon,
     required String label,
@@ -251,6 +253,12 @@ class _SentenceContextDialogState extends State<SentenceContextDialog> {
   }) =>
       OutlinedButton.icon(
         onPressed: onPressed,
+        style: OutlinedButton.styleFrom(
+          visualDensity: VisualDensity.compact,
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+          minimumSize: const Size(0, 36),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
         icon: Icon(icon, size: 18),
         label: Text(label),
       );
@@ -278,6 +286,12 @@ class _SentenceContextDialogState extends State<SentenceContextDialog> {
     }
 
     return AlertDialog(
+      // BUG-908：横屏矮窗里正文竖向空间不足时，旧的 `Flexible(SingleChildScrollView)`
+      // 会把整块滚动区让给固定的计数/按钮区、塌成 0 高——句子预览整段消失，只剩选项
+      // （用户报「手机上看不见句子，只有选项」）。改为让整个对话框正文可滚动
+      // （`scrollable: true` + 正文直接铺卡，不再嵌 Flexible），任何朝向/尺寸下句子预览
+      // 都保有真实高度、按需滚动，不再塌陷也不溢出。
+      scrollable: true,
       // 标题区对齐 Niratan header：小 eyebrow 在上、大标题在下，右侧一个关闭 X（=取消）。
       title: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -323,16 +337,10 @@ class _SentenceContextDialogState extends State<SentenceContextDialog> {
                           ?.copyWith(color: scheme.onSurfaceVariant),
                     ),
                   ),
-                  Flexible(
-                    child: SingleChildScrollView(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: spacedCards,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 14),
+                  // 正文已由 AlertDialog(scrollable: true) 统一滚动，这里直接铺卡，
+                  // 不再嵌 Flexible/SingleChildScrollView（那在矮窗会塌成 0 高）。
+                  ...spacedCards,
+                  const SizedBox(height: 12),
                   // ±上下文：前一组靠左、后一组靠右（对齐 Niratan rangeControls 的
                   // 「Remove/Add Previous … Remove/Add Next」分组）。各半区内用 Wrap
                   // 兜底换行，窄屏不会溢出。

--- a/hibiki/test/pages/sentence_context_dialog_landscape_guard_test.dart
+++ b/hibiki/test/pages/sentence_context_dialog_landscape_guard_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/sentence_context_dialog.dart';
+
+/// BUG-918：「制卡·选择句子上下文」原生对话框在**横屏矮窗**下句子预览塌陷、只剩选项。
+///
+/// 根因：AlertDialog 正文 Column 竖向空间不足时，`Flexible(SingleChildScrollView)`
+/// 把全部空间让给固定的计数/按钮区、塌成 0 高——句子预览整段消失（用户报「手机上
+/// 看不见句子，只有选项」），同时 RenderFlex 溢出。修复改为 `AlertDialog(scrollable: true)`
+/// + 正文直接铺卡，任何朝向/尺寸下句子预览都保有真实高度、按需滚动、不再塌陷或溢出。
+void main() {
+  Map<String, Object?> preview() => <String, Object?>{
+        'prev': const <String>[],
+        'current': '俺に対する同情。',
+        'currentOffset': 2, // 「対する」在偏移 2
+        'next': const <String>[],
+        'total': 0,
+      };
+
+  Widget harness() => MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext ctx) => Center(
+              child: ElevatedButton(
+                onPressed: () => showDialog<void>(
+                  context: ctx,
+                  builder: (_) => SentenceContextDialog(
+                    matched: '対する',
+                    fetchPreview: () async => preview(),
+                    setContext: (int p, int n) async => p + n,
+                    onConfirm: () {},
+                  ),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+  Finder currentSentence() => find.byWidgetPredicate(
+        (Widget w) =>
+            w is RichText &&
+            w.text is TextSpan &&
+            (w.text as TextSpan).toPlainText().contains('俺に対する同情。'),
+      );
+
+  testWidgets('横屏矮窗下句子预览不塌陷、可见、且不溢出', (WidgetTester tester) async {
+    // 手机横屏：2340x1080 物理 / dpr 3 => 780x360 逻辑（用户截图正是横向）。
+    tester.view.physicalSize = const Size(2340, 1080);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(harness());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // 无 RenderFlex 溢出（修复前会「A RenderFlex overflowed」）。
+    expect(tester.takeException(), isNull, reason: '横屏矮窗对话框不得溢出');
+
+    // 当前句必须真正渲染出来、且有可见高度（修复前塌成 0 高不可见）。
+    final Finder sentence = currentSentence();
+    expect(sentence, findsOneWidget, reason: '当前句必须存在于对话框');
+    final Rect rect = tester.getRect(sentence);
+    expect(rect.height, greaterThan(4), reason: '当前句必须有真实渲染高度（塌陷时为 0）');
+
+    // 句子必须落在屏幕可视范围内（顶部可见），不是被挤出屏外。
+    final Size screen = tester.view.physicalSize / tester.view.devicePixelRatio;
+    expect(rect.top, greaterThanOrEqualTo(0.0));
+    expect(rect.top, lessThan(screen.height), reason: '当前句顶必须落在屏幕内、用户看得见');
+  });
+
+  testWidgets('竖屏窄窗下句子预览同样可见、不溢出', (WidgetTester tester) async {
+    // 手机竖屏：1080x2340 物理 / dpr 3 => 360x780 逻辑。
+    tester.view.physicalSize = const Size(1080, 2340);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(harness());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull, reason: '竖屏窄窗对话框不得溢出');
+    final Finder sentence = currentSentence();
+    expect(sentence, findsOneWidget);
+    expect(tester.getRect(sentence).height, greaterThan(4));
+  });
+}


### PR DESCRIPTION
## 现象
手机**横屏**下「制卡·选择句子上下文」对话框只显示计数 + 四颗选项按钮，**看不见句子预览**；用户还反馈「这个选项占位太大」。

## 根因
`sentence_context_dialog.dart` 的 `AlertDialog` 正文是 `Column(mainAxisSize: min)`，句子预览卡放在 `Flexible(SingleChildScrollView)` 里、下面跟固定的计数区 + ±按钮 Row。**横屏矮窗竖向空间不足时，`Flexible`(loose) 把全部剩余空间让给固定兄弟 → 滚动区塌成 0 高**，句子整段消失，同时 RenderFlex 底部溢出 23px。竖屏空间够、不塌陷，所以只在横屏暴露。

无头 widget 测试量到（修复前，780×360）：`SingleChildScrollView = Size(600, 0)` + `A RenderFlex overflowed by 23 pixels`。

## 修复
- `AlertDialog(scrollable: true)` + 正文直接铺卡（删内层 `Flexible`/`SingleChildScrollView`）：整个正文统一滚动，任何朝向/尺寸下句子预览都保有真实高度、按需滚动，不再塌陷或溢出。
- 收紧四颗 ±按钮（`VisualDensity.compact` + 收敛 padding/minSize + shrinkWrap tapTarget），回应「选项占位太大」，给句子让出竖向空间。

## 测试
- 新增 `test/pages/sentence_context_dialog_landscape_guard_test.dart`：横屏 780×360 + 竖屏 360×780 断言「无溢出 + 当前句可见高度 + 句顶落屏内」。修复前横屏用例必失败。
- 原 `sentence_context_dialog_widget_test.dart` 行为用例全绿。
- `flutter analyze` 干净。

真机验证待用户（横屏 reader/有声书/视频点「调整上下文」，句子可见、按钮不占满、增减+确认制卡正常）。

BUG: docs/bugs/BUG-918-scm-landscape-sentence-collapsed.md