### PR TITLE
fix(focus/settings): 焦点导航开关恢复滑块动画 + 宽屏设置详情面回滚整宽（PR#338 遗漏内容重提）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 999 条。点号进各自文件。
+> 共 1000 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1034](bugs/BUG-1034-global-lookup-card-corner-asymmetry.md) | 🚧 | 🚧 | 查词浮窗卡片左侧圆角右侧直角 |
 | [BUG-1032](bugs/BUG-1032-qb-webui-no-request-timeout.md) | ✅ | ✅ | qB WebUI 请求缺少超时 |
 | [BUG-1031](bugs/BUG-1031-download-default-config-no-completion-poll.md) | ✅ | ✅ | 默认下载配置未传给完成轮询 |
 | [BUG-1030](bugs/BUG-1030-extension-subtitle-panel-overlay.md) | ✅ | ✅ | 浏览器扩展字幕列表覆盖页面而非挤压画面 |

--- a/docs/bugs/BUG-1034-global-lookup-card-corner-asymmetry.md
+++ b/docs/bugs/BUG-1034-global-lookup-card-corner-asymmetry.md
@@ -1,0 +1,9 @@
+## BUG-1034 · 查词浮窗卡片左侧圆角右侧直角
+- **报告**：2026-07-22（用户，附截图：app 外查词浮窗（global-lookup 瞬态窗），白卡左上角圆角正常、右上角呈直角，右缘有一条全高暗色竖条）
+- **真实性**：⏳ 待 Windows 真机复现取证（截图无法定论）。卡片 chrome 由 CSS 绘制：`hibiki/assets/popup/popup.css:1386` `html.global-lookup body`（1px 边框 + border-radius 10px，四角对称），Dart 侧 `lib/src/lookup/` 无圆角逻辑——CSS 本身不产生左右不对称。三个候选根因（按嫌疑排序）：
+  1. **UA 默认 body margin 未重置**（popup.css 未见 `body{margin:0}`）+ 纵向滚动条出现时 WebView2 收缩内容盒：右缘 = body margin(8px) + 滚动条 gutter（透明 html 下露桌面成暗条），卡片右圆角被 gutter 视觉挤压/覆盖。
+  2. 宿主 shell（native hwnd 的 `border-radius:10px;overflow:hidden` 裁剪，见 popup.css:71-82 注释）与 WebView2 子窗宽度错位，右侧留缝。
+  3. WebView2 Fluent overlay 滚动条按 `color-scheme` 画出的不透明列压过卡片右缘。
+- **[ ] ① 未修复** — 复现路径：Windows 真机触发 app 外全局查词（UIA 取句），观察窗口右缘；分别验证 body margin 重置（`html.global-lookup body { margin: 8px }` 显式化并配 `scrollbar-gutter: stable`）、宿主 shell 宽度、滚动条方案。修复涉及 popup.css 时注意**三镜像纪律**（app 内 popup / 扩展 content.css 重生成）。
+- **[ ] ② 未加自动化测试** — 候选：popup.css 源码守卫（body margin 显式声明）；真机截图取证留 .codex-test。
+- **备注**：巡检跟进轮建档（原编号 1014，因 develop 已占用改为 1034）；与 BUG-1010 一起排 Windows 真机复现批次。

--- a/hibiki/lib/main.dart
+++ b/hibiki/lib/main.dart
@@ -1533,10 +1533,18 @@ class _HoshiReaderAppState extends ConsumerState<HoshiReaderApp>
   Locale get locale => appModel.appLocale;
 }
 
-/// 按实验开关决定是否包裹自定义焦点导航层（[HibikiFocusRoot] 焦点控制器 +
-/// [HibikiFocusRing] 可见焦点环）。关闭（默认）时原样返回 [child]，App 走 Flutter
-/// 原生焦点遍历——各组件在缺少 HibikiFocusRoot 时会自动降级到 FocusableActionDetector。
+/// 焦点导航层（[HibikiFocusRoot] 焦点控制器 + [HibikiFocusRing] 可见焦点环）
+/// **恒定挂载，行为按实验开关门控**。禁用时 [HibikiFocusRoot.maybeControllerOf]
+/// 返回 null（各组件据此走原生焦点遍历，语义与「未包裹」时代逐字节一致）、
+/// 焦点环不绘制。
+///
+/// 用户实报（2026-07-22）：旧实现按开关插/拔这两层——切「键盘/手柄焦点导航」
+/// 开关时整棵 app 子树因结构变化被重挂载，被切的 Switch 以新状态直接 mount，
+/// 滑块动画消失（其余开关都有动画）。结构恒定后 Element 全保留，动画回归，
+/// 顺带不再丢各页滚动位置。
 Widget _wrapFocusNavigation({required bool enabled, required Widget child}) {
-  if (!enabled) return child;
-  return HibikiFocusRoot(child: HibikiFocusRing(child: child));
+  return HibikiFocusRoot(
+    enabled: enabled,
+    child: HibikiFocusRing(enabled: enabled, child: child),
+  );
 }

