### PR TITLE
test(galgame): ceshi 素材制卡流程真机验证 + 语音捕获 itest

### DIFF
--- a/docs/specs/galgame-mining/handoff.md
+++ b/docs/specs/galgame-mining/handoff.md
@@ -18,6 +18,35 @@
 
 **接缝提醒**：injector 可执行文件约定放在 app 同级 `voice_hook/<arch>/hibiki_voice_injector.exe`（`_resolveGalInjectorPath({is32Bit})`，按 `EngineHookGalAudioSource.targetIsWow64(pid)` 查目标进程位数选 x86/x64——**KiriKiri 多为 32 位必须 x86 注入器**），由 `native/galgame_voice_hook` 单独 cmake（`-A x64` / `-A Win32`）构建后随包分发/按需下载；缺失/位数不符时 A6 自动回退 loopback。C.2 的**校准模式 callsite/音量精筛**（只留角色语音、BGM/SE 不捕获）留 TODO（`dll_main.cpp` 内注释），需真机各引擎标定=C.3。
 
+## ✅ 真机验证（2026-07-21，ceshi 素材批量制卡流程 + 端到端 AnkiConnect 落卡）
+
+**素材清理（"删掉没句子音频的游戏"）**：逐个核对 `C:\Users\wrds\Downloads\Compressed\ceshi` 归档的逐句语音：
+
+| 游戏 / 归档 | 引擎 | 逐句语音归档 | 处置 |
+|---|---|---|---|
+| 完全時間停止 特典：オフィシャル | 自研 NEKOPACK | `voice.pak` **只 2 条 ogg**（`se.pak` 才 1777 条 SE） | **已删**（正文无逐句语音，是特典赠品） |
+| AngelBeats! trial | SiglusEngine | `koe/*.ovk`（29 个 OVK） | 保留（有语音；但非日文 locale 弹 "This Game is Japan Only" 挡门，进不去对白） |
+| 天使☆騒々 RE-BOOT!（`bgimage/tenshi_sz.exe`） | KiriKiriZ | `voice.xp3` 2.1GB | 保留（本轮真机测试对象） |
+| PRETTY×CATION2 バースデー vol.2（`pxc2_bc_vol2.exe`） | KiriKiri | `birthday_vol2.xp3` 322 条 `azu_*.ogg`（在バースデーアペンド） | 保留（有语音；主 exe 是壁纸/日历/时钟赠品菜单，默认不自动播语音→本轮抓到静音） |
+| Sakura Swim Club | Ren'Py | `voice/*.ogg` 1791 条 | 保留（有角色语音，英文文本） |
+| ChronoClock trial（`cmvs32.exe`） | CatSystem2 | `voice.cpz` 41MB | 保留（有语音；非日文 locale 弹 cp932 乱码框，进不去对白） |
+| カスタムメイド3D2 CHU-B LIP（`.mdf`） | KISS 自研 | `voice_cbl_a/b.arc` 2.2GB | 保留（有语音；3D 换装/舞蹈，非文本对白 galgame，未安装磁盘镜像） |
+| 姫様ＬＯＶＥライフ！（`HIMELOVE.ISO`） | AOS | `cv.aos` 675MB | 保留（有语音；未安装 ISO） |
+| 恋愛フェイズ（`RENAIPHASE.ISO`） | 戯画自研 | 4.3GB ISO（未展开核对，戯画系语音作） | 保留（未安装 ISO） |
+
+结论：**唯一真正"没句子音频"的是已删的完全時間停止特典**；其余都带逐句语音归档，不属删除范围（非日文 locale 或磁盘镜像未装只是"本机跑不进对白"，不是"无语音"）。
+
+**制卡流程端到端真机（`integration_test/galgame_card_mining_test.dart` + 新增 `galgame_loopback_voiced_test.dart`）**：
+- **管线机械链路全通**：native 音频捕获（loopback / voice_hook channel）→ WAV（44 字节头，Anki 直接播）→ WGC 窗口截图 → meta → 外层 `push_galcards.py` 经 AnkiConnect `storeMediaFile`+`addNote` → **6 张卡真进 `galgame_card_test` deck，`[sound:]`/`<img>` 媒体 `retrieveMediaFile` 可取回**（`notesInfo` 复核 6/6）。
+- **诚实的质量边界**（本轮暴露，非管线 bug）：
+  1. **"启动即抓" ≠ 有对白语音**。`galgame_card_mining_test` 只做"拉起→等 8s→抓 4s"，5 个游戏都停在标题/首启弹窗，抓到的是标题 BGM / 系统残留——SiglusEngine 与 tenshi 两张卡的 WAV **字节完全相同**（同一段 loopback 残留），pxc2 赠品菜单 **peak=0**（静音）。要真语音必须先把游戏驱动进对白行再抓。
+  2. **驱动进对白后可抓到真游戏音频**：新增 `galgame_loopback_voiced_test.dart`（只 loopback 轮询、保留峰值最大一段），外层 `tenshi_drive.ps1` 先答掉 KiriKiriZ 首启弹窗（`#32770` No/OK，已持久化：二次启动直进标题）、再对 `TVPMainWindow` 客户区中心连点 137 次推进对白。捕获 **peak=0.5898 / rms=0.1395**（明显高于标题残留 0.3457，且字节相异），证明抓到了推进对白时的真实游戏音频。
+  3. **KiriKiriZ 软件混音**：抓到的是"语音+BGM 混音"而非孤立干净语音（与 2026-07-18 otomeki 结论一致，KiriKiriZ 引擎-hook≈loopback）。干净逐句语音只对 per-voice buffer 引擎（Siglus OVK/DirectSound、XAudio2）成立。
+  4. **部分引擎 WGC 截图拿不到画面**：天使☆騒々 的 D3D 硬件表面 WGC/PrintWindow 只截到菜单栏+白色画布（`tenshi_voiced.png` 空白）；同批 pxc2 的 GDI 标题画面则被 WGC 完整截到。硬件表面截图是既有限制，非本轮回归。
+  5. **首启/locale 门**：AngelBeats(Siglus) 被 "Japan Only" 弹窗、ChronoClock(CatSystem2) 被 cp932 乱码框挡住，非日文 locale 机器上自动化进不到对白——engine-hook 干净语音路径在本机无法对这两个走查。
+
+**未真机验证/后续**：① 各游戏"驱动进对白"仍是引擎专属脚本（KiriKiriZ 中心连点可用；Siglus/CatSystem2 需日文 locale 才过门）；② Siglus 干净 OVK 逐句语音本机未复现（AngelBeats trial 被 Japan-only 挡；已验证基线仍是 2026-07-19 anemoi）；③ 天使☆騒々 D3D 画面 WGC 截图空白待查（可能需 window vs monitor 捕获或 DXGI 路径）。证据：`hibiki/.codex-test/windows-itest/win-itest-20260721-15*`、dump 目录 `galcard-out/*.{wav,png,json}`。
+
 ## ✅ 真机验证（2026-07-19，SiglusEngine 1.1.141.3 / anemoi 正式版）
 
 - 原始路径：`D:\anemoi\anemoi (正式版)\SiglusEngine.exe`，32 位 x86，SHA-256 `D94C94EB132FB1FCD6C20F35DD16552ED1301708B7A83DE07B275AD26C97D059`。

