### PR TITLE
fix(video): 字幕偏移输入框边键入边生效，无需回车 (BUG-918)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 894 条。点号进各自文件。
+> 共 895 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-918](bugs/BUG-918-subtitle-offset-input-no-live-update.md) | ✅ | ✅ | 字幕偏移输入框不按回车不更新·退格没反应 |
 | [BUG-917](bugs/BUG-917-video-clip-mp4-muxer.md) | ✅ | ✅ | 视频片段导出 exit -22（捆绑 ffmpeg-min 无 matroska muxer，输出跟随源容器） |
 | [BUG-916](bugs/BUG-916-subtitle-list-shift-hover-offset.md) | ✅ | ✅ | 视频字幕列表Shift悬停查词偏左一格 |
 | [BUG-915](bugs/BUG-915-ass-user-scale-and-plain-off-mode.md) | ✅ | ✅ | 尊重字幕不能调字号；关闭尊重时 ASS 特效层叠印乱字 |

--- a/docs/bugs/BUG-918-subtitle-offset-input-no-live-update.md
+++ b/docs/bugs/BUG-918-subtitle-offset-input-no-live-update.md
@@ -1,0 +1,14 @@
+## BUG-918 · 字幕偏移输入框不按回车不更新·退格没反应
+- **报告**：2026-07-19（用户：视频字幕对轴「偏移(ms)」输入框——不按回车不更新、backspace 没反应）
+- **真实性**：✅ 真 bug（单一根因，两条症状同源）。「偏移(ms)」数值输入框只有 `onSubmitted`（回车）提交、**没有 `onChanged`**：
+  - `hibiki/lib/src/media/video/video_quick_settings_sheet.dart:1092` 的 `AdaptiveSettingsTextField`（快速设置面板字幕分类的偏移框，即用户截图那个）。
+  - `hibiki/lib/src/media/video/subtitle_waveform_align_panel.dart:1251` 的 `AdaptiveSettingsTextField`（波形对轴放大视图内同款偏移框）。
+  - **不按回车不更新**：无 `onChanged`，键入的值不落到延迟，必须按回车（`onSubmitted`）才 `_commitDelay` / `_commit`。
+  - **backspace 没反应**：同源。退格能删字符（TextField 本身正常——排查过全局 / media_kit / 焦点控制器均无夺 backspace 的路径：焦点在输入框时 `EditableText` 的文本编辑 Action 比任何祖先 `Shortcuts`（含 `videoResetSpeed`=Backspace）更靠近焦点、先消费），但删完不落到延迟 → 用户观感「退格没反应」。**不是按键被吞，是编辑不实时生效。**
+- **[x] ① 已修复** — 两个偏移框都加「边键入边去抖生效」：新增 `onChanged: _onDelayInputChanged`，解析成功就去抖 350ms 后走既有权威提交（`_commitDelay` / `_commit`，与滑条 / ± 按钮同源、实时生效），**无需回车**；退格 / 键入实时反映到延迟。
+  - 去抖（`Timer? _delayInputDebounce`）避免逐键提交把字幕来回跳 + OSD 刷屏；`syncField:false` 不回写输入框文本，保住光标与退格（若回写会把光标弹到行尾、下一次退格看似「没反应」）。
+  - 空 / 只有正负号等未成形输入解析失败 → 不提交、不回退，保留用户正在敲的中间态。
+  - 权威提交（滑条 / ± 按钮 / 回车）取消任何待触发的键入去抖，免得陈旧键入值迟到覆盖。`dispose` 取消 timer。
+  - 提交：<PENDING>
+- **[x] ② 已加自动化测试** — 行为测试 `hibiki/test/media/video/subtitle_waveform_align_panel_test.dart`（3 条 BUG-918 用例）：① 键入 `1230` **不按回车**、过 350ms 去抖窗口后 `onCommitDelay` 收到 `1230`，且输入框文本未被回写（`find.text('1230')` 仍在 → 光标/退格不错位）；② 退格删末位 `1230→123` 实时重提交 `123`；③ 清空 / 只留 `-` 等未成形输入不提交、不回退。快速设置面板同款字段逻辑完全一致（develop 无该 sheet 的 widget test harness，共享同一行为守卫）。
+- **备注**：去抖 350ms。实时提交仍走既有 `onSetDelay`→`_setDelayMs`→OSD 反馈路径（BUG-373 范式），慢速键入每位会弹一次 OSD、属可接受的即时反馈。需**真机复测**：在字幕对轴偏移框键入 / 退格，不按回车即看到字幕延迟随之变化。

