### PR TITLE
fix(download): Nyaa 搜索真实报错穿透 + 结果排序 + 罗马音默认 + 集号框宽度 (BUG-1086/1087)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1050 条。点号进各自文件。
+> 共 1052 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1087](bugs/BUG-1087-jimaku-episode-label-truncated.md) | ✅ | ✅ | 番剧下载确认页集号输入框在界面缩放下 label 截断成「集…」 |
+| [BUG-1086](bugs/BUG-1086-nyaa-search-error-swallowed.md) | ✅ | ✅ | Nyaa 搜索网络错误被吞成统一文案，真实报错不可见（生肉分类超时无从定位） |
 | [BUG-1083](bugs/BUG-1083-manga-author-edit-missing.md) | ✅ | ✅ | 漫画编辑对话框缺作者字段(未覆盖supportsAuthorEdit) |
 | [BUG-1082](bugs/BUG-1082-scrape-poster-lowres.md) | ✅ | ✅ | TMDB刮削海报w500缩略图发糊非满分辨率 |
 | [BUG-1081](bugs/BUG-1081-poster-use-no-feedback.md) | ✅ | ✅ | 海报匹配弹窗点使用没反应无进度反馈 |

--- a/docs/bugs/BUG-1086-nyaa-search-error-swallowed.md
+++ b/docs/bugs/BUG-1086-nyaa-search-error-swallowed.md
@@ -3,6 +3,6 @@
 - **真实性**：✅ 真 bug。根因两层：
   - `hibiki/lib/src/media/torrent/nyaa_client.dart:252`（旧版 `search()`）把**所有**异常和非 200 吞成空列表——真实网络故障（本机直连 nyaa.si 被墙，curl 复现 SSL 握手失败 exit 35；走代理四个分类全部秒回）要么被误报成「无结果」，要么只有 20s 超时后的统一文案。「生肉超时、全部能搜」只是直连被墙链路的间歇性，不是分类差异。
   - `hibiki/lib/src/pages/implementations/anime_download_dialog.dart` 错误态 `_buildErrorRetry` 只渲染统一 i18n 文案，异常对象在 `catch (_)` 里被丢弃。
-- **[x] ① 已修复** — `NyaaClient.search` 改为抛错穿透（非 200 抛 `ClientException('HTTP <code>')`，底层网络异常原样上抛）；对话框 `_fetchTorrents`/`_searchAnime` 捕获后把 `error.toString()` 存入 `_torrentsErrorDetail`/`_animeSearchErrorDetail`，错误态展示真实异常串 + 「站点无法直连时可在下载设置配置网络代理」提示 + 「去设置」直达；订阅服务 `_check` 原有整体 try/catch 顺带修正「网络错误被当成无新集并清空 lastError」的隐性问题。
+- **[x] ① 已修复** — `NyaaClient.search` 改为抛错穿透（非 200 抛 `ClientException('HTTP <code>')`，底层网络异常原样上抛）；对话框 `_fetchTorrents`/`_searchAnime` 捕获后把 `error.toString()` 存入 `_torrentsErrorDetail`/`_animeSearchErrorDetail`，错误态展示真实异常串 + 「站点无法直连时可在下载设置配置网络代理」提示 + 「去设置」直达；订阅服务 `_check` 原有整体 try/catch 顺带修正「网络错误被当成无新集并清空 lastError」的隐性问题。提交 a940dcf23。
 - **[x] ② 已加自动化测试** — `hibiki/test/torrent/nyaa_client_test.dart`（非 200 → 抛 ClientException 含状态码；底层握手异常原样穿透，不吞成空列表）；`hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart`（错误态渲染真实异常串 + 代理提示 + 去设置按钮）。
 - **备注**：超时本身是环境问题（直连被墙 + 系统代理「已配置但未启用」，app 下载客户端 auto 模式按 环境变量 > 已启用系统代理 > 直连 回退到直连）；app 侧根治就是把错误穿透出来引导用户配代理——下载设置本就有 auto/直连/自定义代理三档。

--- a/docs/bugs/BUG-1086-nyaa-search-error-swallowed.md
+++ b/docs/bugs/BUG-1086-nyaa-search-error-swallowed.md
@@ -1,0 +1,8 @@
+## BUG-1086 · Nyaa 搜索网络错误被吞成统一文案，真实报错不可见（生肉分类超时无从定位）
+- **报告**：2026-07-25（用户：下载页发现 tab 搜「Watashi wo Tabetai, Hitodenashi」，「全部」能搜、切「生肉」分类转 20s 后只给「搜索失败或超时，请点重试」；要求把真实报错写出来）
+- **真实性**：✅ 真 bug。根因两层：
+  - `hibiki/lib/src/media/torrent/nyaa_client.dart:252`（旧版 `search()`）把**所有**异常和非 200 吞成空列表——真实网络故障（本机直连 nyaa.si 被墙，curl 复现 SSL 握手失败 exit 35；走代理四个分类全部秒回）要么被误报成「无结果」，要么只有 20s 超时后的统一文案。「生肉超时、全部能搜」只是直连被墙链路的间歇性，不是分类差异。
+  - `hibiki/lib/src/pages/implementations/anime_download_dialog.dart` 错误态 `_buildErrorRetry` 只渲染统一 i18n 文案，异常对象在 `catch (_)` 里被丢弃。
+- **[x] ① 已修复** — `NyaaClient.search` 改为抛错穿透（非 200 抛 `ClientException('HTTP <code>')`，底层网络异常原样上抛）；对话框 `_fetchTorrents`/`_searchAnime` 捕获后把 `error.toString()` 存入 `_torrentsErrorDetail`/`_animeSearchErrorDetail`，错误态展示真实异常串 + 「站点无法直连时可在下载设置配置网络代理」提示 + 「去设置」直达；订阅服务 `_check` 原有整体 try/catch 顺带修正「网络错误被当成无新集并清空 lastError」的隐性问题。
+- **[x] ② 已加自动化测试** — `hibiki/test/torrent/nyaa_client_test.dart`（非 200 → 抛 ClientException 含状态码；底层握手异常原样穿透，不吞成空列表）；`hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart`（错误态渲染真实异常串 + 代理提示 + 去设置按钮）。
+- **备注**：超时本身是环境问题（直连被墙 + 系统代理「已配置但未启用」，app 下载客户端 auto 模式按 环境变量 > 已启用系统代理 > 直连 回退到直连）；app 侧根治就是把错误穿透出来引导用户配代理——下载设置本就有 auto/直连/自定义代理三档。

