### PR TITLE
refactor: 架构审查——13 个重复代码簇全部合并（生产 9 + 测试夹具 3 家族）+ 审查报告

### DIFF
--- a/docs/reviews/2026-07-24-project-review.md
+++ b/docs/reviews/2026-07-24-project-review.md
@@ -1,0 +1,68 @@
+# 2026-07-24 项目整体架构审查：冗长热点与重复代码合并
+
+基线：`origin/develop @ dbb1f6c60`。本轮两个目标：①梳理整体架构、标出冗长热点；②扫描「同一段代码存在多份」的簇并**优先合并**。机械扫描（归一化行 + 15 行滑动窗口哈希，全仓 Dart）+ 4 路语义排查（EPUB 生成 / 录音与 creator / 同步后端家族 / 弹窗·统计·anki·解析器）。
+
+## 一、架构总览（代码量分布）
+
+生产代码（非生成 Dart）约 **26.5 万行**；测试 **30.2 万行 / 1729 文件** + 集成测试 1.9 万行 / 80 文件——测试体量已超生产代码。
+
+| 层 | 行数 | 文件数 | 说明 |
+|---|---|---|---|
+| `hibiki/lib/src/pages/` | 79.5k | 126 | 最重的一层；`implementations/` 下 89 个页面文件 |
+| `hibiki/lib/src/media/` | 51.1k | 144 | audiobook 24 / video 72 / torrent 15 |
+| `hibiki/lib/src/sync/` | 40.3k | 98 | 7 个 `*_sync_backend` + 备份/互联/服务器 |
+| `hibiki/lib/src/utils/` | 27.5k | 92 | 含 `hibiki_material_components.dart` 2859 行 |
+| `hibiki/lib/src/reader/` | 12.8k | 17 | JS/CSS 注入封装 |
+| `hibiki/lib/src/models/` | 12.2k | 18 | `app_model.dart` 5514 行 |
+| packages 五包 | ~32k | — | audio 8.0k / core 7.0k / anki 5.8k / dictionary 4.0k / inappwebview fork 6.3k |
+
+### 冗长热点（单文件 Top）
+
+| 文件 | 行数 | 评注 |
+|---|---|---|
+| `video_hibiki_page.dart` | 6485（+18 个 part 共 7153） | 已拆 part 仍在涨；主体里还嵌着弹窗 overlay 同步等可下沉逻辑（见 §三-5） |
+| `hibiki_core/database.dart` | 5589 | schema v51 迁移链，结构性长，可接受 |
+| `app_model.dart` | 5514 | god-object 倾向；初始化 + 词典搜索 + 导入 + 媒体管理同居一类，已有子系统委托但仍在涨 |
+| `backup_service.dart` | 3875 | 备份 + 合并 + 资产打包多职责 |
+| `home_video_page.dart` | 3494 | 与书架页共享的批量合集操作各持一份（§三-6） |
+| `reader_pagination_scripts.dart` | 3283 | JS 字符串包装，结构性长 |
+| `reader_hibiki_page.dart` | 3263（+8 part 共 9649） | part 化后主体可控 |
+| `hibiki_sync_server.dart` / `sync_orchestrator.dart` | 2889 / 2635 | — |
+
+结构性判断：拆 part 只是物理切分，**页面层（79.5k）与 sync（40.3k）的膨胀本质是「共享逻辑在页面间复制」**——本轮机械扫描证实了这一点（下节）。
+
+## 二、本轮已合并的重复簇（4 项，全部测试绿）
+
+| # | 簇 | 重复量 | 合并落点 | commit |
+|---|---|---|---|---|
+| 1 | `TextToEpub` ↔ `CuesToEpub`：整套 ZIP 打包器 + OCF/OPF/NCX/nav 生成器两份逐字复制（仅 uid 前缀漂移） | ~150 行 ×2 | `hibiki_audio/src/matching/epub_builder.dart`（`EpubBuilder.assemble`，uid 前缀参数化保持 `hibiki-` / `hibiki-text-` 不变）；顺带给 TextToEpub 补了行为单测（此前该导入路径**零覆盖**）、测试侧 ZIP 读取器抽 `test/helpers/epub_zip_reader.dart` | `e018cdeab` |
+| 2 | SRT/ASS/VTT 三份解析器的 isolate 派发脚手架（`parseStringAsync` + `_parseStringIsolate` + 阈值判定） | ~45 行 ×3 | `hibiki_audio/src/parsers/cue_parse_dispatch.dart`（`CueParseDispatch.run`）；公开 API 原签名转发，调用方零改动 | `e7448502b` |
+| 3 | `AudioExportField` ↔ `ImageExportField`：`getSearchTermWithFallback` + `setSearching` + 搜索状态字段逐字复制 | ~60 行 ×2 | `hibiki/src/creator/export_field_search.dart`（`ExportFieldSearch` mixin on `Field`） | `853a35ed7` |
+| 4 | AnkiConnect ↔ AnkiDroid：`_renderMinedFields` 尾段（context 克隆 + payload 16 字段透传 + 打包）逐字复制——新增 payload 字段最易漏改一端 | ~50 行 ×2 | `BaseAnkiRepository.renderMediaPayload`（@protected）；两后端只保留真实差异（媒体引用准备方式） | `91d543089` |
+
+验证：`flutter analyze` 0 issue；靶向测试 28（epub）+113（parsers）+49（creator）+192（anki 包）+146（anki app）全绿；全量 `flutter test` 见 PR 描述。
+
+## 三、待合并 backlog（按 收益/风险 排序）
+
+1. **Dropbox ↔ OneDrive OAuth 外壳**（`handleAuthCode`/`_exchangeCode`/`restoreAuth`/`refreshAuth`/`_authHeaders` 五块逐字复制 ~42 行；`_checkResponse` 与授权 URL 是真实协议分叉**不动**）。方案：`PkceBackendAuthMixin` + `persistToken` 钩子。⚠️ 两后端 OAuth **无单测**，重构前先补回归网。
+2. **hibiki_client ↔ webdav 路径式四件套**（`findOrCreateRootFolder`/`listBooks`/`ensureBookFolder`/`listSyncFiles` ~45 行，都基于同一 `WebDavOps`）。方案：`WebDavPathBackendMixin` + `ensureReady()` 钩子（hibiki_client 的 `_ensureResolved()` 时机必须逐点保留）。
+3. **删除确认弹窗三份**：`_DeleteScopeConfirmDialog`（sync/deletion_prompt）↔ `ReaderHistoryDeleteDialog`（reader_history/dialogs.part）↔ `stat_delete_confirm_dialog`，build 主体逐字同构 ~46 行。⚠️ `md3_design_system_static_test.dart:1308,1431` 硬编码断言类名，重构须同步改。
+4. **音频预览播放器三份**：`base_audio_field.dart:203-324` ↔ `audio_recorder_page.dart:175-296` ↔ `play_audio_action.dart:66-96`（AudioSession 配置 + becomingNoisy + 时长/滑条三件套，~105 行）。已实际漂移：recorder 修了 `_durationNotifier` 可空 bug（HBK-AUDIT-107）与 slider `max=1.0` 兜底，base **两处都没拿到**——这是「复制导致修复不同步」的活例。先抽 `beginDuckingPlayback` 会话 helper（覆盖三份），widget 三件套再议。
+5. **查词弹窗根 Overlay 同步**：`home_dictionary_page._syncPopupOverlay` ↔ `video_hibiki_page._syncPopupOverlay` 几乎逐字（两页已共享 `DictionaryPageMixin`，此方法漏在 mixin 外）；`_buildPopupOverlay` 有 BUG-861 hover 转发分叉，上提需抽钩子。
+6. **批量合并合集编排**：`home_video_page:1037` ↔ `reader_history/books.part:662`（决策纯函数已抽 `batch_combine.dart`，残余 DB 编排 + TOCTOU 复查 ~50 行两份）。方案：`combineMergeCollections({db, onRefresh})`。
+7. **Enhancement ↔ QuickAction 注册脚手架**（本地化 map + `getLocalisedLabel/Description` + `initialise` 幂等 ~37 行 ×2，未漂移）：抽 `CreatorRegistryEntry` 基类，纯机械但触面广。
+8. **统计页书/视频行**（`reading_statistics_page:1180` ↔ `video_statistics_page:410`，~45 行）：抽 `buildStatMediaRow`，golden 可能需更新。
+9. **测试夹具成套复制（体量最大）**：sync 测试家族共享 140 行 ×3 / 56 行 ×7 的 harness，audiobook 测试 113 行 ×5、67 行 ×4，integration_test reader 系列 79 行 ×5——是测试 30 万行的主要水分。建议按家族抽 `test/sync/helpers/`、`test/media/audiobook/helpers/` 共享 harness，一个家族一个 PR。
+
+## 四、明确不合并（故意的复制）
+
+- **Material ↔ Cupertino 设置渲染器**：故意的平台双渲染器；auto 五平台统一 MD3，Cupertino 是隐藏内部能力。注意其不会自动获得 Material 侧修复（如 BUG-042 physics），属已知滞后。
+- **`flutter_inappwebview_windows` fork 内 `in_app_webview` ↔ `headless_in_app_webview`（~217 行）**：上游 fork 的固有结构，为保持与上游 diff 最小不动。
+- **弹窗三镜像 / background.js 双镜像**（popup / 扩展 content.css）：构建约束的镜像，改一处必须同步三处（守卫见 `reference_popup_extension_3way_parity`），不是可抽公共模块的重复。
+- **`DictionaryPopupLayer` ↔ `DictionaryPopupWebView` 回调字段**：wrapper 转发层固有；可选抽 `DictionaryPopupCallbacks` 参数对象但改动面大、收益低，暂缓。
+
+## 五、结论
+
+- 「好品味」视角：本轮 4 个合并全部是**把特殊情况参数化后消掉整段复制**（uid 前缀、媒体引用准备、平台守卫），公开 API 零破坏、调用方零改动。
+- 复制的真实代价已在仓里发生：簇 4（音频播放器）两处漂移=一处修了 bug 另一处没有；簇 4（anki payload）新增字段要人肉记得改两端。backlog 1/4/5 三项同属此类，优先级最高。
+- 页面层与 sync 层的「冗长」大头不是单文件长，而是**页面间横向复制**；后续新功能落地时应默认先找 mixin/基类落点再写页面私有方法。

--- a/hibiki/lib/creator.dart
+++ b/hibiki/lib/creator.dart
@@ -4,6 +4,7 @@ export 'src/creator/field.dart';
 export 'src/creator/audio_enhancement.dart';
 export 'src/creator/image_enhancement.dart';
 export 'src/creator/quick_action.dart';
+export 'src/creator/export_field_search.dart';
 export 'src/creator/image_export_field.dart';
 export 'src/creator/audio_export_field.dart';
 

--- a/hibiki/lib/src/creator/audio_export_field.dart
+++ b/hibiki/lib/src/creator/audio_export_field.dart
@@ -9,7 +9,7 @@ import 'package:hibiki/utils.dart';
 /// A special kind of field that has a special widget at the top of the creator.
 /// For example, the audio field has a media player that can be controlled
 /// based on its values.
