### PR TITLE
fix(lookup): preserve Texthooker popup WebView identity

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,7 +27,7 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 826 条。点号进各自文件。
+> 共 827 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
@@ -48,6 +48,7 @@
 | [BUG-830](bugs/BUG-830-playlist-collection-not-reconciled.md) | ✅ | ✅ | m3u8播放列表增删视频后合集成员不更新 |
 | [BUG-829](bugs/BUG-829-ffprobe-missing-logged-as-error.md) | ✅ | ✅ | 内封字幕字体枚举缺 ffprobe 被当错误记日志 |
 | [BUG-828](bugs/BUG-828-backup-orphan-tables-leak.md) | ✅ | ✅ | 备份导出泄漏合集/标签/书架/搜索历史/删除墓碑等未受类别控制的孤儿表 |
+| [BUG-827](bugs/BUG-827-texthooker-popup-platform-view-reparent.md) | ✅ | ✅ | 捕获工作台查词 WebView 重建后空白卡死 |
 | [BUG-827](bugs/BUG-827-android-mine-cover-fileprovider.md) | ✅ | ✅ | 安卓阅读器制卡书籍封面缺失(FileProvider 未覆盖 app_flutter 解压目录) |
 | [BUG-826](bugs/BUG-826-popup-topbar-overlap-narrow.md) | ✅ | ✅ | 查词弹窗顶栏按钮窄宽时重叠 |
 | [BUG-825](bugs/BUG-825-subtitle-hit-seekbar.md) | ✅ | ✅ | 点视频进度条被误判成点字幕触发查词 |

