### PR TITLE
fix(sync): 互联回到同步方式选择器；host 模式不再藏云备份上传开关 (BUG-1084)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1050 条。点号进各自文件。
+> 共 1051 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1084](bugs/BUG-1084-sync-host-hides-cloud-upload-and-interconnect-backend.md) | ✅ | ✅ | host 模式误藏云备份上传开关，互联从同步方式消失且无入口 |
 | [BUG-1083](bugs/BUG-1083-manga-author-edit-missing.md) | ✅ | ✅ | 漫画编辑对话框缺作者字段(未覆盖supportsAuthorEdit) |
 | [BUG-1082](bugs/BUG-1082-scrape-poster-lowres.md) | ✅ | ✅ | TMDB刮削海报w500缩略图发糊非满分辨率 |
 | [BUG-1081](bugs/BUG-1081-poster-use-no-feedback.md) | ✅ | ✅ | 海报匹配弹窗点使用没反应无进度反馈 |

--- a/docs/bugs/BUG-1084-sync-host-hides-cloud-upload-and-interconnect-backend.md
+++ b/docs/bugs/BUG-1084-sync-host-hides-cloud-upload-and-interconnect-backend.md
@@ -1,0 +1,15 @@
+## BUG-1084 · host 模式误藏云备份上传开关，互联从同步方式消失且无入口
+- **报告**：2026-07-25（用户：「同步方式怎么少了 hibiki 互联，还少了上传视频、书籍、有声书之类的全没了」「用互联做备份后端这个按钮根本没有」「我用谷歌云盘等其他的后端也应该能用」）
+- **真实性**：✅ 真 bug（三处叠加，均沿真实代码路径验证）
+  1. `a147a28ca` 给云通道的上传书籍/有声书/视频、自动同步、立即同步、比较统一加了 `!_isHostingInterconnect` 门控（`sync_settings_schema.dart:167/221/234/253/288/296`）。该理由（"host 无出站"）只在互联还是互斥单选（backendType==hibikiServer）的旧模型下成立；互联解耦成独立开关（PR#223）+ 双通道（BUG-988，`sync_auto_trigger.dart:104` `enabledSyncChannelBackends`）后，host 设备的云通道（Google Drive/WebDAV/…）照常出站，门控变成错误特例——用户开了「本机作为服务器」，云盘上传开关整排消失。
+  2. 解耦时 `_isBackendSelectable`（`backend_config.part.dart:293`）对 hibikiServer 返回 false，把互联从「同步方式」选择器摘掉；一次性迁移（`sync_repository.dart:345`）还把已选互联的用户强制改回 googleDrive。
+  3. 唯一补偿入口「设为备份后端」按钮位于互联分类的「交给已配对设备」区，门控 `interconnectActive && !_isHostingInterconnect`（`sync_settings_schema.dart:471`）——host 设备上同样被藏，入口彻底死循环。
+- **[x] ① 已修复** — 见本分支提交：
+  - `_isBackendSelectable(hibikiServer)` → true，互联回到「同步方式」选择器；`_selectBackend` 选中互联时自动 `setInterconnectEnabled(true)`（否则连接配置区不显示、通道认证不过，是个死后端），并在选择器下方加指引行 `sync.interconnect_config_note`（复用既有 i18n key `interconnect_moved_note`，零 key 增删）。
+  - 新谓词 `_cloudOutboundUnavailable` = `backendType == hibikiServer && _isHostingInterconnect`：自动同步/立即同步/比较/host 说明行改用它——只有「同步方式本身是互联且本机在做 host」这个真正无出站的组合才隐藏；云后端无论是否 host 一律可见（引擎侧 `resolveChannelSyncFlags` 本就按通道读开关，纯 UI 门控 bug）。
+  - 三个云通道上传开关（书籍/有声书/视频；漫画走 EPUB 书籍管线，属「上传书籍」通道）改为 `backendType != hibikiServer` 门控：唯一死区是同步方式=互联（该通道按 BUG-988 读互联专属上传开关，在互联分类可配），不再看 host 身份。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/sync_settings_visibility_test.dart`：
+  - 「upload switches hide only when the sync method is the interconnect (BUG-1084)」：源码守卫，三个上传开关必须带 `!= SyncBackendType.hibikiServer` 且禁止出现 `_isHostingInterconnect`。
+  - 「auto-sync gate keys off cloud-outbound availability (BUG-1084)」+「the action gates key off cloud-outbound availability (BUG-084 / BUG-1084)」：六处门控必须走 `_cloudOutboundUnavailable`，且谓词链同时咬住 backendType==hibikiServer、serverEnabled、interconnectEnabled 三条件（BUG-084 的 stale serverEnabled 防线保持）。
+  - 「the backend picker lists the interconnect again (BUG-1084)」+「selecting the interconnect as sync method enables interconnect (BUG-1084)」：选择器必须列出互联、选中必须自动开互联总开关。
+- **备注**：互联独立分类（连接配置/host 开关/互联专属上传开关）保持不变；「设为备份后端」按钮保留（与选择器共用 `applyBackupBackendChange`，语义一致）。

--- a/hibiki/lib/src/sync/sync_settings_schema.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema.dart
@@ -144,9 +144,19 @@ SettingsDestination buildSyncBackupDestination() {
             builder: (SettingsContext ctx) =>
                 _SftpConfigWidget(settingsContext: ctx),
           ),
-          // 互联（局域网端到端）已从「同步方式」枚举里解耦成独立分类 + 独立开关
-          // （buildInterconnectDestination），与云备份后端并存、互不排斥；这里不再
-          // 需要「互联被选为同步方式」的指引行。
+          // 互联被选为同步方式时的指引行（BUG-1084）：连接配置（URL/token/配对/
+          // LAN 发现/host 开关）在独立的「Hibiki 互联」分类里，这里只指路不复制。
+          SettingsCustomItem(
+            id: 'sync.interconnect_config_note',
+            icon: Icons.devices_outlined,
+            visible: (SettingsContext ctx) =>
+                _syncSettings(ctx).backendType == SyncBackendType.hibikiServer,
+            builder: (SettingsContext ctx) => AdaptiveSettingsRow(
+              title: t.sync_backend_hibiki_server,
+              subtitle: t.interconnect_moved_note,
+              icon: Icons.devices_outlined,
+            ),
+          ),
         ],
       ),
       // ── Group 3: What to sync — global, applies to every backend ──────
@@ -158,13 +168,13 @@ SettingsDestination buildSyncBackupDestination() {
             title: t.sync_auto_sync,
             icon: Icons.sync_outlined,
             // Auto-sync is an OUTBOUND switch: it triggers app-open/background/
-            // book-close pushes through the resolved backend. A Hibiki host has
-            // no outbound sync (clients pull from / push to it), so every
-            // auto-sync path early-returns on an unconfigured outbound backend —
-            // the toggle does nothing in host mode. Hide it there, matching the
-            // sync_now / compare gates (BUG-084). Client-mode hibikiServer DOES
-            // have outbound sync, so only hide when actively hosting.
-            visible: (SettingsContext ctx) => !_isHostingInterconnect(ctx),
+            // book-close pushes through the resolved backend. Outbound only
+            // vanishes when the selected sync method IS the interconnect and
+            // this device is the host (clients pull from / push to it, BUG-084).
+            // A cloud backend keeps its outbound regardless of hosting — hiding
+            // on host identity alone blanked Google Drive users' toggle
+            // (BUG-1084).
+            visible: (SettingsContext ctx) => !_cloudOutboundUnavailable(ctx),
             value: (SettingsContext ctx) => _syncSettings(ctx).autoSync,
             onChanged: (SettingsContext ctx, bool value) async {
               _syncSettings(ctx).autoSync = value;
@@ -209,16 +219,18 @@ SettingsDestination buildSyncBackupDestination() {
           ),
           // 「上传X文件」三个开关都是 OUTBOUND：把本机资产推给**云备份**后端。BUG-988
           // 起互联通道不再复用这套共享开关——互联的内容上传由「上传到互联对端」分项开关
-          // 单独控制（见 buildInterconnectDestination），二者互不牵连。互联 host（本机在
-          // 做服务端）没有任何 outbound sync——client 从它拉取/往它推，它自己不上传
-          // （auto_sync 同理已隐藏）。故 host 模式下这三个上传开关纯空转，一律随 auto_sync
-          // 的 `!_isHostingInterconnect` 门控隐藏（client 模式仍可见）。
+          // 单独控制（见 buildInterconnectDestination），二者互不牵连。故这三个开关只在
+          // 云通道本身没有出站语义时才隐藏：同步方式被选成互联（该通道按互联专属开关
+          // 走，共享开关是死开关）。云后端（Google Drive/WebDAV/...）无论本机是否在做
+          // 互联 host 都照常出站——旧的 `!_isHostingInterconnect` 门控把 host 设备上的
+          // 云盘上传开关整排藏掉，是解耦前遗留的错误特例（BUG-1084）。
           SettingsSwitchItem(
             id: 'sync.content',
             title: t.sync_content,
             subtitle: t.sync_content_warning,
             icon: Icons.book_outlined,
-            visible: (SettingsContext ctx) => !_isHostingInterconnect(ctx),
+            visible: (SettingsContext ctx) =>
+                _syncSettings(ctx).backendType != SyncBackendType.hibikiServer,
             value: (SettingsContext ctx) => _syncSettings(ctx).syncContent,
             onChanged: (SettingsContext ctx, bool value) async {
               _syncSettings(ctx).syncContent = value;
@@ -231,7 +243,8 @@ SettingsDestination buildSyncBackupDestination() {
             title: t.sync_audiobook_files,
             subtitle: t.sync_audiobook_files_warning,
             icon: Icons.audio_file_outlined,
-            visible: (SettingsContext ctx) => !_isHostingInterconnect(ctx),
+            visible: (SettingsContext ctx) =>
+                _syncSettings(ctx).backendType != SyncBackendType.hibikiServer,
             value: (SettingsContext ctx) =>
                 _syncSettings(ctx).syncAudioBookFiles,
             onChanged: (SettingsContext ctx, bool value) async {
@@ -244,13 +257,14 @@ SettingsDestination buildSyncBackupDestination() {
           // `__videos__` 伪装资产（run() 非互联分支）；互联（hibikiServer）走
           // _syncVideosLive 的 host 上传端点（client→host）。两条通道同为 upload-only
           // （host→client 仍按需流式/下载，且与本开关正交——客户端手动浏览/下载远端视频
-          // 只看 show_remote_entries，从不受此开关门控）。host 模式无 outbound → 隐藏。
+          // 只看 show_remote_entries，从不受此开关门控）。可见性同上两个上传开关。
           SettingsSwitchItem(
             id: 'sync.video_files',
             title: t.sync_video_files,
             subtitle: t.sync_video_files_warning,
             icon: Icons.video_file_outlined,
-            visible: (SettingsContext ctx) => !_isHostingInterconnect(ctx),
+            visible: (SettingsContext ctx) =>
+                _syncSettings(ctx).backendType != SyncBackendType.hibikiServer,
             value: (SettingsContext ctx) => _syncSettings(ctx).syncVideoFiles,
             onChanged: (SettingsContext ctx, bool value) async {
               _syncSettings(ctx).syncVideoFiles = value;
@@ -267,15 +281,15 @@ SettingsDestination buildSyncBackupDestination() {
       SettingsSection(
         title: t.sync_section_actions,
         items: <SettingsItem>[
-          // Hosting as a Hibiki server has no OUTBOUND sync: the host is a
-          // passive data source that connected clients pull from / push to, so
-          // "sync now" / "compare" resolve to an unconfigured outbound backend
-          // and used to misleadingly say "set up sync first". Hide them in
-          // server mode and explain instead (BUG-084).
+          // Sync-method-is-interconnect + hosting has no OUTBOUND sync: the host
+          // is a passive data source that connected clients pull from / push to,
+          // so "sync now" / "compare" would misleadingly say "set up sync
+          // first". Hide them for that combination only and explain instead
+          // (BUG-084); a cloud backend keeps outbound while hosting (BUG-1084).
           SettingsCustomItem(
             id: 'sync.server_mode_note',
             icon: Icons.router_outlined,
-            visible: (SettingsContext ctx) => _isHostingInterconnect(ctx),
+            visible: (SettingsContext ctx) => _cloudOutboundUnavailable(ctx),
             builder: (SettingsContext ctx) => AdaptiveSettingsRow(
               title: t.sync_server_mode_active,
               subtitle: t.sync_server_mode_clients_drive,
@@ -285,7 +299,7 @@ SettingsDestination buildSyncBackupDestination() {
           SettingsCustomItem(
             id: 'sync.sync_now',
             icon: Icons.sync,
-            visible: (SettingsContext ctx) => !_isHostingInterconnect(ctx),
+            visible: (SettingsContext ctx) => !_cloudOutboundUnavailable(ctx),
             builder: (SettingsContext ctx) =>
                 _SyncNowWidget(settingsContext: ctx),
           ),
@@ -293,7 +307,7 @@ SettingsDestination buildSyncBackupDestination() {
             id: 'sync.compare',
             title: t.sync_compare,
             icon: Icons.compare_arrows,
-            visible: (SettingsContext ctx) => !_isHostingInterconnect(ctx),
+            visible: (SettingsContext ctx) => !_cloudOutboundUnavailable(ctx),
             onTap: (SettingsContext ctx) => showSyncCompareDialog(
               ctx.context,
               ctx.appModel.database,
@@ -559,6 +573,15 @@ AppModel? _activeSyncOwner;
 /// only uses a cloud backend, which would otherwise hide sync-now on the cloud).
 bool _isHostingInterconnect(SettingsContext ctx) =>
     _syncSettings(ctx).serverEnabled && _syncSettings(ctx).interconnectEnabled;
+
+/// 云备份通道此刻是否真的没有出站同步（BUG-1084）：仅当「同步方式」本身选的是互联、
+/// 且本机正在做互联 host——host 是被动数据源，client 从它拉/往它推，它自己无出站
+/// （BUG-084）。云后端（Google Drive/WebDAV/...）的出站与互联 host 身份无关：host
+/// 设备照样往云盘备份。旧门控只看 host 身份，把云通道的上传开关、自动同步、立即
+/// 同步整排藏掉，是互联还与云备份互斥时代遗留的错误特例。
+bool _cloudOutboundUnavailable(SettingsContext ctx) =>
+    _syncSettings(ctx).backendType == SyncBackendType.hibikiServer &&
+    _isHostingInterconnect(ctx);
 
 _SyncSettingsState _syncSettings(SettingsContext ctx) {
   final AppModel owner = ctx.appModel;

--- a/hibiki/lib/src/sync/sync_settings_schema/backend_config.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/backend_config.part.dart
@@ -287,11 +287,12 @@ bool _isBackendSelectable(SyncBackendType type) {
       return OneDriveSyncBackend.isConfigured;
     case SyncBackendType.dropbox:
       return DropboxSyncBackend.isConfigured;
-    // 互联（hibikiServer）不再是「同步方式」的互斥单选项——它已解耦成独立分类 +
-    // 独立开关（buildInterconnectDestination），与云备份并存。故从后端选择器隐藏；
-    // 枚举值与 [_backendLabel] 仅为防御性回显（迁移前的历史持久化值）保留。
+    // BUG-1084：互联回到「同步方式」选择器。解耦（独立分类 + 独立开关，可与云备份
+    // 并存）保留，但把备份后端指向互联必须能从这里直接选——曾经唯一的入口是互联页
+    // 的「设为备份后端」按钮，而它又被 host 门控藏掉，host 设备上入口彻底消失。
+    // 选中后连接配置仍在「Hibiki 互联」分类（选择器下方有指引行）。
     case SyncBackendType.hibikiServer:
-      return false;
+      return true;
     case SyncBackendType.googleDrive:
     case SyncBackendType.webDav:
     case SyncBackendType.ftp:
@@ -379,6 +380,11 @@ class _BackendSelectorWidgetState extends State<_BackendSelectorWidget> {
       previous: previous,
       next: value,
     );
+    // BUG-1084：选互联做同步方式时顺手打开互联总开关——不开互联，连接配置区不显示、
+    // 通道认证也过不去，选完就是个死后端。反向（选回云盘）不动互联开关，二者可并存。
+    if (value == SyncBackendType.hibikiServer && !state.interconnectEnabled) {
+      await state.setInterconnectEnabled(true);
+    }
     widget.settingsContext.refresh();
   }
 }

--- a/hibiki/test/sync/sync_settings_visibility_test.dart
+++ b/hibiki/test/sync/sync_settings_visibility_test.dart
@@ -49,8 +49,8 @@ void main() {
     });
 
     test('group 1 (sync method) holds selector + scoped account/config', () {
-      // 互联已从「同步方式」解耦成独立分类 + 独立开关（不再是 backendType 单选项），
-      // 故这里不再有 'sync.interconnect_pointer' 指引行。
+      // BUG-1084：互联回到「同步方式」选择器；选中时显示一行指引（连接配置在
+      // 「Hibiki 互联」分类），其余后端各自的凭据/配置行不变。
       expect(idsOf(dest.sections[0]), <String>[
         'sync.mode',
         'sync.account_status',
@@ -58,6 +58,7 @@ void main() {
         'sync.webdav_config',
         'sync.ftp_config',
         'sync.sftp_config',
+        'sync.interconnect_config_note',
       ]);
     });
 
@@ -93,18 +94,16 @@ void main() {
     });
 
     test(
-        'auto-sync is gated on the hosting role; other content switches are not',
+        'auto-sync and upload switches are gated; content-scope switches are not',
         () {
-      // Auto-sync is an OUTBOUND switch (TODO-876 / BUG-NNN): a Hibiki host has
-      // no outbound sync, so the toggle is a no-op there and must be hidden in
-      // host mode — same gate as sync_now / compare (BUG-084). The remaining
-      // "what to sync" switches are content-scope settings that still apply to
-      // client mode, so they stay unconditional (always shown).
+      // Auto-sync 与三个「上传X文件」开关都带可见性谓词（见下方 source guard 对
+      // 谓词内容的锁定）；统计/词典/本地音频是 content-scope 设置，恒显。
       final SettingsSection content = dest.sections[1];
       SettingsItem byId(String id) =>
           content.items.firstWhere((SettingsItem i) => i.id == id);
       expect(byId('sync.auto_sync').visible, isNotNull,
-          reason: 'auto-sync must be hidden when hosting as a server');
+          reason:
+              'auto-sync hides when the sync method itself has no outbound');
       for (final String id in <String>[
         'sync.statistics',
         'sync.dictionary',
@@ -113,46 +112,53 @@ void main() {
         expect(byId(id).visible, isNull,
             reason: '$id is a content-scope setting, global to every backend');
       }
-      // a147a28ca：三个「上传X文件」开关都是 OUTBOUND——互联 host 无 outbound
-      // sync，host 模式下纯空转，随 auto_sync 的 !_isHostingInterconnect 门控隐藏
-      //（client 模式仍可见）。基底提交改了源码未同步本断言，这里按其意图更新。
       for (final String id in <String>[
         'sync.content',
         'sync.audiobook_files',
         'sync.video_files',
       ]) {
         expect(byId(id).visible, isNotNull,
-            reason: '$id is an outbound upload switch, hidden while hosting');
+            reason: '$id is a cloud-channel upload switch, gated on backend');
       }
     });
 
-    test('sync.video_files is unconditional across every backend', () {
-      // Source guard: 视频上传开关不再带 backend-scope 门控——云后端与互联(hibikiServer)
-      // 都实现了视频文件上传（云走 syncVideoAssets，互联走 _syncVideosLive host 端点），
-      // 故绝不能再携带 `!= SyncBackendType.hibikiServer` 之类的隐藏判据。
+    test(
+        'upload switches hide only when the sync method is the interconnect '
+        '(BUG-1084)', () {
+      // Source guard: BUG-988 起互联通道读互联专属上传开关（互联分类里那四个），
+      // 共享 sync.* 上传开关只管云通道——它们唯一的死区是「同步方式=互联」（该通道
+      // 按互联专属开关走）。绝不能再按 _isHostingInterconnect 隐藏：host 身份不影响
+      // 云后端出站，旧门控把 host 设备上 Google Drive 的上传开关整排藏掉（BUG-1084）。
       final String src =
           File('lib/src/sync/sync_settings_schema.dart').readAsStringSync();
-      final int at = src.indexOf("id: 'sync.video_files'");
-      expect(at, greaterThanOrEqualTo(0));
-      final String block = src.substring(at, at + 500);
-      expect(block, isNot(contains('!= SyncBackendType.hibikiServer')),
-          reason:
-              'video upload now works on every backend; no hibikiServer gate');
+      for (final String id in <String>[
+        'sync.content',
+        'sync.audiobook_files',
+        'sync.video_files',
+      ]) {
+        final int at = src.indexOf("id: '$id'");
+        expect(at, greaterThanOrEqualTo(0));
+        final String block = src.substring(at, at + 500);
+        expect(block, contains('!= SyncBackendType.hibikiServer'),
+            reason: '$id governs the cloud channel; dead when method=互联');
+        expect(block, isNot(contains('_isHostingInterconnect')),
+            reason: '$id must not hide on host identity (BUG-1084)');
+      }
     });
 
-    test('auto-sync gate keys off the hosting-interconnect role (TODO-876)',
-        () {
-      // Source guard: auto_sync must hide via !_isHostingInterconnect — the same
-      // both-conditions role used by sync_now / compare — so a stale
-      // serverEnabled flag on a cloud backend can't hide auto-sync, and a
-      // client-mode hibikiServer (which DOES have outbound sync) keeps it shown.
+    test('auto-sync gate keys off cloud-outbound availability (BUG-1084)', () {
+      // Source guard: auto_sync must hide via !_cloudOutboundUnavailable — the
+      // combined "method is interconnect AND hosting" predicate shared with
+      // sync_now / compare. Host identity alone (cloud backend selected) must
+      // NOT hide it: the cloud channel keeps its outbound while hosting.
       final String src =
           File('lib/src/sync/sync_settings_schema.dart').readAsStringSync();
       final int autoSyncAt = src.indexOf("id: 'sync.auto_sync'");
       expect(autoSyncAt, greaterThanOrEqualTo(0));
       final String autoSyncBlock = src.substring(autoSyncAt, autoSyncAt + 900);
-      expect(autoSyncBlock, contains('!_isHostingInterconnect('),
-          reason: 'auto-sync must hide only while hosting the interconnect');
+      expect(autoSyncBlock, contains('!_cloudOutboundUnavailable('),
+          reason:
+              'auto-sync hides only when the cloud channel has no outbound');
     });
 
     test('manual-sync actions are gated on server mode (BUG-084)', () {
@@ -170,13 +176,13 @@ void main() {
           reason: 'the server-mode note shows only while hosting');
     });
 
-    test('the action gates key off the hosting-interconnect role (BUG-084)',
-        () {
-      // Source guard: the gates must branch on _isHostingInterconnect, which
-      // requires BOTH serverEnabled AND the hibikiServer backend — so a stale
-      // serverEnabled flag left from a past interconnect session can't hide
-      // sync-now on a cloud backend (observed: serverEnabled=true while
-      // backendType=googleDrive).
+    test(
+        'the action gates key off cloud-outbound availability '
+        '(BUG-084 / BUG-1084)', () {
+      // Source guard: the gates must branch on _cloudOutboundUnavailable, which
+      // requires the sync method to BE the interconnect AND the hosting role —
+      // so neither a stale serverEnabled flag nor genuine hosting can hide
+      // sync-now on a cloud backend (a host still uploads to Google Drive).
       final String src =
           File('lib/src/sync/sync_settings_schema.dart').readAsStringSync();
       final int noteAt = src.indexOf("id: 'sync.server_mode_note'");
@@ -184,17 +190,25 @@ void main() {
       final int compareAt = src.indexOf("id: 'sync.compare'");
       expect(noteAt, greaterThanOrEqualTo(0));
       for (final int at in <int>[noteAt, nowAt, compareAt]) {
-        expect(src.substring(at, at + 200), contains('_isHostingInterconnect'),
-            reason: 'manual-sync gate must use the hosting-interconnect role');
+        expect(
+            src.substring(at, at + 200), contains('_cloudOutboundUnavailable'),
+            reason: 'manual-sync gate must use cloud-outbound availability');
       }
-      // The helper itself must require both conditions (not serverEnabled alone):
-      // 互联解耦后由独立的 interconnectEnabled 开关取代 backendType==hibikiServer，
-      // 故 stale serverEnabled（互联关闭时）不得再隐藏云后端的 sync-now。
-      final int helperAt = src.indexOf('bool _isHostingInterconnect(');
+      // 谓词链自身必须同时咬住三个条件：backendType==hibikiServer（同步方式是互联）
+      // + serverEnabled + interconnectEnabled（_isHostingInterconnect 的两条件，
+      // BUG-084 的 stale serverEnabled 防线保持不变）。
+      final int helperAt = src.indexOf('bool _cloudOutboundUnavailable(');
       expect(helperAt, greaterThanOrEqualTo(0));
-      final String helper = src.substring(helperAt, helperAt + 200);
-      expect(helper, contains('serverEnabled'));
-      expect(helper, contains('interconnectEnabled'),
+      final String helper = src.substring(helperAt, helperAt + 300);
+      expect(helper, contains('== SyncBackendType.hibikiServer'),
+          reason: 'outbound only vanishes when the method itself is 互联');
+      expect(helper, contains('_isHostingInterconnect'),
+          reason: 'and only while actually hosting');
+      final int hostingAt = src.indexOf('bool _isHostingInterconnect(');
+      expect(hostingAt, greaterThanOrEqualTo(0));
+      final String hosting = src.substring(hostingAt, hostingAt + 200);
+      expect(hosting, contains('serverEnabled'));
+      expect(hosting, contains('interconnectEnabled'),
           reason: 'hosting role must also require interconnect to be enabled');
     });
 
@@ -218,6 +232,39 @@ void main() {
           .map((SettingsItem i) => i.id)
           .toList();
       expect(allIds, isNot(contains('sync.smb_config')));
+    });
+
+    test('the backend picker lists the interconnect again (BUG-1084)', () {
+      // Source guard: _isBackendSelectable 对 hibikiServer 必须 return true。
+      // 解耦时它被从选择器摘掉，唯一补偿入口（互联页「设为备份后端」按钮）又被
+      // host 门控藏住，host 设备上「备份写到已配对设备」入口彻底消失。
+      final String src =
+          File('lib/src/sync/sync_settings_schema/backend_config.part.dart')
+              .readAsStringSync();
+      final int fnAt = src.indexOf('bool _isBackendSelectable(');
+      expect(fnAt, greaterThanOrEqualTo(0));
+      final String fn = src.substring(fnAt, src.indexOf('\n}', fnAt));
+      final int caseAt = fn.indexOf('case SyncBackendType.hibikiServer:');
+      expect(caseAt, greaterThanOrEqualTo(0));
+      final String afterCase = fn.substring(caseAt, caseAt + 80);
+      expect(afterCase, contains('return true'),
+          reason: 'hibikiServer must be selectable as a sync method');
+    });
+
+    test(
+        'selecting the interconnect as sync method enables interconnect '
+        '(BUG-1084)', () {
+      // Source guard: _selectBackend 选中 hibikiServer 时必须顺手
+      // setInterconnectEnabled(true)——不开互联总开关，连接配置区不显示、通道认证
+      // 也过不去，选完就是个死后端。
+      final String src =
+          File('lib/src/sync/sync_settings_schema/backend_config.part.dart')
+              .readAsStringSync();
+      final int fnAt = src.indexOf('Future<void> _selectBackend(');
+      expect(fnAt, greaterThanOrEqualTo(0));
+      final String fn = src.substring(fnAt, fnAt + 1200);
+      expect(fn, contains('setInterconnectEnabled(true)'),
+          reason: 'picking 互联 must flip the interconnect master toggle on');
     });
   });
 


### PR DESCRIPTION
## 问题（用户报告）

- 「同步方式」里没有 Hibiki 互联
- 上传书籍/词典/有声书/视频等开关在「同步与备份」里全部消失
- 互联页「设为备份后端」按钮也看不到
- 用户诉求：用 Google Drive 等云后端时上传开关必须存在且生效

## 根因（三处叠加，详见 docs/bugs/BUG-1084）

1. `a147a28ca` 用 `!_isHostingInterconnect` 把云通道的上传/自动同步/立即同步/比较整排藏掉。该理由只在互联还是互斥单选的旧模型成立；解耦（PR#223）+ 双通道（BUG-988）后，host 设备的云通道照常出站，门控成了错误特例。
2. 解耦时 `_isBackendSelectable(hibikiServer)` 改成 false，互联从选择器消失。
3. 唯一补偿入口「设为备份后端」按钮又被同一个 host 门控藏住——host 设备上入口彻底死循环。

## 修复

- `_isBackendSelectable(hibikiServer)` → true，互联回到「同步方式」；选中时自动 `setInterconnectEnabled(true)` 并显示指引行（复用既有 key `interconnect_moved_note`，零 i18n 增删）
- 新谓词 `_cloudOutboundUnavailable` = 同步方式==互联 && 正在做 host：六处门控（auto_sync/sync_now/compare/server_mode_note + 语义反转）只在真正无出站的组合下隐藏
- 三个云通道上传开关改 `backendType != hibikiServer` 门控（同步方式=互联时该通道按 BUG-988 读互联专属开关，共享开关是死开关）；漫画走 EPUB 书籍管线，属「上传书籍」通道
- BUG-084 的 stale serverEnabled 防线保持不变

## 验证

- `flutter analyze` 0 issues
- `flutter test test/sync test/settings --no-pub` 1932 全绿（含新增 4 个 BUG-1084 守卫 + 更新的旧断言）
- `flutter test test/tools --no-pub` 83 全绿（bug 档案守卫）

https://claude.ai/code/session_01CBXmTSFq4SeuBwW4ouocs5