### PR TITLE
feat(interconnect): 互联专属上传分项开关，与云备份解耦 (BUG-988)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 952 条。点号进各自文件。
+> 共 953 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-988](bugs/BUG-988-interconnect-upload-toggles.md) | ✅ | ✅ | 互联解耦后失去「独立控制上不上传到互联对端」的能力 |
 | [BUG-971](bugs/BUG-971-ankiconnect-host-scheme.md) | ✅ | ✅ | AnkiConnect 主机字段吞掉 http:// 变成 http: |
 | [BUG-970](bugs/BUG-970-reading-goal-first-set-no-entry.md) | ✅ | ✅ | 统计页每日/每周目标从未设置时无任何设置入口 |
 | [BUG-969](bugs/BUG-969-reader-settings-sheet-120fps.md) | ✅ | ✅ | 阅读设置抽屉滚动与拖动跑不满120fps |

--- a/docs/bugs/BUG-988-interconnect-upload-toggles.md
+++ b/docs/bugs/BUG-988-interconnect-upload-toggles.md
@@ -1,0 +1,15 @@
+## BUG-988 · 互联解耦后失去「独立控制上不上传到互联对端」的能力
+- **报告**：2026-07-21（用户：没办法给 hibiki 互联上传书/词典了，后端里没了 hibiki 互联；「客户端开了有什么用？我要控制上不上传啊」）
+- **真实性**：✅ 真 bug（发现性 + 控制耦合）。互联解耦（PR#223 `6802606d5`，已进 develop）把「hibikiServer」从「同步方式」后端下拉里 gate 掉（`backend_config.part.dart` `case hibikiServer: return false`），改成独立「启用互联」开关；同时把「上传内容」的分项开关（`sync_content`/`sync_dictionary`/`sync_audiobook_files`/`sync_video_files`）留在**云备份**设置区，且**云备份与互联通道共用同一套开关**：
+  - `hibiki/lib/src/sync/sync_auto_trigger.dart` `_enabledSyncChannelBackends` + `_runSyncChannel` 对两条通道都读同一 `repo.isSyncXxxEnabled()`。
+  - `_runAutoSync`（退出书 per-book 同步）与合集同步也一样。
+  - 后果：解耦前「选 hibikiServer 后端 = 掌握上不上传到对端」的控制没了——用户一开「启用互联」连接（为远端看/读），书/词典就被同一套共享开关裹挟着自动上传给对端，无法只对互联单独控制。
+- **[x] ① 已修复** — 根因修（给互联通道一套自己的上传开关，与云备份/连接开关解耦）：
+  - `sync_repository.dart`：新增 4 个互联专属键 `interconnect_sync_content` / `interconnect_sync_dictionary` / `interconnect_sync_audiobook_files` / `interconnect_sync_video_files` + getter/setter，默认 **false**。
+  - `sync_auto_trigger.dart`：`_enabledSyncChannelBackends` 返回带 `isInterconnect` 标记的 `_SyncChannel`；抽纯函数 `resolveChannelSyncFlags(repo, {isInterconnect})`——互联通道「重内容」四类读互联专属开关、云通道读原共享开关（位置/统计/本地音频仍共享，跨设备续读是互联本意）。四个同步入口（app-open 全量、手动全量、合集、退出书 per-book）全部按通道路由。
+  - `sync_compare_dialog.dart`：手动解决冲突 apply 时，`widget.backend is HibikiClientSyncBackend` 判定读互联/云对应的内容开关（否则「互联内容开、云内容关」时互联冲突内容传输会被误跳过）。
+  - `sync_settings_schema.dart`：「设置 → Hibiki 互联」加 section「上传到互联对端」的 4 个开关（`visible: interconnectActive && !_isHostingInterconnect`，host 无 outbound 时隐藏）；`_SyncSettingsState` 加状态字段 + load。
+  - i18n：10 个 key（section/footer + 4 title + 4 hint）经 `tool/i18n_sync.dart --add`（17 语言）+ `dart run slang` 重生成。
+  - 提交哈希：（见本轮提交）
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/interconnect_upload_toggles_test.dart`：互联开关默认全关时云开着也不上传给互联；开互联开关只影响互联通道不动云；位置/统计/本地音频两通道共享。i18n 完整性/ mojibake 守卫通过。
+- **备注**：默认全关是有意（用户明确要「自己控制、别自动传」）；云备份 sync_* 开关默认本就全关，故绝大多数用户无行为突变。真机复测：两台设备互联，开/关互联上传开关后各触发一次同步，验证书/词典是否按开关上传到对端。属设备验证范畴待勾验。「同步方式」下拉不再列 hibiki 互联是 PR#223 有意设计，不回退。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 37604 (2212 per locale)
+/// Strings: 37774 (2222 per locale)
 ///
-/// Built on 2026-07-21 at 10:28 UTC
+/// Built on 2026-07-21 at 14:46 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2945,6 +2945,21 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get sync_google_drive_hoshi_compat => 'Share progress with Hoshi / ッツ';
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  String get interconnect_upload_content => 'Upload book files';
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  String get interconnect_upload_video_files => 'Upload video files';
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -7948,6 +7963,31 @@ class _StringsAr extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -13024,6 +13064,31 @@ class _StringsDe extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -18116,6 +18181,31 @@ class _StringsEs extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -23219,6 +23309,31 @@ class _StringsFr extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -28249,6 +28364,31 @@ class _StringsId extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -33327,6 +33467,31 @@ class _StringsIt extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -38210,6 +38375,31 @@ class _StringsJa extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -43096,6 +43286,31 @@ class _StringsKo extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -48152,6 +48367,31 @@ class _StringsNl extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -53223,6 +53463,31 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -58277,6 +58542,31 @@ class _StringsRu extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -63276,6 +63566,31 @@ class _StringsTh extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -68307,6 +68622,31 @@ class _StringsTr extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -73325,6 +73665,31 @@ class _StringsVi extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 // Path: <root>
@@ -77994,6 +78359,29 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       '通过共享的 Google Drive 文件夹（ttu-reader-data）同步阅读进度。需完整 Drive 权限并重新登录。';
+  @override
+  String get interconnect_upload_section => '上传到互联对端';
+  @override
+  String get interconnect_upload_section_footer =>
+      '选择本设备要把哪些内容上传到已连接的互联对端。与云备份、以及「启用互联」连接开关互不影响；默认全部关闭。';
+  @override
+  String get interconnect_upload_content => '上传书籍文件';
+  @override
+  String get interconnect_upload_content_hint => '把本设备的书籍/阅读内容上传同步到互联对端。';
+  @override
+  String get interconnect_upload_dictionary => '上传词典';
+  @override
+  String get interconnect_upload_dictionary_hint => '把本设备的词典上传同步到互联对端。';
+  @override
+  String get interconnect_upload_audiobook_files => '上传有声书文件';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      '把本设备的有声书音频+字幕包上传同步到互联对端（体积较大）。';
+  @override
+  String get interconnect_upload_video_files => '上传视频文件';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      '把本设备的本地视频文件上传同步到互联对端（体积较大）。';
 }
 
 // Path: <root>
@@ -82796,6 +83184,31 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get sync_google_drive_hoshi_compat_desc =>
       'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+  @override
+  String get interconnect_upload_section => 'Upload to interconnect peer';
+  @override
+  String get interconnect_upload_section_footer =>
+      'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+  @override
+  String get interconnect_upload_content => 'Upload book files';
+  @override
+  String get interconnect_upload_content_hint =>
+      'Sync this device\'s books and reading content up to the interconnect peer.';
+  @override
+  String get interconnect_upload_dictionary => 'Upload dictionaries';
+  @override
+  String get interconnect_upload_dictionary_hint =>
+      'Sync this device\'s dictionaries up to the interconnect peer.';
+  @override
+  String get interconnect_upload_audiobook_files => 'Upload audiobook files';
+  @override
+  String get interconnect_upload_audiobook_files_hint =>
+      'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+  @override
+  String get interconnect_upload_video_files => 'Upload video files';
+  @override
+  String get interconnect_upload_video_files_hint =>
+      'Sync this device\'s local video files up to the interconnect peer (large).';
 }
 
 /// Flat map(s) containing all translations.
@@ -87312,6 +87725,26 @@ extension on _StringsEn {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -91826,6 +92259,26 @@ extension on _StringsAr {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -96361,6 +96814,26 @@ extension on _StringsDe {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -100895,6 +101368,26 @@ extension on _StringsEs {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -105435,6 +105928,26 @@ extension on _StringsFr {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -109957,6 +110470,26 @@ extension on _StringsId {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -114494,6 +115027,26 @@ extension on _StringsIt {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -118993,6 +119546,26 @@ extension on _StringsJa {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -123496,6 +124069,26 @@ extension on _StringsKo {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -128026,6 +128619,26 @@ extension on _StringsNl {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -132553,6 +133166,26 @@ extension on _StringsPtBr {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -137085,6 +137718,26 @@ extension on _StringsRu {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -141601,6 +142254,26 @@ extension on _StringsTh {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -146126,6 +146799,26 @@ extension on _StringsTr {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -150646,6 +151339,26 @@ extension on _StringsVi {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }
@@ -155132,6 +155845,26 @@ extension on _StringsZhCn {
         return '与 Hoshi / ッツ 共享进度';
       case 'sync_google_drive_hoshi_compat_desc':
         return '通过共享的 Google Drive 文件夹（ttu-reader-data）同步阅读进度。需完整 Drive 权限并重新登录。';
+      case 'interconnect_upload_section':
+        return '上传到互联对端';
+      case 'interconnect_upload_section_footer':
+        return '选择本设备要把哪些内容上传到已连接的互联对端。与云备份、以及「启用互联」连接开关互不影响；默认全部关闭。';
+      case 'interconnect_upload_content':
+        return '上传书籍文件';
+      case 'interconnect_upload_content_hint':
+        return '把本设备的书籍/阅读内容上传同步到互联对端。';
+      case 'interconnect_upload_dictionary':
+        return '上传词典';
+      case 'interconnect_upload_dictionary_hint':
+        return '把本设备的词典上传同步到互联对端。';
+      case 'interconnect_upload_audiobook_files':
+        return '上传有声书文件';
+      case 'interconnect_upload_audiobook_files_hint':
+        return '把本设备的有声书音频+字幕包上传同步到互联对端（体积较大）。';
+      case 'interconnect_upload_video_files':
+        return '上传视频文件';
+      case 'interconnect_upload_video_files_hint':
+        return '把本设备的本地视频文件上传同步到互联对端（体积较大）。';
       default:
         return null;
     }
@@ -159626,6 +160359,26 @@ extension on _StringsZhHk {
         return 'Share progress with Hoshi / ッツ';
       case 'sync_google_drive_hoshi_compat_desc':
         return 'Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.';
+      case 'interconnect_upload_section':
+        return 'Upload to interconnect peer';
+      case 'interconnect_upload_section_footer':
+        return 'Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.';
+      case 'interconnect_upload_content':
+        return 'Upload book files';
+      case 'interconnect_upload_content_hint':
+        return 'Sync this device\'s books and reading content up to the interconnect peer.';
+      case 'interconnect_upload_dictionary':
+        return 'Upload dictionaries';
+      case 'interconnect_upload_dictionary_hint':
+        return 'Sync this device\'s dictionaries up to the interconnect peer.';
+      case 'interconnect_upload_audiobook_files':
+        return 'Upload audiobook files';
+      case 'interconnect_upload_audiobook_files_hint':
+        return 'Sync this device\'s audiobook audio and subtitle packages up to the interconnect peer (large).';
+      case 'interconnect_upload_video_files':
+        return 'Upload video files';
+      case 'interconnect_upload_video_files_hint':
+        return 'Sync this device\'s local video files up to the interconnect peer (large).';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "查词服务已开启",
   "browser_extension_server_off": "查词服务未开启",
   "sync_google_drive_hoshi_compat": "与 Hoshi / ッツ 共享进度",
-  "sync_google_drive_hoshi_compat_desc": "通过共享的 Google Drive 文件夹（ttu-reader-data）同步阅读进度。需完整 Drive 权限并重新登录。"
+  "sync_google_drive_hoshi_compat_desc": "通过共享的 Google Drive 文件夹（ttu-reader-data）同步阅读进度。需完整 Drive 权限并重新登录。",
+  "interconnect_upload_section": "上传到互联对端",
+  "interconnect_upload_section_footer": "选择本设备要把哪些内容上传到已连接的互联对端。与云备份、以及「启用互联」连接开关互不影响；默认全部关闭。",
+  "interconnect_upload_content": "上传书籍文件",
+  "interconnect_upload_content_hint": "把本设备的书籍/阅读内容上传同步到互联对端。",
+  "interconnect_upload_dictionary": "上传词典",
+  "interconnect_upload_dictionary_hint": "把本设备的词典上传同步到互联对端。",
+  "interconnect_upload_audiobook_files": "上传有声书文件",
+  "interconnect_upload_audiobook_files_hint": "把本设备的有声书音频+字幕包上传同步到互联对端（体积较大）。",
+  "interconnect_upload_video_files": "上传视频文件",
+  "interconnect_upload_video_files_hint": "把本设备的本地视频文件上传同步到互联对端（体积较大）。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2210,5 +2210,15 @@
   "browser_extension_server_on": "Lookup server on",
   "browser_extension_server_off": "Lookup server off",
   "sync_google_drive_hoshi_compat": "Share progress with Hoshi / ッツ",
-  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in."
+  "sync_google_drive_hoshi_compat_desc": "Sync reading progress via a shared Google Drive folder (ttu-reader-data). Needs full Drive access and re-sign-in.",
+  "interconnect_upload_section": "Upload to interconnect peer",
+  "interconnect_upload_section_footer": "Choose what this device uploads to the connected peer. Independent from cloud backup and from the Enable interconnect toggle — off by default.",
+  "interconnect_upload_content": "Upload book files",
+  "interconnect_upload_content_hint": "Sync this device's books and reading content up to the interconnect peer.",
+  "interconnect_upload_dictionary": "Upload dictionaries",
+  "interconnect_upload_dictionary_hint": "Sync this device's dictionaries up to the interconnect peer.",
+  "interconnect_upload_audiobook_files": "Upload audiobook files",
+  "interconnect_upload_audiobook_files_hint": "Sync this device's audiobook audio and subtitle packages up to the interconnect peer (large).",
+  "interconnect_upload_video_files": "Upload video files",
+  "interconnect_upload_video_files_hint": "Sync this device's local video files up to the interconnect peer (large)."
 }

--- a/hibiki/lib/src/sync/sync_auto_trigger.dart
+++ b/hibiki/lib/src/sync/sync_auto_trigger.dart
@@ -91,17 +91,78 @@ void logSyncReportErrors(SyncRunReport report) {
 /// 去重：互联后端 [HibikiClientSyncBackend] 是单例；若云通道解析出的恰是同一单例
 /// （历史遗留 backendType=='hibikiServer'，迁移后不再出现，仅防御测试直接构造），
 /// 只保留一条，避免同一通道跑两遍。
-Future<List<SyncBackend>> _enabledSyncChannelBackends(
+/// 一条待跑的同步通道：后端实例 + 它是不是互联通道。isInterconnect 决定分资产开关
+/// 读云备份共享值还是互联专属上传开关（[resolveChannelSyncFlags]，BUG-988）。
+class _SyncChannel {
+  const _SyncChannel(this.backend, {required this.isInterconnect});
+  final SyncBackend backend;
+  final bool isInterconnect;
+}
+
+Future<List<_SyncChannel>> _enabledSyncChannelBackends(
   SyncRepository repo,
 ) async {
   final SyncBackend cloud = resolveSyncBackend(await repo.getBackendType());
-  final List<SyncBackend> backends = <SyncBackend>[cloud];
+  final List<_SyncChannel> channels = <_SyncChannel>[
+    _SyncChannel(cloud, isInterconnect: false),
+  ];
   if (await repo.isInterconnectEnabled()) {
     final SyncBackend interconnect =
         resolveSyncBackend(SyncBackendType.hibikiServer);
-    if (!identical(interconnect, cloud)) backends.add(interconnect);
+    // 去重：仅防御历史 backendType=='hibikiServer'（迁移后不再出现）把同一单例跑两遍。
+    if (!identical(interconnect, cloud)) {
+      channels.add(_SyncChannel(interconnect, isInterconnect: true));
+    }
   }
-  return backends;
+  return channels;
+}
+
+/// 一条同步通道要用的分资产开关集（喂给 [SyncOrchestrator]）。
+class ChannelSyncFlags {
+  const ChannelSyncFlags({
+    required this.syncStats,
+    required this.syncAudioBookPosition,
+    required this.syncContent,
+    required this.syncAudioBookFiles,
+    required this.syncVideoFiles,
+    required this.syncDictionary,
+    required this.syncLocalAudio,
+  });
+  final bool syncStats;
+  final bool syncAudioBookPosition;
+  final bool syncContent;
+  final bool syncAudioBookFiles;
+  final bool syncVideoFiles;
+  final bool syncDictionary;
+  final bool syncLocalAudio;
+}
+
+/// 按通道解析分资产同步开关（BUG-988）。[isInterconnect]==true（互联通道）时「重内容」
+/// 四类——书籍/内容、词典、有声书文件、视频文件——读互联专属上传开关（默认 false，让
+/// 用户独立控制是否上传给互联对端，不被「启用互联连接」裹挟）；false（云备份通道）读
+/// 原共享 sync_*_enabled。位置/统计/本地音频不区分通道（轻量进度，跨设备续读是互联本意）。
+@visibleForTesting
+Future<ChannelSyncFlags> resolveChannelSyncFlags(
+  SyncRepository repo, {
+  required bool isInterconnect,
+}) async {
+  return ChannelSyncFlags(
+    syncStats: await repo.isSyncStatsEnabled(),
+    syncAudioBookPosition: await repo.isSyncAudioBookEnabled(),
+    syncContent: isInterconnect
+        ? await repo.isInterconnectSyncContentEnabled()
+        : await repo.isSyncContentEnabled(),
+    syncAudioBookFiles: isInterconnect
+        ? await repo.isInterconnectSyncAudioBookFilesEnabled()
+        : await repo.isSyncAudioBookFilesEnabled(),
+    syncVideoFiles: isInterconnect
+        ? await repo.isInterconnectSyncVideoFilesEnabled()
+        : await repo.isSyncVideoFilesEnabled(),
+    syncDictionary: isInterconnect
+        ? await repo.isInterconnectSyncDictionaryEnabled()
+        : await repo.isSyncDictionaryEnabled(),
+    syncLocalAudio: await repo.isSyncLocalAudioEnabled(),
+  );
 }
 
 /// 为单个 [backend] 通道构建并运行一轮完整同步编排。认证失败（未配置该通道）返回
@@ -111,6 +172,7 @@ Future<SyncRunReport?> _runSyncChannel({
   required HibikiDatabase db,
   required SyncRepository repo,
   required SyncBackend backend,
+  required bool isInterconnect,
   required Directory dictionaryResourceRoot,
   required Directory audioDatabaseRoot,
   required Directory tempDir,
@@ -121,6 +183,9 @@ Future<SyncRunReport?> _runSyncChannel({
 }) async {
   await backend.restoreAuth(repo);
   if (!await backend.isAuthenticated) return null;
+  // BUG-988：互联通道读互联专属上传开关，云备份通道读原共享开关（两通道互不牵连）。
+  final ChannelSyncFlags flags =
+      await resolveChannelSyncFlags(repo, isInterconnect: isInterconnect);
   final SyncOrchestrator orchestrator = SyncOrchestrator(
     db: db,
     backend: backend,
@@ -128,13 +193,13 @@ Future<SyncRunReport?> _runSyncChannel({
     audioDatabaseRoot: audioDatabaseRoot,
     tempDir: tempDir,
     deviceId: await repo.getOrCreateDeviceId(),
-    syncStats: await repo.isSyncStatsEnabled(),
-    syncAudioBookPosition: await repo.isSyncAudioBookEnabled(),
-    syncContent: await repo.isSyncContentEnabled(),
-    syncAudioBookFiles: await repo.isSyncAudioBookFilesEnabled(),
-    syncVideoFiles: await repo.isSyncVideoFilesEnabled(),
-    syncDictionary: await repo.isSyncDictionaryEnabled(),
-    syncLocalAudio: await repo.isSyncLocalAudioEnabled(),
+    syncStats: flags.syncStats,
+    syncAudioBookPosition: flags.syncAudioBookPosition,
+    syncContent: flags.syncContent,
+    syncAudioBookFiles: flags.syncAudioBookFiles,
+    syncVideoFiles: flags.syncVideoFiles,
+    syncDictionary: flags.syncDictionary,
+    syncLocalAudio: flags.syncLocalAudio,
     localAudioEntries: localAudioEntries,
     onLocalAudioImported: onLocalAudioImported,
     onProgress: onProgress,
@@ -231,12 +296,13 @@ Future<void> _runAutoSyncAll({
 
       // option B 双通道：依次跑云备份通道 + 互联通道（若启用），互不排斥。每条通道
       // 各自认证成功才实际跑；未配置的通道 no-op（_runSyncChannel 返回 null）。
-      for (final SyncBackend backend
+      for (final _SyncChannel channel
           in await _enabledSyncChannelBackends(repo)) {
         final SyncRunReport? report = await _runSyncChannel(
           db: db,
           repo: repo,
-          backend: backend,
+          backend: channel.backend,
+          isInterconnect: channel.isInterconnect,
           dictionaryResourceRoot: dictionaryResourceRoot,
           audioDatabaseRoot: audioDatabaseRoot,
           tempDir: tempDir,
@@ -249,7 +315,7 @@ Future<void> _runAutoSyncAll({
         if (report == null) continue;
         logSyncReportErrors(report);
         await onPostRun?.call(report);
-        onReport?.call(report, backend);
+        onReport?.call(report, channel.backend);
       }
     });
   } catch (e) {
@@ -321,12 +387,13 @@ Future<ManualSyncResult> runManualFullSync({
       final SyncRunReport merged = SyncRunReport();
       final List<ManualSyncChannelReport> channelReports =
           <ManualSyncChannelReport>[];
-      for (final SyncBackend backend
+      for (final _SyncChannel channel
           in await _enabledSyncChannelBackends(repo)) {
         final SyncRunReport? report = await _runSyncChannel(
           db: db,
           repo: repo,
-          backend: backend,
+          backend: channel.backend,
+          isInterconnect: channel.isInterconnect,
           dictionaryResourceRoot: dictionaryResourceRoot,
           audioDatabaseRoot: audioDatabaseRoot,
           tempDir: tempDir,
@@ -343,7 +410,7 @@ Future<ManualSyncResult> runManualFullSync({
         logSyncReportErrors(report);
         await onPostRun?.call(report);
         merged.mergeFrom(report);
-        channelReports.add(ManualSyncChannelReport(backend, report));
+        channelReports.add(ManualSyncChannelReport(channel.backend, report));
       }
       if (channelReports.isEmpty) {
         return const ManualSyncResult(ManualSyncOutcome.notConfigured);
@@ -433,8 +500,9 @@ Future<void> _runCollectionsSync({required HibikiDatabase db}) async {
     await _autoSyncMutex.withLock(() async {
       final repo = SyncRepository(db);
       if (!await repo.isAutoSyncEnabled()) return;
-      for (final SyncBackend backend
+      for (final _SyncChannel channel
           in await _enabledSyncChannelBackends(repo)) {
+        final SyncBackend backend = channel.backend;
         await backend.restoreAuth(repo);
         if (!await backend.isAuthenticated) continue;
         final SyncOrchestrator orchestrator = SyncOrchestrator(
@@ -501,11 +569,16 @@ Future<void> _runAutoSync({
       final syncStats = await repo.isSyncStatsEnabled();
       final syncAudioBook = await repo.isSyncAudioBookEnabled();
       final syncContent = await repo.isSyncContentEnabled();
+      // BUG-988：互联通道的书内容上传读互联专属开关（默认关），云通道读共享开关——
+      // 否则退出书时书内容仍会无视互联上传开关自动推给对端。
+      final interconnectSyncContent =
+          await repo.isInterconnectSyncContentEnabled();
 
       // option B 双通道：退出书时对每条启用的通道（云备份 + 互联）各跑一次 per-book
       // 同步，互不排斥。每条通道各自认证成功才跑；未配置的通道 continue 跳过。
-      for (final SyncBackend backend
+      for (final _SyncChannel channel
           in await _enabledSyncChannelBackends(repo)) {
+        final SyncBackend backend = channel.backend;
         await backend.restoreAuth(repo);
         if (!await backend.isAuthenticated) continue;
 
@@ -515,7 +588,8 @@ Future<void> _runAutoSync({
           syncStats: syncStats,
           statsSyncMode: StatisticsSyncMode.merge,
           syncAudioBook: syncAudioBook,
-          syncContent: syncContent,
+          syncContent:
+              channel.isInterconnect ? interconnectSyncContent : syncContent,
         );
 
         // TODO-132 诉求B：退出书同步静默——不再弹 imported/exported「同步成功」

--- a/hibiki/lib/src/sync/sync_compare_dialog.dart
+++ b/hibiki/lib/src/sync/sync_compare_dialog.dart
@@ -614,7 +614,11 @@ class _SyncCompareDialogState extends State<SyncCompareDialog> {
         final repo = SyncRepository(widget.db);
         final syncStats = await repo.isSyncStatsEnabled();
         final syncAudioBook = await repo.isSyncAudioBookEnabled();
-        final syncContent = await repo.isSyncContentEnabled();
+        // BUG-988：手动解决冲突并应用时，互联通道读互联专属上传开关、云通道读共享开关，
+        // 与自动同步一致——否则「互联内容开、云内容关」时互联冲突的内容传输会被误跳过。
+        final syncContent = widget.backend is HibikiClientSyncBackend
+            ? await repo.isInterconnectSyncContentEnabled()
+            : await repo.isSyncContentEnabled();
 
         var done = 0;
         // Blend per-file transfer fraction into the overall book progress so the

--- a/hibiki/lib/src/sync/sync_repository.dart
+++ b/hibiki/lib/src/sync/sync_repository.dart
@@ -102,6 +102,15 @@ class SyncRepository {
   // 本机 Drive 存储空间/scope），不随备份导入覆盖。
   static const _keyGoogleDriveHoshiCompat = 'google_drive_hoshi_compat';
   static const _keySyncContent = 'sync_content_enabled';
+  // BUG-988：互联通道专属的「上传内容到互联对端」开关，独立于云备份的
+  // sync_*_enabled（那套只管云通道）。互联解耦(PR#223)后互联通道曾复用云备份的
+  // 共享开关，用户失去「只对互联单独控制上不上传」的能力；这四个键把互联通道的内容
+  // 上传拆出来单独控制。默认 false（用户显式 opt-in，不被「启用互联连接」裹挟着自动传）。
+  static const _keyInterconnectSyncContent = 'interconnect_sync_content';
+  static const _keyInterconnectSyncDictionary = 'interconnect_sync_dictionary';
+  static const _keyInterconnectSyncAudioBookFiles =
+      'interconnect_sync_audiobook_files';
+  static const _keyInterconnectSyncVideoFiles = 'interconnect_sync_video_files';
   static const _keyWebDavUrl = 'sync_webdav_url';
   static const _keyWebDavUsername = 'sync_webdav_username';
   static const _keyWebDavPassword = 'sync_webdav_password';
@@ -325,6 +334,32 @@ class SyncRepository {
       _db.getPrefTyped<bool>(_keySyncContent, false);
   Future<void> setSyncContentEnabled(bool v) =>
       _db.setPrefTyped<bool>(_keySyncContent, v);
+
+  // ── 互联通道专属上传开关（BUG-988） ────────────────────────────────
+  // 只作用于互联通道（[_runSyncChannel] 的 isInterconnect==true），与上面的云备份
+  // sync_*_enabled 完全解耦；默认 false，让用户独立控制「要不要把本设备内容上传到
+  // 互联对端」，不被「启用互联连接」自动裹挟。位置/统计等轻量进度仍走共享开关（跨设备
+  // 续读是互联本意），此处仅拆「重内容」四类：书籍/内容、词典、有声书文件、视频文件。
+
+  Future<bool> isInterconnectSyncContentEnabled() =>
+      _db.getPrefTyped<bool>(_keyInterconnectSyncContent, false);
+  Future<void> setInterconnectSyncContentEnabled(bool v) =>
+      _db.setPrefTyped<bool>(_keyInterconnectSyncContent, v);
+
+  Future<bool> isInterconnectSyncDictionaryEnabled() =>
+      _db.getPrefTyped<bool>(_keyInterconnectSyncDictionary, false);
+  Future<void> setInterconnectSyncDictionaryEnabled(bool v) =>
+      _db.setPrefTyped<bool>(_keyInterconnectSyncDictionary, v);
+
+  Future<bool> isInterconnectSyncAudioBookFilesEnabled() =>
+      _db.getPrefTyped<bool>(_keyInterconnectSyncAudioBookFiles, false);
+  Future<void> setInterconnectSyncAudioBookFilesEnabled(bool v) =>
+      _db.setPrefTyped<bool>(_keyInterconnectSyncAudioBookFiles, v);
+
+  Future<bool> isInterconnectSyncVideoFilesEnabled() =>
+      _db.getPrefTyped<bool>(_keyInterconnectSyncVideoFiles, false);
+  Future<void> setInterconnectSyncVideoFilesEnabled(bool v) =>
+      _db.setPrefTyped<bool>(_keyInterconnectSyncVideoFiles, v);
 
   // ── Per-book audiobook position (synced) ──────────────────────────
 

--- a/hibiki/lib/src/sync/sync_settings_schema.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema.dart
@@ -204,11 +204,12 @@ SettingsDestination buildSyncBackupDestination() {
                   .setSyncLocalAudioEnabled(value);
             },
           ),
-          // 「上传X文件」三个开关都是 OUTBOUND：把本机资产推给已解析的后端。互联
-          // host（本机在做服务端）没有任何 outbound sync——client 从它拉取/往它推，
-          // 它自己不上传（auto_sync 同理已隐藏）。故 host 模式下这三个上传开关纯空转，
-          // 一律随 auto_sync 的 `!_isHostingInterconnect` 门控隐藏（client 模式仍可见，
-          // client 确实能往 host 推）。
+          // 「上传X文件」三个开关都是 OUTBOUND：把本机资产推给**云备份**后端。BUG-988
+          // 起互联通道不再复用这套共享开关——互联的内容上传由「上传到互联对端」分项开关
+          // 单独控制（见 buildInterconnectDestination），二者互不牵连。互联 host（本机在
+          // 做服务端）没有任何 outbound sync——client 从它拉取/往它推，它自己不上传
+          // （auto_sync 同理已隐藏）。故 host 模式下这三个上传开关纯空转，一律随 auto_sync
+          // 的 `!_isHostingInterconnect` 门控隐藏（client 模式仍可见）。
           SettingsSwitchItem(
             id: 'sync.content',
             title: t.sync_content,
@@ -392,6 +393,70 @@ SettingsDestination buildInterconnectDestination() {
           ),
         ],
       ),
+      // BUG-988：上传到互联对端——互联通道专属的「本设备内容要不要上传给对端」分项开关，
+      // 独立于云备份的同名开关（那套只管云通道），也独立于上面的「启用互联」连接开关。
+      // 默认全关：用户开互联只为远端看/读时不会被自动上传裹挟，想传哪类自己勾。与云备份
+      // 上传开关同为 OUTBOUND，host 模式（本机做服务端，client 往它推）无 outbound → 隐藏。
+      SettingsSection(
+        title: t.interconnect_upload_section,
+        footer: t.interconnect_upload_section_footer,
+        visible: (SettingsContext ctx) =>
+            interconnectActive(ctx) && !_isHostingInterconnect(ctx),
+        items: <SettingsItem>[
+          SettingsSwitchItem(
+            id: 'interconnect.upload_content',
+            title: t.interconnect_upload_content,
+            subtitle: t.interconnect_upload_content_hint,
+            icon: Icons.book_outlined,
+            value: (SettingsContext ctx) =>
+                _syncSettings(ctx).interconnectSyncContent,
+            onChanged: (SettingsContext ctx, bool value) async {
+              _syncSettings(ctx).interconnectSyncContent = value;
+              await SyncRepository(ctx.appModel.database)
+                  .setInterconnectSyncContentEnabled(value);
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'interconnect.upload_dictionary',
+            title: t.interconnect_upload_dictionary,
+            subtitle: t.interconnect_upload_dictionary_hint,
+            icon: Icons.menu_book_outlined,
+            value: (SettingsContext ctx) =>
+                _syncSettings(ctx).interconnectSyncDictionary,
+            onChanged: (SettingsContext ctx, bool value) async {
+              _syncSettings(ctx).interconnectSyncDictionary = value;
+              await SyncRepository(ctx.appModel.database)
+                  .setInterconnectSyncDictionaryEnabled(value);
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'interconnect.upload_audiobook_files',
+            title: t.interconnect_upload_audiobook_files,
+            subtitle: t.interconnect_upload_audiobook_files_hint,
+            icon: Icons.audio_file_outlined,
+            value: (SettingsContext ctx) =>
+                _syncSettings(ctx).interconnectSyncAudioBookFiles,
+            onChanged: (SettingsContext ctx, bool value) async {
+              _syncSettings(ctx).interconnectSyncAudioBookFiles = value;
+              await SyncRepository(ctx.appModel.database)
+                  .setInterconnectSyncAudioBookFilesEnabled(value);
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'interconnect.upload_video_files',
+            title: t.interconnect_upload_video_files,
+            subtitle: t.interconnect_upload_video_files_hint,
+            icon: Icons.video_file_outlined,
+            value: (SettingsContext ctx) =>
+                _syncSettings(ctx).interconnectSyncVideoFiles,
+            onChanged: (SettingsContext ctx, bool value) async {
+              _syncSettings(ctx).interconnectSyncVideoFiles = value;
+              await SyncRepository(ctx.appModel.database)
+                  .setInterconnectSyncVideoFilesEnabled(value);
+            },
+          ),
+        ],
+      ),
       // 本机作为服务器：host 模式开关（与 client 角色互斥，见 _SyncSettingsState
       // 的 roleRevision 互斥锁）。
       SettingsSection(
@@ -498,6 +563,11 @@ class _SyncSettingsState {
   bool syncContent = false;
   bool syncAudioBookFiles = false;
   bool syncVideoFiles = false;
+  // BUG-988：互联通道专属的「上传内容到对端」开关，独立于上面的云备份 sync* 开关。
+  bool interconnectSyncContent = false;
+  bool interconnectSyncDictionary = false;
+  bool interconnectSyncAudioBookFiles = false;
+  bool interconnectSyncVideoFiles = false;
   bool _loaded = false;
   bool _loading = false;
 
@@ -557,6 +627,13 @@ class _SyncSettingsState {
       syncContent = await _repo.isSyncContentEnabled();
       syncAudioBookFiles = await _repo.isSyncAudioBookFilesEnabled();
       syncVideoFiles = await _repo.isSyncVideoFilesEnabled();
+      interconnectSyncContent = await _repo.isInterconnectSyncContentEnabled();
+      interconnectSyncDictionary =
+          await _repo.isInterconnectSyncDictionaryEnabled();
+      interconnectSyncAudioBookFiles =
+          await _repo.isInterconnectSyncAudioBookFilesEnabled();
+      interconnectSyncVideoFiles =
+          await _repo.isInterconnectSyncVideoFilesEnabled();
       serverEnabled = await _repo.isServerEnabled();
       hasClientConnection = (await _repo.getHibikiClientUrls()).isNotEmpty;
       _loaded = true;

--- a/hibiki/test/sync/interconnect_upload_toggles_test.dart
+++ b/hibiki/test/sync/interconnect_upload_toggles_test.dart
@@ -1,0 +1,92 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/sync_auto_trigger.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+import 'temp_dir_cleanup.dart';
+
+/// BUG-988：互联解耦(PR#223)后，互联通道复用云备份的共享 sync_*_enabled 开关——用户
+/// 一开「启用互联」连接，内容就跟着自动上传给对端，失去「只对互联单独控制上不上传」的
+/// 能力。修复：互联通道的「重内容」四类（书籍/词典/有声书文件/视频文件）改读互联专属
+/// 上传开关（默认关），与云备份共享开关解耦。[resolveChannelSyncFlags] 是路由的纯函数
+/// 落点，本测试直接验它。
+void main() {
+  late Directory tmp;
+  late HibikiDatabase db;
+  late SyncRepository repo;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('ic_upload_toggles_');
+    final String dbDir = p.join(tmp.path, 'db');
+    Directory(dbDir).createSync(recursive: true);
+    db = HibikiDatabase(dbDir);
+    repo = SyncRepository(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+    await cleanupTempDir(tmp);
+  });
+
+  test('互联专属上传开关默认全关，云备份内容开关全开也不上传给互联（BUG-988）', () async {
+    // 云备份内容开关全开（模拟用户为云备份开启）。
+    await repo.setSyncContentEnabled(true);
+    await repo.setSyncDictionaryEnabled(true);
+    await repo.setSyncAudioBookFilesEnabled(true);
+    await repo.setSyncVideoFilesEnabled(true);
+
+    // 云通道：读共享开关 → 全 true。
+    final ChannelSyncFlags cloud =
+        await resolveChannelSyncFlags(repo, isInterconnect: false);
+    expect(cloud.syncContent, isTrue);
+    expect(cloud.syncDictionary, isTrue);
+    expect(cloud.syncAudioBookFiles, isTrue);
+    expect(cloud.syncVideoFiles, isTrue);
+
+    // 互联通道：读互联专属开关（默认全关）→ 云开着也不会上传给互联对端。核心修复。
+    final ChannelSyncFlags ic =
+        await resolveChannelSyncFlags(repo, isInterconnect: true);
+    expect(ic.syncContent, isFalse, reason: '云开着也不该自动上传书给互联对端');
+    expect(ic.syncDictionary, isFalse);
+    expect(ic.syncAudioBookFiles, isFalse);
+    expect(ic.syncVideoFiles, isFalse);
+  });
+
+  test('打开互联专属上传开关只影响互联通道，不动云通道（BUG-988）', () async {
+    await repo.setInterconnectSyncContentEnabled(true);
+    await repo.setInterconnectSyncDictionaryEnabled(true);
+    // 云备份内容开关保持默认关。
+
+    final ChannelSyncFlags ic =
+        await resolveChannelSyncFlags(repo, isInterconnect: true);
+    expect(ic.syncContent, isTrue);
+    expect(ic.syncDictionary, isTrue);
+    expect(ic.syncVideoFiles, isFalse, reason: '未开的类仍不传');
+
+    final ChannelSyncFlags cloud =
+        await resolveChannelSyncFlags(repo, isInterconnect: false);
+    expect(cloud.syncContent, isFalse, reason: '云通道不受互联专属开关影响');
+    expect(cloud.syncDictionary, isFalse);
+  });
+
+  test('位置/统计/本地音频不区分通道（轻量进度共享，跨设备续读是互联本意）', () async {
+    await repo.setSyncStatsEnabled(false);
+    await repo.setSyncLocalAudioEnabled(true);
+
+    final ChannelSyncFlags ic =
+        await resolveChannelSyncFlags(repo, isInterconnect: true);
+    final ChannelSyncFlags cloud =
+        await resolveChannelSyncFlags(repo, isInterconnect: false);
+
+    expect(ic.syncStats, cloud.syncStats);
+    expect(ic.syncStats, isFalse);
+    expect(ic.syncLocalAudio, cloud.syncLocalAudio);
+    expect(ic.syncLocalAudio, isTrue);
+    // 有声书播放位置恒同步（isSyncAudioBookEnabled 恒 true）——两通道一致。
+    expect(ic.syncAudioBookPosition, isTrue);
+    expect(cloud.syncAudioBookPosition, isTrue);
+  });
+}


### PR DESCRIPTION
## 问题
用户报：没法给 hibiki 互联上传书/词典了，「后端里没了 hibiki 互联」，且「客户端开了有什么用？我要控制上不上传啊」。

调查发现：互联解耦（PR#223）把「hibikiServer」从「同步方式」后端下拉里 gate 掉、改成独立「启用互联」开关，同时把「上传内容」的分项开关（`sync_content`/`sync_dictionary`/`sync_audiobook_files`/`sync_video_files`）留在**云备份**设置区，且**云备份与互联通道共用同一套开关**（`sync_auto_trigger.dart` 两通道都读 `repo.isSyncXxxEnabled()`）。

后果：解耦前「选 hibikiServer 后端 = 掌握上不上传到对端」的控制没了——用户一开「启用互联」连接（为远端看/读），书/词典就被同一套共享开关裹挟着自动上传给对端，无法只对互联单独控制。

## 修复（根因：给互联通道自己的上传开关，与云备份/连接开关解耦）
- **`sync_repository.dart`**：新增 4 个互联专属键 `interconnect_sync_content` / `_dictionary` / `_audiobook_files` / `_video_files` + getter/setter，默认 **false**。
- **`sync_auto_trigger.dart`**：`_enabledSyncChannelBackends` 返回带 `isInterconnect` 标记的 `_SyncChannel`；抽纯函数 `resolveChannelSyncFlags(repo, {isInterconnect})`——互联通道「重内容」四类读互联专属开关、云通道读原共享开关（位置/统计/本地音频仍共享，跨设备续读是互联本意）。**四个同步入口**（app-open 全量 / 手动全量 / 合集 / 退出书 per-book）全部按通道路由。
- **`sync_compare_dialog.dart`**：手动解决冲突 apply 时按 `backend is HibikiClientSyncBackend` 读互联/云对应内容开关（否则「互联内容开、云内容关」时互联冲突内容传输被误跳过）。
- **`sync_settings_schema.dart`**：「设置 → Hibiki 互联」加 section「上传到互联对端」的 4 个开关（`visible: interconnectActive && !_isHostingInterconnect`，host 无 outbound 时隐藏）+ 状态字段/load。
- **i18n**：10 个 key 经 `tool/i18n_sync.dart --add`（17 语言）+ `dart run slang` 重生成。

## 默认/兼容
互联上传开关默认**全关**（用户明确要「自己控制、别自动传」）；云备份 `sync_*` 开关默认本就全关，故绝大多数用户无行为突变。「同步方式」下拉不再列 hibiki 互联是 PR#223 有意设计，不回退。

## 测试
- `test/sync/interconnect_upload_toggles_test.dart`：互联默认全关时云开着也不上传给互联；开互联开关只影响互联通道不动云；位置/统计/本地音频两通道共享。
- `flutter analyze` 改动文件 No issues；i18n 完整性 + mojibake 守卫通过。

## 待验
真机：两台设备互联，开/关互联上传开关后各触发一次同步，验证书/词典是否按开关上传到对端。

https://claude.ai/code/session_01U8bqNgrhevwSDKvPpzLV82