### PR TITLE
fix(stats): BUG-935 阅读统计字符汇总补「万」倍率单位

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 915 条。点号进各自文件。
+> 共 916 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-935](bugs/BUG-935-stats-chars-wan-unit.md) | ✅ | ✅ | 阅读统计字符数汇总缺万单位 |
 | [BUG-934](bugs/BUG-934-prev-sentence-dup.md) | ✅ | ✅ | 前加一句制卡把当前句重复采集两遍 |
 | [BUG-933](bugs/BUG-933-mining-ui-jank-isolate.md) | ✅ | ✅ | 制卡媒体处理阻塞UI线程未响应 |
 | [BUG-932](bugs/BUG-932-popup-mine-plus-size.md) | ✅ | ✅ | 查词弹窗制卡加号(+)比相邻图标小 |

--- a/docs/bugs/BUG-935-stats-chars-wan-unit.md
+++ b/docs/bugs/BUG-935-stats-chars-wan-unit.md
@@ -1,0 +1,6 @@
+## BUG-935 · 阅读统计字符数汇总缺万单位
+- **报告**：2026-07-20（用户：mamit / Novel Club）
+- **真实性**：✅ 真 bug。阅读统计页把字符数除以 10000 后交给 i18n `stat_format_chars_wan` 补单位（`hibiki/lib/src/pages/implementations/reading_statistics_page.dart:316-321` `_formatChars`），但 12 种非 CJK 语言的译文（含英文，`hibiki/lib/i18n/strings.i18n.json:428` `"$n characters"`）漏掉了「万」倍率标记；图表坐标轴却硬编码「$x万」（`hibiki/lib/src/pages/implementations/stat_charts.dart:34`）。于是英文界面下 192000 字被渲染成「19.2 characters」而非「19.2万 characters」，与坐标轴不一致。KPI 条（今日/本周/日均，`reading_statistics_page.dart:492/497/504`）和日时段图上方的月/总计汇总（`reading_statistics_page.dart:620`）同源共病。仅 zh-CN(万字)/zh-HK(萬字)/ja(万字)/ko(만자) 原本正确。
+- **[x] ① 已修复** — 在 12 种非 CJK 语言（en/ar/de/es/fr/id/it/nl/pt-BR/ru/th/tr/vi）的 `stat_format_chars_wan` 值里把「$n …」补成「$n万 …」，与坐标轴的硬编码「万」对齐；CJK 四语言各自用 万/萬/만 表达万位（不动）。改源 json 后 `dart run slang` 重生 `strings.g.dart`。提交见本分支。
+- **[x] ② 已加自动化测试** — `hibiki/test/i18n/stat_chars_wan_unit_guard_test.dart`：扫 17 个 slang 源文件，断言每种语言的 `stat_format_chars_wan` 值都含万位标记（万/萬/만），防任一语言再漏倍率单位回潮。`flutter test --no-pub test/i18n/` 全绿。
+- **备注**：值 string 本身合法，只缺倍率 token；未新增/删除 i18n key，故按值编辑而非 `i18n_sync.dart`（后者管 key 集增删）。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 34646 (2038 per locale)
 ///
-/// Built on 2026-07-19 at 16:35 UTC
+/// Built on 2026-07-20 at 04:47 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -676,7 +676,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String stat_format_hours_minutes({required Object h, required Object m}) =>
       '${h} hr ${m} min';
   String stat_format_chars({required Object n}) => '${n} characters';
-  String stat_format_chars_wan({required Object n}) => '${n} characters';
+  String stat_format_chars_wan({required Object n}) => '${n}万 characters';
   String get error_log_share_subject => 'hibiki Error Log';
   String get update_never_remind => 'Don\'t remind me about updates';
   String get update_auto_install => 'Auto-install updates';
