### PR TITLE
UI/UX 重构 PR-4：视频模块（chrome 浅色对比/角标收敛/空态 CTA/几何联动）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 38012 (2236 per locale)
+/// Strings: 38080 (2240 per locale)
 ///
-/// Built on 2026-07-22 at 05:54 UTC
+/// Built on 2026-07-22 at 08:06 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2978,6 +2978,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
   String get error_load_failed => 'Something went wrong while loading';
+  String get video_quality_empty => 'No switchable quality for this video';
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -8038,6 +8043,15 @@ class _StringsAr extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -13171,6 +13185,15 @@ class _StringsDe extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -18320,6 +18343,15 @@ class _StringsEs extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -23480,6 +23512,15 @@ class _StringsFr extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -28567,6 +28608,15 @@ class _StringsId extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -33702,6 +33752,15 @@ class _StringsIt extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -38642,6 +38701,15 @@ class _StringsJa extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -43585,6 +43653,15 @@ class _StringsKo extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -48698,6 +48775,15 @@ class _StringsNl extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -53826,6 +53912,15 @@ class _StringsPtBr extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -58937,6 +59032,15 @@ class _StringsRu extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -63993,6 +64097,15 @@ class _StringsTh extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -69081,6 +69194,15 @@ class _StringsTr extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -74156,6 +74278,15 @@ class _StringsVi extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 // Path: <root>
@@ -78878,6 +79009,14 @@ class _StringsZhCn extends _StringsEn {
   String get settings_destination_system_summary => '通用、更新与诊断';
   @override
   String get error_load_failed => '加载出错';
+  @override
+  String get video_quality_empty => '本视频没有可切换的画质';
+  @override
+  String get video_danmaku_manual_bind_failed => '弹幕加载失败，请稍后重试';
+  @override
+  String remote_video_info_size({required Object size}) => '大小：${size}';
+  @override
+  String get remote_video_info_no_subtitle => '不含字幕';
 }
 
 // Path: <root>
@@ -83736,6 +83875,15 @@ class _StringsZhHk extends _StringsEn {
   String get settings_destination_system_summary => '通用、更新與診斷';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get video_quality_empty => 'No switchable quality for this video';
+  @override
+  String get video_danmaku_manual_bind_failed =>
+      'Couldn\'t load danmaku for this episode. Try again later.';
+  @override
+  String remote_video_info_size({required Object size}) => 'Size: ${size}';
+  @override
+  String get remote_video_info_no_subtitle => 'No subtitles';
 }
 
 /// Flat map(s) containing all translations.