--- a/docs/bugs/BUG-1087-jimaku-episode-label-truncated.md
+++ b/docs/bugs/BUG-1087-jimaku-episode-label-truncated.md
@@ -1,0 +1,6 @@
+## BUG-1087 · 番剧下载确认页集号输入框在界面缩放下 label 截断成「集…」
+- **报告**：2026-07-25（用户截图：4K 下确认推送阶段，字幕手动搜索行右侧集号框只显示「集…」）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/anime_download_dialog.dart` `_buildJimakuManualSearch` 里集号 `TextField` 外层 `SizedBox(width: 72)`：72 逻辑像素减去 `InputDecoration` 内边距后，「集号」两个 CJK 字符在界面缩放（浏览器式缩放）>1 时装不下，resting label 被省略号截断。
+- **[x] ① 已修复** — 宽度 72 → 96（同一提交顺带：字幕搜索词默认预填罗马字并提供 罗马字/日文原名/英文名 下拉切换，与 Nyaa 查询词同口径——用户同轮要求）。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart`：断言集号输入框渲染宽度 96、字幕搜索词预填罗马字、下拉切换日文原名生效。
+- **备注**：更彻底的做法是让 label 自适应宽度（IntrinsicWidth），但集号本就是 1–4 位数字输入，固定 96 已给缩放留足余量，不引入布局复杂度。

