### PR TITLE
fix(reader): BUG-934 前加一句制卡不再重复采集当前句

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 914 条。点号进各自文件。
+> 共 915 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-934](bugs/BUG-934-prev-sentence-dup.md) | ✅ | ✅ | 前加一句制卡把当前句重复采集两遍 |
 | [BUG-933](bugs/BUG-933-mining-ui-jank-isolate.md) | ✅ | ✅ | 制卡媒体处理阻塞UI线程未响应 |
 | [BUG-932](bugs/BUG-932-popup-mine-plus-size.md) | ✅ | ✅ | 查词弹窗制卡加号(+)比相邻图标小 |
 | [BUG-931](bugs/BUG-931-video-favorite-osd-topleft.md) | ✅ | ✅ | 视频收藏快捷键唤起进度条+底部提示统一左上角OSD |

--- a/docs/bugs/BUG-934-prev-sentence-dup.md
+++ b/docs/bugs/BUG-934-prev-sentence-dup.md
@@ -1,0 +1,44 @@
+## BUG-934 · 前加一句制卡把当前句重复采集两遍
+- **报告**：2026-07-20（用户：制卡时同一句原文出现两遍，怀疑「前加一句」导致）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/reader/reader_selection_scripts.dart:750`（`getSurroundingSentences` 往前取句的偏移 off-by-one）
+- **[x] ① 已修复** — `getSentenceContext(before.node, before.offset + 1)` → `before.offset`（提交 <PENDING>）
+- **[x] ② 已加自动化测试** — 源码守卫 `hibiki/test/reader/prev_sentence_context_offset_guard_test.dart`（提交 <PENDING>）
+- **备注**：
+
+### 根因
+
+阅读器制卡的「调整上下文 → 前加一句」走 JS `hoshiSelection.getSurroundingSentences(prevCount, nextCount)`
+（`reader_selection_scripts.dart:725`）。往前逐句采集时：
+
+```js
+var anchorOffset = current.sStartOffset;          // 当前句句首
+var before = this.charBefore(anchorNode, anchorOffset);  // → offset = sStartOffset - 1
+var ctx = this.getSentenceContext(before.node, before.offset + 1);  // ← BUG
+```
+
+`charBefore(node, offset)` 返回 `offset - 1`（`:957`），所以 `before.offset` 正好是「当前句首的前
+一个字符」——即前一句末尾的分隔符（或 trailing）。但取句时又 `+ 1`，把起点推回到 `sStartOffset`
+（当前句句首）。`getSentenceContext` 从当前句首往前立刻撞到分隔符（partsBefore 为空）、往后取到当前
+句末尾，于是**返回的「前一句」其实是当前句本身**。
+
+`MiningSentenceDraft.composeText`（`hibiki/lib/src/media/audiobook/mining_sentence_draft.dart:80`）
+按 `prev + current + next` 合成，于是 `prev=[当前句] + current=当前句` → sentence 字段里同一句出现两遍。
+`describe()` 计算的音频 normOffset 也一并取成当前句，导致合并音频区间同样重复当前句。
+
+对照「后加一句」（`:768`）用 `getSentenceContext(after.node, after.offset)`（**不加 1**），对称且正确
+——故只有用「前加一句」才复现，「后加一句」不会。这也和用户「怀疑是前加一句」的观察吻合。
+
+与已归档的 BUG-660（重复两遍归因为浏览器扩展旧制卡队列残留）**不是同一根因**：BUG-660 是外部残留
+队列，本 bug 是阅读器 JS 采句的 off-by-one，凡在 app 内用「前加一句」制卡即稳定复现。
+
+### 修复
+
+`reader_selection_scripts.dart:750`：`before.offset + 1` → `before.offset`。两种 `charBefore` 分支
+（句内 `offset>0` / 跨节点跨段 `offset==0`）均验证过 `before.offset` 正确落在前一句内。
+
+### 测试
+
+`hibiki/test/reader/prev_sentence_context_offset_guard_test.dart`：源码守卫，断言
+`getSurroundingSentences` 往前取句用 `getSentenceContext(before.node, before.offset)` 且不含
+`before.offset + 1`，防止 off-by-one 回归（JS 逻辑内嵌在 Dart 字符串、无 JS 测试运行时，源码扫描是
+最强可落地层）。

--- a/hibiki/lib/src/reader/reader_selection_scripts.dart
+++ b/hibiki/lib/src/reader/reader_selection_scripts.dart
@@ -747,7 +747,11 @@ window.hoshiSelection = {
     for (var i = 0; i < prevCount; i++) {
       var before = this.charBefore(anchorNode, anchorOffset);
       if (!before) break;
-      var ctx = this.getSentenceContext(before.node, before.offset + 1);
+      // BUG-934：before.offset 已是「当前句首的前一个字符」（前一句末尾的分隔符 /
+      // trailing）。此处必须直接落在该字符上取前一句；若给该偏移再多加 1 会把起点推回当前
+      // 句首，getSentenceContext 立刻撞分隔符 → 往后取回当前句自身，导致「前加一句」把当前
+      // 句重复采集两遍（与「后加一句」用 after.offset 不加偏移对称）。
+      var ctx = this.getSentenceContext(before.node, before.offset);
       if (!ctx.sentence) {
         anchorNode = ctx.sStartNode;
         anchorOffset = ctx.sStartOffset;

--- a/hibiki/test/reader/prev_sentence_context_offset_guard_test.dart
+++ b/hibiki/test/reader/prev_sentence_context_offset_guard_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-934 源码守卫：制卡「前加一句」走 JS `getSurroundingSentences` 往前逐句采集，
+/// 必须以 `before.offset`（当前句首前一个字符，即前一句末尾分隔符）直接取前一句。
+///
+/// 历史缺陷：取句时给该偏移多加了 1，把起点推回当前句首，`getSentenceContext` 立刻撞
+/// 分隔符 → 往后取回当前句自身，导致「前加一句」把当前句重复采集两遍。此守卫锁定正确
+/// 调用形，并反向禁止把偏移 `+ 1` 的回归。JS 逻辑内嵌在 Dart 字符串、无 JS 测试运行时，
+/// 源码扫描是最强可落地层。
+void main() {
+  final String src =
+      File('lib/src/reader/reader_selection_scripts.dart').readAsStringSync();
+
+  test('前加一句：往前取句用 before.offset 直接落在前一句上', () {
+    expect(
+      src.contains('getSentenceContext(before.node, before.offset)'),
+      isTrue,
+      reason: '往前取句必须用 before.offset（前一句末尾分隔符），否则会取回当前句自身',
+    );
+  });
+
+  test('前加一句：偏移不得再 +1（否则起点被推回当前句首 → 重复采句）', () {
+    // 拼接构造禁用字面量，避免本注释/断言字符串误伤同文件被扫描的其它守卫。
+    const String forbidden = 'before.offset' ' + 1';
+    expect(
+      src.contains(forbidden),
+      isFalse,
+      reason: 'before.offset + 1 会把取句起点推回当前句首，BUG-934 复现',
+    );
+  });
+
+  test('后加一句仍用 after.offset（对称正确调用未被破坏）', () {
+    expect(
+      src.contains('getSentenceContext(after.node, after.offset)'),
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
## 问题
制卡「调整上下文 → 前加一句」时，句子字段里同一句原文出现两遍（用户报例：`交換は…しない。` ×2）。用户怀疑正是「前加一句」导致——确认属实。

## 根因
`hibiki/lib/src/reader/reader_selection_scripts.dart` 的 JS `getSurroundingSentences` 往前逐句采集：
- `charBefore(node, sStartOffset)` 返回 `sStartOffset - 1` = 当前句首前一个字符（前一句末尾分隔符）
- 但取句时 `getSentenceContext(before.node, before.offset + 1)` 又把起点 **+1 推回当前句首**，撞分隔符后往后取到当前句末尾 → 返回的「前一句」其实是当前句自身
- `composeText` 按 `prev + current + next` 合成 → `prev=[当前句] + current=当前句`，同一句两遍；音频 normOffset 亦一并重复

「后加一句」用 `after.offset`（不加 1）对称正确，故只有前加一句复现。与已归档 BUG-660（浏览器扩展旧队列残留）**不是同一根因**。

## 修复
`before.offset + 1` → `before.offset`。句内 / 跨段两种 `charBefore` 分支均验证正确落在前一句内。

## 测试
新增源码守卫 `hibiki/test/reader/prev_sentence_context_offset_guard_test.dart`（3 断言全过）：锁定正确调用形、反向禁止偏移 +1 回归、确认后加一句对称调用未破坏。JS 内嵌 Dart 字符串无 JS 运行时，源码扫描是最强可落地层。

## 验证
- `flutter test test/reader/prev_sentence_context_offset_guard_test.dart` → All tests passed
- `flutter analyze` 改动文件 → 0 issue
- ⚠️ 待 Windows/Android 真机复测「前加一句」实际制卡句子字段无重复

BUG-934