### PR TITLE
feat(sync): Google Drive 与 Hoshi/ッツ 共享进度同步（可选开关）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 37570 (2210 per locale)
+/// Strings: 37604 (2212 per locale)
 ///
-/// Built on 2026-07-21 at 07:32 UTC
+/// Built on 2026-07-21 at 10:28 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2942,6 +2942,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get browser_extension_reinstall_button => 'Re-prepare / refresh files';
   String get browser_extension_server_on => 'Lookup server on';
   String get browser_extension_server_off => 'Lookup server off';
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -7940,6 +7943,11 @@ class _StringsAr extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -13011,6 +13019,11 @@ class _StringsDe extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -18098,6 +18111,11 @@ class _StringsEs extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -23196,6 +23214,11 @@ class _StringsFr extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -28221,6 +28244,11 @@ class _StringsId extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -33294,6 +33322,11 @@ class _StringsIt extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -38172,6 +38205,11 @@ class _StringsJa extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -43053,6 +43091,11 @@ class _StringsKo extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -48104,6 +48147,11 @@ class _StringsNl extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -53170,6 +53218,11 @@ class _StringsPtBr extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -58219,6 +58272,11 @@ class _StringsRu extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -63213,6 +63271,11 @@ class _StringsTh extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -68239,6 +68302,11 @@ class _StringsTr extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -73252,6 +73320,11 @@ class _StringsVi extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 // Path: <root>
@@ -77916,6 +77989,11 @@ class _StringsZhCn extends _StringsEn {
   String get browser_extension_server_on => '查词服务已开启';
   @override
   String get browser_extension_server_off => '查词服务未开启';
+  @override
+  String get sync_google_drive_hoshi_compat => '与 Hoshi / ッツ 共享进度';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      '通过共享的 Google Drive 文件夹（ttu-reader-data）同步阅读进度。需完整 Drive 权限并重新登录。';
 }
 
 // Path: <root>
@@ -82713,6 +82791,11 @@ class _StringsZhHk extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
+  @override
+  String get sync_google_drive_hoshi_compat_desc =>
+      'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
 }
 
 /// Flat map(s) containing all translations.
