### PR TITLE
fix(video): 收藏快捷键不再唤起进度条+视频提示统一左上角OSD (BUG-931)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 909 条。点号进各自文件。
+> 共 910 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-931](bugs/BUG-931-video-favorite-osd-topleft.md) | ✅ | ✅ | 视频收藏快捷键唤起进度条+底部提示统一左上角OSD |
 | [BUG-928](bugs/BUG-928-video-card-16x9-gap.md) | ✅ | ✅ | 视频卡对标准 16:9 封面留空隙·封面比例随标题长短浮动 |
 | [BUG-927](bugs/BUG-927-reader-native-selection-blocks-lookup-and-rightclick-crash.md) | ✅ | ✅ | 阅读器原生选区残留卡住查词 + 右键闪退 |
 | [BUG-926](bugs/BUG-926-popup-touch-copy-disabled.md) | ✅ | ✅ | 词典弹窗触屏无法复制释义(撤回BUG-762全量禁选) |

--- a/docs/bugs/BUG-931-video-favorite-osd-topleft.md
+++ b/docs/bugs/BUG-931-video-favorite-osd-topleft.md
@@ -1,0 +1,8 @@
+## BUG-931 · 视频收藏快捷键唤起进度条+底部提示统一左上角OSD
+- **报告**：2026-07-20（用户：）
+- **真实性**：✅ 真 bug。根因两处：
+  - 进度条：`hibiki/lib/src/pages/implementations/video_hibiki_page.dart:4929` `_toggleFavoriteCurrentCue()` 在收藏前调 `_pokeControlsVisible()`，派发合成 hover 唤醒 media_kit 控制条 → 底栏 seekbar 进度条弹出（碍眼）。
+  - 提示位置：视频页收藏/复制/无句可选/资源重链/需重启渲染等提示走全局 `HibikiToast.show(...)`（桌面 `bottom:50` 居中、移动端 `ToastGravity.BOTTOM`），落在屏幕底部；而视频页已有左上角 OSD `_showOsd(...)`（字幕/锁定/画质切换都用它）。两套并存导致部分提示在底部。
+- **[x] ① 已修复** — 删收藏路径的 `_pokeControlsVisible()`（仅收藏这一处；seek/重播仍保留 poke）；把视频页 9 处底部 `HibikiToast.show(...)` 全部改走左上角 `_showOsd(...)`（`video_hibiki_page.dart` + `video_hibiki/lookup_favorite.part.dart`）。提交见 PR。
+- **[x] ② 已加自动化测试** — 源码扫描守卫 `hibiki/test/pages/video_favorite_osd_guard_test.dart`：断言 `_toggleFavoriteCurrentCue` 体内不再调 `_pokeControlsVisible()`，且 `video_hibiki_page.dart` 与 `video_hibiki/*.part.dart` 全域不再出现 `HibikiToast.show`（视频提示一律走 `_showOsd` 左上角）。
+- **备注**：`_showOsd` 是 `_VideoHibikiPageState` 实例方法，part 文件同私有作用域可直接调。不动全局 `HibikiToast`（阅读器/其它页面仍用底部 toast）。

--- a/hibiki/lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart
@@ -104,7 +104,7 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
   Future<void> _toggleFavoriteSentenceForVideo() async {
     final String sentence = _lastLookupSentence;
     if (sentence.isEmpty) {
-      HibikiToast.show(msg: t.no_sentence_selected);
+      _showOsd(t.no_sentence_selected);
       return;
     }
     final AudioCue? cue = _lastLookupCue;
@@ -133,7 +133,7 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
           );
         });
       }
-      HibikiToast.show(msg: t.favorite_removed);
+      _showOsd(t.favorite_removed, icon: Icons.favorite_border);
       return;
     }
     await repo.add(
@@ -163,7 +163,7 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
         ));
       });
     }
-    HibikiToast.show(msg: t.favorite_added);
+    _showOsd(t.favorite_added, icon: Icons.favorite);
   }
 
   /// 从字幕跳转列表面板行内复制某句文本到剪贴板（TODO-152 子A）。不暂停 / 不查词。
@@ -171,7 +171,7 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
     final String text = cue.text.trim();
     if (text.isEmpty) return;
     Clipboard.setData(ClipboardData(text: text));
-    HibikiToast.show(msg: t.copied_to_clipboard);
+    _showOsd(t.copied_to_clipboard, icon: Icons.copy);
   }
 
   /// 字幕跳转列表面板某句是否已收藏（同步，读缓存 [_favoritedVideoSentences]）。
