### PR TITLE
feat(torrent): 改名/移动下载内容不掐断做种 (TODO-1961-② 完整 a→e)

### DIFF
--- a/.github/workflows/build-multiplatform.yml
+++ b/.github/workflows/build-multiplatform.yml
@@ -16,6 +16,9 @@ on:
     paths: &multiplatform_paths
       - 'hibiki/**'
       - 'packages/**'
+      # C ABI bridge 源码：只改 native/ 的 PR 以前触发不了任何构建，
+      # 编译挂了要等下一个不相关改动才暴露。
+      - 'native/**'
       - 'ci/**'
       - 'third_party/**'
       - '.github/workflows/build-multiplatform.yml'
@@ -725,6 +728,27 @@ jobs:
           & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install libtorrent:x64-windows
           if ($LASTEXITCODE -ne 0) { throw "vcpkg install libtorrent failed" }
           powershell -ExecutionPolicy Bypass -File native/hibiki_torrent/build_windows_dll.ps1 -VcpkgRoot "$env:VCPKG_INSTALLATION_ROOT"
+      # `packages/hibiki_torrent` 的测试是**唯一**会真正 dlopen 这个 bridge、
+      # 把 Dart FFI 绑定按真实 ABI 调一遍的地方；它们要 HIBIKI_TORRENT_LIB 指向
+      # 已构建的 DLL，所以在 Linux 上永远整组 skip，main.yml / release.yml 的
+      # 包测试清单里也没收录这个包 —— 换句话说，改 C ABI 在 CI 里原本无人可挡。
+      #
+      # 这个 job 上面刚好已经把 DLL 编出来了，跑一遍近乎零边际成本，且这是唯一
+      # 能验证「新 DLL + 新绑定」真能对上的地方（纯文本层的漂移由
+      # hibiki/test/media/torrent/torrent_ffi_bindings_parity_guard_test.dart
+      # 在所有平台兜底）。
+      - name: Run hibiki_torrent FFI tests against the freshly built DLL
+        shell: pwsh
+        working-directory: packages/hibiki_torrent
+        env:
+          HIBIKI_TORRENT_LIB: ${{ github.workspace }}\native\hibiki_torrent\prebuilt\windows-x64\hibiki_torrent_ffi.dll
+        run: |
+          if (-not (Test-Path -LiteralPath $env:HIBIKI_TORRENT_LIB)) {
+            throw "DLL not found at $env:HIBIKI_TORRENT_LIB — the build step above should have produced it"
+          }
+          dart pub get
+          dart test
+          if ($LASTEXITCODE -ne 0) { throw "hibiki_torrent FFI tests failed" }
       # Windows is the ONLY platform that renders EPUB via the forked
       # flutter_inappwebview_windows C++ plugin; an MSVC/native break here was
       # previously invisible to CI (the audit: Windows never built anywhere).

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ on:
     paths:
       - 'hibiki/**'
       - 'packages/**'
+      # C ABI bridge 源码：只改 native/ 的 PR 以前触发不了任何构建，
+      # 编译挂了要等下一个不相关改动才暴露。
+      - 'native/**'
       - 'ci/**'
       - '.github/workflows/**'
       - 'melos.yaml'

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -12,6 +12,9 @@ on:
     paths:
       - 'hibiki/**'
       - 'packages/**'
+      # C ABI bridge 源码：只改 native/ 的 PR 以前触发不了任何构建，
+      # 编译挂了要等下一个不相关改动才暴露。
+      - 'native/**'
       - 'ci/**'
       - 'tool/**'
       - 'third_party/**'

--- a/docs/specs/2026-07-26-download-dir-configurable-and-rename-seeding-eval.md
+++ b/docs/specs/2026-07-26-download-dir-configurable-and-rename-seeding-eval.md
@@ -91,11 +91,11 @@ Dart 侧也没有任何「启动时重新 add 已有种子」的路径（`addTor
    原计划「把 `ht_poll_piece_events` 泛化成 `ht_poll_alerts`」。实际做法更进一步：
    问题不在于「缺一条通用通道」，而在于 **`pop_alerts` 是破坏性的，却有多个消费者**。
    故改成「一个 session 一个收割点 + 按类型分派进各自队列」，加通道不再需要动契约。
-3. **TODO-1961-c｜`ht_rename_file` / `ht_move_storage` + Dart 绑定 + qb 后端对齐**
-4. **TODO-1961-d｜库路径迁移 API**
+3. **TODO-1961-c｜`ht_rename_file` / `ht_move_storage` + Dart 绑定 + qb 后端对齐** —— ✅ **已落地**
+4. **TODO-1961-d｜库路径迁移 API** —— ✅ **已落地**
    `updateVideoPath` + 字幕 sidecar 路径同步更新；与 c 在同一个用户操作里原子完成
    （引擎移动成功 → 库改路径；引擎失败 → 库不动）。
-5. **TODO-1961-e｜UI：下载页「重命名 / 移动」入口**
+5. **TODO-1961-e｜UI：下载页「重命名 / 移动」入口** —— ✅ **已落地**
    让用户在 Hibiki 内做这件事，而不是在资源管理器里改完再来救。
    资源管理器里手动改名**永远**救不回来（app 收不到通知），这一点应当在设置页说明里写清。
 
@@ -141,11 +141,57 @@ Dart 侧也没有任何「启动时重新 add 已有种子」的路径（`addTor
 种子回来、`hasMetadata` 为真、`numPeers == 0`、每个 piece 都在、进入做种态。
 零 peer 是这个测试的全部说服力：完成度只可能来自磁盘，不可能是重下的。
 
-### 还没做的（c/d/e 原样保留）
+## 7. c/d/e 落地记录（2026-07-26，同批）
 
-「用户改名 / 移动后不掐做种」仍未实现 —— 那要 `ht_rename_file` /
-`ht_move_storage`（c）与库路径迁移 API（d）成对落地，UI 入口是 e。
-本轮只是把它们的前置依赖补上了。
+用户明确选了「**在 Hibiki 内改名/移动**」这条路（另一条「在资源管理器里改完希望
+app 跟上」技术上救不回来，见第 8 节）。第 2 节选定的路线 C 全部实现。
+
+### 改了什么
+
+| 层 | 改动 |
+|---|---|
+| C++ (c) | `ht_rename_file` / `ht_move_storage`；`drain_alerts` 增加 `file_renamed` / `file_rename_failed` / `storage_moved` / `storage_moved_failed` 四种回执分派；`StorageOp` 回执槽 + `await_storage_op` 统一等待 |
+| Dart 包 (c) | `EmbeddedTorrentSession.renameFile/moveStorage` + `HtStorageOpResult` |
+| 后端契约 (c) | `TorrentBackend.renameFile/moveStorage` + `TorrentStorageResult`；内置引擎直通，外接 qb 走 `renameFile` / `setLocation`（qb 认旧相对路径，故 backend 先用文件列表把下标翻成路径） |
+| 库 (d) | `video_path_migration.dart`（纯函数重映射规则）+ `VideoBookRepository.migrateMediaPaths`（三列、一个事务） |
+| 编排 (c+d) | `DownloadRelocateService`：引擎先动、成了再迁库 |
+| UI (e) | 下载任务行「重命名 / 移动」入口 + `_RelocateDialog`（移动整个任务 / 逐文件改名）；8 个 i18n key × 17 语言 |
+
+### 关键判断
+
+- **`move_storage` 用 `fail_if_exist`**。libtorrent 默认是 `always_replace_files`
+  —— 直接覆盖目标同名文件，对用户数据太危险；`dont_replace` 则会静默跳过已存在
+  的文件、留下搬了一半的内容目录。只有「目标非空就整体失败、让用户自己决定」是
+  可接受的默认。守卫：`rename_move_seeding_test.dart` 的
+  「refuses to overwrite an existing file at the destination」用例断言占位文件
+  一个字节没变、源内容也还在。
+- **失败态必须是「什么都没变」**。所以顺序是引擎先、库后：引擎那步才是会失败的
+  一步（目标已存在 / 权限 / 超时），它失败就直接返回，库一个字节不动。反过来
+  先改库的话，引擎一失败库就指向一个磁盘上不存在的路径。
+- **字幕列的哨兵绝不能当路径重写**。`subtitleSource` 是四态编码
+  （绝对路径 / `embedded:<n>` / `off:` / null），把 `embedded:0` 当路径拼一遍
+  就是静默损坏。`remapMediaPath` 逐个排除哨兵与流媒体 URL，且路径比较一律走
+  `package:path`（手写 `startsWith` 会让 `D:\a` 误匹配 `D:\ab`）。
+- **三种结局不能混为一谈**：`success` / `engineFailed`（磁盘与库都没动）/
+  `libraryFailed`（磁盘动了、库没跟上）。最后一种必须如实告诉用户，不能当成功。
+
+### 证据
+
+- `packages/hibiki_torrent/test/rename_move_seeding_test.dart`（5 用例）：改名 /
+  改到子目录 / 移动，每一项都断言**磁盘上真的变了 + 旧路径消失 + 每个 piece 还在
+  + 仍处于做种态**。做种态是关键：引擎要是丢了数据，libtorrent 会掉出 seeding
+  并把 piece 标成缺失。
+- `hibiki/test/media/torrent/download_relocate_service_test.dart`（15 用例）：
+  重映射规则的全部边界 + 原子性（引擎失败时库一个字节不动 / 库失败不许报成功 /
+  目标同现状时两边都不打扰）。
+
+## 8. 明确做不到的事
+
+用户**在资源管理器里**改名或移动下载内容，Hibiki **永远**无法自动跟上：app 收不到
+任何文件系统通知，等下一轮轮询时引擎按旧路径读盘已经失败了。这一点写进了改名
+对话框的说明文案（`anime_download_relocate_hint`）。能给的最好结果是本轮实现的
+「在 app 内改名/移动」；将来若要缓解手动改名的后果，方向是「检测到文件失踪时提示
+用户手动重新定位」，那是另一个独立能力，不属于本 TODO。
 
 ### 顺带记录
 

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45594 (2682 per locale)
+/// Strings: 45747 (2691 per locale)
 ///
-/// Built on 2026-07-26 at 17:55 UTC
+/// Built on 2026-07-26 at 18:44 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3566,6 +3566,20 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  String get anime_download_relocate => 'Rename / move';
+  String get anime_download_relocate_rename_title => 'Rename file';
+  String get anime_download_relocate_move_title => 'Move to folder';
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -9660,6 +9674,29 @@ class _StringsAr extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -15827,6 +15864,29 @@ class _StringsDe extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -22010,6 +22070,29 @@ class _StringsEs extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -28204,6 +28287,29 @@ class _StringsFr extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -34325,6 +34431,29 @@ class _StringsId extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -40494,6 +40623,29 @@ class _StringsIt extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -46468,6 +46620,29 @@ class _StringsJa extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -52445,6 +52620,29 @@ class _StringsKo extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -58592,6 +58790,29 @@ class _StringsNl extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -64754,6 +64975,29 @@ class _StringsPtBr extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -70899,6 +71143,29 @@ class _StringsRu extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -76989,6 +77256,29 @@ class _StringsTh extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -83111,6 +83401,29 @@ class _StringsTr extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -89220,6 +89533,29 @@ class _StringsVi extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 // Path: <root>
@@ -94907,6 +95243,28 @@ class _StringsZhCn extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end}（时长 ${duration} / 共 ${total}）';
+  @override
+  String get anime_download_relocate => '重命名 / 移动';
+  @override
+  String get anime_download_relocate_rename_title => '重命名文件';
+  @override
+  String get anime_download_relocate_move_title => '移动到文件夹';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki 通过下载引擎改名/移动，因此不会掐断做种。在资源管理器里改名则永远无法挽回。';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      '已改名 / 移动，同步更新 ${rows} 个库条目';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      '失败，磁盘与库都未改动：${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      '文件已移动，但库仍指向旧路径：${reason}';
+  @override
+  String get anime_download_relocate_no_files => '该任务还没有可改名的文件（元数据未就绪）';
+  @override
+  String get anime_download_relocate_pick_folder => '选择目标文件夹';
 }
 
 // Path: <root>
@@ -100799,6 +101157,29 @@ class _StringsZhHk extends _StringsEn {
           required Object duration,
           required Object total}) =>
       '${start} - ${end} (selected ${duration} / total ${total})';
+  @override
+  String get anime_download_relocate => 'Rename / move';
+  @override
+  String get anime_download_relocate_rename_title => 'Rename file';
+  @override
+  String get anime_download_relocate_move_title => 'Move to folder';
+  @override
+  String get anime_download_relocate_hint =>
+      'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+  @override
+  String anime_download_relocate_ok({required Object rows}) =>
+      'Renamed / moved; ${rows} library entries updated';
+  @override
+  String anime_download_relocate_engine_failed({required Object reason}) =>
+      'Failed, nothing changed: ${reason}';
+  @override
+  String anime_download_relocate_library_failed({required Object reason}) =>
+      'Files moved, but the library still points at the old path: ${reason}';
+  @override
+  String get anime_download_relocate_no_files =>
+      'This task has no files to rename yet (metadata not ready)';
+  @override
+  String get anime_download_relocate_pick_folder => 'Choose destination folder';
 }
 
 /// Flat map(s) containing all translations.