--- a/docs/bugs/BUG-1087-jimaku-episode-label-truncated.md
+++ b/docs/bugs/BUG-1087-jimaku-episode-label-truncated.md
@@ -1,6 +1,6 @@
 ## BUG-1087 · 番剧下载确认页集号输入框在界面缩放下 label 截断成「集…」
 - **报告**：2026-07-25（用户截图：4K 下确认推送阶段，字幕手动搜索行右侧集号框只显示「集…」）
 - **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/anime_download_dialog.dart` `_buildJimakuManualSearch` 里集号 `TextField` 外层 `SizedBox(width: 72)`：72 逻辑像素减去 `InputDecoration` 内边距后，「集号」两个 CJK 字符在界面缩放（浏览器式缩放）>1 时装不下，resting label 被省略号截断。
-- **[x] ① 已修复** — 宽度 72 → 96（同一提交顺带：字幕搜索词默认预填罗马字并提供 罗马字/日文原名/英文名 下拉切换，与 Nyaa 查询词同口径——用户同轮要求）。
+- **[x] ① 已修复** — 宽度 72 → 96（同一提交顺带：字幕搜索词默认预填罗马字并提供 罗马字/日文原名/英文名 下拉切换，与 Nyaa 查询词同口径——用户同轮要求）。提交 a940dcf23。
 - **[x] ② 已加自动化测试** — `hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart`：断言集号输入框渲染宽度 96、字幕搜索词预填罗马字、下拉切换日文原名生效。
 - **备注**：更彻底的做法是让 label 自适应宽度（IntrinsicWidth），但集号本就是 1–4 位数字输入，固定 96 已给缩放留足余量，不引入布局复杂度。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 44302 (2606 per locale)
+/// Strings: 44370 (2610 per locale)
 ///
-/// Built on 2026-07-25 at 13:49 UTC
+/// Built on 2026-07-25 at 14:19 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3452,6 +3452,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get book_scrape_failed => 'Failed to fetch cover';
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   String get add_to_collection => 'Add to collection';
+  String get anime_download_sort_seeders => 'Seeders';
+  String get anime_download_sort_size => 'Size';
+  String get anime_download_sort_date => 'Published';
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -9356,6 +9361,15 @@ class _StringsAr extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -15333,6 +15347,15 @@ class _StringsDe extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -21326,6 +21349,15 @@ class _StringsEs extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -27330,6 +27362,15 @@ class _StringsFr extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -33261,6 +33302,15 @@ class _StringsId extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -39240,6 +39290,15 @@ class _StringsIt extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -45024,6 +45083,15 @@ class _StringsJa extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -50811,6 +50879,15 @@ class _StringsKo extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -56768,6 +56845,15 @@ class _StringsNl extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -62740,6 +62826,15 @@ class _StringsPtBr extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -68695,6 +68790,15 @@ class _StringsRu extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -74595,6 +74699,15 @@ class _StringsTh extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -80527,6 +80640,15 @@ class _StringsTr extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -86446,6 +86568,15 @@ class _StringsVi extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 // Path: <root>
@@ -91955,6 +92086,14 @@ class _StringsZhCn extends _StringsEn {
   String get book_scrape_search_failed => '搜索失败，请点击「搜索」重试';
   @override
   String get add_to_collection => '加入合集';
+  @override
+  String get anime_download_sort_seeders => '做种数';
+  @override
+  String get anime_download_sort_size => '体积';
+  @override
+  String get anime_download_sort_date => '发布时间';
+  @override
+  String get anime_download_search_error_proxy_hint => '站点无法直连时，可在下载设置中配置网络代理。';
 }
 
 // Path: <root>
@@ -97657,6 +97796,15 @@ class _StringsZhHk extends _StringsEn {
   String get book_scrape_search_failed => 'Search failed. Tap Search to retry.';
   @override
   String get add_to_collection => 'Add to collection';
+  @override
+  String get anime_download_sort_seeders => 'Seeders';
+  @override
+  String get anime_download_sort_size => 'Size';
+  @override
+  String get anime_download_sort_date => 'Published';
+  @override
+  String get anime_download_search_error_proxy_hint =>
+      'If the site cannot be reached directly, configure a network proxy in download settings.';
 }
 
 /// Flat map(s) containing all translations.
@@ -102977,6 +103125,14 @@ extension on _StringsEn {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -108295,6 +108451,14 @@ extension on _StringsAr {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -113634,6 +113798,14 @@ extension on _StringsDe {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -118972,6 +119144,14 @@ extension on _StringsEs {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -124316,6 +124496,14 @@ extension on _StringsFr {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -129642,6 +129830,14 @@ extension on _StringsId {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -134983,6 +135179,14 @@ extension on _StringsIt {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -140286,6 +140490,14 @@ extension on _StringsJa {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -145593,6 +145805,14 @@ extension on _StringsKo {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -150927,6 +151147,14 @@ extension on _StringsNl {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -156258,6 +156486,14 @@ extension on _StringsPtBr {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -161594,6 +161830,14 @@ extension on _StringsRu {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -166914,6 +167158,14 @@ extension on _StringsTh {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -172243,6 +172495,14 @@ extension on _StringsTr {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -177567,6 +177827,14 @@ extension on _StringsVi {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }
@@ -182851,6 +183119,14 @@ extension on _StringsZhCn {
         return '搜索失败，请点击「搜索」重试';
       case 'add_to_collection':
         return '加入合集';
+      case 'anime_download_sort_seeders':
+        return '做种数';
+      case 'anime_download_sort_size':
+        return '体积';
+      case 'anime_download_sort_date':
+        return '发布时间';
+      case 'anime_download_search_error_proxy_hint':
+        return '站点无法直连时，可在下载设置中配置网络代理。';
       default:
         return null;
     }
@@ -188149,6 +188425,14 @@ extension on _StringsZhHk {
         return 'Search failed. Tap Search to retry.';
       case 'add_to_collection':
         return 'Add to collection';
+      case 'anime_download_sort_seeders':
+        return 'Seeders';
+      case 'anime_download_sort_size':
+        return 'Size';
+      case 'anime_download_sort_date':
+        return 'Published';
+      case 'anime_download_search_error_proxy_hint':
+        return 'If the site cannot be reached directly, configure a network proxy in download settings.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "无匹配封面",
   "book_scrape_failed": "封面获取失败",
   "book_scrape_search_failed": "搜索失败，请点击「搜索」重试",
-  "add_to_collection": "加入合集"
+  "add_to_collection": "加入合集",
+  "anime_download_sort_seeders": "做种数",
+  "anime_download_sort_size": "体积",
+  "anime_download_sort_date": "发布时间",
+  "anime_download_search_error_proxy_hint": "站点无法直连时，可在下载设置中配置网络代理。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2604,5 +2604,9 @@
   "book_scrape_empty": "No matching covers",
   "book_scrape_failed": "Failed to fetch cover",
   "book_scrape_search_failed": "Search failed. Tap Search to retry.",
-  "add_to_collection": "Add to collection"
+  "add_to_collection": "Add to collection",
+  "anime_download_sort_seeders": "Seeders",
+  "anime_download_sort_size": "Size",
+  "anime_download_sort_date": "Published",
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
 }

--- a/hibiki/lib/src/media/torrent/nyaa_client.dart
+++ b/hibiki/lib/src/media/torrent/nyaa_client.dart
@@ -249,30 +249,31 @@ class NyaaClient {
   final String baseUrl;
   final http.Client _client;
 
-  /// 按关键词搜索种子。网络错误 / 非 200 返回空列表，不抛。
+  /// 按关键词搜索种子。网络错误 / 非 200 **抛出**（`ClientException` /
+  /// `SocketException` / `HandshakeException` 等），由调用方决定展示或记录：
+  /// 以前这里吞错返回空列表，真实网络故障（如站点被墙、代理未配）会被
+  /// 误报成「无结果」，用户无从判断。RSS 内容坏损仍宽容（[parseNyaaRss]）。
   Future<List<NyaaTorrent>> search(
     String query, {
     String category = '1_0',
     String filter = '0',
   }) async {
-    try {
-      final Uri uri = Uri.parse(baseUrl).replace(
-        path: '/',
-        queryParameters: <String, String>{
-          'page': 'rss',
-          'q': query,
-          'c': category,
-          'f': filter,
-        },
-      );
-      final http.Response res = await _client.get(uri);
-      if (res.statusCode != 200) return const <NyaaTorrent>[];
-      // Nyaa RSS 是 UTF-8 但常不声明 charset，http 的 res.body 会按 latin1 解码 →
-      // 日文标题变乱码（如「ソ・ラ・ノ・ヲ・ト」→「Soã»Ra...」）。显式按 UTF-8 解码。
-      return parseNyaaRss(utf8.decode(res.bodyBytes, allowMalformed: true));
-    } catch (_) {
-      return const <NyaaTorrent>[];
+    final Uri uri = Uri.parse(baseUrl).replace(
+      path: '/',
+      queryParameters: <String, String>{
+        'page': 'rss',
+        'q': query,
+        'c': category,
+        'f': filter,
+      },
+    );
+    final http.Response res = await _client.get(uri);
+    if (res.statusCode != 200) {
+      throw http.ClientException('HTTP ${res.statusCode}', uri);
     }
+    // Nyaa RSS 是 UTF-8 但常不声明 charset，http 的 res.body 会按 latin1 解码 →
+    // 日文标题变乱码（如「ソ・ラ・ノ・ヲ・ト」→「Soã»Ra...」）。显式按 UTF-8 解码。
+    return parseNyaaRss(utf8.decode(res.bodyBytes, allowMalformed: true));
   }
 
   void close() => _client.close();

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -29,6 +29,40 @@ import 'package:hibiki/utils.dart';
 /// 分节渐进式（同 [JimakuSubtitleDialog] 的节奏）：三个阶段互斥展示（搜番结果 /
 /// 种子列表 / 确认推送），底部常驻「下载任务」折叠区列出既有计划。所有网络操作
 /// 容错降级为空结果 + 节内提示，不崩对话框。
+/// 选种结果排序键（一律降序：多的/大的/新的在前）。
+enum TorrentSortKey { seeders, size, date }
+
+/// 选种结果排序比较器（一律降序；size/date 缺失值沉底）。纯函数，便于单测。
+int compareNyaaTorrents(TorrentSortKey key, NyaaTorrent a, NyaaTorrent b) {
+  switch (key) {
+    case TorrentSortKey.seeders:
+      return b.seeders.compareTo(a.seeders);
+    case TorrentSortKey.size:
+      return (b.sizeBytes ?? -1).compareTo(a.sizeBytes ?? -1);
+    case TorrentSortKey.date:
+      final DateTime aDate =
+          a.pubDate ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final DateTime bDate =
+          b.pubDate ?? DateTime.fromMillisecondsSinceEpoch(0);
+      return bDate.compareTo(aDate);
+  }
+}
+
+/// 手动字幕搜索框的标题候选（罗马字优先 → 日文原名 → 英文；去空、去重，保序）。
+/// 首项是默认预填（与 Nyaa 查询词同口径），其余供输入框下拉切换。纯函数。
+List<String> animeTitleOptions(AniListMedia media) {
+  final List<String> out = <String>[];
+  for (final String? title in <String?>[
+    media.romaji,
+    media.native,
+    media.english,
+  ]) {
+    final String q = title?.trim() ?? '';
+    if (q.isNotEmpty && !out.contains(q)) out.add(q);
+  }
+  return out;
+}
+
 class AnimeDownloadDialog extends ConsumerStatefulWidget {
   const AnimeDownloadDialog({
     super.key,
@@ -89,6 +123,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
 
   /// 搜番失败/超时（区分「搜索出错」与「真没结果」，避免超时也显示「无结果」）。
   bool _animeSearchError = false;
+
+  /// 搜番失败的真实错误串（异常 toString），错误态原样展示帮助定位网络问题。
+  String? _animeSearchErrorDetail;
   List<AniListMedia> _animeMatches = const <AniListMedia>[];
   AniListMedia? _selectedMedia;
 
@@ -98,9 +135,14 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
 
   /// 选种搜索失败/超时（区分出错与真无种子）。
   bool _torrentsError = false;
+
+  /// 选种搜索失败的真实错误串（异常 toString，如 HandshakeException / 超时），
+  /// 错误态原样展示：站点被墙 / 代理未配时用户能看出是自己网络的问题。
+  String? _torrentsErrorDetail;
   List<NyaaTorrent> _torrents = const <NyaaTorrent>[];
   String _category = '1_0';
   bool _trustedOnly = false;
+  TorrentSortKey _torrentSort = TorrentSortKey.seeders;
   List<JimakuEntry> _jimakuEntries = const <JimakuEntry>[];
   JimakuEntry? _selectedJimakuEntry;
   List<JimakuFile> _jimakuFiles = const <JimakuFile>[];
@@ -135,6 +177,8 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
     final AniListMedia? debugMedia = widget.debugInitialMedia;
     if (debugMedia != null) {
       _selectedMedia = debugMedia;
+      // 与真实点选路径同口径预填查询词（罗马字），测试直达时行为一致。
+      _prefillQueriesFor(debugMedia);
       final NyaaTorrent? debugTorrent = widget.debugInitialTorrent;
       if (debugTorrent != null) {
         _selectedTorrent = debugTorrent;
@@ -177,6 +221,7 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
       _searchingAnime = true;
       _searchedAnime = false;
       _animeSearchError = false;
+      _animeSearchErrorDetail = null;
       _animeMatches = const <AniListMedia>[];
     });
     AniListClient? anilist;
@@ -191,27 +236,38 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
         _animeMatches = media;
         _searchedAnime = true;
       });
-    } catch (_) {
-      // 超时/网络错误：标记失败态（区分「无结果」），UI 给重试。
-      if (mounted) setState(() => _animeSearchError = true);
+    } catch (error) {
+      // 超时/网络错误：标记失败态（区分「无结果」），UI 给重试 + 真实错误串。
+      if (mounted) {
+        setState(() {
+          _animeSearchError = true;
+          _animeSearchErrorDetail = error.toString();
+        });
+      }
     } finally {
       anilist?.close();
       if (mounted) setState(() => _searchingAnime = false);
     }
   }
 
-  /// 点选某番：进入选种阶段，并行拉 Nyaa 种子与 Jimaku 字幕索引。
-  /// Jimaku 空结果/无 key 不阻塞选种，只是徽标显示无字幕。
-  Future<void> _selectMedia(AniListMedia media) async {
+  /// 选番后的查询词预填：Nyaa 查询词与手动字幕搜索框都预填罗马字（Jimaku
+  /// 条目名多为罗马字，同口径），集号清空；其余标题（日文原名/英文名）在
+  /// 输入框下拉里可选，用户可改词/填集号重搜。
+  void _prefillQueriesFor(AniListMedia media) {
     final String query = (media.romaji?.trim().isNotEmpty ?? false)
         ? media.romaji!.trim()
         : media.displayTitle;
     _nyaaQueryCtrl.text = query;
-    // 手动字幕搜索框预填自动推导标题（日文名优先），集号清空；用户可改词/填集号重搜。
-    final List<String> jimakuQueries = _jimakuFallbackQueries(media);
+    final List<String> titleOptions = _titleOptions(media);
     _jimakuQueryCtrl.text =
-        jimakuQueries.isNotEmpty ? jimakuQueries.first : media.displayTitle;
+        titleOptions.isNotEmpty ? titleOptions.first : media.displayTitle;
     _jimakuEpisodeCtrl.clear();
+  }
+
+  /// 点选某番：进入选种阶段，并行拉 Nyaa 种子与 Jimaku 字幕索引。
+  /// Jimaku 空结果/无 key 不阻塞选种，只是徽标显示无字幕。
+  Future<void> _selectMedia(AniListMedia media) async {
+    _prefillQueriesFor(media);
     setState(() {
       _selectedMedia = media;
       _selectedTorrent = null;
@@ -244,7 +300,7 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
 
   // ---------------------------------------------------------------- 阶段 2
 
-  /// 按当前查询词/分类/Trusted 过滤搜 Nyaa，结果按 seeders 降序。
+  /// 按当前查询词/分类/Trusted 过滤搜 Nyaa，结果按 [_torrentSort] 降序。
   Future<void> _fetchTorrents() async {
     final String query = _nyaaQueryCtrl.text.trim();
     if (query.isEmpty) return;
@@ -252,6 +308,7 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
       _loadingTorrents = true;
       _torrentsLoaded = false;
       _torrentsError = false;
+      _torrentsErrorDetail = null;
     });
     NyaaClient? nyaa;
     try {
@@ -266,19 +323,46 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
           )
           .timeout(const Duration(seconds: 20));
       final List<NyaaTorrent> sorted = List<NyaaTorrent>.of(results)
-        ..sort(
-            (NyaaTorrent a, NyaaTorrent b) => b.seeders.compareTo(a.seeders));
+        ..sort(_compareTorrents);
       if (!mounted) return;
       setState(() {
         _torrents = sorted;
         _torrentsLoaded = true;
       });
-    } catch (_) {
-      if (mounted) setState(() => _torrentsError = true);
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _torrentsError = true;
+          _torrentsErrorDetail = error.toString();
+        });
+      }
     } finally {
       nyaa?.close();
       if (mounted) setState(() => _loadingTorrents = false);
     }
+  }
+
+  int _compareTorrents(NyaaTorrent a, NyaaTorrent b) =>
+      compareNyaaTorrents(_torrentSort, a, b);
+
+  String _torrentSortLabel(TorrentSortKey key) {
+    switch (key) {
+      case TorrentSortKey.seeders:
+        return t.anime_download_sort_seeders;
+      case TorrentSortKey.size:
+        return t.anime_download_sort_size;
+      case TorrentSortKey.date:
+        return t.anime_download_sort_date;
+    }
+  }
+
+  /// 切换排序键：就地重排已加载结果，不重新请求。
+  void _selectTorrentSort(TorrentSortKey key) {
+    if (_torrentSort == key) return;
+    setState(() {
+      _torrentSort = key;
+      _torrents = List<NyaaTorrent>.of(_torrents)..sort(_compareTorrents);
+    });
   }
 
   /// 自动拉 Jimaku 字幕索引（选番时）：先按 AniList id 搜、空则回退标题文本搜。
@@ -466,6 +550,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
     }
     return out;
   }
+
+  /// 手动搜索框的标题候选，见顶层 [animeTitleOptions]。
+  List<String> _titleOptions(AniListMedia media) => animeTitleOptions(media);
 
   /// 手动重搜 Jimaku 字幕（用户填了 key / 出错后重试）。
   Future<void> _retryJimaku() async {
@@ -916,8 +1003,15 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
   }
 
   /// 出错态：一句提示 + 重试按钮（区分「出错/超时」与「真无结果」）。
+  /// [detail] 是真实错误串（异常 toString），原样展示帮助定位（如握手失败 =
+  /// 站点被墙）；[offerSettings] 再补一行代理提示 + 「去设置」直达下载设置。
   Widget _buildErrorRetry(
-      ThemeData theme, String message, VoidCallback onRetry) {
+    ThemeData theme,
+    String message,
+    VoidCallback onRetry, {
+    String? detail,
+    bool offerSettings = false,
+  }) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -926,11 +1020,49 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
               size: 40, color: theme.colorScheme.error),
           const SizedBox(height: 8),
           Text(message, textAlign: TextAlign.center),
+          if (detail != null && detail.isNotEmpty) ...<Widget>[
+            const SizedBox(height: 4),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 520),
+              child: Text(
+                detail,
+                textAlign: TextAlign.center,
+                maxLines: 4,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
+            ),
+          ],
+          if (offerSettings) ...<Widget>[
+            const SizedBox(height: 4),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 520),
+              child: Text(
+                t.anime_download_search_error_proxy_hint,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.outline),
+              ),
+            ),
+          ],
           const SizedBox(height: 8),
-          FilledButton.tonalIcon(
-            onPressed: onRetry,
-            icon: const Icon(Icons.refresh, size: 18),
-            label: Text(t.anime_download_retry),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              FilledButton.tonalIcon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh, size: 18),
+                label: Text(t.anime_download_retry),
+              ),
+              if (offerSettings) ...<Widget>[
+                const SizedBox(width: 8),
+                TextButton(
+                  onPressed: _openBackendSettings,
+                  child: Text(t.download_open_settings),
+                ),
+              ],
+            ],
           ),
         ],
       ),
@@ -943,7 +1075,12 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
     }
     if (_animeSearchError) {
       return _buildErrorRetry(
-          theme, t.anime_download_search_failed, _searchAnime);
+        theme,
+        t.anime_download_search_failed,
+        _searchAnime,
+        detail: _animeSearchErrorDetail,
+        offerSettings: true,
+      );
     }
     if (_searchedAnime && _animeMatches.isEmpty) {
       return Center(child: Text(t.anime_download_no_results));
@@ -1056,6 +1193,25 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
               selected: _trustedOnly,
               onSelected: _loadingTorrents ? null : _toggleTrustedOnly,
             ),
+            PopupMenuButton<TorrentSortKey>(
+              tooltip: t.sort_by,
+              initialValue: _torrentSort,
+              enabled: !_loadingTorrents,
+              onSelected: _selectTorrentSort,
+              itemBuilder: (BuildContext context) =>
+                  <PopupMenuEntry<TorrentSortKey>>[
+                for (final TorrentSortKey key in TorrentSortKey.values)
+                  PopupMenuItem<TorrentSortKey>(
+                    value: key,
+                    child: Text(_torrentSortLabel(key)),
+                  ),
+              ],
+              child: Chip(
+                avatar: const Icon(Icons.sort, size: 18),
+                label: Text('${t.sort_by}: ${_torrentSortLabel(_torrentSort)}'),
+                visualDensity: VisualDensity.compact,
+              ),
+            ),
           ],
         ),
         const SizedBox(height: 8),
@@ -1070,7 +1226,12 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
     }
     if (_torrentsError) {
       return _buildErrorRetry(
-          theme, t.anime_download_search_failed, _fetchTorrents);
+        theme,
+        t.anime_download_search_failed,
+        _fetchTorrents,
+        detail: _torrentsErrorDetail,
+        offerSettings: true,
+      );
     }
     if (_torrentsLoaded && _torrents.isEmpty) {
       return Center(child: Text(t.anime_download_no_results));
@@ -1277,9 +1438,13 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
     );
   }
 
-  /// 字幕手动搜索行：可编辑搜索词（预填自动推导标题）+ 集号 + 搜索按钮。自动搜不到
-  /// 或命中错版时，用户改词/填集号重搜 Jimaku（i18n 复用视频字幕对话框同款 key）。
+  /// 字幕手动搜索行：可编辑搜索词（预填罗马字，下拉可换日文原名/英文名）+
+  /// 集号 + 搜索按钮。自动搜不到或命中错版时，用户改词/填集号重搜 Jimaku
+  /// （i18n 复用视频字幕对话框同款 key）。
   Widget _buildJimakuManualSearch(ThemeData theme) {
+    final AniListMedia? media = _selectedMedia;
+    final List<String> titleOptions =
+        media == null ? const <String>[] : _titleOptions(media);
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: <Widget>[
@@ -1289,6 +1454,27 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
             decoration: InputDecoration(
               labelText: t.video_jimaku_query,
               isDense: true,
+              // 标题候选下拉（≥2 个才显示）：罗马字/日文原名/英文名一键切换。
+              suffixIcon: titleOptions.length < 2
+                  ? null
+                  : PopupMenuButton<String>(
+                      tooltip: t.video_jimaku_query,
+                      icon: const Icon(Icons.arrow_drop_down),
+                      onSelected: (String value) =>
+                          _jimakuQueryCtrl.text = value,
+                      itemBuilder: (BuildContext context) =>
+                          <PopupMenuEntry<String>>[
+                        for (final String title in titleOptions)
+                          PopupMenuItem<String>(
+                            value: title,
+                            child: Text(
+                              title,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                      ],
+                    ),
             ),
             textInputAction: TextInputAction.search,
             onSubmitted: (_) => _searchJimakuManual(),
@@ -1296,7 +1482,8 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
         ),
         const SizedBox(width: 8),
         SizedBox(
-          width: 72,
+          // 96：72 在界面缩放 >1 时装不下「集号」label，会截成「集…」。
+          width: 96,
           child: TextField(
             controller: _jimakuEpisodeCtrl,
             keyboardType: TextInputType.number,

--- a/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
+++ b/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
@@ -1,0 +1,275 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/src/media/torrent/anime_download_config.dart';
+import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
+import 'package:hibiki/src/media/torrent/nyaa_client.dart';
+import 'package:hibiki/src/media/video/anilist_client.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/pages/implementations/anime_download_dialog.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// 番剧下载「发现」流 UX 回归：
+/// - Nyaa 搜索网络故障不再吞成「无结果」/统一文案：错误态展示真实异常串 +
+///   代理提示 + 「去设置」（用户报告：站点被墙时切分类超时无从定位）。
+/// - 选种结果排序（做种数/体积/发布时间，一律降序）。
+/// - 手动字幕搜索词默认罗马字（与 Nyaa 查询词同口径），下拉可切日文原名。
+/// - 集号输入框宽度 96（72 在界面缩放 >1 时 label 截成「集…」）。
+
+const AniListMedia _kMedia = AniListMedia(
+  id: 1,
+  romaji: 'Test Anime',
+  native: 'テスト・アニメ',
+  english: 'The Test Anime',
+  episodes: 12,
+  seasonYear: 2026,
+);
+
+const NyaaTorrent _kTorrent = NyaaTorrent(
+  title: '[Group] Test Anime - 01 [1080p]',
+  torrentUrl: 'https://nyaa.si/download/1.torrent',
+  pageUrl: 'https://nyaa.si/view/1',
+  infoHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  seeders: 100,
+  leechers: 1,
+  downloads: 1000,
+  sizeText: '1.4 GiB',
+  sizeBytes: 1503238553,
+  categoryId: '1_2',
+  trusted: false,
+  remake: false,
+  pubDate: null,
+);
+
+String _rssItem({
+  required String title,
+  required String hash,
+  required int seeders,
+  required String size,
+}) {
+  return '''
+  <item>
+    <title>$title</title>
+    <link>https://nyaa.si/download/$hash.torrent</link>
+    <guid>https://nyaa.si/view/$hash</guid>
+    <nyaa:infoHash>$hash</nyaa:infoHash>
+    <nyaa:seeders>$seeders</nyaa:seeders>
+    <nyaa:size>$size</nyaa:size>
+  </item>''';
+}
+
+final String _kSortRss = '''
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:nyaa="https://nyaa.si/xmlns/nyaa">
+  <channel>
+${_rssItem(title: 'seeders-top', hash: 'a' * 40, seeders: 300, size: '1 GiB')}
+${_rssItem(title: 'size-top', hash: 'b' * 40, seeders: 10, size: '10 GiB')}
+${_rssItem(title: 'middle', hash: 'c' * 40, seeders: 100, size: '5 GiB')}
+  </channel>
+</rss>''';
+
+/// 纯内存计划存储（widget 测试不碰真实文件）。
+class _MemPlanStore extends AnimeDownloadPlanStore {
+  _MemPlanStore() : super(baseDir: Directory('unused-mem-store'));
+
+  @override
+  Future<List<AnimeDownloadPlan>> loadAll() async =>
+      const <AnimeDownloadPlan>[];
+
+  @override
+  Future<void> save(AnimeDownloadPlan plan) async {}
+
+  @override
+  Future<void> delete(String id) async {}
+}
+
+class _FakeAppModel extends AppModel {
+  _FakeAppModel(this._httpHandler) : super(testPlatformServices());
+
+  final Future<http.Response> Function(http.Request request) _httpHandler;
+  final _MemPlanStore store = _MemPlanStore();
+
+  @override
+  String get jimakuApiKey => 'key';
+
+  @override
+  QbConnectionConfig? get qbConnectionConfig => const QbConnectionConfig(
+        backend: QbConnectionConfig.backendQbittorrent,
+        baseUrl: 'http://127.0.0.1:1',
+      );
+
+  @override
+  bool get torrentUploadIntroShown => true;
+
+  @override
+  AnimeDownloadPlanStore? get animeDownloadPlanStore => store;
+
+  @override
+  Future<http.Client> createDownloadHttpClient() async =>
+      MockClient(_httpHandler);
+}
+
+void main() {
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+  });
+
+  Future<void> pumpDialog(
+    WidgetTester tester,
+    _FakeAppModel appModel, {
+    NyaaTorrent? torrent,
+  }) async {
+    await tester.pumpWidget(ProviderScope(
+      overrides: <Override>[
+        appProvider.overrideWith((ref) => appModel),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: AnimeDownloadDialog(
+              embedded: true,
+              debugInitialMedia: _kMedia,
+              debugInitialTorrent: torrent,
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+  }
+
+  group('纯函数', () {
+    test('compareNyaaTorrents：三键降序，size/date 缺失沉底', () {
+      final NyaaTorrent small = _torrentWith(seeders: 5, sizeBytes: 100);
+      final NyaaTorrent big = _torrentWith(seeders: 1, sizeBytes: 900);
+      final NyaaTorrent noSize = _torrentWith(seeders: 9, sizeBytes: null);
+      expect(
+          compareNyaaTorrents(TorrentSortKey.seeders, noSize, small) < 0, true);
+      expect(compareNyaaTorrents(TorrentSortKey.size, big, small) < 0, true);
+      expect(compareNyaaTorrents(TorrentSortKey.size, small, noSize) < 0, true);
+
+      final NyaaTorrent newer =
+          _torrentWith(seeders: 1, pubDate: DateTime.utc(2026, 7, 2));
+      final NyaaTorrent older =
+          _torrentWith(seeders: 1, pubDate: DateTime.utc(2026, 7, 1));
+      final NyaaTorrent noDate = _torrentWith(seeders: 1);
+      expect(compareNyaaTorrents(TorrentSortKey.date, newer, older) < 0, true);
+      expect(compareNyaaTorrents(TorrentSortKey.date, older, noDate) < 0, true);
+    });
+
+    test('animeTitleOptions：罗马字优先、去空去重保序', () {
+      expect(animeTitleOptions(_kMedia),
+          <String>['Test Anime', 'テスト・アニメ', 'The Test Anime']);
+      expect(
+        animeTitleOptions(
+            const AniListMedia(id: 2, romaji: 'Same', native: 'Same')),
+        <String>['Same'],
+      );
+      expect(
+        animeTitleOptions(const AniListMedia(id: 3, native: 'ネイティブ')),
+        <String>['ネイティブ'],
+      );
+    });
+  });
+
+  testWidgets('Nyaa 搜索网络错误：展示真实异常串 + 代理提示 + 去设置', (WidgetTester tester) async {
+    final _FakeAppModel appModel = _FakeAppModel((http.Request req) async {
+      throw http.ClientException('HandshakeException: 站点被墙', req.url);
+    });
+    await pumpDialog(tester, appModel);
+
+    // Nyaa 查询词已预填罗马字，直接点搜索。
+    await tester.tap(find.byTooltip(t.anime_download_search).first);
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.anime_download_search_failed), findsOneWidget);
+    expect(find.textContaining('HandshakeException'), findsOneWidget);
+    expect(find.text(t.anime_download_search_error_proxy_hint), findsOneWidget);
+    expect(find.text(t.download_open_settings), findsOneWidget);
+  });
+
+  testWidgets('选种结果排序：默认做种数降序，切「体积」就地重排', (WidgetTester tester) async {
+    final _FakeAppModel appModel = _FakeAppModel((http.Request req) async {
+      return http.Response.bytes(_kSortRss.codeUnits, 200);
+    });
+    await pumpDialog(tester, appModel);
+
+    await tester.tap(find.byTooltip(t.anime_download_search).first);
+    await tester.pumpAndSettle();
+
+    // 只收结果行（任务折叠区表头也是 ListTile，按已知标题过滤）。
+    const Set<String> known = <String>{'seeders-top', 'middle', 'size-top'};
+    List<String> titles() => tester
+        .widgetList<ListTile>(find.byType(ListTile))
+        .map((ListTile tile) => tile.title)
+        .whereType<Text>()
+        .map((Text text) => text.data)
+        .whereType<String>()
+        .where(known.contains)
+        .toList();
+    expect(titles(), <String>['seeders-top', 'middle', 'size-top']);
+
+    // 打开排序菜单，切换到「体积」。
+    await tester
+        .tap(find.text('${t.sort_by}: ${t.anime_download_sort_seeders}'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.anime_download_sort_size).last);
+    await tester.pumpAndSettle();
+
+    expect(titles(), <String>['size-top', 'middle', 'seeders-top']);
+    expect(find.text('${t.sort_by}: ${t.anime_download_sort_size}'),
+        findsOneWidget);
+  });
+
+  testWidgets('确认阶段：字幕搜索词默认罗马字、下拉可切日文原名、集号框宽 96', (WidgetTester tester) async {
+    final _FakeAppModel appModel =
+        _FakeAppModel((http.Request req) async => http.Response('', 404));
+    await pumpDialog(tester, appModel, torrent: _kTorrent);
+
+    final Finder queryField = find.byWidgetPredicate((Widget w) =>
+        w is TextField && w.decoration?.labelText == t.video_jimaku_query);
+    expect(queryField, findsOneWidget);
+    expect(tester.widget<TextField>(queryField).controller!.text, 'Test Anime');
+
+    // 标题候选下拉：切到日文原名。
+    await tester.tap(find.byIcon(Icons.arrow_drop_down).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('テスト・アニメ').last);
+    await tester.pumpAndSettle();
+    expect(tester.widget<TextField>(queryField).controller!.text, 'テスト・アニメ');
+
+    // 集号输入框宽度 96（回归：72 在界面缩放 >1 时 label 截成「集…」）。
+    final Finder episodeField = find.byWidgetPredicate((Widget w) =>
+        w is TextField && w.decoration?.labelText == t.video_jimaku_episode);
+    expect(episodeField, findsOneWidget);
+    expect(tester.getSize(episodeField).width, 96);
+  });
+}
+
+NyaaTorrent _torrentWith({
+  required int seeders,
+  int? sizeBytes,
+  DateTime? pubDate,
+}) {
+  return NyaaTorrent(
+    title: 't',
+    torrentUrl: '',
+    pageUrl: '',
+    infoHash: '',
+    seeders: seeders,
+    leechers: 0,
+    downloads: 0,
+    sizeText: '',
+    sizeBytes: sizeBytes,
+    categoryId: '1_0',
+    trusted: false,
+    remake: false,
+    pubDate: pubDate,
+  );
+}

--- a/hibiki/test/torrent/nyaa_client_test.dart
+++ b/hibiki/test/torrent/nyaa_client_test.dart
@@ -250,16 +250,38 @@ void main() {
       client.close();
     });
 
-    test('默认 category=1_0 / filter=0；非 200 → 空列表', () async {
+    test('默认 category=1_0 / filter=0；非 200 → 抛 ClientException（含状态码）',
+        () async {
+      // 以前吞错返回空列表，真实网络故障（站点被墙/代理未配）会被误报成
+      // 「无结果」；现在必须抛出让调用方展示真实错误。
       Uri? captured;
       final MockClient mock = MockClient((http.Request req) async {
         captured = req.url;
         return http.Response('server error', 500);
       });
       final NyaaClient client = NyaaClient(client: mock);
-      expect(await client.search('frieren'), isEmpty);
+      await expectLater(
+        client.search('frieren'),
+        throwsA(isA<http.ClientException>().having(
+            (http.ClientException e) => e.message, 'message', 'HTTP 500')),
+      );
       expect(captured!.queryParameters['c'], '1_0');
       expect(captured!.queryParameters['f'], '0');
+      client.close();
+    });
+
+    test('底层网络异常（如握手失败）原样穿透，不吞成空列表', () async {
+      final MockClient mock = MockClient((http.Request req) async {
+        throw http.ClientException('HandshakeException: 模拟被墙', req.url);
+      });
+      final NyaaClient client = NyaaClient(client: mock);
+      await expectLater(
+        client.search('frieren'),
+        throwsA(isA<http.ClientException>().having(
+            (http.ClientException e) => e.message,
+            'message',
+            contains('HandshakeException'))),
+      );
       client.close();
     });
 


### PR DESCRIPTION
## 背景（用户报告）

下载页「发现」搜番选种时：「全部」能搜，切「生肉」分类转 20s 只给统一文案「搜索失败或超时」；要求把真实报错写出来、支持按体积等排序；字幕手动搜索词应默认罗马音（番剧名可选）；集号输入框在 4K/缩放下截成「集…」。

## 根因与修复

- **BUG-1086 错误吞掉**：`NyaaClient.search` 把所有异常/非 200 吞成空列表——真实网络故障（本机直连 nyaa.si 被墙，curl 复现 SSL 握手失败；走代理四分类全部秒回）被误报成「无结果」或统一超时文案。「生肉超时、全部能搜」只是直连被墙的间歇性，不是分类差异。改为抛错穿透，UI 错误态展示真实异常串 + 「站点无法直连可在下载设置配代理」提示 + 「去设置」直达；订阅服务顺带修正「网络错误被当成无新集并清空 lastError」。
- **排序**：选种结果新增排序菜单（做种数/体积/发布时间，降序，缺失值沉底），切换就地重排不重新请求。
- **罗马音默认**：字幕手动搜索词与 Nyaa 查询词同口径预填罗马字，输入框下拉可切日文原名/英文名（`animeTitleOptions` 纯函数）。
- **BUG-1087 集号截断**：`SizedBox(width: 72)` → 96，缩放 >1 时「集号」label 不再截断。

## 验证

- `flutter analyze` 0 issues（全量含 test）
- `flutter test test/torrent test/media/torrent test/pages/anime_download_dialog_* test/i18n --no-pub` 247 全绿；bugs guard 绿
- 新增 `anime_download_dialog_discovery_ux_test.dart`：错误详情/代理提示/去设置、排序重排、罗马音预填、标题下拉、集号框宽度
- i18n 4 个新 key 走 `i18n_sync`（17 语言）+ `dart run slang`
- 待 Windows 真机复测原始失败路径（生肉分类 + 4K 缩放）

https://claude.ai/code/session_01HGPy5DRVxwWbzhRjjEYA5y