### PR TITLE
feat: 墨水屏模式（E-ink）——纯黑白主题+线式高亮+关动画（含 BUG-969 修复）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 949 条。点号进各自文件。
+> 共 950 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-969](bugs/BUG-969-popup-css-ctx-adjust-unclosed-brace.md) | ✅ | ✅ | popup.css .ctx-adjust-button 缺闭合括号吞掉 .global-lookup-ext-hit 高亮规则 |
 | [BUG-968](bugs/BUG-968-audiobook-export-text-audio.md) | ✅ | ✅ | 有声书片段导出文字与选区不符且移动端缺少音频 |
 | [BUG-967](bugs/BUG-967-reader-context-menu-stack.md) | ✅ | ✅ | Windows 查词弹窗后右键菜单位于底层且重复累加 |
 | [BUG-966](bugs/BUG-966-subtitle-list-mining-audio.md) | ✅ | ✅ | 字幕列表点词查词制卡音频截错句(锚到播放位置而非被点cue) |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -31,7 +31,7 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-969](bugs/BUG-969-popup-css-ctx-adjust-unclosed-brace.md) | ✅ | ✅ | popup.css .ctx-adjust-button 缺闭合括号吞掉 .global-lookup-ext-hit 高亮规则 |
+| [BUG-970](bugs/BUG-970-popup-css-ctx-adjust-unclosed-brace.md) | ✅ | ✅ | popup.css .ctx-adjust-button 缺闭合括号吞掉 .global-lookup-ext-hit 高亮规则 |
 | [BUG-968](bugs/BUG-968-audiobook-export-text-audio.md) | ✅ | ✅ | 有声书片段导出文字与选区不符且移动端缺少音频 |
 | [BUG-967](bugs/BUG-967-reader-context-menu-stack.md) | ✅ | ✅ | Windows 查词弹窗后右键菜单位于底层且重复累加 |
 | [BUG-966](bugs/BUG-966-subtitle-list-mining-audio.md) | ✅ | ✅ | 字幕列表点词查词制卡音频截错句(锚到播放位置而非被点cue) |

--- a/docs/bugs/BUG-969-popup-css-ctx-adjust-unclosed-brace.md
+++ b/docs/bugs/BUG-969-popup-css-ctx-adjust-unclosed-brace.md
@@ -1,0 +1,6 @@
+## BUG-969 · popup.css .ctx-adjust-button 缺闭合括号吞掉 .global-lookup-ext-hit 高亮规则
+- **报告**：2026-07-21（agent 在做墨水屏适配（PR eink-mode）审读 popup.css 时自查发现，非用户报告）
+- **真实性**：✅ 真 bug。根因 `hibiki/assets/popup/popup.css`（修复前尾部 `.ctx-adjust-button` 规则）：该规则只写了 `{ opacity: 0.85;` 没有闭合 `}`（全文件 167 个 `{` vs 166 个 `}`）。CSS 错误恢复把随后的 `.global-lookup-ext-hit { background: …; border-radius: 2px; }` 整条当作无效声明消费掉，最后的 `}` 被用来闭合 `.ctx-adjust-button`——净效果是「面板释义区被点击、正在外部瞬态窗里查的那段文字的高亮」（markGlobalLookupExtHit）从未生效。三镜像（两个 vendor popup.css + 生成的 content.css）同样受影响。
+- **[x] ① 已修复** — 给 `.ctx-adjust-button` 补上闭合 `}`，`.global-lookup-ext-hit` 规则恢复；同步两个 vendor popup.css 并重跑 `generate-content-css.mjs` 重生成两份 content.css（与墨水屏模式同一提交，分支 worktree-eink-mode）。
+- **[x] ② 已加自动化测试** — `hibiki/test/build/popup_css_eink_guard_test.dart` 的「popup.css braces are balanced (swallowed-rule guard)」：剥注释后断言 `{`/`}` 计数配平，这一类「少个括号、静默吞掉后续规则」直接翻红。
+- **备注**：括号配平只能挡「数量不平」型；同数量但错位的嵌套错误仍需靠 review。

--- a/docs/bugs/BUG-970-popup-css-ctx-adjust-unclosed-brace.md
+++ b/docs/bugs/BUG-970-popup-css-ctx-adjust-unclosed-brace.md
@@ -1,6 +1,6 @@
-## BUG-969 · popup.css .ctx-adjust-button 缺闭合括号吞掉 .global-lookup-ext-hit 高亮规则
+## BUG-970 · popup.css .ctx-adjust-button 缺闭合括号吞掉 .global-lookup-ext-hit 高亮规则
 - **报告**：2026-07-21（agent 在做墨水屏适配（PR eink-mode）审读 popup.css 时自查发现，非用户报告）
 - **真实性**：✅ 真 bug。根因 `hibiki/assets/popup/popup.css`（修复前尾部 `.ctx-adjust-button` 规则）：该规则只写了 `{ opacity: 0.85;` 没有闭合 `}`（全文件 167 个 `{` vs 166 个 `}`）。CSS 错误恢复把随后的 `.global-lookup-ext-hit { background: …; border-radius: 2px; }` 整条当作无效声明消费掉，最后的 `}` 被用来闭合 `.ctx-adjust-button`——净效果是「面板释义区被点击、正在外部瞬态窗里查的那段文字的高亮」（markGlobalLookupExtHit）从未生效。三镜像（两个 vendor popup.css + 生成的 content.css）同样受影响。
 - **[x] ① 已修复** — 给 `.ctx-adjust-button` 补上闭合 `}`，`.global-lookup-ext-hit` 规则恢复；同步两个 vendor popup.css 并重跑 `generate-content-css.mjs` 重生成两份 content.css（与墨水屏模式同一提交，分支 worktree-eink-mode）。
 - **[x] ② 已加自动化测试** — `hibiki/test/build/popup_css_eink_guard_test.dart` 的「popup.css braces are balanced (swallowed-rule guard)」：剥注释后断言 `{`/`}` 计数配平，这一类「少个括号、静默吞掉后续规则」直接翻红。
-- **备注**：括号配平只能挡「数量不平」型；同数量但错位的嵌套错误仍需靠 review。
+- **备注**：原以 BUG-969 创建，与 PR#312（阅读设置抽屉 120fps）的 BUG-969 撞号后改号 970（提交信息里的 969 指本条）。括号配平只能挡「数量不平」型；同数量但错位的嵌套错误仍需靠 review。

--- a/hibiki/assets/browser_extension/vendor/content.css
+++ b/hibiki/assets/browser_extension/vendor/content.css
@@ -1406,11 +1406,164 @@
 
 .ctx-adjust-button {
     opacity: 0.85;
+}
+
 /* 真机第 5 轮 — 面板释义区被点击、正在外部瞬态窗里查的那段文字的高亮
-   （markGlobalLookupExtHit；下次点击替换、重渲清除）。 */
+   （markGlobalLookupExtHit；下次点击替换、重渲清除）。
+   BUG：上面 .ctx-adjust-button 规则原缺闭合 }，CSS 错误恢复把本条整规则当无效
+   声明吞掉（ext-hit 高亮从未生效）；补上闭合后本条恢复。 */
 .global-lookup-ext-hit {
     background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.22));
     border-radius: 2px;
