### PR TITLE
fix(shortcuts): 文本框放行裸空格，仅非文本输入时中和 (BUG-960)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 940 条。点号进各自文件。
+> 共 941 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-960](bugs/BUG-960-space-textfield-swallowed.md) | ✅ | ✅ | 文本框物理键盘空格被全局 DoNothingIntent 吞掉 |
 | [BUG-959](bugs/BUG-959-local-media-shelf-perf.md) | ✅ | ✅ | 本地视频/书籍页首屏慢：封面全分辨率解码+合集N+1查询+首帧同步stat |
 | [BUG-958](bugs/BUG-958-gal-hook-ready-signal-late.md) | ✅ | ✅ | Galgame helper 已注入但 ready 信号过晚导致 engine_attach_failed |
 | [BUG-957](bugs/BUG-957-galgame-dead-session-controller-leftover.md) | 🚧 | 🚧 | 旧 GalgameSessionController 死代码残留致查词面板 galgame 制卡出口失效 |

--- a/docs/bugs/BUG-960-space-textfield-swallowed.md
+++ b/docs/bugs/BUG-960-space-textfield-swallowed.md
@@ -1,0 +1,8 @@
+## BUG-960 · 文本框物理键盘空格被全局 DoNothingIntent 吞掉
+- **报告**：2026-07-21（用户：群主）
+- **真实性**：✅ 真 bug，根因 `hibiki/lib/src/shortcuts/global_navigation.dart:328`（原 `const SingleActivator(LogicalKeyboardKey.space): const DoNothingIntent()`）
+- **现象**：重命名合集等对话框的输入框里，物理键盘按空格打不出空格；只有点右侧屏幕键盘图标（走 IME text-input 通道）才能插入空格。「脱裤子放屁」。
+- **根因**：`wrapWithGlobalNavigation` 把 `space → DoNothingIntent` 无条件挂进全局 `Shortcuts`。`DoNothingAction.consumesKey` 恒为 `true`，故**无条件吞掉空格按下沿**，包括文本框聚焦时。`EditableText` 对裸空格没有任何 text-editing 动作（空格靠字符输入通道插入），不会在近处被 `onKeyEvent` 消费，于是一路冒泡到全局被吞。物理键盘走 KeyEvent 管线 → 被 handled 截断，引擎不再把空格转给 text-input；屏幕键盘走 IME text-input 通道，绕过快捷键层 → 能打。原注释（316-320 行）自称「文本框输入空格被更近作用域消费，到不了这里」，该假设错误。
+- **[x] ① 已修复** — commit 见下。把中和从无条件 `Shortcuts` 表条目重构为 `_neutralizeBareSpace(event)`：仅在按下沿（`KeyDownEvent`）且 `focusedEditableText() == null`（无文本框聚焦）时返回 `handled` 中和；文本框聚焦时返回 `ignored` 放行，空格冒泡到 text-input 正常插入。挂在外层 `Focus.onKeyEvent` 最前（始终生效，先于框架 `space→ActivateIntent`），与已有 `_handleGlobalBack` 的 `focusedEditableText()` 门控同范式。焦点确认不走空格（Enter/手柄 A）与阅读器翻页/视频·有声书暂停均不变（后者在更近作用域先消费空格）。文件 `hibiki/lib/src/shortcuts/global_navigation.dart`。
+- **[x] ② 已加自动化测试** — `hibiki/test/shortcuts/global_space_no_activate_test.dart`：新增「哨兵祖先 Focus」范式两条——控件聚焦时空格被消费（不冒泡到祖先）、文本框聚焦时空格放行冒泡（可落到 text-input），焦点导航开/关都断言。修复前后者必挂（DoNothingIntent 吞掉空格），修复后通过。另更新 `hibiki/test/reader/reader_chrome_space_pause_test.dart` 源码守卫：锚点从旧 `SingleActivator(space)` 改为 `_neutralizeBareSpace(`，并加固断言 `focusedEditableText() != null` 门控不得回退。
+- **备注**：屏幕键盘图标（`TextField` 的 IME 触发）行为不变；本修复只让物理键盘空格与之一致。

