### PR TITLE
fix(game): 浮窗隐藏背景可点词 (BUG-1036) + 实时台词行内试听音频

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1002 条。点号进各自文件。
+> 共 1003 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1036](bugs/BUG-1036-hook-overlay-transparent-hittest.md) | ✅ | ✅ | 隐藏背景后Hook文本浮窗点不动文字 |
 | [BUG-1035](bugs/BUG-1035-glossary-first-ignores-selected-dict.md) | ✅ | ✅ | 长按选中词典对制卡无效：{glossary-first} 恒取第一本，Lapis 默认无字段消费 {selected-glossary} |
 | [BUG-1034](bugs/BUG-1034-subtitle-row-extent-clip.md) | ✅ | ✅ | 视频字幕列表当前行末行文字被裁掉一半 |
 | [BUG-1033](bugs/BUG-1033-popup-zoom-tooltip-misfire.md) | ✅ | ✅ | 嵌套查词弹出时 A- 的「缩小查词字号」tooltip 自动弹出遮挡正文 |

--- a/docs/bugs/BUG-1036-hook-overlay-transparent-hittest.md
+++ b/docs/bugs/BUG-1036-hook-overlay-transparent-hittest.md
@@ -1,0 +1,6 @@
+## BUG-1036 · 隐藏背景后Hook文本浮窗点不动文字
+- **报告**：2026-07-24（用户：galgame Hook 文本浮窗把背景透明度调到 0（隐藏背景）后，浮窗上的台词文字点不动、无法点词查词；把背景加回来才能点）
+- **真实性**：✅ 真 bug。根因 `hibiki/windows/runner/floating_lyric_window.cpp:757`（Render 的主体背景填充）：浮窗是 `UpdateLayeredWindow` 逐像素 alpha 的分层窗口（`floating_lyric_window.cpp:1069`），Windows 对这种窗口按**像素 alpha** 做命中测试——alpha=0 的像素鼠标事件直接穿透到下层窗口，`WM_NCHITTEST` 返回什么都无关。隐藏背景 = Dart 侧 `gal_hook_text_overlay_controller.dart` 的 `toggleTransparency` 把 `_opacity` 置 0 → `bgColor` alpha 0 → 主体圆角矩形整块以 alpha 0 填充 → 除字形本身的少量不透明像素外整窗穿透，文字区域基本点不中。同文件 text_only（剪贴板浮窗）模式早有正解先例：顶部工具条**常驻 ~2% alpha**（`kTextStripRestAlpha`，"near-invisible, still catchable"）保证透明窗口始终可抓。
+- **[x] ① 已修复** — `floating_lyric_window.cpp` Render()：hook 文本模式且**未开点击穿透**（`hook_text_mode_ && !pass_through_`）时，主体背景 alpha 钳到下限 `kHookTextMinCatchAlpha`（5/255 ≈ 2%，肉眼不可见但逐像素命中测试可命中）；开了穿透（用户明确要点穿到游戏）保持原样 alpha 0。`SetPassThrough` 本就 `RequestRender()`，切换后立即按新钳制重绘。提交 fix/hook-overlay-transparent-hittest 分支。
+- **[x] ② 已加自动化测试** — `hibiki/test/tools/hook_overlay_hittest_alpha_floor_guard_test.dart`（最强可落地层=源码扫描守卫：native C++ 无法在 Dart 测试里跑）：断言 Render 背景填充路径存在 `kHookTextMinCatchAlpha` 钳制、条件绑定 `hook_text_mode_ && !pass_through_`、且钳制值非 0。
+- **备注**：视觉影响：隐藏背景时浮窗区域有 2% 的近黑底（多数游戏画面上不可辨），换来整块文字区域可点词。真机验证路径：开浮窗 → 隐藏背景 → 点台词文字应弹查词。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39389 (2317 per locale)
+/// Strings: 39423 (2319 per locale)
 ///
