### PR TITLE
fix(home)+feat(library): 首页三区块纳入游戏 (BUG-1111/1112) + 书架/视频补搜索复用同一归一化 (P5-A)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1075 条。点号进各自文件。
+> 共 1078 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1112](bugs/BUG-1112-galgame-no-tags.md) | 🚧 | 🚧 | 游戏没有标签：schema 缺 GalgameTagMappings 表 |
+| [BUG-1111](bugs/BUG-1111-activity-timeline-game-no-cover.md) | ✅ | ✅ | 活动时间轴游戏条目只有图标没有封面 |
+| [BUG-1110](bugs/BUG-1110-dashboard-continue-recent-missing-games.md) | ✅ | ✅ | 首页继续与最近添加装不下游戏：_ContinueEntry 用 isVideo 二元标志 |
 | [BUG-1108](bugs/BUG-1108-shelf-continue-hero-raw-title.md) | ✅ | ✅ | 改名后书架继续阅读条仍显示旧名 |
 | [BUG-1107](bugs/BUG-1107-reading-stats-phantom-chars-lost-duration.md) | ✅ | ✅ | 阅读统计速度爆表：幻象字数+纯时长行被拒 |
 | [BUG-1106](bugs/BUG-1106-desktop-settings-smoke-focus-gate-broken.md) | ✅ | ✅ | `desktop_settings_smoke_test.dart`（Windows 离屏 itest 默认门）在全新 profile 上必红 |

--- a/docs/bugs/BUG-1110-dashboard-continue-recent-missing-games.md
+++ b/docs/bugs/BUG-1110-dashboard-continue-recent-missing-games.md
@@ -1,0 +1,21 @@
+## BUG-1110 · 首页继续与最近添加装不下游戏：_ContinueEntry 用 isVideo 二元标志
+- **报告**：2026-07-26（用户：「首页的继续里面没有游戏。最近添加里面。」「全是因为各个地方代码不统一」）
+- **真实性**：✅ 真 bug，**结构性根因不是漏写分支**：
+  - `hibiki/lib/src/pages/implementations/home_dashboard_page.dart` 的 `_ContinueEntry`（修复前）字段是 `final bool isVideo`——**二元标志在结构上就装不下第三种媒体**。「继续」`_buildContinueSection` 与「最近添加」`_buildRecentlyAddedSection` 都只从 `books` + `_videos` 两个来源构造条目，游戏被永久排除，不是某处忘了加 if。
+  - 连带：筛选分段 `_continueFilter` 只有 全部/阅读/观看 三档，且「阅读」档判据是 `!e.isVideo`——**二元取反**，游戏一旦进列表就会被误算进「阅读」。
+  - 对照：同页热力图（`reading_activity` 区块）早已有「游戏」档（`kActivityGame` 日聚合），说明数据侧一直是齐的（`galgames` + `galgame_sessions`），缺的只是这个展示结构。
+  - 相关：游戏封面/最后游玩/添加时间三项数据都在 `GalgameEntry`（`coverPath` / `lastPlayedMs` / `addedAt`），无需新增 schema。
+- **[x] ① 已修复** —
+  - `_ContinueEntry.isVideo`(bool) 改为 `kind`([MediaKind]，P5 枚举地基) + 新增 `game` 字段；派生 `isBook` / `isVideo` / `isGame` 三个 getter。书按真实身份区分 `epub` / `srt`（新增 `_bookMediaKind`），不再把身份抹平。
+  - 「继续」纳入在玩的游戏：判据 `lastPlayedMs > 0`。游戏**没有完成度概念**（`galgames` 无 completedAt），所以不做「未完成」过滤；淹没风险由既有的 recentMs 倒序 + take(10) 兜住。
+  - 「最近添加」纳入游戏：`addedAt` 与书 `importedAt` / 视频 `importedAt` 同量纲，直接混排。
+  - 筛选档：「阅读」判据由 `!e.isVideo` 改为正面判定 `e.isBook`；新增第 4 档「游戏」，复用既有 i18n key `home_filter_game`（与热力图同一组档位，不新增 key）。
+  - 卡片渲染：游戏走竖版封面宽度（同书）；状态段用类型名而非书的「阅读 · x%」（否则一律显示「阅读 · 0%」）；新增 `_gameCover` 读 `galgames.coverPath`。
+  - 点击：游戏卡**切到游戏 tab**，不直接拉起游戏——启动 galgame 要走位数探测/helper 确认下载/注入会话（数秒且可能弹窗），从首页静默触发是危险的误操作面。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/home_dashboard_page_test.dart`
+  - 「玩过的游戏进『继续』区，且『游戏』筛选档只留游戏」（含筛选把视频滤掉的断言）
+  - 「新添加的游戏进『最近添加』（类型 · 相对时间）」
+- **备注**：
+  - 测试定位 chip 必须锁到「继续」区块自己的卡（`_sectionCard` 外层 `DecoratedBox`）：页面上共三组档位（热力图 / 继续 / 活动时间轴）都含「游戏」档，且游戏卡状态副标题本身就是「游戏」，按裸文本或树序取都会点错。
+  - 真机复测（首页三区块实际渲染）待补。
+  - 同批用户反馈的另两条独立建档：[BUG-1111](BUG-1111-activity-timeline-game-no-cover.md)（活动时间轴游戏无封面）、[BUG-1112](BUG-1112-galgame-no-tags.md)（游戏没有标签，schema 缺表）。

--- a/docs/bugs/BUG-1111-activity-timeline-game-no-cover.md
+++ b/docs/bugs/BUG-1111-activity-timeline-game-no-cover.md
@@ -1,0 +1,12 @@
+## BUG-1111 · 活动时间轴游戏条目只有图标没有封面
+- **报告**：2026-07-26（用户：「活动里面没有封面，名字也不一样」）
+- **真实性**：✅ 真 bug，且是**写死的**，不是取图失败：
+  - `hibiki/lib/src/pages/implementations/home_dashboard_page.dart` 的 `_activityLeading`（修复前）只有 `kActivityMediaVideo` 与 `kActivityMediaBook` 两个封面分支，游戏落到末尾的回退分支。该函数自己的注释就写明「查不到（已删/远端 display-only 行/**游戏**/导入无封面）回退原类型图标」——游戏是被显式列进回退清单的。
+  - 但游戏封面一直有：`GalgameEntry.coverPath`（本机文件，目录扫描 / exe 内嵌图标 / 刮削下载三种来源都落成本地文件），且活动行的 `mediaKey` 就是 `galgames.id`，反查即可。
+- **关于「名字也不一样」**：同批查证结论是**已修但未发版**——P4 改名门面已让时间轴按 `galgames.id` 反查库内显示名（`_gameDisplayTitle` → `displayTitleForGame`），改名/刮削后同步。该改动在 PR#431，用户报告时尚未合入 develop，故其版本上仍显示落库时的标题快照。本条不重复修。
+- **[x] ① 已修复** — `_activityLeading` 新增 `kActivityMediaGame` 分支：按 `mediaKey` 反查 `_games` 拿 `coverPath`，走新增的 `_gameCover`（与视频封面同形态：`Image.file` + 占位兜底），尺寸取与书相同的竖版 40×56。同时抽出 `_gameById` 复用，消掉 `_gameDisplayTitle` 里原有的一处线性查找重复。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/home_dashboard_page_test.dart`「活动时间轴的游戏条目渲染封面，不再只有回退图标」：塞真实 1x1 PNG 作封面，断言时间轴出现 `FileImage`（修复前游戏走图标分支，不会有任何 `Image.file`）。
+- **备注**：
+  - 测试必须用**真实可解码**的文件——`Image.file` 对不存在或损坏的文件走 errorBuilder，断言不到 `FileImage`。
+  - 真机复测（时间轴实际渲染）待补。
+  - 同批：[BUG-1110](BUG-1110-dashboard-continue-recent-missing-games.md)、[BUG-1112](BUG-1112-galgame-no-tags.md)。

