### PR TITLE
fix(library): 改名全面生效 + profile 停止吞听书进度/倍速

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 981 条。点号进各自文件。
+> 共 983 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1016](bugs/BUG-1016-profile-swallows-audiobook-progress.md) | ✅ | ✅ | profile 切换吞听书进度/倍速：进度型 pref 被快照/prune/回灌 |
+| [BUG-1015](bugs/BUG-1015-rename-not-applied-everywhere.md) | ✅ | ✅ | 改名/改作者不生效：override title 消费面缺口 + 作者保存不刷新 + SRT 空 bookKey 互踩 + profile 吞 override |
 | [BUG-1014](bugs/BUG-1014-global-lookup-card-corner-asymmetry.md) | 🚧 | 🚧 | 查词浮窗卡片左侧圆角右侧直角 |
 | [BUG-1013](bugs/BUG-1013-external-window-attach-ready-race.md) | ✅ | ✅ | 外部窗口挖矿在helper就绪前打开共享内存导致降级 |
 | [BUG-1012](bugs/BUG-1012-ext-shadow-dom-lookup.md) | ✅ | ✅ | 浏览器扩展无法读取Shadow DOM内文字(B站评论区) |

--- a/docs/bugs/BUG-1015-rename-not-applied-everywhere.md
+++ b/docs/bugs/BUG-1015-rename-not-applied-everywhere.md
@@ -1,0 +1,11 @@
+## BUG-1015 · 改名/改作者不生效：override title 消费面缺口 + 作者保存不刷新 + SRT 空 bookKey 互踩 + profile 吞 override
+- **报告**：2026-07-23（用户：改名/改作者保存后到处不生效）
+- **真实性**：✅ 真 bug，四条独立根因（合一档）：
+  - **A1 消费面缺口**：override title 只在书架 EPUB 卡 / SRT 卡（`hibiki/lib/src/pages/implementations/reader_history/books.part.dart:57` 经 `getDisplayTitleFromMediaItem`）/ 长按对话框三处生效；首页「继续」区直接用 `item.title`（`home_dashboard_page.dart:349`）、活动时间轴直接用 `entry.title`（`home_dashboard_page.dart:693`）、阅读统计页书名列直接用 `book.title`（`reading_statistics_page.dart:1183`）、听书通知元数据直接读 DB 原名（`audiobook_session_launcher.dart:168` / `:102`），全都显示旧名。
+  - **A2 改作者写库成功但 UI 不刷新**：作者真写 `epubBooks.author`（`database.dart:3971-3976`），但书架 provider 的响应源 `_epubBookKeysProvider` 按 key 集合去重（`reader_hibiki_source.dart:27-33`，注释明说纯列更新不触发），编辑对话框 `executeSave` 只 `refreshTab()` 不 invalidate `hibikiBooksProvider`（`media_item_edit_dialog_page.dart:169-197`）。
+  - **A3 独立 SRT 书（bookKey 空串哨兵）身份坍缩**：所有 standalone SRT 书共享 `mediaIdentifierFor('')` == `hoshi://book/`（`books.part.dart:146`）→ override 书名/封面互相踩；作者保存 `parseBookKey==null` 静默 no-op（`reader_hibiki_source.dart:259-261`）。
+  - **A4 profile 切换吞 override**：`override_title://` pref 不在 `ProfileKeys` 排除清单（`profile_keys.dart:26-70`），profile 切换 snapshot/prune 时被吞掉/回灌旧值。
+  - 附带：`setOverrideThumbnailFromMediaItem` 无条件 `createSync`（`media_source.dart:531`），没选新图也留 0 字节 override 封面文件，读取端只查 `existsSync`（`media_source.dart:475`）→ 编辑保存后封面变损坏占位。
+- **[x] ① 已修复** — commit `15c8b77b7`：A1 加 `ReaderHibikiSource.overrideTitleForBookKey/overrideTitleForSrtUid` 统一 helper，首页「继续」区、活动时间轴（仅渲染层替换，events 落库仍存原名）、阅读统计页、听书通知全部接上；A2 `executeSave` 保存后 invalidate `hibikiBooksProvider`/`srtBooksProvider`；A3 standalone SRT 身份改 `hoshi://srtbook/<uid>`、作者真实写穿 `srt_books.author`；A4 `ProfileKeys.isExcludedPref` 增加 `override_title://` 子串排除；附带封面只在真选图/明确清除时写盘。
+- **[x] ② 已加自动化测试** — commit `15c8b77b7`：`hibiki/test/profile/profile_keys_test.dart`（override_title 排除）、`hibiki/test/media/override_identity_test.dart`（SRT 身份唯一性 + 作者写穿 + 封面无新图不落文件）、`hibiki/test/pages/home_dashboard_page_test.dart`（「继续」区显示 override 名）。
+- **备注**：互联远端条目（RemoteContinueCandidate / 远端活动行）标题来自对端，不在本地 override 范围；旧 standalone SRT 书挂在空 key 上的共享 override 不迁移（本就互踩、无单书归属），改身份后自然失效；方案 3（EpubBooks 加 displayTitle 列真改名）本轮不做。

