### PR TITLE
fix(video): BUG-929 字幕轨菜单按视频缓存枚举

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 909 条。点号进各自文件。
+> 共 910 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-929](bugs/BUG-929-subtitle-menu-reenumerate.md) | ✅ | ✅ | 字幕轨菜单每次打开都重跑ffprobe显加载条+已有字幕先消失 |
 | [BUG-928](bugs/BUG-928-video-card-16x9-gap.md) | ✅ | ✅ | 视频卡对标准 16:9 封面留空隙·封面比例随标题长短浮动 |
 | [BUG-927](bugs/BUG-927-reader-native-selection-blocks-lookup-and-rightclick-crash.md) | ✅ | ✅ | 阅读器原生选区残留卡住查词 + 右键闪退 |
 | [BUG-926](bugs/BUG-926-popup-touch-copy-disabled.md) | ✅ | ✅ | 词典弹窗触屏无法复制释义(撤回BUG-762全量禁选) |

--- a/docs/bugs/BUG-929-subtitle-menu-reenumerate.md
+++ b/docs/bugs/BUG-929-subtitle-menu-reenumerate.md
@@ -1,0 +1,15 @@
+## BUG-929 · 字幕轨菜单每次打开都重跑ffprobe显加载条+已有字幕先消失
+
+- **报告**：2026-07-19（用户：截图「字幕轨」区顶部一直转加载条，明明无可加载的字幕轨；且之前枚举出的字幕会消失，要等加载）
+- **真实性**：✅ 真 bug。根因在字幕轨枚举无按视频缓存、且有两个各自枚举的入口：
+  - `hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart:354`（旧 `_showSubtitleSourceMenu`）每次打开都 `_subtitleMenuSources = []` + `_subtitleMenuLoading = true` 再重跑 `_subtitleSourcesForMenu`（ffprobe 枚举内嵌轨 + 同目录外挂）→ 已枚举出的字幕轨先消失、加载条转（「之前有的字幕还会消失，要等加载」）。
+  - `hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart:381`（`_ensureSubtitleMenuSourcesLoaded`，由设置面板「字幕」分类被打开事件 `onSubtitleCategoryShown` 驱动）无条件重枚举，无内嵌轨/外挂的视频枚举恒空却每次都显加载条（「字幕轨要加载，明明根本没有可加载的地方」）。
+
+- **[x] ① 已修复** — commit `<pending>`
+  - 新增按视频路径的枚举缓存 key `_subtitleMenuSourcesPath`（`video_hibiki_page.dart:950` 附近）。
+  - `_ensureSubtitleMenuSourcesLoaded` 成为**唯一枚举者**并加缓存短路：`if (_subtitleMenuSourcesPath == videoPath) return;`，成功后记 `_subtitleMenuSourcesPath = videoPath`；失败不写 key 下次重试。
+  - `_showSubtitleSourceMenu`（控制条「字幕轨」按钮）退化为纯打开设置面板「字幕」分类——枚举交给面板打开必触发的 `_ensureSubtitleMenuSourcesLoaded`（initState / didUpdateWidget / `_selectSubPage` 三条路径），不再自清空 + 重枚举（消除闪烁与重复枚举）。
+  - 缓存失效：换视频/换集（`_applyLoad` 内 `clipExportSourceChanged`）复位缓存；导入外挂字幕档 / Jimaku 下载后 `_invalidateSubtitleMenuSourcesCache()` 让新档下次枚举列进。
+- **[x] ② 已加自动化测试** — `hibiki/test/tools/subtitle_menu_reenumerate_guard_test.dart`（源码扫描守卫：缓存字段存在、`_ensureSubtitleMenuSourcesLoaded` 有路径短路并记录、`_showSubtitleSourceMenu` 不再调 `_subtitleSourcesForMenu` / 不再置 loading=true）。3 用例全绿。
+
+- **备注**：巨型 `_VideoHibikiPageState`（~7300 行）私有方法难做 widget 行为测试（需 controller + ffprobe + DB），按 BUG 流程用源码扫描守卫作最强可落地层。远端视频分支行为不变（远端字幕轨走 `_youtubeCaptionTracks` / `_remoteEmbeddedSubtitleTracks`，本地枚举缓存清空即可）。

