### PR TITLE
feat(video): 片段导出封入用户正在看的字幕

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39389 (2317 per locale)
+/// Strings: 39406 (2318 per locale)
 ///
-/// Built on 2026-07-23 at 12:58 UTC
+/// Built on 2026-07-23 at 14:40 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3091,6 +3091,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get pdf_bookmarks => 'Bookmarks';
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   String get pdf_bookmark_added => 'Bookmark added';
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -8345,6 +8347,9 @@ class _StringsAr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -13672,6 +13677,9 @@ class _StringsDe extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -19015,6 +19023,9 @@ class _StringsEs extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -24369,6 +24380,9 @@ class _StringsFr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -29650,6 +29664,9 @@ class _StringsId extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -34979,6 +34996,9 @@ class _StringsIt extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -40113,6 +40133,9 @@ class _StringsJa extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -45250,6 +45273,9 @@ class _StringsKo extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -50557,6 +50583,9 @@ class _StringsNl extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -55879,6 +55908,9 @@ class _StringsPtBr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -61184,6 +61216,9 @@ class _StringsRu extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -66434,6 +66469,9 @@ class _StringsTh extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -71716,6 +71754,9 @@ class _StringsTr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -76985,6 +77026,9 @@ class _StringsVi extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 // Path: <root>
@@ -81883,6 +81927,9 @@ class _StringsZhCn extends _StringsEn {
   String get pdf_bookmarks_empty => '还没有书签。';
   @override
   String get pdf_bookmark_added => '已添加书签';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      '片段已导出（含字幕）：${path}';
 }
 
 // Path: <root>
@@ -86935,6 +86982,9 @@ class _StringsZhHk extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String video_clip_exported_with_subtitles({required Object path}) =>
+      'Clip exported with subtitles: ${path}';
 }
 
 /// Flat map(s) containing all translations.
