### PR TITLE
设置分类与排序重梳：大类任务优先 + 区内归位

### DIFF
--- a/docs/specs/2026-07-21-settings-refactor-v2-plan.md
+++ b/docs/specs/2026-07-21-settings-refactor-v2-plan.md
@@ -55,6 +55,39 @@
 - 位置重排：快捷键设置所在 section 命名修正（消除「系统 › 系统」语义重复）；逐项审查放错位置的项并归位（记录清单）。
 - 降低重排摩擦：guard 测试只锁「用户决策过的位置」与写穿行为，不再锁死无关项的相对顺序；确保 destination 增删只需改 `SettingsDestinationId` + `buildSettingsSchema` 两处 + i18n。
 
+#### G 落地：分类与排序（旧→新 映射）
+
+所有 item id / pref key / ReaderPlacement / VideoPlacement 均**不变**，只挪声明所属 section/位置。
+
+**顶层大类顺序**（`buildSettingsSchema`）：
+- 旧：外观 → Profile → 阅读 → 查词 → 制卡 → 视频 → 听书 → 下载 → 同步备份 → 互联 → 系统
+- 新：**阅读 → 查词 → 制卡 → 视频 → 听书 → 下载 → 外观 → Profile → 同步备份 → 互联 → 系统**（内容类在前、外观/系统类殿后）。守卫 `test/settings/settings_destination_order_guard_test.dart`。
+
+**阅读 destination**（`settings_schema_reading.dart`）分区重构：
+- 旧分区序：排版 → 布局与显示 → 高级选项(collapsed) → 阅读界面 → 翻页与交互 → 翻页方向(collapsed) → 底栏布局(collapsed)
+- 新分区序：**模式与排版方向**（新 key `reading_section_mode`；由旧「布局与显示」重命名，内含 view_mode → writing_mode → spread_mode → spread_direction → vert_text_orient → furigana_mode，翻页/滚动提到首位）→ **排版**（page_columns 移到 margins 之前）→ **阅读界面**（追加 `reverse_reader_bottom_bar`）→ 翻页与交互 → 翻页方向(collapsed) → **高级选项(collapsed，移到最后)**
+- 「底栏布局」单项分区删除（i18n key `section_bottom_bar_layout` 保留但闲置）。
+
+**查词 destination**（`settings_schema_lookup.dart`）分区重排 + 重命名：
+- 「管理器」→ **「词典与来源」**（原地改 i18n key `manager` 的 en/zh-CN/zh-HK 值，该 key 仅此处用）。
+- 旧序：词典与来源 → 查词触发 → 外部集成 → 剪贴板与全局查词 → 朗读与反馈 → 词条内容 → 弹窗窗口
+- 新序：**词典与来源 → 查词触发 → 词条内容 → 朗读与反馈 → 弹窗窗口 → 剪贴板与全局查词 → 外部集成**（外部集成从第 3 移到末尾；各 collapsed 标志不变）。
+
+**视频 destination**（`settings_schema_video.dart`）两个 item 换区（placement 不变）：
+- `video.quality.loop`「单文件循环」：画质区 → **播放区**（紧随 `auto_play_next`）；VideoPlacement `mpv#200` 不变。
+- `video.playback.pause_at_subtitle_end`「字幕暂停播放模式」：播放区 → **字幕区**（`obscure` 之前）；VideoPlacement `subtitle#30` 不变。
+- `video.controls.reset_layout` 仍在播放区末尾。
+
+**外观 → 系统 item 换区**：
+- `appearance.startup_default_dictionary_tab`「启动时打开查词」：外观「应用」区 → **系统「通用」区**（`focus_navigation` 之后）；item id **保持 `appearance.` 前缀不变**。
+
+**系统 destination**（`settings_schema_system.dart`）：
+- 分区序：**通用 → 更新设置 → 诊断(collapsed)**（原为 更新 → 通用 → 诊断）。
+- 通用区内序：**keyboard_shortcuts → focus_navigation → startup_default_dictionary_tab → low_memory_mode → app_version → github**。
+- destination summary：`section_update`（更新设置，共享给更新区标题）→ 新 key `settings_destination_system_summary`「通用、更新与诊断」。
+
+**新增 i18n key**：`reading_section_mode`、`settings_destination_system_summary`。**闲置 key**：`section_bottom_bar_layout`（停止引用，未删）。
+
 ### D. 收尾（中·Opus）
 - 渲染器复制注释归一、`dispatchChange` 注释澄清、文档更新。
 - 全量 `dart format` + `flutter analyze`（0 告警）+ `flutter test --no-pub` 全绿。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 37961 (2233 per locale)
+/// Strings: 37995 (2235 per locale)
 ///
-/// Built on 2026-07-21 at 21:54 UTC
+/// Built on 2026-07-22 at 00:05 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -349,7 +349,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get server_address => 'Server Address';
   String get text_segmentation => 'Text Segmentation';
   String get settings => 'Settings';
-  String get manager => 'Manager';
+  String get manager => 'Dictionaries & sources';
   String get volume_button_page_turning => 'Volume button page turning';
   String get invert_volume_buttons => 'Invert volume buttons';
   String get invert_swipe_direction => 'Invert swipe page turn direction';
@@ -2974,6 +2974,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get clipboard_panel_block_capture_hint =>
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   String get settings_section_general => 'General';
+  String get reading_section_mode => 'Mode & orientation';
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -8027,6 +8030,11 @@ class _StringsAr extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -13153,6 +13161,11 @@ class _StringsDe extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -18295,6 +18308,11 @@ class _StringsEs extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -23448,6 +23466,11 @@ class _StringsFr extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -28528,6 +28551,11 @@ class _StringsId extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -33656,6 +33684,11 @@ class _StringsIt extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -38589,6 +38622,11 @@ class _StringsJa extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -43525,6 +43563,11 @@ class _StringsKo extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -48631,6 +48674,11 @@ class _StringsNl extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -53752,6 +53800,11 @@ class _StringsPtBr extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -58856,6 +58909,11 @@ class _StringsRu extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -63905,6 +63963,11 @@ class _StringsTh extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -68986,6 +69049,11 @@ class _StringsTr extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -74054,6 +74122,11 @@ class _StringsVi extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => 'General';
+  @override
+  String get reading_section_mode => 'Mode & orientation';
+  @override
+  String get settings_destination_system_summary =>
+      'General, updates & diagnostics';
 }
 
 // Path: <root>
@@ -74373,7 +74446,7 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get settings => '设置';
   @override
-  String get manager => '管理器';
+  String get manager => '词典与来源';
   @override
   String get volume_button_page_turning => '音量键翻页';
   @override
@@ -78770,6 +78843,10 @@ class _StringsZhCn extends _StringsEn {
       '把查词和剪贴板悬浮窗从截图、录屏、直播串流中排除（Windows）。关闭后，截图、录屏和串流即可拍到查词悬浮窗。';
   @override
   String get settings_section_general => '通用';
+  @override
+  String get reading_section_mode => '模式与排版方向';
+  @override
+  String get settings_destination_system_summary => '通用、更新与诊断';
 }
 
 // Path: <root>
@@ -79061,7 +79138,7 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get settings => '設定';
   @override
-  String get manager => '管理員';
+  String get manager => '詞典與來源';
   @override
   String get volume_button_page_turning => '音量鍵翻頁';
   @override
@@ -83622,6 +83699,10 @@ class _StringsZhHk extends _StringsEn {
       'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
   @override
   String get settings_section_general => '通用';
+  @override
+  String get reading_section_mode => '模式與排版方向';
+  @override
+  String get settings_destination_system_summary => '通用、更新與診斷';
 }
 
 /// Flat map(s) containing all translations.
