### PR TITLE
fix(danmaku): 拉弹幕独立超时 + 失败不再被吞成空列表 (BUG-1054)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1020 条。点号进各自文件。
+> 共 1021 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1054](bugs/BUG-1054-danmaku-comment-fetch-timeout-and-swallowed-status.md) | ✅ | ✅ | 手动匹配弹幕「弹幕加载失败」：拉弹幕与搜索共用 8s 超时，且非 2xx 被吞成空列表 |
 | [BUG-1053](bugs/BUG-1053-embedded-torrent-dht-always-on.md) | ✅ | ✅ | 空闲也常驻 libtorrent/DHT（6881），整机网络周期性高延迟 |
 | [BUG-1052](bugs/BUG-1052-reading-time-lost-session-clock-reanchor.md) | ✅ | ✅ | 阅读时长被会话时钟重锚吃掉，速度/统计爆表（今日 0 分钟 / 125666 字·时⁻¹） |
 | [BUG-1051](bugs/BUG-1051-series-audio-subtitle-memory-lost.md) | ✅ | ✅ | 同系列音轨选择与字幕调轴记忆丢失（统一合集迁移回归） |

--- a/docs/bugs/BUG-1054-danmaku-comment-fetch-timeout-and-swallowed-status.md
+++ b/docs/bugs/BUG-1054-danmaku-comment-fetch-timeout-and-swallowed-status.md
@@ -1,0 +1,30 @@
+## BUG-1054 · 手动匹配弹幕「弹幕加载失败」：拉弹幕与搜索共用 8s 超时，且非 2xx 被吞成空列表
+- **报告**：2026-07-24（用户：截图——视频页「匹配弹幕」搜索 `Bad Girl 08` 已列出《坏女孩》TV动画 第8话，点选后左上角弹「弹幕加载失败，请稍后重试」）
+- **真实性**：✅ 真 bug。根因在 `hibiki/lib/src/media/video/dandanplay_client.dart:375-398`（原 `fetchCommentsForMatch`）与其调用方 `hibiki/lib/src/pages/implementations/video_hibiki/danmaku.part.dart:174-203`（原 `_bindDanmakuEpisode`）。
+
+  **定位过程（真实代码路径 + 实测）**
+  1. 那条 toast 文案唯一来源是 `danmaku.part.dart` 里 `_bindDanmakuEpisode` 的 `catch`（i18n key `video_danmaku_manual_bind_failed`），即 `client.fetchCommentsForMatch(...)` **抛了异常**。
+  2. 实测 `https://api.dandanplay.net/api/v2/comment/{id}`：无签名时 **403、约 330ms、body 空**；`/api/v2/search/episodes` 同样 403。而原 `fetchCommentsForMatch` 把任何非 2xx **`return const <VideoDanmakuItem>[]`**——**不抛异常**。故用户看到的报错**不可能**来自服务器拒绝。
+  3. 用户截图里搜索在同一秒成功 → DNS / TLS / 内置凭据 / v2 签名全部正常（生产库 `preferences` 里无 `video_danmaku_config`，走的是构建期注入的内置凭据）。
+  4. 排除下来，`_bindDanmakuEpisode` 的 `catch` 只可能被 `TimeoutException` / `SocketException` / `ClientException` 触发。而这条路径上唯一的超时是 `DandanplayClient` 的**全局 8s**：搜索（几 KB JSON）与拉弹幕**共用同一个值**，且 `http.get().timeout()` 计的是**整个响应体下载完**的时间；`/api/v2/comment/{id}?withRelated=true` 要由服务端聚合第三方弹幕源，正片响应体可达数 MB。这是「搜索成功、拉弹幕失败」最自洽的解释，也是本 bug 的直接触发点。
+
+  **同一处契约还埋着两个静默 bug（与超时同源：失败被压成空列表）**
+  - `_bindDanmakuEpisode`：403/404/5xx 时不报错反而走「成功」分支——面板关闭、`episodeId` 落库、弹幕为空、零提示；下次自动加载还会记住这个错的集。
+  - `_loadDanmakuForVideo`：记住的集拉到空列表就当「缓存失效」，退回整文件匹配，白算一次 16MiB 文件 MD5 + `/api/v2/match` 再失败一遍。
+
+- **[x] ① 已修复** — 根因是**契约**：`fetchCommentsForMatch` 用裸 `List` 做返回值，让「0 条弹幕」和「拉取失败」不可区分；超时按 client 一刀切而不按请求量级分档。改法：
+  - `fetchCommentsForMatch` 改返回带状态的 `DandanplayFetchResult`（非 2xx → `serverError` 且把状态码放进 `error`；IO/超时 → `networkError`；2xx 且 `comments` 是 List → `hit`，`items` 允许为空表示「该集有效但暂无弹幕」）。
+  - `DandanplayClient` 拆两档超时：`timeout`（轻量 match/search，默认 8s 不变）与新增 `commentTimeout`（拉弹幕，默认 30s）。
+  - `fetchBestDanmakuForFile` 如实上抛拉弹幕的失败状态（此前被吞成「hit 且 0 条」），同时保留已匹配到的集供 UI 展示。
+  - `_bindDanmakuEpisode` 按状态分流：失败 → 不落 `episodeId`、不关面板、按类型给具体文案（`video_danmaku_manual_network_error` / 新增 `video_danmaku_manual_bind_server_error`）；成功但 0 条 → 正常绑定并提示新增的 `video_danmaku_manual_bind_empty`。
+  - `_loadDanmakuForVideo` 只在「记住的集有效但确实 0 条」时才退回整文件匹配。
+  - 顺带把三处各写四个 `on ... catch` 的重复分支收敛成共用的 `_statusForError`。
+  - 新增 2 个 i18n key 经 `hibiki/tool/i18n_sync.dart` 同步 17 语言并重跑 `dart run slang`。
+  - 提交：`<待填>`
+
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/media/video/dandanplay_client_test.dart`：非 2xx（403/404/500）→ `serverError` 且 `error` 带状态码；网络异常 → `networkError`；有效集 0 条弹幕 → 仍是 `hit`；**只把轻量 `timeout` 压到 1ms、`commentTimeout` 用默认值时拉弹幕仍成功而搜索超时**（谁再让两者共用一个超时即红）；`fetchBestDanmakuForFile` 在匹配成功但拉弹幕 403 时上报 `serverError` 而非 hit。
+  - `hibiki/test/pages/video_danmaku_wiring_guard_test.dart`：源码守卫钉住 `_bindDanmakuEpisode` 必须先按 `result.status != hit` 分流并 `return`（早于 `setVideoDanmakuEpisodeId`）、三类文案都在；以及 `_loadDanmakuForVideo` 只在「hit 且 items 为空」时才退回整文件匹配。
+  - 定向验证：`flutter test test/i18n test/media/video test/pages/video_quick_settings_sheet_test.dart test/pages/video_settings_schema_guard_test.dart test/settings/settings_schema_coverage_test.dart --no-pub` → 1925 passed / 2 skipped；`flutter analyze` 全绿。
+
+- **备注**：**用户那次的确切异常文本没有取到**——`DebugLogService` 默认关闭且只存内存（`hibiki/lib/src/utils/misc/debug_log_service.dart:45`），无法回溯。上面第 4 步是排除法结论（403 已实测不抛异常、搜索同秒成功已排除网络与凭据），不是抓到的异常栈。修复本身不依赖这个结论：超时分档修掉最可能的触发点，而带状态的返回值让**任何**残留失败都会以「网络错误」/「服务器拒绝」/「暂无弹幕」自报类型，不再是一句笼统的「请稍后重试」。仍需在真机复测原始失败路径（Windows 视频页 → 匹配弹幕 → 搜《坏女孩》→ 选第8话）确认弹幕真正出现。

--- a/docs/bugs/BUG-1054-danmaku-comment-fetch-timeout-and-swallowed-status.md
+++ b/docs/bugs/BUG-1054-danmaku-comment-fetch-timeout-and-swallowed-status.md
@@ -20,7 +20,7 @@
   - `_loadDanmakuForVideo` 只在「记住的集有效但确实 0 条」时才退回整文件匹配。
   - 顺带把三处各写四个 `on ... catch` 的重复分支收敛成共用的 `_statusForError`。
   - 新增 2 个 i18n key 经 `hibiki/tool/i18n_sync.dart` 同步 17 语言并重跑 `dart run slang`。
-  - 提交：`<待填>`
+  - 提交：`1d7a4759f`
 
 - **[x] ② 已加自动化测试** —
   - `hibiki/test/media/video/dandanplay_client_test.dart`：非 2xx（403/404/500）→ `serverError` 且 `error` 带状态码；网络异常 → `networkError`；有效集 0 条弹幕 → 仍是 `hit`；**只把轻量 `timeout` 压到 1ms、`commentTimeout` 用默认值时拉弹幕仍成功而搜索超时**（谁再让两者共用一个超时即红）；`fetchBestDanmakuForFile` 在匹配成功但拉弹幕 403 时上报 `serverError` 而非 hit。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 40222 (2366 per locale)
+/// Strings: 40256 (2368 per locale)
 ///
-/// Built on 2026-07-24 at 04:21 UTC
+/// Built on 2026-07-24 at 07:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3156,6 +3156,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -8524,6 +8528,12 @@ class _StringsAr extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -13965,6 +13975,12 @@ class _StringsDe extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -19422,6 +19438,12 @@ class _StringsEs extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -24890,6 +24912,12 @@ class _StringsFr extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -30285,6 +30313,12 @@ class _StringsId extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -35728,6 +35762,12 @@ class _StringsIt extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -40976,6 +41016,12 @@ class _StringsJa extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -46227,6 +46273,12 @@ class _StringsKo extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -51648,6 +51700,12 @@ class _StringsNl extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -57084,6 +57142,12 @@ class _StringsPtBr extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -62503,6 +62567,12 @@ class _StringsRu extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -67867,6 +67937,12 @@ class _StringsTh extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -73263,6 +73339,12 @@ class _StringsTr extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -78646,6 +78728,12 @@ class _StringsVi extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 // Path: <root>
@@ -83655,6 +83743,10 @@ class _StringsZhCn extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       '匹配中 ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error => '弹幕服务器拒绝了请求，请稍后重试';
+  @override
+  String get video_danmaku_manual_bind_empty => '这一集还没有弹幕';
 }
 
 // Path: <root>
@@ -88821,6 +88913,12 @@ class _StringsZhHk extends _StringsEn {
   String video_scrape_batch_progress(
           {required Object current, required Object total}) =>
       'Matching ${current}/${total}';
+  @override
+  String get video_danmaku_manual_bind_server_error =>
+      'The danmaku server rejected the request. Try again later.';
+  @override
+  String get video_danmaku_manual_bind_empty =>
+      'No danmaku for this episode yet.';
 }
 
 /// Flat map(s) containing all translations.
@@ -93657,6 +93755,10 @@ extension on _StringsEn {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -98491,6 +98593,10 @@ extension on _StringsAr {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -103346,6 +103452,10 @@ extension on _StringsDe {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -108200,6 +108310,10 @@ extension on _StringsEs {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -113060,6 +113174,10 @@ extension on _StringsFr {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -117902,6 +118020,10 @@ extension on _StringsId {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -122759,6 +122881,10 @@ extension on _StringsIt {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -127578,6 +127704,10 @@ extension on _StringsJa {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -132401,6 +132531,10 @@ extension on _StringsKo {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -137251,6 +137385,10 @@ extension on _StringsNl {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -142098,6 +142236,10 @@ extension on _StringsPtBr {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -146950,6 +147092,10 @@ extension on _StringsRu {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -151786,6 +151932,10 @@ extension on _StringsTh {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -156631,6 +156781,10 @@ extension on _StringsTr {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -161471,6 +161625,10 @@ extension on _StringsVi {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }
@@ -166272,6 +166430,10 @@ extension on _StringsZhCn {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             '匹配中 ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return '弹幕服务器拒绝了请求，请稍后重试';
+      case 'video_danmaku_manual_bind_empty':
+        return '这一集还没有弹幕';
       default:
         return null;
     }
@@ -171086,6 +171248,10 @@ extension on _StringsZhHk {
       case 'video_scrape_batch_progress':
         return ({required Object current, required Object total}) =>
             'Matching ${current}/${total}';
+      case 'video_danmaku_manual_bind_server_error':
+        return 'The danmaku server rejected the request. Try again later.';
+      case 'video_danmaku_manual_bind_empty':
+        return 'No danmaku for this episode yet.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "没有可匹配的本地视频",
   "video_scrape_apply_to_collection": "同时应用到本合集全部 $n 集",
   "video_scrape_batch_summary": "完成：应用 $applied，待确认 $confirm，跳过 $skipped",
-  "video_scrape_batch_progress": "匹配中 $current/$total"
+  "video_scrape_batch_progress": "匹配中 $current/$total",
+  "video_danmaku_manual_bind_server_error": "弹幕服务器拒绝了请求，请稍后重试",
+  "video_danmaku_manual_bind_empty": "这一集还没有弹幕"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2364,5 +2364,7 @@
   "video_scrape_batch_empty": "No local videos to match",
   "video_scrape_apply_to_collection": "Also apply to all $n episodes in this collection",
   "video_scrape_batch_summary": "Done: $applied applied, $confirm to review, $skipped skipped",
-  "video_scrape_batch_progress": "Matching $current/$total"
+  "video_scrape_batch_progress": "Matching $current/$total",
+  "video_danmaku_manual_bind_server_error": "The danmaku server rejected the request. Try again later.",
+  "video_danmaku_manual_bind_empty": "No danmaku for this episode yet."
 }

--- a/hibiki/lib/src/media/video/dandanplay_client.dart
+++ b/hibiki/lib/src/media/video/dandanplay_client.dart
@@ -250,21 +250,29 @@ class DandanplayClient {
   /// [config] 缺省读取进程级 [DandanplayConfig.current]（偏好仓库推送），使
   /// 播放页的零参 `DandanplayClient()` 自动吃到用户配置的服务器/凭据。显式 [baseUri]
   /// 优先于 [config] 的服务器地址（测试注入 / 强制覆盖用）。
+  ///
+  /// 超时分两档（BUG-1054）：[timeout] 给轻量请求（match / search，响应几 KB），
+  /// [commentTimeout] 给 `/api/v2/comment/{id}`——后者在 `withRelated=true` 时要由
+  /// 服务端聚合第三方弹幕源，响应体可达数 MB，而 `http.get().timeout()` 计的是
+  /// **整个响应体下载完**的时间；两者共用 8s 会让正片弹幕稳定超时。
   DandanplayClient({
     http.Client? httpClient,
     Uri? baseUri,
     DandanplayConfig? config,
     Duration timeout = const Duration(seconds: 8),
+    Duration commentTimeout = const Duration(seconds: 30),
   })  : _client = httpClient ?? http.Client(),
         _config = config ?? DandanplayConfig.current,
         _baseUri =
             baseUri ?? (config ?? DandanplayConfig.current).resolvedBaseUri,
-        _timeout = timeout;
+        _timeout = timeout,
+        _commentTimeout = commentTimeout;
 
   final http.Client _client;
   final DandanplayConfig _config;
   final Uri _baseUri;
   final Duration _timeout;
+  final Duration _commentTimeout;
 
   void close() => _client.close();
 
@@ -285,34 +293,19 @@ class DandanplayClient {
           matched.match == null) {
         return matched;
       }
-      final List<VideoDanmakuItem> items =
+      final DandanplayFetchResult comments =
           await fetchCommentsForMatch(matched.match!);
+      // 拉弹幕失败时如实上抛失败状态（此前被吞成「命中且 0 条」，见 BUG-1054）；
+      // 匹配信息仍保留，供 UI 展示已匹配到哪一集。
       return DandanplayFetchResult(
-        status: DandanplayFetchStatus.hit,
-        items: items,
+        status: comments.status,
+        items: comments.items,
         match: matched.match,
         matches: matched.matches,
-      );
-    } on SocketException catch (e) {
-      return DandanplayFetchResult(
-        status: DandanplayFetchStatus.networkError,
-        error: e,
-      );
-    } on http.ClientException catch (e) {
-      return DandanplayFetchResult(
-        status: DandanplayFetchStatus.networkError,
-        error: e,
-      );
-    } on TimeoutException catch (e) {
-      return DandanplayFetchResult(
-        status: DandanplayFetchStatus.networkError,
-        error: e,
+        error: comments.error,
       );
     } catch (e) {
-      return DandanplayFetchResult(
-        status: DandanplayFetchStatus.serverError,
-        error: e,
-      );
+      return DandanplayFetchResult(status: _statusForError(e), error: e);
     }
   }
 
@@ -372,7 +365,17 @@ class DandanplayClient {
     );
   }
 
-  Future<List<VideoDanmakuItem>> fetchCommentsForMatch(
+  /// 拉取 [match] 那一集的弹幕。
+  ///
+  /// 返回**带状态**的结果而不是裸列表（BUG-1054）：此前任何非 2xx 都被压成
+  /// `const []`，调用方无从区分「这一集真的 0 条弹幕」与「403 凭据/权限被拒、
+  /// 404 无此集、5xx、超时」。后果是手动绑定在服务器拒绝时反而「成功」——面板关闭、
+  /// episodeId 落库、弹幕为空、零提示；自动加载则把错误当成缓存失效，白跑一次
+  /// 16MiB 文件 hash + `/api/v2/match`。
+  ///
+  /// `hit` 允许 [DandanplayFetchResult.items] 为空：那是「该集有效但暂无弹幕」，
+  /// 与错误是两回事，由调用方分别给反馈。
+  Future<DandanplayFetchResult> fetchCommentsForMatch(
     DandanplayMatch match,
   ) async {
     final String path = '/api/v2/comment/${match.episodeId}';
@@ -382,19 +385,39 @@ class DandanplayClient {
         'withRelated': 'true',
       },
     );
-    final http.Response response =
-        await _client.get(uri, headers: _headersFor(path)).timeout(_timeout);
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      return const <VideoDanmakuItem>[];
+    try {
+      final http.Response response = await _client
+          .get(uri, headers: _headersFor(path))
+          .timeout(_commentTimeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        return DandanplayFetchResult(
+          status: DandanplayFetchStatus.serverError,
+          match: match,
+          error: response.statusCode,
+        );
+      }
+      final dynamic decoded = jsonDecode(response.body);
+      if (decoded is! Map || decoded['comments'] is! List) {
+        return DandanplayFetchResult(
+          status: DandanplayFetchStatus.serverError,
+          match: match,
+        );
+      }
+      return DandanplayFetchResult(
+        status: DandanplayFetchStatus.hit,
+        items: dandanplayCommentsToDanmaku(
+          decoded['comments'] as List<dynamic>,
+          shiftMs: (match.shiftSeconds * 1000).round(),
+        ),
+        match: match,
+      );
+    } catch (e) {
+      return DandanplayFetchResult(
+        status: _statusForError(e),
+        match: match,
+        error: e,
+      );
     }
-    final dynamic decoded = jsonDecode(response.body);
-    if (decoded is! Map) return const <VideoDanmakuItem>[];
-    final dynamic comments = decoded['comments'];
-    if (comments is! List) return const <VideoDanmakuItem>[];
-    return dandanplayCommentsToDanmaku(
-      comments,
-      shiftMs: (match.shiftSeconds * 1000).round(),
-    );
   }
 
   /// 手动按番剧名 [keyword] 搜索候选集（TODO-1376，dandanplay `/api/v2/search/episodes`）。
@@ -442,28 +465,22 @@ class DandanplayClient {
         status: DandanplayFetchStatus.hit,
         animes: animes,
       );
-    } on SocketException catch (e) {
-      return DandanplaySearchResult(
-        status: DandanplayFetchStatus.networkError,
-        error: e,
-      );
-    } on http.ClientException catch (e) {
-      return DandanplaySearchResult(
-        status: DandanplayFetchStatus.networkError,
-        error: e,
-      );
-    } on TimeoutException catch (e) {
-      return DandanplaySearchResult(
-        status: DandanplayFetchStatus.networkError,
-        error: e,
-      );
     } catch (e) {
-      return DandanplaySearchResult(
-        status: DandanplayFetchStatus.serverError,
-        error: e,
-      );
+      return DandanplaySearchResult(status: _statusForError(e), error: e);
     }
   }
+}
+
+/// 把请求期异常归类成 [DandanplayFetchStatus]：连不上/断流/超时算 `networkError`
+/// （用户侧可重试），其余（JSON 畸形等）算 `serverError`。三处调用点共用同一判据，
+/// 消除此前每处各写四个 `on ... catch` 的重复分支。
+DandanplayFetchStatus _statusForError(Object error) {
+  final bool network = error is IOException || // Socket/Handshake/Http 等
+      error is http.ClientException ||
+      error is TimeoutException;
+  return network
+      ? DandanplayFetchStatus.networkError
+      : DandanplayFetchStatus.serverError;
 }
 
 Future<String> dandanplayFileHash(File file) async {

--- a/hibiki/lib/src/pages/implementations/video_hibiki/danmaku.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/danmaku.part.dart
@@ -53,19 +53,16 @@ extension _VideoDanmaku on _VideoHibikiPageState {
       final int? savedEpisodeId =
           appModel.getVideoDanmakuEpisodeId(widget.bookUid);
       if (savedEpisodeId != null) {
-        final DandanplayMatch cached =
-            DandanplayMatch(episodeId: savedEpisodeId);
-        final List<VideoDanmakuItem> cachedItems =
-            await client.fetchCommentsForMatch(cached);
-        if (cachedItems.isNotEmpty) {
-          result = DandanplayFetchResult(
-            status: DandanplayFetchStatus.hit,
-            items: cachedItems,
-            match: cached,
-          );
-        } else {
-          result = await client.fetchBestDanmakuForFile(file);
-        }
+        final DandanplayFetchResult cached = await client.fetchCommentsForMatch(
+          DandanplayMatch(episodeId: savedEpisodeId),
+        );
+        // 只有「记住的这一集有效、但确实 0 条弹幕」才值得退回整文件匹配（多半是记错了
+        // 集）；网络/服务器失败退回去走的是同一条链路，只会白算一次 16MiB 文件 hash
+        // 再失败一遍（BUG-1054：此前失败被吞成空列表，与 0 条弹幕无从区分）。
+        result =
+            cached.status == DandanplayFetchStatus.hit && cached.items.isEmpty
+                ? await client.fetchBestDanmakuForFile(file)
+                : cached;
       } else {
         result = await client.fetchBestDanmakuForFile(file);
       }
@@ -174,10 +171,26 @@ extension _VideoDanmaku on _VideoHibikiPageState {
   Future<void> _bindDanmakuEpisode(DandanplaySearchEpisode episode) async {
     final DandanplayClient client = DandanplayClient();
     try {
-      final List<VideoDanmakuItem> items = await client.fetchCommentsForMatch(
+      final DandanplayFetchResult result = await client.fetchCommentsForMatch(
         DandanplayMatch(episodeId: episode.episodeId),
       );
       if (!mounted) return;
+      if (result.status != DandanplayFetchStatus.hit) {
+        // BUG-1054：拉弹幕失败时保持面板打开、不落 episodeId，并按失败类型给具体
+        // 文案。此前非 2xx 被吞成空列表，反而走「成功」分支：面板关闭、episodeId
+        // 落库、弹幕为空、零提示。
+        debugPrint(
+          '[VideoDanmaku] manual bind failed: episode=${episode.episodeId} '
+          'status=${result.status} error=${result.error}',
+        );
+        _showOsd(
+          result.status == DandanplayFetchStatus.networkError
+              ? t.video_danmaku_manual_network_error
+              : t.video_danmaku_manual_bind_server_error,
+          icon: Icons.error_outline,
+        );
+        return;
+      }
       await appModel.setVideoDanmakuEpisodeId(
           widget.bookUid, episode.episodeId);
       if (!appModel.videoDanmakuEnabled) {
@@ -186,11 +199,16 @@ extension _VideoDanmaku on _VideoHibikiPageState {
       if (!mounted) return;
       // 让任何在途的自动加载作废，避免覆盖用户手动选定的这一集。
       ++_danmakuLoadSeq;
-      _rebuild(() => _applyDanmakuItems(items));
+      _rebuild(() => _applyDanmakuItems(result.items));
       _hideVideoSidePanel();
+      // 该集有效但暂无弹幕：绑定照样生效（之后有人发就会出现），但要说清楚，
+      // 否则用户只看到「面板关了、什么都没有」。
+      if (result.items.isEmpty) {
+        _showOsd(t.video_danmaku_manual_bind_empty, icon: Icons.info_outline);
+      }
       debugPrint(
         '[VideoDanmaku] manual bind episode=${episode.episodeId} '
-        'comments=${items.length}',
+        'comments=${result.items.length}',
       );
     } catch (e) {
       debugPrint('[VideoDanmaku] manual bind failed: $e');

--- a/hibiki/test/media/video/dandanplay_client_test.dart
+++ b/hibiki/test/media/video/dandanplay_client_test.dart
@@ -170,7 +170,7 @@ void main() {
       final File file = File(p.join(tempDir.path, 'Episode 04.mkv'));
       file.writeAsBytesSync(<int>[1, 2, 3, 4]);
       final DandanplayClient client = DandanplayClient(
-        timeout: const Duration(milliseconds: 1),
+        commentTimeout: const Duration(milliseconds: 1),
         httpClient: MockClient((http.Request request) async {
           if (request.url.path == '/api/v2/match') {
             return http.Response(
@@ -196,6 +196,125 @@ void main() {
           await client.fetchBestDanmakuForFile(file);
 
       expect(result.status, DandanplayFetchStatus.networkError);
+      expect(result.items, isEmpty);
+    });
+
+    // ---- BUG-1054 回归：拉弹幕的失败必须能被调用方区分，且不与轻量请求共用超时 ----
+
+    test(
+        'BUG-1054: comment fetch reports non-2xx as serverError instead of an '
+        'empty comment list', () async {
+      for (final int code in <int>[403, 404, 500]) {
+        final DandanplayClient client = DandanplayClient(
+          httpClient: MockClient(
+              (http.Request request) async => http.Response('', code)),
+        );
+
+        final DandanplayFetchResult result = await client
+            .fetchCommentsForMatch(const DandanplayMatch(episodeId: 42));
+
+        expect(result.status, DandanplayFetchStatus.serverError,
+            reason: 'HTTP $code 是失败，不是「这一集 0 条弹幕」——'
+                '此前一律被压成 const []，手动绑定于是「成功」关面板、零提示');
+        expect(result.error, code, reason: '状态码要留在结果里供日志/文案分级');
+        expect(result.items, isEmpty);
+      }
+    });
+
+    test('BUG-1054: comment fetch reports network failure as networkError',
+        () async {
+      final DandanplayClient client = DandanplayClient(
+        httpClient: MockClient((_) async => throw const SocketException('x')),
+      );
+
+      final DandanplayFetchResult result = await client
+          .fetchCommentsForMatch(const DandanplayMatch(episodeId: 42));
+
+      expect(result.status, DandanplayFetchStatus.networkError);
+      expect(result.items, isEmpty);
+    });
+
+    test('BUG-1054: a valid episode with zero comments stays a hit', () async {
+      final DandanplayClient client = DandanplayClient(
+        httpClient: MockClient((_) async => http.Response(
+              jsonEncode(<String, dynamic>{'comments': <dynamic>[]}),
+              200,
+            )),
+      );
+
+      final DandanplayFetchResult result = await client
+          .fetchCommentsForMatch(const DandanplayMatch(episodeId: 42));
+
+      expect(result.status, DandanplayFetchStatus.hit,
+          reason: '「该集有效但暂无弹幕」与「拉取失败」是两回事，必须能分开');
+      expect(result.items, isEmpty);
+    });
+
+    test(
+        'BUG-1054: comment fetch uses its own long timeout, not the light-request '
+        'one', () async {
+      // 直接触发点：搜索/匹配（几 KB）与拉弹幕（withRelated=true，服务端聚合第三方源、
+      // 响应体可达数 MB）此前共用同一个 8s；http.get().timeout() 计的是整个响应体下载完
+      // 的时间，正片弹幕于是稳定超时 → 用户只看到「弹幕加载失败，请稍后重试」。
+      // 只把轻量超时压到 1ms，commentTimeout 用默认值：谁再让拉弹幕复用 _timeout，
+      // 本用例立刻红。
+      final DandanplayClient client = DandanplayClient(
+        timeout: const Duration(milliseconds: 1),
+        httpClient: MockClient((http.Request request) async {
+          await Future<void>.delayed(const Duration(milliseconds: 40));
+          return http.Response(
+            jsonEncode(<String, dynamic>{
+              'comments': <Map<String, dynamic>>[
+                <String, dynamic>{'p': '2.00,1,16777215,100', 'm': 'slow'},
+              ],
+            }),
+            200,
+          );
+        }),
+      );
+
+      final DandanplayFetchResult result = await client
+          .fetchCommentsForMatch(const DandanplayMatch(episodeId: 42));
+
+      expect(result.status, DandanplayFetchStatus.hit,
+          reason: '拉弹幕比 1ms 的轻量超时慢得多也必须成功——它走默认的 commentTimeout');
+      expect(result.items.single.text, 'slow');
+
+      // 对照：同一个 client 下，轻量请求仍受 1ms 约束。
+      final DandanplaySearchResult search = await client.searchEpisodes('demo');
+      expect(search.status, DandanplayFetchStatus.networkError,
+          reason: '搜索仍走 timeout，两档超时确实是分开的');
+    });
+
+    test(
+        'BUG-1054: fetchBestDanmakuForFile propagates the comment failure '
+        'instead of claiming a hit with zero comments', () async {
+      final File file = File(p.join(tempDir.path, 'Episode 10.mkv'));
+      file.writeAsBytesSync(<int>[1, 2, 3, 4]);
+      final DandanplayClient client = DandanplayClient(
+        httpClient: MockClient((http.Request request) async {
+          if (request.url.path == '/api/v2/match') {
+            return http.Response(
+              jsonEncode(<String, dynamic>{
+                'success': true,
+                'isMatched': true,
+                'matches': <Map<String, dynamic>>[
+                  <String, dynamic>{'episodeId': 42},
+                ],
+              }),
+              200,
+            );
+          }
+          return http.Response('', 403);
+        }),
+      );
+
+      final DandanplayFetchResult result =
+          await client.fetchBestDanmakuForFile(file);
+
+      expect(result.status, DandanplayFetchStatus.serverError,
+          reason: '匹配成功但拉弹幕被拒 → 整体是失败，不能报 hit');
+      expect(result.match?.episodeId, 42, reason: '已匹配到的集仍要保留供 UI 展示');
       expect(result.items, isEmpty);
     });
 

--- a/hibiki/test/pages/video_danmaku_wiring_guard_test.dart
+++ b/hibiki/test/pages/video_danmaku_wiring_guard_test.dart
@@ -262,4 +262,50 @@ void main() {
     expect(page, contains('client.searchEpisodes'));
     expect(page, contains('filterVideoDanmaku'));
   });
+
+  test(
+      'BUG-1054 source guard: manual bind gates on fetch status before '
+      'persisting the episode', () {
+    final String page = readVideoHibikiSource();
+    final int start = page.indexOf('Future<void> _bindDanmakuEpisode');
+    expect(start, greaterThanOrEqualTo(0));
+    final int end = page.indexOf('\n  /// 手动匹配侧栏内容', start);
+    expect(end, greaterThan(start));
+    final String body = page.substring(start, end);
+
+    // 失败必须先于「落 episodeId」返回：此前非 2xx 被吞成空列表，直接走成功分支
+    // （面板关闭 + episodeId 落库 + 弹幕为空 + 零提示）。
+    final int gate = body.indexOf('result.status != DandanplayFetchStatus.hit');
+    final int persist = body.indexOf('setVideoDanmakuEpisodeId');
+    expect(gate, greaterThanOrEqualTo(0),
+        reason: '手动绑定必须检查拉弹幕的状态，而不是只看是否抛异常');
+    expect(persist, greaterThan(gate),
+        reason: '拉弹幕失败时不得持久化 episodeId，否则下次自动加载会记住一个错的集');
+    expect(body.indexOf('return;', gate), lessThan(persist),
+        reason: '失败分支必须直接 return，不落库不关面板');
+
+    // 失败按类型给具体文案，而不是一句笼统的「请稍后重试」。
+    expect(body, contains('t.video_danmaku_manual_network_error'));
+    expect(body, contains('t.video_danmaku_manual_bind_server_error'));
+    // 该集有效但 0 条弹幕：绑定生效，但要说清楚。
+    expect(body, contains('t.video_danmaku_manual_bind_empty'));
+  });
+
+  test(
+      'BUG-1054 source guard: cached-episode load only re-matches on a genuine '
+      'empty hit', () {
+    final String page = readVideoHibikiSource();
+    final int start = page.indexOf('Future<void> _loadDanmakuForVideo');
+    expect(start, greaterThanOrEqualTo(0));
+    final int end = page.indexOf('void _clearDanmakuForCurrentVideo', start);
+    expect(end, greaterThan(start));
+    final String body = page.substring(start, end);
+
+    expect(
+      body,
+      contains('cached.status == DandanplayFetchStatus.hit &&'),
+      reason: '记住的集拉失败时不得退回整文件匹配——那只会白算一次 16MiB hash 再失败一遍',
+    );
+    expect(body, contains('cached.items.isEmpty'));
+  });
 }


### PR DESCRIPTION
用户报：视频页「匹配弹幕」搜索 `Bad Girl 08` 已列出《坏女孩》第8话，点选后弹「弹幕加载失败，请稍后重试」。

## 定位（真实代码路径 + 实测）

1. 该 toast 唯一来源是 `_bindDanmakuEpisode` 的 `catch` → `fetchCommentsForMatch` **抛了异常**。
2. 实测 `api.dandanplay.net/api/v2/comment/{id}` 无签名时 **403 / 330ms / 空 body**，而原实现把任何非 2xx **`return const []`**——**不抛异常**。故报错**不可能**来自服务器拒绝。
3. 搜索在同一秒成功 → DNS/TLS/内置凭据/v2 签名均正常。
4. 排除后只剩超时/网络类异常。而这条路径唯一的超时是 `DandanplayClient` 的**全局 8s**：搜索（几 KB）与拉弹幕共用，且 `http.get().timeout()` 计的是**整个响应体下载完**的时间；`/comment/{id}?withRelated=true` 由服务端聚合第三方弹幕源，正片响应体可达数 MB。

同一处契约还埋着两个静默 bug：403/404/5xx 时手动绑定反而走「成功」分支（面板关闭、episodeId 落库、弹幕为空、零提示）；自动加载把失败当缓存失效，白算一次 16MiB 文件 MD5 + `/api/v2/match`。

## 改动

根因是**契约**：裸 `List` 返回值让「0 条弹幕」与「拉取失败」不可区分；超时按 client 一刀切而非按请求量级分档。

- `fetchCommentsForMatch` 返回带状态的 `DandanplayFetchResult`（非 2xx→`serverError` 且状态码进 `error`；IO/超时→`networkError`；`hit` 允许 `items` 为空 = 该集有效但暂无弹幕）。
- `DandanplayClient` 拆两档超时：`timeout`（轻量 match/search，仍 8s）+ 新增 `commentTimeout`（拉弹幕，30s）。
- `fetchBestDanmakuForFile` 如实上抛拉弹幕的失败状态，保留已匹配的集。
- `_bindDanmakuEpisode` 按状态分流：失败不落 `episodeId`、不关面板、按类型给具体文案；成功但 0 条则正常绑定并说明。
- `_loadDanmakuForVideo` 只在「记住的集有效但确实 0 条」时才退回整文件匹配。
- 三处重复的四段 `on...catch` 收敛成共用的 `_statusForError`。
- 新增 2 个 i18n key 经 `tool/i18n_sync.dart` 同步 17 语言并重跑 slang。

## 验证

- `flutter analyze`（含 test）全绿。
- `dandanplay_client_test` 补 5 条 BUG-1054 回归；`video_danmaku_wiring_guard_test` 补源码守卫钉住失败分流早于 `episodeId` 落库。
- 定向：i18n + media/video + video 设置相关 → 1925 passed / 2 skipped。
- 全量 `flutter test`：仅 `platform_updater_test.dart` 的 `runAndExit ... installer file is missing` 超时失败；**已确认与本 PR 无关**——该路径代码与 develop 逐字节相同，机器空闲时同一 worktree 同一 commit 51/51 全过（它在单测里真跑 Windows `tasklist`/注册表探测，负载高时超 30s 预算，属既有 flaky）。

## 待办

⚠️ **尚未真机复测**：Windows 视频页 → 匹配弹幕 → 搜《坏女孩》→ 选第8话，确认弹幕真正出现。

另：用户那次的确切异常文本**未取到**（`DebugLogService` 默认关闭且只存内存，无法回溯），上述第 4 步是排除法结论而非异常栈。修复不依赖该判断——带状态的返回值让**任何**残留失败都会自报「网络错误 / 服务器拒绝 / 暂无弹幕」，不再是笼统的「请稍后重试」。

BUG 档：`docs/bugs/BUG-1054-danmaku-comment-fetch-timeout-and-swallowed-status.md`

https://claude.ai/code/session_015XNFSnxiiFokENkmx3Xwg5
