### PR TITLE
fix(lookup,ext): 嵌套查词鼠标卡顿 + 扩展拖慢滚动 + 扩展更新提示 (BUG-1077/1078/1079)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1043 条。点号进各自文件。
+> 共 1046 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1079](bugs/BUG-1079-extension-update-silent-stale.md) | ✅ | ✅ | 扩展自更新失败永久静默无重试且无任何更新提示 |
+| [BUG-1078](bugs/BUG-1078-extension-passive-wheel-scroll-drag.md) | ✅ | ✅ | 扩展在所有网页常驻非passive wheel监听拖慢浏览器滚动 |
+| [BUG-1077](bugs/BUG-1077-nested-lookup-mouse-hook-starvation.md) | ✅ | ✅ | 嵌套查词瞬间全局鼠标卡顿：钩子线程无优先级+嵌套路径卸装钩子churn |
 | [BUG-1076](bugs/BUG-1076-galgame-helper-update-tied-to-launch.md) | ✅ | ✅ | galgame helper 自动更新绑死游戏启动时刻且 6s 硬超时弱网永远静默放弃 |
 | [BUG-1075](bugs/BUG-1075-daily-goal-no-unit-no-hint.md) | ✅ | ✅ | 每日目标弹窗无单位无口径说明 |
 | [BUG-1074](bugs/BUG-1074-cover-update-button-windows-noop.md) | ✅ | ✅ | 书籍编辑封面更新按钮Windows无反应 |

--- a/docs/bugs/BUG-1077-nested-lookup-mouse-hook-starvation.md
+++ b/docs/bugs/BUG-1077-nested-lookup-mouse-hook-starvation.md
@@ -1,0 +1,15 @@
+## BUG-1077 · 嵌套查词瞬间全局鼠标卡顿：钩子线程无优先级+嵌套路径卸装钩子churn
+- **报告**：2026-07-25（用户：「有时候你嵌套查的时候鼠标会卡一下，不知是整个画面卡还是鼠标卡。app外。」）
+- **真实性**：✅ 真 bug —— BUG-1048 把 `WH_MOUSE_LL` 挪到专用线程后仍留两个残余机制，恰在嵌套查词瞬间叠加发作：
+  1. **钩子线程无优先级**（`hibiki/windows/runner/low_level_mouse_hook.cpp:79`，修复前）：`std::thread(&HookThreadMain)` 默认 `THREAD_PRIORITY_NORMAL`。LL 钩子是**同步**钩子——系统等承载线程被调度并返回（上限 `LowLevelHooksTimeout` 300ms）才把输入分发给前台程序。嵌套查词瞬间进程内 CPU 风暴：Dart isolate 同步 FFI 词典查询（`app_model.dart:3564` → `hoshidicts.dart:553`）+ 整栈重序列化（`global_lookup_render.dart:271-306`，每帧 popupJson 全量重拼再 `jsonEncode`）+ platform 线程 WebView2 `put_Bounds` 同步 COM 与 `SetWindowRgn` 连击（`global_lookup_window.cpp:1771/1664/1676`）+ WebView2 渲染进程 iframe 布局。NORMAL 优先级的钩子线程被抢占几十毫秒 = 全系统鼠标卡一下，时间点精确对上「嵌套那一刻、一次性」。
+  2. **嵌套路径钩子表 churn**（`global_lookup_controller.dart:527` + `global_lookup_window.cpp:744-746`/`:527`）：剪贴板面板嵌套（`clipboard_panel_controller.dart:673 _lookupExternal`）与 galgame 浮窗查词都先走 `GlobalLookupController.lookupText()` 的 reset `hide(notify:false)` → `Hide()` 无条件 `DisarmLowLevelMouseHook()`（真 `UnhookWindowsHookEx`），百毫秒后 `RevealStack` 再 `ArmLowLevelMouseHook()`（真 `SetWindowsHookEx`）。每次嵌套 = 两回全局钩子表变更，桌面级钩子链更新与 Raw Input 线程串行，各是一次全系统输入短暂停顿。
+  3. 次要：`low_level_mouse_hook.cpp:83-87`（修复前）首次建线程用 `Sleep(1)` 自旋等 id 发布，跑在 platform 线程，默认定时器精度下单次可睡 ~15ms——只影响首次查词，不是嵌套主因，一并修掉。
+
+  另有「画面卡」侧的独立贡献因子（同步 FFI 查询阻塞 UI isolate、整栈重序列化 O(N)、`SetWindowPos`+`put_Bounds`+一次嵌套 3~6 次 `SetWindowRgn` 打断 DWM/全屏合成），属更大的架构改动，见备注的后续项，不在本 bug 内。
+- **[x] ① 已修复** —— 全部收敛在 `low_level_mouse_hook.{h,cpp}` 内部，不往 Dart→channel→C++ 穿特例标志：
+  - `HookThreadMain` 开头 `SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL)`——LL 钩子承载线程标准做法；回调每事件只做两次整数比较，高优先级不会饿别人。
+  - `Disarm` 改「立即清 `g_target`（回调纯放行，语义等同已卸载）+ 宽限期 `kDisarmGraceMs=3000ms` 后才真 `UnhookWindowsHookEx`（钩子线程 `SetTimer`/`KillTimer` 线程定时器）；期间新 `Arm` 取消卸载」。嵌套/连续查词的钩子表变更从每次 2 回降到 0；真正闲置超宽限期照样卸钩子，「不查词不留全局钩子」的承诺不变。到期回调再核一次 `g_target` 防御队列里尚未消费的 Arm。
+  - `EnsureHookThread` 的 `Sleep(1)` 自旋改为事件等待（`CreateEventW` + `WaitForSingleObject`，事件句柄进程生命周期常驻）。
+  - `GlobalLookupWindow` 侧零改动：`Hide`/`Reveal`/`RevealStack` 的 Arm/Disarm 调用点、点击外关闭语义、常驻剪贴板面板从不 arm 的约定全部原样。提交：c931d8f98
+- **[x] ② 已加自动化测试** —— `hibiki/test/lookup/global_lookup_mouse_hook_stutter_guard_test.dart`（源码守卫：TIME_CRITICAL 必在；Disarm 必须走 `kDisarmGraceMs` + `SetTimer`/`KillTimer` 延迟真卸，不许退回立卸立装；等线程就绪必须 `WaitForSingleObject`，禁止 `Sleep` 自旋）。纯 Win32 输入队列行为无法在 Dart 行为测试复现，源码守卫是最强可落地层；BUG-1048 既有守卫 `global_lookup_mouse_hook_thread_guard_test.dart` 继续锁专用线程/只 PostMessage 结构。
+- **备注**：native 改动，**待 Windows 真机复测**原始失败路径（app 外浮窗/面板里嵌套查词，观察鼠标是否还卡一下）；建议真机用 WPR 抓一次嵌套查词看 win32k 输入延迟事件。若真机复测仍有「画面卡一下」残余，按调查已定位的后续项开新 bug：① `HoshiDicts.lookup/queryKanji` 移出 UI isolate；② `buildStackRenderScript` 增量化（只下发新增/变更帧）；③ `RenderJson` 去整串复制 + `shellRects`/`WM_SIZE` 的 `SetWindowRgn` 节流合并。

--- a/docs/bugs/BUG-1078-extension-passive-wheel-scroll-drag.md
+++ b/docs/bugs/BUG-1078-extension-passive-wheel-scroll-drag.md
@@ -1,0 +1,44 @@
+## BUG-1078 · 扩展在所有网页常驻非passive wheel监听拖慢浏览器滚动
+- **报告**：2026-07-25（用户：）
+- **真实性**：✅ 真 bug。popup.js 作为 content script 注入 `<all_urls>`，顶层无条件
+  `document.addEventListener('wheel', …, { passive: false })`（修复前
+  `tools/browser-extension/vendor/popup.js:4042`，监听体到 `:4139`；三镜像同源，唯一一个
+  wheel 监听——此前调查说的「:4042 和 :4139 两处」实为同一监听的首尾行）。非 passive wheel
+  监听一旦存在，浏览器就放弃合成器快速滚动路径，宿主页每次滚轮都要同步等主线程跑完监听。
+  更糟的是监听内部顺序反了：昂贵的祖先遍历 `popupAncestorAbsorbsVerticalWheel`
+  （`:3989`，对事件目标每个祖先做 `getComputedStyle` + `scrollHeight/clientHeight` 强制布局读）
+  在 `:4073` 先执行，而真正廉价决定性的早退
+  `if (!scroller && inExtensionContentScript) return;`（`:4082`）排在它后面——弹窗根本不在场
+  时宿主页每次滚轮都白跑整条昂贵路径；且每次 wheel 至少调 2 次 `e.composedPath()`
+  （`__hibikiEventTarget` :10 + `__hibikiWheelScroller` :23，各自分配新数组）。
+- **[x] ① 已修复** — 提交 `c931d8f98`。三层根因修复（`popup.js` 三镜像 + `content.js` 两镜像同步）：
+  1. **懒装监听（扩展上下文）**：popup.js 在扩展上下文（`chrome.runtime.id` 存在）不再挂
+     document，把监听暴露为 `window.__hibikiPopupWheelListener`；content.js 在弹窗 shadow host
+     创建时（`hibikiEnsureContainer`，host 复用路径不重复挂）以 `{passive:false}` 挂到 host 上、
+     `hibikiRemoveContainer` 销毁时卸载。弹窗不在场 ⇒ 宿主页 document 上零 wheel 监听，
+     合成器快速滚动路径完整保留。in-app 弹窗 WebView（无 chrome.runtime，document 即弹窗）
+     保持常驻 document 监听不变——BUG-1026 滚轮速度、BUG-1065 DPR、PR#395 Alt+滚轮词条
+     导航行为全部不动。
+  2. **早退前置（纵深防御）**：监听体最顶部先用一次 `composedPath + indexOf` 解析滚轮表面，
+     `!scroller && inExtensionContentScript` 立即放行原生滚动；昂贵的祖先遍历和词条导航判定
+     只在滚轮确认落在弹窗内（或 in-app）时才执行。原 BUG-732 守卫字面量保留在新位置。
+  3. **composedPath 单次复用**：新增 `__hibikiComposedPath(e)` 把路径缓存在事件对象上，
+     `__hibikiEventTarget` / `__hibikiWheelScroller` 共享同一次 `composedPath()` 结果。
+- **[x] ② 已加自动化测试** —
+  - `tools/browser-extension/popup-wheel-lazy.test.js`（node:test，真加载 popup.js + content.js）：
+    ①扩展上下文加载后 document 零 wheel 监听且监听已全局暴露；②`hibikiEnsureContainer` 挂
+    `{passive:false}` 到 host 且复用不重复挂；③弹窗内滚轮行为不变（preventDefault + 滚 host、
+    不碰 window）；④`hibikiRemoveContainer` 卸载监听。
+  - `hibiki/test/lookup/browser_extension_page_scroll_bug732_test.js`（更新，由同名 `.dart` 在
+    `flutter test` 里驱动）：新增断言扩展上下文 document 无任何 wheel 注册、in-app 恰好一个
+    常驻 `{passive:false}` document 监听；原 BUG-732 四表面行为断言（扩展宿主页放行原生 /
+    弹窗内接管 / in-app 接管）全部保留。
+  - 相邻守卫回归绿：`hibiki/test/build/browser_extension_popup_wheel_surface_guard_test.dart`、
+    `hibiki/test/reader/popup_wheel_scroll_asset_test.dart`、
+    `hibiki/test/reader/popup_wheel_scroll_behavior_test.dart`（+`.js`）、
+    `hibiki/test/reader/popup_wheel_speed_asset_test.dart`、
+    `hibiki/test/shortcuts/popup_entry_wheel_binding_test.dart`。
+- **备注**：改动文件——`tools/browser-extension/vendor/popup.js` /
+  `hibiki/assets/popup/popup.js` / `hibiki/assets/browser_extension/vendor/popup.js`（三镜像逐字节
+  一致）、`tools/browser-extension/content.js` / `hibiki/assets/browser_extension/content.js`
+  （两镜像逐字节一致）。content.js 的 Shift 悬停 / 定时器 / CSS 注入未动（不在本 bug 范围）。

--- a/docs/bugs/BUG-1079-extension-update-silent-stale.md
+++ b/docs/bugs/BUG-1079-extension-update-silent-stale.md
@@ -1,0 +1,43 @@
+## BUG-1079 · 扩展自更新失败永久静默无重试且无任何更新提示
+- **报告**：2026-07-25（用户：）
+- **真实性**：✅ 真 bug（自更新静默失败部分）+ 功能补全（双向版本感知/更新提示部分）。
+  沿真实代码路径验真：
+  - **永不重试 latch**：`tools/browser-extension/background.js:82-83`（修复前）——
+    `maybeSelfReload` 里 `if (st.hibikiReloadedForBuild === remote) return;`，对同一
+    remote build reload 过一次就永久早退。自更新失败（磁盘副本没刷成 / 用户从别的
+    目录加载扩展 / 浏览器拒绝 reload）后扩展永久停在旧版，且无任何提示。
+  - **零感知**：`tools/browser-extension/background.js:150`（修复前）——状态请求体写死
+    `body: '{}'`，从不上报自身 `HIBIKI_DEFAULTS.build`；server 侧
+    `hibiki/lib/src/sync/yomitan_api_server.dart:248-261`（修复前）状态端点完全不读
+    body → app 对浏览器中实际加载的版本零感知；扩展页版本卡
+    `hibiki/lib/src/pages/implementations/browser_extension_page.dart:302-318`（修复前）
+    只显示 app 内置指纹，扩展 action popup 无版本/更新提示。
+  - 注：前轮调查记的 server 路径 `media/sources/player/yomitan_api_server.dart` 有误，
+    实际在 `hibiki/lib/src/sync/yomitan_api_server.dart`。
+- **[x] ① 已修复** — 提交 `c931d8f98`。双向闭环：
+  - 扩展侧新增纯状态机 `tools/browser-extension/self-update.js`
+    （`HIBIKI_SELF_UPDATE.decide`）：同一 remote build 仍只 reload 一次（防无限循环
+    不变），但每次心跳重新比对；已 reload 过仍不一致 → 写
+    `chrome.storage.local.hibikiUpdateStale {remote, local}`；恢复一致 → 清除。
+    `statusRequestBody` 让 `/api/extension/status` 请求体自报
+    `{build, version}`（心跳/启动检查/连接诊断同一路径）。
+  - 提示：`vendor/action-popup.html/js` 连接卡下新增更新提示行（stale 时显示
+    「需到 chrome://extensions 重新加载」+ 两侧 build 简写）；扩展图标打「↑」角标
+    （`refreshUpdateBadge`，录制红点优先——录制中跳过、录制结束恢复）。
+  - app 侧：`yomitan_api_server.dart` `_handleExtensionStatus` 容错解析 body
+    （旧扩展 '{}' / 空 body / 非法 JSON 行为等同现状），经 `onExtensionReport` →
+    `app_model.dart` `browserExtensionReportedBuild`（ValueNotifier）+ 时间戳；
+    `browser_extension_page.dart` 版本卡改双行（app 内置 / 浏览器中加载），不一致时
+    显示 Material 3 警示条（errorContainer 主题色）+ 指引文案。
+  - i18n 新增（i18n_sync + slang 再生成）：`browser_extension_version_app` /
+    `browser_extension_version_browser` / `browser_extension_version_mismatch`。
+- **[x] ② 已加自动化测试** —
+  - JS：`tools/browser-extension/self-update.test.js`（15 例：状态机 reload 一次/
+    stale/clear/缺指纹/录制让位、请求体自报、popup 提示文案、background 接线源码断言）。
+  - Dart：`hibiki/test/sync/yomitan_api_server_status_report_test.dart`（真实 HTTP 层：
+    自报 build+version 回调、'{}' 兼容、空 body/非法 JSON/类型错容错、未注入回调不炸）；
+    `hibiki/test/lookup/browser_extension_update_stale_guard_test.dart`（两镜像接线 +
+    self-update.js 字节一致 + server/app_model/页面警示条源码守卫）。
+- **备注**：`hibiki/assets/browser_extension/` 镜像已同步（background.js /
+  self-update.js / vendor/action-popup.*）。角标策略：录制角标（红点 ●）优先，
+  更新角标（↑）仅在非录制时显示，录制结束由 `setRecordingBadge(false)` 恢复。

--- a/hibiki/assets/browser_extension/background.js
+++ b/hibiki/assets/browser_extension/background.js
@@ -1,6 +1,6 @@
 // TODO-1087：自动配置默认值。app 安装助手在解压时把当前 server 真值写进 hibiki-defaults.js，
 // 于是加载已解压扩展后无需手填。用户仍可在 options 手动覆盖（chrome.storage.local 优先于默认）。
-try { importScripts('hibiki-defaults.js', 'connection-diagnostics.js'); } catch (_) { /* 缺省文件时回落硬编码默认 */ }
+try { importScripts('hibiki-defaults.js', 'connection-diagnostics.js', 'self-update.js'); } catch (_) { /* 缺省文件时回落硬编码默认 */ }
 const HIBIKI_DEFAULTS =
     (self.HIBIKI_DEFAULTS) || { host: '127.0.0.1', port: 19633, token: '' };
 
@@ -15,6 +15,16 @@ async function cfg() {
   return { base: `http://${host}:${port}`, token };
 }
 function authHeader(token) { return 'Basic ' + btoa('hibiki:' + token); }