@@ -88300,6 +88448,14 @@ extension on _StringsEn {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -92862,6 +93018,14 @@ extension on _StringsAr {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -97445,6 +97609,14 @@ extension on _StringsDe {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -102027,6 +102199,14 @@ extension on _StringsEs {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -106615,6 +106795,14 @@ extension on _StringsFr {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -111185,6 +111373,14 @@ extension on _StringsId {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -115770,6 +115966,14 @@ extension on _StringsIt {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -120317,6 +120521,14 @@ extension on _StringsJa {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -124868,6 +125080,14 @@ extension on _StringsKo {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -129446,6 +129666,14 @@ extension on _StringsNl {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -134021,6 +134249,14 @@ extension on _StringsPtBr {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -138601,6 +138837,14 @@ extension on _StringsRu {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -143165,6 +143409,14 @@ extension on _StringsTh {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -147738,6 +147990,14 @@ extension on _StringsTr {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -152306,6 +152566,14 @@ extension on _StringsVi {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }
@@ -156840,6 +157108,14 @@ extension on _StringsZhCn {
         return '通用、更新与诊断';
       case 'error_load_failed':
         return '加载出错';
+      case 'video_quality_empty':
+        return '本视频没有可切换的画质';
+      case 'video_danmaku_manual_bind_failed':
+        return '弹幕加载失败，请稍后重试';
+      case 'remote_video_info_size':
+        return ({required Object size}) => '大小：${size}';
+      case 'remote_video_info_no_subtitle':
+        return '不含字幕';
       default:
         return null;
     }
@@ -161382,6 +161658,14 @@ extension on _StringsZhHk {
         return '通用、更新與診斷';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'video_quality_empty':
+        return 'No switchable quality for this video';
+      case 'video_danmaku_manual_bind_failed':
+        return 'Couldn\'t load danmaku for this episode. Try again later.';
+      case 'remote_video_info_size':
+        return ({required Object size}) => 'Size: ${size}';
+      case 'remote_video_info_no_subtitle':
+        return 'No subtitles';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "通用",
   "reading_section_mode": "模式与排版方向",
   "settings_destination_system_summary": "通用、更新与诊断",
-  "error_load_failed": "加载出错"
+  "error_load_failed": "加载出错",
+  "video_quality_empty": "本视频没有可切换的画质",
+  "video_danmaku_manual_bind_failed": "弹幕加载失败，请稍后重试",
+  "remote_video_info_size": "大小：$size",
+  "remote_video_info_no_subtitle": "不含字幕"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2234,5 +2234,9 @@
   "settings_section_general": "通用",
   "reading_section_mode": "模式與排版方向",
   "settings_destination_system_summary": "通用、更新與診斷",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "video_quality_empty": "No switchable quality for this video",
+  "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
+  "remote_video_info_size": "Size: $size",
+  "remote_video_info_no_subtitle": "No subtitles"
 }

--- a/hibiki/lib/src/media/video/video_chrome_colors.dart
+++ b/hibiki/lib/src/media/video/video_chrome_colors.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+/// 播放器 chrome 的固定亮色前景体系 + 浮层表面 alpha 两档（UI 巡检 PR-4）。
+///
+/// **播放器表面是固定深色 OSD 体系，不随 colorScheme**：media_kit 控制条压在
+/// fork 内固定深色 scrim 上（third_party/media_kit_video `material_desktop.dart`
+/// 的 0x61000000 / `material.dart` 的 0x66000000），chrome 前景（顶栏标题、底栏
+/// 时间、进度条、按钮、侧浮条图标、章节刻度）若跟随主题的 `cs.primary` /
+/// `cs.onSurface`，浅色 / eink 主题下取到的是深色前景 → 压在深色 scrim 上
+/// 黑压黑不可读。故前景收敛到本文件的固定亮色，深色主题下取值与旧实现一致
+/// （深色主题的 `cs.primary` 本就是亮 tone），视觉不变。
+///
+/// 注意边界：带**自有表面**的 chrome（侧边锁按钮的 surface 圆底、各 push-aside
+/// 侧栏、popover 面板）仍按主题 surface/onSurface 自配对——它们不裸压 scrim，
+/// 对比度由自身表面保证，不属于本体系。
+
+/// chrome 中性前景（标题 / 时间文本 / 章节刻度）：固定近白。
+const Color videoChromeNeutralForeground = Colors.white;
+
+/// chrome 强调色（按钮 / 进度条 / 滑块）：恒取「亮 tone」的 primary。
+///
+/// 深色主题的 [ColorScheme.primary] 即亮 tone（MD3 fromSeed tone 80）；浅色主题
+/// 取同一 seed 的 [ColorScheme.inversePrimary]（同为 tone 80）——两个主题下是
+/// 同一支亮色，深色主题视觉与旧实现（cs.primary）完全一致。eink 浅色方案的
+/// inversePrimary 为纯白（见 buildEinkColorScheme），在深色 scrim 上仍可读。
+Color videoChromeAccentColor(ColorScheme cs) =>
+    cs.brightness == Brightness.dark ? cs.primary : cs.inversePrimary;
+
+/// 视频浮层表面 alpha 收敛为两档（此前 0.55 / 0.78 / 0.92 / 0.94 四档并存）。
+///
+/// 实底档：承载列表 / 滑条等密集内容的浮层（控制条 popover、剧集侧栏面板），
+/// 近实底保证行文本可读。
+const double kVideoOverlaySolidAlpha = 0.94;
+
+/// 半透明档：允许画面透出的侧栏 / 独立浮钮（设置等 push-aside 半透明侧栏、
+/// 侧边锁按钮圆底）。
+const double kVideoOverlayTranslucentAlpha = 0.78;

--- a/hibiki/lib/src/media/video/video_episode_panel.dart
+++ b/hibiki/lib/src/media/video/video_episode_panel.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:hibiki/src/media/video/video_chrome_colors.dart';
 import 'package:hibiki/src/media/video/video_panel_auto_scroll.dart';
 
 /// 视频播放列表「剧集列表」push-aside 侧栏面板（TODO-638）。
@@ -100,7 +101,9 @@ class _VideoEpisodePanelState extends State<VideoEpisodePanel> {
     // 它要求 [Material] 是其直接祖先、且祖先与它之间不能夹不透明的 [ColoredBox]（否则
     // 抛 inkwell-on-opaque 断言）。故 Material 直接着色，内层只用 [SizedBox] 定宽。
     return Material(
-      color: cs.surface.withValues(alpha: 0.92),
+      // 浮层 alpha 两档制的实底档（UI 巡检 PR-4，0.92 → 0.94 归档）：剧集行文本
+      // 密集，近实底保证可读。
+      color: cs.surface.withValues(alpha: kVideoOverlaySolidAlpha),
       child: SizedBox(
         width: widget.width,
         child: Column(

--- a/hibiki/lib/src/media/video/video_side_panel.dart
+++ b/hibiki/lib/src/media/video/video_side_panel.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hibiki/src/media/video/video_chrome_colors.dart';
 
 class VideoTranslucentSidePanel extends StatelessWidget {
   const VideoTranslucentSidePanel({
@@ -42,7 +43,9 @@ class VideoTranslucentSidePanel extends StatelessWidget {
           child: SizedBox(
             width: panelWidth,
             child: Material(
-              color: colorScheme.surface.withValues(alpha: 0.78),
+              // 浮层 alpha 两档制的半透明档（UI 巡检 PR-4）。
+              color: colorScheme.surface
+                  .withValues(alpha: kVideoOverlayTranslucentAlpha),
               elevation: 8,
               clipBehavior: Clip.antiAlias,
               borderRadius: borderRadius,

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -2108,12 +2108,15 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     );
   }
 
-  /// 概览用短日期（`M-dd`；跨年补年份）。无 intl 依赖的确定性格式。
+  /// 概览用短日期（跨年补年份）。UI 巡检 PR-4：走 [MaterialLocalizations] 随
+  /// locale 本地化（此前手拼 `M-dd`，任何 locale 都是同一种破折号格式）。
   String _formatOverviewDate(DateTime at) {
-    final DateTime now = DateTime.now();
-    final String dd = at.day.toString().padLeft(2, '0');
-    if (at.year == now.year) return '${at.month}-$dd';
-    return '${at.year}-${at.month}-$dd';
+    final MaterialLocalizations localizations =
+        MaterialLocalizations.of(context);
+    if (at.year == DateTime.now().year) {
+      return localizations.formatShortMonthDay(at);
+    }
+    return localizations.formatShortDate(at);
   }
 
   /// 本地视频区的 sliver 列表：空库 / 筛选无结果时是占满剩余空间的提示；否则
@@ -2428,49 +2431,32 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
               fit: StackFit.expand,
               children: <Widget>[
                 _buildRemoteVideoCover(video),
-                Positioned(
-                  top: 6,
-                  right: 6,
-                  child: ref
-                          .watch(interconnectDownloadManagerProvider)
-                          .isRunning(video.id)
-                      ? RemoteDownloadProgressBadge(
-                          key: ValueKey<String>(
-                              'remote_video_downloading_$safeKey'),
-                          progress: ref
-                              .watch(interconnectDownloadManagerProvider)
-                              .progressFor(video.id),
-                          tooltip: t.remote_video_downloading,
-                        )
-                      : IconButton.filledTonal(
-                          key: ValueKey<String>(
-                              'remote_video_download_$safeKey'),
-                          tooltip: t.remote_video_download,
-                          iconSize: 18,
-                          visualDensity: VisualDensity.compact,
-                          icon: const Icon(Icons.download_outlined),
-                          onPressed: () => _downloadRemote(video),
-                        ),
-                ),
-                if (video.hasSubtitle)
+                // UI 巡检 PR-4：撤掉封面内嵌下载 IconButton——它是卡内嵌套焦点目标
+                // （违反 hero 卡「无独立按钮」纪律，见 [_buildContinueHero]），且热区
+                // <48dp。下载动作收敛到长按 / 右键面板（[_showRemoteVideoDialog] 的
+                // 「下载」快捷动作，云视频短按卡片本体即下载）。下载进行中仍在原位
+                // 显示纯展示的进度徽章（非交互，无焦点问题）。
+                if (ref
+                    .watch(interconnectDownloadManagerProvider)
+                    .isRunning(video.id))
                   Positioned(
                     top: 6,
-                    left: 6,
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 7,
-                        vertical: 3,
-                      ),
-                      decoration: BoxDecoration(
-                        color: Colors.black.withValues(alpha: 0.62),
-                        borderRadius: BorderRadius.circular(10),
-                      ),
-                      child: const Icon(
-                        Icons.subtitles_outlined,
-                        size: 14,
-                        color: Colors.white,
-                      ),
+                    right: 6,
+                    child: RemoteDownloadProgressBadge(
+                      key:
+                          ValueKey<String>('remote_video_downloading_$safeKey'),
+                      progress: ref
+                          .watch(interconnectDownloadManagerProvider)
+                          .progressFor(video.id),
+                      tooltip: t.remote_video_downloading,
                     ),
+                  ),
+                // 字幕角标收敛到共享 [CoverBadge]（UI 巡检 PR-4，PR-0 组件）。
+                if (video.hasSubtitle)
+                  const Positioned(
+                    top: 6,
+                    left: 6,
+                    child: CoverBadge(icon: Icons.subtitles_outlined),
                   ),
                 // TODO-885: 远端播放列表集数角标（与本地卡同款，左下避开右上字幕/下载）。
                 if (video.isPlaylist)
@@ -2515,14 +2501,17 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     final String safeKey = _safeRemoteKey(video.id);
     final String? coverPath = video.coverPath;
     if (coverPath != null && File(coverPath).existsSync()) {
-      return Image.file(
-        File(coverPath),
-        key: ValueKey<String>('remote_video_cover_$safeKey'),
-        // TODO-616 phase C: 视频封面是 16:9（1.78）源，封面卡槽比它更窄
-        // （约 1.3-1.55），BoxFit.cover 会裁掉左右。改用 contain 让整帧完整
-        // 显示，上下留少量空带 = 用户要的「完整显示」。
-        fit: BoxFit.contain,
-        errorBuilder: (_, __, ___) => _coverPlaceholder(),
+      // TODO-616 phase C / BUG-926 后注释更新（UI 巡检 PR-4）：封面槽位现在是精确
+      // 16:9（AspectRatio），标准 16:9 封面 contain 即铺满；保留 contain 是为非
+      // 16:9 源（竖版海报等）完整显示不裁切，露出的空带由 [_coverBacking] 垫
+      // surfaceContainer 衬底（不再透出卡片底色的突兀白/黑边）。
+      return _coverBacking(
+        Image.file(
+          File(coverPath),
+          key: ValueKey<String>('remote_video_cover_$safeKey'),
+          fit: BoxFit.contain,
+          errorBuilder: (_, __, ___) => _coverPlaceholder(),
+        ),
       );
     }
     final String? coverUrl = video.coverUrl;
@@ -2531,32 +2520,40 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     final RemoteCoverFetcher? fetcher =
         remoteCoverFetcherFor(_remoteVideoClient);
     if (coverUrl != null && coverUrl.isNotEmpty && fetcher != null) {
-      return Image(
-        // BUG-847：按稳定 video.id 磁盘缓存（非易变 coverUrl），冷启动/滚动不重下。
-        image: RemoteCoverImage(coverUrl, fetcher, cacheKey: video.id),
-        key: ValueKey<String>('remote_video_cover_$safeKey'),
-        // TODO-616 phase C: 同上，远端云视频封面也用 contain 完整显示不裁切。
-        fit: BoxFit.contain,
-        errorBuilder: (_, __, ___) => _coverPlaceholder(),
+      return _coverBacking(
+        Image(
+          // BUG-847：按稳定 video.id 磁盘缓存（非易变 coverUrl），冷启动/滚动不重下。
+          image: RemoteCoverImage(coverUrl, fetcher, cacheKey: video.id),
+          key: ValueKey<String>('remote_video_cover_$safeKey'),
+          // 非 16:9 源 contain 完整显示，同上衬底。
+          fit: BoxFit.contain,
+          errorBuilder: (_, __, ___) => _coverPlaceholder(),
+        ),
       );
     }
     return _coverPlaceholder();
   }
 
+  /// 封面衬底（UI 巡检 PR-4）：contain 的非 16:9 封面在 16:9 槽位里露出的空带
+  /// 垫 surfaceContainer（与 [_coverPlaceholder] 同色），本地 / 远端卡共用。
+  Widget _coverBacking(Widget cover) {
+    return ColoredBox(
+      color: Theme.of(context).colorScheme.surfaceContainer,
+      child: cover,
+    );
+  }
+
   String _safeRemoteKey(String id) =>
       id.replaceAll(RegExp(r'[^A-Za-z0-9._-]+'), '_');
 
-  /// 云角标 ☁ 视觉：半透明黑底胶囊 + 白色云图标（与字幕/集数徽章同款）。多端库
-  /// 联合视图占位卡的「远端 / 未下载」标识（spec §2.1）。带稳定 key 供 widget 测试定位。
+  /// 云角标 ☁：共享 [CoverBadge]（UI 巡检 PR-4 收敛，与字幕/集数徽章同款视觉）。
+  /// 多端库联合视图占位卡的「远端 / 未下载」标识（spec §2.1）。带稳定 key 供
+  /// widget 测试定位。
   Widget _remoteVideoCloudBadge(String safeKey) {
-    return Container(
+    return CoverBadge(
       key: ValueKey<String>('remote_video_cloud_badge_$safeKey'),
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
-      decoration: BoxDecoration(
-        color: Colors.black.withValues(alpha: 0.55),
-        borderRadius: BorderRadius.circular(10),
-      ),
-      child: const Icon(Icons.cloud_outlined, size: 13, color: Colors.white),
+      icon: Icons.cloud_outlined,
+      iconSize: 13,
     );
   }
 
@@ -2607,6 +2604,15 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
           icon: Icons.bar_chart_outlined,
           onTap: _openStatistics,
         ),
+        // UI 巡检 PR-4：桌面无触屏下拉手势，给「强制刷新远端清单」一个鼠标可达
+        // 的显式入口（与下拉刷新同一汇聚点 [_pullToRefresh]，失败提示一致）。
+        HibikiIconButton(
+          key: const ValueKey<String>('home_video_refresh'),
+          tooltip: t.refresh,
+          label: t.refresh,
+          icon: Icons.refresh,
+          onTap: () => unawaited(_pullToRefresh()),
+        ),
       ],
     );
   }
@@ -2650,8 +2656,12 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     );
   }
 
-  /// 展示远端视频的基本元数据（标题 + 是否含字幕）。纯信息弹窗。
+  /// 展示远端视频的基本元数据（标题 + 大小 + 字幕有无）。纯信息弹窗。
+  ///
+  /// UI 巡检 PR-4：此前只有「含字幕」一条且无字幕时正文整块为空（弹窗只剩标题，
+  /// 像坏了）。补文件大小行（host 清单带 sizeBytes 时），字幕改为显式两态。
   void _showRemoteVideoInfo(RemoteVideoInfo video) {
+    final int? sizeBytes = video.sizeBytes;
     showAppDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) => AlertDialog(
@@ -2660,7 +2670,17 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            if (video.hasSubtitle) Text(t.remote_video_info_has_subtitle),
+            if (sizeBytes != null && sizeBytes > 0)
+              Text(
+                t.remote_video_info_size(
+                  size: formatRemoteVideoSize(sizeBytes),
+                ),
+              ),
+            Text(
+              video.hasSubtitle
+                  ? t.remote_video_info_has_subtitle
+                  : t.remote_video_info_no_subtitle,
+            ),
           ],
         ),
         actions: <Widget>[
@@ -2725,22 +2745,17 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     ref.invalidate(allTagsProvider);
   }
 
+  /// 空库占位（UI 巡检 PR-4）：收敛到共享 [HibikiPlaceholderMessage] 骨架并补
+  /// 「导入视频」CTA——此前只有图标 + 一句话，新用户没有下一步动作入口。
   Widget _buildEmpty() {
-    final ColorScheme colors = Theme.of(context).colorScheme;
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          Icon(Icons.movie_outlined, size: 56, color: colors.onSurfaceVariant),
-          const SizedBox(height: 12),
-          Text(
-            t.video_library_empty,
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium
-                ?.copyWith(color: colors.onSurfaceVariant),
-          ),
-        ],
+    return HibikiPlaceholderMessage(
+      icon: Icons.movie_outlined,
+      message: t.video_library_empty,
+      action: FilledButton.tonalIcon(
+        key: const ValueKey<String>('home_video_empty_import'),
+        onPressed: () => unawaited(_openImport()),
+        icon: const Icon(Icons.add),
+        label: Text(t.video_import_action),
       ),
     );
   }
@@ -2900,7 +2915,9 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
               fit: StackFit.expand,
               children: <Widget>[
                 _buildCover(book),
-                if (tags.isNotEmpty)
+                // UI 巡检 PR-4：多选态勾选框占左上角（同为 top:6,left:6），标签层
+                // 让位隐藏——此前两层同角重叠，勾选框压在标签 chip 上两者都花。
+                if (tags.isNotEmpty && !showSelection)
                   Positioned(
                     top: 6,
                     left: 6,
@@ -3128,29 +3145,12 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     );
   }
 
-  /// 播放列表角标：右上角半透明胶囊「▶ N集」，与单视频卡一眼区分（C 需求②）。
+  /// 播放列表角标：半透明胶囊「▶ N集」，与单视频卡一眼区分（C 需求②）。
+  /// UI 巡检 PR-4：收敛到共享 [CoverBadge]（PR-0 组件，黑@0.6 圆角10 白图标）。
   Widget _buildPlaylistBadge(int episodeCount) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
-      decoration: BoxDecoration(
-        color: Colors.black.withValues(alpha: 0.62),
-        borderRadius: BorderRadius.circular(10),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          const Icon(Icons.playlist_play, size: 14, color: Colors.white),
-          const SizedBox(width: 3),
-          Text(
-            t.video_playlist_episodes(count: episodeCount),
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
-      ),
+    return CoverBadge(
+      icon: Icons.playlist_play,
+      label: t.video_playlist_episodes(count: episodeCount),
     );
   }
 
@@ -3182,14 +3182,17 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     if (cover == null || cover.isEmpty || !File(cover).existsSync()) {
       return _coverPlaceholder();
     }
-    return Image.file(
-      File(cover),
-      // TODO-616 phase C: 本地视频封面同样用 contain（封面卡槽比 16:9 源更窄，
-      // cover 会裁左右），完整显示不裁切。
-      fit: BoxFit.contain,
-      // BUG-959: 按物理像素上限解码，避免视频原生分辨率(1080p/4K)整帧撑爆 ImageCache。
-      cacheWidth: kLocalCoverDecodePixelWidth,
-      errorBuilder: (_, __, ___) => _coverPlaceholder(),
+    // TODO-616 phase C / BUG-926 后注释更新（UI 巡检 PR-4）：槽位现在是精确 16:9，
+    // 标准封面 contain 即铺满；保留 contain 为非 16:9 源完整显示，空带走
+    // [_coverBacking] 的 surfaceContainer 衬底。
+    return _coverBacking(
+      Image.file(
+        File(cover),
+        fit: BoxFit.contain,
+        // BUG-959: 按物理像素上限解码，避免视频原生分辨率(1080p/4K)整帧撑爆 ImageCache。
+        cacheWidth: kLocalCoverDecodePixelWidth,
+        errorBuilder: (_, __, ___) => _coverPlaceholder(),
+      ),
     );
   }
 
@@ -3203,6 +3206,20 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
       ),
     );
   }
+}
+
+/// 远端视频信息弹窗的文件大小格式化（UI 巡检 PR-4）：1024 进制 B/KB/MB/GB，
+/// 保留 1 位小数（B 档不带小数）。纯函数，测试同源。
+String formatRemoteVideoSize(int bytes) {
+  if (bytes < 1024) return '$bytes B';
+  const List<String> units = <String>['KB', 'MB', 'GB'];
+  double value = bytes / 1024;
+  int unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return '${value.toStringAsFixed(1)} ${units[unitIndex]}';
 }
 
 /// 视频批量打标签的三态意图：保持不变 / 添加该标签 / 移除该标签。

--- a/hibiki/lib/src/pages/implementations/video_hibiki/chapter.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/chapter.part.dart
@@ -94,7 +94,6 @@ extension _VideoChapter on _VideoHibikiPageState {
       bottomSystemInset: _videoBottomSystemInset(),
       tickHeight: tickHeight,
     );
-    final ColorScheme cs = _videoChromeColorScheme(context);
     return Positioned.fill(
       child: SafeArea(
         // 全屏安全区与 media_kit 控制条 padding 对齐；窗口态安全区为 0 不影响。
@@ -104,7 +103,11 @@ extension _VideoChapter on _VideoHibikiPageState {
             return IgnorePointer(
               child: AnimatedOpacity(
                 opacity: controlsVisible ? 1.0 : 0.0,
-                duration: _VideoHibikiPageState._videoChromeFadeDuration,
+                // eink 下归零（墨水屏残影，UI 巡检 PR-4）。
+                duration: einkSafeDuration(
+                  context,
+                  _VideoHibikiPageState._videoChromeFadeDuration,
+                ),
                 child: Padding(
                   // 水平内缩 16px 对齐 seekBarMargin；竖直由 band 锚定到 seek bar 轨道。
                   padding: EdgeInsets.only(
@@ -119,9 +122,11 @@ extension _VideoChapter on _VideoHibikiPageState {
                       width: double.infinity,
                       child: VideoChapterMarkers(
                         controller: controller,
-                        // 高对比刻度色：进度条用 primary，刻度改用 onSurface 让它在
-                        // 已播 / 未播段都可见（避免与 primary 进度填充同色被吞）。
-                        color: cs.onSurface.withValues(alpha: 0.7),
+                        // 高对比刻度色：进度条用 chrome 强调色，刻度用 chrome 中性
+                        // 前景（固定近白，UI 巡检 PR-4——onSurface 在浅色 / eink 主题
+                        // 下是深色，压深色 scrim 上不可见），两者恒不同色不被吞。
+                        color: _VideoHibikiPageState._videoChromeNeutralFg
+                            .withValues(alpha: 0.7),
                         thickness: 2.0 * _videoUiScale,
                       ),
                     ),

--- a/hibiki/lib/src/pages/implementations/video_hibiki/controls_popover.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/controls_popover.part.dart
@@ -467,7 +467,9 @@ extension _VideoControlsPopover on _VideoHibikiPageState {
       color: Colors.transparent,
       child: DecoratedBox(
         decoration: BoxDecoration(
-          color: cs.surfaceContainerHighest.withValues(alpha: 0.94),
+          // 浮层 alpha 两档制的实底档（UI 巡检 PR-4）。
+          color: cs.surfaceContainerHighest
+              .withValues(alpha: kVideoOverlaySolidAlpha),
           borderRadius: HibikiBorderRadius.menu,
           border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.7)),
           boxShadow: <BoxShadow>[

--- a/hibiki/lib/src/pages/implementations/video_hibiki/controls_theme.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/controls_theme.part.dart
@@ -77,9 +77,13 @@ extension _VideoControlsTheme on _VideoHibikiPageState {
       // 独立处理、不会冒泡到这里，故启用后点字幕仍是查词、点空白区才暂停，不冲突。
       playAndPauseOnTap: true,
       toggleFullscreenOnDoublePress: false,
-      seekBarPositionColor: cs.primary,
-      seekBarThumbColor: cs.primary,
-      buttonBarButtonColor: cs.primary,
+      // 播放器 chrome 前景固定亮色（UI 巡检 PR-4 P1）：控制条压在 fork 固定深色
+      // scrim（material_desktop.dart 0x61000000）上，表面固定深色 OSD 体系不随
+      // colorScheme——此前 cs.primary 在浅色 / eink 主题下是深色，黑压黑不可读。
+      // [_videoChromeAccent] 恒取亮 tone primary，深色主题取值与旧实现一致。
+      seekBarPositionColor: _videoChromeAccent(cs),
+      seekBarThumbColor: _videoChromeAccent(cs),
+      buttonBarButtonColor: _videoChromeAccent(cs),
       buttonBarHeight: _videoButtonBarHeight,
       buttonBarButtonSize: _videoControlIconSize,
       keyboardShortcuts: _videoKeyboardShortcuts(controller),
@@ -218,9 +222,11 @@ extension _VideoControlsTheme on _VideoHibikiPageState {
       seekBarContainerHeight: _videoSeekBarContainerHeight,
       seekBarThumbSize: _videoSeekBarThumbSize,
       seekBarHeight: _videoSeekBarTrackHeight,
-      seekBarPositionColor: cs.primary,
-      seekBarThumbColor: cs.primary,
-      buttonBarButtonColor: cs.primary,
+      // chrome 前景固定亮色（同桌面 theme，UI 巡检 PR-4 P1）：压固定深色 scrim
+      // （material.dart 0x66000000），不随 colorScheme。
+      seekBarPositionColor: _videoChromeAccent(cs),
+      seekBarThumbColor: _videoChromeAccent(cs),
+      buttonBarButtonColor: _videoChromeAccent(cs),
       buttonBarHeight: _videoButtonBarHeight,
       buttonBarButtonSize: _videoControlIconSize,
       primaryButtonBar: const <Widget>[],
@@ -278,11 +284,18 @@ extension _VideoControlsTheme on _VideoHibikiPageState {
     final String targetLabel =
         VideoSeekIndicatorLabel.target(position, delta, duration);
     final String deltaLabel = VideoSeekIndicatorLabel.deltaSigned(delta);
+    // UI 巡检 PR-4：HUD 表面 / 前景与页内其余 OSD 同源（[_osdSurfaceColor] /
+    // [_osdTextColor]，inverseSurface 自配对），字号 / 内边距吃 [_videoUiScale]
+    // ——此前硬编码 0xCC000000 / 白 / 22px，是页内唯一不吃缩放的 OSD。
+    final ColorScheme cs = _videoChromeColorScheme(context);
+    final Color textColor = _osdTextColor(cs);
+    final double scale = _videoUiScale;
     return Container(
       alignment: Alignment.center,
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      padding:
+          EdgeInsets.symmetric(horizontal: 20 * scale, vertical: 12 * scale),
       decoration: BoxDecoration(
-        color: const Color(0xCC000000),
+        color: _osdSurfaceColor(cs),
         borderRadius: BorderRadius.circular(12),
       ),
       child: Column(
@@ -291,21 +304,21 @@ extension _VideoControlsTheme on _VideoHibikiPageState {
           Text(
             targetLabel,
             textAlign: TextAlign.center,
-            style: const TextStyle(
-              fontSize: 22,
+            style: TextStyle(
+              fontSize: 22 * scale,
               fontWeight: FontWeight.w600,
-              color: Color(0xFFFFFFFF),
-              fontFeatures: <FontFeature>[FontFeature.tabularFigures()],
+              color: textColor,
+              fontFeatures: const <FontFeature>[FontFeature.tabularFigures()],
             ),
           ),
           const SizedBox(height: 2),
           Text(
             deltaLabel,
             textAlign: TextAlign.center,
-            style: const TextStyle(
-              fontSize: 14,
-              color: Color(0xCCFFFFFF),
-              fontFeatures: <FontFeature>[FontFeature.tabularFigures()],
+            style: TextStyle(
+              fontSize: 14 * scale,
+              color: textColor.withValues(alpha: 0.8),
+              fontFeatures: const <FontFeature>[FontFeature.tabularFigures()],
             ),
           ),
         ],

--- a/hibiki/lib/src/pages/implementations/video_hibiki/danmaku.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/danmaku.part.dart
@@ -194,6 +194,9 @@ extension _VideoDanmaku on _VideoHibikiPageState {
       );
     } catch (e) {
       debugPrint('[VideoDanmaku] manual bind failed: $e');
+      // UI 巡检 PR-4：失败给可见反馈（此前只 debugPrint，用户选完集面板不关、
+      // 弹幕不出现、零提示）。原始异常只留日志，不进 UI。
+      _showOsd(t.video_danmaku_manual_bind_failed, icon: Icons.error_outline);
     } finally {
       client.close();
     }

--- a/hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart
@@ -4,9 +4,9 @@ part of '../video_hibiki_page.dart';
 /// episode (剧集 push-aside 侧栏 + 自动连播倒计时) domain methods extracted via
 /// part-of (TODO-590 batch4); shared private scope. Behaviour-preserving: bodies
 /// are verbatim copies — this domain references no `setState(` (so no `_rebuild(`
-/// forwarding) and no `_VideoHibikiPageState` `static` member (so no
-/// full-qualification), unlike batch1/batch2 (setState→`_rebuild`) and batch3
-/// (static→`_VideoHibikiPageState.`). `kAutoPlayNextCountdownSeconds` is a
+/// forwarding). UI 巡检 PR-4 后 [_buildAutoAdvanceOverlay] 引用了一个 host
+/// `static`（`_VideoHibikiPageState._videoBottomChromeBaseline`，倒计时卡几何
+/// 推导），按 batch3 惯例全限定。`kAutoPlayNextCountdownSeconds` is a
 /// top-level const in `video_episode_start_policy.dart` (already imported by the
 /// main shell), not a host-class static, so it stays a bare reference. The
 /// `_episodeListVisible` / `_autoAdvanceCountdownNotifier` notifiers, their
@@ -223,7 +223,8 @@ extension _VideoEpisode on _VideoHibikiPageState {
     final double screenWidth = MediaQuery.sizeOf(context).width;
     final double panelWidth = (screenWidth * 0.28).clamp(240.0, 420.0);
     return AnimatedSize(
-      duration: const Duration(milliseconds: 200),
+      // eink 下归零（墨水屏残影，UI 巡检 PR-4）。
+      duration: einkSafeDuration(context, const Duration(milliseconds: 200)),
       curve: Curves.easeOut,
       alignment: Alignment.centerLeft,
       child: SizedBox(
@@ -273,12 +274,28 @@ extension _VideoEpisode on _VideoHibikiPageState {
   /// Stack，与 OSD 同源）。
   Widget _buildAutoAdvanceOverlay() {
     final ColorScheme cs = _videoChromeColorScheme(context);
+    // 倒计时卡底部避让从进度条真实几何推导（UI 巡检 PR-4）：与章节刻度层同源的
+    // [videoSeekBarTrackBand]（tickHeight 取轨道高 → band 顶缘 = 轨道上缘），卡片
+    // 底缘 = 轨道上缘 + 16×缩放 呼吸间距——此前固定 88 不吃 [_videoUiScale] 也不
+    // 吃系统 inset，缩放 >1 或手势导航高 inset 时压进进度条 / 按钮条。
+    final ({double bottom, double height}) band = videoSeekBarTrackBand(
+      isDesktop: _isDesktopVideoControls,
+      buttonBarHeight: _videoButtonBarHeight,
+      seekBarButtonGap: _videoSeekBarButtonGap,
+      seekBarContainerHeight: _videoSeekBarContainerHeight,
+      seekBarTrackHeight: _videoSeekBarTrackHeight,
+      bottomChromeBaseline: _VideoHibikiPageState._videoBottomChromeBaseline,
+      bottomSystemInset: _videoBottomSystemInset(),
+      tickHeight: _videoSeekBarTrackHeight,
+    );
+    final double countdownBottom =
+        band.bottom + band.height + 16 * _videoUiScale;
     return Positioned(
       right: 0,
       bottom: 0,
       child: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.only(right: 16, bottom: 88),
+          padding: EdgeInsets.only(right: 16, bottom: countdownBottom),
           child: ValueListenableBuilder<int?>(
             valueListenable: _autoAdvanceCountdownNotifier,
             builder: (BuildContext _, int? seconds, __) {

--- a/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
@@ -651,10 +651,10 @@ extension _VideoLayout on _VideoHibikiPageState {
         tooltip: _videoControlItemTooltip(item),
         iconSize: _videoControlIconSize,
         icon: Icon(_videoControlItemIcon(item)),
-        // TODO-604：图标用主题强调色 cs.primary，与底栏 / 顶栏按钮的
-        // buttonBarButtonColor 同源；此前用 cs.onSurface（中性前景）导致左 / 右侧
-        // 浮条按钮看上去「没吃到主题配色」、与底 / 顶栏不一致。
-        color: cs.primary,
+        // TODO-604：与底栏 / 顶栏按钮的 buttonBarButtonColor 同源。UI 巡检 PR-4：
+        // 同源改为 chrome 固定亮色强调色 [_videoChromeAccent]（裸图标浮在画面 /
+        // 固定深色 scrim 上，跟随 cs.primary 在浅色 / eink 主题下黑压黑）。
+        color: _videoChromeAccent(cs),
         onPressed: () => _activateVideoControlItem(
           item,
           controller,
@@ -830,7 +830,11 @@ extension _VideoLayout on _VideoHibikiPageState {
                         // 右侧按钮一样」）。
                         child: _lockButtonHoverKeepAlive(
                           child: Material(
-                            color: cs.surface.withValues(alpha: 0.55),
+                            // 锁按钮带自有 surface 圆底（非裸压 scrim），底色 / 图标
+                            // 仍按主题自配对；alpha 收敛进两档制的半透明档
+                            // （UI 巡检 PR-4，此前 0.55 独立一档）。
+                            color: cs.surface.withValues(
+                                alpha: kVideoOverlayTranslucentAlpha),
                             shape: const CircleBorder(),
                             clipBehavior: Clip.antiAlias,
                             child: IconButton(

--- a/hibiki/lib/src/pages/implementations/video_hibiki/quality.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/quality.part.dart
@@ -273,11 +273,14 @@ extension _VideoQuality on _VideoHibikiPageState {
           ],
         );
       }
+      // UI 巡检 PR-4：空态用专属说明文案（此前复用面板标题「画质」当空态，
+      // 看起来像面板坏了没加载出来）。
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
           child: Text(
-            t.video_quality,
+            t.video_quality_empty,
+            textAlign: TextAlign.center,
             style: TextStyle(color: cs.onSurfaceVariant),
           ),
         ),
@@ -289,7 +292,8 @@ extension _VideoQuality on _VideoHibikiPageState {
         child: Padding(
           padding: const EdgeInsets.all(24),
           child: Text(
-            t.video_quality,
+            t.video_quality_empty,
+            textAlign: TextAlign.center,
             style: TextStyle(color: cs.onSurfaceVariant),
           ),
         ),

--- a/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
@@ -1021,7 +1021,8 @@ extension _VideoSubtitle on _VideoHibikiPageState {
         (_subtitleListWidthDrag ?? (storedWidth > 0 ? storedWidth : autoWidth))
             .clamp(minPanelWidth, maxPanelWidth);
     return AnimatedSize(
-      duration: const Duration(milliseconds: 200),
+      // eink 下归零（墨水屏残影，UI 巡检 PR-4），与剧集侧栏同款。
+      duration: einkSafeDuration(context, const Duration(milliseconds: 200)),
       curve: Curves.easeOut,
       alignment: Alignment.centerLeft,
       child: SizedBox(

--- a/hibiki/lib/src/pages/implementations/video_hibiki/volume_osd.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/volume_osd.part.dart
@@ -246,7 +246,11 @@ extension _VideoVolumeOsd on _VideoHibikiPageState {
           valueListenable: _levelHudNotifier,
           builder: (BuildContext _, _VideoLevelHudState? hud, __) {
             return AnimatedSwitcher(
-              duration: const Duration(milliseconds: 160),
+              // eink 下归零（墨水屏残影，UI 巡检 PR-4）。
+              duration: einkSafeDuration(
+                context,
+                const Duration(milliseconds: 160),
+              ),
               child: hud == null
                   ? const SizedBox.shrink()
                   : switch (hud.kind) {
@@ -273,7 +277,11 @@ extension _VideoVolumeOsd on _VideoHibikiPageState {
             valueListenable: _osdNotifier,
             builder: (BuildContext _, _VideoOsdMessage? osd, __) {
               return AnimatedSwitcher(
-                duration: const Duration(milliseconds: 180),
+                // eink 下归零（墨水屏残影，UI 巡检 PR-4）。
+                duration: einkSafeDuration(
+                  context,
+                  const Duration(milliseconds: 180),
+                ),
                 child:
                     osd == null ? const SizedBox.shrink() : _buildOsdCard(osd),
               );
@@ -330,7 +338,13 @@ extension _VideoVolumeOsd on _VideoHibikiPageState {
         : const EdgeInsets.symmetric(horizontal: 12, vertical: 8);
     final BorderRadius radius = BorderRadius.circular(prominent ? 12 : 6);
     const AlignmentGeometry alignment = Alignment.topLeft;
-    const EdgeInsets outerPadding = EdgeInsets.only(left: 16, top: 52);
+    // OSD 顶部避让从顶栏几何推导（UI 巡检 PR-4）：顶栏高 = [_videoButtonBarHeight]
+    // （56×界面缩放）+ 8×缩放 呼吸间距——此前固定 52 不吃 [_videoUiScale]，缩放
+    // >1 时 OSD 压进顶栏按钮行。SafeArea 已在外层吃掉系统 inset。
+    final EdgeInsets outerPadding = EdgeInsets.only(
+      left: 16,
+      top: _videoButtonBarHeight + 8 * _videoUiScale,
+    );
     return Align(
       alignment: alignment,
       child: Padding(

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -52,6 +52,7 @@ import 'package:hibiki/src/media/video/video_long_press_speed_badge.dart';
 import 'package:hibiki/src/media/video/video_seek_indicator_label.dart';
 import 'package:hibiki/src/media/video/video_asbplayer_config.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
+import 'package:hibiki/src/media/video/video_chrome_colors.dart';
 import 'package:hibiki/src/media/video/video_control_customization.dart';
 import 'package:hibiki/src/media/video/video_control_layout_edit_overlay.dart';
 import 'package:hibiki/src/media/video/video_control_popover_placement.dart';
@@ -115,6 +116,8 @@ import 'package:hibiki/src/mining/immersion_mining_engine.dart';
 import 'package:hibiki/src/mining/immersion_mining_request.dart';
 import 'package:hibiki/src/utils/adaptive/adaptive_widgets.dart'
     show adaptivePageRoute;
+import 'package:hibiki/src/utils/adaptive/adaptive_platform.dart'
+    show einkSafeDuration;
 import 'package:hibiki/src/utils/app_ui_scale.dart';
 import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
@@ -786,12 +789,29 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   ColorScheme _videoChromeColorScheme(BuildContext context) =>
       Theme.of(context).colorScheme;
 
+  // 播放器 chrome 前景固定亮色体系（UI 巡检 PR-4 P1）：控制条 / 顶栏 / 底栏时间 /
+  // 侧浮条 / 章节刻度压在 media_kit fork 的**固定深色 scrim** 上（播放器表面固定
+  // 深色 OSD 体系，不随 colorScheme），前景必须固定亮色——此前跟随 cs.primary /
+  // cs.onSurface，浅色 / eink 主题下黑压黑。深色主题下取值与旧实现一致（视觉不变）。
+  // 单一真相源在 [video_chrome_colors.dart]（纯函数，测试同源）。
+
+  /// chrome 中性前景（标题 / 时间 / 章节刻度）：固定近白，见
+  /// [videoChromeNeutralForeground]。
+  static const Color _videoChromeNeutralFg = videoChromeNeutralForeground;
+
+  /// chrome 强调色（按钮 / 进度条 / 滑块）：恒亮 tone 的 primary，见
+  /// [videoChromeAccentColor]。
+  Color _videoChromeAccent(ColorScheme cs) => videoChromeAccentColor(cs);
+
   /// 顶栏标题字号，随界面大小缩放（TODO-067），与图标按钮同口径。
   double get _videoControlTitleFontSize =>
       _videoControlTitleFontSizeBase * _videoUiScale;
 
-  TextStyle _videoControlTitleStyle(ColorScheme cs) =>
-      TextStyle(color: cs.onSurface, fontSize: _videoControlTitleFontSize);
+  /// 顶栏标题样式：中性前景固定近白（chrome 固定亮色体系，不随 colorScheme）。
+  TextStyle _videoControlTitleStyle() => TextStyle(
+        color: _videoChromeNeutralFg,
+        fontSize: _videoControlTitleFontSize,
+      );
 
   Color _subtitleTextColor(ColorScheme cs) => cs.onSurface;
   Color _subtitleShadowColor(ColorScheme cs) => cs.shadow;
@@ -3207,9 +3227,14 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// 与 media_kit 的 `controlsTransitionDuration` 默认对齐：桌面 150ms、移动 300ms。
   /// [_desktopControlsTheme] / [_mobileControlsTheme] / [_buildSideLockButton] /
   /// [_buildVideoSideActionRail] 都读它，将来调一处全部跟随，不再各写各的 200ms。
-  Duration get _videoControlsTransitionDuration => _isDesktopVideoControls
-      ? const Duration(milliseconds: 150)
-      : const Duration(milliseconds: 300);
+  /// eink 主题下经 [einkSafeDuration] 归零（墨水屏连续重绘=残影），控制条与全部
+  /// 跟随者一次改单点全部生效（UI 巡检 PR-4）。
+  Duration get _videoControlsTransitionDuration => einkSafeDuration(
+        context,
+        _isDesktopVideoControls
+            ? const Duration(milliseconds: 150)
+            : const Duration(milliseconds: 300),
+      );
 
   /// 当前是否有承载光标操作的 overlay 打开（设置 / 音轨等浮层 [_videoSidePanel]，或
   /// 字幕跳转列表 [_subtitleListVisible]，TODO-329）。有 overlay 时光标不该被沉浸 /
@@ -4198,7 +4223,7 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
           textAlign: alignment == AlignmentDirectional.centerEnd
               ? TextAlign.end
               : TextAlign.start,
-          style: _videoControlTitleStyle(_videoChromeColorScheme(context)),
+          style: _videoControlTitleStyle(),
         ),
       ),
     );
@@ -4270,7 +4295,7 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
             icon: Icons.fast_rewind_rounded,
             label: t.video_bottom_seek_back_label,
             tooltip: t.video_bottom_seek_back,
-            color: Theme.of(context).colorScheme.primary,
+            color: _videoChromeAccent(Theme.of(context).colorScheme),
             onPressed: () => _seekRelative(-10000),
           );
         }
@@ -4281,7 +4306,7 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
             icon: Icons.fast_forward_rounded,
             label: t.video_bottom_seek_forward_label,
             tooltip: t.video_bottom_seek_forward,
-            color: Theme.of(context).colorScheme.primary,
+            color: _videoChromeAccent(Theme.of(context).colorScheme),
             onPressed: () => _seekRelative(10000),
           );
         }
@@ -4754,21 +4779,23 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     VideoPlayerController controller, {
     required bool desktop,
   }) {
-    final ColorScheme cs = Theme.of(context).colorScheme;
+    // 底栏时间前景走 chrome 固定亮色强调色（压固定深色 scrim，不随 colorScheme）。
+    final Color chromeAccent =
+        _videoChromeAccent(Theme.of(context).colorScheme);
     final bool roomyBottomBar = _hasRoomyVideoBottomBar();
     final Widget positionIndicator = desktop
         ? MaterialDesktopPositionIndicator(
             style: TextStyle(
               height: 1.0,
               fontSize: 12.0 * _videoUiScale,
-              color: cs.primary,
+              color: chromeAccent,
             ),
           )
         : MaterialPositionIndicator(
             style: TextStyle(
               height: 1.0,
               fontSize: 12.0 * _videoUiScale,
-              color: cs.primary,
+              color: chromeAccent,
             ),
           );
     final List<Widget> rightCluster = <Widget>[
@@ -4925,7 +4952,7 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
             child: Icon(
               icon,
               size: _videoControlIconSize * 0.9,
-              color: Theme.of(context).colorScheme.primary,
+              color: _videoChromeAccent(Theme.of(context).colorScheme),
             ),
           ),
         ),

--- a/hibiki/test/media/video/video_theme_color_static_test.dart
+++ b/hibiki/test/media/video/video_theme_color_static_test.dart
@@ -5,27 +5,32 @@ import '../../pages/video_hibiki_page_source_corpus.dart';
 /// 源码守卫：视频播放器 chrome 必须吃主题色——无法用纯单测覆盖（控制条由 media_kit
 /// 在真实 libmpv player 上渲染），故在源码层钉死：
 ///
-/// 1. 桌面/移动两套控制条主题的 `buttonBarButtonColor` 必须是强调色 `cs.primary`，
-///    与已是 `cs.primary` 的进度条统一（不再用 `cs.onSurface` / `Colors.white`）。
+/// 1. 桌面/移动两套控制条主题的 `buttonBarButtonColor` 必须是 chrome 固定亮色
+///    强调色 `_videoChromeAccent(cs)`（UI 巡检 PR-4：控制条压固定深色 scrim，
+///    直接用 `cs.primary` 在浅色 / eink 主题下黑压黑；深色主题下二者等值）。
 /// 2. 弹出菜单/底部 sheet（音轨/字幕/倍速/剧集）不得硬编码 `Colors.black87` 背景，
 ///    必须跟随 M3 主题表面色（浅色主题下才不会是死黑）。
 void main() {
   // TODO-590 batch11：两套 controls 主题已搬到 controls_theme.part.dart，读「合并语料」
-  // （主壳 + 全部 part）才能数到两处 buttonBarButtonColor: cs.primary。
+  // （主壳 + 全部 part）才能数到两处 buttonBarButtonColor: _videoChromeAccent(cs)。
   final String page = readVideoHibikiSource();
 
-  group('视频控制条按钮吃主题色', () {
-    test('两套控制条主题都用 cs.primary 作为 buttonBarButtonColor', () {
-      final int primaryCount =
-          'buttonBarButtonColor: cs.primary'.allMatches(page).length;
-      expect(primaryCount, 2, reason: '桌面与移动两套控制条主题都必须用 cs.primary（强调色）');
+  group('视频控制条按钮吃 chrome 固定亮色强调色', () {
+    test('两套控制条主题都用 _videoChromeAccent(cs) 作为 buttonBarButtonColor', () {
+      final int accentCount = 'buttonBarButtonColor: _videoChromeAccent(cs)'
+          .allMatches(page)
+          .length;
+      expect(accentCount, 2,
+          reason: '桌面与移动两套控制条主题都必须用 _videoChromeAccent（恒亮 tone 强调色）');
     });
 
-    test('控制条按钮不再用 onSurface / 硬编码白色', () {
+    test('控制条按钮不再用 cs.primary / onSurface / 硬编码白色', () {
+      expect(page.contains('buttonBarButtonColor: cs.primary'), isFalse,
+          reason: 'cs.primary 在浅色 / eink 主题下是深色，压深色 scrim 不可读（PR-4）');
       expect(page.contains('buttonBarButtonColor: cs.onSurface'), isFalse,
-          reason: 'onSurface 在浅色主题下叠在深色 scrim 上对比差，应换强调色');
+          reason: 'onSurface 在浅色主题下叠在深色 scrim 上对比差，应换 chrome 强调色');
       expect(page.contains('buttonBarButtonColor: Colors.white'), isFalse,
-          reason: '移动端硬编码白色不吃主题，应换强调色');
+          reason: '硬编码白色丢主题色相，应走 _videoChromeAccent（亮 tone primary）');
     });
   });
 

--- a/hibiki/test/pages/home_video_cloud_download_test.dart
+++ b/hibiki/test/pages/home_video_cloud_download_test.dart
@@ -120,8 +120,7 @@ void main() {
       while (sw.elapsed < const Duration(seconds: 30)) {
         await Future<void>.delayed(const Duration(milliseconds: 10));
         final InterconnectDownloadTask? task = manager.tasks['cloud/vid1'];
-        if (task != null &&
-            task.status != InterconnectDownloadStatus.running) {
+        if (task != null && task.status != InterconnectDownloadStatus.running) {
           return;
         }
       }
@@ -194,9 +193,15 @@ void main() {
     // 下载前列表无该行（云视频不在 VideoBooks）。
     expect(await repo.getByBookUid('cloud/vid1'), isNull);
 
+    // UI 巡检 PR-4：封面内嵌下载按钮已撤，下载入口 = 长按卡片弹面板 → 「下载」
+    // （云视频短按卡片本体也下载，见下一个用例）。
+    await tester.longPress(
+      find.byKey(const ValueKey<String>('remote_video_card_cloud_vid1')),
+    );
+    await tester.pumpAndSettle();
     await tapAndAwaitDownload(
       tester,
-      find.byKey(const ValueKey<String>('remote_video_download_cloud_vid1')),
+      find.text(t.remote_video_download),
     );
 
     // 撤掉 saveVideoBook 建行后此断言转红（行不存在）。

--- a/hibiki/test/pages/home_video_cover_badge_test.dart
+++ b/hibiki/test/pages/home_video_cover_badge_test.dart
@@ -1,0 +1,225 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/anki/anki_view_model.dart';
+import 'package:hibiki/src/media/video/video_book_repository.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/home_video_page.dart';
+import 'package:hibiki/src/platform/platform_providers.dart';
+import 'package:hibiki/src/platform/platform_services.dart';
+import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/remote_video_client.dart';
+import 'package:hibiki/src/utils/components/cover_badge.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import '../helpers/fake_anki_repository.dart';
+import '../helpers/test_platform_services.dart';
+
+/// UI 巡检 PR-4：视频库卡片的三处封面角标（字幕 / 云端 / 播放列表集数）收敛到
+/// PR-0 共享 [CoverBadge]。断言三处都渲染成 CoverBadge（按 key / icon 定位），
+/// 防止回退成各自手写的黑胶囊 Container。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('hibiki_cover_badge_pp');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      try {
+        pathProviderDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  late HibikiDatabase db;
+  late PlatformServices platformServices;
+  late FakeAnkiRepository ankiRepository;
+  late AppModel appModel;
+
+  setUp(() async {
+    LocaleSettings.setLocale(AppLocale.en);
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    final PreferencesRepository prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    final Directory storeDir =
+        Directory.systemTemp.createTempSync('hibiki_cover_badge_store');
+    platformServices = testPlatformServices();
+    ankiRepository = FakeAnkiRepository();
+    appModel = AppModel(platformServices)
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Widget buildApp(_FakeRemoteVideoClient client) => ProviderScope(
+        overrides: <Override>[
+          platformServicesProvider.overrideWithValue(platformServices),
+          ankiRepositoryProvider.overrideWithValue(ankiRepository),
+          appProvider.overrideWith((ref) => appModel),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: HomeVideoPage(
+                repo: VideoBookRepository(db),
+                remoteVideoClientLoader: () async => client,
+                remoteVideoDownloadDestination: (RemoteVideoInfo v) async =>
+                    File('${pathProviderDir.path}/${v.id.hashCode}.mp4'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('字幕 / 云端 / 播放列表三处角标均渲染为共享 CoverBadge',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    // 单张远端占位卡同时命中三种角标：hasSubtitle（左上字幕）+ episodes>1
+    // （左下集数）+ 云角标（右下恒在）。
+    await tester.pumpWidget(buildApp(_FakeRemoteVideoClient()));
+    await tester.pumpAndSettle();
+
+    final Finder card = find.byKey(
+      const ValueKey<String>('remote_video_card_remote_video-1'),
+    );
+    expect(card, findsOneWidget);
+
+    // 云角标：稳定 key + widget 类型是 CoverBadge。
+    final Finder cloudBadge = find.byKey(
+      const ValueKey<String>('remote_video_cloud_badge_remote_video-1'),
+    );
+    expect(cloudBadge, findsOneWidget);
+    expect(tester.widget(cloudBadge), isA<CoverBadge>());
+
+    // 字幕角标：卡内 CoverBadge 携字幕图标。
+    expect(
+      find.descendant(
+        of: card,
+        matching: find.widgetWithIcon(CoverBadge, Icons.subtitles_outlined),
+      ),
+      findsOneWidget,
+      reason: '字幕角标必须是共享 CoverBadge',
+    );
+
+    // 播放列表集数角标：卡内 CoverBadge 携播放列表图标。
+    expect(
+      find.descendant(
+        of: card,
+        matching: find.widgetWithIcon(CoverBadge, Icons.playlist_play),
+      ),
+      findsOneWidget,
+      reason: '播放列表集数角标必须是共享 CoverBadge',
+    );
+  });
+
+  test('source guard: 视频库页不再手写黑胶囊角标（收敛 CoverBadge）', () {
+    final String src =
+        File('lib/src/pages/implementations/home_video_page.dart')
+            .readAsStringSync();
+    expect(src, contains('CoverBadge('), reason: '角标必须走共享 CoverBadge');
+    expect(src, isNot(contains('Colors.black.withValues(alpha: 0.62)')),
+        reason: '手写黑胶囊角标（0.62）应已被 CoverBadge 取代');
+    expect(src, isNot(contains('Colors.black.withValues(alpha: 0.55)')),
+        reason: '手写黑胶囊角标（0.55）应已被 CoverBadge 取代');
+  });
+}
+
+class _FakeRemoteVideoClient implements RemoteVideoClient {
+  _FakeRemoteVideoClient();
+
+  @override
+  Future<List<RemoteVideoInfo>> listRemoteVideos() async => <RemoteVideoInfo>[
+        RemoteVideoInfo.fromJson(<String, Object?>{
+          'id': 'remote/video-1',
+          'title': 'Remote Episode',
+          'sizeBytes': 1024,
+          'hasSubtitle': true,
+          'coverPath': _writeTinyCover().path,
+          'episodes': <Map<String, Object?>>[
+            <String, Object?>{'index': 0, 'title': 'EP1'},
+            <String, Object?>{'index': 1, 'title': 'EP2'},
+          ],
+        }),
+      ];
+
+  File _writeTinyCover() {
+    final File file = File(
+      '${Directory.systemTemp.path}/hibiki_cover_badge_cover.png',
+    );
+    if (!file.existsSync()) file.writeAsBytesSync(_tinyPngBytes);
+    return file;
+  }
+
+  @override
+  Future<RemoteVideoStreamUrls> remoteVideoStreamUrls(
+    String id, {
+    int episodeIndex = 0,
+  }) async =>
+      const RemoteVideoStreamUrls(
+        streamUrl: 'http://127.0.0.1:1/stream',
+        subtitleUrl: null,
+        subtitleFileName: null,
+      );
+
+  @override
+  Future<void> getRemoteVideoSubtitle(
+    String id,
+    File dest, {
+    int? embeddedStreamIndex,
+    int episodeIndex = 0,
+    void Function(double progress)? onProgress,
+  }) async {}
+
+  @override
+  Future<void> downloadRemoteVideo(
+    String id,
+    File dest, {
+    void Function(double progress)? onProgress,
+  }) async {}
+
+  @override
+  Future<({int positionMs, int updatedAtMs})> remoteVideoPosition(
+    String id, {
+    int episodeIndex = 0,
+  }) async =>
+      (positionMs: 0, updatedAtMs: 0);
+
+  @override
+  Future<void> putRemoteVideoPosition(
+    String id,
+    int positionMs,
+    int updatedAtMs, {
+    int episodeIndex = 0,
+  }) async {}
+}
+
+final List<int> _tinyPngBytes =
+    base64Decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ'
+        'AAAADUlEQVR42mP8z8BQDwAFgwJ/l5YV3wAAAABJRU5ErkJggg==');

--- a/hibiki/test/pages/home_video_interconnect_manager_test.dart
+++ b/hibiki/test/pages/home_video_interconnect_manager_test.dart
@@ -98,22 +98,20 @@ void main() {
     await tester.pumpWidget(buildApp(client: client, manager: manager));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(
-      const ValueKey<String>('remote_video_download_remote_video-1'),
+    // UI 巡检 PR-4：封面内嵌下载按钮已撤，下载入口 = 长按卡片弹面板 → 「下载」。
+    await tester.longPress(find.byKey(
+      const ValueKey<String>('remote_video_card_remote_video-1'),
     ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.remote_video_download));
     await tester.pump();
     await tester.pump();
 
-    // 进度徽章出现（页面从 manager 读 isRunning），下载按钮被替换。
+    // 进度徽章出现（页面从 manager 读 isRunning）。
     expect(
       find.byKey(
           const ValueKey<String>('remote_video_downloading_remote_video-1')),
       findsOneWidget,
-    );
-    expect(
-      find.byKey(
-          const ValueKey<String>('remote_video_download_remote_video-1')),
-      findsNothing,
     );
     // manager（app 级真相源）确实持有该 running 任务。
     expect(manager.isRunning('remote/video-1'), isTrue);

--- a/hibiki/test/pages/home_video_remote_download_dedup_test.dart
+++ b/hibiki/test/pages/home_video_remote_download_dedup_test.dart
@@ -112,10 +112,13 @@ void main() {
     await tester.pumpWidget(buildApp(client: client));
     await tester.pumpAndSettle();
 
-    // 点下载：进入下载中态，badge 出现、原下载按钮被替换（用户看到进行中反馈）。
-    await tester.tap(find.byKey(
-      const ValueKey<String>('remote_video_download_remote_video-1'),
+    // 点下载（UI 巡检 PR-4：封面内嵌下载按钮已撤，入口 = 长按卡片弹面板 →
+    // 「下载」）：进入下载中态，badge 出现（用户看到进行中反馈）。
+    await tester.longPress(find.byKey(
+      const ValueKey<String>('remote_video_card_remote_video-1'),
     ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.remote_video_download));
     await tester.pump();
     await tester.pump();
 
@@ -123,11 +126,6 @@ void main() {
       find.byKey(
           const ValueKey<String>('remote_video_downloading_remote_video-1')),
       findsOneWidget,
-    );
-    expect(
-      find.byKey(
-          const ValueKey<String>('remote_video_download_remote_video-1')),
-      findsNothing,
     );
 
     // 收尾：放行下载让 finally 跑完，避免 pending future 泄漏告警。

--- a/hibiki/test/pages/home_video_remote_download_register_test.dart
+++ b/hibiki/test/pages/home_video_remote_download_register_test.dart
@@ -100,16 +100,18 @@ void main() {
     final InterconnectDownloadManager manager =
         ProviderScope.containerOf(tester.element(find.byType(HomeVideoPage)))
             .read(interconnectDownloadManagerProvider);
+    // UI 巡检 PR-4：封面内嵌下载按钮已撤，下载入口 = 长按卡片弹面板 → 「下载」。
+    await tester.longPress(find.byKey(
+      const ValueKey<String>('remote_video_card_remote-clip'),
+    ));
+    await tester.pumpAndSettle();
     await tester.runAsync(() async {
-      await tester.tap(find.byKey(
-        const ValueKey<String>('remote_video_download_remote-clip'),
-      ));
+      await tester.tap(find.text(t.remote_video_download));
       final Stopwatch sw = Stopwatch()..start();
       while (sw.elapsed < const Duration(seconds: 30)) {
         await Future<void>.delayed(const Duration(milliseconds: 10));
         final InterconnectDownloadTask? task = manager.tasks['remote-clip'];
-        if (task != null &&
-            task.status != InterconnectDownloadStatus.running) {
+        if (task != null && task.status != InterconnectDownloadStatus.running) {
           return;
         }
       }

--- a/hibiki/test/pages/home_video_remote_interconnect_test.dart
+++ b/hibiki/test/pages/home_video_remote_interconnect_test.dart
@@ -100,7 +100,8 @@ void main() {
     await tester.pumpAndSettle();
 
     // 多端库联合视图（spec §2.1，撤独立远端分区）：远端互联视频以占位卡混排进
-    // 主网格——卡片在、带云角标 ☁、右上角保留下载按钮（能力未丢失）。
+    // 主网格——卡片在、带云角标 ☁。UI 巡检 PR-4：封面不再内嵌下载 IconButton
+    // （卡内嵌套焦点目标 + 热区 <48dp），下载收敛到长按 / 右键面板。
     expect(find.text('Remote Episode'), findsOneWidget);
     expect(
       find.byKey(const ValueKey<String>(
@@ -112,7 +113,8 @@ void main() {
       find.byKey(const ValueKey<String>(
         'remote_video_download_remote_video-1',
       )),
-      findsOneWidget,
+      findsNothing,
+      reason: '封面内嵌下载按钮已撤（UI 巡检 PR-4），下载走长按面板',
     );
 
     final String source =
@@ -179,9 +181,12 @@ void main() {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(const ValueKey<String>(
-      'remote_video_download_remote_video-1',
+    // UI 巡检 PR-4：封面内嵌下载按钮已撤，下载入口 = 长按卡片弹面板 → 「下载」。
+    await tester.longPress(find.byKey(const ValueKey<String>(
+      'remote_video_card_remote_video-1',
     )));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.remote_video_download));
     await _pumpUntil(
       tester,
       () => remoteClient.downloadedIds.isNotEmpty,

--- a/hibiki/test/pages/video_controls_size_parity_static_test.dart
+++ b/hibiki/test/pages/video_controls_size_parity_static_test.dart
@@ -30,7 +30,8 @@ void main() {
         contains('static const double _videoPlayPauseIconSizeBase = 36'));
     expect(source,
         contains('static const double _videoControlTitleFontSizeBase = 16'));
-    expect(source, contains('TextStyle _videoControlTitleStyle(ColorScheme'));
+    // UI 巡检 PR-4：标题样式不再吃 ColorScheme（chrome 固定亮色），字号仍随缩放。
+    expect(source, contains('TextStyle _videoControlTitleStyle()'));
 
     // TODO-067:控制条尺寸 getter 必须乘以 _videoUiScale,让顶/底栏图标、按钮条高度、
     // 播放键、标题字号都随「界面大小」缩放(视频页被 HibikiAppUiScaleNeutralizer 中和,

--- a/hibiki/test/pages/video_lock_button_fade_parity_guard_test.dart
+++ b/hibiki/test/pages/video_lock_button_fade_parity_guard_test.dart
@@ -30,11 +30,18 @@ void main() {
   });
 
   test('存在派生 getter _videoControlsTransitionDuration（桌面 150ms / 移动 300ms）', () {
+    // UI 巡检 PR-4：getter 外层套 einkSafeDuration（eink 下动画时长归零防残影），
+    // 桌面 / 移动派生仍在其内、仍是单一真相源。
     expect(
       src.contains(
-          'Duration get _videoControlsTransitionDuration => _isDesktopVideoControls'),
+          'Duration get _videoControlsTransitionDuration => einkSafeDuration('),
       isTrue,
-      reason: '应有按桌面 / 移动派生的 _videoControlsTransitionDuration 单一真相源',
+      reason: '应有按桌面 / 移动派生（外层 einkSafeDuration）的单一真相源 getter',
+    );
+    expect(
+      src.contains('_isDesktopVideoControls'),
+      isTrue,
+      reason: '仍按桌面 / 移动派生时长',
     );
     expect(
       src.contains('? const Duration(milliseconds: 150)'),

--- a/hibiki/test/pages/video_osd_card_created_alignment_guard_test.dart
+++ b/hibiki/test/pages/video_osd_card_created_alignment_guard_test.dart
@@ -52,10 +52,12 @@ void main() {
       reason: 'OSD 卡片不得居中（TODO-1254 回归：居中会遮挡画面）',
     );
     // 突出变体不得再用 all(24) 的居中式外边距，改与被动 OSD 同款左上外边距。
+    // UI 巡检 PR-4：top 从固定 52 改为顶栏几何推导（_videoButtonBarHeight +
+    // 8×_videoUiScale），吃界面缩放；守卫断言推导式而非字面值。
     expect(
-      body.contains('EdgeInsets.only(left: 16, top: 52)'),
+      body.contains('top: _videoButtonBarHeight + 8 * _videoUiScale'),
       isTrue,
-      reason: 'OSD 卡片外边距应锚左上（left:16, top:52，避开顶栏）',
+      reason: 'OSD 卡片外边距应锚左上且 top 由顶栏高推导（避开顶栏、吃界面缩放）',
     );
   });
 }

--- a/hibiki/test/pages/video_rail_scale_theme_guard_test.dart
+++ b/hibiki/test/pages/video_rail_scale_theme_guard_test.dart
@@ -41,13 +41,14 @@ void main() {
             'rail IconButton 必须显式传 iconSize: _videoControlIconSize（吃缩放，TODO-388）');
   });
 
-  test('rail 图标走主题强调色（不再硬编码黑白）', () {
+  test('rail 图标走 chrome 固定亮色强调色（不再硬编码黑白）', () {
     final String body = railForBody();
     expect(body.contains('_videoChromeColorScheme(context)'), isTrue,
-        reason: 'rail 应取 _videoChromeColorScheme（随主题着色）');
-    expect(body.contains('color: cs.primary'), isTrue,
-        reason:
-            'rail 图标应用主题强调色 cs.primary（与底 / 顶栏 buttonBarButtonColor 同源，TODO-604）');
+        reason: 'rail 应取 _videoChromeColorScheme（取当前主题色相）');
+    // UI 巡检 PR-4：cs.primary 在浅色 / eink 主题下是深色，裸图标压画面不可读，
+    // 改与底 / 顶栏 buttonBarButtonColor 同源的 _videoChromeAccent（恒亮 tone）。
+    expect(body.contains('color: _videoChromeAccent(cs)'), isTrue,
+        reason: 'rail 图标应用 chrome 固定亮色强调色（与底 / 顶栏 buttonBarButtonColor 同源）');
     expect(body.contains('Colors.black.withValues(alpha: 0.42)'), isFalse,
         reason: 'rail 不应再硬编码黑色背景（TODO-388）');
     expect(body.contains('color: Colors.white'), isFalse,

--- a/hibiki/test/pages/video_theme_color_static_test.dart
+++ b/hibiki/test/pages/video_theme_color_static_test.dart
@@ -27,7 +27,8 @@ void main() {
 
     expect(source, contains('_subtitleTextColor(ColorScheme'));
     expect(source, contains('_videoChromeColorScheme'));
-    expect(source, contains('_videoControlTitleStyle(ColorScheme'));
+    // UI 巡检 PR-4：标题前景改 chrome 固定近白（不随 colorScheme），签名去 cs 参。
+    expect(source, contains('TextStyle _videoControlTitleStyle()'));
     expect(source, contains('_osdSurfaceColor(ColorScheme'));
     expect(source, contains('_osdTextColor(ColorScheme'));
     expect(source, contains('_subtitleStyle.resolveTextColor('));

--- a/hibiki/test/pages/video_topbar_guards_test.dart
+++ b/hibiki/test/pages/video_topbar_guards_test.dart
@@ -191,8 +191,11 @@ void main() {
           reason: '浮动侧栏 Stack 应只剩屏幕左/右两条（顶部两条已移入顶栏行）');
       // 顶部浮条专属的「让出固定顶栏高度」内边距随浮条一并删除（OSD 通知层用的
       // Alignment.topLeft 与本浮条无关，故不据 Alignment 判删除）。
-      expect(page.contains('_videoButtonBarHeight + 8'), isFalse,
-          reason: '顶部浮条的「让出顶栏高度」内边距应随浮条一并删除');
+      // UI 巡检 PR-4：OSD 通知卡的 top 现在也从顶栏高推导
+      // （`_videoButtonBarHeight + 8 * _videoUiScale`，吃界面缩放）——它是合法几何
+      // 联动、不是复活的顶部浮条；本禁令收紧为旧浮条的**不吃缩放**字面形态。
+      expect(page.contains('_videoButtonBarHeight + 8)'), isFalse,
+          reason: '顶部浮条的「让出顶栏高度」定值内边距应随浮条一并删除');
     });
 
     test('顶栏右侧按钮来自 topRight slot 的同一横排，不再硬编码第二套', () {

--- a/hibiki/test/widgets/video_chrome_colors_test.dart
+++ b/hibiki/test/widgets/video_chrome_colors_test.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_chrome_colors.dart';
+import 'package:hibiki/src/models/theme_notifier.dart';
+
+/// UI 巡检 PR-4 P1：播放器 chrome 前景固定亮色体系。chrome 压在 media_kit fork
+/// 的固定深色 scrim 上，前景在**任何主题**下都必须是亮色——此前跟随 cs.primary /
+/// cs.onSurface，浅色 / eink 主题下黑压黑不可读。
+void main() {
+  group('videoChromeAccentColor 固定亮色', () {
+    test('深色主题取值与旧实现一致（cs.primary，视觉不变）', () {
+      final ColorScheme dark = ColorScheme.fromSeed(
+        seedColor: const Color(0xFF1F4959),
+        brightness: Brightness.dark,
+      );
+      expect(videoChromeAccentColor(dark), dark.primary);
+    });
+
+    test('浅色主题下强调色是亮色（不再黑压黑）', () {
+      final ColorScheme light = ColorScheme.fromSeed(
+        seedColor: const Color(0xFF1F4959),
+        brightness: Brightness.light,
+      );
+      // 旧实现的 cs.primary 在浅色主题是深色（tone 40）——这正是 bug。
+      expect(light.primary.computeLuminance(), lessThan(0.25),
+          reason: '前提：浅色主题 primary 本身是深色（旧实现在深色 scrim 上不可读）');
+      final Color accent = videoChromeAccentColor(light);
+      expect(accent.computeLuminance(), greaterThan(0.25),
+          reason: '修复后：浅色主题下 chrome 强调色必须是亮 tone');
+    });
+
+    test('多个种子色的浅色主题强调色均为亮色', () {
+      for (final Color seed in <Color>[
+        Colors.red,
+        Colors.green,
+        Colors.blue,
+        Colors.purple,
+        Colors.orange,
+      ]) {
+        final ColorScheme light = ColorScheme.fromSeed(
+          seedColor: seed,
+          brightness: Brightness.light,
+        );
+        expect(
+          videoChromeAccentColor(light).computeLuminance(),
+          greaterThan(0.25),
+          reason: 'seed=$seed 的浅色主题 chrome 强调色必须是亮 tone',
+        );
+      }
+    });
+
+    test('eink 两个亮度方案的强调色均为亮色（纯白）', () {
+      final ColorScheme einkLight = buildEinkColorScheme(Brightness.light);
+      final ColorScheme einkDark = buildEinkColorScheme(Brightness.dark);
+      expect(videoChromeAccentColor(einkLight), Colors.white);
+      expect(videoChromeAccentColor(einkDark), Colors.white);
+    });
+
+    test('中性前景固定近白', () {
+      expect(videoChromeNeutralForeground.computeLuminance(), greaterThan(0.9));
+    });
+  });
+
+  group('source guard: 播放器 chrome 不再直接用 cs.primary / cs.onSurface', () {
+    test('controls_theme.part.dart 的控制条前景走 _videoChromeAccent', () {
+      final String src = File(
+        'lib/src/pages/implementations/video_hibiki/controls_theme.part.dart',
+      ).readAsStringSync();
+      expect(src, isNot(contains('seekBarPositionColor: cs.primary')),
+          reason: '进度条前景必须走 chrome 固定亮色 helper');
+      expect(src, isNot(contains('buttonBarButtonColor: cs.primary')),
+          reason: '按钮条前景必须走 chrome 固定亮色 helper');
+      expect(src, contains('buttonBarButtonColor: _videoChromeAccent(cs)'));
+    });
+
+    test('浮层 alpha 收敛两档（无游离字面 alpha）', () {
+      const Map<String, String> files = <String, String>{
+        'controls_popover':
+            'lib/src/pages/implementations/video_hibiki/controls_popover.part.dart',
+        'side_panel': 'lib/src/media/video/video_side_panel.dart',
+        'episode_panel': 'lib/src/media/video/video_episode_panel.dart',
+        'layout': 'lib/src/pages/implementations/video_hibiki/layout.part.dart',
+      };
+      for (final MapEntry<String, String> entry in files.entries) {
+        final String src = File(entry.value).readAsStringSync();
+        for (final String stray in <String>[
+          'alpha: 0.55',
+          'alpha: 0.78',
+          'alpha: 0.92',
+          'alpha: 0.94',
+        ]) {
+          expect(src, isNot(contains(stray)),
+              reason: '${entry.key} 的浮层表面 alpha 必须走 kVideoOverlay* 两档常量，'
+                  '不再写字面 $stray');
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
UI/UX 巡检阶段二 PR-4：视频模块展示层重构。基于 `ui-ux-pr0-shared`（共享组件先行批），只动展示层，播放内核（media_kit/mpv）逻辑不动；不动 third_party fork、不改持久化 key、手势/快捷键/手柄映射不变。

## P1

1. **播放器 chrome 前景固定亮色体系**：控制条/顶栏标题/底栏时间/侧浮条/章节刻度压在 fork 固定深色 scrim 上，此前跟随 `cs.primary`/`cs.onSurface`，浅色 & eink 主题黑压黑。新增 `lib/src/media/video/video_chrome_colors.dart`：`videoChromeAccentColor`（深色主题=cs.primary 原值不变；浅色主题取同 seed 亮 tone 的 `cs.inversePrimary`；eink=纯白）+ `videoChromeNeutralForeground`（近白中性前景）。覆盖 controls_theme（桌面+移动 seekBar/buttonBar）、顶栏标题、底栏时间、±10s 标注键、逐帧键、侧浮 rail、章节刻度。带自有 surface 的 chrome（锁按钮圆底、侧栏、popover）仍按主题自配对（注释已写清边界）。
2. **多选勾选框与标签 chip 同角重叠**：多选态隐藏标签层（home_video_page）。
3. **桌面刷新远端入口**：页头加刷新 HibikiIconButton（`home_video_refresh`）调 `_pullToRefresh`，复用现有 `refresh` key。

## P2

4. OSD 固定 `top:52` → 顶栏高（56×uiScale）+ 8×uiScale 推导。
5. 连播倒计时卡固定 `bottom:88` → `videoSeekBarTrackBand` 同源推导（对照章节刻度层），吃 uiScale + 系统 inset。
6. 横滑 seek HUD 硬编码黑/白/22px → `_osdSurfaceColor`/`_osdTextColor` + ×uiScale。
7. 画质面板空态文案=标题 → 新 key `video_quality_empty`（i18n_sync 17 语言）。
8. 弹幕手动匹配失败零反馈 → catch 里 `_showOsd`（新 key `video_danmaku_manual_bind_failed`）。
9. 远端视频信息弹窗无字幕时正文全空 → 补大小行（`sizeBytes` 格式化，纯函数 `formatRemoteVideoSize`）+ 无字幕显式行（新 key `remote_video_info_size` / `remote_video_info_no_subtitle`）。
10. 库空态收敛 `HibikiPlaceholderMessage` + 「导入视频」CTA。
11. 远端卡封面内嵌下载钮（嵌套焦点+热区<48dp）移除；下载收敛长按/右键面板（已有），下载中仍显进度徽章；5 个相关测试改走面板路径。
12. 封面 contain 过时注释更新（槽位已精确 16:9）+ 非 16:9 封面加 surfaceContainer 衬底（本地+远端）。
13. 日期 `M-dd` → `MaterialLocalizations.formatShortMonthDay`（跨年 `formatShortDate`）。
14. eink：播放器 chrome 全部 Animated* 时长走 `einkSafeDuration`（controls 过渡时长单点收口 + 锁按钮/OSD AnimatedSwitcher/剧集+字幕侧栏 AnimatedSize/章节刻度淡入淡出）。
15. 角标收敛：字幕/云/播放列表三处 → PR-0 `CoverBadge`（云角标保留稳定 key）。
16. 浮层 alpha 四档（0.55/0.78/0.92/0.94）→ 两档常量 `kVideoOverlaySolidAlpha=0.94`（popover、剧集侧栏 0.92→0.94）/ `kVideoOverlayTranslucentAlpha=0.78`（半透明侧栏、锁按钮 0.55→0.78）。

## 跳过项

- BUG-1010（控制条自动隐藏丢焦点）：按指示不动 third_party fork，待 Windows 真机复现另行处理。
- 继续观看 hero 双胞胎合并 / 画质 tile 双胞胎 / push-aside 六层包装抽取：低风险纯重构，本 PR 时间内未做，留后续。
- 字幕正文 `_subtitleTextColor(cs.onSurface)`：浅色主题下同样偏深，但字幕有独立样式系统 + 用户可配色（`VideoSubtitleStyle`），属字幕逻辑不在本 PR 范围，仅记录。

## 新增测试

- `test/pages/home_video_cover_badge_test.dart`：三处角标渲染为共享 CoverBadge（key/icon 定位）+ 源码守卫（无手写黑胶囊）。
- `test/widgets/video_chrome_colors_test.dart`：chrome 强调色浅色/深色/eink/多 seed 亮色断言（浅色主题 primary 深色前提 + 修复后亮色）；控制条前景与浮层 alpha 两档源码守卫。

## 既有测试适配

- 5 个远端下载测试改走「长按卡片 → 面板下载」路径（cloud_download / interconnect_manager / download_dedup / download_register / remote_interconnect）。
- 4 个源码守卫更新为新真相（buttonBarButtonColor=_videoChromeAccent、标题样式签名、rail 强调色、OSD top 推导式）。

## 验证

- `flutter analyze --no-pub`：0 issues
- `dart format .`：仅本 PR 文件（基线约 20 个无关未格式化文件已还原不入 commit）
- 全量 `flutter test --no-pub`：**+12597 通过 / ~5 skip / 0 失败**（第一轮出现的 media 守卫 + platform_updater 两个失败为陈旧编译缓存/被杀测试进程锁 DLL 的假红，单独复跑与第二轮全量均绿）

https://claude.ai/code/session_01CfSqJG9psJkUVSig6DhH9Y
