### PR TITLE
fix(settings): 下载设置输入框宽屏限宽 480（BUG-1084）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1050 条。点号进各自文件。
+> 共 1051 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1084](bugs/BUG-1084-torrent-settings-field-full-width.md) | ✅ | ✅ | 下载设置输入框在宽屏详情面板被拉满整宽 |
 | [BUG-1083](bugs/BUG-1083-manga-author-edit-missing.md) | ✅ | ✅ | 漫画编辑对话框缺作者字段(未覆盖supportsAuthorEdit) |
 | [BUG-1082](bugs/BUG-1082-scrape-poster-lowres.md) | ✅ | ✅ | TMDB刮削海报w500缩略图发糊非满分辨率 |
 | [BUG-1081](bugs/BUG-1081-poster-use-no-feedback.md) | ✅ | ✅ | 海报匹配弹窗点使用没反应无进度反馈 |

--- a/docs/bugs/BUG-1084-torrent-settings-field-full-width.md
+++ b/docs/bugs/BUG-1084-torrent-settings-field-full-width.md
@@ -1,0 +1,6 @@
+## BUG-1084 · 下载设置输入框在宽屏详情面板被拉满整宽
+- **报告**：2026-07-25（用户：4K 全屏截图，「下载」设置里 qBittorrent 分类 / 下载限速 / 最大连接数 / 内存占用上限 / 监听端口等方框宽度堆满整个内容区）
+- **真实性**：✅ 真 bug。设置详情面板按用户拍板（2026-07-22）填满整宽不限宽（`hibiki/lib/src/settings/settings_home_page.dart:332` 注释），而 `TorrentSettingsSection` 根 Column 用 `CrossAxisAlignment.stretch`，`_text` 里的 `TextFormField` 会吃满给定宽度（`hibiki/lib/src/pages/implementations/torrent_settings_section.dart:109`），两者叠加导致 4K 下每条输入框拉到 ~3000px。
+- **[x] ① 已修复** — `_text` 给输入框自身包 `Align(左对齐) + ConstrainedBox(maxWidth: 480)`（`torrent_settings_section.dart` `_kFieldMaxWidth`）：只限输入框，开关行/分段按钮/说明文字仍占满整宽，面板级整宽形态不动；窄面板（小于上限）输入框仍占满可用宽度。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/torrent_settings_field_width_test.dart`：宽面板（2400px）断言所有 `TextFormField` 宽度 ≤480 且左对齐；窄面板（400px）断言仍填满可用宽度。
+- **备注**：不复刻 UI 巡检 PR-5 被回滚的面板级 960 限宽——那次限的是整个详情面板（右侧大片空白被用户打回），这次只限输入控件本身。

--- a/hibiki/lib/src/pages/implementations/torrent_settings_section.dart
+++ b/hibiki/lib/src/pages/implementations/torrent_settings_section.dart
@@ -81,6 +81,12 @@ class _TorrentSettingsSectionState
     ));
   }
 
+  /// 输入框最大宽度。详情面板按用户拍板填满整宽（settings_home_page.dart 的
+  /// 960 限宽已回滚），但 TextFormField 会吃满给定宽度——4K 全屏下一条输入框
+  /// 拉到三千多像素（BUG-1084）。限宽只作用于输入框本身并左对齐：开关行、
+  /// 分段按钮、说明文字仍占满整宽，窄屏（< 上限）不受影响。
+  static const double _kFieldMaxWidth = 480;
+
   static int _nonNegInt(String v) {
     final int n = int.tryParse(v.trim()) ?? 0;
     return n < 0 ? 0 : n;
@@ -106,20 +112,26 @@ class _TorrentSettingsSectionState
         (initial == null) != (controller == null), 'initial 与 controller 二选一');
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
-      child: TextFormField(
-        initialValue: initial,
-        controller: controller,
-        focusNode: focusNode,
-        obscureText: obscure,
-        keyboardType: keyboard,
-        decoration: InputDecoration(
-          labelText: label,
-          hintText: hint,
-          errorText: errorText,
-          isDense: true,
-          border: const OutlineInputBorder(),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: _kFieldMaxWidth),
+          child: TextFormField(
+            initialValue: initial,
+            controller: controller,
+            focusNode: focusNode,
+            obscureText: obscure,
+            keyboardType: keyboard,
+            decoration: InputDecoration(
+              labelText: label,
+              hintText: hint,
+              errorText: errorText,
+              isDense: true,
+              border: const OutlineInputBorder(),
+            ),
+            onChanged: onChanged,
+          ),
         ),
-        onChanged: onChanged,
       ),
     );
   }

--- a/hibiki/test/pages/torrent_settings_field_width_test.dart
+++ b/hibiki/test/pages/torrent_settings_field_width_test.dart
@@ -1,0 +1,134 @@
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/media/torrent/anime_download_config.dart';
+import 'package:hibiki/src/media/torrent/download_network_proxy.dart';
+import 'package:hibiki/src/models/theme_notifier.dart';
+import 'package:hibiki/src/pages/implementations/torrent_settings_section.dart';
+import 'package:hibiki/utils.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../helpers/test_platform_services.dart';
+
+// BUG-1084 守卫：设置详情面板按用户拍板填满整宽（无 960 限宽），而
+// TextFormField 会吃满给定宽度——4K 全屏下「下载设置」每条输入框被拉到
+// 三千多像素。修复是把输入框自身限宽（Align 左对齐 + ConstrainedBox），
+// 开关行/分段按钮不受影响；窄面板（小于上限）输入框仍占满可用宽度。
+class _TestAppModel extends AppModel {
+  _TestAppModel() : super(testPlatformServices());
+
+  @override
+  Locale get appLocale => const Locale('en', 'US');
+
+  @override
+  PackageInfo get packageInfo => PackageInfo(
+        appName: 'Hibiki',
+        packageName: 'jp.hibiki.test',
+        version: '1.0.0',
+        buildNumber: '1',
+      );
+
+  // prefs 未初始化的裸 AppModel：把本组件 build 路径读到的两个 pref-backed
+  // getter 换成常量默认（qb 未配置 → 桌面解析成内置引擎，字段最全）。
+  @override
+  QbConnectionConfig? get qbConnectionConfig => null;
+
+  @override
+  DownloadNetworkProxyConfig get downloadNetworkProxyConfig =>
+      const DownloadNetworkProxyConfig();
+}
+
+Widget _harness({required double paneWidth}) {
+  final HibikiDatabase db = HibikiDatabase.forTesting(
+    DatabaseConnection(NativeDatabase.memory()),
+  );
+  final ThemeNotifier themeNotifier = ThemeNotifier(db, () => const TextTheme())
+    ..loadFromPrefsSnapshot(<String, String>{
+      'design_system': PrefCodec.encode('material'),
+      'app_theme_key': PrefCodec.encode('system-theme'),
+      'brightness_mode': PrefCodec.encode('system'),
+      'custom_theme_seed': PrefCodec.encode(0xFF1F4959),
+    });
+  final AppModel appModel = _TestAppModel()..themeNotifier = themeNotifier;
+  addTearDown(() async {
+    themeNotifier.dispose();
+    await db.close();
+  });
+
+  return ProviderScope(
+    overrides: <Override>[
+      appProvider.overrideWith((Ref ref) => appModel),
+    ],
+    child: MaterialApp(
+      theme: ThemeData(
+        useMaterial3: true,
+        platform: TargetPlatform.android,
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF386A58)),
+        extensions: <ThemeExtension<dynamic>>[
+          HibikiDesignSystemTheme(themeNotifier.designSystemTheme),
+        ],
+      ),
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: paneWidth,
+            child: SingleChildScrollView(
+              child: TorrentSettingsSection(),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets(
+      'wide pane: input fields cap at 480 and stay left-aligned '
+      '(BUG-1084)', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(2600, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_harness(paneWidth: 2400));
+    await tester.pumpAndSettle();
+
+    final Finder fields = find.byType(TextFormField);
+    expect(fields, findsWidgets,
+        reason: 'embedded backend must render its input fields');
+    final double paneLeft =
+        tester.getTopLeft(find.byType(TorrentSettingsSection)).dx;
+    for (final Element element in fields.evaluate()) {
+      final Size size = tester.getSize(find.byWidget(element.widget));
+      expect(size.width, lessThanOrEqualTo(481),
+          reason: 'a field must never stretch across the full-width pane');
+      expect(tester.getTopLeft(find.byWidget(element.widget)).dx,
+          moreOrLessEquals(paneLeft, epsilon: 1.0),
+          reason: 'capped fields stay left-aligned with the pane');
+    }
+  });
+
+  testWidgets('narrow pane: input fields still fill the available width',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    const double paneWidth = 400;
+    await tester.pumpWidget(_harness(paneWidth: paneWidth));
+    await tester.pumpAndSettle();
+
+    final Finder fields = find.byType(TextFormField);
+    expect(fields, findsWidgets);
+    for (final Element element in fields.evaluate()) {
+      final Size size = tester.getSize(find.byWidget(element.widget));
+      expect(size.width, moreOrLessEquals(paneWidth, epsilon: 1.0),
+          reason: 'below the cap a field keeps filling the pane');
+    }
+  });
+}


### PR DESCRIPTION
## 问题
4K 全屏下「设置 → 下载」的 qBittorrent 分类 / 下载限速 / 最大连接数 / 内存占用上限 / 监听端口等输入框宽度堆满整个详情面板（~3000px），观感极差（用户截图报告）。

## 根因
设置详情面板按用户拍板（2026-07-22）填满整宽不限宽（settings_home_page.dart 已回滚过面板级 960 限宽），而 TorrentSettingsSection 根 Column 用 CrossAxisAlignment.stretch，_text 里的 TextFormField 会吃满给定宽度，两者叠加。

## 修复
只给输入框自身限宽：_text 内包 Align(左对齐) + ConstrainedBox(maxWidth: 480)（_kFieldMaxWidth）。开关行、分段按钮、说明文字仍占满整宽，面板级整宽形态不动；窄面板（小于上限）输入框仍占满可用宽度。**不**复刻被打回的面板级 960 限宽。

## 测试
- 新增 hibiki/test/pages/torrent_settings_field_width_test.dart：宽面板（2400px）断言所有 TextFormField ≤480 且左对齐；窄面板（400px）断言仍填满。
- flutter analyze 全量零问题；test/settings + test/media/torrent + 新测试 361 项全绿。
- BUG 档案：docs/bugs/BUG-1084-torrent-settings-field-full-width.md。

待 Windows 4K 真机复测原始截图路径。

https://claude.ai/code/session_01WfpCsJm5jfT7qHYWYd6MNn