+
+// BUG-1079：/api/extension/status 请求体统一自报「浏览器中实际加载的版本」
+// （HIBIKI_DEFAULTS.build + manifest version）。此前写死 '{}'，app 端对浏览器里实际
+// 跑的是哪个 build 零感知。旧 app 忽略 body → 向后兼容。
+function statusRequestBody() {
+  try {
+    return self.HIBIKI_SELF_UPDATE.statusRequestBody(
+        HIBIKI_DEFAULTS, chrome.runtime.getManifest().version);
+  } catch (_) { return '{}'; }
+}
 
 let connectionCache = null;
 async function responseJson(resp) {
@@ -35,7 +45,7 @@ async function diagnoseConnection(force) {
     const r = await fetch(base + '/api/extension/status', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
-      body: '{}',
+      body: statusRequestBody(),
     });
     primary = { status: r.status, body: await responseJson(r) };
     if (r.status === 404 || r.status === 405) {
@@ -71,16 +81,36 @@ async function diagnoseConnection(force) {
 // 两者：不一致 = 磁盘上已有新版而当前加载的还是旧版 → chrome.runtime.reload() 从磁盘拉新
 // （等价于扩展管理页的「重新加载」，未解压包路径不变）。防护：
 // - 任一侧缺指纹（旧 app / 占位默认）→ 不动（向后兼容，绝不空转 reload）；
-// - storage 记录已为该指纹 reload 过 → 不再重试（防「磁盘没刷成」时无限循环）；
+// - storage 记录已为该指纹 reload 过 → 不再重复 reload（防「磁盘没刷成」时无限循环）；
 // - 正在 Netflix 逐句回放录制 → 跳过（reload 会杀掉 offscreen 录制，等录完下次查词再说）。
+// BUG-1079：latch 不再是「永久静默」——每次心跳仍重新比对（决策抽成 self-update.js 的
+// 纯状态机）：已 reload 过仍不一致 = 自更新失效（用户从别的目录加载 / 磁盘没刷成 /
+// 浏览器拒绝 reload），落 chrome.storage.local.hibikiUpdateStale {remote, local} 供
+// action-popup 显示「需手动重载」提示 + 图标角标；恢复一致时清除 stale 与角标。
 async function maybeSelfReload(data) {
   try {
     const remote = data && data.extensionBuild;
     const local = HIBIKI_DEFAULTS.build;
-    if (!remote || !local || remote === local) return;
-    if (await isOffscreenRecording()) return;
-    const st = await chrome.storage.local.get(['hibikiReloadedForBuild']);
-    if (st.hibikiReloadedForBuild === remote) return;
+    const st = await chrome.storage.local.get(
+        ['hibikiReloadedForBuild', 'hibikiUpdateStale']);
+    const decision = self.HIBIKI_SELF_UPDATE.decide(
+        remote, local, st.hibikiReloadedForBuild, await isOffscreenRecording());
+    if (decision.action === 'clear') {
+      if (st.hibikiUpdateStale) {
+        await chrome.storage.local.remove(['hibikiUpdateStale']);
+        refreshUpdateBadge();
+      }
+      return;
+    }
+    if (decision.action === 'stale') {
+      const prev = st.hibikiUpdateStale;
+      if (!prev || prev.remote !== remote || prev.local !== local) {
+        await chrome.storage.local.set({ hibikiUpdateStale: decision.stale });
+      }
+      refreshUpdateBadge();
+      return;
+    }
+    if (decision.action !== 'reload') return;
     // BUG-1047：置重注入标记，reload 后新 SW 据此把 content script 补回已打开网页
     // （chrome.runtime.reload() 会让所有已注入页的 content script 上下文失效 → 不补的话
     // 用户必须手动刷新浏览器才恢复）。
@@ -90,6 +120,19 @@ async function maybeSelfReload(data) {
     });
     chrome.runtime.reload();
   } catch (_) { /* 自更新失败不影响查词本身 */ }
+}
+
+// BUG-1079：自更新失效角标。stale 存在且**不在录制**时在扩展图标打「↑」提醒；录制角标
+// 优先（红点 ● 绝不被盖掉——录制中本函数整个跳过，录制结束由 setRecordingBadge(false)
+// 回调这里恢复）。只动 badge，不动 title（title 归录制状态机管）。
+async function refreshUpdateBadge() {
+  try {
+    if (await isOffscreenRecording()) return; // 录制角标优先
+    const st = await chrome.storage.local.get(['hibikiUpdateStale']);
+    const stale = !!st.hibikiUpdateStale;
+    chrome.action.setBadgeBackgroundColor({ color: stale ? '#F9A825' : '#00000000' });
+    chrome.action.setBadgeText({ text: stale ? '↑' : '' });
+  } catch (_) { /* badge 在某些上下文不可用：忽略 */ }
 }
 
 // BUG-1047：自更新 chrome.runtime.reload() 会让所有已打开标签页里注入的 content script
@@ -144,10 +187,12 @@ async function maybeReinjectAfterReload() {
 async function checkVersionOnStartup() {
   try {
     const { base, token } = await cfg();
+    // BUG-1079：请求体自报 build/version（不再写死 '{}'），app 端据此显示「浏览器中
+    // 实际加载的版本」并在与内置指纹不一致时给出更新提示。
     const r = await fetch(base + '/api/extension/status', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
-      body: '{}',
+      body: statusRequestBody(),
     });
     if (!r.ok) return;
     const status = await responseJson(r);
@@ -199,6 +244,8 @@ function setRecordingBadge(on) {
           : 'Hibiki：点击生成 Netflix 制卡队列（逐集自动回放录制）',
     });
   } catch (_) { /* setBadge 在某些上下文不可用：忽略，不影响录制 */ }
+  // BUG-1079：录制角标撤下后恢复自更新失效角标（若 stale 仍在）。录制中绝不动录制红点。
+  if (!on) refreshUpdateBadge();
 }
 
 // 录制真相源是 **offscreen 文档**（它持有 MediaStream，跨整场持续录），不是这个易失的

--- a/hibiki/assets/browser_extension/content.js
+++ b/hibiki/assets/browser_extension/content.js
@@ -1032,6 +1032,14 @@ function hibikiEnsureContainer() {
     shadow.appendChild(c);
     hibikiContainer = c;
     window.__hibikiRoot = shadow; // popup.js 的 DOM 查询/浮层/选区都相对它解析
+    // BUG-1078：弹窗滚轮监听懒装——popup.js 在扩展上下文里不再常驻 document（常驻的
+    // 非 passive wheel 监听会让浏览器在所有网页放弃合成器快速滚动路径），而是把监听
+    // 暴露为 window.__hibikiPopupWheelListener，由这里在弹窗 host 创建时挂到 shadow
+    // host 上（非 passive 只影响弹窗内滚轮），hibikiRemoveContainer 销毁时卸载。
+    if (typeof window.__hibikiPopupWheelListener === 'function') {
+      hibikiHost.addEventListener('wheel', window.__hibikiPopupWheelListener,
+          { passive: false });
+    }
   }
   if (hibikiHost.parentNode !== parent) parent.appendChild(hibikiHost); // 进/出全屏迁父节点
   return hibikiContainer;
@@ -1152,6 +1160,12 @@ function hibikiRemoveContainer() {
   // ease-out 对齐）。pointer-events:none 避免淡出期误吞点击；transitionend 用 setTimeout
   // 兜底（reduced-motion / 离屏也能移除）。高亮/选区已在上面即时清，不随淡出延迟残留。
   if (dying) {
+    // BUG-1078：随弹窗卸载滚轮监听（挂载见 hibikiEnsureContainer）。节点淡出期间
+    // pointer-events:none 已让事件不再命中它，这里显式卸载把契约钉死：弹窗不在场 ⇒
+    // 页面上不存在任何非 passive wheel 监听。
+    if (typeof window.__hibikiPopupWheelListener === 'function') {
+      dying.removeEventListener('wheel', window.__hibikiPopupWheelListener);
+    }
     dying.style.pointerEvents = 'none';
     dying.style.opacity = '0';
     let dropped = false;

--- a/hibiki/assets/browser_extension/self-update.js
+++ b/hibiki/assets/browser_extension/self-update.js
@@ -1,0 +1,49 @@
+// BUG-1079：扩展自更新状态机（纯函数，node 可测）。
+// 背景：background.js 的自更新此前用「对某 remote build reload 过一次就永不重试」的 latch
+// 防死循环，但 reload 失败（磁盘副本没刷成 / 用户从别的目录加载 / 浏览器拒绝 reload）后
+// 会永久停在旧版且零提示。这里把决策抽成纯函数：
+// - 同一 remote build 仍只 reload 一次（防无限 reload 循环不变）；
+// - 已 reload 过仍不一致 → 判定自更新失效（stale），由调用方落 chrome.storage 提示用户；
+// - 恢复一致 → clear，由调用方清除 stale 提示。
+(function (root, factory) {
+  var api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.HIBIKI_SELF_UPDATE = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  var actions = Object.freeze({
+    none: 'none',       // 任一侧缺指纹 / 录制中：什么都不做（向后兼容，绝不空转）
+    reload: 'reload',   // 首次发现新 build：chrome.runtime.reload() 从磁盘拉新
+    stale: 'stale',     // 已为该 build reload 过仍不一致：自更新失效，提示用户手动重载
+    clear: 'clear',     // 两侧一致：清除 stale 提示（自更新已生效 / 用户已手动重载）
+  });
+
+  // remote = server 下发的内置指纹（extensionBuild）；local = 当前加载副本的
+  // HIBIKI_DEFAULTS.build；reloadedFor = storage 里记录的「已为哪个 build reload 过」；
+  // recording = 正在逐句回放录制（reload 会杀 offscreen 录制，跳过本轮）。
+  function decide(remote, local, reloadedFor, recording) {
+    if (!remote || !local) return { action: actions.none };
+    if (remote === local) return { action: actions.clear };
+    if (recording) return { action: actions.none };
+    if (reloadedFor === remote) {
+      return { action: actions.stale, stale: { remote: remote, local: local } };
+    }
+    return { action: actions.reload };
+  }
+
+  // BUG-1079：/api/extension/status 请求体——扩展自报「浏览器中实际加载的版本」。
+  // 此前写死 '{}'，app 端无从得知浏览器里跑的是哪个 build。旧 app 忽略 body，向后兼容。
+  function statusRequestBody(defaults, manifestVersion) {
+    var body = {};
+    if (defaults && typeof defaults.build === 'string' && defaults.build) {
+      body.build = defaults.build;
+    }
+    if (typeof manifestVersion === 'string' && manifestVersion) {
+      body.version = manifestVersion;
+    }
+    return JSON.stringify(body);
+  }
+
+  return { actions: actions, decide: decide, statusRequestBody: statusRequestBody };
+});

--- a/hibiki/assets/browser_extension/vendor/action-popup.html
+++ b/hibiki/assets/browser_extension/vendor/action-popup.html
@@ -122,6 +122,16 @@
     .hp-connection-detail { display: block; overflow: hidden; margin-top: 1px; opacity: .55; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
     .hp-settings-link { border: 0; padding: 4px; color: inherit; background: transparent; cursor: pointer; opacity: .72; }
     .hp-settings-link:hover { opacity: 1; }
+    /* BUG-1079：自更新失效提示（hibikiUpdateStale 存在时显示）：需到扩展管理页手动重新加载。 */
+    .hp-update {
+      margin: 0 14px 10px;
+      padding: 9px 10px;
+      border: 1px solid rgba(212, 154, 66, 0.55);
+      border-radius: 8px;
+      background: rgba(212, 154, 66, 0.12);
+    }
+    .hp-update-title { display: block; font-size: 12px; font-weight: 600; }
+    .hp-update-detail { display: block; margin-top: 1px; opacity: .7; font-size: 10px; line-height: 1.5; }
     /* TODO-1219：网飞字幕列表面板开关（扩展弹窗入口，方案 B）。独立页脚区，不属于上方 1270 制卡队列。 */
     .hp-settings { border-top: 1px solid rgba(128, 128, 128, 0.22); padding: 10px 14px 12px; }
     .hp-toggle { display: flex; align-items: center; gap: 8px; cursor: pointer; }
@@ -142,6 +152,11 @@
       <span class="hp-connection-detail" id="hp-connection-detail">查词与字幕服务</span>
     </span>
     <button class="hp-settings-link" id="hp-open-options" type="button" title="打开扩展设置" aria-label="打开扩展设置">⚙</button>
+  </div>
+  <!-- BUG-1079：自更新失效提示（默认隐藏；chrome.storage.local.hibikiUpdateStale 存在时显示）。 -->
+  <div class="hp-update" id="hp-update" hidden>
+    <span class="hp-update-title" id="hp-update-title"></span>
+    <span class="hp-update-detail" id="hp-update-detail"></span>
   </div>
   <button class="hp-gen" id="hp-gen" type="button">开始生成 / 录制</button>
   <!-- TODO-1881：按钮不可用/跨站点剩余量的原因提示（状态机 hint，空则隐藏）。 -->

--- a/hibiki/assets/browser_extension/vendor/action-popup.js
+++ b/hibiki/assets/browser_extension/vendor/action-popup.js
@@ -104,11 +104,24 @@ function hibikiGenButtonState(queue, batchActive, tabSite) {
   };
 }
 
+// BUG-1079：自更新失效提示文案（纯函数供 node 测试）。stale = background 写入
+// chrome.storage.local.hibikiUpdateStale 的 {remote, local}（remote=app 内置最新指纹，
+// local=浏览器中实际加载副本的指纹）。无 stale（或缺 remote）返回 null（隐藏提示行）。
+function hibikiUpdateNotice(stale) {
+  if (!stale || !stale.remote) return null;
+  const short = (s) => String(s || '').slice(0, 8);
+  return {
+    title: '扩展有新版本，需手动重新加载',
+    detail: '自动更新未生效：请到 chrome://extensions 找到本扩展点「重新加载」'
+        + '（当前 ' + (short(stale.local) || '未知') + ' → 最新 ' + short(stale.remote) + '）',
+  };
+}
+
 // node 单测导出（浏览器里 module 未定义，直接跳过）。
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     hibikiFilterQueue, hibikiQueueItemLabel, hibikiQueueItemContext, hibikiReadPanelEnabled,
-    hibikiQueueItemUrl, hibikiTabSite, hibikiGenButtonState,
+    hibikiQueueItemUrl, hibikiTabSite, hibikiGenButtonState, hibikiUpdateNotice,
   };
 }
 
@@ -143,6 +156,33 @@ if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.s
   }
   refreshConnection();
   if (connEl) connEl.addEventListener('click', () => refreshConnection());
