### PR TITLE
fix(lookup): 词头 furigana 并入 em 预留 + 被动剪贴板流不再冲掉用户查出的释义 (BUG-1098/1099)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1059 条。点号进各自文件。
+> 共 1061 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1099](bugs/BUG-1099-passive-clipboard-stream-clobbers-lookup.md) | ✅ | ✅ | 查完词后剪贴板一更新，浮窗释义就被清空「缩回去」 |
+| [BUG-1098](bugs/BUG-1098-popup-headword-furigana-clipped.md) | ✅ | ✅ | 查词弹窗词头的假名（furigana）被垂直压扁 / 裁掉 |
 | [BUG-1092](bugs/BUG-1092-gal-locale-resume-skipped.md) | 🚧 | 🚧 | Locale Emulator 启动的游戏永久停在挂起态：窗口永不出现，injector 却报 OK hooked |
 | [BUG-1091](bugs/BUG-1091-gal-injector-diagnostics-mojibake.md) | ✅ | ✅ | injector 诊断按系统代码页解码：会话事件乱码且中文失败分类永久失配 |
 | [BUG-1090](bugs/BUG-1090-audio-source-url-not-editable.md) | ✅ | ✅ | 管理音频来源弹窗里已有远端 URL 无法编辑，只能删了重加 |

--- a/docs/bugs/BUG-1098-popup-headword-furigana-clipped.md
+++ b/docs/bugs/BUG-1098-popup-headword-furigana-clipped.md
@@ -1,0 +1,21 @@
+## BUG-1098 · 查词弹窗词头的假名（furigana）被垂直压扁 / 裁掉
+- **报告**：2026-07-26（用户：查词弹窗上面那个词的注音被削掉一截，有的词好好的，有的词只剩半行）
+- **真实性**：✅ 真 bug（两条并列根因，缺一不成立；沿 popup.css / popup.js 真实渲染路径验证）
+  1. **词头零垂直预留**：`hibiki/assets/popup/popup.css:241-244` 的 `.expression rt { font-size: 13px }` 是词头注音的**全部**样式——没有 `line-height`、没有 `padding-top`、没有定位，读音直接溢出 `.entry-header` 的行盒。词头 ruby 由 `hibiki/assets/popup/popup.js:575-587` `buildFuriganaEl()` 造成**裸** `<ruby>/<rt>`（不带任何 class），因此也进不了 `popup.js:3114` `postProcessRuby()`——它当年只扫 `.glossary-content ruby`。释义正文早在 BUG-108/363/722/850 就拿到了 zoom 免疫的 em 预留（`popup.css` 的 `.ruby-unit{line-height:1;padding-top:0.55em}` + 绝对定位 `rt{top:0;font-size:0.5em}` + `.ruby-reserve` 横向孪生），而 `docs/bugs/BUG-108.md:4` 明写「headword 仍走自己的 `.expression rt`，不受影响」——词头是当年主动划出范围的。
+  2. **溢出方向不可达**：`hibiki/assets/popup/popup.css:180-196` 的 `.expression-scroll{overflow-x:auto;scrollbar-width:none}`。CSS 规范下一轴非 `visible` 会把另一轴 computed 成 `auto`，该盒于是成为滚动容器；而滚动容器的**顶部**溢出永远够不到（`scrollTop` 不能为负），溢出的注音是被永久 **CLIP**，不是「可以滚过去」。`docs/bugs/BUG-775-ext-expression-scroll-scrollbar.md:10` 当年写的「保留 overflow-y:auto，注音溢出几像素仍可滚不裁切」**是错误结论**，本条已在该文件与 `popup.css` 注释里更正。
+  - **为什么只有部分词被削**：`popup.js:586` `return segments.length === 1 && segments[0][1];` → `popup.js:2420-2426` 只在 `needsScroll` 为真时才套 `.expression-scroll`。单段带注音 = 纯汉字词（気配 / 邂逅 / 逢瀬），正是 galgame 高频查的名词；`食べる` 这类切两段的不套 wrapper，故不裁。
+- **[x] ① 已修复** — 见本分支提交（不引入新机制，把词头并入释义体那套已验证的 per-base 单元）：
+  - `hibiki/assets/popup/popup.js:3114` `postProcessRuby()` 选择器扩到 `'.glossary-content ruby, .expression ruby'`，词头 ruby 也拿到 `.ruby-unit` 包装 + `.ruby-reserve` 横向零高孪生（读音比汉字宽时不再侧向压邻字）。
+  - 同函数加幂等门：已是 `.ruby-unit` 的 base 跳过。`renderPopup` 先 `postProcessRuby(firstEntry)` 再 `postProcessRuby(container)`（container 含 firstEntry），首词条本来会被走两遍、套出双层 `.ruby-unit` 叠两份 `padding-top`——这条既有隐患顺带堵上。
+  - `hibiki/assets/popup/popup.css`：`:where(.glossary-group, .glossary-content)` 的 `ruby` / `.ruby-unit` / `rt` / `.ruby-reserve` 四条作用域各加 `.expression`；`.expression rt` 只留 `-webkit-user-select:none`（词头是 `onLinkClick` 点击目标）。删掉的 `font-size:13px` 等价于 `.expression`（26px）的共享 `0.5em`——像素不变，但从此随 `popupContentZoom` 等比缩放，不再让溢出量随 zoom 线性放大。
+  - `.expression-scroll` 保留 `overflow-x:auto`（长词头仍要能横滚）；注音不再溢出，隐式 `overflow-y` 自然无害。注释已更正 BUG-775 的错误判断。
+  - 三镜像同步：`hibiki/assets/browser_extension/vendor/{popup.css,popup.js}`、`tools/browser-extension/vendor/{popup.css,popup.js}` 复制到位，并重跑 `node tools/browser-extension/scripts/generate-content-css.mjs` 重新生成两份 `content.css`（`--check` 已通过）。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/popup_headword_ruby_reserve_bug1098_test.dart`（8 例全绿）：
+  - 四条共享 ruby 规则的 `:where(...)` 作用域必须同时含 `glossary-group` / `glossary-content` / `.expression`；
+  - 预留必须是 em `padding-top` + `line-height:1`，`rt` 必须 `position:absolute` + `top:0` + em 字号；
+  - `.expression rt` 不得再声明 px 字号（`(0,1,1)` 会盖掉零特异性的 `:where(...) rt`），但必须保留 `user-select:none`；
+  - `postProcessRuby` 选择器含 `.expression ruby`，且对已包好的 base 幂等；
+  - 三镜像 `popup.css` / `popup.js` 字节一致，两份 `content.css` 确实带上 `.expression` 作用域（既有 parity 守卫只收集以 `.` 开头的选择器，`:where(...)` 规则漏在它的网外，这里补齐）。
+  - 既有 `hibiki/test/pages/popup_glossary_ruby_lineheight_guard_test.dart`（释义体）与 `hibiki/test/build/browser_extension_popup_parity_guard_test.dart`（三镜像）同批跑通，无回归。
+- **备注**：ruby 几何在无头环境渲染不出来，守卫的是规则存在与作用域；**词头注音的最终观感仍需真机肉眼复测**（Windows 悬浮查词窗 + 浏览器扩展各一次）。
+  另：`hibiki/windows/runner/global_lookup_window.cpp:1055-1069` 的 composition 路径设了 `put_RasterizationScale(dpi/96)` + `put_ShouldDetectMonitorScaleChanges(FALSE)`，而 windowed 回退路径 `:1126-1183` 两项都没设、全文也没有 `WM_DPICHANGED` 处理——多屏 / 非 100% 缩放下亚像素取整误差会被放大。这是**放大器不是根因**（本次 em 预留后即便有取整误差也只是几分之一像素的位移，不会再裁掉整行），且改动涉及 WebView2 控制器生命周期 + 必须 AMD/多屏真机验证，本轮不动，另开跟进。

--- a/docs/bugs/BUG-1099-passive-clipboard-stream-clobbers-lookup.md
+++ b/docs/bugs/BUG-1099-passive-clipboard-stream-clobbers-lookup.md
@@ -1,0 +1,23 @@
+## BUG-1099 · 查完词后剪贴板一更新，浮窗释义就被清空「缩回去」
+- **报告**：2026-07-26（用户：点词查完，游戏台词一往下走，浮窗里的释义就没了，窗口还缩回去）
+- **真实性**：✅ 真 bug（保护逻辑写好了但是死代码；沿 clipboard → dispatcher → 两个消费面的真实路径验证）
+  - 面板侧的保护本来就在：`hibiki/lib/src/lookup/clipboard_panel_controller.dart:183` `if (request.passiveStream && _userOwnedRoot && _visible)` —— 本意正是「用户点出来的释义不被被动台词流冲掉」。
+  - 但 `passiveStream` 在整个 `hibiki/lib` + `hibiki/test` 里**从未被置为 true**（全仓 `passiveStream: true` 命中数 = 0）。溯源：该字段由 `a3330a4bc` 引入，唯一置 true 的调用点是 `galgame_session_controller.dart:236`；该文件在 `2df13d481`「删除旧死代码 GalgameSessionController」中被整体删除（删除时它确已零调用点），于是保护分支从此永不触发，变成死代码。
+  - 结果：剪贴板监听（`desktop_lookup_service.dart:291 onClipboardChanged` → `:332 _handleClipboardChange` → `:344 processClipboardText` → `:353 submitText` → `:129 _queueLookupRequest` → dispatcher `desktop_lookup_dispatcher.dart:33 _onPending`）灌进来的每条新台词都跌到 `clipboard_panel_controller.dart:191` `_userOwnedRoot = false` → `:217 _seedRootFrame(...)` → `:323-339` `_stack` 被整帧替换成只剩 root、`_frameResults.clear()` / `_frameAnchors.clear()`，用户点出来的释义帧全部蒸发。默认去向就是 panel（`preferences_repository.dart:509-513` 读 `desktop_clipboard_destination` 默认 `''` → `:64` 回退 `DesktopClipboardDestination.panel`）。
+  - transient 去向同病异源：dispatcher 的 transient 分支无条件 `GlobalLookupController.instance.lookupText(...)` → `global_lookup_controller.dart:446 GlobalLookupChannel.hide(notify:false)` → `:539-541` `_lastSentWidth = -1; _lastSentHeight = -1; _revealed = false`（丢弃已测尺寸强制从零重测）→ `:1125` `_stack = GlobalLookupStack([root])`。窗口是 auto-size，新 root 内容小 → 窗口跟着缩小，正是用户说的「缩回去」。
+- **[x] ① 已修复** — 见本分支提交：
+  - **主动 / 被动的判据 = 这次文本进 Hibiki 时，用户有没有对 Hibiki 做过动作**（不是靠时间窗、不是靠内容猜）：
+    - 被动（`passiveStream: true`）：`desktop_lookup_service.dart` 的**环境剪贴板监听**——`processClipboardText`（OS 剪贴板变化事件驱动，galgame 台词 hook / 外部 texthooker 正是经这里每 ~400ms 灌一条）与 `endSelfInflictedCapture` 的回放（同一条环境通道，只是抓选区括号期内先到、事后对账放行）。
+    - 主动（保持 `false`）：全局热键 `_onHotKey`（`origin=hotkey`，`dedupe:false`）、悬浮字幕/歌词点词 `triggerLookup`（`origin=explicit`）、面板句子横幅点字 `_lookupFromBanner`、卡内点词压栈 `_lookupNested`、台词浮窗点词 `gal_hook_text_overlay_controller._onLookupText`。这些一律照常重建，绝不被保护分支锁死。
+  - 判据抽成纯函数 `keepUserOwnedCardForPassiveStream(passiveStream, userOwnedCard, visible)`（`hibiki/lib/src/lookup/desktop_lookup_router.dart`），面板与瞬态窗共用同一真相源，两条出口的抢占语义不会再漂开，也可直接单测两个方向。
+  - 面板：`clipboard_panel_controller.dart:183` 改用该纯函数（行为不变，仍是「只换可点句子横幅、不 `++_updateSeq`、不 `_seedRootFrame`、不 `resetRootScroll`」）。
+  - 瞬态窗：`desktop_lookup_dispatcher.dart` transient 分区把 `passiveStream` 透传；`global_lookup_controller.dart` 新增 `_userOwnedCard`（`lookupText` 非被动流时置位、`_onHotKey` 置位、`_lookupNested` 在 `await` 前置位挡在途竞争、`_onOverlayHidden` 复位），命中判据时 `lookupText` **整条早退**（在 `hide()` + `_lookupExternal` 之前），卡原地不动：不重建 root、不清 `_lastSentWidth/_lastSentHeight`、不动窗口。这里比面板更保守（不刷横幅）——瞬态卡是锚在被点词旁的一次性卡，把横幅换成一句无关的新台词既看不懂，又会把制卡 `{sentence}` 上下文（`_currentSentence`）换成用户根本没在看的那句，做出错卡。
+  - 所有权不会永久粘住：瞬态窗一侧由真正的用户关闭（点外 / 前台钩子 / Esc → `_onOverlayHidden`）复位；面板一侧沿用既有的 `hidePanel()` / 任一非被动请求复位。
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/passive_stream_user_card_bug1099_test.dart`（12 例全绿）：
+  - 纯函数四个方向：被动流+用户卡+可见 → 保住；**显式意图恒替换**（本条最容易做错的方向）；卡不是用户点出来的 → 正常替换；卡已不在屏上 → 正常开新卡。
+  - 服务侧真实排队：`processClipboardText` 与括号期回放排出的请求 `passiveStream=true`；`triggerLookup` 排出的 `passiveStream=false`；热键函数体源码不得出现 `passiveStream`。
+  - 接线守卫：面板 `update` 里判据必须在 `_seedRootFrame` 之前；dispatcher 必须透传；瞬态窗早退必须在 `GlobalLookupChannel.hide(` 之前；`_userOwnedCard` 的置位/复位三处齐全（缺复位会永久吞掉后续所有被动流查词）。
+- **备注**：
+  - 已知取舍：用户**自己**在别的 app 里 Ctrl+C（同样走剪贴板监听，OS 层与台词流不可区分）且面板上正挂着自己点出来的释义时，面板只刷新句子横幅、不再自动整句重查——需要点新横幅里的词，或按全局热键强制重查。选择这个方向是因为两边的代价极不对称：台词流下不保护 = 释义每 ~400ms 蒸发一次、完全没法读；主动复制下保护 = 少一次「自动查句首词」的便利、一次点击即可恢复。真要区分只能引入时间窗（台词间隔与「切窗口再复制」的耗时严重重叠，不可靠），故不做。
+  - `hibiki/windows/runner/floating_lyric_window.cpp:329-341 UpdateText()` 已复核：新台词只重置 `text_layout_` 重绘、不碰窗口 rect，本条不需要动 C++。
+  - 本条为桌面（Windows）路径，**仍需真机复测**：galgame 台词流下点词→释义保留→关卡后下一条台词正常开卡；以及热键/悬浮字幕点词照常替换。

