### PR TITLE
fix(popup): 嵌套查词弹出时图标按钮气泡不再自动冒出 (BUG-1024)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 990 条。点号进各自文件。
+> 共 991 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1024](bugs/BUG-1024-popup-zoom-tooltip-misfire.md) | 🚧 | 🚧 | 嵌套查词弹出时 A- 的「缩小查词字号」tooltip 自动弹出遮挡正文 |
 | [BUG-1023](bugs/BUG-1023-drive-transient-408-not-retried.md) | ✅ | ✅ | Google Drive 瞬时故障(408/429/5xx)被判非重试整本skip |
 | [BUG-1022](bugs/BUG-1022-galgame-helper-dialog-latency-and-restack.md) | ✅ | ✅ | galgame 引擎组件下载确认弹窗点击不立即出现且多次点击叠出多个弹窗 |
 | [BUG-1021](bugs/BUG-1021-galgame-cardimage-alias-false-warning.md) | ✅ | ✅ | galgame 场景制卡误报缺少 {card-image}（旧别名瞎眼） |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -31,7 +31,7 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-1024](bugs/BUG-1024-popup-zoom-tooltip-misfire.md) | 🚧 | 🚧 | 嵌套查词弹出时 A- 的「缩小查词字号」tooltip 自动弹出遮挡正文 |
+| [BUG-1024](bugs/BUG-1024-popup-zoom-tooltip-misfire.md) | ✅ | ✅ | 嵌套查词弹出时 A- 的「缩小查词字号」tooltip 自动弹出遮挡正文 |
 | [BUG-1023](bugs/BUG-1023-drive-transient-408-not-retried.md) | ✅ | ✅ | Google Drive 瞬时故障(408/429/5xx)被判非重试整本skip |
 | [BUG-1022](bugs/BUG-1022-galgame-helper-dialog-latency-and-restack.md) | ✅ | ✅ | galgame 引擎组件下载确认弹窗点击不立即出现且多次点击叠出多个弹窗 |
 | [BUG-1021](bugs/BUG-1021-galgame-cardimage-alias-false-warning.md) | ✅ | ✅ | galgame 场景制卡误报缺少 {card-image}（旧别名瞎眼） |

