### PR TITLE
fix(tags): 合集打了标签也能被筛出来 (BUG-937)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,13 +27,14 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 919 条。点号进各自文件。
+> 共 920 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-938](bugs/BUG-938-collections-sync-trigger-gap.md) | ✅ | ✅ | 合集经常没同步：合集维度只搭载低频全量 sweep，日常关书/切后台路径从不推送合集 |
-| [BUG-937](bugs/BUG-937-interconnect-video-cover-n2.md) | ✅ | ✅ | 互联视频浏览极慢：封面端点每张封面重跑整份 listVideos 清单（O(N²)） |
+| [BUG-937](bugs/BUG-937-tag-filter-collection-rescue.md) | ✅ | ✅ | 标签筛选:打了标签的合集筛不出来(成员级过滤先于折叠剥空合集组) |
+| [BUG-936](bugs/BUG-938-collections-sync-trigger-gap.md) | ✅ | ✅ | 合集经常没同步：合集维度只搭载低频全量 sweep，日常关书/切后台路径从不推送合集 |
 | [BUG-936](bugs/BUG-936-video-ime-space-playpause.md) | ✅ | ✅ | 日文IME激活时视频页空格无法播放暂停（BUG-853 修复真机仍失效） |
+| [BUG-935](bugs/BUG-937-interconnect-video-cover-n2.md) | ✅ | ✅ | 互联视频浏览极慢：封面端点每张封面重跑整份 listVideos 清单（O(N²)） |
 | [BUG-935](bugs/BUG-935-stats-chars-wan-unit.md) | ✅ | ✅ | 阅读统计字符数汇总缺万单位 |
 | [BUG-934](bugs/BUG-934-prev-sentence-dup.md) | ✅ | ✅ | 前加一句制卡把当前句重复采集两遍 |
 | [BUG-933](bugs/BUG-933-mining-ui-jank-isolate.md) | ✅ | ✅ | 制卡媒体处理阻塞UI线程未响应 |

