### PR TITLE
refactor(galgame): gal 弹窗统一收口 MD3 设计系统

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45560 (2680 per locale)
+/// Strings: 45594 (2682 per locale)
 ///
-/// Built on 2026-07-26 at 15:02 UTC
+/// Built on 2026-07-26 at 17:55 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3559,6 +3559,13 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get download_clear_finished => 'Clear finished';
   String get download_status_queued => 'Queued';
   String get download_status_cancelled => 'Cancelled';
+  String get game_waveform_select_title => 'Select audio range';
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -9644,6 +9651,15 @@ class _StringsAr extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -15802,6 +15818,15 @@ class _StringsDe extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -21976,6 +22001,15 @@ class _StringsEs extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -28161,6 +28195,15 @@ class _StringsFr extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -34273,6 +34316,15 @@ class _StringsId extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -40433,6 +40485,15 @@ class _StringsIt extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -46398,6 +46459,15 @@ class _StringsJa extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -52366,6 +52436,15 @@ class _StringsKo extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -58504,6 +58583,15 @@ class _StringsNl extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -64657,6 +64745,15 @@ class _StringsPtBr extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -70793,6 +70890,15 @@ class _StringsRu extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -76874,6 +76980,15 @@ class _StringsTh extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -82987,6 +83102,15 @@ class _StringsTr extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -89087,6 +89211,15 @@ class _StringsVi extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 // Path: <root>
@@ -94765,6 +94898,15 @@ class _StringsZhCn extends _StringsEn {
   String get download_status_queued => '排队中';
   @override
   String get download_status_cancelled => '已取消';
+  @override
+  String get game_waveform_select_title => '选择音频范围';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end}（时长 ${duration} / 共 ${total}）';
 }
 
 // Path: <root>
@@ -100648,6 +100790,15 @@ class _StringsZhHk extends _StringsEn {
   String get download_status_queued => 'Queued';
   @override
   String get download_status_cancelled => 'Cancelled';
+  @override
+  String get game_waveform_select_title => 'Select audio range';
+  @override
+  String game_waveform_range_label(
+          {required Object start,
+          required Object end,
+          required Object duration,
+          required Object total}) =>
+      '${start} - ${end} (selected ${duration} / total ${total})';
 }
 
 /// Flat map(s) containing all translations.
