### PR TITLE
refactor(media): 统一媒体页服务 P2+UI收口 — 共享卡片件三页接线 + 单卡加入合集 + 游戏进合集 + 游戏刮削封面落地

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 44149 (2597 per locale)
+/// Strings: 44166 (2598 per locale)
 ///
-/// Built on 2026-07-25 at 08:44 UTC
+/// Built on 2026-07-25 at 12:06 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3443,6 +3443,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get browser_extension_version_browser => 'Loaded in browser';
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -9329,6 +9330,8 @@ class _StringsAr extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -15288,6 +15291,8 @@ class _StringsDe extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -21263,6 +21268,8 @@ class _StringsEs extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -27249,6 +27256,8 @@ class _StringsFr extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -33162,6 +33171,8 @@ class _StringsId extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -39123,6 +39134,8 @@ class _StringsIt extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -44889,6 +44902,8 @@ class _StringsJa extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -50658,6 +50673,8 @@ class _StringsKo extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -56597,6 +56614,8 @@ class _StringsNl extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -62551,6 +62570,8 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -68488,6 +68509,8 @@ class _StringsRu extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -74370,6 +74393,8 @@ class _StringsTh extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -80284,6 +80309,8 @@ class _StringsTr extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -86185,6 +86212,8 @@ class _StringsVi extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 // Path: <root>
@@ -91676,6 +91705,8 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       '浏览器中加载的扩展不是最新版本：如有需要先重新准备扩展，再到浏览器扩展管理页（chrome://extensions）点「重新加载」。';
+  @override
+  String get add_to_collection => '加入合集';
 }
 
 // Path: <root>
@@ -97360,6 +97391,8 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get add_to_collection => 'Add to collection';
 }
 
 /// Flat map(s) containing all translations.
