### PR TITLE
feat(game): 捕获工作台文本线程下拉加台词预览与有音频计数

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39389 (2317 per locale)
+/// Strings: 39406 (2318 per locale)
 ///
-/// Built on 2026-07-23 at 12:58 UTC
+/// Built on 2026-07-23 at 15:56 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3091,6 +3091,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get pdf_bookmarks => 'Bookmarks';
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   String get pdf_bookmark_added => 'Bookmark added';
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -8345,6 +8347,9 @@ class _StringsAr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -13672,6 +13677,9 @@ class _StringsDe extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -19015,6 +19023,9 @@ class _StringsEs extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -24369,6 +24380,9 @@ class _StringsFr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -29650,6 +29664,9 @@ class _StringsId extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -34979,6 +34996,9 @@ class _StringsIt extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -40113,6 +40133,9 @@ class _StringsJa extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -45250,6 +45273,9 @@ class _StringsKo extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -50557,6 +50583,9 @@ class _StringsNl extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -55879,6 +55908,9 @@ class _StringsPtBr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -61184,6 +61216,9 @@ class _StringsRu extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -66434,6 +66469,9 @@ class _StringsTh extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -71716,6 +71754,9 @@ class _StringsTr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -76985,6 +77026,9 @@ class _StringsVi extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 // Path: <root>
@@ -81883,6 +81927,9 @@ class _StringsZhCn extends _StringsEn {
   String get pdf_bookmarks_empty => '还没有书签。';
   @override
   String get pdf_bookmark_added => '已添加书签';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} 行有音频';
 }
 
 // Path: <root>
@@ -86935,6 +86982,9 @@ class _StringsZhHk extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String game_text_thread_audio_count({required Object count}) =>
+      '${count} with audio';
 }
 
 /// Flat map(s) containing all translations.