@@ -83909,7 +83990,7 @@ extension on _StringsEn {
       case 'settings':
         return 'Settings';
       case 'manager':
-        return 'Manager';
+        return 'Dictionaries & sources';
       case 'volume_button_page_turning':
         return 'Volume button page turning';
       case 'invert_volume_buttons':
@@ -88180,6 +88261,10 @@ extension on _StringsEn {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -92736,6 +92821,10 @@ extension on _StringsAr {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -97313,6 +97402,10 @@ extension on _StringsDe {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -101889,6 +101982,10 @@ extension on _StringsEs {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -106471,6 +106568,10 @@ extension on _StringsFr {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -111035,6 +111136,10 @@ extension on _StringsId {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -115614,6 +115719,10 @@ extension on _StringsIt {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -120155,6 +120264,10 @@ extension on _StringsJa {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -124700,6 +124813,10 @@ extension on _StringsKo {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -129272,6 +129389,10 @@ extension on _StringsNl {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -133841,6 +133962,10 @@ extension on _StringsPtBr {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -138415,6 +138540,10 @@ extension on _StringsRu {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -142973,6 +143102,10 @@ extension on _StringsTh {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -147540,6 +147673,10 @@ extension on _StringsTr {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -152102,6 +152239,10 @@ extension on _StringsVi {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return 'General';
+      case 'reading_section_mode':
+        return 'Mode & orientation';
+      case 'settings_destination_system_summary':
+        return 'General, updates & diagnostics';
       default:
         return null;
     }
@@ -152387,7 +152528,7 @@ extension on _StringsZhCn {
       case 'settings':
         return '设置';
       case 'manager':
-        return '管理器';
+        return '词典与来源';
       case 'volume_button_page_turning':
         return '音量键翻页';
       case 'invert_volume_buttons':
@@ -156630,6 +156771,10 @@ extension on _StringsZhCn {
         return '把查词和剪贴板悬浮窗从截图、录屏、直播串流中排除（Windows）。关闭后，截图、录屏和串流即可拍到查词悬浮窗。';
       case 'settings_section_general':
         return '通用';
+      case 'reading_section_mode':
+        return '模式与排版方向';
+      case 'settings_destination_system_summary':
+        return '通用、更新与诊断';
       default:
         return null;
     }
@@ -156887,7 +157032,7 @@ extension on _StringsZhHk {
       case 'settings':
         return '設定';
       case 'manager':
-        return '管理員';
+        return '詞典與來源';
       case 'volume_button_page_turning':
         return '音量鍵翻頁';
       case 'invert_volume_buttons':
@@ -161166,6 +161311,10 @@ extension on _StringsZhHk {
         return 'Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.';
       case 'settings_section_general':
         return '通用';
+      case 'reading_section_mode':
+        return '模式與排版方向';
+      case 'settings_destination_system_summary':
+        return '通用、更新與診斷';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -136,7 +136,7 @@
   "server_address": "Server Address",
   "text_segmentation": "Text Segmentation",
   "settings": "Settings",
-  "manager": "Manager",
+  "manager": "Dictionaries & sources",
   "volume_button_page_turning": "Volume button page turning",
   "invert_volume_buttons": "Invert volume buttons",
   "invert_swipe_direction": "Invert swipe page turn direction",
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "General"
+  "settings_section_general": "General",
+  "reading_section_mode": "Mode & orientation",
+  "settings_destination_system_summary": "General, updates & diagnostics"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -136,7 +136,7 @@
   "server_address": "服务器地址",
   "text_segmentation": "文本分词",
   "settings": "设置",
-  "manager": "管理器",
+  "manager": "词典与来源",
   "volume_button_page_turning": "音量键翻页",
   "invert_volume_buttons": "反转音量键方向",
   "invert_swipe_direction": "反转滑动翻页方向",
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "倍速步进",
   "clipboard_panel_block_capture": "防截屏 / 防录屏",
   "clipboard_panel_block_capture_hint": "把查词和剪贴板悬浮窗从截图、录屏、直播串流中排除（Windows）。关闭后，截图、录屏和串流即可拍到查词悬浮窗。",
-  "settings_section_general": "通用"
+  "settings_section_general": "通用",
+  "reading_section_mode": "模式与排版方向",
+  "settings_destination_system_summary": "通用、更新与诊断"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -122,7 +122,7 @@
   "server_address": "伺服器位址",
   "text_segmentation": "文字分詞",
   "settings": "設定",
-  "manager": "管理員",
+  "manager": "詞典與來源",
   "volume_button_page_turning": "音量鍵翻頁",
   "invert_volume_buttons": "反轉音量鍵方向",
   "invert_swipe_direction": "反轉滑動翻頁方向",
@@ -2231,5 +2231,7 @@
   "video_setting_speed_step": "Speed step",
   "clipboard_panel_block_capture": "Block screen capture",
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
-  "settings_section_general": "通用"
+  "settings_section_general": "通用",
+  "reading_section_mode": "模式與排版方向",
+  "settings_destination_system_summary": "通用、更新與診斷"
 }

--- a/hibiki/lib/src/settings/settings_schema.dart
+++ b/hibiki/lib/src/settings/settings_schema.dart
@@ -14,9 +14,9 @@ import 'package:hibiki/src/sync/sync_settings_schema.dart';
 import 'package:hibiki/utils.dart';
 
 List<SettingsDestination> buildSettingsSchema(SettingsContext context) {
+  // 大类任务优先排序（阶段 G）：把用户最常改的「阅读 / 查词 / 制卡 / 视频 / 听书 /
+  // 下载」内容类放最前，「外观 / Profile / 同步备份 / 互联 / 系统」这类配置/系统类殿后。
   return <SettingsDestination>[
-    buildAppearanceDestination(),
-    buildProfilesDestination(),
     buildReadingDestination(),
     buildLookupDestination(),
     buildCardCreationDestination(),
@@ -24,6 +24,8 @@ List<SettingsDestination> buildSettingsSchema(SettingsContext context) {
     buildListeningDestination(),
     // 「下载」大类：内联既有 torrent 设置组件（详见 buildDownloadsDestination）。
     buildDownloadsDestination(),
+    buildAppearanceDestination(),
+    buildProfilesDestination(),
     buildSyncBackupDestination(),
     // Hibiki 互联从同步分类拆出的独立一级分类（构建函数在 sync_settings_schema
     // 同库，与同步共享私有状态）。

--- a/hibiki/lib/src/settings/settings_schema_appearance.dart
+++ b/hibiki/lib/src/settings/settings_schema_appearance.dart
@@ -112,19 +112,9 @@ SettingsDestination buildAppearanceDestination() {
               settingsContext.refresh();
             },
           ),
-          SettingsSwitchItem(
-            id: 'appearance.startup_default_dictionary_tab',
-            title: t.startup_default_dictionary_tab,
-            subtitle: t.startup_default_dictionary_tab_hint,
-            icon: Icons.manage_search_outlined,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.startupDefaultDictionaryTab,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.appModel
-                  .setStartupDefaultDictionaryTab(value);
-              settingsContext.refresh();
-            },
-          ),
+          // 「启动时打开查词」(id 'appearance.startup_default_dictionary_tab') 已归位到
+          // 「系统 · 通用」分区（它管的是启动落地页/导航行为，与主题/明暗等外观无关）；
+          // id / 持久化 key 保持不变（历史命名 appearance 前缀，仅换展示分类）。
         ],
       ),
     ],

--- a/hibiki/lib/src/settings/settings_schema_lookup.dart
+++ b/hibiki/lib/src/settings/settings_schema_lookup.dart
@@ -154,79 +154,388 @@ SettingsDestination buildLookupDestination() {
           ),
         ],
       ),
-      // 外部集成：远程查词 / Yomitan API / texthooker——都是「让别的程序或设备
-      // 参与查词」的接线项，与本机查词触发行为分开。
+      // 原「查词显示」17 项拆两组：词条内容（词典结果怎么渲染）/ 弹窗窗口
+      //（弹窗容器的尺寸与交互，含从行为区移来的滑动关闭手势对——它们改的是
+      // 弹窗窗口的关闭手势，与尺寸/停靠为伍）。
       SettingsSection(
-        title: t.settings_section_lookup_integrations,
+        title: t.settings_section_lookup_content,
+        collapsedByDefault: true,
         items: <SettingsItem>[
-          // 远端词典查询抽成共享 builder：查词分类与 Hibiki 互联分类都引用（它直连
-          // 互联对端的词典，逻辑上属互联，故互联分类也提供入口）。
-          buildRemoteDictionaryLookupItem(),
           SettingsSwitchItem(
-            id: 'lookup.yomitan_api_server',
-            title: t.yomitan_api_server,
-            subtitle:
-                t.yomitan_api_server_hint + t.settings_experimental_suffix,
-            icon: Icons.api_outlined,
+            id: 'lookup.collapse_dictionaries',
+            title: t.collapse_dictionaries,
+            icon: Icons.unfold_less_outlined,
             value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.yomitanApiServerEnabled,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.appModel.setYomitanApiServerEnabled(value);
-              if (value) {
-                try {
-                  await settingsContext.appModel.startYomitanApiServer();
-                } on SyncServerPortInUseException {
-                  // startYomitanApiServer 已在抛出前把开关复位为 false。
-                  final BuildContext ctx = settingsContext.context;
-                  if (ctx.mounted) {
-                    ScaffoldMessenger.of(ctx).showSnackBar(
-                      SnackBar(
-                        content: Text(
-                          _yomitanApiPortInUseMessage(
-                            settingsContext.appModel.yomitanApiPort,
-                          ),
-                        ),
-                      ),
-                    );
-                  }
-                }
-              } else {
-                await settingsContext.appModel.stopYomitanApiServer();
-              }
+                settingsContext.appModel.collapseDictionaries,
+            onChanged: (SettingsContext settingsContext, bool value) {
+              settingsContext.appModel.toggleCollapseDictionaries();
               settingsContext.refresh();
             },
           ),
-          // 一等文本项（secret）：行尾自动获得眼睛显隐切换。写穿后重启 Yomitan
-          // API 服务（若已开启）。
-          SettingsTextItem(
-            id: 'lookup.yomitan_api_key',
-            title: t.yomitan_api_key,
-            icon: Icons.key_outlined,
-            secret: true,
+          // TODO-845: how many leading dictionary blocks the popup auto-expands
+          // even when "collapse dictionaries" is on. int preference surfaced
+          // through a double slider; min/max (0..6) match the repository clamp.
+          // 仅当「折叠词典显示」开启时才有意义（折叠关闭时所有词典本就展开，「自动展开
+          // 前 N 本」无从谈起）；据此对齐用户预期，仅折叠开启时才显示本项。
+          SettingsSliderItem(
+            id: 'lookup.popup_auto_expand_dictionaries',
+            title: t.popup_auto_expand_dictionaries,
+            subtitle: t.popup_auto_expand_dictionaries_hint,
+            icon: Icons.unfold_more_outlined,
+            visible: (SettingsContext settingsContext) =>
+                settingsContext.appModel.collapseDictionaries,
+            min: 0,
+            max: 6,
+            divisions: 6,
+            titleReadout: true,
             value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.yomitanApiKey,
-            onChanged: (SettingsContext settingsContext, String value) async {
-              await settingsContext.appModel.setYomitanApiKey(value);
-              await _restartYomitanApiServerIfEnabled(settingsContext);
+                settingsContext.appModel.popupAutoExpandDictionaries.toDouble(),
+            label: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) {
+              settingsContext.appModel
+                  .setPopupAutoExpandDictionaries(value.round());
+              settingsContext.refresh();
+            },
+          ),
+          // TODO-776: dictionaries-per-row grid (experimental). int preference
+          // surfaced through a double slider, so value/onChanged bridge int↔double.
+          SettingsSliderItem(
+            id: 'lookup.popup_dictionary_columns',
+            // 语义收敛：列数一直是「自动填充、封顶用户值」（effective = min(用户值,
+            // 视口可容)），文案随之改为「词典最多列数（自动填充）」，不改底层算法。
+            title: t.popup_dictionary_max_columns,
+            subtitle: t.popup_dictionary_max_columns_hint +
+                t.settings_experimental_suffix,
+            icon: Icons.view_column_outlined,
+            min: 1,
+            max: 4,
+            divisions: 3,
+            titleReadout: true,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.popupDictionaryColumns.toDouble(),
+            label: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) {
+              settingsContext.appModel.setPopupDictionaryColumns(value.round());
+              settingsContext.refresh();
             },
           ),
           SettingsSwitchItem(
-            id: 'lookup.texthooker',
-            title: t.texthooker_enabled,
-            subtitle:
-                t.texthooker_enabled_hint + t.settings_experimental_suffix,
-            icon: Icons.sensors_outlined,
+            id: 'lookup.show_expression_tags',
+            title: t.show_expression_tags,
+            icon: Icons.sell_outlined,
             value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.texthookerEnabled,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.appModel.setTexthookerEnabled(value);
-              if (value) {
-                TexthookerWsClientManager.instance
-                    .start(settingsContext.appModel.texthookerUrls);
-              } else {
-                await TexthookerWsClientManager.instance.stop();
-              }
+                settingsContext.appModel.showExpressionTags,
+            onChanged: (SettingsContext settingsContext, bool value) {
+              settingsContext.appModel.toggleShowExpressionTags();
               settingsContext.refresh();
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'lookup.deduplicate_pitch_accents',
+            title: t.deduplicate_pitch_accents,
+            icon: Icons.filter_alt_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.deduplicatePitchAccents,
+            onChanged: (SettingsContext settingsContext, bool value) {
+              settingsContext.appModel.toggleDeduplicatePitchAccents();
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'lookup.harmonic_frequency',
+            title: t.harmonic_frequency,
+            icon: Icons.bar_chart_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.harmonicFrequency,
+            onChanged: (SettingsContext settingsContext, bool value) {
+              settingsContext.appModel.toggleHarmonicFrequency();
+              settingsContext.refresh();
+            },
+          ),
+          SettingsNumberItem(
+            id: 'lookup.dictionary_font_size',
+            title: t.dictionary_font_size,
+            // TODO-1353: 提示 Ctrl+滚轮可在查词弹窗内直接缩放（改的就是这个词典
+            // 字号，持久化）。
+            subtitle: t.dictionary_font_size_zoom_hint,
+            icon: Icons.format_size,
+            min: 0,
+            suffixText: t.unit_pixels,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.dictionaryFontSize,
+            resetValue: (SettingsContext settingsContext) =>
+                settingsContext.appModel.defaultDictionaryFontSize,
+            onChanged: (SettingsContext settingsContext, num value) {
+              settingsContext.appModel.setDictionaryFontSize(value.toDouble());
+              settingsContext.refresh();
+            },
+          ),
+        ],
+      ),
+      // 朗读与反馈：查中词后的语音朗读与播放暂停联动。
+      SettingsSection(
+        title: t.settings_section_lookup_audio,
+        items: <SettingsItem>[
+          SettingsSwitchItem(
+            id: 'lookup.auto_read_on_lookup',
+            title: t.auto_read_on_lookup,
+            icon: Icons.record_voice_over_outlined,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.lookup,
+              order: 0,
+            ),
+            value: (SettingsContext settingsContext) =>
+                settingsContext.readerSource.autoReadOnLookup,
+            onChanged: (SettingsContext settingsContext, bool value) {
+              settingsContext.readerSource.toggleAutoReadOnLookup();
+              notifyReaderSettingsChanged(settingsContext);
+            },
+          ),
+          SettingsSliderItem(
+            id: 'lookup.audio_volume',
+            title: t.lookup_audio_volume,
+            icon: Icons.volume_up_outlined,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.lookup,
+              order: 1,
+            ),
+            value: (SettingsContext settingsContext) =>
+                settingsContext.readerSource.lookupAudioVolume.toDouble(),
+            min: 0,
+            max: 100,
+            // 与有声书音量行（AudiobookVolumeRow）同款粒度契约：拖动 1% 一档
+            // （0–100% 共 100 档），键盘 / 手柄左右键 5% 一步（step 与档位解
+            // 耦——按键也走 1% 的话 0–100% 要按 100 下），标题带实时百分比读数。
+            divisions: 100,
+            step: 5,
+            titleReadout: true,
+            label: (double value) => '${value.round()}%',
+            onChanged: (SettingsContext settingsContext, double value) async {
+              await settingsContext.readerSource.setLookupAudioVolume(value);
+              notifyReaderSettingsChanged(settingsContext);
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'lookup.pause_on_lookup',
+            title: t.pause_on_lookup,
+            icon: Icons.pause_circle_outline,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.lookup,
+              order: 2,
+            ),
+            value: (SettingsContext settingsContext) =>
+                settingsContext.readerSource.pauseOnLookup,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.readerSource.setPauseOnLookup(value: value);
+              notifyReaderSettingsChanged(settingsContext);
+            },
+          ),
+        ],
+      ),
+      SettingsSection(
+        title: t.settings_section_lookup_popup_window,
+        collapsedByDefault: true,
+        items: <SettingsItem>[
+          SettingsSliderItem(
+            id: 'lookup.popup_max_width',
+            // TODO-1352: 放宽查词弹窗最大宽度的强制上限（1000→2000），让宽屏 / 4K 下
+            // 弹窗能拉到接近占满（实际宽度仍由 resolvePopupRect 按当前屏宽 clamp，
+            // 绝不会超出屏幕）。divisions 保持 10px 步进（1750/175）。
+            title: t.popup_max_width,
+            icon: Icons.open_in_full_outlined,
+            min: 250,
+            max: 2000,
+            divisions: 175,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.popupMaxWidth,
+            label: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) {
+              settingsContext.appModel.setPopupMaxWidth(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSliderItem(
+            id: 'lookup.popup_max_height',
+            // TODO-1352 后续：放宽最大高度上限（800→1600），配合高分屏 / 精细调整；
+            // 实际高度仍由 resolvePopupRect 按当前屏高 clamp，绝不会超出屏幕。
+            // 步进保持 10px（1400/140）。
+            title: t.popup_max_height,
+            icon: Icons.height_outlined,
+            min: 200,
+            max: 1600,
+            divisions: 140,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.popupMaxHeight,
+            label: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) {
+              settingsContext.appModel.setPopupMaxHeight(value);
+              settingsContext.refresh();
+            },
+          ),
+          // 弹窗尺寸精细化：app 外覆盖查词窗独立尺寸开关 + 仅在开启时展示的宽/高滑杆。
+          // 关闭时跟随上面的 app 内最大宽高（overlayLookupEffectiveSize 解析）。
+          SettingsSwitchItem(
+            id: 'lookup.overlay_lookup_independent_size',
+            title: t.overlay_lookup_independent_size,
+            subtitle: t.overlay_lookup_independent_size_hint,
+            icon: Icons.open_in_new_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.overlayLookupIndependentSize,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel
+                  .setOverlayLookupIndependentSize(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSliderItem(
+            id: 'lookup.overlay_lookup_max_width',
+            title: t.overlay_lookup_max_width,
+            icon: Icons.open_in_full_outlined,
+            min: 250,
+            max: 2000,
+            divisions: 175,
+            visible: (SettingsContext settingsContext) =>
+                settingsContext.appModel.overlayLookupIndependentSize,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.overlayLookupMaxWidth,
+            label: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) {
+              settingsContext.appModel.setOverlayLookupMaxWidth(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSliderItem(
+            id: 'lookup.overlay_lookup_max_height',
+            title: t.overlay_lookup_max_height,
+            icon: Icons.height_outlined,
+            min: 200,
+            max: 1600,
+            divisions: 140,
+            visible: (SettingsContext settingsContext) =>
+                settingsContext.appModel.overlayLookupIndependentSize,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.overlayLookupMaxHeight,
+            label: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) {
+              settingsContext.appModel.setOverlayLookupMaxHeight(value);
+              settingsContext.refresh();
+            },
+          ),
+          // 弹窗尺寸精细化：浏览器扩展弹窗独立尺寸开关 + 仅在开启时展示的宽/高滑杆。
+          // 关闭时跟随 app 内最大宽高（extensionPopupEffectiveSize 解析，经 theme 下发）。
+          SettingsSwitchItem(
+            id: 'lookup.extension_popup_independent_size',
+            title: t.extension_popup_independent_size,
+            subtitle: t.extension_popup_independent_size_hint,
+            icon: Icons.extension_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.extensionPopupIndependentSize,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel
+                  .setExtensionPopupIndependentSize(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSliderItem(
+            id: 'lookup.extension_popup_max_width',
+            title: t.extension_popup_max_width,
+            icon: Icons.open_in_full_outlined,
+            min: 250,
+            max: 2000,
+            divisions: 175,
+            visible: (SettingsContext settingsContext) =>
+                settingsContext.appModel.extensionPopupIndependentSize,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.extensionPopupMaxWidth,
+            label: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) {
+              settingsContext.appModel.setExtensionPopupMaxWidth(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSliderItem(
+            id: 'lookup.extension_popup_max_height',
+            title: t.extension_popup_max_height,
+            icon: Icons.height_outlined,
+            min: 200,
+            max: 1600,
+            divisions: 140,
+            visible: (SettingsContext settingsContext) =>
+                settingsContext.appModel.extensionPopupIndependentSize,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.extensionPopupMaxHeight,
+            label: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) {
+              settingsContext.appModel.setExtensionPopupMaxHeight(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'lookup.popup_instant_scroll',
+            title: t.popup_instant_scroll,
+            subtitle: t.popup_instant_scroll_hint,
+            icon: Icons.animation_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.popupInstantScroll,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel.setPopupInstantScroll(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'lookup.popup_bottom_docked',
+            title: t.popup_bottom_docked,
+            subtitle: t.popup_bottom_docked_hint,
+            icon: Icons.vertical_align_bottom_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.popupBottomDocked,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel.setPopupBottomDocked(value);
+              settingsContext.refresh();
+            },
+          ),
+          // TODO-436/407②/716：是否允许"水平滑动关闭查词弹窗"。这是查词弹窗窗口的
+          // 关闭手势，与弹窗尺寸/停靠同组；同时经 ReaderPlacement 出现在阅读器快捷
+          // 设置的查词段。开启后既驱动弹窗顶栏滑动关闭（[SwipeDismissWrapper]），也让
+          // 桌面在弹窗正文区（全屏 barrier）水平拖过阈关一层（TODO-716，对齐手机手势）。
+          // Windows/Linux 默认关闭（鼠标框选正文与滑动手势同形易误触），其余平台默认
+          // 开启；任何平台均可用弹窗顶栏的 X 关闭。
+          SettingsSwitchItem(
+            id: 'reading_controls.enable_swipe_to_close',
+            title: t.enable_swipe_to_close,
+            icon: Icons.swipe_left_outlined,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.lookup,
+              order: 3,
+            ),
+            value: (SettingsContext settingsContext) =>
+                settingsContext.readerSource.enableSwipeToClose,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.readerSource.setEnableSwipeToClose(value);
+              notifyReaderSettingsChanged(settingsContext);
+            },
+          ),
+          // TODO-625：滑动关闭的灵敏度阈值，与上面的"允许水平滑动关闭查词弹窗"开关
+          // 配套，同属查词弹窗手势行为（ReaderGroup.lookup，紧邻开关），与开关相邻摆放。
+          // id/偏好 key 沿用 'reading_controls.' 前缀作向后兼容（持久化无关展示分类）。
+          SettingsSliderItem(
+            id: 'reading_controls.dismiss_swipe_sensitivity',
+            title: t.dismiss_swipe_sensitivity,
+            icon: Icons.swipe_down_outlined,
+            min: 0.1,
+            max: 1,
+            divisions: 9,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.lookup,
+              order: 4,
+            ),
+            value: (SettingsContext settingsContext) =>
+                settingsContext.readerSource.dismissSwipeSensitivity,
+            label: (double value) => value.toStringAsFixed(1),
+            onChanged: (SettingsContext settingsContext, double value) async {
+              await settingsContext.readerSource
+                  .setDismissSwipeSensitivity(value);
+              notifyReaderSettingsChanged(settingsContext);
             },
           ),
         ],
@@ -496,388 +805,79 @@ SettingsDestination buildLookupDestination() {
           ),
         ],
       ),
-      // 朗读与反馈：查中词后的语音朗读与播放暂停联动。
+      // 外部集成：远程查词 / Yomitan API / texthooker——都是「让别的程序或设备
+      // 参与查词」的接线项，与本机查词触发行为分开。
       SettingsSection(
-        title: t.settings_section_lookup_audio,
+        title: t.settings_section_lookup_integrations,
         items: <SettingsItem>[
+          // 远端词典查询抽成共享 builder：查词分类与 Hibiki 互联分类都引用（它直连
+          // 互联对端的词典，逻辑上属互联，故互联分类也提供入口）。
+          buildRemoteDictionaryLookupItem(),
           SettingsSwitchItem(
-            id: 'lookup.auto_read_on_lookup',
-            title: t.auto_read_on_lookup,
-            icon: Icons.record_voice_over_outlined,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.lookup,
-              order: 0,
-            ),
+            id: 'lookup.yomitan_api_server',
+            title: t.yomitan_api_server,
+            subtitle:
+                t.yomitan_api_server_hint + t.settings_experimental_suffix,
+            icon: Icons.api_outlined,
             value: (SettingsContext settingsContext) =>
-                settingsContext.readerSource.autoReadOnLookup,
-            onChanged: (SettingsContext settingsContext, bool value) {
-              settingsContext.readerSource.toggleAutoReadOnLookup();
-              notifyReaderSettingsChanged(settingsContext);
-            },
-          ),
-          SettingsSliderItem(
-            id: 'lookup.audio_volume',
-            title: t.lookup_audio_volume,
-            icon: Icons.volume_up_outlined,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.lookup,
-              order: 1,
-            ),
-            value: (SettingsContext settingsContext) =>
-                settingsContext.readerSource.lookupAudioVolume.toDouble(),
-            min: 0,
-            max: 100,
-            // 与有声书音量行（AudiobookVolumeRow）同款粒度契约：拖动 1% 一档
-            // （0–100% 共 100 档），键盘 / 手柄左右键 5% 一步（step 与档位解
-            // 耦——按键也走 1% 的话 0–100% 要按 100 下），标题带实时百分比读数。
-            divisions: 100,
-            step: 5,
-            titleReadout: true,
-            label: (double value) => '${value.round()}%',
-            onChanged: (SettingsContext settingsContext, double value) async {
-              await settingsContext.readerSource.setLookupAudioVolume(value);
-              notifyReaderSettingsChanged(settingsContext);
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'lookup.pause_on_lookup',
-            title: t.pause_on_lookup,
-            icon: Icons.pause_circle_outline,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.lookup,
-              order: 2,
-            ),
-            value: (SettingsContext settingsContext) =>
-                settingsContext.readerSource.pauseOnLookup,
+                settingsContext.appModel.yomitanApiServerEnabled,
             onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.readerSource.setPauseOnLookup(value: value);
-              notifyReaderSettingsChanged(settingsContext);
-            },
-          ),
-        ],
-      ),
-      // 原「查词显示」17 项拆两组：词条内容（词典结果怎么渲染）/ 弹窗窗口
-      //（弹窗容器的尺寸与交互，含从行为区移来的滑动关闭手势对——它们改的是
-      // 弹窗窗口的关闭手势，与尺寸/停靠为伍）。
-      SettingsSection(
-        title: t.settings_section_lookup_content,
-        collapsedByDefault: true,
-        items: <SettingsItem>[
-          SettingsSwitchItem(
-            id: 'lookup.collapse_dictionaries',
-            title: t.collapse_dictionaries,
-            icon: Icons.unfold_less_outlined,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.collapseDictionaries,
-            onChanged: (SettingsContext settingsContext, bool value) {
-              settingsContext.appModel.toggleCollapseDictionaries();
+              await settingsContext.appModel.setYomitanApiServerEnabled(value);
+              if (value) {
+                try {
+                  await settingsContext.appModel.startYomitanApiServer();
+                } on SyncServerPortInUseException {
+                  // startYomitanApiServer 已在抛出前把开关复位为 false。
+                  final BuildContext ctx = settingsContext.context;
+                  if (ctx.mounted) {
+                    ScaffoldMessenger.of(ctx).showSnackBar(
+                      SnackBar(
+                        content: Text(
+                          _yomitanApiPortInUseMessage(
+                            settingsContext.appModel.yomitanApiPort,
+                          ),
+                        ),
+                      ),
+                    );
+                  }
+                }
+              } else {
+                await settingsContext.appModel.stopYomitanApiServer();
+              }
               settingsContext.refresh();
             },
           ),
-          // TODO-845: how many leading dictionary blocks the popup auto-expands
-          // even when "collapse dictionaries" is on. int preference surfaced
-          // through a double slider; min/max (0..6) match the repository clamp.
-          // 仅当「折叠词典显示」开启时才有意义（折叠关闭时所有词典本就展开，「自动展开
-          // 前 N 本」无从谈起）；据此对齐用户预期，仅折叠开启时才显示本项。
-          SettingsSliderItem(
-            id: 'lookup.popup_auto_expand_dictionaries',
-            title: t.popup_auto_expand_dictionaries,
-            subtitle: t.popup_auto_expand_dictionaries_hint,
-            icon: Icons.unfold_more_outlined,
-            visible: (SettingsContext settingsContext) =>
-                settingsContext.appModel.collapseDictionaries,
-            min: 0,
-            max: 6,
-            divisions: 6,
-            titleReadout: true,
+          // 一等文本项（secret）：行尾自动获得眼睛显隐切换。写穿后重启 Yomitan
+          // API 服务（若已开启）。
+          SettingsTextItem(
+            id: 'lookup.yomitan_api_key',
+            title: t.yomitan_api_key,
+            icon: Icons.key_outlined,
+            secret: true,
             value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.popupAutoExpandDictionaries.toDouble(),
-            label: (double value) => value.round().toString(),
-            onChanged: (SettingsContext settingsContext, double value) {
-              settingsContext.appModel
-                  .setPopupAutoExpandDictionaries(value.round());
-              settingsContext.refresh();
-            },
-          ),
-          // TODO-776: dictionaries-per-row grid (experimental). int preference
-          // surfaced through a double slider, so value/onChanged bridge int↔double.
-          SettingsSliderItem(
-            id: 'lookup.popup_dictionary_columns',
-            // 语义收敛：列数一直是「自动填充、封顶用户值」（effective = min(用户值,
-            // 视口可容)），文案随之改为「词典最多列数（自动填充）」，不改底层算法。
-            title: t.popup_dictionary_max_columns,
-            subtitle: t.popup_dictionary_max_columns_hint +
-                t.settings_experimental_suffix,
-            icon: Icons.view_column_outlined,
-            min: 1,
-            max: 4,
-            divisions: 3,
-            titleReadout: true,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.popupDictionaryColumns.toDouble(),
-            label: (double value) => value.round().toString(),
-            onChanged: (SettingsContext settingsContext, double value) {
-              settingsContext.appModel.setPopupDictionaryColumns(value.round());
-              settingsContext.refresh();
+                settingsContext.appModel.yomitanApiKey,
+            onChanged: (SettingsContext settingsContext, String value) async {
+              await settingsContext.appModel.setYomitanApiKey(value);
+              await _restartYomitanApiServerIfEnabled(settingsContext);
             },
           ),
           SettingsSwitchItem(
-            id: 'lookup.show_expression_tags',
-            title: t.show_expression_tags,
-            icon: Icons.sell_outlined,
+            id: 'lookup.texthooker',
+            title: t.texthooker_enabled,
+            subtitle:
+                t.texthooker_enabled_hint + t.settings_experimental_suffix,
+            icon: Icons.sensors_outlined,
             value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.showExpressionTags,
-            onChanged: (SettingsContext settingsContext, bool value) {
-              settingsContext.appModel.toggleShowExpressionTags();
-              settingsContext.refresh();
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'lookup.deduplicate_pitch_accents',
-            title: t.deduplicate_pitch_accents,
-            icon: Icons.filter_alt_outlined,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.deduplicatePitchAccents,
-            onChanged: (SettingsContext settingsContext, bool value) {
-              settingsContext.appModel.toggleDeduplicatePitchAccents();
-              settingsContext.refresh();
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'lookup.harmonic_frequency',
-            title: t.harmonic_frequency,
-            icon: Icons.bar_chart_outlined,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.harmonicFrequency,
-            onChanged: (SettingsContext settingsContext, bool value) {
-              settingsContext.appModel.toggleHarmonicFrequency();
-              settingsContext.refresh();
-            },
-          ),
-          SettingsNumberItem(
-            id: 'lookup.dictionary_font_size',
-            title: t.dictionary_font_size,
-            // TODO-1353: 提示 Ctrl+滚轮可在查词弹窗内直接缩放（改的就是这个词典
-            // 字号，持久化）。
-            subtitle: t.dictionary_font_size_zoom_hint,
-            icon: Icons.format_size,
-            min: 0,
-            suffixText: t.unit_pixels,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.dictionaryFontSize,
-            resetValue: (SettingsContext settingsContext) =>
-                settingsContext.appModel.defaultDictionaryFontSize,
-            onChanged: (SettingsContext settingsContext, num value) {
-              settingsContext.appModel.setDictionaryFontSize(value.toDouble());
-              settingsContext.refresh();
-            },
-          ),
-        ],
-      ),
-      SettingsSection(
-        title: t.settings_section_lookup_popup_window,
-        collapsedByDefault: true,
-        items: <SettingsItem>[
-          SettingsSliderItem(
-            id: 'lookup.popup_max_width',
-            // TODO-1352: 放宽查词弹窗最大宽度的强制上限（1000→2000），让宽屏 / 4K 下
-            // 弹窗能拉到接近占满（实际宽度仍由 resolvePopupRect 按当前屏宽 clamp，
-            // 绝不会超出屏幕）。divisions 保持 10px 步进（1750/175）。
-            title: t.popup_max_width,
-            icon: Icons.open_in_full_outlined,
-            min: 250,
-            max: 2000,
-            divisions: 175,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.popupMaxWidth,
-            label: (double value) => value.round().toString(),
-            onChanged: (SettingsContext settingsContext, double value) {
-              settingsContext.appModel.setPopupMaxWidth(value);
-              settingsContext.refresh();
-            },
-          ),
-          SettingsSliderItem(
-            id: 'lookup.popup_max_height',
-            // TODO-1352 后续：放宽最大高度上限（800→1600），配合高分屏 / 精细调整；
-            // 实际高度仍由 resolvePopupRect 按当前屏高 clamp，绝不会超出屏幕。
-            // 步进保持 10px（1400/140）。
-            title: t.popup_max_height,
-            icon: Icons.height_outlined,
-            min: 200,
-            max: 1600,
-            divisions: 140,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.popupMaxHeight,
-            label: (double value) => value.round().toString(),
-            onChanged: (SettingsContext settingsContext, double value) {
-              settingsContext.appModel.setPopupMaxHeight(value);
-              settingsContext.refresh();
-            },
-          ),
-          // 弹窗尺寸精细化：app 外覆盖查词窗独立尺寸开关 + 仅在开启时展示的宽/高滑杆。
-          // 关闭时跟随上面的 app 内最大宽高（overlayLookupEffectiveSize 解析）。
-          SettingsSwitchItem(
-            id: 'lookup.overlay_lookup_independent_size',
-            title: t.overlay_lookup_independent_size,
-            subtitle: t.overlay_lookup_independent_size_hint,
-            icon: Icons.open_in_new_outlined,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.overlayLookupIndependentSize,
+                settingsContext.appModel.texthookerEnabled,
             onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.appModel
-                  .setOverlayLookupIndependentSize(value);
+              await settingsContext.appModel.setTexthookerEnabled(value);
+              if (value) {
+                TexthookerWsClientManager.instance
+                    .start(settingsContext.appModel.texthookerUrls);
+              } else {
+                await TexthookerWsClientManager.instance.stop();
+              }
               settingsContext.refresh();
-            },
-          ),
-          SettingsSliderItem(
-            id: 'lookup.overlay_lookup_max_width',
-            title: t.overlay_lookup_max_width,
-            icon: Icons.open_in_full_outlined,
-            min: 250,
-            max: 2000,
-            divisions: 175,
-            visible: (SettingsContext settingsContext) =>
-                settingsContext.appModel.overlayLookupIndependentSize,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.overlayLookupMaxWidth,
-            label: (double value) => value.round().toString(),
-            onChanged: (SettingsContext settingsContext, double value) {
-              settingsContext.appModel.setOverlayLookupMaxWidth(value);
-              settingsContext.refresh();
-            },
-          ),
-          SettingsSliderItem(
-            id: 'lookup.overlay_lookup_max_height',
-            title: t.overlay_lookup_max_height,
-            icon: Icons.height_outlined,
-            min: 200,
-            max: 1600,
-            divisions: 140,
-            visible: (SettingsContext settingsContext) =>
-                settingsContext.appModel.overlayLookupIndependentSize,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.overlayLookupMaxHeight,
-            label: (double value) => value.round().toString(),
-            onChanged: (SettingsContext settingsContext, double value) {
-              settingsContext.appModel.setOverlayLookupMaxHeight(value);
-              settingsContext.refresh();
-            },
-          ),
-          // 弹窗尺寸精细化：浏览器扩展弹窗独立尺寸开关 + 仅在开启时展示的宽/高滑杆。
-          // 关闭时跟随 app 内最大宽高（extensionPopupEffectiveSize 解析，经 theme 下发）。
-          SettingsSwitchItem(
-            id: 'lookup.extension_popup_independent_size',
-            title: t.extension_popup_independent_size,
-            subtitle: t.extension_popup_independent_size_hint,
-            icon: Icons.extension_outlined,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.extensionPopupIndependentSize,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.appModel
-                  .setExtensionPopupIndependentSize(value);
-              settingsContext.refresh();
-            },
-          ),
-          SettingsSliderItem(
-            id: 'lookup.extension_popup_max_width',
-            title: t.extension_popup_max_width,
-            icon: Icons.open_in_full_outlined,
-            min: 250,
-            max: 2000,
-            divisions: 175,
-            visible: (SettingsContext settingsContext) =>
-                settingsContext.appModel.extensionPopupIndependentSize,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.extensionPopupMaxWidth,
-            label: (double value) => value.round().toString(),
-            onChanged: (SettingsContext settingsContext, double value) {
-              settingsContext.appModel.setExtensionPopupMaxWidth(value);
-              settingsContext.refresh();
-            },
-          ),
-          SettingsSliderItem(
-            id: 'lookup.extension_popup_max_height',
-            title: t.extension_popup_max_height,
-            icon: Icons.height_outlined,
-            min: 200,
-            max: 1600,
-            divisions: 140,
-            visible: (SettingsContext settingsContext) =>
-                settingsContext.appModel.extensionPopupIndependentSize,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.extensionPopupMaxHeight,
-            label: (double value) => value.round().toString(),
-            onChanged: (SettingsContext settingsContext, double value) {
-              settingsContext.appModel.setExtensionPopupMaxHeight(value);
-              settingsContext.refresh();
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'lookup.popup_instant_scroll',
-            title: t.popup_instant_scroll,
-            subtitle: t.popup_instant_scroll_hint,
-            icon: Icons.animation_outlined,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.popupInstantScroll,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.appModel.setPopupInstantScroll(value);
-              settingsContext.refresh();
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'lookup.popup_bottom_docked',
-            title: t.popup_bottom_docked,
-            subtitle: t.popup_bottom_docked_hint,
-            icon: Icons.vertical_align_bottom_outlined,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.popupBottomDocked,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.appModel.setPopupBottomDocked(value);
-              settingsContext.refresh();
-            },
-          ),
-          // TODO-436/407②/716：是否允许"水平滑动关闭查词弹窗"。这是查词弹窗窗口的
-          // 关闭手势，与弹窗尺寸/停靠同组；同时经 ReaderPlacement 出现在阅读器快捷
-          // 设置的查词段。开启后既驱动弹窗顶栏滑动关闭（[SwipeDismissWrapper]），也让
-          // 桌面在弹窗正文区（全屏 barrier）水平拖过阈关一层（TODO-716，对齐手机手势）。
-          // Windows/Linux 默认关闭（鼠标框选正文与滑动手势同形易误触），其余平台默认
-          // 开启；任何平台均可用弹窗顶栏的 X 关闭。
-          SettingsSwitchItem(
-            id: 'reading_controls.enable_swipe_to_close',
-            title: t.enable_swipe_to_close,
-            icon: Icons.swipe_left_outlined,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.lookup,
-              order: 3,
-            ),
-            value: (SettingsContext settingsContext) =>
-                settingsContext.readerSource.enableSwipeToClose,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.readerSource.setEnableSwipeToClose(value);
-              notifyReaderSettingsChanged(settingsContext);
-            },
-          ),
-          // TODO-625：滑动关闭的灵敏度阈值，与上面的"允许水平滑动关闭查词弹窗"开关
-          // 配套，同属查词弹窗手势行为（ReaderGroup.lookup，紧邻开关），与开关相邻摆放。
-          // id/偏好 key 沿用 'reading_controls.' 前缀作向后兼容（持久化无关展示分类）。
-          SettingsSliderItem(
-            id: 'reading_controls.dismiss_swipe_sensitivity',
-            title: t.dismiss_swipe_sensitivity,
-            icon: Icons.swipe_down_outlined,
-            min: 0.1,
-            max: 1,
-            divisions: 9,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.lookup,
-              order: 4,
-            ),
-            value: (SettingsContext settingsContext) =>
-                settingsContext.readerSource.dismissSwipeSensitivity,
-            label: (double value) => value.toStringAsFixed(1),
-            onChanged: (SettingsContext settingsContext, double value) async {
-              await settingsContext.readerSource
-                  .setDismissSwipeSensitivity(value);
-              notifyReaderSettingsChanged(settingsContext);
             },
           ),
         ],

--- a/hibiki/lib/src/settings/settings_schema_reading.dart
+++ b/hibiki/lib/src/settings/settings_schema_reading.dart
@@ -21,6 +21,204 @@ SettingsDestination buildReadingDestination() {
     summary: t.section_layout,
     icon: Icons.auto_stories_outlined,
     sections: <SettingsSection>[
+      // 「模式与排版方向」：阅读呈现的模式与方向选择（翻页/滚动、竖排、跨页展开、
+      // 竖排取向、振假名）。原「布局与显示」组重命名并把翻页/滚动模式提到首位；纯
+      // 展示重组：item id、持久化 key、ReaderPlacement 全部不变。
+      SettingsSection(
+        title: t.reading_section_mode,
+        items: <SettingsItem>[
+          SettingsSegmentedItem<String>(
+            id: 'reading_display.view_mode',
+            title: t.ttu_view_mode_label,
+            icon: Icons.chrome_reader_mode_outlined,
+            controlBelow: true,
+            // TODO-725：翻页/滚动从「外观」迁到「布局与显示」组（用户最直指的
+            // 「滚动/翻页应放进布局与显示」）。仅改展示分类/排序，onChanged 不变。
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 0,
+            ),
+            options: <SettingsSegmentOption<String>>[
+              SettingsSegmentOption<String>(
+                value: 'paginated',
+                label: t.ttu_paginated,
+                tooltip: t.ttu_paginated,
+              ),
+              SettingsSegmentOption<String>(
+                value: 'continuous',
+                label: t.ttu_scroll,
+                tooltip: t.ttu_scroll,
+              ),
+              // TODO-909: third book view-mode. M0 exposes it so the device
+              // Gate can select VN; the 6 VN-specific sub-settings are M1.
+              SettingsSegmentOption<String>(
+                value: 'vn',
+                label: t.ttu_vn,
+                tooltip: t.ttu_vn,
+              ),
+            ],
+            selected: (SettingsContext c) => c.readerSource.ttuViewMode,
+            onChanged: (SettingsContext c, String v) {
+              c.readerSource.setTtuViewMode(v);
+              notifyReaderLayoutChanged(c);
+            },
+          ),
+          SettingsSegmentedItem<String>(
+            id: 'reading_display.writing_mode',
+            title: t.ttu_writing_direction,
+            icon: Icons.text_rotate_vertical,
+            controlBelow: true,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 4,
+            ),
+            options: <SettingsSegmentOption<String>>[
+              SettingsSegmentOption<String>(
+                value: 'horizontal-tb',
+                label: t.ttu_horizontal,
+                tooltip: t.ttu_horizontal,
+              ),
+              SettingsSegmentOption<String>(
+                value: 'vertical-rl',
+                label: t.ttu_vertical,
+                tooltip: t.ttu_vertical,
+              ),
+            ],
+            selected: (SettingsContext c) => c.readerSource.ttuWritingMode,
+            onChanged: (SettingsContext c, String v) {
+              c.readerSource.setTtuWritingMode(v);
+              notifyReaderLayoutChanged(c);
+            },
+          ),
+          SettingsSegmentedItem<String>(
+            id: 'reading_display.spread_mode',
+            title: t.spread_mode,
+            icon: Icons.menu_book_outlined,
+            controlBelow: true,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 5,
+            ),
+            options: <SettingsSegmentOption<String>>[
+              SettingsSegmentOption<String>(
+                value: 'off',
+                label: t.spread_off,
+                tooltip: t.spread_off,
+              ),
+              SettingsSegmentOption<String>(
+                value: 'on',
+                label: t.spread_on,
+                tooltip: t.spread_on,
+              ),
+              SettingsSegmentOption<String>(
+                value: 'auto',
+                label: t.spread_auto,
+                tooltip: t.spread_auto,
+              ),
+            ],
+            selected: (SettingsContext c) => c.readerSource.ttuSpreadMode,
+            onChanged: (SettingsContext c, String v) {
+              c.readerSource.setTtuSpreadMode(v);
+              notifyReaderLayoutChanged(c);
+            },
+          ),
+          SettingsSegmentedItem<String>(
+            id: 'reading_display.spread_direction',
+            title: t.spread_direction,
+            icon: Icons.swap_horiz_outlined,
+            controlBelow: true,
+            visible: (SettingsContext c) =>
+                c.readerSource.ttuSpreadMode != 'off',
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 6,
+            ),
+            options: <SettingsSegmentOption<String>>[
+              SettingsSegmentOption<String>(
+                value: 'rtl',
+                label: 'RTL',
+                tooltip: t.spread_direction_rtl,
+              ),
+              SettingsSegmentOption<String>(
+                value: 'ltr',
+                label: 'LTR',
+                tooltip: t.spread_direction_ltr,
+              ),
+            ],
+            selected: (SettingsContext c) => c.readerSource.ttuSpreadDirection,
+            onChanged: (SettingsContext c, String v) {
+              c.readerSource.setTtuSpreadDirection(v);
+              notifyReaderLayoutChanged(c);
+            },
+          ),
+          SettingsSegmentedItem<String>(
+            id: 'reading_display.vert_text_orient',
+            title: t.ttu_vert_text_orient,
+            icon: Icons.text_rotation_none,
+            controlBelow: true,
+            visible: isVertical,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 13,
+            ),
+            options: <SettingsSegmentOption<String>>[
+              SettingsSegmentOption<String>(
+                value: 'mixed',
+                label: t.ttu_orient_mixed,
+                tooltip: t.ttu_orient_mixed,
+              ),
+              SettingsSegmentOption<String>(
+                value: 'upright',
+                label: t.ttu_orient_upright,
+                tooltip: t.ttu_orient_upright,
+              ),
+            ],
+            selected: (SettingsContext c) =>
+                c.readerSource.ttuVerticalTextOrientation,
+            onChanged: (SettingsContext c, String v) {
+              c.readerSource.setTtuVerticalTextOrientation(v);
+              notifyReaderSettingsChanged(c);
+            },
+          ),
+          SettingsSegmentedItem<String>(
+            id: 'reading_display.furigana_mode',
+            title: t.ttu_furigana_mode,
+            icon: Icons.translate_outlined,
+            controlBelow: true,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 12,
+            ),
+            options: <SettingsSegmentOption<String>>[
+              SettingsSegmentOption<String>(
+                value: 'show',
+                label: t.ttu_furigana_show,
+                tooltip: t.ttu_furigana_show,
+              ),
+              SettingsSegmentOption<String>(
+                value: 'hide',
+                label: t.ttu_furigana_hide,
+                tooltip: t.ttu_furigana_hide,
+              ),
+              SettingsSegmentOption<String>(
+                value: 'partial',
+                label: t.ttu_furigana_partial,
+                tooltip: t.ttu_furigana_partial,
+              ),
+              SettingsSegmentOption<String>(
+                value: 'toggle',
+                label: t.ttu_furigana_toggle,
+                tooltip: t.ttu_furigana_toggle,
+              ),
+            ],
+            selected: (SettingsContext c) => c.readerSource.ttuFuriganaMode,
+            onChanged: (SettingsContext c, String v) {
+              c.readerSource.setTtuFuriganaMode(v);
+              notifyReaderSettingsChanged(c);
+            },
+          ),
+        ],
+      ),
       SettingsSection(
         title: t.section_typography,
         items: <SettingsItem>[
@@ -104,6 +302,29 @@ SettingsDestination buildReadingDestination() {
               notifyReaderSettingsChanged(c);
             },
           ),
+          // 「每页列数」移到边距之前（先定列、再定边距）：仅翻页模式生效（isPaginated
+          // 门控）。id / 持久化 key / ReaderPlacement 不变，只调组内相对位置。
+          SettingsStepperItem(
+            id: 'reading_display.page_columns',
+            title: t.columns_per_page,
+            icon: Icons.view_column_outlined,
+            visible: isPaginated,
+            min: 0,
+            max: 4,
+            step: 1,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 7,
+            ),
+            value: (SettingsContext c) =>
+                c.readerSource.ttuPageColumns.toDouble(),
+            format: (double v) =>
+                v.round() == 0 ? t.ttu_page_columns_auto : '${v.round()}',
+            onChanged: (SettingsContext c, double v) {
+              c.readerSource.setTtuPageColumns(v.round());
+              notifyReaderLayoutChanged(c);
+            },
+          ),
           // TODO-362（PR#3 响应式页边距）：四个边距都是百分比（左右 = vw / 上下 = vh），
           // 默认左右各 2%、上下 0%。范围 0~50%，禁止负值（负值与百分比语义冲突，且
           // CSS padding 不接受负值）。格式带 `%` 提示用户这是百分比。
@@ -179,328 +400,12 @@ SettingsDestination buildReadingDestination() {
               notifyReaderSettingsChanged(c);
             },
           ),
-          SettingsStepperItem(
-            id: 'reading_display.page_columns',
-            title: t.columns_per_page,
-            icon: Icons.view_column_outlined,
-            visible: isPaginated,
-            min: 0,
-            max: 4,
-            step: 1,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 7,
-            ),
-            value: (SettingsContext c) =>
-                c.readerSource.ttuPageColumns.toDouble(),
-            format: (double v) =>
-                v.round() == 0 ? t.ttu_page_columns_auto : '${v.round()}',
-            onChanged: (SettingsContext c, double v) {
-              c.readerSource.setTtuPageColumns(v.round());
-              notifyReaderLayoutChanged(c);
-            },
-          ),
-        ],
-      ),
-      SettingsSection(
-        title: t.section_layout,
-        items: <SettingsItem>[
-          SettingsSegmentedItem<String>(
-            id: 'reading_display.spread_mode',
-            title: t.spread_mode,
-            icon: Icons.menu_book_outlined,
-            controlBelow: true,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 5,
-            ),
-            options: <SettingsSegmentOption<String>>[
-              SettingsSegmentOption<String>(
-                value: 'off',
-                label: t.spread_off,
-                tooltip: t.spread_off,
-              ),
-              SettingsSegmentOption<String>(
-                value: 'on',
-                label: t.spread_on,
-                tooltip: t.spread_on,
-              ),
-              SettingsSegmentOption<String>(
-                value: 'auto',
-                label: t.spread_auto,
-                tooltip: t.spread_auto,
-              ),
-            ],
-            selected: (SettingsContext c) => c.readerSource.ttuSpreadMode,
-            onChanged: (SettingsContext c, String v) {
-              c.readerSource.setTtuSpreadMode(v);
-              notifyReaderLayoutChanged(c);
-            },
-          ),
-          SettingsSegmentedItem<String>(
-            id: 'reading_display.spread_direction',
-            title: t.spread_direction,
-            icon: Icons.swap_horiz_outlined,
-            controlBelow: true,
-            visible: (SettingsContext c) =>
-                c.readerSource.ttuSpreadMode != 'off',
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 6,
-            ),
-            options: <SettingsSegmentOption<String>>[
-              SettingsSegmentOption<String>(
-                value: 'rtl',
-                label: 'RTL',
-                tooltip: t.spread_direction_rtl,
-              ),
-              SettingsSegmentOption<String>(
-                value: 'ltr',
-                label: 'LTR',
-                tooltip: t.spread_direction_ltr,
-              ),
-            ],
-            selected: (SettingsContext c) => c.readerSource.ttuSpreadDirection,
-            onChanged: (SettingsContext c, String v) {
-              c.readerSource.setTtuSpreadDirection(v);
-              notifyReaderLayoutChanged(c);
-            },
-          ),
-          SettingsSegmentedItem<String>(
-            id: 'reading_display.writing_mode',
-            title: t.ttu_writing_direction,
-            icon: Icons.text_rotate_vertical,
-            controlBelow: true,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 4,
-            ),
-            options: <SettingsSegmentOption<String>>[
-              SettingsSegmentOption<String>(
-                value: 'horizontal-tb',
-                label: t.ttu_horizontal,
-                tooltip: t.ttu_horizontal,
-              ),
-              SettingsSegmentOption<String>(
-                value: 'vertical-rl',
-                label: t.ttu_vertical,
-                tooltip: t.ttu_vertical,
-              ),
-            ],
-            selected: (SettingsContext c) => c.readerSource.ttuWritingMode,
-            onChanged: (SettingsContext c, String v) {
-              c.readerSource.setTtuWritingMode(v);
-              notifyReaderLayoutChanged(c);
-            },
-          ),
-          SettingsSegmentedItem<String>(
-            id: 'reading_display.view_mode',
-            title: t.ttu_view_mode_label,
-            icon: Icons.chrome_reader_mode_outlined,
-            controlBelow: true,
-            // TODO-725：翻页/滚动从「外观」迁到「布局与显示」组（用户最直指的
-            // 「滚动/翻页应放进布局与显示」）。仅改展示分类/排序，onChanged 不变。
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 0,
-            ),
-            options: <SettingsSegmentOption<String>>[
-              SettingsSegmentOption<String>(
-                value: 'paginated',
-                label: t.ttu_paginated,
-                tooltip: t.ttu_paginated,
-              ),
-              SettingsSegmentOption<String>(
-                value: 'continuous',
-                label: t.ttu_scroll,
-                tooltip: t.ttu_scroll,
-              ),
-              // TODO-909: third book view-mode. M0 exposes it so the device
-              // Gate can select VN; the 6 VN-specific sub-settings are M1.
-              SettingsSegmentOption<String>(
-                value: 'vn',
-                label: t.ttu_vn,
-                tooltip: t.ttu_vn,
-              ),
-            ],
-            selected: (SettingsContext c) => c.readerSource.ttuViewMode,
-            onChanged: (SettingsContext c, String v) {
-              c.readerSource.setTtuViewMode(v);
-              notifyReaderLayoutChanged(c);
-            },
-          ),
-          SettingsSegmentedItem<String>(
-            id: 'reading_display.vert_text_orient',
-            title: t.ttu_vert_text_orient,
-            icon: Icons.text_rotation_none,
-            controlBelow: true,
-            visible: isVertical,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 13,
-            ),
-            options: <SettingsSegmentOption<String>>[
-              SettingsSegmentOption<String>(
-                value: 'mixed',
-                label: t.ttu_orient_mixed,
-                tooltip: t.ttu_orient_mixed,
-              ),
-              SettingsSegmentOption<String>(
-                value: 'upright',
-                label: t.ttu_orient_upright,
-                tooltip: t.ttu_orient_upright,
-              ),
-            ],
-            selected: (SettingsContext c) =>
-                c.readerSource.ttuVerticalTextOrientation,
-            onChanged: (SettingsContext c, String v) {
-              c.readerSource.setTtuVerticalTextOrientation(v);
-              notifyReaderSettingsChanged(c);
-            },
-          ),
-          SettingsSegmentedItem<String>(
-            id: 'reading_display.furigana_mode',
-            title: t.ttu_furigana_mode,
-            icon: Icons.translate_outlined,
-            controlBelow: true,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 12,
-            ),
-            options: <SettingsSegmentOption<String>>[
-              SettingsSegmentOption<String>(
-                value: 'show',
-                label: t.ttu_furigana_show,
-                tooltip: t.ttu_furigana_show,
-              ),
-              SettingsSegmentOption<String>(
-                value: 'hide',
-                label: t.ttu_furigana_hide,
-                tooltip: t.ttu_furigana_hide,
-              ),
-              SettingsSegmentOption<String>(
-                value: 'partial',
-                label: t.ttu_furigana_partial,
-                tooltip: t.ttu_furigana_partial,
-              ),
-              SettingsSegmentOption<String>(
-                value: 'toggle',
-                label: t.ttu_furigana_toggle,
-                tooltip: t.ttu_furigana_toggle,
-              ),
-            ],
-            selected: (SettingsContext c) => c.readerSource.ttuFuriganaMode,
-            onChanged: (SettingsContext c, String v) {
-              c.readerSource.setTtuFuriganaMode(v);
-              notifyReaderSettingsChanged(c);
-            },
-          ),
-        ],
-      ),
-      SettingsSection(
-        title: t.section_advanced_typography,
-        collapsedByDefault: true,
-        items: <SettingsItem>[
-          SettingsSwitchItem(
-            id: 'reading_display.text_justify',
-            title: t.ttu_text_justify,
-            icon: Icons.format_align_justify,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 14,
-            ),
-            value: (SettingsContext c) =>
-                c.readerSource.ttuEnableTextJustification,
-            onChanged: (SettingsContext c, bool value) {
-              c.readerSource.setTtuEnableTextJustification(value);
-              notifyReaderSettingsChanged(c);
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'reading_display.vert_kerning',
-            title: t.ttu_vert_kerning,
-            icon: Icons.space_bar,
-            visible: isVertical,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 15,
-            ),
-            value: (SettingsContext c) =>
-                c.readerSource.ttuEnableVerticalFontKerning,
-            onChanged: (SettingsContext c, bool value) {
-              c.readerSource.setTtuEnableVerticalFontKerning(value);
-              notifyReaderSettingsChanged(c);
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'reading_display.font_vpal',
-            title: t.ttu_font_vpal,
-            icon: Icons.format_shapes,
-            visible: isVertical,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 16,
-            ),
-            value: (SettingsContext c) => c.readerSource.ttuEnableFontVPAL,
-            onChanged: (SettingsContext c, bool value) {
-              c.readerSource.setTtuEnableFontVPAL(value);
-              notifyReaderSettingsChanged(c);
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'reading_display.prioritize_reader_styles',
-            title: t.ttu_reader_styles,
-            icon: Icons.style_outlined,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 17,
-            ),
-            value: (SettingsContext c) =>
-                c.readerSource.ttuPrioritizeReaderStyles,
-            onChanged: (SettingsContext c, bool value) {
-              c.readerSource.setTtuPrioritizeReaderStyles(value);
-              notifyReaderLayoutChanged(c);
-            },
-          ),
-          // TODO-861④（移植 Hoshi `f286108`）：图片防剧透模糊。加 `blurred` 类需重跑
-          // 分页脚本（非纯 CSS），故走结构 reload（notifyReaderLayoutChanged）。
-          SettingsSwitchItem(
-            id: 'reading_display.blur_images',
-            title: t.ttu_blur_images,
-            icon: Icons.blur_on_outlined,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 19,
-            ),
-            value: (SettingsContext c) => c.readerSource.ttuBlurImages,
-            onChanged: (SettingsContext c, bool value) {
-              c.readerSource.setTtuBlurImages(value);
-              notifyReaderLayoutChanged(c);
-            },
-          ),
-          // TODO-1128（受限方案 A）：把 0 字符单图 spine 章并入相邻正文章连续显示，
-          // 不再各占一页/一条目录。结构性布局键（改虚拟页映射 + 注入章 DOM），故走
-          // notifyReaderLayoutChanged（重建 spread map + 重排），默认关。
-          SettingsSwitchItem(
-            id: 'reading_display.merge_image_pages',
-            title: t.ttu_merge_image_pages,
-            subtitle: t.ttu_merge_image_pages_subtitle,
-            icon: Icons.collections_bookmark_outlined,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 20,
-            ),
-            value: (SettingsContext c) => c.readerSource.ttuMergeImagePages,
-            onChanged: (SettingsContext c, bool value) {
-              c.readerSource.setTtuMergeImagePages(value);
-              notifyReaderLayoutChanged(c);
-            },
-          ),
         ],
       ),
       // 原「导航」13 项混杂平铺，拆两组：阅读界面（进度条/悬浮 chrome/底栏提示/
