### PR TITLE
fix(galgame): 查词鼠标钩子移出主线程 + 捕获目标自动绑定启动的游戏 (BUG-1041/1042)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1003 条。点号进各自文件。
+> 共 1005 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1042](bugs/BUG-1042-gal-hook-window-autobind-late.md) | ✅ | ✅ | 捕获目标没有自动选中 Hibiki 启动的游戏（窗口迟到即永久停在 window_not_found） |
+| [BUG-1041](bugs/BUG-1041-galgame-lookup-mouse-hook-lag.md) | ✅ | ✅ | galgame 查词后鼠标移动全局卡顿（WH_MOUSE_LL 装在 Flutter 主线程） |
 | [BUG-1036](bugs/BUG-1036-extension-connection-reopen-stale.md) | ✅ | ✅ | 浏览器扩展重开后连接检测误报 API 未开启 |
 | [BUG-1035](bugs/BUG-1035-glossary-first-ignores-selected-dict.md) | ✅ | ✅ | 长按选中词典对制卡无效：{glossary-first} 恒取第一本，Lapis 默认无字段消费 {selected-glossary} |
 | [BUG-1034](bugs/BUG-1034-subtitle-row-extent-clip.md) | ✅ | ✅ | 视频字幕列表当前行末行文字被裁掉一半 |

--- a/docs/bugs/BUG-1041-galgame-lookup-mouse-hook-lag.md
+++ b/docs/bugs/BUG-1041-galgame-lookup-mouse-hook-lag.md
@@ -1,0 +1,10 @@
+## BUG-1041 · galgame 查词后鼠标移动全局卡顿（WH_MOUSE_LL 装在 Flutter 主线程）
+- **报告**：2026-07-24（用户：玩 galgame 时「点击查词鼠标移动都会变卡，不查就没事」）
+- **真实性**：✅ 真 bug —— 根因 `hibiki/windows/runner/global_lookup_window.cpp:456`（修复前；`Reveal` 与 `RevealStack` 两处相同代码）在 **Flutter platform 线程**上 `SetWindowsHookEx(WH_MOUSE_LL, ...)`。
+
+  `WH_MOUSE_LL` 是**同步**低级钩子：系统把每一个鼠标输入事件（含高频移动）投递到安装钩子那条线程的消息队列，等它返回或超时（`LowLevelHooksTimeout`，默认 300ms）才继续分发给前台程序。装在 platform 线程上，等于让全系统鼠标输入排在 Dart/Flutter 的帧与 platform channel 之后——galgame 会话里主线程本就在跑 hook 台词轮询 + 工作台页面重建 + 查词 WebView2，于是查词浮窗一出现，鼠标移动就跟着主线程忙闲一卡一卡；浮窗关闭（`Hide()` 卸钩子）即恢复，正好对上「不查就没事」。
+
+  回调本身对移动事件已是纯比较后 `CallNextHookEx`，所以问题不在回调工作量，而在**它所在的线程**。
+- **[x] ① 已修复** — 新增 `hibiki/windows/runner/low_level_mouse_hook.{h,cpp}`：进程级钩子承载线程（只跑 `GetMessage` 循环），`Arm`/`Disarm` 经 `PostThreadMessage` 装卸钩子；回调只读目标 HWND 几何（`GetWindowRect` + `PtInRect`）并 `PostMessage`（异步）把「屏幕坐标 + 是否落在窗口内」投回窗口线程，绝不 `SendMessage`。`GlobalLookupWindow` 侧：`MouseHookProc` 改为窗口线程上的 `HandleGlobalClick`，`HHOOK mouse_hook_` 改为每实例 `bool mouse_hook_armed_`（常驻剪贴板面板仍从不 arm，其 `Hide()` 不会卸掉瞬态查词覆盖窗的点击外关闭）。点击外关闭 / 转发给 host 的判定语义一字未改。
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/global_lookup_mouse_hook_thread_guard_test.dart`（源码守卫：查词窗口不得自行 `SetWindowsHookEx`；钩子文件必须有 `std::thread` + `GetMessage`；回调只 `PostMessage` 不 `SendMessage`；新源文件已进 runner CMake 目标）。纯 Win32 输入队列行为无法在 Dart 侧行为测试里复现，源码守卫是当前最强可落地层。
+- **备注**：native 改动，**待 Windows 真机复测**原始失败路径（galgame 会话中查词后移动鼠标）。

--- a/docs/bugs/BUG-1042-gal-hook-window-autobind-late.md
+++ b/docs/bugs/BUG-1042-gal-hook-window-autobind-late.md
@@ -1,0 +1,12 @@
+## BUG-1042 · 捕获目标没有自动选中 Hibiki 启动的游戏（窗口迟到即永久停在 window_not_found）
+- **报告**：2026-07-24（用户截图指向捕获工作台的「捕获目标」条：「这个没有自动选中 hibiki 启动的游戏」）
+- **真实性**：✅ 真 bug —— 两处，都在「Hibiki 明明知道自己刚启动的游戏 pid，却没把它当成已选中的目标」这条线上：
+  1. `hibiki/lib/src/mining/gal_hook_session_controller.dart:627`（修复前）：launch 后按 `gamePid` 找顶层窗口只是**一次性**轮询 `windowPollAttempts(20) × windowPollInterval(500ms)` = 10 秒，失败即 `phase=degraded / fallbackReason=window_not_found` 且**永不重试**。带启动器、壳解包（Enigma/Siglus）、首次着色器编译的游戏常常慢过 10 秒，首帧一错过就只能靠用户自己去点「捕获目标」条手动选窗口。
+  2. `hibiki/lib/src/pages/implementations/texthooker_page.dart:319`（修复前）：窗口选择器把系统全部顶层窗口平铺成一个无序 `SimpleDialog`，既不按会话 `gamePid` 排序、也没有任何预选/标注——等于让用户替 app 认它自己拉起的进程。
+- **[x] ① 已修复** —
+  - 会话侧：`_startWindowRebindWatch` / `_tryRebindWindow`（会话级 `Timer.periodic`，默认 2s，构造参数 `windowRebindInterval` 可注入）。绑定成功、会话换代（stop/重启/attach）、pid 变更即自停；`_stopSources` 统一回收。补绑只更新状态并把因 `window_not_found` 降级的会话恢复回真实 phase（有文本信号 → `running`，否则 `waitingSignals`），**不走 `bindWindow`**——那条路径会 `startAttachedCapture` 重启整条会话（launch 会话退化成 attach，正在跑的 engine hook 与已收台词一起丢）。
+  - 选择器侧：按 `gamePid` 把 Hibiki 启动的游戏排到第一条、加「当前游戏」标注（新 i18n key `external_window_current_game`）、并用 `ListTile(autofocus:)` 预置焦点（焦点驱动纪律：打开即落在正确窗口上，Enter 直接确认）。另外，选回**已绑定**的那个窗口现在是 no-op，不再触发上述会话重启。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/mining/gal_hook_session_controller_test.dart`：「窗口迟到时会话继续重绑，不停在 window_not_found」「会话停止后不再继续重绑窗口」两条行为测试（假 window loader 先返回空、后返回游戏窗口）。
+  - `hibiki/test/pages/texthooker_window_picker_guard_test.dart`：选择器源码守卫（按 `gamePid` 置顶、`autofocus`、选回已绑定窗口 no-op）。`_pickExternalWindow` 首行是 `Platform.isWindows` 门 + 静态 `WindowCaptureChannel` + 单例会话，widget 测试不可移植，故锁结构。
+- **备注**：**待 Windows 真机复测**——从游戏库/工作台启动带启动器或壳的游戏，确认窗口迟到时仍会自动绑上；并确认点开「捕获目标」条时当前游戏已在首位且带焦点。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39389 (2317 per locale)
+/// Strings: 39406 (2318 per locale)
 ///
