### PR TITLE
fix(video): BUG-971 进视频页隐藏 macOS 交通灯，修复左上角退出按钮/OSD被挡

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 951 条。点号进各自文件。
+> 共 952 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-971](bugs/BUG-971-macos-traffic-light-video-overlap.md) | ✅ | ✅ | macOS 交通灯遮挡视频退出按钮/左上角OSD |
 | [BUG-970](bugs/BUG-970-reading-goal-first-set-no-entry.md) | ✅ | ✅ | 统计页每日/每周目标从未设置时无任何设置入口 |
 | [BUG-969](bugs/BUG-969-reader-settings-sheet-120fps.md) | ✅ | ✅ | 阅读设置抽屉滚动与拖动跑不满120fps |
 | [BUG-968](bugs/BUG-968-audiobook-export-text-audio.md) | ✅ | ✅ | 有声书片段导出文字与选区不符且移动端缺少音频 |

--- a/docs/bugs/BUG-971-macos-traffic-light-video-overlap.md
+++ b/docs/bugs/BUG-971-macos-traffic-light-video-overlap.md
@@ -9,7 +9,7 @@
   - 新增 helper `hibiki/lib/src/platform/desktop/macos_traffic_lights.dart`：`setMacOSTrafficLightsHidden(bool)`，`Platform.isMacOS` 门控，调 `WindowManipulator.hide/showClose|Miniaturize|ZoomButton`（底层 `NSWindow.standardWindowButton.isHidden`）；非 macOS no-op，channel 失败以 debug 日志吞掉。
   - `video_hibiki_page.dart` initState 隐藏（`setMacOSTrafficLightsHidden(true)`）、dispose 恢复（`false`）。
   - `video_hibiki/fullscreen.part.dart` `_exitVideoNativeFullscreen` 桌面分支：`await defaultExitNativeFullscreen()` 后**重新断言隐藏**——AppKit 退全屏重建标题栏视图可能把 `isHidden` 复位，不 re-hide 则退全屏回窗口态交通灯复现遮挡。
-  - 提交哈希：（提交后回填）
+  - 提交哈希：`7f005a4d1`（fix(video): BUG-971 hide macOS traffic lights while in video page）
 - **[x] ② 已加自动化测试** — `hibiki/test/video/macos_video_trafficlight_hide_guard_test.dart`（源码扫描守卫）：
   - helper 必须 `Platform.isMacOS` 门控 + 隐藏/恢复全部三个按钮（部分隐藏仍遮挡）。
   - 视频页 initState 隐藏、dispose 恢复。

