### PR TITLE
feat(manga): mokuro.moe 在线目录源（O1）——浏览/下载/直通导入链

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 44149 (2597 per locale)
+/// Strings: 44336 (2608 per locale)
 ///
-/// Built on 2026-07-25 at 08:44 UTC
+/// Built on 2026-07-25 at 14:19 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3443,6 +3443,19 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get browser_extension_version_browser => 'Loaded in browser';
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  String get manga_online_catalog_title => 'Online catalog';
+  String get manga_online_search_hint => 'Search series';
+  String get manga_online_load_failed => 'Failed to load catalog';
+  String get manga_online_downloaded => 'Imported';
+  String get manga_online_download_selected => 'Download selected';
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  String get manga_online_stage_extract => 'Extracting…';
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  String get manga_online_failed => 'Download failed';
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -9329,6 +9342,30 @@ class _StringsAr extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -15288,6 +15325,30 @@ class _StringsDe extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -21263,6 +21324,30 @@ class _StringsEs extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -27249,6 +27334,30 @@ class _StringsFr extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -33162,6 +33271,30 @@ class _StringsId extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -39123,6 +39256,30 @@ class _StringsIt extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -44889,6 +45046,30 @@ class _StringsJa extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -50658,6 +50839,30 @@ class _StringsKo extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -56597,6 +56802,30 @@ class _StringsNl extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -62551,6 +62780,30 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -68488,6 +68741,30 @@ class _StringsRu extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -74370,6 +74647,30 @@ class _StringsTh extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -80284,6 +80585,30 @@ class _StringsTr extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -86185,6 +86510,30 @@ class _StringsVi extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 // Path: <root>
@@ -91676,6 +92025,30 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       '浏览器中加载的扩展不是最新版本：如有需要先重新准备扩展，再到浏览器扩展管理页（chrome://extensions）点「重新加载」。';
+  @override
+  String get manga_online_catalog_title => '在线目录';
+  @override
+  String get manga_online_search_hint => '搜索系列';
+  @override
+  String get manga_online_load_failed => '目录加载失败';
+  @override
+  String get manga_online_downloaded => '已入库';
+  @override
+  String get manga_online_download_selected => '下载所选';
+  @override
+  String get manga_online_stage_mokuro => '下载 OCR 数据…';
+  @override
+  String get manga_online_stage_cbz => '下载卷包…';
+  @override
+  String get manga_online_stage_extract => '解包中…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      '第 ${done} / ${total} 卷';
+  @override
+  String get manga_online_failed => '下载失败';
+  @override
+  String get manga_online_base_url_label => '在线目录地址';
 }
 
 // Path: <root>
@@ -97360,6 +97733,30 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get browser_extension_version_mismatch =>
       'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+  @override
+  String get manga_online_catalog_title => 'Online catalog';
+  @override
+  String get manga_online_search_hint => 'Search series';
+  @override
+  String get manga_online_load_failed => 'Failed to load catalog';
+  @override
+  String get manga_online_downloaded => 'Imported';
+  @override
+  String get manga_online_download_selected => 'Download selected';
+  @override
+  String get manga_online_stage_mokuro => 'Downloading OCR data…';
+  @override
+  String get manga_online_stage_cbz => 'Downloading volume…';
+  @override
+  String get manga_online_stage_extract => 'Extracting…';
+  @override
+  String manga_online_queue_progress(
+          {required Object done, required Object total}) =>
+      'Volume ${done} / ${total}';
+  @override
+  String get manga_online_failed => 'Download failed';
+  @override
+  String get manga_online_base_url_label => 'Online catalog URL';
 }
 
 /// Flat map(s) containing all translations.