@@ -91665,6 +91715,8 @@ extension on _StringsEn {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -96393,6 +96445,8 @@ extension on _StringsAr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -101142,6 +101196,8 @@ extension on _StringsDe {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -105890,6 +105946,8 @@ extension on _StringsEs {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -110644,6 +110702,8 @@ extension on _StringsFr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -115380,6 +115440,8 @@ extension on _StringsId {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -120131,6 +120193,8 @@ extension on _StringsIt {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -124844,6 +124908,8 @@ extension on _StringsJa {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -129561,6 +129627,8 @@ extension on _StringsKo {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -134305,6 +134373,8 @@ extension on _StringsNl {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -139046,6 +139116,8 @@ extension on _StringsPtBr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -143792,6 +143864,8 @@ extension on _StringsRu {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -148522,6 +148596,8 @@ extension on _StringsTh {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -153261,6 +153337,8 @@ extension on _StringsTr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -157995,6 +158073,8 @@ extension on _StringsVi {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }
@@ -162693,6 +162773,8 @@ extension on _StringsZhCn {
         return '还没有书签。';
       case 'pdf_bookmark_added':
         return '已添加书签';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} 行有音频';
       default:
         return null;
     }
@@ -167401,6 +167483,8 @@ extension on _StringsZhHk {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_text_thread_audio_count':
+        return ({required Object count}) => '${count} with audio';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "此 PDF 没有目录。",
   "pdf_bookmarks": "书签",
   "pdf_bookmarks_empty": "还没有书签。",
-  "pdf_bookmark_added": "已添加书签"
+  "pdf_bookmark_added": "已添加书签",
+  "game_text_thread_audio_count": "$count 行有音频"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_text_thread_audio_count": "$count with audio"
 }

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -915,6 +915,23 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                         label: '${thread.label} · ${thread.lineCount}',
                       ),
                   ],
+                  // 每条线程第二行：有音频行数 + 最近台词预览——没有预览用户
+                  // 只能对着「引擎 · 地址 · 行数」盲选（用户实拍反馈）。
+                  entrySubtitle: (String key) {
+                    if (key.isEmpty) return null; // 「全部」行不带预览
+                    for (final TexthookerTextThread thread in textThreads) {
+                      if (thread.key == key) {
+                        return texthookerThreadSubtitle(
+                          audioLineCount: thread.audioLineCount,
+                          latestText: thread.latestText,
+                          audioLabel: t.game_text_thread_audio_count(
+                            count: thread.audioLineCount,
+                          ),
+                        );
+                      }
+                    }
+                    return null;
+                  },
                   onChanged: (String value) {
                     TexthookerTextThread? selectedThread;
                     if (value.isNotEmpty) {

--- a/hibiki/lib/src/sync/texthooker_service.dart
+++ b/hibiki/lib/src/sync/texthooker_service.dart
@@ -1,6 +1,32 @@
+import 'package:characters/characters.dart';
 import 'package:flutter/foundation.dart';
 
 enum TexthookerLineSource { websocket, engineHook, unknown }
+
+/// 线程选择下拉的副标题：`[N 行有音频 · ]最近台词预览`。两段都空返回 null
+/// （该行保持单行）。[audioLabel] 由调用方用 i18n 拼好传入（纯函数不碰 t）。
+String? texthookerThreadSubtitle({
+  required int audioLineCount,
+  required String? latestText,
+  required String audioLabel,
+}) {
+  final String preview =
+      latestText == null ? '' : collapseTexthookerPreview(latestText);
+  final List<String> parts = <String>[
+    if (audioLineCount > 0) audioLabel,
+    if (preview.isNotEmpty) preview,
+  ];
+  return parts.isEmpty ? null : parts.join(' · ');
+}
+
+/// 台词预览归一：连续空白（含换行）折成单空格、trim、按**字素簇**截断到
+/// [maxCharacters]（绝不劈开代理对/组合字），超长补省略号。纯函数。
+String collapseTexthookerPreview(String text, {int maxCharacters = 40}) {
+  final String collapsed = text.replaceAll(RegExp(r'\s+'), ' ').trim();
+  final Characters chars = collapsed.characters;
+  if (chars.length <= maxCharacters) return collapsed;
+  return '${chars.take(maxCharacters)}…';
+}
 
 enum TexthookerLineAudioStatus {
   unavailable,
@@ -29,6 +55,8 @@ class TexthookerTextThread {
     required this.latestAt,
     this.hookCode,
     this.nativeThreadId,
+    this.latestText,
+    this.audioLineCount = 0,
   });
 
   final String key;
@@ -37,6 +65,13 @@ class TexthookerTextThread {
   final int? nativeThreadId;
   final int lineCount;
   final DateTime latestAt;
+
+  /// 该线程最近一条台词原文（线程选择下拉的预览；尚无台词为 null）。
+  final String? latestText;
+
+  /// 该线程已配到句音的行数（[TexthookerLineEntry.hasAudio] 计数；语音线程
+  /// 通常≈lineCount，UI 线程为 0——选择下拉靠它区分「选哪个」）。
+  final int audioLineCount;
 }
 
 @immutable
@@ -187,6 +222,10 @@ class TexthookerService extends ChangeNotifier {
         nativeThreadId: entry.nativeTextThreadId ?? previous?.nativeThreadId,
         lineCount: (previous?.lineCount ?? 0) + 1,
         latestAt: entry.receivedAt,
+        // _entries 按接收顺序迭代，最后一次赋值即最新台词。
+        latestText: entry.text,
+        audioLineCount:
+            (previous?.audioLineCount ?? 0) + (entry.hasAudio ? 1 : 0),
       );
     }
     final List<TexthookerTextThread> result = byKey.values.toList()

--- a/hibiki/lib/src/utils/components/hibiki_dropdown.dart
+++ b/hibiki/lib/src/utils/components/hibiki_dropdown.dart
@@ -49,6 +49,7 @@ class GamepadMenuDropdown<T> extends StatefulWidget {
     this.label,
     this.hintText,
     this.focusId,
+    this.entrySubtitle,
   });
 
   final List<GamepadDropdownEntry<T>> entries;
@@ -63,6 +64,12 @@ class GamepadMenuDropdown<T> extends StatefulWidget {
   final String? label;
   final String? hintText;
   final HibikiFocusId? focusId;
+
+  /// Optional per-entry subtitle (a second, muted line under the label inside
+  /// the open menu — e.g. a latest-line preview for text threads). Returning
+  /// null/empty for a value keeps that row single-line. The closed trigger
+  /// still shows only the label.
+  final String? Function(T value)? entrySubtitle;
 
   @override
   State<GamepadMenuDropdown<T>> createState() => _GamepadMenuDropdownState<T>();
@@ -129,7 +136,11 @@ class _GamepadMenuDropdownState<T> extends State<GamepadMenuDropdown<T>> {
       hintText: widget.hintText,
       dropdownMenuEntries: <DropdownMenuEntry<T>>[
         for (final GamepadDropdownEntry<T> e in widget.entries)
-          DropdownMenuEntry<T>(value: e.value, label: e.label),
+          DropdownMenuEntry<T>(
+            value: e.value,
+            label: e.label,
+            labelWidget: _entryLabelWidget(context, e),
+          ),
       ],
       onSelected: widget.enabled
           ? (T? value) {
@@ -140,6 +151,29 @@ class _GamepadMenuDropdownState<T> extends State<GamepadMenuDropdown<T>> {
     return widget.width == null
         ? menu
         : SizedBox(width: widget.width, child: menu);
+  }
+
+  /// Two-line label for the stock [DropdownMenu] path when a subtitle exists;
+  /// null falls back to the plain `label` string rendering.
+  Widget? _entryLabelWidget(BuildContext context, GamepadDropdownEntry<T> e) {
+    final String? subtitle = widget.entrySubtitle?.call(e.value);
+    if (subtitle == null || subtitle.isEmpty) return null;
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(e.label, maxLines: 2, softWrap: true),
+        Text(
+          subtitle,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
   }
 
   Widget _buildMenuAnchor(BuildContext context) {
@@ -274,7 +308,7 @@ class _GamepadMenuDropdownState<T> extends State<GamepadMenuDropdown<T>> {
     final GamepadDropdownEntry<T> entry = widget.entries[i];
     final Color foreground =
         selected ? tokens.surfaces.primary : tokens.surfaces.onSurface;
-    final Widget text = Text(
+    final Widget title = Text(
       entry.label,
       maxLines: 2,
       softWrap: true,
@@ -283,6 +317,24 @@ class _GamepadMenuDropdownState<T> extends State<GamepadMenuDropdown<T>> {
         fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
       ),
     );
+    final String? subtitle = widget.entrySubtitle?.call(entry.value);
+    final Widget text = (subtitle == null || subtitle.isEmpty)
+        ? title
+        : Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              title,
+              Text(
+                subtitle,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: tokens.type.metadata.copyWith(
+                  color: tokens.surfaces.onVariant,
+                ),
+              ),
+            ],
+          );
     // Flex (Expanded) needs a bounded width; only the pinned-width menu hands
     // the item finite constraints. The unbounded fallback uses a min-size row
     // so a flex child can never assert against infinite width.

--- a/hibiki/test/sync/texthooker_line_state_test.dart
+++ b/hibiki/test/sync/texthooker_line_state_test.dart
@@ -1,6 +1,7 @@
 // gal-hook-ux-overhaul：捕获工作台行状态（已制卡 / 已收藏）与筛选 predicate 的纯逻辑测试。
 // 这些逻辑不依赖 i18n key，故与页面层新增 key 解耦，可独立编译运行。
 
+import 'package:characters/characters.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/sync/texthooker_service.dart';
 
@@ -161,6 +162,79 @@ void main() {
       expect(
           lineMatchesFilter(favorited, TexthookerLineFilter.favorited), isTrue);
       expect(lineMatchesFilter(plain, TexthookerLineFilter.favorited), isFalse);
+    });
+  });
+
+  group('textThreads 聚合预览（latestText / audioLineCount）', () {
+    test('latestText 取该线程最新一条，audioLineCount 只数 hasAudio 行', () {
+      final TexthookerService s = TexthookerService.instance;
+      s.appendLine(
+        '第一句',
+        textThreadKey: 'k1',
+        textThreadLabel: 'KiriKiriZ',
+        audioStatus: TexthookerLineAudioStatus.matched,
+      );
+      s.appendLine(
+        '第二句',
+        textThreadKey: 'k1',
+        textThreadLabel: 'KiriKiriZ',
+        audioStatus: TexthookerLineAudioStatus.missing,
+      );
+      s.appendLine(
+        'UI 文本',
+        textThreadKey: 'k2',
+        textThreadLabel: 'TextRender',
+      );
+      final Map<String, TexthookerTextThread> byKey =
+          <String, TexthookerTextThread>{
+        for (final TexthookerTextThread t in s.textThreads) t.key: t,
+      };
+      expect(byKey['k1']!.latestText, '第二句');
+      expect(byKey['k1']!.audioLineCount, 1, reason: 'missing 不算有音频');
+      expect(byKey['k1']!.lineCount, 2);
+      expect(byKey['k2']!.latestText, 'UI 文本');
+      expect(byKey['k2']!.audioLineCount, 0);
+    });
+  });
+
+  group('texthookerThreadSubtitle / collapseTexthookerPreview', () {
+    test('音频段仅在 audioLineCount>0 时出现，两段用 · 连接', () {
+      expect(
+        texthookerThreadSubtitle(
+          audioLineCount: 3,
+          latestText: '「こんにちは」',
+          audioLabel: '3 行有音频',
+        ),
+        '3 行有音频 · 「こんにちは」',
+      );
+      expect(
+        texthookerThreadSubtitle(
+          audioLineCount: 0,
+          latestText: '台词',
+          audioLabel: '0 行有音频',
+        ),
+        '台词',
+      );
+      expect(
+        texthookerThreadSubtitle(
+          audioLineCount: 0,
+          latestText: null,
+          audioLabel: '0 行有音频',
+        ),
+        isNull,
+      );
+    });
+
+    test('预览折叠空白并按字素簇截断', () {
+      expect(collapseTexthookerPreview('  多行\n台词\t文本  '), '多行 台词 文本');
+      final String long = 'あ' * 50;
+      final String out = collapseTexthookerPreview(long);
+      expect(out.characters.length, 41, reason: '40 字素 + 省略号');
+      expect(out.endsWith('…'), isTrue);
+      // 截断不劈开代理对（emoji 是双 code unit）。
+      final String emoji = '😀' * 45;
+      final String cut = collapseTexthookerPreview(emoji);
+      expect(cut.characters.take(40).every((String c) => c == '😀'), isTrue);
     });
   });
 }


### PR DESCRIPTION
## 内容

用户实拍：线程下拉只有「引擎 · 地址 · 行数」（KiriKiriZ · 0x80c450 · 35 …），不知道选哪个。

- `TexthookerTextThread` 聚合时新增 `latestText`（该线程最近一条台词）与 `audioLineCount`（`hasAudio` 行计数——语音线程≈全有音频，UI 线程为 0，一眼区分）
- `GamepadMenuDropdown` 新增可选 `entrySubtitle` 解析器：菜单每行标题下渲染一行弱化副标题；MenuAnchor（桌面手柄路径）与 stock DropdownMenu（Android，`labelWidget`）双路径都支持；现有调用点零改动
- 线程下拉副标题：`N 行有音频 · 最近台词预览`（空白折叠、按字素簇截断 40，不劈代理对）；「全部」行不带
- i18n 走 i18n_sync 加 `game_text_thread_audio_count`

## 验证
- `flutter analyze` 0 issues；全量 `flutter test` 通过（exit 0）
- 新增纯函数/聚合测试：latestText 取最新、audioLineCount 只计 hasAudio、subtitle 拼装、字素簇截断
- 待 Win 真机：下拉打开后每行预览可读性

https://claude.ai/code/session_01EeT6RsEchLWzR3Q2n63JVv