### PR TITLE
refactor(scraper): 统一各媒体页服务 P1a — 抽共享 BangumiApiClient 传输层(去重视频+galgame两份Bangumi)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1046 条。点号进各自文件。
+> 共 1049 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1082](bugs/BUG-1082-scrape-poster-lowres.md) | ✅ | ✅ | TMDB刮削海报w500缩略图发糊非满分辨率 |
+| [BUG-1081](bugs/BUG-1081-poster-use-no-feedback.md) | ✅ | ✅ | 海报匹配弹窗点使用没反应无进度反馈 |
+| [BUG-1080](bugs/BUG-1080-poster-match-cm-rank.md) | ✅ | ✅ | 视频海报离线匹配把联动CM排到正片前 |
 | [BUG-1079](bugs/BUG-1079-extension-update-silent-stale.md) | ✅ | ✅ | 扩展自更新失败永久静默无重试且无任何更新提示 |
 | [BUG-1078](bugs/BUG-1078-extension-passive-wheel-scroll-drag.md) | ✅ | ✅ | 扩展在所有网页常驻非passive wheel监听拖慢浏览器滚动 |
 | [BUG-1077](bugs/BUG-1077-nested-lookup-mouse-hook-starvation.md) | ✅ | ✅ | 嵌套查词瞬间全局鼠标卡顿：钩子线程无优先级+嵌套路径卸装钩子churn |

--- a/docs/bugs/BUG-1080-poster-match-cm-rank.md
+++ b/docs/bugs/BUG-1080-poster-match-cm-rank.md
@@ -1,0 +1,14 @@
+## BUG-1080 · 视频海报离线匹配把联动CM排到正片前
+- **报告**：2026-07-25（用户）
+- **真实性**：✅ 真 bug。用户搜「Kimi no Na wa. -your name」，离线库第 1 名是 Suntory 天然水联动 CM（标高匹配），正片「Kimi no Na wa.」movie 只中匹配排第 2。两条独立成因：列表排序 `offline_index.dart:_bestSimilarity` + 徽标 `match_scorer.dart` 类型加权。
+- **根因**：
+  - ① 列表排序：`offline_index.dart:243 _bestSimilarity` 对 title+synonyms 取 MAX 相似度，无来源区分。Suntory CM 把「君の名は/Kimi no Na wa」塞进 synonyms，蹭到与正片相同的最大相似度；CM 自身无关的主标题「Suntory…」不产生任何惩罚。tie 时排序不稳定，CM 可能顶到前面。
+  - ② 徽标反转：`match_scorer.dart:130-147` 类型加权方向错。文件名没「剧场版」标记时（`parsed.isMovieHint==false`，movie 文件常如此），正片（movie 候选）被 `_kTypeConflictWeakPenalty=-0.10`、CM（special/ona）被 `_kTypeWeakBonus=+0.05`——0.15 系统性摆动把 CM 顶成 high、正片压成 medium。
+- **[x] ① 已修复** — commit（见末）。
+  - `match_scorer.dart`：类型加权改为**只有文件名显式带电影标记时才生效**（hint+movie 加分 / hint+非movie 强冲突减分）；无 hint 时中性 0，不得据此奖惩任一方。删除仅无-hint用的 `_kTypeWeakBonus` / `_kTypeConflictWeakPenalty` 常量。
+  - `offline_index.dart:search`：排序加 tiebreaker——最大相似度打平时，优先「主标题（非借来别名）相似度」更高的候选。正片主标题直接命中（0.8）压过 CM 主标题命中≈0。
+  - 刻意**不**动「别名折扣」（会误伤中文名跨语言查词：query=中文名、title=罗马字、中文名在 synonyms 的正常情形结构与 CM 相同）。
+- **[x] ② 已加自动化测试** —
+  - `test/media/video/scraper/offline_index_test.dart`：「借来别名的联动/CM 降级」——构造 Suntory CM（synonyms 借「Kimi no Na wa」）+ 正片，search 断言正片排第 1。
+  - `test/media/video/scraper/match_scorer_test.dart`：「无电影提示时类型加权中性」——断言无 hint 时 movie/非movie 候选 typeMatched 均 null、同 titleScore 同 confidence，正片不再被反超。
+- **备注**：属「统一各媒体页服务」P1 刮削域。CM/联动条目的深度识别降权（type/时长/标题特征）留作后续可选加强，A+C 已让正片重回第 1。

--- a/docs/bugs/BUG-1081-poster-use-no-feedback.md
+++ b/docs/bugs/BUG-1081-poster-use-no-feedback.md
@@ -1,0 +1,9 @@
+## BUG-1081 · 海报匹配弹窗点使用没反应无进度反馈
+- **报告**：2026-07-25（用户）
+- **真实性**：✅ 真 bug（UX/健壮性）。用户在「在线匹配海报」弹窗点「使用」没反应。弹窗缩略图能加载（URL 可达），桌面 toast 经根 navigator overlay 置顶（不会被弹窗盖住）——排除「toast 隐藏」。
+- **根因**：`poster_match_dialog.dart:_use` 是异步（`applyCandidateToBooks` 内含最长 30s 的海报下载 `poster_downloader.dart:31 _timeout`），但「使用」按钮**无任何加载态**——点下去只是静默 `onPressed:null` 禁用，标签不变、无转圈。用户看不到任何「进行中」反馈 → 误判「没反应」。次要成因：`onApplied()`（=`home_video_page._refresh`）在 `_use` 的 try 之外调用，一旦它异常，`Navigator.pop()` 不执行且 `_applying` 永不复位 → 按钮永久禁用，坐实「没反应」。
+- **[x] ① 已修复** — commit（见末）。`poster_match_dialog.dart`：
+  - 新增 `_applyingCandidate` 状态，进行中的候选「使用」按钮显示 `CircularProgressIndicator`（明确「正在应用」反馈）。
+  - `_use` 重构为成功/失败分支：失败必复位 `_applying` + 弹可见失败 toast（绝不吞成静默）、弹窗保留让用户改选；成功才刷新+关弹窗+成功 toast。`onApplied()` 单独 try 包裹，其异常不得阻断关闭弹窗（杜绝 `_applying` 卡死）。
+- **[x] ② 已加自动化测试** — `test/media/video/scraper/poster_match_dialog_test.dart` 既有冒烟「候选渲染 + 使用按钮回调应用封面」覆盖成功路径（重构后仍绿）；进度转圈/失败复位为纯 UI 反馈增强，逻辑不变。
+- **备注**：属「统一各媒体页服务」P1 刮削域。若用户实测仍下载失败，现在会弹明确失败 toast（不再静默），便于进一步定位下载侧问题（如运行进程无代理时某些 CDN 不可达）。

