### PR TITLE
fix(video): BUG-930 字幕列表调宽把手恢复 resizeLeftRight 光标

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 909 条。点号进各自文件。
+> 共 910 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-930](bugs/BUG-930-subtitle-list-resize-cursor.md) | ✅ | ✅ | 视频字幕列表左缘调宽把手 hover 不显 resizeLeftRight（左右箭头）光标 |
 | [BUG-928](bugs/BUG-928-video-card-16x9-gap.md) | ✅ | ✅ | 视频卡对标准 16:9 封面留空隙·封面比例随标题长短浮动 |
 | [BUG-927](bugs/BUG-927-reader-native-selection-blocks-lookup-and-rightclick-crash.md) | ✅ | ✅ | 阅读器原生选区残留卡住查词 + 右键闪退 |
 | [BUG-926](bugs/BUG-926-popup-touch-copy-disabled.md) | ✅ | ✅ | 词典弹窗触屏无法复制释义(撤回BUG-762全量禁选) |

--- a/docs/bugs/BUG-930-subtitle-list-resize-cursor.md
+++ b/docs/bugs/BUG-930-subtitle-list-resize-cursor.md
@@ -1,0 +1,12 @@
+## BUG-930 · 视频字幕列表左缘调宽把手 hover 不显 resizeLeftRight（左右箭头）光标
+- **报告**：2026-07-19（用户：鼠标放上去没有变成调整样式，就是左右箭头的）
+- **真实性**：✅ 真 bug。字幕列表**已有**左边缘宽度拖拽把手（`_subtitleListResizeHandle`，BUG-877：`resizeLeftRight` 光标 + 拖拽调宽 + 双击复位 + 持久化 `videoSubtitleListWidth`），但桌面 hover 时光标始终是箭头、看不到调宽提示。
+  - 根因：字幕列表侧栏整列被 `_withSubtitleListCursorReveal` 包裹（`controls_visibility.part.dart:258`），其 `onHover` **每帧无条件**经 `_forceRevealOsCursorForPanel`（`controls_visibility.part.dart:231`）走 `SystemChannels.mouseCursor.invokeMethod('activateSystemCursor', {kind:'basic'})` **原生强设** OS 光标为 `basic`（箭头）。
+  - 这是 BUG-391 r5 对「从视频列（控制条淡出 `cursor:none`）跨进侧栏时残留隐藏光标」的推测性缓解——但它绕过框架 MouseTracker、**每帧**原生 SetCursor(箭头)。即便指针在把手上、框架已为把手 MouseRegion 解析出 `resizeLeftRight`，也会被每帧原生「强设 basic」立刻盖回箭头 → 整个面板（含左缘 8px 把手）光标恒为箭头，调宽光标永远出不来。
+  - 即 BUG-391 的光标唤回缓解**踩踏**了 BUG-877 的调宽把手光标。
+- **[x] ① 已修复** — 让 `_forceRevealOsCursorForPanel` 在指针悬于把手时**让位**（不再原生强设 basic），把光标交给框架为把手声明的 `resizeLeftRight`；BUG-391 在面板其余区域的缓解保持不变（blast radius 最小）。
+  - 主壳新增标志 `bool _pointerOverSubtitleResizeHandle`（`video_hibiki_page.dart`），把手 `_subtitleListResizeHandle` 的 `MouseRegion` 接 `onEnter`→置真 / `onExit`→复位（`subtitle.part.dart`）。
+  - `_forceRevealOsCursorForPanel` 开头加 `if (_pointerOverSubtitleResizeHandle) return;`（在原生 `activateSystemCursor` 之前），把手上不再原生强设箭头（`controls_visibility.part.dart`）。
+  - 根因层面：原生「残留光标唤回」缓解现在对「已明确要什么光标」的把手区域让位；enter 早于同帧 parent onHover 处理，稳态下把手光标即为 resize，退出把手复位、面板本体仍走 basic 唤回。提交哈希：<PENDING>
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/video_subtitle_resize_handle_cursor_guard_test.dart`：① 源码扫描守卫，断言 `_forceRevealOsCursorForPanel` 在原生 `activateSystemCursor` **之前**有 `if (_pointerOverSubtitleResizeHandle) return;` 让位门控、把手 `MouseRegion` 保留 `resizeLeftRight` 且 `onEnter/onExit` 翻标志；② headless 行为测试，用同构布局（外层声明式 opaque basic + 内层把手 MouseRegion 叠面板左缘）证框架层把手上光标解析为 `resizeLeftRight`、面板本体为 `basic`。提交哈希：<PENDING>
+- **备注**：#84039 原生 `SetCursor` 竞态 headless 永远复现不了，故「原生强设是否真被让位」的最终有效性需 **Windows 真机验证**（合入硬门槛）；源码守卫只锁「让位门控 + 把手 enter/exit 接线」结构，行为测试只证框架层结构前提。真机验收：把鼠标移到视频字幕列表左边缘，光标变左右箭头、可拖拽调宽；移开把手回箭头；面板本体光标仍可见（不粘 none）。

--- a/docs/bugs/BUG-930-subtitle-list-resize-cursor.md
+++ b/docs/bugs/BUG-930-subtitle-list-resize-cursor.md
@@ -7,6 +7,6 @@
 - **[x] ① 已修复** — 让 `_forceRevealOsCursorForPanel` 在指针悬于把手时**让位**（不再原生强设 basic），把光标交给框架为把手声明的 `resizeLeftRight`；BUG-391 在面板其余区域的缓解保持不变（blast radius 最小）。
   - 主壳新增标志 `bool _pointerOverSubtitleResizeHandle`（`video_hibiki_page.dart`），把手 `_subtitleListResizeHandle` 的 `MouseRegion` 接 `onEnter`→置真 / `onExit`→复位（`subtitle.part.dart`）。
   - `_forceRevealOsCursorForPanel` 开头加 `if (_pointerOverSubtitleResizeHandle) return;`（在原生 `activateSystemCursor` 之前），把手上不再原生强设箭头（`controls_visibility.part.dart`）。
-  - 根因层面：原生「残留光标唤回」缓解现在对「已明确要什么光标」的把手区域让位；enter 早于同帧 parent onHover 处理，稳态下把手光标即为 resize，退出把手复位、面板本体仍走 basic 唤回。提交哈希：<PENDING>
-- **[x] ② 已加自动化测试** — `hibiki/test/pages/video_subtitle_resize_handle_cursor_guard_test.dart`：① 源码扫描守卫，断言 `_forceRevealOsCursorForPanel` 在原生 `activateSystemCursor` **之前**有 `if (_pointerOverSubtitleResizeHandle) return;` 让位门控、把手 `MouseRegion` 保留 `resizeLeftRight` 且 `onEnter/onExit` 翻标志；② headless 行为测试，用同构布局（外层声明式 opaque basic + 内层把手 MouseRegion 叠面板左缘）证框架层把手上光标解析为 `resizeLeftRight`、面板本体为 `basic`。提交哈希：<PENDING>
+  - 根因层面：原生「残留光标唤回」缓解现在对「已明确要什么光标」的把手区域让位；enter 早于同帧 parent onHover 处理，稳态下把手光标即为 resize，退出把手复位、面板本体仍走 basic 唤回。提交哈希：78f5731cb
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/video_subtitle_resize_handle_cursor_guard_test.dart`：① 源码扫描守卫，断言 `_forceRevealOsCursorForPanel` 在原生 `activateSystemCursor` **之前**有 `if (_pointerOverSubtitleResizeHandle) return;` 让位门控、把手 `MouseRegion` 保留 `resizeLeftRight` 且 `onEnter/onExit` 翻标志；② headless 行为测试，用同构布局（外层声明式 opaque basic + 内层把手 MouseRegion 叠面板左缘）证框架层把手上光标解析为 `resizeLeftRight`、面板本体为 `basic`。提交哈希：78f5731cb
 - **备注**：#84039 原生 `SetCursor` 竞态 headless 永远复现不了，故「原生强设是否真被让位」的最终有效性需 **Windows 真机验证**（合入硬门槛）；源码守卫只锁「让位门控 + 把手 enter/exit 接线」结构，行为测试只证框架层结构前提。真机验收：把鼠标移到视频字幕列表左边缘，光标变左右箭头、可拖拽调宽；移开把手回箭头；面板本体光标仍可见（不粘 none）。

