### PR TITLE
fix(mining): 互联视频制卡 host 端裁句子音频 + 补远程发音源单词音频 (BUG-1003/1004)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 969 条。点号进各自文件。
+> 共 971 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1004](bugs/BUG-1004-mining-word-audio-remote-source.md) | ✅ | ✅ | 制卡缺单词音频·扩展needsAudio门+制卡器忽略远程发音源 |
+| [BUG-1003](bugs/BUG-1003-interconnect-mining-audio-host-clip.md) | ✅ | ✅ | 互联视频制卡句子音频改 host 端裁绕开 client ffmpeg 抓远端流 |
 | [BUG-1002](bugs/BUG-1002-jimaku-download-anilist-only-no-query-fallback.md) | ✅ | ✅ | 下载页字幕搜索仅按AniList id无文本回退致误报无字幕 |
 | [BUG-1001](bugs/BUG-1001-lookup-panel-pin-block-off-faint-light.md) | ✅ | ✅ | 桌面查词浮窗顶栏图钉/防截屏关闭态浅色下太淡 |
 | [BUG-1000](bugs/BUG-1000-floating-lyric-tap-dropped-stale-reader-handler.md) | ✅ | ✅ | 桌面悬浮字幕点词后台听书时静默丢弃(reader卸载后channel残留!mounted handler) |

--- a/docs/bugs/BUG-1003-interconnect-mining-audio-host-clip.md
+++ b/docs/bugs/BUG-1003-interconnect-mining-audio-host-clip.md
@@ -1,0 +1,21 @@
+## BUG-1003 · 互联视频制卡句子音频改 host 端裁绕开 client ffmpeg 抓远端流
+- **报告**：2026-07-22（用户：真机——互联远端 Hibiki 库流视频制卡失败，OSD `sentence audio export failed: ffmpeg exit 1; executable=ffmpeg-kit; ... stderr=https://<host>:38765/api/library/videos/<id>/stream?token=...: I/O error`；「这个是 https 的」。伴随「缺少单词音频」「句子音频也少」→ 见 [[BUG-1004]]）
+- **真实性**：✅ 真 bug。是 [[BUG-891]]「远端流媒体制卡 ffmpeg-kit 无 https/自签」修复后的**残余缺口**：BUG-891 已把自编 ffmpeg-kit 重编为 `--enable-openssl` + `tls_pin_sha256` 补丁（worktree AAR 实测含 `--enable-openssl` 且 `libavformat.so` 有 5 处 `tls_pin_sha256` 符号），并在 `desktop_audio_clipper.dart` 注入 `-tls_pin_sha256 <fp>`。但 client ffmpeg 直接抓 host 的自签 https / token 流仍会 I/O error（根因层，均 file:line 核实）：
+  - **分叉点** `hibiki/lib/src/pages/implementations/video_hibiki_page.dart:2442`（`setMiningSourceOverride(videoPath==null ? mediaUri : null)`）：互联视频 `videoPath==null` → `controller.miningSource = mediaUri = host 的 http(s)://.../stream?token=` URL。
+  - **触发层** `hibiki/lib/src/mining/immersion_mining_engine.dart`：LAN host muxed 流 `audioSource==null` → `audioSrc = mediaSource`（远端 URL），直喂 `extractAudioSegmentViaFfmpeg` → `desktop_audio_clipper.dart` 的 `-i <url>`。
+  - **残余缺口**：`-tls_pin_sha256` 依赖 `_effectiveRemoteClient.activeFingerprintSha256`（`lookup_mining.part.dart`）非空且与实际证书一致；指纹缺失/URL 编码/token 短时/网络脆弱任一都让 ffmpeg 打开输入阶段 I/O error。且**桌面自签**（ffmpeg-min 上游默认 `tls_verify=0`、无 pin）与移动端行为不一致。一旦句子音频抽取返 null → `immersion_mining_engine.dart` 的 `requireAudio` 守卫 abort 整卡 → 文本/音频/截图/单词音频全缺，表现为「制卡整体失败」。
+- **[x] ① 已修复** — **host 端裁音频段**：让 host 用**本地文件**裁好句子音频再经已鉴权/钉扎的下载通道回传，client 全程不用 ffmpeg 抓远端流，从根上绕开整类失败（http/https 自签/token/全平台通吃，且只传几十 KB 成品、不做远端 seek）。加法式接入，老 host 404 → 回退现有 ffmpeg-over-URL 抽取（含 BUG-891 的 tls pin），Never break userspace：
+  - host 端点 `GET /api/library/videos/<id>/clipaudio?startMs=&endMs=&episode=&audioStreamIndex=&audioStreamCount=&ac=&bitrate=`（Basic 鉴权，不在 `/stream` 豁免名单）：`hibiki/lib/src/sync/hibiki_sync_server.dart` `_handleLibraryVideos`。
+  - host 服务：`HibikiLibraryHostService.clipVideoAudio(...)`（抽象 `hibiki_library_host_service.dart`；实现 `app_model_library_host_service.dart` = `resolveVideoFile` + `extractAudioSegmentViaFfmpeg` 裁本地文件到独立临时目录）。
+  - client：`HibikiClientSyncBackend.getRemoteVideoAudioClip(...)`（`hibiki_client_sync_backend.dart`，镜像 `getRemoteVideoSubtitle` 的 `downloadContentFile` 范式）。
+  - 请求/引擎：`ImmersionMiningRequest.remoteAudioClipper`（新字段）；`ImmersionMiningEngine.mine` 音频分支先试 host 端裁（命中即用、不再跑 ffmpeg），返 null 回退现有抽取。
+  - 接线：`lookup_mining.part.dart` `_mineVideoCard` 当 `_effectiveRemoteClient is HibikiClientSyncBackend` 时注入调 `getRemoteVideoAudioClip` 的裁切器（带 `_effectiveRemoteInfo!.id` / `_currentEpisode` / 当前音轨 / 压缩档）。
+  - 已知边界：host 产出 adts `aac`（桌面 ffmpeg-min 与移动 ffmpeg-kit 都能产、AnkiDroid/桌面直收），iOS client 从远端 host 制卡拿 `.aac` 在 AnkiMobile 可能不自动下载（窄场景，后续可让 host 按 client 请求产 m4a）。GIF/截图封面仍走现状（互联下截图兜底 `controller.screenshot` 本就可用）。
+  - 提交：<待填>。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/mining/immersion_mining_engine_test.dart`：`remoteAudioClipper` 命中远端流 → 用 host 端裁产物且**不调** ffmpeg 音频抽取；返回 null → 回退 ffmpeg-over-URL 抽取。
+  - `hibiki/test/sync/hibiki_sync_server_video_test.dart`：`clipaudio` 返回音频字节（`audio/aac`、Basic 鉴权、透传 startMs/endMs/audioStreamIndex）/ 非法区间 400 / 未知视频 404 / 未鉴权 401。
+  - `flutter analyze` 全量 0 issue（含为 10 个 `implements HibikiLibraryHostService` 的既有测试 fake 补 `clipVideoAudio` stub）；上述 + `immersion_mining_audio_materialize_test` / `hibiki_client_live_video_test` 全绿。
+- **备注**：
+  - 真机（Android 互联远端流真机制卡出句子音频 + 老 host 回退）验证待办。
+  - 关联 [[BUG-891]]（ffmpeg-kit TLS pin，本 bug 的前置/互补）、[[BUG-1004]]（同轮报告的单词音频缺失，独立根因）。

--- a/docs/bugs/BUG-1004-mining-word-audio-remote-source.md
+++ b/docs/bugs/BUG-1004-mining-word-audio-remote-source.md
@@ -1,0 +1,16 @@
+## BUG-1004 · 制卡缺单词音频·扩展needsAudio门+制卡器忽略远程发音源
+- **报告**：2026-07-22（用户：互联视频制卡「缺少单词音频」，与 [[BUG-1003]] 同轮报告）
+- **真实性**：✅ 真 bug，两条独立根因（均 file:line 核实）：
+  - **场景 A（浏览器扩展 / 沉浸制卡）**：`hibiki/assets/browser_extension/content.js`（及镜像 `tools/browser-extension/content.js`）注入查词结果时只写 `window.audioSources`，**从不写 `window.needsAudio`**；而 `hibiki/assets/popup/popup.js:1282` 的「制卡时重新解析单词音频」分支门是 `window.audioSources?.length && window.needsAudio` → `needsAudio===undefined` → 恒 false → 制卡 payload `audio` 字段恒空（只吃缓存，缓存 token 5 分钟过期后还 404）。对照：App 内 popup 由 `hibiki/lib/src/pages/implementations/popup_settings_injection.dart` 同时注入 `window.audioSources` + `window.needsAudio = true`。
+  - **场景 B（App 内制卡自动填充）**：`hibiki/lib/src/creator/enhancements/local_audio_enhancement.dart` `_generateAudio` 只查本地 Yomitan 音频库（`TtsChannel.queryLocalAudio`）+ TTS，**完全忽略用户配置的远程发音源**（forvo/jpod101/hibikiRemote）。而**播放**路径 `lookup_audio_playback.dart` `resolveLookupAudioUrl` → `WordAudioResolver.resolveConfigured` 走全源。二者分叉——只配了远程发音源（多数日语学习者）、没建本地库、TTS 不可用时制卡恒无单词音频。是 [[BUG-631]]（只修了播放侧的 local-only 退化）在**制卡器侧的孪生 bug**。
+- **[x] ① 已修复** —
+  - **场景 A**：两份 `content.js` 镜像在每处 `window.audioSources = ...` 之后补 `window.needsAudio = true;`（字节级插入，保留文件内 3 个 NUL 字节），与 App 内 popup 注入对齐。
+  - **场景 B**：`local_audio_enhancement.dart` `_generateAudio` 在本地库(step 1)落空后、TTS(step 3)前，插入 step 2 走全源 `resolveLookupAudioUrl(appModel, term, reading)`（尊重用户源顺序/开关，与播放路径统一真相），解析出 ref（远端 URL / 本地路径）后由新增 `materializeWordAudioRef` 物化成本地文件供 Anki 落媒体；失败落 TTS 兜底。本地库优先的现状不变（Never break userspace），仅补远程发音源这一缺口。
+  - 提交：<待填>。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/creator/word_audio_materialize_test.dart`：`materializeWordAudioRef`（远端 200 下载写盘按后缀命名 / 404 不落半成品 / 空体 null / 本地路径命中 / `file://` / 空 ref）+ `wordAudioExtFor`（URL 后缀 > Content-Type > 回退 mp3），注入 `MockClient`。
+  - `hibiki/test/pages/extension_content_needs_audio_guard_test.dart`：两份 `content.js` 镜像每处 audioSources 注入都伴随 `window.needsAudio = true`（源码扫描守卫，防镜像回退）。
+  - `flutter analyze` 0 issue；上述测试全绿。
+- **备注**：
+  - 真机（只配远程发音源时 App 内制卡 + 扩展制卡都出单词音频）验证待办。
+  - 关联 [[BUG-631]]（播放侧同类修复，本 bug 复用其 `resolveConfigured` 全源真相）、[[BUG-1003]]（同轮报告的句子音频/制卡失败，独立根因）。

