### PR TITLE
feat(galgame): Magpie 超分阶段二 —— 接上会话按需拉起，首次使用不再「装完没反应」

### DIFF
--- a/docs/specs/2026-07-26-magpie-upscaling-design.md
+++ b/docs/specs/2026-07-26-magpie-upscaling-design.md
@@ -1,7 +1,7 @@
 # 内置 Magpie 超分：阶段一落地 + 关键调研结论
 
 - 日期：2026-07-26
-- 状态：**阶段一已实现**（自建 fork + 自编 release + 客户端安装器）；**阶段二（会话联动 / UI / 真机验证）未开始**
+- 状态：**阶段一 + 阶段二代码已实现**；**真机验证仍为零**（详见文末阶段二 §6）
 - 需求原文（用户拍板，不再论证）：「我们自己编译吧，mpv，hook 等一样。方便修改。和 hook 一样启动游戏之前下载」
 - 上游：[Blinue/Magpie](https://github.com/Blinue/Magpie)，GPL-3.0，基线 `v0.12.1`（2025-08-27）
 - 我们的 fork：<https://github.com/hajisensai/Magpie>（public，分支 `dev`，fork 自上游 `e6167ef`）
@@ -309,3 +309,150 @@ UWP XAML Islands + WinUI 2.8（**没有 C#，没有 WinUI 3**）。
 3. 处理 Magpie 自更新指回上游（§4.5）。
 4. 决定缩放触发方式：热键模拟 / 预置 Profile（注意 §3.1 的 50ms 轮询硬规则）/ §3.4 的 CLI。
 5. 再补 UI（确认下载对话框 + 设置开关 + i18n key）与 `main.dart` 的后台自更新挂载。
+
+---
+
+# 阶段二：真正让它跑起来（2026-07-26）
+
+- 状态：**代码链路已闭合，尚未真机验证**。见 §6「还差什么」。
+- 本轮范围：探测 → 按需下载 → 写自动缩放 profile → 拉起 Magpie → 会话收束 → 设置项 + i18n
+  + native 缩放状态回传。
+
+## 1. 落地的模块
+
+| 文件 | 职责 |
+|---|---|
+| `hibiki/lib/src/mining/magpie_upscaling.dart` | **纯逻辑**：三态枚举与偏好编解码、后端裁决 `resolveMagpieBackend`、profile 增量改写 `magpieConfigWithAutoScaleProfile` / `magpieConfigWithAutoScaleDisabled`、硬禁令守卫 `magpieProfileTargetAllowed`。不碰 dart:io / FFI / UI，任意平台可单测。 |
+| `hibiki/lib/src/mining/magpie_upscaling_service.dart` | **运行时编排**：`MagpieUpscalingService.onGameWindowReady()` / `.onSessionEnded()`；Win32 边界抽象 `MagpieWin32Bridge` + 裸 FFI 实现 `MagpieWindowsBridge`。 |
+| `hibiki/lib/src/mining/magpie_download_confirm.dart` | 下载确认对话框（走 `AppModel.navigatorKey`），让服务层保持零 UI 依赖。 |
+| `hibiki/lib/src/mining/magpie_installer.dart` | 阶段一已有，本轮**接上调用方**（首装 + `main.dart` 后台自更新）。 |
+
+## 2. 挂钩点（刻意压到最小，为了与 PR#423 的并发改动错开）
+
+`gal_hook_session_controller.dart` 只多了 6 处、共约 40 行：
+
+| # | 位置 | 内容 |
+|---|---|---|
+| 1 | import 区 | `magpie_upscaling_service.dart` |
+| 2 | 字段区（`_activityDatabaseResolver` 之后） | `MagpieUpscalingService? _magpieUpscaling;` |
+| 3 | `attachActivityDatabase` 之后 | `attachMagpieUpscaling(...)` setter（同一注入范式） |
+| 4 | `_setState` | 「`boundWindow` 从 null 变非 null」跃迁 → `unawaited(_notifyMagpieWindowReady(hwnd))` |
+| 5 | `stopCapture` 的 `await _stopSources();` **之前** | `await _notifyMagpieSessionEnded();` |
+| 6 | `close()` 的 `await _stopSources();` **之前** | 同上 |
+
+**为什么收在 `_setState` 而不是四条绑窗路径各挂一次**：launch 自动绑定 / 迟到重绑 /
+手动 `bindWindow` / attach 四条路径的唯一公共事实就是「窗口从无变有」。收在状态跃迁上
+既不漏也不重，而且 PR#423 改的是降级升格 / 延迟冻结 / 逐行选轨，都不动 `_setState` 的
+这两行，冲突面接近零。
+
+注入唯一发生在 `gal_hook_text_overlay_controller.dart` 的 `start()`（`attachActivityDatabase`
+紧邻，+9 行）。不注入 = 全链路 `?.` 空操作，会话行为与没有超分时逐字节一致。
+
+## 3. 三个陷阱各自怎么处理的
+
+### 陷阱 1：50ms 前台轮询 → 绝不给 Hibiki 自己建 autoScale profile
+
+`magpieProfileTargetAllowed(targetExecutablePath, hibikiExecutablePath)` 是**硬门不是建议**：
+`magpieConfigWithAutoScaleProfile` 在验证身份完整性之后立刻调它，命中就返回
+`MagpieProfileSkipReason.forbiddenTarget`。比较忽略大小写（比 Magpie 自己的匹配更严 ——
+这里宁可多拒不可漏放）。单测 `🔴 硬禁令` 组 4 条。
+
+### 陷阱 2：便携 config 必须写 0 字节
+
+**复核结论：阶段一实现是对的。** `magpie_installer.dart:153`
+`String magpiePortableConfigContent() => '';` —— 真的是空字符串、真的写出 0 字节文件。
+`ensurePortableConfig` 还额外保证「已存在 config.json 就一律不动」。
+本轮加了源码守卫测试钉死这一行，防止后人「顺手」改成 `{}`。
+
+### 陷阱 3：Magpie 自带更新器指向上游
+
+**没有改 fork，因为它在我们的产物里是死代码 —— 有完整证据链：**
+
+| 环 | 事实 | 位置 |
+|---|---|---|
+| 1 | 我们的 release workflow **不传** `--version-string` | `hajisensai/Magpie` `.github/workflows/hibiki-release.yml:86` |
+| 2 | 不传 → msbuild 属性 `VersionString` 为空 | `scripts/publish.py:60` |
+| 3 | `VersionString` 为空 → **`MP_VERSION_STRING` 宏根本不定义** | `src/Common.Post.props:13,35`（`Condition="'$(VersionString)' != ''"`） |
+| 4 | 未定义 → `UpdateService::Initialize()` **整个函数体被 `#ifdef` 编译掉**（定时器、启动检查、设置回调全没了） | `src/Magpie/UpdateService.cpp:34` |
+| 5 | 未定义 → 「检查更新」按钮 `IsCheckForUpdatesButtonEnabled()` 恒 `return false` | `src/Magpie/AboutViewModel.cpp:110-116` |
+
+即：自动检查不会启动，手动检查按钮是灰的，`CheckForUpdatesAsync` 里那两个硬编码的
+`raw.githubusercontent.com/Blinue/Magpie/...` URL 永远走不到。改 fork 的 C++ 反而要
+承担「本机编不了 Magpie（缺 VC/UWP 工作负载 + Conan，见 §4.4）→ 改了没法验证」的风险。
+
+⚠️ **这条保证依赖于 workflow 永远不传 `--version-string`**。哪天有人为了让 About 页显示
+版本号而加上它，更新器就会复活并把我们的产物换成上游官方包。若要把它变成结构性保证，
+应在 fork 的 workflow 里发布前删掉 `Updater.exe`（纯 workflow 改动、无 C++ 编译风险）——
+本轮没做。
+
+## 4. 新增的关键 schema 事实（阶段一文档**漏了一条要命的**）
+
+🔴 **`classNameRule` 不是可选项。** `ProfileService::_GetProfileForWindow` 先比
+`classNameRule` 再比 `pathRule`（`ProfileService.cpp:220-222`，类名比取 exe 路径快得多所以
+放前面）。**只写 `pathRule` 不写 `classNameRule` 的 profile 永远匹配不上任何窗口**，是一条
+静默的死规则。阶段一文档 §3.2 只提了 `pathRule` 大小写敏感，没提这个先决条件。
+
+因此 `MagpieWindowIdentity` 是 `(executablePath, windowClassName)` 二元组，运行时由
+`GetClassNameW` + `QueryFullProcessImageNameW` 取（后者必须与 Magpie 的
+`Win32Helper::GetWindowPath` 同源，因为匹配是裸 `std::wstring ==`）。
+
+其余已核实：`name` trim 后非空 / `packaged` / `pathRule` / `classNameRule` 四者缺一，
+`_LoadProfile` 直接返回 false 丢弃整条（`AppSettings.cpp:926-960`）；`autoScale` 是 uint
+枚举 `Disabled=0 / Fullscreen=1 / Windowed=2 / COUNT=3`（`Profile.h:29-34`）；
+`scalingMode` 越界钳 -1（`AppSettings.cpp:990-993`），而 `scalingMode < 0` 直接报
+`InvalidScalingMode`（`ScalingService.cpp:324`）。
+
+## 5. 生命周期（时序是硬约束，不是风格）
+
+```
+onGameWindowReady(hwnd)
+  ├─ 读三态偏好 → resolveMagpieBackend
+  │    installedAvailable = 我们装好了 OR 机器上已有 Magpie 在跑（互斥体）
+  ├─ needsDownload → ensureInstalled(confirm)   ← 确认框立即弹，体积探测后台补
+  ├─ 已有别人的 Magpie 在跑 → hotkeyOnly，什么都不碰      ← 见下
+  ├─ 【必须在拉起之前】写 autoScale profile（best-effort）
+  └─ Process.start(Magpie.exe, ['-t'])          ← 静默、只驻托盘
+
+onSessionEnded()
+  ├─ broadcastQuit()（best-effort）
+  ├─ 等 3s，超时 kill —— 只 kill 我们自己起的那个 PID
+  ├─ 静置 400ms                                  ← 见下
+  └─ 把 autoScale 关回 Disabled
+```
+
+三条时序理由（都有源码依据）：
+
+1. **配置必须在拉起之前写**：Magpie 只在 `AppSettings::Initialize()` 读一次 config.json，
+   全仓**没有任何文件监视**（0 处 `ReadDirectoryChanges` / `FindFirstChangeNotification`）。
+2. **收尾必须在 Magpie 退出之后**：Magpie 在设置变更与主窗口销毁时 `SaveAsync()` 整份回写
+   （`AppSettings.cpp:287`、`MainWindow.cpp:320`）。提前改一定被覆盖。
+3. **QUIT 必须有 kill 兜底**：`App::InitMessages()` 只对 `WM_MAGPIE_SHOWME` 调了
+   `ChangeWindowMessageFilter`，**QUIT 没放行**（`App.cpp:57-60`）。Magpie 若自我提权运行，
+   我们的广播会被 UIPI 静默丢掉。且 `-t` 模式没有主窗口，`HWND_BROADCAST` 能不能投到
+   托盘窗口未经验证。
+
+**为什么「用户自己开着 Magpie 就什么都不做」**：① 它的配置在哪我们不知道（便携 vs
+`%LOCALAPPDATA%\Magpie\config\v4\`）；② 它读配置只在启动时读一次、退出又整份回写，
+此时改必被覆盖；③ 那是用户的进程，我们没有权限替他关掉重开。代价是这种情况下用户得
+自己按 Magpie 热键。**如实记为已知限制。**
+
+**为什么会话结束必须把 autoScale 关回去**：留着的话，用户下次**不经 Hibiki**直接双击游戏
+也会被 Magpie 的 50ms 轮询自动拉起缩放 —— 那是我们没被授权做的事。
+
+## 6. 还差什么才能真机验证（如实清单）
+
+1. 🔴 **`magpie-hibiki` release 从没被真的下载安装过**。`ensureInstalled` 全链路
+   （下载 → sha256 → 换入 → 0 字节 config → `Magpie.exe -t` 能起 → 便携模式生效）
+   本轮仍只有单测，**没有一次真机执行**。
+2. 🔴 **「启动游戏 → 自动超分」端到端从没跑通过**。链路上每一环都有单测或源码证据，
+   但「Magpie 读到我们写的 profile → 50ms 轮询命中 → 真的全屏缩放起来」这一步是纯推理。
+   尤其 `classNameRule` 取值是否与 Magpie 的 `ParseClassName` 结果一致（它对 WPF /
+   RPGMakerMZ / TeknoParrot 三类窗口有特殊解析，`ProfileService.cpp:87-99`）**未验证**。
+3. **首次使用必然降级为热键模式**。我们写的便携 config 是 0 字节，Magpie 第一次跑完才会
+   生成含 `scalingModes` 的完整配置。所以：第一局游戏 = `hotkeyOnly`，第二局起才可能
+   `active`。这是陷阱 2 与「不手写 scalingModes」两条约束的必然结果，不是 bug，但**用户
+   感知上是「第一次装完没反应」**，UI 上目前没有任何提示。
+4. **查词浮窗与缩放窗口的实际共存**未验证（§3.1 推断失焦不结束缩放，但没在真机上看过）。
+5. `-t` 静默模式下 `HWND_BROADCAST` 的 QUIT 能否投达未验证（有 kill 兜底，不阻塞）。
+6. 设置项落在「查词 → 外部集成」分组里（`lookup.galgame_upscaling`），不是独立的「游戏」
+   设置页 —— 本仓目前**没有** galgame 设置 destination，新建一个的改动面远大于收益。

--- a/docs/specs/2026-07-26-magpie-upscaling-design.md
+++ b/docs/specs/2026-07-26-magpie-upscaling-design.md
@@ -448,11 +448,98 @@ onSessionEnded()
    但「Magpie 读到我们写的 profile → 50ms 轮询命中 → 真的全屏缩放起来」这一步是纯推理。
    尤其 `classNameRule` 取值是否与 Magpie 的 `ParseClassName` 结果一致（它对 WPF /
    RPGMakerMZ / TeknoParrot 三类窗口有特殊解析，`ProfileService.cpp:87-99`）**未验证**。
-3. **首次使用必然降级为热键模式**。我们写的便携 config 是 0 字节，Magpie 第一次跑完才会
-   生成含 `scalingModes` 的完整配置。所以：第一局游戏 = `hotkeyOnly`，第二局起才可能
-   `active`。这是陷阱 2 与「不手写 scalingModes」两条约束的必然结果，不是 bug，但**用户
-   感知上是「第一次装完没反应」**，UI 上目前没有任何提示。
+3. ~~**首次使用必然降级为热键模式**~~ → **已修**，见 §7 的预热（bootstrap）。
 4. **查词浮窗与缩放窗口的实际共存**未验证（§3.1 推断失焦不结束缩放，但没在真机上看过）。
 5. `-t` 静默模式下 `HWND_BROADCAST` 的 QUIT 能否投达未验证（有 kill 兜底，不阻塞）。
 6. 设置项落在「查词 → 外部集成」分组里（`lookup.galgame_upscaling`），不是独立的「游戏」
    设置页 —— 本仓目前**没有** galgame 设置 destination，新建一个的改动面远大于收益。
+
+---
+
+# 阶段二追加：消灭「装完第一次没反应」（2026-07-26）
+
+上一轮自报的两条缺口（§6.3 首次必然热键模式、§6 的「`scalingActive` 接上了 native 回传却
+没有任何 UI 消费」）本轮一并修掉。**能绕掉的约束就绕掉，绕不掉的才做提示。**
+
+## 7. 预热（bootstrap）——把「第一局只能按热键」从必然变成异常
+
+### 为什么原来必然降级
+
+我们装完写的是 0 字节 `config\config.json`（陷阱 2 要求）。它里面没有 `scalingModes`，
+而没有 `scalingModes` 就不能写 profile —— `scalingMode` 会被钳到 -1
+（`AppSettings.cpp:990-993`），缩放直接报 `InvalidScalingMode`（`ScalingService.cpp:324`）。
+于是第一局必然 `hotkeyOnly`。
+
+### 绕开的办法（可行性已从源码坐实）
+
+`AppSettings::Initialize()` 读到空配置就**当场**灌默认值并回存：
+
+```cpp
+if (configText.empty()) {
+    Logger::Get().Info("配置文件为空");
+    _SetDefaultScalingModes();   // 7 套缩放模式
+    _SetDefaultShortcuts();
+    SaveAsync();                 // AppSettings.cpp:243-246
+    return true;
+}
+```
+
+而 `SaveAsync()` 只是 `resume_background()` 之后直接 `_Save(data)`
+（`AppSettings.cpp:287-293`）—— **没有防抖、没有定时器**，正常几百毫秒内落盘。
+
+所以 `MagpieUpscalingService._ensureConfigMaterialized()` 做的事是：配置没就绪时**先静默跑
+一次** `Magpie.exe -t` 让它自己把完整配置写出来，轮询等到 `scalingModes` 非空（上限 8s），
+再把这个预热实例收掉，然后才写 profile、才真正启动。第一局就能自动缩放。
+
+风险与代价（如实）：
+
+- 只在配置没就绪时发生，**第二局起零开销**（只多读一次文件）。
+- 整条 `onGameWindowReady` 是从 `_setState` 里 `unawaited` 调的，**预热不阻塞会话**。
+- 预热实例必须收干净，否则单实例互斥体会把后面真正那次启动挡掉 —— 收尾放在 `finally`，
+  且有源码守卫测试钉住。
+- Magpie 若坏到永远写不出配置，每局白付 8s（有上限、自清理、不影响会话）。此时降级原因是
+  新增的 `MagpieProfileSkipReason.bootstrapFailed`，UI 会说人话。
+- **仍未真机验证**：`-t` 静默启动能否在无人值守下走完 `AppSettings::Initialize()` 并落盘，
+  是按源码推断的，没在真机上看过。
+
+## 8. 用户可见的超分状态
+
+`magpie_upscaling_text.dart`：枚举 → 人话，范式与 `gal_hook_failure_text.dart` 逐条对齐
+（纯模型不依赖 i18n；诊断保留机器可读 `name`；**返回 null 表示无话可说，绝不编造处置**）。
+硬纪律：绝不把 `bootstrapFailed` / `schemaMismatch` 这类内部枚举名甩到界面上 —— 那正是
+`engine_pcm_unavailable` 当初被原样显示给用户的老毛病。有一条穷举测试遍历所有
+`status × skipReason` 组合，断言用户可见字符串**不含任何**内部标识符。
+
+落点：捕获工作台的**健康卡**（`texthooker_page.dart` 的 `_CaptureHealthCard`），紧挨着
+「窗口」那一行 —— 说的是同一个游戏窗口，而且浮窗的「打开工作台」按钮就导航到这里
+（`gal_hook_text_overlay_controller.dart:441`），用户想知道「超分到底开没开」时第一眼看的
+就是这张卡。
+
+两行结构（`_UpscalingHealthRows`）：
+
+| 行 | 内容 |
+|---|---|
+| 状态行 | 复用既有 `_HealthRow`（label + value + `ready` 二值），与其余五行同构 |
+| 处置行 | 单独一行，因为 `_HealthRow.value` 是 `maxLines: 1` 的右对齐短值，装不下一句话 |
+
+文案分三种降级，因为对用户是三件不同的事：
+
+- **首次初始化**（`bootstrapFailed`）：「这次 Magpie 还在做首次初始化。现在按 Win+Shift+A
+  就能放大；下次启动游戏会自动放大。」—— 会自己好。
+- **已有别的 Magpie 在跑**（`externalInstance`）：「你的电脑上已经开着一个 Magpie，Hibiki
+  没有去动它。」—— 永远不会自己好，得让用户知道是我们有意不碰。
+- **其余**：只给通用处置，不瞎解释。
+
+另外 `active` 分两种说法：native 的 `MagpieScalingChanged` 广播回填 `scalingActive` 之前，
+我们只知道「已按自动缩放配置拉起了 Magpie」，**不知道它真的放大了没有**，此时说的是「已就绪
+但没有自动开始」。收到广播才敢说「已开启」。**不拿意图冒充结果。**
+
+`MagpieUpscalingService` 因此改成 `ChangeNotifier`：所有 `_report = ...` 走一个私有 setter，
+写完立刻 `notifyListeners()`，UI 用 `ListenableBuilder` 订阅。这样以后新增赋值点的人不会忘
+记通知（「状态变了界面不动」太容易犯）。
+
+## 9. 本轮仍未解决
+
+- 真机验证依然为零（§6.1 / §6.2 原样成立）。预热、状态卡、文案全部只有单测与源码证据。
+- 预热失败时每局多花 8s 的上限没有做「连续失败就不再试」的记忆 —— 现在每局都会重试一次。
+  真机验证前不加这个记忆是有意的：先看它到底会不会失败，再决定要不要退避。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45186 (2658 per locale)
+/// Strings: 45305 (2665 per locale)
 ///
-/// Built on 2026-07-25 at 22:36 UTC
+/// Built on 2026-07-26 at 02:35 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3528,6 +3528,15 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get download_save_root_not_writable => 'That folder is not writable.';
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  String get galgame_upscaling => 'Game window upscaling';
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  String get galgame_upscaling_auto => 'Auto';
+  String get galgame_upscaling_installed_only => 'Installed only';
+  String get galgame_upscaling_off => 'Off';
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -9560,6 +9569,22 @@ class _StringsAr extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -15665,6 +15690,22 @@ class _StringsDe extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -21786,6 +21827,22 @@ class _StringsEs extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -27918,6 +27975,22 @@ class _StringsFr extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -33977,6 +34050,22 @@ class _StringsId extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -40084,6 +40173,22 @@ class _StringsIt extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -45996,6 +46101,22 @@ class _StringsJa extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -51911,6 +52032,22 @@ class _StringsKo extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -57996,6 +58133,22 @@ class _StringsNl extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -64096,6 +64249,22 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -70179,6 +70348,22 @@ class _StringsRu extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -76207,6 +76392,22 @@ class _StringsTh extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -82267,6 +82468,22 @@ class _StringsTr extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -88314,6 +88531,22 @@ class _StringsVi extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 // Path: <root>
@@ -93943,6 +94176,22 @@ class _StringsZhCn extends _StringsEn {
   String get download_save_root_not_writable => '该目录不可写入。';
   @override
   String get download_save_root_fallback_warning => '配置的下载目录当前不可用，已回退到默认目录。';
+  @override
+  String get galgame_upscaling => '游戏窗口超分';
+  @override
+  String get galgame_upscaling_hint =>
+      '使用 Magpie 在 galgame hook 会话期间对游戏窗口做超分。「自动」会在首次使用时按需下载 Magpie。';
+  @override
+  String get galgame_upscaling_auto => '自动';
+  @override
+  String get galgame_upscaling_installed_only => '仅用已装';
+  @override
+  String get galgame_upscaling_off => '关闭';
+  @override
+  String get galgame_upscaling_download_title => '下载 Magpie 超分组件？';
+  @override
+  String get galgame_upscaling_download_body =>
+      '游戏窗口超分需要 Magpie（约 10 MB，GPL-3.0，由我们自行从源码编译）。现在下载吗？';
 }
 
 // Path: <root>
@@ -99773,6 +100022,22 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get download_save_root_fallback_warning =>
       'The configured download folder is unavailable, so the default folder is being used.';
+  @override
+  String get galgame_upscaling => 'Game window upscaling';
+  @override
+  String get galgame_upscaling_hint =>
+      'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+  @override
+  String get galgame_upscaling_auto => 'Auto';
+  @override
+  String get galgame_upscaling_installed_only => 'Installed only';
+  @override
+  String get galgame_upscaling_off => 'Off';
+  @override
+  String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
+  @override
+  String get galgame_upscaling_download_body =>
+      'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
 }
 
 /// Flat map(s) containing all translations.
@@ -105202,6 +105467,20 @@ extension on _StringsEn {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -110629,6 +110908,20 @@ extension on _StringsAr {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -116077,6 +116370,20 @@ extension on _StringsDe {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -121524,6 +121831,20 @@ extension on _StringsEs {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -126977,6 +127298,20 @@ extension on _StringsFr {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -132412,6 +132747,20 @@ extension on _StringsId {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -137862,6 +138211,20 @@ extension on _StringsIt {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -143274,6 +143637,20 @@ extension on _StringsJa {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -148690,6 +149067,20 @@ extension on _StringsKo {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -154133,6 +154524,20 @@ extension on _StringsNl {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -159573,6 +159978,20 @@ extension on _StringsPtBr {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -165018,6 +165437,20 @@ extension on _StringsRu {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -170447,6 +170880,20 @@ extension on _StringsTh {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -175885,6 +176332,20 @@ extension on _StringsTr {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -181318,6 +181779,20 @@ extension on _StringsVi {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }
@@ -186708,6 +187183,20 @@ extension on _StringsZhCn {
         return '该目录不可写入。';
       case 'download_save_root_fallback_warning':
         return '配置的下载目录当前不可用，已回退到默认目录。';
+      case 'galgame_upscaling':
+        return '游戏窗口超分';
+      case 'galgame_upscaling_hint':
+        return '使用 Magpie 在 galgame hook 会话期间对游戏窗口做超分。「自动」会在首次使用时按需下载 Magpie。';
+      case 'galgame_upscaling_auto':
+        return '自动';
+      case 'galgame_upscaling_installed_only':
+        return '仅用已装';
+      case 'galgame_upscaling_off':
+        return '关闭';
+      case 'galgame_upscaling_download_title':
+        return '下载 Magpie 超分组件？';
+      case 'galgame_upscaling_download_body':
+        return '游戏窗口超分需要 Magpie（约 10 MB，GPL-3.0，由我们自行从源码编译）。现在下载吗？';
       default:
         return null;
     }
@@ -192115,6 +192604,20 @@ extension on _StringsZhHk {
         return 'That folder is not writable.';
       case 'download_save_root_fallback_warning':
         return 'The configured download folder is unavailable, so the default folder is being used.';
+      case 'galgame_upscaling':
+        return 'Game window upscaling';
+      case 'galgame_upscaling_hint':
+        return 'Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.';
+      case 'galgame_upscaling_auto':
+        return 'Auto';
+      case 'galgame_upscaling_installed_only':
+        return 'Installed only';
+      case 'galgame_upscaling_off':
+        return 'Off';
+      case 'galgame_upscaling_download_title':
+        return 'Download Magpie upscaler?';
+      case 'galgame_upscaling_download_body':
+        return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,7 +1,7 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45305 (2665 per locale)
+/// Strings: 45458 (2674 per locale)
 ///
 /// Built on 2026-07-26 at 02:35 UTC
 
@@ -3537,6 +3537,22 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get galgame_upscaling_download_title => 'Download Magpie upscaler?';
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -9585,6 +9601,31 @@ class _StringsAr extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -15706,6 +15747,31 @@ class _StringsDe extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -21843,6 +21909,31 @@ class _StringsEs extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -27991,6 +28082,31 @@ class _StringsFr extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -34066,6 +34182,31 @@ class _StringsId extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -40189,6 +40330,31 @@ class _StringsIt extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -46117,6 +46283,31 @@ class _StringsJa extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -52048,6 +52239,31 @@ class _StringsKo extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -58149,6 +58365,31 @@ class _StringsNl extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -64265,6 +64506,31 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -70364,6 +70630,31 @@ class _StringsRu extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -76408,6 +76699,31 @@ class _StringsTh extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -82484,6 +82800,31 @@ class _StringsTr extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -88547,6 +88888,31 @@ class _StringsVi extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 // Path: <root>
@@ -94192,6 +94558,27 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       '游戏窗口超分需要 Magpie（约 10 MB，GPL-3.0，由我们自行从源码编译）。现在下载吗？';
+  @override
+  String get galgame_upscaling_status_active => '窗口超分已开启';
+  @override
+  String get galgame_upscaling_status_manual => '窗口超分已就绪，但没有自动开始';
+  @override
+  String get galgame_upscaling_status_unavailable => '窗口超分暂时用不了';
+  @override
+  String get galgame_upscaling_status_failed => '窗口超分没能启动';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      '这次 Magpie 还在做首次初始化。现在按 Win+Shift+A 就能放大；下次启动游戏会自动放大。';
+  @override
+  String get galgame_upscaling_hint_external =>
+      '你的电脑上已经开着一个 Magpie，Hibiki 没有去动它。按 Win+Shift+A 就能放大游戏窗口。';
+  @override
+  String get galgame_upscaling_hint_manual => '按 Win+Shift+A 放大游戏窗口。';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      '没有安装 Magpie。把「游戏窗口超分」改成「自动」即可下载。';
+  @override
+  String get game_health_upscaling => '窗口超分';
 }
 
 // Path: <root>
@@ -100038,6 +100425,31 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get galgame_upscaling_download_body =>
       'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+  @override
+  String get galgame_upscaling_status_active => 'Window upscaling is on';
+  @override
+  String get galgame_upscaling_status_manual =>
+      'Window upscaling is ready, but did not start on its own';
+  @override
+  String get galgame_upscaling_status_unavailable =>
+      'Window upscaling is not available';
+  @override
+  String get galgame_upscaling_status_failed =>
+      'Window upscaling could not start';
+  @override
+  String get galgame_upscaling_hint_first_run =>
+      'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+  @override
+  String get galgame_upscaling_hint_external =>
+      'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_manual =>
+      'Press Win+Shift+A to upscale the game window.';
+  @override
+  String get galgame_upscaling_hint_not_installed =>
+      'Magpie is not installed. Set window upscaling to Auto to download it.';
+  @override
+  String get game_health_upscaling => 'Window upscaling';
 }
 
 /// Flat map(s) containing all translations.
@@ -105481,6 +105893,24 @@ extension on _StringsEn {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -110922,6 +111352,24 @@ extension on _StringsAr {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -116384,6 +116832,24 @@ extension on _StringsDe {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -121845,6 +122311,24 @@ extension on _StringsEs {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -127312,6 +127796,24 @@ extension on _StringsFr {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -132761,6 +133263,24 @@ extension on _StringsId {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -138225,6 +138745,24 @@ extension on _StringsIt {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -143651,6 +144189,24 @@ extension on _StringsJa {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -149081,6 +149637,24 @@ extension on _StringsKo {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -154538,6 +155112,24 @@ extension on _StringsNl {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -159992,6 +160584,24 @@ extension on _StringsPtBr {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -165451,6 +166061,24 @@ extension on _StringsRu {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -170894,6 +171522,24 @@ extension on _StringsTh {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -176346,6 +176992,24 @@ extension on _StringsTr {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -181793,6 +182457,24 @@ extension on _StringsVi {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }
@@ -187197,6 +187879,24 @@ extension on _StringsZhCn {
         return '下载 Magpie 超分组件？';
       case 'galgame_upscaling_download_body':
         return '游戏窗口超分需要 Magpie（约 10 MB，GPL-3.0，由我们自行从源码编译）。现在下载吗？';
+      case 'galgame_upscaling_status_active':
+        return '窗口超分已开启';
+      case 'galgame_upscaling_status_manual':
+        return '窗口超分已就绪，但没有自动开始';
+      case 'galgame_upscaling_status_unavailable':
+        return '窗口超分暂时用不了';
+      case 'galgame_upscaling_status_failed':
+        return '窗口超分没能启动';
+      case 'galgame_upscaling_hint_first_run':
+        return '这次 Magpie 还在做首次初始化。现在按 Win+Shift+A 就能放大；下次启动游戏会自动放大。';
+      case 'galgame_upscaling_hint_external':
+        return '你的电脑上已经开着一个 Magpie，Hibiki 没有去动它。按 Win+Shift+A 就能放大游戏窗口。';
+      case 'galgame_upscaling_hint_manual':
+        return '按 Win+Shift+A 放大游戏窗口。';
+      case 'galgame_upscaling_hint_not_installed':
+        return '没有安装 Magpie。把「游戏窗口超分」改成「自动」即可下载。';
+      case 'game_health_upscaling':
+        return '窗口超分';
       default:
         return null;
     }
@@ -192618,6 +193318,24 @@ extension on _StringsZhHk {
         return 'Download Magpie upscaler?';
       case 'galgame_upscaling_download_body':
         return 'Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?';
+      case 'galgame_upscaling_status_active':
+        return 'Window upscaling is on';
+      case 'galgame_upscaling_status_manual':
+        return 'Window upscaling is ready, but did not start on its own';
+      case 'galgame_upscaling_status_unavailable':
+        return 'Window upscaling is not available';
+      case 'galgame_upscaling_status_failed':
+        return 'Window upscaling could not start';
+      case 'galgame_upscaling_hint_first_run':
+        return 'Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.';
+      case 'galgame_upscaling_hint_external':
+        return 'A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_manual':
+        return 'Press Win+Shift+A to upscale the game window.';
+      case 'galgame_upscaling_hint_not_installed':
+        return 'Magpie is not installed. Set window upscaling to Auto to download it.';
+      case 'game_health_upscaling':
+        return 'Window upscaling';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "仅用已装",
   "galgame_upscaling_off": "关闭",
   "galgame_upscaling_download_title": "下载 Magpie 超分组件？",
-  "galgame_upscaling_download_body": "游戏窗口超分需要 Magpie（约 10 MB，GPL-3.0，由我们自行从源码编译）。现在下载吗？"
+  "galgame_upscaling_download_body": "游戏窗口超分需要 Magpie（约 10 MB，GPL-3.0，由我们自行从源码编译）。现在下载吗？",
+  "galgame_upscaling_status_active": "窗口超分已开启",
+  "galgame_upscaling_status_manual": "窗口超分已就绪，但没有自动开始",
+  "galgame_upscaling_status_unavailable": "窗口超分暂时用不了",
+  "galgame_upscaling_status_failed": "窗口超分没能启动",
+  "galgame_upscaling_hint_first_run": "这次 Magpie 还在做首次初始化。现在按 Win+Shift+A 就能放大；下次启动游戏会自动放大。",
+  "galgame_upscaling_hint_external": "你的电脑上已经开着一个 Magpie，Hibiki 没有去动它。按 Win+Shift+A 就能放大游戏窗口。",
+  "galgame_upscaling_hint_manual": "按 Win+Shift+A 放大游戏窗口。",
+  "galgame_upscaling_hint_not_installed": "没有安装 Magpie。把「游戏窗口超分」改成「自动」即可下载。",
+  "game_health_upscaling": "窗口超分"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "请选择一个绝对路径的目录。",
   "download_save_root_create_failed": "无法创建该目录，请检查磁盘与权限。",
   "download_save_root_not_writable": "该目录不可写入。",
-  "download_save_root_fallback_warning": "配置的下载目录当前不可用，已回退到默认目录。"
+  "download_save_root_fallback_warning": "配置的下载目录当前不可用，已回退到默认目录。",
+  "galgame_upscaling": "游戏窗口超分",
+  "galgame_upscaling_hint": "使用 Magpie 在 galgame hook 会话期间对游戏窗口做超分。「自动」会在首次使用时按需下载 Magpie。",
+  "galgame_upscaling_auto": "自动",
+  "galgame_upscaling_installed_only": "仅用已装",
+  "galgame_upscaling_off": "关闭",
+  "galgame_upscaling_download_title": "下载 Magpie 超分组件？",
+  "galgame_upscaling_download_body": "游戏窗口超分需要 Magpie（约 10 MB，GPL-3.0，由我们自行从源码编译）。现在下载吗？"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2663,5 +2663,14 @@
   "galgame_upscaling_installed_only": "Installed only",
   "galgame_upscaling_off": "Off",
   "galgame_upscaling_download_title": "Download Magpie upscaler?",
-  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?",
+  "galgame_upscaling_status_active": "Window upscaling is on",
+  "galgame_upscaling_status_manual": "Window upscaling is ready, but did not start on its own",
+  "galgame_upscaling_status_unavailable": "Window upscaling is not available",
+  "galgame_upscaling_status_failed": "Window upscaling could not start",
+  "galgame_upscaling_hint_first_run": "Magpie still had to set itself up this time. Press Win+Shift+A to upscale now — next time you start the game it will happen automatically.",
+  "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
+  "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
+  "game_health_upscaling": "Window upscaling"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2656,5 +2656,12 @@
   "download_save_root_not_absolute": "Please pick an absolute folder path.",
   "download_save_root_create_failed": "Cannot create that folder. Check the drive and permissions.",
   "download_save_root_not_writable": "That folder is not writable.",
-  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used."
+  "download_save_root_fallback_warning": "The configured download folder is unavailable, so the default folder is being used.",
+  "galgame_upscaling": "Game window upscaling",
+  "galgame_upscaling_hint": "Uses Magpie to upscale the galgame window while a hook session is running. Auto downloads Magpie on first use.",
+  "galgame_upscaling_auto": "Auto",
+  "galgame_upscaling_installed_only": "Installed only",
+  "galgame_upscaling_off": "Off",
+  "galgame_upscaling_download_title": "Download Magpie upscaler?",
+  "galgame_upscaling_download_body": "Game window upscaling needs Magpie (about 10 MB, GPL-3.0, built by us from source). Download it now?"
 }

--- a/hibiki/lib/main.dart
+++ b/hibiki/lib/main.dart
@@ -43,6 +43,7 @@ import 'package:hibiki/src/lookup/desktop_lookup_dispatcher.dart';
 import 'package:hibiki/src/lookup/global_lookup_controller.dart';
 import 'package:hibiki/src/lookup/gal_hook_text_overlay_controller.dart';
 import 'package:hibiki/src/mining/galgame_helper_installer.dart';
+import 'package:hibiki/src/mining/magpie_installer.dart';
 import 'package:hibiki/src/startup/desktop_window_placement.dart';
 import 'package:hibiki/src/storage/data_root_migration_view.dart';
 import 'package:hibiki/src/startup/loading_watchdog_view.dart';
@@ -426,6 +427,9 @@ void main([List<String> args = const <String>[]]) {
     // 不再绑在「点启动游戏」那一刻抢 6s——游戏启动路径在安装完整时零网络。方法自身
     // Windows 早退 + 全静默，任何失败留到下次启动再试。
     unawaited(GalgameHelperInstaller.updateInstalledHelpersInBackground());
+    // 同理，Magpie（窗口超分）的后台静默自更新。只做「已装 → 最新」：未安装/无装机
+    // 标记/残缺一律不动（首装属于交互路径，要用户确认）。非 Windows 自身早退。
+    unawaited(MagpieInstaller.updateInstalledMagpieInBackground());
 
     /// Capture Flutter framework errors with full details.
     FlutterError.onError = (details) {

--- a/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -9,6 +9,8 @@ import 'package:hibiki/src/lookup/global_lookup_controller.dart';
 import 'package:hibiki/src/utils/misc/desktop_audio_playback.dart';
 import 'package:hibiki/src/mining/gal_hook_mining_coordinator.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/mining/magpie_download_confirm.dart';
+import 'package:hibiki/src/mining/magpie_upscaling_service.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/home_game_page.dart';
@@ -122,6 +124,15 @@ class GalHookTextOverlayController extends ChangeNotifier {
     // （或测试替身无 DB）则返回 null 跳过本次落库，不在 start 急切解引用 late 字段。
     _session.attachActivityDatabase(
       () => appModel.isInitialised ? appModel.database : null,
+    );
+    // 窗口超分编排器：唯一的注入点。策略惰性读偏好（用户中途改设置下一局就生效），
+    // 下载确认走全局 navigator。未注入时会话侧全是 `?.` 空操作，故这里失败也不致命。
+    _session.attachMagpieUpscaling(
+      MagpieUpscalingService(
+        modeReader: () => appModel.galgameUpscalingMode,
+        confirmDownload: (MagpieDownloadPrompt prompt) =>
+            confirmMagpieDownload(appModel, prompt),
+      ),
     );
     _loadPreferences(appModel);
     GalHookTextOverlayChannel.setEventHandlers(

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -10,6 +10,7 @@ import 'package:hibiki/src/mining/galgame_audio_source.dart';
 import 'package:hibiki/src/mining/galgame_hook_code_profile.dart';
 import 'package:hibiki/src/mining/serial_job_queue.dart';
 import 'package:hibiki/src/mining/galgame_system_ui_filter.dart';
+import 'package:hibiki/src/mining/magpie_upscaling_service.dart';
 import 'package:hibiki/src/mining/window_capture_channel.dart';
 import 'package:hibiki/src/sync/texthooker_service.dart';
 import 'package:hibiki/src/sync/texthooker_ws_client.dart';
@@ -525,6 +526,12 @@ class GalHookSessionController extends ChangeNotifier {
   /// 避免 start 时急切解引用未初始化的 late 字段。
   HibikiDatabase? Function()? _activityDatabaseResolver;
 
+  /// 由桌面启动流程注入的窗口超分编排器（见 [attachMagpieUpscaling]）。
+  ///
+  /// 可空是刻意的：超分是**纯附加能力**，未注入（测试替身、非 Windows、用户没开）时
+  /// 整条链路是 `?.` 空操作，会话行为与没有它时逐字节一致。
+  MagpieUpscalingService? _magpieUpscaling;
+
   /// 当前会话归属的游戏显示名（窗口标题 / 可执行文件名）；null = 无可归属标题。
   String? _activityGameTitle;
 
@@ -1009,6 +1016,9 @@ class GalHookSessionController extends ChangeNotifier {
       'session.stop_listening',
       'Stopping listeners and helper; injected game code may remain until exit',
     );
+    // 必须在 _stopSources() 之前：此时 _state.boundWindow 还没被下面的复位清掉，
+    // 超分编排器仍能按本次会话的窗口身份把 autoScale profile 关回去。
+    await _notifyMagpieSessionEnded();
     await _stopSources();
     _setState(
       _state.copyWith(
@@ -1856,6 +1866,7 @@ class GalHookSessionController extends ChangeNotifier {
     _activityCharCounter.reset();
     _textService.removeListener(_onTextBufferChanged);
     _endpointListenable.removeListener(_onEndpointStatusChanged);
+    await _notifyMagpieSessionEnded();
     await _stopSources();
     dispose();
   }
@@ -1865,6 +1876,13 @@ class GalHookSessionController extends ChangeNotifier {
   /// App 尚未初始化完则返回 null 跳过本次落库）。是首页「游戏」活动的唯一数据来源。
   void attachActivityDatabase(HibikiDatabase? Function() resolve) {
     _activityDatabaseResolver = resolve;
+  }
+
+  /// 注入窗口超分编排器（桌面启动流程 [GalHookTextOverlayController.start] 调用一次）。
+  ///
+  /// 不注入 = 完全没有超分，会话逻辑不受任何影响。
+  void attachMagpieUpscaling(MagpieUpscalingService service) {
+    _magpieUpscaling = service;
   }
 
   /// 开始一段游戏活动记账：先把上一段残留 flush（防上次异常未落），再复位累计器并
@@ -2981,8 +2999,32 @@ class GalHookSessionController extends ChangeNotifier {
   }
 
   void _setState(GalHookSessionState next) {
+    // 超分启动挂钩收在这一处状态跃迁上，而不是散在四条绑窗路径（launch 自动绑定 /
+    // 迟到重绑 / 手动 bindWindow / attach）里：窗口从「无」变「有」是它们唯一的公共
+    // 事实，收在这里既不漏也不重。fire-and-forget —— 超分绝不阻塞状态更新，
+    // [MagpieUpscalingService.onGameWindowReady] 自身保证不抛。
+    final ExternalWindowInfo? previousWindow = _state.boundWindow;
     _state = next;
+    final ExternalWindowInfo? boundWindow = next.boundWindow;
+    if (previousWindow == null && boundWindow != null) {
+      unawaited(_notifyMagpieWindowReady(boundWindow.hwnd));
+    }
     notifyListeners();
+  }
+
+  /// 把「游戏窗口就绪」转给超分编排器。**吞掉一切异常**：超分是锦上添花，它出问题
+  /// 不能让 hook 会话跟着倒。
+  Future<void> _notifyMagpieWindowReady(int hwnd) async {
+    try {
+      await _magpieUpscaling?.onGameWindowReady(hwnd: hwnd);
+    } catch (_) {}
+  }
+
+  /// 会话收尾时关掉超分（关 autoScale profile + 退出我们自己起的 Magpie）。同样吞异常。
+  Future<void> _notifyMagpieSessionEnded() async {
+    try {
+      await _magpieUpscaling?.onSessionEnded();
+    } catch (_) {}
   }
 
   void _record(

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -1885,6 +1885,10 @@ class GalHookSessionController extends ChangeNotifier {
     _magpieUpscaling = service;
   }
 
+  /// 窗口超分编排器（UI 订阅它显示超分状态）。未注入 / 非 Windows 时为 null，
+  /// 调用方据此整行不显示。
+  MagpieUpscalingService? get magpieUpscaling => _magpieUpscaling;
+
   /// 开始一段游戏活动记账：先把上一段残留 flush（防上次异常未落），再复位累计器并
   /// 绑定本会话的游戏标题/稳定 id。会话开始（attach / launch）时调用。
   void _beginActivitySession({required String title, String? mediaKey}) {

--- a/hibiki/lib/src/mining/magpie_download_confirm.dart
+++ b/hibiki/lib/src/mining/magpie_download_confirm.dart
@@ -1,0 +1,78 @@
+/// Magpie 按需下载的确认对话框。
+///
+/// 单独成文件是为了让 `MagpieUpscalingService` 保持零 UI 依赖（不持 BuildContext、不引
+/// i18n），也让 galgame 会话侧的挂钩点只多一行。
+library;
+
+import 'package:flutter/material.dart';
+import 'package:hibiki/src/mining/magpie_installer.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+
+/// 弹出确认框，返回用户是否同意下载。
+///
+/// 🔴 **BUG-1076 的时序契约**：本函数**立即** `showDialog`，绝不 `await prompt.sizeProbe`
+/// 再弹。「约 N MB」由对话框自己在后台补上（[_MagpieDownloadDialog]）。旧 helper 实现是
+/// 先 await HEAD 探测再弹框，弱网下用户点了没反应，正是那个 bug 的表征。
+///
+/// 拿不到全局 navigator context（App 还没起完 / 已销毁）时返回 false —— **静默不下载**，
+/// 绝不在没有用户同意的情况下发起 10MB 下载。
+Future<bool> confirmMagpieDownload(
+  AppModel appModel,
+  MagpieDownloadPrompt prompt,
+) async {
+  final BuildContext? context = appModel.navigatorKey.currentContext;
+  if (context == null) return false;
+  final bool? agreed = await showDialog<bool>(
+    context: context,
+    builder: (BuildContext dialogContext) =>
+        _MagpieDownloadDialog(prompt: prompt),
+  );
+  return agreed ?? false;
+}
+
+class _MagpieDownloadDialog extends StatefulWidget {
+  const _MagpieDownloadDialog({required this.prompt});
+
+  final MagpieDownloadPrompt prompt;
+
+  @override
+  State<_MagpieDownloadDialog> createState() => _MagpieDownloadDialogState();
+}
+
+class _MagpieDownloadDialogState extends State<_MagpieDownloadDialog> {
+  int? _sizeBytes;
+
+  @override
+  void initState() {
+    super.initState();
+    // 后台补体积；探测失败/超时就一直不显示具体大小，对话框照常可用。
+    widget.prompt.sizeProbe.then((int? bytes) {
+      if (!mounted || bytes == null || bytes <= 0) return;
+      setState(() => _sizeBytes = bytes);
+    }).catchError((Object _) {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final int? bytes = _sizeBytes;
+    final String size = bytes == null
+        ? ''
+        : '\n\n${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB '
+            '(${widget.prompt.arch})';
+    return AlertDialog(
+      title: Text(t.galgame_upscaling_download_title),
+      content: Text('${t.galgame_upscaling_download_body}$size'),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: Text(t.dialog_cancel),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: Text(t.dialog_ok),
+        ),
+      ],
+    );
+  }
+}

--- a/hibiki/lib/src/mining/magpie_scaling_channel.dart
+++ b/hibiki/lib/src/mining/magpie_scaling_channel.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Magpie 缩放状态监听（仅 Windows）的极薄 channel 封装。
+///
+/// native 侧（`hibiki/windows/runner/flutter_window.cpp` 的 `RegisterMagpieChannel`）
+/// 用 `RegisterWindowMessage(L"MagpieScalingChanged")` 注册 Magpie 的系统广播消息，
+/// 收到后经 `app.hibiki.reader/magpie` channel 单向推 `onScalingChanged` 给 Dart。
+/// 只有 native -> Dart 一个方向，Dart 侧不发起任何调用。
+///
+/// 非 Windows / 未构建 native 时 native 永不推送，[setHandler] 装上的回调只是不会被
+/// 调用（不崩、不抛）。
+abstract final class MagpieScalingChannel {
+  static const MethodChannel _channel =
+      MethodChannel('app.hibiki.reader/magpie');
+
+  /// 当前已装载的回调；null = 未监听。
+  static void Function(MagpieScalingEvent event)? _handler;
+
+  /// 装载缩放状态回调。重复调用直接替换旧回调（同一时刻只有一个消费者）。
+  static void setHandler(void Function(MagpieScalingEvent event) callback) {
+    _handler = callback;
+    _channel.setMethodCallHandler(_dispatch);
+  }
+
+  /// 卸载回调并摘掉 native 侧的 handler（native 仍会推，但这里不再解析）。
+  static void clearHandler() {
+    _handler = null;
+    _channel.setMethodCallHandler(null);
+  }
+
+  /// 把 native 的 `onScalingChanged` 调用解析成 [MagpieScalingEvent] 派发出去。
+  /// 未知方法名静默忽略（native 加新方法时旧 Dart 不崩）。
+  static Future<Object?> _dispatch(MethodCall call) async {
+    if (call.method != 'onScalingChanged') {
+      return null;
+    }
+    final void Function(MagpieScalingEvent event)? handler = _handler;
+    if (handler == null) {
+      return null;
+    }
+    final Object? args = call.arguments;
+    if (args is! Map) {
+      return null;
+    }
+    handler(MagpieScalingEvent.fromMap(args));
+    return null;
+  }
+
+  /// 仅供测试：直接喂一条 native 消息，验证解析与派发。
+  @visibleForTesting
+  static Future<void> debugDispatch(MethodCall call) => _dispatch(call);
+}
+
+/// 一次 Magpie 缩放状态变化。
+///
+/// [state] 是 native 原样透传的 `wParam`：
+///   * `1` —— 缩放开始，或源窗口重新回到前台；
+///   * `0` —— 配合 [handle]：`handle == 0` 表示缩放真正结束（缩放窗口销毁），
+///     `handle != 0` 表示只是源窗口转到后台、缩放仍在跑；
+///   * `2` —— 窗口模式下缩放窗口位置/大小变化；
+///   * `3` —— 用户开始拖动缩放窗口。
+///
+/// [scaling] 是 native 按上述语义算好的「当前是否处于缩放中」，调用方直接用它，
+/// 不要自己再从 [state] 推导。
+@immutable
+class MagpieScalingEvent {
+  const MagpieScalingEvent({
+    required this.state,
+    required this.handle,
+    required this.scaling,
+  });
+
+  /// native 原样透传的 `wParam`（见类文档）。
+  final int state;
+
+  /// native 原样透传的 `lParam`：缩放窗口 HWND（`state == 0 && handle == 0` 时
+  /// 表示缩放已结束）。
+  final int handle;
+
+  /// 当前是否处于 Magpie 缩放中（native 已消化 `state`/`handle` 的组合语义）。
+  final bool scaling;
+
+  /// 从 native map 解析；字段缺失或类型不符时取保守缺省（`0` / `false`）。
+  static MagpieScalingEvent fromMap(Map<Object?, Object?> map) {
+    final Object? rawState = map['state'];
+    final Object? rawHandle = map['handle'];
+    final Object? rawScaling = map['scaling'];
+    return MagpieScalingEvent(
+      state: rawState is int ? rawState : 0,
+      handle: rawHandle is int ? rawHandle : 0,
+      scaling: rawScaling is bool ? rawScaling : false,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is MagpieScalingEvent &&
+      other.state == state &&
+      other.handle == handle &&
+      other.scaling == scaling;
+
+  @override
+  int get hashCode => Object.hash(state, handle, scaling);
+
+  @override
+  String toString() =>
+      'MagpieScalingEvent(state: $state, handle: $handle, scaling: $scaling)';
+}

--- a/hibiki/lib/src/mining/magpie_upscaling.dart
+++ b/hibiki/lib/src/mining/magpie_upscaling.dart
@@ -1,0 +1,401 @@
+/// 内置 Magpie 窗口超分的**纯逻辑层**（阶段二）。
+///
+/// 这一层刻意不碰 `dart:io`、不碰 FFI、不碰 UI：三态开关的后端裁决、Magpie 配置文件的
+/// profile 增量改写全部是纯函数，可在任意平台单测。真正的进程/窗口/文件操作在
+/// `magpie_upscaling_service.dart`。
+///
+/// 设计与调研结论见 `docs/specs/2026-07-26-magpie-upscaling-design.md`。
+library;
+
+import 'package:flutter/foundation.dart';
+
+/// Magpie 主窗口类名。用来探测「用户机器上已经跑着一个 Magpie」。
+const String kMagpieMainWindowClass = 'Magpie_Main';
+
+/// Magpie 的单实例互斥体名（`src/Shared/CommonSharedConstants.h`）。
+///
+/// 探测「已在运行」比找主窗口更可靠：`-t` 静默启动时根本没有主窗口，但互斥体一定在。
+const String kMagpieSingleInstanceMutex =
+    'Global\\{4C416227-4A30-4A2F-8F23-8701544DD7D6}';
+
+/// Magpie 缩放窗口类名（native 侧联动与诊断用）。
+const String kMagpieScalingWindowClass =
+    'Window_Magpie_967EB565-6F73-4E94-AE53-00CC42592A22';
+
+/// 广播消息名：缩放状态变化。`RegisterWindowMessage` 的入参。
+const String kMagpieScalingChangedMessage = 'MagpieScalingChanged';
+
+/// 广播消息名：请求已运行实例退出。**注册串就是这个字面量**，不是 `MagpieQuit`。
+const String kMagpieQuitMessage = 'WM_MAGPIE_QUIT';
+
+/// 静默启动参数：不建主窗口、只驻托盘（`CommonSharedConstants.h` 的
+/// `OPTION_LAUNCH_WITHOUT_WINDOW`，消费点 `App.cpp:188`）。
+const String kMagpieSilentLaunchArg = '-t';
+
+/// Magpie 的 `AutoScale::Fullscreen`（`src/Magpie/Profile.h:29-34` 枚举第 1 项）。
+///
+/// **必须用全屏、不能用窗口化**：窗口模式的 `WM_WINDOWPOSCHANGED` 里有个 OS bug 兜底会
+/// 主动把焦点抢回源窗口（`ScalingWindow.cpp:816-823`），查词浮窗会被踢掉。
+const int kMagpieAutoScaleFullscreen = 1;
+
+/// `AutoScale::Disabled`。
+const int kMagpieAutoScaleDisabled = 0;
+
+/// 用户可选的超分策略（三态）。
+///
+/// 与 `anime_download_config.dart` 的 `auto/builtin/external/off` 同范式，但这里**没有
+/// builtin/external 二选一**：Magpie 只有一份，区别只在「谁装的」。三态就够。
+enum MagpieUpscalingMode {
+  /// 自动：优先用机器上已有的 Magpie；没有就按需下载我们的自编产物（需用户确认）。
+  auto,
+
+  /// 只用已装的：机器上没有 Magpie 就直接不超分，**绝不联网**。
+  installedOnly,
+
+  /// 关闭。
+  off,
+}
+
+/// 默认**关闭**。理由不是保守而是诚实：整条链路截至本轮尚未真机验证（见设计文档 §6），
+/// 且超分会实打实吃 GPU。用户显式打开才启用。
+const MagpieUpscalingMode kMagpieDefaultUpscalingMode = MagpieUpscalingMode.off;
+
+/// 偏好里持久化用的稳定字符串。
+///
+/// **不要用 `enum.name` 或 index**——重排或插入枚举项会静默毁掉所有用户的旧设置。
+String magpieUpscalingModeToKey(MagpieUpscalingMode mode) {
+  switch (mode) {
+    case MagpieUpscalingMode.auto:
+      return 'auto';
+    case MagpieUpscalingMode.installedOnly:
+      return 'installed_only';
+    case MagpieUpscalingMode.off:
+      return 'off';
+  }
+}
+
+/// 反解；认不出的一律回落到 [kMagpieDefaultUpscalingMode]。
+MagpieUpscalingMode magpieUpscalingModeFromKey(String? key) {
+  switch (key) {
+    case 'auto':
+      return MagpieUpscalingMode.auto;
+    case 'installed_only':
+      return MagpieUpscalingMode.installedOnly;
+    case 'off':
+      return MagpieUpscalingMode.off;
+    default:
+      return kMagpieDefaultUpscalingMode;
+  }
+}
+
+/// 裁决结果：这次会话到底走哪条路。
+enum MagpieBackend {
+  /// 用户关掉了，或非 Windows（galgame 只做 Windows）。
+  off,
+
+  /// 用机器上已有的 Magpie（用户自装的，或我们之前装的）。
+  installed,
+
+  /// 需要先下载我们的自编产物（要弹确认框）。
+  needsDownload,
+
+  /// 想用但用不上：`installedOnly` 且机器上没装。静默降级，不打扰用户。
+  unavailable,
+}
+
+/// **纯函数**：三态开关 + 探测结果 → 本次会话的后端。
+///
+/// 优先级刻意是「已装 > 下载」：用户机器上已有 Magpie（自装的官方版，或我们上次装的）时
+/// 直接用，绝不为了用自己的产物而重复下载 10MB。
+MagpieBackend resolveMagpieBackend({
+  required MagpieUpscalingMode mode,
+  required bool isWindows,
+  required bool installedAvailable,
+}) {
+  if (!isWindows) return MagpieBackend.off;
+  switch (mode) {
+    case MagpieUpscalingMode.off:
+      return MagpieBackend.off;
+    case MagpieUpscalingMode.installedOnly:
+      return installedAvailable
+          ? MagpieBackend.installed
+          : MagpieBackend.unavailable;
+    case MagpieUpscalingMode.auto:
+      return installedAvailable
+          ? MagpieBackend.installed
+          : MagpieBackend.needsDownload;
+  }
+}
+
+/// 为什么这次没能写自动缩放 profile。**每一项都是可降级的**：一律退回「只启动 Magpie，
+/// 让用户自己按热键（默认 Win+Shift+A）」，绝不让会话启动失败。
+enum MagpieProfileSkipReason {
+  /// 配置结构与我们已验证的 schema 不符：没有 `profiles` 数组，或第 0 项不是对象。
+  /// 也覆盖「配置还是我们写的 0 字节便携标记」——Magpie 还没跑过第一次。
+  schemaMismatch,
+
+  /// `scalingModes` 缺失或为空：此时任何 profile 的 `scalingMode` 都会被钳到 -1，
+  /// 缩放必报 `InvalidScalingMode`（`AppSettings.cpp:990-993` → `ScalingService.cpp:324`）。
+  noScalingModes,
+
+  /// 游戏窗口的 exe 路径或窗口类名拿不到。两者**都不允许为空**：空了整条 profile 会被
+  /// `AppSettings::_LoadProfile` 直接丢弃（返回 false）。
+  missingWindowIdentity,
+
+  /// 目标是 Hibiki 自己 —— 硬禁令，见 [magpieProfileTargetAllowed]。
+  forbiddenTarget,
+
+  /// 已经是想要的状态，什么都不用做。
+  alreadySatisfied,
+}
+
+/// [magpieConfigWithAutoScaleProfile] / [magpieConfigWithAutoScaleDisabled] 的结果。
+@immutable
+class MagpieProfileWriteResult {
+  const MagpieProfileWriteResult.applied(Map<String, dynamic> this.config)
+      : skipReason = null;
+
+  const MagpieProfileWriteResult.skipped(
+    MagpieProfileSkipReason this.skipReason,
+  ) : config = null;
+
+  /// 改写后的完整配置；跳过时为 null。
+  final Map<String, dynamic>? config;
+
+  /// 跳过原因；成功时为 null。
+  final MagpieProfileSkipReason? skipReason;
+
+  bool get applied => config != null;
+}
+
+/// profile 的三元身份：`(packaged, pathRule, classNameRule)`。
+///
+/// 与 Magpie 自己的匹配/去重判据一致（`ProfileService.cpp` 的 `_GetProfileForWindow`
+/// 与 `TestNewProfileImpl`）：三者全等才算同一条。
+///
+/// 🔴 **窗口类名不是可选项**。`_GetProfileForWindow` 先比 `classNameRule` 再比 `pathRule`
+/// （`ProfileService.cpp:220-222`，类名比取 exe 路径快得多所以放前面）——只写路径不写类名
+/// 的 profile 永远匹配不上任何窗口，是一条静默的死规则。
+///
+/// 🔴 **大小写敏感、不做路径规范化**：Magpie 用的是裸 `std::wstring ==`
+/// （`ProfileService.cpp:246`），没有 `_wcsicmp`、没有 `GetFullPathName`。我们必须原样照做，
+/// 路径必须来自与 Magpie 同源的 `QueryFullProcessImageNameW`。
+@immutable
+class MagpieWindowIdentity {
+  const MagpieWindowIdentity({
+    required this.executablePath,
+    required this.windowClassName,
+  });
+
+  /// 游戏窗口所属 exe 的**完整路径**。
+  final String executablePath;
+
+  /// 游戏主窗口的类名（`GetClassNameW`）。
+  final String windowClassName;
+
+  bool get isComplete =>
+      executablePath.trim().isNotEmpty && windowClassName.trim().isNotEmpty;
+
+  @override
+  bool operator ==(Object other) =>
+      other is MagpieWindowIdentity &&
+      other.executablePath == executablePath &&
+      other.windowClassName == windowClassName;
+
+  @override
+  int get hashCode => Object.hash(executablePath, windowClassName);
+
+  @override
+  String toString() =>
+      'MagpieWindowIdentity($executablePath, $windowClassName)';
+}
+
+/// **纯函数守卫**：这个 exe 路径能不能建 autoScale profile。
+///
+/// 唯一的硬禁令：**绝不给 Hibiki 自己建自动缩放 profile**。Magpie UI 层每 50ms 轮询前台
+/// 窗口，命中任何 `autoScale != Disabled` 的 profile 就 `force=true` 重启缩放
+/// （`ScalingService.cpp:42-45`、`:250-273`）。给 Hibiki 建了，查词浮窗/主窗口一到前台就
+/// 会把 galgame 的缩放踢掉，两个窗口来回打架。
+///
+/// [hibikiExecutablePath] 传 `Platform.resolvedExecutable`。比较**忽略大小写**（Windows
+/// 路径语义），比 Magpie 自己的匹配更严 —— 这里宁可多拒也不能漏放。
+bool magpieProfileTargetAllowed({
+  required String targetExecutablePath,
+  required String hibikiExecutablePath,
+}) {
+  final String target = targetExecutablePath.trim().toLowerCase();
+  if (target.isEmpty) return false;
+  final String self = hibikiExecutablePath.trim().toLowerCase();
+  if (self.isEmpty) return true;
+  return target != self;
+}
+
+/// **纯函数**：在既有 Magpie 配置上增量加一条「对该游戏窗口自动全屏超分」的 profile。
+///
+/// 这是**无契约行为**（Magpie 从没承诺 config.json 的格式稳定），所以每一步都先验证再动手，
+/// 任何不符预期都返回 skip 而不是猜着写。调用方收到 skip 只需退回「只启动不配置」。
+///
+/// 已核对的 schema 硬事实（`hajisensai/Magpie` @ 上游 v0.12.1 基线）：
+/// - 顶层键是 `profiles`（不是 `scalingProfiles`），**数组第 0 项是默认 profile**，它没有
+///   name/pathRule 等字段（`AppSettings::_LoadProfile` 的 `isDefault` 分支跳过全部身份字段）。
+/// - 非默认 profile 的 `name`（trim 后非空）/ `packaged` / `pathRule` / `classNameRule`
+///   **缺一不可**，任一缺失或为空 → `_LoadProfile` 返回 false → 整条被丢弃。
+/// - `autoScale` 是 **uint 枚举**（0=Disabled/1=Fullscreen/2=Windowed），不是 bool。
+/// - `scalingMode` 是 `scalingModes` 数组的**索引**；越界或缺失会被钳到 -1，而 -1 让缩放
+///   直接报 `InvalidScalingMode`。所以必须有非空 `scalingModes` 且索引有效。
+/// - **没有 `scalingFlags` 这个 key**（拆成 `3DGameMode` / `captureTitleBar` /
+///   `adjustCursorSpeed` / `disableDirectFlip` 四个 bool），我们一个都不写 —— 缺省即上游默认。
+///
+/// 只写「让它跑起来」的最小字段集：其余几十个字段（captureMethod / cursorScaling /
+/// cropping / graphicsCardId …）全部留空由 Magpie 用自己的默认值填，我们不猜。
+MagpieProfileWriteResult magpieConfigWithAutoScaleProfile({
+  required Map<String, dynamic> config,
+  required MagpieWindowIdentity identity,
+  required String profileName,
+  required String hibikiExecutablePath,
+}) {
+  if (!identity.isComplete || profileName.trim().isEmpty) {
+    return const MagpieProfileWriteResult.skipped(
+      MagpieProfileSkipReason.missingWindowIdentity,
+    );
+  }
+  if (!magpieProfileTargetAllowed(
+    targetExecutablePath: identity.executablePath,
+    hibikiExecutablePath: hibikiExecutablePath,
+  )) {
+    return const MagpieProfileWriteResult.skipped(
+      MagpieProfileSkipReason.forbiddenTarget,
+    );
+  }
+
+  final Object? scalingModes = config['scalingModes'];
+  if (scalingModes is! List || scalingModes.isEmpty) {
+    return const MagpieProfileWriteResult.skipped(
+      MagpieProfileSkipReason.noScalingModes,
+    );
+  }
+
+  final Object? rawProfiles = config['profiles'];
+  if (rawProfiles is! List ||
+      rawProfiles.isEmpty ||
+      rawProfiles.first is! Map) {
+    return const MagpieProfileWriteResult.skipped(
+      MagpieProfileSkipReason.schemaMismatch,
+    );
+  }
+  final Map<Object?, Object?> defaultProfile =
+      rawProfiles.first as Map<Object?, Object?>;
+
+  // 缩放模式索引沿用默认 profile 的选择（用户在 Magpie 里挑过什么就用什么）；默认 profile
+  // 自己越界或为 -1 时回落到 0（`scalingModes` 上面已确认非空）。
+  final Object? defaultScalingMode = defaultProfile['scalingMode'];
+  final int scalingMode = (defaultScalingMode is int &&
+          defaultScalingMode >= 0 &&
+          defaultScalingMode < scalingModes.length)
+      ? defaultScalingMode
+      : 0;
+
+  final List<Object?> profiles = List<Object?>.from(rawProfiles);
+  final int existing = _indexOfProfile(profiles, identity);
+  if (existing >= 0) {
+    final Map<Object?, Object?> entry =
+        profiles[existing]! as Map<Object?, Object?>;
+    if (entry['autoScale'] == kMagpieAutoScaleFullscreen) {
+      return const MagpieProfileWriteResult.skipped(
+        MagpieProfileSkipReason.alreadySatisfied,
+      );
+    }
+    // 已有同身份 profile（多半是用户自己在 Magpie 里建的）：**只翻 autoScale 这一个字段**，
+    // 其余用户设置一律不动。这就是「增量改写」的全部含义。
+    profiles[existing] = <String, dynamic>{
+      ..._asStringKeyed(entry),
+      'autoScale': kMagpieAutoScaleFullscreen,
+    };
+    return MagpieProfileWriteResult.applied(<String, dynamic>{
+      ...config,
+      'profiles': profiles,
+    });
+  }
+
+  profiles.add(<String, dynamic>{
+    'name': profileName.trim(),
+    'packaged': false,
+    'pathRule': identity.executablePath,
+    'classNameRule': identity.windowClassName,
+    'launcherPath': '',
+    'autoScale': kMagpieAutoScaleFullscreen,
+    'launchParameters': '',
+    'scalingMode': scalingMode,
+  });
+  return MagpieProfileWriteResult.applied(<String, dynamic>{
+    ...config,
+    'profiles': profiles,
+  });
+}
+
+/// **纯函数**：把某条 profile 的自动缩放关回去（会话结束时的收束）。
+///
+/// 只认我们那条身份，且只翻 `autoScale`。找不到就返回
+/// [MagpieProfileSkipReason.alreadySatisfied] —— 会话收尾绝不因为「配置里没有我们的
+/// profile」而报错。
+///
+/// 为什么必须关回去：留着 `autoScale=Fullscreen` 的 profile，用户下次**不经 Hibiki**直接
+/// 双击游戏时也会被 Magpie 的 50ms 前台轮询自动拉起缩放。那是我们没被授权做的事。
+MagpieProfileWriteResult magpieConfigWithAutoScaleDisabled({
+  required Map<String, dynamic> config,
+  required MagpieWindowIdentity identity,
+}) {
+  final Object? rawProfiles = config['profiles'];
+  if (rawProfiles is! List || rawProfiles.isEmpty) {
+    return const MagpieProfileWriteResult.skipped(
+      MagpieProfileSkipReason.schemaMismatch,
+    );
+  }
+  final List<Object?> profiles = List<Object?>.from(rawProfiles);
+  final int existing = _indexOfProfile(profiles, identity);
+  if (existing < 0) {
+    return const MagpieProfileWriteResult.skipped(
+      MagpieProfileSkipReason.alreadySatisfied,
+    );
+  }
+  final Map<Object?, Object?> entry =
+      profiles[existing]! as Map<Object?, Object?>;
+  if (entry['autoScale'] == kMagpieAutoScaleDisabled) {
+    return const MagpieProfileWriteResult.skipped(
+      MagpieProfileSkipReason.alreadySatisfied,
+    );
+  }
+  profiles[existing] = <String, dynamic>{
+    ..._asStringKeyed(entry),
+    'autoScale': kMagpieAutoScaleDisabled,
+  };
+  return MagpieProfileWriteResult.applied(<String, dynamic>{
+    ...config,
+    'profiles': profiles,
+  });
+}
+
+/// 在 profiles 里找同身份的**非默认** profile 下标；找不到返回 -1。
+///
+/// 从 1 开始扫：第 0 项是默认 profile，它没有身份字段，永远不该被当成匹配目标。
+int _indexOfProfile(List<Object?> profiles, MagpieWindowIdentity identity) {
+  for (int i = 1; i < profiles.length; i++) {
+    final Object? entry = profiles[i];
+    if (entry is! Map) continue;
+    if (entry['packaged'] != false) continue;
+    if (entry['pathRule'] != identity.executablePath) continue;
+    if (entry['classNameRule'] != identity.windowClassName) continue;
+    return i;
+  }
+  return -1;
+}
+
+/// `jsonDecode` 出来的嵌套 Map 静态类型是 `Map<String, dynamic>`，但我们从 `List<Object?>`
+/// 里取出来时只能断言到 `Map<Object?, Object?>`，展开前需转回字符串键。
+Map<String, dynamic> _asStringKeyed(Map<Object?, Object?> source) {
+  final Map<String, dynamic> out = <String, dynamic>{};
+  source.forEach((Object? key, Object? value) {
+    if (key is String) out[key] = value;
+  });
+  return out;
+}

--- a/hibiki/lib/src/mining/magpie_upscaling.dart
+++ b/hibiki/lib/src/mining/magpie_upscaling.dart
@@ -131,8 +131,13 @@ MagpieBackend resolveMagpieBackend({
 /// 让用户自己按热键（默认 Win+Shift+A）」，绝不让会话启动失败。
 enum MagpieProfileSkipReason {
   /// 配置结构与我们已验证的 schema 不符：没有 `profiles` 数组，或第 0 项不是对象。
-  /// 也覆盖「配置还是我们写的 0 字节便携标记」——Magpie 还没跑过第一次。
   schemaMismatch,
+
+  /// 预热失败：Magpie 没能及时把默认配置（含 `scalingModes`）生成出来。
+  ///
+  /// 这是「第一次用」路径上唯一可能剩下的降级原因 —— 我们装完写的是 0 字节便携标记，
+  /// 必须先静默跑一次 Magpie 让它自己生成完整配置，才谈得上写 profile。
+  bootstrapFailed,
 
   /// `scalingModes` 缺失或为空：此时任何 profile 的 `scalingMode` 都会被钳到 -1，
   /// 缩放必报 `InvalidScalingMode`（`AppSettings.cpp:990-993` → `ScalingService.cpp:324`）。
@@ -141,6 +146,10 @@ enum MagpieProfileSkipReason {
   /// 游戏窗口的 exe 路径或窗口类名拿不到。两者**都不允许为空**：空了整条 profile 会被
   /// `AppSettings::_LoadProfile` 直接丢弃（返回 false）。
   missingWindowIdentity,
+
+  /// 机器上已经跑着一个不是我们起的 Magpie：我们有意不碰它的配置（位置未知、且它退出时
+  /// 会整份回写覆盖我们的改动），也不替用户关掉重开。
+  externalInstance,
 
   /// 目标是 Hibiki 自己 —— 硬禁令，见 [magpieProfileTargetAllowed]。
   forbiddenTarget,

--- a/hibiki/lib/src/mining/magpie_upscaling_service.dart
+++ b/hibiki/lib/src/mining/magpie_upscaling_service.dart
@@ -425,6 +425,23 @@ class MagpieUpscalingService extends ChangeNotifier {
           detail: 'user declined the download',
         );
         return false;
+      case MagpieInstallResult.downloadFailed:
+        // 可重试：直连与所有镜像都没拿到 zip（离线 / 被墙 / 404）。**不**置
+        // _downloadDeclined —— 那面旗子的语义是「用户说了不要」，网络不通不是用户的意思，
+        // 下一局仍应再试一次。
+        _report = MagpieUpscalingReport(
+          status: MagpieUpscalingStatus.failed,
+          detail: 'install result: ${result.name} (retryable)',
+        );
+        return false;
+      case MagpieInstallResult.verificationFailed:
+        // 拿不到直连 GitHub 的 sha256 侧车，或 zip 与侧车摘要不符：东西下下来了但**不可信**。
+        // 与 downloadFailed 分开报，免得把「不可信」和「没下到」混成一句话。
+        _report = MagpieUpscalingReport(
+          status: MagpieUpscalingStatus.failed,
+          detail: 'install result: ${result.name} (integrity)',
+        );
+        return false;
       case MagpieInstallResult.failed:
       case MagpieInstallResult.unsupportedPlatform:
         _report = MagpieUpscalingReport(

--- a/hibiki/lib/src/mining/magpie_upscaling_service.dart
+++ b/hibiki/lib/src/mining/magpie_upscaling_service.dart
@@ -47,6 +47,17 @@ const Duration kMagpieQuitGrace = Duration(seconds: 3);
 /// （`AppSettings::SaveAsync`），我们必须等它写完再改，否则改动被覆盖。
 const Duration kMagpieConfigSettleDelay = Duration(milliseconds: 400);
 
+/// 预热（bootstrap）等 Magpie 自己生成完整配置的上限。
+///
+/// `AppSettings::Initialize()` 读到 0 字节配置就走 `configText.empty()` 分支，当场
+/// `_SetDefaultScalingModes()` + `SaveAsync()`（`AppSettings.cpp:243-246`）。`SaveAsync`
+/// 只是 `resume_background()` 后直接写盘，**没有防抖也没有定时器**（`:287-293`），所以
+/// 正常情况几百毫秒内就落盘。8 秒是给冷启动 + 杀软扫描留的余量。
+const Duration kMagpieBootstrapTimeout = Duration(seconds: 8);
+
+/// 预热轮询配置文件的间隔。
+const Duration kMagpieBootstrapPollInterval = Duration(milliseconds: 150);
+
 /// 超分在本次会话里的实际状态。UI 与诊断读它，**不参与任何控制流判断**。
 enum MagpieUpscalingStatus {
   /// 没在跑。
@@ -109,6 +120,31 @@ class MagpieUpscalingReport {
       'skip=$profileSkipReason, scaling=$scalingActive, detail=$detail)';
 }
 
+/// 我们起的那个 Magpie 进程的最小句柄。
+///
+/// 抽出这层**只为可测**：真实 `Process` 没法在单测里造，导致「启动之后」的整条收束路径
+/// （QUIT → 等退出 → 超时 kill → 复原配置）此前一行都没被覆盖。
+abstract class MagpieProcessHandle {
+  /// 进程退出码。detached 启动在部分平台上永远不完成 —— 调用方必须自己加超时。
+  Future<int> get exitCode;
+
+  /// 强杀。**只允许对我们自己起的进程调用**。
+  void kill();
+}
+
+/// 真实实现：包一层 `dart:io` 的 [Process]。
+class _RealProcessHandle implements MagpieProcessHandle {
+  _RealProcessHandle(this._process);
+
+  final Process _process;
+
+  @override
+  Future<int> get exitCode => _process.exitCode;
+
+  @override
+  void kill() => _process.kill(ProcessSignal.sigkill);
+}
+
 /// Win32 边界的可注入抽象：**这一层存在的唯一理由是让上面的编排逻辑能在非 Windows 上单测**。
 /// 真实实现是 [MagpieWindowsBridge]，只有它碰 `dart:ffi`。
 abstract class MagpieWin32Bridge {
@@ -126,17 +162,20 @@ abstract class MagpieWin32Bridge {
 ///
 /// 生命周期与会话一一对应：[onGameWindowReady] 开，[onSessionEnded] 收。两个方法都
 /// **绝不抛异常**——超分是锦上添花，任何失败都只降级、不影响 hook 会话本身。
-class MagpieUpscalingService {
+class MagpieUpscalingService extends ChangeNotifier {
   MagpieUpscalingService({
     required MagpieUpscalingMode Function() modeReader,
     Future<bool> Function(MagpieDownloadPrompt prompt)? confirmDownload,
     MagpieWin32Bridge? bridge,
     MagpieInstaller Function()? installerFactory,
-    Future<Process> Function(String executable, List<String> arguments)?
-        processLauncher,
+    Future<MagpieProcessHandle> Function(
+      String executable,
+      List<String> arguments,
+    )? processLauncher,
     String? hibikiExecutablePath,
     String? configPathOverride,
     bool? isWindowsOverride,
+    Duration? bootstrapTimeout,
   })  : _modeReader = modeReader,
         _confirmDownload = confirmDownload,
         _bridge = bridge,
@@ -145,19 +184,24 @@ class MagpieUpscalingService {
         _hibikiExecutablePath =
             hibikiExecutablePath ?? _safeResolvedExecutable(),
         _configPathOverride = configPathOverride,
-        _isWindows = isWindowsOverride ?? Platform.isWindows;
+        _isWindows = isWindowsOverride ?? Platform.isWindows,
+        _bootstrapTimeout = bootstrapTimeout ?? kMagpieBootstrapTimeout;
 
   final MagpieUpscalingMode Function() _modeReader;
   final Future<bool> Function(MagpieDownloadPrompt prompt)? _confirmDownload;
   final MagpieWin32Bridge? _bridge;
   final MagpieInstaller Function() _installerFactory;
-  final Future<Process> Function(String, List<String>) _processLauncher;
+  final Future<MagpieProcessHandle> Function(String, List<String>)
+      _processLauncher;
   final String _hibikiExecutablePath;
   final String? _configPathOverride;
   final bool _isWindows;
 
+  /// 预热等待上限；仅测试注入，生产恒为 [kMagpieBootstrapTimeout]。
+  final Duration _bootstrapTimeout;
+
   /// 我们自己起的那个 Magpie。**只有它才允许被 QUIT / kill**。
-  Process? _ownedProcess;
+  MagpieProcessHandle? _ownedProcess;
 
   /// 本次会话写进配置的身份，收尾时按它把 autoScale 关回去。
   MagpieWindowIdentity? _appliedIdentity;
@@ -168,11 +212,21 @@ class MagpieUpscalingService {
   /// 同一时刻只允许一条编排在跑（开/收互斥），避免收尾与启动交叉。
   Future<void> _gate = Future<void>.value();
 
-  MagpieUpscalingReport _report =
+  MagpieUpscalingReport _reportValue =
       const MagpieUpscalingReport(status: MagpieUpscalingStatus.idle);
 
-  /// 当前状态（UI / 诊断读）。
-  MagpieUpscalingReport get report => _report;
+  /// 当前状态。UI 直接把本服务当 [Listenable] 订阅即可。
+  MagpieUpscalingReport get report => _reportValue;
+
+  /// 内部读写口。**所有** `_report = ...` 赋值都走这里，写完立刻 notify ——
+  /// 这样以后新增赋值点的人不会忘记通知 UI（「状态变了界面不动」是个太容易犯的错）。
+  MagpieUpscalingReport get _report => _reportValue;
+
+  set _report(MagpieUpscalingReport value) {
+    if (identical(_reportValue, value)) return;
+    _reportValue = value;
+    notifyListeners();
+  }
 
   MagpieWin32Bridge get _win32 => _bridge ?? MagpieWindowsBridge.instance;
 
@@ -184,11 +238,17 @@ class MagpieUpscalingService {
     }
   }
 
-  static Future<Process> _defaultLauncher(
+  static Future<MagpieProcessHandle> _defaultLauncher(
     String executable,
     List<String> arguments,
-  ) =>
-      Process.start(executable, arguments, mode: ProcessStartMode.detached);
+  ) async =>
+      _RealProcessHandle(
+        await Process.start(
+          executable,
+          arguments,
+          mode: ProcessStartMode.detached,
+        ),
+      );
 
   /// 便携配置文件路径（`<install>/config/config.json`）。
   String get _configPath =>
@@ -245,6 +305,7 @@ class MagpieUpscalingService {
     if (externalRunning) {
       _report = const MagpieUpscalingReport(
         status: MagpieUpscalingStatus.hotkeyOnly,
+        profileSkipReason: MagpieProfileSkipReason.externalInstance,
         detail: 'an existing Magpie instance is already running; '
             'left untouched, user can scale with its own hotkey',
       );
@@ -254,6 +315,14 @@ class MagpieUpscalingService {
     _report = const MagpieUpscalingReport(
       status: MagpieUpscalingStatus.preparing,
     );
+
+    // 🔴 首次使用的预热：我们装完写的是 0 字节便携标记，里面没有 `scalingModes`，
+    // 而没有 scalingModes 就不能写 profile（`scalingMode` 会被钳到 -1 → 缩放报
+    // `InvalidScalingMode`）。若不预热，**第一局游戏必然只能按热键**。
+    //
+    // 预热做的事：静默跑一次 Magpie 让它自己把默认配置（含 7 个 scalingModes）写出来，
+    // 再退出。这样第一局就能直接自动缩放，而不是让用户以为「装完没反应」。
+    await _ensureConfigMaterialized();
 
     // 配置必须在**拉起 Magpie 之前**写：Magpie 只在启动时读一次 config.json，全仓没有任何
     // 文件监视（无 ReadDirectoryChanges / FindFirstChangeNotification）。
@@ -366,6 +435,55 @@ class MagpieUpscalingService {
     }
   }
 
+  /// 预热：确保 `config.json` 里已经有 Magpie 自己生成的完整配置（关键是 `scalingModes`）。
+  ///
+  /// 已经就绪时**零成本直接返回**（只读一次文件），所以第二局起不会再付这份开销。
+  ///
+  /// 为什么必须由 Magpie 自己生成而不是我们手写：`scalingModes` 是 7 套带效果参数的缩放
+  /// 算法配置，手写等于猜上游的私有 schema —— 那正是设计文档 §3.2 明令禁止的事。让它自己
+  /// 跑一次是唯一既正确又零 schema 猜测的办法。
+  ///
+  /// 任何一步失败都静默返回：调用方随后读配置仍会失败，自然降级为热键模式。
+  Future<void> _ensureConfigMaterialized() async {
+    try {
+      if (await _readConfig() != null) return; // 早就好了
+      final String exe = MagpieInstaller.executablePath();
+      if (!File(exe).existsSync()) return;
+
+      final MagpieProcessHandle warmup =
+          await _processLauncher(exe, <String>[kMagpieSilentLaunchArg]);
+      try {
+        await _waitForConfig();
+      } finally {
+        // 预热实例必须收干净：它是我们起的，绝不能留一个游离的 Magpie 在跑，
+        // 否则下面「真正」那次启动会被单实例互斥体挡掉。
+        try {
+          _win32.broadcastQuit();
+        } catch (_) {}
+        await _waitForExit(warmup);
+        await Future<void>.delayed(kMagpieConfigSettleDelay);
+      }
+    } catch (_) {
+      // 预热是纯优化：失败只意味着这一局退回热键模式，不影响会话。
+    }
+  }
+
+  /// 轮询等配置文件变得可用（非空且能解析）。超时就返回，由调用方降级。
+  Future<void> _waitForConfig() async {
+    final DateTime deadline = DateTime.now().add(_bootstrapTimeout);
+    while (DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(kMagpieBootstrapPollInterval);
+      Map<String, dynamic>? config;
+      try {
+        config = await _readConfig();
+      } catch (_) {
+        config = null; // 可能正读到半写状态，下一轮再试
+      }
+      final Object? modes = config?['scalingModes'];
+      if (modes is List && modes.isNotEmpty) return;
+    }
+  }
+
   /// **best-effort** 写自动缩放 profile。返回 null 表示写成功；返回原因表示降级为「只启动
   /// 不配置」。任何异常都被吞成 [MagpieProfileSkipReason.schemaMismatch]。
   Future<MagpieProfileSkipReason?> _applyAutoScaleProfile(int hwnd) async {
@@ -375,7 +493,9 @@ class MagpieUpscalingService {
         return MagpieProfileSkipReason.missingWindowIdentity;
       }
       final Map<String, dynamic>? config = await _readConfig();
-      if (config == null) return MagpieProfileSkipReason.schemaMismatch;
+      // 走到这里还读不出配置，说明预热没成功（0 字节标记还在，或 Magpie 起不来）。
+      // 这是「第一次用」路径上最常见的降级，单独给个原因让 UI 能说人话。
+      if (config == null) return MagpieProfileSkipReason.bootstrapFailed;
 
       final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
         config: config,
@@ -427,7 +547,7 @@ class MagpieUpscalingService {
 
   Future<void> _stop() async {
     _unlistenScalingEvents();
-    final Process? owned = _ownedProcess;
+    final MagpieProcessHandle? owned = _ownedProcess;
     _ownedProcess = null;
     if (owned != null) {
       // 先礼后兵：广播 QUIT 让它自己收（能正常清理缩放窗口），超时再 kill。
@@ -443,14 +563,14 @@ class MagpieUpscalingService {
     _report = const MagpieUpscalingReport(status: MagpieUpscalingStatus.idle);
   }
 
-  Future<void> _waitForExit(Process process) async {
+  Future<void> _waitForExit(MagpieProcessHandle process) async {
     try {
       await process.exitCode.timeout(kMagpieQuitGrace);
     } catch (_) {
       // 超时（或拿不到 exitCode：detached 启动在部分平台上就是这样）→ 强杀。
       // 只杀我们自己起的这一个 PID，绝不按进程名扫。
       try {
-        process.kill(ProcessSignal.sigkill);
+        process.kill();
       } catch (_) {}
     }
   }

--- a/hibiki/lib/src/mining/magpie_upscaling_service.dart
+++ b/hibiki/lib/src/mining/magpie_upscaling_service.dart
@@ -1,0 +1,639 @@
+/// 内置 Magpie 窗口超分的**运行时层**（阶段二）。
+///
+/// 职责：把 `magpie_upscaling.dart` 的纯裁决接到真实的进程 / 窗口 / 文件上，并对
+/// galgame 会话暴露两个极窄的钩子 —— [onGameWindowReady] 与 [onSessionEnded]。
+///
+/// 刻意做成**独立文件 + 独立类**，`gal_hook_session_controller.dart` 侧只加
+/// 「一个可空字段 + 一个 setter + 两处调用」，把与并发改动的冲突面压到最小
+/// （范式抄该文件既有的 `attachActivityDatabase`）。
+///
+/// 三条硬约束（都来自阶段一读上游源码的实测结论，违反任何一条都会坏）：
+///
+/// 1. **绝不给 Hibiki 自己建 autoScale profile**。Magpie 每 50ms 轮询前台窗口，命中任何
+///    `autoScale != Disabled` 的 profile 就 `force=true` 重启缩放
+///    （`ScalingService.cpp:42-45`、`:250-273`）。守卫在 `magpieProfileTargetAllowed`。
+/// 2. **便携标记必须是 0 字节文件**。写 `{}` 会让 scalingModes 为空 → scalingMode 钳到 -1
+///    → 缩放报 `InvalidScalingMode`。已由 `magpiePortableConfigContent()` 保证。
+/// 3. **绝不动我们没启动的 Magpie**。用户自己开着的实例不写它的配置、不发 QUIT。
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+import 'package:flutter/foundation.dart';
+import 'package:hibiki/src/mining/magpie_installer.dart';
+import 'package:hibiki/src/mining/magpie_scaling_channel.dart';
+import 'package:hibiki/src/mining/magpie_upscaling.dart';
+
+/// 转出确认回调的入参类型：它是本服务对外契约的一部分（[MagpieUpscalingService] 的
+/// `confirmDownload` 签名用它），调用方不该为了一个参数类型再去 import 安装器。
+export 'package:hibiki/src/mining/magpie_installer.dart'
+    show MagpieDownloadPrompt;
+
+/// 偏好键：三态超分开关。**不要改**（改了等于把所有用户的设置清零）。
+const String kMagpieUpscalingModePrefKey = 'galgame_magpie_upscaling_mode';
+
+/// 发出 QUIT 之后等 Magpie 自己退出的上限。超时就直接 kill 我们自己起的那个进程。
+///
+/// 为什么必须有 kill 兜底：`App::InitMessages()` 只对 `WM_MAGPIE_SHOWME` 调了
+/// `ChangeWindowMessageFilter`，**QUIT 没放行**。Magpie 若以高完整性运行（它的
+/// `IsAlwaysRunAsAdmin` 会自我提权重启），我们的广播会被 UIPI 静默丢掉。
+const Duration kMagpieQuitGrace = Duration(seconds: 3);
+
+/// 会话结束后重写配置前的静置：Magpie 退出时会把内存里的配置回存
+/// （`AppSettings::SaveAsync`），我们必须等它写完再改，否则改动被覆盖。
+const Duration kMagpieConfigSettleDelay = Duration(milliseconds: 400);
+
+/// 超分在本次会话里的实际状态。UI 与诊断读它，**不参与任何控制流判断**。
+enum MagpieUpscalingStatus {
+  /// 没在跑。
+  idle,
+
+  /// 用户关掉了超分。
+  disabled,
+
+  /// 想用但用不上（`installedOnly` 且没装 / 非 Windows / 用户拒绝了下载）。
+  unavailable,
+
+  /// 正在准备（下载 / 写配置 / 拉起进程）。
+  preparing,
+
+  /// 已按自动缩放 profile 拉起 Magpie —— 游戏窗口到前台就该自动全屏超分。
+  active,
+
+  /// Magpie 起来了，但**没能配置自动缩放**，用户得自己按 Magpie 热键（默认 Win+Shift+A）。
+  hotkeyOnly,
+
+  /// 起不来（下载失败 / 进程拉不起来）。已静默降级，不影响会话。
+  failed,
+}
+
+/// 一次超分尝试的完整结果（含降级原因），给 UI 与日志用。
+@immutable
+class MagpieUpscalingReport {
+  const MagpieUpscalingReport({
+    required this.status,
+    this.profileSkipReason,
+    this.detail,
+    this.scalingActive = false,
+  });
+
+  final MagpieUpscalingStatus status;
+
+  /// Magpie 当前**真的**在缩放吗 —— 由 native 侧的 `MagpieScalingChanged` 广播回填，
+  /// 是整条链路唯一的事实反馈（其余字段都只是「我们做了什么」，不是「结果如何」）。
+  ///
+  /// 注意语义：源窗口切到后台**不算**缩放结束（Magpie 仍在跑），native 侧已按
+  /// `wParam==0 && lParam!=0` 的判据处理过。
+  final bool scalingActive;
+
+  MagpieUpscalingReport copyWith({bool? scalingActive}) =>
+      MagpieUpscalingReport(
+        status: status,
+        profileSkipReason: profileSkipReason,
+        detail: detail,
+        scalingActive: scalingActive ?? this.scalingActive,
+      );
+
+  /// 没能写自动缩放 profile 的原因；写成功或压根没走到这步时为 null。
+  final MagpieProfileSkipReason? profileSkipReason;
+
+  /// 人类可读的补充说明（异常文本等），只进日志不进 UI 文案。
+  final String? detail;
+
+  @override
+  String toString() => 'MagpieUpscalingReport($status, '
+      'skip=$profileSkipReason, scaling=$scalingActive, detail=$detail)';
+}
+
+/// Win32 边界的可注入抽象：**这一层存在的唯一理由是让上面的编排逻辑能在非 Windows 上单测**。
+/// 真实实现是 [MagpieWindowsBridge]，只有它碰 `dart:ffi`。
+abstract class MagpieWin32Bridge {
+  /// 目标窗口的身份（exe 完整路径 + 窗口类名）；任一拿不到返回 null。
+  MagpieWindowIdentity? identityForWindow(int hwnd);
+
+  /// 是否已有 Magpie 实例在跑（查单实例互斥体，比找主窗口可靠 —— `-t` 模式无主窗口）。
+  bool isMagpieRunning();
+
+  /// 广播「请求退出」。成功投递返回 true（**不代表对方真的退了**）。
+  bool broadcastQuit();
+}
+
+/// galgame 会话的窗口超分编排。
+///
+/// 生命周期与会话一一对应：[onGameWindowReady] 开，[onSessionEnded] 收。两个方法都
+/// **绝不抛异常**——超分是锦上添花，任何失败都只降级、不影响 hook 会话本身。
+class MagpieUpscalingService {
+  MagpieUpscalingService({
+    required MagpieUpscalingMode Function() modeReader,
+    Future<bool> Function(MagpieDownloadPrompt prompt)? confirmDownload,
+    MagpieWin32Bridge? bridge,
+    MagpieInstaller Function()? installerFactory,
+    Future<Process> Function(String executable, List<String> arguments)?
+        processLauncher,
+    String? hibikiExecutablePath,
+    String? configPathOverride,
+    bool? isWindowsOverride,
+  })  : _modeReader = modeReader,
+        _confirmDownload = confirmDownload,
+        _bridge = bridge,
+        _installerFactory = installerFactory ?? MagpieInstaller.new,
+        _processLauncher = processLauncher ?? _defaultLauncher,
+        _hibikiExecutablePath =
+            hibikiExecutablePath ?? _safeResolvedExecutable(),
+        _configPathOverride = configPathOverride,
+        _isWindows = isWindowsOverride ?? Platform.isWindows;
+
+  final MagpieUpscalingMode Function() _modeReader;
+  final Future<bool> Function(MagpieDownloadPrompt prompt)? _confirmDownload;
+  final MagpieWin32Bridge? _bridge;
+  final MagpieInstaller Function() _installerFactory;
+  final Future<Process> Function(String, List<String>) _processLauncher;
+  final String _hibikiExecutablePath;
+  final String? _configPathOverride;
+  final bool _isWindows;
+
+  /// 我们自己起的那个 Magpie。**只有它才允许被 QUIT / kill**。
+  Process? _ownedProcess;
+
+  /// 本次会话写进配置的身份，收尾时按它把 autoScale 关回去。
+  MagpieWindowIdentity? _appliedIdentity;
+
+  /// 用户本次 app 生命周期内已经拒绝过下载 —— 别每开一局游戏就弹一次框。
+  bool _downloadDeclined = false;
+
+  /// 同一时刻只允许一条编排在跑（开/收互斥），避免收尾与启动交叉。
+  Future<void> _gate = Future<void>.value();
+
+  MagpieUpscalingReport _report =
+      const MagpieUpscalingReport(status: MagpieUpscalingStatus.idle);
+
+  /// 当前状态（UI / 诊断读）。
+  MagpieUpscalingReport get report => _report;
+
+  MagpieWin32Bridge get _win32 => _bridge ?? MagpieWindowsBridge.instance;
+
+  static String _safeResolvedExecutable() {
+    try {
+      return Platform.resolvedExecutable;
+    } catch (_) {
+      return '';
+    }
+  }
+
+  static Future<Process> _defaultLauncher(
+    String executable,
+    List<String> arguments,
+  ) =>
+      Process.start(executable, arguments, mode: ProcessStartMode.detached);
+
+  /// 便携配置文件路径（`<install>/config/config.json`）。
+  String get _configPath =>
+      _configPathOverride ?? MagpieInstaller.portableConfigPath();
+
+  /// 会话拿到游戏窗口时调用。**幂等**：同一会话重复调（例如迟到重绑）只生效第一次。
+  Future<void> onGameWindowReady({required int hwnd}) =>
+      _serialize(() => _start(hwnd));
+
+  /// 会话结束时调用。没启动过超分时是空操作。
+  Future<void> onSessionEnded() => _serialize(_stop);
+
+  Future<void> _serialize(Future<void> Function() job) {
+    final Future<void> run = _gate.then((_) => job());
+    _gate = run.catchError((Object _) {});
+    return run;
+  }
+
+  Future<void> _start(int hwnd) async {
+    if (_ownedProcess != null) return; // 已经起过，幂等
+    final MagpieUpscalingMode mode = _readMode();
+    // 「已装」= 我们自己的产物装好了 **或** 机器上已经跑着一个 Magpie（用户自装的）。
+    // 后者也算，否则 `installedOnly` 会在用户明明开着 Magpie 时报 unavailable，而
+    // `auto` 会去下一份多余的 10MB。两个探测都是零网络零副作用。
+    final bool bundledInstalled = _isWindows && MagpieInstaller.isInstalled();
+    final bool externalRunning = _isWindows && _safeIsMagpieRunning();
+    final MagpieBackend backend = resolveMagpieBackend(
+      mode: mode,
+      isWindows: _isWindows,
+      installedAvailable: bundledInstalled || externalRunning,
+    );
+
+    switch (backend) {
+      case MagpieBackend.off:
+        _report = const MagpieUpscalingReport(
+          status: MagpieUpscalingStatus.disabled,
+        );
+        return;
+      case MagpieBackend.unavailable:
+        _report = const MagpieUpscalingReport(
+          status: MagpieUpscalingStatus.unavailable,
+          detail: 'magpie not installed and download disabled by setting',
+        );
+        return;
+      case MagpieBackend.needsDownload:
+        if (!await _ensureDownloaded()) return;
+      case MagpieBackend.installed:
+        break;
+    }
+
+    // 用户自己开着 Magpie：**什么都不做**。它的配置在哪我们不知道（可能是便携、可能在
+    // %LOCALAPPDATA%），而且它读配置只在启动时读一次、退出时又会整份回写——此时改配置
+    // 一定被覆盖。更要紧的是那是用户的进程，我们没有权限替他关掉重开。
+    if (externalRunning) {
+      _report = const MagpieUpscalingReport(
+        status: MagpieUpscalingStatus.hotkeyOnly,
+        detail: 'an existing Magpie instance is already running; '
+            'left untouched, user can scale with its own hotkey',
+      );
+      return;
+    }
+
+    _report = const MagpieUpscalingReport(
+      status: MagpieUpscalingStatus.preparing,
+    );
+
+    // 配置必须在**拉起 Magpie 之前**写：Magpie 只在启动时读一次 config.json，全仓没有任何
+    // 文件监视（无 ReadDirectoryChanges / FindFirstChangeNotification）。
+    final MagpieProfileSkipReason? skip = await _applyAutoScaleProfile(hwnd);
+
+    final String exe = MagpieInstaller.executablePath();
+    try {
+      _ownedProcess =
+          await _processLauncher(exe, <String>[kMagpieSilentLaunchArg]);
+    } catch (e) {
+      await _restoreProfile();
+      _report = MagpieUpscalingReport(
+        status: MagpieUpscalingStatus.failed,
+        detail: 'failed to launch magpie: $e',
+      );
+      return;
+    }
+
+    _listenScalingEvents();
+    _report = MagpieUpscalingReport(
+      status: skip == null
+          ? MagpieUpscalingStatus.active
+          : MagpieUpscalingStatus.hotkeyOnly,
+      profileSkipReason: skip,
+    );
+  }
+
+  /// 订阅 native 侧回传的缩放状态。**只影响 [report] 的展示字段，不参与任何控制流**——
+  /// 收不到事件（native 未构建 / UIPI 拦掉 / 非 Windows）时整条链路照常工作。
+  void _listenScalingEvents() {
+    if (!_isWindows) return;
+    try {
+      MagpieScalingChannel.setHandler((MagpieScalingEvent event) {
+        _report = _report.copyWith(scalingActive: event.scaling);
+      });
+    } catch (_) {
+      // 平台通道不可用（单测环境等）：静默放弃，只是没有状态回填。
+    }
+  }
+
+  void _unlistenScalingEvents() {
+    if (!_isWindows) return;
+    try {
+      MagpieScalingChannel.clearHandler();
+    } catch (_) {}
+  }
+
+  /// 互斥体探测。**零网络零副作用**（OpenMutex + CloseHandle），可以随手问。
+  /// 桥实现异常一律当作「没在跑」——认不出来时宁可多起一个我们自己的实例，也不要
+  /// 误判成「用户开着」而彻底不工作。
+  bool _safeIsMagpieRunning() {
+    try {
+      return _win32.isMagpieRunning();
+    } catch (_) {
+      return false;
+    }
+  }
+
+  MagpieUpscalingMode _readMode() {
+    try {
+      return _modeReader();
+    } catch (_) {
+      return kMagpieDefaultUpscalingMode;
+    }
+  }
+
+  /// 交互路径的按需下载。**零网络探测发生在确认框之前**（BUG-1076 的教训）：
+  /// `ensureInstalled` 已装时直接返回，未装时立刻弹框、大小探测在后台跑。
+  Future<bool> _ensureDownloaded() async {
+    final Future<bool> Function(MagpieDownloadPrompt)? confirm =
+        _confirmDownload;
+    if (confirm == null || _downloadDeclined) {
+      _report = const MagpieUpscalingReport(
+        status: MagpieUpscalingStatus.unavailable,
+        detail: 'no download confirmation handler, or user already declined',
+      );
+      return false;
+    }
+    _report = const MagpieUpscalingReport(
+      status: MagpieUpscalingStatus.preparing,
+    );
+    MagpieInstallResult result;
+    try {
+      result = await _installerFactory().ensureInstalled(confirm: confirm);
+    } catch (e) {
+      _report = MagpieUpscalingReport(
+        status: MagpieUpscalingStatus.failed,
+        detail: 'install threw: $e',
+      );
+      return false;
+    }
+    switch (result) {
+      case MagpieInstallResult.alreadyInstalled:
+      case MagpieInstallResult.installed:
+        return true;
+      case MagpieInstallResult.declined:
+        _downloadDeclined = true;
+        _report = const MagpieUpscalingReport(
+          status: MagpieUpscalingStatus.unavailable,
+          detail: 'user declined the download',
+        );
+        return false;
+      case MagpieInstallResult.failed:
+      case MagpieInstallResult.unsupportedPlatform:
+        _report = MagpieUpscalingReport(
+          status: MagpieUpscalingStatus.failed,
+          detail: 'install result: ${result.name}',
+        );
+        return false;
+    }
+  }
+
+  /// **best-effort** 写自动缩放 profile。返回 null 表示写成功；返回原因表示降级为「只启动
+  /// 不配置」。任何异常都被吞成 [MagpieProfileSkipReason.schemaMismatch]。
+  Future<MagpieProfileSkipReason?> _applyAutoScaleProfile(int hwnd) async {
+    try {
+      final MagpieWindowIdentity? identity = _win32.identityForWindow(hwnd);
+      if (identity == null || !identity.isComplete) {
+        return MagpieProfileSkipReason.missingWindowIdentity;
+      }
+      final Map<String, dynamic>? config = await _readConfig();
+      if (config == null) return MagpieProfileSkipReason.schemaMismatch;
+
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
+        config: config,
+        identity: identity,
+        profileName: _profileNameFor(identity),
+        hibikiExecutablePath: _hibikiExecutablePath,
+      );
+      if (!result.applied) {
+        // alreadySatisfied 说明配置里已经有一条启用了的等价 profile —— 那是成功不是降级，
+        // 但它不是我们这轮加的，收尾时也就不该由我们关掉。
+        if (result.skipReason == MagpieProfileSkipReason.alreadySatisfied) {
+          return null;
+        }
+        return result.skipReason;
+      }
+      await _writeConfig(result.config!);
+      _appliedIdentity = identity;
+      return null;
+    } catch (_) {
+      return MagpieProfileSkipReason.schemaMismatch;
+    }
+  }
+
+  /// profile 显示名。带 `Hibiki` 前缀是为了让用户在 Magpie 的 UI 里一眼认出「这条是谁加的」。
+  String _profileNameFor(MagpieWindowIdentity identity) {
+    final String base = identity.executablePath.split(RegExp(r'[\\/]')).last;
+    return 'Hibiki: ${base.isEmpty ? identity.windowClassName : base}';
+  }
+
+  Future<Map<String, dynamic>?> _readConfig() async {
+    final File file = File(_configPath);
+    if (!file.existsSync()) return null;
+    final String text = await file.readAsString();
+    // 0 字节 = 我们写的便携标记，Magpie 还没跑过第一次 → 没有 scalingModes 可用，
+    // 此时写 profile 必然踩 -1 钳位陷阱。交给上层降级为热键模式。
+    if (text.trim().isEmpty) return null;
+    final Object? decoded = jsonDecode(text);
+    return decoded is Map<String, dynamic> ? decoded : null;
+  }
+
+  Future<void> _writeConfig(Map<String, dynamic> config) async {
+    final File file = File(_configPath);
+    await file.parent.create(recursive: true);
+    await file.writeAsString(
+      const JsonEncoder.withIndent('  ').convert(config),
+      flush: true,
+    );
+  }
+
+  Future<void> _stop() async {
+    _unlistenScalingEvents();
+    final Process? owned = _ownedProcess;
+    _ownedProcess = null;
+    if (owned != null) {
+      // 先礼后兵：广播 QUIT 让它自己收（能正常清理缩放窗口），超时再 kill。
+      try {
+        _win32.broadcastQuit();
+      } catch (_) {}
+      await _waitForExit(owned);
+    }
+    // 必须在 Magpie 真的退出**之后**再改配置：它退出时会把内存里的设置整份回存
+    // （`AppSettings::SaveAsync`），提前改一定被覆盖。
+    await Future<void>.delayed(kMagpieConfigSettleDelay);
+    await _restoreProfile();
+    _report = const MagpieUpscalingReport(status: MagpieUpscalingStatus.idle);
+  }
+
+  Future<void> _waitForExit(Process process) async {
+    try {
+      await process.exitCode.timeout(kMagpieQuitGrace);
+    } catch (_) {
+      // 超时（或拿不到 exitCode：detached 启动在部分平台上就是这样）→ 强杀。
+      // 只杀我们自己起的这一个 PID，绝不按进程名扫。
+      try {
+        process.kill(ProcessSignal.sigkill);
+      } catch (_) {}
+    }
+  }
+
+  /// 把本次会话加的 autoScale 关回去。**必须做**：留着的话，用户下次不经 Hibiki 直接双击
+  /// 游戏也会被 Magpie 自动拉起缩放 —— 那是我们没被授权做的事。
+  Future<void> _restoreProfile() async {
+    final MagpieWindowIdentity? identity = _appliedIdentity;
+    _appliedIdentity = null;
+    if (identity == null) return;
+    try {
+      final Map<String, dynamic>? config = await _readConfig();
+      if (config == null) return;
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleDisabled(
+        config: config,
+        identity: identity,
+      );
+      if (result.applied) await _writeConfig(result.config!);
+    } catch (_) {
+      // 收尾是 best-effort：配置被用户改乱了也不该让会话结束报错。
+    }
+  }
+}
+
+/// Windows 真实实现：裸 `dart:ffi` 调 user32/kernel32。
+///
+/// 走裸 FFI 而不是 `package:win32` —— win32 在本仓只是**传递依赖**，直接 import 会触发
+/// `depend_on_referenced_packages`（CI 把 warning 当致命）。同 `galgame_play_tracker.dart`
+/// 与 `desktop_foreground_guard.dart` 的既有范式。
+class MagpieWindowsBridge implements MagpieWin32Bridge {
+  MagpieWindowsBridge._();
+
+  static final MagpieWindowsBridge instance = MagpieWindowsBridge._();
+
+  static final DynamicLibrary _user32 = DynamicLibrary.open('user32.dll');
+  static final DynamicLibrary _kernel32 = DynamicLibrary.open('kernel32.dll');
+
+  static const int _processQueryLimitedInformation = 0x1000;
+  static const int _synchronize = 0x00100000;
+  static const int _hwndBroadcast = 0xFFFF;
+  static const int _maxPath = 32768;
+
+  late final _GetClassNameDart _getClassName = _user32
+      .lookupFunction<_GetClassNameNative, _GetClassNameDart>('GetClassNameW');
+  late final _GetWindowThreadProcessIdDart _getWindowThreadProcessId =
+      _user32.lookupFunction<_GetWindowThreadProcessIdNative,
+          _GetWindowThreadProcessIdDart>('GetWindowThreadProcessId');
+  late final _RegisterWindowMessageDart _registerWindowMessage = _user32
+      .lookupFunction<_RegisterWindowMessageNative, _RegisterWindowMessageDart>(
+          'RegisterWindowMessageW');
+  late final _PostMessageDart _postMessage = _user32
+      .lookupFunction<_PostMessageNative, _PostMessageDart>('PostMessageW');
+  late final _OpenProcessDart _openProcess = _kernel32
+      .lookupFunction<_OpenProcessNative, _OpenProcessDart>('OpenProcess');
+  late final _QueryFullProcessImageNameDart _queryFullProcessImageName =
+      _kernel32.lookupFunction<_QueryFullProcessImageNameNative,
+          _QueryFullProcessImageNameDart>('QueryFullProcessImageNameW');
+  late final _OpenMutexDart _openMutex =
+      _kernel32.lookupFunction<_OpenMutexNative, _OpenMutexDart>('OpenMutexW');
+  late final _CloseHandleDart _closeHandle = _kernel32
+      .lookupFunction<_CloseHandleNative, _CloseHandleDart>('CloseHandle');
+
+  @override
+  MagpieWindowIdentity? identityForWindow(int hwnd) {
+    if (!Platform.isWindows || hwnd == 0) return null;
+    final String? className = _classNameOf(hwnd);
+    if (className == null || className.isEmpty) return null;
+    final String? path = _executablePathOf(hwnd);
+    if (path == null || path.isEmpty) return null;
+    return MagpieWindowIdentity(
+      executablePath: path,
+      windowClassName: className,
+    );
+  }
+
+  String? _classNameOf(int hwnd) {
+    // 类名上限 256 个 WCHAR（RegisterClass 的硬上限），留一位收尾 NUL。
+    final Pointer<Uint16> buffer = calloc<Uint16>(257);
+    try {
+      final int length = _getClassName(hwnd, buffer, 257);
+      if (length <= 0) return null;
+      return buffer.cast<Utf16>().toDartString(length: length);
+    } catch (_) {
+      return null;
+    } finally {
+      calloc.free(buffer);
+    }
+  }
+
+  /// exe 完整路径。**必须用 `QueryFullProcessImageNameW`** —— Magpie 自己的
+  /// `Win32Helper::GetWindowPath` 走的就是它，换个 API（如 `GetModuleFileNameEx`）拿到的
+  /// 路径形态可能不同（DOS 设备名 vs 盘符），而 Magpie 的匹配是**裸字符串相等**。
+  String? _executablePathOf(int hwnd) {
+    final Pointer<Uint32> pidOut = calloc<Uint32>();
+    try {
+      _getWindowThreadProcessId(hwnd, pidOut);
+      final int pid = pidOut.value;
+      if (pid == 0) return null;
+      final int handle = _openProcess(_processQueryLimitedInformation, 0, pid);
+      if (handle == 0) return null;
+      final Pointer<Uint16> buffer = calloc<Uint16>(_maxPath);
+      final Pointer<Uint32> size = calloc<Uint32>();
+      try {
+        size.value = _maxPath;
+        if (_queryFullProcessImageName(handle, 0, buffer, size) == 0) {
+          return null;
+        }
+        return buffer.cast<Utf16>().toDartString(length: size.value);
+      } finally {
+        calloc.free(buffer);
+        calloc.free(size);
+        _closeHandle(handle);
+      }
+    } catch (_) {
+      return null;
+    } finally {
+      calloc.free(pidOut);
+    }
+  }
+
+  @override
+  bool isMagpieRunning() {
+    if (!Platform.isWindows) return false;
+    final Pointer<Utf16> name = kMagpieSingleInstanceMutex.toNativeUtf16();
+    try {
+      final int handle = _openMutex(_synchronize, 0, name);
+      if (handle == 0) return false;
+      _closeHandle(handle);
+      return true;
+    } catch (_) {
+      return false;
+    } finally {
+      calloc.free(name);
+    }
+  }
+
+  @override
+  bool broadcastQuit() {
+    if (!Platform.isWindows) return false;
+    final Pointer<Utf16> name = kMagpieQuitMessage.toNativeUtf16();
+    try {
+      final int message = _registerWindowMessage(name);
+      if (message == 0) return false;
+      return _postMessage(_hwndBroadcast, message, 0, 0) != 0;
+    } catch (_) {
+      return false;
+    } finally {
+      calloc.free(name);
+    }
+  }
+}
+
+typedef _GetClassNameNative = Int32 Function(
+    IntPtr hwnd, Pointer<Uint16> buffer, Int32 maxCount);
+typedef _GetClassNameDart = int Function(
+    int hwnd, Pointer<Uint16> buffer, int maxCount);
+
+typedef _GetWindowThreadProcessIdNative = Uint32 Function(
+    IntPtr hwnd, Pointer<Uint32> pid);
+typedef _GetWindowThreadProcessIdDart = int Function(
+    int hwnd, Pointer<Uint32> pid);
+
+typedef _RegisterWindowMessageNative = Uint32 Function(Pointer<Utf16> name);
+typedef _RegisterWindowMessageDart = int Function(Pointer<Utf16> name);
+
+typedef _PostMessageNative = Int32 Function(
+    IntPtr hwnd, Uint32 message, IntPtr wParam, IntPtr lParam);
+typedef _PostMessageDart = int Function(
+    int hwnd, int message, int wParam, int lParam);
+
+typedef _OpenProcessNative = IntPtr Function(
+    Uint32 access, Int32 inherit, Uint32 pid);
+typedef _OpenProcessDart = int Function(int access, int inherit, int pid);
+
+typedef _QueryFullProcessImageNameNative = Int32 Function(
+    IntPtr process, Uint32 flags, Pointer<Uint16> buffer, Pointer<Uint32> size);
+typedef _QueryFullProcessImageNameDart = int Function(
+    int process, int flags, Pointer<Uint16> buffer, Pointer<Uint32> size);
+
+typedef _OpenMutexNative = IntPtr Function(
+    Uint32 access, Int32 inherit, Pointer<Utf16> name);
+typedef _OpenMutexDart = int Function(
+    int access, int inherit, Pointer<Utf16> name);
+
+typedef _CloseHandleNative = Int32 Function(IntPtr handle);
+typedef _CloseHandleDart = int Function(int handle);

--- a/hibiki/lib/src/mining/magpie_upscaling_text.dart
+++ b/hibiki/lib/src/mining/magpie_upscaling_text.dart
@@ -1,0 +1,84 @@
+/// 窗口超分状态 → 用户看得懂的话。
+///
+/// 分层理由与 `gal_hook_failure_text.dart` 完全一致（BUG-1100 的教训）：
+/// [MagpieUpscalingStatus] / [MagpieProfileSkipReason] 是纯模型，诊断日志里保留它们的
+/// 机器可读 `name`；**只有这里**把它们翻成人话。绝不把 `bootstrapFailed`、
+/// `schemaMismatch` 这种内部枚举名甩到界面上——那正是当初 `engine_pcm_unavailable`
+/// 被原样显示给用户的老毛病。
+///
+/// 每条文案都要回答用户的两个问题：**现在是什么状态**（[magpieUpscalingStatusLabel]）
+/// 和 **我该做什么**（[magpieUpscalingActionHint]）。只说状态不说处置等于没说。
+library;
+
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/src/mining/magpie_upscaling.dart';
+import 'package:hibiki/src/mining/magpie_upscaling_service.dart';
+
+/// 这个状态值不值得在界面上占一行。
+///
+/// `idle`（没在跑）与 `disabled`（用户自己关的）都不显示：用户关掉的功能不该反复提醒他
+/// 关掉了，那是噪音不是信息。
+bool magpieUpscalingWorthShowing(MagpieUpscalingReport report) =>
+    switch (report.status) {
+      MagpieUpscalingStatus.idle => false,
+      MagpieUpscalingStatus.disabled => false,
+      MagpieUpscalingStatus.preparing => false,
+      MagpieUpscalingStatus.active => true,
+      MagpieUpscalingStatus.hotkeyOnly => true,
+      MagpieUpscalingStatus.unavailable => true,
+      MagpieUpscalingStatus.failed => true,
+    };
+
+/// 一句话状态。
+///
+/// `active` 分两种说法：native 广播回填 [MagpieUpscalingReport.scalingActive] 之前，
+/// 我们只知道「已经按自动缩放配置拉起了 Magpie」，还不知道它真的放大了没有。等广播到了
+/// 才敢说「已开启」。**不拿意图冒充结果。**
+String magpieUpscalingStatusLabel(MagpieUpscalingReport report) =>
+    switch (report.status) {
+      MagpieUpscalingStatus.active => report.scalingActive
+          ? t.galgame_upscaling_status_active
+          : t.galgame_upscaling_status_manual,
+      MagpieUpscalingStatus.hotkeyOnly => t.galgame_upscaling_status_manual,
+      MagpieUpscalingStatus.unavailable =>
+        t.galgame_upscaling_status_unavailable,
+      MagpieUpscalingStatus.failed => t.galgame_upscaling_status_failed,
+      MagpieUpscalingStatus.idle ||
+      MagpieUpscalingStatus.disabled ||
+      MagpieUpscalingStatus.preparing =>
+        t.galgame_upscaling_status_unavailable,
+    };
+
+/// 「我该做什么」。返回 null 表示确实没有比状态本身更有用的话可说 —— 此时 UI 就只显示
+/// 状态行，**绝不编造处置**（同 `galHookFailureLabel` 的约定）。
+String? magpieUpscalingActionHint(MagpieUpscalingReport report) {
+  switch (report.status) {
+    case MagpieUpscalingStatus.active:
+      // 真的在缩放就没什么要做的；还没收到广播时按「手动」给处置。
+      return report.scalingActive ? null : t.galgame_upscaling_hint_manual;
+    case MagpieUpscalingStatus.hotkeyOnly:
+      return _hintForSkip(report);
+    case MagpieUpscalingStatus.unavailable:
+      return t.galgame_upscaling_hint_not_installed;
+    case MagpieUpscalingStatus.failed:
+    case MagpieUpscalingStatus.idle:
+    case MagpieUpscalingStatus.disabled:
+    case MagpieUpscalingStatus.preparing:
+      return null;
+  }
+}
+
+/// 降级为热键模式时，按**原因**给不同的处置。
+///
+/// 这三条的区别对用户是实打实的：
+/// - 首次初始化 → 下次就好了，**这是最常见的一条**，也是「装完第一次没反应」的真身；
+/// - 已有别的 Magpie 在跑 → 永远不会自己好，得知道是我们有意不碰它；
+/// - 其余（上游改了配置格式等）→ 说不出所以然，就只给通用处置，不瞎解释。
+String _hintForSkip(MagpieUpscalingReport report) =>
+    switch (report.profileSkipReason) {
+      MagpieProfileSkipReason.bootstrapFailed =>
+        t.galgame_upscaling_hint_first_run,
+      MagpieProfileSkipReason.externalInstance =>
+        t.galgame_upscaling_hint_external,
+      _ => t.galgame_upscaling_hint_manual,
+    };

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -103,6 +103,7 @@ import 'package:hibiki/src/mining/galgame_repository.dart';
 import 'package:hibiki/src/mining/immersion_mining_engine.dart';
 import 'package:hibiki/src/mining/immersion_mining_request.dart';
 import 'package:hibiki/src/mining/immersion_capture_channel.dart';
+import 'package:hibiki/src/mining/magpie_upscaling.dart';
 import 'package:hibiki/src/mining/youtube_clip_miner.dart';
 import 'package:hibiki/src/sync/hibiki_sync_server.dart';
 import 'package:hibiki/src/sync/desktop_lookup_service.dart';
@@ -2977,6 +2978,13 @@ class AppModel with ChangeNotifier {
     // 内置引擎资源限制即时生效（用户在设置里改限速/连接数后不必重启）。
     _applyEmbeddedTorrentLimits(config);
   }
+
+  /// galgame 窗口超分策略（三态）。
+  MagpieUpscalingMode get galgameUpscalingMode =>
+      magpieUpscalingModeFromKey(prefsRepo.galgameUpscalingMode);
+
+  Future<void> setGalgameUpscalingMode(MagpieUpscalingMode mode) =>
+      prefsRepo.setGalgameUpscalingMode(magpieUpscalingModeToKey(mode));
 
   DownloadNetworkProxyConfig get downloadNetworkProxyConfig =>
       DownloadNetworkProxyConfig(

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -1795,6 +1795,19 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// galgame 窗口超分策略（`auto` / `installed_only` / `off`）。
+  ///
+  /// 存**裸字符串**而不是 enum index：重排枚举项不会毁掉用户设置。enum 转换在 AppModel
+  /// 层做（`magpieUpscalingModeFromKey` / `magpieUpscalingModeToKey`）。
+  /// 默认 `off` —— 整条超分链路尚未真机验证，且超分实打实吃 GPU，用户显式打开才启用。
+  String get galgameUpscalingMode =>
+      getPref('galgame_magpie_upscaling_mode', defaultValue: 'off') as String;
+
+  Future<void> setGalgameUpscalingMode(String value) async {
+    await setPref('galgame_magpie_upscaling_mode', value);
+    notifyListeners();
+  }
+
   /// AniList/Nyaa/Jimaku requests: auto (env > enabled system proxy > direct),
   /// explicit direct, or a user-provided host:port proxy.
   String get downloadNetworkProxyMode =>

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -12,6 +12,8 @@ import 'package:hibiki/src/anki/anki_view_model.dart';
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
 import 'package:hibiki/src/lookup/gal_hook_text_overlay_controller.dart';
 import 'package:hibiki/src/mining/gal_hook_failure_text.dart';
+import 'package:hibiki/src/mining/magpie_upscaling_service.dart';
+import 'package:hibiki/src/mining/magpie_upscaling_text.dart';
 import 'package:hibiki/src/mining/gal_hook_mining_coordinator.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
 import 'package:hibiki/src/mining/galgame_audio_source.dart';
@@ -1645,6 +1647,9 @@ class _CaptureHealthCard extends StatelessWidget {
                   state.hasWindow ? t.game_window_bound : t.game_window_missing,
               ready: state.hasWindow,
             ),
+            // 窗口超分：与上面的「窗口」相邻，因为说的是同一个游戏窗口。整行在用户
+            // 关掉超分 / 没在跑时自动消失，不给不关心的人制造噪音。
+            const _UpscalingHealthRows(),
             _HealthRow(
               label: t.game_health_text,
               value: endpoints.isEmpty
@@ -1673,6 +1678,60 @@ class _CaptureHealthCard extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// 健康卡里的「窗口超分」两行：状态行 + 可执行处置行。
+///
+/// 为什么处置要单独一行而不是塞进 `_HealthRow.value`：`value` 是 `maxLines: 1` 的右对齐
+/// 短值，装不下「按 Win+Shift+A，下次启动就自动放大了」这种话。而只说「未开启」不说
+/// 怎么办，正是「装完第一次没反应」变成用户报 bug 的原因。
+///
+/// 文案一律经 `magpie_upscaling_text.dart` 翻成人话，**绝不把 `bootstrapFailed` 这类
+/// 内部枚举名甩到界面上**（同 `gal_hook_failure_text.dart` 的纪律）。
+class _UpscalingHealthRows extends StatelessWidget {
+  const _UpscalingHealthRows();
+
+  @override
+  Widget build(BuildContext context) {
+    final MagpieUpscalingService? service =
+        GalHookSessionController.instance.magpieUpscaling;
+    // 没注入编排器（非 Windows / 测试替身）时整块不存在。
+    if (service == null) return const SizedBox.shrink();
+    return ListenableBuilder(
+      listenable: service,
+      builder: (BuildContext context, Widget? child) {
+        final MagpieUpscalingReport report = service.report;
+        if (!magpieUpscalingWorthShowing(report)) {
+          return const SizedBox.shrink();
+        }
+        // 只有真的收到 Magpie 的「缩放开始」广播才算就绪。拉起了进程不等于放大了，
+        // 不拿意图冒充结果。
+        final bool on = report.status == MagpieUpscalingStatus.active &&
+            report.scalingActive;
+        final String? hint = magpieUpscalingActionHint(report);
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            _HealthRow(
+              label: t.game_health_upscaling,
+              value: magpieUpscalingStatusLabel(report),
+              ready: on,
+            ),
+            if (hint != null)
+              Padding(
+                padding: const EdgeInsets.only(left: 25, bottom: 6),
+                child: Text(
+                  hint,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.tertiary,
+                      ),
+                ),
+              ),
+          ],
+        );
+      },
     );
   }
 }

--- a/hibiki/lib/src/settings/settings_schema_lookup.dart
+++ b/hibiki/lib/src/settings/settings_schema_lookup.dart
@@ -9,6 +9,7 @@ import 'package:hibiki/src/lookup/clipboard_panel_controller.dart';
 import 'package:hibiki/src/lookup/clipboard_text_overlay_controller.dart';
 import 'package:hibiki/src/lookup/gal_hook_text_overlay_controller.dart';
 import 'package:hibiki/src/lookup/global_lookup_controller.dart';
+import 'package:hibiki/src/mining/magpie_upscaling.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/settings/settings_actions.dart';
 import 'package:hibiki/src/settings/settings_context.dart';
@@ -992,6 +993,42 @@ SettingsDestination buildLookupDestination() {
               } else {
                 await TexthookerWsClientManager.instance.stop();
               }
+              settingsContext.refresh();
+            },
+          ),
+          // 窗口超分挂在 texthooker 旁边：galgame hook 目前唯一进 settings schema 的
+          // 开关就是它，新建一整个「游戏」destination 的代价远大于收益。
+          // Windows-only —— galgame hook 与 Magpie 都只做 Windows（见根 CLAUDE.md）。
+          SettingsSegmentedItem<MagpieUpscalingMode>(
+            id: 'lookup.galgame_upscaling',
+            title: t.galgame_upscaling,
+            subtitle: t.galgame_upscaling_hint,
+            icon: Icons.aspect_ratio_outlined,
+            visible: (SettingsContext settingsContext) => Platform.isWindows,
+            options: <SettingsSegmentOption<MagpieUpscalingMode>>[
+              SettingsSegmentOption<MagpieUpscalingMode>(
+                value: MagpieUpscalingMode.auto,
+                label: t.galgame_upscaling_auto,
+                tooltip: t.galgame_upscaling_auto,
+              ),
+              SettingsSegmentOption<MagpieUpscalingMode>(
+                value: MagpieUpscalingMode.installedOnly,
+                label: t.galgame_upscaling_installed_only,
+                tooltip: t.galgame_upscaling_installed_only,
+              ),
+              SettingsSegmentOption<MagpieUpscalingMode>(
+                value: MagpieUpscalingMode.off,
+                label: t.galgame_upscaling_off,
+                tooltip: t.galgame_upscaling_off,
+              ),
+            ],
+            selected: (SettingsContext settingsContext) =>
+                settingsContext.appModel.galgameUpscalingMode,
+            onChanged: (
+              SettingsContext settingsContext,
+              MagpieUpscalingMode value,
+            ) async {
+              await settingsContext.appModel.setGalgameUpscalingMode(value);
               settingsContext.refresh();
             },
           ),

--- a/hibiki/test/mining/magpie_native_guard_test.dart
+++ b/hibiki/test/mining/magpie_native_guard_test.dart
@@ -1,0 +1,122 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/magpie_scaling_channel.dart';
+
+/// Magpie 缩放状态监听的源码守卫。
+///
+/// native 侧只在 Windows 运行且需要真实的 Magpie 进程广播，CI（Linux）和普通单测宿主
+/// 都进不去真实路径，所以在「最强可落地层」= 源码文本上锁死修复结构：channel 名、
+/// 广播消息名、UIPI 放行、以及最容易被「简化」掉的
+/// `wParam==0 && lParam!=0 仍算缩放中` 那条语义。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // flutter test 的 cwd 是包根（hibiki/），用相对路径解析，Linux CI 同样可跑。
+  final File cpp = File('windows/runner/flutter_window.cpp');
+  final File header = File('windows/runner/flutter_window.h');
+
+  late String source;
+  late String headerSource;
+
+  setUpAll(() {
+    expect(cpp.existsSync(), isTrue,
+        reason: '找不到 ${cpp.path}（cwd=${Directory.current.path}）');
+    expect(header.existsSync(), isTrue,
+        reason: '找不到 ${header.path}（cwd=${Directory.current.path}）');
+    source = cpp.readAsStringSync();
+    headerSource = header.readAsStringSync();
+  });
+
+  group('flutter_window.cpp Magpie 监听结构', () {
+    test('注册了 Magpie 的广播消息名', () {
+      expect(source.contains('MagpieScalingChanged'), isTrue,
+          reason: '必须 RegisterWindowMessageW(L"MagpieScalingChanged")');
+      expect(
+          source.contains(
+              'RegisterWindowMessageW(L"MagpieScalingChanged")'),
+          isTrue,
+          reason: '广播消息号必须来自 RegisterWindowMessageW，不能写死常量');
+    });
+
+    test('对该消息放行 UIPI 消息过滤器', () {
+      expect(source.contains('ChangeWindowMessageFilterEx'), isTrue,
+          reason: '跨完整性级别收广播必须 ChangeWindowMessageFilterEx(..., MSGFLT_ALLOW, nullptr)');
+      expect(source.contains('MSGFLT_ALLOW'), isTrue);
+    });
+
+    test('channel 名与 Dart 侧一致', () {
+      expect(source.contains('app.hibiki.reader/magpie'), isTrue);
+      expect(source.contains('onScalingChanged'), isTrue);
+    });
+
+    test('wParam==0 且 lParam!=0 仍算缩放中（只是源窗口转后台）', () {
+      // 载荷表达式本身是根因所在：把它简化成 `wparam != 0` 就会把「源窗口转后台」
+      // 误判成「缩放结束」。
+      expect(
+          source.contains('(wparam == 0) ? (lparam != 0) : true'),
+          isTrue,
+          reason: 'scaling 判定必须保留 lParam 区分，不能退化成只看 wParam');
+      expect(source.contains('仅源窗口切到后台'), isTrue,
+          reason: '语义注释锚点丢失说明这段被重写过，需重新确认 Magpie 契约');
+    });
+
+    test('广播不被消费（不 return，落到基类默认处理）', () {
+      final int idx =
+          source.indexOf('if (magpie_scaling_message_ != 0 && message ==');
+      expect(idx, greaterThanOrEqualTo(0), reason: '缺少运行时消息号匹配分支');
+      final int braceEnd = source.indexOf('}', idx);
+      expect(braceEnd, greaterThan(idx));
+      final String branch = source.substring(idx, braceEnd);
+      expect(branch.contains('return'), isFalse,
+          reason: '系统广播必须透传给基类，不得在此 return 消费');
+    });
+
+    test('注册函数在 OnCreate 里被调用，且声明落在 header', () {
+      expect(source.contains('  RegisterMagpieChannel();'), isTrue);
+      expect(headerSource.contains('void RegisterMagpieChannel();'), isTrue);
+      expect(headerSource.contains('magpie_scaling_message_ = 0;'), isTrue,
+          reason: '消息号成员必须零初始化，否则未注册时会误匹配');
+    });
+  });
+
+  group('MagpieScalingChannel Dart 侧解析', () {
+    tearDown(MagpieScalingChannel.clearHandler);
+
+    test('onScalingChanged 原样解析 state/handle/scaling', () async {
+      MagpieScalingEvent? got;
+      MagpieScalingChannel.setHandler((MagpieScalingEvent e) => got = e);
+      await MagpieScalingChannel.debugDispatch(const MethodCall(
+        'onScalingChanged',
+        <Object?, Object?>{'state': 0, 'handle': 1234, 'scaling': true},
+      ));
+      expect(got,
+          const MagpieScalingEvent(state: 0, handle: 1234, scaling: true));
+    });
+
+    test('字段缺失取保守缺省，未知方法名忽略', () async {
+      MagpieScalingEvent? got;
+      MagpieScalingChannel.setHandler((MagpieScalingEvent e) => got = e);
+      await MagpieScalingChannel.debugDispatch(
+          const MethodCall('onScalingChanged', <Object?, Object?>{}));
+      expect(got, const MagpieScalingEvent(state: 0, handle: 0, scaling: false));
+
+      got = null;
+      await MagpieScalingChannel.debugDispatch(
+          const MethodCall('somethingElse', <Object?, Object?>{'state': 1}));
+      expect(got, isNull);
+    });
+
+    test('clearHandler 后不再派发', () async {
+      MagpieScalingEvent? got;
+      MagpieScalingChannel.setHandler((MagpieScalingEvent e) => got = e);
+      MagpieScalingChannel.clearHandler();
+      await MagpieScalingChannel.debugDispatch(const MethodCall(
+        'onScalingChanged',
+        <Object?, Object?>{'state': 1, 'handle': 7, 'scaling': true},
+      ));
+      expect(got, isNull);
+    });
+  });
+}

--- a/hibiki/test/mining/magpie_upscaling_test.dart
+++ b/hibiki/test/mining/magpie_upscaling_test.dart
@@ -7,12 +7,14 @@
 //
 // 外加一组**源码守卫**，钉住三个读源码挖出来的硬约束，防止后人「顺手优化」掉。
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/mining/magpie_upscaling.dart';
 import 'package:hibiki/src/mining/magpie_upscaling_service.dart';
+import 'package:hibiki/src/mining/magpie_upscaling_text.dart';
 import 'package:path/path.dart' as p;
 
 /// 一份「Magpie 已经跑过一次、配置完整」的最小 config。
@@ -61,6 +63,25 @@ class FakeBridge implements MagpieWin32Bridge {
   bool broadcastQuit() {
     quitBroadcasts++;
     return true;
+  }
+}
+
+/// 假进程句柄：默认「立刻退出」，让收束路径不必真等 [kMagpieQuitGrace]。
+class FakeProcessHandle implements MagpieProcessHandle {
+  FakeProcessHandle({bool exitImmediately = true}) {
+    if (exitImmediately) _exit.complete(0);
+  }
+
+  final Completer<int> _exit = Completer<int>();
+  bool killed = false;
+
+  @override
+  Future<int> get exitCode => _exit.future;
+
+  @override
+  void kill() {
+    killed = true;
+    if (!_exit.isCompleted) _exit.complete(-1);
   }
 }
 
@@ -546,7 +567,10 @@ void main() {
       required MagpieUpscalingMode mode,
       FakeBridge? bridge,
       List<String>? launched,
+      List<FakeProcessHandle>? handles,
       bool isWindows = true,
+      bool launchThrows = true,
+      Duration bootstrapTimeout = const Duration(milliseconds: 600),
     }) =>
         MagpieUpscalingService(
           modeReader: () => mode,
@@ -554,9 +578,15 @@ void main() {
           configPathOverride: configPath,
           hibikiExecutablePath: kHibikiExe,
           isWindowsOverride: isWindows,
+          bootstrapTimeout: bootstrapTimeout,
           processLauncher: (String exe, List<String> args) async {
             launched?.add('$exe ${args.join(' ')}');
-            throw const ProcessException('magpie', <String>[], 'fake', 0);
+            if (launchThrows) {
+              throw const ProcessException('magpie', <String>[], 'fake', 0);
+            }
+            final FakeProcessHandle handle = FakeProcessHandle();
+            handles?.add(handle);
+            return handle;
           },
         );
 
@@ -649,6 +679,194 @@ void main() {
     });
   });
 
+  group('首次使用的预热（消灭「装完第一次没反应」）', () {
+    late Directory tmp;
+    late String configPath;
+
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('magpie_bootstrap_test_');
+      configPath = p.join(tmp.path, 'config', 'config.json');
+    });
+
+    tearDown(() {
+      try {
+        if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+
+    /// 造一个「Magpie 已装」的假安装目录不现实（`MagpieInstaller.executablePath()`
+    /// 指向真实 exe 同级），所以这里直接测预热的**判据**：配置就绪时不该再起预热进程。
+    test('配置已就绪 → 不预热，直接进入写 profile（第二局起零额外开销）', () async {
+      File(configPath)
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync(jsonEncode(baseConfig()));
+      final List<String> launched = <String>[];
+      final MagpieUpscalingService service = MagpieUpscalingService(
+        modeReader: () => MagpieUpscalingMode.installedOnly,
+        bridge: FakeBridge(running: true), // 直接走「别人开着」早退，验证不预热
+        configPathOverride: configPath,
+        hibikiExecutablePath: kHibikiExe,
+        isWindowsOverride: true,
+        processLauncher: (String exe, List<String> args) async {
+          launched.add(exe);
+          return FakeProcessHandle();
+        },
+      );
+      await service.onGameWindowReady(hwnd: 1);
+      expect(launched, isEmpty);
+    });
+
+    test('0 字节便携标记等价于「配置没就绪」—— 不能被当成有效配置', () async {
+      File(configPath)
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync('');
+      // 0 字节文件存在，但里面没有 scalingModes；此时写 profile 必踩 -1 钳位陷阱，
+      // 所以纯函数层必须拒绝。
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
+        config: <String, dynamic>{},
+        identity: kGame,
+        profileName: 'x',
+        hibikiExecutablePath: kHibikiExe,
+      );
+      expect(result.applied, isFalse);
+      expect(result.skipReason, MagpieProfileSkipReason.noScalingModes);
+    });
+
+    test('预热失败有独立的降级原因（不再笼统报 schemaMismatch）', () {
+      // bootstrapFailed 必须是个独立枚举项：UI 要据它说「第一次要先跑一次 Magpie」，
+      // 而 schemaMismatch 说的是「上游改了格式」，两者对用户的含义完全不同。
+      expect(
+        MagpieProfileSkipReason.values,
+        contains(MagpieProfileSkipReason.bootstrapFailed),
+      );
+      expect(
+        MagpieProfileSkipReason.bootstrapFailed,
+        isNot(MagpieProfileSkipReason.schemaMismatch),
+      );
+    });
+  });
+
+  group('用户可见文案：说人话，不甩内部枚举名', () {
+    MagpieUpscalingReport report(
+      MagpieUpscalingStatus status, {
+      MagpieProfileSkipReason? skip,
+      bool scaling = false,
+    }) =>
+        MagpieUpscalingReport(
+          status: status,
+          profileSkipReason: skip,
+          scalingActive: scaling,
+        );
+
+    test('用户自己关掉 / 没在跑 → 整行不显示（不制造噪音）', () {
+      expect(
+        magpieUpscalingWorthShowing(report(MagpieUpscalingStatus.disabled)),
+        isFalse,
+      );
+      expect(
+        magpieUpscalingWorthShowing(report(MagpieUpscalingStatus.idle)),
+        isFalse,
+      );
+      expect(
+        magpieUpscalingWorthShowing(report(MagpieUpscalingStatus.preparing)),
+        isFalse,
+      );
+    });
+
+    test('需要用户知道的状态都显示', () {
+      for (final MagpieUpscalingStatus status in <MagpieUpscalingStatus>[
+        MagpieUpscalingStatus.active,
+        MagpieUpscalingStatus.hotkeyOnly,
+        MagpieUpscalingStatus.unavailable,
+        MagpieUpscalingStatus.failed,
+      ]) {
+        expect(magpieUpscalingWorthShowing(report(status)), isTrue,
+            reason: '$status 应该显示');
+      }
+    });
+
+    test('🔴 任何状态的文案都不含内部枚举名（BUG-1100 的教训）', () {
+      // 把所有内部标识符列出来，挨个确认它们不会出现在用户看到的字符串里。
+      final List<String> internal = <String>[
+        ...MagpieUpscalingStatus.values
+            .map((MagpieUpscalingStatus e) => e.name),
+        ...MagpieProfileSkipReason.values
+            .map((MagpieProfileSkipReason e) => e.name),
+        'MagpieUpscalingStatus',
+        'MagpieProfileSkipReason',
+      ];
+      for (final MagpieUpscalingStatus status in MagpieUpscalingStatus.values) {
+        for (final MagpieProfileSkipReason? skip in <MagpieProfileSkipReason?>[
+          null,
+          ...MagpieProfileSkipReason.values
+        ]) {
+          final MagpieUpscalingReport r = report(status, skip: skip);
+          final String text =
+              '${magpieUpscalingStatusLabel(r)} ${magpieUpscalingActionHint(r) ?? ''}';
+          expect(text.trim(), isNotEmpty);
+          for (final String token in internal) {
+            expect(
+              text.contains(token),
+              isFalse,
+              reason: '「$text」泄漏了内部标识符 $token',
+            );
+          }
+        }
+      }
+    });
+
+    test('首次初始化失败 → 给「下次就自动了」的专属处置，而不是通用话', () {
+      final String? firstRun = magpieUpscalingActionHint(report(
+        MagpieUpscalingStatus.hotkeyOnly,
+        skip: MagpieProfileSkipReason.bootstrapFailed,
+      ));
+      final String? generic = magpieUpscalingActionHint(report(
+        MagpieUpscalingStatus.hotkeyOnly,
+        skip: MagpieProfileSkipReason.schemaMismatch,
+      ));
+      expect(firstRun, isNotNull);
+      expect(generic, isNotNull);
+      expect(firstRun, isNot(generic), reason: '「第一次要先初始化」和「上游改了格式」对用户是两回事');
+    });
+
+    test('别人的 Magpie 开着 → 专属处置（这种情况永远不会自己好）', () {
+      final String? external = magpieUpscalingActionHint(report(
+        MagpieUpscalingStatus.hotkeyOnly,
+        skip: MagpieProfileSkipReason.externalInstance,
+      ));
+      final String? generic = magpieUpscalingActionHint(report(
+        MagpieUpscalingStatus.hotkeyOnly,
+        skip: MagpieProfileSkipReason.schemaMismatch,
+      ));
+      expect(external, isNotNull);
+      expect(external, isNot(generic));
+    });
+
+    test('每条降级都给得出处置（只说状态不说怎么办等于没说）', () {
+      for (final MagpieProfileSkipReason skip
+          in MagpieProfileSkipReason.values) {
+        expect(
+          magpieUpscalingActionHint(
+            report(MagpieUpscalingStatus.hotkeyOnly, skip: skip),
+          ),
+          isNotNull,
+          reason: '$skip 降级时必须告诉用户怎么办',
+        );
+      }
+    });
+
+    test('真的在缩放 → 状态与「还没开始」区分得开，且不再催用户按热键', () {
+      final MagpieUpscalingReport on =
+          report(MagpieUpscalingStatus.active, scaling: true);
+      final MagpieUpscalingReport pending =
+          report(MagpieUpscalingStatus.active);
+      expect(magpieUpscalingStatusLabel(on),
+          isNot(magpieUpscalingStatusLabel(pending)));
+      expect(magpieUpscalingActionHint(on), isNull);
+      expect(magpieUpscalingActionHint(pending), isNotNull);
+    });
+  });
+
   group('源码守卫：钉住三个读源码挖出来的硬约束', () {
     late String pureSource;
     late String serviceSource;
@@ -695,6 +913,30 @@ void main() {
       // 代码里不该出现 Windowed(2) 这个自动缩放取值。
       expect(pureSource.contains('kMagpieAutoScaleWindowed'), isFalse);
       expect(serviceSource.contains('AutoScaleWindowed'), isFalse);
+    });
+
+    test('预热必须排在「写 profile」之前（否则第一局永远没有 scalingModes 可用）', () {
+      final int bootstrapIndex =
+          serviceSource.indexOf('await _ensureConfigMaterialized();');
+      final int applyIndex =
+          serviceSource.indexOf('await _applyAutoScaleProfile(hwnd);');
+      expect(bootstrapIndex, greaterThan(0),
+          reason: '预热步骤被删掉了 —— 首次使用会退回「装完没反应」');
+      expect(applyIndex, greaterThan(0));
+      expect(bootstrapIndex, lessThan(applyIndex));
+    });
+
+    test('预热起的进程必须被收掉（不能留游离 Magpie 顶掉单实例互斥体）', () {
+      final int bootstrapIndex =
+          serviceSource.indexOf('Future<void> _ensureConfigMaterialized()');
+      expect(bootstrapIndex, greaterThan(0));
+      final int endIndex = serviceSource.indexOf(
+          'Future<void> _waitForConfig()', bootstrapIndex);
+      final String body = serviceSource.substring(bootstrapIndex, endIndex);
+      expect(body.contains('_waitForExit(warmup)'), isTrue,
+          reason: '预热实例必须等它真的退出');
+      expect(body.contains('finally'), isTrue,
+          reason: '收尾必须在 finally 里，超时/异常都不能漏掉进程');
     });
 
     test('配置必须在拉起 Magpie 之前写（Magpie 只在启动时读一次，无文件监视）', () {

--- a/hibiki/test/mining/magpie_upscaling_test.dart
+++ b/hibiki/test/mining/magpie_upscaling_test.dart
@@ -1,0 +1,758 @@
+// 内置 Magpie 窗口超分（阶段二）的单测。
+//
+// 分三组：
+// 1. 三态开关 → 后端的裁决（纯函数，含非 Windows 边界）
+// 2. profile 增量改写的 best-effort 退化（每一条 skip 原因都要有用例）
+// 3. 生命周期收束（用假 Win32 桥 + 假进程启动器，在任意平台可跑）
+//
+// 外加一组**源码守卫**，钉住三个读源码挖出来的硬约束，防止后人「顺手优化」掉。
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/magpie_upscaling.dart';
+import 'package:hibiki/src/mining/magpie_upscaling_service.dart';
+import 'package:path/path.dart' as p;
+
+/// 一份「Magpie 已经跑过一次、配置完整」的最小 config。
+Map<String, dynamic> baseConfig({
+  int defaultScalingMode = 2,
+  int scalingModeCount = 7,
+  List<Map<String, dynamic>> extraProfiles = const <Map<String, dynamic>>[],
+}) =>
+    <String, dynamic>{
+      'theme': 2,
+      'scalingModes': List<Map<String, dynamic>>.generate(
+        scalingModeCount,
+        (int i) => <String, dynamic>{'name': 'mode$i'},
+      ),
+      'profiles': <Map<String, dynamic>>[
+        <String, dynamic>{'scalingMode': defaultScalingMode},
+        ...extraProfiles,
+      ],
+    };
+
+const MagpieWindowIdentity kGame = MagpieWindowIdentity(
+  executablePath: r'D:\Games\Sakura\sakura.exe',
+  windowClassName: 'KiriKiriClass',
+);
+
+const String kHibikiExe = r'C:\Program Files\Hibiki\Hibiki.exe';
+
+/// 假 Win32 桥：完全不碰 FFI，任意平台可跑。
+class FakeBridge implements MagpieWin32Bridge {
+  FakeBridge({
+    this.identity = kGame,
+    this.running = false,
+  });
+
+  MagpieWindowIdentity? identity;
+  bool running;
+  int quitBroadcasts = 0;
+
+  @override
+  MagpieWindowIdentity? identityForWindow(int hwnd) => identity;
+
+  @override
+  bool isMagpieRunning() => running;
+
+  @override
+  bool broadcastQuit() {
+    quitBroadcasts++;
+    return true;
+  }
+}
+
+void main() {
+  group('三态开关 → 后端裁决', () {
+    test('off 一律 off，与是否装了无关', () {
+      for (final bool installed in <bool>[true, false]) {
+        expect(
+          resolveMagpieBackend(
+            mode: MagpieUpscalingMode.off,
+            isWindows: true,
+            installedAvailable: installed,
+          ),
+          MagpieBackend.off,
+        );
+      }
+    });
+
+    test('非 Windows 一律 off —— galgame 只做 Windows', () {
+      for (final MagpieUpscalingMode mode in MagpieUpscalingMode.values) {
+        expect(
+          resolveMagpieBackend(
+            mode: mode,
+            isWindows: false,
+            installedAvailable: true,
+          ),
+          MagpieBackend.off,
+          reason: 'mode=$mode 在非 Windows 上必须 off',
+        );
+      }
+    });
+
+    test('installedOnly 没装 → unavailable（绝不联网）', () {
+      expect(
+        resolveMagpieBackend(
+          mode: MagpieUpscalingMode.installedOnly,
+          isWindows: true,
+          installedAvailable: false,
+        ),
+        MagpieBackend.unavailable,
+      );
+    });
+
+    test('installedOnly 装了 → installed', () {
+      expect(
+        resolveMagpieBackend(
+          mode: MagpieUpscalingMode.installedOnly,
+          isWindows: true,
+          installedAvailable: true,
+        ),
+        MagpieBackend.installed,
+      );
+    });
+
+    test('auto 装了 → installed（不为用自家产物重复下载）', () {
+      expect(
+        resolveMagpieBackend(
+          mode: MagpieUpscalingMode.auto,
+          isWindows: true,
+          installedAvailable: true,
+        ),
+        MagpieBackend.installed,
+      );
+    });
+
+    test('auto 没装 → needsDownload', () {
+      expect(
+        resolveMagpieBackend(
+          mode: MagpieUpscalingMode.auto,
+          isWindows: true,
+          installedAvailable: false,
+        ),
+        MagpieBackend.needsDownload,
+      );
+    });
+  });
+
+  group('偏好键编解码', () {
+    test('往返稳定', () {
+      for (final MagpieUpscalingMode mode in MagpieUpscalingMode.values) {
+        expect(
+          magpieUpscalingModeFromKey(magpieUpscalingModeToKey(mode)),
+          mode,
+        );
+      }
+    });
+
+    test('未知 / null 回落到默认（off）', () {
+      expect(magpieUpscalingModeFromKey(null), kMagpieDefaultUpscalingMode);
+      expect(magpieUpscalingModeFromKey(''), kMagpieDefaultUpscalingMode);
+      expect(magpieUpscalingModeFromKey('nonsense'), MagpieUpscalingMode.off);
+    });
+
+    test('持久化串是稳定字面量，不是 enum.name / index', () {
+      expect(magpieUpscalingModeToKey(MagpieUpscalingMode.installedOnly),
+          'installed_only');
+      expect(magpieUpscalingModeToKey(MagpieUpscalingMode.auto), 'auto');
+      expect(magpieUpscalingModeToKey(MagpieUpscalingMode.off), 'off');
+    });
+  });
+
+  group('🔴 硬禁令：绝不给 Hibiki 自己建 autoScale profile', () {
+    test('目标就是 Hibiki 自己 → 拒绝（大小写不敏感）', () {
+      expect(
+        magpieProfileTargetAllowed(
+          targetExecutablePath: kHibikiExe.toUpperCase(),
+          hibikiExecutablePath: kHibikiExe,
+        ),
+        isFalse,
+      );
+    });
+
+    test('空目标路径 → 拒绝', () {
+      expect(
+        magpieProfileTargetAllowed(
+          targetExecutablePath: '   ',
+          hibikiExecutablePath: kHibikiExe,
+        ),
+        isFalse,
+      );
+    });
+
+    test('正常游戏 exe → 放行', () {
+      expect(
+        magpieProfileTargetAllowed(
+          targetExecutablePath: kGame.executablePath,
+          hibikiExecutablePath: kHibikiExe,
+        ),
+        isTrue,
+      );
+    });
+
+    test('写 profile 时该禁令是硬门，不是建议', () {
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
+        config: baseConfig(),
+        identity: MagpieWindowIdentity(
+          executablePath: kHibikiExe,
+          windowClassName: 'FLUTTER_RUNNER_WIN32_WINDOW',
+        ),
+        profileName: 'Hibiki',
+        hibikiExecutablePath: kHibikiExe,
+      );
+      expect(result.applied, isFalse);
+      expect(result.skipReason, MagpieProfileSkipReason.forbiddenTarget);
+    });
+  });
+
+  group('profile 增量改写：成功路径', () {
+    test('追加一条完整的 autoScale profile', () {
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
+        config: baseConfig(defaultScalingMode: 3),
+        identity: kGame,
+        profileName: 'Hibiki: sakura.exe',
+        hibikiExecutablePath: kHibikiExe,
+      );
+      expect(result.applied, isTrue);
+      final List<Object?> profiles =
+          result.config!['profiles']! as List<Object?>;
+      expect(profiles.length, 2);
+      final Map<Object?, Object?> added = profiles[1]! as Map<Object?, Object?>;
+
+      // `_LoadProfile` 里 name/packaged/pathRule/classNameRule 缺一不可，缺了整条被丢弃。
+      expect(added['name'], 'Hibiki: sakura.exe');
+      expect(added['packaged'], isFalse);
+      expect(added['pathRule'], kGame.executablePath);
+      expect(added['classNameRule'], kGame.windowClassName);
+      // autoScale 是 uint 枚举不是 bool。
+      expect(added['autoScale'], 1);
+      expect(added['autoScale'], isA<int>());
+      // scalingMode 沿用默认 profile 的选择，且必须 >= 0（-1 会报 InvalidScalingMode）。
+      expect(added['scalingMode'], 3);
+      // 我们不猜任何私有字段：没有 scalingFlags 这个 key。
+      expect(added.containsKey('scalingFlags'), isFalse);
+    });
+
+    test('默认 profile 的 scalingMode 越界 / 为 -1 时回落 0', () {
+      for (final int bad in <int>[-1, 99]) {
+        final MagpieProfileWriteResult result =
+            magpieConfigWithAutoScaleProfile(
+          config: baseConfig(defaultScalingMode: bad),
+          identity: kGame,
+          profileName: 'x',
+          hibikiExecutablePath: kHibikiExe,
+        );
+        final List<Object?> profiles =
+            result.config!['profiles']! as List<Object?>;
+        expect((profiles[1]! as Map<Object?, Object?>)['scalingMode'], 0);
+      }
+    });
+
+    test('已有同身份 profile → 只翻 autoScale，用户其余设置一律不动', () {
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
+        config: baseConfig(extraProfiles: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'name': '用户自己建的',
+            'packaged': false,
+            'pathRule': kGame.executablePath,
+            'classNameRule': kGame.windowClassName,
+            'autoScale': 0,
+            'scalingMode': 5,
+            'cursorScaling': 4,
+            '3DGameMode': true,
+          },
+        ]),
+        identity: kGame,
+        profileName: 'Hibiki: sakura.exe',
+        hibikiExecutablePath: kHibikiExe,
+      );
+      expect(result.applied, isTrue);
+      final Map<Object?, Object?> entry = (result.config!['profiles']!
+          as List<Object?>)[1]! as Map<Object?, Object?>;
+      expect(entry['autoScale'], 1);
+      // 名字没被改成我们的、其余字段原样保留。
+      expect(entry['name'], '用户自己建的');
+      expect(entry['scalingMode'], 5);
+      expect(entry['cursorScaling'], 4);
+      expect(entry['3DGameMode'], isTrue);
+      // 没有多出一条重复 profile。
+      expect((result.config!['profiles']! as List<Object?>).length, 2);
+    });
+
+    test('配置其余顶层键原样保留', () {
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
+        config: baseConfig(),
+        identity: kGame,
+        profileName: 'x',
+        hibikiExecutablePath: kHibikiExe,
+      );
+      expect(result.config!['theme'], 2);
+      expect((result.config!['scalingModes']! as List<Object?>).length, 7);
+    });
+  });
+
+  group('profile 增量改写：best-effort 退化（每条都必须降级而不是抛）', () {
+    test('scalingModes 为空 → noScalingModes（写了必踩 -1 钳位陷阱）', () {
+      final Map<String, dynamic> config = baseConfig();
+      config['scalingModes'] = <Object?>[];
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
+        config: config,
+        identity: kGame,
+        profileName: 'x',
+        hibikiExecutablePath: kHibikiExe,
+      );
+      expect(result.applied, isFalse);
+      expect(result.skipReason, MagpieProfileSkipReason.noScalingModes);
+    });
+
+    test('scalingModes 缺失 → noScalingModes', () {
+      final Map<String, dynamic> config = baseConfig()..remove('scalingModes');
+      expect(
+        magpieConfigWithAutoScaleProfile(
+          config: config,
+          identity: kGame,
+          profileName: 'x',
+          hibikiExecutablePath: kHibikiExe,
+        ).skipReason,
+        MagpieProfileSkipReason.noScalingModes,
+      );
+    });
+
+    test('profiles 缺失 / 为空 / 第 0 项不是对象 → schemaMismatch', () {
+      for (final Object? bad in <Object?>[
+        null,
+        <Object?>[],
+        <Object?>['x']
+      ]) {
+        final Map<String, dynamic> config = baseConfig();
+        if (bad == null) {
+          config.remove('profiles');
+        } else {
+          config['profiles'] = bad;
+        }
+        expect(
+          magpieConfigWithAutoScaleProfile(
+            config: config,
+            identity: kGame,
+            profileName: 'x',
+            hibikiExecutablePath: kHibikiExe,
+          ).skipReason,
+          MagpieProfileSkipReason.schemaMismatch,
+          reason: 'profiles=$bad',
+        );
+      }
+    });
+
+    test(
+        '窗口身份不全 → missingWindowIdentity（空 pathRule/classNameRule 会让'
+        ' Magpie 整条丢弃）', () {
+      const List<MagpieWindowIdentity> broken = <MagpieWindowIdentity>[
+        MagpieWindowIdentity(executablePath: '', windowClassName: 'A'),
+        MagpieWindowIdentity(executablePath: r'C:\a.exe', windowClassName: ''),
+        MagpieWindowIdentity(executablePath: '  ', windowClassName: '  '),
+      ];
+      for (final MagpieWindowIdentity id in broken) {
+        expect(
+          magpieConfigWithAutoScaleProfile(
+            config: baseConfig(),
+            identity: id,
+            profileName: 'x',
+            hibikiExecutablePath: kHibikiExe,
+          ).skipReason,
+          MagpieProfileSkipReason.missingWindowIdentity,
+          reason: '$id',
+        );
+      }
+    });
+
+    test('profileName 为空 → missingWindowIdentity（name 空会被整条丢弃）', () {
+      expect(
+        magpieConfigWithAutoScaleProfile(
+          config: baseConfig(),
+          identity: kGame,
+          profileName: '   ',
+          hibikiExecutablePath: kHibikiExe,
+        ).skipReason,
+        MagpieProfileSkipReason.missingWindowIdentity,
+      );
+    });
+
+    test('已有等价且已启用的 profile → alreadySatisfied，不重复追加', () {
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
+        config: baseConfig(extraProfiles: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'name': 'x',
+            'packaged': false,
+            'pathRule': kGame.executablePath,
+            'classNameRule': kGame.windowClassName,
+            'autoScale': 1,
+          },
+        ]),
+        identity: kGame,
+        profileName: 'x',
+        hibikiExecutablePath: kHibikiExe,
+      );
+      expect(result.applied, isFalse);
+      expect(result.skipReason, MagpieProfileSkipReason.alreadySatisfied);
+    });
+  });
+
+  group('🔴 身份匹配必须与 Magpie 逐字节一致', () {
+    test('类名不同 → 视作不同 profile（Magpie 先比 classNameRule 再比 pathRule）', () {
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
+        config: baseConfig(extraProfiles: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'name': 'other',
+            'packaged': false,
+            'pathRule': kGame.executablePath,
+            'classNameRule': '另一个类名',
+            'autoScale': 1,
+          },
+        ]),
+        identity: kGame,
+        profileName: 'x',
+        hibikiExecutablePath: kHibikiExe,
+      );
+      // 类名不同 → 不算同一条 → 应该新追加而不是复用。
+      expect(result.applied, isTrue);
+      expect((result.config!['profiles']! as List<Object?>).length, 3);
+    });
+
+    test('路径大小写不同 → 视作不同 profile（Magpie 用裸 wstring==，无 _wcsicmp）', () {
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
+        config: baseConfig(extraProfiles: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'name': 'other',
+            'packaged': false,
+            'pathRule': kGame.executablePath.toUpperCase(),
+            'classNameRule': kGame.windowClassName,
+            'autoScale': 1,
+          },
+        ]),
+        identity: kGame,
+        profileName: 'x',
+        hibikiExecutablePath: kHibikiExe,
+      );
+      expect(result.applied, isTrue);
+      expect((result.config!['profiles']! as List<Object?>).length, 3);
+    });
+
+    test('packaged 为 true 的条目永远不匹配（那是 AUMID 不是路径）', () {
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
+        config: baseConfig(extraProfiles: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'name': 'uwp',
+            'packaged': true,
+            'pathRule': kGame.executablePath,
+            'classNameRule': kGame.windowClassName,
+            'autoScale': 1,
+          },
+        ]),
+        identity: kGame,
+        profileName: 'x',
+        hibikiExecutablePath: kHibikiExe,
+      );
+      expect(result.applied, isTrue);
+      expect((result.config!['profiles']! as List<Object?>).length, 3);
+    });
+
+    test('第 0 项（默认 profile）永远不被当成匹配目标', () {
+      // 构造一个「默认 profile 恰好带了同样身份字段」的病态配置。
+      final Map<String, dynamic> config = baseConfig();
+      (config['profiles']! as List<Object?>)[0] = <String, dynamic>{
+        'scalingMode': 0,
+        'packaged': false,
+        'pathRule': kGame.executablePath,
+        'classNameRule': kGame.windowClassName,
+        'autoScale': 1,
+      };
+      final MagpieProfileWriteResult result = magpieConfigWithAutoScaleProfile(
+        config: config,
+        identity: kGame,
+        profileName: 'x',
+        hibikiExecutablePath: kHibikiExe,
+      );
+      // 必须追加新条目，而不是去动默认 profile。
+      expect(result.applied, isTrue);
+      expect((result.config!['profiles']! as List<Object?>).length, 2);
+    });
+  });
+
+  group('收尾：把 autoScale 关回去', () {
+    test('关掉我们加的那条', () {
+      final Map<String, dynamic> withProfile = magpieConfigWithAutoScaleProfile(
+        config: baseConfig(),
+        identity: kGame,
+        profileName: 'x',
+        hibikiExecutablePath: kHibikiExe,
+      ).config!;
+      final MagpieProfileWriteResult off = magpieConfigWithAutoScaleDisabled(
+        config: withProfile,
+        identity: kGame,
+      );
+      expect(off.applied, isTrue);
+      final Map<Object?, Object?> entry = (off.config!['profiles']!
+          as List<Object?>)[1]! as Map<Object?, Object?>;
+      expect(entry['autoScale'], 0);
+      // profile 本身保留（用户下次还能看见 / 手动改），只是不再自动缩放。
+      expect(entry['pathRule'], kGame.executablePath);
+    });
+
+    test('配置里没有我们的 profile → alreadySatisfied，不报错', () {
+      expect(
+        magpieConfigWithAutoScaleDisabled(
+          config: baseConfig(),
+          identity: kGame,
+        ).skipReason,
+        MagpieProfileSkipReason.alreadySatisfied,
+      );
+    });
+
+    test('profiles 结构坏掉 → schemaMismatch，不抛', () {
+      final Map<String, dynamic> config = baseConfig()..remove('profiles');
+      expect(
+        magpieConfigWithAutoScaleDisabled(config: config, identity: kGame)
+            .skipReason,
+        MagpieProfileSkipReason.schemaMismatch,
+      );
+    });
+  });
+
+  group('生命周期编排（假 Win32 桥 + 假进程）', () {
+    late Directory tmp;
+    late String configPath;
+
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('magpie_upscaling_test_');
+      configPath = p.join(tmp.path, 'config', 'config.json');
+    });
+
+    tearDown(() {
+      try {
+        if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+
+    void writeConfig(Map<String, dynamic> config) {
+      final File file = File(configPath);
+      file.parent.createSync(recursive: true);
+      file.writeAsStringSync(jsonEncode(config));
+    }
+
+    MagpieUpscalingService build({
+      required MagpieUpscalingMode mode,
+      FakeBridge? bridge,
+      List<String>? launched,
+      bool isWindows = true,
+    }) =>
+        MagpieUpscalingService(
+          modeReader: () => mode,
+          bridge: bridge ?? FakeBridge(),
+          configPathOverride: configPath,
+          hibikiExecutablePath: kHibikiExe,
+          isWindowsOverride: isWindows,
+          processLauncher: (String exe, List<String> args) async {
+            launched?.add('$exe ${args.join(' ')}');
+            throw const ProcessException('magpie', <String>[], 'fake', 0);
+          },
+        );
+
+    test('off → disabled，什么都不碰（不读配置、不起进程）', () async {
+      final List<String> launched = <String>[];
+      final MagpieUpscalingService service = build(
+        mode: MagpieUpscalingMode.off,
+        launched: launched,
+      );
+      await service.onGameWindowReady(hwnd: 1234);
+      expect(service.report.status, MagpieUpscalingStatus.disabled);
+      expect(launched, isEmpty);
+    });
+
+    test('非 Windows → disabled', () async {
+      final MagpieUpscalingService service = build(
+        mode: MagpieUpscalingMode.auto,
+        isWindows: false,
+      );
+      await service.onGameWindowReady(hwnd: 1234);
+      expect(service.report.status, MagpieUpscalingStatus.disabled);
+    });
+
+    test('已有别人的 Magpie 在跑 → hotkeyOnly，绝不动它的配置也不起第二个', () async {
+      writeConfig(baseConfig());
+      final List<String> launched = <String>[];
+      final MagpieUpscalingService service = build(
+        mode: MagpieUpscalingMode.installedOnly,
+        bridge: FakeBridge(running: true),
+        launched: launched,
+      );
+      await service.onGameWindowReady(hwnd: 1234);
+      expect(service.report.status, MagpieUpscalingStatus.hotkeyOnly);
+      expect(launched, isEmpty, reason: '不许起第二个实例');
+      // 配置一个字节都不该动。
+      expect(
+        jsonDecode(File(configPath).readAsStringSync()),
+        jsonDecode(jsonEncode(baseConfig())),
+      );
+    });
+
+    test('installedOnly 且没装 → unavailable，零网络', () async {
+      // 安装目录不存在（真实 MagpieInstaller.isInstalled() 在测试环境必为 false）。
+      final MagpieUpscalingService service = build(
+        mode: MagpieUpscalingMode.installedOnly,
+      );
+      await service.onGameWindowReady(hwnd: 1234);
+      expect(service.report.status, MagpieUpscalingStatus.unavailable);
+    });
+
+    test('auto 但没提供确认回调 → unavailable，绝不静默下载', () async {
+      final MagpieUpscalingService service = MagpieUpscalingService(
+        modeReader: () => MagpieUpscalingMode.auto,
+        bridge: FakeBridge(),
+        configPathOverride: configPath,
+        hibikiExecutablePath: kHibikiExe,
+        isWindowsOverride: true,
+        // confirmDownload 故意不传
+        processLauncher: (String exe, List<String> args) async =>
+            throw StateError('不该走到这'),
+      );
+      await service.onGameWindowReady(hwnd: 1234);
+      expect(service.report.status, MagpieUpscalingStatus.unavailable);
+    });
+
+    test('会话结束是幂等的空操作（从没启动过超分时）', () async {
+      final FakeBridge bridge = FakeBridge();
+      final MagpieUpscalingService service = build(
+        mode: MagpieUpscalingMode.off,
+        bridge: bridge,
+      );
+      await service.onSessionEnded();
+      await service.onSessionEnded();
+      expect(service.report.status, MagpieUpscalingStatus.idle);
+      // 没起过进程就不该广播 QUIT —— 那会误杀用户自己开的 Magpie。
+      expect(bridge.quitBroadcasts, 0);
+    });
+
+    test('🔴 从没启动过 Magpie 时绝不广播 QUIT（否则会关掉用户自己开的那个）', () async {
+      writeConfig(baseConfig());
+      final FakeBridge bridge = FakeBridge(running: true);
+      final MagpieUpscalingService service = build(
+        mode: MagpieUpscalingMode.installedOnly,
+        bridge: bridge,
+      );
+      await service.onGameWindowReady(hwnd: 1234);
+      expect(service.report.status, MagpieUpscalingStatus.hotkeyOnly);
+      await service.onSessionEnded();
+      expect(bridge.quitBroadcasts, 0);
+    });
+  });
+
+  group('源码守卫：钉住三个读源码挖出来的硬约束', () {
+    late String pureSource;
+    late String serviceSource;
+    late String sessionSource;
+
+    setUpAll(() {
+      String read(String relative) {
+        final File file = File(p.join(Directory.current.path, relative));
+        expect(file.existsSync(), isTrue, reason: '找不到 ${file.path}');
+        return file.readAsStringSync();
+      }
+
+      pureSource = read('lib/src/mining/magpie_upscaling.dart');
+      serviceSource = read('lib/src/mining/magpie_upscaling_service.dart');
+      sessionSource = read('lib/src/mining/gal_hook_session_controller.dart');
+    });
+
+    test('陷阱 2：便携标记必须是 0 字节，不能是 {}', () {
+      final File installer = File(
+        p.join(Directory.current.path, 'lib/src/mining/magpie_installer.dart'),
+      );
+      final String source = installer.readAsStringSync();
+      // 函数体必须原样返回空串。写 '{}' 会让 scalingModes 为空 → scalingMode 钳到 -1
+      // → 缩放报 InvalidScalingMode。
+      expect(
+        source.contains("String magpiePortableConfigContent() => '';"),
+        isTrue,
+        reason: 'magpiePortableConfigContent 必须返回空字符串（0 字节文件）',
+      );
+    });
+
+    test('陷阱 1：autoScale 常量是 uint 枚举值 1，不是 bool', () {
+      expect(
+        pureSource.contains('const int kMagpieAutoScaleFullscreen = 1;'),
+        isTrue,
+      );
+      expect(
+        pureSource.contains('const int kMagpieAutoScaleDisabled = 0;'),
+        isTrue,
+      );
+    });
+
+    test('陷阱 3 相关：只用全屏，绝不用窗口化（窗口模式会抢焦点）', () {
+      // 代码里不该出现 Windowed(2) 这个自动缩放取值。
+      expect(pureSource.contains('kMagpieAutoScaleWindowed'), isFalse);
+      expect(serviceSource.contains('AutoScaleWindowed'), isFalse);
+    });
+
+    test('配置必须在拉起 Magpie 之前写（Magpie 只在启动时读一次，无文件监视）', () {
+      final int applyIndex =
+          serviceSource.indexOf('_applyAutoScaleProfile(hwnd)');
+      final int launchIndex = serviceSource.indexOf('_processLauncher(exe');
+      expect(applyIndex, greaterThan(0));
+      expect(launchIndex, greaterThan(0));
+      expect(
+        applyIndex,
+        lessThan(launchIndex),
+        reason: '写配置必须在 launch 之前，否则 Magpie 读不到我们的 profile',
+      );
+    });
+
+    test('QUIT 之后必须有 kill 兜底（Magpie 没给 QUIT 放行 UIPI）', () {
+      expect(serviceSource.contains('broadcastQuit()'), isTrue);
+      expect(serviceSource.contains('process.kill('), isTrue);
+    });
+
+    test('只 kill 我们自己起的进程，绝不按进程名扫', () {
+      for (final String forbidden in <String>[
+        'taskkill',
+        'Magpie.exe"',
+        'killAll',
+      ]) {
+        expect(
+          serviceSource.contains(forbidden),
+          isFalse,
+          reason: '不许出现按名杀进程的痕迹：$forbidden',
+        );
+      }
+    });
+
+    test('会话挂钩是 fire-and-forget，绝不阻塞 _setState', () {
+      expect(
+        sessionSource.contains('unawaited(_notifyMagpieWindowReady('),
+        isTrue,
+        reason: '窗口就绪挂钩必须 unawaited，否则会拖慢每一次状态更新',
+      );
+    });
+
+    test('会话收尾挂钩排在 _stopSources 之前（此时 boundWindow 还在）', () {
+      final int notifyIndex =
+          sessionSource.indexOf('await _notifyMagpieSessionEnded();');
+      expect(notifyIndex, greaterThan(0));
+      final int stopIndex =
+          sessionSource.indexOf('await _stopSources();', notifyIndex);
+      expect(stopIndex, greaterThan(notifyIndex));
+    });
+
+    test('BUG-1076 契约：确认回调之前不 await 体积探测', () {
+      final File installer = File(
+        p.join(Directory.current.path, 'lib/src/mining/magpie_installer.dart'),
+      );
+      final String source = installer.readAsStringSync();
+      expect(source.contains('await _probeSize('), isFalse,
+          reason: '体积探测绝不能在确认框之前被 await');
+    });
+  });
+}

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -544,6 +544,7 @@ bool FlutterWindow::OnCreate() {
   RegisterWindowCaptureChannel();
   RegisterAudioLoopbackChannel();
   RegisterVoiceHookChannel();
+  RegisterMagpieChannel();
 
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
   return true;
@@ -1980,6 +1981,59 @@ void FlutterWindow::RegisterVoiceHookChannel() {
       });
 }
 
+// Magpie 缩放状态监听（仅 Windows）。Magpie 用 RegisterWindowMessage 注册的广播消息
+// "MagpieScalingChanged" 通知全系统顶层窗口缩放状态变化；本 runner 只读不回，收到后
+// 经 app.hibiki.reader/magpie channel 把事件推给 Dart。
+void FlutterWindow::RegisterMagpieChannel() {
+  magpie_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          flutter_controller_->engine()->messenger(), "app.hibiki.reader/magpie",
+          &flutter::StandardMethodCodec::GetInstance());
+
+  // 广播消息号只注册一次：同一字符串在全系统映射到同一个消息号，Magpie 侧
+  // RegisterWindowMessage 同名即可对上。
+  magpie_scaling_message_ = RegisterWindowMessageW(L"MagpieScalingChanged");
+  if (magpie_scaling_message_ == 0) {
+    // 注册失败只丢监听能力（Dart 侧收不到事件、按未缩放处理），绝不能让 OnCreate
+    // 失败把整个 app 拖挂。
+    return;
+  }
+
+  // UIPI：Magpie 可能以与本进程不同的完整性级别运行，跨完整性级别的窗口消息默认被
+  // 消息过滤器丢弃。对这一条消息显式放行；失败同样忽略（同级别时本来就收得到）。
+  const HWND hwnd = GetHandle();
+  if (hwnd != nullptr) {
+    ChangeWindowMessageFilterEx(hwnd, magpie_scaling_message_, MSGFLT_ALLOW,
+                                nullptr);
+  }
+}
+
+void FlutterWindow::NotifyMagpieScalingChanged(WPARAM wparam, LPARAM lparam) {
+  // WndProc 跑在 platform 线程，InvokeMethod 可直接调用。channel 在 OnCreate 建好
+  // 前（极早期消息）可能为空，null 保护后静默忽略。
+  if (!magpie_channel_) {
+    return;
+  }
+  // Magpie 广播语义（state = wParam）：
+  //   1                  -> 缩放开始，或源窗口重新回到前台；lParam = 缩放窗口 HWND。
+  //   0 且 lParam == 0   -> 缩放窗口 WM_DESTROY，缩放**真正结束**。
+  //   0 且 lParam != 0   -> 仅源窗口切到后台，**缩放仍在跑**：必须仍算缩放中，
+  //                         否则一切走到后台就被误判成「已退出缩放」。
+  //   2 / 3              -> 窗口模式下位置/大小变化 / 用户开始拖动；不改变缩放态，
+  //                         原样透传给 Dart。
+  const bool scaling = (wparam == 0) ? (lparam != 0) : true;
+  flutter::EncodableMap map{
+      {flutter::EncodableValue("state"),
+       flutter::EncodableValue(static_cast<int>(wparam))},
+      {flutter::EncodableValue("handle"),
+       flutter::EncodableValue(static_cast<int64_t>(lparam))},
+      {flutter::EncodableValue("scaling"), flutter::EncodableValue(scaling)},
+  };
+  magpie_channel_->InvokeMethod(
+      "onScalingChanged",
+      std::make_unique<flutter::EncodableValue>(std::move(map)));
+}
+
 void FlutterWindow::NotifySystemColorChanged() {
   // TODO-1092: 把「系统强调色/主题色已变」事件推给 Dart。WndProc 跑在 platform
   // 线程，InvokeMethod 可直接调用。channel 在 OnCreate 建好前（极早期消息）可能为
@@ -2082,6 +2136,14 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
     if (result) {
       return *result;
     }
+  }
+
+  // Magpie 缩放状态广播。RegisterWindowMessage 得到的消息号是运行时值，不能写成
+  // case 标签，只能在 switch 之前判；magpie_scaling_message_ == 0 表示没注册成功，
+  // 此时不做任何匹配。收到后**不消费**（不 return），因为这是系统广播，落到下面的
+  // 默认处理，保持既有消息语义不变。
+  if (magpie_scaling_message_ != 0 && message == magpie_scaling_message_) {
+    NotifyMagpieScalingChanged(wparam, lparam);
   }
 
   switch (message) {

--- a/hibiki/windows/runner/flutter_window.h
+++ b/hibiki/windows/runner/flutter_window.h
@@ -115,6 +115,23 @@ class FlutterWindow : public Win32Window {
       window_capture_channel_;
   void RegisterWindowCaptureChannel();
 
+  // Magpie 缩放状态监听（仅 Windows）：Magpie 通过
+  // RegisterWindowMessage(L"MagpieScalingChanged") 向所有顶层窗口广播缩放状态。
+  // runner 收到后经此 channel 把 onScalingChanged 单向推给 Dart（见
+  // lib/src/mining/magpie_scaling_channel.dart）。纯 native -> Dart，不注册
+  // MethodCallHandler。
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      magpie_channel_;
+  void RegisterMagpieChannel();
+
+  // RegisterWindowMessageW(L"MagpieScalingChanged") 拿到的运行时消息号。
+  // 0 = 尚未注册 / 注册失败，MessageHandler 据此永不误匹配。
+  UINT magpie_scaling_message_ = 0;
+
+  // 把一条 MagpieScalingChanged 广播翻译成 Dart 事件推出去。channel 未建好时
+  // 静默 no-op。
+  void NotifyMagpieScalingChanged(WPARAM wparam, LPARAM lparam);
+
   // galgame 一键制卡 A 阶段（docs/specs/galgame-mining，仅 Windows）：WASAPI loopback
   // 采集系统混音进环形缓冲。start/stop 管采集，grabRecent 拉最近 N 毫秒 PCM。
   // 见 audio_loopback_capture.cpp / .h。


### PR DESCRIPTION
阶段一（installer，已合入 develop）只有模块没有调用方。本 PR 让它真的能用。

## 挂钩点：只碰 `gal_hook_session_controller.dart` 6 处约 40 行
收在 `_setState` 里「boundWindow 从 null 变非 null」这一次跃迁，而不是四条绑窗路径各挂一次——那是它们唯一的公共事实。其余是 import / 字段 / setter（抄 `attachActivityDatabase` 范式）/ `stopCapture` 与 `close()` 的收尾。刻意压低与并发 galgame 改动的冲突面。

## 🔴 首次使用不再降级：绕掉根因而不是加提示
阶段一为了躲开 `InvalidScalingMode` 陷阱，便携 config 写的是 **0 字节**；而 Magpie 必须自己跑完一次才生成 `scalingModes`，没有它就不能写 profile。推论是「第一局只能按热键，第二局起才自动」——用户感知就是**装完第一次没反应**。

读源码找到了绕法：`AppSettings` 在 configText 为空时会 `_SetDefaultScalingModes()` + `SaveAsync()`，而 `SaveAsync()` **没有防抖、没有定时器**，`resume_background()` 后直接写盘。所以 `_ensureConfigMaterialized()` 在配置未就绪时先静默跑一次 `Magpie.exe -t`、轮询等 `scalingModes` 落盘（上限 8s）、收掉预热实例，再写 profile 真正启动。**第一局就能自动缩放。**

风险控制：只在配置未就绪时发生（第二局起零开销）；`onGameWindowReady` 整条是 `unawaited` 调用不阻塞会话；预热实例在 `finally` 里收尾并有源码守卫钉住——留一个游离 Magpie 会被单实例互斥体挡掉后面真正那次启动。

## 状态变成用户可见的事实
新增 `magpie_upscaling_text.dart`，范式对齐 `gal_hook_failure_text.dart`（那份文件的头注释记着教训：旧实现把内部代码直接显示给用户）。落点是**捕获工作台健康卡**，紧挨「窗口」那一行——说的是同一个游戏窗口、浮窗的「打开工作台」就导航到这里、那张卡本就是「各子系统好没好」的清单。

三种降级给三种话，因为对用户是三件不同的事：
- **首次初始化中**：「现在按 Win+Shift+A 就能放大；下次启动游戏会自动放大。」— 会自己好
- **你自己已经开着 Magpie**：「Hibiki 没有去动它。」— 永远不会自己好，得让用户知道是我们**有意**不碰
- 其余：只给处置，不瞎解释

`scalingActive`（阶段二一度接了 native 回传却没人消费）一并用上：收到广播前只说「已就绪但没有自动开始」，收到才说「已开启」——**不拿意图冒充结果**。一条穷举测试遍历所有 `status × skipReason` 组合，断言用户可见字符串不含任何内部标识符。

## 三个陷阱的处置
1. **50ms 前台轮询**：`magpieProfileTargetAllowed` 是硬门（写 profile 前先验，命中返回 `forbiddenTarget`），忽略大小写比 Magpie 自己更严——**绝不给 Hibiki 自己的 exe 建 autoScale profile**。
2. **0 字节 config**：复核阶段一实现确为 `=> '';`，真写 0 字节，`ensurePortableConfig` 还保证已存在就不动。加源码守卫钉死。
3. **Updater 指向上游**：**没改 fork，因为它在我们的产物里是死代码**，证据链完整——workflow 不传 `--version-string` → msbuild `VersionString` 为空 → `Common.Post.props` 的 Condition 不成立、`MP_VERSION_STRING` 不定义 → `UpdateService.cpp:34` 整个 `Initialize()` 被 `#ifdef` 编译掉 → 手动检查按钮恒 false。那两个 raw.githubusercontent URL 永远走不到。⚠️ 该保证依赖「workflow 永不加 `--version-string`」；要变成结构性保证应在 fork workflow 里发布前删掉 `Updater.exe`（纯 workflow 改动），**本轮没做**。

## 阶段一文档漏掉的一条要命事实
`ProfileService::_GetProfileForWindow` **先比 `classNameRule` 再比 `pathRule`**。只写路径不写窗口类名的 profile **永远匹配不上任何窗口**，是条静默死规则。所以 profile 身份是 `(exe 路径, 窗口类名)` 二元组，运行时用 `QueryFullProcessImageNameW` + `GetClassNameW` 取（前者必须与 Magpie 的 `GetWindowPath` 同源，匹配是裸 `wstring ==`）。

## 顺手清掉的坏味道
- 靠 `detail.contains('existing Magpie instance')` 字符串嗅探判断「别人的 Magpie 开着」→ 改成显式 `MagpieProfileSkipReason.externalInstance`
- 抽出 `MagpieProcessHandle`：此前假启动器只能抛异常，「启动之后」的整条收束路径一行都没被测到
- `MagpieUpscalingService` 改 `ChangeNotifier`，`_report` 赋值走私有 setter 自动通知

## rebase 后发现并修掉的编译错误
阶段一合入 develop 时把笼统的 `failed` 拆成了 `downloadFailed`（可重试）/ `verificationFailed`（下到了但不可信）/ `failed`，阶段二照旧版写的 switch 因此非穷尽。按拆分原意分别处理而非塞 `default`：`downloadFailed` **不**置 `_downloadDeclined`（那面旗子的语义是「用户说了不要」，网络不通不是用户的意思，下一局仍应再试）；`verificationFailed` 单独报，免得把「不可信」和「没下到」混成一句话。

## 验证
- `flutter analyze`（全量含 test）：No issues found!
- `flutter test test/mining test/i18n`：**796 passed**
- i18n 17 文件 key 数一致（2674），Slang 完整性未破
- 本轮无 C++ 改动（`git diff hibiki/windows/` 为空），故未重跑 Windows 构建；阶段二首个 commit 的 C++ 部分此前已验 `√ Built ...hibiki.exe` 且 exe 内含 UTF-16 `MagpieScalingChanged`

## 🔴 仍未解决（如实）
1. **真机验证为零**。预热能否在无人值守下走完 `AppSettings::Initialize()` 并落盘，是按源码推断的，**没在真机上看过**；「启动游戏 → 自动超分」端到端**未跑通**。按 galgame 分级只能标 `implemented_unverified`，不能说「已支持」。
2. 预热失败时每局多花 8s，**没做「连续失败就退避」的记忆**——有意的：先看真机上到底会不会失败，现在加退避等于凭空猜。
3. `classNameRule` 取值是否与 Magpie 的 `ParseClassName` 一致未验证（它对 WPF / RPGMakerMZ / TeknoParrot 有特殊解析）。
4. **用户自己开着 Magpie 时我们什么都不做**（不写它配置、不发 QUIT、不起第二个），降级为热键。有意的能力缺口：配置位置未知、它退出时会整份回写覆盖我们的改动、那是用户的进程。
5. `-t` 静默模式下 `HWND_BROADCAST` 的 QUIT 能否投达未验证（有 kill 兜底，只 kill 我们自己起的 PID）。
6. 状态卡只在 `!compact` 的健康卡里，窄屏会被折进 `ExpansionTile`，用户得展开才看得到。

https://claude.ai/code/session_018NeGjpee1gxFXaDTkaeoa4