### PR TITLE
fix(popup): 制卡加号(+)与相邻图标大小对齐 (BUG-932)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 910 条。点号进各自文件。
+> 共 911 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-932](bugs/BUG-932-popup-mine-plus-size.md) | ✅ | ✅ | 查词弹窗制卡加号(+)比相邻图标小 |
 | [BUG-930](bugs/BUG-930-subtitle-list-resize-cursor.md) | ✅ | ✅ | 视频字幕列表左缘调宽把手 hover 不显 resizeLeftRight（左右箭头）光标 |
 | [BUG-928](bugs/BUG-928-video-card-16x9-gap.md) | ✅ | ✅ | 视频卡对标准 16:9 封面留空隙·封面比例随标题长短浮动 |
 | [BUG-927](bugs/BUG-927-reader-native-selection-blocks-lookup-and-rightclick-crash.md) | ✅ | ✅ | 阅读器原生选区残留卡住查词 + 右键闪退 |

--- a/docs/bugs/BUG-932-popup-mine-plus-size.md
+++ b/docs/bugs/BUG-932-popup-mine-plus-size.md
@@ -1,0 +1,6 @@
+## BUG-932 · 查词弹窗制卡加号(+)比相邻图标小
+- **报告**：2026-07-20（用户：截图反馈「加号和其他的 icon 大小不一样」）
+- **真实性**：✅ 真 bug。查词弹窗词条头动作栏（音量/收藏/在Anki打开/制卡/tune）里，音量·收藏·open-anki·tune 都是 `.inline-action-button > svg { width:1em; height:1em }` 的内联 SVG（`viewBox 0 0 24 24` 近乎铺满，18px 下可见 ≈14px）；唯独制卡按钮 `.mine-button` 静息态是**文本字形 `'+'`**（TODO-1325 应用户要求保留 `+ / ✓ / ✓↩` 文本标记，不走 SVG）。四者共用 `font-size:18px`（`hibiki/assets/popup/popup.css:256-267` 合并选择器），但一个文本 `'+'` 字形只占 em 盒约一半高（≈9px），SVG 却铺满 1em，故静息加号目测明显比其余图标小/不齐。根因：`hibiki/assets/popup/popup.css:256-267`（`.mine-button` 与 SVG 图标按钮共用 18px 字号，未补偿文本字形的空白）。
+- **[x] ① 已修复** — 仅给静息 `'+'` 态（未制卡 = 无 `.duplicate` 类）单独放大字号，使其与相邻 1em SVG 图标目测齐平；已制卡 `✓` / `✓↩`（带 `.duplicate` / `.latest`）是高字形本就接近、且 `.latest` 各有专属尺寸，保持不动。表头行高由词条大标题主导，放大按钮不改行高。改 `hibiki/assets/popup/popup.css` 新增 `.mine-button:not(.duplicate){ font-size:24px }`，同步两份 vendored 镜像（`hibiki/assets/browser_extension/vendor/popup.css` + `tools/browser-extension/vendor/popup.css`）并重生成两份 `content.css`（`node tools/browser-extension/scripts/generate-content-css.mjs`）。提交：<commit-pending>
+- **[x] ② 已加自动化测试** — `hibiki/test/dictionary/popup_cards_nav_icon_guard_test.dart` 新增 #8：三 CSS 镜像均须有 `.mine-button:not(.duplicate)` 且 `font-size > 18px`（补偿文本字形），防回退。提交：<commit-pending>
+- **备注**：TODO-1325 明确制卡按钮保留文本标记不走 SVG，故本修不改成 SVG，只在文本层放大静息 `'+'`。像素值 24px 需真机目视微调。

--- a/hibiki/assets/browser_extension/vendor/content.css
+++ b/hibiki/assets/browser_extension/vendor/content.css
@@ -307,6 +307,17 @@
     font-size: 15px;
 }
 
+/* BUG-932: 制卡按钮静息态 '+' 是文本字形（TODO-1325 应用户要求保留 + / ✓ / ✓↩ 文本
+   标记，不走 SVG），与相邻 audio/favorite/open-anki/tune 的 1em SVG 图标共用上面的
+   font-size:18px；但一个文本 '+' 字形只占 em 盒约一半高（≈9px），SVG 却铺满 1em
+   （可见 ≈14px），故静息加号目测明显比其余图标小/不齐。仅给静息 '+' 态（未制卡 =
+   无 .duplicate 类）单独放大字号补偿文本字形的空白，使其与 SVG 图标目测齐平；已制卡
+   ✓ / ✓↩（.duplicate / .latest）是高字形本就接近、且各有专属尺寸，保持不动。表头行高
+   由词条大标题主导，放大按钮不改行高。守卫见 popup_cards_nav_icon_guard #8。 */
+.mine-button:not(.duplicate) {
+    font-size: 24px;
+}
+
 .mine-button:disabled {
     opacity: 0.15;
 }

