### PR TITLE
perf(lookup): 统一查词单词发音走 WebView <audio>，桌面不再比手机慢

### DIFF
--- a/hibiki/assets/browser_extension/bridge-shim.js
+++ b/hibiki/assets/browser_extension/bridge-shim.js
@@ -87,25 +87,10 @@ window.flutter_inappwebview = {
             return null;
           }
         })();
-      case 'playWordAudio':
-        // 单词音频②播放：拿 resolveWordAudio 返回的 file URL 用 HTML5 Audio 播（扩展宿主是
-        // 真实浏览器，直接 new Audio(url).play()）。mode==='interrupt' 时先掐掉上一段。
-        // 成功 resolve(true)、失败 resolve(false) → popup 显示 ✕。
-        return (async function () {
-          try {
-            var opts = args[0] || {};
-            if (!opts.url) return false;
-            if ((opts.mode || 'interrupt') === 'interrupt' && window.__hibikiWordAudio) {
-              try { window.__hibikiWordAudio.pause(); } catch (_) {}
-            }
-            var audio = new Audio(opts.url);
-            window.__hibikiWordAudio = audio;
-            await audio.play();
-            return true;
-          } catch (_) {
-            return false;
-          }
-        })();
+      // 单词音频播放已统一到 popup.js 自身（playWordAudio 直接 new Audio(url).play()），
+      // 三端同一路径，不再经 callHandler('playWordAudio')。故此处旧的 playWordAudio 桥
+      // 已删除。resolveWordAudio 仍返回可直接播放的 URL（扩展侧是 sync server 的
+      // /api/lookup/audio/file 短命 URL），popup.js 拿到后本地播放。
       default:
         return Promise.resolve(null);
     }

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -1883,16 +1883,34 @@ async function fetchAudioUrl(expression, reading) {
     }
 }
 
-async function playWordAudio(audioUrl) {
+// 单词音频播放：统一走 WebView 自己的 HTML5 <audio>，不再回 Dart 交给 native
+// MediaPlayer（Android）或 libmpv（桌面 just_audio）——那条桌面路径每播一次都要
+// stop→loadfile→play，比手机的原生同步 prepare 慢。三端（app 内 InAppWebView / app 外
+// overlay WebView2 / 浏览器扩展真实浏览器）现在同一路径：resolveWordAudio 已返回可直接
+// 播放的 URL（远端 http、本地 base64 data:）。interrupt 模式先掐上一段，留 window.
+// __hibikiWordAudio 句柄。音量取 window.lookupAudioVolume（0..1，宿主注入；扩展缺省 1）。
+function playWordAudio(audioUrl) {
     try {
-        return await window.flutter_inappwebview.callHandler('playWordAudio', {
-            url: audioUrl,
-            mode: window.audioPlaybackMode || 'interrupt'
-        });
-    } catch {
-        return false;
+        if (!audioUrl) return Promise.resolve(false);
+        if ((window.audioPlaybackMode || 'interrupt') === 'interrupt'
+                && window.__hibikiWordAudio) {
+            try { window.__hibikiWordAudio.pause(); } catch (_) { /* no-op */ }
+        }
+        const audio = new Audio(audioUrl);
+        const v = window.lookupAudioVolume;
+        if (typeof v === 'number' && isFinite(v)) {
+            audio.volume = Math.max(0, Math.min(1, v));
+        }
+        window.__hibikiWordAudio = audio;
+        return audio.play().then(() => true).catch(() => false);
+    } catch (_) {
+        return Promise.resolve(false);
     }
 }
+
+// Dart 自动发音（打开词条自动读）驱动入口：宿主解析好 URL 后经 evaluateJavascript
+// 调此函数，让弹窗用同一 <audio> 路径播，桌面自动发音同样变快、且与手动 ♪ 一致。
+window.__hibikiPlayWordAudioUrl = playWordAudio;
 
 function showAudioError(button) {
     setButtonIcon(button, 'audioOff');

--- a/hibiki/lib/src/lookup/overlay_bridge_handlers.dart
+++ b/hibiki/lib/src/lookup/overlay_bridge_handlers.dart
@@ -133,7 +133,7 @@ Future<void> _handleAudioBridge(
           'configs=${model.audioSourceConfigs.length}');
       reply = expression.isEmpty
           ? null
-          : await resolveLookupAudioUrl(model, expression, reading);
+          : await resolveWordAudioWebViewUrl(model, expression, reading);
     }
   } catch (e, st) {
     glog('audio: EXCEPTION $e\n$st');

--- a/hibiki/lib/src/pages/base_source_page.dart
+++ b/hibiki/lib/src/pages/base_source_page.dart
@@ -428,8 +428,18 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
     );
   }
 
