### PR TITLE
fix(dashboard): 继续卡/活动条直接续播 + 活动封面 + 底部「最近添加」通栏

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39287 (2311 per locale)
+/// Strings: 39304 (2312 per locale)
 ///
-/// Built on 2026-07-23 at 11:05 UTC
+/// Built on 2026-07-23 at 13:04 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3084,6 +3084,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String download_subscription_latest_episode({required Object episode}) =>
       'Latest queued: episode ${episode}';
   String get download_subscription_check_now => 'Check now';
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -8325,6 +8326,8 @@ class _StringsAr extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -13639,6 +13642,8 @@ class _StringsDe extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -18969,6 +18974,8 @@ class _StringsEs extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -24310,6 +24317,8 @@ class _StringsFr extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -29578,6 +29587,8 @@ class _StringsId extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -34894,6 +34905,8 @@ class _StringsIt extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -40015,6 +40028,8 @@ class _StringsJa extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -45139,6 +45154,8 @@ class _StringsKo extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -50433,6 +50450,8 @@ class _StringsNl extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -55742,6 +55761,8 @@ class _StringsPtBr extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -61034,6 +61055,8 @@ class _StringsRu extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -66271,6 +66294,8 @@ class _StringsTh extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -71540,6 +71565,8 @@ class _StringsTr extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -76796,6 +76823,8 @@ class _StringsVi extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 // Path: <root>
@@ -81682,6 +81711,8 @@ class _StringsZhCn extends _StringsEn {
       '最近加入：第 ${episode} 集';
   @override
   String get download_subscription_check_now => '立即检查';
+  @override
+  String get home_recently_added => '最近添加';
 }
 
 // Path: <root>
@@ -86721,6 +86752,8 @@ class _StringsZhHk extends _StringsEn {
       'Latest queued: episode ${episode}';
   @override
   String get download_subscription_check_now => 'Check now';
+  @override
+  String get home_recently_added => 'Recently added';
 }
 
 /// Flat map(s) containing all translations.