+
+  // BUG-1079：自更新失效提示行。background 检测到「已 reload 过仍与 app 内置指纹不一致」
+  // 时写 hibikiUpdateStale；这里渲染「需到 chrome://extensions 手动重新加载」并随 storage
+  // 变化实时显隐（恢复一致时 background 清除该键 → 提示消失）。
+  const updateEl = document.getElementById('hp-update');
+  const updateTitleEl = document.getElementById('hp-update-title');
+  const updateDetailEl = document.getElementById('hp-update-detail');
+  function renderUpdateNotice(stale) {
+    if (!updateEl) return;
+    const notice = hibikiUpdateNotice(stale);
+    updateEl.hidden = !notice;
+    if (!notice) return;
+    if (updateTitleEl) updateTitleEl.textContent = notice.title;
+    if (updateDetailEl) updateDetailEl.textContent = notice.detail;
+  }
+  try {
+    chrome.storage.local.get(['hibikiUpdateStale'], (r) => {
+      renderUpdateNotice(r && r.hibikiUpdateStale);
+    });
+  } catch (_) {}
+  try {
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area === 'local' && changes.hibikiUpdateStale) {
+        renderUpdateNotice(changes.hibikiUpdateStale.newValue);
+      }
+    });
+  } catch (_) {}
   const optionsEl = document.getElementById('hp-open-options');
   if (optionsEl) {
     optionsEl.addEventListener('click', (e) => {

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -7,7 +7,12 @@ function __hibikiContainer(){ var r = window.__hibikiRoot; return r ? r.querySel
 function __hibikiOverlayParent(){ return window.__hibikiRoot || document.body; }
 function __hibikiScrollHeight(){ var c = __hibikiContainer(); return c ? c.scrollHeight : document.body.scrollHeight; }
 function __hibikiSel(){ var r = window.__hibikiRoot; try { return (r && r.getSelection) ? r.getSelection() : window.getSelection(); } catch(_){ return window.getSelection(); } }
-function __hibikiEventTarget(e){ try { var p = e.composedPath && e.composedPath(); if (p && p.length) return p[0]; } catch(_){} return e.target; }
+/* BUG-1078: composedPath() allocates a fresh array on every call and the wheel
+   handler used to call it at least twice per event (__hibikiEventTarget +
+   __hibikiWheelScroller). Cache the path on the event object for the duration of
+   its dispatch so every helper shares ONE composedPath() result. */
+function __hibikiComposedPath(e){ if (e.__hibikiPathCache !== undefined) return e.__hibikiPathCache; var p = null; try { p = (e.composedPath && e.composedPath()) || null; } catch(_){ p = null; } try { e.__hibikiPathCache = p; } catch(_){} return p; }
+function __hibikiEventTarget(e){ var p = __hibikiComposedPath(e); if (p && p.length) return p[0]; return e.target; }
 /* BUG-688: the extension floating popup scrolls on the SHADOW HOST
    (#hibiki-popup-host has overflow-y:auto + max-height; #entries-container is
    neutralized to overflow:visible inside the shadow), while the in-app popup
@@ -20,7 +25,7 @@ function __hibikiShadowHost(){ var r = window.__hibikiRoot; return (r && r.host)
 function __hibikiWheelScroller(e){
     var host = __hibikiShadowHost();
     if (!host) return null;
-    try { var p = e.composedPath && e.composedPath(); if (p && p.indexOf(host) !== -1) return host; } catch(_){}
+    try { var p = __hibikiComposedPath(e); if (p && p.indexOf(host) !== -1) return host; } catch(_){}
     return null;
 }
 
@@ -4039,21 +4044,38 @@ function popupEntryWheelAction(e) {
     if (matches(cfg.prev)) return 'prev';
     return null;
 }
-document.addEventListener('wheel', (e) => {
+/* BUG-1078: this listener is non-passive by necessity (it preventDefault()s to
+   re-implement popup scrolling), but a RESIDENT non-passive document wheel
+   listener forces the browser off the compositor fast-scroll path on every page
+   the extension content script touches. Two-part fix:
+   - in-app popup WebView (no chrome.runtime): the document IS the popup — keep
+     the resident document listener exactly as before (BUG-1026 wheel speed,
+     BUG-1065 DPR parity and the Alt+wheel entry navigation all live here);
+   - extension content script: never attach to document. The handler is exposed
+     as window.__hibikiPopupWheelListener and content.js mounts it on the popup
+     shadow host ({passive:false}) when the popup is created, unmounting it in
+     hibikiRemoveContainer — host pages carry ZERO non-passive wheel listeners
+     while no popup is open. */
+const __hibikiPopupWheelListener = (e) => {
+    // BUG-1078 前置早退：先用最廉价的判定（一次 composedPath + indexOf）解析滚轮
+    // 表面。扩展 content script 里滚轮不在弹窗 shadow 内 ⇒ 与弹窗无关，立即放行
+    // 原生滚动——昂贵的祖先 getComputedStyle/scrollHeight 遍历和词条导航判定都不再
+    // 为宿主页滚轮买单。（BUG-732 的放行守卫从 preventDefault 前挪到最前；挂载本身
+    // 已随 BUG-1078 懒装到 shadow host，此守卫是纵深防御 + in-app/扩展共用判据。）
+    const scroller = __hibikiWheelScroller(e);
+    const inExtensionContentScript =
+        typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
+    if (!scroller && inExtensionContentScript) return;
     // 词条导航先于一切滚动处理判定（否则 ctrlKey 早退会吃掉 Ctrl 系绑定）。只有
     // 焦点真的移动了（返回 'moved'）才吞掉事件：单词条 / 已到首尾时返回 'blocked'，
-    // 这一帧继续走下面的正常滚动，弹窗不会「按住 Alt 就滚不动」。
-    // 作用域判据与下面的滚动接管同源：扩展里滚轮必须真的落在弹窗 shadow 内
-    // （__hibikiWheelScroller 非空），in-app 整份文档就是弹窗故允许 null。
+    // 这一帧继续走下面的正常滚动，弹窗不会「按住 Alt 就滚不动」。作用域判据由上面
+    // 的前置早退保证：走到这里的滚轮要么在弹窗 shadow 内（扩展），要么整份文档就是
+    // 弹窗（in-app）。
     const entryAction = popupEntryWheelAction(e);
     if (entryAction && typeof window.hoshiFocusDictionaryEntryMove === 'function') {
-        const inExtensionHost =
-            typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
-        if (__hibikiWheelScroller(e) || !inExtensionHost) {
-            if (window.hoshiFocusDictionaryEntryMove(entryAction) === 'moved') {
-                e.preventDefault();
-                return;
-            }
+        if (window.hoshiFocusDictionaryEntryMove(entryAction) === 'moved') {
+            e.preventDefault();
+            return;
         }
     }
     // Ignore zoom gestures (ctrl+wheel / pinch) and predominantly-horizontal wheels.
@@ -4072,14 +4094,11 @@ document.addEventListener('wheel', (e) => {
     if (deltaPx === 0) return;
     if (popupAncestorAbsorbsVerticalWheel(__hibikiEventTarget(e), deltaPx)) return;
     // BUG-732: 这段缩放平滑滚动只服务查词弹窗。扩展里弹窗是宿主页上的 shadow 覆盖层，
-    // __hibikiWheelScroller 仅当滚轮 composedPath 穿过弹窗 shadow 才返回 host；返回 null
-    // 时唯一合法「滚 window」的表面是 in-app 弹窗文档（整份文档即弹窗，且无 chrome.runtime）。
-    // 普通网页上扩展 content script 有 chrome.runtime.id，此时滚轮不在弹窗内绝不能接管：
-    // 否则整页被 POPUP_WHEEL_PIXEL_FACTOR(0.24) 降速 + preventDefault 抢走原生滚动。
-    const scroller = __hibikiWheelScroller(e);
-    const inExtensionContentScript =
-        typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
-    if (!scroller && inExtensionContentScript) return;
+    // __hibikiWheelScroller 仅当滚轮 composedPath 穿过弹窗 shadow 才返回 host（scroller
+    // 已在本监听最顶部解析并早退）；返回 null 时唯一合法「滚 window」的表面是 in-app
+    // 弹窗文档（整份文档即弹窗，且无 chrome.runtime）。普通网页上扩展 content script 有
+    // chrome.runtime.id，滚轮不在弹窗内已在顶部放行原生滚动：否则整页会被
+    // POPUP_WHEEL_PIXEL_FACTOR(0.24) 降速 + preventDefault 抢走原生滚动。
     e.preventDefault();
     // TODO-1387: carry the sub-pixel remainder across events; BUG-870: also reset
     // the device-class latch here so each new gesture is classified fresh. A
@@ -4136,7 +4155,17 @@ document.addEventListener('wheel', (e) => {
     if (step === 0) return; // sub-pixel this frame — carried to the next event
     if (scroller) { scroller.scrollBy({ top: step, behavior: 'auto' }); }
     else { window.scrollBy({ top: step, behavior: 'auto' }); }
-}, { passive: false });
+};
+if (typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id)) {
+    // BUG-1078: 扩展 content script——绝不常驻 document。content.js 在弹窗 shadow host
+    // 创建时把这个监听挂上去（{passive:false} 只作用于弹窗内滚轮）、销毁时卸载；弹窗
+    // 不在场时宿主页 document 上没有任何非 passive wheel 监听，浏览器保留合成器快速
+    // 滚动路径。
+    window.__hibikiPopupWheelListener = __hibikiPopupWheelListener;
+} else {
+    // in-app 弹窗 WebView：整份文档就是弹窗，常驻 document 监听是正确行为（不变）。
+    document.addEventListener('wheel', __hibikiPopupWheelListener, { passive: false });
+}
 
 
 let _popupMouseDownPos = null;

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -7,7 +7,12 @@ function __hibikiContainer(){ var r = window.__hibikiRoot; return r ? r.querySel
 function __hibikiOverlayParent(){ return window.__hibikiRoot || document.body; }
 function __hibikiScrollHeight(){ var c = __hibikiContainer(); return c ? c.scrollHeight : document.body.scrollHeight; }
 function __hibikiSel(){ var r = window.__hibikiRoot; try { return (r && r.getSelection) ? r.getSelection() : window.getSelection(); } catch(_){ return window.getSelection(); } }
-function __hibikiEventTarget(e){ try { var p = e.composedPath && e.composedPath(); if (p && p.length) return p[0]; } catch(_){} return e.target; }
+/* BUG-1078: composedPath() allocates a fresh array on every call and the wheel
+   handler used to call it at least twice per event (__hibikiEventTarget +
+   __hibikiWheelScroller). Cache the path on the event object for the duration of
+   its dispatch so every helper shares ONE composedPath() result. */
+function __hibikiComposedPath(e){ if (e.__hibikiPathCache !== undefined) return e.__hibikiPathCache; var p = null; try { p = (e.composedPath && e.composedPath()) || null; } catch(_){ p = null; } try { e.__hibikiPathCache = p; } catch(_){} return p; }
+function __hibikiEventTarget(e){ var p = __hibikiComposedPath(e); if (p && p.length) return p[0]; return e.target; }
 /* BUG-688: the extension floating popup scrolls on the SHADOW HOST
    (#hibiki-popup-host has overflow-y:auto + max-height; #entries-container is
    neutralized to overflow:visible inside the shadow), while the in-app popup
@@ -20,7 +25,7 @@ function __hibikiShadowHost(){ var r = window.__hibikiRoot; return (r && r.host)
 function __hibikiWheelScroller(e){
     var host = __hibikiShadowHost();
     if (!host) return null;
-    try { var p = e.composedPath && e.composedPath(); if (p && p.indexOf(host) !== -1) return host; } catch(_){}
+    try { var p = __hibikiComposedPath(e); if (p && p.indexOf(host) !== -1) return host; } catch(_){}
     return null;
 }
 
@@ -4039,21 +4044,38 @@ function popupEntryWheelAction(e) {
     if (matches(cfg.prev)) return 'prev';
     return null;
 }
-document.addEventListener('wheel', (e) => {
+/* BUG-1078: this listener is non-passive by necessity (it preventDefault()s to
+   re-implement popup scrolling), but a RESIDENT non-passive document wheel
+   listener forces the browser off the compositor fast-scroll path on every page
+   the extension content script touches. Two-part fix:
+   - in-app popup WebView (no chrome.runtime): the document IS the popup — keep
+     the resident document listener exactly as before (BUG-1026 wheel speed,
+     BUG-1065 DPR parity and the Alt+wheel entry navigation all live here);
+   - extension content script: never attach to document. The handler is exposed
+     as window.__hibikiPopupWheelListener and content.js mounts it on the popup
+     shadow host ({passive:false}) when the popup is created, unmounting it in
+     hibikiRemoveContainer — host pages carry ZERO non-passive wheel listeners
+     while no popup is open. */
+const __hibikiPopupWheelListener = (e) => {
+    // BUG-1078 前置早退：先用最廉价的判定（一次 composedPath + indexOf）解析滚轮
+    // 表面。扩展 content script 里滚轮不在弹窗 shadow 内 ⇒ 与弹窗无关，立即放行
+    // 原生滚动——昂贵的祖先 getComputedStyle/scrollHeight 遍历和词条导航判定都不再
+    // 为宿主页滚轮买单。（BUG-732 的放行守卫从 preventDefault 前挪到最前；挂载本身
+    // 已随 BUG-1078 懒装到 shadow host，此守卫是纵深防御 + in-app/扩展共用判据。）
+    const scroller = __hibikiWheelScroller(e);
+    const inExtensionContentScript =
+        typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
+    if (!scroller && inExtensionContentScript) return;
     // 词条导航先于一切滚动处理判定（否则 ctrlKey 早退会吃掉 Ctrl 系绑定）。只有
     // 焦点真的移动了（返回 'moved'）才吞掉事件：单词条 / 已到首尾时返回 'blocked'，
-    // 这一帧继续走下面的正常滚动，弹窗不会「按住 Alt 就滚不动」。
-    // 作用域判据与下面的滚动接管同源：扩展里滚轮必须真的落在弹窗 shadow 内
-    // （__hibikiWheelScroller 非空），in-app 整份文档就是弹窗故允许 null。
+    // 这一帧继续走下面的正常滚动，弹窗不会「按住 Alt 就滚不动」。作用域判据由上面
+    // 的前置早退保证：走到这里的滚轮要么在弹窗 shadow 内（扩展），要么整份文档就是
+    // 弹窗（in-app）。
     const entryAction = popupEntryWheelAction(e);
     if (entryAction && typeof window.hoshiFocusDictionaryEntryMove === 'function') {
-        const inExtensionHost =
-            typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
-        if (__hibikiWheelScroller(e) || !inExtensionHost) {
-            if (window.hoshiFocusDictionaryEntryMove(entryAction) === 'moved') {
-                e.preventDefault();
-                return;
-            }
+        if (window.hoshiFocusDictionaryEntryMove(entryAction) === 'moved') {
+            e.preventDefault();
+            return;
         }
     }
     // Ignore zoom gestures (ctrl+wheel / pinch) and predominantly-horizontal wheels.
@@ -4072,14 +4094,11 @@ document.addEventListener('wheel', (e) => {
     if (deltaPx === 0) return;
     if (popupAncestorAbsorbsVerticalWheel(__hibikiEventTarget(e), deltaPx)) return;
     // BUG-732: 这段缩放平滑滚动只服务查词弹窗。扩展里弹窗是宿主页上的 shadow 覆盖层，
-    // __hibikiWheelScroller 仅当滚轮 composedPath 穿过弹窗 shadow 才返回 host；返回 null
-    // 时唯一合法「滚 window」的表面是 in-app 弹窗文档（整份文档即弹窗，且无 chrome.runtime）。
-    // 普通网页上扩展 content script 有 chrome.runtime.id，此时滚轮不在弹窗内绝不能接管：
-    // 否则整页被 POPUP_WHEEL_PIXEL_FACTOR(0.24) 降速 + preventDefault 抢走原生滚动。
-    const scroller = __hibikiWheelScroller(e);
-    const inExtensionContentScript =
-        typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
-    if (!scroller && inExtensionContentScript) return;
+    // __hibikiWheelScroller 仅当滚轮 composedPath 穿过弹窗 shadow 才返回 host（scroller
+    // 已在本监听最顶部解析并早退）；返回 null 时唯一合法「滚 window」的表面是 in-app
+    // 弹窗文档（整份文档即弹窗，且无 chrome.runtime）。普通网页上扩展 content script 有
+    // chrome.runtime.id，滚轮不在弹窗内已在顶部放行原生滚动：否则整页会被
+    // POPUP_WHEEL_PIXEL_FACTOR(0.24) 降速 + preventDefault 抢走原生滚动。
     e.preventDefault();
     // TODO-1387: carry the sub-pixel remainder across events; BUG-870: also reset
     // the device-class latch here so each new gesture is classified fresh. A
@@ -4136,7 +4155,17 @@ document.addEventListener('wheel', (e) => {
     if (step === 0) return; // sub-pixel this frame — carried to the next event
     if (scroller) { scroller.scrollBy({ top: step, behavior: 'auto' }); }
     else { window.scrollBy({ top: step, behavior: 'auto' }); }
-}, { passive: false });
+};
+if (typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id)) {
+    // BUG-1078: 扩展 content script——绝不常驻 document。content.js 在弹窗 shadow host
+    // 创建时把这个监听挂上去（{passive:false} 只作用于弹窗内滚轮）、销毁时卸载；弹窗
+    // 不在场时宿主页 document 上没有任何非 passive wheel 监听，浏览器保留合成器快速
+    // 滚动路径。
+    window.__hibikiPopupWheelListener = __hibikiPopupWheelListener;
+} else {
+    // in-app 弹窗 WebView：整份文档就是弹窗，常驻 document 监听是正确行为（不变）。
+    document.addEventListener('wheel', __hibikiPopupWheelListener, { passive: false });
+}
 
 
 let _popupMouseDownPos = null;

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 43894 (2582 per locale)
+/// Strings: 43945 (2585 per locale)
 ///
-/// Built on 2026-07-25 at 07:20 UTC
+/// Built on 2026-07-25 at 07:54 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3427,6 +3427,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String data_root_unavailable_message({required Object path}) =>
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   String get data_root_use_default_button => 'Start with default location';
+  String get browser_extension_version_app => 'App bundled';
+  String get browser_extension_version_browser => 'Loaded in browser';
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -9282,6 +9286,13 @@ class _StringsAr extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -15210,6 +15221,13 @@ class _StringsDe extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -21154,6 +21172,13 @@ class _StringsEs extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -27109,6 +27134,13 @@ class _StringsFr extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -32991,6 +33023,13 @@ class _StringsId extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -38921,6 +38960,13 @@ class _StringsIt extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -44656,6 +44702,13 @@ class _StringsJa extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -50394,6 +50447,13 @@ class _StringsKo extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -56302,6 +56362,13 @@ class _StringsNl extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -62225,6 +62292,13 @@ class _StringsPtBr extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -68131,6 +68205,13 @@ class _StringsRu extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -73982,6 +74063,13 @@ class _StringsTh extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -79865,6 +79953,13 @@ class _StringsTr extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -85735,6 +85830,13 @@ class _StringsVi extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 // Path: <root>
@@ -91195,6 +91297,13 @@ class _StringsZhCn extends _StringsEn {
       '你设置的数据位置 ${path} 暂时读不到（盘可能在休眠、被占用或未连接）。你的数据是安全的、原封不动留在那里——没有丢失。请点「重试」,等盘就绪即可用回你的数据；或选择用默认位置临时启动（不会改动你原来的数据）。';
   @override
   String get data_root_use_default_button => '仍用默认位置启动';
+  @override
+  String get browser_extension_version_app => 'App 内置';
+  @override
+  String get browser_extension_version_browser => '浏览器中加载';
+  @override
+  String get browser_extension_version_mismatch =>
+      '浏览器中加载的扩展不是最新版本：如有需要先重新准备扩展，再到浏览器扩展管理页（chrome://extensions）点「重新加载」。';
 }
 
 // Path: <root>
@@ -96848,6 +96957,13 @@ class _StringsZhHk extends _StringsEn {
       'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
   @override
   String get data_root_use_default_button => 'Start with default location';
+  @override
+  String get browser_extension_version_app => 'App bundled';
+  @override
+  String get browser_extension_version_browser => 'Loaded in browser';
+  @override
+  String get browser_extension_version_mismatch =>
+      'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
 }
 
 /// Flat map(s) containing all translations.
@@ -102120,6 +102236,12 @@ extension on _StringsEn {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -107390,6 +107512,12 @@ extension on _StringsAr {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -112681,6 +112809,12 @@ extension on _StringsDe {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -117971,6 +118105,12 @@ extension on _StringsEs {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -123267,6 +123407,12 @@ extension on _StringsFr {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -128545,6 +128691,12 @@ extension on _StringsId {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -133838,6 +133990,12 @@ extension on _StringsIt {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -139093,6 +139251,12 @@ extension on _StringsJa {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -144352,6 +144516,12 @@ extension on _StringsKo {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -149638,6 +149808,12 @@ extension on _StringsNl {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -154921,6 +155097,12 @@ extension on _StringsPtBr {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -160209,6 +160391,12 @@ extension on _StringsRu {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -165481,6 +165669,12 @@ extension on _StringsTh {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -170762,6 +170956,12 @@ extension on _StringsTr {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -176038,6 +176238,12 @@ extension on _StringsVi {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }
@@ -181274,6 +181480,12 @@ extension on _StringsZhCn {
             '你设置的数据位置 ${path} 暂时读不到（盘可能在休眠、被占用或未连接）。你的数据是安全的、原封不动留在那里——没有丢失。请点「重试」,等盘就绪即可用回你的数据；或选择用默认位置临时启动（不会改动你原来的数据）。';
       case 'data_root_use_default_button':
         return '仍用默认位置启动';
+      case 'browser_extension_version_app':
+        return 'App 内置';
+      case 'browser_extension_version_browser':
+        return '浏览器中加载';
+      case 'browser_extension_version_mismatch':
+        return '浏览器中加载的扩展不是最新版本：如有需要先重新准备扩展，再到浏览器扩展管理页（chrome://extensions）点「重新加载」。';
       default:
         return null;
     }
@@ -186524,6 +186736,12 @@ extension on _StringsZhHk {
             'Your configured data location ${path} is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).';
       case 'data_root_use_default_button':
         return 'Start with default location';
+      case 'browser_extension_version_app':
+        return 'App bundled';
+      case 'browser_extension_version_browser':
+        return 'Loaded in browser';
+      case 'browser_extension_version_mismatch':
+        return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "快捷预设",
   "data_root_unavailable_title": "数据位置未响应",
   "data_root_unavailable_message": "你设置的数据位置 $path 暂时读不到（盘可能在休眠、被占用或未连接）。你的数据是安全的、原封不动留在那里——没有丢失。请点「重试」,等盘就绪即可用回你的数据；或选择用默认位置临时启动（不会改动你原来的数据）。",
-  "data_root_use_default_button": "仍用默认位置启动"
+  "data_root_use_default_button": "仍用默认位置启动",
+  "browser_extension_version_app": "App 内置",
+  "browser_extension_version_browser": "浏览器中加载",
+  "browser_extension_version_mismatch": "浏览器中加载的扩展不是最新版本：如有需要先重新准备扩展，再到浏览器扩展管理页（chrome://extensions）点「重新加载」。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2580,5 +2580,8 @@
   "stat_goal_presets": "Presets",
   "data_root_unavailable_title": "Data location not responding",
   "data_root_unavailable_message": "Your configured data location $path is temporarily unreachable (the drive may be asleep, busy, or disconnected). Your data is safe and untouched there — nothing is lost. Tap Retry once the drive is ready to load your data, or start with the default location for now (your existing data will NOT be modified).",
-  "data_root_use_default_button": "Start with default location"
+  "data_root_use_default_button": "Start with default location",
+  "browser_extension_version_app": "App bundled",
+  "browser_extension_version_browser": "Loaded in browser",
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
 }

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4936,6 +4936,13 @@ class AppModel with ChangeNotifier {
       // 的「验证插件已正常启用」连接检测显示（扩展 SW 启动时主动打 /api/extension/status，
       // 故装完扩展即刷新，无需用户先划词）。
       onExtensionSeen: () => _browserExtensionLastSeenAt = DateTime.now(),
+      // BUG-1079：扩展经 /api/extension/status 请求体自报「浏览器中实际加载的 build」。
+      // 记到 ValueNotifier 供扩展管理页与内置指纹比对：不一致 = 扩展自更新未生效
+      // （用户从别的目录加载 / reload 失败），页面显示更新警示条。
+      onExtensionReport: (String build, String? version) {
+        _browserExtensionReportedAt = DateTime.now();
+        browserExtensionReportedBuild.value = build;
+      },
       tokenizer: JapaneseLanguage.instance.textToWords,
       readingResolver: (String w) {
         if (!HoshiDicts.isInitialized) return '';
@@ -4961,6 +4968,18 @@ class AppModel with ChangeNotifier {
   /// 浏览器扩展最近一次访问本机 yomitan-api server 的时间（null = 从未连上）。
   /// 扩展管理页「验证插件已正常启用」据此判断连接状态。
   DateTime? get browserExtensionLastSeenAt => _browserExtensionLastSeenAt;
+
+  /// BUG-1079：扩展自报的「浏览器中实际加载的 build」（/api/extension/status 请求体）。
+  /// null = 从未上报（旧扩展发 '{}' / 从未连接）。扩展管理页用 ValueListenableBuilder
+  /// 订阅，与 [browserExtensionBuild] 比对：不一致即显示「扩展需手动重新加载」警示。
+  final ValueNotifier<String?> browserExtensionReportedBuild =
+      ValueNotifier<String?>(null);
+
+  // BUG-1079：最近一次扩展自报版本的时间戳（内存态，与 last-seen 同生命周期）。
+  DateTime? _browserExtensionReportedAt;
+
+  /// BUG-1079：扩展最近一次自报版本的时间（null = 从未上报）。
+  DateTime? get browserExtensionReportedAt => _browserExtensionReportedAt;
 
   /// BUG-726：把已解压的浏览器扩展副本刷新到当前 app 内置版本（详见
   /// [refreshBundledBrowserExtensionIfStale]），并缓存内置指纹供查词响应下发。

--- a/hibiki/lib/src/pages/implementations/browser_extension_page.dart
+++ b/hibiki/lib/src/pages/implementations/browser_extension_page.dart
@@ -181,7 +181,7 @@ class _BrowserExtensionPageState extends ConsumerState<BrowserExtensionPage> {
             _verifyStep(theme),
           ],
           const Divider(height: 32),
-          _versionCard(theme, build),
+          _versionCard(theme, appModel, build),
         ],
       ),
     );
@@ -299,21 +299,67 @@ class _BrowserExtensionPageState extends ConsumerState<BrowserExtensionPage> {
     );
   }
 
-  Widget _versionCard(ThemeData theme, String? build) {
-    return HibikiCard(
-      child: Row(
-        children: <Widget>[
-          Icon(Icons.info_outline,
-              size: 20, color: theme.colorScheme.onSurfaceVariant),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Text(
-              '${t.browser_extension_version_label} · ${build ?? '—'}',
-              style: const TextStyle(fontFamily: 'monospace'),
-            ),
+  /// 版本卡（BUG-1079 扩展为双行）：app 内置指纹 + 扩展自报的「浏览器中实际加载」指纹；
+  /// 两者都有且不一致时显示警示条（扩展自更新未生效，需手动到扩展管理页重新加载）。
+  /// 浏览器侧指纹经 [AppModel.browserExtensionReportedBuild]（ValueNotifier）实时驱动。
+  Widget _versionCard(ThemeData theme, AppModel appModel, String? build) {
+    return ValueListenableBuilder<String?>(
+      valueListenable: appModel.browserExtensionReportedBuild,
+      builder: (BuildContext context, String? reported, Widget? _) {
+        final bool mismatch =
+            build != null && reported != null && build != reported;
+        return HibikiCard(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  Icon(Icons.info_outline,
+                      size: 20, color: theme.colorScheme.onSurfaceVariant),
+                  const SizedBox(width: 10),
+                  Expanded(child: Text(t.browser_extension_version_label)),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '${t.browser_extension_version_app} · ${build ?? '—'}',
+                style: const TextStyle(fontFamily: 'monospace'),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '${t.browser_extension_version_browser} · ${reported ?? '—'}',
+                style: const TextStyle(fontFamily: 'monospace'),
+              ),
+              if (mismatch) ...<Widget>[
+                const SizedBox(height: 10),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(10),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.errorContainer,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Icon(Icons.update,
+                          size: 18, color: theme.colorScheme.onErrorContainer),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          t.browser_extension_version_mismatch,
+                          style: TextStyle(
+                              color: theme.colorScheme.onErrorContainer),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/hibiki/lib/src/sync/yomitan_api_server.dart
+++ b/hibiki/lib/src/sync/yomitan_api_server.dart
@@ -60,6 +60,7 @@ class YomitanApiServer {
     String? Function()? extensionBuildProvider,
     void Function(double maxWidth, double maxHeight)? onExtensionPopupSize,
     void Function()? onExtensionSeen,
+    void Function(String build, String? version)? onExtensionReport,
     String? apiKey,
     bool allowLan = false,
   })  : _requestedPort = port,
@@ -73,6 +74,7 @@ class YomitanApiServer {
         _extensionBuildProvider = extensionBuildProvider,
         _onExtensionPopupSize = onExtensionPopupSize,
         _onExtensionSeen = onExtensionSeen,
+        _onExtensionReport = onExtensionReport,
         _apiKey = apiKey,
         _allowLan = allowLan;
 
@@ -96,6 +98,10 @@ class YomitanApiServer {
   // 供「安装 → 验证插件已正常启用」的连接检测显示）。扩展 background 在 SW 启动时
   // 主动打 /api/extension/status，故装完扩展即刷新 last-seen，无需用户先划词。
   final void Function()? _onExtensionSeen;
+  // BUG-1079：扩展经 /api/extension/status 请求体自报「浏览器中实际加载的 build」
+  // （+ manifest version）。app 侧记录后与内置指纹比对，不一致时在扩展管理页给出
+  // 更新提示。旧扩展发 '{}'（无 build 字段）时不回调——行为等同现状（向后兼容）。
+  final void Function(String build, String? version)? _onExtensionReport;
   final String? _apiKey;
   final bool _allowLan;
 
@@ -246,19 +252,7 @@ class YomitanApiServer {
       case '/api/extension/popup-size':
         return _handleExtensionPopupSize(request);
       case '/api/extension/status':
-        // BUG-726/自更新：状态端点回带当前内置扩展指纹（extensionBuild），扩展
-        // background 在 SW 启动时打这里比对自身 build，不一致即 chrome.runtime.reload()
-        // 从磁盘拉新——把「只有查词才检查更新」升级为「启动即主动检查」。null（指纹
-        // 尚未算好 / 旧 app）时省略该字段，向后兼容。
-        {
-          final String? extensionBuild = _extensionBuildProvider?.call();
-          return _json(<String, dynamic>{
-            'app': 'hibiki',
-            'ready': true,
-            'port': port,
-            if (extensionBuild != null) 'extensionBuild': extensionBuild,
-          });
-        }
+        return _handleExtensionStatus(request);
       case '/api/youtube/captions':
         return _handleYoutubeCaptions(request);
       case '/api/subtitle/parse':
@@ -266,6 +260,35 @@ class YomitanApiServer {
       default:
         return shelf.Response.notFound('Unknown endpoint');
     }
+  }
+
+  /// BUG-726/自更新：状态端点回带当前内置扩展指纹（extensionBuild），扩展
+  /// background 在 SW 启动时打这里比对自身 build，不一致即 chrome.runtime.reload()
+  /// 从磁盘拉新——把「只有查词才检查更新」升级为「启动即主动检查」。null（指纹
+  /// 尚未算好 / 旧 app）时省略该字段，向后兼容。
+  ///
+  /// BUG-1079：请求体可携带扩展自报的 `{build, version}`（浏览器中实际加载的版本），
+  /// 有非空 build 时经 [_onExtensionReport] 记到 app 侧。旧扩展发 '{}' / 空 body /
+  /// 非法 JSON 一律容错——不回调、不报错，响应与现状完全一致（向后兼容）。
+  Future<shelf.Response> _handleExtensionStatus(shelf.Request request) async {
+    final Map<String, dynamic>? body = await _readJson(request);
+    final Object? reportedBuild = body?['build'];
+    if (reportedBuild is String && reportedBuild.isNotEmpty) {
+      final Object? reportedVersion = body?['version'];
+      _onExtensionReport?.call(
+        reportedBuild,
+        reportedVersion is String && reportedVersion.isNotEmpty
+            ? reportedVersion
+            : null,
+      );
+    }
+    final String? extensionBuild = _extensionBuildProvider?.call();
+    return _json(<String, dynamic>{
+      'app': 'hibiki',
+      'ready': true,
+      'port': port,
+      if (extensionBuild != null) 'extensionBuild': extensionBuild,
+    });
   }
 
   /// BUG-530：浏览器扩展查词端点（与 HibikiSyncServer 共享契约）。

--- a/hibiki/lib/src/sync/yomitan_api_server_manager.dart
+++ b/hibiki/lib/src/sync/yomitan_api_server_manager.dart
@@ -17,6 +17,7 @@ class YomitanApiServerManager {
     String? Function()? extensionBuildProvider,
     void Function(double maxWidth, double maxHeight)? onExtensionPopupSize,
     void Function()? onExtensionSeen,
+    void Function(String build, String? version)? onExtensionReport,
   })  : _lookup = lookupService,
         _mining = miningService,
         _history = historyService,
@@ -26,7 +27,8 @@ class YomitanApiServerManager {
         _audioSourcesProvider = audioSourcesProvider,
         _extensionBuildProvider = extensionBuildProvider,
         _onExtensionPopupSize = onExtensionPopupSize,
-        _onExtensionSeen = onExtensionSeen;
+        _onExtensionSeen = onExtensionSeen,
+        _onExtensionReport = onExtensionReport;
 
   final HibikiRemoteLookupService _lookup;
   final HibikiRemoteMiningService? _mining;
@@ -43,6 +45,9 @@ class YomitanApiServerManager {
   final void Function(double maxWidth, double maxHeight)? _onExtensionPopupSize;
   // 浏览器扩展连接探活回调，透传给 [YomitanApiServer]（app 侧记录 last-seen）。
   final void Function()? _onExtensionSeen;
+  // BUG-1079：扩展自报版本回调，透传给 [YomitanApiServer]（app 侧记录浏览器中实际
+  // 加载的 build，与内置指纹比对给出更新提示）。
+  final void Function(String build, String? version)? _onExtensionReport;
 
   YomitanApiServer? _server;
 
@@ -63,6 +68,7 @@ class YomitanApiServerManager {
       extensionBuildProvider: _extensionBuildProvider,
       onExtensionPopupSize: _onExtensionPopupSize,
       onExtensionSeen: _onExtensionSeen,
+      onExtensionReport: _onExtensionReport,
       apiKey: apiKey.isEmpty ? null : apiKey,
       allowLan: true,
     );

--- a/hibiki/test/lookup/browser_extension_page_scroll_bug732_test.js
+++ b/hibiki/test/lookup/browser_extension_page_scroll_bug732_test.js
@@ -11,6 +11,14 @@
 // scrolling (no preventDefault). The in-app popup (flutter_inappwebview, no
 // chrome) and wheels over the popup itself keep the custom scaled scroll.
 //
+// BUG-1078 extends this: even a cheap non-passive document wheel listener makes
+// the browser abandon the compositor fast-scroll path on EVERY page the content
+// script touches. So in the extension context popup.js must NOT attach to
+// document at all — it exposes the handler as window.__hibikiPopupWheelListener
+// and content.js lazily mounts it on the popup shadow host for the popup's
+// lifetime. The in-app popup (no chrome.runtime) keeps the resident document
+// listener ({passive:false}) — there the document IS the popup.
+//
 // This EXECUTES the real popup.js wheel handler against a minimal fake DOM and
 // asserts preventDefault / scrollBy per surface. Reverting the guard turns it red.
 //
@@ -35,7 +43,7 @@ function loadWheelHandler(opts) {
     hostScrollBy: [],
   };
 
-  let wheelHandler = null;
+  const documentWheelRegs = [];
 
   const hostEl = {
     style: {},
@@ -45,8 +53,8 @@ function loadWheelHandler(opts) {
   const documentObj = {
     documentElement: { style: {} },
     body: { tagName: 'BODY' },
-    addEventListener(type, handler) {
-      if (type === 'wheel') wheelHandler = handler;
+    addEventListener(type, handler, options) {
+      if (type === 'wheel') documentWheelRegs.push({ handler, options });
     },
   };
 
@@ -82,8 +90,28 @@ function loadWheelHandler(opts) {
   vm.createContext(sandbox);
   vm.runInContext(source, sandbox, { filename: 'popup.js' });
 
-  assert.ok(typeof wheelHandler === 'function',
-    'popup.js must register a document wheel handler');
+  let wheelHandler = null;
+  if (opts.extension) {
+    // BUG-1078: extension context must leave document COMPLETELY free of wheel
+    // listeners (a resident non-passive listener kills compositor fast scroll on
+    // every page). The handler is exposed for content.js to mount on the shadow
+    // host for the popup's lifetime.
+    assert.strictEqual(documentWheelRegs.length, 0,
+      'extension context must NOT attach any document wheel listener (BUG-1078)');
+    wheelHandler = windowObj.__hibikiPopupWheelListener;
+    assert.ok(typeof wheelHandler === 'function',
+      'extension context must expose window.__hibikiPopupWheelListener for ' +
+      'content.js to lazily mount on the popup shadow host');
+  } else {
+    // In-app popup WebView: the document IS the popup — the resident document
+    // listener must stay, and stay non-passive (it preventDefault()s).
+    assert.strictEqual(documentWheelRegs.length, 1,
+      'in-app popup must keep exactly one resident document wheel listener');
+    assert.ok(documentWheelRegs[0].options &&
+      documentWheelRegs[0].options.passive === false,
+      'in-app document wheel listener must be {passive:false} (it preventDefaults)');
+    wheelHandler = documentWheelRegs[0].handler;
+  }
 
   return { wheelHandler, calls, hostEl };
 }

--- a/hibiki/test/lookup/browser_extension_update_stale_guard_test.dart
+++ b/hibiki/test/lookup/browser_extension_update_stale_guard_test.dart
@@ -1,0 +1,147 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1079 守卫（源码扫描）：扩展自更新失败不再永久静默，且版本感知双向闭环。
+///
+/// 旧行为两处断裂：
+/// ① background.js 对某 remote build reload 过一次就永不重试（latch 永久静默）——自更新
+///    失败（磁盘副本没刷成 / 用户从别的目录加载 / 浏览器拒绝 reload）后永久停在旧版零提示；
+/// ② 扩展状态请求写死 '{}'，app 端对浏览器里实际加载的版本零感知，扩展管理页只显示
+///    app 内置指纹，无从提示「浏览器里那份已过期」。
+///
+/// 修复链路：self-update.js 纯状态机（reload 一次 → 仍不一致落 hibikiUpdateStale →
+/// 恢复一致清除）+ action-popup 提示 + 图标角标（录制角标优先）+ 状态请求自报
+/// build/version + server 解析回调 + app_model 记录 + 扩展管理页双行版本卡与警示条。
+///
+/// flutter test cwd is the hibiki package root.
+void main() {
+  const Map<String, String> mirrors = <String, String>{
+    'assets': 'assets/browser_extension',
+    'tools': '../tools/browser-extension',
+  };
+
+  group('BUG-1079 extension self-update stale detection', () {
+    mirrors.forEach((String name, String root) {
+      test(
+          '[$name] background uses the self-update state machine (no permanent latch)',
+          () {
+        final String src = File('$root/background.js').readAsStringSync();
+        expect(
+            src.contains(
+                "importScripts('hibiki-defaults.js', 'connection-diagnostics.js', 'self-update.js')"),
+            isTrue,
+            reason: '$root background.js must load self-update.js');
+        expect(src.contains('HIBIKI_SELF_UPDATE.decide('), isTrue,
+            reason:
+                '$root background.js must decide via the pure state machine '
+                'instead of an early-return latch');
+        expect(src.contains('hibikiUpdateStale: decision.stale'), isTrue,
+            reason: '$root background.js must persist the stale marker when a '
+                'reload already happened but builds still mismatch');
+        expect(
+            src.contains("chrome.storage.local.remove(['hibikiUpdateStale'])"),
+            isTrue,
+            reason: '$root background.js must clear the stale marker once '
+                'builds match again');
+      });
+
+      test(
+          '[$name] status requests self-report build/version (no hardcoded {})',
+          () {
+        final String src = File('$root/background.js').readAsStringSync();
+        expect(src.contains('statusRequestBody()'), isTrue,
+            reason: '$root background.js must send the self-reported '
+                'build/version body on /api/extension/status');
+        expect(src.contains('chrome.runtime.getManifest().version'), isTrue,
+            reason: '$root background.js must include the manifest version');
+      });
+
+      test('[$name] update badge yields to the recording badge', () {
+        final String src = File('$root/background.js').readAsStringSync();
+        final int fn = src.indexOf('async function refreshUpdateBadge()');
+        expect(fn >= 0, isTrue,
+            reason: '$root background.js must define refreshUpdateBadge()');
+        final String body = src.substring(fn, fn + 600);
+        expect(
+            body.contains('if (await isOffscreenRecording()) return;'), isTrue,
+            reason: '$root refreshUpdateBadge must skip while recording '
+                '(recording badge has priority)');
+        expect(src.contains('if (!on) refreshUpdateBadge();'), isTrue,
+            reason: '$root setRecordingBadge(false) must restore the update '
+                'badge after recording ends');
+      });
+
+      test('[$name] action-popup surfaces the manual-reload notice', () {
+        final String html =
+            File('$root/vendor/action-popup.html').readAsStringSync();
+        final String js =
+            File('$root/vendor/action-popup.js').readAsStringSync();
+        expect(html.contains('id="hp-update"'), isTrue,
+            reason: '$root action-popup.html missing the update notice row');
+        expect(js.contains('hibikiUpdateNotice'), isTrue,
+            reason: '$root action-popup.js missing the notice copy function');
+        expect(js.contains("chrome.storage.local.get(['hibikiUpdateStale']"),
+            isTrue,
+            reason: '$root action-popup.js must read hibikiUpdateStale');
+        expect(js.contains('changes.hibikiUpdateStale'), isTrue,
+            reason: '$root action-popup.js must react to stale changes live');
+      });
+    });
+
+    test('self-update.js mirrors stay byte-identical', () {
+      final List<int> tools =
+          File('../tools/browser-extension/self-update.js').readAsBytesSync();
+      final List<int> assets =
+          File('assets/browser_extension/self-update.js').readAsBytesSync();
+      expect(assets, tools,
+          reason:
+              'assets/browser_extension/self-update.js out of sync with tools/');
+    });
+
+    test('server parses the reported build from the status body (tolerant)',
+        () {
+      final String src =
+          File('lib/src/sync/yomitan_api_server.dart').readAsStringSync();
+      expect(src.contains('onExtensionReport'), isTrue,
+          reason: 'yomitan_api_server.dart must expose the report callback');
+      expect(src.contains('_handleExtensionStatus'), isTrue,
+          reason: 'status endpoint must go through the body-parsing handler');
+      expect(
+          src.contains('reportedBuild is String && reportedBuild.isNotEmpty'),
+          isTrue,
+          reason: 'server must only report a non-empty string build '
+              "(old extensions sending '{}' keep current behavior)");
+    });
+
+    test('app model records the reported build for the extension page', () {
+      final String src =
+          File('lib/src/models/app_model.dart').readAsStringSync();
+      expect(src.contains('browserExtensionReportedBuild'), isTrue,
+          reason: 'app_model.dart must hold the reported-build notifier');
+      expect(src.contains('onExtensionReport:'), isTrue,
+          reason: 'app_model.dart must wire onExtensionReport into the '
+              'yomitan server manager');
+    });
+
+    test('extension page shows both builds and a mismatch warning', () {
+      final String src =
+          File('lib/src/pages/implementations/browser_extension_page.dart')
+              .readAsStringSync();
+      expect(src.contains('browserExtensionReportedBuild'), isTrue,
+          reason: 'version card must subscribe to the reported build');
+      expect(src.contains('browser_extension_version_app'), isTrue,
+          reason: 'version card must label the app bundled build');
+      expect(src.contains('browser_extension_version_browser'), isTrue,
+          reason: 'version card must label the browser-loaded build');
+      expect(src.contains('browser_extension_version_mismatch'), isTrue,
+          reason: 'version card must show the mismatch guidance');
+      expect(
+          src.contains(
+              'build != null && reported != null && build != reported'),
+          isTrue,
+          reason: 'mismatch warning must require both builds known and unequal '
+              '(never warn on missing report — old extensions)');
+    });
+  });
+}

--- a/hibiki/test/lookup/global_lookup_mouse_hook_stutter_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_mouse_hook_stutter_guard_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1077 的静态守卫：app 外**嵌套**查词瞬间全局鼠标不得再卡一下。
+///
+/// BUG-1048 把 `WH_MOUSE_LL` 挪到了专用线程，但留下两个残余机制，正好在嵌套查词
+/// 的瞬间叠加发作：
+///   ① 钩子线程默认 NORMAL 优先级——嵌套查词瞬间进程内 CPU 风暴（同步 FFI 词典
+///      查询 + 整栈 JSON 序列化 + WebView2 COM + 窗口区域重建）把它抢占几十毫秒，
+///      而 LL 钩子是同步的：系统等它返回才分发输入，全系统鼠标跟着卡一下；
+///   ② 剪贴板面板 / galgame 浮窗路径的嵌套查词走「reset Hide → 再 Reveal」，
+///      Hide 无条件 Disarm、Reveal 再 Arm——每次嵌套做两回全局钩子表变更（桌面级
+///      钩子链更新与 Raw Input 线程串行，各是一次全系统输入短暂停顿）。
+///
+/// 纯 Win32 输入队列行为无法在 Dart 侧行为测试里复现，最强可落地层是锁住修复结构：
+///   ① 钩子线程必须以 TIME_CRITICAL 优先级运行；
+///   ② Disarm 必须是「清目标 + 宽限期延迟真卸」（SetTimer/KillTimer 线程定时器），
+///      不允许退回收到 Disarm 就立即 UnhookWindowsHookEx 的立卸立装；
+///   ③ 首次建线程等待 id 发布必须走事件（WaitForSingleObject），不允许退回
+///      Sleep(1) 自旋——那段等待跑在 platform 线程上，默认定时器精度下一次就能
+///      睡 ~15ms。
+void main() {
+  final String hook =
+      File('windows/runner/low_level_mouse_hook.cpp').readAsStringSync();
+
+  test('钩子线程以 TIME_CRITICAL 优先级运行', () {
+    expect(
+      hook.contains('SetThreadPriority(GetCurrentThread(),'
+          ' THREAD_PRIORITY_TIME_CRITICAL)'),
+      isTrue,
+      reason: 'BUG-1077：LL 钩子承载线程被普通优先级抢占时全系统鼠标会卡，'
+          '必须提到 TIME_CRITICAL',
+    );
+  });
+
+  test('Disarm 走宽限期延迟真卸，不立卸立装', () {
+    expect(hook.contains('kDisarmGraceMs'), isTrue,
+        reason: '必须有宽限期常量：嵌套查词 Hide→Reveal 间隔内不得真卸钩子');
+    expect(hook.contains('SetTimer(nullptr,'), isTrue,
+        reason: '延迟卸载靠钩子线程自己的线程定时器');
+    expect(hook.contains('KillTimer(nullptr,'), isTrue,
+        reason: '新的 Arm 到来必须取消挂起的延迟卸载');
+  });
+
+  test('等待钩子线程就绪用事件，不用 Sleep 自旋', () {
+    expect(hook.contains('WaitForSingleObject('), isTrue,
+        reason: '首次 Arm 在 platform 线程上等 id 发布，必须事件等待');
+    expect(
+      hook.contains('Sleep('),
+      isFalse,
+      reason: 'Sleep(1) 自旋在默认定时器精度下单次可睡 ~15ms，会卡 platform 线程',
+    );
+  });
+}

--- a/hibiki/test/sync/yomitan_api_server_status_report_test.dart
+++ b/hibiki/test/sync/yomitan_api_server_status_report_test.dart
@@ -1,0 +1,153 @@
+// BUG-1079：/api/extension/status 请求体解析——扩展自报「浏览器中实际加载的 build」。
+// 此前扩展写死 '{}'、server 完全不读 body → app 对浏览器里实际跑的版本零感知，自更新
+// 静默失败无从发现。本测在真实 HTTP 层验证：
+// - 新扩展带 {build, version} → onExtensionReport 收到；
+// - 旧扩展 '{}' / 空 body / 非法 JSON / build 类型错 → 容错不回调、响应与现状一致。
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_dictionary/hibiki_dictionary.dart';
+
+import 'package:hibiki/src/sync/hibiki_remote_lookup_service.dart';
+import 'package:hibiki/src/sync/yomitan_api_server.dart';
+
+class _FakeLookup implements HibikiRemoteLookupService {
+  @override
+  Future<DictionarySearchResult?> searchDictionary({
+    required String term,
+    required bool wildcards,
+    required int maximumTerms,
+  }) async =>
+      null;
+
+  @override
+  Future<RemoteAudioLookup?> lookupAudio({
+    required String expression,
+    required String reading,
+  }) async =>
+      null;
+}
+
+List<String> _noopTokenize(String text) => <String>[text];
+String _noopReading(String word) => '';
+
+Future<HttpClientResponse> _postRaw(
+  int port,
+  String path,
+  String rawBody, {
+  String? auth,
+}) async {
+  // 不在这里 close client（响应尚未被调用方读取）；测试进程退出即回收。
+  final HttpClient c = HttpClient();
+  final HttpClientRequest req =
+      await c.postUrl(Uri.parse('http://127.0.0.1:$port$path'));
+  req.headers.contentType = ContentType.json;
+  if (auth != null) req.headers.set('authorization', auth);
+  req.write(rawBody);
+  return req.close();
+}
+
+Future<Map<String, dynamic>> _json(HttpClientResponse resp) async {
+  final String s = await resp.transform(utf8.decoder).join();
+  return jsonDecode(s) as Map<String, dynamic>;
+}
+
+void main() {
+  group('BUG-1079 /api/extension/status body report', () {
+    late YomitanApiServer server;
+    late List<(String, String?)> reports;
+    late int seenCount;
+
+    Future<void> startServer() async {
+      reports = <(String, String?)>[];
+      seenCount = 0;
+      server = YomitanApiServer(
+        port: 0, // ephemeral
+        lookupService: _FakeLookup(),
+        tokenizer: _noopTokenize,
+        readingResolver: _noopReading,
+        extensionBuildProvider: () => 'ffff0000ffff0000',
+        onExtensionSeen: () => seenCount++,
+        onExtensionReport: (String build, String? version) =>
+            reports.add((build, version)),
+      );
+      await server.start();
+    }
+
+    setUp(() async => startServer());
+    tearDown(() async => server.stop());
+
+    test('扩展自报 build+version → onExtensionReport 收到', () async {
+      final HttpClientResponse resp = await _postRaw(
+        server.port,
+        '/api/extension/status',
+        jsonEncode(
+            <String, dynamic>{'build': 'abcd1234abcd1234', 'version': '0.3.0'}),
+      );
+      expect(resp.statusCode, 200);
+      final Map<String, dynamic> j = await _json(resp);
+      // 响应契约不变：仍回带内置指纹 + ready。
+      expect(j['app'], 'hibiki');
+      expect(j['ready'], true);
+      expect(j['extensionBuild'], 'ffff0000ffff0000');
+      expect(reports, <(String, String?)>[('abcd1234abcd1234', '0.3.0')]);
+      expect(seenCount, 1, reason: 'last-seen 探活回调不受影响');
+    });
+
+    test('只报 build 不报 version → version 为 null', () async {
+      await _postRaw(server.port, '/api/extension/status',
+          jsonEncode(<String, dynamic>{'build': 'abcd1234abcd1234'}));
+      expect(reports, <(String, String?)>[('abcd1234abcd1234', null)]);
+    });
+
+    test('旧扩展 \'{}\' body → 不回调、响应与现状一致（向后兼容）', () async {
+      final HttpClientResponse resp =
+          await _postRaw(server.port, '/api/extension/status', '{}');
+      expect(resp.statusCode, 200);
+      final Map<String, dynamic> j = await _json(resp);
+      expect(j['app'], 'hibiki');
+      expect(j['extensionBuild'], 'ffff0000ffff0000');
+      expect(reports, isEmpty);
+      expect(seenCount, 1, reason: '旧扩展仍刷新 last-seen');
+    });
+
+    test('空 body / 非法 JSON / build 类型错 → 容错不回调不报错', () async {
+      expect(
+          (await _postRaw(server.port, '/api/extension/status', '')).statusCode,
+          200);
+      expect(
+          (await _postRaw(server.port, '/api/extension/status', 'not json'))
+              .statusCode,
+          200);
+      expect(
+          (await _postRaw(server.port, '/api/extension/status',
+                  jsonEncode(<String, dynamic>{'build': 42})))
+              .statusCode,
+          200);
+      expect(
+          (await _postRaw(server.port, '/api/extension/status',
+                  jsonEncode(<String, dynamic>{'build': ''})))
+              .statusCode,
+          200);
+      expect(reports, isEmpty);
+    });
+
+    test('未注入 onExtensionReport（旧 app 装配）→ 带 build 也不炸', () async {
+      await server.stop();
+      server = YomitanApiServer(
+        port: 0,
+        lookupService: _FakeLookup(),
+        tokenizer: _noopTokenize,
+        readingResolver: _noopReading,
+      );
+      await server.start();
+      final HttpClientResponse resp = await _postRaw(
+          server.port,
+          '/api/extension/status',
+          jsonEncode(<String, dynamic>{'build': 'abcd1234abcd1234'}));
+      expect(resp.statusCode, 200);
+      expect((await _json(resp))['app'], 'hibiki');
+    });
+  });
+}

--- a/hibiki/windows/runner/low_level_mouse_hook.cpp
+++ b/hibiki/windows/runner/low_level_mouse_hook.cpp
@@ -13,13 +13,21 @@ namespace {
 constexpr UINT kThreadArm = WM_APP + 0x60;
 constexpr UINT kThreadDisarm = WM_APP + 0x61;
 
+// BUG-1077 — Disarm 的宽限期（毫秒）。嵌套查词的 reset(Hide) → RevealStack 间隔
+// 只有百毫秒级，立卸立装等于每次嵌套做两次全局钩子表变更（桌面级钩子链更新要与
+// Raw Input 线程串行，本身就是一次全系统输入短暂停顿）。宽限期内 g_target 已清空、
+// 回调纯放行，语义与已卸载等价；超过宽限期仍无新 Arm 才真正 UnhookWindowsHookEx，
+// 维持「不查词不留全局钩子」的承诺。
+constexpr UINT kDisarmGraceMs = 3000;
+
 // 钩子线程与调用线程共享的唯一可变状态：目标窗口。回调只读它，故用 atomic 而不是锁——
 // 钩子回调必须尽快返回，任何可能阻塞（锁竞争、堆分配）的东西都不该出现在这条路径上。
 std::atomic<HWND> g_target{nullptr};
 
 std::mutex g_thread_mutex;
-std::thread g_thread;
 std::atomic<DWORD> g_thread_id{0};
+// 线程 id 发布完成的信号（进程生命周期常驻，不关闭）。
+HANDLE g_thread_ready = nullptr;
 
 LRESULT CALLBACK HookProc(int code, WPARAM wparam, LPARAM lparam) {
   // 只关心「按下」：移动/滚轮直接放行（这条分支每秒会跑上千次，必须是纯比较）。
@@ -44,21 +52,46 @@ LRESULT CALLBACK HookProc(int code, WPARAM wparam, LPARAM lparam) {
 }
 
 void HookThreadMain() {
+  // BUG-1077 — WH_MOUSE_LL 是同步钩子：系统等这条线程被调度并返回才把输入分发给
+  // 前台程序。嵌套查词的瞬间，进程内同时有同步 FFI 词典查询、整栈 JSON 序列化、
+  // WebView2 COM 与窗口区域重建在抢核；NORMAL 优先级的钩子线程被抢占几十毫秒，
+  // 全系统鼠标就跟着卡一下。TIME_CRITICAL 是 LL 钩子承载线程的标准做法——回调
+  // 每个事件只做两次整数比较，高优先级不会饿着任何人。
+  SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
   // 线程必须有消息队列钩子事件才会被投递过来；PeekMessage 强制系统建队列，之后
   // Arm/Disarm 的 PostThreadMessage 才不会丢。
   MSG msg{};
   PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
   g_thread_id.store(GetCurrentThreadId(), std::memory_order_release);
+  SetEvent(g_thread_ready);
 
   HHOOK hook = nullptr;
+  // 宽限期卸载定时器（线程定时器，WM_TIMER 走本线程消息队列）。0 = 未挂起。
+  UINT_PTR disarm_timer = 0;
   while (GetMessage(&msg, nullptr, 0, 0) > 0) {
     if (msg.message == kThreadArm) {
+      if (disarm_timer != 0) {
+        KillTimer(nullptr, disarm_timer);
+        disarm_timer = 0;
+      }
       if (hook == nullptr) {
         hook = SetWindowsHookEx(WH_MOUSE_LL, &HookProc,
                                 GetModuleHandle(nullptr), 0);
       }
     } else if (msg.message == kThreadDisarm) {
-      if (hook != nullptr) {
+      // g_target 已由 Disarm 侧清空（回调此刻起纯放行）；这里只安排宽限期后的
+      // 真正卸载。已有挂起定时器就沿用原先的到期时间。
+      if (hook != nullptr && disarm_timer == 0) {
+        disarm_timer = SetTimer(nullptr, 0, kDisarmGraceMs, nullptr);
+      }
+    } else if (msg.message == WM_TIMER && disarm_timer != 0 &&
+               msg.wParam == disarm_timer) {
+      KillTimer(nullptr, disarm_timer);
+      disarm_timer = 0;
+      // 宽限期内没有新的 Arm（有的话定时器早被杀掉）——真正闲置，卸钩子。
+      // 再核一次 g_target 防御 Arm 消息尚在队列里的窗口期。
+      if (hook != nullptr &&
+          g_target.load(std::memory_order_relaxed) == nullptr) {
         UnhookWindowsHookEx(hook);
         hook = nullptr;
       }
@@ -76,16 +109,18 @@ DWORD EnsureHookThread() {
   std::lock_guard<std::mutex> guard(g_thread_mutex);
   const DWORD after_lock = g_thread_id.load(std::memory_order_acquire);
   if (after_lock != 0) return after_lock;
-  g_thread = std::thread(&HookThreadMain);
-  g_thread.detach();
-  // 线程 id 是线程自己发布的，这里必须等到它可用后才能 PostThreadMessage（否则
-  // Arm 会静默丢失）。发布只隔着 PeekMessage 一步，实测微秒级。
-  for (int spin = 0; spin < 2000; ++spin) {
-    const DWORD id = g_thread_id.load(std::memory_order_acquire);
-    if (id != 0) return id;
-    Sleep(1);
+  // BUG-1077 — 等待 id 发布用事件而不是逐毫秒睡眠自旋：这里跑在 platform 线程上，
+  // 毫秒级睡眠在默认定时器精度下单次可睡 ~15ms，首次查词会白白卡 UI。事件在线程
+  // 建好消息队列、发布 id 之后立即置位，实测微秒级；2s 上限只防线程创建失败。
+  if (g_thread_ready == nullptr) {
+    g_thread_ready = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (g_thread_ready == nullptr) return 0;
   }
-  return 0;
+  std::thread(&HookThreadMain).detach();
+  if (WaitForSingleObject(g_thread_ready, 2000) != WAIT_OBJECT_0) {
+    return 0;
+  }
+  return g_thread_id.load(std::memory_order_acquire);
 }
 
 }  // namespace

--- a/hibiki/windows/runner/low_level_mouse_hook.h
+++ b/hibiki/windows/runner/low_level_mouse_hook.h
@@ -14,6 +14,16 @@
 //
 // 线程常驻（首次 Arm 时懒创建），Arm/Disarm 只是让它装/卸钩子——查词是高频操作，
 // 每次都建销线程反而制造无谓的竞态窗口。
+//
+// BUG-1077 — 两条补强，针对「嵌套查词瞬间鼠标卡一下」：
+//   ① 钩子线程跑在 TIME_CRITICAL 优先级：嵌套查词的瞬间进程内 CPU 风暴（同步 FFI
+//      词典查询 + 整栈 JSON 序列化 + WebView2 COM + 窗口区域重建）会把 NORMAL
+//      优先级的钩子线程抢占几十毫秒，而系统同步等它返回才分发输入——全系统鼠标
+//      跟着卡一下。
+//   ② Disarm 延迟真卸：嵌套/连续查词路径每次都是 Hide(Disarm) → 百毫秒 →
+//      Reveal(Arm)，立卸立装 = 每次两回全局钩子表变更（又各是一次输入停顿）。
+//      Disarm 先清目标（回调立即纯放行，语义等同已卸载），宽限期内无新 Arm 才
+//      真正 UnhookWindowsHookEx。
 
 #include <windows.h>
 
@@ -31,7 +41,8 @@ POINT UnpackMouseHookPoint(WPARAM wparam);
 
 // 装钩子并把命中事件投递给 |target|。重复调用只是替换目标窗口（幂等）。
 void ArmLowLevelMouseHook(HWND target);
-// 卸钩子（目标窗口清空）。未装时是 no-op。
+// 卸钩子：目标窗口立即清空（回调纯放行）；真正的 UnhookWindowsHookEx 延迟一段
+// 宽限期（见 .cpp 的 kDisarmGraceMs），期间再次 Arm 则取消卸载。未装时是 no-op。
 void DisarmLowLevelMouseHook();
 
 }  // namespace hibiki

--- a/tools/browser-extension/background.js
+++ b/tools/browser-extension/background.js
@@ -1,6 +1,6 @@
 // TODO-1087：自动配置默认值。app 安装助手在解压时把当前 server 真值写进 hibiki-defaults.js，
 // 于是加载已解压扩展后无需手填。用户仍可在 options 手动覆盖（chrome.storage.local 优先于默认）。
-try { importScripts('hibiki-defaults.js', 'connection-diagnostics.js'); } catch (_) { /* 缺省文件时回落硬编码默认 */ }
+try { importScripts('hibiki-defaults.js', 'connection-diagnostics.js', 'self-update.js'); } catch (_) { /* 缺省文件时回落硬编码默认 */ }
 const HIBIKI_DEFAULTS =
     (self.HIBIKI_DEFAULTS) || { host: '127.0.0.1', port: 19633, token: '' };
 
@@ -15,6 +15,16 @@ async function cfg() {
   return { base: `http://${host}:${port}`, token };
 }
 function authHeader(token) { return 'Basic ' + btoa('hibiki:' + token); }
+
+// BUG-1079：/api/extension/status 请求体统一自报「浏览器中实际加载的版本」
+// （HIBIKI_DEFAULTS.build + manifest version）。此前写死 '{}'，app 端对浏览器里实际
+// 跑的是哪个 build 零感知。旧 app 忽略 body → 向后兼容。
+function statusRequestBody() {
+  try {
+    return self.HIBIKI_SELF_UPDATE.statusRequestBody(
+        HIBIKI_DEFAULTS, chrome.runtime.getManifest().version);
+  } catch (_) { return '{}'; }
+}
 
 let connectionCache = null;
 async function responseJson(resp) {
@@ -35,7 +45,7 @@ async function diagnoseConnection(force) {
     const r = await fetch(base + '/api/extension/status', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
-      body: '{}',
+      body: statusRequestBody(),
     });
     primary = { status: r.status, body: await responseJson(r) };
     if (r.status === 404 || r.status === 405) {
@@ -71,16 +81,36 @@ async function diagnoseConnection(force) {
 // 两者：不一致 = 磁盘上已有新版而当前加载的还是旧版 → chrome.runtime.reload() 从磁盘拉新
 // （等价于扩展管理页的「重新加载」，未解压包路径不变）。防护：
 // - 任一侧缺指纹（旧 app / 占位默认）→ 不动（向后兼容，绝不空转 reload）；
-// - storage 记录已为该指纹 reload 过 → 不再重试（防「磁盘没刷成」时无限循环）；
+// - storage 记录已为该指纹 reload 过 → 不再重复 reload（防「磁盘没刷成」时无限循环）；
 // - 正在 Netflix 逐句回放录制 → 跳过（reload 会杀掉 offscreen 录制，等录完下次查词再说）。
+// BUG-1079：latch 不再是「永久静默」——每次心跳仍重新比对（决策抽成 self-update.js 的
+// 纯状态机）：已 reload 过仍不一致 = 自更新失效（用户从别的目录加载 / 磁盘没刷成 /
+// 浏览器拒绝 reload），落 chrome.storage.local.hibikiUpdateStale {remote, local} 供
+// action-popup 显示「需手动重载」提示 + 图标角标；恢复一致时清除 stale 与角标。
 async function maybeSelfReload(data) {
   try {
     const remote = data && data.extensionBuild;
     const local = HIBIKI_DEFAULTS.build;
-    if (!remote || !local || remote === local) return;
-    if (await isOffscreenRecording()) return;
-    const st = await chrome.storage.local.get(['hibikiReloadedForBuild']);
-    if (st.hibikiReloadedForBuild === remote) return;
+    const st = await chrome.storage.local.get(
+        ['hibikiReloadedForBuild', 'hibikiUpdateStale']);
+    const decision = self.HIBIKI_SELF_UPDATE.decide(
+        remote, local, st.hibikiReloadedForBuild, await isOffscreenRecording());
+    if (decision.action === 'clear') {
+      if (st.hibikiUpdateStale) {
+        await chrome.storage.local.remove(['hibikiUpdateStale']);
+        refreshUpdateBadge();
+      }
+      return;
+    }
+    if (decision.action === 'stale') {
+      const prev = st.hibikiUpdateStale;
+      if (!prev || prev.remote !== remote || prev.local !== local) {
+        await chrome.storage.local.set({ hibikiUpdateStale: decision.stale });
+      }
+      refreshUpdateBadge();
+      return;
+    }
+    if (decision.action !== 'reload') return;
     // BUG-1047：置重注入标记，reload 后新 SW 据此把 content script 补回已打开网页
     // （chrome.runtime.reload() 会让所有已注入页的 content script 上下文失效 → 不补的话
     // 用户必须手动刷新浏览器才恢复）。
@@ -90,6 +120,19 @@ async function maybeSelfReload(data) {
     });
     chrome.runtime.reload();
   } catch (_) { /* 自更新失败不影响查词本身 */ }
+}
+
+// BUG-1079：自更新失效角标。stale 存在且**不在录制**时在扩展图标打「↑」提醒；录制角标
+// 优先（红点 ● 绝不被盖掉——录制中本函数整个跳过，录制结束由 setRecordingBadge(false)
+// 回调这里恢复）。只动 badge，不动 title（title 归录制状态机管）。
+async function refreshUpdateBadge() {
+  try {
+    if (await isOffscreenRecording()) return; // 录制角标优先
+    const st = await chrome.storage.local.get(['hibikiUpdateStale']);
+    const stale = !!st.hibikiUpdateStale;
+    chrome.action.setBadgeBackgroundColor({ color: stale ? '#F9A825' : '#00000000' });
+    chrome.action.setBadgeText({ text: stale ? '↑' : '' });
+  } catch (_) { /* badge 在某些上下文不可用：忽略 */ }
 }
 
 // BUG-1047：自更新 chrome.runtime.reload() 会让所有已打开标签页里注入的 content script
@@ -144,10 +187,12 @@ async function maybeReinjectAfterReload() {
 async function checkVersionOnStartup() {
   try {
     const { base, token } = await cfg();
+    // BUG-1079：请求体自报 build/version（不再写死 '{}'），app 端据此显示「浏览器中
+    // 实际加载的版本」并在与内置指纹不一致时给出更新提示。
     const r = await fetch(base + '/api/extension/status', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: authHeader(token) },
-      body: '{}',
+      body: statusRequestBody(),
     });
     if (!r.ok) return;
     const status = await responseJson(r);
@@ -199,6 +244,8 @@ function setRecordingBadge(on) {
           : 'Hibiki：点击生成 Netflix 制卡队列（逐集自动回放录制）',
     });
   } catch (_) { /* setBadge 在某些上下文不可用：忽略，不影响录制 */ }
+  // BUG-1079：录制角标撤下后恢复自更新失效角标（若 stale 仍在）。录制中绝不动录制红点。
+  if (!on) refreshUpdateBadge();
 }
 
 // 录制真相源是 **offscreen 文档**（它持有 MediaStream，跨整场持续录），不是这个易失的

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -1032,6 +1032,14 @@ function hibikiEnsureContainer() {
     shadow.appendChild(c);
     hibikiContainer = c;
     window.__hibikiRoot = shadow; // popup.js 的 DOM 查询/浮层/选区都相对它解析
+    // BUG-1078：弹窗滚轮监听懒装——popup.js 在扩展上下文里不再常驻 document（常驻的
+    // 非 passive wheel 监听会让浏览器在所有网页放弃合成器快速滚动路径），而是把监听
+    // 暴露为 window.__hibikiPopupWheelListener，由这里在弹窗 host 创建时挂到 shadow
+    // host 上（非 passive 只影响弹窗内滚轮），hibikiRemoveContainer 销毁时卸载。
+    if (typeof window.__hibikiPopupWheelListener === 'function') {
+      hibikiHost.addEventListener('wheel', window.__hibikiPopupWheelListener,
+          { passive: false });
+    }
   }
   if (hibikiHost.parentNode !== parent) parent.appendChild(hibikiHost); // 进/出全屏迁父节点
   return hibikiContainer;
@@ -1152,6 +1160,12 @@ function hibikiRemoveContainer() {
   // ease-out 对齐）。pointer-events:none 避免淡出期误吞点击；transitionend 用 setTimeout
   // 兜底（reduced-motion / 离屏也能移除）。高亮/选区已在上面即时清，不随淡出延迟残留。
   if (dying) {
+    // BUG-1078：随弹窗卸载滚轮监听（挂载见 hibikiEnsureContainer）。节点淡出期间
+    // pointer-events:none 已让事件不再命中它，这里显式卸载把契约钉死：弹窗不在场 ⇒
+    // 页面上不存在任何非 passive wheel 监听。
+    if (typeof window.__hibikiPopupWheelListener === 'function') {
+      dying.removeEventListener('wheel', window.__hibikiPopupWheelListener);
+    }
     dying.style.pointerEvents = 'none';
     dying.style.opacity = '0';
     let dropped = false;

--- a/tools/browser-extension/popup-wheel-lazy.test.js
+++ b/tools/browser-extension/popup-wheel-lazy.test.js
@@ -1,0 +1,200 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+// BUG-1078 回归守卫：扩展 content script 曾在**所有网页**常驻一个非 passive 的
+// document wheel 监听（popup.js 顶层 addEventListener('wheel', …, {passive:false})）。
+// 非 passive wheel 监听一旦存在，浏览器就放弃合成器快速滚动路径，宿主页每次滚轮都要
+// 同步等主线程跑完监听（含祖先 getComputedStyle/scrollHeight 布局读取）——用户感知为
+// 装了扩展后网页滚动变卡。根因修复：
+//   - popup.js 在扩展上下文（chrome.runtime.id 存在）不再挂 document，改为把监听暴露成
+//     window.__hibikiPopupWheelListener；
+//   - content.js 在弹窗 shadow host 创建时（hibikiEnsureContainer）把它挂到 host 上
+//     （非 passive 只影响弹窗内滚轮），hibikiRemoveContainer 销毁时卸载；
+//   - 弹窗不在场 ⇒ 宿主页上没有任何 wheel 监听，原生滚动零开销。
+// 本测试在受控 vm 里按 manifest 顺序真加载 vendor/popup.js + content.js，驱动真实的
+// hibikiEnsureContainer / hibikiRemoveContainer，断言上述生命周期与弹窗内滚动行为。
+
+const POPUP = path.join(__dirname, 'vendor', 'popup.js');
+const CONTENT = path.join(__dirname, 'content.js');
+
+function fakeEl(tag) {
+  const listeners = Object.create(null);
+  const el = {
+    tagName: String(tag || 'div').toUpperCase(),
+    nodeType: 1,
+    style: {},
+    dataset: {},
+    children: [],
+    parentNode: null,
+    parentElement: null,
+    classList: { add() {}, remove() {}, contains() { return false; } },
+    listeners,
+    scrollByCalls: [],
+    addEventListener(type, fn, options) {
+      (listeners[type] = listeners[type] || []).push({ fn, options });
+    },
+    removeEventListener(type, fn) {
+      const l = listeners[type];
+      if (!l) return;
+      const i = l.findIndex((r) => r.fn === fn);
+      if (i >= 0) l.splice(i, 1);
+    },
+    appendChild(c) { c.parentNode = el; el.children.push(c); return c; },
+    setAttribute() {},
+    getAttribute() { return null; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    remove() { el.parentNode = null; },
+    getBoundingClientRect() { return { left: 0, top: 0, width: 100, height: 100 }; },
+    scrollBy(arg) { el.scrollByCalls.push(arg); },
+    attachShadow() {
+      const shadow = fakeEl('#shadow-root');
+      shadow.host = el;
+      el.shadowRoot = shadow;
+      shadow.getSelection =
+          () => ({ toString() { return ''; }, removeAllRanges() {} });
+      return shadow;
+    },
+  };
+  return el;
+}
+
+// 加载真 popup.js + 真 content.js（manifest 里 popup.js 先于 content.js），返回可
+// 驱动的世界：document wheel 注册记录、window 桩、content.js 的容器函数等。
+function loadWorld() {
+  const docWheelRegs = [];
+  const body = fakeEl('body');
+  const documentObj = {
+    documentElement: { style: {}, dataset: {}, setAttribute() {} },
+    body,
+    fullscreenElement: null,
+    addEventListener(type, handler, options) {
+      if (type === 'wheel') docWheelRegs.push({ handler, options });
+    },
+    createElement(tag) { return fakeEl(tag); },
+    createTextNode(t) { return { nodeType: 3, textContent: String(t) }; },
+    getElementById() { return null; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+  };
+  const windowScrollBy = [];
+  const windowObj = {
+    innerWidth: 1200,
+    innerHeight: 800,
+    addEventListener() {},
+    scrollBy(arg) { windowScrollBy.push(arg); },
+    getSelection() { return { toString() { return ''; }, removeAllRanges() {} }; },
+    getComputedStyle() { return { overflowY: 'visible', fontSize: '15px' }; },
+  };
+  windowObj.window = windowObj;
+
+  const sandbox = {
+    console: { log() {}, warn() {}, error() {} },
+    URL,
+    Node: { TEXT_NODE: 3, ELEMENT_NODE: 1 },
+    location: {
+      hostname: 'example.com',
+      href: 'https://example.com/page',
+      pathname: '/page',
+    },
+    performance: { now() { return 1000; } },
+    setTimeout() { return 0; },
+    clearTimeout() {},
+    requestAnimationFrame() { return 0; },
+    DOMParser: class {
+      parseFromString() { return { body: {}, querySelectorAll() { return []; } }; }
+    },
+    Image: class { addEventListener() {} set src(_v) {} },
+    document: documentObj,
+    window: windowObj,
+    getComputedStyle() { return { overflowY: 'visible', fontSize: '15px' }; },
+    chrome: {
+      runtime: {
+        id: 'test-ext-id',
+        lastError: null,
+        getURL: (p) => 'chrome-extension://test-ext-id/' + p,
+        onMessage: { addListener() {} },
+        sendMessage(_msg, cb) { if (cb) cb({}); },
+      },
+      storage: {
+        local: { get: async () => ({}), set: async () => {} },
+        onChanged: { addListener() {} },
+      },
+    },
+  };
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(POPUP, 'utf8'), sandbox,
+      { filename: 'popup.js' });
+  vm.runInContext(fs.readFileSync(CONTENT, 'utf8'), sandbox,
+      { filename: 'content.js' });
+  return { sandbox, documentObj, windowObj, docWheelRegs, windowScrollBy };
+}
+
+function wheelListenersOf(el) {
+  return (el.listeners && el.listeners.wheel) || [];
+}
+
+test('扩展上下文加载后 document 上没有任何 wheel 监听，监听以全局暴露待懒装', () => {
+  const { docWheelRegs, windowObj } = loadWorld();
+  assert.strictEqual(docWheelRegs.length, 0,
+      '扩展 content script 不得在 document 上常驻 wheel 监听（BUG-1078 根因）');
+  assert.strictEqual(typeof windowObj.__hibikiPopupWheelListener, 'function',
+      'popup.js 必须暴露 window.__hibikiPopupWheelListener 供 content.js 懒装');
+});
+
+test('hibikiEnsureContainer 把非 passive wheel 监听挂到 shadow host，且复用不重复挂', () => {
+  const { sandbox, windowObj } = loadWorld();
+  sandbox.hibikiEnsureContainer();
+  const host = windowObj.__hibikiRoot && windowObj.__hibikiRoot.host;
+  assert.ok(host, 'hibikiEnsureContainer 必须建出 shadow host');
+  const regs = wheelListenersOf(host);
+  assert.strictEqual(regs.length, 1, 'host 上必须恰好挂一个 wheel 监听');
+  assert.strictEqual(regs[0].fn, windowObj.__hibikiPopupWheelListener,
+      '挂的必须是 popup.js 暴露的同一个监听');
+  assert.ok(regs[0].options && regs[0].options.passive === false,
+      '弹窗滚轮监听必须 {passive:false}（它要 preventDefault 接管弹窗滚动）');
+  // 弹窗打开期间再次 ensure（host 复用路径）不得重复挂监听。
+  sandbox.hibikiEnsureContainer();
+  assert.strictEqual(wheelListenersOf(host).length, 1,
+      'host 复用路径不得重复挂 wheel 监听');
+});
+
+test('弹窗内滚轮行为不变：preventDefault + 滚 shadow host，不碰 window', () => {
+  const { sandbox, windowObj, windowScrollBy } = loadWorld();
+  sandbox.hibikiEnsureContainer();
+  const host = windowObj.__hibikiRoot.host;
+  const inner = { nodeType: 1, parentElement: null };
+  let prevented = false;
+  const evt = {
+    ctrlKey: false,
+    deltaY: 100,
+    deltaX: 0,
+    deltaMode: 0,
+    target: inner,
+    composedPath() { return [inner, host]; },
+    preventDefault() { prevented = true; },
+  };
+  for (const r of wheelListenersOf(host)) r.fn(evt);
+  assert.strictEqual(prevented, true, '弹窗内滚轮必须 preventDefault（接管滚动）');
+  assert.strictEqual(host.scrollByCalls.length, 1, '弹窗内滚轮必须滚 shadow host');
+  const step = host.scrollByCalls[0].top;
+  assert.ok(step > 0 && step <= 120,
+      '滚动步长必须是缩放/钳制后的值，got ' + step);
+  assert.strictEqual(windowScrollBy.length, 0, '弹窗内滚轮不得滚宿主页 window');
+});
+
+test('hibikiRemoveContainer 随弹窗卸载 wheel 监听', () => {
+  const { sandbox, windowObj } = loadWorld();
+  sandbox.hibikiEnsureContainer();
+  const host = windowObj.__hibikiRoot.host;
+  assert.strictEqual(wheelListenersOf(host).length, 1);
+  sandbox.hibikiRemoveContainer();
+  assert.strictEqual(wheelListenersOf(host).length, 0,
+      '关弹窗必须卸载 host 上的 wheel 监听（弹窗不在场 ⇒ 页面零 wheel 监听）');
+  assert.strictEqual(windowObj.__hibikiRoot, null,
+      '关弹窗必须清 __hibikiRoot');
+});

--- a/tools/browser-extension/self-update.js
+++ b/tools/browser-extension/self-update.js
@@ -1,0 +1,49 @@
+// BUG-1079：扩展自更新状态机（纯函数，node 可测）。
+// 背景：background.js 的自更新此前用「对某 remote build reload 过一次就永不重试」的 latch
+// 防死循环，但 reload 失败（磁盘副本没刷成 / 用户从别的目录加载 / 浏览器拒绝 reload）后
+// 会永久停在旧版且零提示。这里把决策抽成纯函数：
+// - 同一 remote build 仍只 reload 一次（防无限 reload 循环不变）；
+// - 已 reload 过仍不一致 → 判定自更新失效（stale），由调用方落 chrome.storage 提示用户；
+// - 恢复一致 → clear，由调用方清除 stale 提示。
+(function (root, factory) {
+  var api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.HIBIKI_SELF_UPDATE = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  var actions = Object.freeze({
+    none: 'none',       // 任一侧缺指纹 / 录制中：什么都不做（向后兼容，绝不空转）
+    reload: 'reload',   // 首次发现新 build：chrome.runtime.reload() 从磁盘拉新
+    stale: 'stale',     // 已为该 build reload 过仍不一致：自更新失效，提示用户手动重载
+    clear: 'clear',     // 两侧一致：清除 stale 提示（自更新已生效 / 用户已手动重载）
+  });
+
+  // remote = server 下发的内置指纹（extensionBuild）；local = 当前加载副本的
+  // HIBIKI_DEFAULTS.build；reloadedFor = storage 里记录的「已为哪个 build reload 过」；
+  // recording = 正在逐句回放录制（reload 会杀 offscreen 录制，跳过本轮）。
+  function decide(remote, local, reloadedFor, recording) {
+    if (!remote || !local) return { action: actions.none };
+    if (remote === local) return { action: actions.clear };
+    if (recording) return { action: actions.none };
+    if (reloadedFor === remote) {
+      return { action: actions.stale, stale: { remote: remote, local: local } };
+    }
+    return { action: actions.reload };
+  }
+
+  // BUG-1079：/api/extension/status 请求体——扩展自报「浏览器中实际加载的版本」。
+  // 此前写死 '{}'，app 端无从得知浏览器里跑的是哪个 build。旧 app 忽略 body，向后兼容。
+  function statusRequestBody(defaults, manifestVersion) {
+    var body = {};
+    if (defaults && typeof defaults.build === 'string' && defaults.build) {
+      body.build = defaults.build;
+    }
+    if (typeof manifestVersion === 'string' && manifestVersion) {
+      body.version = manifestVersion;
+    }
+    return JSON.stringify(body);
+  }
+
+  return { actions: actions, decide: decide, statusRequestBody: statusRequestBody };
+});

--- a/tools/browser-extension/self-update.test.js
+++ b/tools/browser-extension/self-update.test.js
@@ -1,0 +1,114 @@
+// BUG-1079：扩展自更新状态机测试。旧实现「对某 remote build reload 过一次就永不重试」
+// 导致自更新失败（磁盘副本没刷成 / 用户从别的目录加载 / 浏览器拒绝 reload）后永久停在
+// 旧版且零提示。新状态机：同一 build 仍只 reload 一次，但每次心跳重新比对；已 reload
+// 过仍不一致 → stale（提示用户手动重载）；恢复一致 → clear（清提示）。
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const selfUpdate = require('./self-update.js');
+const popup = require('./vendor/action-popup.js');
+
+// ── 状态机 decide ──
+
+test('首次发现新 build：reload（从磁盘拉新）', () => {
+  assert.deepEqual(selfUpdate.decide('new1', 'old1', undefined, false), {
+    action: 'reload',
+  });
+});
+
+test('同一 remote build 只 reload 一次：已 reload 过仍不一致 → stale（不再 reload）', () => {
+  const d = selfUpdate.decide('new1', 'old1', 'new1', false);
+  assert.equal(d.action, 'stale');
+  assert.deepEqual(d.stale, { remote: 'new1', local: 'old1' });
+});
+
+test('又出现更新的 build：latch 是对 build 而非永久 → 允许再 reload', () => {
+  assert.equal(selfUpdate.decide('new2', 'old1', 'new1', false).action, 'reload');
+});
+
+test('恢复一致 → clear（清除 stale 提示）', () => {
+  assert.equal(selfUpdate.decide('b1', 'b1', 'b1', false).action, 'clear');
+  assert.equal(selfUpdate.decide('b1', 'b1', undefined, false).action, 'clear');
+});
+
+test('任一侧缺指纹（旧 app / 占位默认）→ none（向后兼容，绝不空转）', () => {
+  assert.equal(selfUpdate.decide(undefined, 'old1', undefined, false).action, 'none');
+  assert.equal(selfUpdate.decide('new1', undefined, undefined, false).action, 'none');
+  assert.equal(selfUpdate.decide('', '', undefined, false).action, 'none');
+});
+
+test('正在录制 → none（reload 会杀 offscreen 录制；也不落 stale 打扰）', () => {
+  assert.equal(selfUpdate.decide('new1', 'old1', undefined, true).action, 'none');
+  assert.equal(selfUpdate.decide('new1', 'old1', 'new1', true).action, 'none');
+});
+
+// ── 状态请求体自报版本 ──
+
+test('statusRequestBody 带上自身 build + manifest version', () => {
+  const body = JSON.parse(
+      selfUpdate.statusRequestBody({ build: 'abcd1234' }, '1.2.3'));
+  assert.deepEqual(body, { build: 'abcd1234', version: '1.2.3' });
+});
+
+test('statusRequestBody 缺指纹时省略字段（占位默认 → 等同旧 \'{}\' 行为）', () => {
+  assert.equal(selfUpdate.statusRequestBody({}, ''), '{}');
+  assert.equal(selfUpdate.statusRequestBody(null, undefined), '{}');
+});
+
+// ── action-popup 提示文案 ──
+
+test('stale 存在 → 提示指向 chrome://extensions 并带两侧 build 简写', () => {
+  const notice = popup.hibikiUpdateNotice({ remote: 'aaaabbbbcccc', local: 'ddddeeeeffff' });
+  assert.ok(notice.title.includes('新版本'));
+  assert.ok(notice.detail.includes('chrome://extensions'));
+  assert.ok(notice.detail.includes('aaaabbbb'));
+  assert.ok(notice.detail.includes('ddddeeee'));
+});
+
+test('无 stale → null（提示行隐藏）', () => {
+  assert.equal(popup.hibikiUpdateNotice(null), null);
+  assert.equal(popup.hibikiUpdateNotice({}), null);
+});
+
+// ── background.js 接线（源码断言，同 connection-reopen.test.js 风格）──
+
+const bg = fs.readFileSync(path.join(__dirname, 'background.js'), 'utf8');
+
+test('background 经 importScripts 装载 self-update 状态机并用它决策', () => {
+  assert.match(bg, /importScripts\('hibiki-defaults\.js', 'connection-diagnostics\.js', 'self-update\.js'\)/);
+  assert.match(bg, /HIBIKI_SELF_UPDATE\.decide\(/);
+});
+
+test('background 状态请求不再写死 {}：心跳/启动检查与连接诊断都自报版本', () => {
+  assert.match(bg, /HIBIKI_SELF_UPDATE\.statusRequestBody\(/);
+  // /api/extension/status 的两处 fetch 都用 statusRequestBody()。
+  const statusFetches = bg.split("'/api/extension/status'").length - 1;
+  const reportingBodies = bg.split('body: statusRequestBody(),').length - 1;
+  assert.ok(statusFetches >= 2, 'expect at least two status fetch sites');
+  assert.equal(reportingBodies, statusFetches);
+});
+
+test('background stale 落盘 hibikiUpdateStale、恢复一致时清除', () => {
+  assert.match(bg, /chrome\.storage\.local\.set\(\{ hibikiUpdateStale: decision\.stale \}\)/);
+  assert.match(bg, /chrome\.storage\.local\.remove\(\['hibikiUpdateStale'\]\)/);
+});
+
+test('自更新角标让位录制角标：录制中跳过、录制结束恢复', () => {
+  // refreshUpdateBadge 先查录制真态，录制中不动 badge（录制红点优先）。
+  const fn = bg.indexOf('async function refreshUpdateBadge()');
+  assert.ok(fn >= 0);
+  const body = bg.slice(fn, fn + 600);
+  assert.match(body, /if \(await isOffscreenRecording\(\)\) return;/);
+  // 录制角标撤下（setRecordingBadge(false)）后恢复自更新角标。
+  assert.match(bg, /if \(!on\) refreshUpdateBadge\(\);/);
+});
+
+test('action-popup 渲染 stale 提示并随 storage 实时显隐', () => {
+  const js = fs.readFileSync(path.join(__dirname, 'vendor', 'action-popup.js'), 'utf8');
+  const html = fs.readFileSync(path.join(__dirname, 'vendor', 'action-popup.html'), 'utf8');
+  assert.match(html, /id="hp-update"/);
+  assert.match(js, /chrome\.storage\.local\.get\(\['hibikiUpdateStale'\]/);
+  assert.match(js, /changes\.hibikiUpdateStale/);
+});

--- a/tools/browser-extension/vendor/action-popup.html
+++ b/tools/browser-extension/vendor/action-popup.html
@@ -122,6 +122,16 @@
     .hp-connection-detail { display: block; overflow: hidden; margin-top: 1px; opacity: .55; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
     .hp-settings-link { border: 0; padding: 4px; color: inherit; background: transparent; cursor: pointer; opacity: .72; }
     .hp-settings-link:hover { opacity: 1; }
+    /* BUG-1079：自更新失效提示（hibikiUpdateStale 存在时显示）：需到扩展管理页手动重新加载。 */
+    .hp-update {
+      margin: 0 14px 10px;
+      padding: 9px 10px;
+      border: 1px solid rgba(212, 154, 66, 0.55);
+      border-radius: 8px;
+      background: rgba(212, 154, 66, 0.12);
+    }
+    .hp-update-title { display: block; font-size: 12px; font-weight: 600; }
+    .hp-update-detail { display: block; margin-top: 1px; opacity: .7; font-size: 10px; line-height: 1.5; }
     /* TODO-1219：网飞字幕列表面板开关（扩展弹窗入口，方案 B）。独立页脚区，不属于上方 1270 制卡队列。 */
     .hp-settings { border-top: 1px solid rgba(128, 128, 128, 0.22); padding: 10px 14px 12px; }
     .hp-toggle { display: flex; align-items: center; gap: 8px; cursor: pointer; }
@@ -142,6 +152,11 @@
       <span class="hp-connection-detail" id="hp-connection-detail">查词与字幕服务</span>
     </span>
     <button class="hp-settings-link" id="hp-open-options" type="button" title="打开扩展设置" aria-label="打开扩展设置">⚙</button>
+  </div>
+  <!-- BUG-1079：自更新失效提示（默认隐藏；chrome.storage.local.hibikiUpdateStale 存在时显示）。 -->
+  <div class="hp-update" id="hp-update" hidden>
+    <span class="hp-update-title" id="hp-update-title"></span>
+    <span class="hp-update-detail" id="hp-update-detail"></span>
   </div>
   <button class="hp-gen" id="hp-gen" type="button">开始生成 / 录制</button>
   <!-- TODO-1881：按钮不可用/跨站点剩余量的原因提示（状态机 hint，空则隐藏）。 -->

--- a/tools/browser-extension/vendor/action-popup.js
+++ b/tools/browser-extension/vendor/action-popup.js
@@ -104,11 +104,24 @@ function hibikiGenButtonState(queue, batchActive, tabSite) {
   };
 }
 
+// BUG-1079：自更新失效提示文案（纯函数供 node 测试）。stale = background 写入
+// chrome.storage.local.hibikiUpdateStale 的 {remote, local}（remote=app 内置最新指纹，
+// local=浏览器中实际加载副本的指纹）。无 stale（或缺 remote）返回 null（隐藏提示行）。
+function hibikiUpdateNotice(stale) {
+  if (!stale || !stale.remote) return null;
+  const short = (s) => String(s || '').slice(0, 8);
+  return {
+    title: '扩展有新版本，需手动重新加载',
+    detail: '自动更新未生效：请到 chrome://extensions 找到本扩展点「重新加载」'
+        + '（当前 ' + (short(stale.local) || '未知') + ' → 最新 ' + short(stale.remote) + '）',
+  };
+}
+
 // node 单测导出（浏览器里 module 未定义，直接跳过）。
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     hibikiFilterQueue, hibikiQueueItemLabel, hibikiQueueItemContext, hibikiReadPanelEnabled,
-    hibikiQueueItemUrl, hibikiTabSite, hibikiGenButtonState,
+    hibikiQueueItemUrl, hibikiTabSite, hibikiGenButtonState, hibikiUpdateNotice,
   };
 }
 
@@ -143,6 +156,33 @@ if (typeof document !== 'undefined' && typeof chrome !== 'undefined' && chrome.s
   }
   refreshConnection();
   if (connEl) connEl.addEventListener('click', () => refreshConnection());
+
+  // BUG-1079：自更新失效提示行。background 检测到「已 reload 过仍与 app 内置指纹不一致」
+  // 时写 hibikiUpdateStale；这里渲染「需到 chrome://extensions 手动重新加载」并随 storage
+  // 变化实时显隐（恢复一致时 background 清除该键 → 提示消失）。
+  const updateEl = document.getElementById('hp-update');
+  const updateTitleEl = document.getElementById('hp-update-title');
+  const updateDetailEl = document.getElementById('hp-update-detail');
+  function renderUpdateNotice(stale) {
+    if (!updateEl) return;
+    const notice = hibikiUpdateNotice(stale);
+    updateEl.hidden = !notice;
+    if (!notice) return;
+    if (updateTitleEl) updateTitleEl.textContent = notice.title;
+    if (updateDetailEl) updateDetailEl.textContent = notice.detail;
+  }
+  try {
+    chrome.storage.local.get(['hibikiUpdateStale'], (r) => {
+      renderUpdateNotice(r && r.hibikiUpdateStale);
+    });
+  } catch (_) {}
+  try {
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area === 'local' && changes.hibikiUpdateStale) {
+        renderUpdateNotice(changes.hibikiUpdateStale.newValue);
+      }
+    });
+  } catch (_) {}
   const optionsEl = document.getElementById('hp-open-options');
   if (optionsEl) {
     optionsEl.addEventListener('click', (e) => {

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -7,7 +7,12 @@ function __hibikiContainer(){ var r = window.__hibikiRoot; return r ? r.querySel
 function __hibikiOverlayParent(){ return window.__hibikiRoot || document.body; }
 function __hibikiScrollHeight(){ var c = __hibikiContainer(); return c ? c.scrollHeight : document.body.scrollHeight; }
 function __hibikiSel(){ var r = window.__hibikiRoot; try { return (r && r.getSelection) ? r.getSelection() : window.getSelection(); } catch(_){ return window.getSelection(); } }
-function __hibikiEventTarget(e){ try { var p = e.composedPath && e.composedPath(); if (p && p.length) return p[0]; } catch(_){} return e.target; }
+/* BUG-1078: composedPath() allocates a fresh array on every call and the wheel
+   handler used to call it at least twice per event (__hibikiEventTarget +
+   __hibikiWheelScroller). Cache the path on the event object for the duration of
+   its dispatch so every helper shares ONE composedPath() result. */
+function __hibikiComposedPath(e){ if (e.__hibikiPathCache !== undefined) return e.__hibikiPathCache; var p = null; try { p = (e.composedPath && e.composedPath()) || null; } catch(_){ p = null; } try { e.__hibikiPathCache = p; } catch(_){} return p; }
+function __hibikiEventTarget(e){ var p = __hibikiComposedPath(e); if (p && p.length) return p[0]; return e.target; }
 /* BUG-688: the extension floating popup scrolls on the SHADOW HOST
    (#hibiki-popup-host has overflow-y:auto + max-height; #entries-container is
    neutralized to overflow:visible inside the shadow), while the in-app popup
@@ -20,7 +25,7 @@ function __hibikiShadowHost(){ var r = window.__hibikiRoot; return (r && r.host)
 function __hibikiWheelScroller(e){
     var host = __hibikiShadowHost();
     if (!host) return null;
-    try { var p = e.composedPath && e.composedPath(); if (p && p.indexOf(host) !== -1) return host; } catch(_){}
+    try { var p = __hibikiComposedPath(e); if (p && p.indexOf(host) !== -1) return host; } catch(_){}
     return null;
 }
 
@@ -4039,21 +4044,38 @@ function popupEntryWheelAction(e) {
     if (matches(cfg.prev)) return 'prev';
     return null;
 }
-document.addEventListener('wheel', (e) => {
+/* BUG-1078: this listener is non-passive by necessity (it preventDefault()s to
+   re-implement popup scrolling), but a RESIDENT non-passive document wheel
+   listener forces the browser off the compositor fast-scroll path on every page
+   the extension content script touches. Two-part fix:
+   - in-app popup WebView (no chrome.runtime): the document IS the popup — keep
+     the resident document listener exactly as before (BUG-1026 wheel speed,
+     BUG-1065 DPR parity and the Alt+wheel entry navigation all live here);
+   - extension content script: never attach to document. The handler is exposed
+     as window.__hibikiPopupWheelListener and content.js mounts it on the popup
+     shadow host ({passive:false}) when the popup is created, unmounting it in
+     hibikiRemoveContainer — host pages carry ZERO non-passive wheel listeners
+     while no popup is open. */
+const __hibikiPopupWheelListener = (e) => {
+    // BUG-1078 前置早退：先用最廉价的判定（一次 composedPath + indexOf）解析滚轮
+    // 表面。扩展 content script 里滚轮不在弹窗 shadow 内 ⇒ 与弹窗无关，立即放行
+    // 原生滚动——昂贵的祖先 getComputedStyle/scrollHeight 遍历和词条导航判定都不再
+    // 为宿主页滚轮买单。（BUG-732 的放行守卫从 preventDefault 前挪到最前；挂载本身
+    // 已随 BUG-1078 懒装到 shadow host，此守卫是纵深防御 + in-app/扩展共用判据。）
+    const scroller = __hibikiWheelScroller(e);
+    const inExtensionContentScript =
+        typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
+    if (!scroller && inExtensionContentScript) return;
     // 词条导航先于一切滚动处理判定（否则 ctrlKey 早退会吃掉 Ctrl 系绑定）。只有
     // 焦点真的移动了（返回 'moved'）才吞掉事件：单词条 / 已到首尾时返回 'blocked'，
-    // 这一帧继续走下面的正常滚动，弹窗不会「按住 Alt 就滚不动」。
-    // 作用域判据与下面的滚动接管同源：扩展里滚轮必须真的落在弹窗 shadow 内
-    // （__hibikiWheelScroller 非空），in-app 整份文档就是弹窗故允许 null。
+    // 这一帧继续走下面的正常滚动，弹窗不会「按住 Alt 就滚不动」。作用域判据由上面
+    // 的前置早退保证：走到这里的滚轮要么在弹窗 shadow 内（扩展），要么整份文档就是
+    // 弹窗（in-app）。
     const entryAction = popupEntryWheelAction(e);
     if (entryAction && typeof window.hoshiFocusDictionaryEntryMove === 'function') {
-        const inExtensionHost =
-            typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
-        if (__hibikiWheelScroller(e) || !inExtensionHost) {
-            if (window.hoshiFocusDictionaryEntryMove(entryAction) === 'moved') {
-                e.preventDefault();
-                return;
-            }
+        if (window.hoshiFocusDictionaryEntryMove(entryAction) === 'moved') {
+            e.preventDefault();
+            return;
         }
     }
     // Ignore zoom gestures (ctrl+wheel / pinch) and predominantly-horizontal wheels.
@@ -4072,14 +4094,11 @@ document.addEventListener('wheel', (e) => {
     if (deltaPx === 0) return;
     if (popupAncestorAbsorbsVerticalWheel(__hibikiEventTarget(e), deltaPx)) return;
     // BUG-732: 这段缩放平滑滚动只服务查词弹窗。扩展里弹窗是宿主页上的 shadow 覆盖层，
-    // __hibikiWheelScroller 仅当滚轮 composedPath 穿过弹窗 shadow 才返回 host；返回 null
-    // 时唯一合法「滚 window」的表面是 in-app 弹窗文档（整份文档即弹窗，且无 chrome.runtime）。
-    // 普通网页上扩展 content script 有 chrome.runtime.id，此时滚轮不在弹窗内绝不能接管：
-    // 否则整页被 POPUP_WHEEL_PIXEL_FACTOR(0.24) 降速 + preventDefault 抢走原生滚动。
-    const scroller = __hibikiWheelScroller(e);
-    const inExtensionContentScript =
-        typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id);
-    if (!scroller && inExtensionContentScript) return;
+    // __hibikiWheelScroller 仅当滚轮 composedPath 穿过弹窗 shadow 才返回 host（scroller
+    // 已在本监听最顶部解析并早退）；返回 null 时唯一合法「滚 window」的表面是 in-app
+    // 弹窗文档（整份文档即弹窗，且无 chrome.runtime）。普通网页上扩展 content script 有
+    // chrome.runtime.id，滚轮不在弹窗内已在顶部放行原生滚动：否则整页会被
+    // POPUP_WHEEL_PIXEL_FACTOR(0.24) 降速 + preventDefault 抢走原生滚动。
     e.preventDefault();
     // TODO-1387: carry the sub-pixel remainder across events; BUG-870: also reset
     // the device-class latch here so each new gesture is classified fresh. A
@@ -4136,7 +4155,17 @@ document.addEventListener('wheel', (e) => {
     if (step === 0) return; // sub-pixel this frame — carried to the next event
     if (scroller) { scroller.scrollBy({ top: step, behavior: 'auto' }); }
     else { window.scrollBy({ top: step, behavior: 'auto' }); }
-}, { passive: false });
+};
+if (typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id)) {
+    // BUG-1078: 扩展 content script——绝不常驻 document。content.js 在弹窗 shadow host
+    // 创建时把这个监听挂上去（{passive:false} 只作用于弹窗内滚轮）、销毁时卸载；弹窗
+    // 不在场时宿主页 document 上没有任何非 passive wheel 监听，浏览器保留合成器快速
+    // 滚动路径。
+    window.__hibikiPopupWheelListener = __hibikiPopupWheelListener;
+} else {
+    // in-app 弹窗 WebView：整份文档就是弹窗，常驻 document 监听是正确行为（不变）。
+    document.addEventListener('wheel', __hibikiPopupWheelListener, { passive: false });
+}
 
 
 let _popupMouseDownPos = null;


### PR DESCRIPTION
用户报告三连：①「app 外嵌套查词时鼠标会卡一下（分不清画面卡还是鼠标卡）」②「插件好像会把浏览器滚动变慢」③「扩展更新应该有个提示」。三条都验真为实，各建一 bug 档案，根因修复 + 最强可落地层测试。

## BUG-1077 · 嵌套查词瞬间全局鼠标卡一下
BUG-1048 把 WH_MOUSE_LL 挪到专用线程后仍留两个残余机制，恰在嵌套瞬间叠加：
- 钩子线程默认 NORMAL 优先级——嵌套瞬间进程内 CPU 风暴（同步 FFI 词典查询 + 整栈 JSON 重序列化 + WebView2 同步 COM + SetWindowRgn 连击）把它抢占几十毫秒，LL 钩子是同步的 → 全系统鼠标卡一下。**修复：TIME_CRITICAL**（LL 钩子承载线程标准做法）。
- 面板/galgame 浮窗嵌套路径走 reset Hide→Reveal，每次嵌套 = 真卸+真装全局钩子各一次（桌面钩子链更新与 Raw Input 串行，各是一次全系统输入停顿）。**修复：Disarm 改宽限期延迟真卸**（清目标即纯放行，3s 内重 Arm 取消卸载；真正闲置照样卸，「不查词不留全局钩子」承诺不变），全部收敛在 `low_level_mouse_hook.{h,cpp}` 内部，不往 Dart 穿特例标志。
- 顺手修掉首次建线程在 platform 线程上的 Sleep(1) 自旋（默认定时器精度单次可睡 ~15ms）→ 事件等待。

测试：新守卫 `global_lookup_mouse_hook_stutter_guard_test.dart`（TIME_CRITICAL/宽限期/禁 Sleep 自旋），BUG-1048 既有守卫继续全绿。`flutter build windows --debug` 编译通过。

## BUG-1078 · 扩展非 passive wheel 常驻监听拖慢浏览器滚动
`vendor/popup.js` 经 content script 在**每个网页**常驻 `document` 级 `{passive:false}` wheel 监听，浏览器被迫放弃合成器快速滚动；且回调在「与弹窗无关」早退前先做昂贵祖先遍历（每祖先 getComputedStyle+布局读取）。
修复：扩展上下文监听**懒装到 shadow host**（弹窗创建才挂、移除即卸→弹窗不在场宿主页零 wheel 监听）；廉价早退前置；composedPath 单次复用。in-app 弹窗（无 chrome.runtime）行为逐字不变（BUG-1026 滚速/BUG-1065 DPR/PR#395 Alt 滚轮不受影响）。三镜像 popup.js + 两镜像 content.js 字节一致（守卫锁定）。
测试：新增 `popup-wheel-lazy.test.js` 4 例；BUG-732 守卫升级（扩展 document 零 wheel 监听 / in-app 恰一个 passive:false）；定向 flutter test 50 例全绿。

## BUG-1079 · 扩展自更新失败永久静默 + 无更新提示
扩展手动侧载，自更新靠比对 app 下发指纹后 `chrome.runtime.reload()`——但一旦记过标记就**永不重试且零提示**，自更新失效时用户永久停在旧版（正对用户体感）。
修复：新增 `self-update.js` 纯状态机（同一新版本只 reload 一次，仍不一致→落 stale→action popup 提示行+工具栏「↑」角标，录制红点优先；恢复一致自动清除）；心跳/启动检查自报 build+version（旧 '{}' body server 容错，行为不降级）；app 扩展页版本卡改双行「App 内置 / 浏览器中加载」，不一致显示主题色警示条。新增 3 个 i18n key 经 i18n_sync + slang。
测试：JS 状态机 15 例 + action-popup 4 例；Dart HTTP 层 6 例 + 双镜像/接线守卫；相邻既有测试全绿。

## 验证
- 全量 `flutter analyze`：No issues found
- 定向 flutter test 41 例 + node 扩展 JS 19 例 + bug732 JS：全绿
- `flutter build windows --debug`：成功（验 C++）
- 已知无关既有失败：`word-audio.test.js` 4 例（Node v24 差异，目标文件本轮未动）
- **待 Windows 真机复测**：嵌套查词鼠标观感、真实网页滚动手感、版本不一致提示链路
- BUG-1077 若真机仍余「画面卡」，档案备注已列后续项（词典查询移出 UI isolate / 渲染栈增量化 / SetWindowRgn 节流）

https://claude.ai/code/session_01U6AUxL7B51CgLc3N7MfbkY