--- a/docs/bugs/BUG-1112-galgame-no-tags.md
+++ b/docs/bugs/BUG-1112-galgame-no-tags.md
@@ -1,0 +1,11 @@
+## BUG-1112 · 游戏没有标签：schema 缺 GalgameTagMappings 表
+- **报告**：2026-07-26（用户：「游戏的标签呢」「全是因为各个地方代码不统一」）
+- **真实性**：✅ 真缺口（**schema 级**，不是 UI 忘接）：
+  - `packages/hibiki_core/lib/src/database/tables.dart` 里标签映射表只有四张：`BookTagMappings` / `SrtBookTagMappings` / `VideoBookTagMappings` / `CollectionTagMappings`，**没有游戏的**。
+  - 标签池 `BookTags` 是共享的，筛选 UI（`tag_filter_bar.dart` / `tag_filter_sheet.dart` / `selectedTagIdsProvider`）也已是书架与视频页共用——即上层早已统一，唯独游戏没有落表就接不进来。
+  - 因此这条**不能靠改 UI 修**：要加表 + schema 迁移，属独立工程。
+- **[ ] ① 未修复** — 需要：新增 `GalgameTagMappings`(gameId → tagId，FK cascade 对齐 `GalgameSources`/`GalgameSessions` 的做法) + schema 版本迁移；游戏库页接入既有 `tag_filter_bar` / `tag_filter_sheet`；标签管理页把游戏纳入统计；同步/备份侧确认标签墓碑（`BookTagMembershipTombstones`）是否需要覆盖游戏——注意游戏是**本机局域身份**（`galgames.id`），跨端同步语义要先定，不能照抄书的做法。
+- **[ ] ② 未加自动化测试** —
+- **备注**：
+  - 本条**刻意不与** [BUG-1110](BUG-1110-dashboard-continue-recent-missing-games.md) / [BUG-1111](BUG-1111-activity-timeline-game-no-cover.md) 同 PR：那两条是纯展示层收口（无 schema 变更），本条要动 schema + 迁移 + 同步语义，混在一起会让一个 PR 同时承担「不可逆的 DB 迁移」和「UI 改动」两种风险。
+  - 跨端同步语义是先决问题：对端没有对应 `galgames` 行时，游戏标签成员该静默忽略还是不同步，需先定契约。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45458 (2674 per locale)
+/// Strings: 45475 (2675 per locale)
 ///
-/// Built on 2026-07-26 at 02:35 UTC
+/// Built on 2026-07-26 at 05:27 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3553,6 +3553,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get galgame_upscaling_hint_not_installed =>
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   String get game_health_upscaling => 'Window upscaling';
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -9626,6 +9627,8 @@ class _StringsAr extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -15772,6 +15775,8 @@ class _StringsDe extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -21934,6 +21939,8 @@ class _StringsEs extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -28107,6 +28114,8 @@ class _StringsFr extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -34207,6 +34216,8 @@ class _StringsId extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -40355,6 +40366,8 @@ class _StringsIt extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -46308,6 +46321,8 @@ class _StringsJa extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -52264,6 +52279,8 @@ class _StringsKo extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -58390,6 +58407,8 @@ class _StringsNl extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -64531,6 +64550,8 @@ class _StringsPtBr extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -70655,6 +70676,8 @@ class _StringsRu extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -76724,6 +76747,8 @@ class _StringsTh extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -82825,6 +82850,8 @@ class _StringsTr extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -88913,6 +88940,8 @@ class _StringsVi extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -94579,6 +94608,8 @@ class _StringsZhCn extends _StringsEn {
       '没有安装 Magpie。把「游戏窗口超分」改成「自动」即可下载。';
   @override
   String get game_health_upscaling => '窗口超分';
+  @override
+  String get library_search => '搜索库';
 }
 
 // Path: <root>
