### PR TITLE
fix(video): BUG-910 续 字幕列表兜底也用 exactOnly(点右侧列表面板重查)

### DIFF
--- a/docs/bugs/BUG-910-video-subtitle-dismiss-halo-reloop.md
+++ b/docs/bugs/BUG-910-video-subtitle-dismiss-halo-reloop.md
@@ -12,7 +12,7 @@
   - `_onDismissBarrierTap` 改 `_subtitleHitTester.hitTest(globalPos, exactOnly: true)`：点字幕行周围空白 halo → 命中为空 → 落到 `_popNestedPopupAt(0)` 关整栈 + 恢复播放（`shouldResumeAfterLookupDismiss`）；点在字形上仍切词（TODO-758 不回归）；嵌套门控 `shouldSwitchWordOnBarrierTap`（BUG-410）不动；查词胖手指容差（TODO-971）不动。恢复了 BUG-410 备注承诺的「落纯空白正常」。
   - hover 换词（`_onDismissBarrierHover`）、Shift 查词（`_triggerShiftLookupAtLastPointer`）仍走宽容差（查词意图）。
   - **补（用户复诉「半个屏幕远也重查」）**：截图证据——第二次查到的是 **市川(いちかわ)**，画面字幕里根本没有，只在**右侧字幕列表面板**里。`_onDismissBarrierTap` 在底部字幕 miss 后**兜底反查字幕列表** `_subtitleListHitTester`（BUG-874），用的也是宽容差（`subtitleListCharHitFromParagraph` 的半字格裙边）。列表面板占右半屏 = 「半个屏幕远」。点列表想关闭 → 被兜底吃成「切列表里的词」反复重查。故给 `subtitleListCharHitFromParagraph` / `_hitTestRows` / `VideoSubtitleListHitTester.hitTest` 同加 `exactOnly`，barrier 列表兜底也用 `exactOnly: true`——点列表**字形盒外**的行距/边距空白落回 dismiss。
-  - ⚠️ **残留（待用户定夺）**：列表面板行文本满宽、字挨字，「点在字上」几乎处处是字。按用户规则「点在字上换词」，点列表行的**真实文字**仍会切到那个列表词；只有点行距/边距空白才关闭。若用户要「查词浮层开着时点列表面板一律关闭、绝不切词」（更彻底但**回退 BUG-874 的列表单击换词**），需再移除 barrier 的列表兜底。
+  - **用户已确认（2026-07-19）**：规则统一为「点在字上换词、点空白关闭」，画面字幕与列表面板同款。列表面板行文本满宽、字挨字，故点列表行的**真实文字**仍切到那个列表词（用户明确接受，且**保留 BUG-874 的列表单击换词**），只有点行距/边距/字形盒外空白才关闭。即当前 exactOnly 实现，无需再移除列表兜底。
   - 提交哈希：（见分支 `worktree-bug-video-subtitle-dismiss-halo` / 本 PR）。
 - **[x] ② 已加自动化测试** — 纯函数行为测试，扩展 `hibiki/test/media/video/subtitle_char_hit_tolerance_test.dart`：
   - `group('BUG-910：exactOnly ...')`：点落字形内 exactOnly 仍命中（切词保留）；字缝 / 描边 halo / 字幕行水平右缘 12px 空白在**默认宽容差命中、exactOnly 下必 -1**（对照断言两路，撤 `exactOnly` 分支即转红）。

--- a/docs/bugs/BUG-910-video-subtitle-dismiss-halo-reloop.md
+++ b/docs/bugs/BUG-910-video-subtitle-dismiss-halo-reloop.md
@@ -10,7 +10,9 @@
   - `resolveSubtitleCharHit`（`video_subtitle_overlay.dart`）加 `bool exactOnly=false`：为 true 时只跑第一段精确 `Rect.contains`、**跳过**第二段裙边兜底容差，字形外一律返回 -1。默认 false，查词/悬停命中语义完全不变。
   - `VideoSubtitleHitTester.hitTest` / 绑定实现 `_charHitTest` / `_hitEntryIndexAt` 透传 `exactOnly`。
   - `_onDismissBarrierTap` 改 `_subtitleHitTester.hitTest(globalPos, exactOnly: true)`：点字幕行周围空白 halo → 命中为空 → 落到 `_popNestedPopupAt(0)` 关整栈 + 恢复播放（`shouldResumeAfterLookupDismiss`）；点在字形上仍切词（TODO-758 不回归）；嵌套门控 `shouldSwitchWordOnBarrierTap`（BUG-410）不动；查词胖手指容差（TODO-971）不动。恢复了 BUG-410 备注承诺的「落纯空白正常」。
