### PR TITLE
feat(reader): 顶部进度与底栏悬浮控制栏默认启用

### DIFF
--- a/hibiki/integration_test/reader_chrome_floating_itest.dart
+++ b/hibiki/integration_test/reader_chrome_floating_itest.dart
@@ -70,16 +70,26 @@ void main() {
         expect(await waitForHome(tester), isTrue, reason: 'Home within 90s');
         await tester.pump(const Duration(seconds: 2));
 
-        // Defaults ARE the 975 baseline: top progress ON + squeeze (18px),
-        // bottom squeeze (bar height), top floating off, bottom floating
-        // (tap_empty_hide_chrome) off. Assert once so a silently-changed default
+        // Defaults now float: top progress ON, top floating ON, bottom floating
+        // (tap_empty_hide_chrome) ON. Assert once so a silently-changed default
         // fails loudly here.
         expect(ReaderHibikiSource.instance.showTopProgressBar, isTrue,
-            reason: 'top progress must default ON (975 baseline).');
+            reason: 'top progress must default ON.');
+        expect(ReaderHibikiSource.instance.topProgressFloating, isTrue,
+            reason: 'top progress must default to floating.');
+        expect(ReaderHibikiSource.instance.tapEmptyToHideChrome, isTrue,
+            reason: 'bottom bar must default to floating.');
+
+        // This test exercises the squeeze -> floating transition, so force both
+        // back to the squeeze baseline BEFORE the reader mounts (prefs land in
+        // the single app DB and are read on first load).
+        ReaderHibikiSource.instance.toggleTopProgressFloating();
+        ReaderHibikiSource.instance.toggleTapEmptyToHideChrome();
+        await _pumpForPref(tester);
         expect(ReaderHibikiSource.instance.topProgressFloating, isFalse,
-            reason: 'top progress must default to squeeze (non-floating).');
+            reason: 'forced squeeze baseline: top floating off.');
         expect(ReaderHibikiSource.instance.tapEmptyToHideChrome, isFalse,
-            reason: 'bottom bar must default to squeeze.');
+            reason: 'forced squeeze baseline: bottom floating off.');
 
         final FocusDriver driver = FocusDriver(tester);
 

