### PR TITLE
fix(games): expose TextRender threads and complete helper packaging

### DIFF
--- a/.github/workflows/voice-hook-helper.yml
+++ b/.github/workflows/voice-hook-helper.yml
@@ -12,9 +12,10 @@
 # - 发布到固定 tag `voice-hook-helper` 的 prerelease、非 Latest release
 #   （prerelease: true + make_latest: false），遵守发布通道硬规则：push/非正式流不得建/更新 Latest。
 #
-# 每架构分发 4 个文件（injector.exe + hook.dll + LunaHook<arch>.dll + LunaHost<arch>.dll，后两者
-# 由 CMake POST_BUILD 拷进 injector 目录），打成 voice_hook_<arch>.zip（文件平铺在 zip 根），并随
-# 附 .sha256 侧车供 app 校验下载完整性。app 下载 URL（稳定，按 tag 而非 run 号）：
+# 每架构分发 injector.exe + hook.dll + LunaHook<arch>.dll + LunaHost<arch>.dll（后两者由
+# CMake POST_BUILD 拷进 injector 目录）；x64 还必须携带 Manosaba/Unity 资源语音所需的
+# unity_audio_runtime/。打成 voice_hook_<arch>.zip，并随附 .sha256 侧车供 app 校验下载完整性。
+# app 下载 URL（稳定，按 tag 而非 run 号）：
 #   https://github.com/<owner>/<repo>/releases/download/voice-hook-helper/voice_hook_<arch>.zip
 name: voice-hook-helper
 
@@ -46,8 +47,9 @@ jobs:
           cmake -S . -B build/x86 -A Win32
           cmake --build build/x86 --config Release
 
-      # 只挑分发所需的 4 个文件（诊断用 ring_probe / luna_symcheck 不分发）。CMake POST_BUILD
-      # 已把 vendored LunaHook<arch>.dll / LunaHost<arch>.dll 拷进各 arch 的 Release 目录。
+      # 只挑分发运行时文件（诊断用 ring_probe / luna_symcheck 不分发）。CMake POST_BUILD
+      # 已把 vendored LunaHook<arch>.dll / LunaHost<arch>.dll 拷进各 arch 的 Release 目录；
+      # x64 的 Unity 资源音频提取器必须保留 unity_audio_runtime 子目录结构。
       - name: Stage helper files
         run: |
           $ErrorActionPreference = 'Stop'
@@ -56,21 +58,36 @@ jobs:
           Copy-Item build/x64/Release/hibiki_voice_hook.dll      dist/x64/
           Copy-Item build/x64/Release/LunaHook64.dll             dist/x64/
           Copy-Item build/x64/Release/LunaHost64.dll             dist/x64/
+          Copy-Item build/x64/Release/unity_audio_runtime        dist/x64/ -Recurse
           Copy-Item build/x86/Release/hibiki_voice_injector.exe dist/x86/
           Copy-Item build/x86/Release/hibiki_voice_hook.dll      dist/x86/
           Copy-Item build/x86/Release/LunaHook32.dll             dist/x86/
           Copy-Item build/x86/Release/LunaHost32.dll             dist/x86/
 
-      # 契约守卫：每架构必须正好 4 个文件，缺一即失败（防漏 DLL 导致 app 端注入器起不来）。
-      - name: Verify 4 files per arch
+      # 契约守卫：两架构的注入运行时及 x64 Unity 资源音频运行时缺一即失败。
+      - name: Verify helper runtime files
         run: |
           $ErrorActionPreference = 'Stop'
-          foreach ($arch in 'x64', 'x86') {
-            $count = (Get-ChildItem "dist/$arch" -File).Count
-            if ($count -ne 4) { throw "arch $arch expected 4 files, got $count" }
+          $required = @(
+            'dist/x64/hibiki_voice_injector.exe',
+            'dist/x64/hibiki_voice_hook.dll',
+            'dist/x64/LunaHook64.dll',
+            'dist/x64/LunaHost64.dll',
+            'dist/x64/unity_audio_runtime/hibiki_unity_audio_extract.exe',
+            'dist/x64/unity_audio_runtime/classdata.tpk',
+            'dist/x64/unity_audio_runtime/vgmstream-cli.exe',
+            'dist/x86/hibiki_voice_injector.exe',
+            'dist/x86/hibiki_voice_hook.dll',
+            'dist/x86/LunaHook32.dll',
+            'dist/x86/LunaHost32.dll'
+          )
+          foreach ($path in $required) {
+            if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+              throw "helper runtime file missing: $path"
+            }
           }
 
-      # 打 zip（文件平铺在 zip 根）+ 产出 sha256 侧车（小写十六进制），供 app 下载后校验完整性。
+      # 打 zip（保留 x64 的 unity_audio_runtime/）+ 产出 sha256 侧车（小写十六进制），供 app 下载后校验完整性。
       - name: Zip + sha256
         run: |
           $ErrorActionPreference = 'Stop'

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 939 条。点号进各自文件。
+> 共 940 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-959](bugs/BUG-959-textrender-thread-catalog.md) | ✅ | ✅ | 9nine 的 Luna 线程列表缺少 TextRender |
 | [BUG-958](bugs/BUG-958-gal-hook-ready-signal-late.md) | ✅ | ✅ | Galgame helper 已注入但 ready 信号过晚导致 engine_attach_failed |
 | [BUG-957](bugs/BUG-957-galgame-dead-session-controller-leftover.md) | 🚧 | 🚧 | 旧 GalgameSessionController 死代码残留致查词面板 galgame 制卡出口失效 |
 | [BUG-956](bugs/BUG-956-gal-mining-serial-queue-poisoning.md) | 🚧 | 🚧 | galgame 制卡串行队列异常毒化后所有后续制卡永久挂起 |

--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -78,7 +78,8 @@ vendored LunaHook/Host DLL）含 `CreateRemoteThread`/`WriteProcessMemory`，**�
 
 - **构建/发布**：workflow `.github/workflows/voice-hook-helper.yml`，**仅手动** `workflow_dispatch`
   （windows-2022）。cmake 编 x64（`-A x64`）+ x86（`-A Win32`），每架构打 `voice_hook_<arch>.zip`
