### PR TITLE
docs: 重构 CLAUDE.md 与项目索引对齐当前代码

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,22 +24,27 @@
 ## 仓库地图
 
 - 仓库根：`D:\APP\vs_claude_code\hibiki`（Melos workspace，名 `hibiki_workspace`）。Flutter app：`hibiki/`；Android 工程：`hibiki/android/`。
-- 阅读器页面：`hibiki/lib/src/pages/implementations/reader_hibiki_page.dart`（`ReaderHibikiPage`，~3200 行主体 + `reader_hibiki/` 下 8 个域 part 文件：WebView 拦截 + JS 分页 + 有声书同步）。
-- 书架页面：`hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart`。
+- 阅读器页面：`hibiki/lib/src/pages/implementations/reader_hibiki_page.dart`（`ReaderHibikiPage`，3242 行主体 + `reader_hibiki/` 下 8 个域 part 共 9583 行：WebView 拦截 + JS 分页 + 有声书同步）。
+- 视频页面：`hibiki/lib/src/pages/implementations/video_hibiki_page.dart`（6358 行主体 + `video_hibiki/` 下 18 个 part 共 6966 行）；视频首页 `home_video_page.dart`（3080 行）。
+- 书架页面：`hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart`；首页 dashboard：`pages/implementations/home_dashboard_page.dart`。
 - reader source：`hibiki/lib/src/media/sources/reader_hibiki_source.dart`（`ReaderHibikiSource`）。
-- 阅读器 JS/CSS：`hibiki/lib/src/reader/`（`reader_pagination_scripts.dart` 等）；JS 桥接全局是 `window.hoshiReader`（历史命名，是真实符号，勿改）。
-- 全局状态：`hibiki/lib/src/models/app_model.dart`（`AppModel`，~3600 行，初始化流程 + 子系统委托核心，改前先理解）。
-- Drift 数据库：`packages/hibiki_core/lib/src/database/database.dart` 和 `tables.dart`（schema v24，28 张表，WAL）。
-- 词典 FFI：`packages/hibiki_dictionary/lib/src/engine/hoshidicts.dart`。
+- 阅读器 JS/CSS：`hibiki/lib/src/reader/`（17 个 JS/CSS 注入封装，`reader_pagination_scripts.dart` 等）；JS 桥接全局是 `window.hoshiReader`（历史命名，是真实符号，勿改）。
+- 全局状态：`hibiki/lib/src/models/app_model.dart`（`AppModel`，~5150 行，初始化流程 + 子系统委托核心，改前先理解）。
+- Drift 数据库：`packages/hibiki_core/lib/src/database/database.dart` 和 `tables.dart`（schema v50，46 张表，WAL）。
+- 词典：Dart 封装 `packages/hibiki_dictionary/lib/src/engine/hoshidicts.dart` + FFI 绑定 `lib/src/ffi/hoshidicts_ffi_bindings.dart`；C++ 引擎源码全在 `native/hoshidicts/`（包内已无 C++），`hoshidicts_external/` 是 vendored 第三方，上游同步基线见 `native/hoshidicts/UPSTREAM.md`。
 - 有声书：`packages/hibiki_audio/` + `hibiki/lib/src/media/audiobook/`（导入入口 `book_import_dialog.dart` / `audiobook_import_dialog.dart`）。
-- i18n 同步脚本：`hibiki/tool/i18n_sync.dart`。
+- 互联/同步：`hibiki/lib/src/sync/`（`interconnect_*.dart`、`aggregate_sync_service.dart`、`backup_*`）。
+- galgame 制卡：Flutter 侧 `hibiki/lib/src/lookup/`（overlay 浮窗）+ `hibiki/lib/src/mining/galgame_*`（9 文件）；C++ hook 在 `native/galgame_voice_hook/`。
+- 浏览器扩展：`tools/browser-extension/`（注意是根级 `tools/`，与 `tool/` 不同目录）。
+- 工具脚本归属：根 `tool/` = `setup_worktree.ps1` / `bootstrap.ps1` / `bug.dart` / `check_release_policy.ps1` / `run_mac_itest.ps1`；`hibiki/tool/` = `i18n_sync.dart` / `run_windows_itest.ps1` / `comprehensive_test_runner.dart`。
 - 审查报告：`docs/reviews/YYYY-MM-DD-project-review.md`；已复现回归：`docs/REGRESSION_BUGS.md`（本地，不入库）；测试证据：`.codex-test/`（不入库）。
 
 ## 当前技术事实
 