--- a/docs/bugs/BUG-1016-profile-swallows-audiobook-progress.md
+++ b/docs/bugs/BUG-1016-profile-swallows-audiobook-progress.md
@@ -1,0 +1,6 @@
+## BUG-1016 · profile 切换吞听书进度/倍速：进度型 pref 被快照/prune/回灌
+- **报告**：2026-07-23（用户：听书「速度飞快但进度 0」）
+- **真实性**：✅ 真 bug。听书进度/倍速等全存 prefs（`audiobook_pos_/pos_at_/speed_/follow_/delay_/volume_/image_pause_/health_overlay_` 前缀 + bookKey，`packages/hibiki_audio/lib/src/audiobook/audiobook_repository.dart:76-111`）。`backup_service.dart:563` 把 `audiobook_pos_*` 当 progress 类数据，但 profile 系统把它们全当**设置**：`ProfileKeys.isExcludedPref`（`profile_keys.dart:63-70`）不排除 → snapshot 收进快照、applyProfile prune 删掉不在目标快照的 pref（`profile_repository.dart:209-213`）、再把旧快照值回灌。开书自动切 profile（`reader_hibiki/audiobook.part.dart:129-166`）后果：同一次 applyProfile 里进度 pref 被 prune（**进度 0**）+ 倍速被旧快照顶掉（**速度飞快**）——两个 key 两种命运。
+- **[x] ① 已修复** — commit `15c8b77b7`：`ProfileKeys._excludedPrefPrefixes` 增加全部 8 个 `audiobook_*_` 每书前缀（进度/内容型=排除；判定与 backup_service 的 progress≠settings 口径对齐），snapshot/prune 经同一 `isExcludedPref` 单一真相源自动生效；`applyProfile` 对**旧快照里已存在的**排除键残值跳过回灌（`prefMap.removeWhere`，不写不删、不迁移数据）。
+- **[x] ② 已加自动化测试** — commit `15c8b77b7`：`hibiki/test/profile/profile_keys_test.dart`（8 前缀排除）、`hibiki/test/profile/profile_repository_test.dart`（快照不含进度键；apply 不 prune 活进度、不回灌旧快照 speed 残值、正常键照常还原）。
+- **备注**：旧 profile 快照里的 `audiobook_*` 残行留在 `profile_settings` 表中（apply 时被跳过，无害），不做数据迁移；阅读偏好型 reader 设置仍随 profile 走，不受影响。

