### PR TITLE
UI/UX 重构 PR-3：书籍模块（BUG-1008/1009/合集详情收敛/eink/收藏页打磨）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 38012 (2236 per locale)
+/// Strings: 38029 (2237 per locale)
 ///
-/// Built on 2026-07-22 at 05:54 UTC
+/// Built on 2026-07-22 at 08:05 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2978,6 +2978,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
   String get error_load_failed => 'Something went wrong while loading';
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -8038,6 +8040,9 @@ class _StringsAr extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -13171,6 +13176,9 @@ class _StringsDe extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -18320,6 +18328,9 @@ class _StringsEs extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -23480,6 +23491,9 @@ class _StringsFr extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -28567,6 +28581,9 @@ class _StringsId extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -33702,6 +33719,9 @@ class _StringsIt extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -38642,6 +38662,9 @@ class _StringsJa extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -43585,6 +43608,9 @@ class _StringsKo extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -48698,6 +48724,9 @@ class _StringsNl extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -53826,6 +53855,9 @@ class _StringsPtBr extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -58937,6 +58969,9 @@ class _StringsRu extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -63993,6 +64028,9 @@ class _StringsTh extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -69081,6 +69119,9 @@ class _StringsTr extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -74156,6 +74197,9 @@ class _StringsVi extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 // Path: <root>
@@ -78878,6 +78922,8 @@ class _StringsZhCn extends _StringsEn {
   String get settings_destination_system_summary => '通用、更新与诊断';
   @override
   String get error_load_failed => '加载出错';
+  @override
+  String get collection_loading_hint => '正在加载收藏并匹配音频文件…';
 }
 
 // Path: <root>
@@ -83736,6 +83782,9 @@ class _StringsZhHk extends _StringsEn {
   String get settings_destination_system_summary => '通用、更新與診斷';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get collection_loading_hint =>
+      'Loading collections and matching audio files…';
 }
 
 /// Flat map(s) containing all translations.