--- a/hibiki/lib/src/media/video/subtitle_waveform_align_panel.dart
+++ b/hibiki/lib/src/media/video/subtitle_waveform_align_panel.dart
@@ -353,6 +353,11 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
   late final TextEditingController _delayController =
       TextEditingController(text: '${widget.initialDelayMs}');
 
+  /// 数值输入框「边键入边生效」去抖（BUG-918）：与 [VideoQuickSettingsSheet] 同款——原字段只在
+  /// [onSubmitted]（Enter）提交、无 [onChanged]，用户报「不按回车不更新、backspace 没反应」。改为
+  /// 键入即去抖 350ms 后 [_commit]，无需回车；[syncField:false] 不回写文本，保住光标与退格。
+  Timer? _delayInputDebounce;
+
   final ScrollController _scrollController = ScrollController();
 
   /// 每根波形柱的目标像素宽（含间隙）。
@@ -516,6 +521,7 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
 
   @override
   void dispose() {
+    _delayInputDebounce?.cancel();
     _positionTicker?.cancel();
     _positionTicker = null;
     _livePositionMs.dispose();
@@ -526,9 +532,25 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
     super.dispose();
   }
 
+  /// 数值输入框 [onChanged]：解析成功就去抖 350ms 后 [_commit] 实时生效（BUG-918），无需回车。
+  /// 空 / 只有正负号等未成形输入解析失败 → 不提交、不回退，保留用户正在敲的中间态。
+  void _onDelayInputChanged(String raw) {
+    _delayInputDebounce?.cancel();
+    final int? parsed = int.tryParse(raw.trim());
+    if (parsed == null) return;
+    _delayInputDebounce = Timer(const Duration(milliseconds: 350), () {
+      if (!mounted) return;
+      // syncField:false —— 键入过程中不回写输入框文本，避免光标弹到行尾、退格错位。
+      _commit(parsed, syncField: false);
+    });
+  }
+
   /// 调轴权威提交：clamp -> 本地 setState -> 可选回写输入框 -> 回调写回上方 `_delayMs`。
   Future<void> _commit(int next, {bool syncField = true}) async {
     final int clamped = next.clamp(-_clampMs, _clampMs);
+    // 权威提交（滑条 / 步进 / 回车回写文本的路径）取消待触发的键入去抖，免得陈旧键入值
+    // 迟到覆盖刚设的值（BUG-918）。
+    if (syncField) _delayInputDebounce?.cancel();
     if (mounted) {
       setState(() {
         _delayMs = clamped;
@@ -1231,7 +1253,10 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
           labelText: t.video_setting_subtitle_sync_input,
           keyboardType: const TextInputType.numberWithOptions(signed: true),
           textInputAction: TextInputAction.done,
+          // 边键入边去抖生效（BUG-918）：不再要求按回车，退格 / 键入实时反映到延迟。
+          onChanged: _onDelayInputChanged,
           onSubmitted: (String raw) {
+            _delayInputDebounce?.cancel();
             final int? parsed = int.tryParse(raw.trim());
             if (parsed == null) {
               _delayController.text = '$_delayMs';

--- a/hibiki/lib/src/media/video/video_quick_settings_sheet.dart
+++ b/hibiki/lib/src/media/video/video_quick_settings_sheet.dart
@@ -373,6 +373,13 @@ class _VideoQuickSettingsSheetState extends State<VideoQuickSettingsSheet> {
   /// 避免每个拖动 tick 都写 DB。null = 未在拖动。
   int? _delayDragMs;
 
+  /// 数值输入框「边键入边生效」的去抖（BUG-918）：用户报「不按回车不更新、backspace 没反应」——
+  /// 原字段只有 [onSubmitted]（Enter）提交、无 [onChanged]，故键入 / 退格不落到延迟上，观感像
+  /// 「输入框没反应」。改为键入即去抖提交（350ms 停手后 [_commitDelay]，与滑条 / ± 按钮同源、
+  /// 实时生效），不再要求按回车。去抖避免逐键提交把字幕来回跳 + OSD 刷屏；[syncField:false]
+  /// 不回写文本，保住光标与退格（回写会把光标弹到行尾、下一次退格看似「没反应」）。
+  Timer? _delayInputDebounce;
+
   /// 一键自动对轴进行中（TODO-701）：按钮显示 spinner 并禁用，防重入。
   bool _autoAligning = false;
 
@@ -397,10 +404,24 @@ class _VideoQuickSettingsSheetState extends State<VideoQuickSettingsSheet> {
 
   @override
   void dispose() {
+    _delayInputDebounce?.cancel();
     _rawConfController.dispose();
     _delayController.dispose();
     _danmakuBlockRulesController.dispose();
     super.dispose();
+  }
+
+  /// 数值输入框 [onChanged]：解析成功就去抖 350ms 后走 [_commitDelay] 实时生效（BUG-918），
+  /// 无需回车。空 / 只有正负号等未成形输入解析失败 → 不提交、不回退（保留用户正在敲的中间态）。
+  void _onDelayInputChanged(String raw) {
+    _delayInputDebounce?.cancel();
+    final int? parsed = int.tryParse(raw.trim());
+    if (parsed == null) return;
+    _delayInputDebounce = Timer(const Duration(milliseconds: 350), () {
+      if (!mounted) return;
+      // syncField:false —— 键入过程中不回写输入框文本，避免光标弹到行尾、退格错位。
+      _commitDelay(parsed, syncField: false);
+    });
   }
 
   @override
@@ -893,6 +914,9 @@ class _VideoQuickSettingsSheetState extends State<VideoQuickSettingsSheet> {
   /// 即时回调 [VideoQuickSettingsSheet.onSetDelay] 落盘+实时生效。
   Future<void> _commitDelay(int next, {bool syncField = true}) async {
     final int clamped = next.clamp(-_subtitleSyncClampMs, _subtitleSyncClampMs);
+    // 权威提交（syncField，即滑条 / ± 按钮 / 回车回写文本的路径）取消任何待触发的键入去抖，
+    // 免得一个陈旧的键入值在按钮点击后姗姗迟到覆盖掉刚设的值（BUG-918）。
+    if (syncField) _delayInputDebounce?.cancel();
     setState(() => _delayMs = clamped);
     if (syncField && _delayController.text != '$clamped') {
       _delayController.text = '$clamped';
@@ -1048,7 +1072,10 @@ class _VideoQuickSettingsSheetState extends State<VideoQuickSettingsSheet> {
             labelText: t.video_setting_subtitle_sync_input,
             keyboardType: const TextInputType.numberWithOptions(signed: true),
             textInputAction: TextInputAction.done,
+            // 边键入边去抖生效（BUG-918）：不再要求按回车，退格 / 键入实时反映到延迟。
+            onChanged: _onDelayInputChanged,
             onSubmitted: (String raw) {
+              _delayInputDebounce?.cancel();
               final int? parsed = int.tryParse(raw.trim());
               if (parsed == null) {
                 // 非法输入 → 回退到当前权威值，不改延迟。

--- a/hibiki/test/media/video/subtitle_waveform_align_panel_test.dart
+++ b/hibiki/test/media/video/subtitle_waveform_align_panel_test.dart
@@ -510,6 +510,91 @@ void main() {
     expect(spaceHits, 1);
   });
 
+  testWidgets(
+      'BUG-918: typing the offset commits live (no Enter) via debounce, '
+      'without clobbering the typed text', (WidgetTester tester) async {
+    final List<int> committed = <int>[];
+    await tester.pumpWidget(_host(
+      cues: <AudioCue>[_cue(1000, 2000)],
+      loadWaveform: () async => <double>[-60, -20, -40, -10, -30, -5],
+      onCommitDelay: (int ms) async => committed.add(ms),
+    ));
+    await tester.pumpAndSettle();
+    await _openZoom(tester);
+    final Finder field = find.descendant(
+      of: find.byType(SubtitleWaveformZoomView),
+      matching: find.byType(TextField),
+    );
+    expect(field, findsOneWidget);
+    await tester.ensureVisible(field);
+    await tester.pumpAndSettle();
+
+    // 键入偏移值但**不按回车**：去抖窗口内还未提交。
+    await tester.enterText(field, '1230');
+    await tester.pump();
+    expect(committed, isEmpty);
+
+    // 停手过了去抖窗口 → 无需回车即落到延迟（onCommitDelay 收到键入值）。
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(committed, <int>[1230]);
+
+    // 去抖提交走 syncField:false，不回写输入框文本：用户键入的字符仍在，
+    // 光标不被弹到行尾（保证随后退格 / 继续编辑不错位）。
+    expect(find.text('1230'), findsWidgets);
+  });
+
+  testWidgets(
+      'BUG-918: erasing a digit re-commits the shortened value live (no Enter)',
+      (WidgetTester tester) async {
+    final List<int> committed = <int>[];
+    await tester.pumpWidget(_host(
+      cues: <AudioCue>[_cue(1000, 2000)],
+      loadWaveform: () async => <double>[-60, -20, -40, -10, -30, -5],
+      initialDelayMs: 1230,
+      onCommitDelay: (int ms) async => committed.add(ms),
+    ));
+    await tester.pumpAndSettle();
+    await _openZoom(tester);
+    final Finder field = find.descendant(
+      of: find.byType(SubtitleWaveformZoomView),
+      matching: find.byType(TextField),
+    );
+    await tester.ensureVisible(field);
+    await tester.pumpAndSettle();
+
+    // 模拟退格删掉末位 0：文本从 1230 → 123，不按回车。
+    await tester.enterText(field, '123');
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(committed, <int>[123]);
+  });
+
+  testWidgets(
+      'BUG-918: partial input (empty / lone sign) does not commit or revert',
+      (WidgetTester tester) async {
+    final List<int> committed = <int>[];
+    await tester.pumpWidget(_host(
+      cues: <AudioCue>[_cue(1000, 2000)],
+      loadWaveform: () async => <double>[-60, -20, -40, -10, -30, -5],
+      onCommitDelay: (int ms) async => committed.add(ms),
+    ));
+    await tester.pumpAndSettle();
+    await _openZoom(tester);
+    final Finder field = find.descendant(
+      of: find.byType(SubtitleWaveformZoomView),
+      matching: find.byType(TextField),
+    );
+    await tester.ensureVisible(field);
+    await tester.pumpAndSettle();
+
+    // 清空 + 只留正负号：解析失败 → 不提交、不回退（保留中间态可继续键入）。
+    await tester.enterText(field, '');
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.enterText(field, '-');
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(committed, isEmpty);
+    expect(find.text('-'), findsWidgets);
+  });
+
   testWidgets('waveform tap seeks the playhead to the tapped time',
       (WidgetTester tester) async {
     final List<int> seeks = <int>[];


### PR DESCRIPTION
## 用户报告
视频字幕对轴「偏移(ms)」输入框：**不按回车不更新、backspace 没反应**。

## 根因（单一，两症状同源）
偏移数值框只有 `onSubmitted`（回车）提交、**没有 `onChanged`**：
- `video_quick_settings_sheet.dart`（快速设置面板字幕分类，截图那个）
- `subtitle_waveform_align_panel.dart`（波形对轴放大视图内同款）

- **不按回车不更新** = 无 onChanged，键入不落到延迟。
- **backspace 没反应** = 同源。退格能删字符（排查过全局/media_kit/焦点控制器均无夺 Backspace 的路径——焦点在框内时 `EditableText` 的编辑 Action 比祖先 `Shortcuts`（含 videoResetSpeed=Backspace）更靠近焦点、先消费），但删完不落到延迟 → 观感「没反应」。**不是按键被吞，是编辑不实时生效。**

## 修复
两个偏移框都加「边键入边去抖生效」：
- `onChanged: _onDelayInputChanged` → 解析成功去抖 350ms 后走既有权威提交（`_commitDelay`/`_commit`，与滑条/±按钮同源、实时生效），**无需回车**。
- `syncField:false` 不回写文本 → 保住光标与退格（回写会把光标弹行尾、下次退格看似没反应）。
- 空/只有正负号等未成形输入不提交、不回退。
- 权威提交（滑条/±/回车）取消待触发的键入去抖；`dispose` 取消 timer。

## 测试
`test/media/video/subtitle_waveform_align_panel_test.dart` 新增 3 条 BUG-918 用例：键入不按回车过去抖窗口即提交且文本不被回写 / 退格缩短值实时重提交 / 未成形输入不提交不回退。**全部通过（24/24）**，`flutter analyze` 无问题。

## 待验证
🔎 需真机复测：字幕对轴偏移框键入/退格，不按回车即看到延迟随之变化。