### PR TITLE
fix(home): 宽屏首页空白修复 + 统计合集名（PR#270 后续未落地的两提交）

### DIFF
--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -98,7 +98,19 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
   }
 
   /// 一次性异步载入视频库 + 统计行 + 活动事件，并派生热力图/时长窗口/最近观看映射。
+  ///
+  /// 整段包 try/catch fail-open：任一 DB 读抛异常也不会让整页卡在 loading 或抛未捕获
+  /// 异常（各区块对空数据都有降级），并补 [ErrorLogService] 使「首页空」这类问题线上
+  /// 可诊断（对照 reader/video 侧统计 flush 的同款 fail-open）。
   Future<void> _loadDashboardData() async {
+    try {
+      await _loadDashboardDataUnsafe();
+    } catch (e, stack) {
+      ErrorLogService.instance.log('HomeDashboardPage.load', e, stack);
+    }
+  }
+
+  Future<void> _loadDashboardDataUnsafe() async {
     final AppModel appModel = ref.read(appProvider);
     final HibikiDatabase db = appModel.database;
     final List<VideoBookRow> videos = await widget.videoRepo.listForShelf();
@@ -169,11 +181,16 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
         final bool wide = constraints.maxWidth >= 900;
         final Widget bodyBelow;
         if (wide) {
+          // 两列并排（左：继续+热力图；右：Activity）。整页在纵向滚动的 ListView 里，
+          // Row 收到的高度约束是无界（h=Infinity）；左列 Column 必须 mainAxisSize.min
+          // 让其高度收敛到内容，否则默认 MainAxisSize.max 会「被迫无限高」而在 layout
+          // 阶段抛 BoxConstraints forces an infinite height，导致宽屏首页整块空白。
           bodyBelow = Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               Expanded(
                 child: Column(
+                  mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: <Widget>[
                     continueCard,
@@ -244,16 +261,20 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
         SizedBox(height: tokens.spacing.gap),
         LayoutBuilder(
           builder: (BuildContext context, BoxConstraints c) {
-            // 宽度足够 4 格横排，否则 2×2 换行。
+            // 宽度足够 4 格横排，否则 2×2 换行。IntrinsicHeight 收界：整页在纵向
+            // ListView 里高度无界，裸 Row(stretch) 会被迫无限高而 layout 崩溃（宽屏
+            // 首页整块空白的同款根因）；IntrinsicHeight 让 Row 高度 = 最高格的自然高。
             if (c.maxWidth >= 560) {
-              return Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: <Widget>[
-                  for (int i = 0; i < tiles.length; i++) ...<Widget>[
-                    if (i > 0) SizedBox(width: tokens.spacing.gap),
-                    Expanded(child: tiles[i]),
+              return IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    for (int i = 0; i < tiles.length; i++) ...<Widget>[
+                      if (i > 0) SizedBox(width: tokens.spacing.gap),
+                      Expanded(child: tiles[i]),
+                    ],
                   ],
-                ],
+                ),
               );
             }
             return Column(
@@ -269,15 +290,18 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
     );
   }
 
-  /// 2×2 布局的一行两格。
+  /// 2×2 布局的一行两格。IntrinsicHeight 收界（同 4 格横排：纵向 ListView 下裸
+  /// Row(stretch) 会被迫无限高崩溃）。
   Widget _statRow(HibikiDesignTokens tokens, Widget left, Widget right) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: <Widget>[
-        Expanded(child: left),
-        SizedBox(width: tokens.spacing.gap),
-        Expanded(child: right),
-      ],
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Expanded(child: left),
+          SizedBox(width: tokens.spacing.gap),
+          Expanded(child: right),
+        ],
+      ),
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
@@ -37,6 +37,14 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
 
   List<ReadingStatisticRow> _allStats = [];
 
+  /// 合集归属映射（书架同源）：按书 tile 显示所属合集名用。
+  /// - [_collectionNamesById]：collectionId → 合集名。
+  /// - [_primaryCollectionByEntry]：'epub|<bookKey>' → 折叠归属的主 collectionId。
+  /// - [_bookKeyByTitle]：reading_statistics 只存 title，经 epub_books 反查 bookKey。
+  Map<int, String> _collectionNamesById = <int, String>{};
+  Map<String, int> _primaryCollectionByEntry = <String, int>{};
+  Map<String, String> _bookKeyByTitle = <String, String>{};
+
   // 聚合数据
   int _todayChars = 0;
   int _todayMs = 0;
@@ -131,6 +139,16 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
       );
       _bookCounters = aggregateStatCountersByTitle(counters);
       _bookFavorites = aggregateStatFavoritesByTitle(favs);
+      // 合集归属（书架同源）：title→bookKey→'epub|bookKey'→合集名，喂 per-book tile。
+      _collectionNamesById = <int, String>{
+        for (final MediaCollectionRow c in await db.getAllMediaCollections())
+          c.id: c.name,
+      };
+      _primaryCollectionByEntry = await db.getPrimaryCollectionIdByEntry();
+      _bookKeyByTitle = <String, String>{
+        for (final EpubBookRow r in await db.getAllEpubBooks())
+          r.title: r.bookKey,
+      };
       // 收藏语句按 source 分桶：非视频来源（书内 / 有声书 / 歌词）都归阅读统计。
       // BUG-893：写入端此前不带 dateKey，旧的 `dateKey != null` 过滤把所有书内收藏
       // 滤光 → 统计恒为 0。改用 `dateKey ?? statDateKey(createdAt)` 回退——createdAt
@@ -1114,11 +1132,24 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     await _loadFromDatabase();
   }
 