@@ -106121,6 +106272,15 @@ extension on _StringsEn {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -111592,6 +111752,15 @@ extension on _StringsAr {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -117084,6 +117253,15 @@ extension on _StringsDe {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -122575,6 +122753,15 @@ extension on _StringsEs {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -128072,6 +128259,15 @@ extension on _StringsFr {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -133551,6 +133747,15 @@ extension on _StringsId {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -139045,6 +139250,15 @@ extension on _StringsIt {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -144501,6 +144715,15 @@ extension on _StringsJa {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -149961,6 +150184,15 @@ extension on _StringsKo {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -155448,6 +155680,15 @@ extension on _StringsNl {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -160932,6 +161173,15 @@ extension on _StringsPtBr {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -166421,6 +166671,15 @@ extension on _StringsRu {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -171894,6 +172153,15 @@ extension on _StringsTh {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -177376,6 +177644,15 @@ extension on _StringsTr {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -182853,6 +183130,15 @@ extension on _StringsVi {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }
@@ -188287,6 +188573,15 @@ extension on _StringsZhCn {
         return '排队中';
       case 'download_status_cancelled':
         return '已取消';
+      case 'game_waveform_select_title':
+        return '选择音频范围';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end}（时长 ${duration} / 共 ${total}）';
       default:
         return null;
     }
@@ -193738,6 +194033,15 @@ extension on _StringsZhHk {
         return 'Queued';
       case 'download_status_cancelled':
         return 'Cancelled';
+      case 'game_waveform_select_title':
+        return 'Select audio range';
+      case 'game_waveform_range_label':
+        return (
+                {required Object start,
+                required Object end,
+                required Object duration,
+                required Object total}) =>
+            '${start} - ${end} (selected ${duration} / total ${total})';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "漫画目录下载",
   "download_clear_finished": "清除已完成",
   "download_status_queued": "排队中",
-  "download_status_cancelled": "已取消"
+  "download_status_cancelled": "已取消",
+  "game_waveform_select_title": "选择音频范围",
+  "game_waveform_range_label": "$start - $end（时长 $duration / 共 $total）"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2678,5 +2678,7 @@
   "manga_online_queue_section": "Manga catalog downloads",
   "download_clear_finished": "Clear finished",
   "download_status_queued": "Queued",
-  "download_status_cancelled": "Cancelled"
+  "download_status_cancelled": "Cancelled",
+  "game_waveform_select_title": "Select audio range",
+  "game_waveform_range_label": "$start - $end (selected $duration / total $total)"
 }

--- a/hibiki/lib/src/mining/galgame_waveform_select_dialog.dart
+++ b/hibiki/lib/src/mining/galgame_waveform_select_dialog.dart
@@ -11,6 +11,7 @@ import 'package:hibiki/src/mining/galgame_audio_source.dart' show GalAudioSlice;
 import 'package:hibiki/src/mining/galgame_waveform.dart'
     show kGalWaveformWindowMs, pcmToEnergyEnvelope;
 import 'package:hibiki/src/mining/galgame_waveform_select.dart';
+import 'package:hibiki/utils.dart';
 
 /// galgame 一键制卡（docs/specs/galgame-mining）波形选区对话框。
 ///
@@ -23,7 +24,7 @@ Future<GalWaveformRange?> showGalWaveformSelectDialog(
   BuildContext context, {
   required GalAudioSlice slice,
 }) {
-  return showDialog<GalWaveformRange>(
+  return showAppDialog<GalWaveformRange>(
     context: context,
     builder: (BuildContext ctx) => _GalWaveformSelectDialog(slice: slice),
   );
@@ -149,87 +150,115 @@ class _GalWaveformSelectDialogState extends State<_GalWaveformSelectDialog> {
 
   @override
   Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     final ColorScheme cs = Theme.of(context).colorScheme;
-    final TextTheme tt = Theme.of(context).textTheme;
-    final String rangeLabel = '${_fmtSeconds(_range.startMs)} - '
-        '${_fmtSeconds(_range.endMs)}'
-        '（时长 ${_fmtSeconds(_range.durationMs)} / 共 ${_fmtSeconds(_totalMs)}）';
-    return AlertDialog(
-      title: const Text('选择音频范围'),
-      content: SizedBox(
-        width: 480,
-        child: Column(
+    final String rangeLabel = t.game_waveform_range_label(
+      start: _fmtSeconds(_range.startMs),
+      end: _fmtSeconds(_range.endMs),
+      duration: _fmtSeconds(_range.durationMs),
+      total: _fmtSeconds(_totalMs),
+    );
+    return HibikiDialogFrame(
+      maxWidth: 520,
+      scrollable: false,
+      child: HibikiModalSheetFrame(
+        title: t.game_waveform_select_title,
+        scrollable: true,
+        bodyPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          0,
+          tokens.spacing.card,
+          tokens.spacing.gap,
+        ),
+        footerPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          tokens.spacing.gap,
+          tokens.spacing.card,
+          tokens.spacing.card,
+        ),
+        body: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
             SizedBox(
               height: 140,
-              child: LayoutBuilder(
-                builder: (BuildContext context, BoxConstraints constraints) {
-                  final double width = constraints.maxWidth.isFinite
-                      ? constraints.maxWidth
-                      : 480.0;
-                  _lastWidth = width;
-                  final int targetBuckets = math.max(1, width ~/ 2);
-                  final List<double> buckets = _bucketsFor(targetBuckets);
-                  return GestureDetector(
-                    behavior: HitTestBehavior.opaque,
-                    onHorizontalDragStart: _onDragStart,
-                    onHorizontalDragUpdate: _onDragUpdate,
-                    onHorizontalDragEnd: _onDragEnd,
-                    child: Stack(
-                      fit: StackFit.expand,
-                      children: <Widget>[
-                        RepaintBoundary(
-                          child: CustomPaint(
-                            painter: SubtitleWaveformPainter(
-                              buckets: buckets,
-                              windowStartMs: 0,
-                              windowEndMs: _totalMs,
-                              cueBoundariesMs: const <int>[],
-                              previewDelayMs: 0,
-                              currentPositionMs: 0,
-                              waveColor: cs.primary.withValues(alpha: 0.55),
-                              cueLineColor: cs.secondary,
-                              playheadColor: cs.tertiary,
-                              centerLineColor: cs.outlineVariant,
+              child: ClipRRect(
+                borderRadius: tokens.radii.controlRadius,
+                child: LayoutBuilder(
+                  builder: (BuildContext context, BoxConstraints constraints) {
+                    final double width = constraints.maxWidth.isFinite
+                        ? constraints.maxWidth
+                        : 480.0;
+                    _lastWidth = width;
+                    final int targetBuckets = math.max(1, width ~/ 2);
+                    final List<double> buckets = _bucketsFor(targetBuckets);
+                    return GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onHorizontalDragStart: _onDragStart,
+                      onHorizontalDragUpdate: _onDragUpdate,
+                      onHorizontalDragEnd: _onDragEnd,
+                      child: Stack(
+                        fit: StackFit.expand,
+                        children: <Widget>[
+                          RepaintBoundary(
+                            child: CustomPaint(
+                              painter: SubtitleWaveformPainter(
+                                buckets: buckets,
+                                windowStartMs: 0,
+                                windowEndMs: _totalMs,
+                                cueBoundariesMs: const <int>[],
+                                previewDelayMs: 0,
+                                currentPositionMs: 0,
+                                waveColor: cs.primary.withValues(alpha: 0.55),
+                                cueLineColor: cs.secondary,
+                                playheadColor: cs.tertiary,
+                                centerLineColor: cs.outlineVariant,
+                              ),
                             ),
                           ),
-                        ),
-                        CustomPaint(
-                          painter: _GalSelectionOverlayPainter(
-                            startMs: _range.startMs,
-                            endMs: _range.endMs,
-                            totalMs: _totalMs,
-                            fillColor: cs.primary.withValues(alpha: 0.16),
-                            edgeColor: cs.primary,
+                          CustomPaint(
+                            painter: _GalSelectionOverlayPainter(
+                              startMs: _range.startMs,
+                              endMs: _range.endMs,
+                              totalMs: _totalMs,
+                              fillColor: cs.primary.withValues(alpha: 0.16),
+                              edgeColor: cs.primary,
+                            ),
                           ),
-                        ),
-                      ],
-                    ),
-                  );
-                },
+                        ],
+                      ),
+                    );
+                  },
+                ),
               ),
             ),
-            const SizedBox(height: 12),
+            SizedBox(height: tokens.spacing.gap),
             Text(
               rangeLabel,
-              style: tt.bodySmall,
+              style: tokens.type.listSubtitle,
               textAlign: TextAlign.center,
             ),
           ],
         ),
+        footer: Wrap(
+          alignment: WrapAlignment.end,
+          spacing: tokens.spacing.gap,
+          runSpacing: tokens.spacing.gap,
+          children: <Widget>[
+            adaptiveDialogAction(
+              context: context,
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(t.dialog_cancel),
+            ),
+            adaptiveDialogAction(
+              context: context,
+              isDefaultAction: true,
+              onPressed: () => Navigator.of(context).pop(_range),
+              child: Text(t.dialog_ok),
+            ),
+          ],
+        ),
       ),
-      actions: <Widget>[
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: const Text('取消'),
-        ),
-        FilledButton(
-          onPressed: () => Navigator.of(context).pop(_range),
-          child: const Text('确定'),
-        ),
-      ],
     );
   }
 }

--- a/hibiki/lib/src/mining/magpie_download_confirm.dart
+++ b/hibiki/lib/src/mining/magpie_download_confirm.dart
@@ -7,7 +7,7 @@ library;
 import 'package:flutter/material.dart';
 import 'package:hibiki/src/mining/magpie_installer.dart';
 import 'package:hibiki/src/models/app_model.dart';
-import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/utils.dart';
 
 /// 弹出确认框，返回用户是否同意下载。
 ///
@@ -23,7 +23,7 @@ Future<bool> confirmMagpieDownload(
 ) async {
   final BuildContext? context = appModel.navigatorKey.currentContext;
   if (context == null) return false;
-  final bool? agreed = await showDialog<bool>(
+  final bool? agreed = await showAppDialog<bool>(
     context: context,
     // 🔴 不许点外部关掉：`_downloadDeclined` 是**整个 app 生命周期**的一次性旗子，
     // 误关一次就等于这次运行里再也不问、超分永久不可用。要拒绝必须显式点「取消」。
@@ -58,24 +58,53 @@ class _MagpieDownloadDialogState extends State<_MagpieDownloadDialog> {
 
   @override
   Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     final int? bytes = _sizeBytes;
     final String size = bytes == null
         ? ''
         : '\n\n${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB '
             '(${widget.prompt.arch})';
-    return AlertDialog(
-      title: Text(t.galgame_upscaling_download_title),
-      content: Text('${t.galgame_upscaling_download_body}$size'),
-      actions: <Widget>[
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(false),
-          child: Text(t.dialog_cancel),
+    return HibikiDialogFrame(
+      maxWidth: 440,
+      scrollable: false,
+      child: HibikiModalSheetFrame(
+        title: t.galgame_upscaling_download_title,
+        scrollable: true,
+        bodyPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          0,
+          tokens.spacing.card,
+          tokens.spacing.gap,
         ),
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(true),
-          child: Text(t.dialog_ok),
+        footerPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          tokens.spacing.gap,
+          tokens.spacing.card,
+          tokens.spacing.card,
         ),
-      ],
+        body: Text(
+          '${t.galgame_upscaling_download_body}$size',
+          style: tokens.type.listSubtitle,
+        ),
+        footer: Wrap(
+          alignment: WrapAlignment.end,
+          spacing: tokens.spacing.gap,
+          runSpacing: tokens.spacing.gap,
+          children: <Widget>[
+            adaptiveDialogAction(
+              context: context,
+              onPressed: () => Navigator.of(context).pop(false),
+              child: Text(t.dialog_cancel),
+            ),
+            adaptiveDialogAction(
+              context: context,
+              isDefaultAction: true,
+              onPressed: () => Navigator.of(context).pop(true),
+              child: Text(t.dialog_ok),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/hibiki/lib/src/pages/implementations/galgame_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_detail_page.dart
@@ -855,7 +855,7 @@ class _GalgameEditTabState extends State<_GalgameEditTab> {
   /// 刮削：输入标题或源 ID → 搜索 → 多结果让用户选 → 取详情 → 落库。
   Future<void> _scrape() async {
     if (_scraping) return; // 再入守卫：一次刮削含多次网络往返。
-    final String? query = await showDialog<String>(
+    final String? query = await showAppDialog<String>(
       context: context,
       builder: (BuildContext ctx) => _ScrapeQueryDialog(
         initial: _name.text.trim().isEmpty
@@ -876,7 +876,7 @@ class _GalgameEditTabState extends State<_GalgameEditTab> {
       }
       SourceCandidate? picked = result.candidates.length == 1
           ? result.candidates.first
-          : await showDialog<SourceCandidate>(
+          : await showAppDialog<SourceCandidate>(
               context: context,
               builder: (BuildContext ctx) =>
                   _SourcePickerDialog(candidates: result.candidates),
@@ -1078,24 +1078,51 @@ class _ScrapeQueryDialogState extends State<_ScrapeQueryDialog> {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      title: Text(t.game_scrape_title),
-      content: TextField(
-        controller: _controller,
-        autofocus: true,
-        decoration: InputDecoration(labelText: t.game_scrape_query),
-        onSubmitted: (String v) => Navigator.of(context).pop(v.trim()),
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return HibikiDialogFrame(
+      maxWidth: 420,
+      scrollable: false,
+      child: HibikiModalSheetFrame(
+        title: t.game_scrape_title,
+        scrollable: true,
+        bodyPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          0,
+          tokens.spacing.card,
+          tokens.spacing.gap,
+        ),
+        footerPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          tokens.spacing.gap,
+          tokens.spacing.card,
+          tokens.spacing.card,
+        ),
+        body: HibikiTextField(
+          controller: _controller,
+          labelText: t.game_scrape_query,
+          autofocus: true,
+          onSubmitted: (String v) => Navigator.of(context).pop(v.trim()),
+        ),
+        footer: Wrap(
+          alignment: WrapAlignment.end,
+          spacing: tokens.spacing.gap,
+          runSpacing: tokens.spacing.gap,
+          children: <Widget>[
+            adaptiveDialogAction(
+              context: context,
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(t.dialog_cancel),
+            ),
+            adaptiveDialogAction(
+              context: context,
+              isDefaultAction: true,
+              onPressed: () =>
+                  Navigator.of(context).pop(_controller.text.trim()),
+              child: Text(t.dialog_ok),
+            ),
+          ],
+        ),
       ),
-      actions: <Widget>[
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(t.dialog_cancel),
-        ),
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(_controller.text.trim()),
-          child: Text(t.dialog_ok),
-        ),
-      ],
     );
   }
 }

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -277,7 +277,7 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
 
   /// 弹状态选择对话框（菜单顺序：想玩 → 在玩 → 玩过 → 搁置 → 弃坑 + 未设置）。
   Future<void> _promptPlayStatus(GalgameEntry game) async {
-    final GalgamePlayStatus? picked = await showDialog<GalgamePlayStatus>(
+    final GalgamePlayStatus? picked = await showAppDialog<GalgamePlayStatus>(
       context: context,
       builder: (BuildContext ctx) => SimpleDialog(
         title: Text(t.games_play_status),
@@ -399,7 +399,7 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   /// 在 `showDialog` 返回后立即 `controller.dispose()`，此时退出动画尚未结束、
   /// TextField 还挂在树上，属于过早释放。
   Future<String?> _promptName({required String initial}) {
-    return showDialog<String>(
+    return showAppDialog<String>(
       context: context,
       builder: (BuildContext ctx) => _RenameGameDialog(initial: initial),
     );
@@ -583,12 +583,14 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   }
 
   /// 筛选面板：状态 / 本地·在线 / 标签多选 / NSFW 隐藏。改动即时生效并持久化。
+  /// 走 [adaptiveModalSheet] + [HibikiModalSheetFrame]（与标签筛选面板同一 MD3
+  /// sheet 骨架），间距/文字全走 [HibikiDesignTokens]。
   Future<void> _showFilterSheet() async {
     final List<String> allTags = collectGalgameTags(_games);
-    await showModalBottomSheet<void>(
+    await adaptiveModalSheet<void>(
       context: context,
-      isScrollControlled: true,
       builder: (BuildContext ctx) {
+        final HibikiDesignTokens tokens = HibikiDesignTokens.of(ctx);
         return StatefulBuilder(
           builder: (BuildContext ctx, StateSetter setSheetState) {
             void apply(GalgameLibraryView next) {
@@ -596,112 +598,108 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
               _setView(next);
             }
 
-            return SafeArea(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    Row(
-                      children: <Widget>[
-                        Expanded(
-                          child: Text(
-                            t.games_filter,
-                            style: Theme.of(ctx).textTheme.titleMedium,
-                          ),
-                        ),
-                        TextButton(
-                          onPressed: () => apply(_view.clearFilters()),
-                          child: Text(t.games_filter_reset),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 8),
-                    Text(t.games_filter_status,
-                        style: Theme.of(ctx).textTheme.labelLarge),
-                    const SizedBox(height: 6),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: <Widget>[
-                        HibikiSelectableChip(
-                          label: t.games_filter_all,
-                          selected: _view.status == null,
-                          onSelected: (_) =>
-                              apply(_view.copyWith(clearStatus: true)),
-                        ),
-                        for (final GalgamePlayStatus status
-                            in <GalgamePlayStatus>[
-                          ...kGalgamePlayStatusMenuOrder,
-                          GalgamePlayStatus.unset,
-                        ])
-                          HibikiSelectableChip(
-                            label: galgamePlayStatusLabel(status),
-                            selected: _view.status == status,
-                            onSelected: (bool selected) => apply(
-                              selected
-                                  ? _view.copyWith(status: status)
-                                  : _view.copyWith(clearStatus: true),
-                            ),
-                          ),
-                      ],
-                    ),
-                    const SizedBox(height: 16),
-                    Text(t.games_filter_source,
-                        style: Theme.of(ctx).textTheme.labelLarge),
-                    const SizedBox(height: 6),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: <Widget>[
-                        for (final GalgameLocalFilter filter
-                            in GalgameLocalFilter.values)
-                          HibikiSelectableChip(
-                            label: galgameLocalFilterLabel(filter),
-                            selected: _view.localFilter == filter,
-                            onSelected: (_) =>
-                                apply(_view.copyWith(localFilter: filter)),
-                          ),
-                      ],
-                    ),
-                    if (allTags.isNotEmpty) ...<Widget>[
-                      const SizedBox(height: 16),
-                      Text(t.games_filter_tags,
-                          style: Theme.of(ctx).textTheme.labelLarge),
-                      const SizedBox(height: 6),
-                      Wrap(
-                        spacing: 8,
-                        runSpacing: 8,
-                        children: <Widget>[
-                          for (final String tag in allTags)
-                            HibikiSelectableChip(
-                              label: tag,
-                              selected: _view.tags.contains(tag),
-                              onSelected: (bool selected) {
-                                final Set<String> next =
-                                    Set<String>.of(_view.tags);
-                                if (selected) {
-                                  next.add(tag);
-                                } else {
-                                  next.remove(tag);
-                                }
-                                apply(_view.copyWith(tags: next));
-                              },
-                            ),
-                        ],
+            Widget sectionLabel(String text) => Padding(
+                  padding: EdgeInsets.only(
+                    top: tokens.spacing.gap * 2,
+                    bottom: tokens.spacing.gap,
+                  ),
+                  child: Text(text, style: tokens.type.sectionLabel),
+                );
+
+            return HibikiModalSheetFrame(
+              title: t.games_filter,
+              leadingIcon: Icons.filter_alt_outlined,
+              scrollable: true,
+              bodyPadding:
+                  EdgeInsets.symmetric(horizontal: tokens.spacing.page),
+              body: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  sectionLabel(t.games_filter_status),
+                  Wrap(
+                    spacing: tokens.spacing.gap,
+                    runSpacing: tokens.spacing.gap,
+                    children: <Widget>[
+                      HibikiSelectableChip(
+                        label: t.games_filter_all,
+                        selected: _view.status == null,
+                        onSelected: (_) =>
+                            apply(_view.copyWith(clearStatus: true)),
                       ),
+                      for (final GalgamePlayStatus status
+                          in <GalgamePlayStatus>[
+                        ...kGalgamePlayStatusMenuOrder,
+                        GalgamePlayStatus.unset,
+                      ])
+                        HibikiSelectableChip(
+                          label: galgamePlayStatusLabel(status),
+                          selected: _view.status == status,
+                          onSelected: (bool selected) => apply(
+                            selected
+                                ? _view.copyWith(status: status)
+                                : _view.copyWith(clearStatus: true),
+                          ),
+                        ),
                     ],
-                    const SizedBox(height: 8),
-                    SwitchListTile(
-                      contentPadding: EdgeInsets.zero,
-                      title: Text(t.games_filter_hide_nsfw),
-                      value: _view.hideNsfw,
-                      onChanged: (bool value) =>
-                          apply(_view.copyWith(hideNsfw: value)),
+                  ),
+                  sectionLabel(t.games_filter_source),
+                  Wrap(
+                    spacing: tokens.spacing.gap,
+                    runSpacing: tokens.spacing.gap,
+                    children: <Widget>[
+                      for (final GalgameLocalFilter filter
+                          in GalgameLocalFilter.values)
+                        HibikiSelectableChip(
+                          label: galgameLocalFilterLabel(filter),
+                          selected: _view.localFilter == filter,
+                          onSelected: (_) =>
+                              apply(_view.copyWith(localFilter: filter)),
+                        ),
+                    ],
+                  ),
+                  if (allTags.isNotEmpty) ...<Widget>[
+                    sectionLabel(t.games_filter_tags),
+                    Wrap(
+                      spacing: tokens.spacing.gap,
+                      runSpacing: tokens.spacing.gap,
+                      children: <Widget>[
+                        for (final String tag in allTags)
+                          HibikiSelectableChip(
+                            label: tag,
+                            selected: _view.tags.contains(tag),
+                            onSelected: (bool selected) {
+                              final Set<String> next =
+                                  Set<String>.of(_view.tags);
+                              if (selected) {
+                                next.add(tag);
+                              } else {
+                                next.remove(tag);
+                              }
+                              apply(_view.copyWith(tags: next));
+                            },
+                          ),
+                      ],
                     ),
                   ],
-                ),
+                  SizedBox(height: tokens.spacing.gap),
+                  AdaptiveSettingsSwitchRow(
+                    title: t.games_filter_hide_nsfw,
+                    value: _view.hideNsfw,
+                    onChanged: (bool value) =>
+                        apply(_view.copyWith(hideNsfw: value)),
+                  ),
+                  SizedBox(height: tokens.spacing.gap),
+                ],
+              ),
+              footer: Row(
+                children: <Widget>[
+                  const Spacer(),
+                  TextButton(
+                    onPressed: () => apply(_view.clearFilters()),
+                    child: Text(t.games_filter_reset),
+                  ),
+                ],
               ),
             );
           },
@@ -991,24 +989,51 @@ class _RenameGameDialogState extends State<_RenameGameDialog> {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      title: Text(t.games_rename),
-      content: TextField(
-        controller: _controller,
-        autofocus: true,
-        decoration: InputDecoration(labelText: t.games_rename_label),
-        onSubmitted: (String v) => Navigator.of(context).pop(v.trim()),
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return HibikiDialogFrame(
+      maxWidth: 420,
+      scrollable: false,
+      child: HibikiModalSheetFrame(
+        title: t.games_rename,
+        scrollable: true,
+        bodyPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          0,
+          tokens.spacing.card,
+          tokens.spacing.gap,
+        ),
+        footerPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          tokens.spacing.gap,
+          tokens.spacing.card,
+          tokens.spacing.card,
+        ),
+        body: HibikiTextField(
+          controller: _controller,
+          labelText: t.games_rename_label,
+          autofocus: true,
+          onSubmitted: (String v) => Navigator.of(context).pop(v.trim()),
+        ),
+        footer: Wrap(
+          alignment: WrapAlignment.end,
+          spacing: tokens.spacing.gap,
+          runSpacing: tokens.spacing.gap,
+          children: <Widget>[
+            adaptiveDialogAction(
+              context: context,
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(t.dialog_cancel),
+            ),
+            adaptiveDialogAction(
+              context: context,
+              isDefaultAction: true,
+              onPressed: () =>
+                  Navigator.of(context).pop(_controller.text.trim()),
+              child: Text(t.dialog_ok),
+            ),
+          ],
+        ),
       ),
-      actions: <Widget>[
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(t.dialog_cancel),
-        ),
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(_controller.text.trim()),
-          child: Text(t.dialog_ok),
-        ),
-      ],
     );
   }
 }

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -155,7 +155,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       HibikiToast.show(msg: t.game_no_tracks);
       return;
     }
-    final int? picked = await showDialog<int>(
+    final int? picked = await showAppDialog<int>(
       context: context,
       builder: (BuildContext dialogContext) => SimpleDialog(
         title: Text(t.game_line_track_dialog_title),
@@ -437,7 +437,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       ...windows
           .where((ExternalWindowInfo w) => gamePid == null || w.pid != gamePid),
     ];
-    final ExternalWindowInfo? picked = await showDialog<ExternalWindowInfo>(
+    final ExternalWindowInfo? picked = await showAppDialog<ExternalWindowInfo>(
       context: context,
       builder: (BuildContext ctx) => SimpleDialog(
         title: Text(t.external_window_select),

--- a/hibiki/test/mining/galgame_waveform_select_dialog_test.dart
+++ b/hibiki/test/mining/galgame_waveform_select_dialog_test.dart
@@ -1,0 +1,80 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/galgame_audio_encode.dart';
+import 'package:hibiki/src/mining/galgame_audio_source.dart';
+import 'package:hibiki/src/mining/galgame_waveform_select.dart';
+import 'package:hibiki/src/mining/galgame_waveform_select_dialog.dart';
+import 'package:hibiki/utils.dart';
+
+/// galgame 波形选区对话框 MD3 收口的 widget 行为守卫：
+/// 走共享对话框骨架（HibikiDialogFrame + HibikiModalSheetFrame）、肯定动作
+/// FilledButton 强调、文案走 i18n（t.game_waveform_select_title /
+/// t.dialog_ok / t.dialog_cancel），同时锁「确定」返回选区、「取消」返回 null
+/// 的既有契约不变。
+void main() {
+  // 1 秒 48kHz 16-bit 单声道：前 500ms 满幅方波、后 500ms 静音，让 VAD 有活干。
+  GalAudioSlice buildSlice() {
+    const int sampleRate = 48000;
+    const PcmFormat fmt = PcmFormat(
+      sampleRate: sampleRate,
+      channels: 1,
+      bitsPerSample: 16,
+      isFloat: false,
+    );
+    final Uint8List bytes = Uint8List(sampleRate * 2);
+    final ByteData bd = ByteData.sublistView(bytes);
+    for (int f = 0; f < sampleRate ~/ 2; f++) {
+      bd.setInt16(f * 2, f.isEven ? 32767 : -32767, Endian.little);
+    }
+    return GalAudioSlice(pcm: bytes, format: fmt);
+  }
+
+  Future<GalWaveformRange?>? dialogResult;
+
+  Future<void> openDialog(WidgetTester tester) async {
+    dialogResult = null;
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) => TextButton(
+            onPressed: () {
+              dialogResult =
+                  showGalWaveformSelectDialog(context, slice: buildSlice());
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('走共享 MD3 骨架：frame + i18n 标题 + FilledButton 肯定动作',
+      (WidgetTester tester) async {
+    await openDialog(tester);
+    expect(find.byType(HibikiDialogFrame), findsOneWidget);
+    expect(find.byType(HibikiModalSheetFrame), findsOneWidget);
+    expect(find.text(t.game_waveform_select_title), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, t.dialog_ok), findsOneWidget);
+    expect(find.widgetWithText(TextButton, t.dialog_cancel), findsOneWidget);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('确定返回选区、取消返回 null（既有契约不变）', (WidgetTester tester) async {
+    await openDialog(tester);
+    await tester.tap(find.text(t.dialog_ok));
+    await tester.pumpAndSettle();
+    final GalWaveformRange? confirmed = await dialogResult!;
+    expect(confirmed, isNotNull);
+    expect(confirmed!.durationMs, greaterThan(0));
+
+    await openDialog(tester);
+    await tester.tap(find.text(t.dialog_cancel));
+    await tester.pumpAndSettle();
+    expect(await dialogResult!, isNull);
+  });
+}

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -258,6 +258,47 @@ void main() {
       'HibikiDialogFrame(',
       'PopupDictionaryPage(',
     ],
+    // galgame 弹窗 MD3 收口：统一走 showAppDialog 入口（MD3 弹窗动画 + Cupertino
+    // 分支）+ 共享对话框骨架（HibikiDialogFrame + HibikiModalSheetFrame）+
+    // adaptiveDialogAction（肯定动作 FilledButton 强调），与同子系统
+    // galgame_helper_installer 的确认/进度框同一套样板；波形选区框文案改走 i18n，
+    // 游戏库筛选面板改走 adaptiveModalSheet + HibikiModalSheetFrame。
+    'lib/src/mining/galgame_waveform_select_dialog.dart': <String>[
+      'showAppDialog<GalWaveformRange>(',
+      'HibikiDialogFrame',
+      'HibikiModalSheetFrame',
+      'adaptiveDialogAction',
+      't.game_waveform_select_title',
+      't.game_waveform_range_label',
+    ],
+    'lib/src/mining/magpie_download_confirm.dart': <String>[
+      'showAppDialog<bool>(',
+      'HibikiDialogFrame',
+      'HibikiModalSheetFrame',
+      'adaptiveDialogAction',
+    ],
+    'lib/src/pages/implementations/galgame_detail_page.dart': <String>[
+      'showAppDialog<String>(',
+      'showAppDialog<SourceCandidate>(',
+      'HibikiDialogFrame',
+      'HibikiModalSheetFrame',
+      'HibikiTextField',
+      'adaptiveDialogAction',
+    ],
+    'lib/src/pages/implementations/games_library_page.dart': <String>[
+      'showAppDialog<GalgamePlayStatus>(',
+      'showAppDialog<String>(',
+      'adaptiveModalSheet<void>(',
+      'HibikiDialogFrame',
+      'HibikiModalSheetFrame',
+      'HibikiTextField',
+      'adaptiveDialogAction',
+      'AdaptiveSettingsSwitchRow',
+    ],
+    'lib/src/pages/implementations/texthooker_page.dart': <String>[
+      'showAppDialog<int>(',
+      'showAppDialog<ExternalWindowInfo>(',
+    ],
   };
 
   test('MD3 design token and shared component files exist', () {
@@ -548,6 +589,30 @@ void main() {
       'lib/src/models/app_model.dart': <String>[
         '=> Dialog(',
         'child: ConstrainedBox(',
+      ],
+      // galgame 弹窗 MD3 收口的反向锁：不再裸 showDialog / AlertDialog /
+      // 手搓 showModalBottomSheet；波形选区框不再硬编码中文文案。
+      'lib/src/mining/galgame_waveform_select_dialog.dart': <String>[
+        'showDialog<',
+        'AlertDialog(',
+        '选择音频范围',
+      ],
+      'lib/src/mining/magpie_download_confirm.dart': <String>[
+        'showDialog<',
+        'AlertDialog(',
+      ],
+      'lib/src/pages/implementations/galgame_detail_page.dart': <String>[
+        'showDialog<',
+        'AlertDialog(',
+      ],
+      'lib/src/pages/implementations/games_library_page.dart': <String>[
+        'showDialog<',
+        'AlertDialog(',
+        'showModalBottomSheet<',
+        'SwitchListTile(',
+      ],
+      'lib/src/pages/implementations/texthooker_page.dart': <String>[
+        'showDialog<',
       ],
     };
 


### PR DESCRIPTION
## 概要

把 galgame 子系统里绕过统一封装的 8 处弹窗全部收口到项目自有的 MD3 设计系统（样板即同子系统的 `galgame_helper_installer.dart` 确认/进度框），不改任何业务逻辑与返回契约。

## 改动

**四个裸 `AlertDialog` → 共享对话框骨架**（`HibikiDialogFrame` + `HibikiModalSheetFrame` + `adaptiveDialogAction`，肯定动作 `FilledButton` 强调，输入框 `HibikiTextField`）：

| 弹窗 | 文件 |
|---|---|
| 波形选区 | `lib/src/mining/galgame_waveform_select_dialog.dart` |
| Magpie 超分下载确认 | `lib/src/mining/magpie_download_confirm.dart`（保留 BUG-1076 立即弹框时序契约与 barrierDismissible: false） |
| 刮削关键词输入 | `lib/src/pages/implementations/galgame_detail_page.dart` |
| 游戏重命名 | `lib/src/pages/implementations/games_library_page.dart` |

**四个选择类弹窗入口 `showDialog` → `showAppDialog`**（补 MD3 弹窗动画 + Cupertino 分支；`SimpleDialog` 本体保留，与 `media_sources_dialog.dart` 同口径）：刮削多结果选择、游玩状态选择（games_library）、选轨、外部窗口选择（texthooker，`_pickExternalWindow` 方法体守卫 token 全部保留）。

**游戏库筛选面板**：手搓 `showModalBottomSheet` → `adaptiveModalSheet` + `HibikiModalSheetFrame`（与 `tag_filter_sheet.dart` 同一骨架），硬编码 padding/字体全部换 `HibikiDesignTokens`，`SwitchListTile` → 共享 `AdaptiveSettingsSwitchRow`；重置动作移入 footer。

**i18n**：波形选区框的硬编码中文（『选择音频范围』/『取消』/『确定』/范围文案）改走 i18n——取消/确定复用 `dialog_cancel` / `dialog_ok`，新增 `game_waveform_select_title` / `game_waveform_range_label`（经 `tool/i18n_sync.dart` 同步 17 语言，`dart run slang` 重新生成）。

**守卫**：
- `test/settings/md3_design_system_static_test.dart`：五个文件加 `migratedSurfaces` 迁移锚点（`showAppDialog<...>` 精确泛型形态 + 骨架组件），并加 `bannedByFile` 反向锁（不再裸 `showDialog<` / `AlertDialog(` / `showModalBottomSheet<` / `SwitchListTile(` / 硬编码『选择音频范围』）。
- 新增 `test/mining/galgame_waveform_select_dialog_test.dart` widget 行为测试：锁共享骨架 + i18n 标题 + `FilledButton` 肯定动作，以及「确定返回选区 / 取消返回 null」的既有契约。

## 验证

- `dart format` 全部改动文件。
- `flutter analyze --no-pub`（3.41.6）：本次改动 0 issue；仅剩 `home_video_page.dart:684/687` 两个 `use_build_context_synchronously` warning，该文件与 develop 逐字节一致，属 3.41.6 分析器对既有代码的报告，与本 PR 无关。
- 定向测试全绿：`test/mining/` 全目录 + `games_library_filter_sort` / `games_library_cover_menu` / `games_collection_detail` / `game_module_focus` / `home_game_page` / `galgame_detail_page` / `texthooker_page` / `texthooker_window_picker_guard` / `md3_design_system_static` / `i18n_completeness`（851 passed / 3 pre-existing skips）。

## 备注

- 未动 `pubspec.yaml` 版本号：按 `docs/agent/build.md` 惯例（`chore(release): bump build to +NNN for PR#NNN landing`），`+build` 由 landing 时统一 +1。
- gal hook 原生浮窗（`gal_hook_text_overlay_controller.dart`）是 Win32 原生窗口，不在 Flutter MD3 改造范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
