### PR TITLE
fix(mining): 制卡媒体处理卸到后台 isolate，消除 UI 未响应 (BUG-933)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 910 条。点号进各自文件。
+> 共 911 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-933](bugs/BUG-933-mining-ui-jank-isolate.md) | ✅ | ✅ | 制卡媒体处理阻塞UI线程未响应 |
 | [BUG-930](bugs/BUG-930-subtitle-list-resize-cursor.md) | ✅ | ✅ | 视频字幕列表左缘调宽把手 hover 不显 resizeLeftRight（左右箭头）光标 |
 | [BUG-928](bugs/BUG-928-video-card-16x9-gap.md) | ✅ | ✅ | 视频卡对标准 16:9 封面留空隙·封面比例随标题长短浮动 |
 | [BUG-927](bugs/BUG-927-reader-native-selection-blocks-lookup-and-rightclick-crash.md) | ✅ | ✅ | 阅读器原生选区残留卡住查词 + 右键闪退 |

--- a/docs/bugs/BUG-933-mining-ui-jank-isolate.md
+++ b/docs/bugs/BUG-933-mining-ui-jank-isolate.md
@@ -1,0 +1,17 @@
+## BUG-933 · 制卡媒体处理阻塞UI线程未响应
+- **报告**：2026-07-20（用户：制卡的时候 anki 总会未响应感觉）
+- **真实性**：✅ 真 bug。制卡媒体处理链**整条在 UI isolate（main）同步跑 CPU 重活**，无一处 `compute()`/`Isolate.run`，几 MB 媒体触发几十~几百 ms 纯 Dart 计算堵住事件循环。根因三处：
+  - 手写 SHA256 逐字节循环算媒体哈希：`packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart:186` `_sha256Hex`（经 `hibikiAnkiMediaFilenameForBytes:84`），被 AnkiConnect 的 `_storeLocalMedia`/`_storeRemoteAudio` 与 AnkiDroid 的 `_preferredMediaNameForFile:584`/`_addRemoteAudio` 同步调用。
+  - 截图 JPEG 解码/缩放/重编码（`package:image` 纯 Dart）：`hibiki/lib/src/utils/misc/card_screenshot_downsampler.dart:48` `downsampleCardScreenshot`，被 `hibiki/lib/src/mining/immersion_mining_engine.dart:137`（视频制卡封面）与 `reader_hibiki/chrome.part.dart:681`（选区插图）同步 await。
+  - base64 编码大媒体：`ankiconnect_repository.dart` 的 `_store*Media`（`base64Encode(bytes)`）。
+  - 排除项：ffmpeg 走子进程/FFI 原生线程、AnkiConnect HTTP / AnkiDroid platform channel / addNote 均正确 await，是异步 I/O（非 jank）；媒体读取用异步 `readAsBytes()`。
+- **[x] ① 已修复** — 把三处 CPU 重活卸到后台 isolate（对齐既有 `encodeClipTextFrameAsJpgAsync` 范式）：
+  - 新增 `downsampleCardScreenshotAsync`（`card_screenshot_downsampler.dart`，`Isolate.run` 包纯函数），改上述两调用点 await 它。
+  - 新增 `hibikiAnkiMediaEncodeForUploadAsync`（一次隔离算完「sha256 文件名+base64」，同段字节只跨隔离拷一次）、`hibikiAnkiMediaFilenameForBytesAsync`、`hibikiAnkiBase64EncodeAsync`（`ankiconnect_repository.dart`），改 AnkiConnect `_storeLocalMedia`/`_storeRemoteAudio`/`_storeDictionaryMedia` 与 AnkiDroid `_preferredMediaNameForFile`/`_addRemoteAudio` 接入。
+  - 阈值兜底 `_isolateMediaThresholdBytes = 64KB`：词典外字（单卡数十个、每个几 KB）走同步分支，避免为小图各起一个 isolate 的风暴/资源挤占；封面/音频等大媒体才卸后台。
+  - 提交哈希：（见 PR）
+- **[x] ② 已加自动化测试** —
+  - `packages/hibiki_anki/test/mining_isolate_offload_test.dart`：三个异步 helper 结果与同步直算逐字节一致（大媒体 200KB 真走 `Isolate.run`，小媒体走同步分支）+ 源码扫描守卫（AnkiDroid 不再裸调同步 sha256/base64；AnkiConnect 调用点已接入 Async 变体）。
+  - `hibiki/test/utils/card_screenshot_downsampler_test.dart`：`downsampleCardScreenshotAsync` 大图后台降采样长边钉 1000、空/坏字节保守回退（内容一致）。
+  - 既有 `packages/hibiki_anki/test/media_filename_guard_test.dart` 的 `mineEntry` 端到端测试已过新异步路径（回归守卫）。
+- **备注**：BUG 编号 931→932→933 两次改号（931 被 PR#275、932 被 PR#276 草稿占用，本机并发撞号）。

