### PR TITLE
fix(sync): 支持匿名 WebDAV/FTP，空账密不再被硬拦 (BUG-1015)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 980 条。点号进各自文件。
+> 共 981 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1015](bugs/BUG-1015-webdav-anonymous-empty-credentials.md) | ✅ | ✅ | WebDAV/FTP 匿名同步：空用户名密码被硬拦 |
 | [BUG-1013](bugs/BUG-1013-external-window-attach-ready-race.md) | ✅ | ✅ | 外部窗口挖矿在helper就绪前打开共享内存导致降级 |
 | [BUG-1012](bugs/BUG-1012-ext-shadow-dom-lookup.md) | ✅ | ✅ | 浏览器扩展无法读取Shadow DOM内文字(B站评论区) |
 | [BUG-1011](bugs/BUG-1011-interconnect-video-collection-playlist-autoplay.md) | ✅ | ✅ | 互联视频合集列表缺失+无自动连播·客户端合集播放 |

--- a/docs/bugs/BUG-1015-webdav-anonymous-empty-credentials.md
+++ b/docs/bugs/BUG-1015-webdav-anonymous-empty-credentials.md
@@ -1,0 +1,18 @@
+## BUG-1015 · WebDAV/FTP 匿名同步：空用户名密码被硬拦
+
+- **报告**：2026-07-22（用户）
+- **现象**：同步与备份 → WebDAV 后端只填服务器地址（`127.0.0.1:1919`），用户名/密码留空，点「测试连接」报 `连接失败: 缺少字段`。匿名 / 无鉴权 WebDAV 无法使用。
+- **真实性**：✅ 真 bug。两处根因：
+  - `hibiki/lib/src/sync/sync_settings_schema/backend_config.part.dart:79` — WebDAV `_testConnection` 硬校验 `url.isEmpty || username.isEmpty || password.isEmpty`，把用户名/密码也当必填，空账密直接报「缺少字段」。（`_saveCredentials` 64-66 已允许存空 → null，仅测试连接这一处一刀切。）
+  - `hibiki/lib/src/sync/webdav_ops.dart:32-33,73` — `_authHeader` 恒构造为 `Basic base64('user:pass')` 并每请求必发；账密都空时发的是 `Basic base64(':')`，匿名服务器多半仍回 401。真正匿名请求应根本不带 `Authorization` 头。
+  - 同类：`hibiki/lib/src/sync/ftp_sync_backend.dart:689` — `_connect` 硬要求 `_host && _username && _password` 全非 null，连"有用户名无密码"的服务器都拦，且与 `testConnection`（放行空账密）不一致 → 匿名 FTP 登录被 ops 层拦掉，「测试能过 / 实际同步失败」。
+  - SFTP（密码/私钥二选一，key-only）与 Hibiki 互联（token 为设备身份，必填合理）不属本 bug，不动。
+- **[x] ① 已修复** —
+  - `backend_config.part.dart` WebDAV 校验改为只 `if (url.isEmpty)`；账密留空放行。
+  - `webdav_ops.dart` `_authHeader` 改为 `String?`：用户名**和**密码都空 → null，`buildRequest` 据此跳过 `Authorization` 头（有任一凭据时字节完全不变）。
+  - `ftp_sync_backend.dart` 新增 `@visibleForTesting static ftpLoginCredentials(user, pass)` 归一（空用户名→`anonymous`，空密码→`''`）；`_connect` 只要求 `_host != null`，`testConnection` 与 `_connect` 均复用该归一，消除不一致、支持匿名 FTP。
+  - 提交：（见分支 worktree-webdav-anon-creds）
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/sync/webdav_ops_anonymous_test.dart`：进程内 HttpServer 断言——空账密 `testConnection()` 不带 `Authorization` 头且成功；有账密时带 `Basic ...`。
+  - `hibiki/test/sync/ftp_anonymous_credentials_test.dart`：`ftpLoginCredentials` 单测——空/空→(`anonymous`,``)、有用户名无密码→(`user`,``)、全有→原样。
+- **备注**：WebDAV 匿名路径已用进程内 mock 端到端验证。FTP 匿名 **live** 登录依赖 `FTPConnect` 库对 `user:'anonymous'/pass:''` 的行为，需真实匿名 FTP 服务器验收（外部系统，无法本地端到端）；纯凭据归一逻辑已单测覆盖。

--- a/hibiki/lib/src/sync/ftp_sync_backend.dart
+++ b/hibiki/lib/src/sync/ftp_sync_backend.dart
@@ -86,9 +86,22 @@ class FtpSyncBackend extends SyncBackend
 
   // ── Auth ──────────────────────────────────────────────────────────
 
+  /// Normalize stored credentials for an FTP login. Only the host is truly
+  /// required; an empty/null username means anonymous FTP (`anonymous` with an
+  /// empty password), and a server that needs a username but no password is
+  /// honored too. Centralized so [testConnection] and [_connect] behave
+  /// identically instead of the old split where the widget test passed empty
+  /// creds through but [_connect] hard-rejected them (BUG-1015).
+  @visibleForTesting
+  static ({String user, String pass}) ftpLoginCredentials(
+      String? username, String? password) {
+    final String user =
+        (username == null || username.isEmpty) ? 'anonymous' : username;
+    return (user: user, pass: password ?? '');
+  }
+
   @override
-  Future<bool> get isAuthenticated async =>
-      _host != null && _username != null && _password != null;
+  Future<bool> get isAuthenticated async => _host != null;
 
   @override
   Future<String?> get currentEmail async => _username;
@@ -574,11 +587,13 @@ class FtpSyncBackend extends SyncBackend
     required String password,
     required bool useTls,
   }) async {
+    final ({String user, String pass}) creds =
+        ftpLoginCredentials(username, password);
     final client = FTPConnect(
       host,
       port: port,
-      user: username,
-      pass: password,
+      user: creds.user,
+      pass: creds.pass,
       securityType: useTls ? SecurityType.ftps : SecurityType.ftp,
       timeout: 15,
     );
@@ -597,14 +612,16 @@ class FtpSyncBackend extends SyncBackend
   // ── Connection management ─────────────────────────────────────────
 
   Future<void> _connect() async {
-    if (_host == null || _username == null || _password == null) {
+    if (_host == null) {
       throw SyncAuthError('FTP credentials not set');
     }
+    final ({String user, String pass}) creds =
+        ftpLoginCredentials(_username, _password);
     _client = FTPConnect(
       _host!,
       port: _port,
-      user: _username!,
-      pass: _password!,
+      user: creds.user,
+      pass: creds.pass,
       securityType: _useTls ? SecurityType.ftps : SecurityType.ftp,
       timeout: 30,
     );

--- a/hibiki/lib/src/sync/sync_settings_schema/backend_config.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/backend_config.part.dart
@@ -229,7 +229,9 @@ class _WebDavConfigWidget extends StatelessWidget {
     final String url = texts[0].trim();
     final String username = texts[1].trim();
     final String password = texts[2];
-    if (url.isEmpty || username.isEmpty || password.isEmpty) {
+    // 仅 URL 必填；用户名/密码留空 = 匿名 / 无鉴权 WebDAV（局域网自建、本机服务
+    // 等合法场景），不再当作「缺少字段」硬拦（BUG-1015）。
+    if (url.isEmpty) {
       return t.sync_webdav_test_failed(message: t.sync_webdav_missing_fields);
     }
     try {

--- a/hibiki/lib/src/sync/webdav_ops.dart
+++ b/hibiki/lib/src/sync/webdav_ops.dart
@@ -29,11 +29,15 @@ class WebDavOps {
   })  : _baseUrl = baseUrl,
         _connectionTimeout = connectionTimeout,
         _pinnedFingerprint = pinnedFingerprint,
-        _authHeader =
-            'Basic ${base64Encode(utf8.encode('$username:$password'))}';
+        // 用户名和密码都空 = 匿名 / 无鉴权 WebDAV：根本不带 Authorization 头，
+        // 而不是发 `Basic base64(':')`（很多匿名服务器仍会因此回 401）。任一凭据
+        // 非空时行为完全不变（BUG-1015）。
+        _authHeader = (username.isEmpty && password.isEmpty)
+            ? null
+            : 'Basic ${base64Encode(utf8.encode('$username:$password'))}';
 
   final String _baseUrl;
-  final String _authHeader;
+  final String? _authHeader;
   final Duration _connectionTimeout;
 
   /// TODO-961 M1: https 端点的证书 SHA-256 钉扎指纹（aa:bb:.. 形式）。null = 明文
@@ -70,7 +74,8 @@ class WebDavOps {
   Future<HttpClientRequest> buildRequest(String method, String url) async {
     final request = await _client().openUrl(method, Uri.parse(url));
     request.followRedirects = false;
-    request.headers.set('Authorization', _authHeader);
+    final String? auth = _authHeader;
+    if (auth != null) request.headers.set('Authorization', auth);
     return request;
   }
 

--- a/hibiki/test/sync/ftp_anonymous_credentials_test.dart
+++ b/hibiki/test/sync/ftp_anonymous_credentials_test.dart
@@ -1,0 +1,34 @@
+// BUG-1015 匿名 FTP：ftpLoginCredentials 归一逻辑单测。
+// 空/空 → (anonymous, '')；有用户名无密码 → (user, '')；全有 → 原样。
+// 消除旧的「testConnection 放行空账密、_connect 硬拒空账密」不一致。
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/ftp_sync_backend.dart';
+
+void main() {
+  group('FtpSyncBackend.ftpLoginCredentials', () {
+    test('null/null → anonymous 登录', () {
+      final creds = FtpSyncBackend.ftpLoginCredentials(null, null);
+      expect(creds.user, 'anonymous');
+      expect(creds.pass, '');
+    });
+
+    test('空串/空串 → anonymous 登录', () {
+      final creds = FtpSyncBackend.ftpLoginCredentials('', '');
+      expect(creds.user, 'anonymous');
+      expect(creds.pass, '');
+    });
+
+    test('有用户名、无密码 → 用户名原样 + 空密码', () {
+      final creds = FtpSyncBackend.ftpLoginCredentials('reader', null);
+      expect(creds.user, 'reader');
+      expect(creds.pass, '');
+    });
+
+    test('用户名+密码全有 → 原样透传', () {
+      final creds = FtpSyncBackend.ftpLoginCredentials('reader', 'pw');
+      expect(creds.user, 'reader');
+      expect(creds.pass, 'pw');
+    });
+  });
+}

--- a/hibiki/test/sync/webdav_ops_anonymous_test.dart
+++ b/hibiki/test/sync/webdav_ops_anonymous_test.dart
@@ -1,0 +1,76 @@
+// BUG-1015 匿名 / 无鉴权 WebDAV：用户名和密码都留空时，请求必须【不带】
+// Authorization 头（而不是发 `Basic base64(':')`，那样匿名服务器多半仍回 401）。
+// 有任一凭据时行为不变，照发 Basic 头。
+//
+// 用进程内 HttpServer 冒充 WebDAV 端点，对 PROPFIND 回 207，记录每个请求收到的
+// Authorization 头，端到端断言 WebDavOps.buildRequest 的真实行为。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/webdav_ops.dart';
+
+class _FakeDav {
+  _FakeDav(this.server, this.origin);
+  final HttpServer server;
+  final String origin;
+  final List<String?> authHeaders = <String?>[];
+
+  static Future<_FakeDav> start() async {
+    final HttpServer srv =
+        await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final _FakeDav fake = _FakeDav(srv, 'http://127.0.0.1:${srv.port}');
+    srv.listen((HttpRequest req) async {
+      fake.authHeaders.add(req.headers.value(HttpHeaders.authorizationHeader));
+      await req.drain<Object?>();
+      // Minimal 207 multistatus so testConnection treats it as success.
+      req.response.statusCode = 207;
+      req.response.headers
+          .set(HttpHeaders.contentTypeHeader, 'application/xml; charset=utf-8');
+      req.response.write(
+          '<?xml version="1.0"?><d:multistatus xmlns:d="DAV:"></d:multistatus>');
+      await req.response.close();
+    });
+    return fake;
+  }
+
+  Future<void> stop() => server.close(force: true);
+}
+
+void main() {
+  late _FakeDav dav;
+
+  setUp(() async {
+    dav = await _FakeDav.start();
+  });
+  tearDown(() async {
+    await dav.stop();
+  });
+
+  test('空用户名+空密码 → 不带 Authorization 头，且连接成功（匿名 WebDAV）', () async {
+    final WebDavOps ops =
+        WebDavOps(baseUrl: '${dav.origin}/dav', username: '', password: '');
+    await ops.testConnection();
+    ops.close();
+    expect(dav.authHeaders, isNotEmpty);
+    expect(dav.authHeaders.every((String? h) => h == null), isTrue,
+        reason: '匿名 WebDAV 请求不应带 Authorization 头');
+  });
+
+  test('有用户名密码 → 照发 Basic 头（行为不变）', () async {
+    final WebDavOps ops = WebDavOps(
+        baseUrl: '${dav.origin}/dav', username: 'reader', password: 'pw');
+    await ops.testConnection();
+    ops.close();
+    expect(dav.authHeaders, isNotEmpty);
+    expect(dav.authHeaders.first, startsWith('Basic '));
+  });
+
+  test('只有密码（用户名空）→ 仍发 Basic 头（非匿名）', () async {
+    final WebDavOps ops = WebDavOps(
+        baseUrl: '${dav.origin}/dav', username: '', password: 'token');
+    await ops.testConnection();
+    ops.close();
+    expect(dav.authHeaders.first, startsWith('Basic '));
+  });
+}


### PR DESCRIPTION
## 问题
用户在「同步与备份 → WebDAV」只填服务器地址、用户名/密码留空，点「测试连接」报 `连接失败: 缺少字段`。匿名 / 无鉴权 WebDAV（局域网自建、本机服务）无法使用。

## 根因（BUG-1015）
1. `backend_config.part.dart` WebDAV `_runTest` 硬校验 `url || username || password` 任一为空即报「缺少字段」——把账密也当必填。
2. `webdav_ops.dart` `_authHeader` 恒构造 `Basic base64('user:pass')` 并每请求必发；空账密发 `Basic base64(':')`，匿名服务器多半仍 401。
3. 同类：`ftp_sync_backend.dart` `_connect` 硬要求 host+username+password 全非 null，连"有用户名无密码"都拦，且与 `testConnection`（放行空账密）不一致 → 匿名 FTP 被 ops 层拦掉，"测试过 / 同步失败"。

## 修改
- WebDAV 校验改为只要求 `url` 非空。
- `WebDavOps._authHeader` 改可空：用户名**和**密码都空 → 不带 `Authorization` 头（真正匿名请求）；任一凭据非空时字节完全不变。
- 新增 `FtpSyncBackend.ftpLoginCredentials` 归一（空用户名→`anonymous`、空密码→`''`），`testConnection` 与 `_connect` 复用，消除不一致、支持匿名 FTP；`isAuthenticated` 只要求 host。
- SFTP（密码/私钥二选一，key-only）与 Hibiki 互联（token 为设备身份，必填合理）不属本 bug，未改。

## 测试
- `test/sync/webdav_ops_anonymous_test.dart`：进程内 HttpServer 端到端断言——空账密不带 Authorization 头且成功；有账密/仅密码时发 `Basic`。
- `test/sync/ftp_anonymous_credentials_test.dart`：`ftpLoginCredentials` 归一单测。
- `flutter analyze` 干净；上述 + 既有 `webdav_ops_test` / `webdav_source_file_system_test` / oauth/obfuscating/utf8/settings 相关测试全绿。

## 待验收
WebDAV 匿名路径已用 mock 端到端验证。**FTP 匿名 live 登录**依赖 `FTPConnect` 对 `user:'anonymous'/pass:''` 的行为，需真实匿名 FTP 服务器真机验收（外部系统，无法本地端到端）；纯凭据归一逻辑已单测覆盖。

https://claude.ai/code/session_01TKv6jaXnoRdP8NLnVVPqiC