### PR TITLE
fix(galgame): wait for external attach helper readiness

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,15 +27,16 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 978 条。点号进各自文件。
+> 共 979 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1013](bugs/BUG-1013-external-window-attach-ready-race.md) | ✅ | ✅ | 外部窗口挖矿在helper就绪前打开共享内存导致降级 |
 | [BUG-1011](bugs/BUG-1011-interconnect-video-collection-playlist-autoplay.md) | ✅ | ✅ | 互联视频合集列表缺失+无自动连播·客户端合集播放 |
 | [BUG-1010](bugs/BUG-1010-video-controls-autohide-focus-loss.md) | 🚧 | 🚧 | 视频控制条自动隐藏后键盘焦点疑似丢失 |
 | [BUG-1009](bugs/BUG-1009-collection-detail-focus-id-clash.md) | 🚧 | 🚧 | 合集详情页返回后书架同名卡手柄焦点不可达 |
 | [BUG-1008](bugs/BUG-1008-shelf-tag-filter-contradictory-empty.md) | 🚧 | 🚧 | 标签筛选下 SRT 命中仍显示无匹配空态且丢失下拉刷新 |
-| [BUG-1007](bugs/BUG-1007-texthooker-anki-health-hardcoded.md) | 🚧 | 🚧 | 游戏工作台健康卡 Anki 行恒显未配置 |
+| [BUG-1007](bugs/BUG-1007-texthooker-anki-health-hardcoded.md) | ✅ | ✅ | 游戏工作台健康卡 Anki 行恒显未配置 |
 | [BUG-1006](bugs/BUG-1006-anime-download-embedded-pop.md) | 🚧 | 🚧 | 下载页内嵌推送成功后误 pop 宿主路由 |
 | [BUG-1005](bugs/BUG-1005-mining-word-audio-remote-source.md) | ✅ | ✅ | 制卡缺单词音频·扩展needsAudio门+制卡器忽略远程发音源 |
 | [BUG-1004](bugs/BUG-1004-interconnect-mining-audio-host-clip.md) | ✅ | ✅ | 互联视频制卡句子音频改 host 端裁绕开 client ffmpeg 抓远端流 |