--- a/docs/bugs/BUG-775-ext-expression-scroll-scrollbar.md
+++ b/docs/bugs/BUG-775-ext-expression-scroll-scrollbar.md
@@ -7,4 +7,5 @@
   - 复现证据：无头 Chrome harness（shadow DOM + 真 content.css + entry-header/expression-scroll/ruby 同构 DOM，`max-height` 模拟真实字体度量下的几像素溢出）→ 按钮左侧出现与用户截图一致的 ▲●▼；计算样式 `scrollbarColor=rgb(...) rgba(0,0,0,0)`（继承已生效）、`overflowY=auto`。
 - **[x] ① 已修复** — `popup.css` `.expression-scroll` 增加标准属性 `scrollbar-width: none`（Chromium 121+/Firefox 通用，且不受继承的 scrollbar-color 干扰；滚轮/拖动滚动能力不变，与原 `::-webkit-scrollbar{display:none}` 意图一致）；三镜像同步 + `generate-content-css.mjs` 重新生成两份 content.css。修复后 harness 复测：同样强制溢出下滚动条消失（`offsetWidth==clientWidth`）。提交：见本分支（与 BUG-752 同 PR#56）。
 - **[x] ② 已加自动化测试** — `hibiki/test/build/browser_extension_popup_parity_guard_test.dart` 新增通用守卫：扫描 popup.css 里所有 `X::-webkit-scrollbar{display:none}` 隐藏点，断言每个 X 必须同时带 `scrollbar-width: none`，否则报 BUG-775 说明。
-- **备注**：词头竖向可滚（overflow-y 派生 auto）本身保留——与 app 内行为一致，注音溢出几像素时仍可滚不裁切；本修只消灭「可见的多余滚动条」。用户已装副本已热更（content.css + popup.css 镜像），需 `chrome://extensions` 重载扩展生效。
+- **备注**：词头竖向可滚（overflow-y 派生 auto）本身保留；本修只消灭「可见的多余滚动条」。
+  ⚠️ **本条当年写的「注音溢出几像素时仍可滚不裁切」是错误结论，已由 BUG-1098 更正**：滚动容器的**顶部**溢出永远够不到（`scrollTop` 不能为负），溢出到行盒上方的 `<rt>` 是被永久 CLIP，不是「可以滚过去」。这句错误判断正是 BUG-1098「词头假名被压扁/裁掉」拖了这么久没被发现的直接来源。BUG-1098 已把词头 ruby 并入释义体那套 em `padding-top` 预留（`.ruby-unit` + 绝对定位 `rt`），词头不再溢出，本条保留的 `overflow-y` 从此真正无害。用户已装副本已热更（content.css + popup.css 镜像），需 `chrome://extensions` 重载扩展生效。

--- a/hibiki/assets/browser_extension/vendor/content.css
+++ b/hibiki/assets/browser_extension/vendor/content.css
@@ -80,6 +80,12 @@
     text-align: left;
 }
 
+
+
+
+
+
+
 :where(#entries-container) {
     overflow-x: hidden;
     padding: 0 10px 10px;
@@ -168,7 +174,15 @@
        overflow-y `auto`, so the extension popup (real Chrome, classic
        scrollbars) showed a tiny arrows+thumb vertical scrollbar squeezed
        against the header buttons. In-app WebView2 hid it only by luck (Fluent
-       overlay scrollbars are invisible at rest). */
+       overlay scrollbars are invisible at rest).
+       BUG-1098 correction: BUG-775 concluded "overflow-y:auto is harmless, the
+       few px of furigana spill can still be scrolled to". That was WRONG - a
+       scroll container's TOP overflow is unreachable (scrollTop can never go
+       negative), so the spilling <rt> was permanently CLIPPED, not scrollable.
+       The real fix is that the headword ruby no longer overflows at all: it now
+       carries the same intrinsic em padding-top reserve as glossary ruby (see
+       the :where(..., .expression) block below), so the implicit overflow-y is
+       genuinely inert. */
     scrollbar-width: none;
 }
 
@@ -215,8 +229,17 @@
     white-space: nowrap;
 }
 
+/* BUG-1098: the headword <rt> geometry (size / absolute anchor / reserve) comes
+   from the SHARED :where(..., .expression) ruby block below - the same intrinsic
+   em reserve glossary furigana has used since BUG-108/363/722/850. The only
+   headword-specific bit left is user-select: the headword is a click target
+   (onLinkClick), so its reading must never be selected by a drag.
+   The old `font-size: 13px` is gone on purpose: 13px == 0.5em of .expression's
+   26px, so the rendered size is unchanged, but a `.expression rt` (0,1,1)
+   declaration used to OUT-RANK the zero-specificity `:where(...) rt` rule and
+   would have pinned the reading to an absolute px size that no longer tracks the
+   popup content zoom. */
 .expression rt {
-    font-size: 13px;
     -webkit-user-select: none;
 }
 
@@ -321,6 +344,9 @@
 .mine-button:disabled {
     opacity: 0.15;
 }
+
+
+
 
 /* TODO-1338: 制卡后图标乱码根因修。制卡按钮的 +/✓/✓↩ 是「文本字形标记」(应用户要求保留
    文本，不走 SVG，见 popup.js setMineState)。默认它会继承 Dart 注入到 html,body 的用户
@@ -815,8 +841,26 @@
     padding: 0 8px;
 }
 
-/* Furigana inside dictionary glossary bodies. Three layout invariants live in
-   this rule group and must stay together. The anchor of all three is the
+/* Furigana inside dictionary glossary bodies AND on the entry headword
+   (.expression). Three layout invariants live in this rule group and must stay
+   together.
+   BUG-1098 — the headword was NOT in this group until now and had zero vertical
+   reserve of its own (`.expression rt { font-size: 13px }` and nothing else),
+   because BUG-108 deliberately scoped its fix to glossary bodies. Its <rt> is
+   built by popup.js buildFuriganaEl as a BARE <ruby>/<rt>, so it also never
+   reached postProcessRuby (which only scanned `.glossary-content ruby`). The
+   reading therefore overflowed the header line box, and .expression-scroll
+   (overflow-x:auto -> computed overflow-y:auto) turned that box into a scroll
+   container whose TOP overflow is unreachable, so the reading was clipped /
+   squashed. Only single-segment readings hit it, because buildFuriganaEl only
+   asks for the .expression-scroll wrapper when the whole word is one segment
+   (pure-kanji nouns: 気配 / 邂逅 / 逢瀬), which is exactly the galgame vocabulary.
+   Fix = no new mechanism: postProcessRuby now also processes `.expression ruby`
+   and these rules cover `.expression`, so the headword gets the identical
+   per-base unit + em reserve + horizontal twin. `.expression` is 26px, so the
+   old hard-coded 13px reading is exactly the shared `font-size: 0.5em` — same
+   pixels today, and now it also tracks the popup content zoom instead of
+   growing the overflow linearly with it. The anchor of all three is the
    per-base UNIT box (.ruby-unit), NOT the <ruby> element — popup.js's
    postProcessRuby wraps each base text node in a <span class="ruby-unit"> and
    moves that base's own <rt> INTO the span, so every rt sizes and positions
@@ -855,14 +899,14 @@
    The <ruby> itself stays inline-block+relative only as a fallback anchor: if
    postProcessRuby ever failed to wrap (never in practice), a bare <rt> would
    still pin to the <ruby> instead of escaping to the viewport. */