--- a/hibiki/lib/src/media/audiobook/audiobook_session_launcher.dart
+++ b/hibiki/lib/src/media/audiobook/audiobook_session_launcher.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:hibiki/src/media/audiobook/audiobook_session.dart';
+import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
@@ -58,7 +59,10 @@ class AudiobookSessionLauncher {
       info: SessionBookInfo(
         bookKey: bookKey,
         audiobook: audiobook,
-        title: title,
+        // BUG-1015 (A1)：通知/悬浮窗元数据走与书架同一 override 书名通道，
+        // 编辑对话框改名后媒体通知同步显示新名；无 override 回退 DB 原名。
+        title: ReaderHibikiSource.instance.overrideTitleForBookKey(bookKey) ??
+            title,
         mediaIdentifier: 'hoshi://book/$bookKey',
         isSrtBookSource: false,
         author: author,
@@ -95,11 +99,17 @@ class AudiobookSessionLauncher {
     final SrtBookRepository srtRepo = SrtBookRepository(_db);
     final List<AudioCue> cues = await srtRepo.cuesFor(key);
 
+    // BUG-1015 (A1)：override 书名按身份取——EPUB 配对行挂在 bookKey 身份上，
+    // standalone SRT 书挂在 `hoshi://srtbook/<uid>` 身份上（A3）。
+    final String? overrideTitle = srtBook.bookKey.isNotEmpty
+        ? ReaderHibikiSource.instance.overrideTitleForBookKey(srtBook.bookKey)
+        : ReaderHibikiSource.instance.overrideTitleForSrtUid(srtBook.uid);
+
     return AudiobookSessionStartRequest(
       info: SessionBookInfo(
         bookKey: key,
         audiobook: synthetic,
-        title: srtBook.title,
+        title: overrideTitle ?? srtBook.title,
         mediaIdentifier: 'hoshi://book/'
             '${srtBook.bookKey.isNotEmpty ? srtBook.bookKey : key}',
         isSrtBookSource: true,

--- a/hibiki/lib/src/media/media_source.dart
+++ b/hibiki/lib/src/media/media_source.dart
@@ -527,11 +527,17 @@ abstract class MediaSource {
       item: item,
     );
 
+    // BUG-1015 (附带): only touch the disk when there is an actual change. The
+    // old unconditional createSync left a 0-byte override file behind on every
+    // "save without picking a new image", and getOverrideThumbnailFromMediaItem
+    // gates only on existsSync — so the cover then rendered as a broken blank.
     File thumbnailFile = File(filename);
-    thumbnailFile.createSync(recursive: true);
     if (clearOverrideImage) {
-      thumbnailFile.deleteSync();
+      if (thumbnailFile.existsSync()) {
+        thumbnailFile.deleteSync();
+      }
     } else if (file != null) {
+      thumbnailFile.parent.createSync(recursive: true);
       file.copySync(filename);
     }
   }

--- a/hibiki/lib/src/media/sources/reader_hibiki_source.dart
+++ b/hibiki/lib/src/media/sources/reader_hibiki_source.dart
@@ -243,6 +243,56 @@ class ReaderHibikiSource extends ReaderMediaSource {
     return bookKey;
   }
 
+  /// BUG-1015 (A3): standalone SRT books (empty bookKey sentinel) need their
+  /// OWN media identity. They previously all shared `mediaIdentifierFor('')`
+  /// == `hoshi://book/`, so every standalone SRT book's override title/cover
+  /// landed on the same preference key and stomped each other, and the author
+  /// save silently no-opped (parseBookKey returned null). Their identity is
+  /// the stable `SrtBook.uid` under a distinct prefix that can never collide
+  /// with a sanitized EPUB bookKey identifier.
+  static const String _srtBookIdentifierPrefix = 'hoshi://srtbook/';
+
+  static String mediaIdentifierForSrtUid(String uid) =>
+      '$_srtBookIdentifierPrefix$uid';
+
+  /// Inverse of [mediaIdentifierForSrtUid]; null for non-SRT identifiers.
+  static String? parseSrtBookUid(String identifier) {
+    if (!identifier.startsWith(_srtBookIdentifierPrefix)) return null;
+    final String uid = identifier.substring(_srtBookIdentifierPrefix.length);
+    if (uid.isEmpty) return null;
+    return uid;
+  }
+
+  /// BUG-1015 (A1): resolve the user's override display title for a book by
+  /// its stable [bookKey], for surfaces that don't hold a full [MediaItem]
+  /// (home continue/activity rows, reading statistics, audiobook notification
+  /// metadata). Single source of truth: the same preference the edit dialog
+  /// writes via [setOverrideTitleFromMediaItem]. Returns null when the user
+  /// never renamed the book (callers fall back to the DB title).
+  String? overrideTitleForBookKey(String bookKey) {
+    if (bookKey.isEmpty) return null;
+    return _overrideTitleForIdentifier(mediaIdentifierFor(bookKey));
+  }
+
+  /// [overrideTitleForBookKey]'s standalone-SRT sibling (identity = uid).
+  String? overrideTitleForSrtUid(String uid) {
+    if (uid.isEmpty) return null;
+    return _overrideTitleForIdentifier(mediaIdentifierForSrtUid(uid));
+  }
+
+  String? _overrideTitleForIdentifier(String mediaIdentifier) {
+    return getOverrideTitleFromMediaItem(MediaItem(
+      mediaIdentifier: mediaIdentifier,
+      title: '',
+      mediaTypeIdentifier: mediaType.uniqueKey,
+      mediaSourceIdentifier: uniqueKey,
+      position: 0,
+      duration: 1,
+      canDelete: false,
+      canEdit: true,
+    ));
+  }
+
   /// BUG-220: EPUB books carry an editable author column, so expose author
   /// editing in the media edit dialog.
   @override
@@ -251,15 +301,31 @@ class ReaderHibikiSource extends ReaderMediaSource {
   /// BUG-220: persist the edited author directly to the `epubBooks.author`
   /// column (NOT the primary key, so no re-key is needed — unlike the title,
   /// which is overridden via a preference). A blank author clears the column.
+  ///
+  /// BUG-1015 (A3): standalone SRT books (identity `hoshi://srtbook/<uid>`)
+  /// write through to the `srt_books.author` column instead of silently
+  /// no-opping like the old empty-bookKey identifier did.
   @override
   Future<void> setAuthorFromMediaItem({
     required MediaItem item,
     required String? author,
   }) async {
-    final String? bookKey = parseBookKey(item.mediaIdentifier);
     final HibikiDatabase? db = sharedDatabase;
-    if (bookKey == null || db == null) return;
-    await db.updateEpubBookAuthor(bookKey, author);
+    if (db == null) return;
+    final String? bookKey = parseBookKey(item.mediaIdentifier);
+    if (bookKey != null) {
+      await db.updateEpubBookAuthor(bookKey, author);
+      return;
+    }
+    final String? srtUid = parseSrtBookUid(item.mediaIdentifier);
+    if (srtUid == null) return;
+    final SrtBookRepository repo = SrtBookRepository(db);
+    final SrtBook? book = await repo.findByUid(srtUid);
+    if (book == null) return;
+    // Mirror updateEpubBookAuthor's blank-clears semantics.
+    final String trimmed = (author ?? '').trim();
+    book.author = trimmed.isEmpty ? null : trimmed;
+    await repo.save(book);
   }
 
   @override

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -346,7 +346,9 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
             ((item.position / item.duration) * 100).clamp(0, 100).round();
         entries.add(_ContinueEntry(
           isVideo: false,
-          title: item.title,
+          // BUG-1015 (A1)：书名走与书架卡同一 override 通道（编辑对话框改名后
+          // 首页「继续」区同步显示新名），不直接读 DB 原名。
+          title: ReaderHibikiSource.instance.getDisplayTitleFromMediaItem(item),
           recentMs: recent,
           percent: percent,
           book: item,
@@ -690,7 +692,7 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
                   Text(
-                    entry.title,
+                    _activityDisplayTitle(entry),
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                     style: tokens.type.listTitle,
@@ -709,6 +711,21 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
         ),
       ),
     );
+  }
+
+  /// BUG-1015 (A1)：活动条**渲染时**应用书的 override 书名（编辑对话框改名后时间轴
+  /// 同步显示新名）。events 落库仍存 DB 原名（历史数据身份，聚合键不变），只在这里
+  /// 按 [ActivityEntry.mediaKey]（书=bookKey）查 override 替换显示。
+  String _activityDisplayTitle(ActivityEntry entry) {
+    if (entry.mediaType == kActivityMediaBook) {
+      final String? bookKey = entry.mediaKey;
+      if (bookKey != null && bookKey.isNotEmpty) {
+        final String? override =
+            ReaderHibikiSource.instance.overrideTitleForBookKey(bookKey);
+        if (override != null) return override;
+      }
+    }
+    return entry.title;
   }
 
   /// 点击活动条：read → 书架 tab；added-book → 书架；其余（watch/added-video/game）→ 视频 tab。

--- a/hibiki/lib/src/pages/implementations/media_item_edit_dialog_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_item_edit_dialog_page.dart
@@ -191,6 +191,16 @@ class _MediaItemEditDialogPageState
         );
       }
 
+      // BUG-1015 (A2): the shelf's reactive source (_epubBookKeysProvider)
+      // dedupes by key set, so a pure column update like the author write above
+      // never re-fires it — refreshTab() alone re-renders stale cached
+      // MediaItems and the edit looks like it "did not save". Invalidate the
+      // book providers so the shelf re-reads the DB rows.
+      if (mediaSource is ReaderHibikiSource) {
+        ref.invalidate(hibikiBooksProvider);
+        ref.invalidate(srtBooksProvider);
+      }
+
       navigator.pop();
       navigator.pop();
       mediaSource.mediaType.refreshTab();

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -143,8 +143,18 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     final ({int position, int duration})? prog =
         _epubProgressByBookKey[book.bookKey];
     return MediaItem(
-      mediaIdentifier: ReaderHibikiSource.mediaIdentifierFor(book.bookKey),
+      // BUG-1015 (A3)：standalone SRT 书（bookKey 空串哨兵）用自己的稳定身份
+      // `hoshi://srtbook/<uid>`——以前所有 standalone SRT 书共享
+      // mediaIdentifierFor('')，override 书名/封面互相踩、作者保存静默 no-op。
+      // EPUB 配对行照旧走 bookKey 身份（与 EPUB 卡同源，进度/override 共享）。
+      mediaIdentifier: book.bookKey.isNotEmpty
+          ? ReaderHibikiSource.mediaIdentifierFor(book.bookKey)
+          : ReaderHibikiSource.mediaIdentifierForSrtUid(book.uid),
       title: book.title,
+      // BUG-1015 (A3)：standalone SRT 书作者列真值在 srt_books.author，回填供
+      // 编辑对话框预填/保存往返。EPUB 配对行作者真值在 epubBooks.author（编辑
+      // 保存按 bookKey 写穿），此处不冒充。
+      author: book.bookKey.isEmpty ? book.author : null,
       mediaTypeIdentifier: ReaderHibikiSource.instance.mediaType.uniqueKey,
       mediaSourceIdentifier: ReaderHibikiSource.instance.uniqueKey,
       position: prog?.position ?? 0,

--- a/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hibiki/media.dart';
 import 'package:hibiki/pages.dart';
 import 'package:hibiki/src/pages/implementations/stat_activity.dart';
 import 'package:hibiki/src/pages/implementations/stat_charts.dart';
@@ -1153,6 +1154,16 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     );
   }
 
+  /// BUG-1015 (A1)：统计页书名列**渲染时**应用 override 书名（编辑对话框改名后
+  /// 这里同步显示新名）。统计行仍按 DB 原 title 聚合/删除（历史数据身份不动），
+  /// title→bookKey 走既有 [_bookKeyByTitle] 反查。
+  String _bookDisplayTitle(String title) {
+    final String? bookKey = _bookKeyByTitle[title];
+    if (bookKey == null) return title;
+    return ReaderHibikiSource.instance.overrideTitleForBookKey(bookKey) ??
+        title;
+  }
+
   Widget _buildBookTile(_BookData book) {
     // TODO-1204：查词/制卡计数按 title 聚合（无记录则 0）。
     final ({int lookups, int mines}) counter =
@@ -1180,7 +1191,7 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                book.title,
+                _bookDisplayTitle(book.title),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
                 style: Theme.of(context).textTheme.bodyMedium,

--- a/hibiki/lib/src/profile/profile_keys.dart
+++ b/hibiki/lib/src/profile/profile_keys.dart
@@ -58,13 +58,37 @@ class ProfileKeys {
   static const List<String> _excludedPrefPrefixes = [
     'current_source/',
     'audio_index/',
+    // BUG-1016: per-book audiobook playback STATE lives in prefs
+    // (`audiobook_<kind>_<bookKey>`, see AudiobookRepository). These are
+    // progress/content data — the same family backup_service already treats as
+    // the `progress` category (`key NOT LIKE 'audiobook_pos_%'` in
+    // settingsPrefPredicate) — NOT per-profile reading preferences. Snapshotting
+    // them meant a profile switch pruned the position prefs (progress reset to
+    // 0) while restoring a stale speed snapshot (playback suddenly fast/slow).
+    // `audiobook_pos_` also covers `audiobook_pos_at_` (its LWW timestamp twin).
+    'audiobook_pos_',
+    'audiobook_follow_',
+    'audiobook_delay_',
+    'audiobook_speed_',
+    'audiobook_volume_',
+    'audiobook_image_pause_',
+    'audiobook_health_overlay_',
   ];
+
+  /// BUG-1015 (A4): per-item display-name overrides are CONTENT tied to a
+  /// media item, not reading preferences. Their persisted form is
+  /// `src:<sourceId>:override_title://<sourceId>/<uniqueKey>` (see
+  /// [MediaSource.getOverrideTitleKey] + `dbSourcePrefKey`), so the marker is
+  /// matched as a substring — excluding them from profile snapshots keeps a
+  /// rename visible across profile switches instead of being pruned/reverted.
+  static const String _overrideTitleMarker = 'override_title://';
 
   static bool isExcludedPref(String key) {
     if (_excludedPrefKeys.contains(key)) return true;
     for (final prefix in _excludedPrefPrefixes) {
       if (key.startsWith(prefix)) return true;
     }
+    if (key.contains(_overrideTitleMarker)) return true;
     if (key.endsWith('/last_picked_file')) return true;
     return false;
   }

--- a/hibiki/lib/src/profile/profile_repository.dart
+++ b/hibiki/lib/src/profile/profile_repository.dart
@@ -203,6 +203,16 @@ class ProfileRepository {
       }
     }
 
+    // BUG-1016: old snapshots (taken before a key entered the exclusion list,
+    // e.g. audiobook_pos_* / audiobook_speed_* / override_title://*) may still
+    // carry excluded keys. Apply must neither restore those stale values (a
+    // months-old speed/position overwriting the live one) nor delete the live
+    // rows (the prune loop below already skips excluded keys) — so drop them
+    // from the restore map here. Same single source of truth as snapshot/prune:
+    // [ProfileKeys.isExcludedPref].
+    prefMap
+        .removeWhere((String key, String _) => ProfileKeys.isExcludedPref(key));
+
     // Wrap DB writes in transaction for consistency
     await _db.transaction(() async {
       final currentPrefs = await _db.getAllPrefs();

--- a/hibiki/test/media/override_identity_test.dart
+++ b/hibiki/test/media/override_identity_test.dart
@@ -1,0 +1,188 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/media.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// BUG-1015：override 身份与写穿。
+///
+/// - A3：standalone SRT 书（bookKey 空串哨兵）以前全部共享
+///   `mediaIdentifierFor('')`，override 书名互相踩、作者保存静默 no-op。现在
+///   身份是 `hoshi://srtbook/<uid>`（每书唯一），作者真实写穿 SrtBooks.author。
+/// - 附带：编辑保存没选新封面时不再落 0 字节 override 封面文件。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  SrtBook standaloneSrtBook(String uid, {String title = '字幕书'}) {
+    return SrtBook()
+      ..uid = uid
+      ..title = title
+      ..srtPath = '/tmp/$uid.srt'
+      ..importedAt = DateTime.now().millisecondsSinceEpoch
+      ..bookKey = '';
+  }
+
+  MediaItem srtItem(String uid) {
+    final ReaderHibikiSource source = ReaderHibikiSource.instance;
+    return MediaItem(
+      mediaIdentifier: ReaderHibikiSource.mediaIdentifierForSrtUid(uid),
+      title: '字幕书',
+      mediaTypeIdentifier: source.mediaType.uniqueKey,
+      mediaSourceIdentifier: source.uniqueKey,
+      position: 0,
+      duration: 1,
+      canDelete: false,
+      canEdit: true,
+    );
+  }
+
+  group('standalone SRT media identity (BUG-1015 A3)', () {
+    test('srt identifiers are per-uid and round-trip losslessly', () {
+      final String a = ReaderHibikiSource.mediaIdentifierForSrtUid('srtbook_1');
+      final String b = ReaderHibikiSource.mediaIdentifierForSrtUid('srtbook_2');
+      expect(a, isNot(b));
+      expect(ReaderHibikiSource.parseSrtBookUid(a), 'srtbook_1');
+      expect(ReaderHibikiSource.parseSrtBookUid(b), 'srtbook_2');
+      // 与 EPUB 书身份空间不相交：互不解析。
+      expect(ReaderHibikiSource.parseBookKey(a), isNull);
+      expect(
+        ReaderHibikiSource.parseSrtBookUid(
+            ReaderHibikiSource.mediaIdentifierFor('someBookKey')),
+        isNull,
+      );
+    });
+
+    test('override title on one standalone SRT book does not leak to another',
+        () async {
+      final ReaderHibikiSource source = ReaderHibikiSource.instance;
+      final MediaItem itemA = srtItem('srtbook_a');
+      final MediaItem itemB = srtItem('srtbook_b');
+      addTearDown(
+          () => source.setOverrideTitleFromMediaItem(item: itemA, title: null));
+
+      await source.setOverrideTitleFromMediaItem(item: itemA, title: '新名A');
+
+      expect(source.overrideTitleForSrtUid('srtbook_a'), '新名A');
+      expect(source.overrideTitleForSrtUid('srtbook_b'), isNull);
+      expect(source.getOverrideTitleFromMediaItem(itemB), isNull);
+    });
+
+    test('setAuthorFromMediaItem writes through to srt_books.author', () async {
+      final HibikiDatabase db =
+          HibikiDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      MediaSource.setDatabase(db);
+      final SrtBookRepository repo = SrtBookRepository(db);
+      await repo.save(standaloneSrtBook('srtbook_author'));
+
+      final ReaderHibikiSource source = ReaderHibikiSource.instance;
+      await source.setAuthorFromMediaItem(
+        item: srtItem('srtbook_author'),
+        author: '  某作者  ',
+      );
+      expect((await repo.findByUid('srtbook_author'))!.author, '某作者');
+
+      // 空白清除（与 updateEpubBookAuthor 同语义）。
+      await source.setAuthorFromMediaItem(
+        item: srtItem('srtbook_author'),
+        author: '   ',
+      );
+      expect((await repo.findByUid('srtbook_author'))!.author, isNull);
+    });
+
+    test('setAuthorFromMediaItem on an unknown srt uid is a safe no-op',
+        () async {
+      final HibikiDatabase db =
+          HibikiDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      MediaSource.setDatabase(db);
+
+      await ReaderHibikiSource.instance.setAuthorFromMediaItem(
+        item: srtItem('srtbook_missing'),
+        author: 'X',
+      );
+      // 不抛、不落行。
+      expect(await db.getSrtBookByUid('srtbook_missing'), isNull);
+    });
+  });
+
+  group('override thumbnail file hygiene (BUG-1015 附带)', () {
+    late Directory storeDir;
+    late HibikiDatabase db;
+    late AppModel appModel;
+
+    setUp(() async {
+      db = HibikiDatabase.forTesting(NativeDatabase.memory());
+      final PreferencesRepository prefs = PreferencesRepository(db);
+      await prefs.loadFromDb();
+      storeDir = Directory.systemTemp.createTempSync('hibiki_override_thumb');
+      appModel = AppModel(testPlatformServices())
+        ..wireDatabaseForTesting(db)
+        ..wireLocalAudioForTesting(
+          prefsRepo: prefs,
+          databaseDirectory: storeDir,
+        );
+    });
+
+    tearDown(() async {
+      await db.close();
+      if (storeDir.existsSync()) {
+        storeDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('save without a new image leaves NO 0-byte override cover behind',
+        () async {
+      final ReaderHibikiSource source = ReaderHibikiSource.instance;
+      final MediaItem item = srtItem('srtbook_cover');
+      final String filename = source.getOverrideThumbnailFilename(
+        appModel: appModel,
+        item: item,
+      );
+
+      await source.setOverrideThumbnailFromMediaItem(
+        appModel: appModel,
+        item: item,
+        file: null,
+        clearOverrideImage: false,
+      );
+
+      expect(File(filename).existsSync(), isFalse,
+          reason: '未选新图也未清除时不得落空文件（否则封面渲染成损坏占位）');
+    });
+
+    test('picking a real image writes it; clearing deletes it', () async {
+      final ReaderHibikiSource source = ReaderHibikiSource.instance;
+      final MediaItem item = srtItem('srtbook_cover2');
+      final String filename = source.getOverrideThumbnailFilename(
+        appModel: appModel,
+        item: item,
+      );
+      final File picked = File('${storeDir.path}/picked.png')
+        ..writeAsBytesSync(<int>[1, 2, 3, 4]);
+
+      await source.setOverrideThumbnailFromMediaItem(
+        appModel: appModel,
+        item: item,
+        file: picked,
+        clearOverrideImage: false,
+      );
+      expect(File(filename).existsSync(), isTrue);
+      expect(File(filename).lengthSync(), 4);
+
+      await source.setOverrideThumbnailFromMediaItem(
+        appModel: appModel,
+        item: item,
+        file: null,
+        clearOverrideImage: true,
+      );
+      expect(File(filename).existsSync(), isFalse);
+    });
+  });
+}

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -214,6 +214,57 @@ void main() {
     expect(find.byType(StatContributionHeatmap), findsOneWidget);
   });
 
+  testWidgets('BUG-1015：「继续」区显示 override 书名而非 DB 原名',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    // 一本在读的书（0 < position < duration 才进「继续」区）。
+    final MediaItem book = MediaItem(
+      mediaIdentifier: ReaderHibikiSource.mediaIdentifierFor('测试书key'),
+      title: '原书名',
+      mediaTypeIdentifier: ReaderHibikiSource.instance.mediaType.uniqueKey,
+      mediaSourceIdentifier: ReaderHibikiSource.instance.uniqueKey,
+      position: 50,
+      duration: 100,
+      canDelete: false,
+      canEdit: true,
+    );
+    // 编辑对话框同一写入通道设置 override 书名；测试后清除（instance 是单例）。
+    await ReaderHibikiSource.instance.setOverrideTitleFromMediaItem(
+      item: book,
+      title: '改后的书名',
+    );
+    addTearDown(() => ReaderHibikiSource.instance
+        .setOverrideTitleFromMediaItem(item: book, title: null));
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: <Override>[
+        platformServicesProvider.overrideWithValue(platformServices),
+        ankiRepositoryProvider.overrideWithValue(ankiRepository),
+        appProvider.overrideWith((ref) => appModel),
+        hibikiBooksProvider
+            .overrideWith((ref, language) async => <MediaItem>[book]),
+        bookLastReadAtProvider
+            .overrideWith((ref) async => <String, int>{'测试书key': 1}),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: HomeDashboardPage(videoRepo: VideoBookRepository(db)),
+          ),
+        ),
+      ),
+    ));
+    await pumpDashboard(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('改后的书名'), findsOneWidget);
+    expect(find.text('原书名'), findsNothing);
+  });
+
   testWidgets('中等宽度（700，<900 窄分支）单列堆叠不抛无限高度', (WidgetTester tester) async {
     // 700px < 900：走窄屏单列堆叠分支（热力图置顶 + 继续 + Activity）。曾因把
     // stretch/Expanded 的 Row 直接放进纵向 ListView 而在此宽度崩溃，锁死不再复发。

--- a/hibiki/test/profile/profile_keys_test.dart
+++ b/hibiki/test/profile/profile_keys_test.dart
@@ -44,6 +44,35 @@ void main() {
       expect(ProfileKeys.isExcludedPref('reader_vertical'), isFalse);
     });
 
+    test(
+        'BUG-1016: per-book audiobook playback state is progress, '
+        'never profile-snapshotted', () {
+      expect(ProfileKeys.isExcludedPref('audiobook_pos_bookA'), isTrue);
+      expect(ProfileKeys.isExcludedPref('audiobook_pos_at_bookA'), isTrue);
+      expect(ProfileKeys.isExcludedPref('audiobook_speed_bookA'), isTrue);
+      expect(ProfileKeys.isExcludedPref('audiobook_follow_bookA'), isTrue);
+      expect(ProfileKeys.isExcludedPref('audiobook_delay_bookA'), isTrue);
+      expect(ProfileKeys.isExcludedPref('audiobook_volume_bookA'), isTrue);
+      expect(ProfileKeys.isExcludedPref('audiobook_image_pause_bookA'), isTrue);
+      expect(
+          ProfileKeys.isExcludedPref('audiobook_health_overlay_bookA'), isTrue);
+    });
+
+    test('BUG-1015 (A4): override_title prefs are content, never snapshotted',
+        () {
+      // Persisted form: src:<sourceId>:override_title://<sourceId>/<uniqueKey>
+      expect(
+        ProfileKeys.isExcludedPref('src:reader_ttu:override_title://reader_ttu/'
+            'reader_ttu/hoshi://book/我的书'),
+        isTrue,
+      );
+      expect(
+        ProfileKeys.isExcludedPref('src:reader_ttu:override_title://reader_ttu/'
+            'reader_ttu/hoshi://srtbook/srtbook_123'),
+        isTrue,
+      );
+    });
+
     test('reading goals are per-Profile (not excluded, TODO-1046)', () {
       // 0=off, but the goal targets themselves are per-Profile prefs: they must
       // NOT be in the exclusion set so each profile keeps its own daily/weekly

--- a/hibiki/test/profile/profile_repository_test.dart
+++ b/hibiki/test/profile/profile_repository_test.dart
@@ -173,6 +173,74 @@ void main() {
       expect(await db.getPref('active_profile_id'), '7'); // excluded → kept
     });
 
+    test(
+        'BUG-1016: audiobook progress/speed + override_title survive a '
+        'profile switch (not snapshotted, not pruned, not restored stale)',
+        () async {
+      final db = await _openDb();
+      final repo = _repo(db);
+      const String overrideTitleKey =
+          'src:reader_ttu:override_title://reader_ttu/'
+          'reader_ttu/hoshi://book/我的书';
+
+      final pid = await repo.createProfile('A');
+      await db.setPref('audiobook_pos_bookA', '111');
+      await db.setPref('audiobook_speed_bookA', '2.0');
+      await db.setPref(overrideTitleKey, '"新书名"');
+      await db.setPref('font_size', '16');
+      await repo.snapshotCurrentSettings(pid);
+
+      // 1) snapshot never contains progress/override keys.
+      final keys = await _prefKeys(db, pid);
+      expect(keys, contains('font_size'));
+      expect(keys, isNot(contains('audiobook_pos_bookA')));
+      expect(keys, isNot(contains('audiobook_speed_bookA')));
+      expect(keys, isNot(contains(overrideTitleKey)));
+
+      // 2) live progress written AFTER the snapshot survives the apply —
+      //    neither pruned (the old "progress reset to 0") nor overwritten.
+      await db.setPref('audiobook_pos_bookA', '999');
+      await db.setPref('audiobook_speed_bookA', '1.25');
+      await repo.applyProfile(pid);
+      expect(await db.getPref('audiobook_pos_bookA'), '999');
+      expect(await db.getPref('audiobook_speed_bookA'), '1.25');
+      expect(await db.getPref(overrideTitleKey), '"新书名"');
+    });
+
+    test(
+        'BUG-1016: stale excluded keys inside an OLD snapshot are neither '
+        'restored nor allowed to delete live values', () async {
+      final db = await _openDb();
+      final repo = _repo(db);
+      final pid = await repo.createProfile('Old');
+
+      // Simulate a pre-fix snapshot that captured progress/speed rows.
+      await db.replaceProfileSettings(pid, <ProfileSettingsCompanion>[
+        ProfileSettingsCompanion.insert(
+          profileId: pid,
+          category: 'pref',
+          key: 'audiobook_speed_bookA',
+          value: '3.0', // months-old stale speed
+        ),
+        ProfileSettingsCompanion.insert(
+          profileId: pid,
+          category: 'pref',
+          key: 'font_size',
+          value: '20',
+        ),
+      ]);
+
+      await db.setPref('audiobook_speed_bookA', '1.5'); // live truth
+      await db.setPref('audiobook_pos_bookA', '4242'); // live progress
+      await repo.applyProfile(pid);
+
+      // Stale snapshot speed must NOT clobber the live one ("速度飞快" symptom)
+      // and the live position must NOT be pruned ("进度 0" symptom).
+      expect(await db.getPref('audiobook_speed_bookA'), '1.5');
+      expect(await db.getPref('audiobook_pos_bookA'), '4242');
+      expect(await db.getPref('font_size'), '20'); // normal restore still works
+    });
+
     test('resolveProfileId precedence: book > mediaType > active', () async {
       final db = await _openDb();
       final repo = _repo(db);


### PR DESCRIPTION
## 症状 → 根因 → 修法

用户实报两组症状：**改名/改作者不生效**（BUG-1015）+ **听书进度变怪：速度飞快但进度 0**（BUG-1016）。

| 症状 | 根因 | 修法 |
|---|---|---|
| 听书进度归 0 + 倍速飞快 | 听书进度/倍速全存 prefs（`audiobook_pos_/speed_/...` 前缀），backup_service 视为 progress 数据，但 profile 系统当设置：applyProfile prune 删掉进度 pref、旧快照回灌顶掉倍速（profile_repository.dart 209-213；开书自动切 profile 触发） | `ProfileKeys` 排除全部 8 个 `audiobook_*_` 每书前缀（snapshot/prune/apply 三处共用同一 `isExcludedPref` 真相源）；applyProfile 对旧快照残值跳过回灌（不写不删） |
| 改名后首页「继续」/活动/统计/听书通知仍显示旧名 | override title 只有书架卡+长按对话框 3 个消费点，其余面直接读 DB 原名（home_dashboard_page.dart:349/693、reading_statistics_page.dart:1183、audiobook_session_launcher.dart:168） | 新增 `overrideTitleForBookKey/overrideTitleForSrtUid` helper，四个面全部接上（活动 events 落库仍存原名，仅渲染层替换） |
| 改作者保存成功但书架不变 | `_epubBookKeysProvider` 按 key 集合去重，纯列更新不触发；executeSave 只 refreshTab() | 保存后 invalidate `hibikiBooksProvider`/`srtBooksProvider` |
| 独立 SRT 书改名互相踩 / 改作者无效 | standalone SRT 书（bookKey 空串哨兵）全部共享 `mediaIdentifierFor('')` 同一 override key；作者保存 parseBookKey==null 静默 no-op | 身份改 `hoshi://srtbook/<uid>`；作者真实写穿 `srt_books.author` |
| 改名/profile 切换后 override 又丢 | `override_title://` pref 被 profile snapshot/prune 吞 | 排除清单加 `override_title://` 子串匹配 |
| 编辑保存后封面变损坏占位 | `setOverrideThumbnailFromMediaItem` 无条件 createSync 留 0 字节文件 | 只在真选新图/明确清除时写盘 |

## 硬约束遵守
- 不改 schema、不改 bookKey 生成、不动 preferences 存储格式（排除清单是读侧逻辑）。
- 未动 uiux-followup-dashboard 分支既有改动（热力图/统计带/焦点动画）。

## 测试
- `test/profile/profile_keys_test.dart`：8 前缀 + override_title 排除。
- `test/profile/profile_repository_test.dart`：快照不含进度键；apply 不 prune 活进度、不回灌旧快照 speed 残值（速度飞快/进度 0 两个症状分别锁死）。
- `test/media/override_identity_test.dart`（新）：SRT 身份唯一性/round-trip、作者写穿+空白清除、未知 uid 安全 no-op、封面无新图不落文件/真图写入/清除删除。
- `test/pages/home_dashboard_page_test.dart`：「继续」区显示 override 名、原名不出现。
- 全量 `flutter test --no-pub`：**12635 passed**（~5 skip），`flutter analyze --no-pub` 零 issue。

## 遗留（本轮不做）
- 方案 3：EpubBooks 加 displayTitle 列做真改名（override pref 仍是显示层方案）。
- 旧 standalone SRT 书挂在空 key 上的共享 override 不迁移（本就互踩、无单书归属，改身份后自然失效）。
- 互联远端条目标题来自对端，不在本地 override 范围。

BUG 档：docs/bugs/BUG-1015-rename-not-applied-everywhere.md / docs/bugs/BUG-1016-profile-swallows-audiobook-progress.md

https://claude.ai/code/session_01CfSqJG9psJkUVSig6DhH9Y