### PR TITLE
fix(lookup): BUG-1017 桌面剪贴板监听页内翻转开关后永久失效

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 983 条。点号进各自文件。
+> 共 984 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1017](bugs/BUG-1017-clipboard-watcher-pref-flip-desync.md) | ✅ | ✅ | Windows剪贴板监听页内翻转开关后永久失效 |
 | [BUG-1016](bugs/BUG-1016-webdav-anonymous-empty-credentials.md) | ✅ | ✅ | WebDAV/FTP 匿名同步：空用户名密码被硬拦 |
 | [BUG-1015](bugs/BUG-1015-desktop-lookup-autoread-first-silent.md) | ✅ | ✅ | 桌面首次查词自动发音无声·media_kit播放器冷启动 |
 | [BUG-1014](bugs/BUG-1014-win-update-desktop-icon-move.md) | ✅ | ✅ | Windows 更新后桌面快捷方式移位 |

--- a/docs/bugs/BUG-1017-clipboard-watcher-pref-flip-desync.md
+++ b/docs/bugs/BUG-1017-clipboard-watcher-pref-flip-desync.md
@@ -1,0 +1,12 @@
+## BUG-1017 · Windows剪贴板监听页内翻转开关后永久失效
+
+- **报告**：2026-07-23（用户）——"不知如何触发。但就是会触发。貌似无法监听粘贴板的问题。。重启应用恢复"（平台：Windows 桌面）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/home_dictionary_page.dart:254-256`（页级 dispose 的 stop 门控读**可变** pref `desktopClipboardEnabled`，与 initState 的 start 门控读的是同一可变量但时刻不同）。
+- **根因**：`DesktopLookupService` 是 app 级单例，剪贴板监听生命周期用共享引用计数 `_startRefCount`（`desktop_lookup_service.dart:85,179-229`），有两个 owner：
+  - **app 级**：`AppModel.applyDesktopClipboardLifecycle`（`app_model.dart:4203-4212`，启动一次 + 每次开关切换）——开=`start()`、关=`stop()`。
+  - **页级**：`HomeDictionaryPage`——initState 按 pref `start()`（`home_dictionary_page.dart:168`）、dispose 按 pref `stop()`（`:254-255`）。
+
+  页级 start/stop 都**现读可变 pref `desktopClipboardEnabled`**，且在 initState 与 dispose 两个不同时刻读。当用户在这两点之间翻转开关，两次读到不同值 → start/stop 失配。永久失效复现序列：① 关状态进词典页（initState 门控为假、不 start）→ ② 页内打开开关（app 级 `start()`，count 0→1，OS watcher 挂上）→ ③ 离开词典页（dispose 读 pref 现在=真 → `stop()`，count 1→0 → `clipboardWatcher.stop()` + `removeListener` 真正拆掉 OS 监听）。净结果：页面 dispose 吞掉了 app 级 hold 的那 +1，count=0、watcher 死，而 pref 仍显示"已开启"、app 级 owner 以为自己还持有着不会再 start → **剪贴板监听永久哑火，直到重启 app（main 重跑 applyLifecycle 重新 start）或手动关再开**。反向（页内关开关再离开）则 dispose 门控为假不 stop → 计数泄漏在 1，长期加剧错配。病根注释 `app_model.dart:4202`"service.start 对已运行是 no-op"是 bool 时代的陈旧假设，BUG-700 改成 refcount 后 start 每次都 +1，该假设失效。
+- **[x] ① 已修复** — `home_dictionary_page.dart`：页级加实例 bool `_desktopLookupStarted`，`_startDesktopLookupIfEnabled` 真正 `start()` 前同步置 true（与 `start()` 内部首个 await 前同步完成的 `_startRefCount++` 天然配对），dispose **仅据此 bool** 决定是否 `stop()`，与可变 pref 彻底解耦。页级 owner 恒为严格配对的 +1/-1，pref 怎么翻都不吞别人的计数；不改动 `DesktopLookupService` refcount 语义，故 BUG-700 断点不变式（`home_dictionary_clipboard_watcher_breakpoint_test.dart`）仍成立。提交 `e2f67aa8a`。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/home_dictionary_clipboard_pref_flip_desync_test.dart`（widget 行为守卫，两例）：① 关状态进页 → app 级 `start()` → 页内翻 enabled=true → 卸载页，断言 `svc.isRunning` 仍为真且 OS watcher 未被 `stop`（复现即本 bug）；② 开状态进页真 start → 页内翻 enabled=false → 卸载页，断言严格配对 `stop`（1→0）无泄漏。已核实两例在旧（pref 门控）代码下均变红（test1 isRunning=false、test2 未 stop），修复后转绿。提交 `e2f67aa8a`。
+- **备注**：移动端（Android/iOS）无此路径——剪贴板自动查词是桌面独有功能，`DesktopLookupService.start()` 首行 `if (!isDesktop) return`。与已修复的 BUG-700（600px 断点重建把 watcher 拆死）是同一 refcount 生命周期的相邻缺陷，但触发条件不同（本 bug=pref 在页生命周期内翻转，BUG-700=窗口跨断点重建）。