@@ -88300,6 +88349,8 @@ extension on _StringsEn {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -92862,6 +92913,8 @@ extension on _StringsAr {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -97445,6 +97498,8 @@ extension on _StringsDe {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -102027,6 +102082,8 @@ extension on _StringsEs {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -106615,6 +106672,8 @@ extension on _StringsFr {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -111185,6 +111244,8 @@ extension on _StringsId {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -115770,6 +115831,8 @@ extension on _StringsIt {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -120317,6 +120380,8 @@ extension on _StringsJa {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -124868,6 +124933,8 @@ extension on _StringsKo {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -129446,6 +129513,8 @@ extension on _StringsNl {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -134021,6 +134090,8 @@ extension on _StringsPtBr {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -138601,6 +138672,8 @@ extension on _StringsRu {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -143165,6 +143238,8 @@ extension on _StringsTh {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -147738,6 +147813,8 @@ extension on _StringsTr {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -152306,6 +152383,8 @@ extension on _StringsVi {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }
@@ -156840,6 +156919,8 @@ extension on _StringsZhCn {
         return '通用、更新与诊断';
       case 'error_load_failed':
         return '加载出错';
+      case 'collection_loading_hint':
+        return '正在加载收藏并匹配音频文件…';
       default:
         return null;
     }
@@ -161382,6 +161463,8 @@ extension on _StringsZhHk {
         return '通用、更新與診斷';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'collection_loading_hint':
+        return 'Loading collections and matching audio files…';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "通用",
   "reading_section_mode": "模式与排版方向",
   "settings_destination_system_summary": "通用、更新与诊断",
-  "error_load_failed": "加载出错"
+  "error_load_failed": "加载出错",
+  "collection_loading_hint": "正在加载收藏并匹配音频文件…"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "通用",
   "reading_section_mode": "模式與排版方向",
   "settings_destination_system_summary": "通用、更新與診斷",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "collection_loading_hint": "Loading collections and matching audio files…"
 }

--- a/hibiki/lib/src/media/collections/collection_shelf_row.dart
+++ b/hibiki/lib/src/media/collections/collection_shelf_row.dart
@@ -310,6 +310,9 @@ class _CollectionShelfRowState extends State<CollectionShelfRow> {
     void Function(BookTagRow tag) onTagDropped,
   ) {
     final Color hoverColor = tokens.surfaces.primary;
+    // eink：半透明高亮罩在墨水屏合成抖动灰，且 primary 已塌缩——去掉填充色，
+    // 只留实心描边 + 图标作拖放悬停反馈。
+    final bool eink = isEinkTheme(context);
     return DragTarget<BookTagRow>(
       onWillAcceptWithDetails: (_) => true,
       onAcceptWithDetails: (DragTargetDetails<BookTagRow> details) {
@@ -335,7 +338,7 @@ class _CollectionShelfRowState extends State<CollectionShelfRow> {
                 child: IgnorePointer(
                   child: DecoratedBox(
                     decoration: BoxDecoration(
-                      color: hoverColor.withValues(alpha: 0.18),
+                      color: eink ? null : hoverColor.withValues(alpha: 0.18),
                       borderRadius: tokens.radii.controlRadius,
                       border: Border.all(
                         color: hoverColor,

--- a/hibiki/lib/src/pages/implementations/collection_detail_shared.dart
+++ b/hibiki/lib/src/pages/implementations/collection_detail_shared.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+
+import 'package:hibiki/src/pages/implementations/collection_name_dialog.dart'
+    show showCollectionNameDialog;
+import 'package:hibiki/src/pages/implementations/tag_picker_page.dart';
+import 'package:hibiki/utils.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 两个合集详情页（视频剧集列表 [MediaCollectionDetailPage] 与书架网格
+/// [MediaCollectionGridDetailPage]）逐行手抄的四组共享行为收口（巡检 PR-3）：
+/// 重命名、编辑标签 + 标签 chip 行、AppBar 排序菜单、删除确认。
+///
+/// 排序回调（两页数据模型不同：VideoBookRow 内存排 vs 成员行现查元数据排）与
+/// 删除后的实际落库仍留在各页；这里只收「同形 UI + 同语义对话框」。
+mixin CollectionDetailShared<T extends StatefulWidget> on State<T> {
+  /// 宿主页提供：数据库 / 合集行 / 当前显示名 / 改动回调。
+  HibikiDatabase get detailDatabase;
+  MediaCollectionRow get detailCollection;
+  String get detailName;
+  set detailName(String value);
+  VoidCallback get detailOnChanged;
+
+  /// 标签 chip 行强制重取计数（编辑标签返回后自增）。
+  int detailTagsRefresh = 0;
+
+  /// 重命名合集：命名弹窗 → renameMediaCollection → setState 更新页题。
+  Future<void> renameDetailCollection() async {
+    final String? newName = await showCollectionNameDialog(
+      context: context,
+      title: t.rename_collection,
+      initialName: detailName,
+    );
+    if (newName == null || newName == detailName) return;
+    await detailDatabase.renameMediaCollection(detailCollection.id, newName);
+    if (!mounted) return;
+    setState(() => detailName = newName);
+    detailOnChanged();
+  }
+
+  /// 编辑本合集的标签：复用共享标签池的 [TagPickerPage]（合集路，传
+  /// collectionId）；返回后自增刷新计数，触发 [buildDetailTagChips] 的
+  /// FutureBuilder 重取，chip 行立即反映新增/移除。
+  Future<void> editDetailCollectionTags() async {
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute<void>(
+        builder: (_) => TagPickerPage(collectionId: detailCollection.id),
+      ),
+    );
+    if (!mounted) return;
+    setState(() => detailTagsRefresh++);
+  }
+
+  /// 详情页头部标签 chip 行：随 [detailTagsRefresh] 强制重取本合集标签；空则不占位。
+  Widget buildDetailTagChips() {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return FutureBuilder<List<BookTagRow>>(
+      key: ValueKey<int>(detailTagsRefresh),
+      future: detailDatabase.getTagsForCollection(detailCollection.id),
+      builder: (BuildContext context, AsyncSnapshot<List<BookTagRow>> snap) {
+        final List<BookTagRow> tags = snap.data ?? const <BookTagRow>[];
+        if (tags.isEmpty) return const SizedBox.shrink();
+        return Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: tokens.spacing.rowVertical,
+            vertical: tokens.spacing.gap,
+          ),
+          child: Wrap(
+            spacing: tokens.spacing.gap * 0.75,
+            runSpacing: tokens.spacing.gap * 0.75,
+            children: <Widget>[
+              for (final BookTagRow tag in tags)
+                HibikiTagChip(
+                  label: tag.name,
+                  color: Color(tag.colorValue),
+                  tone: HibikiTagChipTone.surface,
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  /// AppBar「排序」菜单（按名称 / 按导入时间一键重排）；实际重排落库由宿主页回调。
+  Widget buildDetailSortMenu({
+    required VoidCallback onSortByTitle,
+    required VoidCallback onSortByImported,
+  }) {
+    return MenuAnchor(
+      menuChildren: <Widget>[
+        MenuItemButton(
+          leadingIcon: const Icon(Icons.sort_by_alpha, size: 20),
+          onPressed: onSortByTitle,
+          child: Text(t.collection_sort_by_title),
+        ),
+        MenuItemButton(
+          leadingIcon: const Icon(Icons.history, size: 20),
+          onPressed: onSortByImported,
+          child: Text(t.collection_sort_by_imported),
+        ),
+      ],
+      builder: (BuildContext context, MenuController controller, Widget? _) =>
+          IconButton(
+        tooltip: t.sort_by,
+        icon: const Icon(Icons.sort),
+        onPressed: () =>
+            controller.isOpen ? controller.close() : controller.open(),
+      ),
+    );
+  }
+
+  /// 「删除合集」确认：统一走 PR-0 的 [HibikiDestructiveConfirmDialog]。
+  /// [checkboxLabel] 非空 = 提供「连同成员本体一起删」勾选行；null = 纯解链删除。
+  /// 返回 null = 取消。
+  Future<HibikiDestructiveConfirmResult?> confirmDetailCollectionDelete({
+    String? checkboxLabel,
+  }) {
+    return showAppDialog<HibikiDestructiveConfirmResult>(
+      context: context,
+      builder: (_) => HibikiDestructiveConfirmDialog(
+        title: t.delete_collection,
+        message: t.delete_collection_confirm,
+        confirmLabel: t.delete_collection,
+        checkboxLabel: checkboxLabel,
+      ),
+    );
+  }
+
+  /// 「移出合集」确认（逐成员）：同走 [HibikiDestructiveConfirmDialog]。true = 确认。
+  Future<bool> confirmDetailRemoveMember() async {
+    final HibikiDestructiveConfirmResult? result =
+        await showAppDialog<HibikiDestructiveConfirmResult>(
+      context: context,
+      builder: (_) => HibikiDestructiveConfirmDialog(
+        title: t.collection_remove_member,
+        message: t.collection_remove_member_confirm,
+        confirmLabel: t.collection_remove_member,
+        leadingIcon: Icons.remove_circle_outline,
+      ),
+    );
+    return result != null;
+  }
+}

--- a/hibiki/lib/src/pages/implementations/collections_page.dart
+++ b/hibiki/lib/src/pages/implementations/collections_page.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -168,8 +169,28 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
   /// row 即可定位「该集视频文件 + 时间段」，按需 ffmpeg 抽音（见
   /// [resolveVideoFavoriteAudioClip] / [_playVideoFavoriteAudio]）。
   Map<String, VideoBookRow> _videoRowMap = {};
-  bool _playingAudio = false;
-  final _dateFmt = DateFormat('MM/dd HH:mm');
+
+  /// 正在截取/播放音频的**那一行**的列表键（[_itemKey]）；null = 无进行中播放。
+  /// 旧实现是全局 bool——一行在播，全列表按钮统一变沙漏且禁点（巡检 PR-3）。
+  String? _playingItemKey;
+
+  /// 收藏日期本地化格式（巡检 PR-3）：跟随 app 语言的月日顺序，当年条目省年份、
+  /// 跨年条目补年份（旧硬编码 'MM/dd HH:mm' 对 en 等 locale 月日顺序错，且去年
+  /// 条目与今年同形混淆）。date symbols 已在 [_load] 里 initializeDateFormatting；
+  /// 仅当 app 语言对 intl 是未知 locale（ArgumentError）时退回 intl 默认 locale。
+  String _formatCreatedAt(DateTime createdAt) {
+    final bool sameYear = createdAt.year == DateTime.now().year;
+    final String locale = LocaleSettings.currentLocale.languageTag;
+    DateFormat fmt;
+    try {
+      fmt = sameYear
+          ? DateFormat.Md(locale).add_Hm()
+          : DateFormat.yMd(locale).add_Hm();
+    } on ArgumentError {
+      fmt = sameYear ? DateFormat.Md().add_Hm() : DateFormat.yMd().add_Hm();
+    }
+    return fmt.format(createdAt);
+  }
 
   @override
   void initState() {
@@ -179,6 +200,10 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
 
   Future<void> _load() async {
     setState(() => _loading = true);
+
+    // 本地化日期格式（[_formatCreatedAt]）需要 intl 的 date symbols；纯内存表
+    // 初始化（date_symbol_data_local，无 IO），在首次渲染行之前完成。
+    await initializeDateFormatting();
 
     final db = appModel.database;
     final favoriteRepo = FavoriteSentenceRepository(db);
@@ -487,6 +512,12 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
       return;
     }
 
+    // 巡检 PR-3：换行播放 = 先停旧后播新（其余行不再禁点）。只调整调用顺序，
+    // 播放器逻辑（TtsChannel.playFile / stop）不动。
+    if (_playingItemKey != null && _playingItemKey != _itemKey(item)) {
+      await TtsChannel.instance.stop();
+    }
+
     // 视频来源句：从收藏字段自带的 cue 时间窗 + 该集视频文件抽音（容器内交错，但
     // ffmpeg `-ss`/`-t` 在 `-i` 前快速输入定位，只解码这几秒，不读穿整个文件）。
     if (item.source == kFavoriteSentenceSourceVideo) {
@@ -523,6 +554,7 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
     }
 
     await _extractAndPlay(
+      itemKey: _itemKey(item),
       inputPath: audioFiles[range.audioFileIndex].path,
       startMs: range.startMs,
       endMs: range.endMs,
@@ -553,6 +585,7 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
       return;
     }
     await _extractAndPlay(
+      itemKey: _itemKey(item),
       inputPath: clip.filePath,
       startMs: clip.startMs,
       endMs: clip.endMs,
@@ -565,11 +598,12 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
   /// 桌面端经 [TtsChannel.extractAudioSegment] → ffmpeg；ffmpeg 可执行的「覆盖>捆绑>
   /// PATH」解析与捆绑损坏自动回退 PATH 由 ffmpeg_backend.dart 统一保证（BUG-233）。
   Future<void> _extractAndPlay({
+    required String itemKey,
     required String inputPath,
     required int startMs,
     required int endMs,
   }) async {
-    setState(() => _playingAudio = true);
+    setState(() => _playingItemKey = itemKey);
     try {
       final Directory tmpDir = await getTemporaryDirectory();
       final String outputPath = p.join(
@@ -589,7 +623,11 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
         HibikiToast.show(msg: t.audio_clip_failed);
       }
     } finally {
-      if (mounted) setState(() => _playingAudio = false);
+      // 只清自己那一次的进行中标记：期间用户已点了别的行（先停旧后播新）时，
+      // 新行的 key 不能被旧 finally 抹掉。
+      if (mounted && _playingItemKey == itemKey) {
+        setState(() => _playingItemKey = null);
+      }
     }
   }
 
@@ -898,6 +936,18 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
     return cleaned.isEmpty ? 'export' : cleaned;
   }
 
+  /// 行的稳定列表键（Dismissible key 与「播放中」行标记共用同一编码）。
+  String _itemKey(_CollectionItem item) {
+    switch (item.type) {
+      case _CollectionType.mined:
+        return 'mined_${item.minedId}';
+      case _CollectionType.word:
+        return 'word_${item.text}_${item.wordReading}_${item.wordSourceType}';
+      case _CollectionType.sentence:
+        return 'fav_${item.favoriteId}';
+    }
+  }
+
   bool _hasAudio(_CollectionItem item) {
     // 视频来源句：有该视频的 row 且收藏自带可用 cue 时间窗即可抽音（不进 _cueMap）。
     if (item.source == kFavoriteSentenceSourceVideo) {
@@ -933,11 +983,14 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
           if (hasAudio)
             TextButton.icon(
               icon: Icon(
-                _playingAudio ? Icons.hourglass_top : Icons.volume_up_outlined,
+                _playingItemKey == _itemKey(item)
+                    ? Icons.hourglass_top
+                    : Icons.volume_up_outlined,
                 size: 18,
               ),
               label: Text(t.dialog_play),
-              onPressed: _playingAudio
+              // 仅「本条」正在播时禁点；别的行在播不再连坐（点击先停旧后播新）。
+              onPressed: _playingItemKey == _itemKey(item)
                   ? null
                   : () {
                       Navigator.pop(ctx);
@@ -993,7 +1046,8 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
         if (!_loading && _hasExportableItems)
           HibikiIconButton(
             tooltip: t.dialog_export,
-            icon: Icons.ios_share_outlined,
+            // 全平台统一 Material 分享图标（ios_share 是 iOS 专属视觉，巡检 PR-3）。
+            icon: Icons.share_outlined,
             onTap: _openExportSheet,
           ),
         // 只要列表非空就显示「清空」；点开可选范围面板（书签/收藏句/制卡句/收藏词），
@@ -1006,7 +1060,23 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
           ),
       ],
       body: _loading
-          ? Center(child: adaptiveIndicator(context: context))
+          // 加载耗时源是逐书 cue + 音频文件存在性扫描（[_load]），可能数秒——补一行
+          // 说明文案，用户知道在等什么（巡检 PR-3）。
+          ? Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  adaptiveIndicator(context: context),
+                  SizedBox(height: HibikiDesignTokens.of(context).spacing.gap),
+                  Text(
+                    t.collection_loading_hint,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            )
           : _items.isEmpty
               ? Center(
                   child: HibikiPlaceholderMessage(
@@ -1033,7 +1103,7 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
     required String? metadata,
     required DateTime createdAt,
   }) {
-    final String date = _dateFmt.format(createdAt);
+    final String date = _formatCreatedAt(createdAt);
     final bool hasMetadata = metadata != null && metadata.isNotEmpty;
     if (!hasMetadata) {
       return Text(date, maxLines: 1, overflow: TextOverflow.ellipsis);
@@ -1098,11 +1168,8 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
 
     final canNavigate = item.bookKey != null && item.bookKey!.isNotEmpty;
 
-    final key = isMined
-        ? 'mined_${item.minedId}'
-        : isWord
-            ? 'word_${item.text}_${item.wordReading}_${item.wordSourceType}'
-            : 'fav_${item.favoriteId}';
+    final String key = _itemKey(item);
+    final bool playingThis = _playingItemKey == key;
 
     return Dismissible(
       key: Key(key),
@@ -1167,17 +1234,25 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
             trailing: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
+                // 巡检 PR-3：仅正在播的那一行显示小转圈，其余行保持可点（点即
+                // 先停旧后播新，见 [_playItemAudio]）。
                 if (_hasAudio(item))
-                  HibikiIconButton(
-                    tooltip: t.dialog_play,
-                    icon: _playingAudio
-                        ? Icons.hourglass_top
-                        : Icons.volume_up_outlined,
-                    size: 18,
-                    enabled: !_playingAudio,
-                    padding: EdgeInsets.all(tokens.spacing.gap / 2),
-                    onTap: () => _playItemAudio(item),
-                  ),
+                  playingThis
+                      ? Padding(
+                          padding: EdgeInsets.all(tokens.spacing.gap / 2),
+                          child: const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          ),
+                        )
+                      : HibikiIconButton(
+                          tooltip: t.dialog_play,
+                          icon: Icons.volume_up_outlined,
+                          size: 18,
+                          padding: EdgeInsets.all(tokens.spacing.gap / 2),
+                          onTap: () => _playItemAudio(item),
+                        ),
                 if (item.text != null)
                   HibikiIconButton(
                     tooltip: t.copy,
@@ -1603,7 +1678,7 @@ class _ExportSheetState extends State<_ExportSheet> {
       footer: Align(
         alignment: Alignment.centerRight,
         child: FilledButton.icon(
-          icon: const Icon(Icons.ios_share_outlined, size: 18),
+          icon: const Icon(Icons.share_outlined, size: 18),
           label: Text(t.dialog_export),
           onPressed: _canExport ? _confirm : null,
         ),

--- a/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -2,13 +2,13 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/focus/hibiki_focus_target.dart';
 import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/collections/shelf_sort.dart'
     show naturalCompare;
-import 'package:hibiki/src/pages/implementations/collection_name_dialog.dart'
-    show showCollectionNameDialog;
+import 'package:hibiki/src/pages/implementations/collection_detail_shared.dart';
 import 'package:hibiki/src/pages/implementations/jimaku_batch_dialog.dart';
-import 'package:hibiki/src/pages/implementations/tag_picker_page.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
@@ -50,10 +50,22 @@ class MediaCollectionDetailPage extends StatefulWidget {
       _MediaCollectionDetailPageState();
 }
 
-class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
+class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
+    with CollectionDetailShared<MediaCollectionDetailPage> {
   late String _name;
   List<VideoBookRow> _members = const <VideoBookRow>[];
   bool _loading = true;
+
+  @override
+  HibikiDatabase get detailDatabase => widget.database;
+  @override
+  MediaCollectionRow get detailCollection => widget.collection;
+  @override
+  String get detailName => _name;
+  @override
+  set detailName(String value) => _name = value;
+  @override
+  VoidCallback get detailOnChanged => widget.onChanged;
 
   @override
   void initState() {
@@ -115,37 +127,19 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
   }
 
   /// AppBar「排序」菜单：按名称（natural，卷1<卷2<卷10）/ 按导入时间（旧→新 =
-  /// 原始加入时序）一键重排。
+  /// 原始加入时序）一键重排。菜单外壳共享 [buildDetailSortMenu]。
   Widget _buildSortMenu() {
     int importedMsOf(VideoBookRow r) =>
         r.importedAt?.millisecondsSinceEpoch ?? 0;
-    return MenuAnchor(
-      menuChildren: <Widget>[
-        MenuItemButton(
-          leadingIcon: const Icon(Icons.sort_by_alpha, size: 20),
-          onPressed: () => _applyOneKeySort(
-            (VideoBookRow a, VideoBookRow b) =>
-                naturalCompare(a.title, b.title),
-          ),
-          child: Text(t.collection_sort_by_title),
-        ),
-        MenuItemButton(
-          leadingIcon: const Icon(Icons.history, size: 20),
-          onPressed: () => _applyOneKeySort(
-            (VideoBookRow a, VideoBookRow b) {
-              final int c = importedMsOf(a).compareTo(importedMsOf(b));
-              return c != 0 ? c : naturalCompare(a.title, b.title);
-            },
-          ),
-          child: Text(t.collection_sort_by_imported),
-        ),
-      ],
-      builder: (BuildContext context, MenuController controller, Widget? _) =>
-          IconButton(
-        tooltip: t.sort_by,
-        icon: const Icon(Icons.sort),
-        onPressed: () =>
-            controller.isOpen ? controller.close() : controller.open(),
+    return buildDetailSortMenu(
+      onSortByTitle: () => _applyOneKeySort(
+        (VideoBookRow a, VideoBookRow b) => naturalCompare(a.title, b.title),
+      ),
+      onSortByImported: () => _applyOneKeySort(
+        (VideoBookRow a, VideoBookRow b) {
+          final int c = importedMsOf(a).compareTo(importedMsOf(b));
+          return c != 0 ? c : naturalCompare(a.title, b.title);
+        },
       ),
     );
   }
@@ -169,86 +163,12 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
     );
   }
 
-  Future<void> _rename() async {
-    final String? newName = await showCollectionNameDialog(
-      context: context,
-      title: t.rename_collection,
-      initialName: _name,
-    );
-    if (newName == null || newName == _name) return;
-    await widget.database.renameMediaCollection(widget.collection.id, newName);
-    if (!mounted) return;
-    setState(() => _name = newName);
-    widget.onChanged();
-  }
-
-  /// 编辑本合集的标签：复用共享标签池的 [TagPickerPage]（合集第 4 路，传
-  /// collectionId）；返回后自增刷新计数，触发 [_buildTagChips] 的 FutureBuilder
-  /// 重取，chip 行立即反映新增/移除。
-  int _tagsRefresh = 0;
-
-  Future<void> _editTags() async {
-    await Navigator.of(context).push<void>(
-      MaterialPageRoute<void>(
-        builder: (_) => TagPickerPage(collectionId: widget.collection.id),
-      ),
-    );
-    if (!mounted) return;
-    setState(() => _tagsRefresh++);
-  }
-
-  /// 详情页头部标签 chip 行：随 [_tagsRefresh] 强制重取本合集标签；空则不占位。
-  Widget _buildTagChips() {
-    return FutureBuilder<List<BookTagRow>>(
-      key: ValueKey<int>(_tagsRefresh),
-      future: widget.database.getTagsForCollection(widget.collection.id),
-      builder: (BuildContext context, AsyncSnapshot<List<BookTagRow>> snap) {
-        final List<BookTagRow> tags = snap.data ?? const <BookTagRow>[];
-        if (tags.isEmpty) return const SizedBox.shrink();
-        return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Wrap(
-            spacing: 6,
-            runSpacing: 6,
-            children: <Widget>[
-              for (final BookTagRow tag in tags)
-                HibikiTagChip(
-                  label: tag.name,
-                  color: Color(tag.colorValue),
-                  tone: HibikiTagChipTone.surface,
-                ),
-            ],
-          ),
-        );
-      },
-    );
-  }
-
   /// 逐集「移出合集」（整理排序页删除后本页是视频侧唯一移出入口）：确认 →
   /// [HibikiDatabase.removeFromCollection]（空合集自动删）→ 重载；合集被清空则
   /// 退回上层。条目本身绝不删除。
   Future<void> _removeEpisode(VideoBookRow ep) async {
-    final bool? ok = await showAppDialog<bool>(
-      context: context,
-      builder: (BuildContext ctx) => AlertDialog(
-        title: Text(t.collection_remove_member),
-        content: Text(t.collection_remove_member_confirm),
-        actions: <Widget>[
-          adaptiveDialogAction(
-            context: ctx,
-            onPressed: () => Navigator.pop(ctx, false),
-            child: Text(t.dialog_cancel),
-          ),
-          adaptiveDialogAction(
-            context: ctx,
-            isDestructiveAction: true,
-            onPressed: () => Navigator.pop(ctx, true),
-            child: Text(t.collection_remove_member),
-          ),
-        ],
-      ),
-    );
-    if (ok != true) return;
+    if (!await confirmDetailRemoveMember()) return;
+    if (!mounted) return;
     await widget.database
         .removeFromCollection(widget.collection.id, 'video', ep.bookUid);
     if (!mounted) return;
@@ -267,53 +187,18 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
 
   Future<void> _delete() async {
     // 仅当调用方注入了删本体回调、且合集当前有成员时，才给用户「连同视频一起删」
-    // 选项；否则退回纯解链删除（老行为，零变化）。
+    // 勾选行；否则退回纯解链删除（老行为，零变化）。确认框统一走 PR-0 的
+    // [HibikiDestructiveConfirmDialog]（经 [confirmDetailCollectionDelete]）。
     final bool canDeleteMembers =
         widget.onDeleteMembersMedia != null && _members.isNotEmpty;
-    bool alsoDeleteMembers = false;
-    final bool? ok = await showAppDialog<bool>(
-      context: context,
-      builder: (BuildContext ctx) => StatefulBuilder(
-        builder: (BuildContext ctx, StateSetter setLocal) => AlertDialog(
-          title: Text(t.delete_collection),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(t.delete_collection_confirm),
-              if (canDeleteMembers) ...<Widget>[
-                const SizedBox(height: 8),
-                CheckboxListTile(
-                  value: alsoDeleteMembers,
-                  onChanged: (bool? v) =>
-                      setLocal(() => alsoDeleteMembers = v ?? false),
-                  contentPadding: EdgeInsets.zero,
-                  controlAffinity: ListTileControlAffinity.leading,
-                  title: Text(t.delete_collection_also_videos),
-                ),
-              ],
-            ],
-          ),
-          actions: <Widget>[
-            adaptiveDialogAction(
-              context: ctx,
-              onPressed: () => Navigator.pop(ctx, false),
-              child: Text(t.dialog_cancel),
-            ),
-            adaptiveDialogAction(
-              context: ctx,
-              isDestructiveAction: true,
-              onPressed: () => Navigator.pop(ctx, true),
-              child: Text(t.delete_collection),
-            ),
-          ],
-        ),
-      ),
+    final HibikiDestructiveConfirmResult? result =
+        await confirmDetailCollectionDelete(
+      checkboxLabel: canDeleteMembers ? t.delete_collection_also_videos : null,
     );
-    if (ok != true) return;
+    if (result == null || !mounted) return;
     // 先删各集视频本体（DB 行 + 封面/字幕副本），再解散容器。删视频会连带清各合集
     // 引用行并自删空合集，故随后的 deleteMediaCollection 多为幂等收尾（写合集级墓碑）。
-    if (alsoDeleteMembers && widget.onDeleteMembersMedia != null) {
+    if (result.checked && widget.onDeleteMembersMedia != null) {
       await widget.onDeleteMembersMedia!(List<VideoBookRow>.of(_members));
     }
     await widget.database.deleteMediaCollection(widget.collection.id);
@@ -359,6 +244,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
   @override
   Widget build(BuildContext context) {
     final ColorScheme cs = Theme.of(context).colorScheme;
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     return Scaffold(
       appBar: AppBar(
         title: Text(_name),
@@ -372,12 +258,12 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
           IconButton(
             tooltip: t.rename_collection,
             icon: const Icon(Icons.drive_file_rename_outline),
-            onPressed: _rename,
+            onPressed: renameDetailCollection,
           ),
           IconButton(
             tooltip: t.tag_label,
             icon: const Icon(Icons.sell_outlined),
-            onPressed: _editTags,
+            onPressed: editDetailCollectionTags,
           ),
           IconButton(
             tooltip: t.delete_collection,
@@ -388,15 +274,18 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
       ),
       body: SafeArea(
         child: _loading
-            ? const Center(child: CircularProgressIndicator())
+            ? Center(child: adaptiveIndicator(context: context))
             : _members.isEmpty
-                ? Center(child: Text(t.collection_empty))
+                ? HibikiPlaceholderMessage(
+                    icon: Icons.collections_bookmark_outlined,
+                    message: t.collection_empty,
+                  )
                 : Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: <Widget>[
-                      _buildTagChips(),
+                      buildDetailTagChips(),
                       Padding(
-                        padding: const EdgeInsets.all(12),
+                        padding: EdgeInsets.all(tokens.spacing.rowVertical),
                         child: Align(
                           alignment: AlignmentDirectional.centerStart,
                           child: FilledButton.icon(
@@ -432,20 +321,23 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
                               // 用 InkWell+Row（非 ListTile）保持 MD3 设计系统一致；
                               // VideoBooks 不存总时长无法算集内百分比 → 只标「已看完 /
                               // 看过一半 / 未看」三态图标，不画误导性进度条。
-                              return Material(
+                              final Widget row = Material(
                                 color: isContinue
                                     ? cs.primaryContainer
                                         .withValues(alpha: 0.35)
                                     : Colors.transparent,
                                 child: InkWell(
+                                  canRequestFocus: false,
                                   onTap: () => widget.onOpenEpisode(ep),
                                   child: Padding(
-                                    padding: const EdgeInsets.symmetric(
-                                        horizontal: 16, vertical: 12),
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: tokens.spacing.rowHorizontal,
+                                      vertical: tokens.spacing.rowVertical,
+                                    ),
                                     child: Row(
                                       children: <Widget>[
                                         SizedBox(
-                                          width: 32,
+                                          width: tokens.spacing.gap * 4,
                                           child: Text(
                                             '${i + 1}',
                                             textAlign: TextAlign.center,
@@ -453,11 +345,13 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
                                                 color: cs.onSurfaceVariant),
                                           ),
                                         ),
-                                        const SizedBox(width: 12),
+                                        SizedBox(
+                                            width: tokens.spacing.rowVertical),
                                         // Jellyfin 式：每集独立视频各自的封面缩略图（16:9
                                         // 抽帧；无封面时占位）。
                                         _episodeThumb(ep, cs),
-                                        const SizedBox(width: 12),
+                                        SizedBox(
+                                            width: tokens.spacing.rowVertical),
                                         Expanded(
                                           child: Text(
                                             ep.title,
@@ -472,7 +366,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
                                           Icon(Icons.play_circle_outline,
                                               color: cs.onSurfaceVariant,
                                               size: 20),
-                                        const SizedBox(width: 4),
+                                        SizedBox(width: tokens.spacing.gap / 2),
                                         // 逐集移出（整理页删除后的唯一入口）。
                                         HibikiIconButton(
                                           tooltip: t.collection_remove_member,
@@ -480,7 +374,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
                                           size: 18,
                                           onTap: () => _removeEpisode(ep),
                                         ),
-                                        const SizedBox(width: 4),
+                                        SizedBox(width: tokens.spacing.gap / 2),
                                         // 拖柄图标：纯视觉提示（整行可拖，见类注释）。
                                         Icon(
                                           Icons.drag_handle,
@@ -490,6 +384,29 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage> {
                                       ],
                                     ),
                                   ),
+                                ),
+                              );
+                              // 巡检 PR-3：剧集行接入手柄/键盘方向焦点（裸 InkWell
+                              // 不进 Hibiki 焦点系统，手柄用户到不了任何一集）。
+                              // Enter / 手柄 A 与鼠标点击同路径开该集。
+                              if (HibikiFocusRoot.maybeControllerOf(context) ==
+                                  null) {
+                                return row;
+                              }
+                              return Actions(
+                                actions: <Type, Action<Intent>>{
+                                  ActivateIntent:
+                                      CallbackAction<ActivateIntent>(
+                                    onInvoke: (_) {
+                                      widget.onOpenEpisode(ep);
+                                      return null;
+                                    },
+                                  ),
+                                },
+                                child: HibikiFocusTarget(
+                                  id: HibikiFocusId(
+                                      'collection-episode-${ep.bookUid}'),
+                                  child: row,
                                 ),
                               );
                             },

--- a/hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 
+import 'package:hibiki/src/media/collections/collection_shelf_row.dart'
+    show unifiedShelfCardLayout;
 import 'package:hibiki/src/media/collections/shelf_sort.dart'
     show naturalCompare;
-import 'package:hibiki/src/pages/implementations/collection_name_dialog.dart'
-    show showCollectionNameDialog;
-import 'package:hibiki/src/pages/implementations/tag_picker_page.dart';
+import 'package:hibiki/src/pages/implementations/collection_detail_shared.dart';
+import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart'
+    show kShelfBookCardAspectRatio;
 import 'package:hibiki/src/utils/components/hibiki_reorderable_grid.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki_core/hibiki_core.dart';
@@ -65,9 +67,21 @@ class MediaCollectionGridDetailPage extends StatefulWidget {
 }
 
 class _MediaCollectionGridDetailPageState
-    extends State<MediaCollectionGridDetailPage> {
+    extends State<MediaCollectionGridDetailPage>
+    with CollectionDetailShared<MediaCollectionGridDetailPage> {
   late String _name;
   List<MediaCollectionItemRow> _rows = const <MediaCollectionItemRow>[];
+
+  @override
+  HibikiDatabase get detailDatabase => widget.database;
+  @override
+  MediaCollectionRow get detailCollection => widget.collection;
+  @override
+  String get detailName => _name;
+  @override
+  set detailName(String value) => _name = value;
+  @override
+  VoidCallback get detailOnChanged => widget.onChanged;
 
   /// 当前**可见**成员行（memberCardBuilder 返回非空的子集，与 [_rows] 同序）。build
   /// 时刷新；拖拽 onReorder 的 from/to 是这份列表的下标，用它把可见序回写进 [_rows]
@@ -133,142 +147,28 @@ class _MediaCollectionGridDetailPageState
   }
 
   /// AppBar「排序」菜单：按名称（natural，卷1<卷2<卷10）/ 按导入时间一键重排。
+  /// 菜单外壳共享 [buildDetailSortMenu]。
   Widget _buildSortMenu() {
-    return MenuAnchor(
-      menuChildren: <Widget>[
-        MenuItemButton(
-          leadingIcon: const Icon(Icons.sort_by_alpha, size: 20),
-          onPressed: () => _applyOneKeySort(byTitle: true),
-          child: Text(t.collection_sort_by_title),
-        ),
-        MenuItemButton(
-          leadingIcon: const Icon(Icons.history, size: 20),
-          onPressed: () => _applyOneKeySort(byTitle: false),
-          child: Text(t.collection_sort_by_imported),
-        ),
-      ],
-      builder: (BuildContext context, MenuController controller, Widget? _) =>
-          IconButton(
-        tooltip: t.sort_by,
-        icon: const Icon(Icons.sort),
-        onPressed: () =>
-            controller.isOpen ? controller.close() : controller.open(),
-      ),
-    );
-  }
-
-  Future<void> _rename() async {
-    final String? newName = await showCollectionNameDialog(
-      context: context,
-      title: t.rename_collection,
-      initialName: _name,
-    );
-    if (newName == null || newName == _name) return;
-    await widget.database.renameMediaCollection(widget.collection.id, newName);
-    if (!mounted) return;
-    setState(() => _name = newName);
-    widget.onChanged();
-  }
-
-  /// 编辑本合集的标签：复用共享标签池的 [TagPickerPage]（合集第 4 路，传
-  /// collectionId）；返回后自增刷新计数，触发 [_buildTagChips] 的 FutureBuilder
-  /// 重取，chip 行立即反映新增/移除。
-  int _tagsRefresh = 0;
-
-  Future<void> _editTags() async {
-    await Navigator.of(context).push<void>(
-      MaterialPageRoute<void>(
-        builder: (_) => TagPickerPage(collectionId: widget.collection.id),
-      ),
-    );
-    if (!mounted) return;
-    setState(() => _tagsRefresh++);
-  }
-
-  /// 详情页头部标签 chip 行：随 [_tagsRefresh] 强制重取本合集标签；空则不占位。
-  Widget _buildTagChips() {
-    return FutureBuilder<List<BookTagRow>>(
-      key: ValueKey<int>(_tagsRefresh),
-      future: widget.database.getTagsForCollection(widget.collection.id),
-      builder: (BuildContext context, AsyncSnapshot<List<BookTagRow>> snap) {
-        final List<BookTagRow> tags = snap.data ?? const <BookTagRow>[];
-        if (tags.isEmpty) return const SizedBox.shrink();
-        return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Wrap(
-            spacing: 6,
-            runSpacing: 6,
-            children: <Widget>[
-              for (final BookTagRow tag in tags)
-                HibikiTagChip(
-                  label: tag.name,
-                  color: Color(tag.colorValue),
-                  tone: HibikiTagChipTone.surface,
-                ),
-            ],
-          ),
-        );
-      },
+    return buildDetailSortMenu(
+      onSortByTitle: () => _applyOneKeySort(byTitle: true),
+      onSortByImported: () => _applyOneKeySort(byTitle: false),
     );
   }
 
   Future<void> _delete() async {
     // 仅当调用方注入了删本体回调、且合集当前有成员时，才给用户「连同书一起删」
-    // 选项；否则退回纯解链删除（老行为，零变化）。
+    // 勾选行；否则退回纯解链删除（老行为，零变化）。确认框统一走 PR-0 的
+    // [HibikiDestructiveConfirmDialog]（经 [confirmDetailCollectionDelete]）。
     final bool canDeleteMembers =
         widget.onDeleteMembersMedia != null && _rows.isNotEmpty;
-    bool alsoDeleteMembers = false;
-    final bool? ok = await showAppDialog<bool>(
-      context: context,
-      builder: (BuildContext ctx) => StatefulBuilder(
-        builder: (BuildContext ctx, StateSetter setLocal) => AlertDialog(
-          title: Text(t.delete_collection),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(t.delete_collection_confirm),
-              if (canDeleteMembers) ...<Widget>[
-                const SizedBox(height: 8),
-                InkWell(
-                  onTap: () =>
-                      setLocal(() => alsoDeleteMembers = !alsoDeleteMembers),
-                  child: Row(
-                    children: <Widget>[
-                      Checkbox(
-                        value: alsoDeleteMembers,
-                        onChanged: (bool? v) =>
-                            setLocal(() => alsoDeleteMembers = v ?? false),
-                      ),
-                      Expanded(
-                        child: Text(t.delete_collection_also_books),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ],
-          ),
-          actions: <Widget>[
-            adaptiveDialogAction(
-              context: ctx,
-              onPressed: () => Navigator.pop(ctx, false),
-              child: Text(t.dialog_cancel),
-            ),
-            adaptiveDialogAction(
-              context: ctx,
-              isDestructiveAction: true,
-              onPressed: () => Navigator.pop(ctx, true),
-              child: Text(t.delete_collection),
-            ),
-          ],
-        ),
-      ),
+    final HibikiDestructiveConfirmResult? result =
+        await confirmDetailCollectionDelete(
+      checkboxLabel: canDeleteMembers ? t.delete_collection_also_books : null,
     );
-    if (ok != true) return;
+    if (result == null || !mounted) return;
     // 先删成员本体（书/有声书/视频 DB 行 + 磁盘副本），再解散容器。删书不动合集引用
     // 行，故随后的 deleteMediaCollection 负责清掉残留引用 + 写合集级墓碑。
-    if (alsoDeleteMembers && widget.onDeleteMembersMedia != null) {
+    if (result.checked && widget.onDeleteMembersMedia != null) {
       await widget
           .onDeleteMembersMedia!(List<MediaCollectionItemRow>.of(_rows));
     }
@@ -419,12 +319,12 @@ class _MediaCollectionGridDetailPageState
           IconButton(
             tooltip: t.rename_collection,
             icon: const Icon(Icons.drive_file_rename_outline),
-            onPressed: _rename,
+            onPressed: renameDetailCollection,
           ),
           IconButton(
             tooltip: t.tag_label,
             icon: const Icon(Icons.sell_outlined),
-            onPressed: _editTags,
+            onPressed: editDetailCollectionTags,
           ),
           IconButton(
             tooltip: t.delete_collection,
@@ -435,13 +335,16 @@ class _MediaCollectionGridDetailPageState
       ),
       body: SafeArea(
         child: _loading
-            ? const Center(child: CircularProgressIndicator())
+            ? Center(child: adaptiveIndicator(context: context))
             : members.isEmpty
-                ? Center(child: Text(t.collection_empty))
+                ? HibikiPlaceholderMessage(
+                    icon: Icons.collections_bookmark_outlined,
+                    message: t.collection_empty,
+                  )
                 : Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: <Widget>[
-                      _buildTagChips(),
+                      buildDetailTagChips(),
                       Expanded(child: _buildMemberGrid(members)),
                     ],
                   ),
@@ -449,29 +352,36 @@ class _MediaCollectionGridDetailPageState
     );
   }
 
-  /// 成员网格：消缩放 2D 拖排（[HibikiReorderableGrid]）。列数按可用宽度换算
-  /// （每卡 ≤180 宽，与旧 [SliverGridDelegateWithMaxCrossAxisExtent] 一致）。卡片包在
+  /// 成员网格：消缩放 2D 拖排（[HibikiReorderableGrid]）。卡尺寸对齐书架散卡口径
+  /// （[readerShelfGridExtentForLayout] 断点 → [unifiedShelfCardLayout] 列数、
+  /// [kShelfBookCardAspectRatio] 槽比）——旧实现自带 180+ceil+硬编码 160/260，
+  /// 同一本书在书架与详情页两个网格里尺寸口径不一致（巡检 PR-3）。卡片包在
   /// [IgnorePointer] 里——其内部 InkWell 的 long-press 会与网格触摸长按拖拽争用手势
   /// 竞技场（LongPress 在 500ms 抢先夺胜 → 触摸永远拖不动），故屏蔽卡片自身手势，由
-  /// 网格统一接管：轻点→打开、按下/长按拖→重排、长按松手/右键→上下文菜单。
+  /// 网格统一接管：轻点→打开、按下/长按拖→重排、长按松手/右键→上下文菜单；
+  /// 指针悬停反馈由外层 [_HoverableMemberCard] 补回（IgnorePointer 灭掉了 InkWell
+  /// 自身 hover，桌面上成员卡曾读作死内容）。
   Widget _buildMemberGrid(
       List<({MediaCollectionItemRow row, Widget card})> members) {
     const double spacing = 12;
-    const double maxCardWidth = 180;
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final double available = constraints.maxWidth - 24; // 两侧各 12 padding
-        final int cols = available <= 0
-            ? 1
-            : ((available + spacing) / (maxCardWidth + spacing))
-                .ceil()
-                .clamp(1, 1 << 30);
+        final double targetWidth = readerShelfGridExtentForLayout(
+          mediaWidth: MediaQuery.sizeOf(context).width,
+          contentWidth: available,
+        );
+        final ({int columns, double cardWidth}) layout = unifiedShelfCardLayout(
+          availableWidth: available > 0 ? available : targetWidth,
+          targetWidth: targetWidth,
+          spacing: spacing,
+        );
         return SingleChildScrollView(
           padding: const EdgeInsets.all(12),
           child: HibikiReorderableGrid(
             itemCount: members.length,
-            crossAxisCount: cols,
-            childAspectRatio: 160 / 260,
+            crossAxisCount: layout.columns,
+            childAspectRatio: kShelfBookCardAspectRatio,
             crossAxisSpacing: spacing,
             mainAxisSpacing: spacing,
             feedbackBorderRadius: HibikiBorderRadius.card,
@@ -485,10 +395,61 @@ class _MediaCollectionGridDetailPageState
             onContextMenu: (int i, Offset globalPosition) =>
                 _showMemberMenu(members[i].row, globalPosition),
             itemBuilder: (BuildContext context, int i) =>
-                IgnorePointer(child: members[i].card),
+                _HoverableMemberCard(child: members[i].card),
           ),
         );
       },
+    );
+  }
+}
+
+/// 成员卡的指针悬停反馈壳：卡片本体仍被 [IgnorePointer] 屏蔽（长按拖拽手势竞技场
+/// 决策不变），悬停高亮由本壳的 [MouseRegion]（默认 opaque，自身参与命中测试）
+/// 提供——桌面指针划过成员卡有可交互反馈，触摸/手柄路径零变化。
+class _HoverableMemberCard extends StatefulWidget {
+  const _HoverableMemberCard({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_HoverableMemberCard> createState() => _HoverableMemberCardState();
+}
+
+class _HoverableMemberCardState extends State<_HoverableMemberCard> {
+  bool _hovering = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final bool eink = isEinkTheme(context);
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _hovering = true),
+      onExit: (_) => setState(() => _hovering = false),
+      child: Stack(
+        fit: StackFit.expand,
+        children: <Widget>[
+          IgnorePointer(child: widget.child),
+          if (_hovering)
+            Positioned.fill(
+              child: IgnorePointer(
+                child: DecoratedBox(
+                  // eink 半透明 hover 罩合成抖动灰 → 改描边反馈。
+                  decoration: eink
+                      ? BoxDecoration(
+                          border: Border.all(color: tokens.surfaces.outline),
+                          borderRadius: tokens.radii.cardRadius,
+                        )
+                      : BoxDecoration(
+                          color:
+                              tokens.surfaces.onSurface.withValues(alpha: 0.08),
+                          borderRadius: tokens.radii.cardRadius,
+                        ),
+                ),
+              ),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -1206,7 +1206,16 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     _epubCoverUrisByBookKey = epubCoverUrisByBookKey;
     _epubBackedBookKeys = epubBackedBookKeys;
     _epubProgressByBookKey = epubProgressByBookKey;
-    if (epubBooks.isEmpty && srtBooks.isEmpty && remoteBooks.isEmpty) {
+    // BUG-1008：空态判定看**全部**会渲染成卡的列表（含纯 SRT 远端占位）。标签筛选
+    // 激活时才可能落到 tag_no_books_for_filter；旧实现另有一个
+    // `hasActiveFilter && epubBooks.isEmpty` 特殊分支——SRT 命中已渲染网格却仍
+    // 无条件叠「无匹配」空态文案，且丢 RefreshIndicator / 合集横排行 / 书库概览。
+    // 筛选态与常态统一走下方主分支组装（shelfGroups 已能承载纯 SRT 命中结果），
+    // 特殊分支消灭。
+    if (epubBooks.isEmpty &&
+        srtBooks.isEmpty &&
+        remoteBooks.isEmpty &&
+        remoteSrtBooks.isEmpty) {
       return hasActiveFilter
           ? Center(
               child: HibikiPlaceholderMessage(
@@ -1215,49 +1224,6 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
               ),
             )
           : buildPlaceholder();
-    }
-    if (hasActiveFilter && epubBooks.isEmpty) {
-      return RawScrollbar(
-        thumbVisibility: true,
-        thickness: 3,
-        controller: mediaType.scrollController,
-        child: LayoutBuilder(
-          builder: (context, constraints) => CustomScrollView(
-            controller: mediaType.scrollController,
-            physics: desktopAwareScrollPhysics(),
-            slivers: [
-              SliverToBoxAdapter(child: SizedBox(height: tokens.spacing.gap)),
-              // 标签筛选激活时不混排远端占位（远端书无本地标签，不参与筛选）。
-              // TODO-902: 不再渲染 srt_books_section 分区头，SRT 卡直接进网格。
-              if (srtBooks.isNotEmpty)
-                SliverGrid.builder(
-                  gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-                    maxCrossAxisExtent: _gridExtent(context, constraints),
-                    childAspectRatio: kShelfBookCardAspectRatio,
-                  ),
-                  itemCount: srtBooks.length,
-                  itemBuilder: (_, i) => _buildSrtCard(
-                    srtBooks[i],
-                    epubCoverUri: epubCoverUrisByBookKey[srtBooks[i].bookKey],
-                  ),
-                ),
-              SliverToBoxAdapter(
-                child: Padding(
-                  padding:
-                      EdgeInsets.all(tokens.spacing.card + tokens.spacing.gap),
-                  child: Text(
-                    t.tag_no_books_for_filter,
-                    textAlign: TextAlign.center,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-      );
     }
     return RawScrollbar(
       thumbVisibility: true,
@@ -1608,6 +1574,10 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
   /// 不注入就没有移出项）。
   Widget? _buildCollectionMemberCard(String mediaType, String entryKey,
       {VoidCallback? onRemoveFromCollection}) {
+    // BUG-1009：详情页与书架是两条同时存活的路由（详情页 push 在书架之上），成员卡
+    // 若复用书架同名 focusId，两个 HibikiFocusTarget 撞号——焦点注册表按 id 覆盖，
+    // 后注册者赢、pop 后书架卡失焦。详情页渲染路径统一加 route 前缀隔离命名空间。
+    const String prefix = 'collection-detail-';
     if (mediaType == 'srt') {
       for (final SrtBook book in _visibleSrtBooks) {
         if (book.uid == entryKey) {
@@ -1615,6 +1585,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             book,
             epubCoverUri: _epubCoverUrisByBookKey[book.bookKey],
             removeFromCollection: onRemoveFromCollection,
+            focusIdPrefix: prefix,
           );
         }
       }
@@ -1626,6 +1597,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
           return _buildEpubBookCard(
             item,
             removeFromCollection: onRemoveFromCollection,
+            focusIdPrefix: prefix,
           );
         }
       }
@@ -1759,13 +1731,18 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
   /// 块2：合集行成员卡传 false（selectionKey 置空 → 不画勾、不可单独勾）。
   /// [removeFromCollection] 非空（合集详情页成员卡）时给长按 / 右键对话框补一条
   /// 「移出合集」动作，让键盘/手柄用户（聚焦长按 A 弹此对话框，不经网格指针菜单）也能移出。
+  /// [focusIdPrefix]：详情页渲染路径传 'collection-detail-' 隔离焦点 id 命名空间
+  /// （BUG-1009，见 [_buildCollectionMemberCard]）；书架路径恒空串（id 不变）。
   Widget _buildEpubBookCard(MediaItem item,
-      {bool selectable = true, VoidCallback? removeFromCollection}) {
+      {bool selectable = true,
+      VoidCallback? removeFromCollection,
+      String focusIdPrefix = ''}) {
     final String? bookKey = _parseBookKey(item.mediaIdentifier);
     final Widget card = _bookCardShell(
       slotAspectRatio: kShelfBookCardAspectRatio,
       cardKey: ValueKey<String>('book_entry_${item.mediaIdentifier}'),
-      focusId: HibikiFocusId('reader-shelf-book-${item.mediaIdentifier}'),
+      focusId: HibikiFocusId(
+          '${focusIdPrefix}reader-shelf-book-${item.mediaIdentifier}'),
       selectionKey: selectable ? item.mediaIdentifier : null,
       dragBookId: bookKey,
       onTagDropped:

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -29,10 +29,13 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
   /// （selectionKey 置空 → 不画勾、不可单独勾），点击照常开书。
   /// [removeFromCollection] 非空（合集详情页成员卡）时给长按 / 右键对话框补「移出合集」
   /// 动作，让键盘/手柄用户（聚焦长按 A 弹此对话框，不经网格指针菜单）也能移出。
+  /// [focusIdPrefix]：详情页渲染路径传 'collection-detail-' 隔离焦点 id 命名空间
+  /// （BUG-1009，见 [_buildCollectionMemberCard]）；书架路径恒空串（id 不变）。
   Widget _buildSrtCard(SrtBook book,
       {String? epubCoverUri,
       bool selectable = true,
-      VoidCallback? removeFromCollection}) {
+      VoidCallback? removeFromCollection,
+      String focusIdPrefix = ''}) {
     final String selKey = 'srt_${book.uid}';
     final tagWidget = book.id != null ? _buildSrtBookTagLabels(book.id!) : null;
     final int? srtBookId = book.id;
@@ -55,7 +58,7 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     return _bookCardShell(
       slotAspectRatio: kShelfBookCardAspectRatio,
       cardKey: ValueKey<String>('srt_entry_${book.uid}'),
-      focusId: HibikiFocusId('reader-shelf-srt-${book.uid}'),
+      focusId: HibikiFocusId('${focusIdPrefix}reader-shelf-srt-${book.uid}'),
       selectionKey: selectable ? selKey : null,
       dragBookId: srtBookId,
       onTagDropped:
@@ -367,9 +370,15 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
         ) !=
         CombineTier.noop;
 
-    return Material(
-      elevation: 6,
-      color: theme.colorScheme.surfaceContainer,
+    // 全 app elevation 0 纪律：去阴影改上边框分隔（巡检 PR-3）；窄屏 + 大字体下
+    // 「已选 N / 全选 / 反选」改 Wrap 自动换行（旧 Row 全员不可收缩必溢出）。
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainer,
+        border: Border(
+          top: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
+      ),
       child: SafeArea(
         top: false,
         child: Padding(
@@ -379,22 +388,28 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
           ),
           child: Row(
             children: [
-              Text(
-                t.batch_selected_count(n: selectedCount),
-                style: textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
+              Expanded(
+                child: Wrap(
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  spacing: tokens.spacing.gap,
+                  children: <Widget>[
+                    Text(
+                      t.batch_selected_count(n: selectedCount),
+                      style: textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    TextButton(
+                      onPressed: _selectAll,
+                      child: Text(t.batch_select_all),
+                    ),
+                    TextButton(
+                      onPressed: _invertSelection,
+                      child: Text(t.batch_invert_selection),
+                    ),
+                  ],
                 ),
               ),
-              SizedBox(width: tokens.spacing.gap),
-              TextButton(
-                onPressed: _selectAll,
-                child: Text(t.batch_select_all),
-              ),
-              TextButton(
-                onPressed: _invertSelection,
-                child: Text(t.batch_invert_selection),
-              ),
-              const Spacer(),
               HibikiIconButton(
                 key: const ValueKey<String>('reader_shelf_batch_combine'),
                 enabled: canCombine,

--- a/hibiki/lib/src/pages/implementations/reader_history/card_widgets.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/card_widgets.part.dart
@@ -107,11 +107,14 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
           );
         }
 
-        final int visibleCount = maxSlots <= 1 ? 1 : maxSlots - 1;
+        // 溢出时最后一个槽恒让给「+N」合并 chip。仅 1 槽（书卡容器高恒 ≈1 槽）
+        // 时唯一槽也显示「+N」（N=全部标签数）——旧实现只显示第 1 个标签且无
+        // +N，多标签书在书架上读作「只有 1 个标签」（巡检 PR-3）。
+        final int visibleCount = maxSlots <= 1 ? 0 : maxSlots - 1;
         final int overflow = tags.length - visibleCount;
         return _uniformWidthTagColumn([
           for (final tag in tags.take(visibleCount)) _tagChip(tag),
-          if (overflow > 0 && maxSlots > 1) _overflowChip(overflow),
+          _overflowChip(overflow),
         ]);
       },
     );
@@ -172,11 +175,21 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
   }
 
   Widget _coverPlaceholderIcon(IconData icon) {
-    return Center(
-      child: Icon(
-        icon,
-        size: 40,
-        color: theme.colorScheme.onSurfaceVariant,
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    // 巡检 B11：深色主题下无封面占位（卡面色 ≈ 页面背景）与背景零对比，占位卡
+    // 读作一块空洞。给占位区补 1px outlineVariant 描边（全主题恒有；eink 的卡级
+    // 描边另由 HibikiCard 兜，两者叠加无害）。
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+        borderRadius: tokens.radii.cardRadius,
+      ),
+      child: Center(
+        child: Icon(
+          icon,
+          size: 40,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
       ),
     );
   }
@@ -198,10 +211,7 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
     final bool selected =
         selectionKey != null && _selectedKeys.contains(selectionKey);
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
-    final Color selectionColor = tokens.surfaces.primary;
     final double selectionInset = tokens.spacing.gap / 2;
-    final double selectionPadding = tokens.spacing.gap / 4;
-    final double selectionIconSize = tokens.spacing.gap * 1.75;
     final VoidCallback effectiveTap = _selectionMode && selectionKey != null
         ? () => _toggleSelection(selectionKey)
         : onTap;
@@ -227,43 +237,10 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
                   Positioned(
                     top: selectionInset,
                     left: selectionInset,
-                    child: IgnorePointer(
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: selected
-                              ? selectionColor
-                              : tokens.surfaces.page.withValues(alpha: 0.7),
-                          shape: BoxShape.circle,
-                          border: Border.all(
-                            color: selected
-                                ? selectionColor
-                                : tokens.surfaces.outline,
-                            width: 1.5,
-                          ),
-                        ),
-                        padding: EdgeInsets.all(selectionPadding),
-                        child: Icon(
-                          Icons.check,
-                          size: selectionIconSize,
-                          color: selected
-                              ? theme.colorScheme.onPrimary
-                              : Colors.transparent,
-                        ),
-                      ),
-                    ),
+                    child: ShelfSelectionCheck(selected: selected),
                   ),
                 if (selected)
-                  Positioned.fill(
-                    child: IgnorePointer(
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          color:
-                              tokens.surfaces.primary.withValues(alpha: 0.12),
-                          borderRadius: tokens.radii.cardRadius,
-                        ),
-                      ),
-                    ),
-                  ),
+                  const Positioned.fill(child: ShelfSelectedOverlay()),
               ],
             ),
           ),
@@ -301,31 +278,10 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
   }
 
   /// 块2：合集行头整选勾选框（选=选中整个合集）。与散卡 [_bookCardShell] 的封面
-  /// 勾选框同款圆形对勾视觉；[IgnorePointer] 让点击穿透到行头 InkWell（整选回调）。
-  Widget _buildSelectionCheck(bool selected) {
-    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
-    final Color selectionColor = tokens.surfaces.primary;
-    return IgnorePointer(
-      child: Container(
-        decoration: BoxDecoration(
-          color: selected
-              ? selectionColor
-              : tokens.surfaces.page.withValues(alpha: 0.7),
-          shape: BoxShape.circle,
-          border: Border.all(
-            color: selected ? selectionColor : tokens.surfaces.outline,
-            width: 1.5,
-          ),
-        ),
-        padding: EdgeInsets.all(tokens.spacing.gap / 4),
-        child: Icon(
-          Icons.check,
-          size: tokens.spacing.gap * 1.75,
-          color: selected ? theme.colorScheme.onPrimary : Colors.transparent,
-        ),
-      ),
-    );
-  }
+  /// 勾选框同为共享 [ShelfSelectionCheck]（内建 [IgnorePointer] 让点击穿透到行头
+  /// InkWell 整选回调；eink 实心底由组件统一处理）。
+  Widget _buildSelectionCheck(bool selected) =>
+      ShelfSelectionCheck(selected: selected);
 
   Widget _bookCardLayout({
     required String title,
@@ -406,7 +362,7 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
         ),
         SizedBox(
           height: kShelfTitleFooterHeight,
-          child: _bookCardFooter(title),
+          child: ShelfCardFooter(title: title),
         ),
       ],
     );
@@ -417,32 +373,6 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
       padding: EdgeInsets.zero,
       margin: EdgeInsets.zero,
       child: child,
-    );
-  }
-
-  Widget _bookCardFooter(String title) {
-    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
-    return Padding(
-      padding: EdgeInsetsDirectional.fromSTEB(
-        tokens.spacing.gap * 0.75,
-        tokens.spacing.gap / 2,
-        tokens.spacing.gap * 0.75,
-        0,
-      ),
-      child: Align(
-        alignment: Alignment.topCenter,
-        child: Text(
-          title,
-          overflow: TextOverflow.ellipsis,
-          maxLines: 2,
-          textAlign: TextAlign.center,
-          softWrap: true,
-          style: tokens.type.metadata.copyWith(
-            color: tokens.surfaces.onSurface,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-      ),
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
@@ -163,14 +163,17 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
               _downloadRemoteBook(book);
             },
           ),
-          DialogQuickAction(
-            label: t.remote_book_info,
-            icon: Icons.info_outline,
-            onPressed: () {
-              Navigator.pop(dialogContext);
-              _showRemoteBookInfo(book);
-            },
-          ),
+          // 「信息」弹窗目前只有一条附加元数据（是否含有声书）；无附加信息时弹出
+          // 即空壳，隐藏入口（巡检 PR-3 最小改法——待远端元数据丰富后再放开）。
+          if (book.hasAudiobook)
+            DialogQuickAction(
+              label: t.remote_book_info,
+              icon: Icons.info_outline,
+              onPressed: () {
+                Navigator.pop(dialogContext);
+                _showRemoteBookInfo(book);
+              },
+            ),
         ],
         dangerActions: <DialogDangerAction>[
           if (canDelete)
@@ -629,9 +632,9 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
       cardKey: ValueKey<String>('remote_srt_card_$safeKey'),
       focusId: HibikiFocusId('reader-shelf-remote-srt-$safeKey'),
       onTap: () => _downloadRemoteSrtAudiobook(book),
-      // 长按 / 右键：与短按同为下载入口（远端占位卡无本地副本，唯一动作是下载；
-      // 内部已对同 identity 重复下载去重）。
-      onLongPress: () => _downloadRemoteSrtAudiobook(book),
+      // 长按 / 右键：弹动作面板，与远端 EPUB 卡（[_showRemoteBookDialog]）一致
+      // （巡检 PR-3——旧行为长按直接开始下载，重手势与轻点击等价且不可预览动作）。
+      onLongPress: () => _showRemoteSrtDialog(book),
       child: _bookCardLayout(
         title: title,
         cover: Stack(
@@ -669,6 +672,31 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
                 icon: const Icon(Icons.download_outlined),
                 onPressed: () => _downloadRemoteSrtAudiobook(book),
               ),
+      ),
+    );
+  }
+
+  /// 长按 / 桌面右键纯 SRT 远端占位卡：弹与远端 EPUB 卡一致的动作面板
+  /// （[MediaItemDialogFrame] 复用）。唯一动作是「下载」（远端占位无本地副本；
+  /// 互联删除 API 面向 EPUB 关联包，standalone SRT 不接删除，真实能力边界）。
+  void _showRemoteSrtDialog(RemoteAudiobookInfo book) {
+    final String title = book.title ?? book.identity;
+    showAppDialog<void>(
+      context: context,
+      builder: (BuildContext dialogContext) => MediaItemDialogFrame(
+        cover: _coverPlaceholderIcon(Icons.headphones_outlined),
+        title: title,
+        showLaunchAction: false,
+        quickActions: <DialogQuickAction>[
+          DialogQuickAction(
+            label: t.remote_book_download,
+            icon: Icons.download_outlined,
+            onPressed: () {
+              Navigator.pop(dialogContext);
+              _downloadRemoteSrtAudiobook(book);
+            },
+          ),
+        ],
       ),
     );
   }
@@ -792,18 +820,10 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
   String _safeRemoteBookKey(String title) =>
       sanitizeTtuFilename(title).replaceAll(RegExp(r'[^A-Za-z0-9._-]+'), '_');
 
-  /// 云角标 ☁ 的视觉：半透明黑底胶囊 + 白色云图标（与视频卡字幕/集数徽章同款风格）。
-  /// 多端库联合视图占位卡的「远端 / 未下载」标识（spec §2.1）。
+  /// 云角标 ☁：共享 [CoverBadge]（PR-0 收口的封面角标胶囊，统一各处手抄的
+  /// alpha/圆角/eink 实底）。多端库联合视图占位卡的「远端 / 未下载」标识（spec §2.1）。
   Widget _remoteCloudBadge({Key? key}) {
-    return Container(
-      key: key,
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
-      decoration: BoxDecoration(
-        color: Colors.black.withValues(alpha: 0.55),
-        borderRadius: BorderRadius.circular(10),
-      ),
-      child: const Icon(Icons.cloud_outlined, size: 13, color: Colors.white),
-    );
+    return CoverBadge(key: key, icon: Icons.cloud_outlined, iconSize: 13);
   }
 }
 

--- a/hibiki/lib/src/pages/implementations/series_shelf_card.dart
+++ b/hibiki/lib/src/pages/implementations/series_shelf_card.dart
@@ -27,6 +27,8 @@ class SeriesShelfCard extends StatelessWidget {
     this.selectionMode = false,
     this.selected = false,
     this.onSelectionToggle,
+    this.onLongPress,
+    this.onSecondaryTap,
     super.key,
   });
 
@@ -53,6 +55,11 @@ class SeriesShelfCard extends StatelessWidget {
   final bool selected;
   final VoidCallback? onSelectionToggle;
 
+  /// 长按 / 桌面右键（与散书卡 onLongPress/onSecondaryTap 同语义，巡检 PR-3 补齐
+  /// 交互对称性）。null 时保持纯点击（零破坏）；多选态下自动禁用（与散卡一致）。
+  final VoidCallback? onLongPress;
+  final VoidCallback? onSecondaryTap;
+
   @override
   Widget build(BuildContext context) {
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
@@ -69,6 +76,8 @@ class SeriesShelfCard extends StatelessWidget {
           canRequestFocus: false,
           borderRadius: tokens.radii.cardRadius,
           onTap: effectiveTap,
+          onLongPress: selectionMode ? null : onLongPress,
+          onSecondaryTap: selectionMode ? null : onSecondaryTap,
           child: AspectRatio(
             aspectRatio: slotAspectRatio,
             child: Column(
@@ -97,47 +106,16 @@ class SeriesShelfCard extends StatelessWidget {
                         Positioned(
                           top: tokens.spacing.gap / 2,
                           left: tokens.spacing.gap / 2,
-                          child: _selectionCheck(theme, tokens),
+                          child: ShelfSelectionCheck(selected: selected),
                         ),
                       if (selected)
-                        Positioned.fill(
-                          child: IgnorePointer(
-                            child: DecoratedBox(
-                              decoration: BoxDecoration(
-                                color: tokens.surfaces.primary
-                                    .withValues(alpha: 0.12),
-                                borderRadius: tokens.radii.cardRadius,
-                              ),
-                            ),
-                          ),
-                        ),
+                        const Positioned.fill(child: ShelfSelectedOverlay()),
                     ],
                   ),
                 ),
                 SizedBox(
-                  height: 40,
-                  child: Padding(
-                    padding: EdgeInsetsDirectional.fromSTEB(
-                      tokens.spacing.gap * 0.75,
-                      tokens.spacing.gap / 2,
-                      tokens.spacing.gap * 0.75,
-                      0,
-                    ),
-                    child: Align(
-                      alignment: Alignment.topCenter,
-                      child: Text(
-                        name,
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 2,
-                        textAlign: TextAlign.center,
-                        softWrap: true,
-                        style: tokens.type.metadata.copyWith(
-                          color: tokens.surfaces.onSurface,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                    ),
-                  ),
+                  height: ShelfCardFooter.height,
+                  child: ShelfCardFooter(title: name),
                 ),
               ],
             ),
@@ -192,30 +170,6 @@ class SeriesShelfCard extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-
-  Widget _selectionCheck(ThemeData theme, HibikiDesignTokens tokens) {
-    final Color selectionColor = tokens.surfaces.primary;
-    return IgnorePointer(
-      child: Container(
-        decoration: BoxDecoration(
-          color: selected
-              ? selectionColor
-              : tokens.surfaces.page.withValues(alpha: 0.7),
-          shape: BoxShape.circle,
-          border: Border.all(
-            color: selected ? selectionColor : tokens.surfaces.outline,
-            width: 1.5,
-          ),
-        ),
-        padding: EdgeInsets.all(tokens.spacing.gap / 4),
-        child: Icon(
-          Icons.check,
-          size: tokens.spacing.gap * 1.75,
-          color: selected ? theme.colorScheme.onPrimary : Colors.transparent,
-        ),
       ),
     );
   }

--- a/hibiki/lib/src/pages/implementations/tag_filter_bar.dart
+++ b/hibiki/lib/src/pages/implementations/tag_filter_bar.dart
@@ -107,7 +107,10 @@ class _HibikiTagFilterBarState extends ConsumerState<HibikiTagFilterBar> {
       decoration: BoxDecoration(
         border: Border(
           bottom: BorderSide(
-            color: tokens.surfaces.outline.withValues(alpha: 0.3),
+            // eink：30% alpha 分隔线合成抖动灰 → 实心 outline（巡检 PR-3）。
+            color: isEinkTheme(context)
+                ? tokens.surfaces.outline
+                : tokens.surfaces.outline.withValues(alpha: 0.3),
           ),
         ),
       ),

--- a/hibiki/lib/src/utils/components/shelf_card_widgets.dart
+++ b/hibiki/lib/src/utils/components/shelf_card_widgets.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:hibiki/src/utils/adaptive/adaptive_platform.dart';
+import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
+
+/// 书架卡片 footer / 勾选圈 / 选中罩的共享实现。
+///
+/// 巡检（PR-3）发现 `series_shelf_card.dart` 与
+/// `reader_history/card_widgets.part.dart` 各持一份逐行相同的 footer 与勾选圈
+/// 手抄（两处 40px 标题 footer、三处圆形对勾、两处选中罩），本文件收口为共享
+/// 组件；eink 主题的实心色替代（半透明 alpha 在墨水屏合成抖动灰）也只写在这里。
+
+/// 书架卡片封面下方的固定高标题 footer（两行省略、居中、加粗 metadata 字号）。
+///
+/// 高度由调用方的 SizedBox 固定（书卡用 `kShelfTitleFooterHeight`，系列折叠卡
+/// 用 [ShelfCardFooter.height]，二者同值），长书名换行不得撑动网格。
+class ShelfCardFooter extends StatelessWidget {
+  const ShelfCardFooter({required this.title, super.key});
+
+  /// 与 `kShelfTitleFooterHeight` 同值的 footer 固定高（系列卡无法 import
+  /// part-of 常量，挂在组件上共享）。
+  static const double height = 40.0;
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return Padding(
+      padding: EdgeInsetsDirectional.fromSTEB(
+        tokens.spacing.gap * 0.75,
+        tokens.spacing.gap / 2,
+        tokens.spacing.gap * 0.75,
+        0,
+      ),
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: Text(
+          title,
+          overflow: TextOverflow.ellipsis,
+          maxLines: 2,
+          textAlign: TextAlign.center,
+          softWrap: true,
+          style: tokens.type.metadata.copyWith(
+            color: tokens.surfaces.onSurface,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 多选态的圆形对勾（书卡封面左上角 / 合集行头 / 系列折叠卡共用）。
+///
+/// 点击穿透由内建 [IgnorePointer] 保证（勾选切换走卡片/行头自身的 onTap）。
+/// eink：未选中底色不再用 `page.withValues(alpha: 0.7)`（半透明在墨水屏合成
+/// 抖动中间灰），改实心页面色 + 描边。
+class ShelfSelectionCheck extends StatelessWidget {
+  const ShelfSelectionCheck({required this.selected, super.key});
+
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final ThemeData theme = Theme.of(context);
+    final Color selectionColor = tokens.surfaces.primary;
+    final bool eink = isEinkTheme(context);
+    final Color idleFill = eink
+        ? tokens.surfaces.page
+        : tokens.surfaces.page.withValues(alpha: 0.7);
+    return IgnorePointer(
+      child: Container(
+        decoration: BoxDecoration(
+          color: selected ? selectionColor : idleFill,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: selected ? selectionColor : tokens.surfaces.outline,
+            width: 1.5,
+          ),
+        ),
+        padding: EdgeInsets.all(tokens.spacing.gap / 4),
+        child: Icon(
+          Icons.check,
+          size: tokens.spacing.gap * 1.75,
+          color: selected ? theme.colorScheme.onPrimary : Colors.transparent,
+        ),
+      ),
+    );
+  }
+}
+
+/// 选中态整卡覆盖罩（书卡 / 系列折叠卡共用），配 `Positioned.fill` 使用。
+///
+/// 常规主题为 primary 12% 半透明罩；eink 半透明罩合成抖动灰且 primary 已塌缩，
+/// 改 2px 实心描边作唯一选中信号（与 HibikiCard eink 选中态同语义）。
+class ShelfSelectedOverlay extends StatelessWidget {
+  const ShelfSelectedOverlay({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final bool eink = isEinkTheme(context);
+    return IgnorePointer(
+      child: DecoratedBox(
+        decoration: eink
+            ? BoxDecoration(
+                border: Border.all(color: tokens.surfaces.outline, width: 2),
+                borderRadius: tokens.radii.cardRadius,
+              )
+            : BoxDecoration(
+                color: tokens.surfaces.primary.withValues(alpha: 0.12),
+                borderRadius: tokens.radii.cardRadius,
+              ),
+      ),
+    );
+  }
+}

--- a/hibiki/lib/utils.dart
+++ b/hibiki/lib/utils.dart
@@ -15,6 +15,7 @@ export 'src/utils/components/hibiki_tag.dart';
 export 'src/utils/components/cover_badge.dart';
 export 'src/utils/components/hibiki_destructive_confirm_dialog.dart';
 export 'src/utils/components/hibiki_placeholder_message.dart';
+export 'src/utils/components/shelf_card_widgets.dart';
 export 'src/utils/components/hibiki_text_selection_controls.dart';
 export 'src/utils/components/hibiki_list_tile.dart';
 export 'src/utils/components/hibiki_focusable.dart';

--- a/hibiki/test/pages/collection_date_visible_test.dart
+++ b/hibiki/test/pages/collection_date_visible_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/models.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
@@ -60,7 +62,10 @@ void main() {
   });
 
   // 收藏句不带 bookKey → _load 不会触发 SrtBook/Audiobook/Video 音频解析路径，
-  // 只驱动列表渲染逻辑。createdAt 固定到一个可预测的日期，便于断言日期文本。
+  // 只驱动列表渲染逻辑。createdAt 固定到「当年 6/30 14:05」（当年条目走省年份
+  // 分支且不随真实年份漂移），便于断言日期文本。
+  final DateTime createdAt = DateTime(DateTime.now().year, 6, 30, 14, 5);
+
   Future<void> seedLongMetadataFavorite() async {
     final FavoriteSentenceRepository repo = FavoriteSentenceRepository(db);
     await repo.add(
@@ -72,7 +77,7 @@ void main() {
         chapterLabel: '第一章 これもまた非常に長い章のタイトルであり日付を画面外へ押し出すための'
             'もの',
         source: kFavoriteSentenceSourceBook,
-        createdAt: DateTime(2026, 6, 30, 14, 5),
+        createdAt: createdAt,
       ),
     );
   }
@@ -86,8 +91,12 @@ void main() {
         ),
       );
 
-  // 期望的日期文本，与 CollectionsPage 内部 DateFormat('MM/dd HH:mm') 一致。
-  const String expectedDate = '06/30 14:05';
+  // 期望的日期文本：与 CollectionsPage 的本地化格式（当年条目 Md + Hm，随 app
+  // 语言 en）一致（巡检 PR-3 起不再是硬编码 'MM/dd HH:mm'）。
+  Future<String> expectedDateText() async {
+    await initializeDateFormatting();
+    return DateFormat.Md('en').add_Hm().format(createdAt);
+  }
 
   testWidgets(
       'collection date stays visible on a narrow screen with long book/chapter',
@@ -105,7 +114,7 @@ void main() {
     expect(find.text('これはテスト用の収集された文章です。'), findsOneWidget);
 
     // 关键断言：收藏日期是独立、未被截断的文本，窄屏下仍然可见且有正的渲染宽度。
-    final Finder dateFinder = find.text(expectedDate);
+    final Finder dateFinder = find.text(await expectedDateText());
     expect(dateFinder, findsOneWidget);
     final Size dateSize = tester.getSize(dateFinder);
     expect(dateSize.width, greaterThan(0));
@@ -121,6 +130,6 @@ void main() {
     await tester.pumpWidget(buildPage());
     await tester.pumpAndSettle();
 
-    expect(find.text(expectedDate), findsOneWidget);
+    expect(find.text(await expectedDateText()), findsOneWidget);
   });
 }

--- a/hibiki/test/pages/collection_detail_focus_id_test.dart
+++ b/hibiki/test/pages/collection_detail_focus_id_test.dart
@@ -1,0 +1,174 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/media.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/focus/hibiki_focus_target.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/media_collection_grid_detail_page.dart';
+import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// BUG-1009（预防性）：合集详情页成员卡的手柄/键盘焦点 id 不得与书架同名。
+///
+/// 详情页 push 在书架路由之上、两条路由的 HibikiFocusTarget 同时存活；焦点注册表
+/// 按 id 覆盖（hibiki_focus_controller.dart `_targets[id] = entry`），同名即撞号
+/// ——后注册者赢、owner unregister 时另一方失联。修复 = 详情页渲染路径
+/// （[_buildCollectionMemberCard]）给成员卡 focusId 加 'collection-detail-' 路由
+/// 前缀，书架前缀不动（快捷键/方向锚点语义零变化）。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('hibiki_collection_focus_pp');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      try {
+        pathProviderDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  late HibikiDatabase db;
+  late PreferencesRepository prefs;
+  late AppModel appModel;
+  late Directory storeDir;
+  late List<MediaItem> epubItems;
+  late List<SrtBook> srtItems;
+
+  setUp(() async {
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir = Directory.systemTemp.createTempSync('hibiki_collection_focus');
+    appModel = AppModel(testPlatformServices())
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+    appModel.populateLanguages();
+    epubItems = <MediaItem>[];
+    srtItems = <SrtBook>[];
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (storeDir.existsSync()) {
+      try {
+        storeDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  Future<void> seedEpub(String bookKey, String title) async {
+    await db.insertEpubBook(EpubBooksCompanion.insert(
+      bookKey: bookKey,
+      title: title,
+      epubPath: '${pathProviderDir.path}/$bookKey.epub',
+      extractDir: pathProviderDir.path,
+      chapterCount: 1,
+      chaptersJson: '["a"]',
+      importedAt: 0,
+    ));
+    epubItems.add(MediaItem(
+      mediaIdentifier: ReaderHibikiSource.mediaIdentifierFor(bookKey),
+      title: title,
+      mediaTypeIdentifier: ReaderHibikiSource.instance.mediaType.uniqueKey,
+      mediaSourceIdentifier: ReaderHibikiSource.instance.uniqueKey,
+      position: 0,
+      duration: 1,
+      canDelete: false,
+      canEdit: true,
+    ));
+  }
+
+  Widget buildApp() => ProviderScope(
+        overrides: <Override>[
+          appProvider.overrideWith((ref) => appModel),
+          hibikiBooksProvider.overrideWith(
+            (ref, language) => Future<List<MediaItem>>.value(epubItems),
+          ),
+          srtBooksProvider.overrideWith(
+            (ref) => Future<List<SrtBook>>.value(srtItems),
+          ),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            // 焦点根置于 Navigator 之上：书架与 push 出的详情页共用同一注册表，
+            // 复刻生产的「两条路由同时注册」环境。
+            builder: (BuildContext context, Widget? child) =>
+                HibikiFocusRoot(child: child ?? const SizedBox.shrink()),
+            home: Scaffold(
+              body: ReaderHibikiHistoryPage(
+                remoteBookClientLoader: () async => null,
+              ),
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('BUG-1009：详情页成员卡 focusId 带 collection-detail- 前缀，与书架不撞号',
+      (WidgetTester tester) async {
+    await seedEpub('memberKey', '成员书');
+    final int cid = await db.createMediaCollection('系列甲');
+    await db.addToCollection(cid, 'epub', 'memberKey');
+    final String mediaId = ReaderHibikiSource.mediaIdentifierFor('memberKey');
+
+    tester.view.physicalSize = const Size(1400, 1200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    // 书架合集行内的成员卡：无前缀 id（既有语义不变）。
+    List<String> onstageIds() => tester
+        .widgetList<HibikiFocusTarget>(find.byType(HibikiFocusTarget))
+        .map((HibikiFocusTarget w) => w.id.value)
+        .toList();
+    expect(onstageIds(), contains('reader-shelf-book-$mediaId'),
+        reason: '书架成员卡保持既有无前缀 focusId');
+
+    // 进详情页。
+    await tester.tap(find.text(t.collection_view_all));
+    await tester.pumpAndSettle();
+    expect(find.byType(MediaCollectionGridDetailPage), findsOneWidget);
+
+    // 详情页成员卡：带路由前缀，且不再出现与书架同名的 id。
+    final List<String> detailIds = onstageIds();
+    expect(detailIds, contains('collection-detail-reader-shelf-book-$mediaId'),
+        reason: '详情页成员卡必须带 collection-detail- 前缀（BUG-1009）');
+    expect(detailIds, isNot(contains('reader-shelf-book-$mediaId')),
+        reason: '详情页（onstage）不得复用书架同名 focusId');
+
+    // 书架路由仍在其下存活（offstage），其无前缀 id 未被改动——两条路由并存时
+    // 注册表里是两个不同 id，不再互相覆盖。
+    final List<String> allIds = tester
+        .widgetList<HibikiFocusTarget>(
+            find.byType(HibikiFocusTarget, skipOffstage: false))
+        .map((HibikiFocusTarget w) => w.id.value)
+        .toList();
+    expect(allIds, contains('reader-shelf-book-$mediaId'));
+    expect(allIds, contains('collection-detail-reader-shelf-book-$mediaId'));
+  });
+}

--- a/hibiki/test/pages/collections_export_test.dart
+++ b/hibiki/test/pages/collections_export_test.dart
@@ -83,9 +83,10 @@ void main() {
         ),
       );
 
+  // 巡检 PR-3：分享图标从 iOS 专属 ios_share_outlined 统一为 Material share_outlined。
   Finder exportButton() => find.widgetWithIcon(
         HibikiIconButton,
-        Icons.ios_share_outlined,
+        Icons.share_outlined,
       );
 
   testWidgets('export button hidden when there are no favorite sentences',

--- a/hibiki/test/pages/reader_bookshelf_card_layout_static_test.dart
+++ b/hibiki/test/pages/reader_bookshelf_card_layout_static_test.dart
@@ -13,10 +13,13 @@ void main() {
       isNot(contains('Widget _titleOverlay(String title)')),
       reason: 'book titles must no longer draw inside the cover artwork',
     );
+    // 巡检 PR-3：footer 实现提取到共享组件 ShelfCardFooter（书卡与
+    // SeriesShelfCard 共用，消除逐行手抄），书架侧守卫改锁「layout 消费共享
+    // footer」；footer 本体的排版守卫移到下方对共享文件的断言。
     expect(
       source,
-      contains('Widget _bookCardFooter(String title)'),
-      reason: 'the title must live in a stable below-cover footer',
+      contains('ShelfCardFooter(title: title)'),
+      reason: 'the title must live in the shared below-cover footer component',
     );
     final String layout = _functionSource(source, 'Widget _bookCardLayout({');
     expect(
@@ -31,7 +34,7 @@ void main() {
     );
     expect(
       layout,
-      contains('_bookCardFooter(title)'),
+      contains('ShelfCardFooter(title: title)'),
       reason: 'the title footer must render below the cover stack',
     );
     expect(
@@ -69,7 +72,7 @@ void main() {
     expect(layout, isNot(contains('_titleOverlay(title)')));
     expect(layout, contains('_bookCardTagArea(tagLabels)'));
     final int coverStack = layout.indexOf('Stack(');
-    final int titleFooter = layout.indexOf('_bookCardFooter(title)');
+    final int titleFooter = layout.indexOf('ShelfCardFooter(title: title)');
     expect(titleFooter, greaterThan(coverStack),
         reason: 'the title footer must be after the cover stack');
 
@@ -167,7 +170,7 @@ void main() {
 
     final int coverStack = layout.indexOf('Stack(');
     final int coverFrame = layout.indexOf('_bookCardCoverFrame(');
-    final int footer = layout.indexOf('_bookCardFooter(title)');
+    final int footer = layout.indexOf('ShelfCardFooter(title: title)');
     expect(coverStack, greaterThan(coverFrame),
         reason: 'the visual frame should wrap the cover stack');
     expect(coverFrame, lessThan(footer),
@@ -176,7 +179,15 @@ void main() {
 
   test('book card footer clamps long titles without resizing the grid', () {
     final String source = readReaderHistorySource();
-    final String footer = _functionSource(source, 'Widget _bookCardFooter(');
+    // 巡检 PR-3：footer 实现活在共享组件文件（ShelfCardFooter），排版守卫跟随。
+    final String shared = File(
+      'lib/src/utils/components/shelf_card_widgets.dart',
+    ).readAsStringSync();
+    final String footer = _sectionSource(
+      shared,
+      'class ShelfCardFooter extends StatelessWidget',
+      'class ShelfSelectionCheck',
+    );
 
     expect(source, contains('const double kShelfTitleFooterHeight ='));
     expect(footer, contains('HibikiDesignTokens.of(context)'));
@@ -318,6 +329,15 @@ void main() {
     expect(tagArea, contains('maxHeight: tokens.spacing.gap * 3.5'));
     expect(tagArea, contains('ClipRect(child: tagLabels)'));
   });
+}
+
+/// 从 [source] 里切 [startToken]（含）到 [endToken]（不含）的片段。
+String _sectionSource(String source, String startToken, String endToken) {
+  final int start = source.indexOf(startToken);
+  expect(start, isNonNegative, reason: 'missing $startToken');
+  final int end = source.indexOf(endToken, start);
+  expect(end, greaterThan(start), reason: 'missing $endToken');
+  return source.substring(start, end);
 }
 
 String _functionSource(String source, String startToken) {

--- a/hibiki/test/pages/reader_shelf_tag_filter_empty_state_test.dart
+++ b/hibiki/test/pages/reader_shelf_tag_filter_empty_state_test.dart
@@ -1,0 +1,198 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/media.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart';
+import 'package:hibiki/src/pages/implementations/tag_filter_sheet.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// BUG-1008：标签筛选下的矛盾空态回归。
+///
+/// 旧实现的 `hasActiveFilter && epubBooks.isEmpty` 特殊分支在「筛选命中若干 SRT
+/// 有声书、EPUB 零命中」时已把 SRT 卡渲染成网格，却仍无条件叠一条
+/// `tag_no_books_for_filter`（「没有符合筛选的书」）空态文案，且该分支丢
+/// RefreshIndicator / 合集横排行 / 书库概览。修复 = 消灭特殊分支，筛选态走主分支
+/// 组装；只有整体为空（无任何可渲染卡）时才显示空态。
+///
+/// 渲染层说明（与 reader_shelf_batch_collection_ops_test 同源）：书架
+/// [hibikiBooksProvider] 的真实实现会 `await` 封面 `File.exists()` 真 I/O，假时钟
+/// 下永不完成，故「读」provider 覆写成受控列表；标签筛选走**真 DB**（createTag /
+/// addTagToSrtBook + filteredSrtBookIdsProvider 真实推导），只覆写选中标签集。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('hibiki_shelf_filter_pp');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      try {
+        pathProviderDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  late HibikiDatabase db;
+  late PreferencesRepository prefs;
+  late AppModel appModel;
+  late Directory storeDir;
+  late List<MediaItem> epubItems;
+  late List<SrtBook> srtItems;
+
+  setUp(() async {
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir = Directory.systemTemp.createTempSync('hibiki_shelf_filter');
+    appModel = AppModel(testPlatformServices())
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+    appModel.populateLanguages();
+    epubItems = <MediaItem>[];
+    srtItems = <SrtBook>[];
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (storeDir.existsSync()) {
+      try {
+        storeDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  Future<void> seedEpub(String bookKey, String title) async {
+    await db.insertEpubBook(EpubBooksCompanion.insert(
+      bookKey: bookKey,
+      title: title,
+      epubPath: '${pathProviderDir.path}/$bookKey.epub',
+      extractDir: pathProviderDir.path,
+      chapterCount: 1,
+      chaptersJson: '["a"]',
+      importedAt: 0,
+    ));
+    epubItems.add(MediaItem(
+      mediaIdentifier: ReaderHibikiSource.mediaIdentifierFor(bookKey),
+      title: title,
+      mediaTypeIdentifier: ReaderHibikiSource.instance.mediaType.uniqueKey,
+      mediaSourceIdentifier: ReaderHibikiSource.instance.uniqueKey,
+      position: 0,
+      duration: 1,
+      canDelete: false,
+      canEdit: true,
+    ));
+  }
+
+  Future<SrtBook> seedSrt(String uid, String title) async {
+    final SrtBook book = SrtBook()
+      ..uid = uid
+      ..title = title
+      ..srtPath = '${pathProviderDir.path}/$uid.srt'
+      ..importedAt = 0
+      ..bookKey = '';
+    await SrtBookRepository(db).save(book);
+    final SrtBook? saved = await SrtBookRepository(db).findByUid(uid);
+    srtItems.add(saved ?? book);
+    return saved ?? book;
+  }
+
+  Widget buildApp({required Set<int> selectedTagIds}) => ProviderScope(
+        overrides: <Override>[
+          appProvider.overrideWith((ref) => appModel),
+          hibikiBooksProvider.overrideWith(
+            (ref, language) => Future<List<MediaItem>>.value(epubItems),
+          ),
+          srtBooksProvider.overrideWith(
+            (ref) => Future<List<SrtBook>>.value(srtItems),
+          ),
+          // 选中标签集直接覆写（真 UI 入口是标签栏 chip，这里只测筛选渲染分支）；
+          // filtered*Provider 用真实实现，从真 DB 的标签映射推导命中集。
+          selectedTagIdsProvider.overrideWith((ref) => selectedTagIds),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            builder: (BuildContext context, Widget? child) =>
+                child ?? const SizedBox.shrink(),
+            home: Scaffold(
+              body: ReaderHibikiHistoryPage(
+                remoteBookClientLoader: () async => null,
+              ),
+            ),
+          ),
+        ),
+      );
+
+  Future<void> pumpPage(WidgetTester tester,
+      {required Set<int> selectedTagIds}) async {
+    tester.view.physicalSize = const Size(1400, 1200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(buildApp(selectedTagIds: selectedTagIds));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('BUG-1008：筛选命中 1 本 SRT + 0 本 EPUB → 渲染网格，无矛盾空态、保留下拉刷新',
+      (WidgetTester tester) async {
+    final SrtBook tagged = await seedSrt('srtHit', '命中的有声书');
+    await seedEpub('epubMiss', '未命中的书');
+    final int tagId = await db.createTag('日语', 0xFF112233);
+    await db.addTagToSrtBook(tagged.id!, tagId);
+
+    await pumpPage(tester, selectedTagIds: <int>{tagId});
+
+    // 命中的 SRT 卡在网格里；未命中的 EPUB 卡被筛掉。
+    expect(
+        find.byKey(const ValueKey<String>('srt_entry_srtHit')), findsOneWidget,
+        reason: '命中的 SRT 卡必须渲染');
+    expect(
+      find.byKey(ValueKey<String>(
+          'book_entry_${ReaderHibikiSource.mediaIdentifierFor('epubMiss')}')),
+      findsNothing,
+      reason: '未命中的 EPUB 卡必须被筛掉',
+    );
+    // 有结果时绝不能再叠「没有符合筛选的书」（旧特殊分支的矛盾空态）。
+    expect(find.text(t.tag_no_books_for_filter), findsNothing,
+        reason: '有命中结果时不得显示空态文案（BUG-1008）');
+    // 筛选态不再丢下拉刷新（旧特殊分支没有 RefreshIndicator）。
+    expect(find.byType(RefreshIndicator), findsOneWidget,
+        reason: '筛选态必须保留下拉刷新（BUG-1008）');
+  });
+
+  testWidgets('BUG-1008：筛选全不命中 → 显示 tag_no_books_for_filter 空态',
+      (WidgetTester tester) async {
+    await seedSrt('srtMiss', '有声书');
+    await seedEpub('epubMiss', '书');
+    final int tagId = await db.createTag('无人命中', 0xFF445566);
+
+    await pumpPage(tester, selectedTagIds: <int>{tagId});
+
+    expect(find.text(t.tag_no_books_for_filter), findsOneWidget,
+        reason: '整体为空时才显示空态文案');
+    expect(
+        find.byKey(const ValueKey<String>('srt_entry_srtMiss')), findsNothing);
+    expect(find.byType(RefreshIndicator), findsNothing);
+  });
+}

--- a/hibiki/test/pages/remote_card_longpress_dialog_test.dart
+++ b/hibiki/test/pages/remote_card_longpress_dialog_test.dart
@@ -216,6 +216,9 @@ class _FakeRemoteBookClient implements RemoteBookClient {
           'title': 'Remote Book',
           'hasContent': true,
           'coverPath': coverPath,
+          // 巡检 PR-3：「信息」入口只在有附加元数据（hasAudiobook）时显示——
+          // 本 fake 带有声书，动作面板断言（含 remote_book_info）保持原语义。
+          'hasAudiobook': true,
         }),
       ];
 

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -1109,7 +1109,8 @@ void main() {
 
     expect(cardLayout, contains('HibikiDesignTokens.of(context)'));
     expect(cardLayout, contains('tokens.spacing'));
-    expect(cardLayout, contains('_bookCardFooter(title)'));
+    // 巡检 PR-3：footer 提取到共享 ShelfCardFooter（与 SeriesShelfCard 共用）。
+    expect(cardLayout, contains('ShelfCardFooter(title: title)'));
     expect(cardLayout, contains('height: kShelfTitleFooterHeight'));
     expect(cardLayout, contains('PositionedDirectional('));
     expect(cardLayout, contains('tokens.spacing.gap * 0.75'));
@@ -1192,7 +1193,11 @@ void main() {
 
     expect(cardShell, contains('HibikiDesignTokens.of(context)'));
     expect(cardShell, contains('tokens.spacing'));
-    expect(cardShell, contains('tokens.surfaces'));
+    // 巡检 PR-3：勾选圈 / 选中罩视觉提取到共享 ShelfSelectionCheck /
+    // ShelfSelectedOverlay（与 SeriesShelfCard 共用，eink 实底统一处理），
+    // shell 消费共享组件，token 守卫跟随到共享文件。
+    expect(cardShell, contains('ShelfSelectionCheck(selected: selected)'));
+    expect(cardShell, contains('ShelfSelectedOverlay()'));
     expect(cardShell, isNot(contains('Spacing.of(context)')));
     expect(cardShell, isNot(contains('top: 4,')));
     expect(cardShell, isNot(contains('left: 4,')));
@@ -1201,6 +1206,13 @@ void main() {
     expect(cardShell, isNot(contains('theme.colorScheme.surface.withValues')));
     expect(cardShell, isNot(contains('theme.colorScheme.outline')));
     expect(cardShell, isNot(contains('theme.colorScheme.primary.withValues')));
+
+    final String sharedSelection = File(
+      'lib/src/utils/components/shelf_card_widgets.dart',
+    ).readAsStringSync();
+    expect(sharedSelection, contains('HibikiDesignTokens.of(context)'));
+    expect(sharedSelection, contains('tokens.surfaces'));
+    expect(sharedSelection, isNot(contains('theme.colorScheme.outline')));
   });
 
   test('reader history batch actions use shared MD3 spacing tokens', () {
@@ -1247,10 +1259,15 @@ void main() {
 
   test('reader history title footer and drag target use shared MD3 tokens', () {
     final String source = readReaderHistorySource();
-    final String titleFooter = _functionSource(
-      source,
-      'Widget _bookCardFooter(String title)',
-      'Widget _bookCardTagArea(',
+    // 巡检 PR-3：footer 实现提取到共享 ShelfCardFooter（书卡 / SeriesShelfCard
+    // 共用），MD3 token 守卫跟随到共享文件。
+    final String sharedShelfCard = File(
+      'lib/src/utils/components/shelf_card_widgets.dart',
+    ).readAsStringSync();
+    final String titleFooter = _sectionSource(
+      sharedShelfCard,
+      'class ShelfCardFooter extends StatelessWidget',
+      sharedShelfCard.indexOf('class ShelfSelectionCheck'),
     );
     // BookDragTarget 已提取到独立文件 book_drag_target.dart，守卫跟随。
     final String dragSource = File(


### PR DESCRIPTION
书籍模块 UI/UX 重构（巡检 PR-3，基于 ui-ux-pr0-shared 共享组件先行批 39167a2da）。

## 功能 bug
- **BUG-1008 标签筛选矛盾空态**：消灭 `hasActiveFilter && epubBooks.isEmpty` 特殊分支——筛选态统一走主分支组装（shelfGroups 承载纯 SRT 命中），SRT 命中不再被叠「没有符合筛选的书」，恢复 RefreshIndicator / 合集横排行 / 书库概览；仅整体为空时显示空态。空态判定补上 `remoteSrtBooks`（旧条件漏了纯 SRT 远端占位）。新增 widget 测试 `reader_shelf_tag_filter_empty_state_test.dart`（命中 1 SRT + 0 EPUB → 无空态文案 + 有 RefreshIndicator；全不命中 → 有空态文案）。
- **BUG-1009 预防性修复**：合集详情页成员卡 focusId 加 `collection-detail-` 路由前缀（EPUB + SRT 两路），不再与书架同名撞号（焦点注册表按 id 覆盖）；书架前缀不动。新增 widget 测试 `collection_detail_focus_id_test.dart` 锁两条路由 id 不同。

## 布局 / 一致性
- 批量操作栏：计数/全选/反选改 `Expanded+Wrap`（窄屏大字体不再溢出）；`elevation: 6` 阴影 → 上边框 `BorderSide(outlineVariant)`（全 app elevation 0 纪律）。
- 合集详情两页收敛：`_rename` / `_editTags`+`_buildTagChips` / `_buildSortMenu` / 删除确认四组手抄抽到共享 mixin `CollectionDetailShared`（collection_detail_shared.dart）；删除确认统一 `HibikiDestructiveConfirmDialog`（「连同本体删除」走 checkboxLabel），逐集移出确认同步收口。
- 两详情页加载态 → `adaptiveIndicator`、空态 → `HibikiPlaceholderMessage`。
- grid 详情卡尺寸对齐书架：`readerShelfGridExtentForLayout` + `unifiedShelfCardLayout` + `kShelfBookCardAspectRatio`（去 180+ceil+硬编码 160/260）。
- grid 详情 `IgnorePointer` 保留（手势竞技场决策不变），补 `_HoverableMemberCard` MouseRegion 悬停反馈（eink 走描边）。
- detail 剧集行接焦点：`HibikiFocusTarget('collection-episode-<uid>')` + ActivateIntent；硬编码间距 → tokens。
- 卡片 footer / 勾选圈 / 选中罩收敛：新共享组件 `ShelfCardFooter` / `ShelfSelectionCheck` / `ShelfSelectedOverlay`（utils/components/shelf_card_widgets.dart），书卡与 SeriesShelfCard 共用；静态守卫（card_layout / md3）跟随指向共享文件。
- SeriesShelfCard 补 `onLongPress` / `onSecondaryTap` 参数（与散卡交互对称；防御性调用分支保留未接线——该分支为旧调用防御路径，无对应动作面板语义）。
- 远端云角标 ☁ → PR-0 `CoverBadge`（稳定 key 保留）。
- 书卡标签槽：maxSlots==1 且溢出时唯一槽显示「+N」合并 chip（不再误读为「只有 1 个标签」；容器高未动）。
- 无封面占位对比（截图 B11）：`_coverPlaceholderIcon` 加 1px outlineVariant 描边（全主题）。
- eink alpha 叠层：勾选圈 0.7 / 选中罩 0.12（共享组件内实底/描边）、collection_shelf_row 拖放 0.18（去填充留描边）、tag_filter_bar 分隔线 0.3（实心 outline）。

## 收藏页
- 日期本地化：`DateFormat.Md(locale).add_Hm()`，跨年条目补年份（`yMd`）；locale 符号缺失退回默认（app 未全局 initializeDateFormatting）。
- 播放中态：全局 bool → `_playingItemKey` 按行标记，仅播放行小 CircularProgressIndicator，其余行可点（先 `TtsChannel.stop()` 停旧后播新，播放器逻辑不动）；对话框播放按钮同语义。
- 分享图标 `ios_share_outlined` → `share_outlined`（AppBar 导出入口 + 导出面板确认按钮两处；导出按钮 finder 测试同步）。
- 日期本地化的根因配套：`_load` 先 `initializeDateFormatting()`（date_symbol_data_local，纯内存无 IO）——app 此前从未初始化 intl date symbols，直接 `DateFormat.Md(locale)` 会抛 LocaleDataException。
- 加载态补说明文案（新 i18n key `collection_loading_hint`，经 i18n_sync 落 17 语言 + slang 重生成）。

## 远端卡
- 远端书「信息」入口仅在有附加元数据（hasAudiobook）时显示（空壳弹窗不再出现）。
- 远端纯 SRT 占位卡长按/右键 → 弹 `MediaItemDialogFrame` 动作面板（与远端 EPUB 卡一致），不再重手势直接开始下载。

## 跳过项
- 收藏页导出/清空 bottom sheet 范式迁移（showAppDialog+HibikiDialogFrame、RadioListTile→HibikiListItem）：中等风险 + 触及焦点驱动路径，本轮跳过（清单 #14 允许）。
- 「列表先渲染懒回填」重构：清单明示风险大跳过，已用加载文案缓解。
- SeriesShelfCard 调用点未接长按动作：防御性死路径，无动作面板语义可接；组件层已具备参数。

## 验证
- `flutter analyze --no-pub`：零问题。
- 全量 `flutter test --no-pub`（bash）：见 PR 附言/CI。
- 新增测试：BUG-1008 ×2、BUG-1009 ×1；更新静态守卫 2 个文件（footer/勾选圈提取跟随）。
- 未动：Drift schema / 持久化 key / 导入逻辑 / openMedia / 手势快捷键深链。

https://claude.ai/code/session_01CfSqJG9psJkUVSig6DhH9Y