-      // 常亮）与翻页与交互（点击高亮/音量翻页/滚轮/滑动灵敏度）。纯展示重组：
-      // item id、持久化 key、ReaderPlacement 全部不变（快捷面板分组不动）。
+      // 常亮 + 从「底栏布局」并入的「反转阅读器底栏」）与翻页与交互（点击高亮/音量
+      // 翻页/滚轮/滑动灵敏度）。纯展示重组：item id、持久化 key、ReaderPlacement
+      // 全部不变（快捷面板分组不动）。
       SettingsSection(
         title: t.settings_section_reader_chrome,
         items: <SettingsItem>[
@@ -651,6 +556,25 @@ SettingsDestination buildReadingDestination() {
                 settingsContext.readerSource.keepScreenAwake,
             onChanged: setKeepScreenAwake,
           ),
+          // TODO-830：「反转阅读器底栏」（纯位置镜像，仅左右调换底栏控件位置，左右手
+          // 布局偏好，与翻页方向无关）。原独占一个「底栏布局」单项分组（欠填充结构），
+          // 并入「阅读界面」尾部。id/持久化 key/ReaderPlacement 全不变，仅换 UI 分组。
+          SettingsSwitchItem(
+            id: 'reading_display.reverse_reader_bottom_bar',
+            title: t.reverse_reader_bottom_bar,
+            icon: Icons.swap_horiz_outlined,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.behavior,
+              // order 13：behavior 组内已用 0-9/11/12（10 在 listening），取末位
+              // 空号，避免与 volume_page_turning_speed(6)/keep_screen_awake(7) 撞号。
+              order: 13,
+            ),
+            value: (SettingsContext c) => c.appModel.reverseReaderBottomBar,
+            onChanged: (SettingsContext c, bool value) {
+              c.appModel.toggleReverseReaderBottomBar();
+              notifyReaderChromeChanged(c);
+            },
+          ),
         ],
       ),
       SettingsSection(
@@ -736,7 +660,7 @@ SettingsDestination buildReadingDestination() {
       // TODO-745 / TODO-830：「翻页方向」分组只收**真正反转翻页/句子方向**的
       // 开关（音量键 / 滑动 / 键盘方向键 + 反转底栏前进后退按钮）。原 TODO-745 误把
       // 「反转阅读器底栏」（纯左右镜像底栏控件位置、与翻页方向无关）塞进来，
-      // 现移到下方独立的「底栏布局」分组（id/持久化 key 不变，仅换 UI 分组）。
+      // 现移到上方「阅读界面」分组（id/持久化 key 不变，仅换 UI 分组）。
       // 纯展示重组：各开关的 id/title/value/onChanged 与持久化 key、默认值、
       // 消费点全不变；面板分组（ReaderGroup.behavior）也不动。
       SettingsSection(
@@ -807,26 +731,106 @@ SettingsDestination buildReadingDestination() {
           ),
         ],
       ),
-      // TODO-830：「底栏布局」分组——只放纯位置镜像的「反转阅读器底栏」（与
-      // 翻页方向无关，仅左右调换底栏控件位置，左右手布局偏好）。
+      // 「高级选项」现移到最后（低频排版微调）：文字两端对齐、竖排字距/VPAL、
+      // 优先阅读器样式、图片防剧透模糊、合并插图页。collapsedByDefault 与各项
+      // id/持久化 key/ReaderPlacement 全不变，仅调 section 相对位置。
       SettingsSection(
-        title: t.section_bottom_bar_layout,
+        title: t.section_advanced_typography,
         collapsedByDefault: true,
         items: <SettingsItem>[
           SettingsSwitchItem(
-            id: 'reading_display.reverse_reader_bottom_bar',
-            title: t.reverse_reader_bottom_bar,
-            icon: Icons.swap_horiz_outlined,
+            id: 'reading_display.text_justify',
+            title: t.ttu_text_justify,
+            icon: Icons.format_align_justify,
             reader: const ReaderPlacement(
-              group: ReaderGroup.behavior,
-              // order 13：behavior 组内已用 0-9/11/12（10 在 listening），取末位
-              // 空号，避免与 volume_page_turning_speed(6)/keep_screen_awake(7) 撞号。
-              order: 13,
+              group: ReaderGroup.layout,
+              order: 14,
             ),
-            value: (SettingsContext c) => c.appModel.reverseReaderBottomBar,
+            value: (SettingsContext c) =>
+                c.readerSource.ttuEnableTextJustification,
             onChanged: (SettingsContext c, bool value) {
-              c.appModel.toggleReverseReaderBottomBar();
-              notifyReaderChromeChanged(c);
+              c.readerSource.setTtuEnableTextJustification(value);
+              notifyReaderSettingsChanged(c);
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'reading_display.vert_kerning',
+            title: t.ttu_vert_kerning,
+            icon: Icons.space_bar,
+            visible: isVertical,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 15,
+            ),
+            value: (SettingsContext c) =>
+                c.readerSource.ttuEnableVerticalFontKerning,
+            onChanged: (SettingsContext c, bool value) {
+              c.readerSource.setTtuEnableVerticalFontKerning(value);
+              notifyReaderSettingsChanged(c);
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'reading_display.font_vpal',
+            title: t.ttu_font_vpal,
+            icon: Icons.format_shapes,
+            visible: isVertical,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 16,
+            ),
+            value: (SettingsContext c) => c.readerSource.ttuEnableFontVPAL,
+            onChanged: (SettingsContext c, bool value) {
+              c.readerSource.setTtuEnableFontVPAL(value);
+              notifyReaderSettingsChanged(c);
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'reading_display.prioritize_reader_styles',
+            title: t.ttu_reader_styles,
+            icon: Icons.style_outlined,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 17,
+            ),
+            value: (SettingsContext c) =>
+                c.readerSource.ttuPrioritizeReaderStyles,
+            onChanged: (SettingsContext c, bool value) {
+              c.readerSource.setTtuPrioritizeReaderStyles(value);
+              notifyReaderLayoutChanged(c);
+            },
+          ),
+          // TODO-861④（移植 Hoshi `f286108`）：图片防剧透模糊。加 `blurred` 类需重跑
+          // 分页脚本（非纯 CSS），故走结构 reload（notifyReaderLayoutChanged）。
+          SettingsSwitchItem(
+            id: 'reading_display.blur_images',
+            title: t.ttu_blur_images,
+            icon: Icons.blur_on_outlined,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 19,
+            ),
+            value: (SettingsContext c) => c.readerSource.ttuBlurImages,
+            onChanged: (SettingsContext c, bool value) {
+              c.readerSource.setTtuBlurImages(value);
+              notifyReaderLayoutChanged(c);
+            },
+          ),
+          // TODO-1128（受限方案 A）：把 0 字符单图 spine 章并入相邻正文章连续显示，
+          // 不再各占一页/一条目录。结构性布局键（改虚拟页映射 + 注入章 DOM），故走
+          // notifyReaderLayoutChanged（重建 spread map + 重排），默认关。
+          SettingsSwitchItem(
+            id: 'reading_display.merge_image_pages',
+            title: t.ttu_merge_image_pages,
+            subtitle: t.ttu_merge_image_pages_subtitle,
+            icon: Icons.collections_bookmark_outlined,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 20,
+            ),
+            value: (SettingsContext c) => c.readerSource.ttuMergeImagePages,
+            onChanged: (SettingsContext c, bool value) {
+              c.readerSource.setTtuMergeImagePages(value);
+              notifyReaderLayoutChanged(c);
             },
           ),
         ],

