### PR TITLE
fix(lookup): 音频来源远端 URL 可就地编辑 (BUG-1090)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1055 条。点号进各自文件。
+> 共 1056 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1090](bugs/BUG-1090-audio-source-url-not-editable.md) | ✅ | ✅ | 管理音频来源弹窗里已有远端 URL 无法编辑，只能删了重加 |
 | [BUG-1088](bugs/BUG-1088-sync-host-hides-cloud-upload-and-interconnect-backend.md) | ✅ | ✅ | host 模式误藏云备份上传开关，互联从同步方式消失且无入口 |
 | [BUG-1087](bugs/BUG-1087-jimaku-episode-label-truncated.md) | ✅ | ✅ | 番剧下载确认页集号输入框在界面缩放下 label 截断成「集…」 |
 | [BUG-1086](bugs/BUG-1086-nyaa-search-error-swallowed.md) | ✅ | ✅ | Nyaa 搜索网络错误被吞成统一文案，真实报错不可见（生肉分类超时无从定位） |

--- a/docs/bugs/BUG-1090-audio-source-url-not-editable.md
+++ b/docs/bugs/BUG-1090-audio-source-url-not-editable.md
@@ -1,0 +1,17 @@
+## BUG-1090 · 管理音频来源弹窗里已有远端 URL 无法编辑，只能删了重加
+- **报告**：2026-07-25（用户：截图「设置 → 查词 → 管理音频来源」，反馈"这里没办法编辑"）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/dictionary_settings_dialog_page.dart:218-272`（修复前）——
+  `_buildSourceRow` 的 trailing 只给了 `Switch` / ↑ / ↓ / 删除四个控件，`remoteAudio` 行的 URL 没有任何
+  写入口；`AudioSourceConfig` 本身是 `@immutable` + `copyWith(url:)` 完全支持改写，缺的纯粹是 UI 入口。
+  后果：自定义查词发音 URL（尤其换机后要重指的 `localhost:5050` 这类回环源，见 TODO-1171 的换机警告）
+  写错一个字符就得删掉整条、把长模板 URL 重敲一遍，且删掉重加会丢 label 与排序位置（顺序即优先级）。
+- **[x] ① 已修复** — 远端行加 ✎ 编辑入口，复用下方那个 URL 输入框改写（不另开嵌套弹窗、不生第二套校验）：
+  载入原 URL、`+` 变 ✓、旁边给 ✕ 取消；提交只改 `url`，`label` / `enabled` / 位置全部保留。
+  编辑目标按**值身份**（`indexOf`）而非下标追踪，所以编辑中拖拽重排不会把新 URL 写到别人那行；
+  删掉正在编辑的行即时清空编辑态，提交不会把它当新增复活。
+  提交：见本分支 `fix(lookup): 音频来源远端 URL 可就地编辑 (BUG-1090)`。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/audio_sources_dialog_page_test.dart` 新增 6 条 widget 测试：
+  就地改写保留 label/enabled/位置、取消不动原值、编辑中重排仍写对行、删除被编辑行不复活、
+  仅 remoteAudio 行有 ✎、✎ 占 tune 同槽位不破坏 BUG-027 的开关列对齐。全文件 18/18 绿。
+- **备注**：`hibikiRemote` 行无 URL 可改、`localAudio` 行路径由文件选择器决定（已有 tune 调子来源），
+  故两者都不给 ✎ —— ✎ 只出现在自定义远端行。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 44370 (2610 per locale)
+/// Strings: 44421 (2613 per locale)
 ///
