### PR TITLE
fix(anki): BUG-971 AnkiConnect 主机字段不再吞掉 http:// 变成 http:

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 951 条。点号进各自文件。
+> 共 952 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-971](bugs/BUG-971-ankiconnect-host-scheme.md) | ✅ | ✅ | AnkiConnect 主机字段吞掉 http:// 变成 http: |
 | [BUG-970](bugs/BUG-970-reading-goal-first-set-no-entry.md) | ✅ | ✅ | 统计页每日/每周目标从未设置时无任何设置入口 |
 | [BUG-969](bugs/BUG-969-reader-settings-sheet-120fps.md) | ✅ | ✅ | 阅读设置抽屉滚动与拖动跑不满120fps |
 | [BUG-968](bugs/BUG-968-audiobook-export-text-audio.md) | ✅ | ✅ | 有声书片段导出文字与选区不符且移动端缺少音频 |

--- a/docs/bugs/BUG-971-ankiconnect-host-scheme.md
+++ b/docs/bugs/BUG-971-ankiconnect-host-scheme.md
@@ -1,0 +1,7 @@
+## BUG-971 · AnkiConnect 主机字段吞掉 http:// 变成 http:
+
+- **报告**：2026-07-21（用户：填写 `http://` 会自动变成 `http:`）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/anki/anki_view_model.dart:155` `updateAnkiConnectHost`——旧逻辑对含 `/` `?` `#` 的输入静默 `return` 拒绝保存。用户在主机字段逐字符敲 `http://`：敲到 `http:` 被接受写入偏好，敲下一个 `/`（`http:/`）起每一击都命中 `contains('/')` 被拒；`_AnkiConnectionField` 是非受控字段（`anki_settings_page.dart:447` 持有自己的 controller），失焦时 `didUpdateWidget`（同文件 452 行）用最后被接受的持久值 `http:` 覆盖输入框，于是看起来「自动变成 http:」。
+- **[x] ① 已修复** — 不再静默拒斥，改为把 URL 形态输入规范化成裸主机：剥 scheme/path/query/fragment/userinfo，尾部数字 `:port` 拆到独立端口字段（保留冒号会让 `Uri.parse('http://$host:$port')` 变成 `host:port:port` 破坏请求）。主机原样保留（不小写化、不 punycode）。见 `hibiki/lib/src/anki/anki_view_model.dart` `normalizeAnkiConnectHostInput` + `updateAnkiConnectHost`。提交：<待填>
+- **[x] ② 已加自动化测试** — `hibiki/test/anki/anki_connect_host_normalize_test.dart`：纯函数单测覆盖 `http://localhost`→`localhost`、`http://192.168.1.5:48765/foo`→`(192.168.1.5, 48765)`、`localhost:8765` 端口拆分、裸 `localhost` 原样、打字途中 `http://` / `http:/` / `localhost:` 不再塌成 `http:`、userinfo 剥离、IDN 主机 verbatim 不转 punycode。
+- **备注**：端口自动回填仅在输入携带合法端口时覆盖，否则保留端口字段既有值。IPv6 字面量本就因 `Uri.parse('http://$host:$port')` 不加方括号而不被支持，本次不扩展。

--- a/hibiki/lib/src/anki/anki_view_model.dart
+++ b/hibiki/lib/src/anki/anki_view_model.dart
@@ -153,15 +153,21 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
   }
 
   Future<void> updateAnkiConnectHost(String host) async {
-    final trimmed = host.trim();
-    if (trimmed.isEmpty ||
-        trimmed.contains('/') ||
-        trimmed.contains('?') ||
-        trimmed.contains('#')) {
-      return;
-    }
-    final updated = await _repository
-        .updateSettings((s) => s.copyWith(ankiConnectHost: trimmed));
+    // 不能对含 '/'、'?'、'#' 的输入静默 return（BUG-970）：那样用户逐字符敲
+    // "http://" 时，敲到第一个 '/'（"http:/"）起就全被拒，失焦回退到最后被接受的
+    // "http:"，看起来像 App 把地址吃成了 "http:"。AnkiConnect 恒在 http://host:port
+    // 的根路径，故把 URL 形态输入规范化成裸主机：剥 scheme / path / query / fragment /
+    // userinfo，并把尾部数字 ":port" 拆到独立端口字段（保留在主机里会让
+    // Uri.parse('http://$host:$port') 变成 host:port:port 破坏请求）。
+    final endpoint = normalizeAnkiConnectHostInput(host);
+    if (endpoint.host.isEmpty) return;
+    final updated = await _repository.updateSettings(
+      (s) => s.copyWith(
+        ankiConnectHost: endpoint.host,
+        // 仅当输入里带了合法端口才覆盖，否则保留用户在端口字段里的既有值。
+        ankiConnectPort: endpoint.port ?? s.ankiConnectPort,
+      ),
+    );
     state = state.copyWith(settings: updated);
   }
 