-- Flutter `3.44.0` / Dart `3.12.0`（stable），Dart SDK 约束 `>=3.5.0 <4.0.0`；最低 Android API 24，`compileSdk 36` / `targetSdk 35`。
-- 状态管理 Riverpod；音频 just_audio（桌面经 just_audio_media_kit）；录音 record 6.x。
-- 主存储是 Drift SQLite（`HibikiDatabase`，schema v24），偏好落 Drift `preferences` 表 + `profile_settings` 每 Profile 快照。**已无 Isar/Hive 依赖**；旧注释里的 Isar/Hive 不代表当前事实，先查代码再判断。
+- Flutter 版本分两处：本地钉 `.fvmrc` = `3.41.6`（pubspec `flutter: "^3.41.6"`），CI workflows 用 `3.44.0`；Dart SDK 约束 `>=3.5.0 <4.0.0`。最低 Android API 24，`compileSdk 36` / `targetSdk 35`。
+- 状态管理 Riverpod；音频 just_audio（桌面经 just_audio_media_kit）；录音 record 6.0.0；视频播放走 **media_kit**（third_party vendored 全套）+ youtube_explode_dart。
+- torrent 走内部包 `packages/hibiki_torrent`（libtorrent 2.x C ABI FFI，native 在 `native/hibiki_torrent/`；Windows 预编译 DLL 随包，缺失时回退外接 qBittorrent）。
+- 主存储是 Drift SQLite（`HibikiDatabase`，schema v50），偏好落 Drift `preferences` 表 + `profile_settings` 每 Profile 快照。**已无 Isar/Hive 依赖**；旧注释里的 Isar/Hive 不代表当前事实，先查代码再判断。
 - EPUB 阅读器走 reader_hibiki 实现（见仓库地图）。`reader_ttu` key、`setTtu*` 方法、`ttuBookId` 列、`ttu_*` i18n 只是旧数据兼容残留，不代表还有 TTU 阅读器；没有迁移方案别随手改这些持久化 key。
 - 旧 TTU 迁移代码已移除（develop `90c37b472`：`TtuMigrationServer` / `TtuIdbReader` / `assets/ttu-ebook-reader` 均已删除）；只剩上述命名残留作旧数据兼容。阅读器渲染/交互问题按 reader_hibiki 路径修，不要去上游 ttu fork 仓库改。
 - 词典导入/查询核心走 `hoshidicts` C++ FFI；格式 UI 或旧 Dart format 类不一定是真实导入路径。
@@ -54,10 +59,10 @@
 ## 验证
 
 - 文档改动：至少 `git diff --cached --check`，不必跑 Flutter 测试。
-- Dart/Flutter 改动（在 `hibiki/` 下）：`dart format .` + `flutter test`（用项目的 Flutter 3.44.0 工具链；本机 flutter 不在 PATH 就把完整路径写进 `CLAUDE.local.md`）。
+- Dart/Flutter 改动（在 `hibiki/` 下）：`dart format .` + `flutter test`（用项目钉定的工具链：本地 `.fvmrc` 3.41.6，CI 3.44.0；本机 flutter 不在 PATH 就把完整路径写进 `CLAUDE.local.md`）。
 - Android 资源/manifest/Gradle/权限/通知/前台服务/打包改动：再加 `gradlew :app:assembleRelease`（在 `hibiki/android/`；Windows 用 `.\gradlew.bat`）。
 - 阅读器/导入/播放/布局问题，声明「修好了」前必须用真实模拟器或用户指定设备复测原始失败路径并留证据（见 [docs/agent/integration-testing.md](docs/agent/integration-testing.md)）。
-- 集成测试操作真 app **一律焦点驱动（`FocusDriver` / `tester.sendKeyEvent`，禁止 `tester.tap` 或坐标点击）**：`Tab` 遍历→检测控件类型→Switch/按钮确认用 `Enter`（**不要用空格**——App 已把裸空格中和为 `DoNothingIntent`，焦点确认统一走 Enter / 手柄 A，见 `hibiki/lib/src/shortcuts/global_navigation.dart`）、Slider/Stepper/Segmented 用方向键→断言真写穿 DB/真生效→还原。同一份测试三端可跑（模拟器 `-d emulator-<port>` / Windows 离屏 `tool/run_windows_itest.ps1` / Mac 跨机 `tool/run_mac_itest.ps1`），完整流程见 [docs/agent/integration-testing.md](docs/agent/integration-testing.md) 的「焦点驱动操作」。
+- 集成测试操作真 app **一律焦点驱动（`FocusDriver` / `tester.sendKeyEvent`，禁止 `tester.tap` 或坐标点击）**：`Tab` 遍历→检测控件类型→Switch/按钮确认用 `Enter`（**不要用空格**——App 已把裸空格中和为 `DoNothingIntent`，焦点确认统一走 Enter / 手柄 A，见 `hibiki/lib/src/shortcuts/global_navigation.dart`）、Slider/Stepper/Segmented 用方向键→断言真写穿 DB/真生效→还原。同一份测试三端可跑（模拟器 `-d emulator-<port>` / Windows 离屏 `hibiki/tool/run_windows_itest.ps1` / Mac 跨机 `tool/run_mac_itest.ps1`），完整流程见 [docs/agent/integration-testing.md](docs/agent/integration-testing.md) 的「焦点驱动操作」。
 
 ## 提交
 
