### PR TITLE
UI/UX 重构 PR-0：共享组件层（eink 描边/空态 CTA/CoverBadge/销毁确认收口/设置行单焦点站点）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 37995 (2235 per locale)
+/// Strings: 38012 (2236 per locale)
 ///
-/// Built on 2026-07-22 at 04:30 UTC
+/// Built on 2026-07-22 at 05:54 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2977,6 +2977,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get reading_section_mode => 'Mode & orientation';
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -8035,6 +8036,8 @@ class _StringsAr extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -13166,6 +13169,8 @@ class _StringsDe extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -18313,6 +18318,8 @@ class _StringsEs extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -23471,6 +23478,8 @@ class _StringsFr extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -28556,6 +28565,8 @@ class _StringsId extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -33689,6 +33700,8 @@ class _StringsIt extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -38627,6 +38640,8 @@ class _StringsJa extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -43568,6 +43583,8 @@ class _StringsKo extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -48679,6 +48696,8 @@ class _StringsNl extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -53805,6 +53824,8 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -58914,6 +58935,8 @@ class _StringsRu extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -63968,6 +63991,8 @@ class _StringsTh extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -69054,6 +69079,8 @@ class _StringsTr extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -74127,6 +74154,8 @@ class _StringsVi extends _StringsEn {
   @override
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 // Path: <root>
@@ -78847,6 +78876,8 @@ class _StringsZhCn extends _StringsEn {
   String get reading_section_mode => '模式与排版方向';
   @override
   String get settings_destination_system_summary => '通用、更新与诊断';
+  @override
+  String get error_load_failed => '加载出错';
 }
 
 // Path: <root>
@@ -83703,6 +83734,8 @@ class _StringsZhHk extends _StringsEn {
   String get reading_section_mode => '模式與排版方向';
   @override
   String get settings_destination_system_summary => '通用、更新與診斷';
+  @override
+  String get error_load_failed => 'Something went wrong while loading';
 }
 
 /// Flat map(s) containing all translations.
@@ -88265,6 +88298,8 @@ extension on _StringsEn {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -92825,6 +92860,8 @@ extension on _StringsAr {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -97406,6 +97443,8 @@ extension on _StringsDe {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -101986,6 +102025,8 @@ extension on _StringsEs {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -106572,6 +106613,8 @@ extension on _StringsFr {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -111140,6 +111183,8 @@ extension on _StringsId {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -115723,6 +115768,8 @@ extension on _StringsIt {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -120268,6 +120315,8 @@ extension on _StringsJa {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -124817,6 +124866,8 @@ extension on _StringsKo {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -129393,6 +129444,8 @@ extension on _StringsNl {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -133966,6 +134019,8 @@ extension on _StringsPtBr {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -138544,6 +138599,8 @@ extension on _StringsRu {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -143106,6 +143163,8 @@ extension on _StringsTh {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -147677,6 +147736,8 @@ extension on _StringsTr {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -152243,6 +152304,8 @@ extension on _StringsVi {
         return 'Mode & orientation';
       case 'settings_destination_system_summary':
         return 'General, updates & diagnostics';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }
@@ -156775,6 +156838,8 @@ extension on _StringsZhCn {
         return '模式与排版方向';
       case 'settings_destination_system_summary':
         return '通用、更新与诊断';
+      case 'error_load_failed':
+        return '加载出错';
       default:
         return null;
     }
@@ -161315,6 +161380,8 @@ extension on _StringsZhHk {
         return '模式與排版方向';
       case 'settings_destination_system_summary':
         return '通用、更新與診斷';
+      case 'error_load_failed':
+        return 'Something went wrong while loading';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
-  "settings_destination_system_summary": "General, updates & diagnostics"
+  "settings_destination_system_summary": "General, updates & diagnostics",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "把查词和剪贴板悬浮窗从截图、录屏、直播串流中排除（Windows）。关闭后，截图、录屏和串流即可拍到查词悬浮窗。",
   "settings_section_general": "通用",
   "reading_section_mode": "模式与排版方向",
-  "settings_destination_system_summary": "通用、更新与诊断"
+  "settings_destination_system_summary": "通用、更新与诊断",
+  "error_load_failed": "加载出错"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2233,5 +2233,6 @@
   "clipboard_panel_block_capture_hint": "Excludes the lookup and clipboard popup windows from screenshots, screen recording, and live streaming (Windows). Turn this off to let screenshots, recording, and streaming capture the lookup popup.",
   "settings_section_general": "通用",
   "reading_section_mode": "模式與排版方向",
-  "settings_destination_system_summary": "通用、更新與診斷"
+  "settings_destination_system_summary": "通用、更新與診斷",
+  "error_load_failed": "Something went wrong while loading"
 }

--- a/hibiki/lib/src/pages/base_page.dart
+++ b/hibiki/lib/src/pages/base_page.dart
@@ -65,6 +65,10 @@ abstract class BasePageState<T extends BasePage> extends ConsumerState<T> {
 
   /// Standard error message for use across the application.
   /// General widget for showing an error or a retry screen.
+  ///
+  /// 主文案是通用错误提示（i18n），原始异常串降级为折叠 detail（此前直接
+  /// `'$error'` 上屏，用户看到的是 SqliteException(...) 原文）；调用方传了
+  /// [refresh] 就渲染重试按钮（此前该参数被静默丢弃，页面没有任何恢复入口）。
   Widget buildError({
     Object? error,
     StackTrace? stack,
@@ -73,7 +77,15 @@ abstract class BasePageState<T extends BasePage> extends ConsumerState<T> {
     return Center(
       child: HibikiPlaceholderMessage(
         icon: Icons.error_outline,
-        message: '$error',
+        message: t.error_load_failed,
+        detail: error != null ? '$error' : null,
+        action: refresh != null
+            ? FilledButton.tonalIcon(
+                onPressed: () => refresh(),
+                icon: const Icon(Icons.refresh),
+                label: Text(t.retry),
+              )
+            : null,
       ),
     );
   }

--- a/hibiki/lib/src/utils/adaptive/adaptive_platform.dart
+++ b/hibiki/lib/src/utils/adaptive/adaptive_platform.dart
@@ -61,6 +61,12 @@ bool isEinkTheme(BuildContext context) {
   return Theme.of(context).extension<HibikiEinkTheme>()?.einkMode ?? false;
 }
 
+/// eink 下把动画时长归零（墨水屏连续重绘=残影），否则原样返回。
+/// 共享组件与页面级 Animated* 统一走这里，别再手写三元。
+Duration einkSafeDuration(BuildContext context, Duration duration) {
+  return isEinkTheme(context) ? Duration.zero : duration;
+}
+
 bool isCupertinoPlatform(BuildContext context) {
   final HibikiDesignSystem designSystem =
       Theme.of(context).extension<HibikiDesignSystemTheme>()?.designSystem ??

--- a/hibiki/lib/src/utils/components/cover_badge.dart
+++ b/hibiki/lib/src/utils/components/cover_badge.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:hibiki/src/utils/adaptive/adaptive_platform.dart';
+
+/// 封面角标：压在封面图上的半透明黑胶囊（图标 + 可选文字）。
+///
+/// 统一书架/视频/游戏卡上「字幕/云端/播放列表/有声书」等角标的观感——此前
+/// 同款胶囊在 home_video_page / remote.part 等处至少复制三份且 alpha 各异
+/// （0.55~0.62）。封面上的角标底色**有意**固定深色而非跟随主题：它压在任意
+/// 亮度的封面图上，跟随 colorScheme 反而在浅色主题下失去对比。
+///
+/// eink：半透明黑在墨水屏上合成抖动中间灰，改纯黑实底（前景仍是纯白）。
+class CoverBadge extends StatelessWidget {
+  const CoverBadge({
+    required this.icon,
+    this.label,
+    this.iconSize = 14,
+    super.key,
+  });
+
+  /// 角标图标（14px 白色，与既有视频卡角标同规格）。
+  final IconData icon;
+
+  /// 可选文字（如播放列表集数「12」）；null 时为纯图标胶囊。
+  final String? label;
+
+  /// 图标尺寸，默认 14。
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool eink = isEinkTheme(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      decoration: BoxDecoration(
+        color: eink ? Colors.black : Colors.black.withValues(alpha: 0.6),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Icon(icon, size: iconSize, color: Colors.white),
+          if (label != null) ...[
+            const SizedBox(width: 4),
+            Text(
+              label!,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: Colors.white,
+                  ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/hibiki/lib/src/utils/components/hibiki_destructive_confirm_dialog.dart
+++ b/hibiki/lib/src/utils/components/hibiki_destructive_confirm_dialog.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/src/utils/adaptive/adaptive_widgets.dart';
+import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
+import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
+
+/// [HibikiDestructiveConfirmDialog] 的返回值。
+///
+/// pop `null` = 取消；非 null = 已确认，[checked] 携带可选勾选项状态
+/// （无 [HibikiDestructiveConfirmDialog.checkboxLabel] 时恒为 false）。
+@immutable
+class HibikiDestructiveConfirmResult {
+  const HibikiDestructiveConfirmResult({required this.checked});
+
+  final bool checked;
+}
+
+/// 全 app 统一的「确认销毁」对话框。
+///
+/// 巡检（docs/reviews/2026-07-22-ui-ux-survey.md）发现同一语义至少四种实现
+/// 并存：ReaderHistoryDeleteDialog、CollectionDeleteDialog、两个合集详情页的
+/// 裸 AlertDialog。本组件以 ReaderHistoryDeleteDialog 的观感为基准
+/// （HibikiDialogFrame + HibikiModalSheetFrame + adaptiveDialogAction），
+/// 增加可选勾选项（如「连同书籍本体一起删除」），供各处收口。
+///
+/// 用法：`showAppDialog<HibikiDestructiveConfirmResult>(...)` 后判空即可；
+/// 确认按钮文案默认 t.dialog_delete，可换（如「清空」「移除」）。
+class HibikiDestructiveConfirmDialog extends StatefulWidget {
+  const HibikiDestructiveConfirmDialog({
+    required this.title,
+    required this.message,
+    this.confirmLabel,
+    this.leadingIcon = Icons.delete_outline,
+    this.checkboxLabel,
+    this.checkboxInitialValue = false,
+    super.key,
+  });
+
+  final String title;
+  final String message;
+
+  /// 确认按钮文案；null 用 t.dialog_delete。
+  final String? confirmLabel;
+
+  final IconData leadingIcon;
+
+  /// 非 null 时在正文下方渲染一个勾选行（如「连同本体删除」）。
+  final String? checkboxLabel;
+
+  final bool checkboxInitialValue;
+
+  @override
+  State<HibikiDestructiveConfirmDialog> createState() =>
+      _HibikiDestructiveConfirmDialogState();
+}
+
+class _HibikiDestructiveConfirmDialogState
+    extends State<HibikiDestructiveConfirmDialog> {
+  late bool _checked = widget.checkboxInitialValue;
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+
+    return HibikiDialogFrame(
+      maxWidth: 420,
+      maxHeightFactor: 0.74,
+      child: HibikiModalSheetFrame(
+        title: widget.title,
+        leadingIcon: widget.leadingIcon,
+        bodyPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          0,
+          tokens.spacing.card,
+          tokens.spacing.gap,
+        ),
+        footerPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          tokens.spacing.gap,
+          tokens.spacing.card,
+          tokens.spacing.card,
+        ),
+        body: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(widget.message, style: tokens.type.listSubtitle),
+            if (widget.checkboxLabel != null) ...[
+              SizedBox(height: tokens.spacing.gap),
+              HibikiListItem(
+                density: HibikiListDensity.compact,
+                padding: EdgeInsets.zero,
+                title: Text(widget.checkboxLabel!),
+                // 勾选状态由整行 onTap 驱动；Checkbox 本身既不接指针也不进
+                // 焦点遍历（单站点契约，行即唯一停靠点）。
+                leading: ExcludeFocus(
+                  child: IgnorePointer(
+                    child: Checkbox(
+                      value: _checked,
+                      onChanged: (_) {},
+                    ),
+                  ),
+                ),
+                onTap: () => setState(() => _checked = !_checked),
+              ),
+            ],
+          ],
+        ),
+        footer: Wrap(
+          alignment: WrapAlignment.end,
+          spacing: tokens.spacing.gap,
+          runSpacing: tokens.spacing.gap,
+          children: <Widget>[
+            adaptiveDialogAction(
+              context: context,
+              onPressed: () => Navigator.pop(context),
+              child: Text(t.dialog_cancel),
+            ),
+            adaptiveDialogAction(
+              context: context,
+              isDestructiveAction: true,
+              onPressed: () => Navigator.pop(
+                context,
+                HibikiDestructiveConfirmResult(checked: _checked),
+              ),
+              child: Text(widget.confirmLabel ?? t.dialog_delete),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/hibiki/lib/src/utils/components/hibiki_material_components.dart
+++ b/hibiki/lib/src/utils/components/hibiki_material_components.dart
@@ -61,9 +61,22 @@ class _HibikiCardState extends State<HibikiCard> {
   @override
   Widget build(BuildContext context) {
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final bool eink = isEinkTheme(context);
     final Color effectiveColor = widget.color ??
         (widget.selected ? tokens.surfaces.selected : tokens.surfaces.card);
     final BorderRadius radius = widget.borderRadius ?? tokens.radii.cardRadius;
+    // eink 把所有 surface container 塌缩为背景色（theme_notifier eink scheme），
+    // 卡片没有边就与页面融为一体；主题层只给裸 Card 补了描边（CardThemeData），
+    // HibikiCard 在这里自己补。选中态加粗到 2px——eink 下 selected 填充色同样
+    // 塌缩，边宽是唯一可辨的选中信号。
+    final BorderSide side = widget.borderColor != null
+        ? BorderSide(color: widget.borderColor!)
+        : (eink
+            ? BorderSide(
+                color: tokens.surfaces.outline,
+                width: widget.selected ? 2 : 1,
+              )
+            : BorderSide.none);
     final Widget content = Padding(
       padding: widget.padding ?? EdgeInsets.all(tokens.spacing.card),
       child: widget.child,
@@ -71,15 +84,13 @@ class _HibikiCardState extends State<HibikiCard> {
     final Widget card = Padding(
       padding: widget.margin ?? EdgeInsets.zero,
       child: AnimatedContainer(
-        duration: hibikiMd3StateDuration,
+        duration: einkSafeDuration(context, hibikiMd3StateDuration),
         curve: hibikiMd3StateCurve,
         decoration: ShapeDecoration(
           color: effectiveColor,
           shape: RoundedRectangleBorder(
             borderRadius: radius,
-            side: widget.borderColor != null
-                ? BorderSide(color: widget.borderColor!)
-                : BorderSide.none,
+            side: side,
           ),
         ),
         child: Material(
@@ -1453,40 +1464,40 @@ class HibikiSchemeSwatch extends StatelessWidget {
         // RepaintBoundary，让每张色卡各自栅格化进缓存层，滚动只合成、不重绘。
         child: RepaintBoundary(
           child: CustomPaint(
-          // TODO-1320: pin the painting surface to the card size. A childless
-          // CustomPaint with the default `size: Size.zero` collapses to zero
-          // under the LOOSE constraints the parent AnimatedContainer hands down
-          // (its `alignment: Alignment.center` loosens child constraints). So an
-          // unselected preset swatch — which has no badge child (badge is only
-          // the selection check or the system/custom overlay) — painted onto a
-          // 0x0 canvas and rendered as a blank rounded card. Selected / system /
-          // custom swatches escaped this only because their badge/overlay gave
-          // CustomPaint a non-null child that sized it. Sizing the canvas
-          // explicitly makes EVERY swatch paint the full diagonal preview,
-          // selected or not (the earlier `showGlyph: true` was a no-op on a
-          // zero-size canvas).
-          size: Size.square(size),
-          painter: SchemeDiagonalPainter(
-            textColor: textRole,
-            backgroundColor: backgroundRole,
-            buttonColor: colors[2],
-            menuColor: menuRole,
-            // TODO-138: always paint the full preview — the 「文」 glyph and the
-            // accent dot — for EVERY swatch. The badge (if any) sits in the corner
-            // and no longer replaces the glyph, so system/custom show a complete
-            // preview, not just a base colour behind a centred badge.
-            showGlyph: true,
-            textDirection: Directionality.of(context),
-          ),
-          child: badge == null
-              ? null
-              : Align(
-                  alignment: Alignment.bottomLeft,
-                  child: Padding(
-                    padding: const EdgeInsets.all(2),
-                    child: badge,
+            // TODO-1320: pin the painting surface to the card size. A childless
+            // CustomPaint with the default `size: Size.zero` collapses to zero
+            // under the LOOSE constraints the parent AnimatedContainer hands down
+            // (its `alignment: Alignment.center` loosens child constraints). So an
+            // unselected preset swatch — which has no badge child (badge is only
+            // the selection check or the system/custom overlay) — painted onto a
+            // 0x0 canvas and rendered as a blank rounded card. Selected / system /
+            // custom swatches escaped this only because their badge/overlay gave
+            // CustomPaint a non-null child that sized it. Sizing the canvas
+            // explicitly makes EVERY swatch paint the full diagonal preview,
+            // selected or not (the earlier `showGlyph: true` was a no-op on a
+            // zero-size canvas).
+            size: Size.square(size),
+            painter: SchemeDiagonalPainter(
+              textColor: textRole,
+              backgroundColor: backgroundRole,
+              buttonColor: colors[2],
+              menuColor: menuRole,
+              // TODO-138: always paint the full preview — the 「文」 glyph and the
+              // accent dot — for EVERY swatch. The badge (if any) sits in the corner
+              // and no longer replaces the glyph, so system/custom show a complete
+              // preview, not just a base colour behind a centred badge.
+              showGlyph: true,
+              textDirection: Directionality.of(context),
+            ),
+            child: badge == null
+                ? null
+                : Align(
+                    alignment: Alignment.bottomLeft,
+                    child: Padding(
+                      padding: const EdgeInsets.all(2),
+                      child: badge,
+                    ),
                   ),
-                ),
           ),
         ),
       ),

--- a/hibiki/lib/src/utils/components/hibiki_placeholder_message.dart
+++ b/hibiki/lib/src/utils/components/hibiki_placeholder_message.dart
@@ -12,6 +12,8 @@ class HibikiPlaceholderMessage extends StatelessWidget {
     this.color,
     this.iconSize,
     this.messageStyle,
+    this.detail,
+    this.action,
     super.key,
   });
 
@@ -32,6 +34,13 @@ class HibikiPlaceholderMessage extends StatelessWidget {
 
   /// The text style to be used to display the message below the icon.
   final TextStyle? messageStyle;
+
+  /// 次级说明（如折叠后的原始错误串）。bodySmall + onVariant，最多 3 行省略，
+  /// 不抢 [message] 的主文案层级。
+  final String? detail;
+
+  /// 可选行动按钮（如空态的「导入」、错误态的「重试」），渲染在文案下方。
+  final Widget? action;
 
   @override
   Widget build(BuildContext context) {
@@ -65,6 +74,22 @@ class HibikiPlaceholderMessage extends StatelessWidget {
                             color: foreground,
                           ),
                 ),
+                if (detail != null) ...[
+                  SizedBox(height: tokens.spacing.gap / 2),
+                  Text(
+                    detail!,
+                    textAlign: TextAlign.center,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: foreground,
+                        ),
+                  ),
+                ],
+                if (action != null) ...[
+                  SizedBox(height: tokens.spacing.gap * 1.5),
+                  action!,
+                ],
               ],
             ),
           ),

--- a/hibiki/lib/src/utils/components/settings_shared.dart
+++ b/hibiki/lib/src/utils/components/settings_shared.dart
@@ -515,9 +515,13 @@ class AdaptiveSettingsRow extends StatelessWidget {
             onTap: onTap,
             child: content,
           );
+    // 单焦点站点契约（对齐滑条/步进行的 ExcludeFocus 做法）：焦点根存在时，
+    // 行的键盘/手柄停靠点只有 _SettingsRowFocusTarget 一个——InkWell 与
+    // trailing 里的 Switch 等内部可聚焦控件全部退出 Tab 遍历，否则一行
+    // 最多 3 个站点且激活语义相同，长设置页遍历冗长。
     return _SettingsRowFocusTarget(
       onTap: onTap!,
-      child: tappable,
+      child: ExcludeFocus(child: tappable),
     );
   }
 

--- a/hibiki/lib/utils.dart
+++ b/hibiki/lib/utils.dart
@@ -12,6 +12,8 @@ export 'src/utils/components/hibiki_dropdown.dart';
 export 'src/utils/components/hibiki_option_selection_page.dart';
 export 'src/utils/components/hibiki_marquee.dart';
 export 'src/utils/components/hibiki_tag.dart';
+export 'src/utils/components/cover_badge.dart';
+export 'src/utils/components/hibiki_destructive_confirm_dialog.dart';
 export 'src/utils/components/hibiki_placeholder_message.dart';
 export 'src/utils/components/hibiki_text_selection_controls.dart';
 export 'src/utils/components/hibiki_list_tile.dart';

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -652,6 +652,17 @@ void main() {
               'Surfaces still flow through HibikiDialogFrame + HibikiDesignTokens.',
       'lib/src/pages/implementations/reader_hibiki_history_page.dart':
           'Book-cover overlays and drag affordances are reader-shelf content.',
+      // CoverBadge 是压在封面图上的角标胶囊（字幕/云端/播放列表等），把书架/
+      // 视频卡上至少三份手抄的同款胶囊收口成一个组件。胶囊几何（radius 10）
+      // 与固定深色 scrim 沿用被收口的既有角标像素规格——封面叠层内容，
+      // 非普通页面 chrome，同书架封面叠层豁免类。
+      'lib/src/utils/components/cover_badge.dart':
+          'CoverBadge is the shared cover-art overlay pill (subtitle/cloud/'
+              'playlist badges) consolidating at least three hand-copied '
+              'badge implementations; its fixed dark scrim and pill radius '
+              'preserve the existing badge pixel spec — cover overlay '
+              'content, not ordinary page chrome, same reviewed exception '
+              'class as the reader-shelf book-cover overlays.',
       // TODO-947 系列/合集折叠卡的马赛克封面（2x2 成员封面网格）是书架内容/封面美术，
       // 不是页面 chrome：letterbox 底 surfaceContainerHighest 与格子圆角
       // BorderRadius.circular(cellRadius) 是封面拼图单元，同「书架封面/拖放」豁免类。
@@ -1807,7 +1818,17 @@ void main() {
     ]) {
       final String section = _sectionSource(components, start, end);
       expect(section, contains('AnimatedContainer('));
-      expect(section, contains('duration: hibikiMd3StateDuration'));
+      // MD3 状态动画时长必须来自 hibikiMd3StateDuration；HibikiCard 经
+      // einkSafeDuration 包装（eink 下归零，非 eink 恒等于 MD3 token）也算
+      // 合规——守卫的意图是「用 MD3 token」，不是「禁止 eink 例外」。
+      expect(
+        section.contains('duration: hibikiMd3StateDuration') ||
+            section.contains(
+                'duration: einkSafeDuration(context, hibikiMd3StateDuration)'),
+        isTrue,
+        reason: '$start section must animate with hibikiMd3StateDuration '
+            '(optionally eink-gated via einkSafeDuration)',
+      );
       expect(section, contains('curve: hibikiMd3StateCurve'));
     }
   });

--- a/hibiki/test/settings/settings_switch_row_single_focus_stop_test.dart
+++ b/hibiki/test/settings/settings_switch_row_single_focus_stop_test.dart
@@ -1,0 +1,55 @@
+// 单焦点站点契约：焦点根存在时，设置行（含开关行）在 Tab/手柄遍历里只出现
+// 一个停靠点（_SettingsRowFocusTarget）。此前 InkWell + trailing Switch 也各占
+// 一个站点，同一行最多 3 停且激活语义相同——长设置页遍历冗长（巡检 C2，
+// docs/reviews/2026-07-22-ui-ux-survey.md）。滑条/步进行本就用 ExcludeFocus
+// 收成单站点，这里锁住开关行与之对齐后不再回归。
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/utils/components/settings_shared.dart';
+
+void main() {
+  testWidgets('开关行在焦点根下只有一个 Tab 停靠点，整行点击仍可切换', (WidgetTester tester) async {
+    bool value = false;
+    await tester.pumpWidget(MaterialApp(
+      home: HibikiFocusRoot(
+        child: Scaffold(
+          body: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return AdaptiveSettingsSwitchRow(
+                title: '测试开关',
+                value: value,
+                onChanged: (bool v) => setState(() => value = v),
+              );
+            },
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+
+    final Element row = tester.element(find.byType(AdaptiveSettingsSwitchRow));
+    final FocusScopeNode scope = FocusScope.of(row);
+    expect(scope.traversalDescendants.length, 1,
+        reason: '开关行应只贡献 1 个焦点停靠点（此前 InkWell/Switch 额外各占一个）');
+
+    // 整行 tap 仍切换（ExcludeFocus 只挡焦点遍历，不挡指针）。
+    await tester.tap(find.byType(AdaptiveSettingsSwitchRow));
+    await tester.pump();
+    expect(value, isTrue);
+
+    // 键盘路径：Tab 落到唯一停靠点，Enter 激活切回。
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    final BuildContext? focusedContext =
+        FocusManager.instance.primaryFocus?.context;
+    expect(focusedContext, isNotNull, reason: 'Tab 应落到行的焦点停靠点');
+    Actions.maybeInvoke<ActivateIntent>(
+      focusedContext!,
+      const ActivateIntent(),
+    );
+    await tester.pump();
+    expect(value, isFalse, reason: 'Enter/Activate 应切换开关');
+  });
+}

--- a/hibiki/test/widgets/cover_badge_test.dart
+++ b/hibiki/test/widgets/cover_badge_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/utils/adaptive/adaptive_platform.dart';
+import 'package:hibiki/src/utils/components/cover_badge.dart';
+
+Widget _app({required bool eink, required Widget child}) {
+  return MaterialApp(
+    theme: ThemeData(
+      extensions: <ThemeExtension<dynamic>>[HibikiEinkTheme(eink)],
+    ),
+    home: Scaffold(body: Center(child: child)),
+  );
+}
+
+Color _badgeColor(WidgetTester tester) {
+  final Container container = tester.widget<Container>(
+    find.descendant(
+      of: find.byType(CoverBadge),
+      matching: find.byType(Container),
+    ),
+  );
+  return (container.decoration! as BoxDecoration).color!;
+}
+
+void main() {
+  testWidgets('渲染图标 + 可选文字', (WidgetTester tester) async {
+    await tester.pumpWidget(_app(
+      eink: false,
+      child: const CoverBadge(icon: Icons.subtitles_outlined, label: '12'),
+    ));
+    expect(find.byIcon(Icons.subtitles_outlined), findsOneWidget);
+    expect(find.text('12'), findsOneWidget);
+  });
+
+  testWidgets('常规主题：半透明深色胶囊（固定 scrim，不随 colorScheme）',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app(
+      eink: false,
+      child: const CoverBadge(icon: Icons.cloud_outlined),
+    ));
+    final Color color = _badgeColor(tester);
+    expect(color.a, lessThan(1.0));
+    expect(color.r, 0);
+  });
+
+  testWidgets('eink：纯黑实底（半透明黑在墨水屏合成抖动灰）', (WidgetTester tester) async {
+    await tester.pumpWidget(_app(
+      eink: true,
+      child: const CoverBadge(icon: Icons.cloud_outlined),
+    ));
+    expect(_badgeColor(tester), Colors.black);
+  });
+}

--- a/hibiki/test/widgets/hibiki_card_eink_border_test.dart
+++ b/hibiki/test/widgets/hibiki_card_eink_border_test.dart
@@ -1,0 +1,84 @@
+// eink 下 HibikiCard 必须自带描边：eink scheme 把 surface container 全部塌缩为
+// 背景色，无边卡片与页面融为一体（巡检 C1，docs/reviews/2026-07-22-ui-ux-survey.md）。
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/utils/adaptive/adaptive_platform.dart';
+import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
+
+Widget _app({required bool eink, required Widget child}) {
+  return MaterialApp(
+    theme: ThemeData(
+      extensions: <ThemeExtension<dynamic>>[HibikiEinkTheme(eink)],
+    ),
+    home: Scaffold(body: child),
+  );
+}
+
+RoundedRectangleBorder _cardShape(WidgetTester tester) {
+  final AnimatedContainer container = tester.widget<AnimatedContainer>(
+    find.descendant(
+      of: find.byType(HibikiCard),
+      matching: find.byType(AnimatedContainer),
+    ),
+  );
+  final ShapeDecoration decoration = container.decoration! as ShapeDecoration;
+  return decoration.shape as RoundedRectangleBorder;
+}
+
+void main() {
+  testWidgets('非 eink：默认无描边（现状不变）', (WidgetTester tester) async {
+    await tester.pumpWidget(_app(
+      eink: false,
+      child: const HibikiCard(child: SizedBox(width: 80, height: 48)),
+    ));
+    expect(_cardShape(tester).side, BorderSide.none);
+  });
+
+  testWidgets('eink：自动补 1px 描边', (WidgetTester tester) async {
+    await tester.pumpWidget(_app(
+      eink: true,
+      child: const HibikiCard(child: SizedBox(width: 80, height: 48)),
+    ));
+    final BorderSide side = _cardShape(tester).side;
+    expect(side.style, BorderStyle.solid);
+    expect(side.width, 1);
+  });
+
+  testWidgets('eink + selected：描边加粗到 2px（选中唯一可辨信号）',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app(
+      eink: true,
+      child: const HibikiCard(
+        selected: true,
+        child: SizedBox(width: 80, height: 48),
+      ),
+    ));
+    expect(_cardShape(tester).side.width, 2);
+  });
+
+  testWidgets('显式 borderColor 优先于 eink 默认边', (WidgetTester tester) async {
+    await tester.pumpWidget(_app(
+      eink: true,
+      child: const HibikiCard(
+        borderColor: Colors.red,
+        child: SizedBox(width: 80, height: 48),
+      ),
+    ));
+    expect(_cardShape(tester).side.color, Colors.red);
+  });
+
+  testWidgets('eink：状态动画时长归零（AnimatedContainer 不再连续重绘）',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app(
+      eink: true,
+      child: const HibikiCard(child: SizedBox(width: 80, height: 48)),
+    ));
+    final AnimatedContainer container = tester.widget<AnimatedContainer>(
+      find.descendant(
+        of: find.byType(HibikiCard),
+        matching: find.byType(AnimatedContainer),
+      ),
+    );
+    expect(container.duration, Duration.zero);
+  });
+}

--- a/hibiki/test/widgets/hibiki_destructive_confirm_dialog_test.dart
+++ b/hibiki/test/widgets/hibiki_destructive_confirm_dialog_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/utils/components/hibiki_destructive_confirm_dialog.dart';
+
+void main() {
+  Future<HibikiDestructiveConfirmResult?>? dialogResult;
+
+  Future<void> openDialog(
+    WidgetTester tester, {
+    String? checkboxLabel,
+  }) async {
+    dialogResult = null;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) => TextButton(
+            onPressed: () {
+              dialogResult = showDialog<HibikiDestructiveConfirmResult>(
+                context: context,
+                builder: (_) => HibikiDestructiveConfirmDialog(
+                  title: '删除书籍',
+                  message: '此操作不可撤销。',
+                  checkboxLabel: checkboxLabel,
+                ),
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('取消 pop null', (WidgetTester tester) async {
+    await openDialog(tester);
+    expect(find.text('删除书籍'), findsOneWidget);
+    expect(find.text('此操作不可撤销。'), findsOneWidget);
+
+    await tester.tap(find.text('CANCEL'));
+    await tester.pumpAndSettle();
+    expect(await dialogResult, isNull);
+  });
+
+  testWidgets('确认 pop 结果（无勾选项时 checked=false）', (WidgetTester tester) async {
+    await openDialog(tester);
+    await tester.tap(find.text('DELETE'));
+    await tester.pumpAndSettle();
+    final HibikiDestructiveConfirmResult? value = await dialogResult;
+    expect(value, isNotNull);
+    expect(value!.checked, isFalse);
+  });
+
+  testWidgets('勾选行整行可点，确认后 checked 随之', (WidgetTester tester) async {
+    await openDialog(tester, checkboxLabel: '连同本体删除');
+    expect(find.text('连同本体删除'), findsOneWidget);
+
+    await tester.tap(find.text('连同本体删除'));
+    await tester.pumpAndSettle();
+    final Checkbox checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+    expect(checkbox.value, isTrue);
+
+    await tester.tap(find.text('DELETE'));
+    await tester.pumpAndSettle();
+    expect((await dialogResult)!.checked, isTrue);
+  });
+}

--- a/hibiki/test/widgets/hibiki_placeholder_message_test.dart
+++ b/hibiki/test/widgets/hibiki_placeholder_message_test.dart
@@ -58,5 +58,39 @@ void main() {
       final Icon icon = tester.widget<Icon>(find.byIcon(Icons.search));
       expect(icon.size, 18);
     });
+
+    testWidgets('renders detail below the message, ellipsised to 3 lines',
+        (tester) async {
+      await tester.pumpWidget(buildTestApp(
+        const HibikiPlaceholderMessage(
+          icon: Icons.error_outline,
+          message: 'Something went wrong',
+          detail: 'SqliteException(14): unable to open database file',
+        ),
+      ));
+
+      final Text detail = tester.widget<Text>(
+        find.text('SqliteException(14): unable to open database file'),
+      );
+      expect(detail.maxLines, 3);
+      expect(detail.overflow, TextOverflow.ellipsis);
+    });
+
+    testWidgets('renders action widget and keeps it tappable', (tester) async {
+      int taps = 0;
+      await tester.pumpWidget(buildTestApp(
+        HibikiPlaceholderMessage(
+          icon: Icons.error_outline,
+          message: 'Something went wrong',
+          action: FilledButton(
+            onPressed: () => taps += 1,
+            child: const Text('Retry'),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('Retry'));
+      expect(taps, 1);
+    });
   });
 }


### PR DESCRIPTION
## 内容

巡检报告（docs/reviews/2026-07-22-ui-ux-survey.md，PR#328）阶段二的先行批——五个模块 PR 都建立在这些共享组件上：

- **HibikiCard eink 描边**（巡检 C1）：eink scheme 把 surface container 全部塌缩为背景色后，无边卡片与页面融为一体（主题层只给裸 Card 补了 CardThemeData 描边）。HibikiCard 现在 eink 下自动补 1px outline，selected 加粗 2px（eink 下填充色同样塌缩，边宽是唯一可辨的选中信号）；状态动画经新增的 `einkSafeDuration()` 归零。
- **buildError 根因修复**（巡检 B1）：此前把 `SqliteException(...)` 原始异常串当主文案上屏、且调用方传的 refresh 回调被静默丢弃。现在主文案走 i18n（新 key `error_load_failed`），异常串降级为折叠 detail，refresh 非空渲染重试按钮。影响所有 BasePageState 页面错误态。
- **HibikiPlaceholderMessage 扩展**：新增 `detail` / `action`，为各模块空态加 CTA 铺路（巡检 C3）。
- **CoverBadge**：封面角标胶囊共享组件（书架/视频卡至少 3 份手抄同款收口），eink 纯黑实底。
- **HibikiDestructiveConfirmDialog**：统一「确认销毁」对话框（可选勾选行），巡检发现四种实现并存，模块 PR 逐处收口。
- **设置行单焦点站点**（巡检 C2）：焦点根下 AdaptiveSettingsRow 的 InkWell/trailing Switch 退出 Tab 遍历，开关行与滑条/步进行的 ExcludeFocus 契约对齐——此前一行最多 3 个停靠点且激活语义相同。

## 守卫同步

- `md3_design_system_static_test`：CoverBadge 加入封面叠层豁免类（复用既有 reviewed 例外理由）；「MD3 状态动画」守卫接受 `einkSafeDuration(context, hibikiMd3StateDuration)` 包装形式（守卫意图是用 MD3 token，不是禁止 eink 例外）。

## 验证

- `flutter analyze` 零问题；`dart format` 已过。
- 全量 `flutter test`：**12588 通过 / 0 失败**（bash 环境；`update_manifest_publish_race_test` 需要 PATH 上有 bash，PowerShell 直跑会环境性失败，与本 PR 无关）。
- 新增测试：HibikiCard eink 描边/加粗/动画归零、CoverBadge eink 实底、销毁确认对话框返回值与勾选行、占位组件 detail/action、开关行单焦点站点守卫。
- eink 真实像素验收随 PR#316（eink 全局开关）真机验收一并做；本 PR 组件行为已由 widget 测试锁定。

## 依赖关系

- 无依赖；但阶段二各模块 PR（游戏/下载/书籍/视频/设置）将 base 在本分支上，建议先审本 PR。

https://claude.ai/code/session_01CfSqJG9psJkUVSig6DhH9Y