### PR TITLE
fix(reader): BUG-1015 白屏加固 + PDF阅读器计划（EPUB白屏待设备复现）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 980 条。点号进各自文件。
+> 共 981 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1015](bugs/BUG-1015-reader-fixed-layout-svg-blank.md) | 🚧 | ✅ | 固定版式SVG竖排EPUB打开白屏·cloak被init同步异常卡住 |
 | [BUG-1013](bugs/BUG-1013-external-window-attach-ready-race.md) | ✅ | ✅ | 外部窗口挖矿在helper就绪前打开共享内存导致降级 |
 | [BUG-1012](bugs/BUG-1012-ext-shadow-dom-lookup.md) | ✅ | ✅ | 浏览器扩展无法读取Shadow DOM内文字(B站评论区) |
 | [BUG-1011](bugs/BUG-1011-interconnect-video-collection-playlist-autoplay.md) | ✅ | ✅ | 互联视频合集列表缺失+无自动连播·客户端合集播放 |

--- a/docs/bugs/BUG-1015-reader-fixed-layout-svg-blank.md
+++ b/docs/bugs/BUG-1015-reader-fixed-layout-svg-blank.md
@@ -1,0 +1,28 @@
+## BUG-1015 · 固定版式SVG竖排EPUB打开白屏·cloak被init同步异常卡住
+
+- **报告**：2026-07-23（用户：这两本书打不开——`風紀委員の破廉恥遊戯.epub` / `[西 条陽] わたし、二番目の彼女でいいから。1.epub`）
+- **真实性**：✅ 真 bug。「上了书架但打开后一片空白」。
+  - **先验伪**：把两本真实文件喂当前 `EpubParser` 真跑（`flutter test`）——解析（34/28 章）、导入、全章 `chapterCharacterCount` 全成功。故 Dart 侧解析/导入管线**没坏**，白屏在打开后的 WebView 渲染层。
+  - **共同特征**：两书 spine 都混了固定版式页 `rendition:layout-pre-paginated`，首个 spine 项是 SVG 整页图封面（`<svg viewBox="0 0 1360 1920"><image xlink:href=.../></svg>` + `<meta name="viewport" content="width=... height=...">`），竖排 `vertical-rl`、零文本节点。纯 reflowable 同类竖排书打开正常。
+  - **根因** `hibiki/lib/src/reader/reader_pagination_scripts.dart:1793-1800`（`_sharedInitBoot`）+ `hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart:1331-1332`（cloak 摘除）：
+    - 每章 HTML 的 `<head>` 注入 `#hoshi-cloak` = `body{visibility:hidden!important}`（防 FOUC，webview.part.dart:309-318）。它**唯一的摘除点**在 reader-setup IIFE（webview.part.dart:546-1333）**尾部** 1331 行。
+    - 分页/连续外壳共享的 boot `_sharedInitBoot` 在 `onLoadStop`（`document.readyState==='complete'` 恒真）下**同步**跑 `window.hoshiReader.initialize()`，且**无 try/catch**。`initialize()`（或紧随其后同步执行的 `$caretInit`/`$furiganaJs`）在固定版式 SVG 竖排零文本页上抛同步异常 → 冲出 IIFE、到不了 1331 → cloak 永留 → 整本书 `visibility:hidden` = **永久白屏**。
+    - Dart 侧加载遮罩（`_readerContentReady`）与 BUG-868 兜底超时**只摘 Dart 遮罩，管不到 WebView 内的 CSS cloak**，故白屏永不消失。
+    - **同类先例**：VN 外壳早已为完全相同的类修好（`reader_visual_novel_scripts.dart:3021-3043` 注释直述「同步 TypeError 中止 IIFE，cloak 没摘，页面 visibility:hidden 白屏」），用 try/catch 包 boot；但分页/连续外壳漏了，用裸 `$_sharedInitBoot`。这两本走分页/连续外壳 → 无保护 → 白屏。
+- **[~] ① 加固已落（对齐 VN 先例），但白屏未在离屏复现、根因待设备确认**（见文末备注）— 两层，消除「cloak 摘除依赖整段 IIFE 不抛」这个脆弱契约：
+  - 主修：`_sharedInitBoot` 经受保护的 `_hoshiBootInitialize()` 用 `try{ initialize() }catch{ console.error }` 包两处触发点（`load` 事件 + `readyState==='complete'`）。异常被就地含住 → IIFE 继续跑到尾部摘 cloak（且 caret/furigana/手势照常安装），并把真错打到 console 供进一步定位。分页/连续外壳共享此 boot，一改两覆盖，与 VN 先例对齐。
+  - 兜底：reader-setup IIFE 顶部排一个幂等 microtask（`Promise.resolve().then(() => getElementById('hoshi-cloak')?.remove())`）无条件摘 cloak——无论同步抛点在 boot 还是 caret/furigana 还是别处，microtask 在本 task 展开后仍执行，保证可见；尾部同步摘除保留为快路径（幂等）。
+  - 提交见本轮 commit。
+- **[x] ② 已加自动化测试** —
+  - 源码守卫 `hibiki/test/pages/reader_fixed_layout_blank_cloak_guard_static_test.dart`：断言 ① `_sharedInitBoot` 经 `_hoshiBootInitialize` 用 try/catch+console.error 包 `initialize()`、两处触发都走受保护 boot；② webview IIFE 顶部有幂等 microtask 兜底摘 `hoshi-cloak` + 尾部快路径两处。删掉任一保护即红。（ReaderHibikiPage 过重无法在 widget test 拉起跑该 boot，落最强可落地的源码语料层，与 BUG-868 守卫同纪律。）
+  - 运行时验证 `hibiki/integration_test/bug1015_fixed_layout_blank_verify_itest.dart`：Windows 离屏 runner 导入两本真实固定版式书 → 打开 → CDP 抓 WebView 正文断言 `nonBlank`（白屏检测），并把 `[HoshiReader] boot initialize failed` console 落 runner stdout。
+- **备注 / 验证现状（如实，⚠️ 修复未被证明打中用户实况）**：
+  - 离屏 Windows runner（`.codex-test/windows-itest/`）导入真书、切书架、`debugOpenBook` 打开、同时抓 WebView 正文（CDP）+ Flutter 帧（=用户所见）：
+    - 两本「打不开」书 + 一本 reflowable **对照书**（`負けヒロインが多すぎる！1.epub`，用户报打开**正常**）——**三本全 `WEBVIEW nonBlank=true` 且 `FLUTTER nonBlank=true`**，`[HoshiInit]` 有、无 `[HoshiReader] boot initialize failed`、console 无 error。**还原 fix 的基线运行结果完全相同。**
+    - 三本（含正常对照书）**都** `openMedia timed out`（20s）→ 该超时是**离屏通用假象**（openMedia await 的东西在 headless 下不回传），**不是固定版式书特有**，排除为红鲱鱼。
+  - **结论**：**用户的白屏在「离屏 Windows + 全新打开」下完全不复现**——两本「打不开」的书在此环境与正常对照书**行为一致**（都正常渲染，WebView 与 Flutter 帧皆非白）。故「零文本 SVG 封面页 initialize() 同步抛异常 → cloak 卡住白屏」的初始假设在离屏 Windows **被证伪**。
+  - ① 的两层修复是**对齐 VN 先例的正确加固**（消除「cloak 摘除依赖整段 IIFE 不抛」的脆弱契约，幂等无副作用、`flutter analyze` 干净、守卫测试绿），保留有价值；**但尚未被证明修掉用户的白屏**。
+  - **必须向用户确认才能定位的下一步**：看到白屏的**设备**——
+    - **Android**（最可疑）：WebView 内核不同 + 文件系统**大小写敏感**。`二番目` 封面 xhtml 引用 `../Images/embed0022_HD.jpg`（大写 Images/HD），但 `EpubParser._itemRelHref` 经 `p.canonicalize` 在 Windows 会小写化、Android 保留原样——若某处 case 失配则整页资源 404 → 白屏。这条只有在 Android 真机（adb 可跑）才复现。
+    - **Windows app**（用户实机 WebView2 版本/GPU 与离屏 runner 不同）。
+    - 以及**时机**：首次打开 / 读过一段有保存进度后（VN 那条同类 bug 正是 restore-by-charOffset；本次离屏测试是 saved=null 全新打开，未走 restore）。

