### PR TITLE
fix(download): BUG-897 下载页关 resizeToAvoidBottomInset，软键盘不再顶掉贴底下载任务区

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 871 条。点号进各自文件。
+> 共 872 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-897](bugs/BUG-897-download-kb-inset.md) | ✅ | ✅ | 下载页输入apikey时软键盘顶掉贴底下载任务区 |
 | [BUG-896](bugs/BUG-896-jimaku-download-anilist-only-no-query-fallback.md) | ✅ | ✅ | 下载页字幕搜索仅按AniList id无文本回退致误报无字幕 |
 | [BUG-895](bugs/BUG-895-anilist-macron-search.md) | ✅ | ✅ | 番剧下载AniList搜索:带macron长音的罗马字全无结果 |
 | [BUG-890](bugs/BUG-890-paused-audio-follow-image-snap.md) | ✅ | ✅ | 暂停/图片等待时有声书跟随把阅读器拽回音频位置 |

--- a/docs/bugs/BUG-897-download-kb-inset.md
+++ b/docs/bugs/BUG-897-download-kb-inset.md
@@ -3,6 +3,6 @@
 - **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/downloads_page.dart:23`（`Scaffold` 未设 `resizeToAvoidBottomInset`，默认 `true`）+ `anime_download_dialog.dart:1092-1105`（内联布局：顶部输入框 + 中段唯一 `Expanded(stage)` + 贴底 `_buildTasksSection`）。
   - 数据流：手机点顶部 apikey 输入框 → 软键盘弹出 → `MediaQuery.viewInsets.bottom` 增大 → `resizeToAvoidBottomInset:true` 把 `Scaffold` body 高度压掉键盘高度 → Column 里唯一弹性的 `Expanded(stage)` 被压扁 → 贴底的「下载任务」折叠区被顶到键盘上方；在被键盘缩短的视口里正好升到顶部 apikey 输入框边上，表现为「下载任务爬进输入栏位置、被输入框挤上去」。
   - 桌面端无软键盘，`viewInsets.bottom` 恒为 0，不复现（纯移动端布局问题）。
-- **[x] ① 已修复** — `downloads_page.dart` 的 `Scaffold` 加 `resizeToAvoidBottomInset: false`。所有真正的输入框（apikey / 搜番 / Nyaa 查询 / 通用磁力）都在页面上半部，结果列表与下载任务在下半部；关掉 inset 后键盘只覆盖下半部（打字时本就不看），顶部输入框保持可见、布局不再反流。符合「消除特殊情况而非加补丁」——不再让贴底任务区随键盘反流。提交：<待填>
-- **[x] ② 已加自动化测试** — 源码扫描守卫 `hibiki/test/pages/downloads_page_resize_inset_guard_test.dart`：断言 `downloads_page.dart` 的 `Scaffold` 显式设 `resizeToAvoidBottomInset: false`，防回归（widget 层无法稳定断言「键盘弹出后贴底区不上移」，最强可落地层是源码守卫）。提交：<待填>
+- **[x] ① 已修复** — `downloads_page.dart` 的 `Scaffold` 加 `resizeToAvoidBottomInset: false`。所有真正的输入框（apikey / 搜番 / Nyaa 查询 / 通用磁力）都在页面上半部，结果列表与下载任务在下半部；关掉 inset 后键盘只覆盖下半部（打字时本就不看），顶部输入框保持可见、布局不再反流。符合「消除特殊情况而非加补丁」——不再让贴底任务区随键盘反流。提交：df2558df2
+- **[x] ② 已加自动化测试** — 源码扫描守卫 `hibiki/test/pages/downloads_page_resize_inset_guard_test.dart`：断言 `downloads_page.dart` 的 `Scaffold` 显式设 `resizeToAvoidBottomInset: false`，防回归（widget 层无法稳定断言「键盘弹出后贴底区不上移」，最强可落地层是源码守卫）。提交：df2558df2
 - **备注**：下载页（`DownloadsPage` / `AnimeDownloadDialog(embedded:true)`）当前只存在于 `feat-general-download-upload-toggle` 分支（PR#300），本修复基于 origin 该分支，PR 目标为该分支而非 develop。

--- a/docs/bugs/BUG-897-download-kb-inset.md
+++ b/docs/bugs/BUG-897-download-kb-inset.md
@@ -1,0 +1,8 @@
+## BUG-897 · 下载页输入apikey时软键盘顶掉贴底下载任务区
+- **报告**：2026-07-22（用户：下载里面输入apikey的时候下载任务会进入到输入栏位置，被输入框挤上去）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/downloads_page.dart:23`（`Scaffold` 未设 `resizeToAvoidBottomInset`，默认 `true`）+ `anime_download_dialog.dart:1092-1105`（内联布局：顶部输入框 + 中段唯一 `Expanded(stage)` + 贴底 `_buildTasksSection`）。
+  - 数据流：手机点顶部 apikey 输入框 → 软键盘弹出 → `MediaQuery.viewInsets.bottom` 增大 → `resizeToAvoidBottomInset:true` 把 `Scaffold` body 高度压掉键盘高度 → Column 里唯一弹性的 `Expanded(stage)` 被压扁 → 贴底的「下载任务」折叠区被顶到键盘上方；在被键盘缩短的视口里正好升到顶部 apikey 输入框边上，表现为「下载任务爬进输入栏位置、被输入框挤上去」。
+  - 桌面端无软键盘，`viewInsets.bottom` 恒为 0，不复现（纯移动端布局问题）。
+- **[x] ① 已修复** — `downloads_page.dart` 的 `Scaffold` 加 `resizeToAvoidBottomInset: false`。所有真正的输入框（apikey / 搜番 / Nyaa 查询 / 通用磁力）都在页面上半部，结果列表与下载任务在下半部；关掉 inset 后键盘只覆盖下半部（打字时本就不看），顶部输入框保持可见、布局不再反流。符合「消除特殊情况而非加补丁」——不再让贴底任务区随键盘反流。提交：<待填>
+- **[x] ② 已加自动化测试** — 源码扫描守卫 `hibiki/test/pages/downloads_page_resize_inset_guard_test.dart`：断言 `downloads_page.dart` 的 `Scaffold` 显式设 `resizeToAvoidBottomInset: false`，防回归（widget 层无法稳定断言「键盘弹出后贴底区不上移」，最强可落地层是源码守卫）。提交：<待填>
+- **备注**：下载页（`DownloadsPage` / `AnimeDownloadDialog(embedded:true)`）当前只存在于 `feat-general-download-upload-toggle` 分支（PR#300），本修复基于 origin 该分支，PR 目标为该分支而非 develop。

