### PR TITLE
feat(magpie): 阶段一 —— 自建 Magpie fork 产物的按需下载安装器 + 调研设计文档

### DIFF
--- a/docs/specs/2026-07-26-magpie-upscaling-design.md
+++ b/docs/specs/2026-07-26-magpie-upscaling-design.md
@@ -1,0 +1,311 @@
+# 内置 Magpie 超分：阶段一落地 + 关键调研结论
+
+- 日期：2026-07-26
+- 状态：**阶段一已实现**（自建 fork + 自编 release + 客户端安装器）；**阶段二（会话联动 / UI / 真机验证）未开始**
+- 需求原文（用户拍板，不再论证）：「我们自己编译吧，mpv，hook 等一样。方便修改。和 hook 一样启动游戏之前下载」
+- 上游：[Blinue/Magpie](https://github.com/Blinue/Magpie)，GPL-3.0，基线 `v0.12.1`（2025-08-27）
+- 我们的 fork：<https://github.com/hajisensai/Magpie>（public，分支 `dev`，fork 自上游 `e6167ef`）
+
+---
+
+## 0. 核心判断
+
+```text
+【核心判断】
+✅ 值得做，但**最重要的前提是错的**——继续做，方案要改。
+
+【关键洞察】
+- 数据结构：客户端侧只有一个核心状态——「exe 同级 magpie\ 目录的完整性 + 一枚
+  installed.sha256 装机标记」。下载/校验/换入/自更新全部围绕这一个标记展开，
+  与已验证的 galgame helper 安装器共用同一套原语，零第二实现。
+- 复杂度：**便携配置这块的复杂度可以归零**。原计划「预写 config.json 强制便携模式，
+  并按 CONFIG_VERSION 做 schema 兼容」是伪需求：Magpie 只看文件是否存在，不看内容；
+  而写一个 `{}` 反而会毁掉缩放（见 §3.2）。正确实现是**写一个 0 字节文件**。
+- 风险点：「浮窗夺焦会打断全屏缩放」这个立项前提**在 v0.12.1 上不成立**（见 §3.1）。
+  真正会踢掉缩放的是另一条路径——自动缩放的 50ms 前台轮询。
+```
+
+---
+
+## 1. 阶段一交付物
+
+### 1.1 我们自己的 Magpie fork 与自编产物
+
+| 项 | 事实 | 证据 |
+|---|---|---|
+| fork 仓库 | `hajisensai/Magpie`，public，默认分支 `dev` | `gh repo view hajisensai/Magpie` |
+| fork 基线 | 上游 `dev` 的 `e6167ef`（release 基线 `v0.12.1`） | `git log -1` on fork |
+| 我们的 commit | `ca6491c` ci: add Hibiki self-build release workflow + GPL fork attribution | fork `dev` |
+| 源码改动 | **`src/` 下零改动**；只加了 workflow + `HIBIKI-FORK.md` + README 顶部指针 | 同上 |
+| GPL 合规 | fork 为 public、上游 `LICENSE` 与版权声明未动、`HIBIKI-FORK.md` 记录基线 commit 与全部改动 | `HIBIKI-FORK.md` |
+
+### 1.2 Magpie 构建体系（权威来源 = 上游 CI 定义，非记忆）
+
+| 维度 | 事实 | 证据 |
+|---|---|---|
+| 构建入口 | `python scripts/publish.py`，内部调 `msbuild Magpie.slnx -m -t:Rebuild -restore` | `scripts/publish.py:62-64` |
+| 无 CMake / 无 build.ps1 | 顶层没有 CMake；CMake 只被 Conan 内部用来编依赖 | `src/_ConanDeps/_ConanDeps.vcxproj:117` |
+| CI runner | `windows-2025-vs2026`（**不是** windows-latest；GitHub 官方镜像，见 runner-images 的 `Windows2025-VS2026-Readme.md`） | `.github/workflows/build.yml`、`release.yml` |
+| 编译器 | 上游正式 release 只用 **ClangCL**；CI 日常构建 MSVC×ClangCL 各出 x64/ARM64 | `release.yml`（`--compiler=ClangCL`）、`build.yml` matrix |
+| 工具链 | VS2022 或 VS2026 + 「使用 C++ 的桌面开发」+「通用 UWP 开发」；Windows SDK **10.0.26100**；C++20；C++/WinRT 3.0；WinUI **2.8.7**（UWP XAML Islands，不是 WinAppSDK / 不是 C#） | `docs/编译指南.md:1-21`；`src/Magpie/Magpie.vcxproj:17-20`；`src/Magpie/packages.config` |
+| 依赖 | NuGet（packages.config 老式，靠 `-restore -p:RestorePackagesConfig=true`）+ **Conan**（fmt/spdlog/imgui/rapidjson… `--build=missing`）；**无 vcpkg、无 git submodule** | `src/Magpie/conanfile.txt`；无 `.gitmodules` |
+| .NET | **不需要**（全仓 0 个 `.csproj`） | — |
+| 产物目录 | `publish/<platform>/`（publish.py 用 `-p:OutDir` 覆盖默认 `bin/`） | `scripts/publish.py:63` |
+| 产物内容 | zip 根平铺：`Magpie.exe` / `Microsoft.UI.Xaml.dll` / `resources.pri` / `TouchHelper.exe` / `Updater.exe` + `effects/`（实测 x64 包 10,832,614 B，共 173 个条目） | 实测 `Magpie-v0.12.1-x64.zip` 解包清单 |
+| 上游校验和 | 只有 **MD5**，写在仓库 `version.json` 里给它自己的更新器用；**没有 sha256 侧车** | `scripts/release.py`；`src/Magpie/UpdateService.cpp` |
+| 构建耗时 | **无证据**。上游 workflow 无 `timeout-minutes`，文档也无耗时描述。定性上首次冷构建偏慢（`-t:Rebuild` 全量 + LTCG/LTO + Conan `--build=missing` 现编 9 个依赖 + C++/WinRT 代码生成 + XAML 编译），故上游 CI 专门缓存 `~/.conan2/p` | `.github/workflows/build.yml` 的 Conan cache 步 |
+
+### 1.3 我们的 release workflow
+
+`hajisensai/Magpie` 的 `.github/workflows/hibiki-release.yml`（上游 `release.yml` **未动**）：
+
+- 只 `workflow_dispatch`（照本仓 `.github/workflows/ffmpeg-min.yml` 的手动触发范式）。
+- 固定 tag **`magpie-hibiki`** 反复 upsert 同一 prerelease、非 Latest（照 `hibiki-hook` 的
+  `voice-hook-helper` 约定）。
+- 产物 `Magpie-hibiki-<platform>.zip` + **`.sha256` 侧车**，platform ∈ {x64, ARM64}。
+- 包内多塞一个 `hibiki-magpie.json`：`upstreamVersion` / `forkCommit` / `forkRepo` /
+  **`configVersion`（从 `src/Magpie/AppSettings.cpp` 现场 regex 提取，提不到直接让 job 失败）**
+  / `platform` / `builtAt`。这是客户端与 Magpie 私有实现之间唯一的契约面。
+- 发布前守卫：必需文件存在 + `effects/` 文件数 ≥ 100，否则 job 失败（防止发一个装了等于没装的包）。
+- **不签名**：签名需要 `secrets.MAGPIE_PFX_PASSWORD`，fork 没有；`publish.py` 只在传
+  `--pfx-path` 时才签名，省略即可。代价是 Magpie 的 TouchHelper UIAccess 注册不可用（Hibiki 不用触摸）。
+- 不传 `--version-*`：产物版本号为 `0.0.0`，即 Magpie 自己的「开发版」标识。**故意的** ——
+  自编二进制不应冒充某个官方版本号。
+
+> ⚠️ **产物文件名有意偏离用户原话**。用户要求 `Magpie-hibiki-<ver>-x64.zip`；实际发的是
+> `Magpie-hibiki-x64.zip`（无版本号）。理由：固定 tag 的价值就在于**直链永不变**，文件名一旦
+> 含版本号，每次升级客户端的硬编码 URL 就失效，等于退回「查 Release API」的老路。版本信息
+> 改放 release body + 包内 `hibiki-magpie.json`，可读性不减。这与 `voice_hook_<arch>.zip` 的
+> 既有约定也一致。
+
+### 1.4 客户端安装器 `hibiki/lib/src/mining/magpie_installer.dart`
+
+照 `galgame_helper_installer.dart`（857 行，已在生产验证）的结构新建，**复用而非复制**其纯工具
+（`galgameHelperCandidateUrls` / `parseSha256Sidecar` / `sha256Matches` /
+`galgameHelperSwapInstall` / `galgameHelperSweepStaleFiles`），只新增 Magpie 特有部分。
+
+对外接口：
+
+| 符号 | 语义 |
+|---|---|
+| `kMagpieRepo` / `kMagpieReleaseTag` / `kMagpieUpstreamVersion` | 固定仓库 / 固定 tag / 基线版本 |
+| `magpieZipName(arch)` / `magpieDownloadUrl(arch)` / `magpieSha256Url(arch)` | 稳定直链拼装（不查 Release API） |
+| `magpieArchForProcessorArchitecture(procArch, procArchW6432)` | 纯函数架构判定；认不出回落 x64 |
+| `magpieMissingFiles(present)` / `kMagpieRequiredRootFiles` / `kMagpieRequiredDirs` | 安装完整性清单 |
+| `magpieNeedsUpdate(localSha, remoteSha)` | 自更新判据（任一为 null 一律不更新） |
+| `magpiePortableConfigContent()` | 便携标记内容 = **空字符串**（见 §3.2） |
+| `MagpiePackageMetadata.parse(json)` | 包内元数据解析；坏数据一律 null，绝不抛 |
+| `magpieCanWritePortableConfig(metadata)` | configVersion 门；不一致 → 只装不配 |
+| `MagpieInstaller.installDirectory()` / `.executablePath()` / `.portableConfigPath()` | 落点（`Hibiki.exe` 同级 `magpie\`，免提权） |
+| `MagpieInstaller.isInstalled()` / `.missingInstalledEntries()` | 零网络零副作用的就绪查询 |
+| `MagpieInstaller().ensureInstalled({confirm, onProgress, arch})` → `MagpieInstallResult` | 交互路径主入口 |
+| `MagpieInstaller.updateInstalledMagpieInBackground()` | app 启动后台静默自更新 |
+
+设计要点（与 helper 安装器的差异都是有意的）：
+
+1. **不含任何 UI**。是否下载由调用方通过 `confirm` 回调决定，安装器不持有 `BuildContext`、
+   不引 i18n。阶段一因此**不新增任何 i18n key、不改 `strings.g.dart`**——这是三个并发代理
+   共享的最高冲突文件。
+2. **BUG-1076 的时序教训固化进类型**：`MagpieDownloadPrompt.sizeProbe` 是一个**已发起、
+   未 await** 的 Future，`ensureInstalled` 在调 `confirm` 之前绝不等它。已完整安装时零网络
+   直接返回。这两条有源码扫描守卫兜底。
+3. **换入式安装**：复用 `galgameHelperSwapInstall`——旧文件 rename 成 `.stale` 让位（被进程
+   映射的 DLL 在 Windows 上可改名不可覆盖），任一步失败逆序回滚。Magpie 正在运行时更新不会
+   留半版本残局。
+4. **降级不崩**：非 Windows → `unsupportedPlatform`；下载/校验/换入失败 → `failed`；后台
+   自更新任何异常静默吞掉。绝不影响 app 或游戏启动。
+
+### 1.5 测试
+
+`hibiki/test/mining/magpie_installer_test.dart`，**42 passed / 2 skipped**（跳过的两条是
+Windows 上不能跑真实安装路径的平台边界断言，在 Linux CI 上会真跑）。覆盖：架构判定（含
+ARM64-on-x64-emulation）、zip 名与 URL 拼装、镜像候选、完整性清单大小写、自更新判据、包元数据
+解析容错、便携标记的四种行为（写/不写/不覆盖/版本不符）、**解压目录结构 + zip-slip 防护
+（`../` 逃逸与绝对路径条目）**、staging 元数据读取、以及 4 条 BUG-1076 时序契约的源码守卫。
+
+---
+
+## 2. 与 Magpie 交互的既有契约（不需要 fork 就能用的部分）
+
+来源：上游 `docs/以编程方式与 Magpie 交互.md` 与源码交叉核对。
+
+- 广播消息 `RegisterWindowMessage(L"MagpieScalingChanged")`：
+  - `wParam=1` → 缩放开始，或源窗口回到前台；`lParam` = 缩放窗口句柄
+  - `wParam=0` → **两种情况靠 lParam 区分**：`lParam=0` 缩放真正结束（`WM_DESTROY`）；
+    `lParam=1` 只是源窗口转到后台，**缩放仍在跑**
+    （`src/Magpie.Core/ScalingWindow.cpp:1985-1990` 与 `:900-903`）
+  - `wParam=2` 窗口模式下位置/大小变化；`wParam=3` 用户开始拖动
+- 缩放窗口类名 `Window_Magpie_967EB565-6F73-4E94-AE53-00CC42592A22`；其上挂只读窗口属性
+  `Magpie.SrcHWND` / `Magpie.Windowed` / `Magpie.Src{Left,Top,Right,Bottom}` /
+  `Magpie.Dest{...}`（`ScalingWindow.cpp:1394-1417`）
+- 生命周期：注册消息 `WM_MAGPIE_SHOWME` / `WM_MAGPIE_QUIT`（**实际注册串就是这两个字面量**，
+  不是 `MagpieShowMe`）+ 单实例互斥体 `{4C416227-4A30-4A2F-8F23-8701544DD7D6}`
+  （`src/Shared/CommonSharedConstants.h:4,32-41`）
+- **Magpie 目前没有任何双向控制通道**：全仓 0 处 `CreateNamedPipe` / `WM_COPYDATA` /
+  共享内存 / socket。只有单向广播 + 只读窗口属性。
+
+---
+
+## 3. 三条调研结论（阶段二的输入，本轮不实现）
+
+### 3.1 「浮窗夺焦会打断全屏缩放」——**这个立项前提在 v0.12.1 上不成立**
+
+官方文档把「缩放结束」和「源窗口失焦」塞进了同一个 `wParam=0`，容易误读成失焦即退出。
+实际源码里这是两条完全不同的路径：
+
+- **非 3D 游戏模式（默认）**：源窗口失焦**不会**结束缩放。缩放线程每 2ms 轮询一次
+  （`src/Magpie.Core/ScalingRuntime.cpp:178-186`），`ScalingWindow::_UpdateSrcState()` 取
+  `GetForegroundWindow()`（`ScalingWindow.cpp:1286-1312`），`SrcTracker::UpdateState()` 只翻转
+  `_isFocused` 标志、**不返回 false**（`src/Magpie.Core/SrcTracker.cpp:199-202`）。后果仅两个：
+  ① 广播 `wParam=0, lParam=1`；② 缩放窗口取消置顶并把新前台窗口抬到最上
+  （`ScalingWindow.cpp:1978-1980`、`_CalcTopmostState()` @ `:1993-2006`）。
+- **3D 游戏模式**：唯一真正因失焦退出的分支在
+  `ScalingWindow::_CheckForegroundFor3DGameMode()`（`ScalingWindow.cpp:1369-1392`），返回 false
+  后走 `_DelayedStop()`（`:2143-2164`）→ `Stop()` → `Destroy()` → `WM_DESTROY`（`:869-904`）。
+  该函数**已有两级例外**：系统窗口硬编码白名单 `WindowHelper::IsForbiddenSystemWindow()`
+  （`src/Magpie.Core/WindowHelper.cpp:28-50`，判据是 `(exe 文件名小写, 窗口类名原样)` 二元组）
+  与「重叠面积 < 8px 放行」的容差。
+- Magpie 自己的缩放窗口不需要白名单：它用 `WS_EX_NOACTIVATE` + `WM_MOUSEACTIVATE` 返回
+  `MA_NOACTIVATE`（`ScalingWindow.cpp:666-670`），拿不到焦点。
+
+**改造可行性**（若阶段二实测确有问题）：
+
+| 方案 | 位置 | 规模 | 副作用 |
+|---|---|---|---|
+| A. 给 3D 模式加我们自己的窗口白名单 | `ScalingWindow.cpp:1369-1376` 函数开头加一条 `hwndFore == 我们的 hwnd`（或同 PID）即 `return true` | **~3 行** | 最小；不动 z-order / 光标语义 |
+| B. 不改代码，config 顶层 `"disableTopmost": true` | `AppSettings.cpp:596`(写)/`:795`(读)，消费点 `ScalingWindow.cpp:2002` | **0 行** | 缩放窗口永不置顶；但**源窗口自身置顶时仍无条件置顶**（`:1995-1997`），galgame 开了「窗口置顶」就救不了 |
+| C. 把我们的浮窗当作「源窗口仍聚焦」 | `SrcTracker.cpp:199` | ~1 行 + setter | **侵入最深**：光标黑边阻挡与坐标映射跟着变（`CursorManager.cpp:760-767`、`:1153`），鼠标移到浮窗上时坐标会错 |
+
+**真正的风险不在失焦，在别处**——UI 层有个 **50ms 前台轮询**，只要新前台窗口命中某个
+`autoScale != Disabled` 的 Profile，就会 `force=true` 重启缩放（先 `Stop()` 掉当前的）：
+`src/Magpie/ScalingService.cpp:42-45` + `:250-273`。
+→ **硬规则：绝不能给 Hibiki 自己的 exe 建 autoScale 的 Profile**，否则浮窗一弹就把 galgame
+的缩放踢掉。
+
+### 3.2 便携配置：**原计划的 schema 兼容是伪需求，而且写 `{}` 会毁掉缩放**
+
+- 便携判定只看文件是否存在，不看内容：
+  `AppSettings::Initialize()` @ `src/Magpie/AppSettings.cpp:203-216`
+  （`_isPortableMode = FileExists("config\config.json")`；CWD 在 `main.cpp:56` 已被设成 exe 目录）。
+  `CONFIG_VERSION = 4` @ `AppSettings.cpp:27`，且**版本号根本不写进 config.json**，只体现在
+  非便携模式的目录名 `%LOCALAPPDATA%\Magpie\config\v4\`（`AppSettings.cpp:1312`）。
+- 关键陷阱：默认 scalingModes **只在配置文件不存在或内容为空时**才灌入
+  （`AppSettings.cpp:218-245` 的两个分支各调一次 `_SetDefaultScalingModes()`）。若我们写一个
+  `{}`，Magpie 会认为这是「有效但没有 scalingModes 的配置」→ scalingModes 数组为空 →
+  所有 profile 的 `scalingMode` 索引被钳到 -1（`AppSettings.cpp:990-993`）→ 缩放报
+  `InvalidScalingMode`。
+- 正确实现：**写一个 0 字节的 `config\config.json`**。已核对 `Win32Helper::ReadTextFile`
+  （`src/Magpie.Core/Win32Helper.cpp:350-370`）对 0 字节文件返回 true + 空串，走
+  `configText.empty()` 分支灌默认值并回存。**一个 Magpie 私有字段都不用写**，schema 漂移风险归零。
+- `configVersion` 门（`magpieCanWritePortableConfig`）仍保留，但它守的**不是内容**，而是
+  「便携判定机制本身」：上游若哪天把标记挪走，configVersion 变化是最早的信号，此时退回
+  「只装不配」比装一个假的隔离诚实。
+
+**若阶段二真要预置一条 galgame 的自动缩放 Profile**，schema 事实（`src/Magpie/Profile.h:36-106`、
+写 `AppSettings.cpp:64-147`、读 `:926-1147`、匹配 `src/Magpie/ProfileService.cpp:214-251`）：
+
+- 顶层键是 **`profiles`**（不是 `scalingProfiles`），**数组第 0 项固定是默认/全局 Profile**。
+- `packaged`（**不是** `isPackaged`）、`pathRule`、`classNameRule`、`autoScale`
+  （**uint 枚举** 0=Disabled / 1=Fullscreen / 2=Windowed，**不是 bool**）、`launcherPath`、
+  `launchParameters`、`name`（`name` 为空的条目会被整条丢弃）。
+- `pathRule` 是 **完整路径且大小写敏感**（`ProfileService.cpp:246` 的 `std::wstring ==`，无
+  `_wcsicmp`、无路径规范化）；`packaged: true` 时 `pathRule` 存的是 AUMID 而非路径。
+- **没有 `scalingFlags` 这个 key**：它被拆成 `3DGameMode` / `captureTitleBar` /
+  `adjustCursorSpeed` / `disableDirectFlip` 四个 bool（`AppSettings.cpp:109-116`）。
+- `scalingMode` 是 **scalingModes 数组的索引（int）**，不是名字；写 profiles 就必须同时保证
+  scalingModes 存在，否则又踩回上面的 -1 陷阱。
+- → 结论：**不要手写 profiles**。正确做法是先让 Magpie 自己跑一次生成完整 config，阶段二再
+  在既有 config 上做增量修改（或走 §3.3 的 CLI 方案彻底绕开 config）。
+
+### 3.3 窗口化缩放（Windowed）在 v0.12 的能力与限制
+
+不是独立代码路径，是 `ScalingOptions.flags` 的 1 号 bit
+（`src/Magpie.Core/include/ScalingOptions.h:150,173`），**不存 Profile**，由触发方式决定
+（`ScalingService.cpp:369`）。
+
+能力：缩放窗口用 `WS_OVERLAPPED | WS_CAPTION | WS_THICKFRAME` 创建、owner 是源窗口
+（`ScalingWindow.cpp:220-233`），**双向联动**——拖缩放窗会同步移动源窗口（保持中心重合，
+`:2035-2047`），拖源窗口缩放窗跟随（`:1349-1363`），调整大小强制等比（`WM_SIZING` @ `:694-722`），
+记忆上次尺寸（`:1320-1324`）。
+
+限制（全部有 file:line）：
+
+| 限制 | 位置 |
+|---|---|
+| 3D 游戏模式**不支持**窗口化 | `ScalingWindow.cpp:80-86`；预检 `ScalingService.cpp:341-343` |
+| DesktopDuplication 捕获**不支持**窗口化 | `ScalingWindow.cpp:83-85` |
+| 源窗口已最大化 → 直接拒绝 | `ScalingWindow.cpp:109-116` |
+| `allowScalingMaximized` / `simulateExclusiveFullscreen` 被强制忽略 | `ScalingOptions.h:226-232` |
+| 缩放窗口必须比源窗口大 100 DIP | `ScalingWindow.cpp:19`（`WINDOWED_MODE_MIN_SPACE_AROUND`） |
+
+**对我们最要命的一条**：窗口模式下 `WM_WINDOWPOSCHANGED` 里有个 OS bug 兜底，会主动
+`_srcTracker.SetFocus()` 把焦点抢回源窗口（`ScalingWindow.cpp:816-823`，**仅窗口模式**）。
+→ 浮窗焦点会被抢走。**阶段二应优先用全屏模式，不要用窗口化缩放。**
+
+### 3.4 给 fork 加真正的 CLI / 控制面：改动面
+
+现状：`main.cpp:58-70` 用**整条命令行的字符串相等比较**识别参数，全仓无
+`CommandLineToArgvW` / argv / tokenizer。现有参数只有三个：`-r`（注册 TouchHelper）、
+`-ur`（反注册）、`-t`（静默启动不建主窗口，常量 `OPTION_LAUNCH_WITHOUT_WINDOW` @
+`CommonSharedConstants.h:32`，消费点 `App.cpp:188`）。进程模型是**单进程多线程**
+（缩放跑在 `ScalingRuntime` 起的独立线程，`ScalingRuntime.cpp:13`），UI 是 C++/WinRT +
+UWP XAML Islands + WinUI 2.8（**没有 C#，没有 WinUI 3**）。
+
+| 方案 | 规模 | 要动的锚点 |
+|---|---|---|
+| **A. 命令行参数**（推荐） | **~80–150 行** | `main.cpp:58-70` 换成真 tokenizer；`App::Initialize` 签名（`App.h:24`/`App.cpp:111`）；`App.cpp:188` 的 `-t` 判断同步改；`ScalingService.h:66-68` 的 private 缩放入口需要暴露 public（实现照抄 `ScalingService.cpp:295-303`）；`--scale-exe <path>` 还需自己枚举窗口做 path→HWND |
+| B. 新注册窗口消息（双向性价比最高） | **~20 行** | `App.cpp:53-61 InitMessages()` 加一条 `RegisterWindowMessage` + `ChangeWindowMessageFilter`，`App.cpp:211` 的消息循环加一个 `else if` |
+| C. 命名管道 | 比 A 贵一个数量级 | 零基础设施；需新起监听线程（不能阻塞 `App.cpp:209-219` 的裸 `GetMessage` 循环）+ 自己处理提权边界的 `SECURITY_ATTRIBUTES` |
+
+难点（会真卡住的）：
+
+1. **单实例会静默吞掉参数**：`App.cpp:117` 的 `_CheckSingleInstance()` 在最前，第二个实例带参数
+   启动时走 `App.cpp:342` 广播 SHOWME 后直接 `return false`，**参数丢失**。要支持「转发给已有
+   实例」必须在这里加转发；HWND 是整数可塞 wParam/lParam，字符串路径就得引入 `WM_COPYDATA`。
+2. **初始化时序硬约束**：任何触发缩放的动作必须晚于 `App.cpp:177` 的 `ScalingService::Initialize()`；
+   且 `App.cpp:151-155` 的 `IsAlwaysRunAsAdmin()` 会导致进程重启（`Restart()` @ `:242-256` 原样
+   透传参数），新指令必须能在重启路径上幸存。
+3. `-t` 静默启动时没有主窗口，`PostMessage(HWND_BROADCAST, ...)` 只投递顶层窗口；用户关掉托盘
+   图标后广播接收面就消失了 → 新协议建议自建常驻消息窗口。
+
+**判断**：既然 §3.1 说明失焦不是问题，阶段二应**先按官方广播契约做集成**（监听
+`MagpieScalingChanged`，`wParam==1` 时把浮窗置顶），零 fork 很可能就能跑通。CLI 是次选，
+只有在「必须由 Hibiki 精确控制何时对哪个 HWND 开始/停止缩放」被实测证明必要时才做。
+
+---
+
+## 4. 本轮**没做**的事（如实列出，不是遗漏是范围）
+
+1. **没有任何调用方**。`magpie_installer.dart` 目前无人调用，也没挂进 `main.dart` 的启动
+   后台任务（helper 的对应挂载点是 `hibiki/lib/main.dart:424`）。原因：本轮范围被限定为
+   「新增安装器模块」，且会话联动涉及的
+   `gal_hook_session_controller.dart` / `galgame_audio_source.dart` / `window_capture.cpp`
+   有另外两个并发代理在改，硬碰会冲突。→ 阶段二一并接上。
+2. **没有 UI、没有 i18n key、没有设置项**。确认下载的对话框留给调用方实现（`confirm` 回调）。
+   刻意避免动 `strings.g.dart`（17 语言生成文件，并发下最高冲突面）。
+3. **没有真机验证**。安装器的下载/换入/便携标记全链路**未在真实 Windows 环境跑过**：
+   本轮只跑了单测与源码守卫。真机验证（含「装完能不能真的把 galgame 窗口缩放起来」）属阶段二。
+4. **没有本机自编 Magpie**。本机是 VS 2022 **Build Tools** 17.14.3，缺 `Microsoft.VisualStudio.Workload.VCTools`
+   （`cl.exe` / `clang-cl.exe` 均不存在，实测 `Test-Path ...\VC\Tools\MSVC\14.44.35207\bin\Hostx64\x64\cl.exe`
+   → False）、缺 UWP 工作负载、缺 Conan。另有一个即使装齐也会撞的坑：`scripts/publish.py:41`
+   的 vswhere 调用**漏了 `-products *`**，Build Tools SKU 下返回空 → `:44` 的
+   `.splitlines()[0]` 直接 `IndexError`。→ **构建真相源是 GitHub Actions runner，不是本机。**
+5. **没有解决 Magpie 自带更新器指向上游的问题**。`src/Magpie/UpdateService.cpp:66-69` 硬编码
+   `raw.githubusercontent.com/Blinue/Magpie/{dev,main}/version.json`；用户若在我们的产物里开启
+   Magpie 自身的自动更新，会被拉回上游官方包（覆盖掉我们的 fork 产物）。已记入
+   `HIBIKI-FORK.md` 的 caveats，阶段二应考虑：① 便携 config 里关掉 `autoCheckForUpdates`
+   （key 在 `AppSettings.cpp:616`，默认 **true**），或 ② 直接在 fork 里改掉那两个 URL / 摘掉
+   `Updater.exe`。**注意方案 ① 又会撞回 §3.2 的「不能手写 config」陷阱**，实际上只能在 Magpie
+   首次生成 config 之后再改，或走方案 ②。
+
+---
+
+## 5. 阶段二建议顺序
+
+1. 真机拉一次 `magpie-hibiki` release，验证 `ensureInstalled` 全链路（下载→sha256→换入→
+   空 config.json→`Magpie.exe` 能起、便携模式生效、与用户自装的 Magpie 互不干扰）。
+2. 按官方广播契约做集成（监听 `MagpieScalingChanged`；`wParam==1` 时把 Hibiki 浮窗置顶），
+   **先不 fork 源码**，实测浮窗夺焦到底有没有问题（§3.1 预计没有）。
+3. 处理 Magpie 自更新指回上游（§4.5）。
+4. 决定缩放触发方式：热键模拟 / 预置 Profile（注意 §3.1 的 50ms 轮询硬规则）/ §3.4 的 CLI。
+5. 再补 UI（确认下载对话框 + 设置开关 + i18n key）与 `main.dart` 的后台自更新挂载。

--- a/hibiki/lib/src/mining/magpie_installer.dart
+++ b/hibiki/lib/src/mining/magpie_installer.dart
@@ -1,0 +1,662 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+
+// 与 galgame helper 安装器共用的**纯工具**（镜像候选 URL、sha256 侧车解析/比对、换入式
+// 安装与 .stale 清扫）。这些函数与 helper 语义无关，只是先在那里落地；此处 show 精确复用，
+// 避免第二份实现漂移。（后续若出现第三个按需下载组件，再抽到独立的下载安装模块。）
+import 'package:hibiki/src/mining/galgame_helper_installer.dart'
+    show
+        galgameHelperCandidateUrls,
+        galgameHelperSwapInstall,
+        galgameHelperSweepStaleFiles,
+        parseSha256Sidecar,
+        sha256Matches;
+import 'package:hibiki/src/utils/misc/resumable_downloader.dart';
+import 'package:hibiki/src/utils/misc/update_checker.dart'
+    show applyUpdateProxy;
+
+/// 我们自建的 Magpie fork 仓库 slug。上游是 `Blinue/Magpie`（GPL-3.0）；fork 出来自己编译，
+/// 为的是后续能改源码。fork 保持 public 且带完整源码与原 LICENSE —— 分发 GPL 二进制的
+/// 硬性合规条件。
+const String kMagpieRepo = 'hajisensai/Magpie';
+
+/// fork 上反复 upsert 的固定发布 tag。**不用 Release API 查最新**：固定 tag 直链稳定、
+/// 无 API 限流、离线可预测（与 galgame helper 的 `voice-hook-helper` 同范式）。
+const String kMagpieReleaseTag = 'magpie-hibiki';
+
+/// fork 的上游基线版本（仅用于展示与问题定位，不参与任何判定；是否需要更新一律以 sha256
+/// 侧车与本地装机标记比对为准）。
+const String kMagpieUpstreamVersion = 'v0.12.1';
+
+/// 本客户端**已验证过**的 Magpie 配置 schema 版本（上游 `src/Magpie/AppSettings.cpp` 的
+/// `CONFIG_VERSION`，v0.12.1 时为 4）。见 [magpieCanWritePortableConfig] 说明。
+const int kMagpieKnownConfigVersion = 4;
+
+/// 安装包内我们自己塞的元数据文件名（由 fork 的 release workflow 生成）。它是我们与 Magpie
+/// 私有实现之间唯一的契约面：带 upstreamVersion / forkCommit / configVersion。
+const String kMagpieMetadataName = 'hibiki-magpie.json';
+
+/// 便携模式标记文件的位置（相对安装目录）。Magpie 在 `AppSettings::Initialize()` 里
+/// **只判断 exe 同级 `config\config.json` 是否存在**来决定便携模式，不看内容。
+const String kMagpieConfigDirName = 'config';
+const String kMagpieConfigFileName = 'config.json';
+
+/// 安装目录名（落在 `Hibiki.exe` 同级）。
+const String kMagpieInstallDirName = 'magpie';
+
+/// 校验安装完整性用的根文件清单。**只列缩放真正必需的三个**：主程序、WinUI 运行时、资源
+/// 索引。上游包里另有 `TouchHelper.exe`（只服务触摸）与 `Updater.exe`（Magpie 自己的自更新
+/// 器，与我们的按需下载自更新职责冲突，fork 里随时可能剔除）—— 把它们列进必需清单只会在
+/// 我们精简产物时把客户端打红，故不列。
+const List<String> kMagpieRequiredRootFiles = <String>[
+  'Magpie.exe',
+  'Microsoft.UI.Xaml.dll',
+  'resources.pri',
+];
+
+/// 校验安装完整性用的必需子目录：缺 `effects` 就没有任何缩放算法可用，装了等于没装。
+const List<String> kMagpieRequiredDirs = <String>['effects'];
+
+/// 后台静默更新取 sha256 侧车的总预算。与 galgame helper 同理（BUG-1076）：更新只发生在
+/// app 启动后的后台，不抢任何交互路径，所以给「直连 + 5 镜像」逐个轮询留充分时间。
+const Duration kMagpieBackgroundShaTimeout = Duration(seconds: 90);
+
+/// 已装版本标记文件名：装成功后写入该 zip 的 sha256，下次启动与 release 侧车比对判断新版。
+String magpieMarkerName() => 'installed.sha256';
+
+/// 支持的产物架构。x64 是 Hibiki 桌面版自身的架构；ARM64 由 fork 的 CI 交叉编译产出，供
+/// ARM64 Windows 原生运行（Magpie 重度依赖 D3D11 捕获与着色器，原生切片才有意义）。
+const List<String> kMagpieArchs = <String>['x64', 'ARM64'];
+
+/// **纯函数**：由 Windows 的 `PROCESSOR_ARCHITECTURE` / `PROCESSOR_ARCHITEW6432` 环境变量
+/// 判定应下载哪个架构的包。ARM64 Windows 上以 x64 模拟运行的进程，其 `PROCESSOR_ARCHITECTURE`
+/// 报 AMD64，真实机器架构落在 `PROCESSOR_ARCHITEW6432` —— 两者任一为 ARM64 即取 ARM64。
+/// 判定不出来一律回落 x64（ARM64 上可模拟运行，属可用降级，绝不因认不出机器就装不上）。
+String magpieArchForProcessorArchitecture(
+  String? procArch,
+  String? procArchW6432,
+) {
+  bool isArm64(String? value) =>
+      value != null && value.trim().toUpperCase() == 'ARM64';
+  if (isArm64(procArchW6432) || isArm64(procArch)) return 'ARM64';
+  return 'x64';
+}
+
+/// 当前进程环境下应下载的架构。
+String magpieCurrentArch({Map<String, String>? environment}) {
+  final Map<String, String> env = environment ?? Platform.environment;
+  return magpieArchForProcessorArchitecture(
+    env['PROCESSOR_ARCHITECTURE'],
+    env['PROCESSOR_ARCHITEW6432'],
+  );
+}
+
+/// 某架构的分发 zip 文件名。**故意不含版本号**：固定 tag + 固定文件名才能给出稳定直链，
+/// 版本信息走 release body 与包内 [kMagpieMetadataName]。
+String magpieZipName(String arch) {
+  if (!kMagpieArchs.contains(arch)) {
+    throw ArgumentError.value(arch, 'arch', 'unsupported magpie arch');
+  }
+  return 'Magpie-hibiki-$arch.zip';
+}
+
+/// 某架构 zip 的稳定下载 URL（按固定 tag，不查 Release API）。
+String magpieDownloadUrl(
+  String arch, {
+  String repo = kMagpieRepo,
+  String tag = kMagpieReleaseTag,
+}) =>
+    'https://github.com/$repo/releases/download/$tag/${magpieZipName(arch)}';
+
+/// 某架构 zip 的 sha256 侧车 URL（下载后校验完整性 + 自更新比对基线）。
+///
+/// 注意：上游 Magpie 的官方发布只提供 **MD5**（写在仓库 `version.json` 里，给它自己的
+/// 更新器用），没有 sha256 侧车。这个侧车是我们 fork 的 release workflow 额外产出的。
+String magpieSha256Url(
+  String arch, {
+  String repo = kMagpieRepo,
+  String tag = kMagpieReleaseTag,
+}) =>
+    '${magpieDownloadUrl(arch, repo: repo, tag: tag)}.sha256';
+
+/// 返回缺少的必需根文件名；按 Windows 规则忽略大小写。
+List<String> magpieMissingFiles(Iterable<String> presentFiles) {
+  final Set<String> present =
+      presentFiles.map((String name) => name.toLowerCase()).toSet();
+  return kMagpieRequiredRootFiles
+      .where((String name) => !present.contains(name.toLowerCase()))
+      .toList(growable: false);
+}
+
+/// 是否需要自动更新：**仅当**本地有装机标记、远端侧车可取、且两者不等时才更新。任一为
+/// null（无标记 = 手动放置/旧装，或离线取不到远端）都返回 false —— 保守沿用现有。
+bool magpieNeedsUpdate(String? localSha, String? remoteSha) {
+  if (localSha == null || remoteSha == null) return false;
+  return !sha256Matches(localSha, remoteSha);
+}
+
+/// 便携模式标记文件的内容：**空字符串，故意的**。
+///
+/// Magpie 只用「exe 同级 `config\config.json` 是否存在」判定便携模式，不看内容；而读到
+/// 空文件时会走 `configText.empty()` 分支，自己灌入全套默认配置（含 7 个默认 scalingModes）
+/// 再回存。
+///
+/// 反过来，写一个看似无害的 `{}` 会被 Magpie 当成「有效但没有 scalingModes 的配置」——
+/// 于是 scalingModes 数组为空，所有 profile 的 `scalingMode` 索引被钳到 -1，缩放直接报
+/// `InvalidScalingMode`。**空文件才是对的**：它同时实现了「隔离」和「零 schema 猜测」，
+/// 我们一个 Magpie 私有字段都不用写。
+String magpiePortableConfigContent() => '';
+
+/// 安装包元数据（fork 的 release workflow 写进 zip 根的 [kMagpieMetadataName]）。
+@immutable
+class MagpiePackageMetadata {
+  const MagpiePackageMetadata({
+    required this.upstreamVersion,
+    required this.forkCommit,
+    required this.configVersion,
+  });
+
+  /// fork 基于的上游版本（如 `v0.12.1`）；缺失为空串。
+  final String upstreamVersion;
+
+  /// 构建所用 fork commit SHA；缺失为空串。
+  final String forkCommit;
+
+  /// 该产物源码里的 `CONFIG_VERSION`；解析不出为 null。
+  final int? configVersion;
+
+  /// 从元数据 JSON 文本解析；**任何异常都吞掉返回 null**（元数据是锦上添花，缺失或损坏
+  /// 只降级为「只装不配」，绝不让安装失败）。
+  static MagpiePackageMetadata? parse(String? content) {
+    if (content == null || content.trim().isEmpty) return null;
+    try {
+      final Object? decoded = jsonDecode(content);
+      if (decoded is! Map<String, dynamic>) return null;
+      final Object? version = decoded['configVersion'];
+      final Object? upstream = decoded['upstreamVersion'];
+      final Object? commit = decoded['forkCommit'];
+      return MagpiePackageMetadata(
+        upstreamVersion: upstream is String ? upstream : '',
+        forkCommit: commit is String ? commit : '',
+        configVersion: version is int
+            ? version
+            : (version is String ? int.tryParse(version) : null),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+/// 是否可以安全地写便携标记：**只有**包内元数据明确声明的 configVersion 与本客户端已验证
+/// 的 [kMagpieKnownConfigVersion] 一致时才写。
+///
+/// 我们写的是空文件、不含任何 Magpie 私有字段，所以这个门守的**不是内容**，而是「便携模式
+/// 的判定机制本身」：万一上游哪天把便携标记挪到 `config\v5\config.json` 之类，configVersion
+/// 的变化就是最早能观察到的信号，此时退回「只装不配」（Magpie 仍能装、能跑，只是配置落
+/// `%LOCALAPPDATA%`，与用户自己的 Magpie 共用）总比装一个假的隔离要诚实。
+bool magpieCanWritePortableConfig(MagpiePackageMetadata? metadata) =>
+    metadata?.configVersion == kMagpieKnownConfigVersion;
+
+/// 一次 [MagpieInstaller.ensureInstalled] 的结果。
+enum MagpieInstallResult {
+  /// 非 Windows：Magpie 是 Windows 独占（D3D11 + WinUI）。
+  unsupportedPlatform,
+
+  /// 本来就装好了（零网络、零 UI）。
+  alreadyInstalled,
+
+  /// 本轮下载安装成功。
+  installed,
+
+  /// 用户在确认回调里拒绝了下载。
+  declined,
+
+  /// 下载/校验/解压/换入任一步失败。调用方降级即可，绝不崩。
+  failed,
+}
+
+/// 传给确认回调的下载提示信息。
+///
+/// [sizeProbe] 是**已经发起、尚未等待**的大小探测 Future。`ensureInstalled` 在调用确认回调
+/// 之前不 await 它 —— 这是 BUG-1076 的教训固化进类型：确认 UI 必须立即出现，「约 N MB」由
+/// 回调自己在后台填。回调若选择直接 await 它，那是回调自己的决定。
+@immutable
+class MagpieDownloadPrompt {
+  const MagpieDownloadPrompt({required this.arch, required this.sizeProbe});
+
+  /// 将要下载的架构（`x64` / `ARM64`）。
+  final String arch;
+
+  /// 下载体积探测（字节）；探测失败或超时为 null。
+  final Future<int?> sizeProbe;
+}
+
+/// Magpie（窗口超分）的按需下载安装器。
+///
+/// 与 galgame helper 安装器同范式：固定 tag 稳定直链 + 镜像回退 + sha256 侧车校验 + Range
+/// 续传 + staging 校验 + 换入式安装（旧文件 rename 让位）+ 装机标记驱动的后台静默自更新。
+/// 落点是 `Hibiki.exe` 同级的 `magpie\`（安装器 `PrivilegesRequired=lowest`，此目录用户
+/// 可写、免提权）。
+///
+/// 本类**不含任何 UI**：是否下载由调用方通过 [ensureInstalled] 的 `confirm` 回调决定。这样
+/// 安装器不持有 i18n / BuildContext，消费侧（阶段二的会话联动与设置项）可以自由决定用对话框、
+/// 开关还是静默策略。
+class MagpieInstaller {
+  MagpieInstaller();
+
+  bool _canceled = false;
+  HttpClient? _client;
+
+  /// 换入是唯一与「读取安装目录」竞态的写窗口（亚秒级本地文件操作），全部串到这条门上；
+  /// 下载/解压只碰临时目录，无需互斥。
+  static Future<void> _installGate = Future<void>.value();
+
+  static Future<T> _serializeInstall<T>(Future<T> Function() job) {
+    final Future<T> run = _installGate.then((_) => job());
+    _installGate = run.then<void>((_) {}, onError: (Object _) {});
+    return run;
+  }
+
+  /// 用户主动取消下载：置位并强制关闭在途 client 中断请求。
+  void cancel() {
+    _canceled = true;
+    _client?.close(force: true);
+  }
+
+  /// `Hibiki.exe` 同级的 `magpie\` 安装目录。
+  static Directory installDirectory() {
+    final String exeDir = File(Platform.resolvedExecutable).parent.path;
+    return Directory(p.join(exeDir, kMagpieInstallDirName));
+  }
+
+  /// 已安装的 `Magpie.exe` 绝对路径（不保证存在；调用方自己判 existsSync）。
+  static String executablePath() =>
+      p.join(installDirectory().path, 'Magpie.exe');
+
+  /// 便携标记文件路径 `<install>\config\config.json`。
+  static String portableConfigPath() => p.join(
+        installDirectory().path,
+        kMagpieConfigDirName,
+        kMagpieConfigFileName,
+      );
+
+  static File _markerFile() =>
+      File(p.join(installDirectory().path, magpieMarkerName()));
+
+  /// 安装目录当前缺什么（必需根文件 + 必需子目录）。返回空表示安装完整。
+  static List<String> missingInstalledEntries() {
+    final Directory dir = installDirectory();
+    if (!dir.existsSync()) {
+      return <String>[...kMagpieRequiredRootFiles, ...kMagpieRequiredDirs];
+    }
+    final Iterable<String> rootFiles = dir
+        .listSync(followLinks: false)
+        .whereType<File>()
+        .map((File file) => p.basename(file.path));
+    final List<String> missing = <String>[...magpieMissingFiles(rootFiles)];
+    for (final String required in kMagpieRequiredDirs) {
+      final Directory sub = Directory(p.join(dir.path, required));
+      final bool ok = sub.existsSync() &&
+          sub.listSync(followLinks: false).whereType<File>().isNotEmpty;
+      if (!ok) missing.add(required);
+    }
+    return missing;
+  }
+
+  /// 是否已完整安装（零网络、零副作用；调用方可随手问）。
+  static bool isInstalled() => missingInstalledEntries().isEmpty;
+
+  /// 确保 Magpie 就位。
+  ///
+  /// - 非 Windows → [MagpieInstallResult.unsupportedPlatform]；
+  /// - 已完整安装 → [MagpieInstallResult.alreadyInstalled]（**零网络探测**，自更新一律在
+  ///   app 启动后台，见 [updateInstalledMagpieInBackground]，BUG-1076 的教训）；
+  /// - 残缺安装 → 直接用当前发布包修复，不再打扰用户（用户此前已同意过下载）；
+  /// - 未安装 → 立即调 [confirm]（不等大小探测），同意后下载+校验+换入+复检。
+  Future<MagpieInstallResult> ensureInstalled({
+    required Future<bool> Function(MagpieDownloadPrompt prompt) confirm,
+    ResumableDownloadProgress? onProgress,
+    String? arch,
+  }) async {
+    if (!Platform.isWindows) return MagpieInstallResult.unsupportedPlatform;
+    final String targetArch = arch ?? magpieCurrentArch();
+    // 等在途换入落定再检查文件，绝不读到半换入状态；平时门是已完成 future，零开销。
+    await _installGate;
+
+    final bool hadInstall = installDirectory().existsSync();
+    if (missingInstalledEntries().isEmpty) {
+      return MagpieInstallResult.alreadyInstalled;
+    }
+
+    if (!hadInstall) {
+      // 确认回调**立即**调用，绝不为 best-effort 的大小探测阻塞（旧 helper 实现先 await
+      // HEAD 探测再弹框，弱网下点了没反应，是 BUG-1076 的表征之一）。
+      final Future<int?> sizeProbe = _probeSize(targetArch);
+      // 回调若不 await 它，也不能让它变成未处理异常。
+      unawaited(sizeProbe.catchError((Object _) => null));
+      final bool ok = await confirm(
+        MagpieDownloadPrompt(arch: targetArch, sizeProbe: sizeProbe),
+      );
+      if (!ok) return MagpieInstallResult.declined;
+    }
+
+    try {
+      await _runInstall(arch: targetArch, onProgress: onProgress);
+    } catch (_) {
+      return MagpieInstallResult.failed;
+    }
+    return missingInstalledEntries().isEmpty
+        ? MagpieInstallResult.installed
+        : MagpieInstallResult.failed;
+  }
+
+  /// app 启动后的后台静默自更新（无 UI、无 toast）。只做「已装 → 最新」：未安装/无标记/
+  /// 残缺一律不动（首装与修复属于交互路径）。任一步失败静默放弃，下次启动再试。
+  static Future<void> updateInstalledMagpieInBackground() async {
+    if (!Platform.isWindows) return;
+    try {
+      await MagpieInstaller()._updateSilently();
+    } catch (_) {
+      // 后台更新是锦上添花：绝不影响 app 启动。
+    }
+  }
+
+  Future<void> _updateSilently() async {
+    galgameHelperSweepStaleFiles(installDirectory());
+    final File marker = _markerFile();
+    if (!marker.existsSync()) return; // 手动放置/旧装：保守沿用现有
+    if (missingInstalledEntries().isNotEmpty) return; // 残缺留给交互修复路径
+    final String localSha = (await marker.readAsString()).trim();
+    final String arch = magpieCurrentArch();
+
+    final HttpClient client = HttpClient();
+    client.connectionTimeout = const Duration(seconds: 30);
+    client.idleTimeout = const Duration(seconds: 60);
+    await applyUpdateProxy(client);
+    _client = client;
+    try {
+      final String? remoteSha = await _fetchSha256(client, arch).timeout(
+        kMagpieBackgroundShaTimeout,
+        onTimeout: () => null,
+      );
+      if (!magpieNeedsUpdate(localSha, remoteSha)) return;
+      await _installCore(client: client, arch: arch, expectedSha: remoteSha);
+    } finally {
+      client.close(force: true);
+      _client = null;
+    }
+  }
+
+  /// 交互路径的一次完整安装（自带 client 生命周期）。
+  Future<void> _runInstall({
+    required String arch,
+    ResumableDownloadProgress? onProgress,
+  }) async {
+    final HttpClient client = HttpClient();
+    client.connectionTimeout = const Duration(seconds: 15);
+    client.idleTimeout = const Duration(seconds: 60);
+    await applyUpdateProxy(client); // 中国大陆直连 GitHub 常失败
+    _client = client;
+    try {
+      await _installCore(client: client, arch: arch, onProgress: onProgress);
+    } finally {
+      client.close(force: true);
+      _client = null;
+    }
+  }
+
+  /// UI 无关的安装核心（交互路径与后台静默路径共用）：取 sha256 侧车 → 下载 zip（镜像回退
+  /// + Range 续传 + sha256 校验）→ 解压到 staging 并校验清单 → 换入 → 复检 → 写装机标记
+  /// → best-effort 写便携标记。任一步失败抛异常，由调用方决定提示或静默。
+  Future<void> _installCore({
+    required HttpClient client,
+    required String arch,
+    String? expectedSha,
+    ResumableDownloadProgress? onProgress,
+  }) async {
+    expectedSha ??= await _fetchSha256(client, arch);
+
+    final File dest = File(
+        p.join(Directory.systemTemp.path, 'hibiki_${magpieZipName(arch)}'));
+    final File part = File('${dest.path}.part');
+    final File zip = await _downloadZip(
+      client: client,
+      arch: arch,
+      dest: dest,
+      part: part,
+      expectedSha256: expectedSha,
+      onProgress: onProgress ?? (int _, int? __) {},
+    );
+
+    final Directory staging =
+        await Directory.systemTemp.createTemp('hibiki_magpie_staging_');
+    try {
+      final Set<String> rootFiles = await _extractZip(zip, staging);
+      final List<String> missingFromPackage = magpieMissingFiles(rootFiles);
+      if (missingFromPackage.isNotEmpty) {
+        throw StateError(
+          'magpie package incomplete ($arch): '
+          'missing ${missingFromPackage.join(', ')}',
+        );
+      }
+
+      // 元数据必须在换入**之前**从 staging 读——换入会把 staging 里的文件搬空。
+      final MagpiePackageMetadata? metadata = await readStagedMetadata(staging);
+
+      await _serializeInstall(() => galgameHelperSwapInstall(
+            staging: staging,
+            target: installDirectory(),
+          ));
+
+      final List<String> missingAfter = missingInstalledEntries();
+      if (missingAfter.isNotEmpty) {
+        throw StateError(
+          'magpie install incomplete ($arch): '
+          'missing ${missingAfter.join(', ')}',
+        );
+      }
+
+      if (expectedSha != null) {
+        try {
+          await _markerFile().writeAsString(expectedSha, flush: true);
+        } catch (_) {}
+      }
+
+      await ensurePortableConfig(metadata: metadata);
+
+      try {
+        if (await zip.exists()) await zip.delete();
+        if (await part.exists()) await part.delete();
+      } catch (_) {}
+    } finally {
+      try {
+        if (staging.existsSync()) staging.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  }
+
+  /// 从 staging 读安装包元数据；缺失/损坏返回 null。
+  @visibleForTesting
+  Future<MagpiePackageMetadata?> readStagedMetadata(Directory staging) async {
+    final File file = File(p.join(staging.path, kMagpieMetadataName));
+    if (!file.existsSync()) return null;
+    try {
+      return MagpiePackageMetadata.parse(await file.readAsString());
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// **best-effort** 写便携模式标记（空的 `config\config.json`，见
+  /// [magpiePortableConfigContent]）：
+  /// - 已存在 config.json → 一律不动（Magpie 跑过之后会把真实配置写进去，覆盖等于毁配置）；
+  /// - 元数据缺失 / configVersion 与 [kMagpieKnownConfigVersion] 不一致 → 「只装不配」，
+  ///   返回 false；
+  /// - 写失败 → 吞掉返回 false。安装本身不因为标记写不成而失败。
+  ///
+  /// 返回是否真的写了标记。[installDir] 仅测试注入用。
+  Future<bool> ensurePortableConfig({
+    required MagpiePackageMetadata? metadata,
+    Directory? installDir,
+  }) async {
+    if (!magpieCanWritePortableConfig(metadata)) return false;
+    try {
+      final Directory root = installDir ?? installDirectory();
+      final File config = File(
+        p.join(root.path, kMagpieConfigDirName, kMagpieConfigFileName),
+      );
+      if (config.existsSync()) return false;
+      await config.parent.create(recursive: true);
+      await config.writeAsString(magpiePortableConfigContent(), flush: true);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// 逐镜像候选下载 zip；全部失败则抛最后一个异常。
+  Future<File> _downloadZip({
+    required HttpClient client,
+    required String arch,
+    required File dest,
+    required File part,
+    required String? expectedSha256,
+    required ResumableDownloadProgress onProgress,
+  }) async {
+    final List<String> candidates =
+        galgameHelperCandidateUrls(magpieDownloadUrl(arch));
+    Object? lastError;
+    for (final String url in candidates) {
+      if (_canceled) throw StateError('canceled');
+      try {
+        return await ResumableDownloader(
+          url: url,
+          destination: dest,
+          partFile: part,
+          open: _open(client),
+          expectedSha256: expectedSha256,
+          onProgress: onProgress,
+          firstByteTimeout: const Duration(seconds: 20),
+        ).download();
+      } catch (e) {
+        lastError = e;
+        if (_canceled) rethrow;
+        // 换镜像前清掉可能不一致的 part（不同镜像 body 不可续）。
+        try {
+          if (await part.exists()) await part.delete();
+        } catch (_) {}
+      }
+    }
+    throw Exception(lastError?.toString() ?? 'no download candidate');
+  }
+
+  /// 取 sha256 侧车文本并解析出摘要；任何失败返回 null（降级为不校验 sha256）。
+  Future<String?> _fetchSha256(HttpClient client, String arch) async {
+    final List<String> candidates =
+        galgameHelperCandidateUrls(magpieSha256Url(arch));
+    for (final String url in candidates) {
+      if (_canceled) return null;
+      try {
+        final HttpClientRequest req = await client.getUrl(Uri.parse(url));
+        final HttpClientResponse resp = await req.close();
+        if (resp.statusCode != 200) {
+          await resp.drain<void>();
+          continue;
+        }
+        final String body =
+            await resp.transform(const SystemEncoding().decoder).join();
+        final String? sha = parseSha256Sidecar(body);
+        if (sha != null) return sha;
+      } catch (_) {
+        // 试下一个镜像
+      }
+    }
+    return null;
+  }
+
+  /// 探测 zip 大小（Content-Length）：逐镜像发 HEAD。全失败返回 null。
+  Future<int?> _probeSize(String arch) async {
+    final HttpClient client = HttpClient();
+    client.connectionTimeout = const Duration(seconds: 10);
+    await applyUpdateProxy(client);
+    try {
+      for (final String url
+          in galgameHelperCandidateUrls(magpieDownloadUrl(arch))) {
+        if (_canceled) return null;
+        try {
+          final HttpClientRequest req =
+              await client.openUrl('HEAD', Uri.parse(url));
+          req.followRedirects = true;
+          final HttpClientResponse resp = await req.close();
+          await resp.drain<void>();
+          if (resp.statusCode == 200 && resp.contentLength > 0) {
+            return resp.contentLength;
+          }
+        } catch (_) {
+          // 试下一个镜像
+        }
+      }
+      return null;
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  /// ResumableDownloader 的 open 回调：带代理的 GET（自动跟随 GitHub→S3 重定向）。
+  ResumableDownloadOpen _open(HttpClient client) {
+    return (Uri uri, Map<String, String> headers) async {
+      final HttpClientRequest req = await client.getUrl(uri);
+      req.followRedirects = true;
+      headers.forEach(req.headers.set);
+      final HttpClientResponse resp = await req.close();
+      final Map<String, String> respHeaders = <String, String>{};
+      resp.headers.forEach((String name, List<String> values) {
+        respHeaders[name] = values.join(',');
+      });
+      return ResumableDownloadResponse(
+        statusCode: resp.statusCode,
+        headers: respHeaders,
+        stream: resp,
+      );
+    };
+  }
+
+  /// 解压 zip 到 [targetDir]（staging 临时目录，**不**直接写安装目录），返回 zip 根层的
+  /// 文件名集合。用 archive 包 ZipDecoder；写字节取 `entry.content`（archive 3.6.1 下
+  /// `ArchiveFile.decompress(out)` 会写 0 字节）。只写常规文件、保留相对目录结构，并拒绝
+  /// 绝对路径或逃出目标目录的条目以防 zip-slip。
+  @visibleForTesting
+  Future<Set<String>> extractZip(File zip, Directory targetDir) =>
+      _extractZip(zip, targetDir);
+
+  Future<Set<String>> _extractZip(File zip, Directory targetDir) async {
+    await targetDir.create(recursive: true);
+    final Uint8List bytes = await zip.readAsBytes();
+    final Archive archive = ZipDecoder().decodeBytes(bytes);
+    final String targetRoot = p.normalize(targetDir.absolute.path);
+    final Set<String> rootFiles = <String>{};
+    for (final ArchiveFile entry in archive) {
+      if (!entry.isFile) continue;
+      final String relativePath =
+          entry.name.replaceAll('/', p.separator).replaceAll('\\', p.separator);
+      if (relativePath.isEmpty || p.isAbsolute(relativePath)) continue;
+      final String outputPath = p.normalize(p.join(targetRoot, relativePath));
+      if (!p.isWithin(targetRoot, outputPath)) continue;
+      final Object? content = entry.content;
+      if (content is! List<int>) continue;
+      final File out = File(outputPath);
+      await out.parent.create(recursive: true);
+      await out.writeAsBytes(content, flush: true);
+      if (p.dirname(relativePath) == '.') {
+        rootFiles.add(p.basename(relativePath));
+      }
+    }
+    return rootFiles;
+  }
+}

--- a/hibiki/lib/src/mining/magpie_installer.dart
+++ b/hibiki/lib/src/mining/magpie_installer.dart
@@ -173,9 +173,16 @@ class MagpiePackageMetadata {
   /// 从元数据 JSON 文本解析；**任何异常都吞掉返回 null**（元数据是锦上添花，缺失或损坏
   /// 只降级为「只装不配」，绝不让安装失败）。
   static MagpiePackageMetadata? parse(String? content) {
-    if (content == null || content.trim().isEmpty) return null;
+    if (content == null) return null;
+    // 剥掉可能的 UTF-8 BOM：Dart 的 utf8 解码不会吃掉 U+FEFF，而 jsonDecode 见到它就抛
+    // FormatException —— 那会被下面的 catch 静默吞成 null，表现为「明明发了元数据却永远
+    // 只装不配」。当前 workflow 用 pwsh 7 写出的是无 BOM UTF-8（已实测），但写入端一旦
+    // 换成 Windows PowerShell 5.1 就会带 BOM，这里挡住这类静默降级。
+    final String text =
+        content.startsWith('﻿') ? content.substring(1) : content;
+    if (text.trim().isEmpty) return null;
     try {
-      final Object? decoded = jsonDecode(content);
+      final Object? decoded = jsonDecode(text);
       if (decoded is! Map<String, dynamic>) return null;
       final Object? version = decoded['configVersion'];
       final Object? upstream = decoded['upstreamVersion'];

--- a/hibiki/test/mining/magpie_installer_test.dart
+++ b/hibiki/test/mining/magpie_installer_test.dart
@@ -1,0 +1,471 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/galgame_helper_installer.dart'
+    show galgameHelperCandidateUrls, kGalgameHelperProxyPrefixes;
+import 'package:hibiki/src/mining/magpie_installer.dart';
+import 'package:path/path.dart' as p;
+
+/// 造一个内存 zip：`entries` 是 `zip 内相对路径 -> 内容字节`。
+List<int> _buildZip(Map<String, List<int>> entries) {
+  final Archive archive = Archive();
+  entries.forEach((String name, List<int> bytes) {
+    archive.addFile(ArchiveFile(name, bytes.length, bytes));
+  });
+  return ZipEncoder().encode(archive)!;
+}
+
+void main() {
+  group('架构判定', () {
+    test('PROCESSOR_ARCHITEW6432=ARM64（x64 模拟进程）→ ARM64', () {
+      expect(magpieArchForProcessorArchitecture('AMD64', 'ARM64'), 'ARM64');
+    });
+
+    test('PROCESSOR_ARCHITECTURE=ARM64（原生 ARM64 进程）→ ARM64', () {
+      expect(magpieArchForProcessorArchitecture('ARM64', null), 'ARM64');
+    });
+
+    test('大小写/空白无关', () {
+      expect(magpieArchForProcessorArchitecture(' arm64 ', null), 'ARM64');
+    });
+
+    test('普通 x64 机器 → x64', () {
+      expect(magpieArchForProcessorArchitecture('AMD64', null), 'x64');
+    });
+
+    test('认不出来（全空）→ 回落 x64，绝不因此装不上', () {
+      expect(magpieArchForProcessorArchitecture(null, null), 'x64');
+      expect(magpieArchForProcessorArchitecture('', ''), 'x64');
+    });
+
+    test('magpieCurrentArch 可注入环境', () {
+      expect(
+        magpieCurrentArch(
+            environment: <String, String>{'PROCESSOR_ARCHITEW6432': 'ARM64'}),
+        'ARM64',
+      );
+      expect(magpieCurrentArch(environment: <String, String>{}), 'x64');
+    });
+  });
+
+  group('zip 名与 URL 拼装', () {
+    test('zip 名不含版本号（固定 tag 直链必须稳定）', () {
+      expect(magpieZipName('x64'), 'Magpie-hibiki-x64.zip');
+      expect(magpieZipName('ARM64'), 'Magpie-hibiki-ARM64.zip');
+      expect(magpieZipName('x64'), isNot(contains(kMagpieUpstreamVersion)));
+    });
+
+    test('未知架构被拒', () {
+      expect(() => magpieZipName('x86'), throwsArgumentError);
+      expect(() => magpieZipName('arm64'), throwsArgumentError); // 大小写敏感
+    });
+
+    test('下载 URL 按固定 tag 拼接（非 run 号、非 Release API）', () {
+      final String url = magpieDownloadUrl('x64');
+      expect(url, contains('/releases/download/'));
+      expect(url, contains('/$kMagpieReleaseTag/'));
+      expect(url, endsWith('/Magpie-hibiki-x64.zip'));
+      expect(url, isNot(contains('api.github.com')));
+    });
+
+    test('默认走我们自建的 fork 仓库（非上游 Blinue/Magpie）', () {
+      expect(kMagpieRepo, 'hajisensai/Magpie');
+      expect(magpieDownloadUrl('x64'),
+          startsWith('https://github.com/hajisensai/Magpie/'));
+      expect(magpieDownloadUrl('x64'), isNot(contains('Blinue')));
+    });
+
+    test('sha256 侧车 URL = zip URL + .sha256', () {
+      expect(magpieSha256Url('ARM64'), '${magpieDownloadUrl('ARM64')}.sha256');
+    });
+
+    test('自定义 repo/tag 可注入', () {
+      expect(
+        magpieDownloadUrl('x64', repo: 'foo/bar', tag: 'zzz'),
+        'https://github.com/foo/bar/releases/download/zzz/Magpie-hibiki-x64.zip',
+      );
+    });
+
+    test('镜像候选：直连恒首位，随后每个镜像前缀套一份，无重复', () {
+      final List<String> urls =
+          galgameHelperCandidateUrls(magpieDownloadUrl('x64'));
+      expect(urls.first, magpieDownloadUrl('x64'));
+      expect(urls.length, 1 + kGalgameHelperProxyPrefixes.length);
+      expect(urls.toSet().length, urls.length);
+    });
+  });
+
+  group('安装完整性清单', () {
+    test('必需根文件只含缩放真正需要的三个（不含 TouchHelper/Updater）', () {
+      expect(
+        kMagpieRequiredRootFiles,
+        containsAll(
+            <String>['Magpie.exe', 'Microsoft.UI.Xaml.dll', 'resources.pri']),
+      );
+      expect(kMagpieRequiredRootFiles, isNot(contains('TouchHelper.exe')));
+      expect(kMagpieRequiredRootFiles, isNot(contains('Updater.exe')));
+    });
+
+    test('effects 目录是必需的（缺了等于没装）', () {
+      expect(kMagpieRequiredDirs, contains('effects'));
+    });
+
+    test('缺文件检测忽略大小写', () {
+      expect(
+        magpieMissingFiles(<String>[
+          'magpie.EXE',
+          'microsoft.ui.xaml.DLL',
+          'RESOURCES.PRI',
+        ]),
+        isEmpty,
+      );
+    });
+
+    test('缺哪个报哪个', () {
+      expect(
+        magpieMissingFiles(<String>['Magpie.exe', 'resources.pri']),
+        <String>['Microsoft.UI.Xaml.dll'],
+      );
+    });
+  });
+
+  group('自动更新判据', () {
+    const String shaA =
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+    const String shaB =
+        'da39a3ee5e6b4b0d3255bfef95601890afd80709da39a3ee5e6b4b0d32551234';
+
+    test('标记文件名稳定', () {
+      expect(magpieMarkerName(), 'installed.sha256');
+    });
+
+    test('本地与远端 sha 不同 → 需要更新', () {
+      expect(magpieNeedsUpdate(shaA, shaB), isTrue);
+    });
+
+    test('相同（大小写/空白无关）→ 不更新', () {
+      expect(magpieNeedsUpdate(shaA, ' ${shaA.toUpperCase()} '), isFalse);
+    });
+
+    test('无本地标记（手动放置/旧装）→ 不自动更新（保守）', () {
+      expect(magpieNeedsUpdate(null, shaB), isFalse);
+    });
+
+    test('远端取不到（离线）→ 不更新（不阻塞启动）', () {
+      expect(magpieNeedsUpdate(shaA, null), isFalse);
+      expect(magpieNeedsUpdate(null, null), isFalse);
+    });
+  });
+
+  group('安装包元数据解析', () {
+    test('完整元数据', () {
+      final MagpiePackageMetadata? meta = MagpiePackageMetadata.parse(
+        jsonEncode(<String, Object?>{
+          'upstreamVersion': 'v0.12.1',
+          'forkCommit': 'deadbeef',
+          'configVersion': 4,
+        }),
+      );
+      expect(meta, isNotNull);
+      expect(meta!.upstreamVersion, 'v0.12.1');
+      expect(meta.forkCommit, 'deadbeef');
+      expect(meta.configVersion, 4);
+    });
+
+    test('configVersion 是字符串时也能解析（workflow 注入偶发字符串化）', () {
+      expect(
+        MagpiePackageMetadata.parse('{"configVersion":"4"}')?.configVersion,
+        4,
+      );
+    });
+
+    test('缺字段 → 空串 / null，不抛', () {
+      final MagpiePackageMetadata? meta = MagpiePackageMetadata.parse('{}');
+      expect(meta, isNotNull);
+      expect(meta!.upstreamVersion, '');
+      expect(meta.forkCommit, '');
+      expect(meta.configVersion, isNull);
+    });
+
+    test('null / 空白 / 坏 JSON / 非对象 → null，绝不抛', () {
+      expect(MagpiePackageMetadata.parse(null), isNull);
+      expect(MagpiePackageMetadata.parse('   '), isNull);
+      expect(MagpiePackageMetadata.parse('{ not json'), isNull);
+      expect(MagpiePackageMetadata.parse('[1,2,3]'), isNull);
+      expect(MagpiePackageMetadata.parse('"just a string"'), isNull);
+    });
+  });
+
+  group('便携模式标记（config.json）', () {
+    test('内容必须是空的：写 {} 会让 Magpie 读到「没有 scalingModes 的有效配置」', () {
+      // 这不是风格问题：Magpie 只在 configText 为空时才灌默认 scalingModes；
+      // 一个 "{}" 会让 scalingModes 保持空数组 → profile.scalingMode 钳到 -1
+      // → 缩放报 InvalidScalingMode。空文件同时实现「隔离」与「零 schema 猜测」。
+      expect(magpiePortableConfigContent(), isEmpty);
+      expect(magpiePortableConfigContent(), isNot(contains('{')));
+    });
+
+    test('只有 configVersion 与已验证值一致才写配置', () {
+      expect(
+        magpieCanWritePortableConfig(const MagpiePackageMetadata(
+          upstreamVersion: 'v0.12.1',
+          forkCommit: 'x',
+          configVersion: kMagpieKnownConfigVersion,
+        )),
+        isTrue,
+      );
+    });
+
+    test('元数据缺失 / configVersion 不一致或为 null → 只装不配', () {
+      expect(magpieCanWritePortableConfig(null), isFalse);
+      expect(
+        magpieCanWritePortableConfig(const MagpiePackageMetadata(
+          upstreamVersion: '',
+          forkCommit: '',
+          configVersion: kMagpieKnownConfigVersion + 1,
+        )),
+        isFalse,
+      );
+      expect(
+        magpieCanWritePortableConfig(const MagpiePackageMetadata(
+          upstreamVersion: '',
+          forkCommit: '',
+          configVersion: null,
+        )),
+        isFalse,
+      );
+    });
+
+    test('版本一致 → 真的写出空的 config/config.json', () async {
+      final Directory dir =
+          Directory.systemTemp.createTempSync('magpie_cfg_ok_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final bool wrote = await MagpieInstaller().ensurePortableConfig(
+        metadata: const MagpiePackageMetadata(
+          upstreamVersion: 'v0.12.1',
+          forkCommit: 'x',
+          configVersion: kMagpieKnownConfigVersion,
+        ),
+        installDir: dir,
+      );
+      expect(wrote, isTrue);
+      final File cfg = File(p.join(dir.path, 'config', 'config.json'));
+      expect(cfg.existsSync(), isTrue);
+      expect(cfg.lengthSync(), 0);
+    });
+
+    test('版本不一致 → 一个字节都不写（只装不配）', () async {
+      final Directory dir =
+          Directory.systemTemp.createTempSync('magpie_cfg_skip_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final bool wrote = await MagpieInstaller().ensurePortableConfig(
+        metadata: const MagpiePackageMetadata(
+          upstreamVersion: '',
+          forkCommit: '',
+          configVersion: 99,
+        ),
+        installDir: dir,
+      );
+      expect(wrote, isFalse);
+      expect(Directory(p.join(dir.path, 'config')).existsSync(), isFalse);
+    });
+
+    test('已存在 config.json → 绝不覆盖（用户/Magpie 的真实配置）', () async {
+      final Directory dir =
+          Directory.systemTemp.createTempSync('magpie_cfg_keep_');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final File cfg = File(p.join(dir.path, 'config', 'config.json'));
+      cfg.parent.createSync(recursive: true);
+      cfg.writeAsStringSync('{"theme":1}');
+      final bool wrote = await MagpieInstaller().ensurePortableConfig(
+        metadata: const MagpiePackageMetadata(
+          upstreamVersion: '',
+          forkCommit: '',
+          configVersion: kMagpieKnownConfigVersion,
+        ),
+        installDir: dir,
+      );
+      expect(wrote, isFalse);
+      expect(cfg.readAsStringSync(), '{"theme":1}');
+    });
+  });
+
+  group('解压：目录结构与 zip-slip 防护', () {
+    test('保留 effects/ 子目录结构，只回报根层文件名', () async {
+      final Directory out =
+          Directory.systemTemp.createTempSync('magpie_unzip_ok_');
+      addTearDown(() => out.deleteSync(recursive: true));
+      final File zip = File(p.join(out.path, 'in.zip'))
+        ..writeAsBytesSync(_buildZip(<String, List<int>>{
+          'Magpie.exe': utf8.encode('exe'),
+          'Microsoft.UI.Xaml.dll': utf8.encode('dll'),
+          'resources.pri': utf8.encode('pri'),
+          'hibiki-magpie.json': utf8.encode('{}'),
+          'effects/Lanczos.hlsl': utf8.encode('shader'),
+          'effects/Anime4K/Anime4K_Upscale_L.hlsl': utf8.encode('shader2'),
+        }));
+      final Directory target = Directory(p.join(out.path, 'target'));
+
+      final Set<String> rootFiles =
+          await MagpieInstaller().extractZip(zip, target);
+
+      expect(
+        rootFiles,
+        <String>{
+          'Magpie.exe',
+          'Microsoft.UI.Xaml.dll',
+          'resources.pri',
+          'hibiki-magpie.json',
+        },
+      );
+      expect(magpieMissingFiles(rootFiles), isEmpty);
+      expect(
+        File(p.join(
+                target.path, 'effects', 'Anime4K', 'Anime4K_Upscale_L.hlsl'))
+            .readAsStringSync(),
+        'shader2',
+      );
+      // 内容真的写进去了（archive 3.6.1 的 decompress() 会写 0 字节，故取 content）。
+      expect(File(p.join(target.path, 'Magpie.exe')).lengthSync(), 3);
+    });
+
+    test('zip-slip：../ 逃逸条目被丢弃，目标目录外不留文件', () async {
+      final Directory out =
+          Directory.systemTemp.createTempSync('magpie_unzip_slip_');
+      addTearDown(() => out.deleteSync(recursive: true));
+      final File zip = File(p.join(out.path, 'evil.zip'))
+        ..writeAsBytesSync(_buildZip(<String, List<int>>{
+          'Magpie.exe': utf8.encode('ok'),
+          '../pwned.txt': utf8.encode('pwned'),
+          '../../pwned2.txt': utf8.encode('pwned'),
+          'effects/../../pwned3.txt': utf8.encode('pwned'),
+        }));
+      final Directory target = Directory(p.join(out.path, 'target'));
+
+      final Set<String> rootFiles =
+          await MagpieInstaller().extractZip(zip, target);
+
+      expect(rootFiles, <String>{'Magpie.exe'});
+      expect(File(p.join(out.path, 'pwned.txt')).existsSync(), isFalse);
+      expect(File(p.join(p.dirname(out.path), 'pwned2.txt')).existsSync(),
+          isFalse);
+      expect(File(p.join(out.path, 'pwned3.txt')).existsSync(), isFalse);
+    });
+
+    test('绝对路径条目被丢弃', () async {
+      final Directory out =
+          Directory.systemTemp.createTempSync('magpie_unzip_abs_');
+      addTearDown(() => out.deleteSync(recursive: true));
+      final String absName = Platform.isWindows
+          ? 'C:/Windows/Temp/hibiki_magpie_abs_probe.txt'
+          : '/tmp/hibiki_magpie_abs_probe.txt';
+      final File zip = File(p.join(out.path, 'abs.zip'))
+        ..writeAsBytesSync(_buildZip(<String, List<int>>{
+          'Magpie.exe': utf8.encode('ok'),
+          absName: utf8.encode('pwned'),
+        }));
+      final Directory target = Directory(p.join(out.path, 'target'));
+
+      final Set<String> rootFiles =
+          await MagpieInstaller().extractZip(zip, target);
+
+      expect(rootFiles, <String>{'Magpie.exe'});
+      expect(File(absName).existsSync(), isFalse);
+    });
+  });
+
+  group('staging 元数据读取', () {
+    test('读到并解析', () async {
+      final Directory staging =
+          Directory.systemTemp.createTempSync('magpie_meta_ok_');
+      addTearDown(() => staging.deleteSync(recursive: true));
+      File(p.join(staging.path, kMagpieMetadataName)).writeAsStringSync(
+        jsonEncode(<String, Object?>{'configVersion': 4}),
+      );
+      final MagpiePackageMetadata? meta =
+          await MagpieInstaller().readStagedMetadata(staging);
+      expect(meta?.configVersion, 4);
+    });
+
+    test('元数据缺失 → null（不抛，降级只装不配）', () async {
+      final Directory staging =
+          Directory.systemTemp.createTempSync('magpie_meta_none_');
+      addTearDown(() => staging.deleteSync(recursive: true));
+      expect(await MagpieInstaller().readStagedMetadata(staging), isNull);
+    });
+
+    test('元数据损坏 → null（不抛）', () async {
+      final Directory staging =
+          Directory.systemTemp.createTempSync('magpie_meta_bad_');
+      addTearDown(() => staging.deleteSync(recursive: true));
+      File(p.join(staging.path, kMagpieMetadataName))
+          .writeAsStringSync('{ broken');
+      expect(await MagpieInstaller().readStagedMetadata(staging), isNull);
+    });
+  });
+
+  group('平台边界', () {
+    test('非 Windows 一律 unsupportedPlatform，绝不发网络请求', () async {
+      final MagpieInstallResult result =
+          await MagpieInstaller().ensureInstalled(
+        confirm: (MagpieDownloadPrompt _) async => fail('非 Windows 不该走到确认回调'),
+      );
+      expect(result, MagpieInstallResult.unsupportedPlatform);
+    }, skip: Platform.isWindows ? 'Windows 上走真实安装路径，见源码守卫' : false);
+
+    test('非 Windows 后台自更新直接返回（不碰文件系统）', () async {
+      await MagpieInstaller.updateInstalledMagpieInBackground();
+    }, skip: Platform.isWindows ? 'Windows 上会读安装目录' : false);
+  });
+
+  // 交互路径的时序契约（BUG-1076 的教训）无法在 Linux CI 上跑真实安装路径验证，
+  // 故在源码层加守卫：确认回调必须在任何 await 探测之前被调用；已装完整时必须
+  // 零网络直接返回。改坏这两条会直接把测试打红。
+  group('源码守卫：BUG-1076 时序契约', () {
+    late final String src =
+        File('lib/src/mining/magpie_installer.dart').readAsStringSync();
+
+    test('大小探测发起后不 await，直接进 confirm 回调', () {
+      final int probeAt =
+          src.indexOf('final Future<int?> sizeProbe = _probeSize(');
+      final int confirmAt = src.indexOf('final bool ok = await confirm(');
+      expect(probeAt, greaterThan(0));
+      expect(confirmAt, greaterThan(probeAt));
+      final String between = src.substring(probeAt, confirmAt);
+      expect(between, isNot(contains('await sizeProbe')));
+      expect(between, contains('unawaited(sizeProbe'));
+    });
+
+    test('已完整安装时零网络直接返回 alreadyInstalled', () {
+      final int checkAt =
+          src.indexOf('if (missingInstalledEntries().isEmpty) {');
+      final int probeAt =
+          src.indexOf('final Future<int?> sizeProbe = _probeSize(');
+      expect(checkAt, greaterThan(0));
+      expect(probeAt, greaterThan(checkAt));
+      expect(
+        src.substring(checkAt, probeAt),
+        contains('MagpieInstallResult.alreadyInstalled'),
+      );
+    });
+
+    test('后台自更新只对「已装且有标记」生效', () {
+      expect(src, contains('if (!marker.existsSync()) return;'));
+      expect(
+          src, contains('if (missingInstalledEntries().isNotEmpty) return;'));
+    });
+
+    test('换入前先在 staging 校验包清单，标记在换入成功后才写', () {
+      // 用调用点而非 import show 列表里的同名符号定位。
+      const String swapCall =
+          '_serializeInstall(() => galgameHelperSwapInstall(';
+      expect(src.indexOf(swapCall), greaterThan(0));
+      expect(
+          src.indexOf('missingFromPackage'), lessThan(src.indexOf(swapCall)));
+      expect(src.indexOf(swapCall),
+          lessThan(src.indexOf('_markerFile().writeAsString')));
+    });
+  });
+}

--- a/hibiki/test/mining/magpie_installer_test.dart
+++ b/hibiki/test/mining/magpie_installer_test.dart
@@ -189,6 +189,15 @@ void main() {
       expect(meta.configVersion, isNull);
     });
 
+    test('带 UTF-8 BOM 的元数据仍能解析（否则会静默降级成只装不配）', () {
+      expect(
+        MagpiePackageMetadata.parse(
+                '﻿{"configVersion":4,"upstreamVersion":"v0.12.1"}')
+            ?.configVersion,
+        4,
+      );
+    });
+
     test('null / 空白 / 坏 JSON / 非对象 → null，绝不抛', () {
       expect(MagpiePackageMetadata.parse(null), isNull);
       expect(MagpiePackageMetadata.parse('   '), isNull);


### PR DESCRIPTION
内置 Magpie 超分的阶段一。用户拍板：**自己 fork 编译**（像 mpv/hook 那样便于改源码），**分发照 helper 范式按需下载**，不随包内嵌。

## fork 与自编产物
- fork：https://github.com/hajisensai/Magpie （public，分支 `dev`，基线上游 `e6167ef` / v0.12.1）
- 我们的 commit 只加 release workflow + `HIBIKI-FORK.md` + README 指针，**`src/` 零改动**，上游 LICENSE 未动（GPL-3.0，与 Hibiki 同许可）
- **CI 真跑过**：x64 / ARM64 两平台构建 + release 全 success
- **端到端验证**：用本 PR 的 Dart 代码拼出的下载 URL 真去下了 x64 zip，sha256 与 `.sha256` 侧车**逐字符相同**；包内 metadata 与根文件清单已核

产物名不含版本号（`Magpie-hibiki-x64.zip`）——固定 tag 的全部价值就是直链永不变，文件名带版本 = 每次升级客户端硬编码 URL 失效。版本放 release body + 包内 metadata。未签名（fork 无 pfx secret）；产物版本号故意留 `0.0.0`，不让自编二进制冒充官方版本号。

## `magpie_installer.dart`
复用 `galgame_helper_installer.dart` 已验证的纯工具（镜像 URL / sha256 侧车 / 换入式 `.stale` 安装 / 清扫），零第二实现。两个设计决定：
- **无 UI、无 i18n**：是否下载由调用方经 `confirm` 回调决定，模块不持 BuildContext → 本轮零 i18n key、不动 `strings.g.dart`（并发下最高冲突面）
- BUG-1076 的时序教训固化进类型：`MagpieDownloadPrompt.sizeProbe` 是已发起未 await 的 Future，`confirm` 立即被调（旧实现先 await 探测 = 点了没反应），4 条源码守卫兜底

顺手修的真问题：元数据解析遇 UTF-8 BOM 会被 `jsonDecode` 抛异常并被 catch 静默吞成 null → 表现为「明明带了元数据却永远只装不配」。当前产物无 BOM，但写入端换成 PowerShell 5.1 就会有。

## 三条调研结论（推翻了立项前提）
**① 「源窗口失焦会中断全屏缩放」是错的。** v0.12.1 上失焦**不会**结束缩放，除非开 3D 游戏模式；官方文档把两件事塞进同一个 `wParam=0`，靠 `lParam` 区分。唯一的失焦退出在 3D 游戏模式的前台检查里，**且已有两级例外**（系统窗口白名单 + 8px 重叠容差），加我们自己的窗口只需 ~3 行。查词浮窗与全屏超分本来就能共存。

**真正的雷在别处**：UI 层有个 **50ms 前台轮询**，命中任何 `autoScale != Disabled` 的 Profile 就强制重启缩放 → **绝不能给 Hibiki 自己的 exe 建 autoScale Profile**。

**② 便携配置的 schema 兼容是伪需求，而原方案会毁掉缩放。** Magpie 只看 `config\config.json` 是否存在，`CONFIG_VERSION` 根本不写进文件；默认 scalingModes 只在文件不存在或**内容为空**时才灌入——写 `{}` 会被当成「有效但没有 scalingModes 的配置」→ scalingMode 钳到 -1 → 缩放报 `InvalidScalingMode`。**正确实现是写 0 字节文件**。阶段二若真要写 profiles，另有 6 处 schema 陷阱已记入设计文档。

**③ CLI 改动面**：现在是整条命令行字符串相等比较、无 tokenizer。加 `--scale-hwnd` 约 80–150 行；加一条新注册窗口消息只要 ~20 行。**最大难点**：单实例检查在最前，第二个实例带参数启动会广播 SHOWME 后直接退出，**参数静默丢失**。
顺带：窗口化缩放会主动把焦点抢回源窗口——**阶段二用全屏模式，别用窗口化**。

全部写进 `docs/specs/2026-07-26-magpie-upscaling-design.md`。

## 验证
- `flutter analyze`（全量含 test）：No issues found!
- `flutter test test/mining/magpie_installer_test.dart`：43 passed, 2 skipped（2 条是 Windows 上跳过的平台边界断言，Linux CI 会真跑）

## 未做 / 已知风险
1. **本机编不了 Magpie**（VS Build Tools 缺 VCTools + UWP 工作负载、缺 Conan）。构建真相源是 GitHub Actions，**没有假装本机构建过**。另发现上游 `scripts/publish.py` 的 vswhere 调用漏了 `-products *`，Build Tools SKU 下会 IndexError。
2. **安装器全链路没在真机跑过**，只有单测 + 源码守卫。
3. **无调用方**：模块尚未挂进启动链路，按范围限定避开并发代理的文件。
4. **Magpie 自带更新器仍指向上游**（硬编码 raw.githubusercontent 的上游 version.json），用户若开启其自动更新会被拉回官方包、覆盖我们的产物。想靠便携 config 关掉又会撞 ② 的陷阱——需在 fork 里改 URL 或摘掉 Updater。
5. **ARM64 交叉编译成功但无 ARM64 机器实跑验证**。

https://claude.ai/code/session_018NeGjpee1gxFXaDTkaeoa4