--- a/hibiki/lib/src/pages/implementations/home_dictionary_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dictionary_page.dart
@@ -95,6 +95,15 @@ class _HomeDictionaryPageState<T extends BaseTabPage> extends BaseTabPageState
 
   bool _historyWritten = false;
 
+  /// BUG-1017：本页是否真正对 [DesktopLookupService] 做过一次 start（refcount +1）。
+  /// dispose 的 stop 必须与它配对，**不能**改读可变 pref `desktopClipboardEnabled`——
+  /// 该 pref 会在 initState 与 dispose 之间被用户翻转（页内打开/关闭剪贴板监听开关），
+  /// 令 start 门控与 stop 门控读到不同值 → 页级 stop 吞掉 app 级 hold 的 +1 → 计数归 0
+  /// → OS watcher 被真正拆掉、pref 却仍显示「已开启」→ 剪贴板监听永久哑火直到重启。
+  /// 用实例 bool 记录「本页确实 start 过」，把 stop 与外部可变量彻底解耦，页级 owner
+  /// 恒为严格配对的 +1/-1。
+  bool _desktopLookupStarted = false;
+
   /// 仅测试可见：最近一次派发的查词 future（[debugSearch] 返回它以便
   /// await 失败路径）。生产路径仍 fire-and-forget，不改变行为。
   Future<void>? _lastDispatchedSearch;
@@ -163,11 +172,16 @@ class _HomeDictionaryPageState<T extends BaseTabPage> extends BaseTabPageState
   /// desktopClipboardEnabled 门控），离开时 stop（见 dispose）。与 AppModel 的 app 级
   /// hold 经 [DesktopLookupService] 的 _startRefCount 安全并存（0→1 才真正挂 watcher，
   /// 1→0 才真正拆）。