@@ -73,24 +78,36 @@
 
 | 要做的事 | 看这里 |
 |---|---|
-| 跑集成测试 / 设备验证 / ADB 降级 / AnkiDroid / DB 查询 / 测试素材 | [docs/agent/integration-testing.md](docs/agent/integration-testing.md) |
-| 构建 5 平台 / melos / 依赖补丁机制 | [docs/agent/build.md](docs/agent/build.md) |
-| 持续审查模式 / 报告格式 / 回归记录 | [docs/agent/review-process.md](docs/agent/review-process.md) |
-| 阅读器调试（WebView / 恢复 / 分页 / 有声书遮挡 / 平台特例） | [docs/agent/reader-debugging.md](docs/agent/reader-debugging.md) |
+| 5 平台构建 / Melos / bootstrap + 依赖补丁机制 / 发布通道与版本号规则 / galgame hook 注入器独立分发 | [docs/agent/build.md](docs/agent/build.md) |
+| 模拟器集成测试三层架构 / 焦点驱动（禁坐标点击）/ AnkiDroid provisioning / ADB 降级 / DB 查询 / 测试素材 | [docs/agent/integration-testing.md](docs/agent/integration-testing.md) |
+| 持续审查模式 / docs/reviews 报告格式 / 回归记录 | [docs/agent/review-process.md](docs/agent/review-process.md) |
+| reader_hibiki 构成 / TTU 残留辨析 / WebView / 恢复 / 分页 / 有声书遮挡调试 | [docs/agent/reader-debugging.md](docs/agent/reader-debugging.md) |
+| Computer Use 可见巡检 / 离屏、非焦点抓真实像素 / 确定性开页 debug 钩子 / 证据留存 | [docs/agent/computer-use-testing.md](docs/agent/computer-use-testing.md) |
+| Windows app 外打开视频（文件关联 / argv / 拖拽）数据流 / single-instance WM_COPYDATA 转发 | [docs/agent/external-video-open.md](docs/agent/external-video-open.md) |
+| 全量快捷键 / 手柄 / 鼠标绑定盘点快照（2026-06-11） | [docs/agent/shortcuts-inventory.md](docs/agent/shortcuts-inventory.md) |
 
 ## 模块索引
 
-| 模块 | 语言 | 职责 | 模块文档 |
+| 模块 | 语言 | 职责 / 接入方式 | 文档 |
 |---|---|---|---|
-| `hibiki/` | Dart | Flutter 主应用：UI/阅读器/导入/设置 | [hibiki/CLAUDE.md](hibiki/CLAUDE.md) |
-| `packages/hibiki_core/` | Dart | DB schema（28 表）/偏好/语言配置 | [CLAUDE.md](packages/hibiki_core/CLAUDE.md) |
-| `packages/hibiki_dictionary/` | Dart+C++ | 词典引擎/FFI/多格式导入 | [CLAUDE.md](packages/hibiki_dictionary/CLAUDE.md) |
+| `hibiki/` | Dart | Flutter 主应用：UI/阅读器/视频/导入/设置 | [hibiki/CLAUDE.md](hibiki/CLAUDE.md) |
+| `packages/hibiki_core/` | Dart | DB schema（46 表）/偏好/语言配置 | [CLAUDE.md](packages/hibiki_core/CLAUDE.md) |
+| `packages/hibiki_dictionary/` | Dart | 词典引擎 Dart 侧/FFI 绑定/多格式导入（C++ 在 `native/hoshidicts/`） | [CLAUDE.md](packages/hibiki_dictionary/CLAUDE.md) |
 | `packages/hibiki_anki/` | Dart | Anki 集成（AnkiDroid + AnkiConnect） | [CLAUDE.md](packages/hibiki_anki/CLAUDE.md) |
 | `packages/hibiki_audio/` | Dart | 字幕解析/有声书播放/音频匹配 | [CLAUDE.md](packages/hibiki_audio/CLAUDE.md) |
 | `packages/hibiki_platform/` | Dart | TTS/平台集成/存储路径抽象 | [CLAUDE.md](packages/hibiki_platform/CLAUDE.md) |
 | `packages/flutter_inappwebview_windows/` | Dart+C++ | inappwebview Windows fork | [CLAUDE.md](packages/flutter_inappwebview_windows/CLAUDE.md) |
