### PR TITLE
fix(reader): 原生选区残留卡查词 + 右键复制闪退 (BUG-927)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 906 条。点号进各自文件。
+> 共 907 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-927](bugs/BUG-927-reader-native-selection-blocks-lookup-and-rightclick-crash.md) | ✅ | ✅ | 阅读器原生选区残留卡住查词 + 右键闪退 |
 | [BUG-925](bugs/BUG-925-settings-all-sections-collapsible.md) | ✅ | ✅ | 设置所有带标题分区都应可折叠，默认展开/收起互不影响 |
 | [BUG-924](bugs/BUG-924-video-dict-dismiss-shortcut.md) | ✅ | ✅ | 视频词典浮层无法用快捷键关闭·浮层开着时快捷键穿透控制视频 |
 | [BUG-923](bugs/BUG-923-immersive-cursor-lock-button-no-idle-rehide.md) | ✅ | ✅ | 沉浸模式鼠标光标与沉浸退出按钮静止时不隐藏（缺「空闲重隐」路径，除非把鼠标移到别处） |

--- a/docs/bugs/BUG-927-reader-native-selection-blocks-lookup-and-rightclick-crash.md
+++ b/docs/bugs/BUG-927-reader-native-selection-blocks-lookup-and-rightclick-crash.md
@@ -1,0 +1,14 @@
+## BUG-927 · 阅读器原生选区残留卡住查词 + 右键闪退
+
+- **报告**：2026-07-19（用户：长按左键拖动复制后无法查词；点「复制」出现系统蓝色选区后也查不了词，再按右键闪退）
+- **真实性**：✅ 真 bug。桌面/细指针（鼠标）路径三连锁：
+  - 根因① 查词被吞：`hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart:1051-1065` 的 `pointerup` `_hoshiReaderMouseNativeTextStart` 分支，早退条件是 `if (nativeMoved || hasNativeSelection)`。只要上一轮残留的原生选区（`!isCollapsed`）还在，纯 tap（未移动）也提前 `return`，跳过 `_gestureEnd -> selectText -> clearSelection` 整条链 → 之后每次点击都被吞、查词永远打不开。桌面鼠标拖选/右键复制刻意保留原生选区（供 Ctrl+C），最易触发这个死循环。
+  - 根因② 复制不清选区：桌面右键 `copy`（`chrome.part.dart` `_showReaderTextContextMenu` 的 `'copy'` 分支）与移动端原生 ContextMenu `copy`（`webview.part.dart` `ContextMenuItem id:3`）只 `Clipboard.setData`，从不 `removeAllRanges()`；只有移动端拖选菜单 `'copy'` 调 `_clearReaderAppSelection()`。复制后原生蓝/灰选区残留 → 喂给根因①。
+  - 根因③ 右键闪退：`chrome.part.dart:250 _showReaderTextContextMenu` 从 `onSecondaryTapDown`（`webview.part.dart` `GestureDetector.onSecondaryTapDown`）fire-and-forget 调用，首个 `evaluateJavascript`（`nativeSelectionTextInvocation`）**未 try/catch**。WebView 半销毁/插件通道异常时抛 `PlatformException/MissingPluginException`，逃出 zone 被 `main.dart` `runZonedGuarded` 记为 fatal（进程终止）。孪生 `_fillLookupStateFromNativeSelection` / `_copyNativeSelectionToClipboard` 都已 try/catch，唯独此处漏。
+- **[x] ① 已修复** —
+  - `webview.part.dart` pointerup：早退条件 `nativeMoved || hasNativeSelection` → 仅 `nativeMoved`。纯 tap 落到 `_gestureEnd`，`selectText` 会先 `clearSelection(removeAllRanges)` 再查词，既清残留选区又正常弹词典。删掉不再使用的 `nativeSelection`/`hasNativeSelection` 死变量。
+  - 桌面右键 `copy` 分支 + 移动端原生 ContextMenu `copy` action：复制后补 `await _clearReaderAppSelection()`（内部 `clearSelection` 走 `window.getSelection()?.removeAllRanges()`），与拖选菜单 `'copy'` 对齐。
+  - `_showReaderTextContextMenu` 首个 `evaluateJavascript` 包 try/catch，异常记 `ErrorLogService` 后 `return`，不再逃 zone。
+  - 提交：（见 PR）
+- **[x] ② 已加自动化测试** — `hibiki/test/reader/reader_native_selection_lookup_guard_test.dart`：源码守卫钉死①pointerup 早退不得再含 `hasNativeSelection`；②两处 `copy` 分支复制后必须 `_clearReaderAppSelection()`；③`_showReaderTextContextMenu` 的 eval 必须在 try/catch 内。防回归。
+- **备注**：均为桌面/细指针（鼠标）现象；触屏 `@media(pointer:coarse)` 强制 `user-select:none` 本就不建原生选区，但外接鼠标会让设备报告 `pointer:fine` 从而暴露同一路径。真机验证走 Windows。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
@@ -250,9 +250,21 @@ extension _ReaderChrome on _ReaderHibikiPageState {
   Future<void> _showReaderTextContextMenu(Offset globalPosition) async {
     if (!mounted || !isWindowsPlatform) return;
     // 没有原生选区文本就不弹菜单（右键空白处不打扰）。
-    final Object? rawText = await _controller?.evaluateJavascript(
-      source: ReaderSelectionScripts.nativeSelectionTextInvocation(),
-    );
+    // 本方法从 onSecondaryTapDown fire-and-forget 调用，异常会逃出当前 zone 被记为
+    // fatal（main.dart runZonedGuarded）——WebView 半销毁 / 插件通道异常时右键
+    // evaluateJavascript 会抛 PlatformException / MissingPluginException，表现为闪退。
+    // 与孪生的 _fillLookupStateFromNativeSelection / _copyNativeSelectionToClipboard
+    // 同款：eval 必须 try/catch 吞掉。BUG-927。
+    Object? rawText;
+    try {
+      rawText = await _controller?.evaluateJavascript(
+        source: ReaderSelectionScripts.nativeSelectionTextInvocation(),
+      );
+    } catch (e, stack) {
+      ErrorLogService.instance
+          .log('ReaderHibiki.showReaderTextContextMenu', e, stack);
+      return;
+    }
     final String selectedText =
         ReaderSelectionScripts.nativeSelectionTextFromResult(rawText);
     if (selectedText.isEmpty) return;
@@ -368,6 +380,10 @@ extension _ReaderChrome on _ReaderHibikiPageState {
       case 'copy':
         await Clipboard.setData(ClipboardData(text: selectedText));
         HibikiToast.show(msg: t.copied_to_clipboard);
+        // 复制是终结动作：清掉刻意保留的原生选区，和移动端拖选菜单的 'copy'
+        // （_clearReaderAppSelection）对齐。否则残留的原生蓝色选区会一直卡住后续
+        // 查词（见 webview.part.dart pointerup 里对 nativeMoved 的处理）。BUG-927。
+        await _clearReaderAppSelection();
         return;
       case 'favorite':
         // BUG-854：右键收藏也走「原生选区 → 查词状态」补写（与 search 同源），确保

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -1052,14 +1052,20 @@ extension _ReaderWebView on _ReaderHibikiPageState {
       var nativeDx = e.clientX - startX;
       var nativeDy = e.clientY - startY;
       var nativeMoved = (nativeDx * nativeDx + nativeDy * nativeDy) > 36;
-      var nativeSelection = window.getSelection && window.getSelection();
-      var hasNativeSelection = nativeSelection && !nativeSelection.isCollapsed;
       _hoshiReaderMouseNativeTextStart = false;
       _hoshiReaderMouseDragActive = false;
       _hoshiReaderMouseDragPointerId = null;
       _hoshiReaderMouseDragPageDirection = null;
       _hoshiReaderPointerNoSelect(false);
-      if (nativeMoved || hasNativeSelection) {
+      // 只有「本次手势里指针真的移动过」(nativeMoved) 才当作用户在拖动划原生选区，
+      // 保留选区供复制 / 桌面 Ctrl+C，不再当作查词 tap。
+      // 旧代码还把「残留原生选区未折叠」也塞进这条早退：只要上一轮的选区还在，纯 tap
+      //（未移动）也会在此提前 return，跳过 _gestureEnd -> selectText -> clearSelection
+      // 整条链——于是残留选区会让之后每一次点击都被吞（查词永远打不开）。桌面细指针鼠标
+      // 拖选/右键复制刻意保留原生选区，最容易触发这个死循环。纯 tap 时改为落到下方
+      // _gestureEnd：selectText 会先 clearSelection(removeAllRanges) 再查词，既清掉残留
+      // 选区又能正常弹词典。BUG-927。
+      if (nativeMoved) {
         hasStart = false;
         return;
       }
@@ -1430,6 +1436,9 @@ extension _ReaderWebView on _ReaderHibikiPageState {
                     if (text == null || text.isEmpty) return;
                     await Clipboard.setData(ClipboardData(text: text));
                     HibikiToast.show(msg: t.copied_to_clipboard);
+                    // 复制后清掉 ActionMode 残留的原生选区，和桌面右键 'copy' 对齐，
+                    // 避免残留选区卡住后续查词。BUG-927。
+                    await _clearReaderAppSelection();
                   },
                 ),
               ],

--- a/hibiki/test/reader/reader_native_selection_lookup_guard_test.dart
+++ b/hibiki/test/reader/reader_native_selection_lookup_guard_test.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-927 源码守卫：阅读器桌面/细指针（鼠标）路径「原生选区残留卡住查词 + 右键闪退」
+/// 三连锁的根因修复不得回退。
+///
+/// 为什么源码扫描而非行为测试：阅读器页含真实 `InAppWebView` 平台视图，widget 测试挂
+/// 不上；pointerup/复制/右键都涉浏览器原生 `window.getSelection()` 与 WebView2 半销毁
+/// 竞态，难确定性复现。故照 reader_desktop_copy_guard / reader_lookup_eval_guard 的
+/// 静态断言范式钉死结构。
+void main() {
+  final File webview =
+      File('lib/src/pages/implementations/reader_hibiki/webview.part.dart');
+  final File chrome =
+      File('lib/src/pages/implementations/reader_hibiki/chrome.part.dart');
+
+  test('webview.part.dart：pointerup 早退只认 nativeMoved，不认残留原生选区', () {
+    expect(webview.existsSync(), isTrue,
+        reason: 'webview.part.dart 不存在，路径变了须更新守卫');
+    final String src = webview.readAsStringSync().replaceAll('\r\n', '\n');
+
+    // 根因①：早退条件必须是纯 nativeMoved。旧代码 `nativeMoved || hasNativeSelection`
+    // 会让纯 tap 在残留原生选区时提前 return，跳过 selectText → 查词被吞死循环。
+    expect(src, contains('if (nativeMoved) {'),
+        reason: 'pointerup 原生选词分支早退必须只认 nativeMoved（本次手势真的拖动过）');
+    expect(src.contains('nativeMoved || hasNativeSelection'), isFalse,
+        reason: 'BUG-927 回退：残留原生选区不得再塞进 pointerup 早退条件，'
+            '否则纯 tap 被吞、查词永远打不开');
+    expect(src.contains('hasNativeSelection'), isFalse,
+        reason: 'hasNativeSelection 已随修复删除；复活即回归风险');
+  });
+
+  test('chrome.part.dart：桌面右键复制后清原生选区 + 右键 eval 有 try/catch', () {
+    expect(chrome.existsSync(), isTrue,
+        reason: 'chrome.part.dart 不存在，路径变了须更新守卫');
+    final String src = chrome.readAsStringSync().replaceAll('\r\n', '\n');
+
+    // 根因②：桌面右键 copy 分支复制后必须清选区（与移动端拖选菜单 copy 对齐），
+    // 否则残留原生蓝色选区喂给根因① 卡死查词。selectedText 是桌面路径专有变量。
+    final int copyIdx =
+        src.indexOf('Clipboard.setData(ClipboardData(text: selectedText))');
+    expect(copyIdx, greaterThanOrEqualTo(0),
+        reason: '缺桌面右键 copy 分支（Clipboard.setData(text: selectedText)）');
+    final String copyRegion = src.substring(copyIdx, copyIdx + 700);
+    expect(copyRegion, contains('_clearReaderAppSelection()'),
+        reason: 'BUG-927 回退：桌面右键 copy 复制后必须 _clearReaderAppSelection() 清'
+            '残留原生选区');
+
+    // 根因③：_showReaderTextContextMenu 从 onSecondaryTapDown fire-and-forget 调，
+    // 首个 evaluateJavascript 必须 try/catch（靠此 ErrorLogService tag 标识），否则
+    // WebView 半销毁时抛 PlatformException 逃 zone → 记为 fatal → 右键闪退。
+    expect(src, contains("'ReaderHibiki.showReaderTextContextMenu'"),
+        reason: 'BUG-927 回退：右键菜单首个 evaluateJavascript 必须 try/catch，'
+            '异常记 ErrorLogService 后 return，勿退回裸 eval 让异常逃 zone 闪退');
+  });
+
+  test('webview.part.dart：移动端原生 ContextMenu 复制后也清原生选区', () {
+    final String src = webview.readAsStringSync().replaceAll('\r\n', '\n');
+    // 移动端原生 ContextMenu copy（id:3）用局部 text 变量，复制后同样补清选区。
+    final int copyIdx =
+        src.indexOf('Clipboard.setData(ClipboardData(text: text))');
+    expect(copyIdx, greaterThanOrEqualTo(0),
+        reason: '缺移动端原生 ContextMenu copy 分支');
+    final String copyRegion = src.substring(copyIdx, copyIdx + 700);
+    expect(copyRegion, contains('_clearReaderAppSelection()'),
+        reason: 'BUG-927 回退：移动端原生菜单 copy 复制后也要清选区，与桌面右键对齐');
+  });
+}


### PR DESCRIPTION
## 现象（用户报）
1. 长按左键拖动复制后，再点字**无法查词**。
2. 点选区菜单「复制」→ 出现系统蓝色原生选区，也**查不了词**；此时**再按右键就闪退**。

三者同为桌面/细指针（鼠标）路径的连锁 bug（外接鼠标让触屏设备也报告 `pointer:fine`，故手机接鼠标同样暴露）。

## 根因（三连锁）
- **① 查词被吞** `reader_hibiki/webview.part.dart` pointerup 的 `_hoshiReaderMouseNativeTextStart` 分支早退条件是 `nativeMoved || hasNativeSelection`。只要上一轮残留的原生选区还没折叠，纯 tap（未移动）也提前 `return`，跳过 `_gestureEnd → selectText → clearSelection` 整条链 → 之后每次点击都被吞、查词永远打不开。桌面鼠标拖选/复制刻意保留原生选区（供 Ctrl+C），最易触发死循环。
- **② 复制不清选区** 桌面右键 `copy` 与移动端原生 ContextMenu `copy` 只 `Clipboard.setData`，从不 `removeAllRanges()`；只有移动端拖选菜单 `copy` 调 `_clearReaderAppSelection()`。复制后残留选区喂给根因①。
- **③ 右键闪退** `_showReaderTextContextMenu` 从 `onSecondaryTapDown` fire-and-forget 调用，首个 `evaluateJavascript` **未 try/catch**。WebView 半销毁/插件通道异常时抛 `PlatformException/MissingPluginException`，逃出 zone 被 `main.dart` `runZonedGuarded` 记为 fatal（闪退）。孪生 `_fillLookupStateFromNativeSelection` / `_copyNativeSelectionToClipboard` 都已 try/catch，唯独此处漏。

## 修复（根因）
- pointerup 早退条件 `nativeMoved || hasNativeSelection` → 仅 `nativeMoved`；纯 tap 落到 `_gestureEnd`，`selectText` 先 `clearSelection(removeAllRanges)` 再查词，既清残留选区又正常弹词典。删死变量。
- 桌面右键 `copy` + 移动端原生 ContextMenu `copy` 复制后补 `_clearReaderAppSelection()`（内部 `removeAllRanges`），与拖选菜单 `copy` 对齐（消除特例）。
- `_showReaderTextContextMenu` 首个 eval 包 try/catch，异常记 `ErrorLogService` 后 `return`。

## 测试
- 新增 `test/reader/reader_native_selection_lookup_guard_test.dart`（3 组源码守卫，钉死上面三点，防回退）。
- `flutter analyze`（全量）无问题；`flutter test test/reader/`（1104 项）全过；相关选区/查词/复制既有守卫零回归。

## 待办
- 桌面（Windows）真机复测原始三条失败路径（draft）。