+  ///
+  /// BUG-1017：置 [_desktopLookupStarted] 记录本页确实 start 过——同步在 start() 之前
+  /// 置位，与 start() 内部同步完成的 `_startRefCount++`（首个 await 之前）天然配对；
+  /// dispose 只据此 bool 决定是否 stop，不再改读可变 pref。
   Future<void> _startDesktopLookupIfEnabled() async {
     final AppModel model = appModelNoUpdate;
     if (!DesktopLookupService.isDesktop || !model.desktopClipboardEnabled) {
       return;
     }
+    _desktopLookupStarted = true;
     await DesktopLookupService.instance.start(
       windowMode: model.desktopClipboardWindowMode,
     );
@@ -249,10 +263,13 @@ class _HomeDictionaryPageState<T extends BaseTabPage> extends BaseTabPageState
     final HomeDictionaryPage w = widget as HomeDictionaryPage;
     w.focusSignal?.removeListener(_onFocusSignal);
     DesktopLookupService.instance.removeListener(_onDesktopLookupPending);
-    // TODO-1394 方案B：恢复 1385 页级 stop（受 enabled 门控，refcount -1）。app 级
-    // hold 仍保 watcher 在 tab 卸载后为剪贴板独立面板/瞬态去向运行（见 initState）。
-    if (DesktopLookupService.isDesktop &&
-        appModelNoUpdate.desktopClipboardEnabled) {
+    // TODO-1394 方案B：恢复 1385 页级 stop（refcount -1）。app 级 hold 仍保 watcher 在
+    // tab 卸载后为剪贴板独立面板/瞬态去向运行（见 initState）。BUG-1017：stop 与本页自己
+    // 的 start 严格配对——只据 [_desktopLookupStarted] 判定，**不**改读可变 pref
+    // desktopClipboardEnabled（该 pref 会在 start 与 dispose 之间被翻转，导致页级 stop
+    // 吞掉 app 级 hold 的计数、把 OS watcher 拆死而 pref 仍显示开启 → 永久哑火）。
+    if (_desktopLookupStarted) {
+      _desktopLookupStarted = false;
       unawaited(DesktopLookupService.instance.stop());
     }
     _searchFocusNode.removeListener(_onFocusChanged);

--- a/hibiki/test/pages/home_dictionary_clipboard_pref_flip_desync_test.dart
+++ b/hibiki/test/pages/home_dictionary_clipboard_pref_flip_desync_test.dart
@@ -1,0 +1,247 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/home_dictionary_page.dart';
+import 'package:hibiki/src/sync/desktop_foreground_guard.dart';
+import 'package:hibiki/src/sync/desktop_lookup_service.dart';
+import 'package:hibiki_dictionary/hibiki_dictionary.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// BUG-1017 回归守卫：Windows 桌面剪贴板自动查词在「关闭状态下进词典页 → 页内打开
+/// 剪贴板监听开关 → 离开词典页」这一顺序后永久失效，重启才恢复。
+///
+/// 根因：[DesktopLookupService] 是 app 级单例，监听生命周期用共享引用计数
+/// `_startRefCount`，有两个 owner——app 级（AppModel.applyDesktopClipboardLifecycle，
+/// 开=start/关=stop）与页级（HomeDictionaryPage，initState 按 pref start、dispose 按
+/// pref stop）。缺陷在页级：start 门控读 initState 时的 `desktopClipboardEnabled`、stop
+/// 门控读 dispose 时的同名可变 pref。当用户在 start 与 dispose 之间翻转开关，两次读到
+/// 不同值 → 页级 dispose 的 stop 吞掉 app 级 hold 的 +1 → 计数归 0 → OS watcher 被真正
+/// 拆掉，而 pref 仍显示「已开启」→ 剪贴板监听永久哑火直到重启。
+///
+/// 修法：页级用实例 bool `_desktopLookupStarted` 记录「本页确实 start 过」，dispose 仅
+/// 据此 stop，与可变 pref 解耦——页级 owner 恒为严格配对的 +1/-1，pref 怎么翻都不吞别
+/// 人的计数。
+class _PrefFlipAppModel extends AppModel {
+  _PrefFlipAppModel() : super(testPlatformServices());
+
+  /// 可变，模拟用户在词典页内翻转剪贴板监听开关。
+  bool clipboardEnabled = false;
+
+  @override
+  bool get desktopClipboardEnabled => clipboardEnabled;
+
+  @override
+  DesktopClipboardWindowMode get desktopClipboardWindowMode =>
+      DesktopClipboardWindowMode.normal;
+
+  @override
+  List<DictionarySearchResult> get dictionaryHistory =>
+      <DictionarySearchResult>[];
+
+  @override
+  List<Dictionary> get dictionaries => <Dictionary>[
+        Dictionary(name: 'Test', formatKey: 'test', order: 0),
+      ];
+
+  @override
+  int get maximumTerms => 10;
+
+  @override
+  void addToSearchHistory({
+    required String historyKey,
+    required String searchTerm,
+  }) {}
+
+  @override
+  void addToDictionaryHistory({required DictionarySearchResult result}) {}
+
+  @override
+  Future<DictionarySearchResult> searchDictionary({
+    required String searchTerm,
+    required bool searchWithWildcards,
+    int? overrideMaximumTerms,
+    bool useCache = true,
+    bool allowRemoteLookup = true,
+  }) async {
+    return DictionarySearchResult(searchTerm: searchTerm);
+  }
+}
+
+/// 挂载/卸载 HomeDictionaryPage 的最小外壳：mounted=false 时换成 SizedBox 触发 dispose。
+Widget _wrap(_PrefFlipAppModel appModel, ValueNotifier<bool> mounted) {
+  return ProviderScope(
+    overrides: <Override>[appProvider.overrideWith((ref) => appModel)],
+    child: TranslationProvider(
+      child: MaterialApp(
+        navigatorKey: appModel.navigatorKey,
+        builder: (BuildContext context, Widget? child) =>
+            child ?? const SizedBox.shrink(),
+        home: ValueListenableBuilder<bool>(
+          valueListenable: mounted,
+          builder: (BuildContext context, bool isMounted, _) => Scaffold(
+            body: isMounted
+                ? const HomeDictionaryPage()
+                : const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final List<String> clipboardWatcherCalls = <String>[];
+
+  void installChannels(WidgetTester tester) {
+    final TestDefaultBinaryMessenger m = tester.binding.defaultBinaryMessenger;
+    m.setMockMethodCallHandler(const MethodChannel('window_manager'),
+        (MethodCall call) async {
+      if (call.method == 'isFocused') return false;
+      if (call.method == 'isMinimized') return false;
+      return null;
+    });
+    m.setMockMethodCallHandler(const MethodChannel('clipboard_watcher'),
+        (MethodCall call) async {
+      clipboardWatcherCalls.add(call.method);
+      return null;
+    });
+    m.setMockMethodCallHandler(
+      const MethodChannel('dev.leanflutter.plugins/hotkey_manager'),
+      (MethodCall call) async => null,
+    );
+    // hotKeyManager.register 首次会 lazily 监听该 EventChannel（receiveBroadcastStream
+    // 的 'listen'）；不 mock 会抛 MissingPluginException 到测试 zone 令其失败。
+    m.setMockMethodCallHandler(
+      const MethodChannel('dev.leanflutter.plugins/hotkey_manager_event'),
+      (MethodCall call) async => null,
+    );
+    m.setMockMethodCallHandler(const MethodChannel('app.hibiki/window'),
+        (MethodCall call) async => null);
+    m.setMockMethodCallHandler(SystemChannels.platform,
+        (MethodCall call) async {
+      if (call.method == 'Clipboard.getData') {
+        return <String, Object?>{'text': ''};
+      }
+      return null;
+    });
+  }
+
+  void clearChannels(WidgetTester tester) {
+    final TestDefaultBinaryMessenger m = tester.binding.defaultBinaryMessenger;
+    for (final String name in <String>[
+      'window_manager',
+      'clipboard_watcher',
+      'dev.leanflutter.plugins/hotkey_manager',
+      'dev.leanflutter.plugins/hotkey_manager_event',
+      'app.hibiki/window',
+    ]) {
+      m.setMockMethodCallHandler(MethodChannel(name), null);
+    }
+    m.setMockMethodCallHandler(SystemChannels.platform, null);
+  }
+
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+    clipboardWatcherCalls.clear();
+    DesktopForegroundGuard.debugForegroundOwnedByCurrentProcess = false;
+    DesktopForegroundGuard.debugForegroundOwnedByHibikiAppFamily = false;
+    DesktopForegroundGuard.debugHiddenWindowsRunner = false;
+    DesktopLookupService.instance.debugReset();
+  });
+
+  tearDown(() {
+    DesktopForegroundGuard.debugForegroundOwnedByCurrentProcess = null;
+    DesktopForegroundGuard.debugForegroundOwnedByHibikiAppFamily = null;
+    DesktopForegroundGuard.debugHiddenWindowsRunner = null;
+    DesktopLookupService.instance.debugReset();
+  });
+
+  testWidgets(
+      'toggling clipboard ON inside dictionary page then leaving it keeps the '
+      'app-level watcher alive (no refcount desync)',
+      (WidgetTester tester) async {
+    if (!DesktopLookupService.isDesktop) return;
+    installChannels(tester);
+    addTearDown(() => clearChannels(tester));
+    final DesktopLookupService svc = DesktopLookupService.instance;
+    final _PrefFlipAppModel appModel = _PrefFlipAppModel();
+    final ValueNotifier<bool> mounted = ValueNotifier<bool>(true);
+    addTearDown(mounted.dispose);
+
+    // 1) 关闭状态下进入词典页：页级 initState 门控为假，不 start，watcher 未挂。
+    await tester.pumpWidget(_wrap(appModel, mounted));
+    await tester.pump();
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 50)));
+    expect(svc.isRunning, isFalse, reason: '关状态进页不应 start（页级 initState 门控为假）');
+    expect(clipboardWatcherCalls, isNot(contains('start')));
+
+    // 2) 用户在词典页内打开开关：app 级 hold（applyDesktopClipboardLifecycle）真正
+    //    start 服务；pref 同步翻成 true。此后页级 dispose 若改读 pref 就会误判「本页
+    //    start 过」而 stop——正是被守卫的 desync。
+    appModel.clipboardEnabled = true;
+    await tester.runAsync(
+        () => svc.start(windowMode: DesktopClipboardWindowMode.normal));
+    expect(svc.isRunning, isTrue);
+    expect(clipboardWatcherCalls, contains('start'),
+        reason: 'app 级 hold 0->1 真正启动 OS 剪贴板 watcher');
+
+    // 3) 离开词典页：页级 dispose 触发。修前会读 pref==true → stop → 吞掉 app 级
+    //    +1 → 计数归 0 → watcher 被拆死。修后据 _desktopLookupStarted==false 不 stop。
+    clipboardWatcherCalls.clear();
+    mounted.value = false;
+    await tester.pump();
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 50)));
+    await tester.pump();
+
+    expect(svc.isRunning, isTrue,
+        reason: '页从未 start 过，其 dispose 不得 stop 掉 app 级 hold（修前此处被拆成 false）');
+    expect(clipboardWatcherCalls, isNot(contains('stop')),
+        reason: '页级 dispose 不得拆掉 app 级持有的 OS watcher');
+  });
+
+  testWidgets(
+      'page that DID start still stops exactly once on dispose even if the pref '
+      'was flipped OFF while mounted (no leak)', (WidgetTester tester) async {
+    if (!DesktopLookupService.isDesktop) return;
+    installChannels(tester);
+    addTearDown(() => clearChannels(tester));
+    final DesktopLookupService svc = DesktopLookupService.instance;
+    final _PrefFlipAppModel appModel = _PrefFlipAppModel()
+      ..clipboardEnabled = true;
+    final ValueNotifier<bool> mounted = ValueNotifier<bool>(true);
+    addTearDown(mounted.dispose);
+
+    // 开启状态进入词典页：页级 initState 真正 start（0->1）。
+    await tester.pumpWidget(_wrap(appModel, mounted));
+    await tester.pump();
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 50)));
+    expect(svc.isRunning, isTrue);
+    expect(clipboardWatcherCalls, contains('start'));
+
+    // 用户在页内关闭开关（pref 翻成 false），随后离开页。修前 dispose 门控读 pref==false
+    // → 不 stop → 计数泄漏在 1（watcher 该停不停）。修后据 _desktopLookupStarted==true
+    // 严格配对 stop（1->0），无泄漏。
+    appModel.clipboardEnabled = false;
+    clipboardWatcherCalls.clear();
+    mounted.value = false;
+    await tester.pump();
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 50)));
+    await tester.pump();
+
+    expect(svc.isRunning, isFalse,
+        reason: '本页 start 过就必须在 dispose 严格配对 stop（1->0），不因 pref 翻转而泄漏计数');
+    expect(clipboardWatcherCalls, contains('stop'),
+        reason: '1->0 真正停 OS watcher');
+  });
+}


