### PR TITLE
feat(interconnect): 制卡到已配对设备移入互联 + 加「用互联做备份后端」按钮

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 39389 (2317 per locale)
+/// Strings: 39508 (2324 per locale)
 ///
-/// Built on 2026-07-23 at 12:58 UTC
+/// Built on 2026-07-23 at 17:18 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3091,6 +3091,18 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get pdf_bookmarks => 'Bookmarks';
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   String get pdf_bookmark_added => 'Bookmark added';
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -8345,6 +8357,25 @@ class _StringsAr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -13672,6 +13703,25 @@ class _StringsDe extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -19015,6 +19065,25 @@ class _StringsEs extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -24369,6 +24438,25 @@ class _StringsFr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -29650,6 +29738,25 @@ class _StringsId extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -34979,6 +35086,25 @@ class _StringsIt extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -40113,6 +40239,25 @@ class _StringsJa extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -45250,6 +45395,25 @@ class _StringsKo extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -50557,6 +50721,25 @@ class _StringsNl extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -55879,6 +56062,25 @@ class _StringsPtBr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -61184,6 +61386,25 @@ class _StringsRu extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -66434,6 +66655,25 @@ class _StringsTh extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -71716,6 +71956,25 @@ class _StringsTr extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -76985,6 +77244,25 @@ class _StringsVi extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 // Path: <root>
@@ -81883,6 +82161,23 @@ class _StringsZhCn extends _StringsEn {
   String get pdf_bookmarks_empty => '还没有书签。';
   @override
   String get pdf_bookmark_added => '已添加书签';
+  @override
+  String get interconnect_section_delegate => '交给已配对设备';
+  @override
+  String get interconnect_backup_backend => '用互联做备份后端';
+  @override
+  String get interconnect_backup_backend_hint =>
+      '备份与同步写到已配对设备，而不是云盘。写过去的内容由上面「上传到互联对端」的几个开关决定。';
+  @override
+  String get interconnect_backup_backend_apply => '设为备份后端';
+  @override
+  String get interconnect_backup_backend_active =>
+      '备份已写到已配对设备。要换回云盘，去「同步与备份」里改后端。';
+  @override
+  String get interconnect_backup_backend_needs_pairing => '请先在上面连接一台设备。';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      '当前备份后端：${backend}';
 }
 
 // Path: <root>
@@ -86935,6 +87230,25 @@ class _StringsZhHk extends _StringsEn {
   String get pdf_bookmarks_empty => 'No bookmarks yet.';
   @override
   String get pdf_bookmark_added => 'Bookmark added';
+  @override
+  String get interconnect_section_delegate => 'Delegate to the paired device';
+  @override
+  String get interconnect_backup_backend =>
+      'Use interconnect as the backup backend';
+  @override
+  String get interconnect_backup_backend_hint =>
+      'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+  @override
+  String get interconnect_backup_backend_apply => 'Set as backup backend';
+  @override
+  String get interconnect_backup_backend_active =>
+      'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+  @override
+  String get interconnect_backup_backend_needs_pairing =>
+      'Connect to a device above first.';
+  @override
+  String interconnect_backup_backend_current({required Object backend}) =>
+      'Current backup backend: ${backend}';
 }
 
 /// Flat map(s) containing all translations.
