### PR TITLE
fix(video): BUG-943 视频卡文字块收敛为紧凑固定高，消除卡底常驻空白

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 923 条。点号进各自文件。
+> 共 924 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-943](bugs/BUG-943-video-card-bottom-gap.md) | ✅ | ✅ | 视频卡底部常驻空白（续 BUG-926 16:9 封面修复） |
 | [BUG-942](bugs/BUG-942-prev-cue-button-always-jump.md) | ✅ | ✅ | 上/下一句字幕按钮太远时退化成 3 秒 seek |
 | [BUG-941](bugs/BUG-941-texthooker-popup-platform-view-reparent.md) | ✅ | ✅ | 捕获工作台查词 WebView 重建后空白卡死 |
 | [BUG-940](bugs/BUG-940-tag-filter-collection-rescue.md) | ✅ | ✅ | 标签筛选:打了标签的合集筛不出来(成员级过滤先于折叠剥空合集组) |

--- a/docs/bugs/BUG-943-video-card-bottom-gap.md
+++ b/docs/bugs/BUG-943-video-card-bottom-gap.md
@@ -1,0 +1,9 @@
+## BUG-943 · 视频卡底部常驻空白（续 BUG-926 16:9 封面修复）
+- **报告**：2026-07-21（用户：底部多显示了一块）。截图为视频 tab 合集横排行 S01E06/07 等成员卡：16:9 封面顶对齐正常，但标题下方常驻约 50px 空白块。
+- **真实性**：✅ 真 bug。根因在 `hibiki/lib/src/pages/implementations/home_video_page.dart`。
+  - BUG-926 把封面锁死 16:9（`AspectRatio(16/9)`）后，封面下方文字块高度由常量 `_kVideoCardTextBlock`（`home_video_page.dart:2431`，原值 83）固定预留，卡总高 `_videoCardExtent = cardWidth × 9/16 + _kVideoCardTextBlock`。
+  - 83 是「2 行标题 + 观看进度行 + 内边距」的**最坏预留**，且本是逆算值（`cardWidth=240` 时凑回旧固定 218，非文字实测）。
+  - 但绝大多数视频/剧集卡是**单行标题、无观看进度**（`_buildCardWatchMeta` 返回空、不渲染进度行）：文字实占约 28px，`Expanded` 文字块顶对齐后底部剩约 55px 空白 → 显眼空块（用户看到的「多一块」）。本地卡 `_buildCard` 与远端卡 `_buildRemoteVideoCard` 对称同症。
+- **[x] ① 根因修复** — 收敛为紧凑固定高：`_kVideoCardTextBlock` 83→52（单行标题 + 单行进度 + 内边距）；本地 `_buildCard` / 远端 `_buildRemoteVideoCard` 标题 `maxLines: 2→1`；本地卡进度行包一层 `Flexible` 让位，避免大字号倍率下文字块溢出。无进度卡仅剩约一行的常规内边距、不再是空块，有进度卡两行紧贴。封面仍锁 16:9、`BoxFit.contain` 不裁切均不变（保留 BUG-926 / TODO-616C 决策）。提交哈希：663a557c8
+- **[x] ② 已加自动化测试** — 扩展 `hibiki/test/pages/video_card_cover_aspect_guard_test.dart`：源码扫描守卫断言两张卡标题均 `maxLines: 1`（禁回退 2 行预留）、`_kVideoCardTextBlock ≤ 60`（禁回退到 83 的最坏预留）。原 16:9 AspectRatio 断言 + `video_cover_fit_guard_test.dart`（contain 不裁切）保持通过。提交哈希：663a557c8
+- **备注**：真机验证（Windows 离屏 / Android 模拟器）复测「单行标题无进度的视频卡底部无空块」「有进度卡两行不溢出」「大字号倍率下文字块不溢出」。BUG-926 号在 develop 已归属另一 bug（popup 触屏复制），本续修另起 943 号，代码/守卫注释以 943 记，封面 16:9 血缘仍标注 BUG-926。

