### PR TITLE
Repair incomplete galgame helper installs

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1025 条。点号进各自文件。
+> 共 1026 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1059](bugs/BUG-1059-galgame-x86-helper.md) | ✅ | ✅ | 残缺的 x86 galgame helper 被当成已安装，自动转区失效 |
 | [BUG-1058](bugs/BUG-1058-ffmpeg-min-vendored-missing-movtext.md) | ✅ | ✅ | 入库精简 ffmpeg 缺 movtext 编码器，桌面片段导出永远封不进字幕 |
 | [BUG-1057](bugs/BUG-1057-danmaku-comment-fetch-timeout-and-swallowed-status.md) | ✅ | ✅ | 手动匹配弹幕「弹幕加载失败」：拉弹幕与搜索共用 8s 超时，且非 2xx 被吞成空列表 |
 | [BUG-1056](bugs/BUG-1056-jimaku-source-subscription.md) | ✅ | ✅ | 字幕来源不可选且连载订阅无法绑定合集字幕 |

--- a/docs/bugs/BUG-1059-galgame-x86-helper.md
+++ b/docs/bugs/BUG-1059-galgame-x86-helper.md
@@ -1,0 +1,43 @@
+## BUG-1059 · 残缺的 x86 galgame helper 被当成已安装，自动转区失效
+
+- **报告**：2026-07-24。用户反馈《屋上の百合霊さん フルコーラス》未自动转区，随后显示 “Game launch or early engine injection failed”；同机 Fate/stay night [Realta Nua] 也用于制卡链路回归。
+- **真实性**：✅ 真 bug。用户机 `voice_hook/x86` 只有 injector、hook 与 Luna 文件，缺少 `LoaderDll.dll`、`LocaleEmulator.dll` 和许可证；安装器旧逻辑只检查 `hibiki_voice_injector.exe` 是否存在便直接放行。
+- **[x] ① 已修复** — x86/x64 分别使用与发布工作流一致的完整文件清单；已有残缺安装会自动重新下载当前发布包修复，修复失败则阻止错误启动；解压后在写版本标记前同时校验发布包根目录与最终安装目录。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/galgame_helper_installer_test.dart` 覆盖 x86 Locale Emulator 清单、x64 架构隔离、Windows 文件名大小写、未知架构与“残缺安装先修复、后写 marker”的路径守卫。
+- **备注**：用当前 x86 发布包真机验证《屋上の百合霊さん フルコーラス》能以正确日文标题启动并进入教程；Fate 的 KiriKiri 文本安全配置在配套 hook PR 中处理。
+
+### 根因
+
+`GalgameHelperInstaller.ensureInjector()` 原先把“注入器 exe 存在”等同于“helper 已完整安装”：
+
+```dart
+if (_injectorFile(arch).existsSync()) {
+  await _maybeAutoUpdate(...);
+  return true;
+}
+```
+
+当在线 SHA 检查超时或失败时，`_maybeAutoUpdate` 按 Never break 策略继续沿用旧目录。该策略本身合理，
+但旧目录可能来自早期四文件包，x86 缺少 Locale Emulator 运行库。结果是 UI 认为 helper 已就绪，
+实际无法建立 CP932 环境，非 Unicode 游戏以乱码标题或黑屏启动，随后早期注入失败。
+
+### 修复
+
+- `galgameHelperRequiredFiles(arch)` 成为安装完整性的单一清单，与
+  `.github/workflows/voice-hook-helper.yml` 的 x86/x64 产物对应。
+- 完整安装仍保留 best-effort 静默更新；残缺安装不再走“离线也放行”，而是自动修复并复检。
+- 下载包先校验 SHA-256，再校验 zip 根目录清单和落盘清单；只有全部通过才写 marker，避免把坏包记录成已安装版本。
+
+### 验证
+
+```text
+flutter test --no-pub --no-test-assets \
+  test/mining/galgame_helper_installer_test.dart \
+  test/mining/galgame_helper_launch_guard_test.dart
+# 30 passed
+
+flutter analyze --no-pub \
+  lib/src/mining/galgame_helper_installer.dart \
+  test/mining/galgame_helper_installer_test.dart
+# No issues found
+```

--- a/hibiki/lib/src/mining/galgame_helper_installer.dart
+++ b/hibiki/lib/src/mining/galgame_helper_installer.dart
@@ -43,6 +43,44 @@ List<String> galgameHelperCandidateUrls(String url) => <String>[
 /// 按目标游戏位数选注入器架构目录名：32 位游戏→x86，否则→x64（注入 DLL 位数必须匹配目标进程）。
 String galgameHelperArch({required bool is32Bit}) => is32Bit ? 'x86' : 'x64';
 
+/// helper 发布包根目录清单。必须与
+/// `.github/workflows/voice-hook-helper.yml` 保持一致。
+List<String> galgameHelperRequiredFiles(String arch) {
+  switch (arch) {
+    case 'x86':
+      return const <String>[
+        'hibiki_voice_injector.exe',
+        'hibiki_voice_hook.dll',
+        'LunaHook32.dll',
+        'LunaHost32.dll',
+        'LoaderDll.dll',
+        'LocaleEmulator.dll',
+        'LocaleEmulator-LGPL-3.0.txt',
+      ];
+    case 'x64':
+      return const <String>[
+        'hibiki_voice_injector.exe',
+        'hibiki_voice_hook.dll',
+        'LunaHook64.dll',
+        'LunaHost64.dll',
+      ];
+    default:
+      throw ArgumentError.value(arch, 'arch', 'unsupported helper arch');
+  }
+}
+
+/// 返回缺少的 helper 必需文件名；按 Windows 规则忽略文件名大小写。
+List<String> galgameHelperMissingFiles(
+  String arch,
+  Iterable<String> presentFiles,
+) {
+  final Set<String> present =
+      presentFiles.map((String name) => name.toLowerCase()).toSet();
+  return galgameHelperRequiredFiles(arch)
+      .where((String name) => !present.contains(name.toLowerCase()))
+      .toList(growable: false);
+}
+
 /// 某架构的分发 zip 文件名（与 CI workflow 打包命名一一对应）。
 String galgameHelperZipName(String arch) => 'voice_hook_$arch.zip';
 
@@ -118,17 +156,31 @@ class GalgameHelperInstaller {
     return Directory(p.join(exeDir, 'voice_hook', arch));
   }
 
-  /// 目标架构注入器 exe 的绝对路径。
-  File _injectorFile(String arch) =>
-      File(p.join(_archDir(arch).path, 'hibiki_voice_injector.exe'));
-
   /// 目标架构已装版本标记文件（内容 = 已装 zip 的 sha256）。
   File _markerFile(String arch) =>
       File(p.join(_archDir(arch).path, galgameHelperMarkerName()));
 
+  List<String> _missingInstalledFiles(String arch) {
+    final Directory dir = _archDir(arch);
+    if (!dir.existsSync()) {
+      return galgameHelperRequiredFiles(arch);
+    }
+    final Iterable<String> present = dir
+        .listSync(followLinks: false)
+        .whereType<File>()
+        .map((File file) => p.basename(file.path));
+    return galgameHelperMissingFiles(arch, present);
+  }
+
+  bool _hasExistingInstall(String arch) {
+    final Directory dir = _archDir(arch);
+    return dir.existsSync() && dir.listSync(followLinks: false).isNotEmpty;
+  }
+
   /// 确保对应架构注入器就位：
-  /// - 已存在 → true（幂等，直接放行启动）；
-  /// - 缺失 → 弹确认对话框（标大小）→ 确认后下载+校验+解压→复检；
+  /// - 完整安装 → true（并 best-effort 检查更新）；
+  /// - 已有残缺安装 → 自动下载当前包修复，失败则阻止错误启动；
+  /// - 从未安装 → 弹确认对话框（标大小）→ 确认后下载+校验+解压→复检；
   /// - 用户取消 / 下载失败 / 校验失败 / 解压后仍缺 → false（调用方中止启动）。
   Future<bool> ensureInjector({
     required bool is32Bit,
@@ -136,14 +188,31 @@ class GalgameHelperInstaller {
   }) async {
     if (!Platform.isWindows) return false;
     final String arch = galgameHelperArch(is32Bit: is32Bit);
-    final File injector = _injectorFile(arch);
-    if (injector.existsSync()) {
+    final List<String> missingBefore = _missingInstalledFiles(arch);
+    if (missingBefore.isEmpty) {
       // 已装：best-effort 检查 release 是否有新版（sha256 侧车比对），有则静默刷新（带进度框）。
       // 离线/超时/无标记/更新失败一律沿用现有，绝不阻塞启动（Never break）。
       if (context.mounted) {
         await _maybeAutoUpdate(arch: arch, context: context);
       }
-      return true; // 幂等：已装好（可能刚被刷新）
+      return _missingInstalledFiles(arch).isEmpty;
+    }
+
+    // 旧安装可能只有 injector，缺 Luna 或 Locale Emulator。直接用当前发布包修复；
+    // x86 缺转区组件时不得回退到普通区域启动非 Unicode 游戏。
+    if (_hasExistingInstall(arch)) {
+      final bool repaired = await _downloadAndExtract(
+        context: context,
+        arch: arch,
+        expectedSize: null,
+      );
+      if (!repaired || _missingInstalledFiles(arch).isNotEmpty) {
+        if (context.mounted) {
+          HibikiToast.show(msg: t.galgame_helper_install_incomplete);
+        }
+        return false;
+      }
+      return true;
     }
 
     // 确认对话框**立即**弹出，绝不为 best-effort 的大小探测阻塞 UI（旧实现先 await
@@ -183,7 +252,7 @@ class GalgameHelperInstaller {
     );
     if (!ok) return false;
 
-    if (!injector.existsSync()) {
+    if (_missingInstalledFiles(arch).isNotEmpty) {
       HibikiToast.show(msg: t.galgame_helper_install_incomplete);
       return false;
     }
@@ -361,7 +430,23 @@ class GalgameHelperInstaller {
       );
 
       // 3) 解压到 archDir（覆盖写；保留 x64 unity_audio_runtime/ 子目录）。
-      await _extractZip(zip, _archDir(arch));
+      final Set<String> extractedRootFiles =
+          await _extractZip(zip, _archDir(arch));
+      final List<String> missingFromPackage =
+          galgameHelperMissingFiles(arch, extractedRootFiles);
+      if (missingFromPackage.isNotEmpty) {
+        throw StateError(
+          'helper package incomplete ($arch): '
+          'missing ${missingFromPackage.join(', ')}',
+        );
+      }
+      final List<String> missingAfterExtract = _missingInstalledFiles(arch);
+      if (missingAfterExtract.isNotEmpty) {
+        throw StateError(
+          'helper install incomplete ($arch): '
+          'missing ${missingAfterExtract.join(', ')}',
+        );
+      }
 
       // 记录本次已装 zip 的 sha256 作自动更新比对基线；无 sha 侧车时不写标记（下次不自动更新，
       // 保守）。写标记失败不影响安装成功（best-effort）。
@@ -508,11 +593,12 @@ class GalgameHelperInstaller {
   /// getter（archive 3.6.1 下 ArchiveFile.decompress(out) 会写 0 字节，见
   /// sync_asset_package_service.dart 注释，故取 content 字节直接写）。只写常规文件、保留
   /// 相对目录结构，并拒绝绝对路径或逃出目标目录的条目以防 zip-slip。
-  Future<void> _extractZip(File zip, Directory targetDir) async {
+  Future<Set<String>> _extractZip(File zip, Directory targetDir) async {
     await targetDir.create(recursive: true);
     final Uint8List bytes = await zip.readAsBytes();
     final Archive archive = ZipDecoder().decodeBytes(bytes);
     final String targetRoot = p.normalize(targetDir.absolute.path);
+    final Set<String> extractedRootFiles = <String>{};
     for (final ArchiveFile entry in archive) {
       if (!entry.isFile) continue;
       final String relativePath =
@@ -525,7 +611,11 @@ class GalgameHelperInstaller {
       final File out = File(outputPath);
       await out.parent.create(recursive: true);
       await out.writeAsBytes(content, flush: true);
+      if (p.dirname(relativePath) == '.') {
+        extractedRootFiles.add(p.basename(relativePath));
+      }
     }
+    return extractedRootFiles;
   }
 }
 

--- a/hibiki/test/mining/galgame_helper_installer_test.dart
+++ b/hibiki/test/mining/galgame_helper_installer_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/mining/galgame_helper_installer.dart';
 
@@ -133,5 +135,69 @@ void main() {
       expect(galgameHelperNeedsUpdate(shaA, null), isFalse);
       expect(galgameHelperNeedsUpdate(null, null), isFalse);
     });
+  });
+
+  group('helper release manifest', () {
+    test('x86 requires locale runtime and license', () {
+      expect(
+        galgameHelperRequiredFiles('x86'),
+        containsAll(<String>[
+          'hibiki_voice_injector.exe',
+          'hibiki_voice_hook.dll',
+          'LunaHook32.dll',
+          'LunaHost32.dll',
+          'LoaderDll.dll',
+          'LocaleEmulator.dll',
+          'LocaleEmulator-LGPL-3.0.txt',
+        ]),
+      );
+    });
+
+    test('x64 uses its own Luna binaries and does not require x86 locale DLLs',
+        () {
+      final List<String> required = galgameHelperRequiredFiles('x64');
+      expect(
+          required,
+          containsAll(<String>[
+            'hibiki_voice_injector.exe',
+            'hibiki_voice_hook.dll',
+            'LunaHook64.dll',
+            'LunaHost64.dll',
+          ]));
+      expect(required, isNot(contains('LoaderDll.dll')));
+      expect(required, isNot(contains('LocaleEmulator.dll')));
+    });
+
+    test('missing-file detection is case-insensitive and complete', () {
+      final List<String> present =
+          List<String>.from(galgameHelperRequiredFiles('x86'))
+            ..remove('LocaleEmulator.dll')
+            ..remove('LocaleEmulator-LGPL-3.0.txt')
+            ..add('localeemulator-lgpl-3.0.TXT');
+      expect(
+        galgameHelperMissingFiles('x86', present),
+        <String>['LocaleEmulator.dll'],
+      );
+    });
+
+    test('unknown architecture is rejected', () {
+      expect(
+        () => galgameHelperRequiredFiles('arm64'),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  test('incomplete existing installs are repaired before launch', () {
+    final String source = File(
+      'lib/src/mining/galgame_helper_installer.dart',
+    ).readAsStringSync();
+    expect(source, contains('if (_hasExistingInstall(arch))'));
+    expect(source, contains('expectedSize: null'));
+    expect(source, contains('missingFromPackage'));
+    expect(
+      source.indexOf('missingFromPackage'),
+      lessThan(source.indexOf('_markerFile(arch).writeAsString')),
+    );
   });
 }


### PR DESCRIPTION
## Summary

- validate galgame helper installs against the complete per-architecture release manifest
- automatically repair existing incomplete x86 installs instead of treating the injector alone as sufficient
- verify both the downloaded package and final install before writing the SHA marker
- document the regression as BUG-1059

## Root cause

The installed x86 helper could contain the injector and Luna files but omit `LoaderDll.dll`, `LocaleEmulator.dll`, and the Locale Emulator license. `ensureInjector()` previously checked only `hibiki_voice_injector.exe`; when the best-effort update check timed out, it allowed the incomplete install to launch. Non-Unicode games therefore did not receive CP932 locale emulation and failed during launch or early injection.

## User impact

Existing incomplete x86 installs now self-repair from the current release. If repair or package validation fails, Hibiki stops the bad launch and reports the incomplete install instead of silently launching without automatic locale emulation.

The Fate-specific KiriKiri safety profile is in companion PR [hibiki-hook#3](https://github.com/hajisensai/hibiki-hook/pull/3).

## Validation

- `flutter test --no-pub --no-test-assets test/mining/galgame_helper_installer_test.dart test/mining/galgame_helper_launch_guard_test.dart` — 30 passed
- focused `flutter analyze --no-pub` — no issues
- current x86 release package verified to contain all seven required files
- supplied `屋上の百合霊さんフルコーラス.exe` launched under Japanese CP932 with the correct Japanese title and entered the tutorial
- supplied Fate executable launched successfully with the companion hook build

Windows-only galgame scope.
