### PR TITLE
fix(galgame): 窄屏不再藏掉降级原因，只收窄行数 (BUG-1109)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1075 条。点号进各自文件。
+> 共 1076 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1109](bugs/BUG-1109-narrow-screen-hides-degrade-reason.md) | ✅ | ✅ | 捕获工作台窄屏时藏掉降级原因，只留一个「已降级」徽章 |
 | [BUG-1108](bugs/BUG-1108-shelf-continue-hero-raw-title.md) | ✅ | ✅ | 改名后书架继续阅读条仍显示旧名 |
 | [BUG-1107](bugs/BUG-1107-reading-stats-phantom-chars-lost-duration.md) | ✅ | ✅ | 阅读统计速度爆表：幻象字数+纯时长行被拒 |
 | [BUG-1106](bugs/BUG-1106-desktop-settings-smoke-focus-gate-broken.md) | ✅ | ✅ | `desktop_settings_smoke_test.dart`（Windows 离屏 itest 默认门）在全新 profile 上必红 |

--- a/docs/bugs/BUG-1109-narrow-screen-hides-degrade-reason.md
+++ b/docs/bugs/BUG-1109-narrow-screen-hides-degrade-reason.md
@@ -1,0 +1,31 @@
+## BUG-1109 · 捕获工作台窄屏时藏掉降级原因，只留一个「已降级」徽章
+
+- 报告：用户 2026-07-26。原文「为什么不够宽就不显示，修复」。
+  起因是上一轮验收清单里把「窗口须拉宽到 ≥840px 否则看不到降级原因」写成了操作前置——
+  用户指出这本身就是 bug，不该要求用户迁就 UI。
+- 真实性：真 bug。`texthooker_page.dart` 的 `_SessionOverviewCard` 里，降级原因行的
+  渲染条件是 `if (!compact && state.fallbackReason != null)`，而 `compact` 在窗口
+  宽度 < 840px 时为 true（布局分支 `box.maxWidth >= 840` 的 else 路径）。
+  → 窄屏下降级原因**整行不渲染**。
+
+  更糟的是**不对称**：同一张卡右侧的 `_StatusPill` 完全不看 `compact`，降级时照常亮
+  「已降级」。于是窄屏用户看到的是「出事了 + 不告诉你出了什么事」，比两个都不显示更难
+  排查——用户知道降级了，却拿不到任何可执行处置（「以管理员身份启动」这类）。
+
+  这是优先级搞反：compact 该省的是次要信息（采样率/声道/位深，即 `format`），不是唯一
+  的诊断线索。
+
+- [x] ① 根因修复：渲染条件去掉 `!compact`，改为只看 `state.fallbackReason != null`；
+      窄屏只把 `maxLines` 从 3 收窄到 2，不整行丢弃。`format` 仍按原样在 compact 下省掉
+      （那是 compact 的正当用途）。
+      `hibiki/lib/src/pages/implementations/texthooker_page.dart` `_SessionOverviewCard`
+- [x] ② 自动化测试：`hibiki/test/pages/texthooker_narrow_degrade_reason_guard_test.dart`
+      （5 条，抽取 `_SessionOverviewCard` 类体后断言，避免整文件命中蒙混）：
+      条件不含 `!compact`、`maxLines: compact ? 2 : 3`、format 仍在 compact 下省、
+      以及**徽章与原因的显示条件必须对称**（`_StatusPill` 不得出现 `compact`）。
+      捕获工作台整页依赖真实 WebView 平台视图、widget test 起不来，故守住源码接线——
+      与该页既有守卫（`texthooker_lookup_popup_overlay_test.dart` 等）同范式。
+
+- 备注：仍未真机验证「窄屏下确实能看到那行字」。窄屏渲染需要真机改窗口宽度肉眼看，
+  已并入批次 11 验收清单。相关：BUG-1100 修的是同一行字的**内容**（别把内部代码
+  `engine_pcm_unavailable` 甩给用户），本条修的是它的**可见性**。

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -1497,14 +1497,19 @@ class _SessionOverviewCard extends StatelessWidget {
                 // 降级原因：优先显示结构化失败的可执行处置（「游戏以管理员身份运行，
                 // 请同样以管理员身份启动 Hibiki」之类）。旧实现把 `engine_attach_failed`
                 // 这种内部代码原样甩给用户，等于什么都没说。没有结构化原因时才退回代码。
-                if (!compact && state.fallbackReason != null)
+                //
+                // **窄屏也必须显示**：右侧 _StatusPill 在 compact 下照常亮「已降级」，
+                // 若同时把原因藏掉，用户看到的就是「出事了 + 不告诉你出了什么事」，
+                // 比两个都不显示更难排查。compact 要省的是次要信息（采样率/声道/位深，
+                // 见上面的 format），不是唯一的诊断线索。只收窄行数，不整行丢弃。
+                if (state.fallbackReason != null)
                   Text(
                     // BUG-1100：先看注入失败的可执行处置，再看降级原因自己的人话文案；
                     // 两张表都没有才回退内部代码。
                     galHookFailureLabel(state.injectorFailure) ??
                         galHookFallbackLabel(state.fallbackReason!) ??
                         state.fallbackReason!,
-                    maxLines: 3,
+                    maxLines: compact ? 2 : 3,
                     overflow: TextOverflow.ellipsis,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           color: Theme.of(context).colorScheme.tertiary,

--- a/hibiki/test/pages/texthooker_narrow_degrade_reason_guard_test.dart
+++ b/hibiki/test/pages/texthooker_narrow_degrade_reason_guard_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1109 守卫：窄屏（compact）状态卡不得把降级原因整行藏掉。
+///
+/// 原实现是 `if (!compact && state.fallbackReason != null)` —— 窗口宽度不足 840px
+/// 时降级原因**完全不渲染**。而同一张卡右侧的 `_StatusPill` 在 compact 下照常亮
+/// 「已降级」，于是窄屏用户看到的是「出事了 + 不告诉你出了什么事」，比两个都不显示
+/// 更难排查：用户知道降级了，却拿不到任何可执行处置。
+///
+/// compact 该省的是**次要信息**（采样率 / 声道 / 位深，即 `format`），不是唯一的
+/// 诊断线索。修复后只收窄行数（`maxLines: compact ? 2 : 3`），不整行丢弃。
+///
+/// 捕获工作台整页依赖真实 WebView 平台视图，widget test 起不来，故守住源码接线。
+void main() {
+  late String cardSource;
+
+  setUpAll(() {
+    final String source = File(
+      'lib/src/pages/implementations/texthooker_page.dart',
+    ).readAsStringSync();
+
+    // 抽 _SessionOverviewCard 的类体，避免「整文件命中」把断言蒙混过去。
+    final int start = source.indexOf('class _SessionOverviewCard');
+    expect(start, greaterThanOrEqualTo(0),
+        reason: '找不到 _SessionOverviewCard，测试锚点过期');
+    final int end = source.indexOf('class _LatestLineCard', start);
+    expect(end, greaterThan(start), reason: '找不到类体结束锚点');
+    cardSource = source.substring(start, end);
+  });
+
+  test('降级原因不再被 compact 整行丢弃（BUG-1109）', () {
+    expect(
+      cardSource.contains('if (state.fallbackReason != null)'),
+      isTrue,
+      reason: '降级原因的渲染条件必须只看 fallbackReason，不看屏宽',
+    );
+    expect(
+      cardSource.contains('!compact && state.fallbackReason != null'),
+      isFalse,
+      reason: '窄屏藏掉降级原因正是 BUG-1109，不得回退',
+    );
+  });
+
+  test('compact 只收窄行数，不丢弃内容（BUG-1109）', () {
+    expect(
+      cardSource.contains('maxLines: compact ? 2 : 3'),
+      isTrue,
+      reason: '降级原因在窄屏应收窄到 2 行，而不是整行消失',
+    );
+  });
+
+  test('compact 省掉的是次要信息而非诊断线索（BUG-1109）', () {
+    // 采样率/声道/位深这类次要信息仍可以在窄屏省掉——这是 compact 的正当用途。
+    expect(
+      cardSource
+          .contains("compact\n                      ? '\$phase · \$audio'"),
+      isTrue,
+      reason: 'compact 仍应省掉 format（次要信息），这是它的正当用途',
+    );
+  });
+
+  test('降级徽章与降级原因的显示条件必须对称（BUG-1109）', () {
+    // 不对称正是这个 bug 的本质：徽章无条件亮，原因却被藏。
+    final int pill = cardSource.indexOf('_StatusPill(');
+    expect(pill, greaterThanOrEqualTo(0), reason: '找不到 _StatusPill');
+    final String pillSource = cardSource.substring(pill);
+    expect(
+      pillSource.contains('state.isDegraded'),
+      isTrue,
+      reason: '徽章按 isDegraded 亮',
+    );
+    expect(
+      pillSource.contains('compact'),
+      isFalse,
+      reason: '徽章不看屏宽；原因也不该看——两者必须对称',
+    );
+  });
+}


### PR DESCRIPTION
用户原话：「为什么不够宽就不显示，修复」。

上一轮我把「窗口须拉宽到 ≥840px 否则看不到降级原因」写进了验收清单的操作前置。用户指出这本身就是 bug——不该要求用户迁就 UI。**用户是对的。**

## 根因
`texthooker_page.dart` 的 `_SessionOverviewCard`：
```dart
if (!compact && state.fallbackReason != null)   // ← compact 在 maxWidth < 840 时为 true
```
窄屏下降级原因**整行不渲染**。

## 为什么这比看起来更糟：不对称
同一张卡右侧的 `_StatusPill` **完全不看 `compact`**，降级时照常亮「已降级」。于是窄屏用户看到的组合是：

> **出事了** + **不告诉你出了什么事**

这比两个都不显示更难排查——用户知道降级了，却拿不到任何可执行处置（BUG-1100 刚补上的那些人话文案，比如「游戏以管理员身份运行，请同样以管理员身份启动 Hibiki」）。

## 这是优先级搞反，不是故意隐藏
窄屏布局要省纵向空间，原实现挑了三样省：音频格式（采样率/声道/位深）、文本行数、降级原因。前两样是合理的**次要信息**；第三样是这张卡在出问题时**唯一的诊断线索**。

修复即把优先级摆正：
- 降级原因**无条件显示**，窄屏只把 `maxLines` 从 3 收窄到 2
- `format` 仍按原样在 compact 下省掉（那是 compact 的正当用途）

## 守卫（5 条）
`hibiki/test/pages/texthooker_narrow_degrade_reason_guard_test.dart`，抽取 `_SessionOverviewCard` 类体后断言（避免整文件命中蒙混）：
- 渲染条件不含 `!compact`
- `maxLines: compact ? 2 : 3`（是收窄不是丢弃）
- format 仍在 compact 下省（不矫枉过正）
- **对称性断言**：`_StatusPill` 不许出现 `compact`，原因也不许——两者显示条件必须一致，防止以后只改一边又漂开

捕获工作台整页依赖真实 WebView 平台视图、widget test 起不来，故守住源码接线，与该页既有守卫（`texthooker_lookup_popup_overlay_test.dart` 等）同范式。

## 排查过 —— 没有同类问题
全仓 grep `!compact &&`：改完后零命中，这是唯一一处因屏宽藏掉关键信息的门。

## 验证
- `flutter analyze`（全量含 test）：No issues found!
- `flutter test`（新守卫 + texthooker 既有两套 + bugs 守卫）：21 passed
- `dart run tool/bug.dart check`：1076 条，号唯一，索引同步

## 待真机
窄屏下确实能看到那行字，需要真机改窗口宽度肉眼确认。已并入批次 11 验收清单。

> 相关：BUG-1100 修的是这行字的**内容**（别把内部代码 `engine_pcm_unavailable` 甩给用户），本条修的是它的**可见性**。

https://claude.ai/code/session_018NeGjpee1gxFXaDTkaeoa4