--- a/docs/bugs/BUG-943-video-card-bottom-gap.md
+++ b/docs/bugs/BUG-943-video-card-bottom-gap.md
@@ -4,6 +4,6 @@
   - BUG-926 把封面锁死 16:9（`AspectRatio(16/9)`）后，封面下方文字块高度由常量 `_kVideoCardTextBlock`（`home_video_page.dart:2431`，原值 83）固定预留，卡总高 `_videoCardExtent = cardWidth × 9/16 + _kVideoCardTextBlock`。
   - 83 是「2 行标题 + 观看进度行 + 内边距」的**最坏预留**，且本是逆算值（`cardWidth=240` 时凑回旧固定 218，非文字实测）。
   - 但绝大多数视频/剧集卡是**单行标题、无观看进度**（`_buildCardWatchMeta` 返回空、不渲染进度行）：文字实占约 28px，`Expanded` 文字块顶对齐后底部剩约 55px 空白 → 显眼空块（用户看到的「多一块」）。本地卡 `_buildCard` 与远端卡 `_buildRemoteVideoCard` 对称同症。
-- **[x] ① 根因修复** — 收敛为紧凑固定高：`_kVideoCardTextBlock` 83→52（单行标题 + 单行进度 + 内边距）；本地 `_buildCard` / 远端 `_buildRemoteVideoCard` 标题 `maxLines: 2→1`；本地卡进度行包一层 `Flexible` 让位，避免大字号倍率下文字块溢出。无进度卡仅剩约一行的常规内边距、不再是空块，有进度卡两行紧贴。封面仍锁 16:9、`BoxFit.contain` 不裁切均不变（保留 BUG-926 / TODO-616C 决策）。提交哈希：663a557c8
-- **[x] ② 已加自动化测试** — 扩展 `hibiki/test/pages/video_card_cover_aspect_guard_test.dart`：源码扫描守卫断言两张卡标题均 `maxLines: 1`（禁回退 2 行预留）、`_kVideoCardTextBlock ≤ 60`（禁回退到 83 的最坏预留）。原 16:9 AspectRatio 断言 + `video_cover_fit_guard_test.dart`（contain 不裁切）保持通过。提交哈希：663a557c8
+- **[x] ① 根因修复** — 收敛为紧凑固定高：`_kVideoCardTextBlock` 83→52（单行标题 + 单行进度 + 内边距）；本地 `_buildCard` / 远端 `_buildRemoteVideoCard` 标题 `maxLines: 2→1`；本地卡进度行包一层 `Flexible` 让位，避免大字号倍率下文字块溢出。无进度卡仅剩约一行的常规内边距、不再是空块，有进度卡两行紧贴。封面仍锁 16:9、`BoxFit.contain` 不裁切均不变（保留 BUG-926 / TODO-616C 决策）。提交哈希：4fe2ea05b
+- **[x] ② 已加自动化测试** — 扩展 `hibiki/test/pages/video_card_cover_aspect_guard_test.dart`：源码扫描守卫断言两张卡标题均 `maxLines: 1`（禁回退 2 行预留）、`_kVideoCardTextBlock ≤ 60`（禁回退到 83 的最坏预留）。原 16:9 AspectRatio 断言 + `video_cover_fit_guard_test.dart`（contain 不裁切）保持通过。提交哈希：4fe2ea05b
 - **备注**：真机验证（Windows 离屏 / Android 模拟器）复测「单行标题无进度的视频卡底部无空块」「有进度卡两行不溢出」「大字号倍率下文字块不溢出」。BUG-926 号在 develop 已归属另一 bug（popup 触屏复制），本续修另起 943 号，代码/守卫注释以 943 记，封面 16:9 血缘仍标注 BUG-926。

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -2150,7 +2150,7 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
                       const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
                   child: Text(
                     video.title,
-                    maxLines: 2,
+                    maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
@@ -2420,15 +2420,17 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   /// 连续散视频段落的 [SliverGrid]（TODO-654：随主 [CustomScrollView] 滚动；
   /// 网格 delegate 与远端区一致）。UI v2 Phase C 后合集不再进网格（渲染成全宽
   /// 横排行），本网格只装散视频单卡。
-  /// 视频卡总高 = 16:9 封面高（[cardWidth] × 9/16）+ 文字块（标题 2 行 + 观看进度行
-  /// + 内边距）。文字块 [_kVideoCardTextBlock] = 83，在 cardWidth=240 时回到旧的固定
-  /// 218，向后兼容；卡变窄时封面等比缩，不再出现固定卡高下的封面上下留白。散卡网格
-  /// [mainAxisExtent] 与合集横排行 [CollectionShelfRow.rowHeight] 共用此高，保持逐像素同尺寸。
+  /// 视频卡总高 = 16:9 封面高（[cardWidth] × 9/16）+ 文字块 [_kVideoCardTextBlock]。
+  /// 卡变窄时封面等比缩，不出现固定卡高下的封面上下留白。散卡网格 [mainAxisExtent]
+  /// 与合集横排行 [CollectionShelfRow.rowHeight] 共用此高，保持逐像素同尺寸。
   static double _videoCardExtent(double cardWidth) =>
       cardWidth * 9 / 16 + _kVideoCardTextBlock;
 
-  /// 视频卡封面下方文字块的固定高度（标题 2 行 + 观看进度行 + 内边距）。
-  static const double _kVideoCardTextBlock = 83;
+  /// 视频卡封面下方文字块的固定高度：单行标题 + 单行观看进度 + 内边距（BUG-943：
+  /// 旧值 83 为「2 行标题 + 进度行」的最坏预留，但绝大多数卡是单行标题、无进度，
+  /// 底部常驻约 50px 空白。收敛为紧凑固定高：标题 `maxLines: 1`、进度行用 Flexible
+  /// 内收，无进度时仅剩约一行的常规内边距，不再是显眼空块）。
+  static const double _kVideoCardTextBlock = 52;
 
   Widget _buildLooseVideoGridSliver(
     List<_VideoLooseCard> loose,
@@ -2602,8 +2604,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
               ],
             ),
           ),
