### PR TITLE
feat(video): 视频合集改封面卡网格（用户拍板恢复封面形态）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 38437 (2261 per locale)
+/// Strings: 38471 (2263 per locale)
 ///
-/// Built on 2026-07-22 at 14:47 UTC
+/// Built on 2026-07-22 at 16:24 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3008,6 +3008,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String remote_video_info_size({required Object size}) => 'Size: ${size}';
   String get remote_video_info_no_subtitle => 'No subtitles';
   String get app_icon_presets => 'Presets';
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -8123,6 +8128,13 @@ class _StringsAr extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -13311,6 +13323,13 @@ class _StringsDe extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -18515,6 +18534,13 @@ class _StringsEs extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -23730,6 +23756,13 @@ class _StringsFr extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -28872,6 +28905,13 @@ class _StringsId extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -34062,6 +34102,13 @@ class _StringsIt extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -39057,6 +39104,13 @@ class _StringsJa extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -44055,6 +44109,13 @@ class _StringsKo extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -49223,6 +49284,13 @@ class _StringsNl extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -54406,6 +54474,13 @@ class _StringsPtBr extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -59572,6 +59647,13 @@ class _StringsRu extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -64683,6 +64765,13 @@ class _StringsTh extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -69826,6 +69915,13 @@ class _StringsTr extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -74956,6 +75052,13 @@ class _StringsVi extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 // Path: <root>
@@ -79729,6 +79832,12 @@ class _StringsZhCn extends _StringsEn {
   String get remote_video_info_no_subtitle => '不含字幕';
   @override
   String get app_icon_presets => '预设';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      '已看完 ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) => '继续看 第${n}集';
 }
 
 // Path: <root>
@@ -84642,6 +84751,13 @@ class _StringsZhHk extends _StringsEn {
   String get remote_video_info_no_subtitle => 'No subtitles';
   @override
   String get app_icon_presets => 'Presets';
+  @override
+  String collection_watched_progress(
+          {required Object done, required Object total}) =>
+      'Watched ${done}/${total}';
+  @override
+  String collection_continue_progress({required Object n}) =>
+      'Continue · EP ${n}';
 }
 
 /// Flat map(s) containing all translations.