-  Future<void> _playAutoReadWord(String expression, String reading) =>
-      playLookupAudio(appModel, expression, reading);
+  Future<void> _playAutoReadWord(String expression, String reading) {
+    // Prefer the popup's own <audio> (unified fast path); fall back to the Dart
+    // player when the popup WebView is not ready. Capture the state once so the
+    // callback does not re-evaluate the getter mid-play.
+    final DictionaryPopupWebViewState? popup = topPopupState;
+    return autoReadWordUnified(
+      appModel,
+      expression,
+      reading,
+      playInWebView: popup?.playWordAudioUrl,
+    );
+  }
 
   void clearDictionaryResult() => _dismissPopupAt(0);
 

--- a/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -328,18 +328,34 @@ mixin DictionaryPageMixin {
     return const MinePopupResult();
   }
 
-  /// Resolves and plays the audio for [expression] / [reading] via
-  /// [WordAudioResolver] + [TtsChannel].
-  Future<void> autoReadWord(String expression, String reading) async {
+  /// Resolves and plays the audio for [expression] / [reading]. [popupState] is
+  /// the just-rendered popup WebView (when this surface renders results in a
+  /// popup): auto-read then plays through its own `<audio>` element — the unified
+  /// fast path shared with the manual ♪ button and every surface. Null (e.g. an
+  /// inline full-page view with no popup WebView) falls back to the Dart player.
+  Future<void> autoReadWord(
+    String expression,
+    String reading, {
+    DictionaryPopupWebViewState? popupState,
+  }) async {
     await LookupAutoReadCoordinator.instance.runAutomatic(
       expression: expression,
       reading: reading,
-      play: () => _playAutoReadWord(expression, reading),
+      play: () => _playAutoReadWord(expression, reading, popupState),
     );
   }
 
-  Future<void> _playAutoReadWord(String expression, String reading) =>
-      playLookupAudio(mixinAppModel, expression, reading);
+  Future<void> _playAutoReadWord(
+    String expression,
+    String reading,
+    DictionaryPopupWebViewState? popupState,
+  ) =>
+      autoReadWordUnified(
+        mixinAppModel,
+        expression,
+        reading,
+        playInWebView: popupState?.playWordAudioUrl,
+      );
 
   /// Checks whether a card for [expression] / [reading] already exists in Anki.
   Future<bool> checkDuplicate(String expression, String reading) async {
@@ -827,7 +843,8 @@ mixin DictionaryPageMixin {
       if (autoRead && ReaderHibikiSource.instance.autoReadOnLookup) {
         final first = result.entries.first;
         if (first.word.isNotEmpty) {
-          autoReadWord(first.word, first.reading);
+          autoReadWord(first.word, first.reading,
+              popupState: entry.webViewKey.currentState);
         }
       }
     }

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -9,12 +9,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hibiki_dictionary/hibiki_dictionary.dart';
-import 'package:hibiki/media.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_webview_media.dart';
 import 'package:hibiki/src/pages/implementations/popup_settings_injection.dart';
 import 'package:hibiki/src/reader/popup_swipe_close_script.dart';
 import 'package:hibiki/src/reader/reader_caret_scripts.dart';
+import 'package:hibiki/src/utils/misc/lookup_audio_playback.dart';
 import 'package:hibiki/utils.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -608,38 +608,25 @@ JSON.stringify((function(){
         source: ReaderCaretScripts.refreshInvocation());
   }
 
