### PR TITLE
fix(windows): BUG-1014 更新时保留桌面图标位置

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 980 条。点号进各自文件。
+> 共 981 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1014](bugs/BUG-1014-win-update-desktop-icon-move.md) | ✅ | ✅ | Windows 更新后桌面快捷方式移位 |
 | [BUG-1013](bugs/BUG-1013-external-window-attach-ready-race.md) | ✅ | ✅ | 外部窗口挖矿在helper就绪前打开共享内存导致降级 |
 | [BUG-1012](bugs/BUG-1012-ext-shadow-dom-lookup.md) | ✅ | ✅ | 浏览器扩展无法读取Shadow DOM内文字(B站评论区) |
 | [BUG-1011](bugs/BUG-1011-interconnect-video-collection-playlist-autoplay.md) | ✅ | ✅ | 互联视频合集列表缺失+无自动连播·客户端合集播放 |

--- a/docs/bugs/BUG-1014-win-update-desktop-icon-move.md
+++ b/docs/bugs/BUG-1014-win-update-desktop-icon-move.md
@@ -1,6 +1,6 @@
 ## BUG-1014 · Windows 更新后桌面快捷方式移位
 - **报告**：2026-07-22（用户：每次更新后桌面图标会移动位置）
 - **真实性**：✅ 真 bug。Windows 应用内更新走 Inno Setup 覆盖安装（`hibiki/lib/src/utils/misc/platform_updater.dart:264` `WindowsInstaller.runAndExit` → `/VERYSILENT` 静默安装）。根因在安装脚本 `hibiki/windows/installer/hibiki.iss:43`（旧）：`[Icons]` 无条件创建 `Name: "{userdesktop}\Hibiki"`，每次更新都把桌面上已存在的 `Hibiki.lnk` 重写一遍。Explorer 把被重写的快捷方式当作变更/新项，丢弃 `HKCU\...\Shell\Bags` 里记住的图标坐标，把它重排回默认格子 → 用户观感「每次更新图标移位」。
-- **[x] ① 已修复** — `hibiki/windows/installer/hibiki.iss`：桌面图标改为可选任务 `desktopicon`（默认勾选，保持首装即有图标的旧行为）+ `Check: ShouldCreateDesktopIcon`（`not FileExists({userdesktop}\Hibiki.lnk)`）——仅在快捷方式尚不存在时创建。首装照建；后续更新检测到 `.lnk` 已在即跳过、不重写、位置保留。提交：<pending>
-- **[x] ② 已加自动化测试** — `hibiki/test/build/windows_installer_desktop_icon_guard_test.dart`（源码扫描守卫，3 用例）：桌面图标行必须挂 `Check: ShouldCreateDesktopIcon` + `Tasks: desktopicon`；`ShouldCreateDesktopIcon` 函数逻辑为 `not FileExists({userdesktop}\Hibiki.lnk)`；`desktopicon` 任务默认勾选（不带 `unchecked`）。提交：<pending>
+- **[x] ① 已修复** — `hibiki/windows/installer/hibiki.iss`：桌面图标改为可选任务 `desktopicon`（默认勾选，保持首装即有图标的旧行为）+ `Check: ShouldCreateDesktopIcon`（`not FileExists({userdesktop}\Hibiki.lnk)`）——仅在快捷方式尚不存在时创建。首装照建；后续更新检测到 `.lnk` 已在即跳过、不重写、位置保留。提交：fa9e17a5f
+- **[x] ② 已加自动化测试** — `hibiki/test/build/windows_installer_desktop_icon_guard_test.dart`（源码扫描守卫，3 用例）：桌面图标行必须挂 `Check: ShouldCreateDesktopIcon` + `Tasks: desktopicon`；`ShouldCreateDesktopIcon` 函数逻辑为 `not FileExists({userdesktop}\Hibiki.lnk)`；`desktopicon` 任务默认勾选（不带 `unchecked`）。提交：fa9e17a5f
 - **备注**：真机验证（装旧版→在桌面把 Hibiki 图标摆到自定义位置→应用内触发一次更新→确认图标停在原位不回默认格子）尚待在 Windows 真机走一轮覆盖安装对照；本轮只做根因修复 + 源码守卫。若用户此前手动删过桌面图标，静默更新会因 `.lnk` 不存在而补建一个（放默认位置），符合直觉，非回归。

