### PR TITLE
fix(galgame): 制卡音频不再缺尾巴——PCM 按增长收敛、资源 dump 等写完 (BUG-1107)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1073 条。点号进各自文件。
+> 共 1074 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1107](bugs/BUG-1107-gal-mining-audio-truncated-tail.md) | ✅ | ✅ | galgame 制卡音频尾部被截断：引擎 PCM 首取即冻结 + 资源 dump 写完前就转码 |
 | [BUG-1106](bugs/BUG-1106-desktop-settings-smoke-focus-gate-broken.md) | ✅ | ✅ | `desktop_settings_smoke_test.dart`（Windows 离屏 itest 默认门）在全新 profile 上必红 |
 | [BUG-1105](bugs/BUG-1105-inapp-popup-webview2-status-bar-url.md) | ✅ | ✅ | app 内查词弹窗仍会冒 WebView2 链接地址预览（BUG-1097 只修了一半） |
 | [BUG-1104](bugs/BUG-1104-lookup-overlay-webview2-dpi-inconsistent.md) | ✅ | ✅ | 查词浮窗两条 WebView2 创建路径的 DPI 处理不一致（且无 WM_DPICHANGED） |

--- a/docs/bugs/BUG-1107-gal-mining-audio-truncated-tail.md
+++ b/docs/bugs/BUG-1107-gal-mining-audio-truncated-tail.md
@@ -1,0 +1,54 @@
+## BUG-1107 · galgame 制卡音频尾部被截断：引擎 PCM 首取即冻结 + 资源 dump 写完前就转码
+
+- **报告**：2026-07-26（用户：「gal 的音频，感觉剩一些没放完就断了」）
+- **真实性**：✅ 真 bug（两条独立的「读得太早」）
+  - ① 引擎 PCM：`hibiki/lib/src/mining/gal_hook_session_controller.dart:2517`（文本轮询里
+    `_scheduleLineAudioAttach`）→ `_attachLineAudio` 立刻 `grabUtterance(line.timestampMs)`。
+    文本轮询间隔 80ms（同文件构造参数 `textPollInterval`），而 native 的拼接窗口是**前向**的
+    `[ts-200, ts+6000]`（`hibiki/windows/runner/voice_hook_reader.cpp:511`）——台词到达那一刻
+    窗口的前向部分**还是空的**，只能拼到这句语音当时已提交给混音器的开头。结果冻进
+    `_lineVoiceCache` 后先到先得（制卡只读缓存，`gal_hook_session_controller.dart:1705`），
+    这句语音**永远**停在被截断的版本，隔多久制卡都一样。
+    整段一次性提交给 XAudio2 的引擎看不出问题；分块流式提交的引擎必然缺尾巴——这就是
+    「有时候好、有时候断」的来源。
+  - ② 资源原件：`hibiki/lib/src/mining/galgame_audio_source.dart` 的 `grabPairedVoiceBytes` /
+    `pairedVoiceFilePathForResourceId` 只要 dump 目录里文件**存在**就转码 / 试听，没有等
+    hook 写完。OGG 是分页容器，截断的文件照样解出前半段，所以表现为「有音频但少一截」
+    而不是报错。
+  - 对照：Loopback 那条链的同类缺陷已由 BUG-1101 用「前向延迟冻结」修过；本条是把同一
+    纪律补到剩下两条链上。BUG-1101 的注释里「引擎 PCM 路径早就用的是前向窗口」只对了一半
+    ——窗口是前向的，但**调用时刻**不是，已在本次改动中更正。
+
+- **[x] ① 已修复** — 提交 `HEAD`（分支 `worktree-gal-audio-truncation`）
+  - PCM 链：新增 `_settleLineUtterance`（`gal_hook_session_controller.dart`）。台词到达后按
+    `utteranceSettleInterval`（默认 250ms）重取，每轮把**更长**的结果写回 `_lineVoiceCache`
+    ——制卡随时取到当前最完整的一段，不需要额外的收束通道。终止于三者之一：连续
+    `utteranceSettleStableRounds`（默认 2）轮不再变长（这句播完）／下一句台词到达
+    （`_lastTextSeq > line.seq`，再等下去下一句的段会落进同一个 `ts+6000` 窗口被拼进来）／
+    到 `utteranceSettleMax`（默认 6s，与 native 窗口对齐）。等待全程在串行音频队列**之外**，
+    只有单次 grab 入队（与 `_scheduleLoopbackFreeze` 同纪律，不堵后续台词和制卡）。
+    会话重启 / 音源换走 / 用户裁决（补录、选轨）时立即收手，见 `_canSettleLine`。
+  - 资源链：新增 `awaitStableVoiceDumpFile`（`galgame_audio_source.dart`），转码
+    （`grabPairedVoiceBytes`）与试听（新增 `settledPairedVoiceFilePathForResourceId`，
+    `exportLineAudioPreview` 改用之）前先等文件**静默** `quietPeriod`（默认 240ms）。
+    判据刻意不是「连续两次采样一致」——hook 分块写，块间间隙很容易长过一个采样间隔，
+    两次相同只证明「这一瞬间没在写」，照样放行半个文件（这条是写测试时暴露出来的，
+    第一版实现就栽在这里）。到 `timeout`（默认 1.5s）仍在增长则 fail-open 用当前内容。
+  - **残留限制**：资源链的真正根治要 hook 侧写 `.part` 再原子 rename，代码在独立仓
+    `hajisensai/hibiki-hook`，本仓消费端够不着；静默期是消费端能做到的最强判据。
+    清理条件：hibiki-hook 落地原子 rename 后，这道门可以退化成「文件存在即可读」。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_utterance_settle_test.dart`（5 条）
+  - 引擎 PCM 按增长收敛取整句：桩引擎逐次返回更长 PCM（50ms → 200ms → 500ms），断言
+    首取确实只有 50ms（= 修复前落进卡里的内容），收敛后行时长与 `exportLineAudioPreview`
+    都变成 500ms。
+  - 下一句台词到达即收手：同一批两句，断言旧句只保留首取（`callsFor(ts) == 1`），
+    不继续往前向窗口里拼下一句。
+  - `awaitStableVoiceDumpFile` 三条：分块写入时必须等到写完（这条在第一版「两次相同」
+    实现下是红的）／到上限仍在写则 fail-open 不挂死／文件不存在立即返回。
+  - 另把既有守卫 `engine PCM is frozen on line arrival and reused for that line`
+    （`gal_hook_session_controller_test.dart`）显式关掉收敛（`utteranceSettleMax: Duration.zero`），
+    让它继续只守「首取即冻结 + 制卡复用缓存」那半条契约，不随机器快慢抖动。
+
+- **备注**：真机验收待办——用分块流式提交语音的引擎跑一遍「台词 → 制卡 → 卡里音频听完整句」，
+  并确认下一句到达时旧句音频里没有混进下一句。

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -330,6 +330,14 @@ class GalHookSessionController extends ChangeNotifier {
     // 因此台词到达后先延后这么久再冻结，让本句语音真的进环。默认 4s 覆盖绝大多数单句
     // 语音；文本仍立刻上屏，只有音频后补。
     Duration loopbackFreezeDelay = const Duration(milliseconds: 4000),
+    // BUG-1107：引擎 PCM 的整句拼接窗口在 native 是前向的（`[ts-200, ts+6000]`），
+    // 但台词一到就读，窗口的前向部分还是空的——只能拼到这句语音**已提交给混音器**的
+    // 开头。因此按这个间隔重取，直到长度不再增长（见 [_settleLineUtterance]）。
+    Duration utteranceSettleInterval = const Duration(milliseconds: 250),
+    // 收敛上限：与 native 拼接窗口的前向长度（ts+6000）对齐，超过就不可能再拼到新段。
+    Duration utteranceSettleMax = const Duration(milliseconds: 6000),
+    // 连续多少轮没变长才算「这句播完了」。1 轮容易被单次调度抖动骗到，2 轮够稳。
+    int utteranceSettleStableRounds = 2,
     List<Duration> engineRetryBackoff = kGalEngineRetryBackoff,
     Listenable? endpointListenable,
     List<TexthookerEndpointStatus> Function()? endpointStatusLoader,
@@ -355,6 +363,9 @@ class GalHookSessionController extends ChangeNotifier {
         _windowRebindInterval = windowRebindInterval,
         _trackRefreshInterval = trackRefreshInterval,
         _loopbackFreezeDelay = loopbackFreezeDelay,
+        _utteranceSettleInterval = utteranceSettleInterval,
+        _utteranceSettleMax = utteranceSettleMax,
+        _utteranceSettleStableRounds = utteranceSettleStableRounds,
         _engineRetryBackoff = engineRetryBackoff,
         _endpointListenable =
             endpointListenable ?? TexthookerWsClientManager.instance,
@@ -403,6 +414,9 @@ class GalHookSessionController extends ChangeNotifier {
   final Duration _windowRebindInterval;
   final Duration _trackRefreshInterval;
   final Duration _loopbackFreezeDelay;
+  final Duration _utteranceSettleInterval;
+  final Duration _utteranceSettleMax;
+  final int _utteranceSettleStableRounds;
   final List<Duration> _engineRetryBackoff;
   final Listenable _endpointListenable;
   final List<TexthookerEndpointStatus> Function() _endpointStatusLoader;
@@ -1187,7 +1201,9 @@ class GalHookSessionController extends ChangeNotifier {
     final String? resourceId =
         _isUserAdjudicated(lineId) ? null : _resourceIdForLine(lineId);
     if (engine != null && resourceId != null) {
-      final String? path = engine.pairedVoiceFilePathForResourceId(resourceId);
+      // BUG-1107：hook 可能还在写这个原件，直接播会听到被截断的半句。
+      final String? path =
+          await engine.settledPairedVoiceFilePathForResourceId(resourceId);
       if (path != null) {
         return GalTrackPreview(filePath: path, durationMs: 0);
       }
@@ -2637,29 +2653,133 @@ class GalHookSessionController extends ChangeNotifier {
     required GalHookedLine line,
     required bool resourceReady,
   }) {
-    unawaited(_audioQueue.enqueue<bool>(
-      () async {
-        await _attachLineAudio(
+    unawaited(() async {
+      await _audioQueue.enqueue<bool>(
+        () async {
+          await _attachLineAudio(
+            engine: engine,
+            entry: entry,
+            line: line,
+            resourceReady: resourceReady,
+          );
+          return true;
+        },
+        buildFailure: (Object error, StackTrace stack) => false,
+        onError: (Object error, StackTrace stack) => _record(
+          GalHookEventSeverity.error,
+          'match',
+          'audio.line_attach_exception',
+          'Line audio attach job failed',
+          details: <String, Object?>{
+            'lineId': entry.id,
+            'error': '$error',
+          },
+        ),
+      );
+      // BUG-1107：首取只拿到这句语音的开头，剩下的段还没进环。收敛必须在队列**之外**
+      // 等待（队列里 sleep 会堵住后续台词抓取和制卡），只有单次 grab 入队。
+      try {
+        await _settleLineUtterance(
           engine: engine,
           entry: entry,
           line: line,
           resourceReady: resourceReady,
         );
-        return true;
-      },
-      buildFailure: (Object error, StackTrace stack) => false,
-      onError: (Object error, StackTrace stack) => _record(
-        GalHookEventSeverity.error,
-        'match',
-        'audio.line_attach_exception',
-        'Line audio attach job failed',
-        details: <String, Object?>{
-          'lineId': entry.id,
-          'error': '$error',
-        },
-      ),
-    ));
+      } catch (error) {
+        _record(
+          GalHookEventSeverity.error,
+          'match',
+          'audio.utterance_settle_exception',
+          'Utterance settle loop failed',
+          details: <String, Object?>{
+            'lineId': entry.id,
+            'error': '$error',
+          },
+        );
+      }
+    }());
   }
+
+  /// 引擎 PCM 逐句语音的**增长收敛**（BUG-1107）。
+  ///
+  /// native `VoiceHookReader::GrabUtterance` 的拼接窗口是 `[ts-200, ts+6000]`
+  /// （`windows/runner/voice_hook_reader.cpp`）——**前向 6 秒**是有意设计，等的就是这句
+  /// 语音后续的段。但文本轮询 80ms 一跳，台词一到就读时窗口的前向部分还是空的，只能拼到
+  /// 游戏**当时已经提交给混音器**的那一小段。整段一次性提交的引擎看不出问题；分块流式提交
+  /// 的引擎必然缺尾巴。而 [_lineVoiceCache] 先到先得、制卡只读缓存，于是这句语音**永远**
+  /// 停在被截断的版本，隔多久制卡都一样。
+  ///
+  /// 修法与 [_scheduleLoopbackFreeze] 同纪律（前向等待、等待在队列外）：按
+  /// [_utteranceSettleInterval] 重取，每轮把**更长**的结果写回缓存——制卡随时都能取到
+  /// 当前最完整的一段，不需要额外的收束通道。收敛终止于三者之一：
+  /// - 连续 [_utteranceSettleStableRounds] 轮不再变长（这句播完了）；
+  /// - 下一句台词到达（再等下去，下一句的段会落进同一个 `ts+6000` 窗口被拼进来）；
+  /// - 到 [_utteranceSettleMax]（越过 native 窗口，不可能再有新段）。
+  ///
+  /// 用户裁决（补录 / 选轨）、会话重启、音源被换走时立即收手，绝不回头覆盖。
+  Future<void> _settleLineUtterance({
+    required EngineHookGalAudioSource engine,
+    required TexthookerLineEntry entry,
+    required GalHookedLine line,
+    required bool resourceReady,
+  }) async {
+    // 资源语音（原始 OGG/WAV）走的是文件链，与 PCM 环无关；Loopback 会话有自己的
+    // 延迟冻结。只有「本会话确实在用这个 engine 的 PCM」时才需要收敛。
+    if (resourceReady || !identical(_audioSource, engine)) {
+      return;
+    }
+    int bestBytes = _lineVoiceCache[entry.id]?.pcm.length ?? 0;
+    int stableRounds = 0;
+    final Stopwatch elapsed = Stopwatch()..start();
+    while (elapsed.elapsed < _utteranceSettleMax &&
+        stableRounds < _utteranceSettleStableRounds) {
+      // 下一句台词已经到了 = 这句语音要么播完、要么被玩家跳过，两种情况都该收手。
+      if (_lastTextSeq > line.seq) {
+        return;
+      }
+      await Future<void>.delayed(_utteranceSettleInterval);
+      if (!_canSettleLine(engine: engine, entry: entry)) {
+        return;
+      }
+      final GalAudioSlice? next = await _audioQueue.enqueue<GalAudioSlice?>(
+        () => engine.grabUtterance(line.timestampMs),
+        buildFailure: (Object error, StackTrace stack) => null,
+      );
+      if (next == null || next.isEmpty || next.pcm.length <= bestBytes) {
+        // 还一个字节都没抓到时不计入稳定轮次：这句语音可能只是比文本晚了一点，
+        // 计数会让收敛在真正开播前就结束。真的整行无语音时，下一句到达会收手。
+        if (bestBytes > 0) {
+          stableRounds++;
+        }
+        continue;
+      }
+      // grab 期间也可能夹一次 stop / 补录 / 选轨。
+      if (!_canSettleLine(engine: engine, entry: entry)) {
+        return;
+      }
+      bestBytes = next.pcm.length;
+      stableRounds = 0;
+      _lineVoiceCache[entry.id] = next;
+      _trimCache(_lineVoiceCache);
+      _textService.updateLineAudio(
+        entry.id,
+        status: TexthookerLineAudioStatus.matched,
+        backend: 'engine_pcm',
+        durationMs: (next.pcm.length * 1000) ~/ next.format.byteRate,
+      );
+    }
+  }
+
+  /// 收敛循环每次 await 之后的存活判据：会话没换、行还属于本会话、音源仍是这个 engine、
+  /// 用户没有裁决过这一行。任一不成立就必须收手，不能把旧会话/被裁决过的行改回去。
+  bool _canSettleLine({
+    required EngineHookGalAudioSource engine,
+    required TexthookerLineEntry entry,
+  }) =>
+      engine == _engineSource &&
+      identical(_audioSource, engine) &&
+      isLineInCurrentSession(entry) &&
+      !_isUserAdjudicated(entry.id);
 
   /// 逐行语音抓取（原先内联在 [_pollHookedText] 循环里的三条降级分支，语义不变）：
   /// 引擎 PCM 整句 → 时间窗碎片 → loopback 环冻结 → 明确 missing。
@@ -2829,8 +2949,9 @@ class GalHookSessionController extends ChangeNotifier {
   /// `grabRecent(backMs)` 的语义是**当前时刻往前** backMs，纯后向、零前向等待
   /// （契约见 [GalAudioSource.grabRecent]）。galgame 的时序恒为「文本先绘制 → 语音随后
   /// 播放」，所以在台词到达那一刻抓，窗口里装的全是**上一句** + BGM，一个本句采样都没有
-  /// ——错位一句是旧实现的设计必然，不是抖动。引擎 PCM 路径早就用的是前向窗口
-  /// （`grabUtterance`，native `[ts-200, ts+6000]`），Loopback 必须对称：记下 t0，等到
+  /// ——错位一句是旧实现的设计必然，不是抖动。引擎 PCM 路径的 native 窗口本就是前向的
+  /// （`grabUtterance`，`[ts-200, ts+6000]`；但**调用时刻**同样太早，见 BUG-1107 的
+  /// [_settleLineUtterance]），Loopback 必须对称：记下 t0，等到
   /// t0+[_loopbackFreezeDelay] 再回取 `delay + preRoll`，等价于取 `[t0-preRoll, t0+delay]`。
   ///
   /// 等待刻意放在串行音频队列**之外**：在队列里 sleep 会把后续台词的抓取和制卡一起堵住。

--- a/hibiki/lib/src/mining/galgame_audio_source.dart
+++ b/hibiki/lib/src/mining/galgame_audio_source.dart
@@ -482,6 +482,51 @@ String? pickPairedGameResource({
       );
 }
 
+/// 资源语音 dump 文件的**写入收敛门**（BUG-1107）。
+///
+/// hook DLL 在游戏读取语音资源时把原件写进 dump 目录：文件**出现**不等于**写完**。
+/// 一看见文件就转码（[EngineHookGalAudioSource.grabPairedVoiceBytes]）或试听
+/// （[EngineHookGalAudioSource.pairedVoiceFilePathForResourceId]），在流式落盘的引擎下
+/// 只会拿到前半段——OGG 是分页容器，截断的文件照样能解码出前半段，于是表现为「有音频，
+/// 但莫名少一截」而不是报错。
+///
+/// 因此转码/试听前先盯着文件大小，直到它**静默** [quietPeriod] 这么久才算写完。
+///
+/// 判据刻意不是「连续两次采样一致」：hook 是分块写的，块与块之间的间隙很容易比一个
+/// 采样间隔长，两次相同只能证明「这一瞬间没在写」，照样会放行一个写到一半的文件。要
+/// 求一整段静默期才是「写完了」的可落地近似。真正的根治要 hook 侧写 `.part` 再原子
+/// rename（在独立仓 `hajisensai/hibiki-hook`，本仓消费端够不着），所以这里是消费端能
+/// 做到的最强判据，且对已经写完的文件只多花一个静默期。
+///
+/// 到 [timeout] 仍在增长就 fail-open 用当前内容（Never break：宁可短一点，也不能一声
+/// 不出）。stat 失败（文件被 [EngineHookGalAudioSource.pruneVoiceDump] 清掉等）立即
+/// 返回，交调用方按缺文件处理。
+Future<void> awaitStableVoiceDumpFile(
+  File file, {
+  Duration pollInterval = const Duration(milliseconds: 60),
+  Duration quietPeriod = const Duration(milliseconds: 240),
+  Duration timeout = const Duration(milliseconds: 1500),
+}) async {
+  final Stopwatch elapsed = Stopwatch()..start();
+  int previous = -1;
+  Duration lastChange = Duration.zero;
+  while (elapsed.elapsed < timeout) {
+    final int size;
+    try {
+      size = file.lengthSync();
+    } catch (_) {
+      return;
+    }
+    if (size != previous) {
+      previous = size;
+      lastChange = elapsed.elapsed;
+    } else if (size > 0 && elapsed.elapsed - lastChange >= quietPeriod) {
+      return;
+    }
+    await Future<void>.delayed(pollInterval);
+  }
+}
+
 /// 旧资源名为 `<tick>_<basename>`；具有运行时顺序证据的引擎可写
 /// `<tick>_hibiki_textseq<textSeq>_<basename>`，把资源绑定到稳定的
 /// TextSlot::seq。
@@ -1451,6 +1496,19 @@ class EngineHookGalAudioSource implements GalAudioSource {
     return (file != null && file.existsSync()) ? file.path : null;
   }
 
+  /// [pairedVoiceFilePathForResourceId] 的**等写完**版本（BUG-1107）：试听走的是原件，
+  /// hook 还在写就播会听到被截断的半句。等文件大小停止增长后再交出路径；等待期间文件被
+  /// 清理掉则返回 null（与同步版对缺文件的语义一致）。
+  Future<String?> settledPairedVoiceFilePathForResourceId(
+    String resourceId,
+  ) async {
+    final String? path = pairedVoiceFilePathForResourceId(resourceId);
+    if (path == null) return null;
+    final File file = File(path);
+    await awaitStableVoiceDumpFile(file);
+    return file.existsSync() ? path : null;
+  }
+
   Future<Uint8List?> grabPairedVoiceBytes(
     int textTsMs, {
     required String outputExtension,
@@ -1466,6 +1524,9 @@ class EngineHookGalAudioSource implements GalAudioSource {
           )
         : _voiceFileForResourceId(resourceId);
     if (picked == null) return null;
+    // BUG-1107：hook 可能还在往这个文件里写。转码截断的原件会得到「有音频但少一截」
+    // 的卡，比报错更难发现，所以先等它写完。
+    await awaitStableVoiceDumpFile(picked);
     return transcodeVoiceOggToMiningAudio(
       oggPath: picked.path,
       tempDir: Directory.systemTemp.path,

--- a/hibiki/test/mining/gal_hook_session_controller_test.dart
+++ b/hibiki/test/mining/gal_hook_session_controller_test.dart
@@ -772,6 +772,10 @@ void main() {
       }) =>
           engine,
       textPollInterval: const Duration(milliseconds: 5),
+      // 本例守的是「首取即冻结 + 制卡复用缓存」这半条契约，与 BUG-1107 的增长收敛无关。
+      // 关掉收敛让 grab 次数确定为 1，否则断言会随机器快慢抖动（收敛见
+      // gal_utterance_settle_test.dart）。
+      utteranceSettleMax: Duration.zero,
       endpointListenable: endpoints,
       endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
     );

--- a/hibiki/test/mining/gal_utterance_settle_test.dart
+++ b/hibiki/test/mining/gal_utterance_settle_test.dart
@@ -1,0 +1,307 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/mining/galgame_audio_encode.dart';
+import 'package:hibiki/src/mining/galgame_audio_source.dart';
+import 'package:hibiki/src/mining/window_capture_channel.dart';
+import 'package:hibiki/src/sync/texthooker_service.dart';
+import 'package:hibiki/src/sync/texthooker_ws_client.dart';
+
+/// BUG-1107 守卫：「抓到音频了，但莫名少一截」。
+///
+/// 两条链各有一个「读得太早」的时刻：
+///  ① 引擎 PCM：native `GrabUtterance` 的拼接窗口是前向的 `[ts-200, ts+6000]`，但台词
+///     一到（文本轮询 80ms）就读，窗口的前向部分还是空的，只能拼到这句语音已提交给
+///     混音器的开头；冻结进 `_lineVoiceCache` 后先到先得，这句就永远缺尾巴。
+///  ② 资源原件：hook 还在往 dump 文件里写时就转码/试听，OGG 是分页容器，截断的文件
+///     照样解出前半段——表现为「有音频但少一截」而不是报错。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // 桩引擎的格式恒为 44.1kHz/单声道/16bit（见 [_GrowingEngine._format]），
+  // byteRate = 44100 * 1 * 2 = 88200 B/s，故 4410B=50ms、17640B=200ms、44100B=500ms。
+  const int kHalfSecondBytes = 44100;
+
+  GalHookSessionController buildController({
+    required TexthookerService service,
+    required Listenable endpoints,
+    required EngineHookGalAudioSource engine,
+    Duration settleMax = const Duration(seconds: 2),
+  }) =>
+      GalHookSessionController(
+        textService: service,
+        isWindows: true,
+        targetWow64Probe: (_) async => false,
+        injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+        engineSourceFactory: ({
+          required int targetPid,
+          required String? launchExe,
+          required String injectorPath,
+          required bool lunaPcHooks,
+          int? lunaCodepage,
+          List<String> launchArguments = const <String>[],
+          String launchWorkdir = '',
+        }) =>
+            engine,
+        textPollInterval: const Duration(milliseconds: 5),
+        utteranceSettleInterval: const Duration(milliseconds: 5),
+        utteranceSettleMax: settleMax,
+        endpointListenable: endpoints,
+        endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+      );
+
+  test('BUG-1107 引擎 PCM 按增长收敛取整句，不再停在首取的半句', () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    // 语音分块提交：首取只有 50ms，后续两块补到 500ms，之后不再增长（这句播完了）。
+    final _GrowingEngine engine = _GrowingEngine(
+      stepsByTs: <int, List<int>>{
+        654321: <int>[4410, 17640, kHalfSecondBytes],
+      },
+      lines: const <GalHookedLine>[
+        GalHookedLine(
+          seq: 7,
+          timestampMs: 654321,
+          text: 'エンジン音声の台詞',
+          threadId: 5,
+          hookName: 'Siglus',
+        ),
+      ],
+    );
+    final GalHookSessionController controller = buildController(
+      service: service,
+      endpoints: endpoints,
+      engine: engine,
+    );
+
+    await controller.startAttachedCapture(
+      const ExternalWindowInfo(hwnd: 13, pid: 777, title: 'Engine game'),
+    );
+    for (int i = 0; i < 40 && service.entries.isEmpty; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+    final String lineId = service.entries.single.id;
+    // 首取就是被截断的那半句——这正是修复前卡里落下的内容。
+    expect(service.entries.single.audioDurationMs, 50,
+        reason: '台词到达时窗口的前向部分还是空的，首取只能拿到开头');
+
+    for (int i = 0;
+        i < 200 && service.entries.single.audioDurationMs != 500;
+        i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+    expect(service.entries.single.audioDurationMs, 500,
+        reason: '收敛必须把后续到达的段补齐成整句');
+    expect(service.entries.single.audioBackend, 'engine_pcm');
+
+    // 制卡/试听读的都是同一份缓存：缓存里必须已经是整句，而不是首取的半句。
+    final GalTrackPreview? preview =
+        await controller.exportLineAudioPreview(lineId);
+    expect(preview, isNotNull);
+    expect(preview!.durationMs, 500);
+
+    await controller.close();
+    endpoints.dispose();
+  });
+
+  test('BUG-1107 下一句台词到达即收手，不把下一句的段拼进上一句', () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    // 同一批里两句：seq 7 的收敛必须因为 seq 8 已到而立刻收手，
+    // 否则 `[ts-200, ts+6000]` 会把下一句的语音也拼进 seq 7。
+    final _GrowingEngine engine = _GrowingEngine(
+      stepsByTs: <int, List<int>>{
+        111111: <int>[4410, kHalfSecondBytes],
+        222222: <int>[4410, kHalfSecondBytes],
+      },
+      lines: const <GalHookedLine>[
+        GalHookedLine(
+          seq: 7,
+          timestampMs: 111111,
+          text: '一句目',
+          threadId: 5,
+          hookName: 'Siglus',
+        ),
+        GalHookedLine(
+          seq: 8,
+          timestampMs: 222222,
+          text: '二句目',
+          threadId: 5,
+          hookName: 'Siglus',
+        ),
+      ],
+    );
+    final GalHookSessionController controller = buildController(
+      service: service,
+      endpoints: endpoints,
+      engine: engine,
+    );
+
+    await controller.startAttachedCapture(
+      const ExternalWindowInfo(hwnd: 13, pid: 777, title: 'Engine game'),
+    );
+    for (int i = 0; i < 40 && service.entries.length < 2; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+    // 给足收敛时间，再断言旧句没有被继续重取。
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+
+    expect(engine.callsFor(111111), 1, reason: '下一句已到，旧句只保留首取，绝不继续往前向窗口里拼');
+    expect(engine.callsFor(222222), greaterThan(1), reason: '最新一句仍然正常收敛');
+
+    await controller.close();
+    endpoints.dispose();
+  });
+
+  test('BUG-1107 awaitStableVoiceDumpFile 等到 dump 文件停止增长才放行', () async {
+    final Directory dir =
+        await Directory.systemTemp.createTemp('hibiki-gal-dump-');
+    addTearDown(() => dir.delete(recursive: true));
+    final File file = File('${dir.path}${Platform.pathSeparator}voice.ogg');
+    await file.writeAsBytes(Uint8List(100), flush: true);
+
+    // hook 还在分块写：20ms / 40ms 各补一块，之后停笔。
+    final List<Timer> writers = <Timer>[
+      Timer(const Duration(milliseconds: 20),
+          () => file.writeAsBytesSync(Uint8List(200), mode: FileMode.append)),
+      Timer(const Duration(milliseconds: 40),
+          () => file.writeAsBytesSync(Uint8List(300), mode: FileMode.append)),
+    ];
+    addTearDown(() {
+      for (final Timer t in writers) {
+        t.cancel();
+      }
+    });
+
+    await awaitStableVoiceDumpFile(
+      file,
+      pollInterval: const Duration(milliseconds: 10),
+      // 静默期必须比写入块之间的间隙长，否则「这一瞬间没在写」会被误判成写完。
+      quietPeriod: const Duration(milliseconds: 60),
+      timeout: const Duration(seconds: 5),
+    );
+
+    expect(file.lengthSync(), 600, reason: '放行时文件必须已经写完，否则转码/试听拿到的是截断的前半段');
+  });
+
+  test('BUG-1107 awaitStableVoiceDumpFile 到上限仍在写则 fail-open，不挂死', () async {
+    final Directory dir =
+        await Directory.systemTemp.createTemp('hibiki-gal-dump-');
+    addTearDown(() => dir.delete(recursive: true));
+    final File file = File('${dir.path}${Platform.pathSeparator}voice.ogg');
+    await file.writeAsBytes(Uint8List(100), flush: true);
+    final Timer writer = Timer.periodic(
+      const Duration(milliseconds: 5),
+      (_) => file.writeAsBytesSync(Uint8List(50), mode: FileMode.append),
+    );
+    addTearDown(writer.cancel);
+
+    final Stopwatch elapsed = Stopwatch()..start();
+    await awaitStableVoiceDumpFile(
+      file,
+      pollInterval: const Duration(milliseconds: 5),
+      quietPeriod: const Duration(milliseconds: 40),
+      timeout: const Duration(milliseconds: 120),
+    );
+    elapsed.stop();
+
+    // 宁可短一点也不能一声不出：到点就放行（Never break）。
+    expect(elapsed.elapsed, lessThan(const Duration(seconds: 2)));
+  });
+
+  test('BUG-1107 dump 文件不存在时立即返回，交调用方按缺文件处理', () async {
+    final Directory dir =
+        await Directory.systemTemp.createTemp('hibiki-gal-dump-');
+    addTearDown(() => dir.delete(recursive: true));
+    final Stopwatch elapsed = Stopwatch()..start();
+    await awaitStableVoiceDumpFile(
+      File('${dir.path}${Platform.pathSeparator}missing.ogg'),
+      pollInterval: const Duration(milliseconds: 10),
+      quietPeriod: const Duration(milliseconds: 60),
+      timeout: const Duration(seconds: 5),
+    );
+    elapsed.stop();
+    expect(elapsed.elapsed, lessThan(const Duration(seconds: 2)));
+  });
+}
+
+/// 逐次返回**更长** PCM 的引擎桩：模拟游戏把一句语音分块提交给混音器，
+/// native 拼接窗口里的段随时间变多。同一 `tsMs` 的取用序列由 [stepsByTs] 给出，
+/// 用尽后固定停在最后一个值（这句已经播完，不再增长）。
+class _GrowingEngine extends EngineHookGalAudioSource {
+  _GrowingEngine({required this.stepsByTs, required this.lines})
+      : super(targetPid: 0, launchExe: 'fake.exe', injectorPath: 'fake.exe');
+
+  final Map<int, List<int>> stepsByTs;
+  final List<GalHookedLine> lines;
+  final Map<int, int> _calls = <int, int>{};
+  int _pollCalls = 0;
+
+  static const PcmFormat _format = PcmFormat(
+    sampleRate: 44100,
+    channels: 1,
+    bitsPerSample: 16,
+    isFloat: false,
+  );
+
+  int callsFor(int tsMs) => _calls[tsMs] ?? 0;
+
+  @override
+  int? get gamePid => 4242;
+
+  @override
+  GalHookInjectorDiagnostics get lastFailure =>
+      const GalHookInjectorDiagnostics();
+
+  @override
+  bool get textHookReady => false;
+
+  @override
+  bool get rawVoiceReady => false;
+
+  @override
+  bool get pcmReady => true;
+
+  @override
+  Future<PcmFormat?> start() async => _format;
+
+  @override
+  Future<bool> refreshReadiness() async => false;
+
+  @override
+  Future<GalAudioSlice?> grabUtterance(
+    int tsMs, {
+    int? sourcePtr,
+    List<int>? exclude,
+  }) async {
+    final int index = _calls[tsMs] ?? 0;
+    _calls[tsMs] = index + 1;
+    final List<int>? steps = stepsByTs[tsMs];
+    if (steps == null || steps.isEmpty) return null;
+    final int bytes = steps[index < steps.length ? index : steps.length - 1];
+    if (bytes <= 0) return null;
+    return GalAudioSlice(pcm: Uint8List(bytes), format: _format);
+  }
+
+  @override
+  Future<GalAudioSlice?> grabClipNear(int tsMs, {int tolMs = 8000}) async =>
+      null;
+
+  @override
+  Future<GalTextPoll?> pollText(int sinceSeq) async {
+    _pollCalls++;
+    return GalTextPoll(
+      count: lines.length,
+      lines: _pollCalls == 1 ? lines : const <GalHookedLine>[],
+    );
+  }
+
+  @override
+  Future<bool> selectTextThread(int? threadId) async => true;
+
+  @override
+  Future<void> stop() async {}
+}


### PR DESCRIPTION
用户报「gal 的音频，感觉剩一些没放完就断了」。沿真实代码路径验真伪：**真 bug**，而且是两条独立的「读得太早」，症状都是「有音频，但莫名少一截」。

## 根因

### ① 引擎 PCM：首取即冻结，之后永不重取
- `gal_hook_session_controller.dart` 文本轮询看到新台词就 `_scheduleLineAudioAttach` → `_attachLineAudio` 立刻 `grabUtterance(line.timestampMs)`，轮询间隔 **80ms**。
- 而 native 的拼接窗口是**前向**的 `[ts-200, ts+6000]`（`windows/runner/voice_hook_reader.cpp:511`）——设计意图就是等这一整句。台词到达那一刻，窗口的前向部分**还是空的**，只能拼到游戏当时已提交给混音器的开头。
- 结果冻进 `_lineVoiceCache` 后先到先得，制卡只读缓存，于是这句语音**永远**停在被截断的版本，隔多久制卡都一样。
- 整段一次性提交给 XAudio2 的引擎看不出问题；分块流式提交的引擎必然缺尾巴 —— 这就是「有时候好、有时候断」的来源。

### ② 资源原件：dump 文件写完前就转码/试听
- `grabPairedVoiceBytes` / `pairedVoiceFilePathForResourceId` 只要文件**存在**就用，没等 hook 写完。OGG 是分页容器，截断的文件照样解出前半段，所以表现为「少一截」而不是报错。

> Loopback 那条链的同类缺陷已由 BUG-1101 用「前向延迟冻结」修过；本 PR 是把同一纪律补到剩下两条链上。顺带更正 BUG-1101 注释里「引擎 PCM 早就用的是前向窗口」的说法：窗口是前向的，**调用时刻**不是。

## 改法

- **PCM 链** — 新增 `_settleLineUtterance`：台词到达后按 `utteranceSettleInterval`（250ms）重取，每轮把**更长**的结果写回缓存（制卡随时取到当前最完整的一段，不需要额外收束通道）。终止于三者之一：连续 2 轮不再变长（这句播完）／**下一句台词到达**（再等下去下一句会被拼进同一个 `ts+6000` 窗口）／6s 上限（与 native 窗口对齐）。等待全程在串行音频队列**之外**，只有单次 grab 入队（不堵后续台词与制卡）。会话重启／音源换走／用户裁决（补录、选轨）立即收手。
- **资源链** — 新增 `awaitStableVoiceDumpFile`：转码与试听前等文件**静默 240ms**。判据刻意不是「连续两次采样一致」—— hook 分块写，块间间隙很容易长过一个采样间隔，那样照样放行半个文件（**这条是写测试时暴露的，第一版实现就栽在这里**）。到 1.5s 仍在增长则 fail-open。

### 残留限制
资源链的真正根治要 hook 侧写 `.part` 再原子 rename，代码在独立仓 `hajisensai/hibiki-hook`，本仓消费端够不着；静默期是消费端能做到的最强判据。hibiki-hook 落地原子 rename 后这道门可以退化成「文件存在即可读」。

## 验证
- `flutter analyze`（含 test）全量 **No issues found**
- `flutter test test/mining` **715 passed, 3 skipped**
- 新增 `test/mining/gal_utterance_settle_test.dart` 5 条：收敛取整句（含「首取确实只有半句」的对照断言，= 修复前落进卡里的内容）／下一句到达即收手／dump 文件三条边界
- **待真机验收**：用分块流式提交语音的引擎跑「台词 → 制卡 → 卡里音频听完整句」，并确认旧句里没混进下一句

BUG 记录：`docs/bugs/BUG-1107-gal-mining-audio-truncated-tail.md`

https://claude.ai/code/session_01Lo7GjR6SHRTKTXUNewhH2q