+  /// 按书 tile 的所属合集名（书架同款「主合集」折叠归属，无则 null）。title→bookKey
+  /// 经 epub_books 反查（reading_statistics 只存 title），拼 'epub|<bookKey>' 命中。
+  String? _collectionNameForBook(String title) {
+    final String? bookKey = _bookKeyByTitle[title];
+    if (bookKey == null) return null;
+    return statCollectionName(
+      'epub|$bookKey',
+      _primaryCollectionByEntry,
+      _collectionNamesById,
+    );
+  }
+
   Widget _buildBookTile(_BookData book) {
     // TODO-1204：查词/制卡计数按 title 聚合（无记录则 0）。
     final ({int lookups, int mines}) counter =
         _bookCounters[book.title] ?? (lookups: 0, mines: 0);
     final int favorites = _bookFavorites[book.title] ?? 0;
+    final String? collectionName = _collectionNameForBook(book.title);
     // 进度条填充维度 = 当前排序维度（W1）：first 是当前排序下第一名（最大值）。
     final double topMetric =
         _bookData.isEmpty ? 0 : _sortMetric(_bookData.first);
@@ -1145,6 +1176,10 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
                 overflow: TextOverflow.ellipsis,
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
+              if (collectionName != null) ...[
+                SizedBox(height: tokens.spacing.gap / 4),
+                buildStatCollectionLabel(context, collectionName),
+              ],
               SizedBox(height: tokens.spacing.gap / 2),
               Row(
                 children: [

--- a/hibiki/lib/src/pages/implementations/stat_shared.dart
+++ b/hibiki/lib/src/pages/implementations/stat_shared.dart
@@ -25,6 +25,50 @@ Map<String, ({int lookups, int mines})> aggregateStatCountersByTitle(
   return out;
 }
 
+/// 纯函数：把 '<mediaType>|<entryKey>' 归属键解析成合集名。[key] 命中折叠归属的主
+/// collectionId（[primaryByEntry]，即 getPrimaryCollectionIdByEntry），再取 [namesById]
+/// 的名字；任一步缺失返回 null。锁死统计页 'epub|<bookKey>' / 'video|<bookUid>' 键契约
+/// （书架成员表 entryKey：epub=bookKey、video=bookUid）。
+String? statCollectionName(
+  String key,
+  Map<String, int> primaryByEntry,
+  Map<int, String> namesById,
+) {
+  final int? cid = primaryByEntry[key];
+  if (cid == null) return null;
+  return namesById[cid];
+}
+
+/// 统计页 per-book / per-video tile 的「所属合集」小标签（文件夹图标 + 合集名），
+/// 阅读统计与视频统计共用（同一视觉）。合集名为 null 时调用方不渲染本 widget。
+Widget buildStatCollectionLabel(
+  BuildContext context,
+  String collectionName,
+) {
+  final ColorScheme colorScheme = Theme.of(context).colorScheme;
+  return Row(
+    mainAxisSize: MainAxisSize.min,
+    children: <Widget>[
+      Icon(
+        Icons.folder_outlined,
+        size: 13,
+        color: colorScheme.onSurfaceVariant,
+      ),
+      const SizedBox(width: 4),
+      Flexible(
+        child: Text(
+          collectionName,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+        ),
+      ),
+    ],
+  );
+}
+
 /// TODO-1252：把收藏活行按 [FavoriteWordRow.title] 聚合成每本书/每个视频的收藏数，
 /// 供 per-book / per-video tile 展示。无书收藏（title 空）不入 tile，只进汇总面板。
 /// 聚合键与查词/制卡 tile 的 title 一致。收藏取消即删行 → 聚合活行天然回落。

--- a/hibiki/lib/src/pages/implementations/video_statistics_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_statistics_page.dart
@@ -28,6 +28,14 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
   VideoStatsAggregate _agg = VideoStatsAggregate();
   bool _hasData = false;
 
+  /// 合集归属映射（书架同源）：按视频 tile 显示所属合集名用。
+  /// - [_collectionNamesById]：collectionId → 合集名。
+  /// - [_primaryCollectionByEntry]：'video|<bookUid>' → 折叠归属的主 collectionId。
+  /// - [_bookUidByTitle]：video_watch_statistics 按 title 聚合，经 video_books 反查 uid。
+  Map<int, String> _collectionNamesById = <int, String>{};
+  Map<String, int> _primaryCollectionByEntry = <String, int>{};
+  Map<String, String> _bookUidByTitle = <String, String>{};
+
   // 制卡 / 收藏计数（来源 'video'），按今日/本周/本月/全部分桶。
   StatActivityBuckets _mined = StatActivityBuckets();
   StatActivityBuckets _favorited = StatActivityBuckets();
@@ -71,6 +79,16 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
           .map((VideoBookRow b) => b.completedAt)
           .whereType<DateTime>()
           .toList();
+      // 合集归属（书架同源）：title→bookUid→'video|bookUid'→合集名，喂 per-video tile。
+      // bookUid 直接取自已加载的 video_books（无需额外查询）。
+      _bookUidByTitle = <String, String>{
+        for (final VideoBookRow b in books) b.title: b.bookUid,
+      };
+      _collectionNamesById = <int, String>{
+        for (final MediaCollectionRow c in await db.getAllMediaCollections())
+          c.id: c.name,
+      };
+      _primaryCollectionByEntry = await db.getPrimaryCollectionIdByEntry();
       final DateTime now = DateTime.now();
       _agg = computeVideoStats(
         stats: stats,
@@ -361,11 +379,24 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
     await _loadFromDatabase();
   }
 
+  /// 按视频 tile 的所属合集名（书架同款「主合集」折叠归属，无则 null）。title→bookUid
+  /// 经 video_books 反查（video_watch_statistics 按 title 聚合），拼 'video|<bookUid>'。
+  String? _collectionNameForVideo(String title) {
+    final String? bookUid = _bookUidByTitle[title];
+    if (bookUid == null) return null;
+    return statCollectionName(
+      'video|$bookUid',
+      _primaryCollectionByEntry,
+      _collectionNamesById,
+    );
+  }
+
   Widget _buildVideoTile(VideoStatBookData video) {
     // TODO-1204：查词/制卡计数按 title 聚合（无记录则 0）。
     final ({int lookups, int mines}) counter =
         _videoCounters[video.title] ?? (lookups: 0, mines: 0);
     final int favorites = _videoFavorites[video.title] ?? 0;
+    final String? collectionName = _collectionNameForVideo(video.title);
     // 按观看时长排行（byVideo 已按 ms 降序），进度条与排行同维度。
     final maxMs =
         _agg.byVideo.isEmpty ? 1 : _agg.byVideo.first.ms.clamp(1, 1 << 50);
@@ -393,6 +424,10 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
                 overflow: TextOverflow.ellipsis,
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
+              if (collectionName != null) ...[
+                SizedBox(height: tokens.spacing.gap / 4),
+                buildStatCollectionLabel(context, collectionName),
+              ],
               SizedBox(height: tokens.spacing.gap / 2),
               Row(
                 children: [

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -1,0 +1,180 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/media.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/anki/anki_view_model.dart';
+import 'package:hibiki/src/media/video/video_book_repository.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/home_dashboard_page.dart';
+import 'package:hibiki/src/platform/platform_providers.dart';
+import 'package:hibiki/src/platform/platform_services.dart';
+import 'package:hibiki/src/utils/components/stat_contribution_heatmap.dart';
+import 'package:hibiki/src/utils/misc/hibiki_time_format.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/fake_anki_repository.dart';
+import '../helpers/test_platform_services.dart';
+
+/// 首页仪表盘布局回归：**宽屏（PC/横屏）曾因把 stretch/Expanded 的 Row 直接放进纵向
+/// ListView（高度无界）而在 layout 阶段抛「BoxConstraints forces an infinite height」，
+/// 导致整页空白**。本测试锁死宽/窄两分支渲染都不抛异常、各区块结构可见。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('hibiki_dashboard_pp');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      pathProviderDir.deleteSync(recursive: true);
+    }
+  });
+
+  late HibikiDatabase db;
+  late PlatformServices platformServices;
+  late FakeAnkiRepository ankiRepository;
+  late AppModel appModel;
+  late Directory storeDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    final PreferencesRepository prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir = Directory.systemTemp.createTempSync('hibiki_dashboard');
+    platformServices = testPlatformServices();
+    ankiRepository = FakeAnkiRepository();
+    appModel = AppModel(platformServices)
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (storeDir.existsSync()) {
+      storeDir.deleteSync(recursive: true);
+    }
+  });
+
+  Widget buildApp() => ProviderScope(
+        overrides: <Override>[
+          platformServicesProvider.overrideWithValue(platformServices),
+          ankiRepositoryProvider.overrideWithValue(ankiRepository),
+          appProvider.overrideWith((ref) => appModel),
+          // 覆盖书列表 provider：真实实现依赖 _epubBookKeysProvider 的 drift .watch()
+          // 流，会让 widget 测试进程永不终止（drift watch teardown 挂起 gotcha）。本
+          // 测试聚焦布局不崩 + 视频继续/热力图/活动渲染，书列表用空值即可。
+          hibikiBooksProvider
+              .overrideWith((ref, language) async => <MediaItem>[]),
+          bookLastReadAtProvider.overrideWith((ref) async => <String, int>{}),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: HomeDashboardPage(videoRepo: VideoBookRepository(db)),
+            ),
+          ),
+        ),
+      );
+
+  // 有界 pump：不用 pumpAndSettle（真实 DB isolate + FutureProvider 在 fakeAsync 下
+  // 不会 settle，会挂起）。三帧足够跑完 build + initState 异步载入回填。
+  Future<void> pumpDashboard(WidgetTester tester) async {
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump(const Duration(milliseconds: 200));
+  }
+
+  Future<void> seedSampleData() async {
+    final DateTime now = DateTime.now();
+    final String todayKey = HibikiTimeFormat.dayKey(now);
+    await db.addReadingStatistic(
+      title: '吾輩は猫である',
+      dateKey: todayKey,
+      charsRead: 800,
+      timeMs: 600000,
+    );
+    await db.addActivityEvent(
+      eventType: kActivityRead,
+      mediaType: kActivityMediaBook,
+      title: '活动书名',
+      dateKey: todayKey,
+      timestampMs: now.millisecondsSinceEpoch,
+      durationMs: 600000,
+      charsDelta: 800,
+    );
+    await db.upsertVideoBook(const VideoBooksCompanion(
+      bookUid: Value('video/keep-watching'),
+      title: Value('继续看的视频'),
+      videoPath: Value('/abs/keep.mp4'),
+      lastPositionMs: Value(754000),
+    ));
+  }
+
+  testWidgets('宽屏（1280）有数据：渲染不抛无限高度，四区块结构可见', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await seedSampleData();
+    await tester.pumpWidget(buildApp());
+    await pumpDashboard(tester);
+
+    expect(tester.takeException(), isNull);
+    // 四区块标题结构可见（不依赖异步数据回填即渲染）。
+    expect(find.text(t.home_continue), findsOneWidget);
+    expect(find.text(t.reading_activity), findsOneWidget);
+    expect(find.text(t.home_activity), findsOneWidget);
+    expect(find.byType(StatContributionHeatmap), findsOneWidget);
+  });
+
+  testWidgets('窄屏（420）空 DB：堆叠分支渲染不抛异常', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(420, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(buildApp());
+    await pumpDashboard(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(StatContributionHeatmap), findsOneWidget);
+    expect(find.text(t.home_activity), findsOneWidget);
+  });
+
+  testWidgets('宽屏 560~900 临界（4 格横排统计卡）不抛无限高度', (WidgetTester tester) async {
+    // 700px：走「统计卡 4 格横排」但「主体单列堆叠」——曾是 stretch Row 崩溃点。
+    tester.view.physicalSize = const Size(700, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await seedSampleData();
+    await tester.pumpWidget(buildApp());
+    await pumpDashboard(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(StatContributionHeatmap), findsOneWidget);
+  });
+}

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -163,6 +163,56 @@ void main() {
     expect(find.text(t.home_activity), findsOneWidget);
   });
 
