### PR TITLE
fix(video): 字幕列表点词查词制卡音频锚定被点条目 (BUG-964)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 942 条。点号进各自文件。
+> 共 943 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-964](bugs/BUG-964-subtitle-list-mining-audio.md) | ✅ | ✅ | 字幕列表点词查词制卡音频截错句(锚到播放位置而非被点cue) |
 | [BUG-961](bugs/BUG-961-voice-hook-helper-release-missing.md) | ✅ | ✅ | galgame voice hook helper 引擎组件下载 404（release 从未产出） |
 | [BUG-960](bugs/BUG-960-textrender-thread-catalog.md) | ✅ | ✅ | 9nine 的 Luna 线程列表缺少 TextRender |
 | [BUG-959](bugs/BUG-959-local-media-shelf-perf.md) | ✅ | ✅ | 本地视频/书籍页首屏慢：封面全分辨率解码+合集N+1查询+首帧同步stat |

--- a/docs/bugs/BUG-964-subtitle-list-mining-audio.md
+++ b/docs/bugs/BUG-964-subtitle-list-mining-audio.md
@@ -5,6 +5,6 @@
   - `_lookupAt` 内部只能回落到 `controller.currentCue ?? resolveMiningCueForPosition(播放位置)` 设 `_lastLookupCue`。点列表里的词只 `pause()` 不 seek，播放头仍停在原处。
   - 制卡区间解析 `_resolveVideoMiningRange` 回退分支（`lookup_mining.part.dart:147`）用 `_lastLookupCue` 界定音频截取时间窗 → 卡片**句子文本**是被点条目、**句子音频**却截自播放位置那句 → 声音对不上。
   - 多选勾选制卡走 `_selectedMiningCueForCard` 独立分支，来源正确，不受影响。