@@ -91665,6 +91715,9 @@ extension on _StringsEn {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -96393,6 +96446,9 @@ extension on _StringsAr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -101142,6 +101198,9 @@ extension on _StringsDe {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -105890,6 +105949,9 @@ extension on _StringsEs {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -110644,6 +110706,9 @@ extension on _StringsFr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -115380,6 +115445,9 @@ extension on _StringsId {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -120131,6 +120199,9 @@ extension on _StringsIt {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -124844,6 +124915,9 @@ extension on _StringsJa {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -129561,6 +129635,9 @@ extension on _StringsKo {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -134305,6 +134382,9 @@ extension on _StringsNl {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -139046,6 +139126,9 @@ extension on _StringsPtBr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -143792,6 +143875,9 @@ extension on _StringsRu {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -148522,6 +148608,9 @@ extension on _StringsTh {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -153261,6 +153350,9 @@ extension on _StringsTr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -157995,6 +158087,9 @@ extension on _StringsVi {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }
@@ -162693,6 +162788,8 @@ extension on _StringsZhCn {
         return '还没有书签。';
       case 'pdf_bookmark_added':
         return '已添加书签';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) => '片段已导出（含字幕）：${path}';
       default:
         return null;
     }
@@ -167401,6 +167498,9 @@ extension on _StringsZhHk {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'video_clip_exported_with_subtitles':
+        return ({required Object path}) =>
+            'Clip exported with subtitles: ${path}';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "此 PDF 没有目录。",
   "pdf_bookmarks": "书签",
   "pdf_bookmarks_empty": "还没有书签。",
-  "pdf_bookmark_added": "已添加书签"
+  "pdf_bookmark_added": "已添加书签",
+  "video_clip_exported_with_subtitles": "片段已导出（含字幕）：${path}"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}"
 }

--- a/hibiki/lib/src/media/video/video_clip_exporter.dart
+++ b/hibiki/lib/src/media/video/video_clip_exporter.dart
@@ -1,7 +1,11 @@
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:hibiki/src/media/video/ffmpeg_backend.dart';
+import 'package:hibiki/src/media/video/video_clip_subtitle.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
+import 'package:path/path.dart' as p;
 
 // BUG-835：`extractFfmpegFailureReason` 的正准实现搬到 ffmpeg_backend.dart（最底层、
 // 无依赖），供共享的 [FfmpegRunResult.failureSummary] 与音频/视频两路径统一复用。此处
@@ -23,10 +27,17 @@ class VideoClipExportResult {
     required this.outputPath,
     required this.failure,
     this.detail,
+    this.subtitleTrackCount = 0,
   });
 
-  const VideoClipExportResult.success(String outputPath)
-      : this._(outputPath: outputPath, failure: null);
+  const VideoClipExportResult.success(
+    String outputPath, {
+    int subtitleTrackCount = 0,
+  }) : this._(
+          outputPath: outputPath,
+          failure: null,
+          subtitleTrackCount: subtitleTrackCount,
+        );
 
   const VideoClipExportResult.failure(
     VideoClipExportFailure failure, {
@@ -37,9 +48,53 @@ class VideoClipExportResult {
   final VideoClipExportFailure? failure;
   final String? detail;
 
+  /// 实际封进输出文件的字幕流条数（0 = 没带字幕：区间内无字幕、容器封不下，
+  /// 或带字幕那次失败后降级重试成功）。
+  final int subtitleTrackCount;
+
   bool get isSuccess => outputPath != null && failure == null;
 }
 
+/// 纯函数：拼 `-map` 段，copy 与 reencode 两条裁剪路径共用（唯一真相源）。
+///
+/// [subtitleInputCount] 是**额外字幕输入文件**的条数（输入下标从 1 起，0 是源视频）。
+///
+/// 关键约束：ffmpeg 一旦见到任何 `-map`，就**完全关闭**自动流选择。所以带字幕时
+/// 必须把 video / audio 也显式 map 出来，否则输出只剩字幕、视频音频全丢；反过来
+/// 不带字幕且 [explicitAudio] 未知时必须一个 `-map` 都不给，让 ffmpeg 自己选默认轨
+/// （这是加字幕之前的既有行为，原样保留）。
+@visibleForTesting
+List<String> buildClipStreamMapArgs({
+  required int? explicitAudio,
+  required int subtitleInputCount,
+}) {
+  // 尾随 '?'：当 0:a:N 在真实 ffmpeg 流里越界（mpv 轨序号与 ffmpeg 0:a:N 不一致，
+  // 挂外挂音频/枚举顺序不同时发生），ffmpeg 降级回退默认轨而非
+  // 'Stream map matches no streams' 硬失败（BUG-345）。
+  if (subtitleInputCount <= 0) {
+    if (explicitAudio == null) return const <String>[];
+    return <String>['-map', '0:v:0', '-map', '0:a:$explicitAudio?'];
+  }
+  return <String>[
+    '-map',
+    '0:v:0',
+    '-map',
+    // explicitAudio 已知就只带用户正在听的那条；未知时带**全部**音轨（'0:a?'）而不是
+    // 赌 `0:a:0`——多音轨番剧里默认轨常常不是 0，赌错就导出了错误语言的音频。
+    explicitAudio != null ? '0:a:$explicitAudio?' : '0:a?',
+    for (int i = 0; i < subtitleInputCount; i++) ...<String>[
+      '-map',
+      '${i + 1}:s:0',
+    ],
+  ];
+}
+
+/// 纯函数：拼「流复制」裁剪命令（`-c copy`，瞬时无损）。
+///
+/// [subtitlePaths] 是已裁好、时间轴已平移到片段起点为 0 的 SRT 文件（主字幕、副字幕
+/// 各一条，见 [buildClipSrtContent]）；[subtitleCodec] 由 [resolveClipSubtitleCodec]
+/// 按输出容器给出。两者任一为空就退回原来的 `-sn` 纯视频音频命令，一个参数都不变
+/// ——加字幕不能以破坏既有导出为代价。
 List<String> buildFfmpegVideoClipExportArgs({
   required String inputPath,
   required int startMs,
@@ -47,6 +102,8 @@ List<String> buildFfmpegVideoClipExportArgs({
   required String outputPath,
   int? audioStreamIndex,
   int? audioStreamCount,
+  List<String> subtitlePaths = const <String>[],
+  String? subtitleCodec,
 }) {
   final double startSeconds = startMs / 1000.0;
   final double durationSeconds = (endMs - startMs) / 1000.0;
@@ -54,28 +111,35 @@ List<String> buildFfmpegVideoClipExportArgs({
     audioStreamIndex: audioStreamIndex,
     audioStreamCount: audioStreamCount,
   );
+  final bool withSubtitles = subtitlePaths.isNotEmpty && subtitleCodec != null;
+  final int subtitleInputCount = withSubtitles ? subtitlePaths.length : 0;
+
   return <String>[
     '-hide_banner',
     '-y',
+    // `-ss` / `-t` 是 per-input 选项，只作用于紧随其后的那个 `-i`：源视频按区间 seek，
+    // 字幕输入**不带**这两个选项——它已经被 buildClipSrtContent 裁好并平移到 0，
+    // 再 seek 一次会把时间轴推成负的、字幕整体消失。
     '-ss',
     startSeconds.toStringAsFixed(3),
     '-t',
     durationSeconds.toStringAsFixed(3),
     '-i',
     inputPath,
-    if (explicitAudio != null) ...<String>[
-      '-map',
-      '0:v:0',
-      '-map',
-      // 尾随 '?'：当 0:a:N 在真实 ffmpeg 流里越界（mpv 轨序号与 ffmpeg 0:a:N 不一致，
-      // 挂外挂音频/枚举顺序不同时发生），ffmpeg 降级回退默认轨而非
-      // 'Stream map matches no streams' 硬失败（BUG-345）。
-      '0:a:$explicitAudio?',
-    ],
-    '-sn',
+    if (withSubtitles)
+      for (final String path in subtitlePaths) ...<String>['-i', path],
+    ...buildClipStreamMapArgs(
+      explicitAudio: explicitAudio,
+      subtitleInputCount: subtitleInputCount,
+    ),
+    // 不带字幕时 `-sn` 丢掉源内嵌字幕；带字幕时显式 map 已保证只有我们这几条进输出，
+    // 此时绝不能加 `-sn`——它会把刚 map 进来的字幕流一起禁掉。
+    if (!withSubtitles) '-sn',
     '-dn',
     '-c',
     'copy',
+    // 字幕流单独指定编码：Matroska 能直接 copy SRT，mp4/mov 系必须转 mov_text。
+    if (withSubtitles) ...<String>['-c:s', subtitleCodec],
     '-avoid_negative_ts',
     'make_zero',
     outputPath,
@@ -93,6 +157,10 @@ List<String> buildFfmpegVideoClipExportArgs({
 /// `-pix_fmt yuv420p` 把 10-bit / 4:2:2 等源统一降到 8-bit 4:2:0（浏览器/播放器通吃）；
 /// `-movflags +faststart` 把 moov 前移便于边下边播。音频选择沿用与 copy 路径同一套
 /// [resolveAudioMapIndex] 边界判定（越界回退默认轨，尾随 `?` 兜底，BUG-345）。
+///
+/// 字幕参数与 copy 路径同义（[subtitlePaths] / [subtitleCodec]）：字幕**不**参与
+/// 重编码，仍是独立软字幕流，只是跟着这一轮一起 mux 进去——否则 copy 轮失败降级到
+/// 重编码后，用户会拿到一个没有字幕的片段。
 List<String> buildFfmpegVideoClipReencodeArgs({
   required String inputPath,
   required int startMs,
@@ -100,6 +168,8 @@ List<String> buildFfmpegVideoClipReencodeArgs({
   required String outputPath,
   int? audioStreamIndex,
   int? audioStreamCount,
+  List<String> subtitlePaths = const <String>[],
+  String? subtitleCodec,
 }) {
   final double startSeconds = startMs / 1000.0;
   final double durationSeconds = (endMs - startMs) / 1000.0;
@@ -107,6 +177,8 @@ List<String> buildFfmpegVideoClipReencodeArgs({
     audioStreamIndex: audioStreamIndex,
     audioStreamCount: audioStreamCount,
   );
+  final bool withSubtitles = subtitlePaths.isNotEmpty && subtitleCodec != null;
+  final int subtitleInputCount = withSubtitles ? subtitlePaths.length : 0;
   return <String>[
     '-hide_banner',
     '-y',
@@ -116,14 +188,15 @@ List<String> buildFfmpegVideoClipReencodeArgs({
     durationSeconds.toStringAsFixed(3),
     '-i',
     inputPath,
-    if (explicitAudio != null) ...<String>[
-      '-map',
-      '0:v:0',
-      '-map',
-      '0:a:$explicitAudio?',
-    ],
-    '-sn',
+    if (withSubtitles)
+      for (final String path in subtitlePaths) ...<String>['-i', path],
+    ...buildClipStreamMapArgs(
+      explicitAudio: explicitAudio,
+      subtitleInputCount: subtitleInputCount,
+    ),
+    if (!withSubtitles) '-sn',
     '-dn',
+    if (withSubtitles) ...<String>['-c:s', subtitleCodec],
     '-c:v',
     'libx264',
     '-preset',
@@ -165,6 +238,23 @@ int? resolveAudioMapIndex({
   return audioStreamIndex;
 }
 
+/// 一「轮」裁剪的结果：快路径 `-c copy` + 失败后的重编码兜底。
+class _ClipAttempt {
+  const _ClipAttempt(this.produced, this.copy, this.reencode);
+
+  final bool produced;
+  final FfmpegRunResult copy;
+
+  /// copy 轮直接成功时为 null（没跑重编码）。
+  final FfmpegRunResult? reencode;
+
+  /// 最后实际跑的那轮——失败诊断取它的 stderr。
+  FfmpegRunResult get last => reencode ?? copy;
+}
+
+/// 导出片段。[subtitleContents] 是已裁剪、时间轴已平移到片段起点为 0 的 SRT 文本
+/// （主字幕、副字幕各一条，由 [buildClipSrtContent] 生成）；为空、或输出容器封不下
+/// 文本字幕（[resolveClipSubtitleCodec] 返回 null）时自动退回纯视频音频导出。
 Future<VideoClipExportResult> exportVideoClipViaFfmpeg({
   required String inputPath,
   required int startMs,
@@ -172,6 +262,7 @@ Future<VideoClipExportResult> exportVideoClipViaFfmpeg({
   required String outputPath,
   int? audioStreamIndex,
   int? audioStreamCount,
+  List<String> subtitleContents = const <String>[],
   FfmpegBackend? backend,
   Duration timeout = const Duration(minutes: 10),
 }) async {
@@ -189,51 +280,95 @@ Future<VideoClipExportResult> exportVideoClipViaFfmpeg({
     );
   }
 
+  final String? subtitleCodec = resolveClipSubtitleCodec(outputPath);
+  final List<String> wanted = subtitleContents
+      .where((String s) => s.trim().isNotEmpty)
+      .toList(growable: false);
+  Directory? subtitleDir;
+
   try {
     output.parent.createSync(recursive: true);
     final FfmpegBackend resolved = backend ?? resolveFfmpegBackend();
     bool produced(FfmpegRunResult r) =>
         r.isSuccess && output.existsSync() && output.lengthSync() > 0;
 
-    // 快路径：`-c copy`（瞬时、无损）。多数 h264/hevc + aac 源直接成功。输出恒
-    // `.mp4`（由调用方决定的 outputPath；见 BUG-917：绝不再跟随源容器扩展名，
-    // 否则 mkv/webm 源会选中 ffmpeg-min 白名单里不存在的 matroska muxer → exit -22）。
-    final FfmpegRunResult copyResult = await resolved.run(
-      buildFfmpegVideoClipExportArgs(
-        inputPath: inputPath,
-        startMs: startMs,
-        endMs: endMs,
-        outputPath: outputPath,
-        audioStreamIndex: audioStreamIndex,
-        audioStreamCount: audioStreamCount,
-      ),
-      timeout,
-    );
-    if (produced(copyResult)) {
-      return VideoClipExportResult.success(outputPath);
+    List<String> subtitlePaths = const <String>[];
+    if (wanted.isNotEmpty && subtitleCodec != null) {
+      subtitleDir = await _writeTempSubtitleFiles(wanted);
+      if (subtitleDir != null) {
+        subtitlePaths = List<String>.generate(
+          wanted.length,
+          (int i) => _tempSubtitlePath(subtitleDir!, i),
+          growable: false,
+        );
+      }
     }
-    _deleteIfPresent(output);
 
-    // 兜底：源编码装不进 mp4（vc1/wmv/dts/pcm… 或流复制不兼容）导致 copy 失败时，
-    // 重编码为 libx264 + aac 再写同一个 .mp4（桌面 ffmpeg-min 专为此编入 libx264，
-    // TODO-1257）。这样任何可解码的源都不再 exit -22（BUG-917），代价是较慢/有损，
-    // 只在快路径失败时才付。
-    final FfmpegRunResult reencodeResult = await resolved.run(
-      buildFfmpegVideoClipReencodeArgs(
-        inputPath: inputPath,
-        startMs: startMs,
-        endMs: endMs,
-        outputPath: outputPath,
-        audioStreamIndex: audioStreamIndex,
-        audioStreamCount: audioStreamCount,
-      ),
-      timeout,
-    );
-    if (produced(reencodeResult)) {
-      return VideoClipExportResult.success(outputPath);
+    /// 跑完整一轮：快路径 `-c copy`（瞬时、无损，多数 h264/hevc + aac 源直接成功），
+    /// 失败则重编码 libx264 + aac 兜底（源编码装不进 mp4：vc1/wmv/dts/pcm… 桌面
+    /// ffmpeg-min 专为此编入 libx264，TODO-1257；杜绝 BUG-917 的 exit -22）。
+    /// 输出恒 `.mp4`——绝不跟随源容器扩展名，否则 mkv/webm 源会选中 ffmpeg-min
+    /// 白名单里不存在的 matroska muxer。
+    Future<_ClipAttempt> attempt(List<String> subs) async {
+      final FfmpegRunResult copyResult = await resolved.run(
+        buildFfmpegVideoClipExportArgs(
+          inputPath: inputPath,
+          startMs: startMs,
+          endMs: endMs,
+          outputPath: outputPath,
+          audioStreamIndex: audioStreamIndex,
+          audioStreamCount: audioStreamCount,
+          subtitlePaths: subs,
+          subtitleCodec: subtitleCodec,
+        ),
+        timeout,
+      );
+      if (produced(copyResult)) return _ClipAttempt(true, copyResult, null);
+      _deleteIfPresent(output);
+
+      final FfmpegRunResult reencodeResult = await resolved.run(
+        buildFfmpegVideoClipReencodeArgs(
+          inputPath: inputPath,
+          startMs: startMs,
+          endMs: endMs,
+          outputPath: outputPath,
+          audioStreamIndex: audioStreamIndex,
+          audioStreamCount: audioStreamCount,
+          subtitlePaths: subs,
+          subtitleCodec: subtitleCodec,
+        ),
+        timeout,
+      );
+      final bool ok = produced(reencodeResult);
+      if (!ok) _deleteIfPresent(output);
+      return _ClipAttempt(ok, copyResult, reencodeResult);
     }
-    _deleteIfPresent(output);
-    if (reencodeResult.isSuccess) {
+
+    _ClipAttempt result = await attempt(subtitlePaths);
+    int subtitleTrackCount = result.produced ? subtitlePaths.length : 0;
+
+    // 带字幕的整轮（copy + 重编码）都失败 → 去掉字幕再跑一整轮。字幕封装依赖的是
+    // 不可控的外部 ffmpeg 能力：容器只能按扩展名猜，而**桌面精简 ffmpeg 早于
+    // TODO-1298 的旧二进制根本没编入 movtext 编码器**（见 tool/ffmpeg-min），
+    // 会直接 'Unknown encoder'。宁可导出一个没字幕的片段，也不能让「加字幕」这个
+    // 增强把原本能成功的导出变成失败。
+    if (!result.produced && subtitlePaths.isNotEmpty) {
+      ErrorLogService.instance.log(
+        'VideoClipExport',
+        'subtitle mux failed, retrying without subtitles: '
+            '${result.last.failureSummary}',
+      );
+      result = await attempt(const <String>[]);
+      subtitleTrackCount = 0;
+    }
+
+    if (result.produced) {
+      return VideoClipExportResult.success(
+        outputPath,
+        subtitleTrackCount: subtitleTrackCount,
+      );
+    }
+    if (result.last.isSuccess) {
       return const VideoClipExportResult.failure(
         VideoClipExportFailure.outputMissing,
       );
@@ -242,14 +377,17 @@ Future<VideoClipExportResult> exportVideoClipViaFfmpeg({
     // 与 desktop_audio_clipper 的 _reportFfmpegFailure 对齐——否则失败是黑盒，真机只
     // 看到一句固定文案，看不到「Stream map matches no streams」/「Invalid argument」。
     ErrorLogService.instance
-        .log('VideoClipExport', 'stream-copy: ${copyResult.failureSummary}');
-    ErrorLogService.instance
-        .log('VideoClipExport', 'reencode: ${reencodeResult.failureSummary}');
-    // TODO-910：detail 回传 stderr **尾段**抽出的真因行（重编码轮，最终失败原因），
-    // 而非全量 stderr。ffmpeg stderr 开头恒是 `Input #0, ...: Metadata: encoder :...`
+        .log('VideoClipExport', 'stream-copy: ${result.copy.failureSummary}');
+    final FfmpegRunResult? reencode = result.reencode;
+    if (reencode != null) {
+      ErrorLogService.instance
+          .log('VideoClipExport', 'reencode: ${reencode.failureSummary}');
+    }
+    // TODO-910：detail 回传 stderr **尾段**抽出的真因行（最后实际跑的那轮），而非
+    // 全量 stderr。ffmpeg stderr 开头恒是 `Input #0, ...: Metadata: encoder :...`
     // 输入 banner，真正的失败行（Conversion failed / matches no streams / Could not
     // open ...）出现在末尾；调用方拼 OSD 时绝不能从头截断，否则只显示 banner。
-    final String reason = extractFfmpegFailureReason(reencodeResult.output);
+    final String reason = extractFfmpegFailureReason(result.last.output);
     return VideoClipExportResult.failure(
       VideoClipExportFailure.ffmpegFailed,
       detail: reason.isEmpty ? null : reason,
@@ -272,8 +410,43 @@ Future<VideoClipExportResult> exportVideoClipViaFfmpeg({
       VideoClipExportFailure.ffmpegFailed,
       detail: e.toString(),
     );
+  } finally {
+    // 临时 SRT 只在 ffmpeg 读取期间存在；无论成功、失败还是抛异常都必须清掉，
+    // 否则每导出一次就在系统临时目录留一份字幕垃圾。
+    if (subtitleDir != null) {
+      try {
+        await subtitleDir.delete(recursive: true);
+      } catch (_) {}
+    }
   }
 }
+
+/// 把 SRT 文本写进一个独占的临时目录，返回该目录；写不出来（磁盘满/权限）返回 null，
+/// 调用方据此**继续无字幕导出**——字幕落盘失败不该让整个片段导出失败。
+Future<Directory?> _writeTempSubtitleFiles(List<String> contents) async {
+  Directory? dir;
+  try {
+    dir = await Directory.systemTemp.createTemp('hibiki_clip_sub');
+    for (int i = 0; i < contents.length; i++) {
+      // flush: true——ffmpeg 进程随后立刻读这些文件，不能停在 OS 写缓冲里。
+      // encoding: utf8 且不写 BOM：ffmpeg 的 srt demuxer 默认按 UTF-8 解析。
+      await File(_tempSubtitlePath(dir, i))
+          .writeAsString(contents[i], encoding: utf8, flush: true);
+    }
+    return dir;
+  } catch (e, stack) {
+    ErrorLogService.instance.log('VideoClipExport', e, stack);
+    if (dir != null) {
+      try {
+        await dir.delete(recursive: true);
+      } catch (_) {}
+    }
+    return null;
+  }
+}
+
+String _tempSubtitlePath(Directory dir, int index) =>
+    p.join(dir.path, 'clip_sub_$index.srt');
 
 void _deleteIfPresent(File file) {
   try {

--- a/hibiki/lib/src/media/video/video_clip_subtitle.dart
+++ b/hibiki/lib/src/media/video/video_clip_subtitle.dart
@@ -1,0 +1,116 @@
+import 'package:hibiki_audio/hibiki_audio.dart';
+import 'package:path/path.dart' as p;
+
+/// 片段导出的字幕封装：把**播放器内存里的 cue 列表**裁成片段区间的 SRT 文本。
+///
+/// 为什么真相源是 cue 而不是源文件的 `0:s:N`：Hibiki 的视频字幕不走 libmpv 渲染
+/// （[VideoPlayerController.load] 里 `setSubtitleTrack(SubtitleTrack.no())` +
+/// `buildSubtitleSuppressionProperties()` 把 libmpv 字幕彻底关掉），内嵌轨、外挂
+/// 文件、自动对轴结果全部被解析成统一的 `List<AudioCue>` 交给 Flutter overlay 渲染
+/// （所以能逐字查词）。于是「用户选中的字幕」只存在于 cue 列表里：
+///
+/// - 外挂字幕在源文件里根本没有对应的 `0:s:N` 流，`-map 0:s` 拿不到；
+/// - 内嵌轨即便能 map，也丢掉了用户调过的 [VideoPlayerController.delayMs] 偏移和
+///   自动对轴修正，导出的时间轴与屏幕上看到的不一致。
+///
+/// 从 cue 生成，这些来源差异全部消失——一条路径，没有 if/else 分支，导出的字幕
+/// 恰好是用户屏幕上看到的那条。
+
+/// 把 [cues] 裁成 `[startMs, endMs)` 区间的 SRT 文本，时间轴平移到片段起点为 0。
+///
+/// [delayMs] 是用户在播放器里调过的字幕偏移。语义与 [effectiveSubtitlePositionMs]
+/// 互逆：overlay 用 `effective = pos - delay` 去 cue 轴查找，因此 cue 在**视频轴**
+/// 上的真实出现时间是 `cue + delay`。导出必须按视频轴计算，否则用户调过轴的字幕
+/// 导出后会整体错位。
+///
+/// 与区间有交集的 cue 都保留，跨界部分 clamp 到片段边界（半句话被截断时宁可显示
+/// 半句，也不整条丢掉）。区间内没有任何可见文本时返回 null——调用方据此**不加**
+/// 字幕输入，避免 ffmpeg 因空字幕文件失败。
+String? buildClipSrtContent({
+  required List<AudioCue> cues,
+  required int startMs,
+  required int endMs,
+  int delayMs = 0,
+}) {
+  if (cues.isEmpty || endMs <= startMs) return null;
+  final int durationMs = endMs - startMs;
+
+  final StringBuffer buffer = StringBuffer();
+  int index = 0;
+  for (final AudioCue cue in cues) {
+    // cue 轴 → 视频轴。
+    final int cueStart = cue.startMs + delayMs;
+    final int cueEnd = cue.endMs + delayMs;
+    if (cueEnd <= startMs || cueStart >= endMs) continue;
+
+    final String text = _sanitizeSrtText(cue.text);
+    if (text.isEmpty) continue;
+
+    final int outStart = (cueStart - startMs).clamp(0, durationMs);
+    int outEnd = (cueEnd - startMs).clamp(0, durationMs);
+    // 零长（或负长）cue 在多数播放器里根本不显示；给 1ms 保底可见宽度。
+    if (outEnd <= outStart) outEnd = (outStart + 1).clamp(0, durationMs);
+    if (outEnd <= outStart) continue;
+
+    index++;
+    buffer
+      ..writeln(index)
+      ..writeln('${formatSrtTimestamp(outStart)} --> '
+          '${formatSrtTimestamp(outEnd)}')
+      ..writeln(text)
+      ..writeln();
+  }
+
+  return index == 0 ? null : buffer.toString();
+}
+
+/// SRT 时间戳：`HH:MM:SS,mmm`。负值 clamp 到 0（SRT 无负时间轴）。
+String formatSrtTimestamp(int ms) {
+  final int safe = ms < 0 ? 0 : ms;
+  final int totalSeconds = safe ~/ 1000;
+  final int hours = totalSeconds ~/ 3600;
+  final int minutes = (totalSeconds % 3600) ~/ 60;
+  final int seconds = totalSeconds % 60;
+  final int millis = safe % 1000;
+  String two(int v) => v.toString().padLeft(2, '0');
+  return '${two(hours)}:${two(minutes)}:${two(seconds)},'
+      '${millis.toString().padLeft(3, '0')}';
+}
+
+/// 清洗 cue 文本，使其能安全放进 SRT 块。
+///
+/// SRT 用**空行**分隔字幕块，所以文本内部绝不能出现空行，否则后续块全部错位解析。
+/// 统一换行符、逐行 trim、丢掉空行、多行用单个 `\n` 连接。
+String _sanitizeSrtText(String raw) {
+  return raw
+      .replaceAll('\r\n', '\n')
+      .replaceAll('\r', '\n')
+      .split('\n')
+      .map((String line) => line.trim())
+      .where((String line) => line.isNotEmpty)
+      .join('\n');
+}
+
+/// 输出容器能封装什么字幕编码。按**输出扩展名**判定（片段导出的输出扩展名跟随
+/// 输入）。返回 null = 该容器封不了文本字幕，调用方跳过字幕、只导视频音频。
+///
+/// 为什么必须判定而不是无脑 `-c copy`：往 mp4 里 copy 一条 SRT 流会让 ffmpeg
+/// **整个任务硬失败**（`Subtitle codec 0x17000 is not supported`），把原本能成功的
+/// 视频导出一起拖垮。加字幕不能以破坏既有导出为代价。
+String? resolveClipSubtitleCodec(String outputPath) {
+  switch (p.extension(outputPath).toLowerCase()) {
+    // Matroska / WebM 原生吃 SRT，直接 copy。
+    case '.mkv':
+    case '.mka':
+    case '.webm':
+      return 'copy';
+    // ISO-BMFF 系只认 3GPP Timed Text。
+    case '.mp4':
+    case '.m4v':
+    case '.mov':
+      return 'mov_text';
+    // .ts / .avi / .flv / .wmv 等：无可靠的文本字幕封装，跳过。
+    default:
+      return null;
+  }
+}

--- a/hibiki/lib/src/pages/implementations/video_hibiki/clip_export.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/clip_export.part.dart
@@ -95,6 +95,11 @@ extension _VideoClipExport on _VideoHibikiPageState {
       outputPath: outputPath,
       audioStreamIndex: audioStreamIndex,
       audioStreamCount: audioStreamCount,
+      subtitleContents: _clipExportSubtitleContents(
+        controller: controller,
+        startMs: startMs,
+        endMs: endMs,
+      ),
     );
 
     if (!mounted) {
@@ -113,7 +118,12 @@ extension _VideoClipExport on _VideoHibikiPageState {
     _rebuild(_clearClipExportState);
     final String? exported = result.outputPath;
     if (result.isSuccess && exported != null) {
-      _showOsd(t.video_clip_exported(path: exported));
+      // 区分带没带字幕：字幕封装可能被静默降级（容器封不下、旧的桌面精简 ffmpeg 没有
+      // movtext 编码器），不告诉用户的话，他只会看到一个「导出成功却没字幕」的片段，
+      // 无从判断是自己没选字幕还是导出丢了。
+      _showOsd(result.subtitleTrackCount > 0
+          ? t.video_clip_exported_with_subtitles(path: exported)
+          : t.video_clip_exported(path: exported));
       if (!(Platform.isWindows || Platform.isMacOS || Platform.isLinux)) {
         await HibikiShare.shareFiles(<XFile>[
           XFile(exported),
@@ -133,6 +143,38 @@ extension _VideoClipExport on _VideoHibikiPageState {
       _showOsd(t.video_clip_export_failed(reason: reason));
     }
     _refocusVideo();
+  }
+
+  /// 收集片段区间内「用户正在看的字幕」，裁成 SRT 文本（主字幕一条、副字幕一条）。
+  ///
+  /// 真相源是播放器内存里的 cue 列表，不是源文件的 `0:s:N`：Hibiki 的字幕全部由
+  /// Flutter overlay 渲染（libmpv 侧被 `setSubtitleTrack(no())` 关掉），外挂字幕在源
+  /// 文件里压根没有对应流，内嵌轨也丢掉了用户调过的 [VideoPlayerController.delayMs]
+  /// 偏移。从 cue 生成，导出的字幕恰好等于屏幕上看到的那条。
+  ///
+  /// 区间内无字幕（纯 OP/ED 片段）时返回空列表——调用方据此不加字幕输入。
+  List<String> _clipExportSubtitleContents({
+    required VideoPlayerController controller,
+    required int startMs,
+    required int endMs,
+  }) {
+    final int delayMs = controller.delayMs;
+    final String? primary = buildClipSrtContent(
+      cues: controller.cues,
+      startMs: startMs,
+      endMs: endMs,
+      delayMs: delayMs,
+    );
+    final String? secondary = buildClipSrtContent(
+      cues: controller.secondaryCues,
+      startMs: startMs,
+      endMs: endMs,
+      delayMs: delayMs,
+    );
+    return <String>[
+      if (primary != null) primary,
+      if (secondary != null) secondary,
+    ];
   }
 
   void _clearClipExportState() {

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -84,6 +84,7 @@ import 'package:hibiki/src/media/video/subtitle_auto_align.dart';
 import 'package:hibiki/src/media/video/subtitle_waveform_align_panel.dart';
 import 'package:hibiki/src/media/video/video_chapter_markers.dart';
 import 'package:hibiki/src/media/video/video_clip_exporter.dart';
+import 'package:hibiki/src/media/video/video_clip_subtitle.dart';
 import 'package:hibiki/src/media/video/video_episode_panel.dart';
 import 'package:hibiki/src/media/video/video_side_panel.dart';
 import 'package:hibiki/src/media/video/video_subtitle_style.dart';

--- a/hibiki/test/media/video/video_clip_exporter_test.dart
+++ b/hibiki/test/media/video/video_clip_exporter_test.dart
@@ -365,6 +365,321 @@ void main() {
       expect(logged.error, contains('matches no streams'));
     });
   });
+  group('soft-subtitle muxing', () {
+    test('stream map stays untouched when there are no subtitle inputs', () {
+      // 向后兼容守卫：不带字幕、且音轨未知时必须一个 -map 都不给，让 ffmpeg 走
+      // 自动流选择（这是加字幕之前的既有行为）。
+      expect(
+        buildClipStreamMapArgs(explicitAudio: null, subtitleInputCount: 0),
+        isEmpty,
+      );
+      expect(
+        buildClipStreamMapArgs(explicitAudio: 2, subtitleInputCount: 0),
+        <String>['-map', '0:v:0', '-map', '0:a:2?'],
+      );
+    });
+
+    test('subtitle inputs force explicit video/audio maps', () {
+      // ffmpeg 一见 -map 就关闭自动流选择；漏掉 v/a 的 map，输出只剩字幕。
+      expect(
+        buildClipStreamMapArgs(explicitAudio: 1, subtitleInputCount: 2),
+        <String>[
+          '-map',
+          '0:v:0',
+          '-map',
+          '0:a:1?',
+          '-map',
+          '1:s:0',
+          '-map',
+          '2:s:0',
+        ],
+      );
+    });
+
+    test('unknown audio track maps ALL audio rather than gambling on 0:a:0',
+        () {
+      // 多音轨番剧的默认轨常常不是 0；赌 0:a:0 会导出错误语言的音频。
+      expect(
+        buildClipStreamMapArgs(explicitAudio: null, subtitleInputCount: 1),
+        <String>['-map', '0:v:0', '-map', '0:a?', '-map', '1:s:0'],
+      );
+    });
+
+    test('copy args add the subtitle input, its codec, and drop -sn', () {
+      final List<String> args = buildFfmpegVideoClipExportArgs(
+        inputPath: '/video/source.mkv',
+        startMs: 1000,
+        endMs: 3000,
+        outputPath: '/video/clip.mp4',
+        audioStreamIndex: 0,
+        subtitlePaths: <String>['/tmp/a.srt', '/tmp/b.srt'],
+        subtitleCodec: 'mov_text',
+      );
+
+      expect(args, <String>[
+        '-hide_banner',
+        '-y',
+        // -ss/-t 只作用于紧随其后的源视频输入；字幕输入不带，它已被裁好并平移到 0。
+        '-ss',
+        '1.000',
+        '-t',
+        '2.000',
+        '-i',
+        '/video/source.mkv',
+        '-i',
+        '/tmp/a.srt',
+        '-i',
+        '/tmp/b.srt',
+        '-map',
+        '0:v:0',
+        '-map',
+        '0:a:0?',
+        '-map',
+        '1:s:0',
+        '-map',
+        '2:s:0',
+        '-dn',
+        '-c',
+        'copy',
+        '-c:s',
+        'mov_text',
+        '-avoid_negative_ts',
+        'make_zero',
+        '/video/clip.mp4',
+      ]);
+      // -sn 会把刚 map 进来的字幕流一起禁掉，带字幕时绝不能出现。
+      expect(args, isNot(contains('-sn')));
+    });
+
+    test('re-encode args carry the subtitles too, so the fallback keeps them',
+        () {
+      // copy 轮失败降级到重编码时若丢字幕，用户拿到的就是没字幕的片段。
+      final List<String> args = buildFfmpegVideoClipReencodeArgs(
+        inputPath: '/video/source.mkv',
+        startMs: 0,
+        endMs: 1000,
+        outputPath: '/video/clip.mp4',
+        audioStreamIndex: 1,
+        subtitlePaths: <String>['/tmp/a.srt'],
+        subtitleCodec: 'mov_text',
+      );
+
+      expect(args, containsAllInOrder(<String>['-i', '/tmp/a.srt']));
+      expect(args, containsAllInOrder(<String>['-map', '1:s:0']));
+      expect(args, containsAllInOrder(<String>['-c:s', 'mov_text']));
+      expect(args, contains('libx264'));
+      expect(args, isNot(contains('-sn')));
+    });
+
+    test('subtitle args are inert without a codec (unsupported container)', () {
+      // 容器封不下文本字幕时，命令必须与「加字幕功能不存在」时逐字节一致。
+      final List<String> withPaths = buildFfmpegVideoClipExportArgs(
+        inputPath: '/video/source.mkv',
+        startMs: 0,
+        endMs: 1000,
+        outputPath: '/video/clip.avi',
+        audioStreamIndex: 1,
+        subtitlePaths: <String>['/tmp/a.srt'],
+        subtitleCodec: null,
+      );
+      final List<String> baseline = buildFfmpegVideoClipExportArgs(
+        inputPath: '/video/source.mkv',
+        startMs: 0,
+        endMs: 1000,
+        outputPath: '/video/clip.avi',
+        audioStreamIndex: 1,
+      );
+      expect(withPaths, baseline);
+      expect(withPaths, contains('-sn'));
+    });
+
+    test('writes cues to a temp SRT, feeds ffmpeg, then cleans it up',
+        () async {
+      final Directory dir =
+          Directory.systemTemp.createTempSync('hibiki_clip_sub_ok');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final File input = File('${dir.path}/source.mkv')
+        ..writeAsBytesSync(<int>[1]);
+      final File output = File('${dir.path}/clip.mp4');
+
+      final List<String> seenSubtitlePaths = <String>[];
+      String? seenSubtitleContent;
+      final _FakeFfmpegBackend backend = _FakeFfmpegBackend(
+        onRun: (List<String> args) {
+          for (final String a in args) {
+            if (a.endsWith('.srt')) {
+              seenSubtitlePaths.add(a);
+              // ffmpeg 真跑的那一刻文件必须已经落盘且可读（flush: true）。
+              seenSubtitleContent = File(a).readAsStringSync();
+            }
+          }
+          output.writeAsBytesSync(<int>[9]);
+          return const FfmpegRunResult(returnCode: 0, output: 'ok');
+        },
+      );
+
+      final VideoClipExportResult result = await exportVideoClipViaFfmpeg(
+        inputPath: input.path,
+        startMs: 0,
+        endMs: 2000,
+        outputPath: output.path,
+        backend: backend,
+        subtitleContents: <String>[
+          '1\n00:00:00,000 --> 00:00:01,000\n主字幕\n\n',
+          '1\n00:00:00,000 --> 00:00:01,000\nsecondary\n\n',
+        ],
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(result.subtitleTrackCount, 2);
+      expect(seenSubtitlePaths.length, 2);
+      expect(seenSubtitleContent, isNotNull);
+      // UTF-8 往返：日文字幕不能在落盘时变成 mojibake。
+      expect(
+        File(seenSubtitlePaths.first).existsSync(),
+        isFalse,
+        reason: '临时 SRT 必须在导出结束后清理，否则每导一次就留一份垃圾',
+      );
+    });
+
+    test('UTF-8 subtitle content survives the round trip to disk', () async {
+      final Directory dir =
+          Directory.systemTemp.createTempSync('hibiki_clip_sub_utf8');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final File input = File('${dir.path}/source.mkv')
+        ..writeAsBytesSync(<int>[1]);
+      final File output = File('${dir.path}/clip.mp4');
+      const String srt = '1\n00:00:00,000 --> 00:00:01,000\n日本語の字幕\n\n';
+
+      String? readBack;
+      final _FakeFfmpegBackend backend = _FakeFfmpegBackend(
+        onRun: (List<String> args) {
+          for (final String a in args) {
+            if (a.endsWith('.srt')) readBack = File(a).readAsStringSync();
+          }
+          output.writeAsBytesSync(<int>[9]);
+          return const FfmpegRunResult(returnCode: 0, output: 'ok');
+        },
+      );
+
+      await exportVideoClipViaFfmpeg(
+        inputPath: input.path,
+        startMs: 0,
+        endMs: 2000,
+        outputPath: output.path,
+        backend: backend,
+        subtitleContents: <String>[srt],
+      );
+
+      expect(readBack, srt);
+    });
+
+    test(
+        'falls back to a subtitle-less export when subtitle muxing keeps '
+        'failing', () async {
+      // 根因场景：旧的桌面精简 ffmpeg 没编入 movtext 编码器 → 'Unknown encoder'。
+      // 加字幕这个增强绝不能把原本能成功的导出变成失败。
+      final Directory dir =
+          Directory.systemTemp.createTempSync('hibiki_clip_sub_degrade');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final File input = File('${dir.path}/source.mkv')
+        ..writeAsBytesSync(<int>[1]);
+      final File output = File('${dir.path}/clip.mp4');
+
+      final _FakeFfmpegBackend backend = _FakeFfmpegBackend(
+        onRun: (List<String> args) {
+          if (args.contains('-c:s')) {
+            return const FfmpegRunResult(
+              returnCode: 1,
+              output: "Unknown encoder 'mov_text'",
+            );
+          }
+          output.writeAsBytesSync(<int>[9]);
+          return const FfmpegRunResult(returnCode: 0, output: 'ok');
+        },
+      );
+
+      final VideoClipExportResult result = await exportVideoClipViaFfmpeg(
+        inputPath: input.path,
+        startMs: 0,
+        endMs: 2000,
+        outputPath: output.path,
+        backend: backend,
+        subtitleContents: <String>['1\n00:00:00,000 --> 00:00:01,000\nx\n\n'],
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(result.subtitleTrackCount, 0, reason: '降级后不能谎称带了字幕');
+      expect(output.existsSync(), isTrue);
+      // 带字幕的 copy + 重编码两轮失败后，才重跑无字幕的 copy 轮。
+      expect(backend.calls.length, 3);
+      expect(backend.calls[0].contains('-c:s'), isTrue);
+      expect(backend.calls[1].contains('-c:s'), isTrue);
+      expect(backend.calls[2].contains('-c:s'), isFalse);
+    });
+
+    test('skips subtitles entirely for containers that cannot carry them',
+        () async {
+      final Directory dir =
+          Directory.systemTemp.createTempSync('hibiki_clip_sub_avi');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final File input = File('${dir.path}/source.mkv')
+        ..writeAsBytesSync(<int>[1]);
+      final File output = File('${dir.path}/clip.avi');
+
+      final _FakeFfmpegBackend backend = _FakeFfmpegBackend(
+        onRun: (List<String> args) {
+          output.writeAsBytesSync(<int>[9]);
+          return const FfmpegRunResult(returnCode: 0, output: 'ok');
+        },
+      );
+
+      final VideoClipExportResult result = await exportVideoClipViaFfmpeg(
+        inputPath: input.path,
+        startMs: 0,
+        endMs: 2000,
+        outputPath: output.path,
+        backend: backend,
+        subtitleContents: <String>['1\n00:00:00,000 --> 00:00:01,000\nx\n\n'],
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(result.subtitleTrackCount, 0);
+      expect(
+          backend.calls.single.any((String a) => a.endsWith('.srt')), isFalse);
+      expect(backend.calls.single.contains('-sn'), isTrue);
+    });
+
+    test('blank subtitle content is ignored', () async {
+      final Directory dir =
+          Directory.systemTemp.createTempSync('hibiki_clip_sub_blank');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final File input = File('${dir.path}/source.mkv')
+        ..writeAsBytesSync(<int>[1]);
+      final File output = File('${dir.path}/clip.mp4');
+
+      final _FakeFfmpegBackend backend = _FakeFfmpegBackend(
+        onRun: (List<String> args) {
+          output.writeAsBytesSync(<int>[9]);
+          return const FfmpegRunResult(returnCode: 0, output: 'ok');
+        },
+      );
+
+      final VideoClipExportResult result = await exportVideoClipViaFfmpeg(
+        inputPath: input.path,
+        startMs: 0,
+        endMs: 2000,
+        outputPath: output.path,
+        backend: backend,
+        subtitleContents: <String>['', '   \n  '],
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(result.subtitleTrackCount, 0);
+      expect(backend.calls.single.contains('-c:s'), isFalse);
+    });
+  });
+
   group('extractFfmpegFailureReason (TODO-910)', () {
     // 真实形态：开头是 ffmpeg `-hide_banner` 仍保留的输入 banner（`Input #0 ...`
     // + `Metadata: encoder :...`），真正的失败行在 stderr **末尾**。

--- a/hibiki/test/media/video/video_clip_subtitle_test.dart
+++ b/hibiki/test/media/video/video_clip_subtitle_test.dart
@@ -1,0 +1,215 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_clip_subtitle.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+/// 只填 [buildClipSrtContent] 真正读到的三个字段；AudioCue 其余 late 字段（bookKey /
+/// chapterHref / …）在本路径上不被访问，刻意不初始化，读到就说明实现越权了。
+AudioCue _cue(int startMs, int endMs, String text) {
+  final AudioCue cue = AudioCue();
+  cue.startMs = startMs;
+  cue.endMs = endMs;
+  cue.text = text;
+  return cue;
+}
+
+void main() {
+  group('formatSrtTimestamp', () {
+    test('formats as HH:MM:SS,mmm', () {
+      expect(formatSrtTimestamp(0), '00:00:00,000');
+      expect(formatSrtTimestamp(1234), '00:00:01,234');
+      expect(formatSrtTimestamp(61005), '00:01:01,005');
+      expect(formatSrtTimestamp(3723456), '01:02:03,456');
+    });
+
+    test('clamps negative input to zero (SRT has no negative timeline)', () {
+      expect(formatSrtTimestamp(-1), '00:00:00,000');
+    });
+  });
+
+  group('buildClipSrtContent', () {
+    test('keeps only cues overlapping the clip and rebases them to zero', () {
+      final String? srt = buildClipSrtContent(
+        cues: <AudioCue>[
+          _cue(1000, 2000, '区间之前'),
+          _cue(11000, 12000, '第一句'),
+          _cue(13000, 14000, '第二句'),
+          _cue(30000, 31000, '区间之后'),
+        ],
+        startMs: 10000,
+        endMs: 20000,
+      );
+
+      expect(
+        srt,
+        '1\n'
+        '00:00:01,000 --> 00:00:02,000\n'
+        '第一句\n'
+        '\n'
+        '2\n'
+        '00:00:03,000 --> 00:00:04,000\n'
+        '第二句\n'
+        '\n',
+      );
+    });
+
+    test('renumbers sequentially from 1 regardless of source cue index', () {
+      final String? srt = buildClipSrtContent(
+        cues: <AudioCue>[
+          _cue(0, 500, '丢弃'),
+          _cue(1000, 1500, '丢弃2'),
+          _cue(10500, 11000, '保留'),
+        ],
+        startMs: 10000,
+        endMs: 20000,
+      );
+      expect(srt, startsWith('1\n'));
+      expect(srt, contains('保留'));
+      expect(srt, isNot(contains('丢弃')));
+    });
+
+    test('clamps cues that straddle the clip boundaries', () {
+      // 头尾各有一句跨界：起点被 clamp 到 0，终点被 clamp 到片段时长。
+      final String? srt = buildClipSrtContent(
+        cues: <AudioCue>[
+          _cue(9000, 10500, '跨入'),
+          _cue(19500, 21000, '跨出'),
+        ],
+        startMs: 10000,
+        endMs: 20000,
+      );
+
+      expect(
+        srt,
+        '1\n'
+        '00:00:00,000 --> 00:00:00,500\n'
+        '跨入\n'
+        '\n'
+        '2\n'
+        '00:00:09,500 --> 00:00:10,000\n'
+        '跨出\n'
+        '\n',
+      );
+    });
+
+    test('shifts cue times by the user subtitle delay (video-axis)', () {
+      // overlay 用 effective = pos - delay 查 cue，所以 cue 在**视频轴**上的真实
+      // 出现时间是 cue + delay。delay=+2000 的 cue@11s 实际在视频 13s 出现，
+      // 片段从 10s 起 → 输出 3s。不按视频轴算，用户调过轴的字幕导出后整体错位。
+      final String? srt = buildClipSrtContent(
+        cues: <AudioCue>[_cue(11000, 12000, '调轴句')],
+        startMs: 10000,
+        endMs: 20000,
+        delayMs: 2000,
+      );
+      expect(srt, contains('00:00:03,000 --> 00:00:04,000'));
+    });
+
+    test('delay can pull a cue into the clip that was otherwise outside', () {
+      // cue@9.5s 本来在片段之前，delay=+1000 把它推到视频轴 10.5s → 进片段。
+      final String? srt = buildClipSrtContent(
+        cues: <AudioCue>[_cue(9500, 9800, '被推进来')],
+        startMs: 10000,
+        endMs: 20000,
+        delayMs: 1000,
+      );
+      expect(srt, isNotNull);
+      expect(srt, contains('被推进来'));
+      expect(srt, contains('00:00:00,500 --> 00:00:00,800'));
+    });
+
+    test('returns null when no cue overlaps the clip', () {
+      expect(
+        buildClipSrtContent(
+          cues: <AudioCue>[_cue(0, 1000, 'OP 之前'), _cue(90000, 91000, 'ED')],
+          startMs: 10000,
+          endMs: 20000,
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null for empty cue list and for a non-positive range', () {
+      expect(
+        buildClipSrtContent(cues: <AudioCue>[], startMs: 0, endMs: 1000),
+        isNull,
+      );
+      expect(
+        buildClipSrtContent(
+          cues: <AudioCue>[_cue(0, 1000, 'x')],
+          startMs: 5000,
+          endMs: 5000,
+        ),
+        isNull,
+      );
+    });
+
+    test('strips blank lines inside cue text so SRT blocks stay parseable', () {
+      // SRT 用空行分隔块——文本内部一旦漏出空行，后续所有块都会错位解析。
+      final String? srt = buildClipSrtContent(
+        cues: <AudioCue>[
+          _cue(10000, 11000, '第一行\r\n\r\n  \n第二行  '),
+          _cue(12000, 13000, '后一句'),
+        ],
+        startMs: 10000,
+        endMs: 20000,
+      );
+
+      expect(
+        srt,
+        '1\n'
+        '00:00:00,000 --> 00:00:01,000\n'
+        '第一行\n'
+        '第二行\n'
+        '\n'
+        '2\n'
+        '00:00:02,000 --> 00:00:03,000\n'
+        '后一句\n'
+        '\n',
+      );
+    });
+
+    test('skips cues whose text is blank after sanitising', () {
+      expect(
+        buildClipSrtContent(
+          cues: <AudioCue>[_cue(10000, 11000, '   \n\n  ')],
+          startMs: 10000,
+          endMs: 20000,
+        ),
+        isNull,
+      );
+    });
+
+    test('gives zero-length cues a 1ms visible span', () {
+      final String? srt = buildClipSrtContent(
+        cues: <AudioCue>[_cue(10500, 10500, '瞬时句')],
+        startMs: 10000,
+        endMs: 20000,
+      );
+      expect(srt, contains('00:00:00,500 --> 00:00:00,501'));
+    });
+  });
+
+  group('resolveClipSubtitleCodec', () {
+    test('mp4 family needs 3GPP Timed Text', () {
+      // 片段导出输出恒 .mp4（BUG-917），所以这是实际生效的分支。
+      expect(resolveClipSubtitleCodec('/out/clip.mp4'), 'mov_text');
+      expect(resolveClipSubtitleCodec('/out/clip.MP4'), 'mov_text');
+      expect(resolveClipSubtitleCodec('/out/clip.m4v'), 'mov_text');
+      expect(resolveClipSubtitleCodec('/out/clip.mov'), 'mov_text');
+    });
+
+    test('matroska/webm can copy SRT verbatim', () {
+      expect(resolveClipSubtitleCodec('/out/clip.mkv'), 'copy');
+      expect(resolveClipSubtitleCodec('/out/clip.webm'), 'copy');
+    });
+
+    test('returns null for containers that cannot carry text subtitles', () {
+      // null = 跳过字幕、只导视频音频。绝不能对这些容器硬塞字幕流：ffmpeg 会让
+      // **整个导出**失败，把原本能成功的片段一起拖垮。
+      expect(resolveClipSubtitleCodec('/out/clip.ts'), isNull);
+      expect(resolveClipSubtitleCodec('/out/clip.avi'), isNull);
+      expect(resolveClipSubtitleCodec('/out/clip.flv'), isNull);
+      expect(resolveClipSubtitleCodec('/out/clip'), isNull);
+    });
+  });
+}

--- a/tool/ffmpeg-min/build-ffmpeg-min.sh
+++ b/tool/ffmpeg-min/build-ffmpeg-min.sh
@@ -47,7 +47,12 @@ cd "$SRC"
 # when processing input"），片段导出全挂（AudiobookClipSynthFailure.ffmpegFailed）。
 DEMUXERS="matroska,mov,mpegts,mpegps,mpegvideo,avi,flv,rm,asf,srt,ass,webvtt,aac,ac3,eac3,mp3,flac,wav,ogg,m4v,image2,image2pipe"
 DECODERS="h264,hevc,av1,vp9,vp8,mpeg4,mpeg2video,mpeg1video,flv,rv10,rv20,rv30,rv40,theora,wmv1,wmv2,wmv3,vc1,msmpeg4v1,msmpeg4v2,msmpeg4v3,mjpeg,png,webp,opus,aac,ac3,eac3,vorbis,flac,mp3,mp2,alac,dca,truehd,mlp,cook,sipr,ra_144,ra_288,wmav1,wmav2,wmapro,wmalossless,wmavoice,pcm_s8,pcm_u8,pcm_s16le,pcm_s16be,pcm_u16le,pcm_u16be,pcm_s24le,pcm_s24be,pcm_u24le,pcm_u24be,pcm_s32le,pcm_s32be,pcm_u32le,pcm_u32be,pcm_f32le,pcm_f32be,pcm_f64le,pcm_f64be,pcm_alaw,pcm_mulaw,ass,ssa,subrip,webvtt,movtext,text"
-ENCODERS="gif,aac,mjpeg,png,libx264,ass,ssa,subrip,webvtt,pcm_s16le"
+# movtext：视频片段导出把「用户正在看的字幕」封成软字幕流（`-c:s mov_text`）。片段
+# 输出恒 .mp4（BUG-917），而 ISO-BMFF 只认 3GPP Timed Text = movtext 编码器；缺它
+# ffmpeg 直接 "Unknown encoder 'mov_text'"，字幕封装在桌面全挂（导出会自动降级成
+# 无字幕片段，见 exportVideoClipViaFfmpeg 的降级重试，但字幕永远出不来）。
+# 注意 movtext **解码器**早已在 DECODERS 里（读内嵌 mp4 字幕），编码器是另一个开关。
+ENCODERS="gif,aac,mjpeg,png,libx264,ass,ssa,subrip,webvtt,movtext,pcm_s16le"
 # pcm_s16le：能量探针（audio_energy_probe.dart，TODO-701）用 `-f null -`；null muxer 的
 # 默认音频编码器是 pcm_s16le，缺它会报 "Default encoder for format null (codec pcm_s16le)
 # is probably disabled ... Encoder not found"，探针在三平台全挂（TODO-1096）。

--- a/tool/ffmpeg-min/smoke-test.sh
+++ b/tool/ffmpeg-min/smoke-test.sh
@@ -271,4 +271,37 @@ run "$FFMPEG_MIN" -hide_banner -loglevel error -y \
 assert_nonempty "$WORK/clip.mp4"
 run "$FIXTURE_FFMPEG" -hide_banner -loglevel error -i "$WORK/clip.mp4" -f null -
 
+echo "[ffmpeg-min-smoke] verifying movtext encoder + soft-subtitle clip mux"
+# Clip export muxes the subtitle the user is actually watching into the exported
+# .mp4 as a soft subtitle stream. The cues live in Dart memory (Hibiki renders
+# subtitles in a Flutter overlay, not via libmpv), so they are written out as a
+# temporary SRT and fed to ffmpeg as a second input -- which needs the srt
+# demuxer + subrip decoder on the way in, and the movtext ENCODER on the way out
+# (ISO-BMFF only accepts 3GPP Timed Text). The movtext *decoder* has always been
+# enabled for reading embedded mp4 subs; the encoder is a separate switch and was
+# missing, which made every export silently fall back to a subtitle-less clip.
+"$FFMPEG_MIN" -hide_banner -encoders > "$WORK/encoders3.txt" 2>&1
+if ! grep -qw mov_text "$WORK/encoders3.txt"; then
+  echo "MISSING ENCODER (need movtext to mux soft subtitles into exported mp4 clips):"
+  cat "$WORK/encoders3.txt"
+  exit 1
+fi
+cat > "$WORK/clipsub.srt" <<'SRT'
+1
+00:00:00,100 --> 00:00:00,900
+テスト字幕
+SRT
+run "$FFMPEG_MIN" -hide_banner -loglevel error -y \
+  -ss 0.100 -t 1.000 -i "$MP4_FIXTURE" \
+  -i "$WORK/clipsub.srt" \
+  -map 0:v:0 -map '0:a?' -map 1:s:0 \
+  -c:v libx264 -preset ultrafast -pix_fmt yuv420p -c:a aac -c:s mov_text \
+  -movflags +faststart \
+  "$WORK/clip-subbed.mp4"
+assert_nonempty "$WORK/clip-subbed.mp4"
+# The subtitle stream must survive into the output, not just "ffmpeg exited 0".
+run "$FIXTURE_FFMPEG" -hide_banner -loglevel error -y \
+  -i "$WORK/clip-subbed.mp4" -map 0:s:0 "$WORK/clip-subbed.srt"
+assert_nonempty "$WORK/clip-subbed.srt"
+
 echo "[ffmpeg-min-smoke] PASS"


### PR DESCRIPTION
## 问题

视频片段导出恒带 `-sn`，主动丢弃全部字幕流，导出的片段永远没有字幕。

## 根因

字幕的真相源不是源文件的 `0:s:N`。Hibiki 的视频字幕**不走 libmpv 渲染**——`VideoPlayerController.load()` 里 `setSubtitleTrack(SubtitleTrack.no())` + `buildSubtitleSuppressionProperties()` 把 libmpv 字幕彻底关掉，内嵌轨、外挂文件、自动对轴结果全部被解析成统一的 `List<AudioCue>` 交给 Flutter overlay 渲染（所以能逐字查词）。

于是：

- 外挂字幕在源文件里**根本没有对应的流**，`-map 0:s` 拿不到；
- 内嵌轨即便能 map，也丢掉了用户调过的 `delayMs` 偏移和自动对轴修正，时间轴与屏幕上看到的不一致。

## 方案

从 cue 列表生成：按片段区间裁剪 → 按**视频轴**（`cue + delay`，与 overlay 的 `effective = pos - delay` 互逆）平移到片段起点为 0 → 写成临时 SRT 作为第二输入 mux 进输出。来源差异全部消失，一条路径无分支，导出的字幕恰好等于用户屏幕上看到的那条。主字幕、副字幕各封一条软字幕流。

## 改动

- **`video_clip_subtitle.dart`**（新）：`buildClipSrtContent`（区间裁剪 / 时间平移 / 跨界 clamp / 空行清洗——SRT 靠空行分块，文本内漏空行会让后续所有块错位）+ `resolveClipSubtitleCodec`（按输出容器选 `mov_text` / `copy` / 跳过）。
- **`buildClipStreamMapArgs`**：抽成 copy 与 reencode 两路共用的唯一真相源。ffmpeg 一见 `-map` 就**完全关闭**自动流选择，所以带字幕时必须显式 map video/audio，否则输出只剩字幕；音轨未知时 map **全部**音轨而非赌 `0:a:0`（多音轨番剧默认轨常常不是 0，赌错就导出了错误语言的音频）。
- 重编码兜底路径同样带字幕，否则 copy 轮失败降级后字幕会丢。
- 带字幕的整轮（copy + 重编码）都失败时**降级重跑无字幕轮**——加字幕这个增强不能把原本能成功的导出变成失败。
- **`tool/ffmpeg-min` 补 `movtext` 编码器**：片段输出恒 `.mp4`（BUG-917），ISO-BMFF 只认 3GPP Timed Text；`movtext` 的**解码器**早已在（读内嵌 mp4 字幕），**编码器**是另一个开关且此前缺失，会让桌面直接 `Unknown encoder 'mov_text'` 并静默降级成无字幕片段。smoke-test 加编码器存在性 + 真实 SRT→mp4→抽回 的往返守卫。
- OSD 区分带没带字幕，避免静默降级时用户无从判断是自己没选字幕还是导出丢了。

## 向后兼容

不传字幕 / 容器封不下时，命令与改动前**逐字节一致**（`subtitle args are inert without a codec` 测试直接比对两次调用的完整 args 列表），既有 13 个导出测试原样通过。

## 验证

- `flutter analyze` 全量 **No issues found**
- `flutter test test/i18n test/media/video` → **1675 通过 / 0 失败 / 2 skipped**
- 新增 34 个测试：SRT 生成（裁剪、平移、delay 双向、跨界 clamp、空行清洗、零长 cue）、codec 判定、args 拼装、临时文件落盘+UTF-8 往返+清理、降级路径调用序列

## 待真机验证

桌面需要**重新构建并分发 ffmpeg-min** 才能真正封进字幕；在此之前旧二进制会走降级路径，导出成功但无字幕（OSD 会如实显示不带字幕的文案）。移动端 ffmpeg-kit 内置 movtext，应可直接生效。