### PR TITLE
fix(anki): 长按选中的词典真正落到卡片主释义 {glossary-first} (BUG-1033)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 999 条。点号进各自文件。
+> 共 1000 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1033](bugs/BUG-1033-glossary-first-ignores-selected-dict.md) | ✅ | ✅ | 长按选中词典对制卡无效：{glossary-first} 恒取第一本，Lapis 默认无字段消费 {selected-glossary} |
 | [BUG-1032](bugs/BUG-1032-qb-webui-no-request-timeout.md) | ✅ | ✅ | qB WebUI 请求缺少超时 |
 | [BUG-1031](bugs/BUG-1031-download-default-config-no-completion-poll.md) | ✅ | ✅ | 默认下载配置未传给完成轮询 |
 | [BUG-1030](bugs/BUG-1030-extension-subtitle-panel-overlay.md) | ✅ | ✅ | 浏览器扩展字幕列表覆盖页面而非挤压画面 |

--- a/docs/bugs/BUG-1033-glossary-first-ignores-selected-dict.md
+++ b/docs/bugs/BUG-1033-glossary-first-ignores-selected-dict.md
@@ -8,6 +8,6 @@
 - **[x] ① 已修复** — `packages/hibiki_anki/lib/src/anki_models.dart` 的 `{glossary-first}` 分支改为「**选中优先，没选中才退回第一本**」：先走既有 `_singleGlossaryForDictionary(payload, payload.selectedDictionary)`（含 `[n]` 后缀归一化匹配），空则原样返回 `payload.glossaryFirst`。
   - **为什么落在 Dart 渲染器而不是 popup.js**：`selectedDictionary` 与 `singleGlossaries` 都已在 payload 里，单点改动一次覆盖阅读器 / 视频 / 互联 / 悬浮 / 浏览器扩展**全部**制卡路径，且免去 popup.js 三份镜像（`hibiki/assets/popup/` `hibiki/assets/browser_extension/vendor/` `tools/browser-extension/vendor/`）的同步风险。
   - **零破坏**：没长按 → `selectedDictionary` 为空 → fallback 返回 `glossaryFirst`，行为逐字节不变；选中名在 `singleGlossaries` 查不到时同样退回，不产出空字段。`{selected-glossary}` / `{glossary}` 语义均未改动。
-  - 提交：<待填>
+  - 提交：`36487e3ea`
 - **[x] ② 已加自动化测试** — `packages/hibiki_anki/test/handlebar_glossary_first_selected_test.dart`（9 例，最强可落地层=渲染器纯函数）：选中第二/第三本 → 主释义取那本；未选中 → 逐字节退回第一本；选中名查不到 → 退回第一本不产空；`[n]` 后缀归一化命中；选中时 `{glossary-first}` == `{selected-glossary}`；`{selected-glossary}` 未选中仍空串（不被 fallback 污染）；`{glossary}` 不受影响；Lapis `MainDefinition` 仍映射 `{glossary-first}`（钉死本修复必须落在该键上）。**真红→绿验证过**：临时回退修复 → 4 例红（全是选中相关）、5 例仍绿（零破坏那几条）；恢复后 9 绿。
 - **备注**：Anki 字段 / 弹窗交互类。用户无需改任何字段映射即可生效。**真机复测待用户**：查词弹窗长按某本词典标题（标题变主题色加粗）→ 制卡 → Anki 卡片 MainDefinition 应是那本词典的释义；不长按时仍是第一本。相关：BUG-358（同一 `selectedDictionaries` 的一次性生命周期，已修）。