--- a/docs/specs/pdf-reader-lookup/plan.md
+++ b/docs/specs/pdf-reader-lookup/plan.md
@@ -1,0 +1,72 @@
+# PDF 阅读器 + 文本层查词 —— 实现计划
+
+> 状态：**待用户确认**。用户已选「做正经 PDF 阅读器 + 文本层查词」方案（非 PDF→EPUB 降级）。
+> 本文件是动手前的计划（对应 CLAUDE.md 工作流步骤 1）。确认后再进入实现。
+
+## 目标
+
+在 Hibiki 里新增一种「PDF 书」：真渲染 PDF 页面，点选日语文字→查词→（复用现有）弹词典/制卡/朗读，
+阅读进度按页码保存。首个验收样本：`prince.pdf`（文本 PDF、内嵌字体、无图、横排）。
+
+不在本期范围：扫描图 PDF 的 OCR（无文本层的 PDF 判定为「无法查词」并提示）。
+
+## 核心判断（Linus 式）
+
+- **值得做**：用户明确要；且 Hibiki 的查词/制卡/书架/进度基础设施几乎全可复用，PDF 只是「第二种书身份」。
+- **关键数据结构**：`bookKey` 是全系统书身份轴，`ReaderPositions.sectionIndex` 泛化成「页码」即承接 PDF 进度，
+  `computeBookProgress` 在「全书字数为 0」时已回退到 `sectionIndex/chapterCount` 章级比例——**进度模型几乎零改**。
+- **消除特殊情况**：PDF 作为 `EpubBooks` 表的一行（加 `format` 判别列），复用 `ReaderPositions`/`Bookmarks`/
+  书架 provider/删除事务/墓碑，避免另建平行表打断 `Bookmarks` 外键与整套管线。
+- **查词本质同构**：pdfrx 给「屏幕点→字符索引→子串」，`AppModel.searchDictionary` 给「子串→最长日语词」，
+  两段拼起来就是点选查词，**不需要 PDF 侧做词切分**（与 EPUB 划词等价）。
+
+## 选型
+
+- **渲染库：pdfrx**（`espresso3389/pdfrx`，MIT；底层 PDFium BSD-3）。唯一同时满足
+  「五平台 + 现成 Flutter widget + 暴露**字符级文本坐标**(`loadStructuredText()` 的 `charRects`) + 可编程选区」。
+  - Android/Linux/Windows：Dart native assets（构建期链接 PDFium）。
+  - iOS/macOS：CocoaPods/SwiftPM 链接 PDFium XCFramework。
+- 淘汰：pdfx（仅位图无文本层）、flutter_pdfview（无文本层）、syncfusion（商业许可 + 选区 API 弱）。
+
+## 集成锚点（file:line）
+
+- 查词入口（复用零改）：`hibiki/lib/src/pages/base_source_page.dart:211`
+  `searchDictionaryResult({searchTerm, selectionRect, ...})` → `AppModel.searchDictionary`
+  (`hibiki/lib/src/models/app_model.dart:3233`) → 弹窗栈/朗读/加载更多。PDF 页 tap 后组装
+  `searchTerm`+`selectionRect` 调它即可。
+- 媒体源范本：`hibiki/lib/src/media/sources/reader_hibiki_source.dart`（照抄写 `ReaderPdfSource`）；
+  抽象：`media_source.dart` / `media_type.dart` / `source_types/reader_media_source.dart` /
+  `types/reader_media_type.dart`。PDF 归到**同一个 `ReaderMediaType`**（同一书 tab / 书架）作并列 source。
+- 导入：`hibiki/lib/src/media/audiobook/book_import_dialog.dart` 扩展名白名单加 `pdf` + `_importPdf` 分支；
+  平行写一个轻量 PDF importer（探测页数、抽首页缩略图当封面、落库），不复用 EPUB 解压。
+- 数据：`packages/hibiki_core/lib/src/database/tables.dart`（`EpubBooks:284` / `ReaderPositions:104` /
+  `Bookmarks:118`）。加 schema v51：`EpubBooks` 增 `TextColumn format`（`withDefault('epub')`，老行零破坏）。
+  PDF 行 `format='pdf'`、`chapterCount`=页数、进度 `sectionIndex:=pageIndex`。
+
+## 主要风险
+
+1. **【高】pdfrx native-assets 五平台构建**（Android/Linux/Windows native assets；iOS/mac CocoaPods XCFramework）。
+   必须 **Phase 0 先在五平台各出一次包验证**，尤其远程 Mac（cocoapods 1.12.1 钉版）与 Windows（与现有
+   CMake 下载/代理并存，走 `127.0.0.1:34151`）。**这是能否落地的决定性前提。**
+2. **【中】竖排日语文本抽取顺序**：PDFium 对 tategaki 字符顺序可能非视觉序，句子提取（制卡）需按 charRects
+   几何重排；横排（prince.pdf）无此问题。
+3. **【中】EPUB 专属路径门控**：复用 EpubBooks 方案下，`epub_parser`/spread/WebView 拦截/BookCustomCss 必须按
+   `format` 早退，漏一处会让 PDF 行走进 EPUB 解压逻辑崩溃 → 加源码扫描守卫测试。
+4. **【低】扫描图 PDF 无文本层**：按 `fragments` 为空判定并禁用查词提示，不做 OCR。
+
+## 阶段拆分
+
+- **Phase 0（spike，最高优先）**：加 pdfrx 依赖，`prince.pdf` 在 Android + Windows + 一台 Apple 上渲染 +
+  native-assets 五平台构建全绿。**先打通构建再谈功能。**
+- **Phase 1**：`ReaderPdfSource` + `format` 列（schema v51）+ PDF importer（页数/封面/落库）+ 书架出书 + 打开渲染。
+- **Phase 2**：点选查词 tap→`globalToDocument`→page→charIndex→`fullText.substring`→`searchDictionaryResult`；
+  `charRects`→`selectionRect` 锚点 + 选区高亮。
+- **Phase 3**：页码进度写 `ReaderPositions.sectionIndex` + resume + 书架百分比（复用 `computeBookProgress`）。
+- **Phase 4**：制卡（`fullText` 标点分句 + 页位图裁剪当图 + 接 creator/mining）。
+- **Phase 5**：打磨（Bookmarks 复用、TOC 用 pdfrx outline、竖排处理、阅读设置）。
+
+## 待确认点（给用户）
+
+1. Phase 0 是否先做（构建 spike）——建议**是**，风险 1 决定成败，先花小代价验证五平台可编译再投功能。
+2. 竖排 PDF 支持优先级：先只保证横排（prince.pdf）查词，竖排排序留 Phase 5？（建议是）
+3. 是否本期就要制卡（Phase 4），还是先查词+阅读（Phase 0-3）验收后再说？

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -544,6 +544,16 @@ extension _ReaderWebView on _ReaderHibikiPageState {
 
     return '''
 (function() {
+  // BUG-1015: guarantee the `#hoshi-cloak` FOUC guard is always removed, even if
+  // any synchronous statement in this setup IIFE throws before the tail reaches
+  // its removal (below). Without this a single unhandled sync error anywhere in
+  // setup (init / caret / furigana) left `body{visibility:hidden}` stranded =
+  // permanent blank book. The microtask runs after this task unwinds whether it
+  // completed or threw; the tail removal stays as the fast synchronous path, and
+  // this reveal is idempotent (a second remove() on an absent node is a no-op).
+  Promise.resolve().then(function() {
+    try { var c = document.getElementById('hoshi-cloak'); if (c) c.remove(); } catch (_ignored) {}
+  });
   window.scanNonJapaneseText = ${appModel.scanNonJapaneseText};
   $selectionJs
   $paginationJs

--- a/hibiki/lib/src/reader/reader_pagination_scripts.dart
+++ b/hibiki/lib/src/reader/reader_pagination_scripts.dart
@@ -1790,12 +1790,30 @@ $blurFn
 ''';
   }
 
