### PR TITLE
fix(shelf): BUG-962 合集内有声书成员筛选时丢封面

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 942 条。点号进各自文件。
+> 共 943 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-962](bugs/BUG-962-shelf-filter-collection-cover.md) | ✅ | ✅ | 筛选时合集内有声书成员丢封面 |
 | [BUG-961](bugs/BUG-961-voice-hook-helper-release-missing.md) | ✅ | ✅ | galgame voice hook helper 引擎组件下载 404（release 从未产出） |
 | [BUG-960](bugs/BUG-960-textrender-thread-catalog.md) | ✅ | ✅ | 9nine 的 Luna 线程列表缺少 TextRender |
 | [BUG-959](bugs/BUG-959-local-media-shelf-perf.md) | ✅ | ✅ | 本地视频/书籍页首屏慢：封面全分辨率解码+合集N+1查询+首帧同步stat |

--- a/docs/bugs/BUG-962-shelf-filter-collection-cover.md
+++ b/docs/bugs/BUG-962-shelf-filter-collection-cover.md
@@ -1,0 +1,10 @@
+## BUG-962 · 筛选时合集内有声书成员丢封面
+
+- **报告**：2026-07-21（用户）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart` `_buildBodyWithSrtBooks` 内三张「从 EPUB 借用」的展示映射（封面 `epubCoverUrisByBookKey` / 有 EPUB 背书 `epubBackedBookKeys` / 借用进度 `epubProgressByBookKey`）遍历的是**筛选后的 `books` 参数**（原约 795-796 行的 `for (final MediaItem item in books)`）。
+  - 数据流：书架有两套独立标签过滤——EPUB 走 `filteredBookIdsProvider`、SRT 走 `filteredSrtBookIdsProvider`。合集内的有声书(SRT)成员在渲染时向其关联 EPUB **借封面**（`_buildSrtCard(epubCoverUri: epubCoverUrisByBookKey[srt.bookKey])` → `_buildSrtCover` 回退链，`reader_history/books.part.dart`）。
+  - 当用户只给有声书打了标签、关联 EPUB 未命中同一标签时，EPUB 被 `filteredBookIdsProvider` 筛掉 → 传入 `_buildBodyWithSrtBooks` 的 `books` 不含该 EPUB → 借用映射查不到该 `bookKey` → SRT 成员卡回退占位图标 = 丢封面。未筛选时 `books` = 全量 EPUB，映射齐全，故正常。
+  - BUG-937/BUG-940 让「被筛合集能带命中的 SRT 成员显示出来」后，此借用映射被筛选裁剪的潜在缺陷才暴露（之前合集在筛选下压根不出现）。同根因也影响 BUG-728 的进度借用在筛选下丢失。
+- **[x] ① 已修复** — 借用映射改以**未筛选全量** `ref.read(hibikiBooksProvider(appModel.targetLanguage)).valueOrNull`（新变量 `allEpubBooksForBorrow`，空态回退 `books`）为源，与「参与网格展示的筛选后列表」解耦；三张映射的装配循环改遍历 `allEpubBooksForBorrow`。展示列表（`epubBooks = books.where(...)`）仍用筛选后的 `books`，行为不变。`reader_hibiki_history_page.dart` `_buildBodyWithSrtBooks`。提交见下。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/shelf_collection_cover_borrow_full_corpus_guard_test.dart`（源码扫描守卫，沿仓库既有 `*_guard_test` 范式 + 姊妹 BUG-728 `shelf_srt_card_progress_guard_test.dart`）：切 `_buildBodyWithSrtBooks` 方法体，锁死①借用源 = `ref.read(hibikiBooksProvider(...))` 全量、②装配循环遍历 `allEpubBooksForBorrow`、③回归哨兵不得再 `for (final MediaItem item in books)`、④封面映射写入 `_epubCoverUrisByBookKey` 字段。6 项测试（含 BUG-728 守卫回归复核）全过。
+- **备注**：`flutter analyze` 单文件 No issues；进度借用（BUG-728）在筛选下的同类丢失也随本修复一并根治。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -766,14 +766,23 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     AsyncSnapshot<_RemoteBookState?>? remoteSnapshot,
   ) {
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    // BUG-962：这三张「从 EPUB 借用」的展示映射（封面 / 有 EPUB 背书门控 / 借用进度）
+    // 必须以**未筛选的全量 EpubBooks 行**为源，而不是筛选后的 `books`。标签筛选只裁剪
+    // 参与网格展示的列表；合集内只打了标签的有声书（SRT）成员会向其关联 EPUB 借封面 /
+    // 进度 / 「查看插画」门控，若以筛选子集构建，关联 EPUB 未命中同一标签即被筛掉 → 借不到
+    // → 合集成员丢封面（BUG-937 让被筛合集能带命中成员显示后暴露此缺陷）。此处已 watch
+    // 于上层 build（filteredBookIdsProvider 之上的 hibikiBooksProvider），read 全量安全。
+    final List<MediaItem> allEpubBooksForBorrow =
+        ref.read(hibikiBooksProvider(appModel.targetLanguage)).valueOrNull ??
+            books;
     final Map<String, String> epubCoverUrisByBookKey = {};
-    // TODO-1191：`books` 是 hibikiBooksProvider 的全部 EpubBooks 行；解析出的
-    // bookKey 全集即「有 EpubBooks 行」的真值，供 SRT 卡「查看插画」门控用。
+    // TODO-1191：`allEpubBooksForBorrow` 是 hibikiBooksProvider 的全部 EpubBooks 行；
+    // 解析出的 bookKey 全集即「有 EpubBooks 行」的真值，供 SRT 卡「查看插画」门控用。
     final Set<String> epubBackedBookKeys = {};
     // BUG-728：过滤前先收 EPUB 卡已算好的进度，供只以 SRT 卡出现的有声书复用。
     final Map<String, ({int position, int duration})> epubProgressByBookKey =
         {};
-    for (final MediaItem item in books) {
+    for (final MediaItem item in allEpubBooksForBorrow) {
       final String? key = _parseBookKey(item.mediaIdentifier);
       if (key != null) {
         epubBackedBookKeys.add(key);

--- a/hibiki/test/pages/shelf_collection_cover_borrow_full_corpus_guard_test.dart
+++ b/hibiki/test/pages/shelf_collection_cover_borrow_full_corpus_guard_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-962 guard：书架标签筛选时合集内有声书成员丢封面。
+///
+/// 根因：`_buildBodyWithSrtBooks` 里三张「从 EPUB 借用」的展示映射
+/// （封面 `epubCoverUrisByBookKey` / 有 EPUB 背书门控 `epubBackedBookKeys` /
+/// 借用进度 `epubProgressByBookKey`）以前遍历**筛选后的 `books` 参数**构建。
+/// 合集内只给有声书(SRT)打了标签、关联 EPUB 未命中同一标签时，EPUB 被
+/// `filteredBookIdsProvider` 筛掉 → 映射里查不到 → SRT 成员卡（BUG-937 让被筛
+/// 合集能带命中成员显示）借不到关联 EPUB 封面 → 回退占位图 = 丢封面。
+///
+/// 修复：借用映射改以**未筛选全量** `ref.read(hibikiBooksProvider(...))`
+/// （变量 `allEpubBooksForBorrow`）为源，与「参与网格展示的筛选后列表」解耦。
+/// 借用是纯展示数据，不该被标签筛选裁剪。此守卫锁死数据来源不回归。
+void main() {
+  final String source = File(
+    'lib/src/pages/implementations/reader_hibiki_history_page.dart',
+  ).readAsStringSync();
+
+  // 切出 _buildBodyWithSrtBooks 方法体（到下一个方法 _buildShelfGroupSlivers 为止），
+  // 避免误命中文件别处同名字面量。
+  String buildBody() {
+    const String start = 'Widget _buildBodyWithSrtBooks(';
+    const String end = 'List<Widget> _buildShelfGroupSlivers(';
+    final int startIdx = source.indexOf(start);
+    final int endIdx = source.indexOf(end);
+    expect(startIdx, greaterThanOrEqualTo(0),
+        reason: '找不到 _buildBodyWithSrtBooks');
+    expect(endIdx, greaterThan(startIdx), reason: '找不到方法体结束锚点');
+    return source.substring(startIdx, endIdx);
+  }
+
+  test('借用映射源 = 未筛选全量 hibikiBooksProvider，而非筛选后的 books 参数', () {
+    final String body = buildBody();
+    // 全量来源变量必须存在，且取自 hibikiBooksProvider（未过滤真值），
+    // 空态兜底回退到 books 参数。
+    expect(
+      body.contains(RegExp(
+          r'final List<MediaItem> allEpubBooksForBorrow\s*=\s*\n?\s*ref\.read\(hibikiBooksProvider\(appModel\.targetLanguage\)\)\.valueOrNull\s*\?\?')),
+      isTrue,
+      reason: '借用映射源须为 ref.read(hibikiBooksProvider(...)) 全量列表，'
+          'valueOrNull 为空时回退 books',
+    );
+    // 三张借用映射的唯一装配循环必须遍历全量 allEpubBooksForBorrow。
+    expect(
+      body,
+      contains('for (final MediaItem item in allEpubBooksForBorrow)'),
+      reason: '封面/背书/进度三张映射须遍历未筛选全量列表装配',
+    );
+  });
+
+  test('回归哨兵：装配循环不得再遍历筛选后的 books 参数', () {
+    final String body = buildBody();
+    // 旧写法 `for (final MediaItem item in books)` 会让筛选时借用映射被裁剪，
+    // 复现丢封面。注意 `epubBooks = books.where(...)` 的展示列表过滤仍合法，
+    // 只锁死借用映射的 for-in 循环不得以 books 为源。
+    expect(
+      body.contains(RegExp(r'for\s*\(\s*final MediaItem item in books\s*\)')),
+      isFalse,
+      reason: '借用映射循环不得遍历筛选后的 books（会让筛选时合集成员丢封面）',
+    );
+  });
+
+  test('封面映射最终写入 _epubCoverUrisByBookKey 字段供成员卡读取', () {
+    final String body = buildBody();
+    expect(
+      body,
+      contains('epubCoverUrisByBookKey[key] = imageUrl'),
+      reason: '须收录每本 EPUB 的封面 imageUrl',
+    );
+    expect(
+      body,
+      contains('_epubCoverUrisByBookKey = epubCoverUrisByBookKey'),
+      reason: '须把本帧封面映射赋给字段，供 _buildSrtCard 借用',
+    );
+  });
+}


### PR DESCRIPTION
## 问题
书架按标签筛选时，合集内的有声书(SRT)成员会丢失封面（回退成占位图标）。

## 根因
`reader_hibiki_history_page.dart` `_buildBodyWithSrtBooks` 里三张「从 EPUB 借用」的展示映射（封面 `epubCoverUrisByBookKey` / 有 EPUB 背书门控 `epubBackedBookKeys` / 借用进度 `epubProgressByBookKey`）遍历的是**筛选后的 `books` 参数**。

书架有两套独立标签过滤（EPUB `filteredBookIdsProvider` / SRT `filteredSrtBookIdsProvider`）。合集内 SRT 成员渲染时向关联 EPUB **借封面**。当只给有声书打标签、关联 EPUB 未命中同标签时，EPUB 被筛掉 → 借用映射查不到 → 成员卡丢封面。BUG-937/940 让被筛合集能带命中成员显示后暴露此缺陷；同根因也让 BUG-728 的进度借用在筛选下丢失。

## 修复
借用映射改以未筛选全量 `ref.read(hibikiBooksProvider(...))`（`allEpubBooksForBorrow`，空态回退 `books`）为源，与「参与网格展示的筛选后列表」解耦。展示列表仍用筛选后的 `books`，行为不变。

## 测试
- `test/pages/shelf_collection_cover_borrow_full_corpus_guard_test.dart`（新增源码扫描守卫，3 项）：锁死借用源=全量、装配循环遍历 `allEpubBooksForBorrow`、回归哨兵禁止 `for (final MediaItem item in books)`。
- BUG-728 姊妹守卫 `shelf_srt_card_progress_guard_test.dart` 回归复核通过。
- `flutter analyze` 单文件 No issues。

## 待验收
⚠️ 尚未真机目视复测：需在真实设备上「合集内只给有声书打标签 → 筛选」确认成员封面回来。属书架布局/封面问题，按项目规则需真机验收后才算完全修好。

https://claude.ai/code/session_01F144NXRmDupyswTanJrvRM