-| `packages/gamepads_android_stub/` | Dart | `gamepads_android` 的 no-op stub override | — |
-| `third_party/` | — | vendored 补丁包：carousel_slider / fading_edge_scrollview / flutter_inappwebview_android / network_to_file_image | — |
+| `packages/hibiki_torrent/` | Dart | 内置 torrent 引擎 FFI 绑定 + `EmbeddedTorrentEngine`（path 依赖） | — |
+| `packages/gamepads_windows/` | Dart+C++ | gamepads Windows vendored fork（BUG-116 崩溃修复，path override） | — |
+| `packages/gamepads_android_stub/` | Dart | `gamepads_android` no-op stub（防启动 ClassCastException，path override） | — |
+| `native/hoshidicts/` | C++ | 词典查询/导入引擎（上游深度 fork；`hoshidicts_external/` 为 vendored 第三方）；FFI/JNI 编入 app | [UPSTREAM.md](native/hoshidicts/UPSTREAM.md) |
+| `native/hibiki_torrent/` | C++ | libtorrent 2.x C ABI bridge；FFI，Windows 预编译 DLL 随包 | [README.md](native/hibiki_torrent/README.md) |
+| `native/galgame_voice_hook/` | C++ | galgame 引擎级 voice hook（混音前截语音）；独立子进程 + 共享内存，必报毒故物理隔离、**绝不编进 hibiki.exe**，独立分发 | [README.md](native/galgame_voice_hook/README.md) |
+| `server/log-collector/` | Go | 报错日志接收端（自有服务器 + EdgeOne 版）；独立部署 | [README.md](server/log-collector/README.md) |
+| `server/cf-worker/` | JS | 报错日志接收端（Cloudflare Worker + D1 版，与 Go 版择一）；独立部署 | [README.md](server/cf-worker/README.md) |
+| `tools/browser-extension/` | JS | 浏览器查词扩展（根级 `tools/`，非 `tool/`） | — |
+| `third_party/` | — | 11 个 path-override vendored 补丁包 + 1 个 CI 自编二进制（ffmpeg-min，Windows 最小化 ffmpeg.exe）：carousel_slider、desktop_drop、fading_edge_scrollview、ffmpeg_kit_flutter、flutter_inappwebview_android、media_kit_libs_{android,ios,macos,windows}_video、media_kit_video、network_to_file_image；vendor 原因见 `hibiki/pubspec.yaml` dependency_overrides 逐包注释 | — |
+| `references/ReinaManager` | — | git submodule：galgame 库信息架构参考（AGPL-3.0，不参与构建） | — |
 
 > 完整架构、技术栈、构建命令、致谢见 [README.md](README.md)。`file_picker` 用 pub.dev 版（**不是** fork）。依赖补丁机制（vendored vs apply-patches）见 [docs/agent/build.md](docs/agent/build.md)。
 

--- a/docs/agent/reader-debugging.md
+++ b/docs/agent/reader-debugging.md
@@ -4,7 +4,7 @@
 
 ## 当前阅读器构成
 
-- 页面：`hibiki/lib/src/pages/implementations/reader_hibiki_page.dart`，类 `ReaderHibikiPage`（约 5300 行：WebView 拦截 + JS 分页引擎 + 有声书同步）。
+- 页面：`hibiki/lib/src/pages/implementations/reader_hibiki_page.dart`，类 `ReaderHibikiPage`（3242 行主体 + `reader_hibiki/` 下 8 个域 part 文件 `audiobook` / `caret` / `chrome` / `lookup` / `lyrics` / `mining` / `navigation` / `webview`，共 9583 行：WebView 拦截 + JS 分页引擎 + 有声书同步）。
 - source：`hibiki/lib/src/media/sources/reader_hibiki_source.dart`，类 `ReaderHibikiSource`。
 - JS / CSS：`hibiki/lib/src/reader/` 下 `reader_pagination_scripts.dart`、`reader_content_styles.dart`、`reader_selection_scripts.dart`、`reader_caret_scripts.dart`。
 - **JS 桥接全局仍叫 `window.hoshiReader`**（历史命名，是真实符号，不要改）；字级焦点用 `window.hoshiCaret` + Dart `ReaderCaretRouter`。

--- a/hibiki/CLAUDE.md
+++ b/hibiki/CLAUDE.md
@@ -68,7 +68,7 @@ Hibiki 的 Flutter 多平台主应用：日语 EPUB 阅读器，集成划词查�
 
 ### 5. 应用模型 (`lib/src/models/`)
 
-- `AppModel` -- 全局应用状态（Riverpod `appProvider`，~3600 行），管理初始化、主题、语言、词典、导航。
+- `AppModel` -- 全局应用状态（Riverpod `appProvider`，5149 行），管理初始化、主题、语言、词典、导航。
   - **初始化流程** (`initialise()`): PackageInfo → 目录创建 → Drift DB 打开 → 偏好加载 → Profile 确保 → 词典缓存 → 媒体历史 → 主题调色板 → 语言/格式/增强/快捷操作注册 → 搜索预热
   - **词典搜索** (`searchDictionary()`): emoji/标点/孤立代理项清洗 → 缓存查找 → HoshiDicts FFI lookup → 结果构建
   - **词典导入** (`importDictionary()` / `importDictionaryFromDirectory()`): 格式自动检测(zip/dsl/mdx) → hoshidicts FFI 导入 → 资源目录写入 → 词典类型检测(term/freq/pitch/kanji)
