### PR TITLE
fix(webview): app 内弹窗滚轮还原 DPR，与 app 外弹窗同尺度（BUG-1065）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1029 条。点号进各自文件。
+> 共 1030 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1065](bugs/BUG-1065-inapp-wheel-dpr-parity.md) | ✅ | ✅ | app 内查词弹窗滚轮比 app 外慢 1/dpr（native sendScroll 未还原 DPR） |
 | [BUG-1062](bugs/BUG-1062-anki-glossary-image-size-vs-yomitan.md) | ✅ | ✅ | 制卡词典图片比 Yomitan 卡片小很多（导出把 em 折算成物理 px） |
 | [BUG-1061](bugs/BUG-1061-anki-glossary-label-extra-index.md) | ✅ | ✅ | 制卡 {glossary} 词典名前多出自造序号「1」 |
 | [BUG-1060](bugs/BUG-1060-gal-loopback-engine-pcm-cache.md) | ✅ | ✅ | Loopback 制卡误用引擎 PCM 碎片导致音频异常 |

--- a/docs/bugs/BUG-1065-inapp-wheel-dpr-parity.md
+++ b/docs/bugs/BUG-1065-inapp-wheel-dpr-parity.md
@@ -1,0 +1,12 @@
+## BUG-1065 · app 内查词弹窗滚轮比 app 外慢 1/dpr（native sendScroll 未还原 DPR）
+
+- **报告**：2026-07-25（用户：app 外的查词弹窗和 app 内的查词弹窗滚轮滚动速度感觉不一样）
+- **真实性**：✅ 真 bug — 两条弹窗路径喂给 WebView2 的 wheel 单位不同，差 `devicePixelRatio` 倍。根因链：
+  1. `packages/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart:484-488` — app 内弹窗（`InAppWebView`）的滚轮取 Flutter `PointerScrollEvent.scrollDelta`，而 framework 的 `converter.dart:283-284` 对 scrollDelta 统一做了 `/ devicePixelRatio`，拿到的是**逻辑像素**。
+  2. `packages/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp:1974-1983`（修前）— `sendScroll` 用硬编码 `delta * kScrollMultiplier(6)`，注释自陈前提是「一档 delta≈20」，该前提只在 dpr=1 成立。**同一文件的鼠标坐标（`:1843` / `:1907` / `setPosition`）都乘了 `scaleFactor_` 还原物理像素，唯独滚轮 delta 漏了**。
+  3. `hibiki/windows/runner/global_lookup_window.cpp:913-962` — app 外弹窗是裸 WebView2 overlay，`ForwardCompositionMouse` 把系统原始 `GET_WHEEL_DELTA_WPARAM`（一档 120）原样转发，不打折。
+  - 报告机实测主显示器 DPI 144（150% 缩放，4K），`WheelScrollLines=3`。一档鼠标：app 外 → 120（1 个 WHEEL_DELTA，DOM `deltaY≈100`）；app 内 → `20/1.5×6 = 80`（0.67 档，`deltaY≈67`）。两端跑的是同一份 `assets/popup/popup.js`（同一 0.24 粗档系数 + 同源 zoom 补偿），所以差的就是入口的 1/dpr。
+  - 附带危害：`popup.js` 以 `POPUP_WHEEL_MOUSE_NOTCH_PX=60` 区分粗鼠标/触控板。dpr≥2 时 app 内一档 `deltaY` 跌到 50 < 60，会被**误判成触控板**走 1.0 倍率（而非 0.24），同一台机器上 app 内弹窗反而暴快约 4 倍。修复后分类回到设计假设。
+- **[x] ① 已修复** — `in_app_webview.cpp` `sendScroll` 先按 `scaleFactor_`（`setSurfaceSize` / `setPosition` 存的 `View.devicePixelRatio`，缺省 1.0）把逻辑像素还原成物理像素再乘 `kScrollMultiplier`：`delta * kScrollMultiplier * dprScale + residual`。与同文件坐标处理一致，dpr=1 的机器逐帧与改前完全相同；BUG-870 的跨帧残差累积（`scrollResidualX_/Y_`、`offset==0` 留到下帧）原样保留，触控板慢滑不回归（还原后更容易凑够整 wheel 单位）。
+- **[x] ② 已加自动化测试** — `hibiki/test/build/popup_wheel_native_residual_guard_test.dart` 扩为双端契约守卫：新 group 断言 in-app 侧 `sendScroll` 乘 `scaleFactor_`、旧的无 DPR 形式 `delta * kScrollMultiplier + residual` 不再出现；并锚定 app 外 `global_lookup_window.cpp` 仍原样转发 `GET_WHEEL_DELTA_WPARAM`（对照端不许悄悄改成打折转发）。native 无法在测试宿主运行，故为源码扫描守卫，与 BUG-870 同法。
+- **备注**：爆炸半径 = 所有 Windows `InAppWebView` 的滚轮/触控板输入（查词弹窗、阅读器连续模式、视频页、首页词典），方向是**恢复到与系统原生一致**，不是加速特例。100% 缩放机器零行为变化。真机终验项：150% 缩放下 app 内/app 外弹窗一档滚动距离应目测一致（需 `flutter build windows` 编 native）。