+}
+
+/* =====================================================================
+ * E-ink 墨水屏模式（html.eink）。
+ *
+ * class 由 popup_settings_injection.dart 的 _themeVariablesJs 注入（toggle，
+ * 热复用 WebView 关掉开关也能摘除）；三镜像纪律：改这里必须同步两个 vendor
+ * popup.css 并重新跑 generate-content-css.mjs（生成器把 html.eink 重挂为
+ * :where(#entries-container).eink，扩展侧同样生效）。
+ *
+ * 设计对齐 Hoshi-Reader-Android 的 E-ink 弹窗：纯黑白、方角、实线边框、
+ * 关 transition/animation/阴影；半透明色块高亮改为反色或下划线（大面积
+ * 灰阶在墨水屏上是抖动噪点，且每次变化都是一整块刷新）。
+ * ===================================================================== */
+
+/* 方角 + 去阴影 + 关动效：一条规则压平全部圆角/阴影/补间（逐选择器覆盖 20+
+   处 border-radius 是维护负担，e-ink 下它们统一归零，无一例外）。 */
+:where(#entries-container).eink *,
+:where(#entries-container).eink *::before,
+:where(#entries-container).eink *::after {
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+    transition: none !important;
+    animation: none !important;
+}
+
+:where(#entries-container).eink {
+    --hibiki-radius-card: 0;
+    /* 杀掉亚克力/半透明卡片底（Win11 backdrop 在 e-ink 上只是脏灰）。 */
+    --hibiki-card-bg-alpha: 1;
+    /* 查词命中不再用半透明色块（消费端见下方 underline 覆盖）。 */
+    --hoshi-primary-highlight: transparent;
+    /* tags：色块 → 透明底 + 描边（描边规则见下）。 */
+    --expr-tag-color: transparent;
+}
+
+/* 纯黑白变量：比 html[data-theme] 特异性高（0,2,1 > 0,1,1），连 Dart 注入的
+   --md-* 一并压掉（消费端读的是这些二级变量）。浅色=白底黑字，深色=黑底白字。 */
+:where(#entries-container).eink[data-theme="light"] {
+    --background-color: #fff;
+    --background-color-light: #fff;
+    --background-color-dark1: #fff;
+    --text-color: #000;
+    --text-color-light1: #000;
+    --text-color-light2: #000;
+    --text-color-light3: #000;
+    --text-color-light4: #000;
+    --surface-container: #fff;
+    --surface-container-high: #fff;
+    --outline-variant: #000;
+    --primary-color: #000;
+    --on-surface-variant: #000;
+    --freq-tag-color: #000;
+    --hibiki-card-bg-rgb: 255, 255, 255;
+}
+
+:where(#entries-container).eink[data-theme="dark"] {
+    --background-color: #000;
+    --background-color-light: #000;
+    --background-color-dark1: #000;
+    --text-color: #fff;
+    --text-color-light1: #fff;
+    --text-color-light2: #fff;
+    --text-color-light3: #fff;
+    --text-color-light4: #fff;
+    --surface-container: #000;
+    --surface-container-high: #000;
+    --outline-variant: #fff;
+    --primary-color: #fff;
+    --on-surface-variant: #fff;
+    --freq-tag-color: #fff;
+    --hibiki-card-bg-rgb: 0, 0, 0;
+}
+
+/* tags / 词频：色块改「透明底 + 1px 实线描边」；词频来源药丸反色（黑底白字 /
+   白底黑字），比灰阶底更清晰。 */
+:where(#entries-container).eink .expr-tag,
+:where(#entries-container).eink .deinflection-tag,
+:where(#entries-container).eink .kanji-tag,
+:where(#entries-container).eink .glossary-tag,
+:where(#entries-container).eink .pitch-transcription-tag {
+    background-color: transparent;
+    border: 1px solid currentColor;
+}
+
+:where(#entries-container).eink .frequency-dict-label {
+    color: var(--background-color);
+}
+
+/* 顶部动作按钮静息态 0.5 opacity 在墨水屏上是抖动灰，压到全不透明；交互反馈
+   由按下反色承担（active 态浏览器自带 :active opacity 覆盖被上面的关动效保留，
+   数值本身仍生效）。 */
+:where(#entries-container).eink .audio-button,
+:where(#entries-container).eink .favorite-button,
+:where(#entries-container).eink .open-anki-button,
+:where(#entries-container).eink .mine-button {
+    opacity: 1;
+}
+
+/* 特例态的彩色（收藏金 / 最新可改绿）在灰阶屏上失义，回归前景色。 */
+:where(#entries-container).eink .favorite-button.favorited,
+:where(#entries-container).eink .mine-button.latest {
+    color: var(--text-color);
+}
+
+/* 查词/嵌套查词命中：半透明色块 → 下划线（贴文字的一条线，刷新面积最小）。 */
+:where(#entries-container).eink ::highlight(hoshi-selection) {
+    background-color: transparent;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+:where(#entries-container).eink .hoshi-dict-highlight {
+    background-color: transparent !important;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+/* 原生拖选选区：反色块（纯黑白互换）——e-ink 上最清晰的选中态，无灰阶。 */
+:where(#entries-container).eink ::selection {
+    background-color: var(--text-color);
+    color: var(--background-color);
+}
+
+/* 句子横幅的命中/外部查词高亮与逐字 hover：色块 → 下划线 / 描边。 */
+:where(#entries-container).eink .global-lookup-sentence-hit,
+:where(#entries-container).eink .global-lookup-ext-hit {
+    background: transparent;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+:where(#entries-container).eink .global-lookup-sentence:not(.global-lookup-sentence-panel) .global-lookup-sentence-char:hover {
+    background: transparent;
+    outline: 1px solid currentColor;
+    outline-offset: -1px;
+}
+
+/* app 外全局查词卡壳：半透明灰描边 → 实线前景色描边，方角，不透明底。 */
+:where(#entries-container).eink.global-lookup body {
+    border: 1px solid var(--text-color);
+    background: var(--background-color);
 }
 
 /*

--- a/hibiki/assets/browser_extension/vendor/popup.css
+++ b/hibiki/assets/browser_extension/vendor/popup.css
@@ -1489,9 +1489,163 @@ html.global-lookup[data-theme="dark"] body {
 
 .ctx-adjust-button {
     opacity: 0.85;
+}
+
 /* 真机第 5 轮 — 面板释义区被点击、正在外部瞬态窗里查的那段文字的高亮
-   （markGlobalLookupExtHit；下次点击替换、重渲清除）。 */
+   （markGlobalLookupExtHit；下次点击替换、重渲清除）。
+   BUG：上面 .ctx-adjust-button 规则原缺闭合 }，CSS 错误恢复把本条整规则当无效
+   声明吞掉（ext-hit 高亮从未生效）；补上闭合后本条恢复。 */
 .global-lookup-ext-hit {
     background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.22));
     border-radius: 2px;
+}
+
+/* =====================================================================
+ * E-ink 墨水屏模式（html.eink）。
+ *
+ * class 由 popup_settings_injection.dart 的 _themeVariablesJs 注入（toggle，
+ * 热复用 WebView 关掉开关也能摘除）；三镜像纪律：改这里必须同步两个 vendor
+ * popup.css 并重新跑 generate-content-css.mjs（生成器把 html.eink 重挂为
+ * :where(#entries-container).eink，扩展侧同样生效）。
+ *
+ * 设计对齐 Hoshi-Reader-Android 的 E-ink 弹窗：纯黑白、方角、实线边框、
+ * 关 transition/animation/阴影；半透明色块高亮改为反色或下划线（大面积
+ * 灰阶在墨水屏上是抖动噪点，且每次变化都是一整块刷新）。
+ * ===================================================================== */
+
+/* 方角 + 去阴影 + 关动效：一条规则压平全部圆角/阴影/补间（逐选择器覆盖 20+
+   处 border-radius 是维护负担，e-ink 下它们统一归零，无一例外）。 */
+html.eink *,
+html.eink *::before,
+html.eink *::after {
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+    transition: none !important;
+    animation: none !important;
+}
+
+html.eink {
+    --hibiki-radius-card: 0;
+    /* 杀掉亚克力/半透明卡片底（Win11 backdrop 在 e-ink 上只是脏灰）。 */
+    --hibiki-card-bg-alpha: 1;
+    /* 查词命中不再用半透明色块（消费端见下方 underline 覆盖）。 */
+    --hoshi-primary-highlight: transparent;
+    /* tags：色块 → 透明底 + 描边（描边规则见下）。 */
+    --expr-tag-color: transparent;
+}
+
+/* 纯黑白变量：比 html[data-theme] 特异性高（0,2,1 > 0,1,1），连 Dart 注入的
+   --md-* 一并压掉（消费端读的是这些二级变量）。浅色=白底黑字，深色=黑底白字。 */
+html.eink[data-theme="light"] {
+    --background-color: #fff;
+    --background-color-light: #fff;
+    --background-color-dark1: #fff;
+    --text-color: #000;
+    --text-color-light1: #000;
+    --text-color-light2: #000;
+    --text-color-light3: #000;
+    --text-color-light4: #000;
+    --surface-container: #fff;
+    --surface-container-high: #fff;
+    --outline-variant: #000;
+    --primary-color: #000;
+    --on-surface-variant: #000;
+    --freq-tag-color: #000;
+    --hibiki-card-bg-rgb: 255, 255, 255;
+}
+
+html.eink[data-theme="dark"] {
+    --background-color: #000;
+    --background-color-light: #000;
+    --background-color-dark1: #000;
+    --text-color: #fff;
+    --text-color-light1: #fff;
+    --text-color-light2: #fff;
+    --text-color-light3: #fff;
+    --text-color-light4: #fff;
+    --surface-container: #000;
+    --surface-container-high: #000;
+    --outline-variant: #fff;
+    --primary-color: #fff;
+    --on-surface-variant: #fff;
+    --freq-tag-color: #fff;
+    --hibiki-card-bg-rgb: 0, 0, 0;
+}
+
+/* tags / 词频：色块改「透明底 + 1px 实线描边」；词频来源药丸反色（黑底白字 /
+   白底黑字），比灰阶底更清晰。 */
+html.eink .expr-tag,
+html.eink .deinflection-tag,
+html.eink .kanji-tag,
+html.eink .glossary-tag,
+html.eink .pitch-transcription-tag {
+    background-color: transparent;
+    border: 1px solid currentColor;
+}
+
+html.eink .frequency-dict-label {
+    color: var(--background-color);
+}
+
+/* 顶部动作按钮静息态 0.5 opacity 在墨水屏上是抖动灰，压到全不透明；交互反馈
+   由按下反色承担（active 态浏览器自带 :active opacity 覆盖被上面的关动效保留，
+   数值本身仍生效）。 */
+html.eink .audio-button,
+html.eink .favorite-button,
+html.eink .open-anki-button,
+html.eink .mine-button {
+    opacity: 1;
+}
+
+/* 特例态的彩色（收藏金 / 最新可改绿）在灰阶屏上失义，回归前景色。 */
+html.eink .favorite-button.favorited,
+html.eink .mine-button.latest {
+    color: var(--text-color);
+}
+
+/* 查词/嵌套查词命中：半透明色块 → 下划线（贴文字的一条线，刷新面积最小）。 */
+html.eink ::highlight(hoshi-selection) {
+    background-color: transparent;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+html.eink .hoshi-dict-highlight {
+    background-color: transparent !important;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+/* 原生拖选选区：反色块（纯黑白互换）——e-ink 上最清晰的选中态，无灰阶。 */
+html.eink ::selection {
+    background-color: var(--text-color);
+    color: var(--background-color);
+}
+
+/* 句子横幅的命中/外部查词高亮与逐字 hover：色块 → 下划线 / 描边。 */
+html.eink .global-lookup-sentence-hit,
+html.eink .global-lookup-ext-hit {
+    background: transparent;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+html.eink .global-lookup-sentence:not(.global-lookup-sentence-panel)
+    .global-lookup-sentence-char:hover {
+    background: transparent;
+    outline: 1px solid currentColor;
+    outline-offset: -1px;
+}
+
+/* app 外全局查词卡壳：半透明灰描边 → 实线前景色描边，方角，不透明底。 */
+html.eink.global-lookup body {
+    border: 1px solid var(--text-color);
+    background: var(--background-color);
 }

--- a/hibiki/assets/popup/popup.css
+++ b/hibiki/assets/popup/popup.css
@@ -1489,9 +1489,163 @@ html.global-lookup[data-theme="dark"] body {
 
 .ctx-adjust-button {
     opacity: 0.85;
+}
+
 /* 真机第 5 轮 — 面板释义区被点击、正在外部瞬态窗里查的那段文字的高亮
-   （markGlobalLookupExtHit；下次点击替换、重渲清除）。 */
+   （markGlobalLookupExtHit；下次点击替换、重渲清除）。
+   BUG：上面 .ctx-adjust-button 规则原缺闭合 }，CSS 错误恢复把本条整规则当无效
+   声明吞掉（ext-hit 高亮从未生效）；补上闭合后本条恢复。 */
 .global-lookup-ext-hit {
     background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.22));
     border-radius: 2px;
+}
+
+/* =====================================================================
+ * E-ink 墨水屏模式（html.eink）。
+ *
+ * class 由 popup_settings_injection.dart 的 _themeVariablesJs 注入（toggle，
+ * 热复用 WebView 关掉开关也能摘除）；三镜像纪律：改这里必须同步两个 vendor
+ * popup.css 并重新跑 generate-content-css.mjs（生成器把 html.eink 重挂为
+ * :where(#entries-container).eink，扩展侧同样生效）。
+ *
+ * 设计对齐 Hoshi-Reader-Android 的 E-ink 弹窗：纯黑白、方角、实线边框、
+ * 关 transition/animation/阴影；半透明色块高亮改为反色或下划线（大面积
+ * 灰阶在墨水屏上是抖动噪点，且每次变化都是一整块刷新）。
+ * ===================================================================== */
+
+/* 方角 + 去阴影 + 关动效：一条规则压平全部圆角/阴影/补间（逐选择器覆盖 20+
+   处 border-radius 是维护负担，e-ink 下它们统一归零，无一例外）。 */
+html.eink *,
+html.eink *::before,
+html.eink *::after {
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+    transition: none !important;
+    animation: none !important;
+}
+
+html.eink {
+    --hibiki-radius-card: 0;
+    /* 杀掉亚克力/半透明卡片底（Win11 backdrop 在 e-ink 上只是脏灰）。 */
+    --hibiki-card-bg-alpha: 1;
+    /* 查词命中不再用半透明色块（消费端见下方 underline 覆盖）。 */
+    --hoshi-primary-highlight: transparent;
+    /* tags：色块 → 透明底 + 描边（描边规则见下）。 */
+    --expr-tag-color: transparent;
+}
+
+/* 纯黑白变量：比 html[data-theme] 特异性高（0,2,1 > 0,1,1），连 Dart 注入的
+   --md-* 一并压掉（消费端读的是这些二级变量）。浅色=白底黑字，深色=黑底白字。 */
+html.eink[data-theme="light"] {
+    --background-color: #fff;
+    --background-color-light: #fff;
+    --background-color-dark1: #fff;
+    --text-color: #000;
+    --text-color-light1: #000;
+    --text-color-light2: #000;
+    --text-color-light3: #000;
+    --text-color-light4: #000;
+    --surface-container: #fff;
+    --surface-container-high: #fff;
+    --outline-variant: #000;
+    --primary-color: #000;
+    --on-surface-variant: #000;
+    --freq-tag-color: #000;
+    --hibiki-card-bg-rgb: 255, 255, 255;
+}
+
+html.eink[data-theme="dark"] {
+    --background-color: #000;
+    --background-color-light: #000;
+    --background-color-dark1: #000;
+    --text-color: #fff;
+    --text-color-light1: #fff;
+    --text-color-light2: #fff;
+    --text-color-light3: #fff;
+    --text-color-light4: #fff;
+    --surface-container: #000;
+    --surface-container-high: #000;
+    --outline-variant: #fff;
+    --primary-color: #fff;
+    --on-surface-variant: #fff;
+    --freq-tag-color: #fff;
+    --hibiki-card-bg-rgb: 0, 0, 0;
+}
+
+/* tags / 词频：色块改「透明底 + 1px 实线描边」；词频来源药丸反色（黑底白字 /
+   白底黑字），比灰阶底更清晰。 */
+html.eink .expr-tag,
+html.eink .deinflection-tag,
+html.eink .kanji-tag,
+html.eink .glossary-tag,
+html.eink .pitch-transcription-tag {
+    background-color: transparent;
+    border: 1px solid currentColor;
+}
+
+html.eink .frequency-dict-label {
+    color: var(--background-color);
+}
+
+/* 顶部动作按钮静息态 0.5 opacity 在墨水屏上是抖动灰，压到全不透明；交互反馈
+   由按下反色承担（active 态浏览器自带 :active opacity 覆盖被上面的关动效保留，
+   数值本身仍生效）。 */
+html.eink .audio-button,
+html.eink .favorite-button,
+html.eink .open-anki-button,
+html.eink .mine-button {
+    opacity: 1;
+}
+
+/* 特例态的彩色（收藏金 / 最新可改绿）在灰阶屏上失义，回归前景色。 */
+html.eink .favorite-button.favorited,
+html.eink .mine-button.latest {
+    color: var(--text-color);
+}
+
+/* 查词/嵌套查词命中：半透明色块 → 下划线（贴文字的一条线，刷新面积最小）。 */
+html.eink ::highlight(hoshi-selection) {
+    background-color: transparent;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+html.eink .hoshi-dict-highlight {
+    background-color: transparent !important;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+/* 原生拖选选区：反色块（纯黑白互换）——e-ink 上最清晰的选中态，无灰阶。 */
+html.eink ::selection {
+    background-color: var(--text-color);
+    color: var(--background-color);
+}
+
+/* 句子横幅的命中/外部查词高亮与逐字 hover：色块 → 下划线 / 描边。 */
+html.eink .global-lookup-sentence-hit,
+html.eink .global-lookup-ext-hit {
+    background: transparent;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+html.eink .global-lookup-sentence:not(.global-lookup-sentence-panel)
+    .global-lookup-sentence-char:hover {
+    background: transparent;
+    outline: 1px solid currentColor;
+    outline-offset: -1px;
+}
+
+/* app 外全局查词卡壳：半透明灰描边 → 实线前景色描边，方角，不透明底。 */
+html.eink.global-lookup body {
+    border: 1px solid var(--text-color);
+    background: var(--background-color);
 }

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 37570 (2210 per locale)
+/// Strings: 37604 (2212 per locale)
 ///
-/// Built on 2026-07-21 at 07:32 UTC
+/// Built on 2026-07-21 at 10:24 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2942,6 +2942,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get browser_extension_reinstall_button => 'Re-prepare / refresh files';
   String get browser_extension_server_on => 'Lookup server on';
   String get browser_extension_server_off => 'Lookup server off';
+  String get eink_mode => 'E-ink mode';
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -7940,6 +7943,11 @@ class _StringsAr extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -13011,6 +13019,11 @@ class _StringsDe extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -18098,6 +18111,11 @@ class _StringsEs extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -23196,6 +23214,11 @@ class _StringsFr extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -28221,6 +28244,11 @@ class _StringsId extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -33294,6 +33322,11 @@ class _StringsIt extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -38172,6 +38205,11 @@ class _StringsJa extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -43053,6 +43091,11 @@ class _StringsKo extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -48104,6 +48147,11 @@ class _StringsNl extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -53170,6 +53218,11 @@ class _StringsPtBr extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -58219,6 +58272,11 @@ class _StringsRu extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -63213,6 +63271,11 @@ class _StringsTh extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -68239,6 +68302,11 @@ class _StringsTr extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -73252,6 +73320,11 @@ class _StringsVi extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 // Path: <root>
@@ -77916,6 +77989,10 @@ class _StringsZhCn extends _StringsEn {
   String get browser_extension_server_on => '查词服务已开启';
   @override
   String get browser_extension_server_off => '查词服务未开启';
+  @override
+  String get eink_mode => '墨水屏模式';
+  @override
+  String get eink_mode_hint => '纯黑白主题、无动画、线式高亮，适合墨水屏设备';
 }
 
 // Path: <root>
@@ -82713,6 +82790,11 @@ class _StringsZhHk extends _StringsEn {
   String get browser_extension_server_on => 'Lookup server on';
   @override
   String get browser_extension_server_off => 'Lookup server off';
+  @override
+  String get eink_mode => 'E-ink mode';
+  @override
+  String get eink_mode_hint =>
+      'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
 }
 
 /// Flat map(s) containing all translations.
@@ -87225,6 +87307,10 @@ extension on _StringsEn {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -91735,6 +91821,10 @@ extension on _StringsAr {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -96266,6 +96356,10 @@ extension on _StringsDe {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -100796,6 +100890,10 @@ extension on _StringsEs {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -105332,6 +105430,10 @@ extension on _StringsFr {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -109850,6 +109952,10 @@ extension on _StringsId {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -114383,6 +114489,10 @@ extension on _StringsIt {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -118878,6 +118988,10 @@ extension on _StringsJa {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -123377,6 +123491,10 @@ extension on _StringsKo {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -127903,6 +128021,10 @@ extension on _StringsNl {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -132426,6 +132548,10 @@ extension on _StringsPtBr {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -136954,6 +137080,10 @@ extension on _StringsRu {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -141466,6 +141596,10 @@ extension on _StringsTh {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -145987,6 +146121,10 @@ extension on _StringsTr {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -150503,6 +150641,10 @@ extension on _StringsVi {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }
@@ -154985,6 +155127,10 @@ extension on _StringsZhCn {
         return '查词服务已开启';
       case 'browser_extension_server_off':
         return '查词服务未开启';
+      case 'eink_mode':
+        return '墨水屏模式';
+      case 'eink_mode_hint':
+        return '纯黑白主题、无动画、线式高亮，适合墨水屏设备';
       default:
         return null;
     }
@@ -159475,6 +159621,10 @@ extension on _StringsZhHk {
         return 'Lookup server on';
       case 'browser_extension_server_off':
         return 'Lookup server off';
+      case 'eink_mode':
+        return 'E-ink mode';
+      case 'eink_mode_hint':
+        return 'Pure black-and-white theme with no animations and line-style highlights, for e-ink displays';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "扩展版本",
   "browser_extension_reinstall_button": "重新准备 / 刷新文件",
   "browser_extension_server_on": "查词服务已开启",
-  "browser_extension_server_off": "查词服务未开启"
+  "browser_extension_server_off": "查词服务未开启",
+  "eink_mode": "墨水屏模式",
+  "eink_mode_hint": "纯黑白主题、无动画、线式高亮，适合墨水屏设备"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2208,5 +2208,7 @@
   "browser_extension_version_label": "Extension version",
   "browser_extension_reinstall_button": "Re-prepare / refresh files",
   "browser_extension_server_on": "Lookup server on",
-  "browser_extension_server_off": "Lookup server off"
+  "browser_extension_server_off": "Lookup server off",
+  "eink_mode": "E-ink mode",
+  "eink_mode_hint": "Pure black-and-white theme with no animations and line-style highlights, for e-ink displays"
 }

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -2321,6 +2321,10 @@ class AppModel with ChangeNotifier {
   Future<void> setBrightnessMode(String mode) =>
       themeNotifier.setBrightnessMode(mode);
 
+  /// 墨水屏模式（E-ink）：全局纯黑白主题 + 关动画 + 阅读器/弹窗高对比。
+  bool get einkMode => themeNotifier.einkMode;
+  Future<void> setEinkMode(bool value) => themeNotifier.setEinkMode(value);
+
   /// BUG-530：当前 app 主题（MD3 ColorScheme）的关键色 + 查词弹窗尺寸/列数/字号配置，作为
   /// CSS 变量喂给浏览器扩展的查词弹窗（经查词响应的 `theme` 字段下发，改主题/配置即生效，无需
   /// 重装扩展）。内容 content.js 把每一项 `setProperty` 到 `#entries-container` 上，popup.css

--- a/hibiki/lib/src/models/theme_notifier.dart
+++ b/hibiki/lib/src/models/theme_notifier.dart
@@ -94,6 +94,73 @@ ColorScheme buildHibikiColorScheme({
   );
 }
 
+/// E-ink mode (墨水屏模式): a pure black-and-white [ColorScheme] built by hand
+/// instead of `fromSeed` (any seed would leak hue into the neutral palette).
+/// Light = black text on white; dark = white text on black. Every surface
+/// container collapses to the background and every accent role collapses to
+/// the foreground, so nothing renders as a mid-gray that an e-ink panel would
+/// dither. Contrast between surfaces is re-introduced with explicit outlines
+/// in `_buildThemeData` (cards/switch tracks get 1px borders when eink is on).
+ColorScheme buildEinkColorScheme(Brightness brightness) {
+  final Color bg = brightness == Brightness.light ? Colors.white : Colors.black;
+  final Color fg = brightness == Brightness.light ? Colors.black : Colors.white;
+  return ColorScheme(
+    brightness: brightness,
+    primary: fg,
+    onPrimary: bg,
+    primaryContainer: bg,
+    onPrimaryContainer: fg,
+    secondary: fg,
+    onSecondary: bg,
+    secondaryContainer: bg,
+    onSecondaryContainer: fg,
+    tertiary: fg,
+    onTertiary: bg,
+    tertiaryContainer: bg,
+    onTertiaryContainer: fg,
+    error: fg,
+    onError: bg,
+    errorContainer: bg,
+    onErrorContainer: fg,
+    surface: bg,
+    onSurface: fg,
+    onSurfaceVariant: fg,
+    surfaceDim: bg,
+    surfaceBright: bg,
+    surfaceContainerLowest: bg,
+    surfaceContainerLow: bg,
+    surfaceContainer: bg,
+    surfaceContainerHigh: bg,
+    surfaceContainerHighest: bg,
+    outline: fg,
+    outlineVariant: fg,
+    shadow: Colors.transparent,
+    scrim: Colors.black,
+    inverseSurface: fg,
+    onInverseSurface: bg,
+    inversePrimary: bg,
+    surfaceTint: Colors.transparent,
+  );
+}
+
+/// Zero-motion route transition for e-ink displays: pushing/popping a page
+/// swaps content in a single frame instead of animating, so the panel does a
+/// single refresh rather than smearing through a fade/slide.
+class EinkNoPageTransitionsBuilder extends PageTransitionsBuilder {
+  const EinkNoPageTransitionsBuilder();
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return child;
+  }
+}
+
 /// Default seed for a brand-new / unconfigured custom theme. Matches the legacy
 /// `custom_theme_seed` default (the Hibiki brand teal); used by migration to
 /// decide whether a legacy custom theme was ever actually configured.
@@ -618,6 +685,20 @@ class ThemeNotifier extends ChangeNotifier {
     return list.first;
   }
 
+  /// E-ink mode (墨水屏模式). A single app-global switch (excluded from the
+  /// per-profile snapshot in ProfileKeys — it describes the physical display,
+  /// not a reading preference) that overlays the active theme with a pure
+  /// black-and-white scheme and disables page-transition animations. The
+  /// user's chosen theme key / brightness mode are left untouched, so turning
+  /// the switch off restores the previous colors exactly. Default OFF; getPref
+  /// returns the default only when the key was never written.
+  bool get einkMode => _get('eink_mode', defaultValue: false) as bool;
+
+  Future<void> setEinkMode(bool value) async {
+    await _set('eink_mode', value);
+    notifyListeners();
+  }
+
   String get brightnessMode {
     final String mode = _get('brightness_mode', defaultValue: '');
     if (mode.isNotEmpty) return mode;
@@ -807,6 +888,12 @@ class ThemeNotifier extends ChangeNotifier {
   ThemeData get darkTheme => _buildThemeData(Brightness.dark);
 
   ColorScheme buildColorScheme(Brightness brightness) {
+    // E-ink overlays every theme path (system / preset / custom) with pure
+    // black-and-white; the stored theme key is untouched so switching the
+    // toggle off restores the previous colors without any migration.
+    if (einkMode) {
+      return buildEinkColorScheme(brightness);
+    }
     if (appThemeKey == 'system-theme') {
       return buildSystemThemeColorScheme(
         brightness: brightness,
@@ -841,12 +928,30 @@ class ThemeNotifier extends ChangeNotifier {
   ThemeData _buildThemeData(Brightness brightness) {
     final cs = buildColorScheme(brightness);
     final TextTheme tt = _textThemeBuilder();
+    final bool eink = einkMode;
     return ThemeData(
       useMaterial3: true,
       colorScheme: cs,
       textTheme: tt,
+      // E-ink: swap pages in one frame (single panel refresh, no smearing) and
+      // drop ink ripples — a spreading translucent overlay is exactly the kind
+      // of repeated partial refresh slow panels render worst.
+      pageTransitionsTheme: eink
+          ? const PageTransitionsTheme(
+              builders: <TargetPlatform, PageTransitionsBuilder>{
+                TargetPlatform.android: EinkNoPageTransitionsBuilder(),
+                TargetPlatform.iOS: EinkNoPageTransitionsBuilder(),
+                TargetPlatform.macOS: EinkNoPageTransitionsBuilder(),
+                TargetPlatform.windows: EinkNoPageTransitionsBuilder(),
+                TargetPlatform.linux: EinkNoPageTransitionsBuilder(),
+                TargetPlatform.fuchsia: EinkNoPageTransitionsBuilder(),
+              },
+            )
+          : null,
+      splashFactory: eink ? NoSplash.splashFactory : null,
       extensions: <ThemeExtension<dynamic>>[
         HibikiDesignSystemTheme(designSystemTheme),
+        HibikiEinkTheme(eink),
       ],
       appBarTheme: const AppBarTheme(
         elevation: 0,
@@ -870,6 +975,9 @@ class ThemeNotifier extends ChangeNotifier {
               : cs.surfaceContainerHighest;
         }),
         trackOutlineColor: WidgetStateColor.resolveWith((states) {
+          // E-ink: the selected track is primaryContainer == the background, so
+          // without an outline the switch body vanishes into the page.
+          if (eink) return cs.outline;
           return states.contains(WidgetState.selected)
               ? Colors.transparent
               : cs.outline;
@@ -928,6 +1036,9 @@ class ThemeNotifier extends ChangeNotifier {
         color: cs.surfaceContainerLow,
         shape: RoundedRectangleBorder(
           borderRadius: HibikiBorderRadius.card,
+          // E-ink: surfaceContainerLow == the page background, so cards need a
+          // solid outline to keep their boundary readable in pure black/white.
+          side: eink ? BorderSide(color: cs.outline) : BorderSide.none,
         ),
       ),
       bottomSheetTheme: const BottomSheetThemeData(
@@ -972,7 +1083,9 @@ class ThemeNotifier extends ChangeNotifier {
       ),
       dividerTheme: DividerThemeData(
         color: cs.outlineVariant,
-        thickness: 0.5,
+        // E-ink panels can't render a crisp half-pixel hairline; use a full
+        // pixel so dividers stay solid black/white lines.
+        thickness: eink ? 1 : 0.5,
       ),
     );
   }

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -345,8 +345,10 @@ class _PopupEntranceFadeState extends State<_PopupEntranceFade> {
   @override
   Widget build(BuildContext context) {
     return AnimatedOpacity(
+      // 墨水屏模式：淡入归零为瞬时显示——慢刷新屏上 0→1 补间是一段灰阶残影，
+      // 且弹窗「先出壳后出内容」的观感在 e-ink 上尤其糟。
       opacity: widget.visible && _revealed ? 1.0 : 0.0,
-      duration: _kSlideDuration,
+      duration: isEinkTheme(context) ? Duration.zero : _kSlideDuration,
       curve: Curves.easeOut,
       child: widget.child,
     );
@@ -971,6 +973,15 @@ class _BodySwipeDismissDetectorState extends State<_BodySwipeDismissDetector>
     _controller = AnimationController(vsync: this, duration: _kSlideDuration)
       ..addListener(_onTick)
       ..addStatusListener(_onStatus);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // 墨水屏模式：滑出/弹回补间归零（Duration.zero 的 forward 立即 complete，
+    // onDismiss 时序不变，只是不再画补间帧）。跟随主题切换双向生效。
+    _controller.duration =
+        isEinkTheme(context) ? Duration.zero : _kSlideDuration;
   }
 
   @override

--- a/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
@@ -15,6 +15,7 @@ import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_webview.dart';
+import 'package:hibiki/src/utils/adaptive/adaptive_platform.dart';
 import 'package:hibiki/src/utils/popup_theme_css.dart';
 import 'package:hibiki/src/reader/dictionary_font_css.dart';
 import 'package:hibiki/src/reader/reader_settings.dart';
@@ -81,8 +82,17 @@ String _themeVariablesJs({
       : (mobileExternal
           ? "document.documentElement.classList.add('mobile-external');\n"
           : '');
+  // 墨水屏模式：给 <html> 挂 eink class（popup.css 末尾的 html.eink 覆盖块吃它，
+  // 纯黑白/方角/实线边框/关过渡）。用 toggle 而非 add——in-app 热槽 WebView 跨渲染
+  // 持久，开关关掉后重注入必须能把 class 摘掉。标志从传入的 ThemeData 扩展读
+  // （HibikiEinkTheme，_buildThemeData 挂上），不走 appModel.themeNotifier——
+  // 本函数在弹窗 widget 测试里会被未 initialise 的裸 AppModel 调到（late
+  // themeNotifier 未初始化），theme 才是这里已有的真相源。
+  final bool eink = theme.extension<HibikiEinkTheme>()?.einkMode ?? false;
+  final String einkLine =
+      "document.documentElement.classList.toggle('eink', $eink);\n";
   return '''
-      $classLine      document.documentElement.setAttribute('data-theme', '${isDark ? 'dark' : 'light'}');
+      $classLine      $einkLine      document.documentElement.setAttribute('data-theme', '${isDark ? 'dark' : 'light'}');
       document.documentElement.style.setProperty('--hoshi-primary-highlight', '${vars['--hoshi-primary-highlight']}');
       document.documentElement.style.setProperty('--text-color', '${vars['--text-color']}');
       document.documentElement.style.setProperty('--background-color', '${vars['--background-color']}');

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -2429,6 +2429,10 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
       selectionColor: _colorToCssRgba(rc.selection),
       sasayakiColor: _colorToCssRgba(rc.sasayaki),
       linkColor: _colorToCssRgba(rc.link),
+      // 墨水屏模式：全局单开关叠加在阅读器主题之上（纯黑白+线式高亮+关过渡），
+      // 黑白方向跟 app 明暗模式，与全局 E-ink ColorScheme 一致。
+      einkMode: appModel.einkMode,
+      einkDark: appModel.isDarkMode,
     );
   }
 

--- a/hibiki/lib/src/profile/profile_keys.dart
+++ b/hibiki/lib/src/profile/profile_keys.dart
@@ -31,6 +31,10 @@ class ProfileKeys {
     'app_ui_scale',
     'app_ui_scale_mode',
     'app_locale',
+    // E-ink mode describes the physical display the app is running on (same
+    // family as app_ui_scale), never a per-profile reading preference —
+    // snapshotting it would flip the whole app's colors on profile switch.
+    'eink_mode',
     'last_selected_deck',
     'last_selected_dictionary_format',
     'last_selected_model',

--- a/hibiki/lib/src/reader/reader_content_styles.dart
+++ b/hibiki/lib/src/reader/reader_content_styles.dart
@@ -141,6 +141,8 @@ class ReaderContentStyles {
     String? sasayakiColor,
     String? linkColor,
     String? themeOverride,
+    bool einkMode = false,
+    bool einkDark = false,
   }) {
     return '<style>\n${css(
       settings: settings,
@@ -152,6 +154,8 @@ class ReaderContentStyles {
       sasayakiColor: sasayakiColor,
       linkColor: linkColor,
       themeOverride: themeOverride,
+      einkMode: einkMode,
+      einkDark: einkDark,
     )}\n</style>';
   }
 
@@ -165,9 +169,28 @@ class ReaderContentStyles {
     String? sasayakiColor,
     String? linkColor,
     String? themeOverride,
+    // 墨水屏模式：强制纯黑白正文 + 线式高亮 + 关过渡（叠加在任意主题之上，见
+    // 文件末尾 _einkOverrideCss）。einkDark 决定黑底白字还是白底黑字，取自 app
+    // 明暗模式（与全局 E-ink 主题一致），不读阅读器自己的 theme key。
+    bool einkMode = false,
+    bool einkDark = false,
   }) {
-    final _ThemeColors colors = _themeColors(themeOverride ?? settings.theme,
-        customBg: customBg, customFg: customFg);
+    final _ThemeColors themedColors = _themeColors(
+        themeOverride ?? settings.theme,
+        customBg: customBg,
+        customFg: customFg);
+    // E-ink 覆盖发生在配色解析之后：正文/滚动条/UA color-scheme 全部吃纯黑白，
+    // 高亮的「线式化」由末尾的 _einkOverrideCss 用级联覆盖（同选择器后出现者胜）。
+    final _ThemeColors colors = einkMode
+        ? _ThemeColors(
+            textColor: einkDark ? '#fff' : '#000',
+            backgroundColor: einkDark ? '#000' : '#fff',
+            selectionColor: einkDark ? '#fff' : '#000',
+            sasayakiColor: 'transparent',
+            linkColor: einkDark ? '#fff' : '#000',
+            colorScheme: einkDark ? 'dark' : 'light',
+          )
+        : themedColors;
 
     // 查词高亮用「预合成到背景色的不透明色」：在无重叠区与原半透明色像素一致，
     // 但在与音频(sasayaki)高亮重叠区会覆盖其下的灰层 → 单层、查词优先、无双重高亮
@@ -666,6 +689,107 @@ ruby.hoshi-selection-ruby-active.hoshi-sasayaki-ruby-active {
 }
 a {
   color: ${linkColor ?? colors.linkColor}$readerStylePriority;
+}
+${einkMode ? _einkOverrideCss(einkDark: einkDark) : ''}
+''';
+  }
+
+  /// 墨水屏模式覆盖块（追加在正文 CSS 最末尾，级联优先级最高）。
+  ///
+  /// 设计对齐 Hoshi-Reader-Android 的 E-ink 适配：
+  /// - 高亮全部从「半透明色块背景」改为**线式标记**——色块在墨水屏上是一大片
+  ///   抖动灰阶，且每次高亮移动都触发大面积刷新；下划线只刷新贴近文字的一条线。
+  ///   查词选区=粗实线、有声书跟随=虚线、搜索命中=双线、收藏句=保留原下划线但
+  ///   去掉色块（五色在灰阶屏上不可分，线本身就是收藏语义）。
+  /// - `--hoshi-reader-eink-mode: 1` 点亮 JS 侧既有的 isEInkMode() 分支
+  ///   （reader_visual_novel_scripts / 连续模式滚动缓动短路）。
+  /// - 关掉书籍自带的 transition/animation，慢刷新屏上任何补间都是残影。
+  static String _einkOverrideCss({required bool einkDark}) {
+    final String fg = einkDark ? '#fff' : '#000';
+    return '''
+/* ── E-ink 墨水屏模式覆盖（必须保持在生成 CSS 的最末尾） ── */
+:root {
+  --hoshi-reader-eink-mode: 1;
+  --hoshi-sel-handle: $fg;
+  --hoshi-sasayaki-text-color: inherit;
+  --hoshi-sasayaki-background-color: transparent;
+}
+* {
+  transition: none !important;
+  animation: none !important;
+}
+::highlight(hoshi-selection) {
+  background-color: transparent;
+  color: inherit;
+  text-decoration-line: underline;
+  text-decoration-color: $fg;
+  text-decoration-thickness: 0.14em;
+  text-underline-offset: 0.18em;
+}
+ruby.hoshi-selection-ruby-active {
+  background-color: transparent !important;
+  color: inherit !important;
+  text-decoration-line: underline !important;
+  text-decoration-color: $fg !important;
+  text-decoration-thickness: 0.14em !important;
+  text-underline-offset: 0.18em !important;
+}
+.hoshi-dict-highlight {
+  background-color: transparent !important;
+  color: inherit !important;
+  text-decoration-line: underline !important;
+  text-decoration-color: $fg !important;
+  text-decoration-thickness: 0.14em !important;
+  text-underline-offset: 0.18em !important;
+}
+::highlight(hoshi-sasayaki) {
+  background-color: transparent;
+  color: inherit;
+  text-decoration-line: underline;
+  text-decoration-style: dashed;
+  text-decoration-color: $fg;
+  text-decoration-thickness: 0.10em;
+  text-underline-offset: 0.18em;
+}
+ruby.hoshi-sasayaki-ruby-active {
+  background-color: transparent !important;
+  color: inherit !important;
+  text-decoration-line: underline !important;
+  text-decoration-style: dashed !important;
+  text-decoration-color: $fg !important;
+  text-decoration-thickness: 0.10em !important;
+  text-underline-offset: 0.18em !important;
+}
+.hoshi-sasayaki-cue.hoshi-sasayaki-active {
+  background-color: transparent !important;
+  color: inherit !important;
+  text-decoration-line: underline !important;
+  text-decoration-style: dashed !important;
+  text-decoration-color: $fg !important;
+  text-decoration-thickness: 0.10em !important;
+  text-underline-offset: 0.18em !important;
+}
+/* 查词+有声书重叠：查词的粗实线优先（双类特异性高于单类，语义同 BUG-125）。 */
+ruby.hoshi-selection-ruby-active.hoshi-sasayaki-ruby-active {
+  text-decoration-style: solid !important;
+  text-decoration-thickness: 0.14em !important;
+}
+::highlight(hoshi-search) {
+  background-color: transparent;
+  text-decoration-line: underline;
+  text-decoration-style: double;
+  text-decoration-color: $fg;
+}
+::highlight(hoshi-hl-yellow), .hoshi-hl-yellow, ruby.hoshi-hl-yellow-ruby-active,
+::highlight(hoshi-hl-green), .hoshi-hl-green, ruby.hoshi-hl-green-ruby-active,
+::highlight(hoshi-hl-blue), .hoshi-hl-blue, ruby.hoshi-hl-blue-ruby-active,
+::highlight(hoshi-hl-pink), .hoshi-hl-pink, ruby.hoshi-hl-pink-ruby-active,
+::highlight(hoshi-hl-purple), .hoshi-hl-purple, ruby.hoshi-hl-purple-ruby-active {
+  background-color: transparent;
+  text-decoration-color: $fg;
+}
+a {
+  color: $fg !important;
 }
 ''';
   }

--- a/hibiki/lib/src/reader/reader_pagination_scripts.dart
+++ b/hibiki/lib/src/reader/reader_pagination_scripts.dart
@@ -2711,20 +2711,25 @@ $_sharedJs
     var rect = this.getRect(target);
     var margin = 0.15;
     var wm = window.getComputedStyle(document.body).writingMode;
+    // 墨水屏模式（--hoshi-reader-eink-mode: 1，由 ReaderContentStyles 的 eink 覆盖块
+    // 注入）：跟随滚动退化为瞬时跳——慢刷新屏上 smooth 补间是一整段残影。普通模式
+    // 保持 TODO-825 的 smooth（用户点名要动画，settle 窗治闪屏），零行为变化。
+    var behavior = (window.getComputedStyle(document.documentElement)
+      .getPropertyValue('--hoshi-reader-eink-mode').trim() === '1') ? 'auto' : 'smooth';
     if (wm.startsWith('vertical')) {
       var vw = window.innerWidth;
       var safe = vw * margin;
       if (rect.left >= safe && rect.right <= vw - safe) return false;
       if (wm === 'vertical-rl') {
-        window.scrollBy({left: rect.right - (vw - safe), behavior: 'smooth'});
+        window.scrollBy({left: rect.right - (vw - safe), behavior: behavior});
       } else {
-        window.scrollBy({left: rect.left - safe, behavior: 'smooth'});
+        window.scrollBy({left: rect.left - safe, behavior: behavior});
       }
     } else {
       var vh = window.innerHeight;
       var safe = vh * margin;
       if (rect.top >= safe && rect.bottom <= vh - safe) return false;
-      window.scrollBy({top: rect.top - safe, behavior: 'smooth'});
+      window.scrollBy({top: rect.top - safe, behavior: behavior});
     }
     return true;
   },

--- a/hibiki/lib/src/settings/settings_schema_appearance.dart
+++ b/hibiki/lib/src/settings/settings_schema_appearance.dart
@@ -32,6 +32,20 @@ SettingsDestination buildAppearanceDestination() {
             icon: Icons.contrast_outlined,
             builder: buildBrightnessSelector,
           ),
+          // 墨水屏模式：全局单开关（设备属性，不随 Profile 快照），叠加在主题/
+          // 明暗机制之上——开=纯黑白+无动画+线式高亮，关=还原原主题。
+          SettingsSwitchItem(
+            id: 'appearance.eink_mode',
+            title: t.eink_mode,
+            subtitle: t.eink_mode_hint,
+            icon: Icons.filter_b_and_w_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.einkMode,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel.setEinkMode(value);
+              settingsContext.refresh();
+            },
+          ),
           // 「界面大小」滑条用自定义有状态行：拖动中只更新局部值跟手，松手才提交
           // 真实缩放（见 buildAppUiScaleSelector）。这样拖动期间不触发全局
           // HibikiAppUiScale 的 Transform 重排，滑条不会在手指下被缩放位移、可连续拖。

--- a/hibiki/lib/src/utils/adaptive/adaptive_platform.dart
+++ b/hibiki/lib/src/utils/adaptive/adaptive_platform.dart
@@ -33,6 +33,34 @@ class HibikiDesignSystemTheme extends ThemeExtension<HibikiDesignSystemTheme> {
   }
 }
 
+/// 墨水屏模式标志的 ThemeExtension 载体。挂在 ThemeNotifier._buildThemeData 的
+/// extensions 里，使任意 widget 可经 `Theme.of(context)` 感知 eink（用于把入场
+/// 淡入/滑出等 Flutter 侧动画时长归零），零新增数据流、随主题重建自动更新。
+@immutable
+class HibikiEinkTheme extends ThemeExtension<HibikiEinkTheme> {
+  const HibikiEinkTheme(this.einkMode);
+
+  final bool einkMode;
+
+  @override
+  HibikiEinkTheme copyWith({bool? einkMode}) {
+    return HibikiEinkTheme(einkMode ?? this.einkMode);
+  }
+
+  @override
+  HibikiEinkTheme lerp(
+    covariant ThemeExtension<HibikiEinkTheme>? other,
+    double t,
+  ) {
+    return this;
+  }
+}
+
+/// True 当墨水屏模式开启（读不到扩展时为 false，测试裸 ThemeData 零破坏）。
+bool isEinkTheme(BuildContext context) {
+  return Theme.of(context).extension<HibikiEinkTheme>()?.einkMode ?? false;
+}
+
 bool isCupertinoPlatform(BuildContext context) {
   final HibikiDesignSystem designSystem =
       Theme.of(context).extension<HibikiDesignSystemTheme>()?.designSystem ??

--- a/hibiki/test/build/popup_css_eink_guard_test.dart
+++ b/hibiki/test/build/popup_css_eink_guard_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 墨水屏模式弹窗 CSS 守卫：
+///  1. popup.css 必须含 `html.eink` 覆盖块（纯黑白变量 + 方角/去阴影/关动效的
+///     通配压平规则），且生成的 content.css 里被正确重挂为
+///     `:where(#entries-container).eink`（扩展侧同样生效）。
+///  2. 花括号配平守卫——回归自真实 bug：`.ctx-adjust-button` 规则曾缺闭合 `}`，
+///     CSS 错误恢复把下一条 `.global-lookup-ext-hit` 整条高亮规则当无效声明
+///     吞掉（高亮从未生效）。配平检查让这一类「少个括号、静默吞掉后续规则」
+///     在测试层直接翻红。
+///
+/// flutter test cwd 是 hibiki 包根。
+void main() {
+  const String popupCssPath = 'assets/popup/popup.css';
+  const String contentCssPath = 'assets/browser_extension/vendor/content.css';
+
+  String stripComments(String css) =>
+      css.replaceAll(RegExp(r'/\*[\s\S]*?\*/'), '');
+
+  test('popup.css braces are balanced (swallowed-rule guard)', () {
+    final String css = stripComments(File(popupCssPath).readAsStringSync());
+    final int open = '{'.allMatches(css).length;
+    final int close = '}'.allMatches(css).length;
+    expect(open, close,
+        reason: 'popup.css 花括号不配平（$open 个 { vs $close 个 }）——缺闭合的'
+            '规则会静默吞掉下一条规则（见 .ctx-adjust-button 历史 bug）');
+  });
+
+  test('popup.css carries the html.eink override block', () {
+    final String css = File(popupCssPath).readAsStringSync();
+    expect(css, contains('html.eink'));
+    // 方角/去阴影/关动效的通配压平。
+    expect(css, contains('border-radius: 0 !important'));
+    // 纯黑白两向变量块。
+    expect(css, contains('html.eink[data-theme="light"]'));
+    expect(css, contains('html.eink[data-theme="dark"]'));
+    // 线式查词高亮 + 反色原生选区。
+    expect(css, contains('html.eink ::selection'));
+  });
+
+  test('generated content.css re-roots html.eink for the extension', () {
+    final String css = File(contentCssPath).readAsStringSync();
+    expect(css, contains(':where(#entries-container).eink'));
+    expect(css, contains(':where(#entries-container).eink[data-theme="dark"]'));
+  });
+}

--- a/hibiki/test/reader/audiobook_follow_scroll_settle_guard_test.dart
+++ b/hibiki/test/reader/audiobook_follow_scroll_settle_guard_test.dart
@@ -54,24 +54,48 @@ void main() {
   }
 
   group('TODO-825 跟随滚动恢复平滑动画（不得退化 instant）', () {
-    test('scrollToTarget 三条滚动分支均为 behavior:smooth', () {
+    // 墨水屏模式（eink）更新：三条 scrollBy 的 behavior 收敛为一个共享变量——
+    // 默认仍是 'smooth'（TODO-825 契约不变），仅当 CSS 变量
+    // --hoshi-reader-eink-mode === '1'（用户显式开墨水屏模式）才取 'auto' 瞬时。
+    // 守卫从「三处 smooth 字面量」改为锁这个变量化后的等价不变式：
+    //   ① behavior 变量的 smooth 默认 + eink 门控必须存在；
+    //   ② 三条 scrollBy 都必须走该变量（不得偷偷写死 instant/auto）。
+    test('scrollToTarget：behavior 默认 smooth、仅 eink 降 auto', () {
       final String body = scrollToTargetBody();
-      final int hits = RegExp(r"behavior:\s*'smooth'").allMatches(body).length;
+      expect(
+        RegExp(r"--hoshi-reader-eink-mode").hasMatch(body),
+        isTrue,
+        reason: 'behavior 的瞬时分支必须由墨水屏模式 CSS 变量门控（用户显式 opt-in），'
+            '不得无条件砍动画',
+      );
+      expect(
+        RegExp(r"\?\s*'auto'\s*:\s*'smooth'").hasMatch(body),
+        isTrue,
+        reason: 'behavior 三元的默认分支必须是 smooth（用户要求恢复平滑动画，'
+            'TODO-803 砍成 instant 已被驳回；eink 才允许 auto）',
+      );
+      final int hits = RegExp(r'behavior:\s*behavior').allMatches(body).length;
       expect(
         hits,
         greaterThanOrEqualTo(3),
-        reason: 'scrollToTarget 竖排 rl / 竖排 lr / 横排三条 scrollBy 都必须 smooth'
-            '（用户要求恢复平滑动画，TODO-803 砍成 instant 已被驳回）',
+        reason: 'scrollToTarget 竖排 rl / 竖排 lr / 横排三条 scrollBy 都必须走共享的 '
+            'behavior 变量（默认 smooth）',
       );
     });
 
-    test('scrollToTarget 不得用 behavior:instant（砍动画回归）', () {
+    test('scrollToTarget 不得写死 behavior:instant/smooth 之外的字面量（砍动画回归）', () {
       final String body = scrollToTargetBody();
       expect(
         RegExp(r"behavior:\s*'instant'").hasMatch(body),
         isFalse,
         reason: '跟随滚动退化成 instant = 砍掉动画 = 回归 TODO-803 被驳回的修法；'
             '闪烁必须靠 settle 窗治住，不靠砍动画',
+      );
+      expect(
+        RegExp(r"behavior:\s*'auto'").hasMatch(body),
+        isFalse,
+        reason: "写死 behavior:'auto' 同样是无条件砍动画；瞬时只能经 eink 门控的 "
+            'behavior 变量',
       );
     });
   });

--- a/hibiki/test/reader/reader_eink_mode_test.dart
+++ b/hibiki/test/reader/reader_eink_mode_test.dart
@@ -1,0 +1,111 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:hibiki/src/models/theme_notifier.dart';
+import 'package:hibiki/src/profile/profile_keys.dart';
+import 'package:hibiki/src/reader/reader_content_styles.dart';
+import 'package:hibiki/src/reader/reader_settings.dart';
+
+/// 墨水屏模式（eink_mode）守卫：
+///  1. 阅读器 CSS 生成器的 eink 分支——纯黑白正文、线式高亮、关过渡、
+///     `--hoshi-reader-eink-mode: 1`（JS 侧 isEInkMode() 与连续模式跟随滚动
+///     瞬时化都读它）；关掉时逐项不出现（零行为变化）。
+///  2. buildEinkColorScheme——纯黑白 ColorScheme（手工构造，不走 fromSeed），
+///     surfaceTint/shadow 透明（e-ink 不能有 elevation 灰阶）。
+///  3. eink_mode 必须在 Profile 快照黑名单里（设备属性，切 Profile 不回滚）。
+Future<ReaderSettings> _defaultSettings() async {
+  final HibikiDatabase db = HibikiDatabase.forTesting(NativeDatabase.memory());
+  addTearDown(db.close);
+  final ReaderSettings settings = ReaderSettings(db);
+  await settings.refreshFromDb();
+  return settings;
+}
+
+void main() {
+  group('ReaderContentStyles.css eink branch', () {
+    test('einkMode=true (light) forces pure black-on-white body', () async {
+      final ReaderSettings settings = await _defaultSettings();
+      final String css = ReaderContentStyles.css(
+        settings: settings,
+        einkMode: true,
+      );
+      expect(css, contains('--hoshi-reader-eink-mode: 1'));
+      expect(css, contains('background: #fff !important'));
+      expect(css, contains('color: #000 !important'));
+      // 关过渡：书籍自带动画一并压掉。
+      expect(css, contains('transition: none !important'));
+      expect(css, contains('animation: none !important'));
+      // 线式高亮：查词=实线、sasayaki=虚线、搜索=双线。
+      expect(css, contains('text-decoration-style: dashed'));
+      expect(css, contains('text-decoration-style: double'));
+      expect(css, contains('text-decoration-line: underline'));
+    });
+
+    test('einkMode=true honours einkDark (white-on-black)', () async {
+      final ReaderSettings settings = await _defaultSettings();
+      final String css = ReaderContentStyles.css(
+        settings: settings,
+        einkMode: true,
+        einkDark: true,
+      );
+      expect(css, contains('background: #000 !important'));
+      expect(css, contains('color: #fff !important'));
+      expect(css, contains('--hoshi-reader-eink-mode: 1'));
+    });
+
+    test('einkMode=true overrides themed colors even for preset themes',
+        () async {
+      final ReaderSettings settings = await _defaultSettings();
+      final String css = ReaderContentStyles.css(
+        settings: settings,
+        themeOverride: 'ecru-theme',
+        einkMode: true,
+      );
+      // ecru 的手调底色被 eink 压掉。
+      expect(css, isNot(contains('#f7f6eb')));
+      expect(css, contains('background: #fff !important'));
+    });
+
+    test('einkMode=false (default) leaves normal output untouched', () async {
+      final ReaderSettings settings = await _defaultSettings();
+      final String css = ReaderContentStyles.css(settings: settings);
+      expect(css, isNot(contains('--hoshi-reader-eink-mode')));
+      expect(css, isNot(contains('text-decoration-style: dashed')));
+      // sasayaki 仍是色块填充（背景变量非 transparent）。
+      expect(css, contains('--hoshi-sasayaki-background-color: rgba'));
+    });
+  });
+
+  group('buildEinkColorScheme', () {
+    test('light = black on white, no tint/shadow', () {
+      final ColorScheme cs = buildEinkColorScheme(Brightness.light);
+      expect(cs.surface, Colors.white);
+      expect(cs.onSurface, Colors.black);
+      expect(cs.primary, Colors.black);
+      expect(cs.onPrimary, Colors.white);
+      expect(cs.outline, Colors.black);
+      expect(cs.surfaceContainerLow, Colors.white);
+      expect(cs.surfaceContainerHighest, Colors.white);
+      expect(cs.surfaceTint, Colors.transparent);
+      expect(cs.shadow, Colors.transparent);
+    });
+
+    test('dark = white on black', () {
+      final ColorScheme cs = buildEinkColorScheme(Brightness.dark);
+      expect(cs.surface, Colors.black);
+      expect(cs.onSurface, Colors.white);
+      expect(cs.primary, Colors.white);
+      expect(cs.onPrimary, Colors.black);
+      expect(cs.outline, Colors.white);
+      expect(cs.surfaceTint, Colors.transparent);
+    });
+  });
+
+  group('profile snapshot exclusion', () {
+    test('eink_mode is app-global (excluded from per-profile snapshot)', () {
+      expect(ProfileKeys.isExcludedPref('eink_mode'), isTrue,
+          reason: 'eink_mode 描述物理屏幕，切 Profile 不得把整个 app 颜色翻转回去');
+    });
+  });
+}

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -1406,11 +1406,164 @@
 
 .ctx-adjust-button {
     opacity: 0.85;
+}
+
 /* 真机第 5 轮 — 面板释义区被点击、正在外部瞬态窗里查的那段文字的高亮
-   （markGlobalLookupExtHit；下次点击替换、重渲清除）。 */
+   （markGlobalLookupExtHit；下次点击替换、重渲清除）。
+   BUG：上面 .ctx-adjust-button 规则原缺闭合 }，CSS 错误恢复把本条整规则当无效
+   声明吞掉（ext-hit 高亮从未生效）；补上闭合后本条恢复。 */
 .global-lookup-ext-hit {
     background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.22));
     border-radius: 2px;
+}
+
+/* =====================================================================
+ * E-ink 墨水屏模式（html.eink）。
+ *
+ * class 由 popup_settings_injection.dart 的 _themeVariablesJs 注入（toggle，
+ * 热复用 WebView 关掉开关也能摘除）；三镜像纪律：改这里必须同步两个 vendor
+ * popup.css 并重新跑 generate-content-css.mjs（生成器把 html.eink 重挂为
+ * :where(#entries-container).eink，扩展侧同样生效）。
+ *
+ * 设计对齐 Hoshi-Reader-Android 的 E-ink 弹窗：纯黑白、方角、实线边框、
+ * 关 transition/animation/阴影；半透明色块高亮改为反色或下划线（大面积
+ * 灰阶在墨水屏上是抖动噪点，且每次变化都是一整块刷新）。
+ * ===================================================================== */
+
+/* 方角 + 去阴影 + 关动效：一条规则压平全部圆角/阴影/补间（逐选择器覆盖 20+
+   处 border-radius 是维护负担，e-ink 下它们统一归零，无一例外）。 */
+:where(#entries-container).eink *,
+:where(#entries-container).eink *::before,
+:where(#entries-container).eink *::after {
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+    transition: none !important;
+    animation: none !important;
+}
+
+:where(#entries-container).eink {
+    --hibiki-radius-card: 0;
+    /* 杀掉亚克力/半透明卡片底（Win11 backdrop 在 e-ink 上只是脏灰）。 */
+    --hibiki-card-bg-alpha: 1;
+    /* 查词命中不再用半透明色块（消费端见下方 underline 覆盖）。 */
+    --hoshi-primary-highlight: transparent;
+    /* tags：色块 → 透明底 + 描边（描边规则见下）。 */
+    --expr-tag-color: transparent;
+}
+
+/* 纯黑白变量：比 html[data-theme] 特异性高（0,2,1 > 0,1,1），连 Dart 注入的
+   --md-* 一并压掉（消费端读的是这些二级变量）。浅色=白底黑字，深色=黑底白字。 */
+:where(#entries-container).eink[data-theme="light"] {
+    --background-color: #fff;
+    --background-color-light: #fff;
+    --background-color-dark1: #fff;
+    --text-color: #000;
+    --text-color-light1: #000;
+    --text-color-light2: #000;
+    --text-color-light3: #000;
+    --text-color-light4: #000;
+    --surface-container: #fff;
+    --surface-container-high: #fff;
+    --outline-variant: #000;
+    --primary-color: #000;
+    --on-surface-variant: #000;
+    --freq-tag-color: #000;
+    --hibiki-card-bg-rgb: 255, 255, 255;
+}
+
+:where(#entries-container).eink[data-theme="dark"] {
+    --background-color: #000;
+    --background-color-light: #000;
+    --background-color-dark1: #000;
+    --text-color: #fff;
+    --text-color-light1: #fff;
+    --text-color-light2: #fff;
+    --text-color-light3: #fff;
+    --text-color-light4: #fff;
+    --surface-container: #000;
+    --surface-container-high: #000;
+    --outline-variant: #fff;
+    --primary-color: #fff;
+    --on-surface-variant: #fff;
+    --freq-tag-color: #fff;
+    --hibiki-card-bg-rgb: 0, 0, 0;
+}
+
+/* tags / 词频：色块改「透明底 + 1px 实线描边」；词频来源药丸反色（黑底白字 /
+   白底黑字），比灰阶底更清晰。 */
+:where(#entries-container).eink .expr-tag,
+:where(#entries-container).eink .deinflection-tag,
+:where(#entries-container).eink .kanji-tag,
+:where(#entries-container).eink .glossary-tag,
+:where(#entries-container).eink .pitch-transcription-tag {
+    background-color: transparent;
+    border: 1px solid currentColor;
+}
+
+:where(#entries-container).eink .frequency-dict-label {
+    color: var(--background-color);
+}
+
+/* 顶部动作按钮静息态 0.5 opacity 在墨水屏上是抖动灰，压到全不透明；交互反馈
+   由按下反色承担（active 态浏览器自带 :active opacity 覆盖被上面的关动效保留，
+   数值本身仍生效）。 */
+:where(#entries-container).eink .audio-button,
+:where(#entries-container).eink .favorite-button,
+:where(#entries-container).eink .open-anki-button,
+:where(#entries-container).eink .mine-button {
+    opacity: 1;
+}
+
+/* 特例态的彩色（收藏金 / 最新可改绿）在灰阶屏上失义，回归前景色。 */
+:where(#entries-container).eink .favorite-button.favorited,
+:where(#entries-container).eink .mine-button.latest {
+    color: var(--text-color);
+}
+
+/* 查词/嵌套查词命中：半透明色块 → 下划线（贴文字的一条线，刷新面积最小）。 */
+:where(#entries-container).eink ::highlight(hoshi-selection) {
+    background-color: transparent;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+:where(#entries-container).eink .hoshi-dict-highlight {
+    background-color: transparent !important;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+/* 原生拖选选区：反色块（纯黑白互换）——e-ink 上最清晰的选中态，无灰阶。 */
+:where(#entries-container).eink ::selection {
+    background-color: var(--text-color);
+    color: var(--background-color);
+}
+
+/* 句子横幅的命中/外部查词高亮与逐字 hover：色块 → 下划线 / 描边。 */
+:where(#entries-container).eink .global-lookup-sentence-hit,
+:where(#entries-container).eink .global-lookup-ext-hit {
+    background: transparent;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+:where(#entries-container).eink .global-lookup-sentence:not(.global-lookup-sentence-panel) .global-lookup-sentence-char:hover {
+    background: transparent;
+    outline: 1px solid currentColor;
+    outline-offset: -1px;
+}
+
+/* app 外全局查词卡壳：半透明灰描边 → 实线前景色描边，方角，不透明底。 */
+:where(#entries-container).eink.global-lookup body {
+    border: 1px solid var(--text-color);
+    background: var(--background-color);
 }
 
 /*

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -1489,9 +1489,163 @@ html.global-lookup[data-theme="dark"] body {
 
 .ctx-adjust-button {
     opacity: 0.85;
+}
+
 /* 真机第 5 轮 — 面板释义区被点击、正在外部瞬态窗里查的那段文字的高亮
-   （markGlobalLookupExtHit；下次点击替换、重渲清除）。 */
+   （markGlobalLookupExtHit；下次点击替换、重渲清除）。
+   BUG：上面 .ctx-adjust-button 规则原缺闭合 }，CSS 错误恢复把本条整规则当无效
+   声明吞掉（ext-hit 高亮从未生效）；补上闭合后本条恢复。 */
 .global-lookup-ext-hit {
     background: var(--hoshi-primary-highlight, rgba(56, 106, 88, 0.22));
     border-radius: 2px;
+}
+
+/* =====================================================================
+ * E-ink 墨水屏模式（html.eink）。
+ *
+ * class 由 popup_settings_injection.dart 的 _themeVariablesJs 注入（toggle，
+ * 热复用 WebView 关掉开关也能摘除）；三镜像纪律：改这里必须同步两个 vendor
+ * popup.css 并重新跑 generate-content-css.mjs（生成器把 html.eink 重挂为
+ * :where(#entries-container).eink，扩展侧同样生效）。
+ *
+ * 设计对齐 Hoshi-Reader-Android 的 E-ink 弹窗：纯黑白、方角、实线边框、
+ * 关 transition/animation/阴影；半透明色块高亮改为反色或下划线（大面积
+ * 灰阶在墨水屏上是抖动噪点，且每次变化都是一整块刷新）。
+ * ===================================================================== */
+
+/* 方角 + 去阴影 + 关动效：一条规则压平全部圆角/阴影/补间（逐选择器覆盖 20+
+   处 border-radius 是维护负担，e-ink 下它们统一归零，无一例外）。 */
+html.eink *,
+html.eink *::before,
+html.eink *::after {
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+    transition: none !important;
+    animation: none !important;
+}
+
+html.eink {
+    --hibiki-radius-card: 0;
+    /* 杀掉亚克力/半透明卡片底（Win11 backdrop 在 e-ink 上只是脏灰）。 */
+    --hibiki-card-bg-alpha: 1;
+    /* 查词命中不再用半透明色块（消费端见下方 underline 覆盖）。 */
+    --hoshi-primary-highlight: transparent;
+    /* tags：色块 → 透明底 + 描边（描边规则见下）。 */
+    --expr-tag-color: transparent;
+}
+
+/* 纯黑白变量：比 html[data-theme] 特异性高（0,2,1 > 0,1,1），连 Dart 注入的
+   --md-* 一并压掉（消费端读的是这些二级变量）。浅色=白底黑字，深色=黑底白字。 */
+html.eink[data-theme="light"] {
+    --background-color: #fff;
+    --background-color-light: #fff;
+    --background-color-dark1: #fff;
+    --text-color: #000;
+    --text-color-light1: #000;
+    --text-color-light2: #000;
+    --text-color-light3: #000;
+    --text-color-light4: #000;
+    --surface-container: #fff;
+    --surface-container-high: #fff;
+    --outline-variant: #000;
+    --primary-color: #000;
+    --on-surface-variant: #000;
+    --freq-tag-color: #000;
+    --hibiki-card-bg-rgb: 255, 255, 255;
+}
+
+html.eink[data-theme="dark"] {
+    --background-color: #000;
+    --background-color-light: #000;
+    --background-color-dark1: #000;
+    --text-color: #fff;
+    --text-color-light1: #fff;
+    --text-color-light2: #fff;
+    --text-color-light3: #fff;
+    --text-color-light4: #fff;
+    --surface-container: #000;
+    --surface-container-high: #000;
+    --outline-variant: #fff;
+    --primary-color: #fff;
+    --on-surface-variant: #fff;
+    --freq-tag-color: #fff;
+    --hibiki-card-bg-rgb: 0, 0, 0;
+}
+
+/* tags / 词频：色块改「透明底 + 1px 实线描边」；词频来源药丸反色（黑底白字 /
+   白底黑字），比灰阶底更清晰。 */
+html.eink .expr-tag,
+html.eink .deinflection-tag,
+html.eink .kanji-tag,
+html.eink .glossary-tag,
+html.eink .pitch-transcription-tag {
+    background-color: transparent;
+    border: 1px solid currentColor;
+}
+
+html.eink .frequency-dict-label {
+    color: var(--background-color);
+}
+
+/* 顶部动作按钮静息态 0.5 opacity 在墨水屏上是抖动灰，压到全不透明；交互反馈
+   由按下反色承担（active 态浏览器自带 :active opacity 覆盖被上面的关动效保留，
+   数值本身仍生效）。 */
+html.eink .audio-button,
+html.eink .favorite-button,
+html.eink .open-anki-button,
+html.eink .mine-button {
+    opacity: 1;
+}
+
+/* 特例态的彩色（收藏金 / 最新可改绿）在灰阶屏上失义，回归前景色。 */
+html.eink .favorite-button.favorited,
+html.eink .mine-button.latest {
+    color: var(--text-color);
+}
+
+/* 查词/嵌套查词命中：半透明色块 → 下划线（贴文字的一条线，刷新面积最小）。 */
+html.eink ::highlight(hoshi-selection) {
+    background-color: transparent;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+html.eink .hoshi-dict-highlight {
+    background-color: transparent !important;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+/* 原生拖选选区：反色块（纯黑白互换）——e-ink 上最清晰的选中态，无灰阶。 */
+html.eink ::selection {
+    background-color: var(--text-color);
+    color: var(--background-color);
+}
+
+/* 句子横幅的命中/外部查词高亮与逐字 hover：色块 → 下划线 / 描边。 */
+html.eink .global-lookup-sentence-hit,
+html.eink .global-lookup-ext-hit {
+    background: transparent;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.15em;
+}
+
+html.eink .global-lookup-sentence:not(.global-lookup-sentence-panel)
+    .global-lookup-sentence-char:hover {
+    background: transparent;
+    outline: 1px solid currentColor;
+    outline-offset: -1px;
+}
+
+/* app 外全局查词卡壳：半透明灰描边 → 实线前景色描边，方角，不透明底。 */
+html.eink.global-lookup body {
+    border: 1px solid var(--text-color);
+    background: var(--background-color);
 }


### PR DESCRIPTION
## 概要

对齐 Hoshi-Reader-Android 的 7 类 E-ink 适配，给 Hibiki 加「墨水屏模式」全局单开关（设置→外观）。设备属性（不随 Profile 快照回滚），叠加在现有主题机制之上：开=纯黑白+无动画+线式高亮，关=完整还原原主题；明暗模式决定白底黑字/黑底白字。

## 四个渲染面

**① 全局主题（theme_notifier）**
- `buildEinkColorScheme` 手工构造纯黑白 ColorScheme（不走 fromSeed，避免色相渗入）
- eink 下：`pageTransitionsTheme` 全平台 NoTransition、`NoSplash` 关水波纹、卡片/开关补 1px 描边、分隔线整像素
- 系统栏图标明暗经既有 `AnnotatedRegion` 单点自动跟随（零改动）
- `HibikiEinkTheme` ThemeExtension：任意 widget 经 `Theme.of` 感知 eink

**② 阅读器 WebView（reader_content_styles）**
- `css()` 加 `einkMode/einkDark`：正文强制纯黑白（压过任意 preset/custom），经 `_applyStylesLive` 动态注入不重载章节
- 高亮线式化：查词=粗实线、sasayaki=虚线、搜索=双线、收藏句保留下划线去色块（复用收藏句既有 underline 范式，BUG-110/716 的 ruby/竖排路径零改动）
- 注入 `--hoshi-reader-eink-mode:1` 点亮 JS 侧既有 `isEInkMode()` 钩子；连续模式有声书跟随滚动 smooth→auto（普通模式保持 TODO-825 的 smooth，守卫已更新为锁变量化后的等价不变式）

**③ 查词弹窗（popup.css 三镜像）**
- `html.eink` 覆盖块：纯黑白变量、一条通配规则压平全部圆角/阴影/transition、tags 改描边、词频药丸反色、查词高亮下划线、原生选区反色
- 注入层从 ThemeData 扩展读 eink（不依赖 AppModel late 字段，弹窗 widget 测试可跑）；三镜像已同步 + content.css 重生成（`:where(#entries-container).eink`）
- 入场淡入/滑出补间 eink 下归零

**④ 动画（Flutter 侧）**：页面过渡/水波纹/弹窗补间统一归零

## 顺路修复 BUG-970（原969撞PR#312改号）
popup.css 的 `.ctx-adjust-button` 规则缺闭合 `}`，CSS 错误恢复把下一条 `.global-lookup-ext-hit` 高亮整规则吞掉（从未生效）。已补闭合 + 括号配平守卫测试。`docs/bugs/BUG-970（原969撞PR#312改号）-*.md` 已记档。

## 明确不做（与 Hoshi 同边界）
厂商刷新 API（Boox/A2/Regal）、自动检测墨水屏、灰阶抖动/图片二值化、定期全刷。

## 验证
- `flutter analyze`：0 问题
- `flutter test` 全量：**12400 通过 / 5 跳过 / 0 失败**（exit 0）
- 新守卫：`test/reader/reader_eink_mode_test.dart`（CSS 分支+ColorScheme+快照黑名单）、`test/build/popup_css_eink_guard_test.dart`（eink 块+括号配平+content.css 重挂）
- 三镜像 parity 守卫绿
- ⏳ 待真机：墨水屏设备/模拟器目视验证（开关切换、阅读器高亮、弹窗、有声书跟随）

https://claude.ai/code/session_01952JtRcaGLLxFGE2ZYKJPe