### PR TITLE
docs(agent): 分级快车道工作流(难度分级+子代理分工+验证分级)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
   - 在主 checkout 的 `.worktrees/coordination/claims/` 复制 `_template.json` 新建自己的 claim；若当前位于 `.worktrees/<task>` worktree，则使用同级的 `../coordination/claims/`。
   - claim 写清任务、agent、分支、worktree、base SHA、预计修改文件和高冲突文件；普通任务 agent 只编辑自己的 claim，不在 tracked 文件里记录协调状态。
   - 普通任务 agent 不主动 rebase/merge `develop`；integration owner 统一读取 claims、决定合并顺序、更新 `develop`、跑 broad verification，并将完成/阻塞的 claim 移到 `done/` / `blocked/`。
-- 多使用子代理：遇到 2 个以上可独立推进的分析、审查、文件定位、测试诊断或实现子任务时，优先派发子代理并行处理；主代理负责整合结论、控制范围、复核关键证据和最终提交。不要把需要共享同一脏文件或强顺序依赖的步骤硬拆给多个子代理。子代理**按难度选模型**（fable=根因/架构/整合，opus=独立实现/测试/机械改动，haiku/Explore=定位盘点）、后台派发、绝不同一子任务双模型冗余；难度分级、标准并行时间线和空等禁止清单见 [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md)。
+- 多使用子代理：遇到 2 个以上可独立推进的分析、审查、文件定位、测试诊断或实现子任务时，优先派发子代理并行处理；主代理负责整合结论、控制范围、复核关键证据和最终提交。不要把需要共享同一脏文件或强顺序依赖的步骤硬拆给多个子代理。子代理后台派发、主代理不空等，绝不让两个代理重复做同一子任务；难度分级、标准并行时间线和空等禁止清单见 [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md)。
 - 根因修复：遇到功能异常、测试失败、运行时报错或用户要求修复，先复现或沿真实代码路径定位，再修数据结构、状态同步、生命周期、平台边界或依赖契约。不允许用延迟、重试、吞异常、硬编码、特例分支掩盖症状；只有外部系统或平台限制不可控时才允许临时兼容层，并说明影响范围和清理条件。
 - 函数和新增 Dart helper 要有明确类型签名。
 - 不从零重写现有功能；在当前实现上删减、合并、修正。
@@ -78,7 +78,7 @@
 
 | 要做的事 | 看这里 |
 |---|---|