-:where(.glossary-group, .glossary-content) ruby {
+:where(.glossary-group, .glossary-content, .expression) ruby {
     display: inline-block;
     position: relative;
     line-height: 1;
     vertical-align: baseline;
 }
 
-:where(.glossary-group, .glossary-content) .ruby-unit {
+:where(.glossary-group, .glossary-content, .expression) .ruby-unit {
     display: inline-block;
     position: relative;
     line-height: 1;
@@ -873,7 +917,7 @@
     text-align: center;
 }
 
-:where(.glossary-group, .glossary-content) rt {
+:where(.glossary-group, .glossary-content, .expression) rt {
     font-size: 0.5em;
     position: absolute;
     left: 0;
@@ -897,7 +941,7 @@
    stays zoom-immune. Units whose reading fits its kanji keep the old compaction.
    The twin is aria-hidden + user-select:none so it never affects ruby lookup
    selection (BUG-110/123/125/129). */
-:where(.glossary-group, .glossary-content) .ruby-reserve {
+:where(.glossary-group, .glossary-content, .expression) .ruby-reserve {
     display: block;
     width: -webkit-max-content;
     width: max-content;
@@ -1325,6 +1369,12 @@
     opacity: 0.6;
     -webkit-user-select: none;
 }
+
+
+
+
+
+
 
 /* 用户「词典方框怎么能左右动，Niratan 不会」根因修：app 外全局查词 / 浏览器扩展原本
    在 .global-lookup 下把 .category-body 从 grid 覆盖成 flex-wrap（flex:1 1 auto;

--- a/hibiki/assets/browser_extension/vendor/popup.css
+++ b/hibiki/assets/browser_extension/vendor/popup.css
@@ -191,7 +191,15 @@ html {
        overflow-y `auto`, so the extension popup (real Chrome, classic
        scrollbars) showed a tiny arrows+thumb vertical scrollbar squeezed
        against the header buttons. In-app WebView2 hid it only by luck (Fluent
-       overlay scrollbars are invisible at rest). */
+       overlay scrollbars are invisible at rest).
+       BUG-1098 correction: BUG-775 concluded "overflow-y:auto is harmless, the
+       few px of furigana spill can still be scrolled to". That was WRONG - a
+       scroll container's TOP overflow is unreachable (scrollTop can never go
+       negative), so the spilling <rt> was permanently CLIPPED, not scrollable.
+       The real fix is that the headword ruby no longer overflows at all: it now
+       carries the same intrinsic em padding-top reserve as glossary ruby (see
+       the :where(..., .expression) block below), so the implicit overflow-y is
+       genuinely inert. */
     scrollbar-width: none;
 }
 
@@ -238,8 +246,17 @@ html {
     white-space: nowrap;
 }
 
+/* BUG-1098: the headword <rt> geometry (size / absolute anchor / reserve) comes
+   from the SHARED :where(..., .expression) ruby block below - the same intrinsic
+   em reserve glossary furigana has used since BUG-108/363/722/850. The only
+   headword-specific bit left is user-select: the headword is a click target
+   (onLinkClick), so its reading must never be selected by a drag.
+   The old `font-size: 13px` is gone on purpose: 13px == 0.5em of .expression's
+   26px, so the rendered size is unchanged, but a `.expression rt` (0,1,1)
+   declaration used to OUT-RANK the zero-specificity `:where(...) rt` rule and
+   would have pinned the reading to an absolute px size that no longer tracks the
+   popup content zoom. */
 .expression rt {
-    font-size: 13px;
     -webkit-user-select: none;
 }
 
@@ -852,8 +869,26 @@ html[data-theme="dark"] .glossary-group {
     padding: 0 8px;
 }
 
-/* Furigana inside dictionary glossary bodies. Three layout invariants live in
-   this rule group and must stay together. The anchor of all three is the
+/* Furigana inside dictionary glossary bodies AND on the entry headword
+   (.expression). Three layout invariants live in this rule group and must stay
+   together.
+   BUG-1098 — the headword was NOT in this group until now and had zero vertical
+   reserve of its own (`.expression rt { font-size: 13px }` and nothing else),
+   because BUG-108 deliberately scoped its fix to glossary bodies. Its <rt> is
+   built by popup.js buildFuriganaEl as a BARE <ruby>/<rt>, so it also never
+   reached postProcessRuby (which only scanned `.glossary-content ruby`). The
+   reading therefore overflowed the header line box, and .expression-scroll
+   (overflow-x:auto -> computed overflow-y:auto) turned that box into a scroll
+   container whose TOP overflow is unreachable, so the reading was clipped /
+   squashed. Only single-segment readings hit it, because buildFuriganaEl only
+   asks for the .expression-scroll wrapper when the whole word is one segment
+   (pure-kanji nouns: 気配 / 邂逅 / 逢瀬), which is exactly the galgame vocabulary.
+   Fix = no new mechanism: postProcessRuby now also processes `.expression ruby`
+   and these rules cover `.expression`, so the headword gets the identical
+   per-base unit + em reserve + horizontal twin. `.expression` is 26px, so the
+   old hard-coded 13px reading is exactly the shared `font-size: 0.5em` — same
+   pixels today, and now it also tracks the popup content zoom instead of
+   growing the overflow linearly with it. The anchor of all three is the
    per-base UNIT box (.ruby-unit), NOT the <ruby> element — popup.js's
    postProcessRuby wraps each base text node in a <span class="ruby-unit"> and
    moves that base's own <rt> INTO the span, so every rt sizes and positions
@@ -892,14 +927,14 @@ html[data-theme="dark"] .glossary-group {
    The <ruby> itself stays inline-block+relative only as a fallback anchor: if
    postProcessRuby ever failed to wrap (never in practice), a bare <rt> would
    still pin to the <ruby> instead of escaping to the viewport. */
-:where(.glossary-group, .glossary-content) ruby {
+:where(.glossary-group, .glossary-content, .expression) ruby {
     display: inline-block;
     position: relative;
     line-height: 1;
     vertical-align: baseline;
 }
 
-:where(.glossary-group, .glossary-content) .ruby-unit {
+:where(.glossary-group, .glossary-content, .expression) .ruby-unit {
     display: inline-block;
     position: relative;
     line-height: 1;
@@ -910,7 +945,7 @@ html[data-theme="dark"] .glossary-group {
     text-align: center;
 }
 
-:where(.glossary-group, .glossary-content) rt {
+:where(.glossary-group, .glossary-content, .expression) rt {
     font-size: 0.5em;
     position: absolute;
     left: 0;
@@ -934,7 +969,7 @@ html[data-theme="dark"] .glossary-group {
    stays zoom-immune. Units whose reading fits its kanji keep the old compaction.
    The twin is aria-hidden + user-select:none so it never affects ruby lookup
    selection (BUG-110/123/125/129). */
-:where(.glossary-group, .glossary-content) .ruby-reserve {
+:where(.glossary-group, .glossary-content, .expression) .ruby-reserve {
     display: block;
     width: -webkit-max-content;
     width: max-content;

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -3112,7 +3112,14 @@ function buildEntryElement(entry, idx) {
 }
 
 function postProcessRuby(container) {
-    container.querySelectorAll('.glossary-content ruby').forEach(ruby => {
+    // BUG-1098: `.expression ruby` (the entry HEADWORD's furigana, built as a
+    // bare <ruby>/<rt> by buildFuriganaEl) joins the glossary bodies here. It
+    // used to be skipped entirely, so it never got the per-base unit and never
+    // got popup.css's em padding-top reserve; the reading then overflowed the
+    // header line box and .expression-scroll (a scroll container whose TOP
+    // overflow is unreachable) clipped it. Same wrap, same reserve, no new
+    // mechanism.
+    container.querySelectorAll('.glossary-content ruby, .expression ruby').forEach(ruby => {
         // Wrap each base — a bare text node OR an element base like <rb>/<span>
         // (monolingual dicts such as 明鏡 emit element bases, not bare text) — in
         // a <span class="ruby-unit"> and pull that base's OWN <rt> into the span.
@@ -3140,6 +3147,17 @@ function postProcessRuby(container) {
             // A base is anything that is not a reading (<rt>), a fallback paren
             // (<rp>), or inter-token whitespace.
             if (isEl(node, 'RT') || isEl(node, 'RP') || isBlankText(node)) {
+                continue;
+            }
+            // BUG-1098: idempotence. renderPopup calls postProcessRuby(firstEntry)
+            // and then postProcessRuby(container) for the tail entries, and the
+            // container CONTAINS the first entry — so entry 0's ruby is walked
+            // twice. Without this guard the second pass wraps the existing
+            // .ruby-unit in ANOTHER .ruby-unit, stacking a second padding-top and
+            // pushing entry 0's base text down relative to every other entry.
+            // An already-wrapped base is done; leave it alone.
+            if (node.nodeType === Node.ELEMENT_NODE &&
+                node.classList.contains('ruby-unit')) {
                 continue;
             }
             const unit = document.createElement('span');

--- a/hibiki/assets/popup/popup.css
+++ b/hibiki/assets/popup/popup.css
@@ -191,7 +191,15 @@ html {
        overflow-y `auto`, so the extension popup (real Chrome, classic
        scrollbars) showed a tiny arrows+thumb vertical scrollbar squeezed
        against the header buttons. In-app WebView2 hid it only by luck (Fluent
-       overlay scrollbars are invisible at rest). */
+       overlay scrollbars are invisible at rest).
+       BUG-1098 correction: BUG-775 concluded "overflow-y:auto is harmless, the
+       few px of furigana spill can still be scrolled to". That was WRONG - a
+       scroll container's TOP overflow is unreachable (scrollTop can never go
+       negative), so the spilling <rt> was permanently CLIPPED, not scrollable.
+       The real fix is that the headword ruby no longer overflows at all: it now
+       carries the same intrinsic em padding-top reserve as glossary ruby (see
+       the :where(..., .expression) block below), so the implicit overflow-y is
+       genuinely inert. */
     scrollbar-width: none;
 }
 
@@ -238,8 +246,17 @@ html {
     white-space: nowrap;
 }
 
+/* BUG-1098: the headword <rt> geometry (size / absolute anchor / reserve) comes
+   from the SHARED :where(..., .expression) ruby block below - the same intrinsic
+   em reserve glossary furigana has used since BUG-108/363/722/850. The only
+   headword-specific bit left is user-select: the headword is a click target
+   (onLinkClick), so its reading must never be selected by a drag.
+   The old `font-size: 13px` is gone on purpose: 13px == 0.5em of .expression's
+   26px, so the rendered size is unchanged, but a `.expression rt` (0,1,1)
+   declaration used to OUT-RANK the zero-specificity `:where(...) rt` rule and
+   would have pinned the reading to an absolute px size that no longer tracks the
+   popup content zoom. */
 .expression rt {
-    font-size: 13px;
     -webkit-user-select: none;
 }
 
@@ -852,8 +869,26 @@ html[data-theme="dark"] .glossary-group {
     padding: 0 8px;
 }
 
-/* Furigana inside dictionary glossary bodies. Three layout invariants live in
-   this rule group and must stay together. The anchor of all three is the
+/* Furigana inside dictionary glossary bodies AND on the entry headword
+   (.expression). Three layout invariants live in this rule group and must stay
+   together.
+   BUG-1098 — the headword was NOT in this group until now and had zero vertical
+   reserve of its own (`.expression rt { font-size: 13px }` and nothing else),
+   because BUG-108 deliberately scoped its fix to glossary bodies. Its <rt> is
+   built by popup.js buildFuriganaEl as a BARE <ruby>/<rt>, so it also never
+   reached postProcessRuby (which only scanned `.glossary-content ruby`). The
+   reading therefore overflowed the header line box, and .expression-scroll
+   (overflow-x:auto -> computed overflow-y:auto) turned that box into a scroll
+   container whose TOP overflow is unreachable, so the reading was clipped /
+   squashed. Only single-segment readings hit it, because buildFuriganaEl only
+   asks for the .expression-scroll wrapper when the whole word is one segment
+   (pure-kanji nouns: 気配 / 邂逅 / 逢瀬), which is exactly the galgame vocabulary.
+   Fix = no new mechanism: postProcessRuby now also processes `.expression ruby`
+   and these rules cover `.expression`, so the headword gets the identical
+   per-base unit + em reserve + horizontal twin. `.expression` is 26px, so the
+   old hard-coded 13px reading is exactly the shared `font-size: 0.5em` — same
+   pixels today, and now it also tracks the popup content zoom instead of
+   growing the overflow linearly with it. The anchor of all three is the
    per-base UNIT box (.ruby-unit), NOT the <ruby> element — popup.js's
    postProcessRuby wraps each base text node in a <span class="ruby-unit"> and
    moves that base's own <rt> INTO the span, so every rt sizes and positions
@@ -892,14 +927,14 @@ html[data-theme="dark"] .glossary-group {
    The <ruby> itself stays inline-block+relative only as a fallback anchor: if
    postProcessRuby ever failed to wrap (never in practice), a bare <rt> would
    still pin to the <ruby> instead of escaping to the viewport. */
-:where(.glossary-group, .glossary-content) ruby {
+:where(.glossary-group, .glossary-content, .expression) ruby {
     display: inline-block;
     position: relative;
     line-height: 1;
     vertical-align: baseline;
 }
 
-:where(.glossary-group, .glossary-content) .ruby-unit {
+:where(.glossary-group, .glossary-content, .expression) .ruby-unit {
     display: inline-block;
     position: relative;
     line-height: 1;
@@ -910,7 +945,7 @@ html[data-theme="dark"] .glossary-group {
     text-align: center;
 }
 
-:where(.glossary-group, .glossary-content) rt {
+:where(.glossary-group, .glossary-content, .expression) rt {
     font-size: 0.5em;
     position: absolute;
     left: 0;
@@ -934,7 +969,7 @@ html[data-theme="dark"] .glossary-group {
    stays zoom-immune. Units whose reading fits its kanji keep the old compaction.
    The twin is aria-hidden + user-select:none so it never affects ruby lookup
    selection (BUG-110/123/125/129). */
-:where(.glossary-group, .glossary-content) .ruby-reserve {
+:where(.glossary-group, .glossary-content, .expression) .ruby-reserve {
     display: block;
     width: -webkit-max-content;
     width: max-content;

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -3112,7 +3112,14 @@ function buildEntryElement(entry, idx) {
 }
 
 function postProcessRuby(container) {
-    container.querySelectorAll('.glossary-content ruby').forEach(ruby => {
+    // BUG-1098: `.expression ruby` (the entry HEADWORD's furigana, built as a
+    // bare <ruby>/<rt> by buildFuriganaEl) joins the glossary bodies here. It
+    // used to be skipped entirely, so it never got the per-base unit and never
+    // got popup.css's em padding-top reserve; the reading then overflowed the
+    // header line box and .expression-scroll (a scroll container whose TOP
+    // overflow is unreachable) clipped it. Same wrap, same reserve, no new
+    // mechanism.
+    container.querySelectorAll('.glossary-content ruby, .expression ruby').forEach(ruby => {
         // Wrap each base — a bare text node OR an element base like <rb>/<span>
         // (monolingual dicts such as 明鏡 emit element bases, not bare text) — in
         // a <span class="ruby-unit"> and pull that base's OWN <rt> into the span.
@@ -3140,6 +3147,17 @@ function postProcessRuby(container) {
             // A base is anything that is not a reading (<rt>), a fallback paren
             // (<rp>), or inter-token whitespace.
             if (isEl(node, 'RT') || isEl(node, 'RP') || isBlankText(node)) {
+                continue;
+            }
+            // BUG-1098: idempotence. renderPopup calls postProcessRuby(firstEntry)
+            // and then postProcessRuby(container) for the tail entries, and the
+            // container CONTAINS the first entry — so entry 0's ruby is walked
+            // twice. Without this guard the second pass wraps the existing
+            // .ruby-unit in ANOTHER .ruby-unit, stacking a second padding-top and
+            // pushing entry 0's base text down relative to every other entry.
+            // An already-wrapped base is done; leave it alone.
+            if (node.nodeType === Node.ELEMENT_NODE &&
+                node.classList.contains('ruby-unit')) {
                 continue;
             }
             const unit = document.createElement('span');

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -21,6 +21,7 @@ import 'package:hibiki/src/lookup/global_lookup_controller.dart'
         GlobalLookupMediaRequest,
         resolveGlobalLookupMedia;
 import 'package:hibiki/src/lookup/clipboard_history_payload.dart';
+import 'package:hibiki/src/lookup/desktop_lookup_router.dart';
 import 'package:hibiki/src/lookup/global_lookup_log.dart';
 import 'package:hibiki/src/lookup/global_lookup_render.dart';
 import 'package:hibiki/src/lookup/global_lookup_stack.dart';
@@ -114,7 +115,8 @@ class ClipboardPanelController {
   int _updateSeq = 0;
 
   /// 当前 root 帧是否为**用户显式点词**的结果（`_lookupFromBanner`），而非被动来源自动查词。
-  /// 为 true 时，被动连续文本流（galgame 台词，`request.passiveStream`）不再抢占/重置 root：
+  /// 为 true 时，被动连续文本流（剪贴板监听灌进来的 galgame 台词，
+  /// `request.passiveStream`）不再抢占/重置 root：
   /// 只把可点句子横幅换成最新台词，保留用户点出的释义（否则每 ~400ms 一条新台词会 `++_updateSeq`
   /// 作废点词的在途 searchDictionary + `_seedRootFrame` 整帧重置冲掉释义，表现为「对话流动时
   /// 点词没反应」）。用户显式动作（点新横幅词 / 真剪贴板复制 / 关面板）重置它。
@@ -180,7 +182,13 @@ class ClipboardPanelController {
     // 换 _currentSentence（新台词逐字可点）+ 原地重渲（不 _seedRootFrame、不 resetRootScroll、
     // 不 ++_updateSeq），点词的在途查词与已出释义都不被冲掉。用户点新横幅词即正常换根。
     // 仅对被动流（galgame 台词）生效；真剪贴板复制是显式意图，走下方正常重查。
-    if (request.passiveStream && _userOwnedRoot && _visible) {
+    // BUG-1099：判据抽成纯函数（`keepUserOwnedCardForPassiveStream`），与瞬态覆盖窗
+    // 共用同一真相源并可直接单测两个方向（被动流不清帧 / 显式意图仍替换）。
+    if (keepUserOwnedCardForPassiveStream(
+      passiveStream: request.passiveStream,
+      userOwnedCard: _userOwnedRoot,
+      visible: _visible,
+    )) {
       _currentSentence = request.text;
       _rootHitStart = 0; // 新句与旧词根无对应，撤销高亮基准避免错位高亮
       await _renderPanel(model);

--- a/hibiki/lib/src/lookup/desktop_lookup_dispatcher.dart
+++ b/hibiki/lib/src/lookup/desktop_lookup_dispatcher.dart
@@ -56,8 +56,13 @@ class DesktopLookupDispatcher {
         DesktopLookupService.instance.clearPending();
         // 整句作 root 卡句子横幅 + 制卡 sentence 字段；查词词条由引擎按
         // 前缀/去屈折从句首匹配（与主窗 tab 的整句自动查同语义）。
-        unawaited(GlobalLookupController.instance
-            .lookupText(request.text, sentence: request.text));
+        // BUG-1099：被动剪贴板流（galgame 台词 / 外部 texthooker）标记透传，
+        // 用户点词开出的卡还在屏上时不被整帧重建（不清尺寸、不缩窗）。
+        unawaited(GlobalLookupController.instance.lookupText(
+          request.text,
+          sentence: request.text,
+          passiveStream: request.passiveStream,
+        ));
       case DesktopLookupConsumer.textWindow:
         DesktopLookupService.instance.clearPending();
         // 逐像素透明文字窗原地显示整句：不自动查词，用户点某个字才经 native

--- a/hibiki/lib/src/lookup/desktop_lookup_router.dart
+++ b/hibiki/lib/src/lookup/desktop_lookup_router.dart
@@ -36,3 +36,24 @@ DesktopLookupConsumer resolveDesktopLookupConsumer({
       return DesktopLookupConsumer.textWindow;
   }
 }
+
+/// BUG-1099 纯判据：一条**被动文本流**请求到达时，是否保留用户已点出的那张卡
+/// （只换句子横幅 / 直接忽略），而不是整帧重建 root。
+///
+/// 单一真相源，面板（[ClipboardPanelController.update]）与瞬态覆盖窗
+/// （[GlobalLookupController.lookupText]）共用，两条出口的抢占语义不会漂开。
+///
+/// 三个条件缺一不可：
+/// - [passiveStream]：请求来自**环境剪贴板监听**（用户没有对 Hibiki 做任何动作，
+///   见 [DesktopLookupService.processClipboardText]），而不是热键 / 悬浮字幕点词
+///   这类显式意图。显式意图恒重建，绝不被这条保护锁死。
+/// - [userOwnedCard]：当前这张卡是用户**自己点出来的**（面板横幅点字 /
+///   卡内点词压栈 / 台词浮窗点词），而不是上一条被动流自动查出来的。自动查出来的
+///   卡本来就该被下一条流替换。
+/// - [visible]：卡还在屏幕上。已藏起来的卡没有什么可保护，下一条流正常重开。
+bool keepUserOwnedCardForPassiveStream({
+  required bool passiveStream,
+  required bool userOwnedCard,
+  required bool visible,
+}) =>
+    passiveStream && userOwnedCard && visible;

--- a/hibiki/lib/src/lookup/global_lookup_controller.dart
+++ b/hibiki/lib/src/lookup/global_lookup_controller.dart
@@ -18,6 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' hide ModifierKey;
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/lookup/clipboard_history_payload.dart';
+import 'package:hibiki/src/lookup/desktop_lookup_router.dart';
 import 'package:hibiki/src/lookup/effective_lookup_size.dart';
 import 'package:hibiki/src/lookup/global_lookup_channel.dart';
 import 'package:hibiki/src/lookup/global_lookup_layout.dart';
@@ -109,6 +110,15 @@ class GlobalLookupController {
   // revealed once at its final size (no on-screen jitter). False = still
   // off-screen / awaiting reveal. Reset per lookup.
   bool _revealed = false;
+  // BUG-1099 — 当前这张瞬态卡是否为**用户显式动作**的产物：台词浮窗/面板释义/悬浮
+  // 字幕点词开出的卡（[lookupText] 且非被动流），或用户在卡内点词压出的子卡
+  // （[_lookupNested]）。为 true 且卡还在屏上时，被动剪贴板流不再重建 root——
+  // 否则 [_lookupExternal] 会把 _lastSentWidth/_lastSentHeight 打回 -1、_revealed 清
+  // false 并 `_stack = [新 root]`，auto-size 窗口跟着新 root 的小内容缩下去，正是用户
+  // 报的「查完词后剪贴板一更新，释义被清空缩回去」。
+  // 不会永久粘住：真正的用户关闭（点外/前台钩子/Esc）走 [_onOverlayHidden] 复位，
+  // 任何显式意图（热键/点词）也会重新置位。
+  bool _userOwnedCard = false;
   Timer? _revealSafety;
   // TODO-1079 (B) — ready-driven reveal safety cadence. Each tick re-checks
   // isWebViewReady before revealing; a not-yet-ready surface reschedules up to
@@ -398,6 +408,10 @@ class GlobalLookupController {
         glog('hotkey: empty selection — abort');
         return;
       }
+      // BUG-1099：全局热键是用户最显式的意图，这张卡归用户所有——之后到达的被动
+      // 剪贴板流不得把它整帧重建掉。热键直接走 _lookupExternal（不经 lookupText），
+      // 故所有权在这里置位。
+      _userOwnedCard = true;
       // 用户 2026-07-12 — 手动快捷键查词不显示整句横幅（框）：整句仍传下去供
       // 制卡 `{sentence}` 兜底（sentenceContext），但 showSentenceBanner:false
       // 让 root 卡不贴横幅。只有剪切板自动唤出的瞬态窗（dispatcher）才带横幅。
@@ -419,18 +433,37 @@ class GlobalLookupController {
   /// falls back to its existing in-app route — a tap is never silently lost.
   /// 真机第 5 轮 — [anchorScreenRect]（屏幕逻辑 px）：给出时卡片锚定在该矩形
   /// 下方（剪贴板面板释义点击=被点文字处），null 保持 OS 光标语义。
+  /// BUG-1099 — [passiveStream]：本次文本来自环境剪贴板监听（galgame 台词流 /
+  /// 外部 texthooker），不是用户对 Hibiki 的显式动作。用户自己点出来的卡还在屏上时，
+  /// 被动流**整条丢弃**（不重建 root、不清空已测尺寸、不动窗口），卡原地不动直到用户
+  /// 自己关掉它；关掉后（[_onOverlayHidden]）下一条被动流照常开新卡。
+  ///
+  /// 这里比面板更保守（面板会把新句刷进横幅）：瞬态卡是锚在被点词旁的一次性卡片，
+  /// 把横幅换成一句无关的新台词既看不懂，又会把制卡 `{sentence}` 上下文
+  /// （[_currentSentence]）换成用户根本没在看的那句，做出错卡。
   Future<bool> lookupText(
     String text, {
     String sentence = '',
     Rect? anchorScreenRect,
     bool showSentenceBanner = true,
+    bool passiveStream = false,
     OverlayMiningHandler? miningHandler,
   }) async {
     final String term = text.trim();
     if (!isSupported || !_started || _appModel == null || term.isEmpty) {
       return false;
     }
-    glog('lookupText: "$term"');
+    if (keepUserOwnedCardForPassiveStream(
+      passiveStream: passiveStream,
+      userOwnedCard: _userOwnedCard,
+      visible: _revealed,
+    )) {
+      glog('lookupText: passive stream dropped (user-owned card kept)');
+      return true;
+    }
+    // 显式意图开的卡归用户所有；被动流开的卡不归（下一条流可以正常替换它）。
+    _userOwnedCard = !passiveStream;
+    glog('lookupText: "$term" passive=$passiveStream');
     // TODO-1268 / BUG — mirror _onHotKey's TODO-1079(D) preamble on the
     // programmatic (desktop floating-lyric tap) path: AWAIT a leading
     // hide(notify:false) so the overlay collapses to a confirmed-hidden state
@@ -742,6 +775,9 @@ class GlobalLookupController {
   void _onOverlayHidden() {
     _revealSafety?.cancel();
     _revealed = false;
+    // BUG-1099：用户真把卡关了 = 放弃这次查词，所有权随之释放，下一条被动剪贴板
+    // 流照常开新卡（保护不会永久粘住）。
+    _userOwnedCard = false;
     _lastSentWidth = -1;
     _lastSentHeight = -1;
     _lastSentDx = 0;
@@ -1062,6 +1098,9 @@ class GlobalLookupController {
       // child renders (app-external parity with the in-app popup, which marks the
       // clicked word in the parent via DictionaryPopupWebView.highlightSelection).
       final int parentIndex = _stack.length - 1;
+      // BUG-1099：卡内点词=用户显式动作，这张卡（及其级联）从此归用户所有，
+      // 被动剪贴板流不得再把它整帧重建掉。置位放在 await 之前，挡住在途竞争。
+      _userOwnedCard = true;
       final DictionarySearchResult result = await model.searchDictionary(
         searchTerm: query,
         searchWithWildcards: false,

--- a/hibiki/lib/src/sync/desktop_lookup_service.dart
+++ b/hibiki/lib/src/sync/desktop_lookup_service.dart
@@ -39,10 +39,23 @@ class DesktopLookupRequest {
   final DesktopLookupForegroundPolicy foregroundPolicy;
   final bool showSourcePanel;
 
-  /// 被动连续文本流（galgame 台词 hook 每 ~400ms 灌一条新台词）而非用户一次性显式意图
-  /// （剪贴板复制 / 热键）。悬浮面板据此决定：用户已点词查看释义时，被动流只刷新可点句子
-  /// 横幅、不抢占/不重置用户的查词结果（否则连续流会把点词的 searchDictionary 作废 + 整帧
-  /// 重置冲掉释义，表现为「对话流动时点词没反应」）。真剪贴板复制（false）仍正常重查。
+  /// 被动连续文本流：Hibiki 在**没有收到任何指向自己的用户动作**时被环境喂进来的文本
+  /// （galgame 台词 hook / 外部 texthooker 每 ~400ms 往剪贴板灌一条新台词，由
+  /// [DesktopLookupService.processClipboardText] 的剪贴板监听接住），而不是用户的一次性
+  /// 显式意图（全局热键 [DesktopLookupOrigin.hotkey] / 悬浮字幕点词
+  /// [DesktopLookupOrigin.explicit]）。
+  ///
+  /// 两个消费面据此决定是否保留用户已点出的那张卡（判据单一真相源
+  /// `keepUserOwnedCardForPassiveStream`）：
+  /// - 悬浮面板：用户已点词查看释义时只刷新可点句子横幅，不抢占/不重置 root；
+  /// - 瞬态覆盖窗：用户点词开出的卡直接留在原地，不重建 root、不清空已测尺寸。
+  /// 否则连续流会把点词的 searchDictionary 作废 + 整帧重置冲掉释义，表现为
+  /// 「对话流动时点词没反应 / 释义被清空缩回去」（BUG-1099）。
+  ///
+  /// BUG-1099 根因备忘：本字段自 a3330a4bc 引入后，唯一置 true 的调用点在
+  /// GalgameSessionController；该文件在 2df13d481 作为死代码整体删除，于是全仓再无
+  /// `passiveStream: true`，上面两条保护变成永不触发的死代码，用户报的
+  /// 「查完词后剪贴板一更新释义就被清空」重新出现。现由剪贴板监听路径直接标记。
   final bool passiveStream;
 }
 
@@ -117,6 +130,12 @@ class DesktopLookupService extends ChangeNotifier
   /// 仍可按全局热键（Ctrl+Shift+D，origin=hotkey）或在悬浮字幕上点词（origin=explicit）
   /// ——那些是显式意图，保留 bringToFront。窗口置顶策略（[DesktopClipboardWindowMode]）
   /// 不改变本约定：无论选哪种策略，被动剪贴板变化都不抢焦点。
+  ///
+  /// BUG-1099 — [passiveStream]：本方法的两个调用点（[processClipboardText] 与
+  /// [endSelfInflictedCapture] 的回放）都来自**环境剪贴板监听**，即 Hibiki 没有收到
+  /// 任何指向自己的用户动作，故一律传 true。显式意图（热键 [_onHotKey] / 悬浮字幕点词
+  /// [triggerLookup]）不走本方法，它们直接调 [_queueLookupRequest] 并保持
+  /// `passiveStream: false`，因此永远不会被消费侧的「保留用户卡」分支拦下。
   void submitText(String raw, {bool passiveStream = false}) {
     _queueLookupRequest(
       raw,
@@ -325,7 +344,9 @@ class DesktopLookupService extends ChangeNotifier
     _deferredDuringCapture.clear();
     for (final String text in deferred) {
       if (selfInflicted.contains(text.trim())) continue;
-      submitText(text);
+      // BUG-1099：回放的仍是**剪贴板监听**接住的事件（只是抓选区括号期内先到、
+      // 事后对账放行），来源与 [processClipboardText] 同一条环境通道，故同样是被动流。
+      submitText(text, passiveStream: true);
     }
   }
 
@@ -350,7 +371,11 @@ class DesktopLookupService extends ChangeNotifier
       return;
     }
     if (clipboardIgnores.consume(text)) return;
-    submitText(text);
+    // BUG-1099：剪贴板监听 = 被动文本流。这条路径由 OS 的剪贴板变化事件驱动
+    // （[onClipboardChanged]），用户没有对 Hibiki 做任何动作；galgame 台词 hook /
+    // 外部 texthooker 正是经这里每 ~400ms 灌一条新台词。标 passiveStream 让消费侧
+    // 能把它与热键/点词这类显式意图区分开，不再冲掉用户点出的释义。
+    submitText(text, passiveStream: true);
   }
 
   Future<void> _onHotKey() async {

--- a/hibiki/test/lookup/desktop_lookup_dispatcher_test.dart
+++ b/hibiki/test/lookup/desktop_lookup_dispatcher_test.dart
@@ -38,8 +38,11 @@ void main() {
         dispatcherSrc.indexOf('case DesktopLookupConsumer.panel:');
     final String tail = dispatcherSrc.substring(panelCase);
     expect(tail.contains('clearPending'), isTrue);
-    expect(tail.contains('lookupText(request.text, sentence: request.text)'),
-        isTrue,
+    // BUG-1099：这一段现在还要透传 passiveStream，调用被 dart format 拆成多行，
+    // 故不再钉整行字面量，只钉两条真契约（整句进 root 卡 + 整句作 sentence）。
+    expect(tail.contains('lookupText('), isTrue);
+    expect(tail.contains('request.text,'), isTrue);
+    expect(tail.contains('sentence: request.text,'), isTrue,
         reason: '整句作 root 卡句子横幅 + 制卡 sentence 字段');
   });
 

--- a/hibiki/test/lookup/floating_lyric_lookup_reset_guard_test.dart
+++ b/hibiki/test/lookup/floating_lyric_lookup_reset_guard_test.dart
@@ -18,13 +18,19 @@ void main() {
   setUpAll(
       () => controller = read('lib/src/lookup/global_lookup_controller.dart'));
 
-  /// 抽出 `lookupText` 函数体（从签名到其 `return true;`）。
+  /// 抽出 `lookupText` 的**完整**函数体（签名到函数收尾的 `\n  }`）。
+  ///
+  /// BUG-1099 起 lookupText 开头多了一条被动流早退（命中「用户卡还在屏上」判据时
+  /// 直接 `return true;`），旧写法「截到第一个 return true」会把前置 hide 整段切掉
+  /// 而误报。改成取整个函数体：前置 hide 必须在 _lookupExternal 之前这条契约不变。
   String lookupTextBody(String src) {
     const String sig = 'Future<bool> lookupText(';
     final int at = src.indexOf(sig);
     expect(at, greaterThanOrEqualTo(0),
         reason: 'lookupText 程序化入口必须存在（TODO-872）');
-    final int end = src.indexOf('return true;', at);
+    // 收尾是独占一行的 `  }`；不能只找 `\\n  }`，那会先命中多行签名的
+    // `  }) async {`。
+    final int end = src.indexOf('\n  }\n', at);
     expect(end, greaterThan(at));
     return src.substring(at, end);
   }

--- a/hibiki/test/lookup/passive_stream_user_card_bug1099_test.dart
+++ b/hibiki/test/lookup/passive_stream_user_card_bug1099_test.dart
@@ -1,0 +1,201 @@
+// BUG-1099 — 「查完词后剪贴板一更新，浮窗释义被清空缩回去」。
+//
+// 根因：区分「被动文本流」与「用户显式意图」的 [DesktopLookupRequest.passiveStream]
+// 自 a3330a4bc 引入后，唯一置 true 的调用点在 GalgameSessionController；该文件在
+// 2df13d481 作为死代码整体删除，全仓再无 passiveStream: true，于是
+// ClipboardPanelController 里那条「用户已点词就只换句子横幅」的保护变成永不触发的
+// 死代码。每条新台词（剪贴板监听灌进来）都走正常路径 → _seedRootFrame 整帧重置 →
+// 用户点出的释义蒸发；瞬态覆盖窗那侧还会把 _lastSentWidth/_lastSentHeight 打回 -1、
+// _revealed 清 false，auto-size 窗口跟着新 root 的小内容「缩回去」。
+//
+// 本文件锁三层：
+//  1. 判据纯函数 keepUserOwnedCardForPassiveStream 的两个方向（被动流保住用户卡 /
+//     显式意图照常替换）——面板与瞬态窗共用它，语义不会漂开。
+//  2. 服务侧真实排队：剪贴板监听 = 被动流；悬浮字幕点词等显式意图 = 非被动流。
+//  3. 两个消费面的接线（源码扫描，运行时链要真窗口）。
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/lookup/desktop_lookup_router.dart';
+import 'package:hibiki/src/sync/desktop_foreground_guard.dart';
+import 'package:hibiki/src/sync/desktop_lookup_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    DesktopLookupService.instance.debugReset();
+    DesktopForegroundGuard.debugForegroundOwnedByCurrentProcess = false;
+    DesktopForegroundGuard.debugForegroundOwnedByHibikiAppFamily = false;
+    DesktopForegroundGuard.debugHiddenWindowsRunner = false;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('app.hibiki/window'),
+      (MethodCall call) async => null,
+    );
+  });
+  tearDown(() {
+    DesktopLookupService.instance.debugReset();
+    DesktopForegroundGuard.debugForegroundOwnedByCurrentProcess = null;
+    DesktopForegroundGuard.debugForegroundOwnedByHibikiAppFamily = null;
+    DesktopForegroundGuard.debugHiddenWindowsRunner = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+            const MethodChannel('app.hibiki/window'), null);
+  });
+
+  group('keepUserOwnedCardForPassiveStream（面板/瞬态窗共用判据）', () {
+    test('被动流 + 用户拥有的卡 + 卡可见 → 保住用户的释义（不清帧）', () {
+      expect(
+        keepUserOwnedCardForPassiveStream(
+          passiveStream: true,
+          userOwnedCard: true,
+          visible: true,
+        ),
+        isTrue,
+        reason: 'BUG-1099 的正题：台词流不得冲掉用户点出来的释义',
+      );
+    });
+
+    test('显式意图（热键/点词/悬浮字幕）恒替换——绝不被这条保护锁死', () {
+      // 这是本修复最容易做错的方向：把主动查词也一起挡掉，用户会以为查词坏了。
+      expect(
+        keepUserOwnedCardForPassiveStream(
+          passiveStream: false,
+          userOwnedCard: true,
+          visible: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('卡不是用户点出来的（上一条被动流自动查的）→ 下一条流正常替换', () {
+      expect(
+        keepUserOwnedCardForPassiveStream(
+          passiveStream: true,
+          userOwnedCard: false,
+          visible: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('卡已经不在屏上 → 没有什么要保护，下一条流正常开卡（保护不会永久粘住）', () {
+      expect(
+        keepUserOwnedCardForPassiveStream(
+          passiveStream: true,
+          userOwnedCard: true,
+          visible: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('DesktopLookupService：谁是被动流', () {
+    test('剪贴板监听（processClipboardText）排队的请求 passiveStream=true', () {
+      DesktopLookupService.instance.processClipboardText('お前はもう死んでいる');
+      expect(
+          DesktopLookupService.instance.pendingRequest?.passiveStream, isTrue,
+          reason: '剪贴板变化由 OS 事件驱动，用户没有对 Hibiki 做任何动作 = 被动流');
+      expect(DesktopLookupService.instance.pendingRequest?.origin,
+          DesktopLookupOrigin.clipboard);
+    });
+
+    test('抓选区括号期回放的剪贴板事件同样是被动流（同一条环境通道）', () {
+      DesktopLookupService.instance.beginSelfInflictedCapture();
+      DesktopLookupService.instance.processClipboardText('真实复制');
+      // 括号期内先到的事件被暂存，对账后放行。
+      expect(DesktopLookupService.instance.pendingRequest, isNull);
+      DesktopLookupService.instance.endSelfInflictedCapture(<String>['自产选区']);
+      expect(DesktopLookupService.instance.pendingRequest?.text, '真实复制');
+      expect(
+          DesktopLookupService.instance.pendingRequest?.passiveStream, isTrue);
+    });
+
+    test('显式查词（悬浮字幕点词 triggerLookup）passiveStream=false', () {
+      DesktopLookupService.instance.triggerLookup('気配');
+      expect(
+        DesktopLookupService.instance.pendingRequest?.passiveStream,
+        isFalse,
+        reason: '用户点词是显式意图，必须正常替换当前卡',
+      );
+      expect(DesktopLookupService.instance.pendingRequest?.origin,
+          DesktopLookupOrigin.explicit);
+    });
+
+    test('热键路径源码不标被动流（热键是最显式的意图）', () {
+      final String src =
+          File('lib/src/sync/desktop_lookup_service.dart').readAsStringSync();
+      final int at = src.indexOf('Future<void> _onHotKey()');
+      expect(at, greaterThan(0));
+      final int end = src.indexOf('\n  }', at);
+      expect(src.substring(at, end).contains('passiveStream'), isFalse,
+          reason: '热键必须保持默认 passiveStream:false，否则用户按热键查词会被吞');
+    });
+  });
+
+  group('消费面接线（源码扫描；运行时链要真覆盖窗）', () {
+    final String panelSrc =
+        File('lib/src/lookup/clipboard_panel_controller.dart')
+            .readAsStringSync();
+    final String glcSrc =
+        File('lib/src/lookup/global_lookup_controller.dart').readAsStringSync();
+    final String dispatcherSrc =
+        File('lib/src/lookup/desktop_lookup_dispatcher.dart')
+            .readAsStringSync();
+
+    test('面板 update 用共享判据决定「只换横幅」，不再自己拼条件', () {
+      final int at = panelSrc.indexOf('Future<void> update(');
+      expect(at, greaterThan(0));
+      final int guardAt =
+          panelSrc.indexOf('keepUserOwnedCardForPassiveStream(', at);
+      final int seedAt = panelSrc.indexOf('_seedRootFrame(request.text', at);
+      expect(guardAt, greaterThan(at), reason: 'update 必须先过被动流判据');
+      expect(seedAt, greaterThan(guardAt),
+          reason: '判据必须在整帧重置（_seedRootFrame）之前，否则释义已经没了');
+    });
+
+    test('dispatcher 把 passiveStream 透传给瞬态覆盖窗', () {
+      expect(dispatcherSrc.contains('passiveStream: request.passiveStream'),
+          isTrue,
+          reason: 'transient 分区不透传标记，瞬态窗那侧的保护就永远收不到信号');
+    });
+
+    test('瞬态窗 lookupText 在被动流命中判据时早退（不重建 root、不清尺寸）', () {
+      final int at = glcSrc.indexOf('Future<bool> lookupText(');
+      expect(at, greaterThan(0));
+      final int guardAt =
+          glcSrc.indexOf('keepUserOwnedCardForPassiveStream(', at);
+      final int hideAt = glcSrc.indexOf('GlobalLookupChannel.hide(', at);
+      expect(guardAt, greaterThan(at));
+      expect(hideAt, greaterThan(guardAt),
+          reason: '早退必须在 hide + _lookupExternal 之前，否则窗口已经被清空缩回去了');
+    });
+
+    test('瞬态窗所有权：用户动作置位、真正关卡复位（保护不会永久粘住）', () {
+      expect(glcSrc.contains('_userOwnedCard = !passiveStream'), isTrue,
+          reason: '显式意图开的卡归用户，被动流开的卡不归');
+      final int nestedAt = glcSrc.indexOf('Future<void> _lookupNested(');
+      expect(nestedAt, greaterThan(0));
+      final int nestedEnd = glcSrc.indexOf('\n  }', nestedAt);
+      expect(
+          glcSrc
+              .substring(nestedAt, nestedEnd)
+              .contains('_userOwnedCard = true'),
+          isTrue,
+          reason: '用户在卡里点词开级联，这张卡当然归用户');
+      final int hiddenAt = glcSrc.indexOf('void _onOverlayHidden()');
+      expect(hiddenAt, greaterThan(0));
+      final int hiddenEnd = glcSrc.indexOf('\n  }', hiddenAt);
+      expect(
+        glcSrc
+            .substring(hiddenAt, hiddenEnd)
+            .contains('_userOwnedCard = false'),
+        isTrue,
+        reason: '不复位就会永久吞掉后续所有被动流查词',
+      );
+    });
+  });
+}

--- a/hibiki/test/pages/popup_headword_ruby_reserve_bug1098_test.dart
+++ b/hibiki/test/pages/popup_headword_ruby_reserve_bug1098_test.dart
@@ -1,0 +1,152 @@
+// BUG-1098 — 查词弹窗**词头**的假名（furigana / <rt>）被垂直压扁、裁掉一截。
+//
+// 两条并列根因，缺一不成立：
+//  ① 零垂直预留：popup.css 里词头只有 `.expression rt { font-size: 13px }`，既没有
+//     line-height / padding-top 预留，也不走 popup.js 的 postProcessRuby——后者当年
+//     只扫 `.glossary-content ruby`，而词头 ruby 是 buildFuriganaEl 造的**裸**
+//     <ruby>/<rt>（不带 class）。于是读音直接溢出 header 行盒。
+//  ② 溢出不可达：`.expression-scroll { overflow-x: auto }` 让另一轴 computed 成
+//     auto，该盒变成滚动容器；而滚动容器的**顶部**溢出永远够不到（scrollTop 不能为
+//     负），所以溢出的注音是被永久 CLIP 掉，不是「可以滚过去」。BUG-775 当年写的
+//     「保留 overflow-y:auto，注音溢出几像素仍可滚不裁切」这句结论是错的。
+//
+// 只有部分词被削：buildFuriganaEl 只在**整词一段**时要 .expression-scroll 包装
+// （纯汉字词 気配 / 邂逅 / 逢瀬），正是 galgame 高频查的名词；食べる 这类切两段的
+// 不套 wrapper，所以不裁。
+//
+// 修法不引入新机制：词头 ruby 并入 glossary 那套已验证的 per-base 单元
+//（BUG-108/363/722/850：.ruby-unit 的 em padding-top 纵向预留 + 绝对定位 rt +
+// .ruby-reserve 横向零高孪生），postProcessRuby 一并处理 `.expression ruby`。
+// .expression 是 26px，旧的硬编码 13px 恰好等于共享的 0.5em——像素不变，但从此随
+// 弹窗 content zoom 等比缩放，而不是让溢出量随 zoom 线性放大。
+//
+// ruby 几何在无头环境渲染不出来，故守卫的是规则本身的存在与作用域（与既有
+// popup_glossary_ruby_lineheight_guard_test.dart 同法，那份只覆盖释义体）。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final String css = File('assets/popup/popup.css').readAsStringSync();
+  final String js = File('assets/popup/popup.js').readAsStringSync();
+
+  /// 取 `:where(...) <名字> { ... }` 规则体；作用域必须同时含三个面。
+  String? sharedRubyRuleBody(String css, String name) {
+    final RegExp re = RegExp(
+      r':where\(([^)]*)\)\s*' + RegExp.escape(name) + r'\s*\{([^}]*)\}',
+    );
+    for (final RegExpMatch m in re.allMatches(css)) {
+      final String scope = m.group(1)!;
+      if (scope.contains('glossary-group') &&
+          scope.contains('glossary-content') &&
+          scope.contains('.expression')) {
+        return m.group(2);
+      }
+    }
+    return null;
+  }
+
+  group('词头 furigana 的纵向预留（根因 ①）', () {
+    test('.ruby-unit / rt / ruby / .ruby-reserve 的作用域都覆盖 .expression', () {
+      for (final String name in const <String>[
+        'ruby',
+        '.ruby-unit',
+        'rt',
+        '.ruby-reserve',
+      ]) {
+        expect(sharedRubyRuleBody(css, name), isNotNull,
+            reason: 'popup.css 的 `$name` 规则必须把 .expression 一并纳入作用域，'
+                '否则词头 ruby 又回到「零预留」状态（BUG-1098）');
+      }
+    });
+
+    test('词头继承到的预留是 em padding-top（zoom 免疫），不是行盒 leading', () {
+      final String body = sharedRubyRuleBody(css, '.ruby-unit')!;
+      expect(RegExp(r'padding-top\s*:\s*[\d.]+em').hasMatch(body), isTrue,
+          reason: '预留必须内生于单元且以 em 表达，才能随 popupContentZoom 等比缩放');
+      expect(RegExp(r'line-height\s*:\s*1\b').hasMatch(body), isTrue,
+          reason: 'line-height:1 保证纵向空间只来自 em padding-top');
+    });
+
+    test('rt 绝对定位在预留里（top:0），字号是 em 不是硬编码 px', () {
+      final String body = sharedRubyRuleBody(css, 'rt')!;
+      expect(RegExp(r'position\s*:\s*absolute').hasMatch(body), isTrue);
+      expect(RegExp(r'top\s*:\s*0\b').hasMatch(body), isTrue);
+      expect(RegExp(r'font-size\s*:\s*[\d.]+em').hasMatch(body), isTrue);
+    });
+
+    test('.expression rt 不得再声明 px 字号（会盖掉零特异性的共享规则）', () {
+      // `.expression rt` 特异性 (0,1,1) 高于 `:where(...) rt` 的 (0,0,1)，
+      // 任何在这里写死的 px 字号都会重新把注音钉成绝对像素、脱离 zoom 链。
+      final RegExpMatch? m =
+          RegExp(r'(?<!\S)\.expression\s+rt\s*\{([^}]*)\}').firstMatch(css);
+      expect(m, isNotNull, reason: '词头 rt 仍需要一条规则承载 user-select:none');
+      final String body = m!.group(1)!;
+      expect(RegExp(r'font-size\s*:\s*\d').hasMatch(body), isFalse,
+          reason: '词头 rt 的字号必须来自共享的 `font-size: 0.5em`（BUG-1098）');
+      expect(body.contains('-webkit-user-select: none'), isTrue,
+          reason: '词头是点击目标（onLinkClick），其读音不得被拖选');
+    });
+  });
+
+  group('postProcessRuby 也处理词头（根因 ① 的 JS 半边）', () {
+    test('选择器包含 .expression ruby', () {
+      expect(
+        js.contains(
+            "querySelectorAll('.glossary-content ruby, .expression ruby')"),
+        isTrue,
+        reason: '词头 ruby 是裸 <ruby>/<rt>，不进 postProcessRuby 就拿不到 .ruby-unit '
+            '预留（BUG-1098）',
+      );
+    });
+
+    test('对已包好的 base 幂等（renderPopup 会对首词条走两遍）', () {
+      // renderPopup 先 postProcessRuby(firstEntry)，随后又 postProcessRuby(container)，
+      // 而 container 含 firstEntry。没有这道门就会把 .ruby-unit 再包一层 .ruby-unit，
+      // 叠出第二份 padding-top。
+      final int at = js.indexOf('function postProcessRuby(');
+      expect(at, greaterThan(0));
+      final int end = js.indexOf('\nfunction ', at + 1);
+      final String body = js.substring(at, end);
+      expect(body.contains("classList.contains('ruby-unit')"), isTrue,
+          reason: 'postProcessRuby 必须跳过已经包好的 base，保证幂等');
+    });
+  });
+
+  group('三镜像 + 生成物同步（红线：popup.css/js 一改必须三处齐）', () {
+    const List<String> mirrors = <String>[
+      'assets/browser_extension/vendor',
+      '../tools/browser-extension/vendor',
+    ];
+
+    test('两份扩展 vendor 的 popup.css / popup.js 与 app 侧字节一致', () {
+      for (final String dir in mirrors) {
+        expect(File('$dir/popup.css').readAsBytesSync(),
+            File('assets/popup/popup.css').readAsBytesSync(),
+            reason: '$dir/popup.css 未同步');
+        expect(File('$dir/popup.js').readAsBytesSync(),
+            File('assets/popup/popup.js').readAsBytesSync(),
+            reason: '$dir/popup.js 未同步');
+      }
+    });
+
+    test('两份 content.css 已重新生成，带上 .expression 作用域', () {
+      // 既有的 parity 守卫只收集以 `.` 开头的选择器，`:where(...)` 规则漏在外面，
+      // 所以这里显式核对生成物真的跟着 popup.css 走了一遍生成器。
+      for (final String dir in mirrors) {
+        final String content = File('$dir/content.css').readAsStringSync();
+        for (final String name in const <String>[
+          'ruby',
+          '.ruby-unit',
+          'rt',
+          '.ruby-reserve',
+        ]) {
+          expect(sharedRubyRuleBody(content, name), isNotNull,
+              reason: '$dir/content.css 缺 `$name` 的 .expression 作用域 — '
+                  '改完 popup.css 必须重跑 '
+                  'tools/browser-extension/scripts/generate-content-css.mjs');
+        }
+      }
+    });
+  });
+}

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -80,6 +80,12 @@
     text-align: left;
 }
 
+
+
+
+
+
+
 :where(#entries-container) {
     overflow-x: hidden;
     padding: 0 10px 10px;
@@ -168,7 +174,15 @@
        overflow-y `auto`, so the extension popup (real Chrome, classic
        scrollbars) showed a tiny arrows+thumb vertical scrollbar squeezed
        against the header buttons. In-app WebView2 hid it only by luck (Fluent
-       overlay scrollbars are invisible at rest). */
+       overlay scrollbars are invisible at rest).
+       BUG-1098 correction: BUG-775 concluded "overflow-y:auto is harmless, the
+       few px of furigana spill can still be scrolled to". That was WRONG - a
+       scroll container's TOP overflow is unreachable (scrollTop can never go
+       negative), so the spilling <rt> was permanently CLIPPED, not scrollable.
+       The real fix is that the headword ruby no longer overflows at all: it now
+       carries the same intrinsic em padding-top reserve as glossary ruby (see
+       the :where(..., .expression) block below), so the implicit overflow-y is
+       genuinely inert. */
     scrollbar-width: none;
 }
 
@@ -215,8 +229,17 @@
     white-space: nowrap;
 }
 
+/* BUG-1098: the headword <rt> geometry (size / absolute anchor / reserve) comes
+   from the SHARED :where(..., .expression) ruby block below - the same intrinsic
+   em reserve glossary furigana has used since BUG-108/363/722/850. The only
+   headword-specific bit left is user-select: the headword is a click target
+   (onLinkClick), so its reading must never be selected by a drag.
+   The old `font-size: 13px` is gone on purpose: 13px == 0.5em of .expression's
+   26px, so the rendered size is unchanged, but a `.expression rt` (0,1,1)
+   declaration used to OUT-RANK the zero-specificity `:where(...) rt` rule and
+   would have pinned the reading to an absolute px size that no longer tracks the
+   popup content zoom. */
 .expression rt {
-    font-size: 13px;
     -webkit-user-select: none;
 }
 
@@ -321,6 +344,9 @@
 .mine-button:disabled {
     opacity: 0.15;
 }
+
+
+
 
 /* TODO-1338: 制卡后图标乱码根因修。制卡按钮的 +/✓/✓↩ 是「文本字形标记」(应用户要求保留
    文本，不走 SVG，见 popup.js setMineState)。默认它会继承 Dart 注入到 html,body 的用户
@@ -815,8 +841,26 @@
     padding: 0 8px;
 }
 
-/* Furigana inside dictionary glossary bodies. Three layout invariants live in
-   this rule group and must stay together. The anchor of all three is the
+/* Furigana inside dictionary glossary bodies AND on the entry headword
+   (.expression). Three layout invariants live in this rule group and must stay
+   together.
+   BUG-1098 — the headword was NOT in this group until now and had zero vertical
+   reserve of its own (`.expression rt { font-size: 13px }` and nothing else),
+   because BUG-108 deliberately scoped its fix to glossary bodies. Its <rt> is
+   built by popup.js buildFuriganaEl as a BARE <ruby>/<rt>, so it also never
+   reached postProcessRuby (which only scanned `.glossary-content ruby`). The
+   reading therefore overflowed the header line box, and .expression-scroll
+   (overflow-x:auto -> computed overflow-y:auto) turned that box into a scroll
+   container whose TOP overflow is unreachable, so the reading was clipped /
+   squashed. Only single-segment readings hit it, because buildFuriganaEl only
+   asks for the .expression-scroll wrapper when the whole word is one segment
+   (pure-kanji nouns: 気配 / 邂逅 / 逢瀬), which is exactly the galgame vocabulary.
+   Fix = no new mechanism: postProcessRuby now also processes `.expression ruby`
+   and these rules cover `.expression`, so the headword gets the identical
+   per-base unit + em reserve + horizontal twin. `.expression` is 26px, so the
+   old hard-coded 13px reading is exactly the shared `font-size: 0.5em` — same
+   pixels today, and now it also tracks the popup content zoom instead of
+   growing the overflow linearly with it. The anchor of all three is the
    per-base UNIT box (.ruby-unit), NOT the <ruby> element — popup.js's
    postProcessRuby wraps each base text node in a <span class="ruby-unit"> and
    moves that base's own <rt> INTO the span, so every rt sizes and positions
@@ -855,14 +899,14 @@
    The <ruby> itself stays inline-block+relative only as a fallback anchor: if
    postProcessRuby ever failed to wrap (never in practice), a bare <rt> would
    still pin to the <ruby> instead of escaping to the viewport. */
-:where(.glossary-group, .glossary-content) ruby {
+:where(.glossary-group, .glossary-content, .expression) ruby {
     display: inline-block;
     position: relative;
     line-height: 1;
     vertical-align: baseline;
 }
 
-:where(.glossary-group, .glossary-content) .ruby-unit {
+:where(.glossary-group, .glossary-content, .expression) .ruby-unit {
     display: inline-block;
     position: relative;
     line-height: 1;
@@ -873,7 +917,7 @@
     text-align: center;
 }
 
-:where(.glossary-group, .glossary-content) rt {
+:where(.glossary-group, .glossary-content, .expression) rt {
     font-size: 0.5em;
     position: absolute;
     left: 0;
@@ -897,7 +941,7 @@
    stays zoom-immune. Units whose reading fits its kanji keep the old compaction.
    The twin is aria-hidden + user-select:none so it never affects ruby lookup
    selection (BUG-110/123/125/129). */
-:where(.glossary-group, .glossary-content) .ruby-reserve {
+:where(.glossary-group, .glossary-content, .expression) .ruby-reserve {
     display: block;
     width: -webkit-max-content;
     width: max-content;
@@ -1325,6 +1369,12 @@
     opacity: 0.6;
     -webkit-user-select: none;
 }
+
+
+
+
+
+
 
 /* 用户「词典方框怎么能左右动，Niratan 不会」根因修：app 外全局查词 / 浏览器扩展原本
    在 .global-lookup 下把 .category-body 从 grid 覆盖成 flex-wrap（flex:1 1 auto;

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -191,7 +191,15 @@ html {
        overflow-y `auto`, so the extension popup (real Chrome, classic
        scrollbars) showed a tiny arrows+thumb vertical scrollbar squeezed
        against the header buttons. In-app WebView2 hid it only by luck (Fluent
-       overlay scrollbars are invisible at rest). */
+       overlay scrollbars are invisible at rest).
+       BUG-1098 correction: BUG-775 concluded "overflow-y:auto is harmless, the
+       few px of furigana spill can still be scrolled to". That was WRONG - a
+       scroll container's TOP overflow is unreachable (scrollTop can never go
+       negative), so the spilling <rt> was permanently CLIPPED, not scrollable.
+       The real fix is that the headword ruby no longer overflows at all: it now
+       carries the same intrinsic em padding-top reserve as glossary ruby (see
+       the :where(..., .expression) block below), so the implicit overflow-y is
+       genuinely inert. */
     scrollbar-width: none;
 }
 
@@ -238,8 +246,17 @@ html {
     white-space: nowrap;
 }
 
+/* BUG-1098: the headword <rt> geometry (size / absolute anchor / reserve) comes
+   from the SHARED :where(..., .expression) ruby block below - the same intrinsic
+   em reserve glossary furigana has used since BUG-108/363/722/850. The only
+   headword-specific bit left is user-select: the headword is a click target
+   (onLinkClick), so its reading must never be selected by a drag.
+   The old `font-size: 13px` is gone on purpose: 13px == 0.5em of .expression's
+   26px, so the rendered size is unchanged, but a `.expression rt` (0,1,1)
+   declaration used to OUT-RANK the zero-specificity `:where(...) rt` rule and
+   would have pinned the reading to an absolute px size that no longer tracks the
+   popup content zoom. */
 .expression rt {
-    font-size: 13px;
     -webkit-user-select: none;
 }
 
@@ -852,8 +869,26 @@ html[data-theme="dark"] .glossary-group {
     padding: 0 8px;
 }
 
-/* Furigana inside dictionary glossary bodies. Three layout invariants live in
-   this rule group and must stay together. The anchor of all three is the
+/* Furigana inside dictionary glossary bodies AND on the entry headword
+   (.expression). Three layout invariants live in this rule group and must stay
+   together.
+   BUG-1098 — the headword was NOT in this group until now and had zero vertical
+   reserve of its own (`.expression rt { font-size: 13px }` and nothing else),
+   because BUG-108 deliberately scoped its fix to glossary bodies. Its <rt> is
+   built by popup.js buildFuriganaEl as a BARE <ruby>/<rt>, so it also never
+   reached postProcessRuby (which only scanned `.glossary-content ruby`). The
+   reading therefore overflowed the header line box, and .expression-scroll
+   (overflow-x:auto -> computed overflow-y:auto) turned that box into a scroll
+   container whose TOP overflow is unreachable, so the reading was clipped /
+   squashed. Only single-segment readings hit it, because buildFuriganaEl only
+   asks for the .expression-scroll wrapper when the whole word is one segment
+   (pure-kanji nouns: 気配 / 邂逅 / 逢瀬), which is exactly the galgame vocabulary.
+   Fix = no new mechanism: postProcessRuby now also processes `.expression ruby`
+   and these rules cover `.expression`, so the headword gets the identical
+   per-base unit + em reserve + horizontal twin. `.expression` is 26px, so the
+   old hard-coded 13px reading is exactly the shared `font-size: 0.5em` — same
+   pixels today, and now it also tracks the popup content zoom instead of
+   growing the overflow linearly with it. The anchor of all three is the
    per-base UNIT box (.ruby-unit), NOT the <ruby> element — popup.js's
    postProcessRuby wraps each base text node in a <span class="ruby-unit"> and
    moves that base's own <rt> INTO the span, so every rt sizes and positions
@@ -892,14 +927,14 @@ html[data-theme="dark"] .glossary-group {
    The <ruby> itself stays inline-block+relative only as a fallback anchor: if
    postProcessRuby ever failed to wrap (never in practice), a bare <rt> would
    still pin to the <ruby> instead of escaping to the viewport. */
-:where(.glossary-group, .glossary-content) ruby {
+:where(.glossary-group, .glossary-content, .expression) ruby {
     display: inline-block;
     position: relative;
     line-height: 1;
     vertical-align: baseline;
 }
 
-:where(.glossary-group, .glossary-content) .ruby-unit {
+:where(.glossary-group, .glossary-content, .expression) .ruby-unit {
     display: inline-block;
     position: relative;
     line-height: 1;
@@ -910,7 +945,7 @@ html[data-theme="dark"] .glossary-group {
     text-align: center;
 }
 
-:where(.glossary-group, .glossary-content) rt {
+:where(.glossary-group, .glossary-content, .expression) rt {
     font-size: 0.5em;
     position: absolute;
     left: 0;
@@ -934,7 +969,7 @@ html[data-theme="dark"] .glossary-group {
    stays zoom-immune. Units whose reading fits its kanji keep the old compaction.
    The twin is aria-hidden + user-select:none so it never affects ruby lookup
    selection (BUG-110/123/125/129). */
-:where(.glossary-group, .glossary-content) .ruby-reserve {
+:where(.glossary-group, .glossary-content, .expression) .ruby-reserve {
     display: block;
     width: -webkit-max-content;
     width: max-content;

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -3112,7 +3112,14 @@ function buildEntryElement(entry, idx) {
 }
 
 function postProcessRuby(container) {
-    container.querySelectorAll('.glossary-content ruby').forEach(ruby => {
+    // BUG-1098: `.expression ruby` (the entry HEADWORD's furigana, built as a
+    // bare <ruby>/<rt> by buildFuriganaEl) joins the glossary bodies here. It
+    // used to be skipped entirely, so it never got the per-base unit and never
+    // got popup.css's em padding-top reserve; the reading then overflowed the
+    // header line box and .expression-scroll (a scroll container whose TOP
+    // overflow is unreachable) clipped it. Same wrap, same reserve, no new
+    // mechanism.
+    container.querySelectorAll('.glossary-content ruby, .expression ruby').forEach(ruby => {
         // Wrap each base — a bare text node OR an element base like <rb>/<span>
         // (monolingual dicts such as 明鏡 emit element bases, not bare text) — in
         // a <span class="ruby-unit"> and pull that base's OWN <rt> into the span.
@@ -3140,6 +3147,17 @@ function postProcessRuby(container) {
             // A base is anything that is not a reading (<rt>), a fallback paren
             // (<rp>), or inter-token whitespace.
             if (isEl(node, 'RT') || isEl(node, 'RP') || isBlankText(node)) {
+                continue;
+            }
+            // BUG-1098: idempotence. renderPopup calls postProcessRuby(firstEntry)
+            // and then postProcessRuby(container) for the tail entries, and the
+            // container CONTAINS the first entry — so entry 0's ruby is walked
+            // twice. Without this guard the second pass wraps the existing
+            // .ruby-unit in ANOTHER .ruby-unit, stacking a second padding-top and
+            // pushing entry 0's base text down relative to every other entry.
+            // An already-wrapped base is done; leave it alone.
+            if (node.nodeType === Node.ELEMENT_NODE &&
+                node.classList.contains('ruby-unit')) {
                 continue;
             }
             const unit = document.createElement('span');


### PR DESCRIPTION
## BUG-1098 词头假名被压扁/裁切
两条并列根因，缺一不成立：
1. `.expression rt` 只有 `font-size:13px`，**零垂直预留**；词头 ruby 是裸 `<ruby>`，进不了只扫 `.glossary-content ruby` 的 `postProcessRuby`。
2. `.expression-scroll` 设了 `overflow-x:auto`，按 CSS 规范另一轴被隐式算成 `auto` → 变成滚动容器，而**滚动容器的顶部溢出不可达**（scrollTop 不能为负），注音被永久裁掉。

只有部分词被削是因为只有单段带注音（纯汉字词：気配/邂逅/逢瀬）才会套上那个 wrapper，`食べる` 这类切两段的不套。

修复：把词头并进释义体那套已验证的 per-base 单元（`.ruby-unit` em 预留 + 绝对 `rt` + `.ruby-reserve` 横向孪生），而不是另写一套 CSS——只改 CSS 会因 `rt` 变 absolute 而丢掉横向占位。`.expression` 是 26px，旧的 `13px` 恰好 = 共享 `0.5em`，**像素零变化**，但从此随弹窗缩放等比走。

顺带堵掉的既有隐患：`renderPopup` 先 `postProcessRuby(firstEntry)` 再 `postProcessRuby(container)`，而 container 含 firstEntry → 多词条结果里首词条的 ruby 会被包两层 `.ruby-unit`、叠出两份 padding。已加幂等门。

并更正 `docs/bugs/BUG-775` 里「保留 overflow-y:auto，注音溢出几像素仍可滚不裁切」这条**错误结论**——顶部方向不可滚，它是本问题拖到现在的直接来源。

三镜像已同步，`content.css` 已重新生成（`--check` 返回 in sync）。新守卫补上了既有 parity 守卫的一个洞：它的 `classSelectors` 只收集以 `.` 开头的选择器，`:where(...)` 规则整个漏在网外。

## BUG-1099 被动流冲掉用户查出的释义
`clipboard_panel_controller.dart:183` 的保护分支 `if (request.passiveStream && ...)` 是**死代码**——`passiveStream` 唯一置 true 的调用点在 `2df13d481` 被当死代码删除后，全仓命中数归零。于是每条新台词都把整帧替换成只剩 root，用户点出来的释义全部蒸发。

主动 vs 被动的判据 = **这次文本进 Hibiki 时用户有没有对 Hibiki 做过动作**（不靠时间窗、不靠内容猜）：剪贴板监听与自伤捕获回放 = 被动；热键、悬浮字幕/歌词点词、面板横幅点字、卡内点词、台词浮窗点词 = 主动。新增纯函数 `keepUserOwnedCardForPassiveStream`，面板与瞬态窗共用同一真相源。

瞬态窗做得比面板保守（整条丢弃而非刷横幅）：瞬态卡锚在被点词旁，把横幅换成无关新台词既看不懂，又会把制卡 `{sentence}` 换成用户没在看的那句 → 做出错卡。

### 已知行为变化（需验收时留意）
用户**自己**在别的 app Ctrl+C，与台词流在 OS 层不可区分，走同一条监听。所以面板上挂着用户释义时，一次主动复制只刷新句子横幅、**不再自动整句重查**（点新横幅词或按热键即恢复）。代价不对称：不保护 = 台词流下释义每 ~400ms 蒸发、根本没法读；保护 = 少一次自动查词的便利、一次点击恢复。要真区分只能上时间窗，而台词间隔与「切窗口再复制」耗时严重重叠，不可靠。

## 验证
- `flutter analyze`（全量含 test）：No issues found!
- 定向测试：751 passed（含三镜像 parity 守卫 + 释义体 ruby 守卫 + 两个方向的新单测）

## 待真机验收（未做）
BUG-1098 需肉眼看词头注音（app 内 + 扩展各一次）；BUG-1099 需 galgame 台词流下走「点词 → 释义保留 → 关卡后下一条台词正常开卡」，以及热键/悬浮字幕点词照常替换。

## 未做
`global_lookup_window.cpp` windowed 回退路径缺 `put_RasterizationScale`/`ShouldDetectMonitorScaleChanges`、全文无 `WM_DPICHANGED`——它是放大器不是根因，em 预留后取整误差只剩几分之一像素，不会再裁整行。改它涉及 WebView2 控制器生命周期且需多屏真机验证，建议另开跟进。

https://claude.ai/code/session_018NeGjpee1gxFXaDTkaeoa4