--- a/hibiki/lib/src/shortcuts/global_navigation.dart
+++ b/hibiki/lib/src/shortcuts/global_navigation.dart
@@ -268,6 +268,28 @@ KeyEventResult _handleGlobalToggleFullscreen(
 bool get _isDesktopWindow =>
     Platform.isWindows || Platform.isLinux || Platform.isMacOS;
 
+/// 裸空格中和：焦点确认永不走空格（确认键统一 Enter / 手柄 A，由框架默认提供），故在
+/// 无文本输入时吞掉裸空格的按下沿，阻断 [WidgetsApp] 默认的 space→ActivateIntent。
+///
+/// **但仅在没有文本框聚焦时中和**。以前把 `space → DoNothingIntent` 挂进 [Shortcuts]，
+/// 而 [DoNothingAction.consumesKey] 恒为 true——它无条件吞空格，包括文本框聚焦时
+/// （BUG-960）。文本框里裸空格没有任何 text-editing 动作，不会在近处被消费，会一路冒泡
+/// 到全局被吞掉；物理键盘走 KeyEvent 管线故被吞，屏幕键盘走 IME text-input 通道绕过快捷
+/// 键层故能打——「重命名对话框只有屏幕键盘能打空格」正是这个漏判。现改为：仅按下沿且
+/// [focusedEditableText] 为空时才消费——文本框聚焦时放行，空格落到 text-input 正常插入。
+///
+/// 只吞按下沿（[KeyDownEvent]），与原 [SingleActivator] 一致（激活是按下沿动作）；
+/// repeat/up 放行无害。阅读器翻页 / 视频·有声书播放暂停在更近作用域先消费空格，根本到
+/// 不了这里，故不受影响。始终生效，不受实验性焦点导航开关影响。
+KeyEventResult _neutralizeBareSpace(KeyEvent event) {
+  if (event is! KeyDownEvent ||
+      event.logicalKey != LogicalKeyboardKey.space ||
+      focusedEditableText() != null) {
+    return KeyEventResult.ignored;
+  }
+  return KeyEventResult.handled;
+}
+
 /// Flips the main window between fullscreen and windowed.
 ///
 /// TODO-1375：全屏切换必须由 NSWindow 的**唯一所有者**执行。macOS 壳用
@@ -315,9 +337,10 @@ Future<void> _toggleWindowFullscreen() async {
 ///   没开焦点导航时按 Tab 不该有动作（TODO-112）。开启时不中和，原生 Tab 遍历照常。
 ///   与焦点导航无关、始终生效的两件事不受其影响：
 ///     * Escape 退出整页层级（桌面键盘惯例）；
-///     * 裸空格中和为 [DoNothingIntent]，使焦点确认永不走空格（确认键统一 Enter /
-///       手柄 A，由框架默认提供）。空格被更近作用域消费（阅读器翻页 / 视频·有声书
-///       播放暂停 / 文本框输入空格）时根本到不了这里，故不受影响。
+///     * 裸空格中和（[_neutralizeBareSpace]），使焦点确认永不走空格（确认键统一
+///       Enter / 手柄 A，由框架默认提供）。**仅在没有文本框聚焦时中和**——文本框输入
+///       空格必须放行，否则重命名等输入框打不出空格（BUG-960）。空格被更近作用域消费
+///       （阅读器翻页 / 视频·有声书播放暂停）时根本到不了这里，故不受影响。
 Widget wrapWithGlobalNavigation({
   required GlobalKey<NavigatorState> navigatorKey,
   required Widget child,
@@ -325,7 +348,6 @@ Widget wrapWithGlobalNavigation({
   HibikiShortcutRegistry? registry,
 }) {
   final Map<ShortcutActivator, Intent> shortcuts = <ShortcutActivator, Intent>{
-    const SingleActivator(LogicalKeyboardKey.space): const DoNothingIntent(),
     // 焦点导航总开关关闭时，把 Tab / Shift+Tab 中和成 DoNothingIntent，使 Flutter
     // [WidgetsApp] 内建的 NextFocusIntent/PreviousFocusIntent 遍历不再生效——本
     // Shortcuts 比 WidgetsApp 默认 shortcuts 更靠近焦点节点，故先匹配并阻断冒泡。
@@ -350,6 +372,11 @@ Widget wrapWithGlobalNavigation({
     canRequestFocus: false,
     skipTraversal: true,
     onKeyEvent: (FocusNode node, KeyEvent event) {
+      // 裸空格中和（始终生效，不受焦点导航开关影响）；仅非文本输入时消费，见
+      // [_neutralizeBareSpace]（BUG-960）。放在最前，先于框架 space→ActivateIntent。
+      if (_neutralizeBareSpace(event) == KeyEventResult.handled) {
+        return KeyEventResult.handled;
+      }
       if (focusNavigationEnabled) {
         final KeyEventResult gamepadResult =
             dispatchNativeGamepadButtonIntent(event);

--- a/hibiki/test/reader/reader_chrome_space_pause_test.dart
+++ b/hibiki/test/reader/reader_chrome_space_pause_test.dart
@@ -111,16 +111,25 @@ void main() {
       );
     });
 
-    test('未回退裸空格中和：全局导航仍把 SingleActivator(space) 中和', () {
+    test('未回退裸空格中和：全局导航仍中和裸空格，且仅在非文本输入时（BUG-960 门控）', () {
       final String nav = File(
         'lib/src/shortcuts/global_navigation.dart',
       ).readAsStringSync();
+      // 裸空格中和（c152fcd91 用户裁定的正确全局行为）不得回退。实现已从无条件
+      // SingleActivator→DoNothingIntent 重构为 _neutralizeBareSpace（BUG-960）：既守
+      // 中和仍在，也守它按 focusedEditableText 门控——文本框聚焦时放行，否则重命名等
+      // 输入框打不出空格。两条不变量任一被回退即视为回归。
       expect(
         nav,
-        contains(
-            'const SingleActivator(LogicalKeyboardKey.space): const DoNothingIntent()'),
-        reason: '裸空格中和（c152fcd91 用户裁定的正确全局行为）不得回退；'
+        contains('KeyEventResult _neutralizeBareSpace('),
+        reason: '裸空格中和不得回退：必须保留 _neutralizeBareSpace 中和裸空格按下沿，'
             'BUG-204 的暂停行为靠正文路径的 resolveReaderSpaceOverride，不靠回退中和。',
+      );
+      expect(
+        nav,
+        contains('focusedEditableText() != null'),
+        reason: 'BUG-960 门控不得回退：裸空格中和必须放行文本框（focusedEditableText '
+            '非空时不消费），否则重命名等输入框打不出空格（只有屏幕键盘 IME 能绕过）。',
       );
     });
   });

--- a/hibiki/test/shortcuts/global_space_no_activate_test.dart
+++ b/hibiki/test/shortcuts/global_space_no_activate_test.dart
@@ -3,9 +3,13 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/shortcuts/global_navigation.dart';
 
-/// 焦点确认不走空格：[wrapWithGlobalNavigation] 把裸空格中和成 DoNothingIntent，
-/// 使焦点落在控件上时空格不再触发激活；Enter（与手柄 A，由框架默认提供）仍激活。
-/// 这条行为不受实验性焦点导航开关影响——开/关都成立。
+/// 焦点确认不走空格：[wrapWithGlobalNavigation] 把裸空格中和，使焦点落在控件上时空格
+/// 不再触发激活；Enter（与手柄 A，由框架默认提供）仍激活。这条行为不受实验性焦点导航
+/// 开关影响——开/关都成立。
+///
+/// BUG-960：中和必须只在「没有文本框聚焦」时生效。以前无条件 `space → DoNothingIntent`
+/// 连文本框里的空格也吞掉，导致重命名等对话框物理键盘打不出空格（只有屏幕键盘的 IME
+/// text-input 通道能绕过快捷键层）。文本框聚焦时空格必须放行冒泡到 text-input。
 void main() {
   Future<int> pumpAndCountTaps(
     WidgetTester tester, {
@@ -45,6 +49,61 @@ void main() {
     return taps;
   }
 
+  /// 用「哨兵祖先 Focus」判定空格是否被 [wrapWithGlobalNavigation] 吞掉：哨兵包在其
+  /// 外层，是祖先，故事件冒泡顺序为 焦点控件 → 全局导航 → 哨兵。全局导航消费（返回
+  /// handled）→ 哨兵收不到；全局导航放行（ignored）→ 哨兵能收到。返回哨兵是否见到空格
+  /// 按下沿。[editable] 为 true 时聚焦一个 [TextField]，否则聚焦一个 [TextButton]。
+  Future<bool> pumpAndSpaceReachesSentinel(
+    WidgetTester tester, {
+    required bool editable,
+    required bool focusNavigationEnabled,
+  }) async {
+    bool sentinelSawSpace = false;
+    final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+    final FocusNode focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navKey,
+        home: Focus(
+          canRequestFocus: false,
+          skipTraversal: true,
+          onKeyEvent: (FocusNode node, KeyEvent event) {
+            if (event is KeyDownEvent &&
+                event.logicalKey == LogicalKeyboardKey.space) {
+              sentinelSawSpace = true;
+            }
+            return KeyEventResult.ignored;
+          },
+          child: wrapWithGlobalNavigation(
+            navigatorKey: navKey,
+            focusNavigationEnabled: focusNavigationEnabled,
+            child: Scaffold(
+              body: Center(
+                child: editable
+                    ? TextField(focusNode: focusNode)
+                    : TextButton(
+                        focusNode: focusNode,
+                        onPressed: () {},
+                        child: const Text('确认'),
+                      ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+    return sentinelSawSpace;
+  }
+
   testWidgets('裸空格不激活焦点控件（焦点导航开/关都成立）', (WidgetTester tester) async {
     expect(
       await pumpAndCountTaps(
@@ -76,5 +135,34 @@ void main() {
       1,
       reason: '确认键 Enter 必须仍能激活焦点控件',
     );
+  });
+
+  testWidgets('BUG-960：焦点在控件上时，空格被全局导航消费（不冒泡到祖先）', (WidgetTester tester) async {
+    for (final bool nav in <bool>[false, true]) {
+      expect(
+        await pumpAndSpaceReachesSentinel(
+          tester,
+          editable: false,
+          focusNavigationEnabled: nav,
+        ),
+        isFalse,
+        reason: '控件聚焦时，裸空格必须被中和（消费），不得冒泡激活（nav=$nav）',
+      );
+    }
+  });
+
+  testWidgets('BUG-960：焦点在文本框上时，空格放行冒泡（可落到 text-input）',
+      (WidgetTester tester) async {
+    for (final bool nav in <bool>[false, true]) {
+      expect(
+        await pumpAndSpaceReachesSentinel(
+          tester,
+          editable: true,
+          focusNavigationEnabled: nav,
+        ),
+        isTrue,
+        reason: '文本框聚焦时，空格必须放行到 text-input，否则打不出空格（nav=$nav）',
+      );
+    }
   });
 }


### PR DESCRIPTION
## 问题
重命名合集等对话框的输入框里，**物理键盘按空格打不出空格**；只有点右侧屏幕键盘图标（走 IME text-input 通道）才能插入空格。「脱裤子放屁」。

## 根因
`wrapWithGlobalNavigation` 把 `space → DoNothingIntent` 无条件挂进全局 `Shortcuts`。`DoNothingAction.consumesKey` 恒为 `true`，**无条件吞掉空格按下沿**，包括文本框聚焦时。`EditableText` 对裸空格没有任何 text-editing 动作（空格靠字符输入通道插入），不会在近处被 `onKeyEvent` 消费，一路冒泡到全局被吞 → 引擎不再把空格转给 text-input。物理键盘走 KeyEvent 管线故被截断；屏幕键盘走 IME text-input 通道绕过快捷键层故能打。原注释自称「文本框空格被更近作用域消费」的假设是错的。

## 修复
把中和从无条件 `Shortcuts` 条目重构为 `_neutralizeBareSpace(event)`：仅在按下沿（`KeyDownEvent`）且 `focusedEditableText() == null` 时返回 `handled` 中和；文本框聚焦时 `ignored` 放行到 text-input。挂在外层 `Focus.onKeyEvent` 最前（始终生效），与已有 `_handleGlobalBack` 的 `focusedEditableText()` 门控同范式。焦点确认不走空格（Enter/手柄 A）、阅读器翻页/视频·有声书暂停均不变。

## 测试
- `global_space_no_activate_test`：新增「哨兵祖先 Focus」两条——控件聚焦时空格被消费（不冒泡）、文本框聚焦时空格放行冒泡（可落 text-input），焦点导航开/关都断言。修复前后者必挂。
- `reader_chrome_space_pause_test` 源码守卫锚点更新为 `_neutralizeBareSpace(`，加固 `focusedEditableText() != null` 门控不得回退。
- 相关空格/导航测试全绿（55 条），`flutter analyze` 无 issue。

⚠️ Windows 桌面真机复测原始失败路径（重命名对话框物理键盘打空格）待验收。

https://claude.ai/code/session_01PTGbxaxnH21i6BJAPgzXPk