### PR TITLE
feat(popup): Alt+滚轮跳到查词列表的下一个词条（可改键）

### DIFF
--- a/docs/agent/shortcuts-inventory.md
+++ b/docs/agent/shortcuts-inventory.md
@@ -119,6 +119,33 @@
 弹窗自身（`assets/popup/popup.js`）无键盘快捷键；关闭走 Flutter 层（reader 的 Esc→
 readerDismissDict 关栈顶弹窗 / 全局 Navigator pop / 手柄 B）。
 
+阅读器**选字光标**在弹窗上时另有一组硬编码键（`reader_caret_router.dart`，只在光标
+模式生效）：`]` / `[` 跳下/上一本词典段，`.` / `,` 跳下/上一个词条，RT / LT 是它们的
+手柄同义键。
+
+**滚轮（可配置，见下）**：`dictionaryPopup` scope 的「上/下一个词条」默认 Alt+滚轮
+下/上，鼠标悬在任何查词弹窗上即生效，不需要先进光标模式。
+
+---
+
+## 1b. 可配置注册表（滚轮通道，`dictionaryPopup` scope）
+
+> 后加的第四条绑定通道（键盘 / 手柄 / 鼠标按钮 / **滚轮**）。滚轮绑定不经
+> `resolveKeyboard` 或页面派发：弹窗内容是 WebView，滚轮事件先到它的 JS，故
+> `popup_settings_injection` 把绑定序列化成 `window.__hoshiEntryWheelBindings` 注入给
+> `popup.js`，命中即调 `hoshiFocusDictionaryEntryMove`（TODO-1325 #5 part1 的词条焦点）。
+> 浏览器扩展没有注入通道，吃 popup.js 里的同款默认值。
+
+| 动作 | 默认绑定 | 说明 |
+|---|---|---|
+| `popup_next_entry` | Alt+滚轮下 | 多词条结果里跳到下一个词条并滚进视口（Yomitan Next entry） |
+| `popup_prev_entry` | Alt+滚轮上 | 上一个词条 |
+
+约束：裸滚轮永远留给内容滚动（不可绑定）；修饰键必须**全等**匹配，故 Ctrl+Alt+滚轮
+不会误触 Alt+滚轮；到首/末条时返回 `blocked`，该帧照常滚动内容。设置页对这个 scope
+只渲染滚轮章节（`ShortcutScope.channels`），不给键盘/手柄入口——那些通道在这里绑了
+也永不触发。
+
 ---
 
 ## 3. 待优化（发现的冲突/重复/缺失，报 PM，不擅自改）

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -3703,7 +3703,56 @@ function popupAncestorAbsorbsVerticalWheel(target, deltaPx) {
     }
     return false;
 }
