### PR TITLE
fix(anime-download): 搜索macron修复 + 默认内置引擎开箱即用 + 对话框真走内置引擎 (BUG-895)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 869 条。点号进各自文件。
+> 共 870 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-895](bugs/BUG-895-anilist-macron-search.md) | ✅ | ✅ | 番剧下载AniList搜索:带macron长音的罗马字全无结果 |
 | [BUG-890](bugs/BUG-890-paused-audio-follow-image-snap.md) | ✅ | ✅ | 暂停/图片等待时有声书跟随把阅读器拽回音频位置 |
 | [BUG-887](bugs/BUG-887-top-progress-squeeze-frost.md) | ✅ | ✅ | 挤压模式顶部进度不应有毛玻璃且不应压住正文首行 |
 | [BUG-886](bugs/BUG-886-collapse-header-center.md) | ✅ | ✅ | 折叠设置分组标题头文字与箭头未垂直居中 |

--- a/docs/bugs/BUG-895-anilist-macron-search.md
+++ b/docs/bugs/BUG-895-anilist-macron-search.md
@@ -1,0 +1,19 @@
+## BUG-895 · 番剧下载AniList搜索:带macron长音的罗马字全无结果
+- **报告**：2026-07-19（用户：番剧下载搜索全是无结果，本机搜「Chūnibyō Demo Koi ga Shitai!」）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/video/anilist_client.dart`（`searchAnime` 把用户原串直接当 `search` 变量发给 AniList）。
+- **[x] ① 已修复** — `hibiki/lib/src/media/video/anilist_client.dart` 新增 `normalizeAniListSearch`，把 macron 长音符（ū ō ā ī ē，含预组合字母与 combining U+0304）按修正 Hepburn 展开成双元音（ū→uu、ō→ou…），`searchAnime` 发请求前先归一化。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/anilist_client_test.dart`（macron 展开纯函数单测，含预组合/combining/大小写/no-op；4 tests）。
+- **备注**：
+
+**根因（curl + live AniListClient 实证）**：番剧官方 romaji 常用 macron 转写（Wikipedia/官方，如「Chūnibyō」），用户会直接打或复制。但 AniList 的 GraphQL `search` 索引用**修正 Hepburn 双元音拼法**（「Chuunibyou」）且**不对 macron 做归一化匹配**：
+- `Chūnibyō Demo Koi ga Shitai!`（带 ū ō）→ **0 结果**
+- 简单去 macron 的 `Chunibyo Demo…`（单元音）→ **仍 0**（太短，AniList 模糊匹配也不命中完整串）
+- 双元音 `Chuunibyou Demo…` → **命中**
+
+原 `searchAnime` 把原串（带 macron）直接发出去 → 0 结果 → `catch(_) → 空列表` → UI 显示"无结果"。
+
+**修复**：搜索前 `normalizeAniListSearch(query)` 把 macron 展开成双元音（ā→aa ī→ii ū→uu ē→ee ō→ou；combining U+0304 双写前一元音）。纯函数，无 macron 的输入 no-op，不降低正常命中。
+
+**验证**：真实 `AniListClient.searchAnime('Chūnibyō Demo Koi ga Shitai!')` 修复后返回 **10 结果**（`Chuunibyou demo Koi ga Shitai!` 等），修复前 0。
+
+**范围外（本 bug 不含，另议）**：`searchAnime` 的 `catch(_)→空列表` 把网络失败与真无结果混为一谈（用户网络访问不了 AniList 时也只看到"无结果"）——建议后续区分错误态给不同提示。

