### PR TITLE
fix(video): BUG-915 取消 assUserFontScale，尊重 .ass 恒按作者字号

### DIFF
--- a/docs/bugs/BUG-915-ass-user-scale-and-plain-off-mode.md
+++ b/docs/bugs/BUG-915-ass-user-scale-and-plain-off-mode.md
@@ -4,7 +4,7 @@
   1. **尊重模式字号不可调**：`_styleForGrapheme` 里 `cueFontPx != null` 时字号完全由 ASS 值换算，`widget.fontSize`（用户滑块）只在无 ASS 字号时作回退——滑块对 ASS 字幕零作用，没有 mpv `sub-scale` 那样的用户倍率通道。
   2. **关闭尊重叠印乱字**：respectAssStyle 关时**样式**统一但**位置不统一**——`_posScreen`/`_positionKey` 的 \pos/\an/Layer/MarginV 不受 respect 门控，而 \1a 透明填充、\fscx 缩放、字号、动画全被忽略。KFX/多层特效字幕（一句拆成多条同时事件、依赖透明层/逐段样式区分）被渲染成多份**裸文本**按作者坐标叠画 → 同位叠印乱字（用户截图）。半吊子「样式不尊重、位置却尊重」语义即病根。
 - **[x] ① 已修复** — worktree-ass-size-outline-mpv-parity（叠加在 BUG-891 之上）：
-  - 尊重模式：新增 `VideoSubtitleOverlay.assUserFontScale`（mpv `sub-scale` 语义）——ASS 字号换算出 em 后乘该倍率；页面（`layout.part.dart`）传 `用户字号基准 / 默认 36`，默认 =1.0 完全按作者字号（mpv 平价基线不变），滑块±即整体缩放。只缩文字，不缩描边/阴影/字间距/边距；不含屏幕自适应因子（ASS 路径已按显示区几何缩放，叠加会双重放大）。
+  - 尊重模式：**完全按作者字号**（mpv 平价），用户字号滑块不参与 ASS 字号。曾按根因 1 实现 `assUserFontScale`（mpv `sub-scale` 倍率，commit 0886c2bd6），**2026-07-21 用户决策取消**（「调字号那个取消，尊重ass字号」）——尊重即尊重字号，倍率通道已整体回退，根因 1 按用户意图重新定性为「预期行为」而非缺陷。
   - 关闭尊重 = **纯字幕模式**（asbplayer 语义）：位置/层/边距语义整体归零——全部 cue 折进一个底部组（副字幕仍置顶），`_uniqueByText` 按文本去重（特效层拷贝只渲染一条），文本互异的竖排堆叠不叠印；`_positionCueGroup` 的 `ownMarkup` 按 respect 门控置 null，下游 \pos/\an/margins 全走「无位置信息」分支，零特例。
-- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_ass_user_scale_plain_mode_test.dart`：①默认 1.0 基线不变 / 1.5× 只放大文字不动描边；②纯字幕模式同文本多层去重、\pos 顶部招牌落底部堆叠不叠印、respect 开时 \pos 不回归。旧断言依「定位属尊重语义」更新：`video_subtitle_dual_position_test.dart` / `video_subtitle_overlay_markup_test.dart` 的 \an 定位测试改显式 `respectAssStyle: true`。
-- **备注**：行为变化（有意）：respectAssStyle 关时 \an8 顶部歌词/\pos 招牌不再按自带位置渲染，一律底部堆叠（开关默认开，关=明确选择统一简洁外观）。用户「调大小」诉求在尊重模式下由倍率满足，无需再关尊重。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_ass_user_scale_plain_mode_test.dart`：①尊重模式作者字号基线（48@720→30）+ 用户 fontSize=60 不改 ASS 字号/描边（钉死「滑块不参与」决策）；②纯字幕模式同文本多层去重、\pos 顶部招牌落底部堆叠不叠印、respect 开时 \pos 不回归。旧断言依「定位属尊重语义」更新：`video_subtitle_dual_position_test.dart` / `video_subtitle_overlay_markup_test.dart` 的 \an 定位测试改显式 `respectAssStyle: true`。
+- **备注**：行为变化（有意）：respectAssStyle 关时 \an8 顶部歌词/\pos 招牌不再按自带位置渲染，一律底部堆叠（开关默认开，关=明确选择统一简洁外观）。「调大小」诉求走关闭尊重的纯字幕模式（滑块在该模式下有效），尊重模式恒 mpv 平价。

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -175,7 +175,6 @@ class VideoSubtitleOverlay extends StatefulWidget {
     this.controlsBottomReserve = kVideoControlsBottomReserve,
     this.fontFamily,
     this.respectAssStyle = false,
-    this.assUserFontScale = 1.0,
     super.key,
   });
 