--- a/docs/bugs/BUG-1024-popup-zoom-tooltip-misfire.md
+++ b/docs/bugs/BUG-1024-popup-zoom-tooltip-misfire.md
@@ -1,0 +1,19 @@
+## BUG-1024 · 嵌套查词弹出时 A- 的「缩小查词字号」tooltip 自动弹出遮挡正文
+
+- **报告**：2026-07-23（用户：截图 — 查词弹窗里做嵌套查词，第二层「フォロー」一弹出，左上角 `A-` 的「缩小查词字号」气泡自动冒出来，飘在第一层正文上）
+- **真实性**：✅ 真 bug。根因两处叠加：
+  - `hibiki/lib/src/utils/components/hibiki_icon_button.dart:299`（`_withTooltip`）—— 给全 app 每个纯图标按钮包 `Tooltip` 时没给 `waitDuration`，落到 Material 默认的 `Duration.zero`。而 Flutter 的 MouseTracker 每帧结束后会用**最后已知的光标位置**重新 hit-test，所以「光标一动不动、按钮新出现在它下面」也会触发 `onEnter` 并**立刻**弹气泡 —— 用户没做过任何悬停动作。
+  - `hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart:76`（`calcPopupPosition` → `placeAboveBelow`）—— 子弹窗锚成 `left = selectionRect.left` / `top = selectionRect.bottom + gap`，左上角紧贴被查词；而 `A-`/`A+` 固定钉在顶栏最左端。两者相乘的必然结果：嵌套查词的子层一弹出，`A-` 就落在用户刚点的那个词正下方，也就是光标停留处，于是零延迟气泡必现。
+
+  锚定本身是 BUG-098（不盖住被查词）/ BUG-129（贴住父层里选中的词）的既有契约，不动；根因是「零延迟」，修在按钮组件这唯一出口。
+
+  顺带查出第二个缺陷：`_buildZoomFontButton` 原先在 `HibikiIconButton` **外面又套了一层** `Tooltip`（`HibikiIconButton` 自己已包一层）。两层嵌套下更靠近 child 的内层先命中 hover，外层那句「Ctrl+滚轮也可缩放」**从来没机会显示** —— 桌面用户看到的一直是只有标签的单行气泡（正是截图那个），TODO-1353 想给的提示等于没给。
+
+- **[x] ① 已修复** — commit `1e0d5f9c0`
+  - `hibiki_icon_button.dart`：新增 `kIconButtonTooltipHoverDelay = 500ms`，`_withTooltip` 显式传 `waitDuration`。气泡只对**真实的悬停意图**作出反应；移动端长按触发路径（`TooltipTriggerMode.longPress`）不看此值，行为不变。
+  - `dictionary_popup_layer.dart`：`_buildZoomFontButton` 去掉重复嵌套的外层 `Tooltip`，把带 hint 的完整 message 直接交给 `HibikiIconButton.tooltip`，收成一层 —— 同时真正兑现 TODO-1353 的 Ctrl+滚轮提示。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/popup_zoom_ctrl_wheel_test.dart`（group `BUG-1024：子弹窗落到光标下时 A−/A+ 不得立刻冒气泡`）
+  - **行为级复现**：先把鼠标停在 `A-` 将要出现的坐标上，再让弹窗在该坐标下出现，断言 100ms 内不得冒气泡；同时断言停够 `waitDuration` 后仍必须显示提示（不把功能弄丢）。已验证撤掉 `waitDuration` 该用例立刻变红。
+  - **一层 Tooltip 守卫**：`A-`/`A+` 各只应有一层 `Tooltip`，且那唯一一层必须带 `dictionary_font_size_zoom_hint`（防止重复嵌套重新把 hint 挡掉）。
+  - **源码守卫**：popup layer 不得再自建 `Tooltip`；`hibiki_icon_button.dart` 必须显式给 `waitDuration: kIconButtonTooltipHoverDelay`。
+- **备注**：`HibikiIconButton` 是全 app 共用组件，改动影响所有纯图标按钮的 hover 气泡延迟（0 → 500ms），这正是修复意图。已跑全量 `flutter analyze`（0 issue）+ `flutter test`（12710 passed / 5 skipped）确认无连带破坏。截图那个**单行**气泡（无 hint）与平台无关，是 `HibikiIconButton` 内层气泡，故桌面/移动端同样受影响。桌面真机复测待办。

--- a/docs/bugs/BUG-1024-popup-zoom-tooltip-misfire.md
+++ b/docs/bugs/BUG-1024-popup-zoom-tooltip-misfire.md
@@ -9,7 +9,7 @@
 
   顺带查出第二个缺陷：`_buildZoomFontButton` 原先在 `HibikiIconButton` **外面又套了一层** `Tooltip`（`HibikiIconButton` 自己已包一层）。两层嵌套下更靠近 child 的内层先命中 hover，外层那句「Ctrl+滚轮也可缩放」**从来没机会显示** —— 桌面用户看到的一直是只有标签的单行气泡（正是截图那个），TODO-1353 想给的提示等于没给。
 
-- **[x] ① 已修复** — commit `1e0d5f9c0`
+- **[x] ① 已修复** — commit `ea69cec0a`
   - `hibiki_icon_button.dart`：新增 `kIconButtonTooltipHoverDelay = 500ms`，`_withTooltip` 显式传 `waitDuration`。气泡只对**真实的悬停意图**作出反应；移动端长按触发路径（`TooltipTriggerMode.longPress`）不看此值，行为不变。
   - `dictionary_popup_layer.dart`：`_buildZoomFontButton` 去掉重复嵌套的外层 `Tooltip`，把带 hint 的完整 message 直接交给 `HibikiIconButton.tooltip`，收成一层 —— 同时真正兑现 TODO-1353 的 Ctrl+滚轮提示。
 - **[x] ② 已加自动化测试** — `hibiki/test/pages/popup_zoom_ctrl_wheel_test.dart`（group `BUG-1024：子弹窗落到光标下时 A−/A+ 不得立刻冒气泡`）

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -765,24 +765,27 @@ class DictionaryPopupLayer extends StatelessWidget {
   /// [DictionaryPopupWebViewState.zoomFontStep] 走与 Ctrl+滚轮完全同一条 JS 步进路径
   /// （同 [8,72] 夹紧、就地改 zoom 即时生效不闪烁、popupZoomFont 回调持久化到
   /// dictionaryFontSize），三端一致；WebView 未挂载（无结果占位/搜索中）时安全 no-op。
-  /// 外层可见 [Tooltip]（桌面 hover / 移动端长按）给出按钮语义，桌面平台附带
-  /// 「Ctrl+滚轮也可缩放」提示（dictionary_font_size_zoom_hint）——解决缩放入口零提示。
+  ///
+  /// BUG-1024：这里原本在 [HibikiIconButton] 外面**又**套了一层 [Tooltip]，而
+  /// [HibikiIconButton] 自己已经为纯图标形态包了一层。两层嵌套下，更靠近 child 的内层
+  /// 先命中 hover，外层那句「Ctrl+滚轮也可缩放」从来没机会显示——桌面用户看到的一直是
+  /// 只有标签的单行气泡，TODO-1353 想给的提示等于没给。现在收成一层：把完整 message 直接
+  /// 交给 [HibikiIconButton.tooltip]，由那唯一一层负责显示（并带
+  /// [kIconButtonTooltipHoverDelay] 悬停延迟，避免子弹窗落到光标下就自动冒泡盖住父层正文）。
   Widget _buildZoomFontButton(BuildContext context, {required bool zoomIn}) {
     final String label =
         zoomIn ? t.popup_font_size_increase : t.popup_font_size_decrease;
+    // 桌面才提 Ctrl+滚轮：移动端没有滚轮，多这行只会让气泡更长。
     final String message = isDesktopPlatform
         ? '$label\n${t.dictionary_font_size_zoom_hint}'
         : label;
-    return Tooltip(
-      message: message,
-      child: HibikiIconButton(
-        icon: zoomIn ? Icons.text_increase : Icons.text_decrease,
-        size: 20,
-        tooltip: label,
-        constraints: _topActionConstraints,
-        padding: EdgeInsets.zero,
-        onTap: () => webViewKey.currentState?.zoomFontStep(zoomIn: zoomIn),
-      ),
+    return HibikiIconButton(
+      icon: zoomIn ? Icons.text_increase : Icons.text_decrease,
+      size: 20,
+      tooltip: message,
+      constraints: _topActionConstraints,
+      padding: EdgeInsets.zero,
+      onTap: () => webViewKey.currentState?.zoomFontStep(zoomIn: zoomIn),
     );
   }
 

--- a/hibiki/lib/src/utils/components/hibiki_icon_button.dart
+++ b/hibiki/lib/src/utils/components/hibiki_icon_button.dart
@@ -38,6 +38,22 @@ class HibikiHeaderLabelScope extends InheritedWidget {
       expandLabels != oldWidget.expandLabels;
 }
 
+/// BUG-1024：纯图标按钮气泡的悬停延迟。
+///
+/// Material [Tooltip] 的 `waitDuration` 默认是 [Duration.zero]，而 Flutter 的
+/// MouseTracker 每帧结束后会用**最后已知的光标位置**重新 hit-test。两者相乘的后果是：
+/// 光标一动不动、只要有个带 tooltip 的按钮新出现在它下面，就会立刻冒出气泡——用户没有
+/// 做过任何悬停动作。查词弹窗把这点放大成必现：嵌套查词的子弹窗锚成
+/// `left = selectionRect.left` / `top = selectionRect.bottom + gap`（见
+/// `dictionary_popup_layer.dart` 的 `calcPopupPosition`），左上角紧贴被查词，而顶栏最左端
+/// 正是 A−/A+ ——子层一弹出，按钮必然落在用户刚点的那个词正下方，也就是光标停留处，于是
+/// 「缩小查词字号」气泡自动盖住父层正文。
+///
+/// 根因在「零延迟」而非某一个调用点，故修在本组件这唯一出口：给一段悬停延迟，让气泡只对
+/// **真实的悬停意图**作出反应。长按触发路径（移动端 [TooltipTriggerMode.longPress]）不看
+/// 此值，行为不变。
+const Duration kIconButtonTooltipHoverDelay = Duration(milliseconds: 500);
+
 /// A button that can be set as busy. When busy, the icon is faded out when its
 /// [onTap] action is on-going and processing, which can be used to
 /// indicate when a button cannot be pressed once its click action has been
@@ -298,7 +314,11 @@ class _HibikiIconButtonState extends State<HibikiIconButton> {
   /// 故不走此路径。空 [tooltip] 不包裹，避免弹出空浮层。
   Widget _withTooltip(Widget child) {
     if (widget.tooltip.isEmpty) return child;
-    return Tooltip(message: widget.tooltip, child: child);
+    return Tooltip(
+      message: widget.tooltip,
+      waitDuration: kIconButtonTooltipHoverDelay,
+      child: child,
+    );
   }
 
   Widget _focusable(BuildContext context, Widget button) {

--- a/hibiki/test/pages/popup_zoom_ctrl_wheel_test.dart
+++ b/hibiki/test/pages/popup_zoom_ctrl_wheel_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/i18n/strings.g.dart';
@@ -170,9 +171,128 @@ void main() {
       expect(layerSrc.contains('zoomFontStep(zoomIn: zoomIn)'), isTrue);
       expect(layerSrc.contains('Icons.text_decrease'), isTrue);
       expect(layerSrc.contains('Icons.text_increase'), isTrue);
-      // 可见提示（桌面平台附带 dictionary_font_size_zoom_hint）。
+      // 可见提示（桌面平台附带 dictionary_font_size_zoom_hint）。BUG-1024 后气泡本体由
+      // HibikiIconButton 统一提供，这里只负责把带 hint 的 message 交给它。
       expect(layerSrc.contains('dictionary_font_size_zoom_hint'), isTrue);
-      expect(layerSrc.contains('Tooltip('), isTrue);
+      expect(layerSrc.contains('tooltip: message'), isTrue);
+    });
+  });
+
+  /// BUG-1024 guard：嵌套查词弹出时 A−/A+ 的气泡不得自作主张冒出来。
+  ///
+  /// 复现的是真实几何：[calcPopupPosition] 把子弹窗锚成
+  /// `left = selectionRect.left` / `top = selectionRect.bottom + gap`，A−/A+ 又钉在顶栏
+  /// 最左端，所以嵌套弹窗一出现，A− 必然落在用户刚点的那个词正下方——也就是指针的停留处。
+  /// Material [Tooltip] 默认 waitDuration 是 [Duration.zero]，而 Flutter 的 MouseTracker
+  /// 每帧后会用最后已知光标位置重新 hit-test，于是「光标不动、按钮出现在它下面」就立刻弹出
+  /// 「缩小查词字号」盖住父层正文。根因修在 [HibikiIconButton] 这唯一出口
+  /// （[kIconButtonTooltipHoverDelay]），同时把这里原本重复嵌套的两层 Tooltip 收成一层。
+  group('BUG-1024：子弹窗落到光标下时 A−/A+ 不得立刻冒气泡', () {
+    final String layerSrc = File(
+      'lib/src/pages/implementations/dictionary_popup_layer.dart',
+    ).readAsStringSync();
+
+    Widget buildLayer() => buildTestApp(
+          SizedBox(
+            width: 320,
+            height: 240,
+            child: DictionaryPopupLayer(
+              result: null,
+              isSearching: false,
+              webViewKey: GlobalKey<DictionaryPopupWebViewState>(),
+              onDismiss: () {},
+              onClose: () {},
+              onTextSelected: (String text, Rect rect) {},
+              onLinkClick: (String query, Rect rect) {},
+              onMineEntry: (Map<String, String> fields) async =>
+                  const MinePopupResult(),
+              onDuplicateCheck: (String expression, String reading) async =>
+                  false,
+            ),
+          ),
+        );
+
+    testWidgets('按钮出现在静止光标下时不弹气泡（真实悬停后才弹）', (WidgetTester tester) async {
+      // 先量出 A− 的中心（此时尚无鼠标指针参与）。
+      await tester.pumpWidget(buildLayer());
+      final Offset center = tester.getCenter(find.byIcon(Icons.text_decrease));
+
+      // 换成空壳，把鼠标停到那个坐标——此处当前什么都没有。
+      await tester
+          .pumpWidget(buildTestApp(const SizedBox(width: 320, height: 240)));
+      final TestGesture mouse =
+          await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await mouse.addPointer(location: center);
+      addTearDown(() => mouse.removePointer());
+      await tester.pump();
+
+      // 光标一动不动，子弹窗出现，A− 正落在光标下 —— 不得立刻冒气泡。
+      await tester.pumpWidget(buildLayer());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(
+        find.textContaining(t.popup_font_size_decrease),
+        findsNothing,
+        reason: '子弹窗刚落到光标下就弹「缩小查词字号」会盖住父层正文（BUG-1024）',
+      );
+
+      // 但真实悬停意图（停够 waitDuration）仍要给出提示，不能把功能弄丢。
+      await tester.pump(const Duration(milliseconds: 600));
+      expect(
+        find.textContaining(t.dictionary_font_size_zoom_hint),
+        findsOneWidget,
+        reason: '悬停停留够久仍必须显示 Ctrl+滚轮提示',
+      );
+    });
+
+    testWidgets('A−/A+ 只有一层 Tooltip，且桌面上真能看到 Ctrl+滚轮提示',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildLayer());
+
+      // 每个按钮恰好一层 Tooltip：两层嵌套时内层先吃 hover，外层的 hint 永远显示不出来。
+      final List<String> zoomMessages = tester
+          .widgetList<Tooltip>(find.byType(Tooltip))
+          .map((Tooltip w) => w.message)
+          .whereType<String>()
+          .where((String m) =>
+              m.contains(t.popup_font_size_decrease) ||
+              m.contains(t.popup_font_size_increase))
+          .toList();
+      expect(
+        zoomMessages.length,
+        2,
+        reason: 'A−/A+ 各只应有一层 Tooltip（BUG-1024：原先内外重复嵌套）',
+      );
+      // 那唯一一层必须带上 hint —— 否则 TODO-1353 的提示等于没给。
+      expect(
+        zoomMessages
+            .where((String m) => m.contains(t.dictionary_font_size_zoom_hint))
+            .length,
+        2,
+        reason: '桌面上唯一那层 Tooltip 必须带 Ctrl+滚轮提示',
+      );
+    });
+
+    test('源码守卫：气泡悬停延迟收口在 HibikiIconButton 唯一出口', () {
+      // popup layer 不得再自建 Tooltip（重复嵌套会把 hint 挡掉）。
+      expect(
+        layerSrc.contains('Tooltip('),
+        isFalse,
+        reason: 'A−/A+ 的气泡由 HibikiIconButton 统一提供，不得再套一层（BUG-1024）',
+      );
+      // 根因修在组件唯一出口：不得沿用 Material 的 Duration.zero 默认值。
+      final String buttonSrc = File(
+        'lib/src/utils/components/hibiki_icon_button.dart',
+      ).readAsStringSync();
+      expect(
+        buttonSrc.contains('waitDuration: kIconButtonTooltipHoverDelay'),
+        isTrue,
+        reason: '纯图标按钮的 Tooltip 必须显式给悬停延迟（BUG-1024）',
+      );
+      expect(
+        buttonSrc.contains('const Duration kIconButtonTooltipHoverDelay ='),
+        isTrue,
+      );
     });
   });
 }


### PR DESCRIPTION
## 用户报告

查词弹窗里做嵌套查词，第二层一弹出，左上角 `A-` 的「缩小查词字号」气泡就自动冒出来，飘在第一层正文上。

## 根因（两处叠加）

**1. 零延迟气泡** — `hibiki_icon_button.dart:299` 的 `_withTooltip` 给全 app 每个纯图标按钮包 `Tooltip` 时没给 `waitDuration`，落到 Material 默认的 `Duration.zero`。而 Flutter 的 MouseTracker 每帧结束后会用**最后已知的光标位置**重新 hit-test —— 所以「光标一动不动、按钮新出现在它下面」也会触发 `onEnter` 并立刻弹气泡，用户没做过任何悬停动作。

**2. 锚定必然把按钮送到光标下** — `dictionary_popup_layer.dart:76` 的 `calcPopupPosition` → `placeAboveBelow` 把子弹窗锚成 `left = selectionRect.left` / `top = selectionRect.bottom + gap`，左上角紧贴被查词；而 `A-`/`A+` 固定钉在顶栏最左端。两者相乘：嵌套查词的子层一弹出，`A-` 必然落在用户刚点的那个词正下方，也就是光标停留处。

锚定是 BUG-098（不盖住被查词）/ BUG-129（贴住父层里选中的词）的既有契约，不动。根因是「零延迟」，修在按钮组件这唯一出口。

## 顺带修掉的第二个缺陷

`_buildZoomFontButton` 原先在 `HibikiIconButton` **外面又套了一层** `Tooltip`（组件自己已包一层）。两层嵌套下更靠近 child 的内层先命中 hover，外层那句「Ctrl+滚轮也可缩放」**从来没机会显示** —— 桌面用户看到的一直是只有标签的单行气泡（正是截图那个），TODO-1353 想给的提示等于没给。现收成一层。

## 改动

- `hibiki_icon_button.dart`：新增 `kIconButtonTooltipHoverDelay = 500ms`，`_withTooltip` 显式传 `waitDuration`。移动端长按触发路径（`TooltipTriggerMode.longPress`）不看此值，行为不变。
- `dictionary_popup_layer.dart`：去掉重复嵌套的外层 `Tooltip`，把带 hint 的完整 message 直接交给 `HibikiIconButton.tooltip`。

## 测试

`test/pages/popup_zoom_ctrl_wheel_test.dart` 新增 group `BUG-1024`：

- **行为级复现**：先把鼠标停在 `A-` 将要出现的坐标上，再让弹窗在该坐标下出现，断言 100ms 内不得冒气泡；同时断言停够 `waitDuration` 后仍必须显示提示（不把功能弄丢）。**已验证撤掉 `waitDuration` 该用例立刻变红。**
- **一层 Tooltip 守卫**：`A-`/`A+` 各只应有一层 `Tooltip`，且那唯一一层必须带 `dictionary_font_size_zoom_hint`。
- **源码守卫**：popup layer 不得再自建 `Tooltip`；组件必须显式给 `waitDuration`。

## 验证

- `flutter analyze` — 0 issue
- `flutter test` — **12710 passed / 5 skipped**

## 影响范围与待办

`HibikiIconButton` 是全 app 共用组件，改动影响所有纯图标按钮的 hover 气泡延迟（0 → 500ms），这正是修复意图。截图那个**单行**气泡（无 hint）是组件内层气泡，与平台无关，桌面/移动端同样受影响。

⚠️ **真机复测待办**：桌面上走一遍嵌套查词，确认气泡不再自动冒出、且悬停停留后能看到带「Ctrl+滚轮」的两行提示。

https://claude.ai/code/session_01LyVSewZ6fMAQpMJbdcWY5p