+// 查词弹窗「上/下一个词条」的滚轮绑定（Yomitan 的 Next/Previous entry）。默认
+// Alt+滚轮下 = 下一条、Alt+滚轮上 = 上一条；in-app 由 popup_settings_injection 注入
+// window.__hoshiEntryWheelBindings 覆盖成用户在「快捷键」设置里配的绑定（动作
+// ShortcutAction.popupNextEntry / popupPrevEntry）。浏览器扩展没有那条注入通道，
+// 就吃这里的默认值。
+const HOSHI_ENTRY_WHEEL_DEFAULT_BINDINGS = {
+    next: [{ dir: 'down', mods: ['alt'] }],
+    prev: [{ dir: 'up', mods: ['alt'] }],
+};
+// 本次 wheel 事件命中哪个词条导航动作：'next' / 'prev' / null。
+// 判据：deltaY 的符号给方向，当前按下的修饰键集合必须与某条绑定**全等**（故
+// Alt+滚轮绝不会被 Ctrl+Alt+滚轮误触）。裸滚轮永远留给内容滚动，绝不劫持。
+function popupEntryWheelAction(e) {
+    const raw = window.__hoshiEntryWheelBindings;
+    const cfg = (raw && typeof raw === 'object')
+        ? raw
+        : HOSHI_ENTRY_WHEEL_DEFAULT_BINDINGS;
+    const dir = e.deltaY > 0 ? 'down' : (e.deltaY < 0 ? 'up' : null);
+    if (!dir) return null;
+    const pressed = [];
+    if (e.altKey) pressed.push('alt');
+    if (e.ctrlKey) pressed.push('ctrl');
+    if (e.shiftKey) pressed.push('shift');
+    if (e.metaKey) pressed.push('meta');
+    if (pressed.length === 0) return null;
+    const matches = (list) => Array.isArray(list) && list.some((b) => b &&
+        b.dir === dir && Array.isArray(b.mods) &&
+        b.mods.length === pressed.length &&
+        b.mods.every((m) => pressed.indexOf(m) >= 0));
+    if (matches(cfg.next)) return 'next';
+    if (matches(cfg.prev)) return 'prev';
+    return null;
+}
 document.addEventListener('wheel', (e) => {
+    // 词条导航先于一切滚动处理判定（否则 ctrlKey 早退会吃掉 Ctrl 系绑定）。只有
+    // 焦点真的移动了（返回 'moved'）才吞掉事件：单词条 / 已到首尾时返回 'blocked'，
+    // 这一帧继续走下面的正常滚动，弹窗不会「按住 Alt 就滚不动」。
+    // 作用域判据与下面的滚动接管同源：扩展里滚轮必须真的落在弹窗 shadow 内
+    // （__hibikiWheelScroller 非空），in-app 整份文档就是弹窗故允许 null。
+    const entryAction = popupEntryWheelAction(e);
+    if (entryAction && typeof window.hoshiFocusDictionaryEntryMove === 'function') {
+        const inExtensionHost =
+            typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
+        if (__hibikiWheelScroller(e) || !inExtensionHost) {
+            if (window.hoshiFocusDictionaryEntryMove(entryAction) === 'moved') {
+                e.preventDefault();
+                return;
+            }
+        }
+    }
     // Ignore zoom gestures (ctrl+wheel / pinch) and predominantly-horizontal wheels.
     if (e.ctrlKey) return;
     // TODO-1387: treat a frame as horizontal (leave it to native) only when the

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -3703,7 +3703,56 @@ function popupAncestorAbsorbsVerticalWheel(target, deltaPx) {
     }
     return false;
 }
+// 查词弹窗「上/下一个词条」的滚轮绑定（Yomitan 的 Next/Previous entry）。默认
+// Alt+滚轮下 = 下一条、Alt+滚轮上 = 上一条；in-app 由 popup_settings_injection 注入
+// window.__hoshiEntryWheelBindings 覆盖成用户在「快捷键」设置里配的绑定（动作
+// ShortcutAction.popupNextEntry / popupPrevEntry）。浏览器扩展没有那条注入通道，
+// 就吃这里的默认值。
+const HOSHI_ENTRY_WHEEL_DEFAULT_BINDINGS = {
+    next: [{ dir: 'down', mods: ['alt'] }],
+    prev: [{ dir: 'up', mods: ['alt'] }],
+};
+// 本次 wheel 事件命中哪个词条导航动作：'next' / 'prev' / null。
+// 判据：deltaY 的符号给方向，当前按下的修饰键集合必须与某条绑定**全等**（故
+// Alt+滚轮绝不会被 Ctrl+Alt+滚轮误触）。裸滚轮永远留给内容滚动，绝不劫持。
+function popupEntryWheelAction(e) {
+    const raw = window.__hoshiEntryWheelBindings;
+    const cfg = (raw && typeof raw === 'object')
+        ? raw
+        : HOSHI_ENTRY_WHEEL_DEFAULT_BINDINGS;
+    const dir = e.deltaY > 0 ? 'down' : (e.deltaY < 0 ? 'up' : null);
+    if (!dir) return null;
+    const pressed = [];
+    if (e.altKey) pressed.push('alt');
+    if (e.ctrlKey) pressed.push('ctrl');
+    if (e.shiftKey) pressed.push('shift');
+    if (e.metaKey) pressed.push('meta');
+    if (pressed.length === 0) return null;
+    const matches = (list) => Array.isArray(list) && list.some((b) => b &&
+        b.dir === dir && Array.isArray(b.mods) &&
+        b.mods.length === pressed.length &&
+        b.mods.every((m) => pressed.indexOf(m) >= 0));
+    if (matches(cfg.next)) return 'next';
+    if (matches(cfg.prev)) return 'prev';
+    return null;
+}
 document.addEventListener('wheel', (e) => {
+    // 词条导航先于一切滚动处理判定（否则 ctrlKey 早退会吃掉 Ctrl 系绑定）。只有
+    // 焦点真的移动了（返回 'moved'）才吞掉事件：单词条 / 已到首尾时返回 'blocked'，
+    // 这一帧继续走下面的正常滚动，弹窗不会「按住 Alt 就滚不动」。
+    // 作用域判据与下面的滚动接管同源：扩展里滚轮必须真的落在弹窗 shadow 内
+    // （__hibikiWheelScroller 非空），in-app 整份文档就是弹窗故允许 null。
+    const entryAction = popupEntryWheelAction(e);
+    if (entryAction && typeof window.hoshiFocusDictionaryEntryMove === 'function') {
+        const inExtensionHost =
+            typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
+        if (__hibikiWheelScroller(e) || !inExtensionHost) {
+            if (window.hoshiFocusDictionaryEntryMove(entryAction) === 'moved') {
+                e.preventDefault();
+                return;
+            }
+        }
+    }
     // Ignore zoom gestures (ctrl+wheel / pinch) and predominantly-horizontal wheels.
     if (e.ctrlKey) return;
     // TODO-1387: treat a frame as horizontal (leave it to native) only when the

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 41667 (2451 per locale)
+/// Strings: 41820 (2460 per locale)
 ///
-/// Built on 2026-07-24 at 11:10 UTC
+/// Built on 2026-07-24 at 15:03 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3265,6 +3265,17 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_cloud_ocr_failed => 'Cloud recognition failed';
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  String get shortcut_wheel => 'Mouse wheel';
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  String get shortcut_wheel_up => 'Wheel up';
+  String get shortcut_wheel_down => 'Wheel down';
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -8827,6 +8838,26 @@ class _StringsAr extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -14462,6 +14493,26 @@ class _StringsDe extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -20113,6 +20164,26 @@ class _StringsEs extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -25775,6 +25846,26 @@ class _StringsFr extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -31364,6 +31455,26 @@ class _StringsId extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -37001,6 +37112,26 @@ class _StringsIt extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -42443,6 +42574,26 @@ class _StringsJa extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -47888,6 +48039,26 @@ class _StringsKo extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -53503,6 +53674,26 @@ class _StringsNl extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -59133,6 +59324,26 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -64746,6 +64957,26 @@ class _StringsRu extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -70304,6 +70535,26 @@ class _StringsTh extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -75894,6 +76145,26 @@ class _StringsTr extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -81471,6 +81742,26 @@ class _StringsVi extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 // Path: <root>
@@ -86658,6 +86949,25 @@ class _StringsZhCn extends _StringsEn {
   String get manga_cloud_ocr_failed => '云端识别失败';
   @override
   String get manga_ocr_mobile_note => '移动端下载的模型用于漫画阅读页的框选识别。';
+  @override
+  String get shortcut_scope_dictionary_popup => '查词弹窗';
+  @override
+  String get shortcut_action_popup_next_entry => '下一个词条';
+  @override
+  String get shortcut_action_popup_prev_entry => '上一个词条';
+  @override
+  String get shortcut_wheel => '鼠标滚轮';
+  @override
+  String get shortcut_press_wheel => '按住修饰键在此滚动滚轮';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      '裸滚轮用于滚动弹窗内容，请按住 Alt / Ctrl / Shift 再滚';
+  @override
+  String get shortcut_wheel_up => '滚轮向上';
+  @override
+  String get shortcut_wheel_down => '滚轮向下';
+  @override
+  String get shortcut_scope_dictionary_popup_note => '鼠标位于查词弹窗上时生效';
 }
 
 // Path: <root>
@@ -92018,6 +92328,26 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get manga_ocr_mobile_note =>
       'On mobile, the recognition model powers box scan in the manga reader.';
+  @override
+  String get shortcut_scope_dictionary_popup => 'Dictionary popup';
+  @override
+  String get shortcut_action_popup_next_entry => 'Next word entry';
+  @override
+  String get shortcut_action_popup_prev_entry => 'Previous word entry';
+  @override
+  String get shortcut_wheel => 'Mouse wheel';
+  @override
+  String get shortcut_press_wheel => 'Hold a modifier key and scroll here';
+  @override
+  String get shortcut_wheel_needs_modifier =>
+      'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+  @override
+  String get shortcut_wheel_up => 'Wheel up';
+  @override
+  String get shortcut_wheel_down => 'Wheel down';
+  @override
+  String get shortcut_scope_dictionary_popup_note =>
+      'Works while the pointer is over a dictionary popup';
 }
 
 /// Flat map(s) containing all translations.
@@ -97026,6 +97356,24 @@ extension on _StringsEn {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -102032,6 +102380,24 @@ extension on _StringsAr {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -107059,6 +107425,24 @@ extension on _StringsDe {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -112085,6 +112469,24 @@ extension on _StringsEs {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -117117,6 +117519,24 @@ extension on _StringsFr {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -122131,6 +122551,24 @@ extension on _StringsId {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -127160,6 +127598,24 @@ extension on _StringsIt {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -132151,6 +132607,24 @@ extension on _StringsJa {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -137146,6 +137620,24 @@ extension on _StringsKo {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -142168,6 +142660,24 @@ extension on _StringsNl {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -147187,6 +147697,24 @@ extension on _StringsPtBr {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -152211,6 +152739,24 @@ extension on _StringsRu {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -157219,6 +157765,24 @@ extension on _StringsTh {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -162236,6 +162800,24 @@ extension on _StringsTr {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -167248,6 +167830,24 @@ extension on _StringsVi {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }
@@ -172221,6 +172821,24 @@ extension on _StringsZhCn {
         return '云端识别失败';
       case 'manga_ocr_mobile_note':
         return '移动端下载的模型用于漫画阅读页的框选识别。';
+      case 'shortcut_scope_dictionary_popup':
+        return '查词弹窗';
+      case 'shortcut_action_popup_next_entry':
+        return '下一个词条';
+      case 'shortcut_action_popup_prev_entry':
+        return '上一个词条';
+      case 'shortcut_wheel':
+        return '鼠标滚轮';
+      case 'shortcut_press_wheel':
+        return '按住修饰键在此滚动滚轮';
+      case 'shortcut_wheel_needs_modifier':
+        return '裸滚轮用于滚动弹窗内容，请按住 Alt / Ctrl / Shift 再滚';
+      case 'shortcut_wheel_up':
+        return '滚轮向上';
+      case 'shortcut_wheel_down':
+        return '滚轮向下';
+      case 'shortcut_scope_dictionary_popup_note':
+        return '鼠标位于查词弹窗上时生效';
       default:
         return null;
     }
@@ -177207,6 +177825,24 @@ extension on _StringsZhHk {
         return 'Cloud recognition failed';
       case 'manga_ocr_mobile_note':
         return 'On mobile, the recognition model powers box scan in the manga reader.';
+      case 'shortcut_scope_dictionary_popup':
+        return 'Dictionary popup';
+      case 'shortcut_action_popup_next_entry':
+        return 'Next word entry';
+      case 'shortcut_action_popup_prev_entry':
+        return 'Previous word entry';
+      case 'shortcut_wheel':
+        return 'Mouse wheel';
+      case 'shortcut_press_wheel':
+        return 'Hold a modifier key and scroll here';
+      case 'shortcut_wheel_needs_modifier':
+        return 'A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling';
+      case 'shortcut_wheel_up':
+        return 'Wheel up';
+      case 'shortcut_wheel_down':
+        return 'Wheel down';
+      case 'shortcut_scope_dictionary_popup_note':
+        return 'Works while the pointer is over a dictionary popup';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "模型名",
   "manga_cloud_ocr_privacy": "点击「云端重试」时，所选图片区域将用你自备的 API Key 发送至 Google Gemini API；仅在你手动触发时才会上传。",
   "manga_cloud_ocr_failed": "云端识别失败",
-  "manga_ocr_mobile_note": "移动端下载的模型用于漫画阅读页的框选识别。"
+  "manga_ocr_mobile_note": "移动端下载的模型用于漫画阅读页的框选识别。",
+  "shortcut_scope_dictionary_popup": "查词弹窗",
+  "shortcut_action_popup_next_entry": "下一个词条",
+  "shortcut_action_popup_prev_entry": "上一个词条",
+  "shortcut_wheel": "鼠标滚轮",
+  "shortcut_press_wheel": "按住修饰键在此滚动滚轮",
+  "shortcut_wheel_needs_modifier": "裸滚轮用于滚动弹窗内容，请按住 Alt / Ctrl / Shift 再滚",
+  "shortcut_wheel_up": "滚轮向上",
+  "shortcut_wheel_down": "滚轮向下",
+  "shortcut_scope_dictionary_popup_note": "鼠标位于查词弹窗上时生效"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2449,5 +2449,14 @@
   "manga_cloud_ocr_model": "Model name",
   "manga_cloud_ocr_privacy": "When you tap Cloud retry, the selected image area is sent to the Google Gemini API with your own API key. Nothing is uploaded unless you trigger it manually.",
   "manga_cloud_ocr_failed": "Cloud recognition failed",
-  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader."
+  "manga_ocr_mobile_note": "On mobile, the recognition model powers box scan in the manga reader.",
+  "shortcut_scope_dictionary_popup": "Dictionary popup",
+  "shortcut_action_popup_next_entry": "Next word entry",
+  "shortcut_action_popup_prev_entry": "Previous word entry",
+  "shortcut_wheel": "Mouse wheel",
+  "shortcut_press_wheel": "Hold a modifier key and scroll here",
+  "shortcut_wheel_needs_modifier": "A bare wheel scrolls the popup — hold Alt / Ctrl / Shift while scrolling",
+  "shortcut_wheel_up": "Wheel up",
+  "shortcut_wheel_down": "Wheel down",
+  "shortcut_scope_dictionary_popup_note": "Works while the pointer is over a dictionary popup"
 }

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -2367,6 +2367,17 @@ class AppModel with ChangeNotifier {
         ]),
       ]);
 
+      // 弹窗进程也要加载用户的快捷键绑定：弹窗内的「上/下一个词条」（Alt+滚轮）由
+      // popup_settings_injection 把 shortcutRegistry 里的滚轮绑定注入给 popup.js，
+      // 不加载就只能发默认值、用户改的键在这个进程里不生效。与主 initialise() 同样
+      // 排在 ReaderHibikiSource.initialise() 之后（BUG-207：偏好缓存必须先就位，
+      // 否则读到空缓存会把用户快照写成 's:null'）。
+      await loadShortcutRegistry(
+        shortcutRegistry,
+        ReaderHibikiSource.instance,
+        defaultTargetPlatform,
+      );
+
       debugPrint('[Hibiki-popup] init: DONE');
       _isInitialised = true;
       // TODO-855: prime the prefs-version watermark from the freshly loaded

--- a/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
@@ -15,6 +15,10 @@ import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_webview.dart';
+import 'package:hibiki/src/shortcuts/input_binding.dart';
+import 'package:hibiki/src/shortcuts/shortcut_action.dart';
+import 'package:hibiki/src/shortcuts/shortcut_defaults.dart';
+import 'package:hibiki/src/shortcuts/shortcut_registry.dart';
 import 'package:hibiki/src/utils/adaptive/adaptive_platform.dart';
 import 'package:hibiki/src/utils/popup_theme_css.dart';
 import 'package:hibiki/src/reader/dictionary_font_css.dart';
@@ -253,6 +257,48 @@ String buildPopupEntriesJs(DictionarySearchResult result) {
 ''';
 }
 
+/// 查词弹窗「上/下一个词条」的滚轮绑定 JSON（注入成 `window.__hoshiEntryWheelBindings`）。
+///
+/// 这两个动作的执行体在 popup.js —— 弹窗内容是 WebView，滚轮事件先到它的 JS，Dart
+/// 侧根本收不到（也不该收：只有指针真在弹窗内才算数）。所以「可改键」这件事就是把
+/// 注册表里的绑定翻译成 JS 能直接比对的形状：
+///
+/// ```json
+/// {"next":[{"dir":"down","mods":["alt"]}],"prev":[{"dir":"up","mods":["alt"]}]}
+/// ```
+///
+/// `dir` 取 `WheelEvent.deltaY` 的符号，`mods` 是必须**恰好**按下的修饰键集合
+/// （popup.js 侧全等比对，Alt+滚轮绝不会被 Ctrl+Alt+滚轮误触）。绑定为空时发空表，
+/// popup.js 据此关掉该方向（而不是回退到默认，否则用户清空绑定等于没清）。
+String popupEntryWheelBindingsJson(
+  HibikiShortcutRegistry registry,
+  TargetPlatform platform,
+) {
+  // 注册表还没装载时（弹窗进程的精简初始化早于 loadShortcutRegistry，或测试里的
+  // 裸 registry）每个动作都读到空绑定 —— 而空表在 popup.js 那边的语义是「用户关掉
+  // 了这个方向」，直接下发会让 Alt+滚轮静默失效。这种情况下回落到平台默认表。
+  final Map<ShortcutAction, ShortcutBindingSet>? fallback =
+      registry.isLoaded ? null : ShortcutDefaults.forPlatform(platform);
+  List<WheelBinding> bindingsOf(ShortcutAction action) => fallback == null
+      ? registry.bindingsFor(action).wheelBindings
+      : (fallback[action]?.wheelBindings ?? const <WheelBinding>[]);
+  List<Map<String, Object>> encode(ShortcutAction action) =>
+      <Map<String, Object>>[
+        for (final WheelBinding b in bindingsOf(action))
+          <String, Object>{
+            'dir': b.direction == WheelDirection.up ? 'up' : 'down',
+            'mods': b.modifiers
+                .map((ModifierKey m) => m.label.toLowerCase())
+                .toList(growable: false)
+              ..sort(),
+          },
+      ];
+  return jsonEncode(<String, Object>{
+    'next': encode(ShortcutAction.popupNextEntry),
+    'prev': encode(ShortcutAction.popupPrevEntry),
+  });
+}
+
 /// 静态设置负载（主题变量/词典字体/图标字体覆盖/zoom/开关/名单/词典样式/自定义
 /// CSS）：只随主题、设置、词典集变化，不随查词变化。in-app 路径对 [PopupStaticSettingsJs.combined]
 /// 做串级比对，变了才随下一次推送重发。
@@ -299,6 +345,11 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
     // BUG-1026: 查词弹窗滚轮速度倍率。popup.js 的 wheel 监听器把 factor 乘以它
     // （缺省 1.0）。三种 in-app 弹窗都经此 head 注入；浏览器扩展走 theme 通道另发。
     window.__hoshiPopupWheelSpeed = ${appModel.popupWheelSpeed};
+    // 查词弹窗「上/下一个词条」的滚轮绑定（ShortcutAction.popupNextEntry /
+    // popupPrevEntry，默认 Alt+滚轮下/上）。popup.js 的 wheel 监听读它，命中即调
+    // hoshiFocusDictionaryEntryMove 并吃掉该事件（不滚动内容）。三种 in-app 弹窗
+    // 都经此 head 注入；浏览器扩展没有这条注入通道，用 popup.js 里的同款默认值。
+    window.__hoshiEntryWheelBindings = ${popupEntryWheelBindingsJson(appModel.shortcutRegistry, theme.platform)};
     window.audioSources = ${jsonEncode(appModel.enabledAudioSources)};
     window.needsAudio = true;
     window.lookupAudioVolume = ${ReaderHibikiSource.instance.lookupAudioVolumeGain.clamp(0.0, 1.0).toStringAsFixed(4)};

--- a/hibiki/lib/src/pages/implementations/shortcut_settings/action_tile.part.dart
+++ b/hibiki/lib/src/pages/implementations/shortcut_settings/action_tile.part.dart
@@ -44,6 +44,9 @@ class _ActionTile extends StatelessWidget {
         ),
       for (final MouseBinding b in bindings.mouseBindings)
         _MouseChip(binding: b),
+      // 滚轮绑定（Alt+滚轮…）与鼠标按钮同款图标 chip，列表视图里同样可见。
+      for (final WheelBinding b in bindings.wheelBindings)
+        _InputIconChip(icon: b.icon, label: b.label),
     ];
 
     // TODO-944: the whole row taps into the SAME assign/edit flow, so unmapped
@@ -72,8 +75,8 @@ class _ActionTile extends StatelessWidget {
   }
 }
 
-/// TODO-1050b: 鼠标绑定的小图标 chip（HibikiTagChip 无 leading icon 位，这里用同款
-/// surface 观感自绘一个「图标 + 名称」的小 chip，与文字 chip 并排展示，不改公共组件）。
+/// TODO-1050b: 鼠标绑定的小图标 chip。展示逻辑本身与通道无关（滚轮绑定也用它），
+/// 故实际绘制在 [_InputIconChip]，这里只做「MouseBinding → 图标 + 名称」的薄壳。
 class _MouseChip extends StatelessWidget {
   const _MouseChip({required this.binding, this.onDeleted});
 
@@ -81,6 +84,29 @@ class _MouseChip extends StatelessWidget {
 
   /// TODO-1088: when non-null a trailing delete affordance is shown (edit
   /// dialog); null keeps it a plain read-only chip (list-view display).
+  final VoidCallback? onDeleted;
+
+  @override
+  Widget build(BuildContext context) => _InputIconChip(
+        icon: binding.icon,
+        label: binding.label,
+        onDeleted: onDeleted,
+      );
+}
+
+/// 「图标 + 名称」的小 chip（HibikiTagChip 无 leading icon 位，这里用同款 surface
+/// 观感自绘，与文字 chip 并排展示，不改公共组件）。鼠标按钮与滚轮两条通道共用。
+class _InputIconChip extends StatelessWidget {
+  const _InputIconChip({
+    required this.icon,
+    required this.label,
+    this.onDeleted,
+  });
+
+  final IconData icon;
+  final String label;
+
+  /// 非空时显示删除按钮（编辑对话框）；null 是只读展示（列表视图）。
   final VoidCallback? onDeleted;
 
   @override
@@ -100,10 +126,10 @@ class _MouseChip extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          Icon(binding.icon, size: 14, color: fg),
+          Icon(icon, size: 14, color: fg),
           SizedBox(width: tokens.spacing.gap * 0.375),
           Text(
-            binding.label,
+            label,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: tokens.type.metadata.copyWith(

--- a/hibiki/lib/src/pages/implementations/shortcut_settings/binding_edit_dialog.part.dart
+++ b/hibiki/lib/src/pages/implementations/shortcut_settings/binding_edit_dialog.part.dart
@@ -77,21 +77,25 @@ class ShortcutBindingEditResult {
     this.keyboardReassignments = const <InputBinding>[],
     this.gamepadReassignments = const <GamepadBinding>[],
     this.mouseReassignments = const <MouseBinding>[],
+    this.wheelReassignments = const <WheelBinding>[],
   });
 
   final ShortcutBindingSet bindings;
   final List<InputBinding> keyboardReassignments;
   final List<GamepadBinding> gamepadReassignments;
   final List<MouseBinding> mouseReassignments;
+  final List<WheelBinding> wheelReassignments;
 }
 
 class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
   late List<InputBinding> _keyboard;
   late List<GamepadBinding> _gamepad;
   late List<MouseBinding> _mouse;
+  late List<WheelBinding> _wheel;
   final List<InputBinding> _keyboardReassignments = <InputBinding>[];
   final List<GamepadBinding> _gamepadReassignments = <GamepadBinding>[];
   final List<MouseBinding> _mouseReassignments = <MouseBinding>[];
+  final List<WheelBinding> _wheelReassignments = <WheelBinding>[];
   String? _conflictWarning;
   bool _capturing = false;
   // TODO-1088: distinct capture phase for mouse buttons — a bordered region that
@@ -99,6 +103,9 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
   // (keyboard) so pressing a key while mouse-capturing doesn't record a key, and
   // vice-versa.
   bool _mouseCapturing = false;
+  // 滚轮录制：又一个独立捕获相（与键盘/鼠标/手柄互斥）。滚轮事件是 PointerSignal，
+  // 不走 onPointerDown，故它有自己的捕获区。
+  bool _wheelCapturing = false;
   // 手柄实时录键：与键盘/鼠标同一套「捕获区 + 显式停止」交互（此前手柄是下拉
   // 菜单选按钮，三通道交互割裂）。桌面轮询路径按 [GamepadButtonIntent] 分发到
   // 主焦点，Android 原生路径按 gameButton* KeyEvent 冒泡——捕获区两条都接。
@@ -127,6 +134,7 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
     // TODO-1088: mouse bindings are now editable, so seed the draft from the
     // current bindings (was passed straight through from widget.initial before).
     _mouse = List<MouseBinding>.of(widget.initial.mouseBindings);
+    _wheel = List<WheelBinding>.of(widget.initial.wheelBindings);
   }
 
   @override
@@ -166,14 +174,104 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
     });
   }
 
+  void _removeWheel(int index) {
+    setState(() {
+      final WheelBinding removed = _wheel.removeAt(index);
+      _wheelReassignments.removeWhere(
+        (WheelBinding binding) => binding == removed,
+      );
+      _conflictWarning = null;
+    });
+  }
+
   void _clearAll() {
     setState(() {
       _keyboard.clear();
       _gamepad.clear();
       _mouse.clear();
+      _wheel.clear();
       _keyboardReassignments.clear();
       _gamepadReassignments.clear();
       _mouseReassignments.clear();
+      _wheelReassignments.clear();
+      _conflictWarning = null;
+    });
+  }
+
+  void _startWheelCapture() {
+    setState(() {
+      _wheelCapturing = true;
+      _capturing = false;
+      _mouseCapturing = false;
+      _gamepadCapturing = false;
+      _conflictWarning = null;
+    });
+  }
+
+  void _cancelWheelCapture() {
+    setState(() => _wheelCapturing = false);
+  }
+
+  /// 滚轮捕获区里的一次滚动。修饰键读 [HardwareKeyboard]（PointerScrollEvent 不带
+  /// 修饰键位）；**裸滚轮不可绑定**——弹窗里裸滚轮永远是滚动内容，绑了也永不触发，
+  /// 故此时保持捕获态并给出提示，而不是记录一条死绑定。
+  void _onWheelCapturePointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent) return;
+    final double dy = event.scrollDelta.dy;
+    if (dy == 0) return;
+    final Set<ModifierKey> modifiers = <ModifierKey>{};
+    final HardwareKeyboard hw = HardwareKeyboard.instance;
+    if (hw.isControlPressed) modifiers.add(ModifierKey.ctrl);
+    if (hw.isShiftPressed) modifiers.add(ModifierKey.shift);
+    if (hw.isAltPressed) modifiers.add(ModifierKey.alt);
+    if (hw.isMetaPressed) modifiers.add(ModifierKey.meta);
+    if (modifiers.isEmpty) {
+      setState(() => _conflictWarning = t.shortcut_wheel_needs_modifier);
+      return;
+    }
+    unawaited(_addWheel(WheelBinding(
+      dy > 0 ? WheelDirection.down : WheelDirection.up,
+      modifiers: modifiers,
+    )));
+  }
+
+  /// 与 [_addMouse] 同形的三段式：草稿内重复 → 同组冲突 → 确认后重分配。
+  Future<void> _addWheel(WheelBinding binding) async {
+    if (_wheel.contains(binding)) {
+      setState(() {
+        _wheelCapturing = false;
+        _conflictWarning = t.shortcut_conflict(s: widget.action.label);
+      });
+      return;
+    }
+
+    final ShortcutAction? conflict = widget.registry.hasWheelConflict(
+      widget.action.scope,
+      binding,
+      exclude: widget.action,
+    );
+
+    if (conflict != null) {
+      setState(() {
+        _wheelCapturing = false;
+        _conflictWarning = t.shortcut_conflict(s: conflict.label);
+      });
+      final bool confirmed = await _showConflictReassignmentDialog(conflict);
+      if (!confirmed || !mounted) return;
+      if (_wheel.contains(binding)) return;
+      setState(() {
+        _wheel.add(binding);
+        if (!_wheelReassignments.contains(binding)) {
+          _wheelReassignments.add(binding);
+        }
+        _conflictWarning = null;
+      });
+      return;
+    }
+
+    setState(() {
+      _wheel.add(binding);
+      _wheelCapturing = false;
       _conflictWarning = null;
     });
   }
@@ -479,6 +577,16 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    // 只渲染这个 scope 真正会被消费的通道（见 [ShortcutScope.channels]）：查词弹窗
+    // 的词条导航只由弹窗 WebView 的滚轮触发，给它键盘/手柄入口等于制造死绑定。
+    // 已有绑定即使通道被关也照常显示（历史快照不隐身，可删）。
+    final Set<ShortcutChannel> channels = widget.action.scope.channels;
+    final bool showKeyboard =
+        channels.contains(ShortcutChannel.keyboard) || _keyboard.isNotEmpty;
+    final bool showGamepad =
+        channels.contains(ShortcutChannel.gamepad) || _gamepad.isNotEmpty;
+    final bool showWheel =
+        channels.contains(ShortcutChannel.wheel) || _wheel.isNotEmpty;
 
     return HibikiDialogFrame(
       maxWidth: 520,
@@ -505,112 +613,34 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             // Keyboard section
-            Text(
-              t.shortcut_keyboard,
-              style: themeData.textTheme.labelLarge,
-            ),
-            SizedBox(height: tokens.spacing.gap / 2),
-            Wrap(
-              spacing: tokens.spacing.gap / 2,
-              runSpacing: tokens.spacing.gap / 2,
-              children: <Widget>[
-                for (int i = 0; i < _keyboard.length; i++)
-                  HibikiTagChip(
-                    label: _keyboard[i].displayLabel,
-                    tone: HibikiTagChipTone.surface,
-                    onDeleted: () => _removeKeyboard(i),
-                  ),
-              ],
-            ),
-            SizedBox(height: tokens.spacing.gap),
-            if (_capturing)
-              Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: <Widget>[
-                  Focus(
-                    focusNode: _captureFocusNode,
-                    autofocus: true,
-                    onKeyEvent: _onKeyEvent,
-                    child: Container(
-                      width: double.infinity,
-                      padding: EdgeInsets.symmetric(
-                        vertical: tokens.spacing.gap + 4,
-                        horizontal: tokens.spacing.gap,
-                      ),
-                      decoration: BoxDecoration(
-                        border:
-                            Border.all(color: themeData.colorScheme.primary),
-                        borderRadius: tokens.radii.controlRadius,
-                      ),
-                      child: Text(
-                        t.shortcut_press_key,
-                        textAlign: TextAlign.center,
-                        style: themeData.textTheme.bodyMedium?.copyWith(
-                          color: themeData.colorScheme.primary,
-                        ),
-                      ),
-                    ),
-                  ),
-                  Align(
-                    alignment: Alignment.centerRight,
-                    child: TextButton(
-                      key: const Key('shortcut_stop_capture'),
-                      onPressed: _cancelCapture,
-                      child: Text(t.shortcut_stop_capture),
-                    ),
-                  ),
-                ],
-              )
-            else
-              TextButton.icon(
-                icon: const Icon(Icons.add, size: 18),
-                label: Text(t.shortcut_keyboard),
-                onPressed: _startCapture,
+            if (showKeyboard) ...<Widget>[
+              Text(
+                t.shortcut_keyboard,
+                style: themeData.textTheme.labelLarge,
               ),
-
-            const Divider(height: 24),
-
-            // Gamepad section
-            Text(
-              t.shortcut_gamepad,
-              style: themeData.textTheme.labelLarge,
-            ),
-            SizedBox(height: tokens.spacing.gap / 2),
-            Wrap(
-              spacing: tokens.spacing.gap / 2,
-              runSpacing: tokens.spacing.gap / 2,
-              children: <Widget>[
-                for (int i = 0; i < _gamepad.length; i++)
-                  HibikiTagChip(
-                    label: _gamepad[i].button.label,
-                    tone: HibikiTagChipTone.surface,
-                    onDeleted: () => _removeGamepad(i),
-                  ),
-              ],
-            ),
-            SizedBox(height: tokens.spacing.gap),
-            if (_gamepadCapturing)
-              Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
+              SizedBox(height: tokens.spacing.gap / 2),
+              Wrap(
+                spacing: tokens.spacing.gap / 2,
+                runSpacing: tokens.spacing.gap / 2,
                 children: <Widget>[
-                  // 桌面轮询路径：GamepadService 把按键作为 GamepadButtonIntent
-                  // 分发到主焦点上下文；这里在捕获 Focus 之上挂 Actions 消费，
-                  // 返回 true 即阻断 A→Activate / B→返回 / 十字键→移焦点等回退。
-                  Actions(
-                    actions: <Type, Action<Intent>>{
-                      GamepadButtonIntent: CallbackAction<GamepadButtonIntent>(
-                        onInvoke: (GamepadButtonIntent intent) {
-                          _recordCapturedGamepadButton(intent.button);
-                          return true;
-                        },
-                      ),
-                    },
-                    child: Focus(
-                      focusNode: _gamepadCaptureFocusNode,
+                  for (int i = 0; i < _keyboard.length; i++)
+                    HibikiTagChip(
+                      label: _keyboard[i].displayLabel,
+                      tone: HibikiTagChipTone.surface,
+                      onDeleted: () => _removeKeyboard(i),
+                    ),
+                ],
+              ),
+              SizedBox(height: tokens.spacing.gap),
+              if (_capturing)
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    Focus(
+                      focusNode: _captureFocusNode,
                       autofocus: true,
-                      onKeyEvent: _onGamepadCaptureKeyEvent,
+                      onKeyEvent: _onKeyEvent,
                       child: Container(
                         width: double.infinity,
                         padding: EdgeInsets.symmetric(
@@ -618,13 +648,12 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
                           horizontal: tokens.spacing.gap,
                         ),
                         decoration: BoxDecoration(
-                          border: Border.all(
-                            color: themeData.colorScheme.primary,
-                          ),
+                          border:
+                              Border.all(color: themeData.colorScheme.primary),
                           borderRadius: tokens.radii.controlRadius,
                         ),
                         child: Text(
-                          t.shortcut_press_gamepad,
+                          t.shortcut_press_key,
                           textAlign: TextAlign.center,
                           style: themeData.textTheme.bodyMedium?.copyWith(
                             color: themeData.colorScheme.primary,
@@ -632,67 +661,150 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
                         ),
                       ),
                     ),
-                  ),
-                  Align(
-                    alignment: Alignment.centerRight,
-                    child: TextButton(
-                      key: const Key('shortcut_stop_gamepad_capture'),
-                      onPressed: _cancelGamepadCapture,
-                      child: Text(t.shortcut_stop_capture),
-                    ),
-                  ),
-                ],
-              )
-            else
-              Wrap(
-                spacing: tokens.spacing.gap,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: <Widget>[
-                  TextButton.icon(
-                    key: const Key('shortcut_add_gamepad_capture'),
-                    icon: const Icon(Icons.add, size: 18),
-                    label: Text(t.shortcut_gamepad),
-                    onPressed: _startGamepadCapture,
-                  ),
-                  // 无手柄在手/远程配置时的兜底：仍可从列表点选按钮。
-                  HibikiOverflowMenu<GamepadButton>(
-                    onSelected: (GamepadButton button) {
-                      unawaited(_addGamepad(button));
-                    },
-                    items: <PopupMenuEntry<GamepadButton>>[
-                      for (final GamepadButton btn in GamepadButton.values)
-                        HibikiPopupMenuItem<GamepadButton>(
-                          label: btn.label,
-                          icon: Icons.gamepad_outlined,
-                          value: btn,
-                        ),
-                    ],
-                    padding: EdgeInsets.zero,
-                    child: Padding(
-                      padding: EdgeInsets.symmetric(
-                        vertical: tokens.spacing.gap / 2,
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: TextButton(
+                        key: const Key('shortcut_stop_capture'),
+                        onPressed: _cancelCapture,
+                        child: Text(t.shortcut_stop_capture),
                       ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: <Widget>[
-                          Icon(
-                            Icons.list_outlined,
-                            size: 18,
-                            color: themeData.colorScheme.primary,
+                    ),
+                  ],
+                )
+              else
+                TextButton.icon(
+                  icon: const Icon(Icons.add, size: 18),
+                  label: Text(t.shortcut_keyboard),
+                  onPressed: _startCapture,
+                ),
+            ],
+
+            // Gamepad section
+            if (showGamepad) ...<Widget>[
+              if (showKeyboard) const Divider(height: 24),
+              Text(
+                t.shortcut_gamepad,
+                style: themeData.textTheme.labelLarge,
+              ),
+              SizedBox(height: tokens.spacing.gap / 2),
+              Wrap(
+                spacing: tokens.spacing.gap / 2,
+                runSpacing: tokens.spacing.gap / 2,
+                children: <Widget>[
+                  for (int i = 0; i < _gamepad.length; i++)
+                    HibikiTagChip(
+                      label: _gamepad[i].button.label,
+                      tone: HibikiTagChipTone.surface,
+                      onDeleted: () => _removeGamepad(i),
+                    ),
+                ],
+              ),
+              SizedBox(height: tokens.spacing.gap),
+              if (_gamepadCapturing)
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    // 桌面轮询路径：GamepadService 把按键作为 GamepadButtonIntent
+                    // 分发到主焦点上下文；这里在捕获 Focus 之上挂 Actions 消费，
+                    // 返回 true 即阻断 A→Activate / B→返回 / 十字键→移焦点等回退。
+                    Actions(
+                      actions: <Type, Action<Intent>>{
+                        GamepadButtonIntent:
+                            CallbackAction<GamepadButtonIntent>(
+                          onInvoke: (GamepadButtonIntent intent) {
+                            _recordCapturedGamepadButton(intent.button);
+                            return true;
+                          },
+                        ),
+                      },
+                      child: Focus(
+                        focusNode: _gamepadCaptureFocusNode,
+                        autofocus: true,
+                        onKeyEvent: _onGamepadCaptureKeyEvent,
+                        child: Container(
+                          width: double.infinity,
+                          padding: EdgeInsets.symmetric(
+                            vertical: tokens.spacing.gap + 4,
+                            horizontal: tokens.spacing.gap,
                           ),
-                          SizedBox(width: tokens.spacing.gap / 2),
-                          Text(
-                            t.shortcut_gamepad_pick_list,
-                            style: TextStyle(
+                          decoration: BoxDecoration(
+                            border: Border.all(
+                              color: themeData.colorScheme.primary,
+                            ),
+                            borderRadius: tokens.radii.controlRadius,
+                          ),
+                          child: Text(
+                            t.shortcut_press_gamepad,
+                            textAlign: TextAlign.center,
+                            style: themeData.textTheme.bodyMedium?.copyWith(
                               color: themeData.colorScheme.primary,
                             ),
                           ),
-                        ],
+                        ),
                       ),
                     ),
-                  ),
-                ],
-              ),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: TextButton(
+                        key: const Key('shortcut_stop_gamepad_capture'),
+                        onPressed: _cancelGamepadCapture,
+                        child: Text(t.shortcut_stop_capture),
+                      ),
+                    ),
+                  ],
+                )
+              else
+                Wrap(
+                  spacing: tokens.spacing.gap,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: <Widget>[
+                    TextButton.icon(
+                      key: const Key('shortcut_add_gamepad_capture'),
+                      icon: const Icon(Icons.add, size: 18),
+                      label: Text(t.shortcut_gamepad),
+                      onPressed: _startGamepadCapture,
+                    ),
+                    // 无手柄在手/远程配置时的兜底：仍可从列表点选按钮。
+                    HibikiOverflowMenu<GamepadButton>(
+                      onSelected: (GamepadButton button) {
+                        unawaited(_addGamepad(button));
+                      },
+                      items: <PopupMenuEntry<GamepadButton>>[
+                        for (final GamepadButton btn in GamepadButton.values)
+                          HibikiPopupMenuItem<GamepadButton>(
+                            label: btn.label,
+                            icon: Icons.gamepad_outlined,
+                            value: btn,
+                          ),
+                      ],
+                      padding: EdgeInsets.zero,
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(
+                          vertical: tokens.spacing.gap / 2,
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                            Icon(
+                              Icons.list_outlined,
+                              size: 18,
+                              color: themeData.colorScheme.primary,
+                            ),
+                            SizedBox(width: tokens.spacing.gap / 2),
+                            Text(
+                              t.shortcut_gamepad_pick_list,
+                              style: TextStyle(
+                                color: themeData.colorScheme.primary,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+            ],
 
             // Mouse section (TODO-1088): editable. Existing bindings render as
             // deletable chips; on desktop a capture region records the next
@@ -702,8 +814,9 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
             // hidden and only inherited bindings (if any) show read-only — Never
             // break userspace: nothing captured, nothing lost.
             if (_mouse.isNotEmpty ||
-                _mouseBindingSupported(defaultTargetPlatform)) ...<Widget>[
-              const Divider(height: 24),
+                (channels.contains(ShortcutChannel.mouse) &&
+                    _mouseBindingSupported(defaultTargetPlatform))) ...<Widget>[
+              if (showKeyboard || showGamepad) const Divider(height: 24),
               Text(
                 t.shortcut_mouse_button,
                 style: themeData.textTheme.labelLarge,
@@ -772,6 +885,83 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
               ],
             ],
 
+            // 滚轮章节：修饰键 + 滚轮方向（查词弹窗的「上/下一个词条」）。捕获区吃
+            // PointerSignal 而非 PointerDown，其余（重复/冲突/重分配/删除 chip）与
+            // 键盘、手柄、鼠标三条完全同形。移动端没有滚轮，但 Android 可外接鼠标，
+            // 故这里不按平台隐藏——按 scope 的通道能力隐藏（见上）。
+            if (showWheel) ...<Widget>[
+              if (showKeyboard ||
+                  showGamepad ||
+                  _mouse.isNotEmpty ||
+                  channels.contains(ShortcutChannel.mouse))
+                const Divider(height: 24),
+              Text(
+                t.shortcut_wheel,
+                style: themeData.textTheme.labelLarge,
+              ),
+              SizedBox(height: tokens.spacing.gap / 2),
+              Wrap(
+                spacing: tokens.spacing.gap / 2,
+                runSpacing: tokens.spacing.gap / 2,
+                children: <Widget>[
+                  for (int i = 0; i < _wheel.length; i++)
+                    _InputIconChip(
+                      icon: _wheel[i].icon,
+                      label: _wheel[i].label,
+                      onDeleted: () => _removeWheel(i),
+                    ),
+                ],
+              ),
+              SizedBox(height: tokens.spacing.gap),
+              if (_wheelCapturing)
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    Listener(
+                      key: const Key('shortcut_wheel_capture_region'),
+                      onPointerSignal: _onWheelCapturePointerSignal,
+                      behavior: HitTestBehavior.opaque,
+                      child: Container(
+                        width: double.infinity,
+                        padding: EdgeInsets.symmetric(
+                          vertical: tokens.spacing.gap + 4,
+                          horizontal: tokens.spacing.gap,
+                        ),
+                        decoration: BoxDecoration(
+                          border: Border.all(
+                            color: themeData.colorScheme.primary,
+                          ),
+                          borderRadius: tokens.radii.controlRadius,
+                        ),
+                        child: Text(
+                          t.shortcut_press_wheel,
+                          textAlign: TextAlign.center,
+                          style: themeData.textTheme.bodyMedium?.copyWith(
+                            color: themeData.colorScheme.primary,
+                          ),
+                        ),
+                      ),
+                    ),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: TextButton(
+                        key: const Key('shortcut_stop_wheel_capture'),
+                        onPressed: _cancelWheelCapture,
+                        child: Text(t.shortcut_stop_capture),
+                      ),
+                    ),
+                  ],
+                )
+              else
+                TextButton.icon(
+                  key: const Key('shortcut_add_wheel'),
+                  icon: const Icon(Icons.mouse_outlined, size: 18),
+                  label: Text(t.shortcut_wheel),
+                  onPressed: _startWheelCapture,
+                ),
+            ],
+
             // Conflict warning
             if (_conflictWarning != null) ...[
               SizedBox(height: tokens.spacing.gap),
@@ -810,6 +1000,7 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
                     gamepadBindings:
                         List<GamepadBinding>.unmodifiable(_gamepad),
                     mouseBindings: List<MouseBinding>.unmodifiable(_mouse),
+                    wheelBindings: List<WheelBinding>.unmodifiable(_wheel),
                   ),
                   keyboardReassignments:
                       List<InputBinding>.unmodifiable(_keyboardReassignments),
@@ -817,6 +1008,8 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
                       List<GamepadBinding>.unmodifiable(_gamepadReassignments),
                   mouseReassignments:
                       List<MouseBinding>.unmodifiable(_mouseReassignments),
+                  wheelReassignments:
+                      List<WheelBinding>.unmodifiable(_wheelReassignments),
                 ),
               ),
               child: Text(MaterialLocalizations.of(context).okButtonLabel),

--- a/hibiki/lib/src/pages/implementations/shortcut_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/shortcut_settings_page.dart
@@ -176,6 +176,7 @@ class _ShortcutSettingsPageState extends BasePageState<ShortcutSettingsPage> {
       removeKeyboardConflicts: result.keyboardReassignments,
       removeGamepadConflicts: result.gamepadReassignments,
       removeMouseConflicts: result.mouseReassignments,
+      removeWheelConflicts: result.wheelReassignments,
     );
     await _save();
     setState(() {});
@@ -453,16 +454,29 @@ class _ShortcutSettingsPageState extends BasePageState<ShortcutSettingsPage> {
         ],
       );
     }
+    // 可视化模式只对真的会消费键盘 / 手柄的 scope 有意义。查词弹窗的词条导航是纯
+    // 滚轮通道（[ShortcutScope.channels]），给它画键盘图/手柄图不但是空图，点空键位
+    // 还会写出一条永不触发的死绑定——这类 scope 在可视化模式下也回落到列表行。
+    final bool hasVisualChannels =
+        scope.channels.contains(ShortcutChannel.keyboard) ||
+            scope.channels.contains(ShortcutChannel.gamepad);
     return AdaptiveSettingsSection(
       title: scope.label,
       children: <Widget>[
+        // 纯弹窗内滚轮触发，用户看不到「在哪儿按」时会以为没生效，故给一行说明。
+        if (scope == ShortcutScope.dictionaryPopup)
+          AdaptiveSettingsRow(
+            title: t.shortcut_scope_dictionary_popup_note,
+            icon: Icons.info_outline,
+            showIcon: true,
+          ),
         AdaptiveSettingsRow(
           title: t.shortcut_reset_defaults,
           icon: Icons.restore_outlined,
           showIcon: true,
           onTap: () => _confirmResetScope(scope),
         ),
-        if (_visualMode)
+        if (_visualMode && hasVisualChannels)
           Padding(
             padding: EdgeInsets.symmetric(
               horizontal: tokens.spacing.rowHorizontal,

--- a/hibiki/lib/src/shortcuts/input_binding.dart
+++ b/hibiki/lib/src/shortcuts/input_binding.dart
@@ -518,17 +518,101 @@ class MouseBinding {
   String toString() => 'MouseBinding(${serialize()})';
 }
 
+/// 滚轮方向。滚轮是**离散事件**（没有按下/抬起），故它自成一个绑定通道，而不是
+/// 塞进 [MouseBinding] 的按钮编号：按钮绑定按 `MouseEvent.button` 分发（中键/右键/
+/// 侧键），滚轮按 `WheelEvent.deltaY` 的符号分发，两者的运行时判据根本不同。
+enum WheelDirection {
+  /// 向上滚（`deltaY < 0`）。
+  up('WheelUp'),
+
+  /// 向下滚（`deltaY > 0`）。
+  down('WheelDown');
+
+  const WheelDirection(this.token);
+
+  /// 持久化 / 显示用的稳定 token（与 [InputBinding] 的键名同风格）。
+  final String token;
+
+  static WheelDirection? fromToken(String token) {
+    for (final WheelDirection d in values) {
+      if (d.token == token) return d;
+    }
+    return null;
+  }
+}
+
+/// 「修饰键 + 滚轮方向」绑定（Yomitan 式 Alt+滚轮）。裸滚轮永远是滚动内容，故这个
+/// 通道**要求至少一个修饰键**才有意义——但数据结构不强制（空修饰集合可序列化往返），
+/// 强制留给 UI 的捕获入口，保持数据层纯粹。
+@immutable
+class WheelBinding {
+  const WheelBinding(this.direction, {this.modifiers = const {}});
+
+  final WheelDirection direction;
+  final Set<ModifierKey> modifiers;
+
+  List<String> get _sortedModifierLabels =>
+      (modifiers.toList()..sort((a, b) => a.index.compareTo(b.index)))
+          .map((m) => m.label)
+          .toList(growable: false);
+
+  String serialize() => <String>[
+        ..._sortedModifierLabels,
+        direction.token,
+      ].join('+');
+
+  /// 与 [InputBinding.displayLabel] 同形（`Alt+WheelDown`）。本地化显示名在
+  /// `shortcut_labels.dart` 的 [WheelBindingLabel] 里（那里把方向换成人话）。
+  String get displayLabel => serialize();
+
+  static WheelBinding? deserialize(String s) {
+    if (s.isEmpty) return null;
+    final List<String> parts = s.split('+');
+    final Set<ModifierKey> mods = <ModifierKey>{};
+    WheelDirection? direction;
+    for (final String part in parts) {
+      final ModifierKey? mod = ModifierKey.fromLabel(part);
+      if (mod != null) {
+        mods.add(mod);
+        continue;
+      }
+      direction ??= WheelDirection.fromToken(part);
+    }
+    if (direction == null) return null;
+    return WheelBinding(direction, modifiers: mods);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WheelBinding &&
+          direction == other.direction &&
+          setEquals(modifiers, other.modifiers);
+
+  @override
+  int get hashCode =>
+      Object.hash(direction, Object.hashAllUnordered(modifiers));
+
+  @override
+  String toString() => 'WheelBinding(${serialize()})';
+}
+
 @immutable
 class ShortcutBindingSet {
   const ShortcutBindingSet({
     this.keyboardBindings = const [],
     this.gamepadBindings = const [],
     this.mouseBindings = const [],
+    this.wheelBindings = const [],
   });
 
   final List<InputBinding> keyboardBindings;
   final List<GamepadBinding> gamepadBindings;
   final List<MouseBinding> mouseBindings;
+
+  /// 修饰键 + 滚轮方向（查词弹窗的「上/下一个词条」）。老快照没有这个 key，
+  /// [fromJson] 缺席即空表，不影响任何既有绑定（Never break userspace）。
+  final List<WheelBinding> wheelBindings;
 
   Map<String, dynamic> toJson() => {
         'keyboard':
@@ -537,12 +621,15 @@ class ShortcutBindingSet {
             gamepadBindings.map((b) => b.serialize()).toList(growable: false),
         'mouse':
             mouseBindings.map((b) => b.serialize()).toList(growable: false),
+        'wheel':
+            wheelBindings.map((b) => b.serialize()).toList(growable: false),
       };
 
   factory ShortcutBindingSet.fromJson(Map<String, dynamic> json) {
     final kbRaw = json['keyboard'];
     final gpRaw = json['gamepad'];
     final msRaw = json['mouse'];
+    final whRaw = json['wheel'];
     return ShortcutBindingSet(
       keyboardBindings: kbRaw is List
           ? kbRaw
@@ -565,6 +652,13 @@ class ShortcutBindingSet {
               .whereType<MouseBinding>()
               .toList(growable: false)
           : const [],
+      wheelBindings: whRaw is List
+          ? whRaw
+              .cast<String>()
+              .map(WheelBinding.deserialize)
+              .whereType<WheelBinding>()
+              .toList(growable: false)
+          : const [],
     );
   }
 
@@ -572,10 +666,12 @@ class ShortcutBindingSet {
     List<InputBinding>? keyboardBindings,
     List<GamepadBinding>? gamepadBindings,
     List<MouseBinding>? mouseBindings,
+    List<WheelBinding>? wheelBindings,
   }) =>
       ShortcutBindingSet(
         keyboardBindings: keyboardBindings ?? this.keyboardBindings,
         gamepadBindings: gamepadBindings ?? this.gamepadBindings,
         mouseBindings: mouseBindings ?? this.mouseBindings,
+        wheelBindings: wheelBindings ?? this.wheelBindings,
       );
 }

--- a/hibiki/lib/src/shortcuts/shortcut_action.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_action.dart
@@ -13,7 +13,14 @@ enum ShortcutScope {
   // 绑定注册到操作系统级 hotkey_manager（默认 Ctrl+Alt+D）。它跨页面常驻、不与
   // 任何应用内页面的键盘绑定竞争，故自成独立 co-active 组，冲突检测只扫自己，
   // 绝不与 global/home 等页面 scope 互相牵连。仅桌面（Windows）有意义。
-  globalExternal;
+  globalExternal,
+
+  // 查词弹窗内部的导航动作（Yomitan 式「上/下一个词条」）。这些动作**不经
+  // resolveKeyboard / 页面派发**：弹窗内容是 WebView，输入事件先到 WebView 的
+  // JS，故绑定由 popup_settings_injection 注入给 popup.js，命中即调
+  // hoshiFocusDictionaryEntryMove。它跨所有弹窗宿主（阅读器 / 视频 / 首页词典 /
+  // 桌面全局查词窗）常驻，与任何页面 scope 都不竞争，故自成独立 co-active 组。
+  dictionaryPopup;
 
   // Scopes that are resolved together on the same page. The reader page
   // resolves reader + audiobook bindings; the home page resolves home + global.
@@ -44,9 +51,42 @@ enum ShortcutScope {
       // 应用内 scope 牵连。
       case globalExternal:
         return const <ShortcutScope>[globalExternal];
+      // dictionaryPopup（查词弹窗内导航）同理是独立 co-active 组：它的绑定由弹窗
+      // WebView 的 JS 消费，永不与任何页面 scope 的键位竞争，冲突检测只扫自己。
+      case dictionaryPopup:
+        return const <ShortcutScope>[dictionaryPopup];
+    }
+  }
+
+  /// 本 scope 真正会被消费的输入通道。设置页的编辑对话框据此渲染章节——绑了不会
+  /// 生效的通道根本不给入口，杜绝「设置里能配、按了没反应」的死项（同
+  /// shortcut_action_wiring_guard 的不变式，只是发生在 UI 层）。
+  ///
+  /// 绝大多数 scope 走页面派发，键盘/手柄/鼠标三通道全通；[dictionaryPopup] 的
+  /// 动作只由弹窗 WebView 的滚轮事件触发（见枚举注释），故只开滚轮。
+  Set<ShortcutChannel> get channels {
+    switch (this) {
+      case reader:
+      case audiobook:
+      case home:
+      case global:
+      case video:
+      case gamepad:
+      case globalExternal:
+        return const <ShortcutChannel>{
+          ShortcutChannel.keyboard,
+          ShortcutChannel.gamepad,
+          ShortcutChannel.mouse,
+        };
+      case dictionaryPopup:
+        return const <ShortcutChannel>{ShortcutChannel.wheel};
     }
   }
 }
+
+/// 一个 [ShortcutAction] 可能绑定的输入通道（与 [ShortcutBindingSet] 的四组绑定
+/// 一一对应）。
+enum ShortcutChannel { keyboard, gamepad, mouse, wheel }
 
 enum ShortcutAction {
   // 声明顺序 = 设置页各组的展示顺序（actionsForScope 按 values 声明序过滤），各组
@@ -227,7 +267,20 @@ enum ShortcutAction {
   // 默认 Ctrl+Alt+D），而非页面/媒体 _executeShortcutAction 派发——它是唯一一个
   // 走操作系统热键、不经 resolveKeyboard 的 action。设置页据此渲染出可改键行，
   // 修复「app 外查词快捷键没办法设置」。
-  globalExternalLookup(ShortcutScope.globalExternal, 'global_external_lookup');
+  globalExternalLookup(ShortcutScope.globalExternal, 'global_external_lookup'),
+
+  // 查词弹窗「上/下一个词条」（用户请求，Yomitan 的 Next/Previous entry）：一次查询
+  // 常返回多个词条（.entry），这两个动作把弹窗的词条级焦点（蓝三角 .entry-current）
+  // 移到相邻词条并滚进视口。默认 Alt+滚轮下 / Alt+滚轮上，与 Yomitan 手感一致。
+  //
+  // 执行体不在 Dart 侧：弹窗内容是 WebView，滚轮事件先到 popup.js，故
+  // popup_settings_injection 把这两个动作的滚轮绑定注入成
+  // `window.__hoshiEntryWheelBindings`，popup.js 的 wheel 监听命中即调
+  // `hoshiFocusDictionaryEntryMove('next'|'prev')`（TODO-1325 #5 part1 已有的能力，
+  // 此前只有阅读器选字光标模式下的硬编码 `.` / `,` 能触发，既不可改键也不覆盖
+  // 视频/首页/全局查词的弹窗）。
+  popupNextEntry(ShortcutScope.dictionaryPopup, 'popup_next_entry'),
+  popupPrevEntry(ShortcutScope.dictionaryPopup, 'popup_prev_entry');
 
   const ShortcutAction(this.scope, this.key);
 

--- a/hibiki/lib/src/shortcuts/shortcut_defaults.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_defaults.dart
@@ -390,6 +390,20 @@ class ShortcutDefaults {
     ShortcutAction.globalExternalLookup: _kb([
       _key(LogicalKeyboardKey.keyD, {ModifierKey.ctrl, ModifierKey.alt}),
     ]),
+    // 查词弹窗「上/下一个词条」：默认 Alt+滚轮（Yomitan 的 Next/Previous entry 同款
+    // 手感）。裸滚轮永远滚动弹窗内容，故必须带修饰键；Alt 在 WebView 里没有默认滚轮
+    // 语义（Ctrl+滚轮是缩放、Shift+滚轮是横向滚动，都不能占）。dictionaryPopup 是独立
+    // co-active 组，与任何页面键位不冲突。
+    ShortcutAction.popupNextEntry: const ShortcutBindingSet(
+      wheelBindings: <WheelBinding>[
+        WheelBinding(WheelDirection.down, modifiers: {ModifierKey.alt}),
+      ],
+    ),
+    ShortcutAction.popupPrevEntry: const ShortcutBindingSet(
+      wheelBindings: <WheelBinding>[
+        WheelBinding(WheelDirection.up, modifiers: {ModifierKey.alt}),
+      ],
+    ),
   };
 
   static final Map<ShortcutAction, ShortcutBindingSet> _macOS = {
@@ -406,6 +420,9 @@ class ShortcutDefaults {
         }).toList(growable: false),
         gamepadBindings: entry.value.gamepadBindings,
         mouseBindings: entry.value.mouseBindings,
+        // 滚轮绑定的修饰键不做 Ctrl→Meta 替换：Alt+滚轮在 macOS 上同样空闲，而
+        // Ctrl+滚轮在 macOS 是系统缩放，替换过去反而撞系统手势。
+        wheelBindings: entry.value.wheelBindings,
       ),
   };
 
@@ -437,6 +454,13 @@ class ShortcutDefaults {
           // 无任何 app 内绑定（设置页对该 scope 显示系统级说明文案，不渲染可改键行）。
           case ShortcutScope.globalExternal:
             return const ShortcutBindingSet();
+          // 查词弹窗的词条导航是纯滚轮通道：Android 可接鼠标（平板 / DeX / 桌面
+          // 模式），滚轮事件同样到达弹窗 WebView 的 popup.js，故移动端保留桌面的
+          // Alt+滚轮默认；没有鼠标的设备上它永不触发，无害。
+          case ShortcutScope.dictionaryPopup:
+            return ShortcutBindingSet(
+              wheelBindings: desktop.wheelBindings,
+            );
         }
       }(),
   };

--- a/hibiki/lib/src/shortcuts/shortcut_labels.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_labels.dart
@@ -151,6 +151,10 @@ extension ShortcutActionLabel on ShortcutAction {
         return t.shortcut_action_dpad_right;
       case ShortcutAction.globalExternalLookup:
         return t.shortcut_action_global_external_lookup;
+      case ShortcutAction.popupNextEntry:
+        return t.shortcut_action_popup_next_entry;
+      case ShortcutAction.popupPrevEntry:
+        return t.shortcut_action_popup_prev_entry;
     }
   }
 }
@@ -173,8 +177,28 @@ extension ShortcutScopeLabel on ShortcutScope {
         return t.shortcut_scope_gamepad;
       case ShortcutScope.globalExternal:
         return t.shortcut_scope_global_external;
+      case ShortcutScope.dictionaryPopup:
+        return t.shortcut_scope_dictionary_popup;
     }
   }
+}
+
+/// 滚轮绑定的本地化显示名与小图标（与 [MouseBindingLabel] 同形，供设置页的
+/// chip 复用）。修饰键沿用 [ModifierKey.label] 的英文缩写（Alt/Ctrl/Shift/Meta，
+/// 与键盘 chip 一致），只有方向翻译成人话。
+extension WheelBindingLabel on WheelBinding {
+  String get label {
+    final String direction = switch (this.direction) {
+      WheelDirection.up => t.shortcut_wheel_up,
+      WheelDirection.down => t.shortcut_wheel_down,
+    };
+    if (modifiers.isEmpty) return direction;
+    final List<ModifierKey> sorted = modifiers.toList()
+      ..sort((ModifierKey a, ModifierKey b) => a.index.compareTo(b.index));
+    return '${sorted.map((ModifierKey m) => m.label).join('+')}+$direction';
+  }
+
+  IconData get icon => Icons.mouse_outlined;
 }
 
 /// TODO-1050b: 鼠标绑定的本地化显示名与小图标。

--- a/hibiki/lib/src/shortcuts/shortcut_registry.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_registry.dart
@@ -16,7 +16,7 @@ import 'package:hibiki/src/shortcuts/shortcut_defaults.dart';
 /// 过快捷键设置的用户，其快照里该 action 仍是「旧版本的完整默认」（仅 F），覆盖后新键
 /// （F12）永久丢失 —— 表现为「按 F12 没反应」。迁移只对「用户从未动过该 action（键集
 /// 恰等于旧默认全集）」的快照补回新键，绝不碰用户主动改/删过的绑定。
-const int kShortcutSchemaVersion = 6;
+const int kShortcutSchemaVersion = 7;
 
 /// 持久化 JSON 里记录写入时 schema 版本的保留 key（不是某个 action 的绑定，故单独
 /// 处理，不进 _unknownEntries，也不会被 [ShortcutAction.fromKey] 误解析）。
@@ -28,6 +28,15 @@ class HibikiShortcutRegistry extends ChangeNotifier {
 
   ShortcutBindingSet bindingsFor(ShortcutAction action) =>
       _bindings[action] ?? const ShortcutBindingSet();
+
+  /// 这个注册表是否已经装过绑定（[loadDefaults] / [loadFromJsonString]）。
+  ///
+  /// 未装载时 [bindingsFor] 对**每个** action 都返回空绑定集，这与「用户把某个动作
+  /// 的绑定清空了」在数据上无法区分。绝大多数消费者跑在完成 initialise() 的主进程
+  /// 里、不必关心；但把绑定**序列化下发**给别的运行时（如注入给弹窗 WebView 的
+  /// popup.js）时必须区分：空表在那边的语义是「该动作已被用户关掉」，未装载时误发
+  /// 空表会让功能静默失效。这类调用方用本标志回落到平台默认。
+  bool get isLoaded => _bindings.isNotEmpty;
 
   void loadDefaults(TargetPlatform platform) {
     _bindings
@@ -154,6 +163,14 @@ class HibikiShortcutRegistry extends ChangeNotifier {
     // bump 版本保持不变式诚实。⚠️ 行为面：readerDismissDict（Esc）不再在无弹窗时
     // 退书（执行体侧拆分，见 caret.part.dart），退书统一走 readerExitBook /
     // 返回手势 / 底栏。
+    //
+    // v6 -> v7（查词弹窗 Alt+滚轮词条导航）：新增 popupNextEntry / popupPrevEntry
+    // （dictionaryPopup scope，纯滚轮通道，默认 Alt+滚轮下/上）。**全新 action**，
+    // 老快照里没有它们的 key —— [loadDefaults] 已播种默认，[_loadFromJson] 只覆盖
+    // 快照里显式出现的 key、保留缺席 key 的默认，故老用户升级后天然拿到 Alt+滚轮，
+    // 无需逐个 restore。同时 [ShortcutBindingSet] 新增 `wheel` 序列化字段：老快照
+    // 缺这个 key 时 fromJson 给空表，任何既有 action 的键盘/手柄/鼠标绑定都不受
+    // 影响。这里只需 bump 版本保持「快照版本 < 当前 ⇒ 跑迁移」不变式诚实。
   }
 
   /// 当 [action] 在快照里的键盘绑定**恰等于** [oldDefaultKeyboard]（无序集合相等，
@@ -227,6 +244,7 @@ class HibikiShortcutRegistry extends ChangeNotifier {
     Iterable<InputBinding> removeKeyboardConflicts = const <InputBinding>[],
     Iterable<GamepadBinding> removeGamepadConflicts = const <GamepadBinding>[],
     Iterable<MouseBinding> removeMouseConflicts = const <MouseBinding>[],
+    Iterable<WheelBinding> removeWheelConflicts = const <WheelBinding>[],
   }) {
     final Set<InputBinding> keyboardToRemove =
         Set<InputBinding>.of(removeKeyboardConflicts);
@@ -234,10 +252,13 @@ class HibikiShortcutRegistry extends ChangeNotifier {
         Set<GamepadBinding>.of(removeGamepadConflicts);
     final Set<MouseBinding> mouseToRemove =
         Set<MouseBinding>.of(removeMouseConflicts);
+    final Set<WheelBinding> wheelToRemove =
+        Set<WheelBinding>.of(removeWheelConflicts);
 
     if (keyboardToRemove.isNotEmpty ||
         gamepadToRemove.isNotEmpty ||
-        mouseToRemove.isNotEmpty) {
+        mouseToRemove.isNotEmpty ||
+        wheelToRemove.isNotEmpty) {
       for (final ShortcutScope scope in action.scope.coactiveScopes) {
         for (final ShortcutAction oldAction
             in ShortcutAction.actionsForScope(scope)) {
@@ -252,13 +273,18 @@ class HibikiShortcutRegistry extends ChangeNotifier {
           final List<MouseBinding> mouse = oldBindings.mouseBindings
               .where((MouseBinding b) => !mouseToRemove.contains(b))
               .toList(growable: false);
+          final List<WheelBinding> wheel = oldBindings.wheelBindings
+              .where((WheelBinding b) => !wheelToRemove.contains(b))
+              .toList(growable: false);
           if (keyboard.length != oldBindings.keyboardBindings.length ||
               gamepad.length != oldBindings.gamepadBindings.length ||
-              mouse.length != oldBindings.mouseBindings.length) {
+              mouse.length != oldBindings.mouseBindings.length ||
+              wheel.length != oldBindings.wheelBindings.length) {
             _bindings[oldAction] = oldBindings.copyWith(
               keyboardBindings: keyboard,
               gamepadBindings: gamepad,
               mouseBindings: mouse,
+              wheelBindings: wheel,
             );
           }
         }
@@ -406,6 +432,26 @@ class HibikiShortcutRegistry extends ChangeNotifier {
         if (bindings == null) continue;
         for (final mb in bindings.mouseBindings) {
           if (mb == binding) return action;
+        }
+      }
+    }
+    return null;
+  }
+
+  /// 滚轮绑定的冲突检测，与键盘/手柄/鼠标三条同形：同一 co-active 组里同一
+  /// 「修饰键 + 方向」组合只能属于一个动作，否则后者永远不触发。
+  ShortcutAction? hasWheelConflict(
+    ShortcutScope scope,
+    WheelBinding binding, {
+    required ShortcutAction? exclude,
+  }) {
+    for (final coactive in scope.coactiveScopes) {
+      for (final action in ShortcutAction.actionsForScope(coactive)) {
+        if (action == exclude) continue;
+        final bindings = _bindings[action];
+        if (bindings == null) continue;
+        for (final wb in bindings.wheelBindings) {
+          if (wb == binding) return action;
         }
       }
     }

--- a/hibiki/test/shortcuts/popup_entry_wheel_binding_test.dart
+++ b/hibiki/test/shortcuts/popup_entry_wheel_binding_test.dart
@@ -1,0 +1,301 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart' hide ModifierKey;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/popup_settings_injection.dart';
+import 'package:hibiki/src/shortcuts/input_binding.dart';
+import 'package:hibiki/src/shortcuts/shortcut_action.dart';
+import 'package:hibiki/src/shortcuts/shortcut_defaults.dart';
+import 'package:hibiki/src/shortcuts/shortcut_registry.dart';
+
+/// 查词弹窗「上/下一个词条」（Yomitan 式 Alt+滚轮）的绑定通道守卫。
+///
+/// 这条链路横跨三段，任何一段改名都会让功能静默失效（用户侧表现是「滚轮跳词条
+/// 没反应」，且没有任何报错）：
+///   注册表 wheelBindings → popup_settings_injection 注入 window.__hoshiEntryWheelBindings
+///   → popup.js 的 wheel 监听 → hoshiFocusDictionaryEntryMove。
+/// 故除了数据层往返，这里还钉住 Dart 注入的全局名与 popup.js 读取的全局名一致。
+void main() {
+  group('WheelBinding 序列化往返', () {
+    test('修饰键 + 方向按固定顺序序列化，且能反序列化回等值对象', () {
+      const WheelBinding binding = WheelBinding(
+        WheelDirection.down,
+        modifiers: <ModifierKey>{ModifierKey.alt},
+      );
+      expect(binding.serialize(), 'Alt+WheelDown');
+      expect(WheelBinding.deserialize('Alt+WheelDown'), binding);
+    });
+
+    test('多修饰键按 ModifierKey 声明序排列（与 InputBinding 同规则）', () {
+      const WheelBinding binding = WheelBinding(
+        WheelDirection.up,
+        modifiers: <ModifierKey>{ModifierKey.shift, ModifierKey.ctrl},
+      );
+      expect(binding.serialize(), 'Ctrl+Shift+WheelUp');
+      expect(WheelBinding.deserialize(binding.serialize()), binding);
+    });
+
+    test('裸方向（无修饰键）也能往返；等值只看方向 + 修饰键集合', () {
+      expect(
+        WheelBinding.deserialize('WheelUp'),
+        const WheelBinding(WheelDirection.up),
+      );
+      expect(
+        const WheelBinding(WheelDirection.up,
+            modifiers: <ModifierKey>{ModifierKey.alt}),
+        isNot(const WheelBinding(WheelDirection.down,
+            modifiers: <ModifierKey>{ModifierKey.alt})),
+      );
+    });
+
+    test('无法识别的 token 返回 null（坏快照不炸，退化成没有该绑定）', () {
+      expect(WheelBinding.deserialize(''), isNull);
+      expect(WheelBinding.deserialize('Alt+MouseMiddle'), isNull);
+    });
+  });
+
+  group('ShortcutBindingSet 的 wheel 通道向后兼容', () {
+    test('toJson/fromJson 往返保留滚轮绑定', () {
+      const ShortcutBindingSet set = ShortcutBindingSet(
+        keyboardBindings: <InputBinding>[
+          InputBinding(key: LogicalKeyboardKey.keyA),
+        ],
+        wheelBindings: <WheelBinding>[
+          WheelBinding(WheelDirection.down,
+              modifiers: <ModifierKey>{ModifierKey.alt}),
+        ],
+      );
+      final ShortcutBindingSet round = ShortcutBindingSet.fromJson(
+        jsonDecode(jsonEncode(set.toJson())) as Map<String, dynamic>,
+      );
+      expect(round.wheelBindings, set.wheelBindings);
+      expect(round.keyboardBindings, set.keyboardBindings);
+    });
+
+    test('老快照没有 wheel key 时得到空表，其它通道原样保留', () {
+      final ShortcutBindingSet set = ShortcutBindingSet.fromJson(
+        const <String, dynamic>{
+          'keyboard': <String>['Ctrl+KeyW'],
+          'gamepad': <String>['B'],
+          'mouse': <String>['MouseMiddle'],
+        },
+      );
+      expect(set.wheelBindings, isEmpty);
+      expect(
+          set.keyboardBindings.single,
+          const InputBinding(
+              key: LogicalKeyboardKey.keyW,
+              modifiers: <ModifierKey>{ModifierKey.ctrl}));
+      expect(set.gamepadBindings.single, const GamepadBinding(GamepadButton.b));
+      expect(set.mouseBindings.single, const MouseBinding(1));
+    });
+  });
+
+  group('默认绑定', () {
+    for (final TargetPlatform platform in <TargetPlatform>[
+      TargetPlatform.windows,
+      TargetPlatform.macOS,
+      TargetPlatform.android,
+    ]) {
+      test('$platform 默认 Alt+滚轮下/上 = 下/上一个词条', () {
+        final Map<ShortcutAction, ShortcutBindingSet> defaults =
+            ShortcutDefaults.forPlatform(platform);
+        expect(
+          defaults[ShortcutAction.popupNextEntry]!.wheelBindings,
+          const <WheelBinding>[
+            WheelBinding(WheelDirection.down,
+                modifiers: <ModifierKey>{ModifierKey.alt}),
+          ],
+        );
+        expect(
+          defaults[ShortcutAction.popupPrevEntry]!.wheelBindings,
+          const <WheelBinding>[
+            WheelBinding(WheelDirection.up,
+                modifiers: <ModifierKey>{ModifierKey.alt}),
+          ],
+        );
+      });
+    }
+
+    test('macOS 不把 Alt 换成 Meta（Ctrl→Meta 只作用于键盘通道）', () {
+      final Map<ShortcutAction, ShortcutBindingSet> mac =
+          ShortcutDefaults.forPlatform(TargetPlatform.macOS);
+      expect(
+        mac[ShortcutAction.popupNextEntry]!.wheelBindings.single.modifiers,
+        <ModifierKey>{ModifierKey.alt},
+      );
+    });
+
+    test('dictionaryPopup 是独立 co-active 组、只开滚轮通道', () {
+      expect(ShortcutScope.dictionaryPopup.coactiveScopes,
+          <ShortcutScope>[ShortcutScope.dictionaryPopup]);
+      expect(ShortcutScope.dictionaryPopup.channels,
+          <ShortcutChannel>{ShortcutChannel.wheel});
+      // 其它 scope 保持键盘/手柄/鼠标三通道（不因新通道枚举而改变既有行为）。
+      expect(ShortcutScope.reader.channels.contains(ShortcutChannel.keyboard),
+          isTrue);
+      expect(ShortcutScope.reader.channels.contains(ShortcutChannel.wheel),
+          isFalse);
+    });
+  });
+
+  group('冲突检测', () {
+    test('同一 scope 内同一「修饰键 + 方向」只能属于一个动作', () {
+      final HibikiShortcutRegistry registry = HibikiShortcutRegistry()
+        ..loadDefaults(TargetPlatform.windows);
+      const WheelBinding altDown = WheelBinding(
+        WheelDirection.down,
+        modifiers: <ModifierKey>{ModifierKey.alt},
+      );
+      expect(
+        registry.hasWheelConflict(ShortcutScope.dictionaryPopup, altDown,
+            exclude: ShortcutAction.popupPrevEntry),
+        ShortcutAction.popupNextEntry,
+      );
+      // 排除自己时不算冲突（编辑自己的绑定不该报冲突）。
+      expect(
+        registry.hasWheelConflict(ShortcutScope.dictionaryPopup, altDown,
+            exclude: ShortcutAction.popupNextEntry),
+        isNull,
+      );
+      // 未被占用的组合无冲突。
+      expect(
+        registry.hasWheelConflict(
+          ShortcutScope.dictionaryPopup,
+          const WheelBinding(WheelDirection.down,
+              modifiers: <ModifierKey>{ModifierKey.shift}),
+          exclude: null,
+        ),
+        isNull,
+      );
+    });
+
+    test('重分配会把绑定从旧动作上摘掉（与键盘/手柄/鼠标同形）', () {
+      final HibikiShortcutRegistry registry = HibikiShortcutRegistry()
+        ..loadDefaults(TargetPlatform.windows);
+      const WheelBinding altDown = WheelBinding(
+        WheelDirection.down,
+        modifiers: <ModifierKey>{ModifierKey.alt},
+      );
+      registry.updateBindingWithReassignments(
+        ShortcutAction.popupPrevEntry,
+        ShortcutBindingSet(
+          wheelBindings: <WheelBinding>[
+            ...registry
+                .bindingsFor(ShortcutAction.popupPrevEntry)
+                .wheelBindings,
+            altDown,
+          ],
+        ),
+        removeWheelConflicts: const <WheelBinding>[altDown],
+      );
+      expect(
+        registry.bindingsFor(ShortcutAction.popupNextEntry).wheelBindings,
+        isEmpty,
+      );
+      expect(
+        registry.bindingsFor(ShortcutAction.popupPrevEntry).wheelBindings,
+        contains(altDown),
+      );
+    });
+  });
+
+  group('注入 → popup.js 契约', () {
+    test('popupEntryWheelBindingsJson 输出 popup.js 能直接比对的形状', () {
+      final HibikiShortcutRegistry registry = HibikiShortcutRegistry()
+        ..loadDefaults(TargetPlatform.windows);
+      final Map<String, dynamic> decoded = jsonDecode(
+              popupEntryWheelBindingsJson(registry, TargetPlatform.windows))
+          as Map<String, dynamic>;
+      expect(decoded['next'], <Map<String, Object>>[
+        <String, Object>{
+          'dir': 'down',
+          'mods': <String>['alt'],
+        },
+      ]);
+      expect(decoded['prev'], <Map<String, Object>>[
+        <String, Object>{
+          'dir': 'up',
+          'mods': <String>['alt'],
+        },
+      ]);
+    });
+
+    test('用户清空绑定 → 发空表（popup.js 据此关掉该方向，而不是回落默认）', () {
+      final HibikiShortcutRegistry registry = HibikiShortcutRegistry()
+        ..loadDefaults(TargetPlatform.windows)
+        ..updateBinding(
+            ShortcutAction.popupNextEntry, const ShortcutBindingSet());
+      final Map<String, dynamic> decoded = jsonDecode(
+              popupEntryWheelBindingsJson(registry, TargetPlatform.windows))
+          as Map<String, dynamic>;
+      expect(decoded['next'], isEmpty);
+      expect(decoded['prev'], isNotEmpty);
+    });
+
+    test('注册表尚未装载时回落平台默认，绝不误发空表', () {
+      // 弹窗进程（Android :popup）的精简初始化早于 loadShortcutRegistry；此时每个
+      // action 都读到空绑定，与「用户清空」在数据上同形。若直接下发空表，popup.js
+      // 会认为用户关掉了这个功能 → Alt+滚轮在独立弹窗窗口里静默失效。
+      final Map<String, dynamic> decoded = jsonDecode(
+              popupEntryWheelBindingsJson(
+                  HibikiShortcutRegistry(), TargetPlatform.windows))
+          as Map<String, dynamic>;
+      expect(decoded['next'], isNotEmpty);
+      expect(decoded['prev'], isNotEmpty);
+      expect(HibikiShortcutRegistry().isLoaded, isFalse);
+      expect(
+        (HibikiShortcutRegistry()..loadDefaults(TargetPlatform.windows))
+            .isLoaded,
+        isTrue,
+      );
+    });
+
+    test('弹窗进程的初始化会加载用户的快捷键绑定（否则改键在该进程不生效）', () {
+      final String appModel =
+          File('lib/src/models/app_model.dart').readAsStringSync();
+      final int popupInit = appModel.indexOf('initialiseForDictionaryPopup');
+      expect(popupInit, greaterThan(0));
+      final String popupInitBody = appModel.substring(
+        popupInit,
+        appModel.indexOf('Future<void> refreshPrefCache()', popupInit),
+      );
+      expect(popupInitBody.contains('loadShortcutRegistry'), isTrue,
+          reason: '弹窗进程没加载快捷键快照：注入给 popup.js 的只会是默认绑定');
+    });
+
+    test('Dart 注入的全局名与 popup.js 读取的全局名一致，且三镜像都带这段', () {
+      const String globalName = '__hoshiEntryWheelBindings';
+      final String injection =
+          File('lib/src/pages/implementations/popup_settings_injection.dart')
+              .readAsStringSync();
+      expect(injection.contains('window.$globalName ='), isTrue,
+          reason: '注入端改名了：popup.js 会读到 undefined 并退回默认绑定，用户改键静默失效');
+
+      for (final String path in const <String>[
+        'assets/popup/popup.js',
+        'assets/browser_extension/vendor/popup.js',
+        '../tools/browser-extension/vendor/popup.js',
+      ]) {
+        final String js = File(path).readAsStringSync();
+        expect(js.contains('window.$globalName'), isTrue,
+            reason: '$path 没读注入的绑定');
+        expect(js.contains('popupEntryWheelAction'), isTrue,
+            reason: '$path 缺少滚轮 → 词条导航的判定函数');
+        expect(
+            js.contains('hoshiFocusDictionaryEntryMove(entryAction)'), isTrue,
+            reason: '$path 没把命中的滚轮接到词条焦点移动上');
+        // 未注入时（浏览器扩展）必须有 Alt+滚轮默认，否则扩展里这功能是死的。
+        expect(js.contains('HOSHI_ENTRY_WHEEL_DEFAULT_BINDINGS'), isTrue,
+            reason: '$path 丢了未注入时的默认绑定');
+      }
+    });
+
+    test('裸滚轮永远不劫持（popup.js 无修饰键时早退）', () {
+      final String js = File('assets/popup/popup.js').readAsStringSync();
+      expect(js.contains('if (pressed.length === 0) return null;'), isTrue,
+          reason: '裸滚轮必须留给内容滚动，否则弹窗滚不动了');
+    });
+  });
+}

--- a/hibiki/test/shortcuts/shortcut_action_wiring_guard_test.dart
+++ b/hibiki/test/shortcuts/shortcut_action_wiring_guard_test.dart
@@ -56,6 +56,12 @@ void main() {
       // ShortcutAction.globalToggleFullscreen from the registry inside
       // wrapWithGlobalNavigation and flips WindowManager.setFullScreen on desktop.
       'lib/src/shortcuts/global_navigation.dart',
+      // 查词弹窗「上/下一个词条」（popupNextEntry / popupPrevEntry）的执行体：弹窗
+      // 内容是 WebView，滚轮事件先到 popup.js，故这里把注册表里的滚轮绑定序列化成
+      // window.__hoshiEntryWheelBindings 注入过去，popup.js 命中即调
+      // hoshiFocusDictionaryEntryMove。它与 globalExternalLookup 同类——不经页面
+      // _executeShortcutAction 派发，但绝不是死项。
+      'lib/src/pages/implementations/popup_settings_injection.dart',
     ];
 
     final StringBuffer corpus = StringBuffer();

--- a/hibiki/test/shortcuts/shortcut_wheel_binding_capture_test.dart
+++ b/hibiki/test/shortcuts/shortcut_wheel_binding_capture_test.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' hide ModifierKey;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/src/pages/implementations/shortcut_settings_page.dart';
+import 'package:hibiki/src/shortcuts/input_binding.dart';
+import 'package:hibiki/src/shortcuts/shortcut_action.dart';
+import 'package:hibiki/src/shortcuts/shortcut_registry.dart';
+import 'package:hibiki/src/utils/misc/show_app_dialog.dart';
+
+/// 查词弹窗「上/下一个词条」的**改键入口**：在快捷键设置的绑定对话框里录一条
+/// 「修饰键 + 滚轮方向」。与鼠标按钮捕获同形（shortcut_mouse_binding_capture_test），
+/// 差别只在事件是 PointerSignal 而非 PointerDown。
+///
+/// 同时钉住两条设计约束：
+///   * 裸滚轮不可绑定（弹窗里裸滚轮永远滚内容，绑了必然是死绑定）；
+///   * dictionaryPopup scope 只渲染滚轮章节，不给键盘/手柄入口（同理由）。
+void main() {
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+  });
+
+  void usePlatform(TargetPlatform platform) {
+    debugDefaultTargetPlatformOverride = platform;
+  }
+
+  void resetPlatform() {
+    debugDefaultTargetPlatformOverride = null;
+  }
+
+  HibikiShortcutRegistry buildRegistry(TargetPlatform platform) =>
+      HibikiShortcutRegistry()..loadDefaults(platform);
+
+  Future<void> pumpDialogHost(
+    WidgetTester tester,
+    HibikiShortcutRegistry registry, {
+    required ShortcutAction action,
+    ShortcutBindingSet initial = const ShortcutBindingSet(),
+  }) async {
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) => ElevatedButton(
+                onPressed: () async {
+                  final ShortcutBindingEditResult? result =
+                      await showAppDialog<ShortcutBindingEditResult>(
+                    context: context,
+                    builder: (BuildContext ctx) => ShortcutBindingEditDialog(
+                      action: action,
+                      registry: registry,
+                      initial: initial,
+                    ),
+                  );
+                  if (result == null) return;
+                  registry.updateBindingWithReassignments(
+                    action,
+                    result.bindings,
+                    removeKeyboardConflicts: result.keyboardReassignments,
+                    removeGamepadConflicts: result.gamepadReassignments,
+                    removeMouseConflicts: result.mouseReassignments,
+                    removeWheelConflicts: result.wheelReassignments,
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  /// 在滚轮捕获区上滚一格。[modifier] 非空时按住该修饰键再滚（滚完抬起）。
+  Future<void> scrollCaptureRegion(
+    WidgetTester tester, {
+    required double dy,
+    LogicalKeyboardKey? modifier,
+  }) async {
+    final Offset center = tester.getCenter(
+      find.byKey(const Key('shortcut_wheel_capture_region')),
+    );
+    if (modifier != null) {
+      await tester.sendKeyDownEvent(modifier);
+    }
+    final TestPointer pointer = TestPointer(1, PointerDeviceKind.mouse);
+    pointer.hover(center);
+    await tester.sendEventToBinding(pointer.scroll(Offset(0, dy)));
+    await tester.pumpAndSettle();
+    if (modifier != null) {
+      await tester.sendKeyUpEvent(modifier);
+    }
+  }
+
+  testWidgets('Alt+滚轮下被录成 Alt+WheelDown 并写穿注册表', (WidgetTester tester) async {
+    usePlatform(TargetPlatform.windows);
+    final HibikiShortcutRegistry registry =
+        buildRegistry(TargetPlatform.windows);
+    // 先清空默认，避免录同一条时命中「已绑定到本动作」的重复分支。
+    registry.updateBinding(
+        ShortcutAction.popupNextEntry, const ShortcutBindingSet());
+    await pumpDialogHost(
+      tester,
+      registry,
+      action: ShortcutAction.popupNextEntry,
+    );
+
+    await tester.tap(find.byKey(const Key('shortcut_add_wheel')));
+    await tester.pumpAndSettle();
+    expect(find.text(t.shortcut_press_wheel), findsOneWidget);
+
+    await scrollCaptureRegion(tester,
+        dy: 120, modifier: LogicalKeyboardKey.altLeft);
+
+    // 捕获结束 + chip 出现（"Alt+Wheel down"）。
+    expect(find.text(t.shortcut_press_wheel), findsNothing);
+    expect(find.textContaining(t.shortcut_wheel_down), findsOneWidget);
+
+    await tester.tap(find.text('OK').last);
+    await tester.pumpAndSettle();
+
+    expect(
+      registry.bindingsFor(ShortcutAction.popupNextEntry).wheelBindings,
+      contains(const WheelBinding(WheelDirection.down,
+          modifiers: <ModifierKey>{ModifierKey.alt})),
+    );
+
+    resetPlatform();
+  });
+
+  testWidgets('裸滚轮不记录绑定，只提示需要修饰键（捕获保持开启）', (WidgetTester tester) async {
+    usePlatform(TargetPlatform.windows);
+    final HibikiShortcutRegistry registry =
+        buildRegistry(TargetPlatform.windows);
+    registry.updateBinding(
+        ShortcutAction.popupNextEntry, const ShortcutBindingSet());
+    await pumpDialogHost(
+      tester,
+      registry,
+      action: ShortcutAction.popupNextEntry,
+    );
+
+    await tester.tap(find.byKey(const Key('shortcut_add_wheel')));
+    await tester.pumpAndSettle();
+    await scrollCaptureRegion(tester, dy: -120);
+
+    expect(find.text(t.shortcut_wheel_needs_modifier), findsOneWidget);
+    expect(find.text(t.shortcut_press_wheel), findsOneWidget);
+
+    await tester.tap(find.text('OK').last);
+    await tester.pumpAndSettle();
+
+    expect(
+      registry.bindingsFor(ShortcutAction.popupNextEntry).wheelBindings,
+      isEmpty,
+    );
+
+    resetPlatform();
+  });
+
+  testWidgets('冲突：Alt+滚轮上已属「上一个词条」，重分配后从旧动作摘掉', (WidgetTester tester) async {
+    usePlatform(TargetPlatform.windows);
+    final HibikiShortcutRegistry registry =
+        buildRegistry(TargetPlatform.windows);
+    await pumpDialogHost(
+      tester,
+      registry,
+      action: ShortcutAction.popupNextEntry,
+      initial: registry.bindingsFor(ShortcutAction.popupNextEntry),
+    );
+
+    await tester.tap(find.byKey(const Key('shortcut_add_wheel')));
+    await tester.pumpAndSettle();
+    await scrollCaptureRegion(tester,
+        dy: -120, modifier: LogicalKeyboardKey.altLeft);
+
+    // 冲突确认对话框 → 确认重分配。
+    expect(
+      find.text(t.shortcut_conflict(s: t.shortcut_action_popup_prev_entry)),
+      findsWidgets,
+    );
+    await tester.tap(find.text('OK').last);
+    await tester.pumpAndSettle();
+    // 编辑对话框自身的 OK（写穿）。
+    await tester.tap(find.text('OK').last);
+    await tester.pumpAndSettle();
+
+    const WheelBinding altUp = WheelBinding(WheelDirection.up,
+        modifiers: <ModifierKey>{ModifierKey.alt});
+    expect(registry.bindingsFor(ShortcutAction.popupNextEntry).wheelBindings,
+        contains(altUp));
+    expect(registry.bindingsFor(ShortcutAction.popupPrevEntry).wheelBindings,
+        isNot(contains(altUp)));
+
+    resetPlatform();
+  });
+
+  testWidgets('弹窗 scope 只给滚轮入口，不给键盘/手柄入口（不造死绑定）', (WidgetTester tester) async {
+    usePlatform(TargetPlatform.windows);
+    final HibikiShortcutRegistry registry =
+        buildRegistry(TargetPlatform.windows);
+    await pumpDialogHost(
+      tester,
+      registry,
+      action: ShortcutAction.popupNextEntry,
+    );
+
+    expect(find.byKey(const Key('shortcut_add_wheel')), findsOneWidget);
+    expect(find.text(t.shortcut_keyboard), findsNothing);
+    expect(find.text(t.shortcut_gamepad), findsNothing);
+    expect(find.byKey(const Key('shortcut_add_mouse')), findsNothing);
+
+    resetPlatform();
+  });
+
+  testWidgets('页面 scope 不因新通道而多出滚轮入口（既有对话框不变）', (WidgetTester tester) async {
+    usePlatform(TargetPlatform.windows);
+    final HibikiShortcutRegistry registry =
+        buildRegistry(TargetPlatform.windows);
+    await pumpDialogHost(
+      tester,
+      registry,
+      action: ShortcutAction.homeFocusSearch,
+    );
+
+    expect(find.text(t.shortcut_keyboard), findsWidgets);
+    expect(find.byKey(const Key('shortcut_add_wheel')), findsNothing);
+
+    resetPlatform();
+  });
+}

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -3703,7 +3703,56 @@ function popupAncestorAbsorbsVerticalWheel(target, deltaPx) {
     }
     return false;
 }
+// 查词弹窗「上/下一个词条」的滚轮绑定（Yomitan 的 Next/Previous entry）。默认
+// Alt+滚轮下 = 下一条、Alt+滚轮上 = 上一条；in-app 由 popup_settings_injection 注入
+// window.__hoshiEntryWheelBindings 覆盖成用户在「快捷键」设置里配的绑定（动作
+// ShortcutAction.popupNextEntry / popupPrevEntry）。浏览器扩展没有那条注入通道，
+// 就吃这里的默认值。
+const HOSHI_ENTRY_WHEEL_DEFAULT_BINDINGS = {
+    next: [{ dir: 'down', mods: ['alt'] }],
+    prev: [{ dir: 'up', mods: ['alt'] }],
+};
+// 本次 wheel 事件命中哪个词条导航动作：'next' / 'prev' / null。
+// 判据：deltaY 的符号给方向，当前按下的修饰键集合必须与某条绑定**全等**（故
+// Alt+滚轮绝不会被 Ctrl+Alt+滚轮误触）。裸滚轮永远留给内容滚动，绝不劫持。
+function popupEntryWheelAction(e) {
+    const raw = window.__hoshiEntryWheelBindings;
+    const cfg = (raw && typeof raw === 'object')
+        ? raw
+        : HOSHI_ENTRY_WHEEL_DEFAULT_BINDINGS;
+    const dir = e.deltaY > 0 ? 'down' : (e.deltaY < 0 ? 'up' : null);
+    if (!dir) return null;
+    const pressed = [];
+    if (e.altKey) pressed.push('alt');
+    if (e.ctrlKey) pressed.push('ctrl');
+    if (e.shiftKey) pressed.push('shift');
+    if (e.metaKey) pressed.push('meta');
+    if (pressed.length === 0) return null;
+    const matches = (list) => Array.isArray(list) && list.some((b) => b &&
+        b.dir === dir && Array.isArray(b.mods) &&
+        b.mods.length === pressed.length &&
+        b.mods.every((m) => pressed.indexOf(m) >= 0));
+    if (matches(cfg.next)) return 'next';
+    if (matches(cfg.prev)) return 'prev';
+    return null;
+}
 document.addEventListener('wheel', (e) => {
+    // 词条导航先于一切滚动处理判定（否则 ctrlKey 早退会吃掉 Ctrl 系绑定）。只有
+    // 焦点真的移动了（返回 'moved'）才吞掉事件：单词条 / 已到首尾时返回 'blocked'，
+    // 这一帧继续走下面的正常滚动，弹窗不会「按住 Alt 就滚不动」。
+    // 作用域判据与下面的滚动接管同源：扩展里滚轮必须真的落在弹窗 shadow 内
+    // （__hibikiWheelScroller 非空），in-app 整份文档就是弹窗故允许 null。
+    const entryAction = popupEntryWheelAction(e);
+    if (entryAction && typeof window.hoshiFocusDictionaryEntryMove === 'function') {
+        const inExtensionHost =
+            typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
+        if (__hibikiWheelScroller(e) || !inExtensionHost) {
+            if (window.hoshiFocusDictionaryEntryMove(entryAction) === 'moved') {
+                e.preventDefault();
+                return;
+            }
+        }
+    }
     // Ignore zoom gestures (ctrl+wheel / pinch) and predominantly-horizontal wheels.
     if (e.ctrlKey) return;
     // TODO-1387: treat a frame as horizontal (leave it to native) only when the


### PR DESCRIPTION
用户请求：像 Yomitan 一样按 **Alt+滚轮** 直接跳到查词列表的下一个词，并且能在快捷键设置里改键。

## 现状（为什么不是从零造）

词条级焦点移动的能力本来就有 —— `popup.js` 的 `hoshiFocusDictionaryEntryMove`（TODO-1325 #5 part1，蓝三角 `.entry-current` + `scrollIntoView`）。但此前只有阅读器**选字光标模式**下硬编码的 `.` / `,`（以及手柄 RT/LT 的词典段跳转）能触发它：既不可改键，也不覆盖视频页 / 首页词典 tab / 桌面全局查词窗口的弹窗。这个 PR 把已有能力接到一条**可配置的滚轮通道**上。

## 改了什么

**1. 第四条绑定通道 `WheelBinding`**（修饰键 + 滚轮方向），与键盘 / 手柄 / 鼠标按钮并列，序列化形如 `Alt+WheelDown`。
滚轮是离散事件（无按下/抬起），运行时判据是 `deltaY` 的符号而不是 `MouseEvent.button`，所以它是独立通道而不是塞进 `MouseBinding` 的按钮编号。老快照没有 `wheel` 字段时读成空表 → 既有键盘/手柄/鼠标绑定零影响（schema v6 → v7，全新 action 天然拿到默认）。

**2. 新 scope + 两个动作**：`ShortcutScope.dictionaryPopup`（独立 co-active 组）下的 `popup_next_entry` / `popup_prev_entry`，默认 **Alt+滚轮下 / Alt+滚轮上**。

**3. 执行体在 popup.js，不在 Dart**
弹窗内容是 WebView，滚轮事件先到它的 JS，Flutter 侧收不到 —— 也不该收：只有指针真的在弹窗内才算数，而且只有 JS 能 `preventDefault` 掉这一帧的内容滚动。所以「可改键」这件事就是把注册表里的绑定序列化注入过去：

\`\`\`
注册表 wheelBindings
  → popup_settings_injection: window.__hoshiEntryWheelBindings = {"next":[{"dir":"down","mods":["alt"]}], "prev":[...]}
  → popup.js 的 wheel 监听（修饰键集合全等比对）
  → hoshiFocusDictionaryEntryMove('next'|'prev')
\`\`\`

行为细节：
- 裸滚轮**永远**留给内容滚动，绝不劫持；
- 修饰键必须**全等**匹配 → Ctrl+Alt+滚轮不会误触 Alt+滚轮；
- 命中但到首/末条（JS 返回 `blocked`）时**不吞事件**，弹窗照常滚动，不会「按住 Alt 就滚不动」；
- 钩子排在现有 wheel handler 的 `if (e.ctrlKey) return` 之前，用户若把绑定改成 Ctrl 系也能生效；
- 扩展场景沿用同一条作用域判据（`__hibikiWheelScroller` 非空才接管），普通网页上的滚轮绝不被抢。

三份 popup.js 镜像已同步（字节一致守卫通过）。浏览器扩展没有注入通道，吃 JS 里的同款 Alt+滚轮默认值。

**4. 设置页**：新增 `ShortcutScope.channels` —— 编辑对话框按它渲染通道章节。弹窗 scope 只给滚轮入口，不给键盘/手柄/鼠标入口（那些通道在这里绑了也永不触发，给入口就是造死绑定）；可视化键盘/手柄图对该 scope 也回落成列表行（否则点空键位会写出一条死绑定）。滚轮捕获区吃 `PointerSignal`，裸滚轮拒绝记录并说明原因。冲突检测 / 重分配与其它三通道完全同形。

**5. 顺带修的真 bug**：Android 独立弹窗进程（`:popup`）的精简初始化不加载快捷键快照 → 注入端会把空表下发，而空表在 popup.js 那边的语义是「用户已关闭」→ 那个窗口里 Alt+滚轮静默失效。已补上 `loadShortcutRegistry`（排在 `ReaderHibikiSource.initialise()` 之后，遵守 BUG-207 的顺序约束），并让注入端在注册表未装载时回落平台默认而不是发空表。

## 验证

- \`flutter analyze lib test\` 干净；
- 新增 **24 项单测**（序列化往返 / 老快照兼容 / 三平台默认 / 冲突与重分配 / 注入形状 / 三镜像与全局名 parity / 未装载回落）+ **5 项 widget 测试**（真的在对话框里录 Alt+滚轮并写穿注册表、裸滚轮被拒、冲突重分配、通道可见性）；
- 全量 \`flutter test\`：**13479 通过 / 5 skip**，唯一 1 条失败是 \`video_subtitle_shift_hover_lookup_test\` 的 flutter_tools 加载竞态（`Bad state: Cannot close sink while adding stream`），单独复跑 **6/6 全过**，与本改动无关；
- popup.js 的判定函数在 node 里直接跑了 9 种滚轮组合（默认命中、裸滚轮不劫持、Ctrl+Alt 不误触、注入覆盖默认、清空即关闭）全部符合预期。

## 待验收

真机：在阅读器 / 视频页 / 首页词典 / 桌面全局查词窗四种弹窗上确认 Alt+滚轮跳词条 + 裸滚轮仍正常滚动；以及在「设置 → 快捷键 → 查词弹窗」里改键后即时生效。

## 已知取舍

首次按 Alt+滚轮下会先选中第 1 条（此前无 current 时 `next` 落 index 0），第二次才前进 —— 沿用既有 `.` / `,` 的语义，没有为此改动 JS（Never break userspace）。若真机手感希望第一下就跳到第 2 条，可以再调。

https://claude.ai/code/session_017BjsrnQDBUf2gmRWtQDjWr