--- a/hibiki/test/build/popup_wheel_native_residual_guard_test.dart
+++ b/hibiki/test/build/popup_wheel_native_residual_guard_test.dart
@@ -19,6 +19,7 @@ import 'package:flutter_test/flutter_test.dart';
 /// popup_wheel_scroll_behavior_test.js.
 void main() {
   late String sendScrollBody;
+  late String forwardCompositionMouseBody;
 
   setUpAll(() {
     final String cpp = File(
@@ -31,6 +32,20 @@ void main() {
     expect(end, greaterThan(start),
         reason: 'setScrollDelta must follow sendScroll');
     sendScrollBody = cpp.substring(start, end);
+
+    // BUG-1065 对照端：app 外查词弹窗的裸 WebView2 overlay 转发路径。
+    final String overlayCpp =
+        File('windows/runner/global_lookup_window.cpp').readAsStringSync();
+    final int overlayStart =
+        overlayCpp.indexOf('void GlobalLookupWindow::ForwardCompositionMouse');
+    expect(overlayStart, greaterThanOrEqualTo(0),
+        reason: 'ForwardCompositionMouse must exist in global_lookup_window.cpp');
+    final int overlayEnd =
+        overlayCpp.indexOf('void GlobalLookupWindow::EnsureWebView', overlayStart);
+    expect(overlayEnd, greaterThan(overlayStart),
+        reason: 'EnsureWebView must follow ForwardCompositionMouse');
+    forwardCompositionMouseBody =
+        overlayCpp.substring(overlayStart, overlayEnd);
   });
 
   group('BUG-870 native sendScroll carries a sub-unit remainder', () {
@@ -67,6 +82,59 @@ void main() {
       );
       expect(sendScrollBody.contains('static_cast<short>(scaled)'), isTrue,
           reason: 'the short cast must act on the residual-accumulated value');
+    });
+  });
+
+  // BUG-1065 —— app 内 / app 外两种查词弹窗喂给 WebView2 的 wheel 单位必须同尺度。
+  //
+  // app 内走 Flutter PointerScrollEvent，framework converter.dart 已把 scrollDelta
+  // 除过 devicePixelRatio（逻辑像素）；kScrollMultiplier=6 的「一档 delta≈20」前提
+  // 只在 dpr=1 成立。app 外的裸 WebView2 overlay 则原样转发系统 WHEEL_DELTA。
+  // 150% 缩放下 app 内一档只有 0.67 个 WHEEL_DELTA → 同一份 popup.js 收到的 deltaY
+  // 小 1/dpr，用户直观感受就是「app 内滚得慢」。dpr≥2 时更会跌破 popup.js 的
+  // POPUP_WHEEL_MOUSE_NOTCH_PX=60 粗/细设备阈值而被误判成触控板。
+  group('BUG-1065 wheel delta 与 app 外 overlay 同尺度', () {
+    test('in-app sendScroll 按 scaleFactor_ 还原物理像素后再乘倍数', () {
+      expect(sendScrollBody.contains('scaleFactor_'), isTrue,
+          reason: '滚轮 delta 是逻辑像素，必须用 scaleFactor_（devicePixelRatio）'
+              '还原成物理像素，与同文件鼠标坐标 (x * scaleFactor_) 的处理一致');
+      expect(
+        RegExp(r'delta \* kScrollMultiplier \* \w+ \+ residual')
+            .hasMatch(sendScrollBody),
+        isTrue,
+        reason: '缩放系数必须乘进 scaled，且仍走 BUG-870 的 residual 累积',
+      );
+    });
+
+    test('不再出现无 DPR 还原的旧形式', () {
+      expect(
+        sendScrollBody.contains('delta * kScrollMultiplier + residual'),
+        isFalse,
+        reason: '直接用逻辑像素乘 6 会让高 DPI 机器的 app 内弹窗慢 1/dpr（BUG-1065）',
+      );
+    });
+
+    test('scaleFactor_ 为 0/未初始化时回退 1.0，绝不把 wheel 归零', () {
+      expect(sendScrollBody.contains('1.0'), isTrue,
+          reason: 'scaleFactor_ 非法（<=0）时必须回退 1.0，否则一乘 0 滚轮全死');
+      expect(RegExp(r'scaleFactor_ > 0').hasMatch(sendScrollBody), isTrue,
+          reason: '必须显式判非法缩放系数再回退');
+    });
+
+    test('对照端：app 外 overlay 仍原样转发系统 WHEEL_DELTA', () {
+      // 这是 parity 的另一半锚点：修 app 内是为了对齐这里，若哪天有人反过来给
+      // overlay 加打折，两端又会漂开。
+      expect(
+        forwardCompositionMouseBody.contains('GET_WHEEL_DELTA_WPARAM(wparam)'),
+        isTrue,
+        reason: 'app 外弹窗必须把系统原始 wheel delta 原样交给 WebView2',
+      );
+      expect(
+        RegExp(r'GET_WHEEL_DELTA_WPARAM\(wparam\)\s*[*/]')
+            .hasMatch(forwardCompositionMouseBody),
+        isFalse,
+        reason: 'overlay 侧不得对 wheel delta 再做缩放/打折（parity 对照端）',
+      );
     });
   });
 }