--- a/hibiki/assets/browser_extension/vendor/popup.css
+++ b/hibiki/assets/browser_extension/vendor/popup.css
@@ -330,6 +330,17 @@ html {
     font-size: 15px;
 }
 
+/* BUG-932: 制卡按钮静息态 '+' 是文本字形（TODO-1325 应用户要求保留 + / ✓ / ✓↩ 文本
+   标记，不走 SVG），与相邻 audio/favorite/open-anki/tune 的 1em SVG 图标共用上面的
+   font-size:18px；但一个文本 '+' 字形只占 em 盒约一半高（≈9px），SVG 却铺满 1em
+   （可见 ≈14px），故静息加号目测明显比其余图标小/不齐。仅给静息 '+' 态（未制卡 =
+   无 .duplicate 类）单独放大字号补偿文本字形的空白，使其与 SVG 图标目测齐平；已制卡
+   ✓ / ✓↩（.duplicate / .latest）是高字形本就接近、且各有专属尺寸，保持不动。表头行高
+   由词条大标题主导，放大按钮不改行高。守卫见 popup_cards_nav_icon_guard #8。 */
+.mine-button:not(.duplicate) {
+    font-size: 24px;
+}
+
 .mine-button:disabled {
     opacity: 0.15;
 }

--- a/hibiki/assets/popup/popup.css
+++ b/hibiki/assets/popup/popup.css
@@ -330,6 +330,17 @@ html {
     font-size: 15px;
 }
 
+/* BUG-932: 制卡按钮静息态 '+' 是文本字形（TODO-1325 应用户要求保留 + / ✓ / ✓↩ 文本
+   标记，不走 SVG），与相邻 audio/favorite/open-anki/tune 的 1em SVG 图标共用上面的
+   font-size:18px；但一个文本 '+' 字形只占 em 盒约一半高（≈9px），SVG 却铺满 1em
+   （可见 ≈14px），故静息加号目测明显比其余图标小/不齐。仅给静息 '+' 态（未制卡 =
+   无 .duplicate 类）单独放大字号补偿文本字形的空白，使其与 SVG 图标目测齐平；已制卡
+   ✓ / ✓↩（.duplicate / .latest）是高字形本就接近、且各有专属尺寸，保持不动。表头行高
+   由词条大标题主导，放大按钮不改行高。守卫见 popup_cards_nav_icon_guard #8。 */
+.mine-button:not(.duplicate) {
+    font-size: 24px;
+}
+
 .mine-button:disabled {
     opacity: 0.15;
 }

--- a/hibiki/test/dictionary/popup_cards_nav_icon_guard_test.dart
+++ b/hibiki/test/dictionary/popup_cards_nav_icon_guard_test.dart
@@ -87,6 +87,24 @@ void main() {
         expect(m!.group(0)!.contains('Emoji'), isFalse,
             reason: '字体栈不含彩色 emoji 字体');
       });
+
+      test('#8 静息制卡 + 单独放大字号，与相邻 1em SVG 图标目测齐平（BUG-932）', () {
+        // 制卡按钮静息态 '+' 是文本字形（TODO-1325 保留文本标记不走 SVG），与音量/
+        // 收藏/open-anki/tune 的内联 SVG 共用合并选择器 font-size:18px；但文本 '+'
+        // 只占 em 盒约一半高，SVG 铺满 1em，故同 18px 下加号目测明显更小。必须给
+        // 静息态（未制卡 = 无 .duplicate 类）单独放大字号补偿，否则回退成大小不一。
+        final RegExpMatch? m =
+            RegExp(r'\.mine-button:not\(\.duplicate\)\s*\{([^}]*)\}')
+                .firstMatch(css);
+        expect(m, isNotNull,
+            reason: '缺 .mine-button:not(.duplicate) 静息态放大规则，加号会比 SVG 图标小');
+        final RegExpMatch? fs =
+            RegExp(r'font-size\s*:\s*(\d+)px').firstMatch(m!.group(1)!);
+        expect(fs, isNotNull, reason: '静息加号规则必须声明 font-size');
+        expect(int.parse(fs!.group(1)!), greaterThan(18),
+            reason: '静息 + 字号须大于图标共用的 18px 以补偿文本字形空白，'
+                '否则加号目测比 audio/favorite/tune 图标小（BUG-932 回退）');
+      });
     });
   });
 

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -307,6 +307,17 @@
     font-size: 15px;
 }
 