--- a/hibiki/lib/src/settings/settings_schema_system.dart
+++ b/hibiki/lib/src/settings/settings_schema_system.dart
@@ -15,9 +15,92 @@ SettingsDestination buildSystemDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.system,
     title: t.settings_destination_system,
-    summary: t.section_update,
+    summary: t.settings_destination_system_summary,
     icon: Icons.settings_suggest_outlined,
     sections: <SettingsSection>[
+      SettingsSection(
+        // 文案统一（阶段 F/G）：本 section 原标题与 destination 标题同为「系统」，
+        // 搜索面包屑显示「系统 › 系统」语义重复。改为「通用」——本区聚的是版本 /
+        // 内存 / 手柄导航 / 快捷键 / GitHub 这类通用应用项。框架层另有面包屑去重
+        // （settingsSearchBreadcrumb），双保险消灭整类重复。
+        title: t.settings_section_general,
+        items: <SettingsItem>[
+          // 「界面语言」（id 'appearance.language'）已归位到「外观 · 界面」分区
+          //（与主题/明暗/缩放并列）；id 前缀本就是 appearance，此前放系统分类
+          // 是历史错配。
+          SettingsNavigationItem(
+            id: 'system.keyboard_shortcuts',
+            title: t.shortcut_settings_title,
+            // 「实验性」后缀已摘除（用户决策）：改键/冲突重分配/可视化键盘与
+            // 手柄图/三通道实时录键均已齐备，页面不再是实验功能。
+            icon: Icons.keyboard_outlined,
+            onTap: (SettingsContext settingsContext) async {
+              await pushSettingsPage(
+                settingsContext,
+                (_) => const ShortcutSettingsPage(),
+              );
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'system.focus_navigation',
+            title: t.focus_navigation_enabled,
+            subtitle: t.focus_navigation_enabled_hint +
+                t.settings_experimental_suffix,
+            icon: Icons.gamepad_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.experimentalFocusNavigationEnabled,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel
+                  .setExperimentalFocusNavigationEnabled(value);
+              settingsContext.refresh();
+            },
+          ),
+          // 「启动时打开查词」从「外观 · 应用」分区归位到此处（启动落地页/导航行为，
+          // 与键盘/手柄焦点导航同属通用应用项）。item id 保持 'appearance.
+          // startup_default_dictionary_tab' 不变（历史命名，非持久化 key），仅换分区。
+          SettingsSwitchItem(
+            id: 'appearance.startup_default_dictionary_tab',
+            title: t.startup_default_dictionary_tab,
+            subtitle: t.startup_default_dictionary_tab_hint,
+            icon: Icons.manage_search_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.startupDefaultDictionaryTab,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel
+                  .setStartupDefaultDictionaryTab(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'system.low_memory_mode',
+            title: t.low_memory_mode,
+            subtitle: t.low_memory_mode_hint,
+            icon: Icons.memory_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.lowMemoryMode,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel.setLowMemoryMode(value);
+              settingsContext.refresh();
+            },
+          ),
+          SettingsCustomItem(
+            id: 'system.app_version',
+            icon: Icons.info_outline,
+            builder: _buildRuntimeAppVersionRow,
+          ),
+          SettingsActionItem(
+            id: 'system.github',
+            title: t.options_github,
+            icon: Icons.public_outlined,
+            onTap: (_) async {
+              await launchUrl(
+                Uri.parse('https://github.com/hajisensai/hibiki'),
+                mode: LaunchMode.externalApplication,
+              );
+            },
+          ),
+        ],
+      ),
       SettingsSection(
         title: t.section_update,
         // 更新分区在所有平台可见（至少能「检查→打开发布页」）；自动安装开关
@@ -124,73 +207,6 @@ SettingsDestination buildSystemDestination() {
                   SnackBar(content: Text(t.update_custom_proxy_invalid)),
                 );
               }
-            },
-          ),
-        ],
-      ),
-      SettingsSection(
-        // 文案统一（阶段 F/G）：本 section 原标题与 destination 标题同为「系统」，
-        // 搜索面包屑显示「系统 › 系统」语义重复。改为「通用」——本区聚的是版本 /
-        // 内存 / 手柄导航 / 快捷键 / GitHub 这类通用应用项。框架层另有面包屑去重
-        // （settingsSearchBreadcrumb），双保险消灭整类重复。
-        title: t.settings_section_general,
-        items: <SettingsItem>[
-          // 「界面语言」（id 'appearance.language'）已归位到「外观 · 界面」分区
-          //（与主题/明暗/缩放并列）；id 前缀本就是 appearance，此前放系统分类
-          // 是历史错配。
-          SettingsCustomItem(
-            id: 'system.app_version',
-            icon: Icons.info_outline,
-            builder: _buildRuntimeAppVersionRow,
-          ),
-          SettingsSwitchItem(
-            id: 'system.low_memory_mode',
-            title: t.low_memory_mode,
-            subtitle: t.low_memory_mode_hint,
-            icon: Icons.memory_outlined,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.lowMemoryMode,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.appModel.setLowMemoryMode(value);
-              settingsContext.refresh();
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'system.focus_navigation',
-            title: t.focus_navigation_enabled,
-            subtitle: t.focus_navigation_enabled_hint +
-                t.settings_experimental_suffix,
-            icon: Icons.gamepad_outlined,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.experimentalFocusNavigationEnabled,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.appModel
-                  .setExperimentalFocusNavigationEnabled(value);
-              settingsContext.refresh();
-            },
-          ),
-          SettingsNavigationItem(
-            id: 'system.keyboard_shortcuts',
-            title: t.shortcut_settings_title,
-            // 「实验性」后缀已摘除（用户决策）：改键/冲突重分配/可视化键盘与
-            // 手柄图/三通道实时录键均已齐备，页面不再是实验功能。
-            icon: Icons.keyboard_outlined,
-            onTap: (SettingsContext settingsContext) async {
-              await pushSettingsPage(
-                settingsContext,
-                (_) => const ShortcutSettingsPage(),
-              );
-            },
-          ),
-          SettingsActionItem(
-            id: 'system.github',
-            title: t.options_github,
-            icon: Icons.public_outlined,
-            onTap: (_) async {
-              await launchUrl(
-                Uri.parse('https://github.com/hajisensai/hibiki'),
-                mode: LaunchMode.externalApplication,
-              );
             },
           ),
         ],