@@ -102662,6 +102695,8 @@ extension on _StringsEn {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -107962,6 +107997,8 @@ extension on _StringsAr {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -113283,6 +113320,8 @@ extension on _StringsDe {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -118603,6 +118642,8 @@ extension on _StringsEs {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -123929,6 +123970,8 @@ extension on _StringsFr {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -129237,6 +129280,8 @@ extension on _StringsId {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -134560,6 +134605,8 @@ extension on _StringsIt {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -139845,6 +139892,8 @@ extension on _StringsJa {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -145134,6 +145183,8 @@ extension on _StringsKo {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -150450,6 +150501,8 @@ extension on _StringsNl {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -155763,6 +155816,8 @@ extension on _StringsPtBr {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -161081,6 +161136,8 @@ extension on _StringsRu {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -166383,6 +166440,8 @@ extension on _StringsTh {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -171694,6 +171753,8 @@ extension on _StringsTr {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -177000,6 +177061,8 @@ extension on _StringsVi {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }
@@ -182266,6 +182329,8 @@ extension on _StringsZhCn {
         return '浏览器中加载';
       case 'browser_extension_version_mismatch':
         return '浏览器中加载的扩展不是最新版本：如有需要先重新准备扩展，再到浏览器扩展管理页（chrome://extensions）点「重新加载」。';
+      case 'add_to_collection':
+        return '加入合集';
       default:
         return null;
     }
@@ -187546,6 +187611,8 @@ extension on _StringsZhHk {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'add_to_collection':
+        return 'Add to collection';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "换一个",
   "browser_extension_version_app": "App 内置",
   "browser_extension_version_browser": "浏览器中加载",
-  "browser_extension_version_mismatch": "浏览器中加载的扩展不是最新版本：如有需要先重新准备扩展，再到浏览器扩展管理页（chrome://extensions）点「重新加载」。"
+  "browser_extension_version_mismatch": "浏览器中加载的扩展不是最新版本：如有需要先重新准备扩展，再到浏览器扩展管理页（chrome://extensions）点「重新加载」。",
+  "add_to_collection": "加入合集"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2595,5 +2595,6 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "add_to_collection": "Add to collection"
 }

--- a/hibiki/lib/src/media/collections/add_to_collection_dialog.dart
+++ b/hibiki/lib/src/media/collections/add_to_collection_dialog.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import 'package:hibiki/src/pages/implementations/collection_name_dialog.dart';
+import 'package:hibiki/utils.dart';
+
+/// 单卡「加入合集」的共享弹窗（书架 / 视频库 / 游戏库共用）。
+///
+/// 列出全部现有合集（名称 + 成员数，已含本条目的合集置灰打勾），首项「新建
+/// 合集」走 [showCollectionNameDialog] 命名后创建。落库统一走
+/// [HibikiDatabase.createMediaCollection] / [HibikiDatabase.addToCollection]
+/// （后者自带成员墓碑清理——重加回被移出的成员不会被同步复活逻辑吞掉），与
+/// 多选批量「组合成合集」三档共用同一条 DAO 路径。
+///
+/// 返回是否真的加入了合集（调用方据此刷新分组/网格）。
+Future<bool> showAddToCollectionDialog({
+  required BuildContext context,
+  required HibikiDatabase database,
+  required String mediaType,
+  required String entryKey,
+  String defaultNewName = '',
+}) async {
+  final List<MediaCollectionRow> collections =
+      await database.getAllMediaCollections();
+  final List<MediaCollectionItemRow> allItems =
+      await database.getAllCollectionItems();
+  final Map<int, int> memberCounts = <int, int>{};
+  final Set<int> alreadyIn = <int>{};
+  for (final MediaCollectionItemRow item in allItems) {
+    memberCounts[item.collectionId] =
+        (memberCounts[item.collectionId] ?? 0) + 1;
+    if (item.mediaType == mediaType && item.entryKey == entryKey) {
+      alreadyIn.add(item.collectionId);
+    }
+  }
+  collections.sort(
+    (MediaCollectionRow a, MediaCollectionRow b) => a.name.compareTo(b.name),
+  );
+  if (!context.mounted) return false;
+
+  const int kCreateNewSentinel = -1;
+  final int? picked = await showAppDialog<int>(
+    context: context,
+    builder: (BuildContext dialogContext) => _AddToCollectionDialog(
+      collections: collections,
+      memberCounts: memberCounts,
+      alreadyIn: alreadyIn,
+      createNewSentinel: kCreateNewSentinel,
+    ),
+  );
+  if (picked == null || !context.mounted) return false;
+
+  final int collectionId;
+  if (picked == kCreateNewSentinel) {
+    final String? name = await showCollectionNameDialog(
+      context: context,
+      title: t.create_series,
+      initialName: defaultNewName,
+    );
+    if (name == null || !context.mounted) return false;
+    collectionId = await database.createMediaCollection(name);
+  } else {
+    collectionId = picked;
+  }
+  await database.addToCollection(collectionId, mediaType, entryKey);
+  HibikiToast.show(msg: t.batch_add_to_collection_success(n: 1));
+  return true;
+}
+
+class _AddToCollectionDialog extends StatelessWidget {
+  const _AddToCollectionDialog({
+    required this.collections,
+    required this.memberCounts,
+    required this.alreadyIn,
+    required this.createNewSentinel,
+  });
+
+  final List<MediaCollectionRow> collections;
+  final Map<int, int> memberCounts;
+  final Set<int> alreadyIn;
+  final int createNewSentinel;
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return HibikiDialogFrame(
+      maxWidth: 420,
+      maxHeightFactor: 0.74,
+      scrollable: false,
+      child: HibikiModalSheetFrame(
+        title: t.add_to_collection,
+        leadingIcon: Icons.collections_bookmark_outlined,
+        scrollable: true,
+        bodyPadding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing.gap,
+          vertical: tokens.spacing.gap / 2,
+        ),
+        body: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            HibikiListItem(
+              key: const ValueKey<String>('add_to_collection_create_new'),
+              leading: const Icon(Icons.add),
+              title: Text(t.create_series),
+              onTap: () => Navigator.pop(context, createNewSentinel),
+            ),
+            for (final MediaCollectionRow collection in collections)
+              HibikiListItem(
+                key: ValueKey<String>('add_to_collection_${collection.id}'),
+                leading: const Icon(Icons.collections_bookmark_outlined),
+                title: Text(collection.name),
+                subtitle: Text(
+                  t.series_item_count(n: memberCounts[collection.id] ?? 0),
+                ),
+                trailing: alreadyIn.contains(collection.id)
+                    ? const Icon(Icons.check)
+                    : null,
+                // 已含本条目的合集不可重复加入（置灰不可点）。
+                onTap: alreadyIn.contains(collection.id)
+                    ? null
+                    : () => Navigator.pop(context, collection.id),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/hibiki/lib/src/mining/galgame_cover_download.dart
+++ b/hibiki/lib/src/mining/galgame_cover_download.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:hibiki/src/mining/galgame_cover_resolver.dart';
+
+/// 刮削封面落地：把合并层算出的 `coverUrl`（`galgame_metadata_merge.dart`）真正
+/// 下载落盘。此前刮削只落元数据快照，`coverUrl` 无人消费——用户刮完元数据齐了、
+/// 封面还是默认手柄图标。
+///
+/// 决策（是否下载、扩展名推导）拆成纯函数可单测；网络 IO 收在
+/// [downloadGalgameCoverToFile]，失败一律返回 null 并记 debug 日志（刮削元数据
+/// 本身已成功，封面失败静默降级，不打断用户流程）。
+
+/// 下载体积上限：封面不该超过它（防被超大图/错误资源撑爆内存）。
+const int kGalgameCoverMaxDownloadBytes = 20 * 1024 * 1024;
+
+/// 下载体积下限：小于它的响应不可能是可用封面图（多为错误页/空响应）。
+const int kGalgameCoverMinDownloadBytes = 1024;
+
+/// 纯函数：刮削成功后是否要自动下载封面。
+///
+/// 规则只有一条：**已有可用封面文件（手选/自动/上次下载）绝不覆盖**；没有可用
+/// 封面且合并层给出了 URL 才下载。[hasUsableCoverFile] 由调用方按
+/// 「coverPath 非空且文件真实存在」判定（与卡片渲染的 existsSync 短路同判据）。
+bool shouldAutoDownloadScrapedCover({
+  required bool hasUsableCoverFile,
+  required String? coverUrl,
+}) {
+  if (hasUsableCoverFile) return false;
+  return coverUrl != null && coverUrl.trim().isNotEmpty;
+}
+
+/// 纯函数：从响应 Content-Type / URL 路径推导落盘扩展名（小写、含点）。
+///
+/// 优先信 Content-Type（服务器端真相）；拿不到或不认识再看 URL 路径后缀是否在
+/// [kGameCoverImageExtensions] 白名单内；都不中回退 `.jpg`（bgm/vndb 封面绝大多
+/// 数是 JPEG；解码按内容嗅探，后缀只是文件名）。`.jpeg` 统一归一成 `.jpg`，与
+/// `saveGameCoverFromFile` 的归一化一致。
+String galgameCoverExtension({required String url, String? contentType}) {
+  final String normalizedType =
+      (contentType ?? '').split(';').first.trim().toLowerCase();
+  const Map<String, String> byContentType = <String, String>{
+    'image/png': '.png',
+    'image/jpeg': '.jpg',
+    'image/jpg': '.jpg',
+    'image/webp': '.webp',
+    'image/bmp': '.bmp',
+  };
+  final String? fromType = byContentType[normalizedType];
+  if (fromType != null) return fromType;
+  final Uri? uri = Uri.tryParse(url);
+  if (uri != null && uri.path.isNotEmpty) {
+    final String path = uri.path.toLowerCase();
+    final int dot = path.lastIndexOf('.');
+    if (dot >= 0) {
+      final String ext =
+          path.substring(dot) == '.jpeg' ? '.jpg' : path.substring(dot);
+      if (kGameCoverImageExtensions.contains(ext)) return ext;
+    }
+  }
+  return '.jpg';
+}
+
+/// 下载 [url] 的封面图并落盘为该游戏的封面文件，返回落盘路径；任何失败返回 null。
+///
+/// 校验：仅 http/https、HTTP 200、Content-Type 是 image/*（或缺省——部分图床不给
+/// 类型，交给字节数下限兜底）、字节数在 [kGalgameCoverMinDownloadBytes] 与
+/// [kGalgameCoverMaxDownloadBytes] 之间。落盘复用 [saveGameCoverBytes]（与手动/
+/// 自动封面同名同目录，替换不残留孤儿文件）。[client] / [coverDirectory] 是测试接缝。
+Future<String?> downloadGalgameCoverToFile({
+  required String gameId,
+  required String url,
+  HttpClient? client,
+  Directory? coverDirectory,
+}) async {
+  final Uri? uri = Uri.tryParse(url.trim());
+  if (uri == null || !(uri.isScheme('http') || uri.isScheme('https'))) {
+    debugPrint('[galgame] cover download skipped, bad url: $url');
+    return null;
+  }
+  final HttpClient http = client ?? HttpClient();
+  final bool ownsClient = client == null;
+  try {
+    final HttpClientRequest request = await http.getUrl(uri);
+    final HttpClientResponse response = await request.close();
+    if (response.statusCode != HttpStatus.ok) {
+      debugPrint('[galgame] cover download HTTP ${response.statusCode}: $url');
+      return null;
+    }
+    final String? contentType = response.headers.contentType?.mimeType;
+    if (contentType != null && !contentType.startsWith('image/')) {
+      debugPrint('[galgame] cover download non-image type $contentType: $url');
+      return null;
+    }
+    final BytesBuilder builder = BytesBuilder(copy: false);
+    await for (final List<int> chunk in response) {
+      builder.add(chunk);
+      if (builder.length > kGalgameCoverMaxDownloadBytes) {
+        debugPrint('[galgame] cover download too large (> '
+            '$kGalgameCoverMaxDownloadBytes bytes): $url');
+        return null;
+      }
+    }
+    final Uint8List bytes = builder.takeBytes();
+    if (bytes.length < kGalgameCoverMinDownloadBytes) {
+      debugPrint(
+          '[galgame] cover download too small (${bytes.length} bytes): $url');
+      return null;
+    }
+    return await saveGameCoverBytes(
+      gameId: gameId,
+      bytes: bytes,
+      extension: galgameCoverExtension(url: url, contentType: contentType),
+      coverDirectory: coverDirectory,
+    );
+  } catch (e) {
+    debugPrint('[galgame] cover download failed: $url ($e)');
+    return null;
+  } finally {
+    if (ownsClient) http.close(force: true);
+  }
+}

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -620,8 +620,10 @@ class AppModel with ChangeNotifier {
             await FavoriteSentenceRepository(database)
                 .removeByItemKey(c.itemKey);
           default:
-            // 未知类型：跳过。
-            break;
+            // 未知类型：跳过，但留痕——用户确认了删除、这里静默吞掉会造成
+            // 「以为删了实际没删」且无从排查（mediaType 审计 2026-07-25）。
+            debugPrint(
+                '[sync] skip deletion of unknown mediaType ${c.mediaType}/${c.itemKey}');
         }
       } catch (e) {
         debugPrint('[sync] apply deletion ${c.mediaType}/${c.itemKey}: $e');

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -314,6 +314,23 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 游戏库合集横排行的折叠集（独立命名空间：同一个合集在书架折叠不应连带游戏库
+  /// 折叠，两页各记各的）。存储格式与 [collapsedCollectionIds] 相同。
+  Set<int> get gamesCollapsedCollectionIds {
+    final String raw =
+        getPref('games_collapsed_collection_ids', defaultValue: '') as String;
+    return <int>{
+      for (final String part in raw.split(','))
+        if (int.tryParse(part) case final int id) id,
+    };
+  }
+
+  Future<void> setGamesCollapsedCollectionIds(Set<int> ids) async {
+    final List<int> sorted = ids.toList()..sort();
+    await setPref('games_collapsed_collection_ids', sorted.join(','));
+    notifyListeners();
+  }
+
   /// 多端库联合视图（spec 2026-07-12 §2.1/§2.4）：书架/视频页主网格是否把「远端有、
   /// 本地无」的条目渲染成占位卡（云角标 + 远端封面，点击下载/流播）。**默认 true**——
   /// 用户拍板远端混排默认开。关闭时占位卡全部不渲染，两页只剩本地库。离线/未配对/

--- a/hibiki/lib/src/pages/implementations/galgame_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_detail_page.dart
@@ -7,6 +7,8 @@ import 'package:hibiki_core/hibiki_core.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:hibiki/models.dart';
+import 'package:hibiki/src/media/collections/add_to_collection_dialog.dart';
+import 'package:hibiki/src/mining/galgame_cover_download.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/mining/galgame_repository.dart';
 import 'package:hibiki/src/mining/galgame_scrape_controller.dart';
@@ -15,7 +17,8 @@ import 'package:hibiki/src/mining/metadata/galgame_metadata_draft.dart';
 import 'package:hibiki/src/mining/metadata/galgame_metadata_merge.dart';
 import 'package:hibiki/src/mining/metadata/galgame_metadata_source.dart';
 import 'package:hibiki/src/pages/implementations/games_library_page.dart'
-    show formatGalgameDate, galgamePlayStatusLabel;
+    show formatGalgameDate, galgamePlayStatusLabel, kGameCollectionMediaType;
+import 'package:hibiki/src/utils/cover_image.dart' show evictLocalCoverCache;
 import 'package:hibiki/src/pages/implementations/stat_charts.dart';
 import 'package:hibiki/src/pages/implementations/stat_shared.dart'
     show formatStatTime;
@@ -163,6 +166,18 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
     await _load();
   }
 
+  /// 「加入合集」：mediaType='game'、entryKey=`galgames.id`（本机局域身份，见
+  /// [kGameCollectionMediaType]），与库页卡片菜单同一 DAO 路径。
+  Future<void> _addToCollection(GalgameEntry game) async {
+    await showAddToCollectionDialog(
+      context: context,
+      database: _appModel.database,
+      mediaType: kGameCollectionMediaType,
+      entryKey: game.id,
+      defaultNewName: game.displayName,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final GalgameEntry? game = _game;
@@ -185,6 +200,15 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
+        actions: <Widget>[
+          // 「加入合集」：与库页卡片菜单同一入口语义（mediaType='game'，entryKey=
+          // galgames.id），落库同走 addToCollection DAO；库页返回后 _reload 刷新分组。
+          IconButton(
+            tooltip: t.add_to_collection,
+            icon: const Icon(Icons.collections_bookmark_outlined),
+            onPressed: () => unawaited(_addToCollection(game)),
+          ),
+        ],
       ),
       body: Column(
         children: <Widget>[
@@ -487,27 +511,20 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
     await launchUrl(uri, mode: LaunchMode.externalApplication);
   }
 
+  /// 封面：有 coverPath 且文件存在则经 [ShelfFileCover] 降采样加载（BUG-959 同类，
+  /// 裸 Image.file 整帧解码包装图撑爆 ImageCache），否则共享占位件
+  /// [ShelfCoverPlaceholder]（保持原 overlay 底色 + 手柄图标 40）。
   Widget _buildCover(BuildContext context, GalgameEntry game) {
+    final Widget placeholder = ShelfCoverPlaceholder(
+      icon: Icons.videogame_asset,
+      iconSize: 40,
+      backgroundColor: HibikiDesignTokens.of(context).surfaces.overlay,
+    );
     final String? cover = game.coverPath;
     if (cover != null && cover.isNotEmpty && File(cover).existsSync()) {
-      return Image.file(
-        File(cover),
-        fit: BoxFit.cover,
-        errorBuilder: (BuildContext ctx, Object error, StackTrace? stack) =>
-            _defaultCover(context),
-      );
+      return ShelfFileCover(path: cover, placeholder: placeholder);
     }
-    return _defaultCover(context);
-  }
-
-  Widget _defaultCover(BuildContext context) {
-    final HibikiSurfaceColors surfaces =
-        HibikiDesignTokens.of(context).surfaces;
-    return Container(
-      color: surfaces.overlay,
-      alignment: Alignment.center,
-      child: Icon(Icons.videogame_asset, size: 40, color: surfaces.onVariant),
-    );
+    return placeholder;
   }
 
   // ── 统计 tab ───────────────────────────────────────────────────────────
@@ -883,6 +900,10 @@ class _GalgameEditTabState extends State<_GalgameEditTab> {
       await widget.onSaved();
       if (!mounted) return;
       HibikiToast.show(msg: t.game_scrape_applied);
+      // 刮削封面落地：仅当该游戏当前无可用封面文件时自动下载 coverUrl 并写
+      // coverPath；已有封面（手选/自动/上次下载）绝不覆盖。失败静默降级（元数据
+      // 本身已成功），原因由下载函数记 debug 日志。
+      await _maybeDownloadScrapedCover();
     } on GalgameMetadataException catch (e) {
       if (!mounted) return;
       HibikiToast.show(msg: '${t.game_scrape_failed}: ${e.message}');
@@ -893,6 +914,38 @@ class _GalgameEditTabState extends State<_GalgameEditTab> {
       _scraping = false;
       if (mounted) setState(() {});
     }
+  }
+
+  /// 刮削成功后的封面落地（决策纯函数 [shouldAutoDownloadScrapedCover] 可单测）：
+  /// 读**重载后**的最新条目（合并层已按优先级/手选源算好 coverUrl），无可用封面
+  /// 文件才下载；成功后驱逐旧解码缓存（裸 FileImage 键 + 降采样键都清）、写
+  /// coverPath 并复用 `t.games_cover_updated` 提示。
+  Future<void> _maybeDownloadScrapedCover() async {
+    final GalgameEntry? latest = widget.repo.byId(widget.game.id);
+    if (latest == null) return;
+    final String? coverPath = latest.coverPath;
+    final bool hasUsableCoverFile = coverPath != null &&
+        coverPath.isNotEmpty &&
+        File(coverPath).existsSync();
+    final String? coverUrl = latest.metadata.coverUrl;
+    if (!shouldAutoDownloadScrapedCover(
+      hasUsableCoverFile: hasUsableCoverFile,
+      coverUrl: coverUrl,
+    )) {
+      return;
+    }
+    final String? saved = await downloadGalgameCoverToFile(
+      gameId: latest.id,
+      url: coverUrl!,
+    );
+    if (saved == null) return; // 失败静默：原因已进 debug 日志。
+    await evictLocalCoverCache(saved);
+    // 下载期间条目可能已被移除：仓储按 id 更新，行不在就不写。
+    if (widget.repo.byId(latest.id) == null) return;
+    await widget.repo.setCoverPath(latest.id, saved);
+    await widget.onSaved();
+    if (!mounted) return;
+    HibikiToast.show(msg: t.games_cover_updated);
   }
 
   @override

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -4,9 +4,14 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hibiki_core/hibiki_core.dart';
 
 import 'package:hibiki/models.dart';
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/media/collections/add_to_collection_dialog.dart';
+import 'package:hibiki/src/media/collections/collection_grouping.dart';
+import 'package:hibiki/src/media/collections/collection_shelf_row.dart'
+    show CollectionShelfRow;
 import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
 import 'package:hibiki/src/mining/gal_hook_failure_text.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
@@ -17,7 +22,17 @@ import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/mining/galgame_library_query.dart';
 import 'package:hibiki/src/mining/galgame_repository.dart';
 import 'package:hibiki/src/pages/implementations/galgame_detail_page.dart';
+import 'package:hibiki/src/pages/implementations/media_collection_grid_detail_page.dart';
+import 'package:hibiki/src/pages/implementations/media_item_dialog_page.dart'
+    show DialogDangerAction, DialogQuickAction, MediaItemDialogFrame;
+import 'package:hibiki/src/utils/cover_image.dart' show evictLocalCoverCache;
 import 'package:hibiki/utils.dart';
+
+/// 游戏进合集（统一媒体库）：`media_collection_items.mediaType` 的游戏值。
+/// entryKey = `galgames.id`（添加时刻微秒时间戳字符串）——**游戏本机局域身份**：
+/// 与 exe 路径同为本机事实，跨端同步时对端无对应 `galgames` 行则该成员静默忽略
+/// （合集同步引擎对 mediaType/entryKey 透传，不解引用）。
+const String kGameCollectionMediaType = 'game';
 
 /// 首页「游戏」tab：galgame 库。展示用户添加的游戏网格，点击一个游戏经
 /// [GalHookSessionController.launchGame]（引擎-hook launch 路径）拉起并注入。
@@ -62,6 +77,13 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
 
   final TextEditingController _searchController = TextEditingController();
 
+  /// 合集分组映射（与书架 `_loadShelfMaps` 同款三件套）：合集字典、条目 → 主折叠
+  /// 合集 id、条目在主折叠合集里的 sortIndex。[_reload] 时一并批量预取。
+  Map<int, MediaCollectionRow> _collectionsById =
+      const <int, MediaCollectionRow>{};
+  Map<String, int> _primaryCollectionByEntry = const <String, int>{};
+  Map<String, int> _memberSortIndex = const <String, int>{};
+
   /// 启动流程的**再入守卫**：一次启动含位数探测、helper 确认/下载对话框、注入会话等多个 await，
   /// 全程可能持续数秒。没有此守卫时，用户在等待期间重复点击游戏卡片会各自开一条 _launchGame，
   /// 叠出多个「需要下载 galgame 引擎组件」对话框（用户实测症状）。true 期间忽略新的启动点击。
@@ -79,10 +101,31 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
     super.dispose();
   }
 
-  /// 从 DB 全量重载（三个批量查询，无 N+1）。
+  /// 从 DB 全量重载（三个批量查询，无 N+1）+ 合集分组映射。
   Future<void> _reload() async {
     await _repo.load();
+    await _loadCollectionMaps();
     _refresh();
+  }
+
+  /// 预取合集分组三件套（照书架 `_loadShelfMaps` 的口径：一次 getAllCollectionItems
+  /// 内存分组，不逐合集 N+1；memberSortIndex 只记主折叠合集的行）。
+  Future<void> _loadCollectionMaps() async {
+    final HibikiDatabase db = _appModel.database;
+    final List<MediaCollectionRow> collections =
+        await db.getAllMediaCollections();
+    final Map<String, int> primaryMap =
+        await db.getPrimaryCollectionIdByEntry();
+    final Map<String, int> memberSortIndex = <String, int>{};
+    for (final MediaCollectionItemRow m in await db.getAllCollectionItems()) {
+      final String key = '${m.mediaType}|${m.entryKey}';
+      if (primaryMap[key] == m.collectionId) memberSortIndex[key] = m.sortIndex;
+    }
+    _collectionsById = <int, MediaCollectionRow>{
+      for (final MediaCollectionRow c in collections) c.id: c,
+    };
+    _primaryCollectionByEntry = primaryMap;
+    _memberSortIndex = memberSortIndex;
   }
 
   /// 把仓储缓存同步到本页（仓储的每个写方法内部已重载）。
@@ -192,11 +235,12 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
 
   /// 把新封面路径写回条目并刷新。
   ///
-  /// 必须先 `imageCache.evict`：[FileImage] 按 `(path, scale)` 缓存解码结果，换封面
-  /// 常常落在**同一个** `<id>.<ext>` 路径上，不驱逐旧条目的话 UI 重建会命中旧解码，
-  /// 用户看到的还是换之前那张图（与视频封面同一个坑，见 `setVideoCoverFromPickedFile`）。
+  /// 必须先驱逐旧解码缓存：换封面常常落在**同一个** `<id>.<ext>` 路径上，不驱逐的话
+  /// UI 重建会命中旧解码，用户看到的还是换之前那张图（与视频封面同一个坑，见
+  /// `setVideoCoverFromPickedFile`）。卡片经 [ShelfFileCover] 走降采样键，裸
+  /// FileImage 键与 ResizeImage 键都要清（[evictLocalCoverCache]）。
   Future<void> _applyCover(GalgameEntry game, String coverPath) async {
-    PaintingBinding.instance.imageCache.evict(FileImage(File(coverPath)));
+    await evictLocalCoverCache(coverPath);
     // 后台补齐期间用户可能已删掉这条：仓储按 id 更新，行不在就是空操作。
     if (_repo.byId(game.id) == null) return;
     await _repo.setCoverPath(game.id, coverPath);
@@ -277,6 +321,74 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
       ),
     );
     await _reload();
+  }
+
+  /// 单卡「加入合集」：与书/视频同走 [showAddToCollectionDialog]（同一条
+  /// createMediaCollection / addToCollection DAO 路径）；成功后重取分组映射刷新。
+  Future<void> _addGameToCollection(GalgameEntry game) async {
+    final bool added = await showAddToCollectionDialog(
+      context: context,
+      database: _appModel.database,
+      mediaType: kGameCollectionMediaType,
+      entryKey: game.id,
+      defaultNewName: game.displayName,
+    );
+    if (!added || !mounted) return;
+    await _loadCollectionMaps();
+    _refresh();
+  }
+
+  /// 合集横排行折叠开关（游戏库独立偏好命名空间，见
+  /// [PreferencesRepository.gamesCollapsedCollectionIds]）。setPref 先同步刷内存
+  /// 缓存，setState 重建即读到新值；落库 fire-and-forget（与书架同模式）。
+  void _toggleCollectionCollapsed(int collectionId) {
+    final Set<int> ids = _appModel.prefsRepo.gamesCollapsedCollectionIds;
+    if (!ids.remove(collectionId)) ids.add(collectionId);
+    unawaited(_appModel.prefsRepo.setGamesCollapsedCollectionIds(ids));
+    setState(() {});
+  }
+
+  /// 行头「查看全部」→ 通用合集网格详情页。game 成员用游戏卡渲染、点击进详情页；
+  /// 非 game 成员（混合合集里的书/视频）builder 返 null 由详情页跳过——书架/视频页
+  /// 打开同一合集时依旧渲染它们自己的成员，互不越界。
+  ///
+  /// 不注入 [MediaCollectionGridDetailPage.onDeleteMembersMedia]：game 维度先只支持
+  /// 解散合集不删游戏本体（对齐「删除合集不删媒体本体、勾选才删」语义的保守端——
+  /// 游戏本体是用户安装目录，绝不能从合集路径误删）。
+  void _openCollectionDetail(MediaCollectionRow collection) {
+    Navigator.push<void>(
+      context,
+      adaptivePageRoute<void>(
+        context: context,
+        builder: (_) => MediaCollectionGridDetailPage(
+          database: _appModel.database,
+          collection: collection,
+          memberCardBuilder: (
+            String mediaType,
+            String entryKey, {
+            VoidCallback? onRemoveFromCollection,
+          }) =>
+              buildGameCollectionMemberCard(
+            games: _games,
+            mediaType: mediaType,
+            entryKey: entryKey,
+          ),
+          onOpenMember: _openCollectionMember,
+          onChanged: () {
+            unawaited(_reload());
+          },
+        ),
+      ),
+    );
+  }
+
+  /// 合集详情页「打开成员」：game 成员进详情页（含启动按钮，复用库页带再入守卫的
+  /// [_launchGame]）；其它 mediaType 非本页职责，忽略。
+  void _openCollectionMember(String mediaType, String entryKey) {
+    if (mediaType != kGameCollectionMediaType) return;
+    final GalgameEntry? game = _repo.byId(entryKey);
+    if (game == null) return;
+    unawaited(_openDetail(game));
   }
 
   /// 弹一个单行输入对话框返回用户输入的名称（取消返回 null）。
@@ -638,39 +750,157 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   }
 
   /// 游戏海报网格（对齐 ReinaManager 库页：3:4 竖版海报卡，见
-  /// `docs/design/galgame-library-reina-visual-parity.md` §1）。
+  /// `docs/design/galgame-library-reina-visual-parity.md` §1）+ 合集分区。
   ///
   /// 不再套书架的 extent/比例：galgame 是竖版海报（3:4 封面 + 下方标题），与横向
-  /// 偏方的书封不同形。maxCrossAxisExtent≈168（ReinaManager 海报宽档），间距 16，
+  /// 偏方的书封不同形。目标卡宽≈168（ReinaManager 海报宽档），间距 16，
   /// childAspectRatio 按「3:4 封面 + 一行标题」估（约 0.62），标题超长由卡内省略。
+  ///
+  /// 合集渲染照书架分区范式（去碎片方案 A+顶部）：属合集的游戏折进
+  /// [CollectionShelfRow] 横排行集中在前，散卡合成单一 SliverGrid 在后；排序/筛选
+  /// 作用于 [_visible]（散卡序与成员存活），组内成员序走合集 sortIndex（与书架/
+  /// 详情页同一顺序真相源）。
   Widget _buildGrid(BuildContext context, List<GalgameEntry> visible) {
+    final List<CollectionGroup<GalgameEntry>> groups =
+        groupByCollections<GalgameEntry>(
+      items: <CollectionOrderingItem<GalgameEntry>>[
+        for (final GalgameEntry game in visible)
+          CollectionOrderingItem<GalgameEntry>(
+            mediaType: kGameCollectionMediaType,
+            entryKey: game.id,
+            importedAt: game.addedAt.millisecondsSinceEpoch,
+            payload: game,
+          ),
+      ],
+      primaryCollectionIdByEntry: _primaryCollectionByEntry,
+      collectionsById: _collectionsById,
+      memberSortIndex: _memberSortIndex,
+    );
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        return GridView.builder(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 88),
-          gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-            maxCrossAxisExtent: 168,
-            mainAxisSpacing: 16,
-            crossAxisSpacing: 16,
-            childAspectRatio: 0.62,
-          ),
-          itemCount: visible.length,
-          itemBuilder: (BuildContext context, int i) => _GameCard(
-            game: visible[i],
-            sortLabel: galgameSortValueLabel(visible[i], _view.sortField),
-            onTap: () => unawaited(_launchGame(visible[i])),
-            onRename: () => unawaited(_renameGame(visible[i])),
-            onRemove: () => unawaited(_removeGame(visible[i])),
-            onSetCover: () => unawaited(_setCover(visible[i])),
-            onAutoCover: () => unawaited(_autoCover(visible[i])),
-            onPlayStatus: () => unawaited(_promptPlayStatus(visible[i])),
-            onDetail: () => unawaited(_openDetail(visible[i])),
-            onScrape: () => unawaited(_openDetail(visible[i], initialTab: 2)),
-          ),
+        // 复算 MaxCrossAxisExtent(168) 的列数/卡宽（ceil→卡宽 ≤168），供合集行
+        // 成员卡与散卡网格取同一实际卡宽，行内卡与网格卡逐像素同尺寸。
+        const double spacing = 16;
+        const double targetExtent = 168;
+        const double aspect = 0.62;
+        final double rawWidth = constraints.maxWidth - 32;
+        final double available = rawWidth < 1 ? 1 : rawWidth;
+        final int columns = ((available + spacing) / (targetExtent + spacing))
+            .ceil()
+            .clamp(1, 1 << 10);
+        final double cardWidth =
+            (available - (columns - 1) * spacing) / columns;
+        final List<Widget> slivers = <Widget>[];
+        final List<GalgameEntry> loose = <GalgameEntry>[];
+        for (final CollectionGroup<GalgameEntry> group in groups) {
+          final MediaCollectionRow? collection = group.collection;
+          if (collection == null) {
+            loose.add(group.coverItem.payload);
+          } else {
+            slivers.add(
+              SliverToBoxAdapter(
+                child: _buildCollectionRow(group, collection, cardWidth),
+              ),
+            );
+          }
+        }
+        if (loose.isNotEmpty) {
+          slivers.add(
+            SliverGrid.builder(
+              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: columns,
+                mainAxisSpacing: spacing,
+                crossAxisSpacing: spacing,
+                childAspectRatio: aspect,
+              ),
+              itemCount: loose.length,
+              itemBuilder: (BuildContext context, int i) =>
+                  _buildGameCard(loose[i]),
+            ),
+          );
+        }
+        return CustomScrollView(
+          slivers: <Widget>[
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 88),
+              sliver: SliverMainAxisGroup(slivers: slivers),
+            ),
+          ],
         );
       },
     );
   }
+
+  /// 一个游戏合集的横排行：行头（合集名 + 数量 + 查看全部 → 详情页）+ 行内成员
+  /// 游戏卡（与散卡同一渲染，交互/焦点自带）。折叠偏好走游戏库自己的命名空间。
+  Widget _buildCollectionRow(
+    CollectionGroup<GalgameEntry> group,
+    MediaCollectionRow collection,
+    double cardWidth,
+  ) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    // 槽比 0.62 = 宽/高 → 行高按同比换算，行内卡与网格卡同形。
+    final double rowHeight = cardWidth / 0.62;
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: tokens.spacing.gap / 2),
+      child: CollectionShelfRow(
+        key: ValueKey<String>('games_collection_row_${collection.id}'),
+        title: collection.name,
+        countLabel: t.series_item_count(n: group.items.length),
+        itemCount: group.items.length,
+        itemWidth: cardWidth,
+        rowHeight: rowHeight,
+        itemGap: 16,
+        headerFocusId: HibikiFocusId('games-collection-${collection.id}'),
+        onOpenDetail: () => _openCollectionDetail(collection),
+        collapsed: _appModel.prefsRepo.gamesCollapsedCollectionIds
+            .contains(collection.id),
+        onToggleCollapsed: () => _toggleCollectionCollapsed(collection.id),
+        itemBuilder: (BuildContext _, int i) =>
+            _buildGameCard(group.items[i].payload),
+      ),
+    );
+  }
+
+  /// 单张游戏卡（散卡网格与合集行内共用同一构造，回调全量接线）。
+  Widget _buildGameCard(GalgameEntry game) {
+    return _GameCard(
+      game: game,
+      sortLabel: galgameSortValueLabel(game, _view.sortField),
+      onTap: () => unawaited(_launchGame(game)),
+      onRename: () => unawaited(_renameGame(game)),
+      onRemove: () => unawaited(_removeGame(game)),
+      onSetCover: () => unawaited(_setCover(game)),
+      onAutoCover: () => unawaited(_autoCover(game)),
+      onPlayStatus: () => unawaited(_promptPlayStatus(game)),
+      onDetail: () => unawaited(_openDetail(game)),
+      onScrape: () => unawaited(_openDetail(game, initialTab: 2)),
+      onAddToCollection: () => unawaited(_addGameToCollection(game)),
+    );
+  }
+}
+
+/// 合集详情页的 game 成员卡（纯查找 + 纯 widget，顶层函数供 widget 测试直接驱动）。
+///
+/// 非 game 成员返回 null（详情页跳过，混合合集里的书/视频由各自页面渲染）；game
+/// 成员在 [games] 里找不到（已从库移除的孤儿引用）也返回 null。卡片不带 onTap——
+/// 详情页网格统一接管激活（[MediaCollectionGridDetailPage.onOpenMember]）与
+/// 上下文菜单（移出合集）。
+Widget? buildGameCollectionMemberCard({
+  required List<GalgameEntry> games,
+  required String mediaType,
+  required String entryKey,
+}) {
+  if (mediaType != kGameCollectionMediaType) return null;
+  for (final GalgameEntry game in games) {
+    if (game.id == entryKey) {
+      return GalgamePosterCard(
+        cover: GameCoverThumb(game: game),
+        title: game.displayName,
+      );
+    }
+  }
+  return null;
 }
 
 /// 游玩状态的用户可读标签（枚举 `.name` 直接上屏是 17 语言用户的灾难）。
@@ -789,6 +1019,7 @@ class _GameCard extends StatelessWidget {
     required this.onPlayStatus,
     required this.onDetail,
     required this.onScrape,
+    required this.onAddToCollection,
     this.sortLabel,
   });
 
@@ -805,39 +1036,120 @@ class _GameCard extends StatelessWidget {
   final VoidCallback onPlayStatus;
   final VoidCallback onDetail;
   final VoidCallback onScrape;
+  final VoidCallback onAddToCollection;
 
-  /// 长按 / 右键的上下文菜单：与封面溢出菜单同项。两处菜单**共用**
-  /// [_menuItems] 与 [_dispatchAction]，避免两份手抄。
+  /// 长按 / 右键的上下文菜单：与书卡/视频卡同款 [MediaItemDialogFrame]（封面块 +
+  /// 快捷动作 chips + 底部危险区），替代旧手搓 SimpleDialog。菜单项与封面溢出菜单
+  /// **共用** [_menuItems] 与 [_dispatchAction]，避免两份手抄。
   Future<void> _showContextMenu(BuildContext context) async {
-    final String? action = await showDialog<String>(
+    await showAppDialog<void>(
       context: context,
-      builder: (BuildContext ctx) => SimpleDialog(
-        title: Text(
-          game.displayName,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
-        children: <Widget>[
-          for (final (String value, String label) item in _menuItems)
-            SimpleDialogOption(
-              onPressed: () => Navigator.of(ctx).pop(item.$1),
-              child: Text(item.$2),
-            ),
+      builder: (BuildContext dialogContext) => MediaItemDialogFrame(
+        cover: _dialogCover(dialogContext),
+        title: game.displayName,
+        showLaunchAction: false,
+        quickActions: <DialogQuickAction>[
+          for (final _GameMenuItem item in _menuItems)
+            if (!item.danger)
+              DialogQuickAction(
+                label: item.label,
+                icon: item.icon,
+                onPressed: () {
+                  Navigator.pop(dialogContext);
+                  _dispatchAction(item.action);
+                },
+              ),
+        ],
+        dangerActions: <DialogDangerAction>[
+          for (final _GameMenuItem item in _menuItems)
+            if (item.danger)
+              DialogDangerAction(
+                label: item.label,
+                icon: item.icon,
+                onPressed: () {
+                  Navigator.pop(dialogContext);
+                  _dispatchAction(item.action);
+                },
+              ),
         ],
       ),
     );
-    if (action != null) _dispatchAction(action);
   }
 
-  /// 卡片菜单项单一真相源：`(action, 文案)`。
-  List<(String, String)> get _menuItems => <(String, String)>[
-        ('detail', t.games_view_detail),
-        ('status', t.games_play_status),
-        ('scrape', t.games_scrape),
-        ('rename', t.games_rename),
-        ('cover', t.games_set_cover),
-        ('autocover', t.games_auto_cover),
-        ('remove', t.games_remove),
+  /// 长按对话框顶部的封面块：有封面文件用降采样图（BoxFit.contain 整图可见），
+  /// 无封面用与书架长按框同规格的占位图标（size 40 / onSurfaceVariant）。
+  Widget _dialogCover(BuildContext context) {
+    final String? cover = game.coverPath;
+    if (cover != null && cover.isNotEmpty && File(cover).existsSync()) {
+      return ShelfFileCover(
+        path: cover,
+        placeholder: const SizedBox.shrink(),
+        fit: BoxFit.contain,
+      );
+    }
+    return SizedBox(
+      height: 120,
+      child: Center(
+        child: Icon(
+          Icons.videogame_asset,
+          size: 40,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+
+  /// 卡片菜单项单一真相源：`(action, 文案, 图标, 危险区)`。溢出菜单与长按/右键
+  /// 对话框都从这一份生成，任一处漏项测试即红。
+  List<_GameMenuItem> get _menuItems => <_GameMenuItem>[
+        (
+          action: 'detail',
+          label: t.games_view_detail,
+          icon: Icons.info_outline,
+          danger: false,
+        ),
+        (
+          action: 'status',
+          label: t.games_play_status,
+          icon: Icons.flag_outlined,
+          danger: false,
+        ),
+        (
+          action: 'scrape',
+          label: t.games_scrape,
+          icon: Icons.cloud_download_outlined,
+          danger: false,
+        ),
+        (
+          action: 'rename',
+          label: t.games_rename,
+          icon: Icons.drive_file_rename_outline,
+          danger: false,
+        ),
+        (
+          action: 'cover',
+          label: t.games_set_cover,
+          icon: Icons.image_outlined,
+          danger: false,
+        ),
+        (
+          action: 'autocover',
+          label: t.games_auto_cover,
+          icon: Icons.image_search,
+          danger: false,
+        ),
+        (
+          action: 'collect',
+          label: t.add_to_collection,
+          icon: Icons.collections_bookmark_outlined,
+          danger: false,
+        ),
+        (
+          action: 'remove',
+          label: t.games_remove,
+          icon: Icons.delete_outline,
+          danger: true,
+        ),
       ];
 
   void _dispatchAction(String action) {
@@ -854,6 +1166,8 @@ class _GameCard extends StatelessWidget {
         onSetCover();
       case 'autocover':
         onAutoCover();
+      case 'collect':
+        onAddToCollection();
       case 'remove':
         onRemove();
     }
@@ -868,7 +1182,7 @@ class _GameCard extends StatelessWidget {
     // 浮层 + hover 放大 + 主色选中环，全部由共享组件 [GalgamePosterCard] 负责。
     // focusId 沿用 `game-card-<id>`（手柄/键盘可 requestById 聚焦，focus 测试守）。
     return GalgamePosterCard(
-      cover: _buildCover(colors),
+      cover: GameCoverThumb(game: game),
       title: game.displayName,
       overlayText: sort,
       focusId: HibikiFocusId('game-card-${game.id}'),
@@ -900,38 +1214,44 @@ class _GameCard extends StatelessWidget {
       ),
       onSelected: _dispatchAction,
       itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
-        for (final (String value, String label) item in _menuItems)
-          PopupMenuItem<String>(value: item.$1, child: Text(item.$2)),
+        for (final _GameMenuItem item in _menuItems)
+          PopupMenuItem<String>(value: item.action, child: Text(item.label)),
       ],
     );
   }
+}
 
-  // ── 旧的手搭卡片（HibikiCard + Stack + 手抄标题 footer）已由上面的
-  //    GalgamePosterCard 取代，_buildCover / _defaultCover 仍复用。──
+/// 游戏卡菜单项：action 键 + 文案 + 图标 + 是否落危险区（对话框底部红字）。
+typedef _GameMenuItem = ({
+  String action,
+  String label,
+  IconData icon,
+  bool danger,
+});
 
-  /// 封面：有 coverPath 且文件存在则显示图片，否则默认手柄图标占位。
-  Widget _buildCover(ColorScheme colors) {
+/// 游戏封面缩略图（库页卡片 / 合集行成员卡 / 合集详情成员卡共用）。
+///
+/// 有 coverPath 且文件真实存在 → 经 [ShelfFileCover] 降采样加载（BUG-959 同类：
+/// 旧裸 `Image.file` 整帧解码游戏包装图会撑爆 ImageCache）；否则共享占位件
+/// [ShelfCoverPlaceholder]（保留原 surfaceContainerHighest 底色 + 手柄图标 48）。
+/// existsSync 短路语义保留：缺失文件直接画占位，不进图片加载失败路径。
+class GameCoverThumb extends StatelessWidget {
+  const GameCoverThumb({required this.game, super.key});
+
+  final GalgameEntry game;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final Widget placeholder = ShelfCoverPlaceholder(
+      icon: Icons.videogame_asset,
+      iconSize: 48,
+      backgroundColor: colors.surfaceContainerHighest,
+    );
     final String? cover = game.coverPath;
     if (cover != null && cover.isNotEmpty && File(cover).existsSync()) {
-      return Image.file(
-        File(cover),
-        fit: BoxFit.cover,
-        errorBuilder: (BuildContext context, Object error, StackTrace? stack) =>
-            _defaultCover(colors),
-      );
+      return ShelfFileCover(path: cover, placeholder: placeholder);
     }
-    return _defaultCover(colors);
-  }
-
-  Widget _defaultCover(ColorScheme colors) {
-    return Container(
-      color: colors.surfaceContainerHighest,
-      alignment: Alignment.center,
-      child: Icon(
-        Icons.videogame_asset,
-        size: 48,
-        color: colors.onSurfaceVariant,
-      ),
-    );
+    return placeholder;
   }
 }

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -43,6 +43,7 @@ import 'package:hibiki/src/storage/app_paths.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/pages/implementations/book_drag_target.dart';
 import 'package:hibiki/src/pages/implementations/collections_page.dart';
+import 'package:hibiki/src/media/collections/add_to_collection_dialog.dart';
 import 'package:hibiki/src/media/collections/batch_combine.dart';
 import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
@@ -1556,6 +1557,14 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
               _pickSubtitle(book);
             },
           ),
+          DialogQuickAction(
+            label: t.add_to_collection,
+            icon: Icons.collections_bookmark_outlined,
+            onPressed: () {
+              Navigator.pop(dialogContext);
+              _addToCollection(book);
+            },
+          ),
         ],
         dangerActions: <DialogDangerAction>[
           DialogDangerAction(
@@ -1579,6 +1588,21 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     final String? subtitlePath = result?.files.single.path;
     if (subtitlePath == null || !mounted) return;
     await _attachSubtitleToVideoCard(book, subtitlePath);
+  }
+
+  /// 单卡「加入合集」：entryKey 与批量组合三档同一编码——视频选择键就是裸
+  /// bookUid（见 [shelfSelectionToEntry] 的 video 分支），落库同走
+  /// addToCollection DAO；成功后按 [_combineAddToExisting] 同款
+  /// [_loadLibraryMaps] 刷新分组/网格。
+  Future<void> _addToCollection(VideoBookRow book) async {
+    final bool added = await showAddToCollectionDialog(
+      context: context,
+      database: ref.read(appProvider).database,
+      mediaType: 'video',
+      entryKey: book.bookUid,
+    );
+    if (!added || !mounted) return;
+    await _loadLibraryMaps();
   }
 
   Future<void> _editTags(VideoBookRow book) async {
@@ -2496,21 +2520,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
                   Positioned(
                     top: 6,
                     left: 6,
-                    child: _buildSelectionCheck(selected),
+                    child: ShelfSelectionCheck(selected: selected),
                   ),
                 if (selected)
-                  Positioned.fill(
-                    child: IgnorePointer(
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          color: Theme.of(context)
-                              .colorScheme
-                              .primary
-                              .withValues(alpha: 0.12),
-                        ),
-                      ),
-                    ),
-                  ),
+                  const Positioned.fill(child: ShelfSelectedOverlay()),
               ],
             ),
           ),
@@ -2568,7 +2581,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         // 前景」填充；解码上限与旧 cacheWidth 同源（resizedFileImage 默认 720）。
         return PosterCoverImage(
           image: resizedFileImage(File(cover)),
-          errorBuilder: (BuildContext _) => _coverPlaceholder(),
+          errorBuilder: (BuildContext _) => ShelfCoverPlaceholder(
+            icon: Icons.movie_outlined,
+            backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+          ),
         );
       }
     }
@@ -2580,7 +2596,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
               (remote.coverUrl != null && remote.coverUrl!.isNotEmpty);
       if (hasCover) return _buildRemoteVideoCover(remote, poster: true);
     }
-    return _coverPlaceholder();
+    return ShelfCoverPlaceholder(
+      icon: Icons.movie_outlined,
+      backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+    );
   }
 
   /// 合集卡进度行：有观看痕迹且未整套看完 → 「继续看 第n集」（[continueMemberIndex]
@@ -2729,7 +2748,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         return PosterCoverImage(
           image: FileImage(File(coverPath)),
           imageKey: coverKey,
-          errorBuilder: (BuildContext _) => _coverPlaceholder(),
+          errorBuilder: (BuildContext _) => ShelfCoverPlaceholder(
+            icon: Icons.movie_outlined,
+            backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+          ),
         );
       }
       return _coverBacking(
@@ -2737,7 +2759,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
           File(coverPath),
           key: coverKey,
           fit: BoxFit.contain,
-          errorBuilder: (_, __, ___) => _coverPlaceholder(),
+          errorBuilder: (_, __, ___) => ShelfCoverPlaceholder(
+            icon: Icons.movie_outlined,
+            backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+          ),
         ),
       );
     }
