### PR TITLE
feat(sync): 收藏句删除传播（承接已合并 #346）

### DIFF
--- a/docs/specs/delete-propagation-all-entities/plan.md
+++ b/docs/specs/delete-propagation-all-entities/plan.md
@@ -101,6 +101,13 @@
   接收端逐条确认；消费端按 displayName remove。修正了早前"路径不稳→无意义"的误判。
 - ✅ **收藏词**：aggregate 并集同步。取消收藏写 favoriteword 墓碑（NUL 连接键），aggregate
   applySnapshot 跳过有碑收藏防并集复活；发布+消费+确认复用统一机制。治"取消收藏被并回"痛点。
+- ✅ **收藏句**（pref JSON 载体，无稳定 id）：照收藏词双通道复刻。共享内容键
+  `FavoriteSentenceRepository.itemKey`（aggregate 去重 / 墓碑 itemKey / 接收端删除三处委托
+  同一函数，杜绝分叉）；`removeById/removeByContent/removeAt/clear` 默认写 `favoritesentence`
+  墓碑、`add` 清墓碑、`removeByItemKey` 供接收端确认删；orchestrator present 键 + 通用发布
+  消费循环覆盖云 + 互联；`_writeFavoriteSentences` 剔除有碑句防并集复活。**"改结构可以"后
+  确认无需迁表**——墓碑存进现成统一表，pref 存储不动。顺带修正主 PR c550f3982 遗漏的过时
+  收藏词测试断言（该文件当初未跑到）。
 
 **结构性无法做（无跨设备同步前提，非本功能范畴）**：
 - **书签 / Profile**：当前**完全不 live 同步**（仅整库备份，Profile 导入还刻意保留本机），
@@ -108,7 +115,7 @@
   另一个独立的大功能（"给书签/Profile 建同步"），不属"删除传播"。
 - **搜索历史**：设计上**刻意不同步、连备份都主动 wipe（隐私红线）**。给它建同步会**违反现有
   隐私设计**，不做。
-- **收藏句（pref 式）**：收藏词已闭环，收藏句是 pref 载体、机制略不同，作快速后续。
+- ~~**收藏句（pref 式）**：快速后续~~ → **已完成**（见上，用户「收藏句做，改一下结构可以」后落地）。
 
 > 结论：删除传播已覆盖**所有当前可跨设备同步的实体**（书/视频/有声书/本地音频/收藏词
 > + 已自有机制的合集/标签/词典）。书签/Profile/搜索历史需先有同步才谈得上传删，是独立议题。

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -541,6 +541,13 @@ class AppModel with ChangeNotifier {
       for (final VideoBookRow r in await database.allVideoBooks())
         r.bookUid: r.title,
     };
+    // 收藏句：itemKey 是内容键（用户看不懂），从本地在库收藏句解析回句子文本展示。
+    // deleteLocal 候选必是本地仍在库者，映射通常命中；查不到退回 itemKey。
+    final Map<String, String> favSentenceTexts = <String, String>{
+      for (final FavoriteSentence s
+          in await FavoriteSentenceRepository(database).getAll())
+        FavoriteSentenceRepository.itemKeyOf(s): s.text,
+    };
     return <DeletionCandidateView>[
       for (final DeletionPropagationCandidate c in candidates)
         DeletionCandidateView(
@@ -552,6 +559,7 @@ class AppModel with ChangeNotifier {
             // 收藏词：itemKey 是 NUL 连接键，展示其中的 expression（词本身）。
             'favoriteword' =>
               parseFavoriteWordItemKey(c.itemKey)?.expression ?? c.itemKey,
+            'favoritesentence' => favSentenceTexts[c.itemKey] ?? c.itemKey,
             _ => c.itemKey, // localaudio: displayName 本身即可读。
           },
         ),
@@ -597,6 +605,10 @@ class AppModel with ChangeNotifier {
                 sourceType: parsed.sourceType,
               );
             }
+          case 'favoritesentence':
+            // 按内容键取消收藏。默认写墓碑（本设备也需抑制第三设备并集复活，与源墓碑同键）。
+            await FavoriteSentenceRepository(database)
+                .removeByItemKey(c.itemKey);
           default:
             // 未知类型：跳过。
             break;

