### PR TITLE
fix(anki): 制卡本地源单词发音 data: URI 被丢弃 (BUG-1045)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1007 条。点号进各自文件。
+> 共 1008 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1043](bugs/BUG-1043-video-mine-word-audio-datauri-dropped.md) | 🚧 | 🚧 | 视频/沉浸制卡本地源单词发音被当data:URI丢弃 |
 | [BUG-1040](bugs/BUG-1040-mined-card-dialog-centered-and-above-popup.md) | ✅ | ✅ | 「卡片已在 Anki 中」是底部 sheet 且层级低于查词弹窗（被盖住看不见） |
 | [BUG-1039](bugs/BUG-1039-native-tier-gif-explodes-mining.md) | ✅ | ✅ | 制卡「原片档」把 GIF 按源分辨率+源帧率导出 → 制卡/覆盖巨慢、Anki 无响应 |
 | [BUG-1038](bugs/BUG-1038-galgame-auto-locale.md) | ✅ | ✅ | Hibiki 启动日文非 Unicode 游戏时界面乱码 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -31,7 +31,7 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-1043](bugs/BUG-1043-video-mine-word-audio-datauri-dropped.md) | 🚧 | 🚧 | 视频/沉浸制卡本地源单词发音被当data:URI丢弃 |
+| [BUG-1045](bugs/BUG-1045-video-mine-word-audio-datauri-dropped.md) | ✅ | ✅ | 视频/沉浸制卡本地源单词发音被当 data: URI 丢弃 |
 | [BUG-1040](bugs/BUG-1040-mined-card-dialog-centered-and-above-popup.md) | ✅ | ✅ | 「卡片已在 Anki 中」是底部 sheet 且层级低于查词弹窗（被盖住看不见） |
 | [BUG-1039](bugs/BUG-1039-native-tier-gif-explodes-mining.md) | ✅ | ✅ | 制卡「原片档」把 GIF 按源分辨率+源帧率导出 → 制卡/覆盖巨慢、Anki 无响应 |
 | [BUG-1038](bugs/BUG-1038-galgame-auto-locale.md) | ✅ | ✅ | Hibiki 启动日文非 Unicode 游戏时界面乱码 |