--- a/hibiki/lib/src/media/torrent/anime_download_config.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_config.dart
@@ -8,7 +8,7 @@ import 'dart:convert';
 /// 字符串，解析在消费端做。
 class QbConnectionConfig {
   const QbConnectionConfig({
-    this.backend = backendQbittorrent,
+    this.backend = backendAuto,
     this.baseUrl = '',
     this.username = '',
     this.password = '',
@@ -27,9 +27,23 @@ class QbConnectionConfig {
   /// 后端标识：内置 libtorrent 引擎（桌面；见 EmbeddedTorrentHost）。
   static const String backendEmbedded = 'embedded';
 
-  /// 下载后端（[backendQbittorrent] / [backendEmbedded]）。历史配置无此
-  /// 字段时回退 qb（向后兼容：既有用户行为不变）。
+  /// 后端标识：自动（默认，开箱即用）——桌面用内置引擎、移动端外接 qb。
+  /// 用户没显式选过后端时的值。
+  static const String backendAuto = 'auto';
+
+  /// 下载后端（[backendAuto] / [backendQbittorrent] / [backendEmbedded]）。
+  /// 默认 [backendAuto]，按平台解析（见 [resolveBackend]）。历史配置无此字段
+  /// 但配过 qb 地址的，decode 时回退 qb（向后兼容：老用户行为不变）。
   final String backend;
+
+  /// 把 [backendAuto] 解析成具体后端：桌面 → 内置引擎、移动端 → 外接 qb。
+  /// 已显式选定（embedded/qbittorrent）的原样返回。
+  String resolveBackend({required bool isDesktop}) {
+    if (backend == backendAuto) {
+      return isDesktop ? backendEmbedded : backendQbittorrent;
+    }
+    return backend;
+  }
 
   /// WebUI 地址（如 `http://127.0.0.1:8080`）；空 = 未配置。
   final String baseUrl;
@@ -52,9 +66,10 @@ class QbConnectionConfig {
   /// 内置引擎全局最大连接数（0 = 引擎默认）。
   final int maxConnections;
 
-  /// 是否已配置（[baseUrl] 非空）；未配置时下载入队与完成监听均不动作。
+  /// 是否已配置：内置引擎/自动无需连接参数恒为真（桌面开箱即用）；外接 qb
+  /// 要求 [baseUrl] 非空。未配置时下载入队与完成监听均不动作。
   bool get isConfigured =>
-      backend == backendEmbedded || baseUrl.trim().isNotEmpty;
+      backend != backendQbittorrent || baseUrl.trim().isNotEmpty;
 
   QbConnectionConfig copyWith({
     String? backend,
@@ -79,6 +94,25 @@ class QbConnectionConfig {
   }
 }
 
+/// 解析 backend 字段（向后兼容）：
+/// - 显式 `embedded`/`qbittorrent`/`auto` → 原样
+/// - 无字段/未知值：配过 qb 地址（[baseUrl] 非空）→ qbittorrent（老用户不变）；
+///   否则 → auto（新用户默认，按平台解析）。
+String _decodeBackend(Object? raw, String baseUrl) {
+  if (raw == QbConnectionConfig.backendEmbedded) {
+    return QbConnectionConfig.backendEmbedded;
+  }
+  if (raw == QbConnectionConfig.backendQbittorrent) {
+    return QbConnectionConfig.backendQbittorrent;
+  }
+  if (raw == QbConnectionConfig.backendAuto) {
+    return QbConnectionConfig.backendAuto;
+  }
+  return baseUrl.trim().isNotEmpty
+      ? QbConnectionConfig.backendQbittorrent
+      : QbConnectionConfig.backendAuto;
+}
+
 /// JSON 数字字段容错解析为非负 int（null/非数/负数 → 0）。
 int _nonNegInt(Object? value) {
   final int n = value is num ? value.toInt() : 0;
@@ -94,12 +128,11 @@ QbConnectionConfig? decodeQbConnectionConfig(String raw) {
     final dynamic json = jsonDecode(raw);
     if (json is! Map) return null;
     final dynamic category = json['category'];
-    final dynamic backend = json['backend'];
+    final String baseUrl =
+        json['baseUrl'] is String ? json['baseUrl'] as String : '';
     return QbConnectionConfig(
-      backend: backend == QbConnectionConfig.backendEmbedded
-          ? QbConnectionConfig.backendEmbedded
-          : QbConnectionConfig.backendQbittorrent,
-      baseUrl: json['baseUrl'] is String ? json['baseUrl'] as String : '',
+      backend: _decodeBackend(json['backend'], baseUrl),
+      baseUrl: baseUrl,
       username: json['username'] is String ? json['username'] as String : '',
       password: json['password'] is String ? json['password'] as String : '',
       category: category is String && category.isNotEmpty

--- a/hibiki/lib/src/media/video/anilist_client.dart
+++ b/hibiki/lib/src/media/video/anilist_client.dart
@@ -39,6 +39,48 @@ class AniListMedia {
               : 'AniList #$id';
 }
 
+/// 罗马字长音符（macron）→ **双元音** 展开（修正 Hepburn）。番剧官方 romaji
+/// 常用 macron 转写（ū ō ā ī ē，如「Chūnibyō」），但 AniList 的 search 索引
+/// 用双元音拼法（如「Chuunibyou」）且**不做 macron 归一化匹配**——用户直接
+/// 打/复制带 macron 的标题会 0 结果。
+///
+/// 实测（live AniList）：`Chūnibyō Demo Koi ga Shitai!` → 0；简单去 macron 的
+/// `Chunibyo Demo…`（单元音）→ 仍 0（太短）；双元音 `Chuunibyou Demo…` → 命中。
+/// 故按修正 Hepburn 展开长音：ā→aa ī→ii ū→uu ē→ee ō→ou（ō 取最常见的 おう；
+/// 少数 おお 词靠 AniList 模糊匹配兜底）。
+const Map<int, String> _macronExpand = <int, String>{
+  0x0100: 'Aa', 0x0101: 'aa', // Ā ā
+  0x0112: 'Ee', 0x0113: 'ee', // Ē ē
+  0x012A: 'Ii', 0x012B: 'ii', // Ī ī
+  0x014C: 'Ou', 0x014D: 'ou', // Ō ō
+  0x016A: 'Uu', 0x016B: 'uu', // Ū ū
+};
+
+/// 归一化搜索关键词：把 macron 长音符展开成双元音，让带官方 romaji 长音的
+/// 输入也能命中 AniList。预组合字母（ū…）按 [_macronExpand] 展开；分解形式的
+/// combining macron U+0304 把前一个元音再写一遍（双写）。纯函数：无 macron 的
+/// 输入原样返回（no-op），不会降低正常命中。
+String normalizeAniListSearch(String query) {
+  final StringBuffer sb = StringBuffer();
+  int? prevRune; // 供 combining macron 双写前一元音
+  for (final int rune in query.runes) {
+    if (rune == 0x0304) {
+      // combining macron：分解形式（如 'u' + U+0304）→ 双写前一个字母。
+      if (prevRune != null) sb.writeCharCode(prevRune);
+      continue;
+    }
+    final String? expanded = _macronExpand[rune];
+    if (expanded != null) {
+      sb.write(expanded);
+      prevRune = null;
+    } else {
+      sb.writeCharCode(rune);
+      prevRune = rune;
+    }
+  }
+  return sb.toString();
+}
+
 /// 解析 AniList GraphQL 搜索响应为 [AniListMedia] 列表。纯函数，容错（结构不符 →
 /// 空列表），便于单测。
 List<AniListMedia> parseAniListSearchResponse(String body) {
@@ -95,8 +137,11 @@ query ($search: String) {
 }''';
 
   /// 按 [title] 搜索番剧。网络/解析失败返回空列表（不抛，调用方按空处理）。
+  /// 搜索词先做 macron 归一化（见 [normalizeAniListSearch]），让带官方 romaji
+  /// 长音（ū ō…）的输入也能命中 AniList。
   Future<List<AniListMedia>> searchAnime(String title) async {
-    if (title.trim().isEmpty) return const <AniListMedia>[];
+    final String query = normalizeAniListSearch(title.trim());
+    if (query.isEmpty) return const <AniListMedia>[];
     try {
       final http.Response res = await _client.post(
         Uri.parse(_endpoint),
@@ -106,7 +151,7 @@ query ($search: String) {
         },
         body: jsonEncode(<String, dynamic>{
           'query': _searchQuery,
-          'variables': <String, dynamic>{'search': title},
+          'variables': <String, dynamic>{'search': query},
         }),
       );
       if (res.statusCode != 200) return const <AniListMedia>[];

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -2789,6 +2789,16 @@ class AppModel with ChangeNotifier {
     )..start();
   }
 
+  /// 内置引擎宿主是否就绪（桌面且 DLL 已加载）。下载对话框据此判断能否走
+  /// 内置引擎（不必配置外接 qb）。
+  bool get isEmbeddedTorrentReady => _embeddedTorrentHost != null;
+
+  /// 按配置解析出应使用的下载后端（供下载对话框的推送按钮与轮询服务共用
+  /// 同一选择逻辑）。调用方用完须 `close()`（内置引擎的视图 close 是 no-op，
+  /// 不连累常驻 session）。
+  TorrentBackend createTorrentBackend(QbConnectionConfig config) =>
+      _torrentBackendFor(config);
+
   /// 后端选择：配置选内置且宿主可用 → 内置引擎的共享 session 视图；否则
   /// 外接 qBittorrent（默认 / 内置不可用时的回退）。
   TorrentBackend _torrentBackendFor(QbConnectionConfig config) {

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -2793,7 +2793,9 @@ class AppModel with ChangeNotifier {
   /// 外接 qBittorrent（默认 / 内置不可用时的回退）。
   TorrentBackend _torrentBackendFor(QbConnectionConfig config) {
     final EmbeddedTorrentHost? host = _embeddedTorrentHost;
-    if (config.backend == QbConnectionConfig.backendEmbedded && host != null) {
+    final String backend =
+        config.resolveBackend(isDesktop: _supportsEmbeddedTorrent());
+    if (backend == QbConnectionConfig.backendEmbedded && host != null) {
       return host.backendView();
     }
     return QbTorrentBackend(QBittorrentClient(

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -10,8 +10,6 @@ import 'package:hibiki/src/media/torrent/anime_download_config.dart';
 import 'package:hibiki/src/media/torrent/anime_download_matching.dart';
 import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
 import 'package:hibiki/src/media/torrent/nyaa_client.dart';
-import 'package:hibiki/src/media/torrent/qb_torrent_backend.dart';
-import 'package:hibiki/src/media/torrent/qbittorrent_client.dart';
 import 'package:hibiki/src/media/torrent/torrent_backend.dart';
 import 'package:hibiki/src/media/video/anilist_client.dart';
 import 'package:hibiki/src/media/video/jimaku_client.dart';
@@ -84,11 +82,23 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
     super.dispose();
   }
 
-  /// qBittorrent 是否未配置（推送按钮禁用；浏览选种不禁）。
-  bool get _qbMissing {
-    final QbConnectionConfig? config = ref.read(appProvider).qbConnectionConfig;
-    return config == null || !config.isConfigured;
+  /// 下载后端是否就绪（推送按钮禁用条件；浏览选种不禁）。默认（auto）在桌面
+  /// 走内置引擎、开箱即用；只有显式外接 qb 且没填地址才算未就绪。
+  bool get _backendReady {
+    final AppModel appModel = ref.read(appProvider);
+    final QbConnectionConfig config =
+        appModel.qbConnectionConfig ?? const QbConnectionConfig();
+    // 内置引擎宿主就绪（桌面 + DLL）且未显式选外接 qb → 直接可下载。
+    if (appModel.isEmbeddedTorrentReady &&
+        config.backend != QbConnectionConfig.backendQbittorrent) {
+      return true;
+    }
+    // 否则走外接 qb，需要填了地址。
+    return config.baseUrl.trim().isNotEmpty;
   }
+
+  /// 后端未就绪（推送禁用 + 提示横幅）。
+  bool get _qbMissing => !_backendReady;
 
   void _snack(String message) {
     if (!mounted) return;
@@ -240,10 +250,12 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
   /// 推送下载：暂存字幕 → 落计划 → 推 qBittorrent（失败回滚计划）→ 催一轮 tick。
   Future<void> _push() async {
     final AppModel appModel = ref.read(appProvider);
-    final QbConnectionConfig? config = appModel.qbConnectionConfig;
+    // null（全新用户没进过设置）→ 默认配置（auto：桌面内置引擎，开箱即用）。
+    final QbConnectionConfig config =
+        appModel.qbConnectionConfig ?? const QbConnectionConfig();
     final NyaaTorrent? torrent = _selectedTorrent;
     final AniListMedia? media = _selectedMedia;
-    if (config == null || !config.isConfigured) return;
+    if (!_backendReady) return;
     if (torrent == null || media == null || _pushing) return;
     final AnimeDownloadPlanStore? store = appModel.animeDownloadPlanStore;
     if (store == null) {
@@ -301,12 +313,10 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
     );
     await store.save(plan);
 
-    // ③ 推种子后端（顺序下载 + 首尾块优先，支持边下边播）。
-    final TorrentBackend backend = QbTorrentBackend(QBittorrentClient(
-      baseUrl: config.baseUrl,
-      username: config.username,
-      password: config.password,
-    ));
+    // ③ 推种子后端（顺序下载 + 首尾块优先，支持边下边播）。按配置解析后端
+    // （默认桌面走内置 libtorrent 引擎；显式外接才走 qb）——与轮询服务同一
+    // 选择逻辑，不再硬编码 qb。
+    final TorrentBackend backend = appModel.createTorrentBackend(config);
     bool pushed = false;
     try {
       await backend.prepareCategory(config.category);

--- a/hibiki/lib/src/settings/settings_schema_video.dart
+++ b/hibiki/lib/src/settings/settings_schema_video.dart
@@ -760,8 +760,9 @@ SettingsDestination buildVideoDestination() {
               ),
             ],
             selected: (SettingsContext settingsContext) =>
-                settingsContext.appModel.qbConnectionConfig?.backend ??
-                QbConnectionConfig.backendQbittorrent,
+                (settingsContext.appModel.qbConnectionConfig ??
+                        const QbConnectionConfig())
+                    .resolveBackend(isDesktop: isDesktopPlatform),
             onChanged: (SettingsContext settingsContext, String backend) async {
               await _commitQbConfig(
                 settingsContext,
@@ -816,17 +817,18 @@ SettingsDestination buildVideoDestination() {
 /// 当前是否选外接 qBittorrent 后端（决定 qb 连接字段是否显示）。历史配置
 /// 无 backend 字段回退 qb（既有用户看得见连接字段，行为不变）。
 bool _qbBackendSelected(SettingsContext settingsContext) {
-  final QbConnectionConfig? config =
-      settingsContext.appModel.qbConnectionConfig;
-  return (config?.backend ?? QbConnectionConfig.backendQbittorrent) ==
+  return (settingsContext.appModel.qbConnectionConfig ??
+              const QbConnectionConfig())
+          .resolveBackend(isDesktop: isDesktopPlatform) ==
       QbConnectionConfig.backendQbittorrent;
 }
 
 /// 当前是否选内置 libtorrent 引擎后端（决定内置引擎资源限制字段是否显示）。
 bool _embeddedBackendSelected(SettingsContext settingsContext) {
-  final QbConnectionConfig? config =
-      settingsContext.appModel.qbConnectionConfig;
-  return config?.backend == QbConnectionConfig.backendEmbedded;
+  return (settingsContext.appModel.qbConnectionConfig ??
+              const QbConnectionConfig())
+          .resolveBackend(isDesktop: isDesktopPlatform) ==
+      QbConnectionConfig.backendEmbedded;
 }
 
 /// 把限制字段的文本输入解析为非负整数（空/非数/负数 → 0 = 不限）。

--- a/hibiki/test/media/torrent/anime_download_config_backend_test.dart
+++ b/hibiki/test/media/torrent/anime_download_config_backend_test.dart
@@ -4,9 +4,32 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/torrent/anime_download_config.dart';
 
 void main() {
-  test('backend defaults to qbittorrent', () {
+  test('backend defaults to auto (resolves per platform)', () {
     const QbConnectionConfig config = QbConnectionConfig();
-    expect(config.backend, QbConnectionConfig.backendQbittorrent);
+    expect(config.backend, QbConnectionConfig.backendAuto);
+    // 桌面 → 内置引擎（开箱即用）；移动端 → 外接 qb。
+    expect(config.resolveBackend(isDesktop: true),
+        QbConnectionConfig.backendEmbedded);
+    expect(config.resolveBackend(isDesktop: false),
+        QbConnectionConfig.backendQbittorrent);
+  });
+
+  test('explicit backends resolve to themselves regardless of platform', () {
+    const QbConnectionConfig emb =
+        QbConnectionConfig(backend: QbConnectionConfig.backendEmbedded);
+    expect(emb.resolveBackend(isDesktop: false),
+        QbConnectionConfig.backendEmbedded);
+    const QbConnectionConfig qb =
+        QbConnectionConfig(backend: QbConnectionConfig.backendQbittorrent);
+    expect(qb.resolveBackend(isDesktop: true),
+        QbConnectionConfig.backendQbittorrent);
+  });
+
+  test('auto round-trips through encode/decode', () {
+    const QbConnectionConfig original = QbConnectionConfig();
+    final QbConnectionConfig decoded =
+        decodeQbConnectionConfig(encodeQbConnectionConfig(original))!;
+    expect(decoded.backend, QbConnectionConfig.backendAuto);
   });
 
   test('legacy JSON without backend field decodes as qbittorrent', () {
@@ -36,16 +59,26 @@ void main() {
     expect(config!.backend, QbConnectionConfig.backendQbittorrent);
   });
 
-  test('isConfigured: embedded needs no url, qb needs a url', () {
-    // 内置引擎无连接参数：恒已配置。
+  test('legacy no backend + no url decodes as auto (new user default)', () {
+    // 全新用户：没配过任何东西 → auto（桌面开箱即用内置引擎）。
+    final QbConnectionConfig decoded = decodeQbConnectionConfig('{}')!;
+    expect(decoded.backend, QbConnectionConfig.backendAuto);
+  });
+
+  test('isConfigured: embedded/auto need no url, explicit qb needs a url', () {
+    // 内置引擎/自动无连接参数：恒已配置（开箱即用）。
     const QbConnectionConfig embedded =
         QbConnectionConfig(backend: QbConnectionConfig.backendEmbedded);
     expect(embedded.isConfigured, isTrue);
-    // 外接 qb：URL 空 = 未配置。
-    const QbConnectionConfig qbEmpty = QbConnectionConfig();
+    const QbConnectionConfig auto = QbConnectionConfig();
+    expect(auto.isConfigured, isTrue);
+    // 显式外接 qb：URL 空 = 未配置。
+    const QbConnectionConfig qbEmpty =
+        QbConnectionConfig(backend: QbConnectionConfig.backendQbittorrent);
     expect(qbEmpty.isConfigured, isFalse);
-    const QbConnectionConfig qbSet =
-        QbConnectionConfig(baseUrl: 'http://127.0.0.1:8080');
+    const QbConnectionConfig qbSet = QbConnectionConfig(
+        backend: QbConnectionConfig.backendQbittorrent,
+        baseUrl: 'http://127.0.0.1:8080');
     expect(qbSet.isConfigured, isTrue);
   });
 

--- a/hibiki/test/media/video/anilist_client_test.dart
+++ b/hibiki/test/media/video/anilist_client_test.dart
@@ -1,0 +1,34 @@
+// AniList 搜索关键词 macron 归一化（BUG：带官方 romaji 长音的番剧名搜不到）。
+//
+// 根因（curl 实证）：AniList search 索引用双元音拼法（Chuunibyou），对 macron
+// 长音（Chūnibyō）不做归一化匹配 → 用户打/复制带 macron 的官方 romaji 得 0
+// 结果。normalizeAniListSearch 把 macron 展开成双元音（Chūnibyō→Chuunibyou）让其命中。
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/anilist_client.dart';
+
+void main() {
+  group('normalizeAniListSearch', () {
+    test('strips macron vowels to their base latin letters', () {
+      // 用户复制的官方 romaji（带 macron）→ AniList 认得的拼法基础。
+      expect(normalizeAniListSearch('Chūnibyō Demo Koi ga Shitai!'),
+          'Chuunibyou Demo Koi ga Shitai!');
+      expect(normalizeAniListSearch('Tōkyō Gūru'), 'Toukyou Guuru');
+      expect(normalizeAniListSearch('Frieren'), 'Frieren'); // no-op
+    });
+
+    test('handles all five long vowels, both cases', () {
+      expect(normalizeAniListSearch('ĀāĒēĪīŌōŪū'), 'AaaaEeeeIiiiOuouUuuu');
+    });
+
+    test('drops combining macron (NFD decomposed form, U+0304)', () {
+      // 分解形式：字母 + U+0304（combining macron）→ 基础字母（丢弃 macron）。
+      expect(normalizeAniListSearch('Chūnibyō'), 'Chuunibyoo');
+    });
+
+    test('empty / plain queries are unchanged', () {
+      expect(normalizeAniListSearch(''), '');
+      expect(normalizeAniListSearch('bocchi the rock'), 'bocchi the rock');
+    });
+  });
+}

--- a/hibiki/test/torrent/anime_download_plan_test.dart
+++ b/hibiki/test/torrent/anime_download_plan_test.dart
@@ -69,11 +69,17 @@ void main() {
       expect(decoded2!.category, 'hibiki');
     });
 
-    test('默认构造未配置；copyWith 逐字段', () {
+    test('默认构造=auto(开箱即用/已配置)；显式 qb 空=未配置；copyWith 逐字段', () {
+      // 默认 auto：桌面内置引擎，无需连接参数 → 已配置。
       const QbConnectionConfig config = QbConnectionConfig();
-      expect(config.isConfigured, isFalse);
+      expect(config.backend, QbConnectionConfig.backendAuto);
+      expect(config.isConfigured, isTrue);
       expect(config.category, 'hibiki');
-      final QbConnectionConfig edited = config.copyWith(baseUrl: 'http://x');
+      // 显式外接 qb 但没填地址 → 未配置。
+      const QbConnectionConfig qbEmpty =
+          QbConnectionConfig(backend: QbConnectionConfig.backendQbittorrent);
+      expect(qbEmpty.isConfigured, isFalse);
+      final QbConnectionConfig edited = qbEmpty.copyWith(baseUrl: 'http://x');
       expect(edited.isConfigured, isTrue);
       expect(edited.category, 'hibiki');
       expect(edited.username, '');

--- a/hibiki/test/torrent/anime_download_service_test.dart
+++ b/hibiki/test/torrent/anime_download_service_test.dart
@@ -284,10 +284,15 @@ void main() {
       } catch (_) {}
     });
 
-    test('未配置（null 或空 baseUrl）不动作', () async {
+    test('未配置（null 或显式 qb 空 baseUrl）不动作', () async {
+      // 注：默认 auto 在桌面 = 内置引擎 = 已配置（开箱即用）；"未配置"现指
+      // null 或显式选了外接 qb 但没填地址。
       await store.save(_plan());
       await buildService(config: () => null).tick();
-      await buildService(config: () => const QbConnectionConfig()).tick();
+      await buildService(
+              config: () => const QbConnectionConfig(
+                  backend: QbConnectionConfig.backendQbittorrent))
+          .tick();
       expect(qb.factoryCalls, 0);
       expect(importCalls, isEmpty);
     });


### PR DESCRIPTION
## 用户反馈
「番剧下载搜索全是无结果」——本机搜 `Chūnibyō Demo Koi ga Shitai!`(中二病也想谈恋爱,官方 romaji)零结果。

## 根因(curl + live AniListClient 实证,非猜)
番剧官方 romaji 常用 **macron 长音符**转写(Wikipedia/官方,如 `Chūnibyō`),用户会直接打或复制。但 AniList 的 GraphQL `search` 索引用**修正 Hepburn 双元音拼法**(`Chuunibyou`)且**不对 macron 做归一化匹配**:
| 查询 | 结果 |
|---|---|
| `Chūnibyō Demo Koi ga Shitai!`(带 ū ō) | **0** |
| `Chunibyo Demo…`(简单去 macron,单元音) | **仍 0**(太短) |
| `Chuunibyou Demo…`(双元音) | **命中 3** |

原 `searchAnime` 把带 macron 的原串直接发出去 → 0 → `catch(_)→空列表` → UI 显示无结果。**不是网络、不是中文、不是 UA**(这些我都逐一排除了:本机 curl 直连 AniList 200,中文「孤独摇滚」能搜到,各种 UA 都 200)。

## 修复
搜索前 `normalizeAniListSearch(query)` 把 macron 按修正 Hepburn 展开成**双元音**(ā→aa ī→ii ū→uu ē→ee ō→ou;combining U+0304 双写前一元音)。纯函数,无 macron 输入 no-op,不降低正常命中。

## 验证
- **真实 `AniListClient.searchAnime('Chūnibyō Demo Koi ga Shitai!')` 修复后返回 10 结果**(`Chuunibyou demo Koi ga Shitai!` 等),修复前 0。
- 单测 4/4(预组合/combining U+0304/大小写/no-op)。

## 范围外(本 PR 不含,已在 BUG-895 备注)
`searchAnime` 的 `catch(_)→空列表` 把网络失败与真无结果混淆(用户网络访问不了 AniList 时也只看到'无结果')——建议后续区分错误态给不同提示。

BUG-895。