--- a/hibiki/lib/src/settings/settings_schema_video.dart
+++ b/hibiki/lib/src/settings/settings_schema_video.dart
@@ -43,6 +43,21 @@ SettingsDestination buildVideoDestination() {
               await settingsContext.appModel.setVideoAutoPlayNext(value);
             },
           ),
+          // 「单文件循环」从「画质」分区移到「播放」分区（语义归属播放行为，紧随自动
+          // 连播）。VideoPlacement（mpv/playback order 200）不变——面板投影位置照旧，
+          // 仅调全局设置页所属 SettingsSection。
+          _videoMpvSwitchItem(
+            id: 'video.quality.loop',
+            title: t.video_setting_mpv_loop,
+            icon: Icons.repeat_outlined,
+            video: VideoPlacement(
+              group: VideoGroup.mpv,
+              order: 200,
+              section: t.video_setting_mpv_group_playback,
+            ),
+            read: (VideoMpvConfig c) => c.loopFile,
+            write: (VideoMpvConfig c, bool v) => c.copyWith(loopFile: v),
+          ),
           // 沉浸/画面缩放都是长标签四态：dropdown 渲染（TODO-209，分段条在窄 pane
           // 只能横向滚动裁断）。
           SettingsSegmentedItem<VideoImmersiveMode>(
@@ -187,22 +202,6 @@ SettingsDestination buildVideoDestination() {
               );
             },
           ),