--- a/docs/bugs/BUG-1013-external-window-attach-ready-race.md
+++ b/docs/bugs/BUG-1013-external-window-attach-ready-race.md
@@ -1,0 +1,6 @@
+## BUG-1013 · 外部窗口挖矿在helper就绪前打开共享内存导致降级
+- **报告**：2026-07-22（用户：外部窗口挖矿绑定 manosaba 后显示 `engine_attach_failed`，无实时台词）
+- **真实性**：✅ 真 bug。`hibiki/lib/src/mining/galgame_audio_source.dart:610-624` 的 attach 路径启动 helper 后曾直接调用 native `open`；只有 launch 路径等待 stdout 的 `OK hooked pid=<N>`。helper 尚未创建共享内存时，单次 `OpenFileMapping` 失败会立即终止有效 helper 并误降级到系统 Loopback。相同 helper 直接以 `--pid` 附加同一游戏可正常得到 `hooked=1`、`text_hooked=1`，排除了 native hook/游戏兼容性失败。
+- **[x] ① 已修复** — `040cbe32f`：launch/attach 统一等待 helper 的 `OK hooked` proof-of-life，并校验 attach 回报 PID 与所选窗口 PID 一致后才打开共享内存。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/galgame_audio_test.dart:505` 构造延迟输出 `OK hooked` 的 helper，断言就绪前 `open` 调用为 0、就绪后恰好打开一次并保留文本 hook 会话。
+- **备注**：Windows Debug 真机复测已绑定正在运行的 manosaba（PID 64116）：状态由 `engine_attach_failed` 变为“运行中 · 游戏资源音频”，helper 常驻并收到 engine hook 文本事件；共享环探针为 `hooked=1`、`text_hooked=1`、`luna_active=1`。默认线程同时包含 `WideCharToMultiByte` 系统时间文本，需在现有线程选择器中筛选干净台词；这不是本条附加生命周期失败。

--- a/hibiki/lib/src/mining/galgame_audio_source.dart
+++ b/hibiki/lib/src/mining/galgame_audio_source.dart
@@ -459,7 +459,7 @@ class EngineHookGalAudioSource implements GalAudioSource {
   Process? _injector;
   final List<StreamSubscription<String>> _injectorOutputSubscriptions =
       <StreamSubscription<String>>[];
-  Completer<int?>? _launchedPidCompleter;
+  Completer<int?>? _hookedPidCompleter;
 
   /// 实际注入命中的游戏 PID：attach=`targetPid`；launch=从 injector stdout 解析出的子进程 PID。
   /// [grabRecent]/`open` 都用它开共享内存。
@@ -585,18 +585,18 @@ class EngineHookGalAudioSource implements GalAudioSource {
     } on ProcessException {
       return null;
     }
-    _beginInjectorOutputDrain(_injector!, awaitLaunchedPid: launchMode);
-    if (launchMode) {
-      // 等 injector 打印 `OK hooked pid=<子进程>`（注入成功 proof-of-life）解析出游戏 PID。
-      final int? childPid = await _awaitLaunchedPid();
-      if (childPid == null || childPid <= 0) {
-        await stop();
-        return null; // 启动/注入失败（exe 起不来 / 位数不符 / 超时）
-      }
-      _effectivePid = childPid;
-    } else {
-      _effectivePid = targetPid;
+    _beginInjectorOutputDrain(_injector!);
+    // launch 和 attach 都必须等 helper 宣告注入完成。attach 旧实现启动子进程后立即
+    // `open`，共享内存通常还没创建，单次 OpenFileMapping 失败后便误降级到 loopback。
+    // `OK hooked` 是 helper 创建共享会话后的 proof-of-life，也是两种模式共同的边界。
+    final int? hookedPid = await _awaitHookedPid();
+    if (hookedPid == null ||
+        hookedPid <= 0 ||
+        (!launchMode && hookedPid != targetPid)) {
+      await stop();
+      return null; // 启动/注入失败（目标不符 / 位数不符 / 超时）
     }
+    _effectivePid = hookedPid;
     // 2. open 共享内存（injector 已创建），成功后轮询 status 等 hook DLL 注入 + 拿到语音格式。
     try {
       final Map<Object?, Object?>? opened =
@@ -637,31 +637,27 @@ class EngineHookGalAudioSource implements GalAudioSource {
   /// injector 是常驻 helper，stdout/stderr 也必须贯穿会话持续排空。只在解析到 launch PID
   /// 后取消 stdout 订阅会让后续输出填满匿名管道；完全不订阅 stderr 更会使 native 卡死在
   /// `fprintf(stderr, ...)`，Unity 资源事件队列随之停止消费但进程仍显示存活。
-  void _beginInjectorOutputDrain(
-    Process process, {
-    required bool awaitLaunchedPid,
-  }) {
-    final Completer<int?>? pidCompleter =
-        awaitLaunchedPid ? Completer<int?>() : null;
+  void _beginInjectorOutputDrain(Process process) {
+    final Completer<int?> pidCompleter = Completer<int?>();
     final StringBuffer stdoutBuffer = StringBuffer();
-    _launchedPidCompleter = pidCompleter;
+    _hookedPidCompleter = pidCompleter;
     _injectorOutputSubscriptions.add(
       process.stdout.transform(const SystemEncoding().decoder).listen(
         (String chunk) {
           _emitInjectorOutput(isStderr: false, chunk: chunk);
-          if (pidCompleter == null || pidCompleter.isCompleted) return;
+          if (pidCompleter.isCompleted) return;
           stdoutBuffer.write(chunk);
           final int? pid = parseInjectorHookedPid(stdoutBuffer.toString());
           if (pid != null) pidCompleter.complete(pid);
         },
         onDone: () {
-          if (pidCompleter != null && !pidCompleter.isCompleted) {
+          if (!pidCompleter.isCompleted) {
             pidCompleter
                 .complete(parseInjectorHookedPid(stdoutBuffer.toString()));
           }
         },
         onError: (Object _) {
-          if (pidCompleter != null && !pidCompleter.isCompleted) {
+          if (!pidCompleter.isCompleted) {
             pidCompleter.complete(null);
           }
         },
@@ -689,10 +685,10 @@ class EngineHookGalAudioSource implements GalAudioSource {
     }
   }
 
-  /// launch 模式：等 stdout 中的 `OK hooked pid=<N>`；订阅本身不会在解析成功后取消，
-  /// 仍负责排空 helper 余生的输出。
-  Future<int?> _awaitLaunchedPid() async {
-    final Completer<int?>? completer = _launchedPidCompleter;
+  /// 等 stdout 中的 `OK hooked pid=<N>`；订阅本身不会在解析成功后取消，仍负责排空
+  /// helper 余生的输出。launch 用返回 PID 发现新游戏，attach 用它避免抢跑共享内存。
+  Future<int?> _awaitHookedPid() async {
+    final Completer<int?>? completer = _hookedPidCompleter;
     if (completer == null) return null;
     return completer.future.timeout(_readyTimeout, onTimeout: () => null);
   }
@@ -1145,8 +1141,8 @@ class EngineHookGalAudioSource implements GalAudioSource {
     final List<StreamSubscription<String>> outputSubscriptions =
         List<StreamSubscription<String>>.of(_injectorOutputSubscriptions);
     _injectorOutputSubscriptions.clear();
-    final Completer<int?>? pidCompleter = _launchedPidCompleter;
-    _launchedPidCompleter = null;
+    final Completer<int?>? pidCompleter = _hookedPidCompleter;
+    _hookedPidCompleter = null;
     if (pidCompleter != null && !pidCompleter.isCompleted) {
       pidCompleter.complete(null);
     }

--- a/hibiki/test/mining/galgame_audio_test.dart
+++ b/hibiki/test/mining/galgame_audio_test.dart
@@ -502,6 +502,71 @@ void main() {
       }
     });
 
+    test('attach 等 helper OK 后才打开共享内存', () async {
+      final Directory temp = await Directory.systemTemp.createTemp(
+        'hibiki_helper_attach_ready_test_',
+      );
+      final File injector =
+          File('${temp.path}${Platform.pathSeparator}fake.exe');
+      await injector.writeAsBytes(const <int>[0]);
+      final _FakeProcess process = _FakeProcess();
+      var openCalls = 0;
+
+      setHandler((MethodCall call) async {
+        switch (call.method) {
+          case 'open':
+            openCalls++;
+            expect(call.arguments, <String, Object?>{'pid': 2468});
+            return <String, Object?>{'ok': true};
+          case 'status':
+            return <String, Object?>{
+              'hooked': true,
+              'textHooked': true,
+              'audioHooksReady': true,
+              'ready': false,
+              'rawVoiceReady': false,
+            };
+          case 'close':
+            return null;
+        }
+        return null;
+      });
+
+      final EngineHookGalAudioSource source = EngineHookGalAudioSource(
+        targetPid: 2468,
+        injectorPath: injector.path,
+        processStarter: (String executable, List<String> arguments) async {
+          expect(executable, injector.path);
+          expect(arguments, containsAllInOrder(<String>['--pid', '2468']));
+          return process;
+        },
+        readyTimeout: const Duration(seconds: 1),
+        pollInterval: Duration.zero,
+      );
+
+      try {
+        final Future<PcmFormat?> start = source.start();
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          openCalls,
+          0,
+          reason: 'helper 尚未宣告 hooked 时不能抢跑 OpenFileMapping',
+        );
+
+        process.stdoutController.add(
+          'OK hooked pid=2468 mode=attach\n'.codeUnits,
+        );
+        expect(await start, isNull);
+        expect(openCalls, 1);
+        expect(source.gamePid, 2468);
+        expect(source.textHookReady, isTrue);
+      } finally {
+        await source.stop();
+        await process.dispose();
+        await temp.delete(recursive: true);
+      }
+    });
+
     test('targetPid<=0 -> start null', () async {
       final src =
           EngineHookGalAudioSource(targetPid: 0, injectorPath: 'C:/nope.exe');


### PR DESCRIPTION
## What changed

- Make launch and external-window attach modes both wait for the helper's `OK hooked pid=<N>` proof-of-life before opening shared memory.
- Validate that an attach helper reports the PID selected by the user.
- Add a regression test that delays helper readiness and verifies `open` is not called early.
- Record BUG-1013 and its real-device validation evidence.

## Root cause

External-window attach started the helper and immediately invoked the native shared-memory `open` call. The helper usually had not created its mapping yet, so the single open attempt failed, Hibiki terminated an otherwise valid helper, and the session fell back with `engine_attach_failed`. Launch mode already waited for the helper readiness line, so the two paths had inconsistent lifecycle boundaries.

## User impact

Binding an already-running game through “外部窗口挖矿” now waits for the actual injection session to exist instead of racing it, allowing engine text and resource-audio monitoring to remain active.

## Validation

- `flutter test test/mining/galgame_audio_test.dart` — passed (55 tests).
- `flutter build windows --debug` — passed.
- Real manosaba external attach (PID 64116): UI reached `运行中 · 游戏资源音频`; probe reported `hooked=1`, `text_hooked=1`, and `luna_active=1`.
- The remaining full Flutter suite was skipped at the user's request.