--- a/hibiki/assets/browser_extension/content.js
+++ b/hibiki/assets/browser_extension/content.js
@@ -1298,6 +1298,7 @@ function hibikiSendLookup(term, anchorRect, cueWindow) {
       // 单词音频：查词响应带回 app 已启用的音频源（enabledAudioSources），非空时 popup.js
       // 的 createEntryHeader 才渲染 ♪ 按钮（与 app 内 window.audioSources 注入一致）。
       window.audioSources = Array.isArray(resp.data.audioSources) ? resp.data.audioSources : [];
+      window.needsAudio = true;
       hibikiRender(resp.data.popupJson, termLen, resp.data.theme, anchorRect);
     });
   } catch (_) {
@@ -1346,6 +1347,7 @@ window.__hibikiOnLinkClick = function (query) {
         ? resp.data.result.bestLength : 0;
       const termLen = best > 0 ? best : term.length;
       window.audioSources = Array.isArray(resp.data.audioSources) ? resp.data.audioSources : [];
+      window.needsAudio = true;
       hibikiRender(resp.data.popupJson, termLen, resp.data.theme);
     });
   } catch (_) { /* 扩展上下文失效：静默 */ }

--- a/hibiki/lib/src/creator/enhancements/local_audio_enhancement.dart
+++ b/hibiki/lib/src/creator/enhancements/local_audio_enhancement.dart
@@ -3,10 +3,83 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import 'package:hibiki/creator.dart';
 import 'package:hibiki/models.dart';
+import 'package:hibiki/src/utils/misc/lookup_audio_playback.dart'
+    show resolveLookupAudioUrl;
 import 'package:hibiki/utils.dart';