@@ -241,7 +241,10 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
         _currentVideoSentenceIsFavorited = !wasFavorited;
       }
     });
-    HibikiToast.show(msg: wasFavorited ? t.favorite_removed : t.favorite_added);
+    _showOsd(
+      wasFavorited ? t.favorite_removed : t.favorite_added,
+      icon: wasFavorited ? Icons.favorite_border : Icons.favorite,
+    );
   }
 
   /// 拉本视频已收藏句填充 [_favoritedVideoSentences]（打开字幕跳转列表前调一次）。

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -120,7 +120,6 @@ import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki/src/utils/misc/render_backend_service.dart';
 import 'package:hibiki/src/platform/screen_brightness_controller.dart';
 import 'package:hibiki/src/utils/misc/platform_utils.dart';
-import 'package:hibiki/src/utils/misc/hibiki_toast.dart';
 import 'package:hibiki/src/utils/misc/show_app_dialog.dart';
 import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
@@ -2821,7 +2820,7 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
       _failed = false;
       _failReason = null;
     });
-    HibikiToast.show(msg: t.video_resource_relink_success);
+    _showOsd(t.video_resource_relink_success);
     await _loadSingle(updated);
   }
 
@@ -5300,10 +5299,12 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   Future<void> _toggleFavoriteCurrentCue() async {
     final AudioCue? cue = _currentCueForAction();
     if (cue == null || cue.text.trim().isEmpty) {
-      HibikiToast.show(msg: t.no_sentence_selected);
+      _showOsd(t.no_sentence_selected);
       return;
     }
-    _pokeControlsVisible();
+    // BUG-931：收藏不再唤起 media_kit 控制条——原先那句 poke 会派发合成 hover 把底栏
+    // 进度条弹出来（用户报「碍眼」）。收藏结果走左上角 OSD 即可，无需显现控制条；
+    // seek / 重播仍保留 poke，因为那些操作本就需要看进度。
     await _toggleFavoriteCueForVideo(cue);
   }
 
@@ -5562,7 +5563,7 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
         await RenderBackendService.instance.setImpellerDisabled(true);
     if (!ok || !appModel.platformServices.lifecycle.supportsRestart) {
       // pref 未写成（非 Android）或平台不支持自动重启：降级提示手动重开。
-      if (mounted) HibikiToast.show(msg: t.render_restart_required);
+      if (mounted) _showOsd(t.render_restart_required);
       return;
     }
     try {
@@ -5570,7 +5571,7 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     } catch (e) {
       // 起新进程失败（Process.start 抛错等）→ 降级提示手动重开。
       debugPrint('[render] switch to Skia restart failed: $e');
-      if (mounted) HibikiToast.show(msg: t.render_restart_required);
+      if (mounted) _showOsd(t.render_restart_required);
     }
   }
 