@@ -2754,7 +2779,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         return PosterCoverImage(
           image: remoteImage,
           imageKey: coverKey,
-          errorBuilder: (BuildContext _) => _coverPlaceholder(),
+          errorBuilder: (BuildContext _) => ShelfCoverPlaceholder(
+            icon: Icons.movie_outlined,
+            backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+          ),
         );
       }
       return _coverBacking(
@@ -2763,15 +2791,21 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
           key: coverKey,
           // 非 16:9 源 contain 完整显示，同上衬底。
           fit: BoxFit.contain,
-          errorBuilder: (_, __, ___) => _coverPlaceholder(),
+          errorBuilder: (_, __, ___) => ShelfCoverPlaceholder(
+            icon: Icons.movie_outlined,
+            backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+          ),
         ),
       );
     }
-    return _coverPlaceholder();
+    return ShelfCoverPlaceholder(
+      icon: Icons.movie_outlined,
+      backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+    );
   }
 
   /// 封面衬底（UI 巡检 PR-4）：contain 的非 16:9 封面在 16:9 槽位里露出的空带
-  /// 垫 surfaceContainer（与 [_coverPlaceholder] 同色），本地 / 远端卡共用。
+  /// 垫 surfaceContainer（与共享 [ShelfCoverPlaceholder] 占位同色），本地 / 远端卡共用。
   Widget _coverBacking(Widget cover) {
     return ColoredBox(
       color: Theme.of(context).colorScheme.surfaceContainer,
@@ -3163,21 +3197,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
                   Positioned(
                     top: 6,
                     left: 6,
-                    child: _buildSelectionCheck(selected),
+                    child: ShelfSelectionCheck(selected: selected),
                   ),
                 if (selected)
-                  Positioned.fill(
-                    child: IgnorePointer(
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          color: Theme.of(context)
-                              .colorScheme
-                              .primary
-                              .withValues(alpha: 0.12),
-                        ),
-                      ),
-                    ),
-                  ),
+                  const Positioned.fill(child: ShelfSelectedOverlay()),
                 // TODO-1346：观看进度条（贴封面底部，YouTube 式）。多集按「看到第几集」，
                 // 单视频仅已看完满格；无可展示进度（watchFrac==null）时不画。
                 if (watchFrac != null)
