### PR TITLE
fix(sync): 互联视频 live push 连同外挂字幕 sidecar 一并推送 (BUG-962)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 921 条。点号进各自文件。
+> 共 922 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-962](bugs/BUG-962-interconnect-video-subtitle-not-synced.md) | ✅ | ✅ | 互联视频live push不带外挂字幕 |
 | [BUG-940](bugs/BUG-940-tag-filter-collection-rescue.md) | ✅ | ✅ | 标签筛选:打了标签的合集筛不出来(成员级过滤先于折叠剥空合集组) |
 | [BUG-939](bugs/BUG-939-subtitle-menu-reenumerate.md) | ✅ | ✅ | 字幕轨菜单每次打开都重跑ffprobe显加载条+已有字幕先消失 |
 | [BUG-938](bugs/BUG-938-collections-sync-trigger-gap.md) | ✅ | ✅ | 合集经常没同步：合集维度只搭载低频全量 sweep，日常关书/切后台路径从不推送合集 |

--- a/docs/bugs/BUG-962-interconnect-video-subtitle-not-synced.md
+++ b/docs/bugs/BUG-962-interconnect-video-subtitle-not-synced.md
@@ -1,0 +1,32 @@
+## BUG-962 · 互联视频live push不带外挂字幕
+- **报告**：2026-07-21（用户：「hibiki互联 字幕好像没同步视频」）
+- **真实性**：✅ 真 bug。互联视频 live push（`syncVideoFiles`）只上传视频文件本身：
+  `hibiki/lib/src/sync/sync_orchestrator.dart` `_syncVideosLive` 仅调 `putRemoteVideo`，
+  server 端也没有任何字幕上传端点（`hibiki_sync_server.dart` videos suffix 路由中
+  `subtitle` 只收 GET，非 GET 405）。于是 client 推给 host 的视频，其外挂字幕
+  （sidecar `.srt/.ass/.ssa/.vtt`）留在原机；其它设备从 host 串流/下载这条视频时
+  `resolveVideoSubtitle` 找不到 sidecar → 无外挂字幕、无法查词（内嵌字幕轨在容器内
+  不受影响）。下载方向（host→client）本来就通（`hasSubtitle` →
+  `getRemoteVideoSubtitle` → 解析 cue），唯独上传方向整段缺失。
+- **[x] ① 已修复** — 上传方向补齐整条链：
+  - 纯函数 `listSidecarSubtitles` / `isSidecarSubtitleSuffix`
+    （`hibiki/lib/src/media/video/video_sidecar.dart`）：枚举视频全部同 stem sidecar
+    + 字幕后缀白名单（拒路径穿越）。
+  - host `importVideoSubtitle`（`app_model_library_host_service.dart`）：sidecar 落
+    视频同目录 `<host 视频 stem><suffix>`（`resolveVideoSubtitle` 天然可见），再按
+    学习语言重解析首选 sidecar（多字幕推送顺序无关、收敛），镜像下载路径行语义
+    （`subtitleSource`/`subtitleFormat`、`embeddedSubtitleTrack=null`、cue 落库）。
+  - server 新增 `PUT /api/library/videos/<id>/subtitle`（后缀走
+    `X-Hibiki-Subtitle-Suffix` header，400/404 语义化拒收）。
+  - client `putRemoteVideoSubtitle`：404/405（老 host 无端点）返回 false 不抛。
+  - `_syncVideosLive`：视频本轮上传 ⇒ 其全部 sidecar 一并推（不挑语言，host 端自己
+    按学习语言解析首选）；host 已有视频但清单 `hasSubtitle=false` ⇒ 只补推字幕不重
+    传视频；host 已有任一 sidecar ⇒ 跳过（幂等）；老 host 首个 405 后停止本轮后续
+    字幕推送并在 report.errors 记一条可见提示（与合集端点缺失同纪律）。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/interconnect_video_subtitle_sync_test.dart`
+  （7 例）：纯函数匹配/白名单；host 落位+行语义+cue+可见性、未知视频/非法后缀拒收；
+  端到端视频连同全部 sidecar 推送 + 首选按 ja 解析、重复 sweep 幂等（mtime 不变）、
+  缺字幕补推不重传视频；老 host 405 降级返 false 不抛。
+- **备注**：v1 粒度与视频同尺寸跳过一致——host 已有任一 sidecar 即不再推（后加第二
+  语言字幕、改字幕内容不会自动重推）；多集播放列表本就不在
+  `_isUploadableLocalVideo` 范围（单文件资产模型），其字幕同样不在本批范围。

--- a/hibiki/lib/src/media/video/video_sidecar.dart
+++ b/hibiki/lib/src/media/video/video_sidecar.dart
@@ -59,6 +59,35 @@ String? pickSidecar(
   return null;
 }
 
+/// 纯函数：列出 [dirFiles] 中**所有**属于 `<videoBaseNameNoExt>` 的 sidecar 字幕
+/// 文件名（不区分大小写匹配，返回原始文件名，保持 [dirFiles] 顺序）。
+///
+/// 匹配规则：`<stem><suffix>`，suffix 为可选语言标记 + 字幕扩展名
+/// （`.srt` / `.ja.srt` / `.zh-Hans.ass` …），与 [pickSidecar] 的按语言挑选互补——
+/// 互联 live push 用它把视频的全部外挂字幕推给 host（BUG-962），host 端再按自己的
+/// 学习语言用 [pickSidecar] 解析首选，不在传输层替对端做语言决策。
+List<String> listSidecarSubtitles(
+  String videoBaseNameNoExt,
+  List<String> dirFiles,
+) {
+  final String baseLower = videoBaseNameNoExt.toLowerCase();
+  return <String>[
+    for (final String name in dirFiles)
+      if (name.length > baseLower.length &&
+          name.toLowerCase().startsWith(baseLower) &&
+          isSidecarSubtitleSuffix(name.substring(baseLower.length)))
+        name,
+  ];
+}
+
+/// 纯函数：[suffix] 是否是合法的 sidecar 字幕后缀（`.<ext>` 或 `.<langTag>.<ext>`，
+/// ext ∈ srt/ass/ssa/vtt，langTag 只允许 `[A-Za-z0-9_-]`）。互联字幕上传端点用它做
+/// 服务端白名单校验（后缀由 client 报，绝不放行路径分隔符/穿越）。
+bool isSidecarSubtitleSuffix(String suffix) => RegExp(
+      r'^(\.[A-Za-z0-9_-]{1,32})?\.(srt|ass|ssa|vtt)$',
+      caseSensitive: false,
+    ).hasMatch(suffix);
+
 /// 在 [videoPath] 同目录查找同名 sidecar 字幕（IO 版，包装 [pickSidecar]）。
 ///
 /// [langCode] 是 app 目标学习语言代码（如 `'ja'`/`'ko'`），优先选带该语言标记的

--- a/hibiki/lib/src/sync/app_model_library_host_service.dart
+++ b/hibiki/lib/src/sync/app_model_library_host_service.dart
@@ -4,8 +4,12 @@ import 'dart:io';
 import 'package:drift/drift.dart' show Value;
 import 'package:hibiki/src/models/local_audio_manager.dart'
     show LocalAudioDbEntry;
+import 'package:hibiki/src/media/video/video_import_dialog.dart'
+    show parseSubtitleCues;
 import 'package:hibiki/src/media/video/video_sidecar.dart'
-    show findSidecarSubtitle, pickSidecar;
+    show findSidecarSubtitle, isSidecarSubtitleSuffix, pickSidecar;
+import 'package:hibiki_audio/hibiki_audio.dart'
+    show AudioCue, readTextWithEncoding;
 import 'package:hibiki/src/media/video/m3u8_playlist.dart' show PlaylistEntry;
 import 'package:hibiki/src/sync/aggregate_snapshot.dart';
 import 'package:hibiki/src/sync/aggregate_sync_service.dart';
@@ -1248,6 +1252,68 @@ class AppModelLibraryHostService implements HibikiLibraryHostService {
         }
       }
     }
+  }
+
+  /// 接收 client 上传的视频外挂字幕并落到视频同目录（BUG-962，client→host live push）。
+  ///
+  /// 落盘名 = `<host 视频文件 stem><suffix>`，与 [resolveVideoSubtitle] 的同 stem
+  /// 匹配规则天然一致；[suffix] 经 [isSidecarSubtitleSuffix] 白名单校验（拒路径
+  /// 分隔符/穿越）。落位后按 host 学习语言重解析首选 sidecar（多字幕推送顺序无关、
+  /// 结果收敛），镜像 client 下载路径（home_video_page `_registerDownloadedVideo`）
+  /// 的行语义：`subtitleSource`/`subtitleFormat` 指向首选 sidecar、
+  /// `embeddedSubtitleTrack=null`（播放走外挂）、解析 cue 落库（坏字幕 best-effort
+  /// 跳过，不挡文件落位——host 仍能把字节原样转发给其它 client）。
+  @override
+  Future<void> importVideoSubtitle(
+    File subtitleFile, {
+    required String id,
+    required String suffix,
+  }) async {
+    _assertSafeVideoId(id);
+    if (!isSidecarSubtitleSuffix(suffix)) {
+      throw ArgumentError.value(suffix, 'suffix', 'unsafe subtitle suffix');
+    }
+    await _runExclusive(() async {
+      final VideoBookRow? row = await _db.getVideoBookByBookUid(id);
+      if (row == null) throw StateError('unknown video: $id');
+      final String videoPath = row.videoPath;
+      final String lower = videoPath.toLowerCase();
+      if (videoPath.isEmpty ||
+          lower.startsWith('http://') ||
+          lower.startsWith('https://')) {
+        throw StateError('video has no local file: $id');
+      }
+      final File dest = File(p.join(p.dirname(videoPath),
+          '${p.basenameWithoutExtension(videoPath)}$suffix'));
+      await _moveFileInto(subtitleFile, dest);
+      final String? preferred =
+          findSidecarSubtitle(videoPath, langCode: _videoSubtitleLangCode);
+      if (preferred == null) return; // 防御：刚落位的 dest 本身就是候选。
+      final String ext =
+          p.extension(preferred).replaceFirst('.', '').toLowerCase();
+      List<AudioCue> cues = const <AudioCue>[];
+      try {
+        cues = parseSubtitleCues(
+          content: await readTextWithEncoding(File(preferred)),
+          format: ext,
+          bookUid: id,
+        );
+      } catch (_) {
+        // best-effort：解析失败不挡字幕文件落位。
+      }
+      await _db.upsertVideoBook(VideoBooksCompanion(
+        bookUid: Value(id),
+        title: Value(row.title),
+        videoPath: Value(row.videoPath),
+        subtitleSource: Value<String?>(preferred),
+        subtitleFormat: Value<String?>(ext),
+        embeddedSubtitleTrack: const Value<int?>(null),
+      ));
+      if (cues.isNotEmpty) {
+        await _db.replaceCuesForBook(
+            id, cues.map(AudioCue.toCompanion).toList());
+      }
+    });
   }
 
   /// 校验视频 id 不含路径穿越字符（`..` / `\`）。id 允许 `/`（bookUid 形如

--- a/hibiki/lib/src/sync/hibiki_client_sync_backend.dart
+++ b/hibiki/lib/src/sync/hibiki_client_sync_backend.dart
@@ -1164,6 +1164,35 @@ class HibikiClientSyncBackend extends SyncBackend
     _ops!.checkStatus(res.statusCode, 'PUT /api/library/videos/$id');
   }
 
+  /// 把视频 [id] 的一个外挂字幕 sidecar [file] 推给 host（BUG-962，随
+  /// [putRemoteVideo] 的 live push 一起走）。[suffix] 是相对视频 stem 的字幕后缀
+  /// （`.srt` / `.ja.srt` …，host 端按自己的视频文件名 stem + suffix 落盘）。
+  ///
+  /// 返回 true = host 已接收；false = 老 host 无此端点（404/405），调用方据此
+  /// 停止本轮后续字幕推送并提示升级 host（与合集端点缺失同纪律）。其余失败
+  /// 照常抛（[WebDavOps.checkStatus]）。
+  Future<bool> putRemoteVideoSubtitle(
+    String id,
+    File file, {
+    required String suffix,
+  }) async {
+    await _ensureResolved();
+    final HttpClientRequest req = await _ops!.buildRequest(
+      'PUT',
+      '$_apiBase/api/library/videos/${_encodeVideoId(id)}/subtitle',
+    );
+    final int length = await file.length();
+    req.headers.set('Content-Type', 'application/octet-stream');
+    req.headers.set('Content-Length', '$length');
+    req.headers.set('X-Hibiki-Subtitle-Suffix', Uri.encodeComponent(suffix));
+    await req.addStream(file.openRead());
+    final HttpClientResponse res = await req.close();
+    await res.drain<void>();
+    if (res.statusCode == 404 || res.statusCode == 405) return false;
+    _ops!.checkStatus(res.statusCode, 'PUT /api/library/videos/$id/subtitle');
+    return true;
+  }
+
   /// 向 host 换取可直接播放的视频 stream URL。
   ///
   /// 返回的 [RemoteVideoStreamUrls.streamUrl] 已携带短时 token；播放器不需要

--- a/hibiki/lib/src/sync/hibiki_library_host_service.dart
+++ b/hibiki/lib/src/sync/hibiki_library_host_service.dart
@@ -1237,6 +1237,22 @@ abstract class HibikiLibraryHostService {
     String? originalFileName,
   });
 
+  /// 接收 client 上传的视频外挂字幕（sidecar，BUG-962）。
+  ///
+  /// [subtitleFile] 是已落到临时位置的上传字节；实现把它搬到 [id] 视频文件的
+  /// **同目录**，命名为 `<视频文件 stem><suffix>`（[suffix] 形如 `.srt` / `.ja.srt`，
+  /// 由 client 从其本地 sidecar 名裁出、实现须用 [isSidecarSubtitleSuffix] 白名单
+  /// 校验），使 [resolveVideoSubtitle] 的同 stem 匹配天然可见。落盘后按 host 学习
+  /// 语言重解析首选 sidecar，镜像 client 下载路径的行语义（`subtitleSource` /
+  /// `subtitleFormat`、`embeddedSubtitleTrack=null`、解析 cue 落库）。
+  /// [id] 未知视频抛 [StateError]（端点映射 404）；非法 [suffix] 抛 [ArgumentError]
+  /// （端点映射 400）。
+  Future<void> importVideoSubtitle(
+    File subtitleFile, {
+    required String id,
+    required String suffix,
+  });
+
   /// 按 [id]（即 `VideoBooks.bookUid`）反查真实视频文件。
   ///
   /// 实现**只查 DB** 得到 videoPath，然后验证文件存在后返回；文件不存在或 id 未知

--- a/hibiki/lib/src/sync/hibiki_sync_server.dart
+++ b/hibiki/lib/src/sync/hibiki_sync_server.dart
@@ -1760,8 +1760,43 @@ class HibikiSyncServer {
     }
 
     // GET /api/library/videos/<id>/subtitle — 字幕（需 Basic 鉴权，中间件已处理）
+    // PUT 同路径 — client→host 上传该视频的外挂字幕 sidecar（BUG-962，随
+    // syncVideoFiles live push）。后缀（`.srt` / `.ja.srt` …）经
+    // X-Hibiki-Subtitle-Suffix header 上报，服务端白名单校验；老 host 无此分支
+    // 对 PUT 回 405，client 据此优雅降级。
     final String? subtitleId = _extractVideoId(reqPath, 'subtitle');
     if (subtitleId != null) {
+      if (method == 'PUT') {
+        final String suffix =
+            _decodeHeaderValue(request, 'x-hibiki-subtitle-suffix') ?? '';
+        final Directory tmpDir =
+            Directory.systemTemp.createTempSync('hibiki_subtitle_in');
+        final File tmp = File(p.join(tmpDir.path, 'upload.bin'));
+        final IOSink sink = tmp.openWrite();
+        try {
+          await request.read().forEach(sink.add);
+          await sink.close();
+          await svc.importVideoSubtitle(tmp, id: subtitleId, suffix: suffix);
+          return shelf.Response(200);
+        } on ArgumentError catch (e) {
+          return shelf.Response(400, body: 'Invalid subtitle upload: $e');
+        } on StateError {
+          return shelf.Response.notFound('Video not found');
+        } catch (e) {
+          return shelf.Response(500, body: 'Subtitle import failed: $e');
+        } finally {
+          try {
+            await sink.close();
+          } catch (_) {
+            // best-effort
+          }
+          try {
+            tmpDir.deleteSync(recursive: true);
+          } catch (_) {
+            // best-effort
+          }
+        }
+      }
       if (method != 'GET') return shelf.Response(405);
       final int episodeIndex = _episodeIndexFromRequest(request);
       final String? embeddedIndexText =

--- a/hibiki/lib/src/sync/sync_orchestrator.dart
+++ b/hibiki/lib/src/sync/sync_orchestrator.dart
@@ -4,6 +4,8 @@ import 'package:drift/drift.dart' show Value;
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:hibiki/src/epub/book_css_repository.dart';
 import 'package:hibiki/src/epub/epub_importer.dart';
+import 'package:hibiki/src/media/video/video_sidecar.dart'
+    show listSidecarSubtitles;
 import 'package:hibiki/src/models/local_audio_manager.dart';
 import 'package:hibiki/src/sync/collection_manifest.dart';
 import 'package:hibiki/src/sync/collection_sync_engine.dart';
@@ -1798,21 +1800,24 @@ class SyncOrchestrator {
     SyncRunReport report,
     HibikiClientSyncBackend backend,
   ) async {
-    // host 既有视频（uid → sizeBytes，null=host 无法 stat）。
-    final Map<String, int?> hostSizeByUid = <String, int?>{
+    // host 既有视频（uid → 清单条目；sizeBytes null=host 无法 stat）。
+    final Map<String, RemoteVideoInfo> hostByUid = <String, RemoteVideoInfo>{
       for (final RemoteVideoInfo info in await backend.listRemoteVideos())
-        info.id: info.sizeBytes,
+        info.id: info,
     };
 
     // 稳定顺序（uid 升序）遍历本地可上传视频，先算出真正要传的（host 无 / 尺寸不同），
-    // 让进度分母只计实际上传数。
+    // 让进度分母只计实际上传数。字幕（BUG-962）：视频本轮上传 ⇒ 其全部 sidecar 一并
+    // 推；host 已有视频但清单报无外挂字幕 ⇒ 只补推字幕（不重传视频）。
     final List<VideoBookRow> localVideos = <VideoBookRow>[
       for (final VideoBookRow v in await _db.allVideoBooks())
         if (_isUploadableLocalVideo(v)) v,
     ]..sort((VideoBookRow a, VideoBookRow b) => a.bookUid.compareTo(b.bookUid));
 
-    final List<({VideoBookRow row, File file})> toPush =
-        <({VideoBookRow row, File file})>[];
+    final Map<String, List<String>?> sidecarDirCache =
+        <String, List<String>?>{};
+    final List<({VideoBookRow row, File file, bool pushVideo})> toPush =
+        <({VideoBookRow row, File file, bool pushVideo})>[];
     for (final VideoBookRow v in localVideos) {
       final File file = File(v.videoPath);
       if (!file.existsSync()) {
@@ -1820,38 +1825,118 @@ class SyncOrchestrator {
             'live push video "${v.title}": local file missing: ${v.videoPath}');
         continue;
       }
-      final bool hostHas = hostSizeByUid.containsKey(v.bookUid);
-      final int? hostSize = hostSizeByUid[v.bookUid];
+      final RemoteVideoInfo? host = hostByUid[v.bookUid];
+      final int? hostSize = host?.sizeBytes;
       final int localSize = await file.length();
       // host 已有：尺寸可比且相等 ⇒ 跳过（幂等）；host 尺寸不可知（null）也跳过（无从
       // 判差异，避免每轮全量重传大视频，下轮 host stat 成功即自愈）。host 无 ⇒ 上传。
-      if (hostHas && (hostSize == null || hostSize == localSize)) continue;
-      toPush.add((row: v, file: file));
+      final bool pushVideo =
+          !(host != null && (hostSize == null || hostSize == localSize));
+      // 字幕补推判据与视频同粒度：host 已有任一 sidecar 即跳过（改字幕内容/后加语言
+      // 不重推，与视频同尺寸跳过一致）。
+      // pushVideo==false 蕴含 host!=null（流程分析已提升，无需判空）。
+      final bool pushSubtitles = (pushVideo || !host.hasSubtitle) &&
+          _localSidecarSubtitles(v.videoPath, sidecarDirCache).isNotEmpty;
+      if (!pushVideo && !pushSubtitles) continue;
+      toPush.add((row: v, file: file, pushVideo: pushVideo));
     }
 
     final int total = toPush.length;
     int index = 0;
-    for (final ({VideoBookRow row, File file}) item in toPush) {
+    // 老 host 无字幕端点（首个 404/405）后停止本轮后续字幕推送，只记一条可见提示
+    // （与合集端点缺失的可见性纪律一致），不把每条视频都刷成一条错误。
+    bool subtitleEndpointMissing = false;
+    for (final ({VideoBookRow row, File file, bool pushVideo}) item in toPush) {
       final VideoBookRow v = item.row;
       _emit(SyncPhase.videos,
           itemIndex: index, itemTotal: total, title: v.title);
-      try {
-        await backend.putRemoteVideo(
-          v.bookUid,
-          item.file,
-          title: v.title,
-          onProgress: (double f) => _emit(SyncPhase.videos,
-              itemIndex: index,
-              itemTotal: total,
-              title: v.title,
-              fileFraction: f),
+      bool videoOk = !item.pushVideo;
+      if (item.pushVideo) {
+        try {
+          await backend.putRemoteVideo(
+            v.bookUid,
+            item.file,
+            title: v.title,
+            onProgress: (double f) => _emit(SyncPhase.videos,
+                itemIndex: index,
+                itemTotal: total,
+                title: v.title,
+                fileFraction: f),
+          );
+          report.videosExported++;
+          videoOk = true;
+        } catch (e) {
+          report.errors.add('live push video "${v.title}": $e');
+        }
+      }
+      // 字幕跟着视频走：视频本轮失败就不推字幕（host 侧无行可挂）。
+      if (videoOk && !subtitleEndpointMissing) {
+        subtitleEndpointMissing = !await _pushVideoSubtitlesLive(
+          report: report,
+          backend: backend,
+          row: v,
+          sidecarDirCache: sidecarDirCache,
         );
-        report.videosExported++;
-      } catch (e) {
-        report.errors.add('live push video "${v.title}": $e');
+        if (subtitleEndpointMissing) {
+          report.errors.add(
+              'live push subtitles: host has no subtitle endpoint (older app '
+              'version) — update the host app to sync video subtitles');
+        }
       }
       index++;
     }
+  }
+
+  /// 把 [row] 视频的全部本地 sidecar 字幕推给 host（BUG-962）。
+  ///
+  /// 返回 false 表示 host 无字幕端点（老版本，404/405），调用方停止本轮后续字幕
+  /// 推送；单条字幕的其它失败进 [report.errors] 不中断。
+  Future<bool> _pushVideoSubtitlesLive({
+    required SyncRunReport report,
+    required HibikiClientSyncBackend backend,
+    required VideoBookRow row,
+    required Map<String, List<String>?> sidecarDirCache,
+  }) async {
+    final String stem = p.basenameWithoutExtension(row.videoPath);
+    for (final File sub
+        in _localSidecarSubtitles(row.videoPath, sidecarDirCache)) {
+      final String suffix = p.basename(sub.path).substring(stem.length);
+      try {
+        final bool supported = await backend
+            .putRemoteVideoSubtitle(row.bookUid, sub, suffix: suffix);
+        if (!supported) return false;
+      } catch (e) {
+        report.errors.add('live push subtitle "${p.basename(sub.path)}": $e');
+      }
+    }
+    return true;
+  }
+
+  /// 列出 [videoPath] 同目录属于它的全部 sidecar 字幕文件（[listSidecarSubtitles]
+  /// 匹配规则）。[sidecarDirCache] 按目录缓存一次 listSync（同目录多视频的 sweep
+  /// 不重复扫盘）；目录不可读缓存 null → 返回空。
+  List<File> _localSidecarSubtitles(
+    String videoPath,
+    Map<String, List<String>?> sidecarDirCache,
+  ) {
+    final String dir = p.dirname(videoPath);
+    final List<String>? names = sidecarDirCache.putIfAbsent(dir, () {
+      try {
+        return Directory(dir)
+            .listSync(followLinks: false)
+            .whereType<File>()
+            .map((FileSystemEntity f) => p.basename(f.path))
+            .toList();
+      } on FileSystemException {
+        return null;
+      }
+    });
+    if (names == null) return const <File>[];
+    return <File>[
+      for (final String name
+          in listSidecarSubtitles(p.basenameWithoutExtension(videoPath), names))
+        File(p.join(dir, name)),
+    ];
   }
 
   /// Union-syncs local audio source DBs in the `__local_audio__` namespace.

--- a/hibiki/test/sync/dictionary_delete_propagation_test.dart
+++ b/hibiki/test/sync/dictionary_delete_propagation_test.dart
@@ -176,6 +176,10 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<bool> videoExists(String id) async => false;
 
   @override
+  Future<void> importVideoSubtitle(File subtitleFile,
+      {required String id, required String suffix}) async {}
+
+  @override
   Future<void> importVideo(File videoFile,
       {required String id,
       required String title,

--- a/hibiki/test/sync/hibiki_client_live_audio_test.dart
+++ b/hibiki/test/sync/hibiki_client_live_audio_test.dart
@@ -190,6 +190,10 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<bool> videoExists(String id) async => false;
 
   @override
+  Future<void> importVideoSubtitle(File subtitleFile,
+      {required String id, required String suffix}) async {}
+
+  @override
   Future<void> importVideo(File videoFile,
       {required String id,
       required String title,

--- a/hibiki/test/sync/hibiki_client_live_book_test.dart
+++ b/hibiki/test/sync/hibiki_client_live_book_test.dart
@@ -162,6 +162,10 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<bool> videoExists(String id) async => false;
 
   @override
+  Future<void> importVideoSubtitle(File subtitleFile,
+      {required String id, required String suffix}) async {}
+
+  @override
   Future<void> importVideo(File videoFile,
       {required String id,
       required String title,

--- a/hibiki/test/sync/hibiki_client_live_dict_test.dart
+++ b/hibiki/test/sync/hibiki_client_live_dict_test.dart
@@ -149,6 +149,10 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<bool> videoExists(String id) async => false;
 
   @override
+  Future<void> importVideoSubtitle(File subtitleFile,
+      {required String id, required String suffix}) async {}
+
+  @override
   Future<void> importVideo(File videoFile,
       {required String id,
       required String title,

--- a/hibiki/test/sync/hibiki_client_live_video_test.dart
+++ b/hibiki/test/sync/hibiki_client_live_video_test.dart
@@ -108,6 +108,10 @@ class _FakeLibraryService implements HibikiLibraryHostService {
       id == videoId || uploaded.any((u) => u.id == id);
 
   @override
+  Future<void> importVideoSubtitle(File subtitleFile,
+      {required String id, required String suffix}) async {}
+
+  @override
   Future<void> importVideo(File videoFile,
       {required String id,
       required String title,

--- a/hibiki/test/sync/hibiki_sync_server_audio_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_audio_test.dart
@@ -202,6 +202,10 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<bool> videoExists(String id) async => false;
 
   @override
+  Future<void> importVideoSubtitle(File subtitleFile,
+      {required String id, required String suffix}) async {}
+
+  @override
   Future<void> importVideo(File videoFile,
       {required String id,
       required String title,

--- a/hibiki/test/sync/hibiki_sync_server_books_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_books_test.dart
@@ -151,6 +151,10 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<bool> videoExists(String id) async => false;
 
   @override
+  Future<void> importVideoSubtitle(File subtitleFile,
+      {required String id, required String suffix}) async {}
+
+  @override
   Future<void> importVideo(File videoFile,
       {required String id,
       required String title,

--- a/hibiki/test/sync/hibiki_sync_server_library_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_library_test.dart
@@ -141,6 +141,10 @@ class _FakeLibraryService implements HibikiLibraryHostService {
   Future<bool> videoExists(String id) async => false;
 
   @override
+  Future<void> importVideoSubtitle(File subtitleFile,
+      {required String id, required String suffix}) async {}
+
+  @override
   Future<void> importVideo(File videoFile,
       {required String id,
       required String title,

--- a/hibiki/test/sync/hibiki_sync_server_video_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_video_test.dart
@@ -118,6 +118,10 @@ class _FakeLibraryService implements HibikiLibraryHostService {
       id == videoId || uploaded.any((u) => u.id == id);
 
   @override
+  Future<void> importVideoSubtitle(File subtitleFile,
+      {required String id, required String suffix}) async {}
+
+  @override
   Future<void> importVideo(File videoFile,
       {required String id,
       required String title,

--- a/hibiki/test/sync/interconnect_video_subtitle_sync_test.dart
+++ b/hibiki/test/sync/interconnect_video_subtitle_sync_test.dart
@@ -1,0 +1,328 @@
+/// 互联视频 live push 外挂字幕同步（BUG-962）守卫。
+///
+/// 覆盖整条上传链：
+/// 1. 纯函数 [listSidecarSubtitles] / [isSidecarSubtitleSuffix] 的匹配与白名单规则。
+/// 2. host [AppModelLibraryHostService.importVideoSubtitle]：sidecar 落视频同目录
+///    `<stem><suffix>`、行语义镜像下载路径（subtitleSource/format、内嵌轨置 null、
+///    cue 落库）、未知视频/非法后缀拒收。
+/// 3. 端到端（真实 server/host/client/orchestrator）：视频与其全部 sidecar 一并
+///    推送、重复 sweep 幂等、host 已有视频缺字幕时只补推字幕不重传视频。
+/// 4. 老 host 无字幕端点（404/405）：client 返回 false 优雅降级，不抛异常。
+library;
+
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_sidecar.dart';
+import 'package:hibiki/src/sync/app_model_library_host_service.dart';
+import 'package:hibiki/src/sync/hibiki_client_sync_backend.dart';
+import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/hibiki_sync_server.dart';
+import 'package:hibiki/src/sync/sync_asset_package_service.dart';
+import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/sync_orchestrator.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+const String _srtContent = '1\n'
+    '00:00:01,000 --> 00:00:02,000\n'
+    'こんにちは\n'
+    '\n'
+    '2\n'
+    '00:00:03,000 --> 00:00:04,000\n'
+    'さようなら\n';
+
+HibikiDatabase _memDb() =>
+    HibikiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+
+AppModelLibraryHostService _hostService({
+  required HibikiDatabase db,
+  required Directory work,
+  Directory? uploads,
+}) =>
+    AppModelLibraryHostService(
+      db: db,
+      dictionaryResourceRoot: work,
+      packages: SyncAssetPackageService(db: db),
+      refreshDictionaryCache: () async {},
+      runExclusive: (Future<void> Function() body) => body(),
+      uploadedVideoRoot: uploads,
+      videoSubtitleLangCode: 'ja',
+    );
+
+Future<HibikiClientSyncBackend> _clientBackend({
+  required String base,
+  required String token,
+}) async {
+  final HibikiDatabase db = _memDb();
+  final SyncRepository repo = SyncRepository(db);
+  await repo.setHibikiClientUrls(<HibikiClientUrl>[
+    HibikiClientUrl(url: base, enabled: true),
+  ]);
+  await repo.setHibikiClientToken(token);
+  final HibikiClientSyncBackend backend =
+      HibikiClientSyncBackend.withProbe((String u, String t) async => true);
+  await backend.restoreAuth(repo);
+  await backend.authenticate(repo: repo);
+  return backend;
+}
+
+SyncOrchestrator _orchestrator({
+  required HibikiDatabase db,
+  required SyncBackend backend,
+  required Directory tmp,
+}) =>
+    SyncOrchestrator(
+      db: db,
+      backend: backend,
+      dictionaryResourceRoot: tmp,
+      audioDatabaseRoot: tmp,
+      tempDir: tmp,
+      syncStats: false,
+      syncAudioBookPosition: false,
+      syncContent: false,
+      syncAudioBookFiles: false,
+      syncVideoFiles: true,
+      syncDictionary: false,
+      syncLocalAudio: false,
+    );
+
+void main() {
+  group('sidecar 纯函数', () {
+    test('listSidecarSubtitles 匹配同 stem 的全部字幕（含语言标记，忽略大小写）', () {
+      final List<String> files = <String>[
+        'Movie.mkv',
+        'movie.srt',
+        'Movie.ja.ASS',
+        'movie.zh-Hans.vtt',
+        'movie2.srt', // 别的 stem
+        'movie.txt', // 非字幕扩展
+        'movie.mkv.bak', // 非字幕扩展
+      ];
+      expect(listSidecarSubtitles('Movie', files),
+          <String>['movie.srt', 'Movie.ja.ASS', 'movie.zh-Hans.vtt']);
+      expect(listSidecarSubtitles('other', files), isEmpty);
+    });
+
+    test('isSidecarSubtitleSuffix 白名单：拒路径穿越与陌生扩展', () {
+      expect(isSidecarSubtitleSuffix('.srt'), isTrue);
+      expect(isSidecarSubtitleSuffix('.ja.srt'), isTrue);
+      expect(isSidecarSubtitleSuffix('.zh-Hans.ass'), isTrue);
+      expect(isSidecarSubtitleSuffix('.SSA'), isTrue);
+      expect(isSidecarSubtitleSuffix(''), isFalse);
+      expect(isSidecarSubtitleSuffix('srt'), isFalse);
+      expect(isSidecarSubtitleSuffix('..srt'), isFalse);
+      expect(isSidecarSubtitleSuffix('.exe'), isFalse);
+      expect(isSidecarSubtitleSuffix('./x.srt'), isFalse);
+      expect(isSidecarSubtitleSuffix('.a/b.srt'), isFalse);
+      expect(isSidecarSubtitleSuffix('.a\\b.srt'), isFalse);
+    });
+  });
+
+  group('host importVideoSubtitle', () {
+    late Directory work;
+    late HibikiDatabase db;
+
+    setUp(() async {
+      work = await Directory.systemTemp.createTemp('subtitle_import_');
+      db = _memDb();
+    });
+
+    tearDown(() async {
+      await db.close();
+      if (work.existsSync()) await work.delete(recursive: true);
+    });
+
+    test('sidecar 落视频同目录 <stem><suffix>；行语义镜像下载路径；cue 落库', () async {
+      final Directory vidDir = Directory(p.join(work.path, 'vids'))
+        ..createSync(recursive: true);
+      final File vid = File(p.join(vidDir.path, 'movie.mp4'))
+        ..writeAsBytesSync(<int>[1, 2, 3]);
+      await db.upsertVideoBook(VideoBooksCompanion.insert(
+        bookUid: 'video/movie',
+        title: 'Movie',
+        videoPath: vid.path,
+        embeddedSubtitleTrack: const Value<int?>(0),
+      ));
+      final File upload = File(p.join(work.path, 'upload.tmp'))
+        ..writeAsStringSync(_srtContent);
+
+      final AppModelLibraryHostService svc = _hostService(db: db, work: work);
+      await svc.importVideoSubtitle(upload,
+          id: 'video/movie', suffix: '.ja.srt');
+
+      final File landed = File(p.join(vidDir.path, 'movie.ja.srt'));
+      expect(landed.existsSync(), isTrue,
+          reason: 'sidecar 必须落视频同目录同 stem，resolveVideoSubtitle 才能看见');
+      expect(landed.readAsStringSync(), _srtContent);
+
+      final VideoBookRow row = (await db.getVideoBookByBookUid('video/movie'))!;
+      expect(row.subtitleSource, landed.path);
+      expect(row.subtitleFormat, 'srt');
+      expect(row.embeddedSubtitleTrack, isNull,
+          reason: '外挂字幕就位后播放应走外挂（与 client 下载路径同语义）');
+      expect((await db.getCuesForBook('video/movie')).length, 2,
+          reason: '字幕 cue 应解析落库（查词/句导航可用）');
+
+      // resolveVideoSubtitle / listVideos 可见性。
+      expect(
+          (await svc.resolveVideoSubtitle('video/movie'))?.path, landed.path);
+      final RemoteVideoInfo info = (await svc.listVideos()).single;
+      expect(info.hasSubtitle, isTrue);
+    });
+
+    test('未知视频 StateError；非法后缀 ArgumentError（文件不落盘）', () async {
+      final File upload = File(p.join(work.path, 'upload.tmp'))
+        ..writeAsStringSync(_srtContent);
+      final AppModelLibraryHostService svc = _hostService(db: db, work: work);
+      expect(
+          () =>
+              svc.importVideoSubtitle(upload, id: 'video/nope', suffix: '.srt'),
+          throwsStateError);
+      expect(
+          () => svc.importVideoSubtitle(upload,
+              id: 'video/nope', suffix: '../../evil.srt'),
+          throwsArgumentError);
+    });
+  });
+
+  group('端到端 live push', () {
+    late Directory work;
+    late HibikiSyncServer server;
+    late HibikiDatabase hostDb;
+    late Directory hostUploads;
+    late String base;
+    const String token = 'subtitle-sync-token';
+
+    setUp(() async {
+      work = await Directory.systemTemp.createTemp('subtitle_sync_e2e_');
+      hostDb = _memDb();
+      hostUploads = Directory(p.join(work.path, 'host_uploads'))
+        ..createSync(recursive: true);
+      server = HibikiSyncServer(
+        syncDataDir: p.join(work.path, 'server_data'),
+        port: 0,
+        token: token,
+        allowLan: false,
+        libraryService:
+            _hostService(db: hostDb, work: work, uploads: hostUploads),
+      );
+      await server.start();
+      base = 'http://127.0.0.1:${server.port}';
+    });
+
+    tearDown(() async {
+      await server.stop();
+      await hostDb.close();
+      if (work.existsSync()) await work.delete(recursive: true);
+    });
+
+    test('视频连同全部 sidecar 一并推送；重复 sweep 幂等', () async {
+      final HibikiDatabase localDb = _memDb();
+      addTearDown(localDb.close);
+      final Directory vidDir = Directory(p.join(work.path, 'local_vids'))
+        ..createSync(recursive: true);
+      final File vid = File(p.join(vidDir.path, 'movie.mp4'))
+        ..writeAsBytesSync(<int>[9, 8, 7, 6]);
+      File(p.join(vidDir.path, 'movie.srt')).writeAsStringSync(_srtContent);
+      File(p.join(vidDir.path, 'movie.ja.ass'))
+          .writeAsStringSync('[Script Info]\n');
+      await localDb.upsertVideoBook(VideoBooksCompanion.insert(
+        bookUid: 'video/movie',
+        title: 'Movie',
+        videoPath: vid.path,
+      ));
+
+      final HibikiClientSyncBackend backend =
+          await _clientBackend(base: base, token: token);
+      final SyncRunReport report =
+          await _orchestrator(db: localDb, backend: backend, tmp: work).run();
+      expect(report.videosExported, 1);
+      expect(
+          report.errors.where((String e) => e.contains('subtitle')), isEmpty);
+
+      final VideoBookRow hosted = (await hostDb.allVideoBooks()).single;
+      final String hostedDir = p.dirname(hosted.videoPath);
+      final String hostedStem = p.basenameWithoutExtension(hosted.videoPath);
+      expect(File(p.join(hostedDir, '$hostedStem.srt')).existsSync(), isTrue);
+      expect(
+          File(p.join(hostedDir, '$hostedStem.ja.ass')).existsSync(), isTrue);
+      // host 端首选 sidecar 按学习语言（ja）解析并落行：.ja.ass 优先于 .srt。
+      expect(hosted.subtitleSource, endsWith('.ja.ass'));
+      expect(hosted.subtitleFormat, 'ass');
+      expect(hosted.embeddedSubtitleTrack, isNull);
+
+      // 幂等：再跑一次，不重传视频、不重推字幕（host 已有 sidecar）。
+      final int subMtime = File(p.join(hostedDir, '$hostedStem.srt'))
+          .lastModifiedSync()
+          .millisecondsSinceEpoch;
+      final SyncRunReport report2 =
+          await _orchestrator(db: localDb, backend: backend, tmp: work).run();
+      expect(report2.videosExported, 0);
+      expect(
+          File(p.join(hostedDir, '$hostedStem.srt'))
+              .lastModifiedSync()
+              .millisecondsSinceEpoch,
+          subMtime,
+          reason: 'host 已有 sidecar 时不得重复上传覆盖');
+    });
+
+    test('host 已有视频但缺字幕：只补推字幕，不重传视频', () async {
+      final HibikiDatabase localDb = _memDb();
+      addTearDown(localDb.close);
+      final Directory vidDir = Directory(p.join(work.path, 'local_vids2'))
+        ..createSync(recursive: true);
+      final File vid = File(p.join(vidDir.path, 'ep1.mp4'))
+        ..writeAsBytesSync(<int>[1, 1, 2, 3, 5]);
+      await localDb.upsertVideoBook(VideoBooksCompanion.insert(
+        bookUid: 'video/ep1',
+        title: 'Ep1',
+        videoPath: vid.path,
+      ));
+
+      final HibikiClientSyncBackend backend =
+          await _clientBackend(base: base, token: token);
+      // 第一轮：本地还没有字幕 → host 只有视频。
+      await _orchestrator(db: localDb, backend: backend, tmp: work).run();
+      final VideoBookRow hosted = (await hostDb.allVideoBooks()).single;
+      final int videoMtime =
+          File(hosted.videoPath).lastModifiedSync().millisecondsSinceEpoch;
+
+      // 本地补了字幕后再 sweep：字幕补推、视频不重传。
+      File(p.join(vidDir.path, 'ep1.ja.srt')).writeAsStringSync(_srtContent);
+      final SyncRunReport report2 =
+          await _orchestrator(db: localDb, backend: backend, tmp: work).run();
+      expect(report2.videosExported, 0, reason: '同尺寸视频不得重传');
+      final String hostedStem = p.basenameWithoutExtension(hosted.videoPath);
+      expect(
+          File(p.join(p.dirname(hosted.videoPath), '$hostedStem.ja.srt'))
+              .existsSync(),
+          isTrue,
+          reason: 'host 缺字幕时后续 sweep 必须补推');
+      expect(File(hosted.videoPath).lastModifiedSync().millisecondsSinceEpoch,
+          videoMtime);
+    });
+
+    test('老 host 无字幕端点（405）：client 返回 false 不抛', () async {
+      // 裸 HttpServer 模拟老 host：suffix PUT 一律 405。
+      final HttpServer old = await HttpServer.bind('127.0.0.1', 0);
+      addTearDown(() => old.close(force: true));
+      old.listen((HttpRequest req) {
+        req.drain<void>().then((_) {
+          req.response.statusCode = req.method == 'PUT' ? 405 : 200;
+          req.response.close();
+        });
+      });
+      final HibikiClientSyncBackend backend = await _clientBackend(
+          base: 'http://127.0.0.1:${old.port}', token: token);
+      final File sub = File(p.join(work.path, 'x.srt'))
+        ..writeAsStringSync(_srtContent);
+      expect(
+          await backend.putRemoteVideoSubtitle('video/x', sub, suffix: '.srt'),
+          isFalse);
+    });
+  });
+}

--- a/hibiki/test/sync/sync_backend_utf8_body_test.dart
+++ b/hibiki/test/sync/sync_backend_utf8_body_test.dart
@@ -149,6 +149,10 @@ class _CapturingLibraryService implements HibikiLibraryHostService {
   Future<bool> videoExists(String id) async => false;
 
   @override
+  Future<void> importVideoSubtitle(File subtitleFile,
+      {required String id, required String suffix}) async {}
+
+  @override
   Future<void> importVideo(File videoFile,
       {required String id,
       required String title,

--- a/hibiki/test/sync/sync_compare_live_book_test.dart
+++ b/hibiki/test/sync/sync_compare_live_book_test.dart
@@ -142,6 +142,10 @@ class _LiveBookLibraryService implements HibikiLibraryHostService {
   Future<bool> videoExists(String id) async => false;
 
   @override
+  Future<void> importVideoSubtitle(File subtitleFile,
+      {required String id, required String suffix}) async {}
+
+  @override
   Future<void> importVideo(File videoFile,
       {required String id,
       required String title,


### PR DESCRIPTION
## 问题（用户报告）

「hibiki互联 字幕好像没同步视频」——验真为真 bug：互联视频 live push（`syncVideoFiles`）只上传视频文件本身（`_syncVideosLive` 仅调 `putRemoteVideo`），server 端也没有字幕上传端点（videos suffix 路由非 GET 一律 405）。client 推给 host 的视频，其外挂字幕（sidecar `.srt/.ass/.ssa/.vtt`）留在原机；其它设备从 host 串流/下载这条视频没有外挂字幕、无法查词（内嵌字幕轨在容器内不受影响）。下载方向（host→client）本来就通，唯独上传方向整段缺失。

## 修复（上传方向补齐整条链）

- **纯函数** `listSidecarSubtitles` / `isSidecarSubtitleSuffix`（video_sidecar.dart）：枚举视频**全部**同 stem sidecar（含语言标记变体）+ 字幕后缀白名单（拒路径穿越）。不在传输层挑语言——host 端自己按学习语言解析首选。
- **host** `importVideoSubtitle`：sidecar 落视频同目录 `<host 视频 stem><suffix>`（`resolveVideoSubtitle` 同 stem 匹配天然可见），再按学习语言重解析首选 sidecar（多字幕推送顺序无关、收敛），镜像 client 下载路径行语义：`subtitleSource`/`subtitleFormat`、`embeddedSubtitleTrack=null`、解析 cue 落库（host 本机播放/查词同样可用）。
- **server** 新增 `PUT /api/library/videos/<id>/subtitle`（后缀走 `X-Hibiki-Subtitle-Suffix` header；非法后缀 400、未知视频 404）。
- **client** `putRemoteVideoSubtitle`：404/405（老 host 无端点）返回 false 不抛。
- **orchestrator** `_syncVideosLive`：视频本轮上传 ⇒ 全部 sidecar 一并推；host 已有视频但清单 `hasSubtitle=false` ⇒ 只补推字幕不重传视频；host 已有任一 sidecar ⇒ 跳过（幂等，与视频同尺寸跳过同粒度）；老 host 首个 405 停止本轮后续字幕推送并在 report.errors 记一条可见提示（与合集端点缺失同纪律）。

## 兼容性

- 新 client → 老 host：405 → 优雅降级 + 可见提示，视频照常上传。
- 老 client → 新 host：不打新端点，行为不变。
- 端点/字段全部 additive，零协议破坏。

## 已知限制（v1，PR body 明示）

- host 已有任一 sidecar 即不再推：后加第二语言字幕、修改字幕内容不会自动重推（与视频同尺寸跳过一致的粗粒度幂等）。
- 多集播放列表不在 `_isUploadableLocalVideo` 范围（单文件资产模型），其字幕同样不在本批。

## 验证

- `flutter analyze` 零 issue；新测试 `interconnect_video_subtitle_sync_test.dart` 7 例全过；`test/sync` 1468 全绿；`test/media/video` 1624 全绿。
- BUG 档案：`docs/bugs/BUG-962-interconnect-video-subtitle-not-synced.md`（①②已勾）。**注意**：本 worktree 基于叠层分支，938 之后的号段不可见，962 是避开已知 941/943/946/960 撞号手动选的；落 develop 时如仍撞号按惯例改号 + reindex。

## 真机验收

两台设备配对、开 `syncVideoFiles`：A 端有带外挂字幕的本地视频 → 触发同步 → B 端（或 host 端）播放该视频应有外挂字幕且可查词；再次同步不重传（日志无重复上传）；A 端后补字幕文件 → 下轮同步只补推字幕。

叠层：base = `worktree-interconnect-dashboard`（PR #294），294 合并后自动落到下一层。

https://claude.ai/code/session_01PFqXybjUp82HSNsteG6Eoq