--- a/hibiki/lib/src/mining/immersion_mining_engine.dart
+++ b/hibiki/lib/src/mining/immersion_mining_engine.dart
@@ -139,7 +139,9 @@ class ImmersionMiningEngine {
       if (req.stillFallback == null) return null;
       final Uint8List? shot = await req.stillFallback!();
       if (shot == null) return null;
-      final Uint8List small = downsampleCardScreenshot(
+      // BUG-933：降采样（decode/resize/encodeJpg）卸到后台 isolate，避免 1080p/4K
+      // 截图的纯 Dart CPU 重活阻塞 UI 线程（制卡「未响应」根因之一）。
+      final Uint8List small = await downsampleCardScreenshotAsync(
         shot,
         maxLongEdge: compression.screenshotMaxLongEdge,
         quality: compression.screenshotQuality,

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
@@ -750,8 +750,10 @@ extension _ReaderChrome on _ReaderHibikiPageState {
         final Uint8List bytes = await file.readAsBytes();
         if (bytes.isEmpty) continue;
         // 降采样护体积（长边 1000px / JPEG q90，与制卡截图同档）；小图/无法解码时
-        // downsampleCardScreenshot 原样返回，绝不把有效插图变空。
-        final Uint8List downsampled = downsampleCardScreenshot(bytes);
+        // downsampleCardScreenshot 原样返回，绝不把有效插图变空。BUG-933：解码/编码
+        // 卸到后台 isolate，避免逐张插图的纯 Dart CPU 阻塞 UI。
+        final Uint8List downsampled =
+            await downsampleCardScreenshotAsync(bytes);
         images.add((normOffset: ref.normOffset, bytes: downsampled));
       } catch (e, stack) {
         ErrorLogService.instance

--- a/hibiki/lib/src/utils/misc/card_screenshot_downsampler.dart
+++ b/hibiki/lib/src/utils/misc/card_screenshot_downsampler.dart
@@ -1,3 +1,4 @@
+import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:image/image.dart' as img;
@@ -72,4 +73,30 @@ Uint8List downsampleCardScreenshot(
   } catch (_) {
     return bytes;
   }
+}
+
+/// [downsampleCardScreenshot] 的后台 isolate 变体（BUG-933）。
+///
+/// 根因：制卡封面（libmpv 原始解码帧，可能 1080p/4K）的 `img.decodeImage` +
+/// `copyResize`(lanczos) + `encodeJpg` 是纯 Dart CPU 重活，几十到几百 ms；旧代码在
+/// **UI isolate** 同步 `await` 这条链（`immersion_mining_engine` / reader 选区插图），
+/// 制卡截图那一下明显卡顿/未响应。这里整体卸到后台 isolate（[Isolate.run]，与
+/// `encodeClipTextFrameAsJpgAsync` 同范式）：传 [Uint8List] 进、[Uint8List] 出，
+/// `package:image` 对象只在后台 isolate 内生灭，UI 线程不再被解码/编码阻塞。
+///
+/// 语义与同步版一致：小图/无法解码时原样返回入参字节（跨 isolate 拷贝后内容相等，
+/// 不再是 `identical`，但绝不返回空/破坏媒体）。
+Future<Uint8List> downsampleCardScreenshotAsync(
+  Uint8List bytes, {
+  int maxLongEdge = 1000,
+  int quality = 90,
+}) {
+  if (bytes.isEmpty) return Future<Uint8List>.value(bytes);
+  return Isolate.run<Uint8List>(
+    () => downsampleCardScreenshot(
+      bytes,
+      maxLongEdge: maxLongEdge,
+      quality: quality,
+    ),
+  );
 }

--- a/hibiki/test/utils/card_screenshot_downsampler_test.dart
+++ b/hibiki/test/utils/card_screenshot_downsampler_test.dart
@@ -100,4 +100,33 @@ void main() {
       expect(identical(out, garbage), isTrue);
     });
   });