+  // BUG-1015: `initialize()` runs synchronously inside the outer reader-setup
+  // IIFE (webview.part.dart), whose tail removes the `#hoshi-cloak`
+  // `body{visibility:hidden}` FOUC guard. A synchronous throw in initialize()
+  // (e.g. on a fixed-layout SVG vertical cover page with zero text nodes)
+  // aborted the IIFE before its tail, stranding the cloak -> the whole book
+  // stayed `visibility:hidden` (permanent blank). The VN shell already guards
+  // its boot for exactly this reason (reader_visual_novel_scripts.dart) but the
+  // paginated / continuous shells used a bare call. Contain the throw here so
+  // the IIFE always reaches its cloak removal (and later caret / furigana /
+  // gesture setup still installs), and surface the real error on the console so
+  // the underlying init failure can still be diagnosed and fixed.
   static const String _sharedInitBoot = '''
+function _hoshiBootInitialize() {
+  try {
+    window.hoshiReader.initialize();
+  } catch (e) {
+    try { if (window.console && console.error) console.error('[HoshiReader] boot initialize failed', e); } catch (_ignored) {}
+  }
+}
 window.addEventListener('load', function() {
-  window.hoshiReader.initialize();
+  _hoshiBootInitialize();
 });
 if (document.readyState === 'complete') {
-  window.hoshiReader.initialize();
+  _hoshiBootInitialize();
 }
 ''';
 

