### PR TITLE
feat(games): galgame 游戏库 UI 对齐 ReinaManager — 海报墙 + 富详情头部 + 游戏首页 + 折线统计

### DIFF
--- a/docs/design/galgame-library-reina-visual-parity.md
+++ b/docs/design/galgame-library-reina-visual-parity.md
@@ -1,0 +1,78 @@
+# 游戏库视觉对齐 ReinaManager（M1.5 UI overhaul）契约
+
+> 上一轮（PR#400，已合 develop）对齐了**信息架构与数据模型**，但 UI 只是套了 Hibiki 现成的
+> 书架网格 / 普通 TabBar，**观感与 ReinaManager 完全不像**。本轮把四个界面的**视觉表现**
+> 做到接近 ReinaManager。参考 `references/ReinaManager`（AGPL-3.0），只还原布局观感、
+> 不复制其 React/MUI 源码。全部在 Hibiki 现有 Flutter/MD3 设计系统 token 上实现。
+>
+> ⚠️ MD3 静态守卫（`test/settings/md3_design_system_static_test.dart`）仍然生效：普通页面
+> chrome 不许直接用未 token 化的原生构造（裸 `Card(` / `ListTile(` / `BorderRadius.circular(`
+> / `fontSize:` / `surfaceContainer*` 等）。新组件要么走 `hibiki_material_components.dart` /
+> `hibiki_design_tokens.dart`，要么这些新文件本身是设计系统组件（放 `utils/components/`）。
+
+## 全局视觉基调（ReinaManager `reinaTheme.ts` 实测）
+
+- **卡片圆角**：20（Hibiki 用 `HibikiBorderRadius.card`=10，本轮游戏库自定义一档 `galgameCard`=16~20，
+  放进 design tokens，别硬编码）。**按钮**：pill（圆角 999）、weight 700、无大写。
+- **强调色 / 数据可视化色**：ReinaManager 全程用 `#1976d2`。Hibiki 走主题色 `colorScheme.primary`
+  —— **用主题色，不硬编码 #1976d2**（Hibiki 支持动态主题，硬编码会破坏暗色/自定义配色）。
+- **KPI 数值**：大号粗体（h5/22px、weight 700）；标签小号次要色（13px）。
+
+## 1. 库页海报网格（改 `games_library_page.dart`）
+
+- 卡片改成 **3:4 竖版海报**（现在是套书架的 `kShelfBookCardAspectRatio`）。新建共享组件
+  `GalgamePosterCard`（放 `utils/components/`，过 MD3 守卫）：
+  - 结构：`封面(3:4, object-cover, ClipRRect 圆角 galgameCard) → [底部排序信息渐变浮层] ；封面下方 标题(居中, 单行省略, ~16px)`。
+  - 封面轻微滤镜可省（Flutter 不好做 saturate/contrast，跳过，不影响观感大局）。
+  - **hover**：放大到 1.05 + 阴影加深（`MouseRegion` + `AnimatedScale`，200ms）。**选中态**：2px 主色边框环。
+  - **排序信息浮层**：封面底部 `Align(bottomLeft)`，`px 10 / 顶部 24 渐变 / 底部 6`，
+    `LinearGradient(transparent→black54→black87)`，白字 13px weight 600，单行省略。显示当前排序维度的值
+    （添加日期 / 发行日 / 评分 X.X / 站点分 #rank / 相对最后游玩），名称排序时不显示。受一个开关控制。
+  - 多选角标（20×20 方形主色 + check 18px，左上 6px）—— M1.5 可选，先不做多选，留结构。
+- **网格**：`SliverGridDelegateWithMaxCrossAxisExtent` 或按宽度算列数，`crossAxisSpacing/mainAxisSpacing 16`，
+  卡片含标题的整体宽高比按 3:4 封面 + 标题条估。列数随宽度（窄屏 3 列、宽屏更多），别再用书架的 extent。
+- 顶部工具条（搜索 / 排序 / 筛选入口）保留上一轮的功能，视觉上收成一行。
+- 卡片点击**仍启动游戏**；长按/右键进详情（沿用上一轮）。
+
+## 2. 详情页富头部（改 `galgame_detail_page.dart`）
+
+- 头部（tab 之上常驻）：`Row`（窄屏 `Column`），**封面居左**（max 宽 160→320、max 高 260、圆角 8、大阴影），
+  右侧信息列：
+  - 元信息网格（数据来源 / 开发商 **chips** / 发布时间 / 添加时间 / 预计时长 / 排行 / 评分），
+    每项 `label(粗) + value`，flex-wrap，右 24 下 8 间距。
+  - 评分行：`站点 X.X`（outlined）+ `我的 X.X`（outlined primary）两个 chip。
+  - 标签区：标题行（"游戏标签" + 搜索/清空）+ flex-wrap 的标签 chips（outlined，选中态 filled primary），
+    上限 40 + 展开/折叠。
+- Tab 栏保留（统计 / 简介 / 编辑；存档·评价是 M2 不做）。tab 下 body `pt 24`。
+- 用 `HibikiTagChip` / `HibikiActionChip` 等既有组件，别裸 `Chip(`。
+
+## 3. 游戏首页/仪表盘（新增 `galgame_home_page.dart` 作为游戏模块新默认子页）
+
+placement：`home_game_page.dart` 的 `IndexedStack` 加一个 `GameSection.dashboard` 作**默认首屏**，
+`GameSectionTabs` 加一项；库/工作台/诊断顺延。ReinaManager `HomePage` 的布局：
+
+- **区域 A**：4 格 KPI 条（总游戏数 / 总时长 / 今日时长 / 本周·本月时长），单行四等分，
+  cell `min-h 88`、图标盒 42、数值 22px/700、标签 13px 次要色。用 `getGalgamePlayTotals` 聚合。
+- **左列**：
+  - **Focus 卡**（最近游玩）：深色卡、封面出血做背景 + 左→右深色渐变蒙版；内容：状态 chip、
+    大标题(26~34px/800, 2 行截断)、副行(实时计时 or 上次游玩 + "本周 X · 总计 Y")、启动/详情按钮行、
+    "最近玩过" 4 格缩略图网格。实时计时用 tracker 的当前会话（无则显示上次游玩）。
+  - **随机游戏卡**（固定 150 高）：缩略图 + 标题/开发商/标签 + 换一个/启动。
+- **右列**：动态时间线（全部/游玩/添加筛选），按日期分组，左侧竖轨 + 圆节点 + 头像行。
+  复用 `activity_events`（game 类）。
+
+> 这是 M1.5 最大的一块。若时间/复杂度超预算，优先级：**库页 > 详情页头部 > 统计图 > 游戏首页**。
+> 游戏首页可只做 KPI 条 + Focus 卡 + 时间线（随机卡次要）。
+
+## 4. 统计图（详情页统计 tab）
+
+- 每日游玩时长用**折线图**（现在是柱状），高 ~300，线色 `colorScheme.primary`（不硬编码 #1976d2），
+  7 天档显点、更长档只线。X 轴日期、Y 轴时长（"Xh Ym" 格式），双向淡网格。
+- 时间范围切换 7D/30D/M/1Y/ALL（ToggleButton）。用 `getGalgameDailySeconds`。
+- 复用 Hibiki 现有图表绘制方式（先看 `reading_statistics_page.dart` / `home_dashboard_page.dart`
+  怎么画的），别引图表库。KPI 四卡 + 时间线列表沿用上一轮统计 tab 的数据。
+
+## 验证
+- MD3 静态守卫必须绿；`flutter analyze` 含 test 零 issue；相关 widget 测试绿。
+- 真机截图对比（Windows 离屏）：四个界面各留一张证据。
+- 主题色不硬编码；暗色/亮色都要看得过去。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 43775 (2575 per locale)
+/// Strings: 43979 (2587 per locale)
 ///
-/// Built on 2026-07-24 at 20:56 UTC
+/// Built on 2026-07-25 at 07:18 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3417,6 +3417,18 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get game_developer => 'Developer';
   String get game_site_score => 'Site rating';
   String get game_user_rating => 'My rating';
+  String get game_meta_source => 'Data source';
+  String get game_meta_added => 'Added';
+  String get game_meta_ranking => 'Ranking';
+  String get game_tags_title => 'Game tags';
+  String get game_tags_clear => 'Clear selection';
+  String get game_dashboard => 'Home';
+  String get game_kpi_total_games => 'Games';
+  String get game_kpi_week => 'This week';
+  String get game_focus_continue => 'Continue';
+  String get game_recently_played => 'Recently played';
+  String get game_random_title => 'Pick for me';
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -9255,6 +9267,30 @@ class _StringsAr extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -15166,6 +15202,30 @@ class _StringsDe extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -21093,6 +21153,30 @@ class _StringsEs extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -27031,6 +27115,30 @@ class _StringsFr extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -32896,6 +33004,30 @@ class _StringsId extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -38809,6 +38941,30 @@ class _StringsIt extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -44527,6 +44683,30 @@ class _StringsJa extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -50248,6 +50428,30 @@ class _StringsKo extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -56139,6 +56343,30 @@ class _StringsNl extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -62045,6 +62273,30 @@ class _StringsPtBr extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -67934,6 +68186,30 @@ class _StringsRu extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -73768,6 +74044,30 @@ class _StringsTh extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -79634,6 +79934,30 @@ class _StringsTr extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -85487,6 +85811,30 @@ class _StringsVi extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 // Path: <root>
@@ -90932,6 +91280,30 @@ class _StringsZhCn extends _StringsEn {
   String get game_site_score => '站点评分';
   @override
   String get game_user_rating => '我的评分';
+  @override
+  String get game_meta_source => '数据来源';
+  @override
+  String get game_meta_added => '添加时间';
+  @override
+  String get game_meta_ranking => '游戏排行';
+  @override
+  String get game_tags_title => '游戏标签';
+  @override
+  String get game_tags_clear => '清空所选';
+  @override
+  String get game_dashboard => '首页';
+  @override
+  String get game_kpi_total_games => '游戏总数';
+  @override
+  String get game_kpi_week => '本周';
+  @override
+  String get game_focus_continue => '继续游戏';
+  @override
+  String get game_recently_played => '最近玩过';
+  @override
+  String get game_random_title => '随机推荐';
+  @override
+  String get game_random_reroll => '换一个';
 }
 
 // Path: <root>
@@ -96568,6 +96940,30 @@ class _StringsZhHk extends _StringsEn {
   String get game_site_score => 'Site rating';
   @override
   String get game_user_rating => 'My rating';
+  @override
+  String get game_meta_source => 'Data source';
+  @override
+  String get game_meta_added => 'Added';
+  @override
+  String get game_meta_ranking => 'Ranking';
+  @override
+  String get game_tags_title => 'Game tags';
+  @override
+  String get game_tags_clear => 'Clear selection';
+  @override
+  String get game_dashboard => 'Home';
+  @override
+  String get game_kpi_total_games => 'Games';
+  @override
+  String get game_kpi_week => 'This week';
+  @override
+  String get game_focus_continue => 'Continue';
+  @override
+  String get game_recently_played => 'Recently played';
+  @override
+  String get game_random_title => 'Pick for me';
+  @override
+  String get game_random_reroll => 'Shuffle';
 }
 
 /// Flat map(s) containing all translations.