--- a/docs/bugs/BUG-827-texthooker-popup-platform-view-reparent.md
+++ b/docs/bugs/BUG-827-texthooker-popup-platform-view-reparent.md
@@ -1,0 +1,6 @@
+## BUG-827 · 捕获工作台查词 WebView 重建后空白卡死
+- **报告**：2026-07-20（用户：）
+- **真实性**：✅ 真 bug。冷查词期间 `Stack` 同时包含加载占位和隐藏的弹窗层；结果就绪后占位被移除，未带 key 的两个顶层 `Positioned` 按槽位更新，导致旧槽位里的 Windows WebView 平台视图被销毁，只留下空白弹窗外壳（`hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart:572`、`hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart:269`）。
+- **[x] ① 已修复** — `parkedPopupLayer` 接收并透传 key，调用处用 `ObjectKey(entry)` 固定整层身份；加载占位消失时 Flutter 搬移既有元素，不再拆建 WebView 原生表面。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/dictionary_page_mixin_warm_slot_test.dart` 覆盖冷查词占位移除前后：断言弹窗层 `Element` 与 WebView `State` 均保持同一实例；修复前红、修复后绿。
+- **备注**：Windows Debug 实机重新附着运行中的 9-nine（PID 44132），点击“ 大丈夫 ”后词典正文正常显示并驻留 12 秒。`wgc_capture.log` 同期记录 `create-bridge → set-size → frame-first-success`，未再出现复现时约 6 秒后的 `cpv-dtor`。本提交另通过 4 个相关测试文件（16 tests）及目标文件 `dart analyze`。

--- a/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -565,6 +565,11 @@ mixin DictionaryPageMixin {
             Brightness.dark;
     // BUG-135 parking + Visibility 几何收口在 [parkedPopupLayer]。
     return parkedPopupLayer(
+      // BUG-827：搜索占位层消失时本层会在 Stack children 中前移一位。若顶层
+      // Positioned 无 key，Flutter 会按位置把「占位层的 Positioned」更新成本层、
+      // 再销毁旧位置的平台 WebView；Windows 上最终只剩空白弹窗外壳。以 entry
+      // 身份钉住整层，让元素真正搬位而不是拆建原生表面。
+      key: ObjectKey(entry),
       pos: pos,
       // BUG-797：「选择句子上下文」原生对话框打开期间把弹窗停靠屏外，否则原生平台视图盖住对话框。
       visible: entry.visible && !_sentenceContextDialogOpen,

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -267,12 +267,14 @@ Rect anchorPopupTopLeft({
 /// 此前各写一份此 parking + Visibility 几何（BUG-135 的 `parked ? width+8` 改一处忘另
 /// 一处即漂移），收口于此；两宿主各自的 [DictionaryPopupLayer] 回调差异留在各自方法。
 Widget parkedPopupLayer({
+  Key? key,
   required Rect pos,
   required bool visible,
   required Size screen,
   required Widget child,
 }) {
   return Positioned(
+    key: key,
     left: visible ? pos.left : screen.width + 8,
     top: visible ? pos.top : 0,
     width: pos.width,

--- a/hibiki/test/pages/dictionary_page_mixin_warm_slot_test.dart
+++ b/hibiki/test/pages/dictionary_page_mixin_warm_slot_test.dart
@@ -101,6 +101,13 @@ class MixinHostPageState extends ConsumerState<MixinHostPage>
         autoRead: false,
       );
 
+  void reveal(DictionaryPopupEntry entry) {
+    setState(() {
+      controller.revealRendered(entry);
+      controller.endSearchUi();
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
@@ -108,6 +115,11 @@ class MixinHostPageState extends ConsumerState<MixinHostPage>
         final Size screen = Size(constraints.maxWidth, constraints.maxHeight);
         return Stack(
           children: <Widget>[
+            if (controller.isSearchingUi && controller.pendingRect != null)
+              buildPopupLoadingPlaceholder(
+                rect: controller.pendingRect!,
+                screen: screen,
+              ),
             for (int i = 0; i < controller.entries.length; i++)
               buildNestedPopupLayer(
                 index: i,
@@ -209,6 +221,45 @@ void main() {
     expect(entry.visible, isTrue);
     expect(entry.revealOnRender, isFalse);
     expect(state.controller.isSearchingUi, isFalse);
+  });
+
+  testWidgets(
+      'cold popup keeps its keyed layer element when loading placeholder is removed',
+      (WidgetTester tester) async {
+    final key = GlobalKey<MixinHostPageState>();
+    await tester.pumpWidget(
+      wrap(
+        MixinTestAppModel(
+          results: <DictionaryEntry>[
+            DictionaryEntry(word: '語', reading: 'ご', meaning: 'word'),
+          ],
+        ),
+        key,
+      ),
+    );
+
+    final MixinHostPageState state = key.currentState!;
+    await state.lookup('語');
+    await tester.pump();
+
+    final DictionaryPopupEntry entry = state.controller.entries.single;
+    final Finder popupLayer = find.byKey(ObjectKey(entry));
+    expect(state.controller.isSearchingUi, isTrue);
+    expect(popupLayer, findsOneWidget,
+        reason: 'The parked platform-view layer needs an entry-identity key so '
+            'removing the preceding loading placeholder moves, rather than '
+            'recreates, the Windows WebView subtree.');
+    final Element beforeReveal = tester.element(popupLayer);
+    final Object? webViewBeforeReveal = entry.webViewKey.currentState;
+    expect(webViewBeforeReveal, isNotNull);
+
+    state.reveal(entry);
+    await tester.pump();
+
+    expect(state.controller.isSearchingUi, isFalse);
+    expect(popupLayer, findsOneWidget);
+    expect(tester.element(popupLayer), same(beforeReveal));
+    expect(entry.webViewKey.currentState, same(webViewBeforeReveal));
   });
 
   testWidgets('reuseWarmSlot drops nested children but keeps the warm WebView',


### PR DESCRIPTION
## What changed

- Give each parked dictionary popup layer a stable `ObjectKey(entry)`.
- Forward the key to the top-level `Positioned` that owns the popup platform-view subtree.
- Add a widget regression test that verifies both the popup `Element` and WebView `State` survive removal of the cold-lookup loading placeholder.
- Record the verified defect as BUG-827.

## Why

During a cold Texthooker lookup, the popup `Stack` temporarily contains two unkeyed top-level `Positioned` children: the loading placeholder and the hidden dictionary popup. When the result arrives, removing the placeholder shifts the popup to the preceding slot. Flutter updates the children by position, tears down the old Windows WebView platform-view subtree, and can leave a blank popup shell.

Keeping the popup layer keyed by its entry identity makes Flutter move the existing element instead of recreating the native WebView surface.

## User impact

Dictionary cards opened from captured game text now remain visible instead of becoming a blank, apparently frozen card after loading.

## Validation

- `flutter test test/pages/dictionary_page_mixin_warm_slot_test.dart test/pages/parked_popup_layer_dedup_test.dart test/pages/texthooker_page_test.dart` — 10 tests passed.
- `dart analyze lib/src/pages/implementations/dictionary_popup_layer.dart lib/src/pages/implementations/dictionary_page_mixin.dart test/pages/dictionary_page_mixin_warm_slot_test.dart` — no issues found.
- Windows Debug manual check with a running 9-nine Hook session: looked up `大丈夫`, confirmed dictionary content remained rendered for 12 seconds, and confirmed the native capture log contained `create-bridge → set-size → frame-first-success` without the previous `cpv-dtor` teardown.