@@ -3265,34 +3288,6 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         t.video_last_watched(date: _formatOverviewDate(watched)),
     ];
     return parts.join(' · ');
-  }
-
-  /// 批量选择勾选标记：选中实心对勾，未选空心圆（与书架 _buildBookCard 一致）。
-  Widget _buildSelectionCheck(bool selected) {
-    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
-    final Color selectionColor = tokens.surfaces.primary;
-    return IgnorePointer(
-      child: Container(
-        decoration: BoxDecoration(
-          color: selected
-              ? selectionColor
-              : tokens.surfaces.page.withValues(alpha: 0.7),
-          shape: BoxShape.circle,
-          border: Border.all(
-            color: selected ? selectionColor : tokens.surfaces.outline,
-            width: 1.5,
-          ),
-        ),
-        padding: EdgeInsets.all(tokens.spacing.gap / 4),
-        child: Icon(
-          Icons.check,
-          size: tokens.spacing.gap * 1.75,
-          color: selected
-              ? Theme.of(context).colorScheme.onPrimary
-              : Colors.transparent,
-        ),
-      ),
-    );
   }
 
   /// 批量操作栏（底部，仅选择态显示）：选中计数 + 全选 / 反选 + 打标签 + 删除。
@@ -3410,13 +3405,19 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
     // 单卡一次 stat 成本极小；首屏真正的开销是解码尺寸（下方 cacheWidth 降采样）
     // 与 _repairMovedCoverPaths 的全库 stat（已改异步）。
     if (cover == null || cover.isEmpty || !File(cover).existsSync()) {
-      return _coverPlaceholder();
+      return ShelfCoverPlaceholder(
+        icon: Icons.movie_outlined,
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+      );
     }
     if (poster) {
       // 解码上限与下方 cacheWidth 同源（resizedFileImage 默认 720，BUG-959）。
       return PosterCoverImage(
         image: resizedFileImage(File(cover)),
-        errorBuilder: (BuildContext _) => _coverPlaceholder(),
+        errorBuilder: (BuildContext _) => ShelfCoverPlaceholder(
+          icon: Icons.movie_outlined,
+          backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+        ),
       );
     }
     // TODO-616 phase C / BUG-926 后注释更新（UI 巡检 PR-4）：非 poster 槽位保留
