### PR TITLE
UI/UX 重构 PR-5：设置模块（默认分类/图标对齐/制卡搜索/readout 盘点）

### DIFF
--- a/hibiki/CLAUDE.md
+++ b/hibiki/CLAUDE.md
@@ -111,7 +111,7 @@ Hibiki 的 Flutter 多平台主应用：日语 EPUB 阅读器，集成划词查�
   - **自定义字体**: 白名单校验 + 文件头魔数验证（TrueType/OpenType/WOFF/WOFF2/TTC）。
 - `reader_hibiki_history_page.dart` -- 阅读器与书架。
 - `dictionary_*` 系列 -- 词典相关页面。
-- `hibiki_settings_page.dart` / `display_settings_page.dart` / `switch_settings_page.dart` -- 设置。
+- 设置：schema 化体系在 `lib/src/settings/`（`settings_home_page.dart` 主从入口 + `settings_schema_*.dart` 各分类 schema）；`hibiki_settings_page.dart` 是应用内入口壳，`anki_settings_page.dart` / `shortcut_settings_page.dart` / `miscellaneous_settings_page.dart` 走 `SettingsDestination.body` 逃生口（旧 `display_settings_page.dart` / `switch_settings_page.dart` 已删除）。
 - `profile_management_page.dart` -- Profile 管理。
 - `collections_page.dart` / `tag_*` 系列 -- 集合与标签。
 - `reading_statistics_page.dart` -- 阅读统计。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 38012 (2236 per locale)
+/// Strings: 38029 (2237 per locale)
 ///
