### PR TITLE
fix(storage): 默认数据根不再摊在用户文档根下 —— 新装落 <Documents>/Hibiki/data (BUG-1114)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1081 条。点号进各自文件。
+> 共 1082 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1115](bugs/BUG-1115-default-documents-root-flat.md) | ✅ | ✅ | 默认数据根时 16 个 Hibiki 目录直接摊在用户文档根下 |
 | [BUG-1114](bugs/BUG-1114-local-rig-rate-limit-flake.md) | 🚧 | 🚧 | 内置引擎本地 rig 测试：限速对 loopback peer 不生效导致 peer 观察窗口消失（flaky） |
 | [BUG-1113](bugs/BUG-1113-galgame-no-tags.md) | 🚧 | 🚧 | 游戏没有标签：schema 缺 GalgameTagMappings 表 |
 | [BUG-1112](bugs/BUG-1112-activity-timeline-game-no-cover.md) | ✅ | ✅ | 活动时间轴游戏条目只有图标没有封面 |

--- a/docs/bugs/BUG-1115-default-documents-root-flat.md
+++ b/docs/bugs/BUG-1115-default-documents-root-flat.md
@@ -1,0 +1,87 @@
+## BUG-1115 · 默认数据根时 16 个 Hibiki 目录直接摊在用户文档根下
+- **报告**：2026-07-26（用户：qqbotxiaoxiao）
+- **真实性**：✅ 真 bug — 根因 `hibiki/lib/src/storage/app_paths.dart:196`（改动前）：
+  `_resolveDocumentsRoot()` 在没有自定义数据根时直接 `return getApplicationDocumentsDirectory()`，
+  于是 documentsRoot **等于**平台 `Documents` 本身（Windows = `%USERPROFILE%\Documents`），
+  `AppPaths.hibikiOwnedDocumentsEntries` 那 16 个目录（`audiobooks` / `hoshi_books` /
+  `video_covers` / `game_covers` / `video_subtitles` / `mpv_shaders` / `remote_videos` /
+  `videos` / `anime_downloads` / `custom_fonts` / `hibikiExport` / `browser` / `thumbnails` /
+  `dictionaryResources` / `dictionaryImportWorkingDirectory` / `webArchive`）全部作为顶层项
+  摊在用户文档根下。
+
+  历史成因：TODO-935 E0 把十几处散落的 `getApplicationDocumentsDirectory()` 收敛进 `AppPaths`
+  时，刻意保持「行为等价、旧数据零迁移」，于是「默认根 = 共享用户目录」被固化成常态——
+  TODO-1226 的迁移白名单、`DataRootMigrator` 的选择性搬移模式，都是为这个特殊情况打的补丁。
+
+- **[x] ① 已修复** — commit 见 PR；改动三处：
+  1. `app_paths.dart`：默认 documents 根改为 **`<Documents>/Hibiki/data`**
+     （`defaultDocumentsChildSegments`）。取 `Hibiki/data` 而非 `Hibiki`，是因为
+     `<Documents>/Hibiki` 已被桌面/iOS 的**用户可见导出目录**占用
+     （`DesktopDirectoryService.getHibikiExportDirectory`），数据落其下的 `data/`，
+     文档根下只多出一个 `Hibiki/` 伞，内部数据与导出物分层。
+  2. **老安装零破坏**：新增 `documents_layout` pref（`flat` / `nested`）。判定
+     「support 根下有没有 `hibiki.db`」= 这台机器上是否已有跑过的安装：有 → 锚定 `flat`
+     （documents 根仍是平台 `Documents`，一个字节都不搬）；没有 → `nested`。判定结果
+     **一次性固化**，之后永不重新探测——布局若随「此刻磁盘上有没有某个文件」漂移，同一台
+     机器两次启动就会解析出两个内容根 = 整个书库凭空消失。探测失败/超时一律按老安装处理
+     （保守：宁可新装多摊一次，绝不把老用户切走）。
+     刻意**不**用「Documents 里有没有 `videos`/`browser`/`thumbnails`」当判据：这些名字在
+     用户自己的文档目录里撞名概率不低，全新安装会被误判成老安装。
+
+     **判定只在启动期的 `AppPaths.resolve()` 里做一次**，解析路径（`_resolveDocumentsRoot`
+     / `documentsSubdirectory` 等静态便捷层）**绝不碰文件系统**。这条边界是被测试打出来的：
+     第一版把探测放进解析路径，结果 11 个 `home_video_*` widget 测试集体挂掉——`testWidgets`
+     跑在 FakeAsync 上，真实文件 IO 的 future 在那里永不完成，`.timeout()` 还会留下
+     「Timer is still pending」。解析路径未判定且 prefs 无锚点时兜底 **`flat`**（= 改动前
+     行为），所以没跑过 `resolve()` 的夹具/早期调用一律拿到旧语义，不会被静默切根。
+  4. **iOS 容器重定位跟着修**：`relocateMissingAppDocumentPath`（视频封面/资源在容器 UUID
+     变化后的自愈）是把旧路径里 `Documents/` 之后的相对段拼回当前 documents 根。新布局下
+     那段相对路径**已经包含** `Hibiki/data`，直拼会得到 `.../Documents/Hibiki/data/Hibiki/
+     data/...`，重定位永远落空。改为以「当前根路径里的容器 `Documents` 段」为基准，扁平
+     布局下两者恰好相等、行为逐字节不变。
+  3. **给老安装一条自救路径**：老安装的 documents 根就是共享 `Documents`，想把散落的 16 个
+     目录收进 `Documents\Hibiki` 会被 `validateDataRootTarget` / `DataRootMigrator._validateTarget`
+     的「新数据根不能位于旧数据目录内部」一刀切拒绝。共享根走的是**白名单选择性搬移**——
+     只有白名单顶层项会被搬走，`Hibiki` 不在白名单里、全程是旁观者——所以新增
+     `AppPaths.isSafeNestedTargetInSharedDocuments()`，共享根下的**非白名单**子目录放行；
+     白名单项本身（含其子目录、含大小写变体）仍拒绝，专属根的整树搬移语义下仍拒绝。
+     顺带把 `_currentLocationLabel()` 从显示 `appDirectory.parent`（扁平布局下是用户主目录，
+     新布局下是导出目录，两种都误导）改为显示 documents 根本身。
+
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/storage/app_paths_default_documents_layout_test.dart`（新建，14 例）：
+    新装 → `<Documents>/Hibiki/data`；老装（support 下有 `hibiki.db`）→ 扁平且每个派生点
+    与升级前逐字节一致；两种判定各自固化进 prefs；已锚定后即使主库文件出现/消失也不翻转；
+    **未跑 resolve 且无锚点 → 兜底扁平老布局**；自定义 dataRoot 优先；并发解析拿到同一个
+    根；`isSafeNestedTargetInSharedDocuments` 的白名单/大小写/根内外判定。
+  - `hibiki/test/media/video/video_resource_check_test.dart`（+1 例）：documents 根嵌套在
+    容器 `Documents` 之下时，容器 UUID 变化后仍能重定位，且绝不产出 `Hibiki/data` 拼两遍
+    的路径。
+  - `hibiki/test/media/video/video_cover_repair_test.dart`：封面夹具改为经
+    `AppPaths.videoCoversDirectory()` 解析（与产品侧自愈查的目录同源），不再硬拼
+    `<Documents>/video_covers`。
+  - `hibiki/test/storage/data_root_migrator_test.dart`（+3 例）：共享根内的
+    `Documents\Hibiki` 目标能真正搬成（白名单项离开文档根顶层、共享根本体与用户文件原样
+    保留、DB 路径 rebase）；白名单项当目标仍抛错且旧根一字未动；专属根整树语义下嵌套目标
+    仍抛错。
+  - `hibiki/test/settings/data_root_settings_test.dart`（+4 例 +1 源码守卫）：
+    `validateDataRootTarget` 的 `sharedDocumentsRoot` 放行/拒绝矩阵，以及守卫「共享根判定
+    必须喂给触发前校验」（否则老用户在进确认弹窗之前就被拒）。
+  - 既有 `app_paths_data_root_test.dart` / `write_paths_data_root_test.dart` 的默认根断言
+    同步更新为新布局，并在 setUp/tearDown 清进程内布局缓存。
+
+- **备注**：
+  - 仅改「默认根」的落点，**不做任何自动迁移**：启动期搬整个书库既慢又可能被文件锁半途
+    打断。老用户要整理，走设置 →「数据存储位置」选 `Documents\Hibiki`（迁移引擎会连 DB 里
+    的绝对路径一起 rebase），或任意其它目录。
+  - `ErrorLogService` 的 `error_log.txt` / `*_breadcrumb.txt` 仍直连平台 `Documents`
+    （刻意不随数据根走，搬走会让服务失去续写目标），本次未动——文档根下仍会看到这两类
+    **文件**（不是目录）。要一并收编需单独评估旧日志的续写衔接。
+  - 白名单 `hibikiOwnedDocumentsEntries` 及其守卫 `documents_whitelist_guard_test.dart`
+    **长期有效**：老安装可能永远停在扁平布局，新增 `<documents>/<child>` 派生点仍必须收进
+    白名单。
+  - 未做真机验证（本次是纯路径解析 + 单测可覆盖的逻辑）；真机需验的是：新装首启后
+    `Documents\Hibiki\data` 下出现运行时目录、老装升级后书库/有声书/词典资源全部照常可见。
+  - **本机现有安装（含报告者本人）会被判为老安装、继续用扁平布局**——这是刻意的零破坏
+    设计。要立刻看到文档根变干净，走设置 →「数据存储位置」选 `Documents\Hibiki`（本次
+    放开的正是这条路径），迁移引擎会把 16 个目录搬过去并 rebase DB 里的绝对路径。

--- a/hibiki/lib/src/media/video/video_resource_check.dart
+++ b/hibiki/lib/src/media/video/video_resource_check.dart
@@ -62,8 +62,17 @@ Future<String?> relocateMissingAppDocumentPath(
 
   final Directory root =
       documentsRoot ?? await AppPaths.documentsRootDirectory();
+  // BUG-1115：[relative] 是相对**容器的 `Documents/`** 的，所以基准必须也是容器的
+  // `Documents/`，而不是 documents 根本身。老安装（扁平布局）两者恰好相等；新安装的
+  // documents 根是 `<container>/Documents/Hibiki/data`，直接拼会把 `Hibiki/data` 拼两
+  // 遍（`.../Documents/Hibiki/data/Hibiki/data/...`），重定位永远落空。
+  final List<String> rootSegments = p.split(p.normalize(root.path));
+  final int rootDocumentsIndex = _iosAppDocumentsIndex(rootSegments);
+  final String base = rootDocumentsIndex < 0
+      ? root.path
+      : p.joinAll(rootSegments.sublist(0, rootDocumentsIndex + 1));
   final String relative = p.joinAll(staleSegments.sublist(documentsIndex + 1));
-  final String candidate = p.normalize(p.join(root.path, relative));
+  final String candidate = p.normalize(p.join(base, relative));
   if (p.equals(p.normalize(trimmed), candidate)) return null;
   return await File(candidate).exists() ? candidate : null;
 }

--- a/hibiki/lib/src/storage/app_paths.dart
+++ b/hibiki/lib/src/storage/app_paths.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
+import 'package:hibiki_core/hibiki_core.dart' show hibikiDatabaseFileName;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -15,9 +17,10 @@ import 'package:hibiki/src/utils/misc/platform_utils.dart';
 /// 根」真相源——后续 E1（数据迁移）/E2（设置 UI）/E3（重启换根）无从下手。
 ///
 /// [AppPaths] 把三个根的解析收敛到这里：
-///   - [documentsRoot] —— 内容/书库根（`getApplicationDocumentsDirectory`，
-///     Windows = `%USERPROFILE%\Documents`）。EPUB 正文、有声书音频、视频封面/字幕、
-///     词典资源、缩略图等用户数据都派生自它。
+///   - [documentsRoot] —— 内容/书库根。EPUB 正文、有声书音频、视频封面/字幕、词典资源、
+///     缩略图等用户数据都派生自它。默认（未配置自定义数据根）落平台 Documents 下的
+///     Hibiki 专属容器 `<Documents>/Hibiki/data`；**老安装**仍锚定历史扁平布局
+///     `<Documents>` 本身（见 [_resolveDefaultDocumentsRoot]）。
 ///   - [supportRoot] —— 数据库根（`getApplicationSupportDirectory`，
 ///     Windows = `%APPDATA%\<pkg>`）。`hibiki.db` 与 per-source local-audio DB 落这里。
 ///   - [tempRoot] —— 可丢弃的临时目录（`getTemporaryDirectory`）。
@@ -81,6 +84,12 @@ class AppPaths {
         throw DataRootUnavailableException(configuredPath: configured);
       }
     }
+    // BUG-1115：默认 documents 布局的判定**只在这里**做一次（启动期，真实异步环境）。
+    // 判定要探测文件系统，绝不能塞进 [_resolveDocumentsRoot]——那条路径会被运行时的静态
+    // 便捷层（`documentsSubdirectory` 等）高频调用，其中就包括 widget 测试里的封面/资源
+    // 解析：`testWidgets` 跑在 FakeAsync 上，真实文件 IO 的 future 在那里永不完成、
+    // `.timeout()` 还会留下 pending timer，整批页面测试会挂死或报「Timer is still pending」。
+    await _ensureDocumentsLayoutDecided();
     final Directory documents = await _resolveDocumentsRoot();
     final Directory support = await _resolveSupportRoot();
     final Directory temp = await _resolveTempRoot();
@@ -106,6 +115,41 @@ class AppPaths {
 
   /// `<dataRoot>` 下「数据库/支持」子目录名。
   static const String _dataRootSupportChild = 'support';
+
+  /// BUG-1115：**默认** documents 根的布局键（SharedPreferences，与 [dataRootPrefKey]
+  /// 同一通道，DB 打开前可读）。值只有两个：[_layoutFlat] / [_layoutNested]。
+  ///
+  /// 一经写入就是本机的**永久锚点**，不再重新探测：布局若随「Documents 里此刻有没有某个
+  /// 目录」漂移，同一台机器两次启动就可能解析出两个不同的内容根 = 用户书库凭空消失。
+  static const String documentsLayoutPrefKey = 'documents_layout';
+
+  /// 历史扁平布局：documents 根 = 平台 `Documents` **本身**，16 个 Hibiki 子目录直接摊在
+  /// 用户文档根下。老安装锚定于此（零迁移，见 [_resolveDefaultDocumentsRoot]）。
+  static const String _layoutFlat = 'flat';
+
+  /// 当前默认布局：documents 根 = `<Documents>/Hibiki/data`（Hibiki 专属容器）。
+  static const String _layoutNested = 'nested';
+
+  /// [_layoutNested] 下平台 Documents 到 documents 根的相对路径段。
+  ///
+  /// 为什么是 `Hibiki/data` 而不是 `Hibiki`：`<Documents>/Hibiki` 已经是**用户可见导出
+  /// 目录**（`DesktopDirectoryService.getHibikiExportDirectory` /
+  /// `IosDirectoryService`，卡片导出物落点，刻意不随数据根走）。数据根取它下面的
+  /// `data/`，用户文档根下只多出一个 `Hibiki/` 伞，内部数据与导出物各占一层、互不淹没。
+  static const List<String> defaultDocumentsChildSegments = <String>[
+    'Hibiki',
+    'data',
+  ];
+
+  /// 本进程已判定的默认布局（true=扁平老布局）。由 [_ensureDocumentsLayoutDecided] 在
+  /// 启动期写一次，之后所有解析共用——布局在一次运行里必须恒定。
+  static bool? _legacyFlatDocumentsRoot;
+
+  /// 仅供测试：清掉进程内布局判定，让同一测试文件里的多个用例能各自注入不同的
+  /// prefs / 老安装痕迹（生产永不调用——布局在一次运行里恒定）。
+  @visibleForTesting
+  static void debugResetDocumentsLayoutCache() =>
+      _legacyFlatDocumentsRoot = null;
 
   /// 测试注入钩子：覆盖「读 SharedPreferences 的 data_root」这一步，使 [AppPaths] 的
   /// dataRoot 派生在纯 Dart 单测里可断言（无需平台 SharedPreferences 通道）。返回 null
@@ -193,7 +237,95 @@ class AppPaths {
     if (dataRoot != null) {
       return Directory(p.join(dataRoot.path, _dataRootDocumentsChild));
     }
-    return getApplicationDocumentsDirectory();
+    return _resolveDefaultDocumentsRoot();
+  }
+
+  /// BUG-1115：无自定义数据根时的 documents 根。
+  ///
+  /// 历史上这里直接返回平台 `Documents`，于是 [hibikiOwnedDocumentsEntries] 那 16 个目录
+  /// 全摊在用户文档根下（TODO-935 E0 收敛十几处 `getApplicationDocumentsDirectory()` 时
+  /// 刻意保持零迁移，把「默认根 = 共享用户目录」固化成了常态）。现在默认改为 Hibiki 专属
+  /// 容器 `<Documents>/Hibiki/data`；**老安装保持扁平布局不动**（见
+  /// [_useLegacyFlatDocumentsRoot]），一个字节都不搬。
+  ///
+  /// 老用户要收进子目录，走设置里的「数据存储位置」（[DataRootMigrator] 会连 DB 里的绝对
+  /// 路径一起 rebase）；这里绝不自动迁移——启动期搬整个书库既慢又可能被文件锁半途打断。
+  static Future<Directory> _resolveDefaultDocumentsRoot() async {
+    final Directory platformDocuments =
+        await getApplicationDocumentsDirectory();
+    if (await _useLegacyFlatDocumentsRoot()) return platformDocuments;
+    return Directory(p.joinAll(<String>[
+      platformDocuments.path,
+      ...defaultDocumentsChildSegments,
+    ]));
+  }
+
+  /// 本机默认布局是否为历史扁平布局。**纯读取、绝不探测文件系统**（见 [resolve] 里对
+  /// FakeAsync 的说明）：本进程已判定 → 用判定值；否则读 prefs 里的锚点；连锚点都没有 →
+  /// **扁平老布局**。
+  ///
+  /// 最后那个兜底是保守的一半：没有判定依据时退回 BUG-1115 之前的行为，绝不擅自把一个
+  /// 可能装了满库的机器切到新布局（那会让书库、有声书、词典资源在 UI 上集体消失——文件
+  /// 还在、DB 里的绝对路径也还指向旧位置，但静态派生点全去了新目录）。生产上
+  /// [AppPaths.resolve] 恒在启动最早期跑完 [_ensureDocumentsLayoutDecided]，所以真正走到
+  /// 这个兜底的只有「没跑过 resolve 的测试夹具」。
+  static Future<bool> _useLegacyFlatDocumentsRoot() async {
+    final bool? decided = _legacyFlatDocumentsRoot;
+    if (decided != null) return decided;
+    final SharedPreferences? prefs = await _prefsOrNull();
+    return prefs?.getString(documentsLayoutPrefKey) != _layoutNested;
+  }
+
+  /// 判定 + 固化默认布局。**唯一做探测 IO 的地方**，只由 [resolve] 在启动期调用一次；
+  /// 已判定（本进程判过 / prefs 有锚点）就直接沿用，不再探测。
+  ///
+  /// 判据是 support 根下有没有 `hibiki.db`——即「这台机器上是否已经有一个跑过的安装」。
+  /// 刻意**不**看 Documents 里有没有 `videos` / `browser` / `thumbnails` 这类目录：那些
+  /// 名字在用户自己的文档目录里撞名概率不低，全新安装会被误判成老安装、继续摊开。
+  /// support 根是平台固定落点（`%APPDATA%\<pkg>`），不随本次改动移动，判据稳定。
+  ///
+  /// 探测失败 / 超时一律当**老安装**（保守，同 [_useLegacyFlatDocumentsRoot] 的兜底）。
+  static Future<void> _ensureDocumentsLayoutDecided() async {
+    if (_legacyFlatDocumentsRoot != null) return;
+    final SharedPreferences? prefs = await _prefsOrNull();
+    final String? stored = prefs?.getString(documentsLayoutPrefKey);
+    if (stored == _layoutFlat || stored == _layoutNested) {
+      _legacyFlatDocumentsRoot = stored == _layoutFlat;
+      return;
+    }
+    final bool flat = await _existingInstallHasDatabase();
+    _legacyFlatDocumentsRoot = flat;
+    // 固化锚点（best-effort）。写失败只意味着下次启动再探一次，不改变本次结果——而下次
+    // 探测的判据（hibiki.db 是否存在）此时只会更成立，不会翻转成新布局。
+    try {
+      await prefs?.setString(
+          documentsLayoutPrefKey, flat ? _layoutFlat : _layoutNested);
+    } catch (e) {
+      debugPrint('AppPaths: 固化 documents 布局失败（下次启动重新判定）: $e');
+    }
+  }
+
+  /// support 根下是否已有主库文件 = 本机已存在跑过的安装。与 [_probeDataRootExists] 同一
+  /// 纪律：**只准异步 `exists()` + 超时**，绝不 `existsSync()`（这条路径同样在启动最早期
+  /// 的主 isolate 上跑）。超时/抛错都按「老安装」处理（保守）。
+  static Future<bool> _existingInstallHasDatabase() async {
+    try {
+      final Directory support = await _resolveSupportRoot();
+      return await File(p.join(support.path, hibikiDatabaseFileName))
+          .exists()
+          .timeout(const Duration(seconds: 2), onTimeout: () => true);
+    } catch (_) {
+      return true;
+    }
+  }
+
+  /// SharedPreferences 实例；平台通道不可用（纯 Dart 单测 / 极端启动早期）返回 null。
+  static Future<SharedPreferences?> _prefsOrNull() async {
+    try {
+      return await SharedPreferences.getInstance();
+    } catch (_) {
+      return null;
+    }
   }
 
   static Future<Directory> _resolveSupportRoot() async {
@@ -223,9 +355,12 @@ class AppPaths {
 
   /// TODO-1226：documents 根顶层**属于 Hibiki 的目录名全集**（数据根迁移白名单）。
   ///
-  /// 默认数据根时 documents 根 = 整个用户 `Documents`（共享目录，含用户自己的文件和
-  /// shell junction）。迁移引擎对共享根**只搬这份白名单里的顶层项**，绝不整树搬移 /
-  /// 整树删除用户 `Documents`。每一项都必须对应仓库里一个真实的派生点：
+  /// **老安装（[_layoutFlat]）** 的 documents 根 = 整个用户 `Documents`（共享目录，含
+  /// 用户自己的文件和 shell junction）。迁移引擎对共享根**只搬这份白名单里的顶层项**，
+  /// 绝不整树搬移 / 整树删除用户 `Documents`。BUG-1115 之后新装走
+  /// `<Documents>/Hibiki/data`（Hibiki 专属根，迁移走整树语义），白名单对它不生效——但
+  /// 老安装可能永远停在扁平布局，故白名单及其守卫**长期有效**，新增
+  /// `<documents>/<child>` 派生点仍必须收进来。每一项都必须对应仓库里一个真实的派生点：
   ///
   ///  - `audiobooks` —— [audiobooksDirectory]；`AppModel` 各处
   ///    `join(appDirectory, 'audiobooks')`；`AudiobookStorage.ensurePersistDir`。
@@ -269,6 +404,35 @@ class AppPaths {
     'dictionaryImportWorkingDirectory',
     'webArchive',
   };
+
+  /// BUG-1115：[newDataRoot] 落在**共享** documents 根（老安装的扁平布局 = 平台
+  /// `Documents`）内部时，它是否是一个安全的迁移目标。
+  ///
+  /// 一般规则是「新数据根不能位于旧数据目录内部」（自我嵌套 → 边搬边把目标搬进自己）。
+  /// 但共享根是个例外：那里的迁移是**白名单选择性搬移**——只有
+  /// [hibikiOwnedDocumentsEntries] 里的顶层项会被搬走，别的顶层项一律不碰。所以只要新根
+  /// 的顶层段不是白名单里的名字，它在搬移中就是个旁观者，`Documents\Hibiki` 这种「把散
+  /// 落的 16 个目录收进一个自己的子目录」的迁移是安全的，不该被一刀切拒绝。
+  ///
+  /// 顶层段比较**大小写不敏感**：`p.canonicalize` 在 Windows 上会把路径转小写，直接与
+  /// 白名单原样比对会让 `Documents\hibikiExport` 漏网（它其实是白名单项，会被搬走 →
+  /// 目标边搬边消失）。小写比较在 Linux 上只会更保守（多拒绝几个），不会放行危险目标。
+  /// [ownedEntries] 是本次搬移真正生效的白名单（引擎传
+  /// `DataRootMigrationRequest.documentsTopLevelIncludeNames`，UI 传默认全集）——判定必须
+  /// 与实际会被搬走的顶层项同源，否则两边对「哪些名字会消失」的认知会漂开。
+  static bool isSafeNestedTargetInSharedDocuments({
+    required String sharedDocumentsRoot,
+    required String newDataRoot,
+    Set<String> ownedEntries = hibikiOwnedDocumentsEntries,
+  }) {
+    final String canonRoot = p.canonicalize(sharedDocumentsRoot);
+    final String canonNew = p.canonicalize(newDataRoot);
+    if (!p.isWithin(canonRoot, canonNew)) return false;
+    final String firstSegment =
+        p.split(p.relative(canonNew, from: canonRoot)).first.toLowerCase();
+    return !ownedEntries
+        .any((String owned) => owned.toLowerCase() == firstSegment);
+  }
 
   // ---- 静态便捷层（给无 AppModel 实例的 static 存储助手） ----
 

--- a/hibiki/lib/src/storage/data_root_migrator.dart
+++ b/hibiki/lib/src/storage/data_root_migrator.dart
@@ -258,9 +258,21 @@ class DataRootMigrator {
     Directory newSupport,
   ) async {
     final String canonNew = p.canonicalize(req.newDataRoot);
+    // BUG-1115：共享 documents 根（白名单选择性搬移）下的**非白名单**子目录是安全目标
+    // ——搬移只动白名单顶层项，新根在整个过程里是旁观者。这让老安装能把散落在用户
+    // `Documents` 根下的 16 个 Hibiki 目录一键收进 `Documents\Hibiki`。白名单为 null
+    // （Hibiki 专属根、整树搬移语义）时不适用：那时新根真会被连同整棵树搬走。
+    final Set<String>? whitelist = req.documentsTopLevelIncludeNames;
+    final bool nestedInSharedDocuments = whitelist != null &&
+        AppPaths.isSafeNestedTargetInSharedDocuments(
+          sharedDocumentsRoot: req.oldDocumentsRoot.path,
+          newDataRoot: req.newDataRoot,
+          ownedEntries: whitelist,
+        );
     if (canonNew == p.canonicalize(req.oldDocumentsRoot.path) ||
         canonNew == p.canonicalize(req.oldSupportRoot.path) ||
-        p.isWithin(p.canonicalize(req.oldDocumentsRoot.path), canonNew) ||
+        (p.isWithin(p.canonicalize(req.oldDocumentsRoot.path), canonNew) &&
+            !nestedInSharedDocuments) ||
         p.isWithin(p.canonicalize(req.oldSupportRoot.path), canonNew)) {
       throw const DataRootMigrationException('新数据根不能位于旧数据目录内部');
     }

--- a/hibiki/lib/src/sync/sync_settings_schema/data_root.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/data_root.part.dart
@@ -21,19 +21,30 @@ enum DataRootTargetRejection {
 /// 纯函数：在不触碰文件系统搬移的前提下判断 [newDataRoot] 是否可作为迁移目标。
 /// [existsAndHasFiles] 注入目录是否存在且含文件的判定（生产传真实 FS 探测，测试传
 /// 桩），保持本函数无 IO 依赖、可纯测。
+///
+/// BUG-1115：[sharedDocumentsRoot] 为真表示 [oldDocumentsRoot] 是**共享**的平台
+/// `Documents`（老安装的扁平布局）。此时迁移是白名单选择性搬移，把新根设在它下面的一个
+/// 非白名单子目录（典型：`Documents\Hibiki`，即用户把散落的 16 个目录收进自己的子目录）
+/// 是安全的，不再按 [DataRootTargetRejection.insideCurrentRoot] 一刀切拒绝。
 DataRootTargetRejection? validateDataRootTarget({
   required String newDataRoot,
   required String oldDocumentsRoot,
   required String oldSupportRoot,
   required bool Function(String absolutePath) existsAndHasFiles,
   String? executablePath,
+  bool sharedDocumentsRoot = false,
 }) {
   final String canonNew = p.canonicalize(newDataRoot);
   final String canonDocs = p.canonicalize(oldDocumentsRoot);
   final String canonSupport = p.canonicalize(oldSupportRoot);
+  final bool nestedInSharedDocuments = sharedDocumentsRoot &&
+      AppPaths.isSafeNestedTargetInSharedDocuments(
+        sharedDocumentsRoot: oldDocumentsRoot,
+        newDataRoot: newDataRoot,
+      );
   if (canonNew == canonDocs ||
       canonNew == canonSupport ||
-      p.isWithin(canonDocs, canonNew) ||
+      (p.isWithin(canonDocs, canonNew) && !nestedInSharedDocuments) ||
       p.isWithin(canonSupport, canonNew)) {
     return DataRootTargetRejection.insideCurrentRoot;
   }
@@ -110,8 +121,10 @@ class _DataRootWidgetState extends State<_DataRootWidget> {
     final AppModel appModel = widget.settingsContext.appModel;
     String? defaultRootPath;
     try {
-      // appDirectory 是 documents 根；默认根时其父目录即平台数据目录，展示更直观。
-      defaultRootPath = appModel.appDirectory.parent.path;
+      // BUG-1115：显示 documents 根**本身**（内容真正落的地方）。旧实现显示它的父目录，
+      // 那在扁平老布局下是用户主目录（`C:\Users\<name>`，根本不是数据位置），在
+      // `<Documents>/Hibiki/data` 新布局下则是导出目录 `Hibiki` —— 两种都误导。
+      defaultRootPath = appModel.appDirectory.path;
     } on Error {
       defaultRootPath = null; // late 未初始化 → 只显示「默认位置」不带路径。
     }
@@ -133,6 +146,23 @@ class _DataRootWidgetState extends State<_DataRootWidget> {
     final String oldDocs = appModel.appDirectory.path;
     final String oldSupport = appModel.databaseDirectory.path;
 
+    // TODO-1226：判定旧 documents 根是否就是**共享的平台 Documents**（老安装的扁平布局）。
+    // 不看 data_root pref（pref 存了失效路径时 AppPaths 仍回退默认根，此时按 pref 判
+    // 会把共享 Documents 误当专属根整树搬走）——直接与平台 Documents 实路径比对。
+    // 探测失败按共享处理：宁可少搬（白名单），绝不整搬/整删共享目录。
+    //
+    // BUG-1115：这个判定必须在**校验之前**拿到——共享根下的非白名单子目录
+    // （`Documents\Hibiki`）是合法目标，校验要据此放行。
+    bool sharedDocumentsRoot;
+    try {
+      final Directory platformDocuments =
+          await getApplicationDocumentsDirectory();
+      sharedDocumentsRoot = p.equals(oldDocs, platformDocuments.path);
+    } catch (_) {
+      sharedDocumentsRoot = true;
+    }
+    if (!mounted) return;
+
     // 触发前纯校验：自我迁移 / 目标非空，直接报错，不进确认弹窗。
     final DataRootTargetRejection? rejection = validateDataRootTarget(
       newDataRoot: picked,
@@ -140,6 +170,7 @@ class _DataRootWidgetState extends State<_DataRootWidget> {
       oldSupportRoot: oldSupport,
       existsAndHasFiles: _dirExistsAndHasFiles,
       executablePath: Platform.resolvedExecutable,
+      sharedDocumentsRoot: sharedDocumentsRoot,
     );
     if (rejection != null) {
       if (mounted) {
@@ -165,20 +196,6 @@ class _DataRootWidgetState extends State<_DataRootWidget> {
       }
       return;
     }
-
-    // TODO-1226：判定旧 documents 根是否就是**共享的平台 Documents**（默认数据根）。
-    // 不看 data_root pref（pref 存了失效路径时 AppPaths 仍回退默认根，此时按 pref 判
-    // 会把共享 Documents 误当专属根整树搬走）——直接与平台 Documents 实路径比对。
-    // 探测失败按共享处理：宁可少搬（白名单），绝不整搬/整删共享目录。
-    bool sharedDocumentsRoot;
-    try {
-      final Directory platformDocuments =
-          await getApplicationDocumentsDirectory();
-      sharedDocumentsRoot = p.equals(oldDocs, platformDocuments.path);
-    } catch (_) {
-      sharedDocumentsRoot = true;
-    }
-    if (!mounted) return;
 
     setState(() => _migrating = true);
     // TODO-959: 先把全屏迁移遮罩顶上来，再让引擎 closeResources（含 closeDatabase 置

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+939
+version: 1.2.0+940
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/video/video_cover_repair_test.dart
+++ b/hibiki/test/media/video/video_cover_repair_test.dart
@@ -24,6 +24,7 @@ void main() {
   late HibikiDatabase db;
 
   setUp(() {
+    AppPaths.debugResetDocumentsLayoutCache();
     tmp = Directory.systemTemp.createTempSync('hibiki_cover_repair_');
     docs = Directory(p.join(tmp.path, 'documents'))
       ..createSync(recursive: true);
@@ -51,6 +52,7 @@ void main() {
   tearDown(() async {
     await db.close();
     AppPaths.debugDataRootReader = null;
+    AppPaths.debugResetDocumentsLayoutCache();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
       const MethodChannel('plugins.flutter.io/path_provider'),
@@ -60,8 +62,10 @@ void main() {
   });
 
   test('listForShelf 把指向旧空位置的封面自愈回写到当前 video_covers 里的同名文件', () async {
-    // 当前根下有真实封面文件（迁移把它搬到这里）。
-    final Directory coversDir = Directory(p.join(docs.path, 'video_covers'))
+    // 当前根下有真实封面文件（迁移把它搬到这里）。BUG-1115：目录经 AppPaths 解析而不是
+    // 硬拼 `<Documents>/video_covers`——默认 documents 根已是 `<Documents>/Hibiki/data`，
+    // 夹具必须与产品侧自愈查的目录同源，否则测的是一个产品里不存在的位置。
+    final Directory coversDir = await AppPaths.videoCoversDirectory()
       ..createSync(recursive: true);
     final String realCover = p.join(coversDir.path, 'video_Bk.jpg');
     File(realCover).writeAsBytesSync(<int>[1, 2, 3]);
@@ -88,7 +92,7 @@ void main() {
   });
 
   test('封面文件在当前根也不存在 → 不改写，保持原值（真删除的封面留占位）', () async {
-    Directory(p.join(docs.path, 'video_covers')).createSync(recursive: true);
+    (await AppPaths.videoCoversDirectory()).createSync(recursive: true);
     final String staleCover =
         p.join(tmp.path, 'old_documents', 'video_covers', 'gone.jpg');
     await db.upsertVideoBook(VideoBooksCompanion.insert(
@@ -104,7 +108,7 @@ void main() {
   });
 
   test('封面文件本就存在于存储路径 → 原样返回，不触发写', () async {
-    final Directory coversDir = Directory(p.join(docs.path, 'video_covers'))
+    final Directory coversDir = await AppPaths.videoCoversDirectory()
       ..createSync(recursive: true);
     final String good = p.join(coversDir.path, 'video_Ok.jpg');
     File(good).writeAsBytesSync(<int>[9]);

--- a/hibiki/test/media/video/video_resource_check_test.dart
+++ b/hibiki/test/media/video/video_resource_check_test.dart
@@ -108,6 +108,36 @@ void main() {
       expect(p.equals(relocated!, current.path), isTrue);
     });
 
+    test(
+        'BUG-1115: repairs stale paths when the documents root is nested under '
+        'the container Documents (<Documents>/Hibiki/data)', () async {
+      // 新安装的 documents 根不再是容器的 `Documents` 本身，而是它下面的
+      // `Hibiki/data`。旧路径里 `Documents/` 之后的相对段**已经包含** `Hibiki/data`，
+      // 基准若取 documents 根就会把它拼两遍，重定位永远落空。
+      final Directory dir =
+          await Directory.systemTemp.createTemp('bug1111_relocate_nested');
+      addTearDown(() => dir.delete(recursive: true));
+      final Directory currentDocs = Directory(
+        '${dir.path}/Containers/Data/Application/NEW/Documents/Hibiki/data',
+      )..createSync(recursive: true);
+      final File current = File('${currentDocs.path}/video_covers/cover.jpg')
+        ..createSync(recursive: true);
+      final String stale = '${dir.path}/Containers/Data/Application/OLD/'
+          'Documents/Hibiki/data/video_covers/cover.jpg';
+
+      expect(await File(stale).exists(), isFalse);
+
+      final String? relocated = await relocateMissingAppDocumentPath(
+        stale,
+        documentsRoot: currentDocs,
+      );
+      expect(relocated, isNotNull, reason: '容器 UUID 变化后应能重定位到新容器下的同一相对路径');
+      expect(p.equals(relocated!, current.path), isTrue);
+      // 防回归：绝不产出 `.../Hibiki/data/Hibiki/data/...` 这种拼两遍的路径。
+      expect(relocated.contains('Hibiki${p.separator}data${p.separator}Hibiki'),
+          isFalse);
+    });
+
     test('does not repoint arbitrary user Documents paths', () async {
       final Directory dir =
           await Directory.systemTemp.createTemp('todo897_no_relocate');

--- a/hibiki/test/settings/data_root_settings_test.dart
+++ b/hibiki/test/settings/data_root_settings_test.dart
@@ -107,6 +107,60 @@ void main() {
       );
       expect(r, isNull);
     });
+
+    // BUG-1115：老安装的 documents 根就是共享的平台 `Documents`。把散落其中的 16 个
+    // Hibiki 目录收进 `Documents\Hibiki` 是这批用户唯一自然的整理路径，之前被
+    // insideCurrentRoot 一刀切拒绝（新根「位于」旧根内部）。共享根走白名单选择性搬移，
+    // 非白名单子目录在搬移全程都是旁观者，因此必须放行。
+    test(
+        'BUG-1115: nested non-whitelisted dir under the SHARED documents root '
+        'is accepted', () {
+      final DataRootTargetRejection? r = validateDataRootTarget(
+        newDataRoot: p.join(oldDocs, 'Hibiki'),
+        oldDocumentsRoot: oldDocs,
+        oldSupportRoot: oldSupport,
+        existsAndHasFiles: alwaysEmpty,
+        sharedDocumentsRoot: true,
+      );
+      expect(r, isNull);
+    });
+
+    test(
+        'BUG-1115: the same nested target is still rejected for a DEDICATED '
+        'root (whole-tree move would swallow it)', () {
+      final DataRootTargetRejection? r = validateDataRootTarget(
+        newDataRoot: p.join(oldDocs, 'Hibiki'),
+        oldDocumentsRoot: oldDocs,
+        oldSupportRoot: oldSupport,
+        existsAndHasFiles: alwaysEmpty,
+        // 默认 false = Hibiki 专属根（<dataRoot>/documents），整树搬移语义。
+      );
+      expect(r, DataRootTargetRejection.insideCurrentRoot);
+    });
+
+    test('BUG-1115: a whitelisted top-level dir is never an accepted target',
+        () {
+      final DataRootTargetRejection? r = validateDataRootTarget(
+        newDataRoot: p.join(oldDocs, 'audiobooks'),
+        oldDocumentsRoot: oldDocs,
+        oldSupportRoot: oldSupport,
+        existsAndHasFiles: alwaysEmpty,
+        sharedDocumentsRoot: true,
+      );
+      expect(r, DataRootTargetRejection.insideCurrentRoot);
+    });
+
+    test('BUG-1115: the shared root itself is still a self-migrate rejection',
+        () {
+      final DataRootTargetRejection? r = validateDataRootTarget(
+        newDataRoot: oldDocs,
+        oldDocumentsRoot: oldDocs,
+        oldSupportRoot: oldSupport,
+        existsAndHasFiles: alwaysEmpty,
+        sharedDocumentsRoot: true,
+      );
+      expect(r, DataRootTargetRejection.insideCurrentRoot);
+    });
   });
 
   group('source guards (TODO-935 E2/E3)', () {
@@ -173,6 +227,9 @@ void main() {
           isTrue);
       // 失败切到失败态遮罩（不再立刻重启导致用户看不到失败）。
       expect(src.contains('failDataRootMigration('), isTrue);
+      // BUG-1115：共享根判定必须喂给**触发前校验**（而不是只喂给引擎），否则老安装选
+      // `Documents\Hibiki` 会在进确认弹窗之前就被 insideCurrentRoot 拒掉。
+      expect(src.contains('sharedDocumentsRoot: sharedDocumentsRoot'), isTrue);
     });
 
     test(

--- a/hibiki/test/storage/app_paths_data_root_test.dart
+++ b/hibiki/test/storage/app_paths_data_root_test.dart
@@ -25,7 +25,16 @@ void main() {
   late Directory tmp;
   late Directory fakeTemp;
 
+  /// BUG-1115：默认（无自定义数据根）documents 根 = `<平台 Documents>/Hibiki/data`。
+  /// 本文件的 mock support 根下没有 `hibiki.db`，故一律判为**全新安装** → 新布局。
+  String nestedDefaultDocs(String platformDocuments) => p.joinAll(<String>[
+        platformDocuments,
+        ...AppPaths.defaultDocumentsChildSegments,
+      ]);
+
   setUp(() {
+    // 布局判定有进程内缓存，用例间必须清掉，否则先跑的用例会把结论钉给后面的。
+    AppPaths.debugResetDocumentsLayoutCache();
     tmp = Directory.systemTemp.createTempSync('hibiki_dataroot_');
     fakeTemp = Directory(p.join(tmp.path, 'systemp'))..createSync();
     // path_provider 的 getTemporaryDirectory 走 method channel；mock 它返回 fakeTemp，
@@ -48,6 +57,7 @@ void main() {
 
   tearDown(() {
     AppPaths.debugDataRootReader = null;
+    AppPaths.debugResetDocumentsLayoutCache();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
       const MethodChannel('plugins.flutter.io/path_provider'),
@@ -99,7 +109,7 @@ void main() {
 
       expect(paths.documentsRoot.path, isNot(startsWith(missing)));
       expect(paths.documentsRoot.path,
-          equals(p.join(tmp.path, 'default_documents')));
+          equals(nestedDefaultDocs(p.join(tmp.path, 'default_documents'))));
     });
 
     test('空 data_root → 回退默认（无覆盖等价老用户）', () async {
@@ -118,7 +128,7 @@ void main() {
       AppPaths.debugDataRootReader = null;
       final AppPaths paths = await AppPaths.resolve();
       expect(paths.documentsRoot.path,
-          equals(p.join(tmp.path, 'default_documents')));
+          equals(nestedDefaultDocs(p.join(tmp.path, 'default_documents'))));
       expect(
           paths.supportRoot.path, equals(p.join(tmp.path, 'default_support')));
     });

--- a/hibiki/test/storage/app_paths_data_root_timeout_test.dart
+++ b/hibiki/test/storage/app_paths_data_root_timeout_test.dart
@@ -23,7 +23,15 @@ void main() {
   late Directory tmp;
   late Directory fakeTemp;
 
+  /// BUG-1115：默认 documents 根 = `<平台 Documents>/Hibiki/data`。本文件 mock 的 support
+  /// 根下没有 `hibiki.db`，故 resolve() 一律判为**全新安装** → 新布局。
+  String nestedDefaultDocs() => p.joinAll(<String>[
+        p.join(tmp.path, 'default_documents'),
+        ...AppPaths.defaultDocumentsChildSegments,
+      ]);
+
   setUp(() {
+    AppPaths.debugResetDocumentsLayoutCache();
     tmp = Directory.systemTemp.createTempSync('hibiki_dataroot_timeout_');
     fakeTemp = Directory(p.join(tmp.path, 'systemp'))..createSync();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
@@ -44,6 +52,7 @@ void main() {
 
   tearDown(() {
     AppPaths.debugDataRootReader = null;
+    AppPaths.debugResetDocumentsLayoutCache();
     // 静态开关必须每个 test 复位，否则跨 test 泄漏（一个 test 置 true 会污染后续）。
     AppPaths.forceDefaultRootForSession = false;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
@@ -85,8 +94,7 @@ void main() {
     AppPaths.forceDefaultRootForSession = true;
 
     final AppPaths paths = await AppPaths.resolve();
-    expect(
-        paths.documentsRoot.path, equals(p.join(tmp.path, 'default_documents')),
+    expect(paths.documentsRoot.path, equals(nestedDefaultDocs()),
         reason: '用户显式选择后应退回默认根打开（空态），而不是抛异常');
     expect(paths.supportRoot.path, equals(p.join(tmp.path, 'default_support')));
   });
@@ -94,8 +102,7 @@ void main() {
   test('未配置自定义根（普通默认用户）→ 不抛，正常用默认根', () async {
     AppPaths.debugDataRootReader = () async => null;
     final AppPaths paths = await AppPaths.resolve();
-    expect(
-        paths.documentsRoot.path, equals(p.join(tmp.path, 'default_documents')),
+    expect(paths.documentsRoot.path, equals(nestedDefaultDocs()),
         reason: '无自定义根配置的用户不受 BUG-815 预检影响');
   });
 

--- a/hibiki/test/storage/app_paths_default_documents_layout_test.dart
+++ b/hibiki/test/storage/app_paths_default_documents_layout_test.dart
@@ -1,0 +1,254 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:hibiki/src/storage/app_paths.dart';
+
+/// BUG-1115 单测：**默认**（未配置自定义数据根）documents 根的布局判定。
+///
+/// 历史行为是 documents 根 = 平台 `Documents` **本身**，于是
+/// [AppPaths.hibikiOwnedDocumentsEntries] 那 16 个目录全摊在用户文档根下。现在：
+///  - 全新安装 → `<Documents>/Hibiki/data`（Hibiki 专属容器）；
+///  - 老安装（support 根下已有 `hibiki.db`）→ 仍是扁平的平台 `Documents`，零迁移；
+///  - 判定结果**一次性固化**进 SharedPreferences，之后不再探测——布局在同一台机器上
+///    绝不能随「此刻磁盘上有没有某个文件」漂移（漂一次就是整个书库凭空消失）。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmp;
+  late Directory platformDocuments;
+  late Directory platformSupport;
+
+  String nested() => p.joinAll(<String>[
+        platformDocuments.path,
+        ...AppPaths.defaultDocumentsChildSegments,
+      ]);
+
+  /// 制造「这台机器上已经有一个跑过的安装」的痕迹：support 根下有主库文件。
+  void writeExistingDatabase() {
+    File(p.join(platformSupport.path, 'hibiki.db'))
+        .writeAsStringSync('not a real sqlite file, only its presence matters');
+  }
+
+  setUp(() {
+    AppPaths.debugResetDocumentsLayoutCache();
+    // 无自定义数据根：走默认分支（本文件的被测对象）。
+    AppPaths.debugDataRootReader = () async => '';
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+
+    tmp = Directory.systemTemp.createTempSync('hibiki_docs_layout_');
+    platformDocuments = Directory(p.join(tmp.path, 'Documents'))
+      ..createSync(recursive: true);
+    platformSupport = Directory(p.join(tmp.path, 'AppData', 'hibiki'))
+      ..createSync(recursive: true);
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async {
+        switch (call.method) {
+          case 'getApplicationDocumentsDirectory':
+            return platformDocuments.path;
+          case 'getApplicationSupportDirectory':
+            return platformSupport.path;
+          case 'getTemporaryDirectory':
+            return p.join(tmp.path, 'systemp');
+        }
+        return null;
+      },
+    );
+  });
+
+  tearDown(() {
+    AppPaths.debugDataRootReader = null;
+    AppPaths.debugResetDocumentsLayoutCache();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  group('BUG-1115 默认 documents 布局判定', () {
+    test('全新安装 → <Documents>/Hibiki/data，用户文档根下不再摊开', () async {
+      // 布局判定只在启动期的 resolve() 里做一次（解析路径本身不许碰文件系统）。
+      final Directory root = (await AppPaths.resolve()).documentsRoot;
+
+      expect(root.path, equals(nested()));
+      // 核心断言：16 个目录的父不再是用户文档根本身。
+      expect((await AppPaths.audiobooksDirectory()).path,
+          equals(p.join(nested(), 'audiobooks')));
+      expect((await AppPaths.epubBooksDirectory()).path,
+          isNot(equals(p.join(platformDocuments.path, 'hoshi_books'))));
+    });
+
+    test('老安装（support 下有 hibiki.db）→ 保持扁平布局，一个字节都不搬', () async {
+      writeExistingDatabase();
+
+      final Directory root = (await AppPaths.resolve()).documentsRoot;
+
+      expect(root.path, equals(platformDocuments.path));
+      // 老用户的每个派生点都必须与升级前逐字节一致。
+      expect((await AppPaths.audiobooksDirectory()).path,
+          equals(p.join(platformDocuments.path, 'audiobooks')));
+      expect((await AppPaths.epubBooksDirectory()).path,
+          equals(p.join(platformDocuments.path, 'hoshi_books')));
+    });
+
+    test('判定结果固化进 prefs（新装写 nested）', () async {
+      await AppPaths.resolve();
+
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      expect(
+          prefs.getString(AppPaths.documentsLayoutPrefKey), equals('nested'));
+    });
+
+    test('判定结果固化进 prefs（老装写 flat）', () async {
+      writeExistingDatabase();
+
+      await AppPaths.resolve();
+
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(AppPaths.documentsLayoutPrefKey), equals('flat'));
+    });
+
+    test('未跑过 resolve 且无 prefs 锚点 → 兜底扁平老布局（绝不擅自切走）', () async {
+      // 生产上 resolve() 恒在启动最早期跑完；真正走到这个兜底的是没跑 resolve 的测试
+      // 夹具。兜底必须等于 BUG-1115 之前的行为，否则一批 widget 测试与老用户会被静默
+      // 切到一个空的新根。
+      final Directory root = await AppPaths.documentsRootDirectory();
+
+      expect(root.path, equals(platformDocuments.path));
+    });
+
+    test('已锚定 flat → 即使主库文件消失也不会翻成新布局（锚点不漂移）', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        AppPaths.documentsLayoutPrefKey: 'flat',
+      });
+      // 刻意不建 hibiki.db：模拟用户把库搬走 / 清了 AppData 后再次启动。
+      final Directory root = await AppPaths.documentsRootDirectory();
+
+      expect(root.path, equals(platformDocuments.path));
+    });
+
+    test('已锚定 nested → 即使 support 下出现主库也不会退回扁平布局', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        AppPaths.documentsLayoutPrefKey: 'nested',
+      });
+      writeExistingDatabase();
+
+      final Directory root = await AppPaths.documentsRootDirectory();
+
+      expect(root.path, equals(nested()));
+    });
+
+    test('自定义数据根优先于布局判定（dataRoot 分支不受影响）', () async {
+      final Directory dataRoot = Directory(p.join(tmp.path, 'D_Root'))
+        ..createSync(recursive: true);
+      AppPaths.debugDataRootReader = () async => dataRoot.path;
+
+      final Directory root = await AppPaths.documentsRootDirectory();
+
+      expect(root.path, equals(p.join(dataRoot.path, 'documents')));
+    });
+
+    test('一次运行内布局恒定：并发解析拿到同一个根', () async {
+      await AppPaths.resolve();
+      final List<Directory> roots = await Future.wait(<Future<Directory>>[
+        AppPaths.documentsRootDirectory(),
+        AppPaths.documentsRootDirectory(),
+        AppPaths.documentsRootDirectory(),
+      ]);
+
+      expect(roots.map((Directory d) => d.path).toSet(), hasLength(1));
+      expect(roots.first.path, equals(nested()));
+    });
+  });
+
+  group('BUG-1115 共享 documents 根下的嵌套迁移目标', () {
+    test('非白名单子目录（Documents\\Hibiki）是安全目标', () {
+      expect(
+        AppPaths.isSafeNestedTargetInSharedDocuments(
+          sharedDocumentsRoot: platformDocuments.path,
+          newDataRoot: p.join(platformDocuments.path, 'Hibiki'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('白名单顶层项本身不是安全目标（会被搬走 → 目标边搬边消失）', () {
+      for (final String owned in AppPaths.hibikiOwnedDocumentsEntries) {
+        expect(
+          AppPaths.isSafeNestedTargetInSharedDocuments(
+            sharedDocumentsRoot: platformDocuments.path,
+            newDataRoot: p.join(platformDocuments.path, owned),
+          ),
+          isFalse,
+          reason: '白名单项 $owned 会被选择性搬移搬走，不能同时当迁移目标',
+        );
+        // 白名单项的子目录同样不安全：父被整个搬走，子跟着一起飞。
+        expect(
+          AppPaths.isSafeNestedTargetInSharedDocuments(
+            sharedDocumentsRoot: platformDocuments.path,
+            newDataRoot: p.join(platformDocuments.path, owned, 'sub'),
+          ),
+          isFalse,
+          reason: '$owned/sub 的父目录会被搬走',
+        );
+      }
+    });
+
+    test('白名单顶层项比较大小写不敏感（Windows canonicalize 会转小写）', () {
+      expect(
+        AppPaths.isSafeNestedTargetInSharedDocuments(
+          sharedDocumentsRoot: platformDocuments.path,
+          newDataRoot: p.join(platformDocuments.path, 'HIBIKIEXPORT'),
+        ),
+        isFalse,
+        reason: 'hibikiExport 是白名单项，大小写变体同样不能当目标',
+      );
+    });
+
+    test('根本身 / 根外的目录都不算「嵌套安全目标」', () {
+      expect(
+        AppPaths.isSafeNestedTargetInSharedDocuments(
+          sharedDocumentsRoot: platformDocuments.path,
+          newDataRoot: platformDocuments.path,
+        ),
+        isFalse,
+      );
+      expect(
+        AppPaths.isSafeNestedTargetInSharedDocuments(
+          sharedDocumentsRoot: platformDocuments.path,
+          newDataRoot: p.join(tmp.path, 'Elsewhere'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('传入的白名单是判定依据（引擎传自己的那份，不吃全局常量）', () {
+      // 引擎用 DataRootMigrationRequest.documentsTopLevelIncludeNames 判定；这里证明
+      // 判定确实跟着传入集合走，而不是永远查 AppPaths 的全集。
+      expect(
+        AppPaths.isSafeNestedTargetInSharedDocuments(
+          sharedDocumentsRoot: platformDocuments.path,
+          newDataRoot: p.join(platformDocuments.path, 'audiobooks'),
+          ownedEntries: const <String>{'hoshi_books'},
+        ),
+        isTrue,
+      );
+      expect(
+        AppPaths.isSafeNestedTargetInSharedDocuments(
+          sharedDocumentsRoot: platformDocuments.path,
+          newDataRoot: p.join(platformDocuments.path, 'Hibiki'),
+          ownedEntries: const <String>{'Hibiki'},
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/hibiki/test/storage/data_root_migrator_test.dart
+++ b/hibiki/test/storage/data_root_migrator_test.dart
@@ -598,6 +598,101 @@ void main() {
       }
     });
 
+    test('BUG-1115：目标是共享根内的非白名单子目录（Documents\\Hibiki）→ 允许并搬成', () async {
+      // 老安装唯一自然的整理路径：把散落在共享 Documents 根下的 Hibiki 目录收进
+      // `Documents\Hibiki`。旧实现按「新根位于旧根内部」一律拒绝，用户无路可走。
+      // 白名单搬移只动白名单顶层项，`Hibiki` 不在白名单里 → 全程是旁观者。
+      await seedDb();
+      final File userDoc = File(p.join(oldDocsPath, 'my_essay.docx'))
+        ..writeAsStringSync('user data, do not touch');
+
+      final String newDataRoot = p.join(oldDocsPath, 'Hibiki');
+      String? wrote;
+      final (Directory newDocs, Directory newSupport) =
+          await const DataRootMigrator().migrate(DataRootMigrationRequest(
+        oldDocumentsRoot: oldDocs,
+        oldSupportRoot: oldSupport,
+        newDataRoot: newDataRoot,
+        closeResources: () async {},
+        writeDataRootPref: (String r) async => wrote = r,
+        documentsTopLevelIncludeNames: const <String>{
+          'hoshi_books',
+          'audiobooks',
+          'video_covers',
+        },
+      ));
+
+      // 新根就在旧共享根内部，数据齐全。
+      expect(p.isWithin(oldDocsPath, newDocs.path), isTrue);
+      expect(
+          File(p.join(newDocs.path, 'hoshi_books', 'Bk', 'a.html'))
+              .existsSync(),
+          isTrue);
+      expect(
+          File(p.join(newDocs.path, 'audiobooks', 'Bk', 'a.mp3')).existsSync(),
+          isTrue);
+      // 白名单项已离开共享根顶层——文档根不再摊着 Hibiki 的目录。
+      expect(
+          Directory(p.join(oldDocsPath, 'hoshi_books')).existsSync(), isFalse);
+      expect(
+          Directory(p.join(oldDocsPath, 'audiobooks')).existsSync(), isFalse);
+      expect(
+          Directory(p.join(oldDocsPath, 'video_covers')).existsSync(), isFalse);
+      // 共享根本体与用户文件原样保留。
+      expect(oldDocs.existsSync(), isTrue);
+      expect(userDoc.readAsStringSync(), equals('user data, do not touch'));
+      // pref 已写，DB 路径 rebase 到新根。
+      expect(wrote, equals(newDataRoot));
+      final HibikiDatabase db = HibikiDatabase(newSupport.path);
+      try {
+        final EpubBookRow b = (await db.getAllEpubBooks()).single;
+        expect(b.epubPath, startsWith(newDocs.path));
+      } finally {
+        await db.close();
+      }
+    });
+
+    test('BUG-1115：白名单项本身当目标仍被拒（会被搬走 → 目标边搬边消失）', () async {
+      await seedDb();
+      await expectLater(
+        const DataRootMigrator().migrate(DataRootMigrationRequest(
+          oldDocumentsRoot: oldDocs,
+          oldSupportRoot: oldSupport,
+          newDataRoot: p.join(oldDocsPath, 'audiobooks'),
+          closeResources: () async {},
+          writeDataRootPref: (String r) async {},
+          documentsTopLevelIncludeNames: const <String>{
+            'hoshi_books',
+            'audiobooks',
+          },
+        )),
+        throwsA(isA<DataRootMigrationException>()),
+      );
+      // 旧根一字未动。
+      expect(
+          File(p.join(oldDocsPath, 'audiobooks', 'Bk', 'a.mp3')).existsSync(),
+          isTrue);
+    });
+
+    test('BUG-1115：专属根（整树语义）下嵌套目标仍被拒——整树搬移会把目标一起搬走', () async {
+      await seedDb();
+      await expectLater(
+        const DataRootMigrator().migrate(DataRootMigrationRequest(
+          oldDocumentsRoot: oldDocs,
+          oldSupportRoot: oldSupport,
+          newDataRoot: p.join(oldDocsPath, 'Hibiki'),
+          closeResources: () async {},
+          writeDataRootPref: (String r) async {},
+          // null = Hibiki 专属根、整树搬移语义。
+          documentsTopLevelIncludeNames: null,
+        )),
+        throwsA(isA<DataRootMigrationException>()),
+      );
+      expect(
+          File(p.join(oldDocsPath, 'hoshi_books', 'Bk', 'a.html')).existsSync(),
+          isTrue);
+    });
+
     test('白名单模式回滚：pref 写失败 → 白名单项搬回 Documents，用户文件不动、新根子树清理', () async {
       await seedDb();
       final File userDoc = File(p.join(oldDocsPath, 'keep.txt'))

--- a/hibiki/test/storage/write_paths_data_root_test.dart
+++ b/hibiki/test/storage/write_paths_data_root_test.dart
@@ -27,7 +27,15 @@ void main() {
   late Directory tmp;
   late Directory defaultDocs;
 
+  /// BUG-1115：默认 documents 根 = `<平台 Documents>/Hibiki/data`（全新安装；本文件的
+  /// mock support 根下没有 `hibiki.db`，故一律判为新装）。
+  String defaultDocsRoot() => p.joinAll(<String>[
+        defaultDocs.path,
+        ...AppPaths.defaultDocumentsChildSegments,
+      ]);
+
   setUp(() {
+    AppPaths.debugResetDocumentsLayoutCache();
     tmp = Directory.systemTemp.createTempSync('hibiki_wpaths_');
     defaultDocs = Directory(p.join(tmp.path, 'default_documents'))
       ..createSync(recursive: true);
@@ -53,6 +61,7 @@ void main() {
 
   tearDown(() {
     AppPaths.debugDataRootReader = null;
+    AppPaths.debugResetDocumentsLayoutCache();
     AudiobookStorage.documentsRootResolver = null;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
@@ -80,27 +89,35 @@ void main() {
         isTrue);
   });
 
-  test('未设自定义数据根 → 三个写路径落平台 Documents 默认根', () async {
+  test('未设自定义数据根（全新安装）→ 三个写路径落 <Documents>/Hibiki/data', () async {
     AppPaths.debugDataRootReader = () async => '';
+    // 默认布局判定只在启动期的 resolve() 里做（mock support 根下无 hibiki.db → 新装）。
+    await AppPaths.resolve();
 
     expect((await AppPaths.videoSubtitlesDirectory()).path,
-        equals(p.join(defaultDocs.path, 'video_subtitles')));
+        equals(p.join(defaultDocsRoot(), 'video_subtitles')));
     expect((await AppPaths.videoCoversDirectory()).path,
-        equals(p.join(defaultDocs.path, 'video_covers')));
+        equals(p.join(defaultDocsRoot(), 'video_covers')));
     expect(
         p.equals(await AudiobookStorage.audiobooksRootDir(),
-            p.join(defaultDocs.path, 'audiobooks')),
+            p.join(defaultDocsRoot(), 'audiobooks')),
         isTrue);
+    // BUG-1115 的核心断言：用户文档根下不再直接出现 Hibiki 的内容目录。
+    expect((await AppPaths.videoCoversDirectory()).path,
+        isNot(equals(p.join(defaultDocs.path, 'video_covers'))));
   });
 
   test('data_root 指向不存在目录 → 回退默认（不落失效路径）', () async {
     AppPaths.debugDataRootReader = () async => p.join(tmp.path, 'missing');
+    AppPaths.forceDefaultRootForSession = true; // 配置不可达时 resolve 会抛，显式回退默认根。
+    addTearDown(() => AppPaths.forceDefaultRootForSession = false);
+    await AppPaths.resolve();
 
     expect((await AppPaths.videoCoversDirectory()).path,
-        equals(p.join(defaultDocs.path, 'video_covers')));
+        equals(p.join(defaultDocsRoot(), 'video_covers')));
     expect(
         p.equals(await AudiobookStorage.audiobooksRootDir(),
-            p.join(defaultDocs.path, 'audiobooks')),
+            p.join(defaultDocsRoot(), 'audiobooks')),
         isTrue);
   });
 }

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -274,9 +274,14 @@ Future<void> _rebuildSidecar(File dbFile) async {
       '(main .db untouched, .corrupt-bak-$stamp snapshot kept)');
 }
 
+/// 主库在 support 根下的文件名。唯一真相源：除了 [_openDb] 自身，app 层判定「这台机器
+/// 上是否已经有一个跑过的 Hibiki 安装」时也要认这个文件（见 `AppPaths` 的默认 documents
+/// 布局判据），故抽成导出常量而不是各处重复字面量。
+const String hibikiDatabaseFileName = 'hibiki.db';
+
 LazyDatabase _openDb(String dbDirectory, {bool isMainProcess = true}) {
   return LazyDatabase(() async {
-    final file = File(p.join(dbDirectory, 'hibiki.db'));
+    final file = File(p.join(dbDirectory, hibikiDatabaseFileName));
     return _openWithRecovery(file, allowSidecarDelete: isMainProcess);
   });
 }


### PR DESCRIPTION
## 问题

默认数据根时 `documentsRoot` **等于**平台 `Documents` 本身（Windows = `%USERPROFILE%\Documents`），于是 `AppPaths.hibikiOwnedDocumentsEntries` 那 16 个目录（`audiobooks` / `hoshi_books` / `video_covers` / `game_covers` / `video_subtitles` / `mpv_shaders` / `remote_videos` / `videos` / `anime_downloads` / `custom_fonts` / `hibikiExport` / `browser` / `thumbnails` / `dictionaryResources` / `dictionaryImportWorkingDirectory` / `webArchive`）全部作为顶层项摊在用户文档根下。

根因 `hibiki/lib/src/storage/app_paths.dart`（改动前 `:196`）：

```dart
static Future<Directory> _resolveDocumentsRoot() async {
  ...
  return getApplicationDocumentsDirectory();   // ← 默认根 = 共享用户 Documents
}
```

历史成因：TODO-935 E0 收敛十几处散落的 `getApplicationDocumentsDirectory()` 时刻意保持「行为等价、旧数据零迁移」，把「默认根 = 共享用户目录」固化成了常态——TODO-1226 的迁移白名单、`DataRootMigrator` 的选择性搬移模式，都是为这个特殊情况打的补丁。

详见 `docs/bugs/BUG-1114-default-documents-root-flat.md`。

## 改动

**1. 默认 documents 根改为 `<Documents>/Hibiki/data`**

取 `Hibiki/data` 而非 `Hibiki`，是因为 `<Documents>/Hibiki` 已被**用户可见的导出目录**占用（`DesktopDirectoryService.getHibikiExportDirectory` / `IosDirectoryService`）。数据落其下的 `data/`，用户文档根下只多出一个 `Hibiki/` 伞，内部数据与导出物各占一层。

**2. 老安装零破坏（不做任何自动迁移）**

新增 `documents_layout` pref（`flat` / `nested`），判据是「support 根下有没有 `hibiki.db`」= 这台机器上是否已有跑过的安装：

- 有 → 锚定 `flat`，documents 根仍是平台 `Documents`，**一个字节都不搬**；
- 没有 → `nested`。

判定结果**一次性固化**，之后永不重新探测——布局若随「此刻磁盘上有没有某个文件」漂移，同一台机器两次启动就会解析出两个内容根 = 整个书库凭空消失。探测失败/超时一律按老安装处理。

刻意**不**用「Documents 里有没有 `videos`/`browser`/`thumbnails`」当判据：这些名字在用户自己的文档目录里撞名概率不低，全新安装会被误判成老安装。

判定**只在启动期 `AppPaths.resolve()` 里做一次**，解析路径（`_resolveDocumentsRoot` / `documentsSubdirectory` 等静态便捷层）绝不碰文件系统。这条边界是被测试打出来的：第一版把探测放进解析路径，11 个 `home_video_*` widget 测试集体挂掉——`testWidgets` 跑在 FakeAsync 上，真实文件 IO 的 future 在那里永不完成，`.timeout()` 还会留下「Timer is still pending」。解析路径未判定且 prefs 无锚点时兜底 `flat`（= 改动前行为）。

**3. 给老安装一条自救路径**

老安装的 documents 根就是共享 `Documents`，想把散落的 16 个目录收进 `Documents\Hibiki` 会被「新数据根不能位于旧数据目录内部」一刀切拒绝。但共享根走的是**白名单选择性搬移**——只有白名单顶层项会被搬走，`Hibiki` 不在白名单里、全程是旁观者。新增 `AppPaths.isSafeNestedTargetInSharedDocuments()`，共享根下的**非白名单**子目录放行；白名单项本身（含其子目录、含大小写变体）仍拒绝，专属根的整树搬移语义下仍拒绝。

**4. 顺带修 iOS 容器重定位**

`relocateMissingAppDocumentPath` 是把旧路径里 `Documents/` 之后的相对段拼回当前 documents 根。新布局下那段相对路径**已经包含** `Hibiki/data`，直拼会得到 `.../Documents/Hibiki/data/Hibiki/data/...`，重定位永远落空。改为以「当前根路径里的容器 `Documents` 段」为基准，扁平布局下两者恰好相等、行为逐字节不变。

**5.** 数据存储位置设置项改为显示 documents 根本身（旧实现显示父目录，扁平布局下是用户主目录、新布局下是导出目录，两种都误导）。

## 测试

- `hibiki/test/storage/app_paths_default_documents_layout_test.dart`（新建，14 例）：新装 → `<Documents>/Hibiki/data`；老装 → 扁平且每个派生点与升级前逐字节一致；两种判定各自固化进 prefs；已锚定后即使主库文件出现/消失也不翻转；未跑 resolve 且无锚点 → 兜底扁平；自定义 dataRoot 优先；并发解析拿到同一个根；`isSafeNestedTargetInSharedDocuments` 的白名单/大小写/根内外判定。
- `data_root_migrator_test.dart` +3：共享根内的 `Documents\Hibiki` 目标能真正搬成（白名单项离开文档根顶层、共享根本体与用户文件原样保留、DB 路径 rebase）；白名单项当目标仍抛错且旧根一字未动；专属根整树语义下嵌套目标仍抛错。
- `data_root_settings_test.dart` +4 +1 源码守卫：`sharedDocumentsRoot` 放行/拒绝矩阵，以及守卫「共享根判定必须喂给触发前校验」。
- `video_resource_check_test.dart` +1：嵌套根下容器 UUID 变化后仍能重定位，且绝不产出 `Hibiki/data` 拼两遍的路径。
- `video_cover_repair_test.dart`：封面夹具改为经 `AppPaths.videoCoversDirectory()` 解析（与产品侧自愈同源）。
- 既有默认根断言（`app_paths_data_root_test` / `app_paths_data_root_timeout_test` / `write_paths_data_root_test`）同步更新。

验证：`flutter analyze`（hibiki + hibiki_core）零问题；**全量 `flutter test` 14438 通过 / 0 失败 / 7 skip**。

## 未做 / 需注意

- **本机现有安装（含报告者本人）会被判为老安装、继续用扁平布局**——这是刻意的零破坏设计。要立刻看到文档根变干净，走设置 →「数据存储位置」选 `Documents\Hibiki`（本 PR 放开的正是这条路径），迁移引擎会把 16 个目录搬过去并 rebase DB 里的绝对路径。
- `ErrorLogService` 的 `error_log.txt` / `*_breadcrumb.txt` 仍直连平台 `Documents`（刻意不随数据根走，搬走会让服务失去续写目标），本次未动——文档根下仍会看到这两类**文件**（不是目录）。
- 白名单 `hibikiOwnedDocumentsEntries` 及其守卫**长期有效**：老安装可能永远停在扁平布局，新增 `<documents>/<child>` 派生点仍必须收进白名单。
- 未做真机验证。真机需验：新装首启后 `Documents\Hibiki\data` 下出现运行时目录；老装升级后书库/有声书/词典资源全部照常可见。
- BUG 号：开 PR 前重核发现 PR#436 已占 1111–1113，本 PR 已改号到 **BUG-1114**。

https://claude.ai/code/session_01VJxJB3hmybUdBqQ5QfEasV