-/// Built on 2026-07-23 at 12:58 UTC
+/// Built on 2026-07-23 at 16:27 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3091,6 +3091,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get pdf_bookmarks => 'Bookmarks';
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   String get pdf_bookmark_added => 'Bookmark added';
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -8345,6 +8347,10 @@ class _StringsAr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -13672,6 +13678,10 @@ class _StringsDe extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -19015,6 +19025,10 @@ class _StringsEs extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -24369,6 +24383,10 @@ class _StringsFr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -29650,6 +29668,10 @@ class _StringsId extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -34979,6 +35001,10 @@ class _StringsIt extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -40113,6 +40139,10 @@ class _StringsJa extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -45250,6 +45280,10 @@ class _StringsKo extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -50557,6 +50591,10 @@ class _StringsNl extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -55879,6 +55917,10 @@ class _StringsPtBr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -61184,6 +61226,10 @@ class _StringsRu extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -66434,6 +66480,10 @@ class _StringsTh extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -71716,6 +71766,10 @@ class _StringsTr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -76985,6 +77039,10 @@ class _StringsVi extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 // Path: <root>
@@ -81883,6 +81941,10 @@ class _StringsZhCn extends _StringsEn {
   String get pdf_bookmarks_empty => '还没有书签。';
   @override
   String get pdf_bookmark_added => '已添加书签';
+  @override
+  String get game_line_preview_tooltip => '播放这句音频';
+  @override
+  String get game_line_preview_failed => '这句还没有可播放的音频';
 }
 
 // Path: <root>
@@ -86935,6 +86997,10 @@ class _StringsZhHk extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get game_line_preview_tooltip => 'Play this line\'s audio';
+  @override
+  String get game_line_preview_failed => 'No playable audio for this line';
 }
 
 /// Flat map(s) containing all translations.
