### PR TITLE
fix(popup): 自动展开按「行」计数，与词典列数对齐 (BUG-1041)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1001 条。点号进各自文件。
+> 共 1002 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1041](bugs/BUG-1041-popup-auto-expand-rows-vs-columns.md) | ✅ | ✅ | 折叠词典「自动展开词典数」与「词典列数」冲突：绝对本数不随列数对齐致顶部参差 |
 | [BUG-1034](bugs/BUG-1034-subtitle-row-extent-clip.md) | ✅ | ✅ | 视频字幕列表当前行末行文字被裁掉一半 |
 | [BUG-1033](bugs/BUG-1033-popup-zoom-tooltip-misfire.md) | ✅ | ✅ | 嵌套查词弹出时 A- 的「缩小查词字号」tooltip 自动弹出遮挡正文 |
 | [BUG-1032](bugs/BUG-1032-qb-webui-no-request-timeout.md) | ✅ | ✅ | qB WebUI 请求缺少超时 |

--- a/docs/bugs/BUG-1041-popup-auto-expand-rows-vs-columns.md
+++ b/docs/bugs/BUG-1041-popup-auto-expand-rows-vs-columns.md
@@ -1,0 +1,61 @@
+## BUG-1041 · 折叠词典「自动展开词典数」与「词典列数」冲突：绝对本数不随列数对齐致顶部参差
+
+- **报告**：2026-07-23（用户：反馈「折叠词典显示 自动展开词典数」和「词典列数保持一致」这两件事冲突）
+- **真实性**：✅ 真 bug（设计层面的单位错配，非偶发）
+
+### 根因
+
+两个设置分别用了**互不相关的两套单位**，于是只要展开本数不是列数的整数倍，弹窗顶部就参差：
+
+- `自动展开词典数`（`autoExpandDictionaries`，0..6）是**线性本数**：
+  `hibiki/assets/popup/popup.js:2574`（修前）`const autoExpandN = window.autoExpandDictionaries ?? 1;`
+  配合下一行的 `dictIdx < autoExpandN`，只认词典在词条内的**顺序**，完全不知道有几列。
+- `词典列数`（`--dict-columns`，1..4）是**网格单位**：`layoutMasonry()` 按「最短列打包」
+  （判据 `heights[i] < heights[c]`）把所有 `.glossary-group` 卡片塞进
+  `cols = Math.min(configured, items.length)` 列。
+
+**失效路径**（K=展开本数，N=列数）：K < N 时，前 K 本展开成高卡各占一列顶部，剩余折叠矮条因为
+其余列高度仍是 0，全部被「最短列」规则堆到那几列 —— 出现「一列一张大卡 vs 另一列一摞折叠条」。
+K 与 N 非整数倍时同理出现半行展开的参差。
+
+即：`autoExpandDictionaries` 与 `--dict-columns` 之间没有任何契约，用户把两个滑块当作能配合的
+设置来用，实际互相打架。
+
+### 修复
+
+把「自动展开」的单位从**本数**重锚为**行数**，展开数由列数派生，冲突从数据结构上消失：
+
+- 新增 `autoExpandCount(totalDicts)`（`hibiki/assets/popup/popup.js:2566`）：
+  `展开数 = window.autoExpandRows × Math.max(1, Math.min(dictColumns(), totalDicts))`。
+  列数来源 `dictColumns()`（= 视口收敛后的 `effectiveDictColumns()`）并对该词条**实际卡片数**
+  封顶，与 `layoutMasonry()` 的 `cols = Math.min(configured, items.length)` **严格同源**，因此
+  词典数 < 列数时不会凭空展开不存在的卡。
+- `createGlossarySection` 增加 `totalDicts` 形参；首屏渲染循环传 `dictNames.length`，增量
+  （load-more）路径传 **post-append** 的 `appendIndex + appendDictNames.length`（只数已渲染的
+  会低报列数，误折叠本该展开的卡）。
+- 宿主注入 `window.autoExpandDictionaries` → `window.autoExpandRows`
+  （`hibiki/lib/src/pages/implementations/popup_settings_injection.dart:313`）。
+- 文案改为「自动展开行数」（i18n key 名不变，17 语经 `tool/i18n_sync.dart` 同步）。
+
+**向后兼容**：偏好存储 key 仍是 `popup_auto_expand_dictionaries`、clamp 仍 0..6，**值不迁移**。
+默认列数为 1，`rows × 1 === 旧的绝对本数`，从未调过列数的老用户观感零变化。
+
+- **[x] ① 已修复** — popup.js（三镜像同步：`hibiki/assets/popup/`、
+  `hibiki/assets/browser_extension/vendor/`、`tools/browser-extension/vendor/`）+ 注入 + 文案 + 偏好注释。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/pages/popup_auto_expand_dictionaries_test.js`：Node 真执行 `createGlossarySection`，
+    覆盖 1 列向后兼容、rows=0、缺省回落，以及新契约 **2 列×1 行=顶行 2 张 / 2 列×2 行=4 张 /
+    3 列×1 行=3 张**、**列数被词条卡片数封顶**（4 列设置 + 2 本词典 → 2 列）、**窄视口收敛**
+    （innerWidth=300 → 1 列）。
+  - `hibiki/test/pages/popup_auto_expand_dictionaries_test.dart`：源码级守卫 `rows * cols`、
+    `Math.min(dictColumns(), total)`、`rows > 0` 短路、两处调用点必须传 totalDicts、增量
+    totalDicts 必须是 post-append 计数。
+  - `hibiki/test/settings/settings_schema_coverage_test.dart`：覆盖登记随标题改名同步。
+
+### 备注
+
+- 未改 Dart 侧 getter/setter 名（`popupAutoExpandDictionaries`），避免无谓爆炸半径；单位语义已在
+  `preferences_repository.dart` 注释里写明。
+- 采番：`tool/bug.dart` 依本地 worktree 取到 1035，但 `origin/develop` 已有 BUG-1035
+  （glossary-first-ignores-selected-dict），且 1036~1040 被未合并 PR 占用，故手动改为 1041 并 reindex。
+- 验证：`flutter analyze` 无问题；相关测试 + i18n 完整性通过。真机（弹窗多列 × 多行组合的观感）待复测。

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -2563,15 +2563,33 @@ window.hoshiPopupMineEntryByIndex = function(idx) {
     window.hoshiFocusDictionaryEntryReset = resetEntry;
 })();
 
+// 「自动展开」的单位是「行」，不是「本」：展开数 = window.autoExpandRows × 该词条有效列数。
+// 历史设计里它是绝对本数 N，与 --dict-columns 的 N 列 masonry 毫无关联，于是 N 不是列数的整数倍
+// 时顶部就参差——比如 1 本展开 + 2 列，展开卡独占第 0 列变很高，剩下的折叠条因第 1 列还是 0 高
+// 全堆到第 1 列，「一张大卡 vs 一摞折叠条」。改成按行计数后展开数天生跟随列数，顶部永远是整行。
+//
+// cols 与 masonry 的 `cols = Math.min(configured, items.length)`（layoutMasonry）严格同源：
+// 都用 dictColumns()（= 视口收敛后的 effectiveDictColumns()）再对该词条实际卡片数封顶，所以
+// 词典数 < 列数时不会凭空展开不存在的卡。默认列数 1 时 rows × 1 === 旧的绝对本数，老用户零改变。
+function autoExpandCount(totalDicts) {
+    const rows = window.autoExpandRows ?? 1;
+    if (!(rows > 0)) return 0;
+    const total = Number.isFinite(totalDicts) && totalDicts > 0 ? totalDicts : 1;
+    const cols = Math.max(1, Math.min(dictColumns(), total));
+    return rows * cols;
+}
+
 // TODO-845: `dictIdx` is the dictionary's global position within an entry's
-// glossary body (0-based). The popup auto-expands the leading
-// `window.autoExpandDictionaries` blocks even when collapseDictionaries is on
-// (default 1 = the historical "only the first dictionary expanded" behaviour,
-// where the leading block opened regardless of its per-dictionary collapse flag).
-function createGlossarySection(dictName, contents, dictIdx, entryIdx) {
+// glossary body (0-based); `totalDicts` is that entry's total block count, needed
+// to cap the effective column count the same way masonry does. The popup
+// auto-expands the leading `autoExpandCount(totalDicts)` blocks even when
+// collapseDictionaries is on (default 1 row = the historical "only the first
+// dictionary expanded" behaviour at the default single column, where the leading
+// block opened regardless of its per-dictionary collapse flag).
+function createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts) {
     const details = el('details', { className: 'glossary-group' });
     const perDictCollapsed = (window.collapsedDictionaryNames || []).includes(dictName);
-    const autoExpandN = window.autoExpandDictionaries ?? 1;
+    const autoExpandN = autoExpandCount(totalDicts);
     const autoExpanded = dictIdx < autoExpandN;
     if (autoExpanded || (!window.collapseDictionaries && !perDictCollapsed)) {
         details.open = true;
@@ -2779,7 +2797,7 @@ function buildEntryElement(entry, idx) {
     const { details, body, grouped, dictNames } = glossaryWrapper;
     entryDiv.appendChild(details);
     for (let dictIdx = 0; dictIdx < dictNames.length; dictIdx++) {
-        body.appendChild(createGlossarySection(dictNames[dictIdx], grouped[dictNames[dictIdx]], dictIdx, idx));
+        body.appendChild(createGlossarySection(dictNames[dictIdx], grouped[dictNames[dictIdx]], dictIdx, idx, dictNames.length));
     }
 
     return entryDiv;
@@ -3527,15 +3545,20 @@ window.updatePopupIncremental = function() {
                 // of visible `.glossary-group` children and bump it per appended
                 // block — same `dictIdx < autoExpandN` rule as the first-paint loop,
                 // never a bare `false` (which would forbid any incremental expand).
+                // totalDicts must be the entry's POST-append block count: the row-based
+                // threshold caps columns at the real card count, so counting only the
+                // already-rendered blocks would under-report columns and collapse cards
+                // that the finished layout does have room to expand.
                 let appendIndex =
                     body.querySelectorAll(':scope > .glossary-group').length;
-                for (const dictName of Object.keys(grouped)) {
-                    if (!existingDicts.has(dictName)) {
-                        const section = createGlossarySection(dictName, grouped[dictName], appendIndex, idx);
-                        appendIndex++;
-                        body.appendChild(section);
-                        postProcessRuby(section);
-                    }
+                const appendDictNames = Object.keys(grouped)
+                    .filter(dictName => !existingDicts.has(dictName));
+                const totalDicts = appendIndex + appendDictNames.length;
+                for (const dictName of appendDictNames) {
+                    const section = createGlossarySection(dictName, grouped[dictName], appendIndex, idx, totalDicts);
+                    appendIndex++;
+                    body.appendChild(section);
+                    postProcessRuby(section);
                 }
             }
         } else {

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -2563,15 +2563,33 @@ window.hoshiPopupMineEntryByIndex = function(idx) {
     window.hoshiFocusDictionaryEntryReset = resetEntry;
 })();
 
+// 「自动展开」的单位是「行」，不是「本」：展开数 = window.autoExpandRows × 该词条有效列数。
+// 历史设计里它是绝对本数 N，与 --dict-columns 的 N 列 masonry 毫无关联，于是 N 不是列数的整数倍
+// 时顶部就参差——比如 1 本展开 + 2 列，展开卡独占第 0 列变很高，剩下的折叠条因第 1 列还是 0 高
+// 全堆到第 1 列，「一张大卡 vs 一摞折叠条」。改成按行计数后展开数天生跟随列数，顶部永远是整行。
+//
+// cols 与 masonry 的 `cols = Math.min(configured, items.length)`（layoutMasonry）严格同源：
+// 都用 dictColumns()（= 视口收敛后的 effectiveDictColumns()）再对该词条实际卡片数封顶，所以
+// 词典数 < 列数时不会凭空展开不存在的卡。默认列数 1 时 rows × 1 === 旧的绝对本数，老用户零改变。
+function autoExpandCount(totalDicts) {
+    const rows = window.autoExpandRows ?? 1;
+    if (!(rows > 0)) return 0;
+    const total = Number.isFinite(totalDicts) && totalDicts > 0 ? totalDicts : 1;
+    const cols = Math.max(1, Math.min(dictColumns(), total));
+    return rows * cols;
+}
+
 // TODO-845: `dictIdx` is the dictionary's global position within an entry's
-// glossary body (0-based). The popup auto-expands the leading
-// `window.autoExpandDictionaries` blocks even when collapseDictionaries is on
-// (default 1 = the historical "only the first dictionary expanded" behaviour,
-// where the leading block opened regardless of its per-dictionary collapse flag).
-function createGlossarySection(dictName, contents, dictIdx, entryIdx) {
+// glossary body (0-based); `totalDicts` is that entry's total block count, needed
+// to cap the effective column count the same way masonry does. The popup
+// auto-expands the leading `autoExpandCount(totalDicts)` blocks even when
+// collapseDictionaries is on (default 1 row = the historical "only the first
+// dictionary expanded" behaviour at the default single column, where the leading
+// block opened regardless of its per-dictionary collapse flag).
+function createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts) {
     const details = el('details', { className: 'glossary-group' });
     const perDictCollapsed = (window.collapsedDictionaryNames || []).includes(dictName);
-    const autoExpandN = window.autoExpandDictionaries ?? 1;
+    const autoExpandN = autoExpandCount(totalDicts);
     const autoExpanded = dictIdx < autoExpandN;
     if (autoExpanded || (!window.collapseDictionaries && !perDictCollapsed)) {
         details.open = true;
@@ -2779,7 +2797,7 @@ function buildEntryElement(entry, idx) {
     const { details, body, grouped, dictNames } = glossaryWrapper;
     entryDiv.appendChild(details);
     for (let dictIdx = 0; dictIdx < dictNames.length; dictIdx++) {
-        body.appendChild(createGlossarySection(dictNames[dictIdx], grouped[dictNames[dictIdx]], dictIdx, idx));
+        body.appendChild(createGlossarySection(dictNames[dictIdx], grouped[dictNames[dictIdx]], dictIdx, idx, dictNames.length));
     }
 
     return entryDiv;
@@ -3527,15 +3545,20 @@ window.updatePopupIncremental = function() {
                 // of visible `.glossary-group` children and bump it per appended
                 // block — same `dictIdx < autoExpandN` rule as the first-paint loop,
                 // never a bare `false` (which would forbid any incremental expand).
+                // totalDicts must be the entry's POST-append block count: the row-based
+                // threshold caps columns at the real card count, so counting only the
+                // already-rendered blocks would under-report columns and collapse cards
+                // that the finished layout does have room to expand.
                 let appendIndex =
                     body.querySelectorAll(':scope > .glossary-group').length;
-                for (const dictName of Object.keys(grouped)) {
-                    if (!existingDicts.has(dictName)) {
-                        const section = createGlossarySection(dictName, grouped[dictName], appendIndex, idx);
-                        appendIndex++;
-                        body.appendChild(section);
-                        postProcessRuby(section);
-                    }
+                const appendDictNames = Object.keys(grouped)
+                    .filter(dictName => !existingDicts.has(dictName));
+                const totalDicts = appendIndex + appendDictNames.length;
+                for (const dictName of appendDictNames) {
+                    const section = createGlossarySection(dictName, grouped[dictName], appendIndex, idx, totalDicts);
+                    appendIndex++;
+                    body.appendChild(section);
+                    postProcessRuby(section);
                 }
             }
         } else {

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 39389 (2317 per locale)
 ///
-/// Built on 2026-07-23 at 12:58 UTC
+/// Built on 2026-07-23 at 15:37 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -1938,9 +1938,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Please allow Hibiki to install apps in system settings, then retry.';
   String get update_install_permission_retry => 'Retry install';
   String get update_install_permission_cancel => 'Cancel';
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
   String get profile_export => 'Export';
   String get profile_import => 'Import';
   String get profile_export_failed => 'Export failed';
@@ -3091,6 +3088,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get pdf_bookmarks => 'Bookmarks';
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   String get pdf_bookmark_added => 'Bookmark added';
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -6296,11 +6296,6 @@ class _StringsAr extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -8345,6 +8340,11 @@ class _StringsAr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -11622,11 +11622,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -13672,6 +13667,11 @@ class _StringsDe extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -16965,11 +16965,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -19015,6 +19010,11 @@ class _StringsEs extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -22319,11 +22319,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -24369,6 +24364,11 @@ class _StringsFr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -27600,11 +27600,6 @@ class _StringsId extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -29650,6 +29645,11 @@ class _StringsId extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -32929,11 +32929,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -34979,6 +34974,11 @@ class _StringsIt extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -38067,11 +38067,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -40113,6 +40108,11 @@ class _StringsJa extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -43203,11 +43203,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -45250,6 +45245,11 @@ class _StringsKo extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -48507,11 +48507,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -50557,6 +50552,11 @@ class _StringsNl extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -53829,11 +53829,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -55879,6 +55874,11 @@ class _StringsPtBr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -59134,11 +59134,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -61184,6 +61179,11 @@ class _StringsRu extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -64385,11 +64385,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -66434,6 +66429,11 @@ class _StringsTh extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -69666,11 +69666,6 @@ class _StringsTr extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -71716,6 +71711,11 @@ class _StringsTr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -74936,11 +74936,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get update_install_permission_cancel => 'Cancel';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -76985,6 +76980,11 @@ class _StringsVi extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 // Path: <root>
@@ -79991,11 +79991,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get update_install_permission_cancel => '取消';
   @override
-  String get popup_auto_expand_dictionaries => '自动展开词典数';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      '即使开启「折叠词典」，也保持前 N 个词典展开（0 = 全部折叠）';
-  @override
   String get profile_export => '导出';
   @override
   String get profile_import => '导入';
@@ -81883,6 +81878,11 @@ class _StringsZhCn extends _StringsEn {
   String get pdf_bookmarks_empty => '还没有书签。';
   @override
   String get pdf_bookmark_added => '已添加书签';
+  @override
+  String get popup_auto_expand_dictionaries => '自动展开行数';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      '即使开启「折叠词典」，也保持前 N 行词典方框展开。展开数跟随列数设置：行数 x 词典列数（0 = 全部折叠）';
 }
 
 // Path: <root>
@@ -84893,11 +84893,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get update_install_permission_cancel => '取消';
   @override
-  String get popup_auto_expand_dictionaries => 'Auto-expand dictionaries';
-  @override
-  String get popup_auto_expand_dictionaries_hint =>
-      'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
-  @override
   String get profile_export => 'Export';
   @override
   String get profile_import => 'Import';
@@ -86935,6 +86930,11 @@ class _StringsZhHk extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get popup_auto_expand_dictionaries => 'Auto-expand rows';
+  @override
+  String get popup_auto_expand_dictionaries_hint =>
+      'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
 }
 
 /// Flat map(s) containing all translations.
@@ -89847,10 +89847,6 @@ extension on _StringsEn {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -91665,6 +91661,10 @@ extension on _StringsEn {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -94575,10 +94575,6 @@ extension on _StringsAr {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -96393,6 +96389,10 @@ extension on _StringsAr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -99324,10 +99324,6 @@ extension on _StringsDe {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -101142,6 +101138,10 @@ extension on _StringsDe {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -104072,10 +104072,6 @@ extension on _StringsEs {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -105890,6 +105886,10 @@ extension on _StringsEs {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -108826,10 +108826,6 @@ extension on _StringsFr {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -110644,6 +110640,10 @@ extension on _StringsFr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -113562,10 +113562,6 @@ extension on _StringsId {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -115380,6 +115376,10 @@ extension on _StringsId {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -118313,10 +118313,6 @@ extension on _StringsIt {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -120131,6 +120127,10 @@ extension on _StringsIt {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -123027,10 +123027,6 @@ extension on _StringsJa {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -124844,6 +124840,10 @@ extension on _StringsJa {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -127743,10 +127743,6 @@ extension on _StringsKo {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -129561,6 +129557,10 @@ extension on _StringsKo {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -132487,10 +132487,6 @@ extension on _StringsNl {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -134305,6 +134301,10 @@ extension on _StringsNl {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -137228,10 +137228,6 @@ extension on _StringsPtBr {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -139046,6 +139042,10 @@ extension on _StringsPtBr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -141974,10 +141974,6 @@ extension on _StringsRu {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -143792,6 +143788,10 @@ extension on _StringsRu {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -146704,10 +146704,6 @@ extension on _StringsTh {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -148522,6 +148518,10 @@ extension on _StringsTh {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -151443,10 +151443,6 @@ extension on _StringsTr {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -153261,6 +153257,10 @@ extension on _StringsTr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -156177,10 +156177,6 @@ extension on _StringsVi {
         return 'Retry install';
       case 'update_install_permission_cancel':
         return 'Cancel';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -157995,6 +157991,10 @@ extension on _StringsVi {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }
@@ -160884,10 +160884,6 @@ extension on _StringsZhCn {
         return '重试安装';
       case 'update_install_permission_cancel':
         return '取消';
-      case 'popup_auto_expand_dictionaries':
-        return '自动展开词典数';
-      case 'popup_auto_expand_dictionaries_hint':
-        return '即使开启「折叠词典」，也保持前 N 个词典展开（0 = 全部折叠）';
       case 'profile_export':
         return '导出';
       case 'profile_import':
@@ -162693,6 +162689,10 @@ extension on _StringsZhCn {
         return '还没有书签。';
       case 'pdf_bookmark_added':
         return '已添加书签';
+      case 'popup_auto_expand_dictionaries':
+        return '自动展开行数';
+      case 'popup_auto_expand_dictionaries_hint':
+        return '即使开启「折叠词典」，也保持前 N 行词典方框展开。展开数跟随列数设置：行数 x 词典列数（0 = 全部折叠）';
       default:
         return null;
     }
@@ -165584,10 +165584,6 @@ extension on _StringsZhHk {
         return '重試安裝';
       case 'update_install_permission_cancel':
         return '取消';
-      case 'popup_auto_expand_dictionaries':
-        return 'Auto-expand dictionaries';
-      case 'popup_auto_expand_dictionaries_hint':
-        return 'Keep the first N dictionary blocks expanded even when \'Collapse dictionaries\' is on (0 = collapse all)';
       case 'profile_export':
         return 'Export';
       case 'profile_import':
@@ -167401,6 +167397,10 @@ extension on _StringsZhHk {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'popup_auto_expand_dictionaries':
+        return 'Auto-expand rows';
+      case 'popup_auto_expand_dictionaries_hint':
+        return 'Keep the first N rows of dictionary blocks expanded even when \'Collapse dictionaries\' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "Please allow Hibiki to install apps in system settings, then retry.",
   "update_install_permission_retry": "Retry install",
   "update_install_permission_cancel": "Cancel",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "请在系统设置中允许 Hibiki 安装应用，然后重试安装。",
   "update_install_permission_retry": "重试安装",
   "update_install_permission_cancel": "取消",
-  "popup_auto_expand_dictionaries": "自动展开词典数",
-  "popup_auto_expand_dictionaries_hint": "即使开启「折叠词典」，也保持前 N 个词典展开（0 = 全部折叠）",
   "profile_export": "导出",
   "profile_import": "导入",
   "profile_export_failed": "导出失败",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "此 PDF 没有目录。",
   "pdf_bookmarks": "书签",
   "pdf_bookmarks_empty": "还没有书签。",
-  "pdf_bookmark_added": "已添加书签"
+  "pdf_bookmark_added": "已添加书签",
+  "popup_auto_expand_dictionaries": "自动展开行数",
+  "popup_auto_expand_dictionaries_hint": "即使开启「折叠词典」，也保持前 N 行词典方框展开。展开数跟随列数设置：行数 x 词典列数（0 = 全部折叠）"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1419,8 +1419,6 @@
   "update_install_permission_message": "請在系統設定中允許 Hibiki 安裝應用程式，然後重試安裝。",
   "update_install_permission_retry": "重試安裝",
   "update_install_permission_cancel": "取消",
-  "popup_auto_expand_dictionaries": "Auto-expand dictionaries",
-  "popup_auto_expand_dictionaries_hint": "Keep the first N dictionary blocks expanded even when 'Collapse dictionaries' is on (0 = collapse all)",
   "profile_export": "Export",
   "profile_import": "Import",
   "profile_export_failed": "Export failed",
@@ -2315,5 +2313,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "popup_auto_expand_dictionaries": "Auto-expand rows",
+  "popup_auto_expand_dictionaries_hint": "Keep the first N rows of dictionary blocks expanded even when 'Collapse dictionaries' is on. The expanded count follows the column setting: rows x columns (0 = collapse all)"
 }

--- a/hibiki/lib/src/lookup/global_lookup_render.dart
+++ b/hibiki/lib/src/lookup/global_lookup_render.dart
@@ -36,7 +36,7 @@ import 'package:hibiki/src/reader/popup_swipe_close_script.dart';
 /// [PopupSettingsOptions.globalLookup] = true, then appends the host reset hooks
 /// + renderPopup() this per-frame realm needs. Sharing the body keeps the
 /// app-outside window in lock-step with the in-app popup (dictionary font, zoom
-/// clamp, autoExpandDictionaries, all window.* flags) so the two can never drift
+/// clamp, autoExpandRows, all window.* flags) so the two can never drift
 /// again. It deliberately omits the in-app load-more / instant-scroll wiring —
 /// those belong to the in-app popup, not to an iframe inside the host shell.
 ///

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -659,12 +659,19 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
-  // TODO-845: how many leading dictionary blocks the lookup popup auto-expands
-  // (force-open <details>) even when "collapse dictionaries" is on. Default 1
-  // preserves the historical "only the first dictionary is expanded" behaviour.
-  // Clamped to 0..6 on read and write so a corrupt/out-of-range stored value
-  // can never reach popup.js as an absurd expand threshold; the clamp range is
-  // identical to the lookup settings slider min/max.
+  // TODO-845: how many leading *rows* of dictionary blocks the lookup popup
+  // auto-expands (force-open <details>) even when "collapse dictionaries" is on.
+  // The unit is rows, not blocks: popup.js expands `rows × effective columns`
+  // (see autoExpandCount there), so the expanded region is always whole top rows
+  // and never fights the --dict-columns masonry. Default 1 preserves the
+  // historical "only the first dictionary is expanded" behaviour, because the
+  // default column count is 1 (1 row × 1 column === 1 block).
+  //
+  // The storage key keeps its legacy `popup_auto_expand_dictionaries` name so
+  // existing stored values carry over untouched. Clamped to 0..6 on read and
+  // write so a corrupt/out-of-range stored value can never reach popup.js as an
+  // absurd expand threshold; the clamp range is identical to the lookup settings
+  // slider min/max.
   int get popupAutoExpandDictionaries =>
       (getPref('popup_auto_expand_dictionaries', defaultValue: 1) as int)
           .clamp(0, 6);

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -747,7 +747,7 @@ JSON.stringify((function(){
 
     final appModel = ref.read(appProvider);
     // TODO-895: the SHARED settings body (theme vars + dictionary font + content
-    // zoom + every window.* flag, incl. autoExpandDictionaries) is produced by the
+    // zoom + every window.* flag, incl. autoExpandRows) is produced by the
     // single source of truth in popup_settings_injection.dart — the SAME builder
     // the app-outside global-lookup window uses (options.globalLookup:false here).
     // The in-app-only wiring (instant-scroll pref, __hoshiResetPopupScroll hook,

--- a/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
@@ -2,7 +2,7 @@
 // injection body. Both popup render paths feed the SAME popup assets and end in
 // window.renderPopup(). The settings body was previously hand-copied TWICE (in-app
 // _pushResults + app-outside buildFrameSettingsJs) and drifted: app-outside lost the
-// dictionary font (D1), autoExpandDictionaries (D2), and the clamped/NaN-guarded zoom
+// dictionary font (D1), autoExpandRows (D2), and the clamped/NaN-guarded zoom
 // (D3). This builder is the ONE place that emits the shared body; the two call sites
 // pass their own PopupSettingsOptions for the legitimate differences (app-outside
 // global-lookup class + icon-font override + hidden mine button; in-app sentence i18n
@@ -214,7 +214,7 @@ class PopupStaticSettingsJs {
 
 /// THE single source of truth for the popup settings injection body. Emits the
 /// shared theme vars + dictionary font + content zoom + every `window.*` flag
-/// (audio, dedup/harmonic, collapse + autoExpandDictionaries, collapsed/hidden
+/// (audio, dedup/harmonic, collapse + autoExpandRows, collapsed/hidden
 /// names, lookupEntries/kanjiResults, dictionary styles + custom CSS). Each call
 /// site appends its own reset hooks + window.renderPopup() AFTER this body, so the
 /// body intentionally does NOT call renderPopup itself.
@@ -310,7 +310,7 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
     window.harmonicFrequency = ${appModel.harmonicFrequency};
     window.showExpressionTags = ${appModel.showExpressionTags};
     window.collapseDictionaries = ${appModel.collapseDictionaries};
-    window.autoExpandDictionaries = ${appModel.popupAutoExpandDictionaries};
+    window.autoExpandRows = ${appModel.popupAutoExpandDictionaries};
     window.collapsedDictionaryNames = $collapsedNames;
     window.hiddenDictionaryNames = $hiddenNames;
 ''';

--- a/hibiki/lib/src/settings/settings_schema_lookup.dart
+++ b/hibiki/lib/src/settings/settings_schema_lookup.dart
@@ -173,9 +173,13 @@ SettingsDestination buildLookupDestination() {
               settingsContext.refresh();
             },
           ),
-          // TODO-845: how many leading dictionary blocks the popup auto-expands
-          // even when "collapse dictionaries" is on. int preference surfaced
-          // through a double slider; min/max (0..6) match the repository clamp.
+          // TODO-845: how many leading *rows* of dictionary blocks the popup
+          // auto-expands even when "collapse dictionaries" is on. The unit is
+          // rows so the expanded region always fills whole top rows of the
+          // --dict-columns masonry (popup.js autoExpandCount = rows × effective
+          // columns) instead of fighting it with a column-blind block count.
+          // int preference surfaced through a double slider; min/max (0..6)
+          // match the repository clamp.
           // 仅当「折叠词典显示」开启时才有意义（折叠关闭时所有词典本就展开，「自动展开
           // 前 N 本」无从谈起）；据此对齐用户预期，仅折叠开启时才显示本项。
           SettingsSliderItem(

--- a/hibiki/test/lookup/global_lookup_popup_style_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_popup_style_guard_test.dart
@@ -329,16 +329,18 @@ void main() {
           reason: 'app-outside must not re-implement the font injection');
     });
 
-    test('D2 — autoExpandDictionaries is in the shared body', () {
+    test('D2 — autoExpandRows is in the shared body', () {
       // app-outside previously dropped this flag (folded popups never auto-
-      // expanded). It now lives in the one body both paths emit.
-      expect(inject.contains('window.autoExpandDictionaries ='), isTrue,
-          reason: 'the shared body must inject autoExpandDictionaries');
+      // expanded). It now lives in the one body both paths emit. The value is
+      // the auto-expand ROW count; popup.js multiplies it by the effective
+      // column count (autoExpandCount) to get the expanded block count.
+      expect(inject.contains('window.autoExpandRows ='), isTrue,
+          reason: 'the shared body must inject autoExpandRows');
       expect(inject.contains('appModel.popupAutoExpandDictionaries'), isTrue);
       // No second INJECTION of the flag in the app-outside file (a doc-comment
-      // mention is fine; the actual `window.autoExpandDictionaries =` must not
+      // mention is fine; the actual `window.autoExpandRows =` must not
       // be duplicated there).
-      expect(render.contains('window.autoExpandDictionaries ='), isFalse,
+      expect(render.contains('window.autoExpandRows ='), isFalse,
           reason: 'app-outside must not re-inject the flag (single source)');
     });
 

--- a/hibiki/test/pages/popup_auto_expand_dictionaries_test.dart
+++ b/hibiki/test/pages/popup_auto_expand_dictionaries_test.dart
@@ -2,17 +2,23 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// TODO-845: the lookup popup auto-expands the leading N dictionary blocks
-/// (force-open `<details>`) even when "collapse dictionaries" is on. The count
-/// is the new `popup_auto_expand_dictionaries` preference (default 1 = the
-/// historical "only the first dictionary expanded" behaviour, clamped 0..6).
+/// TODO-845: the lookup popup auto-expands the leading N *rows* of dictionary
+/// blocks (force-open `<details>`) even when "collapse dictionaries" is on. The
+/// row count is the `popup_auto_expand_dictionaries` preference (legacy storage
+/// key kept for compatibility; default 1, clamped 0..6).
+///
+/// 单位是「行」而不是「本」：展开数 = 行数 × 有效列数（popup.js `autoExpandCount`），
+/// 与 `--dict-columns` masonry 的 `cols = min(configured, items.length)` 同源。历史设计
+/// 用的是与列数毫无关联的绝对本数，于是本数不是列数整数倍时顶部参差（1 本 + 2 列 →
+/// 一列一张大卡、另一列一摞折叠条）。默认列数 1 时 行数 × 1 === 旧本数，老用户零改变。
 ///
 /// 三层守护：
 /// ① 行为级——用 Node 真执行 popup.js 的 `createGlossarySection`，断言每个词典块的
-///    `<details>.open` 随 `window.autoExpandDictionaries` 与折叠开关正确变化。无 node 时 skip。
-/// ② popup.js 源码级——保证渲染循环与增量路径都按 `dictIdx < autoExpandN` 计算，
-///    而不是退回硬编码 `dictIdx === 0` / 裸 `false`。
-/// ③ 宿主/偏好源码级——保证 webview 注入了 `window.autoExpandDictionaries`、偏好
+///    `<details>.open` 随 `window.autoExpandRows` × 列数与折叠开关正确变化。无 node 时 skip。
+/// ② popup.js 源码级——保证渲染循环与增量路径都按 `dictIdx < autoExpandN` 计算、且都把
+///    该词条真实卡片数传给列数封顶，而不是退回硬编码 `dictIdx === 0` / 裸 `false`，
+///    也不是退回与列数无关的绝对本数。
+/// ③ 宿主/偏好源码级——保证 webview 注入了 `window.autoExpandRows`、偏好
 ///    clamp 与 Slider 范围都是 0..6 默认 1。
 void main() {
   test(
@@ -57,20 +63,21 @@ void main() {
   test('popup.js drives expand from dictIdx < autoExpandN (no bare false)', () {
     final String js = File('assets/popup/popup.js').readAsStringSync();
 
-    // The expand decision must read the threshold and compare the block index.
-    expect(js.contains('window.autoExpandDictionaries'), isTrue,
-        reason:
-            'createGlossarySection must read window.autoExpandDictionaries');
+    // The expand decision must read the row count and compare the block index.
+    expect(js.contains('window.autoExpandRows'), isTrue,
+        reason: 'autoExpandCount must read window.autoExpandRows');
     expect(js.contains('dictIdx < autoExpandN'), isTrue,
         reason: 'expand must be index-driven, not first-only');
 
-    // First-paint render loop must forward the real index, not `dictIdx === 0`.
+    // First-paint render loop must forward the real index, not `dictIdx === 0`,
+    // AND the entry's real block count so the column cap matches masonry.
     expect(
       js.contains(
-          'createGlossarySection(dictNames[dictIdx], grouped[dictNames[dictIdx]], dictIdx, idx)'),
+          'createGlossarySection(dictNames[dictIdx], grouped[dictNames[dictIdx]], dictIdx, idx, dictNames.length)'),
       isTrue,
       reason: 'the render loop must pass the real dictIdx (regression: '
-          '`dictIdx === 0` collapses everything past the first dictionary)',
+          '`dictIdx === 0` collapses everything past the first dictionary) '
+          'and dictNames.length for the column cap',
     );
 
     // The incremental (load-more) path must compute a global append index, not
@@ -83,16 +90,53 @@ void main() {
     );
     expect(
       js.contains(
-          'createGlossarySection(dictName, grouped[dictName], appendIndex, idx)'),
+          'createGlossarySection(dictName, grouped[dictName], appendIndex, idx, totalDicts)'),
       isTrue,
       reason: 'incremental path must pass a real index, never a bare false '
-          '(regression: appended blocks could never auto-expand)',
+          '(regression: appended blocks could never auto-expand), plus the '
+          'post-append total for the column cap',
+    );
+    // The incremental total must count the blocks that are ABOUT to be appended,
+    // not just the already-rendered ones — otherwise the column cap under-reports
+    // and collapses cards the finished layout has room to expand.
+    expect(
+      js.contains('const totalDicts = appendIndex + appendDictNames.length;'),
+      isTrue,
+      reason: 'incremental totalDicts must be the POST-append block count',
     );
   });
 
-  test(
-      'host injects window.autoExpandDictionaries next to collapseDictionaries',
-      () {
+  test('expanded count is rows x effective columns, capped like masonry', () {
+    final String js = File('assets/popup/popup.js').readAsStringSync();
+
+    final int fn = js.indexOf('function autoExpandCount(');
+    expect(fn, greaterThanOrEqualTo(0),
+        reason: 'the row->block threshold must live in autoExpandCount()');
+    final int fnEnd = js.indexOf('\n}', fn);
+    expect(fnEnd, greaterThan(fn));
+    final String body = js.substring(fn, fnEnd);
+
+    // rows x columns is the whole point: a bare row count (or a bare block
+    // count) would reintroduce the ragged half-row the fix removes.
+    expect(RegExp(r'rows\s*\*\s*cols').hasMatch(body), isTrue,
+        reason: 'expanded count must be rows * cols, not a column-blind count');
+    // Columns must come from the same source masonry uses (dictColumns() =
+    // effectiveDictColumns(), i.e. viewport-converged), and be capped by the
+    // entry's real card count exactly like layoutMasonry's
+    // `cols = Math.min(configured, items.length)`.
+    expect(body.contains('dictColumns()'), isTrue,
+        reason: 'columns must come from dictColumns() (masonry single source)');
+    expect(
+        RegExp(r'Math\.min\(\s*dictColumns\(\)\s*,\s*total\s*\)')
+            .hasMatch(body),
+        isTrue,
+        reason: 'columns must be capped by the entry block count like masonry');
+    // rows <= 0 must expand nothing at all (0 = collapse everything).
+    expect(RegExp(r'rows\s*>\s*0').hasMatch(body), isTrue,
+        reason: 'rows <= 0 must short-circuit to zero expanded blocks');
+  });
+
+  test('host injects window.autoExpandRows next to collapseDictionaries', () {
     // TODO-895: the shared popup settings body (theme vars + every window.* flag)
     // moved to the single source of truth popup_settings_injection.dart.
     final String dart = File(
@@ -102,14 +146,14 @@ void main() {
     final int collapseInject = dart.indexOf('window.collapseDictionaries =');
     expect(collapseInject, greaterThanOrEqualTo(0));
 
-    final int autoExpandInject =
-        dart.indexOf('window.autoExpandDictionaries =');
+    final int autoExpandInject = dart.indexOf('window.autoExpandRows =');
     expect(autoExpandInject, greaterThan(collapseInject),
-        reason: 'autoExpandDictionaries injection must sit next to '
+        reason: 'autoExpandRows injection must sit next to '
             'collapseDictionaries (per-lookup scalar, not the CSS theme path)');
 
     expect(dart.contains('appModel.popupAutoExpandDictionaries'), isTrue,
-        reason: 'injected value must come from the appModel proxy');
+        reason: 'injected value must come from the appModel proxy '
+            '(legacy getter name, value is the row count)');
   });
 
   test('preference clamps 0..6 with default 1 (backward compatible)', () {

--- a/hibiki/test/pages/popup_auto_expand_dictionaries_test.js
+++ b/hibiki/test/pages/popup_auto_expand_dictionaries_test.js
@@ -1,11 +1,15 @@
 // TODO-845 behavior test: the lookup popup auto-expands the leading
-// `window.autoExpandDictionaries` dictionary blocks (force-open <details>) even
-// when "collapse dictionaries" is on. Default 1 reproduces the historical
-// "only the first dictionary is expanded" behaviour; 0 collapses all; N>1
-// expands the first N. This test EXECUTES the real popup.js
-// createGlossarySection against a minimal fake DOM and asserts the resulting
-// <details>.open state per dictionary index. Reverting the fix (hardcoding the
-// expand to dictIdx===0 / a bare false) turns this red.
+// `window.autoExpandRows` ROWS of dictionary blocks (force-open <details>) even
+// when "collapse dictionaries" is on. The unit is rows, not blocks: the expanded
+// count is `rows × effective columns` (popup.js autoExpandCount), so the expanded
+// region is always whole top rows of the --dict-columns masonry. At the default
+// single column that is identical to the historical absolute block count, so
+// rows=1 still reproduces "only the first dictionary is expanded"; 0 collapses
+// all. This test EXECUTES the real popup.js createGlossarySection against a
+// minimal fake DOM and asserts the resulting <details>.open state per dictionary
+// index. Reverting the fix (hardcoding the expand to dictIdx===0 / a bare false,
+// or dropping the column multiplier back to a column-blind block count) turns
+// this red.
 //
 // Run: node hibiki/test/pages/popup_auto_expand_dictionaries_test.js
 // (also driven from popup_auto_expand_dictionaries_test.dart so it executes
@@ -70,7 +74,11 @@ function makeSandbox(opts) {
     hiddenDictionaryNames: [],
     collapsedDictionaryNames: opts.collapsedDictionaryNames || [],
     collapseDictionaries: opts.collapseDictionaries,
-    autoExpandDictionaries: opts.autoExpandDictionaries,
+    autoExpandRows: opts.autoExpandRows,
+    // effectiveDictColumns() converges the configured column count against the
+    // viewport (each column needs >= DICT_COLUMN_MIN_WIDTH=170px). Default wide
+    // so `dictColumns` alone decides unless a case pins a narrow viewport.
+    innerWidth: opts.innerWidth === undefined ? 1200 : opts.innerWidth,
     flutter_inappwebview: { callHandler() { return Promise.resolve(false); } },
     getSelection() { return { toString() { return ''; } }; },
   };
@@ -84,7 +92,18 @@ function makeSandbox(opts) {
     DOMParser: class { parseFromString() { return { body: makeElement('body'), querySelectorAll() { return []; } }; } },
     document: documentObj,
     window: windowObj,
-    getComputedStyle() { return {}; },
+    // The row-based threshold reads the host-injected --dict-columns through
+    // effectiveDictColumns(), so the fake style must actually serve it.
+    getComputedStyle() {
+      return {
+        getPropertyValue(name) {
+          if (name === '--dict-columns') {
+            return String(opts.dictColumns === undefined ? 1 : opts.dictColumns);
+          }
+          return '';
+        },
+      };
+    },
   };
   sandbox.globalThis = sandbox;
   return sandbox;
@@ -95,8 +114,8 @@ function loadPopup(opts) {
   vm.createContext(sandbox);
   const exported = source + `
     ;window.__test = {
-      section: function(dictName, dictIdx) {
-        return createGlossarySection(dictName, [{ content: '"def"', definitionTags: '', termTags: '' }], dictIdx, 0);
+      section: function(dictName, dictIdx, totalDicts) {
+        return createGlossarySection(dictName, [{ content: '"def"', definitionTags: '', termTags: '' }], dictIdx, 0, totalDicts);
       },
     };
   `;
@@ -105,50 +124,98 @@ function loadPopup(opts) {
 }
 
 // Return whether the <details> block for a dictionary at `dictIdx` is open,
-// given collapse on/off and the auto-expand threshold N.
-function isOpen(opts, dictName, dictIdx) {
+// given collapse on/off, the auto-expand ROW count and the entry's total block
+// count (which caps the effective column count exactly like masonry does).
+function isOpen(opts, dictName, dictIdx, totalDicts) {
   const sb = loadPopup(opts);
-  const details = sb.window.__test.section(dictName || 'JMdict', dictIdx);
+  const details = sb.window.__test.section(
+    dictName || 'JMdict', dictIdx, totalDicts === undefined ? 8 : totalDicts);
   return details.open === true;
 }
 
 (function run() {
-  // --- collapse OFF: every dictionary opens regardless of N. ---
+  // --- collapse OFF: every dictionary opens regardless of the row count. ---
   {
-    const opts = { collapseDictionaries: false, autoExpandDictionaries: 1 };
+    const opts = { collapseDictionaries: false, autoExpandRows: 1 };
     assert.strictEqual(isOpen(opts, 'JMdict', 0), true, 'collapse off: idx0 open');
     assert.strictEqual(isOpen(opts, 'Daijirin', 3), true, 'collapse off: idx3 open');
   }
 
-  // --- collapse ON, N=1 (default / backward-compat): only the first opens. ---
+  // --- 1 column (default): rows === the historical absolute block count. ---
+  // This is the backward-compatibility contract — an existing user who never
+  // touched the column slider must see exactly the old behaviour.
   {
-    const opts = { collapseDictionaries: true, autoExpandDictionaries: 1 };
-    assert.strictEqual(isOpen(opts, 'JMdict', 0), true, 'N=1: idx0 open');
-    assert.strictEqual(isOpen(opts, 'Daijirin', 1), false, 'N=1: idx1 collapsed');
-    assert.strictEqual(isOpen(opts, 'Other', 5), false, 'N=1: idx5 collapsed');
+    const opts = { collapseDictionaries: true, autoExpandRows: 1, dictColumns: 1 };
+    assert.strictEqual(isOpen(opts, 'JMdict', 0), true, '1col rows=1: idx0 open');
+    assert.strictEqual(isOpen(opts, 'Daijirin', 1), false, '1col rows=1: idx1 collapsed');
+    assert.strictEqual(isOpen(opts, 'Other', 5), false, '1col rows=1: idx5 collapsed');
+  }
+  {
+    const opts = { collapseDictionaries: true, autoExpandRows: 3, dictColumns: 1 };
+    assert.strictEqual(isOpen(opts, 'D0', 0), true, '1col rows=3: idx0 open');
+    assert.strictEqual(isOpen(opts, 'D1', 1), true, '1col rows=3: idx1 open');
+    assert.strictEqual(isOpen(opts, 'D2', 2), true, '1col rows=3: idx2 open');
+    assert.strictEqual(isOpen(opts, 'D3', 3), false, '1col rows=3: idx3 collapsed');
   }
 
-  // --- collapse ON, N=3: first three open, the rest collapsed. ---
+  // --- rows=0: nothing auto-expands, whatever the column count. ---
   {
-    const opts = { collapseDictionaries: true, autoExpandDictionaries: 3 };
-    assert.strictEqual(isOpen(opts, 'D0', 0), true, 'N=3: idx0 open');
-    assert.strictEqual(isOpen(opts, 'D1', 1), true, 'N=3: idx1 open');
-    assert.strictEqual(isOpen(opts, 'D2', 2), true, 'N=3: idx2 open');
-    assert.strictEqual(isOpen(opts, 'D3', 3), false, 'N=3: idx3 collapsed');
+    const opts = { collapseDictionaries: true, autoExpandRows: 0, dictColumns: 3 };
+    assert.strictEqual(isOpen(opts, 'D0', 0), false, 'rows=0: idx0 collapsed');
+    assert.strictEqual(isOpen(opts, 'D1', 1), false, 'rows=0: idx1 collapsed');
   }
 
-  // --- collapse ON, N=0: nothing auto-expands. ---
+  // --- missing window.autoExpandRows falls back to 1 row. ---
   {
-    const opts = { collapseDictionaries: true, autoExpandDictionaries: 0 };
-    assert.strictEqual(isOpen(opts, 'D0', 0), false, 'N=0: idx0 collapsed');
-    assert.strictEqual(isOpen(opts, 'D1', 1), false, 'N=0: idx1 collapsed');
+    const opts = { collapseDictionaries: true, autoExpandRows: undefined, dictColumns: 1 };
+    assert.strictEqual(isOpen(opts, 'D0', 0), true, 'fallback rows=1: idx0 open');
+    assert.strictEqual(isOpen(opts, 'D1', 1), false, 'fallback rows=1: idx1 collapsed');
   }
 
-  // --- missing window.autoExpandDictionaries falls back to 1 (only first). ---
+  // --- THE FIX: the expanded region follows the column count (rows × columns). ---
+  // 2 columns, 1 row -> the whole TOP ROW expands (2 blocks), not a lone block
+  // that would leave one column a tall card and the other a stack of collapsed
+  // bars. This is the case the old column-blind block count got wrong.
   {
-    const opts = { collapseDictionaries: true, autoExpandDictionaries: undefined };
-    assert.strictEqual(isOpen(opts, 'D0', 0), true, 'fallback N=1: idx0 open');
-    assert.strictEqual(isOpen(opts, 'D1', 1), false, 'fallback N=1: idx1 collapsed');
+    const opts = { collapseDictionaries: true, autoExpandRows: 1, dictColumns: 2 };
+    assert.strictEqual(isOpen(opts, 'D0', 0, 6), true, '2col rows=1: idx0 open');
+    assert.strictEqual(isOpen(opts, 'D1', 1, 6), true, '2col rows=1: idx1 open (same top row)');
+    assert.strictEqual(isOpen(opts, 'D2', 2, 6), false, '2col rows=1: idx2 collapsed');
+  }
+  // 2 columns, 2 rows -> first two rows (4 blocks) expand.
+  {
+    const opts = { collapseDictionaries: true, autoExpandRows: 2, dictColumns: 2 };
+    assert.strictEqual(isOpen(opts, 'D3', 3, 6), true, '2col rows=2: idx3 open');
+    assert.strictEqual(isOpen(opts, 'D4', 4, 6), false, '2col rows=2: idx4 collapsed');
+  }
+  // 3 columns, 1 row -> 3 blocks.
+  {
+    const opts = { collapseDictionaries: true, autoExpandRows: 1, dictColumns: 3 };
+    assert.strictEqual(isOpen(opts, 'D2', 2, 9), true, '3col rows=1: idx2 open');
+    assert.strictEqual(isOpen(opts, 'D3', 3, 9), false, '3col rows=1: idx3 collapsed');
+  }
+
+  // --- columns are capped by the entry's real block count, exactly like masonry
+  //     (layoutMasonry: cols = min(configured, items.length)). A 4-column setting
+  //     on a 2-dictionary entry must not pretend there are 4 cards to expand. ---
+  {
+    const opts = { collapseDictionaries: true, autoExpandRows: 1, dictColumns: 4 };
+    assert.strictEqual(isOpen(opts, 'D0', 0, 2), true, 'cap: idx0 open (2 cards -> 2 cols)');
+    assert.strictEqual(isOpen(opts, 'D1', 1, 2), true, 'cap: idx1 open (2 cards -> 2 cols)');
+    // Single-dictionary entry collapses to 1 column -> only the first expands.
+    assert.strictEqual(isOpen(opts, 'Solo', 0, 1), true, 'cap: solo idx0 open');
+    assert.strictEqual(isOpen(opts, 'Solo', 1, 1), false, 'cap: solo idx1 collapsed');
+  }
+
+  // --- the viewport convergence in effectiveDictColumns() also applies: a narrow
+  //     panel that only fits one 170px column must expand one block per row, even
+  //     with a 4-column setting (otherwise a narrow popup over-expands). ---
+  {
+    const opts = {
+      collapseDictionaries: true, autoExpandRows: 1, dictColumns: 4, innerWidth: 300,
+    };
+    assert.strictEqual(isOpen(opts, 'D0', 0, 8), true, 'narrow: idx0 open');
+    assert.strictEqual(isOpen(opts, 'D1', 1, 8), false, 'narrow: idx1 collapsed (1 fitted column)');
   }
 
   console.log('popup_auto_expand_dictionaries_test.js: all assertions passed');

--- a/hibiki/test/pages/popup_glossary_link_scope_test.js
+++ b/hibiki/test/pages/popup_glossary_link_scope_test.js
@@ -102,7 +102,7 @@ function makeSandbox() {
     hiddenDictionaryNames: [],
     collapsedDictionaryNames: [],
     collapseDictionaries: false,
-    autoExpandDictionaries: 1,
+    autoExpandRows: 1,
     flutter_inappwebview: { callHandler() { return Promise.resolve(false); } },
     getSelection() { return { toString() { return ""; } }; },
   };

--- a/hibiki/test/settings/settings_schema_coverage_test.dart
+++ b/hibiki/test/settings/settings_schema_coverage_test.dart
@@ -359,7 +359,7 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   'lookup/Collapse dictionaries': 'DEVICE: popup.js collapse',
   // TODO-845: 折叠词典时仍展开前 N 本。效果在 popup.js createGlossarySection 的
   // <details>.open（WebView 渲染，widget 测不到）；由 node 行为守卫真执行覆盖。
-  'lookup/Auto-expand dictionaries':
+  'lookup/Auto-expand rows':
       'test/pages/popup_auto_expand_dictionaries_test.js (popup.js node behaviour guard) + test/pages/popup_auto_expand_dictionaries_test.dart',
   'lookup/Show expression tags': 'DEVICE: popup.js expression tags',
   'lookup/Deduplicate pitch accents': 'DEVICE: popup.js pitch dedup',

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -2563,15 +2563,33 @@ window.hoshiPopupMineEntryByIndex = function(idx) {
     window.hoshiFocusDictionaryEntryReset = resetEntry;
 })();
 
+// 「自动展开」的单位是「行」，不是「本」：展开数 = window.autoExpandRows × 该词条有效列数。
+// 历史设计里它是绝对本数 N，与 --dict-columns 的 N 列 masonry 毫无关联，于是 N 不是列数的整数倍
+// 时顶部就参差——比如 1 本展开 + 2 列，展开卡独占第 0 列变很高，剩下的折叠条因第 1 列还是 0 高
+// 全堆到第 1 列，「一张大卡 vs 一摞折叠条」。改成按行计数后展开数天生跟随列数，顶部永远是整行。
+//
+// cols 与 masonry 的 `cols = Math.min(configured, items.length)`（layoutMasonry）严格同源：
+// 都用 dictColumns()（= 视口收敛后的 effectiveDictColumns()）再对该词条实际卡片数封顶，所以
+// 词典数 < 列数时不会凭空展开不存在的卡。默认列数 1 时 rows × 1 === 旧的绝对本数，老用户零改变。
+function autoExpandCount(totalDicts) {
+    const rows = window.autoExpandRows ?? 1;
+    if (!(rows > 0)) return 0;
+    const total = Number.isFinite(totalDicts) && totalDicts > 0 ? totalDicts : 1;
+    const cols = Math.max(1, Math.min(dictColumns(), total));
+    return rows * cols;
+}
+
 // TODO-845: `dictIdx` is the dictionary's global position within an entry's
-// glossary body (0-based). The popup auto-expands the leading
-// `window.autoExpandDictionaries` blocks even when collapseDictionaries is on
-// (default 1 = the historical "only the first dictionary expanded" behaviour,
-// where the leading block opened regardless of its per-dictionary collapse flag).
-function createGlossarySection(dictName, contents, dictIdx, entryIdx) {
+// glossary body (0-based); `totalDicts` is that entry's total block count, needed
+// to cap the effective column count the same way masonry does. The popup
+// auto-expands the leading `autoExpandCount(totalDicts)` blocks even when
+// collapseDictionaries is on (default 1 row = the historical "only the first
+// dictionary expanded" behaviour at the default single column, where the leading
+// block opened regardless of its per-dictionary collapse flag).
+function createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts) {
     const details = el('details', { className: 'glossary-group' });
     const perDictCollapsed = (window.collapsedDictionaryNames || []).includes(dictName);
-    const autoExpandN = window.autoExpandDictionaries ?? 1;
+    const autoExpandN = autoExpandCount(totalDicts);
     const autoExpanded = dictIdx < autoExpandN;
     if (autoExpanded || (!window.collapseDictionaries && !perDictCollapsed)) {
         details.open = true;
@@ -2779,7 +2797,7 @@ function buildEntryElement(entry, idx) {
     const { details, body, grouped, dictNames } = glossaryWrapper;
     entryDiv.appendChild(details);
     for (let dictIdx = 0; dictIdx < dictNames.length; dictIdx++) {
-        body.appendChild(createGlossarySection(dictNames[dictIdx], grouped[dictNames[dictIdx]], dictIdx, idx));
+        body.appendChild(createGlossarySection(dictNames[dictIdx], grouped[dictNames[dictIdx]], dictIdx, idx, dictNames.length));
     }
 
     return entryDiv;
@@ -3527,15 +3545,20 @@ window.updatePopupIncremental = function() {
                 // of visible `.glossary-group` children and bump it per appended
                 // block — same `dictIdx < autoExpandN` rule as the first-paint loop,
                 // never a bare `false` (which would forbid any incremental expand).
+                // totalDicts must be the entry's POST-append block count: the row-based
+                // threshold caps columns at the real card count, so counting only the
+                // already-rendered blocks would under-report columns and collapse cards
+                // that the finished layout does have room to expand.
                 let appendIndex =
                     body.querySelectorAll(':scope > .glossary-group').length;
-                for (const dictName of Object.keys(grouped)) {
-                    if (!existingDicts.has(dictName)) {
-                        const section = createGlossarySection(dictName, grouped[dictName], appendIndex, idx);
-                        appendIndex++;
-                        body.appendChild(section);
-                        postProcessRuby(section);
-                    }
+                const appendDictNames = Object.keys(grouped)
+                    .filter(dictName => !existingDicts.has(dictName));
+                const totalDicts = appendIndex + appendDictNames.length;
+                for (const dictName of appendDictNames) {
+                    const section = createGlossarySection(dictName, grouped[dictName], appendIndex, idx, totalDicts);
+                    appendIndex++;
+                    body.appendChild(section);
+                    postProcessRuby(section);
                 }
             }
         } else {


### PR DESCRIPTION
## 问题

用户反馈：「折叠词典显示 自动展开词典数」和「词典列数保持一致」这两件事**冲突**。

确实冲突，而且是设计层面的单位错配：

- **`自动展开词典数`**（`autoExpandDictionaries`，0..6）是**线性本数** —— `createGlossarySection` 用 `dictIdx < autoExpandN` 决定展开，只认词典在词条内的顺序，完全不知道有几列。
- **`词典列数`**（`--dict-columns`，1..4）是**网格单位** —— `layoutMasonry()` 按「最短列打包」（`heights[i] < heights[c]`）把卡片塞进 `cols = Math.min(configured, items.length)` 列。

两者之间没有任何契约。K（展开本数）不是 N（列数）的整数倍时顶部就参差：**1 本展开 + 2 列** → 卡片 0 展开成高卡独占第 0 列，剩下的折叠矮条因为第 1 列高度仍是 0，被「最短列」规则全堆过去 —— 一列一张大卡、另一列一摞折叠条。

## 修复

把「自动展开」的单位从**本数**重锚为**行数**，展开数由列数派生，冲突从数据结构上消失（而不是加特例补丁）：

```
展开数 = autoExpandRows × max(1, min(dictColumns(), 该词条卡片数))
```

- 新增 `autoExpandCount(totalDicts)`。列数取 `dictColumns()`（= 视口收敛后的 `effectiveDictColumns()`）并对该词条**实际卡片数**封顶，与 `layoutMasonry` 的 `cols = min(configured, items.length)` **严格同源** —— 词典数 < 列数时不会凭空展开不存在的卡。
- `createGlossarySection` 增加 `totalDicts` 形参：首屏渲染传 `dictNames.length`；增量（load-more）路径传 **post-append** 的 `appendIndex + appendDictNames.length`（只数已渲染的会低报列数、误折叠本该展开的卡）。
- 注入 `window.autoExpandDictionaries` → `window.autoExpandRows`；**popup.js 三镜像同步**（`hibiki/assets/popup/`、`hibiki/assets/browser_extension/vendor/`、`tools/browser-extension/vendor/`，已校验三份 byte-identical）。
- 文案改「自动展开行数」，17 语经 `tool/i18n_sync.dart` 同步 + `dart run slang` 重新生成。

## 向后兼容

偏好存储 key `popup_auto_expand_dictionaries` 与 `0..6` clamp **不变、值不迁移**。默认列数为 1，`行数 × 1 === 旧的绝对本数` —— 从未调过列数的老用户观感**零变化**。Dart 侧 getter/setter 名保持不动以缩小爆炸半径，单位语义写在 `preferences_repository.dart` 注释里。

## 测试

`hibiki/test/pages/popup_auto_expand_dictionaries_test.js`（Node 真执行 `createGlossarySection`）：

- 新契约：**2 列×1 行 = 顶行 2 张** / 2 列×2 行 = 4 张 / 3 列×1 行 = 3 张
- **列数被卡片数封顶**：4 列设置 + 2 本词典 → 2 列；单本词典 → 1 列
- **窄视口收敛**：`innerWidth=300` → 1 列（4 列设置也只展开 1 张）
- 回归：1 列向后兼容、`rows=0` 全折叠、缺省回落 1 行、collapse OFF 全开

`hibiki/test/pages/popup_auto_expand_dictionaries_test.dart` 源码守卫：`rows * cols`、`Math.min(dictColumns(), total)`、`rows > 0` 短路、两处调用点必须传 totalDicts、增量 totalDicts 必须是 post-append 计数。

## 验证

- `flutter analyze`：**No issues found**
- `flutter test` 全量：**12829 passed / 5 skipped / 1 failed**。唯一失败 `test/utils/misc/platform_updater_test.dart`（Windows 安装器文件存在性校验）**单独跑 51/51 全通过**，属并发全量下的既有 flake，与本改动无关。
- 设置覆盖登记随标题改名同步，`stillUnaccounted=0`。

## 待办

- ⏳ **Win 真机待验**：弹窗多列 × 多行组合的实际观感（顶行是否整齐、折叠条分布）。
- 未 bump `pubspec.yaml`（draft PR，非发布）。

BUG 记录：`docs/bugs/BUG-1041-popup-auto-expand-rows-vs-columns.md`

https://claude.ai/code/session_01DX38Efg1gEXcCALTDPq6Sm