-- **[x] ① 已修复** — 抽顶层纯函数 `resolveVideoLookupAnchorCue({overrideCue, currentCue, cues, positionMs, delayMs})` = `overrideCue ?? currentCue ?? resolveMiningCueForPosition(...)`；`_lookupAt` 加可选 `AudioCue? overrideCue` 改调该函数；`_handleSubtitleListLookup` 传 `overrideCue: cue` 把被点条目透传。主画面字幕 overlay 查词（`_handleSubtitleLookupTap`）不传 → 保持原「播放位置」逻辑不变。提交：<待填>
-- **[x] ② 已加自动化测试** — `hibiki/test/pages/video_lookup_anchor_cue_test.dart`：断言 override 优先、无 override 时回落 currentCue、currentCue 为 null 时回落按位置解析、空 cue 返回 null。提交：<待填>
+- **[x] ① 已修复** — 抽顶层纯函数 `resolveVideoLookupAnchorCue({overrideCue, currentCue, cues, positionMs, delayMs})` = `overrideCue ?? currentCue ?? resolveMiningCueForPosition(...)`；`_lookupAt` 加可选 `AudioCue? overrideCue` 改调该函数；`_handleSubtitleListLookup` 传 `overrideCue: cue` 把被点条目透传。主画面字幕 overlay 查词（`_handleSubtitleLookupTap`）不传 → 保持原「播放位置」逻辑不变。提交：2ab561b74（PR#306）
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/video_lookup_anchor_cue_test.dart`：断言 override 优先、无 override 时回落 currentCue、currentCue 为 null 时回落按位置解析、空 cue 返回 null。提交：2ab561b74（PR#306）
 - **备注**：与主画面 overlay 查词共用 `_lookupAt`，两条路径由 `overrideCue` 是否传入区分，无特殊情况分支。

--- a/docs/bugs/BUG-964-subtitle-list-mining-audio.md
+++ b/docs/bugs/BUG-964-subtitle-list-mining-audio.md
@@ -1,0 +1,10 @@
+## BUG-964 · 字幕列表点词查词制卡音频截错句(锚到播放位置而非被点cue)
+- **报告**：2026-07-21（用户：本地 hibiki 视频，从字幕跳转列表点词查词后制卡，卡片音频是别的句子的声音）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart:62-67`。
+  - 字幕列表查词回调 `_handleSubtitleListLookup(cue, ...)`（`subtitle.part.dart:97`）手里有被点的那条字幕 `cue`，但调 `_lookupAt` 时只传 `sentence/graphemeIndex/charRect`（`subtitle.part.dart:105`），丢掉了 `cue`。
+  - `_lookupAt` 内部只能回落到 `controller.currentCue ?? resolveMiningCueForPosition(播放位置)` 设 `_lastLookupCue`。点列表里的词只 `pause()` 不 seek，播放头仍停在原处。
+  - 制卡区间解析 `_resolveVideoMiningRange` 回退分支（`lookup_mining.part.dart:147`）用 `_lastLookupCue` 界定音频截取时间窗 → 卡片**句子文本**是被点条目、**句子音频**却截自播放位置那句 → 声音对不上。
+  - 多选勾选制卡走 `_selectedMiningCueForCard` 独立分支，来源正确，不受影响。
+- **[x] ① 已修复** — 抽顶层纯函数 `resolveVideoLookupAnchorCue({overrideCue, currentCue, cues, positionMs, delayMs})` = `overrideCue ?? currentCue ?? resolveMiningCueForPosition(...)`；`_lookupAt` 加可选 `AudioCue? overrideCue` 改调该函数；`_handleSubtitleListLookup` 传 `overrideCue: cue` 把被点条目透传。主画面字幕 overlay 查词（`_handleSubtitleLookupTap`）不传 → 保持原「播放位置」逻辑不变。提交：<待填>
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/video_lookup_anchor_cue_test.dart`：断言 override 优先、无 override 时回落 currentCue、currentCue 为 null 时回落按位置解析、空 cue 返回 null。提交：<待填>
+- **备注**：与主画面 overlay 查词共用 `_lookupAt`，两条路径由 `overrideCue` 是否传入区分，无特殊情况分支。

--- a/hibiki/lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart
@@ -32,8 +32,9 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
   Future<void> _lookupAt(
     String sentence,
     int graphemeIndex,
-    Rect charRect,
-  ) async {
+    Rect charRect, {
+    AudioCue? overrideCue,
+  }) async {
     final VideoPlayerController? controller = _controller;
     if (controller == null) return;
     final String term = subtitleLookupTerm(sentence, graphemeIndex);
@@ -53,16 +54,19 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
     // 「上 N 句 / 下 N 句」上下文选择。热槽 WebView 复用使弹窗 DOM 不重载，草稿若不
     // 在此清空，上一个词攒的上下文会带到下一个词的卡（用户报「弹窗会缓存」）。
     _miningDraft.clear();
-    // 制卡要裁「用户正在学的那句」的真实声轨音频。currentCue 在字幕 gap / 末句后被
-    // 清成 null（BUG-074 字幕条该消失），而查词往往就发生在字幕刚消失那一瞬——若直接
-    // 取 currentCue，制卡时句子音频字段会空（TODO-104b / BUG-188）。故 null 时按当前
-    // 播放位置独立解析最近一条 cue（只读 controller，不复用被 gap 清空的 UI 状态）。
-    _lastLookupCue = controller.currentCue ??
-        resolveMiningCueForPosition(
-          cues: controller.cues,
-          positionMs: controller.positionMs ?? 0,
-          delayMs: controller.delayMs,
-        );
+    // 制卡要裁「用户正在学的那句」的真实声轨音频。锚定 cue 的来源按查词入口分（BUG-964）：
+    // 字幕跳转列表点词查词传 [overrideCue]=被点条目（可能远离播放头，点列表只暂停不 seek），
+    // 必须优先用它，否则制卡音频锚到播放位置那句、截出别的句子的声音。主画面字幕 overlay
+    // 查词不传，回落 currentCue——它在字幕 gap / 末句后被清成 null（BUG-074 字幕条该消失），
+    // 而查词往往就发生在字幕刚消失那一瞬，故 null 时按播放位置独立解析（TODO-104b / BUG-188，
+    // 只读 controller，不复用被 gap 清空的 UI 状态）。
+    _lastLookupCue = resolveVideoLookupAnchorCue(
+      overrideCue: overrideCue,
+      currentCue: controller.currentCue,
+      cues: controller.cues,
+      positionMs: controller.positionMs ?? 0,
+      delayMs: controller.delayMs,
+    );
     await pushNestedPopup(
       query: term,
       selectionRect: charRect,

--- a/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
@@ -102,7 +102,9 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     if (!_immersiveAllowsLookup) return;
     final String sentence = cue.text;
     if (sentence.trim().isEmpty) return;
-    unawaited(_lookupAt(sentence, graphemeIndex, charRect));
+    // BUG-964：把被点的列表 cue 透传给查词，作为制卡音频锚点——列表里的句可能远离播放头
+    // （点列表只暂停不 seek），不透传会回落到播放位置那句、截出别的句子的声音。
+    unawaited(_lookupAt(sentence, graphemeIndex, charRect, overrideCue: cue));
   }
 
   /// TODO-1351：字幕轨/字幕源切换区，收进设置面板「字幕」分类顶部（取代原来外面浮的

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -203,6 +203,33 @@ AudioCue? resolveMiningCueForPosition({
   return idx >= 0 ? cues[idx] : null;
 }
 
+/// 解析查词浮层（及其制卡）应锚定的字幕 cue（BUG-964）。
+///
+/// 两条查词入口共用 [_VideoLookupFavorite._lookupAt]，但被查词句的 cue 来源不同：
+/// - **主画面字幕 overlay 点字符查词**：点的就是当前正在显示的字幕，[overrideCue] 传 null，
+///   回落到 [currentCue]（句间 gap / 末句后为 null）→ 再按播放位置解析（TODO-104b / BUG-188）。
+/// - **字幕跳转列表点词查词**：用户点的是列表里**任意一条**字幕，可能远离播放头（点列表只
+///   暂停、不 seek），此时必须用被点的 [overrideCue]；否则制卡区间会锚到播放位置那句，
+///   卡片句子文本是被点条目、句子音频却截自播放位置那句，声音对不上（BUG-964）。
+///
+/// 优先级：[overrideCue]（列表明确指定的句） > [currentCue]（overlay 正显示的句） >
+/// 按播放位置解析（gap / 末句后兜底）。三者皆无 → null，制卡诚实留空。
+AudioCue? resolveVideoLookupAnchorCue({
+  AudioCue? overrideCue,
+  AudioCue? currentCue,
+  required List<AudioCue> cues,
+  required int positionMs,
+  required int delayMs,
+}) {
+  return overrideCue ??
+      currentCue ??
+      resolveMiningCueForPosition(
+        cues: cues,
+        positionMs: positionMs,
+        delayMs: delayMs,
+      );
+}
+
 /// 同 [resolveMiningCueForPosition]，但返回**下标**而非 cue 对象（一句都没起播过 / 空 cue
 /// 返回 -1）。跨字幕制卡（TODO-102）按下「开始/结束」时要记录 cue 的**下标**来界定区间，
 /// 而单句制卡只要 cue 对象——两者共用同一套「精确命中 → floor 兜底」解析，避免漂移。

--- a/hibiki/test/pages/video_lookup_anchor_cue_test.dart
+++ b/hibiki/test/pages/video_lookup_anchor_cue_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/video_hibiki_page.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+/// BUG-964：字幕跳转列表点词查词制卡，卡片音频截错句（截到播放位置那句，而非被点条目）。
+///
+/// 根因：字幕列表查词入口 `_handleSubtitleListLookup(cue, ...)` 手里有被点的字幕 cue，
+/// 但调 `_lookupAt` 时未透传，`_lookupAt` 只能回落到 `currentCue`／按播放位置解析，制卡区间
+/// 遂锚到播放头停留处那句。点列表只暂停不 seek，播放头远离被点条目 → 文本对、音频错。
+///
+/// 修复：`_lookupAt` 加 `overrideCue`，字幕列表查词透传被点 cue；两条查词入口共用
+/// [resolveVideoLookupAnchorCue] 统一优先级 `overrideCue > currentCue > 按位置解析`。
+/// 本组测试直接覆盖该纯函数：撤掉 `overrideCue ??` 首选会让首个用例转红 = 守卫成立。
+AudioCue _cue(int i, int s, int e) => AudioCue()
+  ..bookKey = 'video/1'
+  ..chapterHref = 'video://default'
+  ..sentenceIndex = i
+  ..textFragmentId = ''
+  ..text = 'line$i'
+  ..startMs = s
+  ..endMs = e
+  ..audioFileIndex = 0;
+
+void main() {
+  group('resolveVideoLookupAnchorCue (BUG-964)', () {
+    final List<AudioCue> cues = <AudioCue>[
+      _cue(0, 0, 1000),
+      _cue(1, 2000, 3000),
+      _cue(2, 5000, 6000),
+    ];
+
+    test('字幕列表查词：overrideCue 优先，即使播放头在别处也锚定被点条目', () {
+      // 用户暂停在 5500（落在 cue2 时间窗内），却在列表里点了远处的 cue0。
+      // 撤掉 `overrideCue ??` 首选此处会返回 cue2（播放位置那句）= 转红，守卫成立。
+      final AudioCue anchor = resolveVideoLookupAnchorCue(
+        overrideCue: cues[0],
+        currentCue: cues[2],
+        cues: cues,
+        positionMs: 5500,
+        delayMs: 0,
+      )!;
+      expect(anchor.text, 'line0', reason: '列表点词必须锚定被点条目，而非播放位置那句');
+    });
+
+    test('overrideCue 优先级高于 currentCue（两者都非 null 时取 override）', () {
+      final AudioCue anchor = resolveVideoLookupAnchorCue(
+        overrideCue: cues[1],
+        currentCue: cues[2],
+        cues: cues,
+        positionMs: 5500,
+        delayMs: 0,
+      )!;
+      expect(anchor.text, 'line1');
+    });
+
+    test('主画面 overlay 查词：无 overrideCue 时回落 currentCue（正显示的句）', () {
+      final AudioCue anchor = resolveVideoLookupAnchorCue(
+        overrideCue: null,
+        currentCue: cues[1],
+        cues: cues,
+        positionMs: 2500,
+        delayMs: 0,
+      )!;
+      expect(anchor.text, 'line1');
+    });
+
+    test('gap / 末句后：override 与 currentCue 皆 null 时按播放位置解析', () {
+      // 1500 落在 cue0..cue1 的静音 gap：currentCue 此刻为 null（BUG-074），
+      // 回落 resolveMiningCueForPosition floor 到「最后看到的」cue0（TODO-104b / BUG-188）。
+      final AudioCue anchor = resolveVideoLookupAnchorCue(
+        overrideCue: null,
+        currentCue: null,
+        cues: cues,
+        positionMs: 1500,
+        delayMs: 0,
+      )!;
+      expect(anchor.text, 'line0');
+    });
+
+    test('三者皆无（位置早于全部 cue）诚实返回 null', () {
+      final List<AudioCue> later = <AudioCue>[_cue(0, 1000, 2000)];
+      expect(
+        resolveVideoLookupAnchorCue(
+          overrideCue: null,
+          currentCue: null,
+          cues: later,
+          positionMs: 500,
+          delayMs: 0,
+        ),
+        isNull,
+      );
+    });
+
+    test('空 cue 列表：即便 override 给定为 null 也返回 null（无字幕视频）', () {
+      expect(
+        resolveVideoLookupAnchorCue(
+          overrideCue: null,
+          currentCue: null,
+          cues: const <AudioCue>[],
+          positionMs: 1234,
+          delayMs: 0,
+        ),
+        isNull,
+      );
+    });
+
+    test('override 给定时跳过位置解析（空 cue 列表也能锚定被点条目）', () {
+      // 极端：cues 已被清空，但用户明确点了列表条目 → 仍锚定它，不因空列表退化为 null。
+      final AudioCue anchor = resolveVideoLookupAnchorCue(
+        overrideCue: _cue(7, 7000, 8000),
+        currentCue: null,
+        cues: const <AudioCue>[],
+        positionMs: 0,
+        delayMs: 0,
+      )!;
+      expect(anchor.text, 'line7');
+    });
+  });
+}


### PR DESCRIPTION
## 现象
本地 hibiki 视频，从**字幕跳转列表点词查词后制卡**，卡片句子文本正确，但**句子音频是别的句子的声音**（用户报 bad girl 卡片）。

## 根因
`_handleSubtitleListLookup(cue, ...)`（`subtitle.part.dart:97`）手里有被点的字幕 `cue`，但调 `_lookupAt` 时只传 `sentence/graphemeIndex/charRect`，**丢掉了 cue**。`_lookupAt`（`lookup_favorite.part.dart`）只能回落到 `controller.currentCue ?? 按播放位置解析` 设 `_lastLookupCue`。点列表里的词只 `pause()` 不 seek，播放头仍停在原处 → 制卡区间（`_resolveVideoMiningRange` 回退分支 `lookup_mining.part.dart:147`）锚到播放位置那句 → 文本对、音频错。

多选勾选制卡走独立分支（`_selectedMiningCueForCard`），来源正确，不受影响。

## 修复
- 抽顶层纯函数 `resolveVideoLookupAnchorCue({overrideCue, currentCue, cues, positionMs, delayMs})`，优先级 `overrideCue > currentCue > 按位置解析`。
- `_lookupAt` 加可选 `AudioCue? overrideCue`，改调该纯函数。
- `_handleSubtitleListLookup` 传 `overrideCue: cue`，把被点条目透传。
- 主画面字幕 overlay 查词（`_handleSubtitleLookupTap`）不传 → 保持原「播放位置」逻辑不变（TODO-104b / BUG-188 的 gap 兜底不回归）。

两条查词入口由 `overrideCue` 是否传入区分，无特殊情况分支。

## 测试
`hibiki/test/pages/video_lookup_anchor_cue_test.dart`（7 用例全绿）：override 优先、优先级高于 currentCue、无 override 回落 currentCue、gap/末句后按位置解析、空 cue 返回 null、override 给定时跳过位置解析。撤掉 `overrideCue ??` 首选首个用例即转红。

## 验证
- `flutter test test/pages/video_lookup_anchor_cue_test.dart` → 7 passed
- `flutter analyze`（4 改动文件）→ No issues found
- 真机复测（字幕列表点词查词制卡、核对音频对上字幕）：待

Commit: `2ab561b74`

https://claude.ai/code/session_01D7YDmUaiq1z4WhzDSgtPGg