### PR TITLE
feat(sync): 首页定时后台同步，静止设备也自动拉远端改动

### DIFF
--- a/hibiki/lib/src/pages/implementations/home_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -201,6 +202,20 @@ class _HomePageState extends BasePageState<HomePage>
   final FocusNode _keyboardFocusNode = FocusNode();
   final ValueNotifier<int> _dictFocusSignal = ValueNotifier<int>(0);
 
+  /// 定时后台同步：app 存活期每隔 [_periodicSyncInterval] 重跑一次 app-open 语义的全量
+  /// sweep，让「手机一直开着、电脑那边改了数据」这种没有任何事件触发的场景也能自动拉到
+  /// 远端改动。此前同步纯事件驱动（只在 app 打开 / 进入后台 / 关书时触发），设备静止不
+  /// 动就永远不同步，只能手动点「立即同步」。
+  ///
+  /// 轮询间隔特意**小于** `_runAutoSyncAll` 里的 5 分钟冷却窗（`_syncCooldownMs`）：真正
+  /// 是否发起网络同步由那道冷却闸决定，轮询只是「频繁探一下、到点即跑」。若把间隔取成恰
+  /// 等于冷却窗，tick 会落在冷却下沿（now-lastSync≈4分58秒 < 5分）被跳过，把有效周期翻
+  /// 倍成 10 分钟；小间隔 + 冷却闸则自校正，且 app-open / 关书 / 后台同步都会自然重置冷
+  /// 却。被闸掉的 tick 只是两次本地 DB 读后早退，开销可忽略；退后台 / 熄屏时 OS 会挂起
+  /// timer，不额外耗电。
+  static const Duration _periodicSyncInterval = Duration(minutes: 1);
+  Timer? _periodicSyncTimer;
+
   @override
   void initState() {
     super.initState();
@@ -254,18 +269,30 @@ class _HomePageState extends BasePageState<HomePage>
         );
       }
 
-      triggerAutoSyncOnAppOpen(
-        db: appModel.database,
-        dictionaryResourceRoot: appModel.dictionaryResourceDirectory,
-        audioDatabaseRoot:
-            Directory('${appModel.appDirectory.path}/audiobooks'),
-        tempDir: appModel.temporaryDirectory,
-        localAudioEntries: appModel.localAudioDbs,
-        onLocalAudioImported: appModel.importSyncedLocalAudioDb,
-        onPostRun: appModel.refreshAfterSyncRun,
-        onReport: appModel.presentAutoConflicts,
-      );
+      _triggerFullAutoSync();
+      // 首帧同步之后挂定时轮询，让静止不动的设备也能周期性拉到远端改动（见
+      // [_periodicSyncInterval] 注释）。dispose 时 cancel。
+      _periodicSyncTimer =
+          Timer.periodic(_periodicSyncInterval, (_) => _triggerFullAutoSync());
     });
+  }
+
+  /// 触发一次 app-open 语义的全量双向同步（导入远端新书 + 同步进度 / 内容 / 词典 / 有声书
+  /// / 统计 / 合集）。首帧 postFrame 与 [_periodicSyncTimer] 定时轮询共用同一入口，保持
+  /// 单一逻辑。内部经 `_runAutoSyncAll` 的自动开关门控 + 5 分钟冷却 + `__all__` 去重锁，
+  /// 重复触发天然安全。
+  void _triggerFullAutoSync() {
+    if (!mounted) return;
+    triggerAutoSyncOnAppOpen(
+      db: appModel.database,
+      dictionaryResourceRoot: appModel.dictionaryResourceDirectory,
+      audioDatabaseRoot: Directory('${appModel.appDirectory.path}/audiobooks'),
+      tempDir: appModel.temporaryDirectory,
+      localAudioEntries: appModel.localAudioDbs,
+      onLocalAudioImported: appModel.importSyncedLocalAudioDb,
+      onPostRun: appModel.refreshAfterSyncRun,
+      onReport: appModel.presentAutoConflicts,
+    );
   }
 
   void refresh() {
@@ -294,6 +321,7 @@ class _HomePageState extends BasePageState<HomePage>
       HomePage.debugSelectTab = null;
       return true;
     }());
+    _periodicSyncTimer?.cancel();
     _dictFocusSignal.dispose();
     _keyboardFocusNode.dispose();
     WidgetsBinding.instance.removeObserver(this);

