### PR TITLE
feat(library): 书架与视频库补搜索，与游戏库同一归一化口径（P5-A）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45458 (2674 per locale)
+/// Strings: 45475 (2675 per locale)
 ///
-/// Built on 2026-07-26 at 02:35 UTC
+/// Built on 2026-07-26 at 05:27 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3553,6 +3553,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get galgame_upscaling_hint_not_installed =>
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   String get game_health_upscaling => 'Window upscaling';
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -9626,6 +9627,8 @@ class _StringsAr extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -15772,6 +15775,8 @@ class _StringsDe extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -21934,6 +21939,8 @@ class _StringsEs extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -28107,6 +28114,8 @@ class _StringsFr extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -34207,6 +34216,8 @@ class _StringsId extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -40355,6 +40366,8 @@ class _StringsIt extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -46308,6 +46321,8 @@ class _StringsJa extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -52264,6 +52279,8 @@ class _StringsKo extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -58390,6 +58407,8 @@ class _StringsNl extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -64531,6 +64550,8 @@ class _StringsPtBr extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -70655,6 +70676,8 @@ class _StringsRu extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -76724,6 +76747,8 @@ class _StringsTh extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -82825,6 +82850,8 @@ class _StringsTr extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -88913,6 +88940,8 @@ class _StringsVi extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 // Path: <root>
@@ -94579,6 +94608,8 @@ class _StringsZhCn extends _StringsEn {
       '没有安装 Magpie。把「游戏窗口超分」改成「自动」即可下载。';
   @override
   String get game_health_upscaling => '窗口超分';
+  @override
+  String get library_search => '搜索库';
 }
 
 // Path: <root>
@@ -100450,6 +100481,8 @@ class _StringsZhHk extends _StringsEn {
       'Magpie is not installed. Set window upscaling to Auto to download it.';
   @override
   String get game_health_upscaling => 'Window upscaling';
+  @override
+  String get library_search => 'Search library';
 }
 
 /// Flat map(s) containing all translations.
