### PR TITLE
fix: 阅读时长被时钟重锚吃掉致统计爆表 (BUG-1042) + 内置 torrent 空闲常驻 DHT 致整机高延迟 (BUG-1043)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1002 条。点号进各自文件。
+> 共 1004 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1043](bugs/BUG-1043-embedded-torrent-dht-always-on.md) | ✅ | ✅ | 空闲也常驻 libtorrent/DHT（6881），整机网络周期性高延迟 |
+| [BUG-1042](bugs/BUG-1042-reading-time-lost-session-clock-reanchor.md) | ✅ | ✅ | 阅读时长被会话时钟重锚吃掉，速度/统计爆表（今日 0 分钟 / 125666 字·时⁻¹） |
 | [BUG-1035](bugs/BUG-1035-glossary-first-ignores-selected-dict.md) | ✅ | ✅ | 长按选中词典对制卡无效：{glossary-first} 恒取第一本，Lapis 默认无字段消费 {selected-glossary} |
 | [BUG-1034](bugs/BUG-1034-subtitle-row-extent-clip.md) | ✅ | ✅ | 视频字幕列表当前行末行文字被裁掉一半 |
 | [BUG-1033](bugs/BUG-1033-popup-zoom-tooltip-misfire.md) | ✅ | ✅ | 嵌套查词弹出时 A- 的「缩小查词字号」tooltip 自动弹出遮挡正文 |

