### PR TITLE
fix(interconnect): 首次配对失败后同源重试重新弹申请框 (BUG-987)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 951 条。点号进各自文件。
+> 共 952 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-987](bugs/BUG-987-interconnect-pair-dialog-latch.md) | ✅ | ✅ | 互联首次配对失败后刷新不再弹申请框、只提示失败 |
 | [BUG-970](bugs/BUG-970-reading-goal-first-set-no-entry.md) | ✅ | ✅ | 统计页每日/每周目标从未设置时无任何设置入口 |
 | [BUG-969](bugs/BUG-969-reader-settings-sheet-120fps.md) | ✅ | ✅ | 阅读设置抽屉滚动与拖动跑不满120fps |
 | [BUG-968](bugs/BUG-968-audiobook-export-text-audio.md) | ✅ | ✅ | 有声书片段导出文字与选区不符且移动端缺少音频 |

--- a/docs/bugs/BUG-987-interconnect-pair-dialog-latch.md
+++ b/docs/bugs/BUG-987-interconnect-pair-dialog-latch.md
@@ -1,0 +1,14 @@
+## BUG-987 · 互联首次配对失败后刷新不再弹申请框、只提示失败
+- **报告**：2026-07-21（用户：hibiki 互联刚开始没添加成功，后面重新刷新不再出现申请框，只会说失败）
+- **真实性**：✅ 真 bug。根因在 host（被添加设备）侧审批弹窗的串行锁未在「未决滞留」态被取代。
+  - `hibiki/lib/src/sync/hibiki_server_controller.dart:423` `_showPairApprovalDialog`：`if (_pairDialogOpen) return Future<bool>.value(false)` —— 已有申请框打开时，新配对请求直接判 `declined`、**不弹新框**。
+  - `_pairDialogOpen`（`:104` 声明，`:426` 置位，仅在弹窗 `whenComplete` `:590` 复位）串行化申请框。
+  - `_promptPairApproval`（`:401`）原「先收起旧框再开新框」的取代逻辑只覆盖 `_pairDialogLingering`（已允许、常驻显示 PIN）这一态（BUG-708），**遗漏了「审批未决但对端会话已死」这一态**。
+  - 失败链路：第一次配对 host 弹申请框等用户点 → client 端先超时/断网/取消（`hibiki_pair_v2_client.dart:40` 默认 65s）→ 那个未决框驻留至 60s autoDeny（`:483`）→ 期间同一 client「重新刷新」重发 `pair/v2·confirm` 全被 `:423` 挡成 `declined` → 只见「失败」、host 不再弹框。若 `popDialog`（`:441`）因 navigator 状态 `canPop()` 为 false 而 no-op，则卡到重启 app。
+  - 次要：`hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart:206` 去重守卫使「重加一个列表里已存在的地址」`added=false` → `:218 if(added)` 不再发起配对 → 点「添加」毫无反应（无法靠再点添加重试）。
+- **[x] ① 已修复** — 根因修：
+  - `hibiki_server_controller.dart`：新增 `_pairDialogRemoteAddress` 记录当前打开申请框的来源；`_promptPairApproval` 把取代条件扩为 `_pairDialogLingering || _isSamePairSource(request.remoteAddress)`——**同源(remoteAddress)重试即取代滞留的未决框、重开新框**，不同来源仍保留防叠弹拒绝（防恶意 peer 顶掉别人正在审批的框）。
+  - `interconnect.part.dart`：add 模式（`index==null`）一律触发配对，与「是否新增列表条目」解耦（去重只防列表重复，不拦重新配对）。
+  - 提交哈希：（见本轮提交）
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/interconnect_pending_pair_supersede_test.dart`：同源重试取代未决框弹新框（原会被 `_pairDialogOpen` 挡成拒绝）；不同来源仍被防叠弹拒绝、旧框保留。
+- **备注**：真机复测项——两台设备局域网互联，第一次配对故意让发起端超时/取消，随后在发起端「刷新/重新添加」，被添加端应重新弹出申请框（而非静默失败）。属 [docs/agent/integration-testing.md] 设备验证范畴，待真机勾验。

--- a/hibiki/lib/src/sync/hibiki_server_controller.dart
+++ b/hibiki/lib/src/sync/hibiki_server_controller.dart
@@ -122,6 +122,14 @@ class HibikiSyncServerController extends ChangeNotifier {
   // _pendingPairPin / _pendingPairPinDismiss 单值字段。仅在等待收起旧常驻弹窗期间非 null。
   Completer<void>? _pairDialogClosed;
 
+  // BUG-987：当前打开的审批弹窗对应的来源地址（remoteAddress）。用于「同源重试
+  // supersede 未决弹窗」——第一次配对被 client 放弃（超时/断网/取消）后，host 那个仍
+  // 处于「审批未决」的申请框会驻留至 60s autoDeny，期间同一 client「重新刷新」重发的
+  // 配对请求都被 _pairDialogOpen 挡成 declined、看不到新申请框。此字段让 _promptPairApproval
+  // 识别「新请求与滞留弹窗同源」并先收起旧框再开新框；不同来源仍保留防叠弹拒绝（防恶意
+  // peer 顶掉别人正在审批的框）。null=当前无打开的弹窗。
+  String? _pairDialogRemoteAddress;
+
   bool get isRunning => _server?.isRunning ?? false;
   int? get boundPort => _server?.port;
 
@@ -391,11 +399,18 @@ class HibikiSyncServerController extends ChangeNotifier {
   /// client 提交 confirm（[onPairSessionResolved] → [_dismissPendingPairPinDialog]）、
   /// 用户手动关、或会话 TTL 超时。免 PIN 会话行为不变（无 PIN 可显示，点选即关）。
   Future<bool> _promptPairApproval(HibikiPairRequest request) async {
-    // TODO-1330 / BUG-708：若当前弹窗只是「已允许、常驻显示 PIN 等对方输入」（approvedPhase），
-    // 它已不再占用审批槽——先收起它，让本次新配对（如取消后「重新配对」）不被误判为 stacked
-    // 请求而拒绝。等旧弹窗彻底 teardown（whenComplete 清单值态）再继续，并把本会话刚生成的
-    // PIN（可能被旧 teardown 清空）恢复回来，杜绝新旧弹窗争用共享单值字段。
-    if (_pairDialogOpen && _pairDialogLingering) {
+    // 先收起一个应被本次新请求取代的旧弹窗，等它彻底 teardown（whenComplete 清共享单值
+    // 态）再开新框，并把本会话刚生成的 PIN（可能被旧 teardown 清空）恢复回来。两种取代：
+    //   (a) TODO-1330 / BUG-708：旧弹窗是「已允许、常驻显示 PIN 等对方输入」（lingering）——
+    //       它已不占审批槽，收起它让「取消后重新配对」不被误判为 stacked 而拒绝。
+    //   (b) BUG-987：旧弹窗仍「审批未决」但与本次新请求同源（同 remoteAddress）——第一次
+    //       配对被 client 放弃（超时/断网/取消）后那个未决框会驻留至 60s autoDeny，期间同一
+    //       client「重新刷新」重发的配对都被 _pairDialogOpen 挡成 declined、看不到新申请框。
+    //       同源取代它即可让重试重新弹框；不同来源的未决框保留（防恶意 peer 顶掉别人正在
+    //       审批的框），仍由 _showPairApprovalDialog 的 _pairDialogOpen 拒绝。
+    final bool supersedeStale = _pairDialogOpen &&
+        (_pairDialogLingering || _isSamePairSource(request.remoteAddress));
+    if (supersedeStale) {
       final String? incomingPin = _pendingPairPin;
       final Completer<void> closed = Completer<void>();
       _pairDialogClosed = closed;
@@ -404,6 +419,16 @@ class HibikiSyncServerController extends ChangeNotifier {
       _pendingPairPin = incomingPin;
     }
     return _showPairApprovalDialog(request);
+  }
+
+  /// BUG-987：新配对请求的来源是否与当前打开的审批弹窗同源（同 remoteAddress）。用于
+  /// 「同源重试取代未决弹窗」。任一来源为空（无法解析来源 IP）时保守判为不同源——不取代，
+  /// 避免把两个匿名来源误当同源互相顶掉别人的审批框。
+  bool _isSamePairSource(String? incoming) {
+    final String? current = _pairDialogRemoteAddress;
+    if (current == null || current.isEmpty) return false;
+    if (incoming == null || incoming.isEmpty) return false;
+    return current == incoming;
   }
 
   /// 实际展示 host 审批 / 常驻 PIN 弹窗并返回审批结果（[_promptPairApproval] 处理完
@@ -417,6 +442,8 @@ class HibikiSyncServerController extends ChangeNotifier {
     if (ctx == null) return Future<bool>.value(false);
     _pairDialogOpen = true;
     _pairDialogLingering = false;
+    // BUG-987：记录本框来源，供同源新请求识别并取代滞留的未决框（见 _promptPairApproval）。
+    _pairDialogRemoteAddress = request.remoteAddress;
 
     final Completer<bool> approval = Completer<bool>();
     // 只有「真的要显示 PIN」的 pinRequired 会话才走常驻分支；免 PIN / 无 PIN 走旧的
@@ -575,6 +602,7 @@ class HibikiSyncServerController extends ChangeNotifier {
       lingerTimeout?.cancel();
       _pairDialogOpen = false;
       _pairDialogLingering = false;
+      _pairDialogRemoteAddress = null;
       _pendingPairPin = null;
       _pendingPairPinDismiss = null;
       // 若有新配对正等本（常驻）弹窗收起，放行它继续（BUG-708）。

--- a/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
@@ -192,7 +192,11 @@ class _HibikiServerConfigWidgetState extends State<_HibikiServerConfigWidget>
       return;
     }
 
-    bool added = false;
+    // BUG-987：add 模式（index==null）一律触发配对，与「是否新增列表条目」解耦。旧实现
+    // 只在 added==true 时配对，导致「重加一个列表里已存在的地址」被去重守卫吞成 added=false
+    // → 不再发起配对 → 点「添加」毫无反应。去重只应防列表出现重复条目，不该拦住重新配对
+    // （尤其首次配对失败后用户想靠再点「添加」重试）。
+    bool shouldPair = false;
     setState(() {
       final List<HibikiClientUrl> copy = <HibikiClientUrl>[..._urls];
       if (index != null) {
@@ -203,19 +207,22 @@ class _HibikiServerConfigWidgetState extends State<_HibikiServerConfigWidget>
           // 编辑保留已有指纹/展示名（copyWith），只换 URL 文本。
           copy[index] = copy[index].copyWith(url: normalizedResult);
         }
-      } else if (!copy.any((HibikiClientUrl u) => u.url == normalizedResult)) {
-        copy.add(HibikiClientUrl(url: normalizedResult));
-        added = true;
+      } else {
+        // 新地址才加进列表（去重防重复条目）；已存在则不重复加，但仍会在下方发起配对。
+        if (!copy.any((HibikiClientUrl u) => u.url == normalizedResult)) {
+          copy.add(HibikiClientUrl(url: normalizedResult));
+        }
+        shouldPair = true;
       }
       _urls = copy;
     });
     await _persistUrls();
 
-    // TODO-963 M2: 新增地址后走「探测 → 配对」。手动输入 IP 也能发起配对（不再只挂
+    // TODO-963 M2: 新增/重加地址后走「探测 → 配对」。手动输入 IP 也能发起配对（不再只挂
     // mDNS 发现设备）：ping 探测可达 + 取指纹做 TOFU → 双确认 → pair/v2 → 自动落
     // token + 指纹（免手粘 token）。探测失败 / 非 hibiki 时静默保留地址（向后兼容：
     // 用户仍可手填 token）。
-    if (added) {
+    if (shouldPair) {
       await _attemptManualPair(normalizedResult);
     }
   }

--- a/hibiki/test/sync/interconnect_pending_pair_supersede_test.dart
+++ b/hibiki/test/sync/interconnect_pending_pair_supersede_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/hibiki_server_controller.dart';
+import 'package:hibiki/src/sync/hibiki_sync_server.dart';
+import 'package:hibiki/utils.dart';
+
+/// BUG-987：互联首次配对被发起端放弃（超时/断网/取消）后，host 那个仍「审批未决」的
+/// 申请框会驻留至 60s autoDeny；期间同一 client「重新刷新」重发的配对全被 `_pairDialogOpen`
+/// 挡成 declined、看不到新申请框，用户只见「失败」。
+///
+/// 修复：`_promptPairApproval` 把「先收起旧框再开新框」的取代条件从「仅 lingering(已允许
+/// 常驻 PIN)」扩到「lingering 或**同源(remoteAddress)**」——同一 client 重试即取代滞留的
+/// 未决框、重开新框；不同来源仍走防叠弹拒绝（防恶意 peer 顶掉别人正在审批的框）。
+void main() {
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+  });
+
+  HibikiSyncServerController buildController(GlobalKey<NavigatorState> navKey) {
+    return HibikiSyncServerController(
+      navigatorKey: navKey,
+      database: () => throw UnimplementedError('db not used in this test'),
+      syncDataDir: () => '.',
+      remoteLookupServiceFactory: () =>
+          throw UnimplementedError('lookup not used in this test'),
+    );
+  }
+
+  Future<void> pumpHost(
+      WidgetTester tester, GlobalKey<NavigatorState> navKey) async {
+    await tester.pumpWidget(TranslationProvider(
+      child: MaterialApp(
+        navigatorKey: navKey,
+        home: const Scaffold(body: SizedBox.shrink()),
+      ),
+    ));
+  }
+
+  testWidgets('同源重试取代滞留的未决申请框、重开新框（BUG-987）', (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+    final HibikiSyncServerController controller = buildController(navKey);
+    addTearDown(controller.dispose);
+    await pumpHost(tester, navKey);
+
+    // 第一次配对（LAN 免 PIN，审批未决）：故意不点「允许」，模拟发起端超时/取消放弃。
+    const HibikiPairRequest firstReq = HibikiPairRequest(
+      deviceName: 'Phone A',
+      remoteAddress: '192.168.1.50',
+      pinRequired: false,
+    );
+    final Future<bool> first = controller.debugPromptPairApproval(firstReq);
+    await tester.pump();
+    expect(find.text('Phone A · 192.168.1.50'), findsOneWidget,
+        reason: '第一次申请框应弹出、处于审批未决');
+    expect(find.text(t.sync_pair_allow), findsOneWidget);
+
+    // 第二次同源重试（同 remoteAddress，展示名不同以便区分是新框）：修复前会命中
+    // `if (_pairDialogOpen) return false` 被静默拒绝、界面仍是旧框；修复后应收起旧框、弹新框。
+    const HibikiPairRequest retryReq = HibikiPairRequest(
+      deviceName: 'Phone A (retry)',
+      remoteAddress: '192.168.1.50',
+      pinRequired: false,
+    );
+    final Future<bool> second = controller.debugPromptPairApproval(retryReq);
+    await tester.pumpAndSettle();
+
+    // 旧未决框被取代 → 其审批 future 归为 false（拒绝，client 早已放弃这条）。
+    expect(await first, isFalse, reason: '滞留的未决框被同源重试取代 → 判 declined');
+    // 新框在，且是新请求的标签（旧标签已消失）。
+    expect(find.text('Phone A (retry) · 192.168.1.50'), findsOneWidget,
+        reason: '同源重试必须弹出新申请框（修复前被静默拒绝、无新框）');
+    expect(find.text('Phone A · 192.168.1.50'), findsNothing,
+        reason: '旧未决框应已收起');
+
+    // 新框可正常允许（而非被挡成拒绝）。
+    expect(find.text(t.sync_pair_allow), findsOneWidget);
+    await tester.tap(find.text(t.sync_pair_allow));
+    await tester.pump();
+    expect(await second, isTrue, reason: '同源重试的审批应能正常允许');
+  });
+
+  testWidgets('不同来源的新请求仍被防叠弹拒绝、旧未决框保留（BUG-987 未回退防护）',
+      (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+    final HibikiSyncServerController controller = buildController(navKey);
+    addTearDown(controller.dispose);
+    await pumpHost(tester, navKey);
+
+    const HibikiPairRequest reqA = HibikiPairRequest(
+      deviceName: 'Phone A',
+      remoteAddress: '192.168.1.50',
+      pinRequired: false,
+    );
+    final Future<bool> first = controller.debugPromptPairApproval(reqA);
+    await tester.pump();
+    expect(find.text('Phone A · 192.168.1.50'), findsOneWidget);
+
+    // 不同来源(不同 IP)在旧框未决时发起 → 应立即被防叠弹拒绝(false)，旧框不受影响。
+    const HibikiPairRequest reqB = HibikiPairRequest(
+      deviceName: 'Attacker B',
+      remoteAddress: '192.168.1.99',
+      pinRequired: false,
+    );
+    final Future<bool> second = controller.debugPromptPairApproval(reqB);
+    await tester.pump();
+    expect(await second, isFalse, reason: '不同来源不得取代别人正在审批的框');
+    expect(find.text('Attacker B · 192.168.1.99'), findsNothing,
+        reason: '不同来源不应弹出新框');
+    expect(find.text('Phone A · 192.168.1.50'), findsOneWidget,
+        reason: '原未决框应仍在');
+
+    // 原框仍可正常允许。
+    await tester.tap(find.text(t.sync_pair_allow));
+    await tester.pump();
+    expect(await first, isTrue);
+  });
+}


### PR DESCRIPTION
## 问题
用户报：hibiki 互联第一次添加设备没成功后，重新刷新不再出现「申请框」，只提示失败。

## 根因（BUG-987）
host（被添加设备）侧审批弹窗用全局单值锁 `_pairDialogOpen` 串行化，只在弹窗关闭时复位。`_promptPairApproval` 原「先收起旧框再开新框」的取代逻辑只覆盖 `_pairDialogLingering`（已允许、常驻显示 PIN）态（BUG-708 修的），**遗漏了「审批未决但对端会话已死」态**：第一次配对被发起端超时/断网/取消放弃后，那个未决申请框驻留至 60s autoDeny，期间同一 client「刷新」重发的 `pair/v2·confirm` 全被 `_showPairApprovalDialog` 的 `if (_pairDialogOpen) return false` 挡成 `declined`、不再弹新框，用户只见「失败」。

顺带修一个次要缺陷：`interconnect.part.dart` add 模式的去重守卫使「重加一个列表里已存在的地址」`added=false` → 不再发起配对 → 点「添加」毫无反应，无法靠再点添加重试。

## 修复（根因修）
- `hibiki_server_controller.dart`：新增 `_pairDialogRemoteAddress` 记录当前打开申请框来源；取代条件扩为 `_pairDialogLingering || _isSamePairSource(request.remoteAddress)`——**同源(remoteAddress)重试即取代滞留的未决框、重开新框**；不同来源仍保留防叠弹拒绝（防恶意 peer 顶掉别人正在审批的框）。
- `interconnect.part.dart`：add 模式一律触发配对，与「是否新增列表条目」解耦（去重只防列表重复，不拦重新配对）。

## 测试
- `test/sync/interconnect_pending_pair_supersede_test.dart`：同源重试取代未决框弹新框（原会被挡成拒绝）；不同来源仍被防叠弹拒绝、旧框保留。
- BUG-708 回归测试仍绿。
- `flutter analyze` 改动文件 No issues；`flutter test` 全过。

## 待验
真机复测：两台设备局域网互联，第一次故意让发起端超时/取消，随后在发起端「刷新/重新添加」，被添加端应重新弹出申请框。

https://claude.ai/code/session_01U8bqNgrhevwSDKvPpzLV82