### PR TITLE
fix(video): BUG-922 词典浮层开着时快捷键先关浮层，对齐阅读器

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 896 条。点号进各自文件。
+> 共 897 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-922](bugs/BUG-922-video-dict-dismiss-shortcut.md) | ✅ | ✅ | 视频词典浮层无法用快捷键关闭·浮层开着时快捷键穿透控制视频 |
 | [BUG-919](bugs/BUG-919-anilist-macron-search.md) | ✅ | ✅ | 番剧下载AniList搜索:带macron长音的罗马字全无结果 |
 | [BUG-918](bugs/BUG-918-subtitle-offset-input-no-live-update.md) | ✅ | ✅ | 字幕偏移输入框不按回车不更新·退格没反应 |
 | [BUG-917](bugs/BUG-917-video-clip-mp4-muxer.md) | ✅ | ✅ | 视频片段导出 exit -22（捆绑 ffmpeg-min 无 matroska muxer，输出跟随源容器） |

--- a/docs/bugs/BUG-922-video-dict-dismiss-shortcut.md
+++ b/docs/bugs/BUG-922-video-dict-dismiss-shortcut.md
@@ -1,0 +1,10 @@
+## BUG-922 · 视频词典浮层无法用快捷键关闭·浮层开着时快捷键穿透控制视频
+- **报告**：2026-07-19（用户：视频里按关闭词典没反应；d 之类没在快捷键设置显示的键按了却有反应）
+- **真实性**：✅ 真 bug。根因：视频页词典浮层开着时，快捷键没有「先关浮层」的优先级。
+  - `video_hibiki_page.dart:3575` `escape:` 回调把 控制条编辑/字幕列表/剧集列表/侧栏/沉浸锁(3596)/全屏(3600) 都排在 `_handleBackOrExit`(3416，唯一关浮层处) 之前——全屏或沉浸锁看视频时按 Esc 先退全屏/解锁，永远关不掉词典浮层。
+  - 其它视频键（方向键/d/空格等）经 `_videoKeyboardShortcuts`(3436) / 手柄 `_handleVideoGamepadButton`(3617) / 裸空格 `_withPageSpaceOverride`(5431) 在浮层开着时直接穿透控制视频（后台 seek/播放），而非关浮层。
+  - 对照阅读器 `reader_hibiki/caret.part.dart:522` `readerDismissDict` 与各导航键：第一件事都是 `if (isDictionaryShown) clearDictionaryResult()`，浮层优先关。视频页缺这套优先级。
+  - 澄清 issue 2：`d` 是 `videoSeekForward` 的别名键（`shortcut_defaults.dart:252`），本就在设置「视频·快进」行显示，并非漏网硬编码键；用户"看不到 d"是别名键可发现性问题 + 浮层穿透造成的错觉。本 bug 通过「浮层开着时 d 改为关浮层」消除该错觉。
+- **[x] ① 已修复** — 新增纯函数 `guardVideoShortcutsWithPopupDismiss`（`video_player_shortcuts.dart`）包裹键盘快捷键表：浮层可见时任一映射键先关顶层浮层并消费、不跑原动作；页面 `_videoKeyboardShortcuts` / `_handleVideoGamepadButton` / `_withPageSpaceOverride` 三条输入通道统一走 `_dismissTopVisiblePopup()` 守卫。与阅读器同模型。提交哈希：97225d22f
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_popup_dismiss_guard_test.dart`：浮层可见→任一键关浮层且不跑原动作；浮层不可见→原动作照跑。提交哈希：97225d22f
+- **备注**：修法范围经用户确认「对齐阅读器」（浮层开着时导航键也先关浮层）。真机验证：Windows 离屏 / 模拟器 复测「全屏+词典浮层→Esc 关浮层」「浮层开着按 d 关浮层不快进」。

--- a/docs/bugs/BUG-922-video-dict-dismiss-shortcut.md
+++ b/docs/bugs/BUG-922-video-dict-dismiss-shortcut.md
@@ -5,6 +5,6 @@
   - 其它视频键（方向键/d/空格等）经 `_videoKeyboardShortcuts`(3436) / 手柄 `_handleVideoGamepadButton`(3617) / 裸空格 `_withPageSpaceOverride`(5431) 在浮层开着时直接穿透控制视频（后台 seek/播放），而非关浮层。
   - 对照阅读器 `reader_hibiki/caret.part.dart:522` `readerDismissDict` 与各导航键：第一件事都是 `if (isDictionaryShown) clearDictionaryResult()`，浮层优先关。视频页缺这套优先级。
   - 澄清 issue 2：`d` 是 `videoSeekForward` 的别名键（`shortcut_defaults.dart:252`），本就在设置「视频·快进」行显示，并非漏网硬编码键；用户"看不到 d"是别名键可发现性问题 + 浮层穿透造成的错觉。本 bug 通过「浮层开着时 d 改为关浮层」消除该错觉。
-- **[x] ① 已修复** — 新增纯函数 `guardVideoShortcutsWithPopupDismiss`（`video_player_shortcuts.dart`）包裹键盘快捷键表：浮层可见时任一映射键先关顶层浮层并消费、不跑原动作；页面 `_videoKeyboardShortcuts` / `_handleVideoGamepadButton` / `_withPageSpaceOverride` 三条输入通道统一走 `_dismissTopVisiblePopup()` 守卫。与阅读器同模型。提交哈希：97225d22f
-- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_popup_dismiss_guard_test.dart`：浮层可见→任一键关浮层且不跑原动作；浮层不可见→原动作照跑。提交哈希：97225d22f
+- **[x] ① 已修复** — 新增纯函数 `guardVideoShortcutsWithPopupDismiss`（`video_player_shortcuts.dart`）包裹键盘快捷键表：浮层可见时任一映射键先关顶层浮层并消费、不跑原动作；页面 `_videoKeyboardShortcuts` / `_handleVideoGamepadButton` / `_withPageSpaceOverride` 三条输入通道统一走 `_dismissTopVisiblePopup()` 守卫。与阅读器同模型。提交哈希：9b895bbf3
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_popup_dismiss_guard_test.dart`：浮层可见→任一键关浮层且不跑原动作；浮层不可见→原动作照跑。提交哈希：9b895bbf3
 - **备注**：修法范围经用户确认「对齐阅读器」（浮层开着时导航键也先关浮层）。真机验证：Windows 离屏 / 模拟器 复测「全屏+词典浮层→Esc 关浮层」「浮层开着按 d 关浮层不快进」。

--- a/hibiki/lib/src/media/video/video_player_shortcuts.dart
+++ b/hibiki/lib/src/media/video/video_player_shortcuts.dart
@@ -182,6 +182,33 @@ Map<ShortcutActivator, VoidCallback> buildVideoPlayerShortcutsFromRegistry(
   return result;
 }
 
+/// BUG-922：词典浮层开着时，让**任一**已映射的视频快捷键先关掉顶层浮层并消费掉这一次
+/// 按键，而不是穿透去控制后面的视频（对齐阅读器：浮层可见时导航/退出类键先关浮层，见
+/// `reader_hibiki/caret.part.dart` 的 `readerDismissDict` 及各键 `isDictionaryShown` 分支）。
+///
+/// 纯函数、无页面依赖，方便单测：把 [base] 里每个回调包一层守卫——[isPopupVisible] 为真时
+/// 调 [dismissPopup] 关一层浮层后 return（不跑原动作）；为假时原样执行 [base] 的回调。视频
+/// scope 没有任何「作用于浮层本身」的快捷键（制卡走浮层内按钮，非视频快捷键），故整表统一
+/// 守卫等价于阅读器的逐键 `isDictionaryShown` 判定，不误吞需要作用于浮层的键。
+Map<ShortcutActivator, VoidCallback> guardVideoShortcutsWithPopupDismiss(
+  Map<ShortcutActivator, VoidCallback> base, {
+  required bool Function() isPopupVisible,
+  required VoidCallback dismissPopup,
+}) {
+  return base.map(
+    (ShortcutActivator activator, VoidCallback callback) => MapEntry(
+      activator,
+      () {
+        if (isPopupVisible()) {
+          dismissPopup();
+          return;
+        }
+        callback();
+      },
+    ),
+  );
+}
+
 /// BUG-853 / TODO-847 对齐（视频版）：Windows 微软 IME 激活时裸 Space 的 [logicalKey]
 /// 会被引擎改写成 [LogicalKeyboardKey.process]，视频页两条空格「播放/暂停」路径
 /// （media_kit controls 的 `keyboardShortcuts` 与页级 `_withPageSpaceOverride`）都用

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -3679,11 +3679,23 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   Map<ShortcutActivator, VoidCallback> _videoKeyboardShortcuts(
     VideoPlayerController controller,
   ) {
-    return buildVideoPlayerShortcutsFromRegistry(
-      appModel.shortcutRegistry,
-      _buildVideoShortcutActions(controller),
+    // BUG-922：词典浮层可见时，任一视频快捷键先关顶层浮层（对齐阅读器），否则穿透去控制
+    // 后台视频（用户报「视频里关不掉词典」「按 d 竟然快进」）。守卫是纯函数，逻辑集中在
+    // [guardVideoShortcutsWithPopupDismiss]，此处只提供页面态谓词与关浮层动作。
+    return guardVideoShortcutsWithPopupDismiss(
+      buildVideoPlayerShortcutsFromRegistry(
+        appModel.shortcutRegistry,
+        _buildVideoShortcutActions(controller),
+      ),
+      isPopupVisible: () => _hasVisiblePopup,
+      dismissPopup: _dismissTopVisiblePopup,
     );
   }
+
+  /// BUG-922：关掉当前顶层可见词典浮层（复用 [_handleBackOrExit] / [_onDismissBarrierTap]
+  /// 同款逐层关调用，index 0 保留隐藏热槽 BUG-092）。键盘 / 手柄 / 裸空格三条输入通道在
+  /// 浮层可见时统一调它先关浮层。
+  void _dismissTopVisiblePopup() => _popNestedPopupAt(_topVisiblePopupIndex);
 
   /// TODO-1342：视频播放器动作回调集合的单一构造点。键盘
   /// （[buildVideoPlayerShortcutsFromRegistry]）与手柄（[_handleVideoGamepadButton]
@@ -3877,6 +3889,13 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
       scope: ShortcutScope.video,
     );
     if (action == null) return false;
+    // BUG-922：词典浮层可见时，任一已绑手柄键先关顶层浮层并消费（对齐阅读器 + 键盘通道），
+    // 而非穿透控制后台视频。放在解析出 action 之后——未绑定的键仍交回 GamepadService 兜底
+    // （焦点移动等），不误吞导航。
+    if (_hasVisiblePopup) {
+      _dismissTopVisiblePopup();
+      return true;
+    }
     final VoidCallback? callback =
         videoActionCallbacks(_buildVideoShortcutActions(controller))[action];
     if (callback == null) return false;
@@ -5829,10 +5848,17 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   ) {
     return CallbackShortcuts(
       bindings: <ShortcutActivator, VoidCallback>{
-        const SingleActivator(LogicalKeyboardKey.space): () =>
-            _runWhenImmersiveAllowsFullControls(
-              () => unawaited(controller.playOrPause()),
-            ),
+        const SingleActivator(LogicalKeyboardKey.space): () {
+          // BUG-922：词典浮层可见时，裸空格也先关浮层（与 [_videoKeyboardShortcuts] 守卫
+          // 同语义），而非在浮层后面 play/pause。浮层不可见时保持原「裸空格=播放/暂停」覆写。
+          if (_hasVisiblePopup) {
+            _dismissTopVisiblePopup();
+            return;
+          }
+          _runWhenImmersiveAllowsFullControls(
+            () => unawaited(controller.playOrPause()),
+          );
+        },
       },
       child: child,
     );

--- a/hibiki/test/media/video/video_popup_dismiss_guard_test.dart
+++ b/hibiki/test/media/video/video_popup_dismiss_guard_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hibiki/src/media/video/video_player_shortcuts.dart';
+
+/// BUG-922 守卫测试：词典浮层可见时，任一视频快捷键先关顶层浮层并**不**跑原动作；浮层
+/// 不可见时原动作照跑一次。这是「视频里关不掉词典 / 浮层开着按 d 竟然快进」的根因守卫
+/// （对齐阅读器：浮层可见时导航键先关浮层）。测纯函数 [guardVideoShortcutsWithPopupDismiss]，
+/// 与页面 / media_kit / 具体键位解绑，不随视频动作增删而脆化。
+void main() {
+  const ShortcutActivator seekForward =
+      SingleActivator(LogicalKeyboardKey.keyD);
+  const ShortcutActivator escape = SingleActivator(LogicalKeyboardKey.escape);
+  const ShortcutActivator space = SingleActivator(LogicalKeyboardKey.space);
+
+  /// 造一张「动作名 → 记录到 log」的快捷键表，模拟 buildVideoPlayerShortcutsFromRegistry
+  /// 的产物形状（Map<ShortcutActivator, VoidCallback>）。
+  Map<ShortcutActivator, VoidCallback> baseMap(List<String> log) {
+    return <ShortcutActivator, VoidCallback>{
+      seekForward: () => log.add('seekForward'),
+      escape: () => log.add('escape'),
+      space: () => log.add('togglePlayPause'),
+    };
+  }
+
+  test('浮层可见：任一键先关浮层、消费掉、不跑原动作', () {
+    final List<String> actions = <String>[];
+    final List<String> dismisses = <String>[];
+    final Map<ShortcutActivator, VoidCallback> guarded =
+        guardVideoShortcutsWithPopupDismiss(
+      baseMap(actions),
+      isPopupVisible: () => true,
+      dismissPopup: () => dismisses.add('dismiss'),
+    );
+
+    // d（快进）：浮层开着时应关浮层，不快进。
+    guarded[seekForward]!();
+    // Esc：同样先关浮层。
+    guarded[escape]!();
+    // 裸空格语义键：同样先关浮层，不 play/pause。
+    guarded[space]!();
+
+    expect(actions, isEmpty, reason: '浮层可见时原视频动作一次都不该跑');
+    expect(dismisses, <String>['dismiss', 'dismiss', 'dismiss'],
+        reason: '每次按键都关一层浮层');
+  });
+
+  test('浮层不可见：原动作照跑一次、不关浮层', () {
+    final List<String> actions = <String>[];
+    final List<String> dismisses = <String>[];
+    final Map<ShortcutActivator, VoidCallback> guarded =
+        guardVideoShortcutsWithPopupDismiss(
+      baseMap(actions),
+      isPopupVisible: () => false,
+      dismissPopup: () => dismisses.add('dismiss'),
+    );
+
+    guarded[seekForward]!();
+    guarded[escape]!();
+    guarded[space]!();
+
+    expect(actions, <String>['seekForward', 'escape', 'togglePlayPause'],
+        reason: '浮层不可见时快捷键保持原行为');
+    expect(dismisses, isEmpty, reason: '没有浮层就不该调关闭');
+  });
+
+  test('浮层可见性是每次按键实时求值（谁先谁后不缓存）', () {
+    final List<String> actions = <String>[];
+    bool visible = true;
+    final Map<ShortcutActivator, VoidCallback> guarded =
+        guardVideoShortcutsWithPopupDismiss(
+      baseMap(actions),
+      isPopupVisible: () => visible,
+      dismissPopup: () {},
+    );
+
+    // 第一次按 d：浮层还开着 → 关浮层（记为已关，翻转谓词）。
+    guarded[seekForward]!();
+    expect(actions, isEmpty);
+
+    // 浮层已关，再按 d → 这次真快进。
+    visible = false;
+    guarded[seekForward]!();
+    expect(actions, <String>['seekForward'], reason: '浮层关掉后同一个键恢复原动作');
+  });
+
+  test('守卫保留原表的键集合，不增删 activator', () {
+    final Map<ShortcutActivator, VoidCallback> base = baseMap(<String>[]);
+    final Map<ShortcutActivator, VoidCallback> guarded =
+        guardVideoShortcutsWithPopupDismiss(
+      base,
+      isPopupVisible: () => false,
+      dismissPopup: () {},
+    );
+    expect(guarded.keys.toSet(), base.keys.toSet());
+  });
+}


### PR DESCRIPTION
## 用户报告
> 关闭词典的快捷键失效…视频里面关闭词典按了没用。并且 d 之类没有在快捷键设置里面显示的按了竟然有反应。

## 根因（✅ 真 bug）
视频页词典浮层可见时缺「快捷键先关浮层」的优先级：
- `video_hibiki_page.dart` 的 `escape:` 回调把 沉浸锁/全屏 等分支排在唯一关浮层处（`_handleBackOrExit`）之前——**全屏或沉浸锁看视频时按 Esc 先退全屏/解锁，永远关不掉词典浮层**。
- 其它键（方向键/d/空格/手柄）经键盘表 / `_handleVideoGamepadButton` / 裸空格覆写在浮层开着时直接**穿透控制后台视频**（seek/播放）。
- 对照阅读器 `readerDismissDict` 及各导航键：第一件事都是 `if (isDictionaryShown) clearDictionaryResult()`，浮层优先关。视频页缺这套。

**澄清 issue 2**：`d` 是 `videoSeekForward` 的别名键（`shortcut_defaults.dart`），本就在设置「视频·快进」行以 chip 显示，并非漏网硬编码键。用户「看不到 d」是别名键可发现性 + 浮层穿透造成的错觉；本修复让浮层开着时 d 变为关浮层，消除错觉。

## 修复（用户确认「对齐阅读器」范围）
- 新增纯函数 `guardVideoShortcutsWithPopupDismiss`（`video_player_shortcuts.dart`）：浮层可见时任一映射键先关顶层浮层并消费、不跑原动作。
- 键盘 / 手柄 / 裸空格三条输入通道统一走 `_dismissTopVisiblePopup()` 守卫。

## 测试
- `test/media/video/video_popup_dismiss_guard_test.dart`（4 例）：浮层可见→任一键关浮层且不跑原动作；浮层不可见→原动作照跑；实时求值；键集合不变。
- 相邻 `video_player_shortcuts_dispatch_test` / `video_shortcut_registry_test` / `video_fullscreen_gamepad_dispatch_test` 全绿。
- `flutter analyze` 全量 No issues。

## 待办
⚠️ **真机验证未做**：需 Windows 离屏 / 模拟器复测「全屏+词典浮层→Esc 关浮层」「浮层开着按 d 关浮层不快进」「手柄 B/A 同理」。

BUG-922 / docs/bugs/BUG-922-video-dict-dismiss-shortcut.md