+
+  group('downsampleCardScreenshotAsync (BUG-933 后台 isolate 卸载)', () {
+    Uint8List jpegOf(int width, int height) {
+      final img.Image image = img.Image(width: width, height: height);
+      img.fill(image, color: img.ColorRgb8(120, 60, 200));
+      return img.encodeJpg(image);
+    }
+
+    test('大图后台降采样：长边钉 1000（与同步版语义一致）', () async {
+      final Uint8List big = jpegOf(2400, 1350);
+      // 卸到后台 isolate 后不再 identical，但内容语义与同步版一致：解码得长边 1000。
+      final img.Image decoded =
+          img.decodeImage(await downsampleCardScreenshotAsync(big))!;
+      expect(decoded.width, 1000);
+      expect(decoded.height, 563);
+    });
+
+    test('空字节原样返回（同步短路，不起 isolate）', () async {
+      final Uint8List empty = Uint8List(0);
+      expect(
+          identical(await downsampleCardScreenshotAsync(empty), empty), isTrue);
+    });
+
+    test('无法解码字节保守回退：内容与入参一致（绝不变空）', () async {
+      final Uint8List garbage = Uint8List.fromList(<int>[0, 1, 2, 3, 4]);
+      final Uint8List out = await downsampleCardScreenshotAsync(garbage);
+      expect(out, orderedEquals(garbage));
+    });
+  });
 }

