### PR TITLE
fix(galgame): BUG-1021 引擎组件下载确认弹窗立即弹出并加再入守卫

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 987 条。点号进各自文件。
+> 共 988 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1021](bugs/BUG-1021-galgame-helper-dialog-latency-and-restack.md) | ✅ | ✅ | galgame 引擎组件下载确认弹窗点击不立即出现且多次点击叠出多个弹窗 |
 | [BUG-1020](bugs/BUG-1020-clipboard-watcher-pref-flip-desync.md) | ✅ | ✅ | Windows剪贴板监听页内翻转开关后永久失效 |
 | [BUG-1019](bugs/BUG-1019-profile-swallows-audiobook-progress.md) | ✅ | ✅ | profile 切换吞听书进度/倍速：进度型 pref 被快照/prune/回灌 |
 | [BUG-1018](bugs/BUG-1018-rename-not-applied-everywhere.md) | ✅ | ✅ | 改名/改作者不生效：override title 消费面缺口 + 作者保存不刷新 + SRT 空 bookKey 互踩 + profile 吞 override |

--- a/docs/bugs/BUG-1021-galgame-helper-dialog-latency-and-restack.md
+++ b/docs/bugs/BUG-1021-galgame-helper-dialog-latency-and-restack.md
@@ -1,0 +1,34 @@
+## BUG-1021 · galgame 引擎组件下载确认弹窗点击不立即出现且多次点击叠出多个弹窗
+
+- **报告**：2026-07-23（用户：截图「需要下载 galgame 引擎组件」确认框）
+- **真实性**：✅ 真 bug。两个独立根因：
+  - **根因 A（点了不立即弹）**：`GalgameHelperInstaller.ensureInjector`
+    （`hibiki/lib/src/mining/galgame_helper_installer.dart:150`，修复前）在弹确认对话框
+    **之前** `await _probeSize(arch)`。`_probeSize` 是一次 HTTP `HEAD`，连接超时 10s，且逐个
+    镜像候选（`galgameHelperCandidateUrls`：直连 + 5 个 gh 代理前缀）串行尝试。弱网/GFW 直连
+    卡住时，点击后要等 `_probeSize` 整轮返回（可达数秒）对话框才出现——用户感知为「点了没反应」。
+  - **根因 B（多次点击多弹窗）**：两个启动调用点都无再入守卫：
+    `games_library_page.dart:109` `_launchGame`（卡片 `onTap: () => unawaited(_launchGame(...))`）
+    与 `texthooker_page.dart:302` `_launchGalgameEngineHook`。启动流程含位数探测、helper 确认/
+    下载对话框、注入会话等多个 await，持续数秒；等待期间每次重复点击各自开一条独立启动流程，
+    各自 `ensureInjector` → 各弹一个确认对话框，叠出多个。
+
+- **[x] ① 已修复** — 提交 `<pending>`
+  - 根因 A：`ensureInjector` 改为**立即**弹确认对话框（大小先填 `t.galgame_helper_size_unknown`），
+    `_probeSize` 以 `unawaited(sizeProbe.then(...))` 在后台并发进行，返回后经 `ValueNotifier<String>`
+    就地把「约 N MB」回填进对话框。`_confirmDownload` 参数由 `String` 改为 `ValueListenable<String>`，
+    正文用 `ValueListenableBuilder` 监听刷新。对话框关闭后置 `dialogClosed` 守卫再 `dispose`，
+    避免向已释放 notifier 写值。expectedSize 复用后台探测结果 `probedSize`（未就绪则 null，下载阶段
+    仍靠 Content-Length / sha256 兜底）。
+  - 根因 B：`_launchGame` 加实例 `bool _launching`、`_launchGalgameEngineHook` 加实例
+    `bool _launchingGalHook` 再入守卫（进入即 `if (flag) return;`，`try/finally` 复位），等待
+    期间的重复点击被忽略，只有一条启动流程、一个确认对话框。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/galgame_helper_launch_guard_test.dart`
+  （静态守卫，本层为最强可落地层：`ensureInjector` 首行 `if (!Platform.isWindows) return false`，
+  非 Windows 测试宿主进不了对话框流程，且对话框依赖真实网络探测，故以剥注释后的源码结构守卫锁死修复）：
+  - A：`ensureInjector` 不得出现 `await _probeSize(`；探测必须 `unawaited(sizeProbe`；
+    `_confirmDownload` 参数为 `ValueListenable<String>` 且正文含 `ValueListenableBuilder`。
+  - B：两个启动方法体各含 `if (flag) return;` + `flag = true` + `finally` 内 `flag = false`。
+- **备注**：main checkout 落后 origin/develop 881 commit，本修复基于 origin/develop 在 worktree
+  `fix/galgame-helper-dialog-latency` 完成。Windows 真机验收：点击游戏卡片/引擎-hook 按钮应
+  **立即**弹出确认框（大小随后从「未知」刷新为「约 1.0 MB」），弱网下连点多次只出一个框。

--- a/hibiki/lib/src/mining/galgame_helper_installer.dart
+++ b/hibiki/lib/src/mining/galgame_helper_installer.dart
@@ -146,14 +146,34 @@ class GalgameHelperInstaller {
       return true; // 幂等：已装好（可能刚被刷新）
     }
 
-    // 探测大小（best-effort，供确认对话框展示；失败则显示「大小未知」）。
-    final int? sizeBytes = await _probeSize(arch);
-    if (!context.mounted) return false;
-    final String sizeText = (sizeBytes != null && sizeBytes > 0)
-        ? formatDownloadSize(sizeBytes)
-        : t.galgame_helper_size_unknown;
+    // 确认对话框**立即**弹出，绝不为 best-effort 的大小探测阻塞 UI（旧实现先 await
+    // _probeSize——一个 10s 连接超时、逐镜像回退的 HTTP HEAD——再弹框，弱网/GFW 下点击后
+    // 要等好几秒对话框才出现，是「点了没反应」的根因）。大小仅作展示，先填「大小未知」，探测
+    // 在后台并发进行，返回后就地更新对话框里的「约 N MB」。
+    final ValueNotifier<String> sizeText =
+        ValueNotifier<String>(t.galgame_helper_size_unknown);
+    // sizeText.dispose() 后不得再写其 value（debug 下会 assert）。用本地守卫记录对话框是否已关闭；
+    // Dart 单线程事件循环下 then 回调与 dispose 后的代码不会真并发，简单 bool 守卫即安全。
+    bool dialogClosed = false;
+    int? probedSize;
+    final Future<int?> sizeProbe = _probeSize(arch);
+    unawaited(sizeProbe.then((int? bytes) {
+      probedSize = bytes;
+      if (!dialogClosed && bytes != null && bytes > 0) {
+        sizeText.value = formatDownloadSize(bytes);
+      }
+    }).catchError((Object _) {
+      // 探测失败：保持「大小未知」，不打扰用户。
+    }));
+
     final bool confirmed = await _confirmDownload(context, sizeText: sizeText);
+    dialogClosed = true;
+    sizeText.dispose();
     if (!confirmed || !context.mounted) return false;
+
+    // 复用后台探测结果作 expectedSize（用户看完对话框再确认，多半已就绪；未就绪则为 null，
+    // 下载阶段仍靠 Content-Length / sha256 兜底校验）。
+    final int? sizeBytes = probedSize;
 
     // 下载 + 校验 + 解压（带进度对话框）。
     final bool ok = await _downloadAndExtract(
@@ -212,10 +232,11 @@ class GalgameHelperInstaller {
     }
   }
 
-  /// 弹确认对话框（复用 app 统一对话框外框），返回用户是否确认下载。
+  /// 弹确认对话框（复用 app 统一对话框外框），返回用户是否确认下载。[sizeText] 是可监听的
+  /// 大小文案：对话框先以「大小未知」立即出现，后台探测返回后就地刷新为「约 N MB」。
   Future<bool> _confirmDownload(
     BuildContext context, {
-    required String sizeText,
+    required ValueListenable<String> sizeText,
   }) async {
     final bool? confirmed = await showAppDialog<bool>(
       context: context,
@@ -244,9 +265,12 @@ class GalgameHelperInstaller {
               tokens.spacing.card,
               tokens.spacing.card,
             ),
-            body: Text(
-              t.galgame_helper_needed_body(size: sizeText),
-              style: tokens.type.listSubtitle,
+            body: ValueListenableBuilder<String>(
+              valueListenable: sizeText,
+              builder: (BuildContext _, String size, Widget? __) => Text(
+                t.galgame_helper_needed_body(size: size),
+                style: tokens.type.listSubtitle,
+              ),
             ),
             footer: Wrap(
               alignment: WrapAlignment.end,

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -49,6 +49,11 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   /// 本页持有的游戏列表（从持久化载入，增删改后回写并 setState 刷新）。
   late List<GalgameEntry> _games = List<GalgameEntry>.of(_appModel.galgames);
 
+  /// 启动流程的**再入守卫**：一次启动含位数探测、helper 确认/下载对话框、注入会话等多个 await，
+  /// 全程可能持续数秒。没有此守卫时，用户在等待期间重复点击游戏卡片会各自开一条 _launchGame，
+  /// 叠出多个「需要下载 galgame 引擎组件」对话框（用户实测症状）。true 期间忽略新的启动点击。
+  bool _launching = false;
+
   /// 覆写持久化 + 刷新本页。
   Future<void> _persist(List<GalgameEntry> next) async {
     await _appModel.setGalgames(next);
@@ -107,38 +112,44 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   /// 启动一个游戏 → 台词进查词弹窗：非 Windows 优雅提示不支持；Windows 上交给
   /// 启动前先按 exe 位数确保 helper 就位，再交给 app 级 Hook 会话。
   Future<void> _launchGame(GalgameEntry game) async {
-    if (!Platform.isWindows) {
-      HibikiToast.show(msg: t.games_launch_unsupported);
-      return;
-    }
-    if (!File(game.exePath).existsSync()) {
-      HibikiToast.show(msg: t.games_exe_missing);
-      return;
-    }
-    final bool is32Bit =
-        await EngineHookGalAudioSource.exeIs32Bit(game.exePath) ?? false;
-    if (GalHookSessionController.defaultInjectorResolver(is32Bit: is32Bit) ==
-        null) {
+    if (_launching) return; // 再入守卫：启动进行中，忽略重复点击（避免多开确认对话框）。
+    _launching = true;
+    try {
+      if (!Platform.isWindows) {
+        HibikiToast.show(msg: t.games_launch_unsupported);
+        return;
+      }
+      if (!File(game.exePath).existsSync()) {
+        HibikiToast.show(msg: t.games_exe_missing);
+        return;
+      }
+      final bool is32Bit =
+          await EngineHookGalAudioSource.exeIs32Bit(game.exePath) ?? false;
+      if (GalHookSessionController.defaultInjectorResolver(is32Bit: is32Bit) ==
+          null) {
+        if (!mounted) return;
+        final bool installed = await GalgameHelperInstaller().ensureInjector(
+          is32Bit: is32Bit,
+          context: context,
+        );
+        if (!installed || !mounted) return;
+      }
+      final bool launched =
+          await (widget.sessionController ?? GalHookSessionController.instance)
+              .launchGame(game.exePath);
       if (!mounted) return;
-      final bool installed = await GalgameHelperInstaller().ensureInjector(
-        is32Bit: is32Bit,
-        context: context,
-      );
-      if (!installed || !mounted) return;
+      if (!launched) {
+        final String? reason =
+            (widget.sessionController ?? GalHookSessionController.instance)
+                .state
+                .lastError;
+        HibikiToast.show(msg: reason ?? t.game_capture_launch_failed);
+        return;
+      }
+      widget.onLaunched?.call();
+    } finally {
+      _launching = false;
     }
-    final bool launched =
-        await (widget.sessionController ?? GalHookSessionController.instance)
-            .launchGame(game.exePath);
-    if (!mounted) return;
-    if (!launched) {
-      final String? reason =
-          (widget.sessionController ?? GalHookSessionController.instance)
-              .state
-              .lastError;
-      HibikiToast.show(msg: reason ?? t.game_capture_launch_failed);
-      return;
-    }
-    widget.onLaunched?.call();
   }
 
   @override

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -82,6 +82,10 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   int _unreadLines = 0;
   String? _lastObservedLineId;
 
+  /// galgame 引擎-hook 启动的**再入守卫**：一次启动含选文件、位数探测、helper 确认/下载对话框、
+  /// 注入会话等多个 await，可持续数秒。没有守卫时重复点击会叠出多个下载确认对话框。
+  bool _launchingGalHook = false;
+
   /// 缓存的 [AppModel] 引用（`appProvider` 为单例，实例不变）。在 [initState] 一次性
   /// 读取：浮层层在 `LayoutBuilder` 回调里访问 `mixinAppModel`，widget 失活后再
   /// `ref.read` 会抛「deactivated widget's ancestor」（与视频页同源），缓存实例规避。
@@ -296,41 +300,48 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   /// 音频源回退都在 [GalHookSessionController]。KiriKiriZ 仍走早注入；SiglusEngine 由
   /// injector 自动改为 Enigma-safe 延迟附着，并通过 raw-only Ogg 路径提供制卡音频。
   Future<void> _launchGalgameEngineHook() async {
-    if (!Platform.isWindows) {
-      HibikiToast.show(msg: t.external_window_unsupported);
-      return;
-    }
-    final FilePickerResult? picked = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: <String>['exe'],
-    );
-    final String? executable =
-        picked == null || picked.files.isEmpty ? null : picked.files.first.path;
-    if (executable == null) return;
-    final bool is32Bit =
-        await EngineHookGalAudioSource.exeIs32Bit(executable) ?? false;
-    if (GalHookSessionController.defaultInjectorResolver(is32Bit: is32Bit) ==
-        null) {
-      if (!context.mounted) return;
-      final bool installed = await GalgameHelperInstaller().ensureInjector(
-        is32Bit: is32Bit,
-        context: context,
+    if (_launchingGalHook) return; // 再入守卫：启动进行中，忽略重复点击（避免多开确认对话框）。
+    _launchingGalHook = true;
+    try {
+      if (!Platform.isWindows) {
+        HibikiToast.show(msg: t.external_window_unsupported);
+        return;
+      }
+      final FilePickerResult? picked = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: <String>['exe'],
       );
-      if (!installed || !mounted) return;
+      final String? executable = picked == null || picked.files.isEmpty
+          ? null
+          : picked.files.first.path;
+      if (executable == null) return;
+      final bool is32Bit =
+          await EngineHookGalAudioSource.exeIs32Bit(executable) ?? false;
+      if (GalHookSessionController.defaultInjectorResolver(is32Bit: is32Bit) ==
+          null) {
+        if (!context.mounted) return;
+        final bool installed = await GalgameHelperInstaller().ensureInjector(
+          is32Bit: is32Bit,
+          context: context,
+        );
+        if (!installed || !mounted) return;
+      }
+      HibikiToast.show(msg: t.game_capture_launching);
+      final bool launched = await _session.launchGame(executable);
+      if (!mounted) return;
+      final GalHookSessionState state = _session.state;
+      if (!launched) {
+        HibikiToast.show(msg: state.lastError ?? t.game_capture_launch_failed);
+        return;
+      }
+      HibikiToast.show(
+        msg: state.boundWindow == null
+            ? t.game_capture_running_no_window
+            : t.game_capture_running,
+      );
+    } finally {
+      _launchingGalHook = false;
     }
-    HibikiToast.show(msg: t.game_capture_launching);
-    final bool launched = await _session.launchGame(executable);
-    if (!mounted) return;
-    final GalHookSessionState state = _session.state;
-    if (!launched) {
-      HibikiToast.show(msg: state.lastError ?? t.game_capture_launch_failed);
-      return;
-    }
-    HibikiToast.show(
-      msg: state.boundWindow == null
-          ? t.game_capture_running_no_window
-          : t.game_capture_running,
-    );
   }
 
   void _onSessionChanged() {

--- a/hibiki/test/mining/galgame_helper_launch_guard_test.dart
+++ b/hibiki/test/mining/galgame_helper_launch_guard_test.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+// 复用同款字符级注释剥除器，避免文档/行/块注释里的示例文字污染静态守卫。
+import '../sync/desktop_lookup_foreground_guard_static_test.dart'
+    show stripDartComments;
+
+/// galgame 引擎-hook 启动路径的静态守卫（用户报「点击『下载引擎组件』不立即弹窗、
+/// 且多次点击叠出多个弹窗」）。
+///
+/// 两个根因、两组守卫——本层是当前**最强可落地层**：`GalgameHelperInstaller.ensureInjector`
+/// 首行 `if (!Platform.isWindows) return false`，非 Windows 测试宿主（CI/本机 test）根本进不了
+/// 对话框流程；下载确认对话框又依赖真实网络探测。因此以源码守卫锁死修复结构，防回归。
+///
+/// 根因 A（点了不弹）：旧实现在弹确认对话框**之前** `await _probeSize()`——一个 10s 连接
+///   超时、逐镜像回退的 HTTP HEAD——弱网/GFW 下点击后要等好几秒对话框才出现。修复：对话框
+///   立即弹出（大小先填「未知」），探测在后台并发回填。
+/// 根因 B（多次点击多弹窗）：两个调用点（游戏库卡片、texthooker 引擎-hook 按钮）的启动方法
+///   都没有再入守卫，等待期间重复点击各自开一条启动流程，叠出多个确认对话框。修复：各加一个
+///   实例 bool 再入守卫。
+void main() {
+  /// 读文件并剥注释（只对真实代码跑守卫，文档/行/块注释里的示例文字不算数）。
+  String readStripped(String path) =>
+      stripDartComments(File(path).readAsStringSync());
+
+  /// 截取某方法体（含花括号）的源码片段。先按括号计数越过参数列表——命名参数 `{ }` 也在
+  /// 括号内，不会被误当成方法体起始花括号——再从参数列表右括号之后的第一个 `{` 起做花括号计数。
+  String methodBody(String source, String signatureNeedle) {
+    final int sigIdx = source.indexOf(signatureNeedle);
+    expect(sigIdx, greaterThanOrEqualTo(0), reason: '找不到方法签名：$signatureNeedle');
+    // 1) 越过参数列表：从签名首个 '(' 起做括号计数，找到匹配右括号。
+    final int parenOpen = source.indexOf('(', sigIdx);
+    expect(parenOpen, greaterThanOrEqualTo(0));
+    int parenDepth = 0;
+    int parenClose = -1;
+    for (int i = parenOpen; i < source.length; i++) {
+      final String c = source[i];
+      if (c == '(') parenDepth++;
+      if (c == ')') {
+        parenDepth--;
+        if (parenDepth == 0) {
+          parenClose = i;
+          break;
+        }
+      }
+    }
+    expect(parenClose, greaterThanOrEqualTo(0),
+        reason: '$signatureNeedle 参数列表括号未闭合');
+    // 2) 方法体起始花括号 = 参数列表右括号之后第一个 '{'（越过 async / async* 等修饰词）。
+    final int braceStart = source.indexOf('{', parenClose);
+    expect(braceStart, greaterThanOrEqualTo(0));
+    int depth = 0;
+    for (int i = braceStart; i < source.length; i++) {
+      final String c = source[i];
+      if (c == '{') depth++;
+      if (c == '}') {
+        depth--;
+        if (depth == 0) return source.substring(braceStart, i + 1);
+      }
+    }
+    fail('方法 $signatureNeedle 花括号未闭合');
+  }
+
+  group('根因 A：确认对话框立即弹出，大小探测在后台并发回填', () {
+    const String installer = 'lib/src/mining/galgame_helper_installer.dart';
+
+    test('ensureInjector 不得在弹确认对话框前 await _probeSize（会阻塞 UI）', () {
+      final String src = readStripped(installer);
+      expect(
+        src.contains(RegExp(r'await\s+_probeSize\s*\(')),
+        isFalse,
+        reason: 'ensureInjector 若 await _probeSize 再弹框，弱网下点击后要等数秒对话框才出现。'
+            '探测必须在后台并发（unawaited），对话框先以「大小未知」立即弹出。',
+      );
+    });
+
+    test('探测在后台并发发起（unawaited sizeProbe）', () {
+      final String src = readStripped(installer);
+      expect(src.contains('_probeSize(arch)'), isTrue);
+      expect(src.contains(RegExp(r'unawaited\s*\(\s*sizeProbe')), isTrue,
+          reason: '探测 future 必须以 unawaited 在后台推进，不阻塞对话框弹出。');
+    });
+
+    test('_confirmDownload 收可监听大小文案，用 ValueListenableBuilder 就地刷新', () {
+      final String src = readStripped(installer);
+      final String body = methodBody(src, 'Future<bool> _confirmDownload(');
+      expect(
+        src.contains(RegExp(
+            r'_confirmDownload\([\s\S]*?required\s+ValueListenable<String>\s+sizeText')),
+        isTrue,
+        reason: '_confirmDownload 的 sizeText 必须是 ValueListenable，才能后台回填。',
+      );
+      expect(body.contains('ValueListenableBuilder'), isTrue,
+          reason: '对话框正文必须监听 sizeText，探测返回时就地更新「约 N MB」。');
+    });
+  });
+
+  group('根因 B：启动方法有再入守卫，重复点击不叠出多个下载对话框', () {
+    void expectReentrancyGuard({
+      required String path,
+      required String signature,
+      required String flag,
+    }) {
+      final String body = methodBody(readStripped(path), signature);
+      expect(
+        body.contains(RegExp('if\\s*\\(\\s*$flag\\s*\\)\\s*return')),
+        isTrue,
+        reason: '$signature 缺再入守卫：应在进入时 `if ($flag) return;`。',
+      );
+      expect(body.contains('$flag = true'), isTrue,
+          reason: '$signature 应置位 $flag = true。');
+      expect(body.contains('$flag = false'), isTrue,
+          reason: '$signature 应在 finally 复位 $flag = false。');
+      expect(body.contains('finally'), isTrue,
+          reason: '$signature 守卫复位必须在 finally，避免异常/提前 return 卡死。');
+    }
+
+    test('games_library_page._launchGame 有 _launching 守卫', () {
+      expectReentrancyGuard(
+        path: 'lib/src/pages/implementations/games_library_page.dart',
+        signature: 'Future<void> _launchGame(GalgameEntry game)',
+        flag: '_launching',
+      );
+    });
+
+    test('texthooker_page._launchGalgameEngineHook 有 _launchingGalHook 守卫', () {
+      expectReentrancyGuard(
+        path: 'lib/src/pages/implementations/texthooker_page.dart',
+        signature: 'Future<void> _launchGalgameEngineHook()',
+        flag: '_launchingGalHook',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 症状（用户报）
点击 galgame 游戏卡片 / 引擎-hook 按钮弹出的「需要下载 galgame 引擎组件」确认框：
1. 点击后**不立即出现**；
2. 多次点击会**叠出多个弹窗**。

## 根因
- **A（点了不弹）**：`GalgameHelperInstaller.ensureInjector` 在弹确认框**前** `await _probeSize()`——一次 HTTP `HEAD`（连接超时 10s，逐镜像候选串行回退）。弱网/GFW 直连卡住时点击后要等整轮探测返回（数秒）对话框才出现。
- **B（多次点击多弹窗）**：`games_library_page._launchGame` 与 `texthooker_page._launchGalgameEngineHook` 无再入守卫；启动流程含多个 await 持续数秒，等待期间重复点击各开一条流程、各弹一个确认框。

## 修复（根因修复，非绕过）
- **A**：确认对话框**立即**弹出（大小先填「大小未知」）；`_probeSize` 以 `unawaited(sizeProbe.then(...))` 后台并发，返回后经 `ValueNotifier<String>` 就地把「约 N MB」回填。`_confirmDownload` 参数 `String → ValueListenable<String>`，正文用 `ValueListenableBuilder` 刷新；对话框关闭后 `dialogClosed` 守卫再 `dispose`，避免写已释放 notifier。expectedSize 复用后台探测结果（未就绪则 null，下载阶段仍靠 Content-Length / sha256 兜底）。
- **B**：`_launchGame` 加 `bool _launching`、`_launchGalgameEngineHook` 加 `bool _launchingGalHook` 再入守卫（进入即 `if (flag) return;`，`try/finally` 复位）。

## 测试
`hibiki/test/mining/galgame_helper_launch_guard_test.dart`（静态守卫，本层为最强可落地层——`ensureInjector` 首行 `if (!Platform.isWindows) return false`，非 Windows 测试宿主进不了对话框流程，且对话框依赖真实网络）：
- A：`ensureInjector` 无 `await _probeSize(`；探测 `unawaited(sizeProbe`；`_confirmDownload` 参数为 `ValueListenable<String>` 且含 `ValueListenableBuilder`。
- B：两个启动方法体各含 `if (flag) return;` + `flag = true` + `finally` 内 `flag = false`。

`flutter analyze lib test` 0 issue；`test/mining/` + game 页面测试全绿。

## 待验收
⚠️ Windows 真机：点击游戏卡片/引擎-hook 按钮应**立即**弹确认框（大小随后从「未知」刷新为「约 1.0 MB」），弱网下连点多次只出一个框。

BUG-1021 · 基于 origin/develop（main checkout 落后 881 commit）。

https://claude.ai/code/session_016nZHtPpHyebVXgUn5QPfLt