--- a/hibiki/lib/src/sync/aggregate_merge_service.dart
+++ b/hibiki/lib/src/sync/aggregate_merge_service.dart
@@ -1,4 +1,5 @@
-import 'package:hibiki_audio/hibiki_audio.dart' show FavoriteSentence;
+import 'package:hibiki_audio/hibiki_audio.dart'
+    show FavoriteSentence, FavoriteSentenceRepository;
 
 /// Pure, side-effect-free merge semantics for the aggregate families that
 /// travel between devices on both offline backup merge-import (TODO-888) and
@@ -111,11 +112,15 @@ class AggregateMergeService {
   ///
   /// On a content collision the row with the EARLIER createdAt is retained
   /// (mirrors favorite-word "earlier createdAt kept"), making the result
-  /// independent of which side is passed as [local]. Deletions do not propagate:
-  /// a sentence removed locally is not re-added just because [remote] still has
-  /// it; but a remote-only sentence IS added. The output is sorted newest-first
-  /// (by createdAt descending) so it matches FavoriteSentenceRepository.getAll's
-  /// ordering when written back.
+  /// independent of which side is passed as [local]. This primitive is a PURE
+  /// union: a remote-only sentence IS added (including one this device just
+  /// un-favorited). Deletion propagation is layered ABOVE this by the
+  /// `favoritesentence` tombstone suppression in
+  /// `AggregateSyncService._writeFavoriteSentences` — it drops any unioned
+  /// sentence that carries a delete tombstone so an un-favorite is not resurrected
+  /// (see `FavoriteSentenceRepository.itemKeyOf`). The output is sorted
+  /// newest-first (by createdAt descending) so it matches
+  /// FavoriteSentenceRepository.getAll's ordering when written back.
   static List<FavoriteSentence> mergeFavoriteSentences(
     List<FavoriteSentence> local,
     List<FavoriteSentence> remote,
@@ -145,21 +150,15 @@ class AggregateMergeService {
     return out;
   }
 
-  /// Content identity of a favorite sentence, matching
-  /// FavoriteSentenceRepository._contentMatch
-  /// ({text, bookKey, sectionIndex, normCharOffset}). Each nullable field uses
-  /// an explicit null sentinel so a missing bookKey never collides with an empty
-  /// string, nor a null sectionIndex with 0; text is length-prefixed so a
-  /// separator inside text cannot forge a field boundary.
-  static String _favoriteSentenceContentKey(FavoriteSentence s) {
-    const String nul = '<null>';
-    final String bookKey = s.bookKey ?? nul;
-    final String section =
-        s.sectionIndex == null ? nul : s.sectionIndex.toString();
-    final String offset =
-        s.normCharOffset == null ? nul : s.normCharOffset.toString();
-    return '${s.text.length}:${s.text}|$bookKey|$section|$offset';
-  }
+  /// Content identity of a favorite sentence — delegates to the single source of
+  /// truth [FavoriteSentenceRepository.itemKeyOf] so this dedup key, the deletion
+  /// tombstone itemKey, and the receiver-side removal all use one identical
+  /// string (no key divergence). Each nullable field uses an explicit null
+  /// sentinel so a missing bookKey never collides with an empty string, nor a
+  /// null sectionIndex with 0; text is length-prefixed so a separator inside text
+  /// cannot forge a field boundary.
+  static String _favoriteSentenceContentKey(FavoriteSentence s) =>
+      FavoriteSentenceRepository.itemKeyOf(s);
 }
 
 /// A single statistics bucket's numeric payload, MAX-merged field-by-field.

--- a/hibiki/lib/src/sync/aggregate_sync_service.dart
+++ b/hibiki/lib/src/sync/aggregate_sync_service.dart
@@ -5,7 +5,11 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:hibiki/src/sync/aggregate_merge_service.dart';
 import 'package:hibiki/src/sync/aggregate_snapshot.dart';
 import 'package:hibiki/src/sync/sync_asset_store.dart';
-import 'package:hibiki_audio/hibiki_audio.dart' show FavoriteSentence;
+import 'package:hibiki_audio/hibiki_audio.dart'
+    show
+        FavoriteSentence,
+        FavoriteSentenceRepository,
+        kFavoriteSentenceTombstoneType;
 import 'package:hibiki_core/hibiki_core.dart';
 
 /// Reserved top-level folder (under the backend root) that holds per-device
@@ -605,8 +609,21 @@ class AggregateSyncService {
     final List<FavoriteSentence> current = await _readFavoriteSentences();
     final List<FavoriteSentence> union =
         AggregateMergeService.mergeFavoriteSentences(current, merged);
+    // 删除传播：剔除有 `favoritesentence` 删除墓碑的收藏句——否则本设备取消收藏后，peer
+    // 快照的并集会把它重新加回（复活）。与收藏词墓碑抑制（applySnapshotToLocal 内）同律。
+    final Set<String> tombstoned = <String>{
+      for (final SyncDeletionTombstoneRow row in await _db
+          .getSyncDeletionTombstonesOfType(kFavoriteSentenceTombstoneType))
+        row.itemKey,
+    };
+    final List<FavoriteSentence> out = tombstoned.isEmpty
+        ? union
+        : union
+            .where((FavoriteSentence s) =>
+                !tombstoned.contains(FavoriteSentenceRepository.itemKeyOf(s)))
+            .toList();
     final String json =
-        jsonEncode(union.map((FavoriteSentence s) => s.toJson()).toList());
+        jsonEncode(out.map((FavoriteSentence s) => s.toJson()).toList());
     await _db.setPref(_favoriteSentencesPrefKey, json);
   }
 }