--- a/docs/bugs/BUG-1042-reading-time-lost-session-clock-reanchor.md
+++ b/docs/bugs/BUG-1042-reading-time-lost-session-clock-reanchor.md
@@ -1,0 +1,79 @@
+## BUG-1042 · 阅读时长被会话时钟重锚吃掉，速度/统计爆表（今日 0 分钟 / 125666 字·时⁻¹）
+- **报告**：2026-07-24（用户截图「阅读统计」页）。今日 1832 字 / 时长 **0 分钟** / 速度 **125666 字·时⁻¹**；速度摘要「最快日 **421249 字·时⁻¹** · 07-22」。用户原话：「统计bug还在」（BUG-892 之后仍未好）。
+- **真实性**：✅ 真 bug。生产库对账坐实，根因见下（旧 `reader_hibiki_page.dart` resumed 分支 / `navigation.part.dart` `_onRestoreComplete` + `_flushReadingStats`）。
+- **[x] ① 已修复** — 见「修复」。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/audiobook/reading_time_tracker_delta_test.dart`（行为层：onDelta 与小时桶同源、stop 收尾结算、停表期间零增量、无 onDelta 向后兼容）+ `hibiki/test/media/audiobook/reading_time_tracker_gap_test.dart` 新增 `BUG-1042` 组（源码守卫：墙钟基准字段已删、恢复完成不重锚、早退不清累计器、PDF 不再整段过守卫）。
+- **备注**：真机复测（读一段带频繁查词的书 → 统计页速度回落到合理区间）待做。历史脏数据不会自动修正，见「未做」。
+
+### 证据（生产库对账）
+同一份 `hibiki.db` 里两条本应一致的时长账目差 4~600 倍——`reading_statistics`（每书/每日，喂
+KPI「时长」与「速度」）远小于 `reading_hourly_logs`（小时桶，喂「Today by hour」）：
+
+| dateKey | 字数 | reading_statistics | reading_hourly_logs |
+|---|---|---|---|
+| 2026-07-18 | 9454 | 84 分钟（6746 cph） | 345 分钟（1642 cph） |
+| 2026-07-19 | 6538 | 30 分钟（13020 cph） | 175 分钟（2238 cph） |
+| 2026-07-20 | 6333 | 19 分钟（19639 cph） | 39 分钟（9705 cph） |
+
+单行更极端：`2026-07-12 / 安達としまむら / 486 字 / 3850 ms` = 454442 cph——486 个日文字符
+不可能在 3.85 秒读完。**是时长这一侧被吃掉了**，字数侧正常。
+
+### 根因
+「每书/每日时长」与「小时桶」是**两个独立时钟**，前者那个是裸的墙钟基准且被多处无条件重锚：
+
+1. `hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart`
+   `_flushReadingStats`：`elapsedMs = now - _sessionStartTime`，且**首行以
+   `_sessionCharsRead <= 0` 早退**——早退时既不落库、也不消费这段时长。
+2. `hibiki/lib/src/pages/implementations/reader_hibiki_page.dart`
+   `didChangeAppLifecycleState` 的 `resumed` 分支：`_sessionStartTime = DateTime.now()`
+   （BUG-892 为「丢弃后台段」加的）。它**不区分**要丢的是后台段还是重锚前那段真实前台
+   阅读时长——配合 ① 的早退，形成确定性的时长蒸发：
+
+   > 翻一页（字数入账）→ 查词，窗口失焦（`inactive`）→ flush 落库 → 回来接着读**同一页**
+   > （高水位不变，`_sessionCharsRead` 恒 0）→ 再查一个词失焦 → flush **早退，不消费时长**
+   > → `resumed` 把 `_sessionStartTime` 推到当下 → **这一段阅读时长永久消失**。
+
+   截图那天「查词 1000 次 / 1832 字」——失焦-回前台上千次，绝大多数发生在没有新字数的时候，
+   于是当天只剩最后一小段（约 52 秒）落了库。
+3. 同一个 `_sessionStartTime` 还在 `_onRestoreComplete`（**每次重排版 / 重恢复都会跑**，不只
+   换章）里被无条件重置，同样在 flush 之前，同样吃掉未落库的时长。
+4. PDF 侧（`reader_pdf_page.dart` `_flushReadingStats`）是另一个变体、更糟：它把**整段会话**
+   `now - _sessionStartTime` 交给 `isContinuousReadingGap` 判一次，而 PDF 只在失焦/退出才
+   flush ⇒ 任何超过 `kMaxReadingGap`(120s) 的正常阅读会话被整段判成「非连续窗口」丢弃，
+   **读多久都记 0**。
+
+`ReadingTimeTracker`（小时桶）没有这个毛病：它按 60s tick 逐段结算、逐段过守卫，重锚吃不掉
+已结算的部分。所以两条账目才会分叉——错的一直是每书/每日那条。
+
+### 修复
+把两条账目并到**同一个**带 gap 守卫的时钟上，彻底删掉可被重锚的墙钟基准（消除特殊情况，
+而不是给每个重锚点打补丁）：
+
+- `packages/hibiki_audio/lib/src/audiobook/reading_time_tracker.dart`：新增
+  `ReadingTimeDelta onDelta` 回调——每确认一段连续窗口，写小时桶的**同时**把同一份增量回吐；
+  新增 `sampleNow()`（结算当前未满一个 tick 的窗口但**不停表**）与 `isRunning`。
+  守卫逻辑一字未改，BUG-892 的保护原样保留。
+- `reader_hibiki_page.dart` / `navigation.part.dart`：删除 `DateTime _sessionStartTime`，
+  换成 `int _sessionReadingMs`（只由 `onDelta` 累加、只由**真正落库**那条路径清零）。
+  `_flushReadingStats` 落库前先 `sampleNow()` 补上尾段；无新字数的早退**保留**累计器。
+  `resumed` 不再重锚（后台段由「tracker 停着不 tick」天然排除）；`_onRestoreComplete`
+  不再重锚（重排版不再吃时长）；失焦分支改成**先 `stop()` 再 flush**，让停表的收尾结算
+  先进累计器。
+- `reader_pdf_page.dart`：同款改造，并删掉「整段会话过一次守卫」那行——守卫改为逐 tick
+  生效（后台/睡眠照样不计，长会话正常累计）。
+
+### 影响面（须知，非 bug）
+统一时钟后，「每书/每日时长」会与「Today by hour」小时桶**对齐**——也就是说它现在会包含
+「阅读器开着 + app 在前台但用户没在翻页」的挂机时间（小时桶一直是这个口径，只是每书那条
+以前因为把时长吃掉了所以显不出来）。后台 / 熄屏 / 睡眠仍然不计（tracker 停表 + `kMaxReadingGap`
+守卫，BUG-892 的保护原样保留）。生产库里能看到极端例子：`2026-07-16` 全天只读 78 字，小时桶
+却有 5 小时——修复后这 5 小时会记到书上。若认为挂机不该算，需要另加「无翻页/无输入即暂停
+计时」的空闲判据（阈值是产品决策，未做）。
+
+### 未做（本轮范围外）
+- **挂机不计时的空闲判据**：见上「影响面」，需定阈值。
+- **历史脏数据不修正**：既有 `reading_statistics` 行仍是被吃掉后的值，统计页「最快日」等
+  极值仍会显示 421249 cph 这类爆表数。要么留着，要么另做一次性重算（可用同日
+  `reading_hourly_logs` 作参考基准），需用户决定，不在本轮。
+- **「速度」是否该忽略过短样本**：一天只读几十字时 cph 天然噪声大。BUG-892 尾部已记过
+  「阅读速度忽略过短翻页 + 设置项」的跟进，仍未做。

--- a/docs/bugs/BUG-1043-embedded-torrent-dht-always-on.md
+++ b/docs/bugs/BUG-1043-embedded-torrent-dht-always-on.md
@@ -1,0 +1,65 @@
+## BUG-1043 · 空闲也常驻 libtorrent/DHT（6881），整机网络周期性高延迟
+- **报告**：2026-07-24。用户原话：「每隔一段时间会造成高延迟，**没开 hibiki 互联**，给 hibiki 关了就不会出现了」。
+- **真实性**：✅ 真 bug，且在用户机上**实测取证**（见下）。根因 `hibiki/lib/src/models/app_model.dart` `startAnimeDownloadService`（旧行 2979-2985）。与「互联」无关——用户排除互联的直觉是对的，真凶是内置 torrent 引擎。
+- **[x] ① 已修复** — 见「修复」。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/torrent/embedded_torrent_lazy_session_test.dart`（源码守卫：启动路径不得建 session、后端工厂走懒建、就绪判定走能力探测、探测里不得建 session、`open()` 全 AppModel 只剩一个调用点）。
+- **备注**：真机复测（开着 Hibiki 不下载任何东西 → `Get-NetTCPConnection/Get-NetUDPEndpoint -OwningProcess <hibiki pid>` 应无 6881）待做。
+
+### 证据（用户机上运行中的 hibiki.exe，2026-07-24）
+```
+PID 96756  hibiki.exe
+TCP Listen  0.0.0.0:6881 / 192.168.1.30:6881 / 127.0.0.1:6881 / 198.18.0.1:6881
+UDP Listen  192.168.1.30:6881 / 127.0.0.1:6881 / 198.18.0.1:6881
+```
+6881 是 BitTorrent 默认端口；**UDP 6881 = DHT**。用户当时没有任何下载任务，也没配过外接
+qBittorrent。DHT 会持续向全球随机节点收发小 UDP 包（routing table 刷新是突发式的，正对上
+「每隔一段时间」），把家用路由器的 NAT / conntrack 表撑满，于是同机其它连接排队 → 整机延迟
+飙升；关掉 Hibiki，表项老化后恢复正常。
+
+### 根因
+`AppModel.startAnimeDownloadService()` 在 **app init 里无条件 fire-and-forget 调用**，其中：
+
+```dart
+if (_supportsEmbeddedTorrent()) {          // = 任意桌面平台
+  _embeddedTorrentHost = EmbeddedTorrentHost.open(...);   // ← 建 libtorrent session
+  _applyEmbeddedTorrentLimits(...);                        // ← enableDht 默认 true
+}
+```
+
+三个事实叠起来才成灾：
+1. `EmbeddedTorrentHost.open` 不是「准备一下」，它**创建 libtorrent session**：
+   `listenInterfaces = '0.0.0.0:6881'`、`enableDht = true`（`embedded_torrent_host.dart` 默认参数）。
+2. 门控只有 `_supportsEmbeddedTorrent()`（Windows/macOS/Linux 恒真），**完全没看用户是否有
+   下载任务、是否选了内置后端**。`QbConnectionConfig.backend` 默认 `auto`，桌面 resolve 成
+   `embedded`，所以「用户选内置后端」这个条件即使加上也是恒真。`EmbeddedTorrentHost` 的类
+   doc 写的是「app 启动时（桌面、**且用户选内置后端**）open 一次」——实现与自己的契约不符。
+3. `AnimeDownloadService._tickOnce` 本来就有「没有等待中的计划就不建连接」的早退，所以
+   **服务层面确实是空转的**；真正常驻烧网络的是那个已经开着的 session 本身。启动注释里写的
+   「未配置 qb 时每 tick 直接返回，无网络开销」只覆盖了 tick，没覆盖 session。
+
+顺带解释了为什么与「互联」无关：互联（`sync_server_enabled` / `sync_interconnect_enabled`）
+走的是自己的 HTTP server + mDNS，跟 6881 没关系。
+
+### 修复
+把「**内置引擎是否可用**」（能力）与「**是否已开一个 libtorrent session**」（资源）拆成两件事：
+
+- `embedded_torrent_host.dart` 新增 `static bool probeAvailable({String? libraryPath})`：
+  只 `EmbeddedTorrentEngine.open`（加载 DLL）、**不建 session、不绑端口、不碰网络**，结果静态
+  缓存（`DynamicLibrary` 本来也卸载不掉）。附 `resetAvailabilityProbeForTesting`。
+- `app_model.dart`：
+  - `startAnimeDownloadService` 只记下 `_embeddedTorrentSavePath`，**不再 open**；
+  - 新增 `EmbeddedTorrentHost? _ensureEmbeddedTorrentHost()`（幂等懒建 + 建好即铺资源限制）；
+  - `_torrentBackendFor` 在解析出内置后端时才调懒建——这正是「真的要用下载后端」那一刻，
+    而 `_tickOnce` 的「无计划不建连接」早退保证空闲用户永远走不到；
+  - `isEmbeddedTorrentReady` 改为能力探测（`_embeddedTorrentHost != null || probeAvailable()`），
+    这样下载对话框/下载页的「内置引擎就绪」不再逼着启动去开 session。
+
+行为不变的部分：有下载任务时照常用内置引擎；DLL 缺失照常回退外接 qb；session 一旦建起来，
+限速/DHT/上传策略等设置照旧即时生效。session 本来就不做断点续传恢复（无 resume data），
+所以懒建不会让「重启后续传」变差——那本来就没有。
+
+### 未做（本轮范围外）
+- **空闲时回收 session**：现在建起来之后活到 app 结束。更彻底的做法是「所有种子完成/移除后
+  关掉 session」，但要考虑做种策略（`setUploadPolicy` / 做种时长上限）的语义，另立跟进。
+- **DHT 是否该默认开**：即使真在下载，DHT 对纯 tracker 种子收益有限却噪声很大。设置里已有
+  `enableDht` 开关（`video_setting_torrent_dht`），默认值是否要翻成关，需用户定。

--- a/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
+++ b/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
@@ -11,9 +11,15 @@ import 'package:hibiki_torrent/hibiki_torrent.dart';
 /// （所有内置下载共享），按需派发短命 [EmbeddedTorrentBackend] 适配器给
 /// `AnimeDownloadService` 的每 tick 用（适配器 close 不连累会话）。
 ///
-/// 生命周期：app 启动时（桌面、且用户选内置后端）`open` 一次，AppModel
-/// 释放时 `dispose`。DLL 加载失败（未构建/缺依赖）返回 null，上层回退外接
+/// 生命周期：**首次真的要用下载后端时**懒建（见 `AppModel._ensureEmbeddedTorrentHost`），
+/// AppModel 释放时 `dispose`。DLL 加载失败（未构建/缺依赖）返回 null，上层回退外接
 /// qb 或静默不动作，绝不 crash 启动流程。
