### PR TITLE
fix(mining): 原片档 GIF 封顶止住制卡卡死 + 已制卡弹窗改居中且不再被查词弹窗盖住 (BUG-1039/1040)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 999 条。点号进各自文件。
+> 共 1001 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1040](bugs/BUG-1040-mined-card-dialog-centered-and-above-popup.md) | ✅ | ✅ | 「卡片已在 Anki 中」是底部 sheet 且层级低于查词弹窗（被盖住看不见） |
+| [BUG-1039](bugs/BUG-1039-native-tier-gif-explodes-mining.md) | ✅ | ✅ | 制卡「原片档」把 GIF 按源分辨率+源帧率导出 → 制卡/覆盖巨慢、Anki 无响应 |
 | [BUG-1032](bugs/BUG-1032-qb-webui-no-request-timeout.md) | ✅ | ✅ | qB WebUI 请求缺少超时 |
 | [BUG-1031](bugs/BUG-1031-download-default-config-no-completion-poll.md) | ✅ | ✅ | 默认下载配置未传给完成轮询 |
 | [BUG-1030](bugs/BUG-1030-extension-subtitle-panel-overlay.md) | ✅ | ✅ | 浏览器扩展字幕列表覆盖页面而非挤压画面 |

--- a/docs/bugs/BUG-1039-native-tier-gif-explodes-mining.md
+++ b/docs/bugs/BUG-1039-native-tier-gif-explodes-mining.md
@@ -1,0 +1,34 @@
+## BUG-1039 · 制卡「原片档」把 GIF 按源分辨率+源帧率导出 → 制卡/覆盖巨慢、Anki 无响应
+- **报告**：2026-07-23（用户：qqbotxiaoxiao，原话「这个覆盖巨慢。直接把 anki 弄无响应了」「不止这里的覆盖，视频普通查词制卡也无响应」，附视频页「卡片已在 Anki 中」弹窗截图，进度条卡在 busy 态）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/utils/misc/desktop_audio_clipper.dart` 的
+  `MiningMediaCompression.imageTiers[3]`（原片档）过去写成 `(gifFps: 0, gifWidth: 0, ...)`，
+  即用「0 = 不限制」哨兵同时表达**截图不缩放**和 **GIF 源分辨率+源帧率**。这是把静态图的
+  语义错套到动图上：截图原图直通只是一张几 MB 的 JPEG，而 GIF 是 8-bit 调色板逐帧 LZW、
+  **无帧间压缩**，体积随「像素×帧数」线性爆炸。
+  `buildFfmpegClipGifArgs`（同文件 L917-921）据此整段省略 `fps=`/`scale=` 滤镜，
+  `ImmersionMiningEngine.mine`（`hibiki/lib/src/mining/immersion_mining_engine.dart:111-123`）
+  把该档喂给 ffmpeg。
+  - **实测**（1080p 番剧源、**4 秒**字幕区间、与代码逐字一致的 ffmpeg 参数）：
+    标准档(480px/8fps) **1.5 秒 / 1.5 MB**；原片档(0/0) **48.9 秒 / 54 MB**（33× 慢、35× 大）。
+    cue 上限 `maxDurationMs=10000` 时约 135 MB，还会撞 `extractClipGifViaFfmpeg` 的 120 秒超时。
+  - **传导链**：GIF → `AnkiConnectRepository._storeLocalMedia` 读全量字节 → base64（已在
+    BUG-933 卸到 isolate）→ `AnkiConnectService._request` 在 UI isolate `jsonEncode` 这坨
+    ~72 MB 字符串 → POST 给 AnkiConnect；**Anki 在自己主线程解析该 JSON → 直接无响应**。
+    落到卡片里后每次复习都要解 54 MB GIF，AnkiWeb 也同步不上去。即「GIF 原片」不是一个更高
+    的质量档，而是**在任何口径下都不可用**的配置。
+  - 覆盖（`updateMinedNote`）与新建（`mineEntry`）走**同一条** `ImmersionMiningEngine` 媒体
+    链路，故用户观察到的「覆盖慢」与「普通制卡也无响应」是同一根因，不是覆盖特有。
+  - 用户生产库偏好实测：`mining_image_quality|i:3`（原片档）、`mining_audio_quality|i:2`。
+- **[x] ① 已修复** — 原片档不再对 GIF 用 0 哨兵：`imageTiers[3]` 的 GIF 参数改为封顶值
+  `gifNativeFps=12` / `gifNativeWidth=960`（新增两个具名常量），截图侧 `maxLongEdge: 0`
+  （原图直通）语义完全不动。实测同一 4 秒区间：**6 秒 / 7.7 MB**，仍明显优于高清档
+  （720px/12fps，4 秒 / 4.3 MB）。同步修正类文档注释与设置项说明文案
+  （`mining_image_quality_hint`，en / zh-CN / zh-HK）。
+- **[x] ② 已加自动化测试** — `hibiki/test/utils/desktop_audio_clipper_test.dart`：
+  新增回归守卫「BUG-1039：没有任何图片档把 GIF 参数留成 0（不限制）哨兵」（遍历全部
+  4 档断言 `gifFps > 0 && gifWidth > 0`）；原「满档用 0 哨兵」用例改断言封顶值；
+  单调递增用例的 GIF 部分从「排除满档」扩到覆盖满档。
+  `hibiki/test/settings/mining_media_quality_guard_test.dart` 同步更新满档断言。
+- **备注**：ffmpeg 参数本身（`-ss`/`-t` 在 `-i` 前的输入侧 seek、palettegen/paletteuse 双遍）
+  没问题，不需要动。**待用户真机复验**：视频页查词 →「+」新建 / 点「✓」→ 覆盖，在原片档下
+  制卡应从 ~49 秒回到个位数秒，Anki 不再卡死。UI 侧的弹窗形态/层级见 [BUG-1040](BUG-1040-mined-card-dialog-centered-and-above-popup.md)。

--- a/docs/bugs/BUG-1039-native-tier-gif-explodes-mining.md
+++ b/docs/bugs/BUG-1039-native-tier-gif-explodes-mining.md
@@ -24,11 +24,23 @@
   （原图直通）语义完全不动。实测同一 4 秒区间：**6 秒 / 7.7 MB**，仍明显优于高清档
   （720px/12fps，4 秒 / 4.3 MB）。同步修正类文档注释与设置项说明文案
   （`mining_image_quality_hint`，en / zh-CN / zh-HK）。
+- **[x] ①b 满档改名（用户追加：「那他不应该叫原图了」）** — 封顶之后「原片」名不副实：这一档
+  对 GIF 已不是源分辨率/源帧率，只有截图仍是原图直通。故满档改叫**「最高 / Maximum」**
+  （只承诺是滑块顶格，不承诺具体保真度），档位阶梯变成 省流 → 标准 → 高清 → 最高。
+  一并修掉**音频**滑块的同类名不副实：音频满档过去也叫「原片」，但 192k 立体声 AAC 本就是
+  有损重编码，同改「最高」（两个滑块顶格叫法也统一）。
+  i18n key 经 `tool/i18n_sync.dart` 重命名（17 语言）：`mining_image_quality_native` →
+  `mining_image_quality_max`、`mining_audio_quality_native` → `mining_audio_quality_max`；
+  代码标识符同步：`imageTierNative` → `imageTierMax`、`gifNativeFps`/`gifNativeWidth` →
+  `gifMaxTierFps`/`gifMaxTierWidth`；档位表与设置页注释里名不副实的「原片」措辞一并改写
+  （仅保留「BUG-1039 前叫原片」这类历史叙述）。
 - **[x] ② 已加自动化测试** — `hibiki/test/utils/desktop_audio_clipper_test.dart`：
   新增回归守卫「BUG-1039：没有任何图片档把 GIF 参数留成 0（不限制）哨兵」（遍历全部
   4 档断言 `gifFps > 0 && gifWidth > 0`）；原「满档用 0 哨兵」用例改断言封顶值；
   单调递增用例的 GIF 部分从「排除满档」扩到覆盖满档。
-  `hibiki/test/settings/mining_media_quality_guard_test.dart` 同步更新满档断言。
+  `hibiki/test/settings/mining_media_quality_guard_test.dart` 同步更新满档断言，并新增
+  「两滑块满档标签是『最高』而非名不副实的『原片』」守卫（钉死 `t.mining_*_quality_max`、
+  禁止旧 `_native` key 复活）。
 - **备注**：ffmpeg 参数本身（`-ss`/`-t` 在 `-i` 前的输入侧 seek、palettegen/paletteuse 双遍）
   没问题，不需要动。**待用户真机复验**：视频页查词 →「+」新建 / 点「✓」→ 覆盖，在原片档下
   制卡应从 ~49 秒回到个位数秒，Anki 不再卡死。UI 侧的弹窗形态/层级见 [BUG-1040](BUG-1040-mined-card-dialog-centered-and-above-popup.md)。

--- a/docs/bugs/BUG-1040-mined-card-dialog-centered-and-above-popup.md
+++ b/docs/bugs/BUG-1040-mined-card-dialog-centered-and-above-popup.md
@@ -1,0 +1,39 @@
+## BUG-1040 · 「卡片已在 Anki 中」是底部 sheet 且层级低于查词弹窗（被盖住看不见）
+- **报告**：2026-07-23（用户：qqbotxiaoxiao，原话「并且不应该是底部弹窗，应该是中间的弹窗。层级也不对，他的层级比查词弹窗的低。导致看不见」，附视频页截图：sheet 贴在窗口下沿、进度条被窗口边缘裁掉）
+- **真实性**：✅ 真 bug，两个独立缺陷叠在同一个 UI 上。
+  1. **形态**：`hibiki/lib/src/anki/anki_mined_card_action_sheet.dart` 的
+     `showAnkiMinedCardActionSheet` 用 `showModalBottomSheet`。这是个「必须当场做决定」的
+     模态选择（覆写哪张 / 新增重复卡 / 去 Anki 看），不是可下拉浏览的内容面板；贴屏幕下沿
+     在视频页会被播放器控件与窗口边缘裁掉半截。同族的 `showAnkiNoteViewer` /
+     `SentenceContextDialog` 本来就是居中 `AlertDialog`，形态不一致。
+  2. **层级**：查词弹窗是**原生平台视图**（桌面 `flutter_inappwebview_windows` 的 WebView2 /
+     Android `InAppWebView` platform view），靠 airspace **永远画在 Flutter 层之上**——不是
+     `OverlayEntry` 顺序问题，改成根 Overlay 顶层 entry 也照样被盖。这与
+     [BUG-797](BUG-797-sentence-context-dialog-behind-popup.md)（「选择句子上下文」对话框被
+     弹窗盖住）是**同一个根因**，只是当时只给那一个对话框打了补丁：
+     `base_source_page.dart` / `dictionary_page_mixin.dart` 各有一个 `bool
+     _sentenceContextDialogOpen`，只与句子上下文对话框接线，`runAnkiMinedCardAction` /
+     `openMinedCardInAnki` 这两条同样弹 Flutter 对话框的路径没接上 → 照样被弹窗盖住。
+- **[x] ① 已修复** — 两处一起根治：
+  - **形态**：`showAnkiMinedCardActionSheet` 与 `showAnkiOpenNotePicker` 都改走 `showAppDialog`
+    居中 `AlertDialog`（`_MinedCardActionSheet` → `_MinedCardActionDialog`）。命中列表放在
+    有界高度的 `Flexible + shrinkWrap ListView`（多张时列表自身滚动），「新增为重复卡」升为
+    对话框 action 按钮并补「取消」。制卡/覆写有副作用，故 `barrierDismissible: false`，
+    误触遮罩不会丢掉整次操作。窄屏取可用宽度九成、宽屏 420，避免横向溢出。
+  - **层级**：把 BUG-797 的单一布尔**泛化**为可嵌套的计数 `int _popupHidingDialogDepth` +
+    统一入口 `runWithLookupPopupHidden<T>(body)`（两车道各一份，收口 setState 增减，
+    `finally` 复位不漏）；`parkedPopupLayer` 的 `visible` 改与 `_popupHidingDialogDepth == 0`
+    相与。改计数而非布尔是必需的：动作对话框里还能再叠一层 note viewer 对话框，用布尔会被
+    内层 `finally` 提前复位、外层对话框当场被弹窗盖回去。
+    新增可选参数 `LookupPopupHiddenRunner? runHidden` 传进 `runAnkiMinedCardAction` /
+    `openMinedCardInAnki`，两车道四个调用点全部接上。刻意**只包住对话框可见那一段**、
+    不包 `findMatchingNotes`——反查是网络往返，Anki 不可达时会等到超时，若一起藏就会出现
+    「弹窗凭空消失好几秒又回来、期间什么都没弹」的空窗。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/sentence_context_dialog_zorder_guard_test.dart`
+  （原 BUG-797 守卫扩写）：钉死两车道的计数字段、统一入口签名、setState 增减、
+  `parkedPopupLayer.visible` 相与表达式，以及三个调用点都接上入口（`runHidden:` 至少两处）；
+  新增一条钉死「本文件不得再出现 `showModalBottomSheet`、动作框与选择框都走 `showAppDialog`、
+  且禁用 barrier 关闭」。airspace 是原生合成层，无头测试照不到，故仍用源码扫描守卫。
+- **备注**：**待用户真机复验**（Windows 视频页）：查词 → 点「✓」→ 对话框居中显示且完整可见、
+  查词弹窗在对话框期间让位、关闭后回位；「在 Anki 中打开」命中多张时的选择框同理。
+  性能侧（制卡/覆盖巨慢）是另一根因，见 [BUG-1039](BUG-1039-native-tier-gif-explodes-mining.md)。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 39287 (2311 per locale)
 ///