@@ -216,6 +222,48 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
       return LapisSetupResult(LapisSetupOutcome.failed, e.toString());
     }
   }
+}
+
+/// 把用户敲/粘进 AnkiConnect **主机**字段的自由文本规范化成裸主机 + 可选端口。
+///
+/// AnkiConnect 恒在 `http://host:port` 的根路径，所以 `http://192.168.1.5:48765/`
+/// 之类的完整 URL（或手敲的 `http://host`）不能被拒绝——剥掉 scheme、path/query/
+/// fragment 与 userinfo，并把尾部的数字 `:port` 拆出来交给独立端口字段（留在主机里
+/// 会让 `Uri.parse('http://$host:$port')` 变成 `host:port:port` 破坏请求）。主机原样
+/// 保留（不小写化、不做 IDNA punycode），用户看到的就是自己敲的值。返回的 [port] 仅在
+/// 输入携带 1..65535 合法端口时非 null；非数字尾部（如错误的 IPv6/笔误）原样保留，
+/// 尽力而为不擅自篡改。
+@visibleForTesting
+({String host, int? port}) normalizeAnkiConnectHostInput(String raw) {
+  var s = raw.trim();
+  // 剥掉开头的 "scheme://"。
+  final schemeSep = s.indexOf('://');
+  if (schemeSep >= 0) s = s.substring(schemeSep + 3);
+  // 在第一个 path / query / fragment 分隔符处截断。
+  for (final sep in const ['/', '?', '#']) {
+    final cut = s.indexOf(sep);
+    if (cut >= 0) s = s.substring(0, cut);
+  }
+  // 丢弃 userinfo（"user:pass@host" / "user@host"）。
+  final at = s.lastIndexOf('@');
+  if (at >= 0) s = s.substring(at + 1);
+  // 拆分尾部 ":<数字>" 作为端口；顺带清掉打字途中残留的孤立尾冒号。
+  int? port;
+  final colon = s.lastIndexOf(':');
+  if (colon >= 0) {
+    final tail = s.substring(colon + 1);
+    if (tail.isEmpty) {
+      s = s.substring(0, colon);
+    } else {
+      final parsed = int.tryParse(tail);
+      if (parsed != null) {
+        if (parsed > 0 && parsed <= 65535) port = parsed;
+        // 数字尾部一律剥离（越界也剥），保证主机不残留冒号破坏 Uri。
+        s = s.substring(0, colon);
+      }
+    }
+  }
+  return (host: s.trim(), port: port);
 }
 
 enum LapisSetupOutcome { created, alreadyExisted, failed }