-| 加功能/修 bug/合并的分级快车道：难度分级、opus/fable 模型分工、并行时间线、验证分级 | [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md) |
+| 加功能/修 bug/合并的分级快车道：难度分级、子代理分工、并行时间线、验证分级 | [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md) |
 | 5 平台构建 / Melos / bootstrap + 依赖补丁机制 / 发布通道与版本号规则 / galgame hook 注入器独立分发 | [docs/agent/build.md](docs/agent/build.md) |
 | 模拟器集成测试三层架构 / 焦点驱动（禁坐标点击）/ AnkiDroid provisioning / ADB 降级 / DB 查询 / 测试素材 | [docs/agent/integration-testing.md](docs/agent/integration-testing.md) |
 | 持续审查模式 / docs/reviews 报告格式 / 回归记录 | [docs/agent/review-process.md](docs/agent/review-process.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
   - 在主 checkout 的 `.worktrees/coordination/claims/` 复制 `_template.json` 新建自己的 claim；若当前位于 `.worktrees/<task>` worktree，则使用同级的 `../coordination/claims/`。
   - claim 写清任务、agent、分支、worktree、base SHA、预计修改文件和高冲突文件；普通任务 agent 只编辑自己的 claim，不在 tracked 文件里记录协调状态。
   - 普通任务 agent 不主动 rebase/merge `develop`；integration owner 统一读取 claims、决定合并顺序、更新 `develop`、跑 broad verification，并将完成/阻塞的 claim 移到 `done/` / `blocked/`。
-- 多使用子代理：遇到 2 个以上可独立推进的分析、审查、文件定位、测试诊断或实现子任务时，优先派发子代理并行处理；主代理负责整合结论、控制范围、复核关键证据和最终提交。不要把需要共享同一脏文件或强顺序依赖的步骤硬拆给多个子代理。
+- 多使用子代理：遇到 2 个以上可独立推进的分析、审查、文件定位、测试诊断或实现子任务时，优先派发子代理并行处理；主代理负责整合结论、控制范围、复核关键证据和最终提交。不要把需要共享同一脏文件或强顺序依赖的步骤硬拆给多个子代理。子代理**按难度选模型**（fable=根因/架构/整合，opus=独立实现/测试/机械改动，haiku/Explore=定位盘点）、后台派发、绝不同一子任务双模型冗余；难度分级、标准并行时间线和空等禁止清单见 [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md)。
 - 根因修复：遇到功能异常、测试失败、运行时报错或用户要求修复，先复现或沿真实代码路径定位，再修数据结构、状态同步、生命周期、平台边界或依赖契约。不允许用延迟、重试、吞异常、硬编码、特例分支掩盖症状；只有外部系统或平台限制不可控时才允许临时兼容层，并说明影响范围和清理条件。
 - 函数和新增 Dart helper 要有明确类型签名。
 - 不从零重写现有功能；在当前实现上删减、合并、修正。
@@ -59,7 +59,7 @@
 ## 验证
 
 - 文档改动：至少 `git diff --cached --check`，不必跑 Flutter 测试。
-- Dart/Flutter 改动（在 `hibiki/` 下）：`dart format .` + `flutter test`（用项目钉定的工具链：本地 `.fvmrc` 3.41.6，CI 3.44.0；本机 flutter 不在 PATH 就把完整路径写进 `CLAUDE.local.md`）。
+- Dart/Flutter 改动（在 `hibiki/` 下）：`dart format` 改动文件 + push 前全量 `flutter analyze`（含 test 目录，CI 把 warning 当致命）+ **按爆炸半径分级的测试**——分支上跑改动覆盖 + 相邻功能的定向 `flutter test <目标> --no-pub`，全量套件由 PR CI 兜底（真单测门是 Build Release APK 的 Run unit tests）；**合入 `develop` 前仍必须本地全量 `flutter test`**。分级判据见 [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md)。（工具链钉定：本地 `.fvmrc` 3.41.6，CI 3.44.0；本机 flutter 不在 PATH 就把完整路径写进 `CLAUDE.local.md`。）
 - Android 资源/manifest/Gradle/权限/通知/前台服务/打包改动：再加 `gradlew :app:assembleRelease`（在 `hibiki/android/`；Windows 用 `.\gradlew.bat`）。
 - 阅读器/导入/播放/布局问题，声明「修好了」前必须用真实模拟器或用户指定设备复测原始失败路径并留证据（见 [docs/agent/integration-testing.md](docs/agent/integration-testing.md)）。
 - 集成测试操作真 app **一律焦点驱动（`FocusDriver` / `tester.sendKeyEvent`，禁止 `tester.tap` 或坐标点击）**：`Tab` 遍历→检测控件类型→Switch/按钮确认用 `Enter`（**不要用空格**——App 已把裸空格中和为 `DoNothingIntent`，焦点确认统一走 Enter / 手柄 A，见 `hibiki/lib/src/shortcuts/global_navigation.dart`）、Slider/Stepper/Segmented 用方向键→断言真写穿 DB/真生效→还原。同一份测试三端可跑（模拟器 `-d emulator-<port>` / Windows 离屏 `hibiki/tool/run_windows_itest.ps1` / Mac 跨机 `tool/run_mac_itest.ps1`），完整流程见 [docs/agent/integration-testing.md](docs/agent/integration-testing.md) 的「焦点驱动操作」。
@@ -78,6 +78,7 @@
 
 | 要做的事 | 看这里 |
 |---|---|
+| 加功能/修 bug/合并的分级快车道：难度分级、opus/fable 模型分工、并行时间线、验证分级 | [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md) |
 | 5 平台构建 / Melos / bootstrap + 依赖补丁机制 / 发布通道与版本号规则 / galgame hook 注入器独立分发 | [docs/agent/build.md](docs/agent/build.md) |
 | 模拟器集成测试三层架构 / 焦点驱动（禁坐标点击）/ AnkiDroid provisioning / ADB 降级 / DB 查询 / 测试素材 | [docs/agent/integration-testing.md](docs/agent/integration-testing.md) |
 | 持续审查模式 / docs/reviews 报告格式 / 回归记录 | [docs/agent/review-process.md](docs/agent/review-process.md) |

--- a/docs/agent/fast-workflow.md
+++ b/docs/agent/fast-workflow.md
@@ -1,0 +1,74 @@
+# 分级快车道：加功能 / 修 bug / 合并的提速流程
+
+目标：单功能或单 bug 从 ~30 分钟压到 **~10–15 分钟**。手段只有三个——**消灭空等、按难度分工、验证按爆炸半径分级**。本文件是 [CLAUDE.md](../../CLAUDE.md) 「多使用子代理」和「验证」条目的展开，不改变真机验收、发布通道、提交纪律等硬规则。
+
+## 现状 30 分钟花在哪（耗时解剖）
+
+| 阶段 | 现状耗时 | 浪费点 |
+|---|---|---|
+| worktree + full bootstrap | 3–5 min 串行阻塞 | 根因分析根本不需要 `.dart_tool`，却在干等 pub get |
+| 定位 / 根因分析 | 5–10 min 串行 | 多个独立疑点逐个查 |
+| 实现 | 5–10 min | 机械面（样板/测试/多文件同构改动）没拆出去 |
+| 验证 | 8–15 min | 小改动也跑全量 `flutter test`，而 CI 本来就会兜底 |
+| 收尾（bug 文档/commit/PR） | 2–3 min | 等测试跑完才开始写 |
+
+## 三条军规
+
+1. **永不空等**：任何 >30 秒的命令（bootstrap / test / gradle / build）一律 `run_in_background`，等待期间推进别的步骤。
+2. **按难度选模型**，绝不在同一子任务上双模型冗余（两个模型做同一件事 = 纯浪费）。
+3. **验证按爆炸半径分级**：分支上定向验证 + PR CI 兜底全量；合入 `develop` 前才要求本地全量。
+
+## 难度分级 × 模型分工
+
+| 级别 | 判据 | 谁干 | 分支上的验证 |
+|---|---|---|---|
+| **S 琐碎** | 文档、注释、单行改动、纯重命名 | 主代理直接干，**不派子代理**（派发开销 > 收益） | `git diff --cached --check`；涉及 Dart 再加定向 analyze |
+| **A 小修** | 单文件或单模块，根因明确 | 主代理修核心；测试可拆一个 opus 子代理并行写 | `flutter analyze` 全量 + 定向 `flutter test <目标> --no-pub` |
+| **B 功能 / 复杂 bug** | 跨模块、多文件、时序/状态/平台边界问题 | fable 定根因和数据结构；机械面（样板、i18n、多文件同构、测试）拆 opus 子代理并行 | 定向 + 相邻功能测试；全量交 PR CI |
+| **C 大型 / 长周期** | 多阶段、需分批审查 | 按 claim 拆多 agent；integration owner 统一收口 | 本地全量（bash 环境） |
+
+**模型速查**（Agent tool 的 `model` 参数）：
+
+- **fable**：主代理本体；根因分析、数据结构/架构决策、并发与时序 bug、多子代理结论整合、最终审查。
+- **opus**：可独立并行的实现子任务、测试编写、机械多文件修改、代码审查执行。
+- **haiku / Explore agent**：文件定位、grep 盘点、大范围扫描——只要结论，不要文件转储。
+
+**子代理纪律**（既有规则，重申）：`run_in_background: true` 派发；每个子代理给明确文件清单，避免撞同一脏文件；强顺序依赖的步骤别硬拆；子代理回传必须核关键证据（`git diff --stat` / `test -f` / grep），不可全信叙述。
+
+## 标准时间线（B 级功能，目标 ~12 min）
+
+```
+t=0   EnterWorktree → setup_worktree -SkipBootstrap（秒级，只搬密钥）
+t=0   ↳ 后台: powershell -File tool/bootstrap.ps1  (run_in_background)
+t=0   ↳ 并行: 主代理读代码定根因；≥2 个独立疑点 → Explore/opus 子代理并行定位
+t=3   根因确定 → 主代理写核心修改；同时 opus 子代理并行写测试/机械面
+t=8   bootstrap 已就绪 → dart format 改动文件 + flutter analyze + 定向 test --no-pub
+t=8   ↳ 测试跑的同时: opus 子代理建 bug 文档 (dart run tool/bug.dart new)，
+      主代理写 commit message / PR 描述
+t=12  测试绿 → commit → push → draft PR（CI 跑全量兜底）
+```
+
+S/A 级同理裁剪：S 级连 worktree bootstrap 都可 `-SkipBootstrap` 到底（纯文档不需要 pub get）；A 级只是没有并行实现面。
+
+## 验证分级细则
+
+- **定向测试** = 改动直接覆盖的 test 文件 + 相邻功能的 test 文件，`flutter test test/<路径> --no-pub`。
+- **`flutter analyze` 全量在 push 前必跑**（含 test 目录）——它本身只要秒级~1 分钟，而 CI 把 warning 当致命，省这一步只会在 CI 上浪费一轮。
+- **分支 draft PR**：定向测试绿 + 全量 analyze 绿即可 push；全量 test 由 CI 兜底（真单测门是 **Build Release APK 的 Run unit tests**，不是 Build and Test）。声明「修好了」的真机复测门槛**不变**（[integration-testing.md](integration-testing.md)）。
+- **合入 `develop`**：integration owner 本地全量 analyze + 全量 test **不变**（bash 环境跑；别 `| tail` 吞退出码；别重叠跑锁 sqlite3.dll）。
+
+## 合并流水线（integration owner）
+
+落地范式不变：干净 worktree ff → merge → 解 i18n → analyze → bump。提速点：
+
+- 全量 test 在后台跑的**同时**，预解下一个 PR 的冲突和 i18n（流水线化，不是并行 merge）。
+- 多 PR 逐个 **rebase 叠加**，不做旧基底 merge——旧基底 merge 会静默删掉先落地 PR 的文件（并发合并竞态）。
+- 合并后核对以独立 `git diff --stat` 为准，不信子代理叙述。
+
+## 空等浪费禁止清单
+
+- ❌ 前台跑 bootstrap / 全量 test / gradle 并盯着输出——一律后台，期间推进其它步骤。
+- ❌ 同一疑点串行试三轮 grep——派一个 Explore 子代理一次扫完拿结论。
+- ❌ 测试跑完才开始写 bug 文档 / PR 描述。
+- ❌ 只为读几个文件就新建 worktree + full bootstrap——**只读/分析不需要 worktree**，直接在原工作区读。
+- ❌ 同一子任务派两个模型各做一遍「互相印证」——要印证就派**不同角度**（如实现 vs 反驳审查），不是重复劳动。

--- a/docs/agent/fast-workflow.md
+++ b/docs/agent/fast-workflow.md
@@ -14,36 +14,30 @@
 
 ## 三条军规
 
-1. **永不空等**：任何 >30 秒的命令（bootstrap / test / gradle / build）一律 `run_in_background`，等待期间推进别的步骤。
-2. **按难度选模型**，绝不在同一子任务上双模型冗余（两个模型做同一件事 = 纯浪费）。
+1. **永不空等**：任何 >30 秒的命令（bootstrap / test / gradle / build）一律后台跑，等待期间推进别的步骤。
+2. **按难度分工**：琐碎活主代理直接干（派发开销 > 收益）；机械面拆给子代理并行；根因、数据结构、整合这些错了会返工的难点主代理亲自把关。绝不让两个代理重复做同一件事。
 3. **验证按爆炸半径分级**：分支上定向验证 + PR CI 兜底全量；合入 `develop` 前才要求本地全量。
 
-## 难度分级 × 模型分工
+## 难度分级 × 分工
 
 | 级别 | 判据 | 谁干 | 分支上的验证 |
 |---|---|---|---|
 | **S 琐碎** | 文档、注释、单行改动、纯重命名 | 主代理直接干，**不派子代理**（派发开销 > 收益） | `git diff --cached --check`；涉及 Dart 再加定向 analyze |
-| **A 小修** | 单文件或单模块，根因明确 | 主代理修核心；测试可拆一个 opus 子代理并行写 | `flutter analyze` 全量 + 定向 `flutter test <目标> --no-pub` |
-| **B 功能 / 复杂 bug** | 跨模块、多文件、时序/状态/平台边界问题 | fable 定根因和数据结构；机械面（样板、i18n、多文件同构、测试）拆 opus 子代理并行 | 定向 + 相邻功能测试；全量交 PR CI |
+| **A 小修** | 单文件或单模块，根因明确 | 主代理修核心；测试可拆一个子代理并行写 | `flutter analyze` 全量 + 定向 `flutter test <目标> --no-pub` |
+| **B 功能 / 复杂 bug** | 跨模块、多文件、时序/状态/平台边界问题 | 主代理定根因和数据结构；机械面（样板、i18n、多文件同构、测试）拆子代理并行 | 定向 + 相邻功能测试；全量交 PR CI |
 | **C 大型 / 长周期** | 多阶段、需分批审查 | 按 claim 拆多 agent；integration owner 统一收口 | 本地全量（bash 环境） |
 
-**模型速查**（Agent tool 的 `model` 参数）：
-
-- **fable**：主代理本体；根因分析、数据结构/架构决策、并发与时序 bug、多子代理结论整合、最终审查。
-- **opus**：可独立并行的实现子任务、测试编写、机械多文件修改、代码审查执行。
-- **haiku / Explore agent**：文件定位、grep 盘点、大范围扫描——只要结论，不要文件转储。
-
-**子代理纪律**（既有规则，重申）：`run_in_background: true` 派发；每个子代理给明确文件清单，避免撞同一脏文件；强顺序依赖的步骤别硬拆；子代理回传必须核关键证据（`git diff --stat` / `test -f` / grep），不可全信叙述。
+**子代理纪律**（既有规则，重申）：后台派发，主代理不空等回传；每个子代理给明确文件清单，避免撞同一脏文件；强顺序依赖的步骤别硬拆；子代理回传必须核关键证据（`git diff --stat` / `test -f` / grep），不可全信叙述。
 
 ## 标准时间线（B 级功能，目标 ~12 min）
 
 ```
 t=0   EnterWorktree → setup_worktree -SkipBootstrap（秒级，只搬密钥）
-t=0   ↳ 后台: powershell -File tool/bootstrap.ps1  (run_in_background)
-t=0   ↳ 并行: 主代理读代码定根因；≥2 个独立疑点 → Explore/opus 子代理并行定位
-t=3   根因确定 → 主代理写核心修改；同时 opus 子代理并行写测试/机械面
+t=0   ↳ 后台: powershell -File tool/bootstrap.ps1
+t=0   ↳ 并行: 主代理读代码定根因；≥2 个独立疑点 → 子代理并行定位
+t=3   根因确定 → 主代理写核心修改；同时子代理并行写测试/机械面
 t=8   bootstrap 已就绪 → dart format 改动文件 + flutter analyze + 定向 test --no-pub
-t=8   ↳ 测试跑的同时: opus 子代理建 bug 文档 (dart run tool/bug.dart new)，
+t=8   ↳ 测试跑的同时: 子代理建 bug 文档 (dart run tool/bug.dart new)，
       主代理写 commit message / PR 描述
 t=12  测试绿 → commit → push → draft PR（CI 跑全量兜底）
 ```
@@ -68,7 +62,7 @@ S/A 级同理裁剪：S 级连 worktree bootstrap 都可 `-SkipBootstrap` 到底
 ## 空等浪费禁止清单
 
 - ❌ 前台跑 bootstrap / 全量 test / gradle 并盯着输出——一律后台，期间推进其它步骤。
-- ❌ 同一疑点串行试三轮 grep——派一个 Explore 子代理一次扫完拿结论。
+- ❌ 同一疑点串行试三轮 grep——派一个搜索子代理一次扫完拿结论。
 - ❌ 测试跑完才开始写 bug 文档 / PR 描述。
 - ❌ 只为读几个文件就新建 worktree + full bootstrap——**只读/分析不需要 worktree**，直接在原工作区读。
-- ❌ 同一子任务派两个模型各做一遍「互相印证」——要印证就派**不同角度**（如实现 vs 反驳审查），不是重复劳动。
+- ❌ 同一子任务派两个子代理各做一遍「互相印证」——要印证就派**不同角度**（如实现 vs 反驳审查），不是重复劳动。


### PR DESCRIPTION
## 背景

加一个功能要 ~30 分钟，别人只要 10 分钟。耗时解剖：full bootstrap 串行阻塞(3-5min)、分析串行、每改必全量 flutter test(8-15min)、收尾串行。

## 改动

- 新增 docs/agent/fast-workflow.md（Claude/Codex 通用，无模型/工具专属表述）：
  - 三条军规：永不空等(>30s 命令一律后台)、按难度分工(琐碎不派子代理、机械面拆子代理并行、难点主代理把关，绝不重复劳动)、验证按爆炸半径分级
  - S/A/B/C 难度分级表 + B 级 ~12min 标准并行时间线
  - 验证分级：分支上定向 test --no-pub + 全量 analyze，全量 test 由 PR CI 兜底；合入 develop 前本地全量不变；真机验收门槛不变
  - 合并流水线：全量 test 后台跑的同时预解下一 PR；rebase 叠加防旧基底 merge 竞态
  - 空等浪费禁止清单
- CLAUDE.md 三处接线：子代理条目、验证条目改分级、docs/agent 表加行

## 政策变化(需知悉)

分支 draft PR 不再要求本地全量 flutter test(改为定向测试+CI 兜底)；合入 develop 前的本地全量 analyze+test 保持不变。

https://claude.ai/code/session_017hS4okebw9GAR8aRyNrAqN