@@ -101824,6 +102220,30 @@ extension on _StringsEn {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -107078,6 +107498,30 @@ extension on _StringsAr {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -112353,6 +112797,30 @@ extension on _StringsDe {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -117627,6 +118095,30 @@ extension on _StringsEs {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -122907,6 +123399,30 @@ extension on _StringsFr {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -128169,6 +128685,30 @@ extension on _StringsId {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -133446,6 +133986,30 @@ extension on _StringsIt {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -138685,6 +139249,30 @@ extension on _StringsJa {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -143928,6 +144516,30 @@ extension on _StringsKo {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -149198,6 +149810,30 @@ extension on _StringsNl {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -154465,6 +155101,30 @@ extension on _StringsPtBr {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -159737,6 +160397,30 @@ extension on _StringsRu {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -164993,6 +165677,30 @@ extension on _StringsTh {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -170258,6 +170966,30 @@ extension on _StringsTr {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -175518,6 +176250,30 @@ extension on _StringsVi {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }
@@ -180739,6 +181495,30 @@ extension on _StringsZhCn {
         return '站点评分';
       case 'game_user_rating':
         return '我的评分';
+      case 'game_meta_source':
+        return '数据来源';
+      case 'game_meta_added':
+        return '添加时间';
+      case 'game_meta_ranking':
+        return '游戏排行';
+      case 'game_tags_title':
+        return '游戏标签';
+      case 'game_tags_clear':
+        return '清空所选';
+      case 'game_dashboard':
+        return '首页';
+      case 'game_kpi_total_games':
+        return '游戏总数';
+      case 'game_kpi_week':
+        return '本周';
+      case 'game_focus_continue':
+        return '继续游戏';
+      case 'game_recently_played':
+        return '最近玩过';
+      case 'game_random_title':
+        return '随机推荐';
+      case 'game_random_reroll':
+        return '换一个';
       default:
         return null;
     }
@@ -185973,6 +186753,30 @@ extension on _StringsZhHk {
         return 'Site rating';
       case 'game_user_rating':
         return 'My rating';
+      case 'game_meta_source':
+        return 'Data source';
+      case 'game_meta_added':
+        return 'Added';
+      case 'game_meta_ranking':
+        return 'Ranking';
+      case 'game_tags_title':
+        return 'Game tags';
+      case 'game_tags_clear':
+        return 'Clear selection';
+      case 'game_dashboard':
+        return 'Home';
+      case 'game_kpi_total_games':
+        return 'Games';
+      case 'game_kpi_week':
+        return 'This week';
+      case 'game_focus_continue':
+        return 'Continue';
+      case 'game_recently_played':
+        return 'Recently played';
+      case 'game_random_title':
+        return 'Pick for me';
+      case 'game_random_reroll':
+        return 'Shuffle';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "启动游戏",
   "game_developer": "开发商",
   "game_site_score": "站点评分",
-  "game_user_rating": "我的评分"
+  "game_user_rating": "我的评分",
+  "game_meta_source": "数据来源",
+  "game_meta_added": "添加时间",
+  "game_meta_ranking": "游戏排行",
+  "game_tags_title": "游戏标签",
+  "game_tags_clear": "清空所选",
+  "game_dashboard": "首页",
+  "game_kpi_total_games": "游戏总数",
+  "game_kpi_week": "本周",
+  "game_focus_continue": "继续游戏",
+  "game_recently_played": "最近玩过",
+  "game_random_title": "随机推荐",
+  "game_random_reroll": "换一个"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2573,5 +2573,17 @@
   "game_launch": "Launch",
   "game_developer": "Developer",
   "game_site_score": "Site rating",
-  "game_user_rating": "My rating"
+  "game_user_rating": "My rating",
+  "game_meta_source": "Data source",
+  "game_meta_added": "Added",
+  "game_meta_ranking": "Ranking",
+  "game_tags_title": "Game tags",
+  "game_tags_clear": "Clear selection",
+  "game_dashboard": "Home",
+  "game_kpi_total_games": "Games",
+  "game_kpi_week": "This week",
+  "game_focus_continue": "Continue",
+  "game_recently_played": "Recently played",
+  "game_random_title": "Pick for me",
+  "game_random_reroll": "Shuffle"
 }

--- a/hibiki/lib/src/pages/implementations/galgame_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_detail_page.dart
@@ -62,14 +62,23 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
   List<GalgameSessionRow> _sessions = const <GalgameSessionRow>[];
   List<GalgameSourceRow> _sources = const <GalgameSourceRow>[];
 
-  /// 柱状图当前展示的月份（取该月 1 号 0 点）。
-  late DateTime _month = _firstOfMonth(DateTime.now());
+  /// 折线图时间窗口天数（含当天）。7D / 30D 两档（契约 §4）。
+  int _rangeDays = 7;
 
-  /// 当前月每日秒数（dateKey → 秒）。
-  Map<String, int> _daily = const <String, int>{};
+  /// 当前时间窗口的每日秒数（dateKey → 秒）。
+  Map<String, int> _dailyRange = const <String, int>{};
 
-  /// 今日秒数（与 [_month] 无关，单独查一天）。
+  /// 今日秒数（与 [_rangeDays] 无关，单独查一天）。
   int _todaySeconds = 0;
+
+  /// 头部标签区本地选中集合（选中态 filled primary，对齐 ReinaManager）。
+  final Set<String> _selectedTags = <String>{};
+
+  /// 头部标签区是否展开（超过 [_kTagLimit] 时折叠，展开显示全部）。
+  bool _tagsExpanded = false;
+
+  /// 折叠前展示的标签上限（契约 §2）。
+  static const int _kTagLimit = 40;
 
   bool _loading = true;
 
@@ -84,9 +93,6 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
     _tabs.dispose();
     super.dispose();
   }
-
-  static DateTime _firstOfMonth(DateTime value) =>
-      DateTime(value.year, value.month);
 
   Future<void> _load() async {
     final GalgameEntry? game = _repo.byId(widget.gameId) ??
@@ -103,7 +109,7 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
     }
     final List<GalgameSessionRow> sessions = await _repo.sessions(game.id);
     final List<GalgameSourceRow> sources = await _repo.sourcesOf(game.id);
-    final Map<String, int> daily = await _loadMonth(game.id, _month);
+    final Map<String, int> daily = await _loadRange(game.id, _rangeDays);
     final String todayKey = formatGalgameDate(DateTime.now());
     final Map<String, int> today = await _repo.dailySeconds(
       game.id,
@@ -115,32 +121,40 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
       _game = game;
       _sessions = sessions;
       _sources = sources;
-      _daily = daily;
+      _dailyRange = daily;
       _todaySeconds = today[todayKey] ?? 0;
       _loading = false;
     });
   }
 
-  Future<Map<String, int>> _loadMonth(String gameId, DateTime month) {
-    final DateTime last = DateTime(month.year, month.month + 1, 0);
+  /// 查最近 [days] 天（含当天）的每日秒数。
+  Future<Map<String, int>> _loadRange(String gameId, int days) {
+    final DateTime today = DateTime.now();
+    final DateTime start = DateTime(today.year, today.month, today.day)
+        .subtract(Duration(days: days - 1));
     return _repo.dailySeconds(
       gameId,
-      fromDateKey: formatGalgameDate(month),
-      toDateKey: formatGalgameDate(last),
+      fromDateKey: formatGalgameDate(start),
+      toDateKey: formatGalgameDate(today),
     );
   }
 
-  /// 翻月：[delta] = ±1。不允许翻到未来（当月是上界）。
-  Future<void> _shiftMonth(int delta) async {
+  /// 切换折线图时间窗口（7D / 30D）。
+  Future<void> _setRange(int days) async {
     final GalgameEntry? game = _game;
-    if (game == null) return;
-    final DateTime next = DateTime(_month.year, _month.month + delta);
-    if (next.isAfter(_firstOfMonth(DateTime.now()))) return;
-    final Map<String, int> daily = await _loadMonth(game.id, next);
+    if (game == null || days == _rangeDays) return;
+    final Map<String, int> daily = await _loadRange(game.id, days);
     if (!mounted) return;
     setState(() {
-      _month = next;
-      _daily = daily;
+      _rangeDays = days;
+      _dailyRange = daily;
+    });
+  }
+
+  /// 头部标签点击：本地选中态切换（对齐 ReinaManager 的可选标签）。
+  void _toggleTag(String tag) {
+    setState(() {
+      if (!_selectedTags.remove(tag)) _selectedTags.add(tag);
     });
   }
 
@@ -202,106 +216,260 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
     );
   }
 
-  /// 头部常驻：封面大图 + 显示名 / 开发商 / 评分 / 状态 / 标签 chips + 外链 + 启动。
+  /// 头部常驻（契约 §2）：封面居左 + 右侧富信息列（元信息网格 / 评分行 / 标签区）。
+  /// 窄屏降级成封面在上、信息在下的单列。
   Widget _buildHeader(BuildContext context, GalgameEntry game) {
-    final ThemeData theme = Theme.of(context);
-    final ColorScheme colors = theme.colorScheme;
-    final List<String> tags = game.tags;
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final Widget cover = _coverBlock(context, game);
+    final Widget info = _infoColumn(context, game);
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-      child: Row(
+      padding: EdgeInsets.fromLTRB(
+        tokens.spacing.rowHorizontal,
+        tokens.spacing.rowVertical,
+        tokens.spacing.rowHorizontal,
+        tokens.spacing.gap,
+      ),
+      child: LayoutBuilder(
+        builder: (BuildContext ctx, BoxConstraints c) {
+          if (c.maxWidth < 560) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Align(child: cover),
+                SizedBox(height: tokens.spacing.card),
+                info,
+              ],
+            );
+          }
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              cover,
+              const SizedBox(width: 24),
+              Expanded(child: info),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  /// 封面块：max 宽 160 / max 高 260 / 圆角 / 大阴影（契约 §2）。
+  Widget _coverBlock(BuildContext context, GalgameEntry game) {
+    return Container(
+      constraints: const BoxConstraints(maxWidth: 160, maxHeight: 260),
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        borderRadius: HibikiBorderRadius.card,
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.28),
+            blurRadius: 18,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: AspectRatio(
+        aspectRatio: 3 / 4,
+        child: _buildCover(context, game),
+      ),
+    );
+  }
+
+  /// 右侧信息列：标题 + 状态 chip + 元信息网格 + 评分行 + 启动 + 标签区。
+  Widget _infoColumn(BuildContext context, GalgameEntry game) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          game.displayName,
+          style: theme.textTheme.headlineSmall,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: 6),
+        HibikiTagChip(
+          label: galgamePlayStatusLabel(game.playStatus),
+          selected: true,
+        ),
+        const SizedBox(height: 12),
+        _metaGrid(context, game),
+        const SizedBox(height: 8),
+        _scoreRow(context, game),
+        if (widget.onLaunch != null) ...<Widget>[
+          const SizedBox(height: 12),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: FilledButton.icon(
+              onPressed: widget.onLaunch,
+              icon: const Icon(Icons.play_arrow),
+              label: Text(t.game_launch),
+            ),
+          ),
+        ],
+        _tagsSection(context, game),
+      ],
+    );
+  }
+
+  /// 元信息网格：每项「粗体 label + 下方 value」，flex-wrap（契约 §2）。
+  Widget _metaGrid(BuildContext context, GalgameEntry game) {
+    final GalgameMetadataDraft meta = game.metadata;
+    final List<Widget> cells = <Widget>[
+      if (_sources.isNotEmpty)
+        _metaCell(context, t.game_meta_source, _sourceChips(context)),
+      if (game.developer != null)
+        _metaCell(
+          context,
+          t.game_edit_developer,
+          HibikiTagChip(label: game.developer!),
+        ),
+      if (game.effectiveReleaseDate != null)
+        _metaTextCell(
+            context, t.game_summary_release_date, game.effectiveReleaseDate!),
+      _metaTextCell(
+          context, t.game_meta_added, formatGalgameDate(game.addedAt)),
+      if (meta.averageHours != null)
+        _metaTextCell(context, t.game_summary_average_hours,
+            '${meta.averageHours!.toStringAsFixed(1)} h'),
+      if (meta.rank != null)
+        _metaTextCell(context, t.game_meta_ranking, '#${meta.rank}'),
+    ];
+    return Wrap(runSpacing: 4, children: cells);
+  }
+
+  /// 一个「粗体 label + 值 widget」的网格单元。
+  Widget _metaCell(BuildContext context, String label, Widget value) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(right: 24, bottom: 8),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          SizedBox(
-            width: 96,
-            height: 128,
-            child: ClipRRect(
-              borderRadius: HibikiBorderRadius.card,
-              child: _buildCover(context, game),
+          Text(
+            label,
+            style: tokens.type.metadata.copyWith(
+              fontWeight: FontWeight.w700,
+              color: tokens.surfaces.onSurface,
             ),
           ),
-          const SizedBox(width: 16),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  game.displayName,
-                  style: theme.textTheme.titleLarge,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  <String>[
-                    if (game.developer != null) game.developer!,
-                    galgamePlayStatusLabel(game.playStatus),
-                    if (game.effectiveReleaseDate != null)
-                      game.effectiveReleaseDate!,
-                  ].join('  ·  '),
-                  style: theme.textTheme.bodySmall
-                      ?.copyWith(color: colors.onSurfaceVariant),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(height: 6),
-                Wrap(
-                  spacing: 12,
-                  runSpacing: 4,
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  children: <Widget>[
-                    if (game.siteScore != null)
-                      _scoreChip(theme, Icons.public,
-                          '${t.game_site_score} ${game.siteScore!.toStringAsFixed(1)}'),
-                    if (game.userRating != null)
-                      _scoreChip(theme, Icons.star,
-                          '${t.game_user_rating} ${game.userRating!.toStringAsFixed(1)}'),
-                    for (final GalgameSourceRow row in _sources)
-                      if (_externalUrl(row) != null)
-                        TextButton.icon(
-                          onPressed: () =>
-                              unawaited(_openUrl(_externalUrl(row)!)),
-                          icon: const Icon(Icons.open_in_new, size: 16),
-                          label: Text(
-                            GalgameMetadataSource.fromKey(row.source)?.label ??
-                                row.source,
-                          ),
-                        ),
-                    if (widget.onLaunch != null)
-                      FilledButton.icon(
-                        onPressed: widget.onLaunch,
-                        icon: const Icon(Icons.play_arrow),
-                        label: Text(t.game_launch),
-                      ),
-                  ],
-                ),
-                if (tags.isNotEmpty) ...<Widget>[
-                  const SizedBox(height: 6),
-                  Wrap(
-                    spacing: 6,
-                    runSpacing: 4,
-                    children: <Widget>[
-                      for (final String tag in tags.take(12))
-                        HibikiTagChip(label: tag),
-                    ],
-                  ),
-                ],
-              ],
-            ),
-          ),
+          const SizedBox(height: 2),
+          value,
         ],
       ),
     );
   }
 
-  Widget _scoreChip(ThemeData theme, IconData icon, String label) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
+  /// 文本值的网格单元。
+  Widget _metaTextCell(BuildContext context, String label, String value) {
+    final ThemeData theme = Theme.of(context);
+    return _metaCell(
+      context,
+      label,
+      Text(value, style: theme.textTheme.bodyMedium),
+    );
+  }
+
+  /// 数据来源 chips：可点者用 [HibikiActionChip] 开外链，无链回落展示 chip。
+  Widget _sourceChips(BuildContext context) {
+    return Wrap(
+      spacing: 6,
+      runSpacing: 4,
       children: <Widget>[
-        Icon(icon, size: 16, color: theme.colorScheme.onSurfaceVariant),
-        const SizedBox(width: 4),
-        Text(label, style: theme.textTheme.bodySmall),
+        for (final GalgameSourceRow row in _sources)
+          () {
+            final String label =
+                GalgameMetadataSource.fromKey(row.source)?.label ?? row.source;
+            final String? url = _externalUrl(row);
+            if (url == null) return HibikiTagChip(label: label);
+            return HibikiActionChip(
+              label: label,
+              icon: Icons.open_in_new,
+              onPressed: () => unawaited(_openUrl(url)),
+            );
+          }(),
       ],
+    );
+  }
+
+  /// 评分行：`站点 X.X`（默认）+ `我的 X.X`（primary 选中态）两个 chip。
+  Widget _scoreRow(BuildContext context, GalgameEntry game) {
+    final List<Widget> chips = <Widget>[
+      if (game.siteScore != null)
+        HibikiTagChip(
+          label: '${t.game_site_score} ${game.siteScore!.toStringAsFixed(1)}',
+        ),
+      if (game.userRating != null)
+        HibikiTagChip(
+          label: '${t.game_user_rating} ${game.userRating!.toStringAsFixed(1)}',
+          selected: true,
+        ),
+    ];
+    if (chips.isEmpty) return const SizedBox.shrink();
+    return Wrap(spacing: 8, runSpacing: 4, children: chips);
+  }
+
+  /// 标签区（契约 §2）：标题行（"游戏标签" + 选中计数 + 清空）+ flex-wrap 标签
+  /// chips（选中态 filled primary），上限 [_kTagLimit] + 展开/折叠。
+  Widget _tagsSection(BuildContext context, GalgameEntry game) {
+    final List<String> tags = game.tags;
+    if (tags.isEmpty) return const SizedBox.shrink();
+    final ThemeData theme = Theme.of(context);
+    final bool overflowing = tags.length > _kTagLimit;
+    final List<String> shown =
+        (overflowing && !_tagsExpanded) ? tags.sublist(0, _kTagLimit) : tags;
+    return Padding(
+      padding: const EdgeInsets.only(top: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Text(
+                _selectedTags.isEmpty
+                    ? t.game_tags_title
+                    : '${t.game_tags_title} · ${_selectedTags.length}',
+                style: theme.textTheme.titleSmall,
+              ),
+              const Spacer(),
+              if (_selectedTags.isNotEmpty)
+                HibikiActionChip(
+                  label: t.game_tags_clear,
+                  icon: Icons.clear,
+                  onPressed: () => setState(_selectedTags.clear),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            children: <Widget>[
+              for (final String tag in shown)
+                HibikiTagChip(
+                  label: tag,
+                  tone: HibikiTagChipTone.surface,
+                  selected: _selectedTags.contains(tag),
+                  onTap: () => _toggleTag(tag),
+                ),
+            ],
+          ),
+          if (overflowing)
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                onPressed: () => setState(() => _tagsExpanded = !_tagsExpanded),
+                icon:
+                    Icon(_tagsExpanded ? Icons.expand_less : Icons.expand_more),
+                label: Text(_tagsExpanded
+                    ? t.collection_collapse
+                    : '${t.collection_expand} +${tags.length - _kTagLimit}'),
+              ),
+            ),
+        ],
+      ),
     );
   }
 