--- a/packages/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
+++ b/packages/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.cpp
@@ -1974,13 +1974,26 @@ namespace flutter_inappwebview_plugin
     // delta * 6 gives me a multiple of WHEEL_DELTA (120) for a mouse notch (delta≈20).
     constexpr auto kScrollMultiplier = 6;
 
+    // BUG-1064 根因：这里的 delta 是 Flutter 的**逻辑像素**（framework converter.dart
+    // 对 scrollDelta 统一除过 devicePixelRatio），而 kScrollMultiplier=6 的前提「一档
+    // delta≈20」只在 dpr=1（100% 缩放）成立。150% 缩放下一档只剩 20/1.5≈13.3 → *6=80
+    // → 0.67 个 WHEEL_DELTA，同一份 popup.js 收到的 deltaY 就比 app 外裸 WebView2 窗
+    // （global_lookup_window.cpp 原样转发系统 WHEEL_DELTA=120）小 1/dpr，用户直观感受
+    // 就是「app 内弹窗滚得比 app 外慢」。本文件的鼠标坐标（sendMouseInput / setPosition）
+    // 早已乘 scaleFactor_ 还原物理像素，唯独滚轮 delta 漏了这一步——先还原再乘倍数，
+    // 使 WebView2 收到的 wheel 单位与系统原生一致。dpr=1 时逐帧与改前完全相同。
+    // 副作用（正向）：dpr≥2 时改前 deltaY 会跌破 popup.js 的 60px 粗/细设备阈值被误判
+    // 成触控板（factor 1.0 而非 0.24）而暴快，还原后分类回到设计假设。
+    const double dprScale =
+      (scaleFactor_ > 0.0f) ? static_cast<double>(scaleFactor_) : 1.0;
+
     // BUG-870 根因：static_cast<short>(delta * 6) 向零截断且无跨帧余量累积。精密触控板
     // 慢滑时 Flutter 每帧下发很小的 delta，delta*6 不足 1 时被截成 0 → 根本不发 wheel 给
     // WebView2 → 弹窗「滚不动 / 很难滚」（鼠标一档 delta≈20→120 不受影响，每帧即过整单位）。
     // 这是 popup.js 的 TODO-1387 子像素残差修复够不到的更上游截断点：wheel 还没进 DOM 就没了。
     // 改为按轴累加被截掉的小数余量，小 delta 攒够整数 wheel 单位再发，绝不丢帧。
     double& residual = horizontal ? scrollResidualX_ : scrollResidualY_;