-/// Built on 2026-07-22 at 05:54 UTC
+/// Built on 2026-07-22 at 09:28 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2978,6 +2978,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get settings_destination_system_summary =>
       'General, updates & diagnostics';
   String get error_load_failed => 'Something went wrong while loading';
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -8038,6 +8039,8 @@ class _StringsAr extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -13171,6 +13174,8 @@ class _StringsDe extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -18320,6 +18325,8 @@ class _StringsEs extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -23480,6 +23487,8 @@ class _StringsFr extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -28567,6 +28576,8 @@ class _StringsId extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -33702,6 +33713,8 @@ class _StringsIt extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -38642,6 +38655,8 @@ class _StringsJa extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -43585,6 +43600,8 @@ class _StringsKo extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -48698,6 +48715,8 @@ class _StringsNl extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -53826,6 +53845,8 @@ class _StringsPtBr extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -58937,6 +58958,8 @@ class _StringsRu extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -63993,6 +64016,8 @@ class _StringsTh extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -69081,6 +69106,8 @@ class _StringsTr extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -74156,6 +74183,8 @@ class _StringsVi extends _StringsEn {
       'General, updates & diagnostics';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 // Path: <root>
@@ -78878,6 +78907,8 @@ class _StringsZhCn extends _StringsEn {
   String get settings_destination_system_summary => '通用、更新与诊断';
   @override
   String get error_load_failed => '加载出错';
+  @override
+  String get app_icon_presets => '预设';
 }
 
 // Path: <root>
@@ -83736,6 +83767,8 @@ class _StringsZhHk extends _StringsEn {
   String get settings_destination_system_summary => '通用、更新與診斷';
   @override
   String get error_load_failed => 'Something went wrong while loading';
+  @override
+  String get app_icon_presets => 'Presets';
 }
 
 /// Flat map(s) containing all translations.
@@ -88300,6 +88333,8 @@ extension on _StringsEn {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -92862,6 +92897,8 @@ extension on _StringsAr {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -97445,6 +97482,8 @@ extension on _StringsDe {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -102027,6 +102066,8 @@ extension on _StringsEs {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -106615,6 +106656,8 @@ extension on _StringsFr {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -111185,6 +111228,8 @@ extension on _StringsId {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -115770,6 +115815,8 @@ extension on _StringsIt {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -120317,6 +120364,8 @@ extension on _StringsJa {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -124868,6 +124917,8 @@ extension on _StringsKo {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -129446,6 +129497,8 @@ extension on _StringsNl {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -134021,6 +134074,8 @@ extension on _StringsPtBr {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -138601,6 +138656,8 @@ extension on _StringsRu {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -143165,6 +143222,8 @@ extension on _StringsTh {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -147738,6 +147797,8 @@ extension on _StringsTr {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -152306,6 +152367,8 @@ extension on _StringsVi {
         return 'General, updates & diagnostics';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }
@@ -156840,6 +156903,8 @@ extension on _StringsZhCn {
         return '通用、更新与诊断';
       case 'error_load_failed':
         return '加载出错';
+      case 'app_icon_presets':
+        return '预设';
       default:
         return null;
     }
@@ -161382,6 +161447,8 @@ extension on _StringsZhHk {
         return '通用、更新與診斷';
       case 'error_load_failed':
         return 'Something went wrong while loading';
+      case 'app_icon_presets':
+        return 'Presets';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "General",
   "reading_section_mode": "Mode & orientation",
   "settings_destination_system_summary": "General, updates & diagnostics",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "通用",
   "reading_section_mode": "模式与排版方向",
   "settings_destination_system_summary": "通用、更新与诊断",
-  "error_load_failed": "加载出错"
+  "error_load_failed": "加载出错",
+  "app_icon_presets": "预设"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2234,5 +2234,6 @@
   "settings_section_general": "通用",
   "reading_section_mode": "模式與排版方向",
   "settings_destination_system_summary": "通用、更新與診斷",
-  "error_load_failed": "Something went wrong while loading"
+  "error_load_failed": "Something went wrong while loading",
+  "app_icon_presets": "Presets"
 }

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -33,6 +33,11 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
   ThemeData get theme => Theme.of(context);
   TextTheme get textTheme => theme.textTheme;
 
+  /// 「创建 Lapis 卡组」在途标记（UI 层，独立于 vm 的 isFetching）。vm 的
+  /// createLapisSetup 内部复用 isFetching，若两行 spinner 都读它，点 Lapis 时
+  /// 「刷新」行也会转圈——各行只对自己的动作显示 busy。
+  bool _creatingLapis = false;
+
   @override
   Widget build(BuildContext context) {
     final uiState = ref.watch(ankiViewModelProvider);
@@ -45,9 +50,11 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       children: [
         AdaptiveSettingsSection(
           children: [
+            // showIcon 与同卡片的刷新/Lapis 行一致，左栏图标对齐。
             AdaptiveSettingsRow(
               title: t.profile_label,
               icon: Icons.person_outline,
+              showIcon: true,
               trailing: const ProfileSelector(),
             ),
             _buildFetchTile(uiState, vm),
@@ -202,8 +209,7 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       t.mining_image_quality_hd,
       t.mining_image_quality_native,
     ];
-    final int tier =
-        appModel.miningImageQuality.clamp(0, labels.length - 1);
+    final int tier = appModel.miningImageQuality.clamp(0, labels.length - 1);
     return AdaptiveSettingsSliderRow(
       title: t.mining_image_quality,
       subtitle: t.mining_image_quality_hint,
@@ -230,8 +236,7 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       t.mining_audio_quality_high,
       t.mining_audio_quality_native,
     ];
-    final int tier =
-        appModel.miningAudioQuality.clamp(0, labels.length - 1);
+    final int tier = appModel.miningAudioQuality.clamp(0, labels.length - 1);
     return AdaptiveSettingsSliderRow(
       title: t.mining_audio_quality,
       subtitle: t.mining_audio_quality_hint,
@@ -282,10 +287,13 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
   }
 
   Widget _buildFetchTile(AnkiUiState uiState, AnkiViewModel vm) {
+    // Lapis 创建在途时 vm 的 isFetching 也为 true（vm 内部复用同一 flag）；
+    // 本行的「正在刷新」文案与 spinner 只对真正的刷新动作显示。
+    final bool fetching = uiState.isFetching && !_creatingLapis;
     return AdaptiveSettingsRow(
       icon: Icons.sync_outlined,
       showIcon: true,
-      title: uiState.isFetching ? t.anki_fetching : t.anki_fetch,
+      title: fetching ? t.anki_fetching : t.anki_fetch,
       // Platform-neutral refresh hint (TODO-400): this row pulls the *current*
       // deck + note-type snapshot from Anki (AnkiConnect on desktop / iOS,
       // AnkiDroid on Android). The dropdowns only ever render what the last
@@ -293,19 +301,22 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       // invisible until the user taps here. The subtitle says exactly that,
       // replacing the old AnkiDroid-only "Fetch from AnkiDroid" label that made
       // desktop AnkiConnect users miss this as the refresh entry point.
-      subtitle: uiState.isFetching ? null : t.anki_refresh_hint,
+      subtitle: fetching ? null : t.anki_refresh_hint,
       // Action row, not navigation: a leading icon + state-layer ripple signals
       // tappability (MD3 list-item convention, same as SettingsActionItem); the
       // tap triggers a fetch (spinner while running) rather than opening a
       // subpage, so there is no trailing chevron.
-      trailing: uiState.isFetching
+      trailing: fetching
           ? SizedBox(
               width: 20,
               height: 20,
               child: adaptiveIndicator(context: context, strokeWidth: 2),
             )
           : null,
-      onTap: uiState.isFetching ? null : () => vm.fetchConfiguration(),
+      // 任一在途动作（刷新或 Lapis 创建）期间都不可重入。
+      onTap: uiState.isFetching || _creatingLapis
+          ? null
+          : () => vm.fetchConfiguration(),
     );
   }
 
@@ -315,20 +326,30 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       showIcon: true,
       title: t.anki_create_lapis,
       subtitle: t.anki_create_lapis_hint,
-      trailing: uiState.isFetching
+      // spinner 只跟本行自己的在途动作（_creatingLapis），不再借 vm 的
+      // isFetching——否则点「刷新」时本行也凭空转圈。
+      trailing: _creatingLapis
           ? SizedBox(
               width: 20,
               height: 20,
               child: adaptiveIndicator(context: context, strokeWidth: 2),
             )
           : null,
-      onTap: uiState.isFetching ? null : () => _runCreateLapis(vm),
+      onTap: uiState.isFetching || _creatingLapis
+          ? null
+          : () => _runCreateLapis(vm),
     );
   }
 
   Future<void> _runCreateLapis(AnkiViewModel vm) async {
     final messenger = ScaffoldMessenger.of(context);
-    final result = await vm.createLapisSetup();
+    setState(() => _creatingLapis = true);
+    final LapisSetupResult result;
+    try {
+      result = await vm.createLapisSetup();
+    } finally {
+      if (mounted) setState(() => _creatingLapis = false);
+    }
     if (!mounted) return;
     final String message;
     switch (result.outcome) {
@@ -678,22 +699,30 @@ class _AnkiHandlebarPickerDialogState extends State<AnkiHandlebarPickerDialog> {
             ),
             SizedBox(height: tokens.spacing.gap),
             Flexible(
-              child: ListView.builder(
-                shrinkWrap: true,
-                itemCount: widget.options.length,
-                itemBuilder: (_, i) {
-                  final opt = widget.options[i];
-                  if (opt == '-') return const Divider(height: 1);
-                  final isSelected = widget.initialValue == opt;
-                  return AdaptiveSettingsRow(
-                    title: widget.labelFor(opt),
-                    trailing: isSelected
-                        ? Icon(
-                            Icons.check,
-                            color: Theme.of(context).colorScheme.primary,
-                          )
-                        : null,
-                    onTap: () => Navigator.pop(context, opt),
+              // 选中勾对照**当前输入框值**而非打开时的旧快照（initialValue）：
+              // 用户在输入框里改过映射后，勾要实时跟着走，不再指向已过时的旧值。
+              // ValueListenableBuilder 只重建选项列表，键入不重建整个弹窗。
+              child: ValueListenableBuilder<TextEditingValue>(
+                valueListenable: _controller,
+                builder: (BuildContext context, TextEditingValue value, _) {
+                  return ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: widget.options.length,
+                    itemBuilder: (_, i) {
+                      final opt = widget.options[i];
+                      if (opt == '-') return const Divider(height: 1);
+                      final bool isSelected = value.text == opt;
+                      return AdaptiveSettingsRow(
+                        title: widget.labelFor(opt),
+                        trailing: isSelected
+                            ? Icon(
+                                Icons.check,
+                                color: Theme.of(context).colorScheme.primary,
+                              )
+                            : null,
+                        onTap: () => Navigator.pop(context, opt),
+                      );
+                    },
                   );
                 },
               ),
@@ -705,21 +734,23 @@ class _AnkiHandlebarPickerDialogState extends State<AnkiHandlebarPickerDialog> {
           spacing: tokens.spacing.gap,
           runSpacing: tokens.spacing.gap,
           children: [
+            // 统一走 slang t.*（MaterialLocalizations 跟系统 locale，与应用内
+            // 语言切换脱节）。首按钮语义是「清空该字段映射」而非删除实体，
+            // 用 dialog_clear。
             adaptiveDialogAction(
               context: context,
               onPressed: () => Navigator.pop(context, ''),
-              child:
-                  Text(MaterialLocalizations.of(context).deleteButtonTooltip),
+              child: Text(t.dialog_clear),
             ),
             adaptiveDialogAction(
               context: context,
               onPressed: () => Navigator.pop(context),
-              child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
+              child: Text(t.dialog_cancel),
             ),
             adaptiveDialogAction(
               context: context,
               onPressed: () => Navigator.pop(context, _controller.text),
-              child: Text(MaterialLocalizations.of(context).okButtonLabel),
+              child: Text(t.dialog_ok),
             ),
           ],
         ),

--- a/hibiki/lib/src/pages/implementations/miscellaneous_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/miscellaneous_settings_page.dart
@@ -8,6 +8,7 @@ import 'package:hibiki/src/pages/base_page.dart';
 import 'package:hibiki/src/settings/settings_context.dart';
 import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/src/settings/settings_detail_page.dart';
+import 'package:hibiki/src/settings/settings_schema_widgets.dart';
 import 'package:hibiki/src/utils/misc/app_icon_preferences.dart';
 import 'package:hibiki/src/utils/misc/shortcut_icon_sync.dart';
 import 'package:hibiki/src/utils/misc/channel_constants.dart';
@@ -168,15 +169,17 @@ class _MiscellaneousSettingsBodyState
               spacing: tokens.spacing.gap,
               runSpacing: tokens.spacing.gap,
               children: [
+                // 统一走 slang t.*（MaterialLocalizations 跟系统 locale，与
+                // 应用内语言切换脱节）。
                 adaptiveDialogAction(
                   context: ctx,
                   onPressed: () => Navigator.pop(ctx, false),
-                  child: Text(MaterialLocalizations.of(ctx).cancelButtonLabel),
+                  child: Text(t.dialog_cancel),
                 ),
                 adaptiveDialogAction(
                   context: ctx,
                   onPressed: () => Navigator.pop(ctx, true),
-                  child: Text(MaterialLocalizations.of(ctx).okButtonLabel),
+                  child: Text(t.dialog_ok),
                 ),
               ],
             ),
@@ -228,34 +231,39 @@ class _MiscellaneousSettingsBodyState
 
   @override
   Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    // 静态提示不再伪装成设置行（行标题会被 titleMaxLines 截断、还带行高/分隔线
+    // 语义），改用与 schema section footer 同款的说明文字样式。
+    TextStyle? footerStyle(BuildContext context) =>
+        Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: HibikiDesignTokens.of(context).surfaces.onVariant,
+            );
+    if (!Platform.isAndroid && !Platform.isWindows) {
+      // 本平台不支持换图标：占位说明，不渲染空设置卡。
+      return HibikiPlaceholderMessage(
+        icon: Icons.widgets_outlined,
+        message: t.icon_shortcut_unsupported,
+      );
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        if (Platform.isAndroid || Platform.isWindows)
-          AdaptiveSettingsSection(
-            title: t.app_icon_label,
-            children: [
-              AdaptiveSettingsRow(
-                title: t.app_icon_label,
-                controlBelow: true,
-                trailing: _buildIconGrid(),
+        // section 标题用「预设」语义；页头已经是「应用图标」，行级不再第三次
+        // 重复同一文案（图标网格直接作为卡片内容，不套多余的行标题）。
+        AdaptiveSettingsSection(
+          title: t.app_icon_presets,
+          children: [
+            Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: tokens.spacing.rowHorizontal,
+                vertical: tokens.spacing.rowVertical,
               ),
-              if (_customSupported) ...[
-                AdaptiveSettingsRow(
-                  title: t.icon_custom_hint,
-                ),
-              ],
-            ],
-          )
-        else
-          AdaptiveSettingsSection(
-            title: t.app_icon_label,
-            children: [
-              AdaptiveSettingsRow(
-                title: t.icon_shortcut_unsupported,
-              ),
-            ],
-          ),
+              child: _buildIconGrid(),
+            ),
+          ],
+        ),
+        if (_customSupported)
+          SettingsSectionFooter(t.icon_custom_hint, style: footerStyle),
       ],
     );
   }

--- a/hibiki/lib/src/pages/implementations/shortcut_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/shortcut_settings_page.dart
@@ -273,6 +273,7 @@ class _ShortcutSettingsPageState extends BasePageState<ShortcutSettingsPage> {
   /// 动作行，其后是各 action 行。返回裸内容（无脚手架），由统一详情壳承载滚动与
   /// 内边距，使从统一设置详情面板点进来不再有风格跳变。
   Widget _buildScopeSections(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
@@ -282,7 +283,7 @@ class _ShortcutSettingsPageState extends BasePageState<ShortcutSettingsPage> {
         // it never interrupts a user who does not touch controller settings.
         if (_gameInputUnavailable) _buildGameInputHint(context),
         Padding(
-          padding: const EdgeInsets.only(bottom: 8),
+          padding: EdgeInsets.only(bottom: tokens.spacing.gap),
           child: Align(
             alignment: Alignment.centerLeft,
             // Wrap the list/keyboard segmented toggle in a
@@ -377,17 +378,19 @@ class _ShortcutSettingsPageState extends BasePageState<ShortcutSettingsPage> {
   /// Wrapped in HibikiAdjustableSegmented so it is a single directional focus
   /// stop reachable by pure-gamepad users (same pattern as the view toggle).
   Widget _buildGamepadBrandSelector() {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
+      padding: EdgeInsets.only(bottom: tokens.spacing.gap),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
           Padding(
-            padding: const EdgeInsets.only(bottom: 4),
+            padding: EdgeInsets.only(bottom: tokens.spacing.gap / 2),
             child: Text(
               t.shortcut_gamepad_brand_label,
-              style: Theme.of(context).textTheme.labelMedium,
+              // 小节标题统一走 sectionLabel token（不再裸用 labelMedium）。
+              style: tokens.type.sectionLabel,
             ),
           ),
           Align(
@@ -433,6 +436,7 @@ class _ShortcutSettingsPageState extends BasePageState<ShortcutSettingsPage> {
   /// remap row. On desktop the same scope is a real, editable Ctrl+Alt+D binding
   /// and renders like every other scope.
   Widget _buildScopeSection(ShortcutScope scope) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     final bool isMobilePlatform =
         defaultTargetPlatform == TargetPlatform.android ||
             defaultTargetPlatform == TargetPlatform.iOS;
@@ -460,9 +464,9 @@ class _ShortcutSettingsPageState extends BasePageState<ShortcutSettingsPage> {
         ),
         if (_visualMode)
           Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: 12,
-              vertical: 8,
+            padding: EdgeInsets.symmetric(
+              horizontal: tokens.spacing.rowHorizontal,
+              vertical: tokens.spacing.gap,
             ),
             // TODO-942 P1: keyboard / gamepad are two separately titled
             // blocks — the gamepad is a full real-layout figure, no longer
@@ -472,10 +476,11 @@ class _ShortcutSettingsPageState extends BasePageState<ShortcutSettingsPage> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 Padding(
-                  padding: const EdgeInsets.only(bottom: 4),
+                  padding: EdgeInsets.only(bottom: tokens.spacing.gap / 2),
                   child: Text(
                     t.shortcut_keyboard,
-                    style: Theme.of(context).textTheme.labelMedium,
+                    // 小节标题统一走 sectionLabel token（不再裸用 labelMedium）。
+                    style: tokens.type.sectionLabel,
                   ),
                 ),
                 KeyboardLayoutView(
@@ -485,12 +490,12 @@ class _ShortcutSettingsPageState extends BasePageState<ShortcutSettingsPage> {
                   onEmptyKeyTap: (LogicalKeyboardKey key) =>
                       _onEmptyKeyboardKeyTap(scope, key),
                 ),
-                const SizedBox(height: 12),
+                SizedBox(height: tokens.spacing.rowVertical),
                 Padding(
-                  padding: const EdgeInsets.only(bottom: 4),
+                  padding: EdgeInsets.only(bottom: tokens.spacing.gap / 2),
                   child: Text(
                     t.shortcut_gamepad,
-                    style: Theme.of(context).textTheme.labelMedium,
+                    style: tokens.type.sectionLabel,
                   ),
                 ),
                 GamepadLayoutView(
@@ -535,7 +540,9 @@ class _ShortcutSettingsPageState extends BasePageState<ShortcutSettingsPage> {
     // (TODO-317). The content is custom/stateful, so it rides the `body` escape
     // hatch instead of schema items.
     final SettingsDestination destination = SettingsDestination(
-      id: SettingsDestinationId.system,
+      // Synthetic own id（对照 appIcon/videoQuickSettings 先例）：不再借
+      // `system`——壳的身份不该冒充真正的系统分类。
+      id: SettingsDestinationId.shortcuts,
       title: t.shortcut_settings_title,
       icon: Icons.keyboard_outlined,
       sections: const <SettingsSection>[],

--- a/hibiki/lib/src/settings/settings_actions.dart
+++ b/hibiki/lib/src/settings/settings_actions.dart
@@ -5,7 +5,7 @@ import 'package:hibiki/models.dart';
 import 'package:hibiki/pages.dart';
 import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki/src/models/theme_notifier.dart'
-    show ThemeNotifier, CustomThemeEntry, kCustomThemeDefaultSeed;
+    show CustomThemeEntry, kCustomThemeDefaultSeed;
 import 'package:hibiki/src/profile/profile_view_model.dart';
 import 'package:hibiki/src/settings/settings_context.dart';
 import 'package:hibiki/utils.dart';
@@ -489,67 +489,11 @@ Widget buildBrightnessSelector(SettingsContext settingsContext) {
   );
 }
 
-/// 「界面大小」设置项。
-///
-/// TODO-374: 删除「自动/自定义」模式切换。界面大小不再有模式概念——首次启动时
-/// [ThemeNotifier.resolveAppUiScaleForViewport] 已按屏幕算出合适值落盘成具体百分比，
-/// 之后用户始终面对一个可拖的具体数值。因此这里恒渲染可拖滑条（[_AppUiScaleSliderRow]），
-/// 不再有内联分段切换、不再有「自动模式只读展示」分支。
-Widget buildAppUiScaleSelector(SettingsContext settingsContext) {
-  return _AppUiScaleSliderRow(appModel: settingsContext.appModel);
-}
-
-/// 「界面大小」滑条行。
-///
-/// 该滑条位于受 [HibikiAppUiScale] 的 [Transform.scale] 缩放的子树内（`main.dart`
-/// 用 `appModel.appUiScale` 驱动整树缩放）。若拖动每帧都提交真实缩放，整棵树会立刻
-/// 按新比例重排，滑块在手指下被缩放位移，拖动手势随即丢失目标——表现为「改一下就
-/// 断、无法连续拖」。
-///
-/// 因此把拖动中的临时值 [_dragValue] 放在与拖动 UI 同生命周期的本 [State] 里：拖动
-/// 中只更新本地值跟手、不碰全局缩放；松手 `onChangeEnd` 才一次性提交。面板销毁时本
-/// State 一并消失，未提交的临时值不会泄漏到全局单例，所有布局下都不会有显示残留。
-class _AppUiScaleSliderRow extends StatefulWidget {
-  const _AppUiScaleSliderRow({required this.appModel});
-
-  final AppModel appModel;
-
-  @override
-  State<_AppUiScaleSliderRow> createState() => _AppUiScaleSliderRowState();
-}
-
-class _AppUiScaleSliderRowState extends State<_AppUiScaleSliderRow> {
-  /// 拖动进行中的临时值；非拖动时为 null，显示已提交的 [AppModel.appUiScale]。
-  double? _dragValue;
-
-  @override
-  Widget build(BuildContext context) {
-    final AppModel appModel = widget.appModel;
-    final double value = (_dragValue ?? appModel.appUiScale)
-        .clamp(
-          HibikiAppUiScale.minScale,
-          HibikiAppUiScale.maxScale,
-        )
-        .toDouble();
-    return AdaptiveSettingsSliderRow(
-      title: t.app_ui_scale,
-      subtitle: t.app_ui_scale_hint,
-      icon: Icons.format_size_outlined,
-      min: HibikiAppUiScale.minScale,
-      max: HibikiAppUiScale.maxScale,
-      divisions: 27,
-      value: value,
-      label: '${(value * 100).round()}%',
-      // 拖动中只更新本地值跟手，不触发全局 Transform 重排（滑条稳定可连续拖）。
-      onChanged: (double next) => setState(() => _dragValue = next),
-      // 松手一次性提交真实缩放并清空本地拖动值，全局界面随之缩放。
-      onChangeEnd: (double next) async {
-        await appModel.setAppUiScale(next);
-        if (mounted) setState(() => _dragValue = null);
-      },
-    );
-  }
-}
+// TODO-374 的「界面大小」自定义滑条行（buildAppUiScaleSelector /
+// _AppUiScaleSliderRow）已删除：拖动解耦语义由通用的
+// SettingsSliderItem(commitOnRelease: true) 承担（settings_schema_appearance
+// 的 'appearance.app_ui_scale'），消掉 commit-on-release 双实现，并顺带获得
+// 常驻标题读数与搜索索引。
 
 // HBK-AUDIT-129: removed dead `customFontsTitle`. It computed a count-aware
 // title ('${t.custom_fonts} (N)') but had zero callers — the custom-fonts row

--- a/hibiki/lib/src/settings/settings_destination.dart
+++ b/hibiki/lib/src/settings/settings_destination.dart
@@ -30,6 +30,10 @@ enum SettingsDestinationId {
   // it never collides with the real video destination（与 readerQuickSettings
   // 同款约定）。
   videoQuickSettings,
+  // Synthetic destination for the pushed shortcut-settings page
+  // (ShortcutSettingsPage)；own id so the shell no longer borrows `system` for
+  // content that isn't the system destination（与 appIcon 同款约定）。
+  shortcuts,
 }
 
 /// 书内快捷面板的分组维度，与全局 [SettingsDestinationId] 正交。
@@ -99,6 +103,7 @@ class SettingsDestination {
     this.summary,
     this.visible,
     this.body,
+    this.bodySearchEntries = const <SettingsBodySearchEntry>[],
   });
 
   final SettingsDestinationId id;
@@ -115,6 +120,11 @@ class SettingsDestination {
   /// **不得**自带脚手架/独立滚动（外层渲染器已提供滚动与内边距）。
   final SettingsItemBuilder? body;
 
+  /// [body] 逃生口里设置行的搜索元数据。设置搜索索引器只遍历 [sections]，
+  /// body 自绘正文里的行对它不可见；在此登记行标题让它们进入搜索。命中后跳转
+  /// 到本分类正文即可——body 行不是 schema item，没有滚动定位挂点。
+  final List<SettingsBodySearchEntry> bodySearchEntries;
+
   bool isVisible(SettingsContext context) => visible?.call(context) ?? true;
 
   List<SettingsSection> visibleSections(SettingsContext context) {
@@ -124,6 +134,28 @@ class SettingsDestination {
         .where((SettingsSection section) => section.items.isNotEmpty)
         .toList(growable: false);
   }
+}
+
+/// [SettingsDestination.bodySearchEntries] 的一条：body 逃生口正文里某个设置行
+/// 的搜索元数据（标题用与正文行一致的 i18n 文案；[subtitle] 参与元数据打分）。
+/// [visible] 为 null 表示恒可搜；否则与渲染同款谓词求值，平台/状态下不显示的
+/// 行不会进搜索索引。
+class SettingsBodySearchEntry {
+  const SettingsBodySearchEntry({
+    required this.id,
+    required this.title,
+    this.subtitle,
+    this.visible,
+  });
+
+  /// 全局唯一 id（约定带所属 destination 前缀，如 `card_creation.anki.deck`）。
+  /// 只用于搜索条目身份，不对应任何 schema item。
+  final String id;
+  final String title;
+  final String? subtitle;
+  final SettingsVisibility? visible;
+
+  bool isVisible(SettingsContext context) => visible?.call(context) ?? true;
 }
 
 /// 测试钩子：为 true 时，渲染器忽略每个 section 的 [SettingsSection.collapsedByDefault]，

--- a/hibiki/lib/src/settings/settings_home_page.dart
+++ b/hibiki/lib/src/settings/settings_home_page.dart
@@ -29,10 +29,11 @@ class SettingsHomePage extends BasePage {
 
 class _SettingsHomePageState extends BasePageState<SettingsHomePage>
     with SettingsContextHost<SettingsHomePage> {
-  // 默认选中 schema 首个分类（外观），与宽屏导航列表的视觉首项一致；
-  // 若首项被平台门控隐藏，build 里的兜底会自动落到第一个可见分类。
-  SettingsDestinationId _selectedDestinationId =
-      SettingsDestinationId.appearance;
+  // 默认选中 schema 首个可见分类（当前重排后是「阅读」），与宽屏导航列表的
+  // 视觉首项一致：不再硬编码某个 id——分类顺序的唯一真相源是 buildSettingsSchema
+  // （有顺序守卫），这里在 build 里首次解析时取 destinations.first.id，顺序调整
+  // 时默认项自动跟随，不会再脱节。
+  SettingsDestinationId? _selectedDestinationId;
 
   // 设置搜索：跨全部分类按标题/副标题/分区/分类名过滤配置项，点结果跳转到
   // 对应分类并滚动定位（SettingsSearchReveal）。
@@ -68,12 +69,14 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
         .where((SettingsDestination destination) =>
             destination.isVisible(settingsContext))
         .toList(growable: false);
+    // 首次进入（null）或当前选中分类被平台门控隐藏时，落到第一个可见分类。
     if (!destinations.any(
       (SettingsDestination destination) =>
           destination.id == _selectedDestinationId,
     )) {
       _selectedDestinationId = destinations.first.id;
     }
+    final SettingsDestinationId selectedDestinationId = _selectedDestinationId!;
     final SettingsRenderer renderer = isCupertinoPlatform(context)
         ? const CupertinoSettingsRenderer()
         : const MaterialSettingsRenderer();
@@ -87,6 +90,7 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
             settingsContext: settingsContext,
             renderer: renderer,
             destinations: destinations,
+            selectedDestinationId: selectedDestinationId,
           );
         }
         // 窄屏单列：居中限宽（单列阅读更舒适）。搜索时结果列表整体替换分类列表。
@@ -101,7 +105,7 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
                     ? renderer.buildHomePage(
                         settingsContext: settingsContext,
                         destinations: destinations,
-                        selectedDestinationId: _selectedDestinationId,
+                        selectedDestinationId: selectedDestinationId,
                         onDestinationSelected: _selectDestination,
                         embedded: widget.embedded,
                       )
@@ -208,8 +212,11 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
 
   /// 点搜索结果：登记滚动定位挂点、清空搜索，宽屏切主从选中分类，窄屏 push
   /// 详情页；目标行由 SettingsSchemaItem 消费挂点后滚入视口并闪烁高亮。
+  /// body 合成条目（bodySearchEntries）不登记挂点——body 行不是 schema item，
+  /// 挂点永远不会被消费，跳转到分类正文即为完整语义。
   void _openSearchResult(SettingsSearchEntry entry, {required bool wide}) {
-    SettingsSearchReveal.pendingItemId = entry.item.id;
+    SettingsSearchReveal.pendingItemId =
+        entry.isBodyEntry ? null : entry.item.id;
     _searchController.clear();
     setState(() {
       _searchQuery = '';
@@ -260,10 +267,11 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
     required SettingsContext settingsContext,
     required SettingsRenderer renderer,
     required List<SettingsDestination> destinations,
+    required SettingsDestinationId selectedDestinationId,
   }) {
     final SettingsDestination selected = destinations.firstWhere(
       (SettingsDestination destination) =>
-          destination.id == _selectedDestinationId,
+          destination.id == selectedDestinationId,
     );
     final bool cupertino = isCupertinoPlatform(context);
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
@@ -295,7 +303,7 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
                           child: renderer.buildDestinationList(
                             settingsContext: settingsContext,
                             destinations: destinations,
-                            selectedDestinationId: _selectedDestinationId,
+                            selectedDestinationId: selectedDestinationId,
                             onDestinationSelected: _selectDestination,
                             pushRoutes: false,
                           ),
@@ -303,7 +311,7 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
                       : renderer.buildDestinationList(
                           settingsContext: settingsContext,
                           destinations: destinations,
-                          selectedDestinationId: _selectedDestinationId,
+                          selectedDestinationId: selectedDestinationId,
                           onDestinationSelected: _selectDestination,
                           pushRoutes:
                               false, // master-detail keeps selection in-pane.
@@ -321,11 +329,26 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
       // 切换目标时整棵子树作废重建，避免 Flutter 复用上一目标同位置的 Switch
       // Element 触发 didUpdateWidget(value 变化)→ 圆点滑动（以及分段滑动、滚动
       // 位置串页等同类复用副作用）。
+      // 详情正文限宽：与窄屏 DesktopContentLayout 的 settings 档共用同一上限
+      // （desktopContentMaxWidth，当前 960），超宽窗口不再把设置行拉成整屏长条；
+      // 左对齐贴导航 pane（不居中，避免详情和导航之间出现空腹）。
       primary: KeyedSubtree(
         key: ValueKey<SettingsDestinationId>(selected.id),
-        child: renderer.buildDetailContent(
-          settingsContext: settingsContext,
-          destination: selected,
+        child: Align(
+          alignment: AlignmentDirectional.topStart,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: desktopContentMaxWidth(
+                    WindowSizeClass.expanded,
+                    DesktopContentKind.settings,
+                  ) ??
+                  double.infinity,
+            ),
+            child: renderer.buildDetailContent(
+              settingsContext: settingsContext,
+              destination: selected,
+            ),
+          ),
         ),
       ),
     );

--- a/hibiki/lib/src/settings/settings_schema_appearance.dart
+++ b/hibiki/lib/src/settings/settings_schema_appearance.dart
@@ -51,14 +51,29 @@ SettingsDestination buildAppearanceDestination() {
               settingsContext.refresh();
             },
           ),
-          // 「界面大小」滑条用自定义有状态行：拖动中只更新局部值跟手，松手才提交
-          // 真实缩放（见 buildAppUiScaleSelector）。这样拖动期间不触发全局
-          // HibikiAppUiScale 的 Transform 重排，滑条不会在手指下被缩放位移、可连续拖。
-          SettingsCustomItem(
+          // 「界面大小」滑条：commitOnRelease——本滑条位于受 HibikiAppUiScale 的
+          // Transform.scale 缩放的子树内，拖动逐帧提交会让整树立刻按新比例重排、
+          // 滑块在手指下位移、手势断裂（TODO-374 旧 _AppUiScaleSliderRow 注释）。
+          // 渲染层 _CommitOnReleaseSlider 拖动只更新本地预览值（跟手 + 标题读数
+          // 实时），松手才经 onChanged 一次性提交真实缩放；键盘/手柄步进每按即提交。
+          // 一等 schema 项同时带来静止常驻读数（titleReadout）与搜索索引，替代原
+          // 自定义 custom 行双实现。id/持久化路径不变。
+          SettingsSliderItem(
             id: 'appearance.app_ui_scale',
+            title: t.app_ui_scale,
+            subtitle: t.app_ui_scale_hint,
             icon: Icons.format_size_outlined,
-            searchTitle: t.app_ui_scale,
-            builder: buildAppUiScaleSelector,
+            min: HibikiAppUiScale.minScale,
+            max: HibikiAppUiScale.maxScale,
+            divisions: 27,
+            label: (double value) => '${(value * 100).round()}%',
+            titleReadout: true,
+            commitOnRelease: true,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.appUiScale,
+            onChanged: (SettingsContext settingsContext, double value) async {
+              await settingsContext.appModel.setAppUiScale(value);
+            },
           ),
           // 「界面语言」从系统分类归位到这里：它改的是界面呈现语言，与主题/明暗/
           // 缩放同属界面外观；id/持久化 key 不变（本就带 appearance 前缀）。

--- a/hibiki/lib/src/settings/settings_schema_card_creation.dart
+++ b/hibiki/lib/src/settings/settings_schema_card_creation.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:hibiki/pages.dart';
+import 'package:hibiki/src/settings/settings_context.dart';
 import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/utils.dart';
 
@@ -14,5 +17,107 @@ SettingsDestination buildCardCreationDestination() {
     // 就看到全部 Anki 配置，不再多跳一层。
     sections: const <SettingsSection>[],
     body: (_) => const AnkiSettingsBody(),
+    // body 正文不走 sections，设置搜索索引器看不见其中的行；在此登记
+    // AnkiSettingsBody 的主要设置行（标题与正文行同一 i18n 文案），让「牌组 /
+    // 字段映射 / 音频质量」等能被搜到并跳转到本分类。快捷键页 / 应用图标页已有
+    // 可搜的导航行入口，不在此重复。
+    bodySearchEntries: <SettingsBodySearchEntry>[
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.profile',
+        title: t.profile_label,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.fetch',
+        title: t.anki_fetch,
+        subtitle: t.anki_refresh_hint,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.create_lapis',
+        title: t.anki_create_lapis,
+        subtitle: t.anki_create_lapis_hint,
+      ),
+      // AnkiConnect 连接参数只在非 Android 平台渲染（Android 走 AnkiDroid），
+      // 搜索可见性与渲染同门控。
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.connect_host',
+        title: t.anki_connect_host,
+        subtitle: 'AnkiConnect',
+        visible: (SettingsContext c) => !Platform.isAndroid,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.connect_port',
+        title: t.anki_connect_port,
+        subtitle: 'AnkiConnect',
+        visible: (SettingsContext c) => !Platform.isAndroid,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.connect_api_key',
+        title: t.anki_connect_api_key,
+        subtitle: 'AnkiConnect',
+        visible: (SettingsContext c) => !Platform.isAndroid,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.deck',
+        title: t.anki_deck,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.note_type',
+        title: t.anki_note_type,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.field_mappings',
+        title: t.anki_field_mappings,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.allow_duplicates',
+        title: t.anki_allow_duplicates,
+        subtitle: t.anki_allow_duplicates_hint,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.overwrite_scope',
+        title: t.anki_overwrite_scope,
+        subtitle: t.anki_overwrite_scope_hint,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.compact_glossaries',
+        title: t.anki_compact_glossaries,
+        subtitle: t.anki_compact_glossaries_hint,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.tags',
+        title: t.anki_tags,
+        subtitle: t.anki_tag_default_section,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.tag_include_hibiki',
+        title: t.anki_tag_include_hibiki,
+        subtitle: t.anki_tag_default_section,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.tag_include_category',
+        title: t.anki_tag_include_category,
+        subtitle: t.anki_tag_default_section,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.tag_book_name',
+        title: t.auto_add_book_name_to_tags,
+        subtitle: t.anki_tag_default_section,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.mining_image_quality',
+        title: t.mining_image_quality,
+        subtitle: t.mining_image_quality_hint,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.mining_audio_quality',
+        title: t.mining_audio_quality,
+        subtitle: t.mining_audio_quality_hint,
+      ),
+      SettingsBodySearchEntry(
+        id: 'card_creation.anki.video_mining_image_mode',
+        title: t.video_mining_image_mode,
+        subtitle: t.video_mining_image_mode_hint,
+      ),
+    ],
   );
 }

--- a/hibiki/lib/src/settings/settings_schema_lookup.dart
+++ b/hibiki/lib/src/settings/settings_schema_lookup.dart
@@ -338,6 +338,7 @@ SettingsDestination buildLookupDestination() {
         items: <SettingsItem>[
           SettingsSliderItem(
             id: 'lookup.popup_max_width',
+            titleReadout: true,
             // TODO-1352: 放宽查词弹窗最大宽度的强制上限（1000→2000），让宽屏 / 4K 下
             // 弹窗能拉到接近占满（实际宽度仍由 resolvePopupRect 按当前屏宽 clamp，
             // 绝不会超出屏幕）。divisions 保持 10px 步进（1750/175）。
@@ -356,6 +357,7 @@ SettingsDestination buildLookupDestination() {
           ),
           SettingsSliderItem(
             id: 'lookup.popup_max_height',
+            titleReadout: true,
             // TODO-1352 后续：放宽最大高度上限（800→1600），配合高分屏 / 精细调整；
             // 实际高度仍由 resolvePopupRect 按当前屏高 clamp，绝不会超出屏幕。
             // 步进保持 10px（1400/140）。
@@ -389,6 +391,7 @@ SettingsDestination buildLookupDestination() {
           ),
           SettingsSliderItem(
             id: 'lookup.overlay_lookup_max_width',
+            titleReadout: true,
             title: t.overlay_lookup_max_width,
             icon: Icons.open_in_full_outlined,
             min: 250,
@@ -406,6 +409,7 @@ SettingsDestination buildLookupDestination() {
           ),
           SettingsSliderItem(
             id: 'lookup.overlay_lookup_max_height',
+            titleReadout: true,
             title: t.overlay_lookup_max_height,
             icon: Icons.height_outlined,
             min: 200,
@@ -438,6 +442,7 @@ SettingsDestination buildLookupDestination() {
           ),
           SettingsSliderItem(
             id: 'lookup.extension_popup_max_width',
+            titleReadout: true,
             title: t.extension_popup_max_width,
             icon: Icons.open_in_full_outlined,
             min: 250,
@@ -455,6 +460,7 @@ SettingsDestination buildLookupDestination() {
           ),
           SettingsSliderItem(
             id: 'lookup.extension_popup_max_height',
+            titleReadout: true,
             title: t.extension_popup_max_height,
             icon: Icons.height_outlined,
             min: 200,

--- a/hibiki/lib/src/settings/settings_schema_reading.dart
+++ b/hibiki/lib/src/settings/settings_schema_reading.dart
@@ -133,15 +133,18 @@ SettingsDestination buildReadingDestination() {
               group: ReaderGroup.layout,
               order: 6,
             ),
+            // label 用本地化全称（从右到左/从左到右），不再用只有排版从业者
+            // 认识的 RTL/LTR 缩写；分段条过宽时 _SegmentedStripHost 自带横向
+            // 滚动兜底。
             options: <SettingsSegmentOption<String>>[
               SettingsSegmentOption<String>(
                 value: 'rtl',
-                label: 'RTL',
+                label: t.spread_direction_rtl,
                 tooltip: t.spread_direction_rtl,
               ),
               SettingsSegmentOption<String>(
                 value: 'ltr',
-                label: 'LTR',
+                label: t.spread_direction_ltr,
                 tooltip: t.spread_direction_ltr,
               ),
             ],
@@ -505,6 +508,7 @@ SettingsDestination buildReadingDestination() {
           // 纯时长不改预留高 → 走 settings 刷新即可，无需重锚。
           SettingsSliderItem(
             id: 'reading_controls.auto_hide_chrome_duration',
+            titleReadout: true,
             title: t.reader_auto_hide_chrome_duration,
             icon: Icons.timer_outlined,
             min: 1,
@@ -617,6 +621,7 @@ SettingsDestination buildReadingDestination() {
           ),
           SettingsSliderItem(
             id: 'reading_controls.wheel_page_turn_interval',
+            titleReadout: true,
             title: t.wheel_page_turn_interval,
             icon: Icons.mouse_outlined,
             min: 150,

--- a/hibiki/lib/src/settings/settings_schema_widgets.dart
+++ b/hibiki/lib/src/settings/settings_schema_widgets.dart
@@ -163,7 +163,8 @@ class SettingsSchemaItem extends StatelessWidget {
     return AdaptiveSettingsSwitchRow(
       title: toggle.title,
       subtitle: toggle.subtitle,
-      icon: showIcons ? toggle.icon : null,
+      icon: toggle.icon,
+      showIcon: showIcons,
       value: value,
       onChanged: (bool next) async {
         await toggle.onChanged(settingsContext, next);
@@ -179,7 +180,8 @@ class SettingsSchemaItem extends StatelessWidget {
       return AdaptiveSettingsPickerRow<T>(
         title: segmented.title,
         subtitle: segmented.subtitle,
-        icon: showIcons ? segmented.icon : null,
+        icon: segmented.icon,
+        showIcon: showIcons,
         controlBelow: segmented.controlBelow,
         selected: segmented.selected(settingsContext),
         options: <AdaptiveSettingsPickerOption<T>>[
@@ -198,7 +200,8 @@ class SettingsSchemaItem extends StatelessWidget {
     return AdaptiveSettingsSegmentedRow<T>(
       title: segmented.title,
       subtitle: segmented.subtitle,
-      icon: showIcons ? segmented.icon : null,
+      icon: segmented.icon,
+      showIcon: showIcons,
       segments: segmented.options.map(_segment).toList(growable: false),
       selected: segmented.selected(settingsContext),
       controlBelow: segmented.controlBelow,
@@ -224,7 +227,8 @@ class SettingsSchemaItem extends StatelessWidget {
     return AdaptiveSettingsSliderRow(
       title: slider.title,
       subtitle: slider.subtitle,
-      icon: showIcons ? slider.icon : null,
+      icon: slider.icon,
+      showIcon: showIcons,
       value: value.clamp(slider.min, slider.max).toDouble(),
       min: slider.min,
       max: slider.max,
@@ -250,7 +254,8 @@ class SettingsSchemaItem extends StatelessWidget {
     return AdaptiveSettingsStepperRow(
       title: stepper.title,
       subtitle: stepper.subtitle,
-      icon: showIcons ? stepper.icon : null,
+      icon: stepper.icon,
+      showIcon: showIcons,
       value: value,
       step: stepper.step,
       min: stepper.min,
@@ -271,7 +276,7 @@ class SettingsSchemaItem extends StatelessWidget {
     return SettingsSecretField(
       title: text.title,
       subtitle: text.subtitle,
-      icon: showIcons ? text.icon : null,
+      icon: text.icon,
       showIcon: showIcons,
       initialValue: text.value(settingsContext),
       obscureText: text.secret,
@@ -306,7 +311,7 @@ class SettingsSchemaItem extends StatelessWidget {
     return SettingsNumberField(
       title: number.title,
       subtitle: number.subtitle,
-      icon: showIcons ? number.icon : null,
+      icon: number.icon,
       showIcon: showIcons,
       suffixText: number.suffixText,
       initialValue: format(number.value(settingsContext)),
@@ -380,7 +385,8 @@ class _CommitOnReleaseSliderState extends State<_CommitOnReleaseSlider> {
     return AdaptiveSettingsSliderRow(
       title: item.title,
       subtitle: item.subtitle,
-      icon: widget.showIcons ? item.icon : null,
+      icon: item.icon,
+      showIcon: widget.showIcons,
       value: value,
       min: item.min,
       max: item.max,

--- a/hibiki/lib/src/settings/settings_search.dart
+++ b/hibiki/lib/src/settings/settings_search.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hibiki/src/focus/hibiki_focus_scroll.dart';
+import 'package:hibiki/src/utils/adaptive/adaptive_platform.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
 import 'package:hibiki/src/settings/settings_context.dart';
 import 'package:hibiki/src/settings/settings_destination.dart';
@@ -21,11 +22,17 @@ class SettingsSearchEntry {
     required this.destination,
     required this.item,
     this.sectionTitle,
+    this.isBodyEntry = false,
   });
 
   final SettingsDestination destination;
   final String? sectionTitle;
   final SettingsItem item;
+
+  /// true = 由 [SettingsDestination.bodySearchEntries] 合成（body 逃生口正文
+  /// 里的行）。命中后只跳转分类，不登记滚动定位挂点——body 行不是 schema item，
+  /// 挂点永远不会被消费。
+  final bool isBodyEntry;
 
   /// 打分与结果展示用的标题（custom 项取 searchTitle，见
   /// [settingsItemSearchTitle]）。
@@ -69,6 +76,23 @@ List<SettingsSearchEntry> flattenVisibleSettings(
           item: item,
         ));
       }
+    }
+    // body 逃生口正文（如「制卡」的 AnkiSettingsBody）不走 sections，索引器
+    // 看不见其中的行；把 destination 声明的 bodySearchEntries 合成为普通搜索
+    // 条目（复用 custom 项的 searchTitle 通道），命中后跳转到该分类正文。
+    for (final SettingsBodySearchEntry bodyEntry
+        in destination.bodySearchEntries) {
+      if (!bodyEntry.isVisible(context)) continue;
+      entries.add(SettingsSearchEntry(
+        destination: destination,
+        item: SettingsCustomItem(
+          id: bodyEntry.id,
+          searchTitle: bodyEntry.title,
+          subtitle: bodyEntry.subtitle,
+          builder: (_) => const SizedBox.shrink(),
+        ),
+        isBodyEntry: true,
+      ));
     }
   }
   return entries;
@@ -145,9 +169,10 @@ class _SettingsRevealTargetState extends State<SettingsRevealTarget> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      // eink 下滚动动画归零（连续重绘=残影），直接跳到目标位置。
       HibikiFocusScroll.ensureVisible(
         context,
-        duration: const Duration(milliseconds: 250),
+        duration: einkSafeDuration(context, const Duration(milliseconds: 250)),
       );
     });
   }
@@ -158,9 +183,11 @@ class _SettingsRevealTargetState extends State<SettingsRevealTarget> {
     // MD3 守卫：圆角一律走 design tokens，不自持字面量。
     final BorderRadius radius =
         HibikiDesignTokens.of(context).radii.controlRadius;
+    // eink 下闪烁衰减动画归零：TweenAnimationBuilder duration zero 直接落在
+    // end（透明），不闪不残影；定位仍由上面的滚动完成。
     return TweenAnimationBuilder<double>(
       tween: Tween<double>(begin: 1, end: 0),
-      duration: const Duration(milliseconds: 1400),
+      duration: einkSafeDuration(context, const Duration(milliseconds: 1400)),
       curve: Curves.easeOut,
       child: widget.child,
       builder: (BuildContext context, double value, Widget? child) {

--- a/hibiki/lib/src/utils/components/settings_shared.dart
+++ b/hibiki/lib/src/utils/components/settings_shared.dart
@@ -318,7 +318,9 @@ class _AdaptiveSettingsSectionState extends State<AdaptiveSettingsSection> {
         onTitleTap: () => setState(() => _expanded = !_expanded),
         titleTrailing: AnimatedRotation(
           turns: _expanded ? 0.5 : 0.0,
-          duration: const Duration(milliseconds: 180),
+          // eink 下动画归零（连续重绘=残影），箭头直接跳到目标朝向。
+          duration:
+              einkSafeDuration(context, const Duration(milliseconds: 180)),
           child: Icon(
             cupertino ? CupertinoIcons.chevron_down : Icons.expand_more,
             size: cupertino ? 16 : 22,
@@ -328,10 +330,11 @@ class _AdaptiveSettingsSectionState extends State<AdaptiveSettingsSection> {
           ),
         ),
         // 收起时行不入树（不可聚焦、不参与焦点驱动），只保留标题头；用 AnimatedSize
-        // 平滑高度过渡，ClipRect 防过渡帧溢出。
+        // 平滑高度过渡，ClipRect 防过渡帧溢出。eink 下高度过渡同样归零。
         child: ClipRect(
           child: AnimatedSize(
-            duration: const Duration(milliseconds: 180),
+            duration:
+                einkSafeDuration(context, const Duration(milliseconds: 180)),
             curve: Curves.easeInOut,
             alignment: Alignment.topCenter,
             child:
@@ -468,12 +471,16 @@ class AdaptiveSettingsRow extends StatelessWidget {
     // impossible width.
     final double textScale = MediaQuery.textScalerOf(context).scale(1);
     final double stackThreshold = (220.0 * textScale).clamp(220.0, 420.0);
+    // 左栏图标占固定宽（badge ~30 + 间距 gap+4 = 12）：堆叠判断必须把它计入
+    // 需求，否则窄 pane（如视频快捷设置侧栏）里带图标的行仍按无图标阈值走
+    // 行内布局，label+trailing 少了一个图标位而右溢出。
+    final double iconExtra = (showIcon && icon != null) ? 42.0 : 0.0;
     final Widget content = LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final bool stackControls = controlBelow ||
             (trailing != null &&
                 !trailingFlexible &&
-                constraints.maxWidth < stackThreshold);
+                constraints.maxWidth < stackThreshold + iconExtra);
         return Padding(
           padding: EdgeInsets.symmetric(
             horizontal: cupertino ? 16 : tokens.spacing.rowHorizontal,
@@ -655,11 +662,17 @@ class AdaptiveSettingsSwitchRow extends StatelessWidget {
     super.key,
     this.subtitle,
     this.icon,
+    this.showIcon = false,
   });
 
   final String title;
   final String? subtitle;
   final IconData? icon;
+
+  /// 与 [AdaptiveSettingsNavigationRow.showIcon] 同款开关：true 且 [icon] 非空
+  /// 才渲染左栏图标徽章。schema 层的 `showIcons` 经此透传（此前只转发 icon 不
+  /// 转发 showIcon，值控件行声明的图标从不渲染，同卡片左栏对不齐）。
+  final bool showIcon;
   final bool value;
   final ValueChanged<bool>? onChanged;
 
@@ -669,6 +682,7 @@ class AdaptiveSettingsSwitchRow extends StatelessWidget {
       title: title,
       subtitle: subtitle,
       icon: icon,
+      showIcon: showIcon,
       trailing: adaptiveSwitch(
         context: context,
         value: value,
@@ -687,6 +701,7 @@ class AdaptiveSettingsSwitchActionRow extends StatelessWidget {
     super.key,
     this.subtitle,
     this.icon,
+    this.showIcon = false,
     this.body,
     this.actions = const <Widget>[],
     this.panel,
@@ -696,6 +711,9 @@ class AdaptiveSettingsSwitchActionRow extends StatelessWidget {
   final String title;
   final String? subtitle;
   final IconData? icon;
+
+  /// 见 [AdaptiveSettingsSwitchRow.showIcon]。
+  final bool showIcon;
   final bool value;
   final ValueChanged<bool>? onChanged;
   final Widget? body;
@@ -719,6 +737,7 @@ class AdaptiveSettingsSwitchActionRow extends StatelessWidget {
       title: title,
       subtitle: subtitle,
       icon: icon,
+      showIcon: showIcon,
       controlBelow: stacked,
       trailing: stacked
           ? _buildStackedTrailing(switchControl)
@@ -826,12 +845,16 @@ class AdaptiveSettingsSegmentedRow<T extends Object> extends StatelessWidget {
     super.key,
     this.subtitle,
     this.icon,
+    this.showIcon = false,
     this.controlBelow = true,
   });
 
   final String title;
   final String? subtitle;
   final IconData? icon;
+
+  /// 见 [AdaptiveSettingsSwitchRow.showIcon]。
+  final bool showIcon;
   final List<ButtonSegment<T>> segments;
   final T selected;
   final ValueChanged<T> onChanged;
@@ -888,6 +911,7 @@ class AdaptiveSettingsSegmentedRow<T extends Object> extends StatelessWidget {
       title: title,
       subtitle: subtitle,
       icon: icon,
+      showIcon: showIcon,
       controlBelow: controlBelow,
       // The segmented strip is intrinsically wide and wrapped in a horizontal
       // scroll view; host it as a flexible (bounded-width) trailing so it
@@ -1044,6 +1068,7 @@ class AdaptiveSettingsPickerRow<T> extends StatelessWidget {
     super.key,
     this.subtitle,
     this.icon,
+    this.showIcon = false,
     this.placeholder,
     this.materialWidth,
     this.controlBelow = false,
@@ -1052,6 +1077,10 @@ class AdaptiveSettingsPickerRow<T> extends StatelessWidget {
   final String title;
   final String? subtitle;
   final IconData? icon;
+
+  /// 见 [AdaptiveSettingsSwitchRow.showIcon]。仅作用于行内 picker 分支；超过
+  /// [kSettingsPickerInlineLimit] 的整页选择器分支沿用「有 icon 即显示」旧契约。
+  final bool showIcon;
   final List<AdaptiveSettingsPickerOption<T>> options;
   final T selected;
   final ValueChanged<T> onChanged;
@@ -1069,6 +1098,7 @@ class AdaptiveSettingsPickerRow<T> extends StatelessWidget {
       title: title,
       subtitle: subtitle,
       icon: icon,
+      showIcon: showIcon,
       controlBelow: cupertino ? false : controlBelow,
       trailingFlexible: !cupertino && !controlBelow,
       trailing: cupertino
@@ -1200,9 +1230,11 @@ class AdaptiveSettingsPickerRow<T> extends StatelessWidget {
                 child: Text(option.label),
               ),
           ],
+          // app 内文案统一走 slang t.*：MaterialLocalizations 跟系统 locale，
+          // 与应用内语言切换脱节（用户把界面切中文后按钮仍是英文）。
           cancelButton: CupertinoActionSheetAction(
             onPressed: () => Navigator.pop(sheetContext),
-            child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
+            child: Text(t.cancel),
           ),
         );
       },
@@ -1304,11 +1336,15 @@ class AdaptiveSettingsStepperRow extends StatelessWidget {
     super.key,
     this.subtitle,
     this.icon,
+    this.showIcon = false,
   });
 
   final String title;
   final String? subtitle;
   final IconData? icon;
+
+  /// 见 [AdaptiveSettingsSwitchRow.showIcon]。
+  final bool showIcon;
   final double value;
   final double step;
   final double min;
@@ -1322,6 +1358,7 @@ class AdaptiveSettingsStepperRow extends StatelessWidget {
       title: title,
       subtitle: subtitle,
       icon: icon,
+      showIcon: showIcon,
       trailing: _KeyboardStepper(
         value: value,
         step: step,
@@ -1635,6 +1672,7 @@ class AdaptiveSettingsSliderRow extends StatelessWidget {
     super.key,
     this.subtitle,
     this.icon,
+    this.showIcon = false,
     this.min = 0,
     this.max = 1,
     this.divisions,
@@ -1647,6 +1685,9 @@ class AdaptiveSettingsSliderRow extends StatelessWidget {
   final String title;
   final String? subtitle;
   final IconData? icon;
+
+  /// 见 [AdaptiveSettingsSwitchRow.showIcon]。
+  final bool showIcon;
   final double value;
   final double min;
   final double max;
@@ -1672,6 +1713,7 @@ class AdaptiveSettingsSliderRow extends StatelessWidget {
       title: readout == null ? title : '$title ($readout)',
       subtitle: subtitle,
       icon: icon,
+      showIcon: showIcon,
       controlBelow: true,
       trailing: _KeyboardSlider(
         value: value,

--- a/hibiki/test/settings/settings_pr5_ui_refactor_test.dart
+++ b/hibiki/test/settings/settings_pr5_ui_refactor_test.dart
@@ -1,0 +1,228 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
+import 'package:hibiki/src/settings/settings_context.dart';
+import 'package:hibiki/src/settings/settings_destination.dart';
+import 'package:hibiki/src/settings/settings_schema_card_creation.dart';
+import 'package:hibiki/src/settings/settings_schema_widgets.dart';
+import 'package:hibiki/src/settings/settings_search.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// UI/UX 重构 PR-5 守卫：
+/// 1. 宽屏设置默认选中分类取 schema 首个可见分类（不再硬编码某个 id）。
+/// 2. 「制卡」分类经 bodySearchEntries 进入设置搜索并跳转正确 destination。
+/// 3. 值控件行（Switch/Slider/Stepper/Segmented/内联 Picker）转发 showIcon，
+///    schema 层 showIcons 真正生效（同卡片左栏图标对齐）。
+void main() {
+  group('默认选中分类 = schema 首项（源码守卫）', () {
+    test('settings_home_page 不再硬编码 appearance 默认值', () {
+      final String home = File('lib/src/settings/settings_home_page.dart')
+          .readAsStringSync()
+          .replaceAll('\r\n', '\n');
+      // 默认项延迟到 build 里从可见分类列表解析，顺序真相源是 buildSettingsSchema
+      // （settings_destination_order_guard_test 锁顺序）；这里锁「不再硬编码」。
+      expect(home, contains('SettingsDestinationId? _selectedDestinationId'));
+      expect(home, contains('destinations.first.id'));
+      expect(
+        home,
+        isNot(contains('SettingsDestinationId.appearance')),
+        reason: '宽屏默认选中分类不得再硬编码外观（重排后首项是阅读，未来跟随 schema）',
+      );
+      // body 合成搜索条目不登记 reveal 挂点（挂点永远不会被消费）。
+      expect(home, contains('entry.isBodyEntry ? null : entry.item.id'));
+    });
+  });
+
+  group('制卡分类搜索可见性', () {
+    late SettingsContext sctx;
+
+    Future<void> pumpContext(WidgetTester tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Consumer(
+              builder: (BuildContext context, WidgetRef ref, _) {
+                sctx = SettingsContext(
+                  context: context,
+                  appModel: _TestAppModel(),
+                  ref: ref,
+                  readerSource: ReaderHibikiSource.instance,
+                  refresh: () {},
+                );
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('bodySearchEntries 被展平进搜索索引且指向 cardCreation',
+        (WidgetTester tester) async {
+      await pumpContext(tester);
+      final SettingsDestination dest = buildCardCreationDestination();
+      final List<SettingsSearchEntry> entries =
+          flattenVisibleSettings(<SettingsDestination>[dest], sctx);
+
+      // sections 为空（body 逃生口），条目全部来自 bodySearchEntries。
+      expect(entries, isNotEmpty,
+          reason: '制卡分类必须有可搜条目（此前 sections 空 = 搜索完全不可见）');
+      for (final SettingsSearchEntry entry in entries) {
+        expect(entry.destination.id, SettingsDestinationId.cardCreation);
+        expect(entry.isBodyEntry, isTrue);
+        expect(entry.title, isNotEmpty);
+      }
+      final List<String> ids =
+          entries.map((SettingsSearchEntry e) => e.item.id).toList();
+      expect(ids, contains('card_creation.anki.deck'));
+      expect(ids, contains('card_creation.anki.note_type'));
+      expect(ids, contains('card_creation.anki.field_mappings'));
+      expect(ids, contains('card_creation.anki.mining_audio_quality'));
+    });
+
+    testWidgets('按「牌组」行标题检索能命中并跳转制卡分类', (WidgetTester tester) async {
+      await pumpContext(tester);
+      final SettingsDestination dest = buildCardCreationDestination();
+      final List<SettingsSearchEntry> entries =
+          flattenVisibleSettings(<SettingsDestination>[dest], sctx);
+      // 用与正文行同源的 i18n 文案检索（locale 无关）。
+      final List<SettingsSearchEntry> hits =
+          filterSettingsEntries(entries, t.anki_deck);
+      expect(hits, isNotEmpty);
+      expect(hits.first.destination.id, SettingsDestinationId.cardCreation);
+      expect(hits.first.item.id, 'card_creation.anki.deck');
+    });
+  });
+
+  group('值控件行 showIcon 转发（schema showIcons 生效）', () {
+    Widget schemaHarness({required bool showIcons}) {
+      final SettingsSection section = SettingsSection(
+        items: <SettingsItem>[
+          SettingsSwitchItem(
+            id: 'x.toggle',
+            title: 'Toggle',
+            icon: Icons.toggle_on_outlined,
+            value: (_) => true,
+            onChanged: (_, __) {},
+          ),
+          SettingsSliderItem(
+            id: 'x.slider',
+            title: 'Slider',
+            icon: Icons.linear_scale_outlined,
+            value: (_) => 0.5,
+            divisions: 4,
+            onChanged: (_, __) {},
+          ),
+          SettingsStepperItem(
+            id: 'x.stepper',
+            title: 'Stepper',
+            icon: Icons.exposure_outlined,
+            value: (_) => 1,
+            step: 1,
+            min: 0,
+            max: 4,
+            format: (double v) => v.toStringAsFixed(0),
+            onChanged: (_, __) {},
+          ),
+          SettingsSegmentedItem<String>(
+            id: 'x.segmented',
+            title: 'Mode',
+            icon: Icons.tune_outlined,
+            options: const <SettingsSegmentOption<String>>[
+              SettingsSegmentOption<String>(value: 'a', label: 'A'),
+              SettingsSegmentOption<String>(value: 'b', label: 'B'),
+            ],
+            selected: (_) => 'a',
+            onChanged: (_, __) {},
+          ),
+          SettingsSegmentedItem<String>(
+            id: 'x.dropdown',
+            title: 'Pick',
+            icon: Icons.list_outlined,
+            dropdown: true,
+            options: const <SettingsSegmentOption<String>>[
+              SettingsSegmentOption<String>(value: 'a', label: 'A'),
+              SettingsSegmentOption<String>(value: 'b', label: 'B'),
+            ],
+            selected: (_) => 'a',
+            onChanged: (_, __) {},
+          ),
+        ],
+      );
+      return ProviderScope(
+        child: MaterialApp(
+          home: Consumer(
+            builder: (BuildContext context, WidgetRef ref, _) {
+              final SettingsContext sctx = SettingsContext(
+                context: context,
+                appModel: _TestAppModel(),
+                ref: ref,
+                readerSource: ReaderHibikiSource.instance,
+                refresh: () {},
+              );
+              return Scaffold(
+                body: ListView(
+                  children: <Widget>[
+                    for (final SettingsItem item in section.items)
+                      SettingsSchemaItem(
+                        item: item,
+                        settingsContext: sctx,
+                        showIcons: showIcons,
+                        routeBuilder:
+                            (BuildContext context, WidgetBuilder builder) =>
+                                MaterialPageRoute<void>(builder: builder),
+                      ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    testWidgets('showIcons=true 时各值控件行真正渲染图标', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1200));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.pumpWidget(schemaHarness(showIcons: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.toggle_on_outlined), findsOneWidget,
+          reason: 'Switch 行声明的 icon 必须渲染（此前 showIcon 未转发从不渲染）');
+      expect(find.byIcon(Icons.linear_scale_outlined), findsOneWidget,
+          reason: 'Slider 行图标');
+      expect(find.byIcon(Icons.exposure_outlined), findsOneWidget,
+          reason: 'Stepper 行图标');
+      expect(find.byIcon(Icons.tune_outlined), findsOneWidget,
+          reason: 'Segmented 行图标');
+      expect(find.byIcon(Icons.list_outlined), findsOneWidget,
+          reason: '内联 Picker（dropdown 分支）行图标');
+    });
+
+    testWidgets('showIcons=false 时不渲染（Cupertino 渲染器契约不变）',
+        (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1200));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.pumpWidget(schemaHarness(showIcons: false));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.toggle_on_outlined), findsNothing);
+      expect(find.byIcon(Icons.linear_scale_outlined), findsNothing);
+      expect(find.byIcon(Icons.exposure_outlined), findsNothing);
+      expect(find.byIcon(Icons.tune_outlined), findsNothing);
+      expect(find.byIcon(Icons.list_outlined), findsNothing);
+    });
+  });
+}
+
+/// 轻量 AppModel：schema 构建/搜索展平只求值 visibility 谓词与本测试自带的
+/// item 闭包，不触碰真实子系统。
+class _TestAppModel extends AppModel {
+  _TestAppModel() : super(testPlatformServices());
+}


### PR DESCRIPTION
阶段二模块 PR-5：设置模块 UI/UX 重构（巡检依据 `.codex-test/ui-survey/review-settings.md`，基于 ui-ux-pr0-shared 共享组件先行批）。

## P1
1. **宽屏默认选中分类**：不再硬编码 `appearance`，build 时取 schema 首个可见分类（当前重排后=「阅读」），顺序真相源仍是 `buildSettingsSchema`（顺序守卫未动）；失实注释一并修（settings_home_page.dart）。
2. **值控件行 icon 转发**：`AdaptiveSettingsSwitchRow / SwitchActionRow / SegmentedRow / 内联 PickerRow / SliderRow / StepperRow` 补 `showIcon` 参数（默认 false，与 NavigationRow 同款），schema 层 `showIcons` 真正生效——同卡片左栏图标对齐。附带根因修复：`AdaptiveSettingsRow` 行内/堆叠阈值把左栏图标固定宽（42px）计入，否则窄 pane（视频快捷设置侧栏 190px）带图标行右溢出 24px。anki 页 profile 行与同卡片行统一 `showIcon: true`。
3. **「制卡」分类搜索可见性**：`SettingsDestination` 新增 `bodySearchEntries`（body 逃生口行的搜索元数据），索引器展平为普通搜索条目（命中跳转分类正文，不登记 reveal 挂点）；制卡分类登记 19 条主要设置行（牌组/笔记类型/字段映射/允许重复/覆写范围/标签/媒体清晰度等，AnkiConnect 三行按平台门控）。**未做** AnkiSettingsBody 整页 schema 化（超范围）。

## P2
4. eink 动画归零：折叠 section AnimatedRotation/AnimatedSize（180ms）与搜索定位滚动（250ms）/闪烁（1400ms）→ `einkSafeDuration`（eink 下闪烁直接落透明帧，不闪不残影）。
5. 「界面大小」滑条改一等 `SettingsSliderItem(commitOnRelease: true, titleReadout: true)`，删 `_AppUiScaleSliderRow`/`buildAppUiScaleSelector` 双实现（拖动解耦语义由 `_CommitOnReleaseSlider` 承担，id/持久化 key 不变），静止常驻百分比读数 + 进搜索索引。
6. 滑条 readout 盘点：补 `titleReadout` 8 处——弹窗最大宽/高、覆盖/扩展弹窗宽高（6，px）、阅读自动隐藏时长（s）、滚轮翻页间隔（ms）。**刻意跳过**：dismiss/swipe 灵敏度（纯相对感受型）；**video schema 全部跳过**（速度/字幕字号等 12+ 处 `find.text` 精确 finder churn + 视频面板属 PR-4 模块范围，避免跨模块冲突；弹幕滑条先例已示范视频模块可自行采用）。
7. MaterialLocalizations 混用 → 统一 t.*：anki handlebar 弹窗（「删除」实为清空映射→`dialog_clear`；cancel/ok→`dialog_cancel`/`dialog_ok`）、应用图标确认弹窗、settings_shared Cupertino picker cancel（→`t.cancel`）。
8. 应用图标页：静态提示不再伪装设置行 → `SettingsSectionFooter` 样式；三重「应用图标」标题 → section 改「预设」（新 key `app_icon_presets`，i18n_sync 17 语言）+ 图标网格直接作卡片内容；不支持平台改 `HibikiPlaceholderMessage`。
9. 快捷键页硬编码 padding/小标题 → `tokens.spacing.*` / `tokens.type.sectionLabel`。
10. RTL/LTR 分段 label → `t.spread_direction_rtl/ltr` 全称（tooltip 保留）。
11. 宽屏详情 pane 限宽：`Align(topStart)+ConstrainedBox`，上限复用 `desktopContentMaxWidth(settings)=960`（与窄屏 DesktopContentLayout 同源），左对齐不居中。
12. Lapis 行独立 busy：UI 层 `_creatingLapis`（vm 契约未动）；「刷新」行 spinner/文案不再在 Lapis 创建期间误亮。
13. handlebar 弹窗选中勾对照当前输入框值（ValueListenableBuilder），不再对照打开时旧快照。
14. 快捷键页借 `system` destination id → 新合成 id `shortcuts`（对照 appIcon/videoQuickSettings 先例；顺序守卫/搜索索引不引用合成 id）。
15. `hibiki/CLAUDE.md` 陈旧引用（已删除的 switch/display_settings_page）→ 改为 schema 体系真实入口。

## 新增守卫（test/settings/settings_pr5_ui_refactor_test.dart）
- 默认选中分类=schema 首项（不再硬编码 appearance）+ body 条目不登记 reveal 挂点（源码守卫）。
- 制卡 bodySearchEntries 展平进索引、按「牌组」标题检索命中且 destination 正确（widget/单元）。
- Switch/Slider/Stepper/Segmented/内联 Picker 五类行 showIcons=true 渲染图标、false 不渲染（Cupertino 契约不变）。

## 跳过项
- 6 中 video schema readout（理由见上）。
- AnkiSettingsBody 整页 schema 化 / `_AnkiConnectionField` 双实现合并（巡检「结构性」项，超本 PR 范围）。

## 验证
- `flutter analyze --no-pub`：0 issues。
- 全量 `flutter test --no-pub`：全部通过（+12593 通过 / ~5 跳过，EXIT=0）。
- `test/settings/` 302 通过；`video_quick_settings_sheet_test` 等受 settings_shared 影响文件单独复跑通过。
- `dart format`：仅新改文件；`git diff --cached --check` 干净。

https://claude.ai/code/session_01CfSqJG9psJkUVSig6DhH9Y