+/* BUG-932: 制卡按钮静息态 '+' 是文本字形（TODO-1325 应用户要求保留 + / ✓ / ✓↩ 文本
+   标记，不走 SVG），与相邻 audio/favorite/open-anki/tune 的 1em SVG 图标共用上面的
+   font-size:18px；但一个文本 '+' 字形只占 em 盒约一半高（≈9px），SVG 却铺满 1em
+   （可见 ≈14px），故静息加号目测明显比其余图标小/不齐。仅给静息 '+' 态（未制卡 =
+   无 .duplicate 类）单独放大字号补偿文本字形的空白，使其与 SVG 图标目测齐平；已制卡
+   ✓ / ✓↩（.duplicate / .latest）是高字形本就接近、且各有专属尺寸，保持不动。表头行高
+   由词条大标题主导，放大按钮不改行高。守卫见 popup_cards_nav_icon_guard #8。 */
+.mine-button:not(.duplicate) {
+    font-size: 24px;
+}
+
 .mine-button:disabled {
     opacity: 0.15;
 }

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -330,6 +330,17 @@ html {
     font-size: 15px;
 }
 
+/* BUG-932: 制卡按钮静息态 '+' 是文本字形（TODO-1325 应用户要求保留 + / ✓ / ✓↩ 文本
+   标记，不走 SVG），与相邻 audio/favorite/open-anki/tune 的 1em SVG 图标共用上面的
+   font-size:18px；但一个文本 '+' 字形只占 em 盒约一半高（≈9px），SVG 却铺满 1em
+   （可见 ≈14px），故静息加号目测明显比其余图标小/不齐。仅给静息 '+' 态（未制卡 =
+   无 .duplicate 类）单独放大字号补偿文本字形的空白，使其与 SVG 图标目测齐平；已制卡
+   ✓ / ✓↩（.duplicate / .latest）是高字形本就接近、且各有专属尺寸，保持不动。表头行高
+   由词条大标题主导，放大按钮不改行高。守卫见 popup_cards_nav_icon_guard #8。 */
+.mine-button:not(.duplicate) {
+    font-size: 24px;
+}
+
 .mine-button:disabled {
     opacity: 0.15;
 }


### PR DESCRIPTION
## 现象
用户截图反馈：查词弹窗词条头动作栏里，**加号（制卡）图标比相邻的音量/收藏/tune 图标小**。

## 根因
动作栏里音量·收藏·open-anki·tune 都是 `.inline-action-button > svg { width:1em; height:1em }` 的内联 SVG（viewBox 0-24 近乎铺满，18px 下可见 ≈14px）；唯独制卡按钮 `.mine-button` 静息态是**文本字形 `'+'`**（TODO-1325 应用户要求保留 `+ / ✓ / ✓↩` 文本标记，不走 SVG）。四者共用 `font-size:18px`，但一个文本 `'+'` 字形只占 em 盒约一半高（≈9px），SVG 却铺满 1em，故静息加号目测明显更小/不齐。

## 修复
仅给静息 `'+'` 态（未制卡 = 无 `.duplicate` 类）单独放大字号补偿文本字形的空白：
```css
.mine-button:not(.duplicate) { font-size: 24px; }
```
- 已制卡 `✓` / `✓↩`（`.duplicate` / `.latest`）是高字形本就接近、且各有专属尺寸，**保持不动**。
- 表头行高由词条大标题主导，放大按钮不改行高。
- 尊重 TODO-1325（保留文本标记不走 SVG），未改回 SVG。

## 三镜像 + content.css
按弹窗三镜像纪律同步 `assets/popup/popup.css` + 两份 vendored `popup.css`，并 `node tools/browser-extension/scripts/generate-content-css.mjs` 重生成两份 `content.css`。

## 测试
- 新增 `popup_cards_nav_icon_guard` #8：三 CSS 镜像均须有 `.mine-button:not(.duplicate)` 且 `font-size > 18px`，防回退。
- `flutter test` guard + byte-parity + content.css 完整性 **全 41 通过**；`flutter analyze` clean。

## 待办
- ⚠️ 像素值 24px 需 **Windows/真机目视微调**（不同符号字体 '+' 字形高度略有差异）。

追踪：`docs/bugs/BUG-932-popup-mine-plus-size.md`