+///
+/// BUG-1043：绝不能在 app 启动时无条件 [open]。[open] 会创建 libtorrent session ——
+/// 绑 6881（TCP+UDP，全网卡）并**默认开 DHT**，于是一个种子都没有的用户，只要开着
+/// Hibiki 就在持续收发全球 DHT 小包，把家用路由器的 NAT/conntrack 表撑爆，表现为
+/// 「每隔一段时间整机网络高延迟，关掉 Hibiki 就好」。能力探测请用 [probeAvailable]，
+/// 它只加载 DLL、**不建 session、不碰网络**。
 ///
 /// 反吸血：持有全局单例 [AntiLeechEngine]（共享连坐段），`sweepAntiLeech`
 /// 每次把所有种子的 peer 喂进引擎判定，新增封段全量重建 libtorrent
@@ -91,6 +97,35 @@ class EmbeddedTorrentHost {
   }
 
   static int _defaultClockMs() => DateTime.now().millisecondsSinceEpoch;
+
+  /// 缓存的能力探测结果（DLL 只需加载一次，`DynamicLibrary` 也无法卸载）。
+  static bool? _availabilityCache;
+
+  /// 内置引擎在本机是否可用——**只加载 DLL，不创建 session**（不绑端口、不起
+  /// DHT、不产生任何网络流量）。
+  ///
+  /// BUG-1043：UI 的「内置引擎就绪」判定（下载对话框/下载页）以前是
+  /// `_embeddedTorrentHost != null`，逼得 AppModel 必须在启动时就把真 session 开
+  /// 起来才能让按钮可用。拆成「能力探测」与「真实会话」两件事之后，就绪判定走
+  /// 这里，session 留到真的要下载时再建。
+  static bool probeAvailable({String? libraryPath}) {
+    final bool? cached = _availabilityCache;
+    if (cached != null) return cached;
+    bool ok;
+    try {
+      EmbeddedTorrentEngine.open(libraryPath: libraryPath);
+      ok = true;
+    } on ArgumentError {
+      ok = false; // DLL 缺失/未构建
+    } on Object {
+      ok = false;
+    }
+    _availabilityCache = ok;
+    return ok;
+  }
+
+  /// 仅测试用：清掉 [probeAvailable] 的缓存。
+  static void resetAvailabilityProbeForTesting() => _availabilityCache = null;
 
   /// 应用用户可调的全局资源限制（速率 + 连接数）。[downloadKbps]/[uploadKbps]
   /// 单位 KB/s（0 = 不限），[maxConnections]（0 = 引擎默认）。config 变更时

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -2959,10 +2959,36 @@ class AppModel with ChangeNotifier {
   AnimeDownloadSubscriptionService? get animeDownloadSubscriptionService =>
       _animeDownloadSubscriptionService;
 
-  /// 内置 libtorrent 下载宿主（桌面且用户选内置后端时懒建；DLL 缺失/加载
-  /// 失败为 null，服务回退外接 qb）。app 释放时 dispose。
+  /// 内置 libtorrent 下载宿主。**懒建**：只在第一次真的要用下载后端时才创建
+  /// （见 [_ensureEmbeddedTorrentHost]）；DLL 缺失/加载失败为 null，服务回退外接
+  /// qb。app 释放时 dispose。
+  ///
+  /// BUG-1043：以前是在 [startAnimeDownloadService] 里对**所有桌面用户无条件**
+  /// 创建——而创建 = 起一个 libtorrent session（绑 6881 TCP+UDP + 默认开 DHT）。
+  /// 于是没有任何下载任务的用户，只要 Hibiki 开着就一直在跑全球 DHT，路由器
+  /// NAT/conntrack 被小包撑爆 → 整机网络周期性高延迟，关掉 Hibiki 即恢复。
   EmbeddedTorrentHost? _embeddedTorrentHost;
   EmbeddedTorrentHost? get embeddedTorrentHost => _embeddedTorrentHost;
+
+  /// 内置下载根目录（懒建 host 时需要）。[startAnimeDownloadService] 里算好存下，
+  /// 避免懒建路径再去 await 一次目录解析。
+  String? _embeddedTorrentSavePath;
+
+  /// 需要真会话时才建（幂等）。不支持的平台 / 无保存路径 / DLL 不可用 → null，
+  /// 调用方自然回退外接 qb。
+  EmbeddedTorrentHost? _ensureEmbeddedTorrentHost() {
+    final EmbeddedTorrentHost? existing = _embeddedTorrentHost;
+    if (existing != null) return existing;
+    final String? savePath = _embeddedTorrentSavePath;
+    if (savePath == null || !_supportsEmbeddedTorrent()) return null;
+    final EmbeddedTorrentHost? host =
+        EmbeddedTorrentHost.open(baseSavePath: savePath);
+    if (host == null) return null;
+    _embeddedTorrentHost = host;
+    // 建好即把已保存的资源限制/会话设置铺上（不必等用户改设置）。
+    _applyEmbeddedTorrentLimits(prefsRepo.qbConnectionConfig);
+    return host;
+  }
 
   /// 启动番剧下载完成监听。幂等（重复调用不重建）；失败由调用方记日志，不破坏 init。
   Future<void> startAnimeDownloadService() async {
@@ -2974,15 +3000,13 @@ class AppModel with ChangeNotifier {
     _animeDownloadPlanStore = store;
 
     // 内置引擎宿主：仅桌面（Android/iOS 阶段4/5 再定），且下载根目录就在
-    // 计划目录旁的 `content/` 子目录（分类再往下分）。DLL 未随包/未构建时
-    // open 返回 null，工厂自然回退 qb。
-    if (_supportsEmbeddedTorrent()) {
-      _embeddedTorrentHost = EmbeddedTorrentHost.open(
-        baseSavePath: path.join(baseDir.path, 'content'),
-      );
-      // 启动即把已保存的资源限制铺到宿主（不必等用户改设置）。
-      _applyEmbeddedTorrentLimits(prefsRepo.qbConnectionConfig);
-    }
+    // 计划目录旁的 `content/` 子目录（分类再往下分）。
+    //
+    // BUG-1043：这里**只记路径，不建 session**。真正的 libtorrent session 会绑
+    // 6881 并起 DHT，对没有下载任务的用户是纯粹的网络噪声（整机延迟）。改由
+    // [_ensureEmbeddedTorrentHost] 在第一次真要用后端时懒建；`_tickOnce` 本就
+    // 「没有等待中的计划就不建连接」，所以空闲用户永远不会走到那一步。
+    _embeddedTorrentSavePath = path.join(baseDir.path, 'content');
 
     _animeDownloadService = AnimeDownloadService(
       store: store,
@@ -3029,9 +3053,18 @@ class AppModel with ChangeNotifier {
     return imported;
   }
 
-  /// 内置引擎宿主是否就绪（桌面且 DLL 已加载）。下载对话框据此判断能否走
+  /// 内置引擎在本机是否可用（桌面 + DLL 能加载）。下载对话框据此判断能否走
   /// 内置引擎（不必配置外接 qb）。
-  bool get isEmbeddedTorrentReady => _embeddedTorrentHost != null;
+  ///
+  /// BUG-1043：这是**能力探测**，不代表已经开了 session。以前它等价于
+  /// `_embeddedTorrentHost != null`，逼得启动就必须建 session（= 绑 6881 + 起
+  /// DHT）才能让下载按钮可用。现在探测只加载 DLL、不碰网络，真会话由
+  /// [_ensureEmbeddedTorrentHost] 在要下载时才建。
+  bool get isEmbeddedTorrentReady =>
+      _embeddedTorrentHost != null ||
+      (_supportsEmbeddedTorrent() &&
+          _embeddedTorrentSavePath != null &&
+          EmbeddedTorrentHost.probeAvailable());
 
   /// 按配置解析出应使用的下载后端（供下载对话框的推送按钮与轮询服务共用
   /// 同一选择逻辑）。调用方用完须 `close()`（内置引擎的视图 close 是 no-op，
@@ -3042,9 +3075,13 @@ class AppModel with ChangeNotifier {
   /// 后端选择：配置选内置且宿主可用 → 内置引擎的共享 session 视图；否则
   /// 外接 qBittorrent（默认 / 内置不可用时的回退）。
   TorrentBackend _torrentBackendFor(QbConnectionConfig config) {
-    final EmbeddedTorrentHost? host = _embeddedTorrentHost;
     final String backend =
         config.resolveBackend(isDesktop: _supportsEmbeddedTorrent());
+    // BUG-1043：到这里才是「真的要用下载后端」，session 在此懒建（幂等）。
+    final EmbeddedTorrentHost? host =
+        backend == QbConnectionConfig.backendEmbedded
+            ? _ensureEmbeddedTorrentHost()
+            : _embeddedTorrentHost;
     if (backend == QbConnectionConfig.backendEmbedded && host != null) {
       return host.backendView();
     }

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -65,6 +65,10 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
         _reapplyChromeInsetsAfterFirstLoad();
         // TODO-700 T3：兜底超时路径也确定性落焦（门控见 helper）。
         _settleFocusOnContentReady();
+        // BUG-1042：兜底超时也要起阅读计时。计时器原本只在 [_onRestoreComplete]
+        // 里建/启，而这条路径正是「JS 迟迟不回 onRestoreComplete」——遮罩已摘、书能
+        // 读，却一秒都不记时长（字数照常累计 ⇒ 速度又爆表）。
+        _ensureReadingTimeTracker();
         HibikiToast.show(msg: t.reader_content_timeout);
       },
     );
@@ -140,9 +144,11 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
       success: true,
     );
 
-    _readingTimeTracker ??= ReadingTimeTracker(appModel.database);
-    _readingTimeTracker!.start();
-    _sessionStartTime = DateTime.now();
+    // BUG-1042：这里**不再**重锚任何会话时钟。本方法（恢复完成）每次重排版/重恢复
+    // 都会跑，旧代码在此重置 `_sessionStartTime`，把上一段还没落库的前台阅读时长整段
+    // 抹掉。[_ensureReadingTimeTracker] 的 start() 对已在跑的计时器是 no-op，重排版
+    // 不打断计时。
+    _ensureReadingTimeTracker();
     // TODO-1192：session 水位只升不降。旧代码在此把水位无条件重置成恢复目标位置，
     // 跨章回读（往回翻章 → 恢复完成）会把水位下调到更靠前那章章首，导致重读那章
     // 正文被再次计入统计（字数虚高）。改用 [sessionWatermarkAfterRestore] 取
@@ -1181,15 +1187,34 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
   /// 供进程退出路径 await（TODO-086/BUG-191）；其余生命周期调用点 fire-and-forget
   /// （不 await 返回的 Future，行为同旧版）。计数器在发起写之前清零，保证同一段
   /// 时长/字数不会被重复累加。
+  /// BUG-1042：建好并启动阅读计时器（幂等）。
+  ///
+  /// 它是本页**唯一**的阅读时钟：既写每小时桶（`reading_hourly_logs`），又经 `onDelta`
+  /// 把同一份 gap 守卫增量喂给 [_sessionReadingMs]，由 [_flushReadingStats] 落进
+  /// `reading_statistics`。两条账目同源，任何一处重锚都不可能再吃掉时长。
+  void _ensureReadingTimeTracker() {
+    _readingTimeTracker ??= ReadingTimeTracker(
+      appModel.database,
+      onDelta: (int deltaMs) => _sessionReadingMs += deltaMs,
+    );
+    _readingTimeTracker!.start();
+  }
+
   Future<void> _flushReadingStats() async {
+    // BUG-1042：先把「上一次 tick 到现在」这段未满一个 tick 的窗口结算进
+    // [_sessionReadingMs]（不停表），否则每次落库都漏掉最多一个 tick 间隔。
+    _readingTimeTracker?.sampleNow();
     if (_sessionCharsRead <= 0 || _book == null) return;
     final DateTime now = DateTime.now();
-    final int elapsedMs = now.difference(_sessionStartTime).inMilliseconds;
+    // BUG-1042：时长来自 [_readingTimeTracker] 的 gap 守卫增量累计，不再是
+    // `now - _sessionStartTime` 墙钟差。早退路径（无新字数）不消费累计器，这段时长
+    // 留到下次真正落库时一并计入——旧实现在这里蒸发。
+    final int elapsedMs = _sessionReadingMs;
     final String dateKey = statDateKey(now);
     final int charsRead = _sessionCharsRead;
     final String title = _book!.title;
     _sessionCharsRead = 0;
-    _sessionStartTime = DateTime.now();
+    _sessionReadingMs = 0;
     try {
       await appModel.database.addReadingStatistic(
         title: title,

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -1151,7 +1151,17 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   // 只升不降）。统计字数只在越过它时增量计入，往返翻页不重复累计。导航/后台
   // flush 起新 session 时由调用方重置到当前位置。
   int _sessionMaxAbsoluteChars = 0;
-  DateTime _sessionStartTime = DateTime.now();
+
+  /// BUG-1042：本 session 尚未落库的阅读时长（ms），由 [_readingTimeTracker] 的
+  /// gap 守卫 tick 累加（见 `ReadingTimeTracker.onDelta`）。
+  ///
+  /// 取代旧的 `DateTime _sessionStartTime` 墙钟基准。旧实现的时长 = `now - 基准`，
+  /// 而这个基准被 **① 生命周期 resumed ② 章节恢复完成（`_onRestoreComplete`，含每次
+  /// 重排版/重恢复）** 无条件重置；只要重置发生在 `_flushReadingStats` 之前（后者又以
+  /// `_sessionCharsRead <= 0` 早退，根本不消费这段时长），这段真实前台阅读时长就被
+  /// 直接丢弃。查词越频繁（失焦→resumed 越多）丢得越狠，表现为「今日 1832 字 / 0 分钟
+  /// / 125666 字·时⁻¹」。累计器只增不重置、只由落库消费，任何时钟重锚都吃不掉它。
+  int _sessionReadingMs = 0;
 
   List<int> _chapterCharCounts = [];
   List<int> _chapterCumulativeChars = [];
@@ -2111,21 +2121,25 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
       // HBK-AUDIT-122: sync lyrics cue position before flushing so backgrounding
       // in lyrics mode persists the current playback position, not a stale scroll.
       _syncAndFlushPosition();
-      _flushReadingStats();
       // BUG-892: 进后台/失焦时停掉阅读时长计时——否则后台挂起、熄屏、睡眠期间的墙钟
       // 时长会在恢复时被一次性计入（34h 的书 / 单小时 >1h / 凌晨幻影阅读）。stop() 先
       // flush 退出瞬间的部分窗口（受 kMaxReadingGap 守卫）再 cancel。
+      //
+      // BUG-1042：必须**先 stop 再 flush 统计**。stop() 的收尾 flush 会把「最后一个
+      // tick 到失焦」这段经 onDelta 记进 [_sessionReadingMs]，随后落库才带得上它；
+      // 反过来（旧序）这段时长会留到下次 start 之后，而 resumed 路径曾把时钟整个重锚。
       _readingTimeTracker?.stop();
+      _flushReadingStats();
     } else if (state == AppLifecycleState.resumed) {
       // TODO-900: OS 层失焦（Alt+Tab 切窗）后 Flutter 不保证把 primaryFocus 归还到
       // 页级 [_focusNode]，导致切窗回来后页级 / 全局快捷键全死，且因是焦点状态而非可
       // 重建对象，只有重启 app 才靠 autofocus 抢回。对齐视频页 [_reclaimVideoFocusIfOwned]
       // 的 resumed 回收范式，把焦点收回正文（门控见 helper，绝不抢对话框 / 查词焦点）。
       _reclaimReaderFocusIfOwned();
-      // BUG-892: 恢复前台时重锚两条计时链，丢弃后台那段间隔——① 每书/每日时长走
-      // [_flushReadingStats] 的 `now - _sessionStartTime`，不重置就会把整段后台算进下次
-      // flush；② 每小时桶走 [ReadingTimeTracker]，重启定时器并重锚 tick 起点。
-      _sessionStartTime = DateTime.now();
+      // BUG-892 / BUG-1042: 后台那段间隔靠「计时器停着」丢弃，而不是靠回前台重锚一个
+      // 墙钟基准——后者会连同重锚前那段**真实前台阅读时长**一起抹掉（见
+      // [_sessionReadingMs] 注释）。这里只重启计时器并重锚 tick 起点；两条账目（小时桶
+      // + 每书每日）都由它同一份 gap 守卫增量驱动，不存在第二个可被重置的时钟。
       _readingTimeTracker?.start();
     }
   }

--- a/hibiki/lib/src/pages/implementations/reader_pdf_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_pdf_page.dart
@@ -64,7 +64,14 @@ class _ReaderPdfPageState extends BaseSourcePageState<ReaderPdfPage>
   bool _restoreDone = false;
 
   ReadingTimeTracker? _readingTimeTracker;
-  DateTime _sessionStartTime = DateTime.now();
+
+  /// BUG-1042：本 session 尚未落库的阅读时长（ms），由 [_readingTimeTracker] 的
+  /// gap 守卫 tick 累加。取代旧的 `DateTime _sessionStartTime` 墙钟基准——旧实现把
+  /// **整段** `now - _sessionStartTime` 交给 `isContinuousReadingGap` 判一次，而
+  /// PDF 侧只在退出/失焦才 flush，于是任何超过 120s 的正常阅读会话都整段被判成
+  /// 「非连续窗口」丢弃：读多久都记 0。改成按 tick 累计后，守卫仍逐 tick 生效
+  /// （后台/睡眠照样不计），长会话则正常累计。
+  int _sessionReadingMs = 0;
 
   /// 无文本层（扫描图 PDF）只提示一次。
   bool _noTextLayerNotified = false;
@@ -109,11 +116,13 @@ class _ReaderPdfPageState extends BaseSourcePageState<ReaderPdfPage>
     super.didChangeAppLifecycleState(state);
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.inactive) {
-      unawaited(_flushPosition());
+      // BUG-1042：先 stop（收尾 flush 把最后一段经 onDelta 记进累计器）再落库，
+      // 顺序同 EPUB 侧。
       _readingTimeTracker?.stop();
+      unawaited(_flushPosition());
     } else if (state == AppLifecycleState.resumed) {
-      // BUG-892 同款纪律：回前台必须重锚会话起点，否则整段后台时长被计入。
-      _sessionStartTime = DateTime.now();
+      // BUG-892 / BUG-1042: 后台那段靠「计时器停着」丢弃，不再重锚墙钟基准
+      // （那会连未落库的前台时长一起抹掉）。
       _readingTimeTracker?.start();
     }
   }
@@ -148,8 +157,11 @@ class _ReaderPdfPageState extends BaseSourcePageState<ReaderPdfPage>
       _lastSavedPageIndex = saved.sectionIndex;
     }
 
-    _readingTimeTracker ??= ReadingTimeTracker(db)..start();
-    _sessionStartTime = DateTime.now();
+    // BUG-1042：小时桶与每书/每日时长共用这一个带 gap 守卫的时钟（同 EPUB 侧）。
+    _readingTimeTracker ??= ReadingTimeTracker(
+      db,
+      onDelta: (int deltaMs) => _sessionReadingMs += deltaMs,
+    )..start();
     return _PdfBookLoad(path: path, row: row);
   }
 