--- a/docs/bugs/BUG-1043-video-mine-word-audio-datauri-dropped.md
+++ b/docs/bugs/BUG-1043-video-mine-word-audio-datauri-dropped.md
@@ -1,0 +1,24 @@
+## BUG-1043 · 视频/沉浸制卡本地源单词发音被当 data: URI 丢弃
+- **报告**：2026-07-24（用户：app 内视频字幕查词制卡出来的卡「还是没有单词音频」。上一轮已合并的 BUG-1005 修复只覆盖扩展 content.js + CreatorModel `local_audio_enhancement.dart` 两条链，未覆盖视频/沉浸制卡这条 popup-mine 落卡链，故复发。）
+- **真实性**：✅ 真 bug（对 origin/develop 顶端逐行核实，均 file:line）。根因是 `AnkiAudioRef` 的音频引用模型不完整——不认 `data:` URI，把它当成不存在的本地文件静默丢弃：
+  - **产出点** `hibiki/lib/src/utils/misc/lookup_audio_playback.dart:140`：`audioRefToWebViewUrl` 为弹窗 HTML5 `<audio>` 播放，把**本地音频库命中**的单词发音编码成 `data:<mime>;base64,…`。
+  - **透传** popup.js（`assets/popup/popup.js:1294` `fetchAudioUrl` → Dart `resolveWordAudio` → `dictionary_popup_webview.dart:_resolveWordAudio` → `resolveWordAudioWebViewUrl`）把该 `data:` URI 原样写进 mine 的 `fields['audio']`；视频页 `_onMineEntryImpl → _mineVideoCard`（`video_hibiki/lookup_mining.part.dart`）→ `ImmersionMiningEngine.mine` → `repo.mineEntry` 原样透传。
+  - **丢弃点**（四后端同根因，`AnkiAudioRef.classify` 无 `data:` 分支，`data:` 落 `localFile` → `File("data:…")` 不存在 → 静默 `none()`）：
+    - AnkiConnect（桌面/iOS 远程，用户主路径）：`packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart` `_storeRemoteAudio` localFile 分支 `if (!file.existsSync()) return none()`。
+    - AnkiDroid：`packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart` `_addRemoteAudio` localFile 分支。
+    - AnkiMobile：`hibiki/lib/src/anki/ankimobile_repository.dart:414` `_audioFieldForAnkiMobile` localFile 分支。
+    - 互联「制卡到服务端」转发：`hibiki/lib/src/anki/remote_mining_anki_repository.dart:111` 仅 `classify==localFile` 才读字节转发。
+  - 命中**远程发音源**（forvo/jpod101/hibikiRemote 返回 http URL）时本就正常；只有落到**本地音频库**（→ `data:` URI）才被丢。与已修的 CreatorModel/扩展是**不同的链**。
+- **[x] ① 已修复** — 在单一收口处补齐 `AnkiAudioRef` 模型，各 repo 解码内联字节入库（http/localFile 路径零改动，Never break userspace）：
+  - `anki_models.dart`：`AnkiAudioRefKind` 新增 `dataUri`；`classify` 认 `data:` 前缀；新增 `AnkiAudioRef.decodeDataUri`（`UriData.parse` + `contentAsBytes`，坏 URI/空体返 null）→ `AnkiAudioData{bytes, extension}`，`_audioExtForMime` 由 MIME 反推扩展名（`audioMimeForPath` 的逆）。
+  - AnkiConnect `_storeRemoteAudio` / AnkiDroid `_addRemoteAudio`：新增 `case dataUri` 解码写缓存文件，复用既有远端下载入库尾部（`storeMediaFile` / `_addMediaFile`）。
+  - AnkiMobile `_audioFieldForAnkiMobile`：新增 `case dataUri` 解码写临时文件经本地媒体服务器（`addFile` copySync 快照）转 URL，用后即删。
+  - 互联转发 `_buildForwardedPayload`：`dataUri` 分支解码成 `wordAudioBytes`/`wordAudioExt` 转发主机。
+  - 提交：<待填>。
+- **[x] ② 已加自动化测试** — `hibiki/test/anki/anki_audio_ref_test.dart` 扩展：
+  - `classify('data:audio/mpeg;base64,…') == AnkiAudioRefKind.dataUri`（与 http/本地路径/`file://`/空 区分）。
+  - `decodeDataUri`：合法 `data:` 各 MIME → 正确 bytes + 扩展名（mpeg→mp3 / ogg→ogg / mp4·aac→m4a / wav→wav / flac→flac / webm→webm / 未知→mp3）；坏 URI / 空体 / 非 data: → null。
+  - `flutter analyze` 0 issue；上述测试全绿。
+- **备注**：
+  - 真机（只配本地音频库、无远程发音源时，视频字幕查词制卡 App 内 AnkiConnect 出单词发音）验证待办。
+  - 关联 [[BUG-1005]]（同报告的扩展/CreatorModel 单词音频，已合，另一条链）、[[BUG-1004]]（同轮句子音频，记忆里「AnkiAudioRef 加 dataUri/decodeDataUri」实际从未落地，本 bug 才真正补上）、[[BUG-631]]（播放侧本地源退化）。

--- a/docs/bugs/BUG-1043-video-mine-word-audio-datauri-dropped.md
+++ b/docs/bugs/BUG-1043-video-mine-word-audio-datauri-dropped.md
@@ -14,7 +14,7 @@
   - AnkiConnect `_storeRemoteAudio` / AnkiDroid `_addRemoteAudio`：新增 `case dataUri` 解码写缓存文件，复用既有远端下载入库尾部（`storeMediaFile` / `_addMediaFile`）。
   - AnkiMobile `_audioFieldForAnkiMobile`：新增 `case dataUri` 解码写临时文件经本地媒体服务器（`addFile` copySync 快照）转 URL，用后即删。
   - 互联转发 `_buildForwardedPayload`：`dataUri` 分支解码成 `wordAudioBytes`/`wordAudioExt` 转发主机。
