### PR TITLE
feat(galgame,lookup): hook 台词浮窗真滚动 + 统一两条 WebView2 创建路径的 DPI (BUG-1095/1104)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1070 条。点号进各自文件。
+> 共 1071 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1104](bugs/BUG-1104-lookup-overlay-webview2-dpi-inconsistent.md) | ✅ | ✅ | 查词浮窗两条 WebView2 创建路径的 DPI 处理不一致（且无 WM_DPICHANGED） |
 | [BUG-1103](bugs/BUG-1103-helper-supply-chain.md) | ✅ | ✅ | galgame helper 安装器：sha256 侧车拉不到就不校验照装 + 侧车与产物同源第三方镜像（注入器/hook DLL 供应链后门） |
 | [BUG-1102](bugs/BUG-1102-gal-audio-track-panel-dead-controls.md) | ✅ | ✅ | 兼容性诊断页「活跃音轨」面板全无效：选轨/排除点了没反应，空轨照样占位 |
 | [BUG-1101](bugs/BUG-1101-gal-loopback-line-audio-off-by-one.md) | ✅ | ✅ | 降级到系统 Loopback 时逐行语音永远配到上一句 |

--- a/docs/bugs/BUG-1095-gal-overlay-font-size-coupled-to-window-height.md
+++ b/docs/bugs/BUG-1095-gal-overlay-font-size-coupled-to-window-height.md
@@ -34,7 +34,48 @@
   - Dart 真单测 `hibiki/test/lookup/gal_hook_text_overlay_controller_test.dart`（新增两条）：
     `show` 携带偏好里的字号；`applyFontSizeFromPreferences()` 把新字号经 `updateStyle` 推给 native。
   - 偏好边界 `hibiki/test/models/preferences_repository_gal_hook_font_test.dart`：默认值 / 上下钳位 / 脏数据收敛。
-- **备注**：native C++ 改动已用 `flutter build windows --debug` 真编译验证。
-  **仍未做**：文本区依旧没有滚动，字号调太大 + 窗口太小时溢出仍被硬裁（只是改成裁句尾）。
-  分层滚动需要在 Direct2D 分层窗里自建滚动条与命中测试，属独立工程量，本轮不做。
-  真机肉眼复测（拖高浮窗看行数是否真变多）待补。
+- **[x] ③ 第二阶段已补完：文本区真滚动**（本条原记为「仍未做」，现已落地）
+  - **仍存在的问题**：字号解耦之后，拖高确实换来更多行，但「字号调大 + 窗口小」仍会把句尾
+    硬裁掉（`PushAxisAlignedClip` / `PopAxisAlignedClip`），用户没有任何办法看到被裁的内容。
+    这个窗是 runner 自有的 Win32 分层窗 + Direct2D 直绘，没有系统滚动条可用。
+  - **方案**：不引入第二个渲染目标，也不做滚动容器——顶端对齐（第一阶段成果）让排版从
+    `text_rect_.top` 起画，于是「滚动」就等于**把绘制原点上移 `scroll_offset_px_`，裁剪框
+    `text_clip` 一动不动**，视口下移、被裁的句尾从下面走进来。
+    - `hibiki/windows/runner/floating_lyric_window.h:205-213`（`ScrollBy` 声明）、`:288-293`
+      （`scroll_offset_px_` / `scroll_max_px_` 状态）。
+    - `hibiki/windows/runner/floating_lyric_window.cpp:97-106`（滚动条 / 滚轮步长常量）、
+      `:356-364`（`UpdateText` 回顶）、`:444-462`（`ScrollBy`，三个接管前置条件集中于此）、
+      `:753-775`（`WM_MOUSEWHEEL`）、`:924-928`（每帧归零行程）、`:953-966`（按实测排版高度
+      算行程 + 夹紧偏移 + 算出 `text_origin_y`）、`:1051-1090`（右侧留白里的滚动指示条）、
+      `:1438-1450`（`CharIndexAt` 视口判边界 / 布局取坐标）。
+  - **交互语义**（三条容易打架的地方，都按「消除特殊情况」处理）：
+    1. **新台词到达 → 回到顶部**（`UpdateText`）。这里换掉的是**整句**而不是往下追加，保留
+       旧偏移只会把用户直接扔进一句他还没读过的话的中间，比跳回开头糟得多。所以没有
+       「用户正在往下看就别动」的分支——那个分支要成立，前提是新旧文本连续，而 hook 台词
+       从来不是。
+    2. **穿透（pass-through）下不滚**。`WM_NCHITTEST` 早已对正文返回 `HTTRANSPARENT`，滚轮
+       根本到不了本窗；顶部那条「恢复带」仍能收到消息，故 `ScrollBy` 里再挡一道
+       `pass_through_`——穿透就是「鼠标整个属于游戏」，不留半个例外。
+    3. **和工具条按钮不打架**：那八个按钮只吃 `WM_LBUTTONDOWN`，从不吃滚轮。所以滚轮的命中
+       区可以是整个窗口，**不需要**「避开按钮」这种特例分支；鼠标停在按钮上滚也照样翻文本。
+       滚动条轨道则画在 `text_rect_` **右侧的留白**（`[width - pad, width]`）里，压不到任何一个字
+       ——若压字就得缩窄换行宽度，而换行宽度会反过来改变排版高度即可滚行程，形成回环；轨道
+       底端另外让开右下角 resize grip，两个可拖拽的东西不叠在同一块像素上。
+    4. **滚到顶 / 滚到底不吞事件**（`ScrollBy` 返回 false → 落回 `DefWindowProc`），窗口不做
+       吃掉滚轮的黑洞。
+  - **向后兼容**：`scroll_max_px_` 每帧先归零、只有 hook 分支会重新赋值；没有溢出时
+    `scroll_offset_px_` 恒为 0，`text_origin_y == text_rect_.top`，滚动条一个像素都不画。
+    有声书歌词条与剪贴板文本窗因此与引入滚动之前逐像素一致。
+  - **自动化测试**：`hibiki/test/build/gal_overlay_scroll_guard_test.dart`（7 例全绿）锁死
+    ①行程由实测排版高度每帧重算 ②滚动 = 移绘制原点、裁剪框不动 ③命中测试视口判边界 /
+    布局取坐标 ④新台词回顶 ⑤接管条件集中在 `ScrollBy` 且滚到头不吞事件 ⑥滚动条在右侧留白
+    且只在真溢出时画 ⑦第一阶段成果与歌词条行为不被连坐。第一阶段守卫
+    `gal_overlay_font_decoupled_guard_test.dart` 里「溢出仍是硬裁」的说明已随之更正。
+  - **顺带修掉第一阶段遗留的红测试**：`hibiki/test/tools/gal_hook_overlay_buttons_guard_test.dart`
+    里那条「hook 台词字号随窗口高度缩放」（commit e8e23dd35 加的）与第一阶段的新契约**直接冲突**
+    ——它断言 `kHookTextBaseHeightForFontDip` 必须存在，而第一阶段正是把这个常量删掉的。
+    第一阶段（commit 64e0e8211）漏掉了它，分支上一直是红的（已用 stash 到 HEAD 复现确认，
+    与第二阶段改动无关）。现就地把断言**反转**成「不得回退」，并在注释里写清契约为什么翻面。
+- **备注**：native C++ 改动已用 `flutter build windows --debug` 真编译验证（第一、第二阶段各一次）。
+  **仍未做**：真机肉眼复测（拖高浮窗看行数是否真变多、滚轮能否翻出被裁的句尾、滚动条位置
+  是否遮字）尚未进行；C++ 无法在 Dart 测试里执行，上述守卫锁的是**源码结构**而非渲染结果。