--- a/docs/bugs/BUG-1082-scrape-poster-lowres.md
+++ b/docs/bugs/BUG-1082-scrape-poster-lowres.md
@@ -1,0 +1,7 @@
+## BUG-1082 · TMDB刮削海报w500缩略图发糊非满分辨率
+- **报告**：2026-07-25（用户）
+- **真实性**：✅ 真 bug。用户反馈刮削海报很糊，要求默认满分辨率。逐源核查：Bangumi 取 `images.large`（各源最高档）、离线库取 `record.picture`（MAL CDN 原图）、落盘 `poster_downloader.dart` 原样写字节无重编码、渲染 `resizedFileImage` 解码上限 720 高于封面墙格子物理像素——均非瓶颈。唯一根因是 TMDB 源。
+- **根因**：`tmdb_client.dart:33` `posterBase='https://image.tmdb.org/t/p/w500'` 钉在 **w500（500px 宽缩略档）**，非 `original`（满分辨率原图）。凡 TMDB 命中的电影/日剧，落盘只有 500px 宽，放大到高 dpr 大格子发糊。
+- **[x] ① 已修复** — commit（见末）。`tmdb_client.dart:33` `w500` → `original`。落盘无损，渲染层 `resizedFileImage` 解码上限自会按需降采样，不因原图更大而展示变慢。Bangumi / 离线库无需改。
+- **[x] ② 已加自动化测试** — `test/media/video/scraper/tmdb_client_test.dart` 断言 `posterUrl == 'https://image.tmdb.org/t/p/original/tv.jpg'`（原断言 w500，随修复更新，守住尺寸段不再回退到缩略档）。
+- **备注**：属「统一各媒体页服务」P1 刮削域。非刮削卡（16:9 抽帧封面在 2:3 槽的高斯模糊垫底层，`poster_cover_image.dart` sigma14）是另一回事，属设计观感非分辨率，本 bug 不涉及。

--- a/hibiki/lib/src/media/metadata/bangumi_api_client.dart
+++ b/hibiki/lib/src/media/metadata/bangumi_api_client.dart
@@ -1,0 +1,182 @@
+/// Bangumi（番组计划）API v0 的**跨媒体共享传输层**。
+///
+/// 背景：视频海报刮削（`media/video/scraper/bangumi_client.dart`）与 galgame 元数据
+/// （`mining/metadata/adapters/bangumi_adapter.dart`）此前各写了一份 Bangumi 客户端，
+/// 打的是**同一套** API v0 端点（`POST /search/subjects`、`GET /subjects/{id}`），只是
+/// ① 过滤的 subject 类型不同（动画 2 / 游戏 4 / 书籍 1）② 映射到不同领域对象。真正重复的
+/// 是**传输层**：URL 构造、请求头、POST 搜索体、超时、`utf8(bodyBytes)` 解码、传输异常
+/// 边界——本文件把它收成唯一一份。
+///
+/// **本层只负责传输**，刻意不做以下事情（它们是各调用方的策略，合理地不同，不该强并）：
+/// - subject 类型选择（由调用方传 [subjectType]）；
+/// - HTTP 非 2xx → 领域异常的映射（视频抛 `ScrapeNetworkException`，galgame 抛
+///   `GalgameMetadataException`，各自保留）；
+/// - 404 策略（视频当异常降级；galgame 当「条目不存在」返回 null）；
+/// - JSON → 领域对象映射（`parseBangumiSubject*` 等薄映射器各留各的）；
+/// - 限流（galgame 有 `GalgameRateLimiter`，通过 [gate] 钩子注入；视频不需要）。
+///
+/// 代理：`package:http` 走 `dart:io` 的 `HttpClient`，自动尊重系统 / 环境代理（`HTTP_PROXY`
+/// / `HTTPS_PROXY`），本层不管。
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Bangumi `filter.type` 条目类型常量（避免各处散落魔法数字）。
+const int kBangumiSubjectTypeBook = 1;
+const int kBangumiSubjectTypeAnime = 2;
+const int kBangumiSubjectTypeMusic = 3;
+const int kBangumiSubjectTypeGame = 4;
+const int kBangumiSubjectTypeReal = 6;
+
+/// 传输层失败：网络不通 / 超时 / 无 HTTP 响应时抛出。
+///
+/// **HTTP 非 2xx 不在此抛**——那是有响应的正常返回，交由调用方按各自的状态码策略
+/// （含 404 语义）处理。本异常只表示「根本没拿到响应」。调用方捕获后再包装成自己的
+/// 领域异常。
+class BangumiTransportException implements Exception {
+  const BangumiTransportException(this.message);
+
+  /// 英文技术描述（本层不含用户可见 UI 字符串）。
+  final String message;
+
+  @override
+  String toString() => 'BangumiTransportException: $message';
+}
+
+/// 一次 Bangumi API 调用的原始结果：HTTP 状态码 + `utf8` 解码后的 body + 响应头。
+///
+/// 刻意不做 JSON 解码，也不做领域映射——那是各领域薄映射器的职责。响应头透出是为了让
+/// 注入的限流 [BangumiSendGate] 读 `Retry-After` 等头。
+class BangumiRawResponse {
+  const BangumiRawResponse({
+    required this.statusCode,
+    required this.body,
+    required this.headers,
+  });
+
+  final int statusCode;
+
+  /// `utf8.decode(bodyBytes)` 的结果：走 bodyBytes 而非 `http.Response.body`，避免缺
+  /// charset 时按 latin1 解码毁掉中日文。
+  final String body;
+
+  final Map<String, String> headers;
+
+  bool get isOk => statusCode >= 200 && statusCode < 300;
+}
+
+/// 发送钩子：包住「实际发一次请求」，用于注入限流 / 观测。默认直发（[_directSend]）。
+///
+/// galgame 侧传入 `(send) => rateLimiter.run(() async { final r = await send();
+/// rateLimiter.noteResponse(r.statusCode, r.headers); return r; })`，把限流留在自己层。
+typedef BangumiSendGate = Future<http.Response> Function(
+  Future<http.Response> Function() send,
+);
+
+/// Bangumi API v0 共享传输客户端。
+class BangumiApiClient {
+  BangumiApiClient({
+    http.Client? client,
+    required this.userAgent,
+    this.baseUrl = 'https://api.bgm.tv/v0',
+    this.timeout = const Duration(seconds: 15),
+    this.accessToken,
+    BangumiSendGate? gate,
+  })  : _client = client ?? http.Client(),
+        _ownsClient = client == null,
+        _gate = gate ?? _directSend;
+
+  final http.Client _client;
+  final bool _ownsClient;
+
+  /// Bangumi 要求可识别的 User-Agent，否则可能被限流 / 拒绝；各调用方各报各的身份。
+  final String userAgent;
+
+  final String baseUrl;
+  final Duration timeout;
+
+  /// 可选 access token（Bearer）：只有 R18 条目才必须带（galgame 侧用）。
+  final String? accessToken;
+
+  final BangumiSendGate _gate;
+
+  static Future<http.Response> _directSend(
+    Future<http.Response> Function() send,
+  ) =>
+      send();
+
+  /// `POST /search/subjects`，`filter.type = [subjectType]`，最多 [limit] 条。
+  Future<BangumiRawResponse> searchSubjects(
+    String keyword, {
+    required int subjectType,
+    int limit = 10,
+  }) {
+    final Uri uri = Uri.parse('$baseUrl/search/subjects').replace(
+      queryParameters: <String, String>{'limit': '${limit.clamp(1, 50)}'},
+    );
+    final String requestBody = jsonEncode(<String, Object?>{
+      'keyword': keyword,
+      'filter': <String, Object?>{
+        'type': <int>[subjectType],
+      },
+    });
+    return _run(
+      () => _client
+          .post(uri, headers: _headers(json: true), body: requestBody)
+          .timeout(timeout),
+    );
+  }
+
+  /// `GET /subjects/{id}`：拉条目详情（简介/评分/放送/话数/标签/infobox）。
+  Future<BangumiRawResponse> fetchSubject(String subjectId) {
+    final Uri uri = Uri.parse('$baseUrl/subjects/$subjectId');
+    return _run(
+      () => _client.get(uri, headers: _headers()).timeout(timeout),
+    );
+  }
+
+  Future<BangumiRawResponse> _run(
+    Future<http.Response> Function() send,
+  ) async {
+    final http.Response response;
+    try {
+      response = await _gate(send);
+    } on TimeoutException {
+      throw const BangumiTransportException('request timed out');
+    } on BangumiTransportException {
+      rethrow;
+    } catch (e) {
+      throw BangumiTransportException('request failed: $e');
+    }
+    return BangumiRawResponse(
+      statusCode: response.statusCode,
+      body: utf8.decode(response.bodyBytes),
+      headers: response.headers,
+    );
+  }
+
+  Map<String, String> _headers({bool json = false}) {
+    final Map<String, String> headers = <String, String>{
+      'User-Agent': userAgent,
+      'Accept': 'application/json',
+    };
+    if (json) {
+      headers['Content-Type'] = 'application/json';
+    }
+    final String? token = accessToken;
+    if (token != null && token.trim().isNotEmpty) {
+      headers['Authorization'] = 'Bearer ${token.trim()}';
+    }
+    return headers;
+  }
+
+  /// 关闭内部 client（若为默认自建）。注入的 mock client 由调用方自行管理。
+  void close() {
+    if (_ownsClient) {
+      _client.close();
+    }
+  }
+}