@@ -91439,6 +91472,8 @@ extension on _StringsEn {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -96155,6 +96190,8 @@ extension on _StringsAr {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -100892,6 +100929,8 @@ extension on _StringsDe {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -105628,6 +105667,8 @@ extension on _StringsEs {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -110370,6 +110411,8 @@ extension on _StringsFr {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -115094,6 +115137,8 @@ extension on _StringsId {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -119833,6 +119878,8 @@ extension on _StringsIt {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -124534,6 +124581,8 @@ extension on _StringsJa {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -129239,6 +129288,8 @@ extension on _StringsKo {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -133971,6 +134022,8 @@ extension on _StringsNl {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -138700,6 +138753,8 @@ extension on _StringsPtBr {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -143434,6 +143489,8 @@ extension on _StringsRu {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -148152,6 +148209,8 @@ extension on _StringsTh {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -152879,6 +152938,8 @@ extension on _StringsTr {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -157601,6 +157662,8 @@ extension on _StringsVi {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }
@@ -162287,6 +162350,8 @@ extension on _StringsZhCn {
         return ({required Object episode}) => '最近加入：第 ${episode} 集';
       case 'download_subscription_check_now':
         return '立即检查';
+      case 'home_recently_added':
+        return '最近添加';
       default:
         return null;
     }
@@ -166983,6 +167048,8 @@ extension on _StringsZhHk {
             'Latest queued: episode ${episode}';
       case 'download_subscription_check_now':
         return 'Check now';
+      case 'home_recently_added':
+        return 'Recently added';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "第 ${episode} 集之后",
   "download_subscription_last_checked": "上次检查：${time}",
   "download_subscription_latest_episode": "最近加入：第 ${episode} 集",
-  "download_subscription_check_now": "立即检查"
+  "download_subscription_check_now": "立即检查",
+  "home_recently_added": "最近添加"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2309,5 +2309,6 @@
   "download_subscription_after_episode": "After episode ${episode}",
   "download_subscription_last_checked": "Last checked: ${time}",
   "download_subscription_latest_episode": "Latest queued: episode ${episode}",
-  "download_subscription_check_now": "Check now"
+  "download_subscription_check_now": "Check now",
+  "home_recently_added": "Recently added"
 }

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -13,6 +13,8 @@ import 'package:hibiki/src/media/video/m3u8_playlist.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/pages/implementations/activity_feed.dart';
 import 'package:hibiki/src/pages/implementations/home_page.dart';
+import 'package:hibiki/src/pages/implementations/home_video_page.dart'
+    show openLocalVideoBook;
 import 'package:hibiki/src/pages/implementations/stat_shared.dart';
 import 'package:hibiki/src/sync/hibiki_client_sync_backend.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
@@ -35,10 +37,24 @@ import 'package:hibiki_core/hibiki_core.dart';
 /// （Activity）；窄屏堆叠。书与阅读位置走 Riverpod provider（响应式）；视频与活动事件在
 /// [initState] 一次性异步载入到本地状态（视频列表天然是 Future）。
 class HomeDashboardPage extends ConsumerStatefulWidget {
-  const HomeDashboardPage({super.key, required this.videoRepo});
+  const HomeDashboardPage({
+    super.key,
+    required this.videoRepo,
+    this.openVideoOverride,
+  });
 
   /// 视频库仓库：仪表盘「继续观看」与视频计数的数据源（[VideoBookRepository.listForShelf]）。
   final VideoBookRepository videoRepo;
+
+  /// 测试缝：打开本地视频播放页的实现覆盖（默认走共享 [openLocalVideoBook] 真实
+  /// 路由）。widget 测试无法构建 media_kit 播放页，注入替身即可断言「点继续卡/
+  /// 活动条 = 直接续播（带 playlistCollectionId）」的接线；生产恒 null。
+  final Future<void> Function(
+    BuildContext context,
+    VideoBookRepository repo,
+    String bookUid,
+    int? playlistCollectionId,
+  )? openVideoOverride;
 
   @override
   ConsumerState<HomeDashboardPage> createState() => _HomeDashboardPageState();
@@ -54,6 +70,7 @@ class _ContinueEntry {
     this.percent = 0,
     this.progress,
     this.collectionName,
+    this.subtitleOverride,
     this.book,
     this.video,
     this.remote,
@@ -75,6 +92,10 @@ class _ContinueEntry {
   /// 所属主合集名（显示名规则：非合集上下文标题=合集名、副标题=条目名+状态）；
   /// null = 散卡。本地条目查折叠归属映射，远端条目由 host 直接携带。
   final String? collectionName;
+
+  /// 副标题状态段的覆盖文案（「最近添加」行用「类型 · 相对时间」替代进度状态）；
+  /// null = 按 继续区 默认规则（书=「阅读 · x%」/ 视频=「观看」+ 远端设备名）。
+  final String? subtitleOverride;
   final MediaItem? book;
   final VideoBookRow? video;
 
@@ -202,6 +223,10 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
   Map<String, int> _primaryCollectionByEntry = const <String, int>{};
   Map<String, String> _bookKeyByTitle = const <String, String>{};
 
+  /// epub bookKey → 导入时刻（epoch 毫秒，`EpubBooks.importedAt`），
+  /// 「最近添加」行的书侧排序时间源（视频侧用 [VideoBookRow.importedAt]）。
+  Map<String, int> _epubImportedAtByKey = const <String, int>{};
+
   /// 每个视频 bookUid 的最近观看时刻（epoch 毫秒），继续观看排序用。
   Map<String, int> _videoWatchAtByUid = const <String, int>{};
 
@@ -273,10 +298,14 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
     final Map<String, int> primaryByEntry =
         await db.getPrimaryCollectionIdByEntry();
     // reading_statistics 行只存 title：日明细拼合集前缀需经 epub_books 反查 bookKey
-    // （阅读统计页 _collectionNameForBook 同范式）。
+    // （阅读统计页 _collectionNameForBook 同范式）。同批顺带取 importedAt 喂
+    // 「最近添加」行（一次查询两用）。
+    final List<EpubBookRow> epubRows = await db.getAllEpubBooks();
     final Map<String, String> bookKeyByTitle = <String, String>{
-      for (final EpubBookRow r in await db.getAllEpubBooks())
-        r.title: r.bookKey,
+      for (final EpubBookRow r in epubRows) r.title: r.bookKey,
+    };
+    final Map<String, int> epubImportedAtByKey = <String, int>{
+      for (final EpubBookRow r in epubRows) r.bookKey: r.importedAt,
     };
 
     // 每日「读到的字数」按来源拆三份（热力图筛选 全部/阅读/观看/游戏）：书内阅读、
@@ -349,6 +378,7 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
       _collectionNamesById = collectionNamesById;
       _primaryCollectionByEntry = primaryByEntry;
       _bookKeyByTitle = bookKeyByTitle;
+      _epubImportedAtByKey = epubImportedAtByKey;
       _videoWatchAtByUid = watchAt;
     });
     // 本地渲染先行，互联数据到达后再增量补位（不阻塞首屏）。
@@ -431,10 +461,26 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
         ref.watch(bookLastReadAtProvider).valueOrNull ?? const <String, int>{};
     final DateTime now = DateTime.now();
 
+    // 活动条封面/点击直达需要「mediaKey → 本地条目」反查映射（渲染层现算，不
+    // 落状态；书键兼容 epub bookKey 与 standalone SRT uid 两种身份）。
+    final Map<String, MediaItem> booksByKey = <String, MediaItem>{};
+    for (final MediaItem item in books) {
+      final String? key =
+          ReaderHibikiSource.parseBookKey(item.mediaIdentifier) ??
+              ReaderHibikiSource.parseSrtBookUid(item.mediaIdentifier);
+      if (key != null) booksByKey[key] = item;
+    }
+    final Map<String, VideoBookRow> videosByUid = <String, VideoBookRow>{
+      for (final VideoBookRow v in _videos) v.bookUid: v,
+    };
+
     final Widget continueCard =
         _buildContinueSection(tokens, appModel, books, lastReadByKey);
     final Widget heatmapCard = _buildHeatmapCard(tokens);
-    final Widget activityCard = _buildActivitySection(tokens, now);
+    final Widget activityCard =
+        _buildActivitySection(tokens, now, appModel, booksByKey, videosByUid);
+    final Widget? recentCard =
+        _buildRecentlyAddedSection(tokens, appModel, books, now);
 
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
@@ -469,6 +515,12 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
             heatmapCard,
             SizedBox(height: tokens.spacing.card),
             bodyBelow,
+            // 区块 4：「最近添加」横滑行，两栏下方通栏（空库不占位——用户反馈
+            // 「底部很空」的填充提案）。
+            if (recentCard != null) ...<Widget>[
+              SizedBox(height: tokens.spacing.card),
+              recentCard,
+            ],
           ],
         );
       },
@@ -581,31 +633,101 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
       ),
       child: filtered.isEmpty
           ? Text(t.home_activity_empty, style: tokens.type.metadata)
-          : SizedBox(
-              height: _kContinueRowHeight,
-              // 桌面默认 MaterialScrollBehavior 的 dragDevices 不含鼠标——横排行
-              // 用鼠标左右拖会毫无反应。显式放开 mouse/trackpad/stylus 拖动
-              // （与合集行 CollectionShelfRow 同款）；触屏行为不变。
-              child: ScrollConfiguration(
-                behavior: ScrollConfiguration.of(context).copyWith(
-                  dragDevices: <PointerDeviceKind>{
-                    PointerDeviceKind.touch,
-                    PointerDeviceKind.mouse,
-                    PointerDeviceKind.stylus,
-                    PointerDeviceKind.trackpad,
-                  },
-                ),
-                child: ListView.separated(
-                  scrollDirection: Axis.horizontal,
-                  physics: desktopAwareScrollPhysics(),
-                  itemCount: filtered.length,
-                  separatorBuilder: (BuildContext _, int __) =>
-                      SizedBox(width: tokens.spacing.gap),
-                  itemBuilder: (BuildContext context, int i) =>
-                      _buildContinueCard(tokens, appModel, filtered[i]),
-                ),
-              ),
-            ),
+          : _continueCardsRow(tokens, appModel, filtered),
+    );
+  }
+
+  /// 横滑卡片行本体（「继续」与「最近添加」共用）：定高横向 ListView。
+  Widget _continueCardsRow(
+    HibikiDesignTokens tokens,
+    AppModel appModel,
+    List<_ContinueEntry> entries,
+  ) {
+    return SizedBox(
+      height: _kContinueRowHeight,
+      // 桌面默认 MaterialScrollBehavior 的 dragDevices 不含鼠标——横排行
+      // 用鼠标左右拖会毫无反应。显式放开 mouse/trackpad/stylus 拖动
+      // （与合集行 CollectionShelfRow 同款）；触屏行为不变。
+      child: ScrollConfiguration(
+        behavior: ScrollConfiguration.of(context).copyWith(
+          dragDevices: <PointerDeviceKind>{
+            PointerDeviceKind.touch,
+            PointerDeviceKind.mouse,
+            PointerDeviceKind.stylus,
+            PointerDeviceKind.trackpad,
+          },
+        ),
+        child: ListView.separated(
+          scrollDirection: Axis.horizontal,
+          physics: desktopAwareScrollPhysics(),
+          itemCount: entries.length,
+          separatorBuilder: (BuildContext _, int __) =>
+              SizedBox(width: tokens.spacing.gap),
+          itemBuilder: (BuildContext context, int i) =>
+              _buildContinueCard(tokens, appModel, entries[i]),
+        ),
+      ),
+    );
+  }
+
+  /// 区块 4：「最近添加」横滑行（底部通栏，用户反馈「底部很空」的填充提案）：
+  /// 本地书（epub importedAt）+ 本地视频（[VideoBookRow.importedAt]）按添加时刻
+  /// 倒序混排取前 12，复用继续卡组件（不画进度条，副标题=「类型 · 相对时间」）。
+  /// 无可排条目（空库/无时间戳）返回 null 不占位。
+  Widget? _buildRecentlyAddedSection(
+    HibikiDesignTokens tokens,
+    AppModel appModel,
+    List<MediaItem> books,
+    DateTime now,
+  ) {
+    final List<_ContinueEntry> entries = <_ContinueEntry>[];
+    for (final MediaItem item in books) {
+      final String? bookKey =
+          ReaderHibikiSource.parseBookKey(item.mediaIdentifier);
+      // standalone SRT 书无 epub 导入时间戳（不在 epub_books），本轮不进最近添加。
+      final int addedMs =
+          bookKey == null ? 0 : (_epubImportedAtByKey[bookKey] ?? 0);
+      if (addedMs <= 0) continue;
+      entries.add(_ContinueEntry(
+        isVideo: false,
+        // BUG-1018 (A1)：与继续卡同一 override 显示名通道。
+        title: ReaderHibikiSource.instance.getDisplayTitleFromMediaItem(item),
+        recentMs: addedMs,
+        collectionName: statCollectionName(
+          _bookCollectionKey(item),
+          _primaryCollectionByEntry,
+          _collectionNamesById,
+        ),
+        subtitleOverride:
+            '${t.home_filter_read} · ${_relativeTimeLabel(addedMs, now)}',
+        book: item,
+      ));
+    }
+    for (final VideoBookRow v in _videos) {
+      final int addedMs = v.importedAt?.millisecondsSinceEpoch ?? 0;
+      if (addedMs <= 0) continue;
+      entries.add(_ContinueEntry(
+        isVideo: true,
+        title: v.title,
+        recentMs: addedMs,
+        collectionName: statCollectionName(
+          'video|${v.bookUid}',
+          _primaryCollectionByEntry,
+          _collectionNamesById,
+        ),
+        subtitleOverride:
+            '${t.home_filter_watch} · ${_relativeTimeLabel(addedMs, now)}',
+        video: v,
+      ));
+    }
+    if (entries.isEmpty) return null;
+    entries.sort((_ContinueEntry a, _ContinueEntry b) =>
+        b.recentMs.compareTo(a.recentMs));
+    final List<_ContinueEntry> top = entries.take(12).toList();
+    return _sectionCard(
+      tokens,
+      title: t.home_recently_added,
+      child: _continueCardsRow(tokens, appModel, top),
     );
   }
 
@@ -640,6 +762,8 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
       // 标明设备来源：优先 host 设备名（配对时存下），取不到回退通用「远端」。
       status = '$status · ${_remoteDeviceName ?? t.home_remote_source}';
     }
+    // 「最近添加」行覆盖状态段（类型 · 相对时间）；继续区恒 null 走上面默认。
+    status = entry.subtitleOverride ?? status;
     final String? collectionName = entry.collectionName;
     final String title = collectionName ?? entry.title;
     final String subtitle =
@@ -763,8 +887,10 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
     );
   }
 
-  /// 打开「继续」条目：本地书走 openMedia，视频切到视频 tab；远端条目切到对应
-  /// tab（远端占位卡在那里承接播放/下载，行为与本地视频条目的 tab 跳转一致）。
+  /// 打开「继续」条目：本地书走 openMedia，本地视频**直接续播**（用户实报点卡
+  /// 只跳视频 tab 不打开——旧竖列表残留；改走与视频页 hero 同一条打开路径，合集
+  /// 成员带 playlistCollectionId 从合集续播）；远端条目仍切到对应 tab（远端占位
+  /// 卡在那里承接播放/下载）。
   Future<void> _openContinueEntry(
     AppModel appModel,
     _ContinueEntry entry,
@@ -775,12 +901,36 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
       return;
     }
     if (entry.isVideo) {
-      homeShellTabNotifier.value = HomeTab.video;
+      await _openLocalVideo(entry.video!.bookUid);
       return;
     }
     final MediaItem item = entry.book!;
     final MediaSource source = item.getMediaSource(appModel: appModel);
     await appModel.openMedia(ref: ref, mediaSource: source, item: item);
+  }
+
+  /// 直接续播本地视频：与视频页 hero/卡片同一条共享路由入口 [openLocalVideoBook]
+  /// （合集成员带主合集 id → 播放器建剧集面板/上下集/连播；散卡单视频打开）。
+  /// 播放页关闭后无需手动刷新——lastPositionMs 落库触发 videoBooks 表级变更，
+  /// [_scheduleReload] 自动重查。测试经 [HomeDashboardPage.openVideoOverride] 注入替身。
+  Future<void> _openLocalVideo(String bookUid) async {
+    final int? playlistCollectionId =
+        _primaryCollectionByEntry['video|$bookUid'];
+    final Future<void> Function(
+      BuildContext context,
+      VideoBookRepository repo,
+      String bookUid,
+      int? playlistCollectionId,
+    ) open = widget.openVideoOverride ??
+        (BuildContext context, VideoBookRepository repo, String bookUid,
+                int? playlistCollectionId) =>
+            openLocalVideoBook(
+              context: context,
+              repo: repo,
+              bookUid: bookUid,
+              playlistCollectionId: playlistCollectionId,
+            );
+    await open(context, widget.videoRepo, bookUid, playlistCollectionId);
   }
 
   // ── 区块 3：学习活动热力图 ───────────────────────────────────────────────
@@ -1104,7 +1254,15 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
   // ── 区块 4：Activity 时间轴 ──────────────────────────────────────────────
 
   /// Activity 时间轴：顶部分类筛选 → 内存过滤 events → 纯函数聚合 → 按日期分组渲染。
-  Widget _buildActivitySection(HibikiDesignTokens tokens, DateTime now) {
+  /// [booksByKey] / [videosByUid] 是「mediaKey → 本地条目」反查映射（封面缩略 +
+  /// 点击直达用；查不到回退图标/切 tab）。
+  Widget _buildActivitySection(
+    HibikiDesignTokens tokens,
+    DateTime now,
+    AppModel appModel,
+    Map<String, MediaItem> booksByKey,
+    Map<String, VideoBookRow> videosByUid,
+  ) {
     final List<ActivityEventRow> filtered = _activityFilter == null
         ? _activityEvents
         : _activityEvents
@@ -1143,7 +1301,8 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
                 for (final ActivityDateGroup g in groups)
-                  _buildActivityGroup(tokens, g, todayKey, yesterdayKey, now),
+                  _buildActivityGroup(tokens, g, todayKey, yesterdayKey, now,
+                      appModel, booksByKey, videosByUid),
               ],
             ),
     );
@@ -1156,6 +1315,9 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
     String todayKey,
     String yesterdayKey,
     DateTime now,
+    AppModel appModel,
+    Map<String, MediaItem> booksByKey,
+    Map<String, VideoBookRow> videosByUid,
   ) {
     final String label;
     if (group.dateKey == todayKey) {
@@ -1176,17 +1338,22 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
           child: Text(label, style: tokens.type.sectionLabel),
         ),
         for (final ActivityEntry e in group.entries)
-          _buildActivityEntry(tokens, e, now),
+          _buildActivityEntry(
+              tokens, e, now, appModel, booksByKey, videosByUid),
       ],
     );
   }
 
-  /// 单条活动：前置图标 + 标题（粗）+ 副行（动作词 · 相对时间 · [时长] · [session 数]）。
-  /// 整行可点：read→书架 tab，视频类→视频 tab（added-book 回书架）。
+  /// 单条活动：前置封面缩略（命中本地条目；否则类型图标）+ 标题（粗）+ 副行
+  /// （动作词 · 相对时间 · [时长] · [session 数]）。整行可点：命中本地条目直接
+  /// 打开（视频续播/书 openMedia），查不到回退切 tab。
   Widget _buildActivityEntry(
     HibikiDesignTokens tokens,
     ActivityEntry entry,
     DateTime now,
+    AppModel appModel,
+    Map<String, MediaItem> booksByKey,
+    Map<String, VideoBookRow> videosByUid,
   ) {
     final List<String> parts = <String>[
       _actionWord(entry.eventType),
@@ -1197,21 +1364,15 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
       if (entry.sourceDevice case final String device) device,
     ];
     return InkWell(
-      onTap: () => _openActivityEntry(entry),
+      onTap: () => unawaited(
+          _openActivityEntry(appModel, entry, booksByKey, videosByUid)),
       borderRadius: HibikiBorderRadius.card,
       child: Padding(
         padding: EdgeInsets.symmetric(vertical: tokens.spacing.gap / 2),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Padding(
-              padding: const EdgeInsets.only(top: 2),
-              child: Icon(
-                _activityIcon(entry.eventType),
-                size: 20,
-                color: tokens.surfaces.primary,
-              ),
-            ),
+            _activityLeading(tokens, appModel, entry, booksByKey, videosByUid),
             SizedBox(width: tokens.spacing.gap + 4),
             Expanded(
               child: Column(
@@ -1282,9 +1443,91 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
     return entry.title;
   }
 
-  /// 点击活动条：read → 书架 tab；added-book → 书架；其余（watch/added-video/game）→ 视频 tab。
-  void _openActivityEntry(ActivityEntry entry) {
-    if (entry.eventType == kActivityRead || entry.mediaType == 'book') {
+  /// 活动条前置视觉：命中本地条目用封面缩略（书 40×56 竖版 / 视频 68×40 横版，
+  /// 圆角裁切，与继续卡同源取图），查不到（已删/远端 display-only 行/游戏/导入
+  /// 无封面）回退原类型图标（用户反馈时间轴只有小图标认不出条目）。
+  Widget _activityLeading(
+    HibikiDesignTokens tokens,
+    AppModel appModel,
+    ActivityEntry entry,
+    Map<String, MediaItem> booksByKey,
+    Map<String, VideoBookRow> videosByUid,
+  ) {
+    final String? key = entry.mediaKey;
+    if (key != null && key.isNotEmpty) {
+      if (entry.mediaType == kActivityMediaVideo) {
+        final VideoBookRow? video = videosByUid[key];
+        if (video != null) {
+          return ClipRRect(
+            borderRadius: HibikiBorderRadius.card,
+            child: SizedBox(
+              width: 68,
+              height: 40,
+              child: _videoCover(tokens, video),
+            ),
+          );
+        }
+      } else if (entry.mediaType == kActivityMediaBook) {
+        final MediaItem? book = booksByKey[key];
+        if (book != null) {
+          return ClipRRect(
+            borderRadius: HibikiBorderRadius.card,
+            child: SizedBox(
+              width: 40,
+              height: 56,
+              child: FadeInImage(
+                placeholder: MemoryImage(kTransparentImage),
+                image: ReaderHibikiSource.instance
+                    .getDisplayThumbnailFromMediaItem(
+                  appModel: appModel,
+                  item: book,
+                ),
+                fit: BoxFit.cover,
+                imageErrorBuilder: (_, __, ___) =>
+                    _coverPlaceholder(tokens, Icons.menu_book_outlined),
+              ),
+            ),
+          );
+        }
+      }
+    }
+    return Padding(
+      padding: const EdgeInsets.only(top: 2),
+      child: Icon(
+        _activityIcon(entry.eventType),
+        size: 20,
+        color: tokens.surfaces.primary,
+      ),
+    );
+  }
+
+  /// 点击活动条：命中本地条目**直接打开**——视频=续播（与继续卡同一条
+  /// [_openLocalVideo] 路径），书=openMedia；查不到（远端 display-only/已删/
+  /// 游戏/导入）保持旧行为：read/book → 书架 tab，其余 → 视频 tab。
+  Future<void> _openActivityEntry(
+    AppModel appModel,
+    ActivityEntry entry,
+    Map<String, MediaItem> booksByKey,
+    Map<String, VideoBookRow> videosByUid,
+  ) async {
+    final String? key = entry.mediaKey;
+    if (key != null && key.isNotEmpty) {
+      if (entry.mediaType == kActivityMediaVideo &&
+          videosByUid.containsKey(key)) {
+        await _openLocalVideo(key);
+        return;
+      }
+      if (entry.mediaType == kActivityMediaBook) {
+        final MediaItem? book = booksByKey[key];
+        if (book != null) {
+          final MediaSource source = book.getMediaSource(appModel: appModel);
+          await appModel.openMedia(ref: ref, mediaSource: source, item: book);
+          return;
+        }
+      }
+    }
+    if (entry.eventType == kActivityRead ||
+        entry.mediaType == kActivityMediaBook) {
       homeShellTabNotifier.value = HomeTab.books;
     } else {
       homeShellTabNotifier.value = HomeTab.video;

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -9,6 +9,7 @@ import 'package:transparent_image/transparent_image.dart';
 import 'package:hibiki/media.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/video/m3u8_playlist.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/pages/implementations/activity_feed.dart';
@@ -227,6 +228,10 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
   /// 「最近添加」行的书侧排序时间源（视频侧用 [VideoBookRow.importedAt]）。
   Map<String, int> _epubImportedAtByKey = const <String, int>{};
 
+  /// '<mediaType>|<entryKey>' → 条目在其主折叠合集里的组内 sortIndex（只记归属
+  /// 主合集的行，书架/视频页同口径）。继续区合集 Next-Up 的组内排序键。
+  Map<String, int> _memberSortIndex = const <String, int>{};
+
   /// 每个视频 bookUid 的最近观看时刻（epoch 毫秒），继续观看排序用。
   Map<String, int> _videoWatchAtByUid = const <String, int>{};
 
@@ -297,6 +302,15 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
     };
     final Map<String, int> primaryByEntry =
         await db.getPrimaryCollectionIdByEntry();
+    // 组内序：条目在其主折叠合集里的 sortIndex（视频页/书架 _loadShelfMaps 同
+    // 口径——一次 getAllCollectionItems 内存分组，只记归属主合集的行）。
+    final Map<String, int> memberSortIndex = <String, int>{};
+    for (final MediaCollectionItemRow m in await db.getAllCollectionItems()) {
+      final String key = '${m.mediaType}|${m.entryKey}';
+      if (primaryByEntry[key] == m.collectionId) {
+        memberSortIndex[key] = m.sortIndex;
+      }
+    }
     // reading_statistics 行只存 title：日明细拼合集前缀需经 epub_books 反查 bookKey
     // （阅读统计页 _collectionNameForBook 同范式）。同批顺带取 importedAt 喂
     // 「最近添加」行（一次查询两用）。
@@ -379,6 +393,7 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
       _primaryCollectionByEntry = primaryByEntry;
       _bookKeyByTitle = bookKeyByTitle;
       _epubImportedAtByKey = epubImportedAtByKey;
+      _memberSortIndex = memberSortIndex;
       _videoWatchAtByUid = watchAt;
     });
     // 本地渲染先行，互联数据到达后再增量补位（不阻塞首屏）。
@@ -563,30 +578,53 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
         ));
       }
     }
+    // 视频侧合集感知 Next-Up（用户实报：合集里看完一集，合集不该从「继续」消
+    // 失，应推进为下一集）：成员按主折叠合集归组，每个合集在继续区**最多一张
+    // 卡**——组内复用视频页 hero 同口径（BUG-848 computeVideoLibraryOverview
+    // 的单元逻辑：sortIndex 排序 + [continueMemberIndex] 的 Jellyfin Next-Up
+    // 语义）；整组看完/整组没看过不出卡。散卡保持「有断点且未看完」现行为。
+    // 单行多集形态（playlistJson/currentEpisode 行内集数）completedAt 按整行，
+    // 天然沿用现行为。
+    final Map<int, List<VideoBookRow>> videosByCollection =
+        <int, List<VideoBookRow>>{};
+    final List<VideoBookRow> standaloneVideos = <VideoBookRow>[];
     for (final VideoBookRow v in _videos) {
+      final int? cid = _primaryCollectionByEntry['video|${v.bookUid}'];
+      if (cid == null) {
+        standaloneVideos.add(v);
+      } else {
+        (videosByCollection[cid] ??= <VideoBookRow>[]).add(v);
+      }
+    }
+    for (final VideoBookRow v in standaloneVideos) {
       if (v.lastPositionMs > 0 && v.completedAt == null) {
         final int recent = _videoWatchAtByUid[v.bookUid] ??
             v.importedAt?.millisecondsSinceEpoch ??
             0;
-        entries.add(_ContinueEntry(
-          isVideo: true,
-          title: v.title,
-          recentMs: recent,
-          // 视频进度到集粒度（VideoBooks 不持久化总时长，无法算章内百分比）：
-          // 多集按 currentEpisode/集数，单视频未看完不画（见 videoWatchFraction）。
-          progress: videoWatchFraction(
-            completed: v.completedAt != null,
-            currentEpisode: v.currentEpisode,
-            episodeCount: playlistEpisodeCount(v.playlistJson),
-          ),
-          collectionName: statCollectionName(
-            'video|${v.bookUid}',
-            _primaryCollectionByEntry,
-            _collectionNamesById,
-          ),
-          video: v,
-        ));
+        entries.add(
+          _videoContinueEntry(v, collectionName: null, recentMs: recent),
+        );
       }
+    }
+    for (final MapEntry<int, List<VideoBookRow>> ce
+        in videosByCollection.entries) {
+      final VideoBookRow? resume = _collectionResumeTarget(ce.value);
+      if (resume == null) continue;
+      // 单元活跃时刻 = 成员观看时刻最大值（含已完成集——Next-Up 卡按「刚看完
+      // 上一集」的时间参与混排），无统计行回退续播目标导入时间。
+      int recent = 0;
+      for (final VideoBookRow m in ce.value) {
+        final int at = _videoWatchAtByUid[m.bookUid] ?? 0;
+        if (at > recent) recent = at;
+      }
+      if (recent == 0) {
+        recent = resume.importedAt?.millisecondsSinceEpoch ?? 0;
+      }
+      entries.add(_videoContinueEntry(
+        resume,
+        collectionName: _collectionNamesById[ce.key],
+        recentMs: recent,
+      ));
     }
     // 互联 host 的远端补位（本地无同 key/uid 的在读书/在看视频），与本地条目
     // 按最近活动时刻统一混排（「继续也走互联」）。
@@ -742,6 +780,57 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
         ReaderHibikiSource.parseSrtBookUid(item.mediaIdentifier);
     if (srtUid != null) return 'srt|$srtUid';
     return 'epub|${item.mediaIdentifier}';
+  }
+
+  /// 视频行 → 继续卡条目（散卡与合集续播目标共用）：进度到集粒度（VideoBooks
+  /// 不持久化总时长，无法算章内百分比——多集按 currentEpisode/集数，单视频未
+  /// 看完不画，见 [videoWatchFraction]）；合集成员由渲染层按 [collectionName]
+  /// 拼「标题=合集名、副标题=集名 · 观看」。
+  _ContinueEntry _videoContinueEntry(
+    VideoBookRow v, {
+    required String? collectionName,
+    required int recentMs,
+  }) {
+    return _ContinueEntry(
+      isVideo: true,
+      title: v.title,
+      recentMs: recentMs,
+      progress: videoWatchFraction(
+        completed: v.completedAt != null,
+        currentEpisode: v.currentEpisode,
+        episodeCount: playlistEpisodeCount(v.playlistJson),
+      ),
+      collectionName: collectionName,
+      video: v,
+    );
+  }
+
+  /// 合集单元的续播目标（**视频页 hero 同口径**，BUG-848
+  /// computeVideoLibraryOverview 的单元逻辑）：成员按主合集组内 sortIndex
+  /// （缺失沉底）→ bookUid 排序，跑 [continueMemberIndex]（最靠后有痕迹一集；
+  /// 它已完成则推进下一集）。整组无痕迹（没看过，不劝人从头开始）或目标仍是
+  /// 已完成集（整季看完）→ null 不出卡（自然滚出继续区）。
+  VideoBookRow? _collectionResumeTarget(List<VideoBookRow> members) {
+    final List<VideoBookRow> sorted = List<VideoBookRow>.of(members)
+      ..sort((VideoBookRow a, VideoBookRow b) {
+        final int ai = _memberSortIndex['video|${a.bookUid}'] ?? 1 << 30;
+        final int bi = _memberSortIndex['video|${b.bookUid}'] ?? 1 << 30;
+        if (ai != bi) return ai.compareTo(bi);
+        return a.bookUid.compareTo(b.bookUid);
+      });
+    final bool anyTrace = sorted.any(
+      (VideoBookRow m) => m.completedAt != null || m.lastPositionMs > 0,
+    );
+    if (!anyTrace) return null;
+    final int idx = continueMemberIndex(<CollectionMemberProgress>[
+      for (final VideoBookRow m in sorted)
+        CollectionMemberProgress(
+          positionMs: m.lastPositionMs,
+          completed: m.completedAt != null,
+        ),
+    ]);
+    final VideoBookRow resume = sorted[idx];
+    return resume.completedAt != null ? null : resume;
   }
 
   /// 「继续」单卡（Jellyfin 式横滑卡）：上=封面（底部贴进度条），下=标题一行 +

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -64,6 +64,30 @@ import 'package:hibiki/src/media/video/video_filename_parser.dart';
 import 'package:hibiki/src/utils/misc/shelf_ordering.dart';
 import 'package:path/path.dart' as p;
 
+/// 顶层 helper：打开本地视频播放页的**共享路由入口**（本页 hero/卡片与首页
+/// dashboard 继续卡/活动条同一条路径），统一经 [VideoHibikiPage.neutralized]
+/// 在路由层中和全局缩放（video_render_fixes_guard 守卫的接线）。
+/// [playlistCollectionId] 非空 = 作为合集一集打开（剧集面板/上下集/连播），
+/// null = 散卡单视频。返回的 Future 在播放页关闭后完成（调用方据此刷新）。
+Future<void> openLocalVideoBook({
+  required BuildContext context,
+  required VideoBookRepository repo,
+  required String bookUid,
+  int? playlistCollectionId,
+}) {
+  return Navigator.push(
+    context,
+    adaptivePageRoute<void>(
+      context: context,
+      builder: (_) => VideoHibikiPage.neutralized(
+        bookUid: bookUid,
+        repo: repo,
+        playlistCollectionId: playlistCollectionId,
+      ),
+    ),
+  );
+}
+
 /// 首页「视频」tab 的内容：已导入视频的库（独立于书架的 EPUB/有声书分区）。
 ///
 /// 仅在实验性视频开关开启时由 [HomePage] 装配进底栏（见 home_page.dart 的
@@ -1078,16 +1102,12 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   Future<void> _open(VideoBookRow book, {int? playlistCollectionId}) async {
     await _showAnime4kFirstUsePromptIfNeeded();
     if (!mounted) return;
-    await Navigator.push(
-      context,
-      adaptivePageRoute<void>(
-        context: context,
-        builder: (_) => VideoHibikiPage.neutralized(
-          bookUid: book.bookUid,
-          repo: widget.repo,
-          playlistCollectionId: playlistCollectionId,
-        ),
-      ),
+    // 路由构造走共享顶层入口 [openLocalVideoBook]（dashboard 续播同一条路径）。
+    await openLocalVideoBook(
+      context: context,
+      repo: widget.repo,
+      bookUid: book.bookUid,
+      playlistCollectionId: playlistCollectionId,
     );
     // 从播放器返回后刷新：继续观看 hero / 概览统计 / 卡片观看进度行都依赖
     // lastPositionMs 与 watch-stats，播完不刷会展示陈旧数据（对抗审查确认）。

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -13,6 +13,8 @@ import 'package:hibiki/src/anki/anki_view_model.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/home_dashboard_page.dart';
+import 'package:hibiki/src/pages/implementations/home_page.dart'
+    show homeShellTabNotifier, HomeTab;
 import 'package:hibiki/src/platform/platform_providers.dart';
 import 'package:hibiki/src/platform/platform_services.dart';
 import 'package:hibiki/src/utils/components/stat_contribution_heatmap.dart';
@@ -76,7 +78,15 @@ void main() {
     }
   });
 
-  Widget buildApp() => ProviderScope(
+  Widget buildApp({
+    Future<void> Function(
+      BuildContext context,
+      VideoBookRepository repo,
+      String bookUid,
+      int? playlistCollectionId,
+    )? openVideoOverride,
+  }) =>
+      ProviderScope(
         overrides: <Override>[
           platformServicesProvider.overrideWithValue(platformServices),
           ankiRepositoryProvider.overrideWithValue(ankiRepository),
@@ -91,7 +101,10 @@ void main() {
         child: TranslationProvider(
           child: MaterialApp(
             home: Scaffold(
-              body: HomeDashboardPage(videoRepo: VideoBookRepository(db)),
+              body: HomeDashboardPage(
+                videoRepo: VideoBookRepository(db),
+                openVideoOverride: openVideoOverride,
+              ),
             ),
           ),
         ),
@@ -427,6 +440,96 @@ void main() {
     expect(tester.takeException(), isNull);
     // 阅读节列出当日读的书（seedSampleData 今天读了 800 字的这本）。
     expect(find.text('吾輩は猫である'), findsOneWidget);
+  });
+
+  testWidgets('点继续区视频卡/活动条直接续播（带主合集 id），不再只是切视频 tab',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final DateTime now = DateTime.now();
+    final String todayKey = HibikiTimeFormat.dayKey(now);
+    await db.upsertVideoBook(const VideoBooksCompanion(
+      bookUid: Value('v1'),
+      title: Value('S01E01'),
+      videoPath: Value('/abs/s01e01.mp4'),
+      lastPositionMs: Value(60000),
+    ));
+    final int cid = await db.createMediaCollection('进击的巨人');
+    await db.addToCollection(cid, 'video', 'v1');
+    // 活动条命中同一本地 uid：点击也应走同一条续播路径。
+    await db.addActivityEvent(
+      eventType: kActivityWatch,
+      mediaType: kActivityMediaVideo,
+      title: 'S01E01',
+      mediaKey: 'v1',
+      dateKey: todayKey,
+      timestampMs: now.millisecondsSinceEpoch,
+      durationMs: 60000,
+    );
+
+    // 注入打开替身（widget 测试无法构建 media_kit 播放页），记录续播调用。
+    final List<(String, int?)> opened = <(String, int?)>[];
+    await tester.pumpWidget(buildApp(
+      openVideoOverride: (
+        BuildContext _,
+        VideoBookRepository __,
+        String bookUid,
+        int? playlistCollectionId,
+      ) async {
+        opened.add((bookUid, playlistCollectionId));
+      },
+    ));
+    await pumpDashboard(tester);
+
+    final HomeTab tabBefore = homeShellTabNotifier.value;
+    // 继续卡点击 → 直接续播（合集成员带 playlistCollectionId 从合集续播）。
+    await tester.tap(find.text('S01E01 · ${t.home_filter_watch}'));
+    await tester.pump();
+    expect(opened, <(String, int?)>[('v1', cid)]);
+    // 活动条点击 → 同一条续播路径。
+    await tester.tap(find.text('进击的巨人 - S01E01'));
+    await tester.pump();
+    expect(opened.length, 2);
+    expect(opened.last, ('v1', cid));
+    // 旧行为（只把首页切到视频 tab）不再发生。
+    expect(homeShellTabNotifier.value, tabBefore);
+    // 活动条前置已是视频封面缩略槽（68×40，占位图标兜底），不再是裸 20px 图标。
+    expect(
+      find.byWidgetPredicate(
+          (Widget w) => w is SizedBox && w.width == 68 && w.height == 40),
+      findsWidgets,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('「最近添加」通栏：按导入时间列出本地视频卡（类型 · 相对时间）', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    // 仅导入（无播放断点）：不进「继续」，只进「最近添加」。
+    await db.upsertVideoBook(VideoBooksCompanion(
+      bookUid: const Value('recent-v'),
+      title: const Value('新导入的视频'),
+      videoPath: const Value('/abs/recent.mp4'),
+      importedAt: Value(DateTime.now()),
+    ));
+
+    await tester.pumpWidget(buildApp());
+    await pumpDashboard(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(t.home_recently_added), findsOneWidget);
+    expect(find.text('新导入的视频'), findsOneWidget);
+    // 副标题 = 类型 · 相对添加时间（刚导入 → 「刚刚」）。
+    expect(
+      find.text('${t.home_filter_watch} · ${t.activity_just_now}'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('中等宽度（700，<900 窄分支）单列堆叠不抛无限高度', (WidgetTester tester) async {

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -532,6 +532,132 @@ void main() {
     );
   });
 
+  /// 合集 Next-Up 三态的公共装配：合集「进击的巨人」+ 两集独立行 E1/E2。
+  Future<int> seedCollectionTwoEpisodes({
+    required VideoBooksCompanion e1,
+    required VideoBooksCompanion e2,
+  }) async {
+    await db.upsertVideoBook(e1);
+    await db.upsertVideoBook(e2);
+    final int cid = await db.createMediaCollection('进击的巨人');
+    await db.addToCollection(cid, 'video', 'e1');
+    await db.addToCollection(cid, 'video', 'e2');
+    return cid;
+  }
+
+  testWidgets('继续区合集 Next-Up：看完 E1 后合集卡推进为 E2，点击直接打开 E2（带合集 id）',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final int cid = await seedCollectionTwoEpisodes(
+      // E1 已看完（旧逻辑会把它踢出继续区、整个合集消失——用户实报）。
+      e1: VideoBooksCompanion(
+        bookUid: const Value('e1'),
+        title: const Value('S01E01'),
+        videoPath: const Value('/abs/e1.mp4'),
+        lastPositionMs: const Value(1200000),
+        completedAt: Value(DateTime.now()),
+      ),
+      // E2 全新未看。
+      e2: const VideoBooksCompanion(
+        bookUid: Value('e2'),
+        title: Value('S01E02'),
+        videoPath: Value('/abs/e2.mp4'),
+      ),
+    );
+
+    final List<(String, int?)> opened = <(String, int?)>[];
+    await tester.pumpWidget(buildApp(
+      openVideoOverride: (
+        BuildContext _,
+        VideoBookRepository __,
+        String bookUid,
+        int? playlistCollectionId,
+      ) async {
+        opened.add((bookUid, playlistCollectionId));
+      },
+    ));
+    await pumpDashboard(tester);
+
+    expect(tester.takeException(), isNull);
+    // 合集卡仍在，且推进为下一集：标题=合集名、副标题=「S01E02 · 观看」。
+    expect(find.text('进击的巨人'), findsOneWidget);
+    expect(find.text('S01E02 · ${t.home_filter_watch}'), findsOneWidget);
+    expect(find.text('S01E01 · ${t.home_filter_watch}'), findsNothing);
+    // 点击 Next-Up 卡 → 直接打开 E2（带合集 id 进合集连播）。
+    await tester.tap(find.text('S01E02 · ${t.home_filter_watch}'));
+    await tester.pump();
+    expect(opened, <(String, int?)>[('e2', cid)]);
+  });
+
+  testWidgets('继续区合集 Next-Up：整个合集全部看完 → 不出卡（自然滚出继续区）',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await seedCollectionTwoEpisodes(
+      e1: VideoBooksCompanion(
+        bookUid: const Value('e1'),
+        title: const Value('S01E01'),
+        videoPath: const Value('/abs/e1.mp4'),
+        lastPositionMs: const Value(1200000),
+        completedAt: Value(DateTime.now()),
+      ),
+      e2: VideoBooksCompanion(
+        bookUid: const Value('e2'),
+        title: const Value('S01E02'),
+        videoPath: const Value('/abs/e2.mp4'),
+        lastPositionMs: const Value(1300000),
+        completedAt: Value(DateTime.now()),
+      ),
+    );
+
+    await tester.pumpWidget(buildApp());
+    await pumpDashboard(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('进击的巨人'), findsNothing);
+    expect(find.text('S01E01 · ${t.home_filter_watch}'), findsNothing);
+    expect(find.text('S01E02 · ${t.home_filter_watch}'), findsNothing);
+  });
+
+  testWidgets('继续区合集 Next-Up：有在看中的集 → 显示该集（回归现行为）',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await seedCollectionTwoEpisodes(
+      // E1 在看中（有断点未完成）。
+      e1: const VideoBooksCompanion(
+        bookUid: Value('e1'),
+        title: Value('S01E01'),
+        videoPath: Value('/abs/e1.mp4'),
+        lastPositionMs: Value(60000),
+      ),
+      e2: const VideoBooksCompanion(
+        bookUid: Value('e2'),
+        title: Value('S01E02'),
+        videoPath: Value('/abs/e2.mp4'),
+      ),
+    );
+
+    await tester.pumpWidget(buildApp());
+    await pumpDashboard(tester);
+
+    expect(tester.takeException(), isNull);
+    // 每合集最多一张卡：显示在看中的 E1，而不是 E2、也不是两张。
+    expect(find.text('进击的巨人'), findsOneWidget);
+    expect(find.text('S01E01 · ${t.home_filter_watch}'), findsOneWidget);
+    expect(find.text('S01E02 · ${t.home_filter_watch}'), findsNothing);
+  });
+
   testWidgets('中等宽度（700，<900 窄分支）单列堆叠不抛无限高度', (WidgetTester tester) async {
     // 700px < 900：走窄屏单列堆叠分支（热力图置顶 + 继续 + Activity）。曾因把
     // stretch/Expanded 的 Row 直接放进纵向 ListView 而在此宽度崩溃，锁死不再复发。


### PR DESCRIPTION
## 背景
用户 Win 真机试用首页仪表盘重构（PR#360 内容已以 3e76394cc 落 develop）后的三条反馈：
1. 点继续区视频卡不打开、只跳视频页；
2. 右侧活动时间轴要有封面；
3. 底部很空。

## 改动
### 1. 继续卡/活动条直接打开（根因：旧竖列表时代「切 tab」行为残留）
- `home_video_page.dart` 抽出顶层共享路由入口 `openLocalVideoBook`（统一走 `VideoHibikiPage.neutralized`，`video_render_fixes_guard` 守卫仍绿；本页 `_open` 改为委托，Anime4K 首用提示/返回刷新行为逐字节等价）。
- dashboard `_openLocalVideo`：用已加载的 `_primaryCollectionByEntry` 带主合集 id 续播（合集成员→剧集面板/上下集/连播；散卡→单视频）。播放返回后 `lastPositionMs` 落库触发表级变更自动重查，无需手动刷新。
- 活动时间轴条目点击同路径升级：视频命中本地 uid → 直接续播；书命中本地 → `openMedia`；查不到（已删/远端）才保持切 tab。
- 测试缝：`HomeDashboardPage.openVideoOverride` 注入替身断言「点卡即打开（带合集 id）、不再改 homeShellTabNotifier」。

### 2. 活动时间轴封面
- 视频事件 68×40 横版（`mediaKey`=uid 查 `_videos` 的 coverPath）；书事件 40×56 竖版（兼容 epub bookKey 与 standalone SRT uid 双身份，走 `getDisplayThumbnailFromMediaItem` override 通道）；游戏/导入/失配回退原图标。

### 3. 底部「最近添加」通栏（提案实现，可否）
- 书按 `EpubBooks.importedAt` + 视频按 `importedAt` 倒序混排取 12，复用继续卡组件（无进度条，副标题=类型·相对时间），合集显示名同规则；空库不占位。
- i18n 新增 `home_recently_added`（i18n_sync 17 语言 + slang 生成）。
- 其他候选方案见 PR 评论区讨论（KPI 统计条 / Next-Up / 收藏词行）。

## 验证
- `flutter analyze` 全量零问题；`home_dashboard_page_test` 11/11（含新增断言）。
- 全量 `flutter test`：12816 过 / 1 挂——`hibiki_library_host_service_books_test.dart`（exportBook 产 epub，本 PR 零改动文件），**单独重跑通过**，属全量并发下文件 IO 偶发，非本 PR 回归。
- 待 Win 真机：视频卡点击直接进播放器（合集成员应带剧集面板）、活动封面行高紧凑度、最近添加通栏观感。

## 已知取舍
- dashboard 续播不弹视频页的 Anime4K 首用提示（纯信息性，首次从视频 tab 打开仍会弹）。
- 「最近添加」不含远端条目与 standalone SRT 书（无 epub importedAt）；若想按「added 活动事件」口径可切换数据源。

https://claude.ai/code/session_01EmSqKpTPf5zuGBTzWa45A5