@@ -87225,6 +87308,10 @@ extension on _StringsEn {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -91735,6 +91822,10 @@ extension on _StringsAr {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -96266,6 +96357,10 @@ extension on _StringsDe {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -100796,6 +100891,10 @@ extension on _StringsEs {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -105332,6 +105431,10 @@ extension on _StringsFr {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -109850,6 +109953,10 @@ extension on _StringsId {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -114383,6 +114490,10 @@ extension on _StringsIt {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -118878,6 +118989,10 @@ extension on _StringsJa {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -123377,6 +123492,10 @@ extension on _StringsKo {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -127903,6 +128022,10 @@ extension on _StringsNl {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -132426,6 +132549,10 @@ extension on _StringsPtBr {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -136954,6 +137081,10 @@ extension on _StringsRu {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -141466,6 +141597,10 @@ extension on _StringsTh {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -145987,6 +146122,10 @@ extension on _StringsTr {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -150503,6 +150642,10 @@ extension on _StringsVi {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }
@@ -154985,6 +155128,10 @@ extension on _StringsZhCn {
         return '查词服务已开启';
       case 'browser_extension_server_off':
         return '查词服务未开启';
+      case 'sync_google_drive_hoshi_compat':
+        return '与 Hoshi / ッツ 共享进度';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return '通过共享的 Google Drive 文件夹（ttu-reader-data）同步阅读进度。需完整 Drive 权限并重新登录。';
       default:
         return null;
     }
@@ -159475,6 +159622,10 @@ extension on _StringsZhHk {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'sync_google_drive_hoshi_compat':
+        return 'Share progress with Hoshi / ッツ';
+      case 'sync_google_drive_hoshi_compat_desc':
+        return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "扩展版本",
   "browser_extension_reinstall_button": "重新准备 / 刷新文件",
   "browser_extension_server_on": "查词服务已开启",
-  "browser_extension_server_off": "查词服务未开启"
+  "browser_extension_server_off": "查词服务未开启",
+  "sync_google_drive_hoshi_compat": "与 Hoshi / ッツ 共享进度",
+  "sync_google_drive_hoshi_compat_desc": "通过共享的 Google Drive 文件夹（ttu-reader-data）同步阅读进度。需完整 Drive 权限并重新登录。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
 }

--- a/hibiki/lib/src/sync/google_drive_auth.dart
+++ b/hibiki/lib/src/sync/google_drive_auth.dart
@@ -12,6 +12,7 @@ import 'package:googleapis_auth/googleapis_auth.dart' as auth;
 import 'package:http/http.dart' as http;
 
 import 'package:hibiki/src/sync/desktop_oauth.dart';
+import 'package:hibiki/src/sync/google_drive_sync_space.dart';
 import 'package:hibiki/src/sync/google_oauth_secret.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
 
@@ -29,16 +30,29 @@ class GoogleDriveAuth {
 
   static bool get useMobileAuth => Platform.isAndroid || Platform.isIOS;
 
-  // TODO-836: sync data now lives in the hidden, app-private appDataFolder
-  // space (drive.appdata) instead of the user-visible Drive. The old
-  // visible-Drive scope forced findOrCreateRootFolder's whole-Drive name
-  // lookup to be a cross-app query → 403 insufficient_scope; drive.appdata
-  // grants full access to the app's own hidden space so the appDataFolder
-  // root lookup is in-scope. We REPLACE (not add) the old scope to keep the
-  // grant minimal — no visible-Drive write access残留.
-  static const _driveAppdataScope =
-      'https://www.googleapis.com/auth/drive.appdata';
+  // Drive 同步有两种存储空间（[GoogleDriveSyncSpace]），OAuth scope 随之切换：
+  // - 默认 appData：`drive.appdata`——app 私有的隐藏空间，别的 app 看不到，历史
+  //   默认（TODO-836：曾从可见 Drive scope 换来，避免全盘按名查触发跨 app 403）。
+  // - Hoshi 兼容 ttuShared：完整 `drive`——才能读到 Hoshi 在可见 My Drive 建的
+  //   文件（`drive.file` 只覆盖本 app 自己建的文件）。这是「与 Hoshi 共享」的必然
+  //   代价，切换开关时强制重新授权（scope 在 consent 时固定，refresh 不能加 scope）。
+  // scope 的真值源是 [GoogleDriveSyncSpace.scope]；此处仅保留 email scope 常量。
   static const _emailScope = 'https://www.googleapis.com/auth/userinfo.email';
+
+  /// 当前 Drive 存储空间 + scope。默认隐藏 appDataFolder；开启「Hoshi 兼容模式」后
+  /// 由 [GoogleDriveSyncBackend] 依偏好切到 [GoogleDriveSyncSpace.ttuShared]。
+  GoogleDriveSyncSpace _space = GoogleDriveSyncSpace.appData;
+
+  GoogleDriveSyncSpace get syncSpace => _space;
+
+  /// 切换存储空间。scope 在 google_sign_in 客户端构造时固定，换 space 必须丢弃缓存的
+  /// `_googleSignIn` 让下次 signIn 用新 scope。移动端已登录账号 [_mobileUser] 由调用方
+  /// signOut 清理（scope 变更本就需要重新授权）。
+  void setSyncSpace(GoogleDriveSyncSpace space) {
+    if (space.id == _space.id) return;
+    _space = space;
+    _googleSignIn = null;
+  }
 
   // 安装型应用（installed-app / PKCE）的 OAuth 凭据按 Google 设计属于非机密
   // 信息，会编译进二进制（见 HBK-AUDIT-072）。client_id 是公开标识，硬编码可接受
@@ -101,7 +115,7 @@ class GoogleDriveAuth {
   GoogleSignIn? _googleSignIn;
   GoogleSignIn get _signIn => _googleSignIn ??= GoogleSignIn(
         clientId: Platform.isIOS ? _iosClientId : null,
-        scopes: [_driveAppdataScope],
+        scopes: [_space.scope],
       );
 
   // The signed-in mobile account, populated by authenticate() or by
@@ -193,6 +207,7 @@ class GoogleDriveAuth {
         buildAuthUrl: (redirectUri) => _buildDesktopAuthUrl(
           redirectUri: redirectUri,
           challenge: challenge,
+          scope: _space.scope,
         ),
       );
       final credentials = await auth_io.obtainAccessCredentialsViaCodeExchange(
@@ -244,12 +259,13 @@ class GoogleDriveAuth {
   static Uri _buildDesktopAuthUrl({
     required String redirectUri,
     required String challenge,
+    required String scope,
   }) =>
       Uri.https('accounts.google.com', 'o/oauth2/v2/auth', {
         'client_id': _oauthClientId,
         'response_type': 'code',
         'redirect_uri': redirectUri,
-        'scope': [_driveAppdataScope, _emailScope].join(' '),
+        'scope': [scope, _emailScope].join(' '),
         'code_challenge': challenge,
         'code_challenge_method': 'S256',
         // Required for Google to issue a refresh token; without it the desktop
@@ -285,10 +301,14 @@ class GoogleDriveAuth {
   }
 
   @visibleForTesting
-  static Uri debugBuildDesktopAuthUrl(String redirectUri) =>
+  static Uri debugBuildDesktopAuthUrl(
+    String redirectUri, {
+    String scope = 'https://www.googleapis.com/auth/drive.appdata',
+  }) =>
       _buildDesktopAuthUrl(
         redirectUri: redirectUri,
         challenge: 'test-challenge',
+        scope: scope,
       );
 
   @visibleForTesting
@@ -450,7 +470,8 @@ class GoogleDriveAuth {
         DateTime.parse(map['expiry'] as String),
       ),
       map['refreshToken'] as String?,
-      (map['scopes'] as List?)?.cast<String>() ?? [_driveAppdataScope],
+      (map['scopes'] as List?)?.cast<String>() ??
+          <String>[GoogleDriveSyncSpace.appData.scope],
     );
   }
 }

--- a/hibiki/lib/src/sync/google_drive_handler.dart
+++ b/hibiki/lib/src/sync/google_drive_handler.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:googleapis/drive/v3.dart' as drive;
 import 'package:googleapis_auth/googleapis_auth.dart' as auth;
 import 'package:hibiki/src/sync/google_drive_auth.dart';
+import 'package:hibiki/src/sync/google_drive_sync_space.dart';
 import 'package:hibiki/src/sync/sync_asset_store.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_backend_file_trio_mixin.dart';
@@ -81,6 +82,22 @@ class GoogleDriveHandler with SyncFolderCache, SyncBackendFileTrioMixin {
   static final GoogleDriveHandler instance = GoogleDriveHandler._();
 
   drive.DriveApi? _cachedApi;
+
+  /// 当前 Drive 存储空间 + scope。默认隐藏 appDataFolder；「Hoshi 兼容模式」开启时
+  /// 切到可见 My Drive / `ttu-reader-data`（见 [GoogleDriveSyncSpace]）。所有
+  /// `files.list` 的 `spaces`、根文件夹的 parent/名字都从这里取，消除散落分支。
+  GoogleDriveSyncSpace _space = GoogleDriveSyncSpace.appData;
+
+  GoogleDriveSyncSpace get syncSpace => _space;
+
+  /// 切换存储空间。变更时清缓存：根/书文件夹 id 与 DriveApi 句柄都归属旧空间，换空间后
+  /// 若复用会拿旧空间的 folderId 打新空间的请求，必须重建（[clearCache] 覆写会连
+  /// `_cachedApi` 一起清）。
+  void setSyncSpace(GoogleDriveSyncSpace space) {
+    if (space.id == _space.id) return;
+    _space = space;
+    clearCache();
+  }
 
   // 缓存字段（rootFolderIdCache / folderIdCache）+ restoreCache /
   // cachedRootFolderId / cachedFolderIds / cacheBookFolderIds / evictFolderId
@@ -183,10 +200,11 @@ class GoogleDriveHandler with SyncFolderCache, SyncBackendFileTrioMixin {
 
     return _call((api) async {
       final list = await api.files.list(
-        // TODO-836: query the hidden App Data space, not the visible Drive.
-        spaces: 'appDataFolder',
+        // 隐藏 appDataFolder 空间下必须显式带 spaces；可见 My Drive 模式用 'drive'
+        // （[GoogleDriveSyncSpace]，TODO-836）。
+        spaces: _space.spaces,
         q: "trashed=false and mimeType='application/vnd.google-apps.folder' "
-            "and name='$kSyncRootFolderName'",
+            "and name='${_space.rootFolderName}'",
         $fields: 'files(id,name)',
       );
 
@@ -197,11 +215,11 @@ class GoogleDriveHandler with SyncFolderCache, SyncBackendFileTrioMixin {
 
       final created = await api.files.create(
         drive.File()
-          ..name = kSyncRootFolderName
+          ..name = _space.rootFolderName
           ..mimeType = 'application/vnd.google-apps.folder'
-          // TODO-836: 'appDataFolder' is the reserved alias for the App Data
-          // space root; this anchors the sync root inside the hidden space.
-          ..parents = ['appDataFolder'],
+          // parent 别名：appDataFolder（隐藏空间根）或 root（My Drive 根），把同步
+          // 根锚进当前空间（[GoogleDriveSyncSpace.rootParent]）。
+          ..parents = [_space.rootParent],
       );
       rootFolderIdCache = created.id!;
       return rootFolderIdCache!;
@@ -216,9 +234,9 @@ class GoogleDriveHandler with SyncFolderCache, SyncBackendFileTrioMixin {
 
       do {
         final list = await api.files.list(
-          // TODO-836: subqueries with `in parents` still default to the visible
-          // Drive space and return EMPTY in appDataFolder unless spaces is set.
-          spaces: 'appDataFolder',
+          // `in parents` 子查询默认落可见 Drive 空间，在 appDataFolder 里必须显式
+          // 带 spaces 否则返回空（[GoogleDriveSyncSpace]，TODO-836）。
+          spaces: _space.spaces,
           q: "trashed=false and '$q' in parents "
               "and mimeType='application/vnd.google-apps.folder'",
           $fields: 'nextPageToken,files(id,name)',
@@ -258,7 +276,7 @@ class GoogleDriveHandler with SyncFolderCache, SyncBackendFileTrioMixin {
 
     return _call((api) async {
       final list = await api.files.list(
-        spaces: 'appDataFolder', // TODO-836: search the App Data space.
+        spaces: _space.spaces, // [GoogleDriveSyncSpace]: 当前空间（appdata/drive）。
         q: "trashed=false and '$qRoot' in parents "
             "and mimeType='application/vnd.google-apps.folder' "
             "and name='$qName'",
@@ -306,7 +324,7 @@ class GoogleDriveHandler with SyncFolderCache, SyncBackendFileTrioMixin {
 
     return _call((api) async {
       final list = await api.files.list(
-        spaces: 'appDataFolder', // TODO-836: search the App Data space.
+        spaces: _space.spaces, // [GoogleDriveSyncSpace]: 当前空间（appdata/drive）。
         q: "trashed=false and '$qParent' in parents "
             "and mimeType='$_folderMimeType' "
             "and name='$qName'",
@@ -339,7 +357,7 @@ class GoogleDriveHandler with SyncFolderCache, SyncBackendFileTrioMixin {
 
       do {
         final list = await api.files.list(
-          spaces: 'appDataFolder', // TODO-836: search the App Data space.
+          spaces: _space.spaces, // [GoogleDriveSyncSpace]: 当前空间（appdata/drive）。
           q: "'$qParent' in parents and trashed=false",
           $fields: 'nextPageToken,files(id,name,mimeType,size)',
           pageSize: 1000,
@@ -388,7 +406,7 @@ class GoogleDriveHandler with SyncFolderCache, SyncBackendFileTrioMixin {
     final q = _escapeQuery(folderId);
     return _call((api) async {
       final list = await api.files.list(
-        spaces: 'appDataFolder', // TODO-836: search the App Data space.
+        spaces: _space.spaces, // [GoogleDriveSyncSpace]: 当前空间（appdata/drive）。
         q: "trashed=false and '$q' in parents "
             "and mimeType!='application/vnd.google-apps.folder'",
         $fields: 'files(id,name)',
@@ -651,7 +669,7 @@ class GoogleDriveHandler with SyncFolderCache, SyncBackendFileTrioMixin {
     final qName = _escapeQuery(fileName);
     return _call((api) async {
       final list = await api.files.list(
-        spaces: 'appDataFolder', // TODO-836: search the App Data space.
+        spaces: _space.spaces, // [GoogleDriveSyncSpace]: 当前空间（appdata/drive）。
         q: "trashed=false and '$qFolder' in parents and name='$qName'",
         $fields: 'files(id,name)',
       );

--- a/hibiki/lib/src/sync/google_drive_sync_backend.dart
+++ b/hibiki/lib/src/sync/google_drive_sync_backend.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 
 import 'package:hibiki/src/sync/google_drive_auth.dart';
 import 'package:hibiki/src/sync/google_drive_handler.dart';
+import 'package:hibiki/src/sync/google_drive_sync_space.dart';
 import 'package:hibiki/src/sync/sync_asset_store.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
@@ -55,6 +56,19 @@ class GoogleDriveSyncBackend extends SyncBackend {
 
   // ── Auth ──────────────────────────────────────────────────────────
 
+  /// 依「Hoshi 兼容模式」偏好把 Drive 存储空间 + scope 推给 auth/handler 两个
+  /// singleton。在每个拿得到 [repo] 的入口（authenticate / restoreAuth）先调用，
+  /// 确保任何 auth 或 Drive API 调用前 space 已正确——scope（google_sign_in 客户端
+  /// 构造时固定）与 spaces/根目录名都随之切换。[GoogleDriveSyncSpace.setSyncSpace]
+  /// 变更时会各自清缓存/丢弃旧客户端。
+  Future<void> _applySyncSpace(SyncRepository repo) async {
+    final space = GoogleDriveSyncSpace.fromHoshiCompat(
+      await repo.isGoogleDriveHoshiCompat(),
+    );
+    _auth.setSyncSpace(space);
+    _drive.setSyncSpace(space);
+  }
+
   @override
   Future<bool> get isAuthenticated => _auth.isAuthenticated;
 
@@ -63,7 +77,10 @@ class GoogleDriveSyncBackend extends SyncBackend {
 
   @override
   Future<void> authenticate({required SyncRepository repo}) =>
-      _wrapVoidErrors(() => _auth.authenticate(repo: repo));
+      _wrapVoidErrors(() async {
+        await _applySyncSpace(repo);
+        await _auth.authenticate(repo: repo);
+      });
 
   @override
   Future<void> signOut({required SyncRepository repo}) =>
@@ -71,6 +88,9 @@ class GoogleDriveSyncBackend extends SyncBackend {
 
   @override
   Future<bool> restoreAuth(SyncRepository repo) async {
+    // 恢复会话前先对齐存储空间/scope，否则移动端会用旧 space 的 scope 重建
+    // google_sign_in 客户端（BUG-047 修复路径依赖正确 scope）。
+    await _applySyncSpace(repo);
     // Mobile: rehydrate the google_sign_in session via signInSilently() instead
     // of the old no-op `return false`, which left the account row showing
     // "未登录"/no email and blocked auto-sync's isAuthenticated gate after a

--- a/hibiki/lib/src/sync/google_drive_sync_space.dart
+++ b/hibiki/lib/src/sync/google_drive_sync_space.dart
@@ -1,0 +1,73 @@
+import 'package:meta/meta.dart';
+
+import 'package:hibiki/src/sync/sync_utils.dart' show kSyncRootFolderName;
+
+/// ttu/Hoshi 共享同步的可见 Drive 根目录名。
+///
+/// 与 ッツ ebook-reader / Hoshi-Reader-Android 的 `ttu-reader-data` 逐字节一致：
+/// 两个 app 因此在用户可见的 My Drive 下落进**同一个**根文件夹，进度文件（都是
+/// `progress_1_6_*` 明文 JSON）得以互相读写。改这个字面量会立刻破坏与 Hoshi/ッツ
+/// 的互通，勿动。
+const String kTtuSharedRootFolderName = 'ttu-reader-data';
+
+/// Google Drive 同步的「存储空间 + OAuth scope」配置。
+///
+/// Hibiki 的 Drive 同步有两种物理落点，本类把两者收敛成一个不可变值对象，让
+/// [GoogleDriveAuth]（决定 scope）与 [GoogleDriveHandler]（决定 spaces / 根文件夹）
+/// 直接读字段，而不是在每个 `files.list` 调用点散落 `if (hoshiCompat)` 分支——
+/// 消除特例，两条路径共用同一套代码。
+///
+/// - [appData]：隐藏的、按 app 隔离的 App Data 空间（`drive.appdata` scope）。历史
+///   默认（TODO-836），别的 app 物理上看不到，老用户云端数据即落于此。
+/// - [ttuShared]：可见 My Drive（完整 `drive` scope）。与 Hoshi/ッツ 共享 `ttu-
+///   reader-data`。需要完整 scope 才能读到 **Hoshi 创建** 的文件——`drive.file`
+///   只能访问本 app 自己建的文件，看不到别的 OAuth client 建的。
+@immutable
+class GoogleDriveSyncSpace {
+  const GoogleDriveSyncSpace({
+    required this.id,
+    required this.scope,
+    required this.spaces,
+    required this.rootParent,
+    required this.rootFolderName,
+  });
+
+  /// 稳定标识（持久化 / 比较用）。
+  final String id;
+
+  /// OAuth scope。隐藏空间用 `drive.appdata`；可见共享用完整 `drive`。
+  final String scope;
+
+  /// `files.list` 的 `spaces` 参数（`appDataFolder` 或 `drive`）。子查询里
+  /// `'<id>' in parents` 在 App Data 空间必须显式带 `spaces`，否则默认落到可见
+  /// Drive 空间并返回空（TODO-836）。
+  final String spaces;
+
+  /// 根文件夹的 parent 别名：`appDataFolder`（隐藏空间根）或 `root`（My Drive 根）。
+  final String rootParent;
+
+  /// 同步根文件夹名。
+  final String rootFolderName;
+
+  /// 默认：隐藏 appDataFolder / `hibiki-data`。老用户云端数据原地不动。
+  static const GoogleDriveSyncSpace appData = GoogleDriveSyncSpace(
+    id: 'appdata',
+    scope: 'https://www.googleapis.com/auth/drive.appdata',
+    spaces: 'appDataFolder',
+    rootParent: 'appDataFolder',
+    rootFolderName: kSyncRootFolderName,
+  );
+
+  /// Hoshi/ッツ 共享：可见 My Drive / `ttu-reader-data` / 完整 `drive` scope。
+  static const GoogleDriveSyncSpace ttuShared = GoogleDriveSyncSpace(
+    id: 'ttu-shared',
+    scope: 'https://www.googleapis.com/auth/drive',
+    spaces: 'drive',
+    rootParent: 'root',
+    rootFolderName: kTtuSharedRootFolderName,
+  );
+
+  /// 由「Hoshi 兼容模式」开关（偏好 bool）解析出对应空间。
+  static GoogleDriveSyncSpace fromHoshiCompat(bool hoshiCompat) =>
+      hoshiCompat ? ttuShared : appData;
+}

--- a/hibiki/lib/src/sync/sync_repository.dart
+++ b/hibiki/lib/src/sync/sync_repository.dart
@@ -97,6 +97,10 @@ class SyncRepository {
   static const _keyCollectionsBaselineMs = 'sync_collections_baseline_ms';
   static const _keyDesktopCredentials = 'sync_desktop_credentials';
   static const _keyBackendType = 'sync_backend_type';
+  // 「与 Hoshi/ッツ 共享」开关：开启后 Google Drive 后端改用可见 My Drive /
+  // ttu-reader-data + 完整 drive scope（[GoogleDriveSyncSpace]）。属设备本地（改的是
+  // 本机 Drive 存储空间/scope），不随备份导入覆盖。
+  static const _keyGoogleDriveHoshiCompat = 'google_drive_hoshi_compat';
   static const _keySyncContent = 'sync_content_enabled';
   static const _keyWebDavUrl = 'sync_webdav_url';
   static const _keyWebDavUsername = 'sync_webdav_username';
@@ -189,6 +193,13 @@ class SyncRepository {
       _db.getPrefTyped<bool>(_keyAutoSync, false);
   Future<void> setAutoSyncEnabled(bool v) =>
       _db.setPrefTyped<bool>(_keyAutoSync, v);
+
+  /// 「与 Hoshi/ッツ 共享 Google Drive」开关。默认关（老用户云端数据留在隐藏
+  /// appDataFolder 原地不动）。
+  Future<bool> isGoogleDriveHoshiCompat() =>
+      _db.getPrefTyped<bool>(_keyGoogleDriveHoshiCompat, false);
+  Future<void> setGoogleDriveHoshiCompat(bool v) =>
+      _db.setPrefTyped<bool>(_keyGoogleDriveHoshiCompat, v);
 
   Future<int?> getLastSyncMs() async {
     final s = await _getStringOrNull(_keyLastSyncMs);
@@ -715,6 +726,7 @@ class SyncRepository {
   /// 这是"哪些 key 属于设备本地"的唯一真相源；备份导入只引用本清单，杜绝两处漂移。
   static const List<String> deviceLocalPrefKeys = <String>[
     _keyBackendType,
+    _keyGoogleDriveHoshiCompat,
     _keyDesktopCredentials,
     _keyOneDriveToken,
     _keyDropboxToken,

--- a/hibiki/lib/src/sync/sync_settings_schema.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema.dart
@@ -90,6 +90,33 @@ SettingsDestination buildSyncBackupDestination() {
             builder: (SettingsContext ctx) =>
                 _SyncAccountWidget(settingsContext: ctx),
           ),
+          // 「与 Hoshi/ッツ 共享 Google Drive」开关：仅 Google Drive 后端可见。开启后
+          // Drive 同步改用可见 My Drive / ttu-reader-data + 完整 drive scope，与
+          // Hoshi-Reader-Android / ッツ ebook-reader 落进同一云文件夹互相读写进度
+          // （[GoogleDriveSyncSpace]）。切换即换 scope（consent 时固定），必须登出重授权。
+          SettingsSwitchItem(
+            id: 'sync.google_drive_hoshi_compat',
+            title: t.sync_google_drive_hoshi_compat,
+            subtitle: t.sync_google_drive_hoshi_compat_desc,
+            icon: Icons.share_outlined,
+            visible: (SettingsContext ctx) =>
+                _syncSettings(ctx).backendType == SyncBackendType.googleDrive,
+            value: (SettingsContext ctx) =>
+                _syncSettings(ctx).googleDriveHoshiCompat,
+            onChanged: (SettingsContext ctx, bool value) async {
+              _syncSettings(ctx).googleDriveHoshiCompat = value;
+              final SyncRepository repo = SyncRepository(ctx.appModel.database);
+              await repo.setGoogleDriveHoshiCompat(value);
+              // 换存储空间 = 换 OAuth scope，旧授权覆盖不了新 scope。登出当前 Google
+              // 账号并清缓存，让下次登录/同步以新 space 的 scope 重新授权（复用与账号行
+              // 登出一致的 signOut + clearCache + clearFolderCache 序列）。
+              final SyncBackend backend =
+                  resolveSyncBackend(SyncBackendType.googleDrive);
+              await backend.signOut(repo: repo);
+              backend.clearCache();
+              await repo.clearFolderCache();
+            },
+          ),
           SettingsCustomItem(
             id: 'sync.webdav_config',
             icon: Icons.dns_outlined,
@@ -458,6 +485,9 @@ class _SyncSettingsState {
   final SyncRepository _repo;
   SyncBackendType backendType = SyncBackendType.googleDrive;
 
+  /// 「与 Hoshi/ッツ 共享 Google Drive」开关（仅 Google Drive 后端有效）。
+  bool googleDriveHoshiCompat = false;
+
   /// 互联总开关（独立于 [backendType] 云备份后端选择）。为 true 时互联作为一条独立
   /// 通道运行，与云备份并存（不再是互斥的 backendType==hibikiServer 单选）。
   bool interconnectEnabled = false;
@@ -518,6 +548,7 @@ class _SyncSettingsState {
     _loading = true;
     try {
       backendType = await _repo.getBackendType();
+      googleDriveHoshiCompat = await _repo.isGoogleDriveHoshiCompat();
       interconnectEnabled = await _repo.isInterconnectEnabled();
       autoSync = await _repo.isAutoSyncEnabled();
       syncStats = await _repo.isSyncStatsEnabled();

--- a/hibiki/test/sync/google_drive_source_guards_test.dart
+++ b/hibiki/test/sync/google_drive_source_guards_test.dart
@@ -2,21 +2,25 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// TODO-836 Google Drive source-scan guards（合并自
-/// google_drive_appdata_guard_test.dart + google_drive_scope_guard_test.dart；
-/// 断言逐字搬运，每条保持独立 test()）。
+/// Google Drive 存储空间 source-scan 守卫。
+///
+/// 历史（TODO-836）：同步根从可见 Drive 搬进隐藏 appDataFolder，每个 `files.list`
+/// 必须显式带 `spaces`，否则子查询默认落回可见 Drive、静默返回空。
+///
+/// 现状（Hoshi 兼容）：Drive 同步支持两种存储空间 [GoogleDriveSyncSpace]——默认隐藏
+/// appDataFolder（`drive.appdata`），开「与 Hoshi/ッツ 共享」后走可见 My Drive /
+/// `ttu-reader-data`（完整 `drive`）。空间/scope/根目录名不再硬编码字面量，而是统一从
+/// `_space` 字段取。这些守卫因此从「必须硬编码 appDataFolder」改为「必须始终把空间
+/// 显式接到 `_space`，绝不遗漏、绝不写死单一空间」——原来的安全意图（`spaces` 绝不能
+/// 缺省）完整保留，只是值变成动态的。
 void main() {
-  /// TODO-836 HARD GUARD: after the sync root moved to the hidden appDataFolder
-  /// space, EVERY `api.files.list(...)` call MUST pass `spaces: 'appDataFolder'`.
-  /// Drive's files.list defaults to `spaces=drive` (the visible Drive); a subquery
-  /// with `'<folderId>' in parents` does NOT auto-follow the parent into the
-  /// appdata space — without an explicit spaces it returns an EMPTY result with NO
-  /// error (a silent data-loss regression worse than the original 403). Missing it
-  /// on even one call breaks that data link, so we assert per-block.
-  group('appDataFolder space pins (google_drive_handler.dart)', () {
+  /// HARD GUARD: 每个 `api.files.list(...)` 仍必须显式传 `spaces`，且值必须是
+  /// `_space.spaces`（不是写死的 'appDataFolder'/'drive'）。缺省 → appData 模式静默
+  /// 返回空；写死单一空间 → Hoshi 兼容模式打错空间。
+  group('space-field pins (google_drive_handler.dart)', () {
     final File handler = File('lib/src/sync/google_drive_handler.dart');
 
-    test('every api.files.list( call passes spaces: \'appDataFolder\'', () {
+    test('every api.files.list( call passes spaces: _space.spaces', () {
       expect(handler.existsSync(), isTrue,
           reason: 'run from the hibiki/ package root');
       final String src = handler.readAsStringSync();
@@ -44,34 +48,81 @@ void main() {
 
       expect(blocks.length, 7,
           reason: 'expected exactly 7 files.list calls in the handler; if this '
-              'changed, audit each new call for spaces: appDataFolder');
+              'changed, audit each new call for spaces: _space.spaces');
 
       final List<int> missing = <int>[];
       for (int b = 0; b < blocks.length; b++) {
-        if (!blocks[b].contains("spaces: 'appDataFolder'")) missing.add(b);
+        if (!blocks[b].contains('spaces: _space.spaces')) missing.add(b);
       }
       expect(missing, isEmpty,
           reason: 'files.list block(s) at index $missing lack '
-              "spaces: 'appDataFolder' → would silently query the visible "
-              'Drive and return empty in the appdata space (TODO-836)');
+              'spaces: _space.spaces → would either silently query the visible '
+              'Drive in appData mode or hit the wrong space in Hoshi-compat mode '
+              '(TODO-836 / GoogleDriveSyncSpace)');
     });
 
-    test('the sync root is created under the appDataFolder space alias', () {
+    test('no files.list hardcodes a single space literal', () {
       final String src = handler.readAsStringSync();
-      expect(src.contains("..parents = ['appDataFolder']"), isTrue,
-          reason: 'findOrCreateRootFolder must anchor the root in the App Data '
-              'space (parents=[appDataFolder]) (TODO-836)');
+      // The migration to a dynamic space is only complete when NO call still
+      // pins a literal space — a leftover literal would ignore the toggle.
+      expect(src.contains("spaces: 'appDataFolder'"), isFalse,
+          reason: 'hardcoded appDataFolder ignores the Hoshi-compat toggle; '
+              'use _space.spaces (GoogleDriveSyncSpace)');
+      expect(src.contains("spaces: 'drive'"), isFalse,
+          reason: 'hardcoded drive space ignores appData mode; '
+              'use _space.spaces (GoogleDriveSyncSpace)');
+    });
+
+    test('the sync root is created under the space parent alias', () {
+      final String src = handler.readAsStringSync();
+      expect(src.contains('..parents = [_space.rootParent]'), isTrue,
+          reason: 'findOrCreateRootFolder must anchor the root in the current '
+              'space (parents=[_space.rootParent]), not a hardcoded alias');
+      expect(src.contains("..parents = ['appDataFolder']"), isFalse,
+          reason: 'hardcoded appDataFolder parent ignores the Hoshi-compat '
+              'toggle (GoogleDriveSyncSpace)');
+      expect(src.contains('name = _space.rootFolderName'), isTrue,
+          reason: 'the root folder name must come from the space '
+              '(hibiki-data vs ttu-reader-data), not a hardcoded literal');
     });
   });
 
-  /// TODO-836: sync data moved from the user-visible Drive (drive.file) into the
-  /// hidden, app-private appDataFolder space (drive.appdata), so the root-folder
-  /// name lookup is no longer a cross-app query that Google rejects with 403
-  /// insufficient_scope. These source-scan guards pin the migration:
-  ///   - the app requests drive.appdata,
-  ///   - it no longer requests the visible-Drive scope (no `auth/drive.file`),
-  ///   - mobile and desktop request the SAME Drive scope (else云数据落不同空间).
-  group('drive.appdata scope pins (google_drive_auth.dart)', () {
+  /// 两种空间的 scope / 空间别名 / 根目录名的真值源，逐字段守死。
+  ///   - appData：drive.appdata / appDataFolder / hibiki-data（老用户数据原地）。
+  ///   - ttuShared：完整 drive / drive / ttu-reader-data（与 Hoshi/ッツ 共享）。
+  group('sync space definitions (google_drive_sync_space.dart)', () {
+    final File spaceFile = File('lib/src/sync/google_drive_sync_space.dart');
+
+    String source() {
+      expect(spaceFile.existsSync(), isTrue,
+          reason: 'run from the hibiki/ package root');
+      return spaceFile.readAsStringSync();
+    }
+
+    test('declares both the appdata and full-drive scopes', () {
+      final String s = source();
+      expect(s.contains('https://www.googleapis.com/auth/drive.appdata'), isTrue,
+          reason: 'appData space must keep the hidden drive.appdata scope');
+      expect(s.contains("'https://www.googleapis.com/auth/drive'"), isTrue,
+          reason: 'ttuShared must request full drive to read Hoshi-created '
+              'files (drive.file only sees files this app created)');
+    });
+
+    test('never falls back to the visible drive.file scope', () {
+      expect(source().contains('auth/drive.file'), isFalse,
+          reason: 'drive.file cannot see files another OAuth client (Hoshi) '
+              'created, so it can never interop — full drive is required');
+    });
+
+    test('pins the shared root folder name ttu-reader-data', () {
+      expect(source().contains("'ttu-reader-data'"), isTrue,
+          reason: 'the shared visible-Drive root MUST byte-match Hoshi/ッツ');
+    });
+  });
+
+  /// auth 侧接线：scope 不再硬编码，统一取自 `_space.scope`；移动端与桌面端因此天然
+  /// 用同一个 scope（云数据落同一空间）。可见-Drive 的 drive.file 仍必须缺席。
+  group('auth scope wiring (google_drive_auth.dart)', () {
     final File authFile = File('lib/src/sync/google_drive_auth.dart');
 
     String source() {
@@ -80,35 +131,24 @@ void main() {
       return authFile.readAsStringSync();
     }
 
-    test('requests the drive.appdata scope', () {
-      expect(source().contains('https://www.googleapis.com/auth/drive.appdata'),
-          isTrue,
-          reason: 'sync root must live in the appDataFolder space (TODO-836)');
-    });
-
     test('no longer requests the visible-Drive drive.file scope', () {
       expect(source().contains('auth/drive.file'), isFalse,
-          reason:
-              'drive.file forced the whole-Drive root lookup → 403 insufficient_scope; '
-              'it must be fully removed, not left dangling (TODO-836)');
+          reason: 'drive.file forced the whole-Drive root lookup → 403; and it '
+              'cannot read Hoshi files. Must stay removed (TODO-836)');
     });
 
-    test(
-        'mobile (scopes:) and desktop (auth URL scope:) request the same '
-        'Drive scope — both drive.appdata', () {
+    test('mobile and desktop both derive the Drive scope from _space.scope', () {
       final String s = source();
-      // Mobile: GoogleSignIn(scopes: [_driveAppdataScope])
-      expect(RegExp(r'scopes:\s*\[_driveAppdataScope\]').hasMatch(s), isTrue,
-          reason: 'mobile sign-in must request drive.appdata');
-      // Desktop PKCE auth URL: scope: [_driveAppdataScope, _emailScope]
-      expect(
-          RegExp(r"'scope':\s*\[_driveAppdataScope,\s*_emailScope\]")
-              .hasMatch(s),
-          isTrue,
-          reason: 'desktop auth URL must request drive.appdata (+ email)');
-      // The old visible-Drive scope symbol must be gone entirely.
-      expect(s.contains('_driveFileScope'), isFalse,
-          reason: 'the drive.file scope constant must be removed (TODO-836)');
+      // Mobile: GoogleSignIn(scopes: [_space.scope])
+      expect(RegExp(r'scopes:\s*\[_space\.scope\]').hasMatch(s), isTrue,
+          reason: 'mobile sign-in must request the current space scope');
+      // Desktop PKCE auth URL passes scope: _space.scope down into the builder.
+      expect(s.contains('scope: _space.scope'), isTrue,
+          reason: 'desktop auth URL must request the current space scope');
+      // The old single-mode hardcoded scope constant must be gone.
+      expect(s.contains('_driveAppdataScope'), isFalse,
+          reason: 'scope is now sourced from GoogleDriveSyncSpace, not a '
+              'hardcoded _driveAppdataScope constant');
     });
   });
 }

--- a/hibiki/test/sync/google_drive_sync_space_test.dart
+++ b/hibiki/test/sync/google_drive_sync_space_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/google_drive_sync_space.dart';
+import 'package:hibiki/src/sync/sync_utils.dart' show kSyncRootFolderName;
+
+/// 守卫 Google Drive 两种存储空间的关键契约。
+///
+/// Hoshi 兼容互通的成立完全依赖 [GoogleDriveSyncSpace.ttuShared] 这几个字段精确：
+/// 完整 `drive` scope（才能读 Hoshi 建的文件）、可见 `drive` 空间、`root` parent、
+/// 根目录名 `ttu-reader-data`（与 Hoshi/ッツ 逐字节一致）。默认 [appData] 必须仍是
+/// 隐藏 appDataFolder / `hibiki-data`，否则老用户云端数据被悄悄换了物理落点。
+void main() {
+  group('GoogleDriveSyncSpace.appData (默认，隐藏空间)', () {
+    const space = GoogleDriveSyncSpace.appData;
+
+    test('用 drive.appdata scope（app 私有隐藏空间）', () {
+      expect(space.scope, 'https://www.googleapis.com/auth/drive.appdata');
+    });
+
+    test('spaces / rootParent 都是 appDataFolder', () {
+      expect(space.spaces, 'appDataFolder');
+      expect(space.rootParent, 'appDataFolder');
+    });
+
+    test('根目录名沿用 hibiki-data（老用户云端数据原地不动）', () {
+      expect(space.rootFolderName, 'hibiki-data');
+      expect(space.rootFolderName, kSyncRootFolderName);
+    });
+  });
+
+  group('GoogleDriveSyncSpace.ttuShared (Hoshi/ッツ 共享)', () {
+    const space = GoogleDriveSyncSpace.ttuShared;
+
+    test('用完整 drive scope（才能读 Hoshi 建的文件，drive.file 不够）', () {
+      expect(space.scope, 'https://www.googleapis.com/auth/drive');
+      // 绝不能退回只读或 drive.file——那样看不到 Hoshi 创建的进度文件。
+      expect(space.scope, isNot(contains('drive.file')));
+      expect(space.scope, isNot(contains('readonly')));
+      expect(space.scope, isNot(contains('appdata')));
+    });
+
+    test('落可见 My Drive：spaces=drive, parent=root', () {
+      expect(space.spaces, 'drive');
+      expect(space.rootParent, 'root');
+    });
+
+    test('根目录名 = ttu-reader-data（与 Hoshi/ッツ 同文件夹）', () {
+      expect(space.rootFolderName, 'ttu-reader-data');
+      expect(space.rootFolderName, kTtuSharedRootFolderName);
+    });
+  });
+
+  group('fromHoshiCompat 开关映射', () {
+    test('关 → appData（隐藏空间）', () {
+      expect(GoogleDriveSyncSpace.fromHoshiCompat(false).id,
+          GoogleDriveSyncSpace.appData.id);
+    });
+
+    test('开 → ttuShared（共享可见 Drive）', () {
+      expect(GoogleDriveSyncSpace.fromHoshiCompat(true).id,
+          GoogleDriveSyncSpace.ttuShared.id);
+    });
+
+    test('两种空间的 id 稳定且互异（持久化/比较用）', () {
+      expect(GoogleDriveSyncSpace.appData.id, 'appdata');
+      expect(GoogleDriveSyncSpace.ttuShared.id, 'ttu-shared');
+    });
+  });
+}

--- a/hibiki/test/sync/sync_settings_visibility_test.dart
+++ b/hibiki/test/sync/sync_settings_visibility_test.dart
@@ -53,6 +53,7 @@ void main() {
       expect(idsOf(dest.sections[0]), <String>[
         'sync.mode',
         'sync.account_status',
+        'sync.google_drive_hoshi_compat',
         'sync.webdav_config',
         'sync.ftp_config',
         'sync.sftp_config',
@@ -65,6 +66,8 @@ void main() {
           method.items.firstWhere((SettingsItem i) => i.id == id);
       expect(byId('sync.mode').visible, isNull);
       expect(byId('sync.account_status').visible, isNotNull);
+      // Hoshi 兼容开关只在 Google Drive 后端可见（切换存储空间/scope）。
+      expect(byId('sync.google_drive_hoshi_compat').visible, isNotNull);
     });
 
     test('content / actions / backup groups remain global', () {

--- a/hibiki/test/sync/ttu_hoshi_interop_parity_test.dart
+++ b/hibiki/test/sync/ttu_hoshi_interop_parity_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/ttu_filename.dart';
+
+/// Hoshi/ッツ 互通逐字节守卫。
+///
+/// 与 Hoshi-Reader-Android 共享同一个可见 Google Drive `ttu-reader-data` 文件夹时，
+/// 一本书的云端文件夹名 = `sanitizeTtuFilename(书名)`，进度文件名 =
+/// `progress_1_6_<ts>_<progress>.json`。只要两端对这两个函数的输出有一个字节不同，
+/// 同一本书就会落进不同文件夹 / 选不到对方最新进度文件，互通静默失效。
+///
+/// 下列断言值直接抄自 Hoshi 源码的 `TtuSyncRulesTest.kt`
+/// （`sanitizeTtuFilenameMatchesIosAndTtuRules` 与 progress 文件名断言），是 Hoshi /
+/// ッツ web / iOS 三端共用的参考实现。改 [sanitizeTtuFilename] / [progressFileName]
+/// 若动到这些输出即视为破坏互通契约，本测试会红。
+void main() {
+  group('Hoshi/ッツ sanitize byte-parity', () {
+    test('trailing space marker matches Hoshi', () {
+      expect(sanitizeTtuFilename('Book '), 'Book~ttu-spc~');
+    });
+
+    test('trailing dot marker matches Hoshi', () {
+      expect(sanitizeTtuFilename('Book.'), 'Book~ttu-dend~');
+    });
+
+    test('full mixed vector matches Hoshi TtuSyncRulesTest verbatim', () {
+      // Hoshi: sanitizeTtuFilename("a*b/c?d<e>f\\g:h|i%j\"k")
+      expect(
+        sanitizeTtuFilename('a*b/c?d<e>f\\g:h|i%j"k'),
+        'a~ttu-star~b%2Fc%3Fd%3Ce%3Ef%5Cg%3Ah%7Ci%25j%22k',
+      );
+    });
+
+    test('every reserved char maps to uppercase percent-encoding', () {
+      // The complete reserved set Hoshi percent-encodes (`*` handled earlier as
+      // ~ttu-star~): / ? < > \ : | % "
+      expect(sanitizeTtuFilename('/'), '%2F');
+      expect(sanitizeTtuFilename('?'), '%3F');
+      expect(sanitizeTtuFilename('<'), '%3C');
+      expect(sanitizeTtuFilename('>'), '%3E');
+      expect(sanitizeTtuFilename('\\'), '%5C');
+      expect(sanitizeTtuFilename(':'), '%3A');
+      expect(sanitizeTtuFilename('|'), '%7C');
+      expect(sanitizeTtuFilename('%'), '%25');
+      expect(sanitizeTtuFilename('"'), '%22');
+    });
+  });
+
+  group('Hoshi/ッツ progress file name parity', () {
+    test('progress_1_6 template matches Hoshi verbatim', () {
+      // Hoshi: progressFileName(TtuProgress(lastBookmarkModified=1700000123456,
+      // progress=0.375, ...)) == "progress_1_6_1700000123456_0.375.json"
+      expect(
+        progressFileName(1700000123456, 0.375),
+        'progress_1_6_1700000123456_0.375.json',
+      );
+    });
+
+    test('audioBook_1_6 template shares the same schema marker', () {
+      expect(
+        audioBookFileName(1700000123456, 12.5),
+        'audioBook_1_6_1700000123456_12.5.json',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 目标
让 Hibiki 能与原版 **Hoshi-Reader-Android**（及 ッツ ebook-reader）**互相同步阅读进度**，本地数据存储位置零改动。

## 背景核对（拉 Hoshi 源码逐点对照）
Hoshi 的进度同步是克隆 ッツ 的 Google Drive 格式。协议层两端**本就同源兼容**：
- 进度 JSON `{dataId, exploredCharCount, progress, lastBookmarkModified}` 逐字段一致；
- 进度文件名 `progress_1_6_<ts>_<progress>.json` 模板一致；
- 一本书 = 文件夹，名 = `sanitizeTtuFilename(书名)`，转义方案（`~ttu-spc~`/`~ttu-dend~`/`~ttu-star~`/`%XX`）逐字节一致；
- `exploredCharCount` 语义（code-point + ttu 可读字符集 + 按 spine 累计）同源。

**真正对不上的是物理落点**（Hoshi 侧证据 `GoogleDriveClient.kt` / `TtuSyncRules.kt`）：
| 硬点 | Hoshi | Hibiki(旧) |
|---|---|---|
| Drive 空间 | 可见 My Drive | 隐藏 appDataFolder（按 app 隔离，互不可见） |
| 根目录名 | `ttu-reader-data` | `hibiki-data` |
| 后端 | 只有 Google Drive | 7 种 |

## 方案（全局开关，additive，不迁移）
新增偏好开关 **「与 Hoshi/ッツ 共享 Google Drive」**（仅 Google Drive 后端可见）：
- **开**：Drive 同步走可见 My Drive / `ttu-reader-data` + 完整 `drive` scope，与 Hoshi 落进同一文件夹互读进度。
- **关（默认）**：保持隐藏 appDataFolder / `hibiki-data`——老用户云端数据原地不动。
- 本地 `hibiki.db` 位置零改动。

### 关键设计
- `GoogleDriveSyncSpace` 值对象把「存储空间 + scope」两模式收敛，消除 handler 里散落的 `spaces:'appDataFolder'` 硬编码分支（7 处 `files.list` + 根目录锚定）。
- OAuth scope 由 `_space.scope` 派生（`drive.appdata` ↔ 完整 `drive`），移动/桌面两端天然同 scope。切换开关登出重授权（scope 在 consent 时固定，refresh 加不了 scope）。
- 偏好 `google_drive_hoshi_compat` 归入 `deviceLocalPrefKeys`（改的是本机 Drive 空间/scope，不随备份导入覆盖）。

## 已知限制
- 内容文件（epub/封面）在共享模式仍被 `ObfuscatingSyncBackend` XOR 混淆，对 Hoshi 是乱码——**不影响明文进度 JSON 互读**（本次目标仅进度同步）。
- 完整 `drive` 是 Google **受限 scope**：需在 Google Cloud Console 同意屏幕加该 scope 并过审核（用户已接受此代价）。代码就绪，真机跑通以此为前提。

## 守卫测试
- `ttu_hoshi_interop_parity_test`：sanitize / 文件名向量**逐字节抄自 Hoshi `TtuSyncRulesTest.kt`**。
- `google_drive_sync_space_test`：两空间 scope/spaces/root 字段契约（ttuShared 必须完整 drive、绝不 drive.file/readonly）。
- `google_drive_source_guards_test`：从「必须硬编码 appDataFolder」**升级为**「必须始终接 `_space`、绝不遗漏/写死单一空间」，保留 `spaces` 绝不缺省的原安全意图。

## 验证
- `flutter analyze`：clean（全量）。
- `flutter test test/i18n/ test/sync/`：1508 通过。
- ⏳ 真机 Drive 交叉写入同一 `ttu-reader-data` 验证：待 Google Cloud Console 配好受限 scope 后进行。

https://claude.ai/code/session_01JCaSvfD7HACQUcXHwCBMwW