--- a/docs/bugs/BUG-1033-glossary-first-ignores-selected-dict.md
+++ b/docs/bugs/BUG-1033-glossary-first-ignores-selected-dict.md
@@ -1,0 +1,13 @@
+## BUG-1033 · 长按选中词典对制卡无效：{glossary-first} 恒取第一本，Lapis 默认无字段消费 {selected-glossary}
+- **报告**：2026-07-23（用户：「长按选中了但是没变成对应的字典」，附 Windows 视频页查词弹窗截图，词条「ポリ」三栏词典）。追问确认症状=**制卡后卡片释义不是长按选中的那本词典**，入口=视频页查词弹窗。
+- **真实性**：✅ **真 bug（死交互，全平台全入口，不限视频页）**。沿真实代码路径逐段验证：
+  - **长按侧完好**：`hibiki/assets/popup/popup.js:2447` `toggleSelection` 把词典名存进 `selectedDictionaries[entryIdx]` 并给 `<summary>` 加 `.selected`（`hibiki/assets/popup/popup.css:897` 渲染成主题色加粗），`popup.js:1308` 把它写进制卡 payload 的 `selectedDictionary`。
+  - **传输侧完好**：`dictionary_popup_webview.dart:1162` 全键透传 → 视频页 `video_hibiki/lookup_mining.part.dart:290` → `immersion_mining_engine.dart:250` `jsonEncode(req.fields)` → `anki_models.dart:319` `AnkiMiningPayload.fromJson` 还原 `selectedDictionary`，一个字节没丢。
+  - **根因在消费侧** `packages/hibiki_anki/lib/src/anki_models.dart:449`：全模板里**只有** `{selected-glossary}` 读 `payload.selectedDictionary`；`{glossary-first}` 只读 `payload.glossaryFirst`，而后者是 `popup.js:1262` 的 `Object.values(singleGlossaries)[0]` —— **恒等于排在第一位的那本词典**，与长按选中无关。
+  - **放大器**：Lapis 出厂默认把 `MainDefinition` 映射成 `{glossary-first}`（`packages/hibiki_anki/lib/src/lapis_note_type.dart:68`），用户实测配置同此（生产库 `profile_settings.fieldMappings` 里 `{selected-glossary}` 出现 **0 次**）。于是长按选词典对绝大多数用户是**死交互**：UI 明确反馈「已选中」，卡片主释义却恒是第一本。
+- **[x] ① 已修复** — `packages/hibiki_anki/lib/src/anki_models.dart` 的 `{glossary-first}` 分支改为「**选中优先，没选中才退回第一本**」：先走既有 `_singleGlossaryForDictionary(payload, payload.selectedDictionary)`（含 `[n]` 后缀归一化匹配），空则原样返回 `payload.glossaryFirst`。
+  - **为什么落在 Dart 渲染器而不是 popup.js**：`selectedDictionary` 与 `singleGlossaries` 都已在 payload 里，单点改动一次覆盖阅读器 / 视频 / 互联 / 悬浮 / 浏览器扩展**全部**制卡路径，且免去 popup.js 三份镜像（`hibiki/assets/popup/` `hibiki/assets/browser_extension/vendor/` `tools/browser-extension/vendor/`）的同步风险。
+  - **零破坏**：没长按 → `selectedDictionary` 为空 → fallback 返回 `glossaryFirst`，行为逐字节不变；选中名在 `singleGlossaries` 查不到时同样退回，不产出空字段。`{selected-glossary}` / `{glossary}` 语义均未改动。
+  - 提交：<待填>
+- **[x] ② 已加自动化测试** — `packages/hibiki_anki/test/handlebar_glossary_first_selected_test.dart`（9 例，最强可落地层=渲染器纯函数）：选中第二/第三本 → 主释义取那本；未选中 → 逐字节退回第一本；选中名查不到 → 退回第一本不产空；`[n]` 后缀归一化命中；选中时 `{glossary-first}` == `{selected-glossary}`；`{selected-glossary}` 未选中仍空串（不被 fallback 污染）；`{glossary}` 不受影响；Lapis `MainDefinition` 仍映射 `{glossary-first}`（钉死本修复必须落在该键上）。**真红→绿验证过**：临时回退修复 → 4 例红（全是选中相关）、5 例仍绿（零破坏那几条）；恢复后 9 绿。
+- **备注**：Anki 字段 / 弹窗交互类。用户无需改任何字段映射即可生效。**真机复测待用户**：查词弹窗长按某本词典标题（标题变主题色加粗）→ 制卡 → Anki 卡片 MainDefinition 应是那本词典的释义；不长按时仍是第一本。相关：BUG-358（同一 `selectedDictionaries` 的一次性生命周期，已修）。