--- a/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
@@ -331,49 +331,25 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     VideoPlayerController controller, {
     VideoControlSlot? sourceSlot,
   }) async {
-    if (_isRemote) {
-      _rebuild(() {
-        _subtitleMenuSources = const <SubtitleSource>[];
-        _subtitleMenuLoading = false;
-      });
-      // TODO-1351：字幕轨切换收进设置面板「字幕」分类顶部（取代外面浮的字幕轨侧栏）。
-      _showPlayerSettings(sourceSlot: sourceSlot, initialCategory: 'subtitle');
-      return;
+    // BUG-929：控制条「字幕轨」按钮不再自己枚举字幕源。枚举的单一真相源是
+    // [_ensureSubtitleMenuSourcesLoaded]——它由设置面板「字幕」分类被打开这一事件驱动
+    // （[VideoQuickSettingsSheet.onSubtitleCategoryShown]，initState / didUpdateWidget /
+    // 手动切分类三条路径都会触发），并按视频路径缓存。此前这里额外清空 `_subtitleMenuSources`
+    // 再重跑 ffprobe，导致每次点按钮已枚举的字幕轨先消失、且与面板回调重复枚举显加载条。
+    // 现在退化为纯粹打开面板即可；无本地路径时顺手清掉可能残留的旧枚举缓存。
+    if (_isRemote || _currentVideoPath == null) {
+      if (_subtitleMenuSources.isNotEmpty ||
+          _subtitleMenuLoading ||
+          _subtitleMenuSourcesPath != null) {
+        _rebuild(() {
+          _subtitleMenuSources = const <SubtitleSource>[];
+          _subtitleMenuLoading = false;
+          _subtitleMenuSourcesPath = null;
+        });
+      }
     }
-    final String? videoPath = _currentVideoPath;
-    if (videoPath == null) {
-      _rebuild(() {
-        _subtitleMenuSources = const <SubtitleSource>[];
-        _subtitleMenuLoading = false;
-      });
-      // TODO-1351：字幕轨切换收进设置面板「字幕」分类顶部（取代外面浮的字幕轨侧栏）。
-      _showPlayerSettings(sourceSlot: sourceSlot, initialCategory: 'subtitle');
-      return;
-    }
-
-    _rebuild(() {
-      _subtitleMenuSources = const <SubtitleSource>[];
-      _subtitleMenuLoading = true;
-    });
     // TODO-1351：字幕轨切换收进设置面板「字幕」分类顶部（取代外面浮的字幕轨侧栏）。
     _showPlayerSettings(sourceSlot: sourceSlot, initialCategory: 'subtitle');
-    final List<SubtitleSource> sources;
-    try {
-      sources = await _subtitleSourcesForMenu(
-        videoPath: videoPath,
-        currentSubtitleSource: _currentSubtitleSource,
-        currentCues: controller.cues,
-      );
-    } catch (_) {
-      if (!mounted) return;
-      _rebuild(() => _subtitleMenuLoading = false);
-      return;
-    }
-    if (!mounted) return;
-    _rebuild(() {
-      _subtitleMenuSources = sources;
-      _subtitleMenuLoading = false;
-    });
   }
 
   /// TODO-1350（字幕轨即时加载）：进入设置面板「字幕」分类时（重新）枚举当前视频的字幕源
@@ -392,14 +368,22 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     if (controller == null) return;
     final String? videoPath = _currentVideoPath;
     if (_isRemote || videoPath == null) {
-      if (_subtitleMenuSources.isNotEmpty || _subtitleMenuLoading) {
+      if (_subtitleMenuSources.isNotEmpty ||
+          _subtitleMenuLoading ||
+          _subtitleMenuSourcesPath != null) {
         _rebuild(() {
           _subtitleMenuSources = const <SubtitleSource>[];
           _subtitleMenuLoading = false;
+          _subtitleMenuSourcesPath = null;
         });
       }
       return;
     }
+    // BUG-929：已为当前视频枚举过就直接用缓存，不再重跑 ffprobe、不再显加载条。
+    // 修「每次进字幕分类都要加载、明明没可加载的地方」——无内嵌轨/外挂的视频枚举结果
+    // 恒空，但只跑一次；有轨的视频重开时也不再把已枚举的字幕轨先清空重来。缓存在换视频
+    // （路径变）与导入新字幕档（[_invalidateSubtitleMenuSourcesCache]）时失效。
+    if (_subtitleMenuSourcesPath == videoPath) return;
     if (_subtitleMenuLoading) return;
     _rebuild(() => _subtitleMenuLoading = true);
     final List<SubtitleSource> sources;
@@ -410,6 +394,7 @@ extension _VideoSubtitle on _VideoHibikiPageState {
         currentCues: controller.cues,
       );
     } catch (_) {
+      // 枚举失败不写缓存 key，下次打开重试（ffprobe 偶发失败不该被缓存成「已加载空」）。
       if (!mounted) return;
       _rebuild(() => _subtitleMenuLoading = false);
       return;
@@ -418,7 +403,15 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     _rebuild(() {
       _subtitleMenuSources = sources;
       _subtitleMenuLoading = false;
+      _subtitleMenuSourcesPath = videoPath;
     });
+  }
+
+  /// BUG-929：让字幕轨枚举缓存失效（下次打开「字幕」分类重新 ffprobe 枚举）。导入新字幕
+  /// 档（[_importExternalSubtitleInner] / Jimaku 下载）后调用——新档不在旧枚举结果里，
+  /// 靠这条让它下次出现在字幕轨列表。换视频不需调它（缓存 key 是视频路径，路径变自然失效）。
+  void _invalidateSubtitleMenuSourcesCache() {
+    _subtitleMenuSourcesPath = null;
   }
 
   /// 选中某副字幕源（TODO-857 / TODO-1312）：抽 cue → [VideoPlayerController.setSecondaryCues]
@@ -600,6 +593,10 @@ extension _VideoSubtitle on _VideoHibikiPageState {
       label: p.basename(downloaded),
     );
     final bool applied = await _selectSubtitleSource(controller, source);
+    // BUG-929：Jimaku 下载的新字幕档不在旧枚举结果里 → 失效缓存，下次打开字幕分类重枚举。
+    if (applied) {
+      _invalidateSubtitleMenuSourcesCache();
+    }
     // 仅在字幕真被应用（解析出 cue）时报「已下载并应用」；cue 为空时
     // _selectSubtitleSource 已弹失败提示，不再叠加误导性的成功提示。
     if (applied && mounted) {
@@ -862,6 +859,9 @@ extension _VideoSubtitle on _VideoHibikiPageState {
       label: p.basename(dest),
     );
     await _selectSubtitleSource(controller, source);
+    // BUG-929：导入了新外挂字幕档，它不在旧枚举结果里 → 失效缓存，下次打开「字幕」分类
+    // 重新枚举把它列进字幕轨列表。
+    _invalidateSubtitleMenuSourcesCache();
     debugPrint(
       '[hibiki-drop] [video-playback] externalSubtitle imported '
       'path=$dest',

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -982,6 +982,13 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   List<SubtitleSource> _subtitleMenuSources = const <SubtitleSource>[];
   bool _subtitleMenuLoading = false;
 
+  /// BUG-929：`_subtitleMenuSources` 已成功枚举时对应的本地视频路径。字幕轨枚举
+  /// （ffprobe 探测内嵌轨 + 同目录外挂）按此 key 记忆：同一视频重开「字幕」分类直接
+  /// 用缓存渲染，不再每次重跑 ffprobe 显加载条、也不再把已枚举出的字幕轨先清空重来
+  /// （用户报「字幕轨每次都要加载、明明没可加载的地方；之前有的字幕还会消失要等」）。
+  /// null=尚未为当前视频枚举 / 已失效（换视频、导入新字幕档）→ 下次打开重新枚举。
+  String? _subtitleMenuSourcesPath;
+
   /// 当前视频是否有内封章节（TODO-424）：控制条章节入口按钮的显隐门控。章节列表是
   /// [VideoPlayerController.refreshChapters] open 后**异步**填充的，故缓存这个布尔并由
   /// [_onControllerChaptersChanged] 监听 controller 通知刷新——章节就绪后触发一次
@@ -2589,6 +2596,13 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
       _missingResource = false;
       _missingRow = null;
       _currentVideoPath = videoPath;
+      // BUG-929：换了视频源（含换集）→ 上一视频的字幕轨枚举缓存作废，清空并复位加载态
+      // + 缓存 key，避免面板停留在「字幕」分类时残留上一集的字幕轨行，下次打开按新路径重枚举。
+      if (clipExportSourceChanged) {
+        _subtitleMenuSources = const <SubtitleSource>[];
+        _subtitleMenuLoading = false;
+        _subtitleMenuSourcesPath = null;
+      }
       // externalSubtitlePath 即持久化值：外挂路径 / `embedded:<n>` / `off:`（显式关闭
       // 哨兵，TODO-818）都按原样写进 _currentSubtitleSource 供菜单高亮。内嵌自动加载
       // （externalSubtitlePath==null）时当前选中由 _currentSubtitleSource 保留（菜单

--- a/hibiki/test/tools/subtitle_menu_reenumerate_guard_test.dart
+++ b/hibiki/test/tools/subtitle_menu_reenumerate_guard_test.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards the BUG-929 fix: opening the video "字幕" (subtitle track) category must
+/// NOT re-run the ffprobe enumeration (`_subtitleSourcesForMenu`) every time, and
+/// the control-bar「字幕轨」button must NOT clear the already-enumerated tracks and
+/// re-enumerate them on every open.
+///
+/// The regression had two owners each running the full ffprobe enumeration on
+/// every open with no memoization:
+///   1. `_showSubtitleSourceMenu` set `_subtitleMenuSources = []` + loading=true
+///      then re-enumerated → already-listed tracks visibly disappeared, then a
+///      LinearProgressIndicator spun ("之前有的字幕还会消失，要等加载").
+///   2. `_ensureSubtitleMenuSourcesLoaded` (fired by the panel opening the
+///      subtitle category) re-enumerated unconditionally → a track-less video
+///      still spun the loading bar on every open ("字幕轨要加载，明明根本没有可加载
+///      的地方").
+///
+/// The fix makes `_ensureSubtitleMenuSourcesLoaded` the single enumeration owner,
+/// memoized by video path (`_subtitleMenuSourcesPath`), and reduces
+/// `_showSubtitleSourceMenu` to purely opening the settings panel. A source-level
+/// guard is the strongest landing layer: the enumeration lives on private methods
+/// of the ~7300-line `_VideoHibikiPageState`, which cannot be stood up in a widget
+/// test without a controller + ffprobe + DB.
+void main() {
+  final String subtitleSrc =
+      File('lib/src/pages/implementations/video_hibiki/subtitle.part.dart')
+          .readAsStringSync();
+  final String pageSrc =
+      File('lib/src/pages/implementations/video_hibiki_page.dart')
+          .readAsStringSync();
+
+  String methodBody(String source, String signatureNeedle) {
+    final int start = source.indexOf(signatureNeedle);
+    expect(start, greaterThanOrEqualTo(0),
+        reason: 'Method "$signatureNeedle" must exist.');
+    // Stop at the next top-level method indentation (`\n  Future` / `\n  void` /
+    // `\n  Widget` / `\n  String` / `\n  bool` / `\n  List`) after the start.
+    final RegExp nextMethod = RegExp(
+      r'\n  (Future|void|Widget|String|bool|List|int)\b',
+    );
+    final Match? next =
+        nextMethod.firstMatch(source.substring(start + signatureNeedle.length));
+    final int end = next == null
+        ? source.length
+        : start + signatureNeedle.length + next.start;
+    return source.substring(start, end);
+  }
+
+  test('_subtitleMenuSourcesPath cache field is declared (BUG-929)', () {
+    expect(pageSrc.contains('String? _subtitleMenuSourcesPath'), isTrue,
+        reason:
+            'The per-video enumeration cache key must exist so the subtitle '
+            'menu does not re-run ffprobe on every open (BUG-929).');
+  });
+
+  test(
+      '_ensureSubtitleMenuSourcesLoaded short-circuits on cached path '
+      '(BUG-929)', () {
+    final String body = methodBody(
+        subtitleSrc, 'Future<void> _ensureSubtitleMenuSourcesLoaded(');
+    expect(
+      body.contains('_subtitleMenuSourcesPath == videoPath'),
+      isTrue,
+      reason:
+          'Must short-circuit when the current video is already enumerated, '
+          'otherwise every subtitle-category open re-runs ffprobe and spins the '
+          'loading bar (BUG-929).',
+    );
+    // On success it must record the path so the short-circuit engages next time.
+    expect(
+      body.contains('_subtitleMenuSourcesPath = videoPath'),
+      isTrue,
+      reason: 'Must record the enumerated video path on success (BUG-929).',
+    );
+  });
+
+  test('_showSubtitleSourceMenu no longer self-enumerates (BUG-929)', () {
+    final String body =
+        methodBody(subtitleSrc, 'Future<void> _showSubtitleSourceMenu(');
+    // The control-bar button must delegate enumeration to
+    // _ensureSubtitleMenuSourcesLoaded; it must not call the ffprobe enumerator
+    // directly (that path cleared + re-enumerated on every open → flicker).
+    expect(
+      body.contains('_subtitleSourcesForMenu('),
+      isFalse,
+      reason:
+          '_showSubtitleSourceMenu must not re-run the ffprobe enumeration; '
+          'it delegates to _ensureSubtitleMenuSourcesLoaded (BUG-929).',
+    );
+    // And it must not set the loading flag true (which drew the spinner on every
+    // open of an already-enumerated / track-less video).
+    expect(
+      body.contains('_subtitleMenuLoading = true'),
+      isFalse,
+      reason: '_showSubtitleSourceMenu must not force the loading spinner on '
+          'every open (BUG-929).',
+    );
+  });
+}


### PR DESCRIPTION
## 现象
视频「字幕」分类顶部「字幕轨」区一直转加载条，明明没有可加载的字幕轨；且之前枚举出的字幕会消失、要等重新加载。

## 根因
字幕轨枚举（ffprobe 探测内嵌轨 + 同目录外挂）**无按视频缓存**，且有两个各自枚举的入口：
- `_showSubtitleSourceMenu`（控制条按钮）每次打开都 `_subtitleMenuSources=[]` + loading=true 再重跑 `_subtitleSourcesForMenu` → 已有字幕先消失、加载条转。
- `_ensureSubtitleMenuSourcesLoaded`（面板「字幕」分类打开事件驱动）无条件重枚举 → 无轨视频枚举恒空却每次显加载条。

## 修复（根因）
- 新增按视频路径的枚举缓存 key `_subtitleMenuSourcesPath`。
- `_ensureSubtitleMenuSourcesLoaded` 成为**唯一枚举者** + 缓存短路 `if (_subtitleMenuSourcesPath == videoPath) return;`，成功记 key、失败不记（下次重试）。
- `_showSubtitleSourceMenu` 退化为纯打开面板（枚举交给面板打开必触发的回调），消除清空闪烁与重复枚举。
- 缓存失效：换视频/换集复位；导入外挂字幕 / Jimaku 下载后 `_invalidateSubtitleMenuSourcesCache()` 让新档下次列进。

## 测试
- `hibiki/test/tools/subtitle_menu_reenumerate_guard_test.dart` 源码扫描守卫 3 用例全绿。
- 全量 `flutter analyze` 无 issue。
- ⚠️ 真机复测（播放路径）待验：Windows 离屏 / Android 模拟器打开有/无内嵌轨视频、重开字幕分类观察加载条不再每次转、已枚举字幕不消失。

BUG-929