-  - 提交：<待填>。
+  - 提交：`3e721862f`（`fix(anki): 制卡本地源单词发音 data: URI 被丢弃 (BUG-1043)`）。
 - **[x] ② 已加自动化测试** — `hibiki/test/anki/anki_audio_ref_test.dart` 扩展：
   - `classify('data:audio/mpeg;base64,…') == AnkiAudioRefKind.dataUri`（与 http/本地路径/`file://`/空 区分）。
   - `decodeDataUri`：合法 `data:` 各 MIME → 正确 bytes + 扩展名（mpeg→mp3 / ogg→ogg / mp4·aac→m4a / wav→wav / flac→flac / webm→webm / 未知→mp3）；坏 URI / 空体 / 非 data: → null。

--- a/docs/bugs/BUG-1045-video-mine-word-audio-datauri-dropped.md
+++ b/docs/bugs/BUG-1045-video-mine-word-audio-datauri-dropped.md
@@ -1,4 +1,4 @@
-## BUG-1043 · 视频/沉浸制卡本地源单词发音被当 data: URI 丢弃
+## BUG-1045 · 视频/沉浸制卡本地源单词发音被当 data: URI 丢弃
 - **报告**：2026-07-24（用户：app 内视频字幕查词制卡出来的卡「还是没有单词音频」。上一轮已合并的 BUG-1005 修复只覆盖扩展 content.js + CreatorModel `local_audio_enhancement.dart` 两条链，未覆盖视频/沉浸制卡这条 popup-mine 落卡链，故复发。）
 - **真实性**：✅ 真 bug（对 origin/develop 顶端逐行核实，均 file:line）。根因是 `AnkiAudioRef` 的音频引用模型不完整——不认 `data:` URI，把它当成不存在的本地文件静默丢弃：
   - **产出点** `hibiki/lib/src/utils/misc/lookup_audio_playback.dart:140`：`audioRefToWebViewUrl` 为弹窗 HTML5 `<audio>` 播放，把**本地音频库命中**的单词发音编码成 `data:<mime>;base64,…`。
@@ -14,7 +14,7 @@
   - AnkiConnect `_storeRemoteAudio` / AnkiDroid `_addRemoteAudio`：新增 `case dataUri` 解码写缓存文件，复用既有远端下载入库尾部（`storeMediaFile` / `_addMediaFile`）。
   - AnkiMobile `_audioFieldForAnkiMobile`：新增 `case dataUri` 解码写临时文件经本地媒体服务器（`addFile` copySync 快照）转 URL，用后即删。
   - 互联转发 `_buildForwardedPayload`：`dataUri` 分支解码成 `wordAudioBytes`/`wordAudioExt` 转发主机。
-  - 提交：`3e721862f`（`fix(anki): 制卡本地源单词发音 data: URI 被丢弃 (BUG-1043)`）。
+  - 提交：`3e721862f`（`fix(anki): 制卡本地源单词发音 data: URI 被丢弃 (BUG-1045)`）。
 - **[x] ② 已加自动化测试** — `hibiki/test/anki/anki_audio_ref_test.dart` 扩展：
   - `classify('data:audio/mpeg;base64,…') == AnkiAudioRefKind.dataUri`（与 http/本地路径/`file://`/空 区分）。
   - `decodeDataUri`：合法 `data:` 各 MIME → 正确 bytes + 扩展名（mpeg→mp3 / ogg→ogg / mp4·aac→m4a / wav→wav / flac→flac / webm→webm / 未知→mp3）；坏 URI / 空体 / 非 data: → null。