--- a/hibiki/test/pages/home_periodic_sync_static_test.dart
+++ b/hibiki/test/pages/home_periodic_sync_static_test.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 源码守卫：首页必须挂一个定时轮询把 app-open 全量同步周期性重跑，让「手机 / 电脑一直
+/// 开着、另一端改了数据」这种没有任何事件触发的场景也能自动拉到远端改动（此前同步纯事件
+/// 驱动——只在 app 打开 / 进入后台 / 关书时触发，设备静止不动就永远不同步，只能手动点
+/// 「立即同步」）。
+///
+/// 不变式：
+/// - 存在共用入口 `_triggerFullAutoSync()`，postFrame 首帧与定时器都走它（单一逻辑）。
+/// - `Timer.periodic` 把该入口按 `_periodicSyncInterval` 周期触发。
+/// - 轮询间隔 < `_runAutoSyncAll` 的 5 分钟冷却窗，否则 tick 卡在冷却下沿被跳过、有效周期
+///   翻倍——此处固化「间隔 = 1 分钟」小于冷却。
+/// - `dispose` 里 `_periodicSyncTimer?.cancel()`，避免页面销毁后 timer 泄漏。
+///
+/// headless widget 测试要拉起完整 AppModel 初始化 + fake time，成本高且脆；用接线守卫固化
+/// 不变式防回归（对齐 home_resumed_focus_reclaim_static_test.dart 的风格）。
+void main() {
+  late String src;
+  setUpAll(() {
+    final File f = File('lib/src/pages/implementations/home_page.dart');
+    expect(f.existsSync(), isTrue, reason: '文件不存在');
+    src = f.readAsStringSync();
+  });
+
+  test('存在共用全量同步入口 _triggerFullAutoSync', () {
+    expect(src, contains('void _triggerFullAutoSync()'),
+        reason: 'postFrame 首帧与定时轮询应共用同一全量同步入口');
+    expect(src, contains('triggerAutoSyncOnAppOpen('),
+        reason: '入口应触发 app-open 语义的全量双向同步');
+  });
+
+  test('定时器把全量同步按 _periodicSyncInterval 周期触发', () {
+    expect(src, contains('Timer? _periodicSyncTimer'),
+        reason: '应持有可取消的周期同步 timer 字段');
+    expect(
+        src,
+        contains(
+            'Timer.periodic(_periodicSyncInterval, (_) => _triggerFullAutoSync())'),
+        reason: '定时器必须周期性重跑共用全量同步入口');
+  });
+
+  test('轮询间隔小于 5 分钟冷却窗（避免卡冷却下沿被跳过、周期翻倍）', () {
+    expect(
+        src,
+        contains(
+            'static const Duration _periodicSyncInterval = Duration(minutes: 1)'),
+        reason: '轮询间隔应显式为 1 分钟，小于 _runAutoSyncAll 的 5 分钟冷却窗；'
+            '若取成恰等于冷却窗，tick 会落在冷却下沿被跳过，把有效周期翻倍成 10 分钟');
+  });
+
+  test('dispose 取消周期同步 timer（不泄漏）', () {
+    final int start = src.indexOf('void dispose()');
+    expect(start, greaterThanOrEqualTo(0));
+    final int end = src.indexOf('\n  }', start);
+    final String body = src.substring(start, end);
+    expect(body, contains('_periodicSyncTimer?.cancel()'),
+        reason: 'dispose 必须取消周期同步 timer，避免页面销毁后回调仍触发');
+  });
+}


### PR DESCRIPTION
## 问题
同步此前**纯事件驱动**——只在 app 打开首帧 / 进入后台 / 关书时触发（外加手动「立即同步」）。设备静止不动（手机一直停在首页/阅读页、电脑一直用着）时**没有任何时机去拉远端改动**，另一端改了数据只能手动触发才同步。

## 根因修复
在 `HomePage` 存活期挂一个 `Timer.periodic`，回调复用现成的 `triggerAutoSyncOnAppOpen` → `_runAutoSyncAll`（已内建：自动开关门控 + **5 分钟冷却** + `__all__` 去重锁 + 冲突回调）。**不写任何新同步逻辑**，只是周期性再触发同一个已被充分测试的入口。

- 首帧 postFrame 与定时器共用抽出的 `_triggerFullAutoSync()` 入口（单一逻辑）。
- `dispose` 里 `_periodicSyncTimer?.cancel()`，不泄漏。

## 关键设计（边界坑）
轮询间隔取 **1 分钟 < 5 分钟冷却窗**：真正是否发起网络同步由冷却闸决定，轮询只是「频繁探、到点即跑」的自校正。若把间隔取成恰等于冷却窗，tick 会落在冷却下沿（`now-lastSync≈4分58秒 < 5分`）被跳过，把有效周期翻倍成 10 分钟。
- 被闸掉的 tick 只是两次本地 DB 读后早退，开销可忽略。
- 实际网络同步仍被 5 分钟冷却封顶，poll 频率只影响本地唤醒。
- 退后台 / 熄屏时 OS 挂起 Flutter timer，不额外耗电；桌面前台常驻 → 持续同步（正合「电脑一直用着」场景）。

## 验证
- `flutter analyze lib/src/pages/implementations/home_page.dart` → No issues。
- 新增源码守卫 `test/pages/home_periodic_sync_static_test.dart`（4 项，全绿）固化接线不变式（共用入口 / Timer.periodic / 间隔<冷却 / dispose cancel）防回归。
- `home_page_tabs_test` 复跑绿，确认 `home_page.dart` 在 widget 测试上下文仍编译。
- ⏳ **待真机验收**：真机跑 5+ 分钟观察静止设备是否自动拉到另一端改动、冲突弹窗行为、无重复同步风暴。

🤖 Generated with [Claude Code](https://claude.com/claude-code)