### PR TITLE
fix(reader): stabilize context menu and clip exports

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 947 条。点号进各自文件。
+> 共 949 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-968](bugs/BUG-968-audiobook-export-text-audio.md) | ✅ | ✅ | 有声书片段导出文字与选区不符且移动端缺少音频 |
+| [BUG-967](bugs/BUG-967-reader-context-menu-stack.md) | ✅ | ✅ | Windows 查词弹窗后右键菜单位于底层且重复累加 |
 | [BUG-966](bugs/BUG-966-subtitle-list-mining-audio.md) | ✅ | ✅ | 字幕列表点词查词制卡音频截错句(锚到播放位置而非被点cue) |
 | [BUG-965](bugs/BUG-965-longpress-speed-drag-jank.md) | ✅ | ✅ | 长按倍速拖动卡顿：每步全页 setState 掉帧 |
 | [BUG-964](bugs/BUG-964-interconnect-video-subtitle-not-synced.md) | ✅ | ✅ | 互联视频live push不带外挂字幕 |

--- a/docs/bugs/BUG-967-reader-context-menu-stack.md
+++ b/docs/bugs/BUG-967-reader-context-menu-stack.md
@@ -1,0 +1,6 @@
+## BUG-967 · Windows 查词弹窗后右键菜单位于底层且重复累加
+- **报告**：2026-07-21（用户：）
+- **真实性**：✅ 真 bug。`hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart:250` 由 `onSecondaryTapDown` fire-and-forget 调用，进入首次 JS await 前没有 single-flight 门控，连续右键可叠加多个 `PopupMenuRoute`；同时 Windows 原生 WebView2 弹层 surface 位于 Flutter route 上方，未先退回 warm slot 时新菜单会被压在底层。
+- **[x] ① 已修复** — 本提交在 `reader_hibiki_page.dart:1090` 增加菜单在途状态，在首个 await 前加锁并由 `finally` 释放；确认选区有效后先 `_webviewPrunePopupStack(0)`，再显示唯一的 Flutter 右键菜单。
+- **[x] ② 已加自动化测试** — `hibiki/test/reader/reader_context_selection_regression_guard_test.dart` 守卫加锁早于 JS await、WebView prune 早于 `showMenu`、菜单结束后必定解锁；聚焦测试 46/46 通过，`flutter analyze --no-pub` 0 问题。
+- **备注**：前序实现已通过不抢前台的 Windows 阅读器集成矩阵 14/14；原始“右键菜单视觉层级”仍需前台人工肉眼操作，当前 PR 不自动抢占用户前台。