@@ -91665,6 +91979,21 @@ extension on _StringsEn {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -96393,6 +96722,21 @@ extension on _StringsAr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -101142,6 +101486,21 @@ extension on _StringsDe {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -105890,6 +106249,21 @@ extension on _StringsEs {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -110644,6 +111018,21 @@ extension on _StringsFr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -115380,6 +115769,21 @@ extension on _StringsId {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -120131,6 +120535,21 @@ extension on _StringsIt {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -124844,6 +125263,21 @@ extension on _StringsJa {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -129561,6 +129995,21 @@ extension on _StringsKo {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -134305,6 +134754,21 @@ extension on _StringsNl {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -139046,6 +139510,21 @@ extension on _StringsPtBr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -143792,6 +144271,21 @@ extension on _StringsRu {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -148522,6 +149016,21 @@ extension on _StringsTh {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -153261,6 +153770,21 @@ extension on _StringsTr {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -157995,6 +158519,21 @@ extension on _StringsVi {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }
@@ -162693,6 +163232,20 @@ extension on _StringsZhCn {
         return '还没有书签。';
       case 'pdf_bookmark_added':
         return '已添加书签';
+      case 'interconnect_section_delegate':
+        return '交给已配对设备';
+      case 'interconnect_backup_backend':
+        return '用互联做备份后端';
+      case 'interconnect_backup_backend_hint':
+        return '备份与同步写到已配对设备，而不是云盘。写过去的内容由上面「上传到互联对端」的几个开关决定。';
+      case 'interconnect_backup_backend_apply':
+        return '设为备份后端';
+      case 'interconnect_backup_backend_active':
+        return '备份已写到已配对设备。要换回云盘，去「同步与备份」里改后端。';
+      case 'interconnect_backup_backend_needs_pairing':
+        return '请先在上面连接一台设备。';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) => '当前备份后端：${backend}';
       default:
         return null;
     }
@@ -167401,6 +167954,21 @@ extension on _StringsZhHk {
         return 'No bookmarks yet.';
       case 'pdf_bookmark_added':
         return 'Bookmark added';
+      case 'interconnect_section_delegate':
+        return 'Delegate to the paired device';
+      case 'interconnect_backup_backend':
+        return 'Use interconnect as the backup backend';
+      case 'interconnect_backup_backend_hint':
+        return 'Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.';
+      case 'interconnect_backup_backend_apply':
+        return 'Set as backup backend';
+      case 'interconnect_backup_backend_active':
+        return 'Backups already go to the paired device. Pick another backend in Sync & backup to switch away.';
+      case 'interconnect_backup_backend_needs_pairing':
+        return 'Connect to a device above first.';
+      case 'interconnect_backup_backend_current':
+        return ({required Object backend}) =>
+            'Current backup backend: ${backend}';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "此 PDF 没有目录。",
   "pdf_bookmarks": "书签",
   "pdf_bookmarks_empty": "还没有书签。",
-  "pdf_bookmark_added": "已添加书签"
+  "pdf_bookmark_added": "已添加书签",
+  "interconnect_section_delegate": "交给已配对设备",
+  "interconnect_backup_backend": "用互联做备份后端",
+  "interconnect_backup_backend_hint": "备份与同步写到已配对设备，而不是云盘。写过去的内容由上面「上传到互联对端」的几个开关决定。",
+  "interconnect_backup_backend_apply": "设为备份后端",
+  "interconnect_backup_backend_active": "备份已写到已配对设备。要换回云盘，去「同步与备份」里改后端。",
+  "interconnect_backup_backend_needs_pairing": "请先在上面连接一台设备。",
+  "interconnect_backup_backend_current": "当前备份后端：$backend"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2315,5 +2315,12 @@
   "pdf_outline_empty": "This PDF has no contents.",
   "pdf_bookmarks": "Bookmarks",
   "pdf_bookmarks_empty": "No bookmarks yet.",
-  "pdf_bookmark_added": "Bookmark added"
+  "pdf_bookmark_added": "Bookmark added",
+  "interconnect_section_delegate": "Delegate to the paired device",
+  "interconnect_backup_backend": "Use interconnect as the backup backend",
+  "interconnect_backup_backend_hint": "Back up and sync to the paired device instead of a cloud drive. Everything the paired-device upload switches above allow is what gets written there.",
+  "interconnect_backup_backend_apply": "Set as backup backend",
+  "interconnect_backup_backend_active": "Backups already go to the paired device. Pick another backend in Sync & backup to switch away.",
+  "interconnect_backup_backend_needs_pairing": "Connect to a device above first.",
+  "interconnect_backup_backend_current": "Current backup backend: $backend"
 }

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4375,7 +4375,7 @@ class AppModel with ChangeNotifier {
   // 语义正确落 false=本地制卡（现状），既复原「读 anki repo 无需完整初始化」的不变量，
   // 又避免早读崩溃。
   bool get mineToServerEnabled => _prefsRepo?.mineToServer ?? false;
-  void toggleMineToServer() => prefsRepo.toggleMineToServer();
+  Future<void> setMineToServer(bool value) => prefsRepo.setMineToServer(value);
 
   // 视频制卡封面图片模式（GIF / 制卡时当前帧 / 字幕开头帧，透传 prefsRepo）。默认 gif=现状。
   VideoMiningImageMode get videoMiningImageMode =>

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -1269,8 +1269,8 @@ class PreferencesRepository extends ChangeNotifier {
   bool get mineToServer =>
       getPref('mine_to_server', defaultValue: false) as bool;
 
-  void toggleMineToServer() async {
-    await setPref('mine_to_server', !mineToServer);
+  Future<void> setMineToServer(bool value) async {
+    await setPref('mine_to_server', value);
     notifyListeners();
   }
 

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -61,19 +61,10 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
             _buildCreateLapisTile(uiState, vm),
           ],
         ),
-        // 互联「制卡到服务端」开关：无条件显示（跨平台——手机也可把卡制到桌面主机的 Anki）。
-        // 开启后所有制卡（查词/阅读器/视频）转发到已配对主机，用主机的 Anki 后端 + 配置落卡；
-        // 目标即互联客户端的配对主机（与远程查词同一目标），需先在「互联/同步」里配对。
-        AdaptiveSettingsSection(
-          children: [
-            AdaptiveSettingsSwitchRow(
-              title: t.anki_mine_to_server,
-              subtitle: t.anki_mine_to_server_hint,
-              value: appModel.mineToServerEnabled,
-              onChanged: (_) => appModel.toggleMineToServer(),
-            ),
-          ],
-        ),
+        // NOTE:「制卡到已配对设备」开关已移到设置 →「Hibiki 互联」→「交给已配对设备」
+        // （见 buildInterconnectDestination）。它的前置条件、目标主机、失效条件全部由互联
+        // 决定（未启用互联/未配对时只会让制卡失败），留在这里是一个与本页其余 Anki 本地
+        // 配置无关、且在互联关闭时纯死的开关。
         if (!Platform.isAndroid)
           AdaptiveSettingsSection(
             title: 'AnkiConnect',

--- a/hibiki/lib/src/sync/sync_auto_trigger.dart
+++ b/hibiki/lib/src/sync/sync_auto_trigger.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki/src/models/local_audio_manager.dart';
 import 'package:hibiki/src/sync/book_exit_sync_scope.dart';
+import 'package:hibiki/src/sync/hibiki_client_sync_backend.dart';
 import 'package:hibiki/src/sync/sync_asset_package_service.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_manager.dart';
@@ -88,30 +89,34 @@ void logSyncReportErrors(SyncRunReport report) {
 /// 当成互斥单选项，现已解耦成独立开关）。两条通道各用自己的后端实例、各自认证成功
 /// 才真正跑（未配置的通道在 [_runSyncChannel] 里 no-op）。
 ///
-/// 去重：互联后端 [HibikiClientSyncBackend] 是单例；若云通道解析出的恰是同一单例
-/// （历史遗留 backendType=='hibikiServer'，迁移后不再出现，仅防御测试直接构造），
-/// 只保留一条，避免同一通道跑两遍。
+/// 去重：互联后端 [HibikiClientSyncBackend] 是单例；若用户把「备份后端」也选成互联
+/// （互联页的「用互联做备份后端」按钮），云通道解析出的就是同一单例，只保留一条，
+/// 避免同一通道跑两遍。
 /// 一条待跑的同步通道：后端实例 + 它是不是互联通道。isInterconnect 决定分资产开关
 /// 读云备份共享值还是互联专属上传开关（[resolveChannelSyncFlags]，BUG-988）。
-class _SyncChannel {
-  const _SyncChannel(this.backend, {required this.isInterconnect});
+class SyncChannel {
+  const SyncChannel(this.backend, {required this.isInterconnect});
   final SyncBackend backend;
   final bool isInterconnect;
 }
 
-Future<List<_SyncChannel>> _enabledSyncChannelBackends(
+@visibleForTesting
+Future<List<SyncChannel>> enabledSyncChannelBackends(
   SyncRepository repo,
 ) async {
   final SyncBackend cloud = resolveSyncBackend(await repo.getBackendType());
-  final List<_SyncChannel> channels = <_SyncChannel>[
-    _SyncChannel(cloud, isInterconnect: false),
+  // isInterconnect 由后端身份决定，不由「它排在云通道那一格」决定：备份后端被选成
+  // 互联时只剩这一条通道，它跑的就是互联链路（SyncOrchestrator 内部同样按
+  // `backend is HibikiClientSyncBackend` 判断），分资产开关必须跟着读互联专属的
+  // 上传开关——否则用户在互联页看到的四个上传开关会被静默忽略、改由云备份开关决定。
+  final List<SyncChannel> channels = <SyncChannel>[
+    SyncChannel(cloud, isInterconnect: cloud is HibikiClientSyncBackend),
   ];
   if (await repo.isInterconnectEnabled()) {
     final SyncBackend interconnect =
         resolveSyncBackend(SyncBackendType.hibikiServer);
-    // 去重：仅防御历史 backendType=='hibikiServer'（迁移后不再出现）把同一单例跑两遍。
     if (!identical(interconnect, cloud)) {
-      channels.add(_SyncChannel(interconnect, isInterconnect: true));
+      channels.add(SyncChannel(interconnect, isInterconnect: true));
     }
   }
   return channels;
@@ -167,7 +172,7 @@ Future<ChannelSyncFlags> resolveChannelSyncFlags(
 
 /// 为单个 [backend] 通道构建并运行一轮完整同步编排。认证失败（未配置该通道）返回
 /// null，调用方视为该通道 no-op 跳过。云备份通道与互联通道各调一次（见
-/// [_enabledSyncChannelBackends]），互不排斥（option B 双通道）。
+/// [enabledSyncChannelBackends]），互不排斥（option B 双通道）。
 Future<SyncRunReport?> _runSyncChannel({
   required HibikiDatabase db,
   required SyncRepository repo,
@@ -296,8 +301,8 @@ Future<void> _runAutoSyncAll({
 
       // option B 双通道：依次跑云备份通道 + 互联通道（若启用），互不排斥。每条通道
       // 各自认证成功才实际跑；未配置的通道 no-op（_runSyncChannel 返回 null）。
-      for (final _SyncChannel channel
-          in await _enabledSyncChannelBackends(repo)) {
+      for (final SyncChannel channel
+          in await enabledSyncChannelBackends(repo)) {
         final SyncRunReport? report = await _runSyncChannel(
           db: db,
           repo: repo,
@@ -387,8 +392,8 @@ Future<ManualSyncResult> runManualFullSync({
       final SyncRunReport merged = SyncRunReport();
       final List<ManualSyncChannelReport> channelReports =
           <ManualSyncChannelReport>[];
-      for (final _SyncChannel channel
-          in await _enabledSyncChannelBackends(repo)) {
+      for (final SyncChannel channel
+          in await enabledSyncChannelBackends(repo)) {
         final SyncRunReport? report = await _runSyncChannel(
           db: db,
           repo: repo,
@@ -500,8 +505,8 @@ Future<void> _runCollectionsSync({required HibikiDatabase db}) async {
     await _autoSyncMutex.withLock(() async {
       final repo = SyncRepository(db);
       if (!await repo.isAutoSyncEnabled()) return;
-      for (final _SyncChannel channel
-          in await _enabledSyncChannelBackends(repo)) {
+      for (final SyncChannel channel
+          in await enabledSyncChannelBackends(repo)) {
         final SyncBackend backend = channel.backend;
         await backend.restoreAuth(repo);
         if (!await backend.isAuthenticated) continue;
@@ -576,8 +581,8 @@ Future<void> _runAutoSync({
 
       // option B 双通道：退出书时对每条启用的通道（云备份 + 互联）各跑一次 per-book
       // 同步，互不排斥。每条通道各自认证成功才跑；未配置的通道 continue 跳过。
-      for (final _SyncChannel channel
-          in await _enabledSyncChannelBackends(repo)) {
+      for (final SyncChannel channel
+          in await enabledSyncChannelBackends(repo)) {
         final SyncBackend backend = channel.backend;
         await backend.restoreAuth(repo);
         if (!await backend.isAuthenticated) continue;

--- a/hibiki/lib/src/sync/sync_repository.dart
+++ b/hibiki/lib/src/sync/sync_repository.dart
@@ -334,14 +334,26 @@ class SyncRepository {
   /// 照常跑、且不再占着「云后端选择」这个位置。互联自身的持久化字段（serverEnabled
   /// / clientUrls / token 等）本就独立存储，无需搬运。
   ///
-  /// 幂等：仅当 backendType 原始字符串恰为 'hibikiServer' 时动作；其余情况 no-op。
+  /// 一次性：迁移过一次后（[_keyInterconnectBackendMigrated] 落盘）永远 no-op。
+  /// 这点是硬要求而非优化——解耦后用户仍可主动把云备份后端选成互联（互联页的
+  /// 「用互联做备份后端」按钮，把备份写到已配对对端而不是云盘）。若迁移继续只看
+  /// 「backendType 是不是 hibikiServer」，这个用户选择会在下次启动被当成旧数据
+  /// 抹回 googleDrive，按钮变成重启即失效的假开关。
+  ///
   /// 必须在任何 [getBackendType]（未知值静默回落 googleDrive）之前、init 期跑一次。
-  /// 用原始 key 字符串读取，独立于枚举符号的存亡。
+  /// 用原始 key 字符串读取 backendType，独立于枚举符号的存亡。
   Future<void> migrateInterconnectBackendToToggle() async {
+    if (await _db.getPrefTyped<bool>(_keyInterconnectBackendMigrated, false)) {
+      return;
+    }
     final String? backend = await _getStringOrNull(_keyBackendType);
-    if (backend != SyncBackendType.hibikiServer.name) return;
-    await setInterconnectEnabled(true);
-    await _setString(_keyBackendType, SyncBackendType.googleDrive.name);
+    if (backend == SyncBackendType.hibikiServer.name) {
+      await setInterconnectEnabled(true);
+      await _setString(_keyBackendType, SyncBackendType.googleDrive.name);
+    }
+    // 无论本机是否真有旧数据要搬，都记「迁移已跑过」：新装用户同样只有这一次窗口，
+    // 之后的 backendType 一律是用户的真实选择。
+    await _db.setPrefTyped<bool>(_keyInterconnectBackendMigrated, true);
   }
 
   // ── Content sync ──────────────────────────────────────────────────
@@ -551,6 +563,14 @@ class SyncRepository {
   // ── Hibiki Server config ────────────────────────────────────────
 
   static const _keyInterconnectEnabled = 'sync_interconnect_enabled';
+
+  /// 「旧互联后端 → 独立开关」迁移的一次性完成标记。见
+  /// [migrateInterconnectBackendToToggle]：迁移过去靠「backendType 不再是
+  /// hibikiServer」当哨兵，于是用户之后主动把备份后端设回互联（互联页的
+  /// 「用互联做备份后端」按钮）会在下次启动被迁移当成旧数据再改回 googleDrive。
+  /// 用独立标记记「本机已迁移过」，让迁移真正只跑一次。
+  static const _keyInterconnectBackendMigrated =
+      'sync_interconnect_backend_migrated';
   static const _keyServerEnabled = 'sync_server_enabled';
   static const _keyServerPort = 'sync_server_port';
   static const _keyServerPassword = 'sync_server_password';

--- a/hibiki/lib/src/sync/sync_settings_schema.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema.dart
@@ -457,6 +457,34 @@ SettingsDestination buildInterconnectDestination() {
           ),
         ],
       ),
+      // 交给已配对设备：本机把某类工作整个甩给对端主机去做。两项都只有 client 角色
+      // 讲得通（host 没有「对端」可交），故与上面的上传区同门控——互联启用且本机不在
+      // host 模式。
+      //   · 制卡到已配对设备：制卡改由主机的 Anki 落卡（原在「制卡」分类，但它的前置
+      //     条件、目标设备、失效条件全由互联决定，互联关掉时在制卡页是个纯死开关）。
+      //   · 用互联做备份后端：把云备份通道也指向对端（详见 _InterconnectBackupBackendWidget）。
+      SettingsSection(
+        title: t.interconnect_section_delegate,
+        visible: (SettingsContext ctx) =>
+            interconnectActive(ctx) && !_isHostingInterconnect(ctx),
+        items: <SettingsItem>[
+          SettingsSwitchItem(
+            id: 'interconnect.mine_to_server',
+            title: t.anki_mine_to_server,
+            subtitle: t.anki_mine_to_server_hint,
+            icon: Icons.note_add_outlined,
+            value: (SettingsContext ctx) => ctx.appModel.mineToServerEnabled,
+            onChanged: (SettingsContext ctx, bool value) =>
+                ctx.appModel.setMineToServer(value),
+          ),
+          SettingsCustomItem(
+            id: 'interconnect.backup_backend',
+            icon: Icons.backup_outlined,
+            builder: (SettingsContext ctx) =>
+                _InterconnectBackupBackendWidget(settingsContext: ctx),
+          ),
+        ],
+      ),
       // 本机作为服务器：host 模式开关（与 client 角色互斥，见 _SyncSettingsState
       // 的 roleRevision 互斥锁）。
       SettingsSection(

--- a/hibiki/lib/src/sync/sync_settings_schema/backend_config.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/backend_config.part.dart
@@ -374,15 +374,31 @@ class _BackendSelectorWidgetState extends State<_BackendSelectorWidget> {
     final SyncBackendType previous = state.backendType;
     if (value == previous) return;
     state.backendType = value;
-    final SyncRepository repo =
-        SyncRepository(widget.settingsContext.appModel.database);
-    await repo.setBackendType(value);
-    await repo.clearFolderCache();
-    // The TLS flag is FTP-only; don't let it linger after switching away.
-    if (previous == SyncBackendType.ftp && value != SyncBackendType.ftp) {
-      await repo.setFtpTlsEnabled(false);
-    }
+    await applyBackupBackendChange(
+      SyncRepository(widget.settingsContext.appModel.database),
+      previous: previous,
+      next: value,
+    );
     widget.settingsContext.refresh();
+  }
+}
+
+/// 切换云备份后端时必须一起做的持久化副作用，集中一处：写 backendType、清目录缓存
+/// （缓存的 folder id 只对旧后端有意义）、离开 FTP 时清掉 FTP 专属的 TLS 标记。
+///
+/// 后端选择器（[_BackendSelectorWidgetState._selectBackend]）与互联页的
+/// 「用互联做备份后端」按钮（[_InterconnectBackupBackendWidget]）共用本函数，两个
+/// 入口不会漂成两套切换语义。不碰内存态 `_SyncSettingsState.backendType`——那是调用方
+/// 各自的 UI 状态。
+Future<void> applyBackupBackendChange(
+  SyncRepository repo, {
+  required SyncBackendType previous,
+  required SyncBackendType next,
+}) async {
+  await repo.setBackendType(next);
+  await repo.clearFolderCache();
+  if (previous == SyncBackendType.ftp && next != SyncBackendType.ftp) {
+    await repo.setFtpTlsEnabled(false);
   }
 }
 

--- a/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
@@ -1405,3 +1405,114 @@ class _LanDiscoveryWidgetState extends State<_LanDiscoveryWidget>
     );
   }
 }
+
+// ── 用互联做备份后端 ────────────────────────────────────────────────
+//
+// 互联从「互斥的 backendType==hibikiServer 单选」解耦成独立开关（PR#223）之后，
+// 后端选择器不再列出互联（[_isBackendSelectable] 对 hibikiServer 返回 false），
+// 于是「备份/同步写到已配对设备而不是云盘」这条路径整个从 UI 上消失了——能力还在
+// （[resolveSyncBackend] 仍把 hibikiServer 解析成 [HibikiClientSyncBackend]），只是
+// 没有入口。这一行把入口放回互联自己的分类里：一个动作，把云备份通道指向对端主机。
+//
+// 退路：[_selectableBackends] 恒把当前值插回选项列表，所以设成互联之后，「同步与
+// 备份」的后端选择器里仍能选回 Google Drive / WebDAV 等，不是单向门。
+class _InterconnectBackupBackendWidget extends StatefulWidget {
+  const _InterconnectBackupBackendWidget({required this.settingsContext});
+  final SettingsContext settingsContext;
+
+  @override
+  State<_InterconnectBackupBackendWidget> createState() =>
+      _InterconnectBackupBackendWidgetState();
+}
+
+class _InterconnectBackupBackendWidgetState
+    extends State<_InterconnectBackupBackendWidget> {
+  bool _busy = false;
+
+  _SyncSettingsState get _state => _syncSettings(widget.settingsContext);
+
+  @override
+  void initState() {
+    super.initState();
+    // 同页配对成功后 hasClientConnection 才翻 true（roleRevision 通知），按钮据此解禁；
+    // 不听就会停在「请先连接一台设备」直到重开页面。
+    _state.roleRevision.addListener(_onRoleRevision);
+  }
+
+  @override
+  void dispose() {
+    _state.roleRevision.removeListener(_onRoleRevision);
+    super.dispose();
+  }
+
+  void _onRoleRevision() {
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _useInterconnectAsBackend() async {
+    final _SyncSettingsState state = _state;
+    final SyncBackendType previous = state.backendType;
+    if (previous == SyncBackendType.hibikiServer) return;
+    setState(() => _busy = true);
+    try {
+      await applyBackupBackendChange(
+        SyncRepository(widget.settingsContext.appModel.database),
+        previous: previous,
+        next: SyncBackendType.hibikiServer,
+      );
+      state.backendType = SyncBackendType.hibikiServer;
+      if (!mounted) return;
+      _showSnackBar(context, t.interconnect_backup_backend_active);
+      // 同步分类的后端选择器/凭据区都按 backendType 门控，刷新让它们立刻跟上。
+      widget.settingsContext.refresh();
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final _SyncSettingsState state = _state;
+    final bool active = state.backendType == SyncBackendType.hibikiServer;
+    final bool paired = state.hasClientConnection;
+    final ThemeData theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          AdaptiveSettingsRow(
+            title: t.interconnect_backup_backend,
+            subtitle: active
+                ? t.interconnect_backup_backend_active
+                : (paired
+                    ? t.interconnect_backup_backend_hint
+                    : t.interconnect_backup_backend_needs_pairing),
+            icon: Icons.backup_outlined,
+          ),
+          Text(
+            t.interconnect_backup_backend_current(
+              backend: _backendLabel(state.backendType),
+            ),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          if (!active) ...<Widget>[
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: <Widget>[
+                FilledButton.tonal(
+                  onPressed:
+                      (paired && !_busy) ? _useInterconnectAsBackend : null,
+                  child: Text(t.interconnect_backup_backend_apply),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+890
+version: 1.2.0+891
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/settings/settings_flatten_anki_profile_test.dart
+++ b/hibiki/test/settings/settings_flatten_anki_profile_test.dart
@@ -185,10 +185,10 @@ void main() {
     //    并入一个无条件显示的区块。未配置 Anki 时它们也都露出——故恰有三个 SwitchRow。
     //    TODO-1650 把旧「压缩制卡媒体」开关换成「图片/GIF 清晰度 + 音频质量」两滑块，
     //    紧随其后的独立无标题区（同样无条件显示）。
-    expect(find.byType(AdaptiveSettingsSwitchRow), findsNWidgets(4),
-        reason: 'TODO-135 方案A 三开关（hibiki / 来源分类 / 自动添加书名）+ PR#343 '
-            '无条件「制卡到服务端」开关，未配置 Anki 时都应显示（旧「压缩」开关已换成'
-            '两滑块，不再是 SwitchRow）');
+    expect(find.byType(AdaptiveSettingsSwitchRow), findsNWidgets(3),
+        reason: 'TODO-135 方案A 三开关（hibiki / 来源分类 / 自动添加书名），未配置 Anki '
+            '时都应显示（旧「压缩」开关已换成两滑块，不再是 SwitchRow；「制卡到已配对'
+            '设备」已移到 Hibiki 互联分类）');
     expect(find.byType(AdaptiveSettingsSliderRow), findsNWidgets(2),
         reason: 'TODO-1650「图片/GIF 清晰度」+「音频质量」两滑块应无条件显示');
     expect(find.textContaining('Image / GIF quality'), findsOneWidget,
@@ -207,11 +207,13 @@ void main() {
         AdaptiveSettingsSwitchRow, 'Auto-add book title to tags');
     expect(autoAddRow, findsOneWidget,
         reason: '「自动添加书名」开关必须仍无条件可用（方案B会破坏，绝不退化）');
-    // PR#343：互联「制卡到服务端」开关无条件显示（跨平台，手机也能把卡制到桌面主机）。
+    // 「制卡到已配对设备」已移出本页，改挂 Hibiki 互联 →「交给已配对设备」（它的前置
+    // 条件、目标设备、失效条件全由互联决定，互联关掉时留在这里就是纯死开关）。归属由
+    // test/sync/sync_settings_visibility_test.dart 咬住；这里只守「不得回流」。
     expect(
         find.widgetWithText(AdaptiveSettingsSwitchRow, 'Mine to paired device'),
-        findsOneWidget,
-        reason: 'PR#343「制卡到服务端」开关应无条件显示于 Anki 正文');
+        findsNothing,
+        reason: '「制卡到已配对设备」不应再出现在 Anki 正文');
 
     // ④「自动添加书名」开关仍真生效（写穿 prefs）——必须保留的用户目标。
     final bool before = appModel.autoAddBookNameToTags;

--- a/hibiki/test/settings/settings_schema_coverage_test.dart
+++ b/hibiki/test/settings/settings_schema_coverage_test.dart
@@ -139,7 +139,9 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   // mineEntry/isDuplicate 经互联链路转发到已配对主机（用主机 Anki 落卡），配置类方法仍委派
   // 本地（非 reader CSS / 主题树），无适用 widget 探针；由专项测试咬住转发路由/字段透传/
   // 序列化契约（远端制卡仓库包装 + 转发载荷 + 服务端 handler）。
-  'cardCreation/Mine to paired device':
+  // 归属：开关已从「制卡」分类移到「Hibiki 互联」→「交给已配对设备」（它的前置条件、
+  // 目标设备、失效条件全由互联决定），故登记键的 destId 随之从 cardCreation 变 interconnect。
+  'interconnect/Mine to paired device':
       'test/anki/remote_mining_anki_repository_test.dart + '
           'test/sync/forwarded_mine_payload_test.dart + '
           'test/sync/hibiki_remote_mining_service_test.dart',

--- a/hibiki/test/sync/interconnect_backup_backend_test.dart
+++ b/hibiki/test/sync/interconnect_backup_backend_test.dart
@@ -1,0 +1,131 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/sync/hibiki_client_sync_backend.dart';
+import 'package:hibiki/src/sync/sync_auto_trigger.dart';
+import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki/src/sync/sync_settings_schema.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+HibikiDatabase _testDb() =>
+    HibikiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+
+/// 用户诉求：「hibiki 互联里面加一个按钮，把备份后端设置为 hibiki 互联」。
+///
+/// 互联解耦（PR#223）后 hibikiServer 从后端选择器里被摘掉，「备份写到已配对设备而不是
+/// 云盘」这条能力还在（[resolveSyncBackend] 仍解析成 [HibikiClientSyncBackend]）但没有
+/// 入口。互联页新增的按钮走 [applyBackupBackendChange] 把它放回来，本测试守住这条路径的
+/// 两个真实落点：切换副作用、以及切换后同步通道的归属。
+void main() {
+  group('applyBackupBackendChange', () {
+    test('把备份后端设成互联：写穿 backendType，并清掉离开 FTP 时的专属 TLS 标记', () async {
+      final HibikiDatabase db = _testDb();
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+
+      await repo.setBackendType(SyncBackendType.ftp);
+      await repo.setFtpTlsEnabled(true);
+
+      await applyBackupBackendChange(
+        repo,
+        previous: SyncBackendType.ftp,
+        next: SyncBackendType.hibikiServer,
+      );
+
+      expect(await repo.getBackendType(), SyncBackendType.hibikiServer);
+      expect(await repo.isFtpTlsEnabled(), isFalse,
+          reason: 'FTP 专属的 TLS 标记不该在切走后残留');
+    });
+
+    test('非 FTP 起点不误动 FTP TLS 标记', () async {
+      final HibikiDatabase db = _testDb();
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+
+      await repo.setFtpTlsEnabled(true);
+
+      await applyBackupBackendChange(
+        repo,
+        previous: SyncBackendType.googleDrive,
+        next: SyncBackendType.hibikiServer,
+      );
+
+      expect(await repo.getBackendType(), SyncBackendType.hibikiServer);
+      expect(await repo.isFtpTlsEnabled(), isTrue);
+    });
+  });
+
+  group('enabledSyncChannelBackends', () {
+    test('备份后端选成互联时只跑一条通道，且按互联通道计（读互联专属上传开关）', () async {
+      final HibikiDatabase db = _testDb();
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+
+      await repo.setInterconnectEnabled(true);
+      await repo.setBackendType(SyncBackendType.hibikiServer);
+
+      final List<SyncChannel> channels = await enabledSyncChannelBackends(repo);
+
+      expect(channels, hasLength(1), reason: '同一单例后端不得跑两遍');
+      expect(channels.single.backend, isA<HibikiClientSyncBackend>());
+      // 关键：这条通道跑的是互联链路，分资产开关就必须读互联专属上传开关，否则用户在
+      // 互联页看到的四个上传开关会被静默忽略、改由云备份开关决定。
+      expect(channels.single.isInterconnect, isTrue);
+    });
+
+    test('云后端 + 互联启用仍是两条通道，各自归属不变', () async {
+      final HibikiDatabase db = _testDb();
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+
+      await repo.setInterconnectEnabled(true);
+      await repo.setBackendType(SyncBackendType.googleDrive);
+
+      final List<SyncChannel> channels = await enabledSyncChannelBackends(repo);
+
+      expect(channels, hasLength(2));
+      expect(channels[0].isInterconnect, isFalse);
+      expect(channels[1].isInterconnect, isTrue);
+      expect(channels[1].backend, isA<HibikiClientSyncBackend>());
+    });
+
+    test('互联未启用时只有云通道', () async {
+      final HibikiDatabase db = _testDb();
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+
+      await repo.setBackendType(SyncBackendType.googleDrive);
+
+      final List<SyncChannel> channels = await enabledSyncChannelBackends(repo);
+
+      expect(channels, hasLength(1));
+      expect(channels.single.isInterconnect, isFalse);
+    });
+  });
+
+  group('mine_to_server 偏好', () {
+    // 「制卡到已配对设备」从「制卡」分类移进互联分类后落在 interconnectEnabled 门控之后，
+    // 设置覆盖 harness（默认互联关）不再遍历到它，那条写穿/持久化验证随之丢失。这里把它
+    // 补回来：显式 setter（取代原来只能盲翻的 toggle）的往返 + 跨 reload 持久化。
+    test('默认关；set 往返并跨 reload 持久化', () async {
+      final HibikiDatabase db = _testDb();
+      addTearDown(db.close);
+      final PreferencesRepository repo = PreferencesRepository(db);
+      await repo.loadFromDb();
+
+      expect(repo.mineToServer, isFalse, reason: '默认本地制卡，零回归');
+
+      await repo.setMineToServer(true);
+      expect(repo.mineToServer, isTrue);
+
+      final PreferencesRepository reloaded = PreferencesRepository(db);
+      await reloaded.loadFromDb();
+      expect(reloaded.mineToServer, isTrue);
+
+      await reloaded.setMineToServer(false);
+      expect(reloaded.mineToServer, isFalse);
+    });
+  });
+}

--- a/hibiki/test/sync/sync_interconnect_decouple_migration_test.dart
+++ b/hibiki/test/sync/sync_interconnect_decouple_migration_test.dart
@@ -56,7 +56,45 @@ void main() {
       await db.setPref('sync_backend_type', 'hibikiServer');
 
       await repo.migrateInterconnectBackendToToggle();
-      // 第二次：backendType 已是 googleDrive → 直接 no-op，不会误关互联开关。
+      // 第二次：迁移已标记跑过 → 直接 no-op，不会误关互联开关。
+      await repo.migrateInterconnectBackendToToggle();
+
+      expect(await repo.isInterconnectEnabled(), isTrue);
+      expect(await repo.getBackendType(), SyncBackendType.googleDrive);
+    });
+
+    test('后续用户主动选回互联做备份后端，不会被下次启动的迁移抹掉', () async {
+      // 互联页的「用互联做备份后端」按钮把 backendType 写成 hibikiServer。迁移若还只看
+      // 「backendType 是不是 hibikiServer」，下次启动就会把这个用户选择当成旧数据改回
+      // googleDrive——按钮变成重启即失效的假开关。一次性标记正是为此。
+      final HibikiDatabase db = _testDb();
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+
+      // 首次启动（云用户，无旧互联数据）：迁移跑过并落标记。
+      await repo.migrateInterconnectBackendToToggle();
+      expect(await repo.getBackendType(), SyncBackendType.googleDrive);
+
+      // 用户按下按钮。
+      await repo.setInterconnectEnabled(true);
+      await repo.setBackendType(SyncBackendType.hibikiServer);
+
+      // 下次启动再跑迁移。
+      await repo.migrateInterconnectBackendToToggle();
+
+      expect(await repo.getBackendType(), SyncBackendType.hibikiServer,
+          reason: '用户主动选的备份后端必须活过重启');
+      expect(await repo.isInterconnectEnabled(), isTrue);
+    });
+
+    test('旧互联用户即使升级后才首次启动，仍能被迁移一次', () async {
+      // 标记只在迁移真跑过一次后才存在：存量 hibikiServer 用户的第一次启动必须仍然
+      // 被搬到独立开关（Never break userspace）。
+      final HibikiDatabase db = _testDb();
+      addTearDown(db.close);
+      final SyncRepository repo = SyncRepository(db);
+
+      await db.setPref('sync_backend_type', 'hibikiServer');
       await repo.migrateInterconnectBackendToToggle();
 
       expect(await repo.isInterconnectEnabled(), isTrue);

--- a/hibiki/test/sync/sync_settings_visibility_test.dart
+++ b/hibiki/test/sync/sync_settings_visibility_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/settings/settings_destination.dart';
+import 'package:hibiki/src/settings/settings_schema_card_creation.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_settings_schema.dart';
 
@@ -229,9 +230,9 @@ void main() {
 
     test('is its own top-level destination (not inside syncBackup)', () {
       expect(dest.id, SettingsDestinationId.interconnect);
-      // 启用开关 + 连接设备 + 上传到互联对端（BUG-988）+ 本机服务器 + 互联相关配置
-      // 镜像（远端词典/音频来源/远端占位卡）。
-      expect(dest.sections, hasLength(5));
+      // 启用开关 + 连接设备 + 上传到互联对端（BUG-988）+ 交给已配对设备（制卡/备份
+      // 后端）+ 本机服务器 + 互联相关配置镜像（远端词典/音频来源/远端占位卡）。
+      expect(dest.sections, hasLength(6));
     });
 
     test('enable toggle is unconditional; config sections gated on the toggle',
@@ -254,8 +255,31 @@ void main() {
         'interconnect.upload_video_files',
       ]);
       expect(dest.sections[2].visible, isNotNull);
-      expect(idsOf(dest.sections[3]), <String>['sync.server_mode']);
+      // 交给已配对设备：制卡到已配对设备（原在「制卡」分类）+ 用互联做备份后端。
+      expect(idsOf(dest.sections[3]), <String>[
+        'interconnect.mine_to_server',
+        'interconnect.backup_backend',
+      ]);
       expect(dest.sections[3].visible, isNotNull);
+      expect(idsOf(dest.sections[4]), <String>['sync.server_mode']);
+      expect(dest.sections[4].visible, isNotNull);
+    });
+
+    test('delegate section lives with interconnect, not in card creation', () {
+      // 用户诉求：「制卡到已配对设备要放到 hibiki 互联里面」。开关的前置条件（配对）、
+      // 目标设备、失效条件全由互联决定，故唯一归宿是互联分类——「制卡」分类里不得再有
+      // 第二份，否则互联关掉时那份就是纯死开关。
+      final List<String> allIds = dest.sections
+          .expand((SettingsSection s) => s.items)
+          .map((SettingsItem i) => i.id)
+          .toList();
+      expect(allIds, contains('interconnect.mine_to_server'));
+      final List<String> cardIds = buildCardCreationDestination()
+          .sections
+          .expand((SettingsSection s) => s.items)
+          .map((SettingsItem i) => i.id)
+          .toList();
+      expect(cardIds, isNot(contains('interconnect.mine_to_server')));
     });
 
     test('mirrors interconnect-related settings from lookup/sync categories',
@@ -264,18 +288,18 @@ void main() {
       // 作用于互联对端；在互联分类镜像同一入口（共享 builder，非复制），仅互联被选为
       // 同步方式时可见（与其它互联配置区一致）。
       expect(
-        idsOf(dest.sections[4]),
+        idsOf(dest.sections[5]),
         <String>[
           'lookup.remote_lookup',
           'lookup.audio_sources',
           'sync.show_remote_entries',
         ],
       );
-      expect(dest.sections[4].visible, isNotNull);
+      expect(dest.sections[5].visible, isNotNull);
     });
 
     test('host-server group keeps its explanatory footer', () {
-      expect(dest.sections[3].footer, isNotNull);
+      expect(dest.sections[4].footer, isNotNull);
     });
   });
 }


### PR DESCRIPTION
## 诉求
> 制卡到已配对设备要放到 hibiki 互联里面。hibiki 互联里面加一个按钮，把备份后端设置为 hibiki 互联

## 改动
- **「制卡到已配对设备」移入互联**：从「制卡」分类移到 设置 → **Hibiki 互联** → 新分区「交给已配对设备」（互联启用且本机非 host 时可见）。该开关的前置条件（配对）、目标设备、失效条件全由互联决定，留在制卡页在互联关闭时是纯死开关。
- **新按钮「用互联做备份后端」**：一键把 `backendType` 设成 `hibikiServer`，把备份/同步写到已配对对端而非云盘。未连接设备时禁用并提示；已生效时显示当前状态。退路仍在「同步与备份」的后端选择器（当前值恒被插回选项，非单向门）。切换副作用与后端选择器共用 `applyBackupBackendChange` 单一真相源。

## 根因修复（不修按钮就是假开关）
1. `migrateInterconnectBackendToToggle` 过去靠「backendType ≠ hibikiServer」当哨兵、**每次启动都跑**——用户按下按钮后重启即被抹回 `googleDrive`。改成一次性标记 `sync_interconnect_backend_migrated`，存量旧互联用户的首次迁移不受影响。
2. 备份后端选成互联后只剩一条同步通道，原代码按「位置」把它当云通道 → **静默忽略互联页那四个上传开关**，改由云备份开关决定。改成按后端身份（`HibikiClientSyncBackend`）判定 `isInterconnect`。
3. `toggleMineToServer` 盲翻 API 改为显式 `setMineToServer(bool)`。

## 测试
- 新增 `test/sync/interconnect_backup_backend_test.dart`：切换副作用 / 通道归属 / mine_to_server 偏好往返（6 例）。
- 更新可见性守卫、迁移守卫（新增「用户主动选回互联活过重启」「存量首启仍迁移」两例）、Anki 平铺守卫、设置覆盖 harness 登记键。
- `flutter analyze` 0 issue；全量 `flutter test` 12839 passed / 0 failed。

**待真机**：桌面/手机上把备份后端设成互联后真跑一轮同步、制卡到已配对主机 Anki 落卡。

https://claude.ai/code/session_01EGQEpkcD3bTvLpv3kKJsWk