### PR TITLE
docs: 用户指南标题/README 徽章改为「平泽唯也能5分钟配置好」(仅文档，直接对 main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **English** | [简体中文](README.zh-CN.md) | [繁體中文](docs/readme/README.zh-Hant.md) | [日本語](docs/readme/README.ja.md) | [한국어](docs/readme/README.ko.md) | [Español](docs/readme/README.es.md) | [Français](docs/readme/README.fr.md) | [Deutsch](docs/readme/README.de.md) | [Português](docs/readme/README.pt-BR.md) | [Русский](docs/readme/README.ru.md) | [Tiếng Việt](docs/readme/README.vi.md) | [ภาษาไทย](docs/readme/README.th.md) | [Bahasa Indonesia](docs/readme/README.id.md) | [Italiano](docs/readme/README.it.md) | [Nederlands](docs/readme/README.nl.md) | [Türkçe](docs/readme/README.tr.md) | [العربية](docs/readme/README.ar.md)
 
-[![5 Minute Setup Guide](https://img.shields.io/badge/%F0%9F%93%96%205%20Minute%20Setup%20Guide-0969DA?style=for-the-badge)](docs/user-guide.md)
+[![The hibiki Setup Guide Even Yui Hirasawa Can Finish in 5 Minutes](https://img.shields.io/badge/%F0%9F%93%96%20The%20hibiki%20Setup%20Guide%20Even%20Yui%20Hirasawa%20Can%20Finish%20in%205%20Minutes-0969DA?style=for-the-badge)](docs/user-guide.md)
 
 **Even Yui Hirasawa can set it up in 5 minutes** — import the recommended dictionaries and audio in one step.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 **English** | [简体中文](README.zh-CN.md) | [繁體中文](docs/readme/README.zh-Hant.md) | [日本語](docs/readme/README.ja.md) | [한국어](docs/readme/README.ko.md) | [Español](docs/readme/README.es.md) | [Français](docs/readme/README.fr.md) | [Deutsch](docs/readme/README.de.md) | [Português](docs/readme/README.pt-BR.md) | [Русский](docs/readme/README.ru.md) | [Tiếng Việt](docs/readme/README.vi.md) | [ภาษาไทย](docs/readme/README.th.md) | [Bahasa Indonesia](docs/readme/README.id.md) | [Italiano](docs/readme/README.it.md) | [Nederlands](docs/readme/README.nl.md) | [Türkçe](docs/readme/README.tr.md) | [العربية](docs/readme/README.ar.md)
 
-[![User Guide](https://img.shields.io/badge/%F0%9F%93%96%20User%20Guide-0969DA?style=for-the-badge)](docs/user-guide.md)
+[![5 Minute Setup Guide](https://img.shields.io/badge/%F0%9F%93%96%205%20Minute%20Setup%20Guide-0969DA?style=for-the-badge)](docs/user-guide.md)
 
-**No fiddly setup** — import the recommended dictionaries and audio in one step.
+**Even Yui Hirasawa can set it up in 5 minutes** — import the recommended dictionaries and audio in one step.
 
 [![Download Latest](https://img.shields.io/badge/%E2%AC%87%20Download%20Latest-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Join our Discord](https://img.shields.io/badge/Join%20our%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
@@ -146,7 +146,7 @@ English · 简体中文 · 繁體中文 · 日本語 · 한국어 · Español ·
 Download the latest release from [GitHub Releases](https://github.com/hajisensai/hibiki/releases) — Android APK and Windows installer are available.
 
 <details open>
-<summary>📖 <b>No fiddly setup</b> — import the recommended dictionaries and audio in one step.</summary>
+<summary>📖 <b>Even Yui Hirasawa can set it up in 5 minutes</b> — import the recommended dictionaries and audio in one step.</summary>
 
 <a href="docs/user-guide.md"><img src="docs/static-assets/user-guide/config-tutorial.en.png" alt="Configuration tutorial — import recommended dictionaries and audio" width="360"></a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,9 +10,9 @@
 
 [English](README.md) | **简体中文** | [繁體中文](docs/readme/README.zh-Hant.md) | [日本語](docs/readme/README.ja.md) | [한국어](docs/readme/README.ko.md) | [Español](docs/readme/README.es.md) | [Français](docs/readme/README.fr.md) | [Deutsch](docs/readme/README.de.md) | [Português](docs/readme/README.pt-BR.md) | [Русский](docs/readme/README.ru.md) | [Tiếng Việt](docs/readme/README.vi.md) | [ภาษาไทย](docs/readme/README.th.md) | [Bahasa Indonesia](docs/readme/README.id.md) | [Italiano](docs/readme/README.it.md) | [Nederlands](docs/readme/README.nl.md) | [Türkçe](docs/readme/README.tr.md) | [العربية](docs/readme/README.ar.md)
 
-[![使用文档](https://img.shields.io/badge/%F0%9F%93%96%20%E4%BD%BF%E7%94%A8%E6%96%87%E6%A1%A3-0969DA?style=for-the-badge)](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb)
+[![5分钟配置指南](https://img.shields.io/badge/%F0%9F%93%96%205%E5%88%86%E9%92%9F%E9%85%8D%E7%BD%AE%E6%8C%87%E5%8D%97-0969DA?style=for-the-badge)](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb)
 
-**无需繁琐配置**，推荐词典与本地音频一键导入即用。
+**平泽唯也能5分钟配置好**，推荐词典与本地音频一键导入即用。
 
 [![下载最新版本](https://img.shields.io/badge/%E2%AC%87%20%E4%B8%8B%E8%BD%BD%E6%9C%80%E6%96%B0%E7%89%88%E6%9C%AC-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![加入 Discord 社区](https://img.shields.io/badge/%E5%8A%A0%E5%85%A5%20Discord%20%E7%A4%BE%E5%8C%BA-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)
@@ -145,7 +145,7 @@ English · 简体中文 · 繁體中文 · 日本語 · 한국어 · Español ·
 从 [GitHub Releases](https://github.com/hajisensai/hibiki/releases) 下载最新版本，支持 Android APK 和 Windows 安装包。
 
 <details open>
-<summary>📖 <b>无需繁琐配置</b>：推荐词典与本地音频一键导入即用。</summary>
+<summary>📖 <b>平泽唯也能5分钟配置好</b>：推荐词典与本地音频一键导入即用。</summary>
 
 <a href="https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb"><img src="docs/static-assets/user-guide/config-tutorial.zh-CN.png" alt="配置教程 — 导入推荐词典和音频" width="420"></a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 
 [English](README.md) | **简体中文** | [繁體中文](docs/readme/README.zh-Hant.md) | [日本語](docs/readme/README.ja.md) | [한국어](docs/readme/README.ko.md) | [Español](docs/readme/README.es.md) | [Français](docs/readme/README.fr.md) | [Deutsch](docs/readme/README.de.md) | [Português](docs/readme/README.pt-BR.md) | [Русский](docs/readme/README.ru.md) | [Tiếng Việt](docs/readme/README.vi.md) | [ภาษาไทย](docs/readme/README.th.md) | [Bahasa Indonesia](docs/readme/README.id.md) | [Italiano](docs/readme/README.it.md) | [Nederlands](docs/readme/README.nl.md) | [Türkçe](docs/readme/README.tr.md) | [العربية](docs/readme/README.ar.md)
 
-[![5分钟配置指南](https://img.shields.io/badge/%F0%9F%93%96%205%E5%88%86%E9%92%9F%E9%85%8D%E7%BD%AE%E6%8C%87%E5%8D%97-0969DA?style=for-the-badge)](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb)
+[![平泽唯也能5分钟配置好的 hibiki 使用指南](https://img.shields.io/badge/%F0%9F%93%96%20%E5%B9%B3%E6%B3%BD%E5%94%AF%E4%B9%9F%E8%83%BD5%E5%88%86%E9%92%9F%E9%85%8D%E7%BD%AE%E5%A5%BD%E7%9A%84%20hibiki%20%E4%BD%BF%E7%94%A8%E6%8C%87%E5%8D%97-0969DA?style=for-the-badge)](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb)
 
 **平泽唯也能5分钟配置好**，推荐词典与本地音频一键导入即用。
 

--- a/docs/readme/README.ar.md
+++ b/docs/readme/README.ar.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | **العربية**
 
-[![دليل المستخدم](https://img.shields.io/badge/%F0%9F%93%96%20%D8%AF%D9%84%D9%8A%D9%84%20%D8%A7%D9%84%D9%85%D8%B3%D8%AA%D8%AE%D8%AF%D9%85-0969DA?style=for-the-badge)](../user-guide.ar.md)
+[![الإعداد في 5 دقائق](https://img.shields.io/badge/%F0%9F%93%96%20%D8%A7%D9%84%D8%A5%D8%B9%D8%AF%D8%A7%D8%AF%20%D9%81%D9%8A%205%20%D8%AF%D9%82%D8%A7%D8%A6%D9%82-0969DA?style=for-the-badge)](../user-guide.ar.md)
 
-**بدون إعداد معقّد** — استورد القواميس والصوت المُوصى بها في خطوة واحدة.
+**حتى يوي هيراساوا يمكنها إعداده في 5 دقائق** — استورد القواميس والصوت المُوصى بها في خطوة واحدة.
 
 [![تنزيل أحدث إصدار](https://img.shields.io/badge/%E2%AC%87%20%D8%AA%D9%86%D8%B2%D9%8A%D9%84%20%D8%A3%D8%AD%D8%AF%D8%AB%20%D8%A5%D8%B5%D8%AF%D8%A7%D8%B1-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![انضم إلى Discord](https://img.shields.io/badge/%D8%A7%D9%86%D8%B6%D9%85%20%D8%A5%D9%84%D9%89%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.ar.md
+++ b/docs/readme/README.ar.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | **العربية**
 
-[![الإعداد في 5 دقائق](https://img.shields.io/badge/%F0%9F%93%96%20%D8%A7%D9%84%D8%A5%D8%B9%D8%AF%D8%A7%D8%AF%20%D9%81%D9%8A%205%20%D8%AF%D9%82%D8%A7%D8%A6%D9%82-0969DA?style=for-the-badge)](../user-guide.ar.md)
+[![دليل hibiki الذي يمكن حتى ليوي هيراساوا إعداده في 5 دقائق](https://img.shields.io/badge/%F0%9F%93%96%20%D8%AF%D9%84%D9%8A%D9%84%20hibiki%20%D8%A7%D9%84%D8%B0%D9%8A%20%D9%8A%D9%85%D9%83%D9%86%20%D8%AD%D8%AA%D9%89%20%D9%84%D9%8A%D9%88%D9%8A%20%D9%87%D9%8A%D8%B1%D8%A7%D8%B3%D8%A7%D9%88%D8%A7%20%D8%A5%D8%B9%D8%AF%D8%A7%D8%AF%D9%87%20%D9%81%D9%8A%205%20%D8%AF%D9%82%D8%A7%D8%A6%D9%82-0969DA?style=for-the-badge)](../user-guide.ar.md)
 
 **حتى يوي هيراساوا يمكنها إعداده في 5 دقائق** — استورد القواميس والصوت المُوصى بها في خطوة واحدة.
 

--- a/docs/readme/README.de.md
+++ b/docs/readme/README.de.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | **Deutsch** | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Benutzerhandbuch](https://img.shields.io/badge/%F0%9F%93%96%20Benutzerhandbuch-0969DA?style=for-the-badge)](../user-guide.de.md)
+[![Einrichtung in 5 Minuten](https://img.shields.io/badge/%F0%9F%93%96%20Einrichtung%20in%205%20Minuten-0969DA?style=for-the-badge)](../user-guide.de.md)
 
-**Kein umständliches Einrichten** — empfohlene Wörterbücher und Audio in einem Schritt importieren.
+**Selbst Yui Hirasawa richtet es in 5 Minuten ein** — empfohlene Wörterbücher und Audio in einem Schritt importieren.
 
 [![Neueste Version herunterladen](https://img.shields.io/badge/%E2%AC%87%20Neueste%20Version%20herunterladen-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Discord beitreten](https://img.shields.io/badge/Discord%20beitreten-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.de.md
+++ b/docs/readme/README.de.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | **Deutsch** | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Einrichtung in 5 Minuten](https://img.shields.io/badge/%F0%9F%93%96%20Einrichtung%20in%205%20Minuten-0969DA?style=for-the-badge)](../user-guide.de.md)
+[![Das hibiki-Handbuch, das selbst Yui Hirasawa in 5 Minuten einrichtet](https://img.shields.io/badge/%F0%9F%93%96%20Das%20hibiki--Handbuch%2C%20das%20selbst%20Yui%20Hirasawa%20in%205%20Minuten%20einrichtet-0969DA?style=for-the-badge)](../user-guide.de.md)
 
 **Selbst Yui Hirasawa richtet es in 5 Minuten ein** — empfohlene Wörterbücher und Audio in einem Schritt importieren.
 

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | **Español** | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Guía de usuario](https://img.shields.io/badge/%F0%9F%93%96%20Gu%C3%ADa%20de%20usuario-0969DA?style=for-the-badge)](../user-guide.es.md)
+[![Configuración en 5 minutos](https://img.shields.io/badge/%F0%9F%93%96%20Configuraci%C3%B3n%20en%205%20minutos-0969DA?style=for-the-badge)](../user-guide.es.md)
 
-**Sin configuración engorrosa** — importa los diccionarios y el audio recomendados en un solo paso.
+**Hasta Yui Hirasawa lo configura en 5 minutos** — importa los diccionarios y el audio recomendados en un solo paso.
 
 [![Descargar la última versión](https://img.shields.io/badge/%E2%AC%87%20Descargar%20la%20%C3%BAltima%20versi%C3%B3n-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Únete a Discord](https://img.shields.io/badge/%C3%9Anete%20a%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | **Español** | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Configuración en 5 minutos](https://img.shields.io/badge/%F0%9F%93%96%20Configuraci%C3%B3n%20en%205%20minutos-0969DA?style=for-the-badge)](../user-guide.es.md)
+[![La guía de hibiki que hasta Yui Hirasawa configura en 5 minutos](https://img.shields.io/badge/%F0%9F%93%96%20La%20gu%C3%ADa%20de%20hibiki%20que%20hasta%20Yui%20Hirasawa%20configura%20en%205%20minutos-0969DA?style=for-the-badge)](../user-guide.es.md)
 
 **Hasta Yui Hirasawa lo configura en 5 minutos** — importa los diccionarios y el audio recomendados en un solo paso.
 

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | **Français** | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Configuration en 5 minutes](https://img.shields.io/badge/%F0%9F%93%96%20Configuration%20en%205%20minutes-0969DA?style=for-the-badge)](../user-guide.fr.md)
+[![Le guide hibiki que même Yui Hirasawa configure en 5 minutes](https://img.shields.io/badge/%F0%9F%93%96%20Le%20guide%20hibiki%20que%20m%C3%AAme%20Yui%20Hirasawa%20configure%20en%205%20minutes-0969DA?style=for-the-badge)](../user-guide.fr.md)
 
 **Même Yui Hirasawa le configure en 5 minutes** — importez les dictionnaires et l'audio recommandés en une étape.
 

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | **Français** | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Guide d'utilisation](https://img.shields.io/badge/%F0%9F%93%96%20Guide%20d%27utilisation-0969DA?style=for-the-badge)](../user-guide.fr.md)
+[![Configuration en 5 minutes](https://img.shields.io/badge/%F0%9F%93%96%20Configuration%20en%205%20minutes-0969DA?style=for-the-badge)](../user-guide.fr.md)
 
-**Aucune configuration fastidieuse** — importez les dictionnaires et l'audio recommandés en une étape.
+**Même Yui Hirasawa le configure en 5 minutes** — importez les dictionnaires et l'audio recommandés en une étape.
 
 [![Télécharger la dernière version](https://img.shields.io/badge/%E2%AC%87%20T%C3%A9l%C3%A9charger%20la%20derni%C3%A8re%20version-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Rejoindre le Discord](https://img.shields.io/badge/Rejoindre%20le%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.id.md
+++ b/docs/readme/README.id.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | **Bahasa Indonesia** | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Panduan Pengguna](https://img.shields.io/badge/%F0%9F%93%96%20Panduan%20Pengguna-0969DA?style=for-the-badge)](../user-guide.id.md)
+[![Setup dalam 5 menit](https://img.shields.io/badge/%F0%9F%93%96%20Setup%20dalam%205%20menit-0969DA?style=for-the-badge)](../user-guide.id.md)
 
-**Tanpa pengaturan rumit** — impor kamus dan audio yang direkomendasikan dalam satu langkah.
+**Bahkan Yui Hirasawa bisa menyiapkannya dalam 5 menit** — impor kamus dan audio yang direkomendasikan dalam satu langkah.
 
 [![Unduh versi terbaru](https://img.shields.io/badge/%E2%AC%87%20Unduh%20versi%20terbaru-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Gabung Discord](https://img.shields.io/badge/Gabung%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.id.md
+++ b/docs/readme/README.id.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | **Bahasa Indonesia** | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Setup dalam 5 menit](https://img.shields.io/badge/%F0%9F%93%96%20Setup%20dalam%205%20menit-0969DA?style=for-the-badge)](../user-guide.id.md)
+[![Panduan hibiki yang bahkan Yui Hirasawa bisa siapkan dalam 5 menit](https://img.shields.io/badge/%F0%9F%93%96%20Panduan%20hibiki%20yang%20bahkan%20Yui%20Hirasawa%20bisa%20siapkan%20dalam%205%20menit-0969DA?style=for-the-badge)](../user-guide.id.md)
 
 **Bahkan Yui Hirasawa bisa menyiapkannya dalam 5 menit** — impor kamus dan audio yang direkomendasikan dalam satu langkah.
 

--- a/docs/readme/README.it.md
+++ b/docs/readme/README.it.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | **Italiano** | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Guida utente](https://img.shields.io/badge/%F0%9F%93%96%20Guida%20utente-0969DA?style=for-the-badge)](../user-guide.it.md)
+[![Configurazione in 5 minuti](https://img.shields.io/badge/%F0%9F%93%96%20Configurazione%20in%205%20minuti-0969DA?style=for-the-badge)](../user-guide.it.md)
 
-**Nessuna configurazione complicata** — importa i dizionari e l'audio consigliati in un solo passaggio.
+**Perfino Yui Hirasawa lo configura in 5 minuti** — importa i dizionari e l'audio consigliati in un solo passaggio.
 
 [![Scarica l'ultima versione](https://img.shields.io/badge/%E2%AC%87%20Scarica%20l%27ultima%20versione-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Unisciti a Discord](https://img.shields.io/badge/Unisciti%20a%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.it.md
+++ b/docs/readme/README.it.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | **Italiano** | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Configurazione in 5 minuti](https://img.shields.io/badge/%F0%9F%93%96%20Configurazione%20in%205%20minuti-0969DA?style=for-the-badge)](../user-guide.it.md)
+[![La guida di hibiki che perfino Yui Hirasawa configura in 5 minuti](https://img.shields.io/badge/%F0%9F%93%96%20La%20guida%20di%20hibiki%20che%20perfino%20Yui%20Hirasawa%20configura%20in%205%20minuti-0969DA?style=for-the-badge)](../user-guide.it.md)
 
 **Perfino Yui Hirasawa lo configura in 5 minuti** — importa i dizionari e l'audio consigliati in un solo passaggio.
 

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | **日本語** | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![使い方ガイド](https://img.shields.io/badge/%F0%9F%93%96%20%E4%BD%BF%E3%81%84%E6%96%B9%E3%82%AC%E3%82%A4%E3%83%89-0969DA?style=for-the-badge)](../user-guide.ja.md)
+[![5分で終わる設定ガイド](https://img.shields.io/badge/%F0%9F%93%96%205%E5%88%86%E3%81%A7%E7%B5%82%E3%82%8F%E3%82%8B%E8%A8%AD%E5%AE%9A%E3%82%AC%E3%82%A4%E3%83%89-0969DA?style=for-the-badge)](../user-guide.ja.md)
 
-**面倒な設定は不要** — 推奨辞書と音声をワンステップでインポート。
+**平沢唯でも5分で設定できる** — 推奨辞書と音声をワンステップでインポート。
 
 [![最新版をダウンロード](https://img.shields.io/badge/%E2%AC%87%20%E6%9C%80%E6%96%B0%E7%89%88%E3%82%92%E3%83%80%E3%82%A6%E3%83%B3%E3%83%AD%E3%83%BC%E3%83%89-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Discord に参加](https://img.shields.io/badge/Discord%20%E3%81%AB%E5%8F%82%E5%8A%A0-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | **日本語** | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![5分で終わる設定ガイド](https://img.shields.io/badge/%F0%9F%93%96%205%E5%88%86%E3%81%A7%E7%B5%82%E3%82%8F%E3%82%8B%E8%A8%AD%E5%AE%9A%E3%82%AC%E3%82%A4%E3%83%89-0969DA?style=for-the-badge)](../user-guide.ja.md)
+[![平沢唯でも5分で設定できる hibiki ユーザーガイド](https://img.shields.io/badge/%F0%9F%93%96%20%E5%B9%B3%E6%B2%A2%E5%94%AF%E3%81%A7%E3%82%825%E5%88%86%E3%81%A7%E8%A8%AD%E5%AE%9A%E3%81%A7%E3%81%8D%E3%82%8B%20hibiki%20%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%82%AC%E3%82%A4%E3%83%89-0969DA?style=for-the-badge)](../user-guide.ja.md)
 
 **平沢唯でも5分で設定できる** — 推奨辞書と音声をワンステップでインポート。
 

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | **한국어** | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![사용 설명서](https://img.shields.io/badge/%F0%9F%93%96%20%EC%82%AC%EC%9A%A9%20%EC%84%A4%EB%AA%85%EC%84%9C-0969DA?style=for-the-badge)](../user-guide.ko.md)
+[![5분 설정 가이드](https://img.shields.io/badge/%F0%9F%93%96%205%EB%B6%84%20%EC%84%A4%EC%A0%95%20%EA%B0%80%EC%9D%B4%EB%93%9C-0969DA?style=for-the-badge)](../user-guide.ko.md)
 
-**번거로운 설정 없이** — 추천 사전과 오디오를 한 번에 가져오기.
+**히라사와 유이도 5분이면 설정 완료** — 추천 사전과 오디오를 한 번에 가져오기.
 
 [![최신 버전 다운로드](https://img.shields.io/badge/%E2%AC%87%20%EC%B5%9C%EC%8B%A0%20%EB%B2%84%EC%A0%84%20%EB%8B%A4%EC%9A%B4%EB%A1%9C%EB%93%9C-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Discord 참여](https://img.shields.io/badge/Discord%20%EC%B0%B8%EC%97%AC-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | **한국어** | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![5분 설정 가이드](https://img.shields.io/badge/%F0%9F%93%96%205%EB%B6%84%20%EC%84%A4%EC%A0%95%20%EA%B0%80%EC%9D%B4%EB%93%9C-0969DA?style=for-the-badge)](../user-guide.ko.md)
+[![히라사와 유이도 5분이면 설정하는 hibiki 사용 설명서](https://img.shields.io/badge/%F0%9F%93%96%20%ED%9E%88%EB%9D%BC%EC%82%AC%EC%99%80%20%EC%9C%A0%EC%9D%B4%EB%8F%84%205%EB%B6%84%EC%9D%B4%EB%A9%B4%20%EC%84%A4%EC%A0%95%ED%95%98%EB%8A%94%20hibiki%20%EC%82%AC%EC%9A%A9%20%EC%84%A4%EB%AA%85%EC%84%9C-0969DA?style=for-the-badge)](../user-guide.ko.md)
 
 **히라사와 유이도 5분이면 설정 완료** — 추천 사전과 오디오를 한 번에 가져오기.
 

--- a/docs/readme/README.nl.md
+++ b/docs/readme/README.nl.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | **Nederlands** | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Instellen in 5 minuten](https://img.shields.io/badge/%F0%9F%93%96%20Instellen%20in%205%20minuten-0969DA?style=for-the-badge)](../user-guide.nl.md)
+[![De hibiki-handleiding die zelfs Yui Hirasawa in 5 minuten instelt](https://img.shields.io/badge/%F0%9F%93%96%20De%20hibiki--handleiding%20die%20zelfs%20Yui%20Hirasawa%20in%205%20minuten%20instelt-0969DA?style=for-the-badge)](../user-guide.nl.md)
 
 **Zelfs Yui Hirasawa stelt het in 5 minuten in** — importeer de aanbevolen woordenboeken en audio in één stap.
 

--- a/docs/readme/README.nl.md
+++ b/docs/readme/README.nl.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | **Nederlands** | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Gebruikershandleiding](https://img.shields.io/badge/%F0%9F%93%96%20Gebruikershandleiding-0969DA?style=for-the-badge)](../user-guide.nl.md)
+[![Instellen in 5 minuten](https://img.shields.io/badge/%F0%9F%93%96%20Instellen%20in%205%20minuten-0969DA?style=for-the-badge)](../user-guide.nl.md)
 
-**Geen omslachtige configuratie** — importeer de aanbevolen woordenboeken en audio in één stap.
+**Zelfs Yui Hirasawa stelt het in 5 minuten in** — importeer de aanbevolen woordenboeken en audio in één stap.
 
 [![Nieuwste versie downloaden](https://img.shields.io/badge/%E2%AC%87%20Nieuwste%20versie%20downloaden-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Word lid van Discord](https://img.shields.io/badge/Word%20lid%20van%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.pt-BR.md
+++ b/docs/readme/README.pt-BR.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | **Português** | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Guia do usuário](https://img.shields.io/badge/%F0%9F%93%96%20Guia%20do%20usu%C3%A1rio-0969DA?style=for-the-badge)](../user-guide.pt-BR.md)
+[![Configuração em 5 minutos](https://img.shields.io/badge/%F0%9F%93%96%20Configura%C3%A7%C3%A3o%20em%205%20minutos-0969DA?style=for-the-badge)](../user-guide.pt-BR.md)
 
-**Sem configuração complicada** — importe os dicionários e o áudio recomendados em uma etapa.
+**Até a Yui Hirasawa configura em 5 minutos** — importe os dicionários e o áudio recomendados em uma etapa.
 
 [![Baixar a versão mais recente](https://img.shields.io/badge/%E2%AC%87%20Baixar%20a%20vers%C3%A3o%20mais%20recente-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Entrar no Discord](https://img.shields.io/badge/Entrar%20no%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.pt-BR.md
+++ b/docs/readme/README.pt-BR.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | **Português** | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Configuração em 5 minutos](https://img.shields.io/badge/%F0%9F%93%96%20Configura%C3%A7%C3%A3o%20em%205%20minutos-0969DA?style=for-the-badge)](../user-guide.pt-BR.md)
+[![O guia do hibiki que até a Yui Hirasawa configura em 5 minutos](https://img.shields.io/badge/%F0%9F%93%96%20O%20guia%20do%20hibiki%20que%20at%C3%A9%20a%20Yui%20Hirasawa%20configura%20em%205%20minutos-0969DA?style=for-the-badge)](../user-guide.pt-BR.md)
 
 **Até a Yui Hirasawa configura em 5 minutos** — importe os dicionários e o áudio recomendados em uma etapa.
 

--- a/docs/readme/README.ru.md
+++ b/docs/readme/README.ru.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | **Русский** | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Настройка за 5 минут](https://img.shields.io/badge/%F0%9F%93%96%20%D0%9D%D0%B0%D1%81%D1%82%D1%80%D0%BE%D0%B9%D0%BA%D0%B0%20%D0%B7%D0%B0%205%20%D0%BC%D0%B8%D0%BD%D1%83%D1%82-0969DA?style=for-the-badge)](../user-guide.ru.md)
+[![Руководство hibiki, которое даже Юи Хирасава настроит за 5 минут](https://img.shields.io/badge/%F0%9F%93%96%20%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE%20hibiki%2C%20%D0%BA%D0%BE%D1%82%D0%BE%D1%80%D0%BE%D0%B5%20%D0%B4%D0%B0%D0%B6%D0%B5%20%D0%AE%D0%B8%20%D0%A5%D0%B8%D1%80%D0%B0%D1%81%D0%B0%D0%B2%D0%B0%20%D0%BD%D0%B0%D1%81%D1%82%D1%80%D0%BE%D0%B8%D1%82%20%D0%B7%D0%B0%205%20%D0%BC%D0%B8%D0%BD%D1%83%D1%82-0969DA?style=for-the-badge)](../user-guide.ru.md)
 
 **Даже Юи Хирасава настроит за 5 минут** — импортируйте рекомендованные словари и аудио за один шаг.
 

--- a/docs/readme/README.ru.md
+++ b/docs/readme/README.ru.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | **Русский** | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Руководство пользователя](https://img.shields.io/badge/%F0%9F%93%96%20%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE%20%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8F-0969DA?style=for-the-badge)](../user-guide.ru.md)
+[![Настройка за 5 минут](https://img.shields.io/badge/%F0%9F%93%96%20%D0%9D%D0%B0%D1%81%D1%82%D1%80%D0%BE%D0%B9%D0%BA%D0%B0%20%D0%B7%D0%B0%205%20%D0%BC%D0%B8%D0%BD%D1%83%D1%82-0969DA?style=for-the-badge)](../user-guide.ru.md)
 
-**Без сложной настройки** — импортируйте рекомендованные словари и аудио за один шаг.
+**Даже Юи Хирасава настроит за 5 минут** — импортируйте рекомендованные словари и аудио за один шаг.
 
 [![Скачать последнюю версию](https://img.shields.io/badge/%E2%AC%87%20%D0%A1%D0%BA%D0%B0%D1%87%D0%B0%D1%82%D1%8C%20%D0%BF%D0%BE%D1%81%D0%BB%D0%B5%D0%B4%D0%BD%D1%8E%D1%8E%20%D0%B2%D0%B5%D1%80%D1%81%D0%B8%D1%8E-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Присоединиться к Discord](https://img.shields.io/badge/%D0%9F%D1%80%D0%B8%D1%81%D0%BE%D0%B5%D0%B4%D0%B8%D0%BD%D0%B8%D1%82%D1%8C%D1%81%D1%8F%20%D0%BA%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.th.md
+++ b/docs/readme/README.th.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | **ภาษาไทย** | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![คู่มือผู้ใช้](https://img.shields.io/badge/%F0%9F%93%96%20%E0%B8%84%E0%B8%B9%E0%B9%88%E0%B8%A1%E0%B8%B7%E0%B8%AD%E0%B8%9C%E0%B8%B9%E0%B9%89%E0%B9%83%E0%B8%8A%E0%B9%89-0969DA?style=for-the-badge)](../user-guide.th.md)
+[![ตั้งค่าใน 5 นาที](https://img.shields.io/badge/%F0%9F%93%96%20%E0%B8%95%E0%B8%B1%E0%B9%89%E0%B8%87%E0%B8%84%E0%B9%88%E0%B8%B2%E0%B9%83%E0%B8%99%205%20%E0%B8%99%E0%B8%B2%E0%B8%97%E0%B8%B5-0969DA?style=for-the-badge)](../user-guide.th.md)
 
-**ไม่ต้องตั้งค่ายุ่งยาก** — นำเข้าพจนานุกรมและเสียงที่แนะนำได้ในขั้นตอนเดียว
+**แม้แต่ฮิราซาวะ ยุอิ ก็ตั้งค่าเสร็จใน 5 นาที** — นำเข้าพจนานุกรมและเสียงที่แนะนำได้ในขั้นตอนเดียว
 
 [![ดาวน์โหลดเวอร์ชันล่าสุด](https://img.shields.io/badge/%E2%AC%87%20%E0%B8%94%E0%B8%B2%E0%B8%A7%E0%B8%99%E0%B9%8C%E0%B9%82%E0%B8%AB%E0%B8%A5%E0%B8%94%E0%B9%80%E0%B8%A7%E0%B8%AD%E0%B8%A3%E0%B9%8C%E0%B8%8A%E0%B8%B1%E0%B8%99%E0%B8%A5%E0%B9%88%E0%B8%B2%E0%B8%AA%E0%B8%B8%E0%B8%94-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![เข้าร่วม Discord](https://img.shields.io/badge/%E0%B9%80%E0%B8%82%E0%B9%89%E0%B8%B2%E0%B8%A3%E0%B9%88%E0%B8%A7%E0%B8%A1%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.th.md
+++ b/docs/readme/README.th.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | **ภาษาไทย** | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![ตั้งค่าใน 5 นาที](https://img.shields.io/badge/%F0%9F%93%96%20%E0%B8%95%E0%B8%B1%E0%B9%89%E0%B8%87%E0%B8%84%E0%B9%88%E0%B8%B2%E0%B9%83%E0%B8%99%205%20%E0%B8%99%E0%B8%B2%E0%B8%97%E0%B8%B5-0969DA?style=for-the-badge)](../user-guide.th.md)
+[![คู่มือ hibiki ที่แม้แต่ฮิราซาวะ ยุอิ ก็ตั้งค่าเสร็จใน 5 นาที](https://img.shields.io/badge/%F0%9F%93%96%20%E0%B8%84%E0%B8%B9%E0%B9%88%E0%B8%A1%E0%B8%B7%E0%B8%AD%20hibiki%20%E0%B8%97%E0%B8%B5%E0%B9%88%E0%B9%81%E0%B8%A1%E0%B9%89%E0%B9%81%E0%B8%95%E0%B9%88%E0%B8%AE%E0%B8%B4%E0%B8%A3%E0%B8%B2%E0%B8%8B%E0%B8%B2%E0%B8%A7%E0%B8%B0%20%E0%B8%A2%E0%B8%B8%E0%B8%AD%E0%B8%B4%20%E0%B8%81%E0%B9%87%E0%B8%95%E0%B8%B1%E0%B9%89%E0%B8%87%E0%B8%84%E0%B9%88%E0%B8%B2%E0%B9%80%E0%B8%AA%E0%B8%A3%E0%B9%87%E0%B8%88%E0%B9%83%E0%B8%99%205%20%E0%B8%99%E0%B8%B2%E0%B8%97%E0%B8%B5-0969DA?style=for-the-badge)](../user-guide.th.md)
 
 **แม้แต่ฮิราซาวะ ยุอิ ก็ตั้งค่าเสร็จใน 5 นาที** — นำเข้าพจนานุกรมและเสียงที่แนะนำได้ในขั้นตอนเดียว
 

--- a/docs/readme/README.tr.md
+++ b/docs/readme/README.tr.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | **Türkçe** | [العربية](README.ar.md)
 
-[![5 dakikada kurulum](https://img.shields.io/badge/%F0%9F%93%96%205%20dakikada%20kurulum-0969DA?style=for-the-badge)](../user-guide.tr.md)
+[![Yui Hirasawa'nın bile 5 dakikada kurabildiği hibiki kılavuzu](https://img.shields.io/badge/%F0%9F%93%96%20Yui%20Hirasawa%27n%C4%B1n%20bile%205%20dakikada%20kurabildi%C4%9Fi%20hibiki%20k%C4%B1lavuzu-0969DA?style=for-the-badge)](../user-guide.tr.md)
 
 **Yui Hirasawa bile 5 dakikada kurar** — önerilen sözlükleri ve sesi tek adımda içe aktarın.
 

--- a/docs/readme/README.tr.md
+++ b/docs/readme/README.tr.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | **Türkçe** | [العربية](README.ar.md)
 
-[![Kullanım Kılavuzu](https://img.shields.io/badge/%F0%9F%93%96%20Kullan%C4%B1m%20K%C4%B1lavuzu-0969DA?style=for-the-badge)](../user-guide.tr.md)
+[![5 dakikada kurulum](https://img.shields.io/badge/%F0%9F%93%96%205%20dakikada%20kurulum-0969DA?style=for-the-badge)](../user-guide.tr.md)
 
-**Zahmetli kurulum yok** — önerilen sözlükleri ve sesi tek adımda içe aktarın.
+**Yui Hirasawa bile 5 dakikada kurar** — önerilen sözlükleri ve sesi tek adımda içe aktarın.
 
 [![En son sürümü indir](https://img.shields.io/badge/%E2%AC%87%20En%20son%20s%C3%BCr%C3%BCm%C3%BC%20indir-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Discord'a katıl](https://img.shields.io/badge/Discord%27a%20kat%C4%B1l-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.vi.md
+++ b/docs/readme/README.vi.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | **Tiếng Việt** | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Cài đặt trong 5 phút](https://img.shields.io/badge/%F0%9F%93%96%20C%C3%A0i%20%C4%91%E1%BA%B7t%20trong%205%20ph%C3%BAt-0969DA?style=for-the-badge)](../user-guide.vi.md)
+[![Hướng dẫn hibiki mà đến Yui Hirasawa cũng cài đặt xong trong 5 phút](https://img.shields.io/badge/%F0%9F%93%96%20H%C6%B0%E1%BB%9Bng%20d%E1%BA%ABn%20hibiki%20m%C3%A0%20%C4%91%E1%BA%BFn%20Yui%20Hirasawa%20c%C5%A9ng%20c%C3%A0i%20%C4%91%E1%BA%B7t%20xong%20trong%205%20ph%C3%BAt-0969DA?style=for-the-badge)](../user-guide.vi.md)
 
 **Đến Yui Hirasawa cũng cài đặt xong trong 5 phút** — nhập từ điển và âm thanh được đề xuất chỉ trong một bước.
 

--- a/docs/readme/README.vi.md
+++ b/docs/readme/README.vi.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | [繁體中文](README.zh-Hant.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | **Tiếng Việt** | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![Hướng dẫn sử dụng](https://img.shields.io/badge/%F0%9F%93%96%20H%C6%B0%E1%BB%9Bng%20d%E1%BA%ABn%20s%E1%BB%AD%20d%E1%BB%A5ng-0969DA?style=for-the-badge)](../user-guide.vi.md)
+[![Cài đặt trong 5 phút](https://img.shields.io/badge/%F0%9F%93%96%20C%C3%A0i%20%C4%91%E1%BA%B7t%20trong%205%20ph%C3%BAt-0969DA?style=for-the-badge)](../user-guide.vi.md)
 
-**Không cần cấu hình rườm rà** — nhập từ điển và âm thanh được đề xuất chỉ trong một bước.
+**Đến Yui Hirasawa cũng cài đặt xong trong 5 phút** — nhập từ điển và âm thanh được đề xuất chỉ trong một bước.
 
 [![Tải bản mới nhất](https://img.shields.io/badge/%E2%AC%87%20T%E1%BA%A3i%20b%E1%BA%A3n%20m%E1%BB%9Bi%20nh%E1%BA%A5t-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![Tham gia Discord](https://img.shields.io/badge/Tham%20gia%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.zh-Hant.md
+++ b/docs/readme/README.zh-Hant.md
@@ -10,9 +10,9 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | **繁體中文** | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![使用文件](https://img.shields.io/badge/%F0%9F%93%96%20%E4%BD%BF%E7%94%A8%E6%96%87%E4%BB%B6-0969DA?style=for-the-badge)](../user-guide.zh-Hant.md)
+[![5分鐘設定指南](https://img.shields.io/badge/%F0%9F%93%96%205%E5%88%86%E9%90%98%E8%A8%AD%E5%AE%9A%E6%8C%87%E5%8D%97-0969DA?style=for-the-badge)](../user-guide.zh-Hant.md)
 
-**無需繁瑣設定**，推薦詞典與本機音訊一鍵匯入即用。
+**平澤唯也能5分鐘設定好**，推薦詞典與本機音訊一鍵匯入即用。
 
 [![下載最新版本](https://img.shields.io/badge/%E2%AC%87%20%E4%B8%8B%E8%BC%89%E6%9C%80%E6%96%B0%E7%89%88%E6%9C%AC-2EA44F?style=for-the-badge)](https://github.com/hajisensai/hibiki/releases)
 [![加入 Discord 社群](https://img.shields.io/badge/%E5%8A%A0%E5%85%A5%20Discord%20%E7%A4%BE%E7%BE%A4-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/WhjwyGmm7f)

--- a/docs/readme/README.zh-Hant.md
+++ b/docs/readme/README.zh-Hant.md
@@ -10,7 +10,7 @@
 
 [简体中文](../../README.zh-CN.md) | [English](../../README.md) | **繁體中文** | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Русский](README.ru.md) | [Tiếng Việt](README.vi.md) | [ภาษาไทย](README.th.md) | [Bahasa Indonesia](README.id.md) | [Italiano](README.it.md) | [Nederlands](README.nl.md) | [Türkçe](README.tr.md) | [العربية](README.ar.md)
 
-[![5分鐘設定指南](https://img.shields.io/badge/%F0%9F%93%96%205%E5%88%86%E9%90%98%E8%A8%AD%E5%AE%9A%E6%8C%87%E5%8D%97-0969DA?style=for-the-badge)](../user-guide.zh-Hant.md)
+[![平澤唯也能5分鐘設定好的 hibiki 使用指南](https://img.shields.io/badge/%F0%9F%93%96%20%E5%B9%B3%E6%BE%A4%E5%94%AF%E4%B9%9F%E8%83%BD5%E5%88%86%E9%90%98%E8%A8%AD%E5%AE%9A%E5%A5%BD%E7%9A%84%20hibiki%20%E4%BD%BF%E7%94%A8%E6%8C%87%E5%8D%97-0969DA?style=for-the-badge)](../user-guide.zh-Hant.md)
 
 **平澤唯也能5分鐘設定好**，推薦詞典與本機音訊一鍵匯入即用。
 

--- a/docs/user-guide.ar.md
+++ b/docs/user-guide.ar.md
@@ -1,4 +1,4 @@
-# دليل مستخدم hibiki
+# دليل hibiki الذي يمكن حتى ليوي هيراساوا إعداده في 5 دقائق
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | **العربية**
 

--- a/docs/user-guide.de.md
+++ b/docs/user-guide.de.md
@@ -1,4 +1,4 @@
-# hibiki Benutzerhandbuch
+# Das hibiki-Handbuch, das selbst Yui Hirasawa in 5 Minuten einrichtet
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | **Deutsch** | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.es.md
+++ b/docs/user-guide.es.md
@@ -1,4 +1,4 @@
-# Guía de usuario de hibiki
+# La guía de hibiki que hasta Yui Hirasawa configura en 5 minutos
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | **Español** | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.fr.md
+++ b/docs/user-guide.fr.md
@@ -1,4 +1,4 @@
-# Guide d'utilisation de hibiki
+# Le guide hibiki que même Yui Hirasawa configure en 5 minutes
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | **Français** | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.id.md
+++ b/docs/user-guide.id.md
@@ -1,4 +1,4 @@
-# Panduan Pengguna hibiki
+# Panduan hibiki yang bahkan Yui Hirasawa bisa siapkan dalam 5 menit
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | **Bahasa Indonesia** | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.it.md
+++ b/docs/user-guide.it.md
@@ -1,4 +1,4 @@
-# Guida utente di hibiki
+# La guida di hibiki che perfino Yui Hirasawa configura in 5 minuti
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | **Italiano** | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.ja.md
+++ b/docs/user-guide.ja.md
@@ -1,4 +1,4 @@
-# hibiki ユーザーガイド
+# 平沢唯でも5分で設定できる hibiki ユーザーガイド
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | **日本語** | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.ko.md
+++ b/docs/user-guide.ko.md
@@ -1,4 +1,4 @@
-# hibiki 사용 설명서
+# 히라사와 유이도 5분이면 설정하는 hibiki 사용 설명서
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | **한국어** | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,4 +1,4 @@
-# 平泽唯也能5分钟配置好的 hibiki 使用指南
+# The hibiki Setup Guide Even Yui Hirasawa Can Finish in 5 Minutes
 
 **English** | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,4 +1,4 @@
-# hibiki User Guide
+# 平泽唯也能5分钟配置好的 hibiki 使用指南
 
 **English** | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.nl.md
+++ b/docs/user-guide.nl.md
@@ -1,4 +1,4 @@
-# hibiki-gebruikershandleiding
+# De hibiki-handleiding die zelfs Yui Hirasawa in 5 minuten instelt
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | **Nederlands** | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.pt-BR.md
+++ b/docs/user-guide.pt-BR.md
@@ -1,4 +1,4 @@
-# Guia do usuário do hibiki
+# O guia do hibiki que até a Yui Hirasawa configura em 5 minutos
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | **Português** | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.ru.md
+++ b/docs/user-guide.ru.md
@@ -1,4 +1,4 @@
-# Руководство пользователя hibiki
+# Руководство hibiki, которое даже Юи Хирасава настроит за 5 минут
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | **Русский** | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.th.md
+++ b/docs/user-guide.th.md
@@ -1,4 +1,4 @@
-# คู่มือผู้ใช้ hibiki
+# คู่มือ hibiki ที่แม้แต่ฮิราซาวะ ยุอิ ก็ตั้งค่าเสร็จใน 5 นาที
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | **ภาษาไทย** | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.tr.md
+++ b/docs/user-guide.tr.md
@@ -1,4 +1,4 @@
-# hibiki Kullanım Kılavuzu
+# Yui Hirasawa'nın bile 5 dakikada kurabildiği hibiki kılavuzu
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | **Türkçe** | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.vi.md
+++ b/docs/user-guide.vi.md
@@ -1,4 +1,4 @@
-# Hướng dẫn sử dụng hibiki
+# Hướng dẫn hibiki mà đến Yui Hirasawa cũng cài đặt xong trong 5 phút
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | [繁體中文](user-guide.zh-Hant.md) | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | **Tiếng Việt** | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 

--- a/docs/user-guide.zh-Hant.md
+++ b/docs/user-guide.zh-Hant.md
@@ -1,4 +1,4 @@
-# hibiki 使用指南
+# 平澤唯也能5分鐘設定好的 hibiki 使用指南
 
 [English](user-guide.md) | [简体中文](https://ncnies6wfjok.feishu.cn/wiki/OZbww3T3IiEAx5kBhHkcF07vncb) | **繁體中文** | [日本語](user-guide.ja.md) | [한국어](user-guide.ko.md) | [Español](user-guide.es.md) | [Français](user-guide.fr.md) | [Deutsch](user-guide.de.md) | [Português](user-guide.pt-BR.md) | [Русский](user-guide.ru.md) | [Tiếng Việt](user-guide.vi.md) | [ภาษาไทย](user-guide.th.md) | [Bahasa Indonesia](user-guide.id.md) | [Italiano](user-guide.it.md) | [Nederlands](user-guide.nl.md) | [Türkçe](user-guide.tr.md) | [العربية](user-guide.ar.md)
 


### PR DESCRIPTION
把「平泽唯也能5分钟配置好的 hibiki 使用指南」这套文案落到 main。

**为什么单开这条分支而不是合 PR#340**：PR#340 基于 develop，而 develop 领先 main 584 个 commit / 5128 个文件，直接合会把整个 develop 推上 main（发版级操作）。这里只把 4 个文档 commit cherry-pick 到 main 上，**相对 main 仅 33 个文档文件、52 行**，无任何非文档改动。

## 内容
- 16 个语言的 `docs/user-guide*.md` H1 标题按各自语言本地化（英/繁中/日/韩/西/法/德/葡/俄/越/泰/印尼/意/荷/土/阿）
- 17 个 README 第 13 行用户指南徽章 → 改为对应语言指南全称（与各语言 H1 逐字一致，已程序化比对）
- 17 个 README 第 15 行 tagline：`No fiddly setup` → `Even Yui Hirasawa can set it up in 5 minutes`，保留后半句说明
- README.md / README.zh-CN.md 的 `<details>` summary 同步

简体中文指南托管在飞书、仓库内无对应文件，其标题由用户自行修改。

https://claude.ai/code/session_01K23D9eBX2YyQDfSZXx8BbZ