### PR TITLE
feat(extension): 工具栏弹窗操作流优化——生成按钮状态机/清空队列/条目跳转/连接重检 (TODO-1881)

### DIFF
--- a/hibiki/assets/browser_extension/vendor/action-popup.html
+++ b/hibiki/assets/browser_extension/vendor/action-popup.html
@@ -44,8 +44,17 @@
     }
     .hp-gen:hover { filter: brightness(1.08); }
     .hp-gen:active { opacity: 0.7; }
+    /* TODO-1881：显式按钮状态——禁用（队列空/站点不对）灰化不可点；取消态（生成中）转警示色。 */
+    .hp-gen:disabled { background: rgba(128, 128, 128, 0.28); color: inherit; opacity: 0.55; cursor: default; }
+    .hp-gen:disabled:hover { filter: none; }
+    .hp-gen[data-mode="cancel"] { background: #a9443e; }
+    .hp-gen-hint { margin: -8px 14px 10px; font-size: 11px; line-height: 1.4; opacity: 0.6; }
     .hp-list { max-height: 320px; overflow-y: auto; padding: 0 6px 8px; }
-    .hp-list-title { padding: 6px 8px 4px; font-size: 11px; font-weight: 600; opacity: 0.55; text-transform: none; }
+    .hp-list-title { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px 8px 4px; font-size: 11px; font-weight: 600; opacity: 0.55; text-transform: none; }
+    /* TODO-1881：清空队列（二次确认时文字变「确认清空？」并转警示色）。 */
+    .hp-clear { border: 0; padding: 2px 6px; border-radius: 4px; background: transparent; color: inherit; font: inherit; font-size: 11px; cursor: pointer; opacity: 0.8; }
+    .hp-clear:hover { background: rgba(128, 128, 128, 0.2); opacity: 1; }
+    .hp-clear[data-confirm="1"] { background: rgba(211, 47, 47, 0.85); color: #fff; opacity: 1; }
     .hp-row {
       display: flex;
       align-items: center;
@@ -61,6 +70,9 @@
       flex-direction: column;
       gap: 1px;
     }
+    /* TODO-1881：带跳转 URL 的条目可点击回到对应视频页（hover 主标签加下划线示意）。 */
+    .hp-row-main[data-url] { cursor: pointer; }
+    .hp-row-main[data-url]:hover .hp-row-text { text-decoration: underline; }
     .hp-row-text {
       overflow: hidden;
       text-overflow: ellipsis;
@@ -91,6 +103,7 @@
     .hp-del:hover { background: rgba(211, 47, 47, 0.85); color: #fff; opacity: 1; }
     .hp-empty { padding: 20px 14px 24px; text-align: center; opacity: 0.6; }
     .hp-connection {
+      cursor: pointer; /* TODO-1881：整行可点=强制重检连接 */
       display: grid;
       grid-template-columns: 9px minmax(0, 1fr) auto;
       align-items: center;
@@ -122,7 +135,7 @@
     <span class="hp-title">Hibiki 制卡队列</span>
     <span class="hp-count" id="hp-count"></span>
   </div>
-  <div class="hp-connection" id="hp-connection" data-tone="loading" title="点击齿轮打开完整设置">
+  <div class="hp-connection" id="hp-connection" data-tone="loading" title="点击重新检测；齿轮打开完整设置">
     <span class="hp-connection-dot" aria-hidden="true"></span>
     <span class="hp-connection-copy">
       <span class="hp-connection-title" id="hp-connection-title">正在检测 Hibiki…</span>
@@ -131,6 +144,8 @@
     <button class="hp-settings-link" id="hp-open-options" type="button" title="打开扩展设置" aria-label="打开扩展设置">⚙</button>
   </div>
   <button class="hp-gen" id="hp-gen" type="button">开始生成 / 录制</button>
+  <!-- TODO-1881：按钮不可用/跨站点剩余量的原因提示（状态机 hint，空则隐藏）。 -->
+  <div class="hp-gen-hint" id="hp-gen-hint" hidden></div>
   <div class="hp-list" id="hp-list"></div>
   <div class="hp-settings">
     <label class="hp-toggle">

--- a/hibiki/assets/browser_extension/vendor/action-popup.js
+++ b/hibiki/assets/browser_extension/vendor/action-popup.js
@@ -38,35 +38,118 @@ function hibikiReadPanelEnabled(stored) {
   return !!(stored && stored.netflixSubtitlePanel === true);
 }
 
+// TODO-1881：队列项能跳回的视频页 URL（Netflix 生成必须在 netflix.com 页面、YouTube 生成要有
+// content script——用户在队列里看到卡片却回不去对应页面是流程断点）。无可跳站点返回 ''。
+function hibikiQueueItemUrl(q) {
+  if (q && q.site === 'netflix' && q.netflixId) {
+    return 'https://www.netflix.com/watch/' + encodeURIComponent(String(q.netflixId));
+  }
+  if (q && q.site === 'youtube' && q.youtubeId) {
+    return 'https://www.youtube.com/watch?v=' + encodeURIComponent(String(q.youtubeId));
+  }
+  return '';
+}
+
+// TODO-1881：从 tab URL 推断站点。与 content.js hibikiSite() 同判据（hostname 后缀），只是输入
+// 从 location 换成 URL 字符串（popup 上下文没有宿主页 location）。
+function hibikiTabSite(url) {
+  try {
+    const h = new URL(String(url || '')).hostname;
+    if (h === 'netflix.com' || h.endsWith('.netflix.com')) return 'netflix';
+    if (h === 'youtu.be' || h === 'youtube.com' || h.endsWith('.youtube.com')) return 'youtube';
+  } catch (_) { /* 无效 URL（chrome:// 空页等）按 other 处理 */ }
+  return 'other';
+}
+
+// TODO-1881：「开始生成/录制」按钮状态机（纯函数，供 node 测试）。
+// 旧实现是隐形三态：同一个按钮承担「取消卡住的生成 / 开始生成 / 静默无操作」，队列空或站点不对时
+// 点击毫无反馈直接关 popup。改为显式状态：
+// - cancel：hibikiNfBatch.active（生成中/卡住残留）→ 可点，取消并清理（逃生口保留，队列空也可点）。
+// - generate：当前 tab 站点与队列中可生成项匹配 → 可点，标签带数量；跨站点剩余量进 hint。
+// - empty / unsupported / wrongSite：不可点 + hint 说明原因与下一步（wrongSite 引导点队列条目跳转）。
+function hibikiGenButtonState(queue, batchActive, tabSite) {
+  if (batchActive) {
+    return { mode: 'cancel', label: '取消生成', enabled: true, hint: '正在生成中，点击取消并清理录制状态' };
+  }
+  const list = Array.isArray(queue) ? queue : [];
+  const nf = list.filter((q) => q && q.site === 'netflix' && q.netflixId).length;
+  const yt = list.filter((q) => q && q.site === 'youtube' && q.youtubeId).length;
+  if (!list.length) {
+    return { mode: 'empty', label: '开始生成 / 录制', enabled: false, hint: '' };
+  }
+  if (!nf && !yt) {
+    return {
+      mode: 'unsupported', label: '开始生成 / 录制', enabled: false,
+      hint: '队列里的卡片来自暂不支持批量生成的站点，可逐项删除或清空',
+    };
+  }
+  if (tabSite === 'netflix' && nf) {
+    return {
+      mode: 'generate', label: '开始录制生成（' + nf + ' 张）', enabled: true,
+      hint: yt ? '另有 YouTube ' + yt + ' 张，需切到 YouTube 页面生成' : '',
+    };
+  }
+  if (tabSite === 'youtube' && yt) {
+    return {
+      mode: 'generate', label: '开始生成（' + yt + ' 张）', enabled: true,
+      hint: nf ? '另有 Netflix ' + nf + ' 张，需切到 Netflix 播放页生成' : '',
+    };
+  }
+  const parts = [];
+  if (nf) parts.push('Netflix ' + nf + ' 张');
+  if (yt) parts.push('YouTube ' + yt + ' 张');
+  return {
+    mode: 'wrongSite', label: '开始生成 / 录制', enabled: false,
+    hint: '待生成：' + parts.join(' · ') + '，点队列条目跳到对应视频页再生成',
+  };
+}
+
 // node 单测导出（浏览器里 module 未定义，直接跳过）。
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { hibikiFilterQueue, hibikiQueueItemLabel, hibikiQueueItemContext, hibikiReadPanelEnabled };
+  module.exports = {
+    hibikiFilterQueue, hibikiQueueItemLabel, hibikiQueueItemContext, hibikiReadPanelEnabled,
+    hibikiQueueItemUrl, hibikiTabSite, hibikiGenButtonState,
+  };
 }
 
 if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.storage) {
   const listEl = document.getElementById('hp-list');
   const countEl = document.getElementById('hp-count');
   const genEl = document.getElementById('hp-gen');
+  const genHintEl = document.getElementById('hp-gen-hint');
 
   // 点扩展图标就能看见连接状态；离线/密钥错/Yomitan 占端口均给可执行提示，齿轮进完整设置。
   const connEl = document.getElementById('hp-connection');
   const connTitleEl = document.getElementById('hp-connection-title');
   const connDetailEl = document.getElementById('hp-connection-detail');
-  try {
-    // BUG-1036：popup 生命周期很短，每次打开都要新探测；否则会把上次瞬时离线缓存继续显示成
-    // “Hibiki API 未开启”，直到用户进完整设置手动重检。
-    chrome.runtime.sendMessage({ type: 'connectionStatus', force: true }, (resp) => {
-      try { if (chrome.runtime.lastError) return; } catch (_) { return; }
-      const c = resp && resp.connection ? resp.connection : { state: 'offline', port: 19633 };
-      const copy = self.HIBIKI_CONNECTION.copy(c.state, c.port);
-      if (connEl) connEl.dataset.tone = copy.tone;
-      if (connTitleEl) connTitleEl.textContent = copy.title;
-      if (connDetailEl) connDetailEl.textContent = copy.detail;
-      if (connEl) connEl.title = copy.detail;
-    });
-  } catch (_) {}
+  // BUG-1036：popup 生命周期很短，每次打开都要新探测；否则会把上次瞬时离线缓存继续显示成
+  // “Hibiki API 未开启”，直到用户进完整设置手动重检。
+  // TODO-1881：探测抽成函数——连接状态行本身可点，点击即强制重检（原来重试只能进 options 页）。
+  function refreshConnection() {
+    if (connEl) connEl.dataset.tone = 'loading';
+    if (connTitleEl) connTitleEl.textContent = '正在检测 Hibiki…';
+    if (connDetailEl) connDetailEl.textContent = '查词与字幕服务';
+    try {
+      chrome.runtime.sendMessage({ type: 'connectionStatus', force: true }, (resp) => {
+        try { if (chrome.runtime.lastError) return; } catch (_) { return; }
+        const c = resp && resp.connection ? resp.connection : { state: 'offline', port: 19633 };
+        const copy = self.HIBIKI_CONNECTION.copy(c.state, c.port);
+        if (connEl) connEl.dataset.tone = copy.tone;
+        if (connTitleEl) connTitleEl.textContent = copy.title;
+        if (connDetailEl) connDetailEl.textContent = copy.detail;
+        if (connEl) connEl.title = copy.detail + '（点击重新检测）';
+      });
+    } catch (_) {}
+  }
+  refreshConnection();
+  if (connEl) connEl.addEventListener('click', () => refreshConnection());
   const optionsEl = document.getElementById('hp-open-options');
-  if (optionsEl) optionsEl.addEventListener('click', () => chrome.runtime.openOptionsPage());
+  if (optionsEl) {
+    optionsEl.addEventListener('click', (e) => {
+      e.stopPropagation(); // 齿轮在连接行内：别把点击冒泡成「重新检测」
+      chrome.runtime.openOptionsPage();
+    });
+  }
 
   function readQueue() {
     return new Promise((resolve) => {
@@ -86,9 +169,40 @@ if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.s
     render(remaining);
   }
 
+  // TODO-1881：清空队列（原来 N 条要点 N 次 ×）。二次确认：首点变「确认清空？」，3 秒内再点才清。
+  let clearConfirmTimer = null;
+  async function clearQueue() {
+    try { await chrome.storage.local.set({ hibikiQueue: [] }); } catch (_) {}
+    render([]);
+  }
+
+  // ── TODO-1881：生成按钮状态机接线 ──
+  // popup 打开时 query 一次当前 tab（popup 绑定于当前窗口活动 tab，生命周期内不变）；
+  // 队列/批量状态经 storage.onChanged 实时驱动重算。
+  let genTab = null; // {id,url}；query 回来前按 other 站点渲染（按钮先禁用，回来后立即修正）
+  function updateGenButton(queue, batch) {
+    if (!genEl) return;
+    const state = hibikiGenButtonState(queue, !!(batch && batch.active), hibikiTabSite(genTab && genTab.url));
+    genEl.textContent = state.label;
+    genEl.disabled = !state.enabled;
+    genEl.dataset.mode = state.mode;
+    if (genHintEl) {
+      genHintEl.textContent = state.hint;
+      genHintEl.hidden = !state.hint;
+    }
+  }
+  function refreshGenButton(queue) {
+    try {
+      chrome.storage.local.get(['hibikiNfBatch'], (r) => {
+        updateGenButton(queue, r && r.hibikiNfBatch);
+      });
+    } catch (_) { updateGenButton(queue, null); }
+  }
+
   function render(queue) {
     const list = Array.isArray(queue) ? queue : [];
     if (countEl) countEl.textContent = list.length ? String(list.length) : '';
+    refreshGenButton(list);
     if (!listEl) return;
     listEl.textContent = '';
     if (!list.length) {
@@ -101,7 +215,29 @@ if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.s
     // TODO-1222：给队列列表加一行标题头（与顶部应用标题区分：这里标注下方是「待生成的卡片」）。
     const heading = document.createElement('div');
     heading.className = 'hp-list-title';
-    heading.textContent = '待生成的卡片（' + list.length + '）';
+    const headingText = document.createElement('span');
+    headingText.textContent = '待生成的卡片（' + list.length + '）';
+    heading.appendChild(headingText);
+    // TODO-1881：清空按钮（二次确认）挂在标题行右侧。
+    const clearBtn = document.createElement('button');
+    clearBtn.className = 'hp-clear';
+    clearBtn.type = 'button';
+    clearBtn.textContent = '清空';
+    clearBtn.addEventListener('click', () => {
+      if (clearBtn.dataset.confirm === '1') {
+        if (clearConfirmTimer) { clearTimeout(clearConfirmTimer); clearConfirmTimer = null; }
+        clearQueue();
+        return;
+      }
+      clearBtn.dataset.confirm = '1';
+      clearBtn.textContent = '确认清空？';
+      if (clearConfirmTimer) clearTimeout(clearConfirmTimer);
+      clearConfirmTimer = setTimeout(() => {
+        clearBtn.dataset.confirm = '';
+        clearBtn.textContent = '清空';
+      }, 3000);
+    });
+    heading.appendChild(clearBtn);
     listEl.appendChild(heading);
     for (const q of list) {
       const row = document.createElement('div');
@@ -127,7 +263,17 @@ if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.s
         sub.textContent = context;
         main.appendChild(sub);
       }
-      main.title = context ? (label + ' — ' + context) : label;
+      // TODO-1881：条目可点击跳回对应视频页（Netflix 生成必须在其页面；wrongSite hint 引导到这里）。
+      const jumpUrl = hibikiQueueItemUrl(q);
+      if (jumpUrl) {
+        main.dataset.url = jumpUrl;
+        main.title = (context ? (label + ' — ' + context) : label) + '\n点击打开视频页';
+        main.addEventListener('click', () => {
+          try { chrome.tabs.create({ url: jumpUrl }); } catch (_) {}
+        });
+      } else {
+        main.title = context ? (label + ' — ' + context) : label;
+      }
       const del = document.createElement('button');
       del.className = 'hp-del';
       del.type = 'button';
@@ -184,13 +330,24 @@ if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.s
   }
 
   // 队列在别处（content 入队 / 生成出队 / 别的标签）变化时，popup 若还开着就实时刷新。
+  // TODO-1881：hibikiNfBatch 变化（生成开始/结束/取消）也要刷新按钮状态（取消↔生成切换）。
   try {
     chrome.storage.onChanged.addListener((changes, area) => {
-      if (area === 'local' && changes.hibikiQueue) {
+      if (area !== 'local') return;
+      if (changes.hibikiQueue) {
         render(Array.isArray(changes.hibikiQueue.newValue) ? changes.hibikiQueue.newValue : []);
+      } else if (changes.hibikiNfBatch) {
+        readQueue().then((q) => updateGenButton(q, changes.hibikiNfBatch.newValue));
       }
     });
   } catch (_) {}
 
+  // TODO-1881：先渲染（按钮按 other 站点保守禁用），tab query 回来后立即按真实站点修正。
   readQueue().then(render);
+  try {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      genTab = (tabs && tabs[0]) || null;
+      readQueue().then((q) => refreshGenButton(q));
+    });
+  } catch (_) {}
 }

--- a/hibiki/test/lookup/browser_extension_icon_popup_guard_test.dart
+++ b/hibiki/test/lookup/browser_extension_icon_popup_guard_test.dart
@@ -139,6 +139,44 @@ void main() {
         expect(src.contains('.hp-row-sub'), isTrue,
             reason: '$root action-popup.html 缺 .hp-row-sub 上下文行样式');
       });
+
+      // TODO-1881：popup 操作流——生成按钮显式状态机（消除「队列空/站点不对点了没反应」的
+      // 隐形三态）+ 清空队列（二次确认）+ 队列条目跳回视频页 + 连接状态行点击重检。
+      test('1881 action-popup.js 生成按钮状态机 + 清空 + 条目跳转 + 连接重检', () {
+        final String src = actionJs.readAsStringSync();
+        expect(src.contains('function hibikiGenButtonState'), isTrue,
+            reason:
+                '$root action-popup.js 缺 hibikiGenButtonState 状态机（回归成隐形三态按钮）');
+        expect(src.contains('function hibikiTabSite'), isTrue,
+            reason: '$root action-popup.js 缺 hibikiTabSite 站点判定');
+        expect(src.contains('function hibikiQueueItemUrl'), isTrue,
+            reason: '$root action-popup.js 缺 hibikiQueueItemUrl（队列条目跳回视频页）');
+        // 取消逃生口必须保留：batch active 时按钮可点（cancel 态）。
+        expect(src.contains("mode: 'cancel'"), isTrue,
+            reason: '$root hibikiGenButtonState 丢了 cancel 逃生口');
+        // 清空队列（二次确认）。
+        expect(src.contains("'hp-clear'"), isTrue,
+            reason: '$root action-popup.js 缺清空队列按钮');
+        expect(src.contains('确认清空'), isTrue,
+            reason: '$root action-popup.js 清空队列缺二次确认');
+        // 连接状态行点击强制重检（探测抽成 refreshConnection 且行上挂 click）。
+        expect(src.contains('function refreshConnection'), isTrue,
+            reason: '$root action-popup.js 连接探测未抽成 refreshConnection（行点击无法重检）');
+        expect(src.contains("connEl.addEventListener('click'"), isTrue,
+            reason: '$root action-popup.js 连接状态行未挂点击重检');
+      });
+
+      test('1881 action-popup.html 有 hint 元素与状态样式', () {
+        final String src = actionHtml.readAsStringSync();
+        expect(src.contains('hp-gen-hint'), isTrue,
+            reason: '$root action-popup.html 缺 hp-gen-hint 原因提示元素');
+        expect(src.contains('.hp-gen:disabled'), isTrue,
+            reason: '$root action-popup.html 缺禁用态样式（按钮不可点无视觉反馈）');
+        expect(src.contains('data-mode="cancel"'), isTrue,
+            reason: '$root action-popup.html 缺取消态警示样式');
+        expect(src.contains('.hp-clear'), isTrue,
+            reason: '$root action-popup.html 缺清空按钮样式');
+      });
     });
   });
 }