@@ -102662,6 +103059,29 @@ extension on _StringsEn {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -107962,6 +108382,29 @@ extension on _StringsAr {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -113283,6 +113726,29 @@ extension on _StringsDe {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -118603,6 +119069,29 @@ extension on _StringsEs {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -123929,6 +124418,29 @@ extension on _StringsFr {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -129237,6 +129749,29 @@ extension on _StringsId {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -134560,6 +135095,29 @@ extension on _StringsIt {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -139845,6 +140403,29 @@ extension on _StringsJa {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -145134,6 +145715,29 @@ extension on _StringsKo {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -150450,6 +151054,29 @@ extension on _StringsNl {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -155763,6 +156390,29 @@ extension on _StringsPtBr {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -161081,6 +161731,29 @@ extension on _StringsRu {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -166383,6 +167056,29 @@ extension on _StringsTh {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -171694,6 +172390,29 @@ extension on _StringsTr {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -177000,6 +177719,29 @@ extension on _StringsVi {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }
@@ -182266,6 +183008,29 @@ extension on _StringsZhCn {
         return '浏览器中加载';
       case 'browser_extension_version_mismatch':
         return '浏览器中加载的扩展不是最新版本：如有需要先重新准备扩展，再到浏览器扩展管理页（chrome://extensions）点「重新加载」。';
+      case 'manga_online_catalog_title':
+        return '在线目录';
+      case 'manga_online_search_hint':
+        return '搜索系列';
+      case 'manga_online_load_failed':
+        return '目录加载失败';
+      case 'manga_online_downloaded':
+        return '已入库';
+      case 'manga_online_download_selected':
+        return '下载所选';
+      case 'manga_online_stage_mokuro':
+        return '下载 OCR 数据…';
+      case 'manga_online_stage_cbz':
+        return '下载卷包…';
+      case 'manga_online_stage_extract':
+        return '解包中…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            '第 ${done} / ${total} 卷';
+      case 'manga_online_failed':
+        return '下载失败';
+      case 'manga_online_base_url_label':
+        return '在线目录地址';
       default:
         return null;
     }
@@ -187546,6 +188311,29 @@ extension on _StringsZhHk {
         return 'Loaded in browser';
       case 'browser_extension_version_mismatch':
         return 'The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser\'s extensions page (chrome://extensions).';
+      case 'manga_online_catalog_title':
+        return 'Online catalog';
+      case 'manga_online_search_hint':
+        return 'Search series';
+      case 'manga_online_load_failed':
+        return 'Failed to load catalog';
+      case 'manga_online_downloaded':
+        return 'Imported';
+      case 'manga_online_download_selected':
+        return 'Download selected';
+      case 'manga_online_stage_mokuro':
+        return 'Downloading OCR data…';
+      case 'manga_online_stage_cbz':
+        return 'Downloading volume…';
+      case 'manga_online_stage_extract':
+        return 'Extracting…';
+      case 'manga_online_queue_progress':
+        return ({required Object done, required Object total}) =>
+            'Volume ${done} / ${total}';
+      case 'manga_online_failed':
+        return 'Download failed';
+      case 'manga_online_base_url_label':
+        return 'Online catalog URL';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "换一个",
   "browser_extension_version_app": "App 内置",
   "browser_extension_version_browser": "浏览器中加载",
-  "browser_extension_version_mismatch": "浏览器中加载的扩展不是最新版本：如有需要先重新准备扩展，再到浏览器扩展管理页（chrome://extensions）点「重新加载」。"
+  "browser_extension_version_mismatch": "浏览器中加载的扩展不是最新版本：如有需要先重新准备扩展，再到浏览器扩展管理页（chrome://extensions）点「重新加载」。",
+  "manga_online_catalog_title": "在线目录",
+  "manga_online_search_hint": "搜索系列",
+  "manga_online_load_failed": "目录加载失败",
+  "manga_online_downloaded": "已入库",
+  "manga_online_download_selected": "下载所选",
+  "manga_online_stage_mokuro": "下载 OCR 数据…",
+  "manga_online_stage_cbz": "下载卷包…",
+  "manga_online_stage_extract": "解包中…",
+  "manga_online_queue_progress": "第 $done / $total 卷",
+  "manga_online_failed": "下载失败",
+  "manga_online_base_url_label": "在线目录地址"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2595,5 +2595,16 @@
   "game_random_reroll": "Shuffle",
   "browser_extension_version_app": "App bundled",
   "browser_extension_version_browser": "Loaded in browser",
-  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions)."
+  "browser_extension_version_mismatch": "The extension loaded in your browser is outdated. Prepare the extension again if needed, then reload it from your browser's extensions page (chrome://extensions).",
+  "manga_online_catalog_title": "Online catalog",
+  "manga_online_search_hint": "Search series",
+  "manga_online_load_failed": "Failed to load catalog",
+  "manga_online_downloaded": "Imported",
+  "manga_online_download_selected": "Download selected",
+  "manga_online_stage_mokuro": "Downloading OCR data…",
+  "manga_online_stage_cbz": "Downloading volume…",
+  "manga_online_stage_extract": "Extracting…",
+  "manga_online_queue_progress": "Volume $done / $total",
+  "manga_online_failed": "Download failed",
+  "manga_online_base_url_label": "Online catalog URL"
 }

--- a/hibiki/lib/src/media/audiobook/book_import_dialog.dart
+++ b/hibiki/lib/src/media/audiobook/book_import_dialog.dart
@@ -27,6 +27,7 @@ import 'package:hibiki/src/media/manga/external_mokuro_runner.dart';
 import 'package:hibiki/src/media/manga/manga_importer.dart';
 import 'package:hibiki/src/media/manga/manga_ocr_provider.dart';
 import 'package:hibiki/src/media/manga/manga_ocr_wizard_dialog.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_catalog_dialog.dart';
 import 'package:hibiki/src/pdf/pdf_importer.dart';
 import 'package:hibiki/src/sync/interconnect_manga_ocr_client.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
@@ -217,6 +218,12 @@ class _BookImportDialogState extends State<BookImportDialog>
               onPressed: importing ? null : _openOcrWizard,
               child: Text(t.manga_ocr_wizard_title),
             ),
+          // 漫画「在线目录」（O1 mokuro.moe 目录源）：卷级下载 → 现有导入链落库。
+          adaptiveDialogAction(
+            context: context,
+            onPressed: importing ? null : _openOnlineCatalog,
+            child: Text(t.manga_online_catalog_title),
+          ),
           adaptiveDialogAction(
             context: context,
             onPressed: () => Navigator.pop(context),
@@ -266,6 +273,20 @@ class _BookImportDialogState extends State<BookImportDialog>
       ),
     );
     if (bookKey != null && mounted) {
+      Navigator.pop(context, true);
+    }
+  }
+
+  /// 打开漫画「在线目录」（O1 mokuro.moe 目录源）：完全照 [_openOcrWizard] 范式，
+  /// 有导入发生（返回成功卷数 > 0）则连同关闭本导入框并回传 true，让书架刷新。
+  /// barrier 不可点关：导入计数经显式关闭按钮回传，点空白会丢「需刷新」信号。
+  Future<void> _openOnlineCatalog() async {
+    final int? imported = await showAppDialog<int>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => MokuroMoeCatalogDialog(db: widget.db),
+    );
+    if (imported != null && imported > 0 && mounted) {
       Navigator.pop(context, true);
     }
   }

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_dialog.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_dialog.dart
@@ -1,0 +1,615 @@
+import 'dart:async';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_client.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_volume_downloader.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/sync/ttu_filename.dart';
+import 'package:hibiki/utils.dart';
+
+/// 测试注入口：替换真实 [MokuroMoeVolumeDownloader.run]（widget 测试绕网络/DB）。
+typedef MokuroMoeVolumeRunner = Stream<MokuroMoeVolumeDownloadEvent> Function({
+  required String seriesName,
+  required String volumeName,
+});
+
+/// mokuro.moe「在线目录」对话框（O1）：浏览/搜索系列 → 选卷 → 顺序逐卷
+/// 下载（断点续传）→ 现有 `.mokuro` 导入链落库。
+///
+/// 照 [MangaOcrWizardDialog] 范式：依赖全构造注入（[clientOverride] /
+/// [runnerOverride] 供 widget 测试绕网络），阶段机 [_CatalogStage]，dispose
+/// 取消订阅。关闭时 `Navigator.pop(context, <int 本次成功导入卷数>)`——调用方
+/// 据 `> 0` 决定是否刷新书架。
+class MokuroMoeCatalogDialog extends ConsumerStatefulWidget {
+  const MokuroMoeCatalogDialog({
+    required this.db,
+    this.clientOverride,
+    this.runnerOverride,
+    super.key,
+  });
+
+  /// 目标数据库（漫画行写入此处）。
+  final HibikiDatabase db;
+
+  /// 测试用 client（null = 按偏好 base URL 构造真实 client）。
+  final MokuroMoeClient? clientOverride;
+
+  /// 测试用下载编排（null = 真实 [MokuroMoeVolumeDownloader]）。
+  final MokuroMoeVolumeRunner? runnerOverride;
+
+  @override
+  ConsumerState<MokuroMoeCatalogDialog> createState() =>
+      _MokuroMoeCatalogDialogState();
+}
+
+/// 对话框所处阶段。
+enum _CatalogStage { browse, series, downloading }
+
+class _MokuroMoeCatalogDialogState
+    extends ConsumerState<MokuroMoeCatalogDialog> {
+  late final MokuroMoeClient _client;
+  final TextEditingController _searchCtrl = TextEditingController();
+
+  _CatalogStage _stage = _CatalogStage.browse;
+
+  // browse。
+  List<MokuroMoeSeries>? _library;
+  bool _loading = false;
+  String? _loadError;
+  String _query = '';
+
+  // series。
+  MokuroMoeSeries? _series;
+  final Set<String> _selectedVolumes = <String>{};
+
+  /// 已在库的书身份 key（`sanitizeTtuFilename(title)`；含本次会话新导入的）。
+  final Set<String> _existingBookKeys = <String>{};
+
+  // downloading。
+  StreamSubscription<MokuroMoeVolumeDownloadEvent>? _sub;
+  MokuroMoeVolumeDownloader? _activeDownloader;
+  bool _cancelRequested = false;
+  String? _activeVolume;
+  MokuroMoeVolumeDownloadEvent? _lastEvent;
+  int _queueIndex = 0;
+  int _queueTotal = 0;
+  String? _downloadError;
+
+  /// 本次会话成功导入（新建行）的卷数——关闭时回传给调用方。
+  int _importedCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _client = widget.clientOverride ??
+        MokuroMoeClient(
+          baseUrl: ref.read(appProvider).mangaOnlineCatalogBaseUrl,
+        );
+    unawaited(_loadLibrary());
+    unawaited(_loadExistingBooks());
+  }
+
+  @override
+  void dispose() {
+    // 对话框被任何途径关掉（Esc/barrier/pop）都不能留下后台孤儿下载：
+    // cancel 保留 .part，下次打开同卷续传。
+    _activeDownloader?.cancel();
+    unawaited(_sub?.cancel());
+    _searchCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadLibrary() async {
+    setState(() {
+      _loading = true;
+      _loadError = null;
+    });
+    try {
+      final List<MokuroMoeSeries> library = await _client.fetchLibrary();
+      if (!mounted) return;
+      setState(() {
+        _library = library;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _loadError = '$e';
+      });
+    }
+  }
+
+  Future<void> _loadExistingBooks() async {
+    final List<EpubBookRow> rows = await widget.db.getAllEpubBooks();
+    if (!mounted) return;
+    setState(() {
+      _existingBookKeys
+          .addAll(rows.map((EpubBookRow r) => sanitizeTtuFilename(r.title)));
+    });
+  }
+
+  /// 一卷的入库身份 key（与导入侧 [MokuroMoeVolumeDownloader.volumeTitle] 同源）。
+  String _volumeKey(String volume) => sanitizeTtuFilename(
+      MokuroMoeVolumeDownloader.volumeTitle(_series?.name ?? '', volume));
+
+  bool _isImported(String volume) =>
+      _existingBookKeys.contains(_volumeKey(volume));
+
+  List<MokuroMoeSeries> get _filteredSeries {
+    final List<MokuroMoeSeries> all = _library ?? const <MokuroMoeSeries>[];
+    final String q = _query.trim().toLowerCase();
+    if (q.isEmpty) return all;
+    return all
+        .where((MokuroMoeSeries s) => s.name.toLowerCase().contains(q))
+        .toList();
+  }
+
+  void _openSeries(MokuroMoeSeries series) {
+    setState(() {
+      _series = series;
+      _selectedVolumes.clear();
+      _downloadError = null;
+      _stage = _CatalogStage.series;
+    });
+  }
+
+  void _backToBrowse() {
+    setState(() {
+      _series = null;
+      _selectedVolumes.clear();
+      _downloadError = null;
+      _stage = _CatalogStage.browse;
+    });
+  }
+
+  Future<void> _downloadSelected() async {
+    final MokuroMoeSeries? series = _series;
+    if (series == null || _selectedVolumes.isEmpty) return;
+    final List<String> queue = series.volumes
+        .map((MokuroMoeVolume v) => v.name)
+        .where(_selectedVolumes.contains)
+        .toList();
+    setState(() {
+      _stage = _CatalogStage.downloading;
+      _cancelRequested = false;
+      _downloadError = null;
+      _queueIndex = 0;
+      _queueTotal = queue.length;
+    });
+    for (int i = 0; i < queue.length; i++) {
+      if (!mounted || _cancelRequested) break;
+      setState(() {
+        _queueIndex = i;
+        _activeVolume = queue[i];
+        _lastEvent = null;
+      });
+      final bool ok = await _runVolume(series.name, queue[i]);
+      if (!mounted) return;
+      if (!ok) break; // 失败/取消即停队列（错误已展示；续传靠 .part）。
+    }
+    if (!mounted) return;
+    setState(() {
+      _activeVolume = null;
+      _activeDownloader = null;
+      _stage = _CatalogStage.series;
+    });
+  }
+
+  /// 跑一卷；成功（含「已在库跳过」）返回 true。
+  Future<bool> _runVolume(String seriesName, String volumeName) {
+    final Completer<bool> completer = Completer<bool>();
+    final Stream<MokuroMoeVolumeDownloadEvent> stream;
+    if (widget.runnerOverride != null) {
+      _activeDownloader = null;
+      stream = widget.runnerOverride!(
+          seriesName: seriesName, volumeName: volumeName);
+    } else {
+      final MokuroMoeVolumeDownloader downloader =
+          MokuroMoeVolumeDownloader(client: _client);
+      _activeDownloader = downloader;
+      stream = downloader.run(
+        db: widget.db,
+        seriesName: seriesName,
+        volumeName: volumeName,
+      );
+    }
+    _sub = stream.listen(
+      (MokuroMoeVolumeDownloadEvent event) {
+        if (!mounted) return;
+        setState(() {
+          _lastEvent = event;
+          if (event.stage == MokuroMoeDownloadStage.done) {
+            // 新建行与「已在库」都标记 ✓（不可重复下）；只有新建行计数。
+            _existingBookKeys.add(_volumeKey(volumeName));
+            _selectedVolumes.remove(volumeName);
+            if (!event.skippedExisting && event.bookKey != null) {
+              _importedCount++;
+            }
+          }
+        });
+        if (event.stage == MokuroMoeDownloadStage.done) {
+          HibikiToast.show(msg: t.manga_ocr_wizard_done);
+        }
+      },
+      onError: (Object e) {
+        if (mounted && e is! MokuroMoeDownloadCancelled) {
+          setState(() => _downloadError = '${t.manga_online_failed}: $e');
+        }
+        if (!completer.isCompleted) completer.complete(false);
+      },
+      onDone: () {
+        if (!completer.isCompleted) {
+          completer.complete(_lastEvent?.stage == MokuroMoeDownloadStage.done);
+        }
+      },
+    );
+    return completer.future;
+  }
+
+  void _cancelDownload() {
+    _cancelRequested = true;
+    final MokuroMoeVolumeDownloader? downloader = _activeDownloader;
+    if (downloader != null) {
+      downloader.cancel();
+    } else {
+      // 注入 runner（测试）没有 cancel 通道：直接掐订阅结束本卷。
+      unawaited(_sub?.cancel());
+      setState(() {
+        _activeVolume = null;
+        _stage = _CatalogStage.series;
+      });
+    }
+  }
+
+  void _close() => Navigator.pop(context, _importedCount);
+
+  // ── UI ───────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    // Esc/返回键关闭也必须带上 _importedCount 回传（否则调用方拿 null，
+    // 已导入的卷丢失书架刷新信号）——统一拦下来走 _close。
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (bool didPop, Object? result) {
+        if (!didPop) {
+          _close();
+        }
+      },
+      child: _buildDialog(tokens),
+    );
+  }
+
+  Widget _buildDialog(HibikiDesignTokens tokens) {
+    return AlertDialog(
+      title: Text(
+        _stage == _CatalogStage.browse
+            ? t.manga_online_catalog_title
+            : (_series?.name ?? t.manga_online_catalog_title),
+        overflow: TextOverflow.ellipsis,
+      ),
+      content: SizedBox(
+        width: 560,
+        height: 440,
+        child: _stage == _CatalogStage.browse
+            ? _buildBrowse(tokens)
+            : _buildSeries(tokens),
+      ),
+      actions: _buildActions(),
+    );
+  }
+
+  Widget _buildBrowse(HibikiDesignTokens tokens) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        TextField(
+          controller: _searchCtrl,
+          decoration: InputDecoration(
+            hintText: t.manga_online_search_hint,
+            prefixIcon: const Icon(Icons.search),
+            isDense: true,
+            border: const OutlineInputBorder(),
+          ),
+          onChanged: (String value) => setState(() => _query = value),
+        ),
+        SizedBox(height: tokens.spacing.gap),
+        Expanded(child: _buildBrowseBody(tokens)),
+      ],
+    );
+  }
+
+  Widget _buildBrowseBody(HibikiDesignTokens tokens) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    final String? error = _loadError;
+    if (error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              '${t.manga_online_load_failed}: $error',
+              style: tokens.type.listSubtitle
+                  .copyWith(color: Theme.of(context).colorScheme.error),
+              textAlign: TextAlign.center,
+              maxLines: 4,
+              overflow: TextOverflow.ellipsis,
+            ),
+            SizedBox(height: tokens.spacing.gap),
+            OutlinedButton(
+              onPressed: _loadLibrary,
+              child: Text(t.retry),
+            ),
+          ],
+        ),
+      );
+    }
+    final List<MokuroMoeSeries> series = _filteredSeries;
+    // 千余系列：GridView.builder 懒构建。
+    return GridView.builder(
+      gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+        maxCrossAxisExtent: 128,
+        childAspectRatio: 0.58,
+        crossAxisSpacing: 8,
+        mainAxisSpacing: 8,
+      ),
+      itemCount: series.length,
+      itemBuilder: (BuildContext context, int index) =>
+          _buildSeriesTile(tokens, series[index]),
+    );
+  }
+
+  Widget _buildSeriesTile(HibikiDesignTokens tokens, MokuroMoeSeries series) {
+    // 无封面占位：MD3 tokens 面色（overlay = 最高 tonal 层），不裸引 scheme 角色。
+    final Widget placeholder = ColoredBox(
+      color: tokens.surfaces.overlay,
+      child: Icon(Icons.menu_book_outlined, color: tokens.surfaces.onVariant),
+    );
+    return InkWell(
+      borderRadius: tokens.radii.cardRadius,
+      onTap: () => _openSeries(series),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Expanded(
+            child: ClipRRect(
+              borderRadius: tokens.radii.cardRadius,
+              child: series.cover.isEmpty
+                  ? placeholder
+                  : Image(
+                      image: CachedNetworkImageProvider(
+                        _client.coverUrl(series.cover),
+                        cacheKey: 'mokuromoe|${series.name}',
+                      ),
+                      fit: BoxFit.cover,
+                      errorBuilder:
+                          (BuildContext _, Object __, StackTrace? ___) =>
+                              placeholder,
+                    ),
+            ),
+          ),
+          SizedBox(height: tokens.spacing.gap / 2),
+          Text(
+            series.name,
+            style: tokens.type.metadata,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSeries(HibikiDesignTokens tokens) {
+    final MokuroMoeSeries? series = _series;
+    if (series == null) return const SizedBox.shrink();
+    final bool downloading = _stage == _CatalogStage.downloading;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        if (downloading) _buildDownloadPanel(tokens),
+        if (_downloadError != null)
+          Padding(
+            padding: EdgeInsets.only(bottom: tokens.spacing.gap),
+            child: Text(
+              _downloadError!,
+              style: tokens.type.listSubtitle
+                  .copyWith(color: Theme.of(context).colorScheme.error),
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        Expanded(
+          child: ListView.builder(
+            itemCount: series.volumes.length,
+            itemBuilder: (BuildContext context, int index) =>
+                _buildVolumeRow(tokens, series.volumes[index], downloading),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildVolumeRow(
+    HibikiDesignTokens tokens,
+    MokuroMoeVolume volume,
+    bool downloading,
+  ) {
+    final bool imported = _isImported(volume.name);
+    final bool active = downloading && _activeVolume == volume.name;
+    final Widget? subtitle = imported
+        ? Text(t.manga_online_downloaded, style: tokens.type.listSubtitle)
+        : (active
+            ? Text(_stageLabel(),
+                style: tokens.type.listSubtitle,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis)
+            : null);
+    // 手排行（MD3 tokens 间距），不走 ListTile（MD3 守卫：普通 chrome 统一走
+    // 共享 tokens 布局）。
+    return InkWell(
+      borderRadius: tokens.radii.controlRadius,
+      onTap: imported || downloading
+          ? null
+          : () => setState(() {
+                if (!_selectedVolumes.remove(volume.name)) {
+                  _selectedVolumes.add(volume.name);
+                }
+              }),
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing.gap,
+          vertical: tokens.spacing.gap / 2,
+        ),
+        child: Row(
+          children: <Widget>[
+            if (imported)
+              Icon(Icons.check_circle, color: tokens.surfaces.primary)
+            else
+              Checkbox(
+                value: _selectedVolumes.contains(volume.name),
+                onChanged: downloading
+                    ? null
+                    : (bool? checked) => setState(() {
+                          if (checked == true) {
+                            _selectedVolumes.add(volume.name);
+                          } else {
+                            _selectedVolumes.remove(volume.name);
+                          }
+                        }),
+              ),
+            SizedBox(width: tokens.spacing.gap),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    volume.name,
+                    style: tokens.type.listTitle,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (subtitle != null) subtitle,
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDownloadPanel(HibikiDesignTokens tokens) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: tokens.spacing.gap),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text(
+            '${t.manga_online_queue_progress(done: _queueIndex + 1, total: _queueTotal)}'
+            ' · ${_stageLabel()}',
+            style: tokens.type.listSubtitle,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          SizedBox(height: tokens.spacing.gap / 2),
+          LinearProgressIndicator(value: _progressValue()),
+        ],
+      ),
+    );
+  }
+
+  /// 当前卷的确定性进度（0..1）；未知总量阶段回 null（转圈条）。
+  double? _progressValue() {
+    final MokuroMoeVolumeDownloadEvent? event = _lastEvent;
+    if (event == null) return null;
+    switch (event.stage) {
+      case MokuroMoeDownloadStage.downloadingCbz:
+        final int? total = event.totalBytes;
+        if (total == null || total <= 0) return null;
+        return (event.receivedBytes / total).clamp(0.0, 1.0);
+      case MokuroMoeDownloadStage.importing:
+        if (event.pagesTotal <= 0) return null;
+        return (event.pagesDone / event.pagesTotal).clamp(0.0, 1.0);
+      case MokuroMoeDownloadStage.done:
+        return 1;
+      case MokuroMoeDownloadStage.downloadingMokuro:
+      case MokuroMoeDownloadStage.extracting:
+        return null;
+    }
+  }
+
+  String _stageLabel() {
+    final MokuroMoeVolumeDownloadEvent? event = _lastEvent;
+    switch (event?.stage) {
+      case null:
+      case MokuroMoeDownloadStage.downloadingMokuro:
+        return t.manga_online_stage_mokuro;
+      case MokuroMoeDownloadStage.downloadingCbz:
+        final int received = event!.receivedBytes;
+        final int? total = event.totalBytes;
+        final String bytes = total != null && total > 0
+            ? '${_mb(received)} / ${_mb(total)} MB'
+            : '${_mb(received)} MB';
+        return '${t.manga_online_stage_cbz} $bytes';
+      case MokuroMoeDownloadStage.extracting:
+        return t.manga_online_stage_extract;
+      case MokuroMoeDownloadStage.importing:
+        return event!.pagesTotal > 0
+            ? t.manga_ocr_wizard_page_progress(
+                done: event.pagesDone, total: event.pagesTotal)
+            : t.manga_ocr_wizard_importing;
+      case MokuroMoeDownloadStage.done:
+        return t.manga_ocr_wizard_done;
+    }
+  }
+
+  static String _mb(int bytes) => (bytes / (1024 * 1024)).toStringAsFixed(1);
+
+  List<Widget> _buildActions() {
+    switch (_stage) {
+      case _CatalogStage.browse:
+        return <Widget>[
+          adaptiveDialogAction(
+            context: context,
+            onPressed: _close,
+            child: Text(t.dialog_close),
+          ),
+        ];
+      case _CatalogStage.series:
+        return <Widget>[
+          adaptiveDialogAction(
+            context: context,
+            onPressed: _backToBrowse,
+            child: Text(t.back),
+          ),
+          adaptiveDialogAction(
+            context: context,
+            onPressed: _selectedVolumes.isEmpty ? null : _downloadSelected,
+            child: Text(t.manga_online_download_selected),
+          ),
+          adaptiveDialogAction(
+            context: context,
+            onPressed: _close,
+            child: Text(t.dialog_close),
+          ),
+        ];
+      case _CatalogStage.downloading:
+        return <Widget>[
+          adaptiveDialogAction(
+            context: context,
+            onPressed: _cancelDownload,
+            child: Text(t.dialog_cancel),
+          ),
+        ];
+    }
+  }
+}

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_client.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_client.dart
@@ -1,0 +1,167 @@
+/// mokuro.moe 在线目录（Mokuro Bunko）REST client：纯数据模型 + 无状态请求封装。
+///
+/// 合同（2026-07-25 实测）：
+/// - `GET /catalog/api/library` 无鉴权 → `{"series":[{name,path,cover,volumes:[...]}]}`；
+/// - `GET /catalog/api/series?name=<enc>` → 单系列同构对象；
+/// - 封面 `GET /catalog/api/cover?path=<enc>`；
+/// - 卷包 `GET /mokuro-reader/<系列>/<卷>.cbz`（纯图片 zip，支持 Range）；
+/// - OCR 数据同路径旁挂 `GET /mokuro-reader/<系列>/<卷>.mokuro`。
+///
+/// http 栈：`dart:io` [HttpClient] + `findProxyFromEnvironment`（与
+/// `manga_ocr_model_downloader.dart` 同范式），[createClient] 可注入指向
+/// loopback 测试服务器。系列名可含 `#` / 空格等字符，URL 段一律
+/// [Uri.encodeComponent] 逐段编码。
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+/// 默认目录站点（偏好 `manga_online_catalog_base_url` 空值时的回退）。
+const String kMokuroMoeDefaultBaseUrl = 'https://mokuro.moe';
+
+/// 归一 base URL：trim + 去尾斜杠；空串回退默认站点。
+String normalizeMokuroMoeBaseUrl(String raw) {
+  String s = raw.trim();
+  while (s.endsWith('/')) {
+    s = s.substring(0, s.length - 1);
+  }
+  return s.isEmpty ? kMokuroMoeDefaultBaseUrl : s;
+}
+
+/// 目录里的一卷（`volumes[]` 条目）。字段缺失/类型不符时全部容错取默认值。
+class MokuroMoeVolume {
+  const MokuroMoeVolume({
+    required this.name,
+    this.cover = '',
+    this.ocrPending = false,
+    this.ocrActive = false,
+  });
+
+  factory MokuroMoeVolume.fromJson(Map<String, Object?> json) {
+    return MokuroMoeVolume(
+      name: json['name'] is String ? json['name']! as String : '',
+      cover: json['cover'] is String ? json['cover']! as String : '',
+      ocrPending: json['ocr_pending'] == true,
+      ocrActive: json['ocr_active'] == true,
+    );
+  }
+
+  /// 卷名（同时是 `/mokuro-reader/<系列>/<卷>.cbz` 的 URL 段与 CBZ 内顶层目录名）。
+  final String name;
+
+  /// 封面相对路径（喂 [MokuroMoeClient.coverUrl]；空串 = 无封面）。
+  final String cover;
+
+  /// 站点侧 OCR 尚未完成/正在跑（此时 `.mokuro` 可能缺失或不完整）。
+  final bool ocrPending;
+  final bool ocrActive;
+}
+
+/// 目录里的一个系列（`series[]` 条目 / `api/series` 响应体）。
+class MokuroMoeSeries {
+  const MokuroMoeSeries({
+    required this.name,
+    this.path = '',
+    this.cover = '',
+    this.volumes = const <MokuroMoeVolume>[],
+  });
+
+  factory MokuroMoeSeries.fromJson(Map<String, Object?> json) {
+    final Object? rawVolumes = json['volumes'];
+    return MokuroMoeSeries(
+      name: json['name'] is String ? json['name']! as String : '',
+      path: json['path'] is String ? json['path']! as String : '',
+      cover: json['cover'] is String ? json['cover']! as String : '',
+      volumes: rawVolumes is List
+          ? rawVolumes
+              .whereType<Map<dynamic, dynamic>>()
+              .map((Map<dynamic, dynamic> v) =>
+                  MokuroMoeVolume.fromJson(v.cast<String, Object?>()))
+              .toList()
+          : const <MokuroMoeVolume>[],
+    );
+  }
+
+  final String name;
+  final String path;
+
+  /// 系列封面相对路径（形如 `<series>/<file>.webp`）。
+  final String cover;
+  final List<MokuroMoeVolume> volumes;
+}
+
+/// mokuro.moe REST client。方法可被测试子类 override（fake client 注入对话框）。
+class MokuroMoeClient {
+  MokuroMoeClient({
+    String baseUrl = kMokuroMoeDefaultBaseUrl,
+    HttpClient Function()? createClient,
+  })  : baseUrl = normalizeMokuroMoeBaseUrl(baseUrl),
+        _createClient = createClient ?? _defaultClient;
+
+  /// 已归一（无尾斜杠、非空）的站点根。
+  final String baseUrl;
+
+  final HttpClient Function() _createClient;
+
+  static HttpClient _defaultClient() =>
+      HttpClient()..findProxy = HttpClient.findProxyFromEnvironment;
+
+  /// 拉全量目录（约千余系列，几百 KB JSON）。
+  Future<List<MokuroMoeSeries>> fetchLibrary() async {
+    final Object? root = await _getJson('$baseUrl/catalog/api/library');
+    if (root is! Map) {
+      throw const FormatException('mokuro.moe library: not a JSON object');
+    }
+    final Object? rawSeries = root.cast<String, Object?>()['series'];
+    if (rawSeries is! List) return const <MokuroMoeSeries>[];
+    return rawSeries
+        .whereType<Map<dynamic, dynamic>>()
+        .map((Map<dynamic, dynamic> s) =>
+            MokuroMoeSeries.fromJson(s.cast<String, Object?>()))
+        .toList();
+  }
+
+  /// 拉单系列详情（与 library 条目同构）。
+  Future<MokuroMoeSeries> fetchSeries(String name) async {
+    final Object? root = await _getJson(
+        '$baseUrl/catalog/api/series?name=${Uri.encodeComponent(name)}');
+    if (root is! Map) {
+      throw const FormatException('mokuro.moe series: not a JSON object');
+    }
+    return MokuroMoeSeries.fromJson(root.cast<String, Object?>());
+  }
+
+  /// 封面绝对 URL（[coverPath] = 模型里的 `cover` 相对路径）。
+  String coverUrl(String coverPath) =>
+      '$baseUrl/catalog/api/cover?path=${Uri.encodeComponent(coverPath)}';
+
+  /// 一卷 CBZ（纯图片 zip）的绝对 URL。
+  String cbzUrl(String series, String volume) =>
+      '$baseUrl/mokuro-reader/${Uri.encodeComponent(series)}/'
+      '${Uri.encodeComponent(volume)}.cbz';
+
+  /// 一卷 `.mokuro`（OCR 数据 JSON）的绝对 URL。
+  String mokuroUrl(String series, String volume) =>
+      '$baseUrl/mokuro-reader/${Uri.encodeComponent(series)}/'
+      '${Uri.encodeComponent(volume)}.mokuro';
+
+  /// GET 一个 JSON 端点；非 200 抛 [HttpException]。
+  Future<Object?> _getJson(String url) async {
+    final HttpClient client = _createClient();
+    try {
+      final HttpClientRequest request = await client.getUrl(Uri.parse(url));
+      final HttpClientResponse response = await request.close();
+      if (response.statusCode != HttpStatus.ok) {
+        await response.drain<void>();
+        throw HttpException(
+          'mokuro.moe request failed: HTTP ${response.statusCode}',
+          uri: Uri.parse(url),
+        );
+      }
+      final String body = await utf8.decodeStream(response);
+      return jsonDecode(body);
+    } finally {
+      client.close(force: true);
+    }
+  }
+}

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_volume_downloader.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_volume_downloader.dart
@@ -1,0 +1,532 @@
+/// mokuro.moe 一卷的完整下载编排：`.mokuro`（小，直下）+ `.cbz`（大：`.part`
+/// 断点续传 + zip 中央目录校验 + 原子 rename）→ isolate 流式解包（防路径穿越）
+/// → [MangaImporter.importFromMokuroPath] 落库 → 清理临时目录。
+///
+/// 布局契约：CBZ 顶层是一个 `<卷名>/` 目录（内放页图），`.mokuro` 的 `img_path`
+/// 与之一致（`<卷名>/001.jpg`）。解包目录 T 下得到 `T/<卷名>/*.jpg`，`.mokuro`
+/// 落 `T/<卷名>.mokuro`——正好满足 [mangaImportCanImport] 的「同级一层子目录有图」
+/// 判定，零转换直通现有导入链。
+///
+/// 下载范式照 `manga_ocr_model_downloader.dart`（Range 续传 / 416 / 非 206 处理），
+/// 但 CBZ 无预知长度：完整性校验放宽为「zip 中央目录可解析」，不做 expectedBytes
+/// 强校验。解包范式照 `backup_service.dart` 的 `_backupExtractWorker`（
+/// `Isolate.spawn` + `InputFileStream` + 4MB 分块 + SendPort 回报进度）。
+///
+/// 多卷排队由 UI 层顺序 await，本类只管一卷；[cancel] 置标志、循环内检查，
+/// 取消保留 `.part` 以便续传。
+library;
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:archive/archive_io.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:hibiki/src/epub/book_title_conflict.dart';
+import 'package:hibiki/src/media/manga/manga_importer.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_client.dart';
+import 'package:hibiki/src/sync/ttu_filename.dart';
+
+/// 两次字节进度事件之间至少累积的字节数（避免大 CBZ 每 chunk 一事件淹没 UI）。
+const int kMokuroMoeProgressInterval = 512 * 1024;
+
+/// 一卷下载所处阶段。
+enum MokuroMoeDownloadStage {
+  downloadingMokuro,
+  downloadingCbz,
+  extracting,
+  importing,
+  done,
+}
+
+/// 下载事件：阶段 + 字节进度（total 未知时为 null）+ 导入页进度。
+/// [stage] == done 时 [bookKey] 非空（skipIfExists 命中则 [skippedExisting]
+/// 为 true、bookKey 为空——该卷已在库，视作成功但无新行）。
+class MokuroMoeVolumeDownloadEvent {
+  const MokuroMoeVolumeDownloadEvent({
+    required this.stage,
+    this.receivedBytes = 0,
+    this.totalBytes,
+    this.pagesDone = 0,
+    this.pagesTotal = 0,
+    this.bookKey,
+    this.skippedExisting = false,
+  });
+
+  final MokuroMoeDownloadStage stage;
+  final int receivedBytes;
+  final int? totalBytes;
+  final int pagesDone;
+  final int pagesTotal;
+  final String? bookKey;
+  final bool skippedExisting;
+}
+
+/// [MokuroMoeVolumeDownloader.cancel] 中止时抛出（事件流以此收尾）；`.part`
+/// 保留供下次续传。UI 层据类型区分「用户取消」与真实失败。
+class MokuroMoeDownloadCancelled implements Exception {
+  const MokuroMoeDownloadCancelled();
+
+  @override
+  String toString() => 'MokuroMoeDownloadCancelled';
+}
+
+/// 一卷的下载/解包/落库编排器（一次 [run]，不可复用）。
+class MokuroMoeVolumeDownloader {
+  MokuroMoeVolumeDownloader({
+    required this.client,
+    HttpClient Function()? createClient,
+    Directory? stagingRoot,
+    this.progressByteInterval = kMokuroMoeProgressInterval,
+  })  : _createClient = createClient ?? _defaultClient,
+        _stagingRoot = stagingRoot ??
+            Directory(p.join(Directory.systemTemp.path, 'hibiki_mokuro_moe'));
+
+  final MokuroMoeClient client;
+  final HttpClient Function() _createClient;
+
+  /// 断点续传的 `.part` / 已下完的 `.cbz` 落此根下的 `<系列>/<卷>/`
+  /// 确定性子目录（跨次运行可续传）。
+  final Directory _stagingRoot;
+
+  final int progressByteInterval;
+
+  bool _cancelled = false;
+
+  static HttpClient _defaultClient() =>
+      HttpClient()..findProxy = HttpClient.findProxyFromEnvironment;
+
+  /// 请求中止当前 run：下载循环在下个 chunk 处、阶段切换处检查并抛
+  /// [MokuroMoeDownloadCancelled]；`.part` 保留。
+  void cancel() => _cancelled = true;
+
+  /// 入库标题：`<系列> <卷>`；卷名已含系列名时直接用卷名（照
+  /// [MangaImporter] `_deriveTitle` 的去重口径）。
+  static String volumeTitle(String series, String volume) {
+    final String s = series.trim();
+    final String v = volume.trim();
+    if (s.isEmpty) return v.isEmpty ? 'manga' : v;
+    if (v.isEmpty) return s;
+    return v.contains(s) ? v : '$s $v';
+  }
+
+  /// 跑完一卷全流程。事件流以 done 事件正常结束；取消以
+  /// [MokuroMoeDownloadCancelled] 错误结束；其余失败以原始异常结束。
+  Stream<MokuroMoeVolumeDownloadEvent> run({
+    required HibikiDatabase db,
+    required String seriesName,
+    required String volumeName,
+  }) {
+    final StreamController<MokuroMoeVolumeDownloadEvent> controller =
+        StreamController<MokuroMoeVolumeDownloadEvent>();
+    controller.onListen = () {
+      _run(controller, db: db, seriesName: seriesName, volumeName: volumeName)
+          .then((void _) => controller.close(),
+              onError: (Object e, StackTrace stack) {
+        controller.addError(e, stack);
+        controller.close();
+      });
+    };
+    return controller.stream;
+  }
+
+  Future<void> _run(
+    StreamController<MokuroMoeVolumeDownloadEvent> controller, {
+    required HibikiDatabase db,
+    required String seriesName,
+    required String volumeName,
+  }) async {
+    final Directory staging = Directory(p.join(
+      _stagingRoot.path,
+      sanitizeTtuFilename(seriesName),
+      sanitizeTtuFilename(volumeName),
+    ));
+    await staging.create(recursive: true);
+    final File mokuroFile = File(p.join(staging.path, 'volume.mokuro'));
+    final File cbzFile = File(p.join(staging.path, 'volume.cbz'));
+    final Directory extractDir = Directory(p.join(staging.path, 'extract'));
+
+    try {
+      // 1. `.mokuro`（小 JSON）：每次重下覆盖（保证与站点最新 OCR 一致）。
+      _checkCancelled();
+      controller.add(const MokuroMoeVolumeDownloadEvent(
+        stage: MokuroMoeDownloadStage.downloadingMokuro,
+      ));
+      await _downloadSmall(
+        client.mokuroUrl(seriesName, volumeName),
+        mokuroFile,
+      );
+
+      // 2. `.cbz`：`.part` 断点续传 + zip 校验 + 原子 rename（已存在则直接复用
+      // ——上次下载完成但导入失败的续跑路径）。
+      _checkCancelled();
+      if (!cbzFile.existsSync()) {
+        await _downloadCbz(
+          controller,
+          url: client.cbzUrl(seriesName, volumeName),
+          target: cbzFile,
+        );
+      }
+
+      // 3. isolate 流式解包到 extract/（残留半成品先清掉，保证幂等）。
+      _checkCancelled();
+      if (extractDir.existsSync()) {
+        extractDir.deleteSync(recursive: true);
+      }
+      extractDir.createSync(recursive: true);
+      controller.add(const MokuroMoeVolumeDownloadEvent(
+        stage: MokuroMoeDownloadStage.extracting,
+      ));
+      await _extractInIsolate(
+        zipPath: cbzFile.path,
+        destDirPath: extractDir.path,
+        onBytes: _throttled(
+          (int received) => controller.add(MokuroMoeVolumeDownloadEvent(
+            stage: MokuroMoeDownloadStage.extracting,
+            receivedBytes: received,
+          )),
+        ),
+      );
+
+      // 4. `.mokuro` 放到解包目录同级（`T/<卷名>.mokuro` 配 `T/<卷名>/` 图片目录，
+      // 满足 mangaImportCanImport 的同级判定；img_path 相对 T 解析）。
+      _checkCancelled();
+      final File placedMokuro =
+          File(p.join(extractDir.path, '$volumeName.mokuro'));
+      mokuroFile.copySync(placedMokuro.path);
+
+      // 5. 现有导入链落库（skipIfExists：同名卷静默跳过，不复制成 `X (2)`）。
+      controller.add(const MokuroMoeVolumeDownloadEvent(
+        stage: MokuroMoeDownloadStage.importing,
+      ));
+      String? bookKey;
+      bool skipped = false;
+      try {
+        bookKey = await MangaImporter.importFromMokuroPath(
+          db: db,
+          mokuroPath: placedMokuro.path,
+          title: volumeTitle(seriesName, volumeName),
+          skipIfExists: true,
+          onProgress: (int done, int total) =>
+              controller.add(MokuroMoeVolumeDownloadEvent(
+            stage: MokuroMoeDownloadStage.importing,
+            pagesDone: done,
+            pagesTotal: total,
+          )),
+        );
+      } on DuplicateImportCancelledException {
+        skipped = true;
+      }
+
+      controller.add(MokuroMoeVolumeDownloadEvent(
+        stage: MokuroMoeDownloadStage.done,
+        bookKey: bookKey,
+        skippedExisting: skipped,
+      ));
+
+      // 成功/已在库：整个 staging 目录（含 cbz/.mokuro）不再需要，清掉。
+      _tryDelete(staging);
+    } catch (_) {
+      // 失败/取消：只清解包半成品；`.part` / 已完成 `.cbz` 保留供续传/重试。
+      _tryDelete(extractDir);
+      rethrow;
+    }
+  }
+
+  void _checkCancelled() {
+    if (_cancelled) throw const MokuroMoeDownloadCancelled();
+  }
+
+  static void _tryDelete(Directory dir) {
+    try {
+      if (dir.existsSync()) dir.deleteSync(recursive: true);
+    } catch (_) {}
+  }
+
+  /// 小文件直下（`.mokuro`）：写 `.part` 再原子 rename，非 200 报错。
+  Future<void> _downloadSmall(String url, File target) async {
+    final HttpClient http = _createClient();
+    try {
+      final HttpClientRequest request = await http.getUrl(Uri.parse(url));
+      final HttpClientResponse response = await request.close();
+      if (response.statusCode != HttpStatus.ok) {
+        await response.drain<void>();
+        throw HttpException(
+          'download failed: HTTP ${response.statusCode}',
+          uri: Uri.parse(url),
+        );
+      }
+      final File part = File('${target.path}.part');
+      final IOSink sink = part.openWrite();
+      try {
+        await for (final List<int> chunk in response) {
+          _checkCancelled();
+          sink.add(chunk);
+        }
+        await sink.flush();
+      } finally {
+        await sink.close();
+      }
+      if (target.existsSync()) target.deleteSync();
+      part.renameSync(target.path);
+    } finally {
+      http.close(force: true);
+    }
+  }
+
+  /// CBZ 下载：`.part` 断点续传；无预知长度，完成校验 = zip 中央目录可解析。
+  /// [retried] 防 416 重试无限递归（一次为限）。
+  Future<void> _downloadCbz(
+    StreamController<MokuroMoeVolumeDownloadEvent> controller, {
+    required String url,
+    required File target,
+    bool retried = false,
+  }) async {
+    final File part = File('${target.path}.part');
+    int offset = part.existsSync() ? part.lengthSync() : 0;
+
+    final HttpClient http = _createClient();
+    try {
+      final HttpClientRequest request = await http.getUrl(Uri.parse(url));
+      if (offset > 0) {
+        request.headers.set(HttpHeaders.rangeHeader, 'bytes=$offset-');
+      }
+      final HttpClientResponse response = await request.close();
+
+      if (offset > 0 &&
+          response.statusCode == HttpStatus.requestedRangeNotSatisfiable) {
+        // `.part` 长度 >= 远端长度：要么上次已下完（rename 前中断），要么坏档。
+        // 无 expectedBytes 可比，直接用 zip 解析判卷：能解析就转正；不能则删掉
+        // 重下一次。
+        await response.drain<void>();
+        if (_zipParses(part.path)) {
+          _finalizeCbz(part, target);
+          return;
+        }
+        part.deleteSync();
+        if (retried) {
+          throw StateError('mokuro.moe CBZ invalid after retry: $url');
+        }
+        await _downloadCbz(controller, url: url, target: target, retried: true);
+        return;
+      }
+
+      final IOSink sink;
+      int received;
+      int? total;
+      if (offset > 0 && response.statusCode == HttpStatus.partialContent) {
+        received = offset;
+        total =
+            response.contentLength > 0 ? offset + response.contentLength : null;
+        sink = part.openWrite(mode: FileMode.append);
+      } else if (response.statusCode == HttpStatus.ok) {
+        // 服务器不支持 Range（或本就无残留）：整文件重下，截断旧残留。
+        received = 0;
+        total = response.contentLength > 0 ? response.contentLength : null;
+        sink = part.openWrite();
+      } else {
+        await response.drain<void>();
+        throw HttpException(
+          'download failed: HTTP ${response.statusCode}',
+          uri: Uri.parse(url),
+        );
+      }
+
+      int lastEmitted = received;
+      controller.add(MokuroMoeVolumeDownloadEvent(
+        stage: MokuroMoeDownloadStage.downloadingCbz,
+        receivedBytes: received,
+        totalBytes: total,
+      ));
+      try {
+        await for (final List<int> chunk in response) {
+          // 取消：先落已到的 chunk 再停，`.part` 保持前缀完整可续传。
+          sink.add(chunk);
+          received += chunk.length;
+          _checkCancelled();
+          if (received - lastEmitted >= progressByteInterval) {
+            controller.add(MokuroMoeVolumeDownloadEvent(
+              stage: MokuroMoeDownloadStage.downloadingCbz,
+              receivedBytes: received,
+              totalBytes: total,
+            ));
+            lastEmitted = received;
+          }
+        }
+        await sink.flush();
+      } finally {
+        await sink.close();
+      }
+
+      controller.add(MokuroMoeVolumeDownloadEvent(
+        stage: MokuroMoeDownloadStage.downloadingCbz,
+        receivedBytes: received,
+        totalBytes: total,
+      ));
+      if (!_zipParses(part.path)) {
+        // 坏档不可信（续传基底错位/传输损坏），删掉避免下次在坏偏移上加码。
+        try {
+          part.deleteSync();
+        } catch (_) {}
+        throw StateError('mokuro.moe CBZ is not a valid zip: $url');
+      }
+      _finalizeCbz(part, target);
+    } finally {
+      http.close(force: true);
+    }
+  }
+
+  static void _finalizeCbz(File part, File target) {
+    if (target.existsSync()) target.deleteSync();
+    part.renameSync(target.path);
+  }
+
+  /// zip 中央目录可解析且至少有一个 entry（不解压，仅结构校验）。
+  static bool _zipParses(String path) {
+    InputFileStream? input;
+    try {
+      input = InputFileStream(path);
+      final Archive archive = ZipDecoder().decodeBuffer(input);
+      return archive.files.isNotEmpty;
+    } catch (_) {
+      return false;
+    } finally {
+      input?.closeSync();
+    }
+  }
+
+  /// 把逐 chunk 字节回报聚成累计值再按 [progressByteInterval] 节流。
+  void Function(int chunkBytes) _throttled(void Function(int received) emit) {
+    int received = 0;
+    int lastEmitted = 0;
+    return (int chunkBytes) {
+      received += chunkBytes;
+      if (received - lastEmitted >= progressByteInterval) {
+        emit(received);
+        lastEmitted = received;
+      }
+    };
+  }
+
+  /// 后台 isolate 解包（照 backup_service `_extractEntriesStreaming` 范式）。
+  Future<void> _extractInIsolate({
+    required String zipPath,
+    required String destDirPath,
+    required void Function(int chunkBytes) onBytes,
+  }) async {
+    final ReceivePort port = ReceivePort();
+    final Completer<void> completer = Completer<void>();
+    port.listen((dynamic message) {
+      if (message is int) {
+        onBytes(message);
+      } else if (message == _extractDoneToken) {
+        if (!completer.isCompleted) completer.complete();
+        port.close();
+      } else {
+        // Worker 失败（'errorText'）或未捕获 isolate 错误（[error, stack]）。
+        if (!completer.isCompleted) {
+          completer.completeError(
+            StateError('mokuro.moe CBZ extraction failed: $message'),
+          );
+        }
+        port.close();
+      }
+    });
+    final Isolate isolate = await Isolate.spawn(
+      _extractCbzWorker,
+      _ExtractRequest(zipPath, destDirPath, port.sendPort),
+      onError: port.sendPort,
+    );
+    try {
+      await completer.future;
+    } finally {
+      isolate.kill(priority: Isolate.immediate);
+    }
+  }
+}
+
+const String _extractDoneToken = 'mokuro-moe-extract-done';
+
+/// 可跨 isolate 传递的解包请求。
+class _ExtractRequest {
+  const _ExtractRequest(this.zipPath, this.destDirPath, this.sendPort);
+  final String zipPath;
+  final String destDirPath;
+  final SendPort sendPort;
+}
+
+/// 后台 isolate 入口：重开 zip、逐 entry 校验路径（防穿越）后流式落盘。
+void _extractCbzWorker(_ExtractRequest request) {
+  final SendPort port = request.sendPort;
+  InputFileStream? input;
+  try {
+    input = InputFileStream(request.zipPath);
+    final Archive archive = ZipDecoder().decodeBuffer(input);
+    for (final ArchiveFile file in archive.files) {
+      if (!file.isFile) continue;
+      final List<String> segments = _safeEntrySegments(file.name);
+      final String dest = p.joinAll(<String>[request.destDirPath, ...segments]);
+      _streamArchiveFileToDisk(file, dest, port);
+    }
+    port.send(_extractDoneToken);
+  } catch (error, stack) {
+    port.send('$error\n$stack');
+  } finally {
+    input?.closeSync();
+  }
+}
+
+/// zip entry 名 → 安全相对路径段。含 `..` / 绝对路径 / 盘符的 entry 一律拒绝
+/// （zip 路径穿越红线）。
+List<String> _safeEntrySegments(String entryName) {
+  if (entryName.startsWith('/') ||
+      entryName.startsWith('\\') ||
+      RegExp(r'^[a-zA-Z]:').hasMatch(entryName)) {
+    throw StateError('zip entry uses absolute path: $entryName');
+  }
+  final List<String> segments = entryName
+      .split(RegExp(r'[\\/]+'))
+      .where((String s) => s.isNotEmpty && s != '.')
+      .toList();
+  if (segments.isEmpty || segments.any((String s) => s == '..')) {
+    throw StateError('zip entry escapes destination: $entryName');
+  }
+  return segments;
+}
+
+/// 单 entry 流式落盘：STORE 走 4MB 分块拷贝（逐块回报字节），DEFLATE 流式
+/// inflate（照 backup_service `_streamArchiveFileToDisk`）。
+void _streamArchiveFileToDisk(
+    ArchiveFile file, String destPath, SendPort port) {
+  File(destPath).parent.createSync(recursive: true);
+  final OutputFileStream output = OutputFileStream(destPath);
+  try {
+    final InputStreamBase? raw = file.rawContent;
+    if (raw != null && !file.isCompressed) {
+      const int chunkSize = 4 * 1024 * 1024; // 每块 4MB 峰值堆
+      final int total = raw.length;
+      int written = 0;
+      while (written < total) {
+        final int want =
+            (total - written) < chunkSize ? (total - written) : chunkSize;
+        final Uint8List bytes = raw.readBytes(want).toUint8List();
+        if (bytes.isEmpty) break;
+        output.writeBytes(bytes);
+        written += bytes.length;
+        port.send(bytes.length);
+      }
+    } else if (raw != null && file.compressionType == ArchiveFile.DEFLATE) {
+      Inflate.stream(raw, output);
+      port.send(file.size);
+    } else {
+      // 兜底（已物化内容）：整块写。
+      output.writeBytes(file.content as List<int>);
+      port.send(file.size);
+    }
+  } finally {
+    output.closeSync();
+  }
+}

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -5257,6 +5257,11 @@ class AppModel with ChangeNotifier {
   Future<void> setMangaExternalMokuroPath(String value) =>
       prefsRepo.setMangaExternalMokuroPath(value);
 
+  /// 漫画「在线目录」站点根 URL（O1 mokuro.moe 目录源；空值由 client 归一回默认）。
+  String get mangaOnlineCatalogBaseUrl => prefsRepo.mangaOnlineCatalogBaseUrl;
+  Future<void> setMangaOnlineCatalogBaseUrl(String value) =>
+      prefsRepo.setMangaOnlineCatalogBaseUrl(value);
+
   /// 漫画云端手写识别（Gemini）开关/API key/模型名（P4 补扫云端兜底；默认关，
   /// 关着时零网络调用）。
   bool get mangaCloudOcrEnabled => prefsRepo.mangaCloudOcrEnabled;

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -1713,6 +1713,17 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 漫画「在线目录」站点根 URL（O1：mokuro.moe 目录源；`MokuroMoeClient` 消费，
+  /// 空串/尾斜杠由 client 侧 `normalizeMokuroMoeBaseUrl` 归一回默认站点）。
+  String get mangaOnlineCatalogBaseUrl =>
+      getPref('manga_online_catalog_base_url',
+          defaultValue: 'https://mokuro.moe') as String;
+
+  Future<void> setMangaOnlineCatalogBaseUrl(String value) async {
+    await setPref('manga_online_catalog_base_url', value);
+    notifyListeners();
+  }
+
   /// 漫画云端手写识别（Gemini）总开关。**默认关**；关着时零网络调用（红线），
   /// 只影响补扫结果卡片是否显示「云端重试」与请求闸门。
   bool get mangaCloudOcrEnabled =>

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -18,6 +18,7 @@ import 'package:hibiki/src/media/drag_drop/drop_classification.dart';
 import 'package:hibiki/src/media/drag_drop/drop_decision.dart';
 import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
 import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_catalog_dialog.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/media/video/video_feature_flags.dart';
 import 'package:hibiki/src/media/video/video_import_dialog.dart';
@@ -491,6 +492,13 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
           icon: Icons.folder_copy_outlined,
           onTap: _openManageSources,
         ),
+        // 漫画「在线目录」（O1 mokuro.moe 目录源）：浏览/搜索 → 卷级下载 →
+        // 现有 .mokuro 导入链落库。
+        _headerAction(
+          tooltip: t.manga_online_catalog_title,
+          icon: Icons.cloud_download_outlined,
+          onTap: _openOnlineCatalog,
+        ),
         // 视频导入入口**只属于视频 tab**（HomeVideoPage），书架不放视频导入——
         // 书架是书的地方。这里保留编译期常量门控（默认关）只为旧调试路径，运行时
         // 实验开关不再在书架放出视频导入（用户反馈：书架不该有视频导入入口）。
@@ -536,6 +544,20 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
       builder: (_) => const MediaSourcesDialog(mediaKind: 'book'),
     );
     if (!mounted) return;
+    ref.invalidate(hibikiBooksProvider(appModel.targetLanguage));
+    ref.invalidate(srtBooksProvider);
+  }
+
+  /// 打开漫画「在线目录」对话框；有导入发生（返回成功卷数 > 0）则刷新书架
+  /// （照 [_openManageSources] 的失效范式）。barrier 不可点关：导入结果经显式
+  /// 关闭按钮回传，避免点空白丢「需刷新」信号。
+  Future<void> _openOnlineCatalog() async {
+    final int? imported = await showAppDialog<int>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => MokuroMoeCatalogDialog(db: appModel.database),
+    );
+    if (!mounted || imported == null || imported <= 0) return;
     ref.invalidate(hibikiBooksProvider(appModel.targetLanguage));
     ref.invalidate(srtBooksProvider);
   }

--- a/hibiki/lib/src/settings/settings_schema_manga_ocr.dart
+++ b/hibiki/lib/src/settings/settings_schema_manga_ocr.dart
@@ -1,5 +1,8 @@
+import 'package:flutter/material.dart';
+
 import 'package:hibiki/src/media/manga/manga_ocr_provider.dart';
 import 'package:hibiki/src/media/manga/manga_ocr_settings_section.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_client.dart';
 import 'package:hibiki/src/settings/settings_context.dart';
 import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/utils.dart';
@@ -23,6 +26,20 @@ SettingsSection buildMangaOcrSection() {
         builder: (SettingsContext c) => MangaOcrSettingsSection(
           service: c.ref.read(mangaOcrServiceProvider),
         ),
+      ),
+      // 漫画「在线目录」站点根 URL（O1 mokuro.moe 目录源）。空串/尾斜杠由
+      // MokuroMoeClient 的 normalizeMokuroMoeBaseUrl 归一回默认站点，故这里
+      // 只 trim 存原值、不做格式校验。
+      SettingsTextItem(
+        id: 'reading.manga_online_catalog_base_url',
+        title: t.manga_online_base_url_label,
+        icon: Icons.cloud_outlined,
+        keyboardType: TextInputType.url,
+        placeholder: kMokuroMoeDefaultBaseUrl,
+        value: (SettingsContext settingsContext) =>
+            settingsContext.appModel.mangaOnlineCatalogBaseUrl,
+        onChanged: (SettingsContext settingsContext, String value) =>
+            settingsContext.appModel.setMangaOnlineCatalogBaseUrl(value.trim()),
       ),
     ],
   );

--- a/hibiki/test/media/manga/online/mokuro_moe_catalog_dialog_test.dart
+++ b/hibiki/test/media/manga/online/mokuro_moe_catalog_dialog_test.dart
@@ -1,0 +1,173 @@
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_catalog_dialog.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_client.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_volume_downloader.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// fake client：内存数据，零网络（封面留空走占位图标路径）。
+class _FakeClient extends MokuroMoeClient {
+  _FakeClient(this.library);
+
+  final List<MokuroMoeSeries> library;
+  Exception? libraryError;
+
+  @override
+  Future<List<MokuroMoeSeries>> fetchLibrary() async {
+    final Exception? error = libraryError;
+    if (error != null) throw error;
+    return library;
+  }
+}
+
+const List<MokuroMoeSeries> _library = <MokuroMoeSeries>[
+  MokuroMoeSeries(
+    name: 'よつばと!',
+    volumes: <MokuroMoeVolume>[
+      MokuroMoeVolume(name: 'よつばと! 第01巻'),
+      MokuroMoeVolume(name: 'よつばと! 第02巻'),
+    ],
+  ),
+  MokuroMoeSeries(
+    name: 'ヨコハマ買い出し紀行',
+    volumes: <MokuroMoeVolume>[MokuroMoeVolume(name: '第01巻')],
+  ),
+];
+
+void main() {
+  late HibikiDatabase db;
+
+  setUp(() {
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  /// 照 `manga_import_dialog_test.dart` 的 TranslationProvider 壳（+ ProviderScope，
+  /// 对话框是 ConsumerStatefulWidget；clientOverride 非 null 时不会触达 appProvider）。
+  Widget wrap(Widget child) {
+    return ProviderScope(
+      child: TranslationProvider(
+        child: MaterialApp(home: Scaffold(body: child)),
+      ),
+    );
+  }
+
+  testWidgets('browse：目录加载后渲染系列，搜索大小写不敏感过滤', (WidgetTester tester) async {
+    await tester.pumpWidget(wrap(MokuroMoeCatalogDialog(
+      db: db,
+      clientOverride: _FakeClient(_library),
+    )));
+    await tester.pumpAndSettle();
+
+    expect(find.text('よつばと!'), findsOneWidget);
+    expect(find.text('ヨコハマ買い出し紀行'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'よつばと');
+    await tester.pumpAndSettle();
+    expect(find.text('よつばと!'), findsOneWidget);
+    expect(find.text('ヨコハマ買い出し紀行'), findsNothing);
+  });
+
+  testWidgets('browse：加载失败显示错误 + 重试按钮，重试后恢复', (WidgetTester tester) async {
+    final _FakeClient client = _FakeClient(_library)
+      ..libraryError = Exception('boom');
+    await tester.pumpWidget(wrap(MokuroMoeCatalogDialog(
+      db: db,
+      clientOverride: client,
+    )));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining(t.manga_online_load_failed), findsOneWidget);
+
+    client.libraryError = null;
+    await tester.tap(find.text(t.retry));
+    await tester.pumpAndSettle();
+    expect(find.text('よつばと!'), findsOneWidget);
+  });
+
+  testWidgets('series → 选卷 → 下载：进度渲染、完成标记 ✓、关闭回传导入数',
+      (WidgetTester tester) async {
+    final StreamController<MokuroMoeVolumeDownloadEvent> events =
+        StreamController<MokuroMoeVolumeDownloadEvent>();
+    final List<(String, String)> runnerCalls = <(String, String)>[];
+    int? popResult;
+
+    await tester.pumpWidget(wrap(Builder(
+      builder: (BuildContext context) => Center(
+        child: ElevatedButton(
+          onPressed: () async {
+            popResult = await showDialog<int>(
+              context: context,
+              builder: (_) => MokuroMoeCatalogDialog(
+                db: db,
+                clientOverride: _FakeClient(_library),
+                runnerOverride: (
+                    {required String seriesName, required String volumeName}) {
+                  runnerCalls.add((seriesName, volumeName));
+                  return events.stream;
+                },
+              ),
+            );
+          },
+          child: const Text('open'),
+        ),
+      ),
+    )));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // 进入 series 阶段。
+    await tester.tap(find.text('よつばと!'));
+    await tester.pumpAndSettle();
+    expect(find.text('よつばと! 第01巻'), findsOneWidget);
+    expect(find.text('よつばと! 第02巻'), findsOneWidget);
+
+    // 未选卷时「下载所选」禁用。
+    final TextButton downloadBtn = tester.widget<TextButton>(
+      find.widgetWithText(TextButton, t.manga_online_download_selected),
+    );
+    expect(downloadBtn.onPressed, isNull);
+
+    // 选第 1 卷 → 下载。
+    await tester.tap(find.text('よつばと! 第01巻'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.manga_online_download_selected));
+    await tester.pump();
+    expect(runnerCalls.single, ('よつばと!', 'よつばと! 第01巻'));
+
+    // CBZ 字节进度 → 进度条 + 阶段文案。
+    events.add(const MokuroMoeVolumeDownloadEvent(
+      stage: MokuroMoeDownloadStage.downloadingCbz,
+      receivedBytes: 512 * 1024,
+      totalBytes: 1024 * 1024,
+    ));
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    // 阶段文案出现在进度面板 + 当前卷 subtitle（两处一致）。
+    expect(find.textContaining(t.manga_online_stage_cbz), findsWidgets);
+
+    // 完成 → 回 series 阶段，该卷标 ✓（不可再选），无复选框残留选中。
+    events.add(const MokuroMoeVolumeDownloadEvent(
+      stage: MokuroMoeDownloadStage.done,
+      bookKey: 'yotsubato-01',
+    ));
+    await events.close();
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    expect(find.text(t.manga_online_downloaded), findsOneWidget);
+
+    // 关闭回传本次成功导入卷数。
+    await tester.tap(find.text(t.dialog_close));
+    await tester.pumpAndSettle();
+    expect(popResult, 1);
+  });
+}

--- a/hibiki/test/media/manga/online/mokuro_moe_client_test.dart
+++ b/hibiki/test/media/manga/online/mokuro_moe_client_test.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_client.dart';
+
+/// loopback HTTP fake（照 `manga_ocr_model_downloader_test.dart` 的
+/// `_ModelServer` 思路）：按路径供响应体，记录完整请求 URI。
+class _CatalogServer {
+  _CatalogServer(this.server) {
+    server.listen(_handle);
+  }
+
+  final HttpServer server;
+  final Map<String, String> bodies = <String, String>{};
+  final List<Uri> requests = <Uri>[];
+
+  static Future<_CatalogServer> start() async {
+    final HttpServer server =
+        await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    return _CatalogServer(server);
+  }
+
+  String get baseUrl => 'http://127.0.0.1:${server.port}';
+
+  Future<void> close() => server.close(force: true);
+
+  void _handle(HttpRequest request) {
+    requests.add(request.uri);
+    final String? body = bodies[request.uri.path];
+    if (body == null) {
+      request.response.statusCode = HttpStatus.notFound;
+      request.response.close();
+      return;
+    }
+    request.response.statusCode = HttpStatus.ok;
+    request.response.headers.contentType =
+        ContentType('application', 'json', charset: 'utf-8');
+    request.response.add(utf8.encode(body));
+    request.response.close();
+  }
+}
+
+void main() {
+  late _CatalogServer server;
+
+  setUp(() async {
+    server = await _CatalogServer.start();
+  });
+
+  tearDown(() async {
+    await server.close();
+  });
+
+  /// 测试直连 loopback，绕开环境代理变量（生产默认 findProxyFromEnvironment）。
+  MokuroMoeClient client() =>
+      MokuroMoeClient(baseUrl: server.baseUrl, createClient: HttpClient.new);
+
+  test('fetchLibrary 解析系列 + 卷，字段缺失容错', () async {
+    server.bodies['/catalog/api/library'] = jsonEncode(<String, Object?>{
+      'series': <Object?>[
+        <String, Object?>{
+          'name': 'よつばと!',
+          'path': 'よつばと!',
+          'cover': 'よつばと!/cover.webp',
+          'volumes': <Object?>[
+            <String, Object?>{
+              'name': 'よつばと! 第01巻',
+              'cover': 'よつばと!/v01.webp',
+              'ocr_pending': false,
+              'ocr_active': false,
+            },
+            // 字段缺失：全部取默认值，不炸。
+            <String, Object?>{'name': 'よつばと! 第02巻'},
+          ],
+        },
+        // volumes 缺失 / cover 类型不符：容错为空。
+        <String, Object?>{'name': 'ヨコハマ買い出し紀行', 'cover': 42},
+      ],
+    });
+
+    final List<MokuroMoeSeries> library = await client().fetchLibrary();
+
+    expect(library, hasLength(2));
+    expect(library[0].name, 'よつばと!');
+    expect(library[0].cover, 'よつばと!/cover.webp');
+    expect(library[0].volumes, hasLength(2));
+    expect(library[0].volumes[0].name, 'よつばと! 第01巻');
+    expect(library[0].volumes[1].cover, '');
+    expect(library[0].volumes[1].ocrPending, isFalse);
+    expect(library[1].cover, '');
+    expect(library[1].volumes, isEmpty);
+  });
+
+  test('fetchSeries：特殊字符系列名（#、空格）经 query 编码往返', () async {
+    server.bodies['/catalog/api/series'] = jsonEncode(<String, Object?>{
+      'name': 'Comic #1 スペース入り',
+      'volumes': <Object?>[
+        <String, Object?>{'name': 'v1'},
+      ],
+    });
+
+    final MokuroMoeSeries series =
+        await client().fetchSeries('Comic #1 スペース入り');
+
+    expect(series.name, 'Comic #1 スペース入り');
+    expect(series.volumes.single.name, 'v1');
+    // 服务器端解出的 query 参数必须逐字节还原（# 未编码会被当 fragment 截断）。
+    expect(
+      server.requests.single.queryParameters['name'],
+      'Comic #1 スペース入り',
+    );
+  });
+
+  test('cbzUrl / mokuroUrl / coverUrl：URL 段逐段 encodeComponent', () {
+    final MokuroMoeClient c = client();
+    final String cbz = c.cbzUrl('Comic #1', '第01巻 (extra)');
+    expect(cbz,
+        '${server.baseUrl}/mokuro-reader/Comic%20%231/%E7%AC%AC01%E5%B7%BB%20(extra).cbz');
+    final String mokuro = c.mokuroUrl('Comic #1', '第01巻 (extra)');
+    expect(mokuro, endsWith('.mokuro'));
+    expect(mokuro, contains('Comic%20%231'));
+    final String cover = c.coverUrl('Comic #1/cover file.webp');
+    expect(cover,
+        '${server.baseUrl}/catalog/api/cover?path=Comic%20%231%2Fcover%20file.webp');
+  });
+
+  test('非 200 抛 HttpException', () async {
+    await expectLater(
+      client().fetchLibrary(),
+      throwsA(isA<HttpException>()),
+    );
+    await expectLater(
+      client().fetchSeries('missing'),
+      throwsA(isA<HttpException>()),
+    );
+  });
+
+  test('base URL 归一：尾斜杠去除、空串回退默认站点', () {
+    expect(MokuroMoeClient(baseUrl: 'https://example.com///').baseUrl,
+        'https://example.com');
+    expect(MokuroMoeClient(baseUrl: '   ').baseUrl, kMokuroMoeDefaultBaseUrl);
+    expect(MokuroMoeClient().baseUrl, kMokuroMoeDefaultBaseUrl);
+    expect(normalizeMokuroMoeBaseUrl(''), kMokuroMoeDefaultBaseUrl);
+  });
+}

--- a/hibiki/test/media/manga/online/mokuro_moe_downloader_test.dart
+++ b/hibiki/test/media/manga/online/mokuro_moe_downloader_test.dart
@@ -1,0 +1,301 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/epub/epub_storage.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_client.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_volume_downloader.dart';
+import 'package:hibiki/src/sync/ttu_filename.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+/// loopback fake：按**解码后**路径供字节，支持 Range，可在 CBZ 传输中途挂起
+/// （测取消）。照 `manga_ocr_model_downloader_test.dart` 的 `_ModelServer` 思路。
+class _VolumeServer {
+  _VolumeServer(this.server) {
+    server.listen(_handle);
+  }
+
+  final HttpServer server;
+  final Map<String, List<int>> payloads = <String, List<int>>{};
+  final List<String?> cbzRangeHeaders = <String?>[];
+  bool supportRange = true;
+
+  /// 非 null 时：CBZ 响应先写这么多字节、flush，等 [release] 完成后再写余下。
+  int? holdCbzAfterBytes;
+  final Completer<void> release = Completer<void>();
+
+  static Future<_VolumeServer> start() async {
+    final HttpServer server =
+        await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    return _VolumeServer(server);
+  }
+
+  String get baseUrl => 'http://127.0.0.1:${server.port}';
+
+  Future<void> close() => server.close(force: true);
+
+  Future<void> _handle(HttpRequest request) async {
+    // 客户端取消会中途断连：写入报错吞掉，避免未处理异步错误判挂测试。
+    try {
+      final String path = '/${request.uri.pathSegments.join('/')}';
+      final List<int>? payload = payloads[path];
+      if (payload == null) {
+        request.response.statusCode = HttpStatus.notFound;
+        await request.response.close();
+        return;
+      }
+      final bool isCbz = path.endsWith('.cbz');
+      final String? range = request.headers.value(HttpHeaders.rangeHeader);
+      if (isCbz) cbzRangeHeaders.add(range);
+
+      int offset = 0;
+      if (range != null && supportRange) {
+        final RegExpMatch? match =
+            RegExp(r'^bytes=(\d+)-$').firstMatch(range.trim());
+        offset = match == null ? 0 : int.parse(match.group(1)!);
+        if (offset >= payload.length) {
+          request.response.statusCode = HttpStatus.requestedRangeNotSatisfiable;
+          await request.response.close();
+          return;
+        }
+        request.response.statusCode = HttpStatus.partialContent;
+      } else {
+        request.response.statusCode = HttpStatus.ok;
+      }
+      final List<int> body = payload.sublist(offset);
+      request.response.contentLength = body.length;
+
+      final int? hold = isCbz ? holdCbzAfterBytes : null;
+      if (hold != null && hold < body.length) {
+        // 前段必须真正上线（默认 8KB 输出缓冲会吞掉小前段导致两端互等死锁）。
+        request.response.bufferOutput = false;
+        request.response.add(body.sublist(0, hold));
+        await request.response.flush();
+        await release.future;
+        request.response.add(body.sublist(hold));
+      } else {
+        request.response.add(body);
+      }
+      await request.response.close();
+    } catch (_) {}
+  }
+}
+
+/// 现场构造一个 CBZ（顶层 `<volume>/` 目录 + 假 jpg）与配套 `.mokuro` JSON。
+List<int> _buildCbz(String volume, Map<String, List<int>> images) {
+  final Archive archive = Archive();
+  images.forEach((String name, List<int> bytes) {
+    archive.addFile(ArchiveFile('$volume/$name', bytes.length, bytes));
+  });
+  return ZipEncoder().encode(archive)!;
+}
+
+String _buildMokuro(String volume, List<String> imageNames) {
+  return jsonEncode(<String, Object?>{
+    'version': '0.2.0',
+    'title': 'ソラの本',
+    'volume': volume,
+    'pages': <Object?>[
+      for (final String name in imageNames)
+        <String, Object?>{
+          'img_width': 1200,
+          'img_height': 1700,
+          'img_path': '$volume/$name',
+          'blocks': <Object?>[
+            <String, Object?>{
+              'box': <int>[10, 20, 110, 220],
+              'vertical': true,
+              'font_size': 32,
+              'lines': <String>['一行目'],
+            },
+          ],
+        },
+    ],
+  });
+}
+
+void main() {
+  // 注意：不初始化 TestWidgetsFlutterBinding——它会把所有 HttpClient mock 成
+  // 恒 400，而本套件走 loopback 真 HTTP；EpubStorage.debugBaseDirectoryOverride
+  // 已绕开 path_provider，无需 binding。
+
+  const String series = 'Comic #1';
+  const String volume = 'vol1';
+
+  late _VolumeServer server;
+  late Directory appDocDir;
+  late Directory stagingRoot;
+  late HibikiDatabase db;
+
+  setUp(() async {
+    server = await _VolumeServer.start();
+    appDocDir = await Directory.systemTemp.createTemp('mokuromoe_app');
+    stagingRoot = await Directory.systemTemp.createTemp('mokuromoe_staging');
+    EpubStorage.debugBaseDirectoryOverride = appDocDir.path;
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await server.close();
+    await db.close();
+    EpubStorage.debugBaseDirectoryOverride = null;
+    for (final Directory d in <Directory>[appDocDir, stagingRoot]) {
+      if (d.existsSync()) await d.delete(recursive: true);
+    }
+  });
+
+  MokuroMoeVolumeDownloader downloader({int interval = 4}) =>
+      MokuroMoeVolumeDownloader(
+        client: MokuroMoeClient(
+            baseUrl: server.baseUrl, createClient: HttpClient.new),
+        createClient: HttpClient.new,
+        stagingRoot: stagingRoot,
+        progressByteInterval: interval,
+      );
+
+  Directory stagingDir() => Directory(p.join(
+        stagingRoot.path,
+        sanitizeTtuFilename(series),
+        sanitizeTtuFilename(volume),
+      ));
+
+  void serveVolume({List<int>? cbz}) {
+    final List<int> zipBytes = cbz ??
+        _buildCbz(volume, <String, List<int>>{
+          '001.jpg': <int>[1, 2, 3],
+          '002.jpg': <int>[4, 5, 6],
+        });
+    server.payloads['/mokuro-reader/$series/$volume.cbz'] = zipBytes;
+    server.payloads['/mokuro-reader/$series/$volume.mokuro'] =
+        utf8.encode(_buildMokuro(volume, <String>['001.jpg', '002.jpg']));
+  }
+
+  test('端到端：下载 → 解包 → importFromMokuroPath 落库，阶段有序、staging 清理', () async {
+    serveVolume();
+
+    final List<MokuroMoeVolumeDownloadEvent> events = await downloader()
+        .run(db: db, seriesName: series, volumeName: volume)
+        .toList();
+
+    // 阶段按序出现且以 done 收尾。
+    final List<MokuroMoeDownloadStage> stages =
+        events.map((MokuroMoeVolumeDownloadEvent e) => e.stage).toList();
+    expect(stages.first, MokuroMoeDownloadStage.downloadingMokuro);
+    expect(stages, contains(MokuroMoeDownloadStage.downloadingCbz));
+    expect(stages, contains(MokuroMoeDownloadStage.extracting));
+    expect(stages, contains(MokuroMoeDownloadStage.importing));
+    expect(stages.last, MokuroMoeDownloadStage.done);
+
+    final MokuroMoeVolumeDownloadEvent done = events.last;
+    expect(done.skippedExisting, isFalse);
+    final String bookKey = done.bookKey!;
+    // 标题 = `<系列> <卷>`（volumeTitle 口径）。
+    expect(
+        bookKey,
+        sanitizeTtuFilename(
+            MokuroMoeVolumeDownloader.volumeTitle(series, volume)));
+
+    final EpubBookRow? row = await db.getEpubBook(bookKey);
+    expect(row, isNotNull);
+    expect(row!.format, 'manga');
+    expect(row.chapterCount, 2);
+    expect(File(p.join(row.extractDir, 'manga.json')).existsSync(), isTrue);
+    // 成功后 staging（cbz/.mokuro/extract）整体清理。
+    expect(stagingDir().existsSync(), isFalse);
+  });
+
+  test('同卷重跑：skipIfExists 命中 → done(skippedExisting=true)，不建重复行', () async {
+    serveVolume();
+    await downloader()
+        .run(db: db, seriesName: series, volumeName: volume)
+        .drain<void>();
+    serveVolume(); // 重新供流（上一轮已消费）。
+
+    final List<MokuroMoeVolumeDownloadEvent> events = await downloader()
+        .run(db: db, seriesName: series, volumeName: volume)
+        .toList();
+
+    expect(events.last.stage, MokuroMoeDownloadStage.done);
+    expect(events.last.skippedExisting, isTrue);
+    expect(events.last.bookKey, isNull);
+    expect((await db.getAllEpubBooks()).length, 1);
+  });
+
+  test('断点续传：预置 .part 触发 Range bytes=N-，拼接后 zip 完整可导入', () async {
+    final List<int> zipBytes = _buildCbz(volume, <String, List<int>>{
+      '001.jpg': List<int>.generate(64, (int i) => i % 251),
+      '002.jpg': <int>[4, 5, 6],
+    });
+    serveVolume(cbz: zipBytes);
+    final Directory staging = stagingDir()..createSync(recursive: true);
+    File(p.join(staging.path, 'volume.cbz.part'))
+        .writeAsBytesSync(zipBytes.sublist(0, 10));
+
+    final List<MokuroMoeVolumeDownloadEvent> events = await downloader()
+        .run(db: db, seriesName: series, volumeName: volume)
+        .toList();
+
+    expect(server.cbzRangeHeaders.single, 'bytes=10-');
+    expect(events.last.stage, MokuroMoeDownloadStage.done);
+    expect(events.last.bookKey, isNotNull);
+  });
+
+  test('zip 路径穿越（../）：解包报错终止，不在目标外落文件', () async {
+    final Archive evil = Archive();
+    evil.addFile(ArchiveFile('../evil.jpg', 3, <int>[1, 2, 3]));
+    evil.addFile(ArchiveFile('$volume/001.jpg', 3, <int>[1, 2, 3]));
+    serveVolume(cbz: ZipEncoder().encode(evil)!);
+
+    await expectLater(
+      downloader()
+          .run(db: db, seriesName: series, volumeName: volume)
+          .drain<void>(),
+      throwsA(isA<StateError>()),
+    );
+    // `../evil.jpg` 若被解出会落在 staging 目录（extract 的父级）——必须不存在。
+    expect(File(p.join(stagingDir().path, 'evil.jpg')).existsSync(), isFalse);
+    expect(File(p.join(stagingRoot.path, 'evil.jpg')).existsSync(), isFalse);
+    // 失败只清解包半成品，已下完的 cbz 保留供重试。
+    expect(File(p.join(stagingDir().path, 'volume.cbz')).existsSync(), isTrue);
+    expect(
+        Directory(p.join(stagingDir().path, 'extract')).existsSync(), isFalse);
+  });
+
+  test('取消：流以 MokuroMoeDownloadCancelled 结束，.part 保留供续传', () async {
+    serveVolume();
+    server.holdCbzAfterBytes = 8;
+
+    final MokuroMoeVolumeDownloader dl = downloader(interval: 1);
+    final Completer<Object> streamError = Completer<Object>();
+    bool cancelled = false;
+    dl.run(db: db, seriesName: series, volumeName: volume).listen(
+          (MokuroMoeVolumeDownloadEvent event) {
+            // CBZ 阶段一开（服务器挂起前段）→ 请求取消 → 放行余量：下载循环在
+            // 下一个 chunk 处看到取消标志并抛错，.part 保留。
+            if (!cancelled &&
+                event.stage == MokuroMoeDownloadStage.downloadingCbz) {
+              cancelled = true;
+              dl.cancel();
+              server.release.complete();
+            }
+          },
+          onError: (Object e) => streamError.complete(e),
+          onDone: () {
+            if (!streamError.isCompleted) {
+              streamError
+                  .complete(StateError('stream completed without error'));
+            }
+          },
+        );
+
+    expect(await streamError.future, isA<MokuroMoeDownloadCancelled>());
+    final File part = File(p.join(stagingDir().path, 'volume.cbz.part'));
+    expect(part.existsSync(), isTrue, reason: '取消必须保留 .part 供续传');
+    expect(File(p.join(stagingDir().path, 'volume.cbz')).existsSync(), isFalse);
+    expect((await db.getAllEpubBooks()), isEmpty);
+  });
+}

--- a/hibiki/test/settings/settings_schema_coverage_test.dart
+++ b/hibiki/test/settings/settings_schema_coverage_test.dart
@@ -72,6 +72,11 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   // cloud_ocr_client_test 的「默认关零网络」gating。
   'reading/Enable cloud recognition':
       'test/media/manga/manga_ocr_settings_section_ui_test.dart + test/ocr/cloud_ocr_client_test.dart',
+  // 漫画「在线目录」站点根 URL（O1 mokuro.moe 目录源）：网络端点，写穿偏好后
+  // 消费点在 MokuroMoeClient 的请求 URL 拼接（widget harness 观测不到真生效）；
+  // 由 client 专项测试咬住（base URL 归一 + URL 编码 + 端点拼接）。
+  'reading/Online catalog URL':
+      'test/media/manga/online/mokuro_moe_client_test.dart',
   // 专项 unit/widget 生效探针（docs/specs/2026-06-03-t4-effect-probes-plan.md T1–T9）
   'reading/Text Orientation': 'test/reader/reader_content_styles_test.dart',
   'reading/Font Kerning (Vertical)':


### PR DESCRIPTION
## 摘要

「漫画抄 Mangatan」O1 阶段实现（设计+拍板见已合并的 PR#411 / docs/specs/2026-07-25-manga-online-source-design.md §10）。

- **MokuroMoeClient**：`/catalog/api/library|series|cover` + `/mokuro-reader/<系列>/<卷>.cbz|.mokuro`，URL 段级编码，站点地址可在设置配置（默认 mokuro.moe）
- **MokuroMoeVolumeDownloader**：`.part`+Range 断点续传 → isolate 流式解 CBZ（防 zip 路径穿越）→ `MangaImporter.importFromMokuroPath(skipIfExists)` 落库 → 清理；取消保留 `.part` 供续传
- **MokuroMoeCatalogDialog**：browse/series/downloading 阶段机、搜索过滤、封面网格（CachedNetworkImage）、多选顺序下载队列、已在库 ✓；PopScope 保证 Esc 关闭也回传导入计数，dispose 取消活动下载不留孤儿
- 入口两处：书架页头（管理来源旁）+ 书导入对话框 actions
- i18n 11 个 `manga_online_*` key 全走 i18n_sync + slang；设置项已登记 kCoveredElsewhere

## 验证

- 全量 `flutter analyze`：**No issues found**
- `flutter test test/media/manga/ test/settings/settings_schema_coverage_test.dart --no-pub`：**145 passed**（含新增 13 个：client 5 / downloader 5 / dialog 3；覆盖 Range 续传、路径穿越拒绝、取消保留 .part、e2e 落库）
- 待真机（保持 draft）：目录搜书 → 下载 → 书架打开 → 查词制卡全链

## 后续分期

O2 种子导入（qb）→ O3 Suwayomi 直读 → O4 阅读期懒 OCR → O5 收藏建行+互联 → O6 离线（看板 TODO-1952）

https://claude.ai/code/session_01Wx1AZQz9zJVpuBfweYdWi9