--- a/docs/bugs/BUG-971-macos-traffic-light-video-overlap.md
+++ b/docs/bugs/BUG-971-macos-traffic-light-video-overlap.md
@@ -1,0 +1,18 @@
+## BUG-971 · macOS 交通灯遮挡视频退出按钮/左上角OSD
+- **报告**：2026-07-21（用户：mac 左上角的三个点经常挡住东西，比如视频退出、快捷键退出等）
+- **真实性**：✅ 真 bug。根因非单点，是 macOS 壳配置 + 视频页左上角控件叠加：
+  - `hibiki/lib/main.dart:201-205`：macOS 启动即 `makeTitlebarTransparent()` + `enableFullSizeContentView()`（macos_ui ToolBar 所需），Flutter 内容延伸到窗口左上角，系统交通灯（红黄绿三圆点）浮在其上，且 macOS **不**把它们计入 `MediaQuery.padding`。
+  - 视频页把交互控件画在同一区域：顶栏「返回/退出」按钮 `controls_theme.part.dart` 的 `topLeft` slot（贴 x≈0）、左上角 OSD 提示卡 `volume_osd.part.dart`（`top:52, left:16` 仍压交通灯右缘，沉浸锁/解锁提示走它 = 用户说的「快捷键退出提示」）、侧锁按钮顶部。
+  - home 壳的 BUG-869 已用 `kMacTitleBarHeight` + `SafeArea.minimum` 预留交通灯高度，但**视频页是独立全屏路由、不走那个 SafeArea**，故仍被挡。
+  - 仅窗口化/沉浸播放态暴露；进原生全屏（media_kit `toggleFullScreen`）时 macOS 自动隐藏交通灯，问题消失。
+- **[x] ① 已修复** — 视频页全程隐藏 macOS 交通灯、退出恢复（用户仍可 Esc / 顶栏返回按钮 / Cmd+Q / 进全屏退出，不损失退出口）。
+  - 新增 helper `hibiki/lib/src/platform/desktop/macos_traffic_lights.dart`：`setMacOSTrafficLightsHidden(bool)`，`Platform.isMacOS` 门控，调 `WindowManipulator.hide/showClose|Miniaturize|ZoomButton`（底层 `NSWindow.standardWindowButton.isHidden`）；非 macOS no-op，channel 失败以 debug 日志吞掉。
+  - `video_hibiki_page.dart` initState 隐藏（`setMacOSTrafficLightsHidden(true)`）、dispose 恢复（`false`）。
+  - `video_hibiki/fullscreen.part.dart` `_exitVideoNativeFullscreen` 桌面分支：`await defaultExitNativeFullscreen()` 后**重新断言隐藏**——AppKit 退全屏重建标题栏视图可能把 `isHidden` 复位，不 re-hide 则退全屏回窗口态交通灯复现遮挡。
+  - 提交哈希：（提交后回填）
+- **[x] ② 已加自动化测试** — `hibiki/test/video/macos_video_trafficlight_hide_guard_test.dart`（源码扫描守卫）：
+  - helper 必须 `Platform.isMacOS` 门控 + 隐藏/恢复全部三个按钮（部分隐藏仍遮挡）。
+  - 视频页 initState 隐藏、dispose 恢复。
+  - `_exitVideoNativeFullscreen` 桌面分支在 `defaultExitNativeFullscreen()` 之后 re-hide。
+  - 用源码守卫的理由：行为经 `dart:io` `Platform.isMacOS` 门控（不可被 `debugDefaultTargetPlatformOverride` 伪造）+ 原生窗口按钮 method channel，`flutter test` 无法驱动真 macOS 窗口，源码扫描是最强可落地层。
+- **备注**：与 home 壳 BUG-869 的「预留空间」互补不冲突——视频外靠预留、视频内靠隐藏、退出恢复交由 home 壳的 SafeArea 预留接管。真机验证（远程 Mac）：进视频后交通灯消失、顶栏返回/OSD 不再被挡；进→退原生全屏后交通灯仍隐藏；退视频回 home 交通灯恢复且不压导航栏。