@@ -89256,6 +89372,11 @@ extension on _StringsEn {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -93868,6 +93989,11 @@ extension on _StringsAr {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -98501,6 +98627,11 @@ extension on _StringsDe {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -103133,6 +103264,11 @@ extension on _StringsEs {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -107771,6 +107907,11 @@ extension on _StringsFr {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -112391,6 +112532,11 @@ extension on _StringsId {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -117026,6 +117172,11 @@ extension on _StringsIt {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -121623,6 +121774,11 @@ extension on _StringsJa {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -126224,6 +126380,11 @@ extension on _StringsKo {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -130852,6 +131013,11 @@ extension on _StringsNl {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -135477,6 +135643,11 @@ extension on _StringsPtBr {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -140107,6 +140278,11 @@ extension on _StringsRu {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -144721,6 +144897,11 @@ extension on _StringsTh {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -149344,6 +149525,11 @@ extension on _StringsTr {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -153962,6 +154148,11 @@ extension on _StringsVi {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }
@@ -158546,6 +158737,11 @@ extension on _StringsZhCn {
         return '不含字幕';
       case 'app_icon_presets':
         return '预设';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            '已看完 ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => '继续看 第${n}集';
       default:
         return null;
     }
@@ -163138,6 +163334,11 @@ extension on _StringsZhHk {
         return 'No subtitles';
       case 'app_icon_presets':
         return 'Presets';
+      case 'collection_watched_progress':
+        return ({required Object done, required Object total}) =>
+            'Watched ${done}/${total}';
+      case 'collection_continue_progress':
+        return ({required Object n}) => 'Continue · EP ${n}';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "弹幕加载失败，请稍后重试",
   "remote_video_info_size": "大小：$size",
   "remote_video_info_no_subtitle": "不含字幕",
-  "app_icon_presets": "预设"
+  "app_icon_presets": "预设",
+  "collection_watched_progress": "已看完 $done/$total",
+  "collection_continue_progress": "继续看 第$n集"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2259,5 +2259,7 @@
   "video_danmaku_manual_bind_failed": "Couldn't load danmaku for this episode. Try again later.",
   "remote_video_info_size": "Size: $size",
   "remote_video_info_no_subtitle": "No subtitles",
-  "app_icon_presets": "Presets"
+  "app_icon_presets": "Presets",
+  "collection_watched_progress": "Watched $done/$total",
+  "collection_continue_progress": "Continue · EP $n"
 }

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -28,7 +28,6 @@ import 'package:hibiki/src/media/video/video_shader_manager.dart';
 import 'package:hibiki/src/media/video/video_shader_tier.dart';
 import 'package:hibiki/src/storage/app_paths.dart';
 import 'package:hibiki/src/models/app_model.dart';
-import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/anime_download_dialog.dart';
 import 'package:hibiki/src/pages/implementations/book_drag_target.dart';
 import 'package:hibiki/src/pages/implementations/collections_page.dart';
@@ -340,16 +339,6 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     unawaited(
       ref.read(appProvider).prefsRepo.setVideoSortModeName(mode.name),
     );
-  }
-
-  /// 合集行折叠开关：`setPref` 先同步刷内存缓存，setState 重建即读到新值；
-  /// 落库 fire-and-forget（`collapsed_collection_ids`，书架/视频页共用）。
-  void _toggleCollectionCollapsed(int collectionId) {
-    final PreferencesRepository prefs = ref.read(appProvider).prefsRepo;
-    final Set<int> ids = prefs.collapsedCollectionIds;
-    if (!ids.remove(collectionId)) ids.add(collectionId);
-    unawaited(prefs.setCollapsedCollectionIds(ids));
-    setState(() {});
   }
 
   /// 统一合集 Phase 2/6：给「缺封面的本地视频行」后台逐个抽一帧当封面。
@@ -1549,7 +1538,8 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     }
   }
 
-  /// 把标签拖到合集行头 = 给整个合集打标签（`CollectionShelfRow.onTagDropped`）。
+  /// 把标签拖到合集封面卡 = 给整个合集打标签（[_buildCollectionCoverCard] 外包的
+  /// [BookDragTarget]）。
   /// `addTagToCollection` 本身幂等（INSERT OR IGNORE），这里先查现有标签给「已存在」
   /// 提示，避免静默无反馈；成功后失效 [filteredCollectionIdsProvider] 让标签过滤下
   /// 合集卡显隐立即刷新（详情页标签行走 FutureBuilder，重进即新）。
@@ -2034,10 +2024,12 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   }
 
   /// 本地视频区的 sliver 列表：空库 / 筛选无结果时是占满剩余空间的提示；否则
-  /// **分区**（去碎片 spec 2026-07-12，已拍板方案 A+顶部）——合集横排行集中
-  /// 渲染在前（[CollectionShelfRow]，区内保持排序模式的组间序），散卡合成
-  /// **单一** [SliverGrid] 在后。旧保序交错布局每个合集行都把网格切段产生残行
-  /// （一两张卡占一行，用户实报）；分区后残行恒 1 个（网格末行）。
+  /// **单一网格**（用户拍板 2026-07-22 恢复封面形态：「一进去就是封面，跟小说
+  /// 那种一样，一眼认出是哪部」）——合集渲染成与散卡同尺寸的**封面卡**
+  /// （[_buildCollectionCoverCard]），与散卡（本地 + 未归属远端占位）合成同一个
+  /// [SliverGrid]：合集卡在前（保持排序模式的组间序）、散卡在后。替代旧
+  /// 「合集横排行 slivers + 散卡网格」两段式（全宽横排行一屏只装下一两个合集，
+  /// 认不出是哪部）。分区序（合集区恒在散卡之上）沿袭去碎片方案 A 拍板。
   List<Widget> _buildLocalVideoSlivers(
     List<VideoBookRow> all,
     List<VideoBookRow> books,
@@ -2085,27 +2077,17 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         ref.watch(filteredCollectionIdsProvider).valueOrNull;
     bool collectionVisible(int collectionId) =>
         collectionFilter == null || collectionFilter.contains(collectionId);
-    // 块2：记录本帧渲染成横排行的合集 id（供全选/反选把可见合集纳入整选集）。
+    // 块2：记录本帧渲染成封面卡的合集 id（供全选/反选把可见合集纳入整选集）。
     // 被标签过滤隐藏的合集不计入可见集，避免全选勾中隐藏合集。
     _visibleCollectionIds = <int>[
       for (final CollectionGroup<_VideoSlot> g in groups)
         if (g.collection != null && collectionVisible(g.collection!.id))
           g.collection!.id,
     ];
-    final bool hasCollectionRows = groups.any(
-      (CollectionGroup<_VideoSlot> g) =>
-          g.collection != null && collectionVisible(g.collection!.id),
-    );
-    // 零合集：单网格 + 原 EdgeInsets.all 内边距（与旧布局逐像素一致）。
-    final EdgeInsetsGeometry gridPadding = hasCollectionRows
-        ? EdgeInsets.symmetric(
-            horizontal: tokens.spacing.card,
-            vertical: tokens.spacing.gap,
-          )
-        : EdgeInsets.all(tokens.spacing.card);
-    final List<Widget> slivers = <Widget>[];
-    // 方案A（去碎片）：合集行集中渲染在前（可含远端占位成员），散卡（本地 + 未归属
-    // 远端占位）合成单一网格在后，按当前排序模式统一排序（远端进度时间戳/目录序退化）。
+    // 合集卡在前（保持排序模式的组间序）、散卡（本地 + 未归属远端占位）在后，
+    // 全部并入同一个网格（cell 逐像素同尺寸）。
+    final List<CollectionGroup<_VideoSlot>> collectionGroups =
+        <CollectionGroup<_VideoSlot>>[];
     final List<_VideoLooseCard> loose = <_VideoLooseCard>[];
     for (final CollectionGroup<_VideoSlot> group in groups) {
       if (group.collection == null) {
@@ -2115,20 +2097,25 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
           build: () => _buildVideoSlotCard(slot),
         ));
       } else if (collectionVisible(group.collection!.id)) {
-        slivers.add(
-          SliverToBoxAdapter(
-            child: _buildVideoCollectionRow(group, cardLayout),
-          ),
-        );
+        collectionGroups.add(group);
       }
-      // 标签过滤隐藏的合集：整行连同成员一并跳过（成员随合集隐藏，符合按合集标签显隐语义）。
+      // 标签过滤隐藏的合集：整卡连同成员一并跳过（成员随合集隐藏，符合按合集标签显隐语义）。
     }
     loose.sort((_VideoLooseCard a, _VideoLooseCard b) =>
         compareShelfSortKeys(a.sortKey, b.sortKey, _sortMode));
-    if (loose.isNotEmpty) {
-      slivers.add(_buildLooseVideoGridSliver(loose, gridPadding, cardLayout));
-    }
-    return slivers;
+    final List<Widget Function()> cells = <Widget Function()>[
+      for (final CollectionGroup<_VideoSlot> group in collectionGroups)
+        () => _buildCollectionCoverCard(group),
+      for (final _VideoLooseCard card in loose) card.build,
+    ];
+    if (cells.isEmpty) return const <Widget>[];
+    return <Widget>[
+      _buildVideoGridSliver(
+        cells,
+        EdgeInsets.all(tokens.spacing.card),
+        cardLayout,
+      ),
+    ];
   }
 
   /// 散卡分派：本地卡 [_buildCard] / 远端占位卡 [_buildRemoteVideoCard]（任务10 union）。
@@ -2238,17 +2225,175 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     );
   }
 
-  /// 一个合集的全宽横排行：头（合集名+集数+查看全部→详情页）+ 横向成员卡列表。
-  /// 本地成员卡复用 [_buildCard] 并带 playlistCollectionId——点某集**直接从该集**进
-  /// 播放器（带剧集面板/上下集/连播）；远端占位成员（任务10 union）走 [_buildRemoteVideoCard]
-  /// （流播/下载，无本地集坐标故不带 playlistCollectionId）。初始横滚定位到「继续看」成员。
-  Widget _buildVideoCollectionRow(
-    CollectionGroup<_VideoSlot> group,
-    ({int columns, double cardWidth}) cardLayout,
-  ) {
-    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+  /// 合集封面卡（用户拍板 2026-07-22 恢复封面形态：「文字合集替换成一个封面」）。
+  /// 几何与散卡逐像素同规格（unifiedShelfCardLayout 卡宽 × [_videoCardExtent]
+  /// cell 高：16:9 封面 + 标题 footer + 进度行），并入主网格。
+  ///
+  /// 原横排行的能力全数搬进整卡（Never break userspace）：
+  /// - 点击 = 进合集详情页（原「查看全部」，点某集从详情页进播放器带连播上下文）；
+  /// - focusId 沿用 `home-video-collection-<id>`（手柄/键盘映射不变）；
+  /// - 多选态整卡勾选 = 选中整个合集（[_selectedCollectionIds]）；
+  /// - 拖标签到卡 = 给合集打标签（[BookDragTarget]，与散卡书级拖放一致）；
+  /// - 计数含远端占位成员（与详情所见同源，BUG-790 口径）；含远端占位时右上云角标。
+  ///
+  /// 折叠偏好（`collapsed_collection_ids`）视频侧退役：封面卡无成员行可折叠；
+  /// 书架横排行照旧读写该偏好，pref 本身不动。
+  Widget _buildCollectionCoverCard(CollectionGroup<_VideoSlot> group) {
     final MediaCollectionRow collection = group.collection!;
-    final int continueIdx = continueMemberIndex(<CollectionMemberProgress>[
+    final List<BookTagRow> tags =
+        ref.watch(collectionTagMapProvider).valueOrNull?[collection.id] ??
+            const <BookTagRow>[];
+    final int memberCount = group.items.length;
+    final bool hasRemoteMember = group.items.any(
+        (CollectionOrderingItem<_VideoSlot> it) => it.payload.remote != null);
+    final bool selected =
+        _selectionMode && _selectedCollectionIds.contains(collection.id);
+    final HibikiCard card = HibikiCard(
+      key: ValueKey<String>('home_video_collection_card_${collection.id}'),
+      focusId: HibikiFocusId('home-video-collection-${collection.id}'),
+      padding: EdgeInsets.zero,
+      selected: selected,
+      // 多选态整卡点击 = 整选合集；平时点击 = 进详情（原「查看全部」）。
+      onTap: _selectionMode
+          ? () => _toggleCollectionSelection(collection.id)
+          : () => _openCollectionDetail(collection),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          AspectRatio(
+            aspectRatio: 16 / 9,
+            child: Stack(
+              fit: StackFit.expand,
+              children: <Widget>[
+                _buildCollectionCover(group),
+                // 合集标签 chip 列（左上，与散卡标签层同形）；多选态让位勾选框。
+                if (tags.isNotEmpty && !_selectionMode)
+                  Positioned(
+                    top: 6,
+                    left: 6,
+                    child: _buildTagLabels(tags),
+                  ),
+                // 含远端占位成员 → 右上云角标（与散卡云角标同款 CoverBadge）。
+                if (hasRemoteMember)
+                  Positioned(
+                    top: 6,
+                    right: 6,
+                    child: CoverBadge(
+                      key: ValueKey<String>(
+                          'home_video_collection_cloud_${collection.id}'),
+                      icon: Icons.cloud_outlined,
+                      iconSize: 13,
+                    ),
+                  ),
+                // 左下 playlist 图标 + 成员数（本地 + 远端占位，与详情所见同源，
+                // BUG-790 口径：数字必须诚实反映合集实际成员数）。
+                Positioned(
+                  bottom: 6,
+                  left: 6,
+                  child: _buildPlaylistBadge(memberCount),
+                ),
+                if (_selectionMode)
+                  Positioned(
+                    top: 6,
+                    left: 6,
+                    child: _buildSelectionCheck(selected),
+                  ),
+                if (selected)
+                  Positioned.fill(
+                    child: IgnorePointer(
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .primary
+                              .withValues(alpha: 0.12),
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          // footer：合集名 + 进度行（结构与散卡 [_buildCard] 同骨架）。
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(8, 6, 8, 2),
+                  child: Text(
+                    collection.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                ),
+                Flexible(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(8, 0, 8, 6),
+                    child: Text(
+                      _collectionProgressLabel(group),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: HibikiDesignTokens.of(context).type.metadata,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+    // 选择态下禁用标签拖放命中（与散卡一致：避免选卡时误触拖标签）。
+    if (_selectionMode) return card;
+    return BookDragTarget(
+      bookId: 'collection:${collection.id}',
+      onTagDropped: (BookTagRow tag) =>
+          _addTagToVideoCollection(collection.id, tag),
+      child: card,
+    );
+  }
+
+  /// 合集卡封面借用：首个有本地封面的成员 → 首个远端成员封面（互联/云 fetch 路径）
+  /// → 无封面占位（与散卡同款 surfaceContainer + movie 图标）。组内序优先，故
+  /// 默认就是 [CollectionGroup.coverItem]（首成员）的封面，成员缺封面时向后借。
+  Widget _buildCollectionCover(CollectionGroup<_VideoSlot> group) {
+    for (final CollectionOrderingItem<_VideoSlot> it in group.items) {
+      final VideoBookRow? local = it.payload.local;
+      if (local == null) continue;
+      final String? cover = local.coverPath;
+      if (cover != null && cover.isNotEmpty && File(cover).existsSync()) {
+        return _coverBacking(
+          Image.file(
+            File(cover),
+            fit: BoxFit.contain,
+            cacheWidth: kLocalCoverDecodePixelWidth,
+            errorBuilder: (_, __, ___) => _coverPlaceholder(),
+          ),
+        );
+      }
+    }
+    for (final CollectionOrderingItem<_VideoSlot> it in group.items) {
+      final RemoteVideoInfo? remote = it.payload.remote;
+      if (remote == null) continue;
+      final bool hasCover =
+          (remote.coverPath != null && File(remote.coverPath!).existsSync()) ||
+              (remote.coverUrl != null && remote.coverUrl!.isNotEmpty);
+      if (hasCover) return _buildRemoteVideoCover(remote);
+    }
+    return _coverPlaceholder();
+  }
+
+  /// 合集卡进度行：有观看痕迹且未整套看完 → 「继续看 第n集」（[continueMemberIndex]
+  /// 纯函数，与旧横排行初始横滚定位同源）；否则 → 「已看完 x/N」（x = completedAt
+  /// 非空的本地成员数；远端占位无本地完成态，只计入 N）。
+  String _collectionProgressLabel(CollectionGroup<_VideoSlot> group) {
+    final int total = group.items.length;
+    int completed = 0;
+    bool hasTrace = false;
+    final List<CollectionMemberProgress> progresses =
+        <CollectionMemberProgress>[
       for (final CollectionOrderingItem<_VideoSlot> it in group.items)
         CollectionMemberProgress(
           // 远端占位无本地播放断点：用远端进度 positionMs、completed 恒 false。
@@ -2257,75 +2402,17 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
               0,
           completed: it.payload.local?.completedAt != null,
         ),
-    ]);
-    // 行头计数 = 行体实际渲染的成员数（本地 + 远端占位），与 itemCount 同源（BUG-790）。
-    // 旧口径只数本地成员，导致「全为未下载远端剧集」的合集行明明有云占位卡却显示「0 集」，
-    // 与眼前所见割裂（用户实报）。行头数字必须诚实反映该行看得见的卡片数。
-    final int memberCount = group.items.length;
-    return Padding(
-      padding: EdgeInsets.fromLTRB(
-        tokens.spacing.card,
-        tokens.spacing.gap,
-        tokens.spacing.card,
-        tokens.spacing.gap,
-      ),
-      child: CollectionShelfRow(
-        key: ValueKey<String>('home_video_collection_row_${collection.id}'),
-        title: collection.name,
-        countLabel: t.video_playlist_episodes(count: memberCount),
-        itemCount: memberCount,
-        // 与散卡网格 cell 同宽同高（unifiedShelfCardLayout + _videoCardExtent：
-        // 16:9 封面 + 标题 + Phase D 观看进度行，随卡宽联动）。
-        itemWidth: cardLayout.cardWidth,
-        rowHeight: _videoCardExtent(cardLayout.cardWidth),
-        initialIndex: continueIdx,
-        headerFocusId: HibikiFocusId('home-video-collection-${collection.id}'),
-        onOpenDetail: () => _openCollectionDetail(collection),
-        collapsed: ref
-            .watch(appProvider)
-            .prefsRepo
-            .collapsedCollectionIds
-            .contains(collection.id),
-        onToggleCollapsed: () => _toggleCollectionCollapsed(collection.id),
-        // 块2：多选态行头挂整选勾选框（选=选中整个合集）；成员卡在多选态不可单独勾。
-        selectionCheckbox: _selectionMode
-            ? _buildSelectionCheck(
-                _selectedCollectionIds.contains(collection.id))
-            : null,
-        onToggleSelected: _selectionMode
-            ? () => _toggleCollectionSelection(collection.id)
-            : null,
-        // 拖标签到行头 = 给整个合集打标签（与散卡书级拖放一致）。
-        onTagDropped: (BookTagRow tag) =>
-            _addTagToVideoCollection(collection.id, tag),
-        // 行头下方展示该合集已打的标签 chip（与散卡标签列同形）。
-        tags: ref.watch(collectionTagMapProvider).valueOrNull?[collection.id],
-        itemBuilder: (BuildContext _, int i) {
-          final _VideoSlot slot = group.items[i].payload;
-          final VideoBookRow? local = slot.local;
-          if (local != null) {
-            return _buildCard(
-              local,
-              playlistCollectionId: collection.id,
-              selectable: false,
-            );
-          }
-          // 客户端合集连播：把本合集的有序远端成员（跳过本地成员）+ 被点成员下标传给卡片，
-          // 播放器据此建剧集列表 + 跨成员自动连播。混合合集里本地成员走本地播放，不入此列。
-          final List<RemoteVideoInfo> remoteMembers = <RemoteVideoInfo>[
-            for (final CollectionOrderingItem<_VideoSlot> it in group.items)
-              if (it.payload.remote != null) it.payload.remote!,
-          ];
-          final int memberIdx = remoteMembers
-              .indexWhere((RemoteVideoInfo m) => m.id == slot.remote!.id);
-          return _buildRemoteVideoCard(
-            slot.remote!,
-            collectionMembers: remoteMembers.length > 1 ? remoteMembers : null,
-            memberIndex: memberIdx < 0 ? 0 : memberIdx,
-          );
-        },
-      ),
-    );
+    ];
+    for (final CollectionMemberProgress p in progresses) {
+      if (p.completed) completed++;
+      if (p.completed || (p.positionMs ?? 0) > 0) hasTrace = true;
+    }
+    if (hasTrace && completed < total) {
+      return t.collection_continue_progress(
+        n: continueMemberIndex(progresses) + 1,
+      );
+    }
+    return t.collection_watched_progress(done: completed, total: total);
   }
 
   /// 多端库联合视图占位卡（spec 2026-07-12 §2.1，撤独立远端分区）：本地视频卡尺寸 +
@@ -2712,12 +2799,9 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     );
   }
 
-  /// 连续散视频段落的 [SliverGrid]（TODO-654：随主 [CustomScrollView] 滚动；
-  /// 网格 delegate 与远端区一致）。UI v2 Phase C 后合集不再进网格（渲染成全宽
-  /// 横排行），本网格只装散视频单卡。
   /// 视频卡总高 = 16:9 封面高（[cardWidth] × 9/16）+ 文字块 [_kVideoCardTextBlock]。
-  /// 卡变窄时封面等比缩，不出现固定卡高下的封面上下留白。散卡网格 [mainAxisExtent]
-  /// 与合集横排行 [CollectionShelfRow.rowHeight] 共用此高，保持逐像素同尺寸。
+  /// 卡变窄时封面等比缩，不出现固定卡高下的封面上下留白。合集封面卡与散卡同处
+  /// 一个网格、共用此 [mainAxisExtent]，逐像素同尺寸。
   static double _videoCardExtent(double cardWidth) =>
       cardWidth * 9 / 16 + _kVideoCardTextBlock;
 
@@ -2727,25 +2811,27 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   /// 内收，无进度时仅剩约一行的常规内边距，不再是显眼空块）。
   static const double _kVideoCardTextBlock = 52;
 
-  Widget _buildLooseVideoGridSliver(
-    List<_VideoLooseCard> loose,
+  /// 视频库主 [SliverGrid]（TODO-654：随主 [CustomScrollView] 滚动）：合集封面
+  /// 卡在前、散卡在后的**单一**网格（[cells] 已按此序拼好）。
+  Widget _buildVideoGridSliver(
+    List<Widget Function()> cells,
     EdgeInsetsGeometry padding,
     ({int columns, double cardWidth}) cardLayout,
   ) {
     return SliverPadding(
       padding: padding,
       sliver: SliverGrid.builder(
-        // FixedCrossAxisCount + 统一卡宽（unifiedShelfCardLayout）：散卡 cell 与
-        // 合集横排行成员卡逐像素同尺寸（用户实报合集卡大一截）。卡高随卡宽按
-        // 16:9 封面联动（_videoCardExtent），窄卡不再残留固定 218 的封面上下留白。
+        // FixedCrossAxisCount + 统一卡宽（unifiedShelfCardLayout）：全部 cell
+        // 逐像素同尺寸。卡高随卡宽按 16:9 封面联动（_videoCardExtent），窄卡
+        // 不再残留固定 218 的封面上下留白。
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: cardLayout.columns,
           mainAxisExtent: _videoCardExtent(cardLayout.cardWidth),
           crossAxisSpacing: 12,
           mainAxisSpacing: 12,
         ),
-        itemCount: loose.length,
-        itemBuilder: (BuildContext context, int i) => loose[i].build(),
+        itemCount: cells.length,
+        itemBuilder: (BuildContext context, int i) => cells[i](),
       ),
     );
   }

--- a/hibiki/test/pages/home_video_batch_collection_ops_test.dart
+++ b/hibiki/test/pages/home_video_batch_collection_ops_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/models.dart';
 import 'package:hibiki/src/anki/anki_view_model.dart';
-import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/home_video_page.dart';
@@ -22,7 +21,7 @@ import '../helpers/fake_anki_repository.dart';
 import '../helpers/test_platform_services.dart';
 
 /// 块2/3/4 视频库批量合集操作 widget 测试（真写穿内存 DB）：
-///  - 多选态合集整选（行头勾选 → 合集入选中集、成员卡无勾选框）；
+///  - 多选态合集整选（封面卡整卡勾选 → 合集入选中集；成员卡收进详情页不在库页）；
 ///  - 组合三档（新建 / 并入 / 合并默认名）；
 ///  - 删除区分（解散不删媒体行 / 混选计数文案）。
 void main() {
@@ -112,7 +111,7 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('块2：行头勾选 → 合集入选中集；成员卡多选态无勾选框', (WidgetTester tester) async {
+  testWidgets('块2：合集封面卡勾选 → 整合集入选中集；成员卡不在库页', (WidgetTester tester) async {
     await seedVideo('video/ep1', '第1集');
     await seedVideo('video/ep2', '第2集');
     final int cid = await db.createMediaCollection('合集甲');
@@ -122,29 +121,26 @@ void main() {
     await pumpPage(tester);
     await enterSelectionMode(tester);
 
-    // 进多选态：行头有 1 个勾选框（透明对勾），成员卡无勾选框。
+    // 进多选态：合集封面卡带 1 个勾选框（透明对勾）；成员卡不在库页（收进详情页）。
     expect(
       find.descendant(
-        of: find.byType(CollectionShelfRow),
+        of: find.byKey(ValueKey<String>('home_video_collection_card_$cid')),
         matching: find.byIcon(Icons.check),
       ),
       findsOneWidget,
-      reason: '仅合集行头一个勾选框；成员卡不画勾（selectable=false）',
+      reason: '合集封面卡多选态画整选勾选框',
     );
     expect(
-      find.descendant(
-        of: find.byKey(const ValueKey<String>('home_video_video/ep1')),
-        matching: find.byIcon(Icons.check),
-      ),
+      find.byKey(const ValueKey<String>('home_video_video/ep1')),
       findsNothing,
-      reason: '成员卡多选态不可单独勾（无勾选框）',
+      reason: '合集成员卡不在库页（封面卡形态），无从单独勾选',
     );
 
-    // 点行头 → 整合集入选中集，底栏计数 = 1。
+    // 点合集卡 → 整合集入选中集，底栏计数 = 1。
     await tester.tap(find.text('合集甲'));
     await tester.pumpAndSettle();
     expect(find.text(t.batch_selected_count(n: 1)), findsOneWidget,
-        reason: '行头勾选把合集计入选中集');
+        reason: '整卡勾选把合集计入选中集');
   });
 
   testWidgets('块3 档1：仅散卡 → 命名弹窗新建合集', (WidgetTester tester) async {

--- a/hibiki/test/pages/home_video_collapse_test.dart
+++ b/hibiki/test/pages/home_video_collapse_test.dart
@@ -20,11 +20,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../helpers/fake_anki_repository.dart';
 import '../helpers/test_platform_services.dart';
 
-/// 合集行折叠端到端接线（视频库页；书架共用同一 CollectionShelfRow +
-/// `collapsed_collection_ids` 偏好，组件行为见 collection_shelf_row_collapse_test）：
-///  - 点行头 chevron 折叠 → 成员卡消失、行头仍在；
-///  - 折叠集写穿偏好（跨启动记住）；
-///  - 带已折叠偏好开页 → 直接折叠渲染。
+/// 视频页折叠语义退役守卫（用户拍板 2026-07-22 合集改封面卡）：
+/// 封面卡无成员行可折叠——视频页不再渲染折叠 chevron、不再读写
+/// `collapsed_collection_ids` 偏好（书架横排行照旧用它，组件行为见
+/// collection_shelf_row_collapse_test）：
+///  - 视频页合集渲染成封面卡：无折叠开关、成员卡不在库页；
+///  - 带「已折叠」偏好开页 → 封面卡照常完整渲染（偏好对视频页无效且不被改写）。
 void main() {
   final TestWidgetsFlutterBinding binding =
       TestWidgetsFlutterBinding.ensureInitialized();
@@ -108,7 +109,7 @@ void main() {
         ),
       );
 
-  testWidgets('点行头 chevron 折叠：成员卡消失、行头仍在、偏好写穿', (WidgetTester tester) async {
+  testWidgets('合集渲染成封面卡：无折叠开关、成员卡不在库页', (WidgetTester tester) async {
     tester.view.physicalSize = const Size(1280, 800);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
@@ -116,29 +117,20 @@ void main() {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
 
-    expect(find.text('某番剧'), findsOneWidget, reason: '合集行头在');
-    expect(find.text('第1集'), findsWidgets, reason: '展开态成员卡在');
-
-    await tester.tap(find.byTooltip(t.collection_collapse));
-    await tester.pumpAndSettle();
-
-    expect(find.text('某番剧'), findsOneWidget, reason: '折叠后行头仍在');
-    expect(find.text('第1集'), findsNothing, reason: '折叠后成员卡消失');
-    expect(find.text('第2集'), findsNothing);
     expect(
-      prefs.collapsedCollectionIds,
-      contains(collectionId),
-      reason: '折叠集必须写穿偏好（跨启动记住）',
+      find.byKey(ValueKey<String>('home_video_collection_card_$collectionId')),
+      findsOneWidget,
+      reason: '合集必须渲染成封面卡',
     );
-
-    // 再点展开：成员回来、偏好清除。
-    await tester.tap(find.byTooltip(t.collection_expand));
-    await tester.pumpAndSettle();
-    expect(find.text('第1集'), findsWidgets);
-    expect(prefs.collapsedCollectionIds, isNot(contains(collectionId)));
+    expect(find.text('某番剧'), findsOneWidget, reason: '卡 footer 显示合集名');
+    expect(find.text('第1集'), findsNothing, reason: '成员卡收进详情页，不在库页');
+    expect(find.text('第2集'), findsNothing);
+    expect(find.byTooltip(t.collection_collapse), findsNothing,
+        reason: '封面卡无成员行可折叠——不得再渲染折叠开关');
+    expect(find.byTooltip(t.collection_expand), findsNothing);
   });
 
-  testWidgets('带已折叠偏好开页：直接折叠渲染', (WidgetTester tester) async {
+  testWidgets('带「已折叠」偏好开页：封面卡照常完整渲染、偏好不被视频页改写', (WidgetTester tester) async {
     tester.view.physicalSize = const Size(1280, 800);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
@@ -147,7 +139,14 @@ void main() {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
 
+    expect(
+      find.byKey(ValueKey<String>('home_video_collection_card_$collectionId')),
+      findsOneWidget,
+      reason: '旧折叠偏好对封面卡无效：卡照常渲染',
+    );
     expect(find.text('某番剧'), findsOneWidget);
-    expect(find.text('第1集'), findsNothing, reason: '开页读偏好：上次折叠的合集保持折叠');
+    // 偏好保持原样（书架还在用；视频页不再读写它）。
+    expect(prefs.collapsedCollectionIds, contains(collectionId),
+        reason: '视频页不得改写 collapsed_collection_ids（书架仍在用）');
   });
 }

--- a/hibiki/test/pages/home_video_collection_cover_card_test.dart
+++ b/hibiki/test/pages/home_video_collection_cover_card_test.dart
@@ -1,0 +1,291 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/anki/anki_view_model.dart';
+import 'package:hibiki/src/media/video/video_book_repository.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/home_video_page.dart';
+import 'package:hibiki/src/pages/implementations/media_collection_detail_page.dart';
+import 'package:hibiki/src/pages/implementations/tag_filter_bar.dart';
+import 'package:hibiki/src/platform/platform_providers.dart';
+import 'package:hibiki/src/platform/platform_services.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/fake_anki_repository.dart';
+import '../helpers/test_platform_services.dart';
+
+/// 合集封面卡渲染守卫（用户拍板 2026-07-22：视频页合集从全宽横排行改回封面卡，
+/// 「一进去就是封面，跟小说那种一样，一眼认出是哪部」）：
+///  - 有封面成员 → 卡显该成员封面（借用组内首个有封面的本地成员）；
+///  - 无封面 → 占位（surfaceContainer + movie 图标，与散卡同款）；
+///  - 集数角标 = 全部成员数；进度行「已看完 x/N」/「继续看 第n集」；
+///  - 点击整卡 → 进合集详情页（原「查看全部」）；
+///  - 拖标签到卡 → 给整个合集打标签（真写穿内存 DB）。
+/// 多选整选另见 home_video_batch_collection_ops_test（块2）。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// 1x1 透明 PNG（真实可解码文件，喂 Image.file）。
+  final List<int> onePixelPng = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ'
+    'AAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  );
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('hibiki_cover_card_pp');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      pathProviderDir.deleteSync(recursive: true);
+    }
+  });
+
+  late HibikiDatabase db;
+  late PreferencesRepository prefs;
+  late PlatformServices platformServices;
+  late FakeAnkiRepository ankiRepository;
+  late AppModel appModel;
+  late Directory storeDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir = Directory.systemTemp.createTempSync('hibiki_cover_card');
+    platformServices = testPlatformServices();
+    ankiRepository = FakeAnkiRepository();
+    appModel = AppModel(platformServices)
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (storeDir.existsSync()) {
+      storeDir.deleteSync(recursive: true);
+    }
+  });
+
+  Future<void> seedEpisode(
+    String uid,
+    String title, {
+    String? coverPath,
+    DateTime? completedAt,
+    int lastPositionMs = 0,
+  }) async {
+    await db.upsertVideoBook(VideoBooksCompanion(
+      bookUid: Value(uid),
+      title: Value(title),
+      videoPath: Value('/abs/$uid.mp4'),
+      coverPath: Value(coverPath),
+      completedAt: Value(completedAt),
+      lastPositionMs: Value(lastPositionMs),
+      importedAt: Value(DateTime(2026, 1, 1)),
+    ));
+  }
+
+  Future<int> seedCollection(List<String> uids, {String name = '某番剧'}) async {
+    final int cid = await db.createMediaCollection(
+      name,
+      collectionType: 'playlist',
+    );
+    for (final String uid in uids) {
+      await db.addToCollection(cid, 'video', uid);
+    }
+    return cid;
+  }
+
+  Widget buildApp() => ProviderScope(
+        overrides: <Override>[
+          platformServicesProvider.overrideWithValue(platformServices),
+          ankiRepositoryProvider.overrideWithValue(ankiRepository),
+          appProvider.overrideWith((ref) => appModel),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(body: HomeVideoPage(repo: VideoBookRepository(db))),
+          ),
+        ),
+      );
+
+  Future<void> pumpPage(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+  }
+
+  Finder cardFinder(int cid) =>
+      find.byKey(ValueKey<String>('home_video_collection_card_$cid'));
+
+  testWidgets('有封面成员 → 卡显该成员封面（借用组内首个有封面的本地成员）', (WidgetTester tester) async {
+    // ep1 无封面、ep2 有封面：组内序首成员缺封面时向后借。
+    final File cover = File('${storeDir.path}/ep2_cover.png')
+      ..writeAsBytesSync(onePixelPng);
+    await seedEpisode('video/ep1', '第1集');
+    await seedEpisode('video/ep2', '第2集', coverPath: cover.path);
+    final int cid = await seedCollection(<String>['video/ep1', 'video/ep2']);
+
+    await pumpPage(tester);
+
+    final Finder images = find.descendant(
+      of: cardFinder(cid),
+      matching: find.byType(Image),
+    );
+    expect(images, findsOneWidget, reason: '合集卡必须渲染成员封面');
+    final Image image = tester.widget<Image>(images);
+    final ImageProvider provider = image.image;
+    final FileImage fileImage = (provider is ResizeImage
+        ? provider.imageProvider
+        : provider) as FileImage;
+    expect(fileImage.file.path, cover.path, reason: '封面必须借用组内首个有封面的本地成员（ep2）');
+    // 有封面时不显示占位图标。
+    expect(
+      find.descendant(
+        of: cardFinder(cid),
+        matching: find.byIcon(Icons.movie_outlined),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets('无封面 → 占位图标；集数角标 = 全部成员数；默认进度「已看完 0/N」',
+      (WidgetTester tester) async {
+    await seedEpisode('video/ep1', '第1集');
+    await seedEpisode('video/ep2', '第2集');
+    final int cid = await seedCollection(<String>['video/ep1', 'video/ep2']);
+
+    await pumpPage(tester);
+
+    expect(cardFinder(cid), findsOneWidget);
+    expect(
+      find.descendant(
+        of: cardFinder(cid),
+        matching: find.byIcon(Icons.movie_outlined),
+      ),
+      findsOneWidget,
+      reason: '全员无封面 → 占位（与散卡同款 movie 图标）',
+    );
+    expect(
+      find.descendant(
+        of: cardFinder(cid),
+        matching: find.text(t.video_playlist_episodes(count: 2)),
+      ),
+      findsOneWidget,
+      reason: '集数角标 = 全部成员数',
+    );
+    expect(
+      find.descendant(
+        of: cardFinder(cid),
+        matching: find.text(t.collection_watched_progress(done: 0, total: 2)),
+      ),
+      findsOneWidget,
+      reason: '无观看痕迹 → 进度行「已看完 0/N」',
+    );
+    // 封面卡形态：成员卡不在库页。
+    expect(find.text('第1集'), findsNothing);
+  });
+
+  testWidgets('进度行：有痕迹未看完 → 「继续看 第n集」；全看完 → 「已看完 N/N」',
+      (WidgetTester tester) async {
+    // ep1 已看完 → 继续看候选 = 第2集。
+    await seedEpisode('video/ep1', '第1集', completedAt: DateTime(2026, 1, 2));
+    await seedEpisode('video/ep2', '第2集');
+    final int cid = await seedCollection(<String>['video/ep1', 'video/ep2']);
+
+    await pumpPage(tester);
+    expect(
+      find.descendant(
+        of: cardFinder(cid),
+        matching: find.text(t.collection_continue_progress(n: 2)),
+      ),
+      findsOneWidget,
+      reason: 'ep1 看完 → 继续看候选落在第2集（continueMemberIndex 同源）',
+    );
+
+    // 全部看完 → 「已看完 2/2」。
+    await db.upsertVideoBook(VideoBooksCompanion(
+      bookUid: const Value('video/ep2'),
+      title: const Value('第2集'),
+      videoPath: const Value('/abs/video/ep2.mp4'),
+      completedAt: Value(DateTime(2026, 1, 3)),
+      importedAt: Value(DateTime(2026, 1, 1)),
+    ));
+    HomeVideoPage.debugRefreshVideos?.call();
+    await tester.pumpAndSettle();
+    expect(
+      find.descendant(
+        of: cardFinder(cid),
+        matching: find.text(t.collection_watched_progress(done: 2, total: 2)),
+      ),
+      findsOneWidget,
+      reason: '全部看完 → 「已看完 N/N」',
+    );
+  });
+
+  testWidgets('点击合集卡 → 打开合集详情页（原「查看全部」行为）', (WidgetTester tester) async {
+    await seedEpisode('video/ep1', '第1集');
+    await seedEpisode('video/ep2', '第2集');
+    final int cid = await seedCollection(<String>['video/ep1', 'video/ep2']);
+
+    await pumpPage(tester);
+    await tester.tap(cardFinder(cid));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MediaCollectionDetailPage), findsOneWidget,
+        reason: '整卡即详情入口（点某集从详情页进播放器带连播上下文）');
+  });
+
+  testWidgets('拖标签到合集卡 → 给整个合集打标签（真写穿 DB）', (WidgetTester tester) async {
+    await seedEpisode('video/ep1', '第1集');
+    await seedEpisode('video/ep2', '第2集');
+    final int cid = await seedCollection(<String>['video/ep1', 'video/ep2']);
+    final int tagId = await db.createTag('Anime', 0xFF2196F3);
+
+    await pumpPage(tester);
+
+    final Finder tagChip = find
+        .descendant(
+          of: find.byType(HibikiTagFilterBar),
+          matching: find.text('Anime'),
+        )
+        .first;
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(tagChip),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 100));
+    await gesture.moveTo(tester.getCenter(cardFinder(cid)));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    final List<BookTagRow> tags = await db.getTagsForCollection(cid);
+    expect(tags.map((BookTagRow t) => t.id), contains(tagId),
+        reason: '拖标签到封面卡必须写穿合集标签（原横排行行头能力保留）');
+  });
+}

--- a/hibiki/test/pages/home_video_partition_test.dart
+++ b/hibiki/test/pages/home_video_partition_test.dart
@@ -20,11 +20,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../helpers/fake_anki_repository.dart';
 import '../helpers/test_platform_services.dart';
 
-/// 去碎片方案 A（spec 2026-07-12-shelf-grid-defrag，已拍板：分区+顶部）：
-/// 构造一个**旧交错布局必然切碎网格**的排序局面——「最近」模式下散卡 A >
-/// 合集 > 散卡 B——锁死分区后的两条不变量：
-///  ① 合集行渲染在所有散卡之上（顶部合集区），即使某散卡比它「更最近」；
-///  ② 两张散卡同行渲染（单一网格；旧布局它们被合集行切成两段、各占一残行）。
+/// 去碎片方案 A（spec 2026-07-12 分区拍板）+ 封面卡形态（用户拍板 2026-07-22）：
+/// 构造「最近」模式下散卡 A > 合集 > 散卡 B 的排序局面，锁死两条不变量：
+///  ① 合集封面卡在网格里排在所有散卡之前（合集区在前），即使某散卡比它「更最近」；
+///  ② 合集卡与散卡合成**单一** [SliverGrid]（旧横排行形态是「行 slivers + 网格」
+///     两段式；更旧的交错布局把散卡切成多个残段网格）。
 void main() {
   final TestWidgetsFlutterBinding binding =
       TestWidgetsFlutterBinding.ensureInitialized();
@@ -133,7 +133,7 @@ void main() {
         ),
       );
 
-  testWidgets('合集区在所有散卡之上；两张散卡同行（单一网格无切碎）', (WidgetTester tester) async {
+  testWidgets('合集封面卡排在所有散卡之前；合集卡+散卡合成单一网格', (WidgetTester tester) async {
     tester.view.physicalSize = const Size(1280, 800);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
@@ -141,16 +141,24 @@ void main() {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
 
-    final double headerTop = tester.getTopLeft(find.text('某番剧').last).dy;
-    final double looseATop = tester.getTopLeft(find.text('Loose New').last).dy;
-    final double looseBTop = tester.getTopLeft(find.text('Loose Old').last).dy;
-
-    expect(headerTop, lessThan(looseATop),
-        reason: '合集区必须在散卡之上——即使散卡「更最近」（方案 A 顶部拍板）');
-    expect(headerTop, lessThan(looseBTop));
-    // 单一网格 = 恰好一个 SliverGrid（旧交错布局把 A/B 切成两个网格段）。
-    // 不比标题 y 等值：卡内徽章/进度行会让同一网格行里的标题差十几像素。
-    expect(find.byType(SliverGrid), findsOneWidget,
-        reason: '散卡必须合成单一网格；旧交错布局是两个残段网格');
+    // 网格 cell 序 = 阅读序（先行后列）：合集卡必须在两张散卡之前——即使散卡
+    // 「更最近」（方案 A 合集区在前拍板；封面卡形态下体现为网格前排 cell）。
+    final Offset collectionPos = tester.getTopLeft(find.text('某番剧').last);
+    final Offset looseAPos = tester.getTopLeft(find.text('Loose New').last);
+    final Offset looseBPos = tester.getTopLeft(find.text('Loose Old').last);
+    bool cellBefore(Offset a, Offset b) =>
+        a.dy < b.dy || (a.dy == b.dy && a.dx < b.dx);
+    expect(cellBefore(collectionPos, looseAPos), isTrue,
+        reason: '合集卡必须排在散卡之前——即使散卡「更最近」');
+    expect(cellBefore(collectionPos, looseBPos), isTrue);
+    // 单一网格 = 恰好一个 SliverGrid（合集卡与散卡同网格；旧横排行形态是
+    // 「行 slivers + 网格」两段式，更旧的交错布局把散卡切成两个网格段）。
+    expect(find.byType(SliverGrid), findsOneWidget, reason: '合集卡与散卡必须合成单一网格');
+    // 封面卡形态：合集卡在，成员卡不再出现在库页（成员收进详情页）。
+    expect(
+      find.byKey(const ValueKey<String>('home_video_video/ep1')),
+      findsNothing,
+      reason: '合集成员卡不再直接渲染在库页（封面卡形态）',
+    );
   });
 }

--- a/hibiki/test/pages/home_video_remote_collection_membership_test.dart
+++ b/hibiki/test/pages/home_video_remote_collection_membership_test.dart
@@ -23,8 +23,9 @@ import '../helpers/fake_anki_repository.dart';
 import '../helpers/test_platform_services.dart';
 
 /// 多端库联合视图 §2.3 任务10：远端视频占位卡的合集归属。host 下发的
-/// [RemoteVideoInfo.collection]（自然键 name+type）解析到本地合集 → 远端占位折进该合集
-/// 横排行（与本地成员同行）；解析不到本地合集 → 散卡降级（不硬造行）。
+/// [RemoteVideoInfo.collection]（自然键 name+type）解析到本地合集 → 远端占位折进该
+/// 合集（封面卡形态：计入集数角标 + 卡带云角标，成员收进详情页）；解析不到本地
+/// 合集 → 散卡降级（不硬造合集卡）。
 void main() {
   final TestWidgetsFlutterBinding binding =
       TestWidgetsFlutterBinding.ensureInitialized();
@@ -98,7 +99,7 @@ void main() {
         ),
       );
 
-  testWidgets('远端归属命中本地合集 → 占位卡折进该合集横排行', (WidgetTester tester) async {
+  testWidgets('远端归属命中本地合集 → 折进合集封面卡（计数含远端 + 云角标）', (WidgetTester tester) async {
     tester.view.physicalSize = const Size(1400, 900);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
@@ -130,16 +131,29 @@ void main() {
     )));
     await tester.pumpAndSettle();
 
-    final Finder collectionRow =
-        find.byKey(ValueKey<String>('home_video_collection_row_$cid'));
-    expect(collectionRow, findsOneWidget, reason: '本地合集横排行必须渲染');
-    final Finder remoteCard = find
-        .byKey(const ValueKey<String>('remote_video_card_video_remote-ep2'));
-    expect(remoteCard, findsOneWidget, reason: '远端占位卡必须渲染');
+    final Finder collectionCard =
+        find.byKey(ValueKey<String>('home_video_collection_card_$cid'));
+    expect(collectionCard, findsOneWidget, reason: '本地合集封面卡必须渲染');
+    // 远端成员折进合集卡：不再单独渲染散卡（成员收进详情页）。
     expect(
-      find.ancestor(of: remoteCard, matching: collectionRow),
+      find.byKey(const ValueKey<String>('remote_video_card_video_remote-ep2')),
+      findsNothing,
+      reason: '远端占位归属命中本地合集 → 折进合集卡，不再渲染独立散卡',
+    );
+    // 集数角标含远端占位成员（BUG-790 口径：1 本地 + 1 远端 = 2）。
+    expect(
+      find.descendant(
+        of: collectionCard,
+        matching: find.text(t.video_playlist_episodes(count: 2)),
+      ),
       findsOneWidget,
-      reason: '远端占位卡归属命中本地合集 → 必须折进该合集横排行（非散卡）',
+      reason: '集数角标必须计入远端占位成员（本地+远端同源）',
+    );
+    // 含远端占位成员 → 合集卡右上云角标。
+    expect(
+      find.byKey(ValueKey<String>('home_video_collection_cloud_$cid')),
+      findsOneWidget,
+      reason: '含远端占位成员的合集卡必须带云角标',
     );
   });
 

--- a/hibiki/test/pages/remote_collection_playback_wiring_guard_test.dart
+++ b/hibiki/test/pages/remote_collection_playback_wiring_guard_test.dart
@@ -47,14 +47,16 @@ void main() {
         reason: '_effectiveRemoteInfo 应优先返回当前成员');
   });
 
-  test('首页合集行把有序远端成员传进播放器', () {
+  test('首页保留有序远端成员 → 播放器的透传接线（_openRemote）', () {
+    // 封面卡形态（用户拍板 2026-07-22）后合集成员不再直接渲染在库页，旧「行内
+    // itemBuilder 收集有序远端成员」的调用点随横排行退役；但 _openRemote /
+    // _buildRemoteVideoCard 的成员透传参数必须保留（散卡远端播放 + 后续详情页
+    // 接入远端成员的既定通道），删参即回退成「远端只认 host 下发 episodes」。
     final String src =
         read('lib/src/pages/implementations/home_video_page.dart');
     expect(src.contains('remoteCollectionMembers:'), true,
         reason: '_openRemote 应把合集成员透传给 neutralizedRemote');
-    // itemBuilder 收集本合集的有序远端成员（跳过本地成员）。
-    expect(
-        src.contains('if (it.payload.remote != null) it.payload.remote!'), true,
-        reason: '合集行应收集有序远端成员列表');
+    expect(src.contains('List<RemoteVideoInfo>? collectionMembers'), true,
+        reason: '_openRemote/_buildRemoteVideoCard 必须保留有序成员透传参数');
   });
 }

--- a/hibiki/test/pages/unified_collections_architecture_guard_test.dart
+++ b/hibiki/test/pages/unified_collections_architecture_guard_test.dart
@@ -83,15 +83,18 @@ void main() {
     expect(historySrc.contains('getPrimaryCollectionIdByEntry'), isTrue);
   });
 
-  test('UI v2 Phase C：合集在两页主区渲染成独占一行的横排行（CollectionShelfRow）', () {
-    // 用户拍板：每个合集独占一行、行内横移看相邻集/卷；撤掉回折叠网格卡即转红。
-    expect(homeSrc.contains('CollectionShelfRow'), isTrue,
-        reason: '视频库合集必须渲染成全宽横排行');
+  test('合集渲染形态：书架横排行（CollectionShelfRow）+ 视频封面卡（用户拍板 2026-07-22）', () {
+    // 书架维持 Phase C 横排行；视频侧用户拍板恢复封面卡形态（「一进去就是封面，
+    // 跟小说那种一样」）：合集渲染成与散卡同尺寸的封面卡并入主网格。互退即转红。
     expect(historySrc.contains('CollectionShelfRow'), isTrue,
         reason: '书架合集必须渲染成全宽横排行');
-    // 视频行成员卡点击直接从该集进播放器（带剧集面板），不再必须绕详情页。
+    expect(homeSrc.contains('_buildCollectionCoverCard'), isTrue,
+        reason: '视频库合集必须渲染成封面卡（一合集一封面）');
+    expect(homeSrc.contains('CollectionShelfRow('), isFalse,
+        reason: '视频库不得回退到全宽横排行（用户拍板封面卡）');
+    // 点某集从该集进播放器（带剧集面板/连播）的能力经详情页保留。
     expect(homeSrc.contains('playlistCollectionId: collection.id'), isTrue,
-        reason: '视频合集行成员卡必须带 playlistCollectionId 直接换集');
+        reason: '视频合集详情页开集必须带 playlistCollectionId 直接换集');
   });
 
   test('UI v2：整理排序页已按用户拍板整体砍掉——零残留 + 能力不回退', () {
@@ -345,37 +348,30 @@ void main() {
         reason: '远端书占位须给真实 mediaType（epub）才能与本地成员共键折叠');
   });
 
-  test('BUG-790：视频合集行头集数 = 行体成员数（本地+远端占位同源），全云端合集不再显示「0 集」', () {
+  test('BUG-790：视频合集卡集数 = 全部成员数（本地+远端占位同源），全云端合集不再显示「0 集」', () {
     // 根因：旧口径 localCount = group.items.where(local != null).length 只数本地成员，
-    // 但行体 itemCount = group.items.length 渲染全部成员（含远端未下载占位卡）。全为
-    // 远端剧集的合集行明明有云占位卡却显示「0 集」，与眼前所见割裂（用户实报）。
-    // 修复：行头计数与行体 itemCount 同源。回退到「行头只数本地」或「与 itemCount 异源」
-    // 即转红。
-    final int rowFn = homeSrc.indexOf('Widget _buildVideoCollectionRow(');
-    expect(rowFn, isNonNegative, reason: '缺 _buildVideoCollectionRow');
-    final int rowEnd = homeSrc.indexOf('\n  /// ', rowFn + 1);
-    final String rowSrc =
-        homeSrc.substring(rowFn, rowEnd < 0 ? homeSrc.length : rowEnd);
+    // 全为远端剧集的合集明明可见却显示「0 集」，与眼前所见割裂（用户实报）。
+    // 封面卡形态下同一口径：集数角标必须喂 group.items.length（memberCount），
+    // 回退到「只数本地」即转红。
+    final int cardFn = homeSrc.indexOf('Widget _buildCollectionCoverCard(');
+    expect(cardFn, isNonNegative, reason: '缺 _buildCollectionCoverCard');
+    final int cardEnd = homeSrc.indexOf('\n  /// ', cardFn + 1);
+    final String cardSrc =
+        homeSrc.substring(cardFn, cardEnd < 0 ? homeSrc.length : cardEnd);
 
-    // ① 行头计数不得再用「只数本地成员」的过滤式喂 video_playlist_episodes。
-    expect(rowSrc.contains('.where((it) => it.payload.local != null).length'),
+    // ① 集数不得再用「只数本地成员」的过滤式。
+    expect(cardSrc.contains('.where((it) => it.payload.local != null).length'),
         isFalse,
-        reason: 'BUG-790：不得再用「只数本地」过滤统计行头集数（localCount）');
+        reason: 'BUG-790：不得再用「只数本地」过滤统计合集集数（localCount）');
+    expect(RegExp(r'_buildPlaylistBadge\(\s*\w*[Ll]ocal').hasMatch(cardSrc),
+        isFalse,
+        reason: 'BUG-790：集数角标不得喂 localCount，须与成员总数同源');
+
+    // ② 集数角标必须喂 group.items.length 派生的 memberCount。
     expect(
-        RegExp(r'video_playlist_episodes\(\s*count:\s*\w*[Ll]ocal')
-            .hasMatch(rowSrc),
-        isFalse,
-        reason: 'BUG-790：行头计数不得喂 localCount，须与行体 itemCount 同源');
-
-    // ② 行头 countLabel 的 count 与 itemCount 必须引用同一变量（同源）。
-    final Match? countMatch =
-        RegExp(r'countLabel:\s*t\.video_playlist_episodes\(count:\s*(\w+)\)')
-            .firstMatch(rowSrc);
-    final Match? itemMatch = RegExp(r'itemCount:\s*(\w+)').firstMatch(rowSrc);
-    expect(countMatch, isNotNull, reason: '未找到行头 countLabel 表达式');
-    expect(itemMatch, isNotNull, reason: '未找到 itemCount 表达式');
-    expect(countMatch!.group(1), equals(itemMatch!.group(1)),
-        reason: 'BUG-790：行头集数与行体 itemCount 必须同源（同一变量），'
-            '否则「看得见却 0 集」回潮');
+        cardSrc.contains('final int memberCount = group.items.length;'), isTrue,
+        reason: 'BUG-790：memberCount 必须 = group.items.length（本地+远端占位同源）');
+    expect(cardSrc.contains('_buildPlaylistBadge(memberCount)'), isTrue,
+        reason: 'BUG-790：集数角标必须喂 memberCount');
   });
 }


### PR DESCRIPTION
## 背景

用户拍板恢复改版前形态：「一进去就是封面，跟小说那种一样，我一眼就能认出来是哪部；相当于文字合集替换成一个封面那样」。视频页合集从全宽横排行（`CollectionShelfRow`）改回**封面卡**。

## 设计要点

- **一合集一封面卡**：`_buildCollectionCoverCard`，几何与散卡逐像素同规格（`unifiedShelfCardLayout` 卡宽 + `_videoCardExtent` 高：16:9 封面 + 标题 footer + 进度行）。
- **单一网格**：合集卡在前（保持排序模式的组间序）、散卡在后，合成同一个 `SliverGrid`（替代「合集行 slivers + 散卡网格」两段式；顺带消灭了 gridPadding 的双分支特例）。
- **封面借用**：组内首个有封面的本地成员 → 首个有封面的远端成员（互联/云 fetch 路径）→ 无封面占位（surfaceContainer + movie 图标，与散卡同款）。
- **角标**：左下 playlist 图标 + 成员数（本地+远端占位同源，BUG-790 口径）；含远端占位成员时右上云角标（共享 `CoverBadge`）。
- **footer 进度行**：有痕迹未看完 → 「继续看 第n集」（`continueMemberIndex` 纯函数，与旧行初始横滚定位同源）；否则 → 「已看完 x/N」。新增 i18n key `collection_continue_progress` / `collection_watched_progress`（经 `i18n_sync` 17 语言 + `dart run slang`）。

## 交互保留清单（Never break userspace）

| 原横排行能力 | 封面卡去向 |
|---|---|
| 「查看全部」→ 详情页 | 整卡点击即入口（`_openCollectionDetail`） |
| 点某集直接进播放器（连播上下文） | 经详情页保留（`playlistCollectionId: collection.id`） |
| focusId `home-video-collection-<id>` | 沿用（手柄/键盘映射不变） |
| 多选态行头整选勾选框 | 整卡勾选 = 选中整个合集（`_selectedCollectionIds`） |
| 拖标签到行头打合集标签 | `BookDragTarget` 包整卡（多选态禁用，与散卡一致） |
| 行头下方标签 chip 列 | 封面左上 chip 层（最多 3 + 溢出「+N」，与散卡同形；多选态让位勾选框） |
| 行头集数（含远端占位，BUG-790） | 左下集数角标同口径 |
| 折叠 chevron + `collapsed_collection_ids` | **视频侧退役**（封面卡无成员行可折叠）；偏好与书架用法不动 |

## 取舍说明

- 标签 chips 摆封面左上（散卡同款）而非 footer：footer 只有两行空间，进度行保留、chip 不降级到详情页。
- 折叠语义视频侧退役但**不改写**偏好（守卫测试锁死：视频页不再读写、书架照旧）。
- ⚠️ **已知能力缺口（诚实声明，需跟进）**：折进合集的**远端占位成员**此前可在横排行内直接点播（跨成员连播）；封面卡形态下成员收进详情页，而详情页目前只列本地成员（`loadMembers` 走 `repo.getByBookUid`）——含未下载远端剧集的合集，这些远端集暂无库页播放入口（云角标仍提示其存在）。本 PR 按拍板范围「明确不动详情页」；跟进项：详情页接入远端占位成员（`_openRemote` 的 `collectionMembers` 透传通道已保留并有守卫锁死，对齐书侧 PR#321 方向）。

## 测试

- 更新：`home_video_partition_test`（单网格 + 合集卡在前）、`home_video_collapse_test`（改「封面卡不再折叠」守卫）、`home_video_batch_collection_ops_test`（整选走卡）、`home_video_remote_collection_membership_test`（远端折进卡：计数含远端 + 云角标）、`unified_collections_architecture_guard_test`（书架横排行/视频封面卡分形态守卫 + BUG-790 口径改卡）、`remote_collection_playback_wiring_guard_test`（改守「_openRemote 成员透传通道保留」）。
- 新增：`home_video_collection_cover_card_test`（封面借用 / 占位 / 集数角标 / 进度行三态 / 点击开详情 / 拖标签写穿 DB，共 5 case）。

## 验证

- `flutter analyze --no-pub`：No issues found
- 全量 `flutter test --no-pub`：**+12629 通过 / ~5 跳过 / 0 失败（All tests passed!）**
- `dart format .` 已跑（18 个基线无关文件的格式化已还原，不入本 commit）

https://claude.ai/code/session_01CfSqJG9psJkUVSig6DhH9Y