-          // 文字块占封面下方剩余固定高度（cell 高 − 16:9 封面 = _kVideoCardTextBlock），
-          // 标题 / 进度用 ellipsis 内收，浮动高度不再反灌进封面区（BUG-926）。
+          // 文字块占封面下方剩余固定高度（cell 高 − 16:9 封面 = _kVideoCardTextBlock）。
+          // 标题单行 ellipsis 内收；进度行用 Flexible 让位，浮动高度不反灌进封面区
+          // （BUG-926 血缘）、大字号倍率下也不溢出。无进度时仅剩常规内边距、无显眼空块
+          // （BUG-943：单行标题无进度卡曾常驻约 50px 空白）。
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -2612,7 +2616,7 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
                   padding: const EdgeInsets.fromLTRB(8, 6, 8, 2),
                   child: Text(
                     book.title,
-                    maxLines: 2,
+                    maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
@@ -2622,13 +2626,15 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
                 // 上次观看日期（watch-stats 有该 title 时）；全无痕迹不渲染本行。
                 if (_buildCardWatchMeta(book) case final String meta
                     when meta.isNotEmpty)
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(8, 0, 8, 6),
-                    child: Text(
-                      meta,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: HibikiDesignTokens.of(context).type.metadata,
+                  Flexible(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(8, 0, 8, 6),
+                      child: Text(
+                        meta,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: HibikiDesignTokens.of(context).type.metadata,
+                      ),
                     ),
                   ),
               ],

--- a/hibiki/test/pages/video_card_cover_aspect_guard_test.dart
+++ b/hibiki/test/pages/video_card_cover_aspect_guard_test.dart
@@ -46,7 +46,38 @@ void main() {
         reason: '$name 封面不得用 Expanded(child: Stack(...)) 包裹——比例会随下方'
             '文字块高度浮动、把空隙灌回封面区（BUG-928 回归）',
       );