+
+/// BUG-1004：把 [resolveLookupAudioUrl] 解析出的单词音频 ref 物化成本地 [File] 供 Anki 落
+/// 媒体。ref 可能是远端 `http(s)://` URL（forvo/jpod101/hibikiRemote 等远程发音源）或本地
+/// 文件路径（本地音频库命中）：前者下载到 [dir] 临时文件（扩展名按 URL/Content-Type 推断，
+/// 默认 mp3——单词音频主流格式），后者存在即直接包 [File]。失败 / 非 2xx / 空体返回 null。
+/// [client] 仅供测试注入（默认自建、用完关闭）。纯逻辑无全局依赖，可单测。
+@visibleForTesting
+Future<File?> materializeWordAudioRef(
+  String ref, {
+  required Directory dir,
+  http.Client? client,
+}) async {
+  if (ref.isEmpty) return null;
+  if (!ref.startsWith('http')) {
+    final String path =
+        ref.startsWith('file://') ? Uri.parse(ref).toFilePath() : ref;
+    final File f = File(path);
+    return f.existsSync() ? f : null;
+  }
+  final http.Client c = client ?? http.Client();
+  try {
+    final Uri uri = Uri.parse(ref);
+    final http.Response res = await c.get(uri);
+    if (res.statusCode < 200 || res.statusCode >= 300) return null;
+    if (res.bodyBytes.isEmpty) return null;
+    final String ext = wordAudioExtFor(uri, res.headers['content-type']);
+    await dir.create(recursive: true);
+    final File out = File('${dir.path}/word_audio_remote.$ext');
+    await out.writeAsBytes(res.bodyBytes, flush: true);
+    return out;
+  } catch (_) {
+    return null;
+  } finally {
+    if (client == null) c.close();
+  }
+}
+
+/// 单词音频物化文件的扩展名：优先按 [uri] 路径末段的已知音频后缀，其次按 [contentType]，
+/// 都不认时回退 `mp3`（单词音频主流格式）。纯函数，便于单测。
+@visibleForTesting
+String wordAudioExtFor(Uri uri, String? contentType) {
+  const Set<String> known = <String>{
+    'mp3',
+    'opus',
+    'ogg',
+    'oga',
+    'm4a',
+    'aac',
+    'wav',
+    'flac',
+    'webm',
+  };
+  final String last = uri.pathSegments.isEmpty ? '' : uri.pathSegments.last;
+  final int dot = last.lastIndexOf('.');
+  if (dot >= 0 && dot < last.length - 1) {
+    final String ext = last.substring(dot + 1).toLowerCase();
+    if (known.contains(ext)) return ext;
+  }
+  final String ct = (contentType ?? '').toLowerCase();
+  if (ct.contains('mpeg') || ct.contains('mp3')) return 'mp3';
+  if (ct.contains('opus')) return 'opus';
+  if (ct.contains('ogg')) return 'ogg';
+  if (ct.contains('mp4') || ct.contains('m4a') || ct.contains('aac')) {
+    return 'm4a';
+  }
+  if (ct.contains('wav')) return 'wav';
+  if (ct.contains('flac')) return 'flac';
+  if (ct.contains('webm')) return 'webm';
+  return 'mp3';
+}
 
 /// Fetches term audio from local Yomitan audio DB, online sources, or TTS.
 class LocalAudioEnhancement extends AudioEnhancement {
@@ -79,7 +152,25 @@ class LocalAudioEnhancement extends AudioEnhancement {
       // Fall through
     }
 
-    // 2. TTS to file
+    // 2. BUG-1004：配置的音频源（含**远程发音源** forvo/jpod101/hibikiRemote）——与查词
+    //    **播放**路径统一走 resolveLookupAudioUrl（尊重用户源顺序/开关，单一真相）。这是
+    //    BUG-631「播放侧已修、制卡器侧仍 local-only」的孪生修复：制卡自动填充此前只查本地
+    //    库(step 1)+TTS(step 3)、**完全忽略远程发音源**，只配了远程源的用户（多数日语学习者）
+    //    制卡恒无单词音频。解析出 ref（远端 URL 或本地路径）后物化成本地文件供 Anki 落媒体；
+    //    失败落到 TTS 兜底。
+    try {
+      final String? ref = await resolveLookupAudioUrl(appModel, term, reading);
+      if (ref != null && ref.isNotEmpty) {
+        final Directory remoteDir = await getApplicationSupportDirectory();
+        final File? materialized =
+            await materializeWordAudioRef(ref, dir: remoteDir);
+        if (materialized != null) return materialized;
+      }
+    } catch (_) {
+      // best-effort：解析/下载失败不阻断，落到 TTS 兜底。
+    }
+
+    // 3. TTS to file
     final dir = await getApplicationSupportDirectory();
     final outPath = '${dir.path}/tts_term_audio.wav';
     final word = reading.isNotEmpty ? reading : term;

--- a/hibiki/lib/src/mining/immersion_mining_engine.dart
+++ b/hibiki/lib/src/mining/immersion_mining_engine.dart
@@ -184,42 +184,60 @@ class ImmersionMiningEngine {
               'immersion_audio.${immersionMiningAudioExtension()}',
           req.providedAudioBytes!);
     } else if (audioSrc != null && req.hasRange) {
-      // TODO-1314（B5）：audio-only DASH 分离流（req.audioSource 非空且为远端 http = YouTube
-      // 分离音频轨）的 ffmpeg HTTP `-ss` seek 会被 googlevideo 限速 stall→120s 超时→无句子音频
-      // （TODO-1301 曾用 muxed 绕行）。改为先用 yt-dlp 式 range 分片下载把整段音频物化到本地
-      // 临时文件、再对**本地文件**裁——本地 seek 即时、无网络 stall，根治 audio-only 不可 seek，
-      // 去掉对 muxed 的硬依赖。muxed 路径（audioSource==null → audioSrc==mediaSource，HTTP seek
-      // 只下小段、效率更高）不走物化、保持不变。物化失败回退直接对 URL 裁（best-effort，不劣于旧）。
-      String cutInput = audioSrc;
-      String? materialized;
-      if (req.audioSource != null && _isRemoteHttp(req.audioSource!)) {
-        materialized = await _materialize(
-          audioUrl: req.audioSource!,
-          outputPath: '$tempDir/immersion_audio_src',
-          onFailure: onFailure,
+      // BUG-1003：互联 host（LAN Hibiki 库）远端流优先走 **host 端裁**——host 用本地文件裁好
+      // 句子音频再经已鉴权/钉扎的下载通道回传，client 全程不用 ffmpeg 抓远端流，从根上绕开
+      // 「client ffmpeg 打不开 host 自签 https / token 流」的整类失败（见 BUG-891 残余缺口：
+      // 移动端自编 ffmpeg-kit 的 TLS pin 仍会因指纹缺失/URL 编码/网络脆弱而 I/O error）。命中
+      // 远端 http(s) 源且注入了裁切器时先试；成功即用，返回 null（老 host 无 clipaudio 端点/
+      // 网络失败）则落到下方现有 ffmpeg-over-URL 抽取（Never break userspace）。
+      if (req.remoteAudioClipper != null && _isRemoteHttp(audioSrc)) {
+        audioPath = await req.remoteAudioClipper!(
+          startMs: req.clipStartMs,
+          endMs: req.clipEndMs,
+          // host 裁出的是 adts aac；命名 .aac 与内容一致（AnkiDroid/桌面直收）。
+          outputPath: '$tempDir/immersion_audio_host.aac',
         );
-        if (materialized != null) cutInput = materialized;
       }
-      audioPath = await _audio(
-        inputPath: cutInput,
-        startMs: req.clipStartMs,
-        endMs: req.clipEndMs,
-        outputPath:
-            '$tempDir/immersion_audio.${immersionMiningAudioExtension()}',
-        audioStreamIndex: req.audioStreamIndex,
-        audioStreamCount: req.audioStreamCount,
-        audioChannels: compression.audioChannels,
-        audioBitrate: compression.audioBitrate,
-        onFailure: onFailure,
-        // BUG-891：cutInput 若是物化后的本地文件（YouTube）pin 被 buildFfmpegRemoteInputArgs
-        // 的远端判定忽略；Hibiki muxed 时 cutInput 是远端 https host，pin 生效。
-        tlsPinSha256: req.mediaSourceTlsPinSha256,
-      );
-      // 物化的整段音频临时文件用完即删（裁好的 immersion_audio.* 才是产物）。
-      if (materialized != null) {
-        try {
-          File(materialized).deleteSync();
-        } catch (_) {}
+      // host 端裁未命中（非互联 host / 老 host 无 clipaudio 端点 / 裁切失败）时回退现有
+      // ffmpeg-over-URL 抽取（YouTube 物化 + 直连 ffmpeg 抽取，含 BUG-891 的 tls pin）。
+      if (audioPath == null) {
+        // TODO-1314（B5）：audio-only DASH 分离流（req.audioSource 非空且为远端 http = YouTube
+        // 分离音频轨）的 ffmpeg HTTP `-ss` seek 会被 googlevideo 限速 stall→120s 超时→无句子音频
+        // （TODO-1301 曾用 muxed 绕行）。改为先用 yt-dlp 式 range 分片下载把整段音频物化到本地
+        // 临时文件、再对**本地文件**裁——本地 seek 即时、无网络 stall，根治 audio-only 不可 seek，
+        // 去掉对 muxed 的硬依赖。muxed 路径（audioSource==null → audioSrc==mediaSource，HTTP seek
+        // 只下小段、效率更高）不走物化、保持不变。物化失败回退直接对 URL 裁（best-effort，不劣于旧）。
+        String cutInput = audioSrc;
+        String? materialized;
+        if (req.audioSource != null && _isRemoteHttp(req.audioSource!)) {
+          materialized = await _materialize(
+            audioUrl: req.audioSource!,
+            outputPath: '$tempDir/immersion_audio_src',
+            onFailure: onFailure,
+          );
+          if (materialized != null) cutInput = materialized;
+        }
+        audioPath = await _audio(
+          inputPath: cutInput,
+          startMs: req.clipStartMs,
+          endMs: req.clipEndMs,
+          outputPath:
+              '$tempDir/immersion_audio.${immersionMiningAudioExtension()}',
+          audioStreamIndex: req.audioStreamIndex,
+          audioStreamCount: req.audioStreamCount,
+          audioChannels: compression.audioChannels,
+          audioBitrate: compression.audioBitrate,
+          onFailure: onFailure,
+          // BUG-891：cutInput 若是物化后的本地文件（YouTube）pin 被 buildFfmpegRemoteInputArgs
+          // 的远端判定忽略；Hibiki muxed 时 cutInput 是远端 https host，pin 生效。
+          tlsPinSha256: req.mediaSourceTlsPinSha256,
+        );
+        // 物化的整段音频临时文件用完即删（裁好的 immersion_audio.* 才是产物）。
+        if (materialized != null) {
+          try {
+            File(materialized).deleteSync();
+          } catch (_) {}
+        }
       }
     }
 

--- a/hibiki/lib/src/mining/immersion_mining_request.dart
+++ b/hibiki/lib/src/mining/immersion_mining_request.dart
@@ -83,6 +83,7 @@ class ImmersionMiningRequest {
     this.requireAudio = true,
     this.imageMode = VideoMiningImageMode.gif,
     this.mediaSourceTlsPinSha256,
+    this.remoteAudioClipper,
   });
 
   final Map<String, String> fields;
@@ -130,6 +131,18 @@ class ImmersionMiningRequest {
   /// `-tls_pin_sha256`，使自编 ffmpeg-kit（`--enable-gnutls` + pin 补丁）按指纹接受自签，
   /// 而非无条件放行。null = 本地源 / 公网有效证书源（YouTube 等），不钉扎、走 ffmpeg 默认。
   final String? mediaSourceTlsPinSha256;
+
+  /// BUG-1003：互联 host（LAN Hibiki 库）远端流的句子音频改由 **host 端**裁好再下载——host
+  /// 用本地文件裁、不经网络/TLS，从根上绕开「client ffmpeg 抓 host 自签 https / token 流」的
+  /// 整类失败（移动端自编 ffmpeg-kit 的 TLS pin 仍有残余缺口、URL 编码/网络脆弱等，见
+  /// BUG-891）。非空且 [audioSource]/[mediaSource] 命中远端 http(s) 时优先调用：返回裁好的
+  /// 本地音频文件路径即成功，返回 null 则回退现有 ffmpeg-over-URL 抽取（老 host 无 `clipaudio`
+  /// 端点时的兼容路径，Never break userspace）。本地/YouTube/直链源不注入（为 null）。
+  final Future<String?> Function({
+    required int startMs,
+    required int endMs,
+    required String outputPath,
+  })? remoteAudioClipper;
 
   bool get hasRange => clipEndMs > clipStartMs;
 }

--- a/hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart
@@ -291,6 +291,57 @@ extension _VideoLookupMining on _VideoHibikiPageState {
     final String? mediaSourceTlsPin = remoteClient is HibikiClientSyncBackend
         ? remoteClient.activeFingerprintSha256
         : null;
+    // BUG-1003：互联 host（LAN Hibiki 库）远端流——注入「host 端裁音频段」裁切器：host 用
+    // 本地文件裁好句子音频再经已鉴权/钉扎的下载通道回传，client 全程不用 ffmpeg 抓远端流，
+    // 从根上绕开 client ffmpeg 打不开 host 自签 https/token 流的整类失败（BUG-891 pin 路径
+    // 的残余缺口：移动端指纹缺失/URL 编码/网络脆弱仍 I/O error）。老 host 无 clipaudio 端点
+    // → 404 → 裁切器返 null → 引擎回退现有 ffmpeg-over-URL 抽取。非 Hibiki host（本地/
+    // YouTube/直链）不注入。
+    final RemoteVideoInfo? remoteInfo = _effectiveRemoteInfo;
+    Future<String?> Function({
+      required int startMs,
+      required int endMs,
+      required String outputPath,
+    })? remoteAudioClipper;
+    if (remoteClient is HibikiClientSyncBackend && remoteInfo != null) {
+      final HibikiClientSyncBackend backend = remoteClient;
+      final String remoteId = remoteInfo.id;
+      final int episode = _currentEpisode;
+      final int? audioIdx = controller.currentAudioStreamIndex;
+      final int audioCount = controller.realAudioStreamCount;
+      final int ac = mediaCompression.audioChannels;
+      final String bitrate = mediaCompression.audioBitrate;
+      remoteAudioClipper = ({
+        required int startMs,
+        required int endMs,
+        required String outputPath,
+      }) async {
+        final File dest = File(outputPath);
+        try {
+          await backend.getRemoteVideoAudioClip(
+            remoteId,
+            dest,
+            startMs: startMs,
+            endMs: endMs,
+            episodeIndex: episode,
+            audioStreamIndex: audioIdx,
+            audioStreamCount: audioCount,
+            audioChannels: ac,
+            audioBitrate: bitrate,
+          );
+          if (dest.existsSync() && dest.lengthSync() > 0) return dest.path;
+        } catch (e, st) {
+          // 老 host 无端点(404)/网络失败：记录并回 null，让引擎回退直连 ffmpeg 抽取。
+          ErrorLogService.instance.log('mineVideoCard.remoteAudioClip', e, st);
+        }
+        if (dest.existsSync()) {
+          try {
+            dest.deleteSync();
+          } catch (_) {}
+        }
+        return null;
+      };
+    }
     // TODO-1000：委托统一沉浸制卡引擎。媒体降级阶梯 / 无音频中止 / 组 context / 落卡都在
     // 引擎内；本壳只管 OSD + 视频统计。onFailure 捕获 GIF(首)/音频(末)失败摘要供 OSD。
     String? gifFailure;
@@ -301,6 +352,8 @@ extension _VideoLookupMining on _VideoHibikiPageState {
         mediaSource: controller.miningSource,
         audioSource: controller.miningAudioSource,
         mediaSourceTlsPinSha256: mediaSourceTlsPin,
+        // BUG-1003：互联 host 远端流句子音频优先走 host 端裁（绕开 client ffmpeg 抓远端流）。
+        remoteAudioClipper: remoteAudioClipper,
         clipStartMs: clipStartMs,
         clipEndMs: clipEndMs,
         sentence: sentence,

--- a/hibiki/lib/src/sync/app_model_library_host_service.dart
+++ b/hibiki/lib/src/sync/app_model_library_host_service.dart
@@ -20,6 +20,8 @@ import 'package:hibiki/src/sync/sync_asset_package_service.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/src/sync/sync_manager.dart'
     show repackageExtractedEpub, resolveExtractedEpubRoot;
+import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart'
+    show extractAudioSegmentViaFfmpeg;
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:hibiki_audio/hibiki_audio.dart' show AudiobookStorage;
 import 'package:path/path.dart' as p;
@@ -1129,6 +1131,46 @@ class AppModelLibraryHostService implements HibikiLibraryHostService {
     if (subPath == null) return null;
     final File f = File(subPath);
     return f.existsSync() ? f : null;
+  }
+
+  /// BUG-1003：host 端本地裁 mining 句子音频（见抽象声明）。用 [resolveVideoFile] 反查真实
+  /// 本地文件后调 [extractAudioSegmentViaFfmpeg]（本地路径、不经网络/TLS——绕开 client
+  /// ffmpeg 抓 host 自签 https/token 流的整类失败）。裁到独立临时目录，产物返回给调用方，
+  /// 调用方读完删该目录；失败清理临时目录并返回 null。
+  @override
+  Future<File?> clipVideoAudio(
+    String id, {
+    required int startMs,
+    required int endMs,
+    int episodeIndex = 0,
+    int? audioStreamIndex,
+    int? audioStreamCount,
+    int audioChannels = 1,
+    String audioBitrate = '64k',
+  }) async {
+    if (endMs <= startMs) return null;
+    final File? file = await resolveVideoFile(id, episodeIndex: episodeIndex);
+    if (file == null) return null;
+    final Directory tmp =
+        Directory.systemTemp.createTempSync('hibiki_clip_audio');
+    final String out = p.join(tmp.path, 'clip.aac');
+    final String? result = await extractAudioSegmentViaFfmpeg(
+      inputPath: file.path,
+      startMs: startMs,
+      endMs: endMs,
+      outputPath: out,
+      audioStreamIndex: audioStreamIndex,
+      audioStreamCount: audioStreamCount,
+      audioChannels: audioChannels,
+      audioBitrate: audioBitrate,
+    );
+    if (result == null) {
+      try {
+        tmp.deleteSync(recursive: true);
+      } catch (_) {}
+      return null;
+    }
+    return File(result);
   }
 
   /// 读 host 端 [id] 视频的播放断点（TODO-653 / TODO-816 断点②）。

--- a/hibiki/lib/src/sync/hibiki_client_sync_backend.dart
+++ b/hibiki/lib/src/sync/hibiki_client_sync_backend.dart
@@ -1245,6 +1245,46 @@ class HibikiClientSyncBackend extends SyncBackend
     );
   }
 
+  /// BUG-1003：请求 host 在其**本地**裁出视频 [id] 的 `[startMs,endMs)` 段音频（mining 句子
+  /// 音频），经已鉴权/钉扎的 [downloadContentFile] 通道落到 [dest]。host 用本地文件裁、不经
+  /// 网络/TLS，从根上绕开「移动端 client ffmpeg 打不开 host 自签 https / token 流」的整类失败
+  /// （BUG-891 残余缺口）。[audioChannels]/[audioBitrate] 对齐制卡压缩档，使 host 裁出的片段与
+  /// 本地路径同规格；[audioStreamIndex]/[audioStreamCount] 选多音轨视频里用户当前听的轨。
+  ///
+  /// 老 host 无 `clipaudio` 端点 → 该子路径 GET 落 host 兜底 → 404 → [downloadContentFile]
+  /// 抛可重试 `SyncBackendError`；调用方 catch 后回退直连 ffmpeg 抽取（Never break userspace）。
+  Future<void> getRemoteVideoAudioClip(
+    String id,
+    File dest, {
+    required int startMs,
+    required int endMs,
+    int episodeIndex = 0,
+    int? audioStreamIndex,
+    int? audioStreamCount,
+    int audioChannels = 1,
+    String audioBitrate = '64k',
+    void Function(double progress)? onProgress,
+  }) async {
+    await _ensureResolved();
+    final Map<String, String> query = <String, String>{
+      'startMs': '$startMs',
+      'endMs': '$endMs',
+      if (episodeIndex > 0) 'episode': '$episodeIndex',
+      if (audioStreamIndex != null) 'audioStreamIndex': '$audioStreamIndex',
+      if (audioStreamCount != null) 'audioStreamCount': '$audioStreamCount',
+      'ac': '$audioChannels',
+      'bitrate': audioBitrate,
+    };
+    final Uri uri = Uri.parse(
+      '$_apiBase/api/library/videos/${_encodeVideoId(id)}/clipaudio',
+    ).replace(queryParameters: query);
+    await downloadContentFile(
+      fileId: uri.toString(),
+      destination: dest,
+      onProgress: onProgress,
+    );
+  }
+
   /// 整段下载对端视频到 [dest]（用于 UI 的「下载到本机」）。
   ///
   /// 下载走 host 签发的 token stream URL，避免依赖播放器/header 兼容性；失败时

--- a/hibiki/lib/src/sync/hibiki_library_host_service.dart
+++ b/hibiki/lib/src/sync/hibiki_library_host_service.dart
@@ -1300,6 +1300,23 @@ abstract class HibikiLibraryHostService {
     int episodeIndex = 0,
   });
 
+  /// BUG-1003：在 host **本地**对视频 [id] 的 `[startMs,endMs)` 段裁出 mining 句子音频，
+  /// 返回临时 aac(adts) 文件（调用方读完负责删其所在临时目录）；无该视频 / 区间非法 /
+  /// ffmpeg 失败时返回 null。host 用本地文件裁、不经网络/TLS，是「client ffmpeg 打不开 host
+  /// 自签 https / token 流」（BUG-891 残余缺口）的根治路径——client 全程不用 ffmpeg 抓远端流。
+  /// [audioStreamIndex]/[audioStreamCount] 选多音轨视频里用户当前听的轨（越界回退默认轨）；
+  /// [audioChannels]/[audioBitrate] 对齐制卡压缩档，使 host 裁出的片段与本地路径同规格。
+  Future<File?> clipVideoAudio(
+    String id, {
+    required int startMs,
+    required int endMs,
+    int episodeIndex = 0,
+    int? audioStreamIndex,
+    int? audioStreamCount,
+    int audioChannels = 1,
+    String audioBitrate = '64k',
+  });
+
   /// 读 host 端记录的视频 [id] 播放断点（TODO-653）。返回 (位置毫秒, 更新时间毫秒)；
   /// 无记录时返回 (0, 0)。[episodeIndex]>0（TODO-885）按集隔离读断点。
   Future<({int positionMs, int updatedAtMs})> getVideoPosition(

--- a/hibiki/lib/src/sync/hibiki_sync_server.dart
+++ b/hibiki/lib/src/sync/hibiki_sync_server.dart
@@ -1857,6 +1857,60 @@ class HibikiSyncServer {
       }
     }
 
+    // GET /api/library/videos/<id>/clipaudio?startMs=&endMs=&episode=&audioStreamIndex=
+    //     &audioStreamCount=&ac=&bitrate= — BUG-1003：host 端本地裁 mining 句子音频段并回传。
+    // 需 Basic 鉴权（中间件已处理，clipaudio 不在 /stream 豁免名单）。client ffmpeg 打不开
+    // host 自签 https / token 流（移动端自编 ffmpeg-kit TLS pin 残余缺口）时改走此端点——host
+    // 用本地文件裁、不经网络/TLS，只回传几十 KB 的成品音频，不做远端 seek。老 host 无此分支
+    // 对该子路径的 GET 走下方兜底 → 404，client 据此回退直连 ffmpeg 抽取（Never break userspace）。
+    final String? clipAudioId = _extractVideoId(reqPath, 'clipaudio');
+    if (clipAudioId != null) {
+      if (method != 'GET') return shelf.Response(405);
+      final int episodeIndex = _episodeIndexFromRequest(request);
+      final int? startMs =
+          int.tryParse(request.url.queryParameters['startMs'] ?? '');
+      final int? endMs =
+          int.tryParse(request.url.queryParameters['endMs'] ?? '');
+      if (startMs == null || endMs == null || endMs <= startMs) {
+        return shelf.Response(400, body: 'Invalid clip range');
+      }
+      final int? audioStreamIndex =
+          int.tryParse(request.url.queryParameters['audioStreamIndex'] ?? '');
+      final int? audioStreamCount =
+          int.tryParse(request.url.queryParameters['audioStreamCount'] ?? '');
+      final int audioChannels =
+          int.tryParse(request.url.queryParameters['ac'] ?? '') ?? 1;
+      final String audioBitrate =
+          request.url.queryParameters['bitrate'] ?? '64k';
+      final File? clip = await svc.clipVideoAudio(
+        clipAudioId,
+        startMs: startMs,
+        endMs: endMs,
+        episodeIndex: episodeIndex,
+        audioStreamIndex: audioStreamIndex,
+        audioStreamCount: audioStreamCount,
+        audioChannels: audioChannels,
+        audioBitrate: audioBitrate,
+      );
+      if (clip == null) {
+        return shelf.Response.notFound('Clip unavailable');
+      }
+      try {
+        final Uint8List bytes = await clip.readAsBytes();
+        return shelf.Response.ok(
+          bytes,
+          headers: <String, String>{'Content-Type': 'audio/aac'},
+        );
+      } finally {
+        // 裁到独立临时目录，回传后连目录一并清（clipVideoAudio 建的 temp 目录）。
+        try {
+          clip.parent.deleteSync(recursive: true);
+        } catch (_) {
+          // best-effort
+        }
+      }
+    }
+
     // PUT /api/library/videos/<id> — client→host 上传本地视频文件并注册进 host 视频库
     // （syncVideoFiles 开关驱动的 live push）。走到此处的 PUT 必是「裸 id 无 suffix」：
     // 所有带 suffix 的端点（cover/streamurl/stream/subtitle/position）已在上方消化（非

--- a/hibiki/test/creator/word_audio_materialize_test.dart
+++ b/hibiki/test/creator/word_audio_materialize_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:hibiki/src/creator/enhancements/local_audio_enhancement.dart';
+
+/// BUG-1004：制卡器单词音频物化 helper 守卫。制卡自动填充在本地库落空后走全源
+/// [resolveLookupAudioUrl]（含远程发音源），再由 [materializeWordAudioRef] 把解析出的
+/// ref（远端 URL / 本地路径）落成本地文件供 Anki。这里覆盖 helper 的下载/回退/扩展名推断。
+void main() {
+  late Directory dir;
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('word_audio_mat');
+  });
+  tearDown(() async {
+    if (dir.existsSync()) await dir.delete(recursive: true);
+  });
+
+  group('wordAudioExtFor', () {
+    test('优先取 URL 路径已知音频后缀', () {
+      expect(wordAudioExtFor(Uri.parse('https://a/x.mp3'), null), 'mp3');
+      expect(wordAudioExtFor(Uri.parse('https://a/x.opus'), null), 'opus');
+      expect(wordAudioExtFor(Uri.parse('https://a/x.m4a?y=1'), null), 'm4a');
+    });
+    test('URL 无后缀时按 Content-Type', () {
+      expect(wordAudioExtFor(Uri.parse('https://a/get?term=x'), 'audio/ogg'),
+          'ogg');
+      expect(wordAudioExtFor(Uri.parse('https://a/get'), 'audio/mpeg'), 'mp3');
+    });
+    test('都不认时回退 mp3', () {
+      expect(wordAudioExtFor(Uri.parse('https://a/get'), null), 'mp3');
+      expect(
+          wordAudioExtFor(Uri.parse('https://a/x.txt'), 'text/plain'), 'mp3');
+    });
+  });
+
+  group('materializeWordAudioRef', () {
+    test('远端 http 200 → 下载写盘并按后缀命名', () async {
+      final http.Client client = MockClient((http.Request req) async {
+        expect(req.url.toString(), 'https://forvo.example/word.mp3');
+        return http.Response.bytes(<int>[1, 2, 3, 4], 200);
+      });
+      final File? f = await materializeWordAudioRef(
+          'https://forvo.example/word.mp3',
+          dir: dir,
+          client: client);
+      expect(f, isNotNull);
+      expect(f!.path, endsWith('.mp3'));
+      expect(await f.readAsBytes(), <int>[1, 2, 3, 4]);
+    });
+
+    test('远端非 2xx（404「本源没有此词」）→ null，不落半成品', () async {
+      final http.Client client =
+          MockClient((http.Request req) async => http.Response('no', 404));
+      final File? f = await materializeWordAudioRef(
+          'https://forvo.example/word.mp3',
+          dir: dir,
+          client: client);
+      expect(f, isNull);
+      expect(dir.listSync(), isEmpty);
+    });
+
+    test('远端空体 → null', () async {
+      final http.Client client = MockClient(
+          (http.Request req) async => http.Response.bytes(<int>[], 200));
+      final File? f = await materializeWordAudioRef('https://a/x.mp3',
+          dir: dir, client: client);
+      expect(f, isNull);
+    });
+
+    test('本地路径存在 → 直接包 File；不存在 → null', () async {
+      final File local = File('${dir.path}/local.mp3')
+        ..writeAsBytesSync(<int>[9, 9]);
+      final File? hit = await materializeWordAudioRef(local.path, dir: dir);
+      expect(hit?.path, local.path);
+      final File? miss =
+          await materializeWordAudioRef('${dir.path}/nope.mp3', dir: dir);
+      expect(miss, isNull);
+    });
+
+    test('file:// ref → 解析成本地路径', () async {
+      final File local = File('${dir.path}/f.mp3')..writeAsBytesSync(<int>[1]);
+      final String fileUri = Uri.file(local.path).toString();
+      final File? hit = await materializeWordAudioRef(fileUri, dir: dir);
+      expect(hit, isNotNull);
+      expect(hit!.readAsBytesSync(), <int>[1]);
+    });
+
+    test('空 ref → null', () async {
+      expect(await materializeWordAudioRef('', dir: dir), isNull);
+    });
+  });
+}