--- a/docs/bugs/BUG-1014-win-update-desktop-icon-move.md
+++ b/docs/bugs/BUG-1014-win-update-desktop-icon-move.md
@@ -1,0 +1,6 @@
+## BUG-1014 · Windows 更新后桌面快捷方式移位
+- **报告**：2026-07-22（用户：每次更新后桌面图标会移动位置）
+- **真实性**：✅ 真 bug。Windows 应用内更新走 Inno Setup 覆盖安装（`hibiki/lib/src/utils/misc/platform_updater.dart:264` `WindowsInstaller.runAndExit` → `/VERYSILENT` 静默安装）。根因在安装脚本 `hibiki/windows/installer/hibiki.iss:43`（旧）：`[Icons]` 无条件创建 `Name: "{userdesktop}\Hibiki"`，每次更新都把桌面上已存在的 `Hibiki.lnk` 重写一遍。Explorer 把被重写的快捷方式当作变更/新项，丢弃 `HKCU\...\Shell\Bags` 里记住的图标坐标，把它重排回默认格子 → 用户观感「每次更新图标移位」。
+- **[x] ① 已修复** — `hibiki/windows/installer/hibiki.iss`：桌面图标改为可选任务 `desktopicon`（默认勾选，保持首装即有图标的旧行为）+ `Check: ShouldCreateDesktopIcon`（`not FileExists({userdesktop}\Hibiki.lnk)`）——仅在快捷方式尚不存在时创建。首装照建；后续更新检测到 `.lnk` 已在即跳过、不重写、位置保留。提交：<pending>
+- **[x] ② 已加自动化测试** — `hibiki/test/build/windows_installer_desktop_icon_guard_test.dart`（源码扫描守卫，3 用例）：桌面图标行必须挂 `Check: ShouldCreateDesktopIcon` + `Tasks: desktopicon`；`ShouldCreateDesktopIcon` 函数逻辑为 `not FileExists({userdesktop}\Hibiki.lnk)`；`desktopicon` 任务默认勾选（不带 `unchecked`）。提交：<pending>
+- **备注**：真机验证（装旧版→在桌面把 Hibiki 图标摆到自定义位置→应用内触发一次更新→确认图标停在原位不回默认格子）尚待在 Windows 真机走一轮覆盖安装对照；本轮只做根因修复 + 源码守卫。若用户此前手动删过桌面图标，静默更新会因 `.lnk` 不存在而补建一个（放默认位置），符合直觉，非回归。