### PR DESCRIPTION
## 症状
用户报（Windows 桌面）：剪贴板监听在某个未知时机失效、复制任何内容都不再自动查词，**重启应用才恢复**。"不知如何触发，但就是会触发。"

## 根因（已源码实证）
剪贴板自动查词是桌面独有功能（`DesktopLookupService.start()` 首行 `if(!isDesktop) return`，移动端无此路径）。监听生命周期用共享引用计数 `_startRefCount`，两个 owner：
- **app 级** `AppModel.applyDesktopClipboardLifecycle`（启动一次 + 开关切换）：开=start 关=stop
- **页级** `HomeDictionaryPage`：initState 按 pref start、dispose 按 pref stop

缺陷：页级 start（`home_dictionary_page.dart:168`）与 stop（`:254-255`）**各自在不同时刻现读可变 pref `desktopClipboardEnabled`**，没记住"本页到底 start 过没有"。pref 一旦在 mount 与 unmount 之间被翻转，start/stop 失配：

> 关状态进词典页（不 start）→ 页内打开开关（app 级 start，refcount 0→1，OS watcher 挂上）→ 离开页（dispose 读 pref=真 → stop，refcount 1→0 → `clipboardWatcher.stop()` 真拆掉监听）

页面 dispose 吞掉了 app 级 hold 的那 +1 → count=0、watcher 死，而 pref 仍显示"已开启"、app 级 owner 以为还持有着不会再 start → **永久哑火直到重启**。（`app_model.dart:4202` 注释"start 对已运行是 no-op"是 bool 时代陈旧假设，BUG-700 改 refcount 后失效。）