@@ -3427,18 +3428,10 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
         fit: BoxFit.contain,
         // BUG-959: 按物理像素上限解码，避免视频原生分辨率(1080p/4K)整帧撑爆 ImageCache。
         cacheWidth: kLocalCoverDecodePixelWidth,
-        errorBuilder: (_, __, ___) => _coverPlaceholder(),
-      ),
-    );
-  }
-
-  Widget _coverPlaceholder() {
-    final ColorScheme colors = Theme.of(context).colorScheme;
-    return ColoredBox(
-      color: colors.surfaceContainer,
-      child: Center(
-        child: Icon(Icons.movie_outlined,
-            size: 40, color: colors.onSurfaceVariant),
+        errorBuilder: (_, __, ___) => ShelfCoverPlaceholder(
+          icon: Icons.movie_outlined,
+          backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+        ),
       ),
     );
   }

--- a/hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart
@@ -4,6 +4,8 @@ import 'package:hibiki/src/media/collections/collection_shelf_row.dart'
     show unifiedShelfCardLayout;
 import 'package:hibiki/src/media/collections/shelf_sort.dart'
     show naturalCompare;
+import 'package:hibiki/src/mining/metadata/galgame_metadata_merge.dart'
+    show GalgameCustomData;
 import 'package:hibiki/src/pages/implementations/collection_detail_shared.dart';
 import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart'
     show kShelfBookCardAspectRatio;
@@ -108,16 +110,25 @@ class _MediaCollectionGridDetailPageState
 
   /// 一键整理（排序交互重设计层次 B2；覆盖 95% 场景，配合网格拖拽精修）：按名称 /
   /// 导入时间（旧→新）重排全表并落盘 sortIndex（`reorderCollectionItems`），库页合集行
-  /// 同源立即同序。标题/导入时间从 epub/srt 两表现查（成员行只有身份键）。
+  /// 同源立即同序。标题/导入时间从 epub/srt/galgames 三表现查（成员行只有身份键）。
   Future<void> _applyOneKeySort({required bool byTitle}) async {
     final List<EpubBookRow> epubs = await widget.database.getAllEpubBooks();
     final List<SrtBookRow> srts = await widget.database.getAllSrtBooks();
+    // game 成员（游戏库页打开本详情页）：标题取用户覆盖名（customDataJson.name）
+    // 优先，回落本地默认名；导入时间 = addedAt。查不到的类型仍走下面的
+    // (entryKey, 0) 兜底，不 throw。
+    final List<GalgameRow> games = await widget.database.getAllGalgames();
     final Map<String, ({String title, int importedAt})> meta =
         <String, ({String title, int importedAt})>{
       for (final EpubBookRow r in epubs)
         'epub|${r.bookKey}': (title: r.title, importedAt: r.importedAt),
       for (final SrtBookRow r in srts)
         'srt|${r.uid}': (title: r.title, importedAt: r.importedAt),
+      for (final GalgameRow r in games)
+        'game|${r.id}': (
+          title: GalgameCustomData.decode(r.customDataJson).name ?? r.name,
+          importedAt: r.addedAt,
+        ),
     };
     ({String title, int importedAt}) metaOf(MediaCollectionItemRow r) =>
         meta['${r.mediaType}|${r.entryKey}'] ??

--- a/hibiki/lib/src/pages/implementations/media_item_dialog_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_item_dialog_page.dart
@@ -225,7 +225,10 @@ class _MediaItemDialogPageState extends BasePageState<MediaItemDialogPage> {
 /// Title, author, and actions sit in the foreground using shared MD3 controls.
 /// The launch/read affordance is optional so shelf book long-press menus can
 /// stay management-only while ordinary history dialogs can still expose it.
-@visibleForTesting
+///
+/// 不是 `@visibleForTesting`：视频卡（`home_video_page._showVideoMenu`）与游戏卡
+/// （`games_library_page._GameCard`）的长按菜单在生产直接复用本骨架——它是三库
+/// 共用的正式 API，不再只服务测试。
 class MediaItemDialogFrame extends StatelessWidget {
   const MediaItemDialogFrame({
     required this.title,

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -33,6 +33,7 @@ import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/epub/epub_storage.dart';
 import 'package:hibiki/src/pages/implementations/book_css_editor_page.dart';
 import 'package:hibiki/src/pages/implementations/illustrations_viewer_page.dart';
+import 'package:hibiki/src/media/collections/add_to_collection_dialog.dart';
 import 'package:hibiki/src/media/collections/batch_combine.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
@@ -1456,6 +1457,12 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             compactDatabase: false,
           );
           anyVideo = true;
+        case 'game':
+          // 游戏成员**刻意跳过**：game 维度只支持解散合集不删本体——游戏本体是
+          // 用户安装目录（exe 及其资源），绝不能从合集删除路径连带删除；从库移除
+          // 走游戏库页自己的「移除」。合集引用行随后由 deleteMediaCollection
+          // cascade 清理，游戏回到游戏库散卡。
+          break;
       }
     }
     if (anyVideo) {
@@ -1502,6 +1509,8 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
       }
       return null;
     }
+    // 其它 mediaType（'video' / 'game' / 未来新增）：本页不认识 → 返 null 由详情页
+    // 跳过，不当成 epub 渲染。混合合集的 game 成员在游戏库页打开同一合集时渲染。
     return null;
   }
 
@@ -1667,7 +1676,9 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             extraActions: removeFromCollection == null
                 ? extraActions
                 : (MediaItem it) => <DialogAction>[
-                      ...extraActions(it),
+                      // 合集详情页成员卡语境：隐藏「加入合集」（同一条目在详情页
+                      // 语境下再加合集没有意义），只补「移出合集」。
+                      ..._epubExtraActions(it, inCollectionDetail: true),
                       DialogListAction(
                         label: t.collection_remove_member,
                         icon: Icons.remove_circle_outline,
@@ -1692,6 +1703,14 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
 
   @override
   List<DialogAction> extraActions(MediaItem item) {
+    return _epubExtraActions(item);
+  }
+
+  /// EPUB 书卡长按菜单动作真身。[inCollectionDetail] = 合集详情页成员卡语境
+  /// （菜单已注入「移出合集」）——该语境下隐藏「加入合集」，同一条目在详情页
+  /// 语境下再加合集没有意义。
+  List<DialogAction> _epubExtraActions(MediaItem item,
+      {bool inCollectionDetail = false}) {
     final String? bookKey = _parseBookKey(item.mediaIdentifier);
     if (bookKey == null) return const [];
     return <DialogAction>[
@@ -1718,6 +1737,14 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             : Icons.check_circle_outline,
         onPressed: () => _toggleBookCompleted(bookKey),
       ),
+      // 单卡「加入合集」：与批量三档共用同一 DAO 路径；entryKey 编码与
+      // shelfSelectionToEntry 对 epub 选择键的解码一致（= bookKey）。
+      if (!inCollectionDetail)
+        DialogListAction(
+          label: t.add_to_collection,
+          icon: Icons.collections_bookmark_outlined,
+          onPressed: () => _addEpubToCollection(item, bookKey),
+        ),
       DialogListAction(
         label: t.profile_book_profile,
         icon: Icons.account_circle_outlined,
@@ -1739,6 +1766,26 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
           onPressed: () => _toggleFloatingLyricFromShelf(bookKey),
         ),
     ];
+  }
+
+  /// 单卡「加入合集」（EPUB 卡菜单入口）：先收起长按菜单，再弹共享的合集选择
+  /// 弹窗（新建合集默认名 = 该书标题剥卷号，与批量档1同款推导）；加入成功后按
+  /// [_combineAddToExisting] 同款刷新（重取分组映射 + 重绘）。
+  Future<void> _addEpubToCollection(MediaItem item, String bookKey) async {
+    Navigator.pop(context);
+    final bool added = await showAddToCollectionDialog(
+      context: context,
+      database: appModel.database,
+      mediaType: 'epub',
+      entryKey: bookKey,
+      defaultNewName: deriveSeriesDefaultName(
+        <String>[item.title],
+        fallback: t.series_default_name,
+      ),
+    );
+    if (!added || !mounted) return;
+    _shelfMapsFuture = _loadShelfMaps();
+    _rebuild(() {});
   }
 
   /// 手动切换书 / 有声书「已读完」状态：写 EpubBooks.completedAt（单一真值，按

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -217,6 +217,19 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
             await _relocateSrtBookAudio(book);
           },
         ),