--- a/hibiki/test/anki/anki_connect_host_normalize_test.dart
+++ b/hibiki/test/anki/anki_connect_host_normalize_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/anki/anki_view_model.dart';
+
+/// BUG-971 守卫：AnkiConnect 主机字段规范化。
+///
+/// 旧逻辑对含 `/` 的输入静默拒绝保存，导致用户逐字符敲 `http://` 时，输入框失焦后
+/// 回退到最后被接受的 `http:`（看起来「自动变成 http:」）。修复后 [normalizeAnkiConnectHostInput]
+/// 把 URL 形态输入规范化成裸主机 + 可选端口，而不是拒斥。
+void main() {
+  group('normalizeAnkiConnectHostInput', () {
+    test('裸主机原样保留，不带端口', () {
+      final r = normalizeAnkiConnectHostInput('localhost');
+      expect(r.host, 'localhost');
+      expect(r.port, isNull);
+    });
+
+    test('剥掉 http:// scheme，得到裸主机', () {
+      final r = normalizeAnkiConnectHostInput('http://localhost');
+      expect(r.host, 'localhost');
+      expect(r.port, isNull);
+    });
+
+    test('完整 URL：剥 scheme + path，拆出端口', () {
+      final r = normalizeAnkiConnectHostInput('http://192.168.1.5:48765/foo');
+      expect(r.host, '192.168.1.5');
+      expect(r.port, 48765);
+    });
+
+    test('host:port 拆分到独立端口', () {
+      final r = normalizeAnkiConnectHostInput('localhost:8765');
+      expect(r.host, 'localhost');
+      expect(r.port, 8765);
+    });
+
+    test('userinfo 被剥离', () {
+      final r = normalizeAnkiConnectHostInput('http://user:pass@example.cn:80');
+      expect(r.host, 'example.cn');
+      expect(r.port, 80);
+    });
+
+    test('IDN 主机原样保留，不转 punycode / 不小写', () {
+      final r = normalizeAnkiConnectHostInput('日本語.example.CN');
+      expect(r.host, '日本語.example.CN');
+      expect(r.port, isNull);
+    });
+
+    // BUG-971 的核心：打字途中的中间态绝不能塌成 "http:"。
+    group('BUG-971 打字中间态不再塌成 http:', () {
+      test('"http:" → "http"（尾部孤立冒号被剥，主机不残留冒号）', () {
+        // 关键不是产出什么，而是这一步不再走「拒绝保存 → 失焦回退」的旧塌陷路径。
+        expect(normalizeAnkiConnectHostInput('http:').host, 'http');
+      });
+
+      test('"http:/" 单斜杠 → "http"（斜杠截断 + 尾冒号剥离）', () {
+        expect(normalizeAnkiConnectHostInput('http:/').host, 'http');
+      });
+
+      test('"http://"（scheme 完整但主机为空）→ 空主机，不写入', () {
+        expect(normalizeAnkiConnectHostInput('http://').host, isEmpty);
+      });
+
+      test('"http://l" → "l"，最终收敛到真实主机', () {
+        expect(normalizeAnkiConnectHostInput('http://l').host, 'l');
+      });
+
+      test('"http://localhost" 完整键入 → "localhost"', () {
+        expect(normalizeAnkiConnectHostInput('http://localhost').host,
+            'localhost');
+      });
+    });
+
+    test('打字途中的孤立尾冒号 "localhost:" 不残留冒号', () {
+      final r = normalizeAnkiConnectHostInput('localhost:');
+      expect(r.host, 'localhost');
+      expect(r.port, isNull);
+    });
+
+    test('越界数字端口被剥离但不设 port（主机不残留冒号）', () {
+      final r = normalizeAnkiConnectHostInput('localhost:99999');
+      expect(r.host, 'localhost');
+      expect(r.port, isNull);
+    });
+
+    test('首尾空白被 trim', () {
+      final r = normalizeAnkiConnectHostInput('  http://localhost:8765  ');
+      expect(r.host, 'localhost');
+      expect(r.port, 8765);
+    });
+
+    test('查询串 / fragment 被截断', () {
+      expect(normalizeAnkiConnectHostInput('localhost?x=1').host, 'localhost');
+      expect(normalizeAnkiConnectHostInput('localhost#frag').host, 'localhost');
+    });
+  });
+}


### PR DESCRIPTION
## 问题（BUG-971）
用户报告：在 AnkiConnect **主机**字段填 `http://` 会自动变成 `http:`。

## 根因
`hibiki/lib/src/anki/anki_view_model.dart` 的 `updateAnkiConnectHost` 旧逻辑对含 `/` `?` `#` 的输入**静默 `return` 拒绝保存**。逐字符敲 `http://`：到 `http:` 被接受写入偏好，敲下一个 `/`（`http:/`）起每一击都命中 `contains('/')` 被拒；`_AnkiConnectionField` 是非受控字段，失焦时 `didUpdateWidget` 用最后被接受的持久值 `http:` 覆盖输入框 → 看起来「自动变成 http:」。

## 修复
不再静默拒斥，改为把 URL 形态输入规范化成裸主机（`normalizeAnkiConnectHostInput`）：
- 剥掉 `scheme://` / path / query / fragment / userinfo；
- 尾部数字 `:port` 拆到独立端口字段（保留冒号会让 `Uri.parse('http://\$host:\$port')` 变成 `host:port:port` 破坏请求）；
- 主机原样保留（不小写化、不 IDNA punycode）；
- 仅当输入携带合法端口才覆盖端口字段，否则保留既有值。

## 测试
`hibiki/test/anki/anki_connect_host_normalize_test.dart` — 15 项纯函数守卫全绿（`http://localhost`→`localhost`、`http://192.168.1.5:48765/foo`→`(192.168.1.5,48765)`、`localhost:8765` 端口拆分、打字中间态不塌陷、userinfo 剥离、IDN verbatim 等）。`flutter analyze` 两文件 No issues。

## 备注
- 仅改一处 viewmodel + 新增测试 + bug 文档；无行为回归风险。
- IPv6 字面量本就因 `Uri.parse` 不加方括号而不支持，本次不扩展。
- 待桌面真机复测原始失败路径（在主机框输 `http://host:port` 应落成 host + port）。

https://claude.ai/code/session_01DAu6y46z572dKNMk96fFrr