### PR TITLE
fix(galgame,lookup): 台词浮窗字号与窗高解耦 + 捕获目标/光标可证 + 关掉 WebView2 状态栏 (BUG-1095/1096/1097)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1059 条。点号进各自文件。
+> 共 1062 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1097](bugs/BUG-1097-lookup-overlay-webview2-status-bar-url.md) | ✅ | ✅ | 查词浮窗左下角冒出 `https://hibiki.popup/popup.html?query=…&wildcards=off` |
+| [BUG-1096](bugs/BUG-1096-window-capture-two-mouse-cursors.md) | ✅ | ✅ | 画面捕获出现两个鼠标指针 |
+| [BUG-1095](bugs/BUG-1095-gal-overlay-font-size-coupled-to-window-height.md) | ✅ | ✅ | galgame 台词浮窗拖动窗口时字号跟着变，「放不下」怎么拖都放不下 |
 | [BUG-1092](bugs/BUG-1092-gal-locale-resume-skipped.md) | 🚧 | 🚧 | Locale Emulator 启动的游戏永久停在挂起态：窗口永不出现，injector 却报 OK hooked |
 | [BUG-1091](bugs/BUG-1091-gal-injector-diagnostics-mojibake.md) | ✅ | ✅ | injector 诊断按系统代码页解码：会话事件乱码且中文失败分类永久失配 |
 | [BUG-1090](bugs/BUG-1090-audio-source-url-not-editable.md) | ✅ | ✅ | 管理音频来源弹窗里已有远端 URL 无法编辑，只能删了重加 |

--- a/docs/bugs/BUG-1095-gal-overlay-font-size-coupled-to-window-height.md
+++ b/docs/bugs/BUG-1095-gal-overlay-font-size-coupled-to-window-height.md
@@ -27,7 +27,7 @@
     `gal_hook_text_window_rect` 语义未变，不需要迁移。
   - 顺带：hook 模式下台词一旦装不下就从垂直居中改成**顶端对齐**（`floating_lyric_window.cpp:874-890`），
     保住阅读起点，只丢句尾；装得下时仍居中（像素不变）。
-  - 提交：d2ef8ed0e
+  - 提交：fceb21443
 - **[x] ② 已加自动化测试** —
   - 源码守卫 `hibiki/test/build/gal_overlay_font_decoupled_guard_test.dart`：断言 hook 分支不再
     出现按窗高缩放的常量/表达式、恒为 1.0f，且溢出顶端对齐存在。

--- a/docs/bugs/BUG-1095-gal-overlay-font-size-coupled-to-window-height.md
+++ b/docs/bugs/BUG-1095-gal-overlay-font-size-coupled-to-window-height.md
@@ -1,0 +1,40 @@
+## BUG-1095 · galgame 台词浮窗拖动窗口时字号跟着变，「放不下」怎么拖都放不下
+
+- **报告**：2026-07-26（用户：）
+- **真实性**：✅ 真 bug。根因 `hibiki/windows/runner/floating_lyric_window.cpp:825-831`（修复前）：
+  hook 模式的字号是 `style_.font_size * clamp(strip_height_dip_ / 140dip, 0.9, 2.5)`，
+  而 `strip_height_dip_` 的唯一来源就是窗口实际 rect（`SyncStripSizeFromWindow()`，
+  每次 `WM_SIZE` 都重算并 `text_format_.Reset()`）。于是「把浮窗拖高」和「把台词放大」
+  是同一个手势：从默认 140dip 拖到上限 480dip（3.4×）时字号同步 ×2.5，可见行数只从
+  约 2.3 行涨到约 4.3 行——用户「放不下想拖高」永远拖不出想要的效果。
+  另一半是文本区没有滚动：段落垂直居中 + `PushAxisAlignedClip` 硬裁，溢出直接被切掉。
+  字号当时**没有任何独立真值**（`kGalHookTextFontSize = 30.0` 是硬常量、无 pref），
+  整个 galgame 浮窗在设置页也一条条目都没有。
+- **[x] ① 已修复** — 字号与窗高彻底解耦：
+  - native `hibiki/windows/runner/floating_lyric_window.cpp:45-62`（常量注释）、`:828-841`
+    hook 模式的 `height_scale` 恒为 `1.0f`，直接用 `style_.font_size`；有声书歌词条保持
+    原有随高缩放行为不变。删除 `kHookTextBaseHeightForFontDip` / `kHookTextFontScaleMin`
+    / `kHookTextFontScaleMax` 三个常量。
+  - 新增独立偏好 `gal_hook_text_font_size`（`hibiki/lib/src/models/preferences_repository.dart`
+    `galHookTextFontSize`，范围 12..72，默认 30）+ `AppModel` 委托 + 设置项
+    `card_creation.gal_hook_text_font_size`（`hibiki/lib/src/settings/settings_schema_card_creation.dart`，
+    仅 Windows 可见）。
+  - `GalHookTextOverlayChannel.show/updateStyle` 传真实 `fontSize`；
+    `GalHookTextOverlayController.applyFontSizeFromPreferences()` 在设置页改完立刻推 native。
+  - **向后兼容**：默认 30 恰好等于旧公式在默认窗高 140dip 下的实际字号（`clamp(140/140)=1.0`），
+    没拖过浮窗的用户逐像素不变；拖过窗的用户字号回到 30 并从此由设置项控制——这正是本 bug
+    要求的行为改变（拖高 = 多显示几行，而不是把同样两行放得更大）。老 rect pref
+    `gal_hook_text_window_rect` 语义未变，不需要迁移。
+  - 顺带：hook 模式下台词一旦装不下就从垂直居中改成**顶端对齐**（`floating_lyric_window.cpp:874-890`），
+    保住阅读起点，只丢句尾；装得下时仍居中（像素不变）。
+  - 提交：d2ef8ed0e
+- **[x] ② 已加自动化测试** —
+  - 源码守卫 `hibiki/test/build/gal_overlay_font_decoupled_guard_test.dart`：断言 hook 分支不再
+    出现按窗高缩放的常量/表达式、恒为 1.0f，且溢出顶端对齐存在。
+  - Dart 真单测 `hibiki/test/lookup/gal_hook_text_overlay_controller_test.dart`（新增两条）：
+    `show` 携带偏好里的字号；`applyFontSizeFromPreferences()` 把新字号经 `updateStyle` 推给 native。
+  - 偏好边界 `hibiki/test/models/preferences_repository_gal_hook_font_test.dart`：默认值 / 上下钳位 / 脏数据收敛。
+- **备注**：native C++ 改动已用 `flutter build windows --debug` 真编译验证。
+  **仍未做**：文本区依旧没有滚动，字号调太大 + 窗口太小时溢出仍被硬裁（只是改成裁句尾）。
+  分层滚动需要在 Direct2D 分层窗里自建滚动条与命中测试，属独立工程量，本轮不做。
+  真机肉眼复测（拖高浮窗看行数是否真变多）待补。

--- a/docs/bugs/BUG-1096-window-capture-two-mouse-cursors.md
+++ b/docs/bugs/BUG-1096-window-capture-two-mouse-cursors.md
@@ -1,0 +1,41 @@
+## BUG-1096 · 画面捕获出现两个鼠标指针
+
+- **报告**：2026-07-26（用户：）
+- **真实性**：✅ 真 bug（成因在捕获目标，不在我们画光标）。本仓画面捕获只有一条链：
+  Dart `hibiki/lib/src/mining/window_capture_channel.dart:16`（`app.hibiki.reader/window_capture`）
+  → native WGC 单帧 `hibiki/windows/runner/window_capture.cpp`。全仓零 `gdigrab` /
+  `-draw_mouse` / `DXGI_OUTDUPL_POINTER` / `DrawIcon` / `GetCursorInfo`——**我们只关不画**，
+  GIF 也只是连拍静帧再 ffmpeg 合成（`galgame_window_gif.dart`，ffmpeg 只吃 PNG 序列）。
+  所以两个指针只能是捕获源画面里本来就有两个，两种成因：
+  ① **捕获目标是 Magpie（或同类缩放工具）的缩放窗口**：Magpie 与我们对称地关掉了 WGC
+  合成光标，然后**自己按 cursorScaling 把光标画进缩放输出**，于是它的窗口里 =
+  游戏自绘光标 + Magpie 补画的一个 = 两个；我们再抓这个窗口就原样进 GIF。Magpie 的缩放窗
+  是普通顶层窗口（类名 `Window_Magpie_<GUID>`），完全可能被 `listWindows()` 选中，它上面挂
+  着窗口属性 `Magpie.SrcHWND` 指向真实源窗口。
+  ② **`put_IsCursorCaptureEnabled(false)` 在用户机器上没生效**：`IGraphicsCaptureSession2`
+  需要 Win10 build 19041+，而 `window_capture.cpp:310-318`（修复前）的 QI 结果与 put_ 的
+  HRESULT **两处都被静默吞掉、不写任何日志**，是彻底的盲区——「到底关掉没有」不可证。
+- **[x] ① 已修复**（提交 d2ef8ed0e）— 两条成因都覆盖：
+  - **成因①（捕获目标）**：新增 `hibiki::ResolveScalingSourceWindow()`
+    （`hibiki/windows/runner/window_capture.cpp` + `.h`），按窗口属性 `Magpie.SrcHWND`
+    （**不按类名**——类名里的 GUID 是实现细节，属性名才是稳定契约）把缩放窗解析成源窗口。
+    两处都过一遍：`EnumProc`（枚举阶段，连 `title`/`pid` 一起换成源窗口的——PID 以前会是
+    Magpie.exe，voice hook 的注入目标同样会错；并按 hwnd 去重）与 `CaptureWindowPng`
+    （绑定阶段，覆盖 Dart 侧缓存句柄 / 选窗后才开 Magpie 的情况）。
+    拿不到属性 / 句柄失效时保持原窗口不变（没装 Magpie 的用户路径逐字不变）。
+  - **成因②（盲区）**：`WindowCaptureResult` 新增 `diagnostics` 字段（与 `error` 正交，
+    成功路径也带）。QI 失败与 `put_IsCursorCaptureEnabled` 的 HRESULT 都写进去，
+    经 `flutter_window.cpp` 的 `WM_WINDOWCAP_DONE` 回复带到 Dart
+    （`WindowCaptureResult.diagnostics`），由 `galgame_window_gif.dart` /
+    `gal_hook_mining_coordinator.dart` 在非空时记一条日志。捕获目标被重定向也记一条。
+  - **不在范围内**：游戏**自绘**的光标是画面内容本身，任何捕获 API 都剥不掉；本轮没修也修不了。
+- **[x] ② 已加自动化测试** —
+  - 源码守卫 `hibiki/test/build/window_capture_magpie_cursor_guard_test.dart`：断言
+    `Magpie.SrcHWND` 重定向在枚举与绑定两处都存在、`put_IsCursorCaptureEnabled` 的 HRESULT
+    与 QI 结果不再被丢弃、`diagnostics` 经 channel 回到 Dart。
+  - Dart 单测 `hibiki/test/mining/window_capture_channel_test.dart`（新增）：
+    `diagnostics` 字段解析，且带 diagnostics 的成功结果仍是 `ok`。
+- **备注**：native C++ 改动已用 `flutter build windows --debug` 真编译验证。
+  **未做真机验证**：需要用户装着 Magpie 的原始路径复跑一次，确认 GIF 里只剩一个指针，
+  并在日志里看到重定向/光标抑制两条 diagnostics 的实际取值。在此之前只能算
+  `implemented_unverified`。