-          SettingsSwitchItem(
-            id: 'video.playback.pause_at_subtitle_end',
-            title: t.playback_auto_pause,
-            icon: Icons.pause_circle_outline,
-            // 面板里按语义归「字幕」分类（句尾自动暂停按字幕 cue 边界暂停）。
-            video: VideoPlacement(group: VideoGroup.subtitle, order: 30),
-            value: (SettingsContext settingsContext) =>
-                currentVideoAsbConfig(settingsContext).pauseAtSubtitleEnd,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await commitVideoAsbConfig(
-                settingsContext,
-                (VideoAsbplayerConfig c) =>
-                    c.copyWith(pauseAtSubtitleEnd: value),
-              );
-            },
-          ),
           // 「重置控件布局」原独占一个「控件」section（仅此一项）；单项撑一个分区
           // 是欠填充结构，并入「播放」尾部。面板里归「控制」分类、排在拖拽编辑器后。
           SettingsActionItem(
@@ -299,20 +298,8 @@ SettingsDestination buildVideoDestination() {
             read: (VideoMpvConfig c) => c.deband,
             write: (VideoMpvConfig c, bool v) => c.copyWith(deband: v),
           ),
-          _videoMpvSwitchItem(
-            id: 'video.quality.loop',
-            title: t.video_setting_mpv_loop,
-            icon: Icons.repeat_outlined,
-            video: VideoPlacement(
-              group: VideoGroup.mpv,
-              order: 200,
-              section: t.video_setting_mpv_group_playback,
-            ),
-            read: (VideoMpvConfig c) => c.loopFile,
-            write: (VideoMpvConfig c, bool v) => c.copyWith(loopFile: v),
-          ),
           // TODO-1247：把播放页内 mpv 画质组里的其余布尔项平移到首页（纯 pref），与播放
-          // 页内设置同源，消除「首页改不了」。
+          // 页内设置同源，消除「首页改不了」。（「单文件循环」已移到「播放」分区。）
           _videoMpvSwitchItem(
             id: 'video.quality.dither',
             title: t.video_setting_mpv_dither,
@@ -610,6 +597,24 @@ SettingsDestination buildVideoDestination() {
       SettingsSection(
         title: t.section_video_subtitles,
         items: <SettingsItem>[
+          // 「字幕暂停播放模式」从「播放」分区移到「字幕」分区（句尾自动暂停按字幕 cue
+          // 边界暂停，语义归字幕）。VideoPlacement（subtitle order 30）不变——面板投影
+          // 位置照旧，仅调全局设置页所属 SettingsSection。
+          SettingsSwitchItem(
+            id: 'video.playback.pause_at_subtitle_end',
+            title: t.playback_auto_pause,
+            icon: Icons.pause_circle_outline,
+            video: VideoPlacement(group: VideoGroup.subtitle, order: 30),
+            value: (SettingsContext settingsContext) =>
+                currentVideoAsbConfig(settingsContext).pauseAtSubtitleEnd,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await commitVideoAsbConfig(
+                settingsContext,
+                (VideoAsbplayerConfig c) =>
+                    c.copyWith(pauseAtSubtitleEnd: value),
+              );
+            },
+          ),
           // TODO-840 Part B：遮蔽模式三态选择器——不遮蔽 / 模糊（听力沉浸）/ 隐藏。
           // 持久化是 preferences 层 lazy 投影（见
           // [PreferencesRepository.videoSubtitleObscureMode]），无新 Drift schema。

--- a/hibiki/test/settings/settings_destination_order_guard_test.dart
+++ b/hibiki/test/settings/settings_destination_order_guard_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 阶段 G 守卫：`buildSettingsSchema` 顶层大类顺序（内容类在前、外观/系统类殿后）。
+///
+/// 这是「用户决策过的位置」——把最常改的阅读 / 查词 / 制卡 / 视频 / 听书 / 下载放最前，
+/// 外观 / Profile / 同步备份 / 互联 / 系统殿后。锁死顺序让未来漂移必须是有意为之
+/// （改 `buildSettingsSchema` 时同步改本守卫）。用源码顺序断言（零 harness 依赖：
+/// 无需构造 SettingsContext + AppModel 即可校验 destination 列表次序）。
+void main() {
+  test('buildSettingsSchema keeps the task-first top-level destination order',
+      () {
+    final String src = File('lib/src/settings/settings_schema.dart')
+        .readAsStringSync()
+        .replaceAll('\r\n', '\n');
+    final int fnStart =
+        src.indexOf('List<SettingsDestination> buildSettingsSchema');
+    expect(fnStart, isNonNegative, reason: 'buildSettingsSchema must exist');
+    final int fnEnd = src.indexOf('\n}', fnStart);
+    expect(fnEnd, greaterThan(fnStart));
+    final String body = src.substring(fnStart, fnEnd);
+
+    const List<String> expectedOrder = <String>[
+      'buildReadingDestination()',
+      'buildLookupDestination()',
+      'buildCardCreationDestination()',
+      'buildVideoDestination()',
+      'buildListeningDestination()',
+      'buildDownloadsDestination()',
+      'buildAppearanceDestination()',
+      'buildProfilesDestination()',
+      'buildSyncBackupDestination()',
+      'buildInterconnectDestination()',
+      'buildSystemDestination()',
+    ];
+
+    int previous = -1;
+    for (final String token in expectedOrder) {
+      final int idx = body.indexOf(token);
+      expect(idx, isNonNegative,
+          reason: 'buildSettingsSchema must call $token');
+      expect(idx, greaterThan(previous),
+          reason: '$token 必须排在前一个 destination 之后（顶层大类顺序被锁定）');
+      previous = idx;
+    }
+  });
+}

--- a/hibiki/test/settings/settings_schema_coverage_test.dart
+++ b/hibiki/test/settings/settings_schema_coverage_test.dart
@@ -69,6 +69,13 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   'appearance/Design System': 'test/models/theme_notifier_test.dart',
   'appearance/UI size': 'test/models/theme_notifier_test.dart',
   'reading/Spread Mode': 'test/epub/epub_spread_map_test.dart',
+  // 阶段 G 重排后，「模式」分区（含 view_mode）在设置页排在「排版」分区（含
+  // page_columns）之前，覆盖 harness 焦点遍历会先把 view_mode 从 paginated 切走，
+  // 随后驱动 page_columns 时 reader 已非翻页态、T1 reader CSS 探针看不到 column-count
+  // 变化（多列模型只在 _paginatedLayoutCss）。page_columns 的 CSS 生效（翻页态发
+  // column-count、连续/VN 态不发）与 paginated-only 可见性由专项测试咬住。
+  'reading/Columns per Page':
+      'test/settings/page_columns_paginated_only_test.dart',
   // TODO-1128：合并插图页到正文（reading_display.merge_image_pages）。结构性布局键，
   // 焦点遍历能切到并写穿 DB（changed=true），但生效点在 reader 分页布局（
   // notifyReaderLayoutChanged 需活 reader/WebView 重排），无适用 T4 探针；合并语义/
@@ -386,7 +393,9 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   "system/Don't remind me about updates": 'DEVICE: Android-only UpdateChecker',
   'system/Auto-install updates': 'DEVICE: Android-only UpdateChecker install',
   'appearance/Reverse navigation bar': 'WIDGET-TODO: HomePage nav order',
-  'appearance/Open lookup on startup': 'test/pages/home_page_tabs_test.dart',
+  // 阶段 G 归位：「启动时打开查词」从 appearance 移到 system·通用（item id 不变，
+  // destId 随所属 destination 改为 system）。
+  'system/Open lookup on startup': 'test/pages/home_page_tabs_test.dart',
   'reading/Reverse reader bottom bar':
       'DEVICE: reader bottom-bar layout order (like reverse nav bar)',
   // TODO-830: 反转有声书底栏 ⏮⏭ 前进/后退按钮的功能方向（per-reader）。change/

--- a/hibiki/test/settings/startup_default_dictionary_tab_settings_test.dart
+++ b/hibiki/test/settings/startup_default_dictionary_tab_settings_test.dart
@@ -6,9 +6,9 @@ void main() {
   test(
       'startup default dictionary tab setting is wired through schema and i18n',
       () {
+    // 阶段 G 归位：该项从「外观」分区移到「系统 · 通用」分区（item id 不变）。
     final String schema =
-        File('lib/src/settings/settings_schema_appearance.dart')
-            .readAsStringSync();
+        File('lib/src/settings/settings_schema_system.dart').readAsStringSync();
     expect(schema, contains("id: 'appearance.startup_default_dictionary_tab'"));
     expect(schema, contains('t.startup_default_dictionary_tab'));
     expect(schema, contains('t.startup_default_dictionary_tab_hint'));


### PR DESCRIPTION
承接已落 develop 的设置系统重构 v2（原 PR#322，内容已由 integration 以 rebase 落入 develop），本 PR 只含用户追加要求的「分类和排序」实施（单提交 8827a2ce5）。

## 大类顺序（任务优先）

旧：外观 → 配置方案 → 阅读 → 查词 → 制卡 → 视频 → 听书 → 下载 → 同步 → 互联 → 系统
新：**阅读 → 查词 → 制卡 → 视频 → 听书 → 下载** → 外观 → 配置方案 → 同步与备份 → Hibiki 互联 → 系统

媒体任务六类连块前置（对应 app 媒体类型），全局低频类后置，系统垫底。新增 `settings_destination_order_guard_test` 锁定顺序（未来变更必须显式改守卫）。

## 区内重排

- **阅读**：新增首区「模式与排版方向」（翻页/滚动、排版方向、跨页、文字方向、振假名——结构性选择前置）；「排版」数值项集中（每页列数提到边距前）；砍掉单条目分区「底栏布局」并入「阅读界面」；「高级选项」沉底。
- **查词**：「管理器」改名「词典与来源」；区序改为 词典与来源→查词触发→词条内容→朗读与反馈→弹窗窗口→剪贴板与全局查词→外部集成（实验性集成沉底）。
- **视频**：「单文件循环」画质→播放（播放语义，面板侧本就在播放小节）；「字幕暂停播放模式」播放→字幕（其面板投影本就是 subtitle 组）。
- **外观→系统**：「启动时打开查词」移入系统「通用」（启动行为非外观）；item id 不变。
- **系统**：「通用」提前到「更新设置」前（快捷键设置是最高频入口）；destination 副标题改「通用、更新与诊断」（原「更新设置」名不副实）。

不变：全部 item id / pref key / ReaderPlacement / VideoPlacement（阅读器与视频面板投影布局零影响，id 集逐字节比对确认）。

## 验证

- `flutter analyze` 0 issues；定向 `test/settings/ test/i18n/ video_settings_schema_guard` 324 绿（coverage 全行驱动 stillUnaccounted=0）。
- 全量 `flutter test --no-pub`：1 个文件 loading 阶段瞬时失败（`backup_merge_category_selection_test`，develop 既有备份代码、与本改动无关），单独复跑 3/3 绿；其余全绿。
- i18n：新 key `reading_section_mode`、`settings_destination_system_summary`（经 i18n_sync）；「管理器→词典与来源」为仅此处使用 key 的值内编辑；闲置 key `section_bottom_bar_layout` 保留待清理。
- 旧→新完整对照已附在 docs/specs/2026-07-21-settings-refactor-v2-plan.md G 节。

待真机：设置首页大类顺序、阅读/查词/视频/系统各区新布局走查、搜索面包屑随迁移正确（「启动时打开查词」现显示 系统 › 通用）。

https://claude.ai/code/session_01KyFknwThdHHymwL8WorWWt