@@ -3622,7 +3622,7 @@ class _StringsAr extends _StringsEn {
   @override
   String stat_format_chars({required Object n}) => '${n} حرف';
   @override
-  String stat_format_chars_wan({required Object n}) => '${n} حرف';
+  String stat_format_chars_wan({required Object n}) => '${n}万 حرف';
   @override
   String get error_log_share_subject => 'سجل أخطاء hibiki';
   @override
@@ -8256,7 +8256,7 @@ class _StringsDe extends _StringsEn {
   @override
   String stat_format_chars({required Object n}) => '${n} Zeichen';
   @override
-  String stat_format_chars_wan({required Object n}) => '${n} Zeichen';
+  String stat_format_chars_wan({required Object n}) => '${n}万 Zeichen';
   @override
   String get error_log_share_subject => 'hibiki Fehlerprotokoll';
   @override
@@ -12951,7 +12951,7 @@ class _StringsEs extends _StringsEn {
   @override
   String stat_format_chars({required Object n}) => '${n} caracteres';
   @override
-  String stat_format_chars_wan({required Object n}) => '${n} caracteres';
+  String stat_format_chars_wan({required Object n}) => '${n}万 caracteres';
   @override
   String get error_log_share_subject => 'Registro de errores de hibiki';
   @override
@@ -17660,7 +17660,7 @@ class _StringsFr extends _StringsEn {
   @override
   String stat_format_chars({required Object n}) => '${n} caractères';
   @override
-  String stat_format_chars_wan({required Object n}) => '${n} caractères';
+  String stat_format_chars_wan({required Object n}) => '${n}万 caractères';
   @override
   String get error_log_share_subject => 'Journal d\'erreurs hibiki';
   @override
@@ -22356,7 +22356,7 @@ class _StringsId extends _StringsEn {
   @override
   String stat_format_chars({required Object n}) => '${n} karakter';
   @override
-  String stat_format_chars_wan({required Object n}) => '${n} karakter';
+  String stat_format_chars_wan({required Object n}) => '${n}万 karakter';
   @override
   String get error_log_share_subject => 'Log Error hibiki';
   @override
@@ -27012,7 +27012,7 @@ class _StringsIt extends _StringsEn {
   @override
   String stat_format_chars({required Object n}) => '${n} caratteri';
   @override
-  String stat_format_chars_wan({required Object n}) => '${n} caratteri';
+  String stat_format_chars_wan({required Object n}) => '${n}万 caratteri';
   @override
   String get error_log_share_subject => 'Registro errori hibiki';
   @override
@@ -40691,7 +40691,7 @@ class _StringsNl extends _StringsEn {
   @override
   String stat_format_chars({required Object n}) => '${n} tekens';
   @override
-  String stat_format_chars_wan({required Object n}) => '${n} tekens';
+  String stat_format_chars_wan({required Object n}) => '${n}万 tekens';
   @override
   String get error_log_share_subject => 'hibiki foutenlogboek';
   @override
@@ -45368,7 +45368,7 @@ class _StringsPtBr extends _StringsEn {
   @override
   String stat_format_chars({required Object n}) => '${n} caracteres';
   @override
-  String stat_format_chars_wan({required Object n}) => '${n} caracteres';
+  String stat_format_chars_wan({required Object n}) => '${n}万 caracteres';
   @override
   String get error_log_share_subject => 'Log de Erros do hibiki';
   @override
@@ -50045,7 +50045,7 @@ class _StringsRu extends _StringsEn {
   @override
   String stat_format_chars({required Object n}) => '${n} символов';
   @override
-  String stat_format_chars_wan({required Object n}) => '${n} символов';
+  String stat_format_chars_wan({required Object n}) => '${n}万 символов';
   @override
   String get error_log_share_subject => 'Журнал ошибок hibiki';
   @override
@@ -54698,7 +54698,7 @@ class _StringsTh extends _StringsEn {
   @override
   String stat_format_chars({required Object n}) => '${n} ตัวอักษร';
   @override
-  String stat_format_chars_wan({required Object n}) => '${n} ตัวอักษร';
+  String stat_format_chars_wan({required Object n}) => '${n}万 ตัวอักษร';
   @override
   String get error_log_share_subject => 'บันทึกข้อผิดพลาด hibiki';
   @override
@@ -59319,7 +59319,7 @@ class _StringsTr extends _StringsEn {
   @override
   String stat_format_chars({required Object n}) => '${n} karakter';
   @override
-  String stat_format_chars_wan({required Object n}) => '${n} karakter';
+  String stat_format_chars_wan({required Object n}) => '${n}万 karakter';
   @override
   String get error_log_share_subject => 'hibiki Hata Günlüğü';
   @override
@@ -63957,7 +63957,7 @@ class _StringsVi extends _StringsEn {
   @override
   String stat_format_chars({required Object n}) => '${n} ký tự';
   @override
-  String stat_format_chars_wan({required Object n}) => '${n} ký tự';
+  String stat_format_chars_wan({required Object n}) => '${n}万 ký tự';
   @override
   String get error_log_share_subject => 'Nhật ký lỗi hibiki';
   @override
@@ -77303,7 +77303,7 @@ extension on _StringsEn {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} characters';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} characters';
+        return ({required Object n}) => '${n}万 characters';
       case 'error_log_share_subject':
         return 'hibiki Error Log';
       case 'update_never_remind':
@@ -81417,7 +81417,7 @@ extension on _StringsAr {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} حرف';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} حرف';
+        return ({required Object n}) => '${n}万 حرف';
       case 'error_log_share_subject':
         return 'سجل أخطاء hibiki';
       case 'update_never_remind':
@@ -85588,7 +85588,7 @@ extension on _StringsDe {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} Zeichen';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} Zeichen';
+        return ({required Object n}) => '${n}万 Zeichen';
       case 'error_log_share_subject':
         return 'hibiki Fehlerprotokoll';
       case 'update_never_remind':
@@ -89772,7 +89772,7 @@ extension on _StringsEs {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} caracteres';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} caracteres';
+        return ({required Object n}) => '${n}万 caracteres';
       case 'error_log_share_subject':
         return 'Registro de errores de hibiki';
       case 'update_never_remind':
@@ -93954,7 +93954,7 @@ extension on _StringsFr {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} caractères';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} caractères';
+        return ({required Object n}) => '${n}万 caractères';
       case 'error_log_share_subject':
         return 'Journal d\'erreurs hibiki';
       case 'update_never_remind':
@@ -98144,7 +98144,7 @@ extension on _StringsId {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} karakter';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} karakter';
+        return ({required Object n}) => '${n}万 karakter';
       case 'error_log_share_subject':
         return 'Log Error hibiki';
       case 'update_never_remind':
@@ -102317,7 +102317,7 @@ extension on _StringsIt {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} caratteri';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} caratteri';
+        return ({required Object n}) => '${n}万 caratteri';
       case 'error_log_share_subject':
         return 'Registro errori hibiki';
       case 'update_never_remind':
@@ -114807,7 +114807,7 @@ extension on _StringsNl {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} tekens';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} tekens';
+        return ({required Object n}) => '${n}万 tekens';
       case 'error_log_share_subject':
         return 'hibiki foutenlogboek';
       case 'update_never_remind':
@@ -118985,7 +118985,7 @@ extension on _StringsPtBr {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} caracteres';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} caracteres';
+        return ({required Object n}) => '${n}万 caracteres';
       case 'error_log_share_subject':
         return 'Log de Erros do hibiki';
       case 'update_never_remind':
@@ -123162,7 +123162,7 @@ extension on _StringsRu {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} символов';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} символов';
+        return ({required Object n}) => '${n}万 символов';
       case 'error_log_share_subject':
         return 'Журнал ошибок hibiki';
       case 'update_never_remind':
@@ -127343,7 +127343,7 @@ extension on _StringsTh {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} ตัวอักษร';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} ตัวอักษร';
+        return ({required Object n}) => '${n}万 ตัวอักษร';
       case 'error_log_share_subject':
         return 'บันทึกข้อผิดพลาด hibiki';
       case 'update_never_remind':
@@ -131510,7 +131510,7 @@ extension on _StringsTr {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} karakter';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} karakter';
+        return ({required Object n}) => '${n}万 karakter';
       case 'error_log_share_subject':
         return 'hibiki Hata Günlüğü';
       case 'update_never_remind':
@@ -135684,7 +135684,7 @@ extension on _StringsVi {
       case 'stat_format_chars':
         return ({required Object n}) => '${n} ký tự';
       case 'stat_format_chars_wan':
-        return ({required Object n}) => '${n} ký tự';
+        return ({required Object n}) => '${n}万 ký tự';
       case 'error_log_share_subject':
         return 'Nhật ký lỗi hibiki';
       case 'update_never_remind':

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -425,7 +425,7 @@
   "stat_format_minutes": "$n min",
   "stat_format_hours_minutes": "$h hr $m min",
   "stat_format_chars": "$n characters",
-  "stat_format_chars_wan": "$n characters",
+  "stat_format_chars_wan": "$n万 characters",
   "error_log_share_subject": "hibiki Error Log",
   "update_never_remind": "Don't remind me about updates",
   "update_auto_install": "Auto-install updates",

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -402,7 +402,7 @@
   "stat_format_minutes": "$n د",
   "stat_format_hours_minutes": "$h س $m د",
   "stat_format_chars": "$n حرف",
-  "stat_format_chars_wan": "$n حرف",
+  "stat_format_chars_wan": "$n万 حرف",
   "error_log_share_subject": "سجل أخطاء hibiki",
   "update_never_remind": "عدم التذكير بالتحديثات",
   "update_auto_install": "تثبيت التحديثات تلقائياً",

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -402,7 +402,7 @@
   "stat_format_minutes": "$n Min.",
   "stat_format_hours_minutes": "$h Std. $m Min.",
   "stat_format_chars": "$n Zeichen",
-  "stat_format_chars_wan": "$n Zeichen",
+  "stat_format_chars_wan": "$n万 Zeichen",
   "error_log_share_subject": "hibiki Fehlerprotokoll",
   "update_never_remind": "Nicht mehr erinnern",
   "update_auto_install": "Updates automatisch installieren",

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -402,7 +402,7 @@
   "stat_format_minutes": "$n min",
   "stat_format_hours_minutes": "$h h $m min",
   "stat_format_chars": "$n caracteres",
-  "stat_format_chars_wan": "$n caracteres",
+  "stat_format_chars_wan": "$n万 caracteres",
   "error_log_share_subject": "Registro de errores de hibiki",
   "update_never_remind": "No recordar de nuevo",
   "update_auto_install": "Instalar actualizaciones automáticamente",

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -402,7 +402,7 @@
   "stat_format_minutes": "$n min",
   "stat_format_hours_minutes": "$h h $m min",
   "stat_format_chars": "$n caractères",
-  "stat_format_chars_wan": "$n caractères",
+  "stat_format_chars_wan": "$n万 caractères",
   "error_log_share_subject": "Journal d'erreurs hibiki",
   "update_never_remind": "Ne plus rappeler",
   "update_auto_install": "Installer automatiquement les mises à jour",

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -402,7 +402,7 @@
   "stat_format_minutes": "$n mnt",
   "stat_format_hours_minutes": "$h jam $m mnt",
   "stat_format_chars": "$n karakter",
-  "stat_format_chars_wan": "$n karakter",
+  "stat_format_chars_wan": "$n万 karakter",
   "error_log_share_subject": "Log Error hibiki",
   "update_never_remind": "Jangan ingatkan lagi",
   "update_auto_install": "Pasang pembaruan otomatis",

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -402,7 +402,7 @@
   "stat_format_minutes": "$n min",
   "stat_format_hours_minutes": "$h ore $m min",
   "stat_format_chars": "$n caratteri",
-  "stat_format_chars_wan": "$n caratteri",
+  "stat_format_chars_wan": "$n万 caratteri",
   "error_log_share_subject": "Registro errori hibiki",
   "update_never_remind": "Non ricordarmelo più",
   "update_auto_install": "Installa automaticamente gli aggiornamenti",

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -402,7 +402,7 @@
   "stat_format_minutes": "$n min",
   "stat_format_hours_minutes": "$h uur $m min",
   "stat_format_chars": "$n tekens",
-  "stat_format_chars_wan": "$n tekens",
+  "stat_format_chars_wan": "$n万 tekens",
   "error_log_share_subject": "hibiki foutenlogboek",
   "update_never_remind": "Niet meer herinneren",
   "update_auto_install": "Updates automatisch installeren",

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -402,7 +402,7 @@
   "stat_format_minutes": "$n min",
   "stat_format_hours_minutes": "$h h $m min",
   "stat_format_chars": "$n caracteres",
-  "stat_format_chars_wan": "$n caracteres",
+  "stat_format_chars_wan": "$n万 caracteres",
   "error_log_share_subject": "Log de Erros do hibiki",
   "update_never_remind": "Não lembrar novamente",
   "update_auto_install": "Instalar atualizações automaticamente",

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -402,7 +402,7 @@
   "stat_format_minutes": "$n мин.",
   "stat_format_hours_minutes": "$h ч $m мин.",
   "stat_format_chars": "$n символов",
-  "stat_format_chars_wan": "$n символов",
+  "stat_format_chars_wan": "$n万 символов",
   "error_log_share_subject": "Журнал ошибок hibiki",
   "update_never_remind": "Больше не напоминать",
   "update_auto_install": "Автоустановка обновлений",

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -402,7 +402,7 @@
   "stat_format_minutes": "$n นาที",
   "stat_format_hours_minutes": "$h ชม. $m นาที",
   "stat_format_chars": "$n ตัวอักษร",
-  "stat_format_chars_wan": "$n ตัวอักษร",
+  "stat_format_chars_wan": "$n万 ตัวอักษร",
   "error_log_share_subject": "บันทึกข้อผิดพลาด hibiki",
   "update_never_remind": "ไม่ต้องแจ้งเตือน",
   "update_auto_install": "ติดตั้งอัปเดตอัตโนมัติ",

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -402,7 +402,7 @@
   "stat_format_minutes": "$n dk",
   "stat_format_hours_minutes": "$h sa $m dk",
   "stat_format_chars": "$n karakter",
-  "stat_format_chars_wan": "$n karakter",
+  "stat_format_chars_wan": "$n万 karakter",
   "error_log_share_subject": "hibiki Hata Günlüğü",
   "update_never_remind": "Güncellemeleri hatırlatma",
   "update_auto_install": "Güncellemeleri otomatik yükle",

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -402,7 +402,7 @@
   "stat_format_minutes": "$n phút",
   "stat_format_hours_minutes": "$h giờ $m phút",
   "stat_format_chars": "$n ký tự",
-  "stat_format_chars_wan": "$n ký tự",
+  "stat_format_chars_wan": "$n万 ký tự",
   "error_log_share_subject": "Nhật ký lỗi hibiki",
   "update_never_remind": "Không nhắc lại",
   "update_auto_install": "Tự động cài đặt bản cập nhật",

--- a/hibiki/test/i18n/stat_chars_wan_unit_guard_test.dart
+++ b/hibiki/test/i18n/stat_chars_wan_unit_guard_test.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+/// 守卫 `stat_format_chars_wan`（阅读统计里 ≥10000 字符的汇总文案）在 **每种语言**
+/// 都带上「万」倍率单位（BUG-935 / TODO）。
+///
+/// 事故特征：阅读统计页把字符数除以 10000 后交给 `stat_format_chars_wan` 补单位，
+/// 但 12 种非 CJK 语言（en/de/es/fr/ar/id/it/nl/pt-BR/ru/th/tr/vi）的译文只写了
+/// 「$n characters」之类，漏掉了倍率标记 —— 于是 192000 字被渲染成「19.2 characters」
+/// 而不是「19.2万 characters」，与图表坐标轴标签（`stat_charts.dart` 里硬编码「$x万」）
+/// 不一致。修复方式是在这些语言的译文里补回「万」。CJK 语言各自用 万/萬/만 表达万位。
+///
+/// 本守卫直接扫源文件（json），防止任一语言再次漏掉倍率单位而回潮。
+
+const String _key = 'stat_format_chars_wan';
+
+/// 各语言允许的「万」倍率标记：简体/日文/英文等用 万，繁体用 萬，韩文用 만。
+const List<String> _myriadMarkers = <String>['万', '萬', '만'];
+
+/// 17 个 slang 源文件（相对 `hibiki/` 工作目录）。
+const List<String> _localeFiles = <String>[
+  'strings.i18n.json', // en（默认）
+  'strings_ar.i18n.json',
+  'strings_de.i18n.json',
+  'strings_es.i18n.json',
+  'strings_fr.i18n.json',
+  'strings_id.i18n.json',
+  'strings_it.i18n.json',
+  'strings_ja.i18n.json',
+  'strings_ko.i18n.json',
+  'strings_nl.i18n.json',
+  'strings_pt-BR.i18n.json',
+  'strings_ru.i18n.json',
+  'strings_th.i18n.json',
+  'strings_tr.i18n.json',
+  'strings_vi.i18n.json',
+  'strings_zh-CN.i18n.json',
+  'strings_zh-HK.i18n.json',
+];
+
+void main() {
+  group('stat_format_chars_wan myriad-unit guard (BUG-935)', () {
+    test('every locale keeps the 万/萬/만 multiplier marker', () {
+      final List<String> offenders = <String>[];
+      for (final String name in _localeFiles) {
+        final File file =
+            File(p.join(Directory.current.path, 'lib', 'i18n', name));
+        expect(file.existsSync(), isTrue, reason: '$name 应存在于 ${file.path}');
+        final Map<String, dynamic> json =
+            jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+        expect(json.containsKey(_key), isTrue, reason: '$name 缺少 key "$_key"');
+        final String value = json[_key] as String;
+        final bool hasMarker =
+            _myriadMarkers.any((String m) => value.contains(m));
+        if (!hasMarker) {
+          offenders.add('$name: "$value"');
+        }
+      }
+      expect(offenders, isEmpty,
+          reason: '以下语言的 "$_key" 漏掉「万」倍率单位（会渲染成「19.2 characters」而非'
+              '「19.2万 characters」，与图表坐标轴不一致）：\n${offenders.join("\n")}');
+    });
+  });
+}


### PR DESCRIPTION
## 问题
用户（mamit / Novel Club）报：阅读统计里字符数汇总显示「19.2 characters」，缺了「万」——应为「19.2万 characters」，与图表坐标轴标签一致。日时段图上方的月/总计汇总同病。

## 根因
汇总把字符数 ÷10000 后交给 i18n `stat_format_chars_wan` 补单位（`reading_statistics_page.dart:316-321`），但 12 种非 CJK 语言的译文（含英文，`strings.i18n.json:428` = `"$n characters"`）漏掉「万」倍率标记；坐标轴却在 `stat_charts.dart:34` 硬编码「$x万」。故英文界面数字与坐标轴不一致。仅 zh-CN/zh-HK/ja/ko 原本正确。

## 修复
- 12 语言（en/ar/de/es/fr/id/it/nl/pt-BR/ru/th/tr/vi）的 `stat_format_chars_wan` 补成「$n万 …」，与坐标轴对齐；CJK 四语言不动。
- `dart run slang` 重生 `strings.g.dart`。
- 新守卫 `test/i18n/stat_chars_wan_unit_guard_test.dart`：扫 17 语言源文件，断言每种语言都含万位标记（万/萬/만），防回潮。

## 验证
`flutter test --no-pub test/i18n/` 全绿（含新守卫 + 既有 i18n 完整性/zh-CN mojibake 守卫）。docs/bugs/BUG-935 已记录。

⏳ 待真机目视：英文 locale 下统计页汇总数字显示「N万 characters」。