@@ -96,8 +96,8 @@ Hibiki 的 Flutter 多平台主应用：日语 EPUB 阅读器，集成划词查�
 
 ### 8. 页面 (`lib/src/pages/implementations/`)
 
-64 个页面实现，主要包括：
-- `home_page.dart` / `home_reader_page.dart` / `home_dictionary_page.dart` -- 首页。
+85 个页面实现，主要包括：
+- `home_page.dart` -- 首页外壳；`home_dashboard_page.dart` -- 首页 dashboard；同级 tab 页 `home_reader_page.dart` / `home_video_page.dart` / `home_game_page.dart` / `home_dictionary_page.dart`。
 - `reader_hibiki_page.dart` (~3200 行主体 + `reader_hibiki/` 下 8 个域 part 文件) -- 核心阅读器页面：
   - **WebView 架构**: `InAppWebView` + `hoshi.local` 虚拟域名拦截（`shouldInterceptRequest`），EPUB HTML/CSS/字体/图片全部经过安全校验后在拦截器中提供。
   - **分页系统**: JS 端 `hoshiReader` 分页引擎 + Dart 端 `ReaderPaginationScripts`，支持分页/连续两种模式。
@@ -116,10 +116,40 @@ Hibiki 的 Flutter 多平台主应用：日语 EPUB 阅读器，集成划词查�
 - `collections_page.dart` / `tag_*` 系列 -- 集合与标签。
 - `reading_statistics_page.dart` -- 阅读统计。
 
+### 9. 视频播放 (`video_hibiki_page.dart` + `lib/src/media/video/`)
+
+- `lib/src/pages/implementations/video_hibiki_page.dart`（6358 行主体）+ `video_hibiki/` 下 18 个 part（共 6966 行，最大 `subtitle.part.dart` 1375 行）-- 视频播放页：字幕查词/制卡、倍速、沉浸模式。
+- `home_video_page.dart`（3080 行）-- 视频首页（书架/合集/继续观看）。
+- `lib/src/media/video/` -- 视频导入与管理（含 `video_import_dialog.dart`）。
+- 播放栈 media_kit（`third_party/` vendored，Windows 构建需下载 mpv/ANGLE，见 `CLAUDE.local.md` 代理说明）。
+
+### 10. 互联/同步 (`lib/src/sync/`)
+
+- `interconnect_*.dart` -- 局域网互联（设备配对、远程书库/视频、远程查词）。
+- `aggregate_sync_service.dart` / `backup_merge_engine.dart` -- 聚合同步与备份合并引擎。
+- `cloud_remote_book_client.dart` -- 云端远程书籍客户端；另有 Google Drive / WebDAV / Dropbox / FTP 等 backend。
+- DB 侧配对设备表 `HibikiPairedPeers`（定义在 `hibiki_core`）。
+
+### 11. torrent 下载 (`lib/src/media/torrent/`)
+
+- `embedded_torrent_backend.dart` -- 内置引擎的 `TorrentBackend` 实现；同目录含番剧下载/nyaa/qBittorrent 客户端。
+- 引擎在 `packages/hibiki_torrent`（Dart FFI）+ `native/hibiki_torrent`（libtorrent C ABI）；DLL 缺失时回退外接 qBittorrent（`qb_torrent_backend.dart`）。
+
+### 12. galgame 制卡 (`lib/src/lookup/` + `lib/src/mining/`)
+
+- `lib/src/lookup/gal_hook_text_overlay_controller.dart` / `overlay_window_channel.dart` -- Hook 文本浮窗通道。
+- `lib/src/mining/galgame_*`（9 文件，含 `galgame_helper_installer.dart`）-- 场景制卡/语音捕获/波形选段。
+- C++ hook 在 `native/galgame_voice_hook/`（Helper 独立分发，不编进 app）。
+
+### 13. 浏览器扩展 (仓库根 `tools/browser-extension/`)
+
+- `content.js` / `background.js` 等 -- 浏览器内查词扩展，与 app 经本地 HTTP 通信。
+- 弹窗样式须与 app 内弹窗三镜像同步（popup / 扩展 content.css）。
+
 ## 关键依赖与配置
 
 - **状态管理**：`flutter_riverpod: ^2.3.6`
-- **数据库**：`drift: ^2.23.0` + `sqlite3_flutter_libs`（通过 `hibiki_core`）
+- **数据库**：`drift: ">=2.33.0 <2.34.0"` + `sqlite3_flutter_libs`（通过 `hibiki_core`）
 - **WebView**：`flutter_inappwebview: ^6.1.5`
 - **音频**：`just_audio: ^0.9.31`（通过 `hibiki_audio`）
 - **国际化**：`slang: ^3.13.0` / `slang_flutter`，17 种语言