-/// Built on 2026-07-23 at 12:58 UTC
+/// Built on 2026-07-23 at 17:11 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3091,6 +3091,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get pdf_bookmarks => 'Bookmarks';
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   String get pdf_bookmark_added => 'Bookmark added';
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -8345,6 +8346,8 @@ class _StringsAr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -13672,6 +13675,8 @@ class _StringsDe extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -19015,6 +19020,8 @@ class _StringsEs extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -24369,6 +24376,8 @@ class _StringsFr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -29650,6 +29659,8 @@ class _StringsId extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -34979,6 +34990,8 @@ class _StringsIt extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -40113,6 +40126,8 @@ class _StringsJa extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -45250,6 +45265,8 @@ class _StringsKo extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -50557,6 +50574,8 @@ class _StringsNl extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -55879,6 +55898,8 @@ class _StringsPtBr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -61184,6 +61205,8 @@ class _StringsRu extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -66434,6 +66457,8 @@ class _StringsTh extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -71716,6 +71741,8 @@ class _StringsTr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -76985,6 +77012,8 @@ class _StringsVi extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 // Path: <root>
@@ -81883,6 +81912,8 @@ class _StringsZhCn extends _StringsEn {
   String get pdf_bookmarks_empty => '还没有书签。';
   @override
   String get pdf_bookmark_added => '已添加书签';
+  @override
+  String get external_window_current_game => '当前游戏';
 }
 
 // Path: <root>
@@ -86935,6 +86966,8 @@ class _StringsZhHk extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get external_window_current_game => 'Current game';
 }
 
 /// Flat map(s) containing all translations.