--- a/hibiki/lib/src/sync/sync_orchestrator.dart
+++ b/hibiki/lib/src/sync/sync_orchestrator.dart
@@ -22,6 +22,8 @@ import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/src/sync/ttu_filename.dart';
 import 'package:hibiki/src/sync/ttu_models.dart';
 import 'package:hibiki/src/sync/video_manifest.dart';
+import 'package:hibiki_audio/hibiki_audio.dart'
+    show FavoriteSentence, FavoriteSentenceRepository;
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:path/path.dart' as p;
 
@@ -768,6 +770,13 @@ class SyncOrchestrator {
         for (final FavoriteWordRow r in await _db.getAllFavoriteWords())
           HibikiDatabase.favoriteWordItemKey(
               r.expression, r.reading, r.sourceType),
+      },
+      // 收藏句无稳定 id，用内容键（[FavoriteSentenceRepository.itemKeyOf]）；与写墓碑点、
+      // aggregate 去重键同源。
+      'favoritesentence': <String>{
+        for (final FavoriteSentence s
+            in await FavoriteSentenceRepository(_db).getAll())
+          FavoriteSentenceRepository.itemKeyOf(s),
       },
     };
   }

--- a/hibiki/test/database/sync_deletion_tombstone_test.dart
+++ b/hibiki/test/database/sync_deletion_tombstone_test.dart
@@ -5,6 +5,7 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/sync/deletion_propagation.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
 HibikiDatabase _memDb() => HibikiDatabase.forTesting(NativeDatabase.memory());
@@ -110,6 +111,84 @@ void main() {
       propagateDeletion: false,
     );
     expect(await db.getSyncDeletionTombstonesOfType('favoriteword'), isEmpty);