--- a/hibiki/integration_test/reader_top_progress_inset_dom_test.dart
+++ b/hibiki/integration_test/reader_top_progress_inset_dom_test.dart
@@ -64,14 +64,19 @@ void main() {
       expect(await waitForHome(tester), isTrue, reason: 'Home within 90s');
       await tester.pump(const Duration(seconds: 2));
 
-      // 顶部进度默认 ON、非悬浮（show_top_progress_bar=true / top_progress_floating
-      // =false，见 reader_hibiki_source.dart）——这正是 BUG-470 触发配置，无需改偏好。
-      // 显式断言一次，免得默认值被悄悄改掉后测试静默失效。
+      // BUG-470 关心「挤压模式首载 inset 缺口」。顶部进度默认已改为悬浮
+      // （top_progress_floating=true，悬浮不占预留），故本测试在开书前显式切回挤压
+      // 模式，保住原始触发场景（进度键经单一 app DB 共享，开书前写入会被 per-book
+      // ReaderSettings 首载读到）。
       expect(ReaderHibikiSource.instance.showTopProgressBar, isTrue,
           reason: '顶部阅读进度必须默认开启（BUG-470 的触发条件）。若默认被改，'
               '此测试需显式经偏好开启 show_top_progress_bar。');
+      if (ReaderHibikiSource.instance.topProgressFloating) {
+        ReaderHibikiSource.instance.toggleTopProgressFloating();
+        await tester.pump(const Duration(milliseconds: 500));
+      }
       expect(ReaderHibikiSource.instance.topProgressFloating, isFalse,
-          reason: '顶部进度默认应为挤压（非悬浮）模式——挤压模式才会占 18px 预留，'
+          reason: '本测试需挤压（非悬浮）模式——挤压模式才会占 18px 预留，'
               '正是 BUG-470 关心的首载 inset 缺口场景。');
 
       final FocusDriver driver = FocusDriver(tester);

--- a/hibiki/lib/src/media/sources/reader_hibiki_source.dart
+++ b/hibiki/lib/src/media/sources/reader_hibiki_source.dart
@@ -1126,7 +1126,7 @@ class ReaderHibikiSource extends ReaderMediaSource {
 
   bool get tapEmptyToHideChrome =>
       readerSettings?.tapEmptyToHideChrome ??
-      getPreference<bool>(key: 'tap_empty_hide_chrome', defaultValue: false);
+      getPreference<bool>(key: 'tap_empty_hide_chrome', defaultValue: true);
 
   void toggleTapEmptyToHideChrome() async {
     await (readerSettings?.toggleTapEmptyToHideChrome() ??
@@ -1173,10 +1173,10 @@ class ReaderHibikiSource extends ReaderMediaSource {
   }
 
   // TODO-975 决策#2：顶部进度悬浮开关（per-reader，分层同 showTopProgressBar），
-  // 默认 false = 现状。底栏悬浮复用 tapEmptyToHideChrome（决策#3），不另设开关。
+  // 默认 true = 悬浮。底栏悬浮复用 tapEmptyToHideChrome（决策#3），不另设开关。
   bool get topProgressFloating =>
       readerSettings?.topProgressFloating ??
-      getPreference<bool>(key: 'top_progress_floating', defaultValue: false);
+      getPreference<bool>(key: 'top_progress_floating', defaultValue: true);
 
   void toggleTopProgressFloating() async {
     await (readerSettings?.toggleTopProgressFloating() ??

--- a/hibiki/lib/src/reader/reader_settings.dart
+++ b/hibiki/lib/src/reader/reader_settings.dart
@@ -479,15 +479,15 @@ class ReaderSettings {
 
   // TODO-975 决策#3：「点空白处隐藏控制栏」开启 ⟺ 底栏进入悬浮模式（点击唤出、
   // 计时自动收起、不占正文位置）。复用此既有 key 作为底栏悬浮开关，不新增独立偏好
-  // （单一真相源、消除并列开关的特例分支）。默认 false = 现状（挤压底栏，无自动隐藏）。
-  bool get tapEmptyToHideChrome => _get<bool>('tap_empty_hide_chrome', false);
+  // （单一真相源、消除并列开关的特例分支）。默认 true = 底栏悬浮（点击唤出、自动收起）。
+  bool get tapEmptyToHideChrome => _get<bool>('tap_empty_hide_chrome', true);
   Future<void> toggleTapEmptyToHideChrome() =>
       _set<bool>('tap_empty_hide_chrome', !tapEmptyToHideChrome);
 
   /// TODO-975 决策#2：顶部阅读进度悬浮开关（与底栏悬浮独立，时长共用）。开启时顶部
-  /// 进度变成「点击唤出、计时自动收起、不占正文位置」。默认 false = 现状（挤压，常驻
-  /// 显示，占 18px 预留）。与 [showTopProgressBar] 正交：进度关时本开关在 UI 隐藏。
-  bool get topProgressFloating => _get<bool>('top_progress_floating', false);
+  /// 进度变成「点击唤出、计时自动收起、不占正文位置」。默认 true = 悬浮（不占 18px
+  /// 预留）。与 [showTopProgressBar] 正交：进度关时本开关在 UI 隐藏。
+  bool get topProgressFloating => _get<bool>('top_progress_floating', true);
   Future<void> toggleTopProgressFloating() =>
       _set<bool>('top_progress_floating', !topProgressFloating);
 

--- a/hibiki/test/reader/reader_chrome_floating_test.dart
+++ b/hibiki/test/reader/reader_chrome_floating_test.dart
@@ -12,7 +12,7 @@ import '../pages/reader_hibiki_page_source_corpus.dart';
 ///
 /// reader 页含真实 InAppWebView，整页 widget 测试挂不起来；故拆成
 ///  ① 纯函数真值表（预留高 / 可见性 / 时长归一）——挤压↔悬浮模型的单一真相源；
-///  ② 偏好持久化（per-reader 分层 + 默认值 = 老用户零行为变化）；
+///  ② 偏好持久化（per-reader 分层 + 默认值 = 顶部进度/底栏默认悬浮开启）；
 ///  ③ 源码扫描守卫——钉死「预留高经派生 getter 单一真相、悬浮显隐不重锚、改预留高
 ///     走重锚通道、5 处三元式已收敛」等结构不变式（撤回任一即红）。
 void main() {
@@ -110,12 +110,11 @@ void main() {
     });
   });
 
-  group('preferences default to zero behavior change for old users', () {
+  group('floating chrome defaults on (top progress + bottom bar float)', () {
     setUp(() => ReaderHibikiSource.readerSettings = null);
     tearDown(() => ReaderHibikiSource.readerSettings = null);
 
-    test('topProgressFloating defaults false; autoHide defaults 3000',
-        () async {
+    test('topProgressFloating defaults true; autoHide defaults 3000', () async {
       final db = HibikiDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);
       MediaSource.setDatabase(db);
@@ -123,7 +122,7 @@ void main() {
       final source = ReaderHibikiSource.instance;
       await source.refreshPreferencesFromDb();
 
-      expect(source.topProgressFloating, isFalse);
+      expect(source.topProgressFloating, isTrue);
       expect(source.autoHideChromeMillis, 3000);
     });
 
@@ -140,12 +139,13 @@ void main() {
       await perBook.refreshFromDb();
       ReaderHibikiSource.readerSettings = perBook;
 
-      expect(source.topProgressFloating, isFalse);
+      // 默认悬浮开启；toggle 一次落到关闭并持久化。
+      expect(source.topProgressFloating, isTrue);
       source.toggleTopProgressFloating();
       await Future<void>.delayed(Duration.zero);
-      expect(perBook.topProgressFloating, isTrue);
-      expect(source.topProgressFloating, isTrue);
-      expect(await db.getPref('src:reader_ttu:top_progress_floating'), 'true');
+      expect(perBook.topProgressFloating, isFalse);
+      expect(source.topProgressFloating, isFalse);
+      expect(await db.getPref('src:reader_ttu:top_progress_floating'), 'false');
     });
 
     test('autoHideChromeMillis round-trips + normalizes a bad stored value',
@@ -181,9 +181,10 @@ void main() {
         await bookA.refreshFromDb();
         await bookB.refreshFromDb();
 
+        // 两本书默认都悬浮开启；bookA 关掉不得影响 bookB。
         await bookA.toggleTopProgressFloating();
-        expect(bookA.topProgressFloating, isTrue);
-        expect(bookB.topProgressFloating, isFalse,
+        expect(bookA.topProgressFloating, isFalse);
+        expect(bookB.topProgressFloating, isTrue,
             reason: 'per-reader 偏好不得跨书泄漏');
       });
     });


### PR DESCRIPTION
## 需求
用户：floating control bar 和 进度，默认启用。

## 改动
把阅读器两个悬浮开关的默认值从 `false` 翻转为 `true`：
- **悬浮控制栏** `tap_empty_hide_chrome`（底栏点击唤出 + 自动收起）
- **悬浮阅读进度** `top_progress_floating`（顶部进度悬浮，不占 18px 预留）

每个开关有两层默认（per-reader `ReaderSettings` + source 级 `ReaderHibikiSource`），四处均改。`show_top_progress_bar` 本就默认开启，未改。

## 测试
- `test/reader/reader_chrome_floating_test.dart`：断言新默认；round-trip / 跨书隔离用例改为「默认开→toggle 关」方向。19 用例全绿。
- 两个集成测试（`reader_chrome_floating_itest` / `reader_top_progress_inset_dom_test`）：在开书前显式切回挤压模式，保住 BUG-470 首载 inset 触发场景（进度键经单一 app DB 共享，开书前写入被 per-book 首载读到）。
- `flutter analyze` 全项目 0 issue；`dart format` 无变化。

## 待验
Windows / Android 真机确认默认悬浮观感（首开书顶部进度悬浮隐藏、点空白唤出底栏、计时自动收起）。