### PR TITLE
fix(settings): 所有带标题分区都可折叠，解耦默认收起 (BUG-922)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 898 条。点号进各自文件。
+> 共 899 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-922](bugs/BUG-922-settings-all-sections-collapsible.md) | ✅ | ✅ | 设置所有带标题分区都应可折叠，默认展开/收起互不影响 |
 | [BUG-921](bugs/BUG-921-mining-collection-tag.md) | ✅ | ✅ | 制卡缺少所属合集名标签 |
 | [BUG-920](bugs/BUG-920-media-source-open-folder-forward-slash.md) | ✅ | ✅ | 管理来源打开文件夹按钮路径不对 |
 | [BUG-919](bugs/BUG-919-anilist-macron-search.md) | ✅ | ✅ | 番剧下载AniList搜索:带macron长音的罗马字全无结果 |

--- a/docs/bugs/BUG-922-settings-all-sections-collapsible.md
+++ b/docs/bugs/BUG-922-settings-all-sections-collapsible.md
@@ -1,0 +1,6 @@
+## BUG-922 · 设置所有带标题分区都应可折叠，默认展开/收起互不影响
+- **报告**：2026-07-19（用户：）
+- **真实性**：✅ 真 bug（能力缺失）。根因 `hibiki/lib/src/settings/settings_schema_widgets.dart:55`：折叠「能力」被和「默认收起」耦合进同一个 `collapsedByDefault` 字段——`collapsible = section.collapsedByDefault && (title 非空)`。结果只有声明 `collapsedByDefault: true` 的 17 组才长折叠头，其余带标题分区一律平铺、没有折叠箭头。所有分区本就走同一个 `SettingsSchemaSection` → `AdaptiveSettingsSection` 封装，不是特判排除也不是另一套渲染路径，纯粹是判据把两件事绑死了。
+- **[x] ① 已修复** — `settings_schema_widgets.dart:55` 解耦：`collapsible = section.title?.isNotEmpty ?? false`（折叠能力只看有无标题）；`initiallyExpanded`（:64-66）继续用 `collapsedByDefault` 决定默认展开/收起。所有带标题分区都获得折叠头，各自默认态互不影响，正好对应诉求「都能折叠，某些默认折叠某些不是」。无标题分区（如 interconnect 指引组）没有可点的头，仍平铺，符合既有设计。commit: 见下
+- **[x] ② 已加自动化测试** — `hibiki/test/settings/settings_renderer_test.dart`「BUG-922: every titled section is collapsible…」：构造「有标题+默认展开」「有标题+默认收起」「无标题」三分区，关掉 `debugSettingsForceExpandAllSections` 后断言：折叠头恰好 2 个（两带标题分区，无标题不出）、默认展开组的行入树、默认收起组的行不入树、无标题组的行始终平铺可见。旧耦合判据下「默认展开组」不会长折叠头，`findsNWidgets(2)` 必失败。
+- **备注**：折叠态目前纯内存（`AdaptiveSettingsSection` state），不跨页面持久化；若产品要「记住每组展开/收起」需另加 pref/provider，超出本次范围。

--- a/hibiki/lib/src/settings/settings_schema_widgets.dart
+++ b/hibiki/lib/src/settings/settings_schema_widgets.dart
@@ -52,8 +52,10 @@ class SettingsSchemaSection extends StatelessWidget {
           ),
         )
         .toList(growable: false);
-    final bool collapsible =
-        section.collapsedByDefault && (section.title?.isNotEmpty ?? false);
+    // 折叠能力只取决于「有没有标题」（无标题 section 没有可点的折叠头）；
+    // 「默认展开还是收起」由 collapsedByDefault 单独决定（见下方 initiallyExpanded）。
+    // 两者解耦——所有带标题分区都可折叠，各自默认态互不影响。
+    final bool collapsible = section.title?.isNotEmpty ?? false;
     // 搜索跳转落在折叠 section 内的项时强制展开——否则收起态下目标行不入树、
     // SettingsSearchReveal 的一次性挂点永不被消费，定位失效。测试钩子强制全展开
     // 让覆盖守卫能焦点驱动到所有行（见 debugSettingsForceExpandAllSections）。

--- a/hibiki/test/settings/settings_renderer_test.dart
+++ b/hibiki/test/settings/settings_renderer_test.dart
@@ -1168,6 +1168,88 @@ void main() {
     expect(paragraph.didExceedMaxLines, isFalse,
         reason: '两行内「同步与备份（实验性）」应完整显示，不触发 ellipsis');
   });