--- a/packages/hibiki_anki/lib/src/anki_models.dart
+++ b/packages/hibiki_anki/lib/src/anki_models.dart
@@ -446,8 +446,25 @@ class AnkiHandlebarRenderer {
         return payload.audio;
       case '{glossary}':
         return payload.glossary;
+      // BUG-1033：「首选词典释义」= 用户在弹窗里长按选中的那本，没长按才退回排在第一位
+      // 的那本（[AnkiMiningPayload.glossaryFirst]，popup.js 的 singleGlossaries 首项）。
+      //
+      // 此前这里只读 glossaryFirst，而全模板里只有 {selected-glossary} 消费
+      // [AnkiMiningPayload.selectedDictionary]。Lapis 出厂默认把 MainDefinition 映射成
+      // {glossary-first}（lapis_note_type.dart），于是长按选词典对绝大多数用户是**死交互**：
+      // 弹窗把词典标题染成主题色加粗（popup.css `.dict-label.selected`）给了明确「已选中」
+      // 反馈，制出来的卡片主释义却恒是第一本。长按选中本就是「这张卡我要这本词典的释义」，
+      // 让 first 退化成「无选中时的兜底」消除了这个特殊情况，无需任何用户改字段映射。
+      //
+      // 零破坏：没长按 → selectedDictionary 为空 → _singleGlossaryForDictionary 返回 ''
+      // → 原样退回 glossaryFirst，行为逐字节不变。选中的词典名在 singleGlossaries 里查
+      // 不到（理论上不该发生：两者同源于同一 dictName）时同样退回，不产出空字段。
       case '{glossary-first}':
-        return payload.glossaryFirst;
+        final String selectedGlossary =
+            _singleGlossaryForDictionary(payload, payload.selectedDictionary);
+        return selectedGlossary.isNotEmpty
+            ? selectedGlossary
+            : payload.glossaryFirst;
       case '{selected-glossary}':
         return _singleGlossaryForDictionary(
             payload, payload.selectedDictionary);

--- a/packages/hibiki_anki/test/handlebar_glossary_first_selected_test.dart
+++ b/packages/hibiki_anki/test/handlebar_glossary_first_selected_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+/// BUG-1033：弹窗里长按选中的词典必须真的落到卡片主释义上。
+///
+/// 回归背景：`{glossary-first}` 原本只读 [AnkiMiningPayload.glossaryFirst]（popup.js
+/// 的 `Object.values(singleGlossaries)[0]`，恒是排在第一位的那本词典），而全模板里只有
+/// `{selected-glossary}` 消费 [AnkiMiningPayload.selectedDictionary]。Lapis 出厂默认把
+/// `MainDefinition` 映射成 `{glossary-first}`，于是「长按词典标题选中」在默认配置下是**死
+/// 交互**：弹窗把标题染成主题色加粗给了明确「已选中」反馈，制出的卡片主释义却恒是第一本。
+///
+/// 修复语义：`{glossary-first}` = 选中优先，没选中才退回第一本。没长按时逐字节零变化。
+void main() {
+  const Map<String, String> singleGlossaries = <String, String>{
+    '三省堂国語辞典 第八版': '〔俗〕←ポリス。',
+    '大辞泉 第二版': '「ポリス」「ポリスマン」の略。',
+    '日本語俗語辞書': 'ポリとは、警察、警察官、巡査のこと。',
+  };
+
+  const AnkiMiningContext context = AnkiMiningContext(sentence: 'ポリが来た！');
+
+  AnkiMiningPayload payloadWith(String selected) => AnkiMiningPayload(
+        expression: 'ポリ',
+        singleGlossaries: singleGlossaries,
+        // popup.js 恒把「第一本」放进 glossaryFirst，与选中无关。
+        glossaryFirst: singleGlossaries.values.first,
+        selectedDictionary: selected,
+      );
+
+  String renderFirst(AnkiMiningPayload payload) =>
+      AnkiHandlebarRenderer.render('{glossary-first}', payload, context);
+
+  group('{glossary-first} 选中优先（BUG-1033）', () {
+    test('长按选中第二本 → 主释义取那本，而不是第一本', () {
+      final String value = renderFirst(payloadWith('大辞泉 第二版'));
+      expect(value, '「ポリス」「ポリスマン」の略。');
+      expect(value, isNot(singleGlossaries.values.first),
+          reason: '选中了却仍渲染第一本 = 长按是死交互，正是 BUG-1033 的症状');
+    });
+
+    test('长按选中第三本 → 主释义取那本', () {
+      expect(renderFirst(payloadWith('日本語俗語辞書')), 'ポリとは、警察、警察官、巡査のこと。');
+    });
+
+    test('没长按（selectedDictionary 空）→ 逐字节退回第一本（零破坏）', () {
+      expect(renderFirst(payloadWith('')), singleGlossaries.values.first);
+    });
+
+    test('选中的词典名在 singleGlossaries 里查不到 → 退回第一本，不产出空字段', () {
+      expect(
+          renderFirst(payloadWith('存在しない辞典')), singleGlossaries.values.first);
+    });
+
+    test('词典名带 [n] 后缀时按归一化命中（与 {selected-glossary} 同一匹配规则）', () {
+      expect(renderFirst(payloadWith('大辞泉 第二版 [2]')), '「ポリス」「ポリスマン」の略。');
+    });
+
+    test('选中时 {glossary-first} 与 {selected-glossary} 同值', () {
+      final AnkiMiningPayload payload = payloadWith('大辞泉 第二版');
+      expect(
+        renderFirst(payload),
+        AnkiHandlebarRenderer.render('{selected-glossary}', payload, context),
+      );
+    });
+
+    test('{selected-glossary} 语义不变：没选中时仍是空串（不被本次 fallback 污染）', () {
+      expect(
+        AnkiHandlebarRenderer.render(
+            '{selected-glossary}', payloadWith(''), context),
+        '',
+      );
+    });
+
+    test('{glossary} 全量释义不受选中影响', () {
+      const AnkiMiningPayload payload = AnkiMiningPayload(
+        expression: 'ポリ',
+        glossary: '全部辞書の釈義',
+        singleGlossaries: singleGlossaries,
+        selectedDictionary: '大辞泉 第二版',
+      );
+      expect(AnkiHandlebarRenderer.render('{glossary}', payload, context),
+          '全部辞書の釈義');
+    });
+  });
+
+  group('Lapis 默认映射前提（BUG-1033 的放大器）', () {
+    test('MainDefinition 仍映射 {glossary-first}——故本修复必须落在该键上', () {
+      expect(LapisNoteType.defaultFieldMappings['MainDefinition'],
+          '{glossary-first}');
+    });
+  });
+}


### PR DESCRIPTION
## 用户报告

「长按选中了但是没变成对应的字典」（Windows 视频页查词弹窗，词条「ポリ」）。追问确认：**制卡后卡片释义不是长按选中的那本词典**。

## 根因（不限视频页，全平台全入口）

长按侧和传输侧都是好的：

- `popup.js:2447` 把词典名存进 `selectedDictionaries[entryIdx]`，`.dict-label.selected`（`popup.css:897`）染成主题色加粗给出明确「已选中」反馈
- `popup.js:1308` 写进 payload 的 `selectedDictionary` → `dictionary_popup_webview.dart:1162` 全键透传 → 视频页 `lookup_mining.part.dart:290` → `immersion_mining_engine.dart:250` `jsonEncode` → `AnkiMiningPayload.fromJson`，一个字节没丢

**断在消费侧** `packages/hibiki_anki/lib/src/anki_models.dart:449`：全模板里只有 `{selected-glossary}` 读 `payload.selectedDictionary`；`{glossary-first}` 只读 `payload.glossaryFirst`，而后者是 `popup.js:1262` 的 `Object.values(singleGlossaries)[0]` —— **恒是排第一的那本**。

放大器：Lapis 出厂默认把 `MainDefinition` 映射成 `{glossary-first}`（`lapis_note_type.dart:68`），用户实测配置同此（生产库 `fieldMappings` 里 `{selected-glossary}` 出现 0 次）。于是长按选词典对绝大多数用户是**死交互**。

## 改动

`{glossary-first}` 改为「**选中优先，没选中才退回第一本**」，复用既有 `_singleGlossaryForDictionary`（含 `[n]` 后缀归一化匹配）。

**为什么落在 Dart 渲染器而不是 popup.js**：`selectedDictionary` 与 `singleGlossaries` 都已在 payload 里，单点改动一次覆盖阅读器 / 视频 / 互联 / 悬浮 / 浏览器扩展全部制卡路径，且免去 popup.js 三份镜像的同步风险。

**零破坏**：没长按 → `selectedDictionary` 空 → 原样退回 `glossaryFirst`，逐字节不变；选中名查不到时同样退回，不产出空字段。`{selected-glossary}` / `{glossary}` 语义未动。用户无需改任何字段映射。

## 验证

- `packages/hibiki_anki/test/handlebar_glossary_first_selected_test.dart` 9 例全绿，**真红→绿验证过**（临时回退修复 → 4 例红全是选中相关、5 例零破坏用例仍绿）
- `hibiki_anki` 包全量 192 绿；主应用 `test/anki` + `test/creator` 195 绿
- `flutter analyze`：主应用 `No issues found`；`hibiki_anki` 仅 1 条**基线预存** warning（`test/ankiconnect_commit_unknown_test.dart`，来自 `47b68c9af`，非本轮）
- 未 bump `pubspec.yaml`（草稿 PR，版本由 integration owner 落地时统一处理）

## 待真机验收

查词弹窗长按某本词典标题（标题变主题色加粗）→ 制卡 → Anki 卡片 MainDefinition 应是那本词典的释义；不长按时仍是第一本。

相关：BUG-358（同一 `selectedDictionaries` 的一次性生命周期，已修）

https://claude.ai/code/session_01Rvrw3cPPRXdvkZTZmFTXvp