-    double scaled = delta * kScrollMultiplier + residual;
+    double scaled = delta * kScrollMultiplier * dprScale + residual;
     // 防极快甩动 delta*6 溢出 short（否则环绕成反向跳变）；被夹掉的部分直接丢弃、不进余量。
     if (scaled > 32760.0) { scaled = 32760.0; }
     else if (scaled < -32760.0) { scaled = -32760.0; }


### PR DESCRIPTION
## 问题

用户报「app 外的查词弹窗和 app 内的查词弹窗滚轮滚动速度感觉不一样」。属实：两条路径喂给 WebView2 的 wheel 单位差 `devicePixelRatio` 倍。

## 根因

1. `custom_platform_view.dart:484-488` — app 内弹窗（`InAppWebView`）滚轮取 Flutter `PointerScrollEvent.scrollDelta`，framework `converter.dart:283-284` 已对它做 `/ devicePixelRatio`，拿到的是**逻辑像素**。
2. `in_app_webview.cpp` `sendScroll` — 硬编码 `delta * kScrollMultiplier(6)`，注释自陈前提「一档 delta≈20」，只在 dpr=1 成立。**同文件鼠标坐标（`x * scaleFactor_`）早已还原物理像素，唯独滚轮 delta 漏了这一步。**
3. `hibiki/windows/runner/global_lookup_window.cpp:913-962` — app 外弹窗是裸 WebView2 overlay，`ForwardCompositionMouse` 原样转发系统 `GET_WHEEL_DELTA_WPARAM`（一档 120），不打折。

报告机 150% 缩放（DPI 144 / 4K，`WheelScrollLines=3`）。一档鼠标：app 外 → 120（DOM `deltaY≈100`）；app 内 → `20/1.5×6 = 80`（0.67 档，`deltaY≈67`）。两端跑同一份 `popup.js`（同一 0.24 粗档系数、同源 zoom 补偿），差的就是入口这 1/dpr。

附带危害：`popup.js` 用 `POPUP_WHEEL_MOUSE_NOTCH_PX=60` 分粗鼠标/触控板。dpr≥2 时 app 内一档 `deltaY` 跌到 50 < 60 会被**误判成触控板**走 1.0 而非 0.24 倍率，同机反而暴快约 4 倍。

## 改动

- `sendScroll` 先按 `scaleFactor_`（`setSurfaceSize`/`setPosition` 存的 `View.devicePixelRatio`，缺省 1.0，`<=0` 回退 1.0）还原物理像素再乘倍数：`delta * kScrollMultiplier * dprScale + residual`。
- BUG-870 的跨帧残差累积（`scrollResidualX_/Y_`、`offset==0` 留到下帧）原样保留，触控板慢滑不回归——还原后反而更容易凑够整 wheel 单位。
- **dpr=1 的机器逐帧与改前完全相同。**

## 测试

`hibiki/test/build/popup_wheel_native_residual_guard_test.dart` 扩为双端契约守卫（native 跑不了测试宿主，故源码扫描，与 BUG-870 同法）：
- in-app 侧必须乘 `scaleFactor_`、必须有 `<=0` 回退、旧的无 DPR 形式 `delta * kScrollMultiplier + residual` 不得复现；
- 对照端锚定 app 外 overlay 仍原样转发 `GET_WHEEL_DELTA_WPARAM`、不得加缩放。

验证：
- `flutter test test/build/popup_wheel_native_residual_guard_test.dart test/reader/popup_wheel_scroll_asset_test.dart test/reader/popup_wheel_speed_asset_test.dart test/reader/popup_wheel_scroll_behavior_test.dart --no-pub` → 27 passed
- 反证：把 native 改回旧形式，两条新断言立刻转红（确认守卫不是空转）
- `flutter analyze`（全量含 test）→ No issues found

## 爆炸半径 / 待验

影响所有 Windows `InAppWebView` 的滚轮与触控板输入（查词弹窗、阅读器连续模式、视频页、首页词典），方向是**恢复到与系统原生一致**，不是加速特例；100% 缩放机器零行为变化。

**待真机**：需 `flutter build windows` 编 native 后，在 150% 缩放下目测 app 内 / app 外弹窗一档滚动距离是否一致，以及触控板慢滑仍不回归 BUG-870。

BUG 记录：`docs/bugs/BUG-1065-inapp-wheel-dpr-parity.md`

https://claude.ai/code/session_01QkFYkrKMZ5X2TPgKosdrSs