### PR TITLE
feat(games): 游戏库支持设置封面与自动获取封面

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39389 (2317 per locale)
+/// Strings: 39474 (2322 per locale)
 ///
-/// Built on 2026-07-23 at 12:58 UTC
+/// Built on 2026-07-23 at 14:27 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3091,6 +3091,12 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get pdf_bookmarks => 'Bookmarks';
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   String get pdf_bookmark_added => 'Bookmark added';
+  String get games_set_cover => 'Set cover';
+  String get games_auto_cover => 'Fetch cover automatically';
+  String get games_cover_updated => 'Cover updated';
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -8345,6 +8351,17 @@ class _StringsAr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -13672,6 +13689,17 @@ class _StringsDe extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -19015,6 +19043,17 @@ class _StringsEs extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -24369,6 +24408,17 @@ class _StringsFr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -29650,6 +29700,17 @@ class _StringsId extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -34979,6 +35040,17 @@ class _StringsIt extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -40113,6 +40185,17 @@ class _StringsJa extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -45250,6 +45333,17 @@ class _StringsKo extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -50557,6 +50651,17 @@ class _StringsNl extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -55879,6 +55984,17 @@ class _StringsPtBr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -61184,6 +61300,17 @@ class _StringsRu extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -66434,6 +66561,17 @@ class _StringsTh extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -71716,6 +71854,17 @@ class _StringsTr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -76985,6 +77134,17 @@ class _StringsVi extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 // Path: <root>
@@ -81883,6 +82043,16 @@ class _StringsZhCn extends _StringsEn {
   String get pdf_bookmarks_empty => '还没有书签。';
   @override
   String get pdf_bookmark_added => '已添加书签';
+  @override
+  String get games_set_cover => '设置封面';
+  @override
+  String get games_auto_cover => '自动获取封面';
+  @override
+  String get games_cover_updated => '封面已更新';
+  @override
+  String get games_cover_not_found => '游戏目录和程序图标里都没找到可用封面';
+  @override
+  String get games_cover_searching => '正在查找封面...';
 }
 
 // Path: <root>
@@ -86935,6 +87105,17 @@ class _StringsZhHk extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get games_set_cover => 'Set cover';
+  @override
+  String get games_auto_cover => 'Fetch cover automatically';
+  @override
+  String get games_cover_updated => 'Cover updated';
+  @override
+  String get games_cover_not_found =>
+      'No usable cover found in the game folder or executable';
+  @override
+  String get games_cover_searching => 'Looking for a cover...';
 }
 
 /// Flat map(s) containing all translations.