--- a/hibiki/test/build/windows_installer_desktop_icon_guard_test.dart
+++ b/hibiki/test/build/windows_installer_desktop_icon_guard_test.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1014 回归守卫：Windows 安装器不得在更新时无条件重写桌面快捷方式。
+///
+/// 根因：`hibiki.iss` 的 `[Icons]` 旧版无条件创建 `{userdesktop}\Hibiki`，
+/// 每次应用内静默更新（/VERYSILENT）都把已存在的 `Hibiki.lnk` 重写一遍，
+/// Explorer 把重写的快捷方式当作变更/新项，丢弃 `Shell\Bags` 里记住的坐标，
+/// 桌面图标被重排回默认格子 → 用户观感「每次更新图标移位」。
+///
+/// 修复：桌面图标改为可选 `desktopicon` 任务（默认勾选，保持首装即有图标的旧行为），
+/// 并加 `Check: ShouldCreateDesktopIcon` —— 仅在 `{userdesktop}\Hibiki.lnk` 尚不
+/// 存在时才创建，更新时跳过、不重写、位置保留。
+void main() {
+  String readInstallerScript() {
+    final File file = File('windows/installer/hibiki.iss');
+    expect(
+      file.existsSync(),
+      isTrue,
+      reason: 'expected Inno Setup script at ${file.absolute.path}',
+    );
+    return file.readAsStringSync();
+  }
+
+  test('desktop icon entry is gated so updates never rewrite it', () {
+    final String iss = readInstallerScript();
+
+    // 找到 [Icons] 段里的桌面快捷方式行。
+    final RegExp desktopIconLine = RegExp(
+      r'^\s*Name:\s*"\{userdesktop\}\\Hibiki".*$',
+      multiLine: true,
+    );
+    final Iterable<RegExpMatch> matches = desktopIconLine.allMatches(iss);
+    expect(
+      matches.length,
+      1,
+      reason: 'expected exactly one {userdesktop}\\Hibiki icon entry',
+    );
+    final String line = matches.first.group(0)!;
+
+    // 必须挂 Check 守卫（避免更新时重写 .lnk）+ 归到可选 desktopicon 任务。
+    expect(
+      line.contains('Check: ShouldCreateDesktopIcon'),
+      isTrue,
+      reason: 'desktop icon must be guarded by Check: ShouldCreateDesktopIcon '
+          'so an update does not rewrite the shortcut (BUG-1014). Line: $line',
+    );
+    expect(
+      line.contains('Tasks: desktopicon'),
+      isTrue,
+      reason: 'desktop icon must be an optional "desktopicon" task. '
+          'Line: $line',
+    );
+  });
+
+  test('ShouldCreateDesktopIcon skips creation when the shortcut exists', () {
+    final String iss = readInstallerScript();
+
+    // 守卫函数必须存在，且逻辑是「快捷方式已存在 → 不创建」。
+    final RegExp fn = RegExp(
+      r'function\s+ShouldCreateDesktopIcon\s*\(\s*\)\s*:\s*Boolean\s*;'
+      r'.*?Result\s*:=\s*not\s+FileExists\s*\(\s*'
+      r"ExpandConstant\s*\(\s*'\{userdesktop\}\\Hibiki\.lnk'\s*\)\s*\)\s*;"
+      r'.*?end\s*;',
+      dotAll: true,
+    );
+    expect(
+      fn.hasMatch(iss),
+      isTrue,
+      reason: 'ShouldCreateDesktopIcon must return '
+          "not FileExists({userdesktop}\\Hibiki.lnk) (BUG-1014).",
+    );
+  });
+
+  test('desktopicon task is declared and defaults to checked', () {
+    final String iss = readInstallerScript();
+
+    final RegExp taskLine = RegExp(
+      r'^\s*Name:\s*"desktopicon".*$',
+      multiLine: true,
+    );
+    final RegExpMatch? match = taskLine.firstMatch(iss);
+    expect(
+      match,
+      isNotNull,
+      reason: 'expected a [Tasks] entry Name: "desktopicon"',
+    );
+    // 默认勾选：保持旧行为（首装桌面即有图标）。不得带 unchecked 标志。
+    expect(
+      match!.group(0)!.toLowerCase().contains('unchecked'),
+      isFalse,
+      reason: 'desktopicon must default to checked to preserve the '
+          'existing first-install behaviour (icon on desktop).',
+    );
+  });
+}

--- a/hibiki/windows/installer/hibiki.iss
+++ b/hibiki/windows/installer/hibiki.iss
@@ -30,6 +30,12 @@ RestartApplications=no
 AppMutex=HibikiSingleInstanceMutex
 
 [Tasks]