--- a/docs/bugs/BUG-1096-window-capture-two-mouse-cursors.md
+++ b/docs/bugs/BUG-1096-window-capture-two-mouse-cursors.md
@@ -15,7 +15,7 @@
   ② **`put_IsCursorCaptureEnabled(false)` 在用户机器上没生效**：`IGraphicsCaptureSession2`
   需要 Win10 build 19041+，而 `window_capture.cpp:310-318`（修复前）的 QI 结果与 put_ 的
   HRESULT **两处都被静默吞掉、不写任何日志**，是彻底的盲区——「到底关掉没有」不可证。
-- **[x] ① 已修复**（提交 d2ef8ed0e）— 两条成因都覆盖：
+- **[x] ① 已修复**（提交 fceb21443）— 两条成因都覆盖：
   - **成因①（捕获目标）**：新增 `hibiki::ResolveScalingSourceWindow()`
     （`hibiki/windows/runner/window_capture.cpp` + `.h`），按窗口属性 `Magpie.SrcHWND`
     （**不按类名**——类名里的 GUID 是实现细节，属性名才是稳定契约）把缩放窗解析成源窗口。

--- a/docs/bugs/BUG-1097-lookup-overlay-webview2-status-bar-url.md
+++ b/docs/bugs/BUG-1097-lookup-overlay-webview2-status-bar-url.md
@@ -10,7 +10,7 @@
   preventDefault 只拦点击，**拦不住 hover 预览**。看着像「主窗口左下角」是因为覆盖窗是撑满
   整个级联包围盒的 topmost 无边框窗（`global_lookup_window.cpp:461-481`），status bar 画在它
   自己的左下角。
-- **[x] ① 已修复**（提交 d2ef8ed0e）— `hibiki/windows/runner/global_lookup_window.cpp` 的 `ConfigureWebView()`
+- **[x] ① 已修复**（提交 fceb21443）— `hibiki/windows/runner/global_lookup_window.cpp` 的 `ConfigureWebView()`
   函数体开头（null guard 之后）加 `get_Settings` + `put_IsStatusBarEnabled(FALSE)`，并把失败的
   HRESULT 经 `ReportOverlayError` 记进 native 日志（不静默吞）。`put_IsStatusBarEnabled` 在
   **基类** `ICoreWebView2Settings` 上，不需要 QI 新版本接口。`ConfigureWebView()` 是两条创建

--- a/docs/bugs/BUG-1097-lookup-overlay-webview2-status-bar-url.md
+++ b/docs/bugs/BUG-1097-lookup-overlay-webview2-status-bar-url.md
@@ -1,0 +1,25 @@
+## BUG-1097 · 查词浮窗左下角冒出 `https://hibiki.popup/popup.html?query=…&wildcards=off`
+
+- **报告**：2026-07-26（用户：）
+- **真实性**：✅ 真 bug。那不是我们拼的字符串，是 **WebView2 的 status bar（链接地址预览）**。
+  虚拟域名 `hibiki.popup` 全仓只注册在 runner 自有的裸 WebView2 `GlobalLookupWindow`
+  （不走 flutter_inappwebview 插件）：`hibiki/windows/runner/global_lookup_window.cpp:1106-1108`
+  （composition 路径）/ `:1172-1174`（windowed 路径）`SetVirtualHostNameToFolderMapping`。
+  URL 里的 `?query=…&wildcards=off` 是 **Yomitan 结构化内容的词典内链**被原样写进 href
+  （`hibiki/assets/popup/popup.js:1807` `element.setAttribute('href', node.href)`）；onclick 的
+  preventDefault 只拦点击，**拦不住 hover 预览**。看着像「主窗口左下角」是因为覆盖窗是撑满
+  整个级联包围盒的 topmost 无边框窗（`global_lookup_window.cpp:461-481`），status bar 画在它
+  自己的左下角。
+- **[x] ① 已修复**（提交 d2ef8ed0e）— `hibiki/windows/runner/global_lookup_window.cpp` 的 `ConfigureWebView()`
+  函数体开头（null guard 之后）加 `get_Settings` + `put_IsStatusBarEnabled(FALSE)`，并把失败的
+  HRESULT 经 `ReportOverlayError` 记进 native 日志（不静默吞）。`put_IsStatusBarEnabled` 在
+  **基类** `ICoreWebView2Settings` 上，不需要 QI 新版本接口。`ConfigureWebView()` 是两条创建
+  路径（composition / windowed）与 BUG-693 自愈重建的唯一漏斗，一处覆盖全部 surface。
+  href 保持不动（点击处理要用它，且 preventDefault 本就拦不住预览）。
+- **[x] ② 已加自动化测试** — 源码守卫
+  `hibiki/test/lookup/global_lookup_status_bar_guard_test.dart`：断言 `put_IsStatusBarEnabled(FALSE)`
+  出现在 `ConfigureWebView()` 函数体内（而不是散在某一条创建路径里），且失败被上报而非丢弃。
+- **备注**：native C++ 改动已用 `flutter build windows --debug` 真编译验证；真机肉眼复测
+  （hover 词典内链看左下角是否再无 URL）待补。
+  相关但**未动**：`docs/bugs/BUG-842-popup-native-title-tooltip-flies.md` 是同一根因家族
+  （原生 OS 提示窗定位），当年明确把「词典内容来源的 title」划在范围外，本轮只关 status bar。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 44761 (2633 per locale)
+/// Strings: 44812 (2636 per locale)
 ///
-/// Built on 2026-07-25 at 18:31 UTC
+/// Built on 2026-07-25 at 19:07 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3489,6 +3489,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get yomitan_port_kill_confirm => 'End process';
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -9457,6 +9461,13 @@ class _StringsAr extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -15498,6 +15509,13 @@ class _StringsDe extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -21555,6 +21573,13 @@ class _StringsEs extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -27623,6 +27648,13 @@ class _StringsFr extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -33618,6 +33650,13 @@ class _StringsId extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -39661,6 +39700,13 @@ class _StringsIt extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -45509,6 +45555,13 @@ class _StringsJa extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -51360,6 +51413,13 @@ class _StringsKo extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -57381,6 +57441,13 @@ class _StringsNl extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -63417,6 +63484,13 @@ class _StringsPtBr extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -69436,6 +69510,13 @@ class _StringsRu extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -75400,6 +75481,13 @@ class _StringsTh extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -81396,6 +81484,13 @@ class _StringsTr extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -87379,6 +87474,13 @@ class _StringsVi extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 // Path: <root>
@@ -92950,6 +93052,13 @@ class _StringsZhCn extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} 是关键系统进程，Hibiki 不会结束它；请改用其他端口。';
+  @override
+  String get gal_hook_text_font_size => 'Galgame 台词浮窗字号';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      '拖动浮窗右下角只改窗口大小（换来更多可见行），字号在这里单独设置。';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame 台词浮窗';
 }
 
 // Path: <root>
@@ -98716,6 +98825,13 @@ class _StringsZhHk extends _StringsEn {
   @override
   String yomitan_port_kill_protected({required Object process}) =>
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+  @override
+  String get gal_hook_text_font_size => 'Galgame caption font size';
+  @override
+  String get gal_hook_text_font_size_hint =>
+      'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+  @override
+  String get settings_section_gal_hook_overlay => 'Galgame caption overlay';
 }
 
 /// Flat map(s) containing all translations.