-  - 仅动 barrier **tap** 一处；hover 换词（`_onDismissBarrierHover:3327`）、Shift 查词（`_triggerShiftLookupAtLastPointer:1243`）仍走宽容差。字幕列表侧栏兜底（`_subtitleListHitTester`）不在本 bug 路径，未改。
+  - hover 换词（`_onDismissBarrierHover`）、Shift 查词（`_triggerShiftLookupAtLastPointer`）仍走宽容差（查词意图）。
+  - **补（用户复诉「半个屏幕远也重查」）**：截图证据——第二次查到的是 **市川(いちかわ)**，画面字幕里根本没有，只在**右侧字幕列表面板**里。`_onDismissBarrierTap` 在底部字幕 miss 后**兜底反查字幕列表** `_subtitleListHitTester`（BUG-874），用的也是宽容差（`subtitleListCharHitFromParagraph` 的半字格裙边）。列表面板占右半屏 = 「半个屏幕远」。点列表想关闭 → 被兜底吃成「切列表里的词」反复重查。故给 `subtitleListCharHitFromParagraph` / `_hitTestRows` / `VideoSubtitleListHitTester.hitTest` 同加 `exactOnly`，barrier 列表兜底也用 `exactOnly: true`——点列表**字形盒外**的行距/边距空白落回 dismiss。
+  - ⚠️ **残留（待用户定夺）**：列表面板行文本满宽、字挨字，「点在字上」几乎处处是字。按用户规则「点在字上换词」，点列表行的**真实文字**仍会切到那个列表词；只有点行距/边距空白才关闭。若用户要「查词浮层开着时点列表面板一律关闭、绝不切词」（更彻底但**回退 BUG-874 的列表单击换词**），需再移除 barrier 的列表兜底。
   - 提交哈希：（见分支 `worktree-bug-video-subtitle-dismiss-halo` / 本 PR）。
 - **[x] ② 已加自动化测试** — 纯函数行为测试，扩展 `hibiki/test/media/video/subtitle_char_hit_tolerance_test.dart`：
   - `group('BUG-910：exactOnly ...')`：点落字形内 exactOnly 仍命中（切词保留）；字缝 / 描边 halo / 字幕行水平右缘 12px 空白在**默认宽容差命中、exactOnly 下必 -1**（对照断言两路，撤 `exactOnly` 分支即转红）。

--- a/hibiki/lib/src/media/video/video_subtitle_jump_panel.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_jump_panel.dart
@@ -68,17 +68,24 @@ typedef SubtitleListHit = ({AudioCue cue, int graphemeIndex, Rect charRect});
 /// 点击 → 点列表里下一个词只会关浮层、查不了下一个词。让 barrier 先用本句柄反查是否点到了
 /// 列表字符，是则切换查词（保持暂停 + `replaceStack`），否则才 dismiss。
 class VideoSubtitleListHitTester {
-  SubtitleListHit? Function(Offset globalPos)? _impl;
+  SubtitleListHit? Function(Offset globalPos, {bool exactOnly})? _impl;
 
   /// [VideoSubtitleJumpPanel] build 时绑定当前可见行的命中实现。
-  void bindHitTest(SubtitleListHit? Function(Offset globalPos) impl) =>
+  void bindHitTest(
+          SubtitleListHit? Function(Offset globalPos, {bool exactOnly}) impl) =>
       _impl = impl;
 
   /// 面板卸载（侧栏隐藏）时解绑，避免 barrier 调到已失效的实现。
   void unbind() => _impl = null;
 
   /// 无绑定（无查词能力 / 面板已卸载）时返回 null，barrier 落回原 dismiss。
-  SubtitleListHit? hitTest(Offset globalPos) => _impl?.call(globalPos);
+  ///
+  /// [exactOnly]（BUG-910）：为 true 时只在点**落在字形选区盒内**才命中，跳过半字格裙边
+  /// 容差——查词浮层 dismiss barrier 用它区分「点列表空白想关闭」与「点列表字上想切词」。
+  /// 列表面板占右半屏、行文本满宽，若 barrier 判定吃裙边容差，点面板行距 / 行尾空白想关闭
+  /// 浮层会被误判成切词重查（用户报「点半个屏幕外一直重复查词」）。悬停查词仍用宽容差。
+  SubtitleListHit? hitTest(Offset globalPos, {bool exactOnly = false}) =>
+      _impl?.call(globalPos, exactOnly: exactOnly);
 }
 
 /// 字幕文本每个 grapheme 的 UTF-16 起始偏移（按 [String.characters] 顺序）。列表行内 tap 的