-/// Built on 2026-07-25 at 14:19 UTC
+/// Built on 2026-07-25 at 15:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3457,6 +3457,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get anime_download_sort_date => 'Published';
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  String get audio_source_edit_url => 'Edit audio source link';
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -9370,6 +9374,13 @@ class _StringsAr extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -15356,6 +15367,13 @@ class _StringsDe extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -21358,6 +21376,13 @@ class _StringsEs extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -27371,6 +27396,13 @@ class _StringsFr extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -33311,6 +33343,13 @@ class _StringsId extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -39299,6 +39338,13 @@ class _StringsIt extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -45092,6 +45138,13 @@ class _StringsJa extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -50888,6 +50941,13 @@ class _StringsKo extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -56854,6 +56914,13 @@ class _StringsNl extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -62835,6 +62902,13 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -68799,6 +68873,13 @@ class _StringsRu extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -74708,6 +74789,13 @@ class _StringsTh extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -80649,6 +80737,13 @@ class _StringsTr extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -86577,6 +86672,13 @@ class _StringsVi extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 // Path: <root>
@@ -92094,6 +92196,12 @@ class _StringsZhCn extends _StringsEn {
   String get anime_download_sort_date => '发布时间';
   @override
   String get anime_download_search_error_proxy_hint => '站点无法直连时，可在下载设置中配置网络代理。';
+  @override
+  String get audio_source_edit_target_gone => '该音频来源已不存在，编辑已丢弃';
+  @override
+  String get audio_source_edit_url => '编辑音频来源链接';
+  @override
+  String get audio_source_updated => '已更新音频来源';
 }
 
 // Path: <root>
@@ -97805,6 +97913,13 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get audio_source_edit_target_gone =>
+      'That audio source no longer exists — edit discarded';
+  @override
+  String get audio_source_edit_url => 'Edit audio source link';
+  @override
+  String get audio_source_updated => 'Audio source updated';
 }
 
 /// Flat map(s) containing all translations.