@@ -105911,6 +105944,8 @@ extension on _StringsEn {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -111370,6 +111405,8 @@ extension on _StringsAr {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -116850,6 +116887,8 @@ extension on _StringsDe {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -122329,6 +122368,8 @@ extension on _StringsEs {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -127814,6 +127855,8 @@ extension on _StringsFr {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -133281,6 +133324,8 @@ extension on _StringsId {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -138763,6 +138808,8 @@ extension on _StringsIt {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -144207,6 +144254,8 @@ extension on _StringsJa {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -149655,6 +149704,8 @@ extension on _StringsKo {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -155130,6 +155181,8 @@ extension on _StringsNl {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -160602,6 +160655,8 @@ extension on _StringsPtBr {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -166079,6 +166134,8 @@ extension on _StringsRu {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -171540,6 +171597,8 @@ extension on _StringsTh {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -177010,6 +177069,8 @@ extension on _StringsTr {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -182475,6 +182536,8 @@ extension on _StringsVi {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }
@@ -187897,6 +187960,8 @@ extension on _StringsZhCn {
         return '没有安装 Magpie。把「游戏窗口超分」改成「自动」即可下载。';
       case 'game_health_upscaling':
         return '窗口超分';
+      case 'library_search':
+        return '搜索库';
       default:
         return null;
     }
@@ -193336,6 +193401,8 @@ extension on _StringsZhHk {
         return 'Magpie is not installed. Set window upscaling to Auto to download it.';
       case 'game_health_upscaling':
         return 'Window upscaling';
+      case 'library_search':
+        return 'Search library';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "你的电脑上已经开着一个 Magpie，Hibiki 没有去动它。按 Win+Shift+A 就能放大游戏窗口。",
   "galgame_upscaling_hint_manual": "按 Win+Shift+A 放大游戏窗口。",
   "galgame_upscaling_hint_not_installed": "没有安装 Magpie。把「游戏窗口超分」改成「自动」即可下载。",
-  "game_health_upscaling": "窗口超分"
+  "game_health_upscaling": "窗口超分",
+  "library_search": "搜索库"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2672,5 +2672,6 @@
   "galgame_upscaling_hint_external": "A copy of Magpie was already running, so Hibiki left it alone. Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_manual": "Press Win+Shift+A to upscale the game window.",
   "galgame_upscaling_hint_not_installed": "Magpie is not installed. Set window upscaling to Auto to download it.",
-  "game_health_upscaling": "Window upscaling"
+  "game_health_upscaling": "Window upscaling",
+  "library_search": "Search library"
 }

--- a/hibiki/lib/src/media/media_search_text.dart
+++ b/hibiki/lib/src/media/media_search_text.dart
@@ -1,0 +1,122 @@
+/// 库页搜索的**共享**归一化与匹配（P5-A）：书架 / 视频 / 游戏三个库页同一口径。
+///
+/// 此前这套实现只长在游戏库页（`galgame_library_query.dart` 的
+/// `normalizeGalgameSearchText`），书架与视频页**根本没有搜索**。补搜索时不该
+/// 各写一套「大概也做全角转半角」的近似实现——同一个库、同一批日文标题，在三个
+/// 页面搜出不同结果比没有搜索更难解释。故把已在游戏页验证过的实现原样上提到
+/// 媒体层，游戏侧改为委托（行为逐字节不变）。
+///
+/// 刻意**不引入**模糊匹配 / 拼音 / 分词依赖：目标只是让排版差异（全角、片假名、
+/// 中点、长音符）不再挡住命中。
+library;
+
+/// 搜索归一化：全角 ASCII → 半角、大写 → 小写、片假名 → 平假名、丢掉空白与常见
+/// 标点。目的是让「Fate／stay night」「fate stay night」「ＦＡＴＥ・ｓｔａｙ」
+/// 互相能命中，而不引入任何模糊匹配依赖。
+///
+/// 片假名折叠只做基本区（U+30A1..U+30F6 平移 -0x60），长音符 `ー`、中点 `・`
+/// 这类连接符直接丢弃——它们在标题里出现与否全凭排版习惯。
+String normalizeMediaSearchText(String raw) {
+  if (raw.isEmpty) return '';
+  final StringBuffer out = StringBuffer();
+  for (final int code in raw.runes) {
+    int c = code;
+    // 全角 ASCII（U+FF01..U+FF5E）→ 半角。
+    if (c >= 0xFF01 && c <= 0xFF5E) {
+      c -= 0xFEE0;
+    }
+    // 全角空格 → 视作空白（下面被丢弃）。
+    if (c == 0x3000) {
+      continue;
+    }
+    // 片假名 → 平假名（基本区）。
+    if (c >= 0x30A1 && c <= 0x30F6) {
+      c -= 0x60;
+    }
+    final String ch = String.fromCharCode(c);
+    if (_isDroppedSearchChar(ch, c)) {
+      continue;
+    }
+    out.write(ch.toLowerCase());
+  }
+  return out.toString();
+}
+
+/// 候选标题里是否有一条命中 [query]：两侧都经 [normalizeMediaSearchText] 后做
+/// 子串匹配。**空查询恒命中**（搜索框为空 = 不过滤）。纯函数。
+///
+/// [titles] 传该条目的全部可搜标题（原名 / 显示名 / 别名 / 译名…），任意一条命中
+/// 即算命中——用户记得住哪个名字是随机的。
+bool matchesMediaSearch({
+  required String query,
+  required Iterable<String> titles,
+}) {
+  final String needle = normalizeMediaSearchText(query);
+  if (needle.isEmpty) return true;
+  for (final String title in titles) {
+    if (normalizeMediaSearchText(title).contains(needle)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// 归一化时丢弃的字符：空白 + 常见分隔/装饰标点（含日文全角标点）。
+bool _isDroppedSearchChar(String ch, int code) {
+  if (code <= 0x20) return true; // 控制字符与空格
+  return _kDroppedSearchChars.contains(ch);
+}
+
+/// 见 [_isDroppedSearchChar]。
+const Set<String> _kDroppedSearchChars = <String>{
+  '!',
+  '"',
+  '#',
+  '\$',
+  '%',
+  '&',
+  "'",
+  '(',
+  ')',
+  '*',
+  '+',
+  ',',
+  '-',
+  '.',
+  '/',
+  ':',
+  ';',
+  '<',
+  '=',
+  '>',
+  '?',
+  '@',
+  '[',
+  '\\',
+  ']',
+  '^',
+  '_',
+  '`',
+  '{',
+  '|',
+  '}',
+  '~',
+  '・',
+  'ー',
+  '、',
+  '。',
+  '「',
+  '」',
+  '『',
+  '』',
+  '〜',
+  '＝',
+  '−',
+  '–',
+  '—',
+  '“',
+  '”',
+  '‘',
+  '’',
+  '…',
+};

--- a/hibiki/lib/src/mining/galgame_library_query.dart
+++ b/hibiki/lib/src/mining/galgame_library_query.dart
@@ -6,6 +6,7 @@ library;
 
 import 'dart:convert';
 
+import 'package:hibiki/src/media/media_search_text.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 
 /// 排序维度（契约 §4.1）。[key] 是持久化字符串，**不可随意改**。
@@ -173,111 +174,17 @@ class GalgameLibraryView {
   }
 }
 
-/// 搜索归一化：全角 ASCII → 半角、大写 → 小写、片假名 → 平假名、丢掉空白与常见
-/// 标点。目的是让「Fate／stay night」「fate stay night」「ＦＡＴＥ・ｓｔａｙ」
-/// 互相能命中，而不引入任何模糊匹配依赖。
-///
-/// 片假名折叠只做基本区（U+30A1..U+30F6 平移 -0x60），长音符 `ー`、中点 `・`
-/// 这类连接符直接丢弃——它们在标题里出现与否全凭排版习惯。
-String normalizeGalgameSearchText(String raw) {
-  if (raw.isEmpty) return '';
-  final StringBuffer out = StringBuffer();
-  for (final int code in raw.runes) {
-    int c = code;
-    // 全角 ASCII（U+FF01..U+FF5E）→ 半角。
-    if (c >= 0xFF01 && c <= 0xFF5E) {
-      c -= 0xFEE0;
-    }
-    // 全角空格 → 视作空白（下面被丢弃）。
-    if (c == 0x3000) {
-      continue;
-    }
-    // 片假名 → 平假名（基本区）。
-    if (c >= 0x30A1 && c <= 0x30F6) {
-      c -= 0x60;
-    }
-    final String ch = String.fromCharCode(c);
-    if (_isDroppedSearchChar(ch, c)) {
-      continue;
-    }
-    out.write(ch.toLowerCase());
-  }
-  return out.toString();
-}
-
-/// 归一化时丢弃的字符：空白 + 常见分隔/装饰标点（含日文全角标点）。
-bool _isDroppedSearchChar(String ch, int code) {
-  if (code <= 0x20) return true; // 控制字符与空格
-  return _kDroppedSearchChars.contains(ch);
-}
-
-/// 见 [_isDroppedSearchChar]。
-
-const Set<String> _kDroppedSearchChars = <String>{
-  '!',
-  '"',
-  '#',
-  '\$',
-  '%',
-  '&',
-  "'",
-  '(',
-  ')',
-  '*',
-  '+',
-  ',',
-  '-',
-  '.',
-  '/',
-  ':',
-  ';',
-  '<',
-  '=',
-  '>',
-  '?',
-  '@',
-  '[',
-  '\\',
-  ']',
-  '^',
-  '_',
-  '`',
-  '{',
-  '|',
-  '}',
-  '~',
-  '・',
-  'ー',
-  '、',
-  '。',
-  '「',
-  '」',
-  '『',
-  '』',
-  '〜',
-  '＝',
-  '−',
-  '–',
-  '—',
-  '“',
-  '”',
-  '‘',
-  '’',
-  '…',
-};
+/// 搜索归一化。**实现已上提到媒体层** [normalizeMediaSearchText]（P5-A：书架 /
+/// 视频 / 游戏三个库页共用同一口径），这里保留原名做委托——它是本文件的公开
+/// API，已被游戏库页与其单测引用，改名没有收益只会破坏调用方。
+String normalizeGalgameSearchText(String raw) => normalizeMediaSearchText(raw);
 
 /// 某条游戏是否命中搜索词：对 [GalgameEntry.searchTitles] 全部标题做归一化子串匹配。
 /// 空查询恒命中。纯函数。
-bool matchesGalgameSearch(GalgameEntry entry, String query) {
-  final String needle = normalizeGalgameSearchText(query);
-  if (needle.isEmpty) return true;
-  for (final String title in entry.searchTitles) {
-    if (normalizeGalgameSearchText(title).contains(needle)) {
-      return true;
-    }
-  }
-  return false;
-}
+///
+/// P5-A：判定逻辑收口到共享的 [matchesMediaSearch]，与书架/视频页同一口径。
+bool matchesGalgameSearch(GalgameEntry entry, String query) =>
+    matchesMediaSearch(query: query, titles: entry.searchTitles);
 
 /// 某条游戏是否通过筛选（不含搜索）。纯函数。
 bool matchesGalgameFilters(GalgameEntry entry, GalgameLibraryView view) {

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -49,6 +49,7 @@ import 'package:hibiki/src/media/collections/batch_combine.dart';
 import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
+import 'package:hibiki/src/media/media_search_text.dart';
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
 import 'package:hibiki/src/pages/implementations/media_collection_detail_page.dart';
 import 'package:hibiki/src/pages/implementations/media_item_dialog_page.dart';
@@ -209,6 +210,11 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   /// 最近观看，用户拍板）。旧 `ShelfEntries.sortOrder` 手动权重已废弃不再读取。
   ShelfSortMode _sortMode = ShelfSortMode.recent;
 
+  /// P5-A：视频库搜索词（原文，匹配时才归一化）。**刻意不持久化**——下次进
+  /// 视频库还挂着上次的搜索词只会让人以为库空了（与书架/游戏库页同一决定）。
+  String _searchQuery = '';
+  final TextEditingController _searchController = TextEditingController();
+
   /// 层次 C：`'video|<uid>' → 该条目在其主折叠合集里的 sortIndex`（组内序真相源，
   /// 与详情页/播放器 `getCollectionItems` 同源——详情页拖完库页行立即同序）。
   Map<String, int> _memberSortIndex = const <String, int>{};
@@ -262,6 +268,7 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
 
   @override
   void dispose() {
+    _searchController.dispose();
     homeShellTabNotifier.removeListener(_onShellTabActivated);
     _videoUidsSub?.cancel();
     _autoScrape?.dispose();
@@ -1881,6 +1888,7 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
             child: Column(
               children: <Widget>[
                 if (!isCupertinoPlatform(context)) _buildPageHeader(canImport),
+                _buildVideoSearchBar(),
                 _buildTagFilterBar(allTags),
                 // 下拉同步可能跑几十秒，光一个转圈看不出进展；没同步在飞时零高度。
                 const SyncProgressBanner(),
@@ -1931,9 +1939,19 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
                   collectionFilter: collectionFilter,
                 );
               }).toList();
+        // P5-A：搜索按标题匹配，归一化走与书架/游戏库页同一份
+        // [matchesMediaSearch]（全角/片假名/标点折叠），三页搜出的结果口径一致。
+        final List<VideoBookRow> searched = _searchQuery.trim().isEmpty
+            ? books
+            : books
+                .where((VideoBookRow b) => matchesMediaSearch(
+                      query: _searchQuery,
+                      titles: <String>[b.title],
+                    ))
+                .toList();
         // 排序交互重设计：卡片间序在 group 层按当前排序方式做（[_groupVideos]），
         // 这里不再预排散列表（旧 ShelfEntries.sortOrder 死权重已废弃，用户拍板）。
-        final List<VideoBookRow> ordered = books;
+        final List<VideoBookRow> ordered = searched;
         // 记录当前可见（已过滤）的本地视频，供批量「全选 / 反选」用。
         _visibleVideos = ordered;
         return FutureBuilder<_RemoteVideoState?>(
@@ -2956,6 +2974,39 @@ class _HomeVideoPageState extends ConsumerState<HomeVideoPage> {
   /// 整栏**（不再「无标签隐藏」），批量选择按钮才能常驻露出（否则空标签库点不到
   /// 批量入口、无法批量删除）。组件内部「管理标签」齿轮仍只在有标签时显示，故无
   /// 标签时整栏只剩「批量选择」按钮。
+  /// P5-A 视频库搜索框。形态与书架/游戏库页一致（三个库页搜索长一个样），
+  /// 搜索词只影响本次会话、不落库。
+  Widget _buildVideoSearchBar() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: SizedBox(
+        height: 40,
+        child: TextField(
+          key: const ValueKey<String>('video_search_field'),
+          controller: _searchController,
+          decoration: InputDecoration(
+            isDense: true,
+            prefixIcon: const Icon(Icons.search, size: 18),
+            hintText: t.library_search,
+            border: const OutlineInputBorder(),
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            suffixIcon: _searchQuery.isEmpty
+                ? null
+                : IconButton(
+                    icon: const Icon(Icons.close, size: 18),
+                    onPressed: () {
+                      _searchController.clear();
+                      setState(() => _searchQuery = '');
+                    },
+                  ),
+          ),
+          onChanged: (String value) => setState(() => _searchQuery = value),
+        ),
+      ),
+    );
+  }
+
   Widget _buildTagFilterBar(List<BookTagRow> tags) {
     return HibikiTagFilterBar(
       tags: tags,

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -40,6 +40,7 @@ import 'package:hibiki/src/media/collections/add_to_collection_dialog.dart';
 import 'package:hibiki/src/media/collections/batch_combine.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
+import 'package:hibiki/src/media/media_search_text.dart';
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
 import 'package:hibiki/src/pages/implementations/media_collection_grid_detail_page.dart';
 import 'package:hibiki/src/pages/implementations/series_shelf_card.dart';
@@ -200,6 +201,11 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
   Future<void>? _shelfMapsFuture;
   ShelfSortMode _sortMode = ShelfSortMode.recent;
 
+  /// P5-A：书架搜索词（原文，匹配时才归一化）。**刻意不持久化**——下次进书架还
+  /// 挂着上次的搜索词只会让人以为书没了（与游戏库页同一决定）。
+  String _searchQuery = '';
+  final TextEditingController _searchController = TextEditingController();
+
   /// 层次 C：`'mediaType|entryKey' → 该条目在其主折叠合集里的 sortIndex`（组内序
   /// 真相源，与详情页 `getCollectionItems` 同源）。
   Map<String, int> _memberSortIndex = const <String, int>{};
@@ -331,6 +337,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
 
   @override
   void dispose() {
+    _searchController.dispose();
     mediaType.tabRefreshNotifier.removeListener(_reloadShelfMapsOnTabRefresh);
     homeShellTabNotifier.removeListener(_onShellTabActivated);
     assert(() {
@@ -397,6 +404,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             child: Column(
               children: [
                 if (!isCupertinoPlatform(context)) _buildPageHeader(),
+                _buildSearchBar(),
                 _buildTagBar(allTags.valueOrNull ?? const []),
                 // 下拉同步可能跑几十秒，光一个转圈看不出进展；没同步在飞时零高度。
                 const SyncProgressBanner(),
@@ -407,7 +415,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
                       _remoteBooksFuture ??= _loadRemoteBooks();
                       _shelfMapsFuture ??= _loadShelfMaps();
                       final Set<String>? filterSet = filteredIds.valueOrNull;
-                      final List<MediaItem> filtered;
+                      List<MediaItem> filtered;
                       if (filterSet == null) {
                         filtered = bookList;
                       } else {
@@ -422,6 +430,22 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
                             primaryCollectionId: _primaryCollectionByEntry[
                                 MediaKind.epub.compositeKey(key)],
                             collectionFilter: tagCollectionFilter,
+                          );
+                        }).toList();
+                      }
+                      // P5-A：搜索按**显示名 + DB 原名**双口径匹配——改过名的书
+                      // 用户既可能记得新名也可能记得旧名，只匹配其一都会「搜不到
+                      // 明明在书架上的书」。归一化走与游戏库页同一份
+                      // [matchesMediaSearch]（全角/片假名/标点折叠）。
+                      if (_searchQuery.trim().isNotEmpty) {
+                        filtered = filtered.where((MediaItem item) {
+                          return matchesMediaSearch(
+                            query: _searchQuery,
+                            titles: <String>[
+                              ReaderHibikiSource.instance
+                                  .getDisplayTitleFromMediaItem(item),
+                              item.title,
+                            ],
                           );
                         }).toList();
                       }
@@ -632,6 +656,39 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     if (!ids.remove(collectionId)) ids.add(collectionId);
     unawaited(prefs.setCollapsedCollectionIds(ids));
     setState(() {});
+  }
+
+  /// P5-A 书架搜索框。形态与游戏库页工具条一致（三个库页搜索长一个样），
+  /// 搜索词只影响本次会话、不落库。
+  Widget _buildSearchBar() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: SizedBox(
+        height: 40,
+        child: TextField(
+          key: const ValueKey<String>('shelf_search_field'),
+          controller: _searchController,
+          decoration: InputDecoration(
+            isDense: true,
+            prefixIcon: const Icon(Icons.search, size: 18),
+            hintText: t.library_search,
+            border: const OutlineInputBorder(),
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            suffixIcon: _searchQuery.isEmpty
+                ? null
+                : IconButton(
+                    icon: const Icon(Icons.close, size: 18),
+                    onPressed: () {
+                      _searchController.clear();
+                      setState(() => _searchQuery = '');
+                    },
+                  ),
+          ),
+          onChanged: (String value) => setState(() => _searchQuery = value),
+        ),
+      ),
+    );
   }
 
   String _sortModeLabel(ShelfSortMode mode) => switch (mode) {

--- a/hibiki/test/media/media_search_text_test.dart
+++ b/hibiki/test/media/media_search_text_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/media_search_text.dart';
+import 'package:hibiki/src/mining/galgame_library_query.dart'
+    show normalizeGalgameSearchText;
+
+/// P5-A：书架 / 视频 / 游戏三个库页共用的搜索归一化与匹配。
+///
+/// 这套实现原本只长在游戏库页；补书架与视频搜索时上提到媒体层，游戏侧改委托。
+/// 本测试锁住两件事：① 归一化语义（全角 / 片假名 / 标点折叠）；② 游戏侧委托后
+/// 与共享实现**逐字符一致**（防有人日后改一边忘另一边）。
+void main() {
+  group('normalizeMediaSearchText', () {
+    test('全角 ASCII 折成半角、大写折成小写', () {
+      expect(normalizeMediaSearchText('ＦＡＴＥ'), 'fate');
+      expect(normalizeMediaSearchText('Fate'), 'fate');
+    });
+
+    test('片假名折成平假名（基本区）', () {
+      expect(normalizeMediaSearchText('カタカナ'), 'かたかな');
+      // 已经是平假名的保持不变。
+      expect(normalizeMediaSearchText('かたかな'), 'かたかな');
+    });
+
+    test('空白与常见标点被丢弃（含全角空格、中点、长音符）', () {
+      expect(normalizeMediaSearchText('fate stay night'), 'fatestaynight');
+      expect(normalizeMediaSearchText('Fate／stay night'), 'fatestaynight');
+      expect(normalizeMediaSearchText('ＦＡＴＥ・ｓｔａｙ'), 'fatestay');
+      expect(normalizeMediaSearchText('　全角空格'), '全角空格');
+      expect(normalizeMediaSearchText('ラーメン'), 'らめん'); // 长音符丢弃
+    });
+
+    test('空串返回空串（不抛）', () {
+      expect(normalizeMediaSearchText(''), '');
+    });
+  });
+
+  group('matchesMediaSearch', () {
+    test('空查询恒命中（搜索框为空 = 不过滤）', () {
+      expect(
+        matchesMediaSearch(query: '', titles: <String>['任意']),
+        isTrue,
+      );
+      // 纯标点的查询归一化后为空，同样视作不过滤。
+      expect(
+        matchesMediaSearch(query: '・・・', titles: <String>['任意']),
+        isTrue,
+      );
+    });
+
+    test('排版差异不挡命中：全角/片假名/中点/空格', () {
+      const List<String> titles = <String>['Fate／stay night'];
+      for (final String q in <String>[
+        'fate stay night',
+        'ＦＡＴＥ・ｓｔａｙ',
+        'staynight',
+        'FATE',
+      ]) {
+        expect(matchesMediaSearch(query: q, titles: titles), isTrue,
+            reason: '「$q」应命中 Fate／stay night');
+      }
+    });
+
+    test('多标题任一命中即算命中（记得住哪个名字是随机的）', () {
+      const List<String> titles = <String>['原名カタカナ', '改过的显示名'];
+      expect(matchesMediaSearch(query: 'かたかな', titles: titles), isTrue);
+      expect(matchesMediaSearch(query: '显示名', titles: titles), isTrue);
+    });
+
+    test('真不匹配时返回 false（不是恒真）', () {
+      expect(
+        matchesMediaSearch(query: 'zzz不存在', titles: <String>['Fate']),
+        isFalse,
+      );
+    });
+
+    test('空标题列表：非空查询不命中', () {
+      expect(
+        matchesMediaSearch(query: 'fate', titles: const <String>[]),
+        isFalse,
+      );
+    });
+  });
+
+  test('游戏侧 normalizeGalgameSearchText 委托后与共享实现逐字符一致', () {
+    for (final String s in <String>[
+      'Fate／stay night',
+      'ＦＡＴＥ・ｓｔａｙ',
+      'カタカナ　テスト',
+      'ラーメン',
+      '「括弧」〜波ダッシュ…',
+      '',
+    ]) {
+      expect(normalizeGalgameSearchText(s), normalizeMediaSearchText(s),
+          reason: '委托必须逐字符一致：$s');
+    }
+  });
+}

--- a/hibiki/test/pages/home_video_batch_collection_ops_test.dart
+++ b/hibiki/test/pages/home_video_batch_collection_ops_test.dart
@@ -231,8 +231,10 @@ void main() {
         .tap(find.byKey(const ValueKey<String>('home_video_batch_combine')));
     await tester.pumpAndSettle();
     // 合并弹命名框，默认名 = 成员最多合集名（大集，3 > 2）。
+    // 库页自 P5-A 起有常驻搜索框（key=video_search_field），全页 EditableText
+    // 不止一个。命名弹窗是压在页面之上的 route，其输入框在树序最后。
     final EditableText field = tester.widget<EditableText>(
-      find.byType(EditableText),
+      find.byType(EditableText).last,
     );
     expect(field.controller.text, '大集', reason: '默认名=成员最多合集名');
     await tester.tap(find.text(t.dialog_ok));

--- a/hibiki/test/pages/home_video_page_menu_test.dart
+++ b/hibiki/test/pages/home_video_page_menu_test.dart
@@ -541,7 +541,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_1.png',
-        text: 'cover-one',
+        bytes: _kOnePixelPng,
       ),
       subtitle: writeAppOwnedAsset(
         dirName: VideoStorage.subtitlesDirName,
@@ -555,7 +555,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_2.png',
-        text: 'cover-two',
+        bytes: _kOnePixelPng,
       ),
       subtitle: writeAppOwnedAsset(
         dirName: VideoStorage.subtitlesDirName,
@@ -608,7 +608,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_1.png',
-        text: 'cover-one',
+        bytes: _kOnePixelPng,
       ),
       subtitle: sharedSubtitle,
     );
@@ -618,7 +618,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_2.png',
-        text: 'cover-two',
+        bytes: _kOnePixelPng,
       ),
       subtitle: writeAppOwnedAsset(
         dirName: VideoStorage.subtitlesDirName,
@@ -632,7 +632,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_3.png',
-        text: 'cover-three',
+        bytes: _kOnePixelPng,
       ),
       subtitle: sharedSubtitle,
     );
@@ -688,7 +688,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_1.png',
-        text: 'cover-one',
+        bytes: _kOnePixelPng,
       ),
       subtitle: writeAppOwnedAsset(
         dirName: VideoStorage.subtitlesDirName,
@@ -702,7 +702,7 @@ void main() {
       cover: writeAppOwnedAsset(
         dirName: VideoStorage.coversDirName,
         fileName: 'video_2.png',
-        text: 'cover-two',
+        bytes: _kOnePixelPng,
       ),
       subtitle: writeAppOwnedAsset(
         dirName: VideoStorage.subtitlesDirName,
@@ -816,3 +816,18 @@ void main() {
     );
   });
 }
+
+/// 合法 1x1 PNG：封面 fixture 必须是**真能解码**的图片。此前写的是纯文本
+/// （'cover-one'），只因当时布局下封面没被绘制才没暴露；P5-A 加了库页搜索框后
+/// 布局变化让封面真的进了绘制，Image.file 解码即抛 'Invalid image data'。
+const List<int> _kOnePixelPng = <int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+  0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+  0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+  0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+  0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+  0x42, 0x60, 0x82,
+];


### PR DESCRIPTION
## 背景：这批工作差点丢掉

用户在 P5 剩余方向上拍板走 **A 方案**：给书架/视频补搜索，复用游戏那套已验证的归一化纯函数。

实现完成后推到了 [#436](https://github.com/hajisensai/hibiki/pull/436) 所在分支，但 **#436 在同一时刻被合并了，且只带走了它当时的 head（首页那个 commit）**。内容级核对确认：develop 上没有 `media_search_text.dart`、没有两个搜索框的 key、没有 `library_search` i18n key，而首页部分的 `final MediaKind kind` 在。

合并后追加 push 的 commit 不会自动进 develop，所以这两个 commit 已成孤儿。本 PR 把它们 cherry-pick 到当前 develop 重新承载（cherry-pick 无冲突）。

## 为什么这不是「三套实现去重」

查证结论：**只有游戏库页有搜索**，书架页与视频页全文无 `search` 符号——**根本没有搜索入口**。所以「搜索统一」实际是补功能。

但归一化必须共用：同一个库、同一批日文标题，在三个页面搜出不同结果，比没有搜索更难解释。

## 改动

- 新增 `hibiki/lib/src/media/media_search_text.dart`：`normalizeMediaSearchText`（实现自游戏页**原样上提**，逐字符逻辑未改）+ `matchesMediaSearch`（归一化子串匹配，空查询恒命中，多标题任一命中即算命中）。
- `galgame_library_query.dart` 的 `normalizeGalgameSearchText` / `matchesGalgameSearch` 改委托，删掉重复的丢弃字符集副本。**保留原函数名**——它们是该文件公开 API、已被游戏库页与单测引用，改名无收益只破坏调用方。
- 书架页 / 视频页各加常驻搜索框（key `shelf_search_field` / `video_search_field`），形态与游戏库页工具条一致。
- 书架搜索按**显示名 + DB 原名**双口径匹配：改过名的书，用户既可能记得新名也可能记得旧名，只匹配其一都会「搜不到明明在书架上的书」。
- 搜索词**不持久化**（三页同一决定）：下次进页面还挂着上次的搜索词只会让人以为库空了。
- 新 i18n key `library_search`，经 `tool/i18n_sync.dart` 补齐 17 语言 + 重跑 slang。

## 顺带修的两处既有测试脆弱点（不是掩盖，是 fixture 本身有错）

加搜索框带来的布局变化，把两处一直存在的问题暴露了出来：

1. `home_video_batch_collection_ops_test`：`find.byType(EditableText)` 假设全页只有一个输入框，库页有了常驻搜索框后命中 2 个 → 改取树序最后一个（命名弹窗是压在页面之上的 route）。
2. `home_video_page_menu_test`：**7 处封面 fixture 写的是纯文本 `'cover-one'` 而非图片字节**。此前布局下封面没被绘制才没暴露；加搜索框后封面真的进了绘制，`Image.file` 解码即抛 `Invalid image data` → 改写合法 1x1 PNG。

## 验证（基于当前 develop 重跑）

- `flutter analyze` hibiki 全量（含 test 目录）：**No issues found**
- `flutter test test/pages + test/media + test/mining + test/i18n + test/goldens`：**6434 passed**（exit 0）
- 新增 `test/media/media_search_text_test.dart` **10 个用例**：归一化语义（全角/片假名/标点/长音符）、匹配语义（空查询恒命中、多标题任一命中、真不匹配为 false）、以及**游戏侧委托后与共享实现逐字符一致**（防日后改一边忘另一边）
- 游戏侧回归：`test/mining` 全绿，确认提取为纯重构、零行为变化

## 尚未做

- **搜索 UI 未真机验收**（书架/视频两页搜索框的实际交互）。按仓库规则在真机复验前不宣称完成。