+  });
+
+  FavoriteSentence mkSentence({
+    String? id,
+    String text = '猫が好き',
+    String? bookKey = 'a',
+    int? sectionIndex = 0,
+    int? normCharOffset = 5,
+  }) =>
+      FavoriteSentence(
+        id: id,
+        text: text,
+        bookTitle: 'BookA',
+        bookKey: bookKey,
+        sectionIndex: sectionIndex,
+        normCharOffset: normCharOffset,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(100),
+      );
+
+  test('取消收藏句 removeById 写 favoritesentence 墓碑；重新收藏清碑', () async {
+    final repo = FavoriteSentenceRepository(db);
+    final FavoriteSentence s = mkSentence(id: 'hl_1');
+    await repo.add(s);
+    await repo.removeById('hl_1');
+    final rows = await db.getSyncDeletionTombstonesOfType('favoritesentence');
+    expect(rows, hasLength(1));
+    expect(rows.single.itemKey, FavoriteSentenceRepository.itemKeyOf(s));
+    // 重新收藏同内容 → 清碑（清的是内容键，与 id 无关）。
+    await repo.add(mkSentence(id: 'hl_2'));
+    expect(
+        await db.getSyncDeletionTombstonesOfType('favoritesentence'), isEmpty);
+  });
+
+  test('removeByContent 写墓碑；propagateDeletion:false 不写', () async {
+    final repo = FavoriteSentenceRepository(db);
+    await repo.add(mkSentence(id: 'hl_c1'));
+    await repo.removeByContent(
+      text: '猫が好き',
+      bookKey: 'a',
+      sectionIndex: 0,
+      normCharOffset: 5,
+    );
+    expect(await db.getSyncDeletionTombstonesOfType('favoritesentence'),
+        hasLength(1));
+
+    await db.clearSyncDeletionTombstone(
+        'favoritesentence', FavoriteSentenceRepository.itemKeyOf(mkSentence()));
+    await repo.add(mkSentence(id: 'hl_c2'));
+    await repo.removeByContent(
+      text: '猫が好き',
+      bookKey: 'a',
+      sectionIndex: 0,
+      normCharOffset: 5,
+      propagateDeletion: false,
+    );
+    expect(
+        await db.getSyncDeletionTombstonesOfType('favoritesentence'), isEmpty);
+  });
+
+  test('removeByItemKey 删本地 + 写墓碑（接收端确认路径）', () async {
+    final repo = FavoriteSentenceRepository(db);
+    final FavoriteSentence s = mkSentence(id: 'hl_k1');
+    await repo.add(s);
+    final String key = FavoriteSentenceRepository.itemKeyOf(s);
+    await repo.removeByItemKey(key);
+    expect(await repo.getAll(), isEmpty);
+    final rows = await db.getSyncDeletionTombstonesOfType('favoritesentence');
+    expect(rows.single.itemKey, key);
+  });
+
+  test('清空收藏句为每条写墓碑', () async {
+    final repo = FavoriteSentenceRepository(db);
+    await repo.add(mkSentence(id: 'hl_a', text: '一', normCharOffset: 1));
+    await repo.add(mkSentence(id: 'hl_b', text: '二', normCharOffset: 2));
+    await repo.clear();
+    expect(await repo.getAll(), isEmpty);
+    expect(await db.getSyncDeletionTombstonesOfType('favoritesentence'),
+        hasLength(2));
   });
 
   test('发布标记 remotePublishedAt', () async {

--- a/hibiki/test/sync/aggregate_sync_service_cloud_test.dart
+++ b/hibiki/test/sync/aggregate_sync_service_cloud_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/sync/aggregate_snapshot.dart';
 import 'package:hibiki/src/sync/aggregate_sync_service.dart';
 import 'package:hibiki/src/sync/sync_asset_store.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
 import 'fake_asset_store.dart';
@@ -84,6 +85,47 @@ void main() {
     await AggregateSyncService(db).sync(store: store, deviceId: 'dev-A');
     final String ns = await store.ensureNamespace(kSyncAggregateNamespace);
     expect((await store.listChildren(ns)).isEmpty, isTrue);
+  });
+
+  test('取消收藏句后 peer 快照并集不复活（favoritesentence 墓碑抑制）', () async {
+    final HibikiDatabase db = await _freshDb('agg_fs_tomb_');
+    addTearDown(db.close);
+    final FavoriteSentenceRepository repo = FavoriteSentenceRepository(db);
+    final FavoriteSentence s = FavoriteSentence(
+      id: 'hl_x',
+      text: '消したい文',
+      bookTitle: 'BookA',
+      bookKey: 'a',
+      sectionIndex: 0,
+      normCharOffset: 7,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(100),
+    );
+    // 收藏后取消 → 本地删掉 + 写墓碑。
+    await repo.add(s);
+    await repo.removeById('hl_x');
+    expect(await repo.getAll(), isEmpty);
+
+    // peer 快照仍带同一句（不同 id / 较晚 createdAt）→ 应用后**不得**复活。
+    final AggregateSnapshot peer = AggregateSnapshot(
+      favoriteSentences: <FavoriteSentence>[
+        FavoriteSentence(
+          id: 'hl_peer',
+          text: '消したい文',
+          bookTitle: 'BookA',
+          bookKey: 'a',
+          sectionIndex: 0,
+          normCharOffset: 7,
+          createdAt: DateTime.fromMillisecondsSinceEpoch(900),
+        ),
+      ],
+    );
+    await AggregateSyncService(db).applySnapshotToLocal(peer);
+    expect(await repo.getAll(), isEmpty, reason: '有墓碑 → 并集不复活');
+
+    // 重新收藏 → 清碑；此后 peer 快照的同句可正常并入。
+    await repo.add(s);
+    await AggregateSyncService(db).applySnapshotToLocal(peer);
+    expect((await repo.getAll()).single.text, '消したい文');
   });
 
   test('two devices converge to the union via the store', () async {
@@ -246,8 +288,10 @@ void main() {
     expect((await dbB.getMiningStatisticsBySource('book')).single.count, 4);
   });
 
-  test('union re-adds a peer-still-present word; delete does not propagate',
-      () async {
+  test('取消收藏词写墓碑后 peer 快照并集不复活；重新收藏清碑可再并入', () async {
+    // 删除传播上线后行为更新：`removeFavoriteWord` 默认写 favoriteword 墓碑，
+    // `applySnapshotToLocal` 跳过有碑收藏 → 取消收藏不再被 peer 并集复活（旧「delete does
+    // not propagate」断言已随删除传播作废）。
     final FakeAssetStore store = FakeAssetStore();
 
     final HibikiDatabase dbA = await _freshDb('agg_delA_');
@@ -265,13 +309,25 @@ void main() {
     addTearDown(dbB.close);
     await AggregateSyncService(dbB).sync(store: store, deviceId: 'dev-B');
     expect((await dbB.getAllFavoriteWords()).length, 1);
+    // 取消收藏 → 本地删 + 写墓碑。
     await dbB.removeFavoriteWord(
         expression: 'wShared', reading: 'r', sourceType: 'book');
     expect((await dbB.getAllFavoriteWords()).isEmpty, isTrue);
 
-    // The aggregate model is union / only-grows: a peer snapshot that still
-    // carries the word re-adds it on B. Deletion propagation is a deliberate
-    // non-goal (a delete must be performed on every device).
+    // A 的快照仍带 wShared；B 再同步折进 merged，但墓碑令 applySnapshotToLocal 跳过它
+    // → 保持删除（删除传播生效）。
+    await AggregateSyncService(dbB).sync(store: store, deviceId: 'dev-B');
+    expect((await dbB.getAllFavoriteWords()).isEmpty, isTrue,
+        reason: '墓碑抑制并集复活');
+
+    // 重新收藏 → 清碑；此后 peer 快照的同词可正常并入（「重加清墓碑」语义）。
+    await dbB.addFavoriteWord(
+      expression: 'wShared',
+      reading: 'r',
+      glossary: 'g',
+      sourceType: 'book',
+      dateKey: '2026-06-02',
+    );
     await AggregateSyncService(dbB).sync(store: store, deviceId: 'dev-B');
     expect((await dbB.getAllFavoriteWords()).length, 1);
   });

--- a/packages/hibiki_audio/lib/src/audiobook/favorite_sentence_repository.dart
+++ b/packages/hibiki_audio/lib/src/audiobook/favorite_sentence_repository.dart
@@ -11,6 +11,11 @@ const String kFavoriteSentenceSourceVideo = 'video';
 const String kFavoriteSentenceSourceAudiobook = 'audiobook';
 const String kFavoriteSentenceSourceLyrics = 'lyrics';
 
+/// 收藏句删除传播墓碑的 mediaType（与收藏词 `'favoriteword'` 并列）。存进统一表
+/// [HibikiDatabase.writeSyncDeletionTombstone]，供 aggregate 并集抑制复活 + orchestrator
+/// 逐条确认删对端两条通道共用。
+const String kFavoriteSentenceTombstoneType = 'favoritesentence';
+
 class FavoriteSentence {
   factory FavoriteSentence.fromJson(Map<String, dynamic> json) =>
       FavoriteSentence(
@@ -93,6 +98,37 @@ class FavoriteSentenceRepository {
 
   static const String _key = 'favorite_sentences';
 
+  /// 跨设备稳定的内容身份键（**唯一真源**：aggregate 去重、删除墓碑 itemKey、接收端删除
+  /// 三处共用同一函数，杜绝键分叉）。`收藏句无稳定 id`（本机随机），只能靠内容四元组。
+  /// text 长度前缀防分隔符伪造字段边界；可空字段用显式 `<null>` 哨兵，避免 null 与空串/0
+  /// 撞键。与 `AggregateMergeService._favoriteSentenceContentKey`（已改为委托本函数）一致。
+  static String itemKey({
+    required String text,
+    required String? bookKey,
+    required int? sectionIndex,
+    required int? normCharOffset,
+  }) {
+    const String nul = '<null>';
+    final String bk = bookKey ?? nul;
+    final String section = sectionIndex == null ? nul : sectionIndex.toString();
+    final String offset =
+        normCharOffset == null ? nul : normCharOffset.toString();
+    return '${text.length}:$text|$bk|$section|$offset';
+  }
+
+  /// [itemKey] 的便捷重载：直接从一条收藏句取内容键。
+  static String itemKeyOf(FavoriteSentence s) => itemKey(
+        text: s.text,
+        bookKey: s.bookKey,
+        sectionIndex: s.sectionIndex,
+        normCharOffset: s.normCharOffset,
+      );
+
+  /// 写删除墓碑（取消收藏 → 传播删除）。
+  Future<void> _writeTombstone(FavoriteSentence s) =>
+      _db.writeSyncDeletionTombstone(kFavoriteSentenceTombstoneType,
+          itemKeyOf(s), DateTime.now().millisecondsSinceEpoch);
+
   Future<List<FavoriteSentence>> getAll() async {
     final raw = await _db.getPref(_key);
     if (raw == null || raw.isEmpty) return [];
@@ -117,6 +153,10 @@ class FavoriteSentenceRepository {
       _key,
       jsonEncode(sentences.map((s) => s.toJson()).toList()),
     );
+    // 重新收藏 → 清除该内容键的删除墓碑；否则墓碑会在 aggregate 并集里把这条刚收藏的句
+    // 再次抑制掉（与收藏词 addFavoriteWord 清墓碑同律）。
+    await _db.clearSyncDeletionTombstone(
+        kFavoriteSentenceTombstoneType, itemKeyOf(sentence));
   }
 
   /// 查已收藏项：返回**匹配到的条目 id**（未收藏 → null）。id-first——先按内容键（含
@@ -161,6 +201,7 @@ class FavoriteSentenceRepository {
     required String? bookKey,
     required int? sectionIndex,
     required int? normCharOffset,
+    bool propagateDeletion = true,
   }) async {
     final sentences = await getAll();
     // BUG-494：只删**第一条**匹配内容键的记录（非 removeWhere 全删），避免同章重复短句
@@ -171,34 +212,77 @@ class FavoriteSentenceRepository {
         s.sectionIndex == sectionIndex &&
         s.normCharOffset == normCharOffset);
     if (idx < 0) return;
+    final FavoriteSentence removed = sentences[idx];
     sentences.removeAt(idx);
     await _db.setPref(
       _key,
       jsonEncode(sentences.map((s) => s.toJson()).toList()),
     );
+    if (propagateDeletion) await _writeTombstone(removed);
   }
 
-  Future<void> removeAt(int index) async {
+  Future<void> removeAt(int index, {bool propagateDeletion = true}) async {
     final sentences = await getAll();
     if (index < 0 || index >= sentences.length) return;
+    final FavoriteSentence removed = sentences[index];
     sentences.removeAt(index);
     await _db.setPref(
       _key,
       jsonEncode(sentences.map((s) => s.toJson()).toList()),
     );
+    if (propagateDeletion) await _writeTombstone(removed);
   }
 
-  Future<void> removeById(String id) async {
+  Future<void> removeById(String id, {bool propagateDeletion = true}) async {
     final sentences = await getAll();
+    // id 理论唯一，但 BUG-494 前的旧数据可能撞 id；捕获全部被删条目各写一次墓碑（同内容
+    // 键幂等）。
+    final List<FavoriteSentence> removed =
+        sentences.where((s) => s.id == id).toList();
+    if (removed.isEmpty) return;
     sentences.removeWhere((s) => s.id == id);
     await _db.setPref(
       _key,
       jsonEncode(sentences.map((s) => s.toJson()).toList()),
     );
+    if (propagateDeletion) {
+      for (final FavoriteSentence s in removed) {
+        await _writeTombstone(s);
+      }
+    }
+  }
+
+  /// 按内容键取消收藏（删除传播**接收端**确认后调用）。默认写墓碑：本设备也需墓碑抑制
+  /// 第三设备 aggregate 快照的并集复活（与收藏词 `_applyConfirmedDeletions` 同律）。本地
+  /// 已无此句时仍写墓碑（幂等，防复活）。
+  Future<void> removeByItemKey(String key,
+      {bool propagateDeletion = true}) async {
+    final sentences = await getAll();
+    final int idx = sentences.indexWhere((s) => itemKeyOf(s) == key);
+    if (idx < 0) {
+      if (propagateDeletion) {
+        await _db.writeSyncDeletionTombstone(kFavoriteSentenceTombstoneType,
+            key, DateTime.now().millisecondsSinceEpoch);
+      }
+      return;
+    }
+    final FavoriteSentence removed = sentences[idx];
+    sentences.removeAt(idx);
+    await _db.setPref(
+      _key,
+      jsonEncode(sentences.map((s) => s.toJson()).toList()),
+    );
+    if (propagateDeletion) await _writeTombstone(removed);
   }
 
   /// 清空全部收藏句。收藏夹「清空」面板的收藏句范围走这里，直接删掉承载偏好键。
-  Future<void> clear() async {
+  /// [propagateDeletion] 时为清空前的每条各写一个删除墓碑（传播到其它设备）。
+  Future<void> clear({bool propagateDeletion = true}) async {
+    if (propagateDeletion) {
+      for (final FavoriteSentence s in await getAll()) {
+        await _writeTombstone(s);
+      }
+    }
     await _db.deletePref(_key);
   }
 }


### PR DESCRIPTION
承接已合并的 PR #346（全实体删除传播），补上当时列为「快速后续」的**收藏句**（用户后续要求「收藏句做，改一下结构可以」）。

## 背景
收藏句是 pref JSON 载体、**无稳定 id**（本机随机时钟+计数器），但内容键（text+bookKey+section+offset）跨设备稳定。之前已走 aggregate 并集「只增不删」→ 与收藏词修复前同样的取消收藏被并集复活痛点。照收藏词**双通道**（aggregate 静默抑制 + orchestrator 逐条确认）复刻。

## 改动
- **共享内容键** `FavoriteSentenceRepository.itemKey`（唯一真源：aggregate 去重 / 墓碑 itemKey / 接收端删除三处委托同一函数，杜绝分叉）；merge 服务 `_favoriteSentenceContentKey` 改为委托本函数。
- **源端**：`removeById/removeByContent/removeAt/clear` 默认写 `favoritesentence` 墓碑；`add` 清墓碑（重新收藏语义）；新增 `removeByItemKey` 供接收端确认后按内容键删。签名均为可选默认参数，向后兼容旧调用点。
- **发布/消费**：orchestrator `_collectPresentDeletionKeys` 加 favoritesentence present 键，通用墓碑发布/消费循环自动覆盖云 + 互联两通道。
- **接收端**：`_resolveDeletionViews` 展示句子文本，`_applyConfirmedDeletions` 路由 favoritesentence → `removeByItemKey`（默认写墓碑抑制第三设备复活）。
- **aggregate**：`_writeFavoriteSentences` 剔除有墓碑的句，防 peer 并集复活。

## 顺带修正
主 PR c550f3982（收藏词删除传播）遗漏更新 `aggregate_sync_service_cloud_test` 的过时断言「收藏词 delete does not propagate」——该文件当初未跑到，其断言与已上线的收藏词墓碑抑制矛盾。改为断言取消收藏后并集不复活 + 重加清碑可再并入。

## 结构判断
用户说「改结构可以」，但调查确认**无需迁表**：墓碑存进现成统一 `SyncDeletionTombstones` 表，pref 存储不动，最小且对齐收藏词。

## 验证
- DB 层墓碑门控 4 例（removeById / removeByContent 门控 / removeByItemKey / clear）
- aggregate 抑制 1 例（取消收藏后 peer 快照并集不复活 + 重加清碑复通）
- 全量 `flutter analyze`（lib+test）干净
- 待**双设备真机**验收：A 取消收藏句 → B 同步逐条确认 → B 本地取消；取消后重新收藏不被误删

https://claude.ai/code/session_01SEKsJnoe6vEnWT8k1N9L3o