@@ -288,16 +287,6 @@ class VideoSubtitleOverlay extends StatefulWidget {
   /// 外观像素级一致（仅行内 \i \b \u \s \c \fs 这些旧就支持的 span 样式照旧生效——那是本开关
   /// 出现前既有行为、不受影响）。
   final bool respectAssStyle;
-
-  /// 尊重 .ass 模式下的**用户字号倍率**（mpv `sub-scale` 同语义，BUG-915）。
-  ///
-  /// 此前 [respectAssStyle] 开时 ASS 绝对字号完全接管、[fontSize] 滑块失效——用户要调
-  /// 大小只能关掉尊重开关（又会失去自带样式，特效字幕塌成叠印乱字）。本倍率乘在 ASS
-  /// 字号换算出的 em 上：页面传「用户字号基准 / 默认 36」，默认基准时 =1.0（完全按作者
-  /// 字号，mpv 平价基线不变），滑块±即整体缩放。只乘字号，不乘描边/阴影/字间距/边距
-  /// （对齐 mpv `sub-scale` 只缩文字的语义）；不含屏幕自适应因子（ASS 路径已按显示区
-  /// 几何缩放，再叠屏幕因子会双重放大）。respectAssStyle 关时不参与（[fontSize] 直用）。
-  final double assUserFontScale;
 
   /// 听力沉浸「模糊态」的高斯模糊 sigma（逻辑像素）。以前是硬编码 8——一个只对默认字号
   /// 36 勉强够用的绝对值（8/36≈0.22×字宽），用户把字幕字号调大后同样的 8px 相对字形就
@@ -1772,12 +1761,12 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
             : _fontWeight(widget.fontWeight));
     final bool baseItalic = respect && (cue?.italic ?? false);
     // ASS 字号 → em：先按 PlayRes 占比缩放，再按字体 cell/em 系数校准
-    // （libass REAL_DIM 语义，见 [_assFontSizeToEm]），再乘用户字号倍率
-    // （[VideoSubtitleOverlay.assUserFontScale]，mpv sub-scale 语义，BUG-915），最后夹上限。
+    // （libass REAL_DIM 语义，见 [_assFontSizeToEm]），再乘缺字体栅格补偿，最后夹
+    // 上限。尊重模式完全按作者字号（mpv 平价）：曾有 assUserFontScale 用户倍率通道
+    // （mpv sub-scale），BUG-915 后按用户决策取消——尊重即尊重字号，滑块不参与。
     final double baseFontSize = cueFontPx != null
         ? _scaleAssFontSize(_assFontSizeToEm(cueFontPx * assFontScale,
                 baseFontFamily, baseWeight, baseItalic) *
-            widget.assUserFontScale *
             baseMissingFontRasterCompensation.fontScale)
         : widget.fontSize;
 
@@ -1853,7 +1842,6 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
                       spanFontFamily ?? baseFontFamily,
                       span.bold ? FontWeight.bold : baseWeight,
                       span.italic || baseItalic) *
-                  widget.assUserFontScale *
                   spanMissingFontRasterCompensation.fontScale)
               : span.fontSizePx!)
           : base.fontSize,

--- a/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
@@ -404,12 +404,6 @@ extension _VideoLayout on _VideoHibikiPageState {
                           // TODO-1105：尊重 .ass 自带样式（字体/主色/描边/阴影）。开关默认开；
                           // 关时 overlay 全走上面的统一样式，外观与历史像素级一致。
                           respectAssStyle: appModel.videoRespectAssStyle,
-                          // BUG-903：尊重模式下用户字号滑块=ASS 字号的整体倍率（mpv
-                          // sub-scale 语义）。用**用户基准/默认 36**而非上面已乘屏幕因子的
-                          // fontSize——ASS 路径按显示区几何缩放已与 mpv 同源，再叠屏幕
-                          // 因子会双重放大；默认基准 36 → 1.0 = 完全按作者字号。
-                          assUserFontScale: _subtitleStyle.fontSize /
-                              VideoSubtitleStyle.defaults.fontSize,
                         ),
                       ),
                       _buildOsdOverlay(),

--- a/hibiki/test/media/video/video_subtitle_ass_user_scale_plain_mode_test.dart
+++ b/hibiki/test/media/video/video_subtitle_ass_user_scale_plain_mode_test.dart
@@ -5,8 +5,8 @@ import 'package:hibiki/src/media/video/video_subtitle_overlay.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 
 /// BUG-915 守卫：
-/// ① 尊重 .ass 模式下用户字号滑块 = ASS 字号的整体倍率（mpv `sub-scale` 语义，
-///   [VideoSubtitleOverlay.assUserFontScale]）；默认 1.0 完全按作者字号（mpv 平价基线）。
+/// ① 尊重 .ass 模式**完全按作者字号**（mpv 平价基线；用户决策：尊重即尊重字号，
+///   用户字号滑块不参与 ASS 字号——曾试做 sub-scale 倍率，按用户要求取消）。
 /// ② respectAssStyle 关 = 纯字幕模式（asbplayer 语义）：\pos/\an/层/边距全不参与——主
 ///   字幕恒底部居中、同文本多层拷贝（KFX 特效层）去重只渲染一条、文本互异的竖排堆叠。
 ///   旧行为「样式不尊重、位置却尊重」把特效层渲染成同位叠印乱字（用户截图）。