--- a/docs/bugs/BUG-968-audiobook-export-text-audio.md
+++ b/docs/bugs/BUG-968-audiobook-export-text-audio.md
@@ -1,0 +1,6 @@
+## BUG-968 · 有声书片段导出文字与选区不符且移动端缺少音频
+- **报告**：2026-07-21（用户：）
+- **真实性**：✅ 真 bug。`hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart:1176` 的动态卡片直接渲染对齐 cue 文本而非 EPUB 实际选区；`audiobook_clip_export.dart:351` / `:502` 依赖 FFmpeg 隐式选流；移动端仅分享 MJPEG/MOV 视频时，部分接收端会忽略容器内 AAC，造成用户看到“缺少音频”。
+- **[x] ① 已修复** — 本提交仅在 cue 拼接文本与实际选区按空白归一化后完全一致时启用动态卡片，否则回退到精确选区静态卡片；两条 FFmpeg 路径显式映射 `0:v:0` 与 `1:a:0`；移动端 MOV 分享时同时附带裁剪后的 AAC，并保留文件供系统异步读取。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/audiobook/audiobook_clip_export_contract_test.dart` 覆盖选区/cue 一致与不一致、静态/动态显式音频映射、MOV 附带 AAC；连同现有合成和移动选区守卫共 46/46 通过，`flutter analyze --no-pub` 0 问题。
+- **备注**：当前没有已连接的 Android 实机，因此“手机端接收应用实际拿到视频 + AAC”仍待真机导出复测；PR 保持 Draft，不把源码与自动化结果冒充实机结论。

--- a/hibiki/lib/src/media/audiobook/audiobook_clip_export.dart
+++ b/hibiki/lib/src/media/audiobook/audiobook_clip_export.dart
@@ -133,6 +133,22 @@ List<AudiobookClipCueSpan> clipCueSpansWithDelay({
   }).toList(growable: false);
 }
 
+/// Dynamic cards render cue text segment by segment. Only use that path when
+/// the aligned cue text and the actual EPUB selection match after whitespace
+/// normalization; otherwise the caller must render the exact selection.
+bool audiobookClipCueTextMatchesSelection({
+  required String selectedText,
+  required List<AudiobookClipCueSpan> cueSpans,
+}) {
+  String normalize(String value) => value.replaceAll(RegExp(r'\s+'), '');
+  final String actual = normalize(selectedText);
+  if (actual.isEmpty || cueSpans.isEmpty) return false;
+  final String cueText = normalize(
+    cueSpans.map((AudiobookClipCueSpan span) => span.text).join(),
+  );
+  return actual == cueText;
+}
+
 /// 多句片段导出的分类结果（纯数据）。
 ///
 /// [kind] 复用 [AudiobookClipBoundaryKind]：emptySelection / noAudio /
@@ -351,6 +367,10 @@ List<String> buildFfmpegImageAudioToVideoArgs({
     imagePath,
     '-i',
     audioPath,
+    '-map',
+    '0:v:0',
+    '-map',
+    '1:a:0',
     ..._clipVideoCodecArgs(h264: h264, pixFmt: pixFmt),
     '-r',
     '$fps',
@@ -498,6 +518,10 @@ List<String> buildFfmpegImageSeqAudioToVideoArgs({
     inputPattern,
     '-i',
     audioPath,
+    '-map',
+    '0:v:0',
+    '-map',
+    '1:a:0',
     // BUG-809：桌面 h264（带帧间压缩，逐句高亮的大量重复帧压到近零）/ 移动 mjpeg。
     ..._clipVideoCodecArgs(h264: h264, pixFmt: pixFmt),
     '-vf',

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
@@ -1176,6 +1176,16 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
       maxDurationMs: _kAudiobookClipMaxDurationMs,
     );
     if (!result.isExportable) return null;
+
+    // Aligned cues are subtitle data, not necessarily the exact EPUB text the
+    // user selected. Mismatches must use the static exact-selection card.
+    if (!audiobookClipCueTextMatchesSelection(
+      selectedText: classifyText,
+      cueSpans: result.cueSpans,
+    )) {
+      return null;
+    }
+
     // TODO-1127：把选区里抽取到的插图按归一化文档位置分配到各 cue 段之后。cue 的
     // normCharStart 从 sasayaki 编码的 textFragmentId 解出（解不出的 cue 传 null，不作
     // 归属锚点）；`span` 与 result.cueSpans 同序等长（classify 只包一层不可变拷贝），故
@@ -1229,6 +1239,7 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
     File? audioClip;
     File? imageFile;
     File? videoFile;
+    bool retainAudioClipForShare = false;
     Directory? framesDir;
     final bool isDesktop =
         Platform.isWindows || Platform.isMacOS || Platform.isLinux;
@@ -1422,16 +1433,20 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
           if (mounted) HibikiToast.show(msg: t.audiobook_export_clip_saved);
         }
       } else {
-        await HibikiShare.shareFiles(
-          <XFile>[
-            XFile(
-              outPath,
-              // BUG-809：容器与编码器一致（桌面 mp4/h264 / 移动 mov/mjpeg）。
-              mimeType: useH264 ? 'video/mp4' : 'video/quicktime',
-            ),
-          ],
-          subject: text,
-        );
+        final List<XFile> sharedFiles = <XFile>[
+          XFile(
+            outPath,
+            // BUG-809：容器与编码器一致（桌面 mp4/h264 / 移动 mov/mjpeg）。
+            mimeType: useH264 ? 'video/mp4' : 'video/quicktime',
+          ),
+        ];
+        if (!useH264) {
+          // Some mobile receivers ignore AAC embedded in MJPEG/MOV. Share the
+          // exact clipped AAC beside the video so the export never loses audio.
+          sharedFiles.add(XFile(audioClip.path, mimeType: 'audio/aac'));
+          retainAudioClipForShare = true;
+        }
+        await HibikiShare.shareFiles(sharedFiles, subject: text);
         if (mounted) HibikiToast.show(msg: t.audiobook_export_clip_saved);
       }
     } catch (e, stack) {
@@ -1443,7 +1458,9 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
       _audiobookClipExporting = false;
       // 清理临时中间文件。桌面端最终视频已 copy 到用户选定路径，可一并清理；移动端
       // 系统 Share 异步读取 outPath，保留视频文件供其读取，仅清理音频/图中间产物。
-      await _deleteClipTempFile(audioClip);
+      if (!retainAudioClipForShare) {
+        await _deleteClipTempFile(audioClip);
+      }
       await _deleteClipTempFile(imageFile);
       // TODO-1115：动态路径的 N 帧 JPEG 序列帧目录一并清理（无论成功/回退/桌面/移动）。
       await _deleteClipFramesDir(framesDir);

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
@@ -248,7 +248,15 @@ extension _ReaderChrome on _ReaderHibikiPageState {
   // 复制/导出三项随界面大小缩放，而鼠标锚点与 WebView 命中测试不受影响。导出项仅在本书
   // 有音频 cue 时出现；其它两项恒在。
   Future<void> _showReaderTextContextMenu(Offset globalPosition) async {
-    if (!mounted || !isWindowsPlatform) return;
+    if (!mounted ||
+        !isWindowsPlatform ||
+        _readerTextContextMenuActive) {
+      return;
+    }
+    // onSecondaryTapDown does not await this Future. Gate before the first JS
+    // await so repeated right-clicks cannot stack multiple PopupMenuRoutes.
+    _readerTextContextMenuActive = true;
+    try {
     // 没有原生选区文本就不弹菜单（右键空白处不打扰）。
     // 本方法从 onSecondaryTapDown fire-and-forget 调用，异常会逃出当前 zone 被记为
     // fatal（main.dart runZonedGuarded）——WebView 半销毁 / 插件通道异常时右键
@@ -269,6 +277,11 @@ extension _ReaderChrome on _ReaderHibikiPageState {
         ReaderSelectionScripts.nativeSelectionTextFromResult(rawText);
     if (selectedText.isEmpty) return;
     if (!mounted) return;
+
+    // A native WebView2 popup surface is above Flutter routes on Windows. Move
+    // it back to the warm slot before opening the Flutter context menu; pruning
+    // does not clear the reader's native text selection.
+    _webviewPrunePopupStack(0);
 
     final RenderBox overlay =
         Overlay.of(context).context.findRenderObject()! as RenderBox;
@@ -404,6 +417,9 @@ extension _ReaderChrome on _ReaderHibikiPageState {
         return;
       default:
         return;
+    }
+    } finally {
+      _readerTextContextMenuActive = false;
     }
   }
 

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -1087,6 +1087,7 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   int _currentChapter = 0;
   bool _readerContentReady = false;
   bool _hasEverLoaded = false;
+  bool _readerTextContextMenuActive = false;
   bool _restoreInFlight = false;
   bool _isNavigatingToChapter = false;
   // TODO-1037：跨章推进经过的「纯图片章逐个停留」序列在途时为真，防重入跨章导航。

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+885
+version: 1.2.0+886
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/audiobook/audiobook_clip_export_contract_test.dart
+++ b/hibiki/test/media/audiobook/audiobook_clip_export_contract_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/audiobook/audiobook_clip_export.dart';
+
+void main() {
+  group('exported card text follows the actual reader selection', () {
+    test('accepts cue text only when it exactly represents the selection', () {
+      const List<AudiobookClipCueSpan> cues = <AudiobookClipCueSpan>[
+        AudiobookClipCueSpan(text: 'first', startMs: 0, endMs: 1000),
+        AudiobookClipCueSpan(text: 'second', startMs: 1000, endMs: 2000),
+      ];
+      expect(
+        audiobookClipCueTextMatchesSelection(
+          selectedText: 'first\nsecond',
+          cueSpans: cues,
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects subtitle wording or a wider cue than the selected text', () {
+      const List<AudiobookClipCueSpan> cues = <AudiobookClipCueSpan>[
+        AudiobookClipCueSpan(text: 'subtitle wording', startMs: 0, endMs: 1000),
+      ];
+      expect(
+        audiobookClipCueTextMatchesSelection(
+          selectedText: 'epub wording',
+          cueSpans: cues,
+        ),
+        isFalse,
+      );
+      expect(
+        audiobookClipCueTextMatchesSelection(
+          selectedText: 'sub',
+          cueSpans: cues,
+        ),
+        isFalse,
+      );
+    });
+
+    test('reader plan falls back before rendering differing cue text', () {
+      final String source = File(
+        'lib/src/pages/implementations/reader_hibiki/audiobook.part.dart',
+      ).readAsStringSync();
+      final int exportable = source.indexOf(
+        'if (!result.isExportable) return null;',
+      );
+      final int equalityGate = source.indexOf(
+        'audiobookClipCueTextMatchesSelection(',
+        exportable,
+      );
+      final int renderCueText = source.indexOf(
+        'text: plan.cueSpans[i].text',
+        equalityGate,
+      );
+      expect(exportable, greaterThanOrEqualTo(0));
+      expect(equalityGate, greaterThan(exportable));
+      expect(renderCueText, greaterThan(equalityGate));
+    });
+  });
+
+  group('every synthesized clip explicitly carries the audio input', () {
+    void expectExplicitMaps(List<String> args) {
+      expect(
+        args,
+        containsAllInOrder(<String>['-map', '0:v:0', '-map', '1:a:0']),
+      );
+      expect(args, containsAllInOrder(<String>['-c:a', 'aac']));
+    }
+
+    test('static card maps video input 0 and audio input 1', () {
+      expectExplicitMaps(
+        buildFfmpegImageAudioToVideoArgs(
+          imagePath: '/card.jpg',
+          audioPath: '/clip.aac',
+          outputPath: '/clip.mp4',
+          h264: true,
+        ),
+      );
+    });
+
+    test('dynamic frame sequence maps video input 0 and audio input 1', () {
+      expectExplicitMaps(
+        buildFfmpegImageSeqAudioToVideoArgs(
+          framesDir: '/frames',
+          audioPath: '/clip.aac',
+          outputPath: '/clip.mp4',
+          h264: true,
+        ),
+      );
+    });
+
+    test('MOV compatibility fallback shares the AAC companion', () {
+      final String source = File(
+        'lib/src/pages/implementations/reader_hibiki/audiobook.part.dart',
+      ).readAsStringSync();
+      expect(source, contains('sharedFiles.add('));
+      expect(
+        source,
+        contains("XFile(audioClip.path, mimeType: 'audio/aac')"),
+      );
+      expect(source, contains('retainAudioClipForShare = true;'));
+      expect(
+        source,
+        contains(
+          'if (!retainAudioClipForShare) {',
+        ),
+      );
+    });
+  });
+}

--- a/hibiki/test/reader/reader_context_selection_regression_guard_test.dart
+++ b/hibiki/test/reader/reader_context_selection_regression_guard_test.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/reader/reader_selection_scripts.dart';
+
+String _between(String source, String start, String end) {
+  final int from = source.indexOf(start);
+  final int to = source.indexOf(end, from + start.length);
+  expect(from, greaterThanOrEqualTo(0));
+  expect(to, greaterThan(from));
+  return source.substring(from, to);
+}
+
+void main() {
+  test('Windows right-click menu is single-flight and above popup WebView', () {
+    final String state = File(
+      'lib/src/pages/implementations/reader_hibiki_page.dart',
+    ).readAsStringSync();
+    final String chrome = File(
+      'lib/src/pages/implementations/reader_hibiki/chrome.part.dart',
+    ).readAsStringSync();
+    final String body = _between(
+      chrome,
+      'Future<void> _showReaderTextContextMenu(',
+      'Future<void> _handleSelectionMenu(',
+    );
+    expect(state, contains('bool _readerTextContextMenuActive = false;'));
+    final int gate = body.indexOf('_readerTextContextMenuActive = true;');
+    final int jsAwait = body.indexOf('evaluateJavascript(');
+    final int prune = body.indexOf('_webviewPrunePopupStack(0);');
+    final int menu = body.indexOf('showMenu<String>(');
+    final int reset = body.lastIndexOf('_readerTextContextMenuActive = false;');
+    expect(jsAwait, greaterThan(gate));
+    expect(prune, greaterThan(jsAwait));
+    expect(menu, greaterThan(prune));
+    expect(body, contains('finally {'));
+    expect(reset, greaterThan(menu));
+  });
+
+  test('Android caret hit test falls back when WebView returns an element', () {
+    final String js = ReaderSelectionScripts.source();
+    final String body = _between(
+      js,
+      'getCaretRange: function',
+      'getCharacterAtPoint: function',
+    );
+    final int caret = body.indexOf('caretPositionFromPoint');
+    final int textNode = body.indexOf('nodeType === Node.TEXT_NODE');
+    final int fallback =
+        body.indexOf('var element = document.elementFromPoint');
+    expect(caret, greaterThanOrEqualTo(0));
+    expect(textNode, greaterThan(caret));
+    expect(fallback, greaterThan(textNode));
+    expect(body, isNot(contains('if (!pos) return null;')));
+  });
+
+  test('selection handle has a larger touch target and themed inner ball', () {
+    final String js = ReaderSelectionScripts.source();
+    final String body = _between(
+      js,
+      'ensureSelectionHandles: function',
+      '_wireHandle: function',
+    );
+    expect(body, contains('width:32px;height:32px'));
+    expect(body, contains("'data-hoshi-sel-ball'"));
+    expect(body, contains('var(--hoshi-sel-handle'));
+    expect(body, isNot(contains('rgba(255,138,0,0.98)')));
+    final String cssSource = File(
+      'lib/src/reader/reader_content_styles.dart',
+    ).readAsStringSync();
+    expect(cssSource, contains('--hoshi-sel-handle:'));
+  });
+}


### PR DESCRIPTION
## Summary

- Make the Windows reader selection context menu single-flight and retire the native WebView popup surface before showing Flutter's menu, preventing underlay and repeated menu stacking.
- Keep audiobook clip card text faithful to the actual EPUB selection; differing aligned cue text now falls back to the exact-selection card.
- Explicitly map the image/video and AAC inputs in both FFmpeg synthesis paths, and share the clipped AAC beside mobile MJPEG/MOV exports for receivers that ignore embedded audio.
- Add regression guards for the desktop menu lifecycle, Android selection-handle fallback/styling, exact text selection, stream mapping, and mobile AAC sharing.

## Root cause

The right-click handler was launched fire-and-forget and could enter multiple times while awaiting JavaScript, creating multiple `PopupMenuRoute`s. On Windows, a native WebView2 popup surface can also remain above Flutter routes.

Dynamic audiobook cards rendered aligned cue text without confirming it matched the user's EPUB selection. FFmpeg relied on implicit stream selection, while some mobile share receivers ignore AAC embedded in MJPEG/MOV when only the video file is shared.

## Validation

- `flutter test --no-pub --no-test-assets` on the two new regression suites plus existing clip synthesis and selection-handle guards: **46/46 passed**.
- `flutter analyze --no-pub`: **No issues found**.
- `dart run tool/bug.dart check`: **949 entries, unique numbers, synchronized index**.
- The predecessor implementation passed the non-activating Windows reader integration matrix: **14/14**.

## Remaining device validation

No Android physical device is currently connected. The code paths and regression guards pass, but the final receiving-app behavior for the shared MOV + AAC pair still needs a physical-phone export check. This PR is therefore opened as a draft.
