### PR TITLE
feat(pdf): Phase 0 spike — pdfrx 渲染 + 字符级文本层打通

### DIFF
--- a/hibiki/integration_test/pdf_spike_render_text_itest.dart
+++ b/hibiki/integration_test/pdf_spike_render_text_itest.dart
@@ -1,0 +1,239 @@
+// PDF 阅读器 Phase 0 spike 验证（只打通渲染 + 文本层，不接书架/查词/进度/制卡）。
+//
+// 目标：
+//   1. 证明 pdfrx（PDFium）能把一份真实 PDF 栅格化成页面位图（离屏落盘取证）。
+//   2. 证明文本层可用：loadStructuredText() 拿到 fullText + 字符级 charRects，
+//      这是后续「点选查词」的地基（每个字符一个矩形，可按点命中）。
+//   3. 证明 PdfViewer 组件能在真 widget 树里挂载并触发 onViewerReady（组件路径可用）。
+//
+// 运行（Windows 离屏）：
+//   cd hibiki
+//   .\tool\run_windows_itest.ps1 integration_test\pdf_spike_render_text_itest.dart
+// 或裸跑（需要一个已连接设备/桌面）：
+//   flutter test integration_test\pdf_spike_render_text_itest.dart -d windows \
+//     --dart-define=PDF_SPIKE_PATH=C:\Users\wrds\Downloads\QQ\prince.pdf
+//
+// PDF 路径来源：--dart-define=PDF_SPIKE_PATH，缺省回落到本机 spike 素材路径；
+// 文件不存在时跳过（不硬失败），以免在没有该素材的机器上误红。
+//
+// 取证抓图故意走 PdfPage.render()（PDFium 直接栅格化成 BGRA 位图 → 落 PNG），
+// 不走 PdfViewer 组件的 OffsetLayer.toImage：离屏无头环境下 GPU 纹理回读 / vsync 帧
+// 可能永不完成，导致 pump / toImage 卡死。page.render() 是纯 CPU/FFI 路径，真离屏可靠。
+// 组件路径只做「挂载 + onViewerReady」轻量确认，不抓图、绝不 pumpAndSettle。
+// 所有 pdfrx await 都套 timeout，保证进程必定退出、stdout 必定 flush 出证据。
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/startup/observe_blank_detector.dart';
+import 'package:hibiki/src/startup/test_environment.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:pdfrx/pdfrx.dart';
+
+const String _kPdfPath = String.fromEnvironment(
+  'PDF_SPIKE_PATH',
+  defaultValue: r'C:\Users\wrds\Downloads\QQ\prince.pdf',
+);
+
+/// 取证目录 `<evidenceDir>/screenshots/`，与 observe_capture 同约定：
+/// run_windows_itest.ps1 传 HIBIKI_TEST_ROOT=<evidenceDir>/isolated-root。
+Directory _screenshotDir() {
+  final String? root = hibikiTestRootPath();
+  Directory base;
+  if (root != null && root.isNotEmpty) {
+    base = Directory(root);
+    final String leaf = base.path.split(Platform.pathSeparator).last;
+    if (leaf.toLowerCase() == 'isolated-root') {
+      base = base.parent;
+    }
+  } else {
+    final String? runId = hibikiTestRunId();
+    final String runLeaf =
+        (runId != null && runId.isNotEmpty) ? runId : 'local';
+    base = Directory('.codex-test/observe/$runLeaf');
+  }
+  final Directory dir = Directory('${base.path}/screenshots');
+  dir.createSync(recursive: true);
+  return dir;
+}
+
+/// 把 PDFium 输出的 BGRA8888 位图编码成 PNG 落盘并判非空白（纯 CPU codec，无 GPU 回读）。
+/// 返回 (nonBlank, pngBytes, path)。
+Future<(bool, int, String)> _saveBgraAsPng(
+  Uint8List bgra,
+  int width,
+  int height,
+  String name,
+) async {
+  final ui.ImmutableBuffer buffer =
+      await ui.ImmutableBuffer.fromUint8List(bgra);
+  final ui.ImageDescriptor descriptor = ui.ImageDescriptor.raw(
+    buffer,
+    width: width,
+    height: height,
+    pixelFormat: ui.PixelFormat.bgra8888,
+  );
+  final ui.Codec codec = await descriptor.instantiateCodec();
+  final ui.FrameInfo frame = await codec.getNextFrame();
+  final ui.Image image = frame.image;
+  try {
+    final ByteData? png =
+        await image.toByteData(format: ui.ImageByteFormat.png);
+    // 非空白判定直接用原始 BGRA（通道顺序不影响「像素是否有变化」的方差判据）。
+    final bool nonBlank = rgbaLooksNonBlank(bgra);
+    if (png == null) return (nonBlank, 0, '');
+    final Uint8List bytes = png.buffer.asUint8List();
+    final String path = '${_screenshotDir().path}/$name.png';
+    await File(path).writeAsBytes(bytes, flush: true);
+    return (nonBlank, bytes.length, path);
+  } finally {
+    image.dispose();
+    codec.dispose();
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('pdfrx 渲染 + 文本层 charRects spike', (WidgetTester tester) async {
+    // 关键（Phase 0 发现）：pdfium_dart 用 DynamicLibrary.open('pdfium.dll') 裸名加载，
+    // 不吃 Flutter 的 native_assets.json FFI 解析；而 `flutter test -d windows` 运行时
+    // pdfium.dll 既不在 exe 同目录、也没有 pdfium_dart 期望的 .dart_tool/native_assets.yaml，
+    // 导致 worker isolate 里 open 失败 → worker 回调抛错但不回传 → 首个 compute 永久挂死。
+    // 解法：显式把 Pdfrx.pdfiumModulePath 钉到真实 DLL 绝对路径（会传播到 worker isolate）。
+    final String sep = Platform.pathSeparator;
+    final String exeDir = File(Platform.resolvedExecutable).parent.path;
+    final String cwd = Directory.current.path;
+    final List<String> candidates = <String>[
+      '$exeDir${sep}pdfium.dll',
+      '$cwd${sep}build${sep}native_assets${sep}windows${sep}pdfium.dll',
+    ];
+    debugPrint('[pdf-spike] resolvedExecutable=${Platform.resolvedExecutable}');
+    debugPrint('[pdf-spike] cwd=$cwd');
+    String? pdfiumDll;
+    for (final String c in candidates) {
+      final bool exists = File(c).existsSync();
+      debugPrint('[pdf-spike] pdfium.dll candidate=$c exists=$exists');
+      if (exists && pdfiumDll == null) pdfiumDll = c;
+    }
+    if (pdfiumDll != null) {
+      Pdfrx.pdfiumModulePath = pdfiumDll;
+      debugPrint('[pdf-spike] set Pdfrx.pdfiumModulePath=$pdfiumDll');
+    }
+
+    // 引擎 API（PdfDocument.openFile）在任何 widget 构建前使用，必须先初始化 PDFium。
+    debugPrint('[pdf-spike] step: before pdfrxFlutterInitialize');
+    await pdfrxFlutterInitialize().timeout(const Duration(seconds: 20));
+    debugPrint('[pdf-spike] step: after pdfrxFlutterInitialize');
+
+    final File pdfFile = File(_kPdfPath);
+    if (!pdfFile.existsSync()) {
+      markTestSkipped('spike PDF 不存在，跳过：$_kPdfPath');
+      return;
+    }
+
+    debugPrint('[pdf-spike] step: before PdfDocument.openFile');
+    final PdfDocument document = await PdfDocument.openFile(_kPdfPath)
+        .timeout(const Duration(seconds: 20));
+    debugPrint('[pdf-spike] step: after PdfDocument.openFile');
+    expect(document.pages, isNotEmpty, reason: 'PDF 至少应有一页');
+    debugPrint('[pdf-spike] pageCount=${document.pages.length}');
+
+    // ---- 文本层可行性：扫全书选一页正文最多的页做证据（首页常是仅含页码的封面）----
+    debugPrint('[pdf-spike] step: before loadStructuredText scan');
+    int bestIndex = 0;
+    PdfPageText? bestText;
+    int bestLen = -1;
+    for (int i = 0; i < document.pages.length; i++) {
+      final PdfPageText t = await document.pages[i]
+          .loadStructuredText()
+          .timeout(const Duration(seconds: 20));
+      // 逐页硬校验：charRects 与 fullText 逐字符一一对应（点选查词地基）。
+      expect(t.charRects.length, t.fullText.length,
+          reason: 'page ${i + 1}: charRects 必须与 fullText 逐字符对应');
+      if (t.fullText.trim().length > bestLen) {
+        bestLen = t.fullText.trim().length;
+        bestIndex = i;
+        bestText = t;
+      }
+    }
+    debugPrint('[pdf-spike] step: after loadStructuredText scan');
+    final PdfPage page = document.pages[bestIndex];
+    final PdfPageText pageText = bestText!;
+    final String fullText = pageText.fullText;
+    final List<PdfRect> charRects = pageText.charRects;
+    debugPrint('[pdf-spike] richest page=${bestIndex + 1} '
+        'size=${page.width}x${page.height}');
+    debugPrint('[pdf-spike] fullText.length=${fullText.length}');
+    final String sample =
+        fullText.length > 100 ? fullText.substring(0, 100) : fullText;
+    debugPrint('[pdf-spike] fullText[0:100]=<<<$sample>>>');
+    debugPrint('[pdf-spike] charRects.length=${charRects.length}');
+    if (charRects.isNotEmpty) {
+      debugPrint('[pdf-spike] charRects.first=${charRects.first}');
+      debugPrint('[pdf-spike] charRects.last=${charRects.last}');
+    }
+
+    expect(fullText.trim(), isNotEmpty, reason: '正文页应抽到非空文本');
+    expect(charRects.length, fullText.length,
+        reason: 'charRects 必须与 fullText 逐字符一一对应（点选查词地基）');
+
+    // ---- 渲染验证：PDFium 直接把这页栅格化成位图并落 PNG ----
+    final double fullWidth = page.width * 2; // 2x 提高可读性
+    final double fullHeight = page.height * 2;
+    final PdfImage? rendered = await page
+        .render(
+          fullWidth: fullWidth,
+          fullHeight: fullHeight,
+          backgroundColor: 0xFFFFFFFF, // 不透明白底，保证非空白判据有意义
+        )
+        .timeout(const Duration(seconds: 30));
+    expect(rendered, isNotNull, reason: 'PDFium 应能栅格化该页');
+    debugPrint(
+        '[pdf-spike] rendered bitmap=${rendered!.width}x${rendered.height} '
+        'pixels=${rendered.pixels.length}B');
+
+    final (bool nonBlank, int pngBytes, String path) = await _saveBgraAsPng(
+      rendered.pixels,
+      rendered.width,
+      rendered.height,
+      'pdf-spike-prince-page${bestIndex + 1}',
+    ).timeout(const Duration(seconds: 30));
+    rendered.dispose();
+    debugPrint('[pdf-spike] screenshot nonBlank=$nonBlank '
+        'pngBytes=$pngBytes path=$path');
+    expect(nonBlank, isTrue, reason: '正文页应栅格化出非空白像素');
+    expect(pngBytes, greaterThan(0), reason: '应写出 PNG');
+
+    // ---- 组件路径轻量确认：PdfViewer 能挂载并触发 onViewerReady（不抓图/不 settle）----
+    final Completer<void> ready = Completer<void>();
+    await tester.pumpWidget(
+      MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: Scaffold(
+          body: PdfViewer.file(
+            _kPdfPath,
+            params: PdfViewerParams(
+              onViewerReady: (_, __) {
+                if (!ready.isCompleted) ready.complete();
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    final DateTime deadline = DateTime.now().add(const Duration(seconds: 15));
+    while (!ready.isCompleted && DateTime.now().isBefore(deadline)) {
+      await tester.pump(const Duration(milliseconds: 200));
+    }
+    debugPrint(
+        '[pdf-spike] PdfViewer onViewerReady fired=${ready.isCompleted}');
+    expect(ready.isCompleted, isTrue,
+        reason: 'PdfViewer 组件应挂载并在超时前触发 onViewerReady');
+
+    await document.dispose();
+  });
+}

--- a/hibiki/ios/Runner/GeneratedPluginRegistrant.m
+++ b/hibiki/ios/Runner/GeneratedPluginRegistrant.m
@@ -162,6 +162,12 @@
 @import path_provider_foundation;
 #endif
 
+#if __has_include(<pdfium_flutter/PDFiumFlutterPlugin.h>)
+#import <pdfium_flutter/PDFiumFlutterPlugin.h>
+#else
+@import pdfium_flutter;
+#endif
+
 #if __has_include(<permission_handler_apple/PermissionHandlerPlugin.h>)
 #import <permission_handler_apple/PermissionHandlerPlugin.h>
 #else
@@ -239,6 +245,7 @@
   [MediaKitVideoPlugin registerWithRegistrar:[registry registrarForPlugin:@"MediaKitVideoPlugin"]];
   [FLTPackageInfoPlusPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLTPackageInfoPlusPlugin"]];
   [PathProviderPlugin registerWithRegistrar:[registry registrarForPlugin:@"PathProviderPlugin"]];
+  [PDFiumFlutterPlugin registerWithRegistrar:[registry registrarForPlugin:@"PDFiumFlutterPlugin"]];
   [PermissionHandlerPlugin registerWithRegistrar:[registry registrarForPlugin:@"PermissionHandlerPlugin"]];
   [RecordIosPlugin registerWithRegistrar:[registry registrarForPlugin:@"RecordIosPlugin"]];
   [FPPSharePlusPlugin registerWithRegistrar:[registry registrarForPlugin:@"FPPSharePlusPlugin"]];

--- a/hibiki/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/hibiki/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -26,6 +26,7 @@ import media_kit_libs_macos_video
 import media_kit_video
 import package_info_plus
 import path_provider_foundation
+import pdfium_flutter
 import record_macos
 import screen_retriever_macos
 import share_plus
@@ -58,6 +59,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   MediaKitVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitVideoPlugin"))
   FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  PDFiumFlutterPlugin.register(with: registry.registrar(forPlugin: "PDFiumFlutterPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/hibiki/pubspec.lock
+++ b/hibiki/pubspec.lock
@@ -1544,6 +1544,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdfium_dart:
+    dependency: transitive
+    description:
+      name: pdfium_dart
+      sha256: "86e95c66b09f3245b95c4924f2edce8d4f7c9786876e5c5ee8e36b104a94bbb0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.5"
+  pdfium_flutter:
+    dependency: transitive
+    description:
+      name: pdfium_flutter
+      sha256: "0b115c0917aef9cf6bb9c4d47d0efc61d97f44844cd76287c921f997c26cf15d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.3"
+  pdfrx:
+    dependency: "direct main"
+    description:
+      name: pdfrx
+      sha256: "4e0efc23547d319ae6089e9593c2c9aca6d858a844eaa7848f95e2c2efea919c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.5"
+  pdfrx_engine:
+    dependency: transitive
+    description:
+      name: pdfrx_engine
+      sha256: "80a1facaf8f587fb2592b53d424a6dc61f74e26c009395f8e52da7d3d3b6b1e6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.4"
   permission_handler:
     dependency: "direct main"
     description:

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -94,6 +94,11 @@ dependencies:
   path: ^1.8.2
   path_provider: ^2.0.13
   permission_handler: ^10.2.0
+  # PDF 阅读器（Phase 0 spike）：PDFium 底层、字符级文本矩形供点选查词。
+  # 五平台 + native-assets/build-hook 下载 PDFium。见 docs/specs/pdf-reader-lookup。
+  # 钉 2.4.5：>=2.4.6 经 pdfrx_engine 拉 image ^4.8.0 → 要 archive ^4.0.7 / xml ^7.0.1，
+  # 与本仓 archive ^3.6.1 / xml ^6.3.0 冲突（升 archive/xml 主版本代价大，Phase 0 先钉）。
+  pdfrx: 2.4.5
   progress_indicators: ^1.0.0
   recase: ^4.1.0
   receive_intent:


### PR DESCRIPTION
## Phase 0 spike（只打通构建/渲染/文本层，不接书架/查词/进度/制卡）

选型 **pdfrx**（espresso3389/pdfrx，MIT，底层 PDFium，五平台，暴露字符级文本矩形供点选查词）。

### 结果（Windows 已验证）
- **pdfrx 版本**：钉 `2.4.5`。`>=2.4.6` 经 `pdfrx_engine` 拉 `image ^4.8.0` → 要 `archive ^4.0.7 / xml ^7.0.1`，与本仓 `archive ^3.6.1 / xml ^6.3.0` 冲突（升 archive/xml 主版本代价大，Phase 0 先钉）。解析后 `pdfrx 2.4.5 / pdfrx_engine 0.4.4 / pdfium_flutter 0.2.3 / pdfium_dart 0.2.5`，无 archive/xml bump。
- **Windows build --debug 全绿**：native-assets build hook 成功下 PDFium 到 `build/native_assets/windows/pdfium.dll`（7.2MB）并写 `native_assets.json`（与 sqlite3 并列）。native-assets 机制在 Flutter 3.44 工作。
- **prince.pdf 渲染出来**：`PdfPage.render()` 栅格化第 9 页（正文）成 1190×1684 BGRA 位图 → 非空白 PNG（截图见测试证据 `pdf-spike-prince-page9.png`：Copyright/邮箱/URL/`$Id`/页码 9）。
- **文本层 charRects 拿到**：`loadStructuredText()` 逐页 `charRects.length == fullText.length`（逐字符 1:1，点选查词地基）。第 9 页 `fullText="Copyright (C) 2000 by Hiroshi Yuki ( )\n..."`（197 字符 / 197 rects）。
- **PdfViewer 组件**：能挂载并触发 `onViewerReady`。
- 集成测试 `integration_test/pdf_spike_render_text_itest.dart`（Windows 离屏 `run_windows_itest.ps1`）**All tests passed**。

### 关键 gotcha（Phase 1 必须关注）
`pdfium_dart` 用 `DynamicLibrary.open('pdfium.dll')` **裸名加载**，不吃 Flutter `native_assets.json` 的 FFI 解析。`flutter test -d windows` 运行时 pdfium.dll 既不在 exe 同目录、也无 `.dart_tool/native_assets.yaml` → worker isolate `open` 失败且**不回传错误** → 首个 `BackgroundWorker.compute` 永久挂死。解法：显式钉 `Pdfrx.pdfiumModulePath` 到真实 DLL 绝对路径（传播到 worker isolate）。**含义：Phase 1 真机打包必须确保 pdfium.dll 随各平台 exe/bundle 一起分发到可被裸名/显式路径加载的位置**——`flutter build windows --debug` 当前把 DLL 放在 `build/native_assets/`，未复制到 runner 同目录，需在打包/分发环节处理。

### 五平台落地已知风险
- 只在 **Windows** 验证。**Mac/iOS/Android/Linux 待验证**（Mac/iOS 需远程 Mac，Android 需 Android 构建）。
- iOS/macOS：pdfium_flutter 是 ffiPlugin（PDFium 静态链进 app），pub get 已改 `GeneratedPluginRegistrant`（本 PR 含）；CocoaPods/XCFramework 拉取待 Mac 真机验证。
- Android/Linux：native-assets 下 `libpdfium.so` 的路径/打包待验证。
- 依赖钉版限制了 pdfrx 后续升级空间，除非本仓升 archive/xml 主版本。

不合并；后续 Phase 1 接入书架/查词/渲染页。