@@ -104095,6 +104211,12 @@ extension on _StringsEn {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -109472,6 +109594,12 @@ extension on _StringsAr {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -114870,6 +114998,12 @@ extension on _StringsDe {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -120267,6 +120401,12 @@ extension on _StringsEs {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -125670,6 +125810,12 @@ extension on _StringsFr {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -131055,6 +131201,12 @@ extension on _StringsId {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -136455,6 +136607,12 @@ extension on _StringsIt {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -141817,6 +141975,12 @@ extension on _StringsJa {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -147183,6 +147347,12 @@ extension on _StringsKo {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -152576,6 +152746,12 @@ extension on _StringsNl {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -157966,6 +158142,12 @@ extension on _StringsPtBr {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -163361,6 +163543,12 @@ extension on _StringsRu {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -168740,6 +168928,12 @@ extension on _StringsTh {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -174128,6 +174322,12 @@ extension on _StringsTr {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -179511,6 +179711,12 @@ extension on _StringsVi {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }
@@ -184851,6 +185057,12 @@ extension on _StringsZhCn {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} 是关键系统进程，Hibiki 不会结束它；请改用其他端口。';
+      case 'gal_hook_text_font_size':
+        return 'Galgame 台词浮窗字号';
+      case 'gal_hook_text_font_size_hint':
+        return '拖动浮窗右下角只改窗口大小（换来更多可见行），字号在这里单独设置。';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame 台词浮窗';
       default:
         return null;
     }
@@ -190208,6 +190420,12 @@ extension on _StringsZhHk {
       case 'yomitan_port_kill_protected':
         return ({required Object process}) =>
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
+      case 'gal_hook_text_font_size':
+        return 'Galgame caption font size';
+      case 'gal_hook_text_font_size_hint':
+        return 'Drag the overlay\'s corner to resize the window; the caption size is set here.';
+      case 'settings_section_gal_hook_overlay':
+        return 'Galgame caption overlay';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "该端口目前被以下进程占用：$process",
   "yomitan_port_kill_self_instance": "该进程是本应用的另一个正在运行的实例。",
   "yomitan_port_kill_confirm": "结束进程",
-  "yomitan_port_kill_protected": "$process 是关键系统进程，Hibiki 不会结束它；请改用其他端口。"
+  "yomitan_port_kill_protected": "$process 是关键系统进程，Hibiki 不会结束它；请改用其他端口。",
+  "gal_hook_text_font_size": "Galgame 台词浮窗字号",
+  "gal_hook_text_font_size_hint": "拖动浮窗右下角只改窗口大小（换来更多可见行），字号在这里单独设置。",
+  "settings_section_gal_hook_overlay": "Galgame 台词浮窗"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2631,5 +2631,8 @@
   "yomitan_port_kill_confirm_message": "The port is currently used by: $process",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
   "yomitan_port_kill_confirm": "End process",
-  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead."
+  "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
+  "gal_hook_text_font_size": "Galgame caption font size",
+  "gal_hook_text_font_size_hint": "Drag the overlay's corner to resize the window; the caption size is set here.",
+  "settings_section_gal_hook_overlay": "Galgame caption overlay"
 }

--- a/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -10,6 +10,7 @@ import 'package:hibiki/src/utils/misc/desktop_audio_playback.dart';
 import 'package:hibiki/src/mining/gal_hook_mining_coordinator.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
 import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/home_game_page.dart';
 import 'package:hibiki/src/pages/implementations/home_page.dart';
 import 'package:hibiki/src/platform/gal_hook_text_overlay_channel.dart';
@@ -59,6 +60,11 @@ class GalHookTextOverlayController extends ChangeNotifier {
   static const String _opacityPreferenceKey = 'gal_hook_text_window_bg_opacity';
   static const double _defaultOpacity = 0.88;
 
+  /// BUG-1095：台词字号的持久化 key。与 [_rectPreferenceKey]（窗口几何）严格分开——
+  /// 这两件事以前被 native 的「字号 = 基准 × 窗高比例」耦成一件，正是「放不下拖高
+  /// 还是放不下」的根因。范围/默认值的唯一真值在 `PreferencesRepository`。
+  static const String _fontSizePreferenceKey = 'gal_hook_text_font_size';
+
   final GalHookSessionController _session;
   final GalHookMiningCoordinator _miningCoordinator;
   final GalHookPreferenceReader? _preferenceReader;
@@ -85,6 +91,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
   String? _displayedLineId;
   double _opacity = _defaultOpacity;
   double _lastNonZeroOpacity = _defaultOpacity;
+  double _fontSize = kGalHookTextFontSize;
   GalHookTextWindowRect? _savedRect;
 
   static bool get isSupported =>
@@ -98,6 +105,9 @@ class GalHookTextOverlayController extends ChangeNotifier {
   String? get displayedLineId => _displayedLineId;
   bool get isReplaying => _replaying;
   bool get isRecapturing => _session.isRecapturing;
+
+  /// BUG-1095：当前台词字号（逻辑 px），与窗口高度无关。
+  double get fontSize => _fontSize;
 
   /// 试听兜底复位上限：资源原件（OGG/WAV）时长未知时按它把按钮高亮收回，
   /// 与实时台词列表的行内试听同一上限。
@@ -149,6 +159,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
         storedOpacity is num ? storedOpacity.toDouble() : _defaultOpacity;
     _opacity = stored.clamp(0.0, 1.0);
     if (_opacity > 0) _lastNonZeroOpacity = _opacity;
+    _fontSize = _readFontSizePreference();
     final Object? storedRect = read(_rectPreferenceKey, '');
     final String encoded = storedRect is String ? storedRect : '';
     if (encoded.isEmpty) return;
@@ -162,6 +173,22 @@ class GalHookTextOverlayController extends ChangeNotifier {
     } catch (_) {
       _savedRect = null;
     }
+  }
+
+  /// BUG-1095：读台词字号偏好（逻辑 px）。范围钳位与默认值的唯一真值在
+  /// [PreferencesRepository]；这里只负责取值并按同一区间收敛脏数据。
+  double _readFontSizePreference() {
+    const double fallback = PreferencesRepository.galHookTextFontSizeDefault;
+    final AppModel? model = _appModel;
+    final Object? stored = _preferenceReader != null
+        ? _preferenceReader(_fontSizePreferenceKey, defaultValue: fallback)
+        : model?.prefsRepo
+            .getPref(_fontSizePreferenceKey, defaultValue: fallback);
+    final double value = stored is num ? stored.toDouble() : fallback;
+    return value.clamp(
+      PreferencesRepository.galHookTextFontSizeMin,
+      PreferencesRepository.galHookTextFontSizeMax,
+    );
   }
 
   void _scheduleSync() {
@@ -234,6 +261,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
       );
       _visible = await GalHookTextOverlayChannel.show(
         rect: _savedRect,
+        fontSize: _fontSize,
         bgColor: _backgroundColor,
         following: _following,
         passThrough: _passThrough,
@@ -311,7 +339,30 @@ class GalHookTextOverlayController extends ChangeNotifier {
         await model.prefsRepo.setPref(_opacityPreferenceKey, _opacity);
       }
     }
-    await GalHookTextOverlayChannel.updateStyle(bgColor: _backgroundColor);
+    await GalHookTextOverlayChannel.updateStyle(
+      bgColor: _backgroundColor,
+      fontSize: _fontSize,
+    );
+    notifyListeners();
+  }
+
+  /// BUG-1095：把字号偏好重新读进来并立刻推给 native 浮窗。
+  ///
+  /// 设置页写偏好（`AppModel.setGalHookTextFontSize`）后调用本方法，与悬浮字幕的
+  /// 「setFloatingLyricFontSize + applyFloatingLyricStyle」同款纪律：漏掉这一步字号
+  /// 只落了盘，浮窗要等下一次改透明度才顺带刷新。窗口几何完全不动——这正是修复的
+  /// 要点：拖窗只改窗口大小（换来更多可见行），字号只由这条偏好决定。
+  Future<void> applyFontSizeFromPreferences() async {
+    // 未 start（非 Windows / 测试替身 / 初始化尚未走到）时没有偏好源也没有 native
+    // 窗口可推；start() 自己会读一次最新值，这里静默返回即可。
+    if (!_started) return;
+    final double next = _readFontSizePreference();
+    if (next == _fontSize) return;
+    _fontSize = next;
+    await GalHookTextOverlayChannel.updateStyle(
+      bgColor: _backgroundColor,
+      fontSize: next,
+    );
     notifyListeners();
   }
 

--- a/hibiki/lib/src/mining/gal_hook_mining_coordinator.dart
+++ b/hibiki/lib/src/mining/gal_hook_mining_coordinator.dart
@@ -182,6 +182,16 @@ class GalHookMiningCoordinator {
     bool degradedToStill = false;
     if (coverBytes == null || coverBytes.isEmpty) {
       final WindowCaptureResult still = await _captureStill(window.hwnd);
+      // BUG-1096：native 成功路径诊断（WGC 光标抑制是否生效 / 是否从 Magpie 缩放窗
+      // 重定向到源窗口）。降级到单帧时也要留痕，否则这条路径仍是盲区。
+      final String? diagnostics = still.diagnostics;
+      if (diagnostics != null && diagnostics.isNotEmpty) {
+        ErrorLogService.instance.log(
+          'galHookMineLine',
+          'window capture diagnostics: $diagnostics',
+          StackTrace.current,
+        );
+      }
       if (!still.ok) {
         return GalHookMiningResult(
           failureReason: still.error ?? 'game window capture failed',

--- a/hibiki/lib/src/mining/galgame_window_gif.dart
+++ b/hibiki/lib/src/mining/galgame_window_gif.dart
@@ -33,12 +33,26 @@ Future<Uint8List?> captureWindowGifBytes({
     tempDir = await Directory.systemTemp.createTemp('hibiki_gal_gif_');
     // 连续抓帧：任一帧失败跳过该帧；帧间 sleep [intervalMs]（捕获本身还有 WGC 延迟）。
     int captured = 0;
+    // BUG-1096：native 的成功路径诊断（光标抑制是否真的生效 / 捕获目标是否被从
+    // Magpie 缩放窗重定向）。每轮只记一次，逐帧刷会把日志淹掉。
+    String? loggedDiagnostics;
     for (int i = 0; i < frames; i++) {
       if (i > 0 && intervalMs > 0) {
         await Future<void>.delayed(Duration(milliseconds: intervalMs));
       }
       final WindowCaptureResult cap =
           await WindowCaptureChannel.captureWindow(hwnd);
+      final String? diagnostics = cap.diagnostics;
+      if (diagnostics != null &&
+          diagnostics.isNotEmpty &&
+          diagnostics != loggedDiagnostics) {
+        loggedDiagnostics = diagnostics;
+        ErrorLogService.instance.log(
+          'captureWindowGifBytes',
+          'window capture diagnostics: $diagnostics',
+          StackTrace.current,
+        );
+      }
       if (!cap.ok) {
         continue; // 该帧失败：跳过，尽力而为。
       }

--- a/hibiki/lib/src/mining/window_capture_channel.dart
+++ b/hibiki/lib/src/mining/window_capture_channel.dart
@@ -104,13 +104,19 @@ class ExternalWindowInfo {
 
 /// [WindowCaptureChannel.captureWindow] 的结果：成功带 PNG 字节，失败带人类可读原因。
 class WindowCaptureResult {
-  const WindowCaptureResult({this.pngBytes, this.error});
+  const WindowCaptureResult({this.pngBytes, this.error, this.diagnostics});
 
   /// 捕获到的 PNG 图像字节（成功时非空）。
   final Uint8List? pngBytes;
 
   /// 失败原因（成功时为 null）。
   final String? error;
+
+  /// BUG-1096：**成功路径**上值得记录的 native 事实，与 [error] 正交（有它不代表失败）。
+  /// 目前两类：① WGC 光标合成抑制没能生效（`IGraphicsCaptureSession2` 缺失或
+  /// `put_IsCursorCaptureEnabled` 失败——以前这两处 HRESULT 都被 native 静默吞掉）；
+  /// ② 捕获目标被从 Magpie 缩放窗重定向到了真实源窗口。native 无话可说时为 null。
+  final String? diagnostics;
 
   /// true = 成功拿到非空图像字节。
   bool get ok => error == null && pngBytes != null && pngBytes!.isNotEmpty;
@@ -119,5 +125,6 @@ class WindowCaptureResult {
       WindowCaptureResult(
         pngBytes: m['pngBytes'] as Uint8List?,
         error: m['error'] as String?,
+        diagnostics: m['diagnostics'] as String?,
       );
 }

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -5166,6 +5166,11 @@ class AppModel with ChangeNotifier {
   Future<void> setFloatingLyricClickLookup(bool value) =>
       prefsRepo.setFloatingLyricClickLookup(value);
 
+  // BUG-1095: galgame Hook 台词浮窗字号（逻辑 px），与窗高解耦后的唯一真值。
+  double get galHookTextFontSize => prefsRepo.galHookTextFontSize;
+  Future<void> setGalHookTextFontSize(double value) =>
+      prefsRepo.setGalHookTextFontSize(value);
+
   // TODO-370: 悬浮字幕透明度（按钮底色 / 文字），0..100 百分比，100=保持现观感。
   int get floatingLyricButtonBgOpacity =>
       prefsRepo.floatingLyricButtonBgOpacity;

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -1540,6 +1540,32 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  // BUG-1095: galgame Hook 台词浮窗字号（逻辑 px）。以前这个值没有真值来源——native
+  // 按浮窗高度对基准 30 做 0.9~2.5 倍缩放，于是「把浮窗拖高」和「把字放大」是同一个
+  // 手势，用户「放不下想拖高」永远拖不出更多行。现在窗高只管窗高，字号是这条独立
+  // 偏好。默认 30 == 旧基准在默认窗高（140dip）下的实际字号，没拖过窗的用户观感不变。
+  static const double galHookTextFontSizeMin = 12.0;
+  static const double galHookTextFontSizeMax = 72.0;
+  static const double galHookTextFontSizeDefault = 30.0;
+
+  double get galHookTextFontSize {
+    final Object? stored = getPref(
+      'gal_hook_text_font_size',
+      defaultValue: galHookTextFontSizeDefault,
+    );
+    final double value =
+        stored is num ? stored.toDouble() : galHookTextFontSizeDefault;
+    return value.clamp(galHookTextFontSizeMin, galHookTextFontSizeMax);
+  }
+
+  Future<void> setGalHookTextFontSize(double value) async {
+    await setPref(
+      'gal_hook_text_font_size',
+      value.clamp(galHookTextFontSizeMin, galHookTextFontSizeMax).toDouble(),
+    );
+    notifyListeners();
+  }
+
   bool get floatingLyricClickLookup =>
       getPref('floating_lyric_click_lookup', defaultValue: true) as bool;
 

--- a/hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart
+++ b/hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart
@@ -53,8 +53,13 @@ typedef GalHookTextBoundsHandler = FutureOr<void> Function(
   GalHookTextWindowRect rect,
 );
 
-/// Hook 台词浮窗的基准字号（逻辑 px）。native 在 hook 模式下按窗口高度对它做
-/// 0.9~2.5 倍缩放（`kHookTextBaseHeightForFontDip`），所以把浮窗拖高就能放大台词。
+/// Hook 台词浮窗的默认字号（逻辑 px）。
+///
+/// BUG-1095：以前 native 会在 hook 模式下按窗口高度对它做 0.9~2.5 倍缩放，于是
+/// 「拖高浮窗」＝「放大台词」，可见行数几乎不涨，用户「放不下想拖高」永远无解。
+/// 现在 native 直接用这个值（不再乘窗高比例），真值来自 `gal_hook_text_font_size`
+/// 偏好；本常量只是它的默认值，等于旧公式在默认窗高（140dip）下的实际字号，
+/// 所以没拖过窗的用户观感逐像素不变。
 const double kGalHookTextFontSize = 30.0;
 
 /// Windows Hook 台词浮窗的专用 MethodChannel 契约。
@@ -226,10 +231,11 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
   static Future<void> updateStyle({
     required int bgColor,
     int textColor = 0xFFFFFFFF,
+    double fontSize = kGalHookTextFontSize,
   }) async {
     if (!_instance.isSupported) return;
     await _instance.channel.invokeMethod<void>('updateStyle', <String, Object?>{
-      'fontSize': kGalHookTextFontSize,
+      'fontSize': fontSize,
       'bgColor': bgColor,
       'textColor': textColor,
       'buttonTextColor': 0xFFFFFFFF,

--- a/hibiki/lib/src/settings/settings_schema_lookup.dart
+++ b/hibiki/lib/src/settings/settings_schema_lookup.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
@@ -6,6 +7,7 @@ import 'package:hibiki/models.dart';
 import 'package:hibiki/pages.dart';
 import 'package:hibiki/src/lookup/clipboard_panel_controller.dart';
 import 'package:hibiki/src/lookup/clipboard_text_overlay_controller.dart';
+import 'package:hibiki/src/lookup/gal_hook_text_overlay_controller.dart';
 import 'package:hibiki/src/lookup/global_lookup_controller.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/settings/settings_actions.dart';
@@ -990,6 +992,38 @@ SettingsDestination buildLookupDestination() {
               } else {
                 await TexthookerWsClientManager.instance.stop();
               }
+              settingsContext.refresh();
+            },
+          ),
+        ],
+      ),
+      // BUG-1095: galgame Hook 台词浮窗此前在设置页**一条条目都没有**——字号只能靠
+      // 「把窗口拖高」这个副作用去改，而 native 同时按窗高把字放大，可见行数几乎不涨
+      // （「放不下，上下拖还是放不下」）。字号现在是与窗口几何完全解耦的独立偏好，这里
+      // 是它唯一的入口。挂在查词分类：浮窗对用户就是「显示台词 + 点词查词」的那块面板，
+      // 紧邻上面的 texthooker（台词的来源）。仅 Windows——galgame Hook 只做 Windows。
+      SettingsSection(
+        title: t.settings_section_gal_hook_overlay,
+        visible: (_) => Platform.isWindows,
+        items: <SettingsItem>[
+          SettingsStepperItem(
+            id: 'lookup.gal_hook_text_font_size',
+            title: t.gal_hook_text_font_size,
+            subtitle: t.gal_hook_text_font_size_hint,
+            icon: Icons.format_size,
+            visible: (_) => Platform.isWindows,
+            min: PreferencesRepository.galHookTextFontSizeMin,
+            max: PreferencesRepository.galHookTextFontSizeMax,
+            step: 1,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.galHookTextFontSize,
+            format: (double value) => value.round().toString(),
+            onChanged: (SettingsContext settingsContext, double value) async {
+              await settingsContext.appModel.setGalHookTextFontSize(value);
+              // 与悬浮字幕字号同款纪律（TODO-1069）：写完 pref 立刻把整支 style 推给
+              // native 浮窗，否则字号只落了盘，浮窗要等下次改透明度才顺带刷新。
+              await GalHookTextOverlayController.instance
+                  .applyFontSizeFromPreferences();
               settingsContext.refresh();
             },
           ),

--- a/hibiki/test/build/gal_overlay_font_decoupled_guard_test.dart
+++ b/hibiki/test/build/gal_overlay_font_decoupled_guard_test.dart
@@ -1,0 +1,68 @@
+// BUG-1095 源码守卫：galgame Hook 台词浮窗的字号必须与窗口高度解耦。
+//
+// 浮窗不是 Flutter widget，是 runner 自有的 Win32 分层窗（Direct2D/DirectWrite 直绘），
+// C++ 无法在 Dart 测试里执行，故在源码层锁死修复结构：
+//   ① hook 模式不再按窗高缩放字号（三个缩放常量必须消失）；
+//   ② hook 分支的缩放系数恒为 1.0f，即直接用 style_.font_size；
+//   ③ 有声书歌词条的历史行为（按窗高缩放）不得被顺手砍掉；
+//   ④ 溢出时 hook 台词顶端对齐（保住阅读起点，只丢句尾）。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final String src =
+      File('windows/runner/floating_lyric_window.cpp').readAsStringSync();
+
+  test('① 按窗高缩放 hook 字号的三个常量必须消失（BUG-1095）', () {
+    for (final String name in <String>[
+      'kHookTextBaseHeightForFontDip',
+      'kHookTextFontScaleMin',
+      'kHookTextFontScaleMax',
+    ]) {
+      expect(
+        src.contains(name),
+        isFalse,
+        reason: '$name 是「拖高浮窗 = 放大台词」的耦合来源；'
+            '它一旦回来，用户「放不下想拖高」就又拖不出更多行了',
+      );
+    }
+  });
+
+  test('② hook 分支的高度缩放系数恒为 1.0f', () {
+    expect(
+      src.contains('hook_text_mode_ ? 1.0f'),
+      isTrue,
+      reason: 'hook 模式必须直接用 style_.font_size（真值来自 gal_hook_text_font_size '
+          '偏好），不得再从 strip_height_dip_ 推导字号',
+    );
+    // 缩放仍旧只作用在 style_.font_size 上（没有把整支字号逻辑删掉）。
+    expect(
+      src.contains(
+          'const float scaled_font = static_cast<float>(style_.font_size) *'),
+      isTrue,
+      reason: '字号仍必须以 style_.font_size 为基准（channel 送来的用户偏好值）',
+    );
+  });
+
+  test('③ 有声书歌词条保持按窗高缩放（never break userspace）', () {
+    expect(
+      src.contains('strip_height_dip_ / kBaseStripHeightForFontDip'),
+      isTrue,
+      reason: '本次修复只解耦 hook 模式；歌词条「拖高放大」是既有行为，不得连坐',
+    );
+  });
+
+  test('④ hook 台词溢出时顶端对齐，装得下仍居中', () {
+    expect(
+      src.contains('DWRITE_PARAGRAPH_ALIGNMENT_NEAR'),
+      isTrue,
+      reason: '溢出仍是硬裁（分层窗无滚动），但必须裁句尾而不是把头尾一起裁掉',
+    );
+    expect(
+      src.contains('metrics.height > text_rect_.height'),
+      isTrue,
+      reason: '顶端对齐必须由「实测排版高度超出文本区」触发，而不是无条件改对齐',
+    );
+  });
+}

--- a/hibiki/test/build/window_capture_magpie_cursor_guard_test.dart
+++ b/hibiki/test/build/window_capture_magpie_cursor_guard_test.dart
@@ -1,0 +1,98 @@
+// BUG-1096 源码守卫：画面捕获里的「两个鼠标指针」。
+//
+// 两条成因各锁一半，C++ 无法在 Dart 测试里执行，故在源码层锁死结构：
+//   ① 捕获目标：Magpie 缩放窗必须按窗口属性 Magpie.SrcHWND 重定向到真实源窗口，
+//      且枚举阶段与绑定阶段**两处都做**（Dart 侧可能拿的是缓存句柄）；
+//   ② 盲区：put_IsCursorCaptureEnabled 的 HRESULT 与 IGraphicsCaptureSession2 的 QI
+//      结果不得再被静默丢弃，必须写进可回传的 diagnostics；
+//   ③ diagnostics 要真的经 channel 回到 Dart（否则等于没记）。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final String capture =
+      File('windows/runner/window_capture.cpp').readAsStringSync();
+  final String header =
+      File('windows/runner/window_capture.h').readAsStringSync();
+  final String flutterWindow =
+      File('windows/runner/flutter_window.cpp').readAsStringSync();
+
+  test('① Magpie 缩放窗按 Magpie.SrcHWND 属性重定向到源窗口', () {
+    expect(
+      capture.contains('GetPropW(hwnd, L"Magpie.SrcHWND")'),
+      isTrue,
+      reason: '判定契约是窗口属性名（跨版本稳定），不是类名里的 GUID',
+    );
+    expect(
+      header.contains('HWND ResolveScalingSourceWindow(HWND hwnd);'),
+      isTrue,
+      reason: '重定向必须是一个具名、可复用的入口，不得内联进某一条路径',
+    );
+    // 拿不到属性 / 句柄失效必须原样返回，不改变没装 Magpie 的用户路径。
+    expect(
+      capture.contains('if (source == hwnd || !IsWindow(source)) {'),
+      isTrue,
+      reason: '属性指向自身或已失效的句柄必须回落到原窗口，不得崩也不得抓错窗',
+    );
+  });
+
+  test('① 枚举阶段与捕获绑定阶段都过一次重定向', () {
+    final int enumUse =
+        'ResolveScalingSourceWindow('.allMatches(capture).length;
+    expect(
+      enumUse,
+      greaterThanOrEqualTo(3),
+      reason: '至少三处：函数定义 + EnumProc（换 hwnd/title/pid）+ CaptureWindowPng（绑定前）',
+    );
+    expect(
+      capture.contains('GetWindowThreadProcessId(target, &w.pid)'),
+      isTrue,
+      reason: 'PID 必须取重定向后的窗口——否则 voice hook 会注入 Magpie.exe 而不是游戏',
+    );
+  });
+
+  test('② 光标抑制的 QI 与 HRESULT 不再被静默丢弃', () {
+    expect(
+      capture.contains('const HRESULT cursor_qi = session.As(&session2);'),
+      isTrue,
+      reason: 'IGraphicsCaptureSession2 的 QI 结果必须被接住（Win10 19041- 上会失败）',
+    );
+    expect(
+      capture.contains(
+          'const HRESULT cursor_hr = session2->put_IsCursorCaptureEnabled(false);'),
+      isTrue,
+      reason: 'put_IsCursorCaptureEnabled 的 HRESULT 必须被接住，不得裸调丢弃',
+    );
+    expect(
+      capture.contains('AppendDiagnostic(out, "put_IsCursorCaptureEnabled'),
+      isTrue,
+      reason: 'put_ 失败必须留痕，否则「用户机器上到底关掉没有」又变成盲区',
+    );
+    expect(
+      capture.contains('IGraphicsCaptureSession2 unavailable'),
+      isTrue,
+      reason: '接口本身缺失（旧系统）同样要留痕，不能与「已关掉」混为一谈',
+    );
+  });
+
+  test('③ diagnostics 经 channel 回到 Dart', () {
+    expect(
+      header.contains('std::string diagnostics;'),
+      isTrue,
+      reason: 'diagnostics 必须与 error 正交（成功路径也要能说话）',
+    );
+    expect(
+      flutterWindow.contains('flutter::EncodableValue("diagnostics")'),
+      isTrue,
+      reason: 'native 记了但不回传等于没记',
+    );
+    final String dartChannel =
+        File('lib/src/mining/window_capture_channel.dart').readAsStringSync();
+    expect(
+      dartChannel.contains("diagnostics: m['diagnostics'] as String?"),
+      isTrue,
+      reason: 'Dart 侧必须解析该字段',
+    );
+  });
+}

--- a/hibiki/test/lookup/gal_hook_text_overlay_controller_test.dart
+++ b/hibiki/test/lookup/gal_hook_text_overlay_controller_test.dart
@@ -6,6 +6,7 @@ import 'package:hibiki/src/mining/galgame_audio_encode.dart';
 import 'package:hibiki/src/mining/galgame_audio_source.dart';
 import 'package:hibiki/src/mining/window_capture_channel.dart';
 import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/platform/gal_hook_text_overlay_channel.dart';
 import 'package:hibiki/src/sync/texthooker_service.dart';
 
@@ -265,6 +266,72 @@ void main() {
           (preferences['gal_hook_text_window_rect'] as String?)
               ?.contains('"left":50') ==
           true,
+    );
+  });
+
+  // BUG-1095：字号是一条独立偏好，与窗口几何（gal_hook_text_window_rect）互不影响。
+  // 修复前 native 按窗口高度缩放字号，「拖高浮窗」＝「放大台词」，可见行数几乎不涨。
+  test('保存的字号随 show 一起送给 native，且窗口几何不受影响', () async {
+    preferences['gal_hook_text_font_size'] = 48.0;
+    preferences['gal_hook_text_window_rect'] =
+        '{"left":12,"top":34,"width":800,"height":180}';
+    await controller.start(appModel: AppModel(testPlatformServices()));
+    await startSession();
+    textService.appendLine(
+      'フォントサイズ',
+      source: TexthookerLineSource.websocket,
+    );
+    await _waitUntil(() => controller.isVisible);
+
+    final MethodCall show = nativeCalls.lastWhere(
+      (MethodCall call) => call.method == 'show',
+    );
+    final Map<Object?, Object?> args = show.arguments as Map<Object?, Object?>;
+    expect(args['fontSize'], 48.0, reason: '字号必须来自偏好，而不是硬常量');
+    expect(controller.fontSize, 48.0);
+    expect(args['height'], 180, reason: '改字号不得连带改窗口几何（两者已解耦）');
+  });
+
+  test('越界的历史脏字号被收敛到合法区间', () async {
+    preferences['gal_hook_text_font_size'] = 9999.0;
+    await controller.start(appModel: AppModel(testPlatformServices()));
+    expect(
+      controller.fontSize,
+      PreferencesRepository.galHookTextFontSizeMax,
+    );
+  });
+
+  test('applyFontSizeFromPreferences 立刻把新字号经 updateStyle 推给 native', () async {
+    await controller.start(appModel: AppModel(testPlatformServices()));
+    await startSession();
+    textService.appendLine(
+      '設定から変更',
+      source: TexthookerLineSource.websocket,
+    );
+    await _waitUntil(() => controller.isVisible);
+    expect(controller.fontSize, kGalHookTextFontSize);
+
+    // 设置页写 pref（真实链路是 AppModel.setGalHookTextFontSize）后调用本方法。
+    preferences['gal_hook_text_font_size'] = 20.0;
+    await controller.applyFontSizeFromPreferences();
+
+    expect(controller.fontSize, 20.0);
+    final MethodCall style = nativeCalls.lastWhere(
+      (MethodCall call) => call.method == 'updateStyle',
+    );
+    expect(
+      (style.arguments as Map<Object?, Object?>)['fontSize'],
+      20.0,
+      reason: '漏掉这一步字号只落了盘，浮窗要等下次改透明度才顺带刷新（TODO-1069 同款纪律）',
+    );
+
+    // 幂等：值没变时不再重复推 native。
+    final int stylePushes =
+        nativeCalls.where((MethodCall c) => c.method == 'updateStyle').length;
+    await controller.applyFontSizeFromPreferences();
+    expect(
+      nativeCalls.where((MethodCall c) => c.method == 'updateStyle').length,
+      stylePushes,
     );
   });
 }

--- a/hibiki/test/lookup/global_lookup_status_bar_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_status_bar_guard_test.dart
@@ -1,0 +1,66 @@
+// BUG-1097 源码守卫：查词浮窗不得再画 WebView2 的链接地址预览（status bar）。
+//
+// 用户看到的 `https://hibiki.popup/popup.html?query=…&wildcards=off` 是 WebView2 自带的
+// status bar：Yomitan 结构化内容把词典内链原样写进 href，hover 就触发预览；onclick 的
+// preventDefault 只拦点击，拦不住预览。覆盖窗是撑满级联包围盒的 topmost 无边框窗，
+// 于是预览画在它自己的左下角，看着像「主窗口左下角冒出一条 URL」。
+//
+// 修复必须落在 ConfigureWebView() 里——它是 composition / windowed 两条创建路径与
+// BUG-693 自愈重建的唯一漏斗。C++ 无法在 Dart 测试里执行，故在源码层锁定：
+//   ① put_IsStatusBarEnabled(FALSE) 确实在 ConfigureWebView() 函数体内；
+//   ② 失败被上报而不是静默吞掉；
+//   ③ href 没被顺手删掉（点击处理仍要用它，那是 BUG-842 划在范围外的另一件事）。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 取出 `GlobalLookupWindow::[name]` 的函数体源码（到下一个成员函数定义为止）。
+/// 在 main() 顶层调用，故不能用 expect（那是 OutsideTestException），直接抛。
+String _memberSource(String src, String name) {
+  final int start = src.indexOf('void GlobalLookupWindow::$name() {');
+  if (start < 0) {
+    throw StateError('GlobalLookupWindow::$name 必须存在（守卫依赖它作为唯一漏斗）');
+  }
+  final int next = src.indexOf('\nvoid GlobalLookupWindow::', start + 1);
+  return src.substring(start, next == -1 ? src.length : next);
+}
+
+void main() {
+  final String src =
+      File('windows/runner/global_lookup_window.cpp').readAsStringSync();
+  final String configure = _memberSource(src, 'ConfigureWebView');
+
+  test('① status bar 在 ConfigureWebView() 里被关掉（BUG-1097）', () {
+    expect(
+      configure.contains('put_IsStatusBarEnabled(FALSE)'),
+      isTrue,
+      reason: '必须在 ConfigureWebView() 内关闭——它是 composition / windowed 两条创建路径 '
+          '与 BUG-693 自愈重建的唯一漏斗；散在单条路径里会漏掉重建出来的新 surface',
+    );
+    expect(
+      configure.contains('webview_->get_Settings(&settings)'),
+      isTrue,
+      reason:
+          'put_IsStatusBarEnabled 在基类 ICoreWebView2Settings 上，走 get_Settings 即可，'
+          '不需要 QI 新版本接口',
+    );
+  });
+
+  test('② 关闭失败必须上报，不得静默吞掉', () {
+    expect(
+      configure.contains('ReportOverlayError("put_IsStatusBarEnabled(FALSE) '),
+      isTrue,
+      reason: '一旦失败那条 URL 就会回来；HRESULT 被吞掉就只能从零重查一遍',
+    );
+  });
+
+  test('③ 词典内链的 href 保持不动（本轮只关 status bar）', () {
+    final String popupJs = File('assets/popup/popup.js').readAsStringSync();
+    expect(
+      popupJs.contains("setAttribute('href', node.href)"),
+      isTrue,
+      reason: 'href 是点击处理的输入，不得为了消掉预览而删链接；'
+          '「原生提示窗定位」是 BUG-842 家族的另一件事，本轮不动',
+    );
+  });
+}

--- a/hibiki/test/mining/window_capture_channel_test.dart
+++ b/hibiki/test/mining/window_capture_channel_test.dart
@@ -94,5 +94,47 @@ void main() {
       final res = await WindowCaptureChannel.captureWindow(1);
       expect(res.ok, false);
     });
+
+    // BUG-1096：native 的成功路径诊断（WGC 光标抑制是否真的生效 / 捕获目标是否被从
+    // Magpie 缩放窗重定向）。它与 error 正交——有诊断不代表这一帧失败了。
+    test('diagnostics 与 error 正交：带诊断的成功结果仍然是 ok', () async {
+      final Uint8List png = Uint8List.fromList([0x89, 0x50, 0x4E, 0x47]);
+      messenger.setMockMethodCallHandler(channel, (MethodCall call) async {
+        return <Object?, Object?>{
+          'pngBytes': png,
+          'diagnostics': 'capture target redirected: Magpie scaling window -> '
+              'source window (Magpie.SrcHWND)',
+        };
+      });
+      final res = await WindowCaptureChannel.captureWindow(1);
+      expect(res.ok, true);
+      expect(res.error, isNull);
+      expect(res.diagnostics, contains('Magpie.SrcHWND'));
+    });
+
+    test('失败结果也能带诊断（光标抑制未生效这类事实不因失败而丢）', () async {
+      messenger.setMockMethodCallHandler(channel, (MethodCall call) async {
+        return <Object?, Object?>{
+          'error': 'capture timed out',
+          'diagnostics': 'IGraphicsCaptureSession2 unavailable (needs Windows '
+              '10 build 19041+); WGC cursor NOT suppressed hr=0x80004002',
+        };
+      });
+      final res = await WindowCaptureChannel.captureWindow(1);
+      expect(res.ok, false);
+      expect(res.error, 'capture timed out');
+      expect(res.diagnostics, contains('cursor NOT suppressed'));
+    });
+
+    test('native 不带 diagnostics 时为 null（无话可说 = 一切如预期）', () async {
+      messenger.setMockMethodCallHandler(channel, (MethodCall call) async {
+        return <Object?, Object?>{
+          'pngBytes': Uint8List.fromList([1, 2, 3, 4]),
+        };
+      });
+      final res = await WindowCaptureChannel.captureWindow(1);
+      expect(res.ok, true);
+      expect(res.diagnostics, isNull);
+    });
   });
 }

--- a/hibiki/test/models/preferences_repository_gal_hook_font_test.dart
+++ b/hibiki/test/models/preferences_repository_gal_hook_font_test.dart
@@ -1,0 +1,88 @@
+// BUG-1095：galgame Hook 台词浮窗字号偏好（真 DB，非源码扫描）。
+//
+// 这个值以前不存在——native 按窗口高度对硬常量 30 做 0.9~2.5 倍缩放，于是「拖高浮窗」
+// 就是「放大台词」，用户「放不下想拖高」永远拖不出更多行。现在它是独立偏好；本测试锁住
+// 默认值恰好等于旧公式在默认窗高（140dip）下的实际字号（老用户观感不变）、读写两端的
+// 钳位、以及历史脏数据（越界 / int / 非数字）的收敛。
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/platform/gal_hook_text_overlay_channel.dart';
+
+void main() {
+  late HibikiDatabase db;
+  late PreferencesRepository repo;
+
+  setUp(() async {
+    db = HibikiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    repo = PreferencesRepository(db);
+    await repo.loadFromDb();
+  });
+
+  tearDown(() async {
+    repo.dispose();
+    await db.close();
+  });
+
+  test('默认值 = 旧公式在默认窗高下的实际字号（never break userspace）', () {
+    expect(
+      PreferencesRepository.galHookTextFontSizeDefault,
+      kGalHookTextFontSize,
+      reason: '旧公式是 30 * clamp(140/140, 0.9, 2.5) = 30；两者必须一致，'
+          '否则没拖过浮窗的老用户升级后会看到字号突变',
+    );
+    expect(repo.galHookTextFontSize, kGalHookTextFontSize);
+  });
+
+  test('写入的值原样读回', () async {
+    await repo.setGalHookTextFontSize(44);
+    expect(repo.galHookTextFontSize, 44);
+  });
+
+  test('写入端按 [min, max] 钳位', () async {
+    await repo.setGalHookTextFontSize(9999);
+    expect(
+        repo.galHookTextFontSize, PreferencesRepository.galHookTextFontSizeMax);
+
+    await repo.setGalHookTextFontSize(-1);
+    expect(
+        repo.galHookTextFontSize, PreferencesRepository.galHookTextFontSizeMin);
+  });
+
+  test('读取端也钳位：绕过 setter 写进来的越界脏值不会漏出去', () async {
+    await repo.setPref('gal_hook_text_font_size', 500.0);
+    expect(
+        repo.galHookTextFontSize, PreferencesRepository.galHookTextFontSizeMax);
+
+    await repo.setPref('gal_hook_text_font_size', 1.0);
+    expect(
+        repo.galHookTextFontSize, PreferencesRepository.galHookTextFontSizeMin);
+  });
+
+  test('非 double 的历史脏值不炸：int 收下、非数字回落默认', () async {
+    await repo.setPref('gal_hook_text_font_size', 36);
+    expect(repo.galHookTextFontSize, 36.0);
+
+    await repo.setPref('gal_hook_text_font_size', 'not-a-number');
+    expect(
+      repo.galHookTextFontSize,
+      PreferencesRepository.galHookTextFontSizeDefault,
+    );
+  });
+
+  test('区间自洽且默认值落在区间内', () {
+    expect(
+      PreferencesRepository.galHookTextFontSizeMin,
+      lessThan(PreferencesRepository.galHookTextFontSizeMax),
+    );
+    expect(
+      PreferencesRepository.galHookTextFontSizeDefault,
+      inInclusiveRange(
+        PreferencesRepository.galHookTextFontSizeMin,
+        PreferencesRepository.galHookTextFontSizeMax,
+      ),
+    );
+  });
+}

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -766,6 +766,13 @@ void main() {
           'AppModel builds the FloatingLyricStyle data object (overlay font '
               'size is user content passed to the platform overlay), not an '
               'ordinary page-chrome TextStyle.',
+      'lib/src/lookup/gal_hook_text_overlay_controller.dart':
+          'BUG-1095: the fontSize: hits are named arguments of the '
+              'GalHookTextOverlayChannel MethodChannel wrapper (the caption '
+              'size handed to the native Win32 overlay window), not a Flutter '
+              'TextStyle — this controller renders no widgets at all. Same '
+              'reviewed exception class as the allowlisted AppModel '
+              'FloatingLyricStyle payload.',
       'lib/src/media/video/video_subtitle_overlay.dart':
           'Video subtitle overlay renders caption content (fixed '
               'white-on-black caption radius/size), not ordinary page chrome.',

--- a/hibiki/test/settings/settings_schema_coverage_test.dart
+++ b/hibiki/test/settings/settings_schema_coverage_test.dart
@@ -35,6 +35,15 @@ import '../helpers/test_platform_services.dart';
 /// 让覆盖测试不对「别处已覆盖」的项裸喊 UNVERIFIED/FAIL，且强制每个 changed
 /// 但未 effect-verified 的设置都必须有去处（no silent caps）。
 const Map<String, String> kCoveredElsewhere = <String, String>{
+  // BUG-1095：galgame Hook 台词浮窗字号。写 prefsRepo（changed=true），生效点在
+  // runner 自有的 Win32 分层浮窗（Direct2D/DirectWrite 直绘，不是 Flutter widget
+  // 树），本进程内没有任何可探的渲染输入，故无适用探针；由三层专项测试咬住：
+  // 偏好边界（默认/钳位/脏值）、控制器把字号经 show/updateStyle 真推给 native、
+  // 以及 native 源码守卫（hook 模式不再按窗高缩放字号）。
+  'lookup/Galgame caption font size':
+      'test/models/preferences_repository_gal_hook_font_test.dart + '
+          'test/lookup/gal_hook_text_overlay_controller_test.dart + '
+          'test/build/gal_overlay_font_decoupled_guard_test.dart',
   // 视频条目自动刮削总闸。写 prefsRepo（changed=true），生效点在
   // VideoScrapeAutoService.sweep 的进场门（关=零网络请求、零资料落库），不是
   // reader CSS / 主题树，无适用探针；由专项服务测试咬住（关=不发请求、关→开

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -45,14 +45,21 @@ constexpr float kDragThresholdDip = 6.0f;
 // Base logical font size the lyric text was authored at; the rendered font
 // scales with the bar height so growing the bar enlarges the text too.
 constexpr float kBaseStripHeightForFontDip = 96.0f;
-// Hook mode authors its font against its own default window height (140dip) and
-// scales with the live height, so dragging the overlay taller enlarges the
-// caption instead of leaving it stranded at the authored size. Clamped so a
-// deliberately short, wide overlay (hugging the game's text box) never shrinks
-// the text below readability.
-constexpr float kHookTextBaseHeightForFontDip = 140.0f;
-constexpr float kHookTextFontScaleMin = 0.9f;
-constexpr float kHookTextFontScaleMax = 2.5f;
+// BUG-1095 — hook mode does NOT scale its font with the window height.
+//
+// It used to: the caption font was style_.font_size * clamp(height / 140dip,
+// 0.9, 2.5). Because strip_height_dip_ is read straight back off the live
+// window rect (SyncStripSizeFromWindow on every WM_SIZE), "drag the overlay
+// taller" and "enlarge the caption" were the SAME gesture. Dragging from the
+// 140dip default to the 480dip ceiling (3.4x taller) also multiplied the font
+// by 2.5, so the visible line count only crept from ~2.3 to ~4.3 — which is
+// exactly the user report: "it doesn't fit, and dragging it taller STILL
+// doesn't fit". Height and font size are two independent things the user
+// wants to control, so they are now two independent inputs: the window rect
+// stays the drag target, and the font size comes from its own preference
+// (gal_hook_text_font_size -> Style::font_size). At the authored default
+// height the old formula evaluated to exactly 1.0, so a user who never
+// dragged the overlay sees pixel-identical text.
 // Control row slots, in draw / hit-test order: previous, play-pause, next,
 // lock, close. The lock button (slot 3) is the TODO-136 addition; both Render()
 // and ControlActionAt() derive their geometry from this single count so the
@@ -818,15 +825,16 @@ void FloatingLyricWindow::Render() {
                                         brush.GetAddressOf());
   render_target_->FillRoundedRectangle(bg_rect, brush.Get());
 
-  // Text format / layout. The authored font size assumes the default bar
-  // height; the live font scales with strip_height_dip_ so dragging the resize
-  // grip larger enlarges the lyric text too.
+  // Text format / layout. The audiobook lyric strip keeps its historical
+  // behaviour: its authored font size assumes the default bar height and the
+  // live font scales with strip_height_dip_, so dragging the resize grip larger
+  // enlarges the lyric text too. Hook mode does NOT (BUG-1095): its font size is
+  // an independent user preference, so dragging the overlay taller buys visible
+  // LINES instead of re-inflating the same two lines.
   if (text_format_ == nullptr) {
     const float height_scale =
-        hook_text_mode_
-            ? std::clamp(strip_height_dip_ / kHookTextBaseHeightForFontDip,
-                         kHookTextFontScaleMin, kHookTextFontScaleMax)
-            : strip_height_dip_ / kBaseStripHeightForFontDip;
+        hook_text_mode_ ? 1.0f
+                        : strip_height_dip_ / kBaseStripHeightForFontDip;
     const float scaled_font = static_cast<float>(style_.font_size) *
                               std::max(0.5f, height_scale);
     dwrite_factory_->CreateTextFormat(
@@ -864,6 +872,23 @@ void FloatingLyricWindow::Render() {
                                         text_layout_.GetAddressOf());
     }
     if (text_layout_ != nullptr) {
+      // BUG-1095: overflow still CLIPS (there is no scrolling in a layered
+      // Direct2D strip), but WHICH end gets clipped matters. With the paragraph
+      // vertically centred, an over-long caption loses its head AND its tail
+      // symmetrically — the user cannot even start reading. Top-align the hook
+      // caption the moment it no longer fits, so reading order is preserved and
+      // only the tail is lost; a caption that fits stays centred (unchanged
+      // pixels). Scoped to hook mode: the audiobook lyric strip wants its
+      // current line near the middle, so its centring is left alone.
+      if (hook_text_mode_) {
+        DWRITE_TEXT_METRICS metrics = {};
+        if (SUCCEEDED(text_layout_->GetMetrics(&metrics))) {
+          text_layout_->SetParagraphAlignment(
+              metrics.height > text_rect_.height
+                  ? DWRITE_PARAGRAPH_ALIGNMENT_NEAR
+                  : DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+        }
+      }
       // BUG-1070: the lyric / hook-text body is vertically centred
       // (DWRITE_PARAGRAPH_ALIGNMENT_CENTER) inside a layout box whose top edge
       // is text_rect_.top == controls_h, i.e. just below the hover control band

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -2122,18 +2122,23 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
       // silent empty success).
       auto* pending = reinterpret_cast<WindowCapturePending*>(lparam);
       if (pending != nullptr) {
+        flutter::EncodableMap reply;
         if (pending->result.ok && !pending->result.png.empty()) {
-          pending->reply->Success(flutter::EncodableValue(flutter::EncodableMap{
-              {flutter::EncodableValue("pngBytes"),
-               flutter::EncodableValue(pending->result.png)}}));
+          reply[flutter::EncodableValue("pngBytes")] =
+              flutter::EncodableValue(pending->result.png);
         } else {
-          const std::string err = pending->result.error.empty()
-                                      ? std::string("capture failed")
-                                      : pending->result.error;
-          pending->reply->Success(flutter::EncodableValue(flutter::EncodableMap{
-              {flutter::EncodableValue("error"),
-               flutter::EncodableValue(err)}}));
+          reply[flutter::EncodableValue("error")] =
+              flutter::EncodableValue(pending->result.error.empty()
+                                          ? std::string("capture failed")
+                                          : pending->result.error);
         }
+        // BUG-1096 — 成功路径上的可观测事实（WGC 光标抑制是否真的生效 / 捕获目标是否
+        // 被从 Magpie 缩放窗重定向）。空则不带字段，Dart 侧只在非空时记一条日志。
+        if (!pending->result.diagnostics.empty()) {
+          reply[flutter::EncodableValue("diagnostics")] =
+              flutter::EncodableValue(pending->result.diagnostics);
+        }
+        pending->reply->Success(flutter::EncodableValue(std::move(reply)));
         delete pending;
       }
       return 0;

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -1203,6 +1203,36 @@ void GlobalLookupWindow::ConfigureWebView() {
     return;
   }
 
+  // BUG-1097 — turn off the WebView2 status bar (the link-target preview).
+  //
+  // Yomitan structured content writes dictionary-internal links straight into
+  // href (assets/popup/popup.js: element.setAttribute('href', node.href)), so
+  // hovering a glossary cross-reference makes WebView2 paint
+  // "https://hibiki.popup/popup.html?query=…&wildcards=off" in the bottom-left
+  // corner of ITS OWN surface. The overlay host is a topmost frameless window
+  // stretched over the whole cascade bounding box, so that strip reads to the
+  // user as a stray URL in the bottom-left of the app. The href itself must
+  // stay (the click handler needs it, and preventDefault only cancels the
+  // click — it can never cancel the hover preview), so the fix is to disable
+  // the preview surface.
+  //
+  // put_IsStatusBarEnabled lives on the BASE ICoreWebView2Settings, so no
+  // version QI is needed. ConfigureWebView() is the single funnel for both
+  // creation paths (composition + windowed) and for the BUG-693 self-heal
+  // rebuild, so this one call covers every surface this window ever owns.
+  wil::com_ptr<ICoreWebView2Settings> settings;
+  HRESULT status_bar_hr = webview_->get_Settings(&settings);
+  if (SUCCEEDED(status_bar_hr) && settings != nullptr) {
+    status_bar_hr = settings->put_IsStatusBarEnabled(FALSE);
+  } else if (SUCCEEDED(status_bar_hr)) {
+    status_bar_hr = E_POINTER;  // get_Settings said OK but handed back null.
+  }
+  if (FAILED(status_bar_hr)) {
+    // Never swallow it: a failure here means the stray URL is back, and we do
+    // not want to re-investigate that from zero.
+    ReportOverlayError("put_IsStatusBarEnabled(FALSE) failed", status_bar_hr);
+  }
+
   // Inject the bridge adapter at document start so popup.js's
   // window.flutter_inappwebview.callHandler maps to chrome.webview.postMessage.
   std::wstring adapter = LoadAdapterScript();

--- a/hibiki/windows/runner/window_capture.cpp
+++ b/hibiki/windows/runner/window_capture.cpp
@@ -73,6 +73,38 @@ HRESULT GetActivationFactory(const wchar_t* class_name, I** out) {
                                 reinterpret_cast<void**>(out));
 }
 
+// BUG-1096：把一次「成功但值得记录」的事实追加进 diagnostics（多条以 "; " 相连）。
+// [hr] 为 S_OK 时不附 HRESULT（纯陈述），否则附十六进制码。
+void AppendDiagnostic(WindowCaptureResult* out, const char* note, HRESULT hr) {
+  if (out == nullptr || note == nullptr) {
+    return;
+  }
+  std::string line = note;
+  if (hr != S_OK) {
+    char hr_buf[16];
+    _snprintf_s(hr_buf, sizeof(hr_buf), _TRUNCATE, "0x%08lX",
+                static_cast<unsigned long>(hr));
+    line += " hr=";
+    line += hr_buf;
+  }
+  if (!out->diagnostics.empty()) {
+    out->diagnostics += "; ";
+  }
+  out->diagnostics += line;
+}
+
+// 读窗口标题（无标题返回空串）。
+std::wstring ReadWindowTitle(HWND hwnd) {
+  const int len = GetWindowTextLengthW(hwnd);
+  if (len <= 0) {
+    return std::wstring();
+  }
+  std::wstring title(static_cast<size_t>(len) + 1, L'\0');
+  const int got = GetWindowTextW(hwnd, title.data(), len + 1);
+  title.resize(got > 0 ? static_cast<size_t>(got) : 0);
+  return title;
+}
+
 struct EnumContext {
   HWND self;
   std::vector<ExternalWindow>* out;
@@ -95,21 +127,32 @@ BOOL CALLBACK EnumProc(HWND hwnd, LPARAM lparam) {
   if (ex_style & WS_EX_TOOLWINDOW) {
     return TRUE;
   }
-  const int len = GetWindowTextLengthW(hwnd);
-  if (len <= 0) {
-    return TRUE;
-  }
-  std::wstring title(static_cast<size_t>(len) + 1, L'\0');
-  const int got = GetWindowTextW(hwnd, title.data(), len + 1);
-  title.resize(got > 0 ? static_cast<size_t>(got) : 0);
+  std::wstring title = ReadWindowTitle(hwnd);
   if (title.empty()) {
     return TRUE;
   }
+  // BUG-1096：Magpie 缩放窗口在这里就换成它正在缩放的**源窗口**——否则用户选中的
+  // 是「游戏画面 + Magpie 补画的第二个光标」那一层，PID 也是 Magpie.exe 而不是游戏
+  // （voice hook 的注入目标同样会错）。拿不到属性时保持原窗口不变。
+  HWND target = hwnd;
+  if (const HWND source = ResolveScalingSourceWindow(hwnd)) {
+    target = source;
+    std::wstring source_title = ReadWindowTitle(source);
+    if (!source_title.empty()) {
+      title = std::move(source_title);
+    }
+  }
+  // 重定向后可能与单独枚举到的源窗口重合（Z 序谁先到都可能），按 hwnd 去重。
+  for (const ExternalWindow& existing : *ctx->out) {
+    if (existing.hwnd == target) {
+      return TRUE;
+    }
+  }
   ExternalWindow w;
-  w.hwnd = hwnd;
+  w.hwnd = target;
   w.title = WideToUtf8(title);
   // 所属进程 PID（供 galgame 引擎级 voice hook 注入目标；纯读，不改窗口）。
-  GetWindowThreadProcessId(hwnd, &w.pid);
+  GetWindowThreadProcessId(target, &w.pid);
   ctx->out->push_back(std::move(w));
   return TRUE;
 }
@@ -204,6 +247,25 @@ ComPtr<ID3D11Device> CreateD3DDevice() {
 }
 
 }  // namespace
+
+// BUG-1096：Magpie 缩放窗 -> 源窗口。判定契约是**窗口属性** `Magpie.SrcHWND`
+// （Magpie 在缩放窗上 SetProp 的公开标记），不是类名——类名里的 GUID 属于实现细节，
+// 属性名才是跨版本稳定的那一条。属性缺失 / 指向自身 / 句柄已失效都返回 nullptr，
+// 调用方原样保留传入窗口（Never break：没装 Magpie 的用户走的路径与以前逐字相同）。
+HWND ResolveScalingSourceWindow(HWND hwnd) {
+  if (hwnd == nullptr || !IsWindow(hwnd)) {
+    return nullptr;
+  }
+  const HANDLE prop = GetPropW(hwnd, L"Magpie.SrcHWND");
+  if (prop == nullptr) {
+    return nullptr;
+  }
+  HWND source = static_cast<HWND>(prop);
+  if (source == hwnd || !IsWindow(source)) {
+    return nullptr;
+  }
+  return source;
+}
 
 std::vector<ExternalWindow> EnumerateTopLevelWindows(HWND self) {
   std::vector<ExternalWindow> out;
@@ -307,10 +369,24 @@ void CaptureCore(HWND hwnd, WindowCaptureResult* out) {
     out->error = "capture session create failed";
     return;
   }
-  // 尽力关闭鼠标捕获与黄框（旧系统无对应接口时静默跳过，不影响捕获）。
+  // BUG-1096：关闭 WGC 合成光标。IGraphicsCaptureSession2 需要 Win10 build 19041+，
+  // 以前 QI 的失败和 put_ 的 HRESULT **两处都被静默丢掉**——「用户机器上到底关掉了
+  // 没有」是个彻底的盲区。现在两条路径都写进 diagnostics（经 channel 回到 Dart 日志），
+  // 成不成立变成可证的事实，而不是靠推断。注意：游戏**自绘**的光标是画面内容本身，
+  // 任何捕获 API 都剥不掉，这里只负责不再由 WGC 额外合成一个。
   ComPtr<WGC::IGraphicsCaptureSession2> session2;
-  if (SUCCEEDED(session.As(&session2))) {
-    session2->put_IsCursorCaptureEnabled(false);
+  const HRESULT cursor_qi = session.As(&session2);
+  if (SUCCEEDED(cursor_qi) && session2) {
+    const HRESULT cursor_hr = session2->put_IsCursorCaptureEnabled(false);
+    if (FAILED(cursor_hr)) {
+      AppendDiagnostic(out, "put_IsCursorCaptureEnabled(false) failed",
+                       cursor_hr);
+    }
+  } else {
+    AppendDiagnostic(out,
+                     "IGraphicsCaptureSession2 unavailable (needs Windows 10 "
+                     "build 19041+); WGC cursor NOT suppressed",
+                     SUCCEEDED(cursor_qi) ? E_POINTER : cursor_qi);
   }
   ComPtr<WGC::IGraphicsCaptureSession3> session3;
   if (SUCCEEDED(session.As(&session3))) {
@@ -427,6 +503,15 @@ WindowCaptureResult CaptureWindowPng(HWND hwnd) {
   if (hwnd == nullptr || !IsWindow(hwnd)) {
     out.error = "window handle invalid";
     return out;
+  }
+  // BUG-1096：捕获绑定前重定向。Dart 侧可能拿的是**上一次枚举缓存**的句柄，或者
+  // Magpie 是在选窗之后才起来的，所以枚举侧重定向不够，绑定这一步必须再过一次。
+  if (const HWND source = ResolveScalingSourceWindow(hwnd)) {
+    AppendDiagnostic(&out,
+                     "capture target redirected: Magpie scaling window -> "
+                     "source window (Magpie.SrcHWND)",
+                     S_OK);
+    hwnd = source;
   }
   const HRESULT ro = RoInitialize(RO_INIT_MULTITHREADED);
   // RPC_E_CHANGED_MODE = 本线程已按其它套间初始化；照常用、但不由我们反初始化。

--- a/hibiki/windows/runner/window_capture.h
+++ b/hibiki/windows/runner/window_capture.h
@@ -24,15 +24,31 @@ struct ExternalWindow {
 struct WindowCaptureResult {
   std::vector<uint8_t> png;
   std::string error;
+  // BUG-1096：**成功路径**上值得记录的事实，非空即有话说，空 = 一切如预期。
+  // 目前两类：① 光标合成抑制没能生效（IGraphicsCaptureSession2 缺失 / put_ 失败，
+  // 以前这两处 HRESULT 都被静默丢掉，用户机器上到底有没有关掉光标完全不可证）；
+  // ② 捕获目标被从 Magpie 缩放窗重定向到了真实源窗口。与 [error] 正交：有
+  // diagnostics 不代表失败，[ok] 不受它影响。
+  std::string diagnostics;
   bool ok = false;
 };
 
+// BUG-1096：把 Magpie（及同类缩放工具）的缩放窗口解析成它正在缩放的**源窗口**。
+// Magpie 的缩放窗口上挂着窗口属性 `Magpie.SrcHWND` 指向源窗口（类名形如
+// `Window_Magpie_<GUID>`，但属性名才是稳定契约，故只按属性判定）。Magpie 自己也
+// 关掉了 WGC 合成光标、再按 cursorScaling 把光标**画进**缩放输出，所以抓它的窗口
+// 必然得到「游戏自绘光标 + Magpie 补画的一个」= 两个指针。返回 nullptr 表示不是
+// 这种窗口（或属性指向的句柄已失效），调用方保持原窗口不变。绝不抛异常。
+HWND ResolveScalingSourceWindow(HWND hwnd);
+
 // 枚举可见、有标题、未 cloaked 的顶层窗口（排除自身 [self]，绝不截自己）。
-// 按 EnumWindows 的 Z 序返回。绝不抛异常。
+// 按 EnumWindows 的 Z 序返回；Magpie 缩放窗按 [ResolveScalingSourceWindow] 重定向到
+// 源窗口，并按 hwnd 去重（重定向后可能与单独枚举到的源窗口重合）。绝不抛异常。
 std::vector<ExternalWindow> EnumerateTopLevelWindows(HWND self);
 
 // 对 [hwnd] 抓一帧（Windows.Graphics.Capture）转 PNG 字节。任何失败（系统不支持 /
 // 窗口已关 / DRM 黑帧 / 超时 / D3D/WIC 失败）返回带非空 error、空 png 的结果。
+// BUG-1096：绑定前先过 [ResolveScalingSourceWindow]，命中 Magpie 缩放窗时改抓源窗口。
 // 同步运行在**调用线程**上（自建 WinRT MTA apartment，用完即退）；调用方应放到
 // 非 UI 线程调用（会阻塞等首帧，最长约 1.5s）。绝不抛异常。
 WindowCaptureResult CaptureWindowPng(HWND hwnd);


### PR DESCRIPTION
三条 Windows 端 runner 改动。**已真编译验证**：`flutter build windows --debug` 退出码 0，四个改动的编译单元均产出 obj，改动文件零警告。

## BUG-1095 台词浮窗拖高还是放不下
hook 模式字号 = `style_.font_size * clamp(窗高/140dip, 0.9, 2.5)`，而窗高唯一来源就是窗口 rect（`WM_SIZE → SyncStripSizeFromWindow`）——**「拖高窗口」和「放大台词」是同一个手势**，3.4 倍窗高只换来约 2 倍可见行数。字号根本没有独立真值，是窗高的派生量。

修复：hook 分支 `height_scale` 恒为 1.0，字号改由独立偏好 `galHookTextFontSize`（12..72，默认 30）驱动，加设置项。

**向后兼容**：旧公式在默认窗高 140dip 下正好 `clamp(140/140)=1.0`，所以默认 30 == 老用户没拖过窗时的实际字号，**逐像素不变**。拖过窗的用户字号回到 30、之后由设置项控制——这正是本 bug 要求的行为改变。窗口 rect 语义未变，无需迁移。

顺带把溢出从「头尾一起裁」改成「只裁句尾、顶端对齐」，保住阅读起点。

### 未做（明说）
溢出**仍然是硬裁、没有滚动**。分层 Direct2D 窗做滚动要自建滚动条 + 命中测试，是独立工程量。字号调太大 + 窗口太小仍会截断。

## BUG-1096 画面捕获出现两个鼠标
不是我们画的——全仓零 `gdigrab`/`-draw_mouse`/`DrawIcon`/DXGI 桌面复制，`put_IsCursorCaptureEnabled(false)` 早就在那。两个指针只能是捕获源画面里本来就有两个。两个成因都覆盖：

1. **捕获目标是 Magpie 缩放窗口**：Magpie 行为与我们对称——它也关掉 WGC 合成光标，然后自己按 cursorScaling 把光标画进缩放输出，于是它的窗口里 = 游戏自绘光标 + Magpie 补画的 = 两个。新增 `ResolveScalingSourceWindow()` 重定向到源窗口，判据用**窗口属性 `Magpie.SrcHWND`** 而非类名（GUID 类名是实现细节，属性名跨版本更稳）。
   **连带修复**：重定向同时修了 `listWindows()` 回传的 **PID**——原来会是 `Magpie.exe` 的 PID，意味着语音 hook 会**注入错进程**。这是原先未察觉的 bug。
2. **`put_IsCursorCaptureEnabled` 是否生效不可证**：`IGraphicsCaptureSession2` 需 Win10 19041+，而 QI 失败与 `put_` 的 HRESULT **两处都被静默吞掉**。新增 `AppendDiagnostic()` 把两者写入 `WindowCaptureResult::diagnostics`（与 `error` 正交），经 channel 回到 Dart 记日志。盲区打开。

游戏**自绘**光标是画面内容，任何捕获 API 都剥不掉——没修，也修不了。

## BUG-1097 左下角冒出 hibiki.popup URL
WebView2 的 status bar（链接地址预览）。URL 不是我们拼的，是 Yomitan 结构化内容把词典内链原样写进 href，`preventDefault` 只拦点击拦不住 hover。看着在「主窗口左下角」是因为覆盖窗是撑满整个级联包围盒的 topmost 无边框窗。

`ConfigureWebView()` 此前**全文零 `Settings` 调用**，`IsStatusBarEnabled` 一直是默认 TRUE。加 `get_Settings` + `put_IsStatusBarEnabled(FALSE)`，该函数是 composition/windowed 两条创建路径 + BUG-693 自愈重建的唯一漏斗。href 不动（BUG-842 家族划在范围外）。

## 一处设计约束导致的调整
设置项本想挂「制卡」分类，但该分类是 body-only 设计（`sections: const []` + `AnkiSettingsBody`），加 section 会打破既有不变式——那不是测试过时，是真实设计事实（制卡页 = Anki 配置）。改挂「查词」分类末尾、紧邻 texthooker，仅 Windows 可见。

## 验证
- `flutter analyze`（全量含 test）：No issues found!
- `flutter build windows --debug`：退出码 0
- 定向测试：201 passed

## 待真机验收（未做）
BUG-1096 没有装着 Magpie 的机器复跑原始路径，没看到 GIF 里真的只剩一个指针，也没看到 diagnostics 的实际取值——按 galgame SOP 只能算 `implemented_unverified`。BUG-1095/1097 缺肉眼复测（拖高看行数、hover 内链看左下角）。

https://claude.ai/code/session_018NeGjpee1gxFXaDTkaeoa4