--- a/hibiki/lib/src/pages/implementations/video_hibiki/controls_visibility.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/controls_visibility.part.dart
@@ -230,6 +230,10 @@ extension _VideoControlsVisibility on _VideoHibikiPageState {
   /// `SystemMouseCursors.basic.kind == 'basic'`）。
   void _forceRevealOsCursorForPanel(int device) {
     if (!_isDesktopVideoControls) return;
+    // BUG-930：悬在字幕列表宽度拖拽把手上时**不**原生强设 basic——否则每帧 SetCursor(箭头)
+    // 会盖掉框架为把手下发的 resizeLeftRight，用户永远看不到调宽光标。让位给把手 MouseRegion
+    // 声明的 resize 光标；把手区域几何上就是「已明确要什么光标」，无需本层的残留唤回缓解。
+    if (_pointerOverSubtitleResizeHandle) return;
     SystemChannels.mouseCursor.invokeMethod<void>(
       'activateSystemCursor',
       <String, dynamic>{'device': device, 'kind': 'basic'},

--- a/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
@@ -1127,6 +1127,12 @@ extension _VideoSubtitle on _VideoHibikiPageState {
   }) {
     return MouseRegion(
       cursor: SystemMouseCursors.resizeLeftRight,
+      // BUG-930：进 / 出把手时翻 [_pointerOverSubtitleResizeHandle]，让侧栏
+      // [_forceRevealOsCursorForPanel] 的每帧原生「强设 basic」在把手上让位，
+      // 使框架声明的 resizeLeftRight 光标不被盖掉（enter 早于同帧 parent onHover 处理，
+      // 稳态下光标即为 resize；退出把手复位、面板其余区域仍走 basic 唤回缓解）。
+      onEnter: (PointerEnterEvent _) => _pointerOverSubtitleResizeHandle = true,
+      onExit: (PointerExitEvent _) => _pointerOverSubtitleResizeHandle = false,
       child: GestureDetector(
         behavior: HitTestBehavior.translucent,
         onHorizontalDragUpdate: (DragUpdateDetails details) {

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -939,6 +939,14 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// 回到读持久化值。避免每次 `onHorizontalDragUpdate` 都写 DB。
   double? _subtitleListWidthDrag;
 
+  /// BUG-930：鼠标是否正悬在字幕列表宽度拖拽把手（[_subtitleListResizeHandle]）上。
+  /// 把手要显 `resizeLeftRight`（左右箭头）光标，但侧栏 [_withSubtitleListCursorReveal]
+  /// 的 `onHover` 每帧经 [_forceRevealOsCursorForPanel] **原生强设** OS 光标为 `basic`
+  /// （箭头，BUG-391 缓解），会盖掉框架为把手下发的 resize 光标 → 调宽光标永远出不来。
+  /// 悬在把手上时置真，让 [_forceRevealOsCursorForPanel] 让位（不再强设 basic），把光标
+  /// 交给把手 MouseRegion 声明的 resize。只被 hover 回调读、不触发重建，故不走 setState。
+  bool _pointerOverSubtitleResizeHandle = false;
+
   /// 剧集列表 push-aside 侧栏可见性（TODO-638）。剧集列表此前是
   /// `showModalBottomSheet`（底部弹层），与其它侧栏（字幕列表 push-aside、设置 /
   /// 倍速等 overlay）显示风格不一致。改成与字幕列表同款的 push-aside 侧栏后，可见性

--- a/hibiki/test/pages/video_subtitle_resize_handle_cursor_guard_test.dart
+++ b/hibiki/test/pages/video_subtitle_resize_handle_cursor_guard_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'video_hibiki_page_source_corpus.dart';
+
+/// BUG-930：视频字幕列表左边缘的宽度拖拽把手（[_subtitleListResizeHandle]，BUG-877）在桌面
+/// hover 时不显 `resizeLeftRight`（左右箭头）光标——用户看不到「可调宽」的提示。
+///
+/// 根因：字幕列表侧栏整列被 [_withSubtitleListCursorReveal] 包裹，其 `onHover` **每帧无条件**
+/// 经 [_forceRevealOsCursorForPanel] 走 `SystemChannels.mouseCursor.activateSystemCursor`
+/// **原生强设** OS 光标为 `basic`（箭头，BUG-391 对「跨列残留隐藏光标」的推测性缓解）。这个
+/// 原生 SetCursor 绕过框架 MouseTracker，即便指针在把手上、框架已为把手 MouseRegion 解析出
+/// `resizeLeftRight`，也会被每帧的原生「强设 basic」立刻盖回箭头 → 调宽光标永远出不来。
+///
+/// 根因修：把手进 / 出时翻 [_pointerOverSubtitleResizeHandle]；[_forceRevealOsCursorForPanel]
+/// 在该标志为真时**提前返回、不再原生强设 basic**，把光标让位给把手 MouseRegion 声明的 resize。
+/// BUG-391 在面板其余区域的缓解**保持不变**（把手区域本就「已明确要什么光标」，无需残留唤回）。
+///
+/// **诚实标注**：#84039 的原生 `SetCursor` 竞态 headless 永远复现不了，故「原生强设是否真被
+/// 让位」的最终有效性仍需 Windows 真机验证。源码守卫只锁「让位门控 + 把手 enter/exit 接线」这一
+/// 结构前提；下方行为测试只在同构布局里证「框架层把手 MouseRegion 能解析出 resizeLeftRight」。
+void main() {
+  group('源码守卫：字幕列表宽度把手光标不被原生唤回盖掉（BUG-930）', () {
+    late String src;
+    setUpAll(() {
+      src = readVideoHibikiSource();
+    });
+
+    test('主壳声明 _pointerOverSubtitleResizeHandle 标志', () {
+      expect(src.contains('bool _pointerOverSubtitleResizeHandle = false;'),
+          isTrue,
+          reason: '需有「指针是否在把手上」的标志，供 _forceRevealOsCursorForPanel 让位');
+    });
+
+    test('_forceRevealOsCursorForPanel 悬在把手上时提前返回（不原生强设 basic）', () {
+      final int start =
+          src.indexOf('void _forceRevealOsCursorForPanel(int device) {');
+      expect(start, greaterThanOrEqualTo(0), reason: '应有直发 OS 光标通道的 helper');
+      final int end = src.indexOf('\n  }', start) + 4;
+      expect(end, greaterThan(start));
+      final String body = src.substring(start, end);
+
+      final int guardIdx =
+          body.indexOf('if (_pointerOverSubtitleResizeHandle) return;');
+      expect(guardIdx, greaterThanOrEqualTo(0),
+          reason: '把手上必须让位：提前 return，不再原生强设 basic');
+      final int invokeIdx =
+          body.indexOf('SystemChannels.mouseCursor.invokeMethod');
+      expect(invokeIdx, greaterThan(guardIdx),
+          reason: '让位门控必须在原生 activateSystemCursor 之前（否则仍会先盖掉 resize 光标）');
+    });
+
+    test('_subtitleListResizeHandle 保留 resize 光标且 enter/exit 翻标志', () {
+      final int start = src.indexOf('Widget _subtitleListResizeHandle({');
+      expect(start, greaterThanOrEqualTo(0), reason: '应有字幕列表宽度拖拽把手');
+      final int end = src.indexOf('\n  Widget ', start + 1);
+      final String body = src.substring(start, end > start ? end : src.length);
+
+      expect(
+          body.contains('cursor: SystemMouseCursors.resizeLeftRight'), isTrue,
+          reason: '把手 MouseRegion 必须声明 resizeLeftRight（左右箭头）光标');
+      expect(body.contains('_pointerOverSubtitleResizeHandle = true'), isTrue,
+          reason: 'onEnter 必须置标志真，让 _forceRevealOsCursorForPanel 让位');
+      expect(body.contains('_pointerOverSubtitleResizeHandle = false'), isTrue,
+          reason: 'onExit 必须复位标志，面板其余区域仍走 basic 唤回缓解');
+      expect(body.contains('onEnter:'), isTrue, reason: '需接线 onEnter 置标志');
+      expect(body.contains('onExit:'), isTrue, reason: '需接线 onExit 复位标志');
+    });
+  });
+
+  // 诚实标注：headless 复现不了 #84039 原生 SetCursor 竞态，本行为测试只证**框架层**结构前提
+  // ——把手 MouseRegion（叠在面板之上、声明 resizeLeftRight）能在 MouseTracker 解析中胜过外层
+  // 声明式 basic 包裹层。真正被质疑的「原生每帧强设 basic 是否已让位」仅 Windows 真机可验。
+  group('行为：同构布局下把手上光标解析为 resizeLeftRight（BUG-930·headless 对真机零增益）', () {
+    testWidgets('把手叠在面板左缘、外层声明 basic：把手上光标 = resizeLeftRight',
+        (WidgetTester tester) async {
+      const double panelWidth = 300;
+      bool overHandle = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                const Expanded(child: ColoredBox(color: Color(0xFF000000))),
+                SizedBox(
+                  width: panelWidth,
+                  // 同构外层：_withSidePanelOpaqueCursor 声明式 opaque basic。
+                  child: MouseRegion(
+                    opaque: true,
+                    cursor: SystemMouseCursors.basic,
+                    // 同构救场层：_withSubtitleListCursorReveal（opaque:false，onHover 唤回）。
+                    child: MouseRegion(
+                      opaque: false,
+                      onHover: (PointerHoverEvent _) {},
+                      child: Stack(
+                        children: <Widget>[
+                          const Positioned.fill(
+                            child: ColoredBox(color: Color(0xEE112233)),
+                          ),
+                          Positioned(
+                            left: 0,
+                            top: 0,
+                            bottom: 0,
+                            // 同构把手：叠在面板左缘、声明 resizeLeftRight + enter/exit 翻标志。
+                            child: MouseRegion(
+                              cursor: SystemMouseCursors.resizeLeftRight,
+                              onEnter: (PointerEnterEvent _) =>
+                                  overHandle = true,
+                              onExit: (PointerExitEvent _) =>
+                                  overHandle = false,
+                              child: const SizedBox(width: 8),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final TestGesture gesture =
+          await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(gesture.removePointer);
+
+      String kind(MouseCursor c) =>
+          c is SystemMouseCursor ? c.kind : c.toString();
+      MouseCursor active() =>
+          RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1)!;
+
+      // 面板本体（把手右侧）：外层声明式 basic 胜出。
+      await tester.pump();
+      final Size size = tester.getSize(find.byType(MaterialApp));
+      final double panelLeft = size.width - panelWidth;
+      await gesture.moveTo(Offset(panelLeft + 150, size.height / 2));
+      await tester.pump();
+      expect(kind(active()), 'basic', reason: '面板本体上光标为 basic（外层声明式胜出）');
+      expect(overHandle, isFalse, reason: '尚未进把手');
+
+      // 把手上（面板左缘 8px 内）：把手 MouseRegion（更靠前）解析出 resizeLeftRight。
+      await gesture.moveTo(Offset(panelLeft + 4, size.height / 2));
+      await tester.pump();
+      expect(overHandle, isTrue,
+          reason: '进把手应翻标志（真码据此让 _forceRevealOsCursorForPanel 让位）');
+      expect(kind(active()), 'resizeLeftRight',
+          reason: '把手上框架层光标必须解析为 resizeLeftRight（叠在面板之上、胜过外层 basic）');
+
+      // 收尾：移出所有 region，复位 cursor session 防跨测试泄漏。
+      await gesture.moveTo(const Offset(-100, -100));
+      await tester.pump();
+    });
+  });
+}


### PR DESCRIPTION
## 问题
视频字幕列表左边缘的宽度拖拽把手（`_subtitleListResizeHandle`，BUG-877 已实现调宽 + 持久化 + 双击复位）在桌面 hover 时**不显 `resizeLeftRight`（左右箭头）光标**，用户看不到「可调宽」提示（用户报：鼠标放上去没有变成调整样式，就是左右箭头的）。

## 根因
字幕列表侧栏整列被 `_withSubtitleListCursorReveal` 包裹，其 `onHover` **每帧无条件**经 `_forceRevealOsCursorForPanel` 走 `SystemChannels.mouseCursor.activateSystemCursor` **原生强设** OS 光标为 `basic`（箭头，BUG-391 r5 对「跨列残留隐藏光标」的推测性缓解）。该原生 SetCursor 绕过框架 MouseTracker——即便指针在把手上、框架已解析出 `resizeLeftRight`，也被每帧原生「强设 basic」立刻盖回箭头。即 BUG-391 的光标唤回缓解**踩踏**了 BUG-877 的调宽把手光标。

## 修复（根因，blast radius 最小）
让 `_forceRevealOsCursorForPanel` 在指针悬于把手时**让位**（不再原生强设 basic），把光标交给框架为把手声明的 resize；BUG-391 在面板其余区域的缓解保持不变。
- 主壳加标志 `_pointerOverSubtitleResizeHandle`；把手 `MouseRegion` 接 `onEnter`→真 / `onExit`→复位。
- `_forceRevealOsCursorForPanel` 开头 `if (_pointerOverSubtitleResizeHandle) return;`（在原生 `activateSystemCursor` 之前）。

## 测试
`test/pages/video_subtitle_resize_handle_cursor_guard_test.dart`：源码守卫（让位门控在原生调用前 + 把手 enter/exit 接线 + 保留 resize 光标）+ headless 行为测试（同构布局证框架层把手上光标解析为 `resizeLeftRight`、面板本体为 `basic`）。`flutter analyze` 4 项 0 issue；相关守卫（BUG-391 光标唤回 / BUG-877~881 wiring）全绿。

## ⚠️ 真机验收（合入硬门槛）
#84031 原生 `SetCursor` 竞态 headless 复现不了，「原生强设是否真被让位」需 **Windows 真机**验证：鼠标移到视频字幕列表左边缘→光标变左右箭头、可拖拽调宽；移开→回箭头；面板本体光标仍可见（不粘 none）。

BUG: docs/bugs/BUG-930-subtitle-list-resize-cursor.md