@@ -106281,6 +106662,27 @@ extension on _StringsEn {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -111761,6 +112163,27 @@ extension on _StringsAr {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -117262,6 +117685,27 @@ extension on _StringsDe {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -122762,6 +123206,27 @@ extension on _StringsEs {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -128268,6 +128733,27 @@ extension on _StringsFr {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -133756,6 +134242,27 @@ extension on _StringsId {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -139259,6 +139766,27 @@ extension on _StringsIt {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -144724,6 +145252,27 @@ extension on _StringsJa {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -150193,6 +150742,27 @@ extension on _StringsKo {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -155689,6 +156259,27 @@ extension on _StringsNl {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -161182,6 +161773,27 @@ extension on _StringsPtBr {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -166680,6 +167292,27 @@ extension on _StringsRu {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -172162,6 +172795,27 @@ extension on _StringsTh {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -177653,6 +178307,27 @@ extension on _StringsTr {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -183139,6 +183814,27 @@ extension on _StringsVi {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }
@@ -188582,6 +189278,24 @@ extension on _StringsZhCn {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end}（时长 ${duration} / 共 ${total}）';
+      case 'anime_download_relocate':
+        return '重命名 / 移动';
+      case 'anime_download_relocate_rename_title':
+        return '重命名文件';
+      case 'anime_download_relocate_move_title':
+        return '移动到文件夹';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki 通过下载引擎改名/移动，因此不会掐断做种。在资源管理器里改名则永远无法挽回。';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) => '已改名 / 移动，同步更新 ${rows} 个库条目';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) => '失败，磁盘与库都未改动：${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) => '文件已移动，但库仍指向旧路径：${reason}';
+      case 'anime_download_relocate_no_files':
+        return '该任务还没有可改名的文件（元数据未就绪）';
+      case 'anime_download_relocate_pick_folder':
+        return '选择目标文件夹';
       default:
         return null;
     }
@@ -194042,6 +194756,27 @@ extension on _StringsZhHk {
                 required Object duration,
                 required Object total}) =>
             '${start} - ${end} (selected ${duration} / total ${total})';
+      case 'anime_download_relocate':
+        return 'Rename / move';
+      case 'anime_download_relocate_rename_title':
+        return 'Rename file';
+      case 'anime_download_relocate_move_title':
+        return 'Move to folder';
+      case 'anime_download_relocate_hint':
+        return 'Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.';
+      case 'anime_download_relocate_ok':
+        return ({required Object rows}) =>
+            'Renamed / moved; ${rows} library entries updated';
+      case 'anime_download_relocate_engine_failed':
+        return ({required Object reason}) =>
+            'Failed, nothing changed: ${reason}';
+      case 'anime_download_relocate_library_failed':
+        return ({required Object reason}) =>
+            'Files moved, but the library still points at the old path: ${reason}';
+      case 'anime_download_relocate_no_files':
+        return 'This task has no files to rename yet (metadata not ready)';
+      case 'anime_download_relocate_pick_folder':
+        return 'Choose destination folder';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "排队中",
   "download_status_cancelled": "已取消",
   "game_waveform_select_title": "选择音频范围",
-  "game_waveform_range_label": "$start - $end（时长 $duration / 共 $total）"
+  "game_waveform_range_label": "$start - $end（时长 $duration / 共 $total）",
+  "anime_download_relocate": "重命名 / 移动",
+  "anime_download_relocate_rename_title": "重命名文件",
+  "anime_download_relocate_move_title": "移动到文件夹",
+  "anime_download_relocate_hint": "Hibiki 通过下载引擎改名/移动，因此不会掐断做种。在资源管理器里改名则永远无法挽回。",
+  "anime_download_relocate_ok": "已改名 / 移动，同步更新 $rows 个库条目",
+  "anime_download_relocate_engine_failed": "失败，磁盘与库都未改动：$reason",
+  "anime_download_relocate_library_failed": "文件已移动，但库仍指向旧路径：$reason",
+  "anime_download_relocate_no_files": "该任务还没有可改名的文件（元数据未就绪）",
+  "anime_download_relocate_pick_folder": "选择目标文件夹"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2680,5 +2680,14 @@
   "download_status_queued": "Queued",
   "download_status_cancelled": "Cancelled",
   "game_waveform_select_title": "Select audio range",
-  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)",
+  "anime_download_relocate": "Rename / move",
+  "anime_download_relocate_rename_title": "Rename file",
+  "anime_download_relocate_move_title": "Move to folder",
+  "anime_download_relocate_hint": "Hibiki renames/moves through the download engine, so seeding is not interrupted. Renaming in Explorer can never be recovered.",
+  "anime_download_relocate_ok": "Renamed / moved; $rows library entries updated",
+  "anime_download_relocate_engine_failed": "Failed, nothing changed: $reason",
+  "anime_download_relocate_library_failed": "Files moved, but the library still points at the old path: $reason",
+  "anime_download_relocate_no_files": "This task has no files to rename yet (metadata not ready)",
+  "anime_download_relocate_pick_folder": "Choose destination folder"
 }

--- a/hibiki/lib/src/media/torrent/download_relocate_service.dart
+++ b/hibiki/lib/src/media/torrent/download_relocate_service.dart
@@ -43,16 +43,22 @@ class DownloadRelocateService {
     if (trimmed.isEmpty) {
       return const RelocateOutcome.engineFailed('new name is empty');
     }
-    final String normalized = p.normalize(trimmed);
-    final List<String> segments = p.split(normalized);
-    if (p.isAbsolute(normalized) ||
+    // 种子内路径跨平台固定用 POSIX `/`；只有拼进本地 save root 时才转成
+    // 宿主分隔符。否则 Windows 会把传给 qB/libtorrent 的路径改成 `\`。
+    final String normalized =
+        p.posix.normalize(trimmed.replaceAll(r'\', '/'));
+    final List<String> segments = p.posix.split(normalized);
+    if (p.posix.isAbsolute(normalized) ||
+        p.windows.rootPrefix(trimmed).isNotEmpty ||
         normalized == '.' ||
         segments.isEmpty ||
         segments.first == '..') {
       return const RelocateOutcome.engineFailed(
           'new name must stay inside the torrent');
     }
-    if (p.equals(normalized, p.normalize(currentRelativePath))) {
+    final String normalizedCurrent =
+        p.posix.normalize(currentRelativePath.replaceAll(r'\', '/'));
+    if (normalized == normalizedCurrent) {
       // 名字没变：不打扰引擎，也不动库。
       return const RelocateOutcome.unchanged();
     }
@@ -60,7 +66,7 @@ class DownloadRelocateService {
       op: (TorrentBackend backend) =>
           backend.renameFile(infoHash, fileIndex, normalized),
       fromPath: p.join(saveRoot, currentRelativePath),
-      toPath: p.join(saveRoot, normalized),
+      toPath: p.joinAll(<String>[saveRoot, ...segments]),
     );
   }
 

--- a/hibiki/lib/src/media/torrent/download_relocate_service.dart
+++ b/hibiki/lib/src/media/torrent/download_relocate_service.dart
@@ -1,0 +1,157 @@
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki/src/media/torrent/torrent_backend.dart';
+
+/// TODO-1961-c+d：把「引擎侧改名/移动」与「库路径迁移」绑成**一个**用户操作。
+///
+/// 两件事必须成对完成，缺一即断：
+/// - 只改引擎 → 做种保住了，但库里 `videoPath` 是死路径，条目点开就是文件不存在；
+/// - 只改库 → 库对了，但引擎按旧路径读盘，做种当场断。
+///
+/// 顺序是**引擎先、库后**，因为引擎那步才是可能失败的一步（目标已存在、权限、
+/// 超时）。引擎失败就直接返回，库一个字节都不动 —— 这样失败态永远是「什么都
+/// 没变」，而不是需要人工修的半吊子状态。库那步失败则如实报告：磁盘已经动了，
+/// 用户必须知道库还指着旧路径（而不是以为整件事没发生）。
+class DownloadRelocateService {
+  const DownloadRelocateService({
+    required TorrentBackend Function() backendFactory,
+    required Future<int> Function(
+            {required String fromPath, required String toPath})
+        migrateLibraryPaths,
+  })  : _backendFactory = backendFactory,
+        _migrateLibraryPaths = migrateLibraryPaths;
+
+  final TorrentBackend Function() _backendFactory;
+  final Future<int> Function({
+    required String fromPath,
+    required String toPath,
+  }) _migrateLibraryPaths;
+
+  /// 改名：把种子内下标 [fileIndex] 的文件改成 [newRelativePath]
+  /// （种子内相对路径，可含子目录，分隔符 `/`）。
+  ///
+  /// [saveRoot] 是该种子当前的 save_path，用来把种子内相对路径拼成库里存的
+  /// 绝对路径 —— 库存的是绝对路径，重映射必须在同一坐标系里做。
+  Future<RelocateOutcome> renameFile({
+    required String infoHash,
+    required int fileIndex,
+    required String currentRelativePath,
+    required String newRelativePath,
+    required String saveRoot,
+  }) async {
+    final String trimmed = newRelativePath.trim();
+    if (trimmed.isEmpty) {
+      return const RelocateOutcome.engineFailed('new name is empty');
+    }
+    if (p.equals(p.normalize(trimmed), p.normalize(currentRelativePath))) {
+      // 名字没变：不打扰引擎，也不动库。
+      return const RelocateOutcome.unchanged();
+    }
+    return _run(
+      op: (TorrentBackend backend) =>
+          backend.renameFile(infoHash, fileIndex, trimmed),
+      fromPath: p.join(saveRoot, currentRelativePath),
+      toPath: p.join(saveRoot, trimmed),
+    );
+  }
+
+  /// 移动：把整个种子的内容搬到 [newSaveRoot]。
+  ///
+  /// 库侧按「旧 save_path → 新 save_path」整体重映射：该种子下的每个视频、每个
+  /// 字幕 sidecar 都跟着走，不需要逐文件登记。
+  Future<RelocateOutcome> moveTorrent({
+    required String infoHash,
+    required String currentSaveRoot,
+    required String newSaveRoot,
+  }) async {
+    final String trimmed = newSaveRoot.trim();
+    if (trimmed.isEmpty) {
+      return const RelocateOutcome.engineFailed('destination is empty');
+    }
+    if (p.equals(p.normalize(trimmed), p.normalize(currentSaveRoot))) {
+      return const RelocateOutcome.unchanged();
+    }
+    return _run(
+      op: (TorrentBackend backend) => backend.moveStorage(infoHash, trimmed),
+      fromPath: currentSaveRoot,
+      toPath: trimmed,
+    );
+  }
+
+  /// 共用骨架：引擎先动，成了再迁库。后端连接每次现开现关（与
+  /// `AnimeDownloadService` 每 tick 建后端的姿态一致）。
+  Future<RelocateOutcome> _run({
+    required Future<TorrentStorageResult> Function(TorrentBackend) op,
+    required String fromPath,
+    required String toPath,
+  }) async {
+    final TorrentBackend backend = _backendFactory();
+    TorrentStorageResult result;
+    try {
+      result = await op(backend);
+    } catch (e) {
+      return RelocateOutcome.engineFailed('$e');
+    } finally {
+      backend.close();
+    }
+    if (!result.ok) {
+      // 引擎没动 → 库也不动。失败态 = 什么都没变。
+      return RelocateOutcome.engineFailed(
+          result.error ?? 'backend refused the operation');
+    }
+    try {
+      final int rows =
+          await _migrateLibraryPaths(fromPath: fromPath, toPath: toPath);
+      return RelocateOutcome.success(
+          newPath: result.path ?? toPath, rows: rows);
+    } catch (e) {
+      // 磁盘已经动了，库没跟上 —— 必须如实报告，绝不当成功。
+      return RelocateOutcome.libraryFailed('$e',
+          newPath: result.path ?? toPath);
+    }
+  }
+}
+
+/// 一次改名/移动的结局。UI 据此给出不同的提示（三种情况不能混为一谈）。
+class RelocateOutcome {
+  /// 目标与现状相同：什么都没做（也不该报错）。
+  const RelocateOutcome.unchanged()
+      : status = RelocateStatus.unchanged,
+        newPath = null,
+        rowsMigrated = 0,
+        error = null;
+
+  /// 引擎拒绝/失败：**磁盘与库都没动**。
+  const RelocateOutcome.engineFailed(String reason)
+      : status = RelocateStatus.engineFailed,
+        newPath = null,
+        rowsMigrated = 0,
+        error = reason;
+
+  /// 引擎成功、库迁移失败：磁盘已经动了，库还指着旧路径（需要用户知道）。
+  const RelocateOutcome.libraryFailed(String reason, {this.newPath})
+      : status = RelocateStatus.libraryFailed,
+        rowsMigrated = 0,
+        error = reason;
+
+  /// 两步都成了。
+  const RelocateOutcome.success({required this.newPath, required int rows})
+      : status = RelocateStatus.success,
+        rowsMigrated = rows,
+        error = null;
+
+  final RelocateStatus status;
+
+  /// 新路径（改名 = 种子内相对路径；移动 = 新的 save_path）。
+  final String? newPath;
+
+  /// 库里被改到的行数（成功时有意义）。
+  final int rowsMigrated;
+
+  /// 失败原因（后端原文优先）。
+  final String? error;
+
+  bool get isSuccess => status == RelocateStatus.success;
+}
+
+enum RelocateStatus { success, unchanged, engineFailed, libraryFailed }

--- a/hibiki/lib/src/media/torrent/download_relocate_service.dart
+++ b/hibiki/lib/src/media/torrent/download_relocate_service.dart
@@ -43,15 +43,24 @@ class DownloadRelocateService {
     if (trimmed.isEmpty) {
       return const RelocateOutcome.engineFailed('new name is empty');
     }
-    if (p.equals(p.normalize(trimmed), p.normalize(currentRelativePath))) {
+    final String normalized = p.normalize(trimmed);
+    final List<String> segments = p.split(normalized);
+    if (p.isAbsolute(normalized) ||
+        normalized == '.' ||
+        segments.isEmpty ||
+        segments.first == '..') {
+      return const RelocateOutcome.engineFailed(
+          'new name must stay inside the torrent');
+    }
+    if (p.equals(normalized, p.normalize(currentRelativePath))) {
       // 名字没变：不打扰引擎，也不动库。
       return const RelocateOutcome.unchanged();
     }
     return _run(
       op: (TorrentBackend backend) =>
-          backend.renameFile(infoHash, fileIndex, trimmed),
+          backend.renameFile(infoHash, fileIndex, normalized),
       fromPath: p.join(saveRoot, currentRelativePath),
-      toPath: p.join(saveRoot, trimmed),
+      toPath: p.join(saveRoot, normalized),
     );
   }
 

--- a/hibiki/lib/src/media/torrent/embedded_torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/embedded_torrent_backend.dart
@@ -117,6 +117,24 @@ class EmbeddedTorrentBackend implements TorrentBackend {
   }
 
   @override
+  Future<TorrentStorageResult> renameFile(
+    String torrentId,
+    int fileIndex,
+    String newPath,
+  ) async =>
+      _toStorageResult(_session.renameFile(torrentId, fileIndex, newPath));
+
+  @override
+  Future<TorrentStorageResult> moveStorage(
+    String torrentId,
+    String newSavePath,
+  ) async =>
+      _toStorageResult(_session.moveStorage(torrentId, newSavePath));
+
+  static TorrentStorageResult _toStorageResult(HtStorageOpResult r) =>
+      TorrentStorageResult(ok: r.ok, path: r.path, error: r.error);
+
+  @override
   void close() {
     if (_closesSession) _session.close();
   }

--- a/hibiki/lib/src/media/torrent/qb_torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/qb_torrent_backend.dart
@@ -40,6 +40,47 @@ class QbTorrentBackend implements TorrentBackend {
   Future<List<TorrentFileEntry>> listFiles(String torrentId) =>
       _client.fetchTorrentFiles(torrentId);
 
+  /// TODO-1961-c：qb 的 renameFile 认的是**旧相对路径**而不是文件下标，
+  /// 所以先用文件列表把下标翻成路径（内置引擎那边下标就是天然主键）。
+  /// 翻不出来说明种子/下标不对，直接报错而不是猜一个路径去改。
+  @override
+  Future<TorrentStorageResult> renameFile(
+    String torrentId,
+    int fileIndex,
+    String newPath,
+  ) async {
+    final List<TorrentFileEntry> files =
+        await _client.fetchTorrentFiles(torrentId);
+    String? oldPath;
+    for (final TorrentFileEntry f in files) {
+      if (f.index == fileIndex) {
+        oldPath = f.name;
+        break;
+      }
+    }
+    if (oldPath == null) {
+      return const TorrentStorageResult.failure('file index not found');
+    }
+    final (bool ok, String? error) = await _client.renameFile(
+      hash: torrentId,
+      oldPath: oldPath,
+      newPath: newPath,
+    );
+    return TorrentStorageResult(
+        ok: ok, path: ok ? newPath : null, error: error);
+  }
+
+  @override
+  Future<TorrentStorageResult> moveStorage(
+    String torrentId,
+    String newSavePath,
+  ) async {
+    final (bool ok, String? error) =
+        await _client.setLocation(hash: torrentId, location: newSavePath);
+    return TorrentStorageResult(
+        ok: ok, path: ok ? newSavePath : null, error: error);
+  }
+
   @override
   void close() => _client.close();
 }

--- a/hibiki/lib/src/media/torrent/qbittorrent_client.dart
+++ b/hibiki/lib/src/media/torrent/qbittorrent_client.dart
@@ -202,6 +202,59 @@ class QBittorrentClient {
     return parseQbTorrentFiles(res.body);
   }
 
+  /// TODO-1961-c：改名种子内文件：`POST /api/v2/torrents/renameFile`
+  /// （qb ≥ 4.2.1，参数 hash / oldPath / newPath）。
+  ///
+  /// 与内置引擎同语义：qb 自己改，做种不断。返回 (成功, 失败原因)：
+  /// - 409 = qb 明确拒绝（目标已存在 / 名字非法），body 是可读原因；
+  /// - 其它非 200 或网络失败 → 通用原因串。
+  Future<(bool ok, String? error)> renameFile({
+    required String hash,
+    required String oldPath,
+    required String newPath,
+  }) async {
+    if (hash.isEmpty || oldPath.isEmpty || newPath.isEmpty) {
+      return (false, 'invalid rename arguments');
+    }
+    final http.Response? res = await _request(
+      'POST',
+      '/api/v2/torrents/renameFile',
+      form: <String, String>{
+        'hash': hash,
+        'oldPath': oldPath,
+        'newPath': newPath,
+      },
+    );
+    if (res == null) return (false, 'qBittorrent request failed');
+    if (res.statusCode == 200) return (true, null);
+    final String body = res.body.trim();
+    return (false, body.isEmpty ? 'HTTP ${res.statusCode}' : body);
+  }
+
+  /// TODO-1961-c：移动种子内容：`POST /api/v2/torrents/setLocation`
+  /// （参数 hashes / location）。
+  ///
+  /// 注意与内置引擎的**语义差异**：qb 的 setLocation 对目标已存在的文件不保证
+  /// 「整体失败不覆盖」——那是 qb 自身的策略，本客户端管不了。调用方在 UI 上
+  /// 对外接 qb 后端应当提示这一点。
+  Future<(bool ok, String? error)> setLocation({
+    required String hash,
+    required String location,
+  }) async {
+    if (hash.isEmpty || location.isEmpty) {
+      return (false, 'invalid setLocation arguments');
+    }
+    final http.Response? res = await _request(
+      'POST',
+      '/api/v2/torrents/setLocation',
+      form: <String, String>{'hashes': hash, 'location': location},
+    );
+    if (res == null) return (false, 'qBittorrent request failed');
+    if (res.statusCode == 200) return (true, null);
+    final String body = res.body.trim();
+    return (false, body.isEmpty ? 'HTTP ${res.statusCode}' : body);
+  }
+
   /// 带会话编排的请求：懒登录 → 发请求 → 403 时重新登录一次并重试。
   /// 任何异常/登录失败返回 null。
   Future<http.Response?> _request(

--- a/hibiki/lib/src/media/torrent/torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/torrent_backend.dart
@@ -110,6 +110,44 @@ abstract interface class TorrentBackend {
   /// 列某个种子内的文件；[torrentId] 是 infohash。
   Future<List<TorrentFileEntry>> listFiles(String torrentId);
 
+  /// TODO-1961-c：给种子内的一个文件改名（[newPath] 是种子内相对路径，可含
+  /// 子目录，分隔符 `/`）。**必须走后端**而不是 `File.rename` —— 引擎按自己
+  /// 记的路径读盘上传，绕过它改名 = 当场掐断做种。
+  ///
+  /// 与本接口其它方法不同，这里返回 [TorrentStorageResult] 而不是 bool：
+  /// 失败原因（目标已存在 / 权限不足）必须能原样呈现给用户。
+  Future<TorrentStorageResult> renameFile(
+    String torrentId,
+    int fileIndex,
+    String newPath,
+  );
+
+  /// TODO-1961-c：把种子内容整体移动到 [newSavePath]。同样必须走后端。
+  /// 目标已存在同名文件时应当失败而不是覆盖用户数据。
+  Future<TorrentStorageResult> moveStorage(
+    String torrentId,
+    String newSavePath,
+  );
+
   /// 释放底层连接资源。
   void close();
+}
+
+/// 改名 / 移动的结果。失败时 [error] 必须带上可读原因（后端原文优先）。
+class TorrentStorageResult {
+  const TorrentStorageResult({required this.ok, this.path, this.error});
+
+  const TorrentStorageResult.failure(String reason)
+      : ok = false,
+        path = null,
+        error = reason;
+
+  /// 是否成功落地。
+  final bool ok;
+
+  /// 成功时的新路径（改名 = 种子内相对路径；移动 = 新的 save_path）。
+  final String? path;
+
+  /// 失败原因。调用方**必须**反馈给用户，不得静默吞掉。
+  final String? error;
 }

--- a/hibiki/lib/src/media/video/video_book_repository.dart
+++ b/hibiki/lib/src/media/video/video_book_repository.dart
@@ -12,6 +12,7 @@ import 'package:hibiki/src/media/video/external_video.dart'
 import 'package:hibiki/src/media/video/m3u8_playlist.dart' show PlaylistEntry;
 import 'package:hibiki/src/media/video/scraper/scraper_types.dart'
     show ScrapeInfoboxEntry, ScrapeMetadata, ScrapeSource, ScrapeTag;
+import 'package:hibiki/src/media/video/video_path_migration.dart';
 import 'package:hibiki/src/media/video/video_storage.dart';
 import 'package:hibiki/src/sync/deletion_propagation.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
@@ -385,6 +386,55 @@ class VideoBookRepository {
           ? const Value.absent()
           : Value<String?>(subtitleSource),
     ));
+  }
+
+  /// TODO-1961-d：把库里落在 [fromPath] 下的路径整体重映射到 [toPath]，
+  /// 返回实际改动的行数。
+  ///
+  /// 引擎侧改名 / 移动（TODO-1961-c）之后必须**立刻**调这个 —— 两件事成对完成，
+  /// 缺一即断：只改引擎 = 做种保住了但库里全是死路径；只改库 = 库对了但引擎按
+  /// 旧路径读盘，做种当场断。
+  ///
+  /// 三列（videoPath / subtitleSource / secondarySubtitleSource）各自判断，
+  /// 哨兵值（`embedded:<n>` / `off:`）与流媒体 URL 一律不动，规则见
+  /// [remapVideoBookPaths]。整批在一个事务里写，中途失败不会留下改了一半的库。
+  Future<int> migrateMediaPaths({
+    required String fromPath,
+    required String toPath,
+  }) async {
+    if (fromPath.trim().isEmpty || toPath.trim().isEmpty) return 0;
+    final List<VideoBookRow> rows = await _db.allVideoBooks();
+    final Map<String, VideoPathRemap> pending = <String, VideoPathRemap>{};
+    for (final VideoBookRow row in rows) {
+      final VideoPathRemap remap = remapVideoBookPaths(
+        videoPath: row.videoPath,
+        subtitleSource: row.subtitleSource,
+        secondarySubtitleSource: row.secondarySubtitleSource,
+        fromPath: fromPath,
+        toPath: toPath,
+      );
+      if (!remap.isEmpty) pending[row.bookUid] = remap;
+    }
+    if (pending.isEmpty) return 0;
+    await _db.transaction(() async {
+      for (final MapEntry<String, VideoPathRemap> entry in pending.entries) {
+        final VideoPathRemap remap = entry.value;
+        await (_db.update(_db.videoBooks)
+              ..where((tbl) => tbl.bookUid.equals(entry.key)))
+            .write(VideoBooksCompanion(
+          videoPath: remap.videoPath == null
+              ? const Value.absent()
+              : Value<String>(remap.videoPath!),
+          subtitleSource: remap.subtitleSource == null
+              ? const Value.absent()
+              : Value<String?>(remap.subtitleSource),
+          secondarySubtitleSource: remap.secondarySubtitleSource == null
+              ? const Value.absent()
+              : Value<String?>(remap.secondarySubtitleSource),
+        ));
+      }
+    });
+    return pending.length;
   }
 
   /// 更新播放列表当前集索引（多集导航切集后持久化）。

--- a/hibiki/lib/src/media/video/video_path_migration.dart
+++ b/hibiki/lib/src/media/video/video_path_migration.dart
@@ -1,0 +1,102 @@
+/// TODO-1961-d：库里「路径类」列的重映射规则（纯函数，无 IO）。
+///
+/// 背景：视频入库是**纯引用绝对路径**（`VideoBooks.videoPath`，字幕 sidecar 走
+/// `subtitleSource` / `secondarySubtitleSource`）。引擎侧改名 / 移动
+/// （TODO-1961-c）之后，磁盘上的东西换地方了，这些列就成了死路径 —— 做种保住了、
+/// 库条目却断了。两件事必须**成对**完成，缺一即断，所以引擎成功后立刻用这里的
+/// 规则把库改过来。
+///
+/// 为什么单独抽成纯函数：这里全是「什么该改、什么绝不能改」的判断，是最容易
+/// 出错也最该被单测钉死的部分。IO 留给仓库层。
+library;
+
+import 'package:path/path.dart' as p;
+
+/// 内嵌字幕轨哨兵前缀（`embedded:<n>`）——不是路径，绝不能当路径重写。
+const String kEmbeddedSubtitlePrefix = 'embedded:';
+
+/// 「用户显式关闭字幕」哨兵前缀（`off:`）——同样不是路径。
+const String kOffSubtitlePrefix = 'off:';
+
+/// 一个值是否是本地绝对路径（而不是哨兵 / 流媒体 URL / 相对路径）。
+///
+/// 字幕源列是四态编码（绝对路径 / `embedded:<n>` / `off:` / null），
+/// `videoPath` 还可能是 http(s) 流媒体。只有真·本地绝对路径才参与重映射。
+bool isRemappableMediaPath(String? value) {
+  if (value == null) return false;
+  final String trimmed = value.trim();
+  if (trimmed.isEmpty) return false;
+  if (trimmed.startsWith(kEmbeddedSubtitlePrefix)) return false;
+  if (trimmed.startsWith(kOffSubtitlePrefix)) return false;
+  // 流媒体书：videoPath 是 http/https，磁盘上没有对应文件。
+  final Uri? uri = Uri.tryParse(trimmed);
+  if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+    return false;
+  }
+  return p.isAbsolute(trimmed);
+}
+
+/// 把 [value] 按 [fromPath] → [toPath] 重映射；不该改时返回 null。
+///
+/// 覆盖两种情形，它们其实是同一件事（一次路径重映射），所以不分两个函数：
+/// - **改名**：[fromPath] 是那个文件本身 → 全等匹配，直接换成 [toPath]；
+/// - **移动**：[fromPath] 是旧的内容根 → [value] 落在它里面时，把相对部分接到
+///   [toPath] 下面。
+///
+/// 路径比较一律走 `package:path`（Windows 的大小写不敏感与 `/` `\` 混用由它
+/// 负责，别自己写 `startsWith` —— `D:\a` 会误匹配 `D:\ab`）。
+String? remapMediaPath(
+  String? value, {
+  required String fromPath,
+  required String toPath,
+}) {
+  if (!isRemappableMediaPath(value)) return null;
+  if (fromPath.trim().isEmpty || toPath.trim().isEmpty) return null;
+  final String current = p.normalize(value!.trim());
+  final String from = p.normalize(fromPath.trim());
+  final String to = p.normalize(toPath.trim());
+  if (p.equals(current, from)) return to;
+  if (p.isWithin(from, current)) {
+    return p.normalize(p.join(to, p.relative(current, from: from)));
+  }
+  return null;
+}
+
+/// 一行视频书在一次重映射里要改的列（全 null = 这行不受影响，别写库）。
+class VideoPathRemap {
+  const VideoPathRemap({
+    this.videoPath,
+    this.subtitleSource,
+    this.secondarySubtitleSource,
+  });
+
+  final String? videoPath;
+  final String? subtitleSource;
+  final String? secondarySubtitleSource;
+
+  /// 这行是否真有列要改（避免为没变化的行发无谓的 UPDATE）。
+  bool get isEmpty =>
+      videoPath == null &&
+      subtitleSource == null &&
+      secondarySubtitleSource == null;
+}
+
+/// 算出一行视频书在 [fromPath] → [toPath] 下要改的列。
+///
+/// 三列各自独立判断：视频被移走了但字幕是内嵌轨（`embedded:0`）时，只改
+/// videoPath、不碰字幕列 —— 这正是把哨兵当路径重写会造成的静默损坏。
+VideoPathRemap remapVideoBookPaths({
+  required String? videoPath,
+  required String? subtitleSource,
+  required String? secondarySubtitleSource,
+  required String fromPath,
+  required String toPath,
+}) {
+  return VideoPathRemap(
+    videoPath: remapMediaPath(videoPath, fromPath: fromPath, toPath: toPath),
+    subtitleSource:
+        remapMediaPath(subtitleSource, fromPath: fromPath, toPath: toPath),
+    secondarySubtitleSource: remapMediaPath(secondarySubtitleSource,
+        fromPath: fromPath, toPath: toPath),
+  );
+}

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -47,6 +47,7 @@ import 'package:hibiki/src/media/manga/online/mokuro_moe_client.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_download_queue.dart';
 import 'package:hibiki/src/media/torrent/anime_download_config.dart';
 import 'package:hibiki/src/media/torrent/download_network_proxy.dart';
+import 'package:hibiki/src/media/torrent/download_relocate_service.dart';
 import 'package:hibiki/src/media/torrent/download_save_root.dart';
 import 'package:hibiki/src/media/torrent/embedded_torrent_host.dart';
 import 'package:hibiki/src/media/torrent/qb_torrent_backend.dart';
@@ -3279,6 +3280,23 @@ class AppModel with ChangeNotifier {
     // BUG-1053 修复后的行为逐字节一致。
     await _restoreEmbeddedTorrentSession(store);
   }
+
+  /// TODO-1961-c+d：下载内容改名 / 移动（引擎侧动，做种不断；库路径同步迁移）。
+  ///
+  /// 后端工厂复用 [_torrentBackendFor]，所以内置引擎与外接 qb 两条路都走得通；
+  /// 库迁移走 [VideoBookRepository.migrateMediaPaths]。两步的原子性由
+  /// [DownloadRelocateService] 保证（引擎失败则库不动）。
+  DownloadRelocateService get downloadRelocateService =>
+      DownloadRelocateService(
+        backendFactory: () => _torrentBackendFor(
+            effectiveTorrentConfig(prefsRepo.qbConnectionConfig)),
+        migrateLibraryPaths: ({
+          required String fromPath,
+          required String toPath,
+        }) =>
+            VideoBookRepository(database)
+                .migrateMediaPaths(fromPath: fromPath, toPath: toPath),
+      );
 
   /// 刷新 [_animeDownloadPlanIds]（resume 剪枝的真相源）并返回它。
   /// 返回值非空：调用过一次之后哨兵就不再是 null。

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:hibiki/src/media/torrent/anime_download_config.dart';
@@ -11,6 +12,7 @@ import 'package:hibiki/src/media/torrent/anime_download_matching.dart';
 import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
 import 'package:hibiki/src/media/torrent/anime_download_service.dart';
 import 'package:hibiki/src/media/torrent/anime_download_subscription.dart';
+import 'package:hibiki/src/media/torrent/download_relocate_service.dart';
 import 'package:hibiki/src/media/torrent/nyaa_client.dart';
 import 'package:hibiki/src/media/torrent/torrent_backend.dart';
 import 'package:hibiki/src/media/video/anilist_client.dart';
@@ -761,6 +763,77 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
         ref.read(appProvider).animeDownloadPlanStore;
     if (store == null) return;
     await store.delete(plan.id);
+    await _reloadPlans();
+  }
+
+  /// TODO-1961-e：改名 / 移动入口。
+  ///
+  /// 为什么必须在 app 里做：引擎按自己记的路径读盘上传，用户在资源管理器里改名
+  /// 之后 app 收不到任何通知，等下一轮轮询时文件已经不见了 —— 那种情况**永远**
+  /// 救不回来。走这里则由引擎自己改（做种不断），库路径同步迁移。
+  Future<void> _relocatePlan(AnimeDownloadPlan plan) async {
+    final AppModel appModel = ref.read(appProvider);
+    final QbConnectionConfig config =
+        effectiveTorrentConfig(appModel.qbConnectionConfig);
+    // 先拿这个种子的当前快照（save_path + 文件列表）：改名要文件下标与旧相对
+    // 路径，移动要旧 save_path，都得从后端现问，不能猜。
+    final TorrentBackend backend = appModel.createTorrentBackend(config);
+    TorrentSnapshot? snapshot;
+    List<TorrentFileEntry> files = const <TorrentFileEntry>[];
+    try {
+      for (final TorrentSnapshot t in await backend.listTorrents(
+          category: config.category.isEmpty ? null : config.category)) {
+        if (t.hash.toLowerCase() == plan.id.toLowerCase()) {
+          snapshot = t;
+          break;
+        }
+      }
+      if (snapshot != null) files = await backend.listFiles(snapshot.hash);
+    } catch (_) {
+      snapshot = null;
+    } finally {
+      backend.close();
+    }
+    if (!mounted) return;
+    if (snapshot == null || snapshot.savePath.isEmpty) {
+      _snack(t.anime_download_relocate_no_files);
+      return;
+    }
+
+    final _RelocateChoice? choice = await showDialog<_RelocateChoice>(
+      context: context,
+      builder: (BuildContext context) =>
+          _RelocateDialog(snapshot: snapshot!, files: files),
+    );
+    if (choice == null || !mounted) return;
+
+    final DownloadRelocateService service = appModel.downloadRelocateService;
+    final RelocateOutcome outcome = choice.isMove
+        ? await service.moveTorrent(
+            infoHash: plan.id,
+            currentSaveRoot: snapshot.savePath,
+            newSaveRoot: choice.value,
+          )
+        : await service.renameFile(
+            infoHash: plan.id,
+            fileIndex: choice.fileIndex!,
+            currentRelativePath: choice.currentRelativePath!,
+            newRelativePath: choice.value,
+            saveRoot: snapshot.savePath,
+          );
+    if (!mounted) return;
+    switch (outcome.status) {
+      case RelocateStatus.success:
+        _snack(t.anime_download_relocate_ok(rows: '${outcome.rowsMigrated}'));
+      case RelocateStatus.unchanged:
+        break;
+      case RelocateStatus.engineFailed:
+        _snack(t.anime_download_relocate_engine_failed(
+            reason: outcome.error ?? ''));
+      case RelocateStatus.libraryFailed:
+        _snack(t.anime_download_relocate_library_failed(
+            reason: outcome.error ?? ''));
+    }
     await _reloadPlans();
   }
 
@@ -1770,6 +1843,12 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
               onTap: () => _retryPlan(plan),
             ),
           HibikiIconButton(
+            tooltip: t.anime_download_relocate,
+            icon: Icons.drive_file_move_outline,
+            size: 20,
+            onTap: () => _relocatePlan(plan),
+          ),
+          HibikiIconButton(
             tooltip: t.anime_download_delete,
             icon: Icons.delete_outline,
             size: 20,
@@ -1877,6 +1956,161 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog> {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// TODO-1961-e：用户在改名/移动对话框里做出的选择。
+class _RelocateChoice {
+  const _RelocateChoice.move(this.value)
+      : isMove = true,
+        fileIndex = null,
+        currentRelativePath = null;
+
+  const _RelocateChoice.rename({
+    required this.value,
+    required int this.fileIndex,
+    required String this.currentRelativePath,
+  }) : isMove = false;
+
+  /// true = 移动整个种子到 [value]（新 save_path）；false = 把某个文件改成 [value]。
+  final bool isMove;
+
+  /// 移动 = 目标目录绝对路径；改名 = 种子内新相对路径。
+  final String value;
+
+  /// 改名时的文件下标（移动时为 null）。
+  final int? fileIndex;
+
+  /// 改名时该文件当前的种子内相对路径（移动时为 null）。
+  final String? currentRelativePath;
+}
+
+/// 改名 / 移动对话框：上半是「移动整个任务到某目录」，下半是逐文件改名。
+///
+/// 刻意**不**做成两个入口：用户想的是「整理这个下载」，移动和改名是同一件事的
+/// 两个面，放一个弹窗里他一眼能看到自己有哪些文件、现在在哪。
+class _RelocateDialog extends StatefulWidget {
+  const _RelocateDialog({required this.snapshot, required this.files});
+
+  final TorrentSnapshot snapshot;
+  final List<TorrentFileEntry> files;
+
+  @override
+  State<_RelocateDialog> createState() => _RelocateDialogState();
+}
+
+class _RelocateDialogState extends State<_RelocateDialog> {
+  /// 逐文件的改名输入框（key = 文件下标），初值 = 当前种子内相对路径。
+  late final Map<int, TextEditingController> _controllers =
+      <int, TextEditingController>{
+    for (final TorrentFileEntry f in widget.files)
+      f.index: TextEditingController(text: f.name),
+  };
+
+  @override
+  void dispose() {
+    for (final TextEditingController c in _controllers.values) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  Future<void> _pickDestination() async {
+    final String? picked = await FilePicker.platform.getDirectoryPath(
+      dialogTitle: t.anime_download_relocate_pick_folder,
+    );
+    if (picked == null || picked.trim().isEmpty || !mounted) return;
+    Navigator.pop(context, _RelocateChoice.move(picked.trim()));
+  }
+
+  void _submitRename(TorrentFileEntry file) {
+    final String next = _controllers[file.index]?.text.trim() ?? '';
+    if (next.isEmpty) return;
+    Navigator.pop(
+      context,
+      _RelocateChoice.rename(
+        value: next,
+        fileIndex: file.index,
+        currentRelativePath: file.name,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return AlertDialog(
+      title: Text(t.anime_download_relocate),
+      content: SizedBox(
+        width: 520,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              // 为什么必须在 app 里改名，而不是去资源管理器 —— 说清楚，否则用户
+              // 改完再来问「怎么做种断了」。
+              Text(
+                t.anime_download_relocate_hint,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.outline),
+              ),
+              const SizedBox(height: 16),
+              Text(t.anime_download_relocate_move_title,
+                  style: theme.textTheme.titleSmall),
+              const SizedBox(height: 6),
+              Text(widget.snapshot.savePath, style: theme.textTheme.bodySmall),
+              const SizedBox(height: 6),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: FilledButton.tonalIcon(
+                  onPressed: _pickDestination,
+                  icon: const Icon(Icons.folder_open_outlined, size: 18),
+                  label: Text(t.anime_download_relocate_pick_folder),
+                ),
+              ),
+              if (widget.files.isNotEmpty) ...<Widget>[
+                const Divider(height: 28),
+                Text(t.anime_download_relocate_rename_title,
+                    style: theme.textTheme.titleSmall),
+                const SizedBox(height: 6),
+                for (final TorrentFileEntry file in widget.files)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Row(
+                      children: <Widget>[
+                        Expanded(
+                          child: TextField(
+                            controller: _controllers[file.index],
+                            decoration: const InputDecoration(
+                              isDense: true,
+                              border: OutlineInputBorder(),
+                            ),
+                            onSubmitted: (_) => _submitRename(file),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        HibikiIconButton(
+                          tooltip: t.anime_download_relocate_rename_title,
+                          icon: Icons.drive_file_rename_outline,
+                          size: 20,
+                          onTap: () => _submitRename(file),
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ],
+          ),
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(t.dialog_cancel),
+        ),
+      ],
     );
   }
 }

--- a/hibiki/test/media/torrent/download_relocate_service_test.dart
+++ b/hibiki/test/media/torrent/download_relocate_service_test.dart
@@ -226,6 +226,41 @@ void main() {
       expect(outcome.isSuccess, isFalse, reason: '磁盘动了库没跟上 —— 用户必须知道，不能当成功');
     });
 
+    test('改名拒绝绝对路径和逃出种子目录的路径，且不触碰后端或库', () async {
+      final _FakeBackend backend = _FakeBackend();
+      bool libraryTouched = false;
+      final DownloadRelocateService service = DownloadRelocateService(
+        backendFactory: () => backend,
+        migrateLibraryPaths: (
+            {required String fromPath, required String toPath}) async {
+          libraryTouched = true;
+          return 1;
+        },
+      );
+
+      final List<String> invalid = <String>[
+        p.join(p.rootPrefix(p.current), 'outside.mkv'),
+        p.join('..', 'outside.mkv'),
+        p.join('season', '..', '..', 'outside.mkv'),
+      ];
+      for (final String newPath in invalid) {
+        final RelocateOutcome outcome = await service.renameFile(
+          infoHash: 'abc',
+          fileIndex: 0,
+          currentRelativePath: 'old.mkv',
+          newRelativePath: newPath,
+          saveRoot: root,
+        );
+        expect(outcome.status, RelocateStatus.engineFailed,
+            reason: '应拒绝 $newPath');
+        expect(outcome.error, contains('inside the torrent'));
+      }
+
+      expect(backend.calls, isEmpty);
+      expect(backend.closed, isFalse, reason: '校验失败前不应创建后端');
+      expect(libraryTouched, isFalse);
+    });
+
     test('目标与现状相同 → unchanged，不打扰引擎也不动库', () async {
       final _FakeBackend backend = _FakeBackend();
       bool libraryTouched = false;

--- a/hibiki/test/media/torrent/download_relocate_service_test.dart
+++ b/hibiki/test/media/torrent/download_relocate_service_test.dart
@@ -318,7 +318,9 @@ void main() {
 
       // 库里存的是绝对路径，所以重映射必须在绝对路径坐标系里做。
       expect(seenFrom, p.join(root, 'old.mkv'));
-      expect(seenTo, p.join(root, 'S1/new.mkv'));
+      expect(seenTo, p.join(root, 'S1', 'new.mkv'));
+      expect(backend.calls.single, 'rename(abc,2,S1/new.mkv)',
+          reason: '种子内路径跨平台固定使用 POSIX 分隔符');
     });
   });
 }

--- a/hibiki/test/media/torrent/download_relocate_service_test.dart
+++ b/hibiki/test/media/torrent/download_relocate_service_test.dart
@@ -1,0 +1,289 @@
+// TODO-1961-c+d：改名/移动的原子性与库路径重映射规则。
+//
+// 这里钉死两件在真机上很难复现、错了又是静默数据损坏的事：
+// ① 引擎失败时**库一个字节都不许动**（否则库指向一个磁盘上不存在的新路径）；
+// ② 字幕列的哨兵值（`embedded:<n>` / `off:`）与流媒体 URL **绝不能**当路径重写。
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/torrent/download_relocate_service.dart';
+import 'package:hibiki/src/media/torrent/torrent_backend.dart';
+import 'package:hibiki/src/media/video/video_path_migration.dart';
+import 'package:path/path.dart' as p;
+
+/// 可编程后端：记录收到的调用，按需返回成功/失败。
+class _FakeBackend implements TorrentBackend {
+  _FakeBackend({this.result = const TorrentStorageResult(ok: true, path: 'x')});
+
+  TorrentStorageResult result;
+  final List<String> calls = <String>[];
+  bool closed = false;
+
+  @override
+  Future<TorrentStorageResult> renameFile(
+      String torrentId, int fileIndex, String newPath) async {
+    calls.add('rename($torrentId,$fileIndex,$newPath)');
+    return result;
+  }
+
+  @override
+  Future<TorrentStorageResult> moveStorage(
+      String torrentId, String newSavePath) async {
+    calls.add('move($torrentId,$newSavePath)');
+    return result;
+  }
+
+  @override
+  void close() => closed = true;
+
+  @override
+  Future<String?> probeConnection() async => 'fake';
+
+  @override
+  Future<bool> prepareCategory(String category) async => true;
+
+  @override
+  Future<bool> addTorrent(String magnetOrUrl,
+          {required String category,
+          bool sequential = false,
+          bool firstLastPiecePrio = false}) async =>
+      true;
+
+  @override
+  Future<List<TorrentSnapshot>> listTorrents({String? category}) async =>
+      const <TorrentSnapshot>[];
+
+  @override
+  Future<List<TorrentFileEntry>> listFiles(String torrentId) async =>
+      const <TorrentFileEntry>[];
+}
+
+void main() {
+  group('remapMediaPath — 什么该改、什么绝不能改', () {
+    final String root = p.join(p.rootPrefix(p.current), 'dl');
+    final String moved = p.join(p.rootPrefix(p.current), 'moved');
+
+    test('全等匹配（改名）→ 换成新路径', () {
+      expect(
+        remapMediaPath(p.join(root, 'a.mkv'),
+            fromPath: p.join(root, 'a.mkv'), toPath: p.join(root, 'b.mkv')),
+        p.join(root, 'b.mkv'),
+      );
+    });
+
+    test('前缀内（移动）→ 相对部分接到新根下', () {
+      expect(
+        remapMediaPath(p.join(root, 'S1', 'ep01.mkv'),
+            fromPath: root, toPath: moved),
+        p.join(moved, 'S1', 'ep01.mkv'),
+      );
+    });
+
+    test('兄弟目录不被误当成前缀命中', () {
+      // 手写 startsWith 会让 <root> 误匹配 <root>x —— 必须走 package:path。
+      expect(
+        remapMediaPath('${root}x${p.separator}ep.mkv',
+            fromPath: root, toPath: moved),
+        isNull,
+      );
+    });
+
+    test('范围外路径不动', () {
+      final String elsewhere =
+          p.join(p.rootPrefix(p.current), 'somewhere', 'else.mkv');
+      expect(remapMediaPath(elsewhere, fromPath: root, toPath: moved), isNull);
+    });
+
+    test('内嵌字幕哨兵 embedded:<n> 绝不当路径重写', () {
+      expect(
+          remapMediaPath('embedded:2', fromPath: root, toPath: moved), isNull);
+      expect(isRemappableMediaPath('embedded:2'), isFalse);
+    });
+
+    test('显式关闭哨兵 off: 绝不当路径重写', () {
+      expect(remapMediaPath('off:', fromPath: root, toPath: moved), isNull);
+      expect(isRemappableMediaPath('off:'), isFalse);
+    });
+
+    test('流媒体 URL 不动（磁盘上没有对应文件）', () {
+      expect(
+        remapMediaPath('https://example.com/v.m3u8',
+            fromPath: root, toPath: moved),
+        isNull,
+      );
+    });
+
+    test('null / 空串 / 相对路径都不动', () {
+      expect(remapMediaPath(null, fromPath: root, toPath: moved), isNull);
+      expect(remapMediaPath('  ', fromPath: root, toPath: moved), isNull);
+      expect(remapMediaPath('relative/a.mkv', fromPath: root, toPath: moved),
+          isNull);
+    });
+
+    test('三列各自独立：视频跟着走、内嵌字幕轨原样保留', () {
+      final VideoPathRemap remap = remapVideoBookPaths(
+        videoPath: p.join(root, 'ep01.mkv'),
+        subtitleSource: 'embedded:0',
+        secondarySubtitleSource: p.join(root, 'ep01.zh.srt'),
+        fromPath: root,
+        toPath: moved,
+      );
+      expect(remap.videoPath, p.join(moved, 'ep01.mkv'));
+      expect(remap.subtitleSource, isNull, reason: '哨兵不该被重写');
+      expect(remap.secondarySubtitleSource, p.join(moved, 'ep01.zh.srt'));
+      expect(remap.isEmpty, isFalse);
+    });
+
+    test('全不命中时 isEmpty 为真（不发无谓 UPDATE）', () {
+      final VideoPathRemap remap = remapVideoBookPaths(
+        videoPath: 'https://example.com/v.m3u8',
+        subtitleSource: 'off:',
+        secondarySubtitleSource: null,
+        fromPath: root,
+        toPath: moved,
+      );
+      expect(remap.isEmpty, isTrue);
+    });
+  });
+
+  group('DownloadRelocateService — 引擎与库必须成对', () {
+    final String root = p.join(p.rootPrefix(p.current), 'dl');
+
+    test('引擎失败 → 库一个字节都不动，且原因原样带回', () async {
+      final _FakeBackend backend = _FakeBackend(
+          result: const TorrentStorageResult.failure('target already exists'));
+      bool libraryTouched = false;
+      final DownloadRelocateService service = DownloadRelocateService(
+        backendFactory: () => backend,
+        migrateLibraryPaths: (
+            {required String fromPath, required String toPath}) async {
+          libraryTouched = true;
+          return 1;
+        },
+      );
+
+      final RelocateOutcome outcome = await service.moveTorrent(
+        infoHash: 'abc',
+        currentSaveRoot: root,
+        newSaveRoot: p.join(p.rootPrefix(p.current), 'elsewhere'),
+      );
+
+      expect(outcome.status, RelocateStatus.engineFailed);
+      expect(outcome.error, 'target already exists');
+      expect(libraryTouched, isFalse, reason: '引擎没动，库绝不能动 —— 否则库会指向磁盘上不存在的路径');
+      expect(backend.closed, isTrue, reason: '后端连接必须释放');
+    });
+
+    test('两步都成 → success，并带回迁移行数', () async {
+      final _FakeBackend backend = _FakeBackend(
+          result: TorrentStorageResult(
+              ok: true, path: p.join(p.rootPrefix(p.current), 'moved')));
+      String? seenFrom;
+      String? seenTo;
+      final DownloadRelocateService service = DownloadRelocateService(
+        backendFactory: () => backend,
+        migrateLibraryPaths: (
+            {required String fromPath, required String toPath}) async {
+          seenFrom = fromPath;
+          seenTo = toPath;
+          return 3;
+        },
+      );
+
+      final String target = p.join(p.rootPrefix(p.current), 'moved');
+      final RelocateOutcome outcome = await service.moveTorrent(
+        infoHash: 'abc',
+        currentSaveRoot: root,
+        newSaveRoot: target,
+      );
+
+      expect(outcome.isSuccess, isTrue);
+      expect(outcome.rowsMigrated, 3);
+      expect(seenFrom, root);
+      expect(seenTo, target);
+      expect(backend.calls.single, 'move(abc,$target)');
+    });
+
+    test('引擎成功但库迁移抛错 → libraryFailed，不许报成功', () async {
+      final _FakeBackend backend = _FakeBackend(
+          result: const TorrentStorageResult(ok: true, path: 'newname.mkv'));
+      final DownloadRelocateService service = DownloadRelocateService(
+        backendFactory: () => backend,
+        migrateLibraryPaths: (
+                {required String fromPath, required String toPath}) async =>
+            throw StateError('db is locked'),
+      );
+
+      final RelocateOutcome outcome = await service.renameFile(
+        infoHash: 'abc',
+        fileIndex: 0,
+        currentRelativePath: 'old.mkv',
+        newRelativePath: 'newname.mkv',
+        saveRoot: root,
+      );
+
+      expect(outcome.status, RelocateStatus.libraryFailed);
+      expect(outcome.error, contains('db is locked'));
+      expect(outcome.isSuccess, isFalse, reason: '磁盘动了库没跟上 —— 用户必须知道，不能当成功');
+    });
+
+    test('目标与现状相同 → unchanged，不打扰引擎也不动库', () async {
+      final _FakeBackend backend = _FakeBackend();
+      bool libraryTouched = false;
+      final DownloadRelocateService service = DownloadRelocateService(
+        backendFactory: () => backend,
+        migrateLibraryPaths: (
+            {required String fromPath, required String toPath}) async {
+          libraryTouched = true;
+          return 0;
+        },
+      );
+
+      final RelocateOutcome renamed = await service.renameFile(
+        infoHash: 'abc',
+        fileIndex: 0,
+        currentRelativePath: 'same.mkv',
+        newRelativePath: 'same.mkv',
+        saveRoot: root,
+      );
+      expect(renamed.status, RelocateStatus.unchanged);
+
+      final RelocateOutcome moved = await service.moveTorrent(
+        infoHash: 'abc',
+        currentSaveRoot: root,
+        newSaveRoot: root,
+      );
+      expect(moved.status, RelocateStatus.unchanged);
+
+      expect(backend.calls, isEmpty);
+      expect(libraryTouched, isFalse);
+    });
+
+    test('改名把种子内相对路径拼成绝对路径再迁库（同一坐标系）', () async {
+      final _FakeBackend backend = _FakeBackend(
+          result: const TorrentStorageResult(ok: true, path: 'S1/new.mkv'));
+      String? seenFrom;
+      String? seenTo;
+      final DownloadRelocateService service = DownloadRelocateService(
+        backendFactory: () => backend,
+        migrateLibraryPaths: (
+            {required String fromPath, required String toPath}) async {
+          seenFrom = fromPath;
+          seenTo = toPath;
+          return 1;
+        },
+      );
+
+      await service.renameFile(
+        infoHash: 'abc',
+        fileIndex: 2,
+        currentRelativePath: 'old.mkv',
+        newRelativePath: 'S1/new.mkv',
+        saveRoot: root,
+      );
+
+      // 库里存的是绝对路径，所以重映射必须在绝对路径坐标系里做。
+      expect(seenFrom, p.join(root, 'old.mkv'));
+      expect(seenTo, p.join(root, 'S1/new.mkv'));
+    });
+  });
+}

--- a/hibiki/test/media/torrent/torrent_ffi_bindings_parity_guard_test.dart
+++ b/hibiki/test/media/torrent/torrent_ffi_bindings_parity_guard_test.dart
@@ -1,0 +1,147 @@
+// 守卫：`native/hibiki_torrent` 的 C ABI 头文件与手写镜像的 Dart FFI 绑定必须
+// 逐符号、逐参数对齐。
+//
+// 为什么需要它：`packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart`
+// 是**手写镜像**（`ffigen.yaml` 明确允许：本机没有 LLVM/libclang 时不跑 ffigen）。
+// 手写就会漂，而 FFI 的漂移**不会**给你一个干净的报错：
+// - 少写一个符号 → 用户运行时 `lookup` 抛（只有装了新 DLL 的用户才撞上）；
+// - 参数个数写错 → `asFunction` 拿错误签名去调，是**未定义行为**（栈错位/内存损坏），
+//   不是异常。
+//
+// 而这两件事在 CI 里原本**无人可挡**：`packages/hibiki_torrent` 的测试要
+// `HIBIKI_TORRENT_LIB` 指向已构建的 DLL，Linux CI 没有 DLL → 整组 skip；
+// 而 main.yml / release.yml 的包测试清单本就没收录这个包。
+//
+// 本守卫是**纯文本扫描**，不需要 DLL、不需要 native 工具链，因此能跟着主 app 测试
+// 套件在任何平台的 CI 上跑 —— 这正是它存在的意义。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 头文件里一个导出函数的签名摘要。
+class _CExport {
+  const _CExport(this.name, this.paramCount);
+
+  final String name;
+  final int paramCount;
+}
+
+/// 按顶层逗号切分参数列表（尖括号/圆括号内的逗号不算）。
+/// C 侧没有尖括号，但函数指针参数会有圆括号，一并处理。
+int _countTopLevelParams(String params) {
+  final String trimmed = params.trim();
+  if (trimmed.isEmpty) return 0;
+  // C 的 `(void)` = 无参。
+  if (trimmed == 'void') return 0;
+  int depth = 0;
+  int count = 1;
+  for (final int unit in trimmed.codeUnits) {
+    final String ch = String.fromCharCode(unit);
+    if (ch == '(' || ch == '<') depth++;
+    if (ch == ')' || ch == '>') depth--;
+    if (ch == ',' && depth == 0) count++;
+  }
+  return count;
+}
+
+/// 从 C 头文件抽出所有 `HT_EXPORT` 函数（跨行声明也能吃）。
+List<_CExport> _parseHeader(String source) {
+  final List<_CExport> out = <_CExport>[];
+  // HT_EXPORT <返回类型…> ht_name( …参数… );
+  final RegExp re = RegExp(
+    r'HT_EXPORT\s+[^;(]*?\b(ht_\w+)\s*\(([^;]*?)\)\s*;',
+    dotAll: true,
+  );
+  for (final RegExpMatch m in re.allMatches(source)) {
+    out.add(_CExport(m.group(1)!, _countTopLevelParams(m.group(2)!)));
+  }
+  return out;
+}
+
+/// 从手写绑定里抽出每个 `_lookup<...>('ht_xxx')` 对应的 Dart 侧参数个数。
+///
+/// 取的是 `asFunction<Ret Function(...)>` 里的参数个数（真正决定调用约定的那个），
+/// 而不是外层包装方法的形参 —— 包装方法写错顶多编译不过，`asFunction` 写错才是
+/// 内存损坏。
+Map<String, int> _parseBindings(String source) {
+  final Map<String, int> out = <String, int>{};
+  // late final _ht_xxx = _ht_xxxPtr.asFunction<Ret Function(params)>();
+  final RegExp re = RegExp(
+    r'_(ht_\w+)\s*=\s*_\1Ptr\s*\.?\s*asFunction<[^(]*?Function\((.*?)\)>\(\)',
+    dotAll: true,
+  );
+  for (final RegExpMatch m in re.allMatches(source)) {
+    out[m.group(1)!] = _countTopLevelParams(m.group(2)!);
+  }
+  return out;
+}
+
+/// 绑定里 `_lookup<...>('name')` 声明过的符号集合（查符号名是否齐）。
+Set<String> _parseLookedUpSymbols(String source) {
+  // 泛型实参是多层嵌套的（`_lookup<ffi.NativeFunction<... Function(...)>>`），
+  // 别试图匹配尖括号配对 —— 用惰性跨行匹配吃到 `>(` 再取符号字面量。
+  return RegExp(r"_lookup<[\s\S]*?>\(\s*'(ht_\w+)'")
+      .allMatches(source)
+      .map((RegExpMatch m) => m.group(1)!)
+      .toSet();
+}
+
+void main() {
+  // 测试的工作目录是 `hibiki/`，native 与 packages 在它的上一级。
+  final File headerFile =
+      File('../native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h');
+  final File bindingsFile = File(
+      '../packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart');
+
+  test('C ABI 头文件与手写 FFI 绑定：符号集合必须完全一致', () {
+    expect(headerFile.existsSync(), isTrue,
+        reason: '找不到 ${headerFile.path} —— 守卫失去意义，先修路径');
+    expect(bindingsFile.existsSync(), isTrue,
+        reason: '找不到 ${bindingsFile.path}');
+
+    final List<_CExport> exports = _parseHeader(headerFile.readAsStringSync());
+    expect(exports, isNotEmpty, reason: '头文件里一个 HT_EXPORT 都没解析到，正则失效了');
+
+    final Set<String> exported =
+        exports.map((_CExport e) => e.name).toSet();
+    final Set<String> lookedUp =
+        _parseLookedUpSymbols(bindingsFile.readAsStringSync());
+
+    final Set<String> missing = exported.difference(lookedUp);
+    expect(missing, isEmpty,
+        reason: '这些 C 导出没有对应的 Dart 绑定：$missing\n'
+            '新增 HT_EXPORT 之后必须同步 hibiki_torrent_bindings.dart '
+            '（本机有 LLVM 就 `dart run ffigen --config ffigen.yaml`，'
+            '没有就照既有风格手写镜像）。漏了的话，只有装上新 DLL 的用户会在运行时'
+            '撞到 lookup 抛异常。');
+
+    final Set<String> stale = lookedUp.difference(exported);
+    expect(stale, isEmpty,
+        reason: '这些 Dart 绑定在 C 头文件里已不存在：$stale\n'
+            '删/改 C ABI 符号时必须同步删掉绑定，否则 lookup 会在运行时抛。');
+  });
+
+  test('C ABI 头文件与手写 FFI 绑定：每个函数的参数个数必须一致', () {
+    final List<_CExport> exports = _parseHeader(headerFile.readAsStringSync());
+    final Map<String, int> bindings =
+        _parseBindings(bindingsFile.readAsStringSync());
+
+    final List<String> mismatches = <String>[];
+    for (final _CExport e in exports) {
+      final int? dartArity = bindings[e.name];
+      if (dartArity == null) {
+        mismatches.add('${e.name}: 绑定里没有 asFunction 签名');
+        continue;
+      }
+      if (dartArity != e.paramCount) {
+        mismatches.add('${e.name}: C 侧 ${e.paramCount} 个参数，'
+            'Dart asFunction 写了 $dartArity 个');
+      }
+    }
+    expect(mismatches, isEmpty,
+        reason: '参数个数对不上：\n${mismatches.join('\n')}\n'
+            '这不是「会报错」的那种错 —— asFunction 拿错误签名去调是**未定义行为**'
+            '（栈错位/内存损坏），改 C ABI 参数后必须同步改绑定。');
+  });
+}

--- a/hibiki/test/pages/anime_download_dialog_embedded_push_test.dart
+++ b/hibiki/test/pages/anime_download_dialog_embedded_push_test.dart
@@ -105,6 +105,18 @@ class _FakeBackend implements TorrentBackend {
 
   @override
   void close() {}
+
+  // TODO-1961-c：本 fake 不测改名/移动路径，给出明确的「未实现」结果而不是
+  // 假装成功——真要测这条链路的用例应当显式覆盖它。
+  @override
+  Future<TorrentStorageResult> renameFile(
+          String torrentId, int fileIndex, String newPath) async =>
+      const TorrentStorageResult.failure('not supported by fake');
+
+  @override
+  Future<TorrentStorageResult> moveStorage(
+          String torrentId, String newSavePath) async =>
+      const TorrentStorageResult.failure('not supported by fake');
 }
 
 class _FakeAppModel extends AppModel {

--- a/hibiki/test/pages/download_subscriptions_panel_test.dart
+++ b/hibiki/test/pages/download_subscriptions_panel_test.dart
@@ -61,6 +61,18 @@ class _NoopBackend implements TorrentBackend {
   @override
   void close() {}
 
+  // TODO-1961-c：本 fake 不测改名/移动路径，给出明确的「未实现」结果而不是
+  // 假装成功——真要测这条链路的用例应当显式覆盖它。
+  @override
+  Future<TorrentStorageResult> renameFile(
+          String torrentId, int fileIndex, String newPath) async =>
+      const TorrentStorageResult.failure('not supported by fake');
+
+  @override
+  Future<TorrentStorageResult> moveStorage(
+          String torrentId, String newSavePath) async =>
+      const TorrentStorageResult.failure('not supported by fake');
+
   @override
   Future<List<TorrentFileEntry>> listFiles(String torrentId) async =>
       const <TorrentFileEntry>[];

--- a/hibiki/test/torrent/anime_download_service_progress_test.dart
+++ b/hibiki/test/torrent/anime_download_service_progress_test.dart
@@ -44,6 +44,18 @@ class _FakeBackend implements TorrentBackend {
 
   @override
   void close() {}
+
+  // TODO-1961-c：本 fake 不测改名/移动路径，给出明确的「未实现」结果而不是
+  // 假装成功——真要测这条链路的用例应当显式覆盖它。
+  @override
+  Future<TorrentStorageResult> renameFile(
+          String torrentId, int fileIndex, String newPath) async =>
+      const TorrentStorageResult.failure('not supported by fake');
+
+  @override
+  Future<TorrentStorageResult> moveStorage(
+          String torrentId, String newSavePath) async =>
+      const TorrentStorageResult.failure('not supported by fake');
 }
 
 TorrentSnapshot _snapshot({required double progress, required String state}) {

--- a/hibiki/test/torrent/anime_download_subscription_test.dart
+++ b/hibiki/test/torrent/anime_download_subscription_test.dart
@@ -74,6 +74,18 @@ class _FakeBackend implements TorrentBackend {
   @override
   void close() => closed = true;
 
+  // TODO-1961-c：本 fake 不测改名/移动路径，给出明确的「未实现」结果而不是
+  // 假装成功——真要测这条链路的用例应当显式覆盖它。
+  @override
+  Future<TorrentStorageResult> renameFile(
+          String torrentId, int fileIndex, String newPath) async =>
+      const TorrentStorageResult.failure('not supported by fake');
+
+  @override
+  Future<TorrentStorageResult> moveStorage(
+          String torrentId, String newSavePath) async =>
+      const TorrentStorageResult.failure('not supported by fake');
+
   @override
   Future<List<TorrentFileEntry>> listFiles(String torrentId) async =>
       const <TorrentFileEntry>[];

--- a/native/hibiki_torrent/README.md
+++ b/native/hibiki_torrent/README.md
@@ -39,6 +39,8 @@ hibiki/lib/src/media/torrent/
 `ht_torrent_pieces` / `ht_poll_piece_events` / `ht_set_piece_deadline` /
 `ht_apply_first_last_priority` / `ht_remove_torrent`。
 持久化（TODO-1961-a）：`ht_save_resume_data` / `ht_load_resume_dir`。
+存储整理（TODO-1961-c）：`ht_rename_file` / `ht_move_storage`（都是同步等回执的
+封装；改名/移动由引擎自己做，故做种不断）。
 出参 JSON 一律 `ht_free_string` 释放；详细契约见 `hibiki_torrent.h` 注释。
 
 ### 关键语义（踩过的坑，别再踩）
@@ -57,6 +59,10 @@ hibiki/lib/src/media/torrent/
   `drain_alerts`，各 poll 函数只读自己的队列。新增任何需要 alert 的能力时，
   往 `drain_alerts` 里加一个分支，**绝不要**再写第二处 `pop_alerts` ——
   两个消费者会静默吃掉彼此的事件。
+- **改名 / 移动必须走引擎**：libtorrent 按自己记的 save_path + 种子内相对路径
+  读盘上传。在引擎之外动文件（资源管理器改名、脚本 mv）= 当场掐断做种，且
+  **无法补救**（引擎收不到通知）。`ht_move_storage` 用 `fail_if_exist`：目标
+  已有同名文件就整体失败，绝不覆盖用户数据、也绝不留下搬了一半的目录。
 - **resume data 只对已有元数据的种子有意义**：磁力刚加时没有 info dict，
   `ht_save_resume_data` 会跳过这类种子（存了也重建不出来）。保存时带
   `save_info_dict`，故恢复后无需再向 DHT/peer 取元数据。

--- a/native/hibiki_torrent/hibiki_torrent_ffi.cpp
+++ b/native/hibiki_torrent/hibiki_torrent_ffi.cpp
@@ -117,6 +117,30 @@ struct PieceEvent {
 // 「进度提示」，丢了不影响正确性（真相在 ht_torrent_pieces 的位图里）。
 constexpr std::size_t kMaxQueuedPieceEvents = 4096;
 
+// TODO-1961-c：一次异步存储操作（改名 / 移动）的回执槽。
+//
+// `pending` 是「已发出、还没回执」；`ok` 只有在 `pending == 0` 时才有意义。
+// `detail` 成功时装新路径（move）、失败时装引擎给的错误串 —— 失败原因必须原样
+// 带回 Dart，不能吞成一个光秃秃的 false（用户要知道是「目标已存在」还是
+// 「权限不足」）。
+struct StorageOp {
+  int pending = 0;
+  bool ok = false;
+  std::string detail;
+
+  void arm() {
+    pending = 1;
+    ok = false;
+    detail.clear();
+  }
+
+  void settle(bool success, std::string message) {
+    if (pending > 0) pending--;
+    ok = success;
+    detail = std::move(message);
+  }
+};
+
 // session 句柄的真身：拥有 lt::session + 已收割待取的 alert 队列。
 //
 // TODO-1961-b：为什么必须有队列 —— `pop_alerts` 是**破坏性**的（取走即从
@@ -141,6 +165,13 @@ struct ht_session_ctx {
 
   // 本轮 save_resume_data 失败的个数（诊断用，随每轮保存清零）。
   int resume_failed = 0;
+
+  // TODO-1961-c：改名 / 移动的回执槽。两者都是**异步**的：调用只是把请求排进
+  // libtorrent，成没成只能从 file_renamed_alert / file_rename_failed_alert /
+  // storage_moved_alert / storage_moved_failed_alert 得知。同一时刻只允许一个
+  // 在飞（Dart 侧是同步 FFI 调用，天然串行），故一个槽足够，不必建队列。
+  StorageOp rename_op;
+  StorageOp move_op;
 };
 
 ht_session_ctx* as_ctx(void* session) {
@@ -196,7 +227,41 @@ void drain_alerts(ht_session_ctx* ctx) {
       ctx->resume_failed++;
       continue;
     }
+    // TODO-1961-c：改名 / 移动的回执。
+    if (const auto* fr = lt::alert_cast<lt::file_renamed_alert>(a)) {
+      ctx->rename_op.settle(true, fr->new_name());
+      continue;
+    }
+    if (const auto* rf = lt::alert_cast<lt::file_rename_failed_alert>(a)) {
+      ctx->rename_op.settle(false, rf->error.message());
+      continue;
+    }
+    if (const auto* sm = lt::alert_cast<lt::storage_moved_alert>(a)) {
+      ctx->move_op.settle(true, sm->storage_path());
+      continue;
+    }
+    if (const auto* mf = lt::alert_cast<lt::storage_moved_failed_alert>(a)) {
+      ctx->move_op.settle(false, mf->error.message());
+      continue;
+    }
   }
+}
+
+// 等一个异步存储操作落地（或超时）。挂在 wait_for_alert 上，**不** sleep 轮询。
+// 返回 true = 已落地（成没成看 op.ok）；false = 超时。
+bool await_storage_op(ht_session_ctx* ctx, const StorageOp& op, int timeout_ms) {
+  const int budget_ms = timeout_ms > 0 ? timeout_ms : 15000;
+  const std::chrono::steady_clock::time_point deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(budget_ms);
+  while (op.pending > 0) {
+    const std::chrono::steady_clock::time_point now =
+        std::chrono::steady_clock::now();
+    if (now >= deadline) return false;
+    ctx->ses.wait_for_alert(
+        std::chrono::duration_cast<lt::time_duration>(deadline - now));
+    drain_alerts(ctx);
+  }
+  return true;
 }
 
 // 按小写十六进制 infohash 找种子；找不到返回无效 handle。
@@ -851,6 +916,71 @@ HT_EXPORT int ht_remove_torrent(void* session, const char* info_hash,
     return 1;
   } catch (...) {
     return 0;
+  }
+}
+
+HT_EXPORT char* ht_rename_file(void* session, const char* info_hash,
+                               int file_index, const char* new_path,
+                               int timeout_ms) {
+  if (session == nullptr) return json_error("session is null");
+  if (new_path == nullptr || *new_path == '\0') {
+    return json_error("new_path is empty");
+  }
+  if (file_index < 0) return json_error("file_index is negative");
+  try {
+    ht_session_ctx* ctx = as_ctx(session);
+    lt::torrent_handle h = find_torrent(&ctx->ses, info_hash);
+    if (!h.is_valid()) return json_error("torrent not found");
+    if (!h.torrent_file()) return json_error("no metadata");
+
+    // 先把之前可能残留的回执清掉再发，避免读到上一次的结果。
+    drain_alerts(ctx);
+    ctx->rename_op.arm();
+    h.rename_file(lt::file_index_t(file_index), std::string(new_path));
+    if (!await_storage_op(ctx, ctx->rename_op, timeout_ms)) {
+      return json_error("rename timed out");
+    }
+    if (!ctx->rename_op.ok) return json_error(ctx->rename_op.detail);
+    std::string out = "{\"ok\":true,";
+    append_json_str_field(out, "path", ctx->rename_op.detail);
+    out += '}';
+    return dup_string(out);
+  } catch (const std::exception& e) {
+    return json_error(e.what());
+  } catch (...) {
+    return json_error("unknown error in ht_rename_file");
+  }
+}
+
+HT_EXPORT char* ht_move_storage(void* session, const char* info_hash,
+                                const char* new_save_path, int timeout_ms) {
+  if (session == nullptr) return json_error("session is null");
+  if (new_save_path == nullptr || *new_save_path == '\0') {
+    return json_error("new_save_path is empty");
+  }
+  try {
+    ht_session_ctx* ctx = as_ctx(session);
+    lt::torrent_handle h = find_torrent(&ctx->ses, info_hash);
+    if (!h.is_valid()) return json_error("torrent not found");
+
+    drain_alerts(ctx);
+    ctx->move_op.arm();
+    // fail_if_exist：目标已有同名文件就**整体失败**，绝不覆盖用户数据、也绝不
+    // 「跳过已存在的、搬走其余的」留下半个内容目录。用户拿到明确错误后自己决定
+    // （libtorrent 的默认 always_replace_files 会直接覆盖，对用户数据太危险）。
+    h.move_storage(std::string(new_save_path), lt::move_flags_t::fail_if_exist);
+    if (!await_storage_op(ctx, ctx->move_op, timeout_ms)) {
+      return json_error("move timed out");
+    }
+    if (!ctx->move_op.ok) return json_error(ctx->move_op.detail);
+    std::string out = "{\"ok\":true,";
+    append_json_str_field(out, "path", ctx->move_op.detail);
+    out += '}';
+    return dup_string(out);
+  } catch (const std::exception& e) {
+    return json_error(e.what());
+  } catch (...) {
+    return json_error("unknown error in ht_move_storage");
   }
 }
 

--- a/native/hibiki_torrent/hibiki_torrent_ffi.cpp
+++ b/native/hibiki_torrent/hibiki_torrent_ffi.cpp
@@ -127,15 +127,24 @@ struct StorageOp {
   int pending = 0;
   bool ok = false;
   std::string detail;
+  lt::torrent_handle handle;
+  int file_index = -1;
 
-  void arm() {
+  bool arm(lt::torrent_handle target, int index = -1) {
+    // 超时只代表调用方不再等，不代表 libtorrent 已取消操作。迟到 alert 在被
+    // drain 之前必须继续占着槽；否则下一次调用会把它误认成自己的回执。
+    if (pending > 0) return false;
     pending = 1;
     ok = false;
     detail.clear();
+    handle = std::move(target);
+    file_index = index;
+    return true;
   }
 
   void settle(bool success, std::string message) {
-    if (pending > 0) pending--;
+    if (pending <= 0) return;
+    pending = 0;
     ok = success;
     detail = std::move(message);
   }
@@ -229,19 +238,31 @@ void drain_alerts(ht_session_ctx* ctx) {
     }
     // TODO-1961-c：改名 / 移动的回执。
     if (const auto* fr = lt::alert_cast<lt::file_renamed_alert>(a)) {
-      ctx->rename_op.settle(true, fr->new_name());
+      if (ctx->rename_op.pending > 0 &&
+          ctx->rename_op.handle == fr->handle &&
+          ctx->rename_op.file_index == int(fr->index)) {
+        ctx->rename_op.settle(true, fr->new_name());
+      }
       continue;
     }
     if (const auto* rf = lt::alert_cast<lt::file_rename_failed_alert>(a)) {
-      ctx->rename_op.settle(false, rf->error.message());
+      if (ctx->rename_op.pending > 0 &&
+          ctx->rename_op.handle == rf->handle &&
+          ctx->rename_op.file_index == int(rf->index)) {
+        ctx->rename_op.settle(false, rf->error.message());
+      }
       continue;
     }
     if (const auto* sm = lt::alert_cast<lt::storage_moved_alert>(a)) {
-      ctx->move_op.settle(true, sm->storage_path());
+      if (ctx->move_op.pending > 0 && ctx->move_op.handle == sm->handle) {
+        ctx->move_op.settle(true, sm->storage_path());
+      }
       continue;
     }
     if (const auto* mf = lt::alert_cast<lt::storage_moved_failed_alert>(a)) {
-      ctx->move_op.settle(false, mf->error.message());
+      if (ctx->move_op.pending > 0 && ctx->move_op.handle == mf->handle) {
+        ctx->move_op.settle(false, mf->error.message());
+      }
       continue;
     }
   }
@@ -935,7 +956,9 @@ HT_EXPORT char* ht_rename_file(void* session, const char* info_hash,
 
     // 先把之前可能残留的回执清掉再发，避免读到上一次的结果。
     drain_alerts(ctx);
-    ctx->rename_op.arm();
+    if (!ctx->rename_op.arm(h, file_index)) {
+      return json_error("previous rename is still pending");
+    }
     h.rename_file(lt::file_index_t(file_index), std::string(new_path));
     if (!await_storage_op(ctx, ctx->rename_op, timeout_ms)) {
       return json_error("rename timed out");
@@ -964,7 +987,9 @@ HT_EXPORT char* ht_move_storage(void* session, const char* info_hash,
     if (!h.is_valid()) return json_error("torrent not found");
 
     drain_alerts(ctx);
-    ctx->move_op.arm();
+    if (!ctx->move_op.arm(h)) {
+      return json_error("previous move is still pending");
+    }
     // fail_if_exist：目标已有同名文件就**整体失败**，绝不覆盖用户数据、也绝不
     // 「跳过已存在的、搬走其余的」留下半个内容目录。用户拿到明确错误后自己决定
     // （libtorrent 的默认 always_replace_files 会直接覆盖，对用户数据太危险）。

--- a/native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h
+++ b/native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h
@@ -158,6 +158,33 @@ HT_EXPORT int ht_remove_torrent(void* session, const char* info_hash,
                                 int delete_files);
 
 // 释放本库返回的 char* 串；传 NULL 为 no-op。
+// TODO-1961-c：把种子内第 [file_index] 个文件改名成 [new_path]（种子内相对
+// 路径，可含子目录；分隔符用 '/'）。**引擎侧改名**，所以做种不断 —— 引擎自己
+// 知道数据换了名字，继续从新名字读盘上传。
+//
+// 同步语义：libtorrent 的 rename_file 是异步的（回执走 file_renamed_alert /
+// file_rename_failed_alert），本函数挂在 wait_for_alert 上等回执，最多
+// [timeout_ms] 毫秒（<=0 取默认 15000）。
+//
+// 返回 {"ok":true,"path":"<种子内新相对路径>"}；失败
+// {"ok":false,"error":"..."}，error 原样带回引擎给的原因（如目标已存在、
+// 权限不足），调用方必须显示给用户，不得吞掉。
+HT_EXPORT char* ht_rename_file(void* session, const char* info_hash,
+                               int file_index, const char* new_path,
+                               int timeout_ms);
+
+// TODO-1961-c：把种子的内容整体移动到 [new_save_path]（新的 save_path）。
+// 同样是**引擎侧移动**，做种不断。
+//
+// 用 libtorrent 的 `fail_if_exist`：目标已有同名文件就整体失败，**绝不覆盖**
+// 用户数据，也绝不「跳过已存在的、搬走其余的」留下半个内容目录。
+// （libtorrent 默认的 always_replace_files 会直接覆盖，对用户数据太危险。）
+//
+// 同步语义同 ht_rename_file（回执走 storage_moved_alert /
+// storage_moved_failed_alert）。返回 {"ok":true,"path":"<新 save_path>"}。
+HT_EXPORT char* ht_move_storage(void* session, const char* info_hash,
+                                const char* new_save_path, int timeout_ms);
+
 // TODO-1961-a：把当前 session 里**所有已有元数据**的种子的 resume data 落盘到
 // [out_dir]（每种子一个 `<infohash>.resume`，先写 .tmp 再 rename，绝不留半个
 // 文件）。resume 里带 info dict，故磁力添加的种子重启后无需再取元数据。

--- a/packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart
+++ b/packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart
@@ -330,6 +330,32 @@ class HtPieceEvent {
   final int piece;
 }
 
+/// 一次异步存储操作（[EmbeddedTorrentSession.renameFile] /
+/// [EmbeddedTorrentSession.moveStorage]）的结果。
+class HtStorageOpResult {
+  const HtStorageOpResult({required this.ok, this.path, this.error});
+
+  /// 操作是否成功落地（引擎已回执且无错）。
+  final bool ok;
+
+  /// 成功时的新路径：改名 = 种子内新相对路径；移动 = 新的 save_path。
+  final String? path;
+
+  /// 失败原因（引擎原文，或超时 / 种子不存在等）。**必须**反馈给用户。
+  final String? error;
+
+  factory HtStorageOpResult._fromJson(Object? json) {
+    if (json is! Map<String, dynamic>) {
+      return const HtStorageOpResult(ok: false, error: 'bad native response');
+    }
+    return HtStorageOpResult(
+      ok: json['ok'] == true,
+      path: json['path'] as String?,
+      error: json['error'] as String?,
+    );
+  }
+}
+
 /// 一轮 [EmbeddedTorrentSession.saveResumeData] 的结果。
 class HtResumeSaveResult {
   const HtResumeSaveResult({
@@ -575,6 +601,55 @@ class EmbeddedTorrentSession {
               piece: (e['piece'] as num?)?.toInt() ?? -1,
             ))
         .toList(growable: false);
+  }
+
+  /// TODO-1961-c：引擎侧给种子内第 [fileIndex] 个文件改名（[newPath] 是种子内
+  /// 相对路径，可含子目录，分隔符 `/`）。**做种不断** —— 引擎知道数据换了名字，
+  /// 继续从新名字读盘上传。
+  ///
+  /// 返回 [HtStorageOpResult]：失败时 `error` 原样带回引擎给的原因，调用方
+  /// 必须显示给用户（不得吞成一个光秃秃的 false）。
+  HtStorageOpResult renameFile(
+    String infoHash,
+    int fileIndex,
+    String newPath, {
+    int timeoutMs = 15000,
+  }) {
+    if (isClosed) {
+      return const HtStorageOpResult(ok: false, error: 'session closed');
+    }
+    final Pointer<Char> id = infoHash.toNativeUtf8().cast<Char>();
+    final Pointer<Char> target = newPath.toNativeUtf8().cast<Char>();
+    try {
+      return HtStorageOpResult._fromJson(_engine._consumeJson(
+          _b.ht_rename_file(_session, id, fileIndex, target, timeoutMs)));
+    } finally {
+      malloc.free(id);
+      malloc.free(target);
+    }
+  }
+
+  /// TODO-1961-c：引擎侧把种子内容整体移动到 [newSavePath]（做种不断）。
+  ///
+  /// 目标已有同名文件时**整体失败**（libtorrent `fail_if_exist`），绝不覆盖
+  /// 用户数据、也绝不留下搬了一半的内容目录。
+  HtStorageOpResult moveStorage(
+    String infoHash,
+    String newSavePath, {
+    int timeoutMs = 15000,
+  }) {
+    if (isClosed) {
+      return const HtStorageOpResult(ok: false, error: 'session closed');
+    }
+    final Pointer<Char> id = infoHash.toNativeUtf8().cast<Char>();
+    final Pointer<Char> target = newSavePath.toNativeUtf8().cast<Char>();
+    try {
+      return HtStorageOpResult._fromJson(_engine
+          ._consumeJson(_b.ht_move_storage(_session, id, target, timeoutMs)));
+    } finally {
+      malloc.free(id);
+      malloc.free(target);
+    }
   }
 
   /// TODO-1961-a：把当前所有已有元数据的种子的 resume data 落盘到 [dir]

--- a/packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart
+++ b/packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart
@@ -402,6 +402,53 @@ class HibikiTorrentBindings {
   late final _ht_remove_torrent = _ht_remove_torrentPtr.asFunction<
       int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>, int)>();
 
+  /// 引擎侧给种子内第 file_index 个文件改名（做种不断）；同步等回执最多
+  /// timeout_ms。返回 malloc JSON（ht_free_string 释放）。
+  ffi.Pointer<ffi.Char> ht_rename_file(
+    ffi.Pointer<ffi.Void> session,
+    ffi.Pointer<ffi.Char> info_hash,
+    int file_index,
+    ffi.Pointer<ffi.Char> new_path,
+    int timeout_ms,
+  ) {
+    return _ht_rename_file(
+        session, info_hash, file_index, new_path, timeout_ms);
+  }
+
+  late final _ht_rename_filePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Char>,
+              ffi.Int,
+              ffi.Pointer<ffi.Char>,
+              ffi.Int)>>('ht_rename_file');
+  late final _ht_rename_file = _ht_rename_filePtr.asFunction<
+      ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>,
+          ffi.Pointer<ffi.Char>, int, ffi.Pointer<ffi.Char>, int)>();
+
+  /// 引擎侧把种子内容整体移动到 new_save_path（做种不断；目标已存在则整体
+  /// 失败，绝不覆盖）。返回 malloc JSON（ht_free_string 释放）。
+  ffi.Pointer<ffi.Char> ht_move_storage(
+    ffi.Pointer<ffi.Void> session,
+    ffi.Pointer<ffi.Char> info_hash,
+    ffi.Pointer<ffi.Char> new_save_path,
+    int timeout_ms,
+  ) {
+    return _ht_move_storage(session, info_hash, new_save_path, timeout_ms);
+  }
+
+  late final _ht_move_storagePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(
+              ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Char>,
+              ffi.Pointer<ffi.Char>,
+              ffi.Int)>>('ht_move_storage');
+  late final _ht_move_storage = _ht_move_storagePtr.asFunction<
+      ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>,
+          ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Char>, int)>();
+
   /// 把所有已有元数据的种子的 resume data 落盘到 out_dir；同步等待最多
   /// timeout_ms（<=0 取默认 5000）。返回 malloc JSON（ht_free_string 释放）。
   ffi.Pointer<ffi.Char> ht_save_resume_data(

--- a/packages/hibiki_torrent/test/rename_move_seeding_test.dart
+++ b/packages/hibiki_torrent/test/rename_move_seeding_test.dart
@@ -1,0 +1,275 @@
+// TODO-1961-c：引擎侧改名 / 移动**不掐断做种**的端到端证明。
+//
+// 这正是用户诉求的核心：「我把下好的东西整理一下，别把上传搞断」。
+// 在资源管理器里手动改名永远救不回来（app 收不到通知，引擎按旧路径读盘直接
+// 失败）；能救的做法只有一条 —— 让引擎自己去改，它改完就知道数据在哪。
+//
+// 测试构造：本地 rig 下完一份内容 → 改名 / 移动 → 断言
+//   ① 引擎报告成功且给出新路径；
+//   ② 新路径**在磁盘上真的存在**、旧路径已消失；
+//   ③ 种子仍然完整（每个 piece 都在）且仍处于做种态 —— 即上传能力没断。
+// ③ 是关键：如果引擎丢了数据，libtorrent 会掉出 seeding 并把 piece 标成缺失。
+//
+// 库路径解析同其它 native 测试：HIBIKI_TORRENT_LIB 指向 DLL；缺库整组 skip。
+
+import 'dart:io';
+
+import 'package:hibiki_torrent/hibiki_torrent.dart';
+import 'package:hibiki_torrent/testing.dart';
+import 'package:test/test.dart';
+
+String? _resolveLibPath() {
+  final String? env = Platform.environment['HIBIKI_TORRENT_LIB'];
+  if (env != null && env.isNotEmpty) {
+    return File(env).existsSync() ? env : null;
+  }
+  return null;
+}
+
+Future<void> _pollUntil(
+  bool Function() done, {
+  required Duration timeout,
+  required String what,
+  void Function()? onTick,
+}) async {
+  final Stopwatch sw = Stopwatch()..start();
+  while (!done()) {
+    if (sw.elapsed > timeout) fail('timeout waiting for $what');
+    onTick?.call();
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+}
+
+void main() {
+  final String? explicit = _resolveLibPath();
+
+  EmbeddedTorrentEngine? tryOpen() {
+    try {
+      return EmbeddedTorrentEngine.open(libraryPath: explicit);
+    } on ArgumentError {
+      return null;
+    }
+  }
+
+  final EmbeddedTorrentEngine? engine = tryOpen();
+  final String? skip =
+      engine == null ? 'hibiki_torrent_ffi native lib not built' : null;
+
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('ht_rename_');
+  });
+
+  tearDown(() {
+    try {
+      tempDir.deleteSync(recursive: true);
+    } on FileSystemException {
+      // Windows 上偶发句柄未释放；留给系统临时目录清理。
+    }
+  });
+
+  /// 起一个已经下完（因而在做种）的 session，返回它与下载目录。
+  Future<(EmbeddedTorrentSession, LocalSeedRig, Directory)>
+      seedingSession() async {
+    final LocalSeedRig rig = await LocalSeedRig.start(
+        engine: engine!, workDir: tempDir, contentBytes: 512 * 1024);
+    addTearDown(rig.dispose);
+
+    final EmbeddedTorrentSession? leecher =
+        EmbeddedTorrentSession.open(engine, listenInterfaces: '127.0.0.1:0');
+    expect(leecher, isNotNull);
+    addTearDown(leecher!.close);
+
+    final Directory dlDir = Directory('${tempDir.path}/dl')..createSync();
+    final HtAddResult added =
+        leecher.addMagnet(rig.magnetUri, savePath: dlDir.path);
+    expect(added.ok, isTrue, reason: 'addMagnet: ${added.error}');
+    expect(
+        leecher.connectPeer(rig.infoHash, '127.0.0.1', rig.seederPort), isTrue);
+
+    await _pollUntil(
+      () {
+        final HtTorrentStatus? t = leecher
+            .listTorrents()
+            .where((HtTorrentStatus e) => e.id == rig.infoHash)
+            .firstOrNull;
+        return t != null && t.isFinished && t.progress >= 1.0 && t.left == 0;
+      },
+      timeout: const Duration(seconds: 120),
+      what: 'download completion',
+      onTick: () =>
+          leecher.connectPeer(rig.infoHash, '127.0.0.1', rig.seederPort),
+    );
+    return (leecher, rig, dlDir);
+  }
+
+  /// 断言种子仍然完整且在做种 —— 即上传没断。
+  Future<void> expectStillSeeding(
+      EmbeddedTorrentSession session, String infoHash) async {
+    await _pollUntil(
+      () {
+        final HtTorrentStatus? t = session
+            .listTorrents()
+            .where((HtTorrentStatus e) => e.id == infoHash)
+            .firstOrNull;
+        return t != null && t.isSeeding;
+      },
+      timeout: const Duration(seconds: 30),
+      what: 'torrent to stay in seeding state',
+    );
+    final HtPieceMap? pieces = session.torrentPieces(infoHash);
+    expect(pieces, isNotNull);
+    expect(pieces!.haveCount, pieces.numPieces,
+        reason: 'every piece must still be present — a broken rename/move '
+            'would make libtorrent drop out of seeding with missing pieces');
+  }
+
+  test(
+    'renameFile keeps seeding: engine follows the new name on disk',
+    () async {
+      final (
+        EmbeddedTorrentSession session,
+        LocalSeedRig rig,
+        Directory dlDir
+      ) = await seedingSession();
+
+      final List<HtFileEntry>? before = session.torrentFiles(rig.infoHash);
+      expect(before, hasLength(1));
+      final String oldName = before!.single.path;
+      final File oldFile = File('${dlDir.path}/$oldName');
+      expect(oldFile.existsSync(), isTrue);
+
+      const String newName = '整理过的名字.bin';
+      final HtStorageOpResult result =
+          session.renameFile(rig.infoHash, before.single.index, newName);
+      expect(result.ok, isTrue, reason: 'rename failed: ${result.error}');
+      expect(result.path, newName);
+
+      // 磁盘上真的换了名字（不是只改了引擎内部的账本）。
+      expect(File('${dlDir.path}/$newName').existsSync(), isTrue);
+      expect(oldFile.existsSync(), isFalse);
+
+      // 引擎的文件列表跟着变，且做种没断。
+      final List<HtFileEntry>? after = session.torrentFiles(rig.infoHash);
+      expect(after!.single.path, newName);
+      expect(after.single.done, after.single.size);
+      await expectStillSeeding(session, rig.infoHash);
+    },
+    skip: skip,
+    timeout: const Timeout(Duration(minutes: 4)),
+  );
+
+  test(
+    'renameFile can move a file into a subdirectory of the torrent',
+    () async {
+      final (
+        EmbeddedTorrentSession session,
+        LocalSeedRig rig,
+        Directory dlDir
+      ) = await seedingSession();
+
+      final List<HtFileEntry>? before = session.torrentFiles(rig.infoHash);
+      const String nested = 'Season 1/ep01.bin';
+      final HtStorageOpResult result =
+          session.renameFile(rig.infoHash, before!.single.index, nested);
+      expect(result.ok, isTrue, reason: 'rename failed: ${result.error}');
+
+      expect(File('${dlDir.path}/Season 1/ep01.bin').existsSync(), isTrue,
+          reason: 'engine must create the subdirectory and move data into it');
+      await expectStillSeeding(session, rig.infoHash);
+    },
+    skip: skip,
+    timeout: const Timeout(Duration(minutes: 4)),
+  );
+
+  test(
+    'moveStorage keeps seeding: content lands in the new save path',
+    () async {
+      final (
+        EmbeddedTorrentSession session,
+        LocalSeedRig rig,
+        Directory dlDir
+      ) = await seedingSession();
+
+      final List<HtFileEntry>? files = session.torrentFiles(rig.infoHash);
+      final String name = files!.single.path;
+      expect(File('${dlDir.path}/$name').existsSync(), isTrue);
+
+      final Directory target = Directory('${tempDir.path}/moved');
+      final HtStorageOpResult result =
+          session.moveStorage(rig.infoHash, target.path);
+      expect(result.ok, isTrue, reason: 'move failed: ${result.error}');
+      expect(result.path, isNotNull);
+
+      expect(File('${target.path}/$name').existsSync(), isTrue,
+          reason: 'content must exist under the new save path');
+      expect(File('${dlDir.path}/$name').existsSync(), isFalse,
+          reason:
+              'move must not leave a copy behind (it is a move, not a copy)');
+
+      // savePath 跟着变，做种没断。
+      final HtTorrentStatus moved = session
+          .listTorrents()
+          .firstWhere((HtTorrentStatus t) => t.id == rig.infoHash);
+      expect(File(moved.contentPath).existsSync(), isTrue);
+      await expectStillSeeding(session, rig.infoHash);
+    },
+    skip: skip,
+    timeout: const Timeout(Duration(minutes: 4)),
+  );
+
+  test(
+    'moveStorage refuses to overwrite an existing file at the destination',
+    () async {
+      final (
+        EmbeddedTorrentSession session,
+        LocalSeedRig rig,
+        Directory dlDir
+      ) = await seedingSession();
+
+      final List<HtFileEntry>? files = session.torrentFiles(rig.infoHash);
+      final String name = files!.single.path;
+
+      // 目标目录里先放一个同名文件（模拟「那边已经有一份了」）。
+      final Directory target = Directory('${tempDir.path}/occupied')
+        ..createSync(recursive: true);
+      final File squatter = File('${target.path}/$name')
+        ..writeAsStringSync('do not clobber me');
+
+      final HtStorageOpResult result =
+          session.moveStorage(rig.infoHash, target.path);
+      expect(result.ok, isFalse,
+          reason: 'must refuse rather than overwrite user data');
+      expect(result.error, isNotNull);
+
+      // 用户的文件一个字节都没被动，源内容也还在（不是搬了一半）。
+      expect(squatter.readAsStringSync(), 'do not clobber me');
+      expect(File('${dlDir.path}/$name').existsSync(), isTrue);
+      await expectStillSeeding(session, rig.infoHash);
+    },
+    skip: skip,
+    timeout: const Timeout(Duration(minutes: 4)),
+  );
+
+  test(
+    'rename/move on an unknown torrent reports an error instead of crashing',
+    () {
+      final EmbeddedTorrentSession? session =
+          EmbeddedTorrentSession.open(engine!, listenInterfaces: '');
+      expect(session, isNotNull);
+      addTearDown(session!.close);
+
+      final HtStorageOpResult renamed =
+          session.renameFile('0' * 40, 0, 'whatever.bin');
+      expect(renamed.ok, isFalse);
+      expect(renamed.error, isNotNull);
+
+      final HtStorageOpResult moved =
+          session.moveStorage('0' * 40, tempDir.path);
+      expect(moved.ok, isFalse);
+      expect(moved.error, isNotNull);
+    },
+    skip: skip,
+  );
+}


### PR DESCRIPTION
完成 **TODO-1961-②「改名后还能上传」** 的全部五步（a→e）。

用户明确选了「**在 Hibiki 内改名/移动**」这条路。另一条「在资源管理器里改完希望 app 跟上」**技术上救不回来** —— app 收不到任何文件系统通知，等下一轮轮询时引擎按旧路径读盘已经失败了；这一点写进了改名对话框的说明文案。

评估文档 `docs/specs/2026-07-26-download-dir-configurable-and-rename-seeding-eval.md` 追加了「6. a/b 落地记录」「7. c/d/e 落地记录」「8. 明确做不到的事」。

---

## 为什么 a/b 是前置，不是并列项

在此之前内置引擎的 session 是**纯内存**的 —— native 侧没有任何 `save_resume_data` / 启动重加路径，于是**每次重启 app，所有种子（下载中 + 做种中）全部蒸发**：做种断、续传断，`AnimeDownloadService` 还会在 48h 后把仍是 `downloading` 的计划判失败。不补上它，「改名不掐做种」的收益上限只有「同一次 app 会话内」这一个窗口。

### a｜resume data 持久化

`ht_save_resume_data` / `ht_load_resume_dir`。save 带 `save_info_dict`（磁力种子恢复后无需再取元数据）；`wait_for_alert` 等回执而不是 sleep 猜；先写 `.tmp` 再 rename（半个 resume 文件会让整个种子加不回来）。resume 目录是 `<计划目录>/resume` —— **跟数据根走、不跟用户配置的下载根走**，因为它是 app 状态而非下载内容。

**两条必须守住的不变量**：
1. **计划是真相源**：resume 目录只是计划集合的落盘镜像，load 与 save 之后都按 `keepIds` 剪枝。否则用户删掉的任务会靠残留 `.resume` 复活成「UI 里看不见、却在后台占带宽做种」的幽灵种子。
2. **BUG-1053 不许破**：启动时**只有**「resume 目录里存在属于现存计划的 `.resume`」才建 session。没下载过东西的用户依然不绑端口、不起 DHT。

### b｜alert 分派收割

根因不是「缺一条通用 alert 通道」，而是 **`pop_alerts` 是破坏性的、却要有多个消费者**：原 `ht_poll_piece_events` 一边 pop 一边把非 piece 的 alert 全丢掉，看起来「无状态」；一旦 resume 的完成信号也要 alert，两个消费者就会静默互吃。

改成**一个 session 一个收割点**：句柄从裸 `lt::session*` 换成 `ht_session_ctx`，`drain_alerts` 按类型分派，各 poll 只读自己的队列。`as_session()` 保留原签名，21 处既有调用点零改动。piece 队列封顶 4096（生产端只有边下边播才消费，而 resume 保存每分钟也会 drain —— 无上限会一直涨）。

---

## c/d/e：真正的「改名不掐做种」

### c｜引擎侧改名 / 移动

`ht_rename_file` / `ht_move_storage`，复用 b 的分派加四种回执。`TorrentBackend` 契约加 `renameFile`/`moveStorage` + `TorrentStorageResult`（返回结构体而非 bool：失败原因必须能原样呈现给用户）。外接 qb 走 `renameFile`/`setLocation` 对齐 —— qb 认的是旧相对路径而非下标，故 backend 先用文件列表把下标翻成路径。

**`move_storage` 用 `fail_if_exist`**：libtorrent 默认 `always_replace_files` 会直接覆盖目标同名文件，对用户数据太危险；`dont_replace` 又会静默跳过已存在的、留下搬了一半的内容目录。只有「目标非空就整体失败、让用户自己决定」可接受。

### d｜库路径迁移

视频库此前**没有任何**更新 `videoPath` 的 API。新增 `video_path_migration.dart`（纯函数重映射规则）+ `VideoBookRepository.migrateMediaPaths`（三列、一个事务）。

字幕列是四态编码（绝对路径 / `embedded:<n>` / `off:` / null），把哨兵当路径拼一遍就是静默损坏，故逐个排除哨兵与流媒体 URL。路径比较一律走 `package:path` —— 手写 `startsWith` 会让 `D:\a` 误匹配 `D:\ab`。

### c+d 原子性

`DownloadRelocateService`：**引擎先动、成了再迁库**。引擎那步才是会失败的一步，它失败就直接返回、库一个字节不动，所以失败态永远是「什么都没变」。三种结局分开报：`success` / `engineFailed`（磁盘与库都没动）/ `libraryFailed`（磁盘动了、库没跟上 —— 必须让用户知道，不能当成功）。

### e｜UI

下载任务行「重命名 / 移动」入口 + `_RelocateDialog`（上半移动整个任务、下半逐文件改名）。8 个 i18n key × 17 语言。

---

## 验证

| 测试 | 覆盖 |
|---|---|
| `resume_persistence_test.dart` | 下完 → 存 → **关掉整个 session** → 新 session **全程零 peer**（`enableDht:false`、不 `connectPeer`、纯 btih 无 tracker）→ 种子回来、`hasMetadata`、`numPeers == 0`、每个 piece 都在、进入做种。零 peer 是全部说服力：完成度只能来自磁盘 |
| `rename_move_seeding_test.dart`（5） | 改名 / 改到子目录 / 移动 / 拒绝覆盖 / 未知种子报错。每项都断言磁盘真的变了 + 旧路径消失 + 每个 piece 还在 + **仍处于做种态**（引擎丢数据的话 libtorrent 会掉出 seeding 并把 piece 标缺失）。拒绝覆盖那条还断言占位文件一个字节没变、源内容也还在 |
| `download_relocate_service_test.dart`（15） | 重映射规则全部边界（哨兵 / URL / 兄弟目录误匹配 / 相对路径）+ 原子性（引擎失败库不动 / 库失败不许报成功 / 目标同现状两边都不打扰） |
| `embedded_torrent_host_test.dart`（+3） | resume 剪枝 / 节流 / 空目录（含「被删计划的 resume 必须被剪掉」） |

`flutter analyze` 全量 **0 issue**；`flutter test` 全量 **14423 passed / 0 failed**。Windows DLL 已用 `build_windows_dll.ps1` 重建验证（vcpkg x64-windows）。

> ⚠️ **改了 C ABI，随包预编译 DLL 必须重出**，否则用户装上是旧 DLL、新绑定 `lookup` 直接抛。

## 顺带发现（未修，已记录）

**BUG-1109**：`embedded_pipeline_test` 的 ip_filter 用例本地 flaky。用基线 DLL 与本改动各跑 5 次，**同为 1/5 通过** → 已对照排除本轮改动。根因是 libtorrent 把本地网络 peer 归进独立 local peer class，该 class 不受 session 全局限速约束 → loopback 传输根本没被限速 → 观察窗口消失。CI 不受影响（缺 DLL 整组 skip）。

附带一个**产品侧问题**（已登记 TODO-2002）：既然 local peer class 不受全局限速约束，用户配的上传/下载限速对**局域网 peer 同样不生效** —— 从未声明过，也没有开关。

https://claude.ai/code/session_01PLnkCH8yNHZACcw5LzozN6