### PR TITLE
feat(interconnect): 客户端互联视频合集播放——剧集列表 + 跨成员自动连播 (BUG-1011)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 977 条。点号进各自文件。
+> 共 978 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1011](bugs/BUG-1011-interconnect-video-collection-playlist-autoplay.md) | ✅ | ✅ | 互联视频合集列表缺失+无自动连播·客户端合集播放 |
 | [BUG-1010](bugs/BUG-1010-video-controls-autohide-focus-loss.md) | 🚧 | 🚧 | 视频控制条自动隐藏后键盘焦点疑似丢失 |
 | [BUG-1009](bugs/BUG-1009-collection-detail-focus-id-clash.md) | 🚧 | 🚧 | 合集详情页返回后书架同名卡手柄焦点不可达 |
 | [BUG-1008](bugs/BUG-1008-shelf-tag-filter-contradictory-empty.md) | 🚧 | 🚧 | 标签筛选下 SRT 命中仍显示无匹配空态且丢失下拉刷新 |

--- a/docs/bugs/BUG-1011-interconnect-video-collection-playlist-autoplay.md
+++ b/docs/bugs/BUG-1011-interconnect-video-collection-playlist-autoplay.md
@@ -1,0 +1,23 @@
+## BUG-1011 · 互联视频合集列表缺失+无自动连播·客户端合集播放
+- **报告**：2026-07-22（用户：互联视频观看时缺少合集列表、无法自动连播）
+- **真实性**：✅ 真 bug（功能级缺口，TODO-885 远端播放列表一直未完成）。客户端播放器的连播机制**完好**（`video_hibiki/episode.part.dart` `_handlePlaybackCompleted`→倒计时→`_switchEpisode`；剧集面板渲染 `_episodes`），它 100% 靠 `RemoteVideoInfo.episodes` 驱动。丢在 **host 下发层 + client 不消费合集成员**（均 file:line 核实）：
+  - host 唯一的 episodes 来源 `app_model_library_host_service.dart:1057 _episodesFromRow` **只读旧的单行 `VideoBooks.playlistJson`**（m3u8 多集模型）。「统一合集 Phase 3」把播放列表重构成 **N 个独立 `VideoBooks` 行 + `MediaCollections/Items` 分组**，成员行 `playlistJson` 为 null → `episodes` 恒空 → `RemoteVideoInfo.isPlaylist=false`。
+  - client `video_hibiki_page.dart:_initRemote` 只从 `info.episodes` 建 `_episodes`、**从不读 `info.collection`** → 合集成员看不到剧集列表、无连播。
+  - host 虽算了每视频的 `RemoteCollectionMembership`（`_primaryCollectionMembership`），但它**不含成员清单**，且 client `RemoteVideoInfo.fromJson`（`hibiki_library_host_service.dart:946`）**根本没解析 `collection`**（`RemoteBookInfo.fromJson` 有、视频侧漏）→ LAN 远端视频连首页书架合集分组都收不到（全成散卡）。
+  - 本地对照：`_initRemote`/本地路径靠 `playlistCollectionId → getCollectionItems()` 查兄弟集建 `_episodes`——远端 client 手里没有 host 的合集成员表，这正是缺的那份数据。
+- **[x] ① 已修复** — **客户端合集播放**（用户选定方案；client 已在 listVideos 收到全部成员，首页已按 collection 分组，把成员列表传进播放器即可，无需改 host 协议）：
+  - **fromJson 补解析**：`RemoteVideoInfo.fromJson` 加 `collection: RemoteCollectionMembership.fromJson(json['collection'])`——恢复首页合集分组（根因之一，独立可见）。
+  - **首页传成员**：`home_video_page.dart` 合集行 itemBuilder 收集本合集**有序远端成员**（跳过本地成员）+ 被点成员下标 → `_buildRemoteVideoCard` → `_openRemote(video, collectionMembers, startIndex)` → `neutralizedRemote(remoteCollectionMembers:, initialEpisodeIndex:)`。散卡区不传（单视频）。
+  - **播放器合集模式**：`VideoHibikiPage.remote`/`neutralizedRemote` 新增 `remoteCollectionMembers`；State 加 `_remoteMembers`（有序成员）+ 可变 `_activeRemoteMember`（当前成员指针）；`_effectiveRemoteInfo` 改为 `_activeRemoteMember ?? widget.remoteInfo ?? _resolvedStreamInfo`（换成员即跟随）。
+  - **`_initRemote` 合集分支**：`_isRemoteCollection`（`_remoteMembers.length>1`）时用成员建 `_episodes`（绕开 `info.isPlaylist` 门控），起播下标 = `initialEpisodeIndex`。
+  - **`_loadRemoteEpisode` 换成员 id**（最硬点）：合集模式下 `info = _remoteMembers[index]`、`episodeIndex=0`、`_activeRemoteMember = info`、`_delayMs = info.delayMs`；host-playlist/单视频保持「同 id 换 episodeIndex」旧行为零变化。连播 `_switchEpisode`/`_handlePlaybackCompleted` 无需改（依赖 `_episodes.length`）。
+  - **断点/字幕键按成员隔离**：新增 `_remotePositionKeyForIndex(index)`——合集模式 `(成员 id, 0)`、否则 `(widget.bookUid, index)`；position 读/写（`_readPersistedRemotePosition*`/`_persistRemotePosition`）+ 字幕读（`_loadRemoteEpisode`）+ 字幕写（`subtitle.part.dart` ×2）统一走它。合集成员各带 host `positionMs`，`_resolveRemoteInitialPositionMs` 用成员 info。
+  - 提交：<待填>。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/sync/remote_video_info_collection_test.dart`：`fromJson` 解析 collection / 无 collection→null（旧 host 兼容）/ toJson→fromJson 往返（协议闭环）。
+  - `hibiki/test/pages/remote_collection_playback_wiring_guard_test.dart`：源码守卫——`_initRemote` 合集模式用 `_remoteMembers` 建 `_episodes`；`_loadRemoteEpisode` 换成员 id + 切 `_activeRemoteMember`；首页合集行传有序成员进播放器。
+  - `flutter analyze` 主包 0 issue；上述 + 既有 `home_video_remote_*` / `hibiki_sync_server_video_test`（43 测）全绿。
+- **备注**：
+  - 真机验证待办（Android/桌面互联：远端合集出剧集列表 + 播完自动连下一成员 + 断点按成员隔离 + 首页合集分组恢复）。
+  - 混合合集（部分本地已下载 + 部分远端）：远端成员组成远端子播放列表连播，本地成员走本地播放，不跨类连播（v1 范围）。合集详情页入口的成员上下文透传为后续跟进。
+  - 与 host 端「翻译 episodes（方案 A）」相比，本方案不改 host 协议、不产生首页冗余 playlist 卡。

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -1097,7 +1097,11 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     if (mounted) _refresh();
   }
 
-  Future<void> _openRemote(RemoteVideoInfo video) async {
+  Future<void> _openRemote(
+    RemoteVideoInfo video, {
+    List<RemoteVideoInfo>? collectionMembers,
+    int startIndex = 0,
+  }) async {
     final RemoteVideoClient? client = _remoteVideoClient;
     if (client == null) {
       // #4：云后端视频无 live host、不能流播；短按 = 下载入库（对齐书侧短按=下载语义），
@@ -1120,6 +1124,16 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
           info: video,
           repo: widget.repo,
           client: client,
+          // 客户端合集播放：合集里点某成员时带上有序远端成员列表 + 起播下标，播放器据此
+          // 建剧集列表 + 跨成员自动连播（成员是各自独立 video id，非同 id 换 episodeIndex）。
+          remoteCollectionMembers:
+              (collectionMembers != null && collectionMembers.length > 1)
+                  ? collectionMembers
+                  : null,
+          initialEpisodeIndex:
+              (collectionMembers != null && collectionMembers.length > 1)
+                  ? startIndex
+                  : null,
         ),
       ),
     );
@@ -2393,7 +2407,19 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
               selectable: false,
             );
           }
-          return _buildRemoteVideoCard(slot.remote!);
+          // 客户端合集连播：把本合集的有序远端成员（跳过本地成员）+ 被点成员下标传给卡片，
+          // 播放器据此建剧集列表 + 跨成员自动连播。混合合集里本地成员走本地播放，不入此列。
+          final List<RemoteVideoInfo> remoteMembers = <RemoteVideoInfo>[
+            for (final CollectionOrderingItem<_VideoSlot> it in group.items)
+              if (it.payload.remote != null) it.payload.remote!,
+          ];
+          final int memberIdx = remoteMembers
+              .indexWhere((RemoteVideoInfo m) => m.id == slot.remote!.id);
+          return _buildRemoteVideoCard(
+            slot.remote!,
+            collectionMembers: remoteMembers.length > 1 ? remoteMembers : null,
+            memberIndex: memberIdx < 0 ? 0 : memberIdx,
+          );
         },
       ),
     );
@@ -2403,7 +2429,11 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   /// 远端封面 + 云角标 ☁，混排进视频库主网格散卡区（[_buildLocalVideoSlivers]）。
   /// 短按走现有远端流播 [_openRemote]；右上角下载按钮/进度徽章复用 [_downloadRemote]
   /// （下载委托 InterconnectDownloadManager，切 tab/退页仍推进）。
-  Widget _buildRemoteVideoCard(RemoteVideoInfo video) {
+  Widget _buildRemoteVideoCard(
+    RemoteVideoInfo video, {
+    List<RemoteVideoInfo>? collectionMembers,
+    int memberIndex = 0,
+  }) {
     final String safeKey = _safeRemoteKey(video.id);
     // 不再固定 260 宽：和本地 [_buildCard] 一样让卡片填满网格 cell，宽度由
     // 响应式网格决定（TODO-593）。
@@ -2411,7 +2441,9 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
       key: ValueKey<String>('remote_video_card_$safeKey'),
       focusId: HibikiFocusId('home-video-remote-$safeKey'),
       padding: EdgeInsets.zero,
-      onTap: () => _openRemote(video),
+      // 合集行内点远端成员：带合集成员上下文进播放器（连播）；散卡区无上下文（单视频）。
+      onTap: () => _openRemote(video,
+          collectionMembers: collectionMembers, startIndex: memberIndex),
       // 短按仍流式播放（_openRemote）；长按 / 桌面右键弹选项面板，与本地视频
       // 卡长按一致（TODO-768 / BUG-416）。原先远端视频卡无 onLongPress（长按
       // 没反应），现在补齐。

--- a/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
@@ -683,8 +683,12 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     // 持久化用户为该远端集的字幕选择（根因修复：远端字幕原本只进内存、退出即丢）。
     // 本地已下载/导入的字幕文件路径（Jimaku 落 video_subtitles/、导入亦复制到该目录）可
     // 在重进时按路径重放；embedded:<n> 等非文件源退出后落回 host 默认，不阻塞当前应用。
+    // 合集连播下按当前成员 id 记忆字幕选择（键 = (成员 id, 0)），与 _loadRemoteEpisode 读取
+    // 端同源；单视频/host-playlist 沿用 (widget.bookUid, _currentEpisode)。
+    final (String subUid, int subEp) =
+        _remotePositionKeyForIndex(_currentEpisode);
     unawaited(
-      appModel.setRemoteSubtitleSource(widget.bookUid, _currentEpisode, source),
+      appModel.setRemoteSubtitleSource(subUid, subEp, source),
     );
     _showOsd(t.video_subtitle_switched(label: displayLabel));
   }
@@ -749,10 +753,12 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     _rebuild(() => _currentSubtitleSource = null);
     // 持久化「显式关闭」（off: 哨兵）：重进 _loadRemoteEpisode 时保持关闭，不再自动加载
     // host 默认字幕（否则用户每次进影片都要重新关一遍）。
+    final (String subUid, int subEp) =
+        _remotePositionKeyForIndex(_currentEpisode);
     unawaited(
       appModel.setRemoteSubtitleSource(
-        widget.bookUid,
-        _currentEpisode,
+        subUid,
+        subEp,
         SubtitleSource.offSentinel,
       ),
     );

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -365,7 +365,8 @@ class VideoHibikiPage extends ConsumerStatefulWidget {
     this.initialFullscreen = false,
     super.key,
   })  : remoteInfo = null,
-        remoteClient = null;
+        remoteClient = null,
+        remoteCollectionMembers = null;
 
   VideoHibikiPage.remote({
     required RemoteVideoInfo info,
@@ -374,6 +375,7 @@ class VideoHibikiPage extends ConsumerStatefulWidget {
     this.initialCueStartMs,
     this.initialEpisodeIndex,
     this.initialSubtitleListVisible = false,
+    this.remoteCollectionMembers,
     super.key,
   })  : bookUid = info.id,
         remoteInfo = info,
@@ -385,6 +387,12 @@ class VideoHibikiPage extends ConsumerStatefulWidget {
   final VideoBookRepository repo;
   final RemoteVideoInfo? remoteInfo;
   final RemoteVideoClient? remoteClient;
+
+  /// 客户端互联视频合集播放：本远端视频所属合集的**有序成员**（含自己）。非空且 >1 = 作为
+  /// 合集某一集打开，播放器据此建剧集列表 + 跨成员自动连播（成员各自独立 video id，换集换
+  /// 的是成员 id 而非同 id 的 episodeIndex）。null/单元素 = 独立单视频打开。远端专用；本地走
+  /// [playlistCollectionId]，host-playlist 走 host 下发的 [RemoteVideoInfo.episodes]。
+  final List<RemoteVideoInfo>? remoteCollectionMembers;
 
   /// 统一合集 Phase 3：本集所属 playlist 合集 id（非空 = 作为播放列表某一集打开，
   /// player 据此建兄弟集列表 + 剧集面板 + 上下集 + 自动连播；null = 独立单视频打开）。
@@ -435,6 +443,7 @@ class VideoHibikiPage extends ConsumerStatefulWidget {
     int? initialCueStartMs,
     int? initialEpisodeIndex,
     bool initialSubtitleListVisible = false,
+    List<RemoteVideoInfo>? remoteCollectionMembers,
   }) =>
       HibikiAppUiScaleNeutralizer(
         child: VideoHibikiPage.remote(
@@ -444,6 +453,7 @@ class VideoHibikiPage extends ConsumerStatefulWidget {
           initialCueStartMs: initialCueStartMs,
           initialEpisodeIndex: initialEpisodeIndex,
           initialSubtitleListVisible: initialSubtitleListVisible,
+          remoteCollectionMembers: remoteCollectionMembers,
         ),
       );
 
@@ -1573,14 +1583,38 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   RemoteVideoInfo? _resolvedStreamInfo;
   UrlStreamVideoClient? _resolvedStreamClient;
 
-  /// 有效远端 info/client：LAN 远端书用构造器传入的 widget.remote*，书架流媒体书用
-  /// [_init] 重建的 _resolvedStream*。二者互斥、至多一个非空。
+  /// 客户端互联视频合集播放：有序远端合集成员（来自 widget.remoteCollectionMembers）。
+  /// `length > 1` = 合集连播模式；单视频 / host-playlist 恒空。
+  List<RemoteVideoInfo> _remoteMembers = const <RemoteVideoInfo>[];
+
+  /// 合集连播模式下的「当前成员」（可变）：换成员时更新，使 [_effectiveRemoteInfo] /
+  /// 断点键 / 字幕键 / host 上报天然跟到新成员 id。非合集模式为 null（回落 widget.remoteInfo）。
+  RemoteVideoInfo? _activeRemoteMember;
+
+  /// 是否处于客户端合集连播模式（成员是各自独立 video id）。
+  bool get _isRemoteCollection => _remoteMembers.length > 1;
+
+  /// 有效远端 info/client：合集连播优先返回当前成员 [_activeRemoteMember]（换成员即跟随）；
+  /// 否则 LAN 远端书用构造器传入的 widget.remote*，书架流媒体书用 [_init] 重建的
+  /// _resolvedStream*。二者互斥、至多一个非空。
   RemoteVideoInfo? get _effectiveRemoteInfo =>
-      widget.remoteInfo ?? _resolvedStreamInfo;
+      _activeRemoteMember ?? widget.remoteInfo ?? _resolvedStreamInfo;
   RemoteVideoClient? get _effectiveRemoteClient =>
       widget.remoteClient ?? _resolvedStreamClient;
 
   bool get _isRemote => _effectiveRemoteInfo != null;
+
+  /// 远端断点 / 字幕 prefs 键 `(uid, episodeIndex)`。**合集连播模式**：每个成员是独立视频
+  /// id，键 = `(成员 id, 0)`，天然按成员隔离，且与 host 按成员带回的 positionMs 对齐；
+  /// **host-playlist / 单视频模式**：`(widget.bookUid, index)`（旧行为，index==0 时兼容旧单
+  /// 视频 prefs）。[index] 是目标集下标（读某集断点时传目标；写当前集传 [_currentEpisode]）。
+  (String uid, int episodeIndex) _remotePositionKeyForIndex(int index) {
+    if (_isRemoteCollection) {
+      final int i = index.clamp(0, _remoteMembers.length - 1);
+      return (_remoteMembers[i].id, 0);
+    }
+    return (widget.bookUid, index);
+  }
 
   /// app 当前目标学习语言代码（如 `'ja'`/`'ko'`），用于 sidecar 字幕语言优先检测。
   String get _targetLangCode => appModel.targetLanguage.locale.languageCode;
@@ -1855,6 +1889,11 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   }
 
   Future<void> _initRemote() async {
+    // 客户端合集连播：有序成员列表（>1 才成合集）。起播成员 = 首页点的那个（widget.remoteInfo，
+    // 其下标 = initialEpisodeIndex）。
+    _remoteMembers =
+        widget.remoteCollectionMembers ?? const <RemoteVideoInfo>[];
+    _activeRemoteMember = null;
     final RemoteVideoInfo info = _effectiveRemoteInfo!;
     _currentSubtitleSource = null;
     _currentSecondarySubtitleSource = null;
@@ -1868,8 +1907,30 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     _asbConfig = VideoAsbplayerConfig.decode(appModel.videoAsbplayerConfig);
     _controlLayoutNotifier.value = appModel.videoControlLayout;
 
-    // TODO-885: 远端播放列表——把 host 下发的 episodes 映射成 _episodes（path 留空，
-    // 切集靠 episodeIndex 向 host 重新建流），复用既有 _isPlaylist / 剧集面板 / 上下集。
+    // 客户端合集连播（Phase 3 合集 = N 个独立 VideoBooks 行）：host 不把兄弟集填进
+    // RemoteVideoInfo.episodes（那是旧单行 playlistJson 模型），故由 client 用合集成员列表
+    // 建 _episodes，绕开 info.isPlaylist 门控。换集换的是成员 id（见 _loadRemoteEpisode）。
+    if (_isRemoteCollection) {
+      final int startIndex =
+          (widget.initialEpisodeIndex ?? 0).clamp(0, _remoteMembers.length - 1);
+      _episodes = <_PlaylistEpisodeRef>[
+        for (final RemoteVideoInfo m in _remoteMembers)
+          _PlaylistEpisodeRef(title: m.title),
+      ];
+      _activeRemoteMember = _remoteMembers[startIndex];
+      _delayMs = _remoteMembers[startIndex].delayMs;
+      await _loadRemoteEpisode(
+        startIndex,
+        startIntent: EpisodeStartIntent.initialOpen,
+        initialPositionMsOverride: _resolveRemoteInitialPositionMs(
+            _remoteMembers[startIndex], startIndex),
+      );
+      return;
+    }
+
+    // TODO-885: 远端播放列表（旧单行多集 playlistJson 模型）——把 host 下发的 episodes 映射成
+    // _episodes（path 留空，切集靠 episodeIndex 向 host 重新建流），复用既有 _isPlaylist / 剧集
+    // 面板 / 上下集。
     final int startIndex = info.isPlaylist
         ? (widget.initialEpisodeIndex ?? info.currentEpisode)
             .clamp(0, info.episodes.length - 1)
@@ -1896,7 +1957,20 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     required EpisodeStartIntent startIntent,
     int? initialPositionMsOverride,
   }) async {
-    final RemoteVideoInfo info = _effectiveRemoteInfo!;
+    // 合集连播模式：换集换的是**兄弟成员 id**（各自独立单视频，episodeIndex 恒 0），并把
+    // 当前成员指针切到目标成员，使 _effectiveRemoteInfo / 断点键 / 字幕键 / host 上报跟随。
+    // host-playlist / 单视频模式：同一 info.id 换 episodeIndex（旧行为，零变化）。
+    final RemoteVideoInfo info;
+    final int streamEpisodeIndex;
+    if (_isRemoteCollection) {
+      info = _remoteMembers[index.clamp(0, _remoteMembers.length - 1)];
+      streamEpisodeIndex = 0;
+      _activeRemoteMember = info;
+      _delayMs = info.delayMs;
+    } else {
+      info = _effectiveRemoteInfo!;
+      streamEpisodeIndex = index;
+    }
     final RemoteVideoClient client = _effectiveRemoteClient!;
     final int seq = ++_episodeLoadSeq;
     // TODO-1307：新一集起播重置「用户已关字幕」标记（字幕后置自动应用的门控，见
@@ -1916,7 +1990,7 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     try {
       final RemoteVideoStreamUrls urls = await client.remoteVideoStreamUrls(
         info.id,
-        episodeIndex: index,
+        episodeIndex: streamEpisodeIndex,
       );
       _remoteEmbeddedSubtitleTracks = urls.embeddedSubtitleTracks;
       String? externalSub;
@@ -1924,8 +1998,11 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
       // 优先恢复用户上次为该远端集手选的字幕：远端视频无本地 DB 行，字幕只进内存、退出即丢
       // （用户报「下载字幕没持久化退出影片就没了」的根因）。选择按 <bookUid>#ep 记忆在 prefs
       // （见 PreferencesRepository.remoteSubtitleSources），这里在落回 host 默认字幕之前重放。
+      // 合集连播下按成员 id 记忆字幕选择（键 = (成员 id, 0)）；单视频/host-playlist 沿用
+      // (widget.bookUid, index)。
+      final (String subUid, int subEp) = _remotePositionKeyForIndex(index);
       final String? persistedSub =
-          appModel.remoteSubtitleSource(widget.bookUid, episodeIndex: index);
+          appModel.remoteSubtitleSource(subUid, episodeIndex: subEp);
       bool subtitleResolved = false;
       if (persistedSub != null) {
         if (SubtitleSource.isOff(persistedSub)) {
@@ -2109,9 +2186,9 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// [episodeIndex]>0 用按集 key（`#ep<index>` 后缀），0 回退整书 key（向后兼容单视频 /
   /// 旧 TODO-559 prefs）。
   int _readPersistedRemotePositionForEpisode(int episodeIndex) {
-    final Object? raw = appModel.prefsRepo.getPref(
-        videoRemotePositionEpisodePrefKey(widget.bookUid, episodeIndex),
-        defaultValue: 0);
+    final (String uid, int ep) = _remotePositionKeyForIndex(episodeIndex);
+    final Object? raw = appModel.prefsRepo
+        .getPref(videoRemotePositionEpisodePrefKey(uid, ep), defaultValue: 0);
     final int v =
         raw is num ? raw.toInt() : int.tryParse(raw?.toString() ?? '') ?? 0;
     return v < 0 ? 0 : v;
@@ -2119,9 +2196,9 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
 
   /// 读 per-book/per-episode 远端断点的本地「最后更新时间」（无则 0）。TODO-653 冲突解决用。
   int _readPersistedRemotePositionAtForEpisode(int episodeIndex) {
-    final Object? raw = appModel.prefsRepo.getPref(
-        videoRemotePositionEpisodeAtPrefKey(widget.bookUid, episodeIndex),
-        defaultValue: 0);
+    final (String uid, int ep) = _remotePositionKeyForIndex(episodeIndex);
+    final Object? raw = appModel.prefsRepo
+        .getPref(videoRemotePositionEpisodeAtPrefKey(uid, ep), defaultValue: 0);
     final int v =
         raw is num ? raw.toInt() : int.tryParse(raw?.toString() ?? '') ?? 0;
     return v < 0 ? 0 : v;
@@ -2162,18 +2239,20 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     // → 下次打开从头播放。近起点不算有效进度，跳过不写即可。
     const int kMeaningfulRemoteWatchMs = 5000;
     if (clamped < kMeaningfulRemoteWatchMs) return;
-    // TODO-885: 按当前集 key 落库 + 上报（_currentEpisode 是状态真相；单视频恒 0 回退
-    // 整书 key，与旧 prefs 兼容）。
-    final int episodeIndex = _currentEpisode;
-    await appModel.prefsRepo
-        .setPref(videoRemotePositionEpisodePrefKey(uid, episodeIndex), clamped);
-    await appModel.prefsRepo
-        .setPref(videoRemotePositionEpisodeAtPrefKey(uid, episodeIndex), nowMs);
+    // TODO-885 / 合集连播：按当前集 key 落库 + 上报。合集模式键 = (当前成员 id, 0)（成员天然
+    // 隔离，与 host 按成员带回的 positionMs 对齐）；单视频/host-playlist = (widget.bookUid,
+    // _currentEpisode)（此时 keyUid==uid，行为零变化）。传入的 [uid] 恒是 widget.bookUid。
+    final (String keyUid, int episodeIndex) =
+        _remotePositionKeyForIndex(_currentEpisode);
+    await appModel.prefsRepo.setPref(
+        videoRemotePositionEpisodePrefKey(keyUid, episodeIndex), clamped);
+    await appModel.prefsRepo.setPref(
+        videoRemotePositionEpisodeAtPrefKey(keyUid, episodeIndex), nowMs);
     final RemoteVideoClient? client = _effectiveRemoteClient;
     if (client == null) return;
     try {
       await client.putRemoteVideoPosition(
-        uid,
+        keyUid,
         clamped,
         nowMs,
         episodeIndex: episodeIndex,

--- a/hibiki/lib/src/sync/hibiki_library_host_service.dart
+++ b/hibiki/lib/src/sync/hibiki_library_host_service.dart
@@ -970,6 +970,10 @@ class RemoteVideoInfo {
       tags: _jsonStringList(json['tags']),
       tagsAddedAt: _jsonNameIntMap(json['tagsAddedAt']),
       tagTombstones: _jsonNameIntMap(json['tagTombstones']),
+      // BUG：toJson 写了 'collection'（合集归属）但 fromJson 从不解析 → LAN 远端视频
+      // video.collection 恒 null → 首页收不到合集分组（全成散卡）、播放器也无从重建合集连播。
+      // 对齐 RemoteBookInfo.fromJson。旧 host 无该字段 → fromJson 返 null（向后兼容）。
+      collection: RemoteCollectionMembership.fromJson(json['collection']),
     );
   }
 }

--- a/hibiki/test/pages/remote_collection_playback_wiring_guard_test.dart
+++ b/hibiki/test/pages/remote_collection_playback_wiring_guard_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 源码守卫：客户端互联视频合集连播的关键接线，防后续重构悄悄回退成「远端只认
+/// host 下发的 episodes」（Phase 3 合集成员各自独立行、host 不填 episodes → 无列表无连播）。
+///
+/// 验证三条不变量：
+///  1. 播放器 `_initRemote` 在合集模式（`_isRemoteCollection`）下用 `_remoteMembers` 建 `_episodes`。
+///  2. 播放器 `_loadRemoteEpisode` 在合集模式下换的是**成员 id**（`_remoteMembers[...]`）并把
+///     当前成员指针 `_activeRemoteMember` 切到目标成员（而非同 id 换 episodeIndex）。
+///  3. 首页合集行把有序远端成员列表（`collectionMembers` / `remoteCollectionMembers`）传进播放器。
+void main() {
+  String read(String rel) {
+    final File f = File(rel);
+    expect(f.existsSync(), true, reason: '找不到源文件：$rel');
+    return f.readAsStringSync();
+  }
+
+  test('播放器 _initRemote 合集模式用成员列表建 _episodes', () {
+    final String src =
+        read('lib/src/pages/implementations/video_hibiki_page.dart');
+    expect(src.contains('bool get _isRemoteCollection'), true,
+        reason: '应有合集连播模式判据 _isRemoteCollection');
+    expect(
+        src.contains('widget.remoteCollectionMembers ?? const <RemoteVideoInfo>[]'),
+        true,
+        reason: '_initRemote 应从 widget 取远端合集成员列表');
+    // 合集模式下用成员建 _episodes（每成员一个 _PlaylistEpisodeRef）。
+    expect(
+        RegExp(r'for \(final RemoteVideoInfo m in _remoteMembers\)')
+            .hasMatch(src),
+        true,
+        reason: '合集模式应遍历 _remoteMembers 建剧集列表');
+  });
+
+  test('播放器 _loadRemoteEpisode 合集模式换成员 id + 切当前成员指针', () {
+    final String src =
+        read('lib/src/pages/implementations/video_hibiki_page.dart');
+    expect(src.contains('_activeRemoteMember = info'), true,
+        reason: '换集时应把当前成员指针切到目标成员');
+    expect(src.contains('streamEpisodeIndex'), true,
+        reason: '合集成员各自单视频，episodeIndex 应恒 0（streamEpisodeIndex）');
+    // _effectiveRemoteInfo 优先返回可变的当前成员，使断点/字幕/上报跟随成员 id。
+    expect(
+        src.contains('_activeRemoteMember ?? widget.remoteInfo'), true,
+        reason: '_effectiveRemoteInfo 应优先返回当前成员');
+  });
+
+  test('首页合集行把有序远端成员传进播放器', () {
+    final String src =
+        read('lib/src/pages/implementations/home_video_page.dart');
+    expect(src.contains('remoteCollectionMembers:'), true,
+        reason: '_openRemote 应把合集成员透传给 neutralizedRemote');
+    // itemBuilder 收集本合集的有序远端成员（跳过本地成员）。
+    expect(src.contains('if (it.payload.remote != null) it.payload.remote!'),
+        true,
+        reason: '合集行应收集有序远端成员列表');
+  });
+}

--- a/hibiki/test/sync/remote_video_info_collection_test.dart
+++ b/hibiki/test/sync/remote_video_info_collection_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+
+/// 守卫：`RemoteVideoInfo.fromJson` 必须解析 `collection` 归属字段。此前 toJson 写了
+/// `collection` 但 fromJson 从不读 → LAN 远端视频 `video.collection` 恒 null → 首页收不到
+/// 合集分组（全成散卡），播放器也无从重建合集连播（互联视频「缺合集列表/无连播」根因之一）。
+void main() {
+  test('fromJson 解析 collection 归属（合集分组根因）', () {
+    final RemoteVideoInfo info = RemoteVideoInfo.fromJson(<String, Object?>{
+      'id': 'video/series/ep1',
+      'title': 'Episode 1',
+      'collection': <String, Object?>{
+        'name': 'My Series',
+        'collectionType': 'playlist',
+        'sortIndex': 3,
+      },
+    });
+    expect(info.collection, isNotNull);
+    expect(info.collection!.collectionName, 'My Series');
+    expect(info.collection!.collectionType, 'playlist');
+    expect(info.collection!.sortIndex, 3);
+  });
+
+  test('fromJson 无 collection → null（旧 host 向后兼容，降级散卡）', () {
+    final RemoteVideoInfo info = RemoteVideoInfo.fromJson(<String, Object?>{
+      'id': 'v',
+      'title': 't',
+    });
+    expect(info.collection, isNull);
+  });
+
+  test('toJson→fromJson 往返保留 collection（协议闭环）', () {
+    final RemoteVideoInfo original = RemoteVideoInfo.fromJson(<String, Object?>{
+      'id': 'v',
+      'title': 't',
+      'collection': <String, Object?>{
+        'name': 'C',
+        'collectionType': 'collection',
+        'sortIndex': 2,
+      },
+    });
+    final RemoteVideoInfo restored =
+        RemoteVideoInfo.fromJson(original.toJson());
+    expect(restored.collection?.collectionName, 'C');
+    expect(restored.collection?.collectionType, 'collection');
+    expect(restored.collection?.sortIndex, 2);
+  });
+}


### PR DESCRIPTION
## 背景
用户报「互联（远端 Hibiki 库流式）视频观看时缺少合集列表、无法自动连播」。沿真实代码路径验为功能级缺口（TODO-885 远端播放列表一直未完成）。

## 根因（已验证）
客户端连播机制**完好**（`episode.part.dart` `_handlePlaybackCompleted`→倒计时→`_switchEpisode`，剧集面板渲染 `_episodes`），100% 靠 `RemoteVideoInfo.episodes` 驱动。丢在 host 下发 + client 不消费合集成员：
- host `_episodesFromRow` 只读旧单行 `playlistJson`；「统一合集 Phase 3」把播放列表拆成 **N 个独立 VideoBooks 行 + MediaCollections 分组**，成员行 playlistJson 为 null → `episodes` 恒空 → `isPlaylist=false` → 无列表无连播。
- `RemoteVideoInfo.fromJson` **从没解析 `collection`**（`RemoteBookInfo` 有、视频漏）→ LAN 远端视频连首页合集分组都收不到（散卡）。
- client `_initRemote` 只读 `info.episodes`、从不读 `info.collection`；本地靠 `playlistCollectionId → getCollectionItems()` 查兄弟集，远端缺这份成员表。

## 修法（用户选定：客户端合集播放，不改 host 协议）
client 已在 `listVideos` 收到全部成员、首页已按 collection 分组，把成员列表传进播放器即可：
- **fromJson 补 `collection` 解析**（恢复首页合集分组）。
- **首页合集行**把有序远端成员 + 起播下标传进 `neutralizedRemote(remoteCollectionMembers:, initialEpisodeIndex:)`。散卡区不传（单视频）。
- **播放器**加 `_remoteMembers` + 可变 `_activeRemoteMember`；`_effectiveRemoteInfo` 优先返回当前成员；`_initRemote` 合集模式用成员建 `_episodes`；**`_loadRemoteEpisode` 换成员 id（episodeIndex=0）而非同 id 换 episodeIndex**（最硬点）。
- **断点/字幕键按成员 id 隔离**（`_remotePositionKeyForIndex`）。
- host-playlist / 单视频路径**零变化**（Never break userspace）。

## 测试
- `remote_video_info_collection_test`：fromJson 解析/兼容/往返。
- `remote_collection_playback_wiring_guard_test`：合集播放关键接线源码守卫。
- `flutter analyze` 主包 **0 issue**；既有 `home_video_remote_*` / `hibiki_sync_server_video_test`（43 测）全绿。

## 待办 / 范围
- 真机验证（远端合集出剧集列表 + 播完自动连下一成员 + 断点按成员隔离 + 首页分组恢复）。
- 混合合集（本地+远端）：远端成员组成远端子播放列表连播，本地成员走本地播放（v1 范围）。合集详情页入口透传为后续跟进。

https://claude.ai/code/session_016RsqS7PAy3QNnEvMbYdhvu