--- a/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -91,6 +92,68 @@ String hibikiAnkiMediaFilenameForBytes({
     fallbackExtension: fallbackExtension,
   );
   return '${_safeMediaPrefix(prefix)}${_sha256Hex(bytes)}.$ext';
+}
+
+/// BUG-933：制卡「未响应」根因之一——旧代码在 **UI isolate** 对整段媒体字节同步跑
+/// [_sha256Hex]（纯 Dart 逐字节 SHA256，几 MB 音频=数百万次迭代）和 [base64Encode]，
+/// 阻塞主线程。这里把「哈希文件名 + base64」一次卸到后台 isolate，同段字节只跨 isolate
+/// 拷贝一次。
+///
+/// 阈值兜底：词典外字（单卡可能数十个、每个仅几 KB）走同步分支——为几 KB 图各起一个
+/// isolate 反而挤占资源、拖慢总时长（且不会 jank）；只有封面/音频等大媒体才卸后台。
+const int _isolateMediaThresholdBytes = 64 * 1024;
+
+/// AnkiConnect 上传路径：计算 sha256 文件名 + base64 数据。大媒体在后台 isolate 完成，
+/// 小媒体同步完成。返回记录 `(filename, base64Data)` 供 `storeMediaFile`。
+Future<({String filename, String base64Data})>
+    hibikiAnkiMediaEncodeForUploadAsync({
+  required String prefix,
+  required List<int> bytes,
+  required String sourceName,
+  String fallbackExtension = 'bin',
+}) {
+  ({String filename, String base64Data}) encode() => (
+        filename: hibikiAnkiMediaFilenameForBytes(
+          prefix: prefix,
+          bytes: bytes,
+          sourceName: sourceName,
+          fallbackExtension: fallbackExtension,
+        ),
+        base64Data: base64Encode(bytes),
+      );
+  if (bytes.length < _isolateMediaThresholdBytes) {
+    return Future<({String filename, String base64Data})>.value(encode());
+  }
+  return Isolate.run(encode);
+}
+
+/// AnkiDroid 路径：媒体由 platform channel 按文件路径落库（不走 base64），只需 sha256
+/// 文件名。大媒体在后台 isolate 完成，小媒体同步完成。
+Future<String> hibikiAnkiMediaFilenameForBytesAsync({
+  required String prefix,
+  required List<int> bytes,
+  required String sourceName,
+  String fallbackExtension = 'bin',
+}) {
+  String compute() => hibikiAnkiMediaFilenameForBytes(
+        prefix: prefix,
+        bytes: bytes,
+        sourceName: sourceName,
+        fallbackExtension: fallbackExtension,
+      );
+  if (bytes.length < _isolateMediaThresholdBytes) {
+    return Future<String>.value(compute());
+  }
+  return Isolate.run(compute);
+}
+
+/// [base64Encode] 的按需后台变体（BUG-933）：大媒体卸到 isolate，小媒体同步。用于
+/// 文件名已定、只剩 base64 的路径（远端下载音频 / 词典外字上传）。
+Future<String> hibikiAnkiBase64EncodeAsync(List<int> bytes) {
+  if (bytes.length < _isolateMediaThresholdBytes) {
+    return Future<String>.value(base64Encode(bytes));
+  }
+  return Isolate.run(() => base64Encode(bytes));
 }
 
 String _safeMediaPrefix(String prefix) {
@@ -851,16 +914,17 @@ class AnkiConnectRepository extends BaseAnkiRepository {
       final file = File(filePath);
       if (!file.existsSync()) return null;
       final bytes = await file.readAsBytes();
-      final filename = hibikiAnkiMediaFilenameForBytes(
+      // BUG-933：sha256 + base64 卸到后台 isolate（大媒体），避免阻塞 UI。
+      final encoded = await hibikiAnkiMediaEncodeForUploadAsync(
         prefix: prefix,
         bytes: bytes,
         sourceName: filePath,
       );
       await service.storeMediaFile(
-        filename: filename,
-        data: base64Encode(bytes),
+        filename: encoded.filename,
+        data: encoded.base64Data,
       );
-      return filename;
+      return encoded.filename;
     } catch (e, stack) {
       debugPrint('AnkiConnectRepository._storeLocalMedia: $e\n$stack');
       return null;
@@ -882,17 +946,18 @@ class AnkiConnectRepository extends BaseAnkiRepository {
           final file = File(AnkiAudioRef.localPath(url));
           if (!file.existsSync()) return const AudioFetchOutcome.none();
           final bytes = await file.readAsBytes();
-          final filename = hibikiAnkiMediaFilenameForBytes(
+          // BUG-933：本地音频 sha256 + base64 卸到后台 isolate。
+          final encoded = await hibikiAnkiMediaEncodeForUploadAsync(
             prefix: 'hibiki_audio_',
             bytes: bytes,
             sourceName: file.path,
             fallbackExtension: 'mp3',
           );
           await service.storeMediaFile(
-            filename: filename,
-            data: base64Encode(bytes),
+            filename: encoded.filename,
+            data: encoded.base64Data,
           );
-          return AudioFetchOutcome.stored(filename);
+          return AudioFetchOutcome.stored(encoded.filename);
         case AnkiAudioRefKind.remoteUrl:
           final client = HttpClient();
           try {
@@ -917,7 +982,8 @@ class AnkiConnectRepository extends BaseAnkiRepository {
             // Content-Type (falling back to the URL path, then mp3) so non-mp3
             // audio is not mislabeled as .mp3 in Anki.
             final ext = _audioExtension(response.headers.contentType, url);
-            final filename = hibikiAnkiMediaFilenameForBytes(
+            // BUG-933：远端音频 sha256 卸到后台 isolate。
+            final filename = await hibikiAnkiMediaFilenameForBytesAsync(
               prefix: 'hibiki_audio_',
               bytes: bytes,
               sourceName: url,
@@ -935,9 +1001,10 @@ class AnkiConnectRepository extends BaseAnkiRepository {
       if (!audioFile.existsSync()) return const AudioFetchOutcome.none();
       final bytes = await audioFile.readAsBytes();
       final filename = audioFile.uri.pathSegments.last;
+      // BUG-933：文件名已定（下载时已按 sha256 命名），只剩 base64 卸到后台 isolate。
       await service.storeMediaFile(
         filename: filename,
-        data: base64Encode(bytes),
+        data: await hibikiAnkiBase64EncodeAsync(bytes),
       );
       return AudioFetchOutcome.stored(filename);
     } catch (e, stack) {
@@ -994,9 +1061,10 @@ class AnkiConnectRepository extends BaseAnkiRepository {
       final file = File('${ankiDictionaryMediaCacheDirPath()}/$filename');
       if (!file.existsSync()) return null;
       final bytes = await file.readAsBytes();
+      // BUG-933：外字通常几 KB（走同步分支），偶发大图才卸后台 isolate。
       await service.storeMediaFile(
         filename: filename,
-        data: base64Encode(bytes),
+        data: await hibikiAnkiBase64EncodeAsync(bytes),
       );
       // 返回**裸文件名**（与 AnkiDroid 经 ankiInlineMediaReference 对称）。义项 HTML
       // 已是 <img src="hoshi_dict_N.ext">，buildMinedFields 用 replaceAll 把 src 里的占位符

--- a/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
@@ -614,7 +614,8 @@ class AnkiRepository extends BaseAnkiRepository {
     final file = File(path);
     if (!file.existsSync()) return null;
     final bytes = await file.readAsBytes();
-    return hibikiAnkiMediaFilenameForBytes(
+    // BUG-933：sha256 卸到后台 isolate（大媒体），避免阻塞 UI。
+    return hibikiAnkiMediaFilenameForBytesAsync(
       prefix: prefix,
       bytes: bytes,
       sourceName: file.path,
@@ -667,7 +668,8 @@ class AnkiRepository extends BaseAnkiRepository {
                 await response.fold<List<int>>([], (a, b) => a..addAll(b));
             final cacheDir = await _mediaCacheDir();
             final ext = _audioExtension(response.headers.contentType, url);
-            final preferredName = hibikiAnkiMediaFilenameForBytes(
+            // BUG-933：远端音频 sha256 卸到后台 isolate。
+            final preferredName = await hibikiAnkiMediaFilenameForBytesAsync(
               prefix: 'hibiki_audio_',
               bytes: bytes,
               sourceName: url,

--- a/packages/hibiki_anki/test/mining_isolate_offload_test.dart
+++ b/packages/hibiki_anki/test/mining_isolate_offload_test.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+/// BUG-933：制卡媒体的 sha256 文件名与 base64 编码从 UI isolate 卸到后台 isolate。
+/// 这里锁定「异步 helper 的结果与同步计算逐字节一致」（大媒体真走 [Isolate.run]），
+/// 并用源码扫描守卫防止调用点回退到会阻塞 UI 的同步版本。
+void main() {
+  group('BUG-933 制卡媒体后台 isolate 卸载', () {
+    // 大于阈值（64KB）→ 真正走 Isolate.run；小于阈值 → 同步分支。两条都要与直算一致。
+    final Uint8List big = Uint8List.fromList(
+      List<int>.generate(200 * 1024, (int i) => (i * 31 + 7) & 0xff),
+    );
+    final Uint8List small = Uint8List.fromList(<int>[1, 2, 3, 4, 5]);
+
+    test('hibikiAnkiMediaEncodeForUploadAsync：文件名+base64 与同步计算一致（大媒体走隔离）',
+        () async {
+      final encoded = await hibikiAnkiMediaEncodeForUploadAsync(
+        prefix: 'hibiki_audio_',
+        bytes: big,
+        sourceName: 'clip.mp3',
+      );
+      expect(
+        encoded.filename,
+        hibikiAnkiMediaFilenameForBytes(
+          prefix: 'hibiki_audio_',
+          bytes: big,
+          sourceName: 'clip.mp3',
+        ),
+      );
+      expect(encoded.base64Data, base64Encode(big));
+    });
+
+    test('hibikiAnkiMediaEncodeForUploadAsync：小媒体走同步分支也一致', () async {
+      final encoded = await hibikiAnkiMediaEncodeForUploadAsync(
+        prefix: 'hibiki_cover_',
+        bytes: small,
+        sourceName: 'x.jpg',
+      );
+      expect(
+        encoded.filename,
+        hibikiAnkiMediaFilenameForBytes(
+          prefix: 'hibiki_cover_',
+          bytes: small,
+          sourceName: 'x.jpg',
+        ),
+      );
+      expect(encoded.base64Data, base64Encode(small));
+    });
+
+    test('hibikiAnkiMediaFilenameForBytesAsync 与同步版逐字节一致（大/小两路）', () async {
+      expect(
+        await hibikiAnkiMediaFilenameForBytesAsync(
+          prefix: 'hibiki_audio_',
+          bytes: big,
+          sourceName: 'clip.mp3',
+        ),
+        hibikiAnkiMediaFilenameForBytes(
+          prefix: 'hibiki_audio_',
+          bytes: big,
+          sourceName: 'clip.mp3',
+        ),
+      );
+      expect(
+        await hibikiAnkiMediaFilenameForBytesAsync(
+          prefix: 'hibiki_audio_',
+          bytes: small,
+          sourceName: 'clip.mp3',
+        ),
+        hibikiAnkiMediaFilenameForBytes(
+          prefix: 'hibiki_audio_',
+          bytes: small,
+          sourceName: 'clip.mp3',
+        ),
+      );
+    });
+
+    test('hibikiAnkiBase64EncodeAsync 与 base64Encode 一致（大/小两路）', () async {
+      expect(await hibikiAnkiBase64EncodeAsync(big), base64Encode(big));
+      expect(await hibikiAnkiBase64EncodeAsync(small), base64Encode(small));
+    });
+  });
+
+  group('BUG-933 源码守卫：制卡媒体路径不得同步跑 CPU 重活', () {
+    File _pkgFile(String relative) {
+      // 测试 cwd 为包目录（packages/hibiki_anki）。
+      final File f = File(relative);
+      expect(f.existsSync(), isTrue,
+          reason: '找不到 $relative（cwd=${Directory.current.path}）');
+      return f;
+    }
+
+    test('ankidroid/anki_repository.dart 不直接调用同步 sha256/ base64', () {
+      final String src =
+          _pkgFile('lib/src/ankidroid/anki_repository.dart').readAsStringSync();
+      // 同步文件名/编码会在 UI isolate 对整段媒体跑纯 Dart 循环 → 卡顿。必须走
+      // ...Async 变体（Async 后缀不匹配 `(` 前的裸调用）。
+      expect(
+        RegExp(r'hibikiAnkiMediaFilenameForBytes\(').hasMatch(src),
+        isFalse,
+        reason: 'AnkiDroid 应改用 hibikiAnkiMediaFilenameForBytesAsync',
+      );
+      expect(
+        RegExp(r'\bbase64Encode\(').hasMatch(src),
+        isFalse,
+        reason: 'AnkiDroid 媒体走 platform channel，不该在此 base64 编码',
+      );
+    });
+
+    test('ankiconnect_repository.dart 媒体上传接入 Async 变体', () {
+      final String src =
+          _pkgFile('lib/src/ankiconnect/ankiconnect_repository.dart')
+              .readAsStringSync();
+      // 正向守卫：三个后台 helper 都被真实调用（调用点已接入），而非仅定义。
+      // 定义各出现 1 次，接入后调用点使总数 >1。
+      expect(
+        RegExp(r'hibikiAnkiMediaEncodeForUploadAsync\(').allMatches(src).length,
+        greaterThanOrEqualTo(2),
+        reason: '_storeLocalMedia / _storeRemoteAudio 应接入合并编码 helper',
+      );
+      expect(
+        RegExp(r'hibikiAnkiBase64EncodeAsync\(').allMatches(src).length,
+        greaterThanOrEqualTo(2),
+        reason: '远端音频 / 词典外字上传应接入 base64 后台 helper',
+      );
+      expect(
+        RegExp(r'hibikiAnkiMediaFilenameForBytesAsync\(').hasMatch(src),
+        isTrue,
+        reason: '远端音频文件名应走后台 sha256',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 问题
用户反馈：制卡时 App 总是「未响应」感觉。

## 根因（真 bug）
制卡媒体处理链**整条在 UI isolate 同步跑 CPU 重活**，无一处 `compute()`/`Isolate.run`：
1. 手写 SHA256 逐字节循环算媒体哈希（`ankiconnect_repository.dart` `_sha256Hex`，几 MB 音频=数百万次纯 Dart 迭代）。
2. 截图 JPEG 解码/缩放/重编码（`card_screenshot_downsampler.dart`，1080p/4K 封面几十~几百 ms）。
3. base64 编码大媒体。

几 MB 媒体触发的纯 Dart 计算堵住事件循环 → 制卡时明显卡顿/未响应。
（ffmpeg 走子进程/FFI、HTTP/platform channel/addNote 均异步 await，非 jank。）

## 修复（根因，非补丁）
对齐既有 `encodeClipTextFrameAsJpgAsync` 范式，把三处重活卸到后台 isolate：
- `downsampleCardScreenshotAsync`（`Isolate.run` 包纯函数）→ 视频封面 + 阅读器选区插图两调用点。
- `hibikiAnkiMediaEncodeForUploadAsync`（一次隔离算完 sha256 文件名+base64）/ `hibikiAnkiMediaFilenameForBytesAsync` / `hibikiAnkiBase64EncodeAsync` → AnkiConnect + AnkiDroid 媒体上传。
- **64KB 阈值兜底**：词典外字（单卡数十个、每个几 KB）走同步分支，避免为小图各起 isolate 的风暴。

## 测试
- `packages/hibiki_anki/test/mining_isolate_offload_test.dart`：异步 helper 结果与同步直算逐字节一致（200KB 真走 Isolate.run，小媒体走同步分支）+ 源码扫描守卫。
- `hibiki/test/utils/card_screenshot_downsampler_test.dart`：异步降采样长边钉 1000、空/坏字节保守回退。
- 既有 `media_filename_guard_test.dart` 的 mineEntry 端到端已过新异步路径。
- `flutter analyze` 改动文件 No issues；hibiki_anki 11 + 截图 14 + mining 213 全绿。

## 验证状态
⚠️ 单测/analyze 全绿；真机制卡复测（视频截图卡 + 带音频卡）待 Win/Android 真机确认帧率不再掉。

修复文件：`docs/bugs/BUG-933-mining-ui-jank-isolate.md`