### PR TITLE
feat(sync): 书架/视频/词典下拉刷新改为手动同步（互联 + 云备份）

### DIFF
--- a/hibiki/lib/src/pages/implementations/home_dictionary_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dictionary_page.dart
@@ -16,6 +16,8 @@ import 'package:hibiki/src/lookup/desktop_lookup_router.dart';
 import 'package:hibiki/src/lookup/global_lookup_controller.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/sync/desktop_lookup_service.dart';
+import 'package:hibiki/src/sync/manual_sync_ui.dart';
+import 'package:hibiki/src/sync/sync_progress_banner.dart';
 import 'package:hibiki/src/utils/misc/swipe_dismiss_wrapper.dart';
 import 'package:hibiki/src/utils/components/clipboard_lookup_text_panel.dart';
 import 'package:hibiki/utils.dart';
@@ -337,6 +339,30 @@ class _HomeDictionaryPageState<T extends BaseTabPage> extends BaseTabPageState
     _clearSearch();
   }
 
+  /// 词典页下拉 = **手动同步**（云备份 + 互联两条通道）。
+  ///
+  /// 与书架 / 视频页不同，词典页没有「远端词典列表」这种视图——词典资源是被**同步进
+  /// 来的**（同步流程的 dictionaries 阶段，互联通道走 listRemoteDictionaries）。所以这里
+  /// 下拉只有同步一件事，跑完 setState 重读 `appModel.dictionaries` /
+  /// `dictionaryHistory`（本页不走 Riverpod，数据直读 AppModel），让同步落地的新词典
+  /// 和新查词历史立刻显示。
+  ///
+  /// 只挂在历史列表 / 空态上，**不挂查询结果屏**：那一屏的下拉早已被「清空查询」占用
+  /// （[_clearSearchFromResultPull]，手势的真实来源是结果 WebView 内的 JS），再叠一层
+  /// 刷新就是两个手势抢同一个下拉。
+  Future<void> _pullToRefreshDictionary() async {
+    await runManualSyncWithFeedback(
+      context: context,
+      appModel: appModel,
+      // 绝大多数用户没配云同步，每次下拉都弹「同步不可用」是纯噪音；已有同步在飞时
+      // 用户下拉，数据照样会更新，不必打断。冲突/错误提示仍然照给。
+      announceNotConfigured: false,
+      announceBusy: false,
+    );
+    if (!mounted) return;
+    setState(() {});
+  }
+
   // ── build ──────────────────────────────────────────────────────────
 
   @override
@@ -361,6 +387,8 @@ class _HomeDictionaryPageState<T extends BaseTabPage> extends BaseTabPageState
             children: [
               if (!isCupertinoPlatform(context)) _buildPageHeader(),
               _buildSearchHeader(),
+              // 下拉同步可能跑几十秒，光一个转圈看不出进展；没同步在飞时零高度。
+              const SyncProgressBanner(),
               Expanded(child: _buildBody()),
             ],
           ),
@@ -441,12 +469,16 @@ class _HomeDictionaryPageState<T extends BaseTabPage> extends BaseTabPageState
 
   Widget _buildBody() {
     if (_hasActiveQuery) {
+      // 查询结果屏不包 RefreshIndicator：那儿的下拉是「清空查询」
+      // （[_clearSearchFromResultPull]），两个手势不能抢同一个下拉。
       return _buildQueryBody();
     }
-    if (appModel.dictionaryHistory.isEmpty) {
-      return _buildPlaceholder();
-    }
-    return _buildDictionaryHistory();
+    return RefreshIndicator(
+      onRefresh: _pullToRefreshDictionary,
+      child: appModel.dictionaryHistory.isEmpty
+          ? _buildPlaceholder()
+          : _buildDictionaryHistory(),
+    );
   }
 
   Widget _buildQueryBody() {
@@ -467,25 +499,36 @@ class _HomeDictionaryPageState<T extends BaseTabPage> extends BaseTabPageState
   Widget _buildPlaceholder() {
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     final noDictionaries = appModel.dictionaries.isEmpty;
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          HibikiPlaceholderMessage(
-            icon: mediaType.outlinedIcon,
-            message: noDictionaries
-                ? t.dictionaries_menu_empty
-                : t.info_empty_home_tab,
+    final Widget content = Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        HibikiPlaceholderMessage(
+          icon: mediaType.outlinedIcon,
+          message: noDictionaries
+              ? t.dictionaries_menu_empty
+              : t.info_empty_home_tab,
+        ),
+        if (noDictionaries) ...[
+          SizedBox(height: tokens.spacing.gap + tokens.spacing.gap / 2),
+          FilledButton.icon(
+            icon: const Icon(Icons.auto_stories_outlined, size: 18),
+            label: Text(t.dialog_import_dictionary),
+            onPressed: appModel.showDictionaryMenu,
           ),
-          if (noDictionaries) ...[
-            SizedBox(height: tokens.spacing.gap + tokens.spacing.gap / 2),
-            FilledButton.icon(
-              icon: const Icon(Icons.auto_stories_outlined, size: 18),
-              label: Text(t.dialog_import_dictionary),
-              onPressed: appModel.showDictionaryMenu,
-            ),
-          ],
         ],
+      ],
+    );
+    // 空态也要能下拉同步——RefreshIndicator 需要一个真实 Scrollable 后代，裸 Center
+    // 没有滚动就吃不到下拉手势。撑到 minHeight = 视口高度既保住原来的垂直居中，又让
+    // AlwaysScrollableScrollPhysics 在内容不满一屏时仍然响应下拉。
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) =>
+          SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(minHeight: constraints.maxHeight),
+          child: Center(child: content),
+        ),
       ),
     );
   }
@@ -503,6 +546,8 @@ class _HomeDictionaryPageState<T extends BaseTabPage> extends BaseTabPageState
         top: tokens.spacing.gap / 2,
         bottom: tokens.spacing.page,
       ),
+      // 历史只有一两条、撑不满一屏时，默认 physics 不可滚 → 下拉同步吃不到手势。
+      physics: const AlwaysScrollableScrollPhysics(),
       controller: DictionaryMediaType.instance.scrollController,
       itemCount: historyResults.length,
       itemBuilder: (context, index) {

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -48,12 +48,14 @@ import 'package:hibiki/src/sync/deletion_prompt.dart';
 import 'package:hibiki/src/sync/deletion_propagation.dart';
 import 'package:hibiki/src/sync/hibiki_client_sync_backend.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/manual_sync_ui.dart';
 import 'package:hibiki/src/sync/remote_download_progress_badge.dart';
 import 'package:hibiki/src/sync/interconnect_download_manager.dart';
 import 'package:hibiki/src/sync/cloud_remote_video_client.dart';
 import 'package:hibiki/src/sync/remote_cover_image.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/sync_progress_banner.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/src/sync/video_manifest.dart';
 import 'package:hibiki/utils.dart';
@@ -255,14 +257,28 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     _maybeBackfillCovers();
   }
 