--- a/hibiki/lib/src/pages/implementations/video_hibiki/fullscreen.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/fullscreen.part.dart
@@ -320,7 +320,15 @@ extension _VideoFullscreen on _VideoHibikiPageState {
   /// `Utils.ExitNativeFullscreen` 把 OS 窗口还原回非全屏），与进入回调对称。桌面分支不碰
   /// 设备方向，无竖屏问题。
   Future<void> _exitVideoNativeFullscreen() async {
-    if (!isMobilePlatform) return defaultExitNativeFullscreen();
+    if (!isMobilePlatform) {
+      await defaultExitNativeFullscreen();
+      // BUG-971: AppKit 的 `toggleFullScreen` 退出原生全屏会重建标题栏视图、可能把
+      // `standardWindowButton.isHidden` 复位 → 交通灯在窗口化播放态重新遮住左上角控件。
+      // 退全屏后重新断言隐藏（与 initState 的隐藏一致）。仅 macOS 有交通灯；
+      // Windows / Linux 桌面 no-op。
+      await setMacOSTrafficLightsHidden(true);
+      return;
+    }
     await SystemChrome.setEnabledSystemUIMode(
       SystemUiMode.immersiveSticky,
       overlays: <SystemUiOverlay>[],

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -118,6 +118,7 @@ import 'package:hibiki/src/utils/app_ui_scale.dart';
 import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki/src/utils/misc/render_backend_service.dart';
+import 'package:hibiki/src/platform/desktop/macos_traffic_lights.dart';
 import 'package:hibiki/src/platform/screen_brightness_controller.dart';
 import 'package:hibiki/src/utils/misc/platform_utils.dart';
 import 'package:hibiki/src/utils/misc/show_app_dialog.dart';
@@ -1618,6 +1619,11 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     unawaited(_ensureEnterBrightness());
     // TODO-099: 进入视频页强制横屏（移动端），退出 [dispose] 还原；桌面 no-op。
     unawaited(_lockLandscapeForVideo());
+    // BUG-971: 进入视频页隐藏 macOS 系统交通灯（左上角三个圆点），退出 [dispose] 恢复。
+    // 交通灯浮在透明标题栏 + 全尺寸内容视图之上，会遮住视频顶栏返回按钮 / 左上角 OSD
+    // 提示（用户报告）。仅 macOS 有交通灯；Windows / Linux / 移动端恒 no-op。用户仍可
+    // Esc / 顶栏返回按钮 / Cmd+Q / 进原生全屏退出，不损失退出口。
+    unawaited(setMacOSTrafficLightsHidden(true));
     // TODO-158/BUG-219: 进入视频页显式持有「沉浸隐藏系统栏」所有权（移动端）。原先
     // 只靠 [AppModel.openMedia] 在打开媒体时一次性设 immersiveSticky（书 / 视频共用
     // 入口），从不重申 → 后台返回 / 通知栏交互 / 全屏路由后系统栏残留。退出由
@@ -3080,6 +3086,9 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     unawaited(_brightness.restore(previous: _enterBrightness));
     // TODO-099: 退出视频页还原屏幕方向允许态（移动端），不把其他页锁死在横屏；桌面 no-op。
     unawaited(_restoreOrientationOnExit());
+    // BUG-971: 退出视频页恢复 macOS 系统交通灯（与 initState 的隐藏对称）；桌面非
+    // macOS / 移动端 no-op。
+    unawaited(setMacOSTrafficLightsHidden(false));
     _clearClipExportState();
     // TODO-669：销毁缩略图预览（作废在途取帧 + 销毁离屏 Player + 释放末帧）。
     _disposeThumbnailPreview();

--- a/hibiki/lib/src/platform/desktop/macos_traffic_lights.dart
+++ b/hibiki/lib/src/platform/desktop/macos_traffic_lights.dart
@@ -1,0 +1,39 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:macos_ui/macos_ui.dart' show WindowManipulator;
+
+/// 隐藏 / 恢复 macOS 系统交通灯（关闭 / 最小化 / 缩放三个圆点）。
+///
+/// macOS 壳启动时开了透明标题栏 + 全尺寸内容视图（`main.dart` 的
+/// `makeTitlebarTransparent` + `enableFullSizeContentView`），Flutter 内容一直画到
+/// 窗口左上角，系统交通灯浮在其上。视频页把「退出 / 返回」按钮和左上角 OSD 提示画在
+/// 同一位置会被交通灯遮住（BUG-971 用户报告）。视频页全程隐藏交通灯即根除遮挡——
+/// 用户仍可用 Esc / 顶栏返回按钮 / Cmd+Q / 进原生全屏退出，不损失任何退出口。
+///
+/// 底层是 `NSWindow.standardWindowButton(_).isHidden`（见 macos_window_utils 的
+/// `MainFlutterWindowManipulator`），一个持久属性。只有 macOS 有交通灯，其它平台
+/// （Windows / Linux 桌面、移动端）恒 no-op。任何 platform-channel 失败以 debug 日志
+/// 吞掉，绝不因窗口按钮操作崩溃调用方。
+///
+/// ⚠️ 时序：AppKit 的 `toggleFullScreen` 进出原生全屏会重建标题栏视图、可能把
+/// `isHidden` 复位。故不能「隐藏一次」了事——退出原生全屏后需重新调用本函数断言隐藏
+/// （视频页在 `_exitVideoNativeFullscreen` 处理）。
+Future<void> setMacOSTrafficLightsHidden(bool hidden) async {
+  if (!Platform.isMacOS) {
+    return;
+  }
+  try {
+    if (hidden) {
+      await WindowManipulator.hideCloseButton();
+      await WindowManipulator.hideMiniaturizeButton();
+      await WindowManipulator.hideZoomButton();
+    } else {
+      await WindowManipulator.showCloseButton();
+      await WindowManipulator.showMiniaturizeButton();
+      await WindowManipulator.showZoomButton();
+    }
+  } catch (e) {
+    debugPrint('[Hibiki] macOS traffic light toggle skipped: $e');
+  }
+}

--- a/hibiki/test/video/macos_video_trafficlight_hide_guard_test.dart
+++ b/hibiki/test/video/macos_video_trafficlight_hide_guard_test.dart
@@ -1,0 +1,117 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards the BUG-971 fix: on macOS the app enables a transparent titlebar +
+/// full-size content view (`main.dart`), so the red/yellow/green traffic light
+/// buttons float over the top-left of the Flutter content. The video page draws
+/// its exit/back button (top bar `topLeft` slot) and left-corner OSD toasts in
+/// that same region, and macOS does NOT report the traffic lights as
+/// `MediaQuery.padding`, so they overlap. Unlike the home shell (BUG-869, which
+/// reserves `kMacTitleBarHeight` via `SafeArea.minimum`), the video page is a
+/// full-page route that owns its own chrome, so the fix hides the traffic
+/// lights for the whole video session and restores them on exit.
+///
+/// A source guard is the strongest feasible landing layer: the behaviour is
+/// gated on `dart:io`'s `Platform.isMacOS` (which, unlike
+/// `debugDefaultTargetPlatformOverride`, can't be faked in a widget test on the
+/// Linux/Windows CI host) and drives native `NSWindow.standardWindowButton`
+/// visibility through a method channel, neither of which exists under
+/// `flutter test`. So we pin the wiring instead: the helper must gate on macOS
+/// and toggle all three buttons, and the video lifecycle must hide on enter /
+/// restore on exit / re-assert after leaving native fullscreen.
+void main() {
+  test(
+      'setMacOSTrafficLightsHidden gates on macOS and toggles all three '
+      'traffic-light buttons (BUG-971)', () {
+    final String source =
+        File('lib/src/platform/desktop/macos_traffic_lights.dart')
+            .readAsStringSync();
+
+    expect(
+      RegExp(r'if\s*\(\s*!\s*Platform\.isMacOS\s*\)').hasMatch(source),
+      isTrue,
+      reason: 'The helper must early-return on non-macOS so it is a no-op on '
+          'Windows/Linux/mobile (no traffic lights there).',
+    );
+
+    for (final String call in <String>[
+      'hideCloseButton',
+      'hideMiniaturizeButton',
+      'hideZoomButton',
+      'showCloseButton',
+      'showMiniaturizeButton',
+      'showZoomButton',
+    ]) {
+      expect(
+        source.contains('WindowManipulator.$call'),
+        isTrue,
+        reason: 'The helper must call WindowManipulator.$call so every traffic '
+            'light is hidden/restored (a partial hide still leaves overlap).',
+      );
+    }
+  });
+
+  test(
+      'video page hides traffic lights on enter and restores on exit '
+      '(BUG-971)', () {
+    final String source =
+        File('lib/src/pages/implementations/video_hibiki_page.dart')
+            .readAsStringSync();
+
+    final int initState = source.indexOf('void initState()');
+    final int dispose = source.indexOf('void dispose()');
+    expect(initState, greaterThanOrEqualTo(0));
+    expect(dispose, greaterThan(initState),
+        reason:
+            'dispose() is expected to follow initState() in the state class.');
+
+    final String initBody = source.substring(initState, dispose);
+    expect(
+      initBody.contains('setMacOSTrafficLightsHidden(true)'),
+      isTrue,
+      reason:
+          'initState must hide the macOS traffic lights when the video page '
+          'mounts, or the exit button / OSD stay under them (BUG-971).',
+    );
+
+    // Bound dispose to the next member so we do not accidentally read a later
+    // method. dispose() is large; scan a generous window from its start.
+    final String disposeBody = source.substring(dispose);
+    expect(
+      disposeBody.contains('setMacOSTrafficLightsHidden(false)'),
+      isTrue,
+      reason: 'dispose must restore the traffic lights on exit (symmetry with '
+          'the initState hide), so the home shell gets them back (BUG-971).',
+    );
+  });
+
+  test('exiting native fullscreen re-asserts the traffic-light hide (BUG-971)',
+      () {
+    final String source = File(
+      'lib/src/pages/implementations/video_hibiki/fullscreen.part.dart',
+    ).readAsStringSync();
+
+    final int exitFs = source.indexOf('_exitVideoNativeFullscreen()');
+    expect(exitFs, greaterThanOrEqualTo(0));
+    // Scan the method body: from its declaration to the next method.
+    final int nextMethod = source.indexOf('\n  Future<', exitFs + 1);
+    final int nextAny = source.indexOf('\n  Widget ', exitFs + 1);
+    int end = source.length;
+    if (nextMethod > exitFs) end = nextMethod;
+    if (nextAny > exitFs && nextAny < end) end = nextAny;
+    final String body = source.substring(exitFs, end);
+
+    // AppKit's toggleFullScreen can reset standardWindowButton.isHidden when it
+    // rebuilds the titlebar; the desktop branch must re-hide AFTER exiting.
+    final int defaultExit = body.indexOf('defaultExitNativeFullscreen()');
+    final int reHide = body.indexOf('setMacOSTrafficLightsHidden(true)');
+    expect(defaultExit, greaterThanOrEqualTo(0),
+        reason: 'desktop branch still exits native fullscreen via media_kit.');
+    expect(reHide, greaterThan(defaultExit),
+        reason:
+            'The desktop branch must re-assert the traffic-light hide after '
+            'defaultExitNativeFullscreen(), because AppKit can reset the '
+            'button visibility when leaving fullscreen (BUG-971).');
+  });
+}


### PR DESCRIPTION
## 问题
macOS 左上角系统交通灯（红黄绿三圆点）浮在透明标题栏 + 全尺寸内容视图之上，遮住视频页画在左上角的**返回/退出按钮**和**左上角 OSD 提示**（沉浸锁/解锁提示 = 用户说的「快捷键退出」）。用户报告：「mac 左上角的三个点经常挡住东西，比如视频退出、快捷键退出等」。

home 壳的 BUG-869 已用 `kMacTitleBarHeight` + `SafeArea.minimum` 预留交通灯高度，但视频页是**独立全屏路由、不走那个 SafeArea**，故仍被挡。

## 根因
- `main.dart:201-205` macOS 启动即 `makeTitlebarTransparent()` + `enableFullSizeContentView()`；交通灯不计入 `MediaQuery.padding`。
- 视频顶栏 `topLeft` slot 贴 x≈0、OSD `top:52,left:16` 仍压交通灯右缘。
- 仅窗口化/沉浸态暴露；进原生全屏时 macOS 自动隐藏交通灯。

## 修复（方案：进视频隐藏，退出恢复）
用户在两个方案（隐藏 vs 预留空间）中选择「进视频就隐藏交通灯」——一招同时消除三处遮挡，用户仍可 Esc / 顶栏返回按钮 / Cmd+Q / 进全屏退出，不损失退出口。

- 新增 `hibiki/lib/src/platform/desktop/macos_traffic_lights.dart`：`setMacOSTrafficLightsHidden(bool)`，`Platform.isMacOS` 门控，调 `WindowManipulator.hide/showClose|Miniaturize|ZoomButton`（底层 `NSWindow.standardWindowButton.isHidden`）；非 macOS no-op，channel 失败以 debug 日志吞掉。
- `video_hibiki_page.dart`：initState 隐藏、dispose 恢复。
- `video_hibiki/fullscreen.part.dart` `_exitVideoNativeFullscreen`：桌面分支 `await defaultExitNativeFullscreen()` 后**重新断言隐藏**——AppKit 退全屏重建标题栏视图可能复位 `isHidden`。

与 home 壳 BUG-869 互补不冲突：视频外靠预留、视频内靠隐藏、退出恢复交回预留接管。

## 测试
- 源码扫描守卫 `hibiki/test/video/macos_video_trafficlight_hide_guard_test.dart`（3 用例全绿）：helper 门控 + 三按钮、initState/dispose 对称、退全屏 re-hide。
- `flutter analyze`：No issues found。
- 行为经 `dart:io` `Platform.isMacOS` 门控 + 原生 method channel，`flutter test` 无法驱动真 macOS 窗口，源码守卫是最强可落地层。

## 待验证（远程 Mac 真机）
进视频→交通灯消失、返回/OSD 不被挡；进→退原生全屏→交通灯仍隐藏；退视频回 home→交通灯恢复且不压导航栏。

https://claude.ai/code/session_01FcAtNzEntPPhrZruMbe752