--- a/hibiki/test/pages/reader_fixed_layout_blank_cloak_guard_static_test.dart
+++ b/hibiki/test/pages/reader_fixed_layout_blank_cloak_guard_static_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1015 源码守卫：固定版式 SVG 竖排 EPUB 打开一片空白。
+///
+/// 根因 = 每章 HTML 注入的 `#hoshi-cloak`（`body{visibility:hidden}` 防 FOUC）唯一的摘除点
+/// 在 reader-setup IIFE（webview.part.dart）尾部。分页/连续外壳的 boot（reader_pagination_scripts
+/// 的 `_sharedInitBoot`）在 `readyState==='complete'`（onLoadStop 恒真）下**同步**跑
+/// `initialize()`，且**无 try/catch**。固定版式 SVG 竖排零文本封面页上 `initialize()` 抛同步异常
+/// → 冲出 IIFE、到不了尾部 → cloak 永留 → 整本书 `visibility:hidden` = 永久白屏。
+/// （VN 外壳早已用 try/catch 包 boot 修好同类，见 reader_visual_novel_scripts.dart；分页/连续漏了。）
+///
+/// 修复两层：
+/// ① `_sharedInitBoot` 经 `_hoshiBootInitialize` 用 try/catch 包 `initialize()` 并 console.error
+///    暴露真错——异常被就地含住，IIFE 继续跑到尾部摘 cloak。分页/连续外壳共享此 boot，一改两覆盖。
+/// ② webview.part.dart 的 setup IIFE 顶部排一个幂等 microtask 无条件摘 `hoshi-cloak`，兜底任意抛点
+///    （caret/furigana 等），彻底消除「cloak 依赖整段 IIFE 不抛」这个脆弱契约。
+///
+/// 守卫落在最强可靠可落地的源码语料层（ReaderHibikiPage 过重无法在 widget test 拉起跑该 boot，
+/// 与 reader_* 一系列 *_static_test / BUG-868 守卫同纪律）。删掉任一保护即红。
+void main() {
+  String read(String rel) {
+    final File f = File(rel);
+    expect(f.existsSync(), isTrue, reason: '文件不存在：$rel');
+    return f.readAsStringSync().replaceAll('\r\n', '\n');
+  }
+
+  test('分页/连续外壳共享的 boot 必须 try/catch 包 initialize()（BUG-1015 ①）', () {
+    final String src = read('lib/src/reader/reader_pagination_scripts.dart');
+
+    // 定位 `_sharedInitBoot` 常量体。
+    final int start = src.indexOf("static const String _sharedInitBoot = '''");
+    expect(start, greaterThan(-1), reason: '找不到 _sharedInitBoot');
+    final int end = src.indexOf("''';", start);
+    expect(end, greaterThan(start), reason: 'boot 常量未闭合');
+    final String boot = src.substring(start, end);
+
+    // boot 定义受保护的 `_hoshiBootInitialize`：try 里调 initialize()，catch 里 console.error。
+    expect(boot.contains('function _hoshiBootInitialize()'), isTrue,
+        reason: 'boot 必须经受保护的 _hoshiBootInitialize 调用 initialize()');
+    expect(boot.contains('try {'), isTrue,
+        reason: 'boot 必须 try 包 initialize()');
+    expect(boot.contains('window.hoshiReader.initialize();'), isTrue,
+        reason: 'boot 仍要调 initialize()');
+    expect(boot.contains('} catch (e) {'), isTrue,
+        reason: 'boot 必须 catch 住 initialize() 的同步抛（否则冲出 IIFE 卡 cloak）');
+    expect(boot.contains('console.error'), isTrue,
+        reason: 'boot catch 必须 console.error 暴露真错供定位');
+    // 裸调用（不经 _hoshiBootInitialize）会绕过保护 —— boot 里两处触发都必须走它
+    // （带分号的调用点，排除 `function _hoshiBootInitialize()` 定义本身）。
+    expect(RegExp(r'_hoshiBootInitialize\(\);').allMatches(boot).length, 2,
+        reason: 'load 事件与 readyState==="complete" 两处都必须走受保护的 boot');
+  });
+
+  test('reader-setup IIFE 必须无条件兜底摘 hoshi-cloak（BUG-1015 ②）', () {
+    final String src =
+        read('lib/src/pages/implementations/reader_hibiki/webview.part.dart');
+
+    // 顶部幂等 microtask 兜底摘 cloak：Promise.resolve().then 里 getElementById('hoshi-cloak').remove()。
+    final int iifeStart = src.indexOf("return '''\n(function() {");
+    expect(iifeStart, greaterThan(-1), reason: '找不到 reader-setup IIFE');
+    final String iife = src.substring(iifeStart);
+    expect(iife.contains('Promise.resolve().then(function() {'), isTrue,
+        reason: 'IIFE 顶部必须排 microtask 兜底（任意抛点后仍摘 cloak）');
+    expect(
+        RegExp(r"getElementById\('hoshi-cloak'\)").allMatches(iife).length >= 2,
+        isTrue,
+        reason: '兜底 microtask 与尾部快路径两处都要摘 hoshi-cloak');
+  });
+}