--- a/hibiki/test/pages/video_favorite_osd_guard_test.dart
+++ b/hibiki/test/pages/video_favorite_osd_guard_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'video_hibiki_page_source_corpus.dart';
+
+/// BUG-931：视频播放器里的两个 UX 契约，用源码扫描守卫锁死，防未来重构悄悄回退。
+///
+/// 1) 收藏快捷键（Ctrl+D → `_toggleFavoriteCurrentCue`）**不得**再调
+///    `_pokeControlsVisible()`——那会派发合成 hover 唤醒 media_kit 控制条，把底栏
+///    seekbar 进度条弹出来（用户报「碍眼」）。收藏结果提示走左上角 OSD 即可，不需要
+///    显现控制条。注意 seek / 重播（`_replay*AndPokeControls`）**仍**保留 poke，因为
+///    那些操作本就需要看进度，所以守卫只针对收藏这一处。
+///
+/// 2) 视频页所有短提示统一走左上角 OSD `_showOsd(...)`，**不得**再用底部全局
+///    `HibikiToast.show(...)`（桌面 `bottom:50` 居中 / 移动端 `ToastGravity.BOTTOM`）。
+///    这样收藏加/移除、复制、无句可选、资源重链、需重启渲染等提示都落在屏幕左上角，
+///    与字幕 / 锁定 / 画质切换的 OSD 一致。全局 `HibikiToast` 本身不动（阅读器等其它
+///    页面继续用底部 toast）。
+///
+/// 提取 `_toggleFavoriteCurrentCue` 方法体：从签名起，到下一个 2 空格缩进的成员声明
+/// （`\n  Future<` / `\n  void `）为止。签名/邻接方法名变了这里会取到更大的窗口，
+/// 断言只会更保守（更容易发现误加的 poke），不会漏。
+String _methodBody(String src, String signature) {
+  final int start = src.indexOf(signature);
+  expect(start, greaterThanOrEqualTo(0),
+      reason: '找不到方法签名 `$signature`——视频页收藏入口被重命名了？请更新守卫。');
+  final int bodyStart = start + signature.length;
+  final RegExp nextMember = RegExp(r'\n  (Future<|void |bool |String |int )');
+  final Match? next = nextMember.firstMatch(src.substring(bodyStart));
+  final int end = next == null ? src.length : bodyStart + next.start;
+  return src.substring(start, end);
+}
+
+void main() {
+  group('BUG-931 视频收藏 OSD / 无进度条守卫', () {
+    test('收藏快捷键不再唤起控制条进度条（_toggleFavoriteCurrentCue 无 _pokeControlsVisible）',
+        () {
+      final String src = readVideoHibikiSource();
+      final String body =
+          _methodBody(src, 'Future<void> _toggleFavoriteCurrentCue() async {');
+      expect(
+        body.contains('_pokeControlsVisible'),
+        isFalse,
+        reason: 'BUG-931：收藏不得调 `_pokeControlsVisible()`，否则会把底栏进度条弹出来'
+            '（碍眼）。收藏提示走 `_showOsd` 左上角即可。',
+      );
+      // 正向证据：收藏路径确实改走了左上角 OSD。
+      expect(
+        body.contains('_showOsd(t.no_sentence_selected)'),
+        isTrue,
+        reason: '收藏无句可选时应走左上角 `_showOsd`，不是底部 toast。',
+      );
+    });
+
+    test('视频页所有短提示走左上角 OSD，全域无 HibikiToast.show（底部 toast）', () {
+      final String src = readVideoHibikiSource();
+      expect(
+        src.contains('HibikiToast.show'),
+        isFalse,
+        reason: 'BUG-931：视频页短提示统一走左上角 `_showOsd(...)`；出现 '
+            '`HibikiToast.show` 说明有提示回退到了屏幕底部。',
+      );
+      // 收藏加/移除确实用 OSD（防止有人把提示整个删掉来「绕过」守卫）。
+      expect(src.contains('_showOsd(t.favorite_added'), isTrue,
+          reason: '收藏成功应走左上角 `_showOsd(t.favorite_added ...)`。');
+      expect(src.contains('_showOsd(t.favorite_removed'), isTrue,
+          reason: '取消收藏应走左上角 `_showOsd(t.favorite_removed ...)`。');
+    });
+  });
+}


### PR DESCRIPTION
## 用户诉求
- 视频里按收藏快捷键（Ctrl+D）会把底栏进度条弹出来，碍眼——收藏不要显现进度条。
- 视频底部的各种提示统一挪到屏幕左上角。

## 根因
1. **进度条**：`_toggleFavoriteCurrentCue()`（video_hibiki_page.dart:4929）在收藏前调 `_pokeControlsVisible()`，派发合成 hover 唤醒 media_kit 控制条 → 底栏 seekbar 进度条弹出。
2. **提示位置**：视频页收藏/复制/无句可选/资源重链/需重启渲染等提示走全局 `HibikiToast.show(...)`（桌面 bottom:50 居中 / 移动端 ToastGravity.BOTTOM），落屏幕底部；而视频页已有左上角 OSD `_showOsd(...)`（字幕/锁定/画质切换都用它）。两套并存。

## 修复
- 删收藏路径的 `_pokeControlsVisible()`（**仅收藏这一处**；seek/重播仍保留 poke，因为那些操作本就需要看进度）。
- 把视频页 9 处底部 `HibikiToast.show(...)` 全部改走左上角 `_showOsd(...)`（收藏加/移除还加了 favorite 图标）。移除随之变未使用的 hibiki_toast import。全局 `HibikiToast` 不动（阅读器等其它页面继续用底部 toast）。

## 测试
- 新增源码扫描守卫 `hibiki/test/pages/video_favorite_osd_guard_test.dart`：断言 `_toggleFavoriteCurrentCue` 体内不再 poke，且视频语料全域无 `HibikiToast.show`。
- `flutter analyze` 改动文件 0 issue；相关视频/收藏守卫（video_controls_poke_guard、sentence_favorites_todo047_guard、favorite_word_toast 等）全通过。

## 验证状态
⚠️ 待 Windows 真机复测原始失败路径（按 Ctrl+D 观察进度条不再弹出、提示落左上角）。

BUG-931