@@ -100450,6 +100481,8 @@ class _StringsZhHk extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 /// Flat map(s) containing all translations.
@@ -105911,6 +105944,8 @@ extension on _StringsEn {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -111370,6 +111405,8 @@ extension on _StringsAr {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -116850,6 +116887,8 @@ extension on _StringsDe {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -122329,6 +122368,8 @@ extension on _StringsEs {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -127814,6 +127855,8 @@ extension on _StringsFr {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -133281,6 +133324,8 @@ extension on _StringsId {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -138763,6 +138808,8 @@ extension on _StringsIt {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -144207,6 +144254,8 @@ extension on _StringsJa {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -149655,6 +149704,8 @@ extension on _StringsKo {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -155130,6 +155181,8 @@ extension on _StringsNl {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -160602,6 +160655,8 @@ extension on _StringsPtBr {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -166079,6 +166134,8 @@ extension on _StringsRu {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -171540,6 +171597,8 @@ extension on _StringsTh {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -177010,6 +177069,8 @@ extension on _StringsTr {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -182475,6 +182536,8 @@ extension on _StringsVi {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -187897,6 +187960,8 @@ extension on _StringsZhCn {
         return '没有安装 Magpie。把「游戏窗口超分」改成「自动」即可下载。';
       case 'game_health_upscaling':
         return '窗口超分';
+      case 'library_search':
+        return '搜索库';
       default:
         return null;
     }
@@ -193336,6 +193401,8 @@ extension on _StringsZhHk {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "你的电脑上已经开着一个 Magpie，Hibiki 没有去动它。按 Win+Shift+A 就能放大游戏窗口。",
   "galgame_upscaling_hint_manual": "按 Win+Shift+A 放大游戏窗口。",
   "galgame_upscaling_hint_not_installed": "没有安装 Magpie。把「游戏窗口超分」改成「自动」即可下载。",
-  "game_health_upscaling": "窗口超分"
+  "game_health_upscaling": "窗口超分",
+  "library_search": "搜索库"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/src/media/media_search_text.dart
+++ b/hibiki/lib/src/media/media_search_text.dart
@@ -1,0 +1,122 @@
+/// 库页搜索的**共享**归一化与匹配（P5-A）：书架 / 视频 / 游戏三个库页同一口径。
+///
+/// 此前这套实现只长在游戏库页（`galgame_library_query.dart` 的
+/// `normalizeGalgameSearchText`），书架与视频页**根本没有搜索**。补搜索时不该
+/// 各写一套「大概也做全角转半角」的近似实现——同一个库、同一批日文标题，在三个
+/// 页面搜出不同结果比没有搜索更难解释。故把已在游戏页验证过的实现原样上提到
+/// 媒体层，游戏侧改为委托（行为逐字节不变）。
+///
+/// 刻意**不引入**模糊匹配 / 拼音 / 分词依赖：目标只是让排版差异（全角、片假名、
+/// 中点、长音符）不再挡住命中。
+library;
+
+/// 搜索归一化：全角 ASCII → 半角、大写 → 小写、片假名 → 平假名、丢掉空白与常见
+/// 标点。目的是让「Fate／stay night」「fate stay night」「ＦＡＴＥ・ｓｔａｙ」
+/// 互相能命中，而不引入任何模糊匹配依赖。
+///
+/// 片假名折叠只做基本区（U+30A1..U+30F6 平移 -0x60），长音符 `ー`、中点 `・`
+/// 这类连接符直接丢弃——它们在标题里出现与否全凭排版习惯。
+String normalizeMediaSearchText(String raw) {
+  if (raw.isEmpty) return '';
+  final StringBuffer out = StringBuffer();
+  for (final int code in raw.runes) {
+    int c = code;
+    // 全角 ASCII（U+FF01..U+FF5E）→ 半角。
+    if (c >= 0xFF01 && c <= 0xFF5E) {
+      c -= 0xFEE0;
+    }
+    // 全角空格 → 视作空白（下面被丢弃）。
+    if (c == 0x3000) {
+      continue;
+    }
+    // 片假名 → 平假名（基本区）。
+    if (c >= 0x30A1 && c <= 0x30F6) {
+      c -= 0x60;
+    }
+    final String ch = String.fromCharCode(c);
+    if (_isDroppedSearchChar(ch, c)) {
+      continue;
+    }
+    out.write(ch.toLowerCase());
+  }
+  return out.toString();
+}
+
+/// 候选标题里是否有一条命中 [query]：两侧都经 [normalizeMediaSearchText] 后做
+/// 子串匹配。**空查询恒命中**（搜索框为空 = 不过滤）。纯函数。
+///
+/// [titles] 传该条目的全部可搜标题（原名 / 显示名 / 别名 / 译名…），任意一条命中
+/// 即算命中——用户记得住哪个名字是随机的。
+bool matchesMediaSearch({
+  required String query,
+  required Iterable<String> titles,
+}) {
+  final String needle = normalizeMediaSearchText(query);
+  if (needle.isEmpty) return true;
+  for (final String title in titles) {
+    if (normalizeMediaSearchText(title).contains(needle)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// 归一化时丢弃的字符：空白 + 常见分隔/装饰标点（含日文全角标点）。
+bool _isDroppedSearchChar(String ch, int code) {
+  if (code <= 0x20) return true; // 控制字符与空格
+  return _kDroppedSearchChars.contains(ch);
+}
+
+/// 见 [_isDroppedSearchChar]。
+const Set<String> _kDroppedSearchChars = <String>{
+  '!',
+  '"',
+  '#',
+  '\$',
+  '%',
+  '&',
+  "'",
+  '(',
+  ')',
+  '*',
+  '+',
+  ',',
+  '-',
+  '.',
+  '/',
+  ':',
+  ';',
+  '<',
+  '=',
+  '>',
+  '?',
+  '@',
+  '[',
+  '\\',
+  ']',
+  '^',
+  '_',
+  '`',
+  '{',
+  '|',
+  '}',
+  '~',
+  '・',
+  'ー',
+  '、',
+  '。',
+  '「',
+  '」',
+  '『',
+  '』',
+  '〜',
+  '＝',
+  '−',
+  '–',
+  '—',
+  '“',
+  '”',
+  '‘',
+  '’',
+  '…',
+};

--- a/hibiki/lib/src/mining/galgame_library_query.dart
+++ b/hibiki/lib/src/mining/galgame_library_query.dart
@@ -6,6 +6,7 @@ library;
 
 import 'dart:convert';
 
+import 'package:hibiki/src/media/media_search_text.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 
 /// 排序维度（契约 §4.1）。[key] 是持久化字符串，**不可随意改**。
@@ -173,111 +174,17 @@ class GalgameLibraryView {
   }
 }
 
-/// 搜索归一化：全角 ASCII → 半角、大写 → 小写、片假名 → 平假名、丢掉空白与常见
-/// 标点。目的是让「Fate／stay night」「fate stay night」「ＦＡＴＥ・ｓｔａｙ」
-/// 互相能命中，而不引入任何模糊匹配依赖。
-///
-/// 片假名折叠只做基本区（U+30A1..U+30F6 平移 -0x60），长音符 `ー`、中点 `・`
-/// 这类连接符直接丢弃——它们在标题里出现与否全凭排版习惯。
-String normalizeGalgameSearchText(String raw) {
-  if (raw.isEmpty) return '';
-  final StringBuffer out = StringBuffer();
-  for (final int code in raw.runes) {
-    int c = code;
-    // 全角 ASCII（U+FF01..U+FF5E）→ 半角。
-    if (c >= 0xFF01 && c <= 0xFF5E) {
-      c -= 0xFEE0;
-    }
-    // 全角空格 → 视作空白（下面被丢弃）。
-    if (c == 0x3000) {
-      continue;
-    }
-    // 片假名 → 平假名（基本区）。
-    if (c >= 0x30A1 && c <= 0x30F6) {
-      c -= 0x60;
-    }
-    final String ch = String.fromCharCode(c);
-    if (_isDroppedSearchChar(ch, c)) {
-      continue;
-    }
-    out.write(ch.toLowerCase());
-  }
-  return out.toString();
-}
-
-/// 归一化时丢弃的字符：空白 + 常见分隔/装饰标点（含日文全角标点）。
-bool _isDroppedSearchChar(String ch, int code) {
-  if (code <= 0x20) return true; // 控制字符与空格
-  return _kDroppedSearchChars.contains(ch);
-}
-
-/// 见 [_isDroppedSearchChar]。
-
-const Set<String> _kDroppedSearchChars = <String>{
-  '!',
-  '"',
-  '#',
-  '\$',
-  '%',
-  '&',
-  "'",
-  '(',
-  ')',
-  '*',
-  '+',
-  ',',
-  '-',
-  '.',
-  '/',
-  ':',
-  ';',
-  '<',
-  '=',
-  '>',
-  '?',
-  '@',
-  '[',
-  '\\',
-  ']',
-  '^',
-  '_',
-  '`',
-  '{',
-  '|',
-  '}',
-  '~',
-  '・',
-  'ー',
-  '、',
-  '。',
-  '「',
-  '」',
-  '『',
-  '』',
-  '〜',
-  '＝',
-  '−',
-  '–',
-  '—',
-  '“',
-  '”',
-  '‘',
-  '’',
-  '…',
-};
+/// 搜索归一化。**实现已上提到媒体层** [normalizeMediaSearchText]（P5-A：书架 /
+/// 视频 / 游戏三个库页共用同一口径），这里保留原名做委托——它是本文件的公开
+/// API，已被游戏库页与其单测引用，改名没有收益只会破坏调用方。
+String normalizeGalgameSearchText(String raw) => normalizeMediaSearchText(raw);
 
 /// 某条游戏是否命中搜索词：对 [GalgameEntry.searchTitles] 全部标题做归一化子串匹配。
 /// 空查询恒命中。纯函数。
-bool matchesGalgameSearch(GalgameEntry entry, String query) {
-  final String needle = normalizeGalgameSearchText(query);
-  if (needle.isEmpty) return true;
-  for (final String title in entry.searchTitles) {
-    if (normalizeGalgameSearchText(title).contains(needle)) {
-      return true;
-    }
-  }
-  return false;
-}
+///
+/// P5-A：判定逻辑收口到共享的 [matchesMediaSearch]，与书架/视频页同一口径。
+bool matchesGalgameSearch(GalgameEntry entry, String query) =>
+    matchesMediaSearch(query: query, titles: entry.searchTitles);
 
 /// 某条游戏是否通过筛选（不含搜索）。纯函数。
 bool matchesGalgameFilters(GalgameEntry entry, GalgameLibraryView view) {

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -67,11 +67,17 @@ class HomeDashboardPage extends ConsumerStatefulWidget {
   ConsumerState<HomeDashboardPage> createState() => _HomeDashboardPageState();
 }
 
-/// 「继续」统一列表的单条：书与视频归一到同一结构，按 [recentMs] 倒序混排。
-/// [book]/[video]/[remote] 恰有一个非空（本地书 / 本地视频 / 互联 host 条目）。
+/// 「继续」统一列表的单条：书 / 视频 / 游戏归一到同一结构，按 [recentMs] 倒序混排。
+/// [book]/[video]/[game]/[remote] 恰有一个非空（本地书 / 本地视频 / 本地游戏 /
+/// 互联 host 条目）。
+///
+/// BUG-1110：此前这里是 `final bool isVideo`——**二元标志结构上装不下第三种媒体**，
+/// 于是「继续」「最近添加」只能由 books + videos 两个来源构造，游戏被永久排除在
+/// 首页之外（用户报「首页的继续里面没有游戏」）。改用 [MediaKind]（P5 枚举地基）
+/// 后第三种媒体才有位置；新增媒体种类也不再需要动这个结构。
 class _ContinueEntry {
   const _ContinueEntry({
-    required this.isVideo,
+    required this.kind,
     required this.title,
     required this.recentMs,
     this.percent = 0,
@@ -80,10 +86,23 @@ class _ContinueEntry {
     this.subtitleOverride,
     this.book,
     this.video,
+    this.game,
     this.remote,
   });
 
-  final bool isVideo;
+  /// 本条的媒体种类。书按真实身份区分 [MediaKind.epub] / [MediaKind.srt]
+  /// （两者在本区块行为一致，经 [isBook] 归并），不再用一个 bool 硬编码二元。
+  final MediaKind kind;
+
+  /// 视频分支（横版封面 / 直接续播）。
+  bool get isVideo => kind == MediaKind.video;
+
+  /// 书分支（竖版封面 / openMedia）：EPUB 与 SRT 在本区块完全同行为。
+  bool get isBook => kind == MediaKind.epub || kind == MediaKind.srt;
+
+  /// 游戏分支（竖版封面 / 跳游戏 tab）。
+  bool get isGame => kind == MediaKind.game;
+
   final String title;
 
   /// 最近活动时刻（epoch 毫秒），仅用于混排排序。
@@ -105,6 +124,10 @@ class _ContinueEntry {
   final String? subtitleOverride;
   final MediaItem? book;
   final VideoBookRow? video;
+
+  /// 本地游戏（BUG-1110）。游戏是**本机局域身份**（`galgames.id`），不参与互联
+  /// 远端补位——对端没有对应行，拿过来也打不开。
+  final GalgameEntry? game;
 
   /// 互联 host 上的在读书/在看视频（本地无此条目时的远端补位，「继续也走互联」）。
   final RemoteContinueCandidate? remote;
@@ -682,7 +705,7 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
         final int percent =
             ((item.position / item.duration) * 100).clamp(0, 100).round();
         entries.add(_ContinueEntry(
-          isVideo: false,
+          kind: _bookMediaKind(item),
           // BUG-1018 (A1)：书名走与书架卡同一 override 通道（编辑对话框改名后
           // 首页「继续」区同步显示新名），不直接读 DB 原名。
           title: ReaderHibikiSource.instance.getDisplayTitleFromMediaItem(item),
@@ -747,11 +770,30 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
         recentMs: recent,
       ));
     }
+    // BUG-1110：在玩的游戏。判据是「玩过」（lastPlayedMs>0）——游戏没有「读完/
+    // 看完」这种完成度概念（`galgames` 无 completedAt，时长/次数由
+    // `galgame_sessions` 现算），所以不做「未完成」过滤；排序与取前 N 由下面统一
+    // 的 recentMs 倒序 + take(10) 兜住，不会淹没书与视频。
+    for (final GalgameEntry g in _games) {
+      if (g.lastPlayedMs <= 0) continue;
+      entries.add(_ContinueEntry(
+        kind: MediaKind.game,
+        // 与库页/时间轴同一显示名口径（改名/刮削后首页同步）。
+        title: g.displayName,
+        recentMs: g.lastPlayedMs,
+        collectionName: statCollectionName(
+          MediaKind.game.compositeKey(g.id),
+          _primaryCollectionByEntry,
+          _collectionNamesById,
+        ),
+        game: g,
+      ));
+    }
     // 互联 host 的远端补位（本地无同 key/uid 的在读书/在看视频），与本地条目
     // 按最近活动时刻统一混排（「继续也走互联」）。
     for (final RemoteContinueCandidate c in _remoteContinue) {
       entries.add(_ContinueEntry(
-        isVideo: c.isVideo,
+        kind: c.isVideo ? MediaKind.video : MediaKind.epub,
         title: c.title,
         recentMs: c.recentMs,
         percent: c.percent,
@@ -767,9 +809,13 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
         .where((_ContinueEntry e) {
           switch (_continueFilter) {
             case 1:
-              return !e.isVideo;
+              // BUG-1110：旧实现是 `!e.isVideo`——二元取反，游戏一旦进列表就会被
+              // 误算进「阅读」。按种类正面判定。
+              return e.isBook;
             case 2:
               return e.isVideo;
+            case 3:
+              return e.isGame;
             default:
               return true;
           }
@@ -788,6 +834,8 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
           (0, t.home_filter_all),
           (1, t.home_filter_read),
           (2, t.home_filter_watch),
+          // BUG-1110：与下方热力图筛选同一组档位（复用既有 key，不新增 i18n）。
+          (3, t.home_filter_game),
         ],
       ),
       child: filtered.isEmpty
@@ -848,7 +896,7 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
           bookKey == null ? 0 : (_epubImportedAtByKey[bookKey] ?? 0);
       if (addedMs <= 0) continue;
       entries.add(_ContinueEntry(
-        isVideo: false,
+        kind: _bookMediaKind(item),
         // BUG-1018 (A1)：与继续卡同一 override 显示名通道。
         title: ReaderHibikiSource.instance.getDisplayTitleFromMediaItem(item),
         recentMs: addedMs,
@@ -866,7 +914,7 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
       final int addedMs = v.importedAt?.millisecondsSinceEpoch ?? 0;
       if (addedMs <= 0) continue;
       entries.add(_ContinueEntry(
-        isVideo: true,
+        kind: MediaKind.video,
         title: v.title,
         recentMs: addedMs,
         collectionName: statCollectionName(
@@ -879,6 +927,25 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
         video: v,
       ));
     }
+    // BUG-1110：游戏也进「最近添加」。addedAt 即 `galgames.id` 的微秒时间戳来源
+    // （添加时刻），与书的 importedAt / 视频的 importedAt 同量纲，可直接混排。
+    for (final GalgameEntry g in _games) {
+      final int addedMs = g.addedAt.millisecondsSinceEpoch;
+      if (addedMs <= 0) continue;
+      entries.add(_ContinueEntry(
+        kind: MediaKind.game,
+        title: g.displayName,
+        recentMs: addedMs,
+        collectionName: statCollectionName(
+          MediaKind.game.compositeKey(g.id),
+          _primaryCollectionByEntry,
+          _collectionNamesById,
+        ),
+        subtitleOverride:
+            '${t.home_filter_game} · ${_relativeTimeLabel(addedMs, now)}',
+        game: g,
+      ));
+    }
     if (entries.isEmpty) return null;
     entries.sort((_ContinueEntry a, _ContinueEntry b) =>
         b.recentMs.compareTo(a.recentMs));
@@ -889,6 +956,14 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
       child: _continueCardsRow(tokens, appModel, top),
     );
   }
+
+  /// 书 [MediaItem] 的真实媒体种类：standalone SRT 书身份是
+  /// `hoshi://srtbook/<uid>`（BUG-1018 A3），其余按 EPUB。两者在「继续/最近添加」
+  /// 区块行为一致（[_ContinueEntry.isBook]），但身份不该被抹平成同一个值。
+  MediaKind _bookMediaKind(MediaItem item) =>
+      ReaderHibikiSource.parseSrtBookUid(item.mediaIdentifier) != null
+          ? MediaKind.srt
+          : MediaKind.epub;
 
   /// 书 [MediaItem] → 合集归属键：epub 用 bookKey（'epub|<bookKey>'），standalone
   /// SRT 书身份是 `hoshi://srtbook/<uid>`（BUG-1018 A3）→ 'srt|<uid>'；识别不出
@@ -915,7 +990,7 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
     required int recentMs,
   }) {
     return _ContinueEntry(
-      isVideo: true,
+      kind: MediaKind.video,
       title: v.title,
       recentMs: recentMs,
       progress: videoWatchFraction(
@@ -969,11 +1044,18 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
     AppModel appModel,
     _ContinueEntry entry,
   ) {
+    // 视频是横版 16:9，书与游戏都是竖版封面（galgame 封面同为竖版海报）。
     final double coverWidth =
         entry.isVideo ? _kContinueVideoCoverWidth : _kContinueBookCoverWidth;
-    String status = entry.isVideo
-        ? t.home_filter_watch
-        : '${t.home_filter_read} · ${entry.percent}%';
+    // BUG-1110：游戏没有阅读百分比（无完成度概念），状态段只标类型，不能套用
+    // 书的「阅读 · x%」——否则一律显示「阅读 · 0%」。
+    String status = switch (entry.kind) {
+      MediaKind.video => t.home_filter_watch,
+      MediaKind.game => t.home_filter_game,
+      MediaKind.epub ||
+      MediaKind.srt =>
+        '${t.home_filter_read} · ${entry.percent}%',
+    };
     if (entry.remote != null) {
       // 标明设备来源：优先 host 设备名（配对时存下），取不到回退通用「远端」。
       status = '$status · ${_remoteDeviceName ?? t.home_remote_source}';
@@ -1051,6 +1133,7 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
   ) {
     if (entry.remote != null) return _remoteCover(tokens, entry);
     if (entry.isVideo) return _videoCover(tokens, entry.video!);
+    if (entry.isGame) return _gameCover(tokens, entry.game!);
     return FadeInImage(
       placeholder: MemoryImage(kTransparentImage),
       image: ReaderHibikiSource.instance.getDisplayThumbnailFromMediaItem(
@@ -1095,6 +1178,22 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
     return _coverPlaceholder(tokens, Icons.movie_outlined);
   }
 
+  /// 游戏封面（BUG-1110 / BUG-1111）：`galgames.coverPath` 存在则 [Image.file]，
+  /// 否则占位图标。与 [_videoCover] 同一形态——封面是本机文件路径（目录扫描 /
+  /// exe 内嵌图标 / 刮削下载三种来源都落成本地文件），不走网络取图。
+  Widget _gameCover(HibikiDesignTokens tokens, GalgameEntry game) {
+    final String? path = game.coverPath;
+    if (path != null && path.isNotEmpty && File(path).existsSync()) {
+      return Image.file(
+        File(path),
+        fit: BoxFit.cover,
+        errorBuilder: (_, __, ___) =>
+            _coverPlaceholder(tokens, Icons.videogame_asset_outlined),
+      );
+    }
+    return _coverPlaceholder(tokens, Icons.videogame_asset_outlined);
+  }
+
   /// 封面占位：中性底色 + 图标。
   Widget _coverPlaceholder(HibikiDesignTokens tokens, IconData icon) {
     return DecoratedBox(
@@ -1118,6 +1217,13 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
     }
     if (entry.isVideo) {
       await _openLocalVideo(entry.video!.bookUid);
+      return;
+    }
+    // BUG-1110：游戏卡点击**切到游戏 tab**，不直接拉起游戏。启动 galgame 要走
+    // 位数探测 / helper 确认下载 / 注入会话（`GamesLibraryPage._launchGame`，
+    // 数秒且可能弹窗），从首页静默触发是危险的误操作面；库页才是启动入口。
+    if (entry.isGame) {
+      homeShellTabNotifier.value = HomeTab.games;
       return;
     }
     final MediaItem item = entry.book!;
@@ -1407,16 +1513,18 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
   /// 游戏活动标题 → 显示名（P4）：先按 [mediaKey]（galgames.id）精确命中，
   /// 再按「落库时的标题快照 == 库内条目任一已知名」兜底（老事件无 mediaKey），
   /// 最后回落快照原文。查找委托 [displayTitleForGame]。
-  String _gameDisplayTitle(String rawTitle, {String? mediaKey}) {
-    GalgameEntry? entry;
-    if (mediaKey != null && mediaKey.isNotEmpty) {
-      for (final GalgameEntry g in _games) {
-        if (g.id == mediaKey) {
-          entry = g;
-          break;
-        }
-      }
+  /// 按 `galgames.id` 反查本页已加载的游戏；找不到返回 null（已删除条目的历史
+  /// 活动行仍会渲染，只是没有封面/新名可用）。
+  GalgameEntry? _gameById(String? id) {
+    if (id == null || id.isEmpty) return null;
+    for (final GalgameEntry g in _games) {
+      if (g.id == id) return g;
     }
+    return null;
+  }
+
+  String _gameDisplayTitle(String rawTitle, {String? mediaKey}) {
+    GalgameEntry? entry = _gameById(mediaKey);
     if (entry == null) {
       for (final GalgameEntry g in _games) {
         if (g.name == rawTitle ||
@@ -1762,6 +1870,21 @@ class _HomeDashboardPageState extends ConsumerState<HomeDashboardPage> {
               width: 68,
               height: 40,
               child: _videoCover(tokens, video),
+            ),
+          );
+        }
+      } else if (entry.mediaType == kActivityMediaGame) {
+        // BUG-1111：游戏此前被硬编码进「回退图标」分支，时间轴上只有一个小图标，
+        // 而书与视频都有封面（用户报「活动里面没有封面」）。游戏封面就在
+        // `galgames.coverPath`（本机文件），按 mediaKey = galgames.id 反查即可。
+        final GalgameEntry? game = _gameById(key);
+        if (game != null) {
+          return ClipRRect(
+            borderRadius: HibikiBorderRadius.card,
+            child: SizedBox(
+              width: 40,
+              height: 56,
+              child: _gameCover(tokens, game),
             ),
           );
         }

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -49,6 +49,7 @@ import 'package:hibiki/src/media/collections/batch_combine.dart';
 import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
+import 'package:hibiki/src/media/media_search_text.dart';
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
 import 'package:hibiki/src/pages/implementations/media_collection_detail_page.dart';
 import 'package:hibiki/src/pages/implementations/media_item_dialog_page.dart';
@@ -209,6 +210,11 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   /// 最近观看，用户拍板）。旧 `ShelfEntries.sortOrder` 手动权重已废弃不再读取。
   ShelfSortMode _sortMode = ShelfSortMode.recent;
 
+  /// P5-A：视频库搜索词（原文，匹配时才归一化）。**刻意不持久化**——下次进
+  /// 视频库还挂着上次的搜索词只会让人以为库空了（与书架/游戏库页同一决定）。
+  String _searchQuery = '';
+  final TextEditingController _searchController = TextEditingController();
+
   /// 层次 C：`'video|<uid>' → 该条目在其主折叠合集里的 sortIndex`（组内序真相源，
   /// 与详情页/播放器 `getCollectionItems` 同源——详情页拖完库页行立即同序）。
   Map<String, int> _memberSortIndex = const <String, int>{};
@@ -262,6 +268,7 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
 
   @override
   void dispose() {
+    _searchController.dispose();
     homeShellTabNotifier.removeListener(_onShellTabActivated);
     _videoUidsSub?.cancel();
     _autoScrape?.dispose();
@@ -1881,6 +1888,7 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
             child: Column(
               children: <Widget>[
                 if (!isCupertinoPlatform(context)) _buildPageHeader(canImport),
+                _buildVideoSearchBar(),
                 _buildTagFilterBar(allTags),
                 // 下拉同步可能跑几十秒，光一个转圈看不出进展；没同步在飞时零高度。
                 const SyncProgressBanner(),
@@ -1931,9 +1939,19 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
                   collectionFilter: collectionFilter,
                 );
               }).toList();
+        // P5-A：搜索按标题匹配，归一化走与书架/游戏库页同一份
+        // [matchesMediaSearch]（全角/片假名/标点折叠），三页搜出的结果口径一致。
+        final List<VideoBookRow> searched = _searchQuery.trim().isEmpty
+            ? books
+            : books
+                .where((VideoBookRow b) => matchesMediaSearch(
+                      query: _searchQuery,
+                      titles: <String>[b.title],
+                    ))
+                .toList();
         // 排序交互重设计：卡片间序在 group 层按当前排序方式做（[_groupVideos]），
         // 这里不再预排散列表（旧 ShelfEntries.sortOrder 死权重已废弃，用户拍板）。
-        final List<VideoBookRow> ordered = books;
+        final List<VideoBookRow> ordered = searched;
         // 记录当前可见（已过滤）的本地视频，供批量「全选 / 反选」用。
         _visibleVideos = ordered;
         return FutureBuilder<_RemoteVideoState?>(
@@ -2956,6 +2974,39 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   /// 整栏**（不再「无标签隐藏」），批量选择按钮才能常驻露出（否则空标签库点不到
   /// 批量入口、无法批量删除）。组件内部「管理标签」齿轮仍只在有标签时显示，故无
   /// 标签时整栏只剩「批量选择」按钮。
+  /// P5-A 视频库搜索框。形态与书架/游戏库页一致（三个库页搜索长一个样），
+  /// 搜索词只影响本次会话、不落库。
+  Widget _buildVideoSearchBar() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: SizedBox(
+        height: 40,
+        child: TextField(
+          key: const ValueKey<String>('video_search_field'),
+          controller: _searchController,
+          decoration: InputDecoration(
+            isDense: true,
+            prefixIcon: const Icon(Icons.search, size: 18),
+            hintText: t.library_search,
+            border: const OutlineInputBorder(),
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            suffixIcon: _searchQuery.isEmpty
+                ? null
+                : IconButton(
+                    icon: const Icon(Icons.close, size: 18),
+                    onPressed: () {
+                      _searchController.clear();
+                      setState(() => _searchQuery = '');
+                    },
+                  ),
+          ),
+          onChanged: (String value) => setState(() => _searchQuery = value),
+        ),
+      ),
+    );
+  }
+
   Widget _buildTagFilterBar(List<BookTagRow> tags) {
     return HibikiTagFilterBar(
       tags: tags,

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -40,6 +40,7 @@ import 'package:hibiki/src/media/collections/add_to_collection_dialog.dart';
 import 'package:hibiki/src/media/collections/batch_combine.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
+import 'package:hibiki/src/media/media_search_text.dart';
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
 import 'package:hibiki/src/pages/implementations/media_collection_grid_detail_page.dart';
 import 'package:hibiki/src/pages/implementations/series_shelf_card.dart';
@@ -200,6 +201,11 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
   Future<void>? _shelfMapsFuture;
   ShelfSortMode _sortMode = ShelfSortMode.recent;
 
+  /// P5-A：书架搜索词（原文，匹配时才归一化）。**刻意不持久化**——下次进书架还
+  /// 挂着上次的搜索词只会让人以为书没了（与游戏库页同一决定）。
+  String _searchQuery = '';
+  final TextEditingController _searchController = TextEditingController();
+
   /// 层次 C：`'mediaType|entryKey' → 该条目在其主折叠合集里的 sortIndex`（组内序
   /// 真相源，与详情页 `getCollectionItems` 同源）。
   Map<String, int> _memberSortIndex = const <String, int>{};
@@ -331,6 +337,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
 
   @override
   void dispose() {
+    _searchController.dispose();
     mediaType.tabRefreshNotifier.removeListener(_reloadShelfMapsOnTabRefresh);
     homeShellTabNotifier.removeListener(_onShellTabActivated);
     assert(() {
@@ -397,6 +404,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             child: Column(
               children: [
                 if (!isCupertinoPlatform(context)) _buildPageHeader(),
+                _buildSearchBar(),
                 _buildTagBar(allTags.valueOrNull ?? const []),
                 // 下拉同步可能跑几十秒，光一个转圈看不出进展；没同步在飞时零高度。
                 const SyncProgressBanner(),
@@ -407,7 +415,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
                       _remoteBooksFuture ??= _loadRemoteBooks();
                       _shelfMapsFuture ??= _loadShelfMaps();
                       final Set<String>? filterSet = filteredIds.valueOrNull;
-                      final List<MediaItem> filtered;
+                      List<MediaItem> filtered;
                       if (filterSet == null) {
                         filtered = bookList;
                       } else {
@@ -422,6 +430,22 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
                             primaryCollectionId: _primaryCollectionByEntry[
                                 MediaKind.epub.compositeKey(key)],
                             collectionFilter: tagCollectionFilter,
+                          );
+                        }).toList();
+                      }
+                      // P5-A：搜索按**显示名 + DB 原名**双口径匹配——改过名的书
+                      // 用户既可能记得新名也可能记得旧名，只匹配其一都会「搜不到
+                      // 明明在书架上的书」。归一化走与游戏库页同一份
+                      // [matchesMediaSearch]（全角/片假名/标点折叠）。
+                      if (_searchQuery.trim().isNotEmpty) {
+                        filtered = filtered.where((MediaItem item) {
+                          return matchesMediaSearch(
+                            query: _searchQuery,
+                            titles: <String>[
+                              ReaderHibikiSource.instance
+                                  .getDisplayTitleFromMediaItem(item),
+                              item.title,
+                            ],
                           );
                         }).toList();
                       }
@@ -632,6 +656,39 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     if (!ids.remove(collectionId)) ids.add(collectionId);
     unawaited(prefs.setCollapsedCollectionIds(ids));
     setState(() {});
+  }
+
+  /// P5-A 书架搜索框。形态与游戏库页工具条一致（三个库页搜索长一个样），
+  /// 搜索词只影响本次会话、不落库。
+  Widget _buildSearchBar() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: SizedBox(
+        height: 40,
+        child: TextField(
+          key: const ValueKey<String>('shelf_search_field'),
+          controller: _searchController,
+          decoration: InputDecoration(
+            isDense: true,
+            prefixIcon: const Icon(Icons.search, size: 18),
+            hintText: t.library_search,
+            border: const OutlineInputBorder(),
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            suffixIcon: _searchQuery.isEmpty
+                ? null
+                : IconButton(
+                    icon: const Icon(Icons.close, size: 18),
+                    onPressed: () {
+                      _searchController.clear();
+                      setState(() => _searchQuery = '');
+                    },
+                  ),
+          ),
+          onChanged: (String value) => setState(() => _searchQuery = value),
+        ),
+      ),
+    );
   }
 
   String _sortModeLabel(ShelfSortMode mode) => switch (mode) {

--- a/hibiki/test/media/media_search_text_test.dart
+++ b/hibiki/test/media/media_search_text_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/media_search_text.dart';
+import 'package:hibiki/src/mining/galgame_library_query.dart'
+    show normalizeGalgameSearchText;
+
+/// P5-A：书架 / 视频 / 游戏三个库页共用的搜索归一化与匹配。
+///
+/// 这套实现原本只长在游戏库页；补书架与视频搜索时上提到媒体层，游戏侧改委托。
+/// 本测试锁住两件事：① 归一化语义（全角 / 片假名 / 标点折叠）；② 游戏侧委托后
+/// 与共享实现**逐字符一致**（防有人日后改一边忘另一边）。
+void main() {
+  group('normalizeMediaSearchText', () {
+    test('全角 ASCII 折成半角、大写折成小写', () {
+      expect(normalizeMediaSearchText('ＦＡＴＥ'), 'fate');
+      expect(normalizeMediaSearchText('Fate'), 'fate');
+    });
+
+    test('片假名折成平假名（基本区）', () {
+      expect(normalizeMediaSearchText('カタカナ'), 'かたかな');
+      // 已经是平假名的保持不变。
+      expect(normalizeMediaSearchText('かたかな'), 'かたかな');
+    });
+
+    test('空白与常见标点被丢弃（含全角空格、中点、长音符）', () {
+      expect(normalizeMediaSearchText('fate stay night'), 'fatestaynight');
+      expect(normalizeMediaSearchText('Fate／stay night'), 'fatestaynight');
+      expect(normalizeMediaSearchText('ＦＡＴＥ・ｓｔａｙ'), 'fatestay');
+      expect(normalizeMediaSearchText('　全角空格'), '全角空格');
+      expect(normalizeMediaSearchText('ラーメン'), 'らめん'); // 长音符丢弃
+    });
+
+    test('空串返回空串（不抛）', () {
+      expect(normalizeMediaSearchText(''), '');
+    });
+  });
+
+  group('matchesMediaSearch', () {
+    test('空查询恒命中（搜索框为空 = 不过滤）', () {
+      expect(
+        matchesMediaSearch(query: '', titles: <String>['任意']),
+        isTrue,
+      );
+      // 纯标点的查询归一化后为空，同样视作不过滤。
+      expect(
+        matchesMediaSearch(query: '・・・', titles: <String>['任意']),
+        isTrue,
+      );
+    });
+
+    test('排版差异不挡命中：全角/片假名/中点/空格', () {
+      const List<String> titles = <String>['Fate／stay night'];
+      for (final String q in <String>[
+        'fate stay night',
+        'ＦＡＴＥ・ｓｔａｙ',
+        'staynight',
+        'FATE',
+      ]) {
+        expect(matchesMediaSearch(query: q, titles: titles), isTrue,
+            reason: '「$q」应命中 Fate／stay night');
+      }
+    });
+
+    test('多标题任一命中即算命中（记得住哪个名字是随机的）', () {
+      const List<String> titles = <String>['原名カタカナ', '改过的显示名'];
+      expect(matchesMediaSearch(query: 'かたかな', titles: titles), isTrue);
+      expect(matchesMediaSearch(query: '显示名', titles: titles), isTrue);
+    });
+
+    test('真不匹配时返回 false（不是恒真）', () {
+      expect(
+        matchesMediaSearch(query: 'zzz不存在', titles: <String>['Fate']),
+        isFalse,
+      );
+    });
+
+    test('空标题列表：非空查询不命中', () {
+      expect(
+        matchesMediaSearch(query: 'fate', titles: const <String>[]),
+        isFalse,
+      );
+    });
+  });
+
+  test('游戏侧 normalizeGalgameSearchText 委托后与共享实现逐字符一致', () {
+    for (final String s in <String>[
+      'Fate／stay night',
+      'ＦＡＴＥ・ｓｔａｙ',
+      'カタカナ　テスト',
+      'ラーメン',
+      '「括弧」〜波ダッシュ…',
+      '',
+    ]) {
+      expect(normalizeGalgameSearchText(s), normalizeMediaSearchText(s),
+          reason: '委托必须逐字符一致：$s');
+    }
+  });
+}

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -533,6 +533,151 @@ void main() {
     );
   });
 
+  /// BUG-1110/BUG-1111 公共装配：塞一个游戏行；[playedAt] 非空则再塞一条游玩会话
+  /// （仓储的 lastPlayedMs 由 `galgame_sessions` 现算，不是 `galgames` 上的列）。
+  Future<void> seedGame({
+    required String id,
+    required String name,
+    required DateTime addedAt,
+    DateTime? playedAt,
+    String? coverPath,
+  }) async {
+    await db.upsertGalgame(GalgamesCompanion(
+      id: Value(id),
+      name: Value(name),
+      exePath: Value('/abs/$id.exe'),
+      workdir: const Value('/abs'),
+      addedAt: Value(addedAt.millisecondsSinceEpoch),
+      coverPath: Value(coverPath),
+    ));
+    if (playedAt != null) {
+      await db.insertGalgameSession(GalgameSessionsCompanion(
+        gameId: Value(id),
+        startMs: Value(playedAt.millisecondsSinceEpoch - 60000),
+        endMs: Value(playedAt.millisecondsSinceEpoch),
+        durationSeconds: const Value(60),
+        dateKey: Value(HibikiTimeFormat.dayKey(playedAt)),
+      ));
+    }
+  }
+
+  testWidgets('BUG-1110：玩过的游戏进「继续」区，且「游戏」筛选档只留游戏', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final DateTime now = DateTime.now();
+    // 在看的视频（进继续区）+ 玩过的游戏（本条修复前**结构上进不来**）。
+    // 刻意不设 importedAt：让视频只出现在「继续」区，不进「最近添加」——否则
+    // 下面按文本断言「游戏档滤掉视频」会被「最近添加」里的同名卡干扰。
+    await db.upsertVideoBook(const VideoBooksCompanion(
+      bookUid: Value('v-1'),
+      title: Value('某视频'),
+      videoPath: Value('/abs/v1.mp4'),
+      lastPositionMs: Value(5000),
+    ));
+    await seedGame(
+      id: 'g-1',
+      name: '某游戏',
+      addedAt: now.subtract(const Duration(days: 3)),
+      playedAt: now,
+    );
+
+    await tester.pumpWidget(buildApp());
+    await pumpDashboard(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(t.home_continue), findsOneWidget);
+    // 游戏出现在「继续」区（修复前恒不出现）。
+    expect(find.text('某游戏'), findsWidgets);
+
+    // 「游戏」筛选档存在（与热力图同一组档位），点它只剩游戏、视频被滤掉。
+    // 页面上有两组档位：热力图（置顶）在前、「继续」在后——必须点后者，
+    // 点 .first 改的是热力图筛选，继续区纹丝不动。
+    // 必须锁到「继续」区块自己的 chip：页面上共有三组档位（热力图 / 继续 /
+    // 活动时间轴）都含「游戏」档，且游戏卡的状态副标题本身也是「游戏」——
+    // 按裸文本或按树序取都会点错。`_sectionCard` 外层是 DecoratedBox，
+    // find.ancestor 由近及远，第一个即本区块卡。
+    final Finder continueCard = find
+        .ancestor(
+          of: find.text(t.home_continue),
+          matching: find.byType(DecoratedBox),
+        )
+        .first;
+    final Finder gameChip = find.descendant(
+      of: continueCard,
+      matching: find.widgetWithText(ChoiceChip, t.home_filter_game),
+    );
+    expect(gameChip, findsOneWidget);
+    await tester.tap(gameChip);
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(find.text('某游戏'), findsWidgets);
+    expect(find.text('某视频'), findsNothing);
+  });
+
+  testWidgets('BUG-1110：新添加的游戏进「最近添加」（类型 · 相对时间）', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    // 只添加、没玩过：不进「继续」，只进「最近添加」（与视频「只导入」同口径）。
+    await seedGame(id: 'g-2', name: '刚加的游戏', addedAt: DateTime.now());
+
+    await tester.pumpWidget(buildApp());
+    await pumpDashboard(tester);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(t.home_recently_added), findsOneWidget);
+    expect(find.text('刚加的游戏'), findsWidgets);
+    expect(
+      find.text('${t.home_filter_game} · ${t.activity_just_now}'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('BUG-1111：活动时间轴的游戏条目渲染封面，不再只有回退图标', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    // 真封面文件：1x1 PNG（Image.file 需要真实可解码文件）。
+    final File cover = File('${storeDir.path}/g3_cover.png')
+      ..writeAsBytesSync(_kOnePixelPng);
+
+    final DateTime now = DateTime.now();
+    await seedGame(
+      id: 'g-3',
+      name: '有封面的游戏',
+      addedAt: now,
+      playedAt: now,
+      coverPath: cover.path,
+    );
+    // 时间轴的游戏行：mediaKey = galgames.id（据此反查封面）。
+    await db.addActivityEvent(
+      eventType: kActivityGame,
+      mediaType: kActivityMediaGame,
+      title: '有封面的游戏',
+      dateKey: HibikiTimeFormat.dayKey(now),
+      timestampMs: now.millisecondsSinceEpoch,
+      mediaKey: 'g-3',
+      durationMs: 60000,
+    );
+
+    await tester.pumpWidget(buildApp());
+    await pumpDashboard(tester);
+
+    expect(tester.takeException(), isNull);
+    // 修复前游戏走「回退原类型图标」分支，时间轴上不会有任何 Image.file。
+    final Finder fileImages = find.byWidgetPredicate(
+      (Widget w) => w is Image && w.image is FileImage,
+    );
+    expect(fileImages, findsWidgets,
+        reason: '游戏活动条应渲染 galgames.coverPath 封面（BUG-1111）');
+  });
+
   /// 合集 Next-Up 三态的公共装配：合集「进击的巨人」+ 两集独立行 E1/E2。
   Future<int> seedCollectionTwoEpisodes({
     required VideoBooksCompanion e1,
@@ -832,3 +977,17 @@ void main() {
     expect(find.byType(StatContributionHeatmap), findsOneWidget);
   });
 }
+
+/// 1x1 透明 PNG：BUG-1111 需要一个**真实可解码**的封面文件（`Image.file` 对不存在
+/// 或损坏的文件走 errorBuilder，断言不到 FileImage）。
+const List<int> _kOnePixelPng = <int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+  0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+  0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+  0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+  0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+  0x42, 0x60, 0x82,
+];

--- a/hibiki/test/pages/home_video_batch_collection_ops_test.dart
+++ b/hibiki/test/pages/home_video_batch_collection_ops_test.dart
@@ -231,8 +231,10 @@ void main() {
         .tap(find.byKey(const ValueKey<String>('home_video_batch_combine')));
     await tester.pumpAndSettle();
     // 合并弹命名框，默认名 = 成员最多合集名（大集，3 > 2）。
+    // 库页自 P5-A 起有常驻搜索框（key=video_search_field），全页 EditableText
+    // 不止一个。命名弹窗是压在页面之上的 route，其输入框在树序最后。
     final EditableText field = tester.widget<EditableText>(
-      find.byType(EditableText),
+      find.byType(EditableText).last,
     );
     expect(field.controller.text, '大集', reason: '默认名=成员最多合集名');
     await tester.tap(find.text(t.dialog_ok));

--- a/hibiki/test/pages/home_video_page_menu_test.dart
+++ b/hibiki/test/pages/home_video_page_menu_test.dart
@@ -541,7 +541,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_1.png',
-        text: 'cover-one',
+        bytes: _kOnePixelPng,
       ),
       subtitle: writeAppOwnedAsset(
         dirName: VideoStorage.subtitlesDirName,
@@ -555,7 +555,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_2.png',
-        text: 'cover-two',
+        bytes: _kOnePixelPng,
       ),
       subtitle: writeAppOwnedAsset(
         dirName: VideoStorage.subtitlesDirName,
@@ -608,7 +608,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_1.png',
-        text: 'cover-one',
+        bytes: _kOnePixelPng,
       ),
       subtitle: sharedSubtitle,
     );
@@ -618,7 +618,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_2.png',
-        text: 'cover-two',
+        bytes: _kOnePixelPng,
       ),
       subtitle: writeAppOwnedAsset(
         dirName: VideoStorage.subtitlesDirName,
@@ -632,7 +632,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_3.png',
-        text: 'cover-three',
+        bytes: _kOnePixelPng,
       ),
       subtitle: sharedSubtitle,
     );
@@ -688,7 +688,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_1.png',
-        text: 'cover-one',
+        bytes: _kOnePixelPng,
       ),
       subtitle: writeAppOwnedAsset(
         dirName: VideoStorage.subtitlesDirName,
@@ -702,7 +702,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_2.png',
-        text: 'cover-two',
+        bytes: _kOnePixelPng,
       ),
       subtitle: writeAppOwnedAsset(
         dirName: VideoStorage.subtitlesDirName,
@@ -816,3 +816,18 @@ void main() {
     );
   });
 }
+
+/// 合法 1x1 PNG：封面 fixture 必须是**真能解码**的图片。此前写的是纯文本
+/// （'cover-one'），只因当时布局下封面没被绘制才没暴露；P5-A 加了库页搜索框后
+/// 布局变化让封面真的进了绘制，Image.file 解码即抛 'Invalid image data'。
+const List<int> _kOnePixelPng = <int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+  0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+  0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+  0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+  0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+  0x42, 0x60, 0x82,
+];


### PR DESCRIPTION
## 来源

用户反馈（2026-07-26）：

> 游戏的标签呢。首页的继续里面没有游戏。最近添加里面。活动里面没有封面，名字也不一样，游戏改名，这里没改名。**全是因为各个地方代码不统一**

逐条沿代码路径查证，结论如下（三条真缺口 + 一条已修未发版）：

| 反馈 | 查证 | 处置 |
|---|---|---|
| 「继续」里没有游戏 | ✅ 真 · 结构性 | 本 PR 修（BUG-1111） |
| 「最近添加」里没有游戏 | ✅ 真 · 同一函数同一根因 | 本 PR 修（BUG-1111） |
| 活动里没有封面 | ✅ 真 · 游戏被**写死**在图标回退分支 | 本 PR 修（BUG-1112） |
| 游戏改名这里没改名 | ⚠️ 已修**未发版**（P4 在 #431，用户报告时未合入 develop） | 不重复修 |
| 游戏没有标签 | ✅ 真 · **schema 缺表** | 单独建档 BUG-1113，**不在本 PR** |

## BUG-1111：根因是数据结构，不是漏写分支

`_ContinueEntry` 的字段是 `final bool isVideo` —— **二元标志在结构上就装不下第三种媒体**。「继续」`_buildContinueSection` 与「最近添加」`_buildRecentlyAddedSection` 都只从 `books` + `_videos` 两个来源构造条目，游戏被永久排除。这不是某处忘了加 `if`。

连带缺陷：筛选「阅读」档的判据是 `!e.isVideo` —— **二元取反**，游戏一旦进列表就会被误算进「阅读」。

值得注意的是数据侧一直是齐的：同页热力图早就有「游戏」档（`kActivityGame` 日聚合），`GalgameEntry` 也一直带着 `coverPath` / `lastPlayedMs` / `addedAt`。缺的只是这个展示结构。

### 改法

- `isVideo`(bool) → `kind`(`MediaKind`，P5 枚举地基) + 新增 `game` 字段；派生 `isBook` / `isVideo` / `isGame` 三个 getter。书按真实身份区分 `epub` / `srt`（新增 `_bookMediaKind`），不再把身份抹平成一个 bool。
- 「继续」纳入 `lastPlayedMs > 0` 的游戏。游戏**没有完成度概念**（`galgames` 无 `completedAt`），所以不做「未完成」过滤；淹没风险由既有的 `recentMs` 倒序 + `take(10)` 兜住。
- 「最近添加」纳入游戏（`addedAt` 与书/视频的 `importedAt` 同量纲，直接混排）。
- 「阅读」档改**正面判定** `e.isBook`；新增第 4 档「游戏」，复用既有 i18n key `home_filter_game`（与热力图同一组档位，**不新增 key**）。
- 游戏卡走竖版封面宽度（同书）；状态段用类型名，不套书的「阅读 · x%」（否则一律显示「阅读 · 0%」）。
- 游戏卡点击**切到游戏 tab，不直接拉起游戏**：启动 galgame 要走位数探测 / helper 确认下载 / 注入会话（数秒且可能弹窗），从首页静默触发是危险的误操作面，库页才是启动入口。

## BUG-1112：活动时间轴游戏封面是被写死掉的

`_activityLeading` 只有 video 与 book 两个封面分支，游戏落到末尾回退。该函数自己的注释就写着「查不到（已删 / 远端 display-only 行 / **游戏** / 导入无封面）回退原类型图标」——游戏是被显式列进回退清单的，不是取图失败。

而封面一直在 `GalgameEntry.coverPath`（本机文件：目录扫描 / exe 内嵌图标 / 刮削下载三种来源都落成本地文件），活动行的 `mediaKey` 就是 `galgames.id`，反查即可。

改法：新增 `kActivityMediaGame` 分支走新的 `_gameCover`（与视频封面同形态，`Image.file` + 占位兜底），尺寸取与书相同的竖版 40×56；顺手抽出 `_gameById` 复用，消掉 `_gameDisplayTitle` 里原有的一处线性查找重复。

## 为什么游戏标签（BUG-1113）不在这个 PR

标签映射表只有 `BookTagMappings` / `SrtBookTagMappings` / `VideoBookTagMappings` / `CollectionTagMappings` 四张，**没有游戏的**。标签池与筛选 UI 其实早已是书架/视频共用，唯独游戏没有落表所以接不进来——这条**改 UI 修不了**，要加表 + schema 迁移，而且得先定跨端同步语义（游戏是**本机局域身份** `galgames.id`，对端没有对应行时标签成员该静默忽略还是不同步）。

把不可逆的 DB 迁移和纯展示层改动塞进同一个 PR 会让两种风险绑在一起，所以单独建档、单独做。

## 验证

- `flutter analyze` hibiki 全量（含 test 目录）：**No issues found**
- `flutter test test/pages test/tools`：**2363 passed**（exit 0），含 3 条新用例：
  - 玩过的游戏进「继续」区，且「游戏」筛选档只留游戏（含视频被滤掉的断言）
  - 新添加的游戏进「最近添加」（类型 · 相对时间）
  - 活动时间轴的游戏条目渲染封面，不再只有回退图标（塞真实 1x1 PNG，断言出现 `FileImage`）

## 尚未做

- **未做真机复测**。首页三区块的实际渲染属 UI 行为，按仓库规则在真机复验前不宣称「已修好」。

---

# 第二部分：P5-A 书架/视频补搜索（同分支追加）

用户在本轮拍板 P5 走 **A 方案**：给书架/视频补搜索，复用游戏那套已验证的归一化纯函数。因为改动同属「媒体层统一」主题且基于同一分支，未另开分支（不做 force-push 重写已推送历史）。

## 为什么这不是「三套实现去重」

查证结论：**只有游戏库页有搜索**，书架页与视频页全文无 `search` 符号——**根本没有搜索入口**。所以「搜索统一」实际是补功能。

但归一化必须共用：同一个库、同一批日文标题，在三个页面搜出不同结果，比没有搜索更难解释。

## 改动

- 新增 `hibiki/lib/src/media/media_search_text.dart`：`normalizeMediaSearchText`（实现自游戏页原样上提，逐字符逻辑未改）+ `matchesMediaSearch`。
- `galgame_library_query.dart` 的 `normalizeGalgameSearchText` / `matchesGalgameSearch` 改委托，删掉重复的丢弃字符集副本。**保留原函数名**——它们是该文件公开 API、已被游戏库页与单测引用，改名无收益只破坏调用方。
- 书架页 / 视频页各加常驻搜索框（key `shelf_search_field` / `video_search_field`），形态与游戏库页一致。
- 书架搜索按**显示名 + DB 原名**双口径匹配：改过名的书，用户既可能记得新名也可能记得旧名，只匹配其一都会「搜不到明明在书架上的书」。
- 搜索词**不持久化**（三页同一决定）：下次进页面还挂着上次的搜索词只会让人以为库空了。
- 新 i18n key `library_search`，经 `tool/i18n_sync.dart` 补齐 17 语言 + 重跑 slang。

## 顺带修的两处既有测试脆弱点（不是掩盖，是 fixture 本身有错）

布局变化把两处一直存在的问题暴露了出来：

1. `home_video_batch_collection_ops_test`：`find.byType(EditableText)` 假设全页只有一个输入框，库页有了常驻搜索框后命中 2 个 → 改取树序最后一个（命名弹窗是压在页面之上的 route）。
2. `home_video_page_menu_test`：**7 处封面 fixture 写的是纯文本 `'cover-one'` 而非图片字节**。此前布局下封面没被绘制才没暴露；加搜索框后封面真的进了绘制，`Image.file` 解码即抛 `Invalid image data` → 改写合法 1x1 PNG。

## 第二部分验证

- `flutter analyze` hibiki 全量（含 test）：**No issues found**
- `flutter test test/pages + test/media + test/mining + test/i18n`：**6385 passed**（exit 0）
- `flutter test test/goldens`：**35 passed**（布局改动无 golden 回归）
- 新增 `test/media/media_search_text_test.dart` **10 个用例**：归一化语义（全角/片假名/标点/长音符）、匹配语义（空查询恒命中、多标题任一命中、真不匹配为 false）、以及**游戏侧委托后与共享实现逐字符一致**（防日后改一边忘另一边）
- 游戏侧回归：`test/mining` 799 passed，确认提取为纯重构、零行为变化

> 期间遇到一次 `home_video_remote_download_register_test` 批量跑失败、单独跑与重跑批量均通过，判定为 flaky，非本改动引入。

## 第二部分尚未做

- **搜索 UI 未真机验收**（书架/视频两页的搜索框实际交互）。按仓库规则在真机复验前不宣称完成。


---

## 补充：BUG 号已第四次上移（2026-07-26）

本分支开工时取的 1110/1111/1112 在开 PR 后又被 develop 占用（PR#435 拿了 BUG-1110「捕获工作台窄屏藏降级原因」）。三条按序上移为 **BUG-1111 / BUG-1112 / BUG-1113**，文件名 + 正文 H2 + 三条文档互相引用 + 代码/测试引用（`home_dashboard_page.dart` 11 处、`home_dashboard_page_test.dart` 7 处）同步改；develop 自己的 BUG-1110 文档与 `texthooker_narrow_degrade_reason_guard_test.dart` 的 6 处引用**未动**（逐一核对）。

`dart run tool/bug.dart check` 通过：1080 条，号唯一、索引同步。