--- a/hibiki/lib/src/pages/implementations/downloads_page.dart
+++ b/hibiki/lib/src/pages/implementations/downloads_page.dart
@@ -21,6 +21,12 @@ class _DownloadsPageState extends State<DownloadsPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      // BUG-897：内联下载流程把 apikey/搜番等输入框全放在页面上半部，下载任务折叠区
+      // 贴底、中段结果列表是唯一的 Expanded。默认 resizeToAvoidBottomInset:true 时，
+      // 手机软键盘弹出会压掉 body 高度、顶掉贴底任务区，使其爬到顶部输入框边上（看似
+      // 「下载任务被输入框挤上去」）。关掉 inset 让键盘只覆盖下半部结果/任务区（打字时
+      // 本就不看），顶部输入框保持可见、布局不反流。
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(
         title: Text(_showSettings ? t.download_settings : t.nav_downloads),
         actions: <Widget>[

--- a/hibiki/test/pages/downloads_page_resize_inset_guard_test.dart
+++ b/hibiki/test/pages/downloads_page_resize_inset_guard_test.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 源码守卫（BUG-897）：独立「下载」页（[DownloadsPage] → 内联
+/// [AnimeDownloadDialog]）的 [Scaffold] 必须显式 `resizeToAvoidBottomInset: false`。
+///
+/// 根因：内联下载流程把 apikey / 搜番 / Nyaa 查询 / 通用磁力等**输入框全放在页面
+/// 上半部**，中段结果列表是唯一的 `Expanded`、「下载任务」折叠区贴底。默认
+/// `resizeToAvoidBottomInset:true` 时，手机点顶部 apikey 输入框弹出软键盘会压掉
+/// `Scaffold` body 高度 → 唯一弹性的中段被压扁 → 贴底任务区被顶到键盘上方、爬到
+/// 顶部输入框边上（用户报「下载任务被输入框挤上去」）。关掉 inset 让键盘只覆盖下半部
+/// 结果 / 任务区（打字时本就不看），顶部输入框保持可见、布局不反流。
+///
+/// 键盘弹出后的几何依赖真实 `MediaQuery.viewInsets` + 平台软键盘，widget 测试难稳定
+/// 复现，故用源码扫描守卫钉住这行接线不被回退。
+void main() {
+  test(
+      'downloads_page 的 Scaffold 设 resizeToAvoidBottomInset:false（软键盘不顶掉贴底任务区）',
+      () {
+    final File f = File('lib/src/pages/implementations/downloads_page.dart');
+    expect(f.existsSync(), isTrue,
+        reason: '找不到 downloads_page.dart（路径变了要同步本守卫）');
+    final String src = f.readAsStringSync();
+
+    // 必须出现在文件里且落在 Scaffold(...) 内（本文件只有一个 Scaffold）。
+    final int scaffold = src.indexOf('return Scaffold(');
+    expect(scaffold, greaterThanOrEqualTo(0), reason: '下载页应是一个 Scaffold');
+    expect(
+      src.contains('resizeToAvoidBottomInset: false'),
+      isTrue,
+      reason: '下载页 Scaffold 必须显式 resizeToAvoidBottomInset:false，'
+          '否则软键盘弹出会把贴底「下载任务」区顶到顶部输入框边上（BUG-897）',
+    );
+  });
+}


### PR DESCRIPTION
## 问题
下载页里点顶部 apikey 输入框输入时，贴底的「下载任务」区被软键盘顶上来，爬到输入框边上（用户：「下载里面输入apikey的时候下载任务会进入到输入栏位置，被输入框挤上去」）。

## 根因
`DownloadsPage`（`downloads_page.dart`）内联 `AnimeDownloadDialog(embedded:true)`：所有输入框（apikey/搜番/Nyaa 查询/通用磁力）在页面上半部，中段结果列表是唯一的 `Expanded`、「下载任务」折叠区贴底。`Scaffold` 未设 `resizeToAvoidBottomInset`（默认 `true`），手机软键盘弹出压掉 body 高度 → 唯一弹性的中段被压扁 → 贴底任务区被顶到键盘上方、正好升到顶部输入框边上。桌面端无软键盘不复现。

## 修复
给下载页 `Scaffold` 设 `resizeToAvoidBottomInset: false`。键盘只覆盖下半部结果/任务区（打字时本就不看），顶部输入框保持可见、布局不再反流。消除特殊情况，不加补丁/延迟。

## 测试
- 源码扫描守卫 `hibiki/test/pages/downloads_page_resize_inset_guard_test.dart`（钉住这行接线，绿）。
- `flutter analyze --no-pub`（改动文件）：No issues found。
- ⚠️ 仍需 Android 真机复测原始失败路径（键盘弹出后任务区不再上移）——布局/键盘几何 widget 层难稳定复现。

BUG 跟踪：`docs/bugs/BUG-897-download-kb-inset.md`。目标分支是 `feat-general-download-upload-toggle`（PR#300，下载页只在该分支存在），非 develop。

https://claude.ai/code/session_01Ars2n5Sf34GSaYBt8sez48