@@ -143,6 +150,9 @@ SubtitleListCharHit? subtitleListCharHitFromParagraph(
   String text, {
   required Offset localPosition,
   required Offset globalPosition,
+  // BUG-910：为 true 时只在点落在字形选区盒内才命中，跳过半字格裙边容差（barrier 关闭
+  // 判定用）——点列表行距 / 行尾空白想关闭浮层不被误判成切词。查词/悬停默认 false。
+  bool exactOnly = false,
 }) {
   final List<int> starts = subtitleGraphemeStartOffsets(text);
   if (starts.isEmpty) return null;
@@ -163,6 +173,9 @@ SubtitleListCharHit? subtitleListCharHitFromParagraph(
   );
   if (localRect.isEmpty) return null;
   if (!localRect.contains(localPosition)) {
+    // BUG-910：exactOnly（barrier 关闭判定）不吃裙边——点在字形盒外一律 miss → barrier
+    // 落回 dismiss，不把「点面板空白想关闭」误判成切词重查。
+    if (exactOnly) return null;
     // BUG-879：容差从 1px 放宽到半个字格（≈ 行高一半，CJK 方块字 ≈ 半字宽），与画面字幕
     // resolveSubtitleCharHit 的半字宽字缝兜底同量级——点在字缝 / 行距上仍命中最近字符。
     final double tol = localRect.height * 0.5;
@@ -518,7 +531,7 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
   /// 供 [VideoSubtitleListHitTester] 绑定给查词浮层 dismiss barrier。无查词能力 / 无命中
   /// 返回 null（barrier 落回原 dismiss）。遍历 [_rowTextKeys]：滚出屏的行 `currentContext`
   /// 为 null 自动跳过；先粗判点落在哪行的段落框内，再逐字符精查。
-  SubtitleListHit? _hitTestRows(Offset globalPos) {
+  SubtitleListHit? _hitTestRows(Offset globalPos, {bool exactOnly = false}) {
     if (widget.onLookupCue == null || _rowHitCues.isEmpty) return null;
     for (final MapEntry<int, GlobalKey> entry in _rowTextKeys.entries) {
       final AudioCue? cue = _rowHitCues[entry.key];
@@ -532,6 +545,7 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
         cue.text,
         localPosition: local,
         globalPosition: globalPos,
+        exactOnly: exactOnly,
       );
       if (hit == null) continue;
       return (

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -3425,7 +3425,13 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     // （[_handleSubtitleListLookup] → [_lookupAt] 的 `replaceStack`，保持浮层与暂停）。这是
     // 列表行文本明确点在某字符上的显式换词意图，不吃底部字幕那条的嵌套门控
     // （[shouldSwitchWordOnBarrierTap]）——replaceStack 本就重置整栈，等价于一次新查词。
-    final SubtitleListHit? listHit = _subtitleListHitTester.hitTest(globalPos);
+    //
+    // BUG-910：反查同样用 `exactOnly: true`——列表面板占右半屏、行文本满宽，若吃半字格裙边
+    // 容差，点面板行距 / 行尾空白想关闭浮层会被误判成「切列表里的词」反复重查（用户报「点半
+    // 个屏幕外的空白一直重复查一个词」；截图里查到的词根本不在画面字幕里、只在列表面板里）。
+    // exactOnly 只在点**落在列表字形盒内**才切词，点面板空白落回下方 dismiss+续播。
+    final SubtitleListHit? listHit =
+        _subtitleListHitTester.hitTest(globalPos, exactOnly: true);
     if (listHit != null) {
       _handleSubtitleListLookup(
         listHit.cue,

--- a/hibiki/test/media/video/video_subtitle_jump_panel_hit_tester_test.dart
+++ b/hibiki/test/media/video/video_subtitle_jump_panel_hit_tester_test.dart
@@ -224,6 +224,63 @@ void main() {
           reason: 'lookup disabled → no reverse-hit registration');
     });
 
+    testWidgets(
+        'BUG-910 exactOnly: on-glyph tap still switches; skirt blank dismisses',
+        (WidgetTester tester) async {
+      final VideoPlayerController controller = VideoPlayerController();
+      addTearDown(controller.dispose);
+      controller.setCues(<AudioCue>[
+        _cue(0, 0, 1000, 'first line'),
+        _cue(1, 2000, 3000, 'second line'),
+      ]);
+      final VideoSubtitleListHitTester hitTester = VideoSubtitleListHitTester();
+
+      await tester.pumpWidget(_wrap(SizedBox(
+        width: 420,
+        height: 500,
+        child: VideoSubtitleJumpPanel(
+          controller: controller,
+          onTapCue: (_) {},
+          onLookupCue: (AudioCue _, int __, Rect ___) {},
+          hitTester: hitTester,
+          onClose: () {},
+          onCopyCue: (_) {},
+          onFavoriteCue: (_) async {},
+          isCueFavorited: (_) => false,
+          colorScheme: const ColorScheme.dark(),
+          title: 'Subtitle list',
+          emptyHint: 'empty',
+          width: 420,
+        ),
+      )));
+      await tester.pump();
+
+      final ({Offset globalPoint, int graphemeIndex}) target =
+          _pointForGrapheme(tester, 'second line', 'c');
+
+      // 点在字形正中：exactOnly 也命中 → barrier 切词（用户要的「点在字上换词」保留）。
+      final SubtitleListHit? onGlyph =
+          hitTester.hitTest(target.globalPoint, exactOnly: true);
+      expect(onGlyph, isNotNull, reason: 'exactOnly：点列表字形正中仍命中→切词');
+      expect(onGlyph!.graphemeIndex, target.graphemeIndex);
+
+      // 行首字符左外侧的空白（在默认半字格容差内、在字形盒外的左边距，中间不夹相邻字）：
+      // 默认宽容差会兜底命中最近字符（旧行为，点这里被误判成切词）；exactOnly 必须 miss →
+      // barrier 落回 dismiss（用户要的「点空白关闭」）。
+      final SubtitleListHit? headHit = hitTester
+          .hitTest(_pointForGrapheme(tester, 'second line', 's').globalPoint);
+      expect(headHit, isNotNull);
+      final Rect head = headHit!.charRect;
+      final Offset leftSkirt = head.centerLeft - Offset(head.height * 0.4, 0);
+      final SubtitleListHit? generous = hitTester.hitTest(leftSkirt);
+      // 仅当该布局下左边距确被默认容差兜底命中，才断言 exactOnly 反差（不同 Text 布局下
+      // 左边距可能落在行框外→默认也 miss，此时两者都 null 亦是「点空白关闭」正确行为）。
+      if (generous != null) {
+        expect(hitTester.hitTest(leftSkirt, exactOnly: true), isNull,
+            reason: 'BUG-910：行首左侧空白 exactOnly 必 miss → barrier 关闭浮层续播');
+      }
+    });
+
     testWidgets('unbinds on panel dispose (hidden sidebar)',
         (WidgetTester tester) async {
       final VideoPlayerController controller = VideoPlayerController();


### PR DESCRIPTION
接续已合并的 PR#242(画面字幕 exactOnly)。用户复诉「点半个屏幕外也重复查同一个词」。

## 复诉根因(截图证据)
第二张截图查到的是 **市川(いちかわ)**——画面底部字幕里根本没有这个词,只在**右侧字幕列表面板**里。`_onDismissBarrierTap` 在底部字幕 miss 后会**兜底反查字幕列表**(`_subtitleListHitTester`,BUG-874),用的也是宽容差(`subtitleListCharHitFromParagraph` 的半字格裙边)。列表面板占**右半屏** = 用户说的「半个屏幕远」。点列表想关闭浮层 → 被兜底吃成「切换到列表里那个词」→ 反复重查。

## 修复
给 `subtitleListCharHitFromParagraph` / `_hitTestRows` / `VideoSubtitleListHitTester.hitTest` 同加 `exactOnly`,barrier 列表兜底用 `exactOnly: true`——点列表**字形盒外**的行距/边距空白落回 dismiss+续播。查词/悬停仍用宽容差。

## ⚠️ 残留(待用户定夺,见下)
列表面板行文本满宽、字挨字,「点在字上」几乎处处是字。按用户规则「点在字上换词」,点列表行的**真实文字**仍会切到那个列表词;只有点行距/边距空白才关闭。若用户要「查词浮层开着时点列表面板一律关闭、绝不切词」(更彻底但**回退 BUG-874 的列表单击换词**),需再移除 barrier 的列表兜底——等用户拍板。

## 测试
- `video_subtitle_jump_panel_hit_tester_test.dart` 加 exactOnly 用例(点字形内仍命中→切词;行首左侧空白默认命中而 exactOnly miss→关闭)。
- `test/media/video/` 全绿(1601 pass/2 skip);analyze 0 issue。

🔴 待真机 + 待用户定夺列表面板行为。