--- a/hibiki/integration_test/galgame_loopback_voiced_test.dart
+++ b/hibiki/integration_test/galgame_loopback_voiced_test.dart
@@ -1,0 +1,168 @@
+// ignore_for_file: avoid_print
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:hibiki/src/mining/galgame_audio_encode.dart';
+import 'package:hibiki/src/mining/galgame_audio_source.dart';
+import 'package:hibiki/src/mining/window_capture_channel.dart';
+
+/// 真机语音制卡验证（不启动游戏，只做系统 loopback 捕获）。
+///
+/// 外层脚本先把一个**真在播对白语音**的 galgame 驱动进对话；本测试在 ~[GALV_SECONDS] 秒内
+/// 每 1.2s 抓一段 loopback，保留**峰值最大**（最像语音）的那段，再截目标游戏窗口，dump
+/// WAV+PNG+meta 到 GALV_OUT。外层再经 AnkiConnect 推卡。
+///
+/// 不初始化 AppModel / 不开 Drift DB（只 pump 平凡 widget 让 runner 起 native 通道），绝不碰生产库。
+///
+/// 环境变量：
+///   - GALV_WINDOW_MATCH：目标游戏窗口标题子串（截图用；缺则截第一个有标题窗口）。
+///   - GALV_OUT：dump 目录（缺省 systemTemp）。
+///   - GALV_SECONDS：捕获轮询总秒数（缺省 50）。
+///   - GALV_NAME：媒体文件 basename（缺省 galvoiced）。
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('loopback 捕获最响一段对白语音并 dump', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    final Map<String, String> env = Platform.environment;
+    final String outDir = env['GALV_OUT'] ?? Directory.systemTemp.path;
+    final String match = env['GALV_WINDOW_MATCH'] ?? '';
+    final int seconds = int.tryParse(env['GALV_SECONDS'] ?? '') ?? 50;
+    final String name = env['GALV_NAME'] ?? 'galvoiced';
+    Directory(outDir).createSync(recursive: true);
+
+    final LoopbackGalAudioSource loopback = LoopbackGalAudioSource();
+    final PcmFormat? fmt = await loopback.start();
+    if (fmt == null) {
+      print('GALV SKIP: loopback 无法启动（非 Windows / native 缺失）');
+      return;
+    }
+    print(
+        'GALV START fmt=${fmt.sampleRate}/${fmt.channels}/${fmt.bitsPerSample} '
+        'float=${fmt.isFloat} seconds=$seconds match="$match"');
+
+    Uint8List? bestPcm;
+    double bestPeak = 0;
+    double bestRms = 0;
+    final DateTime deadline = DateTime.now().add(Duration(seconds: seconds));
+    int polls = 0;
+    while (DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 1200));
+      final GalAudioSlice? s = await loopback.grabRecent(3000);
+      polls++;
+      if (s == null || s.isEmpty) {
+        continue;
+      }
+      final (double peak, double rms) = _peakRms(s.pcm, s.format);
+      if (peak > bestPeak) {
+        bestPeak = peak;
+        bestRms = rms;
+        bestPcm = Uint8List.fromList(s.pcm);
+      }
+      if (polls % 5 == 0) {
+        print('GALV POLL $polls bestPeak=${bestPeak.toStringAsFixed(4)} '
+            'bestRms=${bestRms.toStringAsFixed(5)}');
+      }
+    }
+    await loopback.stop();
+
+    if (bestPcm == null || bestPeak <= 0) {
+      print('GALV RESULT name=$name captured=false peak=0 '
+          'note=无声（游戏未播语音或 loopback 静音）');
+      return;
+    }
+
+    // 取整段最响的（最多 4s）拼 WAV。
+    final int durMs = pcmDurationMs(bestPcm.length, fmt.byteRate);
+    final Uint8List sub = slicePcmByMs(bestPcm, fmt, 0, math.min(4000, durMs));
+    final Uint8List wav = buildWavBytes(sub, fmt);
+    final String wavPath = '$outDir/$name.wav';
+    File(wavPath).writeAsBytesSync(wav);
+
+    // 截目标游戏窗口。
+    String? pngPath;
+    final Uint8List? png = await _captureMatchingWindow(match);
+    if (png != null && png.isNotEmpty) {
+      pngPath = '$outDir/$name.png';
+      File(pngPath).writeAsBytesSync(png);
+    }
+
+    final String metaPath = '$outDir/$name.json';
+    File(metaPath).writeAsStringSync(jsonEncode(<String, Object?>{
+      'mediaBase': name,
+      'game': match.isEmpty ? name : match,
+      'source': 'loopback',
+      'fmt': '${fmt.sampleRate}/${fmt.channels}/${fmt.bitsPerSample}',
+      'pcmBytes': sub.length,
+      'peak': bestPeak,
+      'rms': bestRms,
+      'wav': '$name.wav',
+      'png': pngPath != null ? '$name.png' : null,
+    }));
+
+    print('GALV RESULT name=$name captured=true '
+        'peak=${bestPeak.toStringAsFixed(4)} rms=${bestRms.toStringAsFixed(5)} '
+        'durMs=${pcmDurationMs(sub.length, fmt.byteRate)} '
+        'wav=$wavPath png=${pngPath ?? "none"}');
+    expect(bestPeak, greaterThan(0));
+  }, timeout: const Timeout(Duration(minutes: 5)));
+}
+
+/// 计算一段 PCM 的峰值与 RMS（归一化到 0..1）。支持 16bit 整型与 32bit float。
+(double, double) _peakRms(List<int> pcm, PcmFormat fmt) {
+  final Uint8List bytes = Uint8List.fromList(pcm);
+  final ByteData bd = ByteData.sublistView(bytes);
+  double peak = 0;
+  double sumSq = 0;
+  int n = 0;
+  if (fmt.isFloat && fmt.bitsPerSample == 32) {
+    for (int i = 0; i + 4 <= bytes.length; i += 4) {
+      final double v = bd.getFloat32(i, Endian.little).abs();
+      if (v > peak) peak = v;
+      sumSq += v * v;
+      n++;
+    }
+  } else if (fmt.bitsPerSample == 16) {
+    for (int i = 0; i + 2 <= bytes.length; i += 2) {
+      final double v = bd.getInt16(i, Endian.little).abs() / 32768.0;
+      if (v > peak) peak = v;
+      sumSq += v * v;
+      n++;
+    }
+  } else if (fmt.bitsPerSample == 32) {
+    for (int i = 0; i + 4 <= bytes.length; i += 4) {
+      final double v = bd.getInt32(i, Endian.little).abs() / 2147483648.0;
+      if (v > peak) peak = v;
+      sumSq += v * v;
+      n++;
+    }
+  }
+  final double rms = n > 0 ? math.sqrt(sumSq / n) : 0;
+  return (peak, rms);
+}
+
+/// 截标题含 [match] 的第一个窗口（[match] 空则截首个有标题窗口）。失败返回 null。
+Future<Uint8List?> _captureMatchingWindow(String match) async {
+  final List<ExternalWindowInfo> wins =
+      await WindowCaptureChannel.listWindows();
+  ExternalWindowInfo? target;
+  for (final ExternalWindowInfo w in wins) {
+    if (w.title.trim().isEmpty) continue;
+    if (match.isEmpty || w.title.contains(match)) {
+      target = w;
+      break;
+    }
+  }
+  if (target == null) return null;
+  final WindowCaptureResult r =
+      await WindowCaptureChannel.captureWindow(target.hwnd);
+  return r.pngBytes;
+}