--- a/hibiki/lib/src/media/video/cover_ui/poster_match_dialog.dart
+++ b/hibiki/lib/src/media/video/cover_ui/poster_match_dialog.dart
@@ -73,6 +73,9 @@ class _PosterMatchDialogState extends ConsumerState<PosterMatchDialog> {
   bool _applyToCollection = false;
   bool _applying = false;
 
+  /// 正在应用的候选（用于在其「使用」按钮上显示转圈；null = 无进行中应用）。
+  ScrapeCandidate? _applyingCandidate;
+
   @override
   void initState() {
     super.initState();
@@ -159,25 +162,45 @@ class _PosterMatchDialogState extends ConsumerState<PosterMatchDialog> {
 
   Future<void> _use(ScrapeCandidate candidate) async {
     if (_applying) return;
-    setState(() => _applying = true);
+    // 记录进行中的候选：按钮转圈给用户明确「正在应用」反馈（下载海报最长 30s，无反馈
+    // 会被误当成「点了没反应」，BUG-1081）。
+    setState(() {
+      _applying = true;
+      _applyingCandidate = candidate;
+    });
     final List<String> targets =
         _applyToCollection && widget.collectionMemberUids.length > 1
             ? widget.collectionMemberUids
             : <String>[widget.book.bookUid];
+    bool ok = false;
     try {
       await widget.service.applyCandidateToBooks(
         bookUids: targets,
         candidate: candidate,
         aliasKey: _parsed?.title,
       );
+      ok = true;
     } catch (_) {
-      if (!mounted) return;
-      setState(() => _applying = false);
+      // ok 保持 false，走下方失败分支——绝不吞成静默无反馈。
+    }
+    if (!mounted) return;
+    if (!ok) {
+      // 失败：复位 _applying（否则按钮永久禁用），弹可见失败提示，弹窗保留让用户改选。
+      setState(() {
+        _applying = false;
+        _applyingCandidate = null;
+      });
       HibikiToast.show(msg: t.video_scrape_apply_failed);
       return;
     }
+    // 成功：刷新库页 + 关弹窗 + 成功提示。onApplied 单独 guard，任何异常都不得阻断关闭
+    // 弹窗（否则 _applying 卡在 true、按钮永久禁用 = 「使用没反应」的另一条成因）。
+    try {
+      widget.onApplied();
+    } catch (_) {
+      // 刷新回调异常不影响「已应用」这一既成事实，吞掉即可。
+    }
     if (!mounted) return;
-    widget.onApplied();
     Navigator.of(context).pop();
     HibikiToast.show(msg: t.video_scrape_applied);
   }
@@ -378,7 +401,13 @@ class _PosterMatchDialogState extends ConsumerState<PosterMatchDialog> {
           const SizedBox(width: 8),
           FilledButton.tonal(
             onPressed: _applying ? null : () => _use(candidate),
-            child: Text(t.video_scrape_use),
+            child: identical(_applyingCandidate, candidate)
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Text(t.video_scrape_use),
           ),
         ],
       ),

--- a/hibiki/lib/src/media/video/scraper/bangumi_client.dart
+++ b/hibiki/lib/src/media/video/scraper/bangumi_client.dart
@@ -11,9 +11,9 @@
 /// 在中国大陆一般可直连；若用户所在网络不通，交由外层代理生效即可。
 library;
 
-import 'dart:async';
 import 'dart:convert';
 
+import 'package:hibiki/src/media/metadata/bangumi_api_client.dart';
 import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
 import 'package:http/http.dart' as http;
 
@@ -35,59 +35,43 @@ class ScrapeNetworkException implements Exception {
 }
 
 /// Bangumi 搜索客户端。构造函数注入 [http.Client]（默认自建），测试用 mock client。
+///
+/// 传输层（URL / 请求头 / 超时 / utf8 解码 / 传输异常边界）现由跨媒体共享的
+/// [BangumiApiClient] 承担；本类只保留「动画（type=2）」语义 + `ScrapeCandidate` /
+/// `ScrapeMetadata` 领域映射 + `ScrapeNetworkException` 异常契约。
 class BangumiClient {
-  BangumiClient({http.Client? client}) : _client = client ?? http.Client();
+  BangumiClient({http.Client? client})
+      : _api = BangumiApiClient(client: client, userAgent: _userAgent);
 
-  final http.Client _client;
+  final BangumiApiClient _api;
 
   /// Bangumi API 要求可识别的 User-Agent（否则可能被限流/拒绝）。
   static const String _userAgent =
       'hibiki-reader/scraper (https://github.com/hajisensai)';
 
-  static const Duration _timeout = Duration(seconds: 15);
-
   /// 搜索关键词 [keyword]，返回动画候选（最多 [limit] 条）。
   ///
   /// 网络失败 / 非 2xx / JSON 异常 → 抛 [ScrapeNetworkException]。
   Future<List<ScrapeCandidate>> search(String keyword, {int limit = 10}) async {
-    final Uri uri = Uri.parse('https://api.bgm.tv/v0/search/subjects')
-        .replace(queryParameters: <String, String>{'limit': '$limit'});
-    final String requestBody = jsonEncode(<String, Object?>{
-      'keyword': keyword,
-      'filter': <String, Object?>{
-        'type': <int>[2], // 2 = 动画
-      },
-    });
-
-    final http.Response response;
+    final BangumiRawResponse response;
     try {
-      response = await _client
-          .post(
-            uri,
-            headers: const <String, String>{
-              'User-Agent': _userAgent,
-              'Content-Type': 'application/json',
-              'Accept': 'application/json',
-            },
-            body: requestBody,
-          )
-          .timeout(_timeout);
-    } on TimeoutException {
-      throw const ScrapeNetworkException('Bangumi search timed out');
-    } catch (e) {
-      throw ScrapeNetworkException('Bangumi request failed: $e');
+      response = await _api.searchSubjects(
+        keyword,
+        subjectType: kBangumiSubjectTypeAnime,
+        limit: limit,
+      );
+    } on BangumiTransportException catch (e) {
+      throw ScrapeNetworkException('Bangumi search ${e.message}');
     }
 
-    if (response.statusCode < 200 || response.statusCode >= 300) {
+    if (!response.isOk) {
       throw ScrapeNetworkException(
         'Bangumi search HTTP ${response.statusCode}',
         statusCode: response.statusCode,
       );
     }
 
-    // 服务器返回的是 utf8 原始字节；用 bodyBytes 走 utf8 解码，避免 http.Response.body
-    // 在缺 charset 时按 latin1 解码毁掉中日文。
-    return parseBangumiSearchResponse(utf8.decode(response.bodyBytes));
+    return parseBangumiSearchResponse(response.body);
   }
 
   /// 拉取条目详情 `GET /v0/subjects/{id}`，返回条目级资料（简介/评分/放送/话数/
@@ -100,35 +84,25 @@ class BangumiClient {
   /// 网络失败 / 非 2xx / JSON 异常 → 抛 [ScrapeNetworkException]；404（条目不存在
   /// 或被删）同样走异常，由上层降级为「只有封面没有资料」。
   Future<ScrapeMetadata> fetchSubject(String subjectId) async {
-    final Uri uri = Uri.parse('https://api.bgm.tv/v0/subjects/$subjectId');
-    final http.Response response;
+    final BangumiRawResponse response;
     try {
-      response = await _client.get(
-        uri,
-        headers: const <String, String>{
-          'User-Agent': _userAgent,
-          'Accept': 'application/json',
-        },
-      ).timeout(_timeout);
-    } on TimeoutException {
-      throw const ScrapeNetworkException('Bangumi subject fetch timed out');
-    } catch (e) {
-      throw ScrapeNetworkException('Bangumi subject request failed: $e');
+      response = await _api.fetchSubject(subjectId);
+    } on BangumiTransportException catch (e) {
+      throw ScrapeNetworkException('Bangumi subject ${e.message}');
     }
 
-    if (response.statusCode < 200 || response.statusCode >= 300) {
+    if (!response.isOk) {
       throw ScrapeNetworkException(
         'Bangumi subject HTTP ${response.statusCode}',
         statusCode: response.statusCode,
       );
     }
 
-    // 同 search：走 bodyBytes + utf8，避免缺 charset 时按 latin1 毁中日文。
-    return parseBangumiSubjectResponse(utf8.decode(response.bodyBytes));
+    return parseBangumiSubjectResponse(response.body);
   }
 
   /// 关闭内部 client（若为默认自建）。测试注入的 mock client 由调用方自行管理。
-  void close() => _client.close();
+  void close() => _api.close();
 }
 
 /// 纯函数：把 Bangumi `/v0/subjects/{id}` 响应体解析为 [ScrapeMetadata]。

--- a/hibiki/lib/src/media/video/scraper/match_scorer.dart
+++ b/hibiki/lib/src/media/video/scraper/match_scorer.dart
@@ -27,15 +27,8 @@ const double _kYearFarPenalty = -0.20;
 /// 电影提示与候选类型一致（剧场版 hint + movie 条目）：加分。
 const double _kTypeMovieBonus = 0.10;
 
-/// 无电影提示且候选是剧集类（tv/ova/special）：弱一致，小幅加分
-/// （「没写剧场版」是弱信号，权重必须低于显式 hint）。
-const double _kTypeWeakBonus = 0.05;
-
 /// 显式电影提示但候选不是 movie：强冲突减分。
 const double _kTypeConflictStrongPenalty = -0.20;
-
-/// 无电影提示但候选是 movie：弱冲突减分（剧集文件常省略标记，罚轻些）。
-const double _kTypeConflictWeakPenalty = -0.10;
 
 /// 季度记号对上（parsed.season≥2 且候选标题/别名含对应季度记号）：加分。
 const double _kSeasonBonus = 0.15;
@@ -127,22 +120,21 @@ class MatchScorer {
       }
     }
 
-    // --- 类型：isMovieHint 与 candidate.type == movie 互验；unknown 不参与。---
+    // --- 类型：只有文件名显式带电影标记（剧场版/Movie/映画）时类型才是可信信号。---
+    // hint + movie → 一致加分；hint + 非 movie → 强冲突减分。
+    // 文件名**没**电影标记时，候选是不是电影从文件名根本推不出来（剧集文件常省略、
+    // 电影文件也常不写「剧场版」）——此时保持中性 0，不得据此奖惩任一方。旧实现给
+    // 「无 hint + movie 候选」−0.10、给「无 hint + 剧集候选」+0.05，这 0.15 的系统性
+    // 摆动会把无标记的正片压到联动 CM / 剧集条目之下（BUG-1080）。unknown 同样不参与。
     bool? typeMatched;
-    if (candidate.type != ScrapeEntryType.unknown) {
+    if (candidate.type != ScrapeEntryType.unknown && parsed.isMovieHint) {
       final bool candidateIsMovie = candidate.type == ScrapeEntryType.movie;
-      if (parsed.isMovieHint && candidateIsMovie) {
+      if (candidateIsMovie) {
         typeMatched = true;
         total += _kTypeMovieBonus;
-      } else if (parsed.isMovieHint && !candidateIsMovie) {
+      } else {
         typeMatched = false;
         total += _kTypeConflictStrongPenalty;
-      } else if (!parsed.isMovieHint && candidateIsMovie) {
-        typeMatched = false;
-        total += _kTypeConflictWeakPenalty;
-      } else {
-        typeMatched = true;
-        total += _kTypeWeakBonus;
       }
     }
 

--- a/hibiki/lib/src/media/video/scraper/offline_index.dart
+++ b/hibiki/lib/src/media/video/scraper/offline_index.dart
@@ -228,13 +228,22 @@ class OfflineIndex {
     final List<int> limitedPool = pool.length > _kCandidatePoolLimit
         ? pool.sublist(0, _kCandidatePoolLimit)
         : pool;
-    // 细算相似度并排序。
-    final List<(int, double)> scored = <(int, double)>[
+    // 细算相似度并排序。主键 = title+synonyms 的最大相似度；打平时 tiebreaker = 主
+    // 标题本身的相似度：借来的别名蹭分的联动/CM（如「Suntory×君の名は」CM 把「君の名は」
+    // 塞进 synonyms）主标题与查询几乎无关，应排到「真名直接命中」的正片之后（BUG-1080）。
+    final List<(int, double, double)> scored = <(int, double, double)>[
       for (final int recordIndex in limitedPool)
-        (recordIndex, _bestSimilarity(rawTitle, _records[recordIndex])),
-    ]..sort(((int, double) a, (int, double) b) => b.$2.compareTo(a.$2));
+        (
+          recordIndex,
+          _bestSimilarity(rawTitle, _records[recordIndex]),
+          TitleNormalizer.similarity(rawTitle, _records[recordIndex].title),
+        ),
+    ]..sort(((int, double, double) a, (int, double, double) b) {
+        final int byBest = b.$2.compareTo(a.$2);
+        return byBest != 0 ? byBest : b.$3.compareTo(a.$3);
+      });
     return <ScrapeCandidate>[
-      for (final (int recordIndex, double _) in scored.take(limit))
+      for (final (int recordIndex, double _, double _) in scored.take(limit))
         _toCandidate(recordIndex, _records[recordIndex]),
     ];
   }

--- a/hibiki/lib/src/media/video/scraper/tmdb_client.dart
+++ b/hibiki/lib/src/media/video/scraper/tmdb_client.dart
@@ -29,8 +29,13 @@ class TmdbClient {
 
   static const Duration _timeout = Duration(seconds: 15);
 
-  /// TMDB 海报基址（w500 尺寸）。
-  static const String posterBase = 'https://image.tmdb.org/t/p/w500';
+  /// TMDB 海报基址：`original` = 满分辨率原图（用户要求默认满分辨率，BUG-1082）。
+  ///
+  /// 旧值 `w500`（500px 宽缩略档）落盘后放大到高 dpr 大格子会发糊。Bangumi(large) /
+  /// 离线库(picture) 本就取各源最高档，唯 TMDB 之前钉在缩略档，是刮削海报发糊的根因。
+  /// 落盘无损（[PosterDownloader] 原样写字节），渲染层 `resizedFileImage` 解码上限自会
+  /// 按需降采样，不会因原图更大而变慢展示。
+  static const String posterBase = 'https://image.tmdb.org/t/p/original';
 
   /// 搜索关键词 [keyword]（[year] 仅用于占位/未来精确化，multi 端点本身不接受 year）。
   ///

--- a/hibiki/lib/src/mining/metadata/adapters/bangumi_adapter.dart
+++ b/hibiki/lib/src/mining/metadata/adapters/bangumi_adapter.dart
@@ -9,6 +9,7 @@ library;
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:hibiki/src/media/metadata/bangumi_api_client.dart';
 import 'package:hibiki/src/mining/metadata/galgame_metadata_adapter.dart';
 import 'package:hibiki/src/mining/metadata/galgame_metadata_draft.dart';
 import 'package:hibiki/src/mining/metadata/galgame_metadata_rate_limit.dart';
@@ -34,19 +35,22 @@ class BangumiMetadataAdapter implements GalgameMetadataAdapter {
     String? accessToken,
     String baseUrl = 'https://api.bgm.tv/v0',
     Duration timeout = const Duration(seconds: 15),
-  })  : _client = client ?? http.Client(),
-        _ownsClient = client == null,
-        _rateLimiter = rateLimiter ?? GalgameRateLimiter(),
-        _accessToken = accessToken,
-        _baseUrl = baseUrl,
-        _timeout = timeout;
+  }) : _rateLimiter = rateLimiter ?? GalgameRateLimiter() {
+    _api = BangumiApiClient(
+      client: client,
+      userAgent: _userAgent,
+      baseUrl: baseUrl,
+      timeout: timeout,
+      accessToken: accessToken,
+      gate: _gate,
+    );
+  }
 
-  final http.Client _client;
-  final bool _ownsClient;
+  /// 跨媒体共享传输层（URL / 请求头 / 超时 / utf8 解码 / 传输异常边界）。本 adapter 只
+  /// 保留「游戏（type=4）」语义 + 限流注入 + `GalgameMetadataDraft` 领域映射 + 404 策略。
+  late final BangumiApiClient _api;
+
   final GalgameRateLimiter _rateLimiter;
-  final String? _accessToken;
-  final String _baseUrl;
-  final Duration _timeout;
 
   /// Bangumi 要求可识别的 User-Agent，否则可能被限流 / 拒绝。
   static const String _userAgent =
@@ -70,10 +74,9 @@ class BangumiMetadataAdapter implements GalgameMetadataAdapter {
         source: source,
       );
     }
-    final http.Response response = await _send(
-      () => _client
-          .get(Uri.parse('$_baseUrl/subjects/$trimmed'), headers: _headers())
-          .timeout(_timeout),
+    final BangumiRawResponse response = await _fetch(
+      () => _api.fetchSubject(trimmed),
+      'fetch subject $trimmed',
     );
     if (response.statusCode == 404) {
       return null; // 条目不存在是正常结果，不是异常。
@@ -100,19 +103,13 @@ class BangumiMetadataAdapter implements GalgameMetadataAdapter {
     if (keyword.isEmpty) {
       return const <SourceCandidate>[];
     }
-    final Uri uri = Uri.parse('$_baseUrl/search/subjects').replace(
-      queryParameters: <String, String>{'limit': '${limit.clamp(1, 50)}'},
-    );
-    final String body = jsonEncode(<String, Object?>{
-      'keyword': keyword,
-      'filter': <String, Object?>{
-        'type': <int>[kBangumiSubjectTypeGame],
-      },
-    });
-    final http.Response response = await _send(
-      () => _client
-          .post(uri, headers: _headers(json: true), body: body)
-          .timeout(_timeout),
+    final BangumiRawResponse response = await _fetch(
+      () => _api.searchSubjects(
+        keyword,
+        subjectType: kBangumiSubjectTypeGame,
+        limit: limit,
+      ),
+      'search "$keyword"',
     );
     if (response.statusCode == 404) {
       return const <SourceCandidate>[]; // 无命中时 Bangumi 偶尔回 404。
@@ -125,49 +122,36 @@ class BangumiMetadataAdapter implements GalgameMetadataAdapter {
   }
 
   @override
-  void close() {
-    if (_ownsClient) {
-      _client.close();
-    }
-  }
+  void close() => _api.close();
 
-  Map<String, String> _headers({bool json = false}) {
-    final Map<String, String> headers = <String, String>{
-      'User-Agent': _userAgent,
-      'Accept': 'application/json',
-    };
-    if (json) {
-      headers['Content-Type'] = 'application/json';
-    }
-    final String? token = _accessToken;
-    if (token != null && token.trim().isNotEmpty) {
-      headers['Authorization'] = 'Bearer ${token.trim()}';
-    }
-    return headers;
-  }
-
-  /// 过限流器发一次请求，并把 429/503 的 `Retry-After` 记回桶里。
-  Future<http.Response> _send(Future<http.Response> Function() send) {
+  /// 限流 gate（注入进共享传输层）：过限流器发一次请求，并把 429/503 的 `Retry-After`
+  /// 记回桶里。超时 / 网络失败在共享层归一为 [BangumiTransportException]，由 [_fetch] 再
+  /// 包装成 galgame 领域异常。
+  Future<http.Response> _gate(Future<http.Response> Function() send) {
     return _rateLimiter.run(() async {
-      final http.Response response;
-      try {
-        response = await send();
-      } on TimeoutException {
-        throw GalgameMetadataException('Bangumi request timed out',
-            source: source);
-      } on GalgameMetadataException {
-        rethrow;
-      } catch (e) {
-        throw GalgameMetadataException('Bangumi request failed: $e',
-            source: source);
-      }
+      final http.Response response = await send();
       _rateLimiter.noteResponse(response.statusCode, response.headers);
       return response;
     });
   }
 
-  void _ensureOk(http.Response response, String what) {
-    if (response.statusCode >= 200 && response.statusCode < 300) {
+  /// 把共享传输层的 [BangumiTransportException] 归一成 galgame 领域异常。
+  Future<BangumiRawResponse> _fetch(
+    Future<BangumiRawResponse> Function() run,
+    String what,
+  ) async {
+    try {
+      return await run();
+    } on BangumiTransportException catch (e) {
+      throw GalgameMetadataException(
+        'Bangumi $what ${e.message}',
+        source: source,
+      );
+    }
+  }
+
+  void _ensureOk(BangumiRawResponse response, String what) {
+    if (response.isOk) {
       return;
     }
     throw GalgameMetadataException(
@@ -177,10 +161,10 @@ class BangumiMetadataAdapter implements GalgameMetadataAdapter {
     );
   }
 
-  /// 用 bodyBytes + utf8 解码：缺 charset 时 `http.Response.body` 会按 latin1 解，毁中日文。
-  Object? _decodeJson(http.Response response, String what) {
+  /// 共享层已用 bodyBytes + utf8 解好码（避免缺 charset 时 latin1 毁中日文），这里只做 JSON 解析。
+  Object? _decodeJson(BangumiRawResponse response, String what) {
     try {
-      return jsonDecode(utf8.decode(response.bodyBytes));
+      return jsonDecode(response.body);
     } catch (e) {
       throw GalgameMetadataException(
         'Bangumi $what returned malformed JSON: $e',

--- a/hibiki/test/media/metadata/bangumi_api_client_test.dart
+++ b/hibiki/test/media/metadata/bangumi_api_client_test.dart
@@ -1,0 +1,176 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/metadata/bangumi_api_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// 共享传输层 [BangumiApiClient] 的契约测试。
+///
+/// 只验证「传输层职责」：URL / 请求头 / POST 体 / subjectType 过滤 / utf8 解码 /
+/// 传输异常边界 / 限流 gate 注入 / token。领域映射（ScrapeCandidate / GalgameDraft）
+/// 由各调用方自己的测试覆盖，不在此重复。
+void main() {
+  group('BangumiApiClient.searchSubjects', () {
+    test('POST /search/subjects：UA/Content-Type 头、body 含 keyword+filter.type、limit query',
+        () async {
+      Map<String, String>? headers;
+      Object? body;
+      Uri? uri;
+      final MockClient client = MockClient((http.Request req) async {
+        headers = req.headers;
+        body = jsonDecode(req.body);
+        uri = req.url;
+        return http.Response.bytes(utf8.encode('{"data":[]}'), 200);
+      });
+      final BangumiApiClient api =
+          BangumiApiClient(client: client, userAgent: 'ua/test');
+
+      final BangumiRawResponse res = await api.searchSubjects(
+        '鬼滅',
+        subjectType: kBangumiSubjectTypeGame,
+        limit: 5,
+      );
+
+      expect(res.statusCode, 200);
+      expect(res.isOk, isTrue);
+      expect(uri?.path, '/v0/search/subjects');
+      expect(uri?.queryParameters['limit'], '5');
+      expect(headers?['user-agent'], 'ua/test');
+      expect(headers?['content-type'], contains('application/json'));
+      final Map<String, Object?> decoded =
+          (body as Map).cast<String, Object?>();
+      expect(decoded['keyword'], '鬼滅');
+      expect((decoded['filter'] as Map)['type'], <int>[4]);
+    });
+
+    test('limit 超 50 被 clamp 到 50', () async {
+      Uri? uri;
+      final MockClient client = MockClient((http.Request req) async {
+        uri = req.url;
+        return http.Response.bytes(utf8.encode('{}'), 200);
+      });
+      await BangumiApiClient(client: client, userAgent: 'ua')
+          .searchSubjects('x', subjectType: kBangumiSubjectTypeAnime, limit: 999);
+      expect(uri?.queryParameters['limit'], '50');
+    });
+
+    test('subjectType 透传：书籍=1', () async {
+      Object? body;
+      final MockClient client = MockClient((http.Request req) async {
+        body = jsonDecode(req.body);
+        return http.Response.bytes(utf8.encode('{}'), 200);
+      });
+      await BangumiApiClient(client: client, userAgent: 'ua')
+          .searchSubjects('x', subjectType: kBangumiSubjectTypeBook);
+      expect(((body as Map)['filter'] as Map)['type'], <int>[1]);
+    });
+  });
+
+  group('BangumiApiClient.fetchSubject', () {
+    test('GET /subjects/{id}：带 UA/Accept、不带 Content-Type', () async {
+      Map<String, String>? headers;
+      Uri? uri;
+      final MockClient client = MockClient((http.Request req) async {
+        headers = req.headers;
+        uri = req.url;
+        return http.Response.bytes(utf8.encode('{"id":123}'), 200);
+      });
+      final BangumiRawResponse res =
+          await BangumiApiClient(client: client, userAgent: 'ua/x')
+              .fetchSubject('123');
+
+      expect(uri?.path, '/v0/subjects/123');
+      expect(headers?['user-agent'], 'ua/x');
+      expect(headers?['accept'], 'application/json');
+      expect(headers?.containsKey('content-type'), isFalse);
+      expect(res.body, contains('123'));
+    });
+
+    test('utf8 解码：中日文 body 不被 latin1 毁坏', () async {
+      final MockClient client = MockClient(
+        (http.Request req) async =>
+            http.Response.bytes(utf8.encode('{"name_cn":"鬼滅の刃"}'), 200),
+      );
+      final BangumiRawResponse res =
+          await BangumiApiClient(client: client, userAgent: 'ua')
+              .fetchSubject('1');
+      expect(res.body, contains('鬼滅の刃'));
+    });
+  });
+
+  group('BangumiApiClient 状态码 / 异常边界', () {
+    test('非 2xx（含 404）不抛：返回 BangumiRawResponse 由调用方定策略', () async {
+      for (final int code in <int>[404, 500, 429]) {
+        final MockClient client = MockClient(
+          (http.Request req) async => http.Response('err', code),
+        );
+        final BangumiRawResponse res =
+            await BangumiApiClient(client: client, userAgent: 'ua')
+                .fetchSubject('1');
+        expect(res.statusCode, code);
+        expect(res.isOk, isFalse);
+      }
+    });
+
+    test('传输失败 → BangumiTransportException（不吞异常）', () async {
+      final MockClient client =
+          MockClient((http.Request req) async => throw Exception('boom'));
+      await expectLater(
+        BangumiApiClient(client: client, userAgent: 'ua').fetchSubject('1'),
+        throwsA(isA<BangumiTransportException>()),
+      );
+    });
+  });
+
+  group('BangumiApiClient 注入点', () {
+    test('accessToken → Authorization: Bearer 头', () async {
+      Map<String, String>? headers;
+      final MockClient client = MockClient((http.Request req) async {
+        headers = req.headers;
+        return http.Response.bytes(utf8.encode('{}'), 200);
+      });
+      await BangumiApiClient(
+        client: client,
+        userAgent: 'ua',
+        accessToken: 'tok123',
+      ).fetchSubject('1');
+      expect(headers?['authorization'], 'Bearer tok123');
+    });
+
+    test('gate 被调用且能观察响应（限流注入点）', () async {
+      int gateCalls = 0;
+      int? seenStatus;
+      final MockClient client = MockClient(
+        (http.Request req) async => http.Response.bytes(utf8.encode('{}'), 200),
+      );
+      final BangumiApiClient api = BangumiApiClient(
+        client: client,
+        userAgent: 'ua',
+        gate: (Future<http.Response> Function() send) async {
+          gateCalls++;
+          final http.Response r = await send();
+          seenStatus = r.statusCode;
+          return r;
+        },
+      );
+      await api.fetchSubject('1');
+      expect(gateCalls, 1);
+      expect(seenStatus, 200);
+    });
+
+    test('自定义 baseUrl 生效', () async {
+      Uri? uri;
+      final MockClient client = MockClient((http.Request req) async {
+        uri = req.url;
+        return http.Response.bytes(utf8.encode('{}'), 200);
+      });
+      await BangumiApiClient(
+        client: client,
+        userAgent: 'ua',
+        baseUrl: 'https://mirror.example/v0',
+      ).fetchSubject('9');
+      expect(uri.toString(), 'https://mirror.example/v0/subjects/9');
+    });
+  });
+}

--- a/hibiki/test/media/video/scraper/match_scorer_test.dart
+++ b/hibiki/test/media/video/scraper/match_scorer_test.dart
@@ -193,6 +193,36 @@ void main() {
       expect(best.typeMatched, isTrue);
     });
 
+    test('无电影提示时类型加权中性，正片不被联动 CM 徽标反超（BUG-1080）', () {
+      // 文件名没写「剧场版」时，候选是不是电影从文件名根本推不出来，不得据此奖惩。
+      // 旧实现给「无 hint + movie 候选」−0.10、给「无 hint + 非 movie 候选」+0.05，这
+      // 0.15 摆动会把正片压成 medium、把靠借来别名蹭到同样 titleScore 的联动 CM 顶成 high。
+      const ParsedMediaName parsed =
+          ParsedMediaName(title: 'kimi no na wa'); // 无 isMovieHint
+      final MatchDecision movie = MatchScorer.score(
+        parsed: parsed,
+        candidate:
+            candidateOf(title: 'Kimi no Na wa.', type: ScrapeEntryType.movie),
+      );
+      final MatchDecision cm = MatchScorer.score(
+        parsed: parsed,
+        candidate: candidateOf(
+          title: 'Suntory Minami Alps no Tennensui',
+          aliases: <String>['Kimi no Na wa'], // 借来的别名蹭 titleScore
+          type: ScrapeEntryType.special,
+        ),
+      );
+      // 修后：无 hint 时类型加权恒为 0，typeMatched 不可判定；两者 titleScore 同为 1.0
+      // → 同级，正片不再被 CM 的类型加权反超。
+      expect(movie.typeMatched, isNull);
+      expect(cm.typeMatched, isNull);
+      expect(movie.titleScore, 1.0);
+      expect(cm.titleScore, 1.0);
+      expect(movie.confidence, cm.confidence,
+          reason: '标题同分时类型不再制造偏差，正片不再被联动 CM 徽标反超');
+      expect(movie.confidence, MatchConfidence.high);
+    });
+
     test('罗马数字季度记号（Ⅱ/ii）也能对上', () {
       final ScrapeCandidate romanTwo = candidateOf(
         title: 'Mushoku Tensei II',

--- a/hibiki/test/media/video/scraper/offline_index_test.dart
+++ b/hibiki/test/media/video/scraper/offline_index_test.dart
@@ -146,4 +146,33 @@ void main() {
       expect(index.search('～！？'), isEmpty);
     });
   });
+
+  group('借来别名的联动/CM 降级（BUG-1080）', () {
+    test('主标题直接命中的正片，排在只靠借来别名命中的联动 CM 之前', () {
+      // 复刻真实 bug：Suntory「天然水」联动 CM 把「君の名は / Kimi no Na wa」塞进
+      // synonyms，于是它对查询的 title+synonyms 最大相似度与正片相同；但 CM 自己的主
+      // 标题「Suntory…」与查询无关。tiebreaker（主标题相似度）应让正片压过 CM。
+      final OfflineIndex idx = OfflineIndex(const <OfflineAnimeRecord>[
+        OfflineAnimeRecord(
+          title: 'Suntory Minami Alps no Tennensui',
+          synonyms: <String>['Kimi no Na wa', '君の名は'],
+          type: ScrapeEntryType.special,
+          picture: 'https://example.invalid/cm.jpg',
+          sourceId: 'anidb/cm',
+        ),
+        OfflineAnimeRecord(
+          title: 'Kimi no Na wa.',
+          synonyms: <String>['你的名字。', 'Your Name.'],
+          type: ScrapeEntryType.movie,
+          picture: 'https://example.invalid/movie.jpg',
+          sourceId: 'myanimelist.net/anime/32281',
+        ),
+      ]);
+      // 用户实际输入（含 "-your name"），两者 best 相似度打平在 0.8。
+      final List<ScrapeCandidate> results =
+          idx.search('Kimi no Na wa. -your name');
+      expect(results.first.title, 'Kimi no Na wa.',
+          reason: '正片主标题直接命中，应压过靠借来别名蹭分的联动 CM');
+    });
+  });
 }

--- a/hibiki/test/media/video/scraper/tmdb_client_test.dart
+++ b/hibiki/test/media/video/scraper/tmdb_client_test.dart
@@ -29,7 +29,7 @@ void main() {
       expect(tv.title, '进击的巨人');
       expect(tv.aliases, <String>['進撃の巨人']);
       expect(tv.year, 2013);
-      expect(tv.posterUrl, 'https://image.tmdb.org/t/p/w500/tv.jpg');
+      expect(tv.posterUrl, 'https://image.tmdb.org/t/p/original/tv.jpg');
       expect(tv.detailUrl, 'https://www.themoviedb.org/tv/100');
       expect(tv.ratingText, 'TMDB 8.7'); // 8.65(≈8.6500000003) → 一位小数进为 8.7
 


### PR DESCRIPTION
## 背景：统一各媒体页服务的第 1 期（P1a）

用户目标：书籍/漫画/视频/游戏各页各自维护渲染与命名代码，要尽量统一服务层（改名/改封面/刮削/合集…共 24 个服务域）。本 PR 是**刮削统一**的第一步，也是最典型的「各页各写」实例：视频海报刮削（`media/video/scraper/bangumi_client.dart`）与 galgame 元数据（`mining/metadata/adapters/bangumi_adapter.dart`）**各写了一份 Bangumi 客户端**，打的是**同一套 API v0 端点**。

## 做法（Linus 式：只统一意外重复的传输层，不强并合理不同的领域映射）

新增跨媒体共享 `hibiki/lib/src/media/metadata/bangumi_api_client.dart`：
- 只负责传输：URL 构造、请求头（UA/Accept/可选 token/Content-Type）、POST 搜索体、超时、`utf8(bodyBytes)` 解码、传输异常边界。
- **不负责**（各调用方策略，保留）：subject 类型选择、HTTP 状态→领域异常映射、404 策略、JSON→领域对象映射、限流。

两侧改为消费共享层：
- **视频 `BangumiClient`**：留 `type=2` 动画语义 + `ScrapeCandidate`/`ScrapeMetadata` 映射 + `ScrapeNetworkException` 契约（404 抛异常降级）。净 −34 行。
- **galgame `BangumiMetadataAdapter`**：留 `type=4` 游戏语义 + `GalgameMetadataDraft` 映射 + 404 返 null；限流 `GalgameRateLimiter` 通过 `gate` 钩子**注入**共享层，不下沉。

subjectType 常量预留 `kBangumiSubjectTypeBook=1`，为后续给书/漫画加刮削复用同一传输层铺路（P1b）。

## 零行为变更验证
- 既有 `bangumi_client_test` / `bangumi_subject_test` / `bangumi_adapter_test`（含 header/body/URL/404/500/token 行为断言）**原封不动全绿** = 行为未变。
- 新增 `bangumi_api_client_test`：覆盖共享传输契约（subjectType 透传/utf8 中日文/非2xx不抛/传输异常/gate 注入/token/limit clamp/自定义 baseUrl）。
- `flutter analyze`（4 目录）No issues；上述 4 个测试文件共 53 tests 全绿。

## 不在本 PR 范围
封面服务、改名门面、游戏进合集、书/漫画刮削 UI 等其余 23 个服务域按后续分期 PR 逐个落地（P1b→P5）。

https://claude.ai/code/session_01R8J5bNtpUb35aCpo1qw4eJ