+      // 单卡「加入合集」：与 EPUB 卡菜单对称，纯字幕书（bookKey 为空）也可加入；
+      // entryKey 编码与 shelfSelectionToEntry 对 'srt_<uid>' 选择键的解码一致（= uid）。
+      // 合集详情页成员卡语境（已注入「移出合集」）不显示——同一条目在详情页语境下
+      // 再加合集没有意义。
+      if (removeFromCollection == null)
+        DialogListAction(
+          label: t.add_to_collection,
+          icon: Icons.collections_bookmark_outlined,
+          onPressed: () async {
+            Navigator.pop(dialogContext);
+            await _addSrtToCollection(book);
+          },
+        ),
       if (bookKey.isNotEmpty) ...[
         // 与 EPUB 卡菜单对称：手动「标记为已读完 / 取消」。有声书完成状态与 EPUB 共用
         // 同一 EpubBooks.completedAt（按配对 bookKey），故复用同一 [_toggleBookCompleted]。
@@ -232,8 +245,8 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
         // TODO-1191：与 EPUB 卡菜单对称补「查看插画」。仅在该 SRT 书有对应
         // EpubBooks 行（[_epubBackedBookKeys] 命中 = extractDir 存在）时展示，
         // 复用 EPUB 侧同一 [_openIllustrations]（自行 Navigator.pop + 打开
-        // [IllustrationsViewerPage]，无插图时页面友好占位）。「选择封面图片」照旧
-        // 保留——EPUB 卡不能选封面、SRT 卡可选是合理差异。
+        // [IllustrationsViewerPage]，无插图时页面友好占位）。菜单里的「选择封面
+        // 图片」动作已移除——选封面统一走「编辑信息」弹窗的封面字段（EPUB / SRT 皆可）。
         if (_epubBackedBookKeys.contains(bookKey))
           DialogQuickAction(
             label: t.view_illustrations,
@@ -274,6 +287,25 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
           ),
       ],
     ];
+  }
+
+  /// 单卡「加入合集」（SRT/有声书卡菜单入口）：弹共享的合集选择弹窗（新建合集
+  /// 默认名 = 该书标题剥卷号，与批量档1同款推导）；加入成功后按
+  /// [_combineAddToExisting] 同款刷新（重取分组映射 + 重绘）。
+  Future<void> _addSrtToCollection(SrtBook book) async {
+    final bool added = await showAddToCollectionDialog(
+      context: context,
+      database: appModel.database,
+      mediaType: 'srt',
+      entryKey: book.uid,
+      defaultNewName: deriveSeriesDefaultName(
+        <String>[book.title],
+        fallback: t.series_default_name,
+      ),
+    );
+    if (!added || !mounted) return;
+    _shelfMapsFuture = _loadShelfMaps();
+    _rebuild(() {});
   }
 
   Future<void> _showSrtBookDialog(SrtBook book,

--- a/hibiki/lib/src/sync/collection_manifest.dart
+++ b/hibiki/lib/src/sync/collection_manifest.dart
@@ -257,10 +257,13 @@ class CollectionManifestMember {
     required this.sortIndex,
   });
 
-  /// 'epub' | 'srt' | 'video'（同 MediaCollectionItems.mediaType 值域）。
+  /// 'epub' | 'srt' | 'video' | 'game'（同 MediaCollectionItems.mediaType 值域，
+  /// 引擎对值透传不解引用）。
   final String mediaType;
 
-  /// 条目稳定身份：epub=bookKey / srt=uid / video=bookUid。
+  /// 条目稳定身份：epub=bookKey / srt=uid / video=bookUid / game=galgames.id
+  /// （game 是本机局域身份：对端无对应 galgames 行时该成员在对端静默不渲染，
+  /// 归属关系仍随清单往返、不丢失）。
   final String entryKey;
 
   /// 合集内序（整合集 LWW 覆盖的载荷）。

--- a/hibiki/lib/src/utils/components/shelf_card_widgets.dart
+++ b/hibiki/lib/src/utils/components/shelf_card_widgets.dart
@@ -1,6 +1,10 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:hibiki/src/utils/adaptive/adaptive_platform.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
+import 'package:hibiki/src/utils/cover_image.dart';
+import 'package:transparent_image/transparent_image.dart';
 
 /// 书架卡片 footer / 勾选圈 / 选中罩的共享实现。
 ///
@@ -113,6 +117,78 @@ class ShelfSelectedOverlay extends StatelessWidget {
                 borderRadius: tokens.radii.cardRadius,
               ),
       ),
+    );
+  }
+}
+
+/// 无封面占位（书架 / 视频库 / 游戏库共用）。
+///
+/// 巡检 B11：深色主题下无封面占位（卡面色 ≈ 页面背景）与背景零对比，占位卡读作
+/// 一块空洞——统一补 1px 描边（tokens.surfaces.outline，全主题恒有；eink 的卡级
+/// 描边另由 HibikiCard 兜，叠加无害）。[backgroundColor] 供视频/游戏库保留各自的
+/// 高阶容器底色，书架传 null 维持无底色原样。
+class ShelfCoverPlaceholder extends StatelessWidget {
+  const ShelfCoverPlaceholder({
+    required this.icon,
+    this.iconSize = 40,
+    this.backgroundColor,
+    super.key,
+  });
+
+  final IconData icon;
+  final double iconSize;
+  final Color? backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    // 全走 tokens（tokens.surfaces.outline 即 scheme 的 outlineVariant、onVariant
+    // 即 onSurfaceVariant）：本文件被 MD3 静态守卫盯着，不许直读 scheme 的描边角色。
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        border: Border.all(color: tokens.surfaces.outline),
+        borderRadius: tokens.radii.cardRadius,
+      ),
+      child: Center(
+        child: Icon(
+          icon,
+          size: iconSize,
+          color: tokens.surfaces.onVariant,
+        ),
+      ),
+    );
+  }
+}
+
+/// 本地文件封面的统一加载（书架 / 视频库 / 游戏库共用）。
+///
+/// BUG-959：一律经 [resizedFileImage] 降采样解码，避免原始封面（EPUB 常
+/// 1600×2400、游戏包装图更大）整帧解码撑爆 ImageCache；FadeInImage 提供淡入与
+/// 解码失败回退 [placeholder]。文件是否存在由调用方判定（各页对缺失文件的
+/// 短路语义不同，不在此处吞）。
+class ShelfFileCover extends StatelessWidget {
+  const ShelfFileCover({
+    required this.path,
+    required this.placeholder,
+    this.fit = BoxFit.cover,
+    this.alignment = Alignment.center,
+    super.key,
+  });
+
+  final String path;
+  final Widget placeholder;
+  final BoxFit fit;
+  final Alignment alignment;
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeInImage(
+      imageErrorBuilder: (_, __, ___) => placeholder,
+      placeholder: MemoryImage(kTransparentImage),
+      image: resizedFileImage(File(path)),
+      alignment: alignment,
+      fit: fit,
     );
   }
 }

--- a/hibiki/lib/src/utils/cover_image.dart
+++ b/hibiki/lib/src/utils/cover_image.dart
@@ -23,3 +23,15 @@ ImageProvider resizedFileImage(
   int width = kLocalCoverDecodePixelWidth,
 }) =>
     ResizeImage(FileImage(file), width: width, allowUpscaling: false);
+
+/// 换封面（同路径覆盖写）后驱逐该路径的**全部**旧解码缓存条目。
+///
+/// [ImageCache] 按 provider key 存条目：裸 [FileImage] 与 [resizedFileImage]
+/// （[ResizeImage] 包装键）是**两个不同的 key**——只驱逐 FileImage 的话，走降采样
+/// 渲染的卡片重建时仍命中旧解码，用户看到的还是换之前那张图（游戏封面卡与视频
+/// 封面同坑，见 `setVideoCoverFromPickedFile` 注释）。两个键都清才干净。
+Future<void> evictLocalCoverCache(String path) async {
+  final File file = File(path);
+  await FileImage(file).evict();
+  await resizedFileImage(file).evict();
+}

--- a/hibiki/test/database/media_collections_game_member_test.dart
+++ b/hibiki/test/database/media_collections_game_member_test.dart
@@ -1,0 +1,89 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 游戏进合集：mediaType='game' 走既有合集 DAO 的往返测试。
+///
+/// 合集成员表对 mediaType 是自由字符串（无 CHECK / 无 FK），本测试钉住 'game'
+/// 成员的完整生命周期：加入（含墓碑清理路径）→ 读取 → 主折叠归属映射 → 移出
+/// （移空自删）→ 删合集 cascade，全程与 epub/video 成员同一条 DAO 路径。
+Future<HibikiDatabase> _openDb() async {
+  final HibikiDatabase db = HibikiDatabase.forTesting(NativeDatabase.memory());
+  addTearDown(db.close);
+  return db;
+}
+
+void main() {
+  test('addToCollection game 成员往返：写入 → 读取 → 归属映射', () async {
+    final HibikiDatabase db = await _openDb();
+    // 真实 galgames 行（entryKey = galgames.id，微秒时间戳字符串）。
+    await db.upsertGalgame(
+      GalgamesCompanion.insert(
+        id: '1753400000000001',
+        name: 'ATRI',
+        exePath: r'D:\games\atri\atri.exe',
+        workdir: r'D:\games\atri',
+        addedAt: 1753400000000,
+        coverPath: const Value<String?>(null),
+      ),
+    );
+    final int c = await db.createMediaCollection('ネコぱら全集');
+    await db.addToCollection(c, 'game', '1753400000000001');
+    await db.addToCollection(c, 'epub', 'book-1'); // 混合合集：书成员共存。
+
+    final List<MediaCollectionItemRow> items = await db.getCollectionItems(c);
+    expect(
+      items
+          .map((MediaCollectionItemRow m) => '${m.mediaType}|${m.entryKey}')
+          .toList(),
+      <String>['game|1753400000000001', 'epub|book-1'],
+    );
+
+    // 主折叠归属映射（游戏库分组用）按 'game|<id>' 键返回。
+    final Map<String, int> primary = await db.getPrimaryCollectionIdByEntry();
+    expect(primary['game|1753400000000001'], c);
+
+    // 幂等：重复加入不新增、不改序。
+    await db.addToCollection(c, 'game', '1753400000000001');
+    expect((await db.getCollectionItems(c)).length, 2);
+  });
+
+  test('removeFromCollection game 成员 → 移空自删 + 重加回不被墓碑吞', () async {
+    final HibikiDatabase db = await _openDb();
+    final int c = await db.createMediaCollection('G');
+    await db.addToCollection(c, 'game', 'g1');
+
+    await db.removeFromCollection(c, 'game', 'g1');
+    // 唯一成员移出 → 合集自删（与书/视频同语义）。
+    expect(await db.getMediaCollectionById(c), isNull);
+
+    // 重建同名合集再加回：addToCollection 自带墓碑清理，成员不被同步复活逻辑吞。
+    final int c2 = await db.createMediaCollection('G');
+    await db.addToCollection(c2, 'game', 'g1');
+    expect((await db.getCollectionItems(c2)).single.mediaType, 'game');
+  });
+
+  test('deleteMediaCollection cascade 清 game 引用行，不动 galgames 本体', () async {
+    final HibikiDatabase db = await _openDb();
+    await db.upsertGalgame(
+      GalgamesCompanion.insert(
+        id: 'g-keep',
+        name: 'keep',
+        exePath: r'D:\g\keep.exe',
+        workdir: r'D:\g',
+        addedAt: 1,
+      ),
+    );
+    final int c = await db.createMediaCollection('X');
+    await db.addToCollection(c, 'game', 'g-keep');
+    await db.deleteMediaCollection(c);
+
+    expect(await db.getAllCollectionItems(), isEmpty);
+    // 游戏本体行必须原样存活（合集只解链，绝不连带删游戏）。
+    expect(
+      (await db.getAllGalgames()).map((GalgameRow r) => r.id).toList(),
+      <String>['g-keep'],
+    );
+  });
+}

