### PR TITLE
fix(settings): 「外观」大类置顶（覆盖阶段G纯任务优先排序）

### DIFF
--- a/hibiki/lib/src/settings/settings_schema.dart
+++ b/hibiki/lib/src/settings/settings_schema.dart
@@ -14,9 +14,12 @@ import 'package:hibiki/src/sync/sync_settings_schema.dart';
 import 'package:hibiki/utils.dart';
 
 List<SettingsDestination> buildSettingsSchema(SettingsContext context) {
-  // 大类任务优先排序（阶段 G）：把用户最常改的「阅读 / 查词 / 制卡 / 视频 / 听书 /
-  // 下载」内容类放最前，「外观 / Profile / 同步备份 / 互联 / 系统」这类配置/系统类殿后。
+  // 「外观」置顶（用户拍板，覆盖阶段 G 的纯任务优先排序）：全局界面外观是
+  // 装完 app 第一批要调的东西，压在「下载」后面找不到。其余保持任务优先：
+  // 「阅读 / 查词 / 制卡 / 视频 / 听书 / 下载」内容类在前，
+  // 「Profile / 同步备份 / 互联 / 系统」配置/系统类殿后。
   return <SettingsDestination>[
+    buildAppearanceDestination(),
     buildReadingDestination(),
     buildLookupDestination(),
     buildCardCreationDestination(),
@@ -24,7 +27,6 @@ List<SettingsDestination> buildSettingsSchema(SettingsContext context) {
     buildListeningDestination(),
     // 「下载」大类：内联既有 torrent 设置组件（详见 buildDownloadsDestination）。
     buildDownloadsDestination(),
-    buildAppearanceDestination(),
     buildProfilesDestination(),
     buildSyncBackupDestination(),
     // Hibiki 互联从同步分类拆出的独立一级分类（构建函数在 sync_settings_schema

--- a/hibiki/test/settings/settings_destination_order_guard_test.dart
+++ b/hibiki/test/settings/settings_destination_order_guard_test.dart
@@ -2,15 +2,17 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// 阶段 G 守卫：`buildSettingsSchema` 顶层大类顺序（内容类在前、外观/系统类殿后）。
+/// 顶层大类顺序守卫：`buildSettingsSchema`「外观」置顶 + 内容类在前、系统类殿后。
 ///
-/// 这是「用户决策过的位置」——把最常改的阅读 / 查词 / 制卡 / 视频 / 听书 / 下载放最前，
-/// 外观 / Profile / 同步备份 / 互联 / 系统殿后。锁死顺序让未来漂移必须是有意为之
+/// 这是「用户决策过的位置」——外观置顶（2026-07-25 用户拍板，覆盖阶段 G 纯任务
+/// 优先排序），其后是最常改的阅读 / 查词 / 制卡 / 视频 / 听书 / 下载，
+/// Profile / 同步备份 / 互联 / 系统殿后。锁死顺序让未来漂移必须是有意为之
 /// （改 `buildSettingsSchema` 时同步改本守卫）。用源码顺序断言（零 harness 依赖：
 /// 无需构造 SettingsContext + AppModel 即可校验 destination 列表次序）。
 void main() {
-  test('buildSettingsSchema keeps the task-first top-level destination order',
-      () {
+  test(
+      'buildSettingsSchema keeps the appearance-first top-level destination '
+      'order', () {
     final String src = File('lib/src/settings/settings_schema.dart')
         .readAsStringSync()
         .replaceAll('\r\n', '\n');
@@ -22,13 +24,13 @@ void main() {
     final String body = src.substring(fnStart, fnEnd);
 
     const List<String> expectedOrder = <String>[
+      'buildAppearanceDestination()',
       'buildReadingDestination()',
       'buildLookupDestination()',
       'buildCardCreationDestination()',
       'buildVideoDestination()',
       'buildListeningDestination()',
       'buildDownloadsDestination()',
-      'buildAppearanceDestination()',
       'buildProfilesDestination()',
       'buildSyncBackupDestination()',
       'buildInterconnectDestination()',


### PR DESCRIPTION
## 背景

用户反馈：设置里「外观」的位置不对、大类排序不对。阶段 G（`00b6fe61e`/`c132b2f21`）按「任务优先」把「外观」从第 1 位挪到第 7 位（压在「下载」后面），全局界面外观反而难找。

## 改动

- `settings_schema.dart`：`buildAppearanceDestination()` 挪回列表第 1 位；其余「阅读 / 查词 / 制卡 / 视频 / 听书 / 下载 / Profile / 同步备份 / 互联 / 系统」相对顺序不变。
- `settings_destination_order_guard_test.dart`：顶层顺序守卫同步更新（该守卫注释即要求改顺序须同步改守卫）。

副作用（符合意图）：设置主从页默认选中项取 `destinations.first.id`，现在打开设置默认落在「外观」（`settings_home_page.dart:34` 注释已声明顺序调整安全）。

## 验证

- 全量 `flutter analyze`：No issues found
- `flutter test test/settings/ --no-pub`：305 passed
- `flutter test test/pages/video_settings_schema_guard_test.dart --no-pub`：9 passed

https://claude.ai/code/session_01GJivAbewUf3ekiCP26rD6a