--- a/hibiki/lib/src/focus/hibiki_focus_controller.dart
+++ b/hibiki/lib/src/focus/hibiki_focus_controller.dart
@@ -699,15 +699,21 @@ class _GeometricMoveResult {
 }
 
 class HibikiFocusRoot extends StatefulWidget {
-  const HibikiFocusRoot({super.key, required this.child});
+  const HibikiFocusRoot({super.key, this.enabled = true, required this.child});
 
   final Widget child;
+
+  /// False = 焦点导航系统关闭但**保持挂载**：[maybeControllerOf] 返回 null，
+  /// 消费方据此走「无焦点根」的原生遍历路径（语义与根本不挂载时一致）。
+  /// 恒定挂载的意义：切换实验开关不再改变树结构 → 整棵 app 子树的 Element
+  /// 全保留（开关滑块动画、各页滚动位置不丢）。
+  final bool enabled;
 
   static HibikiFocusController controllerOf(BuildContext context) {
     final _HibikiFocusScope? scope =
         context.dependOnInheritedWidgetOfExactType<_HibikiFocusScope>();
-    assert(scope != null, 'No HibikiFocusRoot found in context');
-    return scope!.controller;
+    assert(scope?.controller != null, 'No HibikiFocusRoot found in context');
+    return scope!.controller!;
   }
 
   static HibikiFocusController? maybeControllerOf(
@@ -745,12 +751,14 @@ class _HibikiFocusRootState extends State<HibikiFocusRoot> {
 
   @override
   Widget build(BuildContext context) {
+    // 结构恒定（Focus → scope → child），enabled 只影响 scope 暴露的控制器：
+    // 禁用时消费方拿到 null，走原生遍历路径；控制器实例保活，重新启用即恢复。
     return Focus(
       focusNode: _controller.fallbackNode,
-      canRequestFocus: true,
+      canRequestFocus: widget.enabled,
       skipTraversal: true,
       child: _HibikiFocusScope(
-        controller: _controller,
+        controller: widget.enabled ? _controller : null,
         child: widget.child,
       ),
     );
@@ -759,10 +767,10 @@ class _HibikiFocusRootState extends State<HibikiFocusRoot> {
 
 class _HibikiFocusScope extends InheritedNotifier<HibikiFocusController> {
   const _HibikiFocusScope({
-    required HibikiFocusController controller,
+    required this.controller,
     required super.child,
-  })  : controller = controller,
-        super(notifier: controller);
+  }) : super(notifier: controller);
 
-  final HibikiFocusController controller;
+  /// null = 焦点导航禁用（HibikiFocusRoot.enabled == false）。
+  final HibikiFocusController? controller;
 }

--- a/hibiki/lib/src/settings/settings_home_page.dart
+++ b/hibiki/lib/src/settings/settings_home_page.dart
@@ -329,26 +329,14 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
       // 切换目标时整棵子树作废重建，避免 Flutter 复用上一目标同位置的 Switch
       // Element 触发 didUpdateWidget(value 变化)→ 圆点滑动（以及分段滑动、滚动
       // 位置串页等同类复用副作用）。
-      // 详情正文限宽：与窄屏 DesktopContentLayout 的 settings 档共用同一上限
-      // （desktopContentMaxWidth，当前 960），超宽窗口不再把设置行拉成整屏长条；
-      // 左对齐贴导航 pane（不居中，避免详情和导航之间出现空腹）。
+      // 详情正文填满 pane 整宽：UI 巡检 PR-5 曾按 MD3 list-detail 惯例加过
+      // 960 限宽 + 左对齐，用户实机反馈「右边空了一大堆」（2026-07-22 截图，
+      // 4K 窗口下右侧 2400px 空白）——用户拍板回滚到填满整宽的原始形态。
       primary: KeyedSubtree(
         key: ValueKey<SettingsDestinationId>(selected.id),
-        child: Align(
-          alignment: AlignmentDirectional.topStart,
-          child: ConstrainedBox(
-            constraints: BoxConstraints(
-              maxWidth: desktopContentMaxWidth(
-                    WindowSizeClass.expanded,
-                    DesktopContentKind.settings,
-                  ) ??
-                  double.infinity,
-            ),
-            child: renderer.buildDetailContent(
-              settingsContext: settingsContext,
-              destination: selected,
-            ),
-          ),
+        child: renderer.buildDetailContent(
+          settingsContext: settingsContext,
+          destination: selected,
         ),
       ),
     );

--- a/hibiki/lib/src/utils/components/hibiki_focus_ring.dart
+++ b/hibiki/lib/src/utils/components/hibiki_focus_ring.dart
@@ -17,9 +17,14 @@ import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
 /// A deliberate manual scroll that leaves focus behind is NOT yanked back; the
 /// ring simply tracks the control to its new (possibly off-screen) position.
 class HibikiFocusRing extends StatefulWidget {
-  const HibikiFocusRing({super.key, required this.child});
+  const HibikiFocusRing({super.key, this.enabled = true, required this.child});
 
   final Widget child;
+
+  /// False = 焦点环禁用但保持挂载（不绘制、不做几何计算）。与
+  /// [HibikiFocusRoot.enabled] 同步门控：实验开关切换只改行为不改树结构，
+  /// child 的 Element 全保留（见 main.dart `_wrapFocusNavigation`）。
+  final bool enabled;
 
   @override
   State<HibikiFocusRing> createState() => _HibikiFocusRingState();
@@ -100,6 +105,17 @@ class _HibikiFocusRingState extends State<HibikiFocusRing>
     _scheduleRecompute();
   }
 
+  @override
+  void didUpdateWidget(HibikiFocusRing oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.enabled && !widget.enabled) {
+      // 关闭时立刻收掉残留的环（不等下一次焦点事件）。
+      setState(() => _rect = null);
+    } else if (!oldWidget.enabled && widget.enabled) {
+      _scheduleRecompute();
+    }
+  }
+
   void _onHighlight(FocusHighlightMode _) => _scheduleRecompute();
 
   void _onFocusManagerChange() {
@@ -124,6 +140,7 @@ class _HibikiFocusRingState extends State<HibikiFocusRing>
   }
 
   void _scheduleRecompute() {
+    if (!widget.enabled) return;
     if (_recomputeScheduled || !mounted) return;
     _recomputeScheduled = true;
     // By post-frame time the element tree is finalized: every element is either
@@ -227,7 +244,7 @@ class _HibikiFocusRingState extends State<HibikiFocusRing>
     // this single-scale mapping breaks — switch to localToGlobal(ancestor: <this
     // Stack's RenderObject>) to resolve the focused rect in local space directly.
     final double scale = HibikiAppUiScale.of(context);
-    final Rect? globalRect = _rect;
+    final Rect? globalRect = widget.enabled ? _rect : null;
     final Rect? ringRect = globalRect == null
         ? null
         : _scaleRect(globalRect.inflate(2), 1 / scale);

--- a/hibiki/lib/src/utils/components/settings_shared.dart
+++ b/hibiki/lib/src/utils/components/settings_shared.dart
@@ -497,38 +497,45 @@ class AdaptiveSettingsRow extends StatelessWidget {
     if (onTap == null) return content;
     final bool hasFocusRoot =
         HibikiFocusRoot.maybeControllerOf(context) != null;
-    if (!hasFocusRoot) {
-      return cupertino
-          // Cupertino has no InkWell; HibikiFocusable keeps the row reachable by
-          // directional focus navigation (gamepad/keyboard) instead of a bare,
-          // unfocusable GestureDetector.
-          ? HibikiFocusable(
-              onTap: onTap,
-              borderRadius: BorderRadius.zero,
-              child: content,
-            )
-          : InkWell(
-              onTap: onTap,
-              child: content,
-            );
-    }
-    final Widget tappable = cupertino
-        ? GestureDetector(
+    if (cupertino) {
+      // Cupertino 是隐藏内部能力，维持原有两分支（结构恒定化只做 Material
+      // 主路径）。无焦点根时 HibikiFocusable 保持方向键可达（GestureDetector
+      // 本身不可聚焦）。
+      if (!hasFocusRoot) {
+        return HibikiFocusable(
+          onTap: onTap,
+          borderRadius: BorderRadius.zero,
+          child: content,
+        );
+      }
+      return _SettingsRowFocusTarget(
+        onTap: onTap!,
+        child: ExcludeFocus(
+          child: GestureDetector(
             behavior: HitTestBehavior.opaque,
             onTap: onTap,
             child: content,
-          )
-        : InkWell(
-            onTap: onTap,
-            child: content,
-          );
-    // 单焦点站点契约（对齐滑条/步进行的 ExcludeFocus 做法）：焦点根存在时，
-    // 行的键盘/手柄停靠点只有 _SettingsRowFocusTarget 一个——InkWell 与
-    // trailing 里的 Switch 等内部可聚焦控件全部退出 Tab 遍历，否则一行
-    // 最多 3 个站点且激活语义相同，长设置页遍历冗长。
+          ),
+        ),
+      );
+    }
+    // Material：**结构恒定，行为按 hasFocusRoot 门控**。此前按有无焦点根换两棵
+    // 不同的树（裸 InkWell vs 目标+ExcludeFocus 包裹），切「键盘/手柄焦点导航」
+    // 实验开关时行子树整体重挂载，行里的 Switch 以新状态直接 mount——滑块动画
+    // 消失（用户实报 2026-07-22）。恒定结构下两态语义不变：
+    // - 有焦点根：目标可聚焦 + ExcludeFocus 生效 → 单停靠点（PR-0 契约）；
+    // - 无焦点根：目标 skipTraversal + ExcludeFocus 直通 → InkWell/Switch 照旧
+    //   参与原生 Tab 遍历，与旧「裸 InkWell」分支逐字节同语义。
     return _SettingsRowFocusTarget(
       onTap: onTap!,
-      child: ExcludeFocus(child: tappable),
+      focusEnabled: hasFocusRoot,
+      child: ExcludeFocus(
+        excluding: hasFocusRoot,
+        child: InkWell(
+          onTap: onTap,
+          child: content,
+        ),
+      ),
     );
   }
 
@@ -614,10 +621,15 @@ class _SettingsRowFocusTarget extends StatefulWidget {
     required this.onTap,
     required this.child,
     this.autoHome = true,
+    this.focusEnabled = true,
   });
 
   final VoidCallback onTap;
   final Widget child;
+
+  /// False = 目标保持挂载但不参与遍历/注册（无焦点根时的恒定结构模式，
+  /// 见调用处注释）。透传 [HibikiFocusTarget.enabled]。
+  final bool focusEnabled;
 
   /// False for a collapsible section's fold header: it stays keyboard/gamepad
   /// reachable but passive focus auto-home skips it so the cursor lands on the
@@ -648,6 +660,7 @@ class _SettingsRowFocusTargetState extends State<_SettingsRowFocusTarget> {
       child: HibikiFocusTarget(
         id: _focusId,
         autoHome: widget.autoHome,
+        enabled: widget.focusEnabled,
         child: widget.child,
       ),
     );

--- a/hibiki/test/models/app_ui_font_locale_guard_test.dart
+++ b/hibiki/test/models/app_ui_font_locale_guard_test.dart
@@ -41,7 +41,9 @@ void main() {
     appLocaleGetterSource = _functionSource(
       mainSource,
       'Locale get locale',
-      '}\n\n/// 按实验开关',
+      // 锚 = locale getter 之后下一个顶层声明的 doc 注释首行（_wrapFocusNavigation，
+      // 2026-07-22 焦点层恒定挂载改造后注释重写，锚随之更新）。
+      '}\n\n/// 焦点导航层',
     );
     // TODO-960: the primary app subtree is now wrapped in a locale-keyed
     // [KeyedSubtree] (so a desktop hot language switch remounts everything),

--- a/hibiki/test/settings/switch_toggle_animation_probe_test.dart
+++ b/hibiki/test/settings/switch_toggle_animation_probe_test.dart
@@ -1,0 +1,106 @@
+// 用户报「键盘/手柄焦点导航开关没有动画，其他的有」（2026-07-22）。
+// 根因：旧 _wrapFocusNavigation 按开关插/拔 HibikiFocusRoot/Ring 两层——树结构
+// 变化导致整棵 app 子树重挂载，被切的 Switch 以新状态直接 mount，滑块动画消失。
+// 修复：焦点层恒定挂载（enabled 门控行为）+ 设置行结构恒定（ExcludeFocus.excluding
+// / HibikiFocusTarget.enabled 门控而非换树）。本文件两个测试分别锁：
+// 1) schema 式开关行本身动画健在（判别基线）；
+// 2) 翻转 HibikiFocusRoot.enabled 同帧切换开关值时，Switch State 存活且动画运行
+//    ——正是用户点「键盘/手柄焦点导航」开关的场景。
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/utils/components/settings_shared.dart';
+
+void main() {
+  testWidgets('schema 式开关行（异步 onChanged + setState）保有滑块动画',
+      (WidgetTester tester) async {
+    bool value = false;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return AdaptiveSettingsSwitchRow(
+              title: '探针开关',
+              value: value,
+              onChanged: (bool next) async {
+                // 复刻 settings_schema_widgets._switch：先异步落库再刷新。
+                await Future<void>.delayed(const Duration(milliseconds: 10));
+                setState(() => value = next);
+              },
+            );
+          },
+        ),
+      ),
+    ));
+
+    await tester.tap(find.byType(Switch));
+    // 放异步写完成 + 触发 setState 回灌新值。
+    await tester.pump(const Duration(milliseconds: 20));
+    // value 变化帧：Switch didUpdateWidget 启动滑块动画 → 必有后续排帧。
+    await tester.pump();
+    expect(tester.binding.hasScheduledFrame, isTrue,
+        reason: '值翻转后应有进行中的滑块动画（还在排帧）；若无排帧说明 Switch '
+            '被重挂载或动画被吞');
+    // 动画自然结束后收敛。
+    await tester.pumpAndSettle();
+    expect(value, isTrue);
+  });
+
+  testWidgets('翻转 HibikiFocusRoot.enabled 时开关行 Element 存活、滑块动画运行',
+      (WidgetTester tester) async {
+    bool focusNav = false;
+    Widget app() => MaterialApp(
+          home: Scaffold(
+            body: StatefulBuilder(
+              builder: (BuildContext context, StateSetter setState) {
+                // 复刻真实壳结构：恒定挂载的焦点根，enabled 随开关值走——
+                // 用户点「键盘/手柄焦点导航」= 同帧翻 enabled + 翻 Switch 值。
+                return HibikiFocusRoot(
+                  enabled: focusNav,
+                  child: AdaptiveSettingsSwitchRow(
+                    title: '键盘/手柄焦点导航',
+                    value: focusNav,
+                    onChanged: (bool next) async {
+                      await Future<void>.delayed(
+                          const Duration(milliseconds: 10));
+                      setState(() => focusNav = next);
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+    await tester.pumpWidget(app());
+
+    // Switch 是 StatelessWidget（内部 _MaterialSwitch 才持 State）——用 Element
+    // 身份判定重挂载：Element 存活 = 子树未被重建，内部动画 State 必然同存活。
+    final Element switchElementBefore = tester.element(find.byType(Switch));
+
+    await tester.tap(find.byType(Switch));
+    await tester.pump(const Duration(milliseconds: 20));
+    await tester.pump();
+
+    // 结构恒定 → 同一个 Switch Element 存活（旧实现这里是新实例，动画无从谈起）。
+    expect(
+      identical(tester.element(find.byType(Switch)), switchElementBefore),
+      isTrue,
+      reason: '翻转焦点导航开关不得重挂载设置行子树（结构恒定化契约）',
+    );
+    expect(tester.binding.hasScheduledFrame, isTrue,
+        reason: '值翻转后滑块动画应在运行（有排帧）');
+    await tester.pumpAndSettle();
+    expect(focusNav, isTrue);
+
+    // 反向再翻一次（enabled true→false 同样不得重挂载）。
+    await tester.tap(find.byType(Switch));
+    await tester.pump(const Duration(milliseconds: 20));
+    await tester.pump();
+    expect(
+      identical(tester.element(find.byType(Switch)), switchElementBefore),
+      isTrue,
+    );
+    await tester.pumpAndSettle();
+    expect(focusNav, isFalse);
+  });
+}


### PR DESCRIPTION
## 背景

用户截图反馈：**「键盘/手柄焦点导航」开关没有滑块动画，其他开关都有**；以及**设置宽屏详情面右侧空了一大堆**。

这两项原本在 PR#338 分支的最后两个 commit 里，但 #338 合并时只带走了前面的 commit，这两个 commit 从未进入 develop（`git merge-base --is-ancestor` 核实：`3b458130e` / `db4b23ed0` 均 NOT in develop）。本 PR 把它们改基到最新 develop 重新提交。

## 1. 焦点导航开关无动画（根因修复）

**根因**：`main.dart::_wrapFocusNavigation` 旧实现按开关值**插/拔** `HibikiFocusRoot` + `HibikiFocusRing` 两层：

```dart
if (!enabled) return child;                       // 开 → 关：拔掉两层
return HibikiFocusRoot(child: HibikiFocusRing(child: child));
```

Widget 树结构随开关值变化 → 整棵 app 子树重挂载 → 被切的那个 `Switch` 以**新值**直接 mount，`didUpdateWidget` 从不触发，滑块动画无从谈起。其他开关不改变树结构，所以都正常——正是用户观察到的差异。

**修复**（结构恒定化，行为用 `enabled` 门控）：

- `_wrapFocusNavigation`：恒定返回 `HibikiFocusRoot(enabled:) > HibikiFocusRing(enabled:)`，树形不再随值变。
- `HibikiFocusRoot`：新增 `enabled`，build 结构不变，向 `_HibikiFocusScope` 传 `controller: enabled ? _controller : null`；`controllerOf` 断言非空，`maybeControllerOf` 关闭时返回 null（下游注册天然失效）。
- `HibikiFocusRing`：新增 `enabled`；`didUpdateWidget` 关闭时清 `_rect`，`_scheduleRecompute` 提前返回，ringRect 门控——关掉后不留残影、不做无用几何计算。
- `settings_shared.dart`：Material 行路径改为结构恒定
  `_SettingsRowFocusTarget(focusEnabled:) > ExcludeFocus(excluding:) > InkWell`，
  用参数门控替代「有没有 focus root 就换一套树」。

## 2. 设置宽屏详情面回滚为填满整宽

PR-5 巡检报告曾推测超宽窗口该给详情正文加 960 上限。用户实拍截图否决：**右边空了一大堆**。按 Never break userspace，回滚 `Align(topStart) + ConstrainedBox(desktopContentMaxWidth)`，恢复 `primary: KeyedSubtree(...)` 填满整宽。

## 3. BUG-1034 建档

app 外查词浮窗卡片左圆角右直角（用户截图）。**未修复**，标 ⏳ 待 Windows 真机复现取证——CSS 四角对称，三个候选根因（UA body margin 未重置 + 滚动条 gutter / 宿主 shell 宽度错位 / WebView2 Fluent 滚动条压边）都需真机分辨。原编号 1014，因 develop 已占用改为 1034（1033 被在飞的 PR#364 占用）。

## 测试

新增 `test/settings/switch_toggle_animation_probe_test.dart`（2 个）：

1. schema 式开关行（异步 onChanged + setState）保有滑块动画——判别基线；
2. **翻转 `HibikiFocusRoot.enabled` 同帧切换开关值时，`Switch` 的 Element 身份不变且动画在排帧**——正是用户点「键盘/手柄焦点导航」的场景，旧实现下必红。

（`Switch` 是 StatelessWidget，内部 `_MaterialSwitch` 才持 State，因此用 Element 身份判重挂载。）

同时修 `test/models/app_ui_font_locale_guard_test.dart` 的源码切片锚点——`_wrapFocusNavigation` 注释重写后旧锚点 `'}\n\n/// 按实验开关'` 失效。

## 验证

- `dart format` 干净（本轮文件 0 changed）
- `flutter analyze`：**No issues found!**
- `flutter test` 全量：见 PR 评论/CI

## 影响范围

纯 UI/交互层。无 schema 改动、无持久化 key 改动、无引擎逻辑改动。焦点导航开关的**行为**与之前一致（关 = 无焦点环、无方向导航、设置行不吃焦点），只是不再靠重建树来实现。