### PR DESCRIPTION
## 用户报告
1. 两本固定版式 SVG 竖排 EPUB「上了书架但打开后一片空白」（`風紀委員の破廉恥遊戯` / `わたし、二番目の彼女でいいから。1`）。
2. `prince.pdf` 支持 PDF 文字查词导入 → 用户选「做正经 PDF 阅读器 + 文本层查词」。

## 本 PR 内容

### ① EPUB 白屏（BUG-1015）— 加固已落，⚠️ 但白屏未复现、根因待设备确认
- **已验证正常**：两本书 `EpubParser` 解析（34/28 章）、导入、全章文字计数全成功 → Dart 侧管线没坏。
- **加固**（`reader_pagination_scripts.dart` + `webview.part.dart`）：分页/连续外壳的 boot 同步跑 `initialize()` 无 try/catch，若在固定版式零文本页抛同步异常会冲出 reader-setup IIFE、到不了尾部摘除 `#hoshi-cloak` → 永久 `visibility:hidden` 白屏。VN 外壳早已为同类用 try/catch 修好，分页/连续漏了。两层修：boot try/catch + IIFE 顶部幂等 microtask 无条件摘 cloak。守卫测试 `reader_fixed_layout_blank_cloak_guard_static_test`。
- **⚠️ 诚实结论**：离屏 Windows runner 导入两本「打不开」书 + 一本 reflowable 对照书（用户报正常），**三本全部 WebView 正文 + Flutter 帧皆非白、行为一致**；还原 fix 的基线结果相同。→ **用户白屏在离屏 Windows 全新打开下不复现**，本加固正确但**未被证明修掉用户实况**。真实根因待确认**设备**（疑 Android 大小写敏感 FS——`二番目` 封面 `../Images/embed0022_HD.jpg` 被 parser 小写化会失配；或有保存进度的 restore 路径）后在对的平台复现。

### ② PDF 阅读器 + 文本层查词 — 仅计划（`docs/specs/pdf-reader-lookup/plan.md`），待确认后实现
选型 pdfrx（MIT/PDFium/五平台/字符级文本矩形）；PDF 作 `EpubBooks` 一行（加 `format` 列 schema v51）复用书架/进度/查词/制卡；Phase 0 先打通 native-assets 五平台构建。**未动代码。**

## 验证
- `flutter analyze` 干净；`test/reader test/pages test/epub` 全 3364 通过。
- 离屏证据 `.codex-test/windows-itest/`（不入库）。

https://claude.ai/code/session_0161NSA13H4kt34ZKoYQYAUW