### PR TITLE
feat(galgame): hook 浮窗重播/补录按钮 + 台词显示去阻塞 (BUG-1062)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1026 条。点号进各自文件。
+> 共 1027 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1062](bugs/BUG-1062-gal-hook-line-display-latency.md) | ✅ | ✅ | galgame hook 台词显示慢：文本推进被逐行语音抓取阻塞 |
 | [BUG-1059](bugs/BUG-1059-galgame-x86-helper.md) | ✅ | ✅ | 残缺的 x86 galgame helper 被当成已安装，自动转区失效 |
 | [BUG-1058](bugs/BUG-1058-ffmpeg-min-vendored-missing-movtext.md) | ✅ | ✅ | 入库精简 ffmpeg 缺 movtext 编码器，桌面片段导出永远封不进字幕 |
 | [BUG-1057](bugs/BUG-1057-danmaku-comment-fetch-timeout-and-swallowed-status.md) | ✅ | ✅ | 手动匹配弹幕「弹幕加载失败」：拉弹幕与搜索共用 8s 超时，且非 2xx 被吞成空列表 |

--- a/docs/bugs/BUG-1062-gal-hook-line-display-latency.md
+++ b/docs/bugs/BUG-1062-gal-hook-line-display-latency.md
@@ -1,0 +1,9 @@
+## BUG-1062 · galgame hook 台词显示慢：文本推进被逐行语音抓取阻塞
+- **报告**：2026-07-25（用户：hook 文字的显示有点慢）
+- **真实性**：✅ 真 bug。三处叠加，均在 `hibiki/lib/src/mining/gal_hook_session_controller.dart`：
+  1. `textPollInterval` 原为 400ms。native `pollText`（`hibiki/windows/runner/flutter_window.cpp:1763`）只读共享内存环并拷贝新行，无 IO、无锁等待，400ms 是纯人为延迟：平均 +200ms、最坏 +400ms。
+  2. 每个 tick 先 `await engine.refreshReadiness()` 再 `pollText`（旧 `_pollHookedText` 开头），文本链路白白串上一次 IPC 往返。
+  3. 最重的一条：旧 `_pollHookedText` 的 for 循环里对每一行 `await engine.grabUtterance() ?? grabClipNear()` / `_cacheLoopbackForLine()`。同一批的第二句台词要排在第一句的语音抓取之后，抓取期间 `_pollInFlight` 还会让下一个 tick 整轮跳过——台词显示被自己的语音配对拖慢。
+- **[x] ① 已修复** — `textPollInterval` 400ms → 80ms；readiness 改走 `_refreshReadinessThrottled`（≥500ms 一次，晚到资源 hook 的升格路径不变）；语音抓取整体移出文本主循环，改由 `_scheduleLineAudioAttach` 入串行音频队列（与制卡采集共用同一队列，native 语音缓冲同一时刻仍只有一个读取者），BUG-950 的 engine generation 复检随抓取一起搬进 `_attachLineAudio`。提交见分支 `worktree-gal-overlay-replay-latency`。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_hook_line_latency_recapture_test.dart`：语音抓取挂起（未完成的 Completer）时后续台词仍照常进文本服务（已反向验证：临时改回内联 await 后该断言变红，只剩第一句）；readiness 被降频且时钟推过窗口后仍会重查。`hibiki/test/mining/gal_hook_session_controller_test.dart` 的源码守卫改成钉「文本主路径只许 await `_refreshReadinessThrottled` 与 `engine.pollText`」+「`_attachLineAudio` 内保留 BUG-950 复检」。
+- **备注**：同轮给浮窗加了「重播」「重播并录音」两个语音按钮（功能新增，不属本条）。真机验收仍需在 Windows 跑原始 galgame 路径确认观感。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 41718 (2454 per locale)
+/// Strings: 41786 (2458 per locale)
 ///
-/// Built on 2026-07-24 at 15:00 UTC
+/// Built on 2026-07-24 at 15:54 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3269,6 +3269,13 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get games_drop_no_exe => 'No new game .exe among the dropped files';
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -8838,6 +8845,17 @@ class _StringsAr extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -14480,6 +14498,17 @@ class _StringsDe extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -20138,6 +20167,17 @@ class _StringsEs extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -25807,6 +25847,17 @@ class _StringsFr extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -31403,6 +31454,17 @@ class _StringsId extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -37047,6 +37109,17 @@ class _StringsIt extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -42496,6 +42569,17 @@ class _StringsJa extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -47948,6 +48032,17 @@ class _StringsKo extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -53570,6 +53665,17 @@ class _StringsNl extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -59207,6 +59313,17 @@ class _StringsPtBr extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -64827,6 +64944,17 @@ class _StringsRu extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -70392,6 +70520,17 @@ class _StringsTh extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -75989,6 +76128,17 @@ class _StringsTr extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -81573,6 +81723,17 @@ class _StringsVi extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 // Path: <root>
@@ -86766,6 +86927,14 @@ class _StringsZhCn extends _StringsEn {
   String get games_drop_no_exe => '拖入的文件里没有新的游戏 .exe';
   @override
   String games_drop_imported({required Object count}) => '已添加 ${count} 个游戏';
+  @override
+  String get game_hook_recapture_started => '录音中——请在游戏里重播这句语音';
+  @override
+  String get game_hook_recapture_saved => '补录语音已绑定到这句';
+  @override
+  String get game_hook_recapture_empty => '补录窗口内没有录到声音';
+  @override
+  String get game_hook_recapture_unavailable => '补录需要系统声音采集可用';
 }
 
 // Path: <root>
@@ -92133,6 +92302,17 @@ class _StringsZhHk extends _StringsEn {
   @override
   String games_drop_imported({required Object count}) =>
       'Added ${count} game(s)';
+  @override
+  String get game_hook_recapture_started =>
+      'Recording — replay this line in the game';
+  @override
+  String get game_hook_recapture_saved => 'Recaptured voice saved to this line';
+  @override
+  String get game_hook_recapture_empty =>
+      'No audio captured in the recapture window';
+  @override
+  String get game_hook_recapture_unavailable =>
+      'Voice recapture needs system loopback audio';
 }
 
 /// Flat map(s) containing all translations.
@@ -97147,6 +97327,14 @@ extension on _StringsEn {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -102159,6 +102347,14 @@ extension on _StringsAr {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -107192,6 +107388,14 @@ extension on _StringsDe {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -112224,6 +112428,14 @@ extension on _StringsEs {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -117262,6 +117474,14 @@ extension on _StringsFr {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -122282,6 +122502,14 @@ extension on _StringsId {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -127317,6 +127545,14 @@ extension on _StringsIt {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -132314,6 +132550,14 @@ extension on _StringsJa {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -137315,6 +137559,14 @@ extension on _StringsKo {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -142343,6 +142595,14 @@ extension on _StringsNl {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -147368,6 +147628,14 @@ extension on _StringsPtBr {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -152398,6 +152666,14 @@ extension on _StringsRu {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -157412,6 +157688,14 @@ extension on _StringsTh {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -162435,6 +162719,14 @@ extension on _StringsTr {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -167453,6 +167745,14 @@ extension on _StringsVi {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }
@@ -172432,6 +172732,14 @@ extension on _StringsZhCn {
         return '拖入的文件里没有新的游戏 .exe';
       case 'games_drop_imported':
         return ({required Object count}) => '已添加 ${count} 个游戏';
+      case 'game_hook_recapture_started':
+        return '录音中——请在游戏里重播这句语音';
+      case 'game_hook_recapture_saved':
+        return '补录语音已绑定到这句';
+      case 'game_hook_recapture_empty':
+        return '补录窗口内没有录到声音';
+      case 'game_hook_recapture_unavailable':
+        return '补录需要系统声音采集可用';
       default:
         return null;
     }
@@ -177424,6 +177732,14 @@ extension on _StringsZhHk {
         return 'No new game .exe among the dropped files';
       case 'games_drop_imported':
         return ({required Object count}) => 'Added ${count} game(s)';
+      case 'game_hook_recapture_started':
+        return 'Recording — replay this line in the game';
+      case 'game_hook_recapture_saved':
+        return 'Recaptured voice saved to this line';
+      case 'game_hook_recapture_empty':
+        return 'No audio captured in the recapture window';
+      case 'game_hook_recapture_unavailable':
+        return 'Voice recapture needs system loopback audio';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "移动端下载的模型用于漫画阅读页的框选识别。",
   "games_already_added": "该游戏已在库中",
   "games_drop_no_exe": "拖入的文件里没有新的游戏 .exe",
-  "games_drop_imported": "已添加 $count 个游戏"
+  "games_drop_imported": "已添加 $count 个游戏",
+  "game_hook_recapture_started": "录音中——请在游戏里重播这句语音",
+  "game_hook_recapture_saved": "补录语音已绑定到这句",
+  "game_hook_recapture_empty": "补录窗口内没有录到声音",
+  "game_hook_recapture_unavailable": "补录需要系统声音采集可用"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2452,5 +2452,9 @@
   "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
   "games_already_added": "This game is already in the library",
   "games_drop_no_exe": "No new game .exe among the dropped files",
-  "games_drop_imported": "Added $count game(s)"
+  "games_drop_imported": "Added $count game(s)",
+  "game_hook_recapture_started": "Recording — replay this line in the game",
+  "game_hook_recapture_saved": "Recaptured voice saved to this line",
+  "game_hook_recapture_empty": "No audio captured in the recapture window",
+  "game_hook_recapture_unavailable": "Voice recapture needs system loopback audio"
 }

--- a/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 
 import 'package:hibiki/src/lookup/global_lookup_controller.dart';
+import 'package:hibiki/src/utils/misc/desktop_audio_playback.dart';
 import 'package:hibiki/src/mining/gal_hook_mining_coordinator.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
 import 'package:hibiki/src/models/app_model.dart';
@@ -71,6 +72,14 @@ class GalHookTextOverlayController extends ChangeNotifier {
   bool _suppressedForSession = false;
   bool _syncing = false;
   bool _syncAgain = false;
+
+  /// 当前行语音正在试听（浮窗「重播」按钮高亮）。
+  bool _replaying = false;
+  Timer? _replayResetTimer;
+
+  /// 已推给 native 的语音控件状态，避免每轮 sync 都发一次 channel 调用。
+  bool _pushedReplaying = false;
+  bool _pushedRecapturing = false;
   int? _sessionKey;
   String? _displayedLineId;
   double _opacity = _defaultOpacity;
@@ -86,6 +95,12 @@ class GalHookTextOverlayController extends ChangeNotifier {
   bool get isLocked => _locked;
   bool get isSuppressedForSession => _suppressedForSession;
   String? get displayedLineId => _displayedLineId;
+  bool get isReplaying => _replaying;
+  bool get isRecapturing => _session.isRecapturing;
+
+  /// 试听兜底复位上限：资源原件（OGG/WAV）时长未知时按它把按钮高亮收回，
+  /// 与实时台词列表的行内试听同一上限。
+  static const int _replayMaxMs = 15000;
 
   Future<void> start({required AppModel appModel}) async {
     if (_started || !isSupported) return;
@@ -105,6 +120,8 @@ class GalHookTextOverlayController extends ChangeNotifier {
       onToggleTransparency: toggleTransparency,
       onOpenWorkbench: openWorkbench,
       onClose: closeForCurrentSession,
+      onReplayVoice: replayCurrentLine,
+      onRecaptureVoice: recaptureCurrentLine,
       onLockChanged: _onLockChanged,
       onBoundsChanged: _onBoundsChanged,
     );
@@ -175,6 +192,10 @@ class GalHookTextOverlayController extends ChangeNotifier {
       _passThrough = false;
       _locked = false;
       _displayedLineId = null;
+      // 新会话：上一局的试听计时不能把高亮留在新浮窗上。
+      _replayResetTimer?.cancel();
+      _replayResetTimer = null;
+      _replaying = false;
       await GalHookTextOverlayChannel.setFollowing(true);
       await GalHookTextOverlayChannel.setPassThrough(false);
       await GalHookTextOverlayChannel.setLocked(false);
@@ -190,6 +211,11 @@ class GalHookTextOverlayController extends ChangeNotifier {
       if (_visible) {
         await GalHookTextOverlayChannel.hide();
         _visible = false;
+        // 浮窗收起后试听高亮无处可显示，本地状态跟着收——否则下次 show 会把一个
+        // 早已播完的试听态推给新窗口。
+        _replayResetTimer?.cancel();
+        _replayResetTimer = null;
+        _replaying = false;
         notifyListeners();
       }
       if (nextSessionKey == null) _sessionKey = null;
@@ -212,8 +238,13 @@ class GalHookTextOverlayController extends ChangeNotifier {
         passThrough: _passThrough,
         locked: _locked,
       );
+      // native 在 show 里把语音控件复位（见 flutter_window.cpp），本地镜像跟着复位，
+      // 否则下一次 _syncVoiceState 会认为「已经推过了」而不再推。
+      _pushedReplaying = false;
+      _pushedRecapturing = false;
       if (_visible) _displayedLineId = latest.id;
       notifyListeners();
+      await _syncVoiceState();
       return;
     }
     if (_following && latest.id != _displayedLineId) {
@@ -224,6 +255,9 @@ class GalHookTextOverlayController extends ChangeNotifier {
       _displayedLineId = latest.id;
       notifyListeners();
     }
+    // 补录窗口可能由 session 侧超时自行收束：每轮都比对一次，浮窗上的「录音中」
+    // 高亮才不会停在已结束的状态上。
+    await _syncVoiceState();
   }
 
   int get _backgroundColor {
@@ -296,6 +330,100 @@ class GalHookTextOverlayController extends ChangeNotifier {
         await model.prefsRepo.setPref(_rectPreferenceKey, value);
       }
     }
+  }
+
+  /// 浮窗「重播」：试听当前显示行已配的语音；正在试听时再点即停止。
+  /// 只读既有配对结果（资源原件直接播，PCM/loopback 冻结切片拼 WAV），不改行状态。
+  Future<void> replayCurrentLine() async {
+    if (!_started) return;
+    if (_replaying) {
+      await _stopReplay();
+      return;
+    }
+    final String? lineId = _displayedLineId;
+    if (lineId == null) {
+      HibikiToast.show(msg: t.game_hook_line_unavailable);
+      return;
+    }
+    final GalTrackPreview? preview =
+        await _session.exportLineAudioPreview(lineId);
+    if (preview == null) {
+      HibikiToast.show(msg: t.game_line_preview_failed);
+      return;
+    }
+    if (!await DesktopAudioPlayback.playFile(preview.filePath)) {
+      HibikiToast.show(msg: t.game_line_preview_failed);
+      return;
+    }
+    _replaying = true;
+    _replayResetTimer?.cancel();
+    _replayResetTimer = Timer(
+      Duration(
+        milliseconds:
+            preview.durationMs > 0 ? preview.durationMs + 300 : _replayMaxMs,
+      ),
+      () {
+        _replaying = false;
+        unawaited(_syncVoiceState());
+        notifyListeners();
+      },
+    );
+    await _syncVoiceState();
+    notifyListeners();
+  }
+
+  Future<void> _stopReplay() async {
+    _replayResetTimer?.cancel();
+    _replayResetTimer = null;
+    _replaying = false;
+    await DesktopAudioPlayback.stop();
+    await _syncVoiceState();
+    notifyListeners();
+  }
+
+  /// 浮窗「重播并录音」：为当前显示行开一段补录窗口——用户随后在游戏里重播这句
+  /// 语音（回退/重听），窗口内录到的系统声音就绑定到这一行，覆盖此前配错或缺失的
+  /// 语音。正在补录时再点即立刻收束。
+  Future<void> recaptureCurrentLine() async {
+    if (!_started) return;
+    if (_session.isRecapturing) {
+      final bool saved = await _session.finishLineRecapture();
+      HibikiToast.show(
+        msg: saved ? t.game_hook_recapture_saved : t.game_hook_recapture_empty,
+      );
+      await _syncVoiceState();
+      notifyListeners();
+      return;
+    }
+    final String? lineId = _displayedLineId;
+    if (lineId == null) {
+      HibikiToast.show(msg: t.game_hook_line_unavailable);
+      return;
+    }
+    final bool started = await _session.startLineRecapture(lineId);
+    HibikiToast.show(
+      msg: started
+          ? t.game_hook_recapture_started
+          : t.game_hook_recapture_unavailable,
+    );
+    await _syncVoiceState();
+    notifyListeners();
+  }
+
+  /// 把语音控件状态推给浮窗（只在变化时发 channel 调用）。补录窗口也可能由 session
+  /// 侧超时自行收束，所以每轮 sync 都比对一次。
+  Future<void> _syncVoiceState() async {
+    final bool replaying = _replaying;
+    final bool recapturing = _session.isRecapturing;
+    if (replaying == _pushedReplaying && recapturing == _pushedRecapturing) {
+      return;
+    }
+    _pushedReplaying = replaying;
+    _pushedRecapturing = recapturing;
+    await GalHookTextOverlayChannel.setVoiceState(
+      replaying: replaying,
+      recapturing: recapturing,
+    );
   }
 
   Future<void> openWorkbench() async {

--- a/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:ui' show Rect;
 
 import 'package:flutter/foundation.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
@@ -436,6 +437,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
     String lineId,
     String text,
     int index,
+    Rect? wordRect,
   ) async {
     final AppModel? model = _appModel;
     final TexthookerLineEntry? entry = _session.entryById(lineId);
@@ -453,6 +455,10 @@ class GalHookTextOverlayController extends ChangeNotifier {
     await GlobalLookupController.instance.lookupText(
       term,
       sentence: entry.text,
+      // 卡片锚在被点中的那个词上（native 给的屏幕逻辑 px 矩形），而不是鼠标位置：
+      // 浮窗里点词跟阅读器/剪贴板面板一样是「点哪个词看哪个词」。老 native 不带
+      // 矩形时为 null，自动回落到光标定位。
+      anchorScreenRect: wordRect,
       miningHandler: ({
         required Map<String, String> fields,
         int? updateNoteId,

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -225,7 +225,10 @@ class GalHookSessionController extends ChangeNotifier {
     GalInjectorResolver? injectorResolver,
     DateTime Function()? now,
     bool? isWindows,
-    Duration textPollInterval = const Duration(milliseconds: 400),
+    // 台词显示延迟直接由本间隔决定（浮窗只在 append 触发的 notify 后刷新）。native
+    // `pollText` 只读共享内存环并拷贝新行，无 IO、无锁等待，400ms 纯粹是人为的
+    // 感知延迟（平均 +200ms、最坏 +400ms）。降到 80ms 后仍是每秒 12.5 次廉价调用。
+    Duration textPollInterval = const Duration(milliseconds: 80),
     Duration windowPollInterval = const Duration(milliseconds: 500),
     Duration resourceAudioWait = const Duration(milliseconds: 1200),
     Duration resourceAudioPollInterval = const Duration(milliseconds: 80),
@@ -270,6 +273,9 @@ class GalHookSessionController extends ChangeNotifier {
   static final GalHookSessionController instance = GalHookSessionController();
   static const int _voiceCacheMax = 200;
   static const int _galAudioBackMs = 8000;
+
+  /// 资源语音就绪查询的最小间隔（见 [_lastReadinessRefreshAt]）。
+  static const Duration _readinessRefreshInterval = Duration(milliseconds: 500);
   static const int _eventLimit = 400;
 
   final TexthookerService _textService;
@@ -352,6 +358,10 @@ class GalHookSessionController extends ChangeNotifier {
   Timer? _windowRebindTimer;
   bool _windowRebindInFlight = false;
   bool _pollInFlight = false;
+
+  /// 上次向 native 问「资源语音是否就绪」的时刻。文本轮询降到 80ms 后不能每 tick
+  /// 都跟着做一次 IPC 往返——就绪状态是秒级变化的会话属性，与单行台词无关。
+  DateTime? _lastReadinessRefreshAt;
   int _lastTextSeq = 0;
   int _eventId = 0;
   int _operationGeneration = 0;
@@ -1008,6 +1018,165 @@ class GalHookSessionController extends ChangeNotifier {
     return null;
   }
 
+  // ── 手动补录（浮窗「重播并录音」）────────────────────────────────────────
+  /// 补录窗口上限：够用户在游戏里触发一次「重播这句语音」并等它播完；到点自动收束。
+  /// 与 [_galAudioBackMs] 对齐——loopback 环只保留这么长，取不到更早的声音。
+  static const Duration _recaptureWindow =
+      Duration(milliseconds: _galAudioBackMs);
+
+  /// 补录至少回取的毫秒数：用户手速极快时也别取出一段空 PCM。
+  static const int _recaptureMinBackMs = 500;
+
+  String? _recapturingLineId;
+  Timer? _recaptureTimer;
+  Stopwatch? _recaptureElapsed;
+
+  /// 引擎资源/PCM 会话里临时拉起的 loopback 源（会话本身没有 loopback 时才有），
+  /// 补录结束即停——不改变会话的常驻音源。
+  LoopbackGalAudioSource? _recaptureTempSource;
+
+  /// 手动补录过的行：制卡与试听时其冻结切片**优先于**资源配对。用户手动补录本身
+  /// 就是「自动配对的结果不对」的判据，绝不能再被 game_resource 覆盖回去。
+  final Set<String> _manualRecaptureLines = <String>{};
+
+  String? get recapturingLineId => _recapturingLineId;
+  bool get isRecapturing => _recapturingLineId != null;
+
+  @visibleForTesting
+  bool debugIsManualRecapture(String lineId) =>
+      _manualRecaptureLines.contains(lineId);
+
+  /// 浮窗「重播并录音」：正在补录同一行 → 立即收束；否则为 [lineId] 开一段补录窗口。
+  Future<bool> toggleLineRecapture(String lineId) async {
+    if (_recapturingLineId == lineId) {
+      return finishLineRecapture();
+    }
+    if (_recapturingLineId != null) {
+      await finishLineRecapture();
+    }
+    return startLineRecapture(lineId);
+  }
+
+  /// 开始为 [lineId] 补录：确保有一个在录的 loopback 环，随后等用户在游戏里重播该句
+  /// 语音。到 [_recaptureWindow] 自动收束，也可再点一次按钮提前收束。
+  Future<bool> startLineRecapture(String lineId) async {
+    if (_recapturingLineId != null) return false;
+    final TexthookerLineEntry? entry = _textService.entryById(lineId);
+    if (entry == null || !isLineInCurrentSession(entry)) {
+      _record(
+        GalHookEventSeverity.warning,
+        'audio',
+        'audio.recapture_line_unavailable',
+        'Recapture target line is not part of the current session',
+        details: <String, Object?>{'lineId': lineId},
+      );
+      return false;
+    }
+    LoopbackGalAudioSource? temp;
+    if (_audioSource is! LoopbackGalAudioSource) {
+      temp = _loopbackSourceFactory();
+      final PcmFormat? format = await temp.start();
+      if (format == null) {
+        await temp.stop();
+        _record(
+          GalHookEventSeverity.error,
+          'audio',
+          'audio.recapture_source_unavailable',
+          'System loopback could not be started for manual recapture',
+          details: <String, Object?>{'lineId': lineId},
+        );
+        return false;
+      }
+    }
+    _recaptureTempSource = temp;
+    _recapturingLineId = lineId;
+    _recaptureElapsed = Stopwatch()..start();
+    _recaptureTimer = Timer(
+      _recaptureWindow,
+      () => unawaited(finishLineRecapture()),
+    );
+    _textService.updateLineAudio(
+      lineId,
+      status: TexthookerLineAudioStatus.pending,
+      backend: 'system_loopback',
+      fallbackReason: 'manual_recapture_recording',
+    );
+    _record(
+      GalHookEventSeverity.info,
+      'audio',
+      'audio.recapture_started',
+      'Manual voice recapture window opened',
+      details: <String, Object?>{'lineId': lineId},
+    );
+    notifyListeners();
+    return true;
+  }
+
+  /// 收束当前补录窗口：把窗口内的 loopback 环冻结成该行的语音（[discard] 时只收束
+  /// 不取音，用于会话结束）。取不到声音时把行标成 missing，不留“录了但没有”的假象。
+  Future<bool> finishLineRecapture({bool discard = false}) async {
+    final String? lineId = _recapturingLineId;
+    if (lineId == null) return false;
+    _recaptureTimer?.cancel();
+    _recaptureTimer = null;
+    final int elapsedMs = _recaptureElapsed?.elapsedMilliseconds ?? 0;
+    _recaptureElapsed = null;
+    _recapturingLineId = null;
+    final LoopbackGalAudioSource? temp = _recaptureTempSource;
+    _recaptureTempSource = null;
+    final GalAudioSource? live = _audioSource;
+    final LoopbackGalAudioSource? source =
+        temp ?? (live is LoopbackGalAudioSource ? live : null);
+    notifyListeners();
+    try {
+      if (discard || source == null) {
+        if (!discard) _markLineAudioMissing(lineId, 'manual_recapture_empty');
+        return false;
+      }
+      final int backMs =
+          elapsedMs.clamp(_recaptureMinBackMs, _galAudioBackMs).toInt();
+      final GalAudioSlice? slice = await _audioQueue.enqueue<GalAudioSlice?>(
+        () => source.grabRecent(backMs),
+        buildFailure: (Object error, StackTrace stack) => null,
+        onError: (Object error, StackTrace stack) => _record(
+          GalHookEventSeverity.error,
+          'audio',
+          'audio.recapture_exception',
+          'Manual voice recapture failed',
+          details: <String, Object?>{'lineId': lineId, 'error': '$error'},
+        ),
+      );
+      if (slice == null || slice.isEmpty) {
+        _markLineAudioMissing(lineId, 'manual_recapture_empty');
+        return false;
+      }
+      _lineVoiceCache[lineId] = slice;
+      _trimCache(_lineVoiceCache);
+      _manualRecaptureLines.add(lineId);
+      // 补录即用户裁决：清掉这行的资源配对，也别让延迟资源匹配再把它改回去。
+      _pendingResourceMatches.remove(lineId);
+      _textService.updateLineAudio(
+        lineId,
+        status: TexthookerLineAudioStatus.fallback,
+        backend: 'system_loopback',
+        durationMs: (slice.pcm.length * 1000) ~/ slice.format.byteRate,
+        fallbackReason: 'manual_recapture',
+        clearResourceId: true,
+      );
+      _record(
+        GalHookEventSeverity.success,
+        'match',
+        'audio.recapture_locked',
+        'Manually recaptured audio locked to the line',
+        details: <String, Object?>{'lineId': lineId, 'backMs': backMs},
+      );
+      return true;
+    } finally {
+      await temp?.stop();
+      notifyListeners();
+    }
+  }
+
   void selectVoiceTrack(int sourcePtr) {
     final EngineHookGalAudioSource? engine = _engineSource;
     if (engine == null) {
@@ -1131,6 +1300,19 @@ class GalHookSessionController extends ChangeNotifier {
       _markLineAudioMissing(lineId, 'audio_source_unavailable');
       return null;
     }
+    // 手动补录优先于一切自动配对：用户点了浮窗「重播并录音」就说明自动结果不对，
+    // 这里再去等资源配对会把补录的那段直接顶掉。
+    final GalAudioSlice? recaptured =
+        _manualRecaptureLines.contains(lineId) ? _lineVoiceCache[lineId] : null;
+    if (recaptured != null && !recaptured.isEmpty) {
+      return _encodeLineSlice(
+        lineId: lineId,
+        slice: recaptured,
+        backend: 'system_loopback',
+        outputExtension: outputExtension,
+        fallbackReason: 'manual_recapture',
+      );
+    }
     final int timestamp = _lineTimestampCache[lineId] ?? 0;
     if (engine != null && _isWindows) {
       final Uint8List? paired = await _waitForPairedResourceAudio(
@@ -1194,6 +1376,25 @@ class GalHookSessionController extends ChangeNotifier {
       _markLineAudioMissing(lineId, 'line_audio_not_cached');
       return null;
     }
+    return _encodeLineSlice(
+      lineId: lineId,
+      slice: slice,
+      backend: identical(source, engine) ? 'engine_pcm' : 'system_loopback',
+      outputExtension: outputExtension,
+      fallbackReason:
+          timestamp > 0 ? 'paired_voice_not_found' : 'no_engine_timestamp',
+    );
+  }
+
+  /// 把一段冻结 PCM 切片转成制卡容器字节，并把该行标成 encoded。
+  /// 制卡链路上「有切片了」之后的收尾只有这一份实现（PCM 兜底与手动补录共用）。
+  Future<Uint8List?> _encodeLineSlice({
+    required String lineId,
+    required GalAudioSlice slice,
+    required String backend,
+    required String outputExtension,
+    required String? fallbackReason,
+  }) async {
     final Directory jobDirectory = await Directory.systemTemp.createTemp(
       'hibiki-gal-mining-job-',
     );
@@ -1208,15 +1409,12 @@ class GalHookSessionController extends ChangeNotifier {
         _markLineAudioMissing(lineId, 'pcm_encode_failed');
         return null;
       }
-      final String backend =
-          identical(source, engine) ? 'engine_pcm' : 'system_loopback';
       _textService.updateLineAudio(
         lineId,
         status: TexthookerLineAudioStatus.encoded,
         backend: backend,
         durationMs: (slice.pcm.length * 1000) ~/ slice.format.byteRate,
-        fallbackReason:
-            timestamp > 0 ? 'paired_voice_not_found' : 'no_engine_timestamp',
+        fallbackReason: fallbackReason,
       );
       _record(
         GalHookEventSeverity.success,
@@ -1576,7 +1774,9 @@ class GalHookSessionController extends ChangeNotifier {
     _engineSource = engine;
     _lastTextSeq = 0;
     _pollInFlight = false;
+    _lastReadinessRefreshAt = null;
     _lineVoiceCache.clear();
+    _manualRecaptureLines.clear();
     _lineTimestampCache.clear();
     _lineTextEventIdCache.clear();
     _loopbackCacheInFlight.clear();
@@ -1643,6 +1843,9 @@ class GalHookSessionController extends ChangeNotifier {
   }
 
   Future<void> _stopSources() async {
+    // 补录窗口挂在会话音源上，会话停就必须先收束（丢弃取音）：否则临时 loopback
+    // 源泄漏，超时回调还会往已结束的会话行里写状态。
+    await finishLineRecapture(discard: true);
     _textPollTimer?.cancel();
     _textPollTimer = null;
     _trackRefreshTimer?.cancel();
@@ -1651,10 +1854,12 @@ class GalHookSessionController extends ChangeNotifier {
     _windowRebindTimer = null;
     _windowRebindInFlight = false;
     _pollInFlight = false;
+    _lastReadinessRefreshAt = null;
     final EngineHookGalAudioSource? engine = _engineSource;
     _engineSource = null;
     _lastTextSeq = 0;
     _lineVoiceCache.clear();
+    _manualRecaptureLines.clear();
     _lineTimestampCache.clear();
     _lineTextEventIdCache.clear();
     _loopbackCacheInFlight.clear();
@@ -1673,12 +1878,8 @@ class GalHookSessionController extends ChangeNotifier {
     if (engine == null) return;
     _pollInFlight = true;
     try {
-      final bool hadResourceAudio = engine.rawVoiceReady;
-      await engine.refreshReadiness();
+      await _refreshReadinessThrottled(engine);
       if (engine != _engineSource) return;
-      if (!hadResourceAudio && engine.rawVoiceReady) {
-        _promoteLateResourceAudio(engine);
-      }
       final GalTextPoll? poll = await engine.pollText(_lastTextSeq);
       if (poll == null || engine != _engineSource) return;
       final List<GalHookedLine> ordered = List<GalHookedLine>.from(poll.lines)
@@ -1749,8 +1950,8 @@ class GalHookSessionController extends ChangeNotifier {
         _trimCache(_lineTimestampCache);
         _lineTextEventIdCache[entry.id] = line.seq;
         _trimCache(_lineTextEventIdCache);
-        GalAudioSlice? clip;
-        final String? resourceId = engine.rawVoiceReady
+        final bool resourceReady = engine.rawVoiceReady;
+        final String? resourceId = resourceReady
             ? engine.findPairedVoiceResourceId(
                 line.timestampMs,
                 textEventId: line.seq,
@@ -1771,7 +1972,7 @@ class GalHookSessionController extends ChangeNotifier {
             'Original game resource audio matched to captured line',
             details: <String, Object?>{'lineId': entry.id, 'seq': line.seq},
           );
-        } else if (engine.rawVoiceReady) {
+        } else if (resourceReady) {
           _pendingResourceMatches[entry.id] = (
             timestampMs: line.timestampMs,
             textEventId: line.seq,
@@ -1782,50 +1983,18 @@ class GalHookSessionController extends ChangeNotifier {
             status: TexthookerLineAudioStatus.pending,
             backend: 'game_resource',
           );
-        } else {
-          clip = await engine.grabUtterance(line.timestampMs) ??
-              await engine.grabClipNear(line.timestampMs);
         }
-        if (!resourceMatched && clip != null && !clip.isEmpty) {
-          _lineVoiceCache[entry.id] = clip;
-          _trimCache(_lineVoiceCache);
-          _textService.updateLineAudio(
-            entry.id,
-            status: TexthookerLineAudioStatus.matched,
-            backend: 'engine_pcm',
-            durationMs: (clip.pcm.length * 1000) ~/ clip.format.byteRate,
+        // BUG-1062：台词已进缓冲、UI 已被通知；余下的语音抓取（PCM 拷贝、loopback
+        // 环冻结）一律离开文本主路径，改由串行音频队列执行。此前它们 await 在本循环
+        // 里：同一批的后续台词要排在前一句语音抓取之后，且 _pollInFlight 会让下一个
+        // tick 整轮跳过——台词显示被自己的语音配对拖慢。
+        if (!resourceMatched) {
+          _scheduleLineAudioAttach(
+            engine: engine,
+            entry: entry,
+            line: line,
+            resourceReady: resourceReady,
           );
-          _record(
-            GalHookEventSeverity.success,
-            'match',
-            'audio.utterance_locked',
-            'Audio utterance locked to captured line',
-            details: <String, Object?>{'lineId': entry.id, 'seq': line.seq},
-          );
-        } else if (!resourceMatched && _audioSource is LoopbackGalAudioSource) {
-          // Loopback 必须在台词到达时冻结对应环形片段；制卡时再抓“最近声音”会把
-          // 后续台词/BGM 错配给旧行。资源音频尚未落盘时也先保留这份逐行兜底，
-          // 稍后若资源匹配成功会覆盖为 game_resource。
-          await _cacheLoopbackForLine(entry);
-        } else if (!engine.rawVoiceReady) {
-          _textService.updateLineAudio(
-            entry.id,
-            status: TexthookerLineAudioStatus.missing,
-            fallbackReason: 'utterance_not_found',
-          );
-          _record(
-            GalHookEventSeverity.warning,
-            'match',
-            'audio.utterance_not_found',
-            'No engine utterance matched the captured line',
-            details: <String, Object?>{'lineId': entry.id, 'seq': line.seq},
-          );
-        }
-        // BUG-950：上面 grabUtterance / grabClipNear / _cacheLoopbackForLine 的 await 可能
-        // 跨越一次 stop/重启。期间 engine 被换掉则当前迭代属于旧会话，立即收手——绝不再推进
-        // cursor（否则把新会话已重置的 _lastTextSeq 覆写成旧大值，新文本全被判 duplicate 丢弃）。
-        if (engine != _engineSource) {
-          return;
         }
         cursor = line.seq;
       }
@@ -1844,6 +2013,118 @@ class GalHookSessionController extends ChangeNotifier {
       }
     } finally {
       _pollInFlight = false;
+    }
+  }
+
+  /// 资源语音就绪查询降频：文本轮询每 tick 都跑，但这一次 IPC 往返最多每
+  /// [_readinessRefreshInterval] 做一次。首次调用（会话刚起）不节流；晚到的资源
+  /// hook 仍在这里升格为主音源（[_promoteLateResourceAudio]），只是最迟晚半秒。
+  Future<void> _refreshReadinessThrottled(
+    EngineHookGalAudioSource engine,
+  ) async {
+    final DateTime now = _now();
+    final DateTime? last = _lastReadinessRefreshAt;
+    if (last != null && now.difference(last) < _readinessRefreshInterval) {
+      return;
+    }
+    _lastReadinessRefreshAt = now;
+    final bool hadResourceAudio = engine.rawVoiceReady;
+    await engine.refreshReadiness();
+    if (engine != _engineSource) return;
+    if (!hadResourceAudio && engine.rawVoiceReady) {
+      _promoteLateResourceAudio(engine);
+    }
+  }
+
+  /// 把某行的语音抓取排进串行音频队列（BUG-1062）。与制卡采集共用同一队列：native
+  /// 语音缓冲同一时刻只该有一个读取者，串行也保证补录/制卡不与逐行抓取交错。
+  void _scheduleLineAudioAttach({
+    required EngineHookGalAudioSource engine,
+    required TexthookerLineEntry entry,
+    required GalHookedLine line,
+    required bool resourceReady,
+  }) {
+    unawaited(_audioQueue.enqueue<bool>(
+      () async {
+        await _attachLineAudio(
+          engine: engine,
+          entry: entry,
+          line: line,
+          resourceReady: resourceReady,
+        );
+        return true;
+      },
+      buildFailure: (Object error, StackTrace stack) => false,
+      onError: (Object error, StackTrace stack) => _record(
+        GalHookEventSeverity.error,
+        'match',
+        'audio.line_attach_exception',
+        'Line audio attach job failed',
+        details: <String, Object?>{
+          'lineId': entry.id,
+          'error': '$error',
+        },
+      ),
+    ));
+  }
+
+  /// 逐行语音抓取（原先内联在 [_pollHookedText] 循环里的三条降级分支，语义不变）：
+  /// 引擎 PCM 整句 → 时间窗碎片 → loopback 环冻结 → 明确 missing。
+  ///
+  /// BUG-950：这里的 await 可能跨越一次 stop/重启，期间 engine 被换掉则本任务属于
+  /// 旧会话，立即收手，绝不把旧数据写进新会话的行。
+  Future<void> _attachLineAudio({
+    required EngineHookGalAudioSource engine,
+    required TexthookerLineEntry entry,
+    required GalHookedLine line,
+    required bool resourceReady,
+  }) async {
+    // BUG-950：入队到执行之间、以及下面每个 await 之间都可能夹一次 stop/重启。
+    if (engine != _engineSource || !isLineInCurrentSession(entry)) return;
+    GalAudioSlice? clip;
+    if (!resourceReady) {
+      clip = await engine.grabUtterance(line.timestampMs) ??
+          await engine.grabClipNear(line.timestampMs);
+      if (engine != _engineSource) return;
+    }
+    if (clip != null && !clip.isEmpty) {
+      _lineVoiceCache[entry.id] = clip;
+      _trimCache(_lineVoiceCache);
+      _textService.updateLineAudio(
+        entry.id,
+        status: TexthookerLineAudioStatus.matched,
+        backend: 'engine_pcm',
+        durationMs: (clip.pcm.length * 1000) ~/ clip.format.byteRate,
+      );
+      _record(
+        GalHookEventSeverity.success,
+        'match',
+        'audio.utterance_locked',
+        'Audio utterance locked to captured line',
+        details: <String, Object?>{'lineId': entry.id, 'seq': line.seq},
+      );
+      return;
+    }
+    if (_audioSource is LoopbackGalAudioSource) {
+      // Loopback 必须在台词到达时冻结对应环形片段；制卡时再抓“最近声音”会把
+      // 后续台词/BGM 错配给旧行。资源音频尚未落盘时也先保留这份逐行兜底，
+      // 稍后若资源匹配成功会覆盖为 game_resource。
+      await _cacheLoopbackForLine(entry);
+      return;
+    }
+    if (!resourceReady) {
+      _textService.updateLineAudio(
+        entry.id,
+        status: TexthookerLineAudioStatus.missing,
+        fallbackReason: 'utterance_not_found',
+      );
+      _record(
+        GalHookEventSeverity.warning,
+        'match',
+        'audio.utterance_not_found',
+        'No engine utterance matched the captured line',
+        details: <String, Object?>{'lineId': entry.id, 'seq': line.seq},
+      );
     }
   }
 

--- a/hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart
+++ b/hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart
@@ -73,6 +73,8 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
   static GalHookTextEventHandler? _onToggleTransparency;
   static GalHookTextEventHandler? _onOpenWorkbench;
   static GalHookTextEventHandler? _onClose;
+  static GalHookTextEventHandler? _onReplayVoice;
+  static GalHookTextEventHandler? _onRecaptureVoice;
   static GalHookTextLockHandler? _onLockChanged;
   static GalHookTextBoundsHandler? _onBoundsChanged;
 
@@ -83,6 +85,8 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     GalHookTextEventHandler? onToggleTransparency,
     GalHookTextEventHandler? onOpenWorkbench,
     GalHookTextEventHandler? onClose,
+    GalHookTextEventHandler? onReplayVoice,
+    GalHookTextEventHandler? onRecaptureVoice,
     GalHookTextLockHandler? onLockChanged,
     GalHookTextBoundsHandler? onBoundsChanged,
   }) {
@@ -92,6 +96,8 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     _onToggleTransparency = onToggleTransparency;
     _onOpenWorkbench = onOpenWorkbench;
     _onClose = onClose;
+    _onReplayVoice = onReplayVoice;
+    _onRecaptureVoice = onRecaptureVoice;
     _onLockChanged = onLockChanged;
     _onBoundsChanged = onBoundsChanged;
     _instance.channel.setMethodCallHandler(_handleNativeCall);
@@ -104,6 +110,8 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     _onToggleTransparency = null;
     _onOpenWorkbench = null;
     _onClose = null;
+    _onReplayVoice = null;
+    _onRecaptureVoice = null;
     _onLockChanged = null;
     _onBoundsChanged = null;
     _instance.channel.setMethodCallHandler(null);
@@ -133,6 +141,12 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
         break;
       case 'openWorkbench':
         await _onOpenWorkbench?.call();
+        break;
+      case 'replayVoice':
+        await _onReplayVoice?.call();
+        break;
+      case 'recaptureVoice':
+        await _onRecaptureVoice?.call();
         break;
       case 'close':
         await _onClose?.call();
@@ -218,6 +232,21 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     await _instance.channel.invokeMethod<void>(
       'setPassThrough',
       <String, Object?>{'enabled': enabled},
+    );
+  }
+
+  /// 语音控件的可见状态（浮窗是独立窗口，用户只能在这里看到「正在试听 / 正在补录」）。
+  static Future<void> setVoiceState({
+    required bool replaying,
+    required bool recapturing,
+  }) async {
+    if (!_instance.isSupported) return;
+    await _instance.channel.invokeMethod<void>(
+      'setVoiceState',
+      <String, Object?>{
+        'replaying': replaying,
+        'recapturing': recapturing,
+      },
     );
   }
 

--- a/hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart
+++ b/hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart
@@ -45,12 +45,17 @@ typedef GalHookTextLookupHandler = FutureOr<void> Function(
   String lineId,
   String text,
   int index,
+  Rect? wordRect,
 );
 typedef GalHookTextEventHandler = FutureOr<void> Function();
 typedef GalHookTextLockHandler = FutureOr<void> Function(bool locked);
 typedef GalHookTextBoundsHandler = FutureOr<void> Function(
   GalHookTextWindowRect rect,
 );
+
+/// Hook 台词浮窗的基准字号（逻辑 px）。native 在 hook 模式下按窗口高度对它做
+/// 0.9~2.5 倍缩放（`kHookTextBaseHeightForFontDip`），所以把浮窗拖高就能放大台词。
+const double kGalHookTextFontSize = 30.0;
 
 /// Windows Hook 台词浮窗的专用 MethodChannel 契约。
 class GalHookTextOverlayChannel extends FloatingOverlayChannel {
@@ -127,7 +132,7 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
         final String text = args['text']?.toString() ?? '';
         final int index = (args['index'] as num?)?.toInt() ?? 0;
         if (lineId.isNotEmpty && text.trim().isNotEmpty) {
-          await _onLookupText?.call(lineId, text, index);
+          await _onLookupText?.call(lineId, text, index, _wordRect(args));
         }
         break;
       case 'toggleFollow':
@@ -163,9 +168,23 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     }
   }
 
+  /// native 回传的被点字矩形（屏幕逻辑 px）。老 native 不带这几项时返回 null，
+  /// 调用方回落到原来的光标定位（Never break）。
+  static Rect? _wordRect(Map<Object?, Object?> args) {
+    final double? left = (args['wordLeft'] as num?)?.toDouble();
+    final double? top = (args['wordTop'] as num?)?.toDouble();
+    final double? width = (args['wordWidth'] as num?)?.toDouble();
+    final double? height = (args['wordHeight'] as num?)?.toDouble();
+    if (left == null || top == null || width == null || height == null) {
+      return null;
+    }
+    if (width <= 0 || height <= 0) return null;
+    return Rect.fromLTWH(left, top, width, height);
+  }
+
   static Future<bool> show({
     GalHookTextWindowRect? rect,
-    double fontSize = 24,
+    double fontSize = kGalHookTextFontSize,
     int textColor = 0xFFFFFFFF,
     int bgColor = 0xE0000000,
     bool following = true,
@@ -210,7 +229,7 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
   }) async {
     if (!_instance.isSupported) return;
     await _instance.channel.invokeMethod<void>('updateStyle', <String, Object?>{
-      'fontSize': 24.0,
+      'fontSize': kGalHookTextFontSize,
       'bgColor': bgColor,
       'textColor': textColor,
       'buttonTextColor': 0xFFFFFFFF,

--- a/hibiki/test/lookup/gal_hook_overlay_voice_controls_test.dart
+++ b/hibiki/test/lookup/gal_hook_overlay_voice_controls_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/lookup/gal_hook_text_overlay_controller.dart';
+import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/mining/galgame_audio_encode.dart';
+import 'package:hibiki/src/mining/galgame_audio_source.dart';
+import 'package:hibiki/src/mining/window_capture_channel.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/platform/gal_hook_text_overlay_channel.dart';
+import 'package:hibiki/src/sync/texthooker_service.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// 浮窗语音控件（「重播」/「重播并录音」）：native 按钮 → Dart 分发 → 状态回推。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel =
+      MethodChannel('app.hibiki.reader/gal_hook_text');
+  late List<MethodCall> nativeCalls;
+  late TexthookerService textService;
+  late GalHookSessionController session;
+  late GalHookTextOverlayController controller;
+
+  setUp(() {
+    nativeCalls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      nativeCalls.add(call);
+      if (call.method == 'show' || call.method == 'isShowing') return true;
+      return null;
+    });
+    GalHookTextOverlayChannel.platformOverride = true;
+    textService = TexthookerService.test();
+    session = GalHookSessionController(
+      textService: textService,
+      isWindows: true,
+      targetWow64Probe: (_) async => false,
+      injectorResolver: ({required bool is32Bit}) => 'fake.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+      }) =>
+          _VoiceTestEngine(),
+      loopbackSourceFactory: _VoiceTestLoopback.new,
+      endpointStatusLoader: () => const [],
+    );
+    controller = GalHookTextOverlayController.test(
+      session: session,
+      preferenceReader: (String key, {required Object? defaultValue}) =>
+          defaultValue,
+      preferenceWriter: (String key, Object? value) async {},
+    );
+  });
+
+  tearDown(() async {
+    await controller.stopForTesting();
+    await session.close();
+    GalHookTextOverlayChannel.platformOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  Future<void> invokeNative(String method) async {
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+      channel.name,
+      const StandardMethodCodec().encodeMethodCall(MethodCall(method)),
+      (_) {},
+    );
+  }
+
+  Future<void> waitUntil(bool Function() done) async {
+    for (int i = 0; i < 100 && !done(); i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+  }
+
+  Future<TexthookerLineEntry> showFirstLine() async {
+    await controller.start(appModel: AppModel(testPlatformServices()));
+    await session.startAttachedCapture(
+      const ExternalWindowInfo(hwnd: 77, pid: 1234, title: 'Game'),
+    );
+    final TexthookerLineEntry line = textService.appendLine(
+      '補録テスト台詞',
+      source: TexthookerLineSource.websocket,
+    )!;
+    await waitUntil(() => controller.displayedLineId == line.id);
+    return line;
+  }
+
+  test('native 的 recaptureVoice 按钮开启补录窗口并把状态推回浮窗', () async {
+    final TexthookerLineEntry line = await showFirstLine();
+
+    await invokeNative('recaptureVoice');
+    await waitUntil(() => session.isRecapturing);
+
+    expect(session.recapturingLineId, line.id);
+    expect(controller.isRecapturing, isTrue);
+    final MethodCall pushed = nativeCalls.lastWhere(
+      (MethodCall call) => call.method == 'setVoiceState',
+    );
+    expect(
+      (pushed.arguments as Map<Object?, Object?>)['recapturing'],
+      isTrue,
+    );
+
+    // 再点一次 = 立即收束；状态必须回推成静止态。
+    await invokeNative('recaptureVoice');
+    await waitUntil(() => !session.isRecapturing);
+    final MethodCall settled = nativeCalls.lastWhere(
+      (MethodCall call) => call.method == 'setVoiceState',
+    );
+    expect(
+      (settled.arguments as Map<Object?, Object?>)['recapturing'],
+      isFalse,
+    );
+  });
+
+  test('没有可播语音时 replayVoice 不进入试听态', () async {
+    await showFirstLine();
+
+    await invokeNative('replayVoice');
+    await waitUntil(() => false);
+
+    expect(controller.isReplaying, isFalse);
+    expect(
+      nativeCalls.where(
+        (MethodCall call) =>
+            call.method == 'setVoiceState' &&
+            (call.arguments as Map<Object?, Object?>)['replaying'] == true,
+      ),
+      isEmpty,
+    );
+  });
+}
+
+class _VoiceTestEngine extends EngineHookGalAudioSource {
+  _VoiceTestEngine()
+      : super(targetPid: 0, launchExe: null, injectorPath: 'fake.exe');
+
+  @override
+  bool get textHookReady => true;
+
+  @override
+  Future<PcmFormat?> start() async => null;
+
+  @override
+  Future<bool> refreshReadiness() async => false;
+
+  @override
+  Future<GalTextPoll?> pollText(int sinceSeq) async =>
+      const GalTextPoll(count: 0, lines: <GalHookedLine>[]);
+
+  @override
+  Future<bool> selectTextThread(int? threadId) async => true;
+
+  @override
+  Future<Uint8List?> grabPairedVoiceBytes(
+    int textTsMs, {
+    required String outputExtension,
+    int? textEventId,
+    String? resourceId,
+    bool allowLatestSessionFallback = true,
+  }) async =>
+      null;
+
+  @override
+  Future<void> stop() async {}
+}
+
+class _VoiceTestLoopback extends LoopbackGalAudioSource {
+  @override
+  Future<PcmFormat?> start() async => const PcmFormat(
+        sampleRate: 44100,
+        channels: 2,
+        bitsPerSample: 16,
+        isFloat: false,
+      );
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<GalAudioSlice?> grabRecent(int backMs) async => null;
+}

--- a/hibiki/test/lookup/gal_hook_text_overlay_channel_test.dart
+++ b/hibiki/test/lookup/gal_hook_text_overlay_channel_test.dart
@@ -29,11 +29,13 @@ void main() {
     String? lineId;
     String? text;
     int? index;
+    Rect? wordRect;
     GalHookTextOverlayChannel.setEventHandlers(
-      onLookupText: (String id, String value, int valueIndex) {
+      onLookupText: (String id, String value, int valueIndex, Rect? rect) {
         lineId = id;
         text = value;
         index = valueIndex;
+        wordRect = rect;
       },
     );
 
@@ -46,6 +48,40 @@ void main() {
     expect(lineId, 'line-42');
     expect(text, 'これは本だ');
     expect(index, 3);
+    expect(wordRect, isNull, reason: '老 native 不带词矩形时必须回落到光标定位，不能伪造锚点');
+  });
+
+  test('被点词的屏幕矩形随查词事件送达，作为查词卡锚点', () async {
+    Rect? wordRect;
+    GalHookTextOverlayChannel.setEventHandlers(
+      onLookupText: (String id, String value, int valueIndex, Rect? rect) {
+        wordRect = rect;
+      },
+    );
+
+    await invokeFromNative('lookupText', <String, Object?>{
+      'lineId': 'line-7',
+      'text': 'これは本だ',
+      'index': 3,
+      'wordLeft': 320.5,
+      'wordTop': 880.0,
+      'wordWidth': 28.0,
+      'wordHeight': 34.0,
+    });
+
+    expect(wordRect, const Rect.fromLTWH(320.5, 880.0, 28.0, 34.0));
+
+    // 退化矩形（native 未命中字形）同样按「没有锚点」处理。
+    await invokeFromNative('lookupText', <String, Object?>{
+      'lineId': 'line-7',
+      'text': 'これは本だ',
+      'index': 3,
+      'wordLeft': 10.0,
+      'wordTop': 10.0,
+      'wordWidth': 0.0,
+      'wordHeight': 0.0,
+    });
+    expect(wordRect, isNull);
   });
 
   test('toolbar and native window state events are forwarded', () async {

--- a/hibiki/test/mining/gal_hook_line_latency_recapture_test.dart
+++ b/hibiki/test/mining/gal_hook_line_latency_recapture_test.dart
@@ -1,0 +1,392 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/mining/galgame_audio_encode.dart';
+import 'package:hibiki/src/mining/galgame_audio_source.dart';
+import 'package:hibiki/src/mining/window_capture_channel.dart';
+import 'package:hibiki/src/sync/texthooker_service.dart';
+import 'package:hibiki/src/sync/texthooker_ws_client.dart';
+
+/// BUG-1062：台词显示不得被自己的语音配对拖慢，以及浮窗「重播并录音」补录链路。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> waitUntil(bool Function() done) async {
+    for (int i = 0; i < 200 && !done(); i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+  }
+
+  test('语音抓取挂起时后续台词照常显示（BUG-1062 显示延迟根因守卫）', () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    final Completer<GalAudioSlice?> blockedUtterance =
+        Completer<GalAudioSlice?>();
+    final _LatencyEngine engine = _LatencyEngine(
+      utterance: blockedUtterance.future,
+      polledLines: const <GalHookedLine>[
+        GalHookedLine(
+          seq: 1,
+          timestampMs: 1000,
+          text: '一句目',
+          threadId: 5,
+          hookName: 'fake',
+        ),
+        GalHookedLine(
+          seq: 2,
+          timestampMs: 2000,
+          text: '二句目',
+          threadId: 5,
+          hookName: 'fake',
+        ),
+      ],
+    );
+    final GalHookSessionController controller = GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      targetWow64Probe: (_) async => false,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+      }) =>
+          engine,
+      loopbackSourceFactory: _SilentLoopback.new,
+      textPollInterval: const Duration(milliseconds: 5),
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+
+    await controller.startAttachedCapture(
+      const ExternalWindowInfo(hwnd: 3, pid: 4242, title: 'Game'),
+    );
+    await waitUntil(() => service.entries.length >= 2);
+
+    expect(
+      service.entries.map((TexthookerLineEntry e) => e.text),
+      <String>['一句目', '二句目'],
+      reason: '第一句的语音抓取还挂着，第二句台词也必须已经显示',
+    );
+    expect(engine.utteranceCalls, greaterThan(0));
+
+    blockedUtterance.complete(null);
+    await controller.close();
+    endpoints.dispose();
+  });
+
+  test('poll 提速后 readiness 查询仍被降频（不给文本链路加 IPC 往返）', () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    DateTime clock = DateTime(2026, 7, 24, 12);
+    final _LatencyEngine engine = _LatencyEngine(
+      utterance: Future<GalAudioSlice?>.value(),
+    );
+    final GalHookSessionController controller = GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      targetWow64Probe: (_) async => false,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+      }) =>
+          engine,
+      loopbackSourceFactory: _SilentLoopback.new,
+      textPollInterval: const Duration(milliseconds: 5),
+      now: () => clock,
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+
+    await controller.startAttachedCapture(
+      const ExternalWindowInfo(hwnd: 3, pid: 4242, title: 'Game'),
+    );
+    await waitUntil(() => engine.pollCalls >= 8);
+    expect(
+      engine.readinessCalls,
+      lessThan(engine.pollCalls),
+      reason: '文本轮询每 tick 都跑，readiness 不能跟着每 tick 做一次 IPC',
+    );
+
+    // 时钟推过节流窗口后，晚到的资源 hook 仍能被发现。
+    final int before = engine.readinessCalls;
+    clock = clock.add(const Duration(seconds: 2));
+    await waitUntil(() => engine.readinessCalls > before);
+    expect(engine.readinessCalls, greaterThan(before));
+
+    await controller.close();
+    endpoints.dispose();
+  });
+
+  test('手动补录把 loopback 录到的语音绑定到该行，并优先于资源配对', () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    final _LatencyEngine engine = _LatencyEngine(
+      utterance: Future<GalAudioSlice?>.value(),
+      audioFormat: null,
+      rawReady: true,
+      pairedCandidate: true,
+    );
+    final _SilentLoopback loopback = _SilentLoopback(withPcm: true);
+    final GalHookSessionController controller = GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      targetWow64Probe: (_) async => false,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+      }) =>
+          engine,
+      loopbackSourceFactory: () => loopback,
+      textPollInterval: const Duration(milliseconds: 5),
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+
+    await controller.startAttachedCapture(
+      const ExternalWindowInfo(hwnd: 3, pid: 4242, title: 'Game'),
+    );
+    final TexthookerLineEntry line = service.appendLine(
+      '補録したい台詞',
+      source: TexthookerLineSource.websocket,
+    )!;
+
+    // 先让会话自身的逐行 loopback 兜底跑完，再补录——否则断言看到的是它写的状态。
+    await waitUntil(() => loopback.grabRecentCalls > 0);
+    final int autoGrabs = loopback.grabRecentCalls;
+
+    expect(await controller.startLineRecapture(line.id), isTrue);
+    expect(controller.isRecapturing, isTrue);
+    expect(controller.recapturingLineId, line.id);
+    expect(
+      service.entries.last.audioStatus,
+      TexthookerLineAudioStatus.pending,
+    );
+
+    expect(await controller.finishLineRecapture(), isTrue);
+    expect(controller.isRecapturing, isFalse);
+    final TexthookerLineEntry recaptured = service.entries.last;
+    expect(recaptured.audioStatus, TexthookerLineAudioStatus.fallback);
+    expect(recaptured.audioBackend, 'system_loopback');
+    expect(recaptured.fallbackReason, 'manual_recapture');
+    expect(controller.debugIsManualRecapture(line.id), isTrue);
+    expect(
+      loopback.grabRecentCalls,
+      autoGrabs + 1,
+      reason: '补录必须自己冻结一段环形缓冲，而不是复用自动兜底的那一段',
+    );
+
+    // 补录即用户裁决：制卡不得再回头等资源配对把它顶掉。
+    await controller.captureAudioBytes(
+      lineId: line.id,
+      sentence: line.text,
+      outputExtension: 'aac',
+    );
+    expect(
+      engine.pairedRequests,
+      isEmpty,
+      reason: '补录过的行必须直接用补录切片，不再询问资源语音',
+    );
+
+    await controller.close();
+    endpoints.dispose();
+  });
+
+  test('会话结束会收束补录窗口并停掉临时 loopback', () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    final _LatencyEngine engine = _LatencyEngine(
+      utterance: Future<GalAudioSlice?>.value(),
+      rawReady: true,
+    );
+    final List<_SilentLoopback> loopbacks = <_SilentLoopback>[];
+    final GalHookSessionController controller = GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      targetWow64Probe: (_) async => false,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+      }) =>
+          engine,
+      loopbackSourceFactory: () {
+        final _SilentLoopback source = _SilentLoopback(withPcm: true);
+        loopbacks.add(source);
+        return source;
+      },
+      textPollInterval: const Duration(milliseconds: 5),
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+
+    await controller.startAttachedCapture(
+      const ExternalWindowInfo(hwnd: 3, pid: 4242, title: 'Game'),
+    );
+    final TexthookerLineEntry line = service.appendLine(
+      '会話終了時の台詞',
+      source: TexthookerLineSource.websocket,
+    )!;
+    expect(await controller.startLineRecapture(line.id), isTrue);
+
+    await controller.stopCapture();
+    expect(controller.isRecapturing, isFalse);
+    for (final _SilentLoopback source in loopbacks) {
+      expect(source.stopCalls, greaterThan(0));
+    }
+
+    await controller.close();
+    endpoints.dispose();
+  });
+}
+
+class _LatencyEngine extends EngineHookGalAudioSource {
+  _LatencyEngine({
+    required this.utterance,
+    this.polledLines = const <GalHookedLine>[],
+    this.audioFormat = const PcmFormat(
+      sampleRate: 44100,
+      channels: 1,
+      bitsPerSample: 16,
+      isFloat: false,
+    ),
+    this.rawReady = false,
+    this.pairedCandidate = false,
+  }) : super(targetPid: 0, launchExe: 'fake.exe', injectorPath: 'fake.exe');
+
+  final Future<GalAudioSlice?> utterance;
+  final List<GalHookedLine> polledLines;
+  final PcmFormat? audioFormat;
+  final bool rawReady;
+  final bool pairedCandidate;
+
+  int pollCalls = 0;
+  int readinessCalls = 0;
+  int utteranceCalls = 0;
+  final List<int> pairedRequests = <int>[];
+
+  @override
+  int? get gamePid => 4242;
+
+  @override
+  bool get textHookReady => true;
+
+  @override
+  bool get rawVoiceReady => rawReady;
+
+  @override
+  bool get pcmReady => !rawReady && audioFormat != null;
+
+  @override
+  Future<PcmFormat?> start() async => audioFormat;
+
+  @override
+  Future<bool> refreshReadiness() async {
+    readinessCalls++;
+    return rawReady;
+  }
+
+  @override
+  Future<GalTextPoll?> pollText(int sinceSeq) async {
+    pollCalls++;
+    return GalTextPoll(
+      count: polledLines.length,
+      lines: pollCalls == 1 ? polledLines : const <GalHookedLine>[],
+    );
+  }
+
+  @override
+  Future<bool> selectTextThread(int? threadId) async => true;
+
+  @override
+  Future<GalAudioSlice?> grabUtterance(
+    int tsMs, {
+    int? sourcePtr,
+    List<int>? exclude,
+  }) {
+    utteranceCalls++;
+    return utterance;
+  }
+
+  @override
+  Future<GalAudioSlice?> grabClipNear(int tsMs, {int tolMs = 8000}) async =>
+      null;
+
+  @override
+  String? findPairedVoiceResourceId(
+    int textTsMs, {
+    int? textEventId,
+    bool allowLatestSessionFallback = true,
+  }) =>
+      pairedCandidate ? 'fake-$textTsMs.ogg' : null;
+
+  @override
+  Future<Uint8List?> grabPairedVoiceBytes(
+    int textTsMs, {
+    required String outputExtension,
+    int? textEventId,
+    String? resourceId,
+    bool allowLatestSessionFallback = true,
+  }) async {
+    pairedRequests.add(textTsMs);
+    return null;
+  }
+
+  @override
+  Future<void> stop() async {}
+}
+
+class _SilentLoopback extends LoopbackGalAudioSource {
+  _SilentLoopback({this.withPcm = false});
+
+  final bool withPcm;
+  int startCalls = 0;
+  int stopCalls = 0;
+  int grabRecentCalls = 0;
+
+  @override
+  Future<PcmFormat?> start() async {
+    startCalls++;
+    return const PcmFormat(
+      sampleRate: 44100,
+      channels: 2,
+      bitsPerSample: 16,
+      isFloat: false,
+    );
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+  }
+
+  @override
+  Future<GalAudioSlice?> grabRecent(int backMs) async {
+    grabRecentCalls++;
+    if (!withPcm) return null;
+    return GalAudioSlice(
+      pcm: Uint8List.fromList(List<int>.filled(64, 3)),
+      format: const PcmFormat(
+        sampleRate: 44100,
+        channels: 2,
+        bitsPerSample: 16,
+        isFloat: false,
+      ),
+    );
+  }
+}

--- a/hibiki/test/mining/gal_hook_session_controller_test.dart
+++ b/hibiki/test/mining/gal_hook_session_controller_test.dart
@@ -985,27 +985,38 @@ void main() {
 }
 
 void _bug950Guard() {
-  test('poll 循环 await 归来后有 engine generation 复检（BUG-950 回归守卫）', () {
-    // grabUtterance/_cacheLoopbackForLine 的 await 跨越 stop/重启时，恢复后必须复检
-    // engine == _engineSource 再推进 cursor，否则新会话的 _lastTextSeq 被旧 cursor 倒灌、
-    // 新文本全被判 duplicate 丢弃。此为跨异步 gap + 私有 seq 的时序 bug，行为断言留真机轮；
-    // 源码守卫确保复检不被后续改动悄悄删掉。
+  test('文本 poll 主路径零阻塞 + 语音抓取内复检 engine（BUG-950 / BUG-1062 守卫）', () {
+    // BUG-1062：文本主循环里一旦重新出现语音抓取的 await，同批后续台词就要排在前一句
+    // 的语音之后，_pollInFlight 还会让下一个 tick 整轮跳过——台词显示被自己的语音配对
+    // 拖慢。BUG-950：抓取的 await 跨越 stop/重启时，恢复后必须复检 engine == _engineSource，
+    // 否则旧会话的数据写进新会话的行。两者都是跨异步 gap 的时序不变量，用源码守卫钉住。
     final File src = File('lib/src/mining/gal_hook_session_controller.dart');
     expect(src.existsSync(), isTrue);
     final String body = src.readAsStringSync();
     final int pollAt = body.indexOf('Future<void> _pollHookedText()');
     expect(pollAt, greaterThan(0), reason: '_pollHookedText 不存在，守卫需更新');
-    final int cursorWriteAt =
-        body.indexOf('cursor = line.seq;\n      }', pollAt);
-    expect(cursorWriteAt, greaterThan(pollAt), reason: '找不到循环末尾 cursor 推进点');
-    // 紧邻循环末尾 cursor 推进之前的窗口里，必须存在 engine != _engineSource 复检 + BUG-950 标记
-    // （前面别处也有 generation 检查，故只看贴着 cursor 写入的这一段，避免误过）。
-    final String window = body.substring(cursorWriteAt - 400, cursorWriteAt);
+    final int pollEnd =
+        body.indexOf('Future<void> _refreshReadinessThrottled', pollAt);
+    expect(pollEnd, greaterThan(pollAt), reason: '找不到 _pollHookedText 结尾');
+    final List<String> awaited = RegExp(r'await ([A-Za-z_.]+)\(')
+        .allMatches(body.substring(pollAt, pollEnd))
+        .map((RegExpMatch m) => m.group(1)!)
+        .toList();
     expect(
-      window.contains('if (engine != _engineSource)') &&
-          window.contains('BUG-950'),
+      awaited,
+      <String>['_refreshReadinessThrottled', 'engine.pollText'],
+      reason: 'BUG-1062：文本主路径只许等 readiness 与 pollText 本身，'
+          '语音抓取必须走 _scheduleLineAudioAttach 的后台队列',
+    );
+
+    final int attachAt = body.indexOf('Future<void> _attachLineAudio(');
+    expect(attachAt, greaterThan(0), reason: '_attachLineAudio 不存在，守卫需更新');
+    final String attachBody = body.substring(attachAt, attachAt + 1200);
+    expect(
+      attachBody.contains('if (engine != _engineSource)') &&
+          attachBody.contains('BUG-950'),
       isTrue,
-      reason: 'BUG-950：推进 cursor 前必须复检 engine generation（await 跨重启防倒灌）',
+      reason: 'BUG-950：语音抓取 await 归来后必须复检 engine generation',
     );
   });
 

--- a/hibiki/test/tools/gal_hook_overlay_buttons_guard_test.dart
+++ b/hibiki/test/tools/gal_hook_overlay_buttons_guard_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+/// Hook 台词浮窗工具栏的绘制与命中必须来自同一个槽数：Render() 画 N 个按钮，
+/// ControlActionAt() 就得给出 N 个 action，否则点击会落到看不见的按钮上，或者
+/// 整排按钮相对居中布局漂移（浮窗是独立 native 窗口，Dart 侧测不到这层）。
+void main() {
+  final String runner = p.join('windows', 'runner');
+  final File window = File(p.join(runner, 'floating_lyric_window.cpp'));
+  final File host = File(p.join(runner, 'flutter_window.cpp'));
+
+  test('hook 工具栏槽数与绘制、命中映射三者一致', () {
+    final String source = window.readAsStringSync();
+    final RegExp slotCount =
+        RegExp(r'kHookTextControlSlotCount\s*=\s*(\d+)\s*;');
+    final Match? declared = slotCount.firstMatch(source);
+    expect(declared, isNotNull, reason: '找不到 kHookTextControlSlotCount 声明');
+    final int slots = int.parse(declared!.group(1)!);
+
+    final List<int> drawn = RegExp(r'hook_button\((\d+),')
+        .allMatches(source)
+        .map((Match m) => int.parse(m.group(1)!))
+        .toList()
+      ..sort();
+    expect(
+      drawn,
+      List<int>.generate(slots, (int i) => i),
+      reason: 'Render() 必须正好画出 0..N-1 全部槽位',
+    );
+
+    final int hookHitStart = source.indexOf('if (hook_text_mode_) {',
+        source.indexOf('std::string FloatingLyricWindow::ControlActionAt'));
+    expect(hookHitStart, greaterThan(0));
+    // 只截 hook 分支自身：后面还有 clipboard / 歌词条的槽位 switch，混进来会误判。
+    final int hookHitEnd = source.indexOf('const float lock_x', hookHitStart);
+    expect(hookHitEnd, greaterThan(hookHitStart));
+    final String hookHit = source.substring(hookHitStart, hookHitEnd);
+    final List<int> mapped = RegExp(r'case (\d+):')
+        .allMatches(hookHit)
+        .map((Match m) => int.parse(m.group(1)!))
+        .toList()
+      ..sort();
+    expect(
+      mapped,
+      List<int>.generate(slots, (int i) => i),
+      reason: 'ControlActionAt() 必须为每个绘制出来的槽位给出 action',
+    );
+  });
+
+  test('语音控件 action 与 native 状态方法齐全', () {
+    final String source = window.readAsStringSync();
+    for (final String action in <String>['replayVoice', 'recaptureVoice']) {
+      expect(
+        source,
+        contains('"$action"'),
+        reason: '浮窗必须能把「$action」按钮点击回传给 Dart',
+      );
+    }
+    expect(
+      source,
+      contains('void FloatingLyricWindow::SetVoiceState'),
+      reason: '试听 / 补录状态没有回写入口，用户就看不到自己在录音',
+    );
+    expect(
+      host.readAsStringSync(),
+      contains('setVoiceState'),
+      reason: 'gal_hook_text channel 必须暴露 setVoiceState',
+    );
+  });
+}

--- a/hibiki/test/tools/gal_hook_overlay_buttons_guard_test.dart
+++ b/hibiki/test/tools/gal_hook_overlay_buttons_guard_test.dart
@@ -69,4 +69,50 @@ void main() {
       reason: 'gal_hook_text channel 必须暴露 setVoiceState',
     );
   });
+
+  test('hook 台词字号随窗口高度缩放（不再钉死在作者尺寸）', () {
+    final String source = window.readAsStringSync();
+    expect(
+      source,
+      contains('kHookTextBaseHeightForFontDip'),
+      reason: 'hook 模式必须有自己的字号基准高度',
+    );
+    // 旧写法是 hook_text_mode_ ? 1.0f : ...，等于把台词字号钉死；缩放必须真的用上
+    // 实时高度，否则用户把浮窗拖大字还是原来那么小。
+    final int scaleAt = source.indexOf('const float height_scale');
+    expect(scaleAt, greaterThan(0));
+    final String scaleExpr = source.substring(scaleAt, scaleAt + 400);
+    expect(
+      scaleExpr.contains('strip_height_dip_ / kHookTextBaseHeightForFontDip'),
+      isTrue,
+      reason: 'hook 分支必须按实时窗口高度缩放字号',
+    );
+  });
+
+  test('点词查询回传该字的屏幕矩形（查词卡锚定到词而非鼠标）', () {
+    final String source = window.readAsStringSync();
+    expect(
+      source,
+      contains('int FloatingLyricWindow::CharIndexAt(float x, float y,'),
+      reason: 'CharIndexAt 必须能输出命中字符的矩形',
+    );
+    expect(
+      source.contains(
+          'on_context_lookup_(context_id_, utf8, index, screen_rect)'),
+      isTrue,
+      reason: '查词事件必须带上屏幕逻辑 px 的词矩形',
+    );
+    for (final String key in <String>[
+      'wordLeft',
+      'wordTop',
+      'wordWidth',
+      'wordHeight',
+    ]) {
+      expect(
+        host.readAsStringSync(),
+        contains('"$key"'),
+        reason: 'channel 载荷缺少 $key，Dart 侧拿不到锚点',
+      );
+    }
+  });
 }

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -31,6 +31,11 @@ constexpr float kControlsTopDip = 8.0f;
 // Bottom-right resize grip and the min / max the user may drag the bar to.
 constexpr float kResizeGripDip = 18.0f;
 constexpr float kMinStripWidthDip = 280.0f;
+// Hook mode draws a centred 8-slot toolbar (8 * 30 + 7 * 10 = 310dip). The
+// generic 280dip floor would let the user drag the window narrower than its own
+// controls, clipping the leading voice buttons; hook mode therefore floors at
+// the toolbar width plus a small margin.
+constexpr float kHookTextMinStripWidthDip = 330.0f;
 constexpr float kMinStripHeightDip = 64.0f;
 constexpr float kMaxStripWidthDip = 2400.0f;
 constexpr float kMaxStripHeightDip = 480.0f;
@@ -45,7 +50,12 @@ constexpr float kBaseStripHeightForFontDip = 96.0f;
 // and ControlActionAt() derive their geometry from this single count so the
 // hit areas can never drift from what is drawn.
 constexpr int kControlSlotCount = 5;
-constexpr int kHookTextControlSlotCount = 6;
+// Hook text toolbar slots, in draw / hit-test order: replay voice, replay +
+// recapture, follow, click-through, transparency, lock, workbench, close. The
+// two leading slots are the voice controls (replay the line's captured audio;
+// open a recapture window so the user can replay the line inside the game and
+// have it recorded onto that line).
+constexpr int kHookTextControlSlotCount = 8;
 
 // Text-only clipboard window (Luna-style hover toolbar). A thin top strip is
 // ALWAYS a mouse catch (drawn at ~2% alpha across the full width) so the fully
@@ -243,7 +253,7 @@ bool FloatingLyricWindow::Show(HWND owner) {
     // TODO-708 P2: 首次创建即用设置宽度（>0，夹到拖拽边界），否则历史 720dip 起始宽。
     strip_width_dip_ = style_.window_width > 0.0
                            ? std::clamp(static_cast<float>(style_.window_width),
-                                        kMinStripWidthDip, kMaxStripWidthDip)
+                                        MinStripWidthDip(), kMaxStripWidthDip)
                            : kStripWidthDip;
     strip_height_dip_ = style_.window_height > 0.0
                             ? std::clamp(
@@ -345,7 +355,7 @@ void FloatingLyricWindow::ApplyStyleWidth() {
     return;
   }
   const float target_dip =
-      std::clamp(static_cast<float>(style_.window_width), kMinStripWidthDip,
+      std::clamp(static_cast<float>(style_.window_width), MinStripWidthDip(),
                  kMaxStripWidthDip);
   RECT rc;
   if (!GetWindowRect(hwnd_, &rc)) {
@@ -379,6 +389,19 @@ void FloatingLyricWindow::UpdateLabels(const Labels& labels) {
 
 void FloatingLyricWindow::SetPlaybackState(bool playing) {
   playing_ = playing;
+  RequestRender();
+}
+
+float FloatingLyricWindow::MinStripWidthDip() const {
+  return hook_text_mode_ ? kHookTextMinStripWidthDip : kMinStripWidthDip;
+}
+
+void FloatingLyricWindow::SetVoiceState(bool replaying, bool recapturing) {
+  if (replaying_ == replaying && recapturing_ == recapturing) {
+    return;
+  }
+  replaying_ = replaying;
+  recapturing_ = recapturing;
   RequestRender();
 }
 
@@ -682,7 +705,7 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       // Clamp the system resize to the same sane bounds the bar is authored
       // for, so the user cannot drag it to an unusable size.
       auto* mmi = reinterpret_cast<MINMAXINFO*>(lparam);
-      mmi->ptMinTrackSize.x = static_cast<LONG>(ScaleForDpi(kMinStripWidthDip));
+      mmi->ptMinTrackSize.x = static_cast<LONG>(ScaleForDpi(MinStripWidthDip()));
       mmi->ptMinTrackSize.y = static_cast<LONG>(ScaleForDpi(kMinStripHeightDip));
       mmi->ptMaxTrackSize.x = static_cast<LONG>(ScaleForDpi(kMaxStripWidthDip));
       mmi->ptMaxTrackSize.y = static_cast<LONG>(ScaleForDpi(kMaxStripHeightDip));
@@ -961,12 +984,14 @@ void FloatingLyricWindow::Render() {
         auto hook_button = [&](int slot, const wchar_t* glyph, bool active) {
           draw_tbtn(left + slot * (t_btn + t_gap), glyph, active);
         };
-        hook_button(0, playing_ ? L"⏸" : L"▶", !playing_);
-        hook_button(1, L"↗", pass_through_);
-        hook_button(2, L"◐", false);
-        hook_button(3, locked_ ? L"\U0001F512" : L"\U0001F513", locked_);
-        hook_button(4, L"▣", false);
-        hook_button(5, L"✕", false);
+        hook_button(0, L"↺", replaying_);
+        hook_button(1, L"⏺", recapturing_);
+        hook_button(2, playing_ ? L"⏸" : L"▶", !playing_);
+        hook_button(3, L"↗", pass_through_);
+        hook_button(4, L"◐", false);
+        hook_button(5, locked_ ? L"\U0001F512" : L"\U0001F513", locked_);
+        hook_button(6, L"▣", false);
+        hook_button(7, L"✕", false);
       } else {
         const float lock_x = width - t_pad - t_btn;
         const float top_x = lock_x - t_gap - t_btn;
@@ -1120,16 +1145,20 @@ std::string FloatingLyricWindow::ControlActionAt(float x, float y) {
         if (x < bx || x > bx + btn) continue;
         switch (slot) {
           case 0:
-            return "toggleFollow";
+            return "replayVoice";
           case 1:
-            return "togglePassThrough";
+            return "recaptureVoice";
           case 2:
-            return "toggleTransparency";
+            return "toggleFollow";
           case 3:
-            return "lock";
+            return "togglePassThrough";
           case 4:
-            return "openWorkbench";
+            return "toggleTransparency";
           case 5:
+            return "lock";
+          case 6:
+            return "openWorkbench";
+          case 7:
             return "close";
           default:
             return std::string();

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -45,6 +45,14 @@ constexpr float kDragThresholdDip = 6.0f;
 // Base logical font size the lyric text was authored at; the rendered font
 // scales with the bar height so growing the bar enlarges the text too.
 constexpr float kBaseStripHeightForFontDip = 96.0f;
+// Hook mode authors its font against its own default window height (140dip) and
+// scales with the live height, so dragging the overlay taller enlarges the
+// caption instead of leaving it stranded at the authored size. Clamped so a
+// deliberately short, wide overlay (hugging the game's text box) never shrinks
+// the text below readability.
+constexpr float kHookTextBaseHeightForFontDip = 140.0f;
+constexpr float kHookTextFontScaleMin = 0.9f;
+constexpr float kHookTextFontScaleMax = 2.5f;
 // Control row slots, in draw / hit-test order: previous, play-pause, next,
 // lock, close. The lock button (slot 3) is the TODO-136 addition; both Render()
 // and ControlActionAt() derive their geometry from this single count so the
@@ -643,8 +651,10 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       // lookup now — single-tap lookup preserved.
       if (!was_dragging && was_pressed && was_text &&
           (on_lookup_ || on_context_lookup_)) {
+        D2D1_RECT_F char_rect = {};
         const int index = CharIndexAt(static_cast<float>(lookup_pt.x),
-                                      static_cast<float>(lookup_pt.y));
+                                      static_cast<float>(lookup_pt.y),
+                                      &char_rect);
         if (index >= 0) {
           int utf8_len = WideCharToMultiByte(CP_UTF8, 0, text_.c_str(),
                                              static_cast<int>(text_.size()),
@@ -654,7 +664,18 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
                               static_cast<int>(text_.size()), utf8.data(),
                               utf8_len, nullptr, nullptr);
           if (on_context_lookup_) {
-            on_context_lookup_(context_id_, utf8, index);
+            // Client-area physical px -> screen logical px: the lookup card
+            // anchors to the tapped word, so it must be in the same unit
+            // system Dart uses for screen rects.
+            const float scale = std::max(0.01f, static_cast<float>(dpi_) / 96.0f);
+            RECT wr = {};
+            GetWindowRect(hwnd_, &wr);
+            const D2D1_RECT_F screen_rect = D2D1::RectF(
+                (wr.left + char_rect.left) / scale,
+                (wr.top + char_rect.top) / scale,
+                (wr.left + char_rect.right) / scale,
+                (wr.top + char_rect.bottom) / scale);
+            on_context_lookup_(context_id_, utf8, index, screen_rect);
           } else if (on_lookup_) {
             on_lookup_(utf8, index);
           }
@@ -801,10 +822,11 @@ void FloatingLyricWindow::Render() {
   // height; the live font scales with strip_height_dip_ so dragging the resize
   // grip larger enlarges the lyric text too.
   if (text_format_ == nullptr) {
-    const float height_scale = hook_text_mode_
-                                   ? 1.0f
-                                   : strip_height_dip_ /
-                                         kBaseStripHeightForFontDip;
+    const float height_scale =
+        hook_text_mode_
+            ? std::clamp(strip_height_dip_ / kHookTextBaseHeightForFontDip,
+                         kHookTextFontScaleMin, kHookTextFontScaleMax)
+            : strip_height_dip_ / kBaseStripHeightForFontDip;
     const float scaled_font = static_cast<float>(style_.font_size) *
                               std::max(0.5f, height_scale);
     dwrite_factory_->CreateTextFormat(
@@ -1243,7 +1265,8 @@ void FloatingLyricWindow::SyncStripSizeFromWindow() {
   strip_height_dip_ = static_cast<float>(rc.bottom - rc.top) / scale;
 }
 
-int FloatingLyricWindow::CharIndexAt(float x, float y) {
+int FloatingLyricWindow::CharIndexAt(float x, float y,
+                                     D2D1_RECT_F* out_char_rect) {
   if (text_.empty() || text_layout_ == nullptr) {
     return -1;
   }
@@ -1262,6 +1285,13 @@ int FloatingLyricWindow::CharIndexAt(float x, float y) {
   }
   if (!is_inside) {
     return -1;
+  }
+  if (out_char_rect != nullptr) {
+    // Hit-test metrics are layout-local; lift them back into client-area px.
+    out_char_rect->left = text_rect_.left + metrics.left;
+    out_char_rect->top = text_rect_.top + metrics.top;
+    out_char_rect->right = out_char_rect->left + metrics.width;
+    out_char_rect->bottom = out_char_rect->top + metrics.height;
   }
   return static_cast<int>(metrics.textPosition);
 }

--- a/hibiki/windows/runner/floating_lyric_window.h
+++ b/hibiki/windows/runner/floating_lyric_window.h
@@ -113,6 +113,11 @@ class FloatingLyricWindow {
   void UpdateStyle(const Style& style);
   void UpdateLabels(const Labels& labels);
   void SetPlaybackState(bool playing);
+  // Hook-text voice controls: whether the line's captured audio is currently
+  // being replayed, and whether a recapture window is open. Drives the two
+  // leading toolbar glyphs' active highlight — the overlay is a separate
+  // window, so this is the only place the user can see either state.
+  void SetVoiceState(bool replaying, bool recapturing);
   void SetClickLookupEnabled(bool enabled);
   // Text-only mode (the transparent clipboard text window): the strip draws
   // ONLY the draggable, tappable text — no playback / lock / close control
@@ -210,10 +215,17 @@ class FloatingLyricWindow {
   // cursor is not necessarily over the strip. No-op when already inside.
   void ClampCurrentPositionToWindowMonitor();
 
+  // Narrowest width the strip may be resized / restored to. Hook mode floors at
+  // its own 8-slot toolbar width so the voice buttons can never be clipped.
+  float MinStripWidthDip() const;
+
   HWND hwnd_ = nullptr;
   bool class_registered_ = false;
   bool visible_ = false;
   bool playing_ = false;
+  // Hook-text voice control state (see SetVoiceState).
+  bool replaying_ = false;
+  bool recapturing_ = false;
   bool click_lookup_enabled_ = true;
   // Text-only clipboard window: suppress control buttons + resize grip, use the
   // full window height for text. Never true for the audiobook lyric strip.

--- a/hibiki/windows/runner/floating_lyric_window.h
+++ b/hibiki/windows/runner/floating_lyric_window.h
@@ -38,8 +38,12 @@ class FloatingLyricWindow {
   // Reports a tap on a character at |char_index| within the full |text|.
   using LookupCallback =
       std::function<void(const std::string& text, int char_index)>;
+  // |word_rect| is the tapped character's rectangle in SCREEN LOGICAL px
+  // (already un-scaled by DPI) — the lookup card anchors to the word the user
+  // actually pointed at instead of to the mouse cursor.
   using ContextLookupCallback = std::function<void(
-      const std::string& context_id, const std::string& text, int char_index)>;
+      const std::string& context_id, const std::string& text, int char_index,
+      const D2D1_RECT_F& word_rect)>;
   // Reports a tap on one of the control buttons. |action| is one of
   // "previousCue", "playPause", "nextCue", "close" (the "lock" button is
   // handled internally and surfaced through LockCallback instead).
@@ -174,7 +178,10 @@ class FloatingLyricWindow {
 
   // Returns the UTF-16 code-unit index nearest the client point, or -1 when
   // the point is outside the text area or no text is present.
-  int CharIndexAt(float x, float y);
+  // Returns the character index under the client-area point, or -1. When
+  // |out_char_rect| is given it receives that character's rect in client-area
+  // physical px (callers lift it to screen logical px for the lookup anchor).
+  int CharIndexAt(float x, float y, D2D1_RECT_F* out_char_rect = nullptr);
 
   // Returns the control action at the client point, or empty when none.
   std::string ControlActionAt(float x, float y);

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -901,13 +901,25 @@ void FlutterWindow::RegisterGalHookTextChannel() {
 
   gal_hook_text_window_->SetContextLookupCallback(
       [this](const std::string& line_id, const std::string& text,
-             int char_index) {
+             int char_index, const D2D1_RECT_F& word_rect) {
+        // wordLeft/Top/Width/Height：被点字的屏幕逻辑 px 矩形，供查词卡锚定到
+        // 那个词（而不是鼠标位置）。
         flutter::EncodableMap map{
             {flutter::EncodableValue("lineId"),
              flutter::EncodableValue(line_id)},
             {flutter::EncodableValue("text"), flutter::EncodableValue(text)},
             {flutter::EncodableValue("index"),
              flutter::EncodableValue(char_index)},
+            {flutter::EncodableValue("wordLeft"),
+             flutter::EncodableValue(static_cast<double>(word_rect.left))},
+            {flutter::EncodableValue("wordTop"),
+             flutter::EncodableValue(static_cast<double>(word_rect.top))},
+            {flutter::EncodableValue("wordWidth"),
+             flutter::EncodableValue(
+                 static_cast<double>(word_rect.right - word_rect.left))},
+            {flutter::EncodableValue("wordHeight"),
+             flutter::EncodableValue(
+                 static_cast<double>(word_rect.bottom - word_rect.top))},
         };
         gal_hook_text_channel_->InvokeMethod(
             "lookupText",

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -958,6 +958,9 @@ void FlutterWindow::RegisterGalHookTextChannel() {
               BoolFromValue(args, "passThrough", false));
           gal_hook_text_window_->SetPlaybackState(
               BoolFromValue(args, "following", true));
+          // 同一 window 对象跨会话复用：重新 show 时语音控件必须回到静止态，
+          // 否则上一会话遗留的「录音中」高亮会挂在新会话的浮窗上。
+          gal_hook_text_window_->SetVoiceState(false, false);
           gal_hook_text_window_->SetInitialBounds(
               IntFromValue(args, "left", 0), IntFromValue(args, "top", 0),
               IntFromValue(args, "width", 0),
@@ -993,6 +996,11 @@ void FlutterWindow::RegisterGalHookTextChannel() {
         } else if (method == "setFollowing") {
           gal_hook_text_window_->SetPlaybackState(
               BoolFromValue(args, "following", true));
+          result->Success();
+        } else if (method == "setVoiceState") {
+          gal_hook_text_window_->SetVoiceState(
+              BoolFromValue(args, "replaying", false),
+              BoolFromValue(args, "recapturing", false));
           result->Success();
         } else {
           result->NotImplemented();


### PR DESCRIPTION
## 用户诉求
1. gal 文字浮窗要加「重播」按钮，以及「重播并自动录音」（回退重听那个）按钮。
2. hook 文字的显示有点慢。

## 一、台词显示慢（BUG-1062，根因修复）
三处叠加，全在 `hibiki/lib/src/mining/gal_hook_session_controller.dart`：

| # | 根因 | 修法 |
|---|---|---|
| 1 | `textPollInterval` 400ms。native `pollText` 只读共享内存环，无 IO / 无锁，400ms 是纯人为延迟（平均 +200ms、最坏 +400ms） | 降到 80ms |
| 2 | 每 tick 先 `await engine.refreshReadiness()` 才 `pollText`，文本链路白白串一次 IPC 往返 | 改 `_refreshReadinessThrottled`（≥500ms 一次），晚到资源 hook 的升格路径不变 |
| 3 | **最重**：poll 的 for 循环里逐行 `await grabUtterance / grabClipNear / _cacheLoopbackForLine`。同批第二句台词要排在第一句语音之后，抓取期间 `_pollInFlight` 还让下一个 tick 整轮跳过 | 抓取整体移出文本主路径，走 `_scheduleLineAudioAttach` 入串行音频队列（与制卡采集共用，native 语音缓冲仍只有一个读取者）；BUG-950 的 engine generation 复检随抓取搬进 `_attachLineAudio` |

## 二、浮窗语音按钮（功能新增）
Hook 工具栏 6 槽 → 8 槽，最左两个：

- **↺ 重播**：试听当前显示行已配语音（`game_resource` 原件直接播，PCM/loopback 冻结切片拼 WAV），播放中高亮，再点即停。
- **⏺ 重播并录音**：为当前行开最长 8s 补录窗口 → 用户在游戏里回退/重听这句 → 窗口内录到的系统声音绑定到该行；再点一次提前收束。补录 = 用户裁决：制卡与试听都优先用它，`clearResourceId` + 移出 `_pendingResourceMatches`，延迟资源匹配不会再改回去。会话没有 loopback 时临时拉起一个，收束即停。

状态经新的 `setVoiceState` 回推 native 做高亮（浮窗是独立窗口，是用户唯一能看见「正在录音」的地方）。hook 模式最小宽 280→330dip，窄窗口不再把工具栏裁掉。

## 验证
- `flutter analyze` 全量零问题。
- `flutter test` 全量 **13473 通过**（5 skip）。
- 新增测试：
  - `test/mining/gal_hook_line_latency_recapture_test.dart` — 语音抓取挂起时后续台词照常显示（**反向验证过：改回内联 await 该断言变红，只剩第一句**）、readiness 降频、补录绑定与制卡优先、会话结束收束补录。
  - `test/lookup/gal_hook_overlay_voice_controls_test.dart` — native 按钮 → Dart 分发 → `setVoiceState` 回推。
  - `test/tools/gal_hook_overlay_buttons_guard_test.dart` — Render 槽数 / ControlActionAt 映射 / native 状态方法三者一致。
  - 旧 BUG-950 源码守卫改为钉「文本主路径只许 await readiness 与 pollText」+「抓取内保留 generation 复检」。

## 仍待真机
Windows 上跑原始 galgame 路径确认观感延迟，以及两个按钮的实际手感（native 绘制部分本轮未做 Windows 构建验证）。

## 未做
没有让 Hibiki 主动向游戏发送「回退」按键来触发重播——那要按引擎逐个适配按键/滚轮语义，且会改变游戏状态；本轮按钮只负责开录音窗口，重播动作仍由用户在游戏内完成。需要的话可在此基础上加。

https://claude.ai/code/session_01DQMHJfB6kEW5DYwQTR8kXn