## 修复（根因，最小）
页级加实例 bool `_desktopLookupStarted`：真正 start 前同步置位（与 `start()` 内部同步的 `_startRefCount++` 天然配对），dispose **仅据此 bool** 决定 stop，与可变 pref 彻底解耦 → 页级 owner 恒为严格配对 +1/-1，pref 怎么翻都不吞别人的计数。不改 `DesktopLookupService` refcount 语义，BUG-700 600px 断点不变式仍成立。

## 测试
新增 `home_dictionary_clipboard_pref_flip_desync_test.dart` 两例（widget 行为守卫）：
1. desync：关状态进页 → app 级 start → 页内翻 enabled=true → 卸载页 → 断言 watcher 仍活、未被 stop
2. 反向泄漏：开状态进页真 start → 页内翻 enabled=false → 卸载页 → 断言严格配对 stop（1→0）无泄漏

**已核实两例在旧（pref 门控）代码下均变红、修复后转绿。** `flutter analyze` 干净；本地跑 pref-flip + BUG-700 断点 + desktop_lookup_service 共 27 例全绿。

## 验证状态
- [x] flutter analyze / flutter test（相关测试）
- [ ] Windows 真机复测原始失败路径（按 docs/agent 焦点驱动，待桌面真机）

BUG 跟踪：`docs/bugs/BUG-1017-clipboard-watcher-pref-flip-desync.md`

https://claude.ai/code/session_019QHHrdDc3ccMCnRNXvw4GD