--- a/hibiki/test/mining/immersion_mining_engine_test.dart
+++ b/hibiki/test/mining/immersion_mining_engine_test.dart
@@ -133,6 +133,102 @@ void main() {
     expect(repo.minedContext!.source, AnkiMiningSource.video);
   });
 
+  test('BUG-1003 remoteAudioClipper 命中远端流 → 用 host 端裁产物、不调 ffmpeg 音频抽取',
+      () async {
+    final repo = _FakeRepo();
+    bool audioCalled = false;
+    bool clipperCalled = false;
+    Future<String?> trackingAudio(
+        {required String inputPath,
+        required int startMs,
+        required int endMs,
+        required String outputPath,
+        int? audioStreamIndex,
+        int? audioStreamCount,
+        FfmpegFailureReporter? onFailure,
+        int audioChannels = 1,
+        String audioBitrate = '64k',
+        String? tlsPinSha256}) async {
+      audioCalled = true;
+      return outputPath;
+    }
+
+    final res =
+        await build(gif: okGif, audio: trackingAudio, frame: okFrame).mine(
+            ImmersionMiningRequest(
+              fields: const {'expression': '走る'},
+              // 互联 host 自签 https 流：client ffmpeg 打不开，改走 host 端裁。
+              mediaSource:
+                  'https://host.example:38765/api/library/videos/v/stream?token=x',
+              clipStartMs: 1000,
+              clipEndMs: 3000,
+              sentence: '走り出した。',
+              remoteAudioClipper: ({
+                required int startMs,
+                required int endMs,
+                required String outputPath,
+              }) async {
+                clipperCalled = true;
+                expect(startMs, 1000);
+                expect(endMs, 3000);
+                return outputPath;
+              },
+            ),
+            compression: MiningMediaCompression.compressed,
+            tempDir: tmp.path,
+            repo: repo);
+    expect(res.aborted, false);
+    expect(clipperCalled, true, reason: 'host 端裁切器应被调用');
+    expect(audioCalled, false, reason: 'host 端裁命中后不得再对远端 URL 跑 ffmpeg 抽取');
+    expect(repo.minedContext!.sasayakiAudioPath,
+        endsWith('immersion_audio_host.aac'));
+  });
+
+  test('BUG-1003 remoteAudioClipper 返回 null → 回退 ffmpeg-over-URL 抽取', () async {
+    final repo = _FakeRepo();
+    bool audioCalled = false;
+    Future<String?> trackingAudio(
+        {required String inputPath,
+        required int startMs,
+        required int endMs,
+        required String outputPath,
+        int? audioStreamIndex,
+        int? audioStreamCount,
+        FfmpegFailureReporter? onFailure,
+        int audioChannels = 1,
+        String audioBitrate = '64k',
+        String? tlsPinSha256}) async {
+      audioCalled = true;
+      return outputPath;
+    }
+
+    final res =
+        await build(gif: okGif, audio: trackingAudio, frame: okFrame).mine(
+            ImmersionMiningRequest(
+              fields: const {'expression': '走る'},
+              mediaSource:
+                  'https://host.example:38765/api/library/videos/v/stream?token=x',
+              clipStartMs: 1000,
+              clipEndMs: 3000,
+              sentence: '走り出した。',
+              // 老 host 无 clipaudio 端点 / 网络失败：裁切器返 null。
+              remoteAudioClipper: ({
+                required int startMs,
+                required int endMs,
+                required String outputPath,
+              }) async =>
+                  null,
+            ),
+            compression: MiningMediaCompression.compressed,
+            tempDir: tmp.path,
+            repo: repo);
+    expect(res.aborted, false);
+    expect(audioCalled, true,
+        reason: 'host 端裁返 null 后必须回退直连 ffmpeg 抽取（Never break userspace）');
+    expect(repo.minedContext!.sasayakiAudioPath,
+        endsWith('immersion_audio.${immersionMiningAudioExtension()}'));
+  });
+
   test('provided audio bytes use the platform-aware immersion audio filename',
       () async {
     final repo = _FakeRepo();

--- a/hibiki/test/pages/extension_content_needs_audio_guard_test.dart
+++ b/hibiki/test/pages/extension_content_needs_audio_guard_test.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1004 场景A 守卫：浏览器扩展 `content.js` 注入词典查词结果时，必须在每处
+/// `window.audioSources = ...` 之后同时注入 `window.needsAudio = true;`——否则
+/// `popup.js` 的「制卡时重新解析单词音频」分支（门 `window.audioSources?.length &&
+/// window.needsAudio`）恒为 false，扩展/沉浸制卡的 payload `audio` 字段恒空（缺单词音频）。
+/// App 内 popup 由 `popup_settings_injection.dart` 两者都注入；此守卫防扩展镜像回退。
+///
+/// content.js 有两份**逐字节镜像**（app 内置分发 + 扩展源），都要守。文件含少量 NUL 字节，
+/// 按字节读、宽容解码。
+void main() {
+  const List<String> mirrors = <String>[
+    'assets/browser_extension/content.js',
+    '../tools/browser-extension/content.js',
+  ];
+
+  const String audioInject =
+      'window.audioSources = Array.isArray(resp.data.audioSources)';
+  const String needsInject = 'window.needsAudio = true;';
+
+  for (final String rel in mirrors) {
+    test('content.js 每处 audioSources 注入都伴随 needsAudio：$rel', () {
+      final File f = File(rel);
+      expect(f.existsSync(), true, reason: '找不到 content.js 镜像：$rel');
+      final String src = utf8.decode(f.readAsBytesSync(), allowMalformed: true);
+
+      final int audioCount = audioInject.allMatches(src).length;
+      final int needsCount = needsInject.allMatches(src).length;
+      expect(audioCount, greaterThan(0),
+          reason: 'content.js 应注入 window.audioSources');
+      expect(needsCount, greaterThanOrEqualTo(audioCount),
+          reason: '每处 audioSources 注入都必须伴随 window.needsAudio=true '
+              '（否则扩展制卡永远拿不到重新解析的单词音频，BUG-1004）');
+    });
+  }
+}

--- a/hibiki/test/sync/dictionary_delete_propagation_test.dart
+++ b/hibiki/test/sync/dictionary_delete_propagation_test.dart
@@ -49,6 +49,18 @@ class _RecordingBackend implements SyncBackend {
 // ── live 分支集成：验证 HibikiClientSyncBackend 路由到 host DELETE 端点 ─────
 
 class _FakeLibraryService implements HibikiLibraryHostService {
+  // BUG-1003：host 端裁 mining 句子音频（本测试不涉及，返 null 即可）。
+  @override
+  Future<File?> clipVideoAudio(String id,
+          {required int startMs,
+          required int endMs,
+          int episodeIndex = 0,
+          int? audioStreamIndex,
+          int? audioStreamCount,
+          int audioChannels = 1,
+          String audioBitrate = '64k'}) async =>
+      null;
+
   @override
   Future<List<RemoteActivityEvent>> listActivityEvents(
           {int limit = 100}) async =>

--- a/hibiki/test/sync/hibiki_client_live_audio_test.dart
+++ b/hibiki/test/sync/hibiki_client_live_audio_test.dart
@@ -15,6 +15,18 @@ import 'package:hibiki_core/hibiki_core.dart';
 // ── fake 库服务（local audio + audiobook 完整 round-trip）─────────────────
 
 class _FakeLibraryService implements HibikiLibraryHostService {
+  // BUG-1003：host 端裁 mining 句子音频（本测试不涉及，返 null 即可）。
+  @override
+  Future<File?> clipVideoAudio(String id,
+          {required int startMs,
+          required int endMs,
+          int episodeIndex = 0,
+          int? audioStreamIndex,
+          int? audioStreamCount,
+          int audioChannels = 1,
+          String audioBitrate = '64k'}) async =>
+      null;
+
   @override
   Future<List<RemoteActivityEvent>> listActivityEvents(
           {int limit = 100}) async =>

--- a/hibiki/test/sync/hibiki_client_live_book_test.dart
+++ b/hibiki/test/sync/hibiki_client_live_book_test.dart
@@ -15,6 +15,18 @@ import 'package:hibiki_core/hibiki_core.dart';
 // ── fake 库服务（books 完整 round-trip）────────────────────────────────────
 
 class _FakeLibraryService implements HibikiLibraryHostService {
+  // BUG-1003：host 端裁 mining 句子音频（本测试不涉及，返 null 即可）。
+  @override
+  Future<File?> clipVideoAudio(String id,
+          {required int startMs,
+          required int endMs,
+          int episodeIndex = 0,
+          int? audioStreamIndex,
+          int? audioStreamCount,
+          int audioChannels = 1,
+          String audioBitrate = '64k'}) async =>
+      null;
+
   @override
   Future<List<RemoteActivityEvent>> listActivityEvents(
           {int limit = 100}) async =>

--- a/hibiki/test/sync/hibiki_client_live_dict_test.dart
+++ b/hibiki/test/sync/hibiki_client_live_dict_test.dart
@@ -15,6 +15,18 @@ import 'package:hibiki_core/hibiki_core.dart';
 // ── fake 库服务（与 hibiki_sync_server_library_test 同款）─────────────────
 
 class _FakeLibraryService implements HibikiLibraryHostService {
+  // BUG-1003：host 端裁 mining 句子音频（本测试不涉及，返 null 即可）。
+  @override
+  Future<File?> clipVideoAudio(String id,
+          {required int startMs,
+          required int endMs,
+          int episodeIndex = 0,
+          int? audioStreamIndex,
+          int? audioStreamCount,
+          int audioChannels = 1,
+          String audioBitrate = '64k'}) async =>
+      null;
+
   @override
   Future<List<RemoteActivityEvent>> listActivityEvents(
           {int limit = 100}) async =>

--- a/hibiki/test/sync/hibiki_client_live_video_test.dart
+++ b/hibiki/test/sync/hibiki_client_live_video_test.dart
@@ -17,6 +17,18 @@ import 'package:hibiki_core/hibiki_core.dart';
 const List<int> _coverBytes = <int>[0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4];
 
 class _FakeLibraryService implements HibikiLibraryHostService {
+  // BUG-1003：host 端裁 mining 句子音频（本测试不涉及，返 null 即可）。
+  @override
+  Future<File?> clipVideoAudio(String id,
+          {required int startMs,
+          required int endMs,
+          int episodeIndex = 0,
+          int? audioStreamIndex,
+          int? audioStreamCount,
+          int audioChannels = 1,
+          String audioBitrate = '64k'}) async =>
+      null;
+
   @override
   Future<List<RemoteActivityEvent>> listActivityEvents(
           {int limit = 100}) async =>

--- a/hibiki/test/sync/hibiki_sync_server_audio_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_audio_test.dart
@@ -8,6 +8,18 @@ import 'package:hibiki/src/sync/hibiki_sync_server.dart';
 
 /// Fake 库服务：本地音频 + 有声书方法真实记录调用；dict/books 方法存根。
 class _FakeLibraryService implements HibikiLibraryHostService {
+  // BUG-1003：host 端裁 mining 句子音频（本测试不涉及，返 null 即可）。
+  @override
+  Future<File?> clipVideoAudio(String id,
+          {required int startMs,
+          required int endMs,
+          int episodeIndex = 0,
+          int? audioStreamIndex,
+          int? audioStreamCount,
+          int audioChannels = 1,
+          String audioBitrate = '64k'}) async =>
+      null;
+
   @override
   Future<List<RemoteActivityEvent>> listActivityEvents(
           {int limit = 100}) async =>

--- a/hibiki/test/sync/hibiki_sync_server_books_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_books_test.dart
@@ -10,6 +10,18 @@ const List<int> _coverBytes = <int>[0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4];
 
 /// Fake service：dict 方法存根（不抛，返回空），books 方法真实记录调用。
 class _FakeLibraryService implements HibikiLibraryHostService {
+  // BUG-1003：host 端裁 mining 句子音频（本测试不涉及，返 null 即可）。
+  @override
+  Future<File?> clipVideoAudio(String id,
+          {required int startMs,
+          required int endMs,
+          int episodeIndex = 0,
+          int? audioStreamIndex,
+          int? audioStreamCount,
+          int audioChannels = 1,
+          String audioBitrate = '64k'}) async =>
+      null;
+
   @override
   Future<List<RemoteActivityEvent>> listActivityEvents(
           {int limit = 100}) async =>

--- a/hibiki/test/sync/hibiki_sync_server_library_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_library_test.dart
@@ -7,6 +7,18 @@ import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/hibiki_sync_server.dart';
 
 class _FakeLibraryService implements HibikiLibraryHostService {
+  // BUG-1003：host 端裁 mining 句子音频（本测试不涉及，返 null 即可）。
+  @override
+  Future<File?> clipVideoAudio(String id,
+          {required int startMs,
+          required int endMs,
+          int episodeIndex = 0,
+          int? audioStreamIndex,
+          int? audioStreamCount,
+          int audioChannels = 1,
+          String audioBitrate = '64k'}) async =>
+      null;
+
   @override
   Future<List<RemoteActivityEvent>> listActivityEvents(
           {int limit = 100}) async =>

--- a/hibiki/test/sync/hibiki_sync_server_video_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_video_test.dart
@@ -149,6 +149,36 @@ class _FakeLibraryService implements HibikiLibraryHostService {
     return null;
   }
 
+  /// BUG-1003：host 端裁音频段 fake——已知视频 + 合法区间时返回一个**独立临时目录**里的
+  /// 音频文件（服务端回传后会 deleteSync 该文件父目录，故绝不能落在共享 tmp）。记录入参供断言。
+  static const List<int> clipBytes = <int>[0xAA, 0xBB, 0xCC, 0xDD];
+  int? lastClipStartMs;
+  int? lastClipEndMs;
+  int? lastClipEpisode;
+  int? lastClipAudioIndex;
+
+  @override
+  Future<File?> clipVideoAudio(
+    String id, {
+    required int startMs,
+    required int endMs,
+    int episodeIndex = 0,
+    int? audioStreamIndex,
+    int? audioStreamCount,
+    int audioChannels = 1,
+    String audioBitrate = '64k',
+  }) async {
+    lastClipStartMs = startMs;
+    lastClipEndMs = endMs;
+    lastClipEpisode = episodeIndex;
+    lastClipAudioIndex = audioStreamIndex;
+    if (endMs <= startMs) return null;
+    final File? f = await resolveVideoFile(id, episodeIndex: episodeIndex);
+    if (f == null) return null;
+    final Directory d = Directory.systemTemp.createTempSync('hbk_clip_fake');
+    return File('${d.path}/clip.aac')..writeAsBytesSync(clipBytes);
+  }
+
   // ── dict stubs ──────────────────────────────────────────────────────────────
   @override
   Future<List<RemoteDictionaryInfo>> listDictionaries() async =>
@@ -340,6 +370,62 @@ void main() {
     expect(first['id'], 'video/sample', reason: 'id 含斜杠应被正确序列化');
     expect(first['title'], 'Sample Video');
     expect(first['hasSubtitle'], true);
+    c.close();
+  });
+
+  // ── clipaudio（BUG-1003：host 端裁 mining 句子音频）──────────────────────────
+
+  test('GET clipaudio 返回裁好的音频字节（audio/aac，Basic 鉴权，透传入参）', () async {
+    final String encodedId = Uri.encodeFull(_FakeLibraryService.videoId);
+    final HttpClient c = HttpClient();
+    final HttpClientRequest req =
+        await c.getUrl(Uri.parse('$base/api/library/videos/$encodedId/clipaudio'
+            '?startMs=1000&endMs=3000&audioStreamIndex=2&ac=1&bitrate=64k'));
+    req.headers.set('authorization', authHeader());
+    final HttpClientResponse res = await req.close();
+    expect(res.statusCode, 200);
+    expect(res.headers.contentType?.mimeType, 'audio/aac');
+    final List<int> bytes =
+        await res.fold<List<int>>(<int>[], (List<int> a, List<int> b) {
+      a.addAll(b);
+      return a;
+    });
+    expect(bytes, _FakeLibraryService.clipBytes);
+    expect(lib.lastClipStartMs, 1000);
+    expect(lib.lastClipEndMs, 3000);
+    expect(lib.lastClipAudioIndex, 2);
+    c.close();
+  });
+
+  test('GET clipaudio 非法区间（endMs<=startMs / 缺参）→ 400', () async {
+    final String encodedId = Uri.encodeFull(_FakeLibraryService.videoId);
+    final HttpClient c = HttpClient();
+    final HttpClientRequest req = await c.getUrl(Uri.parse(
+        '$base/api/library/videos/$encodedId/clipaudio?startMs=3000&endMs=1000'));
+    req.headers.set('authorization', authHeader());
+    final HttpClientResponse res = await req.close();
+    expect(res.statusCode, 400);
+    c.close();
+  });
+
+  test('GET clipaudio 未知视频 → 404', () async {
+    final HttpClient c = HttpClient();
+    final HttpClientRequest req = await c.getUrl(Uri.parse(
+        '$base/api/library/videos/video/nope/clipaudio?startMs=0&endMs=1000'));
+    req.headers.set('authorization', authHeader());
+    final HttpClientResponse res = await req.close();
+    expect(res.statusCode, 404);
+    c.close();
+  });
+
+  test('GET clipaudio 未鉴权 → 401（不在 /stream 豁免名单）', () async {
+    final String encodedId = Uri.encodeFull(_FakeLibraryService.videoId);
+    final HttpClient c = HttpClient();
+    final HttpClientRequest req = await c.getUrl(Uri.parse(
+        '$base/api/library/videos/$encodedId/clipaudio?startMs=0&endMs=1000'));
+    // 不设 Authorization 头
+    final HttpClientResponse res = await req.close();
+    expect(res.statusCode, 401);
     c.close();
   });
 

--- a/hibiki/test/sync/sync_backend_utf8_body_test.dart
+++ b/hibiki/test/sync/sync_backend_utf8_body_test.dart
@@ -29,6 +29,18 @@ import 'package:drift/native.dart';
 /// Fake library service: captures the aggregate snapshot and book progress the
 /// client PUTs, so the test can assert the UTF-8 round-trip.
 class _CapturingLibraryService implements HibikiLibraryHostService {
+  // BUG-1003：host 端裁 mining 句子音频（本测试不涉及，返 null 即可）。
+  @override
+  Future<File?> clipVideoAudio(String id,
+          {required int startMs,
+          required int endMs,
+          int episodeIndex = 0,
+          int? audioStreamIndex,
+          int? audioStreamCount,
+          int audioChannels = 1,
+          String audioBitrate = '64k'}) async =>
+      null;
+
   @override
   Future<List<RemoteActivityEvent>> listActivityEvents(
           {int limit = 100}) async =>

--- a/hibiki/test/sync/sync_compare_live_book_test.dart
+++ b/hibiki/test/sync/sync_compare_live_book_test.dart
@@ -15,6 +15,18 @@ import 'package:hibiki_core/hibiki_core.dart';
 HibikiDatabase _memDb() => HibikiDatabase.forTesting(NativeDatabase.memory());
 
 class _LiveBookLibraryService implements HibikiLibraryHostService {
+  // BUG-1003：host 端裁 mining 句子音频（本测试不涉及，返 null 即可）。
+  @override
+  Future<File?> clipVideoAudio(String id,
+          {required int startMs,
+          required int endMs,
+          int episodeIndex = 0,
+          int? audioStreamIndex,
+          int? audioStreamCount,
+          int audioChannels = 1,
+          String audioBitrate = '64k'}) async =>
+      null;
+
   @override
   Future<List<RemoteActivityEvent>> listActivityEvents(
           {int limit = 100}) async =>

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -1298,6 +1298,7 @@ function hibikiSendLookup(term, anchorRect, cueWindow) {
       // 单词音频：查词响应带回 app 已启用的音频源（enabledAudioSources），非空时 popup.js
       // 的 createEntryHeader 才渲染 ♪ 按钮（与 app 内 window.audioSources 注入一致）。
       window.audioSources = Array.isArray(resp.data.audioSources) ? resp.data.audioSources : [];
+      window.needsAudio = true;
       hibikiRender(resp.data.popupJson, termLen, resp.data.theme, anchorRect);
     });
   } catch (_) {
@@ -1346,6 +1347,7 @@ window.__hibikiOnLinkClick = function (query) {
         ? resp.data.result.bestLength : 0;
       const termLen = best > 0 ? best : term.length;
       window.audioSources = Array.isArray(resp.data.audioSources) ? resp.data.audioSources : [];
+      window.needsAudio = true;
       hibikiRender(resp.data.popupJson, termLen, resp.data.theme);
     });
   } catch (_) { /* 扩展上下文失效：静默 */ }


### PR DESCRIPTION
## 背景
用户真机报「互联视频制卡失败 + 缺少单词音频 + 句子音频也少」，日志 `sentence audio export failed: ffmpeg exit 1; executable=ffmpeg-kit; ... stream?token=...: I/O error`（https）。沿真实代码路径查出**两个独立真 bug**。

## BUG-1003 · 互联视频制卡句子音频（host 端裁）
- **根因**：互联视频 `videoPath==null` → `miningSource` = host 的 `http(s)://…/stream?token=` URL；LAN muxed 流 `audioSource==null` → 直喂 ffmpeg 抽取。这是 [BUG-891](../blob/develop/docs/bugs/BUG-891-remote-mining-audio-tls.md) 「ffmpeg-kit TLS pin」修复后的**残余缺口**：client ffmpeg 抓 host 自签 https/token 流仍会因指纹缺失/URL 编码/token 短时/网络脆弱而 I/O error；句子音频返 null → `requireAudio` abort 整卡 → 文本/音频/截图/单词音频全缺。
- **修法（用户选定：host 端裁）**：新增 `GET /api/library/videos/<id>/clipaudio`——host 用**本地文件**裁好句子音频再经已鉴权/钉扎的下载通道回传，client 全程不用 ffmpeg 抓远端流，根上绕开整类失败（http/https 自签/token/全平台通吃，只传几十 KB 成品）。加法式接入：老 host 404 → 回退现有 ffmpeg-over-URL 抽取（含 BUG-891 的 tls pin），Never break userspace。
  - `HibikiLibraryHostService.clipVideoAudio`（抽象 + `AppModelLibraryHostService` 实现 = `resolveVideoFile` + `extractAudioSegmentViaFfmpeg`）
  - `HibikiSyncServer` `/clipaudio` 端点（Basic 鉴权）
  - `HibikiClientSyncBackend.getRemoteVideoAudioClip`（镜像 `getRemoteVideoSubtitle`）
  - `ImmersionMiningRequest.remoteAudioClipper` + 引擎音频分支优先走 host 端裁
  - `lookup_mining.part.dart` 当 `_effectiveRemoteClient is HibikiClientSyncBackend` 时注入裁切器

## BUG-1004 · 制卡缺单词音频（两处独立）
- **场景 A（扩展/沉浸制卡）**：`content.js` 从不注入 `window.needsAudio`，`popup.js` 制卡重解析分支恒 false → payload `audio` 空。两份镜像补 `window.needsAudio = true`（对齐 App 内 popup 注入）。
- **场景 B（App 内制卡自动填充）**：`LocalAudioEnhancement` 只查本地库+TTS、忽略远程发音源（forvo/jpod101/hibikiRemote）；改走全源 `resolveLookupAudioUrl` + `materializeWordAudioRef` 物化到文件（BUG-631 播放侧修复的制卡器孪生）。

## 测试
- `immersion_mining_engine_test`：host 端裁命中→不调 ffmpeg / 返 null→回退抽取
- `hibiki_sync_server_video_test`：`/clipaudio` 200(audio/aac,透传入参)/400/404/401
- `word_audio_materialize_test`：物化下载/回退/扩展名推断（MockClient）
- `extension_content_needs_audio_guard_test`：两份 content.js needsAudio 注入守卫
- `flutter analyze` 全量 **0 issue**；相关测试全绿。为 10 个既有测试 fake 补 `clipVideoAudio` stub。

## 待办
真机验证（Android 互联远端流制卡出句子音频 + 老 host 回退；只配远程发音源时 App 内/扩展制卡出单词音频）。

https://claude.ai/code/session_016RsqS7PAy3QNnEvMbYdhvu