--- a/hibiki/test/media/collection_grouping_game_test.dart
+++ b/hibiki/test/media/collection_grouping_game_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/collections/collection_grouping.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 游戏进合集：'game' mediaType 经 [groupByCollections] 折叠的纯函数测试。
+///
+/// 分组核心是纯键运算（`'<mediaType>|<entryKey>'`），本测试钉住：game 成员正常
+/// 折进合集组、与同名 entryKey 的其它 mediaType 不串键、组内按 sortIndex 排序、
+/// 散游戏保持输入序。
+MediaCollectionRow _collection(int id, String name) => MediaCollectionRow(
+      id: id,
+      name: name,
+      collectionType: 'collection',
+      sortOrder: 0,
+      coverSource: null,
+      createdAt: 0,
+      orderUpdatedAt: 0,
+    );
+
+CollectionOrderingItem<String> _game(
+  String id, {
+  int importedAt = 0,
+}) =>
+    CollectionOrderingItem<String>(
+      mediaType: 'game',
+      entryKey: id,
+      importedAt: importedAt,
+      payload: 'game:$id',
+    );
+
+void main() {
+  test('game 成员折进合集组，散游戏保持输入序', () {
+    final Map<int, MediaCollectionRow> collections = <int, MediaCollectionRow>{
+      7: _collection(7, 'ネコぱら'),
+    };
+    final List<CollectionGroup<String>> groups = groupByCollections<String>(
+      items: <CollectionOrderingItem<String>>[
+        _game('g1'),
+        _game('g2'),
+        _game('g3'),
+      ],
+      primaryCollectionIdByEntry: <String, int>{
+        'game|g1': 7,
+        'game|g3': 7,
+      },
+      collectionsById: collections,
+      memberSortIndex: <String, int>{'game|g1': 1, 'game|g3': 0},
+    );
+
+    // g1 是合集首成员 → 合集组出现在 g1 的位置（首位）；g2 散卡随后。
+    expect(groups, hasLength(2));
+    expect(groups[0].collection?.id, 7);
+    // 组内按 memberSortIndex 升序：g3(0) 在 g1(1) 前。
+    expect(
+      groups[0].items.map((CollectionOrderingItem<String> it) => it.entryKey),
+      <String>['g3', 'g1'],
+    );
+    expect(groups[1].collection, isNull);
+    expect(groups[1].coverItem.entryKey, 'g2');
+  });
+
+  test('game 与同名 entryKey 的其它 mediaType 不串键', () {
+    final Map<int, MediaCollectionRow> collections = <int, MediaCollectionRow>{
+      1: _collection(1, 'mixed'),
+    };
+    final List<CollectionGroup<String>> groups = groupByCollections<String>(
+      items: <CollectionOrderingItem<String>>[
+        _game('same-key'),
+        const CollectionOrderingItem<String>(
+          mediaType: 'video',
+          entryKey: 'same-key',
+          importedAt: 0,
+          payload: 'video:same-key',
+        ),
+      ],
+      // 只有 video|same-key 归属合集；game|same-key 必须留在散卡。
+      primaryCollectionIdByEntry: <String, int>{'video|same-key': 1},
+      collectionsById: collections,
+      memberSortIndex: const <String, int>{},
+    );
+
+    expect(groups, hasLength(2));
+    expect(groups[0].collection, isNull);
+    expect(groups[0].coverItem.mediaType, 'game');
+    expect(groups[1].collection?.id, 1);
+    expect(groups[1].coverItem.mediaType, 'video');
+  });
+
+  test('归属合集已删（孤儿引用）→ game 退化为散卡，不丢条目', () {
+    final List<CollectionGroup<String>> groups = groupByCollections<String>(
+      items: <CollectionOrderingItem<String>>[_game('g1')],
+      primaryCollectionIdByEntry: <String, int>{'game|g1': 999},
+      collectionsById: const <int, MediaCollectionRow>{},
+      memberSortIndex: const <String, int>{},
+    );
+    expect(groups, hasLength(1));
+    expect(groups[0].collection, isNull);
+    expect(groups[0].coverItem.entryKey, 'g1');
+  });
+}