-abstract class AudioExportField extends Field {
+abstract class AudioExportField extends Field with ExportFieldSearch {
   /// Initialise this field with the predetermined and hardset values.
   AudioExportField({
     required super.uniqueKey,
@@ -21,14 +21,6 @@ abstract class AudioExportField extends Field {
   /// The image file selected for export.
   File? get exportFile => _exportFile;
   File? _exportFile;
-
-  /// The current search term for the image.
-  String? get currentSearchTerm => _currentSearchTerm;
-  String? _currentSearchTerm;
-
-  /// Whether or not searching is in progress.
-  bool get isSearching => _isSearching;
-  bool _isSearching = false;
 
   /// Whether or not the current media cannot be overridden by an auto enhancement.
   bool _autoCannotOverride = false;
@@ -42,20 +34,8 @@ abstract class AudioExportField extends Field {
     required CreatorModel creatorModel,
   }) {
     _exportFile = null;
-    _currentSearchTerm = null;
+    currentSearchTermInternal = null;
     _autoCannotOverride = false;
-    creatorModel.refresh();
-  }
-
-  /// Flag for showing the loading state of the picker.
-  void setSearching({
-    required AppModel appModel,
-    required CreatorModel creatorModel,
-    required bool isSearching,
-    String? searchTerm,
-  }) {
-    _isSearching = isSearching;
-    _currentSearchTerm = searchTerm;
     creatorModel.refresh();
   }
 
@@ -68,48 +48,9 @@ abstract class AudioExportField extends Field {
   }) {
     creatorModel.getFieldController(this).clear();
     _exportFile = file;
-    _currentSearchTerm = searchTermUsed;
-    _isSearching = false;
+    currentSearchTermInternal = searchTermUsed;
+    isSearchingInternal = false;
     creatorModel.refresh();
-  }
-
-  /// Fetches the search term to use from the [CreatorModel]. If the field
-  /// controller is empty, use a fallback and inform the user that a fallback
-  /// has been used.
-  String? getSearchTermWithFallback({
-    required AppModel appModel,
-    required CreatorModel creatorModel,
-    required List<Field> fallbackSearchTerms,
-  }) {
-    String searchTerm = creatorModel.getFieldController(this).text.trim();
-    if (searchTerm.isNotEmpty) {
-      return searchTerm;
-    } else {
-      for (Field fallbackField in fallbackSearchTerms) {
-        String fallbackTerm =
-            creatorModel.getFieldController(fallbackField).text.trim();
-        if (fallbackTerm.isNotEmpty) {
-          HibikiToast.show(
-            msg: t.field_fallback_used(
-              field: getLocalisedLabel(appModel),
-              secondField: fallbackField.getLocalisedLabel(appModel),
-            ),
-            toastLength: Toast.LENGTH_SHORT,
-            gravity: ToastGravity.BOTTOM,
-          );
-
-          return fallbackTerm;
-        }
-      }
-    }
-
-    HibikiToast.show(
-      msg: t.no_text_to_search,
-      toastLength: Toast.LENGTH_SHORT,
-      gravity: ToastGravity.BOTTOM,
-    );
-
-    return null;
   }
 
   /// Media fields are special and have a [Widget] that is shown at the top of

--- a/hibiki/lib/src/creator/export_field_search.dart
+++ b/hibiki/lib/src/creator/export_field_search.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+import 'package:hibiki/creator.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/utils.dart';
+
+/// 媒体导出字段（音频 / 图片）共用的搜索状态与回退取词逻辑。
+///
+/// [AudioExportField] 与 [ImageExportField] 此前各自复制了
+/// `setSearching` / `getSearchTermWithFallback` 与搜索状态字段；
+/// 此 mixin 是单一真相源，行为与原实现逐字一致。
+mixin ExportFieldSearch on Field {
+  /// The current search term for the media being searched.
+  String? get currentSearchTerm => _currentSearchTerm;
+  String? _currentSearchTerm;
+
+  /// Whether or not searching is in progress.
+  bool get isSearching => _isSearching;
+  bool _isSearching = false;
+
+  /// 子类内部写搜索词状态（不触发 refresh）。
+  @protected
+  set currentSearchTermInternal(String? value) => _currentSearchTerm = value;
+
+  /// 子类内部写搜索中状态（不触发 refresh）。
+  @protected
+  set isSearchingInternal(bool value) => _isSearching = value;
+
+  /// Flag for showing the loading state of the picker.
+  void setSearching({
+    required AppModel appModel,
+    required CreatorModel creatorModel,
+    required bool isSearching,
+    String? searchTerm,
+  }) {
+    _isSearching = isSearching;
+    _currentSearchTerm = searchTerm;
+    creatorModel.refresh();
+  }
+
+  /// Fetches the search term to use from the [CreatorModel]. If the field
+  /// controller is empty, use a fallback and inform the user that a fallback
+  /// has been used.
+  String? getSearchTermWithFallback({
+    required AppModel appModel,
+    required CreatorModel creatorModel,
+    required List<Field> fallbackSearchTerms,
+  }) {
+    String searchTerm = creatorModel.getFieldController(this).text.trim();
+    if (searchTerm.isNotEmpty) {
+      return searchTerm;
+    } else {
+      for (Field fallbackField in fallbackSearchTerms) {
+        String fallbackTerm =
+            creatorModel.getFieldController(fallbackField).text.trim();
+        if (fallbackTerm.isNotEmpty) {
+          HibikiToast.show(
+            msg: t.field_fallback_used(
+              field: getLocalisedLabel(appModel),
+              secondField: fallbackField.getLocalisedLabel(appModel),
+            ),
+            toastLength: Toast.LENGTH_SHORT,
+            gravity: ToastGravity.BOTTOM,
+          );
+
+          return fallbackTerm;
+        }
+      }
+    }
+
+    HibikiToast.show(
+      msg: t.no_text_to_search,
+      toastLength: Toast.LENGTH_SHORT,
+      gravity: ToastGravity.BOTTOM,
+    );
+
+    return null;
+  }
+}

--- a/hibiki/lib/src/creator/image_export_field.dart
+++ b/hibiki/lib/src/creator/image_export_field.dart
@@ -3,12 +3,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:network_to_file_image/network_to_file_image.dart';
 import 'package:hibiki/creator.dart';
 import 'package:hibiki/models.dart';
-import 'package:hibiki/utils.dart';
 
 /// A special kind of field that has a special widget at the top of the creator.
 /// For example, the audio field has a media player that can be controlled
 /// based on its values.
-abstract class ImageExportField extends Field with ChangeNotifier {
+abstract class ImageExportField extends Field
+    with ChangeNotifier, ExportFieldSearch {
   /// Initialise this field with the predetermined and hardset values.
   ImageExportField({
     required super.uniqueKey,
@@ -32,14 +32,6 @@ abstract class ImageExportField extends Field with ChangeNotifier {
   ValueNotifier<int> get indexNotifier => _indexNotifier;
   final ValueNotifier<int> _indexNotifier = ValueNotifier<int>(0);
 
-  /// The current search term for the image.
-  String? get currentSearchTerm => _currentSearchTerm;
-  String? _currentSearchTerm;
-
-  /// Whether or not searching is in progress.
-  bool get isSearching => _isSearching;
-  bool _isSearching = false;
-
   /// Whether or not the current media cannot be overridden by an auto enhancement.
   bool _autoCannotOverride = false;
 
@@ -56,8 +48,8 @@ abstract class ImageExportField extends Field with ChangeNotifier {
     _exportFile = null;
     _imageSuggestions = null;
     _indexNotifier.value = 0;
-    _currentSearchTerm = null;
-    _isSearching = false;
+    currentSearchTermInternal = null;
+    isSearchingInternal = false;
     _autoCannotOverride = false;
 
     creatorModel.refresh();
@@ -114,18 +106,6 @@ abstract class ImageExportField extends Field with ChangeNotifier {
     }
   }
 
-  /// Flag for showing the loading state of the picker.
-  void setSearching({
-    required AppModel appModel,
-    required CreatorModel creatorModel,
-    required bool isSearching,
-    String? searchTerm,
-  }) {
-    _isSearching = isSearching;
-    _currentSearchTerm = searchTerm;
-    creatorModel.refresh();
-  }
-
   /// Takes a non-empty new list of images to set as the new image suggestions.
   /// By default, this replaces the [exportFile] with the index set in
   /// [newSelectedSuggestionIndex].
@@ -153,8 +133,8 @@ abstract class ImageExportField extends Field with ChangeNotifier {
     _imageSuggestions = images;
     _exportFile = images.first;
     _indexNotifier.value = newSelectedSuggestionIndex;
-    _currentSearchTerm = searchTermUsed;
-    _isSearching = false;
+    currentSearchTermInternal = searchTermUsed;
+    isSearchingInternal = false;
     creatorModel.refresh();
     carouselNotifier.notifyListeners();
   }
@@ -171,45 +151,6 @@ abstract class ImageExportField extends Field with ChangeNotifier {
     }
 
     _indexNotifier.value = index;
-  }
-
-  /// Fetches the search term to use from the [CreatorModel]. If the field
-  /// controller is empty, use a fallback and inform the user that a fallback
-  /// has been used.
-  String? getSearchTermWithFallback({
-    required AppModel appModel,
-    required CreatorModel creatorModel,
-    required List<Field> fallbackSearchTerms,
-  }) {
-    String searchTerm = creatorModel.getFieldController(this).text.trim();
-    if (searchTerm.isNotEmpty) {
-      return searchTerm;
-    } else {
-      for (Field fallbackField in fallbackSearchTerms) {
-        String fallbackTerm =
-            creatorModel.getFieldController(fallbackField).text.trim();
-        if (fallbackTerm.isNotEmpty) {
-          HibikiToast.show(
-            msg: t.field_fallback_used(
-              field: getLocalisedLabel(appModel),
-              secondField: fallbackField.getLocalisedLabel(appModel),
-            ),
-            toastLength: Toast.LENGTH_SHORT,
-            gravity: ToastGravity.BOTTOM,
-          );
-
-          return fallbackTerm;
-        }
-      }
-    }
-
-    HibikiToast.show(
-      msg: t.no_text_to_search,
-      toastLength: Toast.LENGTH_SHORT,
-      gravity: ToastGravity.BOTTOM,
-    );
-
-    return null;
   }
 
   /// Media fields are special and have a [Widget] that is shown at the top of

--- a/hibiki/lib/src/media/audiobook/text_to_epub.dart
+++ b/hibiki/lib/src/media/audiobook/text_to_epub.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -7,6 +6,10 @@ import 'package:hibiki_audio/hibiki_audio.dart';
 
 /// Converts plain text files (TXT, HTML, MD, etc.) into valid EPUB 3 bytes
 /// suitable for import via [EpubImporter].
+///
+/// Container assembly (ZIP/OPF/NCX/nav) is shared with [CuesToEpub] via
+/// [EpubBuilder]; only the input parsing and chapter body generation live
+/// here.
 class TextToEpub {
   static const int kMaxCharsPerChapter = 30000;
 
@@ -41,39 +44,22 @@ class TextToEpub {
     final String ext = file.path.split('.').last.toLowerCase();
     final List<String> chapters = _splitIntoChapters(content, ext);
 
-    final zip = _EpubZip();
-    zip.addStored('mimetype', utf8.encode('application/epub+zip'));
-    zip.addDeflated('META-INF/container.xml', utf8.encode(_containerXml()));
-    zip.addDeflated(
-      'OEBPS/content.opf',
-      utf8.encode(_contentOpf(
-        title: title,
-        author: author,
-        chapterCount: chapters.length,
-      )),
-    );
-    zip.addDeflated(
-      'OEBPS/toc.ncx',
-      utf8.encode(_tocNcx(title: title, chapterCount: chapters.length)),
-    );
-    zip.addDeflated(
-      'OEBPS/nav.xhtml',
-      utf8.encode(_navXhtml(title: title, chapterCount: chapters.length)),
-    );
-
-    for (int i = 0; i < chapters.length; i++) {
-      zip.addDeflated(
-        'OEBPS/chapter-${i + 1}.xhtml',
-        utf8.encode(_chapterXhtml(
+    final List<String> chapterXhtmls = <String>[
+      for (int i = 0; i < chapters.length; i++)
+        _chapterXhtml(
           title: title,
           chapterIndex: i,
           totalChapters: chapters.length,
           bodyHtml: chapters[i],
-        )),
-      );
-    }
+        ),
+    ];
 
-    return zip.build();
+    return EpubBuilder.assemble(
+      title: title,
+      author: author,
+      uidPrefix: 'hibiki-text-',
+      chapterXhtmls: chapterXhtmls,
+    );
   }
 
   // ── Content splitting ─────────────────────────────────────────────────────
@@ -182,106 +168,7 @@ class TextToEpub {
         .trim();
   }
 
-  // ── XML/XHTML generators ──────────────────────────────────────────────────
-
-  static String _containerXml() => '<?xml version="1.0" encoding="UTF-8"?>\n'
-      '<container version="1.0"'
-      ' xmlns="urn:oasis:names:tc:opendocument:xmlns:container">\n'
-      '  <rootfiles>\n'
-      '    <rootfile full-path="OEBPS/content.opf"'
-      ' media-type="application/oebps-package+xml"/>\n'
-      '  </rootfiles>\n'
-      '</container>\n';
-
-  static String _contentOpf({
-    required String title,
-    required int chapterCount,
-    String? author,
-  }) {
-    final authorTag = (author != null && author.isNotEmpty)
-        ? '\n    <dc:creator>${_esc(author)}</dc:creator>'
-        : '';
-    final now = DateTime.now()
-        .toUtc()
-        .toIso8601String()
-        .replaceFirst(RegExp(r'\.\d+Z$'), 'Z');
-
-    final manifest = StringBuffer();
-    final spine = StringBuffer();
-    for (int i = 1; i <= chapterCount; i++) {
-      manifest.write('    <item id="chapter-$i" href="chapter-$i.xhtml"'
-          ' media-type="application/xhtml+xml"/>\n');
-      spine.write('    <itemref idref="chapter-$i"/>\n');
-    }
-
-    final uid = 'hibiki-text-${DateTime.now().millisecondsSinceEpoch}';
-    return '<?xml version="1.0" encoding="UTF-8"?>\n'
-        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"\n'
-        '         unique-identifier="uid" xml:lang="ja">\n'
-        '  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">\n'
-        '    <dc:identifier id="uid">$uid</dc:identifier>\n'
-        '    <dc:title>${_esc(title)}</dc:title>$authorTag\n'
-        '    <dc:language>ja</dc:language>\n'
-        '    <meta property="dcterms:modified">$now</meta>\n'
-        '  </metadata>\n'
-        '  <manifest>\n'
-        '$manifest'
-        '    <item id="nav" href="nav.xhtml"'
-        ' media-type="application/xhtml+xml" properties="nav"/>\n'
-        '    <item id="ncx" href="toc.ncx"'
-        ' media-type="application/x-dtbncx+xml"/>\n'
-        '  </manifest>\n'
-        '  <spine toc="ncx">\n'
-        '$spine'
-        '  </spine>\n'
-        '</package>\n';
-  }
-
-  static String _tocNcx({required String title, required int chapterCount}) {
-    final navPoints = StringBuffer();
-    for (int i = 1; i <= chapterCount; i++) {
-      navPoints.write(
-        '  <navPoint id="chapter-$i" playOrder="$i">\n'
-        '    <navLabel><text>Chapter $i</text></navLabel>\n'
-        '    <content src="chapter-$i.xhtml"/>\n'
-        '  </navPoint>\n',
-      );
-    }
-    return '<?xml version="1.0" encoding="UTF-8"?>\n'
-        '<!DOCTYPE ncx PUBLIC "-//NISO//DTD ncx 2005-1//EN"'
-        ' "http://www.daisy.org/z3986/2005/ncx-2005-1.dtd">\n'
-        '<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/"'
-        ' version="2005-1">\n'
-        '  <head>\n'
-        '    <meta name="dtb:uid" content="hibiki-toc"/>\n'
-        '    <meta name="dtb:depth" content="1"/>\n'
-        '  </head>\n'
-        '  <docTitle><text>${_esc(title)}</text></docTitle>\n'
-        '  <navMap>\n'
-        '$navPoints'
-        '  </navMap>\n'
-        '</ncx>\n';
-  }
-
-  static String _navXhtml({required String title, required int chapterCount}) {
-    final items = StringBuffer();
-    for (int i = 1; i <= chapterCount; i++) {
-      items.write('      <li><a href="chapter-$i.xhtml">Chapter $i</a></li>\n');
-    }
-    return '<?xml version="1.0" encoding="utf-8"?>\n'
-        '<!DOCTYPE html>\n'
-        '<html xmlns="http://www.w3.org/1999/xhtml"'
-        ' xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="ja">\n'
-        '<head><meta charset="utf-8"/><title>${_esc(title)}</title></head>\n'
-        '<body>\n'
-        '  <nav epub:type="toc" id="toc">\n'
-        '    <ol>\n'
-        '$items'
-        '    </ol>\n'
-        '  </nav>\n'
-        '</body>\n'
-        '</html>\n';
-  }
+  // ── Chapter XHTML (pre-rendered body; unique to this converter) ───────────
 
   static String _chapterXhtml({
     required String title,
@@ -304,153 +191,5 @@ class TextToEpub {
         '</html>\n';
   }
 
-  static String _esc(String s) => s
-      .replaceAll('&', '&amp;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;')
-      .replaceAll('"', '&quot;')
-      .replaceAll("'", '&apos;');
-}
-
-// ── Minimal ZIP builder (same as in cues_to_epub.dart) ───────────────────────
-
-class _EpubZip {
-  final List<_ZipEntry> _entries = [];
-
-  void addStored(String name, List<int> data) => _entries
-      .add(_ZipEntry(name: name, data: Uint8List.fromList(data), store: true));
-
-  void addDeflated(String name, List<int> data) => _entries
-      .add(_ZipEntry(name: name, data: Uint8List.fromList(data), store: false));
-
-  Uint8List build() {
-    final buf = BytesBuilder(copy: false);
-    final List<_LocalRecord> locals = [];
-
-    for (final entry in _entries) {
-      final int localOffset = buf.length;
-      final Uint8List nameBytes = Uint8List.fromList(utf8.encode(entry.name));
-      final int crc = _crc32(entry.data);
-
-      Uint8List compressed;
-      int method;
-      if (entry.store) {
-        compressed = entry.data;
-        method = 0;
-      } else {
-        compressed =
-            Uint8List.fromList(ZLibCodec(raw: true).encode(entry.data));
-        method = 8;
-      }
-
-      buf.add(_le32(0x04034b50));
-      buf.add(_le16(20));
-      buf.add(_le16(0));
-      buf.add(_le16(method));
-      buf.add(_le16(0));
-      buf.add(_le16(0));
-      buf.add(_le32(crc));
-      buf.add(_le32(compressed.length));
-      buf.add(_le32(entry.data.length));
-      buf.add(_le16(nameBytes.length));
-      buf.add(_le16(0));
-      buf.add(nameBytes);
-      buf.add(compressed);
-
-      locals.add(_LocalRecord(
-        nameBytes: nameBytes,
-        method: method,
-        crc: crc,
-        compressedSize: compressed.length,
-        uncompressedSize: entry.data.length,
-        localOffset: localOffset,
-      ));
-    }
-
-    final int cdOffset = buf.length;
-    for (final rec in locals) {
-      buf.add(_le32(0x02014b50));
-      buf.add(_le16(20));
-      buf.add(_le16(20));
-      buf.add(_le16(0));
-      buf.add(_le16(rec.method));
-      buf.add(_le16(0));
-      buf.add(_le16(0));
-      buf.add(_le32(rec.crc));
-      buf.add(_le32(rec.compressedSize));
-      buf.add(_le32(rec.uncompressedSize));
-      buf.add(_le16(rec.nameBytes.length));
-      buf.add(_le16(0));
-      buf.add(_le16(0));
-      buf.add(_le16(0));
-      buf.add(_le16(0));
-      buf.add(_le32(0));
-      buf.add(_le32(rec.localOffset));
-      buf.add(rec.nameBytes);
-    }
-    final int cdSize = buf.length - cdOffset;
-
-    buf.add(_le32(0x06054b50));
-    buf.add(_le16(0));
-    buf.add(_le16(0));
-    buf.add(_le16(locals.length));
-    buf.add(_le16(locals.length));
-    buf.add(_le32(cdSize));
-    buf.add(_le32(cdOffset));
-    buf.add(_le16(0));
-
-    return buf.toBytes();
-  }
-
-  static final Uint32List _table = _buildCrcTable();
-
-  static Uint32List _buildCrcTable() {
-    final t = Uint32List(256);
-    for (int n = 0; n < 256; n++) {
-      int c = n;
-      for (int k = 0; k < 8; k++) {
-        c = (c & 1) != 0 ? 0xEDB88320 ^ (c >> 1) : c >> 1;
-      }
-      t[n] = c;
-    }
-    return t;
-  }
-
-  static int _crc32(Uint8List data) {
-    int crc = 0xFFFFFFFF;
-    for (final byte in data) {
-      crc = _table[(crc ^ byte) & 0xFF] ^ (crc >> 8);
-    }
-    return crc ^ 0xFFFFFFFF;
-  }
-
-  static Uint8List _le16(int v) =>
-      Uint8List(2)..buffer.asByteData().setUint16(0, v, Endian.little);
-
-  static Uint8List _le32(int v) =>
-      Uint8List(4)..buffer.asByteData().setUint32(0, v, Endian.little);
-}
-
-class _ZipEntry {
-  _ZipEntry({required this.name, required this.data, required this.store});
-  final String name;
-  final Uint8List data;
-  final bool store;
-}
-
-class _LocalRecord {
-  _LocalRecord({
-    required this.nameBytes,
-    required this.method,
-    required this.crc,
-    required this.compressedSize,
-    required this.uncompressedSize,
-    required this.localOffset,
-  });
-  final Uint8List nameBytes;
-  final int method;
-  final int crc;
-  final int compressedSize;
-  final int uncompressedSize;
-  final int localOffset;
+  static String _esc(String s) => EpubBuilder.escXml(s);
 }

--- a/hibiki/test/helpers/epub_zip_reader.dart
+++ b/hibiki/test/helpers/epub_zip_reader.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+// ── Minimal ZIP reader for tests (no external deps) ──────────────────────────
+//
+// Reads the Central Directory to enumerate entries, then reads each Local
+// File Header to locate file data.  Supports STORE and DEFLATE.
+//
+// Shared by cues_to_epub_test.dart and text_to_epub_test.dart to verify
+// EPUB output produced via EpubBuilder.
+
+class EpubZipReader {
+  EpubZipReader(Uint8List bytes) : _b = bytes;
+  final Uint8List _b;
+  late final Map<String, String> _files = _parseAll();
+
+  /// Returns all file names in the ZIP.
+  Set<String> get names => _files.keys.toSet();
+
+  /// Returns the UTF-8 content of [name], or null if absent.
+  String? operator [](String name) => _files[name];
+
+  /// Returns the name of the very first entry (by local offset 0).
+  String get firstEntry {
+    // Signature of local file header: PK\x03\x04
+    // The very first local header should be at offset 0.
+    final int nameLen = _u16(26);
+    return utf8.decode(_b.sublist(30, 30 + nameLen));
+  }
+
+  /// Returns the compression method of the very first entry (0 = STORE).
+  int get firstEntryMethod => _u16(8);
+
+  Map<String, String> _parseAll() {
+    final result = <String, String>{};
+    // Find end of central directory (signature 0x06054b50, last 22 bytes minimum)
+    int eocdOffset = _findEocd();
+    final int cdOffset = _u32(eocdOffset + 16);
+    final int cdEntries = _u16(eocdOffset + 10);
+
+    int pos = cdOffset;
+    for (int i = 0; i < cdEntries; i++) {
+      // Central directory entry signature: 0x02014b50
+      final int nameLen = _u16(pos + 28);
+      final int extraLen = _u16(pos + 30);
+      final int commentLen = _u16(pos + 32);
+      final int localOffset = _u32(pos + 42);
+      final String name = utf8.decode(_b.sublist(pos + 46, pos + 46 + nameLen));
+
+      // Read local file header for data offset
+      // Local file header sig: 0x04034b50
+      final int lNameLen = _u16(localOffset + 26);
+      final int lExtraLen = _u16(localOffset + 28);
+      final int method = _u16(localOffset + 8);
+      final int compSize = _u32(localOffset + 18);
+      final int dataStart = localOffset + 30 + lNameLen + lExtraLen;
+
+      final Uint8List raw = _b.sublist(dataStart, dataStart + compSize);
+      final Uint8List data;
+      if (method == 0) {
+        data = raw; // STORE
+      } else {
+        // DEFLATE (raw, wbits = -15)
+        data = Uint8List.fromList(ZLibCodec(raw: true).decode(raw));
+      }
+      result[name] = utf8.decode(data);
+
+      pos += 46 + nameLen + extraLen + commentLen;
+    }
+    return result;
+  }
+
+  int _findEocd() {
+    // Search backwards for EOCD signature 0x06054b50
+    for (int i = _b.length - 22; i >= 0; i--) {
+      if (_b[i] == 0x50 &&
+          _b[i + 1] == 0x4b &&
+          _b[i + 2] == 0x05 &&
+          _b[i + 3] == 0x06) {
+        return i;
+      }
+    }
+    throw StateError('EOCD signature not found — not a valid ZIP');
+  }
+
+  int _u16(int offset) => _b[offset] | (_b[offset + 1] << 8);
+
+  int _u32(int offset) =>
+      _b[offset] |
+      (_b[offset + 1] << 8) |
+      (_b[offset + 2] << 16) |
+      (_b[offset + 3] << 24);
+}

--- a/hibiki/test/media/audiobook/cues_to_epub_test.dart
+++ b/hibiki/test/media/audiobook/cues_to_epub_test.dart
@@ -1,94 +1,9 @@
-import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 
-// ── Minimal ZIP reader for tests (no external deps) ──────────────────────────
-//
-// Reads the Central Directory to enumerate entries, then reads each Local
-// File Header to locate file data.  Supports STORE and DEFLATE.
-
-class _ZipReader {
-  _ZipReader(Uint8List bytes) : _b = bytes;
-  final Uint8List _b;
-  late final Map<String, String> _files = _parseAll();
-
-  /// Returns all file names in the ZIP.
-  Set<String> get names => _files.keys.toSet();
-
-  /// Returns the UTF-8 content of [name], or null if absent.
-  String? operator [](String name) => _files[name];
-
-  /// Returns the name of the very first entry (by local offset 0).
-  String get firstEntry {
-    // Signature of local file header: PK\x03\x04
-    // The very first local header should be at offset 0.
-    final int nameLen = _u16(26);
-    return utf8.decode(_b.sublist(30, 30 + nameLen));
-  }
-
-  Map<String, String> _parseAll() {
-    final result = <String, String>{};
-    // Find end of central directory (signature 0x06054b50, last 22 bytes minimum)
-    int eocdOffset = _findEocd();
-    final int cdOffset = _u32(eocdOffset + 16);
-    final int cdEntries = _u16(eocdOffset + 10);
-
-    int pos = cdOffset;
-    for (int i = 0; i < cdEntries; i++) {
-      // Central directory entry signature: 0x02014b50
-      final int nameLen = _u16(pos + 28);
-      final int extraLen = _u16(pos + 30);
-      final int commentLen = _u16(pos + 32);
-      final int localOffset = _u32(pos + 42);
-      final String name = utf8.decode(_b.sublist(pos + 46, pos + 46 + nameLen));
-
-      // Read local file header for data offset
-      // Local file header sig: 0x04034b50
-      final int lNameLen = _u16(localOffset + 26);
-      final int lExtraLen = _u16(localOffset + 28);
-      final int method = _u16(localOffset + 8);
-      final int compSize = _u32(localOffset + 18);
-      final int dataStart = localOffset + 30 + lNameLen + lExtraLen;
-
-      final Uint8List raw = _b.sublist(dataStart, dataStart + compSize);
-      final Uint8List data;
-      if (method == 0) {
-        data = raw; // STORE
-      } else {
-        // DEFLATE (raw, wbits = -15)
-        data = Uint8List.fromList(ZLibCodec(raw: true).decode(raw));
-      }
-      result[name] = utf8.decode(data);
-
-      pos += 46 + nameLen + extraLen + commentLen;
-    }
-    return result;
-  }
-
-  int _findEocd() {
-    // Search backwards for EOCD signature 0x06054b50
-    for (int i = _b.length - 22; i >= 0; i--) {
-      if (_b[i] == 0x50 &&
-          _b[i + 1] == 0x4b &&
-          _b[i + 2] == 0x05 &&
-          _b[i + 3] == 0x06) {
-        return i;
-      }
-    }
-    throw StateError('EOCD signature not found — not a valid ZIP');
-  }
-
-  int _u16(int offset) => _b[offset] | (_b[offset + 1] << 8);
-
-  int _u32(int offset) =>
-      _b[offset] |
-      (_b[offset + 1] << 8) |
-      (_b[offset + 2] << 16) |
-      (_b[offset + 3] << 24);
-}
+import '../../helpers/epub_zip_reader.dart';
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -111,8 +26,8 @@ AudioCue _cue({
     ..audioFileIndex = 0;
 }
 
-/// Generates an EPUB in [dir] and returns the decoded [_ZipReader].
-Future<_ZipReader> _generateAndRead(
+/// Generates an EPUB in [dir] and returns the decoded [EpubZipReader].
+Future<EpubZipReader> _generateAndRead(
   Directory dir, {
   required List<AudioCue> cues,
   String title = 'テスト',
@@ -125,7 +40,7 @@ Future<_ZipReader> _generateAndRead(
     cues: cues,
     outputPath: path,
   );
-  return _ZipReader(File(path).readAsBytesSync());
+  return EpubZipReader(File(path).readAsBytesSync());
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────

--- a/hibiki/test/media/audiobook/text_to_epub_test.dart
+++ b/hibiki/test/media/audiobook/text_to_epub_test.dart
@@ -1,0 +1,145 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/audiobook/text_to_epub.dart';
+
+import '../../helpers/epub_zip_reader.dart';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+Future<EpubZipReader> _convertText(
+  Directory dir,
+  String content, {
+  String name = 'input.txt',
+  String title = 'テスト本',
+  String? author,
+}) async {
+  final File file = File('${dir.path}/$name');
+  file.writeAsStringSync(content);
+  final bytes = await TextToEpub.convert(
+    file: file,
+    title: title,
+    author: author,
+  );
+  return EpubZipReader(bytes);
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+void main() {
+  late Directory tmpDir;
+
+  setUp(() {
+    tmpDir = Directory.systemTemp.createTempSync('text_to_epub_test_');
+  });
+
+  tearDown(() {
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  test('isSupported accepts known extensions and rejects others', () {
+    expect(TextToEpub.isSupported('a.txt'), isTrue);
+    expect(TextToEpub.isSupported('a.md'), isTrue);
+    expect(TextToEpub.isSupported('a.HTML'), isTrue);
+    expect(TextToEpub.isSupported('a.epub'), isFalse);
+    expect(TextToEpub.isSupported('a.mp3'), isFalse);
+  });
+
+  test('mimetype is the first entry, stored, with the EPUB media type',
+      () async {
+    final reader = await _convertText(tmpDir, 'こんにちは。\n\n二段落目。');
+    expect(reader.firstEntry, 'mimetype');
+    expect(reader.firstEntryMethod, 0); // STORE per EPUB spec
+    expect(reader['mimetype'], 'application/epub+zip');
+  });
+
+  test('container structure and OPF metadata are generated', () async {
+    final reader = await _convertText(
+      tmpDir,
+      'こんにちは。',
+      title: 'A & B <C>',
+      author: "O'Brien",
+    );
+    expect(
+      reader.names,
+      containsAll(<String>{
+        'META-INF/container.xml',
+        'OEBPS/content.opf',
+        'OEBPS/toc.ncx',
+        'OEBPS/nav.xhtml',
+        'OEBPS/chapter-1.xhtml',
+      }),
+    );
+    expect(
+      reader['META-INF/container.xml'],
+      contains('full-path="OEBPS/content.opf"'),
+    );
+
+    final String opf = reader['OEBPS/content.opf']!;
+    // Identity prefix distinguishes text-generated books; must stay stable.
+    expect(opf, contains('<dc:identifier id="uid">hibiki-text-'));
+    expect(opf, contains('<dc:title>A &amp; B &lt;C&gt;</dc:title>'));
+    expect(opf, contains('<dc:creator>O&apos;Brien</dc:creator>'));
+    expect(opf, contains('<itemref idref="chapter-1"/>'));
+  });
+
+  test('plain text paragraphs become <p>, single newlines become <br/>',
+      () async {
+    final reader = await _convertText(
+      tmpDir,
+      '一行目\n二行目\n\n次の段落',
+    );
+    final String chapter = reader['OEBPS/chapter-1.xhtml']!;
+    expect(chapter, contains('<p>一行目<br/>二行目</p>'));
+    expect(chapter, contains('<p>次の段落</p>'));
+  });
+
+  test('markdown headings map to <hN>', () async {
+    final reader = await _convertText(
+      tmpDir,
+      '# 見出し\n\n本文です。',
+      name: 'input.md',
+    );
+    final String chapter = reader['OEBPS/chapter-1.xhtml']!;
+    expect(chapter, contains('<h1>見出し</h1>'));
+    expect(chapter, contains('<p>本文です。</p>'));
+  });
+
+  test('html input keeps only body content', () async {
+    final reader = await _convertText(
+      tmpDir,
+      '<html><head><title>t</title></head>'
+      '<body><p>中身</p></body></html>',
+      name: 'input.html',
+    );
+    final String chapter = reader['OEBPS/chapter-1.xhtml']!;
+    expect(chapter, contains('<p>中身</p>'));
+    expect(chapter, isNot(contains('<title>t</title>')));
+  });
+
+  test('long input splits into multiple chapters at paragraph boundaries',
+      () async {
+    // Build > kMaxCharsPerChapter of HTML from many paragraphs.
+    final String para = '${'あ' * 200}。';
+    final String content =
+        List<String>.filled(200, para).join('\n\n'); // ~40k chars of <p>
+    final reader = await _convertText(tmpDir, content);
+
+    expect(reader.names, contains('OEBPS/chapter-1.xhtml'));
+    expect(reader.names, contains('OEBPS/chapter-2.xhtml'));
+
+    final String opf = reader['OEBPS/content.opf']!;
+    expect(opf, contains('<itemref idref="chapter-2"/>'));
+    // NCX and nav must list every chapter.
+    final int chapterCount =
+        reader.names.where((n) => n.startsWith('OEBPS/chapter-')).length;
+    expect(
+      RegExp('<navPoint ').allMatches(reader['OEBPS/toc.ncx']!).length,
+      chapterCount,
+    );
+    expect(
+      RegExp('<li>').allMatches(reader['OEBPS/nav.xhtml']!).length,
+      chapterCount,
+    );
+  });
+}

--- a/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -637,46 +637,18 @@ class AnkiConnectRepository extends BaseAnkiRepository {
         mediaResults[3] as Map<String, String>;
 
     final String? remoteAudioRef = remoteAudio.ref;
-    final String processedAudio =
-        remoteAudioRef != null ? '[sound:$remoteAudioRef]' : '';
 
-    final mediaContext = AnkiMiningContext(
-      sentence: context.sentence,
-      cueSentence: context.cueSentence,
-      documentTitle: context.documentTitle,
-      coverPath: coverMediaRef != null ? '<img src="$coverMediaRef">' : null,
-      sasayakiAudioPath:
+    return renderMediaPayload(
+      settings: settings,
+      payload: payload,
+      context: context,
+      coverRef: coverMediaRef != null ? '<img src="$coverMediaRef">' : null,
+      sasayakiRef:
           sasayakiMediaRef != null ? '[sound:$sasayakiMediaRef]' : null,
-      sentenceOffset: context.sentenceOffset,
-    );
-
-    final mediaPayload = AnkiMiningPayload(
-      expression: payload.expression,
-      reading: payload.reading,
-      matched: payload.matched,
-      furiganaPlain: payload.furiganaPlain,
-      frequenciesHtml: payload.frequenciesHtml,
-      freqHarmonicRank: payload.freqHarmonicRank,
-      glossary: payload.glossary,
-      glossaryFirst: payload.glossaryFirst,
-      singleGlossaries: payload.singleGlossaries,
-      pitchPositions: payload.pitchPositions,
-      pitchCategories: payload.pitchCategories,
-      popupSelectionText: payload.popupSelectionText,
-      audio: processedAudio,
-      selectedDictionary: payload.selectedDictionary,
-      dictionaryMedia: payload.dictionaryMedia,
-    );
-
-    return RenderedMinedFields(
-      buildMinedFields(
-        fieldMappings: settings.fieldMappings,
-        payload: mediaPayload,
-        context: mediaContext,
-        dictionaryMediaTags: dictionaryMediaTags,
-        keepEmpty: keepEmpty,
-      ),
+      processedAudio: remoteAudioRef != null ? '[sound:$remoteAudioRef]' : '',
+      dictionaryMediaTags: dictionaryMediaTags,
       audioWarning: remoteAudio.failureReason,
+      keepEmpty: keepEmpty,
     );
   }
 

--- a/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart
@@ -322,44 +322,16 @@ class AnkiRepository extends BaseAnkiRepository {
     final Map<String, String> dictionaryMediaTags =
         mediaResults[3] as Map<String, String>;
 
-    final mediaContext = AnkiMiningContext(
-      sentence: context.sentence,
-      cueSentence: context.cueSentence,
-      documentTitle: context.documentTitle,
-      coverPath: coverRef,
-      sasayakiAudioPath: sasayakiRef,
-      sentenceOffset: context.sentenceOffset,
-    );
-
-    final processedAudio = rawAudio != null ? '[sound:$rawAudio]' : '';
-
-    final mediaPayload = AnkiMiningPayload(
-      expression: payload.expression,
-      reading: payload.reading,
-      matched: payload.matched,
-      furiganaPlain: payload.furiganaPlain,
-      frequenciesHtml: payload.frequenciesHtml,
-      freqHarmonicRank: payload.freqHarmonicRank,
-      glossary: payload.glossary,
-      glossaryFirst: payload.glossaryFirst,
-      singleGlossaries: payload.singleGlossaries,
-      pitchPositions: payload.pitchPositions,
-      pitchCategories: payload.pitchCategories,
-      popupSelectionText: payload.popupSelectionText,
-      audio: processedAudio,
-      selectedDictionary: payload.selectedDictionary,
-      dictionaryMedia: payload.dictionaryMedia,
-    );
-
-    return RenderedMinedFields(
-      buildMinedFields(
-        fieldMappings: settings.fieldMappings,
-        payload: mediaPayload,
-        context: mediaContext,
-        dictionaryMediaTags: dictionaryMediaTags,
-        keepEmpty: keepEmpty,
-      ),
+    return renderMediaPayload(
+      settings: settings,
+      payload: payload,
+      context: context,
+      coverRef: coverRef,
+      sasayakiRef: sasayakiRef,
+      processedAudio: rawAudio != null ? '[sound:$rawAudio]' : '',
+      dictionaryMediaTags: dictionaryMediaTags,
       audioWarning: remoteAudio.failureReason,
+      keepEmpty: keepEmpty,
     );
   }
 

--- a/packages/hibiki_anki/lib/src/base_anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/base_anki_repository.dart
@@ -364,6 +364,66 @@ abstract class BaseAnkiRepository {
     return fields;
   }
 
+  /// 用已备好的媒体引用把 [payload] + [context] 组装成最终渲染结果。
+  ///
+  /// 两 backend 的差异只在「媒体引用怎么准备」（AnkiConnect 远程上传后内联
+  /// `<img>` / `[sound:]`；AnkiDroid 平台通道写入返回已格式化引用）；引用备好
+  /// 之后的 payload 字段透传 + [buildMinedFields] 渲染 + 打包完全一致，收敛在
+  /// 这里，杜绝两份 16 字段透传漂移。
+  ///
+  /// [coverRef] / [sasayakiRef] / [processedAudio] 均须是**已格式化**的最终
+  /// 引用（`<img src>` / `[sound:]`；无则 null / 空串）。
+  @protected
+  RenderedMinedFields renderMediaPayload({
+    required AnkiSettings settings,
+    required AnkiMiningPayload payload,
+    required AnkiMiningContext context,
+    required String? coverRef,
+    required String? sasayakiRef,
+    required String processedAudio,
+    required Map<String, String> dictionaryMediaTags,
+    String? audioWarning,
+    bool keepEmpty = false,
+  }) {
+    final mediaContext = AnkiMiningContext(
+      sentence: context.sentence,
+      cueSentence: context.cueSentence,
+      documentTitle: context.documentTitle,
+      coverPath: coverRef,
+      sasayakiAudioPath: sasayakiRef,
+      sentenceOffset: context.sentenceOffset,
+    );
+
+    final mediaPayload = AnkiMiningPayload(
+      expression: payload.expression,
+      reading: payload.reading,
+      matched: payload.matched,
+      furiganaPlain: payload.furiganaPlain,
+      frequenciesHtml: payload.frequenciesHtml,
+      freqHarmonicRank: payload.freqHarmonicRank,
+      glossary: payload.glossary,
+      glossaryFirst: payload.glossaryFirst,
+      singleGlossaries: payload.singleGlossaries,
+      pitchPositions: payload.pitchPositions,
+      pitchCategories: payload.pitchCategories,
+      popupSelectionText: payload.popupSelectionText,
+      audio: processedAudio,
+      selectedDictionary: payload.selectedDictionary,
+      dictionaryMedia: payload.dictionaryMedia,
+    );
+
+    return RenderedMinedFields(
+      buildMinedFields(
+        fieldMappings: settings.fieldMappings,
+        payload: mediaPayload,
+        context: mediaContext,
+        dictionaryMediaTags: dictionaryMediaTags,
+        keepEmpty: keepEmpty,
+      ),
+      audioWarning: audioWarning,
+    );
+  }
+
   // ── 远程单词音频失败原因（TODO-779）：两 backend 共用，杜绝两份文案漂移 ──────────
 
   /// 把单词远程音频的**非 200 HTTP 响应**格式化成给用户看的简短失败原因

--- a/packages/hibiki_audio/lib/hibiki_audio.dart
+++ b/packages/hibiki_audio/lib/hibiki_audio.dart
@@ -34,3 +34,4 @@ export 'src/matching/collection_audio_matcher.dart';
 export 'src/matching/cue_file_index_assigner.dart';
 export 'src/matching/sasayaki_match_codec.dart';
 export 'src/matching/cues_to_epub.dart';
+export 'src/matching/epub_builder.dart';

--- a/packages/hibiki_audio/lib/src/matching/cues_to_epub.dart
+++ b/packages/hibiki_audio/lib/src/matching/cues_to_epub.dart
@@ -1,8 +1,7 @@
-import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import '../audiobook/audiobook_model.dart';
+import 'epub_builder.dart';
 
 /// Converts a flat [AudioCue] list into a valid EPUB 3 file.
 ///
@@ -23,6 +22,9 @@ import '../audiobook/audiobook_model.dart';
 /// ```
 /// The bridge can locate each span with the CSS selector
 /// `[data-cue-id="N"]` and highlight it during audio playback.
+///
+/// Container assembly (ZIP/OPF/NCX/nav) is shared with the app-side
+/// text importer via [EpubBuilder].
 class CuesToEpub {
   // ── thresholds (adjust here without touching logic) ──────────────────────
 
@@ -48,44 +50,27 @@ class CuesToEpub {
     String? author,
   }) async {
     final List<List<AudioCue>> chapters = splitChapters(cues);
-    final _EpubZip zip = _EpubZip();
 
-    // mimetype MUST be the first entry and stored (no compression) per EPUB spec.
-    zip.addStored('mimetype', utf8.encode('application/epub+zip'));
-
-    zip.addDeflated('META-INF/container.xml', utf8.encode(_containerXml()));
-    zip.addDeflated(
-      'OEBPS/content.opf',
-      utf8.encode(
-        _contentOpf(
-            title: title, author: author, chapterCount: chapters.length),
-      ),
-    );
-    zip.addDeflated(
-      'OEBPS/toc.ncx',
-      utf8.encode(_tocNcx(title: title, chapterCount: chapters.length)),
-    );
-    zip.addDeflated(
-      'OEBPS/nav.xhtml',
-      utf8.encode(_navXhtml(title: title, chapterCount: chapters.length)),
-    );
-
-    for (int i = 0; i < chapters.length; i++) {
-      zip.addDeflated(
-        'OEBPS/chapter-${i + 1}.xhtml',
-        utf8.encode(
-          _chapterXhtml(
-            bookTitle: title,
-            chapterIndex: i,
-            totalChapters: chapters.length,
-            cues: chapters[i],
-          ),
+    final List<String> chapterXhtmls = <String>[
+      for (int i = 0; i < chapters.length; i++)
+        _chapterXhtml(
+          bookTitle: title,
+          chapterIndex: i,
+          totalChapters: chapters.length,
+          cues: chapters[i],
         ),
-      );
-    }
+    ];
 
     final file = File(outputPath);
-    await file.writeAsBytes(zip.build(), flush: true);
+    await file.writeAsBytes(
+      EpubBuilder.assemble(
+        title: title,
+        author: author,
+        uidPrefix: 'hibiki-',
+        chapterXhtmls: chapterXhtmls,
+      ),
+      flush: true,
+    );
     return file;
   }
 
@@ -143,112 +128,7 @@ class CuesToEpub {
     return paragraphs;
   }
 
-  // ── XML / XHTML generators ────────────────────────────────────────────────
-
-  static String _containerXml() => '<?xml version="1.0" encoding="UTF-8"?>\n'
-      '<container version="1.0"'
-      ' xmlns="urn:oasis:names:tc:opendocument:xmlns:container">\n'
-      '  <rootfiles>\n'
-      '    <rootfile full-path="OEBPS/content.opf"'
-      ' media-type="application/oebps-package+xml"/>\n'
-      '  </rootfiles>\n'
-      '</container>\n';
-
-  static String _contentOpf({
-    required String title,
-    required int chapterCount,
-    String? author,
-  }) {
-    final String authorTag = (author != null && author.isNotEmpty)
-        ? '\n    <dc:creator>${_esc(author)}</dc:creator>'
-        : '';
-    final String now = DateTime.now()
-        .toUtc()
-        .toIso8601String()
-        .replaceFirst(RegExp(r'\.\d+Z$'), 'Z');
-
-    final StringBuffer manifest = StringBuffer();
-    final StringBuffer spine = StringBuffer();
-    for (int i = 1; i <= chapterCount; i++) {
-      manifest.write('    <item id="chapter-$i" href="chapter-$i.xhtml"'
-          ' media-type="application/xhtml+xml"/>\n');
-      spine.write('    <itemref idref="chapter-$i"/>\n');
-    }
-
-    final String uid = 'hibiki-${DateTime.now().millisecondsSinceEpoch}';
-    return '<?xml version="1.0" encoding="UTF-8"?>\n'
-        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"\n'
-        '         unique-identifier="uid" xml:lang="ja">\n'
-        '  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">\n'
-        '    <dc:identifier id="uid">$uid</dc:identifier>\n'
-        '    <dc:title>${_esc(title)}</dc:title>$authorTag\n'
-        '    <dc:language>ja</dc:language>\n'
-        '    <meta property="dcterms:modified">$now</meta>\n'
-        '  </metadata>\n'
-        '  <manifest>\n'
-        '$manifest'
-        '    <item id="nav" href="nav.xhtml"'
-        ' media-type="application/xhtml+xml" properties="nav"/>\n'
-        '    <item id="ncx" href="toc.ncx"'
-        ' media-type="application/x-dtbncx+xml"/>\n'
-        '  </manifest>\n'
-        '  <spine toc="ncx">\n'
-        '$spine'
-        '  </spine>\n'
-        '</package>\n';
-  }
-
-  static String _tocNcx({
-    required String title,
-    required int chapterCount,
-  }) {
-    final StringBuffer navPoints = StringBuffer();
-    for (int i = 1; i <= chapterCount; i++) {
-      navPoints.write(
-        '  <navPoint id="chapter-$i" playOrder="$i">\n'
-        '    <navLabel><text>Chapter $i</text></navLabel>\n'
-        '    <content src="chapter-$i.xhtml"/>\n'
-        '  </navPoint>\n',
-      );
-    }
-    return '<?xml version="1.0" encoding="UTF-8"?>\n'
-        '<!DOCTYPE ncx PUBLIC "-//NISO//DTD ncx 2005-1//EN"'
-        ' "http://www.daisy.org/z3986/2005/ncx-2005-1.dtd">\n'
-        '<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/"'
-        ' version="2005-1">\n'
-        '  <head>\n'
-        '    <meta name="dtb:uid" content="hibiki-toc"/>\n'
-        '    <meta name="dtb:depth" content="1"/>\n'
-        '  </head>\n'
-        '  <docTitle><text>${_esc(title)}</text></docTitle>\n'
-        '  <navMap>\n'
-        '$navPoints'
-        '  </navMap>\n'
-        '</ncx>\n';
-  }
-
-  static String _navXhtml({
-    required String title,
-    required int chapterCount,
-  }) {
-    final StringBuffer items = StringBuffer();
-    for (int i = 1; i <= chapterCount; i++) {
-      items.write('      <li><a href="chapter-$i.xhtml">Chapter $i</a></li>\n');
-    }
-    return '<?xml version="1.0" encoding="utf-8"?>\n'
-        '<!DOCTYPE html>\n'
-        '<html xmlns="http://www.w3.org/1999/xhtml"'
-        ' xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="ja">\n'
-        '<head><meta charset="utf-8"/><title>${_esc(title)}</title></head>\n'
-        '<body>\n'
-        '  <nav epub:type="toc" id="toc">\n'
-        '    <ol>\n'
-        '$items'
-        '    </ol>\n'
-        '  </nav>\n'
-        '</body>\n'
-        '</html>\n';
-  }
+  // ── chapter XHTML (cue spans; unique to this converter) ───────────────────
 
   static String _chapterXhtml({
     required String bookTitle,
@@ -290,171 +170,5 @@ class CuesToEpub {
         '</html>\n';
   }
 
-  // ── XML escaping ──────────────────────────────────────────────────────────
-
-  static String _esc(String s) => s
-      .replaceAll('&', '&amp;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;')
-      .replaceAll('"', '&quot;')
-      .replaceAll("'", '&apos;');
-}
-
-// ── Self-contained ZIP builder ───────────────────────────────────────────────
-//
-// Implements just enough of the ZIP spec (PKZIP 2.0, APPNOTE.TXT) for EPUB:
-//   • STORE  (method 0) for mimetype (required by EPUB spec)
-//   • DEFLATE (method 8) for all other files
-//
-// Uses dart:io ZLibCodec with raw=true for raw DEFLATE output.
-
-class _EpubZip {
-  final List<_ZipEntry> _entries = [];
-
-  void addStored(String name, List<int> data) => _entries
-      .add(_ZipEntry(name: name, data: Uint8List.fromList(data), store: true));
-
-  void addDeflated(String name, List<int> data) => _entries
-      .add(_ZipEntry(name: name, data: Uint8List.fromList(data), store: false));
-
-  Uint8List build() {
-    final buf = BytesBuilder(copy: false);
-    final List<_LocalRecord> locals = [];
-
-    for (final entry in _entries) {
-      final int localOffset = buf.length;
-
-      final Uint8List nameBytes = Uint8List.fromList(utf8.encode(entry.name));
-      final int crc = _crc32(entry.data);
-
-      Uint8List compressed;
-      int method;
-      if (entry.store) {
-        compressed = entry.data;
-        method = 0; // STORE
-      } else {
-        // raw DEFLATE (wbits = -15)
-        compressed = Uint8List.fromList(
-          ZLibCodec(raw: true).encode(entry.data),
-        );
-        method = 8; // DEFLATE
-      }
-
-      // Local file header (signature 0x04034b50)
-      buf.add(_le32(0x04034b50));
-      buf.add(_le16(20)); // version needed: 2.0
-      buf.add(_le16(0)); // general purpose bit flag
-      buf.add(_le16(method));
-      buf.add(_le16(0)); // last mod time
-      buf.add(_le16(0)); // last mod date
-      buf.add(_le32(crc));
-      buf.add(_le32(compressed.length));
-      buf.add(_le32(entry.data.length));
-      buf.add(_le16(nameBytes.length));
-      buf.add(_le16(0)); // extra field length
-      buf.add(nameBytes);
-      buf.add(compressed);
-
-      locals.add(_LocalRecord(
-        nameBytes: nameBytes,
-        method: method,
-        crc: crc,
-        compressedSize: compressed.length,
-        uncompressedSize: entry.data.length,
-        localOffset: localOffset,
-      ));
-    }
-
-    // Central directory
-    final int cdOffset = buf.length;
-    for (final rec in locals) {
-      buf.add(_le32(0x02014b50)); // central directory signature
-      buf.add(_le16(20)); // version made by
-      buf.add(_le16(20)); // version needed
-      buf.add(_le16(0)); // general purpose bit flag
-      buf.add(_le16(rec.method));
-      buf.add(_le16(0)); // last mod time
-      buf.add(_le16(0)); // last mod date
-      buf.add(_le32(rec.crc));
-      buf.add(_le32(rec.compressedSize));
-      buf.add(_le32(rec.uncompressedSize));
-      buf.add(_le16(rec.nameBytes.length));
-      buf.add(_le16(0)); // extra field length
-      buf.add(_le16(0)); // file comment length
-      buf.add(_le16(0)); // disk number start
-      buf.add(_le16(0)); // internal file attributes
-      buf.add(_le32(0)); // external file attributes
-      buf.add(_le32(rec.localOffset));
-      buf.add(rec.nameBytes);
-    }
-    final int cdSize = buf.length - cdOffset;
-
-    // End of central directory record
-    buf.add(_le32(0x06054b50)); // signature
-    buf.add(_le16(0)); // disk number
-    buf.add(_le16(0)); // disk with start of central directory
-    buf.add(_le16(locals.length)); // entries on this disk
-    buf.add(_le16(locals.length)); // total entries
-    buf.add(_le32(cdSize));
-    buf.add(_le32(cdOffset));
-    buf.add(_le16(0)); // comment length
-
-    return buf.toBytes();
-  }
-
-  // ── CRC-32 (ISO 3309) ────────────────────────────────────────────────────
-
-  static final Uint32List _table = _buildCrcTable();
-
-  static Uint32List _buildCrcTable() {
-    final t = Uint32List(256);
-    for (int n = 0; n < 256; n++) {
-      int c = n;
-      for (int k = 0; k < 8; k++) {
-        c = (c & 1) != 0 ? 0xEDB88320 ^ (c >> 1) : c >> 1;
-      }
-      t[n] = c;
-    }
-    return t;
-  }
-
-  static int _crc32(Uint8List data) {
-    int crc = 0xFFFFFFFF;
-    for (final byte in data) {
-      crc = _table[(crc ^ byte) & 0xFF] ^ (crc >> 8);
-    }
-    return crc ^ 0xFFFFFFFF;
-  }
-
-  // ── Little-endian helpers ─────────────────────────────────────────────────
-
-  static Uint8List _le16(int v) =>
-      Uint8List(2)..buffer.asByteData().setUint16(0, v, Endian.little);
-
-  static Uint8List _le32(int v) =>
-      Uint8List(4)..buffer.asByteData().setUint32(0, v, Endian.little);
-}
-
-class _ZipEntry {
-  _ZipEntry({required this.name, required this.data, required this.store});
-  final String name;
-  final Uint8List data;
-  final bool store;
-}
-
-class _LocalRecord {
-  _LocalRecord({
-    required this.nameBytes,
-    required this.method,
-    required this.crc,
-    required this.compressedSize,
-    required this.uncompressedSize,
-    required this.localOffset,
-  });
-  final Uint8List nameBytes;
-  final int method;
-  final int crc;
-  final int compressedSize;
-  final int uncompressedSize;
-  final int localOffset;
+  static String _esc(String s) => EpubBuilder.escXml(s);
 }

--- a/packages/hibiki_audio/lib/src/matching/epub_builder.dart
+++ b/packages/hibiki_audio/lib/src/matching/epub_builder.dart
@@ -1,0 +1,336 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+/// Shared EPUB 3 assembly infrastructure.
+///
+/// Single source of truth for the EPUB container pieces that are identical
+/// regardless of how chapter bodies are produced: the ZIP packer ([EpubZip]),
+/// the OCF/OPF/NCX/nav XML generators and XML escaping.
+///
+/// Used by [CuesToEpub] (cue spans) and the app-side `TextToEpub`
+/// (plain text / HTML / Markdown); both render their own chapter XHTML and
+/// hand the finished strings to [assemble].
+class EpubBuilder {
+  /// Packs [chapterXhtmls] plus all container metadata into EPUB bytes.
+  ///
+  /// [uidPrefix] is embedded verbatim before the timestamp in the
+  /// `dc:identifier` (e.g. `'hibiki-'`, `'hibiki-text-'`); callers rely on it
+  /// for identity/dedup of generated books, so it must stay stable.
+  static Uint8List assemble({
+    required String title,
+    required List<String> chapterXhtmls,
+    required String uidPrefix,
+    String? author,
+  }) {
+    final EpubZip zip = EpubZip();
+    final int chapterCount = chapterXhtmls.length;
+
+    // mimetype MUST be the first entry and stored (no compression) per EPUB spec.
+    zip.addStored('mimetype', utf8.encode('application/epub+zip'));
+
+    zip.addDeflated('META-INF/container.xml', utf8.encode(containerXml()));
+    zip.addDeflated(
+      'OEBPS/content.opf',
+      utf8.encode(contentOpf(
+        title: title,
+        author: author,
+        chapterCount: chapterCount,
+        uidPrefix: uidPrefix,
+      )),
+    );
+    zip.addDeflated(
+      'OEBPS/toc.ncx',
+      utf8.encode(tocNcx(title: title, chapterCount: chapterCount)),
+    );
+    zip.addDeflated(
+      'OEBPS/nav.xhtml',
+      utf8.encode(navXhtml(title: title, chapterCount: chapterCount)),
+    );
+
+    for (int i = 0; i < chapterCount; i++) {
+      zip.addDeflated(
+        'OEBPS/chapter-${i + 1}.xhtml',
+        utf8.encode(chapterXhtmls[i]),
+      );
+    }
+
+    return zip.build();
+  }
+
+  // ── XML / XHTML generators ────────────────────────────────────────────────
+
+  static String containerXml() => '<?xml version="1.0" encoding="UTF-8"?>\n'
+      '<container version="1.0"'
+      ' xmlns="urn:oasis:names:tc:opendocument:xmlns:container">\n'
+      '  <rootfiles>\n'
+      '    <rootfile full-path="OEBPS/content.opf"'
+      ' media-type="application/oebps-package+xml"/>\n'
+      '  </rootfiles>\n'
+      '</container>\n';
+
+  static String contentOpf({
+    required String title,
+    required int chapterCount,
+    required String uidPrefix,
+    String? author,
+  }) {
+    final String authorTag = (author != null && author.isNotEmpty)
+        ? '\n    <dc:creator>${escXml(author)}</dc:creator>'
+        : '';
+    final String now = DateTime.now()
+        .toUtc()
+        .toIso8601String()
+        .replaceFirst(RegExp(r'\.\d+Z$'), 'Z');
+
+    final StringBuffer manifest = StringBuffer();
+    final StringBuffer spine = StringBuffer();
+    for (int i = 1; i <= chapterCount; i++) {
+      manifest.write('    <item id="chapter-$i" href="chapter-$i.xhtml"'
+          ' media-type="application/xhtml+xml"/>\n');
+      spine.write('    <itemref idref="chapter-$i"/>\n');
+    }
+
+    final String uid = '$uidPrefix${DateTime.now().millisecondsSinceEpoch}';
+    return '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"\n'
+        '         unique-identifier="uid" xml:lang="ja">\n'
+        '  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">\n'
+        '    <dc:identifier id="uid">$uid</dc:identifier>\n'
+        '    <dc:title>${escXml(title)}</dc:title>$authorTag\n'
+        '    <dc:language>ja</dc:language>\n'
+        '    <meta property="dcterms:modified">$now</meta>\n'
+        '  </metadata>\n'
+        '  <manifest>\n'
+        '$manifest'
+        '    <item id="nav" href="nav.xhtml"'
+        ' media-type="application/xhtml+xml" properties="nav"/>\n'
+        '    <item id="ncx" href="toc.ncx"'
+        ' media-type="application/x-dtbncx+xml"/>\n'
+        '  </manifest>\n'
+        '  <spine toc="ncx">\n'
+        '$spine'
+        '  </spine>\n'
+        '</package>\n';
+  }
+
+  static String tocNcx({
+    required String title,
+    required int chapterCount,
+  }) {
+    final StringBuffer navPoints = StringBuffer();
+    for (int i = 1; i <= chapterCount; i++) {
+      navPoints.write(
+        '  <navPoint id="chapter-$i" playOrder="$i">\n'
+        '    <navLabel><text>Chapter $i</text></navLabel>\n'
+        '    <content src="chapter-$i.xhtml"/>\n'
+        '  </navPoint>\n',
+      );
+    }
+    return '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<!DOCTYPE ncx PUBLIC "-//NISO//DTD ncx 2005-1//EN"'
+        ' "http://www.daisy.org/z3986/2005/ncx-2005-1.dtd">\n'
+        '<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/"'
+        ' version="2005-1">\n'
+        '  <head>\n'
+        '    <meta name="dtb:uid" content="hibiki-toc"/>\n'
+        '    <meta name="dtb:depth" content="1"/>\n'
+        '  </head>\n'
+        '  <docTitle><text>${escXml(title)}</text></docTitle>\n'
+        '  <navMap>\n'
+        '$navPoints'
+        '  </navMap>\n'
+        '</ncx>\n';
+  }
+
+  static String navXhtml({
+    required String title,
+    required int chapterCount,
+  }) {
+    final StringBuffer items = StringBuffer();
+    for (int i = 1; i <= chapterCount; i++) {
+      items.write('      <li><a href="chapter-$i.xhtml">Chapter $i</a></li>\n');
+    }
+    return '<?xml version="1.0" encoding="utf-8"?>\n'
+        '<!DOCTYPE html>\n'
+        '<html xmlns="http://www.w3.org/1999/xhtml"'
+        ' xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="ja">\n'
+        '<head><meta charset="utf-8"/><title>${escXml(title)}</title></head>\n'
+        '<body>\n'
+        '  <nav epub:type="toc" id="toc">\n'
+        '    <ol>\n'
+        '$items'
+        '    </ol>\n'
+        '  </nav>\n'
+        '</body>\n'
+        '</html>\n';
+  }
+
+  // ── XML escaping ──────────────────────────────────────────────────────────
+
+  static String escXml(String s) => s
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&apos;');
+}
+
+// ── Self-contained ZIP builder ───────────────────────────────────────────────
+//
+// Implements just enough of the ZIP spec (PKZIP 2.0, APPNOTE.TXT) for EPUB:
+//   • STORE  (method 0) for mimetype (required by EPUB spec)
+//   • DEFLATE (method 8) for all other files
+//
+// Uses dart:io ZLibCodec with raw=true for raw DEFLATE output.
+
+class EpubZip {
+  final List<_ZipEntry> _entries = [];
+
+  void addStored(String name, List<int> data) => _entries
+      .add(_ZipEntry(name: name, data: Uint8List.fromList(data), store: true));
+
+  void addDeflated(String name, List<int> data) => _entries
+      .add(_ZipEntry(name: name, data: Uint8List.fromList(data), store: false));
+
+  Uint8List build() {
+    final buf = BytesBuilder(copy: false);
+    final List<_LocalRecord> locals = [];
+
+    for (final entry in _entries) {
+      final int localOffset = buf.length;
+
+      final Uint8List nameBytes = Uint8List.fromList(utf8.encode(entry.name));
+      final int crc = _crc32(entry.data);
+
+      Uint8List compressed;
+      int method;
+      if (entry.store) {
+        compressed = entry.data;
+        method = 0; // STORE
+      } else {
+        // raw DEFLATE (wbits = -15)
+        compressed = Uint8List.fromList(
+          ZLibCodec(raw: true).encode(entry.data),
+        );
+        method = 8; // DEFLATE
+      }
+
+      // Local file header (signature 0x04034b50)
+      buf.add(_le32(0x04034b50));
+      buf.add(_le16(20)); // version needed: 2.0
+      buf.add(_le16(0)); // general purpose bit flag
+      buf.add(_le16(method));
+      buf.add(_le16(0)); // last mod time
+      buf.add(_le16(0)); // last mod date
+      buf.add(_le32(crc));
+      buf.add(_le32(compressed.length));
+      buf.add(_le32(entry.data.length));
+      buf.add(_le16(nameBytes.length));
+      buf.add(_le16(0)); // extra field length
+      buf.add(nameBytes);
+      buf.add(compressed);
+
+      locals.add(_LocalRecord(
+        nameBytes: nameBytes,
+        method: method,
+        crc: crc,
+        compressedSize: compressed.length,
+        uncompressedSize: entry.data.length,
+        localOffset: localOffset,
+      ));
+    }
+
+    // Central directory
+    final int cdOffset = buf.length;
+    for (final rec in locals) {
+      buf.add(_le32(0x02014b50)); // central directory signature
+      buf.add(_le16(20)); // version made by
+      buf.add(_le16(20)); // version needed
+      buf.add(_le16(0)); // general purpose bit flag
+      buf.add(_le16(rec.method));
+      buf.add(_le16(0)); // last mod time
+      buf.add(_le16(0)); // last mod date
+      buf.add(_le32(rec.crc));
+      buf.add(_le32(rec.compressedSize));
+      buf.add(_le32(rec.uncompressedSize));
+      buf.add(_le16(rec.nameBytes.length));
+      buf.add(_le16(0)); // extra field length
+      buf.add(_le16(0)); // file comment length
+      buf.add(_le16(0)); // disk number start
+      buf.add(_le16(0)); // internal file attributes
+      buf.add(_le32(0)); // external file attributes
+      buf.add(_le32(rec.localOffset));
+      buf.add(rec.nameBytes);
+    }
+    final int cdSize = buf.length - cdOffset;
+
+    // End of central directory record
+    buf.add(_le32(0x06054b50)); // signature
+    buf.add(_le16(0)); // disk number
+    buf.add(_le16(0)); // disk with start of central directory
+    buf.add(_le16(locals.length)); // entries on this disk
+    buf.add(_le16(locals.length)); // total entries
+    buf.add(_le32(cdSize));
+    buf.add(_le32(cdOffset));
+    buf.add(_le16(0)); // comment length
+
+    return buf.toBytes();
+  }
+
+  // ── CRC-32 (ISO 3309) ────────────────────────────────────────────────────
+
+  static final Uint32List _table = _buildCrcTable();
+
+  static Uint32List _buildCrcTable() {
+    final t = Uint32List(256);
+    for (int n = 0; n < 256; n++) {
+      int c = n;
+      for (int k = 0; k < 8; k++) {
+        c = (c & 1) != 0 ? 0xEDB88320 ^ (c >> 1) : c >> 1;
+      }
+      t[n] = c;
+    }
+    return t;
+  }
+
+  static int _crc32(Uint8List data) {
+    int crc = 0xFFFFFFFF;
+    for (final byte in data) {
+      crc = _table[(crc ^ byte) & 0xFF] ^ (crc >> 8);
+    }
+    return crc ^ 0xFFFFFFFF;
+  }
+
+  // ── Little-endian helpers ─────────────────────────────────────────────────
+
+  static Uint8List _le16(int v) =>
+      Uint8List(2)..buffer.asByteData().setUint16(0, v, Endian.little);
+
+  static Uint8List _le32(int v) =>
+      Uint8List(4)..buffer.asByteData().setUint32(0, v, Endian.little);
+}
+
+class _ZipEntry {
+  _ZipEntry({required this.name, required this.data, required this.store});
+  final String name;
+  final Uint8List data;
+  final bool store;
+}
+
+class _LocalRecord {
+  _LocalRecord({
+    required this.nameBytes,
+    required this.method,
+    required this.crc,
+    required this.compressedSize,
+    required this.uncompressedSize,
+    required this.localOffset,
+  });
+  final Uint8List nameBytes;
+  final int method;
+  final int crc;
+  final int compressedSize;
+  final int uncompressedSize;
+  final int localOffset;
+}

--- a/packages/hibiki_audio/lib/src/parsers/ass_parser.dart
+++ b/packages/hibiki_audio/lib/src/parsers/ass_parser.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 
 import '../audiobook/audiobook_model.dart';
+import 'cue_parse_dispatch.dart';
 import 'srt_parser.dart';
 import 'subtitle_markup.dart';
 import 'text_file_io.dart';
@@ -31,12 +32,11 @@ import 'text_file_io.dart';
 /// - 软换行符 `\N`、`\n`、`\h` 转为空格
 /// - textFragmentId 格式为 `[data-cue-id="<sentenceIndex>"]`，供 AudiobookBridge CSS selector 定位
 class AssParser {
-  static const int largeContentComputeThreshold = 1024 * 1024;
+  static const int largeContentComputeThreshold =
+      CueParseDispatch.largeContentComputeThreshold;
 
-  static bool shouldParseInIsolate(String content) {
-    return SrtParser.utf8ContentByteLength(content) >
-        largeContentComputeThreshold;
-  }
+  static bool shouldParseInIsolate(String content) =>
+      CueParseDispatch.shouldParseInIsolate(content);
 
   /// 与 [SrtParser.defaultChapter] 共用同一章节标识。
   static const String defaultChapter = SrtParser.defaultChapter;
@@ -65,28 +65,14 @@ class AssParser {
     String chapterHref = defaultChapter,
     int audioFileIndex = 0,
   }) {
-    if (shouldParseInIsolate(content)) {
-      return compute(_parseStringIsolate, <String, dynamic>{
-        'content': content,
-        'bookKey': bookKey,
-        'chapterHref': chapterHref,
-        'audioFileIndex': audioFileIndex,
-      });
-    }
-    return Future<List<AudioCue>>.value(parseString(
+    return CueParseDispatch.run(
       content: content,
-      bookKey: bookKey,
-      chapterHref: chapterHref,
-      audioFileIndex: audioFileIndex,
-    ));
-  }
-
-  static List<AudioCue> _parseStringIsolate(Map<String, dynamic> args) {
-    return parseString(
-      content: args['content'] as String,
-      bookKey: args['bookKey'] as String,
-      chapterHref: args['chapterHref'] as String,
-      audioFileIndex: args['audioFileIndex'] as int,
+      parse: () => parseString(
+        content: content,
+        bookKey: bookKey,
+        chapterHref: chapterHref,
+        audioFileIndex: audioFileIndex,
+      ),
     );
   }
 

--- a/packages/hibiki_audio/lib/src/parsers/cue_parse_dispatch.dart
+++ b/packages/hibiki_audio/lib/src/parsers/cue_parse_dispatch.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import '../audiobook/audiobook_model.dart';
+
+/// 字幕解析器（SRT / ASS / VTT）共用的 isolate 派发脚手架。
+///
+/// 解析主体是各格式自己的纯函数 `parseString`；这里只负责统一的
+/// 「大文件切 isolate、小文件同步解析」决策，避免三份逐字复制。
+class CueParseDispatch {
+  /// 超过该字节数（UTF-8 编码后）的内容切 isolate 解析，避免阻塞 UI。
+  static const int largeContentComputeThreshold = 1024 * 1024;
+
+  static int utf8ContentByteLength(String content) {
+    return utf8.encode(content).length;
+  }
+
+  static bool shouldParseInIsolate(String content) {
+    return utf8ContentByteLength(content) > largeContentComputeThreshold;
+  }
+
+  /// 按内容大小决定同步解析或切 isolate。
+  ///
+  /// [parse] 必须是只捕获不可变入参的纯函数闭包（跨 isolate 发送）。
+  static Future<List<AudioCue>> run({
+    required String content,
+    required List<AudioCue> Function() parse,
+  }) {
+    if (shouldParseInIsolate(content)) {
+      return compute((_) => parse(), null);
+    }
+    return Future<List<AudioCue>>.value(parse());
+  }
+}

--- a/packages/hibiki_audio/lib/src/parsers/srt_parser.dart
+++ b/packages/hibiki_audio/lib/src/parsers/srt_parser.dart
@@ -1,9 +1,7 @@
-import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
-
 import '../audiobook/audiobook_model.dart';
+import 'cue_parse_dispatch.dart';
 import 'subtitle_markup.dart';
 import 'text_file_io.dart';
 
@@ -20,15 +18,14 @@ import 'text_file_io.dart';
 /// 名前はまだない。
 /// ```
 class SrtParser {
-  static const int largeContentComputeThreshold = 1024 * 1024;
+  static const int largeContentComputeThreshold =
+      CueParseDispatch.largeContentComputeThreshold;
 
-  static int utf8ContentByteLength(String content) {
-    return utf8.encode(content).length;
-  }
+  static int utf8ContentByteLength(String content) =>
+      CueParseDispatch.utf8ContentByteLength(content);
 
-  static bool shouldParseInIsolate(String content) {
-    return utf8ContentByteLength(content) > largeContentComputeThreshold;
-  }
+  static bool shouldParseInIsolate(String content) =>
+      CueParseDispatch.shouldParseInIsolate(content);
 
   /// SRT 独立书籍使用的固定章节标识。
   static const String defaultChapter = 'srt://default';
@@ -64,28 +61,14 @@ class SrtParser {
     String chapterHref = defaultChapter,
     int audioFileIndex = 0,
   }) {
-    if (shouldParseInIsolate(content)) {
-      return compute(_parseStringIsolate, <String, dynamic>{
-        'content': content,
-        'bookKey': bookKey,
-        'chapterHref': chapterHref,
-        'audioFileIndex': audioFileIndex,
-      });
-    }
-    return Future<List<AudioCue>>.value(parseString(
+    return CueParseDispatch.run(
       content: content,
-      bookKey: bookKey,
-      chapterHref: chapterHref,
-      audioFileIndex: audioFileIndex,
-    ));
-  }
-
-  static List<AudioCue> _parseStringIsolate(Map<String, dynamic> args) {
-    return parseString(
-      content: args['content'] as String,
-      bookKey: args['bookKey'] as String,
-      chapterHref: args['chapterHref'] as String,
-      audioFileIndex: args['audioFileIndex'] as int,
+      parse: () => parseString(
+        content: content,
+        bookKey: bookKey,
+        chapterHref: chapterHref,
+        audioFileIndex: audioFileIndex,
+      ),
     );
   }
 

--- a/packages/hibiki_audio/lib/src/parsers/vtt_parser.dart
+++ b/packages/hibiki_audio/lib/src/parsers/vtt_parser.dart
@@ -1,8 +1,7 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
-
 import '../audiobook/audiobook_model.dart';
+import 'cue_parse_dispatch.dart';
 import 'srt_parser.dart';
 import 'subtitle_markup.dart';
 import 'text_file_io.dart';
@@ -28,12 +27,11 @@ import 'text_file_io.dart';
 /// - 剥离 HTML/VTT 行内标签（`<b>`、`<ruby>`、`<c.class>` 等）
 /// - textFragmentId 格式为 `[data-cue-id="<sentenceIndex>"]`，供 AudiobookBridge CSS selector 定位
 class VttParser {
-  static const int largeContentComputeThreshold = 1024 * 1024;
+  static const int largeContentComputeThreshold =
+      CueParseDispatch.largeContentComputeThreshold;
 
-  static bool shouldParseInIsolate(String content) {
-    return SrtParser.utf8ContentByteLength(content) >
-        largeContentComputeThreshold;
-  }
+  static bool shouldParseInIsolate(String content) =>
+      CueParseDispatch.shouldParseInIsolate(content);
 
   /// 与 [SrtParser.defaultChapter] 共用同一章节标识。
   static const String defaultChapter = SrtParser.defaultChapter;
@@ -63,28 +61,14 @@ class VttParser {
     String chapterHref = defaultChapter,
     int audioFileIndex = 0,
   }) {
-    if (shouldParseInIsolate(content)) {
-      return compute(_parseStringIsolate, <String, dynamic>{
-        'content': content,
-        'bookKey': bookKey,
-        'chapterHref': chapterHref,
-        'audioFileIndex': audioFileIndex,
-      });
-    }
-    return Future<List<AudioCue>>.value(parseString(
+    return CueParseDispatch.run(
       content: content,
-      bookKey: bookKey,
-      chapterHref: chapterHref,
-      audioFileIndex: audioFileIndex,
-    ));
-  }
-
-  static List<AudioCue> _parseStringIsolate(Map<String, dynamic> args) {
-    return parseString(
-      content: args['content'] as String,
-      bookKey: args['bookKey'] as String,
-      chapterHref: args['chapterHref'] as String,
-      audioFileIndex: args['audioFileIndex'] as int,
+      parse: () => parseString(
+        content: content,
+        bookKey: bookKey,
+        chapterHref: chapterHref,
+        audioFileIndex: audioFileIndex,
+      ),
     );
   }
 


### PR DESCRIPTION
## 概要

按 2026-07-24 架构审查（`docs/reviews/2026-07-24-project-review.md`，随 PR 入库并已更新）把「同一段代码多份共存」的**全部**簇合并完毕：首批 4 簇 + backlog 9 项，共 13 个合并单元。全部是抽单一真相源 + 参数化真实差异，公开 API 零破坏。

## 合并清单（每项一个 commit）

**生产代码**
1. EPUB 打包器双份 → `hibiki_audio` `EpubBuilder`（uid 前缀字节不变；顺带补 TextToEpub 零覆盖单测）
2. SRT/ASS/VTT isolate 脚手架 ×3 → `CueParseDispatch`
3. creator 导出字段搜索 ×2 → `ExportFieldSearch` mixin
4. Anki 双后端 payload 16 字段透传 → `BaseAnkiRepository.renderMediaPayload`
5. Dropbox/OneDrive OAuth 外壳 ×2 → `PkceBackendAuthMixin`（**新增 19 例回归测试**——此前该链路零测试；协议分叉 _checkResponse/scopes/端口/signOut revoke 原地保留）
6. hibiki_client/webdav 路径四件套 ×2 → `WebDavPathBackendMixin`（`_ensureResolved` 时机逐点保留；顺带删死 shim `findByPrefix`）
7. 删除确认弹窗 ×3 → `DeleteScopeConfirmDialog`（公开名与 md3 静态断言保持）
8. AudioSession 会话块 ×3 → `beginDuckingPlayback`（**顺带修 base_audio_field 两处漂移 bug**：HBK-AUDIT-107 nullable notifier、slider max=0 断言）
9. 词典/视频页根 Overlay 同步 ×2（~200 行）→ `DictionaryPopupOverlayHostMixin`（BUG-121/051/135/861 兜底逐一保留；texthooker 第三份为后续候选）
10. 合集合并编排 ×2 → `combineMergeCollections`（TOCTOU 语义不变）
11. Enhancement/QuickAction 脚手架 ×2 → `CreatorRegistryEntry`（全部子类零改动）
12. 统计页媒体行 ×2 → `buildStatMediaRow`

**测试夹具（净删 ~3800 行）**
13. sync 家族 4 harness（−2214）/ audiobook 家族 harness（−1646）/ integration reader helper（−592）；断言与 test 名逐字保留

## 验证

- `flutter analyze`（hibiki + hibiki_anki）：**0 issue**
- 全量 `flutter test` 两轮：首批后 12905 过；backlog 全落后 12923 过 + 3 个源码守卫随代码移位修正后单独复跑绿（守卫断言意图不变）；sync 目录 1585 / audiobook 目录 825 / popup 相关 86 / OAuth 新增 19 全绿
- 已知偶发：`sync_orchestrator_collections_test` 全量 shard 偶发挂、隔离即绿（未触碰该文件）

## 明确不合并（故意的复制，报告§四）

双设置渲染器（Cupertino 隐藏能力）、inappwebview fork 上游结构、弹窗三镜像、popup wrapper 转发字段、sync_manager↔orchestrator conflict fake（真实漂移）、audiobook cue 建造器（真实分化）。

https://claude.ai/code/session_01LXQ71KadNQwAjg3j6X2DXL