-/// Built on 2026-07-23 at 11:05 UTC
+/// Built on 2026-07-23 at 12:06 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2648,7 +2648,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Tag ${name} is already on this collection.';
   String get mining_image_quality => 'Image / GIF quality';
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   String get mining_image_quality_thrift => 'Data saver';
   String get mining_image_quality_standard => 'Standard';
   String get mining_image_quality_hd => 'HD';
@@ -7546,7 +7546,7 @@ class _StringsAr extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -12860,7 +12860,7 @@ class _StringsDe extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -18190,7 +18190,7 @@ class _StringsEs extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -23531,7 +23531,7 @@ class _StringsFr extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -28799,7 +28799,7 @@ class _StringsId extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -34115,7 +34115,7 @@ class _StringsIt extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -39237,7 +39237,7 @@ class _StringsJa extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -44361,7 +44361,7 @@ class _StringsKo extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -49654,7 +49654,7 @@ class _StringsNl extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -54963,7 +54963,7 @@ class _StringsPtBr extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -60255,7 +60255,7 @@ class _StringsRu extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -65492,7 +65492,7 @@ class _StringsTh extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -70761,7 +70761,7 @@ class _StringsTr extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -76017,7 +76017,7 @@ class _StringsVi extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -80965,7 +80965,8 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get mining_image_quality => '图片 / GIF 清晰度';
   @override
-  String get mining_image_quality_hint => '越高越清晰，卡片体积也越大。原片档保留源分辨率与帧率。';
+  String get mining_image_quality_hint =>
+      '越高越清晰，卡片体积也越大。原片档的截图保留源分辨率；动图有上限，避免卡片大到不可用。';
   @override
   String get mining_image_quality_thrift => '省流';
   @override