+  testWidgets('宽屏 1280 + 真实载入数据（异步回填后）：下段两列渲染不抛无限高度',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final DateTime now = DateTime.now();
+    for (int i = 0; i < 20; i++) {
+      final String dk =
+          HibikiTimeFormat.dayKey(now.subtract(Duration(days: i)));
+      await db.addReadingStatistic(
+        title: '书$i',
+        dateKey: dk,
+        charsRead: 500 + i * 10,
+        timeMs: 300000,
+      );
+      await db.addActivityEvent(
+        eventType: i.isEven ? kActivityRead : kActivityWatch,
+        mediaType: i.isEven ? kActivityMediaBook : kActivityMediaVideo,
+        title: '活动$i',
+        dateKey: dk,
+        timestampMs: now.subtract(Duration(days: i)).millisecondsSinceEpoch,
+        durationMs: 120000,
+      );
+    }
+    for (int i = 0; i < 3; i++) {
+      await db.upsertVideoBook(VideoBooksCompanion(
+        bookUid: Value('video/watch$i'),
+        title: Value('在看$i'),
+        videoPath: Value('/abs/w$i.mp4'),
+        lastPositionMs: const Value(60000),
+      ));
+    }
+
+    // runAsync 让真实 DB isolate 的 _loadDashboardData 跑完（fakeAsync 的 pump 不推进
+    // 后台 isolate），再退出 runAsync pump 应用 setState → 用真数据重建下段。
+    await tester.runAsync(() async {
+      await tester.pumpWidget(buildApp());
+      await Future<void>.delayed(const Duration(milliseconds: 600));
+    });
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(t.home_continue), findsOneWidget);
+    expect(find.text(t.home_activity), findsOneWidget);
+    expect(find.byType(StatContributionHeatmap), findsOneWidget);
+  });
+
   testWidgets('宽屏 560~900 临界（4 格横排统计卡）不抛无限高度', (WidgetTester tester) async {
     // 700px：走「统计卡 4 格横排」但「主体单列堆叠」——曾是 stretch Row 崩溃点。
     tester.view.physicalSize = const Size(700, 900);

--- a/hibiki/test/pages/stat_collection_name_test.dart
+++ b/hibiki/test/pages/stat_collection_name_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/stat_shared.dart';
+
+/// 守卫统计页「按书/按视频 tile 显示所属合集名」的解析契约：
+/// '<mediaType>|<entryKey>' 归属键（epub=bookKey / video=bookUid）经折叠归属主
+/// collectionId 映到合集名，任一步缺失回退 null。
+void main() {
+  group('statCollectionName', () {
+    final Map<String, int> primaryByEntry = <String, int>{
+      'epub|book-a': 1,
+      'video|uid-x': 2,
+    };
+    final Map<int, String> namesById = <int, String>{
+      1: '夏目漱石全集',
+      2: '进击的巨人 第一季',
+    };
+
+    test('书 entryKey=bookKey 命中合集名', () {
+      expect(
+        statCollectionName('epub|book-a', primaryByEntry, namesById),
+        '夏目漱石全集',
+      );
+    });
+
+    test('视频 entryKey=bookUid 命中合集名', () {
+      expect(
+        statCollectionName('video|uid-x', primaryByEntry, namesById),
+        '进击的巨人 第一季',
+      );
+    });
+
+    test('条目不属任何合集 → null', () {
+      expect(
+        statCollectionName('epub|orphan', primaryByEntry, namesById),
+        isNull,
+      );
+    });
+
+    test('归属到已被删除的合集（名字缺失）→ null 不崩', () {
+      expect(
+        statCollectionName(
+          'epub|dangling',
+          <String, int>{'epub|dangling': 99},
+          namesById,
+        ),
+        isNull,
+      );
+    });
+
+    test('媒体前缀区分：同 entryKey 不同 mediaType 不串', () {
+      final Map<String, int> mixed = <String, int>{
+        'epub|same': 1,
+        'video|same': 2,
+      };
+      expect(statCollectionName('epub|same', mixed, namesById), '夏目漱石全集');
+      expect(statCollectionName('video|same', mixed, namesById), '进击的巨人 第一季');
+    });
+  });
+}


### PR DESCRIPTION
## 背景
PR #270（首页仪表盘 + Activity 事件流）已合并进 develop，但合并**之后**我又往原分支追加了两个提交，原 PR 已 closed 无法带上它们。本 PR 把这两个补上——**其一是修复用户实测发现的「宽屏首页整块空白」的 layout 崩溃，是 develop 现存 bug**。

## 提交 1：fix(home) 宽屏首页空白（重要，修 develop 现存 bug）
用户报「首页基本上什么都没有（无热力图/继续/活动）」。根因不是数据空，而是 **layout 崩溃**：首页把 `stretch`/`Expanded` 的 Row 直接放进纵向 `ListView`（高度无界）——统计卡 4 格横排 Row、2×2 `_statRow`、宽屏两列 `bodyBelow`——layout 阶段抛 `BoxConstraints forces an infinite height`，整页空白（桌面/宽屏/横屏；宽≥560 触发统计 Row，≥900 触发两列）。崩溃把有数据的热力图/继续也一起 blank。
- 修：4 格 Row + `_statRow` 套 `IntrinsicHeight`；宽屏左列 Column 加 `mainAxisSize.min`；`_loadDashboardData` 包 try/catch + ErrorLogService（fail-open·可诊断）。
- 测试 `home_dashboard_page_test`：宽 1280 / 窄 420 / 临界 700 三分支渲染不抛异常 + 区块结构可见（override drift `.watch()` provider 规避 widget 测试进程挂起 gotcha）。

## 提交 2：feat(stats) 统计每条目显示所属合集名
阅读统计 per-book / 视频统计 per-video tile 标题下加合集名标签（文件夹图标 + 名，书架同源「主合集」折叠归属）。书 title→bookKey(epub_books 反查)拼 'epub|key'、视频 title→bookUid(video_books)拼 'video|uid' → `getPrimaryCollectionIdByEntry` → 合集名。纯函数 `statCollectionName` + 共享 `buildStatCollectionLabel`（stat_shared）两页复用。测试 `stat_collection_name_test`（5 例键契约）。

## 验证
- `flutter analyze` 全绿（0 error 0 warning，跑在**当前 develop**基线含游戏子系统等新变更）。
- 关联测试全绿：home_dashboard_page / stat_collection_name / stat_activity / video_stat_aggregates / reading_statistics / activity_events（35 例）。
- cherry-pick 到最新 develop **无冲突**。

## 待真机
宽屏/桌面首页现在应正常显示（layout 已修）；统计页合集名视觉、三端布局仍建议真机复看。Activity 空是 v49 新表 by-design（只记升级后新活动）。