### PR TITLE
fix(video): align missing ASS fonts with mpv

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 909 条。点号进各自文件。
+> 共 910 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-929](bugs/BUG-929-ass-mpv-windows-font-fallback.md) | ✅ | ✅ | ASS 缺失字体在 Windows 上与 mpv 回退不一致 |
 | [BUG-928](bugs/BUG-928-video-card-16x9-gap.md) | ✅ | ✅ | 视频卡对标准 16:9 封面留空隙·封面比例随标题长短浮动 |
 | [BUG-927](bugs/BUG-927-reader-native-selection-blocks-lookup-and-rightclick-crash.md) | ✅ | ✅ | 阅读器原生选区残留卡住查词 + 右键闪退 |
 | [BUG-926](bugs/BUG-926-popup-touch-copy-disabled.md) | ✅ | ✅ | 词典弹窗触屏无法复制释义(撤回BUG-762全量禁选) |

--- a/docs/bugs/BUG-929-ass-mpv-windows-font-fallback.md
+++ b/docs/bugs/BUG-929-ass-mpv-windows-font-fallback.md
@@ -1,0 +1,6 @@
+## BUG-929 · ASS 缺失字体在 Windows 上与 mpv 回退不一致
+- **报告**：2026-07-20（用户：本机播放列表实测）
+- **真实性**：✅ 真 bug。样例 ASS 指定未安装的 `A-OTF Shin Maru Go Pr6N DB`；mpv/libass DirectWrite 日文字形实际回退 `Microsoft YaHei UI`，Hibiki 却从 `Yu Gothic` 开始，且 Skia 缺失字体字形相对 libass/FreeType 继续偏小，导致字号、字宽、描边占比和视觉颜色面积均不一致。根因见 `hibiki/lib/src/media/video/video_subtitle_overlay.dart:334`、`:365`、`:1433`、`:1729`。
+- **[x] ① 已修复** — Windows ASS 缺失字体链先选 `Microsoft YaHei UI` / `Microsoft YaHei`，渲染与 cell/em 度量共用该链；仅对 Windows“作者字体确实缺失”的路径补 libass 实测栅格尺寸校准（横向字号 1.09、纵向 1.055），已安装作者字体和其他平台保持原逻辑。本提交。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_ass_mpv_fallback_test.dart` 直接复刻用户样例的 65 字号、白色正文、`#D93F61` 描边、2.5 字距和 3px Outline，守卫 Windows 回退顺序、字号/纵向缩放与颜色/描边；定向测试 2/2 通过，定向 analyze 无问题。
+- **备注**：用同一 ASS 在 1920×1080 黑底帧实测：mpv 像素框 `157×56`；Hibiki 修改前 `141×46`，修改后 `158×56`。Windows 真应用 runner `win-itest-20260720-051637-b69db471` 通过，权威 Flutter 帧位于 `.codex-test/windows-itest/win-itest-20260720-051637-b69db471/screenshots/ass-mpv-fallback-after.png`。ASS 原始主色/描边色解析本来正确，本修复通过对齐字形、字号和宽高恢复与 mpv 相同的颜色面积观感。

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -325,11 +325,24 @@ class VideoSubtitleOverlay extends StatefulWidget {
 /// 单字（典型如假名「の」）字形与周围突兀不一致。
 ///
 /// 这里给出覆盖五个出包平台主流系统日文字体的有序列表。Flutter 引擎按顺序解析、
-/// 自动跳过当前平台不存在的字体名，故无需平台分支：
-/// - Windows：`Yu Gothic` / `Yu Gothic UI` / `Meiryo` / `MS Gothic`
+/// 自动跳过当前平台不存在的字体名：
+/// - Windows：先跟随 mpv/libass DirectWrite 的缺字回退 `Microsoft YaHei UI`，再走
+///   `Yu Gothic` / `Yu Gothic UI` / `Meiryo` / `MS Gothic`。同一列表还用于 ASS
+///   cell/em 字号换算，避免渲染字形与字号度量选到两套字体（BUG-929）。
 /// - macOS / iOS：`Hiragino Sans` / `Hiragino Kaku Gothic ProN`
 /// - Android / Linux：`Noto Sans CJK JP` / `Noto Sans JP`
-const List<String> _kSubtitleCjkFallback = <String>[
+const List<String> _kWindowsSubtitleCjkFallback = <String>[
+  'Microsoft YaHei UI',
+  'Microsoft YaHei',
+  'Yu Gothic',
+  'Yu Gothic UI',
+  'Meiryo',
+  'MS Gothic',
+  'Noto Sans CJK JP',
+  'Noto Sans JP',
+];
+
+const List<String> _kDefaultSubtitleCjkFallback = <String>[
   'Yu Gothic',
   'Yu Gothic UI',
   'Hiragino Sans',
@@ -339,6 +352,42 @@ const List<String> _kSubtitleCjkFallback = <String>[
   'Meiryo',
   'MS Gothic',
 ];
+
+@visibleForTesting
+List<String> subtitleCjkFontFallbacks(TargetPlatform platform) =>
+    platform == TargetPlatform.windows
+        ? _kWindowsSubtitleCjkFallback
+        : _kDefaultSubtitleCjkFallback;
+
+List<String> get _subtitleCjkFallback =>
+    subtitleCjkFontFallbacks(defaultTargetPlatform);
+
+/// Windows 上作者字体缺失时，Flutter/Skia 以同一 YaHei UI face 渲染仍比
+/// mpv/libass FreeType REAL_DIM 的实像素偏窄、偏矮。BUG-929 用用户原片黑底帧校准：
+/// 字号补 1.09、仅纵轴再补 1.055，可把 `きれえ` 从 146×50 对齐到 158×56
+///（mpv 157×56）。仅缺失作者字体的 Windows ASS 路径使用；已安装字体和其他平台不变。
+
+const double _kWindowsMissingAssFontRasterScale = 1.09;
+const double _kWindowsMissingAssFontRasterYScale = 1.055;
+
+@visibleForTesting
+({double fontScale, double yScale}) assMissingFontRasterCompensation(
+  TargetPlatform platform, {
+  required bool hasRequestedFamily,
+  required bool requestedFamilyResolved,
+  required bool fallbackFamilyAvailable,
+}) {
+  if (platform == TargetPlatform.windows &&
+      hasRequestedFamily &&
+      !requestedFamilyResolved &&
+      fallbackFamilyAvailable) {
+    return (
+      fontScale: _kWindowsMissingAssFontRasterScale,
+      yScale: _kWindowsMissingAssFontRasterYScale,
+    );
+  }
+  return (fontScale: 1.0, yScale: 1.0);
+}
 
 class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     with SingleTickerProviderStateMixin {
@@ -1392,7 +1441,15 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     // 样式表 ScaleX/ScaleY（百分比）作为基线缩放；行内 \fscx\fscy（sc）按 ASS 语义
     // **覆盖**样式值而非叠乘。
     final double styleSx = (markup.cueStyle?.scaleXPct ?? 100) / 100.0;
-    final double styleSy = (markup.cueStyle?.scaleYPct ?? 100) / 100.0;
+    final String? cueFontName = markup.cueStyle?.fontName;
+    final bool cueFontResolved = cueFontName == null ||
+        cueFontName.isEmpty ||
+        _resolveAssFontFamily(cueFontName) != null;
+    final ({double fontScale, double yScale}) fallbackRasterCompensation =
+        _missingAssFontRasterCompensation(cueFontName, cueFontResolved);
+    final double styleSy = (markup.cueStyle?.scaleYPct ?? 100) /
+        100.0 *
+        fallbackRasterCompensation.yScale;
     final double? frx = markup.rotationXDeg;
     final double? fry = markup.rotationYDeg;
     final double? fax = markup.shearX;
@@ -1670,7 +1727,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// 字号 / 颜色的基线恒为用户统一样式，与历史像素级一致。
   /// respectAssStyle 开：字体名 / 主色 / 字号 / 粗斜下删线优先取 .ass 值（行内 span >
   /// [SubtitleCueStyle] cue 默认 > 用户统一样式，TODO-1105）。字体缺字时仍挂
-  /// [_kSubtitleCjkFallback] 兜底。
+  /// [_subtitleCjkFallback] 兜底。
   TextStyle _styleForGrapheme(int i, SubtitleMarkup? markup,
       {int? elapsedMs, int? durMs}) {
     final bool respect = widget.respectAssStyle && markup != null;
@@ -1683,6 +1740,14 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     // 解析不到（未装）沿用原名字符串进回退链（历史行为，CJK 链兜底）。
     final ({String family, FontWeight? weight})? resolvedBase =
         respect ? _resolveAssFontFamily(cue?.fontName) : null;
+    final ({
+      double fontScale,
+      double yScale
+    }) baseMissingFontRasterCompensation = _missingAssFontRasterCompensation(
+      respect ? cue?.fontName : null,
+      resolvedBase != null,
+    );
+
     final String? baseFontFamily = resolvedBase?.family ??
         (respect ? cue?.fontName : null) ??
         widget.fontFamily;
@@ -1712,7 +1777,8 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     final double baseFontSize = cueFontPx != null
         ? _scaleAssFontSize(_assFontSizeToEm(cueFontPx * assFontScale,
                 baseFontFamily, baseWeight, baseItalic) *
-            widget.assUserFontScale)
+            widget.assUserFontScale *
+            baseMissingFontRasterCompensation.fontScale)
         : widget.fontSize;
 
     final TextStyle base = TextStyle(
@@ -1724,7 +1790,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
       // 时，引擎按本列表顺序找到第一个存在的系统日文字体，而非各字符独立走引擎默认
       // fallback（不同字符可能落到不同字体、字形割裂）。引擎自动忽略当前平台不存在的
       // 项，故一条列表覆盖全平台、无需平台分支（TODO-088）。
-      fontFamilyFallback: _kSubtitleCjkFallback,
+      fontFamilyFallback: _subtitleCjkFallback,
       fontWeight: baseWeight,
       // 样式表 Spacing 字间距（px，PlayRes 空间）与字号同源缩放；行内 \fsp 在 span
       // 分支覆盖。respect 关恒 null（历史像素级不变）。
@@ -1751,6 +1817,14 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     // 全名解析成真实家族（装了就用真字体）。
     final ({String family, FontWeight? weight})? resolvedSpan =
         respect ? _resolveAssFontFamily(span.fontName) : null;
+    final ({
+      double fontScale,
+      double yScale
+    }) spanMissingFontRasterCompensation = span.fontName != null &&
+            span.fontName!.isNotEmpty
+        ? _missingAssFontRasterCompensation(span.fontName, resolvedSpan != null)
+        : baseMissingFontRasterCompensation;
+
     final String? spanFontFamily =
         resolvedSpan?.family ?? (respect ? span.fontName : null);
     // \1a/\alpha 主填充透明度（respect 时）：施于最终生效的填充色（行内 \c 优先，否则
@@ -1779,7 +1853,8 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
                       spanFontFamily ?? baseFontFamily,
                       span.bold ? FontWeight.bold : baseWeight,
                       span.italic || baseItalic) *
-                  widget.assUserFontScale)
+                  widget.assUserFontScale *
+                  spanMissingFontRasterCompensation.fontScale)
               : span.fontSizePx!)
           : base.fontSize,
       decoration: decos.isEmpty ? null : TextDecoration.combine(decos),
@@ -1884,6 +1959,21 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// 字体存在性探测缓存：key=family，value=是否解析到真实字体（而非引擎默认回退）。
   final Map<String, bool> _fontExistsCache = <String, bool>{};
 
+  ({double fontScale, double yScale}) _missingAssFontRasterCompensation(
+    String? requestedFamily,
+    bool requestedFamilyResolved,
+  ) {
+    final bool fallbackFamilyAvailable =
+        defaultTargetPlatform == TargetPlatform.windows &&
+            _subtitleCjkFallback.any(_fontFamilyExists);
+    return assMissingFontRasterCompensation(
+      defaultTargetPlatform,
+      hasRequestedFamily: requestedFamily != null && requestedFamily.isNotEmpty,
+      requestedFamilyResolved: requestedFamilyResolved,
+      fallbackFamilyAvailable: fallbackFamilyAvailable,
+    );
+  }
+
   /// [family] 是否真实存在（Skia 能解析出该家族，而非落到引擎默认字体）。
   ///
   /// Flutter 无系统字体枚举 API，用双测量近似：同一探针串分别以 [family] 与一个必不
@@ -1961,7 +2051,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   double _cellPerEmFor(String? family, FontWeight weight, bool italic) {
     for (final String candidate in <String>[
       if (family != null && family.isNotEmpty) family,
-      ..._kSubtitleCjkFallback,
+      ..._subtitleCjkFallback,
     ]) {
       if (!_fontFamilyExists(candidate)) continue;
       AssFontCellIndex.instance.ensureSystemScan();
@@ -1975,7 +2065,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
         style: TextStyle(
           fontSize: 100,
           fontFamily: family,
-          fontFamilyFallback: _kSubtitleCjkFallback,
+          fontFamilyFallback: _subtitleCjkFallback,
           fontWeight: weight,
           fontStyle: italic ? FontStyle.italic : FontStyle.normal,
         ),

--- a/hibiki/test/media/video/video_subtitle_ass_mpv_fallback_test.dart
+++ b/hibiki/test/media/video/video_subtitle_ass_mpv_fallback_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_player_controller.dart';
+import 'package:hibiki/src/media/video/video_subtitle_overlay.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+/// BUG-929 guard: the reported ASS requests a font that is not installed on
+/// Windows. mpv/libass (DirectWrite) resolves its Japanese glyphs through
+/// Microsoft YaHei UI, so Hibiki must use the same first fallback for both
+/// Flutter glyph rendering and ASS cell/em size conversion.
+const String _reportedAss = r'''
+[Script Info]
+PlayResX: 1920
+PlayResY: 1080
+LayoutResX: 1920
+LayoutResY: 1080
+WrapStyle: 2
+ScaledBorderAndShadow: yes
+YCbCr Matrix: TV.709
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Text_JP,A-OTF Shin Maru Go Pr6N DB,65,&H00FFFFFF,&H000000FF,&H00613FD9,&H00000000,0,0,0,0,100,100,2.5,0,1,3,0,2,10,10,30,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:23.80,0:00:25.00,Text_JP,,0,0,0,,きれえ
+''';
+
+Text _fill(WidgetTester tester, String character) => tester
+    .widgetList<Text>(find.text(character))
+    .firstWhere((Text text) => text.style?.foreground == null);
+
+Text _stroke(WidgetTester tester, String character) => tester
+    .widgetList<Text>(find.text(character))
+    .firstWhere((Text text) => text.style?.foreground != null);
+
+void main() {
+  test('Windows fallback mirrors mpv without changing other platforms', () {
+    expect(
+      subtitleCjkFontFallbacks(TargetPlatform.windows).take(2),
+      <String>['Microsoft YaHei UI', 'Microsoft YaHei'],
+    );
+    expect(
+      subtitleCjkFontFallbacks(TargetPlatform.linux).take(2),
+      <String>['Yu Gothic', 'Yu Gothic UI'],
+    );
+    expect(
+      assMissingFontRasterCompensation(
+        TargetPlatform.windows,
+        hasRequestedFamily: true,
+        requestedFamilyResolved: false,
+        fallbackFamilyAvailable: true,
+      ),
+      (fontScale: 1.09, yScale: 1.055),
+    );
+    expect(
+      assMissingFontRasterCompensation(
+        TargetPlatform.windows,
+        hasRequestedFamily: true,
+        requestedFamilyResolved: false,
+        fallbackFamilyAvailable: false,
+      ),
+      (fontScale: 1.0, yScale: 1.0),
+      reason: 'Flutter test fonts must not activate production calibration',
+    );
+  });
+
+  testWidgets(
+      'reported ASS keeps mpv size, colors, spacing, outline and Windows fallback',
+      (WidgetTester tester) async {
+    final TargetPlatform? previousPlatform = debugDefaultTargetPlatformOverride;
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    addTearDown(() => debugDefaultTargetPlatformOverride = previousPlatform);
+    await tester.binding.setSurfaceSize(const Size(1920, 1080));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final List<AudioCue> cues =
+        AssParser.parseString(content: _reportedAss, bookKey: 'bug-929');
+    final VideoPlayerController controller = VideoPlayerController()
+      ..debugVideoWidthOverride = 1920
+      ..debugVideoHeightOverride = 1080
+      ..setCues(cues)
+      ..debugSetPositionForTesting(24000)
+      ..debugUpdateCueForPosition(24000);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: VideoSubtitleOverlay(
+            controller: controller,
+            respectAssStyle: true,
+            bottomPadding: 30,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final Text fill = _fill(tester, 'き');
+    final Text stroke = _stroke(tester, 'き');
+    expect(fill.style?.fontFamily, 'A-OTF Shin Maru Go Pr6N DB');
+    expect(
+      fill.style?.fontFamilyFallback?.take(2),
+      <String>['Microsoft YaHei UI', 'Microsoft YaHei'],
+    );
+    expect(fill.style?.fontSize, closeTo(65, 0.01));
+    expect(fill.style?.letterSpacing, closeTo(2.5, 0.01));
+    expect(fill.style?.color?.toARGB32(), 0xFFFFFFFF);
+    expect(stroke.style?.foreground?.color.toARGB32(), 0xFFD93F61);
+    debugDefaultTargetPlatformOverride = previousPlatform;
+    expect(stroke.style?.foreground?.strokeWidth, closeTo(6, 0.01));
+  });
+}


### PR DESCRIPTION
## Summary

- align Windows ASS missing-font fallback with mpv/libass by preferring `Microsoft YaHei UI`
- keep glyph rendering and ASS cell/em metrics on the same platform-aware fallback chain
- apply measured Windows-only raster compensation only when the authored font is missing and a real fallback font exists
- track the fix as BUG-929 and add a regression fixture based on the reported ASS

## Verification

- `flutter test --no-pub --no-test-assets` on the new test plus three neighboring ASS suites: 16/16 passed
- `flutter analyze --no-pub lib/src/media/video/video_subtitle_overlay.dart test/media/video/video_subtitle_ass_mpv_fallback_test.dart`: no issues
- Windows integration runner `win-itest-20260720-051637-b69db471`: passed
- 1920x1080 black-frame bounds: mpv `157x56`; Hibiki before `141x46`; Hibiki after `158x56`

## Tracking

- BUG-929