@@ -85947,7 +85948,7 @@ class _StringsZhHk extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
@@ -90746,7 +90747,7 @@ extension on _StringsEn {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -95462,7 +95463,7 @@ extension on _StringsAr {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -100199,7 +100200,7 @@ extension on _StringsDe {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -104935,7 +104936,7 @@ extension on _StringsEs {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -109677,7 +109678,7 @@ extension on _StringsFr {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -114401,7 +114402,7 @@ extension on _StringsId {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -119140,7 +119141,7 @@ extension on _StringsIt {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -123841,7 +123842,7 @@ extension on _StringsJa {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -128546,7 +128547,7 @@ extension on _StringsKo {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -133278,7 +133279,7 @@ extension on _StringsNl {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -138007,7 +138008,7 @@ extension on _StringsPtBr {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -142741,7 +142742,7 @@ extension on _StringsRu {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -147459,7 +147460,7 @@ extension on _StringsTh {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -152186,7 +152187,7 @@ extension on _StringsTr {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -156908,7 +156909,7 @@ extension on _StringsVi {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
@@ -161597,7 +161598,7 @@ extension on _StringsZhCn {
       case 'mining_image_quality':
         return '图片 / GIF 清晰度';
       case 'mining_image_quality_hint':
-        return '越高越清晰，卡片体积也越大。原片档保留源分辨率与帧率。';
+        return '越高越清晰，卡片体积也越大。原片档的截图保留源分辨率；动图有上限，避免卡片大到不可用。';
       case 'mining_image_quality_thrift':
         return '省流';
       case 'mining_image_quality_standard':
@@ -166290,7 +166291,7 @@ extension on _StringsZhHk {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.';
+        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 39287 (2311 per locale)
 ///
-/// Built on 2026-07-23 at 12:06 UTC
+/// Built on 2026-07-23 at 13:18 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2648,17 +2648,15 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Tag ${name} is already on this collection.';
   String get mining_image_quality => 'Image / GIF quality';
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   String get mining_image_quality_thrift => 'Data saver';
   String get mining_image_quality_standard => 'Standard';
   String get mining_image_quality_hd => 'HD';
-  String get mining_image_quality_native => 'Native';
   String get mining_audio_quality => 'Audio quality';
   String get mining_audio_quality_hint =>
       'Higher bitrate is clearer but makes larger cards.';
   String get mining_audio_quality_standard => 'Standard';
   String get mining_audio_quality_high => 'High';
-  String get mining_audio_quality_native => 'Native';
   String get video_setting_torrent_backend => 'Download backend';
   String get video_setting_torrent_backend_qb => 'External qBittorrent';
   String get video_setting_torrent_backend_embedded =>
@@ -3084,6 +3082,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String download_subscription_latest_episode({required Object episode}) =>
       'Latest queued: episode ${episode}';
   String get download_subscription_check_now => 'Check now';
+  String get mining_image_quality_max => 'Maximum';
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -7546,15 +7546,13 @@ class _StringsAr extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -7564,8 +7562,6 @@ class _StringsAr extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -8325,6 +8321,10 @@ class _StringsAr extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -12860,15 +12860,13 @@ class _StringsDe extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -12878,8 +12876,6 @@ class _StringsDe extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -13639,6 +13635,10 @@ class _StringsDe extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -18190,15 +18190,13 @@ class _StringsEs extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -18208,8 +18206,6 @@ class _StringsEs extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -18969,6 +18965,10 @@ class _StringsEs extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -23531,15 +23531,13 @@ class _StringsFr extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -23549,8 +23547,6 @@ class _StringsFr extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -24310,6 +24306,10 @@ class _StringsFr extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -28799,15 +28799,13 @@ class _StringsId extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -28817,8 +28815,6 @@ class _StringsId extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -29578,6 +29574,10 @@ class _StringsId extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -34115,15 +34115,13 @@ class _StringsIt extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -34133,8 +34131,6 @@ class _StringsIt extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -34894,6 +34890,10 @@ class _StringsIt extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -39237,15 +39237,13 @@ class _StringsJa extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -39255,8 +39253,6 @@ class _StringsJa extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -40015,6 +40011,10 @@ class _StringsJa extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -44361,15 +44361,13 @@ class _StringsKo extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -44379,8 +44377,6 @@ class _StringsKo extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -45139,6 +45135,10 @@ class _StringsKo extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -49654,15 +49654,13 @@ class _StringsNl extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -49672,8 +49670,6 @@ class _StringsNl extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -50433,6 +50429,10 @@ class _StringsNl extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -54963,15 +54963,13 @@ class _StringsPtBr extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -54981,8 +54979,6 @@ class _StringsPtBr extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -55742,6 +55738,10 @@ class _StringsPtBr extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -60255,15 +60255,13 @@ class _StringsRu extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -60273,8 +60271,6 @@ class _StringsRu extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -61034,6 +61030,10 @@ class _StringsRu extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -65492,15 +65492,13 @@ class _StringsTh extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -65510,8 +65508,6 @@ class _StringsTh extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -66271,6 +66267,10 @@ class _StringsTh extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -70761,15 +70761,13 @@ class _StringsTr extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -70779,8 +70777,6 @@ class _StringsTr extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -71540,6 +71536,10 @@ class _StringsTr extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -76017,15 +76017,13 @@ class _StringsVi extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -76035,8 +76033,6 @@ class _StringsVi extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -76796,6 +76792,10 @@ class _StringsVi extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 // Path: <root>
@@ -80966,15 +80966,13 @@ class _StringsZhCn extends _StringsEn {
   String get mining_image_quality => '图片 / GIF 清晰度';
   @override
   String get mining_image_quality_hint =>
-      '越高越清晰，卡片体积也越大。原片档的截图保留源分辨率；动图有上限，避免卡片大到不可用。';
+      '越高越清晰，卡片体积也越大。最高档的截图保留源分辨率；动图有上限，避免卡片大到不可用。';
   @override
   String get mining_image_quality_thrift => '省流';
   @override
   String get mining_image_quality_standard => '标准';
   @override
   String get mining_image_quality_hd => '高清';
-  @override
-  String get mining_image_quality_native => '原片';
   @override
   String get mining_audio_quality => '音频质量';
   @override
@@ -80983,8 +80981,6 @@ class _StringsZhCn extends _StringsEn {
   String get mining_audio_quality_standard => '标准';
   @override
   String get mining_audio_quality_high => '高音质';
-  @override
-  String get mining_audio_quality_native => '原片';
   @override
   String get video_setting_torrent_backend => '下载后端';
   @override
@@ -81683,6 +81679,10 @@ class _StringsZhCn extends _StringsEn {
       '最近加入：第 ${episode} 集';
   @override
   String get download_subscription_check_now => '立即检查';
+  @override
+  String get mining_image_quality_max => '最高';
+  @override
+  String get mining_audio_quality_max => '最高';
 }
 
 // Path: <root>
@@ -85948,15 +85948,13 @@ class _StringsZhHk extends _StringsEn {
   String get mining_image_quality => 'Image / GIF quality';
   @override
   String get mining_image_quality_hint =>
-      'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+      'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
   @override
   String get mining_image_quality_thrift => 'Data saver';
   @override
   String get mining_image_quality_standard => 'Standard';
   @override
   String get mining_image_quality_hd => 'HD';
-  @override
-  String get mining_image_quality_native => 'Native';
   @override
   String get mining_audio_quality => 'Audio quality';
   @override
@@ -85966,8 +85964,6 @@ class _StringsZhHk extends _StringsEn {
   String get mining_audio_quality_standard => 'Standard';
   @override
   String get mining_audio_quality_high => 'High';
-  @override
-  String get mining_audio_quality_native => 'Native';
   @override
   String get video_setting_torrent_backend => 'Download backend';
   @override
@@ -86722,6 +86718,10 @@ class _StringsZhHk extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get mining_image_quality_max => 'Maximum';
+  @override
+  String get mining_audio_quality_max => 'Maximum';
 }
 
 /// Flat map(s) containing all translations.
@@ -90747,15 +90747,13 @@ extension on _StringsEn {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -90764,8 +90762,6 @@ extension on _StringsEn {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -91440,6 +91436,10 @@ extension on _StringsEn {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -95463,15 +95463,13 @@ extension on _StringsAr {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -95480,8 +95478,6 @@ extension on _StringsAr {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -96156,6 +96152,10 @@ extension on _StringsAr {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -100200,15 +100200,13 @@ extension on _StringsDe {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -100217,8 +100215,6 @@ extension on _StringsDe {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -100893,6 +100889,10 @@ extension on _StringsDe {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -104936,15 +104936,13 @@ extension on _StringsEs {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -104953,8 +104951,6 @@ extension on _StringsEs {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -105629,6 +105625,10 @@ extension on _StringsEs {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -109678,15 +109678,13 @@ extension on _StringsFr {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -109695,8 +109693,6 @@ extension on _StringsFr {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -110371,6 +110367,10 @@ extension on _StringsFr {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -114402,15 +114402,13 @@ extension on _StringsId {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -114419,8 +114417,6 @@ extension on _StringsId {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -115095,6 +115091,10 @@ extension on _StringsId {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -119141,15 +119141,13 @@ extension on _StringsIt {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -119158,8 +119156,6 @@ extension on _StringsIt {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -119834,6 +119830,10 @@ extension on _StringsIt {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -123842,15 +123842,13 @@ extension on _StringsJa {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -123859,8 +123857,6 @@ extension on _StringsJa {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -124535,6 +124531,10 @@ extension on _StringsJa {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -128547,15 +128547,13 @@ extension on _StringsKo {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -128564,8 +128562,6 @@ extension on _StringsKo {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -129240,6 +129236,10 @@ extension on _StringsKo {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -133279,15 +133279,13 @@ extension on _StringsNl {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -133296,8 +133294,6 @@ extension on _StringsNl {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -133972,6 +133968,10 @@ extension on _StringsNl {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -138008,15 +138008,13 @@ extension on _StringsPtBr {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -138025,8 +138023,6 @@ extension on _StringsPtBr {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -138701,6 +138697,10 @@ extension on _StringsPtBr {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -142742,15 +142742,13 @@ extension on _StringsRu {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -142759,8 +142757,6 @@ extension on _StringsRu {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -143435,6 +143431,10 @@ extension on _StringsRu {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -147460,15 +147460,13 @@ extension on _StringsTh {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -147477,8 +147475,6 @@ extension on _StringsTh {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -148153,6 +148149,10 @@ extension on _StringsTh {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -152187,15 +152187,13 @@ extension on _StringsTr {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -152204,8 +152202,6 @@ extension on _StringsTr {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -152880,6 +152876,10 @@ extension on _StringsTr {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -156909,15 +156909,13 @@ extension on _StringsVi {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -156926,8 +156924,6 @@ extension on _StringsVi {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -157602,6 +157598,10 @@ extension on _StringsVi {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }
@@ -161598,15 +161598,13 @@ extension on _StringsZhCn {
       case 'mining_image_quality':
         return '图片 / GIF 清晰度';
       case 'mining_image_quality_hint':
-        return '越高越清晰，卡片体积也越大。原片档的截图保留源分辨率；动图有上限，避免卡片大到不可用。';
+        return '越高越清晰，卡片体积也越大。最高档的截图保留源分辨率；动图有上限，避免卡片大到不可用。';
       case 'mining_image_quality_thrift':
         return '省流';
       case 'mining_image_quality_standard':
         return '标准';
       case 'mining_image_quality_hd':
         return '高清';
-      case 'mining_image_quality_native':
-        return '原片';
       case 'mining_audio_quality':
         return '音频质量';
       case 'mining_audio_quality_hint':
@@ -161615,8 +161613,6 @@ extension on _StringsZhCn {
         return '标准';
       case 'mining_audio_quality_high':
         return '高音质';
-      case 'mining_audio_quality_native':
-        return '原片';
       case 'video_setting_torrent_backend':
         return '下载后端';
       case 'video_setting_torrent_backend_qb':
@@ -162288,6 +162284,10 @@ extension on _StringsZhCn {
         return ({required Object episode}) => '最近加入：第 ${episode} 集';
       case 'download_subscription_check_now':
         return '立即检查';
+      case 'mining_image_quality_max':
+        return '最高';
+      case 'mining_audio_quality_max':
+        return '最高';
       default:
         return null;
     }
@@ -166291,15 +166291,13 @@ extension on _StringsZhHk {
       case 'mining_image_quality':
         return 'Image / GIF quality';
       case 'mining_image_quality_hint':
-        return 'Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
+        return 'Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.';
       case 'mining_image_quality_thrift':
         return 'Data saver';
       case 'mining_image_quality_standard':
         return 'Standard';
       case 'mining_image_quality_hd':
         return 'HD';
-      case 'mining_image_quality_native':
-        return 'Native';
       case 'mining_audio_quality':
         return 'Audio quality';
       case 'mining_audio_quality_hint':
@@ -166308,8 +166306,6 @@ extension on _StringsZhHk {
         return 'Standard';
       case 'mining_audio_quality_high':
         return 'High';
-      case 'mining_audio_quality_native':
-        return 'Native';
       case 'video_setting_torrent_backend':
         return 'Download backend';
       case 'video_setting_torrent_backend_qb':
@@ -166984,6 +166980,10 @@ extension on _StringsZhHk {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'mining_image_quality_max':
+        return 'Maximum';
+      case 'mining_audio_quality_max':
+        return 'Maximum';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop only)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "标签「$name」已添加到合集。",
   "tag_already_on_collection": "标签「$name」已在此合集上。",
   "mining_image_quality": "图片 / GIF 清晰度",
-  "mining_image_quality_hint": "越高越清晰，卡片体积也越大。原片档保留源分辨率与帧率。",
+  "mining_image_quality_hint": "越高越清晰，卡片体积也越大。原片档的截图保留源分辨率；动图有上限，避免卡片大到不可用。",
   "mining_image_quality_thrift": "省流",
   "mining_image_quality_standard": "标准",
   "mining_image_quality_hd": "高清",

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "标签「$name」已添加到合集。",
   "tag_already_on_collection": "标签「$name」已在此合集上。",
   "mining_image_quality": "图片 / GIF 清晰度",
-  "mining_image_quality_hint": "越高越清晰，卡片体积也越大。原片档的截图保留源分辨率；动图有上限，避免卡片大到不可用。",
+  "mining_image_quality_hint": "越高越清晰，卡片体积也越大。最高档的截图保留源分辨率；动图有上限，避免卡片大到不可用。",
   "mining_image_quality_thrift": "省流",
   "mining_image_quality_standard": "标准",
   "mining_image_quality_hd": "高清",
-  "mining_image_quality_native": "原片",
   "mining_audio_quality": "音频质量",
   "mining_audio_quality_hint": "比特率越高越清晰，卡片体积也越大。",
   "mining_audio_quality_standard": "标准",
   "mining_audio_quality_high": "高音质",
-  "mining_audio_quality_native": "原片",
   "video_setting_torrent_backend": "下载后端",
   "video_setting_torrent_backend_qb": "外接 qBittorrent",
   "video_setting_torrent_backend_embedded": "内置引擎（仅桌面）",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "第 ${episode} 集之后",
   "download_subscription_last_checked": "上次检查：${time}",
   "download_subscription_latest_episode": "最近加入：第 ${episode} 集",
-  "download_subscription_check_now": "立即检查"
+  "download_subscription_check_now": "立即检查",
+  "mining_image_quality_max": "最高",
+  "mining_audio_quality_max": "最高"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1966,7 +1966,7 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps the source resolution and frame rate.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1966,16 +1966,14 @@
   "tag_added_to_collection": "Tag $name added to collection.",
   "tag_already_on_collection": "Tag $name is already on this collection.",
   "mining_image_quality": "Image / GIF quality",
-  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Native keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
+  "mining_image_quality_hint": "Higher is sharper but makes larger cards. Maximum keeps screenshots at the source resolution; animated GIFs stay capped so cards remain usable.",
   "mining_image_quality_thrift": "Data saver",
   "mining_image_quality_standard": "Standard",
   "mining_image_quality_hd": "HD",
-  "mining_image_quality_native": "Native",
   "mining_audio_quality": "Audio quality",
   "mining_audio_quality_hint": "Higher bitrate is clearer but makes larger cards.",
   "mining_audio_quality_standard": "Standard",
   "mining_audio_quality_high": "High",
-  "mining_audio_quality_native": "Native",
   "video_setting_torrent_backend": "Download backend",
   "video_setting_torrent_backend_qb": "External qBittorrent",
   "video_setting_torrent_backend_embedded": "Built-in engine (desktop only)",
@@ -2309,5 +2307,7 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "mining_image_quality_max": "Maximum",
+  "mining_audio_quality_max": "Maximum"
 }

--- a/hibiki/lib/src/anki/anki_mined_card_action_sheet.dart
+++ b/hibiki/lib/src/anki/anki_mined_card_action_sheet.dart
@@ -1,7 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 
+import 'package:hibiki/src/utils/misc/show_app_dialog.dart';
 import 'package:hibiki/utils.dart' show t, HibikiToast;
+
+/// BUG-1040：把「一段期间内让查词弹窗让位」的执行权交回宿主页面的钩子。
+///
+/// 查词弹窗是**原生平台视图**（桌面 WebView2 / Android platform view），靠 airspace
+/// 永远画在 Flutter 层之上——任何 `showDialog` 弹出来的东西都会被它盖住（BUG-797 已
+/// 在「选择句子上下文」对话框上踩过同一个坑）。所以本文件的对话框不能自己解决层级，
+/// 必须由持有弹窗层的宿主页面在对话框期间把弹窗停靠屏外。两条查词车道
+/// （`BaseSourcePageState` / `DictionaryPageMixin`）各实现一份并传进来；为 null 时
+/// 原样执行（无弹窗层的宿主，如纯查词页）。
+typedef LookupPopupHiddenRunner = Future<T> Function<T>(
+    Future<T> Function() body);
+
+/// [LookupPopupHiddenRunner] 缺省实现：直接跑，不动任何层级。
+Future<T> _runDirect<T>(Future<T> Function() body) => body();
 
 /// TODO-1007/1008：点查词弹窗「✓」（卡已存在）时弹出操作选择 + note viewer。
 /// 根因修复：旧行为点 ✓ 默默 return / 只覆写最近一张，把别处/上次会话建的同词卡挡死。
@@ -33,6 +48,11 @@ class AnkiMinedCardActionResult {
 
 /// 弹出操作选择并执行用户选择，返回结果。matches 由调用方先用
 /// BaseAnkiRepository.findMatchingNotes 查好（命中多张全部传入）。
+///
+/// BUG-1040：从底部 sheet 改为**居中对话框**。这是个「必须当场做决定」的模态选择
+/// （覆写哪张 / 新增重复卡 / 去 Anki 看），不是可下拉浏览的内容面板；底部 sheet 贴在
+/// 屏幕下沿、在视频页还会被播放器控件与窗口边缘裁掉半截（用户附图里进度条已被切）。
+/// 与同族的 [showAnkiNoteViewer] / [SentenceContextDialog] 统一走 [showAppDialog]。
 Future<AnkiMinedCardActionResult> showAnkiMinedCardActionSheet({
   required BuildContext context,
   required List<MinedNoteRef> matches,
@@ -40,11 +60,11 @@ Future<AnkiMinedCardActionResult> showAnkiMinedCardActionSheet({
   required Future<AnkiCardMutationResult> Function() mineNew,
   required Future<AnkiCardMutationResult> Function(int noteId) overwrite,
 }) async {
-  final result = await showModalBottomSheet<AnkiMinedCardActionResult>(
+  final result = await showAppDialog<AnkiMinedCardActionResult>(
     context: context,
-    isScrollControlled: true,
-    showDragHandle: true,
-    builder: (sheetContext) => _MinedCardActionSheet(
+    // 制卡/覆写是有副作用的选择，误触 barrier 就丢掉整次操作——只允许显式取消。
+    barrierDismissible: false,
+    builder: (dialogContext) => _MinedCardActionDialog(
       matches: matches,
       repo: repo,
       mineNew: mineNew,
@@ -54,8 +74,8 @@ Future<AnkiMinedCardActionResult> showAnkiMinedCardActionSheet({
   return result ?? const AnkiMinedCardActionResult.unchanged();
 }
 
-class _MinedCardActionSheet extends StatefulWidget {
-  const _MinedCardActionSheet({
+class _MinedCardActionDialog extends StatefulWidget {
+  const _MinedCardActionDialog({
     required this.matches,
     required this.repo,
     required this.mineNew,
@@ -68,10 +88,10 @@ class _MinedCardActionSheet extends StatefulWidget {
   final Future<AnkiCardMutationResult> Function(int noteId) overwrite;
 
   @override
-  State<_MinedCardActionSheet> createState() => _MinedCardActionSheetState();
+  State<_MinedCardActionDialog> createState() => _MinedCardActionDialogState();
 }
 
-class _MinedCardActionSheetState extends State<_MinedCardActionSheet> {
+class _MinedCardActionDialogState extends State<_MinedCardActionDialog> {
   bool _busy = false;
 
   Future<void> _runMineNew() async {
@@ -133,72 +153,80 @@ class _MinedCardActionSheetState extends State<_MinedCardActionSheet> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final matches = widget.matches;
-    return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(20, 4, 20, 4),
-            child: Text(t.anki_mined_card_title,
-                style: theme.textTheme.titleMedium),
-          ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
-            child: Text(
+    // 窄屏（手机）时不硬撑 420，取可用宽度的九成，避免对话框横向溢出。
+    final double width = MediaQuery.sizeOf(context).width * 0.9 < 420
+        ? MediaQuery.sizeOf(context).width * 0.9
+        : 420;
+    return AlertDialog(
+      title: Text(t.anki_mined_card_title),
+      content: SizedBox(
+        width: width,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
               matches.length > 1
                   ? t.anki_mined_multiple_matches(count: matches.length)
                   : t.anki_mined_card_subtitle,
               style: theme.textTheme.bodySmall,
             ),
-          ),
-          const Divider(height: 1),
-          Flexible(
-            child: ListView.builder(
-              shrinkWrap: true,
-              itemCount: matches.length,
-              itemBuilder: (context, i) {
-                final note = matches[i];
-                final preview =
-                    note.preview.isEmpty ? '#${note.noteId}' : note.preview;
-                return ListTile(
-                  title: Text(preview,
-                      maxLines: 2, overflow: TextOverflow.ellipsis),
-                  trailing: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      IconButton(
-                        tooltip: t.anki_mined_action_overwrite,
-                        icon: const Icon(Icons.edit_outlined),
-                        onPressed:
-                            _busy ? null : () => _runOverwrite(note.noteId),
-                      ),
-                      IconButton(
-                        tooltip: t.anki_mined_action_view,
-                        icon: const Icon(Icons.open_in_new),
-                        onPressed: _busy ? null : () => _viewNote(note.noteId),
-                      ),
-                    ],
-                  ),
-                  onTap: _busy ? null : () => _viewNote(note.noteId),
-                );
-              },
+            const SizedBox(height: 12),
+            // AlertDialog 的 content 拿到的是**有界**高度（Dialog 已按屏幕减 inset 收口），
+            // 故此处 Flexible + shrinkWrap 列表安全：命中少时按内容高，多时自身滚动。
+            Flexible(
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: matches.length,
+                itemBuilder: (context, i) {
+                  final note = matches[i];
+                  final preview =
+                      note.preview.isEmpty ? '#${note.noteId}' : note.preview;
+                  return ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(preview,
+                        maxLines: 2, overflow: TextOverflow.ellipsis),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        IconButton(
+                          tooltip: t.anki_mined_action_overwrite,
+                          icon: const Icon(Icons.edit_outlined),
+                          onPressed:
+                              _busy ? null : () => _runOverwrite(note.noteId),
+                        ),
+                        IconButton(
+                          tooltip: t.anki_mined_action_view,
+                          icon: const Icon(Icons.open_in_new),
+                          onPressed:
+                              _busy ? null : () => _viewNote(note.noteId),
+                        ),
+                      ],
+                    ),
+                    onTap: _busy ? null : () => _viewNote(note.noteId),
+                  );
+                },
+              ),
             ),
-          ),
-          const Divider(height: 1),
-          ListTile(
-            leading: const Icon(Icons.add),
-            title: Text(t.anki_mined_action_add_duplicate),
-            enabled: !_busy,
-            onTap: _busy ? null : _runMineNew,
-          ),
-          if (_busy)
-            const Padding(
-              padding: EdgeInsets.all(12),
-              child: LinearProgressIndicator(),
-            ),
-        ],
+            if (_busy)
+              const Padding(
+                padding: EdgeInsets.only(top: 12),
+                child: LinearProgressIndicator(),
+              ),
+          ],
+        ),
       ),
+      actions: [
+        TextButton(
+          onPressed: _busy ? null : () => Navigator.of(context).pop(),
+          child: Text(t.dialog_cancel),
+        ),
+        FilledButton.tonalIcon(
+          onPressed: _busy ? null : _runMineNew,
+          icon: const Icon(Icons.add),
+          label: Text(t.anki_mined_action_add_duplicate),
+        ),
+      ],
     );
   }
 }
@@ -353,6 +381,12 @@ class _AnkiNoteViewerDialogState extends State<_AnkiNoteViewerDialog> {
 ///   - 有命中 → 弹 [showAnkiMinedCardActionSheet] 让用户选（覆写哪张 / 新增重复卡 /
 ///     查看·在 Anki 中打开）。
 /// 返回值映射成 popup.js 用的 (ankiConnect, noteId) 元组，由调用方包成 MinePopupResult。
+///
+/// BUG-1040：[runHidden] 由宿主页面传入，用来在**对话框可见期间**把查词弹窗停靠屏外
+/// （原生平台视图 airspace 会盖住对话框，见 [LookupPopupHiddenRunner]）。刻意只包住
+/// 对话框那一段、不包 [BaseAnkiRepository.findMatchingNotes]——反查是网络往返，Anki
+/// 不可达时会一直等到超时，若连它一起藏就会出现「弹窗凭空消失好几秒又回来、期间什么
+/// 都没弹」的空窗。
 Future<AnkiCardMutationResult> runAnkiMinedCardAction({
   required BuildContext context,
   required BaseAnkiRepository repo,
@@ -360,6 +394,7 @@ Future<AnkiCardMutationResult> runAnkiMinedCardAction({
   required String reading,
   required Future<AnkiCardMutationResult> Function() mineNew,
   required Future<AnkiCardMutationResult> Function(int noteId) overwrite,
+  LookupPopupHiddenRunner? runHidden,
 }) async {
   final matches = await repo.findMatchingNotes(expression, reading);
   if (matches.isEmpty) {
@@ -370,12 +405,15 @@ Future<AnkiCardMutationResult> runAnkiMinedCardAction({
   if (!context.mounted) {
     return const (ankiConnect: false, noteId: null);
   }
-  final result = await showAnkiMinedCardActionSheet(
-    context: context,
-    matches: matches,
-    repo: repo,
-    mineNew: mineNew,
-    overwrite: overwrite,
+  final LookupPopupHiddenRunner hide = runHidden ?? _runDirect;
+  final result = await hide<AnkiMinedCardActionResult>(
+    () => showAnkiMinedCardActionSheet(
+      context: context,
+      matches: matches,
+      repo: repo,
+      mineNew: mineNew,
+      overwrite: overwrite,
+    ),
   );
   return (ankiConnect: result.ankiConnect, noteId: result.noteId);
 }
@@ -393,6 +431,7 @@ Future<void> openMinedCardInAnki({
   required BaseAnkiRepository repo,
   required String expression,
   required String reading,
+  LookupPopupHiddenRunner? runHidden,
 }) async {
   final matches = await repo.findMatchingNotes(expression, reading);
   if (matches.isEmpty) {
@@ -407,21 +446,26 @@ Future<void> openMinedCardInAnki({
     return;
   }
   if (!context.mounted) return;
-  await showAnkiOpenNotePicker(context: context, matches: matches, repo: repo);
+  // BUG-1040：与 [runAnkiMinedCardAction] 同理——选择框也是 Flutter 层，需宿主让位。
+  final LookupPopupHiddenRunner hide = runHidden ?? _runDirect;
+  await hide<void>(
+    () =>
+        showAnkiOpenNotePicker(context: context, matches: matches, repo: repo),
+  );
 }
 
 /// TODO-1360：同词命中多张卡时的轻量选择——只列预览行，点任意一张在 Anki 中打开。
 /// 不带覆写/新增（那是点 ✓ 的职责），保持本入口「查找并打开」单一语义。
+/// BUG-1040：与 [showAnkiMinedCardActionSheet] 同步改为居中对话框（同族模态选择，
+/// 不该一个居中一个贴底沿）。
 Future<void> showAnkiOpenNotePicker({
   required BuildContext context,
   required List<MinedNoteRef> matches,
   required BaseAnkiRepository repo,
 }) {
-  return showModalBottomSheet<void>(
+  return showAppDialog<void>(
     context: context,
-    isScrollControlled: true,
-    showDragHandle: true,
-    builder: (sheetContext) => _OpenNotePicker(matches: matches, repo: repo),
+    builder: (dialogContext) => _OpenNotePicker(matches: matches, repo: repo),
   );
 }
 
@@ -456,48 +500,54 @@ class _OpenNotePickerState extends State<_OpenNotePicker> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final matches = widget.matches;
-    return SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(20, 4, 20, 4),
-            child: Text(t.anki_mined_card_title,
-                style: theme.textTheme.titleMedium),
-          ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
-            child: Text(
+    final double width = MediaQuery.sizeOf(context).width * 0.9 < 420
+        ? MediaQuery.sizeOf(context).width * 0.9
+        : 420;
+    return AlertDialog(
+      title: Text(t.anki_mined_card_title),
+      content: SizedBox(
+        width: width,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
               t.anki_mined_multiple_matches(count: matches.length),
               style: theme.textTheme.bodySmall,
             ),
-          ),
-          const Divider(height: 1),
-          Flexible(
-            child: ListView.builder(
-              shrinkWrap: true,
-              itemCount: matches.length,
-              itemBuilder: (context, i) {
-                final note = matches[i];
-                final preview =
-                    note.preview.isEmpty ? '#${note.noteId}' : note.preview;
-                return ListTile(
-                  title: Text(preview,
-                      maxLines: 2, overflow: TextOverflow.ellipsis),
-                  trailing: const Icon(Icons.open_in_new),
-                  onTap: _busy ? null : () => _open(note.noteId),
-                );
-              },
+            const SizedBox(height: 12),
+            Flexible(
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: matches.length,
+                itemBuilder: (context, i) {
+                  final note = matches[i];
+                  final preview =
+                      note.preview.isEmpty ? '#${note.noteId}' : note.preview;
+                  return ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(preview,
+                        maxLines: 2, overflow: TextOverflow.ellipsis),
+                    trailing: const Icon(Icons.open_in_new),
+                    onTap: _busy ? null : () => _open(note.noteId),
+                  );
+                },
+              ),
             ),
-          ),
-          if (_busy)
-            const Padding(
-              padding: EdgeInsets.all(12),
-              child: LinearProgressIndicator(),
-            ),
-        ],
+            if (_busy)
+              const Padding(
+                padding: EdgeInsets.only(top: 12),
+                child: LinearProgressIndicator(),
+              ),
+          ],
+        ),
       ),
+      actions: [
+        TextButton(
+          onPressed: _busy ? null : () => Navigator.of(context).pop(),
+          child: Text(t.dialog_cancel),
+        ),
+      ],
     );
   }
 }

--- a/hibiki/lib/src/pages/base_source_page.dart
+++ b/hibiki/lib/src/pages/base_source_page.dart
@@ -681,9 +681,10 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
     // BUG-135 parking + Visibility 几何收口在 [parkedPopupLayer]。
     return parkedPopupLayer(
       pos: pos,
-      // BUG-797：「选择句子上下文」原生对话框打开期间把弹窗停靠屏外，否则原生平台视图
+      // BUG-797 / BUG-1040：任何「必须盖住弹窗」的 Flutter 对话框（选择句子上下文 /
+      // 已制卡动作 / 打开卡片选择）期间把弹窗停靠屏外，否则原生平台视图
       // （WebView2 / Android platform view）盖住 showAppDialog 弹的对话框（层级不对）。
-      visible: item.visible && !_sentenceContextDialogOpen,
+      visible: item.visible && _popupHidingDialogDepth == 0,
       screen: screen,
       child: DictionaryPopupLayer(
         result: item.result,
@@ -807,13 +808,32 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
     );
   }
 
-  /// BUG-797：「制卡·选择句子上下文」原生对话框打开期间置真。查词弹窗是**原生平台视图**
-  /// （桌面 WebView2 / Android platform view），总画在 Flutter overlay 之上——`showAppDialog`
-  /// 弹的对话框在 Flutter overlay 层，会被原生弹窗**盖住**（用户报「层级不对」，对话框被词典
-  /// 弹窗遮住右半边）。对话框期间据此把弹窗 [parkedPopupLayer] 的 `visible` 强制翻假 → 弹窗
-  /// 停靠到屏外（[parkedPopupLayer] 的 BUG-135 停靠语义，webview 仍存活、确认制卡回点照常），
-  /// 让对话框独占屏幕；关闭后复原。
-  bool _sentenceContextDialogOpen = false;
+  /// BUG-797 / BUG-1040：有多少个「必须盖住查词弹窗」的 Flutter 对话框正开着。
+  ///
+  /// 查词弹窗是**原生平台视图**（桌面 WebView2 / Android platform view），总画在 Flutter
+  /// overlay 之上——`showAppDialog` 弹的对话框在 Flutter overlay 层，会被原生弹窗**盖住**
+  /// （用户报「层级不对」，对话框被词典弹窗遮住）。这些对话框期间据此把弹窗
+  /// [parkedPopupLayer] 的 `visible` 强制翻假 → 弹窗停靠到屏外（[parkedPopupLayer] 的
+  /// BUG-135 停靠语义，webview 仍存活、确认制卡回点照常），让对话框独占屏幕；关闭后复原。
+  ///
+  /// BUG-1040 从 bool 改成**计数**：已制卡动作对话框里还能再叠一层 note viewer 对话框，
+  /// 用 bool 会被内层 `finally` 提前复位、外层对话框当场被弹窗盖回去。计数支持嵌套。
+  int _popupHidingDialogDepth = 0;
+
+  /// BUG-1040：在 [body] 执行期间把查词弹窗停靠屏外的统一入口（收口 setState 增减，
+  /// 杜绝各调用点各写一份 try/finally 漏复位）。[body] 抛错时照常复位。
+  // 类型参数用 R（本 State 类自身已有类型参数 T，避免遮蔽）。
+  Future<R> runWithLookupPopupHidden<R>(Future<R> Function() body) async {
+    if (mounted) setState(() => _popupHidingDialogDepth++);
+    try {
+      return await body();
+    } finally {
+      if (mounted) {
+        setState(() => _popupHidingDialogDepth =
+            _popupHidingDialogDepth > 0 ? _popupHidingDialogDepth - 1 : 0);
+      }
+    }
+  }
 
   /// BUG-763/766：弹窗点某词条「调整上下文」→ 弹 **app 原生顶层对话框**
   /// （[SentenceContextDialog]，不再画在查词弹窗 WebView 内——那受弹窗表面尺寸/半透明
@@ -829,9 +849,8 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
     required String matched,
   }) async {
     if (!mounted) return;
-    setState(() => _sentenceContextDialogOpen = true);
-    try {
-      await showAppDialog<void>(
+    await runWithLookupPopupHidden<void>(
+      () => showAppDialog<void>(
         context: context,
         builder: (_) => SentenceContextDialog(
           matched: matched,
@@ -840,10 +859,8 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
           onConfirm: () =>
               webViewKey.currentState?.mineEntryByIndex(entryIndex),
         ),
-      );
-    } finally {
-      if (mounted) setState(() => _sentenceContextDialogOpen = false);
-    }
+      ),
+    );
   }
 
   /// TODO-058：某弹窗层 WebView 渲染完成（`popupRendered`）。先把挂起的冷层翻为
@@ -1121,6 +1138,8 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
         final res = await onUpdateFromPopup(noteId, fields);
         return (ankiConnect: res.ankiConnect, noteId: res.noteId);
       },
+      // BUG-1040：对话框期间停靠查词弹窗，否则原生平台视图盖住它（用户报「看不见」）。
+      runHidden: runWithLookupPopupHidden,
     );
     return MinePopupResult(ankiConnect: r.ankiConnect, noteId: r.noteId);
   }
@@ -1135,6 +1154,8 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
       repo: repo,
       expression: expression,
       reading: reading,
+      // BUG-1040：多卡选择框同样是 Flutter 层，期间停靠弹窗。
+      runHidden: runWithLookupPopupHidden,
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -200,7 +200,8 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
         // TODO-1650 制卡媒体清晰度：媒体清晰度与「卡片带哪些标签」语义无关，单独占
         // 一个无标题区，紧随默认标签区之后。无条件显示（与标签区一致，不藏在
         // `uiState.isConfigured` 门控里）。图片/GIF 清晰度与音频质量各是一个独立滑块
-        // （替代旧的单一「压缩」开关）：越高越清晰、体积越大；满档=原片（源分辨率/帧率）。
+        // （替代旧的单一「压缩」开关）：越高越清晰、体积越大；满档=最高（截图原图直通，
+        // GIF 封顶——BUG-1039）。
         AdaptiveSettingsSection(
           children: [
             _buildMiningImageQualityRow(),
@@ -213,14 +214,17 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
   }
 
   /// TODO-1650 图片/GIF 清晰度滑块（4 档 0..3，透传 [AppModel.miningImageQuality]）。
-  /// 只管截图分辨率/质量 + GIF 帧率/宽度；满档=原片（源分辨率+源帧率）。滑块值即档位下标，
+  /// 只管截图分辨率/质量 + GIF 帧率/宽度；满档=最高（截图原图直通，GIF 封顶）。滑块值即档位下标，
   /// `divisions/step=1` 让它按档吸附，`readout`/`label` 显示当前档名。
   Widget _buildMiningImageQualityRow() {
     final List<String> labels = <String>[
       t.mining_image_quality_thrift,
       t.mining_image_quality_standard,
       t.mining_image_quality_hd,
-      t.mining_image_quality_native,
+      // BUG-1039：满档过去叫「原片」，但它对 GIF 已不是源分辨率/源帧率（见
+      // [MiningMediaCompression.imageTiers]），只有截图仍是原图直通——名不副实，
+      // 改叫「最高」：只承诺是滑块顶格，不承诺具体保真度。
+      t.mining_image_quality_max,
     ];
     final int tier = appModel.miningImageQuality.clamp(0, labels.length - 1);
     return AdaptiveSettingsSliderRow(
@@ -242,12 +246,14 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
   }
 
   /// TODO-1650 音频质量滑块（3 档 0..2，透传 [AppModel.miningAudioQuality]）。只管句子/cue
-  /// 音频声道 + 比特率；满档=原片（立体声 192k）。
+  /// 音频声道 + 比特率；满档=最高（立体声 192k）。
   Widget _buildMiningAudioQualityRow() {
     final List<String> labels = <String>[
       t.mining_audio_quality_standard,
       t.mining_audio_quality_high,
-      t.mining_audio_quality_native,
+      // BUG-1039：满档过去也叫「原片」，但 192k 立体声 AAC 是有损重编码、不是原片；
+      // 与图片滑块统一改叫「最高」（只承诺是滑块顶格）。
+      t.mining_audio_quality_max,
     ];
     final int tier = appModel.miningAudioQuality.clamp(0, labels.length - 1);
     return AdaptiveSettingsSliderRow(

--- a/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -95,15 +95,35 @@ mixin DictionaryPageMixin {
   Future<Map<String, Object?>> Function()?
       get onSentenceContextPreviewToDraft => null;
 
+  /// BUG-797 / BUG-1040：有多少个「必须盖住查词弹窗」的 Flutter 对话框正开着。
+  ///
+  /// 查词弹窗是**原生平台视图**（桌面 WebView2 / Android platform view），靠 airspace 永远
+  /// 画在 Flutter overlay 之上——任何 `showAppDialog` 弹出来的对话框都会被它盖住（用户报
+  /// 「层级不对/看不见」）。这些对话框期间据此把弹窗 [parkedPopupLayer] 的 `visible` 强制
+  /// 翻假 → 停靠屏外（BUG-135 停靠语义，webview 仍存活、回点制卡照常），让对话框独占屏幕。
+  ///
+  /// BUG-1040 从 bool 改成**计数**：制卡动作对话框里还能再叠一层 note viewer 对话框，用
+  /// bool 会被内层的 `finally` 提前复位、外层对话框当场被弹窗盖住。计数天然支持嵌套。
+  int _popupHidingDialogDepth = 0;
+
+  /// BUG-1040：在 [body] 执行期间把查词弹窗停靠屏外的统一入口（收口 setState 增减，杜绝
+  /// 各调用点各写一份 try/finally 漏复位）。[body] 抛错时照常复位。
+  Future<T> runWithLookupPopupHidden<T>(Future<T> Function() body) async {
+    if (mounted) setState(() => _popupHidingDialogDepth++);
+    try {
+      return await body();
+    } finally {
+      if (mounted) {
+        setState(() => _popupHidingDialogDepth =
+            _popupHidingDialogDepth > 0 ? _popupHidingDialogDepth - 1 : 0);
+      }
+    }
+  }
+
   /// BUG-763/766：视频/首页车道点某词条「调整上下文」→ 弹 **app 原生顶层对话框**
   /// （[SentenceContextDialog]，不再画在查词弹窗 WebView 内）。复用视频覆写的
   /// [onSentenceContextPreviewToDraft]/[onSetSentenceContextToDraft] 驱动预览+增减；
   /// 「确认制卡」回 [webViewKey] 那层弹窗精确点中第 [entryIndex] 个词条制卡按钮。
-  /// BUG-797：「制卡·选择句子上下文」原生对话框打开期间置真。查词弹窗是原生平台视图，总
-  /// 画在 Flutter overlay 之上，会盖住 showAppDialog 弹的对话框（层级不对）。对话框期间据此
-  /// 把弹窗 [parkedPopupLayer] 的 `visible` 强制翻假 → 停靠屏外，让对话框独占屏幕；关闭后复原。
-  bool _sentenceContextDialogOpen = false;
-
   Future<void> _openSentenceContextDialogForVideo({
     required GlobalKey<DictionaryPopupWebViewState> webViewKey,
     required int entryIndex,
@@ -114,9 +134,8 @@ mixin DictionaryPageMixin {
     final Future<int> Function(int, int)? setter = onSetSentenceContextToDraft;
     if (preview == null || setter == null) return;
     // BUG-797：对话框期间把弹窗 WebView 停靠屏外，否则原生平台视图盖住对话框。
-    setState(() => _sentenceContextDialogOpen = true);
-    try {
-      await showAppDialog<void>(
+    await runWithLookupPopupHidden<void>(
+      () => showAppDialog<void>(
         context: context,
         builder: (_) => SentenceContextDialog(
           matched: matched,
@@ -125,10 +144,8 @@ mixin DictionaryPageMixin {
           onConfirm: () =>
               webViewKey.currentState?.mineEntryByIndex(entryIndex),
         ),
-      );
-    } finally {
-      setState(() => _sentenceContextDialogOpen = false);
-    }
+      ),
+    );
   }
 
   // 今日统计 dateKey 走 stat_activity 的权威实现（statTodayKey），不在此重复格式化。
@@ -396,6 +413,8 @@ mixin DictionaryPageMixin {
         final res = await onUpdateEntry(noteId, fields);
         return (ankiConnect: res.ankiConnect, noteId: res.noteId);
       },
+      // BUG-1040：对话框期间停靠查词弹窗，否则原生平台视图盖住它（用户报「看不见」）。
+      runHidden: runWithLookupPopupHidden,
     );
     return MinePopupResult(ankiConnect: r.ankiConnect, noteId: r.noteId);
   }
@@ -410,6 +429,8 @@ mixin DictionaryPageMixin {
       repo: repo,
       expression: expression,
       reading: reading,
+      // BUG-1040：多卡选择框同样是 Flutter 层，期间停靠弹窗。
+      runHidden: runWithLookupPopupHidden,
     );
   }
 
@@ -587,8 +608,9 @@ mixin DictionaryPageMixin {
       // 身份钉住整层，让元素真正搬位而不是拆建原生表面。
       key: ObjectKey(entry),
       pos: pos,
-      // BUG-797：「选择句子上下文」原生对话框打开期间把弹窗停靠屏外，否则原生平台视图盖住对话框。
-      visible: entry.visible && !_sentenceContextDialogOpen,
+      // BUG-797 / BUG-1040：任何「必须盖住弹窗」的 Flutter 对话框（选择句子上下文 /
+      // 已制卡动作 / 打开卡片选择）期间把弹窗停靠屏外，否则原生平台视图盖住对话框。
+      visible: entry.visible && _popupHidingDialogDepth == 0,
       screen: screen,
       child: DictionaryPopupLayer(
         result: entry.result,

--- a/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
+++ b/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
@@ -194,15 +194,15 @@ Future<String?> materializeRemoteAudioViaRangeDownload({
 ///
 /// 由两个用户可调的清晰度滑块组装（各是独立有序档位，替代旧的单一「压缩」开关）：
 /// - **图片/GIF 清晰度**（`AppModel.miningImageQuality`，4 档 0..3）：只管截图分辨率/
-///   JPEG 质量 + GIF 帧率/宽度。见 [imageTiers]。满档 [imageTierNative]=原片（截图不缩、
-///   原图直通；GIF 源分辨率+源帧率），最省档 0 更小更省流。默认档 [defaultImageTier]=1
-///   与旧「压缩档」逐字节一致——零行为破坏。
+///   JPEG 质量 + GIF 帧率/宽度。见 [imageTiers]。满档 [imageTierMax]=**最高**（截图不缩、
+///   原图直通；GIF 走封顶档，非源分辨率/源帧率——BUG-1039），最省档 0 更小更省流。
+///   默认档 [defaultImageTier]=1 与旧「压缩档」逐字节一致——零行为破坏。
 /// - **音频质量**（`AppModel.miningAudioQuality`，3 档 0..2）：只管句子/cue 音频声道 +
 ///   比特率。见 [audioTiers]。默认档 [defaultAudioTier]=0 = 旧压缩档（单声道 64k）。
 ///
 /// 不可变值对象（纯数据，可单测、可在隔离中构造）。各底层纯函数（[buildFfmpegClipArgs]
 /// / [buildFfmpegClipGifArgs] / [downsampleCardScreenshot]）仍接收原始可选参数，本类只是
-/// 调用点选档时的参数捆绑，不让纯函数读全局偏好。原片档用 [screenshotMaxLongEdge] == 0
+/// 调用点选档时的参数捆绑，不让纯函数读全局偏好。最高档用 [screenshotMaxLongEdge] == 0
 /// 表示「不缩放」（截图原图直通），由底层纯函数解读；**GIF 侧没有 0 哨兵档**（BUG-1039，
 /// 见 [imageTiers]），任何档位的 [gifFps]/[gifWidth] 都是有限值。
 class MiningMediaCompression {
@@ -221,25 +221,29 @@ class MiningMediaCompression {
   /// 音频比特率（`-b:a`，如 `'64k'`）。
   final String audioBitrate;
 
-  /// cue 封面 GIF 帧率（`fps=`）。**0 = 源帧率**（原片档，不加 fps 滤镜）。
+  /// cue 封面 GIF 帧率（`fps=`）。**0 = 源帧率**（不加 fps 滤镜）。BUG-1039 后已无档位
+  /// 产出 0——GIF 侧全档有限值；纯函数仍支持 0 供直接调用方使用。
   final int gifFps;
 
-  /// cue 封面 GIF 宽度（`scale=W:-2`）。**0 = 源分辨率**（原片档，不加 scale 滤镜）。
+  /// cue 封面 GIF 宽度（`scale=W:-2`）。**0 = 源分辨率**（不加 scale 滤镜）。同上，
+  /// BUG-1039 后已无档位产出 0。
   final int gifWidth;
 
-  /// 帧截图封面降采样长边（px）。**0 = 不缩放**（原片档，原图字节直通）。
+  /// 帧截图封面降采样长边（px）。**0 = 不缩放**（最高档，原图字节直通）。
   final int screenshotMaxLongEdge;
 
-  /// 帧截图封面重编码 JPEG 质量（0–100）。原片档不重编码，此值不生效。
+  /// 帧截图封面重编码 JPEG 质量（0–100）。最高档不重编码，此值不生效。
   final int screenshotQuality;
 
-  /// 图片/GIF 清晰度有序档位（索引 0..[imageTierNative]）：低→高。
+  /// 图片/GIF 清晰度有序档位（索引 0..[imageTierMax]）：低→高。
   /// 档 1 = 旧「压缩档」（1000px/q90/GIF 480px·8fps），逐字节保持现状。
   /// 档 2 = 旧「高保真档」（2000px/q95/GIF 720px·12fps）。
-  /// 档 3 = 原片：**截图**不缩、原图直通（`maxLongEdge` 用 0 哨兵）；**GIF** 走
-  /// [gifNativeFps]/[gifNativeWidth] 的封顶档，见下方 BUG-1039 说明。
+  /// 档 3 = **最高**（UI 文案 `mining_image_quality_max`）：**截图**不缩、原图直通
+  /// （`maxLongEdge` 用 0 哨兵）；**GIF** 走 [gifMaxTierFps]/[gifMaxTierWidth] 的封顶档。
+  /// BUG-1039 前这一档叫「原片」，但它对 GIF 已不再是源分辨率/源帧率——只有截图仍是
+  /// 原图，故改名为「最高」：只承诺是滑块顶格，不承诺具体保真度。
   ///
-  /// BUG-1039：原片档过去对 GIF 也用 0 哨兵（源分辨率 + 源帧率），这是把「截图」的
+  /// BUG-1039：这一档过去对 GIF 也用 0 哨兵（源分辨率 + 源帧率），这是把「截图」的
   /// 语义错套到「动图」上——截图原图直通只是几 MB 的一张 JPEG，而 GIF 是 8-bit 调色板
   /// 逐帧 LZW、**无帧间压缩**，「源分辨率+源帧率」必然线性爆炸。1080p 源、**4 秒**字幕
   /// 区间实测：标准档(480/8) 1.5 秒 / 1.5 MB，原片档(0/0) **48.9 秒 / 54 MB**；cue 上限
@@ -255,24 +259,25 @@ class MiningMediaCompression {
     (gifFps: 8, gifWidth: 480, maxLongEdge: 1000, quality: 90), // 1 标准（默认=旧压缩档）
     (gifFps: 12, gifWidth: 720, maxLongEdge: 2000, quality: 95), // 2 高清（=旧高保真档）
     (
-      gifFps: gifNativeFps,
-      gifWidth: gifNativeWidth,
+      gifFps: gifMaxTierFps,
+      gifWidth: gifMaxTierWidth,
       maxLongEdge: 0,
       quality: 100
-    ), // 3 原片（截图原图直通；GIF 封顶，BUG-1039）
+    ), // 3 最高（截图原图直通；GIF 封顶，BUG-1039）
   ];
 
-  /// BUG-1039：原片档 GIF 的封顶帧率 / 宽度。GIF 无帧间压缩，不存在可用的「源分辨率+
+  /// BUG-1039：最高档 GIF 的封顶帧率 / 宽度。GIF 无帧间压缩，不存在可用的「源分辨率+
   /// 源帧率」档；这两个值是「仍明显优于高清档、且体积与耗时可控」的实测折中。
-  static const int gifNativeFps = 12;
-  static const int gifNativeWidth = 960;
+  static const int gifMaxTierFps = 12;
+  static const int gifMaxTierWidth = 960;
 
   /// 音频质量有序档位（索引 0..2）：低→高。
-  /// 档 0 = 旧压缩档（单声道 64k），档 1 = 旧高保真档（立体声 128k），档 2 = 原片（立体声 192k）。
+  /// 档 0 = 旧压缩档（单声道 64k），档 1 = 旧高保真档（立体声 128k），档 2 = 最高（立体声
+  /// 192k）。BUG-1039 前档 2 叫「原片」，但 192k AAC 是有损重编码、并非原片，故一并改名。
   static const List<({int channels, String bitrate})> audioTiers = [
     (channels: 1, bitrate: '64k'), // 0 标准（默认=旧压缩档）
     (channels: 2, bitrate: '128k'), // 1 高音质（=旧高保真档）
-    (channels: 2, bitrate: '192k'), // 2 原片
+    (channels: 2, bitrate: '192k'), // 2 最高
   ];
 
   static const int imageTierCount = 4;
@@ -284,8 +289,8 @@ class MiningMediaCompression {
   /// 默认音频档（= 旧压缩档，单声道 64k）。
   static const int defaultAudioTier = 0;
 
-  /// 满档索引（原片，供 UI / 调用点判定「原片」语义）。
-  static const int imageTierNative = imageTierCount - 1;
+  /// 满档索引（最高档，供 UI / 调用点判定「滑块顶格」语义）。
+  static const int imageTierMax = imageTierCount - 1;
 
   static int _clampImageTier(int tier) =>
       tier < 0 ? 0 : (tier >= imageTierCount ? imageTierCount - 1 : tier);
@@ -935,7 +940,7 @@ List<String> buildFfmpegClipGifArgs({
   final int clampedDur =
       rawDur > maxDurationMs ? maxDurationMs : (rawDur < 1 ? 1 : rawDur);
   final double durationSeconds = clampedDur / 1000.0;
-  // 原片档（清晰度滑块满档）用 [fps]<=0 / [width]<=0 表示「源帧率 / 源分辨率」：
+  // [fps]<=0 / [width]<=0 表示「源帧率 / 源分辨率」（BUG-1039 后无档位再传 0，仅供直接调用方）：
   // 对应滤镜前缀整段省略（不降帧、不缩放），仅保留 palettegen/paletteuse 双遍避免抖动。
   final StringBuffer pre = StringBuffer();
   if (fps > 0) pre.write('fps=$fps,');

--- a/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
+++ b/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
@@ -202,8 +202,9 @@ Future<String?> materializeRemoteAudioViaRangeDownload({
 ///
 /// 不可变值对象（纯数据，可单测、可在隔离中构造）。各底层纯函数（[buildFfmpegClipArgs]
 /// / [buildFfmpegClipGifArgs] / [downsampleCardScreenshot]）仍接收原始可选参数，本类只是
-/// 调用点选档时的参数捆绑，不让纯函数读全局偏好。原片档用 [gifFps]/[gifWidth]/
-/// [screenshotMaxLongEdge] == 0 表示「源帧率 / 源分辨率 / 不缩放」，由底层纯函数解读。
+/// 调用点选档时的参数捆绑，不让纯函数读全局偏好。原片档用 [screenshotMaxLongEdge] == 0
+/// 表示「不缩放」（截图原图直通），由底层纯函数解读；**GIF 侧没有 0 哨兵档**（BUG-1039，
+/// 见 [imageTiers]），任何档位的 [gifFps]/[gifWidth] 都是有限值。
 class MiningMediaCompression {
   const MiningMediaCompression({
     required this.audioChannels,
@@ -235,14 +236,36 @@ class MiningMediaCompression {
   /// 图片/GIF 清晰度有序档位（索引 0..[imageTierNative]）：低→高。
   /// 档 1 = 旧「压缩档」（1000px/q90/GIF 480px·8fps），逐字节保持现状。
   /// 档 2 = 旧「高保真档」（2000px/q95/GIF 720px·12fps）。
-  /// 档 3 = 原片（不缩 / 源分辨率 / 源帧率），用 0 哨兵表达。
+  /// 档 3 = 原片：**截图**不缩、原图直通（`maxLongEdge` 用 0 哨兵）；**GIF** 走
+  /// [gifNativeFps]/[gifNativeWidth] 的封顶档，见下方 BUG-1039 说明。
+  ///
+  /// BUG-1039：原片档过去对 GIF 也用 0 哨兵（源分辨率 + 源帧率），这是把「截图」的
+  /// 语义错套到「动图」上——截图原图直通只是几 MB 的一张 JPEG，而 GIF 是 8-bit 调色板
+  /// 逐帧 LZW、**无帧间压缩**，「源分辨率+源帧率」必然线性爆炸。1080p 源、**4 秒**字幕
+  /// 区间实测：标准档(480/8) 1.5 秒 / 1.5 MB，原片档(0/0) **48.9 秒 / 54 MB**；cue 上限
+  /// 10 秒时约 135 MB、还会撞 [extractClipGifViaFfmpeg] 的 120 秒超时。这条链路后面是
+  /// base64 + jsonEncode + POST 给 AnkiConnect，Anki 在自己主线程解析这坨 JSON → 直接
+  /// 无响应；落到卡片里每次复习都要解 54 MB GIF、AnkiWeb 也同步不上去。也就是说「GIF
+  /// 原片」不是一个更高的质量档，而是一个**在任何口径下都不可用**的配置。故档 3 对 GIF
+  /// 给出真实可用的封顶值（仍显著高于高清档：960px·12fps ≈ 高清档 1.8 倍像素，实测同一
+  /// 4 秒区间 6 秒 / 7.7 MB），截图侧的原图直通语义完全不动。
   static const List<({int gifFps, int gifWidth, int maxLongEdge, int quality})>
       imageTiers = [
     (gifFps: 6, gifWidth: 360, maxLongEdge: 720, quality: 80), // 0 省流
     (gifFps: 8, gifWidth: 480, maxLongEdge: 1000, quality: 90), // 1 标准（默认=旧压缩档）
     (gifFps: 12, gifWidth: 720, maxLongEdge: 2000, quality: 95), // 2 高清（=旧高保真档）
-    (gifFps: 0, gifWidth: 0, maxLongEdge: 0, quality: 100), // 3 原片
+    (
+      gifFps: gifNativeFps,
+      gifWidth: gifNativeWidth,
+      maxLongEdge: 0,
+      quality: 100
+    ), // 3 原片（截图原图直通；GIF 封顶，BUG-1039）
   ];
+
+  /// BUG-1039：原片档 GIF 的封顶帧率 / 宽度。GIF 无帧间压缩，不存在可用的「源分辨率+
+  /// 源帧率」档；这两个值是「仍明显优于高清档、且体积与耗时可控」的实测折中。
+  static const int gifNativeFps = 12;
+  static const int gifNativeWidth = 960;
 
   /// 音频质量有序档位（索引 0..2）：低→高。
   /// 档 0 = 旧压缩档（单声道 64k），档 1 = 旧高保真档（立体声 128k），档 2 = 原片（立体声 192k）。

--- a/hibiki/test/pages/sentence_context_dialog_zorder_guard_test.dart
+++ b/hibiki/test/pages/sentence_context_dialog_zorder_guard_test.dart
@@ -2,12 +2,19 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// BUG-797 守卫：「制卡·选择句子上下文」原生对话框（[SentenceContextDialog]，BUG-766）
-/// 打开期间，必须把查词弹窗 WebView 停靠屏外，否则**原生平台视图**（桌面 WebView2 /
-/// Android platform view，总画在 Flutter overlay 之上）盖住 `showAppDialog` 弹的对话框
-/// （用户报「层级不对」）。airspace 无头测试照不到，故用源码扫描钉死两车道接线：
-///   ① 有状态位 `_sentenceContextDialogOpen`；② 对话框打开/关闭 setState 翻真/假；
-///   ③ `parkedPopupLayer` 的 `visible` 与该状态位相与（对话框期间强制停靠屏外）。
+/// BUG-797 / BUG-1040 守卫：任何盖在查词弹窗之上的 Flutter 对话框（「制卡·选择句子
+/// 上下文」[SentenceContextDialog]、「卡片已在 Anki 中」动作对话框、「打开卡片」多卡
+/// 选择框）打开期间，必须把查词弹窗 WebView 停靠屏外，否则**原生平台视图**（桌面
+/// WebView2 / Android platform view，靠 airspace 总画在 Flutter overlay 之上）会盖住
+/// `showAppDialog` 弹的对话框（用户报「层级不对 / 看不见」）。
+///
+/// airspace 无头测试照不到，故用源码扫描钉死两车道接线：
+///   ① 有嵌套安全的计数 `_popupHidingDialogDepth`（BUG-1040 从 bool 改计数：动作对话框
+///      里还能叠一层 note viewer，bool 会被内层 finally 提前复位）；
+///   ② 有统一入口 `runWithLookupPopupHidden`，且增减都经 setState（触发重建让弹窗真移动）；
+///   ③ `parkedPopupLayer` 的 `visible` 与「计数为 0」相与（对话框期间强制停靠屏外）；
+///   ④ 三个调用点（句子上下文对话框 / runAnkiMinedCardAction / openMinedCardInAnki）
+///      都接上了该入口。
 void main() {
   String read(String rel) {
     final File f = File(rel);
@@ -16,28 +23,37 @@ void main() {
   }
 
   void assertZOrderWiring(String src, String visibleExpr, String label) {
-    expect(src.contains('_sentenceContextDialogOpen'), isTrue,
-        reason: '$label 缺对话框打开状态位');
-    // 对话框打开置真、关闭（finally）置假。
-    expect(src.contains('_sentenceContextDialogOpen = true'), isTrue,
-        reason: '$label 打开对话框必须置真（停靠弹窗）');
-    expect(src.contains('_sentenceContextDialogOpen = false'), isTrue,
-        reason: '$label 关闭对话框必须置假（复原弹窗）');
-    // parkedPopupLayer 的 visible 与状态位相与 → 对话框期间弹窗停靠屏外。
+    expect(src.contains('int _popupHidingDialogDepth = 0'), isTrue,
+        reason: '$label 缺「盖住弹窗的对话框」嵌套计数');
+    expect(
+        RegExp(r'Future<(\w+)> runWithLookupPopupHidden<\1>\(Future<\1> Function\(\) body\)')
+            .hasMatch(src),
+        isTrue,
+        reason: '$label 缺统一停靠入口 runWithLookupPopupHidden');
+    // 增减都必须经 setState，否则弹窗不会真的移动。
+    expect(src.contains('setState(() => _popupHidingDialogDepth++)'), isTrue,
+        reason: '$label 计数自增须走 setState');
+    expect(src.contains('setState(() => _popupHidingDialogDepth ='), isTrue,
+        reason: '$label 计数复位须走 setState');
+    // parkedPopupLayer 的 visible 与「无对话框」相与 → 对话框期间弹窗停靠屏外。
     expect(src.contains(visibleExpr), isTrue,
         reason:
-            '$label 的 parkedPopupLayer visible 必须与 !_sentenceContextDialogOpen 相与');
-    // 置真/置假必须经 setState（触发重建让弹窗真的移动）。
-    expect(src.contains('setState(() => _sentenceContextDialogOpen = true)'),
-        isTrue,
-        reason: '$label 置真须走 setState');
+            '$label 的 parkedPopupLayer visible 必须与 _popupHidingDialogDepth == 0 相与');
+    // 三个调用点都接上统一入口。
+    expect(src.contains('runWithLookupPopupHidden<void>('), isTrue,
+        reason: '$label 的句子上下文对话框必须走统一停靠入口');
+    expect(
+        RegExp(r'runHidden: runWithLookupPopupHidden').allMatches(src).length,
+        greaterThanOrEqualTo(2),
+        reason:
+            '$label 的 runAnkiMinedCardAction 与 openMinedCardInAnki 都须传 runHidden');
   }
 
   test('reader 车道 (base_source_page) 对话框期间停靠弹窗', () {
     final String src = read('lib/src/pages/base_source_page.dart');
     assertZOrderWiring(
       src,
-      'visible: item.visible && !_sentenceContextDialogOpen',
+      'visible: item.visible && _popupHidingDialogDepth == 0',
       'base_source_page',
     );
   });
@@ -47,8 +63,22 @@ void main() {
         read('lib/src/pages/implementations/dictionary_page_mixin.dart');
     assertZOrderWiring(
       src,
-      'visible: entry.visible && !_sentenceContextDialogOpen',
+      'visible: entry.visible && _popupHidingDialogDepth == 0',
       'dictionary_page_mixin',
     );
+  });
+
+  // BUG-1040：对话框本体必须是**居中对话框**而非底部 sheet——这是「必须当场决定」的模态
+  // 选择，贴屏幕下沿在视频页会被播放器控件/窗口边缘裁掉半截（用户附图里进度条已被切）。
+  test('已制卡动作 / 打开卡片选择都走居中对话框，不再是 bottom sheet', () {
+    final String src = read('lib/src/anki/anki_mined_card_action_sheet.dart');
+    expect(src.contains('showModalBottomSheet'), isFalse,
+        reason: '同族模态选择不得再用 bottom sheet（BUG-1040）');
+    expect(RegExp(r'showAppDialog<').allMatches(src).length,
+        greaterThanOrEqualTo(2),
+        reason: '动作对话框与打开卡片选择都须走 showAppDialog');
+    // 制卡/覆写有副作用，误触 barrier 不该丢掉整次操作。
+    expect(src.contains('barrierDismissible: false'), isTrue,
+        reason: '动作对话框须禁用 barrier 关闭');
   });
 }

--- a/hibiki/test/settings/mining_media_quality_guard_test.dart
+++ b/hibiki/test/settings/mining_media_quality_guard_test.dart
@@ -108,14 +108,16 @@ void main() {
       expect(r.audioBitrate, '64k');
     });
 
-    test('满档（图片原片 + 音频原片）= 0 哨兵 + 立体声 192k', () {
+    test('满档（图片原片 + 音频原片）= 截图 0 哨兵 + GIF 封顶 + 立体声 192k', () {
       final MiningMediaCompression r = MiningMediaCompression.resolve(
         imageTier: MiningMediaCompression.imageTierNative,
         audioTier: MiningMediaCompression.audioTierCount - 1,
       );
       expect(r.screenshotMaxLongEdge, 0, reason: '0 = 不缩放（原图直通）');
-      expect(r.gifWidth, 0, reason: '0 = 源分辨率');
-      expect(r.gifFps, 0, reason: '0 = 源帧率');
+      // BUG-1039：GIF 侧不存在「源分辨率/源帧率」档——GIF 无帧间压缩，0 哨兵会让
+      // 1080p 源的 4 秒区间涨到 54 MB / 48.9 秒，把 Anki 打成无响应。
+      expect(r.gifWidth, MiningMediaCompression.gifNativeWidth);
+      expect(r.gifFps, MiningMediaCompression.gifNativeFps);
       expect(r.audioChannels, 2);
       expect(r.audioBitrate, '192k');
     });

--- a/hibiki/test/settings/mining_media_quality_guard_test.dart
+++ b/hibiki/test/settings/mining_media_quality_guard_test.dart
@@ -110,14 +110,14 @@ void main() {
 
     test('满档（图片原片 + 音频原片）= 截图 0 哨兵 + GIF 封顶 + 立体声 192k', () {
       final MiningMediaCompression r = MiningMediaCompression.resolve(
-        imageTier: MiningMediaCompression.imageTierNative,
+        imageTier: MiningMediaCompression.imageTierMax,
         audioTier: MiningMediaCompression.audioTierCount - 1,
       );
       expect(r.screenshotMaxLongEdge, 0, reason: '0 = 不缩放（原图直通）');
       // BUG-1039：GIF 侧不存在「源分辨率/源帧率」档——GIF 无帧间压缩，0 哨兵会让
       // 1080p 源的 4 秒区间涨到 54 MB / 48.9 秒，把 Anki 打成无响应。
-      expect(r.gifWidth, MiningMediaCompression.gifNativeWidth);
-      expect(r.gifFps, MiningMediaCompression.gifNativeFps);
+      expect(r.gifWidth, MiningMediaCompression.gifMaxTierWidth);
+      expect(r.gifFps, MiningMediaCompression.gifMaxTierFps);
       expect(r.audioChannels, 2);
       expect(r.audioBitrate, '192k');
     });
@@ -182,6 +182,23 @@ void main() {
           reason: '音频滑块标题用 i18n key mining_audio_quality');
       expect(src.contains('appModel.setMiningImageQuality'), isTrue);
       expect(src.contains('appModel.setMiningAudioQuality'), isTrue);
+    });
+
+    // BUG-1039：两个滑块的满档过去都叫「原片 / Native」，但都名不副实——图片满档对 GIF
+    // 已是封顶档（只有截图仍是原图），音频满档 192k AAC 本就是有损重编码。统一改叫
+    // 「最高 / Maximum」（只承诺是滑块顶格，不承诺保真度）。钉死不许滑回旧名。
+    test('BUG-1039：两滑块满档标签是「最高」而非名不副实的「原片」', () {
+      final String src = File(
+        'lib/src/pages/implementations/anki_settings_page.dart',
+      ).readAsStringSync();
+      expect(src.contains('t.mining_image_quality_max'), isTrue,
+          reason: '图片满档标签必须用 mining_image_quality_max');
+      expect(src.contains('t.mining_audio_quality_max'), isTrue,
+          reason: '音频满档标签必须用 mining_audio_quality_max');
+      expect(src.contains('t.mining_image_quality_native'), isFalse,
+          reason: '「原片」是名不副实的旧名，不得复活');
+      expect(src.contains('t.mining_audio_quality_native'), isFalse,
+          reason: '「原片」是名不副实的旧名，不得复活');
     });
   });
 }

--- a/hibiki/test/utils/desktop_audio_clipper_test.dart
+++ b/hibiki/test/utils/desktop_audio_clipper_test.dart
@@ -1246,27 +1246,43 @@ void main() {
       expect(r.audioBitrate, h.audioBitrate);
     });
 
-    test('原片档（满档）用 0 哨兵表达源分辨率/源帧率/不缩放', () {
+    test('原片档（满档）截图用 0 哨兵不缩放，GIF 走封顶档（BUG-1039）', () {
       final MiningMediaCompression r = MiningMediaCompression.resolve(
         imageTier: MiningMediaCompression.imageTierNative,
         audioTier: MiningMediaCompression.audioTierCount - 1,
       );
-      expect(r.gifFps, 0, reason: '0 = 源帧率');
-      expect(r.gifWidth, 0, reason: '0 = 源分辨率');
-      expect(r.screenshotMaxLongEdge, 0, reason: '0 = 不缩放');
+      expect(r.screenshotMaxLongEdge, 0, reason: '0 = 不缩放（截图原图直通，语义不变）');
+      expect(r.gifFps, MiningMediaCompression.gifNativeFps);
+      expect(r.gifWidth, MiningMediaCompression.gifNativeWidth);
       expect(r.audioChannels, 2);
       expect(r.audioBitrate, '192k');
     });
 
+    // BUG-1039 回归守卫：GIF 无帧间压缩，「源分辨率+源帧率」会线性爆炸（1080p 源 4 秒
+    // 区间实测 48.9 秒 / 54 MB，Anki 收到后主线程解析直接无响应）。**任何**档位都不得
+    // 再把 0 哨兵（=不限制）传给 GIF 抽取。截图侧的 0（不缩放）不受此约束。
+    test('BUG-1039：没有任何图片档把 GIF 参数留成 0（不限制）哨兵', () {
+      for (int t = 0; t < MiningMediaCompression.imageTierCount; t++) {
+        final MiningMediaCompression c =
+            MiningMediaCompression.resolve(imageTier: t, audioTier: 0);
+        expect(c.gifFps, greaterThan(0), reason: '档 $t 的 gifFps 不得为 0（源帧率）');
+        expect(c.gifWidth, greaterThan(0),
+            reason: '档 $t 的 gifWidth 不得为 0（源分辨率）');
+      }
+    });
+
     test('图片档单调递增（清晰度越高，分辨率/质量/GIF 越大）', () {
-      // 原片档 maxLongEdge=0 是「不缩放」哨兵（语义上最大），单独排除在数值比较外。
-      for (int t = 1; t < MiningMediaCompression.imageTierNative; t++) {
+      // 原片档 maxLongEdge=0 是「不缩放」哨兵（语义上最大），单独排除在截图数值比较外；
+      // GIF 侧 BUG-1039 后全档都是有限值，故 gif 参数覆盖到满档一起校单调。
+      for (int t = 1; t < MiningMediaCompression.imageTierCount; t++) {
         final MiningMediaCompression lo =
             MiningMediaCompression.resolve(imageTier: t - 1, audioTier: 0);
         final MiningMediaCompression hi =
             MiningMediaCompression.resolve(imageTier: t, audioTier: 0);
-        expect(hi.screenshotMaxLongEdge,
-            greaterThanOrEqualTo(lo.screenshotMaxLongEdge));
+        if (t < MiningMediaCompression.imageTierNative) {
+          expect(hi.screenshotMaxLongEdge,
+              greaterThanOrEqualTo(lo.screenshotMaxLongEdge));
+        }
         expect(hi.gifWidth, greaterThanOrEqualTo(lo.gifWidth));
         expect(hi.gifFps, greaterThanOrEqualTo(lo.gifFps));
       }

--- a/hibiki/test/utils/desktop_audio_clipper_test.dart
+++ b/hibiki/test/utils/desktop_audio_clipper_test.dart
@@ -1248,12 +1248,12 @@ void main() {
 
     test('原片档（满档）截图用 0 哨兵不缩放，GIF 走封顶档（BUG-1039）', () {
       final MiningMediaCompression r = MiningMediaCompression.resolve(
-        imageTier: MiningMediaCompression.imageTierNative,
+        imageTier: MiningMediaCompression.imageTierMax,
         audioTier: MiningMediaCompression.audioTierCount - 1,
       );
       expect(r.screenshotMaxLongEdge, 0, reason: '0 = 不缩放（截图原图直通，语义不变）');
-      expect(r.gifFps, MiningMediaCompression.gifNativeFps);
-      expect(r.gifWidth, MiningMediaCompression.gifNativeWidth);
+      expect(r.gifFps, MiningMediaCompression.gifMaxTierFps);
+      expect(r.gifWidth, MiningMediaCompression.gifMaxTierWidth);
       expect(r.audioChannels, 2);
       expect(r.audioBitrate, '192k');
     });
@@ -1279,7 +1279,7 @@ void main() {
             MiningMediaCompression.resolve(imageTier: t - 1, audioTier: 0);
         final MiningMediaCompression hi =
             MiningMediaCompression.resolve(imageTier: t, audioTier: 0);
-        if (t < MiningMediaCompression.imageTierNative) {
+        if (t < MiningMediaCompression.imageTierMax) {
           expect(hi.screenshotMaxLongEdge,
               greaterThanOrEqualTo(lo.screenshotMaxLongEdge));
         }
@@ -1299,7 +1299,7 @@ void main() {
       final MiningMediaCompression over =
           MiningMediaCompression.resolve(imageTier: 99, audioTier: 99);
       final MiningMediaCompression top = MiningMediaCompression.resolve(
-        imageTier: MiningMediaCompression.imageTierNative,
+        imageTier: MiningMediaCompression.imageTierMax,
         audioTier: MiningMediaCompression.audioTierCount - 1,
       );
       expect(over.screenshotMaxLongEdge, top.screenshotMaxLongEdge);


### PR DESCRIPTION
## 用户报告

- 「这个覆盖巨慢。直接把 anki 弄无响应了」
- 「不止这里的覆盖，视频普通查词制卡也无响应」
- 「不应该是底部弹窗，应该是中间的弹窗。层级也不对，他的层级比查词弹窗的低。导致看不见」
- 「查词弹窗加载也巨慢」

## BUG-1039 · 制卡/覆盖巨慢 + Anki 无响应（根因）

`MiningMediaCompression.imageTiers[3]`（原片档）用 `0`=不限制哨兵**同时**表达「截图不缩放」和「GIF 源分辨率+源帧率」——把静态图的语义错套到动图上。截图原图直通只是一张几 MB 的 JPEG；GIF 是 8-bit 调色板逐帧 LZW、**无帧间压缩**，体积随「像素×帧数」线性爆炸。

实测（1080p 番剧源、**4 秒**字幕区间、与代码逐字一致的 ffmpeg 参数）：

| 档位 | fps/宽 | 耗时 | 体积 |
|---|---|---|---|
| 标准 tier1 | 8/480 | 1.5 s | 1.5 MB |
| 高清 tier2 | 12/720 | 4 s | 4.3 MB |
| **原片 tier3（旧，0/0）** | 源/源 | **48.9 s** | **54 MB** |
| **原片 tier3（本 PR，960/12）** | 12/960 | 6 s | 7.7 MB |

传导链：GIF → `_storeLocalMedia` 读全量字节 → base64（BUG-933 已卸到 isolate）→ `AnkiConnectService._request` 在 UI isolate `jsonEncode` 这坨 ~72 MB 字符串 → POST；**Anki 在自己主线程解析该 JSON → 无响应**。落到卡片后每次复习都要解 54 MB GIF，AnkiWeb 也同步不上去。即「GIF 原片」不是更高的质量档，而是**在任何口径下都不可用**的配置。

覆盖（`updateMinedNote`）与新建（`mineEntry`）走**同一条** `ImmersionMiningEngine` 媒体链路，所以「覆盖慢」和「普通制卡也无响应」是同一根因，不是覆盖特有。用户生产库偏好实测 `mining_image_quality=3`。

**改法**：原片档 GIF 走封顶 `gifNativeFps=12` / `gifNativeWidth=960`（新增具名常量），截图侧 `maxLongEdge: 0`（原图直通）语义完全不动。设置项说明文案同步修正（17 语言，其余 14 个本来就是未翻译的英文占位）。

## BUG-1040 · 弹窗形态 + 层级

1. **形态**：`showAnkiMinedCardActionSheet` 用 `showModalBottomSheet`，贴屏幕下沿，在视频页被播放器控件与窗口边缘裁掉半截（附图里进度条已被切）；而同族的 `showAnkiNoteViewer` / `SentenceContextDialog` 本来就是居中 `AlertDialog`。
2. **层级**：查词弹窗是**原生平台视图**（WebView2 / Android platform view），靠 airspace **永远画在 Flutter 层之上**——不是 `OverlayEntry` 顺序问题，改成根 Overlay 顶层 entry 也照样被盖。这与 BUG-797 是同一根因，但当时只给「选择句子上下文」一个对话框打了补丁，`runAnkiMinedCardAction` / `openMinedCardInAnki` 没接上。

**改法**：两个选择框都改走 `showAppDialog` 居中 `AlertDialog`（`barrierDismissible: false`——制卡/覆写有副作用，误触遮罩不该丢掉整次操作）；把 BUG-797 的单 bool 泛化成可嵌套计数 `_popupHidingDialogDepth` + 统一入口 `runWithLookupPopupHidden`，两车道四个调用点全接上。改计数是必需的：动作框里还能再叠一层 note viewer，用 bool 会被内层 `finally` 提前复位、外层当场被弹窗盖回去。刻意**只包住对话框可见那一段**、不包 `findMatchingNotes`——反查是网络往返，Anki 不可达会等到超时，一起藏就会出现「弹窗凭空消失好几秒又回来、期间什么都没弹」的空窗。

## 「查词弹窗加载也巨慢」

暂未单独立案。视频页的常驻热槽预热（BUG-094，`_seedWarmPopup` 在 controller 就绪时 seed）是接好的，每次查词冷加载不是设计行为；截图里的黑框更像是同进程被 54 MB GIF 的 ffmpeg + ~150 MB 瞬时字符串分配饿死时 WebView2 首帧被拖慢。**请在 BUG-1039 落地后复测**，若仍慢我再单独查并立案。

## 验证

- `flutter analyze` 干净。
- `flutter test` **12792 passed / 5 skipped / 1 failed**；唯一失败 `md3_design_system_static_test` 指向**未改动**的 `download_subscriptions_panel.dart`（develop `c5a7d8205` 既有红，不是本 PR 引入，`git diff --name-only origin/develop` 不含该文件）。
- 新增/扩写守卫：`desktop_audio_clipper_test`「没有任何图片档把 GIF 参数留成 0」；`sentence_context_dialog_zorder_guard_test` 钉死计数/统一入口/三个调用点/不得再用 bottom sheet。

## 待真机验证（Windows 视频页）

1. 原片档下查词 →「+」新建 / 点「✓」→ 覆盖：应从 ~49 秒回到个位数秒，Anki 不再卡死。
2. 点「✓」：对话框**居中**且完整可见；期间查词弹窗让位、关闭后回位。
3. 「在 Anki 中打开」命中多张时的选择框同理。

https://claude.ai/code/session_016W386aSdMCD8PKp6kCZKGM