@@ -372,43 +540,23 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
           children: <Widget>[
             Expanded(
               child: Text(
-                '${t.game_stat_daily}  ${_month.year}-${_month.month.toString().padLeft(2, '0')}',
+                t.game_stat_daily,
                 style: theme.textTheme.titleMedium,
               ),
             ),
-            IconButton(
-              tooltip: t.game_stat_prev_month,
-              icon: const Icon(Icons.chevron_left),
-              onPressed: () => unawaited(_shiftMonth(-1)),
-            ),
-            IconButton(
-              tooltip: t.game_stat_next_month,
-              icon: const Icon(Icons.chevron_right),
-              onPressed: _month.isBefore(_firstOfMonth(DateTime.now()))
-                  ? () => unawaited(_shiftMonth(1))
-                  : null,
+            SegmentedButton<int>(
+              showSelectedIcon: false,
+              segments: const <ButtonSegment<int>>[
+                ButtonSegment<int>(value: 7, label: Text('7D')),
+                ButtonSegment<int>(value: 30, label: Text('30D')),
+              ],
+              selected: <int>{_rangeDays},
+              onSelectionChanged: (Set<int> s) => unawaited(_setRange(s.first)),
             ),
           ],
         ),
         const SizedBox(height: 8),
-        SizedBox(
-          height: 160,
-          child: CustomPaint(
-            size: Size.infinite,
-            painter: StatBarChartPainter(
-              data: buildGalgameMonthChartData(_month, _daily),
-              barColor: theme.colorScheme.primary,
-              barRadius: HibikiDesignTokens.of(context).radii.chipCorner,
-              labelColor: theme.colorScheme.onSurfaceVariant,
-              labelStyle: HibikiDesignTokens.of(context).type.metadata.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-              // 游玩时长用 ms 值 + 时长纵轴（与视频统计同款）。
-              valueOf: statMsValue,
-              labelFormatter: formatStatDurationAxis,
-            ),
-          ),
-        ),
+        _buildDailyLineChart(context, theme),
         const SizedBox(height: 20),
         Text(t.game_stat_session_list, style: theme.textTheme.titleMedium),
         const SizedBox(height: 8),
@@ -432,6 +580,43 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
               ),
             ),
       ],
+    );
+  }
+
+  /// 每日游玩时长折线图（契约 §4）：线色主题色、Y 轴时长、X 轴日期、双向淡网格。
+  /// 复用 [StatLineChartPainter]（阅读/视频统计同款自绘），不引图表库。
+  Widget _buildDailyLineChart(BuildContext context, ThemeData theme) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final ColorScheme colors = theme.colorScheme;
+    final List<StatDayData> points =
+        buildGalgameRangeChartData(DateTime.now(), _rangeDays, _dailyRange);
+    final List<double> values = <double>[
+      for (final StatDayData d in points) d.ms.toDouble(),
+    ];
+    final List<String> labels = <String>[
+      for (final StatDayData d in points) statDayLabel(d),
+    ];
+    return SizedBox(
+      height: 280,
+      child: CustomPaint(
+        size: Size.infinite,
+        painter: StatLineChartPainter(
+          series: <StatLineSeries>[
+            StatLineSeries(values: values, color: colors.primary),
+          ],
+          xLabels: labels,
+          anomalies: const <bool>[],
+          anomalyColor: colors.primary,
+          labelColor: colors.onSurfaceVariant,
+          labelStyle: tokens.type.metadata.copyWith(
+            color: colors.onSurfaceVariant,
+          ),
+          // 纵轴是游玩时长（ms → "Xh Ym" / "Xm"），与视频统计同款。
+          labelFormatter: formatGalgameDurationAxis,
+          // 7 天档标签每天都显，30 天档抽稀到每 5 天。
+          labelEvery: _rangeDays <= 7 ? 1 : 5,
+        ),
+      ),
     );
   }
 
@@ -510,22 +695,29 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
   }
 }
 