@@ -217,19 +229,20 @@ class _ReaderPdfPageState extends BaseSourcePageState<ReaderPdfPage>
   /// PDF 无字数会被整段丢弃。这里以**时长**为触发条件，且 `charsRead` 恒 0——
   /// 「页数」绝不能塞进 charsRead，否则会污染统计页的「字数」口径与其派生指标。
   Future<void> _flushReadingStats() async {
+    // BUG-1042：先结算「上一次 tick 到现在」这段未满一个 tick 的窗口（不停表）。
+    _readingTimeTracker?.sampleNow();
     final EpubBookRow? row = _bookRow;
     if (row == null) return;
     final DateTime now = DateTime.now();
-    final int elapsedMs = now.difference(_sessionStartTime).inMilliseconds;
-    // 重锚会话起点，保证多次 flush 不重复计时。
-    _sessionStartTime = now;
-    // 太短的会话（<1s）不记账，避免生命周期抖动刷屏。
+    // BUG-1042：时长 = [_readingTimeTracker] 逐 tick 确认的累计增量。BUG-892 的
+    // `isContinuousReadingGap` 守卫仍然生效，但作用在**每个 tick 窗口**上（tracker
+    // 内部），不再拿整段会话去过一次守卫——旧写法让任何 >120s 的正常 PDF 阅读会话
+    // 被整段判成非连续窗口丢弃，读多久都记 0。
+    final int elapsedMs = _sessionReadingMs;
+    // 太短的会话（<1s）不记账，避免生命周期抖动刷屏；未达阈值时保留累计器，
+    // 留到下次 flush 一并计入（不丢时长）。
     if (elapsedMs < 1000) return;
-    // BUG-892 同款守卫：整段超过连续阅读窗口（例如后台挂起）视为非阅读，丢弃。
-    if (!isContinuousReadingGap(
-        now.subtract(Duration(milliseconds: elapsedMs)), now)) {
-      return;
-    }
+    _sessionReadingMs = 0;
     final String dateKey = statDateKey(now);
     try {
       await appModel.database.addReadingStatistic(

--- a/hibiki/test/media/audiobook/reading_time_tracker_delta_test.dart
+++ b/hibiki/test/media/audiobook/reading_time_tracker_delta_test.dart
@@ -1,0 +1,133 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+// BUG-1042：「每书/每日阅读时长」（reading_statistics.reading_time_ms）与「小时桶」
+// （reading_hourly_logs）此前是**两个独立时钟**——前者拿 `now - _sessionStartTime` 的
+// 墙钟差，后者走 ReadingTimeTracker 的 gap 守卫 tick。而 `_sessionStartTime` 被生命周期
+// resumed / 章节恢复完成无条件重锚，重锚前那段前台阅读时长直接蒸发（`_flushReadingStats`
+// 以 `_sessionCharsRead <= 0` 早退时压根不消费它）。生产库对账：同一天前者 84 分钟、
+// 后者 345 分钟。
+//
+// 修复把两条账目并到**同一个** tick 上：tracker 每确认一段连续窗口，既写小时桶，也把
+// 同一份增量经 onDelta 回吐给会话累计器。本测试锁定这个不变量。
+Future<HibikiDatabase> _openDb() async {
+  final HibikiDatabase db = HibikiDatabase.forTesting(NativeDatabase.memory());
+  addTearDown(db.close);
+  return db;
+}
+
+Future<int> _hourlyTotalMs(HibikiDatabase db) async {
+  final List<ReadingHourlyLogRow> rows = await db.getAllReadingHourlyLogs();
+  return rows.fold<int>(
+      0, (int a, ReadingHourlyLogRow r) => a + r.readingTimeMs);
+}
+
+/// 建 tracker 并登记「先停表排空写入、再关库」的 teardown。
+///
+/// `_write` 是 fire-and-forget 的 DB 写；若测试结束时先关库，未落盘的写会撞
+/// `This database has already been closed`。addTearDown 是 LIFO：本函数在
+/// [_openDb] 之后登记，因此排空先于 close 执行。
+ReadingTimeTracker _makeTracker(
+  HibikiDatabase db, {
+  ReadingTimeDelta? onDelta,
+}) {
+  final ReadingTimeTracker tracker = ReadingTimeTracker(db, onDelta: onDelta);
+  addTearDown(() async {
+    tracker.dispose();
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+  });
+  return tracker;
+}
+
+void main() {
+  group('ReadingTimeTracker.onDelta（每书时长与小时桶同源）', () {
+    test('sampleNow 结算的增量同时进小时桶和 onDelta，两者相等', () async {
+      final HibikiDatabase db = await _openDb();
+      int sessionMs = 0;
+      final ReadingTimeTracker tracker =
+          _makeTracker(db, onDelta: (int ms) => sessionMs += ms);
+
+      tracker.start();
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      tracker.sampleNow();
+      // _write 是 fire-and-forget 的 DB 写，给它落盘的机会。
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+
+      expect(sessionMs, greaterThan(0),
+          reason: 'onDelta 没回吐 → 每书时长恒 0（正是 BUG-1042 症状）');
+      expect(sessionMs, await _hourlyTotalMs(db),
+          reason: '两条账目必须来自同一个 tick，不得各算各的');
+    });
+
+    test('sampleNow 不停表：可以连续多次结算，增量累计不重复也不丢', () async {
+      final HibikiDatabase db = await _openDb();
+      int sessionMs = 0;
+      final ReadingTimeTracker tracker =
+          _makeTracker(db, onDelta: (int ms) => sessionMs += ms);
+
+      tracker.start();
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      tracker.sampleNow();
+      final int first = sessionMs;
+      expect(tracker.isRunning, isTrue, reason: 'sampleNow 不得停表');
+
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      tracker.sampleNow();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+
+      expect(sessionMs, greaterThan(first));
+      expect(sessionMs, await _hourlyTotalMs(db));
+    });
+
+    test('stop 的收尾结算也回吐 onDelta（失焦那一刻的部分窗口不丢）', () async {
+      final HibikiDatabase db = await _openDb();
+      int sessionMs = 0;
+      final ReadingTimeTracker tracker =
+          _makeTracker(db, onDelta: (int ms) => sessionMs += ms);
+
+      tracker.start();
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      tracker.stop();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+
+      expect(tracker.isRunning, isFalse);
+      expect(sessionMs, greaterThan(0), reason: 'BUG-1042：失焦瞬间的部分窗口必须结算进会话累计器');
+      expect(sessionMs, await _hourlyTotalMs(db));
+    });
+
+    test('停表期间不产生任何增量（后台时长永不入账，BUG-892 不回归）', () async {
+      final HibikiDatabase db = await _openDb();
+      int sessionMs = 0;
+      final ReadingTimeTracker tracker =
+          _makeTracker(db, onDelta: (int ms) => sessionMs += ms);
+
+      tracker.start();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      tracker.stop();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      final int afterStop = sessionMs;
+
+      // 「后台」期间：表停着，无论过多久都不该再累加。
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+      tracker.sampleNow();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+
+      expect(sessionMs, afterStop, reason: '停表后 sampleNow 必须是 no-op');
+      expect(sessionMs, await _hourlyTotalMs(db));
+    });
+
+    test('不传 onDelta 时行为不变（小时桶照常写，向后兼容）', () async {
+      final HibikiDatabase db = await _openDb();
+      final ReadingTimeTracker tracker = _makeTracker(db);
+
+      tracker.start();
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      tracker.stop();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+
+      expect(await _hourlyTotalMs(db), greaterThan(0));
+    });
+  });
+}

--- a/hibiki/test/media/audiobook/reading_time_tracker_gap_test.dart
+++ b/hibiki/test/media/audiobook/reading_time_tracker_gap_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
@@ -7,6 +8,14 @@ import 'package:hibiki_audio/hibiki_audio.dart';
 // 单小时 >1h / 凌晨幻影阅读）。根因是 ReadingTimeTracker 的 60s 定时器按墙钟差累加，
 // 缺视频侧早有的「异常大间隔整窗丢弃」守卫。本测试锁定移植过来的纯函数
 // isContinuousReadingGap / splitReadingTime（对照 video_watch_tracker_test）。
+/// 去掉整行注释后再做源码守卫匹配——本轮修复的注释里**刻意**保留了旧字段名
+/// （`_sessionStartTime`）作为历史说明，不能让它把「字段已删除」的断言判假。
+/// 只剥整行 `//` 注释，不碰行尾注释与字符串（本文件断言的目标都在代码行上）。
+String _codeOnly(String src) => src
+    .split('\n')
+    .where((String l) => !l.trimLeft().startsWith('//'))
+    .join('\n');
+
 void main() {
   group('isContinuousReadingGap (discard suspend/sleep timer gaps)', () {
     test('normal ~60s heartbeat window is continuous', () {
@@ -98,8 +107,9 @@ void main() {
   group('BUG-892 lifecycle wiring guards (reader page)', () {
     late String src;
     setUpAll(() {
-      src = File('lib/src/pages/implementations/reader_hibiki_page.dart')
-          .readAsStringSync();
+      src = _codeOnly(
+          File('lib/src/pages/implementations/reader_hibiki_page.dart')
+              .readAsStringSync());
     });
 
     test('进后台/失焦时停掉阅读计时器', () {
@@ -112,13 +122,87 @@ void main() {
           reason: 'BUG-892 回归：后台不停计时 → 挂起时长被计入');
     });
 
-    test('恢复前台时重置会话计时起点并重启计时器', () {
+    test('恢复前台时重启计时器（后台段靠「计时器停着」丢弃，不靠重锚墙钟）', () {
       final int resumed = src.indexOf('AppLifecycleState.resumed');
-      final String resumedBranch = src.substring(resumed, resumed + 600);
-      expect(
-          resumedBranch.contains('_sessionStartTime = DateTime.now()'), isTrue,
-          reason: 'BUG-892：不重置 _sessionStartTime → 每书时长把后台段算进下次 flush');
-      expect(resumedBranch.contains('_readingTimeTracker?.start()'), isTrue);
+      final String resumedBranch = src.substring(resumed, resumed + 900);
+      expect(resumedBranch.contains('_readingTimeTracker?.start()'), isTrue,
+          reason: 'BUG-892：不重启小时桶计时器 → 回前台后阅读时长不再记账');
+      // BUG-1042：这里曾经是 `_sessionStartTime = DateTime.now()`。那个重锚在丢弃
+      // 后台段的同时，把**重锚前那段还没落库的前台阅读时长**一并抹掉（`_flushReadingStats`
+      // 以 `_sessionCharsRead <= 0` 早退时根本不消费它）。查词频繁 = 失焦/回前台频繁
+      // = 几乎全部时长蒸发。现在后台段由「tracker 停着不 tick」天然排除，无需重锚。
+      expect(resumedBranch.contains('_sessionStartTime'), isFalse,
+          reason: 'BUG-1042 回归：resumed 重锚墙钟基准会吃掉未落库的前台阅读时长');
+    });
+  });
+
+  // ── BUG-1042：每书/每日时长与小时桶必须共用同一个带守卫的时钟 ──────────────
+  //
+  // 症状（用户 2026-07-23 反馈截图）：今日 1832 字 / 时长 0 分钟 / 速度 125666 字·时⁻¹，
+  // 「最快日」421249 字·时⁻¹。生产库对账坐实——同一天 reading_statistics 记 84 分钟，
+  // reading_hourly_logs 记 345 分钟；两条账目差 4 倍以上，前者是错的那条。
+  group('BUG-1042 单一时钟：会话时长累计器不被任何重锚吃掉', () {
+    test('EPUB 阅读器不再持有可被重置的墙钟基准字段', () {
+      final String page = _codeOnly(
+          File('lib/src/pages/implementations/reader_hibiki_page.dart')
+              .readAsStringSync());
+      final String nav = _codeOnly(File(
+              'lib/src/pages/implementations/reader_hibiki/navigation.part.dart')
+          .readAsStringSync());
+      // 字段本体必须已删除（注释里可以留历史说明，故只查声明与赋值形态）。
+      expect(page.contains('DateTime _sessionStartTime'), isFalse);
+      expect(page.contains('_sessionStartTime ='), isFalse);
+      expect(nav.contains('_sessionStartTime ='), isFalse);
+      // 取而代之：由 tracker 的 onDelta 累加的会话累计器。
+      expect(page.contains('int _sessionReadingMs = 0'), isTrue);
+      expect(nav.contains('onDelta:'), isTrue);
+      expect(nav.contains('_sessionReadingMs += deltaMs'), isTrue);
+    });
+
+    test('恢复完成（每次重排版都会跑）不得重锚会话时钟', () {
+      final String nav = _codeOnly(File(
+              'lib/src/pages/implementations/reader_hibiki/navigation.part.dart')
+          .readAsStringSync());
+      final int i = nav.indexOf('void _onRestoreComplete()');
+      expect(i, greaterThanOrEqualTo(0));
+      final int end = nav.indexOf('\n  void ', i + 10);
+      final String body = nav.substring(i, end > i ? end : i + 4000);
+      expect(body.contains('_sessionStartTime'), isFalse,
+          reason: 'BUG-1042 回归：重排版/重恢复会抹掉上一段未落库的阅读时长');
+      expect(body.contains('_sessionReadingMs = 0'), isFalse,
+          reason: 'BUG-1042 回归：恢复完成不得清空会话时长累计器');
+    });
+
+    test('无新字数的早退路径不清空累计器（时长留到下次落库）', () {
+      final String nav = _codeOnly(File(
+              'lib/src/pages/implementations/reader_hibiki/navigation.part.dart')
+          .readAsStringSync());
+      final int i = nav.indexOf('Future<void> _flushReadingStats()');
+      expect(i, greaterThanOrEqualTo(0));
+      final String body = nav.substring(i, math.min(i + 1600, nav.length));
+      final int guard = body.indexOf('_sessionCharsRead <= 0');
+      final int clear = body.indexOf('_sessionReadingMs = 0');
+      expect(guard, greaterThanOrEqualTo(0));
+      expect(clear, greaterThan(guard), reason: 'BUG-1042：累计器只能在真正落库那条路径上清零');
+      // 落库前必须先把「上一次 tick 到现在」这段补进累计器。
+      expect(body.indexOf('sampleNow()'), inInclusiveRange(0, guard),
+          reason: 'BUG-1042：不 sampleNow 每次落库都漏掉最多一个 tick 间隔');
+    });
+
+    test('PDF 阅读器不再拿整段会话去过一次 gap 守卫', () {
+      final String pdf = _codeOnly(
+          File('lib/src/pages/implementations/reader_pdf_page.dart')
+              .readAsStringSync());
+      expect(pdf.contains('DateTime _sessionStartTime'), isFalse);
+      expect(pdf.contains('int _sessionReadingMs = 0'), isTrue);
+      final int i = pdf.indexOf('Future<void> _flushReadingStats()');
+      expect(i, greaterThanOrEqualTo(0));
+      final String body = pdf.substring(i, i + 1400);
+      // 旧写法：if (!isContinuousReadingGap(now - elapsed, now)) return;
+      // → 任何 >120s 的正常 PDF 阅读会话被整段丢弃，读多久都记 0。
+      expect(body.contains('isContinuousReadingGap('), isFalse,
+          reason: 'BUG-1042 回归：整段会话过守卫 = 长会话时长恒为 0');
+      expect(body.contains('sampleNow()'), isTrue);
     });
   });
 }

--- a/hibiki/test/media/torrent/embedded_torrent_lazy_session_test.dart
+++ b/hibiki/test/media/torrent/embedded_torrent_lazy_session_test.dart
@@ -1,0 +1,89 @@
+// BUG-1043：Hibiki 桌面版一启动就无条件创建 libtorrent session（绑 6881 TCP+UDP、
+// DHT 默认开），哪怕用户一个下载任务都没有、也没配过 qBittorrent。持续的全球 DHT
+// 小包把家用路由器 NAT/conntrack 表撑爆 → 整机网络周期性高延迟，关掉 Hibiki 即恢复。
+//
+// 实测取证（2026-07-24，用户机上运行中的 hibiki.exe）：
+//   TCP Listen  0.0.0.0:6881 / 192.168.1.30:6881 / 127.0.0.1:6881
+//   UDP Listen  同上（UDP 6881 = DHT）
+//
+// 修复把「能力探测」与「真实会话」拆开：探测只加载 DLL 不碰网络，session 留到第一次
+// 真的要用下载后端时才懒建。本测试用源码守卫锁死这条不变量——真会话的行为层验证需要
+// 本地做种夹具 + DLL（见 embedded_torrent_host_test.dart，CI 上多半 skip），守不住
+// 「启动时不许开 session」这件事，故必须在源码层守。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _read(String relPath) => File(relPath).readAsStringSync();
+
+/// 截取 [src] 中从 [start] 起、到下一个同级成员声明为止的片段。
+String _memberBody(String src, String start, {int fallbackLen = 2500}) {
+  final int i = src.indexOf(start);
+  expect(i, greaterThanOrEqualTo(0), reason: '找不到 $start');
+  final int end = src.indexOf('\n  }', i);
+  return src.substring(i, end > i ? end + 4 : (i + fallbackLen));
+}
+
+void main() {
+  group('BUG-1043 内置 torrent 会话必须懒建（空闲用户不得跑 DHT）', () {
+    late String appModel;
+    late String host;
+
+    setUpAll(() {
+      appModel = _read('lib/src/models/app_model.dart');
+      host = _read('lib/src/media/torrent/embedded_torrent_host.dart');
+    });
+
+    test('startAnimeDownloadService 不得创建 libtorrent session', () {
+      final String body =
+          _memberBody(appModel, 'Future<void> startAnimeDownloadService()');
+      expect(body.contains('EmbeddedTorrentHost.open('), isFalse,
+          reason: 'BUG-1043 回归：启动即建 session = 空闲也在跑 DHT/占 6881');
+      // 只记保存路径，真会话交给懒建入口。
+      expect(body.contains('_embeddedTorrentSavePath'), isTrue);
+    });
+
+    test('后端工厂在真要用时才懒建（且仅内置后端路径）', () {
+      final String body =
+          _memberBody(appModel, 'TorrentBackend _torrentBackendFor(');
+      expect(body.contains('_ensureEmbeddedTorrentHost()'), isTrue,
+          reason: 'BUG-1043：内置后端路径必须走懒建入口');
+      expect(
+          appModel
+              .contains('EmbeddedTorrentHost? _ensureEmbeddedTorrentHost()'),
+          isTrue);
+    });
+
+    test('就绪判定走能力探测，不再等价于「已开 session」', () {
+      final int i = appModel.indexOf('bool get isEmbeddedTorrentReady');
+      expect(i, greaterThanOrEqualTo(0));
+      final String body = appModel.substring(i, i + 400);
+      expect(body.contains('EmbeddedTorrentHost.probeAvailable()'), isTrue,
+          reason: 'BUG-1043：就绪判定若仍要求 session 存在，启动就又得开 session');
+    });
+
+    test('probeAvailable 只加载引擎，绝不创建 session', () {
+      final int i = host.indexOf('static bool probeAvailable(');
+      expect(i, greaterThanOrEqualTo(0));
+      final int end = host.indexOf('\n  }', i);
+      final String body = host.substring(i, end > i ? end : i + 1200);
+      expect(body.contains('EmbeddedTorrentEngine.open('), isTrue);
+      expect(body.contains('EmbeddedTorrentSession.open('), isFalse,
+          reason: 'BUG-1043：探测里建 session 就等于没修');
+      // 探测不该需要保存路径（不落盘、不下载）。
+      expect(body.contains('baseSavePath'), isFalse);
+    });
+
+    test('只有 open() 建 session，且它只被懒建入口调用', () {
+      // 全仓（lib 下）对 EmbeddedTorrentHost.open 的调用点应当只剩懒建入口一处。
+      final Iterable<Match> hits =
+          RegExp(r'EmbeddedTorrentHost\.open\(').allMatches(appModel);
+      expect(hits.length, 1,
+          reason:
+              'BUG-1043：AppModel 里 open() 只应出现在 _ensureEmbeddedTorrentHost');
+      final String ensure = _memberBody(
+          appModel, 'EmbeddedTorrentHost? _ensureEmbeddedTorrentHost()');
+      expect(ensure.contains('EmbeddedTorrentHost.open('), isTrue);
+    });
+  });
+}

--- a/packages/hibiki_audio/lib/src/audiobook/reading_time_tracker.dart
+++ b/packages/hibiki_audio/lib/src/audiobook/reading_time_tracker.dart
@@ -44,14 +44,29 @@ List<(String, int, int)> splitReadingTime(DateTime start, DateTime now) {
 String _formatDateKey(DateTime d) =>
     '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
 
+/// 一次已确认的连续阅读增量（[ReadingTimeTracker] 的 tick 产物）。
+typedef ReadingTimeDelta = void Function(int deltaMs);
+
 class ReadingTimeTracker {
-  ReadingTimeTracker(this._database);
+  /// [onDelta]：每次 tick 确认一段连续阅读窗口时，把**同一份**毫秒增量回吐给调用方。
+  ///
+  /// BUG-1042：每书/每日阅读时长（`reading_statistics.reading_time_ms`）此前自己拿
+  /// `now - _sessionStartTime` 算墙钟差，与本 tracker 各算各的；而 `_sessionStartTime`
+  /// 被生命周期 resumed / 章节恢复完成等多处无条件重置，重置前那段前台阅读时长直接蒸发。
+  /// 现在两条账目共用**同一个**带 [isContinuousReadingGap] 守卫的时钟：本 tracker 记小时
+  /// 桶，[onDelta] 把同一增量喂给会话累计器，任何重置都不再能吃掉时长。
+  ReadingTimeTracker(this._database, {ReadingTimeDelta? onDelta})
+      : _onDelta = onDelta;
 
   final HibikiDatabase _database;
+  final ReadingTimeDelta? _onDelta;
   Timer? _timer;
   DateTime? _tickStart;
 
   static const _interval = Duration(seconds: 60);
+
+  /// 计时中（已 [start] 且未 [stop]）。后台期间恒 false，故后台时长永不入账。
+  bool get isRunning => _timer != null;
 
   void start() {
     if (_timer != null) return;
@@ -70,6 +85,12 @@ class ReadingTimeTracker {
     stop();
   }
 
+  /// 立刻结算当前这段未满一个 tick 的窗口（不停表）。
+  ///
+  /// 供每书/每日统计在落库前把「上一次 tick 到现在」这段补进 [onDelta]——否则每次
+  /// 落库都会漏掉最多一个 tick 间隔的时长。守卫与定时 tick 完全一致。
+  void sampleNow() => _flush();
+
   void _flush() {
     final start = _tickStart;
     if (start == null) return;
@@ -80,10 +101,13 @@ class ReadingTimeTracker {
     // 熄屏 / 睡眠 / 长 GC 停顿致定时器跨越非阅读窗口），整窗丢弃而非凭空计入阅读时长，
     // 并保证 [splitReadingTime] 输入恒 ≤ kMaxReadingGap（单次至多跨一个边界）。BUG-892。
     if (!isContinuousReadingGap(start, now)) return;
+    int accepted = 0;
     for (final (String dateKey, int hour, int ms)
         in splitReadingTime(start, now)) {
       _write(dateKey, hour, ms);
+      accepted += ms;
     }
+    if (accepted > 0) _onDelta?.call(accepted);
   }
 
   void _write(String dateKey, int hour, int deltaMs) {


### PR DESCRIPTION
用户 2026-07-24 反馈的两个问题，均已沿真实代码路径验真 + 生产数据/运行进程取证。

## BUG-1042 · 阅读统计速度爆表（今日 1832 字 / 0 分钟 / 125666 字·时⁻¹）

**不是显示问题，是阅读时长被吃掉了。** 生产库对账（同一份 hibiki.db 两条本该一致的账目）：

| dateKey | 字数 | reading_statistics | reading_hourly_logs |
|---|---|---|---|
| 2026-07-18 | 9454 | 84 分钟（6746 cph） | 345 分钟（1642 cph） |
| 2026-07-19 | 6538 | 30 分钟（13020 cph） | 175 分钟（2238 cph） |

单行极端：`2026-07-12 / 安達としまむら / 486 字 / 3850 ms` = 454442 cph。

**根因**：每书/每日时长与小时桶是两个独立时钟。前者是裸墙钟基准 `_sessionStartTime`，被
① `didChangeAppLifecycleState` 的 resumed 分支（BUG-892 为丢弃后台段所加）
② `_onRestoreComplete`（每次重排版/重恢复都跑）
无条件重置；而 `_flushReadingStats` 以 `_sessionCharsRead <= 0` 早退、不消费这段时长：

> 翻一页（字数入账）→ 查词失焦 → flush 落库 → 回来读**同一页**（无新字数）→ 再失焦 →
> flush **早退不消费** → resumed 把基准推到当下 → **这段阅读时长永久消失**

截图那天查词 1000 次 / 1832 字，于是只剩最后约 52 秒落库。PDF 侧是另一变体、更糟：把
**整段会话**交给 `isContinuousReadingGap` 判一次，任何 >120s 的正常阅读会话被整段丢弃。

**修复**：两条账目并到同一个带 gap 守卫的时钟。`ReadingTimeTracker` 新增 `onDelta`
（写小时桶时回吐同一份增量）+ `sampleNow()`（结算未满一 tick 的窗口但不停表）；阅读器删掉
`_sessionStartTime`，换成只由 onDelta 累加、只由真正落库路径清零的 `_sessionReadingMs`。
BUG-892 的后台保护改由「计时器停着不 tick」天然保证，守卫逻辑一字未改。

**影响面（须知）**：统一后每书时长会与小时桶对齐，即包含「阅读器开着+前台但没翻页」的挂机
时间（小时桶一直是这口径）。后台/熄屏/睡眠仍不计。若要排除挂机需另加空闲判据（阈值是产品
决策，未做）。

## BUG-1043 · 每隔一段时间整机网络高延迟，关掉 Hibiki 就好

用户机上运行中的 hibiki.exe（PID 96756）实测：
```
TCP Listen  0.0.0.0:6881 / 192.168.1.30:6881 / 127.0.0.1:6881
UDP Listen  192.168.1.30:6881 / 127.0.0.1:6881     ← UDP 6881 = DHT
```
用户当时没有任何下载任务，也没配过外接 qBittorrent。

**根因**：`AppModel.startAnimeDownloadService()` 在 app init 里无条件
`EmbeddedTorrentHost.open()`，而 open 就是建 libtorrent session（`0.0.0.0:6881`，
`enableDht` 默认 true）。门控只有 `_supportsEmbeddedTorrent()`（桌面恒真），完全不看有没有
下载任务；`backend` 默认 `auto` 在桌面又恒 resolve 成 `embedded`，所以 `EmbeddedTorrentHost`
类 doc 里写的「且用户选内置后端」实际也是恒真——实现与自己的契约不符。DHT 持续收发全球小
UDP 包撑爆路由器 NAT/conntrack。与「互联」无关（互联走自己的 HTTP server + mDNS）。

**修复**：拆开「能力」与「资源」。`probeAvailable()` 只加载 DLL、不建 session 不碰网络；
`_ensureEmbeddedTorrentHost()` 在 `_torrentBackendFor` 解析出内置后端时才懒建
（`_tickOnce` 本就「无待下载计划不建连接」，空闲永远走不到）；`isEmbeddedTorrentReady`
改走能力探测，不再逼着启动开 session。

## 验证

- `flutter analyze`（含 test）干净
- `flutter test` **12844 passed / 5 skipped / 0 failed**
- 新增测试：
  - `hibiki/test/media/audiobook/reading_time_tracker_delta_test.dart`（行为层：onDelta 与小时桶同源、stop 收尾结算、停表期间零增量、无 onDelta 向后兼容）
  - `reading_time_tracker_gap_test.dart` 新增 BUG-1042 组（源码守卫：墙钟基准已删、恢复完成不重锚、早退不清累计器、PDF 不再整段过守卫）
  - `hibiki/test/media/torrent/embedded_torrent_lazy_session_test.dart`（源码守卫：启动不建 session、后端工厂走懒建、就绪走探测、探测里不得建 session）

## 待办（真机）

- BUG-1042：频繁查词读一段书 → 统计页速度回落合理区间
- BUG-1043：不下载任何东西时 `Get-NetTCPConnection/Get-NetUDPEndpoint -OwningProcess <hibiki pid>` 应无 6881

⚠️ BUG-1043 的因果链有一环未直接证明：DHT 在跑是实测确认的，「它就是延迟元凶」是最强解释但
未做对照实验。**无需新版本即可验证**：设置 → 下载 → 会话设置 → 关掉 DHT（即时生效），看延迟
是否消失。

https://claude.ai/code/session_01N8S53aSQ4gPC1EFiQ86rUg