@@ -128,7 +158,7 @@ Hibiki 的 Flutter 多平台主应用：日语 EPUB 阅读器，集成划词查�
 
 ## 数据模型
 
-数据模型全部定义在 `hibiki_core`（28 张 Drift 表），本模块仅消费。
+数据模型全部定义在 `hibiki_core`（46 张 Drift 表，schema v50），本模块仅消费。互联配对设备表 `HibikiPairedPeers` 也在其中。
 
 ## 测试与质量
 
@@ -152,7 +182,7 @@ Hibiki 的 Flutter 多平台主应用：日语 EPUB 阅读器，集成划词查�
 
 ## Android 原生代码 (`android/`)
 
-18 个 Java 文件，包括：
+20 个 Java 文件，包括：
 - `MainActivity.java` -- 主 Activity。
 - `PopupDictActivity.java` -- 弹窗词典 Activity。
 - `FloatingDictService.java` / `FloatingLyricService.java` / `BaseFloatingService.java` -- 悬浮窗服务。
@@ -171,21 +201,29 @@ Hibiki 的 Flutter 多平台主应用：日语 EPUB 阅读器，集成划词查�
 
 ## 相关文件清单
 
+`lib/src/` 一级目录 19 个：anki / creator / dictionary / epub / focus / lookup / media / mining / models / pages / platform / profile / reader / settings / shortcuts / startup / storage / sync / utils。
+
 - `lib/main.dart` -- 主入口
 - `lib/popup_main.dart` -- 弹窗词典入口
 - `lib/floating_dict_main.dart` -- 悬浮词典入口
 - `lib/creator.dart` / `lib/media.dart` / `lib/models.dart` / `lib/pages.dart` / `lib/utils.dart` -- barrel files
-- `lib/src/epub/` -- EPUB 处理（10 文件）
-- `lib/src/reader/` -- 阅读器渲染（6 文件）
-- `lib/src/media/audiobook/` -- 有声书桥接（10 文件）
-- `lib/src/creator/` -- 卡片创建器（~50 文件）
-- `lib/src/models/` -- 应用模型（6 文件）
-- `lib/src/pages/` -- 页面（~62 文件）
-- `lib/src/utils/` -- 工具（~45 文件）
+- `lib/src/epub/` -- EPUB 处理（9 文件）
+- `lib/src/reader/` -- 阅读器 JS/CSS 注入封装（17 文件）
+- `lib/src/media/` -- 媒体子系统，下分 `audiobook/`（24 文件）/ `video/`（72 文件）/ `torrent/`（15 文件）/ `sources/` / `collections/` / `drag_drop/` 等
+- `lib/src/sync/` -- 互联/同步/备份（94 文件）
+- `lib/src/lookup/` -- 查词浮窗/galgame Hook 浮窗通道（18 文件）
+- `lib/src/mining/` -- galgame/沉浸制卡（18 文件）
+- `lib/src/creator/` -- 卡片创建器（47 文件）
+- `lib/src/models/` -- 应用模型（18 文件）
+- `lib/src/pages/implementations/` -- 页面实现（85 文件）
+- `lib/src/shortcuts/` -- 全局快捷键与手柄绑定（18 文件，含 `global_navigation.dart`）
+- `lib/src/utils/` -- 工具（87 文件）
 - `lib/src/profile/` -- Profile 系统（4 文件）
-- `lib/src/anki/` -- Anki ViewModel（1 文件）
+- `lib/src/anki/` -- Anki ViewModel（3 文件）
 - `lib/i18n/` -- 国际化（17 语言 + 生成文件）
+- 仓库根 `tools/browser-extension/` -- 浏览器扩展（content.js / background.js）
 
 ## 变更记录 (Changelog)
 
 - 2026-05-23: 初始文档生成。
+- 2026-07-21: 校准数字（表数 46/schema v50、AppModel 5149 行、页面 85、Java 20、drift 版本等），补视频/互联/torrent/galgame/浏览器扩展五大子系统入口与目录总览。

--- a/packages/hibiki_core/CLAUDE.md
+++ b/packages/hibiki_core/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## 模块职责
 
-共享核心模块：定义 Drift SQLite 数据库 schema（28 张表，当前 schemaVersion=28）、表迁移逻辑、偏好键值编解码器（PrefCodec）、语言配置模型和文本选区模型。是所有其他 packages 的基础依赖。
+共享核心模块：定义 Drift SQLite 数据库 schema（46 张表，当前 schemaVersion=50）、表迁移逻辑、偏好键值编解码器（PrefCodec）、语言配置模型和文本选区模型。是所有其他 packages 的基础依赖。
 
 ## 入口与启动
 
@@ -20,32 +20,59 @@
 
 ## 关键依赖与配置
 