### PR DESCRIPTION
## 背景
用户提供 `ceshi` galgame 素材，要求「删掉没句子音频的游戏，然后实机测试制卡流程」。

## 做了什么
### 1. 素材清理
逐个核对各游戏逐句语音归档（OVK/xp3/cpz/aos/NEKOPACK 索引）。**唯一真正无逐句语音的是「完全時間停止 特典」（voice.pak 仅 2 条 ogg），已删**；其余（AngelBeats/天使騒々/pxc2/Sakura/ChronoClock/CM3D2/姫様LOVE/恋愛フェイズ）都带逐句语音归档，保留。详见 handoff.md 表。

### 2. 制卡流程端到端真机
- **机械链路全通**：native 音频捕获 → WAV → WGC 截图 → AnkiConnect `storeMediaFile`+`addNote`，**6 张卡真进 `galgame_card_test` deck，媒体可 `retrieveMediaFile` 取回**。
- 新增 `integration_test/galgame_loopback_voiced_test.dart`：loopback 轮询保留峰值最大一段；配合外层驱动脚本把 KiriKiriZ 天使騒々 推进对白后抓到真实游戏音频（**peak=0.59**，高于标题残留 0.35）。

### 3. 诚实的质量边界（handoff.md 已记录）
- "启动即抓" ≠ 有对白语音：`galgame_card_mining_test` 只做启动+抓，5 个游戏停在标题，抓的是 BGM/残留（Siglus 与 tenshi 两张卡 WAV 字节相同、pxc2 静音）。
- KiriKiriZ 软件混音 → 抓到的是语音+BGM 混音，非干净逐句语音（与既有基线一致）。
- 天使騒々 D3D 硬件表面 WGC 截图空白（既有限制）。
- AngelBeats(Siglus)/ChronoClock(CatSystem2) 非日文 locale 被首启/locale 门挡住，本机进不去对白。

## 验证
- `flutter analyze integration_test/galgame_loopback_voiced_test.dart` → 0 issue；`dart format` 已过。
- 仅新增 itest + 文档，无产品代码改动。

Claude-Session: https://claude.ai/code/session_01ER8V3e746bPLCXHtbaACfK