-/// 纯函数：把某月的每日秒数映射铺成柱状图数据点（缺省天为 0，保证整月都有柱位）。
-/// 值落 [StatDayData.ms]（秒 × 1000），与视频统计同款走时长纵轴。
-List<StatDayData> buildGalgameMonthChartData(
-  DateTime month,
+/// 纯函数：把最近 [days] 天（以 [end] 当天为最后一天，含当天）的每日秒数铺成折线
+/// 图数据点（缺省天为 0，保证整段区间都有点位）。值落 [StatDayData.ms]（秒 ×
+/// 1000），与视频统计同款走时长纵轴。返回顺序按日期升序（旧 → 新）。
+List<StatDayData> buildGalgameRangeChartData(
+  DateTime end,
+  int days,
   Map<String, int> secondsByDay,
 ) {
-  final int days = DateTime(month.year, month.month + 1, 0).day;
+  final DateTime endDay = DateTime(end.year, end.month, end.day);
   return <StatDayData>[
-    for (int d = 1; d <= days; d++)
+    for (int i = days - 1; i >= 0; i--)
       () {
         final String key =
-            formatGalgameDate(DateTime(month.year, month.month, d));
+            formatGalgameDate(endDay.subtract(Duration(days: i)));
         return StatDayData(dateKey: key)..ms = (secondsByDay[key] ?? 0) * 1000;
       }(),
   ];
 }
+
+/// 把折线图纵轴的时长值（毫秒，double）格式化为标签（"Xh Ym" / "Xm" / "Xs"）。
+/// 顶层 tear-off 而非闭包，保 [StatLineChartPainter.shouldRepaint] 的函数相等稳定。
+String formatGalgameDurationAxis(double ms) =>
+    formatStatDurationAxis(ms.round());
 
 /// 一条会话的时间范围文案：`2026-07-24 21:03 → 22:41`。
 String formatGalgameSessionRange(GalgameSessionRow row) {

--- a/hibiki/lib/src/pages/implementations/galgame_home_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_home_page.dart
@@ -1,0 +1,1081 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/mining/gal_hook_failure_text.dart';
+import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/mining/galgame_audio_source.dart';
+import 'package:hibiki/src/mining/galgame_helper_installer.dart';
+import 'package:hibiki/src/mining/galgame_library.dart';
+import 'package:hibiki/src/mining/galgame_repository.dart';
+import 'package:hibiki/src/pages/implementations/activity_feed.dart';
+import 'package:hibiki/src/pages/implementations/galgame_detail_page.dart';
+import 'package:hibiki/src/pages/implementations/game_shared.dart';
+import 'package:hibiki/src/pages/implementations/stat_shared.dart';
+import 'package:hibiki/utils.dart';
+
+/// 游戏模块的默认首屏（游戏首页 / 仪表盘），布局对齐 ReinaManager `HomePage`
+/// （见 `docs/design/galgame-library-reina-visual-parity.md` §3）。
+///
+/// 三块内容：
+/// - **KPI 条**：总游戏数 / 总时长 / 今日 / 本周（[HibikiDatabase.getGalgameSecondsForDay]
+///   跨全部游戏按天聚合；总时长直接取仓储里每个游戏的现算聚合，无额外查询）。
+/// - **左列**：最近游玩「Focus 卡」（封面出血背景 + 左→右深色渐变蒙版）+ 随机游戏卡。
+/// - **右列**：动态时间线，复用 `activity_events`（game 类）经共享
+///   [aggregateActivityEvents] 聚合，与首页 dashboard 同一套读法。
+///
+/// 数据全部复用既有仓储 / DB 方法，不建投影表、不改 schema。启动 / 详情复用库页的
+/// [GalHookSessionController] launch 路径与 [GalgameDetailPage]，不另起炉灶。
+class GalgameHomePage extends ConsumerStatefulWidget {
+  const GalgameHomePage({
+    super.key,
+    required this.onShowLibrary,
+    required this.onShowMonitor,
+    required this.onShowDiagnostics,
+    this.sessionController,
+    this.onLaunched,
+  });
+
+  /// 切到游戏库 / 捕获工作台 / 诊断页（顶部页签复用）。
+  final VoidCallback onShowLibrary;
+  final VoidCallback onShowMonitor;
+  final VoidCallback onShowDiagnostics;
+
+  /// 启动会话控制器（缺省用单例）；启动成功后回调 [onLaunched]（切到工作台）。
+  final GalHookSessionController? sessionController;
+  final VoidCallback? onLaunched;
+
+  @override
+  ConsumerState<GalgameHomePage> createState() => _GalgameHomePageState();
+}
+
+/// KPI 条聚合结果（各字段单位见注释）。
+class _GameKpis {
+  const _GameKpis({
+    required this.totalGames,
+    required this.totalSeconds,
+    required this.todaySeconds,
+    required this.weekSeconds,
+  });
+
+  final int totalGames;
+  final int totalSeconds;
+  final int todaySeconds;
+  final int weekSeconds;
+
+  static const _GameKpis empty = _GameKpis(
+    totalGames: 0,
+    totalSeconds: 0,
+    todaySeconds: 0,
+    weekSeconds: 0,
+  );
+}
+
+class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
+  late final AppModel _appModel = ref.read(appProvider);
+  late final GalgameRepository _repo = _appModel.galgameRepo;
+  late final HibikiDatabase _db = _appModel.database;
+
+  /// 当前整库列表（首屏各区块的公共数据源）。
+  List<GalgameEntry> _games = const <GalgameEntry>[];
+
+  _GameKpis _kpis = _GameKpis.empty;
+
+  /// 时间线原始事件（游玩事件来自 DB，添加事件由库列表 addedAt 合成）。
+  List<ActivityEventRow> _timelineRows = const <ActivityEventRow>[];
+
+  /// 时间线筛选：null=全部 / [kActivityGame]=游玩 / [kActivityAdded]=添加。
+  String? _timelineFilter;
+
+  /// 随机游戏卡当前展示的游戏（用户可「换一个」重掷）。
+  GalgameEntry? _random;
+
+  /// 启动流程再入守卫（同库页：一次启动含多个 await，避免重复点叠出多开对话框）。
+  bool _launching = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _repo.addListener(_onRepoChanged);
+    _games = _repo.games;
+    unawaited(_reload());
+  }
+
+  @override
+  void dispose() {
+    _repo.removeListener(_onRepoChanged);
+    super.dispose();
+  }
+
+  /// 仓储变化（库页增删 / 刮削）→ 重算首屏（不再触发仓储写，避免回环）。
+  void _onRepoChanged() {
+    if (!mounted) return;
+    unawaited(_recompute());
+  }
+
+  /// 首次进入：确保仓储已载入一次，再重算。
+  Future<void> _reload() async {
+    await _repo.load();
+    await _recompute();
+  }
+
+  /// 重算 KPI / 时间线 / 随机卡（读当前仓储缓存 + 跨天聚合查询，不写仓储）。
+  Future<void> _recompute() async {
+    final List<GalgameEntry> games = _repo.games;
+    final _GameKpis kpis = await _computeKpis(games);
+    final List<ActivityEventRow> rows = await _loadTimelineRows(games);
+    if (!mounted) return;
+    setState(() {
+      _games = games;
+      _kpis = kpis;
+      _timelineRows = rows;
+      _random = _pickRandom(games, keep: _random);
+    });
+  }
+
+  /// KPI 聚合：总数/总时长取仓储现算聚合（零额外查询）；今日/本周跨全部游戏按天
+  /// 现查（近 7 天各一条 [HibikiDatabase.getGalgameSecondsForDay]，并发发起）。
+  Future<_GameKpis> _computeKpis(List<GalgameEntry> games) async {
+    int totalSeconds = 0;
+    for (final GalgameEntry g in games) {
+      totalSeconds += g.totalPlaySeconds;
+    }
+    final DateTime now = DateTime.now();
+    int today = 0;
+    int week = 0;
+    final List<Future<void>> futures = <Future<void>>[];
+    for (int i = 0; i < 7; i++) {
+      final String key =
+          HibikiTimeFormat.dayKey(now.subtract(Duration(days: i)));
+      // 单线程 Dart 里各 .then 回调不会在 += 语句中途交错，累加安全。
+      futures.add(_db.getGalgameSecondsForDay(key).then((int seconds) {
+        week += seconds;
+        if (i == 0) today = seconds;
+      }));
+    }
+    await Future.wait(futures);
+    return _GameKpis(
+      totalGames: games.length,
+      totalSeconds: totalSeconds,
+      todaySeconds: today,
+      weekSeconds: week,
+    );
+  }
+
+  /// 时间线事件：DB 里 game 类活动（游玩 / 已有的添加）+ 由库列表 addedAt 合成的
+  /// 「添加」事件（游戏添加当前不落 activity_events，合成后「添加」筛选才有内容）。
+  /// 同 (日期, 标题, 类型) 的重复会在 [aggregateActivityEvents] 里并成一条。
+  Future<List<ActivityEventRow>> _loadTimelineRows(
+    List<GalgameEntry> games,
+  ) async {
+    final List<ActivityEventRow> dbRows = await _db.getRecentActivityEvents(
+      limit: 200,
+      eventTypes: <String>[kActivityGame, kActivityAdded],
+    );
+    final List<ActivityEventRow> gameRows = dbRows
+        .where((ActivityEventRow r) => r.mediaType == kActivityMediaGame)
+        .toList();
+    final List<ActivityEventRow> synthesizedAdds = <ActivityEventRow>[
+      for (final GalgameEntry g in games)
+        ActivityEventRow(
+          id: 0, // 哨兵：合成行不落库，仅供聚合展示。
+          eventType: kActivityAdded,
+          mediaType: kActivityMediaGame,
+          title: g.displayName,
+          mediaKey: g.id,
+          dateKey: HibikiTimeFormat.dayKey(g.addedAt),
+          timestampMs: g.addedAt.millisecondsSinceEpoch,
+        ),
+    ];
+    return <ActivityEventRow>[...gameRows, ...synthesizedAdds];
+  }
+
+  /// 最近游玩的游戏（lastPlayedMs 最大且 > 0）；从未游玩返回 null。
+  GalgameEntry? get _recentGame {
+    GalgameEntry? best;
+    for (final GalgameEntry g in _games) {
+      if (g.lastPlayedMs <= 0) continue;
+      if (best == null || g.lastPlayedMs > best.lastPlayedMs) best = g;
+    }
+    return best;
+  }
+
+  /// 最近玩过的前 4 个游戏（按 lastPlayedMs 倒序）。
+  List<GalgameEntry> get _recentlyPlayed {
+    final List<GalgameEntry> played = _games
+        .where((GalgameEntry g) => g.lastPlayedMs > 0)
+        .toList()
+      ..sort((GalgameEntry a, GalgameEntry b) =>
+          b.lastPlayedMs.compareTo(a.lastPlayedMs));
+    return played.take(4).toList();
+  }
+
+  /// 随机取一个游戏：优先保留 [keep]（仍在库里就不动，避免每次重算都跳），否则随机。
+  GalgameEntry? _pickRandom(List<GalgameEntry> games, {GalgameEntry? keep}) {
+    if (games.isEmpty) return null;
+    if (keep != null) {
+      for (final GalgameEntry g in games) {
+        if (g.id == keep.id) return g;
+      }
+    }
+    return games[math.Random().nextInt(games.length)];
+  }
+
+  void _reroll() {
+    if (_games.isEmpty) return;
+    setState(() {
+      final GalgameEntry current = _random ?? _games.first;
+      GalgameEntry next = current;
+      // 库里 >1 个游戏时保证换到不同的一个。
+      for (int i = 0;
+          i < 8 && next.id == current.id && _games.length > 1;
+          i++) {
+        next = _games[math.Random().nextInt(_games.length)];
+      }
+      _random = next;
+    });
+  }
+
+  /// 启动一个游戏（复用库页 launch 路径：非 Windows 提示不支持；Windows 按位数确保
+  /// helper 就位后交给 app 级 Hook 会话）。带再入守卫，失败给可执行处置文案。
+  Future<void> _launchGame(GalgameEntry game) async {
+    if (_launching) return;
+    _launching = true;
+    try {
+      if (!Platform.isWindows) {
+        HibikiToast.show(msg: t.games_launch_unsupported);
+        return;
+      }
+      if (!File(game.exePath).existsSync()) {
+        HibikiToast.show(msg: t.games_exe_missing);
+        return;
+      }
+      final bool is32Bit =
+          await EngineHookGalAudioSource.exeIs32Bit(game.exePath) ?? false;
+      if (GalHookSessionController.defaultInjectorResolver(is32Bit: is32Bit) ==
+          null) {
+        if (!mounted) return;
+        final bool installed = await GalgameHelperInstaller().ensureInjector(
+          is32Bit: is32Bit,
+          context: context,
+        );
+        if (!installed || !mounted) return;
+      }
+      final GalHookSessionController controller =
+          widget.sessionController ?? GalHookSessionController.instance;
+      final bool launched = await controller.launchGame(game.exePath);
+      if (!mounted) return;
+      if (!launched) {
+        final GalHookSessionState state = controller.state;
+        HibikiToast.show(
+          msg: galHookFailureLabel(state.injectorFailure) ??
+              state.lastError ??
+              t.game_capture_launch_failed,
+        );
+        return;
+      }
+      widget.onLaunched?.call();
+    } finally {
+      _launching = false;
+    }
+  }
+
+  /// 打开详情页；返回后重载（把详情页的编辑 / 刮削同步回首屏）。
+  Future<void> _openDetail(GalgameEntry game) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext ctx) => GalgameDetailPage(
+          gameId: game.id,
+          onLaunch: () {
+            final GalgameEntry? latest = _repo.byId(game.id);
+            if (latest != null) unawaited(_launchGame(latest));
+          },
+        ),
+      ),
+    );
+    await _reload();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DesktopContentLayout(
+      kind: DesktopContentKind.readerShelf,
+      child: Column(
+        children: <Widget>[
+          HibikiPageHeader(
+            title: t.nav_game,
+            subtitle: t.game_home_subtitle,
+            bottom: GameSectionTabs(
+              selected: GameSection.dashboard,
+              focusIdPrefix: 'game-dashboard-tab',
+              onSelectLibrary: widget.onShowLibrary,
+              onSelectMonitor: widget.onShowMonitor,
+              onSelectDiagnostics: widget.onShowDiagnostics,
+            ),
+          ),
+          Expanded(
+            child: _games.isEmpty ? _buildEmpty(context) : _buildBody(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 空库态：与库页同款图标 + 提示 + 「添加游戏」入口（切到库页添加）。
+  Widget _buildEmpty(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Icon(Icons.videogame_asset_outlined,
+              size: 64, color: colors.onSurfaceVariant),
+          const SizedBox(height: 16),
+          Text(
+            t.games_empty,
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: colors.onSurfaceVariant,
+                ),
+          ),
+          const SizedBox(height: 16),
+          FilledButton.icon(
+            onPressed: widget.onShowLibrary,
+            icon: const Icon(Icons.add),
+            label: Text(t.games_add),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 有游戏态：KPI 条 + （宽屏）左右两列 /（窄屏）纵向堆叠。
+  Widget _buildBody(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final bool wide = constraints.maxWidth >= 1000;
+        final Widget left = _buildLeftColumn(context);
+        final Widget timeline = _buildTimeline(context);
+        final Widget content = wide
+            ? Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Expanded(flex: 6, child: left),
+                  SizedBox(width: tokens.spacing.card),
+                  Expanded(flex: 5, child: timeline),
+                ],
+              )
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  left,
+                  SizedBox(height: tokens.spacing.card),
+                  timeline,
+                ],
+              );
+        return SingleChildScrollView(
+          padding: EdgeInsets.fromLTRB(
+            tokens.spacing.page,
+            tokens.spacing.rowVertical,
+            tokens.spacing.page,
+            tokens.spacing.section,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              _buildKpiStrip(context),
+              SizedBox(height: tokens.spacing.card),
+              content,
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  // ── 区域 A：KPI 条 ────────────────────────────────────────────────────────
+
+  Widget _buildKpiStrip(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final List<Widget> cells = <Widget>[
+      _KpiCell(
+        icon: Icons.sports_esports_outlined,
+        value: '${_kpis.totalGames}',
+        label: t.game_kpi_total_games,
+      ),
+      _KpiCell(
+        icon: Icons.timelapse_outlined,
+        value: formatStatTime(_kpis.totalSeconds * 1000),
+        label: t.game_stat_total_time,
+      ),
+      _KpiCell(
+        icon: Icons.today_outlined,
+        value: formatStatTime(_kpis.todaySeconds * 1000),
+        label: t.game_stat_today,
+      ),
+      _KpiCell(
+        icon: Icons.date_range_outlined,
+        value: formatStatTime(_kpis.weekSeconds * 1000),
+        label: t.game_kpi_week,
+      ),
+    ];
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final double gap = tokens.spacing.gap + 4;
+        // 单行四等分（宽屏）；窄屏降级 2×2。
+        if (constraints.maxWidth >= 640) {
+          return Row(
+            children: <Widget>[
+              for (int i = 0; i < cells.length; i++) ...<Widget>[
+                if (i > 0) SizedBox(width: gap),
+                Expanded(child: cells[i]),
+              ],
+            ],
+          );
+        }
+        return Column(
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Expanded(child: cells[0]),
+                SizedBox(width: gap),
+                Expanded(child: cells[1]),
+              ],
+            ),
+            SizedBox(height: gap),
+            Row(
+              children: <Widget>[
+                Expanded(child: cells[2]),
+                SizedBox(width: gap),
+                Expanded(child: cells[3]),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  // ── 左列：Focus 卡 + 随机游戏卡 ──────────────────────────────────────────
+
+  Widget _buildLeftColumn(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final GalgameEntry? recent = _recentGame ?? _random;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        if (recent != null) _buildFocusCard(context, recent),
+        if (recent != null && _random != null)
+          SizedBox(height: tokens.spacing.card),
+        if (_random != null) _buildRandomSection(context, _random!),
+      ],
+    );
+  }
+
+  /// Focus 卡（最近游玩）：封面出血作背景 + 左→右深色渐变蒙版，内容叠在上面。
+  Widget _buildFocusCard(BuildContext context, GalgameEntry game) {
+    final ThemeData theme = Theme.of(context);
+    final bool hasPlayed = game.lastPlayedMs > 0;
+    final String statusLabel = game.playStatus == GalgamePlayStatus.playing
+        ? t.games_status_playing
+        : (hasPlayed ? t.game_focus_continue : t.game_launch);
+    final List<String> subParts = <String>[
+      if (hasPlayed)
+        '${t.game_stat_last_played}  ${_formatDay(game.lastPlayedMs)}',
+      '${t.game_stat_total_time}  ${formatStatTime(game.totalPlaySeconds * 1000)}',
+    ];
+    final List<GalgameEntry> recent = _recentlyPlayed;
+
+    return ClipRRect(
+      borderRadius: HibikiBorderRadius.poster,
+      child: Stack(
+        children: <Widget>[
+          // 封面出血背景。
+          Positioned.fill(child: _coverImage(context, game)),
+          // 左→右深色渐变蒙版（蒙版内容色，非 surface 语义角色，允许字面深色）。
+          const Positioned.fill(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.centerLeft,
+                  end: Alignment.centerRight,
+                  colors: <Color>[
+                    Color(0xF00B1017),
+                    Color(0xC00B1017),
+                    Color(0x300B1017),
+                  ],
+                  stops: <double>[0.0, 0.55, 1.0],
+                ),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                _StatusPill(label: statusLabel),
+                const SizedBox(height: 12),
+                Text(
+                  game.displayName,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.headlineLarge?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  subParts.join('   ·   '),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: Colors.white.withValues(alpha: 0.82),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: <Widget>[
+                    FilledButton.icon(
+                      onPressed: () => unawaited(_launchGame(game)),
+                      icon: const Icon(Icons.play_arrow),
+                      label: Text(t.game_launch),
+                    ),
+                    const SizedBox(width: 12),
+                    OutlinedButton.icon(
+                      onPressed: () => unawaited(_openDetail(game)),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.white,
+                        side: BorderSide(
+                          color: Colors.white.withValues(alpha: 0.5),
+                        ),
+                      ),
+                      icon: const Icon(Icons.info_outline),
+                      label: Text(t.games_view_detail),
+                    ),
+                  ],
+                ),
+                if (recent.isNotEmpty) ...<Widget>[
+                  const SizedBox(height: 20),
+                  Text(
+                    t.game_recently_played,
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: Colors.white.withValues(alpha: 0.7),
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: <Widget>[
+                      for (final GalgameEntry g in recent) ...<Widget>[
+                        _RecentThumb(
+                          cover: _coverImage(context, g),
+                          onTap: () => unawaited(_launchGame(g)),
+                          semanticLabel: g.displayName,
+                        ),
+                        const SizedBox(width: 8),
+                      ],
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 随机游戏卡（固定约 150 高）：缩略图 + 标题 / 开发商 / 标签 + 换一个 / 启动。
+  Widget _buildRandomSection(BuildContext context, GalgameEntry game) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colors = theme.colorScheme;
+    final List<String> tags = game.tags.take(3).toList();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: Text(
+                t.game_random_title,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: colors.onSurface,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            HibikiActionChip(
+              label: t.game_random_reroll,
+              icon: Icons.casino_outlined,
+              onPressed: _reroll,
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        HibikiCard(
+          padding: const EdgeInsets.all(12),
+          focusId: HibikiFocusId('game-dashboard-random-${game.id}'),
+          onTap: () => unawaited(_launchGame(game)),
+          onSecondaryTap: () => unawaited(_openDetail(game)),
+          child: SizedBox(
+            height: 126,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                AspectRatio(
+                  aspectRatio: 3 / 4,
+                  child: ClipRRect(
+                    borderRadius: HibikiBorderRadius.control,
+                    child: _coverImage(context, game),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        game.displayName,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          color: colors.onSurface,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      if (game.developer != null &&
+                          game.developer!.isNotEmpty) ...<Widget>[
+                        const SizedBox(height: 4),
+                        Text(
+                          game.developer!,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colors.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                      const Spacer(),
+                      if (tags.isNotEmpty)
+                        Wrap(
+                          spacing: 6,
+                          runSpacing: 6,
+                          children: <Widget>[
+                            for (final String tag in tags)
+                              HibikiTagChip(label: tag),
+                          ],
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ── 右列：动态时间线 ─────────────────────────────────────────────────────
+
+  Widget _buildTimeline(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final List<ActivityEventRow> filtered = _timelineFilter == null
+        ? _timelineRows
+        : _timelineRows
+            .where((ActivityEventRow r) => r.eventType == _timelineFilter)
+            .toList();
+    final List<ActivityDateGroup> groups = aggregateActivityEvents(filtered);
+    final DateTime now = DateTime.now();
+    final String todayKey = HibikiTimeFormat.dayKey(now);
+    final String yesterdayKey =
+        HibikiTimeFormat.dayKey(now.subtract(const Duration(days: 1)));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Text(
+          t.home_activity,
+          style: theme.textTheme.titleMedium?.copyWith(
+            color: theme.colorScheme.onSurface,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        SizedBox(height: tokens.spacing.gap),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: <Widget>[
+            _timelineChip(null, t.home_filter_all),
+            _timelineChip(kActivityGame, t.home_filter_game),
+            _timelineChip(kActivityAdded, t.home_filter_added),
+          ],
+        ),
+        SizedBox(height: tokens.spacing.gap),
+        if (groups.isEmpty)
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: tokens.spacing.card),
+            child: Text(t.home_activity_empty, style: tokens.type.metadata),
+          )
+        else
+          for (final ActivityDateGroup g in groups)
+            _buildTimelineGroup(context, g, todayKey, yesterdayKey, now),
+      ],
+    );
+  }
+
+  Widget _timelineChip(String? value, String label) {
+    return HibikiSelectableChip(
+      label: label,
+      selected: _timelineFilter == value,
+      onSelected: (_) => setState(() => _timelineFilter = value),
+    );
+  }
+
+  Widget _buildTimelineGroup(
+    BuildContext context,
+    ActivityDateGroup group,
+    String todayKey,
+    String yesterdayKey,
+    DateTime now,
+  ) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final String label;
+    if (group.dateKey == todayKey) {
+      label = t.home_today;
+    } else if (group.dateKey == yesterdayKey) {
+      label = t.home_yesterday;
+    } else {
+      label = formatStatHeatmapDay(group.dateKey);
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Padding(
+          padding: EdgeInsets.only(
+            top: tokens.spacing.gap,
+            bottom: tokens.spacing.gap / 2,
+          ),
+          child: Text(label, style: tokens.type.sectionLabel),
+        ),
+        for (int i = 0; i < group.entries.length; i++)
+          _buildTimelineEntry(
+            context,
+            group.entries[i],
+            now,
+            isLast: i == group.entries.length - 1,
+          ),
+      ],
+    );
+  }
+
+  Widget _buildTimelineEntry(
+    BuildContext context,
+    ActivityEntry entry,
+    DateTime now, {
+    required bool isLast,
+  }) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colors = theme.colorScheme;
+    final GalgameEntry? game = _gameForActivity(entry);
+    final List<String> parts = <String>[
+      _actionWord(entry.eventType),
+      _relativeTime(entry.latestTimestampMs, now),
+      if (entry.sessionCount > 1) t.home_session_count(n: entry.sessionCount),
+    ];
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          // 左侧竖轨 + 圆节点。
+          Column(
+            children: <Widget>[
+              Container(
+                width: 12,
+                height: 12,
+                margin: const EdgeInsets.only(top: 6),
+                decoration: BoxDecoration(
+                  color: colors.primary,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              if (!isLast)
+                Expanded(
+                  child: Container(
+                    width: 2,
+                    color: colors.outlineVariant,
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(width: 12),
+          // 头像（游戏封面缩略，命中不到回退图标）。
+          _TimelineAvatar(
+            cover: game == null ? null : _coverImage(context, game),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Text(
+                    entry.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: colors.onSurface,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    parts.join('  ·  '),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: colors.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 活动条 → 对应的库内游戏（先按 mediaKey==id，再按显示名匹配；查不到返回 null）。
+  GalgameEntry? _gameForActivity(ActivityEntry entry) {
+    final String? key = entry.mediaKey;
+    for (final GalgameEntry g in _games) {
+      if (key != null && g.id == key) return g;
+    }
+    for (final GalgameEntry g in _games) {
+      if (g.displayName == entry.title) return g;
+    }
+    return null;
+  }
+
+  String _actionWord(String eventType) {
+    switch (eventType) {
+      case kActivityAdded:
+        return t.home_filter_added;
+      case kActivityGame:
+        return t.home_filter_game;
+      default:
+        return t.home_filter_all;
+    }
+  }
+
+  String _relativeTime(int timestampMs, DateTime now) {
+    final ActivityRelativeTime rel = activityRelativeTime(timestampMs, now);
+    switch (rel.unit) {
+      case ActivityRelativeUnit.justNow:
+        return t.activity_just_now;
+      case ActivityRelativeUnit.minutesAgo:
+        return t.activity_minutes_ago(n: rel.value);
+      case ActivityRelativeUnit.hoursAgo:
+        return t.activity_hours_ago(n: rel.value);
+      case ActivityRelativeUnit.daysAgo:
+        return t.activity_days_ago(n: rel.value);
+    }
+  }
+
+  String _formatDay(int epochMs) =>
+      HibikiTimeFormat.dayKey(DateTime.fromMillisecondsSinceEpoch(epochMs));
+
+  /// 封面 widget：有 coverPath 且文件存在则显示图片（cover 铺满），否则默认手柄图标
+  /// 占位（回落逻辑与库页卡片一致）。
+  Widget _coverImage(BuildContext context, GalgameEntry game) {
+    final String? cover = game.coverPath;
+    if (cover != null && cover.isNotEmpty && File(cover).existsSync()) {
+      return Image.file(
+        File(cover),
+        fit: BoxFit.cover,
+        errorBuilder: (BuildContext context, Object error, StackTrace? stack) =>
+            _coverFallback(context),
+      );
+    }
+    return _coverFallback(context);
+  }
+
+  Widget _coverFallback(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return ColoredBox(
+      color: tokens.surfaces.overlay,
+      child: Center(
+        child: Icon(
+          Icons.videogame_asset,
+          color: tokens.surfaces.onVariant,
+          size: 32,
+        ),
+      ),
+    );
+  }
+}
+
+/// KPI 单格：图标盒 + 数值（大号粗体）+ 标签（小号次要色）。
+class _KpiCell extends StatelessWidget {
+  const _KpiCell({
+    required this.icon,
+    required this.value,
+    required this.label,
+  });
+
+  final IconData icon;
+  final String value;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colors = theme.colorScheme;
+    return HibikiCard(
+      padding: const EdgeInsets.all(14),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: 60),
+        child: Row(
+          children: <Widget>[
+            Container(
+              width: 42,
+              height: 42,
+              decoration: BoxDecoration(
+                color: colors.primary.withValues(alpha: 0.12),
+                borderRadius: HibikiBorderRadius.control,
+              ),
+              child: Icon(icon, color: colors.primary, size: 22),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    value,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.headlineMedium?.copyWith(
+                      color: colors.onSurface,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      color: colors.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Focus 卡左上角的状态胶囊（叠在深色封面上，主色底 + 白字）。
+class _StatusPill extends StatelessWidget {
+  const _StatusPill({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primary,
+        borderRadius: HibikiBorderRadius.chip,
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelMedium?.copyWith(
+          color: theme.colorScheme.onPrimary,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}
+
+/// Focus 卡底部「最近玩过」缩略图（3:4 小海报，可点启动）。
+class _RecentThumb extends StatelessWidget {
+  const _RecentThumb({
+    required this.cover,
+    required this.onTap,
+    required this.semanticLabel,
+  });
+
+  final Widget cover;
+  final VoidCallback onTap;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: semanticLabel,
+      button: true,
+      child: GestureDetector(
+        onTap: onTap,
+        child: SizedBox(
+          width: 44,
+          height: 58,
+          child: ClipRRect(
+            borderRadius: HibikiBorderRadius.chip,
+            child: cover,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 时间线头像：游戏封面缩略（命中）或类型占位图标。
+class _TimelineAvatar extends StatelessWidget {
+  const _TimelineAvatar({required this.cover});
+
+  final Widget? cover;
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final Widget child = cover ??
+        ColoredBox(
+          color: tokens.surfaces.overlay,
+          child: Icon(
+            Icons.videogame_asset,
+            size: 18,
+            color: tokens.surfaces.onVariant,
+          ),
+        );
+    return SizedBox(
+      width: 36,
+      height: 36,
+      child: ClipRRect(
+        borderRadius: HibikiBorderRadius.chip,
+        child: child,
+      ),
+    );
+  }
+}

--- a/hibiki/lib/src/pages/implementations/game_shared.dart
+++ b/hibiki/lib/src/pages/implementations/game_shared.dart
@@ -11,12 +11,14 @@ import 'package:hibiki/utils.dart';
 /// `_formatTime` 两份拷贝、section tab chip 行三份拷贝，且多处枚举 `.name`
 /// 直接上屏（camelCase 英文暴露给 17 语言用户）。
 
-/// 游戏页子区。
-enum GameSection { library, monitor, diagnostics }
+/// 游戏页子区。[dashboard] 是游戏模块的默认首屏（游戏首页/仪表盘），排在最前，
+/// 库/工作台/诊断顺延——枚举顺序即 [HomeGamePage] 的 IndexedStack 索引顺序。
+enum GameSection { dashboard, library, monitor, diagnostics }
 
-/// App 级游戏页子区导航。原生 Hook 浮窗可在主窗最小化时请求回到捕获工作台。
+/// App 级游戏页子区导航。默认停在游戏首页（[GameSection.dashboard]）；原生 Hook
+/// 浮窗可在主窗最小化时请求回到捕获工作台（写 [GameSection.monitor]）。
 final ValueNotifier<GameSection> gameSectionNotifier =
-    ValueNotifier<GameSection>(GameSection.library);
+    ValueNotifier<GameSection>(GameSection.dashboard);
 
 /// Hook 会话音频后端的用户可读标签。
 String galHookAudioBackendLabel(GalHookAudioBackend backend) =>
@@ -87,6 +89,7 @@ class GameSectionTabs extends StatelessWidget {
     required this.onSelectLibrary,
     required this.onSelectMonitor,
     required this.onSelectDiagnostics,
+    this.onSelectDashboard,
     super.key,
   });
 
@@ -95,6 +98,11 @@ class GameSectionTabs extends StatelessWidget {
 
   /// focusId 前缀（如 `game-library-tab`）。
   final String focusIdPrefix;
+
+  /// 游戏首页（仪表盘）页签回调。可空：未接线时回落到直接写
+  /// [gameSectionNotifier]（[HomeGamePage] 监听该 notifier 完成导航），这样不改
+  /// 捕获工作台 / 诊断页的构造签名也能让「首页」页签在三页里都工作。
+  final VoidCallback? onSelectDashboard;
 
   final VoidCallback onSelectLibrary;
   final VoidCallback onSelectMonitor;
@@ -106,6 +114,15 @@ class GameSectionTabs extends StatelessWidget {
       scrollDirection: Axis.horizontal,
       child: Row(
         children: <Widget>[
+          HibikiSelectableChip(
+            label: t.game_dashboard,
+            leadingIcon: Icons.dashboard_outlined,
+            selected: selected == GameSection.dashboard,
+            focusId: HibikiFocusId('$focusIdPrefix-dashboard'),
+            onSelected: (_) => (onSelectDashboard ??
+                () => gameSectionNotifier.value = GameSection.dashboard)(),
+          ),
+          const SizedBox(width: 8),
           HibikiSelectableChip(
             label: t.game_library,
             leadingIcon: Icons.sports_esports_outlined,

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -17,9 +17,6 @@ import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/mining/galgame_library_query.dart';
 import 'package:hibiki/src/mining/galgame_repository.dart';
 import 'package:hibiki/src/pages/implementations/galgame_detail_page.dart';
-// 书架卡片规格单一真相源（kShelfBookCardAspectRatio / kShelfTitleFooterHeight）。
-import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart'
-    show kShelfBookCardAspectRatio, kShelfTitleFooterHeight;
 import 'package:hibiki/utils.dart';
 
 /// 首页「游戏」tab：galgame 库。展示用户添加的游戏网格，点击一个游戏经
@@ -640,25 +637,22 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
     );
   }
 
-  /// 游戏网格（无「继续游戏」/热力图，纯列表）。
+  /// 游戏海报网格（对齐 ReinaManager 库页：3:4 竖版海报卡，见
+  /// `docs/design/galgame-library-reina-visual-parity.md` §1）。
   ///
-  /// 卡槽规格对齐书架（巡检 C4：旧硬编码 180/0.72 自成一派）：extent 走书架的
-  /// 响应式断点 [readerShelfGridExtentForLayout]，槽比用 [kShelfBookCardAspectRatio]，
-  /// 标题在固定 40px footer（[kShelfTitleFooterHeight]）里，同一封面在书架与游戏库
-  /// 同形同宽。
+  /// 不再套书架的 extent/比例：galgame 是竖版海报（3:4 封面 + 下方标题），与横向
+  /// 偏方的书封不同形。maxCrossAxisExtent≈168（ReinaManager 海报宽档），间距 16，
+  /// childAspectRatio 按「3:4 封面 + 一行标题」估（约 0.62），标题超长由卡内省略。
   Widget _buildGrid(BuildContext context, List<GalgameEntry> visible) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         return GridView.builder(
-          padding: const EdgeInsets.fromLTRB(12, 12, 12, 88),
-          gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-            maxCrossAxisExtent: readerShelfGridExtentForLayout(
-              mediaWidth: MediaQuery.sizeOf(context).width,
-              contentWidth: constraints.maxWidth,
-            ),
-            mainAxisSpacing: 12,
-            crossAxisSpacing: 12,
-            childAspectRatio: kShelfBookCardAspectRatio,
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 88),
+          gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+            maxCrossAxisExtent: 168,
+            mainAxisSpacing: 16,
+            crossAxisSpacing: 16,
+            childAspectRatio: 0.62,
           ),
           itemCount: visible.length,
           itemBuilder: (BuildContext context, int i) => _GameCard(
@@ -870,110 +864,50 @@ class _GameCard extends StatelessWidget {
     final ColorScheme colors = Theme.of(context).colorScheme;
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     final String? sort = sortLabel;
-    return HibikiCard(
-      padding: EdgeInsets.zero,
+    // 竖版海报卡（对齐 ReinaManager 库页观感）：封面 3:4 + 标题居中 + 底部排序
+    // 浮层 + hover 放大 + 主色选中环，全部由共享组件 [GalgamePosterCard] 负责。
+    // focusId 沿用 `game-card-<id>`（手柄/键盘可 requestById 聚焦，focus 测试守）。
+    return GalgamePosterCard(
+      cover: _buildCover(colors),
+      title: game.displayName,
+      overlayText: sort,
       focusId: HibikiFocusId('game-card-${game.id}'),
       onTap: onTap,
       onLongPress: () => unawaited(_showContextMenu(context)),
       onSecondaryTap: () => unawaited(_showContextMenu(context)),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          Expanded(
-            child: Stack(
-              fit: StackFit.expand,
-              children: <Widget>[
-                _buildCover(colors),
-                Positioned(
-                  top: 0,
-                  right: 0,
-                  child: PopupMenuButton<String>(
-                    // 半透明 scrim 圆底承托图标（书架选择勾同款调性），替代
-                    // Colors.black54 阴影——浅色封面上阴影对比不足且 eink 下发灰。
-                    icon: Container(
-                      padding: const EdgeInsets.all(4),
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: tokens.surfaces.page.withValues(
-                          alpha: isEinkTheme(context) ? 1 : 0.7,
-                        ),
-                        border: Border.all(color: tokens.surfaces.outline),
-                      ),
-                      child: Icon(
-                        Icons.more_vert,
-                        size: 18,
-                        color: colors.onSurface,
-                      ),
-                    ),
-                    onSelected: _dispatchAction,
-                    itemBuilder: (BuildContext context) =>
-                        <PopupMenuEntry<String>>[
-                      for (final (String value, String label) item
-                          in _menuItems)
-                        PopupMenuItem<String>(
-                          value: item.$1,
-                          child: Text(item.$2),
-                        ),
-                    ],
-                  ),
-                ),
-                if (sort != null && sort.isNotEmpty)
-                  Positioned(
-                    left: 4,
-                    bottom: 4,
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 6, vertical: 2),
-                      decoration: BoxDecoration(
-                        color: tokens.surfaces.page.withValues(
-                          alpha: isEinkTheme(context) ? 1 : 0.78,
-                        ),
-                        borderRadius: BorderRadius.circular(8),
-                        border: Border.all(color: tokens.surfaces.outline),
-                      ),
-                      child: Text(
-                        sort,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: tokens.type.metadata.copyWith(
-                          color: tokens.surfaces.onSurface,
-                        ),
-                      ),
-                    ),
-                  ),
-              ],
-            ),
-          ),
-          // 与书架书卡同款固定标题 footer（40px，长名不推挤网格）。
-          SizedBox(
-            height: kShelfTitleFooterHeight,
-            child: Padding(
-              padding: EdgeInsetsDirectional.fromSTEB(
-                tokens.spacing.gap * 0.75,
-                tokens.spacing.gap / 2,
-                tokens.spacing.gap * 0.75,
-                0,
-              ),
-              child: Align(
-                alignment: Alignment.topCenter,
-                child: Text(
-                  game.displayName,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.center,
-                  softWrap: true,
-                  style: tokens.type.metadata.copyWith(
-                    color: tokens.surfaces.onSurface,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
+      trailing: _menuButton(context, colors, tokens),
+      semanticLabel: game.displayName,
     );
   }
+
+  /// 卡片右上角的更多菜单按钮（半透明 scrim 圆底承托图标，浅色封面上也清晰）。
+  Widget _menuButton(
+    BuildContext context,
+    ColorScheme colors,
+    HibikiDesignTokens tokens,
+  ) {
+    return PopupMenuButton<String>(
+      icon: Container(
+        padding: const EdgeInsets.all(4),
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: tokens.surfaces.page.withValues(
+            alpha: isEinkTheme(context) ? 1 : 0.7,
+          ),
+          border: Border.all(color: tokens.surfaces.outline),
+        ),
+        child: Icon(Icons.more_vert, size: 18, color: colors.onSurface),
+      ),
+      onSelected: _dispatchAction,
+      itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+        for (final (String value, String label) item in _menuItems)
+          PopupMenuItem<String>(value: item.$1, child: Text(item.$2)),
+      ],
+    );
+  }
+
+  // ── 旧的手搭卡片（HibikiCard + Stack + 手抄标题 footer）已由上面的
+  //    GalgamePosterCard 取代，_buildCover / _defaultCover 仍复用。──
 
   /// 封面：有 coverPath 且文件存在则显示图片，否则默认手柄图标占位。
   Widget _buildCover(ColorScheme colors) {

--- a/hibiki/lib/src/pages/implementations/home_game_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_game_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/pages/implementations/galgame_home_page.dart';
 import 'package:hibiki/src/pages/implementations/game_diagnostics_page.dart';
 import 'package:hibiki/src/pages/implementations/game_shared.dart';
 import 'package:hibiki/src/pages/implementations/games_library_page.dart';
@@ -22,6 +23,13 @@ typedef GameLibraryBuilder = Widget Function(
   VoidCallback onLaunched,
 );
 
+/// 游戏首页（仪表盘）子页构造器；测试可注入桩，绕开 [GalgameHomePage] 对
+/// `appProvider`（Drift DB / 仓储）的依赖。
+typedef GameDashboardBuilder = Widget Function(
+  BuildContext context,
+  VoidCallback onShowLibrary,
+);
+
 /// 首页一级「游戏」模块。
 ///
 /// 集成持久化游戏库、Hook 监控工作台与兼容性诊断。内部使用 [IndexedStack]，
@@ -32,13 +40,16 @@ class HomeGamePage extends StatefulWidget {
     super.key,
     this.monitorBuilder,
     this.libraryBuilder,
+    this.dashboardBuilder,
     this.controller,
   });
 
   final GameMonitorBuilder? monitorBuilder;
   final GameLibraryBuilder? libraryBuilder;
+  final GameDashboardBuilder? dashboardBuilder;
   final GalHookSessionController? controller;
 
+  static const Key dashboardKey = ValueKey<String>('game-dashboard');
   static const Key libraryKey = ValueKey<String>('game-library');
   static const Key monitorKey = ValueKey<String>('game-monitor');
   static const Key diagnosticsKey = ValueKey<String>('game-diagnostics');
@@ -65,8 +76,9 @@ class _HomeGamePageState extends State<HomeGamePage> {
   void dispose() {
     gameSectionNotifier.removeListener(_onSectionRequested);
     // HomeGamePage 生命周期结束后不要把一次外部导航请求泄漏给下一次挂载（也避免
-    // profile/窗口重建后意外停在旧工作台）。运行中的页面仍由 notifier 正常保态。
-    gameSectionNotifier.value = GameSection.library;
+    // profile/窗口重建后意外停在旧工作台）。回落到默认首屏（游戏首页）。运行中的
+    // 页面仍由 notifier 正常保态。
+    gameSectionNotifier.value = GameSection.dashboard;
     super.dispose();
   }
 
@@ -84,6 +96,7 @@ class _HomeGamePageState extends State<HomeGamePage> {
     _onSectionRequested();
   }
 
+  void _showDashboard() => _showSection(GameSection.dashboard);
   void _showLibrary() => _showSection(GameSection.library);
   void _showMonitor() => _showSection(GameSection.monitor);
   void _showDiagnostics() => _showSection(GameSection.diagnostics);
@@ -96,11 +109,23 @@ class _HomeGamePageState extends State<HomeGamePage> {
               onShowLibrary: onShowLibrary,
               onShowDiagnostics: _showDiagnostics,
             );
+    final GameDashboardBuilder dashboardBuilder = widget.dashboardBuilder ??
+        (BuildContext context, VoidCallback onShowLibrary) => GalgameHomePage(
+              sessionController: _controller,
+              onShowLibrary: onShowLibrary,
+              onShowMonitor: _showMonitor,
+              onShowDiagnostics: _showDiagnostics,
+              onLaunched: _showMonitor,
+            );
     return Material(
       type: MaterialType.transparency,
       child: IndexedStack(
         index: _section.index,
         children: <Widget>[
+          KeyedSubtree(
+            key: HomeGamePage.dashboardKey,
+            child: dashboardBuilder(context, _showLibrary),
+          ),
           KeyedSubtree(
             key: HomeGamePage.libraryKey,
             child: _buildLibrary(context),
@@ -135,6 +160,7 @@ class _HomeGamePageState extends State<HomeGamePage> {
             bottom: GameSectionTabs(
               selected: GameSection.library,
               focusIdPrefix: 'game-library-tab',
+              onSelectDashboard: _showDashboard,
               onSelectLibrary: _showLibrary,
               onSelectMonitor: _showMonitor,
               onSelectDiagnostics: _showDiagnostics,

--- a/hibiki/lib/src/utils/components/galgame_poster_card.dart
+++ b/hibiki/lib/src/utils/components/galgame_poster_card.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+
+import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
+
+/// galgame 竖版海报卡（对齐 ReinaManager 库页/首页的卡片观感，见
+/// `docs/design/galgame-library-reina-visual-parity.md` §1）。
+///
+/// 共享设计系统组件：封面 3:4、圆角 [HibikiBorderRadius.poster]、hover 放大 1.05 +
+/// 阴影加深、选中 2px 主色环、封面底部可选「排序信息」渐变浮层、封面下方居中单行标题。
+///
+/// 刻意**不做文件 IO**：[cover] 由调用方传入（`Image.file` / 占位图 / 网络图都行），
+/// 这样卡片本身是纯 widget、可 widget-test，也不与封面来源耦合。
+///
+/// 圆角走 token、字号走 textTheme、颜色走 colorScheme 语义角色，是设计系统组件而非页面
+/// chrome，故在 MD3 静态守卫的 allowlist 内（同 `hibiki_material_components.dart`）。
+class GalgamePosterCard extends StatefulWidget {
+  const GalgamePosterCard({
+    super.key,
+    required this.cover,
+    required this.title,
+    this.overlayText,
+    this.selected = false,
+    this.multiSelected = false,
+    this.onTap,
+    this.onLongPress,
+    this.onSecondaryTap,
+    this.trailing,
+    this.semanticLabel,
+  });
+
+  /// 封面 widget（3:4 会被外层裁剪；建议 `fit: BoxFit.cover`）。
+  final Widget cover;
+
+  /// 标题（封面下方居中，单行省略）。
+  final String title;
+
+  /// 封面底部「排序信息」浮层文本；null / 空则不显示浮层。
+  final String? overlayText;
+
+  /// 选中态（当前详情/焦点）：加 2px 主色环。
+  final bool selected;
+
+  /// 批量多选态：左上角方形勾标（预留，M1.5 暂不启用多选）。
+  final bool multiSelected;
+
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+
+  /// 右键（桌面）→ 一般用于打开详情菜单。
+  final VoidCallback? onSecondaryTap;
+
+  /// 右上角悬浮控件（如更多菜单按钮）。
+  final Widget? trailing;
+
+  final String? semanticLabel;
+
+  @override
+  State<GalgamePosterCard> createState() => _GalgamePosterCardState();
+}
+
+class _GalgamePosterCardState extends State<GalgamePosterCard> {
+  bool _hovering = false;
+
+  void _setHover(bool value) {
+    if (_hovering != value) {
+      setState(() => _hovering = value);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colors = theme.colorScheme;
+
+    final Widget cover = _buildCover(context, colors);
+
+    final Widget titleText = Padding(
+      padding: const EdgeInsets.fromLTRB(6, 8, 6, 2),
+      child: Text(
+        widget.title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        textAlign: TextAlign.center,
+        style: theme.textTheme.titleSmall?.copyWith(
+          fontWeight: FontWeight.w600,
+          color: widget.selected ? colors.primary : colors.onSurface,
+        ),
+      ),
+    );
+
+    final Widget card = Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Flexible(child: cover),
+        titleText,
+      ],
+    );
+
+    // hover 放大 + 阴影：AnimatedScale 做缩放，AnimatedContainer 做阴影过渡。
+    final Widget interactive = MouseRegion(
+      onEnter: (_) => _setHover(true),
+      onExit: (_) => _setHover(false),
+      cursor: widget.onTap == null
+          ? MouseCursor.defer
+          : SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: widget.onTap,
+        onLongPress: widget.onLongPress,
+        onSecondaryTap: widget.onSecondaryTap,
+        behavior: HitTestBehavior.opaque,
+        child: AnimatedScale(
+          scale: _hovering ? 1.05 : 1.0,
+          duration: const Duration(milliseconds: 120),
+          curve: Curves.easeOut,
+          child: card,
+        ),
+      ),
+    );
+
+    return Semantics(
+      label: widget.semanticLabel ?? widget.title,
+      button: widget.onTap != null,
+      selected: widget.selected,
+      child: interactive,
+    );
+  }
+
+  Widget _buildCover(BuildContext context, ColorScheme colors) {
+    const BorderRadius radius = HibikiBorderRadius.poster;
+    final bool elevated = _hovering || widget.selected;
+
+    return AspectRatio(
+      aspectRatio: 3 / 4,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 120),
+        decoration: BoxDecoration(
+          borderRadius: radius,
+          border: widget.selected
+              ? Border.all(color: colors.primary, width: 2)
+              : null,
+          boxShadow: <BoxShadow>[
+            BoxShadow(
+              color: colors.shadow.withValues(alpha: elevated ? 0.28 : 0.12),
+              blurRadius: elevated ? 16 : 6,
+              offset: Offset(0, elevated ? 8 : 3),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: radius,
+          child: Stack(
+            fit: StackFit.expand,
+            children: <Widget>[
+              widget.cover,
+              if (widget.overlayText != null &&
+                  widget.overlayText!.isNotEmpty)
+                _buildSortOverlay(context),
+              if (widget.multiSelected) _buildSelectBadge(colors),
+              if (widget.trailing != null)
+                Positioned(top: 4, right: 4, child: widget.trailing!),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 封面底部的排序信息渐变浮层：白字、单行、左对齐，底部深色渐变蒙版托底。
+  Widget _buildSortOverlay(BuildContext context) {
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 0,
+      child: IgnorePointer(
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(10, 24, 10, 6),
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: <Color>[
+                Color(0x00000000),
+                Color(0x4D0F1720),
+                Color(0xD90F1720),
+              ],
+              stops: <double>[0.0, 0.5, 1.0],
+            ),
+          ),
+          child: Text(
+            widget.overlayText!,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.left,
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w600,
+                  shadows: const <Shadow>[
+                    Shadow(color: Color(0x99000000), blurRadius: 2),
+                  ],
+                ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 左上角方形多选勾标（20×20，主色底 + 勾）。
+  Widget _buildSelectBadge(ColorScheme colors) {
+    return Positioned(
+      top: 6,
+      left: 6,
+      child: Container(
+        width: 20,
+        height: 20,
+        decoration: BoxDecoration(
+          color: colors.primary,
+          borderRadius: HibikiBorderRadius.chip,
+        ),
+        child: Icon(Icons.check, size: 14, color: colors.onPrimary),
+      ),
+    );
+  }
+}

--- a/hibiki/lib/src/utils/components/galgame_poster_card.dart
+++ b/hibiki/lib/src/utils/components/galgame_poster_card.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/focus/hibiki_focus_target.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
 
 /// galgame 竖版海报卡（对齐 ReinaManager 库页/首页的卡片观感，见
@@ -26,6 +28,7 @@ class GalgamePosterCard extends StatefulWidget {
     this.onSecondaryTap,
     this.trailing,
     this.semanticLabel,
+    this.focusId,
   });
 
   /// 封面 widget（3:4 会被外层裁剪；建议 `fit: BoxFit.cover`）。
@@ -53,6 +56,10 @@ class GalgamePosterCard extends StatefulWidget {
   final Widget? trailing;
 
   final String? semanticLabel;
+
+  /// 焦点站点 id（手柄/键盘导航）。传入时注册到 [HibikiFocusRoot]，`Enter`/A 键
+  /// 触发 [onTap]。库页靠它保持 `game-card-<id>` 焦点站点可被 requestById 聚焦。
+  final HibikiFocusId? focusId;
 
   @override
   State<GalgamePosterCard> createState() => _GalgamePosterCardState();
@@ -118,13 +125,37 @@ class _GalgamePosterCardState extends State<GalgamePosterCard> {
       ),
     );
 
-    return Semantics(
+    final Widget semantic = Semantics(
       label: widget.semanticLabel ?? widget.title,
       button: widget.onTap != null,
       selected: widget.selected,
       child: interactive,
     );
+
+    // 焦点注册：与 HibikiCard 同款——有 onTap 且存在焦点根时，注册焦点站点并把
+    // ActivateIntent（Enter / 手柄 A）接到 onTap。无焦点根（纯 widget-test）直接返回。
+    if (widget.onTap == null ||
+        HibikiFocusRoot.maybeControllerOf(context) == null) {
+      return semantic;
+    }
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        ActivateIntent: CallbackAction<ActivateIntent>(
+          onInvoke: (_) {
+            widget.onTap?.call();
+            return null;
+          },
+        ),
+      },
+      child: HibikiFocusTarget(
+        id: widget.focusId ?? _fallbackFocusId,
+        child: semantic,
+      ),
+    );
   }
+
+  late final HibikiFocusId _fallbackFocusId =
+      HibikiFocusId('galgame-poster-${identityHashCode(this)}');
 
   Widget _buildCover(BuildContext context, ColorScheme colors) {
     const BorderRadius radius = HibikiBorderRadius.poster;

--- a/hibiki/lib/src/utils/components/hibiki_design_tokens.dart
+++ b/hibiki/lib/src/utils/components/hibiki_design_tokens.dart
@@ -72,6 +72,10 @@ class HibikiRadii {
   static const double dialogValue = 16;
   static const double sheetValue = 16;
 
+  /// galgame 竖版海报卡的圆角（对齐 ReinaManager 的圆润卡片观感，比 Hibiki 常规
+  /// [cardValue] 稍大一档；见 `docs/design/galgame-library-reina-visual-parity.md`）。
+  static const double posterValue = 16;
+
   final double group;
   final double card;
   final double control;
@@ -101,6 +105,8 @@ abstract final class HibikiBorderRadius {
       BorderRadius.all(Radius.circular(HibikiRadii.groupValue));
   static const BorderRadius card =
       BorderRadius.all(Radius.circular(HibikiRadii.cardValue));
+  static const BorderRadius poster =
+      BorderRadius.all(Radius.circular(HibikiRadii.posterValue));
   static const BorderRadius control =
       BorderRadius.all(Radius.circular(HibikiRadii.controlValue));
   static const BorderRadius chip =

--- a/hibiki/lib/utils.dart
+++ b/hibiki/lib/utils.dart
@@ -20,6 +20,7 @@ export 'src/utils/components/hibiki_text_selection_controls.dart';
 export 'src/utils/components/hibiki_list_tile.dart';
 export 'src/utils/components/hibiki_focusable.dart';
 export 'src/utils/components/hibiki_focus_ring.dart';
+export 'src/utils/components/galgame_poster_card.dart';
 export 'src/utils/components/hibiki_design_tokens.dart';
 export 'src/utils/components/hibiki_motion_tokens.dart';
 export 'src/utils/components/hibiki_material_components.dart';

--- a/hibiki/test/pages/galgame_detail_page_test.dart
+++ b/hibiki/test/pages/galgame_detail_page_test.dart
@@ -140,10 +140,10 @@ void main() {
     expect(find.text(t.game_stat_sessions), findsOneWidget);
     expect(find.text('2'), findsOneWidget);
 
-    // 柱状图与会话流水都在（流水在折叠线以下，先滚上来）。
+    // 折线图与会话流水都在（流水在折叠线以下，先滚上来）。
     expect(
       find.byWidgetPredicate(
-          (Widget w) => w is CustomPaint && w.painter is StatBarChartPainter),
+          (Widget w) => w is CustomPaint && w.painter is StatLineChartPainter),
       findsOneWidget,
     );
     await tester.drag(find.byType(ListView), const Offset(0, -400));
@@ -164,7 +164,9 @@ void main() {
     expect(find.text('这是简介。'), findsOneWidget);
     expect(find.text(t.game_summary_aliases), findsOneWidget);
     expect(find.text('アルファ'), findsOneWidget);
-    expect(find.text(t.game_summary_release_date), findsOneWidget);
+    // 发行日标签现在同时出现在常驻头部的元信息网格与简介 tab（富头部改造后），
+    // 故断言放宽为 findsWidgets（原为 findsOneWidget）。
+    expect(find.text(t.game_summary_release_date), findsWidgets);
     expect(find.text('2024-03-15'), findsWidgets);
   });
 
@@ -221,15 +223,16 @@ void main() {
     await tester.pump(const Duration(seconds: 4)); // 放掉桌面 toast 计时器
   });
 
-  test('buildGalgameMonthChartData 铺满整月且缺省天为 0', () {
-    final List<StatDayData> data = buildGalgameMonthChartData(
-      DateTime(2026, 2),
-      <String, int>{'2026-02-03': 120},
+  test('buildGalgameRangeChartData 铺满区间且缺省天为 0', () {
+    final List<StatDayData> data = buildGalgameRangeChartData(
+      DateTime(2026, 7, 7),
+      7,
+      <String, int>{'2026-07-05': 120},
     );
-    expect(data.length, 28);
-    expect(data.first.dateKey, '2026-02-01');
-    expect(data.last.dateKey, '2026-02-28');
-    expect(data[2].ms, 120 * 1000);
+    expect(data.length, 7);
+    expect(data.first.dateKey, '2026-07-01');
+    expect(data.last.dateKey, '2026-07-07');
+    expect(data[4].ms, 120 * 1000); // 2026-07-05 是第 5 个点（index 4）
     expect(data[0].ms, 0);
   });
 

--- a/hibiki/test/pages/galgame_home_page_test.dart
+++ b/hibiki/test/pages/galgame_home_page_test.dart
@@ -1,0 +1,152 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/mining/galgame_library.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/galgame_home_page.dart';
+import 'package:hibiki/utils.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// 游戏首页（仪表盘）widget 测试：KPI 渲染 / 空态 / 有游戏时 Focus 卡渲染。
+///
+/// 数据经 in-memory Drift DB 注入 [AppModel]（与 game_module_focus_test 同款测试
+/// 接线），首页读仓储 + 会话聚合现算，不建投影表。
+void main() {
+  late Directory tmpDir;
+
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  /// 构造一个接好 in-memory DB + 偏好的 [AppModel]。
+  Future<AppModel> buildAppModel(WidgetTester tester) async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final PreferencesRepository prefsRepo = PreferencesRepository(db);
+    await prefsRepo.loadFromDb();
+    tmpDir = Directory.systemTemp.createTempSync('hibiki_game_home_');
+    addTearDown(() {
+      try {
+        tmpDir.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+    return AppModel(testPlatformServices())
+      ..wireLocalAudioForTesting(
+          prefsRepo: prefsRepo, databaseDirectory: tmpDir)
+      ..wireDatabaseForTesting(db);
+  }
+
+  Future<void> pumpHome(WidgetTester tester, AppModel appModel) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[appProvider.overrideWith((ref) => appModel)],
+        child: TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GalgameHomePage(
+                onShowLibrary: () {},
+                onShowMonitor: () {},
+                onShowDiagnostics: () {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('empty library shows the empty state',
+      (WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final AppModel appModel = await buildAppModel(tester);
+
+    await pumpHome(tester, appModel);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(t.games_empty), findsOneWidget);
+  });
+
+  testWidgets('KPI strip renders total games and labels',
+      (WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final AppModel appModel = await buildAppModel(tester);
+    await appModel.setGalgames(<GalgameEntry>[
+      GalgameEntry(
+        id: 'g1',
+        name: 'First Game',
+        exePath: r'Z:\games\g1.exe',
+        workdir: r'Z:\games',
+        addedAt: DateTime(2026, 7, 20),
+      ),
+      GalgameEntry(
+        id: 'g2',
+        name: 'Second Game',
+        exePath: r'Z:\games\g2.exe',
+        workdir: r'Z:\games',
+        addedAt: DateTime(2026, 7, 21),
+      ),
+    ]);
+
+    await pumpHome(tester, appModel);
+
+    expect(tester.takeException(), isNull);
+    // KPI 标签四格。
+    expect(find.text(t.game_kpi_total_games), findsOneWidget);
+    expect(find.text(t.game_stat_total_time), findsOneWidget);
+    expect(find.text(t.game_stat_today), findsOneWidget);
+    expect(find.text(t.game_kpi_week), findsOneWidget);
+    // 总游戏数值。
+    expect(find.text('2'), findsWidgets);
+  });
+
+  testWidgets('Focus card renders for the most recently played game',
+      (WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final AppModel appModel = await buildAppModel(tester);
+    await appModel.setGalgames(<GalgameEntry>[
+      GalgameEntry(
+        id: 'g1',
+        name: 'Recent Game',
+        exePath: r'Z:\games\g1.exe',
+        workdir: r'Z:\games',
+        addedAt: DateTime(2026, 7, 20),
+      ),
+    ]);
+    // 一段游玩会话 → getGalgamePlayTotals 给出 lastPlayedMs>0，Focus 卡「继续游戏」。
+    final DateTime now = DateTime.now();
+    await appModel.database.insertGalgameSession(
+      GalgameSessionsCompanion.insert(
+        gameId: 'g1',
+        startMs: now.millisecondsSinceEpoch - 600000,
+        endMs: now.millisecondsSinceEpoch,
+        durationSeconds: 600,
+        dateKey: HibikiTimeFormat.dayKey(now),
+      ),
+    );
+
+    await pumpHome(tester, appModel);
+
+    expect(tester.takeException(), isNull);
+    // Focus 卡标题（游戏名，出现在卡片 + 时间线）。
+    expect(find.text('Recent Game'), findsWidgets);
+    // 已游玩过 → 状态胶囊「继续游戏」，启动按钮「启动」。
+    expect(find.text(t.game_focus_continue), findsOneWidget);
+    expect(find.text(t.game_launch), findsWidgets);
+    // 时间线区块标题。
+    expect(find.text(t.home_activity), findsOneWidget);
+  });
+}

--- a/hibiki/test/pages/home_game_page_test.dart
+++ b/hibiki/test/pages/home_game_page_test.dart
@@ -13,9 +13,20 @@ Widget _testLibrary(
 ) =>
     const Center(child: Icon(Icons.sports_esports_outlined));
 
+/// 新增游戏首页（dashboard）后，游戏模块默认停在首页；这些针对库/工作台/诊断的
+/// 断言仍要在「库」子区上验证。用桩 dashboard 绕开首页对 appProvider 的依赖，并在
+/// setUp 里把 IndexedStack 起始子区切到库（与旧默认行为等价）。
+Widget _stubDashboard(BuildContext _, VoidCallback __) => const SizedBox();
+
 void main() {
-  setUp(() => TexthookerService.instance.clear());
-  tearDown(() => TexthookerService.instance.clear());
+  setUp(() {
+    TexthookerService.instance.clear();
+    gameSectionNotifier.value = GameSection.library;
+  });
+  tearDown(() {
+    TexthookerService.instance.clear();
+    gameSectionNotifier.value = GameSection.dashboard;
+  });
 
   testWidgets('library shows real capture count and true empty state',
       (WidgetTester tester) async {
@@ -25,6 +36,7 @@ void main() {
         home: HomeGamePage(
           monitorBuilder: (_, __) => const SizedBox(),
           libraryBuilder: _testLibrary,
+          dashboardBuilder: _stubDashboard,
         ),
       ),
     );
@@ -43,6 +55,7 @@ void main() {
       MaterialApp(
         home: HomeGamePage(
           libraryBuilder: _testLibrary,
+          dashboardBuilder: _stubDashboard,
           monitorBuilder: (_, VoidCallback onShowLibrary) => _TestMonitor(
             onShowLibrary: onShowLibrary,
             onInit: () => initCount++,
@@ -79,6 +92,7 @@ void main() {
           child: HomeGamePage(
             monitorBuilder: (_, __) => const SizedBox(),
             libraryBuilder: _testLibrary,
+            dashboardBuilder: _stubDashboard,
           ),
         ),
       ),
@@ -110,6 +124,7 @@ void main() {
         home: HibikiFocusRoot(
           child: HomeGamePage(
             libraryBuilder: _testLibrary,
+            dashboardBuilder: _stubDashboard,
             monitorBuilder: (_, __) => const Text('focused-monitor'),
           ),
         ),
@@ -143,6 +158,7 @@ void main() {
           home: HomeGamePage(
             monitorBuilder: (_, __) => const SizedBox(),
             libraryBuilder: _testLibrary,
+            dashboardBuilder: _stubDashboard,
           ),
         ),
       );

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -600,6 +600,10 @@ void main() {
           'Token source owns app radii and semantic surface roles.',
       'lib/src/utils/components/hibiki_material_components.dart':
           'Shared MD3 component implementation may map tokens to framework widgets.',
+      'lib/src/utils/components/galgame_poster_card.dart':
+          'Shared galgame poster-card component maps radius/typography/color '
+              'tokens to framework widgets; the class name PosterCard trips the '
+              'crude Card( substring scan.',
       'lib/src/utils/components/settings_shared.dart':
           'Shared adaptive settings primitives own compact settings controls.',
       'lib/src/utils/components/hibiki_dropdown.dart':

--- a/hibiki/test/widgets/galgame_poster_card_test.dart
+++ b/hibiki/test/widgets/galgame_poster_card_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/utils/components/galgame_poster_card.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(width: 160, child: child),
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets('渲染标题 + 封面，3:4 比例', (WidgetTester tester) async {
+    await tester.pumpWidget(_host(
+      const GalgamePosterCard(
+        cover: ColoredBox(color: Colors.blue),
+        title: 'テストゲーム',
+      ),
+    ));
+    expect(find.text('テストゲーム'), findsOneWidget);
+    expect(find.byType(AspectRatio), findsOneWidget);
+    final AspectRatio ar = tester.widget(find.byType(AspectRatio));
+    expect(ar.aspectRatio, 3 / 4);
+  });
+
+  testWidgets('overlayText 有值时显示排序浮层，空时不显示',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_host(
+      const GalgamePosterCard(
+        cover: ColoredBox(color: Colors.blue),
+        title: 'G',
+        overlayText: '8.5 #123',
+      ),
+    ));
+    expect(find.text('8.5 #123'), findsOneWidget);
+
+    await tester.pumpWidget(_host(
+      const GalgamePosterCard(
+        cover: ColoredBox(color: Colors.blue),
+        title: 'G',
+        overlayText: '',
+      ),
+    ));
+    expect(find.text('8.5 #123'), findsNothing);
+  });
+
+  testWidgets('选中态加主色环，标题染主色', (WidgetTester tester) async {
+    await tester.pumpWidget(_host(
+      const GalgamePosterCard(
+        cover: ColoredBox(color: Colors.blue),
+        title: 'Sel',
+        selected: true,
+      ),
+    ));
+    final AnimatedContainer container = tester.widget(
+      find.byType(AnimatedContainer),
+    );
+    final BoxDecoration deco = container.decoration! as BoxDecoration;
+    expect(deco.border, isNotNull, reason: '选中态应有边框环');
+  });
+
+  testWidgets('点击 / 长按 / 右键各自回调', (WidgetTester tester) async {
+    int taps = 0;
+    int longs = 0;
+    int secondary = 0;
+    await tester.pumpWidget(_host(
+      GalgamePosterCard(
+        cover: const ColoredBox(color: Colors.blue),
+        title: 'Tap',
+        onTap: () => taps++,
+        onLongPress: () => longs++,
+        onSecondaryTap: () => secondary++,
+      ),
+    ));
+    await tester.tap(find.byType(GalgamePosterCard));
+    await tester.longPress(find.byType(GalgamePosterCard));
+    expect(taps, 1);
+    expect(longs, 1);
+  });
+
+  testWidgets('multiSelected 显示勾标', (WidgetTester tester) async {
+    await tester.pumpWidget(_host(
+      const GalgamePosterCard(
+        cover: ColoredBox(color: Colors.blue),
+        title: 'M',
+        multiSelected: true,
+      ),
+    ));
+    expect(find.byIcon(Icons.check), findsOneWidget);
+  });
+
+  testWidgets('trailing 控件渲染在卡上', (WidgetTester tester) async {
+    await tester.pumpWidget(_host(
+      const GalgamePosterCard(
+        cover: ColoredBox(color: Colors.blue),
+        title: 'T',
+        trailing: Icon(Icons.more_vert),
+      ),
+    ));
+    expect(find.byIcon(Icons.more_vert), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## galgame 游戏库 UI 对齐 ReinaManager（M1.5 视觉重构）

上一轮（PR#400，已合 develop）对齐了 galgame 库的**信息架构与数据模型**，但 UI 只是套了 Hibiki 现成的书架网格 / 普通 TabBar，**观感与 ReinaManager 完全不像**（用户拿真实截图比过，反馈「表现形式完全不一样」）。本轮把四个界面的**视觉表现**做到接近 ReinaManager。

参考 `references/ReinaManager`（AGPL-3.0），只还原布局观感、不复制其 React/MUI 源码，全部在 Hibiki 现有 Flutter/MD3 设计系统 token 上实现。视觉规格考据见 `docs/design/galgame-library-reina-visual-parity.md`。

### 四个界面

1. **库页 → 竖版海报墙**：新建共享组件 `GalgamePosterCard`（3:4 封面、圆角 poster token、hover 放大 1.05、选中 2px 主色环、封面底部排序信息渐变浮层、居中标题）。库页网格从「套书架横向比例」改成海报网格（maxExtent 168 / 间距 16）。海报卡带焦点支持（手柄/键盘 `game-card-<id>` 站点不丢）。

2. **详情页 → 富头部 + 折线图**：封面居左（3:4, max 160×260）+ 右侧元信息（数据来源/开发商 chip、发布/添加时间、预计时长、排行、站点·我的评分双 chip、标签区含选中态 + 40 上限展开/折叠）。每日游玩图从柱状换**折线**（复用既有 `StatLineChartPainter`，线色主题色不硬编码，7D/30D 切换）。窄屏降级单列。

3. **游戏首页/仪表盘（新增）**：作为游戏模块新默认子页。4 格 KPI 条（总游戏数/总时长/今日/本周）+ Focus 大卡（最近游玩，封面出血背景 + 深色渐变蒙版 + 状态胶囊 + 启动/详情 + 最近玩过 4 格）+ 随机游戏卡 + 动态时间线（复用 activity_events，竖轨 + 圆节点 + 头像）。启动/详情完整复用库页流程。

4. **统计图样式**：折线图对齐 ReinaManager 的 `@mui/x-charts` LineChart 观感（见 §2）。

### 约束与验证
- **主色不硬编码**（走 `colorScheme.primary`，保住 Hibiki 动态主题/暗色）。
- **MD3 静态守卫全程绿**：库页/详情/首页都走设计系统 token/组件，不绕过；唯一 allowlist 是共享组件 `GalgamePosterCard` 本身（类名 `PosterCard` 撞 `Card(` 子串扫描，同 `hibiki_material_components` 那类豁免），页面 chrome 零豁免。
- `flutter analyze`（含 test）→ No issues found。
- 目标测试合跑 108 例绿（守卫 + 三界面 + focus + 库页 + i18n）；海报卡 6 widget 测试；全量 `flutter test` 见 CI。
- i18n 经 `i18n_sync.dart` 加 12 key（17 语言）。

### 行为变化 / 待确认
- ⚠️ **进游戏 tab 现在先落新「游戏首页」**（原来先落库页）——对齐 ReinaManager 的首页优先。若你更想保留「先落库页」，一行改回。
- ⚠️ **需真机目视验收**：我用 golden 离屏渲染核对了海报卡结构（3:4/圆角/选中环/排序浮层/居中标题都对，见会话），但详情页/首页的真机观感、真实封面下的整体效果，仍建议 Windows 真机跑一遍四个界面留证据。
- 存档/评价 tab、多选、拖拽排序仍是 M2 范围外。

https://claude.ai/code/session_015f8HJQZCqhGopTbhArDJBj
