### PR TITLE
feat(anki): 制卡追加所属合集/系列名标签 (BUG-919)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 894 条。点号进各自文件。
+> 共 895 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-919](bugs/BUG-919-mining-collection-tag.md) | ✅ | ✅ | 制卡缺少所属合集名标签 |
 | [BUG-917](bugs/BUG-917-video-clip-mp4-muxer.md) | ✅ | ✅ | 视频片段导出 exit -22（捆绑 ffmpeg-min 无 matroska muxer，输出跟随源容器） |
 | [BUG-916](bugs/BUG-916-subtitle-list-shift-hover-offset.md) | ✅ | ✅ | 视频字幕列表Shift悬停查词偏左一格 |
 | [BUG-915](bugs/BUG-915-ass-user-scale-and-plain-off-mode.md) | ✅ | ✅ | 尊重字幕不能调字号；关闭尊重时 ASS 特效层叠印乱字 |

--- a/docs/bugs/BUG-919-mining-collection-tag.md
+++ b/docs/bugs/BUG-919-mining-collection-tag.md
@@ -1,0 +1,17 @@
+## BUG-919 · 制卡缺少所属合集名标签
+- **报告**：2026-07-19（用户：）
+- **真实性**：✅ 真 bug（功能缺口，非回归）。制卡的标签一直只有「用户自定义 + hibiki + 分类(video/book) + 单集/单本标题」四类，**从未把条目所属合集/系列名加进 tag**。
+  - 标签组装：`packages/hibiki_anki/lib/src/base_anki_repository.dart:246`（`buildNoteTags`，只接 `titleTag`，无合集概念）。
+  - 视频入口：`hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart:315` 只用单集名 `_title`；合集/系列名 `_playlistTitle` 已在内存（`video_hibiki_page.dart:872/1694`）却只喂给 `documentTitle`，未进 tag。
+  - 阅读器入口：`hibiki/lib/src/pages/implementations/reader_hibiki/mining.part.dart:170` 只用单本书名 `_book?.title`，reader 未反查所属合集。
+  - 对比 `origin/develop`：这几行未被改动，全仓库 `seriesTag`/`collectionTag` 零命中 → 确认从未实现，不是被删。
+- **[x] ① 已修复** — 新增贯穿 mining 链路的 `collectionTag`（与 `bookTitleTag` 并列、同「自动添加书名到标签」开关、经 `sanitizeTitleTag` 清洗、`buildNoteTags` 去重）。
+  - 模型/组装：`packages/hibiki_anki/lib/src/anki_models.dart`（`AnkiMiningContext.collectionTag`）、`base_anki_repository.dart`（`buildNoteTags` 加 `collectionTag` 参数并追加，去重合并）。
+  - 三 backend 透传：`ankidroid/anki_repository.dart` / `ankiconnect/ankiconnect_repository.dart` / `hibiki/lib/src/anki/ankimobile_repository.dart`（含其 context 重建）。
+  - 链路透传：`hibiki/lib/src/mining/immersion_mining_request.dart`（新字段）、`immersion_mining_engine.dart`（注入 context）。
+  - 视频注入：`lookup_mining.part.dart` 用 `_playlistTitle`（系列名）。
+  - 阅读器注入：`reader_hibiki/mining.part.dart` 新增 `_resolveCollectionName()`——按 `getPrimaryCollectionIdByEntry()` 折叠归属反查（EPUB/EPUB-有声书用 `epub|<bookKey>`，纯 SRT 有声书用 `srt|<uid>`，srt-backed 两身份都试兜 BUG-812），一处覆盖书+有声书。
+  - 行为：合集名与单集/单本名**并列各成一个 tag**（用户选定方案）；不属合集/开关关闭时为 null 不追加（Never break userspace）。
+  - 提交：（见本分支提交哈希）
+- **[x] ② 已加自动化测试** — `packages/hibiki_anki/test/mining_tag_and_parallel_test.dart` 新增 `collectionTag ...` 测试组 6 例：合集名追加于书名后、单独存在、与书名/分类/用户 tag 去重、空值不加、空格清洗成单 tag。撤掉 `buildNoteTags` 的 `collectionTag` 追加即转红。全量 28 例通过。
+- **备注**：合集名标签复用现有「自动添加书名到标签」（`autoAddBookNameToTags`）开关，不新增偏好项——它本就是「标题类标签」总开关。视频侧 `_playlistTitle` 只在播放列表下非空，单视频/远端无系列名 → null。撞号说明：`bug.dart` 初取 918 与本会话 PR#253 冲突，已改为 919。