-- `drift: ^2.23.0` + `sqlite3_flutter_libs: ^0.5.28` -- ORM 和 SQLite native 绑定。
+- `drift: ">=2.33.0 <2.34.0"` + `sqlite3_flutter_libs: ^0.5.28` -- ORM 和 SQLite native 绑定。
 - `path: ^1.8.2` -- 路径处理。
-- 代码生成：`drift_dev` + `build_runner`，生成 `database.g.dart`。
+- 代码生成：`drift_dev: ^2.23.0` + `build_runner`，生成 `database.g.dart`。
 
 ## 数据模型
 
-28 张 Drift 表（按功能分组）：
+46 张 Drift 表（按功能分组，以 `database.dart` 的 `@DriftDatabase(tables: [...])` 注册清单为准）：
 
 | 分组 | 表名 |
 |------|------|
 | 媒体 | `MediaItems` |
+| 来源库 | `MediaSources` |
 | Anki | `AnkiMappings` |
 | 搜索 | `SearchHistoryItems` |
 | 有声书 | `Audiobooks`, `AudioCues`, `SrtBooks` |
 | 阅读位置 | `ReaderPositions`, `Bookmarks` |
+| 阅读器渲染 | `BookCustomCss`, `RevealedImages` |
 | 统计 | `ReadingStatistics`, `ReadingHourlyLogs` |
 | 偏好 | `Preferences` |
+| 剪贴板/活动 | `ClipboardHistory`, `ActivityEvents` |
 | 词典 | `DictionaryMetadata`, `DictionaryHistory` |
 | EPUB | `EpubBooks` |
-| 标签 | `BookTags`, `BookTagMappings`, `SrtBookTagMappings` |
+| 标签 | `BookTags`, `BookTagMappings`, `SrtBookTagMappings`, `CollectionTagMappings` |
 | Profile | `Profiles`, `ProfileSettings`, `MediaTypeProfiles`, `BookProfiles` |
-| 同步 | `SyncBaselines` |
+| 同步基线 | `SyncBaselines` |
 | 视频 | `VideoBooks`, `VideoBookTagMappings`, `VideoWatchStatistics`, `VideoHourlyLogs` |
-| 收藏/制卡 | `FavoriteWords`, `MiningStatistics` |
+| 收藏/制卡 | `FavoriteWords`, `MiningStatistics`, `MinedSentences`, `LookupMiningCounters` |
+| 合集/系列 | `MediaCollections`, `MediaCollectionItems`, `Series`, `ShelfEntries` |
+| 互联 | `HibikiPairedPeers` |
+| 删除墓碑 | `BookTombstones`, `StatisticsTombstones`, `CollectionMemberTombstones`, `BookTagMembershipTombstones`, `SyncDeletionTombstones` |
 
-迁移策略：`onUpgrade` 逐版本增量迁移（v1->v24），支持降级时自动备份并重建。
+新增表（相对旧文档的 28 张补齐的 18 张）用途：
+
+- `MediaSources` -- TODO-817 网络/本地来源库：一个媒体根扫描产出多本书/视频，敏感凭据绝不入 `configJson`。
+- `ActivityEvents` -- 首页活动时间轴，每次 session 一行的精确时间戳事件流（read/watch/added）。
+- `ClipboardHistory` -- 桌面剪贴板复制历史，供查词面板/瞬态浮窗的历史按钮读取。
+- `MinedSentences` -- 制卡历史逐条记录（句子 + 跳回原文的定位锚点），供收藏夹跨媒体查看。
+- `LookupMiningCounters` -- per-book 查词/制卡终身累加计数（区别于 `MinedSentences` 的滚动历史）。
+- `Series` -- 旧「系列」容器，自 v38 冻结为遗留残留（勿再读写系列语义）。
+- `ShelfEntries` -- 以 `(mediaType, entryKey)` 统管本地+远端条目的自定义排序权重与（遗留）系列归属。
+- `MediaCollections` -- 统一合集容器（collection 无序 / playlist 有序，Jellyfin BoxSet/Playlist 式）。
+- `MediaCollectionItems` -- 合集成员引用（复合键按合集去重，同一条目可属多个合集）。
+- `CollectionMemberTombstones` -- 合集成员移出/合集删除墓碑，防跨端并集同步复活。
+- `CollectionTagMappings` -- 合集 ↔ 标签 多对多映射（复用共享 `BookTags` 标签池）。
+- `HibikiPairedPeers` -- 互联（局域网配对）的 per-peer 授权凭据表，token 明文列存（红线：不进日志/明文导出）。
+- `BookTombstones` -- 已删书墓碑，供备份「合并导入」跳过、避免复活已删的书。
+- `StatisticsTombstones` -- per-book/video 统计删除墓碑，防 MAX-union 同步/备份把删掉的统计加回。
+- `BookTagMembershipTombstones` -- 书/视频标签移除墓碑（LWW-element-set add/remove 裁决，防跨端复活/误删）。
+- `SyncDeletionTombstones` -- sync 通道跨资产统一的删除墓碑（带发布状态，删除需双向确认、不静默传播）。
+- `BookCustomCss` -- per-book 自定义 CSS 文本 + `updatedAt` 的跨端同步载体（LWW，`deleted`=重置墓碑）。
+- `RevealedImages` -- 图片防剧透遮罩「已揭开」状态的持久真相源（书内 ↔ 图片库双向同步）。
+
+迁移策略：`onUpgrade` 逐版本增量迁移（v1->v50），支持降级时自动备份并重建。
 
 ## 测试与质量
 