@@ -103133,6 +103248,12 @@ extension on _StringsEn {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -108459,6 +108580,12 @@ extension on _StringsAr {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -113806,6 +113933,12 @@ extension on _StringsDe {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -119152,6 +119285,12 @@ extension on _StringsEs {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -124504,6 +124643,12 @@ extension on _StringsFr {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -129838,6 +129983,12 @@ extension on _StringsId {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -135187,6 +135338,12 @@ extension on _StringsIt {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -140498,6 +140655,12 @@ extension on _StringsJa {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -145813,6 +145976,12 @@ extension on _StringsKo {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -151155,6 +151324,12 @@ extension on _StringsNl {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -156494,6 +156669,12 @@ extension on _StringsPtBr {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -161838,6 +162019,12 @@ extension on _StringsRu {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -167166,6 +167353,12 @@ extension on _StringsTh {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -172503,6 +172696,12 @@ extension on _StringsTr {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -177835,6 +178034,12 @@ extension on _StringsVi {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }
@@ -183127,6 +183332,12 @@ extension on _StringsZhCn {
         return '发布时间';
       case 'anime_download_search_error_proxy_hint':
         return '站点无法直连时，可在下载设置中配置网络代理。';
+      case 'audio_source_edit_target_gone':
+        return '该音频来源已不存在，编辑已丢弃';
+      case 'audio_source_edit_url':
+        return '编辑音频来源链接';
+      case 'audio_source_updated':
+        return '已更新音频来源';
       default:
         return null;
     }
@@ -188433,6 +188644,12 @@ extension on _StringsZhHk {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'audio_source_edit_target_gone':
+        return 'That audio source no longer exists — edit discarded';
+      case 'audio_source_edit_url':
+        return 'Edit audio source link';
+      case 'audio_source_updated':
+        return 'Audio source updated';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "做种数",
   "anime_download_sort_size": "体积",
   "anime_download_sort_date": "发布时间",
-  "anime_download_search_error_proxy_hint": "站点无法直连时，可在下载设置中配置网络代理。"
+  "anime_download_search_error_proxy_hint": "站点无法直连时，可在下载设置中配置网络代理。",
+  "audio_source_edit_target_gone": "该音频来源已不存在，编辑已丢弃",
+  "audio_source_edit_url": "编辑音频来源链接",
+  "audio_source_updated": "已更新音频来源"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "audio_source_edit_target_gone": "That audio source no longer exists — edit discarded",
+  "audio_source_edit_url": "Edit audio source link",
+  "audio_source_updated": "Audio source updated"
 }

--- a/hibiki/lib/src/pages/implementations/dictionary_settings_dialog_page.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_settings_dialog_page.dart
@@ -48,6 +48,17 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
   bool _referenceOriginal = false;
   bool _urlValid = false;
   final TextEditingController _controller = TextEditingController();
+  final FocusNode _urlFocusNode = FocusNode();
+  final GlobalKey _urlFieldKey = GlobalKey();
+
+  /// 正在编辑的远端来源（按**值身份**而非下标追踪）。远端 URL 过去只能删了重加：写错
+  /// 一个字符就得整条重敲。编辑不另开嵌套弹窗，而是复用下方那个 URL 输入框——载入该行
+  /// URL、`+` 变 ✓、旁边给 ✕ 取消，校验/报错沿用同一条路径，不生第二套输入 UI。
+  ///
+  /// 存值而非 index：编辑中用户仍可拖拽重排（`_sources` 顺序会变），存下标就会把新 URL
+  /// 写到**别人**那行上。[AudioSourceConfig] 是 `@immutable` 且实现了 `==`，提交时用
+  /// `indexOf` 现场定位即可；该行被删掉则 `indexOf` 返回 -1，编辑态在删除处即时清空。
+  AudioSourceConfig? _editingSource;
 
   @override
   void initState() {
@@ -63,6 +74,7 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
     // 回收）。把持久化下沉到 dispose 后，所有关闭路径行为一致（BUG-053）。
     widget.onSave(_sources);
     _controller.dispose();
+    _urlFocusNode.dispose();
     super.dispose();
   }
 
@@ -198,6 +210,9 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
     final AudioSourceConfig source = _sources[index];
     final bool isHibiki = source.kind == AudioSourceKind.hibikiRemote;
     final bool isLocal = source.kind == AudioSourceKind.localAudio;
+    final bool isRemoteUrl = source.kind == AudioSourceKind.remoteAudio;
+    final bool isEditingThis =
+        _editingSource != null && _editingSource == source;
     final String title =
         isHibiki ? t.audio_source_hibiki_interconnect : source.displayLabel;
     final bool loopbackWarn = source.pointsAtLoopbackHost;
@@ -229,6 +244,19 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
               tooltip: t.local_audio_edit_sources,
               padding: EdgeInsets.all(tokens.spacing.gap / 2),
               onTap: () => widget.onEditLocalSources!(source.path!),
+            ),
+          // 「编辑 URL」只在自定义远端行出现，占的是与本地行 tune 完全相同的槽位
+          // （开关左侧）→ 两类行各多一个同尺寸按钮，开关/↑/↓/删除四列仍跨行右贴边
+          // 对齐（BUG-027）。hibikiRemote 无 URL 可改、本地库路径由选择器决定，都不给。
+          if (isRemoteUrl)
+            HibikiIconButton(
+              icon: isEditingThis ? Icons.edit : Icons.edit_outlined,
+              size: 18,
+              tooltip: t.dialog_edit,
+              enabledColor:
+                  isEditingThis ? Theme.of(context).colorScheme.primary : null,
+              padding: EdgeInsets.all(tokens.spacing.gap / 2),
+              onTap: () => _beginEditRemoteUrl(source),
             ),
           Switch.adaptive(
             value: source.enabled,
@@ -266,7 +294,12 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
             tooltip: t.dialog_delete,
             enabled: !isHibiki,
             padding: EdgeInsets.all(tokens.spacing.gap / 2),
-            onTap: () => setState(() => _sources.removeAt(index)),
+            onTap: () => setState(() {
+              _sources.removeAt(index);
+              // 删掉的正是在编辑的那行 → 编辑态当场失效（否则提交时 indexOf 找不到
+              // 它，或在存在等值重复行时改到别人头上）。
+              if (isEditingThis) _cancelEdit();
+            }),
           ),
         ],
       ),
@@ -275,22 +308,30 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
 
   Widget _buildUrlField(HibikiDesignTokens tokens) {
     final bool showError = _controller.text.trim().isNotEmpty && !_urlValid;
+    final bool editing = _editingSource != null;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         AdaptiveSettingsTextField(
+          key: _urlFieldKey,
           controller: _controller,
+          focusNode: _urlFocusNode,
+          // 编辑态给出可见标签，让「这一栏现在改的是已有那行、不是新增」有据可依。
+          labelText: editing ? t.audio_source_edit_url : null,
           hintText: 'https://...{term}...{reading}',
           onChanged: (String value) => setState(
             () => _urlValid = AudioSourcesDialog.isValidRemoteUrl(value),
           ),
-          onSubmitted: (_) => _addRemoteUrl(),
+          onSubmitted: (_) => _commitRemoteUrl(),
           suffixIcon: Row(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              if (!_sources.any((AudioSourceConfig s) =>
-                  s.kind == AudioSourceKind.hibikiRemote))
+              // 编辑态下不再暴露「加入 Hibiki 互联源」——那是新增动作，与当前正在改的
+              // 那一行无关，混在一起只会让 ✓ 的语义变模糊。
+              if (!editing &&
+                  !_sources.any((AudioSourceConfig s) =>
+                      s.kind == AudioSourceKind.hibikiRemote))
                 HibikiIconButton(
                   icon: Icons.hub_outlined,
                   tooltip: t.audio_source_hibiki_interconnect,
@@ -300,12 +341,19 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
                         AudioSourceConfig.hibikiRemote(),
                       )),
                 ),
+              if (editing)
+                HibikiIconButton(
+                  icon: Icons.close,
+                  tooltip: t.dialog_cancel,
+                  padding: EdgeInsets.all(tokens.spacing.gap / 2),
+                  onTap: () => setState(_cancelEdit),
+                ),
               HibikiIconButton(
-                icon: Icons.add,
-                tooltip: t.dialog_add,
+                icon: editing ? Icons.check : Icons.add,
+                tooltip: editing ? t.dialog_save : t.dialog_add,
                 enabled: _urlValid,
                 padding: EdgeInsets.all(tokens.spacing.gap / 2),
-                onTap: _addRemoteUrl,
+                onTap: _commitRemoteUrl,
               ),
             ],
           ),
@@ -323,18 +371,65 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
   }
 
   // ── actions ──────────────────────────────────────────────────────────────
-  void _addRemoteUrl() {
+
+  /// 把某个远端行的 URL 载入下方输入框，进入编辑态（光标置末尾，便于改个别字符）。
+  void _beginEditRemoteUrl(AudioSourceConfig source) {
+    final String url = source.url ?? '';
+    setState(() {
+      _editingSource = source;
+      _controller.text = url;
+      _controller.selection = TextSelection.collapsed(offset: url.length);
+      _urlValid = AudioSourcesDialog.isValidRemoteUrl(url);
+    });
+    _urlFocusNode.requestFocus();
+    // 来源多时输入框可能在可视区之外：滚进视野，别让用户以为点了没反应。
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final BuildContext? fieldContext = _urlFieldKey.currentContext;
+      if (fieldContext != null && mounted) {
+        Scrollable.ensureVisible(
+          fieldContext,
+          duration: const Duration(milliseconds: 150),
+          alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+        );
+      }
+    });
+  }
+
+  /// 退出编辑态并清空输入框。**不**自带 setState：调用点已在 setState 内（删除行）或
+  /// 自行包裹（✕ / 提交），避免嵌套 setState。
+  void _cancelEdit() {
+    _editingSource = null;
+    _controller.clear();
+    _urlValid = false;
+  }
+
+  /// 输入框提交：编辑态改写目标行的 URL，否则按新增插到最前。
+  void _commitRemoteUrl() {
     final String text = _controller.text.trim();
     if (!AudioSourcesDialog.isValidRemoteUrl(text)) {
       _showSnack(t.audio_source_url_invalid);
       return;
     }
+    final AudioSourceConfig? editing = _editingSource;
+    // 现场按值定位：编辑期间的拖拽重排不会让我们写错行（存下标才会）。
+    final int index = editing == null ? -1 : _sources.indexOf(editing);
+    if (editing != null && index < 0) {
+      // 目标行已在编辑期间消失（理论上删除处已清编辑态，这里是兜底）：不静默把它
+      // 当新增塞回去——那等于复活用户刚删掉的来源。
+      setState(_cancelEdit);
+      _showSnack(t.audio_source_edit_target_gone);
+      return;
+    }
     setState(() {
-      _sources.insert(0, AudioSourceConfig.remoteAudio(url: text));
-      _controller.clear();
-      _urlValid = false;
+      if (index >= 0) {
+        // label / enabled 保持原样：用户改的只是链接，不该顺手重置显示名和启用状态。
+        _sources[index] = _sources[index].copyWith(url: text);
+      } else {
+        _sources.insert(0, AudioSourceConfig.remoteAudio(url: text));
+      }
+      _cancelEdit();
     });
-    _showSnack(t.audio_source_added);
+    _showSnack(index >= 0 ? t.audio_source_updated : t.audio_source_added);
   }
 
   Future<void> _addLocalDb() async {
@@ -371,6 +466,8 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
 
   void _resetToDefaults() {
     setState(() {
+      // 整表重建 → 编辑目标不再属于新列表，编辑态必须一起清掉。
+      _cancelEdit();
       final bool hadHibiki = _sources
           .any((AudioSourceConfig s) => s.kind == AudioSourceKind.hibikiRemote);
       final List<AudioSourceConfig> locals = _sources

--- a/hibiki/test/pages/audio_sources_dialog_page_test.dart
+++ b/hibiki/test/pages/audio_sources_dialog_page_test.dart
@@ -355,6 +355,216 @@ void main() {
         saved!.map((AudioSourceConfig s) => s.url).toList();
     expect(order.indexOf(urlA), greaterThan(order.indexOf(urlB)));
   });
+  // 远端 URL 过去只能删了重加（行尾只有开关/↑/↓/删除），写错一个字符就得整条重敲。
+  // 修复=远端行给 ✎，把该行 URL 载入下方输入框改写，✓ 提交后落到**同一行**且保留
+  // label / enabled / 位置。
+  testWidgets(
+      'editing a remote row rewrites that row in place, keeping its '
+      'label, enabled state and position', (WidgetTester tester) async {
+    List<AudioSourceConfig>? saved;
+    await openDialog(
+      tester,
+      AudioSourcesDialog(
+        sources: <AudioSourceConfig>[
+          AudioSourceConfig.remoteAudio(url: 'https://keep.example.com/{term}'),
+          AudioSourceConfig.remoteAudio(
+            url: 'http://localhost:5050/?term={term}',
+            label: 'Anki',
+            enabled: false,
+          ),
+        ],
+        onSave: (List<AudioSourceConfig> v) => saved = v,
+      ),
+    );
+
+    // 第 2 行（label=Anki、已关闭）的 ✎。
+    expect(find.byIcon(Icons.edit_outlined), findsNWidgets(2));
+    await tester.tap(find.byIcon(Icons.edit_outlined).at(1));
+    await tester.pumpAndSettle();
+
+    // 进入编辑态：原 URL 已载入输入框，+ 变 ✓，并出现取消 ✕。
+    expect(find.byType(TextField), findsOneWidget);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller?.text,
+      'http://localhost:5050/?term={term}',
+    );
+    expect(find.byIcon(Icons.check), findsOneWidget);
+    expect(find.byIcon(Icons.add), findsNothing);
+    expect(find.byIcon(Icons.close), findsOneWidget);
+
+    await tester.enterText(
+        find.byType(TextField), 'http://192.168.1.9:5050/?term={term}');
+    await tester.pump();
+    await tester.tap(find.byIcon(Icons.check));
+    await tester.pumpAndSettle();
+
+    // 提交后退出编辑态（✓ 变回 +，输入框清空）。
+    expect(find.byIcon(Icons.add), findsOneWidget);
+    expect(find.byIcon(Icons.check), findsNothing);
+
+    await tester.tap(find.text(t.dialog_close));
+    await tester.pumpAndSettle();
+
+    expect(saved, isNotNull);
+    // 没有变成「删一条加一条」：仍是 2 条，且改的是原位那条。
+    expect(saved!.length, 2);
+    expect(saved![0].url, 'https://keep.example.com/{term}');
+    expect(saved![1].url, 'http://192.168.1.9:5050/?term={term}');
+    // 用户改的只是链接：显示名与启用状态不该被顺手重置。
+    expect(saved![1].label, 'Anki');
+    expect(saved![1].enabled, isFalse);
+  });
+
+  testWidgets('cancelling an edit leaves the source untouched',
+      (WidgetTester tester) async {
+    List<AudioSourceConfig>? saved;
+    await openDialog(
+      tester,
+      AudioSourcesDialog(
+        sources: <AudioSourceConfig>[
+          AudioSourceConfig.remoteAudio(url: 'https://a.example.com/{term}'),
+        ],
+        onSave: (List<AudioSourceConfig> v) => saved = v,
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.edit_outlined));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+        find.byType(TextField), 'https://typo.example.com/{term}');
+    await tester.pump();
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+
+    // 取消后回到新增态，且不多出一条。
+    expect(find.byIcon(Icons.add), findsOneWidget);
+    await tester.tap(find.text(t.dialog_close));
+    await tester.pumpAndSettle();
+
+    expect(saved!.length, 1);
+    expect(saved!.single.url, 'https://a.example.com/{term}');
+  });
+
+  // 编辑目标按值身份而非下标追踪：编辑期间把该行拖到别处（这里用等价的 ↓ 按钮重排），
+  // 提交仍必须改到**它自己**，而不是原下标上现在那一行。
+  testWidgets(
+      'reordering while editing still writes to the edited row, not '
+      'whatever now sits at its old index', (WidgetTester tester) async {
+    List<AudioSourceConfig>? saved;
+    await openDialog(
+      tester,
+      AudioSourcesDialog(
+        sources: <AudioSourceConfig>[
+          AudioSourceConfig.remoteAudio(
+              url: 'https://first.example.com/{term}'),
+          AudioSourceConfig.remoteAudio(
+              url: 'https://other.example.com/{term}'),
+        ],
+        onSave: (List<AudioSourceConfig> v) => saved = v,
+      ),
+    );
+
+    // 编辑第 1 行，然后把它用 ↓ 移到第 2 位（编辑态保持）。
+    await tester.tap(find.byIcon(Icons.edit_outlined).at(0));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.keyboard_arrow_down).at(0));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.byType(TextField), 'https://fixed.example.com/{term}');
+    await tester.pump();
+    await tester.tap(find.byIcon(Icons.check));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.dialog_close));
+    await tester.pumpAndSettle();
+
+    expect(saved!.length, 2);
+    // 被编辑的那条现在在第 2 位，改写落在它身上；未参与编辑的那条原文不动。
+    expect(saved![0].url, 'https://other.example.com/{term}');
+    expect(saved![1].url, 'https://fixed.example.com/{term}');
+  });
+
+  // 编辑中把该行删掉：提交不得把它当新增复活（那等于撤销用户的删除）。
+  testWidgets('deleting the row being edited does not resurrect it on submit',
+      (WidgetTester tester) async {
+    List<AudioSourceConfig>? saved;
+    await openDialog(
+      tester,
+      AudioSourcesDialog(
+        sources: <AudioSourceConfig>[
+          AudioSourceConfig.remoteAudio(url: 'https://gone.example.com/{term}'),
+        ],
+        onSave: (List<AudioSourceConfig> v) => saved = v,
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.edit_outlined));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await tester.pumpAndSettle();
+
+    // 删除即退出编辑态（输入框清空、回到新增态的 +）。
+    expect(find.byIcon(Icons.check), findsNothing);
+    expect(find.byIcon(Icons.add), findsOneWidget);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller?.text,
+      isEmpty,
+    );
+
+    await tester.tap(find.text(t.dialog_close));
+    await tester.pumpAndSettle();
+    expect(saved, isNotNull);
+    expect(saved, isEmpty);
+  });
+
+  // hibikiRemote 无 URL 可改、本地库路径由文件选择器决定 → 都不给 ✎（只有自定义远端行有）。
+  testWidgets('only remoteAudio rows expose the edit button',
+      (WidgetTester tester) async {
+    await openDialog(
+      tester,
+      AudioSourcesDialog(
+        sources: <AudioSourceConfig>[
+          AudioSourceConfig.hibikiRemote(),
+          AudioSourceConfig.localAudio(
+              label: 'a.db', path: '/a.db', enabled: true),
+          AudioSourceConfig.remoteAudio(url: 'https://a.example.com/{term}'),
+        ],
+        onSave: (_) {},
+        onEditLocalSources: (String _) async {},
+      ),
+    );
+
+    expect(find.byIcon(Icons.edit_outlined), findsOneWidget);
+  });
+
+  // BUG-027 的开关列对齐必须继续成立：远端行的 ✎ 占的是本地行 tune 的同一槽位
+  // （开关左侧），所以两类行的开关/↑/↓/删除四列仍右贴边对齐。
+  testWidgets(
+      'the edit button sits left of the switch and keeps the switch '
+      'column aligned across local and remote rows (BUG-027)',
+      (WidgetTester tester) async {
+    await openDialog(
+      tester,
+      AudioSourcesDialog(
+        sources: <AudioSourceConfig>[
+          AudioSourceConfig.localAudio(
+              label: 'a.db', path: '/a.db', enabled: true),
+          AudioSourceConfig.remoteAudio(url: 'https://b.example.com/{term}'),
+        ],
+        onSave: (_) {},
+        onEditLocalSources: (String _) async {},
+      ),
+    );
+
+    final Finder switches = find.byType(Switch);
+    expect(switches, findsNWidgets(2));
+    final double localSwitchX = tester.getCenter(switches.at(0)).dx;
+    final double remoteSwitchX = tester.getCenter(switches.at(1)).dx;
+    expect((localSwitchX - remoteSwitchX).abs(), lessThan(1.0));
+    expect(tester.getCenter(find.byIcon(Icons.edit_outlined)).dx,
+        lessThan(remoteSwitchX));
+  });
+
   testWidgets(
       'a loopback remoteAudio source shows the cross-machine re-point warning '
       '(TODO-1171)', (WidgetTester tester) async {


### PR DESCRIPTION
## 用户报告

设置 → 查词 → **管理音频来源**：「这里没办法编辑」。

## 根因

`hibiki/lib/src/pages/implementations/dictionary_settings_dialog_page.dart` 的 `_buildSourceRow`
trailing 只给了 `Switch` / ↑ / ↓ / 删除四个控件，`remoteAudio` 行的 URL **没有任何写入口**。
`AudioSourceConfig` 是 `@immutable` + `copyWith(url:)`，改写能力本来就有，缺的纯粹是 UI 入口。

后果：自定义查词发音 URL（尤其换机后要重指的 `localhost:5050` 这类回环源，见 TODO-1171 的
换机警告）写错一个字符就得删掉整条、把长模板 URL 重敲一遍；而且删了重加会丢 `label` 和
排序位置——这个列表的顺序就是优先级。

## 修法

远端行加 ✎，**复用下方已有的那个 URL 输入框**做改写，不另开嵌套弹窗、不生第二套校验/报错 UI：

- 点 ✎ → 载入该行 URL（光标置末尾）、滚进视野、聚焦；`+` 变 ✓，旁边出现 ✕ 取消，输入框带编辑态标签。
- 提交只改 `url`：`label` / `enabled` / 位置原样保留（用户改的是链接，不该顺手重置显示名和开关）。
- 编辑目标按**值身份** `indexOf` 现场定位，不存下标 —— 编辑期间用户仍可拖拽/↑↓ 重排，存下标就会
  把新 URL 写到别人那行上。
- 删掉正在编辑的那行 → 编辑态即时清空，提交不会把它当新增复活（等于撤销用户的删除）；兜底路径
  给可见提示，不静默丢弃。
- `hibikiRemote` 无 URL 可改、`localAudio` 路径由文件选择器决定（已有 tune），两者都不给 ✎。

✎ 占的是本地库行 `tune` 的**同一槽位**（开关左侧），所以两类行各多一个同尺寸按钮，
开关/↑/↓/删除四列仍跨行右贴边对齐（BUG-027 不回归，已有测试 + 新增测试双向锁住）。

## 验证

- `test/pages/audio_sources_dialog_page_test.dart` 新增 6 条 widget 测试，全文件 **18/18 绿**：
  就地改写保留 label/enabled/位置、取消不动原值、编辑中重排仍写对行、删除被编辑行不复活、
  仅 remoteAudio 行有 ✎、开关列跨行仍对齐。
- i18n 完整性 + 相邻音频弹窗测试 + MD3 设计系统守卫 + bug per-file 守卫：**93 项绿**。
- `flutter analyze`（含 test 目录）：**No issues found**。
- 3 个新 i18n key 经 `tool/i18n_sync.dart` 写入 17 个语言文件并 `dart run slang` 重生成。

⚠️ 未做真机验证（纯 widget 层改动，桌面/移动端行为一致），落地前建议在 Windows 真机点一次 ✎ 改 URL。

BUG 档案：`docs/bugs/BUG-1090-audio-source-url-not-editable.md`

https://claude.ai/code/session_01EEiSaaBpAg1xZugdzRwVtd