@@ -91665,6 +91698,8 @@ extension on _StringsEn {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -96393,6 +96428,8 @@ extension on _StringsAr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -101142,6 +101179,8 @@ extension on _StringsDe {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -105890,6 +105929,8 @@ extension on _StringsEs {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -110644,6 +110685,8 @@ extension on _StringsFr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -115380,6 +115423,8 @@ extension on _StringsId {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -120131,6 +120176,8 @@ extension on _StringsIt {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -124844,6 +124891,8 @@ extension on _StringsJa {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -129561,6 +129610,8 @@ extension on _StringsKo {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -134305,6 +134356,8 @@ extension on _StringsNl {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -139046,6 +139099,8 @@ extension on _StringsPtBr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -143792,6 +143847,8 @@ extension on _StringsRu {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -148522,6 +148579,8 @@ extension on _StringsTh {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -153261,6 +153320,8 @@ extension on _StringsTr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -157995,6 +158056,8 @@ extension on _StringsVi {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }
@@ -162693,6 +162756,8 @@ extension on _StringsZhCn {
         return '还没有书签。';
       case 'pdf_bookmark_added':
         return '已添加书签';
+      case 'external_window_current_game':
+        return '当前游戏';
       default:
         return null;
     }
@@ -167401,6 +167466,8 @@ extension on _StringsZhHk {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'external_window_current_game':
+        return 'Current game';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "此 PDF 没有目录。",
   "pdf_bookmarks": "书签",
   "pdf_bookmarks_empty": "还没有书签。",
-  "pdf_bookmark_added": "已添加书签"
+  "pdf_bookmark_added": "已添加书签",
+  "external_window_current_game": "当前游戏"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2315,5 +2315,6 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "external_window_current_game": "Current game"
 }

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -229,6 +229,7 @@ class GalHookSessionController extends ChangeNotifier {
     Duration resourceAudioWait = const Duration(milliseconds: 1200),
     Duration resourceAudioPollInterval = const Duration(milliseconds: 80),
     int windowPollAttempts = 20,
+    Duration windowRebindInterval = const Duration(seconds: 2),
     Duration trackRefreshInterval = const Duration(seconds: 5),
     Listenable? endpointListenable,
     List<TexthookerEndpointStatus> Function()? endpointStatusLoader,
@@ -251,6 +252,7 @@ class GalHookSessionController extends ChangeNotifier {
         _resourceAudioWait = resourceAudioWait,
         _resourceAudioPollInterval = resourceAudioPollInterval,
         _windowPollAttempts = windowPollAttempts,
+        _windowRebindInterval = windowRebindInterval,
         _trackRefreshInterval = trackRefreshInterval,
         _endpointListenable =
             endpointListenable ?? TexthookerWsClientManager.instance,
@@ -283,6 +285,7 @@ class GalHookSessionController extends ChangeNotifier {
   final Duration _resourceAudioWait;
   final Duration _resourceAudioPollInterval;
   final int _windowPollAttempts;
+  final Duration _windowRebindInterval;
   final Duration _trackRefreshInterval;
   final Listenable _endpointListenable;
   final List<TexthookerEndpointStatus> Function() _endpointStatusLoader;
@@ -335,6 +338,9 @@ class GalHookSessionController extends ChangeNotifier {
   EngineHookGalAudioSource? _engineSource;
   Timer? _textPollTimer;
   Timer? _trackRefreshTimer;
+  // BUG-1042：launch 后游戏窗口尚未出现时的重绑监视（见 [_startWindowRebindWatch]）。
+  Timer? _windowRebindTimer;
+  bool _windowRebindInFlight = false;
   bool _pollInFlight = false;
   int _lastTextSeq = 0;
   int _eventId = 0;
@@ -657,8 +663,78 @@ class GalHookSessionController extends ChangeNotifier {
         'window.not_found',
         'Audio hook is active, but no game window was found for screenshots',
       );
+      // BUG-1042：开场那 10 秒只是「窗口通常多快出现」的经验值，不是硬事实——带启动器 /
+      // 壳解包 / 首次着色器编译的游戏常常更慢，而首帧一旦错过，旧实现就永久停在
+      // window_not_found，用户只能自己去点「捕获目标」条手动选窗口（明明是 Hibiki 自己
+      // 启动的进程）。绑定因此改成会话级监视：只要这条会话还活着且仍没有窗口，就继续
+      // 按同一个 pid 找，找到即自动绑上。
+      // gamePid 为空表示 hook 根本没拿到目标进程，没有可重试的匹配依据。
+      if (gamePid != null) _startWindowRebindWatch(generation, gamePid);
     }
     return true;
+  }
+
+  /// launch 会话的窗口重绑监视：周期性按 [gamePid] 找顶层窗口，找到就补上绑定并把
+  /// 因 `window_not_found` 降级的会话恢复回真实 phase（文本信号来了就是 running，
+  /// 否则还在等信号）。绑定成功 / 会话被换代（stop、重启、attach）即自停。
+  ///
+  /// 只更新状态，不走 [bindWindow]——那条路径是给「用户手动改绑另一个窗口」用的，
+  /// 会 [startAttachedCapture] 重启整条会话；这里 hook 已经在跑，重启只会丢台词。
+  void _startWindowRebindWatch(int generation, int gamePid) {
+    _windowRebindTimer?.cancel();
+    _windowRebindTimer = Timer.periodic(_windowRebindInterval, (Timer timer) {
+      if (generation != _operationGeneration ||
+          _state.boundWindow != null ||
+          _state.gamePid != gamePid) {
+        timer.cancel();
+        _windowRebindTimer = null;
+        return;
+      }
+      if (_windowRebindInFlight) return;
+      _windowRebindInFlight = true;
+      unawaited(
+        _tryRebindWindow(generation, gamePid).whenComplete(() {
+          _windowRebindInFlight = false;
+        }),
+      );
+    });
+  }
+
+  Future<void> _tryRebindWindow(int generation, int gamePid) async {
+    final List<ExternalWindowInfo> windows = await _windowListLoader();
+    if (generation != _operationGeneration ||
+        _state.boundWindow != null ||
+        _state.gamePid != gamePid) {
+      return;
+    }
+    for (final ExternalWindowInfo candidate in windows) {
+      if (candidate.pid != gamePid) continue;
+      _windowRebindTimer?.cancel();
+      _windowRebindTimer = null;
+      final bool degradedForWindow =
+          _state.phase == GalHookSessionPhase.degraded &&
+              _state.fallbackReason == 'window_not_found';
+      _setState(
+        _state.copyWith(
+          boundWindow: candidate,
+          gamePid: gamePid,
+          phase: degradedForWindow
+              ? (_state.textSignalReceived
+                  ? GalHookSessionPhase.running
+                  : GalHookSessionPhase.waitingSignals)
+              : _state.phase,
+          clearFallbackReason: degradedForWindow,
+        ),
+      );
+      _record(
+        GalHookEventSeverity.success,
+        'window',
+        'window.auto_bound_late',
+        'Bound the launched game window once it appeared',
+        details: <String, Object?>{'pid': gamePid, 'hwnd': candidate.hwnd},
+      );
+      return;
+    }
   }
 
   Future<void> stopCapture({bool keepBinding = true}) async {
@@ -1481,6 +1557,9 @@ class GalHookSessionController extends ChangeNotifier {
     _textPollTimer = null;
     _trackRefreshTimer?.cancel();
     _trackRefreshTimer = null;
+    _windowRebindTimer?.cancel();
+    _windowRebindTimer = null;
+    _windowRebindInFlight = false;
     _pollInFlight = false;
     final EngineHookGalAudioSource? engine = _engineSource;
     _engineSource = null;

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -316,24 +316,52 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       return;
     }
     if (!context.mounted) return;
+    // BUG-1042：Hibiki 自己启动的游戏必须在这份列表里「已经选好」。会话知道游戏 pid，
+    // 却把它和一屏无关窗口平铺在一起，等于让用户替 app 认自己刚拉起的进程。按 pid
+    // 把它排到第一条、标注出来并预置焦点：打开即落在正确的窗口上，回车就绑。
+    final int? gamePid = _session.state.gamePid;
+    final int? boundHwnd = _session.state.boundWindow?.hwnd;
+    final List<ExternalWindowInfo> ordered = <ExternalWindowInfo>[
+      ...windows
+          .where((ExternalWindowInfo w) => gamePid != null && w.pid == gamePid),
+      ...windows
+          .where((ExternalWindowInfo w) => gamePid == null || w.pid != gamePid),
+    ];
     final ExternalWindowInfo? picked = await showDialog<ExternalWindowInfo>(
       context: context,
       builder: (BuildContext ctx) => SimpleDialog(
         title: Text(t.external_window_select),
         children: <Widget>[
-          for (final ExternalWindowInfo window in windows)
-            SimpleDialogOption(
-              onPressed: () => Navigator.of(ctx).pop(window),
-              child: Text(
+          for (final ExternalWindowInfo window in ordered)
+            ListTile(
+              // 焦点驱动纪律：这一项拿到初始焦点，Tab/方向键从它开始，Enter 直接确认。
+              autofocus: gamePid != null
+                  ? window.pid == gamePid
+                  : window.hwnd == boundHwnd,
+              title: Text(
                 window.title.isEmpty ? '#${window.hwnd}' : window.title,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
+              trailing: gamePid != null && window.pid == gamePid
+                  ? Text(
+                      t.external_window_current_game,
+                      style: Theme.of(ctx).textTheme.labelSmall?.copyWith(
+                            color: Theme.of(ctx).colorScheme.primary,
+                          ),
+                    )
+                  : null,
+              onTap: () => Navigator.of(ctx).pop(window),
             ),
         ],
       ),
     );
-    if (picked != null) await _session.bindWindow(picked);
+    // 选回当前已绑定的那个窗口是 no-op，不是「重新绑定」：bindWindow 在捕获模式下会
+    // startAttachedCapture 重启整条会话（launch 会话会因此退化成 attach，正在跑的
+    // engine hook 与已收台词一起丢）。预选中当前游戏后回车确认是最自然的操作，绝不能
+    // 因此把会话打断。
+    if (picked == null || picked.hwnd == boundHwnd) return;
+    await _session.bindWindow(picked);
   }
 
   /// galgame 引擎-hook（launch 模式）：页面只发起会话；位数解析、注入器选择、窗口绑定、

--- a/hibiki/test/lookup/global_lookup_mouse_hook_thread_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_mouse_hook_thread_guard_test.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1041 的静态守卫：全局查词浮窗的 `WH_MOUSE_LL` 必须装在**专用线程**上。
+///
+/// 低级鼠标钩子是同步钩子——系统把每个鼠标事件（含高频移动）投递到安装钩子的线程的
+/// 消息队列，等它返回或超时才继续分发。装在 Flutter 的 platform 线程上时，全系统鼠标
+/// 输入就排在 Dart 渲染与 platform channel 之后：用户实测「galgame 里点一次查词，之后
+/// 鼠标移动全程卡；不查词就没事」。
+///
+/// 这条路径没法在 Dart 侧行为测试里复现（纯 Win32 + 真实输入队列），最强可落地层就是
+/// 锁住修复的结构：
+///   ① `global_lookup_window.cpp` 不得再自己 `SetWindowsHookEx(WH_MOUSE_LL, ...)`；
+///   ② 钩子只在 `low_level_mouse_hook.cpp` 里装，且那里必须有自己的线程 + 消息循环；
+///   ③ 钩子回调只 `PostMessage`（异步）回窗口线程，不得 `SendMessage`（同步会把窗口
+///      线程的忙闲重新拽回输入路径，等于没修）；
+///   ④ 新源文件真的进了 runner 的 CMake 目标（否则链接不到，改动等于没编）。
+void main() {
+  const String runnerDir = 'windows/runner';
+  String read(String name) => File('$runnerDir/$name').readAsStringSync();
+
+  test('查词浮窗不再在自己的线程上装低级鼠标钩子', () {
+    final String window = read('global_lookup_window.cpp');
+    expect(
+      window.contains('SetWindowsHookEx'),
+      isFalse,
+      reason: 'BUG-1041：钩子必须交给 low_level_mouse_hook 的专用线程安装',
+    );
+    expect(
+      window.contains('hibiki::ArmLowLevelMouseHook'),
+      isTrue,
+      reason: '浮窗显示时应通过专用线程装钩子',
+    );
+    expect(
+      window.contains('hibiki::DisarmLowLevelMouseHook'),
+      isTrue,
+      reason: '浮窗隐藏/析构时必须卸钩子，否则钩子会一直拦全系统鼠标',
+    );
+  });
+
+  test('低级鼠标钩子跑在自己的线程 + 消息循环上', () {
+    final String hook = read('low_level_mouse_hook.cpp');
+    expect(hook.contains('SetWindowsHookEx(WH_MOUSE_LL'), isTrue);
+    expect(hook.contains('std::thread'), isTrue, reason: '钩子必须有自己的承载线程');
+    expect(hook.contains('GetMessage('), isTrue,
+        reason: '低级钩子事件靠线程消息队列分发，线程必须有消息循环');
+  });
+
+  test('钩子回调只异步投递，不同步等窗口线程', () {
+    final String hook = read('low_level_mouse_hook.cpp');
+    expect(hook.contains('PostMessage('), isTrue);
+    expect(
+      hook.contains('SendMessage('),
+      isFalse,
+      reason: 'SendMessage 会阻塞到窗口线程处理完，等于把卡顿原样搬回来',
+    );
+  });
+
+  test('钩子线程源文件已接入 runner CMake 目标', () {
+    final String cmake = read('CMakeLists.txt');
+    expect(cmake.contains('"low_level_mouse_hook.cpp"'), isTrue);
+  });
+}

--- a/hibiki/test/mining/gal_hook_session_controller_test.dart
+++ b/hibiki/test/mining/gal_hook_session_controller_test.dart
@@ -735,6 +735,104 @@ void main() {
     endpoints.dispose();
   });
 
+  test('BUG-1042：窗口迟到时会话继续重绑，不停在 window_not_found', () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    final _FakeEngineSource engine = _FakeEngineSource(
+      pairedBytes: Uint8List.fromList(<int>[1, 2, 3, 4]),
+    );
+    // 启动那一刻游戏窗口还没建好（带启动器/壳解包的真实情况）；几秒后才出现。
+    List<ExternalWindowInfo> windows = const <ExternalWindowInfo>[];
+    final GalHookSessionController controller = GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      exe32BitProbe: (_) async => true,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+      }) =>
+          engine,
+      loopbackSourceFactory: _FakeLoopbackSource.new,
+      windowListLoader: () async => windows,
+      windowPollAttempts: 1,
+      windowRebindInterval: const Duration(milliseconds: 10),
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+
+    expect(await controller.launchGame(r'D:\anemoi\SiglusEngine.exe'), isTrue);
+    expect(controller.state.boundWindow, isNull);
+    expect(controller.state.phase, GalHookSessionPhase.degraded);
+    expect(controller.state.fallbackReason, 'window_not_found');
+
+    // 窗口出现（pid 与 hook 注入的目标一致）。
+    windows = const <ExternalWindowInfo>[
+      ExternalWindowInfo(hwnd: 12, pid: 9, title: '别的窗口'),
+      ExternalWindowInfo(hwnd: 34, pid: 4242, title: '天使☆騒々 RE-BOOT!'),
+    ];
+    for (int i = 0; i < 40 && controller.state.boundWindow == null; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+
+    expect(controller.state.boundWindow?.hwnd, 34,
+        reason: '游戏窗口一出现就该自动绑上，不必用户手动去选');
+    expect(controller.state.fallbackReason, isNull);
+    expect(controller.state.phase, isNot(GalHookSessionPhase.degraded));
+    expect(
+      controller.events.map((GalHookEvent event) => event.code),
+      contains('window.auto_bound_late'),
+    );
+
+    await controller.close();
+    endpoints.dispose();
+  });
+
+  test('BUG-1042：会话停止后不再继续重绑窗口', () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    final _FakeEngineSource engine = _FakeEngineSource(
+      pairedBytes: Uint8List.fromList(<int>[1, 2, 3, 4]),
+    );
+    List<ExternalWindowInfo> windows = const <ExternalWindowInfo>[];
+    final GalHookSessionController controller = GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      exe32BitProbe: (_) async => true,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+      }) =>
+          engine,
+      loopbackSourceFactory: _FakeLoopbackSource.new,
+      windowListLoader: () async => windows,
+      windowPollAttempts: 1,
+      windowRebindInterval: const Duration(milliseconds: 10),
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+
+    expect(await controller.launchGame(r'D:\anemoi\SiglusEngine.exe'), isTrue);
+    await controller.stopCapture(keepBinding: false);
+    windows = const <ExternalWindowInfo>[
+      ExternalWindowInfo(hwnd: 34, pid: 4242, title: '天使☆騒々 RE-BOOT!'),
+    ];
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+
+    expect(controller.state.boundWindow, isNull,
+        reason: '会话已停，迟到的窗口不该把 app 拉回一条死会话');
+
+    await controller.close();
+    endpoints.dispose();
+  });
+
   test('游戏活动落库：hook 台词累计字符/时长写入 activity_events（game 类别）', () async {
     final HibikiDatabase db =
         HibikiDatabase.forTesting(NativeDatabase.memory());

--- a/hibiki/test/pages/texthooker_window_picker_guard_test.dart
+++ b/hibiki/test/pages/texthooker_window_picker_guard_test.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../sync/desktop_lookup_foreground_guard_static_test.dart'
+    show stripDartComments;
+
+/// BUG-1042 的静态守卫：捕获目标的窗口选择器必须把 **Hibiki 自己启动的游戏**当成
+/// 已选中的那一项。
+///
+/// 用户实测：从 Hibiki 启动游戏后点「捕获目标」条，弹出的窗口列表把游戏和一屏无关
+/// 窗口平铺在一起、没有任何预选，等于让用户替 app 认它刚拉起来的进程。
+///
+/// 这条路径没法用 widget 测试可移植地覆盖：`_pickExternalWindow` 首行就是
+/// `Platform.isWindows` 门（非 Windows CI 直接短路），窗口列表来自静态
+/// `WindowCaptureChannel`，会话又是单例。故在源码层锁住修复结构。
+void main() {
+  /// 截取方法体（含花括号）：先越过参数列表，再从其后第一个 `{` 起做花括号计数。
+  String methodBody(String source, String signatureNeedle) {
+    final int sigIdx = source.indexOf(signatureNeedle);
+    if (sigIdx < 0) throw StateError('找不到方法签名：$signatureNeedle');
+    final int parenOpen = source.indexOf('(', sigIdx);
+    int parenDepth = 0;
+    int parenClose = -1;
+    for (int i = parenOpen; i < source.length; i++) {
+      if (source[i] == '(') parenDepth++;
+      if (source[i] == ')') {
+        parenDepth--;
+        if (parenDepth == 0) {
+          parenClose = i;
+          break;
+        }
+      }
+    }
+    if (parenClose <= 0) throw StateError('参数列表没有闭合：$signatureNeedle');
+    final int bodyOpen = source.indexOf('{', parenClose);
+    if (bodyOpen <= 0) throw StateError('找不到方法体：$signatureNeedle');
+    int depth = 0;
+    for (int i = bodyOpen; i < source.length; i++) {
+      if (source[i] == '{') depth++;
+      if (source[i] == '}') {
+        depth--;
+        if (depth == 0) return source.substring(bodyOpen, i + 1);
+      }
+    }
+    throw StateError('方法体没有闭合：$signatureNeedle');
+  }
+
+  // 惰性读取：test 外不能调 expect，故文件解析放在这里、由各用例按需取。
+  String pickerBody() => methodBody(
+        stripDartComments(
+          File('lib/src/pages/implementations/texthooker_page.dart')
+              .readAsStringSync(),
+        ),
+        'Future<void> _pickExternalWindow()',
+      );
+
+  test('窗口列表按会话 gamePid 把当前游戏排到最前', () {
+    final String body = pickerBody();
+    expect(body.contains('_session.state.gamePid'), isTrue,
+        reason: '会话已经知道自己启动的游戏 pid，选择器必须用上它');
+    expect(body.contains('w.pid == gamePid'), isTrue,
+        reason: 'Hibiki 启动的游戏窗口应排在列表最前');
+  });
+
+  test('当前游戏那一项预置焦点（打开即选中、回车即绑）', () {
+    expect(pickerBody().contains('autofocus:'), isTrue);
+  });
+
+  test('选回已绑定的窗口是 no-op，不重启会话', () {
+    // bindWindow 在捕获模式下会 startAttachedCapture 重启整条会话（launch 会话
+    // 会退化成 attach，正在跑的 engine hook 与已收台词一起丢）。
+    expect(pickerBody().contains('picked.hwnd == boundHwnd'), isTrue);
+  });
+}

--- a/hibiki/windows/runner/CMakeLists.txt
+++ b/hibiki/windows/runner/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(${BINARY_NAME} WIN32
   "floating_lyric_window.cpp"
   "foreground_selection.cpp"
   "global_lookup_window.cpp"
+  "low_level_mouse_hook.cpp"
   "main.cpp"
   "utils.cpp"
   "win32_window.cpp"

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -4,6 +4,7 @@
 #include <shlwapi.h>
 #include <windowsx.h>  // GET_X_LPARAM / GET_KEYSTATE_WPARAM（composition 鼠标转发）
 
+#include "low_level_mouse_hook.h"
 #include "resource.h"
 
 #include <cmath>
@@ -184,33 +185,22 @@ void CALLBACK GlobalLookupWindow::ForegroundHookProc(HWINEVENTHOOK, DWORD,
   }
 }
 
-LRESULT CALLBACK GlobalLookupWindow::MouseHookProc(int code, WPARAM wparam,
-                                                   LPARAM lparam) {
-  if (code >= 0 &&
-      (wparam == WM_LBUTTONDOWN || wparam == WM_RBUTTONDOWN ||
-       wparam == WM_NCLBUTTONDOWN)) {
-    GlobalLookupWindow* self = s_hook_owner_;
-    if (self != nullptr && self->IsShowing() && self->hwnd_ != nullptr) {
-      const MSLLHOOKSTRUCT* info =
-          reinterpret_cast<const MSLLHOOKSTRUCT*>(lparam);
-      RECT rc;
-      GetWindowRect(self->hwnd_, &rc);
-      // TODO-867 P3c C4/E2 — the window is now the whole nested-stack bounding
-      // box (E1): the transparent area BETWEEN cards is inside the HWND rect, so
-      // a coarse "PtInRect -> Hide" would wrongly close on a click in that gap.
-      // Split the decision: a click OUTSIDE the whole window rect dismisses the
-      // overlay (clicked another app); a click INSIDE the window is forwarded to
-      // the web host, which owns the per-shell geometry truth and decides whether
-      // to keep (hit a card) or dismiss the root (gap between cards). C++ only
-      // feeds coordinates; the host hit-tests (no shell geometry duplicated here).
-      if (!PtInRect(&rc, info->pt)) {
-        self->Hide();  // Click outside the whole stack window -> dismiss.
-      } else {
-        self->ForwardGlobalClickToHost(info->pt.x, info->pt.y);
-      }
-    }
+void GlobalLookupWindow::HandleGlobalClick(POINT screen_pt,
+                                           bool inside_window) {
+  if (!IsShowing()) return;
+  // TODO-867 P3c C4/E2 — the window is now the whole nested-stack bounding
+  // box (E1): the transparent area BETWEEN cards is inside the HWND rect, so
+  // a coarse "PtInRect -> Hide" would wrongly close on a click in that gap.
+  // Split the decision: a click OUTSIDE the whole window rect dismisses the
+  // overlay (clicked another app); a click INSIDE the window is forwarded to
+  // the web host, which owns the per-shell geometry truth and decides whether
+  // to keep (hit a card) or dismiss the root (gap between cards). C++ only
+  // feeds coordinates; the host hit-tests (no shell geometry duplicated here).
+  if (!inside_window) {
+    Hide();  // Click outside the whole stack window -> dismiss.
+  } else {
+    ForwardGlobalClickToHost(screen_pt.x, screen_pt.y);
   }
-  return CallNextHookEx(nullptr, code, wparam, lparam);
 }
 
 GlobalLookupWindow::GlobalLookupWindow() = default;
@@ -220,9 +210,9 @@ GlobalLookupWindow::~GlobalLookupWindow() {
     UnhookWinEvent(foreground_hook_);
     foreground_hook_ = nullptr;
   }
-  if (mouse_hook_ != nullptr) {
-    UnhookWindowsHookEx(mouse_hook_);
-    mouse_hook_ = nullptr;
+  if (mouse_hook_armed_) {
+    hibiki::DisarmLowLevelMouseHook();
+    mouse_hook_armed_ = false;
   }
   // Only clear the hook owner if it is ours (two instances share the static;
   // see Hide()).
@@ -452,11 +442,10 @@ void GlobalLookupWindow::Reveal(int width, int height) {
           &GlobalLookupWindow::ForegroundHookProc, 0, 0,
           WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
     }
-    if (mouse_hook_ == nullptr) {
-      mouse_hook_ = SetWindowsHookEx(WH_MOUSE_LL,
-                                     &GlobalLookupWindow::MouseHookProc,
-                                     GetModuleHandle(nullptr), 0);
-    }
+    // BUG-1041 — 钩子跑在专用线程上（见 low_level_mouse_hook.h）：装在 platform 线程
+    // 时，全系统每个鼠标事件都要排在 Flutter 的帧后面，游戏里鼠标一动就卡。
+    hibiki::ArmLowLevelMouseHook(hwnd_);
+    mouse_hook_armed_ = true;
   }
 }
 
@@ -533,11 +522,10 @@ void GlobalLookupWindow::RevealStack(int dx, int dy, int width, int height,
           &GlobalLookupWindow::ForegroundHookProc, 0, 0,
           WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
     }
-    if (mouse_hook_ == nullptr) {
-      mouse_hook_ = SetWindowsHookEx(WH_MOUSE_LL,
-                                     &GlobalLookupWindow::MouseHookProc,
-                                     GetModuleHandle(nullptr), 0);
-    }
+    // BUG-1041 — 钩子跑在专用线程上（见 low_level_mouse_hook.h）：装在 platform 线程
+    // 时，全系统每个鼠标事件都要排在 Flutter 的帧后面，游戏里鼠标一动就卡。
+    hibiki::ArmLowLevelMouseHook(hwnd_);
+    mouse_hook_armed_ = true;
   }
 }
 
@@ -753,9 +741,9 @@ void GlobalLookupWindow::Hide(bool notify) {
     UnhookWinEvent(foreground_hook_);
     foreground_hook_ = nullptr;
   }
-  if (mouse_hook_ != nullptr) {
-    UnhookWindowsHookEx(mouse_hook_);
-    mouse_hook_ = nullptr;
+  if (mouse_hook_armed_) {
+    hibiki::DisarmLowLevelMouseHook();
+    mouse_hook_armed_ = false;
   }
   // spec 2026-07-10 — only clear the hook owner if it is OURS: the persistent
   // clipboard panel never arms the hooks, and its Hide() must not disarm the
@@ -1758,6 +1746,12 @@ void GlobalLookupWindow::ForwardGlobalClickToHost(int screen_x, int screen_y) {
 LRESULT GlobalLookupWindow::HandleMessage(UINT message, WPARAM wparam,
                                           LPARAM lparam) {
   switch (message) {
+    case hibiki::kLowLevelMouseClickMessage:
+      // BUG-1041 — 钩子线程投递的全局点击（wparam 打包屏幕物理坐标，lparam=是否
+      // 落在本窗口 rect 内）。真正的决策（关闭 / 转发给 host）在这里做，钩子线程
+      // 只搬坐标：那条线程必须随时能返回，否则整个系统的鼠标输入都跟着它排队。
+      HandleGlobalClick(hibiki::UnpackMouseHookPoint(wparam), lparam != 0);
+      return 0;
     case WM_SIZE:
       if (controller_) {
         RECT rc;

--- a/hibiki/windows/runner/global_lookup_window.h
+++ b/hibiki/windows/runner/global_lookup_window.h
@@ -211,9 +211,10 @@ class GlobalLookupWindow {
                                           HWND hwnd, LONG id_object,
                                           LONG id_child, DWORD thread,
                                           DWORD time);
-  // Closes the overlay when a click lands outside the card (incl. blank space in
-  // the same app, which the foreground hook does not catch).
-  static LRESULT CALLBACK MouseHookProc(int code, WPARAM wparam, LPARAM lparam);
+  // BUG-1041 — 处理钩子线程投递过来的「全局点击」消息（见 low_level_mouse_hook.h）：
+  // 落在窗口外 -> 关闭浮窗；落在窗口内 -> 交给 web host 自己命中测试。跑在窗口线程，
+  // 钩子线程只搬坐标，不碰任何 C++ 对象。
+  void HandleGlobalClick(POINT screen_pt, bool inside_window);
   LRESULT HandleMessage(UINT message, WPARAM wparam, LPARAM lparam);
   int OffscreenX() const;
   // TODO-867 P2: round the window corners to match popup.css's card radius.
@@ -270,7 +271,10 @@ class GlobalLookupWindow {
 
   HWND hwnd_ = nullptr;
   HWINEVENTHOOK foreground_hook_ = nullptr;
-  HHOOK mouse_hook_ = nullptr;
+  // BUG-1041 — 本实例是否已让钩子线程装上 WH_MOUSE_LL（钩子本身不再由本线程持有）。
+  // 仍是**每实例**标志：常驻剪贴板面板从不 arm，它的 Hide() 也就不会卸掉瞬态查词
+  // 覆盖窗的点击外关闭。
+  bool mouse_hook_armed_ = false;
   static GlobalLookupWindow* s_hook_owner_;
   bool visible_ = false;
   bool revealed_ = false;

--- a/hibiki/windows/runner/low_level_mouse_hook.cpp
+++ b/hibiki/windows/runner/low_level_mouse_hook.cpp
@@ -1,0 +1,127 @@
+#include "low_level_mouse_hook.h"
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+namespace hibiki {
+
+namespace {
+
+// 钩子线程私有的控制消息（PostThreadMessage）。
+constexpr UINT kThreadArm = WM_APP + 0x60;
+constexpr UINT kThreadDisarm = WM_APP + 0x61;
+
+// 钩子线程与调用线程共享的唯一可变状态：目标窗口。回调只读它，故用 atomic 而不是锁——
+// 钩子回调必须尽快返回，任何可能阻塞（锁竞争、堆分配）的东西都不该出现在这条路径上。
+std::atomic<HWND> g_target{nullptr};
+
+std::mutex g_thread_mutex;
+std::thread g_thread;
+std::atomic<DWORD> g_thread_id{0};
+
+LRESULT CALLBACK HookProc(int code, WPARAM wparam, LPARAM lparam) {
+  // 只关心「按下」：移动/滚轮直接放行（这条分支每秒会跑上千次，必须是纯比较）。
+  if (code >= 0 &&
+      (wparam == WM_LBUTTONDOWN || wparam == WM_RBUTTONDOWN ||
+       wparam == WM_NCLBUTTONDOWN)) {
+    const HWND target = g_target.load(std::memory_order_relaxed);
+    if (target != nullptr && IsWindow(target)) {
+      const MSLLHOOKSTRUCT* info =
+          reinterpret_cast<const MSLLHOOKSTRUCT*>(lparam);
+      RECT rc{};
+      // GetWindowRect 是跨线程安全的只读查询；命中判定留在这里，是为了让窗口线程
+      // 拿到的消息自带结论，不必在忙碌时再回头查几何。
+      const BOOL inside =
+          GetWindowRect(target, &rc) && PtInRect(&rc, info->pt);
+      PostMessage(target, kLowLevelMouseClickMessage,
+                  PackMouseHookPoint(info->pt.x, info->pt.y),
+                  inside ? 1 : 0);
+    }
+  }
+  return CallNextHookEx(nullptr, code, wparam, lparam);
+}
+
+void HookThreadMain() {
+  // 线程必须有消息队列钩子事件才会被投递过来；PeekMessage 强制系统建队列，之后
+  // Arm/Disarm 的 PostThreadMessage 才不会丢。
+  MSG msg{};
+  PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
+  g_thread_id.store(GetCurrentThreadId(), std::memory_order_release);
+
+  HHOOK hook = nullptr;
+  while (GetMessage(&msg, nullptr, 0, 0) > 0) {
+    if (msg.message == kThreadArm) {
+      if (hook == nullptr) {
+        hook = SetWindowsHookEx(WH_MOUSE_LL, &HookProc,
+                                GetModuleHandle(nullptr), 0);
+      }
+    } else if (msg.message == kThreadDisarm) {
+      if (hook != nullptr) {
+        UnhookWindowsHookEx(hook);
+        hook = nullptr;
+      }
+    }
+  }
+  if (hook != nullptr) {
+    UnhookWindowsHookEx(hook);
+  }
+}
+
+// 返回钩子线程 id（必要时懒创建并等它把 id 发布出来）。0 表示创建失败。
+DWORD EnsureHookThread() {
+  const DWORD existing = g_thread_id.load(std::memory_order_acquire);
+  if (existing != 0) return existing;
+  std::lock_guard<std::mutex> guard(g_thread_mutex);
+  const DWORD after_lock = g_thread_id.load(std::memory_order_acquire);
+  if (after_lock != 0) return after_lock;
+  g_thread = std::thread(&HookThreadMain);
+  g_thread.detach();
+  // 线程 id 是线程自己发布的，这里必须等到它可用后才能 PostThreadMessage（否则
+  // Arm 会静默丢失）。发布只隔着 PeekMessage 一步，实测微秒级。
+  for (int spin = 0; spin < 2000; ++spin) {
+    const DWORD id = g_thread_id.load(std::memory_order_acquire);
+    if (id != 0) return id;
+    Sleep(1);
+  }
+  return 0;
+}
+
+}  // namespace
+
+WPARAM PackMouseHookPoint(int x, int y) {
+  return (static_cast<WPARAM>(static_cast<uint32_t>(x)) << 32) |
+         static_cast<WPARAM>(static_cast<uint32_t>(y));
+}
+
+POINT UnpackMouseHookPoint(WPARAM wparam) {
+  POINT pt{};
+  pt.x = static_cast<LONG>(static_cast<int32_t>(
+      static_cast<uint32_t>((wparam >> 32) & 0xFFFFFFFFull)));
+  pt.y = static_cast<LONG>(
+      static_cast<int32_t>(static_cast<uint32_t>(wparam & 0xFFFFFFFFull)));
+  return pt;
+}
+
+void ArmLowLevelMouseHook(HWND target) {
+  if (target == nullptr) {
+    DisarmLowLevelMouseHook();
+    return;
+  }
+  g_target.store(target, std::memory_order_relaxed);
+  const DWORD thread_id = EnsureHookThread();
+  if (thread_id != 0) {
+    PostThreadMessage(thread_id, kThreadArm, 0, 0);
+  }
+}
+
+void DisarmLowLevelMouseHook() {
+  g_target.store(nullptr, std::memory_order_relaxed);
+  const DWORD thread_id = g_thread_id.load(std::memory_order_acquire);
+  if (thread_id != 0) {
+    PostThreadMessage(thread_id, kThreadDisarm, 0, 0);
+  }
+}
+
+}  // namespace hibiki

--- a/hibiki/windows/runner/low_level_mouse_hook.h
+++ b/hibiki/windows/runner/low_level_mouse_hook.h
@@ -1,0 +1,39 @@
+#ifndef RUNNER_LOW_LEVEL_MOUSE_HOOK_H_
+#define RUNNER_LOW_LEVEL_MOUSE_HOOK_H_
+
+// BUG-1041 — 进程级 WH_MOUSE_LL 承载线程。
+//
+// 低级鼠标钩子是**同步**钩子：系统把每一个鼠标输入事件（含高频 WM_MOUSEMOVE）投递到
+// 安装钩子的那条线程的消息队列，并等它返回或超时（LowLevelHooksTimeout，默认 300ms）
+// 才继续分发给前台程序。把它装在 Flutter 的 platform 线程上，等于让「全系统鼠标输入」
+// 排在 Dart/Flutter 的渲染与 platform channel 之后：查词浮窗一出现，游戏里的鼠标移动
+// 就跟着主线程的忙闲一卡一卡（用户实测「点击查词后鼠标移动都会变卡，不查就没事」）。
+//
+// 根因修复是让钩子跑在一条**只做钩子**的线程上：这里的线程除了 GetMessage 什么都不做，
+// 回调只读 HWND 几何并 PostMessage（异步）回窗口线程，永远不会被 Flutter 的帧阻塞。
+//
+// 线程常驻（首次 Arm 时懒创建），Arm/Disarm 只是让它装/卸钩子——查词是高频操作，
+// 每次都建销线程反而制造无谓的竞态窗口。
+
+#include <windows.h>
+
+namespace hibiki {
+
+// 钩子命中时 PostMessage 给目标窗口的消息（WM_APP 段，进程内私有）：
+//   wparam = 打包的屏幕物理坐标 ((uint32)x << 32) | (uint32)y
+//   lparam = 1 表示点击落在目标窗口 rect 内，0 表示在外
+// 窗口线程自己决定「转发给 host / 关闭浮窗」——钩子线程不碰任何 C++ 对象。
+constexpr UINT kLowLevelMouseClickMessage = WM_APP + 0x51;
+
+// 打包/解包屏幕坐标（x64 下 WPARAM 为 64 位；坐标可为负，故按 uint32 位模式搬运）。
+WPARAM PackMouseHookPoint(int x, int y);
+POINT UnpackMouseHookPoint(WPARAM wparam);
+
+// 装钩子并把命中事件投递给 |target|。重复调用只是替换目标窗口（幂等）。
+void ArmLowLevelMouseHook(HWND target);
+// 卸钩子（目标窗口清空）。未装时是 no-op。
+void DisarmLowLevelMouseHook();
+
+}  // namespace hibiki
+
+#endif  // RUNNER_LOW_LEVEL_MOUSE_HOOK_H_


### PR DESCRIPTION
用户反馈两个 galgame 捕获工作台问题，均已定位为真 bug 并根因修复。

## BUG-1037 · 查词后鼠标移动全局变卡（不查就没事）
**根因**：查词浮窗显示时在 **Flutter platform 线程**上 `SetWindowsHookEx(WH_MOUSE_LL, ...)`（`global_lookup_window.cpp` 的 `Reveal`/`RevealStack`）。`WH_MOUSE_LL` 是同步钩子，系统把每个鼠标事件（含高频移动）投递到安装线程的消息队列并等它返回或超时（默认 300ms）才继续分发给游戏。galgame 会话里主线程忙于台词轮询 + 工作台重建 + 查词 WebView2，鼠标输入排在 Flutter 帧后 → 全局卡；浮窗关闭卸钩子即恢复，正好对上「不查就没事」。

**修复**：新增 `low_level_mouse_hook.{h,cpp}`——钩子跑在只做 `GetMessage` 的进程级专用线程上，`Arm`/`Disarm` 经 `PostThreadMessage` 装卸；回调只读目标 HWND 几何后 `PostMessage`（异步）把「坐标 + 是否落在窗口内」投回窗口线程，绝不 `SendMessage`。点击外关闭 / 转发 host 语义一字未改。`HHOOK mouse_hook_` → 每实例 `bool mouse_hook_armed_`（常驻面板仍从不 arm）。

## BUG-1038 · 捕获目标没自动选中 Hibiki 启动的游戏
**根因**：① launch 后按 `gamePid` 找窗口只做一次性 10s 轮询（`windowPollAttempts×Interval`），超时永久停在 `window_not_found`——带启动器 / Enigma 壳的游戏常慢过 10s，之后只能手动选。② 选择器把全部顶层窗口无序平铺、既不按 `gamePid` 排序也无预选。

**修复**：① 会话级持续重绑监视（`_startWindowRebindWatch`，默认 2s；绑上 / 会话换代即停，只补状态并恢复降级 phase，**不走 `bindWindow`** 以免重启会话丢台词）。② 选择器按 `gamePid` 置顶当前游戏 + 「当前游戏」标注（新 i18n key）+ `ListTile(autofocus:)` 预选；选回已绑定窗口改为 no-op。

## 测试
- `gal_hook_session_controller_test.dart`：窗口迟到继续重绑 / 会话停止后不再重绑（行为测试 ×2）
- `global_lookup_mouse_hook_thread_guard_test.dart`：钩子必须在专用线程、只 PostMessage、已进 CMake（源码守卫）
- `texthooker_window_picker_guard_test.dart`：选择器置顶 / autofocus / no-op（源码守卫）
- `flutter analyze lib test` 干净；`flutter build windows --debug` 通过

## ⚠️ 待验
native + 会话时序改动，**待 Windows 真机复测**原始失败路径。