### PR TITLE
fix(galgame): 修复 Loopback 制卡音频倍速异常

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1026 条。点号进各自文件。
+> 共 1027 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1060](bugs/BUG-1060-gal-loopback-engine-pcm-cache.md) | ✅ | ✅ | Loopback 制卡误用引擎 PCM 碎片导致音频异常 |
 | [BUG-1059](bugs/BUG-1059-galgame-x86-helper.md) | ✅ | ✅ | 残缺的 x86 galgame helper 被当成已安装，自动转区失效 |
 | [BUG-1058](bugs/BUG-1058-ffmpeg-min-vendored-missing-movtext.md) | ✅ | ✅ | 入库精简 ffmpeg 缺 movtext 编码器，桌面片段导出永远封不进字幕 |
 | [BUG-1057](bugs/BUG-1057-danmaku-comment-fetch-timeout-and-swallowed-status.md) | ✅ | ✅ | 手动匹配弹幕「弹幕加载失败」：拉弹幕与搜索共用 8s 超时，且非 2xx 被吞成空列表 |

--- a/docs/bugs/BUG-1060-gal-loopback-engine-pcm-cache.md
+++ b/docs/bugs/BUG-1060-gal-loopback-engine-pcm-cache.md
@@ -1,0 +1,7 @@
+## BUG-1060 · Loopback 制卡误用引擎 PCM 碎片导致音频异常
+- **报告**：2026-07-24（用户：`屋上の百合霊さんフルコーラス.exe` 的 `正解` 卡片句子音频像倍速）
+- **真实性**：✅ 真 bug。捕获工作台明确显示会话已降级为 `systemLoopback`（48 kHz / 2 ch / 32 bit），但逐行状态却是 `engine_pcm` 且多条不同长度台词都固定约 1.72–1.74 秒；实际 Anki AAC 仅 1.77 秒、基频中位数约 533 Hz。根因是 `hibiki/lib/src/mining/gal_hook_session_controller.dart` 的文本轮询和制卡补抓在 `_audioSource` 已选 Loopback 后，仍无条件调用保活 helper 的 `grabUtterance`，把未通过 PCM readiness 的残留碎片写入 `_lineVoiceCache`，随后又按当前会话来源误标为 `system_loopback`。
+- **[x] ① 已修复** — 仅当 `_audioSource` 与 `engine` 是同一实例（readiness 已正式选择 engine PCM）时才允许抓取 engine clip；文本 helper + Loopback 会话直接冻结真实 Loopback，制卡补抓也不再复活不可信 engine PCM。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_hook_session_controller_test.dart` 的 BUG-1060 用例让 text-only helper 故意暴露一段“可读但未就绪”的 engine utterance，断言行到达和制卡阶段均零次调用它、只缓存一次 Loopback。
+- **验证**：目标测试 20/20 通过，`flutter analyze --no-pub` 通过，Windows Debug 构建成功；隔离构建实机启动该游戏时也确认失败分支会明确落到 `系统 Loopback（混音）· 48000 Hz · 2 ch · 32 bit`。全量测试跑至 13,304 个通过事件、143 个既有 UI/字体/视频/设置并发失败后停止，未发现 BUG-1060 相关失败。
+- **备注**：Windows-only galgame 消费状态机修复；不修改或扩展其它平台的 galgame 实现。

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -1186,7 +1186,13 @@ class GalHookSessionController extends ChangeNotifier {
       }
     }
     GalAudioSlice? slice = _lineVoiceCache[lineId];
-    if ((slice == null || slice.isEmpty) && engine != null && timestamp > 0) {
+    // 会话已经选用 Loopback 时，engine 仍需保活来提供文本/资源事件，但它的 PCM
+    // 明确没有通过 readiness 门。此时绝不能因为共享内存里残留着可读 clip 就重新
+    // 借用 engine PCM；否则会把错误格式/碎片缓存伪装成 system_loopback。
+    if ((slice == null || slice.isEmpty) &&
+        engine != null &&
+        identical(source, engine) &&
+        timestamp > 0) {
       slice = await engine.grabUtterance(timestamp) ??
           await engine.grabClipNear(timestamp);
     }
@@ -1782,7 +1788,10 @@ class GalHookSessionController extends ChangeNotifier {
             status: TexthookerLineAudioStatus.pending,
             backend: 'game_resource',
           );
-        } else {
+        } else if (identical(_audioSource, engine)) {
+          // 只有 readiness 已选择 engine PCM 作为当前音频源时才读取 engine clip。
+          // 文本 helper 在 Loopback 降级会话中仍然保活，但它暴露的残留/未通过门控
+          // PCM 不能覆盖真正的逐行 Loopback 缓存（BUG-1060）。
           clip = await engine.grabUtterance(line.timestampMs) ??
               await engine.grabClipNear(line.timestampMs);
         }

--- a/hibiki/test/mining/gal_hook_session_controller_test.dart
+++ b/hibiki/test/mining/gal_hook_session_controller_test.dart
@@ -398,7 +398,7 @@ void main() {
     endpoints.dispose();
   });
 
-  test('text-only engine hook stays active with loopback audio fallback',
+  test('BUG-1060 text-only engine ignores stale PCM and caches loopback audio',
       () async {
     final TexthookerService service = TexthookerService.test();
     final ChangeNotifier endpoints = ChangeNotifier();
@@ -415,6 +415,17 @@ void main() {
           hookName: 'Unity',
         ),
       ],
+      // 真实故障里 helper 虽未通过 PCM readiness，旧 DirectSound 段仍可被
+      // grabUtterance 读到。降级会话必须忽略它，不能把碎片伪装成 Loopback。
+      utteranceSlice: GalAudioSlice(
+        pcm: Uint8List(192000),
+        format: const PcmFormat(
+          sampleRate: 48000,
+          channels: 2,
+          bitsPerSample: 16,
+          isFloat: false,
+        ),
+      ),
     );
     final _FakeLoopbackSource loopback = _FakeLoopbackSource();
     final GalHookSessionController controller = GalHookSessionController(
@@ -462,6 +473,8 @@ void main() {
     expect(service.entries.single.audioBackend, 'system_loopback');
     expect(loopback.grabRecentCalls, 1,
         reason: 'loopback audio is cached when the exact line arrives');
+    expect(engine.utteranceTimestamps, isEmpty,
+        reason: 'failed engine PCM readiness must remain authoritative');
 
     await controller.captureAudioBytes(
       lineId: service.entries.single.id,
@@ -470,6 +483,9 @@ void main() {
     );
     expect(loopback.grabRecentCalls, 1,
         reason: 'mining must reuse the line cache instead of recording later');
+    expect(engine.utteranceTimestamps, isEmpty,
+        reason:
+            'mining must not revive stale engine PCM in a loopback session');
 
     await controller.close();
     expect(engine.stopCalls, 1);


### PR DESCRIPTION
## 修复内容

- Loopback 降级会话不再从仍保活的文本 helper 读取未通过 readiness 的引擎 PCM。
- 行到达时只缓存当前已选音频源；制卡补抓也不再复活残留引擎片段。
- 新增 BUG-1060 回归用例，模拟 helper 暴露“可读但未就绪”的旧 PCM。

## 根因与影响

`屋上の百合霊さんフルコーラス.exe` 的引擎 PCM readiness 失败后，会话已选择系统 Loopback，但文本轮询和制卡补抓仍无条件调用 `grabUtterance`。残留的短 PCM 片段因此被写入逐行缓存，又被误标成 `system_loopback`，最终生成类似倍速、音调偏高的 Anki 音频。

修复后，只有 readiness 明确选择 engine PCM 时才允许读取 engine clip；Loopback 会话始终使用真实 Loopback 录音。

## 验证

- `flutter test --no-pub --no-test-assets test/mining/gal_hook_session_controller_test.dart`：20/20 通过。
- `flutter analyze --no-pub`：通过。
- Windows Debug 构建：通过。
- 隔离构建实机启动目标游戏：确认失败分支明确进入 `系统 Loopback（混音）· 48000 Hz · 2 ch · 32 bit`。
- 全量测试跑至 13,304 个通过事件、143 个既有 UI/字体/视频/设置并发失败后停止；未发现 BUG-1060 相关失败。

Windows-only galgame 修复；未修改其它平台实现。