-  /// 下拉刷新：强制重拉远端视频列表 + 本地列表，await 远端 future 完成后指示器才收起。
+  /// 下拉刷新 = **手动同步**：先跑一遍云备份 / 互联同步，再强制重拉远端视频列表 + 本地
+  /// 列表，await 全程完成后指示器才收起。
   ///
   /// 顶层 tab 保活（[HomePage] 的 `_keepAliveTabs`）后，切回视频 tab 不再隐式重拉远端，
   /// 故给用户一个**显式**强制刷新入口——别的设备新上传的互联视频，不重启 app 也能刷出来。
+  ///
+  /// 同步排在重读列表**之前**：同步会往本地库里落新视频和观看进度，先刷列表就会漏掉
+  /// 本次同步的产物。没配同步后端时 [runManualSyncWithFeedback] 直接返回 notConfigured
+  /// 且不弹提示，退化成纯列表刷新——与加同步之前的行为一字不差。
   /// [_loadRemoteVideos] 内部吞异常返回 `failed:true`，await 不会抛，指示器必定收起
   /// （客户端 [listRemoteVideos] 已用 listTimeout 封顶，host 卡响应也不会无限转圈）。
   /// 显式刷新失败时给一个可见 SnackBar（带原因），避免「看不到远端视频却不知为何」。
   Future<void> _pullToRefresh() async {
+    await runManualSyncWithFeedback(
+      context: context,
+      appModel: ref.read(appProvider),
+      // 绝大多数用户没配云同步，每次下拉都弹「同步不可用」是纯噪音；已有同步在飞时
+      // 用户下拉，数据照样会更新，不必打断。冲突/错误提示仍然照给。
+      announceNotConfigured: false,
+      announceBusy: false,
+    );
+    if (!mounted) return;
     final Future<_RemoteVideoState?> remote = _loadRemoteVideos();
     if (mounted) {
       setState(() {
@@ -1679,6 +1695,8 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
               children: <Widget>[
                 if (!isCupertinoPlatform(context)) _buildPageHeader(canImport),
                 _buildTagFilterBar(allTags),
+                // 下拉同步可能跑几十秒，光一个转圈看不出进展；没同步在飞时零高度。
+                const SyncProgressBanner(),
                 Expanded(
                   child: _buildVideoLibraryBody(),
                 ),

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -50,11 +50,13 @@ import 'package:hibiki/src/sync/cloud_remote_book_client.dart';
 import 'package:hibiki/src/sync/deletion_propagation.dart';
 import 'package:hibiki/src/sync/hibiki_client_sync_backend.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/manual_sync_ui.dart';
 import 'package:hibiki/src/sync/remote_download_progress_badge.dart';
 import 'package:hibiki/src/sync/remote_cover_image.dart';
 import 'package:hibiki/src/sync/remote_book_client.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_asset_package_service.dart';
+import 'package:hibiki/src/sync/sync_progress_banner.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/src/sync/ttu_filename.dart';
 import 'package:hibiki/utils.dart';
@@ -392,6 +394,8 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
               children: [
                 if (!isCupertinoPlatform(context)) _buildPageHeader(),
                 _buildTagBar(allTags.valueOrNull ?? const []),
+                // 下拉同步可能跑几十秒，光一个转圈看不出进展；没同步在飞时零高度。
+                const SyncProgressBanner(),
                 Expanded(
                   child: books.when(
                     data: (bookList) {

--- a/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
@@ -75,13 +75,27 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
     });
   }
 
-  /// 下拉刷新：强制重拉远端书列表（并失效本地书 / 有声书列表 provider 一并重读），
-  /// await 远端 future 完成后指示器才收起。
+  /// 下拉刷新 = **手动同步**：先跑一遍云备份 / 互联同步，再强制重拉远端书列表（并失效
+  /// 本地书 / 有声书列表 provider 一并重读），await 全程完成后指示器才收起。
   ///
   /// 顶层 tab 保活（[HomePage] 的 `_keepAliveTabs`）后，切回书架不再隐式重拉远端，
   /// 故给用户一个**显式**强制刷新入口——对端设备 / 云盘新增的书，不重启 app 也能刷出来。
+  ///
+  /// 同步必须排在重读列表**之前**：同步会往本地库里落新书和新进度，先刷列表就会漏掉
+  /// 本次同步的产物，用户得再下拉一次才看得见。没配同步后端时
+  /// [runManualSyncWithFeedback] 直接返回 notConfigured（且不弹提示），退化成纯列表
+  /// 刷新——与加同步之前的行为一字不差。
   /// [_loadRemoteBooks] 内部吞异常返回 failed 态，await 不会抛，指示器必定收起。
   Future<void> _pullToRefreshBooks() async {
+    await runManualSyncWithFeedback(
+      context: context,
+      appModel: appModel,
+      // 绝大多数用户没配云同步，每次下拉都弹「同步不可用」是纯噪音；已有同步在飞时
+      // 用户下拉，数据照样会更新，不必打断。冲突/错误提示仍然照给。
+      announceNotConfigured: false,
+      announceBusy: false,
+    );
+    if (!mounted) return;
     ref.invalidate(hibikiBooksProvider);
     ref.invalidate(srtBooksProvider);
     _batchAudiobookInfoFuture = null;

--- a/hibiki/lib/src/sync/manual_sync_ui.dart
+++ b/hibiki/lib/src/sync/manual_sync_ui.dart
@@ -1,0 +1,162 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/sync/sync_auto_trigger.dart';
+import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/sync_conflict_prompter.dart';
+import 'package:hibiki/src/sync/sync_error_messages.dart';
+import 'package:hibiki/src/sync/sync_message_dialog.dart';
+import 'package:hibiki/src/sync/sync_orchestrator.dart';
+import 'package:hibiki/src/sync/sync_progress.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki/utils.dart';
+
+/// 手动同步完成后的 SnackBar 摘要（消费 [SyncRunReport]）。纯函数，便于单测边界：
+/// 全 0 → "无新增"；多类型 → ` · ` 拼接；有失败 → 追加失败计数后缀。
+@visibleForTesting
+String summarizeSyncReport(SyncRunReport r) {
+  final List<String> parts = <String>[
+    if (r.booksImported > 0) t.sync_now_books_in(count: r.booksImported),
+    if (r.dictionariesImported > 0)
+      t.sync_now_dicts_in(count: r.dictionariesImported),
+    if (r.dictionariesExported > 0)
+      t.sync_now_dicts_out(count: r.dictionariesExported),
+    if (r.audiobooksImported > 0)
+      t.sync_now_audio_in(count: r.audiobooksImported),
+    if (r.audiobooksExported > 0)
+      t.sync_now_audio_out(count: r.audiobooksExported),
+    if (r.localAudioImported > 0)
+      t.sync_now_local_audio_in(count: r.localAudioImported),
+    if (r.localAudioExported > 0)
+      t.sync_now_local_audio_out(count: r.localAudioExported),
+  ];
+  final String head = parts.isEmpty ? t.sync_now_no_changes : parts.join(' · ');
+  final String done = t.sync_now_done(detail: head);
+  return r.errors.isEmpty
+      ? done
+      : '$done${t.sync_now_failed_suffix(count: r.errors.length)}';
+}
+
+/// 本地化的同步阶段名（进度行用）。
+String syncPhaseLabel(SyncPhase phase) {
+  switch (phase) {
+    case SyncPhase.books:
+      return t.sync_progress_books;
+    case SyncPhase.readingData:
+      return t.sync_progress_reading;
+    case SyncPhase.dictionaries:
+      return t.sync_progress_dictionaries;
+    case SyncPhase.localAudio:
+      return t.sync_progress_local_audio;
+    case SyncPhase.audiobooks:
+      return t.sync_progress_audiobooks;
+    case SyncPhase.videos:
+      return t.sync_progress_videos;
+  }
+}
+
+/// "阶段 (k/N) 标题" —— 阶段没有条目总数时省略计数。
+String syncProgressLine(SyncProgress p) {
+  final String phase = syncPhaseLabel(p.phase);
+  if (p.itemTotal <= 0) return phase;
+  final String head = '$phase (${p.itemIndex + 1}/${p.itemTotal})';
+  final String? title = p.title;
+  return (title == null || title.isEmpty) ? head : '$head $title';
+}
+
+/// 手动同步在 UI 层的**单一入口**：跑 [runManualFullSync]，再统一处理三种 outcome
+/// 的提示、逐通道冲突解决、鉴权失效登出。
+///
+/// 设置页的「立即同步」行和各媒体页的下拉刷新共用这一条路径 —— 否则「跑同步 +
+/// 反馈」那套（冲突必须按**各自通道的后端**呈现、[SyncAuthError] 必须登出以让登录
+/// 按钮回来）会被复制成 N 份，任何一份漏掉一步就是静默写错端或卡在无效会话。
+///
+/// [announceNotConfigured] / [announceBusy] / [announceCompleted] 控制三种结果是否
+/// 弹 SnackBar。下拉刷新把前两者关掉：绝大多数用户没配云同步，每次下拉都弹「同步
+/// 不可用」纯属噪音；已有同步在跑时用户下拉，结果与他期望的一致（数据照样会更
+/// 新），不需要打断。冲突提示和错误提示**永远**给 —— 那是不能吞的东西。
+///
+/// 返回实际发生的 outcome，调用方可据此决定后续（下拉刷新据此不重复刷列表）。
+/// 全程不抛：错误都转成用户可读的 SnackBar。
+Future<ManualSyncOutcome> runManualSyncWithFeedback({
+  required BuildContext context,
+  required AppModel appModel,
+  bool announceNotConfigured = true,
+  bool announceBusy = true,
+  bool announceCompleted = true,
+}) async {
+  // 重入 / 已在飞 guard：设置页整行是焦点目标（Activate 也会触发），且后台/开机
+  // 自动同步可能已经持有 sweep 锁。两种情况下第二次触发都是 no-op —— 全局
+  // [syncInProgress] 已经在驱动进度条（BUG-101），这里没别的事可做。
+  if (syncInProgress.value) {
+    if (announceBusy) showSyncMessage(context, t.sync_now_busy);
+    return ManualSyncOutcome.busy;
+  }
+  try {
+    final ManualSyncResult result = await runManualFullSync(
+      db: appModel.database,
+      dictionaryResourceRoot: appModel.dictionaryResourceDirectory,
+      audioDatabaseRoot: Directory('${appModel.appDirectory.path}/audiobooks'),
+      tempDir: appModel.temporaryDirectory,
+      localAudioEntries: appModel.localAudioDbs,
+      onLocalAudioImported: appModel.importSyncedLocalAudioDb,
+      onPostRun: appModel.refreshAfterSyncRun,
+    );
+    if (!context.mounted) return result.outcome;
+    switch (result.outcome) {
+      case ManualSyncOutcome.notConfigured:
+        if (announceNotConfigured) {
+          showSyncMessage(context, t.sync_compare_unavailable);
+        }
+      case ManualSyncOutcome.busy:
+        if (announceBusy) showSyncMessage(context, t.sync_now_busy);
+      case ManualSyncOutcome.completed:
+        final SyncRunReport report = result.report!;
+        if (announceCompleted) {
+          showSyncMessage(context, summarizeSyncReport(report));
+        }
+        // 手动同步是用户的显式动作：立刻解冲突，不受 in-book/snooze 约束
+        // （ConflictSource.manual）。option B 双通道：逐通道用**各自的**后端呈现
+        // 该通道的冲突 —— 合并报告的冲突可能来自互联通道，用云后端去 apply 会
+        // 写错端。
+        for (final ManualSyncChannelReport channel in result.channelReports) {
+          if (channel.report.conflicts.isEmpty) continue;
+          if (!context.mounted) return result.outcome;
+          await appModel.syncConflictPrompter.present(
+            navigatorKey: appModel.navigatorKey,
+            db: appModel.database,
+            backend: channel.backend,
+            conflicts: channel.report.conflicts,
+            source: ConflictSource.manual,
+            inBook: appModel.isMediaOpen,
+          );
+        }
+    }
+    return result.outcome;
+  } on SyncAuthError catch (e) {
+    // TODO-836: insufficient_scope（或任何鉴权错误）—— 存下来的会话已经不可用了。
+    // 先登出，让账号行退回「未登录」（登录按钮重新出现），再提示重新登录。登出
+    // 序列与 account.part.dart 里的手动登出路径一致。
+    final SyncRepository repo = SyncRepository(appModel.database);
+    try {
+      final SyncBackend backend =
+          resolveSyncBackend(await repo.getBackendType());
+      await backend.signOut(repo: repo);
+      backend.clearCache();
+      await repo.clearFolderCache();
+    } catch (_) {
+      // 尽力登出；绝不因此盖掉原本要给用户的重新登录提示。
+    }
+    if (context.mounted) showSyncMessage(context, friendlySyncError(e));
+    return ManualSyncOutcome.notConfigured;
+  } catch (e) {
+    if (context.mounted) {
+      showSyncMessage(
+          context, t.sync_error(message: friendlySyncErrorDetail(e)));
+    }
+    return ManualSyncOutcome.notConfigured;
+  }
+  // 没有本地收尾：进度条由全局 [syncInProgress] / [syncProgress] 驱动，各同步入口
+  // 在自己的 finally 里复位。
+}

--- a/hibiki/lib/src/sync/sync_progress_banner.dart
+++ b/hibiki/lib/src/sync/sync_progress_banner.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:hibiki/src/sync/manual_sync_ui.dart';
+import 'package:hibiki/src/sync/sync_auto_trigger.dart';
+import 'package:hibiki/src/sync/sync_progress.dart';
+
+/// 同步进行中的细进度条 —— 挂在媒体页列表上方。
+///
+/// 下拉同步一次全量可能要几十秒，光靠 RefreshIndicator 那个圈用户看不出在干什么、
+/// 卡在哪一步。这条 banner 直接消费全局 [syncInProgress] / [syncProgress]，因此它
+/// 对**任何**在飞的同步都亮（含后台/开机自动同步），不只是本页下拉触发的那次 ——
+/// 页面本地 flag 做不到这点（BUG-101 同款教训）。
+///
+/// 没有同步在跑时收成零高度（[SizedBox.shrink]），不占布局、不改现有几何。
+class SyncProgressBanner extends StatelessWidget {
+  const SyncProgressBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: syncInProgress,
+      builder: (BuildContext context, bool syncing, _) {
+        if (!syncing) return const SizedBox.shrink();
+        return ValueListenableBuilder<SyncProgress?>(
+          valueListenable: syncProgress,
+          builder: (BuildContext context, SyncProgress? p, __) {
+            final ThemeData theme = Theme.of(context);
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                if (p != null)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+                    child: Text(
+                      syncProgressLine(p),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                // 阶段没有可测总数时退化成不确定进度条（value 为 null）。
+                LinearProgressIndicator(value: p?.fraction, minHeight: 2),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/hibiki/lib/src/sync/sync_settings_schema.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema.dart
@@ -28,6 +28,7 @@ import 'package:hibiki/src/sync/onedrive_sync_backend.dart';
 import 'package:hibiki/src/sync/hibiki_server_controller.dart';
 import 'package:hibiki/src/sync/hibiki_sync_server.dart';
 import 'package:hibiki/src/sync/lan_discovery_service.dart';
+import 'package:hibiki/src/sync/manual_sync_ui.dart';
 import 'package:hibiki/src/sync/pairing/hibiki_pair_v2_client.dart';
 import 'package:hibiki/src/sync/pairing/hibiki_ping_client.dart';
 import 'package:hibiki/src/sync/pairing/discovered_pairing_probe.dart';
@@ -36,9 +37,7 @@ import 'package:hibiki/src/sync/tls/hibiki_tofu_probe.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_auto_trigger.dart';
 import 'package:hibiki/src/sync/sync_compare_dialog.dart';
-import 'package:hibiki/src/sync/sync_conflict_prompter.dart';
 import 'package:hibiki/src/sync/sync_error_messages.dart';
-import 'package:hibiki/src/sync/sync_orchestrator.dart';
 import 'package:hibiki/src/sync/sync_progress.dart';
 import 'package:hibiki/src/sync/sync_message_dialog.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
@@ -54,6 +53,10 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:hibiki/src/utils/misc/hibiki_share.dart';
+
+/// [summarizeSyncReport] 的实现搬去了 manual_sync_ui.dart（媒体页下拉同步共用），
+/// 这里再导出一次以保持既有导入点（test/sync/sync_summary_test.dart）不变。
+export 'package:hibiki/src/sync/manual_sync_ui.dart' show summarizeSyncReport;
 
 part 'sync_settings_schema/account.part.dart';
 part 'sync_settings_schema/backend_config.part.dart';

--- a/hibiki/lib/src/sync/sync_settings_schema/actions.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/actions.part.dart
@@ -1,34 +1,13 @@
 // GENERATED-NOTE: extracted from sync_settings_schema.dart (TODO-585).
 part of '../sync_settings_schema.dart';
 
-// Manual sync action row (sync-now) + sync-report summary.
+// Manual sync action row (sync-now).
 // Shares the parent library's imports + private scope (_syncSettings / _showSnackBar / _SyncSettingsState); moved verbatim.
-
-/// 手动同步完成后的 SnackBar 摘要（消费 [SyncRunReport]）。纯函数，便于单测边界：
-/// 全 0 → "无新增"；多类型 → ` · ` 拼接；有失败 → 追加失败计数后缀。
-@visibleForTesting
-String summarizeSyncReport(SyncRunReport r) {
-  final List<String> parts = <String>[
-    if (r.booksImported > 0) t.sync_now_books_in(count: r.booksImported),
-    if (r.dictionariesImported > 0)
-      t.sync_now_dicts_in(count: r.dictionariesImported),
-    if (r.dictionariesExported > 0)
-      t.sync_now_dicts_out(count: r.dictionariesExported),
-    if (r.audiobooksImported > 0)
-      t.sync_now_audio_in(count: r.audiobooksImported),
-    if (r.audiobooksExported > 0)
-      t.sync_now_audio_out(count: r.audiobooksExported),
-    if (r.localAudioImported > 0)
-      t.sync_now_local_audio_in(count: r.localAudioImported),
-    if (r.localAudioExported > 0)
-      t.sync_now_local_audio_out(count: r.localAudioExported),
-  ];
-  final String head = parts.isEmpty ? t.sync_now_no_changes : parts.join(' · ');
-  final String done = t.sync_now_done(detail: head);
-  return r.errors.isEmpty
-      ? done
-      : '$done${t.sync_now_failed_suffix(count: r.errors.length)}';
-}
+//
+// 「跑同步 + 统一反馈」的实现搬去了 lib/src/sync/manual_sync_ui.dart
+// （[runManualSyncWithFeedback] / [summarizeSyncReport]），因为媒体页的下拉同步要走
+// 同一条路径 —— 冲突必须按各自通道后端呈现、鉴权失效必须登出，这些不能被复制成
+// 多份各自演化。本行现在只是那个入口的一层壳。
 
 // ── Backup export widget ─────────────────────────────────────────────
 
@@ -41,107 +20,16 @@ class _SyncNowWidget extends StatefulWidget {
 }
 
 class _SyncNowWidgetState extends State<_SyncNowWidget> {
+  /// 设置页「立即同步」——只是 [runManualSyncWithFeedback] 的壳。重入 guard、三种
+  /// outcome 的提示、逐通道冲突呈现、鉴权失效登出全在那个共享入口里，与媒体页下拉
+  /// 同步同一份实现。设置页是显式动作，三种结果都要给用户回音（全 announce 默认 true）。
   Future<void> _syncNow() async {
-    // Re-entrant / already-in-flight guard: the whole row is a focus target
-    // whose Activate (A/Enter, see [AdaptiveSettingsRow.onTap] below) runs this
-    // too, AND a background/app-open auto-sync may already hold the sweep lock.
-    // In both cases a second trigger is a no-op — the global [syncInProgress]
-    // notifier already drives the inline bar (BUG-101), so there's nothing to do
-    // here but let it run.
-    if (syncInProgress.value) return;
-    try {
-      final AppModel appModel = widget.settingsContext.appModel;
-      final ManualSyncResult result = await runManualFullSync(
-        db: appModel.database,
-        dictionaryResourceRoot: appModel.dictionaryResourceDirectory,
-        audioDatabaseRoot:
-            Directory('${appModel.appDirectory.path}/audiobooks'),
-        tempDir: appModel.temporaryDirectory,
-        localAudioEntries: appModel.localAudioDbs,
-        onLocalAudioImported: appModel.importSyncedLocalAudioDb,
-        onPostRun: appModel.refreshAfterSyncRun,
-      );
-      if (!mounted) return;
-      switch (result.outcome) {
-        case ManualSyncOutcome.notConfigured:
-          _showSnackBar(context, t.sync_compare_unavailable);
-        case ManualSyncOutcome.busy:
-          _showSnackBar(context, t.sync_now_busy);
-        case ManualSyncOutcome.completed:
-          final SyncRunReport report = result.report!;
-          _showSnackBar(context, summarizeSyncReport(report));
-          // Manual sync is an explicit user action: prompt resolution
-          // immediately, unconstrained by in-book/snooze (ConflictSource.manual).
-          // option B 双通道：逐通道用**各自的**后端呈现该通道的冲突——合并报告的
-          // 冲突可能来自互联通道，用云后端去 apply 会写错端。
-          for (final ManualSyncChannelReport channel in result.channelReports) {
-            if (channel.report.conflicts.isEmpty) continue;
-            if (!mounted) return;
-            await appModel.syncConflictPrompter.present(
-              navigatorKey: appModel.navigatorKey,
-              db: appModel.database,
-              backend: channel.backend,
-              conflicts: channel.report.conflicts,
-              source: ConflictSource.manual,
-              inBook: appModel.isMediaOpen,
-            );
-          }
-      }
-    } on SyncAuthError catch (e) {
-      // TODO-836: insufficient_scope (or any auth error) — the saved session is
-      // no longer usable. Sign out so the account row falls back to "not signed
-      // in" (the sign-in button reappears), then prompt re-login. The sign-out
-      // sequence mirrors the manual sign-out path in account.part.dart.
-      final AppModel appModel = widget.settingsContext.appModel;
-      final SyncRepository repo = SyncRepository(appModel.database);
-      try {
-        final SyncBackend backend =
-            resolveSyncBackend(await repo.getBackendType());
-        await backend.signOut(repo: repo);
-        backend.clearCache();
-        await repo.clearFolderCache();
-      } catch (_) {
-        // Best-effort sign-out; never hide the original re-login prompt.
-      }
-      if (mounted) _showSnackBar(context, friendlySyncError(e));
-    } catch (e) {
-      if (mounted) {
-        _showSnackBar(
-          context,
-          t.sync_error(message: friendlySyncErrorDetail(e)),
-        );
-      }
-    }
-    // No local teardown: the inline bar is driven by the global [syncInProgress]
-    // / [syncProgress] notifiers, which the sync entry points reset in their own
-    // finally blocks.
-  }
-
-  /// Localized phase name for the inline progress line.
-  String _phaseLabel(SyncPhase phase) {
-    switch (phase) {
-      case SyncPhase.books:
-        return t.sync_progress_books;
-      case SyncPhase.readingData:
-        return t.sync_progress_reading;
-      case SyncPhase.dictionaries:
-        return t.sync_progress_dictionaries;
-      case SyncPhase.localAudio:
-        return t.sync_progress_local_audio;
-      case SyncPhase.audiobooks:
-        return t.sync_progress_audiobooks;
-      case SyncPhase.videos:
-        return t.sync_progress_videos;
-    }
-  }
-
-  /// "phase (k/N) title" — count omitted when the phase has no items.
-  String _progressLine(SyncProgress p) {
-    final String phase = _phaseLabel(p.phase);
-    if (p.itemTotal <= 0) return phase;
-    final String head = '$phase (${p.itemIndex + 1}/${p.itemTotal})';
-    final String? title = p.title;
-    return (title == null || title.isEmpty) ? head : '$head $title';
+    await runManualSyncWithFeedback(
+      context: context,
+      appModel: widget.settingsContext.appModel,
+      // 已在同步中时这一行本就在显示进度条，再弹一句 toast 是噪音（BUG-101）。
+      announceBusy: false,
+    );
   }
 
   @override
@@ -159,7 +47,7 @@ class _SyncNowWidgetState extends State<_SyncNowWidget> {
             final AdaptiveSettingsRow row = AdaptiveSettingsRow(
               title: t.sync_now,
               subtitle:
-                  syncing && p != null ? _progressLine(p) : t.sync_now_hint,
+                  syncing && p != null ? syncProgressLine(p) : t.sync_now_hint,
               icon: Icons.sync,
               controlBelow: true,
               // The action lives on the trailing button; giving the ROW an onTap

--- a/hibiki/test/pages/home_dictionary_pull_to_sync_test.dart
+++ b/hibiki/test/pages/home_dictionary_pull_to_sync_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/home_dictionary_page.dart';
+import 'package:hibiki/src/sync/desktop_lookup_service.dart';
+import 'package:hibiki_dictionary/hibiki_dictionary.dart';
+
+import '../helpers/fake_inappwebview_platform.dart';
+import '../helpers/test_platform_services.dart';
+
+/// 词典页「下拉 = 手动同步」的手势可达性测试。
+///
+/// 词典页原本**完全没有**下拉刷新：主体要么是查词结果 WebView，要么是 `Center` 包的
+/// 空态，要么是历史 `ListView`。后两者加 [RefreshIndicator] 时有个容易翻车的点 ——
+/// RefreshIndicator 只对**真实可滚动的**后代生效：裸 `Center` 没有 Scrollable，历史只
+/// 有一两条时默认 physics 也不可滚，两种情况下手势会被静默吞掉（widget 树里有
+/// RefreshIndicator，下拉却毫无反应）。所以这里不只断言「有 RefreshIndicator」，还断言
+/// 它下面挂着能响应下拉的 Scrollable。
+class _PullSyncAppModel extends AppModel {
+  _PullSyncAppModel({required this.history}) : super(testPlatformServices());
+
+  final List<DictionarySearchResult> history;
+
+  @override
+  List<DictionarySearchResult> get dictionaryHistory => history;
+
+  @override
+  bool get autoSearchEnabled => false;
+
+  @override
+  bool get desktopClipboardEnabled => false;
+
+  @override
+  DesktopClipboardWindowMode get desktopClipboardWindowMode =>
+      DesktopClipboardWindowMode.normal;
+
+  @override
+  List<Dictionary> get dictionaries => <Dictionary>[
+        Dictionary(name: 'Test', formatKey: 'test', order: 0),
+      ];
+
+  @override
+  int get maximumTerms => 10;
+
+  @override
+  double get defaultDictionaryFontSize => 26;
+
+  @override
+  double get dictionaryFontSize => 26;
+
+  @override
+  double get appUiScale => 1.0;
+
+  @override
+  List<String> get enabledAudioSources => const <String>[];
+}
+
+Widget _wrap(_PullSyncAppModel appModel) {
+  return ProviderScope(
+    overrides: <Override>[appProvider.overrideWith((ref) => appModel)],
+    child: TranslationProvider(
+      child: MaterialApp(
+        navigatorKey: appModel.navigatorKey,
+        builder: (BuildContext context, Widget? child) =>
+            child ?? const SizedBox.shrink(),
+        home: const Scaffold(body: HomeDictionaryPage()),
+      ),
+    ),
+  );
+}
+
+DictionarySearchResult _result(String term) => DictionarySearchResult(
+      searchTerm: term,
+      entries: <DictionaryEntry>[
+        DictionaryEntry(
+          dictionaryName: 'Test',
+          word: term,
+          reading: term,
+          meaning: '["x"]',
+        ),
+      ],
+    );
+
+/// RefreshIndicator 下面挂着的、真正会响应下拉的 Scrollable 的 physics。
+ScrollPhysics? _refreshablePhysics(WidgetTester tester) {
+  final Finder scrollable = find.descendant(
+    of: find.byType(RefreshIndicator),
+    matching: find.byType(Scrollable),
+  );
+  if (scrollable.evaluate().isEmpty) return null;
+  return tester.widget<Scrollable>(scrollable.first).physics;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(installFakeInAppWebViewPlatform);
+
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+    DesktopLookupService.instance.debugReset();
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(const MethodChannel('window_manager'), null);
+    DesktopLookupService.instance.debugReset();
+  });
+
+  testWidgets('空历史（空态）也能下拉同步：Center 被撑成可滚动视口', (WidgetTester tester) async {
+    final _PullSyncAppModel appModel =
+        _PullSyncAppModel(history: <DictionarySearchResult>[]);
+    await tester.pumpWidget(_wrap(appModel));
+    await tester.pump();
+
+    expect(find.byType(RefreshIndicator), findsOneWidget);
+    final ScrollPhysics? physics = _refreshablePhysics(tester);
+    expect(
+      physics,
+      isNotNull,
+      reason: '空态若还是裸 Center，RefreshIndicator 找不到 Scrollable，下拉手势被静默吞掉',
+    );
+    expect(
+      physics,
+      isA<AlwaysScrollableScrollPhysics>(),
+      reason: '内容不满一屏时必须仍能下拉，否则空态永远同步不了',
+    );
+  });
+
+  testWidgets('历史列表能下拉同步，且只有一条时也可滚', (WidgetTester tester) async {
+    final _PullSyncAppModel appModel = _PullSyncAppModel(
+      history: <DictionarySearchResult>[_result('猫')],
+    );
+    await tester.pumpWidget(_wrap(appModel));
+    await tester.pump();
+
+    expect(find.byType(RefreshIndicator), findsOneWidget);
+    expect(
+      _refreshablePhysics(tester),
+      isA<AlwaysScrollableScrollPhysics>(),
+      reason: '历史只有一条时 ListView 默认不可滚，下拉同步会吃不到手势',
+    );
+  });
+
+  testWidgets('下拉真的能拉出刷新指示器（手势没被吞）', (WidgetTester tester) async {
+    final _PullSyncAppModel appModel = _PullSyncAppModel(
+      history: <DictionarySearchResult>[_result('猫')],
+    );
+    await tester.pumpWidget(_wrap(appModel));
+    await tester.pump();
+
+    // 从列表区域往下拖，RefreshIndicator 应当露出进度圈。用 fling 之外的持续拖拽，
+    // 避免依赖 fling 速度阈值。
+    final TestGesture gesture =
+        await tester.startGesture(tester.getCenter(find.byType(ListView)));
+    await gesture.moveBy(const Offset(0, 250));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(
+      find.byType(RefreshProgressIndicator),
+      findsOneWidget,
+      reason: '下拉没能拉出指示器 —— 手势被吞了',
+    );
+
+    // 松手后让指示器回弹收尾，避免 pending timer 泄漏到下一个用例。
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+}

--- a/hibiki/test/settings/settings_redesign_static_test.dart
+++ b/hibiki/test/settings/settings_redesign_static_test.dart
@@ -101,7 +101,9 @@ void main() {
       'SettingsDestination buildSyncBackupDestination',
       'SettingsDestinationId.syncBackup',
       'sync.sync_now',
-      'runManualFullSync',
+      // 手动同步的实现搬去了 lib/src/sync/manual_sync_ui.dart（媒体页下拉同步共用
+      // 同一入口），设置页这一行现在接的是那个共享入口。
+      'runManualSyncWithFeedback',
     ],
     // schema 行的自适应组件收口在共享 settings_schema_widgets（见下条），两个渲染器
     // 只保留各自平台外壳并复用共享 SettingsSchemaSection。

--- a/hibiki/test/sync/manual_sync_ui_test.dart
+++ b/hibiki/test/sync/manual_sync_ui_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/sync/manual_sync_ui.dart';
+import 'package:hibiki/src/sync/sync_auto_trigger.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// [runManualSyncWithFeedback] 的 busy 分支行为。
+///
+/// 这条分支是加「下拉 = 手动同步」时新引入的：设置页原来的实现遇到 `syncInProgress`
+/// 直接 `return` 且什么都不说，而下拉刷新需要在同样的情况下**不打断用户**，同时仍要
+/// 如实返回 busy 让调用方知道这次没跑同步。两种口径靠 `announceBusy` 区分，所以要钉住
+/// 「busy 时绝不触发第二次同步」和「announceBusy 决定是否出声」这两点。
+///
+/// 注：只测 busy 分支 —— 它在碰 `appModel.database` 之前就返回，因此不需要一个初始化
+/// 过的 AppModel。真正跑同步的路径依赖完整 DB + 后端，属于集成测试范围。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppModel appModel;
+
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+    appModel = AppModel(testPlatformServices());
+    syncInProgress.value = false;
+  });
+
+  tearDown(() => syncInProgress.value = false);
+
+  Future<ManualSyncOutcome> callWith(
+    WidgetTester tester, {
+    required bool announceBusy,
+  }) async {
+    late ManualSyncOutcome outcome;
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) => TextButton(
+                onPressed: () async {
+                  outcome = await runManualSyncWithFeedback(
+                    context: context,
+                    appModel: appModel,
+                    announceBusy: announceBusy,
+                  );
+                },
+                child: const Text('go'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('go'));
+    await tester.pump();
+    return outcome;
+  }
+
+  testWidgets('同步已在飞时返回 busy 且不再触发第二次同步', (WidgetTester tester) async {
+    syncInProgress.value = true;
+    final ManualSyncOutcome outcome =
+        await callWith(tester, announceBusy: false);
+
+    expect(outcome, ManualSyncOutcome.busy);
+    // 第二次触发必须是彻底的 no-op：连 SnackBar 都不该有（下拉刷新的口径）。
+    expect(find.byType(SnackBar), findsNothing);
+    // 没有把全局标志改坏 —— 在飞的那次同步还得靠它复位自己的进度条。
+    expect(syncInProgress.value, isTrue);
+  });
+
+  testWidgets('announceBusy 打开时给出可见提示（设置页口径）', (WidgetTester tester) async {
+    syncInProgress.value = true;
+    final ManualSyncOutcome outcome =
+        await callWith(tester, announceBusy: true);
+
+    expect(outcome, ManualSyncOutcome.busy);
+    await tester.pump();
+    expect(find.byType(SnackBar), findsOneWidget);
+  });
+}

--- a/hibiki/test/sync/pull_to_sync_wiring_guard_test.dart
+++ b/hibiki/test/sync/pull_to_sync_wiring_guard_test.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 「下拉 = 手动同步」的接线守卫。
+///
+/// 需求：书架 / 视频 / 词典三页下拉刷新时，除了刷新互联远端列表，还要跑一遍云备份 +
+/// 互联同步。实现方式是把设置页「立即同步」那 75 行（跑同步 + 三种 outcome 提示 +
+/// **逐通道**冲突呈现 + 鉴权失效登出）抽成单点 [runManualSyncWithFeedback]，四个入口
+/// 共用。
+///
+/// 这里钉住的是**单点**这件事本身：一旦有人图省事把 `runManualFullSync` 直接抄回某个
+/// 页面，冲突就会用错通道的后端去 apply（写错端），或者鉴权失效后卡在无效会话里 ——
+/// 这两个坑不会让编译报错，也不会让别的测试变红，只会在真机上表现成难查的数据错乱。
+///
+/// 页面运行时表面在 headless 测试里挂不稳（AppModel 未初始化），故用源码扫描锁不变式；
+/// 词典页的实际手势行为另有 widget 测试（home_dictionary_pull_to_sync_test.dart）。
+void main() {
+  String read(String path) => File(path).readAsStringSync();
+
+  /// 截取 [src] 中从 [signature] 开始、长度 [span] 的片段（够覆盖一个短方法体）。
+  String bodyAfter(String src, String signature, {int span = 700}) {
+    final int start = src.indexOf(signature);
+    expect(start, isNonNegative, reason: '找不到 $signature');
+    final int end = (start + span) > src.length ? src.length : start + span;
+    return src.substring(start, end);
+  }
+
+  final Map<String, ({String file, String signature})> pullEntries =
+      <String, ({String file, String signature})>{
+    '书架': (
+      file: 'lib/src/pages/implementations/reader_history/remote.part.dart',
+      signature: 'Future<void> _pullToRefreshBooks() async {',
+    ),
+    '视频': (
+      file: 'lib/src/pages/implementations/home_video_page.dart',
+      signature: 'Future<void> _pullToRefresh() async {',
+    ),
+    '词典': (
+      file: 'lib/src/pages/implementations/home_dictionary_page.dart',
+      signature: 'Future<void> _pullToRefreshDictionary() async {',
+    ),
+  };
+
+  pullEntries.forEach((String page, ({String file, String signature}) e) {
+    test('$page页下拉刷新调用共享的 runManualSyncWithFeedback', () {
+      final String body = bodyAfter(read(e.file), e.signature);
+      expect(
+        body,
+        contains('runManualSyncWithFeedback('),
+        reason: '$page页下拉必须跑手动同步，而不只是刷列表',
+      );
+    });
+
+    test('$page页下拉不弹「同步未配置」噪音', () {
+      final String body = bodyAfter(read(e.file), e.signature);
+      expect(
+        body,
+        contains('announceNotConfigured: false'),
+        reason: '没配同步后端的用户每次下拉都被弹一句「同步不可用」是纯噪音；'
+            '此时下拉应静默退化成纯列表刷新',
+      );
+      expect(
+        body,
+        contains('announceBusy: false'),
+        reason: '已有同步在飞时用户下拉，数据照样会更新，不该再打断他',
+      );
+    });
+
+    test('$page页不得自己复制一份 runManualFullSync 调用', () {
+      expect(
+        read(e.file),
+        isNot(contains('runManualFullSync(')),
+        reason: '同步 + 反馈只能有一份实现（manual_sync_ui.dart）：复制出去的那份迟早'
+            '漏掉逐通道冲突呈现（写错端）或鉴权失效登出',
+      );
+    });
+  });
+
+  test('设置页「立即同步」与下拉同步走同一入口', () {
+    final String src =
+        read('lib/src/sync/sync_settings_schema/actions.part.dart');
+    final String body = bodyAfter(src, 'Future<void> _syncNow() async {');
+    expect(body, contains('runManualSyncWithFeedback('));
+    expect(
+      src,
+      isNot(contains('runManualFullSync(')),
+      reason: '设置页也必须是共享入口的壳，否则两条路径会各自演化',
+    );
+  });
+
+  test('共享入口保留逐通道冲突呈现与鉴权失效登出', () {
+    final String src = read('lib/src/sync/manual_sync_ui.dart');
+    // 合并报告的冲突可能来自互联通道，用云后端 apply 会写错端（option B 双通道）。
+    expect(src, contains('for (final ManualSyncChannelReport channel in'));
+    expect(src, contains('backend: channel.backend'));
+    expect(src, contains('source: ConflictSource.manual'));
+    // TODO-836：鉴权失效必须登出，否则账号行不退回「未登录」，用户无从重新登录。
+    expect(src, contains('on SyncAuthError catch'));
+    expect(src, contains('await backend.signOut(repo: repo)'));
+  });
+
+  test('三页都挂了同步进度条（下拉可能跑几十秒）', () {
+    for (final String file in <String>[
+      'lib/src/pages/implementations/reader_hibiki_history_page.dart',
+      'lib/src/pages/implementations/home_video_page.dart',
+      'lib/src/pages/implementations/home_dictionary_page.dart',
+    ]) {
+      expect(
+        read(file),
+        contains('const SyncProgressBanner()'),
+        reason: '$file 缺同步进度条：光一个 RefreshIndicator 转圈看不出跑到哪一步',
+      );
+    }
+  });
+
+  test('词典页查询结果屏不叠下拉刷新（手势与「清空查询」冲突）', () {
+    final String src =
+        read('lib/src/pages/implementations/home_dictionary_page.dart');
+    final String body = bodyAfter(src, 'Widget _buildBody() {', span: 500);
+    final int queryReturn = body.indexOf('return _buildQueryBody();');
+    final int refreshStart = body.indexOf('RefreshIndicator(');
+    expect(queryReturn, isNonNegative);
+    expect(
+      refreshStart,
+      greaterThan(queryReturn),
+      reason: '有活跃查询时必须在包 RefreshIndicator 之前就 return —— 结果屏的下拉'
+          '已经是 _clearSearchFromResultPull（清空查询），两个手势不能抢',
+    );
+  });
+}


### PR DESCRIPTION
## 需求

用户要求：给书架、视频页、词典页加下拉手动同步 hibiki 互联和云同步。

（用户最初说的是「上划」，确认后明确为**下拉刷新**——把现有下拉从「只刷互联列表」扩成「互联刷新 + 云同步」，没有下拉的界面补上。用户同时指出 texthooker 顶层 tab 已删，核对 `home_page.dart` 后确认属实，故不在范围内。）

## 改动前的事实

- 只有书架和视频页有 `RefreshIndicator`，且**只刷互联远端列表**，完全不碰云同步。
- 云同步的统一入口 `runManualFullSync()` 只挂在设置页「立即同步」，媒体页够不着。
- 词典页**没有任何下拉刷新**。

## 做法

没有把设置页那 75 行「跑同步 + 反馈」复制三份，而是抽成单点 `runManualSyncWithFeedback()`（新文件 `lib/src/sync/manual_sync_ui.dart`），**设置页也改成走同一入口**。

理由是那段逻辑里有两个复制就会漏掉、且不会让编译或既有测试变红的坑：
1. 冲突必须按**各自通道的后端**呈现——合并报告里的冲突可能来自互联通道，用云后端 apply 会**写错端**；
2. `SyncAuthError` 必须登出，否则账号行不退回「未登录」，用户卡在无效会话里无从重新登录。

## 三页

| 页面 | 改动 |
|---|---|
| 书架 `remote.part.dart:84` | 下拉从「刷互联列表」→「跑同步 → 再刷列表」 |
| 视频 `home_video_page.dart:265` | 同上 |
| 词典 `home_dictionary_page.dart` | 从零加下拉；无远端词典列表视图，故下拉 = 同步 + 重读 `appModel.dictionaries/dictionaryHistory` |

**同步排在重读列表之前**：同步会往本地库落新书/新视频/新进度，先刷列表就会漏掉本次同步的产物，用户得再下拉一次。

**词典页只挂历史列表与空态，不挂查询结果屏**——那一屏的下拉早就是 `_clearSearchFromResultPull`（清空查询，手势真实来源是结果 WebView 内的 JS），叠上去就是两个手势抢同一个下拉。

**手势可达性**（容易静默翻车的点）：空态原本是裸 `Center`、历史只有一两条时 `ListView` 默认 physics 不可滚——两种情况下 widget 树里有 `RefreshIndicator` 但下拉**毫无反应**。故空态改为撑满视口的可滚动容器（保持垂直居中），历史列表加 `AlwaysScrollableScrollPhysics`。

## 两个刻意的取舍

- 没配同步后端时**不弹**「同步不可用」（`announceNotConfigured: false`）：绝大多数用户没配云同步，每次下拉都弹是纯噪音。此时静默退化成纯列表刷新，**行为与改动前一字不差**。
- 已有同步在飞时**不打断**（`announceBusy: false`）：数据照样会更新。
- 冲突提示和错误提示**永远给**——那是不能吞的东西。

## 附带

新增 `SyncProgressBanner` 挂在三页列表上方（无同步时零高度，不占布局）：全量同步可能跑几十秒，光一个 RefreshIndicator 转圈看不出跑到哪一步。它消费全局 `syncInProgress`/`syncProgress`，因此对**任何**在飞的同步都亮（含后台/开机自动同步），而非只有本页触发的那次。

**i18n 零新增**，全部复用既有 key。

## 验证

- `flutter analyze`：No issues found。
- `flutter test` 分三批跑完全量：**4453 + 4683 + 3688 = 12824 全绿，0 失败**。
- 新增 18 个测试：
  - 13 个接线守卫（`test/sync/pull_to_sync_wiring_guard_test.dart`）——钉住「单点」这件事本身，包括三页不得自己复制 `runManualFullSync`、共享入口必须保留逐通道冲突呈现与鉴权失效登出。
  - 3 个词典页 widget 行为（`test/pages/home_dictionary_pull_to_sync_test.dart`）——其中一个用**真实拖拽**验证指示器能被拉出来（即手势没被吞），另两个断言 RefreshIndicator 下挂着 `AlwaysScrollableScrollPhysics` 的 Scrollable。
  - 2 个 busy 分支行为（`test/sync/manual_sync_ui_test.dart`）。
- 更新 1 个既有守卫：`settings_redesign_static_test` 里的符号跟随入口改名（意图不变）。

## 未验证 / 待真机

真机未跑。下拉真正触发一次完整云同步的端到端表现（尤其同步耗时较长时 RefreshIndicator 一直转 + banner 进度是否够用、冲突弹窗从媒体页弹出是否自然）需要在真机上确认。

https://claude.ai/code/session_018G1hrcfRVAkqTxfDS8zYr5