-  Future<String?> _resolveWordAudio(String expression, String reading) async {
-    final appModel = ref.read(appProvider);
-    final WordAudioResolver resolver = WordAudioResolver(
-      queryLocalAudio: (expression, reading) async {
-        try {
-          return await TtsChannel.instance
-              .queryLocalAudio(expression, reading)
-              .timeout(const Duration(milliseconds: 500));
-        } on TimeoutException {
-          return null;
-        }
-      },
-      queryLocalAudioByDbIndex: (expression, reading, dbIndex) async {
-        try {
-          return await TtsChannel.instance
-              .queryLocalAudio(expression, reading, dbIndex: dbIndex)
-              .timeout(const Duration(milliseconds: 500));
-        } on TimeoutException {
-          return null;
-        }
-      },
-      extractLocalAudio: TtsChannel.instance.extractLocalAudio,
-      queryRemoteAudio: (expression, reading) => appModel.lookupRemoteAudio(
-        expression,
-        reading,
-      ),
+  /// Resolves the word audio into a URL popup.js can play directly with an HTML5
+  /// `<audio>` element (remote `http(s)://` pass-through, local file → base64
+  /// `data:` URL). Shared single source of truth with the overlay + auto-read so
+  /// every surface plays word audio the same way (see [resolveWordAudioWebViewUrl]).
+  Future<String?> _resolveWordAudio(String expression, String reading) =>
+      resolveWordAudioWebViewUrl(ref.read(appProvider), expression, reading);
+
+  /// Auto-read entry point: drives the popup's own `<audio>` element to play an
+  /// already-resolved URL (from [resolveWordAudioWebViewUrl]). Returns false when
+  /// the WebView is not ready, so the Dart caller can fall back to its player and
+  /// never lose auto-read (Never break userspace).
+  Future<bool> playWordAudioUrl(String url) async {
+    final InAppWebViewController? controller = _controller;
+    if (controller == null || !_ready || url.isEmpty) return false;
+    await controller.evaluateJavascript(
+      source: 'window.__hibikiPlayWordAudioUrl && '
+          'window.__hibikiPlayWordAudioUrl(${jsonEncode(url)})',
     );
-    return resolver.resolveConfigured(
-      expression: expression,
-      reading: reading,
-      sources: appModel.audioSourceConfigs,
-    );
+    return true;
   }
 
   // No dispose() override that disposes _controller here.
@@ -1048,6 +1035,12 @@ JSON.stringify((function(){
         allowUniversalAccessFromFileURLs: true,
         useShouldInterceptRequest: true,
         resourceCustomSchemes: dictionaryMediaCustomSchemes,
+        // 单词发音统一走弹窗自己的 HTML5 <audio>（见 resolveWordAudioWebViewUrl）。
+        // 自动发音（打开词条自动读）没有用户手势，默认的 autoplay 策略
+        // （mediaPlaybackRequiresUserGesture=true）会静默拦截 audio.play() —— 手动 ♪
+        // 有手势不受影响，但自动发音会哑。这里放行媒体自动播放，让 <audio> 统一路径的
+        // 自动发音真正出声（手动路径不受影响）。
+        mediaPlaybackRequiresUserGesture: false,
         // BUG-477（BUG-468 同根，弹窗 WebView 漏修）：Windows 上压制 WebView2 原生右键
         // 菜单的唯一真值是 `disableContextMenu`→`put_AreDefaultContextMenusEnabled`；
         // 上面 `ContextMenu` 的 `hideDefaultSystemContextMenuItems` 是跨平台 API，在
@@ -1638,29 +1631,10 @@ JSON.stringify((function(){
           },
         );
 
-        controller.addJavaScriptHandler(
-          handlerName: 'playWordAudio',
-          callback: (args) async {
-            return _guardJsBridge<bool>(
-              'DictPopupWebview.playWordAudio',
-              false,
-              ErrorLogService.instance,
-              () async {
-                String url = '';
-                if (args.isNotEmpty && args[0] is Map) {
-                  final data = args[0] as Map;
-                  url = data['url']?.toString() ?? '';
-                }
-                // Plays remote URLs and local file paths uniformly, including
-                // Windows drive-letter paths (BUG-046).
-                return TtsChannel.instance.playAudioRef(
-                  url,
-                  volume: ReaderHibikiSource.instance.lookupAudioVolumeGain,
-                );
-              },
-            );
-          },
-        );
+        // Word audio no longer round-trips to a native/libmpv player: popup.js
+        // plays the resolved URL itself with an HTML5 <audio> element (unified
+        // with the browser extension and every desktop surface — see
+        // resolveWordAudioWebViewUrl). The old `playWordAudio` handler is gone.
       },
       onLoadStop: (controller, url) {
         _ready = true;

--- a/hibiki/lib/src/pages/implementations/home_dictionary_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dictionary_page.dart
@@ -670,7 +670,8 @@ class _HomeDictionaryPageState<T extends BaseTabPage> extends BaseTabPageState
           if (shouldAutoRead) {
             final entry = result.entries.first;
             if (entry.word.isNotEmpty) {
-              autoReadWord(entry.word, entry.reading);
+              autoReadWord(entry.word, entry.reading,
+                  popupState: _resultWebViewKey.currentState);
             }
           }
         }

--- a/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
@@ -274,6 +274,7 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
     window.__hoshiPopupFontSize = ${appModel.dictionaryFontSize};
     window.audioSources = ${jsonEncode(appModel.enabledAudioSources)};
     window.needsAudio = true;
+    window.lookupAudioVolume = ${ReaderHibikiSource.instance.lookupAudioVolumeGain.clamp(0.0, 1.0).toStringAsFixed(4)};
     window.i18nNoAudioAvailable = ${jsonEncode(t.popup_no_audio_available)};
     window.sentenceDraftEnabled = ${options.sentenceDraftEnabled};
     window._noResultsMessage = ${jsonEncode(t.no_search_results)};

--- a/hibiki/lib/src/utils/misc/lookup_audio_playback.dart
+++ b/hibiki/lib/src/utils/misc/lookup_audio_playback.dart
@@ -1,4 +1,7 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki/src/models/app_model.dart';
@@ -67,4 +70,100 @@ Future<String?> resolveLookupAudioUrl(
     reading: reading,
     sources: appModel.audioSourceConfigs,
   );
+}
+
+/// Auto-read a word, preferring the popup's own HTML5 `<audio>` element (the
+/// unified fast path — no native/libmpv round-trip) and falling back to the Dart
+/// player when no ready popup WebView is available, so auto-read never silently
+/// drops (Never break userspace).
+///
+/// [playInWebView] plays an already-resolved WebView URL in the popup and
+/// returns whether it actually did (false when the WebView is not ready); pass
+/// null when this surface has no popup WebView (e.g. an inline full-page view),
+/// which goes straight to the Dart fallback.
+Future<void> autoReadWordUnified(
+  AppModel appModel,
+  String expression,
+  String reading, {
+  required Future<bool> Function(String url)? playInWebView,
+}) async {
+  if (playInWebView != null) {
+    final String? url =
+        await resolveWordAudioWebViewUrl(appModel, expression, reading);
+    if (url != null && url.isNotEmpty && await playInWebView(url)) return;
+  }
+  await playLookupAudio(appModel, expression, reading);
+}
+
+/// Resolves word audio for [expression] / [reading] into a URL that an HTML5
+/// `<audio>` element inside the popup WebView can play directly on **every**
+/// surface — the in-app InAppWebView, the app-external overlay WebView2, and the
+/// browser extension. This is the single unified word-audio play path: instead
+/// of handing the ref back to a native player (Android `MediaPlayer`) or libmpv
+/// (desktop `just_audio`), the popup plays it itself, exactly like the browser
+/// extension already does (`assets/browser_extension/bridge-shim.js`).
+///
+/// See [audioRefToWebViewUrl] for the ref → URL conversion. Returns null when no
+/// enabled source resolves.
+Future<String?> resolveWordAudioWebViewUrl(
+  AppModel appModel,
+  String expression,
+  String reading,
+) async =>
+    audioRefToWebViewUrl(
+        await resolveLookupAudioUrl(appModel, expression, reading));
+
+/// Converts a resolved audio ref (from [resolveLookupAudioUrl] /
+/// [WordAudioResolver], i.e. a remote `http(s)://` URL **or** a local file path)
+/// into a URL an HTML5 `<audio>` element can load with no per-WebView custom
+/// scheme or native file handler:
+///  - remote `http(s)://` refs pass through so `<audio>` streams them directly;
+///  - a local file becomes a base64 `data:<mime>;base64,…` URL.
+///
+/// A `data:` URL is used (rather than a custom `audio://` scheme) precisely so
+/// the app-external overlay's **native** WebView2 window needs zero native
+/// changes — every WebView host can already play a `data:` URL. Word-audio clips
+/// are small (tens of KB), so the one-time base64 is negligible and popup.js
+/// caches the result per entry.
+///
+/// Returns null when [ref] is empty or the local file is missing.
+Future<String?> audioRefToWebViewUrl(String? ref) async {
+  if (ref == null || ref.isEmpty) return null;
+  if (ref.startsWith('http')) return ref;
+  final String path =
+      ref.startsWith('file://') ? Uri.parse(ref).toFilePath() : ref;
+  final File file = File(path);
+  if (!await file.exists()) return null;
+  final Uint8List bytes = await file.readAsBytes();
+  if (bytes.isEmpty) return null;
+  final String mime = audioMimeForPath(path);
+  return 'data:$mime;base64,${base64Encode(bytes)}';
+}
+
+/// Audio Content-Type by file extension for `data:` URLs, so the WebView picks
+/// the right decoder. Covers the formats the local-audio libraries emit
+/// (Yomitan local audio server: mp3 / opus; plus common fallbacks). Unknown
+/// extensions fall back to `audio/mpeg` (the dominant word-audio format).
+String audioMimeForPath(String path) {
+  final String ext = path.split('.').last.toLowerCase();
+  switch (ext) {
+    case 'mp3':
+      return 'audio/mpeg';
+    case 'opus':
+    case 'ogg':
+    case 'oga':
+      return 'audio/ogg';
+    case 'm4a':
+    case 'mp4':
+    case 'aac':
+      return 'audio/mp4';
+    case 'wav':
+      return 'audio/wav';
+    case 'flac':
+      return 'audio/flac';
+    case 'webm':
+      return 'audio/webm';
+    default:
+      return 'audio/mpeg';
+  }
 }

--- a/hibiki/test/pages/dictionary_popup_mine_bridge_crash_test.dart
+++ b/hibiki/test/pages/dictionary_popup_mine_bridge_crash_test.dart
@@ -126,7 +126,9 @@ void main() {
       'onLinkClick': 'null',
       'queryLocalAudio': 'null',
       'resolveWordAudio': 'null',
-      'playWordAudio': 'false',
+      // playWordAudio bridge removed: popup.js now plays the resolved URL itself
+      // with an HTML5 <audio> element (unified across all surfaces), so there is
+      // no Dart handler to boundary-guard here.
     };
 
     for (final MapEntry<String, String> entry in fallbacks.entries) {

--- a/hibiki/test/pages/lookup_audio_playback_dedup_test.dart
+++ b/hibiki/test/pages/lookup_audio_playback_dedup_test.dart
@@ -1,10 +1,11 @@
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
-/// 源码守卫：自动发音的 WordAudioResolver 装配 + resolveConfigured + playAudioRef
-/// 逻辑只有一份（顶层 playLookupAudio），base_source_page 与 dictionary_page_mixin
-/// 的 _playAutoReadWord 都转调它，不再各自手抄一份 WordAudioResolver 装配。
-/// 防止两份发音逻辑漂移（任一处改了另一处漏改）。
+/// 源码守卫：自动发音的解析/播放逻辑单一真相。WordAudioResolver 装配 +
+/// resolveConfigured 只住在 lookup_audio_playback.dart；base_source_page 与
+/// dictionary_page_mixin 的 _playAutoReadWord 都转调统一入口 autoReadWordUnified
+/// （优先弹窗 <audio>、兜底 playLookupAudio），不再各自手抄一份 WordAudioResolver
+/// 装配。防止两份发音逻辑漂移（任一处改了另一处漏改）。
 void main() {
   final playback = File(
     'lib/src/utils/misc/lookup_audio_playback.dart',
@@ -29,19 +30,19 @@ void main() {
     });
 
     test(
-        'base_source_page 的 _playAutoReadWord 转调 playLookupAudio 且不再自建 WordAudioResolver',
+        'base_source_page 的 _playAutoReadWord 转调统一入口 autoReadWordUnified 且不再自建 WordAudioResolver',
         () {
-      expect(base, contains('playLookupAudio('),
-          reason: 'base 应转调 playLookupAudio');
+      expect(base, contains('autoReadWordUnified('),
+          reason: 'base 应转调统一入口 autoReadWordUnified');
       expect(base.contains('WordAudioResolver('), isFalse,
           reason: 'base 不应再手抄一份 WordAudioResolver 装配');
     });
 
     test(
-        'dictionary_page_mixin 的 _playAutoReadWord 转调 playLookupAudio 且不再自建 WordAudioResolver',
+        'dictionary_page_mixin 的 _playAutoReadWord 转调统一入口 autoReadWordUnified 且不再自建 WordAudioResolver',
         () {
-      expect(mixin, contains('playLookupAudio('),
-          reason: 'mixin 应转调 playLookupAudio');
+      expect(mixin, contains('autoReadWordUnified('),
+          reason: 'mixin 应转调统一入口 autoReadWordUnified');
       expect(mixin.contains('WordAudioResolver('), isFalse,
           reason: 'mixin 不应再手抄一份 WordAudioResolver 装配');
     });

--- a/hibiki/test/utils/misc/audio_ref_webview_url_test.dart
+++ b/hibiki/test/utils/misc/audio_ref_webview_url_test.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/utils/misc/lookup_audio_playback.dart';
+
+/// Unit coverage for the unified word-audio play path: word audio is played by
+/// the popup's own HTML5 <audio> element on every surface (in-app InAppWebView,
+/// app-external overlay WebView2, browser extension), so [resolveWordAudioWebViewUrl]
+/// must hand back a URL <audio> can load directly with no per-WebView custom
+/// scheme or native file handler — remote http(s) pass-through, local file →
+/// base64 `data:` URL. See [audioRefToWebViewUrl] / [audioMimeForPath].
+void main() {
+  group('audioRefToWebViewUrl', () {
+    test('null / empty ref resolves to null', () async {
+      expect(await audioRefToWebViewUrl(null), isNull);
+      expect(await audioRefToWebViewUrl(''), isNull);
+    });
+
+    test('remote http(s) refs pass through unchanged so <audio> streams them',
+        () async {
+      expect(
+        await audioRefToWebViewUrl('https://example.com/a.mp3'),
+        'https://example.com/a.mp3',
+      );
+      expect(
+        await audioRefToWebViewUrl('http://host/audio/file?id=42&token=abc'),
+        'http://host/audio/file?id=42&token=abc',
+      );
+    });
+
+    test('a local file becomes a base64 data: URL with the right MIME',
+        () async {
+      final Directory dir = await Directory.systemTemp.createTemp('hibiki_wa');
+      addTearDown(() => dir.delete(recursive: true));
+      final List<int> bytes = <int>[1, 2, 3, 4, 5, 250, 128, 0];
+      final File mp3 = File('${dir.path}/word.mp3')..writeAsBytesSync(bytes);
+
+      final String? url = await audioRefToWebViewUrl(mp3.path);
+      expect(url, 'data:audio/mpeg;base64,${base64Encode(bytes)}');
+    });
+
+    test('a file:// URI ref is decoded to a path then base64-encoded',
+        () async {
+      final Directory dir = await Directory.systemTemp.createTemp('hibiki_wa');
+      addTearDown(() => dir.delete(recursive: true));
+      final List<int> bytes = <int>[9, 8, 7];
+      final File opus = File('${dir.path}/word.opus')..writeAsBytesSync(bytes);
+
+      final String? url = await audioRefToWebViewUrl(opus.uri.toString());
+      expect(url, 'data:audio/ogg;base64,${base64Encode(bytes)}');
+    });
+
+    test('a missing local file resolves to null (no broken data: URL)',
+        () async {
+      final Directory dir = await Directory.systemTemp.createTemp('hibiki_wa');
+      addTearDown(() => dir.delete(recursive: true));
+      expect(await audioRefToWebViewUrl('${dir.path}/nope.mp3'), isNull);
+    });
+  });
+
+  group('audioMimeForPath', () {
+    test('maps the formats the local-audio libraries emit', () {
+      expect(audioMimeForPath('a.mp3'), 'audio/mpeg');
+      expect(audioMimeForPath('a.opus'), 'audio/ogg');
+      expect(audioMimeForPath('a.ogg'), 'audio/ogg');
+      expect(audioMimeForPath('a.m4a'), 'audio/mp4');
+      expect(audioMimeForPath('a.aac'), 'audio/mp4');
+      expect(audioMimeForPath('a.wav'), 'audio/wav');
+      expect(audioMimeForPath('a.flac'), 'audio/flac');
+      expect(audioMimeForPath('a.webm'), 'audio/webm');
+    });
+
+    test('is case-insensitive on the extension', () {
+      expect(audioMimeForPath('WORD.MP3'), 'audio/mpeg');
+      expect(audioMimeForPath('WORD.Opus'), 'audio/ogg');
+    });
+
+    test(
+        'unknown extensions fall back to audio/mpeg (dominant word-audio '
+        'format)', () {
+      expect(audioMimeForPath('a.xyz'), 'audio/mpeg');
+      expect(audioMimeForPath('noext'), 'audio/mpeg');
+    });
+  });
+}

--- a/hibiki/test/utils/misc/lookup_audio_volume_wiring_static_test.dart
+++ b/hibiki/test/utils/misc/lookup_audio_volume_wiring_static_test.dart
@@ -6,40 +6,74 @@ String _read(String path) => File(path).readAsStringSync();
 
 void main() {
   group('lookup audio volume wiring', () {
-    test('all lookup playback paths pass the configured gain to TtsChannel',
-        () {
-      // 自动发音的 gain 接线收口在 playLookupAudio（lookup_audio_playback.dart）；
-      // reader/source（base）与 dictionary/video（mixin）都转调它，不再各自手抄一份
-      // playAudioRef + gain。popup webview 的手动发音按钮另走自己的路径（仍带 gain）。
+    test(
+        'auto-read routes through the unified WebView-first path with a '
+        'volume-carrying Dart fallback', () {
+      // 单词发音已统一：弹窗自己用 HTML5 <audio> 播（三端 + 扩展同一路径），不再回
+      // Dart 交给 native/libmpv。自动发音走 autoReadWordUnified —— 优先驱动弹窗
+      // <audio>，WebView 未就绪时回退 playLookupAudio（仍带 gain，Never break userspace）。
       final String playback =
           _read('lib/src/utils/misc/lookup_audio_playback.dart');
-      expect(playback, contains('lookupAudioVolumeGain'),
-          reason: 'playLookupAudio must read the lookup audio volume setting');
+      // Dart 兜底仍把配置音量传进播放器。
       expect(playback, contains('playAudioRef('));
       expect(
         playback,
         contains('volume: ReaderHibikiSource.instance.lookupAudioVolumeGain'),
-        reason: 'playLookupAudio must pass the configured volume to playback',
+        reason: 'the Dart fallback (playLookupAudio) must still pass the '
+            'configured volume',
+      );
+      // 统一入口 + 兜底接线。
+      expect(playback, contains('autoReadWordUnified('));
+      expect(
+        playback,
+        contains('await playLookupAudio(appModel, expression, reading)'),
+        reason: 'autoReadWordUnified must fall back to the Dart player when no '
+            'popup WebView is ready',
       );
 
-      // base/mixin 经 playLookupAudio 转调（gain 接线随之统一到上面那一处）。
+      // base/mixin 自动发音都经统一 helper（不再各自手抄 playLookupAudio + gain）。
       for (final String path in <String>[
         'lib/src/pages/base_source_page.dart',
         'lib/src/pages/implementations/dictionary_page_mixin.dart',
       ]) {
-        expect(_read(path), contains('playLookupAudio('),
-            reason: '$path auto-read must route through playLookupAudio');
+        expect(_read(path), contains('autoReadWordUnified('),
+            reason: '$path auto-read must route through the unified helper');
       }
+    });
 
-      // popup webview 的手动发音按钮仍各自传 gain（不经 playLookupAudio）。
-      final String popup =
+    test(
+        'manual + auto word audio applies the configured volume in the '
+        'WebView <audio>', () {
+      // 音量不再在 Dart 侧 playAudioRef 应用（弹窗不回 Dart 播），改注入
+      // window.lookupAudioVolume（0..1，源自 lookupAudioVolumeGain），popup.js 设
+      // audio.volume。
+      final String injection =
+          _read('lib/src/pages/implementations/popup_settings_injection.dart');
+      expect(injection, contains('window.lookupAudioVolume'));
+      expect(injection, contains('lookupAudioVolumeGain'));
+
+      final String popupJs = _read('assets/popup/popup.js');
+      expect(popupJs, contains('new Audio('),
+          reason:
+              'popup.js must play word audio with an HTML5 <audio> element');
+      expect(popupJs, contains('audio.volume'),
+          reason: 'popup.js must apply the injected lookup audio volume');
+      expect(popupJs, contains('window.lookupAudioVolume'));
+
+      // 旧的 Dart 往返已删：弹窗不再自己回 Dart 播音频。
+      final String popupWebView =
           _read('lib/src/pages/implementations/dictionary_popup_webview.dart');
-      expect(popup, contains('lookupAudioVolumeGain'));
-      expect(popup, contains('playAudioRef('));
       expect(
-        popup,
-        contains('volume: ReaderHibikiSource.instance.lookupAudioVolumeGain'),
-        reason: 'manual popup audio must still pass the configured volume',
+        popupWebView,
+        isNot(contains("handlerName: 'playWordAudio'")),
+        reason: 'the playWordAudio Dart bridge must be removed (unified to '
+            '<audio>)',
+      );
+      expect(
+        popupWebView,
+        isNot(contains('playAudioRef(')),
+        reason: 'the popup must not round-trip word audio to a native/libmpv '
+            'player',
       );
     });
 


### PR DESCRIPTION
## 问题
手机查词单词发音"秒出"，电脑（桌面端）却更慢。

## 根因
取音频两端一致，但**播放后端**不同：
- **Android**：复用的原生 `MediaPlayer`，本地文件同步 `prepare()`，几乎瞬时 → "秒出"。
- **桌面**：`just_audio` → `just_audio_media_kit` → **libmpv**，每播一次都 `stop→loadfile→play`，libmpv 重新 demux + 开解码器，比原生慢。
- 分叉点：`tts_channel.dart:43` `_isSupported = Platform.isAndroid`。

浏览器扩展早就直接在 WebView 里 `new Audio(url).play()`，又快又简单。

## 方案（全面统一）
单词发音改由**弹窗自己的 HTML5 `<audio>`** 播，三端（app 内 InAppWebView / app 外 overlay WebView2 / 浏览器扩展）+ 手动 ♪ + 自动发音同一路径，彻底绕开 native/libmpv。

- `resolveWordAudio` 直接返回可播 URL：远端 `http(s)` 透传，本地文件 → base64 `data:` URL（用 `data:` 而非自定义 scheme，**app 外 overlay 的原生 WebView2 零原生改动**）。
- `popup.js` 的 `playWordAudio` → `new Audio(url).play()`，删掉回 Dart 的 `playWordAudio` 桥（app 内 + overlay + 扩展 shim 三处）。
- 自动发音经统一入口 `autoReadWordUnified`：优先驱动弹窗 `<audio>`，WebView 未就绪回退 `playLookupAudio`（libmpv，**Never break userspace**），去重协调器不变。
- 音量注入 `window.lookupAudioVolume`（0..1，源自 `lookupAudioVolumeGain`），`popup.js` 设 `audio.volume`；弹窗 WebView 放行 `mediaPlaybackRequiresUserGesture` 以免 autoplay 策略静默拦截自动发音。

## 测试
- 新增 `audio_ref_webview_url_test`：http 透传 / 本地→data URL / file:// 解码 / 缺失文件→null / MIME 映射。
- 更新音量接线、自动发音去重、mine 桥守卫为新架构。
- `flutter analyze` 全绿，相关测试通过。

## 已知剩余
app 外 overlay 的**自动发音**（`global_lookup_controller._autoReadFirstEntry`）仍走 libmpv，作为次要 app 外面的已知剩余项，本轮未动（overlay 手动 ♪ 已统一）。

## 待验证
⚠️ Win 真机复测桌面 ♪ + 自动发音"秒出" & 无回归；Android 真机确认仍"秒出"不回归。