-  （4 个文件平铺）+ `.sha256` 侧车，`softprops/action-gh-release@v3` upsert 到**固定 tag
+  （两架构均含 injector/hook/LunaHook/LunaHost；x64 另保留 `unity_audio_runtime/`）+ `.sha256`
+  侧车，`softprops/action-gh-release@v3` upsert 到**固定 tag
   `voice-hook-helper`** 的 **prerelease、`make_latest: false`**（遵守发布通道硬规则；push 不建 Latest）。
 - **发布守卫**：`tool/check_release_policy.ps1` 只扫 `release.yml` / `release-desktop.yml`，此独立
   workflow 天然豁免；固定 tag + prerelease + 非 Latest 不违反任何红线。

--- a/docs/bugs/BUG-959-textrender-thread-catalog.md
+++ b/docs/bugs/BUG-959-textrender-thread-catalog.md
@@ -1,0 +1,6 @@
+## BUG-959 · 9nine 的 Luna 线程列表缺少 TextRender
+- **报告**：2026-07-21（用户：同一 9nine 会话中，LunaTranslator 能列出 `TextRender`，Hibiki 线程选择器缺少该项）
+- **真实性**：✅ 真 bug。LunaTranslator 直接用 LunaHook 的 `ThreadCreate` 回调维护完整线程列表；Hibiki 的 `native/galgame_voice_hook/injector/injector_main.cpp` 原先却把该回调做成空 stub，只能从通过 `LunaShouldWriteLine` 自动赢家/伪影过滤的输出反推候选。9nine 的 `TextRender` 在线程被选中前没有发布行，因此既进不了 `hibiki/lib/src/sync/texthooker_service.dart` 的历史行聚合，也永远无法在 UI 中被选择。
+- **[x] ① 已修复** — 提交 `770a263a5` 将共享内存协议升级到 v10：injector 独立发布 Luna `ThreadCreate` 事件，Windows runner/Dart 完整透传事件类型，控制器把发现事件登记到独立线程目录而不伪造空台词。线程选择器现在可先显示 `TextRender · 0xf94600 · 0`，真实输出到达后再累计行数。
+- **[x] ② 已加自动化测试** — 新增 `hibiki/test/mining/galgame_text_thread_discovery_guard_test.dart`，并扩展 MethodChannel 解析、会话控制器、线程目录及选择器 widget 测试，覆盖“发现事件不受自动赢家过滤”“0 行可选”“发现事件不进入台词历史”和 IPC 两端结构一致。
+- **备注**：Windows Debug 主程序及 x86/x64 Release helper 已构建成功；按用户要求跳过单元测试。当前 9nine 进程若仍加载旧 helper，需在更新构建后重启捕获会话完成最终实机复测。

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -1177,6 +1177,7 @@ class GalHookSessionController extends ChangeNotifier {
       final List<GalHookedLine> ordered = List<GalHookedLine>.from(poll.lines)
         ..sort((a, b) => a.seq.compareTo(b.seq));
       int cursor = _lastTextSeq;
+      bool receivedTextLine = false;
       for (final GalHookedLine line in ordered) {
         if (line.seq <= cursor) {
           _setState(
@@ -1198,6 +1199,20 @@ class GalHookSessionController extends ChangeNotifier {
             details: <String, Object?>{'from': cursor, 'to': line.seq},
           );
         }
+        if (line.eventKind == GalTextEventKind.threadDiscovered) {
+          final String? threadKey = line.textThreadKey;
+          final String? threadLabel = line.textThreadLabel;
+          if (threadKey != null && threadLabel != null) {
+            _textService.registerTextThread(
+              key: threadKey,
+              label: threadLabel,
+              hookCode: line.hookCode.isEmpty ? null : line.hookCode,
+              nativeThreadId: line.threadId,
+            );
+          }
+          cursor = line.seq;
+          continue;
+        }
         final TexthookerLineEntry? entry = _textService.appendLine(
           line.text,
           source: TexthookerLineSource.engineHook,
@@ -1214,6 +1229,7 @@ class GalHookSessionController extends ChangeNotifier {
           cursor = line.seq;
           continue;
         }
+        receivedTextLine = true;
         _lineTimestampCache[entry.id] = line.timestampMs;
         _trimCache(_lineTimestampCache);
         GalAudioSlice? clip;
@@ -1287,7 +1303,7 @@ class GalHookSessionController extends ChangeNotifier {
       _refreshPendingResourceMatches(engine);
       // 只推进到实际看见并处理完成的最大 seq；不能盲用 native header count 跳过未提交槽。
       if (cursor > _lastTextSeq) _lastTextSeq = cursor;
-      if (ordered.isNotEmpty) {
+      if (receivedTextLine) {
         _setState(
           _state.copyWith(
             phase: _state.fallbackReason == null

--- a/hibiki/lib/src/mining/galgame_audio_source.dart
+++ b/hibiki/lib/src/mining/galgame_audio_source.dart
@@ -754,9 +754,8 @@ class EngineHookGalAudioSource implements GalAudioSource {
     }
   }
 
-  /// v2 文本 hook：取序号在 `(fromSeq, count]` 的新台词行（我们注入 DLL 的文本 hook 抓的），
-  /// 供喂 Hibiki texthooker。返回 `count`(当前总行数) + `lines`(每行 seq/ts(GetTickCount64)/text)。
-  /// native 缺失 / 失败返回 null。
+  /// v7 文本 hook：取序号在 `(fromSeq, count]` 的新台词/线程发现事件，供喂 Hibiki
+  /// texthooker 与线程选择器。native 缺失 / 失败返回 null。
   Future<GalTextPoll?> pollText(int fromSeq) async {
     try {
       final Map<Object?, Object?>? r =
@@ -787,6 +786,10 @@ class EngineHookGalAudioSource implements GalAudioSource {
               threadContext2: (e['threadContext2'] as int?) ?? 0,
               processId: (e['processId'] as int?) ?? 0,
               sourceKind: (e['sourceKind'] as int?) ?? 0,
+              eventKind: GalTextEventKind.fromNative(
+                (e['eventKind'] as int?) ?? 0,
+              ),
+              eventFlags: (e['eventFlags'] as int?) ?? 0,
               hookName: (e['hookName'] as String?) ?? '',
               hookCode: (e['hookCode'] as String?) ?? '',
             ));
@@ -1150,8 +1153,18 @@ class GalTextPoll {
   final List<GalHookedLine> lines;
 }
 
-/// 一条文本 hook 抓到的台词行：单调 [seq]、hook 写入时刻 [timestampMs]（GetTickCount64，与语音
-/// clip 同一时钟，供 [EngineHookGalAudioSource.grabClipNear] 按句配对语音）、[text]。
+enum GalTextEventKind {
+  line,
+  threadDiscovered;
+
+  static GalTextEventKind fromNative(int value) => switch (value) {
+        1 => GalTextEventKind.threadDiscovered,
+        _ => GalTextEventKind.line,
+      };
+}
+
+/// 一条文本 hook 事件：台词行携带 [text]；线程发现事件的 [text] 为空，只携带 Luna
+/// ThreadParam/hook 元数据。所有事件共享单调 [seq] 与 [timestampMs]（GetTickCount64）。
 class GalHookedLine {
   const GalHookedLine({
     required this.seq,
@@ -1163,6 +1176,8 @@ class GalHookedLine {
     this.threadContext2 = 0,
     this.processId = 0,
     this.sourceKind = 0,
+    this.eventKind = GalTextEventKind.line,
+    this.eventFlags = 0,
     this.hookName = '',
     this.hookCode = '',
   });
@@ -1175,6 +1190,8 @@ class GalHookedLine {
   final int threadContext2;
   final int processId;
   final int sourceKind;
+  final GalTextEventKind eventKind;
+  final int eventFlags;
   final String hookName;
   final String hookCode;
 

--- a/hibiki/lib/src/mining/galgame_helper_installer.dart
+++ b/hibiki/lib/src/mining/galgame_helper_installer.dart
@@ -329,7 +329,7 @@ class GalgameHelperInstaller {
         },
       );
 
-      // 3) 解压到 archDir（覆盖写；4 个文件平铺在 zip 根）。
+      // 3) 解压到 archDir（覆盖写；保留 x64 unity_audio_runtime/ 子目录）。
       await _extractZip(zip, _archDir(arch));
 
       // 记录本次已装 zip 的 sha256 作自动更新比对基线；无 sha 侧车时不写标记（下次不自动更新，
@@ -475,20 +475,24 @@ class GalgameHelperInstaller {
 
   /// 解压 zip 到 [targetDir]（覆盖写）。用 archive 包 ZipDecoder；写字节用 file.content
   /// getter（archive 3.6.1 下 ArchiveFile.decompress(out) 会写 0 字节，见
-  /// sync_asset_package_service.dart 注释，故取 content 字节直接写）。只写常规文件、剥掉
-  /// 目录前缀防 zip-slip。
+  /// sync_asset_package_service.dart 注释，故取 content 字节直接写）。只写常规文件、保留
+  /// 相对目录结构，并拒绝绝对路径或逃出目标目录的条目以防 zip-slip。
   Future<void> _extractZip(File zip, Directory targetDir) async {
     await targetDir.create(recursive: true);
     final Uint8List bytes = await zip.readAsBytes();
     final Archive archive = ZipDecoder().decodeBytes(bytes);
+    final String targetRoot = p.normalize(targetDir.absolute.path);
     for (final ArchiveFile entry in archive) {
       if (!entry.isFile) continue;
-      // 只取文件名（zip 根平铺），防路径穿越。
-      final String name = p.basename(entry.name);
-      if (name.isEmpty) continue;
+      final String relativePath =
+          entry.name.replaceAll('/', p.separator).replaceAll('\\', p.separator);
+      if (relativePath.isEmpty || p.isAbsolute(relativePath)) continue;
+      final String outputPath = p.normalize(p.join(targetRoot, relativePath));
+      if (!p.isWithin(targetRoot, outputPath)) continue;
       final Object? content = entry.content;
       if (content is! List<int>) continue;
-      final File out = File(p.join(targetDir.path, name));
+      final File out = File(outputPath);
+      await out.parent.create(recursive: true);
       await out.writeAsBytes(content, flush: true);
     }
   }

--- a/hibiki/lib/src/sync/texthooker_service.dart
+++ b/hibiki/lib/src/sync/texthooker_service.dart
@@ -121,6 +121,8 @@ class TexthookerService extends ChangeNotifier {
   static const int maxLines = 500;
 
   final List<TexthookerLineEntry> _entries = <TexthookerLineEntry>[];
+  final Map<String, TexthookerTextThread> _discoveredTextThreads =
+      <String, TexthookerTextThread>{};
   int _nextId = 0;
 
   List<TexthookerLineEntry> get entries =>
@@ -136,10 +138,13 @@ class TexthookerService extends ChangeNotifier {
     return null;
   }
 
-  /// 当前缓冲中出现过的可选文本线程，最近活跃的排在前面。
+  /// 当前会话已发现的可选文本线程，最近活跃的排在前面。
+  ///
+  /// Luna 的 ThreadCreate 事件会先放入 [_discoveredTextThreads]，因此被自动赢家过滤、当前
+  /// 尚无已发布台词的候选也会以 0 行显示；已有台词再从 [_entries] 聚合计数。
   List<TexthookerTextThread> get textThreads {
     final Map<String, TexthookerTextThread> byKey =
-        <String, TexthookerTextThread>{};
+        Map<String, TexthookerTextThread>.from(_discoveredTextThreads);
     for (final TexthookerLineEntry entry in _entries) {
       final String? key = entry.textThreadKey;
       if (key == null || key.isEmpty) continue;
@@ -156,6 +161,33 @@ class TexthookerService extends ChangeNotifier {
     final List<TexthookerTextThread> result = byKey.values.toList()
       ..sort((a, b) => b.latestAt.compareTo(a.latestAt));
     return List<TexthookerTextThread>.unmodifiable(result);
+  }
+
+  void registerTextThread({
+    required String key,
+    required String label,
+    String? hookCode,
+    int? nativeThreadId,
+    DateTime? discoveredAt,
+  }) {
+    final String normalizedKey = key.trim();
+    if (normalizedKey.isEmpty) return;
+    final TexthookerTextThread? previous =
+        _discoveredTextThreads[normalizedKey];
+    final DateTime observedAt = discoveredAt ?? DateTime.now();
+    _discoveredTextThreads[normalizedKey] = TexthookerTextThread(
+      key: normalizedKey,
+      label: label.trim().isEmpty
+          ? previous?.label ?? normalizedKey
+          : label.trim(),
+      hookCode: hookCode ?? previous?.hookCode,
+      nativeThreadId: nativeThreadId ?? previous?.nativeThreadId,
+      lineCount: 0,
+      latestAt: previous != null && previous.latestAt.isAfter(observedAt)
+          ? previous.latestAt
+          : observedAt,
+    );
+    notifyListeners();
   }
 
   /// [threadKey] 为 null 时返回所有行；否则只返回指定 Hook 线程的文本。
@@ -230,8 +262,9 @@ class TexthookerService extends ChangeNotifier {
   }
 
   void clear() {
-    if (_entries.isEmpty) return;
+    if (_entries.isEmpty && _discoveredTextThreads.isEmpty) return;
     _entries.clear();
+    _discoveredTextThreads.clear();
     notifyListeners();
   }
 }

--- a/hibiki/test/mining/gal_hook_session_controller_test.dart
+++ b/hibiki/test/mining/gal_hook_session_controller_test.dart
@@ -270,6 +270,65 @@ void main() {
     }
   });
 
+  test('thread discovery reaches selector without becoming a captured line',
+      () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    final _FakeEngineSource engine = _FakeEngineSource(
+      pairedBytes: Uint8List(0),
+      audioFormat: null,
+      textReady: true,
+      polledLines: const <GalHookedLine>[
+        GalHookedLine(
+          seq: 1,
+          timestampMs: 123456,
+          text: '',
+          threadId: 9,
+          threadAddress: 0xf94600,
+          sourceKind: 2,
+          eventKind: GalTextEventKind.threadDiscovered,
+          hookName: 'TextRender',
+          hookCode: 'HS932@f94600',
+        ),
+      ],
+    );
+    final _FakeLoopbackSource loopback = _FakeLoopbackSource();
+    final GalHookSessionController controller = GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      targetWow64Probe: (_) async => false,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+      }) =>
+          engine,
+      loopbackSourceFactory: () => loopback,
+      textPollInterval: const Duration(milliseconds: 5),
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+
+    await controller.startAttachedCapture(
+      const ExternalWindowInfo(hwnd: 8, pid: 909, title: '9nine'),
+    );
+    for (int i = 0; i < 20 && service.textThreads.isEmpty; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+
+    expect(service.entries, isEmpty);
+    expect(service.textThreads, hasLength(1));
+    expect(service.textThreads.single.label, 'TextRender · 0xf94600');
+    expect(service.textThreads.single.lineCount, 0);
+    expect(service.textThreads.single.nativeThreadId, 9);
+
+    await controller.close();
+    endpoints.dispose();
+  });
+
   test('text-only engine hook stays active with loopback audio fallback',
       () async {
     final TexthookerService service = TexthookerService.test();

--- a/hibiki/test/mining/galgame_audio_test.dart
+++ b/hibiki/test/mining/galgame_audio_test.dart
@@ -564,7 +564,8 @@ void main() {
       await src.stop();
     });
 
-    test('pollText keeps Luna thread metadata for the UI selector', () async {
+    test('pollText keeps Luna thread discovery metadata for the UI selector',
+        () async {
       setHandler((MethodCall call) async {
         if (call.method != 'pollText') return null;
         expect(call.arguments, <String, Object?>{'fromSeq': 7});
@@ -574,14 +575,16 @@ void main() {
             <Object?, Object?>{
               'seq': 8,
               'ts': 123456,
-              'text': '選択する台詞',
+              'text': '',
               'threadId': 0x1234,
               'threadAddress': 0x5678,
               'threadContext': 9,
               'threadContext2': 10,
               'processId': 42,
               'sourceKind': 2,
-              'hookName': 'SiglusEngine',
+              'eventKind': 1,
+              'eventFlags': 1,
+              'hookName': 'TextRender',
               'hookCode': 'HS932@5678',
             },
           ],
@@ -596,10 +599,12 @@ void main() {
       expect(poll!.count, 8);
       final GalHookedLine line = poll.lines.single;
       expect(line.textThreadKey, 'luna:1234');
-      expect(line.textThreadLabel, 'SiglusEngine · 0x5678');
+      expect(line.textThreadLabel, 'TextRender · 0x5678');
       expect(line.hookCode, 'HS932@5678');
       expect(line.processId, 42);
       expect(line.threadContext2, 10);
+      expect(line.eventKind, GalTextEventKind.threadDiscovered);
+      expect(line.eventFlags, 1);
     });
 
     test('Siglus exact text source has a stable selectable thread label', () {

--- a/hibiki/test/mining/galgame_text_thread_discovery_guard_test.dart
+++ b/hibiki/test/mining/galgame_text_thread_discovery_guard_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Luna ThreadCreate is published independently from filtered output', () {
+    final String injector = File(
+      '../native/galgame_voice_hook/injector/injector_main.cpp',
+    ).readAsStringSync();
+    final String threadCreate = _between(
+      injector,
+      'void LunaThreadCreate(',
+      'void LunaThreadRemove(',
+    );
+    final String output = _between(
+      injector,
+      'void LunaOutput(',
+      'void LunaConnect(',
+    );
+
+    expect(threadCreate, contains('LunaTextThreadId('));
+    expect(threadCreate, contains('kTextEventThreadDiscovered'));
+    expect(threadCreate, contains('WriteLunaTextEvent('));
+    expect(threadCreate, isNot(contains('LunaShouldWriteLine(')));
+    expect(output, contains('LunaShouldWriteLine('));
+  });
+
+  test('IPC v10 event kind is synchronized through the Windows channel', () {
+    final String nativeHeader = File(
+      '../native/galgame_voice_hook/include/voice_hook_ipc.h',
+    ).readAsStringSync();
+    final String runnerHeader =
+        File('windows/runner/voice_hook_ipc.h').readAsStringSync();
+    final String runner =
+        File('windows/runner/voice_hook_reader.cpp').readAsStringSync();
+    final String channel =
+        File('windows/runner/flutter_window.cpp').readAsStringSync();
+
+    for (final String header in <String>[nativeHeader, runnerHeader]) {
+      expect(header, contains('kSharedVersion = 10'));
+      expect(header, contains('kTextEventThreadDiscovered = 1'));
+      expect(header, contains('uint32_t event_kind'));
+    }
+    expect(
+      _structDeclarations(nativeHeader, 'TextSlot'),
+      _structDeclarations(runnerHeader, 'TextSlot'),
+      reason: 'injector 与 runner 的 TextSlot 字段顺序必须逐项一致',
+    );
+    expect(runner, contains('line.event_kind = slot->event_kind'));
+    expect(channel, contains('flutter::EncodableValue("eventKind")'));
+  });
+}
+
+List<String> _structDeclarations(String source, String name) {
+  final String body = _between(source, 'struct $name {', '};');
+  return RegExp(
+    r'^\s*(?:volatile\s+)?(?:uint64_t|uint32_t|char|wchar_t)\s+'
+    r'[a-zA-Z0-9_]+(?:\[[a-zA-Z0-9_]+\])?\s*;',
+    multiLine: true,
+  ).allMatches(body).map((Match match) {
+    return match.group(0)!.replaceAll(RegExp(r'\s+'), ' ').trim();
+  }).toList();
+}
+
+String _between(String source, String start, String end) {
+  final int startIndex = source.indexOf(start);
+  expect(startIndex, isNonNegative, reason: 'Missing start marker: $start');
+  final int endIndex = source.indexOf(end, startIndex + start.length);
+  expect(endIndex, isNonNegative, reason: 'Missing end marker: $end');
+  return source.substring(startIndex, endIndex);
+}

--- a/hibiki/test/pages/texthooker_page_test.dart
+++ b/hibiki/test/pages/texthooker_page_test.dart
@@ -76,6 +76,27 @@ void main() {
     expect(find.textContaining('坏'), findsNothing);
   });
 
+  testWidgets('thread selector lists discovered TextRender before any output',
+      (WidgetTester tester) async {
+    TexthookerService.instance.registerTextThread(
+      key: 'luna:textrender',
+      label: 'TextRender · 0xf94600',
+      hookCode: 'HS932@f94600',
+      nativeThreadId: 0x9,
+    );
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: TexthookerPage())),
+    );
+    await tester.pump();
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('game-text-thread-selector')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('TextRender · 0xf94600 · 0'), findsWidgets);
+  });
+
   testWidgets('embedded mode reuses parent scaffold and exposes back action',
       (WidgetTester tester) async {
     bool returned = false;

--- a/hibiki/test/sync/texthooker_service_test.dart
+++ b/hibiki/test/sync/texthooker_service_test.dart
@@ -132,4 +132,35 @@ void main() {
       hasLength(3),
     );
   });
+
+  test('discovered Luna thread is selectable before it publishes a line', () {
+    final DateTime discoveredAt = DateTime(2026, 7, 21, 12);
+    TexthookerService.instance.registerTextThread(
+      key: 'luna:textrender',
+      label: 'TextRender · 0xf94600',
+      hookCode: 'HS932@f94600',
+      nativeThreadId: 0x9,
+      discoveredAt: discoveredAt,
+    );
+
+    expect(TexthookerService.instance.entries, isEmpty);
+    expect(TexthookerService.instance.textThreads, hasLength(1));
+    expect(
+      TexthookerService.instance.textThreads.single.label,
+      'TextRender · 0xf94600',
+    );
+    expect(TexthookerService.instance.textThreads.single.lineCount, 0);
+
+    TexthookerService.instance.appendLine(
+      'このように、とても素敵な性格のお方である。',
+      textThreadKey: 'luna:textrender',
+      textThreadLabel: 'TextRender · 0xf94600',
+      nativeTextThreadId: 0x9,
+      receivedAt: discoveredAt.add(const Duration(seconds: 1)),
+    );
+    expect(TexthookerService.instance.textThreads.single.lineCount, 1);
+
+    TexthookerService.instance.clear();
+    expect(TexthookerService.instance.textThreads, isEmpty);
+  });
 }

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -1776,6 +1776,12 @@ void FlutterWindow::RegisterVoiceHookChannel() {
                 {flutter::EncodableValue("sourceKind"),
                  flutter::EncodableValue(
                      static_cast<int64_t>(ln.source_kind))},
+                {flutter::EncodableValue("eventKind"),
+                 flutter::EncodableValue(
+                     static_cast<int64_t>(ln.event_kind))},
+                {flutter::EncodableValue("eventFlags"),
+                 flutter::EncodableValue(
+                     static_cast<int64_t>(ln.event_flags))},
                 {flutter::EncodableValue("hookName"),
                  flutter::EncodableValue(ln.hook_name)},
                 {flutter::EncodableValue("hookCode"),

--- a/hibiki/windows/runner/voice_hook_ipc.h
+++ b/hibiki/windows/runner/voice_hook_ipc.h
@@ -10,11 +10,12 @@
 // **host 端副本**（真相源 `native/galgame_voice_hook/include/voice_hook_ipc.h`，须同步）。
 // v2：音频环形 + 文本环（hook 抓的台词行）+ 语音 clip 索引（按句切的语音片段，含时间戳供配对）。
 // v6：clip 索引之后追加 loopback 混音环 + 时间戳↔环位置标记表（无引擎专属纯人声 hook 时的兜底）。
+// v10：文本槽追加事件类型，透传 Luna ThreadCreate，使尚无台词的候选线程也可被选择。
 // 读共享内存不是注入、不被杀软标记，可安全进 hibiki.exe。契约用 magic/version 版本化。
 namespace hibiki_voice_hook {
 
 constexpr uint32_t kSharedMagic = 0x31485648;  // 'H''V''H''1'
-constexpr uint32_t kSharedVersion = 9;
+constexpr uint32_t kSharedVersion = 10;
 
 constexpr uint32_t kTextSlotCount = 256;
 constexpr uint32_t kTextSlotBytes = 2048;
@@ -25,6 +26,8 @@ constexpr uint32_t kTextSourceGdi = 1;
 constexpr uint32_t kTextSourceLuna = 2;
 constexpr uint32_t kTextSourceUnityTmp = 3;
 constexpr uint32_t kTextSourceSiglus = 4;
+constexpr uint32_t kTextEventLine = 0;
+constexpr uint32_t kTextEventThreadDiscovered = 1;
 constexpr uint32_t kClipCount = 1024;
 constexpr uint32_t kDiagStartupAudioHooksReady = 0x00000001u;
 constexpr uint32_t kDiagUnityIl2CppHooksReady = 0x00000002u;
@@ -76,6 +79,8 @@ struct TextSlot {
   uint32_t source_kind;
   uint32_t hook_name_len;
   uint32_t hook_code_len;
+  uint32_t event_kind;
+  uint32_t event_flags;
   char hook_name[kTextHookNameChars];
   wchar_t hook_code[kTextHookCodeChars];
   // 紧跟文本字节。

--- a/hibiki/windows/runner/voice_hook_reader.cpp
+++ b/hibiki/windows/runner/voice_hook_reader.cpp
@@ -312,6 +312,8 @@ void VoiceHookReader::PollText(uint64_t from_seq,
     line.thread_context2 = slot->thread_context2;
     line.process_id = slot->process_id;
     line.source_kind = slot->source_kind;
+    line.event_kind = slot->event_kind;
+    line.event_flags = slot->event_flags;
     const uint32_t hook_name_len = (std::min)(
         slot->hook_name_len, hibiki_voice_hook::kTextHookNameChars);
     line.hook_name.assign(slot->hook_name, hook_name_len);

--- a/hibiki/windows/runner/voice_hook_reader.h
+++ b/hibiki/windows/runner/voice_hook_reader.h
@@ -33,7 +33,7 @@ struct VoiceHookStatus {
   bool ok = false;           // 映射有效且格式已就绪（音频格式已填）
 };
 
-// 一条 hook 抓到的台词行（v2 文本环）。
+// 一条 hook 文本事件（台词行或 Luna 线程发现，v10 文本环）。
 struct VoiceHookText {
   uint64_t seq = 0;           // 单调序号
   uint64_t timestamp_ms = 0;  // hook 写入时刻（GetTickCount64）
@@ -44,6 +44,8 @@ struct VoiceHookText {
   uint64_t thread_context2 = 0;
   uint32_t process_id = 0;
   uint32_t source_kind = 0;
+  uint32_t event_kind = 0;
+  uint32_t event_flags = 0;
   std::string hook_name;
   std::string hook_code;
 };
@@ -80,11 +82,11 @@ class VoiceHookReader {
   // 全部。未打开 / hook 未就绪 / 无数据时 [out] 清空、返回 ok=false。
   VoiceHookStatus GrabRecent(int back_ms, std::vector<uint8_t>& out);
 
-  // 当前文本行总数（text_write_count）；未打开返回 0。Dart 侧记住 last，取 (last, count] 的新行。
+  // 当前文本事件总数（text_write_count）；未打开返回 0。Dart 侧记住 last，取 (last, count]。
   uint64_t TextWriteCount();
 
-  // 取序号在 (from_seq, text_write_count] 区间的文本行（供 Dart 喂 texthooker）。最多回最近
-  // kTextSlotCount 条（更旧的已被覆盖）。未打开 / 无新行时 [out] 空。
+  // 取序号在 (from_seq, text_write_count] 区间的文本事件（供 Dart 喂 texthooker/线程目录）。最多
+  // 回最近 kTextSlotCount 个（更旧的已被覆盖）。未打开 / 无新事件时 [out] 空。
   void PollText(uint64_t from_seq, std::vector<VoiceHookText>& out);
 
   // 选择 Luna 文本线程：0 恢复自动选择，非 0 写入共享 header 让 injector 只发布该线程。

--- a/native/galgame_voice_hook/include/voice_hook_ipc.h
+++ b/native/galgame_voice_hook/include/voice_hook_ipc.h
@@ -28,16 +28,17 @@ constexpr uint32_t kSharedMagic = 0x31485648;  // 'H''V''H''1'
 //     hook 的游戏（Atelier Kaguya、未识别引擎等）的**兜底**——WASAPI loopback 抓系统渲染端点的
 //     最终混音（voice+BGM），按文本时刻抽窗口做卡。与引擎级纯人声路径并存，互不干扰。
 // v9：合并 v8 的引擎诊断/Unity 资源事件与 v6 的 loopback 环。
-constexpr uint32_t kSharedVersion = 9;
+// v10：文本槽追加事件类型，透传 Luna ThreadCreate，使尚无台词的候选线程也可被选择。
+constexpr uint32_t kSharedVersion = 10;
 
 // 环形缓冲保留时长（秒）。C 阶段语音轨常见 48k 立体声 float32；60s 上界 ≈ 23MB。
 // 32 位游戏地址空间有限，共享内存映射进游戏进程也吃它的地址空间——故设硬上界。
 constexpr uint32_t kRingSeconds = 60;
 constexpr uint32_t kMaxRingBytes = 64u * 1024u * 1024u;  // ≤64MB（spec C 阶段预算）
 
-// 文本环：最近 kTextSlotCount 条台词行，循环覆盖。每槽固定 kTextSlotBytes 字节
-// （TextSlot 头 + 紧跟的文本字节）。v6 保留 Luna ThreadParam / hook 名称与 hookcode，
-// host 才能像 Luna Translator 一样列出并选择干净文本线程。
+// 文本事件环：最近 kTextSlotCount 个台词/线程发现事件，循环覆盖。每槽固定 kTextSlotBytes 字节
+// （TextSlot 头 + 紧跟的文本字节）。v6 保留 Luna ThreadParam / hook 名称与 hookcode；v10 再透传
+// Luna ThreadCreate，使被自动赢家过滤、尚无已发布台词的 TextRender 等线程也能先出现在选择器里。
 constexpr uint32_t kTextSlotCount = 256;
 constexpr uint32_t kTextSlotBytes = 2048;
 constexpr uint32_t kTextHookNameChars = 64;
@@ -47,6 +48,8 @@ constexpr uint32_t kTextSourceGdi = 1;
 constexpr uint32_t kTextSourceLuna = 2;
 constexpr uint32_t kTextSourceUnityTmp = 3;
 constexpr uint32_t kTextSourceSiglus = 4;
+constexpr uint32_t kTextEventLine = 0;
+constexpr uint32_t kTextEventThreadDiscovered = 1;
 // 语音 clip 索引：最近 kClipCount 条语音片段的位置记录（按 source voice / DirectSound buffer
 // 的一次提交切一条；galgame 一句台词≈一条语音）。指向音频环形里的 [ring_offset, byte_len)。
 constexpr uint32_t kClipCount = 1024;  // clip 索引环：128≈仅2秒历史不够重建整句语音，扩到 ~16秒
@@ -103,7 +106,8 @@ constexpr uint32_t kMaxLoopbackBytes = 16u * 1024u * 1024u;  // ≤16MB（32 位
 // 时间戳↔环位置标记表槽数。loopback 线程每 ~200ms 记一条 {tick, total}；60s → 300 条，512 留余。
 constexpr uint32_t kLoopbackMarkerCount = 512;
 
-// 文本槽：seq==全局 text_write_count 对应值时该槽有效；文本紧跟本头之后（kTextSlotBytes-头长）。
+// 文本事件槽：seq==全局 text_write_count 对应值时该槽有效；event_kind==kTextEventLine 时，文本
+// 紧跟本头之后（kTextSlotBytes-头长）；线程发现事件的 byte_len 为 0、只携带线程元数据。
 #pragma pack(push, 8)
 struct TextSlot {
   volatile uint64_t seq;    // 写入序号（0=空；等于所在 text_write_count 快照即有效）
@@ -118,6 +122,8 @@ struct TextSlot {
   uint32_t source_kind;     // kTextSource*；决定 UI 标签
   uint32_t hook_name_len;   // hook_name 有效字节数（不含结尾 0）
   uint32_t hook_code_len;   // hook_code 有效 wchar 数（不含结尾 0）
+  uint32_t event_kind;      // kTextEvent*；0 保持旧写者默认语义为台词行
+  uint32_t event_flags;     // 预留（当前线程发现事件写 Luna embedable 到 bit 0）
   char hook_name[kTextHookNameChars];
   wchar_t hook_code[kTextHookCodeChars];
   // 紧跟文本字节。
@@ -179,7 +185,7 @@ struct SharedHeader {
   // ── v2 区偏移（injector 填，header 起算的字节偏移）──
   uint32_t text_region_offset;      // 文本环起始
   uint32_t clip_region_offset;      // clip 索引起始
-  volatile uint64_t text_write_count;  // 单调：已写文本行数（host 取 last..count 的新行）
+  volatile uint64_t text_write_count;  // 单调：已写文本事件数（host 取 last..count 的新事件）
   volatile uint64_t clip_write_count;  // 单调：已写语音 clip 数
   // 0=injector 自动选干净线程；非 0=用户在 Hibiki 选择的 TextSlot::thread_id。
   // injector 仍无条件过滤重复伪影，再仅写该线程。
@@ -190,7 +196,7 @@ struct SharedHeader {
   volatile uint32_t luna_active;
   uint32_t reserved_luna;  // 32 位引擎诊断位（已满，loopback 另立字段）
   // Helper 自身诊断位。不能复用 reserved_luna：其 32 位已被各引擎探针占满，且 Siglus
-  // 原始 OGG dump 也使用最高位。v7 单独扩展，避免启动同步与 Siglus 状态互相误判。
+  // 原始 OGG dump 也使用最高位。v10 单独扩展，避免启动同步与 Siglus 状态互相误判。
   volatile uint32_t hook_diagnostics;
   uint32_t reserved_hook_diagnostics;
   volatile uint64_t unity_voice_write_count;

--- a/native/galgame_voice_hook/injector/injector_main.cpp
+++ b/native/galgame_voice_hook/injector/injector_main.cpp
@@ -427,10 +427,10 @@ bool LunaPassesFilter(const wchar_t* text, int len) {
   return has_wide || non_ws >= 2;
 }
 
-// 把一行文本写进共享内存文本环（host 侧 LunaHook 写者）。与游戏内 DLL 的 WriteTextRingLocked
-// **完全同一套协议**：InterlockedIncrement64 原子占唯一槽号 → 填文本 + 字段 → 最后写 seq 作
-// 完成标记。跨进程双写同环靠原子占号防撞槽、防丢更新。LunaHook 的 Output 回调可能在其内部工作
-// 线程并发触发，原子占号同样保证 injector 侧多次调用互不撞槽。
+// 把台词或线程发现事件写进共享内存文本环（host 侧 LunaHook 写者）。与游戏内 DLL 的
+// WriteTextRingLocked **完全同一套协议**：InterlockedIncrement64 原子占唯一槽号 → 填文本 + 字段
+// → 最后写 seq 作完成标记。跨进程双写同环靠原子占号防撞槽、防丢更新。LunaHook 的回调可能在
+// 其内部工作线程并发触发，原子占号同样保证 injector 侧多次调用互不撞槽。
 uint64_t Fnv1a64(uint64_t hash, const void* data, size_t size) {
   const auto* bytes = static_cast<const uint8_t*>(data);
   for (size_t i = 0; i < size; i++) {
@@ -456,10 +456,13 @@ uint64_t LunaTextThreadId(const wchar_t* hookcode, const char* hookname,
   return hash == 0 ? 1 : hash;
 }
 
-void WriteLunaTextLine(SharedHeader* header, const wchar_t* hookcode,
-                       const char* hookname, const LunaThreadParam& tp,
-                       uint64_t thread_id, const wchar_t* text, int wlen) {
-  if (header == nullptr || text == nullptr || wlen <= 0) {
+void WriteLunaTextEvent(SharedHeader* header, const wchar_t* hookcode,
+                        const char* hookname, const LunaThreadParam& tp,
+                        uint64_t thread_id, uint32_t event_kind,
+                        uint32_t event_flags, const wchar_t* text, int wlen) {
+  if (header == nullptr ||
+      (event_kind == hibiki_voice_hook::kTextEventLine &&
+       (text == nullptr || wlen <= 0))) {
     return;
   }
   uint8_t* text_base =
@@ -473,21 +476,27 @@ void WriteLunaTextLine(SharedHeader* header, const wchar_t* hookcode,
   memset(ts, 0, sizeof(TextSlot));
   uint32_t max_bytes = kTextSlotBytes - static_cast<uint32_t>(sizeof(TextSlot));
   max_bytes -= (max_bytes % static_cast<uint32_t>(sizeof(wchar_t)));  // wchar 边界
-  uint32_t byte_len = static_cast<uint32_t>(wlen) *
-                      static_cast<uint32_t>(sizeof(wchar_t));
+  uint32_t byte_len = text == nullptr || wlen <= 0
+                          ? 0
+                          : static_cast<uint32_t>(wlen) *
+                                static_cast<uint32_t>(sizeof(wchar_t));
   if (byte_len > max_bytes) {
     byte_len = max_bytes;  // 截断到槽容量
   }
-  memcpy(slot + sizeof(TextSlot), text, byte_len);
+  if (byte_len != 0) {
+    memcpy(slot + sizeof(TextSlot), text, byte_len);
+  }
   ts->timestamp_ms = GetTickCount64();
   ts->byte_len = byte_len;
-  ts->is_utf8 = 0;                            // UTF-16LE
+  ts->is_utf8 = 0;  // UTF-16LE
   ts->thread_id = thread_id;
   ts->thread_address = tp.addr;
   ts->thread_context = tp.ctx;
   ts->thread_context2 = tp.ctx2;
   ts->process_id = tp.processId;
   ts->source_kind = hibiki_voice_hook::kTextSourceLuna;
+  ts->event_kind = event_kind;
+  ts->event_flags = event_flags;
   if (hookname != nullptr) {
     const size_t n = (std::min)(strlen(hookname),
                                 static_cast<size_t>(
@@ -508,6 +517,13 @@ void WriteLunaTextLine(SharedHeader* header, const wchar_t* hookcode,
   if (header->text_hooked == 0) {
     header->text_hooked = 1;  // 首次 flush：文本 hook proof-of-life
   }
+}
+
+void WriteLunaTextLine(SharedHeader* header, const wchar_t* hookcode,
+                       const char* hookname, const LunaThreadParam& tp,
+                       uint64_t thread_id, const wchar_t* text, int wlen) {
+  WriteLunaTextEvent(header, hookcode, hookname, tp, thread_id,
+                     hibiki_voice_hook::kTextEventLine, 0, text, wlen);
 }
 
 // ── 多 hook 自动选干净线程（LunaHook 伪影过滤）────
@@ -766,14 +782,21 @@ void LunaConnect(DWORD pid) {
 void LunaDisconnect(DWORD pid) {
   fprintf(stderr, "[luna] disconnected pid=%lu\n", pid);
 }
-// 以下 stub 仅满足 Luna_Start 的前 8 个参数槽及签名，不做业务。
+// ThreadCreate 是 LunaTranslator 线程列表的真相源。不能再只从已通过自动赢家过滤的 Output
+// 反推线程，否则 TextRender 这类候选在线程被选中前没有已发布行，就永远无法出现在选择器里。
 void LunaThreadCreate(const wchar_t* hookcode, const char* hookname,
                       LunaThreadParam tp, bool embedable) {
-  (void)hookcode;
-  (void)hookname;
-  (void)tp;
-  (void)embedable;
+  if (g_luna.header == nullptr) {
+    return;
+  }
+  const uint64_t thread_id = LunaTextThreadId(hookcode, hookname, tp);
+  WriteLunaTextEvent(
+      g_luna.header, hookcode, hookname, tp, thread_id,
+      hibiki_voice_hook::kTextEventThreadDiscovered, embedable ? 1u : 0u,
+      nullptr, 0);
 }
+// 线程目录按捕获会话整体清理；移除事件暂不透传，避免用户刚选中的短生命周期线程在 Luna
+// 重建同一 ThreadParam 的间隙被 UI 擅自切回自动。
 void LunaThreadRemove(const wchar_t* hookcode, const char* hookname,
                       LunaThreadParam tp) {
   (void)hookcode;

--- a/native/galgame_voice_hook/tools/ring_probe.cpp
+++ b/native/galgame_voice_hook/tools/ring_probe.cpp
@@ -817,12 +817,12 @@ int main(int argc, char** argv) {
           r, hooked, calibrating, sr, ch, bits, is_float, cap, write_pos,
           static_cast<unsigned long long>(total), state);
     }
-    // v2：文本 hook 计数 + 按句语音 clip 计数 + 最近一条台词（UTF-16LE→UTF-8）。
+    // v10：文本事件计数 + 按句语音 clip 计数 + 最近一条台词（UTF-16LE→UTF-8）。
     const uint32_t text_hooked = header->text_hooked;
     const uint64_t twc = header->text_write_count;
     const uint64_t cwc = header->clip_write_count;
     const uint64_t uwc = header->unity_voice_write_count;
-    printf("     [v2] text_hooked=%u luna_active=%u decdiag=0x%08x hookdiag=0x%08x text_lines=%llu voice_clips=%llu unity_events=%llu",
+    printf("     [v10] text_hooked=%u luna_active=%u decdiag=0x%08x hookdiag=0x%08x text_events=%llu voice_clips=%llu unity_events=%llu",
            text_hooked, header->luna_active, header->reserved_luna,
            header->hook_diagnostics,
            static_cast<unsigned long long>(twc),


### PR DESCRIPTION
## What

- publish Luna `ThreadCreate` events through the native IPC, Windows runner, and Dart session so quiet candidates such as 9nine's `TextRender` appear in the thread selector before their first line
- keep thread discovery separate from captured line history, while retaining selection and line counts when real text arrives
- package the x64 `unity_audio_runtime/` directory with the voice-hook helper and preserve safe nested paths during installation

## Why

Hibiki previously built its selectable thread catalog only from text lines that survived Luna's automatic winner/filter path. `TextRender` did not emit a line until selected, so it could never enter Hibiki's selector even though LunaTranslator showed it from `ThreadCreate`.

The helper release workflow also assumed every archive contained exactly four flat files. The Unity resource-audio extractor introduced by the merged game-capture work is a nested runtime directory, so released helpers could inject successfully but still degrade to `engine_pcm_unavailable` because that runtime was absent after download/install.

## Impact

- 9nine can expose `TextRender` as a selectable zero-line thread, then accumulate real lines normally
- x64 helper releases contain the Unity resource-audio extractor and its vgmstream/class database dependencies
- archive extraction preserves required subdirectories while continuing to reject absolute paths and zip-slip traversal

## Validation

- `flutter build windows --debug` — passed
- x64 helper CMake configure + Release build — passed
- x86 helper CMake configure + Release build — passed
- staged and inspected a workflow-equivalent x64 archive; required root binaries and `unity_audio_runtime/{hibiki_unity_audio_extract.exe,classdata.tpk,vgmstream-cli.exe}` are present
- `dart format` on all touched Dart files — no changes
- `git diff --check` — passed
- unit tests intentionally skipped per user request

Tracks BUG-959.