--- a/hibiki/lib/src/anki/ankimobile_repository.dart
+++ b/hibiki/lib/src/anki/ankimobile_repository.dart
@@ -412,7 +412,7 @@ class AnkiMobileRepository extends BaseAnkiRepository {
       case AnkiAudioRefKind.remoteUrl:
         return _AnkiMobileAudioField(audio);
       case AnkiAudioRefKind.dataUri:
-        // BUG-1043：查词弹窗把本地音频库命中的单词发音编码成 `data:` URI 塞进
+        // BUG-1045：查词弹窗把本地音频库命中的单词发音编码成 `data:` URI 塞进
         // fields['audio']。解码内联字节写临时文件，经本地媒体服务器（addFile 复制
         // 快照）转成 AnkiMobile 可取的 URL，与 localFile 走同一入库通道。
         final data = AnkiAudioRef.decodeDataUri(audio);

--- a/hibiki/lib/src/anki/ankimobile_repository.dart
+++ b/hibiki/lib/src/anki/ankimobile_repository.dart
@@ -411,6 +411,28 @@ class AnkiMobileRepository extends BaseAnkiRepository {
         return const _AnkiMobileAudioField('');
       case AnkiAudioRefKind.remoteUrl:
         return _AnkiMobileAudioField(audio);
+      case AnkiAudioRefKind.dataUri:
+        // BUG-1043：查词弹窗把本地音频库命中的单词发音编码成 `data:` URI 塞进
+        // fields['audio']。解码内联字节写临时文件，经本地媒体服务器（addFile 复制
+        // 快照）转成 AnkiMobile 可取的 URL，与 localFile 走同一入库通道。
+        final data = AnkiAudioRef.decodeDataUri(audio);
+        if (data == null) return const _AnkiMobileAudioField('');
+        final tempFile = File('${Directory.systemTemp.path}'
+            '${Platform.pathSeparator}hibiki_word_audio_'
+            '${DateTime.now().microsecondsSinceEpoch}.${data.extension}');
+        try {
+          await tempFile.writeAsBytes(data.bytes);
+          final url = await localMediaRef(tempFile.path,
+              mimePath: 'word_audio.${data.extension}');
+          if (url != null) return _AnkiMobileAudioField(url);
+          return const _AnkiMobileAudioField('');
+        } finally {
+          if (tempFile.existsSync()) {
+            try {
+              tempFile.deleteSync();
+            } catch (_) {}
+          }
+        }
       case AnkiAudioRefKind.localFile:
         final path = AnkiAudioRef.localPath(audio);
         final url = await localMediaRef(path);

--- a/hibiki/lib/src/anki/remote_mining_anki_repository.dart
+++ b/hibiki/lib/src/anki/remote_mining_anki_repository.dart
@@ -114,7 +114,7 @@ class RemoteMiningAnkiRepository extends BaseAnkiRepository {
         wordAudioBytes = await _readPath(localPath);
         wordAudioExt = _extOf(localPath);
       } else if (audioKind == AnkiAudioRefKind.dataUri) {
-        // BUG-1043：`data:` 内联单词发音（本地音频库命中）——解码成字节转发给主机，
+        // BUG-1045：`data:` 内联单词发音（本地音频库命中）——解码成字节转发给主机，
         // 否则互联「制卡到服务端」丢单词音频（与本地落卡同一根因）。
         final AnkiAudioData? data = AnkiAudioRef.decodeDataUri(parsed.audio);
         if (data != null) {

--- a/hibiki/lib/src/anki/remote_mining_anki_repository.dart
+++ b/hibiki/lib/src/anki/remote_mining_anki_repository.dart
@@ -108,10 +108,19 @@ class RemoteMiningAnkiRepository extends BaseAnkiRepository {
     try {
       final AnkiMiningPayload parsed = AnkiMiningPayload.fromJson(
           jsonDecode(rawPayloadJson) as Map<String, dynamic>);
-      if (AnkiAudioRef.classify(parsed.audio) == AnkiAudioRefKind.localFile) {
+      final AnkiAudioRefKind audioKind = AnkiAudioRef.classify(parsed.audio);
+      if (audioKind == AnkiAudioRefKind.localFile) {
         final String localPath = AnkiAudioRef.localPath(parsed.audio);
         wordAudioBytes = await _readPath(localPath);
         wordAudioExt = _extOf(localPath);
+      } else if (audioKind == AnkiAudioRefKind.dataUri) {
+        // BUG-1043：`data:` 内联单词发音（本地音频库命中）——解码成字节转发给主机，
+        // 否则互联「制卡到服务端」丢单词音频（与本地落卡同一根因）。
+        final AnkiAudioData? data = AnkiAudioRef.decodeDataUri(parsed.audio);
+        if (data != null) {
+          wordAudioBytes = data.bytes;
+          wordAudioExt = data.extension;
+        }
       }
       dictMedia = _collectDictionaryMedia(parsed.dictionaryMedia);
     } catch (_) {

--- a/hibiki/test/anki/anki_audio_ref_test.dart
+++ b/hibiki/test/anki/anki_audio_ref_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 
@@ -50,6 +52,72 @@ void main() {
         AnkiAudioRef.classify('C:/Users/me/AppData/Local/Temp/word.mp3'),
         AnkiAudioRefKind.localFile,
       );
+    });
+
+    // BUG-1043: the popup encodes a local-audio-library word pronunciation as a
+    // `data:<mime>;base64,…` URI (audioRefToWebViewUrl) and reuses it verbatim
+    // as the mine payload's audio field. It must classify as its own dataUri
+    // kind — not localFile, where the repos treated it as a missing file and
+    // silently dropped the word audio from video/immersion cards.
+    test('data: URI classifies as dataUri', () {
+      expect(
+        AnkiAudioRef.classify('data:audio/mpeg;base64,${base64Encode(const [
+              1,
+              2,
+              3
+            ])}'),
+        AnkiAudioRefKind.dataUri,
+      );
+    });
+  });
+
+  group('AnkiAudioRef.decodeDataUri', () {
+    test('decodes bytes and derives extension from MIME', () {
+      final List<int> raw = List<int>.generate(64, (int i) => i);
+      final AnkiAudioData? data =
+          AnkiAudioRef.decodeDataUri('data:audio/mpeg;base64,${base64Encode(raw)}');
+      expect(data, isNotNull);
+      expect(data!.bytes, raw);
+      expect(data.extension, 'mp3');
+    });
+
+    test('maps each producible MIME to the right extension', () {
+      // Mirrors audioMimeForPath's output set (lookup_audio_playback.dart).
+      const Map<String, String> mimeToExt = <String, String>{
+        'audio/mpeg': 'mp3',
+        'audio/ogg': 'ogg',
+        'audio/mp4': 'm4a',
+        'audio/aac': 'm4a',
+        'audio/wav': 'wav',
+        'audio/flac': 'flac',
+        'audio/webm': 'webm',
+      };
+      final String payload = base64Encode(const <int>[9, 8, 7]);
+      mimeToExt.forEach((String mime, String ext) {
+        final AnkiAudioData? data =
+            AnkiAudioRef.decodeDataUri('data:$mime;base64,$payload');
+        expect(data, isNotNull, reason: mime);
+        expect(data!.extension, ext, reason: mime);
+      });
+    });
+
+    test('unknown MIME falls back to mp3', () {
+      final AnkiAudioData? data = AnkiAudioRef.decodeDataUri(
+          'data:audio/x-unknown;base64,${base64Encode(const [1])}');
+      expect(data?.extension, 'mp3');
+    });
+
+    test('empty payload returns null (no broken media written)', () {
+      expect(AnkiAudioRef.decodeDataUri('data:audio/mpeg;base64,'), isNull);
+    });
+
+    test('non-data: ref returns null', () {
+      expect(AnkiAudioRef.decodeDataUri('https://example.com/a.mp3'), isNull);
+      expect(AnkiAudioRef.decodeDataUri('/tmp/word.mp3'), isNull);
+    });
+
+    test('malformed data: URI returns null', () {
+      expect(AnkiAudioRef.decodeDataUri('data:not-a-valid-uri'), isNull);
     });
   });
 

--- a/hibiki/test/anki/anki_audio_ref_test.dart
+++ b/hibiki/test/anki/anki_audio_ref_test.dart
@@ -54,7 +54,7 @@ void main() {
       );
     });
 