--- a/packages/hibiki_dictionary/CLAUDE.md
+++ b/packages/hibiki_dictionary/CLAUDE.md
@@ -13,6 +13,12 @@
 - FFI 绑定：`lib/src/ffi/hoshidicts_ffi_bindings.dart` -- 自动/手动生成的 FFI 函数签名。
 - 应用启动时调用 `HoshiDicts.preloadTransforms()` 预加载语言变换表。
 
+## C++ 引擎真实位置（不在本包）
+
+- **本包只剩纯 Dart**：`lib/src/` 下仅 `engine/`、`ffi/`、`formats/`、`language/`、`models/` 五个目录，无任何 `.cpp/.cc/.h`；FFI 绑定在 `lib/src/ffi/hoshidicts_ffi_bindings.dart`。
+- **C++ 引擎源码全在仓库根 `native/hoshidicts/`**：`hoshidicts_src/`（`deinflector.cpp` / `importer.cpp` / `lookup.cpp` / `query.cpp` / `popup_json.cpp` 等实现）、`hoshidicts_include/`（头文件）、`hoshidicts_ffi.cpp`（C ABI 导出，供 Dart FFI）、`hoshidicts_jni.cpp`（Android JNI 桥）、`CMakeLists.txt`（构建）；`hoshidicts_external/` 为 vendored 第三方依赖（glaze / libdeflate / unordered_dense / utf8proc / utfcpp / xxHash / zstd）；`UPSTREAM.md` 记上游同步基线。
+- **改 C++ 引擎行为（查询/导入/去屈折/解析）去 `native/hoshidicts/`，不在本包**；本包只做 Dart 侧绑定、格式注册与语言处理封装。
+
 ## 对外接口
 
 - `HoshiDicts` -- 静态类，提供词典查询核心 API（search / import / delete）。


### PR DESCRIPTION
## 摘要

对根 CLAUDE.md 及各级 agent 文档做全面事实校准与索引重构（基于 develop 942974e81，4 轮只读审计逐项核实 file:line 后落笔）。

### 根 CLAUDE.md
- **schema v24/28 表 → v50/46 表**（database.dart:402 实测）
- Flutter 版本改为三源如实表述：本地 .fvmrc 3.41.6 / pubspec ^3.41.6 / CI 3.44.0；删除无仓库证据的「Dart 3.12.0」
- 仓库地图：补视频页（video_hibiki_page.dart 6358 行 + 18 part 6966 行）、互联/同步（lib/src/sync/）、galgame 制卡（lookup+mining+native hook）、浏览器扩展（tools/browser-extension/）、词典 C++ 引擎实际位置 native/hoshidicts/；修正 app_model 行数（~3600→~5150）、run_windows_itest.ps1 归属（实在 hibiki/tool/）
- docs/agent 流程表 4 篇 → 7 篇（补 computer-use-testing / external-video-open / shortcuts-inventory）
- 模块索引 9 行 → 18 行：补 packages/hibiki_torrent、gamepads_windows、native/ 三个 C++ 模块、server/ 两个日志端、third_party 完整 12 项、ReinaManager submodule
- 「基本规则 / i18n / 验证 / 提交」纪律条款语义原样保留

### 子级文档
- hibiki/CLAUDE.md：数字校准（AppModel 5149 行、页面 85、Java 20、drift >=2.33.0），新增视频/互联/torrent/galgame/浏览器扩展五大子系统导引 + lib/src 一级目录总览（实测 19 个）
- packages/hibiki_core/CLAUDE.md：46 表分组补齐 18 张缺表并按 tables.dart 注释逐表一句话用途；迁移 v1->v50
- packages/hibiki_dictionary/CLAUDE.md：新增「C++ 引擎真实位置」节（包内已无 C++，全在 native/hoshidicts/）
- docs/agent/reader-debugging.md：行数 5300 → 3242 主体 + 8 part 共 9583

## 验证
- 纯文档改动：git diff --cached --check 通过；只 stage 本轮 5 个文件
- 全部数字/路径经 4 个只读审计子代理逐项 wc -l / ls / Read 实测核实

https://claude.ai/code/session_013ZzzPWZPZYdP276qLH4EXe