### PR TITLE
fix(media-source): 管理来源「打开文件夹」用反斜杠路径 (BUG-920)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 894 条。点号进各自文件。
+> 共 895 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-920](bugs/BUG-920-media-source-open-folder-forward-slash.md) | ✅ | ✅ | 管理来源打开文件夹按钮路径不对 |
 | [BUG-917](bugs/BUG-917-video-clip-mp4-muxer.md) | ✅ | ✅ | 视频片段导出 exit -22（捆绑 ffmpeg-min 无 matroska muxer，输出跟随源容器） |
 | [BUG-916](bugs/BUG-916-subtitle-list-shift-hover-offset.md) | ✅ | ✅ | 视频字幕列表Shift悬停查词偏左一格 |
 | [BUG-915](bugs/BUG-915-ass-user-scale-and-plain-off-mode.md) | ✅ | ✅ | 尊重字幕不能调字号；关闭尊重时 ASS 特效层叠印乱字 |

--- a/docs/bugs/BUG-920-media-source-open-folder-forward-slash.md
+++ b/docs/bugs/BUG-920-media-source-open-folder-forward-slash.md
@@ -1,0 +1,8 @@
+## BUG-920 · 管理来源打开文件夹按钮路径不对
+- **报告**：2026-07-19（用户：）
+- **真实性**：✅ 真 bug。根因 `packages/hibiki_core/lib/src/database/media_source_util.dart:23` + `hibiki/lib/src/pages/implementations/media_sources_dialog.dart:516`。
+  - `normalizeSourceRootPath` 对本地来源把所有反斜杠 `\` 归一化成正斜杠 `/`（跨平台一致 + dedup/label 依赖），故 `MediaSources.rootPath` 存的是 `C:/Users/.../foo`。
+  - `_openFolder` 把这个正斜杠路径直接 `Process.run('explorer', [row.rootPath])`。Windows `explorer.exe` 只认反斜杠路径参数，收到正斜杠会忽略该参数、打开默认「文档」目录 → 现象即「打开的路径不对」。
+- **[x] ① 已修复** — 在 `_openFolder` 这个平台边界把 `rootPath` 的 `/` 转回 `\` 再传给 explorer（不动存储归一化）。`hibiki/lib/src/pages/implementations/media_sources_dialog.dart:513`。提交：e67a51652
+- **[x] ② 已加自动化测试** — 源码守卫测试：断言 `_openFolder` 传给 `Process.run('explorer', ...)` 的实参经过 `replaceAll('/', r'\')` 转换，防回归到裸 `row.rootPath`。`hibiki/test/pages/media_source_open_folder_backslash_guard_test.dart`。提交：e67a51652
+- **备注**：存储层继续用正斜杠归一化是对的（dedup/label/网络来源都依赖它），只在 Windows explorer 边界做方向转换。号从工具初分的 918 改到 920，避开 draft PR#253/#255 对 918 的既有占用（撞号纪律）。

--- a/hibiki/lib/src/pages/implementations/media_sources_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/media_sources_dialog.dart
@@ -513,7 +513,11 @@ class _MediaSourcesDialogState extends ConsumerState<MediaSourcesDialog> {
   Future<void> _openFolder(MediaSourceRow row) async {
     if (!Platform.isWindows || row.transport != 'local') return;
     try {
-      await Process.run('explorer', <String>[row.rootPath]);
+      // rootPath 由 normalizeSourceRootPath 归一化为正斜杠（跨平台一致 + dedup），
+      // 但 Windows explorer.exe 只认反斜杠路径参数：传正斜杠会被忽略、改开默认
+      // 「文档」目录（BUG-920）。仅在 explorer 这个平台边界把 `/` 转回 `\`。
+      final String windowsPath = row.rootPath.replaceAll('/', r'\');
+      await Process.run('explorer', <String>[windowsPath]);
     } catch (_) {
       // 打开失败不致命（路径可能已不存在）；静默即可。
     }

--- a/hibiki/test/pages/media_source_open_folder_backslash_guard_test.dart
+++ b/hibiki/test/pages/media_source_open_folder_backslash_guard_test.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-920 守卫：管理来源「打开文件夹」必须把 rootPath 的正斜杠转回反斜杠再交给
+/// Windows explorer.exe。
+///
+/// 根因：normalizeSourceRootPath 把本地 rootPath 归一化为正斜杠（跨平台一致 +
+/// dedup/label 依赖），而 explorer.exe 只认反斜杠路径参数——传正斜杠会被忽略、
+/// 改开默认「文档」目录。存储层归一化不动，仅在 explorer 平台边界做方向转换。
+void main() {
+  late String source;
+
+  setUp(() {
+    source = File('lib/src/pages/implementations/media_sources_dialog.dart')
+        .readAsStringSync();
+  });
+
+  test('_openFolder 把 rootPath 的 / 转成 \\ 再传 explorer', () {
+    final int idx = source.indexOf('Future<void> _openFolder(');
+    expect(idx, isNonNegative, reason: '必须存在 _openFolder');
+    // 方法体窗口：到下一个方法前足够覆盖。
+    final String body = source.substring(idx, idx + 600);
+
+    expect(
+      body.contains(r"replaceAll('/', r'\')"),
+      isTrue,
+      reason: 'explorer 只认反斜杠，rootPath 必须先 replaceAll(/ → \\)（BUG-920）',
+    );
+    expect(
+      body.contains("Process.run('explorer'"),
+      isTrue,
+      reason: '仍复用 explorer 打开文件夹',
+    );
+  });
+
+  test('不得把归一化的正斜杠 rootPath 裸传给 explorer（回归守卫）', () {
+    expect(
+      source.contains("Process.run('explorer', <String>[row.rootPath])"),
+      isFalse,
+      reason: '裸 row.rootPath（正斜杠）传 explorer 会打开错误目录（BUG-920 回归）',
+    );
+  });
+}


### PR DESCRIPTION
## 问题
管理来源对话框的「打开文件夹」按钮打开的路径不对（打开了默认「文档」目录，而非来源真实目录）。

## 根因
- `normalizeSourceRootPath`(`media_source_util.dart:23`) 把本地 `rootPath` 归一化为正斜杠 `/`（跨平台一致 + dedup/label 依赖），故存的是 `C:/Users/.../foo`。
- `_openFolder`(`media_sources_dialog.dart`) 把该正斜杠路径直接 `Process.run('explorer', [row.rootPath])`。Windows `explorer.exe` **只认反斜杠**路径参数，收到正斜杠会忽略参数、改开默认「文档」目录 → 现象即「路径不对」。

## 修复
仅在 `_openFolder` 这个平台边界把 `/` 转回 `\` 再传 explorer；存储层归一化不动（dedup/label/网络来源都依赖正斜杠）。

## 测试
- 新增源码守卫 `test/pages/media_source_open_folder_backslash_guard_test.dart`：断言 explorer 实参经 `replaceAll('/', r'\')` 转换、且不存在裸 `row.rootPath` 回归。2 用例通过。
- `flutter analyze` 改动文件 No issues found。

## 待验
Windows 真机点「打开文件夹」确认打开的是来源真实目录。BUG-920。