--- a/docs/bugs/BUG-1104-lookup-overlay-webview2-dpi-inconsistent.md
+++ b/docs/bugs/BUG-1104-lookup-overlay-webview2-dpi-inconsistent.md
@@ -1,0 +1,50 @@
+## BUG-1104 · 查词浮窗两条 WebView2 创建路径的 DPI 处理不一致（且无 WM_DPICHANGED）
+
+- **报告**：2026-07-26（从 `docs/bugs/BUG-1098-popup-headword-furigana-clipped.md` 备注里拆出来的跟进项——
+  那条备注明写「这是**放大器**不是根因……本轮不动，另开跟进」。编号避开 1098~1103（`origin/develop`
+  上已被并发 PR 占用），落 1104。）
+- **真实性**：✅ 真的不一致，但**不是**词头假名被裁的根因（根因是 BUG-1098 的 em 预留缺失，已在 PR#424 修掉）。
+  沿真实代码路径核实（修复前）：
+  - composition 路径 `hibiki/windows/runner/global_lookup_window.cpp:1055-1069`：QI
+    `ICoreWebView2Controller3` 后设了 `put_BoundsMode(USE_RAW_PIXELS)` +
+    `put_ShouldDetectMonitorScaleChanges(FALSE)` + `put_RasterizationScale(dpi/96)`。
+  - windowed 回退路径 `:1126-1183`：**三项一个都没设**，任由 WebView2 自己探测 monitor scale。
+  - 全文**没有** `WM_DPICHANGED` 处理。
+  于是同一个窗口走哪条创建路径，位图缩放的真值来源不同：一个是我们按 `GetDpiForWindow(hwnd_)` 钉的，
+  一个是 WebView2 自己探测的。而窗口坐标、shell 卡矩形（`ApplyRoundedRegion` 的圆角直径）、
+  `commitLayerShift` 的 CSS px 换算**全部**按 `GetDpiForWindow(hwnd_)` 算。单屏 100% 时两者恰好相等，
+  多屏 / 非 100% 缩放时可以差一档——差出来的就是被放大的亚像素取整误差。
+  更麻烦的是 composition 路径关掉了自动探测**却没人负责跟随 DPI 变化**：这个窗是开机预热、整个 app
+  会话只 `SW_HIDE` 不销毁的长命窗口，「建窗那一刻所在的那块屏」可能是几小时前的事，拖到另一块
+  缩放不同的显示器后光栅缩放会一直停在旧值。
+- **[x] ① 已修复** — 消除「两个真值来源」，而不是给 windowed 路径打补丁：
+  - 新增单一入口 `GlobalLookupWindow::ApplyDpiScale()`（`hibiki/windows/runner/global_lookup_window.h:268-272`、
+    `global_lookup_window.cpp:1196-1229`）：读 `GetDpiForWindow(hwnd_)`，一次性设齐 `put_BoundsMode` /
+    `put_ShouldDetectMonitorScaleChanges(FALSE)` / `put_RasterizationScale(dpi/96)`。
+    拿不到 `ICoreWebView2Controller3` 的老 runtime 整体返回，保持它自己的默认行为——绝不半套地只设一项。
+  - composition 路径 `:1055-1059` 的内联代码替换成 `ApplyDpiScale()`；windowed 回退路径 `:1152-1158`
+    在 `put_Bounds` 之前补上同一句。两条路径行为从此按构造相同。
+  - 新增 `case WM_DPICHANGED`（`:1851-1886`）：照单全收 `lparam` 里系统按新 DPI 算好的建议矩形
+    （`SWP_NOZORDER | SWP_NOACTIVATE`，且不带任何「显示窗口」标志，预热期的隐藏窗不会凭空出现在桌面），
+    再 `ApplyDpiScale()` + `put_Bounds` + composition 的 `Commit()` / windowed 的 `ApplyRoundedRegion()`
+    （圆角直径按 DPI 算，换屏必须重算）。关掉自动探测之后跟随 DPI 变化就是我们自己的责任，这一句补上了。
+  - **BUG-693 自愈重建未受影响**：`RecoverDeadWebView` 走 `EnsureWebView` → 创建路径 → `ApplyDpiScale()`，
+    重建出来的实例自动拿到一致的 DPI 设置；PR#425 的 `put_IsStatusBarEnabled(FALSE)`（BUG-1097）原样保留。
+  - **向后兼容**：单屏 100% 缩放下 `dpi/96 == 1.0`，windowed 路径新设的值与 WebView2 自己探测出来的
+    完全一致，渲染逐像素不变；只有多屏 / 非 100% 缩放才会看到差别，而那正是本条要修的场景。
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/global_lookup_dpi_scale_guard_test.dart`（4 例全绿，源码守卫）：
+  ① `ApplyDpiScale()` 存在且三项设置齐全、真值来自 `GetDpiForWindow(hwnd_)`、老 runtime 整体返回；
+  ② `put_RasterizationScale` / `put_ShouldDetectMonitorScaleChanges` 在全文**各只出现一次**（谁再自己设
+  DPI 就红），且 `ApplyDpiScale();` 恰好三处调用（composition 创建 / windowed 创建 / `WM_DPICHANGED`）；
+  ③ `WM_DPICHANGED` 收下建议矩形、不动 Z 序、**不含**任何显示窗口标志、并重算圆角区域；
+  ④ BUG-693 自愈与 BUG-1097 状态栏关闭不被顺手改掉，且自愈仍复用创建路径。
+- **备注**：C++ 无法在 Dart 测试里执行，守卫锁的是**源码结构**而非渲染结果。
+  已用 `flutter build windows --debug` 真编译验证（exit 0）。
+  **仍未做 / 已知风险**：
+  - **多屏 + 不同缩放的真机验证未做**（本机当前无法构造该场景）。`WM_DPICHANGED` 的实际观感——
+    拖过去之后卡片是否立刻按新缩放重绘、有没有一帧旧缩放的闪烁——只能真机看。
+  - `WM_DPICHANGED` 里没有重建 WebView2 控制器，只改了光栅缩放与 bounds。这是刻意的：
+    重建涉及控制器生命周期 + BUG-693 自愈状态机，风险远高于收益；WebView2 的
+    `put_RasterizationScale` 本就是为运行时改缩放设计的，不需要重建。
+  - DComp 视觉树在 DPI 切换时是否需要额外的 `SetTransform` 未验证（当前只 `Commit()`）。若真机
+    发现 composition 路径换屏后有整体缩放偏差，从这里查。

--- a/hibiki/test/build/gal_overlay_font_decoupled_guard_test.dart
+++ b/hibiki/test/build/gal_overlay_font_decoupled_guard_test.dart
@@ -5,7 +5,12 @@
 //   ① hook 模式不再按窗高缩放字号（三个缩放常量必须消失）；
 //   ② hook 分支的缩放系数恒为 1.0f，即直接用 style_.font_size；
 //   ③ 有声书歌词条的历史行为（按窗高缩放）不得被顺手砍掉；
-//   ④ 溢出时 hook 台词顶端对齐（保住阅读起点，只丢句尾）。
+//   ④ 溢出时 hook 台词顶端对齐（保住阅读起点）。
+//
+// 注：第一阶段写的“溢出仍是硬裁”已经过时——第二阶段给这个浮窗加了真正的
+// 垂直滚动（滚轮 + 指示条），句尾不再永久丢失，见
+// hibiki/test/build/gal_overlay_scroll_guard_test.dart。顶端对齐从“止损”变成了
+// 滚动能成立的前提：排版必须从 text_rect_.top 起画，滚动才等于平移绘制原点。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -57,7 +62,8 @@ void main() {
     expect(
       src.contains('DWRITE_PARAGRAPH_ALIGNMENT_NEAR'),
       isTrue,
-      reason: '溢出仍是硬裁（分层窗无滚动），但必须裁句尾而不是把头尾一起裁掉',
+      reason: '顶端对齐是滚动的前提（排版从 text_rect_.top 起画，滚动 = 平移绘制原点）；'
+          '改回居中会让滚动偏移与实际排版对不上，且未滚动时头尾一起被裁',
     );
     expect(
       src.contains('metrics.height > text_rect_.height'),

--- a/hibiki/test/build/gal_overlay_scroll_guard_test.dart
+++ b/hibiki/test/build/gal_overlay_scroll_guard_test.dart
@@ -1,0 +1,181 @@
+// BUG-1095（第二阶段）源码守卫：galgame Hook 台词浮窗**装不下时必须能滚**。
+//
+// 第一阶段（字号与窗高解耦）之后，字号调大 + 窗口不够高仍会把句尾硬裁掉，用户
+// 看不到被裁的内容。这个浮窗是 runner 自有的 Win32 分层窗（Direct2D/DirectWrite
+// 直绘），既不是 Flutter widget 也没有系统滚动条，C++ 无法在 Dart 测试里执行，
+// 故在源码层锁死修复结构：
+//   ① 滚动状态存在，且每帧由实测排版高度重算行程；
+//   ② 绘制原点随偏移上移（滚动的实现方式），裁剪框不动；
+//   ③ 命中测试在视口判边界、在布局取坐标（滚动后点字不错行）；
+//   ④ 新台词回到顶部；
+//   ⑤ 接管条件（hook 模式 / 非穿透 / 有溢出）集中在 ScrollBy，滚到头不吞事件；
+//   ⑥ 滚动条画在文本区右侧留白里，且只在 hook 模式真溢出时画；
+//   ⑦ 不滚动时逐像素不变（歌词条 / 剪贴板文本窗完全不受影响）。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final String src =
+      File('windows/runner/floating_lyric_window.cpp').readAsStringSync();
+  final String hdr =
+      File('windows/runner/floating_lyric_window.h').readAsStringSync();
+
+  test('① 滚动状态存在，行程由实测排版高度每帧重算（BUG-1095）', () {
+    expect(hdr.contains('float scroll_offset_px_ = 0.0f;'), isTrue,
+        reason: '滚动偏移必须是窗口自己的状态');
+    expect(hdr.contains('float scroll_max_px_ = 0.0f;'), isTrue,
+        reason: '可滚行程必须是窗口自己的状态');
+    expect(hdr.contains('bool ScrollBy(float delta_px);'), isTrue,
+        reason: 'ScrollBy 是唯一的滚动入口');
+    expect(
+      src.contains(
+          'scroll_max_px_ = std::max(0.0f, metrics.height - text_rect_.height);'),
+      isTrue,
+      reason: '行程 = 实测排版高度 - 文本区高度；写死常量或按行数估算都会在换字号 / '
+          '换窗高之后失准',
+    );
+    // 每帧先归零再重算：字号、窗高、文本任一变化都不会把旧行程留下来
+    // （另一处归零在 UpdateText 里）。
+    expect(
+      'scroll_max_px_ = 0.0f;'.allMatches(src).length >= 2,
+      isTrue,
+      reason: '每帧必须从零重算行程，UpdateText 也要一起归零',
+    );
+    expect(
+      src.contains(
+          'scroll_offset_px_ = std::clamp(scroll_offset_px_, 0.0f, scroll_max_px_);'),
+      isTrue,
+      reason: '行程变小（拖高窗口 / 调小字号）后偏移必须重新夹紧，否则会卡在空白处',
+    );
+  });
+
+  test('② 滚动 = 绘制原点上移，裁剪框不动', () {
+    expect(
+      src.contains(
+          'const float text_origin_y = text_rect_.top - scroll_offset_px_;'),
+      isTrue,
+      reason: '分层窗没有第二个渲染目标，滚动只能靠移动绘制原点',
+    );
+    expect(
+      src.contains('D2D1::Point2F(text_rect_.left, text_origin_y)'),
+      isTrue,
+      reason: '正文必须按滚动后的原点画',
+    );
+    expect(
+      src.contains(
+          'D2D1::RectF(text_rect_.left + m.left, text_origin_y + m.top,'),
+      isTrue,
+      reason: '高亮底框必须跟着一起滚，否则滚动后高亮会留在原地',
+    );
+    // 裁剪框仍以 text_rect_ 为准（BUG-1070 的成果不得被顺手改掉）。
+    expect(
+      src.contains('render_target_->PushAxisAlignedClip(text_clip,'),
+      isTrue,
+      reason: '视口裁剪是滚动能成立的前提，也是 BUG-1070（文字溢进工具条）的修复',
+    );
+  });
+
+  test('③ 命中测试：视口判边界、布局取坐标', () {
+    expect(src.contains('const float viewport_y = y - text_rect_.top;'), isTrue,
+        reason: '用户只点得到看得见的字，边界必须判在视口里');
+    expect(
+      src.contains('const float local_y = viewport_y + scroll_offset_px_;'),
+      isTrue,
+      reason: '换算到布局坐标要加回偏移，否则滚动后点第一行会命中被滚走的那一行',
+    );
+    expect(
+      src.contains(
+          'out_char_rect->top = text_rect_.top + metrics.top - scroll_offset_px_;'),
+      isTrue,
+      reason: '查词卡的锚点矩形是客户区坐标，必须减回偏移才对得上屏幕上的那个字',
+    );
+  });
+
+  test('④ 新台词回到顶部', () {
+    final int i = src.indexOf('void FloatingLyricWindow::UpdateText(');
+    expect(i, greaterThan(0));
+    final int end = src.indexOf('void FloatingLyricWindow::Highlight(', i);
+    expect(end, greaterThan(i));
+    final String updateText = src.substring(i, end);
+    expect(
+      updateText.contains('scroll_offset_px_ = 0.0f;'),
+      isTrue,
+      reason: '换的是整句而不是往下追加：保留旧偏移只会把用户扔到一句他还没读过的'
+          '话的中间，比跳回开头糟得多',
+    );
+  });
+
+  test('⑤ 接管条件集中在 ScrollBy，滚到头不吞事件', () {
+    expect(
+      src.contains(
+          'if (!hook_text_mode_ || pass_through_ || scroll_max_px_ <= 0.0f) {'),
+      isTrue,
+      reason: '三个前置条件必须写在一处：hook 模式 / 非穿透 / 真有溢出。'
+          '穿透 = 鼠标整个属于游戏，顶部恢复带也不例外',
+    );
+    expect(src.contains('case WM_MOUSEWHEEL:'), isTrue, reason: '滚轮是最低交互要求');
+    expect(
+      src.contains('GET_WHEEL_DELTA_WPARAM(wparam)'),
+      isTrue,
+      reason: '滚动量要按真实 wheel delta 折算，不能一格一个固定值',
+    );
+    // 到顶 / 到底时 ScrollBy 返回 false，滚轮落回 DefWindowProc，
+    // 窗口不做吃掉滚轮的黑洞。
+    final int i = src.indexOf('bool FloatingLyricWindow::ScrollBy(');
+    expect(i, greaterThan(0));
+    final String scrollBy = src.substring(
+        i, src.indexOf('void FloatingLyricWindow::SetLocked(', i));
+    expect(
+      scrollBy.contains('if (next == scroll_offset_px_) {'),
+      isTrue,
+      reason: '偏移没变就不能返回 true，否则窗口会变成吃掉滚轮的黑洞',
+    );
+    final int w = src.indexOf('case WM_MOUSEWHEEL:');
+    final String wheelCase = src.substring(w, src.indexOf('case WM_SIZE:', w));
+    expect(
+      wheelCase
+          .contains('return DefWindowProc(hwnd_, message, wparam, lparam);'),
+      isTrue,
+      reason: '不接管的滚轮必须落回 DefWindowProc',
+    );
+  });
+
+  test('⑥ 滚动条画在右侧留白，且只在 hook 模式真溢出时出现', () {
+    expect(src.contains('kScrollBarWidthDip'), isTrue);
+    expect(src.contains('kScrollBarMinThumbDip'), isTrue);
+    expect(
+      src.contains('if (hook_text_mode_ && scroll_max_px_ > 0.0f) {'),
+      isTrue,
+      reason: '没有溢出就一个像素都不画（不滚动时逐像素不变）',
+    );
+    expect(
+      src.contains('static_cast<float>(width) - pad * 0.5f - bar_w * 0.5f;'),
+      isTrue,
+      reason: '轨道必须落在 text_rect_ 右侧的留白里：压到文字就要缩窄换行宽度，'
+          '而换行宽度会反过来改行程，形成回环',
+    );
+    expect(
+      src.contains('text_rect_.height - ScaleForDpi(kResizeGripDip)'),
+      isTrue,
+      reason: '轨道底端要让开右下角 resize grip，两个可拖拽的东西不叠在一起',
+    );
+  });
+
+  test('⑦ 歌词条 / 剪贴板文本窗不受滚动影响', () {
+    // 非 hook 模式行程恒为 0：归零发生在排版分支之前，只有 hook 分支会重新赋值。
+    final int layout =
+        src.indexOf('  if (text_format_ != nullptr && !text_.empty()) {');
+    expect(layout, greaterThan(0));
+    final int zero = src.lastIndexOf('  scroll_max_px_ = 0.0f;', layout);
+    expect(zero, greaterThan(0), reason: '归零必须发生在排版分支之前，且只有 hook 分支会重新赋值');
+    expect(layout - zero, lessThan(400),
+        reason: '归零要紧挨着排版分支，中间塞了别的逻辑就说明它跑到别处去了');
+    // 第一阶段的成果不得被本次改动顺手撤掉。
+    expect(src.contains('hook_text_mode_ ? 1.0f'), isTrue,
+        reason: 'BUG-1095 第一阶段：hook 字号与窗高解耦，不得回退');
+    expect(
+        src.contains('strip_height_dip_ / kBaseStripHeightForFontDip'), isTrue,
+        reason: '有声书歌词条「拖高放大」是既有行为，不得连坐');
+  });
+}

--- a/hibiki/test/lookup/global_lookup_dpi_scale_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_dpi_scale_guard_test.dart
@@ -1,0 +1,106 @@
+// BUG-1104 源码守卫：查词浮窗两条 WebView2 创建路径的 DPI 处理必须同源。
+//
+// 背景（BUG-1098 备注里记下的“放大器”）：composition 路径当年钉了
+// put_RasterizationScale(dpi/96) + put_ShouldDetectMonitorScaleChanges(FALSE)，
+// 而 windowed 回退路径两项都没设、全文也没有 WM_DPICHANGED 处理。于是同一个窗
+// 走哪条路径出来的位图缩放真值来源不同（我们钉的 vs WebView2 自己探测的），多屏 /
+// 非 100% 缩放时可以差一档。
+//
+// 这是 Win32 + WebView2 代码，Dart 测试跑不了，故在源码层锁死结构：
+//   ① 只有一个 DPI 入口 ApplyDpiScale()，三项都在里面；
+//   ② 两条创建路径 + WM_DPICHANGED 都调它，别处不得再出现这些 put_；
+//   ③ WM_DPICHANGED 存在且不会把预热隐藏窗弄可见；
+//   ④ BUG-693 自愈重建与 BUG-1097 状态栏关闭不得被顺手改掉。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final String src =
+      File('windows/runner/global_lookup_window.cpp').readAsStringSync();
+  final String hdr =
+      File('windows/runner/global_lookup_window.h').readAsStringSync();
+
+  test('① DPI 只有一个入口，三项设置都在里面（BUG-1104）', () {
+    expect(hdr.contains('void ApplyDpiScale();'), isTrue,
+        reason: 'ApplyDpiScale 必须是声明出来的成员，而不是某条路径里的内联代码');
+    final int i = src.indexOf('void GlobalLookupWindow::ApplyDpiScale() {');
+    expect(i, greaterThan(0));
+    final String fn = src.substring(
+        i, src.indexOf('void GlobalLookupWindow::ConfigureWebView', i));
+    for (final String call in <String>[
+      'put_BoundsMode(COREWEBVIEW2_BOUNDS_MODE_USE_RAW_PIXELS)',
+      'put_ShouldDetectMonitorScaleChanges(FALSE)',
+      'put_RasterizationScale(static_cast<double>(dpi) / 96.0)',
+    ]) {
+      expect(fn.contains(call), isTrue, reason: '三项必须一起设：只设其中一两项就是半套状态，比不设更难查');
+    }
+    expect(fn.contains('GetDpiForWindow(hwnd_)'), isTrue,
+        reason: '真值来源只有一个——这个 HWND 的 DPI，与窗口坐标 / 卡片矩形同源');
+    expect(fn.contains('ICoreWebView2Controller3'), isTrue);
+    expect(
+      fn.contains('controller3 == nullptr'),
+      isTrue,
+      reason: '老 runtime 拿不到 Controller3 时必须整体返回，保持它自己的默认行为',
+    );
+  });
+
+  test('② 三项 put_ 在全文只出现一次（两条路径都从同一个入口走）', () {
+    for (final String call in <String>[
+      'put_RasterizationScale',
+      'put_ShouldDetectMonitorScaleChanges',
+    ]) {
+      expect(
+        call.allMatches(src).length,
+        1,
+        reason: '$call 出现多于一次 = 又有路径在自己设 DPI，两条路径必然再次漂开',
+      );
+    }
+    // composition 创建、windowed 创建、WM_DPICHANGED 三处调用。
+    expect(
+      'ApplyDpiScale();'.allMatches(src).length,
+      3,
+      reason: 'composition 创建路径、windowed 回退路径、WM_DPICHANGED 三处都必须调；'
+          '少一处就回到了 BUG-1104 的不一致状态',
+    );
+  });
+
+  test('③ WM_DPICHANGED 跟随新显示器，且不会弄可见预热中的隐藏窗', () {
+    final int i = src.indexOf('case WM_DPICHANGED: {');
+    expect(i, greaterThan(0),
+        reason: '关掉了自动 monitor-scale 探测，跟随 DPI 变化就是我们自己的责任');
+    final String block =
+        src.substring(i, src.indexOf('case WM_ENTERSIZEMOVE:', i));
+    expect(
+      block.contains('reinterpret_cast<const RECT*>(lparam)'),
+      isTrue,
+      reason: 'lparam 是系统按新 DPI 算好的建议矩形，照单全收是官方契约',
+    );
+    expect(block.contains('SWP_NOZORDER | SWP_NOACTIVATE'), isTrue,
+        reason: '不动 Z 序、不抢焦点');
+    expect(
+      block.contains('SWP_SHOWWINDOW'),
+      isFalse,
+      reason: '这个窗开机就预热并长期隐藏；带上 SWP_SHOWWINDOW 会让它凭空出现在桌面',
+    );
+    expect(block.contains('ApplyDpiScale();'), isTrue);
+    expect(block.contains('ApplyRoundedRegion();'), isTrue,
+        reason: 'windowed 路径的圆角直径按 DPI 算，换屏必须重算');
+  });
+
+  test('④ 既有机制不得被顺手改掉', () {
+    expect(src.contains('void GlobalLookupWindow::RecoverDeadWebView'), isTrue,
+        reason: 'BUG-693 的死 WebView 自愈重建');
+    expect(src.contains('put_IsStatusBarEnabled(FALSE)'), isTrue,
+        reason: 'BUG-1097 的 WebView2 状态栏关闭');
+    // 自愈重建走 EnsureWebView -> 创建路径 -> ApplyDpiScale，重建后的实例也拿到
+    // 一致的 DPI 设置；这里锁死自愈仍旧复用创建路径。
+    final int i = src.indexOf('void GlobalLookupWindow::RecoverDeadWebView');
+    expect(i, greaterThan(0));
+    expect(
+      src.substring(i, i + 2000).contains('EnsureWebView'),
+      isTrue,
+      reason: '自愈必须复用创建路径，否则重建出来的 WebView 又没有 DPI 设置',
+    );
+  });
+}

--- a/hibiki/test/tools/gal_hook_overlay_buttons_guard_test.dart
+++ b/hibiki/test/tools/gal_hook_overlay_buttons_guard_test.dart
@@ -75,6 +75,11 @@ void main() {
     // 设置项 gal_hook_text_font_size 单独控制（旧的按高度缩放让「拖高一点」变成
     // 「字也跟着变」，两个诉求被绑死）。守卫从「必须缩放」翻转为「必须不缩放」。
     final String source = window.readAsStringSync();
+    expect(
+      source.contains('kHookTextBaseHeightForFontDip'),
+      isFalse,
+      reason: '这个常量就是「拖高浮窗 = 放大台词」的耦合来源，不得回来',
+    );
     final int scaleAt = source.indexOf('const float height_scale');
     expect(scaleAt, greaterThan(0), reason: '非 hook 的歌词条仍按高度缩放，该表达式应当还在');
     final String scaleExpr = source.substring(scaleAt, scaleAt + 400);
@@ -85,7 +90,7 @@ void main() {
     );
     // 有声书歌词条的「拖高放大」不受影响：非 hook 分支仍拿实时高度算比例。
     expect(
-      scaleExpr.contains('strip_height_dip_'),
+      scaleExpr.contains('strip_height_dip_ / kBaseStripHeightForFontDip'),
       isTrue,
       reason: '非 hook 分支仍须按实时窗口高度缩放字号',
     );

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -95,6 +95,16 @@ constexpr float kTextStripHoverAlpha = 0.55f;  // visible toolbar band on hover
 // pass-through toggle keeps true alpha 0 (clicks are MEANT to fall through).
 constexpr uint32_t kHookTextMinCatchAlpha = 5;  // ~2%, invisible but hittable
 
+// BUG-1095 (第二阶段) — hook 台词的滚动条 / 滚轮步长（逻辑 96-DPI px）。
+//
+// 轨道画在文本区**右侧的留白**里：text_rect_ 只占 [pad, width - pad]，所以这条
+// 指示条压不到任何一个字，也就不必为它缩窄换行宽度——缩窄宽度会反过来改变
+// metrics.height，从而改变可滚行程，形成回环。轨道底端让开右下角 resize grip，
+// 免得两个可拖拽的东西叠在同一块像素上。
+constexpr float kScrollBarWidthDip = 4.0f;
+constexpr float kScrollBarMinThumbDip = 16.0f;
+constexpr float kScrollWheelStepDip = 40.0f;
+
 // ARGB (0xAARRGGBB) -> D2D1_COLOR_F (straight alpha).
 D2D1_COLOR_F ColorFromArgb(uint32_t argb) {
   const float a = ((argb >> 24) & 0xFF) / 255.0f;
@@ -344,6 +354,13 @@ void FloatingLyricWindow::UpdateText(const std::wstring& text,
   highlight_start_ = -1;
   highlight_length_ = 0;
   text_layout_.Reset();
+  // BUG-1095 (第二阶段) — 新台词一律回到顶部。
+  //
+  // 这里换掉的是**整句**，不是往下追加：保留旧偏移只会把用户直接扔到一句他还
+  // 没读过的话的中间，比「跳回开头」糟得多。所以没有「用户正在往下看就别动」
+  // 的分支——那个分支要成立，前提是新旧文本连续，而 hook 台词从来不是。
+  scroll_offset_px_ = 0.0f;
+  scroll_max_px_ = 0.0f;
   RequestRender();
 }
 
@@ -422,6 +439,25 @@ void FloatingLyricWindow::SetVoiceState(bool replaying, bool recapturing) {
 
 void FloatingLyricWindow::SetClickLookupEnabled(bool enabled) {
   click_lookup_enabled_ = enabled;
+}
+
+bool FloatingLyricWindow::ScrollBy(float delta_px) {
+  // 三个前置条件写在一处，调用方（WM_MOUSEWHEEL）不必再抄一遍：
+  //  * 只有 hook 台词能滚——歌词条 / 剪贴板文本窗保持历史行为，一字不改；
+  //  * 穿透模式下鼠标整个属于游戏，滚轮不归我们（WM_NCHITTEST 已经对正文返回
+  //    HTTRANSPARENT，这里再挡一道是为了顶部“恢复带”那几十像素也不例外）；
+  //  * 没有溢出就没有行程，返回 false 让事件继续往下传。
+  if (!hook_text_mode_ || pass_through_ || scroll_max_px_ <= 0.0f) {
+    return false;
+  }
+  const float next =
+      std::clamp(scroll_offset_px_ + delta_px, 0.0f, scroll_max_px_);
+  if (next == scroll_offset_px_) {
+    return false;  // 已经顶到头 / 到底：不吞事件。
+  }
+  scroll_offset_px_ = next;
+  RequestRender();
+  return true;
 }
 
 void FloatingLyricWindow::SetLocked(bool locked) {
@@ -714,6 +750,29 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       }
       return HTCLIENT;
     }
+    case WM_MOUSEWHEEL: {
+      // BUG-1095 (第二阶段) — 滚轮翻台词。交互契约写在这里，别处不再重复：
+      //
+      //  * **接管条件**全在 ScrollBy 里（hook 模式 + 非穿透 + 真有溢出）。不满足
+      //    就落回 DefWindowProc，歌词条 / 剪贴板文本窗的行为一字不改。
+      //  * **穿透模式**下 WM_NCHITTEST 已经对正文返回 HTTRANSPARENT，滚轮压根到
+      //    不了这里；顶部那条“恢复带”仍能收到消息，ScrollBy 的 pass_through_
+      //    判据把它也挡掉——穿透就是「鼠标整个属于游戏」，不留半个例外。
+      //  * **和工具条不打架**：那八个按钮只吃 WM_LBUTTONDOWN，从不吃滚轮。所以
+      //    滚轮的命中区可以是整个窗口，不需要「避开按钮」这种特例分支——鼠标停
+      //    在按钮上滚也照样翻文本，这正是用户预期。
+      //  * **滚到顶 / 滚到底不吞事件**（ScrollBy 返回 false），避免把窗口变成一
+      //    个吃掉滚轮的黑洞。
+      const int delta = GET_WHEEL_DELTA_WPARAM(wparam);
+      if (delta != 0) {
+        const float step = ScaleForDpi(kScrollWheelStepDip) *
+                           (-static_cast<float>(delta) / WHEEL_DELTA);
+        if (ScrollBy(step)) {
+          return 0;
+        }
+      }
+      return DefWindowProc(hwnd_, message, wparam, lparam);
+    }
     case WM_SIZE: {
       // A system resize (corner drag) changed the window rect; recompute the
       // logical strip size and re-render so the text + controls follow.
@@ -863,6 +922,11 @@ void FloatingLyricWindow::Render() {
   text_rect_.width = std::max(1.0f, width - pad * 2);
   text_rect_.height = std::max(1.0f, height - controls_h - pad * 0.5f);
 
+  // BUG-1095 (第二阶段) — 可滚行程每帧从零重算：文本 / 字号 / 窗高任何一项变了都
+  // 在下面的排版分支里重新量出来。没有文本 = 没有行程（分支根本不执行）；非 hook
+  // 模式也永远停在 0，歌词条 / 剪贴板窗因此完全不受滚动这套东西影响。
+  scroll_max_px_ = 0.0f;
+
   if (text_format_ != nullptr && !text_.empty()) {
     if (text_layout_ == nullptr) {
       dwrite_factory_->CreateTextLayout(text_.c_str(),
@@ -887,8 +951,19 @@ void FloatingLyricWindow::Render() {
               metrics.height > text_rect_.height
                   ? DWRITE_PARAGRAPH_ALIGNMENT_NEAR
                   : DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+          // BUG-1095 (第二阶段) — 溢出量就是可滚动行程。
+          //
+          // 顶端对齐（上面那句 NEAR）让排版从 text_rect_.top 起画，于是「滚动」
+          // 就是把绘制原点整体上移 scroll_offset_px_，而下面的裁剪框 text_clip
+          // 一动不动 —— 视口下移，被裁掉的句尾从下面走进来。这是分层窗里唯一
+          // 不需要第二个渲染目标就能做出来的滚动。
+          scroll_max_px_ = std::max(0.0f, metrics.height - text_rect_.height);
         }
       }
+      scroll_offset_px_ = std::clamp(scroll_offset_px_, 0.0f, scroll_max_px_);
+      // 没有溢出时 scroll_offset_px_ 恒为 0，text_origin_y == text_rect_.top，
+      // 与滚动引入之前逐像素一致。
+      const float text_origin_y = text_rect_.top - scroll_offset_px_;
       // BUG-1070: the lyric / hook-text body is vertically centred
       // (DWRITE_PARAGRAPH_ALIGNMENT_CENTER) inside a layout box whose top edge
       // is text_rect_.top == controls_h, i.e. just below the hover control band
@@ -926,9 +1001,9 @@ void FloatingLyricWindow::Render() {
               ColorFromArgb(style_.highlight_color), hl.GetAddressOf());
           for (const auto& m : metrics) {
             D2D1_ROUNDED_RECT hr = D2D1::RoundedRect(
-                D2D1::RectF(text_rect_.left + m.left, text_rect_.top + m.top,
+                D2D1::RectF(text_rect_.left + m.left, text_origin_y + m.top,
                             text_rect_.left + m.left + m.width,
-                            text_rect_.top + m.top + m.height),
+                            text_origin_y + m.top + m.height),
                 ScaleForDpi(4), ScaleForDpi(4));
             render_target_->FillRoundedRectangle(hr, hl.Get());
           }
@@ -968,12 +1043,53 @@ void FloatingLyricWindow::Render() {
         }
       }
       render_target_->DrawTextLayout(
-          D2D1::Point2F(text_rect_.left, text_rect_.top), text_layout_.Get(),
+          D2D1::Point2F(text_rect_.left, text_origin_y), text_layout_.Get(),
           brush.Get(), D2D1_DRAW_TEXT_OPTIONS_NONE);
       // BUG-1070: balance the PushAxisAlignedClip that fenced the text to
       // text_rect_ (must pop before the control band / toolbar is drawn so the
       // buttons are unaffected).
       render_target_->PopAxisAlignedClip();
+
+      // BUG-1095 (第二阶段) — 滚动指示条。没有它用户根本不知道「下面还有」，
+      // 也看不出自己滚到了哪里。画在 text_rect_ 右侧的留白里（见
+      // kScrollBarWidthDip 的注释），所以不遮字、不改换行宽度；只在 hook 模式
+      // 且真有溢出时才出现，其余情况一个像素都不画。
+      if (hook_text_mode_ && scroll_max_px_ > 0.0f) {
+        const float bar_w = ScaleForDpi(kScrollBarWidthDip);
+        const float bar_x =
+            static_cast<float>(width) - pad * 0.5f - bar_w * 0.5f;
+        const float track_top = text_rect_.top;
+        const float track_bottom = std::max(
+            track_top + bar_w,
+            text_rect_.top + text_rect_.height - ScaleForDpi(kResizeGripDip));
+        const float track_h = track_bottom - track_top;
+        const float content_h = text_rect_.height + scroll_max_px_;
+        const float min_thumb =
+            std::min(track_h, ScaleForDpi(kScrollBarMinThumbDip));
+        const float thumb_h = std::clamp(
+            track_h * (text_rect_.height / std::max(1.0f, content_h)),
+            min_thumb, track_h);
+        const float thumb_y =
+            track_top +
+            (track_h - thumb_h) * (scroll_offset_px_ / scroll_max_px_);
+        Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> bar;
+        render_target_->CreateSolidColorBrush(
+            ColorFromArgb(style_.button_text_color), bar.GetAddressOf());
+        if (bar != nullptr) {
+          bar->SetOpacity(hovered_ ? 0.12f : 0.05f);
+          render_target_->FillRoundedRectangle(
+              D2D1::RoundedRect(
+                  D2D1::RectF(bar_x, track_top, bar_x + bar_w, track_bottom),
+                  bar_w / 2.0f, bar_w / 2.0f),
+              bar.Get());
+          bar->SetOpacity(hovered_ ? 0.75f : 0.35f);
+          render_target_->FillRoundedRectangle(
+              D2D1::RoundedRect(
+                  D2D1::RectF(bar_x, thumb_y, bar_x + bar_w, thumb_y + thumb_h),
+                  bar_w / 2.0f, bar_w / 2.0f),
+              bar.Get());
+        }
+      }
     }
   }
 
@@ -1320,11 +1436,15 @@ int FloatingLyricWindow::CharIndexAt(float x, float y,
     return -1;
   }
   const float local_x = x - text_rect_.left;
-  const float local_y = y - text_rect_.top;
-  if (local_x < 0 || local_x > text_rect_.width || local_y < 0 ||
-      local_y > text_rect_.height) {
+  // BUG-1095 (第二阶段) — 边界判在**视口**里（用户只点得到看得见的字），坐标
+  // 换算到**布局**里（加回滚动偏移）。少了这一步，滚动之后点第一行会命中已经
+  // 被滚上去的那一行。scroll_offset_px_ 在非 hook 模式恒为 0，旧行为不变。
+  const float viewport_y = y - text_rect_.top;
+  if (local_x < 0 || local_x > text_rect_.width || viewport_y < 0 ||
+      viewport_y > text_rect_.height) {
     return -1;
   }
+  const float local_y = viewport_y + scroll_offset_px_;
   BOOL is_trailing = FALSE;
   BOOL is_inside = FALSE;
   DWRITE_HIT_TEST_METRICS metrics = {};
@@ -1338,7 +1458,7 @@ int FloatingLyricWindow::CharIndexAt(float x, float y,
   if (out_char_rect != nullptr) {
     // Hit-test metrics are layout-local; lift them back into client-area px.
     out_char_rect->left = text_rect_.left + metrics.left;
-    out_char_rect->top = text_rect_.top + metrics.top;
+    out_char_rect->top = text_rect_.top + metrics.top - scroll_offset_px_;
     out_char_rect->right = out_char_rect->left + metrics.width;
     out_char_rect->bottom = out_char_rect->top + metrics.height;
   }

--- a/hibiki/windows/runner/floating_lyric_window.h
+++ b/hibiki/windows/runner/floating_lyric_window.h
@@ -202,6 +202,16 @@ class FloatingLyricWindow {
 
   float ScaleForDpi(float value) const;
 
+  // BUG-1095 (第二阶段) — hook 台词的垂直滚动。
+  //
+  // 这是个分层窗 + Direct2D 自绘的条，没有任何系统滚动条：文本超出
+  // text_rect_ 时曾经只能硬裁（见 Render 里的 PushAxisAlignedClip）。ScrollBy
+  // 把滚动偏移推进 |delta_px| 物理像素并夹到 [0, scroll_max_px_]，返回
+  // true 表示偏移真的变了（调用方据此决定要不要吞掉 WM_MOUSEWHEEL）。
+  // 非 hook 模式、穿透模式、没有溢出时恒为 no-op，歌词条与剪贴板文本
+  // 窗逐像素不变。
+  bool ScrollBy(float delta_px);
+
   // Minimum visible margin (in 96-DPI logical px) that must always stay inside
   // the target monitor's work area, so the strip can never be dragged or
   // restored entirely off-screen (TODO-832). Run through ScaleForDpi before use
@@ -274,6 +284,13 @@ class FloatingLyricWindow {
   Labels labels_;
 
   TextLayoutRect text_rect_;
+
+  // BUG-1095 (第二阶段) — hook 台词的垂直滚动状态，单位是客户区物理 px。
+  // scroll_max_px_ 每帧由 Render 依据实测排版高度重算（0 = 没有溢出，整支滚动
+  // 关闭），scroll_offset_px_ 随之重新夹紧——字号 / 窗高 / 文本任一变化都不会
+  // 把偏移留在旧行程外。
+  float scroll_offset_px_ = 0.0f;
+  float scroll_max_px_ = 0.0f;
 
   // Press / drag / resize state for moving and sizing the strip.
   //

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -1059,21 +1059,11 @@ void GlobalLookupWindow::EnsureWebView() {
                                 controller2->put_DefaultBackgroundColor(
                                     transparent);
                               }
-                              // BoundsMode=RAW_PIXELS + rasterization scale 按 DPI。
-                              UINT dpi = GetDpiForWindow(hwnd_);
-                              if (dpi == 0) {
-                                dpi = 96;
-                              }
-                              wil::com_ptr<ICoreWebView2Controller3> controller3;
-                              if (SUCCEEDED(controller_->QueryInterface(
-                                      IID_PPV_ARGS(&controller3)))) {
-                                controller3->put_BoundsMode(
-                                    COREWEBVIEW2_BOUNDS_MODE_USE_RAW_PIXELS);
-                                controller3->put_ShouldDetectMonitorScaleChanges(
-                                    FALSE);
-                                controller3->put_RasterizationScale(
-                                    static_cast<double>(dpi) / 96.0);
-                              }
+                              // BUG-1104 — BoundsMode=RAW_PIXELS + 按窗口 DPI
+                              // 钉死光栅缩放。原来这段是 composition 路径的内联
+                              // 代码，windowed 回退路径没有对应物；现在两条路径
+                              // 共用 ApplyDpiScale()。
+                              ApplyDpiScale();
                               // WebView 的 visual 挂到 DComp 视觉树 → Commit 上桌面。
                               composition_controller_->put_RootVisualTarget(
                                   dcomp_visual_.get());
@@ -1166,6 +1156,13 @@ void GlobalLookupWindow::EnsureWebView() {
                         COREWEBVIEW2_COLOR transparent = {0, 0, 0, 0};
                         controller2->put_DefaultBackgroundColor(transparent);
                       }
+                      // BUG-1104 — windowed 回退路径过去**完全没有** DPI 处理：
+                      // composition 路径钉了 RasterizationScale 并关掉自动探测，
+                      // 这条路径却任由 WebView2 自己探测 monitor scale。于是同一
+                      // 个窗在两条路径下位图缩放的真值来源不同，多屏 / 非 100%
+                      // 缩放时可以差一档，亚像素取整误差被放大（BUG-1098 备注里
+                      // 记的“放大器”）。统一到同一个入口。
+                      ApplyDpiScale();
                       RECT rc;
                       GetClientRect(hwnd_, &rc);
                       controller_->put_Bounds(rc);
@@ -1203,6 +1200,39 @@ void GlobalLookupWindow::EnsureWebView() {
         "CreateCoreWebView2EnvironmentWithOptions call failed (sync)",
         create_hr);
   }
+}
+
+// BUG-1104 — 两条 WebView2 创建路径的 DPI 处理必须同源。
+//
+// 窗口坐标、shell 卡矩形、commitLayerShift 的 CSS px 换算，全部按
+// GetDpiForWindow(hwnd_) 算；而 WebView2 默认打开 ShouldDetectMonitorScaleChanges，
+// 自己去探测 monitor scale。这是两个独立的真值来源——单屏 100% 时恰好相等，多屏
+// 或非 100% 缩放时可以差一档，差出来的就是被放大的亚像素取整误差。composition
+// 路径当年已经钉死了这一项，windowed 回退路径没有，于是同一个窗走哪条路径出来
+// 的渲染都不完全一样。
+//
+// 解法是消除“两个来源”，而不是给 windowed 打补丁：真值只有一个——这个 HWND 的
+// DPI，两条创建路径和 WM_DPICHANGED 都从这里读。关掉自动探测之后跟随 DPI 变化
+// 就成了我们自己的责任，见 HandleMessage 的 WM_DPICHANGED。
+//
+// 老 runtime 拿不到 ICoreWebView2Controller3 时直接返回：保持它自己的默认行为，
+// 绝不半套地只设一项。
+void GlobalLookupWindow::ApplyDpiScale() {
+  if (!controller_ || hwnd_ == nullptr) {
+    return;
+  }
+  UINT dpi = GetDpiForWindow(hwnd_);
+  if (dpi == 0) {
+    dpi = 96;
+  }
+  wil::com_ptr<ICoreWebView2Controller3> controller3;
+  if (FAILED(controller_->QueryInterface(IID_PPV_ARGS(&controller3))) ||
+      controller3 == nullptr) {
+    return;
+  }
+  controller3->put_BoundsMode(COREWEBVIEW2_BOUNDS_MODE_USE_RAW_PIXELS);
+  controller3->put_ShouldDetectMonitorScaleChanges(FALSE);
+  controller3->put_RasterizationScale(static_cast<double>(dpi) / 96.0);
 }
 
 void GlobalLookupWindow::ConfigureWebView() {
@@ -1828,6 +1858,43 @@ LRESULT GlobalLookupWindow::HandleMessage(UINT message, WPARAM wparam,
       // border supplies the card frame, this region supplies the rounded corners.
       ApplyRoundedRegion();
       return 0;
+    case WM_DPICHANGED: {
+      // BUG-1104 — 窗口被拖到另一块缩放不同的显示器（或用户改了缩放）。
+      //
+      // 两条创建路径都关掉了 WebView2 的自动 monitor-scale 探测（理由见
+      // ApplyDpiScale），所以跟随 DPI 变化是**我们的**责任；不处理的话光栅缩放
+      // 会永远停在建窗那一刻所在的那块屏上——而这个窗是开机预热、整个 app 会话
+      // 只隐藏不销毁的长命窗口，"建窗那一刻" 可能是几小时前的事。
+      //
+      // lparam 是系统按新 DPI 算好的建议矩形，照单全收是官方契约（窗口的物理
+      // 观感大小不变）。SWP_NOZORDER | SWP_NOACTIVATE 保证不动 Z 序、不抢焦点；
+      // 且不带任何“显示窗口”标志，所以预热期的隐藏窗口不会凭空出现在桌面上
+      // （守卫 global_lookup_dpi_scale_guard_test.dart ③ 就是盯这一点）。
+      const RECT* suggested = reinterpret_cast<const RECT*>(lparam);
+      if (suggested != nullptr && hwnd_ != nullptr) {
+        SetWindowPos(hwnd_, nullptr, suggested->left, suggested->top,
+                     suggested->right - suggested->left,
+                     suggested->bottom - suggested->top,
+                     SWP_NOZORDER | SWP_NOACTIVATE);
+      }
+      ApplyDpiScale();
+      // 上面的 SetWindowPos 若真改了尺寸会触发 WM_SIZE 走同样的收尾；尺寸没变时
+      // 不会，所以这里显式再收一次（幂等）。
+      if (controller_) {
+        RECT rc;
+        GetClientRect(hwnd_, &rc);
+        controller_->put_Bounds(rc);
+      }
+      if (composition_active_) {
+        if (dcomp_device_ != nullptr) {
+          dcomp_device_->Commit();
+        }
+      } else {
+        // 圆角区域的直径按 DPI 算（ApplyRoundedRegion），换屏必须重算。
+        ApplyRoundedRegion();
+      }
+      return 0;
+    }
     case WM_ENTERSIZEMOVE:
       // Phase C（弹窗尺寸精细化 2026-07-13）— 进入模态 move/size 循环（面板拖动/调整，
       // 或 —— Phase C 起 —— 瞬态覆盖窗拖右下角 grip）。瞬态窗平时按 shell 卡矩形裁剪

--- a/hibiki/windows/runner/global_lookup_window.h
+++ b/hibiki/windows/runner/global_lookup_window.h
@@ -265,6 +265,11 @@ class GlobalLookupWindow {
   // swallows it) so the "app-external lookup shows no popup" cause is visible.
   void ReportOverlayError(const std::string& message, HRESULT hr);
   void ConfigureWebView();
+  // BUG-1104 — 把「这个 HWND 当前的 DPI」推给 WebView2 控制器（BoundsMode /
+  // ShouldDetectMonitorScaleChanges / RasterizationScale）。composition 与
+  // windowed 两条创建路径、以及 WM_DPICHANGED 都只走这一个入口，两条路径的
+  // DPI 行为因此不可能再漂开。
+  void ApplyDpiScale();
   std::wstring LoadAdapterScript() const;
   // TODO-867 P3c — reads global_lookup_host.js for top-level injection.
   std::wstring LoadHostScript() const;


### PR DESCRIPTION
补完 PR#425 明确记录为「未做」的两处遗留。

## BUG-1095 第二阶段：台词浮窗真滚动
PR#425 已把字号与窗高解耦，但**溢出仍是硬裁、没有任何滚动**——用户看不到被裁掉的句尾。

**方案**：不引入第二个渲染目标、不做滚动容器。第一阶段的顶端对齐让排版从 `text_rect_.top` 起画，于是**滚动 = 把绘制原点上移 `scroll_offset_px_`，裁剪框一动不动**，视口下移让句尾从下面走进来。这是分层 Direct2D 窗里唯一不需要额外渲染目标的做法。

### 交互语义（都按「消除特殊情况」而非加分支）
1. **新台词回到顶部**，且**刻意没有**「用户正在往下看就别动」的分支——那个分支成立的前提是新旧文本连续，而 hook 台词换的是**整句**，保留旧偏移会把用户扔进一句他还没读过的话的中间，比跳回开头糟。
2. **穿透下不滚**：正文本就返回 `HTTRANSPARENT`、滚轮到不了本窗，但顶部「恢复带」仍收消息，故 `ScrollBy` 里再挡一道——穿透就是鼠标整个属于游戏，不留例外。
3. **与工具条不打架不需要特例**：那八个按钮只吃 `WM_LBUTTONDOWN`、从不吃滚轮，所以滚轮命中区就是整窗。滚动条画在 `text_rect_` 右侧留白，压不到字（若压字就得缩窄换行宽度，而换行宽度会反过来改滚动行程，形成回环），轨道底端另让开 resize grip。
4. 滚到顶/底返回 false → 落回 `DefWindowProc`，不做滚轮黑洞。

**向后兼容**：`scroll_max_px_` 每帧先归零、只有 hook 分支赋值；无溢出时偏移恒 0、滚动条一个像素不画。歌词条 / 剪贴板文本窗逐像素不变。

### ⚠️ 已知风险
该窗是 `WS_EX_NOACTIVATE`、永不拿键盘焦点，所以 `WM_MOUSEWHEEL` 依赖 Win10+ 的「悬停滚动非活动窗口」（系统默认开）。用户若关掉该设置滚轮会失效，**无兜底路径**（键盘不可用；加滚动按钮要动 8 槽工具条布局与最小宽度，改动面更大）。

## BUG-1104 两条 WebView2 创建路径的 DPI 处理不一致
composition 路径设了 `RasterizationScale` + `ShouldDetectMonitorScaleChanges(FALSE)`，**windowed 回退路径两项都没设**，且全文无 `WM_DPICHANGED`。多屏 / 非 100% 缩放下亚像素取整误差被放大，两条路径行为不一致。

- 新增单一入口 `ApplyDpiScale()`：`BoundsMode(RAW_PIXELS)` + `ShouldDetectMonitorScaleChanges(FALSE)` + `RasterizationScale(dpi/96)`，真值只有一个——这个 HWND 的 DPI。老 runtime 拿不到 `Controller3` 时整体返回，**不半套地只设一项**。
- 两条创建路径都改为调用它。
- **`WM_DPICHANGED` 做了**：收下建议矩形（`SWP_NOZORDER|SWP_NOACTIVATE`，不带显示标志，预热隐藏窗不会现身）→ `ApplyDpiScale()` → `put_Bounds` → composition `Commit()` / windowed `ApplyRoundedRegion()`。做它是**必须**的：关掉自动探测后，跟随 DPI 就成了我们的责任，不做就是半套。
- **刻意没做**：DPI 变化时不重建 WebView2 控制器（涉及 BUG-693 自愈状态机，风险远高于收益；`put_RasterizationScale` 本就是为运行时改缩放设计的）。BUG-693 自愈走 `EnsureWebView` 复用创建路径，重建实例自动拿到一致设置，未破坏。

## 一处守卫合并
`gal_hook_overlay_buttons_guard_test.dart` 里那条「字号必须按窗高缩放」的旧契约，develop 侧与本分支各自反转过一次。合并时取 develop 的结构 + 本分支多出来的一条更强断言：**`kHookTextBaseHeightForFontDip` 这个常量不得回来**（它就是「拖高浮窗 = 放大台词」的耦合来源）。

## 验证
- `flutter analyze`（全量含 test）：No issues found!
- 定向测试：**751 passed**
- `flutter build windows --debug`：**exit 0**，`√ Built ...\hibiki.exe`

## 待真机验收
两项都**没有真机验证**——C++ 在 Dart 测试里跑不了，新增的是源码结构守卫，锁的是「修复结构存在」而非渲染结果。滚轮能否真翻出句尾、滚动条是否遮字、拖高是否真多行、`WM_DPICHANGED` 有没有一帧旧缩放闪烁，都要 Windows 真机肉眼看。本机无法构造多屏 + 不同缩放场景。

https://claude.ai/code/session_018NeGjpee1gxFXaDTkaeoa4