+
+      // BUG-943（续 BUG-926）：标题必须单行——2 行预留在绝大多数单行标题卡下把底部撑出
+      // 约 50px 空白块（用户实报「底部多显示了一块」）。
+      expect(
+        body,
+        contains('maxLines: 1'),
+        reason: '$name 标题必须 maxLines: 1，避免 2 行预留在单行标题卡下留底部空白',
+      );
+      expect(
+        body,
+        isNot(contains('maxLines: 2')),
+        reason: '$name 不得回退到 maxLines: 2 的两行标题预留（BUG-943（续 BUG-926）空白回归）',
+      );
     }
+  });
+
+  test(
+      'video card text block stays compact (no worst-case reservation) '
+      '— BUG-943（续 BUG-926）', () {
+    final String source = File(path).readAsStringSync();
+    final RegExpMatch? m = RegExp(r'_kVideoCardTextBlock\s*=\s*(\d+(?:\.\d+)?)')
+        .firstMatch(source);
+    expect(m, isNotNull, reason: '找不到 _kVideoCardTextBlock 常量');
+    final double block = double.parse(m!.group(1)!);
+    // 单行标题 + 单行进度 + 内边距约 52；旧值 83 是「2 行标题 + 进度行」最坏预留，
+    // 单行标题无进度卡下底部常驻约 50px 空白（用户实报）。守住紧凑上限。
+    expect(
+      block,
+      lessThanOrEqualTo(60),
+      reason: '_kVideoCardTextBlock 不得回退到最坏预留（如 83），否则视频卡底部'
+          '再次出现约 50px 常驻空白块（BUG-943（续 BUG-926））',
+    );
   });
 }
 


### PR DESCRIPTION
## 用户报告
截图：视频 tab 合集横排行 S01E06/07 等卡，16:9 封面顶对齐正常，但**标题下方常驻约 50px 空白块**（"底部多显示了一块"）。

## 根因（续 BUG-926 16:9 封面修复）
BUG-926 把封面锁死 `AspectRatio(16/9)` 后，封面下方文字块高度由 `_kVideoCardTextBlock`（原 83）固定预留，卡总高 `_videoCardExtent = cardWidth×9/16 + 83`。
- 83 是「2 行标题 + 观看进度行」的**最坏预留**（且本是逆算值，`cardWidth=240` 时凑回旧固定 218）。
- 绝大多数视频/剧集卡是**单行标题、无观看进度**（`_buildCardWatchMeta` 返回空、不渲染进度行）：文字实占约 28px，`Expanded` 文字块顶对齐后底部剩约 55px 空白。本地卡 `_buildCard` 与远端卡 `_buildRemoteVideoCard` 对称同症。

## 修复
- `_kVideoCardTextBlock` 83→52（单行标题 + 单行进度 + 内边距）
- 两张卡标题 `maxLines: 2→1`
- 本地卡进度行包一层 `Flexible` 让位，避免大字号倍率下文字块溢出
- 封面仍锁 16:9、`BoxFit.contain` 不裁切均不变

## 测试
- 扩展 `video_card_cover_aspect_guard_test.dart`：断言两卡标题 `maxLines: 1`、`_kVideoCardTextBlock ≤ 60`（禁回退最坏预留）
- 原 16:9 AspectRatio 断言 + `video_cover_fit_guard_test.dart`（contain 不裁切）+ `bugs_per_file_guard_test` 全通过
- `flutter analyze` 全仓无 issue

## 待真机验证
Windows 离屏 / Android 模拟器复测：单行标题无进度卡底部无空块、有进度卡两行不溢出、大字号倍率不溢出。

## 编号说明
BUG-926 号在 develop 已归属另一 bug（popup 触屏复制），本续修另起 **BUG-943**；封面 16:9 血缘仍标注 BUG-926。