--- a/docs/bugs/BUG-937-tag-filter-collection-rescue.md
+++ b/docs/bugs/BUG-937-tag-filter-collection-rescue.md
@@ -1,0 +1,14 @@
+## BUG-937 · 标签筛选:打了标签的合集筛不出来(成员级过滤先于折叠剥空合集组)
+- **报告**：2026-07-20（用户：标签筛选没筛选合集；追问确认「打了标签的合集筛不出来」，书架页+视频页都有）
+- **真实性**：✅ 真 bug。根因是**时序**：成员级标签过滤发生在合集折叠**之前**。
+  - 书架页 epub `reader_hibiki_history_page.dart:364` 谓词 `filterSet.contains(key)`、srt `:790` 谓词 `srtFilterSet.contains(b.id)` 先把成员剥光；视频页 `home_video_page.dart:1695` `filter.contains(b.bookUid)` 同理。
+  - 折叠 `groupByCollections`/`_groupVideos` 只对**存活成员**折叠——合集组仅当有 ≥1 存活成员才生成。
+  - 合集自身打了标签、但成员没打时，成员被上面的成员级过滤全部剥掉 → 折不出该合集组 → 之后按合集标签保留组的 `filteredCollectionIdsProvider`（书架 `:923 removeWhere` / 视频 `collectionVisible`）**无组可留** → 合集永远筛不出来。
+  - 数据层（`CollectionTagMappings` + `getCollectionIdsForAllTags` database.dart:4334）与 provider（`filteredCollectionIdsProvider` tag_filter_sheet.dart:111）都正确，缺口在页面的过滤/折叠**顺序**。
+- **[x] ① 已修复** — 提交 `88dcc7968`
+  - 新增纯函数 `keepMemberUnderTagFilter({memberMatched, primaryCollectionId, collectionFilter})`（`hibiki/lib/src/media/collections/collection_grouping.dart`）：成员存活 ⟺ 自身命中全部标签 **或** 其主折叠合集在 `collectionFilter` 内。消除特例，三处过滤点共用。
+  - 三处成员过滤谓词改用它，并把 `_primaryCollectionByEntry['<type>|<key>']` 主合集 + `filteredCollectionIdsProvider` 传入：epub（`reader_hibiki_history_page.dart` build 闭包）、srt（`_buildBodyWithSrtBooks`，与末尾 `removeWhere` 共用一次 `collectionFilter` 读取）、video（`home_video_page.dart` FutureBuilder 闭包）。
+  - 效果：打了标签的合集其成员整组存活 → 折叠出合集组 → 由既有 collectionFilter 保留，合集能筛出来（并显示全部成员，符合「按合集标签显隐」语义）。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/collection_grouping_test.dart`（提交 `88dcc7968`）
+  - 5 例覆盖 `keepMemberUnderTagFilter`：成员命中→留；**根因场景（成员没命中但合集命中→留）**；成员没命中+合集不在集→剔；散条目没命中→剔；collectionFilter=null 退化旧语义。`flutter test --no-pub` 10/10 通过。
+- **备注**：功能仅存在于 origin/develop（commit a97b74ebd「filter collection cards by selected tags」2026-07-14），主 checkout（落后 648）尚无。修复基于 origin/develop tip。多合集成员按 `getPrimaryCollectionIdByEntry` 的 MIN(collection_id) 主合集判定，与折叠归属同源。

--- a/hibiki/lib/src/media/collections/collection_grouping.dart
+++ b/hibiki/lib/src/media/collections/collection_grouping.dart
@@ -57,6 +57,29 @@ class CollectionGroup<T> {
 
 String _composite(String mediaType, String entryKey) => '$mediaType|$entryKey';
 
+/// 标签筛选下判断一个媒体条目是否应存活到 [groupByCollections] 折叠阶段。
+///
+/// 根因（BUG-937）：成员级标签过滤发生在折叠**之前**。当一个合集自身打了标签、
+/// 但其成员没打时，只按成员标签过滤会把成员全部剥光，导致折叠不出该合集组；
+/// 之后页面按合集标签保留组的 `collectionFilter` 便无组可留，合集永远筛不出来
+/// （用户实报「打了标签的合集筛不出来」）。
+///
+/// 修法（消除特例）：条目存活当且仅当 —— 条目自身命中全部选中标签
+/// （[memberMatched]），**或**其主折叠合集（[primaryCollectionId]，与
+/// [groupByCollections] 折叠归属同源）命中全部选中标签（在 [collectionFilter] 内）。
+/// 后者让被标签命中的合集其成员整组存活、折叠出合集组，再由页面的 collectionFilter
+/// 保留该组。[collectionFilter] 为 null（无选中合集标签维度）或 [primaryCollectionId]
+/// 为 null（散条目/无归属）时，仅按 [memberMatched] 判定，与旧语义一致。
+bool keepMemberUnderTagFilter({
+  required bool memberMatched,
+  required int? primaryCollectionId,
+  required Set<int>? collectionFilter,
+}) {
+  if (memberMatched) return true;
+  if (collectionFilter == null || primaryCollectionId == null) return false;
+  return collectionFilter.contains(primaryCollectionId);
+}
+
 /// 把 [items] 按所属合集折叠，返回 group 列表（散 group 保持输入序、合集 group 在
 /// 首成员位置；卡片间最终排序由页面按排序模式完成）。
 ///

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -1689,11 +1689,23 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         final List<VideoBookRow> all = loaded;
         final Set<String>? filter =
             ref.watch(filteredVideoBookUidsProvider).valueOrNull;
+        // BUG-937：合集标签维度。视频成员级过滤须并入——否则「合集打了标签但成员
+        // 没打」时成员被剥光、_groupVideos 折叠不出合集组，之后 collectionVisible 也
+        // 救不回（无组可留），合集永远筛不出来。
+        final Set<int>? collectionFilter =
+            ref.watch(filteredCollectionIdsProvider).valueOrNull;
         final List<VideoBookRow> books = filter == null
             ? all
-            : all
-                .where((VideoBookRow b) => filter.contains(b.bookUid))
-                .toList();
+            : all.where((VideoBookRow b) {
+                // 成员命中标签、或所属合集命中标签都保留（后者让打了标签的合集其成员
+                // 整组存活、折叠出合集组）。
+                return keepMemberUnderTagFilter(
+                  memberMatched: filter.contains(b.bookUid),
+                  primaryCollectionId:
+                      _primaryCollectionByEntry['video|${b.bookUid}'],
+                  collectionFilter: collectionFilter,
+                );
+              }).toList();
         // 排序交互重设计：卡片间序在 group 层按当前排序方式做（[_groupVideos]），
         // 这里不再预排散列表（旧 ShelfEntries.sortOrder 死权重已废弃，用户拍板）。
         final List<VideoBookRow> ordered = books;

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -327,6 +327,11 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     }());
     final AsyncValue<Set<String>?> filteredIds =
         ref.watch(filteredBookIdsProvider);
+    // BUG-937：合集标签维度（含全部选中标签的合集 id；null=无选中标签不过滤）。成员
+    // 级标签过滤须并入此维度，否则「合集打了标签但成员没打」时成员被剥光、折叠不出
+    // 合集组，合集永远筛不出来。
+    final Set<int>? tagCollectionFilter =
+        ref.watch(filteredCollectionIdsProvider).valueOrNull;
     final allTags = ref.watch(allTagsProvider);
 
     // BUG-250: 书架批量选择模式（[_selectionMode]）活在本 tab 内容里，不是独立
@@ -364,7 +369,15 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
                         filtered = bookList.where((item) {
                           final String? key =
                               _parseBookKey(item.mediaIdentifier);
-                          return key != null && filterSet.contains(key);
+                          if (key == null) return false;
+                          // BUG-937：成员命中标签、或所属合集命中标签都保留（后者让
+                          // 打了标签的合集其成员整组存活，折叠出合集组）。
+                          return keepMemberUnderTagFilter(
+                            memberMatched: filterSet.contains(key),
+                            primaryCollectionId:
+                                _primaryCollectionByEntry['epub|$key'],
+                            collectionFilter: tagCollectionFilter,
+                          );
                         }).toList();
                       }
                       return FutureBuilder<Map<String, _AudiobookInfo>>(
@@ -785,10 +798,21 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     final bool hasActiveFilter = ref.read(selectedTagIdsProvider).isNotEmpty;
     final Set<int>? srtFilterSet =
         ref.watch(filteredSrtBookIdsProvider).valueOrNull;
+    // BUG-937：合集标签维度（含全部选中标签的合集 id）。srt 成员级过滤与末尾的
+    // 合集组保留（[shelfGroups.removeWhere]）共用此集，避免「合集打了标签但成员没打」
+    // 时 srt 成员被剥光、折叠不出合集组。
+    final Set<int>? collectionFilter =
+        ref.watch(filteredCollectionIdsProvider).valueOrNull;
     final List<SrtBook> srtBooks;
     if (srtFilterSet != null) {
       srtBooks = allSrtBooks
-          .where((b) => b.id != null && srtFilterSet.contains(b.id))
+          .where((b) =>
+              b.id != null &&
+              keepMemberUnderTagFilter(
+                memberMatched: srtFilterSet.contains(b.id),
+                primaryCollectionId: _primaryCollectionByEntry['srt|${b.uid}'],
+                collectionFilter: collectionFilter,
+              ))
           .toList();
     } else if (hasActiveFilter) {
       srtBooks = const [];
@@ -918,8 +942,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     // 合集标签过滤：含【全部】选中标签的合集 id（null = 无选中标签，不过滤）。被标签
     // 过滤隐藏的合集连同成员从 shelfGroups 移除（成员随合集隐藏，符合按合集标签显隐
     // 语义）；散书由 filteredBookIdsProvider / filteredSrtBookIdsProvider 另行过滤。
-    final Set<int>? collectionFilter =
-        ref.watch(filteredCollectionIdsProvider).valueOrNull;
+    // collectionFilter 已在 srt 过滤前读取（BUG-937 成员救回共用同一集）。
     if (collectionFilter != null) {
       shelfGroups.removeWhere((CollectionGroup<_ShelfBookSlot> g) =>
           g.collection != null && !collectionFilter.contains(g.collection!.id));

--- a/hibiki/test/media/collection_grouping_test.dart
+++ b/hibiki/test/media/collection_grouping_test.dart
@@ -127,4 +127,62 @@ void main() {
       <String>['looseA', 'S', 'looseB'],
     );
   });
+
+  group('keepMemberUnderTagFilter (BUG-937 合集标签救回成员)', () {
+    test('成员自身命中标签 → 保留', () {
+      expect(
+        keepMemberUnderTagFilter(
+          memberMatched: true,
+          primaryCollectionId: null,
+          collectionFilter: null,
+        ),
+        isTrue,
+      );
+    });
+
+    test('根因场景：成员没命中、但所属合集命中标签 → 保留（旧逻辑会剥光成员→合集筛不出）',
+        () {
+      expect(
+        keepMemberUnderTagFilter(
+          memberMatched: false,
+          primaryCollectionId: 7,
+          collectionFilter: <int>{7},
+        ),
+        isTrue,
+      );
+    });
+
+    test('成员没命中、所属合集也不在筛选集 → 剔除', () {
+      expect(
+        keepMemberUnderTagFilter(
+          memberMatched: false,
+          primaryCollectionId: 7,
+          collectionFilter: <int>{3, 5},
+        ),
+        isFalse,
+      );
+    });
+
+    test('散条目（无合集归属）没命中标签 → 剔除', () {
+      expect(
+        keepMemberUnderTagFilter(
+          memberMatched: false,
+          primaryCollectionId: null,
+          collectionFilter: <int>{1},
+        ),
+        isFalse,
+      );
+    });
+
+    test('collectionFilter 为 null（无合集标签维度）→ 仅按成员命中，与旧语义一致', () {
+      expect(
+        keepMemberUnderTagFilter(
+          memberMatched: false,
+          primaryCollectionId: 7,
+          collectionFilter: null,
+        ),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## 现象
用户报「标签筛选没筛选合集」→ 追问确认是**「打了标签的合集筛不出来」**，书架页 + 视频页都有。

## 根因（时序，非补丁）
成员级标签过滤发生在合集折叠**之前**：
- 书架 epub `reader_hibiki_history_page.dart` / srt `_buildBodyWithSrtBooks`、视频 `home_video_page.dart` 都先按成员标签把成员剥光。
- `groupByCollections` / `_groupVideos` 只对**存活成员**折叠——合集组仅当有 ≥1 存活成员才生成。
- 合集自身打了标签、但成员没打时，成员被全部剥掉 → 折不出合集组 → 之后按合集标签保留组的 `filteredCollectionIdsProvider`（书架 `removeWhere` / 视频 `collectionVisible`）**无组可留** → 合集永远筛不出来。
- 数据层（`getCollectionIdsForAllTags`）与 provider 都正确，缺口在页面过滤/折叠**顺序**。

## 修复（消除特例）
新增纯函数 `keepMemberUnderTagFilter({memberMatched, primaryCollectionId, collectionFilter})`：成员存活 ⟺ **自身命中全部标签 OR 其主折叠合集在 collectionFilter 内**。三处成员过滤谓词（epub/srt/video）改用它，把 `_primaryCollectionByEntry['<type>|<key>']` 主合集 + `filteredCollectionIdsProvider` 传入。被标签命中的合集其成员整组存活 → 折叠出合集组 → 由既有 collectionFilter 保留（并显示全部成员，符合「按合集标签显隐」语义）。

## 测试
`hibiki/test/media/collection_grouping_test.dart` 加 5 例（含**根因场景**：成员没命中但合集命中→保留）。`flutter test --no-pub` 10/10 通过；改动 4 文件 `flutter analyze` 零问题。

## 备注
功能仅在 origin/develop（commit a97b74ebd，2026-07-14），主 checkout 落后 648 尚无；本 PR 基于 develop tip。**待真机复测**：书架/视频页给合集打标签→按该标签筛→合集应出现且含全部成员。

BUG: docs/bugs/BUG-937-tag-filter-collection-rescue.md