+
+  testWidgets(
+      'BUG-922: every titled section is collapsible; collapsedByDefault only '
+      'controls the initial open/closed state, not the ability to fold',
+      (WidgetTester tester) async {
+    // 折叠「能力」与「默认收起」解耦后（settings_schema_widgets.dart）：
+    //   有标题 → 一定有折叠头（chevron），不管 collapsedByDefault；
+    //   collapsedByDefault 只决定进页面时展开还是收起；
+    //   无标题 → 没有可点的折叠头，永远平铺。
+    // 关掉全展开钩子，才能同时验「默认收起」这一半（setUp 默认置 true）。
+    debugSettingsForceExpandAllSections = false;
+
+    final SettingsDestination destination = SettingsDestination(
+      id: SettingsDestinationId.appearance,
+      title: 'Folding',
+      icon: Icons.palette_outlined,
+      sections: <SettingsSection>[
+        SettingsSection(
+          title: 'Expanded group',
+          // collapsedByDefault 缺省 = false → 默认展开。
+          items: <SettingsItem>[
+            SettingsSwitchItem(
+              id: 'alpha',
+              title: 'Alpha row',
+              value: (_) => true,
+              onChanged: (_, __) {},
+            ),
+          ],
+        ),
+        SettingsSection(
+          title: 'Collapsed group',
+          collapsedByDefault: true, // 默认收起。
+          items: <SettingsItem>[
+            SettingsSwitchItem(
+              id: 'bravo',
+              title: 'Bravo row',
+              value: (_) => true,
+              onChanged: (_, __) {},
+            ),
+          ],
+        ),
+        SettingsSection(
+          // 无标题 → 不可折叠。
+          items: <SettingsItem>[
+            SettingsSwitchItem(
+              id: 'charlie',
+              title: 'Charlie row',
+              value: (_) => true,
+              onChanged: (_, __) {},
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      _harness(
+        platform: TargetPlatform.android,
+        builder: (SettingsContext settingsContext) {
+          return MaterialSettingsRenderer().buildDetailPage(
+            settingsContext: settingsContext,
+            destination: destination,
+          );
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 两个带标题分区各有一个折叠头；无标题分区没有。
+    expect(find.byIcon(Icons.expand_more), findsNWidgets(2),
+        reason: '每个带标题 section 都必须长出折叠头；无标题 section 不出');
+
+    // collapsedByDefault 决定默认态：展开组的行在树内，收起组的行不入树。
+    expect(find.text('Alpha row'), findsOneWidget,
+        reason: 'collapsedByDefault:false 的分区默认展开，行应可见');
+    expect(find.text('Bravo row'), findsNothing,
+        reason: 'collapsedByDefault:true 的分区默认收起，行应不入树');
+
+    // 无标题分区永远平铺，行始终可见。
+    expect(find.text('Charlie row'), findsOneWidget,
+        reason: '无标题 section 不可折叠，行始终平铺可见');
+  });
 }
 
 /// 渲染器测试用的轻量 AppModel：未跑 initialise()、prefsRepo 为空。阅读设置里


### PR DESCRIPTION
## 问题
用户报告：设置里并非所有部分都能折叠——应该所有分区都能折叠，只不过某些默认折叠某些默认展开。

## 根因
`hibiki/lib/src/settings/settings_schema_widgets.dart:55` 把折叠「能力」和「默认收起」耦合进同一个 `collapsedByDefault` 字段：
```dart
final bool collapsible = section.collapsedByDefault && (section.title?.isNotEmpty ?? false);
```
结果只有声明 `collapsedByDefault: true` 的 17 组才长折叠头，其余带标题分区一律平铺、没有折叠箭头。所有分区本就走同一个 `SettingsSchemaSection` → `AdaptiveSettingsSection` 封装，不是特判排除，纯粹是判据把两件事绑死。

## 修复
解耦——可折叠只看有无标题；默认展开/收起继续由 `collapsedByDefault` 独立决定：
```dart
final bool collapsible = section.title?.isNotEmpty ?? false;
```
`initiallyExpanded`（用 `collapsedByDefault`）一行不动。所有带标题分区都获得折叠头，各自默认态互不影响，正好对应诉求。无标题分区（如 interconnect 指引组）没有可点的头，仍平铺，符合既有设计。

## 测试
- 新增 `test/settings/settings_renderer_test.dart`「BUG-922」守卫：三分区（有标题+默认展开 / 有标题+默认收起 / 无标题），关掉 `debugSettingsForceExpandAllSections` 后断言折叠头恰好 2 个、默认展开组入树、默认收起组不入树、无标题组始终平铺。旧耦合判据下必失败。
- `flutter analyze` 干净；`test/settings/` + `test/widgets/settings_shared_test.dart` 全过（294）。

## 待验
待真机复测：进设置各分区点折叠头能收起/展开，默认态符合预期。

BUG: docs/bugs/BUG-922-settings-all-sections-collapsible.md