--- a/hibiki/test/mining/galgame_cover_download_test.dart
+++ b/hibiki/test/mining/galgame_cover_download_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/galgame_cover_download.dart';
+
+/// 刮削封面落地的决策纯函数测试（是否下载 / 扩展名推导）。
+///
+/// 下载 IO 本体（HttpClient GET）不在单测射程内——决策与推导拆成纯函数的目的
+/// 就是让「已有封面绝不覆盖」「扩展名归一」这些判定不用起网络就能钉死。
+void main() {
+  group('shouldAutoDownloadScrapedCover', () {
+    test('无可用封面 + 有 URL → 下载', () {
+      expect(
+        shouldAutoDownloadScrapedCover(
+          hasUsableCoverFile: false,
+          coverUrl: 'https://example.com/cover.jpg',
+        ),
+        isTrue,
+      );
+    });
+
+    test('已有可用封面文件（手选/自动/上次下载）→ 绝不覆盖', () {
+      expect(
+        shouldAutoDownloadScrapedCover(
+          hasUsableCoverFile: true,
+          coverUrl: 'https://example.com/cover.jpg',
+        ),
+        isFalse,
+      );
+    });
+
+    test('无 URL / 空白 URL → 不下载', () {
+      expect(
+        shouldAutoDownloadScrapedCover(
+          hasUsableCoverFile: false,
+          coverUrl: null,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldAutoDownloadScrapedCover(
+          hasUsableCoverFile: false,
+          coverUrl: '   ',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('galgameCoverExtension', () {
+    test('Content-Type 优先于 URL 后缀', () {
+      expect(
+        galgameCoverExtension(
+          url: 'https://example.com/cover.png',
+          contentType: 'image/jpeg',
+        ),
+        '.jpg',
+      );
+    });
+
+    test('Content-Type 带 charset 参数也能识别', () {
+      expect(
+        galgameCoverExtension(
+          url: 'https://example.com/x',
+          contentType: 'image/png; charset=utf-8',
+        ),
+        '.png',
+      );
+    });
+
+    test('无 Content-Type 时回落 URL 后缀（白名单内）', () {
+      expect(
+        galgameCoverExtension(url: 'https://example.com/a/b/cover.webp'),
+        '.webp',
+      );
+      // .jpeg 归一成 .jpg（与 saveGameCoverFromFile 的归一化一致）。
+      expect(
+        galgameCoverExtension(url: 'https://example.com/cover.JPEG'),
+        '.jpg',
+      );
+    });
+
+    test('URL 带查询串不影响后缀推导', () {
+      expect(
+        galgameCoverExtension(url: 'https://example.com/cover.png?w=600&h=800'),
+        '.png',
+      );
+    });
+
+    test('两头都推不出 → 回退 .jpg', () {
+      expect(galgameCoverExtension(url: 'https://example.com/cover'), '.jpg');
+      expect(
+        galgameCoverExtension(
+          url: 'https://example.com/cover.php',
+          contentType: 'application/octet-stream',
+        ),
+        '.jpg',
+      );
+    });
+  });
+}

--- a/hibiki/test/pages/booklongpress_floating_lyric_toggle_test.dart
+++ b/hibiki/test/pages/booklongpress_floating_lyric_toggle_test.dart
@@ -101,6 +101,40 @@ void main() {
     );
   });
 
+  test('单卡长按菜单含「加入合集」入口，合集详情页语境隐藏', () {
+    final String epubActions = _sectionSource(
+      src,
+      'List<DialogAction> extraActions(MediaItem item) {',
+      '  String? _parseBookKey(String mediaIdentifier) =>',
+    );
+    final String srtActions = _sectionSource(
+      src,
+      'List<DialogAction> _srtExtraActions(',
+      '  Future<void> _showSrtBookDialog(',
+    );
+    // EPUB 卡：有入口，entryKey 编码与批量三档一致（epub → bookKey），
+    // 合集详情页成员卡语境（inCollectionDetail）隐藏。
+    expect(epubActions, contains('t.add_to_collection'));
+    expect(epubActions, contains("mediaType: 'epub'"));
+    expect(epubActions, contains('entryKey: bookKey'));
+    expect(epubActions, contains('if (!inCollectionDetail)'));
+    // SRT/有声书卡：有入口，entryKey 编码一致（srt → uid），详情页注入
+    // 「移出合集」时隐藏（removeFromCollection 非空）。
+    expect(srtActions, contains('t.add_to_collection'));
+    expect(srtActions, contains("mediaType: 'srt'"));
+    expect(srtActions, contains('entryKey: book.uid'));
+    expect(srtActions, contains('if (removeFromCollection == null)'));
+    // 合集详情页渲染路径必须真的走 inCollectionDetail: true（隐藏加入入口）。
+    expect(
+      src,
+      contains('_epubExtraActions(it, inCollectionDetail: true)'),
+      reason: '详情页成员卡菜单必须经 inCollectionDetail 隐藏「加入合集」。',
+    );
+    // 两侧落库都走共享单卡弹窗（与批量三档同一 addToCollection DAO 路径）。
+    expect(epubActions, contains('showAddToCollectionDialog'));
+    expect(srtActions, contains('showAddToCollectionDialog'));
+  });
+
   test('SRT 卡长按菜单对称补「查看插画」并 EPUB-backed 门控（TODO-1191）', () {
     final String srtActions = _sectionSource(
       src,

--- a/hibiki/test/pages/games_collection_detail_test.dart
+++ b/hibiki/test/pages/games_collection_detail_test.dart
@@ -1,0 +1,107 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:hibiki/src/mining/galgame_library.dart';
+import 'package:hibiki/src/pages/implementations/games_library_page.dart';
+import 'package:hibiki/src/pages/implementations/media_collection_grid_detail_page.dart';
+import 'package:hibiki/utils.dart';
+
+/// 游戏进合集：通用合集网格详情页（[MediaCollectionGridDetailPage]）加载 'game'
+/// 成员的 widget 测试。
+///
+/// 钉住三条：
+/// 1. game 成员经 [buildGameCollectionMemberCard] 用游戏卡视觉（[GalgamePosterCard]）
+///    渲染，标题上屏；
+/// 2. 库里找不到的 game 孤儿引用返回 null → 详情页跳过、不崩；
+/// 3. 非 game mediaType 交回 null（书/SRT 由书架页自己的 builder 渲染，本 builder
+///    不越界），混合合集里书成员在游戏侧详情不渲染也不误当游戏。
+void main() {
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  GalgameEntry entry(String id, String name) => GalgameEntry(
+        id: id,
+        name: name,
+        exePath: 'Z:\\missing\\$id.exe',
+        workdir: r'Z:\missing',
+        addedAt: DateTime(2026),
+      );
+
+  test('buildGameCollectionMemberCard：查找/越界/孤儿三态', () {
+    final List<GalgameEntry> games = <GalgameEntry>[entry('g1', 'ATRI')];
+    expect(
+      buildGameCollectionMemberCard(
+        games: games,
+        mediaType: 'game',
+        entryKey: 'g1',
+      ),
+      isA<Widget>(),
+    );
+    // 孤儿引用（游戏已从库移除）→ null，详情页跳过。
+    expect(
+      buildGameCollectionMemberCard(
+        games: games,
+        mediaType: 'game',
+        entryKey: 'gone',
+      ),
+      isNull,
+    );
+    // 非 game mediaType → null（不把 epub 行误当游戏渲染）。
+    expect(
+      buildGameCollectionMemberCard(
+        games: games,
+        mediaType: 'epub',
+        entryKey: 'g1',
+      ),
+      isNull,
+    );
+  });
+
+  testWidgets('合集详情页渲染 game 成员卡；孤儿与书成员被跳过', (WidgetTester tester) async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final int c = await db.createMediaCollection('ネコぱら全集');
+    await db.addToCollection(c, 'game', 'g1');
+    await db.addToCollection(c, 'game', 'gone'); // 孤儿：库里无此游戏。
+    await db.addToCollection(c, 'epub', 'book-1'); // 混合合集：书成员。
+    final MediaCollectionRow collection = (await db.getMediaCollectionById(c))!;
+
+    final List<GalgameEntry> games = <GalgameEntry>[entry('g1', 'ATRI')];
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          home: MediaCollectionGridDetailPage(
+            database: db,
+            collection: collection,
+            memberCardBuilder: (
+              String mediaType,
+              String entryKey, {
+              VoidCallback? onRemoveFromCollection,
+            }) =>
+                buildGameCollectionMemberCard(
+              games: games,
+              mediaType: mediaType,
+              entryKey: entryKey,
+            ),
+            onChanged: () {},
+          ),
+        ),
+      ),
+    );
+    // initState 里 getCollectionItems 异步返回后再重建。
+    await tester.pumpAndSettle();
+
+    // 在库的 game 成员用游戏卡视觉渲染、标题上屏。
+    expect(find.byType(GalgamePosterCard), findsOneWidget);
+    expect(find.text('ATRI'), findsOneWidget);
+    // 孤儿 game 引用与 epub 成员都被跳过：不渲染、不崩、不出现幽灵卡。
+    expect(find.text('gone'), findsNothing);
+    expect(find.text('book-1'), findsNothing);
+  });
+}

--- a/hibiki/test/pages/games_library_cover_menu_test.dart
+++ b/hibiki/test/pages/games_library_cover_menu_test.dart
@@ -12,6 +12,8 @@ import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/games_library_page.dart';
+import 'package:hibiki/src/pages/implementations/media_item_dialog_page.dart'
+    show MediaItemDialogFrame;
 import 'package:hibiki/utils.dart';
 
 import '../helpers/test_platform_services.dart';
@@ -68,7 +70,20 @@ void main() {
     await tester.pump();
   }
 
-  testWidgets('溢出菜单含设置封面 / 自动获取封面', (WidgetTester tester) async {
+  /// 卡片菜单应含的全部项（与 `_GameCard._menuItems` 单一真相源对账：任一处漏项
+  /// 本表即断言失败）。'remove' 在长按对话框落危险区，但文案仍必须在场。
+  List<String> menuLabels() => <String>[
+        t.games_view_detail,
+        t.games_play_status,
+        t.games_scrape,
+        t.games_rename,
+        t.games_set_cover,
+        t.games_auto_cover,
+        t.add_to_collection,
+        t.games_remove,
+      ];
+
+  testWidgets('溢出菜单项齐全（含设置封面 / 自动获取封面 / 加入合集）', (WidgetTester tester) async {
     final AppModel appModel = await buildModel(<GalgameEntry>[
       GalgameEntry(
         id: 'g1',
@@ -83,13 +98,13 @@ void main() {
     await tester.tap(find.byType(PopupMenuButton<String>));
     await tester.pumpAndSettle();
 
-    expect(find.text(t.games_set_cover), findsOneWidget);
-    expect(find.text(t.games_auto_cover), findsOneWidget);
-    expect(find.text(t.games_rename), findsOneWidget);
-    expect(find.text(t.games_remove), findsOneWidget);
+    for (final String label in menuLabels()) {
+      expect(find.text(label), findsOneWidget, reason: '溢出菜单缺「$label」');
+    }
   });
 
-  testWidgets('长按菜单与溢出菜单项一致', (WidgetTester tester) async {
+  testWidgets('长按菜单走 MediaItemDialogFrame 且与溢出菜单项一致',
+      (WidgetTester tester) async {
     final AppModel appModel = await buildModel(<GalgameEntry>[
       GalgameEntry(
         id: 'g1',
@@ -101,12 +116,21 @@ void main() {
     ]);
     await pumpPage(tester, appModel);
 
-    await tester.longPress(find.text('テスト'));
+    await tester.longPress(find.text('テスト', skipOffstage: false).first);
     await tester.pumpAndSettle();
 
-    expect(find.byType(SimpleDialog), findsOneWidget);
-    expect(find.text(t.games_set_cover), findsOneWidget);
-    expect(find.text(t.games_auto_cover), findsOneWidget);
+    // 与书/视频卡同款对话框骨架（不再是手搓 SimpleDialog）。
+    expect(find.byType(MediaItemDialogFrame), findsOneWidget);
+    for (final String label in menuLabels()) {
+      expect(
+        find.descendant(
+          of: find.byType(MediaItemDialogFrame),
+          matching: find.text(label),
+        ),
+        findsOneWidget,
+        reason: '长按菜单缺「$label」（须与溢出菜单同源同项）',
+      );
+    }
   });
 
   testWidgets('有封面文件时卡片渲染封面图而非占位图标', (WidgetTester tester) async {
@@ -133,10 +157,17 @@ void main() {
     ]);
     await pumpPage(tester, appModel);
 
+    // 封面统一走 ShelfFileCover（BUG-959：resizedFileImage 降采样 + FadeInImage），
+    // 底层 provider 是 ResizeImage 包 FileImage——两层都断言，防退回裸 Image.file。
     expect(
-      find.byWidgetPredicate((Widget w) => w is Image && w.image is FileImage),
+      find.byWidgetPredicate(
+        (Widget w) =>
+            w is FadeInImage &&
+            w.image is ResizeImage &&
+            (w.image as ResizeImage).imageProvider is FileImage,
+      ),
       findsOneWidget,
-      reason: 'coverPath 指向的文件存在时必须渲染封面图',
+      reason: 'coverPath 指向的文件存在时必须经降采样封面加载器渲染封面图',
     );
   });
 }

--- a/hibiki/test/pages/games_library_filter_sort_test.dart
+++ b/hibiki/test/pages/games_library_filter_sort_test.dart
@@ -86,8 +86,10 @@ void main() {
 
   /// 只在网格里找卡片标题：搜索框里刚敲进去的同名文字也是一个 Text，
   /// 不限定祖先会把它一起数进来（findsOneWidget 直接红）。
+  /// 游戏进合集后网格改为 CustomScrollView 分区（合集横排行 + 散卡 SliverGrid），
+  /// 祖先随之从 GridView 换成 CustomScrollView，语义不变。
   Finder cardTitle(String title) => find.descendant(
-        of: find.byType(GridView),
+        of: find.byType(CustomScrollView),
         matching: find.text(title),
       );
 

--- a/hibiki/test/pages/home_video_page_menu_test.dart
+++ b/hibiki/test/pages/home_video_page_menu_test.dart
@@ -314,7 +314,7 @@ void main() {
     );
   });
 
-  testWidgets('长按视频卡弹出封面背景动作面板（五项管理动作、无播放）', (WidgetTester tester) async {
+  testWidgets('长按视频卡弹出封面背景动作面板（管理动作、无播放）', (WidgetTester tester) async {
     await seedTaggedVideo();
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
@@ -331,6 +331,8 @@ void main() {
     expect(t.video_import_pick_subtitle, isNot(contains('srt')));
     expect(t.video_import_pick_subtitle, isNot(contains('vtt')));
     expect(t.video_import_pick_subtitle, isNot(contains('ass')));
+    // 单卡「加入合集」（共享 showAddToCollectionDialog 入口）。
+    expect(find.text(t.add_to_collection), findsOneWidget);
     expect(find.text(t.dialog_delete), findsOneWidget);
     expect(find.text(t.dialog_read), findsNothing);
   });
@@ -351,6 +353,7 @@ void main() {
     expect(find.text(t.video_rename), findsOneWidget);
     expect(find.text(t.srt_import_pick_cover), findsOneWidget);
     expect(find.text(t.video_import_pick_subtitle), findsOneWidget);
+    expect(find.text(t.add_to_collection), findsOneWidget);
     expect(find.text(t.dialog_delete), findsOneWidget);
   });
 

--- a/packages/hibiki_core/lib/src/database/tables.dart
+++ b/packages/hibiki_core/lib/src/database/tables.dart
@@ -716,7 +716,8 @@ class Series extends Table {
 // 远端-only 条目无本地 row 可挂列，故用独立映射表。
 @DataClassName('ShelfEntryRow')
 class ShelfEntries extends Table {
-  /// 媒体种类：'epub' | 'srt' | 'video'。
+  /// 媒体种类：'epub' | 'srt' | 'video'（'game' 不写本表——游戏库排序走
+  /// `galgame_library_query.dart` 的视图偏好，合集归属见 [MediaCollectionItems]）。
   TextColumn get mediaType => text()();
 
   /// 条目稳定身份：本地 = bookKey / srtUid / videoBookUid；远端 = downloadId /
@@ -799,18 +800,21 @@ class MediaCollections extends Table {
 // ── media_collection_items (合集成员引用 = Jellyfin LinkedChildren) ────
 // 复合主键 (collectionId, mediaType, entryKey) 按合集去重：**同一条目可属于多个
 // 合集**；删合集 cascade 只删本表引用行。entryKey 是逻辑外键（epub=bookKey / srt=uid /
-// video=bookUid），不加本地三表 DB FK——与 [ShelfEntries].entryKey 同理由（远端条目无
-// 本地行，写 FK 会违反约束）。孤儿由删除路径主动清理 + 读取期过滤兜底。
+// video=bookUid / game=galgames.id），不加本地媒体表 DB FK——与 [ShelfEntries].entryKey
+// 同理由（远端条目无本地行，写 FK 会违反约束）。孤儿由删除路径主动清理 + 读取期过滤兜底。
 @DataClassName('MediaCollectionItemRow')
 class MediaCollectionItems extends Table {
   /// 所属合集（[MediaCollections].id）。onDelete:cascade = 删合集连带删本引用行。
   IntColumn get collectionId => integer()
       .references(MediaCollections, #id, onDelete: KeyAction.cascade)();
 
-  /// 媒体种类：'epub' | 'srt' | 'video'（同 [ShelfEntries].mediaType 值域）。
+  /// 媒体种类：'epub' | 'srt' | 'video' | 'game'（前三者同 [ShelfEntries].mediaType
+  /// 值域；'game' 仅存在于本表——游戏库无书架排序行）。自由 TextColumn，无 CHECK。
   TextColumn get mediaType => text()();
 
-  /// 条目稳定身份：epub=bookKey / srt=uid / video=bookUid。
+  /// 条目稳定身份：epub=bookKey / srt=uid / video=bookUid / game=galgames.id
+  /// （game 的 id 是添加时刻微秒时间戳字符串，**本机局域身份**：与 exe 路径同为
+  /// 本机事实，跨端同步时对端无对应行则该成员静默忽略）。
   TextColumn get entryKey => text()();
 
   /// 合集内序：playlist 的播放顺序 / collection 的展示顺序。


### PR DESCRIPTION
## 背景

用户诉求：书籍/漫画/视频/游戏各页各自维护渲染与命名代码，要求统一，且四类媒体均应有改名/改封面/刮削封面/合集能力；**书籍合集与视频合集样式外观不变**（统一的是代码）。多期路线中 P1a（共享 BangumiApiClient，commit 073bf564b）已进 develop，P1b 书/漫画刮削 + 漫画作者编辑修复由 **PR#409** 覆盖；本 PR 交付 **P2（游戏进合集）+ UI 收口**。与 PR#409 无文件级重叠（i18n 17 文件两侧各自追加 key，合并时按常规解 i18n 冲突即可）。

## 改动

### 1. 共享地基（feat(collections)）
- `shelf_card_widgets.dart` 新增 `ShelfCoverPlaceholder`（B11 描边占位，MD3 tokens 通道）/ `ShelfFileCover`（resizedFileImage 降采样 + FadeInImage，BUG-959 同源修复）
- `cover_image.dart` 新增 `evictLocalCoverCache`：FileImage + ResizeImage 两键齐清（旧驱逐只清 FileImage 键对降采样渲染无效）
- 新增跨媒体共享 `showAddToCollectionDialog`：单卡「加入合集」弹窗，与批量三档同走 `addToCollection` DAO（自带成员墓碑清理）
- i18n 新增 `add_to_collection`（17 语言）

### 2. 视频库（refactor(video)）
- 手抄的选中对勾/选中罩/封面占位（10 处）→ 共享件；获得 eink 分支与深色占位描边，其余像素不变，widget key 全保留
- 单卡菜单新增「加入合集」（entryKey=bookUid 与批量同编码）

### 3. 书架（refactor(shelf)）
- EPUB/SRT 单卡菜单新增「加入合集」（`('epub', bookKey)` / `('srt', uid)` 同编码同 DAO）；合集详情页语境自动隐藏
- 漫画/PDF 与 EPUB 共用书架，能力自动继承

### 4. 游戏库（feat(games)）
- 卡片占位/封面加载换共享件（补降采样）；长按/右键菜单从手搓 SimpleDialog 换成书/视频同款 `MediaItemDialogFrame`（footer 统一豁免：TODO-1946 已落 `GalgamePosterCard`，不倒退）
- **刮削封面落地**：刮削成功后自动下载合并层 `coverUrl` 到 `game_covers`（已有封面绝不覆盖；Content-Type/大小校验；纯函数决策层带单测）
- **游戏进合集（P2）**：`mediaType 'game'` + entryKey=`galgames.id`（本机局域身份，注释写明跨端语义）；游戏库前置 `CollectionShelfRow` 横排行（书架样式、独立折叠偏好）；卡菜单/详情页「加入合集」；合集详情页认识 game 成员（只解散不删本体）；全仓 mediaType switch 审计（删合集连删本体跳过 game、未知类型删除留痕、一键排序补 game meta）。**无 schema 迁移**——`mediaType`/`entryKey` 是无 CHECK 的自由 TextColumn（tables.dart 实证 + DB 往返测试），仅注释值域更新

## 验证
- 全量 `flutter analyze`（含 test）：No issues found
- `test/pages` 全量 2179 绿；`test/media` + `test/database` 3611 绿（含 6 个新增测试文件：合集分组 game 三态、DB 往返/墓碑/cascade、详情页 game 成员加载、封面下载决策全分支）
- 守卫全绿：MD3 静态守卫、书架卡布局守卫、i18n 完整性、bugs 索引守卫
- 书/视频合集样式：未动渲染结构，仅内部实现换共享件（widget key 与断言全保留）

## 后续（不在本期）
- P3 封面服务统一（`MediaCoverService` 三岛路由；本期 `evictLocalCoverCache`/`ShelfFileCover`/`galgame_cover_download` 是其地基件）/ P4 改名门面 / P5 MediaKind 地基
- 顺手记录的既有问题：视频换封面 evict 只清 FileImage 键（video_import_dialog.dart:97）、`backup_service` 分类剥离无 'game' 开关、首页活动条点游戏跳视频 tab、远端封面非 poster 分支仍裸 Image.file、game 成员进视频 playlist 会被 'video' 白名单滞留（书成员同病，既有共性）

## 真机验收点（合并前）
- Windows：游戏库合集行折叠/展开、游戏加入合集→详情页查看/移出、刮削后封面自动落地且不覆盖手选封面
- 书架/视频库：单卡「加入合集」入场、外观与改前逐像素一致（重点合集行/合集封面卡）

https://claude.ai/code/session_01LAhD7GjMaspKwRPK6nz941