--- a/tools/browser-extension/action-popup.test.js
+++ b/tools/browser-extension/action-popup.test.js
@@ -1,7 +1,10 @@
 // TODO-1184 守卫：action popup 队列删除 + 标签的纯逻辑单测（无 chrome/DOM 依赖）。
 const { test } = require('node:test');
 const assert = require('node:assert');
-const { hibikiFilterQueue, hibikiQueueItemLabel, hibikiQueueItemContext, hibikiReadPanelEnabled } = require('./vendor/action-popup.js');
+const {
+  hibikiFilterQueue, hibikiQueueItemLabel, hibikiQueueItemContext, hibikiReadPanelEnabled,
+  hibikiQueueItemUrl, hibikiTabSite, hibikiGenButtonState,
+} = require('./vendor/action-popup.js');
 
 test('hibikiFilterQueue removes only the matching id', () => {
   const q = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
@@ -52,4 +55,81 @@ test('TODO-1219: hibikiReadPanelEnabled only true for boolean true (default off)
   // 非严格 true 的真值一律当关（防 'true' 字符串/1 之类误开）。
   assert.strictEqual(hibikiReadPanelEnabled({ netflixSubtitlePanel: 'true' }), false);
   assert.strictEqual(hibikiReadPanelEnabled({ netflixSubtitlePanel: 1 }), false);
+});
+
+// ── TODO-1881：队列条目跳转 URL（Netflix/YouTube 可跳，other 无跳转）──
+test('TODO-1881: hibikiQueueItemUrl builds watch URLs per site, empty otherwise', () => {
+  assert.strictEqual(
+    hibikiQueueItemUrl({ site: 'netflix', netflixId: '81011111' }),
+    'https://www.netflix.com/watch/81011111');
+  assert.strictEqual(
+    hibikiQueueItemUrl({ site: 'youtube', youtubeId: 'dQw4w9WgXcQ' }),
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+  // 无 id / other 站点 / 垃圾输入 → ''（不渲染跳转）。
+  assert.strictEqual(hibikiQueueItemUrl({ site: 'netflix' }), '');
+  assert.strictEqual(hibikiQueueItemUrl({ site: 'other', youtubeId: 'x' }), '');
+  assert.strictEqual(hibikiQueueItemUrl(null), '');
+  // id 会被 URL 编码（防注入路径分隔等特殊字符）。
+  assert.strictEqual(
+    hibikiQueueItemUrl({ site: 'youtube', youtubeId: 'a/b?c' }),
+    'https://www.youtube.com/watch?v=a%2Fb%3Fc');
+});
+
+// ── TODO-1881：tab URL 站点判定（与 content.js hibikiSite 同判据：hostname 后缀）──
+test('TODO-1881: hibikiTabSite classifies by hostname suffix, garbage-safe', () => {
+  assert.strictEqual(hibikiTabSite('https://www.netflix.com/watch/81011111'), 'netflix');
+  assert.strictEqual(hibikiTabSite('https://netflix.com/browse'), 'netflix');
+  assert.strictEqual(hibikiTabSite('https://www.youtube.com/watch?v=abc'), 'youtube');
+  assert.strictEqual(hibikiTabSite('https://youtu.be/abc'), 'youtube');
+  assert.strictEqual(hibikiTabSite('https://example.com/'), 'other');
+  // 恶意后缀不误判（evilnetflix.com 不是 *.netflix.com）。
+  assert.strictEqual(hibikiTabSite('https://evilnetflix.com/'), 'other');
+  assert.strictEqual(hibikiTabSite('chrome://newtab/'), 'other');
+  assert.strictEqual(hibikiTabSite(''), 'other');
+  assert.strictEqual(hibikiTabSite(undefined), 'other');
+});
+
+// ── TODO-1881：生成按钮状态机——消除旧「隐形三态」（取消/生成/静默 no-op）──
+test('TODO-1881: gen button = cancel while batch active (escape hatch, even with empty queue)', () => {
+  const s = hibikiGenButtonState([], true, 'other');
+  assert.strictEqual(s.mode, 'cancel');
+  assert.strictEqual(s.enabled, true);
+});
+test('TODO-1881: gen button disabled with empty queue', () => {
+  const s = hibikiGenButtonState([], false, 'netflix');
+  assert.strictEqual(s.mode, 'empty');
+  assert.strictEqual(s.enabled, false);
+});
+test('TODO-1881: gen button disabled when queue has only non-generatable (other-site) items', () => {
+  const s = hibikiGenButtonState([{ site: 'other', id: '1' }], false, 'netflix');
+  assert.strictEqual(s.mode, 'unsupported');
+  assert.strictEqual(s.enabled, false);
+  assert.ok(s.hint.length > 0);
+});
+test('TODO-1881: gen button enabled with count on matching site', () => {
+  const q = [
+    { site: 'netflix', netflixId: 'a' }, { site: 'netflix', netflixId: 'b' },
+    { site: 'youtube', youtubeId: 'c' },
+  ];
+  const nf = hibikiGenButtonState(q, false, 'netflix');
+  assert.strictEqual(nf.mode, 'generate');
+  assert.strictEqual(nf.enabled, true);
+  assert.ok(nf.label.includes('2'));
+  assert.ok(nf.hint.includes('YouTube')); // 跨站点剩余量提示
+  const yt = hibikiGenButtonState(q, false, 'youtube');
+  assert.strictEqual(yt.mode, 'generate');
+  assert.ok(yt.label.includes('1'));
+  assert.ok(yt.hint.includes('Netflix'));
+});
+test('TODO-1881: gen button disabled on wrong site, hint lists pending sites', () => {
+  const q = [{ site: 'netflix', netflixId: 'a' }, { site: 'youtube', youtubeId: 'c' }];
+  const s = hibikiGenButtonState(q, false, 'other');
+  assert.strictEqual(s.mode, 'wrongSite');
+  assert.strictEqual(s.enabled, false);
+  assert.ok(s.hint.includes('Netflix 1 张'));
+  assert.ok(s.hint.includes('YouTube 1 张'));
+  // 站点匹配但该站点无可生成项（netflix tab + 只有 yt 项）同样按 wrongSite 处理。
+  const s2 = hibikiGenButtonState([{ site: 'youtube', youtubeId: 'c' }], false, 'netflix');
+  assert.strictEqual(s2.mode, 'wrongSite');
+  assert.strictEqual(s2.enabled, false);
 });

--- a/tools/browser-extension/vendor/action-popup.html
+++ b/tools/browser-extension/vendor/action-popup.html
@@ -44,8 +44,17 @@
     }
     .hp-gen:hover { filter: brightness(1.08); }
     .hp-gen:active { opacity: 0.7; }
+    /* TODO-1881：显式按钮状态——禁用（队列空/站点不对）灰化不可点；取消态（生成中）转警示色。 */
+    .hp-gen:disabled { background: rgba(128, 128, 128, 0.28); color: inherit; opacity: 0.55; cursor: default; }
+    .hp-gen:disabled:hover { filter: none; }
+    .hp-gen[data-mode="cancel"] { background: #a9443e; }
+    .hp-gen-hint { margin: -8px 14px 10px; font-size: 11px; line-height: 1.4; opacity: 0.6; }
     .hp-list { max-height: 320px; overflow-y: auto; padding: 0 6px 8px; }
-    .hp-list-title { padding: 6px 8px 4px; font-size: 11px; font-weight: 600; opacity: 0.55; text-transform: none; }
+    .hp-list-title { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px 8px 4px; font-size: 11px; font-weight: 600; opacity: 0.55; text-transform: none; }
+    /* TODO-1881：清空队列（二次确认时文字变「确认清空？」并转警示色）。 */
+    .hp-clear { border: 0; padding: 2px 6px; border-radius: 4px; background: transparent; color: inherit; font: inherit; font-size: 11px; cursor: pointer; opacity: 0.8; }
+    .hp-clear:hover { background: rgba(128, 128, 128, 0.2); opacity: 1; }
+    .hp-clear[data-confirm="1"] { background: rgba(211, 47, 47, 0.85); color: #fff; opacity: 1; }
     .hp-row {
       display: flex;
       align-items: center;
@@ -61,6 +70,9 @@
       flex-direction: column;
       gap: 1px;
     }
+    /* TODO-1881：带跳转 URL 的条目可点击回到对应视频页（hover 主标签加下划线示意）。 */
+    .hp-row-main[data-url] { cursor: pointer; }
+    .hp-row-main[data-url]:hover .hp-row-text { text-decoration: underline; }
     .hp-row-text {
       overflow: hidden;
       text-overflow: ellipsis;
@@ -91,6 +103,7 @@
     .hp-del:hover { background: rgba(211, 47, 47, 0.85); color: #fff; opacity: 1; }
     .hp-empty { padding: 20px 14px 24px; text-align: center; opacity: 0.6; }
     .hp-connection {
+      cursor: pointer; /* TODO-1881：整行可点=强制重检连接 */
       display: grid;
       grid-template-columns: 9px minmax(0, 1fr) auto;
       align-items: center;
@@ -122,7 +135,7 @@
     <span class="hp-title">Hibiki 制卡队列</span>
     <span class="hp-count" id="hp-count"></span>
   </div>
-  <div class="hp-connection" id="hp-connection" data-tone="loading" title="点击齿轮打开完整设置">
+  <div class="hp-connection" id="hp-connection" data-tone="loading" title="点击重新检测；齿轮打开完整设置">
     <span class="hp-connection-dot" aria-hidden="true"></span>
     <span class="hp-connection-copy">
       <span class="hp-connection-title" id="hp-connection-title">正在检测 Hibiki…</span>
@@ -131,6 +144,8 @@
     <button class="hp-settings-link" id="hp-open-options" type="button" title="打开扩展设置" aria-label="打开扩展设置">⚙</button>
   </div>
   <button class="hp-gen" id="hp-gen" type="button">开始生成 / 录制</button>
+  <!-- TODO-1881：按钮不可用/跨站点剩余量的原因提示（状态机 hint，空则隐藏）。 -->
+  <div class="hp-gen-hint" id="hp-gen-hint" hidden></div>
   <div class="hp-list" id="hp-list"></div>
   <div class="hp-settings">
     <label class="hp-toggle">

--- a/tools/browser-extension/vendor/action-popup.js
+++ b/tools/browser-extension/vendor/action-popup.js
@@ -38,35 +38,118 @@ function hibikiReadPanelEnabled(stored) {
   return !!(stored && stored.netflixSubtitlePanel === true);
 }
 
+// TODO-1881：队列项能跳回的视频页 URL（Netflix 生成必须在 netflix.com 页面、YouTube 生成要有
+// content script——用户在队列里看到卡片却回不去对应页面是流程断点）。无可跳站点返回 ''。
+function hibikiQueueItemUrl(q) {
+  if (q && q.site === 'netflix' && q.netflixId) {
+    return 'https://www.netflix.com/watch/' + encodeURIComponent(String(q.netflixId));
+  }
+  if (q && q.site === 'youtube' && q.youtubeId) {
+    return 'https://www.youtube.com/watch?v=' + encodeURIComponent(String(q.youtubeId));
+  }
+  return '';
+}
+
+// TODO-1881：从 tab URL 推断站点。与 content.js hibikiSite() 同判据（hostname 后缀），只是输入
+// 从 location 换成 URL 字符串（popup 上下文没有宿主页 location）。
+function hibikiTabSite(url) {
+  try {
+    const h = new URL(String(url || '')).hostname;
+    if (h === 'netflix.com' || h.endsWith('.netflix.com')) return 'netflix';
+    if (h === 'youtu.be' || h === 'youtube.com' || h.endsWith('.youtube.com')) return 'youtube';
+  } catch (_) { /* 无效 URL（chrome:// 空页等）按 other 处理 */ }
+  return 'other';
+}
+
+// TODO-1881：「开始生成/录制」按钮状态机（纯函数，供 node 测试）。
+// 旧实现是隐形三态：同一个按钮承担「取消卡住的生成 / 开始生成 / 静默无操作」，队列空或站点不对时
+// 点击毫无反馈直接关 popup。改为显式状态：
+// - cancel：hibikiNfBatch.active（生成中/卡住残留）→ 可点，取消并清理（逃生口保留，队列空也可点）。
+// - generate：当前 tab 站点与队列中可生成项匹配 → 可点，标签带数量；跨站点剩余量进 hint。
+// - empty / unsupported / wrongSite：不可点 + hint 说明原因与下一步（wrongSite 引导点队列条目跳转）。
+function hibikiGenButtonState(queue, batchActive, tabSite) {
+  if (batchActive) {
+    return { mode: 'cancel', label: '取消生成', enabled: true, hint: '正在生成中，点击取消并清理录制状态' };
+  }
+  const list = Array.isArray(queue) ? queue : [];
+  const nf = list.filter((q) => q && q.site === 'netflix' && q.netflixId).length;
+  const yt = list.filter((q) => q && q.site === 'youtube' && q.youtubeId).length;
+  if (!list.length) {
+    return { mode: 'empty', label: '开始生成 / 录制', enabled: false, hint: '' };
+  }
+  if (!nf && !yt) {
+    return {
+      mode: 'unsupported', label: '开始生成 / 录制', enabled: false,
+      hint: '队列里的卡片来自暂不支持批量生成的站点，可逐项删除或清空',
+    };
+  }
+  if (tabSite === 'netflix' && nf) {
+    return {
+      mode: 'generate', label: '开始录制生成（' + nf + ' 张）', enabled: true,
+      hint: yt ? '另有 YouTube ' + yt + ' 张，需切到 YouTube 页面生成' : '',
+    };
+  }
+  if (tabSite === 'youtube' && yt) {
+    return {
+      mode: 'generate', label: '开始生成（' + yt + ' 张）', enabled: true,
+      hint: nf ? '另有 Netflix ' + nf + ' 张，需切到 Netflix 播放页生成' : '',
+    };
+  }
+  const parts = [];
+  if (nf) parts.push('Netflix ' + nf + ' 张');
+  if (yt) parts.push('YouTube ' + yt + ' 张');
+  return {
+    mode: 'wrongSite', label: '开始生成 / 录制', enabled: false,
+    hint: '待生成：' + parts.join(' · ') + '，点队列条目跳到对应视频页再生成',
+  };
+}
+
 // node 单测导出（浏览器里 module 未定义，直接跳过）。
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { hibikiFilterQueue, hibikiQueueItemLabel, hibikiQueueItemContext, hibikiReadPanelEnabled };
+  module.exports = {
+    hibikiFilterQueue, hibikiQueueItemLabel, hibikiQueueItemContext, hibikiReadPanelEnabled,
+    hibikiQueueItemUrl, hibikiTabSite, hibikiGenButtonState,
+  };
 }
 
 if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.storage) {
   const listEl = document.getElementById('hp-list');
   const countEl = document.getElementById('hp-count');
   const genEl = document.getElementById('hp-gen');
+  const genHintEl = document.getElementById('hp-gen-hint');
 
   // 点扩展图标就能看见连接状态；离线/密钥错/Yomitan 占端口均给可执行提示，齿轮进完整设置。
   const connEl = document.getElementById('hp-connection');
   const connTitleEl = document.getElementById('hp-connection-title');
   const connDetailEl = document.getElementById('hp-connection-detail');
-  try {
-    // BUG-1036：popup 生命周期很短，每次打开都要新探测；否则会把上次瞬时离线缓存继续显示成
-    // “Hibiki API 未开启”，直到用户进完整设置手动重检。
-    chrome.runtime.sendMessage({ type: 'connectionStatus', force: true }, (resp) => {
-      try { if (chrome.runtime.lastError) return; } catch (_) { return; }
-      const c = resp && resp.connection ? resp.connection : { state: 'offline', port: 19633 };
-      const copy = self.HIBIKI_CONNECTION.copy(c.state, c.port);
-      if (connEl) connEl.dataset.tone = copy.tone;
-      if (connTitleEl) connTitleEl.textContent = copy.title;
-      if (connDetailEl) connDetailEl.textContent = copy.detail;
-      if (connEl) connEl.title = copy.detail;
-    });
-  } catch (_) {}
+  // BUG-1036：popup 生命周期很短，每次打开都要新探测；否则会把上次瞬时离线缓存继续显示成
+  // “Hibiki API 未开启”，直到用户进完整设置手动重检。
+  // TODO-1881：探测抽成函数——连接状态行本身可点，点击即强制重检（原来重试只能进 options 页）。
+  function refreshConnection() {
+    if (connEl) connEl.dataset.tone = 'loading';
+    if (connTitleEl) connTitleEl.textContent = '正在检测 Hibiki…';
+    if (connDetailEl) connDetailEl.textContent = '查词与字幕服务';
+    try {
+      chrome.runtime.sendMessage({ type: 'connectionStatus', force: true }, (resp) => {
+        try { if (chrome.runtime.lastError) return; } catch (_) { return; }
+        const c = resp && resp.connection ? resp.connection : { state: 'offline', port: 19633 };
+        const copy = self.HIBIKI_CONNECTION.copy(c.state, c.port);
+        if (connEl) connEl.dataset.tone = copy.tone;
+        if (connTitleEl) connTitleEl.textContent = copy.title;
+        if (connDetailEl) connDetailEl.textContent = copy.detail;
+        if (connEl) connEl.title = copy.detail + '（点击重新检测）';
+      });
+    } catch (_) {}
+  }
+  refreshConnection();
+  if (connEl) connEl.addEventListener('click', () => refreshConnection());
   const optionsEl = document.getElementById('hp-open-options');
-  if (optionsEl) optionsEl.addEventListener('click', () => chrome.runtime.openOptionsPage());
+  if (optionsEl) {
+    optionsEl.addEventListener('click', (e) => {
+      e.stopPropagation(); // 齿轮在连接行内：别把点击冒泡成「重新检测」
+      chrome.runtime.openOptionsPage();
+    });
+  }
 
   function readQueue() {
     return new Promise((resolve) => {
@@ -86,9 +169,40 @@ if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.s
     render(remaining);
   }
 
+  // TODO-1881：清空队列（原来 N 条要点 N 次 ×）。二次确认：首点变「确认清空？」，3 秒内再点才清。
+  let clearConfirmTimer = null;
+  async function clearQueue() {
+    try { await chrome.storage.local.set({ hibikiQueue: [] }); } catch (_) {}
+    render([]);
+  }
+
+  // ── TODO-1881：生成按钮状态机接线 ──
+  // popup 打开时 query 一次当前 tab（popup 绑定于当前窗口活动 tab，生命周期内不变）；
+  // 队列/批量状态经 storage.onChanged 实时驱动重算。
+  let genTab = null; // {id,url}；query 回来前按 other 站点渲染（按钮先禁用，回来后立即修正）
+  function updateGenButton(queue, batch) {
+    if (!genEl) return;
+    const state = hibikiGenButtonState(queue, !!(batch && batch.active), hibikiTabSite(genTab && genTab.url));
+    genEl.textContent = state.label;
+    genEl.disabled = !state.enabled;
+    genEl.dataset.mode = state.mode;
+    if (genHintEl) {
+      genHintEl.textContent = state.hint;
+      genHintEl.hidden = !state.hint;
+    }
+  }
+  function refreshGenButton(queue) {
+    try {
+      chrome.storage.local.get(['hibikiNfBatch'], (r) => {
+        updateGenButton(queue, r && r.hibikiNfBatch);
+      });
+    } catch (_) { updateGenButton(queue, null); }
+  }
+
   function render(queue) {
     const list = Array.isArray(queue) ? queue : [];
     if (countEl) countEl.textContent = list.length ? String(list.length) : '';
+    refreshGenButton(list);
     if (!listEl) return;
     listEl.textContent = '';
     if (!list.length) {
@@ -101,7 +215,29 @@ if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.s
     // TODO-1222：给队列列表加一行标题头（与顶部应用标题区分：这里标注下方是「待生成的卡片」）。
     const heading = document.createElement('div');
     heading.className = 'hp-list-title';
-    heading.textContent = '待生成的卡片（' + list.length + '）';
+    const headingText = document.createElement('span');
+    headingText.textContent = '待生成的卡片（' + list.length + '）';
+    heading.appendChild(headingText);
+    // TODO-1881：清空按钮（二次确认）挂在标题行右侧。
+    const clearBtn = document.createElement('button');
+    clearBtn.className = 'hp-clear';
+    clearBtn.type = 'button';
+    clearBtn.textContent = '清空';
+    clearBtn.addEventListener('click', () => {
+      if (clearBtn.dataset.confirm === '1') {
+        if (clearConfirmTimer) { clearTimeout(clearConfirmTimer); clearConfirmTimer = null; }
+        clearQueue();
+        return;
+      }
+      clearBtn.dataset.confirm = '1';
+      clearBtn.textContent = '确认清空？';
+      if (clearConfirmTimer) clearTimeout(clearConfirmTimer);
+      clearConfirmTimer = setTimeout(() => {
+        clearBtn.dataset.confirm = '';
+        clearBtn.textContent = '清空';
+      }, 3000);
+    });
+    heading.appendChild(clearBtn);
     listEl.appendChild(heading);
     for (const q of list) {
       const row = document.createElement('div');
@@ -127,7 +263,17 @@ if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.s
         sub.textContent = context;
         main.appendChild(sub);
       }
-      main.title = context ? (label + ' — ' + context) : label;
+      // TODO-1881：条目可点击跳回对应视频页（Netflix 生成必须在其页面；wrongSite hint 引导到这里）。
+      const jumpUrl = hibikiQueueItemUrl(q);
+      if (jumpUrl) {
+        main.dataset.url = jumpUrl;
+        main.title = (context ? (label + ' — ' + context) : label) + '\n点击打开视频页';
+        main.addEventListener('click', () => {
+          try { chrome.tabs.create({ url: jumpUrl }); } catch (_) {}
+        });
+      } else {
+        main.title = context ? (label + ' — ' + context) : label;
+      }
       const del = document.createElement('button');
       del.className = 'hp-del';
       del.type = 'button';
@@ -184,13 +330,24 @@ if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.s
   }
 
   // 队列在别处（content 入队 / 生成出队 / 别的标签）变化时，popup 若还开着就实时刷新。
+  // TODO-1881：hibikiNfBatch 变化（生成开始/结束/取消）也要刷新按钮状态（取消↔生成切换）。
   try {
     chrome.storage.onChanged.addListener((changes, area) => {
-      if (area === 'local' && changes.hibikiQueue) {
+      if (area !== 'local') return;
+      if (changes.hibikiQueue) {
         render(Array.isArray(changes.hibikiQueue.newValue) ? changes.hibikiQueue.newValue : []);
+      } else if (changes.hibikiNfBatch) {
+        readQueue().then((q) => updateGenButton(q, changes.hibikiNfBatch.newValue));
       }
     });
   } catch (_) {}
 
+  // TODO-1881：先渲染（按钮按 other 站点保守禁用），tab query 回来后立即按真实站点修正。
   readQueue().then(render);
+  try {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      genTab = (tabs && tabs[0]) || null;
+      readQueue().then((q) => refreshGenButton(q));
+    });
+  } catch (_) {}
 }


### PR DESCRIPTION
## 背景

浏览器扩展的工具栏弹窗（action popup）是制卡队列的操作中枢，但有四个流程断点：

1. **「开始生成/录制」是隐形三态**：同一按钮承担「取消卡住的生成 / 开始生成 / 静默无操作」。队列空、或当前标签页不是 Netflix/YouTube 时，点击毫无反馈直接关弹窗。
2. **队列只能逐项删**：N 条要点 N 次 ×。
3. **队列条目不能跳转**：Netflix 批量生成必须在 netflix.com 页面才能启动，但用户在队列里看到卡片却没法一键回到对应视频页。
4. **连接状态行只读**：重试检测只能进完整设置页。

## 改动

- `hibikiGenButtonState(queue, batchActive, tabSite)` 纯函数状态机：
  - `cancel`：生成中/卡住残留 → 可点取消（逃生口保留，队列空也可点）
  - `generate`：当前站点与队列可生成项匹配 → 带数量标签（如「开始录制生成（2 张）」），跨站点剩余量进 hint
  - `empty` / `unsupported` / `wrongSite`：禁用 + 原因 hint（wrongSite 引导点队列条目跳转）
- 队列标题行加「清空」按钮（首点变「确认清空？」，3 秒内再点才清）
- 队列条目点击打开对应视频页（`hibikiQueueItemUrl`：NF watch / YT watch?v=，id URL 编码防注入）
- 连接状态行整行可点 = 强制重检（探测抽成 `refreshConnection`；齿轮 `stopPropagation`）
- `hibikiNfBatch` storage 变化实时驱动按钮取消↔生成切换

## 验证

- node 单测：`action-popup.test.js` 13/13 绿（新增 7 项覆盖三个纯函数全分支）
- Dart 守卫：`browser_extension_icon_popup_guard_test.dart` 加 TODO-1881 锚点，双镜像 24 项绿
- 镜像漂移：`browser_extension_installer_test.dart` 绿（tools/ 与 assets/ 字节一致）
- 既有 `word-audio.test.js` 4 红为 develop 基线既有环境性失败，与本 PR 无关（基线复测确认）
- ⚠️ 待真机：Chrome 加载已解压扩展后手动过一遍五态按钮/清空/跳转/重检

https://claude.ai/code/session_01Lp8WcPdoLi94krTKFQz5dG