+; 桌面快捷方式：默认勾选（保持旧行为——首装桌面即有图标），允许用户取消。
+; 配合 [Icons] 的 Check: ShouldCreateDesktopIcon，仅在快捷方式尚不存在时创建，
+; 应用内静默更新（/VERYSILENT，用户看不到向导、无法取消）不会重写已存在的 .lnk，
+; 桌面图标位置得以保留（BUG-1014）。
+Name: "desktopicon"; Description: "创建桌面快捷方式"; GroupDescription: "附加快捷方式："
+
 ; 可选：把 Hibiki 注册为视频文件的「打开方式」候选（不抢占系统默认播放器，
 ; 只在资源管理器右键「打开方式」里出现 Hibiki，并支持拖视频到 hibiki.exe）。
 Name: "videoassoc"; Description: "将 Hibiki 加入视频文件的「打开方式」（mkv / mp4 等）"; GroupDescription: "文件关联："
@@ -40,7 +46,11 @@ Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs 
 
 [Icons]
 Name: "{group}\Hibiki"; Filename: "{app}\hibiki.exe"
-Name: "{userdesktop}\Hibiki"; Filename: "{app}\hibiki.exe"
+; BUG-1014：只在桌面快捷方式尚不存在时创建。旧版无条件重写 {userdesktop}\Hibiki.lnk，
+; 每次静默更新都把用户在桌面摆好的图标重排回默认格子（Explorer 把重写的 .lnk 当作
+; 变更/新项，丢弃 Shell\Bags 里记住的坐标）。加 Check 后：首装照建（默认勾选 desktopicon
+; 任务），后续更新检测到 .lnk 已在即跳过、不重写、位置保留。
+Name: "{userdesktop}\Hibiki"; Filename: "{app}\hibiki.exe"; Tasks: desktopicon; Check: ShouldCreateDesktopIcon
 
 [Registry]
 ; 一个 Hibiki 应用 ProgId：双击/「打开方式」时以 hibiki.exe "<文件>" 启动。
@@ -147,6 +157,16 @@ begin
   Exec(ExpandConstant('{sys}\taskkill.exe'),
        '/F /IM ' + ExeName + ' /T',
        '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+end;
+
+{ BUG-1014: preserve the user's desktop icon position across updates.
+  Return False (skip creating the desktop shortcut) when {userdesktop}\Hibiki.lnk
+  already exists, so an update never rewrites it -- Explorer keeps the remembered
+  grid position. On a first install the file is absent -> True -> the shortcut is
+  created as before (gated by the default-checked "desktopicon" task). }
+function ShouldCreateDesktopIcon(): Boolean;
+begin
+  Result := not FileExists(ExpandConstant('{userdesktop}\Hibiki.lnk'));
 end;
 
 function InitializeSetup(): Boolean;


### PR DESCRIPTION
## 问题
用户报：Windows 每次更新后桌面图标会移动位置。

## 根因
Windows 应用内更新走 Inno Setup 覆盖安装（`platform_updater.dart:264` → `/VERYSILENT`）。`hibiki.iss` 的 `[Icons]` 旧版**无条件**创建 `{userdesktop}\Hibiki`，每次更新都重写桌面 `Hibiki.lnk`。Explorer 把被重写的快捷方式当作变更/新项，丢弃 `HKCU\...\Shell\Bags` 里记住的坐标，把图标重排回默认格子 → 观感「每次更新图标移位」。

## 修复
- 桌面图标改为可选任务 `desktopicon`（默认勾选，保持首装即有图标的旧行为）
- 加 `Check: ShouldCreateDesktopIcon`（`not FileExists({userdesktop}\Hibiki.lnk)`）——仅在快捷方式尚不存在时创建；更新时跳过、不重写、位置保留
- 加源码扫描守卫 `windows_installer_desktop_icon_guard_test.dart`（3 用例，已过）

## 验证
- ✅ `flutter test test/build/windows_installer_desktop_icon_guard_test.dart`（3/3 通过）
- ⏳ 待 Windows 真机走一轮覆盖安装对照：装旧版→桌面摆好图标→触发更新→确认图标停原位

详见 `docs/bugs/BUG-1014-win-update-desktop-icon-move.md`。

https://claude.ai/code/session_01FxZBB6XF2dqZKVrU3VsbYp