@@ -91665,6 +91846,16 @@ extension on _StringsEn {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -96393,6 +96584,16 @@ extension on _StringsAr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -101142,6 +101343,16 @@ extension on _StringsDe {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -105890,6 +106101,16 @@ extension on _StringsEs {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -110644,6 +110865,16 @@ extension on _StringsFr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -115380,6 +115611,16 @@ extension on _StringsId {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -120131,6 +120372,16 @@ extension on _StringsIt {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -124844,6 +125095,16 @@ extension on _StringsJa {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -129561,6 +129822,16 @@ extension on _StringsKo {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -134305,6 +134576,16 @@ extension on _StringsNl {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -139046,6 +139327,16 @@ extension on _StringsPtBr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -143792,6 +144083,16 @@ extension on _StringsRu {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -148522,6 +148823,16 @@ extension on _StringsTh {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -153261,6 +153572,16 @@ extension on _StringsTr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -157995,6 +158316,16 @@ extension on _StringsVi {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }
@@ -162693,6 +163024,16 @@ extension on _StringsZhCn {
         return '还没有书签。';
       case 'pdf_bookmark_added':
         return '已添加书签';
+      case 'games_set_cover':
+        return '设置封面';
+      case 'games_auto_cover':
+        return '自动获取封面';
+      case 'games_cover_updated':
+        return '封面已更新';
+      case 'games_cover_not_found':
+        return '游戏目录和程序图标里都没找到可用封面';
+      case 'games_cover_searching':
+        return '正在查找封面...';
       default:
         return null;
     }
@@ -167401,6 +167742,16 @@ extension on _StringsZhHk {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'games_set_cover':
+        return 'Set cover';
+      case 'games_auto_cover':
+        return 'Fetch cover automatically';
+      case 'games_cover_updated':
+        return 'Cover updated';
+      case 'games_cover_not_found':
+        return 'No usable cover found in the game folder or executable';
+      case 'games_cover_searching':
+        return 'Looking for a cover...';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "此 PDF 没有目录。",
   "pdf_bookmarks": "书签",
   "pdf_bookmarks_empty": "还没有书签。",
-  "pdf_bookmark_added": "已添加书签"
+  "pdf_bookmark_added": "已添加书签",
+  "games_set_cover": "设置封面",
+  "games_auto_cover": "自动获取封面",
+  "games_cover_updated": "封面已更新",
+  "games_cover_not_found": "游戏目录和程序图标里都没找到可用封面",
+  "games_cover_searching": "正在查找封面..."
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2315,5 +2315,10 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "games_set_cover": "Set cover",
+  "games_auto_cover": "Fetch cover automatically",
+  "games_cover_updated": "Cover updated",
+  "games_cover_not_found": "No usable cover found in the game folder or executable",
+  "games_cover_searching": "Looking for a cover..."
 }

--- a/hibiki/lib/src/mining/galgame_cover_resolver.dart
+++ b/hibiki/lib/src/mining/galgame_cover_resolver.dart
@@ -1,0 +1,354 @@
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:hibiki/src/mining/galgame_exe_icon.dart';
+import 'package:hibiki/src/storage/app_paths.dart';
+import 'package:image/image.dart' as img;
+import 'package:path/path.dart' as p;
+
+/// 游戏库「自动获取封面」的解析器：给一条 [GalgameEntry] 的 exe / 工作目录，
+/// 按**离线级联**挑一张封面并落盘到 `<documents>/game_covers/<id>.<ext>`。
+///
+/// 级联顺序（先便宜且质量高的）：
+///   1. 游戏目录里已有的封面图（`cover.png` / `パッケージ.jpg` / 与游戏同名的图…），
+///      按文件名启发式打分 + 真实像素尺寸校验；
+///   2. exe 内嵌的最大图标（[extractLargestIconPng]，纯 Dart 解析 PE 资源）。
+///
+/// 两级都不中就返回 null（保持默认手柄占位图，不硬塞一张随便的图当封面）。
+/// 全程 **fail-safe**：单个文件读不动 / 解码失败只跳过该候选，不中断整轮解析。
+///
+/// 手动「设置封面」走同一套落盘入口 [saveGameCoverFromFile]，所以自动与手动封面
+/// 在磁盘上同名同目录，替换封面时不会残留两份。
+
+/// 一个待验证的封面候选：路径 + 文件名启发式得分（越大越像封面）。
+class GameCoverCandidate {
+  const GameCoverCandidate({required this.path, required this.score});
+
+  final String path;
+  final int score;
+
+  @override
+  String toString() => 'GameCoverCandidate($path, score: $score)';
+}
+
+/// 允许作为封面来源的图片扩展名（小写，含点）。
+const Set<String> kGameCoverImageExtensions = <String>{
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.webp',
+  '.bmp',
+  '.ico',
+};
+
+/// 封面像素下限：小于它的图当封面会糊成一团（多数是 UI 素材 / 小图标）。
+const int kGameCoverMinPixels = 180;
+
+/// 目录扫描上限：galgame 安装目录常有上万个素材文件，只看前这么多项，避免
+/// 一次自动获取把线程钉在目录枚举上。
+const int kGameCoverScanLimit = 4000;
+
+/// 文件名启发式：命中即加分（key 已是小写；日文按原文匹配）。
+const Map<String, int> _kNamePositiveScores = <String, int>{
+  'cover': 100,
+  'パッケージ': 100,
+  'package': 90,
+  'jacket': 90,
+  'keyvisual': 80,
+  'key_visual': 80,
+  'mainvisual': 80,
+  'main_visual': 80,
+  'poster': 70,
+  'title': 45,
+  'top': 35,
+  'logo': 40,
+  'banner': 35,
+  'folder': 35,
+  'thumbnail': 30,
+  'thumb': 25,
+  'icon': 20,
+  'game': 15,
+};
+
+/// 文件名启发式：命中即扣分（galgame 目录里最常见的「不是封面」的图）。
+const Map<String, int> _kNameNegativeScores = <String, int>{
+  'background': -70,
+  'bgimage': -70,
+  'wallpaper': -60,
+  'sprite': -60,
+  'chara': -60,
+  'char_': -60,
+  'face': -50,
+  'button': -50,
+  'cursor': -50,
+  'save': -40,
+  'load': -40,
+  'config': -40,
+  'menu': -30,
+  'bg': -30,
+};
+
+/// 纯函数：按文件名启发式给 [filePaths] 打分，降序返回**得分为正**的候选。
+///
+/// 只看名字，不碰磁盘——像素尺寸校验留给 [autoResolveGameCover] 的 IO 阶段，
+/// 这样打分规则本身完全可单测。同分时按路径升序稳定排序（避免目录枚举顺序抖动
+/// 导致同一游戏每次自动获取选到不同的图）。
+List<GameCoverCandidate> rankGameCoverCandidates({
+  required List<String> filePaths,
+  required String gameName,
+}) {
+  final String normalizedGame = _normalizeName(gameName);
+  final List<GameCoverCandidate> scored = <GameCoverCandidate>[];
+  for (final String path in filePaths) {
+    final String extension = p.extension(path).toLowerCase();
+    if (!kGameCoverImageExtensions.contains(extension)) continue;
+    final String base = p.basenameWithoutExtension(path);
+    final String lower = base.toLowerCase();
+    int score = 0;
+    for (final MapEntry<String, int> e in _kNamePositiveScores.entries) {
+      if (lower.contains(e.key)) score += e.value;
+    }
+    for (final MapEntry<String, int> e in _kNameNegativeScores.entries) {
+      if (lower.contains(e.key)) score += e.value;
+    }
+    // 与游戏同名的图几乎总是封面（`ATRI.png` / `sakura_moyu.jpg`）。
+    final String normalizedBase = _normalizeName(base);
+    if (normalizedGame.isNotEmpty && normalizedBase == normalizedGame) {
+      score += 90;
+    } else if (normalizedGame.isNotEmpty &&
+        normalizedBase.isNotEmpty &&
+        (normalizedBase.contains(normalizedGame) ||
+            normalizedGame.contains(normalizedBase))) {
+      score += 45;
+    }
+    // `.ico` 能用但通常只有 32/48px，压到正分尾部。
+    if (extension == '.ico') score -= 25;
+    if (score > 0) {
+      scored.add(GameCoverCandidate(path: path, score: score));
+    }
+  }
+  scored.sort((GameCoverCandidate a, GameCoverCandidate b) {
+    final int byScore = b.score.compareTo(a.score);
+    return byScore != 0 ? byScore : a.path.compareTo(b.path);
+  });
+  return scored;
+}
+
+/// 归一化名字用于比对：小写 + 去掉分隔符/空白/常见修饰。
+String _normalizeName(String value) =>
+    value.toLowerCase().replaceAll(RegExp(r'[\s_\-\.\(\)\[\]（）【】]'), '').trim();
+
+/// 读 [path] 的图像宽高（只读文件头部，避免把 20MB 的图整个读进内存）。
+/// 解不出返回 null。
+Future<(int width, int height)?> probeImageSize(String path) async {
+  RandomAccessFile? handle;
+  try {
+    final File file = File(path);
+    if (!await file.exists()) return null;
+    handle = await file.open();
+    final int length = await handle.length();
+    // 128KB 足够覆盖 PNG/BMP/ICO 的头，以及绝大多数 JPEG 的 SOF 段。
+    final int readLength = length < 131072 ? length : 131072;
+    final Uint8List head = await handle.read(readLength);
+    final img.Decoder? decoder = img.findDecoderForData(head);
+    if (decoder == null) return null;
+    final img.DecodeInfo? info = decoder.startDecode(head);
+    if (info == null || info.width <= 0 || info.height <= 0) return null;
+    return (info.width, info.height);
+  } catch (_) {
+    return null;
+  } finally {
+    await handle?.close();
+  }
+}
+
+/// 判定一张图的像素尺寸是否够格当封面：两边都不小于 [kGameCoverMinPixels]，
+/// 且宽高比不极端（横幅 / 细长条不是封面）。纯函数。
+bool isUsableCoverSize(int width, int height) {
+  if (width < kGameCoverMinPixels || height < kGameCoverMinPixels) return false;
+  final double ratio = width / height;
+  return ratio >= 0.35 && ratio <= 2.6;
+}
+
+/// 列出 [directory] 下**直接子文件**里的图片路径（不递归：galgame 目录动辄上万素材，
+/// 递归既慢又容易挖出一堆立绘）。目录不存在 / 读不动返回空列表。
+Future<List<String>> listCoverCandidateFiles(String directory) async {
+  try {
+    final Directory dir = Directory(directory);
+    if (!await dir.exists()) return const <String>[];
+    final List<String> out = <String>[];
+    await for (final FileSystemEntity entity in dir.list(followLinks: false)) {
+      if (entity is! File) continue;
+      final String extension = p.extension(entity.path).toLowerCase();
+      if (!kGameCoverImageExtensions.contains(extension)) continue;
+      out.add(entity.path);
+      if (out.length >= kGameCoverScanLimit) break;
+    }
+    return out;
+  } catch (_) {
+    return const <String>[];
+  }
+}
+
+/// exe 解析上限：超过这个体积就不为了找图标把整个文件读进内存（PE 资源段在文件
+/// 尾部，无法只读头部）。绝大多数 galgame 主程序 < 32MB。
+const int kGameExeIconMaxBytes = 128 * 1024 * 1024;
+
+/// 从 [exePath] 里抽最大的内嵌图标并编码成 PNG 字节；不可用返回 null。
+///
+/// 整段（读盘 + PE 解析 + ICO→PNG 重编码）扔进 [Isolate.run]：exe 可能有几十 MB，
+/// 图标解码也是纯 CPU，跑在 UI isolate 上会直接掉帧。
+Future<Uint8List?> extractExeIconPng(String exePath) async {
+  try {
+    return await Isolate.run(() => _readExeIconSync(exePath));
+  } catch (_) {
+    return null;
+  }
+}
+
+/// [extractExeIconPng] 的同步内核（在后台 isolate 里跑）。
+Uint8List? _readExeIconSync(String exePath) {
+  try {
+    final File file = File(exePath);
+    if (!file.existsSync()) return null;
+    if (file.lengthSync() > kGameExeIconMaxBytes) return null;
+    return extractLargestIconPng(file.readAsBytesSync(), minSize: 48);
+  } catch (_) {
+    return null;
+  }
+}
+
+/// 自动解析结果：来源用于给用户一个准确的反馈文案。
+enum GameCoverSource {
+  /// 游戏目录里已有的封面图。
+  directoryImage,
+
+  /// exe 内嵌图标。
+  exeIcon,
+}
+
+/// 自动解析出的封面（已落盘）。
+class ResolvedGameCover {
+  const ResolvedGameCover({required this.path, required this.source});
+
+  final String path;
+  final GameCoverSource source;
+}
+
+/// 为一个游戏自动解析封面并落盘，返回结果；两级来源都不中返回 null。
+///
+/// [gameId] 决定落盘文件名（同一游戏重复获取会覆盖，不堆垃圾）；[gameName] 参与
+/// 文件名启发式；[workdir] 为空时用 exe 所在目录。
+Future<ResolvedGameCover?> autoResolveGameCover({
+  required String gameId,
+  required String gameName,
+  required String exePath,
+  String? workdir,
+  Directory? coverDirectory,
+}) async {
+  final String directory =
+      (workdir != null && workdir.isNotEmpty) ? workdir : p.dirname(exePath);
+  final List<String> files = await listCoverCandidateFiles(directory);
+  final List<GameCoverCandidate> ranked =
+      rankGameCoverCandidates(filePaths: files, gameName: gameName);
+  for (final GameCoverCandidate candidate in ranked) {
+    final (int, int)? size = await probeImageSize(candidate.path);
+    if (size == null) continue;
+    if (!isUsableCoverSize(size.$1, size.$2)) continue;
+    final String? saved = await saveGameCoverFromFile(
+      gameId: gameId,
+      sourcePath: candidate.path,
+      coverDirectory: coverDirectory,
+    );
+    if (saved != null) {
+      return ResolvedGameCover(
+        path: saved,
+        source: GameCoverSource.directoryImage,
+      );
+    }
+  }
+  final Uint8List? icon = await extractExeIconPng(exePath);
+  if (icon != null) {
+    final String? saved = await saveGameCoverBytes(
+      gameId: gameId,
+      bytes: icon,
+      extension: '.png',
+      coverDirectory: coverDirectory,
+    );
+    if (saved != null) {
+      return ResolvedGameCover(path: saved, source: GameCoverSource.exeIcon);
+    }
+  }
+  return null;
+}
+
+/// 把 [sourcePath] 的图片拷成本游戏的封面，返回落盘路径；失败返回 null。
+/// 手动「设置封面」与自动获取共用此入口。
+///
+/// [coverDirectory] 是测试接缝：默认落 [AppPaths.gameCoversDirectory]，测试传临时
+/// 目录即可断言真实落盘行为，不必去 mock `path_provider` 平台通道。
+Future<String?> saveGameCoverFromFile({
+  required String gameId,
+  required String sourcePath,
+  Directory? coverDirectory,
+}) async {
+  try {
+    final String extension = _normalizedCoverExtension(sourcePath);
+    final Directory dir =
+        coverDirectory ?? await AppPaths.gameCoversDirectory();
+    await dir.create(recursive: true);
+    await _deleteExistingCovers(dir, gameId);
+    final String dest = p.join(dir.path, '$gameId$extension');
+    await File(sourcePath).copy(dest);
+    return dest;
+  } catch (_) {
+    return null;
+  }
+}
+
+/// 把内存里的图片字节写成本游戏的封面（exe 图标路径用），返回落盘路径。
+Future<String?> saveGameCoverBytes({
+  required String gameId,
+  required Uint8List bytes,
+  required String extension,
+  Directory? coverDirectory,
+}) async {
+  try {
+    final Directory dir =
+        coverDirectory ?? await AppPaths.gameCoversDirectory();
+    await dir.create(recursive: true);
+    await _deleteExistingCovers(dir, gameId);
+    final String dest = p.join(dir.path, '$gameId$extension');
+    await File(dest).writeAsBytes(bytes, flush: true);
+    return dest;
+  } catch (_) {
+    return null;
+  }
+}
+
+/// 删除该游戏此前的封面文件（任意扩展名）。换封面时扩展名可能从 `.png` 变成
+/// `.jpg`，不清理就会在目录里堆一堆孤儿文件。
+Future<void> _deleteExistingCovers(Directory dir, String gameId) async {
+  try {
+    await for (final FileSystemEntity entity in dir.list(followLinks: false)) {
+      if (entity is! File) continue;
+      if (p.basenameWithoutExtension(entity.path) != gameId) continue;
+      try {
+        await entity.delete();
+      } catch (_) {
+        // 文件被占用：让后面的写覆盖同名文件即可，不因清理失败中断换封面。
+      }
+    }
+  } catch (_) {
+    // 目录还不存在等：交给调用方后续的 create/write。
+  }
+}
+
+/// 归一化落盘扩展名：`.jpeg` 统一成 `.jpg`，未知/非图片回退 `.png`
+/// （字节内容不变，只是文件名后缀；解码按内容嗅探，不看后缀）。
+String _normalizedCoverExtension(String sourcePath) {
+  final String raw = p.extension(sourcePath).toLowerCase();
+  if (raw == '.jpeg') return '.jpg';
+  return kGameCoverImageExtensions.contains(raw) ? raw : '.png';
+}

--- a/hibiki/lib/src/mining/galgame_exe_icon.dart
+++ b/hibiki/lib/src/mining/galgame_exe_icon.dart
@@ -1,0 +1,263 @@
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+/// 从 Windows PE 可执行文件（`.exe` / `.dll`）里**纯 Dart** 解析内嵌图标资源
+/// （`RT_ICON`），供游戏库「自动获取封面」在游戏目录里找不到封面图时兜底。
+///
+/// 为什么不走 native：Win32 的 `ExtractIconEx` / `SHGetFileInfo` 只能拿到 `HICON`，
+/// 还要一串 GDI 调用（`GetIconInfo` / `GetDIBits`）才能变成像素，且只有真机能跑、
+/// 无法单测。PE 资源树是**纯字节结构**，解析它是确定性纯函数：三端都能跑测试，
+/// 合成字节即可覆盖边界（截断 / 非 PE / 无 .rsrc / 多尺寸）。
+///
+/// 全部入口 **fail-safe**：任何越界、非法结构、解码失败都返回 null / 空列表，
+/// 绝不抛给调用方（封面缺失是可接受降级，崩溃不是）。
+
+/// PE 资源里的一个图标条目（已定位到真实字节）。
+class PeIconEntry {
+  const PeIconEntry({
+    required this.width,
+    required this.height,
+    required this.bitCount,
+    required this.isPng,
+    required this.bytes,
+  });
+
+  /// 像素宽（PNG 取 IHDR，DIB 取 `biWidth`）。
+  final int width;
+
+  /// 像素高（DIB 的 `biHeight` 是图像高 + AND 掩码高的两倍，这里已折半还原）。
+  final int height;
+
+  /// 位深（PNG 统一记 32；DIB 取 `biBitCount`）。
+  final int bitCount;
+
+  /// true = 资源本身就是 PNG（Vista+ 的 256×256 图标常见），可直接落盘。
+  final bool isPng;
+
+  /// 图标资源原始字节（PNG 文件字节，或不含文件头的 DIB）。
+  final Uint8List bytes;
+
+  /// 面积，用于挑「最大」的一张。
+  int get area => width * height;
+}
+
+const int _rtIcon = 3;
+const List<int> _pngSignature = <int>[
+  0x89,
+  0x50,
+  0x4E,
+  0x47,
+  0x0D,
+  0x0A,
+  0x1A,
+  0x0A
+];
+
+/// 解析 [exeBytes] 里所有 `RT_ICON` 资源；非 PE / 无资源段 / 结构损坏返回空列表。
+List<PeIconEntry> parsePeIcons(Uint8List exeBytes) {
+  try {
+    return _parsePeIconsUnsafe(exeBytes);
+  } catch (_) {
+    // 任何越界或格式假设不成立：当作「这个 exe 没有可用图标」。
+    return const <PeIconEntry>[];
+  }
+}
+
+/// 取 [exeBytes] 内**面积最大**（并列时位深更高）的图标并归一成 PNG 字节。
+///
+/// 资源本身是 PNG 时原样返回（零重编码）；是 DIB 时包成单帧 `.ico` 交
+/// `package:image` 解码（它已处理 AND 掩码透明与自下而上行序）再编码 PNG。
+/// [minSize] 是可用下限：小于它的图标（16/32 px 系统托盘图标）当封面太糊，返回 null。
+Uint8List? extractLargestIconPng(Uint8List exeBytes, {int minSize = 48}) {
+  final List<PeIconEntry> icons = parsePeIcons(exeBytes);
+  if (icons.isEmpty) return null;
+  PeIconEntry? best;
+  for (final PeIconEntry icon in icons) {
+    if (icon.width < minSize || icon.height < minSize) continue;
+    if (best == null ||
+        icon.area > best.area ||
+        (icon.area == best.area && icon.bitCount > best.bitCount)) {
+      best = icon;
+    }
+  }
+  if (best == null) return null;
+  if (best.isPng) return best.bytes;
+  return _dibIconToPng(best);
+}
+
+/// DIB 图标 → PNG：包一层最小 `.ico` 容器再走 [img.IcoDecoder]。
+///
+/// 刻意**只塞这一帧**：`IcoDecoder.decodeImageLargest` 按 ICONDIRENTRY 的宽高字节挑帧，
+/// 而 256px 图标在该字段里编码为 0（规范如此），会被它当成最小帧丢掉。我们已经在
+/// PE 层知道真实尺寸，自己挑完只交一帧，绕开那个坑。
+Uint8List? _dibIconToPng(PeIconEntry icon) {
+  try {
+    final BytesBuilder builder = BytesBuilder();
+    final ByteData header = ByteData(6 + 16);
+    header.setUint16(0, 0, Endian.little); // reserved
+    header.setUint16(2, 1, Endian.little); // type = icon
+    header.setUint16(4, 1, Endian.little); // count = 1
+    // ICONDIRENTRY：宽高各占一字节，256 编码为 0（`& 0xFF` 天然满足）。
+    header.setUint8(6, icon.width & 0xFF);
+    header.setUint8(7, icon.height & 0xFF);
+    header.setUint8(8, 0); // colorCount（>=8bpp 时为 0）
+    header.setUint8(9, 0); // reserved
+    header.setUint16(10, 1, Endian.little); // planes
+    header.setUint16(12, icon.bitCount, Endian.little);
+    header.setUint32(14, icon.bytes.length, Endian.little);
+    header.setUint32(18, 22, Endian.little); // 数据偏移 = 6 + 16
+    builder.add(header.buffer.asUint8List());
+    builder.add(icon.bytes);
+    final img.Image? decoded = img.IcoDecoder().decode(builder.toBytes());
+    if (decoded == null) return null;
+    return img.encodePng(decoded);
+  } catch (_) {
+    return null;
+  }
+}
+
+List<PeIconEntry> _parsePeIconsUnsafe(Uint8List bytes) {
+  final ByteData data = ByteData.sublistView(bytes);
+  if (bytes.length < 0x40) return const <PeIconEntry>[];
+  if (bytes[0] != 0x4D || bytes[1] != 0x5A) {
+    return const <PeIconEntry>[]; // 不是 'MZ'
+  }
+  final int peOffset = data.getUint32(0x3C, Endian.little);
+  if (peOffset <= 0 || peOffset + 24 > bytes.length) {
+    return const <PeIconEntry>[];
+  }
+  if (bytes[peOffset] != 0x50 ||
+      bytes[peOffset + 1] != 0x45 ||
+      bytes[peOffset + 2] != 0 ||
+      bytes[peOffset + 3] != 0) {
+    return const <PeIconEntry>[]; // 不是 'PE\0\0'
+  }
+  final int coff = peOffset + 4;
+  final int sectionCount = data.getUint16(coff + 2, Endian.little);
+  final int optionalHeaderSize = data.getUint16(coff + 16, Endian.little);
+  final int sectionTable = coff + 20 + optionalHeaderSize;
+  if (sectionCount <= 0 || sectionTable + sectionCount * 40 > bytes.length) {
+    return const <PeIconEntry>[];
+  }
+
+  // 找 .rsrc 段：资源树里的所有偏移都相对该段，叶子里的 RVA 也在该段内。
+  int rsrcRva = -1;
+  int rsrcFileOffset = -1;
+  int rsrcSize = 0;
+  for (int i = 0; i < sectionCount; i++) {
+    final int base = sectionTable + i * 40;
+    final String name = String.fromCharCodes(
+      bytes.sublist(base, base + 8).takeWhile((int b) => b != 0),
+    );
+    if (name == '.rsrc') {
+      rsrcRva = data.getUint32(base + 12, Endian.little);
+      rsrcSize = data.getUint32(base + 16, Endian.little);
+      rsrcFileOffset = data.getUint32(base + 20, Endian.little);
+      break;
+    }
+  }
+  if (rsrcRva < 0 || rsrcFileOffset < 0 || rsrcFileOffset >= bytes.length) {
+    return const <PeIconEntry>[];
+  }
+  final int rsrcEnd = rsrcFileOffset + rsrcSize > bytes.length
+      ? bytes.length
+      : rsrcFileOffset + rsrcSize;
+
+  /// 资源段内 RVA → 文件偏移；越界返回 -1。
+  int rvaToFile(int rva) {
+    final int offset = rva - rsrcRva + rsrcFileOffset;
+    if (offset < rsrcFileOffset || offset >= rsrcEnd) return -1;
+    return offset;
+  }
+
+  /// 读一层资源目录的所有条目：`(id 或 -1, 相对 .rsrc 的偏移, 是否子目录)`。
+  List<(int, int, bool)> readDirectory(int relativeOffset) {
+    final int dir = rsrcFileOffset + relativeOffset;
+    if (dir < rsrcFileOffset || dir + 16 > rsrcEnd) {
+      return const <(int, int, bool)>[];
+    }
+    final int namedCount = data.getUint16(dir + 12, Endian.little);
+    final int idCount = data.getUint16(dir + 14, Endian.little);
+    final int total = namedCount + idCount;
+    final List<(int, int, bool)> out = <(int, int, bool)>[];
+    for (int i = 0; i < total; i++) {
+      final int entry = dir + 16 + i * 8;
+      if (entry + 8 > rsrcEnd) break;
+      final int nameField = data.getUint32(entry, Endian.little);
+      final int offsetField = data.getUint32(entry + 4, Endian.little);
+      final bool isNamed = nameField & 0x80000000 != 0;
+      final bool isDirectory = offsetField & 0x80000000 != 0;
+      out.add((
+        isNamed ? -1 : nameField,
+        offsetField & 0x7FFFFFFF,
+        isDirectory,
+      ));
+    }
+    return out;
+  }
+
+  final List<PeIconEntry> icons = <PeIconEntry>[];
+  for (final (int typeId, int typeOffset, bool typeIsDir) in readDirectory(0)) {
+    if (typeId != _rtIcon || !typeIsDir) continue;
+    // Level 2：每个图标资源 id；Level 3：语言。叶子才是数据条目。
+    for (final (int _, int nameOffset, bool nameIsDir)
+        in readDirectory(typeOffset)) {
+      final List<(int, int, bool)> languages = nameIsDir
+          ? readDirectory(nameOffset)
+          : <(int, int, bool)>[(0, nameOffset, false)];
+      for (final (int _, int leafOffset, bool leafIsDir) in languages) {
+        if (leafIsDir) continue;
+        final int leaf = rsrcFileOffset + leafOffset;
+        if (leaf < rsrcFileOffset || leaf + 8 > rsrcEnd) continue;
+        final int dataRva = data.getUint32(leaf, Endian.little);
+        final int dataSize = data.getUint32(leaf + 4, Endian.little);
+        final int dataOffset = rvaToFile(dataRva);
+        if (dataOffset < 0 || dataSize <= 0) continue;
+        final int end = dataOffset + dataSize;
+        if (end > bytes.length) continue;
+        final PeIconEntry? icon =
+            _describeIcon(Uint8List.sublistView(bytes, dataOffset, end));
+        if (icon != null) icons.add(icon);
+      }
+    }
+  }
+  return icons;
+}
+
+/// 判定一段图标资源是 PNG 还是 DIB，并读出尺寸/位深；都不像则返回 null。
+PeIconEntry? _describeIcon(Uint8List blob) {
+  if (blob.length >= 24 && _hasPngSignature(blob)) {
+    final ByteData d = ByteData.sublistView(blob);
+    return PeIconEntry(
+      width: d.getUint32(16), // IHDR width（大端）
+      height: d.getUint32(20),
+      bitCount: 32,
+      isPng: true,
+      bytes: Uint8List.fromList(blob),
+    );
+  }
+  if (blob.length < 40) return null;
+  final ByteData d = ByteData.sublistView(blob);
+  final int headerSize = d.getUint32(0, Endian.little);
+  if (headerSize < 40) return null; // 只认 BITMAPINFOHEADER 及其扩展
+  final int width = d.getInt32(4, Endian.little);
+  final int doubledHeight = d.getInt32(8, Endian.little);
+  final int bitCount = d.getUint16(14, Endian.little);
+  if (width <= 0 || doubledHeight <= 0) return null;
+  return PeIconEntry(
+    // 图标 DIB 的高度含 AND 掩码，是真实高度的两倍。
+    width: width,
+    height: doubledHeight ~/ 2,
+    bitCount: bitCount,
+    isPng: false,
+    bytes: Uint8List.fromList(blob),
+  );
+}
+
+bool _hasPngSignature(Uint8List blob) {
+  for (int i = 0; i < _pngSignature.length; i++) {
+    if (blob[i] != _pngSignature[i]) return false;
+  }
+  return true;
+}

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -9,6 +9,7 @@ import 'package:hibiki/models.dart';
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
 import 'package:hibiki/src/mining/galgame_audio_source.dart';
+import 'package:hibiki/src/mining/galgame_cover_resolver.dart';
 import 'package:hibiki/src/mining/galgame_helper_installer.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 // 书架卡片规格单一真相源（kShelfBookCardAspectRatio / kShelfTitleFooterHeight）。
@@ -62,6 +63,9 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   }
 
   /// 添加游戏：文件选择器选一个 `.exe`，以文件名去扩展名作默认名，追加进列表。
+  ///
+  /// 落库后**不等封面**就返回（卡片先用默认占位图出现），封面解析在后台跑完再回填：
+  /// 目录扫描 + exe 图标解析是磁盘/CPU 活，让它阻塞「添加」这一步会让 UI 无谓地卡住。
   Future<void> _addGame() async {
     final FilePickerResult? picked = await FilePicker.platform.pickFiles(
       type: FileType.custom,
@@ -75,6 +79,66 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
     }
     final GalgameEntry entry = newGalgameEntryFromExe(exe);
     await _persist(<GalgameEntry>[..._games, entry]);
+    unawaited(_autoCover(entry, silent: true));
+  }
+
+  /// 自动获取封面：游戏目录里的封面图 → exe 内嵌图标（[autoResolveGameCover]）。
+  ///
+  /// [silent] = 添加游戏后的后台补齐（成功静默、失败不打扰）；用户从菜单主动触发时
+  /// 为 false，两种结局都给 toast，否则「点了没反应」无从判断。
+  Future<void> _autoCover(GalgameEntry game, {bool silent = false}) async {
+    if (!silent) HibikiToast.show(msg: t.games_cover_searching);
+    final ResolvedGameCover? resolved = await autoResolveGameCover(
+      gameId: game.id,
+      gameName: game.name,
+      exePath: game.exePath,
+      workdir: game.workdir,
+    );
+    if (resolved == null) {
+      if (!silent) HibikiToast.show(msg: t.games_cover_not_found);
+      return;
+    }
+    await _applyCover(game, resolved.path);
+    if (!silent) HibikiToast.show(msg: t.games_cover_updated);
+  }
+
+  /// 手动设置封面：选一张图 → 拷进 `<documents>/game_covers` → 回填条目。
+  /// 与视频卡「设置封面」同款语义（拷盘而非引用原图，原图移动/删除不会让封面消失）。
+  Future<void> _setCover(GalgameEntry game) async {
+    final FilePickerResult? picked = await FilePicker.platform.pickFiles(
+      type: FileType.image,
+    );
+    final String? source = (picked != null && picked.files.isNotEmpty)
+        ? picked.files.first.path
+        : null;
+    if (source == null || source.isEmpty) return;
+    final String? saved = await saveGameCoverFromFile(
+      gameId: game.id,
+      sourcePath: source,
+    );
+    if (saved == null) {
+      HibikiToast.show(msg: t.games_cover_not_found);
+      return;
+    }
+    await _applyCover(game, saved);
+    HibikiToast.show(msg: t.games_cover_updated);
+  }
+
+  /// 把新封面路径写回条目并刷新。
+  ///
+  /// 必须先 `imageCache.evict`：[FileImage] 按 `(path, scale)` 缓存解码结果，换封面
+  /// 常常落在**同一个** `<id>.<ext>` 路径上，不驱逐旧条目的话 UI 重建会命中旧解码，
+  /// 用户看到的还是换之前那张图（与视频封面同一个坑，见 `setVideoCoverFromPickedFile`）。
+  Future<void> _applyCover(GalgameEntry game, String coverPath) async {
+    PaintingBinding.instance.imageCache.evict(FileImage(File(coverPath)));
+    if (!mounted) return;
+    // 以最新列表为基准改写（后台补齐期间用户可能已重命名/删除这条）。
+    final List<GalgameEntry> next = _games
+        .map((GalgameEntry g) =>
+            g.id == game.id ? g.copyWith(coverPath: coverPath) : g)
+        .toList();
+    if (!next.any((GalgameEntry g) => g.id == game.id)) return; // 已被删除
+    await _persist(next);
   }
 
   /// 移除一个游戏（按 id 定位）。
@@ -234,6 +298,8 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
             onTap: () => unawaited(_launchGame(_games[i])),
             onRename: () => unawaited(_renameGame(_games[i])),
             onRemove: () => unawaited(_removeGame(_games[i])),
+            onSetCover: () => unawaited(_setCover(_games[i])),
+            onAutoCover: () => unawaited(_autoCover(_games[i])),
           ),
         );
       },
@@ -299,14 +365,19 @@ class _GameCard extends StatelessWidget {
     required this.onTap,
     required this.onRename,
     required this.onRemove,
+    required this.onSetCover,
+    required this.onAutoCover,
   });
 
   final GalgameEntry game;
   final VoidCallback onTap;
   final VoidCallback onRename;
   final VoidCallback onRemove;
+  final VoidCallback onSetCover;
+  final VoidCallback onAutoCover;
 
-  /// 长按 / 右键的上下文菜单：与封面溢出菜单同两项（重命名 / 移除）。
+  /// 长按 / 右键的上下文菜单：与封面溢出菜单同四项（重命名 / 设置封面 /
+  /// 自动获取封面 / 移除）。两处菜单**共用** [_dispatchAction]，避免两份手抄。
   Future<void> _showContextMenu(BuildContext context) async {
     final String? action = await showDialog<String>(
       context: context,
@@ -317,21 +388,35 @@ class _GameCard extends StatelessWidget {
           overflow: TextOverflow.ellipsis,
         ),
         children: <Widget>[
-          SimpleDialogOption(
-            onPressed: () => Navigator.of(ctx).pop('rename'),
-            child: Text(t.games_rename),
-          ),
-          SimpleDialogOption(
-            onPressed: () => Navigator.of(ctx).pop('remove'),
-            child: Text(t.games_remove),
-          ),
+          for (final (String value, String label) item in _menuItems)
+            SimpleDialogOption(
+              onPressed: () => Navigator.of(ctx).pop(item.$1),
+              child: Text(item.$2),
+            ),
         ],
       ),
     );
-    if (action == 'rename') {
-      onRename();
-    } else if (action == 'remove') {
-      onRemove();
+    if (action != null) _dispatchAction(action);
+  }
+
+  /// 卡片菜单项单一真相源：`(action, 文案)`。
+  List<(String, String)> get _menuItems => <(String, String)>[
+        ('rename', t.games_rename),
+        ('cover', t.games_set_cover),
+        ('autocover', t.games_auto_cover),
+        ('remove', t.games_remove),
+      ];
+
+  void _dispatchAction(String action) {
+    switch (action) {
+      case 'rename':
+        onRename();
+      case 'cover':
+        onSetCover();
+      case 'autocover':
+        onAutoCover();
+      case 'remove':
+        onRemove();
     }
   }
 
@@ -374,23 +459,15 @@ class _GameCard extends StatelessWidget {
                         color: colors.onSurface,
                       ),
                     ),
-                    onSelected: (String value) {
-                      if (value == 'rename') {
-                        onRename();
-                      } else if (value == 'remove') {
-                        onRemove();
-                      }
-                    },
+                    onSelected: _dispatchAction,
                     itemBuilder: (BuildContext context) =>
                         <PopupMenuEntry<String>>[
-                      PopupMenuItem<String>(
-                        value: 'rename',
-                        child: Text(t.games_rename),
-                      ),
-                      PopupMenuItem<String>(
-                        value: 'remove',
-                        child: Text(t.games_remove),
-                      ),
+                      for (final (String value, String label) item
+                          in _menuItems)
+                        PopupMenuItem<String>(
+                          value: item.$1,
+                          child: Text(item.$2),
+                        ),
                     ],
                   ),
                 ),

--- a/hibiki/lib/src/storage/app_paths.dart
+++ b/hibiki/lib/src/storage/app_paths.dart
@@ -178,6 +178,7 @@ class AppPaths {
   ///    `join(appDirectory, 'audiobooks')`；`AudiobookStorage.ensurePersistDir`。
   ///  - `hoshi_books` —— [epubBooksDirectory]；`EpubStorage`；backup restore。
   ///  - `video_covers` —— [videoCoversDirectory]；`VideoStorage.coversDirName`。
+  ///  - `game_covers` —— [gameCoversDirectory]；游戏库封面（手选 + 自动获取）。
   ///  - `video_subtitles` —— [videoSubtitlesDirectory]；`VideoStorage.subtitlesDirName`。
   ///  - `mpv_shaders` —— [mpvShadersDirectory]。
   ///  - `remote_videos` —— [remoteVideosDirectory]。
@@ -201,6 +202,7 @@ class AppPaths {
     'audiobooks',
     'hoshi_books',
     'video_covers',
+    'game_covers',
     'video_subtitles',
     'mpv_shaders',
     'remote_videos',
@@ -244,6 +246,11 @@ class AppPaths {
   /// 视频封面目录 `<documents>/video_covers`。
   static Future<Directory> videoCoversDirectory() =>
       documentsSubdirectory('video_covers');
+
+  /// 游戏库封面目录 `<documents>/game_covers`（手动设置与自动获取的统一落点，
+  /// 文件名是 `<GalgameEntry.id>.<ext>`）。
+  static Future<Directory> gameCoversDirectory() =>
+      documentsSubdirectory('game_covers');
 
   /// 视频外挂字幕副本目录 `<documents>/video_subtitles`。
   static Future<Directory> videoSubtitlesDirectory() =>

--- a/hibiki/test/mining/galgame_cover_resolver_test.dart
+++ b/hibiki/test/mining/galgame_cover_resolver_test.dart
@@ -1,0 +1,241 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/galgame_cover_resolver.dart';
+import 'package:image/image.dart' as img;
+import 'package:path/path.dart' as p;
+
+/// 游戏库「自动获取封面」的解析器测试：文件名打分（纯函数）+ 真实目录上的级联落盘。
+void main() {
+  group('rankGameCoverCandidates', () {
+    test('封面类文件名排在立绘/背景之前，非图片被过滤', () {
+      final List<GameCoverCandidate> ranked = rankGameCoverCandidates(
+        filePaths: <String>[
+          r'C:\game\bg_school.png',
+          r'C:\game\cover.png',
+          r'C:\game\chara_yuki.png',
+          r'C:\game\readme.txt',
+          r'C:\game\パッケージ.jpg',
+        ],
+        gameName: 'Some Game',
+      );
+
+      expect(ranked.map((GameCoverCandidate c) => p.basename(c.path)),
+          <String>['cover.png', 'パッケージ.jpg']);
+    });
+
+    test('与游戏同名的图拿到额外加分', () {
+      final List<GameCoverCandidate> ranked = rankGameCoverCandidates(
+        filePaths: <String>[r'C:\g\sakura_moyu.png', r'C:\g\thumb.png'],
+        gameName: 'Sakura Moyu',
+      );
+      expect(p.basename(ranked.first.path), 'sakura_moyu.png');
+    });
+
+    test('.ico 可用但排在同类正分图片之后', () {
+      final List<GameCoverCandidate> ranked = rankGameCoverCandidates(
+        filePaths: <String>[r'C:\g\cover.ico', r'C:\g\cover.png'],
+        gameName: 'Game',
+      );
+      expect(p.basename(ranked.first.path), 'cover.png');
+      expect(ranked, hasLength(2));
+    });
+
+    test('同分候选按路径稳定排序（目录枚举顺序不影响结果）', () {
+      final List<String> files = <String>[
+        r'C:\g\b_cover.png',
+        r'C:\g\a_cover.png'
+      ];
+      expect(
+        rankGameCoverCandidates(filePaths: files, gameName: 'x')
+            .map((GameCoverCandidate c) => c.path),
+        rankGameCoverCandidates(
+                filePaths: files.reversed.toList(), gameName: 'x')
+            .map((GameCoverCandidate c) => c.path),
+      );
+    });
+  });
+
+  group('isUsableCoverSize', () {
+    test('太小或过于细长的图不作封面', () {
+      expect(isUsableCoverSize(600, 800), isTrue);
+      expect(isUsableCoverSize(64, 64), isFalse); // 小图标
+      expect(isUsableCoverSize(1920, 200), isFalse); // 横幅
+    });
+  });
+
+  group('autoResolveGameCover', () {
+    late Directory root;
+    late Directory gameDir;
+    late Directory coverDir;
+
+    setUp(() async {
+      root = await Directory.systemTemp.createTemp('hibiki_game_cover_test_');
+      gameDir = Directory(p.join(root.path, 'game'))..createSync();
+      coverDir = Directory(p.join(root.path, 'covers'))..createSync();
+    });
+
+    tearDown(() async {
+      if (root.existsSync()) {
+        root.deleteSync(recursive: true);
+      }
+    });
+
+    test('优先选目录里够大的封面图，落盘到封面目录', () async {
+      _writePng(p.join(gameDir.path, 'bg_town.png'), 800, 600);
+      _writePng(p.join(gameDir.path, 'cover.png'), 600, 800);
+      final String exe = p.join(gameDir.path, 'game.exe');
+      File(exe).writeAsBytesSync(Uint8List.fromList(<int>[0, 1, 2]));
+
+      final ResolvedGameCover? resolved = await autoResolveGameCover(
+        gameId: 'g1',
+        gameName: 'Game',
+        exePath: exe,
+        workdir: gameDir.path,
+        coverDirectory: coverDir,
+      );
+
+      expect(resolved, isNotNull);
+      expect(resolved!.source, GameCoverSource.directoryImage);
+      expect(p.basename(resolved.path), 'g1.png');
+      expect(File(resolved.path).existsSync(), isTrue);
+      // 落盘的是 cover.png（600×800），不是同目录更大的背景图。
+      final img.Image? decoded = img.decodePng(
+        File(resolved.path).readAsBytesSync(),
+      );
+      expect(decoded!.width, 600);
+      expect(decoded.height, 800);
+    });
+
+    test('目录里只有过小的图时跳过它（不硬塞一张糊图当封面）', () async {
+      _writePng(p.join(gameDir.path, 'cover.png'), 64, 64);
+      final String exe = p.join(gameDir.path, 'game.exe');
+      File(exe).writeAsBytesSync(Uint8List.fromList(<int>[0, 1, 2]));
+
+      final ResolvedGameCover? resolved = await autoResolveGameCover(
+        gameId: 'g2',
+        gameName: 'Game',
+        exePath: exe,
+        workdir: gameDir.path,
+        coverDirectory: coverDir,
+      );
+
+      // 目录候选被尺寸门槛挡下，exe 又不是真 PE：整体无封面可用。
+      expect(resolved, isNull);
+      expect(coverDir.listSync(), isEmpty);
+    });
+
+    test('目录里没有候选时回退到 exe 内嵌图标', () async {
+      final String exe = p.join(gameDir.path, 'game.exe');
+      File(exe).writeAsBytesSync(_peWith64pxIcon());
+
+      final ResolvedGameCover? resolved = await autoResolveGameCover(
+        gameId: 'g3',
+        gameName: 'Game',
+        exePath: exe,
+        workdir: gameDir.path,
+        coverDirectory: coverDir,
+      );
+
+      expect(resolved, isNotNull);
+      expect(resolved!.source, GameCoverSource.exeIcon);
+      final img.Image? decoded =
+          img.decodePng(File(resolved.path).readAsBytesSync());
+      expect(decoded!.width, 64);
+    });
+
+    test('换封面时清掉该游戏的旧封面文件（不同扩展名也不残留）', () async {
+      final String jpg = p.join(gameDir.path, 'old.jpg');
+      File(jpg)
+          .writeAsBytesSync(img.encodeJpg(img.Image(width: 300, height: 400)));
+      await saveGameCoverFromFile(
+        gameId: 'g4',
+        sourcePath: jpg,
+        coverDirectory: coverDir,
+      );
+      expect(
+          coverDir.listSync().map((FileSystemEntity e) => p.basename(e.path)),
+          <String>['g4.jpg']);
+
+      _writePng(p.join(gameDir.path, 'new.png'), 300, 400);
+      final String? second = await saveGameCoverFromFile(
+        gameId: 'g4',
+        sourcePath: p.join(gameDir.path, 'new.png'),
+        coverDirectory: coverDir,
+      );
+
+      expect(second, isNotNull);
+      expect(
+          coverDir.listSync().map((FileSystemEntity e) => p.basename(e.path)),
+          <String>['g4.png']);
+    });
+
+    test('exe 不存在 / 目录不存在时安静返回 null', () async {
+      final ResolvedGameCover? resolved = await autoResolveGameCover(
+        gameId: 'g5',
+        gameName: 'Ghost',
+        exePath: p.join(root.path, 'missing', 'nope.exe'),
+        workdir: p.join(root.path, 'missing'),
+        coverDirectory: coverDir,
+      );
+      expect(resolved, isNull);
+    });
+  });
+}
+
+void _writePng(String path, int width, int height) {
+  final img.Image image = img.Image(width: width, height: height);
+  img.fill(image, color: img.ColorRgb8(10, 120, 200));
+  File(path).writeAsBytesSync(img.encodePng(image));
+}
+
+/// 一个含 64×64 PNG 图标的最小 PE（结构同 `galgame_exe_icon_test.dart` 里的构造器）。
+Uint8List _peWith64pxIcon() {
+  final img.Image image = img.Image(width: 64, height: 64);
+  img.fill(image, color: img.ColorRgb8(255, 200, 0));
+  final Uint8List icon = img.encodePng(image);
+
+  const int peOffset = 0x80;
+  const int optionalHeaderSize = 0xE0;
+  const int sectionTableOffset = peOffset + 4 + 20 + optionalHeaderSize;
+  const int rsrcFileOffset = sectionTableOffset + 40;
+  const int rsrcRva = 0x1000;
+  const int l2 = 24;
+  const int langBase = l2 + 24;
+  const int leafBase = langBase + 24;
+  const int dataBase = leafBase + 16;
+  final int rsrcSize = dataBase + icon.length;
+
+  final Uint8List out = Uint8List(rsrcFileOffset + rsrcSize);
+  final ByteData view = ByteData.sublistView(out);
+  out[0] = 0x4D;
+  out[1] = 0x5A;
+  view.setUint32(0x3C, peOffset, Endian.little);
+  out[peOffset] = 0x50;
+  out[peOffset + 1] = 0x45;
+  view.setUint16(peOffset + 6, 1, Endian.little); // NumberOfSections
+  view.setUint16(peOffset + 20, optionalHeaderSize, Endian.little);
+  for (int i = 0; i < '.rsrc'.length; i++) {
+    out[sectionTableOffset + i] = '.rsrc'.codeUnitAt(i);
+  }
+  view.setUint32(sectionTableOffset + 8, rsrcSize, Endian.little);
+  view.setUint32(sectionTableOffset + 12, rsrcRva, Endian.little);
+  view.setUint32(sectionTableOffset + 16, rsrcSize, Endian.little);
+  view.setUint32(sectionTableOffset + 20, rsrcFileOffset, Endian.little);
+
+  int abs(int relative) => rsrcFileOffset + relative;
+  view.setUint16(abs(0) + 14, 1, Endian.little);
+  view.setUint32(abs(0) + 16, 3, Endian.little); // RT_ICON
+  view.setUint32(abs(0) + 20, 0x80000000 | l2, Endian.little);
+  view.setUint16(abs(l2) + 14, 1, Endian.little);
+  view.setUint32(abs(l2) + 16, 1, Endian.little);
+  view.setUint32(abs(l2) + 20, 0x80000000 | langBase, Endian.little);
+  view.setUint16(abs(langBase) + 14, 1, Endian.little);
+  view.setUint32(abs(langBase) + 16, 1033, Endian.little);
+  view.setUint32(abs(langBase) + 20, leafBase, Endian.little);
+  view.setUint32(abs(leafBase), rsrcRva + dataBase, Endian.little);
+  view.setUint32(abs(leafBase) + 4, icon.length, Endian.little);
+  out.setRange(abs(dataBase), abs(dataBase) + icon.length, icon);
+  return out;
+}

--- a/hibiki/test/mining/galgame_exe_icon_test.dart
+++ b/hibiki/test/mining/galgame_exe_icon_test.dart
@@ -1,0 +1,201 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/galgame_exe_icon.dart';
+import 'package:image/image.dart' as img;
+
+/// PE 图标提取（游戏库「自动获取封面」的兜底源）的纯字节测试。
+///
+/// 用**合成 PE** 覆盖：多尺寸挑最大、PNG 直通、DIB→PNG 重编码、minSize 过滤，
+/// 以及三类坏输入（非 PE / 无 .rsrc / 资源段声明越界）必须 fail-safe 不抛。
+void main() {
+  group('parsePeIcons', () {
+    test('解析出所有 RT_ICON 并读对尺寸（PNG 与 DIB 混合）', () {
+      final Uint8List png = _png(64, 64);
+      final Uint8List dib = _dib(32, 32);
+      final List<PeIconEntry> icons =
+          parsePeIcons(_buildPeWithIcons(<Uint8List>[dib, png]));
+
+      expect(icons, hasLength(2));
+      final PeIconEntry dibEntry =
+          icons.firstWhere((PeIconEntry e) => !e.isPng);
+      final PeIconEntry pngEntry = icons.firstWhere((PeIconEntry e) => e.isPng);
+      expect(dibEntry.width, 32);
+      // DIB 的 biHeight 含 AND 掩码（写入 64），解析后应还原成 32。
+      expect(dibEntry.height, 32);
+      expect(pngEntry.width, 64);
+      expect(pngEntry.height, 64);
+    });
+
+    test('非 PE / 截断 / 无 .rsrc 都返回空列表，不抛', () {
+      expect(parsePeIcons(Uint8List.fromList(<int>[1, 2, 3])), isEmpty);
+      expect(parsePeIcons(Uint8List(0)), isEmpty);
+      expect(parsePeIcons(_buildPeWithIcons(<Uint8List>[], omitRsrc: true)),
+          isEmpty);
+
+      // .rsrc 声明的大小远超文件实际长度：越界读必须被夹住而不是抛出。
+      final Uint8List truncated =
+          _buildPeWithIcons(<Uint8List>[_dib(32, 32)], inflateRsrcSize: true);
+      expect(parsePeIcons(truncated), isNotNull);
+    });
+  });
+
+  group('extractLargestIconPng', () {
+    test('多尺寸时取面积最大的一张，PNG 资源原样直通', () {
+      final Uint8List png = _png(128, 128);
+      final Uint8List bytes =
+          _buildPeWithIcons(<Uint8List>[_dib(32, 32), png, _dib(48, 48)]);
+
+      final Uint8List? out = extractLargestIconPng(bytes);
+      expect(out, isNotNull);
+      // 128×128 的 PNG 资源最大，且不该被重新编码。
+      expect(out, equals(png));
+    });
+
+    test('只有 DIB 图标时重编码成可解码的 PNG', () {
+      final Uint8List bytes = _buildPeWithIcons(<Uint8List>[_dib(64, 64)]);
+
+      final Uint8List? out = extractLargestIconPng(bytes);
+      expect(out, isNotNull);
+      final img.Image? decoded = img.decodePng(out!);
+      expect(decoded, isNotNull);
+      expect(decoded!.width, 64);
+      expect(decoded.height, 64);
+    });
+
+    test('所有图标都小于 minSize 时返回 null（不拿 32px 托盘图标当封面）', () {
+      final Uint8List bytes =
+          _buildPeWithIcons(<Uint8List>[_dib(16, 16), _dib(32, 32)]);
+      expect(extractLargestIconPng(bytes, minSize: 48), isNull);
+      // 放宽下限后同一份字节应能取到 32×32。
+      expect(extractLargestIconPng(bytes, minSize: 16), isNotNull);
+    });
+  });
+}
+
+/// 生成一张真实可解码的 PNG（纯色）。
+Uint8List _png(int width, int height) {
+  final img.Image image = img.Image(width: width, height: height);
+  img.fill(image, color: img.ColorRgb8(120, 90, 200));
+  return img.encodePng(image);
+}
+
+/// 生成一段 32bpp 的图标 DIB：BITMAPINFOHEADER + BGRA 像素 + AND 掩码。
+///
+/// 图标 DIB 的 `biHeight` 按规范写成真实高度的两倍（图像 + 掩码）。
+Uint8List _dib(int width, int height) {
+  final int pixelBytes = width * height * 4;
+  final int maskRowBytes = (((width + 31) ~/ 32)) * 4;
+  final int maskBytes = maskRowBytes * height;
+  final Uint8List out = Uint8List(40 + pixelBytes + maskBytes);
+  final ByteData view = ByteData.sublistView(out);
+  view.setUint32(0, 40, Endian.little); // biSize
+  view.setInt32(4, width, Endian.little); // biWidth
+  view.setInt32(8, height * 2, Endian.little); // biHeight（含掩码）
+  view.setUint16(12, 1, Endian.little); // biPlanes
+  view.setUint16(14, 32, Endian.little); // biBitCount
+  for (int i = 0; i < pixelBytes; i += 4) {
+    out[40 + i] = 200; // B
+    out[40 + i + 1] = 90; // G
+    out[40 + i + 2] = 120; // R
+    out[40 + i + 3] = 255; // A
+  }
+  return out;
+}
+
+/// 组装一个最小但结构合法的 PE：DOS 头 + PE 签名 + COFF 头 + 一个 `.rsrc` 段，
+/// 段内是三层资源树（type=RT_ICON → 每图标一个 id → 语言叶子）。
+///
+/// [omitRsrc] 把段名改成 `.text`（模拟没有资源段的 exe）；[inflateRsrcSize] 把段
+/// 声明大小写成远超文件长度的值（模拟被截断/损坏的文件）。
+Uint8List _buildPeWithIcons(
+  List<Uint8List> icons, {
+  bool omitRsrc = false,
+  bool inflateRsrcSize = false,
+}) {
+  const int peOffset = 0x80;
+  const int optionalHeaderSize = 0xE0;
+  const int sectionTableOffset = peOffset + 4 + 20 + optionalHeaderSize;
+  const int rsrcFileOffset = sectionTableOffset + 40;
+  const int rsrcRva = 0x1000;
+
+  // 资源段布局：L1 目录 → L2 目录 → 每个图标一层语言目录 → 叶子 → 数据。
+  final int count = icons.length;
+  const int l1 = 0;
+  const int l1Size = 16 + 8; // 只有 RT_ICON 一个类型条目
+  const int l2 = l1 + l1Size;
+  final int l2Size = 16 + 8 * count;
+  final int langBase = l2 + l2Size;
+  const int langSize = 16 + 8; // 每个图标一个语言条目
+  final int leafBase = langBase + langSize * count;
+  const int leafSize = 16;
+  final int dataBase = leafBase + leafSize * count;
+
+  int dataCursor = dataBase;
+  final List<int> dataOffsets = <int>[];
+  for (final Uint8List icon in icons) {
+    dataOffsets.add(dataCursor);
+    dataCursor += icon.length;
+  }
+  final int rsrcSize = dataCursor;
+
+  final Uint8List out = Uint8List(rsrcFileOffset + rsrcSize);
+  final ByteData view = ByteData.sublistView(out);
+
+  // DOS 头：'MZ' + e_lfanew。
+  out[0] = 0x4D;
+  out[1] = 0x5A;
+  view.setUint32(0x3C, peOffset, Endian.little);
+  // PE 签名 + COFF 头。
+  out[peOffset] = 0x50;
+  out[peOffset + 1] = 0x45;
+  view.setUint16(peOffset + 4 + 2, 1, Endian.little); // NumberOfSections
+  view.setUint16(
+      peOffset + 4 + 16, optionalHeaderSize, Endian.little); // SizeOfOptional
+
+  // 段头。
+  final String sectionName = omitRsrc ? '.text' : '.rsrc';
+  for (int i = 0; i < sectionName.length; i++) {
+    out[sectionTableOffset + i] = sectionName.codeUnitAt(i);
+  }
+  view.setUint32(
+      sectionTableOffset + 8, rsrcSize, Endian.little); // VirtualSize
+  view.setUint32(sectionTableOffset + 12, rsrcRva, Endian.little);
+  view.setUint32(
+    sectionTableOffset + 16,
+    inflateRsrcSize ? rsrcSize + 0x100000 : rsrcSize,
+    Endian.little,
+  );
+  view.setUint32(sectionTableOffset + 20, rsrcFileOffset, Endian.little);
+
+  int abs(int relative) => rsrcFileOffset + relative;
+
+  // L1：一个 RT_ICON(3) 类型条目，指向 L2 子目录。
+  view.setUint16(abs(l1) + 14, 1, Endian.little); // NumberOfIdEntries
+  view.setUint32(abs(l1) + 16, 3, Endian.little); // type id = RT_ICON
+  view.setUint32(abs(l1) + 20, 0x80000000 | l2, Endian.little);
+
+  // L2：每个图标一个 id 条目，指向自己的语言目录。
+  view.setUint16(abs(l2) + 14, count, Endian.little);
+  for (int i = 0; i < count; i++) {
+    final int entry = abs(l2) + 16 + i * 8;
+    view.setUint32(entry, i + 1, Endian.little); // 图标资源 id
+    view.setUint32(
+      entry + 4,
+      0x80000000 | (langBase + langSize * i),
+      Endian.little,
+    );
+    // 语言目录：一个条目指向叶子（无高位 = 数据条目）。
+    final int lang = abs(langBase + langSize * i);
+    view.setUint16(lang + 14, 1, Endian.little);
+    view.setUint32(lang + 16, 1033, Endian.little); // LANG_ENGLISH
+    view.setUint32(lang + 20, leafBase + leafSize * i, Endian.little);
+    // 叶子：数据 RVA + 大小。
+    final int leaf = abs(leafBase + leafSize * i);
+    view.setUint32(leaf, rsrcRva + dataOffsets[i], Endian.little);
+    view.setUint32(leaf + 4, icons[i].length, Endian.little);
+    out.setRange(
+        abs(dataOffsets[i]), abs(dataOffsets[i]) + icons[i].length, icons[i]);
+  }
+  return out;
+}

--- a/hibiki/test/pages/games_library_cover_menu_test.dart
+++ b/hibiki/test/pages/games_library_cover_menu_test.dart
@@ -1,0 +1,153 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/mining/galgame_library.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/games_library_page.dart';
+import 'package:hibiki/utils.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// 游戏卡封面入口守卫：视频/合集早就能自定义封面，游戏库过去只有「重命名 / 移除」，
+/// `GalgameEntry.coverPath` 字段无人写 → 每张卡永远是默认手柄图标。
+///
+/// 本测试钉住两条：
+/// 1. 卡片溢出菜单与长按/右键菜单**都**含「设置封面」「自动获取封面」（两处菜单
+///    共用同一份 `_menuItems`，任一处漏项都会红）；
+/// 2. 有 coverPath 且文件真实存在时，卡片渲染的是 [Image]（封面），而不是占位图标。
+void main() {
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  Future<AppModel> buildModel(List<GalgameEntry> games) async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final PreferencesRepository prefsRepo = PreferencesRepository(db);
+    await prefsRepo.loadFromDb();
+    final Directory tmpDir =
+        Directory.systemTemp.createTempSync('hibiki_game_cover_menu_');
+    addTearDown(() {
+      try {
+        tmpDir.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+    final AppModel appModel = AppModel(testPlatformServices())
+      ..wireLocalAudioForTesting(
+          prefsRepo: prefsRepo, databaseDirectory: tmpDir);
+    await appModel.setGalgames(games);
+    return appModel;
+  }
+
+  Future<void> pumpPage(WidgetTester tester, AppModel appModel) async {
+    final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+    HibikiToast.navigatorKey = navKey;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[appProvider.overrideWith((_) => appModel)],
+        child: TranslationProvider(
+          child: MaterialApp(
+            navigatorKey: navKey,
+            home: const HibikiFocusRoot(child: GamesLibraryPage()),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('溢出菜单含设置封面 / 自动获取封面', (WidgetTester tester) async {
+    final AppModel appModel = await buildModel(<GalgameEntry>[
+      GalgameEntry(
+        id: 'g1',
+        name: 'テスト',
+        exePath: r'Z:\missing\game.exe',
+        workdir: r'Z:\missing',
+        addedAt: DateTime(2026),
+      ),
+    ]);
+    await pumpPage(tester, appModel);
+
+    await tester.tap(find.byType(PopupMenuButton<String>));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.games_set_cover), findsOneWidget);
+    expect(find.text(t.games_auto_cover), findsOneWidget);
+    expect(find.text(t.games_rename), findsOneWidget);
+    expect(find.text(t.games_remove), findsOneWidget);
+  });
+
+  testWidgets('长按菜单与溢出菜单项一致', (WidgetTester tester) async {
+    final AppModel appModel = await buildModel(<GalgameEntry>[
+      GalgameEntry(
+        id: 'g1',
+        name: 'テスト',
+        exePath: r'Z:\missing\game.exe',
+        workdir: r'Z:\missing',
+        addedAt: DateTime(2026),
+      ),
+    ]);
+    await pumpPage(tester, appModel);
+
+    await tester.longPress(find.text('テスト'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SimpleDialog), findsOneWidget);
+    expect(find.text(t.games_set_cover), findsOneWidget);
+    expect(find.text(t.games_auto_cover), findsOneWidget);
+  });
+
+  testWidgets('有封面文件时卡片渲染封面图而非占位图标', (WidgetTester tester) async {
+    final Directory dir =
+        Directory.systemTemp.createTempSync('hibiki_game_cover_render_');
+    addTearDown(() {
+      try {
+        dir.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+    // 1×1 PNG：只需要文件真实存在且能被 Image.file 拿到。
+    final File cover = File('${dir.path}${Platform.pathSeparator}g1.png')
+      ..writeAsBytesSync(_onePixelPng);
+
+    final AppModel appModel = await buildModel(<GalgameEntry>[
+      GalgameEntry(
+        id: 'g1',
+        name: 'テスト',
+        exePath: r'Z:\missing\game.exe',
+        workdir: r'Z:\missing',
+        coverPath: cover.path,
+        addedAt: DateTime(2026),
+      ),
+    ]);
+    await pumpPage(tester, appModel);
+
+    expect(
+      find.byWidgetPredicate((Widget w) => w is Image && w.image is FileImage),
+      findsOneWidget,
+      reason: 'coverPath 指向的文件存在时必须渲染封面图',
+    );
+  });
+}
+
+/// 最小合法 PNG（1×1，透明）。
+final List<int> _onePixelPng = <int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+  0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+  0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+  0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+  0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+  0x42, 0x60, 0x82,
+];


### PR DESCRIPTION
## 背景

视频卡长按可换封面（`setVideoCoverFromPickedFile`），合集能选成员当封面（`MediaCollections.coverSource`），而**游戏库只有「重命名 / 移除」**：`GalgameEntry.coverPath` 字段一直存在却没有任何代码写入它，所以每张游戏卡永远显示默认手柄图标。

## 改动

**入口**（`games_library_page.dart`）
- 卡片溢出菜单与长按/右键菜单新增「设置封面」「自动获取封面」，两处菜单共用同一份 `_menuItems`（消除两份手抄）。
- 添加游戏后在后台静默补一次封面（不阻塞「添加」这一步）；用户主动触发时成功/失败都有 toast。

**自动获取：离线两级级联**（`galgame_cover_resolver.dart`）
1. 扫游戏目录**直接子文件**（不递归，galgame 目录动辄上万素材），按文件名启发式打分——`cover` / `パッケージ` / `jacket` / `keyvisual` / 与游戏同名加分，`bg` / `chara` / `button` / `save` 扣分——再用**真实像素尺寸**卡门槛（≥180px、宽高比 0.35~2.6，挡掉小图标与横幅）。
2. 目录无货则回退 **exe 内嵌图标**（`galgame_exe_icon.dart`）：纯 Dart 解析 PE 的 `.rsrc` 资源树取最大 `RT_ICON`，PNG 资源直通、DIB 包成单帧 `.ico` 交 `package:image` 转 PNG。读盘 + 解码整段跑在 `Isolate.run` 里，不占 UI 帧。

两级都不中就返回 null，保持占位图标 —— 不硬塞一张随便的图当封面。

**落盘**（`AppPaths`）
- 新增 `<documents>/game_covers`（含 documents 迁移白名单条目，否则守卫测试会红），文件名 `<GalgameEntry.id>.<ext>`。
- 手动与自动共用同一落盘入口；换封面先删该游戏的旧封面文件（扩展名可能从 `.png` 变 `.jpg`），再 `imageCache.evict` —— `FileImage` 按 `(path, scale)` 缓存解码，同名路径不驱逐就会看到换之前那张图，正是视频封面踩过的坑。

## 为什么不走 native 提图标

Win32 的 `ExtractIconEx` / `SHGetFileInfo` 只能拿 `HICON`，还要一串 GDI 调用才能变像素，且只有真机能跑、无法单测。PE 资源树是纯字节结构，解析它是确定性纯函数，三端都能跑测试，合成字节即可覆盖边界。

## 测试

- `test/mining/galgame_exe_icon_test.dart`（5）：合成 PE 覆盖多尺寸挑最大、PNG 直通、DIB→PNG 真解码、`minSize` 过滤，以及非 PE / 无 `.rsrc` / 资源段声明越界必须 fail-safe 不抛。
- `test/mining/galgame_cover_resolver_test.dart`（10）：打分排序（封面 > 立绘/背景、同名加分、`.ico` 靠后、同分稳定序）+ 真实临时目录上的级联落盘、尺寸门槛拦截、exe 图标回退、旧封面清理。
- `test/pages/games_library_cover_menu_test.dart`（3）：两处菜单都含新入口、有封面文件时渲染 `Image`。

## 验证

- `flutter analyze`（含 test）：`No issues found!`
- `flutter test`：12843 通过 / 5 skipped / 1 失败 —— 失败项是 `test/sync/hibiki_library_host_service_books_test.dart` 在 tearDown `deleteSync` 撞 Windows 文件占用（errno 32），与本改动无关；**单独重跑该文件 26/26 全过**。
- ⚠️ 真机未验：需在 Windows 上用真实 galgame 目录 / exe 验证自动获取的命中率与图标画质。

## 待定

封面来源目前**只用本地**（目录图 + exe 图标）。若希望像 Steam 那样按游戏名联网抓官方封面（VNDB 等），需要额外确认：会引入第三方网络请求，且 galgame 封面常含 R18 内容，得决定默认开关与匹配确认交互。

https://claude.ai/code/session_01ByKpVzWddY7PgcUtk3UUcj
