### PR TITLE
fix(lookup): Yomitan API 端口冲突提示写明真实占用者 + 一键结束进程重试

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 44370 (2610 per locale)
+/// Strings: 44421 (2613 per locale)
 ///
-/// Built on 2026-07-25 at 14:19 UTC
+/// Built on 2026-07-25 at 15:46 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2632,7 +2632,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get desktop_clipboard_window_mode_hint =>
       'Controls whether Hibiki stays above other windows';
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   String get interconnect_enable => 'Enable interconnect';
   String get interconnect_enable_hint =>
       'Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don\'t conflict.';
@@ -3457,6 +3457,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get anime_download_sort_date => 'Published';
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  String get yomitan_port_kill_action => 'End process and retry';
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -7891,7 +7895,7 @@ class _StringsAr extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -9370,6 +9374,13 @@ class _StringsAr extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -13877,7 +13888,7 @@ class _StringsDe extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -15356,6 +15367,13 @@ class _StringsDe extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -19879,7 +19897,7 @@ class _StringsEs extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -21358,6 +21376,13 @@ class _StringsEs extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -25892,7 +25917,7 @@ class _StringsFr extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -27371,6 +27396,13 @@ class _StringsFr extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -31832,7 +31864,7 @@ class _StringsId extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -33311,6 +33343,13 @@ class _StringsId extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -37820,7 +37859,7 @@ class _StringsIt extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -39299,6 +39338,13 @@ class _StringsIt extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -43614,7 +43660,7 @@ class _StringsJa extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -45092,6 +45138,13 @@ class _StringsJa extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -49410,7 +49463,7 @@ class _StringsKo extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -50888,6 +50941,13 @@ class _StringsKo extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -55375,7 +55435,7 @@ class _StringsNl extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -56854,6 +56914,13 @@ class _StringsNl extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -61356,7 +61423,7 @@ class _StringsPtBr extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -62835,6 +62902,13 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -67320,7 +67394,7 @@ class _StringsRu extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -68799,6 +68873,13 @@ class _StringsRu extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -73229,7 +73310,7 @@ class _StringsTh extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -74708,6 +74789,13 @@ class _StringsTh extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -79170,7 +79258,7 @@ class _StringsTr extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -80649,6 +80737,13 @@ class _StringsTr extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -85098,7 +85193,7 @@ class _StringsVi extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -86577,6 +86672,13 @@ class _StringsVi extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 // Path: <root>
@@ -90720,7 +90822,7 @@ class _StringsZhCn extends _StringsEn {
   String get desktop_clipboard_window_mode_hint => '控制 Hibiki 是否保持在其他窗口上方';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      '端口 ${port} 正被 Yomitan API 占用。请先在 Yomitan 高级设置中关闭 Yomitan API，再回 Hibiki 开启 Yomitan API 服务器。';
+      '端口 ${port} 正被其他进程占用（通常是浏览器拉起的 yomitan-api 组件，即一个 Python 进程）。可直接结束该进程，或在 Yomitan 高级设置中关闭 Yomitan API，然后重新开启 Hibiki 的 Yomitan API 服务器。';
   @override
   String get interconnect_enable => '启用互联';
   @override
@@ -92094,6 +92196,13 @@ class _StringsZhCn extends _StringsEn {
   String get anime_download_sort_date => '发布时间';
   @override
   String get anime_download_search_error_proxy_hint => '站点无法直连时，可在下载设置中配置网络代理。';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API 服务器已开启';
+  @override
+  String get yomitan_port_kill_action => '结束进程并重试';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      '无法结束 ${process}，请手动结束该进程后重试。';
 }
 
 // Path: <root>
@@ -96331,7 +96440,7 @@ class _StringsZhHk extends _StringsEn {
       'Controls whether Hibiki stays above other windows';
   @override
   String browser_extension_yomitan_port_conflict({required Object port}) =>
-      'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+      'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
   @override
   String get interconnect_enable => 'Enable interconnect';
   @override
@@ -97805,6 +97914,13 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anime_download_search_error_proxy_hint =>
       'If the site cannot be reached directly, configure a network proxy in download settings.';
+  @override
+  String get yomitan_api_server_started => 'Yomitan API server started';
+  @override
+  String get yomitan_port_kill_action => 'End process and retry';
+  @override
+  String yomitan_port_kill_failed({required Object process}) =>
+      'Could not end ${process}. Please end it manually, then retry.';
 }
 
 /// Flat map(s) containing all translations.
@@ -101805,7 +101921,7 @@ extension on _StringsEn {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -103133,6 +103249,13 @@ extension on _StringsEn {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -107131,7 +107254,7 @@ extension on _StringsAr {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -108459,6 +108582,13 @@ extension on _StringsAr {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -112478,7 +112608,7 @@ extension on _StringsDe {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -113806,6 +113936,13 @@ extension on _StringsDe {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -117824,7 +117961,7 @@ extension on _StringsEs {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -119152,6 +119289,13 @@ extension on _StringsEs {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -123176,7 +123320,7 @@ extension on _StringsFr {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -124504,6 +124648,13 @@ extension on _StringsFr {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -128510,7 +128661,7 @@ extension on _StringsId {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -129838,6 +129989,13 @@ extension on _StringsId {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -133859,7 +134017,7 @@ extension on _StringsIt {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -135187,6 +135345,13 @@ extension on _StringsIt {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -139170,7 +139335,7 @@ extension on _StringsJa {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -140498,6 +140663,13 @@ extension on _StringsJa {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -144485,7 +144657,7 @@ extension on _StringsKo {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -145813,6 +145985,13 @@ extension on _StringsKo {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -149827,7 +150006,7 @@ extension on _StringsNl {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -151155,6 +151334,13 @@ extension on _StringsNl {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -155166,7 +155352,7 @@ extension on _StringsPtBr {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -156494,6 +156680,13 @@ extension on _StringsPtBr {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -160510,7 +160703,7 @@ extension on _StringsRu {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -161838,6 +162031,13 @@ extension on _StringsRu {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -165838,7 +166038,7 @@ extension on _StringsTh {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -167166,6 +167366,13 @@ extension on _StringsTh {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -171175,7 +171382,7 @@ extension on _StringsTr {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -172503,6 +172710,13 @@ extension on _StringsTr {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -176507,7 +176721,7 @@ extension on _StringsVi {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -177835,6 +178049,13 @@ extension on _StringsVi {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }
@@ -181807,7 +182028,7 @@ extension on _StringsZhCn {
         return '控制 Hibiki 是否保持在其他窗口上方';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            '端口 ${port} 正被 Yomitan API 占用。请先在 Yomitan 高级设置中关闭 Yomitan API，再回 Hibiki 开启 Yomitan API 服务器。';
+            '端口 ${port} 正被其他进程占用（通常是浏览器拉起的 yomitan-api 组件，即一个 Python 进程）。可直接结束该进程，或在 Yomitan 高级设置中关闭 Yomitan API，然后重新开启 Hibiki 的 Yomitan API 服务器。';
       case 'interconnect_enable':
         return '启用互联';
       case 'interconnect_enable_hint':
@@ -183127,6 +183348,12 @@ extension on _StringsZhCn {
         return '发布时间';
       case 'anime_download_search_error_proxy_hint':
         return '站点无法直连时，可在下载设置中配置网络代理。';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API 服务器已开启';
+      case 'yomitan_port_kill_action':
+        return '结束进程并重试';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) => '无法结束 ${process}，请手动结束该进程后重试。';
       default:
         return null;
     }
@@ -187105,7 +187332,7 @@ extension on _StringsZhHk {
         return 'Controls whether Hibiki stays above other windows';
       case 'browser_extension_yomitan_port_conflict':
         return ({required Object port}) =>
-            'Port ${port} is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.';
+            'Port ${port} is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan\'s advanced settings, then enable the Yomitan API server in Hibiki again.';
       case 'interconnect_enable':
         return 'Enable interconnect';
       case 'interconnect_enable_hint':
@@ -188433,6 +188660,13 @@ extension on _StringsZhHk {
         return 'Published';
       case 'anime_download_search_error_proxy_hint':
         return 'If the site cannot be reached directly, configure a network proxy in download settings.';
+      case 'yomitan_api_server_started':
+        return 'Yomitan API server started';
+      case 'yomitan_port_kill_action':
+        return 'End process and retry';
+      case 'yomitan_port_kill_failed':
+        return ({required Object process}) =>
+            'Could not end ${process}. Please end it manually, then retry.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "暂不可提前入库（元数据未就绪或连接失败），稍后再试",
   "interconnect_section_related": "远端内容与查词",
   "desktop_clipboard_window_mode_hint": "控制 Hibiki 是否保持在其他窗口上方",
-  "browser_extension_yomitan_port_conflict": "端口 $port 正被 Yomitan API 占用。请先在 Yomitan 高级设置中关闭 Yomitan API，再回 Hibiki 开启 Yomitan API 服务器。",
+  "browser_extension_yomitan_port_conflict": "端口 $port 正被其他进程占用（通常是浏览器拉起的 yomitan-api 组件，即一个 Python 进程）。可直接结束该进程，或在 Yomitan 高级设置中关闭 Yomitan API，然后重新开启 Hibiki 的 Yomitan API 服务器。",
   "interconnect_enable": "启用互联",
   "interconnect_enable_hint": "通过局域网连接你的其他设备。与云备份后端并存，互不冲突。",
   "reading_activity": "学习活动",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "做种数",
   "anime_download_sort_size": "体积",
   "anime_download_sort_date": "发布时间",
-  "anime_download_search_error_proxy_hint": "站点无法直连时，可在下载设置中配置网络代理。"
+  "anime_download_search_error_proxy_hint": "站点无法直连时，可在下载设置中配置网络代理。",
+  "yomitan_api_server_started": "Yomitan API 服务器已开启",
+  "yomitan_port_kill_action": "结束进程并重试",
+  "yomitan_port_kill_failed": "无法结束 $process，请手动结束该进程后重试。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1954,7 +1954,7 @@
   "anime_download_play_now_fail": "Not ready yet (metadata pending or connection failed) — try again later",
   "interconnect_section_related": "Remote content & lookup",
   "desktop_clipboard_window_mode_hint": "Controls whether Hibiki stays above other windows",
-  "browser_extension_yomitan_port_conflict": "Port $port is occupied by Yomitan API. Disable Yomitan API in Yomitan advanced settings, then enable the Yomitan API server in Hibiki.",
+  "browser_extension_yomitan_port_conflict": "Port $port is in use by another process (usually the yomitan-api component — a Python process launched by your browser). End that process, or disable Yomitan API in Yomitan's advanced settings, then enable the Yomitan API server in Hibiki again.",
   "interconnect_enable": "Enable interconnect",
   "interconnect_enable_hint": "Connect to your other devices over the LAN. Works alongside a cloud backup backend — they don't conflict.",
   "reading_activity": "Study activity",
@@ -2608,5 +2608,8 @@
   "anime_download_sort_seeders": "Seeders",
   "anime_download_sort_size": "Size",
   "anime_download_sort_date": "Published",
-  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings."
+  "anime_download_search_error_proxy_hint": "If the site cannot be reached directly, configure a network proxy in download settings.",
+  "yomitan_api_server_started": "Yomitan API server started",
+  "yomitan_port_kill_action": "End process and retry",
+  "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry."
 }

--- a/hibiki/lib/src/settings/settings_schema_lookup.dart
+++ b/hibiki/lib/src/settings/settings_schema_lookup.dart
@@ -14,6 +14,7 @@ import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/src/sync/deletion_propagation.dart';
 import 'package:hibiki/src/sync/desktop_lookup_service.dart';
 import 'package:hibiki/src/sync/hibiki_sync_server.dart';
+import 'package:hibiki/src/sync/port_process_terminator.dart';
 import 'package:hibiki/src/sync/texthooker_ws_client_manager.dart';
 import 'package:hibiki/src/sync/yomitan_api_server.dart'
     show kYomitanApiDefaultPort;
@@ -23,6 +24,79 @@ String _yomitanApiPortInUseMessage(int port) {
   return port == kYomitanApiDefaultPort
       ? t.browser_extension_yomitan_port_conflict(port: port)
       : t.sync_server_port_in_use(port: port);
+}
+
+void _showSettingsSnackBar(SettingsContext settingsContext, String message) {
+  final BuildContext ctx = settingsContext.context;
+  if (!ctx.mounted) return;
+  ScaffoldMessenger.of(ctx).showSnackBar(SnackBar(content: Text(message)));
+}
+
+/// 端口冲突提示：说明占用者（默认端口时通常是浏览器拉起的 yomitan-api Python
+/// 进程），并在支持的桌面平台附「结束进程并重试」action——直接结束占用进程后
+/// 自动重试开启，免去用户去 Yomitan 高级设置绕一圈。
+void _showYomitanPortConflictSnackBar(SettingsContext settingsContext) {
+  final BuildContext ctx = settingsContext.context;
+  if (!ctx.mounted) return;
+  final int port = settingsContext.appModel.yomitanApiPort;
+  ScaffoldMessenger.of(ctx).showSnackBar(
+    SnackBar(
+      content: Text(_yomitanApiPortInUseMessage(port)),
+      duration: const Duration(seconds: 10),
+      action: PortProcessTerminator.isSupported
+          ? SnackBarAction(
+              label: t.yomitan_port_kill_action,
+              onPressed: () => unawaited(
+                _terminatePortOwnerAndRetry(settingsContext, port),
+              ),
+            )
+          : null,
+    ),
+  );
+}
+
+Future<void> _terminatePortOwnerAndRetry(
+  SettingsContext settingsContext,
+  int port,
+) async {
+  final AppModel appModel = settingsContext.appModel;
+  final PortListenerInfo? listener =
+      await PortProcessTerminator.findListener(port);
+  if (listener != null) {
+    final bool killed = await PortProcessTerminator.terminate(listener);
+    if (!killed) {
+      _showSettingsSnackBar(
+        settingsContext,
+        t.yomitan_port_kill_failed(
+          process: '${listener.processName} (PID ${listener.pid})',
+        ),
+      );
+      return;
+    }
+  }
+  // 占用进程已结束（或本就已退出）：重试开启。进程退出后 OS 释放端口可能有极短
+  // 延迟，端口仍占时再等一拍重试一次，仍失败按端口冲突报出。
+  await appModel.setYomitanApiServerEnabled(true);
+  for (int attempt = 0;; attempt++) {
+    try {
+      await appModel.startYomitanApiServer();
+      break;
+    } on SyncServerPortInUseException {
+      if (attempt >= 1) {
+        _showSettingsSnackBar(
+          settingsContext,
+          _yomitanApiPortInUseMessage(port),
+        );
+        settingsContext.refresh();
+        return;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      // startYomitanApiServer 抛出前把开关复位成 false，重试前需重新置位。
+      await appModel.setYomitanApiServerEnabled(true);
+    }
+  }
+  _showSettingsSnackBar(settingsContext, t.yomitan_api_server_started);
+  settingsContext.refresh();
 }
 
 SettingsDestination buildLookupDestination() {
@@ -858,18 +932,7 @@ SettingsDestination buildLookupDestination() {
                   await settingsContext.appModel.startYomitanApiServer();
                 } on SyncServerPortInUseException {
                   // startYomitanApiServer 已在抛出前把开关复位为 false。
-                  final BuildContext ctx = settingsContext.context;
-                  if (ctx.mounted) {
-                    ScaffoldMessenger.of(ctx).showSnackBar(
-                      SnackBar(
-                        content: Text(
-                          _yomitanApiPortInUseMessage(
-                            settingsContext.appModel.yomitanApiPort,
-                          ),
-                        ),
-                      ),
-                    );
-                  }
+                  _showYomitanPortConflictSnackBar(settingsContext);
                 }
               } else {
                 await settingsContext.appModel.stopYomitanApiServer();
@@ -1018,16 +1081,6 @@ Future<void> _restartYomitanApiServerIfEnabled(
   try {
     await settingsContext.appModel.startYomitanApiServer();
   } on SyncServerPortInUseException {
-    final BuildContext ctx = settingsContext.context;
-    if (!ctx.mounted) return;
-    ScaffoldMessenger.of(ctx).showSnackBar(
-      SnackBar(
-        content: Text(
-          _yomitanApiPortInUseMessage(
-            settingsContext.appModel.yomitanApiPort,
-          ),
-        ),
-      ),
-    );
+    _showYomitanPortConflictSnackBar(settingsContext);
   }
 }

--- a/hibiki/lib/src/sync/port_process_terminator.dart
+++ b/hibiki/lib/src/sync/port_process_terminator.dart
@@ -1,0 +1,125 @@
+import 'dart:io';
+
+/// 监听某端口的进程信息（用于「端口被占用 → 一键结束占用进程」）。
+class PortListenerInfo {
+  const PortListenerInfo({required this.pid, required this.processName});
+
+  final int pid;
+  final String processName;
+}
+
+/// 桌面端「查找并结束占用端口的进程」工具。典型场景：Yomitan API 默认端口 19633
+/// 被浏览器经 native messaging 拉起的 yomitan-api 组件（Python 进程）占着，Hibiki
+/// 起 server 失败；SnackBar 上的「结束进程并重试」按钮走这里直接结束占用者。
+///
+/// 平台命令：Windows 用 `netstat -ano` + `tasklist` + `taskkill`；macOS/Linux 用
+/// `lsof` + `ps` + 信号（SIGTERM → 短暂等待 → SIGKILL 兜底）。解析逻辑抽成顶层
+/// 纯函数，便于单元测试覆盖各平台输出格式。
+class PortProcessTerminator {
+  static bool get isSupported =>
+      Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+
+  /// 找出正在 LISTEN [port] 的进程；找不到（或就是本进程自己）返回 null。
+  static Future<PortListenerInfo?> findListener(int port) async {
+    if (!isSupported) return null;
+    try {
+      final int? listenerPid = Platform.isWindows
+          ? await _findListenerPidWindows(port)
+          : await _findListenerPidPosix(port);
+      // pid 等于自身说明端口已是本进程持有（并发下 server 已起来），不能杀自己。
+      if (listenerPid == null || listenerPid == pid) return null;
+      final String name = await _processName(listenerPid);
+      return PortListenerInfo(pid: listenerPid, processName: name);
+    } on ProcessException {
+      return null;
+    }
+  }
+
+  /// 结束 [listener] 对应进程。返回是否成功发出并确认结束。
+  static Future<bool> terminate(PortListenerInfo listener) async {
+    if (!isSupported || listener.pid == pid) return false;
+    try {
+      if (Platform.isWindows) {
+        final ProcessResult result = await Process.run(
+          'taskkill',
+          <String>['/PID', '${listener.pid}', '/T', '/F'],
+        );
+        return result.exitCode == 0;
+      }
+      // POSIX：先 SIGTERM（yomitan-api 注册了 SIGTERM 清理句柄），给它一点退出
+      // 时间；仍未退出再 SIGKILL 兜底。
+      final bool delivered =
+          Process.killPid(listener.pid, ProcessSignal.sigterm);
+      if (!delivered) return false;
+      await Future<void>.delayed(const Duration(milliseconds: 600));
+      Process.killPid(listener.pid, ProcessSignal.sigkill);
+      return true;
+    } on ProcessException {
+      return false;
+    }
+  }
+
+  static Future<int?> _findListenerPidWindows(int port) async {
+    final ProcessResult result =
+        await Process.run('netstat', <String>['-ano', '-p', 'tcp']);
+    if (result.exitCode != 0) return null;
+    return parseNetstatListenerPid('${result.stdout}', port);
+  }
+
+  static Future<int?> _findListenerPidPosix(int port) async {
+    final ProcessResult result = await Process.run(
+      'lsof',
+      <String>['-nP', '-iTCP:$port', '-sTCP:LISTEN', '-t'],
+    );
+    if (result.exitCode != 0) return null;
+    final String out = '${result.stdout}'.trim();
+    if (out.isEmpty) return null;
+    return int.tryParse(out.split('\n').first.trim());
+  }
+
+  static Future<String> _processName(int targetPid) async {
+    final String fallback = 'PID $targetPid';
+    try {
+      if (Platform.isWindows) {
+        final ProcessResult result = await Process.run(
+          'tasklist',
+          <String>['/FI', 'PID eq $targetPid', '/FO', 'CSV', '/NH'],
+        );
+        if (result.exitCode != 0) return fallback;
+        return parseTasklistProcessName('${result.stdout}') ?? fallback;
+      }
+      final ProcessResult result =
+          await Process.run('ps', <String>['-p', '$targetPid', '-o', 'comm=']);
+      if (result.exitCode != 0) return fallback;
+      final String name = '${result.stdout}'.trim();
+      return name.isEmpty ? fallback : name;
+    } on ProcessException {
+      return fallback;
+    }
+  }
+}
+
+/// 从 `netstat -ano -p tcp` 输出解析 LISTEN [port] 的 PID；无匹配返回 null。
+/// 行格式：`TCP    0.0.0.0:19633    0.0.0.0:0    LISTENING    188544`
+/// （netstat 的 TCP 状态名不随系统语言本地化）。
+int? parseNetstatListenerPid(String output, int port) {
+  for (final String line in output.split('\n')) {
+    final List<String> columns = line.trim().split(RegExp(r'\s+'));
+    if (columns.length < 5) continue;
+    if (!columns[1].endsWith(':$port')) continue;
+    if (!columns[3].toUpperCase().contains('LISTEN')) continue;
+    final int? listenerPid = int.tryParse(columns.last);
+    if (listenerPid != null && listenerPid > 0) return listenerPid;
+  }
+  return null;
+}
+
+/// 从 `tasklist /FO CSV /NH` 输出解析进程映像名（首列，去引号）；解析不出返回 null。
+/// 行格式：`"python.exe","188544","Console","1","25,932 K"`
+String? parseTasklistProcessName(String output) {
+  final String line = output.trim().split('\n').first.trim();
+  if (!line.startsWith('"')) return null;
+  final int end = line.indexOf('"', 1);
+  if (end <= 1) return null;
+  return line.substring(1, end);
+}

--- a/hibiki/test/sync/port_process_terminator_test.dart
+++ b/hibiki/test/sync/port_process_terminator_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/port_process_terminator.dart';
+
+void main() {
+  group('parseNetstatListenerPid', () {
+    const String netstatOutput = '''
+Active Connections
+
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       1234
+  TCP    0.0.0.0:19633          0.0.0.0:0              LISTENING       188544
+  TCP    127.0.0.1:19633        127.0.0.1:52001        ESTABLISHED     188544
+  TCP    127.0.0.1:52001        127.0.0.1:19633        TIME_WAIT       0
+  TCP    [::]:19633             [::]:0                 LISTENING       188544
+''';
+
+    test('resolves LISTENING pid on the target port', () {
+      expect(parseNetstatListenerPid(netstatOutput, 19633), 188544);
+    });
+
+    test('ignores other ports and non-LISTEN states', () {
+      expect(parseNetstatListenerPid(netstatOutput, 52001), isNull);
+      expect(parseNetstatListenerPid(netstatOutput, 135), 1234);
+    });
+
+    test('does not match ports that merely share a suffix', () {
+      // 9633 是 19633 的后缀：`:9633` 不能匹配到 `:19633` 的行。
+      expect(parseNetstatListenerPid(netstatOutput, 9633), isNull);
+    });
+
+    test('returns null on empty or malformed output', () {
+      expect(parseNetstatListenerPid('', 19633), isNull);
+      expect(parseNetstatListenerPid('garbage output', 19633), isNull);
+    });
+  });
+
+  group('parseTasklistProcessName', () {
+    test('extracts image name from CSV row', () {
+      expect(
+        parseTasklistProcessName(
+          '"python.exe","188544","Console","1","25,932 K"\r\n',
+        ),
+        'python.exe',
+      );
+    });
+
+    test('returns null when no matching task (info message)', () {
+      expect(
+        parseTasklistProcessName(
+          'INFO: No tasks are running which match the specified criteria.',
+        ),
+        isNull,
+      );
+      expect(parseTasklistProcessName(''), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## 背景

用户开启 Hibiki「Yomitan API 服务器」时报「端口 19633 正被 Yomitan API 占用」。实际占用者是浏览器经 native messaging 拉起的 yomitan-api 组件（`yomitan_api.py`，Python 进程，监听 0.0.0.0:19633），旧文案只给了「去 Yomitan 高级设置关闭」一条绕路，且该 Python 进程偶发残留（.crowbar 单实例机制的孤儿），关了扩展开关端口也可能不释放。

## 改动

- **文案更正**（`browser_extension_yomitan_port_conflict`，17 语言）：说明占用者通常是浏览器拉起的 yomitan-api 组件（Python 进程），可直接结束该进程，或在 Yomitan 高级设置关闭后重开。
- **SnackBar 新增「结束进程并重试」action**（设置页开关 + API key 改动重启两处收敛到共享 helper）：
  - `PortProcessTerminator`：Windows `netstat -ano` + `tasklist` 定位监听 PID / 映像名，`taskkill /T /F` 结束；macOS/Linux `lsof` + SIGTERM→SIGKILL。拒杀自身 PID。
  - 结束后自动重试启动；端口释放有极短延迟时等 500ms 再试一次；仍失败按原冲突文案报出，结束失败给出进程名+PID 提示手动处理。
- 解析逻辑抽成纯函数（`parseNetstatListenerPid` / `parseTasklistProcessName`）+ 单元测试。

## 验证

- `flutter analyze` 全量无告警。
- `flutter test test/sync/port_process_terminator_test.dart test/settings test/i18n test/models/browser_extension_yomitan_autostart_test.dart --no-pub` 335 全绿。
- 真机路径（Windows，端口被真实 yomitan-api Python 进程占用 → 点按钮 → 进程结束 → server 起来）待真机验证。

https://claude.ai/code/session_01S3eUFLgswFBQhEnHSxM1Qj