### PR TITLE
fix(settings): 「数据存储位置」从同步备份挪到「系统」大类

### DIFF
--- a/hibiki/lib/src/settings/settings_schema_system.dart
+++ b/hibiki/lib/src/settings/settings_schema_system.dart
@@ -5,6 +5,8 @@ import 'package:hibiki/pages.dart';
 import 'package:hibiki/src/settings/settings_actions.dart';
 import 'package:hibiki/src/settings/settings_context.dart';
 import 'package:hibiki/src/settings/settings_destination.dart';
+import 'package:hibiki/src/sync/sync_settings_schema.dart'
+    show buildDataStorageLocationSection;
 import 'package:hibiki/src/utils/misc/crash_dump_locator.dart';
 import 'package:hibiki/src/utils/misc/platform_updater.dart';
 import 'package:hibiki/utils.dart';
@@ -101,6 +103,10 @@ SettingsDestination buildSystemDestination() {
           ),
         ],
       ),
+      // 「数据存储位置」从同步备份大类挪来（用户拍板：数据根是设备级存储配置，
+      // 与备份无关）。构建函数在 sync_settings_schema（行 widget 是该库私有 part），
+      // item id 'sync.data_storage_location' 不变。
+      buildDataStorageLocationSection(),
       SettingsSection(
         title: t.section_update,
         // 更新分区在所有平台可见（至少能「检查→打开发布页」）；自动安装开关

--- a/hibiki/lib/src/sync/sync_settings_schema.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema.dart
@@ -339,22 +339,28 @@ SettingsDestination buildSyncBackupDestination() {
           ),
         ],
       ),
