### PR TITLE
fix(stats): BUG-970 统计页目标设置入口恒驻顶栏

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 949 条。点号进各自文件。
+> 共 950 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-970](bugs/BUG-970-reading-goal-first-set-no-entry.md) | ✅ | ✅ | 统计页每日/每周目标从未设置时无任何设置入口 |
 | [BUG-968](bugs/BUG-968-audiobook-export-text-audio.md) | ✅ | ✅ | 有声书片段导出文字与选区不符且移动端缺少音频 |
 | [BUG-967](bugs/BUG-967-reader-context-menu-stack.md) | ✅ | ✅ | Windows 查词弹窗后右键菜单位于底层且重复累加 |
 | [BUG-966](bugs/BUG-966-subtitle-list-mining-audio.md) | ✅ | ✅ | 字幕列表点词查词制卡音频截错句(锚到播放位置而非被点cue) |

--- a/docs/bugs/BUG-970-reading-goal-first-set-no-entry.md
+++ b/docs/bugs/BUG-970-reading-goal-first-set-no-entry.md
@@ -1,0 +1,6 @@
+## BUG-970 · 统计页每日/每周目标从未设置时无任何设置入口
+- **报告**：2026-07-21（用户：）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/reading_statistics_page.dart:649-651` —— `_buildGoalPanel()` 在 `dailyGoal <= 0 && weeklyGoal <= 0` 时 `return const SizedBox.shrink()`，整块目标卡（含右上唯一的 `Icons.edit` 编辑入口 line 682-686）一起隐藏；而调 `_editGoals()` 的入口**只存在于该卡内部**（全文件仅 line 685 一处调用），页面顶栏 actions（line 352-364）只有刷新/清空。结果：全新安装、从未设过目标的用户，卡片不渲染 → 无任何 UI 能首次设置目标（先有鸡还是先有蛋）。TODO-1046 的「零视觉变化」意图把设置入口本身也一并藏没了。
+- **[x] ① 已修复** —— 把目标设置入口提到页面顶栏 `HibikiPageScaffold.actions`（`Icons.flag_outlined`，tooltip 复用现成 `t.stat_goal_set`，`onTap: _editGoals`），与刷新/清空并列，**不受目标是否为 0 影响，始终可见**。目标卡仍保持两目标皆 0 时 `SizedBox.shrink()`（不破坏 TODO-1046 的零视觉变化红线）与卡内快捷 `Icons.edit`。提交见分支 `worktree-reading-goal-entry-bug970`。
+- **[x] ② 已加自动化测试** —— `hibiki/test/pages/reading_statistics_goal_card_static_test.dart` 新增守卫：顶栏 actions 含 `Icons.flag_outlined` + `onTap: _editGoals` 的目标入口，且该入口位于 scaffold `actions`（`body:` 之前），不被任何 `dailyGoal`/`weeklyGoal` 条件包裹 —— 坐实首次设置入口恒可达。
+- **备注**：复用 `stat_goal_set` 文案，不新增 i18n key。

--- a/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
@@ -328,6 +328,15 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     return HibikiPageScaffold(
       title: t.reading_statistics,
       actions: <Widget>[
+        // BUG-970：目标设置入口恒驻顶栏——目标卡在两目标皆 0 时整块隐藏
+        // (_buildGoalPanel -> SizedBox.shrink)，卡内 edit 图标随之消失，
+        // 否则从未设过目标的用户没有任何 UI 能首次设置目标。
+        HibikiIconButton(
+          icon: Icons.flag_outlined,
+          tooltip: t.stat_goal_set,
+          enabled: !_loading,
+          onTap: _editGoals,
+        ),
         HibikiIconButton(
           icon: Icons.refresh,
           tooltip: t.stat_refresh,

--- a/hibiki/test/pages/reading_statistics_goal_card_static_test.dart
+++ b/hibiki/test/pages/reading_statistics_goal_card_static_test.dart
@@ -77,4 +77,32 @@ void main() {
     expect(text.contains('setState(() {})'), isTrue,
         reason: '写 pref 后 setState 即时刷新卡片');
   });
+
+  test('BUG-970: goal-set entry lives in the page top bar, always reachable',
+      () {
+    final String text = src.readAsStringSync();
+    // 目标卡在两目标皆 0 时整块隐藏（上一个测试的 never-break 红线），因此设置
+    // 入口必须常驻页面顶栏 actions，否则从未设过目标的用户无法首次设置。守卫：
+    //   1) 顶栏有 flag 图标按钮，onTap 直接调 _editGoals；
+    //   2) 该按钮位于 scaffold actions（在 body: 之前）；
+    //   3) 顶栏入口不被任何 dailyGoal/weeklyGoal 条件包裹（恒可见）。
+    final int actionsIdx = text.indexOf('actions: <Widget>[');
+    expect(actionsIdx, greaterThanOrEqualTo(0),
+        reason: '页面应有 scaffold actions');
+    final int bodyIdx = text.indexOf('body: _loading', actionsIdx);
+    expect(bodyIdx, greaterThan(actionsIdx), reason: '应能定位 actions 与 body 边界');
+
+    final String actionsRegion = text.substring(actionsIdx, bodyIdx);
+    expect(actionsRegion.contains('icon: Icons.flag_outlined'), isTrue,
+        reason: '顶栏应有 flag 目标设置图标按钮');
+    expect(actionsRegion.contains('onTap: _editGoals'), isTrue,
+        reason: '顶栏目标按钮应直接调 _editGoals');
+    expect(actionsRegion.contains('tooltip: t.stat_goal_set'), isTrue,
+        reason: '顶栏目标按钮复用 stat_goal_set 文案');
+    // 恒可见：顶栏 actions 区域内不得出现目标数值的门控条件。
+    expect(actionsRegion.contains('dailyGoal'), isFalse,
+        reason: '顶栏目标入口不得被 dailyGoal 条件门控');
+    expect(actionsRegion.contains('weeklyGoal'), isFalse,
+        reason: '顶栏目标入口不得被 weeklyGoal 条件门控');
+  });
 }


### PR DESCRIPTION
## 问题（真 bug）
阅读统计页的「每日/每周目标」设置入口（铅笔图标）**只存在于目标卡内部**。而目标卡在两目标皆 0 时整块 `SizedBox.shrink()` 隐藏（TODO-1046 的「零视觉变化」）。结果：**全新安装、从未设过目标的用户，卡片不渲染 → 没有任何 UI 能首次设置目标**（先有鸡还是先有蛋）。页面顶栏只有刷新/清空。

根因：`hibiki/lib/src/pages/implementations/reading_statistics_page.dart:649-651`（卡片隐藏）+ 全文件仅 line 685 一处调 `_editGoals()`。

## 修复
把目标设置入口提到 `HibikiPageScaffold.actions`（`Icons.flag_outlined`，tooltip 复用现成 `t.stat_goal_set`，`onTap: _editGoals`），与刷新/清空并列，**不受目标数值门控，始终可见**。

- 目标卡仍保持两目标皆 0 时 `SizedBox.shrink()` —— **不破坏 TODO-1046 零视觉变化红线**；卡内 `Icons.edit` 快捷入口保留。
- 不新增 i18n key（复用 `stat_goal_set`）。

## 测试
`test/pages/reading_statistics_goal_card_static_test.dart` 新增源码 wiring 守卫：顶栏 actions 含 `Icons.flag_outlined` + `onTap: _editGoals`，位于 `body:` 之前，且不被 `dailyGoal`/`weeklyGoal` 条件包裹。全 5 测试通过；改动文件 `flutter analyze` 干净。

## 待验收
真机目视：进入阅读统计页 → 顶栏出现 flag 图标 → 点击弹出目标设置对话框 → 填数字保存 → 目标卡出现。

https://claude.ai/code/session_019m75mkUjXP9tvH5AdMdjYM