@@ -91665,6 +91731,10 @@ extension on _StringsEn {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -96393,6 +96463,10 @@ extension on _StringsAr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -101142,6 +101216,10 @@ extension on _StringsDe {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -105890,6 +105968,10 @@ extension on _StringsEs {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -110644,6 +110726,10 @@ extension on _StringsFr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -115380,6 +115466,10 @@ extension on _StringsId {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -120131,6 +120221,10 @@ extension on _StringsIt {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -124844,6 +124938,10 @@ extension on _StringsJa {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -129561,6 +129659,10 @@ extension on _StringsKo {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -134305,6 +134407,10 @@ extension on _StringsNl {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -139046,6 +139152,10 @@ extension on _StringsPtBr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -143792,6 +143902,10 @@ extension on _StringsRu {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -148522,6 +148636,10 @@ extension on _StringsTh {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -153261,6 +153379,10 @@ extension on _StringsTr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -157995,6 +158117,10 @@ extension on _StringsVi {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }
@@ -162693,6 +162819,10 @@ extension on _StringsZhCn {
         return '还没有书签。';
       case 'pdf_bookmark_added':
         return '已添加书签';
+      case 'game_line_preview_tooltip':
+        return '播放这句音频';
+      case 'game_line_preview_failed':
+        return '这句还没有可播放的音频';
       default:
         return null;
     }
@@ -167401,6 +167531,10 @@ extension on _StringsZhHk {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'game_line_preview_tooltip':
+        return 'Play this line\'s audio';
+      case 'game_line_preview_failed':
+        return 'No playable audio for this line';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "此 PDF 没有目录。",
   "pdf_bookmarks": "书签",
   "pdf_bookmarks_empty": "还没有书签。",
-  "pdf_bookmark_added": "已添加书签"
+  "pdf_bookmark_added": "已添加书签",
+  "game_line_preview_tooltip": "播放这句音频",
+  "game_line_preview_failed": "这句还没有可播放的音频"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2315,5 +2315,7 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "game_line_preview_tooltip": "Play this line's audio",
+  "game_line_preview_failed": "No playable audio for this line"
 }

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -845,6 +845,65 @@ class GalHookSessionController extends ChangeNotifier {
     }
   }
 
+  /// 测试缝：向行级 PCM 缓存注入一条冻结切片（[exportLineAudioPreview] 的 ② 路径
+  /// 依赖会话期缓存，单测无真实引擎会话）。
+  @visibleForTesting
+  void debugCacheLineVoice(String lineId, GalAudioSlice slice) {
+    _lineVoiceCache[lineId] = slice;
+  }
+
+  /// 试听指定台词行已配的音频（实时台词列表行内播放按钮）：
+  ///  ① `game_resource` 行 → 直接返回 dump 目录里的原始资源文件路径（OGG/WAV，
+  ///     播放器原生可解，**不走** ffmpeg 转码链；时长未知记 0，调用方按上限兜底复位）；
+  ///  ② 引擎 PCM / loopback 兜底行 → [_lineVoiceCache] 冻结切片拼 WAV 写临时目录。
+  /// 只读既有配对结果，不改行状态、不影响制卡链路；取不到返回 null 并记结构化事件。
+  Future<GalTrackPreview?> exportLineAudioPreview(String lineId) async {
+    final EngineHookGalAudioSource? engine = _engineSource;
+    final String? resourceId = _resourceIdForLine(lineId);
+    if (engine != null && resourceId != null) {
+      final String? path = engine.pairedVoiceFilePathForResourceId(resourceId);
+      if (path != null) {
+        return GalTrackPreview(filePath: path, durationMs: 0);
+      }
+    }
+    final GalAudioSlice? slice = _lineVoiceCache[lineId];
+    if (slice != null && !slice.isEmpty) {
+      try {
+        final Directory dir = Directory(
+          '${Directory.systemTemp.path}${Platform.pathSeparator}'
+          'hibiki_gal_track_preview',
+        );
+        await dir.create(recursive: true);
+        final File out = File(
+          '${dir.path}${Platform.pathSeparator}gal_line_preview_$lineId.wav',
+        );
+        await out.writeAsBytes(buildWavBytes(slice.pcm, slice.format),
+            flush: true);
+        return GalTrackPreview(
+          filePath: out.path,
+          durationMs: pcmDurationMs(slice.pcm.length, slice.format.byteRate),
+        );
+      } catch (error) {
+        _record(
+          GalHookEventSeverity.error,
+          'audio',
+          'audio.line_preview_failed',
+          'Line preview export failed',
+          details: <String, Object?>{'lineId': lineId, 'error': '$error'},
+        );
+        return null;
+      }
+    }
+    _record(
+      GalHookEventSeverity.warning,
+      'audio',
+      'audio.line_preview_unavailable',
+      'No playable audio for the selected line',
+      details: <String, Object?>{'lineId': lineId},
+    );
+    return null;
+  }
+
   void selectVoiceTrack(int sourcePtr) {
     final EngineHookGalAudioSource? engine = _engineSource;
     if (engine == null) {

--- a/hibiki/lib/src/mining/galgame_audio_source.dart
+++ b/hibiki/lib/src/mining/galgame_audio_source.dart
@@ -1004,6 +1004,14 @@ class EngineHookGalAudioSource implements GalAudioSource {
     return file.existsSync() ? file : null;
   }
 
+  /// 已配对语音资源文件（dump 目录里的 OGG/WAV 原件）的绝对路径。列表行试听直接
+  /// 播原文件（media_kit 原生可解），**不走** [grabPairedVoiceBytes] 的 ffmpeg
+  /// 转码链。文件不存在（已被 [pruneVoiceDump] 清理）返回 null。
+  String? pairedVoiceFilePathForResourceId(String resourceId) {
+    final File? file = _voiceFileForResourceId(resourceId);
+    return (file != null && file.existsSync()) ? file.path : null;
+  }
+
   Future<Uint8List?> grabPairedVoiceBytes(
     int textTsMs, {
     required String outputExtension,

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -23,6 +23,7 @@ import 'package:hibiki/src/pages/implementations/dictionary_popup_webview.dart'
     show MinePopupResult;
 import 'package:hibiki/src/sync/texthooker_service.dart';
 import 'package:hibiki/src/sync/texthooker_ws_client.dart';
+import 'package:hibiki/src/utils/misc/desktop_audio_playback.dart';
 import 'package:hibiki/src/utils/misc/swipe_dismiss_wrapper.dart';
 import 'package:hibiki/media.dart';
 import 'package:hibiki/utils.dart';
@@ -93,6 +94,50 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   /// 实时台词列表的筛选维度（全部 / 有音频 / 已制卡 / 已收藏）。与线程下拉正交叠加。
   TexthookerLineFilter _lineFilter = TexthookerLineFilter.all;
 
+  /// 正在行内试听的行 id；null = 未在试听（样式对齐诊断页逐轨试听）。
+  String? _previewingLineId;
+
+  /// 试听播完把按钮从「停止」复位回「播放」的定时器。资源原件时长未知（durationMs
+  /// 0）时按 [_kLinePreviewMaxMs] 上限兜底复位。
+  Timer? _linePreviewResetTimer;
+
+  /// 资源原件（OGG/WAV）时长未知时的复位上限：galgame 单句语音极少超过它。
+  static const int _kLinePreviewMaxMs = 15000;
+
+  /// 行内试听 / 停止：经 controller 取该行已配音频（game_resource 原件直接播，
+  /// PCM/loopback 冻结切片拼 WAV），只读不改行状态、不碰制卡链路。
+  Future<void> _toggleLinePreview(TexthookerLineEntry line) async {
+    if (_previewingLineId == line.id) {
+      _linePreviewResetTimer?.cancel();
+      setState(() => _previewingLineId = null);
+      await DesktopAudioPlayback.stop();
+      return;
+    }
+    final GalTrackPreview? preview =
+        await _session.exportLineAudioPreview(line.id);
+    if (!mounted) return;
+    if (preview == null) {
+      HibikiToast.show(msg: t.game_line_preview_failed);
+      return;
+    }
+    final bool started = await DesktopAudioPlayback.playFile(preview.filePath);
+    if (!mounted) return;
+    if (!started) {
+      HibikiToast.show(msg: t.game_line_preview_failed);
+      return;
+    }
+    _linePreviewResetTimer?.cancel();
+    setState(() => _previewingLineId = line.id);
+    final int resetMs =
+        preview.durationMs > 0 ? preview.durationMs + 300 : _kLinePreviewMaxMs;
+    _linePreviewResetTimer = Timer(
+      Duration(milliseconds: resetMs),
+      () {
+        if (mounted) setState(() => _previewingLineId = null);
+      },
+    );
+  }
+
   /// 分词结果缓存：行文本按 id 不可变，缓存 textToWords 避免每次 rebuild 重复分词
   /// （每来一行整页 setState）。行对象随音频/制卡/收藏态 copyWith 换新但 id/text 不变，
   /// 按 id 缓存恒安全。上限略高于行 buffer 上限，越界淘汰最旧插入项。
@@ -142,6 +187,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
 
   @override
   void dispose() {
+    _linePreviewResetTimer?.cancel();
     TexthookerService.instance.removeListener(_onLines);
     _session.removeListener(_onSessionChanged);
     final OverlayEntry? popupOverlay = _popupOverlayEntry;
@@ -990,9 +1036,12 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                         // 分词结果按行 id 缓存，避免每次 rebuild 重复 textToWords。
                         words: _wordCache.wordsFor(line.id, line.text),
                         selected: line.id == _activeLineId,
+                        previewingAudio: line.id == _previewingLineId,
                         onSelectLine: _selectLine,
                         onWordTap: _onWordTap,
                         onToggleFavorite: _toggleLineFavorite,
+                        onPreviewAudio: (TexthookerLineEntry l) =>
+                            unawaited(_toggleLinePreview(l)),
                       );
                     },
                   ),
@@ -1513,16 +1562,24 @@ class _TexthookerLine extends StatelessWidget {
     required this.line,
     required this.words,
     required this.selected,
+    required this.previewingAudio,
     required this.onSelectLine,
     required this.onWordTap,
     required this.onToggleFavorite,
+    required this.onPreviewAudio,
   });
 
   final TexthookerLineEntry line;
   final List<String> words;
   final bool selected;
+
+  /// 本行是否正被行内试听（播放按钮显示为停止）。
+  final bool previewingAudio;
   final ValueChanged<TexthookerLineEntry> onSelectLine;
   final ValueChanged<TexthookerLineEntry> onToggleFavorite;
+
+  /// 行内试听已配音频（仅 [TexthookerLineEntry.hasAudio] 行显示按钮）。
+  final ValueChanged<TexthookerLineEntry> onPreviewAudio;
   final void Function(
     TexthookerLineEntry line,
     String word,
@@ -1567,6 +1624,23 @@ class _TexthookerLine extends StatelessWidget {
                 ],
                 _LineAudioChip(status: line.audioStatus),
                 const SizedBox(width: 4),
+                // 行内试听已配音频（用户实拍：音频就绪却听不了）。仅 hasAudio 行显示；
+                // 试听中变停止钮。样式对齐收藏星。
+                if (line.hasAudio) ...<Widget>[
+                  HibikiIconButton(
+                    icon: previewingAudio
+                        ? Icons.stop_circle_outlined
+                        : Icons.play_circle_outline,
+                    tooltip: previewingAudio
+                        ? t.game_track_preview_stop
+                        : t.game_line_preview_tooltip,
+                    size: 18,
+                    enabledColor: previewingAudio ? colors.primary : null,
+                    focusId: HibikiFocusId('game-line-preview-${line.id}'),
+                    onTap: () => onPreviewAudio(line),
+                  ),
+                  const SizedBox(width: 4),
+                ],
                 // 会话内存态收藏星（不落 DB）；已收藏填充金黄星，未收藏描边星。
                 HibikiIconButton(
                   icon: line.favorited ? Icons.star : Icons.star_border,

--- a/hibiki/test/mining/gal_hook_session_controller_test.dart
+++ b/hibiki/test/mining/gal_hook_session_controller_test.dart
@@ -841,6 +841,70 @@ void _bug950Guard() {
       reason: 'BUG-950：推进 cursor 前必须复检 engine generation（await 跨重启防倒灌）',
     );
   });
+
+  group('exportLineAudioPreview（实时台词行内试听）', () {
+    test('PCM 缓存路径：冻结切片拼 WAV 落临时目录，时长>0，不改行状态', () async {
+      final TexthookerService service = TexthookerService.test();
+      final TexthookerLineEntry line = service.appendLine('試聴の台詞')!;
+      final ChangeNotifier endpoints = ChangeNotifier();
+      final GalHookSessionController controller = GalHookSessionController(
+        textService: service,
+        isWindows: false,
+        endpointListenable: endpoints,
+        endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+      );
+      controller.debugCacheLineVoice(
+        line.id,
+        GalAudioSlice(
+          pcm: Uint8List(44100), // 单声道 16bit 44.1kHz 下 0.5s
+          format: const PcmFormat(
+            sampleRate: 44100,
+            channels: 1,
+            bitsPerSample: 16,
+            isFloat: false,
+          ),
+        ),
+      );
+
+      final GalTrackPreview? preview =
+          await controller.exportLineAudioPreview(line.id);
+      expect(preview, isNotNull);
+      expect(File(preview!.filePath).existsSync(), isTrue);
+      expect(preview.durationMs, greaterThan(0));
+      // 只读试听：不得动行的音频状态（制卡链路语义不受影响）。
+      expect(
+        service.entryById(line.id)!.audioStatus,
+        TexthookerLineAudioStatus.unavailable,
+      );
+
+      try {
+        File(preview.filePath).deleteSync();
+      } catch (_) {}
+      await controller.close();
+      endpoints.dispose();
+    });
+
+    test('无任何已配音频：返回 null 并记结构化事件（不静默）', () async {
+      final TexthookerService service = TexthookerService.test();
+      final TexthookerLineEntry line = service.appendLine('音無しの台詞')!;
+      final ChangeNotifier endpoints = ChangeNotifier();
+      final GalHookSessionController controller = GalHookSessionController(
+        textService: service,
+        isWindows: false,
+        endpointListenable: endpoints,
+        endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+      );
+
+      expect(await controller.exportLineAudioPreview(line.id), isNull);
+      expect(
+        controller.events.map((GalHookEvent e) => e.code),
+        contains('audio.line_preview_unavailable'),
+      );
+
+      await controller.close();
+      endpoints.dispose();
+    });
+  });
 }
 
 class _FakeEngineSource extends EngineHookGalAudioSource {

--- a/hibiki/test/tools/hook_overlay_hittest_alpha_floor_guard_test.dart
+++ b/hibiki/test/tools/hook_overlay_hittest_alpha_floor_guard_test.dart
@@ -1,0 +1,49 @@
+// BUG-1036 源码守卫：Hook 文本浮窗隐藏背景后必须仍可点词。
+//
+// 浮窗是 UpdateLayeredWindow 逐像素 alpha 的分层窗口，Windows 对它按像素 alpha
+// 做命中测试——alpha 0 的像素点击直接穿透，WM_NCHITTEST 说什么都没用。修复是在
+// native Render() 里给 hook 文本模式（且未开点击穿透）的主体背景钳一个近不可见的
+// alpha 下限。native C++ 无法在 Dart 测试里执行，此守卫锁定源码接线不被退化：
+//   ① 下限常量存在且非 0；
+//   ② 主体背景填充路径存在按 hook_text_mode_ && !pass_through_ 的钳制分支；
+//   ③ 钳制结果（body_bg）真的被用于背景刷子，而不是钳完扔掉。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final String src =
+      File('windows/runner/floating_lyric_window.cpp').readAsStringSync();
+
+  test('① alpha 下限常量存在且非 0（BUG-1036）', () {
+    final RegExp constant =
+        RegExp(r'constexpr\s+uint32_t\s+kHookTextMinCatchAlpha\s*=\s*(\d+)');
+    final RegExpMatch? m = constant.firstMatch(src);
+    expect(m, isNotNull, reason: 'kHookTextMinCatchAlpha 常量不得被移除（隐藏背景时的可点击底线）');
+    expect(int.parse(m!.group(1)!), greaterThan(0),
+        reason: '下限为 0 等于没修：alpha 0 像素会被分层窗口命中测试穿透');
+  });
+
+  test('② 钳制分支绑定 hook_text_mode_ && !pass_through_', () {
+    expect(
+      src.contains('hook_text_mode_ && !pass_through_ &&'),
+      isTrue,
+      reason: '钳制必须只在「hook 文本模式且未开穿透」生效：'
+          '开穿透时保持真 alpha 0（点击本就该穿到游戏）',
+    );
+    expect(
+      src.contains(
+          'body_bg = (kHookTextMinCatchAlpha << 24) | (body_bg & 0x00FFFFFF);'),
+      isTrue,
+      reason: '主体背景 alpha 钳制表达式不得被移除',
+    );
+  });
+
+  test('③ 钳制结果真的用于背景填充刷子', () {
+    expect(
+      src.contains('CreateSolidColorBrush(ColorFromArgb(body_bg)'),
+      isTrue,
+      reason: '背景刷子必须用钳制后的 body_bg（而非原始 style_.bg_color）',
+    );
+  });
+}

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -61,6 +61,15 @@ constexpr float kTextGripTopDip = 9.0f;
 constexpr float kTextStripRestAlpha = 0.02f;   // near-invisible, still catchable
 constexpr float kTextStripHoverAlpha = 0.55f;  // visible toolbar band on hover
 
+// BUG-1036: hook-text overlay body alpha floor. UpdateLayeredWindow windows are
+// hit-tested per PIXEL — alpha-0 pixels pass clicks through to the window
+// below no matter what WM_NCHITTEST returns. With the background hidden
+// (opacity 0) the whole body painted at alpha 0 made the caption text
+// unclickable (only the thin glyph pixels ever hit). Clamp the body fill to a
+// near-invisible minimum while the window is interactive; an explicit
+// pass-through toggle keeps true alpha 0 (clicks are MEANT to fall through).
+constexpr uint32_t kHookTextMinCatchAlpha = 5;  // ~2%, invisible but hittable
+
 // ARGB (0xAARRGGBB) -> D2D1_COLOR_F (straight alpha).
 D2D1_COLOR_F ColorFromArgb(uint32_t argb) {
   const float a = ((argb >> 24) & 0xFF) / 255.0f;
@@ -753,8 +762,15 @@ void FloatingLyricWindow::Render() {
       D2D1::RectF(0, 0, static_cast<float>(width), static_cast<float>(height)),
       corner, corner);
 
+  // BUG-1036: keep the interactive hook-text body hit-testable when the user
+  // hides the background — floor the fill alpha (see kHookTextMinCatchAlpha).
+  uint32_t body_bg = style_.bg_color;
+  if (hook_text_mode_ && !pass_through_ &&
+      (body_bg >> 24) < kHookTextMinCatchAlpha) {
+    body_bg = (kHookTextMinCatchAlpha << 24) | (body_bg & 0x00FFFFFF);
+  }
   Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush;
-  render_target_->CreateSolidColorBrush(ColorFromArgb(style_.bg_color),
+  render_target_->CreateSolidColorBrush(ColorFromArgb(body_bg),
                                         brush.GetAddressOf());
   render_target_->FillRoundedRectangle(bg_rect, brush.Get());
 


### PR DESCRIPTION
## BUG-1036：隐藏背景后 Hook 文本浮窗点不动文字

用户实拍：浮窗背景透明度调 0 后台词点不动、无法点词，加回背景才能点。

**根因**（`hibiki/windows/runner/floating_lyric_window.cpp:757`）：浮窗是 `UpdateLayeredWindow` 逐像素 alpha 的分层窗口，Windows 对它按**像素 alpha** 命中测试——alpha 0 像素点击直接穿透（`WM_NCHITTEST` 返回什么都无关）。隐藏背景 = 主体圆角矩形整块 alpha 0 → 除字形本身外整窗穿透。

**修复**：Render() 在 `hook_text_mode_ && !pass_through_` 时给主体背景 alpha 钳下限 `kHookTextMinCatchAlpha = 5`（~2%，肉眼不可见但可命中；同文件 text_only 剪贴板浮窗 `kTextStripRestAlpha = 0.02` 先例）。用户显式开「点击穿透」时保持真 alpha 0（点击本就该穿到游戏）。`SetPassThrough` 已有 `RequestRender()`，切换即按新钳制重绘。

**测试**：native C++ 无法在 Dart 测试跑，按最强可落地层加源码扫描守卫 `test/tools/hook_overlay_hittest_alpha_floor_guard_test.dart`（常量非 0 / 条件绑定 / 钳制结果真用于刷子）。

## 实时台词行内试听（用户实拍：音频就绪却听不了）

- `hasAudio` 行行头加播放/停止按钮（样式对齐收藏星，手柄焦点站点注册）
- controller 新增 `exportLineAudioPreview(lineId)`：
  - `game_resource` 行 → 直接播 dump 目录原件（OGG/WAV media_kit 原生可解，**不走 ffmpeg 转码链**，desktop 无 HIBIKI_FFMPEG 也能听）；时长未知按 15s 上限兜底复位按钮
  - 引擎 PCM / loopback 兜底行 → 会话缓存冻结切片拼 WAV 写临时目录
  - 只读既有配对结果，不改行状态、不碰制卡链路；取不到 toast + 结构化事件
- 行为测试：PCM 路径出 WAV 且不动行状态；无音频路径 null + 事件

## 验证
- `flutter analyze` 0 issues；`flutter build windows --debug` 通过（native 改动编译验证）
- 定向测试 33 过；全量套件一轮中 audiobook 三文件偶发 "did not complete"（并行 shard 挂起，孤立重跑全过、模块与本分支无关、前两轮全量同环境绿）
- 待 Win 真机：浮窗隐藏背景点词、行内试听两条路径

https://claude.ai/code/session_01EeT6RsEchLWzR3Q2n63JVv