-      // Group 6: Data storage location — desktop only (TODO-935 E2), appended last so the
-      // existing five-section index contract above is untouched. 移动端沙箱固定，整个 section 用 isDesktopPlatform 门控隐藏；桌面选新目录后走
-      // 已实现的 DataRootMigrator 整目录迁移 + 迁移成功后自动重启。
-      SettingsSection(
-        title: t.settings_section_data_storage,
+    ],
+  );
+}
+
+/// 桌面端「数据存储位置」小节（TODO-935 E2）。历史上挂在同步备份大类尾部，
+/// 2026-07-26 用户拍板挪到「系统」大类展示——数据根是设备级存储配置，与备份无关。
+/// 构建函数留在本库（[_DataRootWidget] 是本库私有 part），由
+/// `settings_schema_system.dart` 调用；item id 保持 'sync.data_storage_location'
+/// 不变（历史命名前缀，搜索/导航锚点，仅换展示分类）。移动端沙箱固定，整个
+/// section 用 isDesktopPlatform 门控隐藏；桌面选新目录后走已实现的
+/// DataRootMigrator 整目录迁移 + 迁移成功后自动重启。
+SettingsSection buildDataStorageLocationSection() {
+  return SettingsSection(
+    title: t.settings_section_data_storage,
+    visible: (SettingsContext ctx) => isDesktopPlatform,
+    collapsedByDefault: true,
+    items: <SettingsItem>[
+      SettingsCustomItem(
+        id: 'sync.data_storage_location',
+        icon: Icons.folder_special_outlined,
         visible: (SettingsContext ctx) => isDesktopPlatform,
-        collapsedByDefault: true,
-        items: <SettingsItem>[
-          SettingsCustomItem(
-            id: 'sync.data_storage_location',
-            icon: Icons.folder_special_outlined,
-            visible: (SettingsContext ctx) => isDesktopPlatform,
-            builder: (SettingsContext ctx) =>
-                _DataRootWidget(settingsContext: ctx),
-          ),
-        ],
+        builder: (SettingsContext ctx) => _DataRootWidget(settingsContext: ctx),
       ),
     ],
   );

--- a/hibiki/test/sync/sync_settings_visibility_test.dart
+++ b/hibiki/test/sync/sync_settings_visibility_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/src/settings/settings_schema_card_creation.dart';
+import 'package:hibiki/src/settings/settings_schema_system.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_settings_schema.dart';
 
@@ -35,17 +36,19 @@ void main() {
     List<String> idsOf(SettingsSection s) =>
         s.items.map((SettingsItem i) => i.id).toList();
 
-    test(
-        'regroups into four intent-based sections + a desktop data-storage tail',
-        () {
+    test('regroups into four intent-based sections', () {
       // 互联（client 配置 / LAN 发现 / host 模式）已拆到独立的
-      // buildInterconnectDestination（见下方 group），同步分类剩：
-      // method / content / actions / backup + 桌面 data-storage 尾巴。
-      expect(dest.sections, hasLength(5));
-      // The appended section is desktop-gated and carries only the data-root row.
-      expect(dest.sections[4].visible, isNotNull,
-          reason: 'data-storage section must be desktop-only gated');
-      expect(idsOf(dest.sections[4]), <String>['sync.data_storage_location']);
+      // buildInterconnectDestination（见下方 group），「数据存储位置」已挪到
+      // 「系统」大类展示（buildDataStorageLocationSection，见下方 group），
+      // 同步分类剩：method / content / actions / backup。
+      expect(dest.sections, hasLength(4));
+      expect(
+        dest.sections
+            .expand((SettingsSection s) => s.items)
+            .where((SettingsItem i) => i.id == 'sync.data_storage_location'),
+        isEmpty,
+        reason: '数据存储位置不再挂在同步备份大类',
+      );
     });
 
     test('group 1 (sync method) holds selector + scoped account/config', () {
@@ -265,6 +268,29 @@ void main() {
       final String fn = src.substring(fnAt, fnAt + 1200);
       expect(fn, contains('setInterconnectEnabled(true)'),
           reason: 'picking 互联 must flip the interconnect master toggle on');
+    });
+  });
+
+  group('buildDataStorageLocationSection placement', () {
+    test('the data-storage section now lives in the system destination', () {
+      // 用户拍板（2026-07-26）：数据根是设备级存储配置，与备份无关，从同步备份
+      // 大类挪到「系统」展示；item id 'sync.data_storage_location' 保持不变
+      // （历史命名前缀，搜索/导航锚点）。
+      final SettingsSection section = buildDataStorageLocationSection();
+      expect(section.visible, isNotNull,
+          reason: 'data-storage section must be desktop-only gated');
+      expect(
+        section.items.map((SettingsItem i) => i.id),
+        <String>['sync.data_storage_location'],
+      );
+      final SettingsDestination system = buildSystemDestination();
+      expect(
+        system.sections
+            .expand((SettingsSection s) => s.items)
+            .where((SettingsItem i) => i.id == 'sync.data_storage_location'),
+        hasLength(1),
+        reason: '系统大类必须恰好承载一份数据存储位置行',
+      );
     });
   });
 


### PR DESCRIPTION
## 背景

用户反馈:「数据存储位置」不应该在备份里面。该行(桌面端数据根迁移,TODO-935 E2)历史上作为 Group 6 挂在「同步备份」大类尾部,但它是设备级存储配置,与备份/同步无关。

## 改动

- `sync_settings_schema.dart`:该节从 `buildSyncBackupDestination()` 摘出,抽成公开的 `buildDataStorageLocationSection()`(行 widget `_DataRootWidget` 是该库私有 part,构建函数留在原库)
- `settings_schema_system.dart`:在「系统 · 通用」之后、「更新」之前插入该节
- item id `'sync.data_storage_location'` **不变**(历史命名前缀,搜索/导航锚点,仅换展示分类,与 `appearance.language` 归位同一惯例)
- 桌面 gating(`isDesktopPlatform`)原样保留,移动端照旧不可见
- `sync_settings_visibility_test.dart`:同步备份结构测试降为 4 节 + 断言数据存储不在其中;新增 group 断言系统大类恰好承载一份

已 rebase 到最新 develop(PR#415 对同文件的改动已并入)。

## 验证

- 全量 `flutter analyze`:No issues found
- `flutter test test/sync/sync_settings_visibility_test.dart test/settings/ --no-pub`:331 passed(含 data_root 守卫、schema 覆盖)

https://claude.ai/code/session_01GJivAbewUf3ekiCP26rD6a