--- a/hibiki/lib/src/anki/ankimobile_repository.dart
+++ b/hibiki/lib/src/anki/ankimobile_repository.dart
@@ -302,6 +302,7 @@ class AnkiMobileRepository extends BaseAnkiRepository {
         includeHibiki: settings.tagIncludeHibiki,
         includeCategory: settings.tagIncludeCategory,
         titleTag: context.bookTitleTag,
+        collectionTag: context.collectionTag,
       );
       final success = Uri.parse(hibikiAnkiSuccessCallback).replace(
         queryParameters: <String, String>{
@@ -370,6 +371,7 @@ class AnkiMobileRepository extends BaseAnkiRepository {
       sentenceOffset: context.sentenceOffset,
       source: context.source,
       bookTitleTag: context.bookTitleTag,
+      collectionTag: context.collectionTag,
     );
 
     final mediaPayload = AnkiMiningPayload(

--- a/hibiki/lib/src/mining/immersion_mining_engine.dart
+++ b/hibiki/lib/src/mining/immersion_mining_engine.dart
@@ -251,6 +251,7 @@ class ImmersionMiningEngine {
       sasayakiAudioPath: audioPath,
       source: req.source,
       bookTitleTag: req.bookTitleTag,
+      collectionTag: req.collectionTag,
     );
 
     final MineOutcome outcome = req.updateNoteId == null

--- a/hibiki/lib/src/mining/immersion_mining_request.dart
+++ b/hibiki/lib/src/mining/immersion_mining_request.dart
@@ -73,6 +73,7 @@ class ImmersionMiningRequest {
     this.audioStreamCount,
     this.source = AnkiMiningSource.video,
     this.bookTitleTag,
+    this.collectionTag,
     this.updateNoteId,
     this.stillFallback,
     this.providedCoverBytes,
@@ -99,6 +100,11 @@ class ImmersionMiningRequest {
   final int? audioStreamCount;
   final AnkiMiningSource source;
   final String? bookTitleTag;
+
+  /// 合集/系列名标签（视频=播放列表系列名）：与 [bookTitleTag] 同「自动添加书名到标签」
+  /// 开关，非 null 时经 [BaseAnkiRepository.buildNoteTags] 追加为独立 tag。不属合集/单视频
+  /// 无系列名时为 null。透传进 [AnkiMiningContext.collectionTag]。
+  final String? collectionTag;
 
   /// 非 null = 覆盖现有卡（走 updateMinedNote，不计统计）。
   final int? updateNoteId;

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/mining.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/mining.part.dart
@@ -153,6 +153,12 @@ extension _ReaderMining on _ReaderHibikiPageState {
       return (context: null, cleanup: cleanupSasayakiTempDir);
     }
 
+    // 合集名标签（同「自动添加书名到标签」开关）：反查当前书/有声书所属合集名，作独立 tag。
+    // 开关关闭或不属任何合集时 null 不追加。DB 反查放此处（_prepareMiningContext 本就 async）。
+    final String? collectionTag = appModel.autoAddBookNameToTags
+        ? BaseAnkiRepository.sanitizeTitleTag(await _resolveCollectionName())
+        : null;
+
     // TODO-644 / BUG-357：用 await 前的快照值构造上下文（cue 句 / 加粗偏移），不再
     // 读 currentCueSentence / _cachedSentenceOffset 这两个会被并发查词改写的可变成员。
     final AnkiMiningContext miningContext = AnkiMiningContext(
@@ -170,9 +176,31 @@ extension _ReaderMining on _ReaderHibikiPageState {
       bookTitleTag: appModel.autoAddBookNameToTags
           ? BaseAnkiRepository.sanitizeTitleTag(_book?.title)
           : null,
+      collectionTag: collectionTag,
     );
 
     return (context: miningContext, cleanup: cleanupSasayakiTempDir);
+  }
+
+  /// 反查当前书/有声书所属合集名（供制卡「合集名标签」用）。折叠归属跟随
+  /// [HibikiDatabase.getPrimaryCollectionIdByEntry] 的「最小 collectionId」语义，与书架
+  /// 折叠归行一致。键构造（见 collection_grouping / shelf_ordering）：
+  /// - EPUB / 普通 EPUB-有声书 → `'epub|<bookKey>'`（[bookKey] 恒同步可用）。
+  /// - 纯 SRT 有声书（[_srtBookUid] 非空）→ `'srt|<uid>'`；srt-backed 有声书两身份都试
+  ///   （BUG-812：可能存成 `srt|uid`，先 epub 键 miss 再回退，与 host service 同策略）。
+  /// 不属任何合集 / 合集已删（孤儿）→ `null`，[buildNoteTags] 不追加。
+  Future<String?> _resolveCollectionName() async {
+    final HibikiDatabase db = appModel.database;
+    final Map<String, int> primaryByEntry =
+        await db.getPrimaryCollectionIdByEntry();
+    if (primaryByEntry.isEmpty) return null;
+    final String? srtUid = _srtBookUid;
+    final int? collectionId = srtUid != null
+        ? (primaryByEntry['srt|$srtUid'] ??
+            primaryByEntry['epub|${widget.bookKey}'])
+        : primaryByEntry['epub|${widget.bookKey}'];
+    if (collectionId == null) return null;
+    return (await db.getMediaCollectionById(collectionId))?.name;
   }
 
   Future<MinePopupResult> _onMineFromPopupInner(

--- a/hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart
@@ -315,6 +315,11 @@ extension _VideoLookupMining on _VideoHibikiPageState {
         bookTitleTag: appModel.autoAddBookNameToTags
             ? BaseAnkiRepository.sanitizeTitleTag(_title)
             : null,
+        // 合集/系列名标签（同上开关）：播放列表下用系列名 _playlistTitle（col.name，已在内存）
+        // 作独立 tag，与剧集名并列；单视频/远端无系列名时为 null 不追加。
+        collectionTag: appModel.autoAddBookNameToTags
+            ? BaseAnkiRepository.sanitizeTitleTag(_playlistTitle)
+            : null,
         updateNoteId: updateNoteId,
         stillFallback: controller.screenshot,
         // 用户在 Anki 设置里选的封面图片模式（GIF / 制卡时当前帧 / 字幕开头帧）；

--- a/packages/hibiki_anki/lib/src/anki_models.dart
+++ b/packages/hibiki_anki/lib/src/anki_models.dart
@@ -379,6 +379,7 @@ class AnkiMiningContext {
     this.sentenceOffset,
     this.source,
     this.bookTitleTag,
+    this.collectionTag,
   });
   final String sentence;
   final String? cueSentence;
@@ -399,6 +400,15 @@ class AnkiMiningContext {
   /// app；标题来源也按来源不同（书=书名 / 视频=番名）。故由调用方读开关 + 取标题 + 清洗后
   /// 注入，本包只负责按既有 [buildNoteTags] 去重规则追加，与 `book`/`video` 分类标签同构。
   final String? bookTitleTag;
+
+  /// 「自动添加书名到标签」开关开启且当前条目**归属某合集**时，调用方（reader / video）
+  /// 算好的**已清洗合集名标签**（空格/Tab→下划线，单个 Anki tag 字面量）；不属任何合集、
+  /// 开关关闭或无合集名时为 `null`，[BaseAnkiRepository.buildNoteTags] 不追加。
+  ///
+  /// 与 [bookTitleTag] 并列：视频从播放列表（系列）名取、reader 从书所属合集反查取，
+  /// 二者字面量不同则各成一个 tag（Anki 里可按系列聚合、也可按单集/单本区分）；相同时由
+  /// [buildNoteTags] 去重合并。见视频 `lookup_mining` / reader `mining` 注入点。
+  final String? collectionTag;
 }
 
 class AnkiHandlebarRenderer {

--- a/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -439,6 +439,8 @@ class AnkiConnectRepository extends BaseAnkiRepository {
       // TODO-681 / BUG-393：调用方按「自动添加书名到标签」开关注入已清洗书名/番名标签
       // （书籍/视频同语义）；关闭或无标题时为 null，buildNoteTags 不追加。
       titleTag: context.bookTitleTag,
+      // 合集/系列名标签（同上开关）：视频=播放列表系列名、书籍=所属合集名；不属合集时 null。
+      collectionTag: context.collectionTag,
     );
 
     // `fields` only holds entries that rendered to a non-empty value; if it is

--- a/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
@@ -232,6 +232,8 @@ class AnkiRepository extends BaseAnkiRepository {
       // TODO-681 / BUG-393：调用方按「自动添加书名到标签」开关注入已清洗书名/番名标签
       // （书籍/视频同语义）；关闭或无标题时为 null，buildNoteTags 不追加。
       titleTag: context.bookTitleTag,
+      // 合集/系列名标签（同上开关）：视频=播放列表系列名、书籍=所属合集名；不属合集时 null。
+      collectionTag: context.collectionTag,
     );
 
     try {

--- a/packages/hibiki_anki/lib/src/base_anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/base_anki_repository.dart
@@ -241,6 +241,9 @@ abstract class BaseAnkiRepository {
   /// - 两个开关默认 `true`，等价 TODO-115/062 的固定行为（Never break userspace）。
   /// - [titleTag]（TODO-681 开关，「自动添加书名到标签」）非空时追加**已清洗的书名/番名
   ///   标签**（去重后），书籍/视频同语义。
+  /// - [collectionTag]（同「自动添加书名到标签」开关）非空时追加**已清洗的合集/系列名
+  ///   标签**（去重后）：视频=播放列表系列名，书籍=所属合集名。与 [titleTag] 并列，二者
+  ///   字面量不同则各成一个 tag，相同时由 [seen] 去重合并。
   /// - 两 backend（AnkiConnect / AnkiDroid）共用同一逻辑，避免一端漏加或漂移。
   @protected
   List<String> buildNoteTags(
@@ -249,6 +252,7 @@ abstract class BaseAnkiRepository {
     bool includeHibiki = true,
     bool includeCategory = true,
     String? titleTag,
+    String? collectionTag,
   }) {
     final seen = <String>{};
     final result = <String>[];
@@ -266,6 +270,13 @@ abstract class BaseAnkiRepository {
     // 同一标题标签时不会重复追加（两处清洗规则同源故字面量相同）。
     final clean = sanitizeTitleTag(titleTag);
     if (clean != null && seen.add(clean)) result.add(clean);
+    // 合集/系列名标签（与 titleTag 同「自动添加书名到标签」开关）：视频=播放列表系列名、
+    // 书籍=所属合集名。调用方读开关 + 取合集名 + 清洗后注入；与书名标签并列，字面量相同时
+    // 由 [seen] 去重合并（如单视频合集名==剧集名时不重复追加）。
+    final cleanCollection = sanitizeTitleTag(collectionTag);
+    if (cleanCollection != null && seen.add(cleanCollection)) {
+      result.add(cleanCollection);
+    }
     return result;
   }
 

--- a/packages/hibiki_anki/test/mining_tag_and_parallel_test.dart
+++ b/packages/hibiki_anki/test/mining_tag_and_parallel_test.dart
@@ -492,6 +492,100 @@ void main() {
     });
   });
 
+  group(
+      'collectionTag appends the collection/series tag alongside the title tag, '
+      'de-duped, sanitised', () {
+    Future<List<String>> tagsForConnect(
+      String configured, {
+      AnkiMiningSource? source,
+      String? bookTitleTag,
+      String? collectionTag,
+    }) async {
+      final service = _RecordingAnkiConnectService();
+      final repo = _ConfiguredAnkiConnectRepository(
+        service: service,
+        settings: _settingsWithTags(configured),
+      );
+      final outcome = await repo.mineEntry(
+        rawPayloadJson: _payload,
+        context: AnkiMiningContext(
+          sentence: '',
+          source: source,
+          bookTitleTag: bookTitleTag,
+          collectionTag: collectionTag,
+        ),
+      );
+      expect(outcome.result, MineResult.success);
+      return service.addedTags.single;
+    }
+
+    test(
+        'collection tag is appended after the title tag (video: series + episode)',
+        () async {
+      // 撤掉 buildNoteTags 的 collectionTag 追加（或 video/reader 调用方不传）此处转红。
+      expect(
+        await tagsForConnect('',
+            source: AnkiMiningSource.video,
+            bookTitleTag: 'S1E01',
+            collectionTag: 'Attack_on_Titan'),
+        <String>['hibiki', 'video', 'S1E01', 'Attack_on_Titan'],
+      );
+    });
+
+    test('collection tag alone (no title) still appends', () async {
+      expect(
+        await tagsForConnect('jp',
+            source: AnkiMiningSource.book, collectionTag: 'My_Series'),
+        <String>['jp', 'hibiki', 'book', 'My_Series'],
+      );
+    });
+
+    test('collection tag equal to the title tag is de-duped (single tag)',
+        () async {
+      // 单视频/单本时合集名==标题名（如合集只有一个条目）不重复追加。
+      expect(
+        await tagsForConnect('',
+            source: AnkiMiningSource.video,
+            bookTitleTag: 'Same',
+            collectionTag: 'Same'),
+        <String>['hibiki', 'video', 'Same'],
+      );
+    });
+
+    test('collection tag equal to a user/category tag is de-duped', () async {
+      expect(
+        await tagsForConnect('video',
+            source: AnkiMiningSource.video, collectionTag: 'video'),
+        <String>['video', 'hibiki'],
+      );
+    });
+
+    test('null / empty collection tag appends nothing (not in a collection)',
+        () async {
+      expect(
+        await tagsForConnect('jp',
+            source: AnkiMiningSource.video, bookTitleTag: 'Ep'),
+        <String>['jp', 'hibiki', 'video', 'Ep'],
+      );
+      expect(
+        await tagsForConnect('jp',
+            source: AnkiMiningSource.video,
+            bookTitleTag: 'Ep',
+            collectionTag: ''),
+        <String>['jp', 'hibiki', 'video', 'Ep'],
+      );
+    });
+
+    test('spaces / tabs in collection name are sanitised to a single tag',
+        () async {
+      expect(
+        await tagsForConnect('',
+            source: AnkiMiningSource.book, collectionTag: 'My Big Series'),
+        <String>['hibiki', 'book', 'My_Big_Series'],
+      );
+    });
+  });
+
   group('media uploads run in parallel (timing proof for the 6s fix)', () {
     late Directory dir;
 


### PR DESCRIPTION
## 问题
用户反馈「制卡的时候少了合集名标签」。验真：合集名标签**历史上从未存在过**——制卡标签一直只有 用户自定义 + `hibiki` + 分类(`video`/`book`) + 单集/单本标题（`bookTitleTag`），从未把条目所属**合集/系列名**加进 tag。非回归，是功能缺口。

- 视频 `lookup_mining.part.dart` 只用单集名 `_title`；合集名 `_playlistTitle` 已在内存却只喂给 `documentTitle`。
- 阅读器 `mining.part.dart` 只用单本书名，未反查所属合集。

## 方案（用户选定：合集名 + 单集名**都加**；覆盖 视频/阅读器(书·漫画)/有声书）
新增贯穿 mining 链路的 `collectionTag`，与 `bookTitleTag` 并列、同 `autoAddBookNameToTags` 开关、经 `sanitizeTitleTag` 清洗、`buildNoteTags` 去重：

- 模型/组装：`AnkiMiningContext.collectionTag` + `buildNoteTags` 追加去重
- 三 backend 透传：ankidroid / ankiconnect / ankimobile（含其 context 重建）
- 链路：`ImmersionMiningRequest` 新字段 + `immersion_mining_engine` 注入 context
- 视频：用播放列表系列名 `_playlistTitle`
- 阅读器：新增 `_resolveCollectionName()` 按 `getPrimaryCollectionIdByEntry` 折叠归属反查（`epub|bookKey` / `srt|uid`，srt-backed 两身份兜 BUG-812），一处覆盖书+有声书

合集名与单集/单本名并列各成一个 tag；不属合集/开关关闭时 null 不追加（Never break userspace）。合集名标签复用现有「自动添加书名到标签」开关，不新增偏好项。

## 测试
- `packages/hibiki_anki/test/mining_tag_and_parallel_test.dart` 新增 `collectionTag` 守卫组 6 例：追加于书名后 / 单独存在 / 与书名·分类·用户 tag 去重 / 空值不加 / 空格清洗成单 tag。撤掉追加即转红。
- `flutter analyze`（hibiki_anki + 改动 app 文件）无问题；hibiki_anki 全量 177 例、hibiki test/mining+test/anki 314 例全过。

## 待验收
真机验证：视频(播放列表)/EPUB(属合集)/有声书 制卡后卡片带对应合集名 tag。

BUG-919