@@ -30,7 +30,7 @@ Future<VideoPlayerController> _pump(
   WidgetTester tester,
   List<AudioCue> cues, {
   required bool respect,
-  double assUserFontScale = 1.0,
+  double fontSize = 36,
 }) async {
   final VideoPlayerController c = VideoPlayerController();
   addTearDown(c.dispose);
@@ -46,7 +46,7 @@ Future<VideoPlayerController> _pump(
       body: VideoSubtitleOverlay(
         controller: c,
         respectAssStyle: respect,
-        assUserFontScale: assUserFontScale,
+        fontSize: fontSize,
       ),
     ),
   ));
@@ -59,9 +59,8 @@ Text _fill(WidgetTester tester, String ch) => tester
     .firstWhere((Text t) => t.style?.foreground == null);
 
 void main() {
-  group('① assUserFontScale（mpv sub-scale 语义）', () {
-    testWidgets('默认 1.0：ASS 字号按显示几何缩放，完全按作者字号（基线不变）',
-        (WidgetTester tester) async {
+  group('① 尊重 .ass = 尊重字号（完全按作者字号，滑块不参与）', () {
+    testWidgets('ASS 字号按显示几何缩放，完全按作者字号（mpv 平价基线）', (WidgetTester tester) async {
       await _pump(
           tester, _parse(r'Dialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,あ'),
           respect: true);
@@ -70,13 +69,14 @@ void main() {
       expect(_fill(tester, 'あ').style?.fontSize, closeTo(30, 0.01));
     });
 
-    testWidgets('1.5 倍：ASS 字号整体放大 1.5×；描边不随之缩放（sub-scale 只缩文字）',
+    testWidgets('用户字号滑块（fontSize）不影响 ASS 字号（尊重即尊重字号）',
         (WidgetTester tester) async {
       await _pump(
           tester, _parse(r'Dialogue: 0,0:00:00.00,0:00:02.00,D,,0,0,0,,あ'),
-          respect: true, assUserFontScale: 1.5);
-      expect(_fill(tester, 'あ').style?.fontSize, closeTo(45, 0.01));
-      // 描边宽不乘用户倍率：Outline=2 → 半径 2×450/720=1.25 → strokeWidth ×2 = 2.5。
+          respect: true, fontSize: 60);
+      // fontSize 60（滑块调大）不得放大 ASS 字幕：仍是作者字号换算的 30。
+      expect(_fill(tester, 'あ').style?.fontSize, closeTo(30, 0.01));
+      // 描边同理不受滑块影响：Outline=2 → 半径 2×450/720=1.25 → strokeWidth ×2 = 2.5。
       final Text stroke = tester
           .widgetList<Text>(find.text('あ'))
           .firstWhere((Text t) => t.style?.foreground != null);


### PR DESCRIPTION
## 背景

用户决策（2026-07-21）：「调字号那个取消，尊重ass字号」。

BUG-915（原 903，集成时改号）曾加 `assUserFontScale`（mpv `sub-scale` 语义：字号滑块=ASS 字号整体倍率）。本 PR 按用户决策整体回退该通道：**尊重 .ass 模式恒按作者字号（mpv 平价），用户字号滑块不参与**。

## 改动

- `video_subtitle_overlay.dart`：删 `assUserFontScale` 参数/字段，base 与行内 span 两处字号换算不再乘用户倍率（develop 上后加的**缺字体栅格补偿乘子保留**，解冲突时未动）。
- `layout.part.dart`：删传参。
- `video_subtitle_ass_user_scale_plain_mode_test.dart`：①组守卫反转——改钉「fontSize=60 不改 ASS 字号/描边」（尊重即尊重字号）；②组纯字幕模式守卫不变。
- `docs/bugs/BUG-915-...md`：记用户决策与回退；根因 1 重新定性为预期行为。

纯字幕模式（respect 关：位置归零+文本去重）不受影响。

## 验证

- `flutter analyze` 0 issues（全量）。
- 定向字幕测试 35 项全过。
- 全量 `flutter test` 12332 过；仅 `test/tools/update_manifest_publish_race_test.dart` 5 项失败——`Process.run('bash', ...)` 本机 PATH 无 bash 的环境性失败（`where bash` 找不到），与本改动零交集。

## 待真机

尊重开：拖字号滑块 ASS 字幕不变（恒作者字号）；尊重关（纯字幕模式）滑块照常生效。

https://claude.ai/code/session_01898XfuhkjcMJzW6x1zKEgS