### PR TITLE
chore(galgame): voice-hook helper 仓库更名 → hibiki-hook

### DIFF
--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -74,19 +74,19 @@ Flutter 3.44.0 下部分上游依赖未适配，两种补法并存（对个别�
 
 galgame 一键制卡的引擎-hook 注入器（injector.exe + hook.dll + vendored LunaHook/Host DLL）含
 `CreateRemoteThread`/`WriteProcessMemory`，**必被杀软报毒**，故与 `hibiki.exe` **物理隔离**——
-**源码与 workflow 已完全迁到独立仓库 [`hajisensai/hibiki-voice-hook`](https://github.com/hajisensai/hibiki-voice-hook)**
+**源码与 workflow 已完全迁到独立仓库 [`hajisensai/hibiki-hook`](https://github.com/hajisensai/hibiki-hook)**
 （原 `native/galgame_voice_hook` + `.github/workflows/voice-hook-helper.yml` 已从本仓库移除）。
 连注入源码都不在主仓库，绝不进主 app 安装包（维持主包分发口碑）。
 
-- **构建/发布**：在 **hibiki-voice-hook 仓库**里 workflow `voice-hook-helper.yml`，**仅手动**
+- **构建/发布**：在 **hibiki-hook 仓库**里 workflow `voice-hook-helper.yml`，**仅手动**
   `workflow_dispatch`（windows-2022；该 workflow 在其**默认分支 main** 上，故可正常 dispatch——
   这正是迁出独立仓库的根因：主仓库那份不在默认分支，GitHub 不暴露 dispatch 入口，release 从没被产出过）。
   cmake 编 x64（`-A x64`）+ x86（`-A Win32`），每架构打 `voice_hook_<arch>.zip`（injector/hook/
   LunaHook/LunaHost）+ `.sha256` 侧车，`softprops/action-gh-release@v3` upsert 到**固定 tag
   `voice-hook-helper`** 的 **prerelease、`make_latest: false`**。
 - **稳定下载 URL**（按 tag 而非 run 号，指向**独立仓库**；app 端 slug 为
-  `kGalgameHelperRepo = 'hajisensai/hibiki-voice-hook'`）：
-  `https://github.com/hajisensai/hibiki-voice-hook/releases/download/voice-hook-helper/voice_hook_<arch>.zip`（+ `.sha256`）。
+  `kGalgameHelperRepo = 'hajisensai/hibiki-hook'`）：
+  `https://github.com/hajisensai/hibiki-hook/releases/download/voice-hook-helper/voice_hook_<arch>.zip`（+ `.sha256`）。
 - **app 端按需下载**：开 galgame 需要注入器却缺失时，`GalgameHelperInstaller`（`hibiki/lib/src/mining/
   galgame_helper_installer.dart`）弹确认对话框（标大小）→ 下载对应架构 zip（走系统代理 + gh 镜像回退
   + sha256 校验）→ 解压到 `<app目录>\voice_hook\<arch>\` → 继续启动。幂等：已存在跳过。

--- a/docs/specs/galgame-mining/engine-adapter-plan.md
+++ b/docs/specs/galgame-mining/engine-adapter-plan.md
@@ -6,7 +6,7 @@
 > 等成熟的沉浸学习工具同类，属正常语言学习用途。本文只讨论如何把"新增一个游戏引擎的适配成本"降下来。
 >
 > 面向接手的 AI/开发者，**自包含**。总设计见 [design.md](design.md)，已完成进度与真机证据见 [handoff.md](handoff.md)。
-> 一句话目标：在 **hibiki-voice-hook**（native 采集组件）与 **hibiki**（Dart 消费端）两仓之间，建立
+> 一句话目标：在 **hibiki-hook**（native 采集组件）与 **hibiki**（Dart 消费端）两仓之间，建立
 > 数据驱动 + 模块化 + 可诊断 + 可离线验证的引擎适配体系，把"新增一个引擎"从"改 2666 行巨型
 > `dll_main.cpp` / 从零调查"降到"加 profile + 独立 adapter + fixture"，并完成至少一批高复用适配
 > （RealLive / VisualArt's）作为验证。**核心不是承诺"支持所有引擎"，而是显著降低新增成本并落一批验证。**
@@ -42,7 +42,7 @@ P0 (真相源) ──► P1 (拆 adapter) ──┬─► P3 (probe/new/replay �
 
 ## 0. 开工前必读 & 纪律（指针，不重复）
 - hibiki 侧：读根 `CLAUDE.md` + `hibiki/CLAUDE.md` + 本目录 `design.md` / `handoff.md` + `docs/agent/build.md`。
-  native 侧：读 hibiki-voice-hook 仓的 README + CMake。
+  native 侧：读 hibiki-hook 仓的 README + CMake。
 - 两仓都用**独立 worktree/分支**；hibiki 侧新建 worktree 后先跑 `tool/setup_worktree.ps1`，并在
   `.worktrees/coordination/claims/` 登记 ownership。不覆盖用户或其它 agent 的未提交改动。
 - **根因修复**，不做延迟/重试/吞异常/硬编码/特例分支式绕过；只有外部/平台限制才允许临时兼容层并说明清理条件。
@@ -55,15 +55,15 @@ P0 (真相源) ──► P1 (拆 adapter) ──┬─► P3 (probe/new/replay �
 ## 1. 当前真相（已核实 @ 2026-07-21，origin/develop；接手前提，先信这些再动手）
 
 ### 【两仓架构 —— 最重要】
-- native 采集组件已在 commit `d53e1238d`「voice hook helper 完全迁移到独立仓库 hibiki-voice-hook」
-  **从 hibiki 单仓整体迁出到独立仓 `hajisensai/hibiki-voice-hook`**，理由有二：
+- native 采集组件已在 commit `d53e1238d`「voice hook helper 完全迁移到独立仓库 hibiki-hook」
+  **从 hibiki 单仓整体迁出到独立仓 `hajisensai/hibiki-hook`**，理由有二：
   1. 该组件随游戏进程加载做文本/音频采集，部分杀软对这类"随进程加载的采集模块"存在误报，物理隔离到独立仓
      可与主 app 分开构建/分发、降低对主 app 的误报牵连；
   2. 独立仓默认分支上的 `voice-hook-helper.yml` 才能正常 `workflow_dispatch` 刷新 release（主仓那份不在
      默认分支无法 dispatch）。
 - **因此：原始设想里要拆的"巨型主流程" `native/galgame_voice_hook/hook/dll_main.cpp`（~2666 行）现在在
-  hibiki-voice-hook，不在 hibiki。** hibiki 已无此目录（迁出前最后快照见 `origin/worktree-galgame-mining`）。
-- hibiki-voice-hook 现有结构（要重构的对象）：
+  hibiki-hook，不在 hibiki。** hibiki 已无此目录（迁出前最后快照见 `origin/worktree-galgame-mining`）。
+- hibiki-hook 现有结构（要重构的对象）：
   - `CMakeLists.txt`（`-A x64` / `-A Win32` 双架构）
   - `hook/dll_main.cpp`（**2666 行**，Unity/Siglus/KiriKiri/Ren'Py/XAudio2/DirectSound/文本渲染逻辑全堆在此）
   - `injector/injector_main.cpp`（`--launch <exe>` 随启动加载 / `--pid` 运行中附着 两种模式）
@@ -82,7 +82,7 @@ P0 (真相源) ──► P1 (拆 adapter) ──┬─► P3 (probe/new/replay �
   `LoopbackGalAudioSource`）、`galgame_audio_encode.dart`、`galgame_library.dart`、
   `galgame_system_ui_filter.dart`、`galgame_waveform*.dart`。
 - helper 安装/下载：`hibiki/lib/src/mining/galgame_helper_installer.dart`
-  （`kGalgameHelperRepo = 'hajisensai/hibiki-voice-hook'`、tag `voice-hook-helper`、镜像回退纯函数
+  （`kGalgameHelperRepo = 'hajisensai/hibiki-hook'`、tag `voice-hook-helper`、镜像回退纯函数
   `galgameHelperCandidateUrls`、`exeIs32Bit` 读 PE COFF Machine 选 x86/x64 组件）。
 - 文本覆盖：`hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart`。
 - 现成可复用件（design.md 已核实 file:line）：制卡入口 `ImmersionMiningEngine.mine`
@@ -114,17 +114,17 @@ P0 (真相源) ──► P1 (拆 adapter) ──┬─► P3 (probe/new/replay �
 
 ### 【原始设想里的幽灵引用（写了但仓库没有 → 新建或改指）】
 - `tool/galhook.ps1`（无，待建）、`engine-support.yaml`（无，待建）、`docs/agent/galgame-hooking.md`（无，待建）。
-- `native/galgame_voice_hook/hook/dll_main.cpp` 的正确归属是 **hibiki-voice-hook**，非 hibiki。
+- `native/galgame_voice_hook/hook/dll_main.cpp` 的正确归属是 **hibiki-hook**，非 hibiki。
 
 ---
 
 ## 2. 仓库边界（推荐方案，可由用户推翻）
-- **hibiki-voice-hook（native 采集相关全归这里，延续隔离）**：
+- **hibiki-hook（native 采集相关全归这里，延续隔离）**：
   engine-support.yaml 真相源 + 文档生成器、adapter registry、各引擎 adapter、LunaHost 桥接层 + ABI 守卫
   （扩 `tools/luna_symcheck.cpp`）、probe/new/replay 三条 native 流水线（`tool/galhook.ps1` 落这里）、
   CTest + fixture。
 - **hibiki（消费端）**：IPC 契约版本/导出守卫、helper installer / 版本匹配（按 exe/module 哈希）、
-  Hook Code 用户导入/导出/保存、Dart 侧文本-音频配对/回放测试、以及从 hibiki-voice-hook 同步/生成的
+  Hook Code 用户导入/导出/保存、Dart 侧文本-音频配对/回放测试、以及从 hibiki-hook 同步/生成的
   **支持矩阵文档副本** + `docs/agent/galgame-hooking.md`（SOP，从 `hibiki/CLAUDE.md` 操作流程索引链接）。
 - 若真相源或矩阵文档想主放在 hibiki，请在开工前指明；否则按上表。
 
@@ -142,7 +142,7 @@ P0 (真相源) ──► P1 (拆 adapter) ──┬─► P3 (probe/new/replay �
 - 用 §1 真机基线填 Siglus/KiriKiriZ/XAudio2/Unity 真实状态，消除 handoff 与旧设想口径不一致。
 - **完成定义**：yaml 单一真相源存在且能自动生成矩阵 md；Siglus/KiriKiriZ/XAudio2/Unity 状态与 §1 基线逐条一致；本阶段零代码行为变化。
 
-### Phase 1 — 无行为变化拆分 `dll_main.cpp`（在 hibiki-voice-hook）
+### Phase 1 — 无行为变化拆分 `dll_main.cpp`（在 hibiki-hook）
 - 统一 adapter 契约：`probe`（是否适用）/ `install` / `capabilities`（text, resourceAudio, pcmAudio）/
   `onModuleLoaded`（延迟加载 DLL）/ `shutdown`（安全停止释放）/ `diagnostics`（结构化诊断）。
 - 建中心 registry；主 worker 只负责生命周期 + 注册调度。把现有 Unity/Siglus/KiriKiri/Ren'Py/XAudio2/
@@ -150,7 +150,7 @@ P0 (真相源) ──► P1 (拆 adapter) ──┬─► P3 (probe/new/replay �
 - 用模块加载通知 / 统一 LoadLibrary 观察机制替代硬编码重复轮询。
 - **完成定义**：adapter 契约 + registry 落地，各引擎逻辑全部搬进独立 adapter，主 worker 只剩生命周期/注册调度；CTest 全绿且行为与拆分前逐项一致（零行为变化，不与 P3+ 能力扩展同提交）。
 
-### Phase 2 — 收敛 LunaHook 集成（在 hibiki-voice-hook，向 hibiki 输出稳定 IPC）
+### Phase 2 — 收敛 LunaHook 集成（在 hibiki-hook，向 hibiki 输出稳定 IPC）
 - LunaHook 仍是主文本来源（复用这一开源文本提取工具，不重造上游引擎文本能力）。把对特定 LunaHost ABI 的
   依赖收进独立桥接层，向 hibiki 输出**版本化、稳定的 IPC**。新增：LunaHost/LunaHook 版本 + 导出检查
   （扩 `luna_symcheck`）；上游版本同步 + 差异检查工具；ABI 契约测试；Hook Code 数据驱动配置；用户导入/
@@ -203,7 +203,7 @@ P0 (真相源) ──► P1 (拆 adapter) ──┬─► P3 (probe/new/replay �
 - [ ] **[P5]** 至少完成 RealLive/VisualArt's 首批适配 + fixture + native 测试 + 上层配对测试。
 - [ ] **[P4]** FFmpeg 版本识别与子进程跟随不再只针对单一旧版 Ren'Py。
 - [ ] **[P1+P3]** 新增一个普通引擎的主要工作可限于 profile + 独立 adapter + fixture，不需改主 worker 主干。
-- [ ] **[全阶段]** hibiki-voice-hook x86/x64 native 构建 + CTest 通过；hibiki 侧 `dart format` + `flutter analyze`
+- [ ] **[全阶段]** hibiki-hook x86/x64 native 构建 + CTest 通过；hibiki 侧 `dart format` + `flutter analyze`
       + `flutter test` 通过。
 - [ ] **[全阶段]** 所有宣称"支持/修好"的真实引擎按仓库规则走原始路径真机验证并留证据；缺样本能力显式标未真机验证。
 - [ ] **[全阶段]** 每阶段独立提交；最终报告含各提交哈希、验证命令、真机证据、未验证项、后续候选

--- a/hibiki/integration_test/galgame_engine_hook_launch_test.dart
+++ b/hibiki/integration_test/galgame_engine_hook_launch_test.dart
@@ -20,7 +20,7 @@ import 'package:hibiki/src/mining/galgame_audio_source.dart';
 /// 需要**环境变量**指到本机素材（缺任一则 skip、不误报失败，故 CI/无游戏机器上自动跳过）：
 ///   - `GALTEST_GAME_EXE`：目标游戏 exe（如 32 位 KiriKiriZ `otomeki.exe`）。
 ///   - `GALTEST_INJECTOR`：与游戏位数匹配的 `hibiki_voice_injector.exe`
-///     （helper 已迁至独立仓库 hibiki-voice-hook，本机构建落 `build/<arch>/Release/`；
+///     （helper 已迁至独立仓库 hibiki-hook，本机构建落 `build/<arch>/Release/`；
 ///     或 app 按需下载后落在 `<app>/voice_hook/<arch>/`）。
 ///
 /// 实测（2026-07-18，otomeki.exe 32 位 KiriKiriZ）：
@@ -57,8 +57,7 @@ void main() {
       // start：拉起游戏 + 早注入 + 轮询 status 等 hook 拿到语音格式。
       fmt = await src.start();
       gpid = src.gamePid;
-      expect(fmt, isNotNull,
-          reason: '引擎-hook 未就绪（注入失败 / DS hook 未命中 / 超时）');
+      expect(fmt, isNotNull, reason: '引擎-hook 未就绪（注入失败 / DS hook 未命中 / 超时）');
       expect(fmt!.sampleRate, greaterThan(0));
       expect(fmt.channels, greaterThan(0));
 

--- a/hibiki/lib/src/mining/galgame_helper_installer.dart
+++ b/hibiki/lib/src/mining/galgame_helper_installer.dart
@@ -21,7 +21,7 @@ const String kGalgameHelperReleaseTag = 'voice-hook-helper';
 /// 进程注入代码会被杀软报毒，故物理隔离到独立仓库单独构建/分发（见该仓库 README）；且独立仓库
 /// 默认分支上的 `voice-hook-helper.yml` 可正常 workflow_dispatch 刷新 release（主仓库那份因不在
 /// 默认分支无法 dispatch，是迁出独立仓库的根因）。
-const String kGalgameHelperRepo = 'hajisensai/hibiki-voice-hook';
+const String kGalgameHelperRepo = 'hajisensai/hibiki-hook';
 
 /// gh 加速代理前缀（GFW 兜底；raw release 资产可走镜像，与 update_checker 的
 /// updateCheckProxyPrefixes / video_shader_downloader 的 _kGhProxyPrefixes 同范式、同名单）。

--- a/hibiki/test/mining/galgame_helper_installer_test.dart
+++ b/hibiki/test/mining/galgame_helper_installer_test.dart
@@ -27,12 +27,12 @@ void main() {
       expect(kGalgameHelperReleaseTag, 'voice-hook-helper');
     });
 
-    test('helper 默认走独立仓库 hibiki-voice-hook（非主 app 仓库）', () {
-      expect(kGalgameHelperRepo, 'hajisensai/hibiki-voice-hook');
+    test('helper 默认走独立仓库 hibiki-hook（非主 app 仓库）', () {
+      expect(kGalgameHelperRepo, 'hajisensai/hibiki-hook');
       expect(galgameHelperDownloadUrl('x64'),
-          startsWith('https://github.com/hajisensai/hibiki-voice-hook/'));
+          startsWith('https://github.com/hajisensai/hibiki-hook/'));
       expect(galgameHelperSha256Url('x86'),
-          startsWith('https://github.com/hajisensai/hibiki-voice-hook/'));
+          startsWith('https://github.com/hajisensai/hibiki-hook/'));
     });
 
     test('sha256 侧车 URL = zip URL + .sha256', () {

--- a/hibiki/windows/runner/voice_hook_ipc.h
+++ b/hibiki/windows/runner/voice_hook_ipc.h
@@ -7,7 +7,7 @@
 #include <string>
 
 // galgame 一键制卡 C 阶段（docs/specs/galgame-mining）—— 引擎级 voice/text hook 共享内存契约的
-// **host 端副本**（真相源在独立仓库 hibiki-voice-hook 的 `include/voice_hook_ipc.h`，须同步）。
+// **host 端副本**（真相源在独立仓库 hibiki-hook 的 `include/voice_hook_ipc.h`，须同步）。
 // v2：音频环形 + 文本环（hook 抓的台词行）+ 语音 clip 索引（按句切的语音片段，含时间戳供配对）。
 // v6：clip 索引之后追加 loopback 混音环 + 时间戳↔环位置标记表（无引擎专属纯人声 hook 时的兜底）。
 // v10：文本槽追加事件类型，透传 Luna ThreadCreate，使尚无台词的候选线程也可被选择。

--- a/hibiki/windows/runner/voice_hook_reader.h
+++ b/hibiki/windows/runner/voice_hook_reader.h
@@ -10,7 +10,7 @@
 // galgame 一键制卡 C 阶段（docs/specs/galgame-mining）—— hibiki.exe **读侧** native。
 //
 // 隔离红线：注入进游戏、装 XAudio2/DirectSound hook 的代码全在独立组件
-// 独立仓库 hibiki-voice-hook（injector + hook DLL），会被杀软报毒，**绝不进 hibiki.exe**。
+// 独立仓库 hibiki-hook（injector + hook DLL），会被杀软报毒，**绝不进 hibiki.exe**。
 // 本 reader 只做一件被杀软视为无害的事：按名 [OpenFileMappingW] 打开那个组件建好的**共享内存**，
 // 读环形缓冲里 hook 抓到的干净语音 PCM。它是 A 阶段 [AudioLoopbackCapture] 的引擎-hook 版对偶：
 // 同样「开一路 → 需要时取最近 N 毫秒」，只是数据源从本进程 WASAPI 换成跨进程共享内存。
@@ -106,7 +106,7 @@ class VoiceHookReader {
   //   - [target_source] 为 0：按能量自动选语音源（说话前静音、文本时刻突然有能量者），并排除
   //     [exclude_sources] 里的源（用户标记的 BGM）。自动选源在真机上可能误选 BGM，故提供手动。
   // 找不到语音源 / 段全被环形覆盖 / 无数据则 [out] 空、返回 ok=false（调用方回退 GrabClipNear）。
-  // 算法真相源：独立仓库 hibiki-voice-hook 的 `tools/ring_probe.cpp` 的 DumpUtterance（已真机验证）。
+  // 算法真相源：独立仓库 hibiki-hook 的 `tools/ring_probe.cpp` 的 DumpUtterance（已真机验证）。
   VoiceHookStatus GrabUtterance(uint64_t ts_ms, uint64_t target_source,
                                 const std::vector<uint64_t>& exclude_sources,
                                 std::vector<uint8_t>& out);


### PR DESCRIPTION
## 动机
用户把 GitHub 仓库 `hajisensai/hibiki-voice-hook` 重命名为 `hajisensai/hibiki-hook`（galgame 引擎-hook 注入器组件，与主 app 物理隔离）。本 PR 把主仓库里所有仓库名引用同步到新名。

## 改动
整 token 替换 `hibiki-voice-hook` → `hibiki-hook`，共 7 文件：
- `hibiki/lib/src/mining/galgame_helper_installer.dart` — `kGalgameHelperRepo` 下载 URL 常量（**功能性**）
- `hibiki/test/mining/galgame_helper_installer_test.dart` — 仓库名断言
- `hibiki/integration_test/galgame_engine_hook_launch_test.dart` — 注释
- `hibiki/windows/runner/voice_hook_ipc.h` / `voice_hook_reader.h` — host 端头注释
- `docs/agent/build.md` / `docs/specs/galgame-mining/engine-adapter-plan.md`

## 不动
release tag `voice-hook-helper`、workflow 文件名、`voice_hook_<arch>.zip`、`native/galgame_voice_hook` 路径名 —— 这些是 tag/文件/目录名，不是仓库名。

## 验证
- `dart format` + `flutter test test/mining/galgame_helper_installer_test.dart` → 20 项全过
- 新名下载 URL `https://github.com/hajisensai/hibiki-hook/releases/download/voice-hook-helper/voice_hook_x64.zip` → HTTP 302 通
- 旧名 `hibiki-voice-hook` → 301 重定向到 `hibiki-hook`，存量下载不断

https://claude.ai/code/session_01ER8V3e746bPLCXHtbaACfK