### PR TITLE
fix(settings): 顶层大类四块分层排序——外观/内容/横切工具/数据与设备（PR#412 跟进）

### DIFF
--- a/hibiki/lib/src/settings/settings_schema.dart
+++ b/hibiki/lib/src/settings/settings_schema.dart
@@ -14,19 +14,20 @@ import 'package:hibiki/src/sync/sync_settings_schema.dart';
 import 'package:hibiki/utils.dart';
 
 List<SettingsDestination> buildSettingsSchema(SettingsContext context) {
-  // 「外观」置顶（用户拍板，覆盖阶段 G 的纯任务优先排序）：全局界面外观是
-  // 装完 app 第一批要调的东西，压在「下载」后面找不到。其余保持任务优先：
-  // 「阅读 / 查词 / 制卡 / 视频 / 听书 / 下载」内容类在前，
-  // 「Profile / 同步备份 / 互联 / 系统」配置/系统类殿后。
+  // 四块分层排序（用户拍板，取代阶段 G 的纯任务优先排序）——块内相关项相邻：
+  // ① 外观：全局界面，装完 app 第一批要调的，置顶。
+  // ② 内容：阅读 → 听书（同一本书的两面）→ 视频 → 下载（torrent/番剧，喂视频库）。
+  // ③ 横切工具：查词 → 制卡（阅读/视频/galgame/扩展共用一套查词弹窗；制卡依赖查词）。
+  // ④ 数据与设备：Profile（上述设置的快照）→ 同步备份 → 互联；「系统」惯例殿后。
   return <SettingsDestination>[
     buildAppearanceDestination(),
     buildReadingDestination(),
-    buildLookupDestination(),
-    buildCardCreationDestination(),
-    buildVideoDestination(),
     buildListeningDestination(),
+    buildVideoDestination(),
     // 「下载」大类：内联既有 torrent 设置组件（详见 buildDownloadsDestination）。
     buildDownloadsDestination(),
+    buildLookupDestination(),
+    buildCardCreationDestination(),
     buildProfilesDestination(),
     buildSyncBackupDestination(),
     // Hibiki 互联从同步分类拆出的独立一级分类（构建函数在 sync_settings_schema

--- a/hibiki/test/settings/settings_destination_order_guard_test.dart
+++ b/hibiki/test/settings/settings_destination_order_guard_test.dart
@@ -2,17 +2,17 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// 顶层大类顺序守卫：`buildSettingsSchema`「外观」置顶 + 内容类在前、系统类殿后。
+/// 顶层大类顺序守卫：`buildSettingsSchema` 四块分层（外观 → 内容 → 横切工具 →
+/// 数据与设备/系统）。
 ///
-/// 这是「用户决策过的位置」——外观置顶（2026-07-25 用户拍板，覆盖阶段 G 纯任务
-/// 优先排序），其后是最常改的阅读 / 查词 / 制卡 / 视频 / 听书 / 下载，
-/// Profile / 同步备份 / 互联 / 系统殿后。锁死顺序让未来漂移必须是有意为之
-/// （改 `buildSettingsSchema` 时同步改本守卫）。用源码顺序断言（零 harness 依赖：
-/// 无需构造 SettingsContext + AppModel 即可校验 destination 列表次序）。
+/// 这是「用户决策过的位置」（2026-07-26 用户拍板，取代阶段 G 纯任务优先排序）：
+/// 外观置顶；内容块内相关项相邻（阅读→听书、视频→下载）；查词/制卡是跨媒体
+/// 横切工具排内容之后；Profile / 同步备份 / 互联 / 系统殿后。锁死顺序让未来漂移
+/// 必须是有意为之（改 `buildSettingsSchema` 时同步改本守卫）。用源码顺序断言
+/// （零 harness 依赖：无需构造 SettingsContext + AppModel 即可校验列表次序）。
 void main() {
-  test(
-      'buildSettingsSchema keeps the appearance-first top-level destination '
-      'order', () {
+  test('buildSettingsSchema keeps the four-block top-level destination order',
+      () {
     final String src = File('lib/src/settings/settings_schema.dart')
         .readAsStringSync()
         .replaceAll('\r\n', '\n');
@@ -26,11 +26,11 @@ void main() {
     const List<String> expectedOrder = <String>[
       'buildAppearanceDestination()',
       'buildReadingDestination()',
+      'buildListeningDestination()',
+      'buildVideoDestination()',
+      'buildDownloadsDestination()',
       'buildLookupDestination()',
       'buildCardCreationDestination()',
-      'buildVideoDestination()',
-      'buildListeningDestination()',
-      'buildDownloadsDestination()',
       'buildProfilesDestination()',
       'buildSyncBackupDestination()',
       'buildInterconnectDestination()',


### PR DESCRIPTION
## 背景

PR#412 只把「外观」置顶,用户反馈其余层级也要重排,不止外观。

## 排序方案（四块分层,块内相关项相邻）

1. **外观** — 全局界面,置顶（PR#412 已定）
2. **阅读 → 听书** — 有声书和阅读是同一本书的两面,相邻
3. **视频 → 下载** — 下载(torrent/番剧)主要喂视频库,跟在视频后
4. **查词 → 制卡** — 跨媒体横切工具（阅读/视频/galgame/扩展共用查词弹窗,制卡依赖查词）,排内容块之后
5. **Profile → 同步备份 → 互联** — 数据与设备管理块（Profile 是上述设置的快照）
6. **系统** — 惯例殿后

对比 PR#412 后的顺序:听书提前到阅读旁、下载紧跟视频、查词/制卡从第 2/3 位挪到内容块后。

## 改动

- `settings_schema.dart`:重排 destination 列表 + 注释说明分层依据
- `settings_destination_order_guard_test.dart`:顺序守卫同步更新

## 验证

- 全量 `flutter analyze`:No issues found
- `flutter test test/settings/ test/pages/video_settings_schema_guard_test.dart --no-pub`:314 passed

https://claude.ai/code/session_01GJivAbewUf3ekiCP26rD6a