-    // BUG-1043: the popup encodes a local-audio-library word pronunciation as a
+    // BUG-1045: the popup encodes a local-audio-library word pronunciation as a
     // `data:<mime>;base64,…` URI (audioRefToWebViewUrl) and reuses it verbatim
     // as the mine payload's audio field. It must classify as its own dataUri
     // kind — not localFile, where the repos treated it as a missing file and

--- a/packages/hibiki_anki/lib/src/anki_models.dart
+++ b/packages/hibiki_anki/lib/src/anki_models.dart
@@ -721,7 +721,7 @@ String ankiDictionaryMediaCacheFilename(String dictionary, String path) {
 
 /// Kind of audio reference resolved by [WordAudioResolver] and handed to the
 /// repo media-store paths.
-enum AnkiAudioRefKind { empty, remoteUrl, localFile }
+enum AnkiAudioRefKind { empty, remoteUrl, dataUri, localFile }
 
 /// Classifies a word-audio reference for Anki media storage, decided purely
 /// from its string form so the repo audio paths are unit-testable.
@@ -739,6 +739,13 @@ class AnkiAudioRef {
   static AnkiAudioRefKind classify(String ref) {
     if (ref.isEmpty) return AnkiAudioRefKind.empty;
     if (ref.startsWith('http')) return AnkiAudioRefKind.remoteUrl;
+    // BUG-1043：查词弹窗把命中本地音频库的单词发音编码成 `data:<mime>;base64,…`
+    // （audioRefToWebViewUrl，本为弹窗 HTML5 <audio> 播放而生）。视频/沉浸制卡时该
+    // URI 原样进 fields['audio']；它既不是 http 也不是真实文件路径——早先落到
+    // localFile 分支被当成不存在的文件（existsSync()==false）静默丢弃，导致本地源
+    // 单词发音永远进不了卡。识别为独立 kind，由各 repo 解码内联字节入库（远程 http
+    // 发音源本就正常，不受影响）。
+    if (ref.startsWith('data:')) return AnkiAudioRefKind.dataUri;
     return AnkiAudioRefKind.localFile;
   }
 
@@ -746,6 +753,65 @@ class AnkiAudioRef {
   /// decoding `file://` URIs and returning bare paths unchanged.
   static String localPath(String ref) =>
       ref.startsWith('file://') ? Uri.parse(ref).toFilePath() : ref;
+
+  /// Decodes a [AnkiAudioRefKind.dataUri] ref (`data:<mime>;base64,<payload>`,
+  /// produced by `audioRefToWebViewUrl` for popup HTML5 playback and reused
+  /// verbatim as the mine payload's audio field) into its raw bytes plus a
+  /// filename extension derived from the MIME type. Returns null when [ref] is
+  /// not a well-formed data: URI or carries no bytes, so callers fall back to
+  /// "no audio" instead of writing a broken media file into the card.
+  static AnkiAudioData? decodeDataUri(String ref) {
+    if (!ref.startsWith('data:')) return null;
+    final UriData data;
+    try {
+      data = UriData.parse(ref);
+    } catch (_) {
+      return null;
+    }
+    final Uint8List bytes;
+    try {
+      bytes = data.contentAsBytes();
+    } catch (_) {
+      return null;
+    }
+    if (bytes.isEmpty) return null;
+    return AnkiAudioData(
+      bytes: bytes,
+      extension: _audioExtForMime(data.mimeType),
+    );
+  }
+
+  /// Inverse of `audioMimeForPath`: the filename extension to store a decoded
+  /// `data:` audio payload under, from its MIME type. Unknown types fall back to
+  /// `mp3` (the dominant word-audio format).
+  static String _audioExtForMime(String mime) {
+    switch (mime.toLowerCase()) {
+      case 'audio/mpeg':
+        return 'mp3';
+      case 'audio/ogg':
+        return 'ogg';
+      case 'audio/mp4':
+      case 'audio/aac':
+        return 'm4a';
+      case 'audio/wav':
+      case 'audio/x-wav':
+        return 'wav';
+      case 'audio/flac':
+        return 'flac';
+      case 'audio/webm':
+        return 'webm';
+      default:
+        return 'mp3';
+    }
+  }
+}
+
+/// Decoded inline audio payload from a [AnkiAudioRefKind.dataUri] ref: the raw
+/// [bytes] and the filename [extension] to store them under in Anki media.
+class AnkiAudioData {
+  const AnkiAudioData({required this.bytes, required this.extension});
+  final Uint8List bytes;
+  final String extension;
 }
 
 String ankiInlineMediaReference(String addMediaResult) {

--- a/packages/hibiki_anki/lib/src/anki_models.dart
+++ b/packages/hibiki_anki/lib/src/anki_models.dart
@@ -739,7 +739,7 @@ class AnkiAudioRef {
   static AnkiAudioRefKind classify(String ref) {
     if (ref.isEmpty) return AnkiAudioRefKind.empty;
     if (ref.startsWith('http')) return AnkiAudioRefKind.remoteUrl;
-    // BUG-1043：查词弹窗把命中本地音频库的单词发音编码成 `data:<mime>;base64,…`
+    // BUG-1045：查词弹窗把命中本地音频库的单词发音编码成 `data:<mime>;base64,…`
     // （audioRefToWebViewUrl，本为弹窗 HTML5 <audio> 播放而生）。视频/沉浸制卡时该
     // URI 原样进 fields['audio']；它既不是 http 也不是真实文件路径——早先落到
     // localFile 分支被当成不存在的文件（existsSync()==false）静默丢弃，导致本地源

--- a/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -941,6 +941,22 @@ class AnkiConnectRepository extends BaseAnkiRepository {
       switch (AnkiAudioRef.classify(url)) {
         case AnkiAudioRefKind.empty:
           return const AudioFetchOutcome.none();
+        case AnkiAudioRefKind.dataUri:
+          // BUG-1043：查词弹窗把本地音频库命中的单词发音编码成 `data:` URI 塞进
+          // fields['audio']。解码内联字节写入缓存文件，走与远端下载相同的入库尾部
+          // （下方 storeMediaFile），不再当成不存在的本地文件丢弃。
+          final data = AnkiAudioRef.decodeDataUri(url);
+          if (data == null) return const AudioFetchOutcome.none();
+          final cacheDir = Directory('${Directory.systemTemp.path}/anki-media');
+          if (!cacheDir.existsSync()) cacheDir.createSync(recursive: true);
+          final filename = await hibikiAnkiMediaFilenameForBytesAsync(
+            prefix: 'hibiki_audio_',
+            bytes: data.bytes,
+            sourceName: 'word_audio.${data.extension}',
+            fallbackExtension: data.extension,
+          );
+          audioFile = File('${cacheDir.path}/$filename');
+          await audioFile.writeAsBytes(data.bytes);
         case AnkiAudioRefKind.localFile:
           // file:// URI or a bare absolute path (Unix `/…` or Windows `C:\…`).
           final file = File(AnkiAudioRef.localPath(url));

--- a/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -942,7 +942,7 @@ class AnkiConnectRepository extends BaseAnkiRepository {
         case AnkiAudioRefKind.empty:
           return const AudioFetchOutcome.none();
         case AnkiAudioRefKind.dataUri:
-          // BUG-1043：查词弹窗把本地音频库命中的单词发音编码成 `data:` URI 塞进
+          // BUG-1045：查词弹窗把本地音频库命中的单词发音编码成 `data:` URI 塞进
           // fields['audio']。解码内联字节写入缓存文件，走与远端下载相同的入库尾部
           // （下方 storeMediaFile），不再当成不存在的本地文件丢弃。
           final data = AnkiAudioRef.decodeDataUri(url);

--- a/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
@@ -632,6 +632,21 @@ class AnkiRepository extends BaseAnkiRepository {
       switch (AnkiAudioRef.classify(url)) {
         case AnkiAudioRefKind.empty:
           return const AudioFetchOutcome.none();
+        case AnkiAudioRefKind.dataUri:
+          // BUG-1043：查词弹窗把本地音频库命中的单词发音编码成 `data:` URI 塞进
+          // fields['audio']。解码内联字节写入缓存文件，走与远端下载相同的入库尾部
+          // （下方 _addMediaFile），不再当成不存在的本地文件丢弃。
+          final data = AnkiAudioRef.decodeDataUri(url);
+          if (data == null) return const AudioFetchOutcome.none();
+          final cacheDir = await _mediaCacheDir();
+          final preferredName = await hibikiAnkiMediaFilenameForBytesAsync(
+            prefix: 'hibiki_audio_',
+            bytes: data.bytes,
+            sourceName: 'word_audio.${data.extension}',
+            fallbackExtension: data.extension,
+          );
+          audioFile = File('${cacheDir.path}/$preferredName');
+          await audioFile.writeAsBytes(data.bytes);
         case AnkiAudioRefKind.localFile:
           // file:// URI or a bare absolute path (Unix `/…` or Windows `C:\…`).
           final file = File(AnkiAudioRef.localPath(url));

--- a/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
@@ -633,7 +633,7 @@ class AnkiRepository extends BaseAnkiRepository {
         case AnkiAudioRefKind.empty:
           return const AudioFetchOutcome.none();
         case AnkiAudioRefKind.dataUri:
-          // BUG-1043：查词弹窗把本地音频库命中的单词发音编码成 `data:` URI 塞进
+          // BUG-1045：查词弹窗把本地音频库命中的单词发音编码成 `data:` URI 塞进
           // fields['audio']。解码内联字节写入缓存文件，走与远端下载相同的入库尾部
           // （下方 _addMediaFile），不再当成不存在的本地文件丢弃。
           final data = AnkiAudioRef.decodeDataUri(url);


### PR DESCRIPTION
## 问题
用户报告：**App 内视频字幕查词制卡出来的卡还是没有单词音频**。

上一轮确认的 BUG-1005 修复只覆盖了**浏览器扩展 content.js** 和 **CreatorModel 自动填充**（`local_audio_enhancement.dart`）两条链；视频/沉浸制卡走的是**第三条 popup-mine 落卡链**，未被覆盖，故复发。

## 根因（对 origin/develop 顶端逐行核实）
`AnkiAudioRef` 的音频引用模型不认 `data:` URI：
1. `audioRefToWebViewUrl`（`lookup_audio_playback.dart:140`）为弹窗 HTML5 `<audio>` 播放，把**本地音频库命中**的单词发音编码成 `data:<mime>;base64,…`。
2. popup.js 制卡时把该 `data:` URI 原样写进 `fields['audio']`，经 `_mineVideoCard → ImmersionMiningEngine → repo.mineEntry` 透传。
3. `AnkiAudioRef.classify` 只有 `http→remoteUrl` / 其余→`localFile`，**无 `data:` 分支** → `data:` 落 `localFile` → `File("data:…")` 不存在 → 各 repo `existsSync()==false` **静默丢弃**（连 warning 都没有）。

命中**远程发音源**（forvo/jpod101/hibikiRemote 返回 http URL）时本就正常；只有落到**本地音频库**才被丢。

## 修复（单一收口，四后端一致，http/localFile 零改动）
- `anki_models.dart`：`AnkiAudioRefKind` 增 `dataUri`；`classify` 认 `data:`；新增 `AnkiAudioRef.decodeDataUri`（`UriData`→bytes + 由 MIME 反推扩展名，坏 URI/空体返 null）+ `AnkiAudioData`。
- **AnkiConnect** `_storeRemoteAudio` / **AnkiDroid** `_addRemoteAudio`：`case dataUri` 解码写缓存文件，复用既有远端下载入库尾部。
- **AnkiMobile** `_audioFieldForAnkiMobile`：`case dataUri` 解码写临时文件经本地媒体服务器转 URL。
- **互联转发** `_buildForwardedPayload`：`dataUri` 分支解码成字节转发主机（否则「制卡到服务端」同样漏单词音频）。

## 测试
- `hibiki/test/anki/anki_audio_ref_test.dart` 扩展：`classify(data:)==dataUri`；`decodeDataUri` 各可产 MIME → 正确 bytes+扩展名（mpeg→mp3/ogg→ogg/mp4·aac→m4a/wav→wav/flac→flac/webm→webm/未知→mp3）；坏 URI/空体/非 data: → null。
- `flutter analyze` 我改的文件 0 issue；`test/anki` 全量 **153 绿**（含 remote_mining 转发回归）。

## 待办
- 真机：只配本地音频库、无远程发音源时，视频字幕查词制卡 App 内 AnkiConnect 出单词发音。

关联 BUG-1005（已合，扩展/CreatorModel 链）、BUG-1004（同轮句子音频）、BUG-631（播放侧本地源退化）。

https://claude.ai/code/session_01UyntRttpAywe6zQoTNCCm9
