### PR TITLE
fix(browser-extension): 就绪时不再显示与步骤5重复的完成横幅

### DIFF
--- a/hibiki/lib/src/pages/implementations/browser_extension_page.dart
+++ b/hibiki/lib/src/pages/implementations/browser_extension_page.dart
@@ -431,42 +431,39 @@ class BrowserExtensionInstallSteps extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final bool autoReady = serverEnabled && hasToken;
-    final Color bannerColor = autoReady
-        ? theme.colorScheme.primaryContainer
-        : theme.colorScheme.tertiaryContainer;
-    final Color bannerFg = autoReady
-        ? theme.colorScheme.onPrimaryContainer
-        : theme.colorScheme.onTertiaryContainer;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        // 自动配置状态横幅：server+token 就绪 → 成功；否则提醒先开 server / 端口冲突。
-        HibikiCard(
-          color: bannerColor,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Icon(
-                autoReady ? Icons.check_circle : Icons.info_outline,
-                color: bannerFg,
-                size: 20,
-              ),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Text(
-                  autoReady
-                      ? t.browser_extension_step_done_auto
-                      : portConflict
-                          ? _portInUseMessage()
-                          : t.browser_extension_enable_server_first,
-                  style: TextStyle(color: bannerFg),
+        // 自动配置状态横幅：仅在未就绪时提醒（端口冲突 / 先开 server）。
+        // 就绪时不再显示——「完成」由步骤 5 承担，横幅重复它反而是句废话。
+        if (!autoReady) ...<Widget>[
+          HibikiCard(
+            color: theme.colorScheme.tertiaryContainer,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Icon(
+                  Icons.info_outline,
+                  color: theme.colorScheme.onTertiaryContainer,
+                  size: 20,
                 ),
-              ),
-            ],
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    portConflict
+                        ? _portInUseMessage()
+                        : t.browser_extension_enable_server_first,
+                    style: TextStyle(
+                      color: theme.colorScheme.onTertiaryContainer,
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
-        ),
-        const SizedBox(height: 16),
+          const SizedBox(height: 16),
+        ],
         // 步骤 1：打开扩展管理页（chrome:// / edge:// 无法程序化导航，给可复制文本）。
         _step(
           context,

--- a/hibiki/test/settings/browser_extension_install_dialog_test.dart
+++ b/hibiki/test/settings/browser_extension_install_dialog_test.dart
@@ -83,11 +83,16 @@ void main() {
     expect(copied, 'chrome://extensions');
   });
 
-  testWidgets('banner shows ready state when server+token configured',
+  testWidgets(
+      'ready state hides the redundant banner (done text only at step 5)',
       (WidgetTester tester) async {
     await pumpSteps(tester, serverEnabled: true, hasToken: true);
-    expect(find.byIcon(Icons.check_circle), findsWidgets);
-    expect(find.text(t.browser_extension_step_done_auto), findsWidgets);
+    // 就绪时不再显示顶部横幅：既没有提醒文案，也没有横幅的实心对勾图标。
+    expect(find.text(t.browser_extension_enable_server_first), findsNothing);
+    expect(find.byIcon(Icons.check_circle), findsNothing);
+    // 「完成」文案只在步骤 5 出现一次（步骤 5 用的是描边对勾 check_circle_outline）。
+    expect(find.text(t.browser_extension_step_done_auto), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
   });
 
   testWidgets('banner nudges to enable server when not ready',


### PR DESCRIPTION
## 问题
浏览器扩展安装引导页（`BrowserExtensionPage`）顶部横幅在 `autoReady`（server+token 就绪）时，渲染的正是与**步骤 5** 完全相同的 `browser_extension_step_done_auto` 文案「完成。已自动开启 Yomitan API 服务器，扩展已配置好连接本应用……」——同一句话在同一屏出现两次，顶部这条是纯废话。用户截图红箭头即指此句。

## 根因
`browser_extension_page.dart` 的横幅用同一个 i18n key 服务两个用途：就绪时当"成功确认"（重复步骤 5），未就绪时当"提醒"（端口冲突 / 先开 server）。前者与步骤 5 语义重复。

## 改动
- 就绪时**不再渲染横幅**；横幅只在未就绪时出现，承担有用的两种提醒（`portConflict` / `enable_server_first`）。「完成」确认交给步骤 5 独占。
- 顺带删去因就绪分支消失而多余的 `bannerColor` / `bannerFg` 三元色，横幅固定走 `tertiaryContainer` + `info_outline`。
- 未动 i18n key（步骤 5 仍在用）。

## 测试
- 更新原「banner shows ready state」测试为「就绪时隐藏冗余横幅」：断言就绪时无提醒文案、无横幅实心对勾，`browser_extension_step_done_auto` 与描边对勾各只出现一次（步骤 5）。
- `flutter analyze`（改动两文件）无问题；`flutter test test/settings/browser_extension_install_dialog_test.dart` 全 9 项通过。

https://claude.ai/code/session_01DSrzvBmSDGxjsnRDZZpFYP