### PR TITLE
refactor(extension): 移植 asbplayer 核心功能 + 导入/自更新链路易懂化

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,4 +1,4 @@
 # tools/browser-extension is the source of truth. These app assets are
 # byte-for-byte mirrors maintained by scripts/sync-mirrors.mjs, so counting both
 # sides as independent copy-paste blocks makes every extension change duplicate.
-sonar.cpd.exclusions=hibiki/assets/browser_extension/content.js,hibiki/assets/browser_extension/options.js,hibiki/assets/browser_extension/self-update.js,hibiki/assets/browser_extension/stream-bridge.js,hibiki/assets/browser_extension/subtitle-adapters.js,hibiki/assets/browser_extension/subtitle-panel.js,hibiki/assets/browser_extension/video-shortcuts.js
+sonar.cpd.exclusions=hibiki/assets/browser_extension/content.js,hibiki/assets/browser_extension/options.html,hibiki/assets/browser_extension/options.js,hibiki/assets/browser_extension/self-update.js,hibiki/assets/browser_extension/stream-bridge.js,hibiki/assets/browser_extension/subtitle-adapters.js,hibiki/assets/browser_extension/subtitle-panel.js,hibiki/assets/browser_extension/video-shortcuts.js

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,4 @@
+# tools/browser-extension is the source of truth. These app assets are
+# byte-for-byte mirrors maintained by scripts/sync-mirrors.mjs, so counting both
+# sides as independent copy-paste blocks makes every extension change duplicate.
+sonar.cpd.exclusions=hibiki/assets/browser_extension/content.js,hibiki/assets/browser_extension/options.js,hibiki/assets/browser_extension/self-update.js,hibiki/assets/browser_extension/stream-bridge.js,hibiki/assets/browser_extension/subtitle-adapters.js,hibiki/assets/browser_extension/subtitle-panel.js,hibiki/assets/browser_extension/video-shortcuts.js

--- a/hibiki/assets/browser_extension/THIRD_PARTY_LICENSES.md
+++ b/hibiki/assets/browser_extension/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,32 @@
+# Third-party licenses
+
+## asbplayer
+
+Portions of `stream-bridge.js` and the associated streaming-site adapters are
+derived from asbplayer:
+
+- Source: https://github.com/asbplayer/asbplayer
+- Upstream files: `extension/src/entrypoints/*-page.ts`
+- License: MIT
+
+MIT License
+
+Copyright (c) 2020-2026 asbplayer authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/hibiki/assets/browser_extension/content.js
+++ b/hibiki/assets/browser_extension/content.js
@@ -219,6 +219,31 @@ window.addEventListener('message', (e) => {
 // 面板只剩预取的下一集轨（列表空）。接收端就位后立刻请求 bridge 重放已存档的 cue 消息，消除时序运气。
 try { window.postMessage({ __hibikiNf: 'replayCues' }, '/'); } catch (_) {}
 
+// ── asb 移植：通用流媒体字幕桥（stream-bridge.js，MAIN 世界）→ store ──
+// TVer / Bilibili.tv / Hulu JP / Prime Video 的主世界桥抓到整集字幕原文后经
+// {__hibikiStream:'cues'} 送到这里，按 format 分派解析器写进 hibikiEpisodeCues。
+// 轨 key 用桥捕获时的 host+path（与 hibikiVideoKey 的通用回落同构）——SPA 换集后
+// 消息晚到也落在正确的视频 key 下。存档/重放握手与 netflix-bridge 相同。
+function hibikiOnStreamCues(msg) {
+  try {
+    let cues;
+    if (msg.format === 'ttml') cues = parseTtml(msg.text);
+    else if (msg.format === 'bbjson') cues = parseBilibiliJson(msg.text);
+    else cues = parseWebVtt(msg.text); // webvtt / srt（parseWebVtt 兼容 SRT 块）
+    if (!cues || !cues.length) return;
+    const vidKey = (location.hostname + (msg.path || location.pathname)).replace(/\|/g, '_');
+    const lang = String(msg.lang || 'und').replace(/\|/g, '_');
+    const key = vidKey + '|' + lang;
+    hibikiEpisodeCues[key] = cues;
+    hibikiNotifyPanel(key);
+  } catch (_) {}
+}
+window.addEventListener('message', (e) => {
+  if (e.source !== window || !e.data || e.data.__hibikiStream !== 'cues') return;
+  hibikiOnStreamCues(e.data);
+});
+try { window.postMessage({ __hibikiStream: 'replayCues' }, '/'); } catch (_) {}
+
 // ── TODO-1363：通用字幕轨 provider（所有站点） ──
 // 数据契约不变：window.hibikiEpisodeCues[`${videoKey}|${lang}`] = [{startMs,endMs,text}]，新数据到达
 // 即调 window.hibikiSubtitlePanelOnCues(key)。Netflix 整集拦截之外新增两条通用通道，站点差异全部

--- a/hibiki/assets/browser_extension/manifest.json
+++ b/hibiki/assets/browser_extension/manifest.json
@@ -9,12 +9,30 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["bridge-shim.js", "subtitle-adapters.js", "vendor/dict-media.js", "vendor/selection.js", "vendor/popup.js", "scan.js", "content.js", "subtitle-panel.js"],
+      "js": ["bridge-shim.js", "subtitle-adapters.js", "vendor/dict-media.js", "vendor/selection.js", "vendor/popup.js", "scan.js", "content.js", "subtitle-panel.js", "video-shortcuts.js"],
       "css": ["vendor/content.css"]
     },
     {
       "matches": ["*://*.netflix.com/*"],
       "js": ["netflix-bridge.js"],
+      "world": "MAIN",
+      "run_at": "document_start"
+    },
+    {
+      "matches": [
+        "*://*.tver.jp/*",
+        "*://*.bilibili.tv/*",
+        "*://www.hulu.jp/*",
+        "*://*.primevideo.com/*",
+        "*://*.amazon.com/*",
+        "*://*.amazon.co.jp/*",
+        "*://*.amazon.co.uk/*",
+        "*://*.amazon.de/*",
+        "*://*.amazon.fr/*",
+        "*://*.amazon.it/*",
+        "*://*.amazon.es/*"
+      ],
+      "js": ["stream-bridge.js"],
       "world": "MAIN",
       "run_at": "document_start"
     }

--- a/hibiki/assets/browser_extension/options.html
+++ b/hibiki/assets/browser_extension/options.html
@@ -48,6 +48,27 @@
               </span>
               <span class="switch"><input id="subtitleAutoScroll" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
+            <label class="setting-row" for="subtitleOverlayAllTracks">
+              <span class="setting-copy">
+                <strong>所有字幕轨都用扩展覆盖层显示</strong>
+                <small>站点检测到的字幕轨也叠到视频上，配合防剧透模糊与悬停暂停使用。</small>
+              </span>
+              <span class="switch"><input id="subtitleOverlayAllTracks" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="subtitleOverlayBlur">
+              <span class="setting-copy">
+                <strong>防剧透模糊</strong>
+                <small>覆盖层字幕默认模糊，鼠标悬停即清晰——先听再看。</small>
+              </span>
+              <span class="switch"><input id="subtitleOverlayBlur" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="subtitleHoverPause">
+              <span class="setting-copy">
+                <strong>悬停字幕时暂停</strong>
+                <small>鼠标移到覆盖层字幕上自动暂停，移开继续播放，方便查词。</small>
+              </span>
+              <span class="switch"><input id="subtitleHoverPause" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
           </div>
         </section>
 
@@ -73,6 +94,27 @@
               </span>
               <span class="switch"><input id="subtitleCondensedPlayback" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
+            <label class="setting-row" for="subtitleAutoPauseAtStart">
+              <span class="setting-copy">
+                <strong>自动暂停改在句首</strong>
+                <small>开启「自动暂停」时改为每句开播即暂停（先猜再听），默认是句尾暂停。</small>
+              </span>
+              <span class="switch"><input id="subtitleAutoPauseAtStart" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="subtitleFastForwardPlayback">
+              <span class="setting-copy">
+                <strong>快进无字幕段</strong>
+                <small>无字幕区间以 2.7 倍速播过（保留画面连续性），进句自动恢复原速。</small>
+              </span>
+              <span class="switch"><input id="subtitleFastForwardPlayback" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutsEnabled">
+              <span class="setting-copy">
+                <strong>视频页快捷键</strong>
+                <small>←/→ 上一句/下一句 · ↑ 重播本句 · Shift+P/O/F 暂停/精简/快进 · Shift+S 面板 · Ctrl+Shift+←/→/↓ 偏移 · Ctrl+Shift+Z 复制字幕 · Ctrl+Shift+[ ] 变速。</small>
+              </span>
+              <span class="switch"><input id="videoShortcutsEnabled" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
           </div>
         </section>
 
@@ -80,17 +122,23 @@
           <div class="section-heading compact">
             <div>
               <p class="section-kicker">站点适配</p>
-              <h2 id="site-heading">Netflix</h2>
+              <h2 id="site-heading">流媒体站点</h2>
             </div>
           </div>
           <div class="setting-list">
             <label class="setting-row" for="nfHideNext">
               <span class="setting-copy">
-                <strong>隐藏“下一集”和分级遮挡</strong>
+                <strong>Netflix：隐藏“下一集”和分级遮挡</strong>
                 <small>避免剧末按钮、后播层和开场分级标识进入制卡截图。</small>
               </span>
               <span class="switch"><input id="nfHideNext" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
+            <div class="setting-row">
+              <span class="setting-copy">
+                <strong>整集字幕自动检测</strong>
+                <small>Netflix、YouTube、TVer、Bilibili.tv、Hulu（日本）、Prime Video 播放时自动抓取整集字幕进字幕列表；其它站点走通用采集（原生字幕轨收割 + 实时采样）。</small>
+              </span>
+            </div>
           </div>
         </section>
       </main>
@@ -136,6 +184,12 @@
           </form>
         </details>
 
+        <div class="tip" id="updateCard">
+          <strong id="updTitle">版本与更新</strong>
+          <p id="updDetail">正在读取扩展版本信息…</p>
+          <code id="updBuild"></code>
+        </div>
+
         <div class="tip">
           <strong>加载自己的字幕</strong>
           <p>开启字幕列表后，点侧栏中的“＋”，或直接把字幕文件拖到视频上。</p>
@@ -147,6 +201,7 @@
   <div class="save-toast" id="status" role="status" aria-live="polite"></div>
   <script src="hibiki-defaults.js"></script>
   <script src="connection-diagnostics.js"></script>
+  <script src="self-update.js"></script>
   <script src="options.js"></script>
 </body>
 </html>

--- a/hibiki/assets/browser_extension/options.js
+++ b/hibiki/assets/browser_extension/options.js
@@ -9,6 +9,13 @@ const subtitleDefaults = Object.freeze({
   subtitleAutoPause: false,
   subtitleCondensedPlayback: false,
   netflixHideNextEpisode: true,
+  // asb 移植（默认关，快捷键默认开）。
+  subtitleAutoPauseAtStart: false,
+  subtitleFastForwardPlayback: false,
+  subtitleHoverPause: false,
+  subtitleOverlayBlur: false,
+  subtitleOverlayAllTracks: false,
+  videoShortcutsEnabled: true,
 });
 const toggleIds = Object.freeze({
   nfSubList: 'netflixSubtitlePanel',
@@ -18,6 +25,12 @@ const toggleIds = Object.freeze({
   subtitleAutoPause: 'subtitleAutoPause',
   subtitleCondensedPlayback: 'subtitleCondensedPlayback',
   nfHideNext: 'netflixHideNextEpisode',
+  subtitleAutoPauseAtStart: 'subtitleAutoPauseAtStart',
+  subtitleFastForwardPlayback: 'subtitleFastForwardPlayback',
+  subtitleHoverPause: 'subtitleHoverPause',
+  subtitleOverlayBlur: 'subtitleOverlayBlur',
+  subtitleOverlayAllTracks: 'subtitleOverlayAllTracks',
+  videoShortcutsEnabled: 'videoShortcutsEnabled',
 });
 
 let toastTimer = null;
@@ -130,6 +143,23 @@ $('showToken').addEventListener('click', () => {
 
 $('check').addEventListener('click', () => refreshConnection(true));
 
+// 「版本与更新」卡片：把自更新链路状态翻成人话（self-update.js describeUpdateState），
+// 让「扩展怎么更新、现在是不是最新」在设置页一眼可见，不再只有失效时的角标。
+async function refreshUpdateCard() {
+  const titleEl = $('updTitle');
+  const detailEl = $('updDetail');
+  const buildEl = $('updBuild');
+  if (!titleEl || !self.HIBIKI_SELF_UPDATE) return;
+  let stale = null;
+  try {
+    stale = (await chrome.storage.local.get('hibikiUpdateStale')).hibikiUpdateStale || null;
+  } catch (_) { /* storage 不可用：按无 stale 渲染 */ }
+  const s = self.HIBIKI_SELF_UPDATE.describeUpdateState(self.HIBIKI_DEFAULTS, stale);
+  titleEl.textContent = '版本与更新 · ' + s.title;
+  if (detailEl) detailEl.textContent = s.detail;
+  if (buildEl) buildEl.textContent = s.build ? 'build ' + s.build : '';
+}
+
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area !== 'local') return;
   for (const [id, key] of Object.entries(toggleIds)) {
@@ -137,8 +167,10 @@ chrome.storage.onChanged.addListener((changes, area) => {
     const input = $(id);
     if (input) input.checked = changes[key].newValue === true;
   }
+  if (changes.hibikiUpdateStale) refreshUpdateCard();
 });
 
 // BUG-1036：选项页每次打开都应报告当前真状态，不能复用 background 最多 5 秒的离线缓存；
 // 手动“重新检测”本来就是 force=true，首次自动检测保持同一语义。
 loadSettings().then(() => refreshConnection(true));
+refreshUpdateCard();

--- a/hibiki/assets/browser_extension/self-update.js
+++ b/hibiki/assets/browser_extension/self-update.js
@@ -45,5 +45,42 @@
     return JSON.stringify(body);
   }
 
-  return { actions: actions, decide: decide, statusRequestBody: statusRequestBody };
+  // options 页「版本与更新」卡片：把自更新链路的状态翻成用户可读文案（纯函数，node 可测）。
+  // 三态：stale（自动更新失效，需手动重载）/ dev（无内容指纹的开发副本，不参与自动更新）/
+  // ok（正常：Hibiki 升级 → 磁盘副本刷新 → 扩展自动 reload）。
+  function describeUpdateState(defaults, stale) {
+    var build = (defaults && typeof defaults.build === 'string' && defaults.build)
+        ? defaults.build : '';
+    var short = function (s) { return String(s || '').slice(0, 8); };
+    if (stale && stale.remote) {
+      return {
+        tone: 'warn',
+        title: '自动更新未生效',
+        detail: 'Hibiki 已内置新版扩展（' + short(stale.remote) + '），请到 chrome://extensions '
+            + '找到本扩展点「重新加载」。当前加载：' + (short(stale.local) || '未知') + '。',
+        build: build,
+      };
+    }
+    if (!build) {
+      return {
+        tone: 'neutral',
+        title: '开发副本（不参与自动更新）',
+        detail: '此副本没有内容指纹（未经 Hibiki 安装助手解压），不会自动跟随 Hibiki 更新。',
+        build: '',
+      };
+    }
+    return {
+      tone: 'ok',
+      title: '随 Hibiki 自动更新',
+      detail: 'Hibiki 升级后会刷新磁盘副本，扩展在下次心跳/查词时自动重载到最新版。',
+      build: build,
+    };
+  }
+
+  return {
+    actions: actions,
+    decide: decide,
+    statusRequestBody: statusRequestBody,
+    describeUpdateState: describeUpdateState,
+  };
 });

--- a/hibiki/assets/browser_extension/stream-bridge.js
+++ b/hibiki/assets/browser_extension/stream-bridge.js
@@ -157,12 +157,10 @@
   function fetchTrack(track) {
     if (!track || !track.url || seenUrls[track.url]) return;
     seenUrls[track.url] = 1;
-    try {
-      fetch(track.url, { credentials: 'include' })
-        .then(function (r) { return r.text(); })
-        .then(function (text) { if (text) postCues(track.label, track.format, text); })
-        .catch(function () {});
-    } catch (_) {}
+    fetch(track.url, { credentials: 'include' })
+      .then(function (r) { return r.text(); })
+      .then(function (text) { if (text) postCues(track.label, track.format, text); })
+      .catch(function () {});
   }
   function fetchTracks(tracks) {
     if (!tracks) return;
@@ -229,17 +227,15 @@
       var slot = captured[titleId];
       if (!slot || !slot.url || !slot.body || slot.done) return;
       slot.done = true;
-      try {
-        fetch(slot.url, {
-          method: 'POST',
-          body: slot.body,
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-        })
-          .then(function (r) { return r.json(); })
-          .then(function (json) { fetchTracks(A.amazonTracks(json)); })
-          .catch(function () {});
-      } catch (_) {}
+      fetch(slot.url, {
+        method: 'POST',
+        body: slot.body,
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+      })
+        .then(function (r) { return r.json(); })
+        .then(function (json) { fetchTracks(A.amazonTracks(json)); })
+        .catch(function () {});
     }
     var origOpen = window.XMLHttpRequest.prototype.open;
     window.XMLHttpRequest.prototype.open = function () {

--- a/hibiki/assets/browser_extension/stream-bridge.js
+++ b/hibiki/assets/browser_extension/stream-bridge.js
@@ -1,0 +1,287 @@
+// asb 移植：通用流媒体字幕桥（manifest 里 world:MAIN、document_start 注入，站点见 manifest
+// matches）。做的事与 netflix-bridge.js 同构——在页面主世界拦截站点自己的网络层，拿到字幕轨
+// URL 后用页面身份（cookie）抓字幕原文，postMessage 送隔离世界 content.js 解析进
+// window.hibikiEpisodeCues（`${host+path}|${label}` 轨）。字幕面板 / 覆盖层 / 查词 / 快捷键
+// 零站点特例地消费这些轨。
+//
+// 四类手法全部来自 asbplayer（extension/src/entrypoints/*-page.ts，MIT）：
+//   · TVer / Bilibili.tv —— JSON.parse 纯透传 hook，从站点自己的播放数据里嗅探字幕轨；
+//   · Hulu JP —— XMLHttpRequest load 旁路读响应（播放元数据带 tracks）；
+//   · Prime Video —— 捕获 GetVodPlaybackResources 请求（URL+body），原样重放一次拿
+//     timedTextUrls（TTML）。
+// 红线与 netflix-bridge 相同：所有 hook 纯透传、异常绝不外泄、绝不影响站点自身播放。
+//
+// 时序竞态同 netflix-bridge：本脚本 document_start 抓字幕，content.js document_idle 才注册
+// 接收端 → 抓到的 payload 一律存档，content.js 就绪后发 {__hibikiStream:'replayCues'} 整批重放。
+//
+// 验证状态（诚实标注）：Netflix/YouTube 走既有已验证路径；本文件四站点为 implemented_unverified
+// ——提取逻辑逐行对照 asbplayer 已上线代码移植、纯函数部分有 node 单测，但本仓库开发环境无
+// 各站点账号，未做真站点端到端验证。
+(function (root, factory) {
+  var api = factory();
+  try { if (typeof module !== 'undefined' && module.exports) module.exports = api; } catch (_) { /* 页面自带 module 时忽略 */ }
+  if (root) root.HIBIKI_STREAM_ADAPTERS = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // ── 纯函数 track 提取器（node 可测）──
+  // 统一输出 [{ label, url, format }]；format ∈ webvtt|srt|ttml|bbjson（content.js 按此分派解析器）。
+
+  function urlParam(url, name) {
+    try { return new URL(url, 'https://invalid.example').searchParams.get(name); } catch (_) { return null; }
+  }
+
+  // TVer（asb tver-page.ts）：播放数据 JSON 的 tracks[] 里 kind==='captions' 且 type text/vtt。
+  function tverTracks(value) {
+    var out = [];
+    var tracks = value && Array.isArray(value.tracks) ? value.tracks : null;
+    if (!tracks) return out;
+    for (var i = 0; i < tracks.length; i++) {
+      var t = tracks[i];
+      if (!t || t.kind !== 'captions') continue;
+      if (t.type !== 'text/vtt' && t.type !== 'text/webvtt') continue;
+      if (typeof t.src !== 'string' || !t.src || typeof t.srclang !== 'string') continue;
+      var label = (typeof t.label === 'string' && t.label) ? (t.srclang + ' - ' + t.label) : t.srclang;
+      out.push({ label: label, url: t.src.replace(/^http:\/\//, 'https://'), format: 'webvtt' });
+    }
+    return out;
+  }
+
+  // Bilibili.tv（asb bilibili-page.ts）：data.subtitles[]，url 以 .json 结尾是 bbjson，否则 srt。
+  function bilibiliTracks(value) {
+    var out = [];
+    var subs = value && value.data && Array.isArray(value.data.subtitles) ? value.data.subtitles : null;
+    if (!subs) return out;
+    for (var i = 0; i < subs.length; i++) {
+      var t = subs[i];
+      if (!t || typeof t.lang !== 'string' || !t.lang) continue;
+      var url = (t.srt && typeof t.srt === 'object' && typeof t.srt.url === 'string') ? t.srt.url
+          : (typeof t.url === 'string' ? t.url : '');
+      if (!url) continue;
+      var format = /\.json([?#]|$)/i.test(url) ? 'bbjson' : 'srt';
+      out.push({ label: t.lang, url: url, format: format });
+    }
+    return out;
+  }
+
+  // Hulu JP（asb hulu-jp-page.ts）：播放元数据 {ref_id, tracks[]}，kind==='subtitles'。
+  function huluJpTracks(value) {
+    if (!value || typeof value.ref_id !== 'string' || !Array.isArray(value.tracks)) return null;
+    var out = [];
+    for (var i = 0; i < value.tracks.length; i++) {
+      var t = value.tracks[i];
+      if (!t || t.kind !== 'subtitles') continue;
+      if (typeof t.src !== 'string' || !t.src || typeof t.srclang !== 'string') continue;
+      out.push({ label: String(t.label || t.srclang), url: t.src, format: 'webvtt' });
+    }
+    return out.length ? { videoId: value.ref_id, tracks: out } : null;
+  }
+
+  // Prime Video（asb amazon-prime-page.ts）：识别 GetVodPlaybackResources 请求（titleId 在
+  // query）；捕齐 URL+body 后重放一次，从响应 timedTextUrls.result.subtitleUrls[] 取轨。
+  function amazonCapture(url) {
+    if (typeof url !== 'string' || url.indexOf('GetVodPlaybackResources') < 0) return null;
+    var titleId = urlParam(url, 'titleId');
+    return titleId ? { kind: 'vod', titleId: titleId } : null;
+  }
+  function amazonTracks(json) {
+    var out = [];
+    var urls = json && json.timedTextUrls && json.timedTextUrls.result &&
+        json.timedTextUrls.result.subtitleUrls;
+    if (!Array.isArray(urls)) return out;
+    for (var i = 0; i < urls.length; i++) {
+      var t = urls[i];
+      if (!t || typeof t.url !== 'string' || !t.url) continue;
+      out.push({
+        label: String(t.displayName || t.languageCode || 'und'),
+        url: t.url,
+        format: 'ttml',
+      });
+    }
+    return out;
+  }
+
+  function siteForHost(host) {
+    var h = String(host || '');
+    if (/(^|\.)tver\.jp$/.test(h)) return 'tver';
+    if (/(^|\.)bilibili\.tv$/.test(h)) return 'bilibili';
+    if (/^www\.hulu\.jp$/.test(h)) return 'hulu-jp';
+    if (/(^|\.)primevideo\.com$/.test(h)) return 'prime';
+    if (/(^|\.)amazon\.(com|co\.jp|co\.uk|de|fr|it|es)$/.test(h)) return 'prime';
+    return null;
+  }
+
+  return {
+    tverTracks: tverTracks,
+    bilibiliTracks: bilibiliTracks,
+    huluJpTracks: huluJpTracks,
+    amazonCapture: amazonCapture,
+    amazonTracks: amazonTracks,
+    siteForHost: siteForHost,
+    urlParam: urlParam,
+  };
+});
+
+// ── 浏览器运行时（node 单测里 window/document 缺省 → 整段跳过）──
+(function () {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (window.__hibikiStreamBridge) return; // 防重复注入
+  window.__hibikiStreamBridge = true;
+  var A = (typeof self !== 'undefined' ? self : window).HIBIKI_STREAM_ADAPTERS;
+  var site = A.siteForHost(location.hostname);
+  if (!site) return;
+
+  // BUG-769 同款：跨世界自投消息用 targetOrigin '/'，接收端比对 window.origin。
+  var ORIGIN = window.origin;
+  var seenUrls = Object.create(null); // 字幕 URL 去重，同一轨只抓一次
+  var archive = [];
+  var ARCHIVE_MAX = 120;
+
+  function post(payload) {
+    try { window.postMessage(payload, '/'); } catch (_) {}
+  }
+  function postCues(label, format, text) {
+    var payload = {
+      __hibikiStream: 'cues',
+      path: location.pathname,
+      lang: label,
+      format: format,
+      text: text,
+    };
+    archive.push(payload);
+    if (archive.length > ARCHIVE_MAX) archive.shift();
+    post(payload);
+  }
+  // 拿到轨 URL → 页面身份抓字幕原文 → 送隔离世界。best-effort，失败静默（不影响站点播放）。
+  function fetchTrack(track) {
+    if (!track || !track.url || seenUrls[track.url]) return;
+    seenUrls[track.url] = 1;
+    try {
+      fetch(track.url, { credentials: 'include' })
+        .then(function (r) { return r.text(); })
+        .then(function (text) { if (text) postCues(track.label, track.format, text); })
+        .catch(function () {});
+    } catch (_) {}
+  }
+  function fetchTracks(tracks) {
+    if (!tracks) return;
+    for (var i = 0; i < tracks.length; i++) fetchTrack(tracks[i]);
+  }
+
+  window.addEventListener('message', function (e) {
+    if (e.origin !== ORIGIN || e.source !== window || !e.data) return;
+    if (e.data.__hibikiStream === 'replayCues') {
+      // content.js（隔离世界）接收端就绪：重放全部已存档 cue，消除注入时序竞态。
+      for (var i = 0; i < archive.length; i++) post(archive[i]);
+    }
+  });
+
+  // JSON.parse 纯透传 hook（TVer / Bilibili）：先原样返回站点自己的解析结果，再旁路嗅探。
+  function installJsonHook(extract) {
+    var orig = JSON.parse;
+    JSON.parse = function () {
+      var r = orig.apply(this, arguments);
+      try { fetchTracks(extract(r)); } catch (_) {}
+      return r;
+    };
+  }
+
+  // Hulu JP：XHR load 旁路读响应（站点用 XHR 拉播放元数据）。
+  function installHuluJpHook() {
+    var origSend = window.XMLHttpRequest.prototype.send;
+    window.XMLHttpRequest.prototype.send = function () {
+      try {
+        this.addEventListener('load', function () {
+          try {
+            var body = this.response;
+            if (typeof body === 'string') {
+              try { body = JSON.parse(body); } catch (_) { body = null; }
+            }
+            var got = A.huluJpTracks(body);
+            if (got) fetchTracks(got.tracks);
+          } catch (_) {}
+        });
+      } catch (_) {}
+      return origSend.apply(this, arguments);
+    };
+  }
+
+  // Prime Video：XHR + fetch 双通道捕获 GetVodPlaybackResources 的 URL 与请求体，捕齐后
+  // 原样重放一次（POST，同凭据）→ 响应里的 timedTextUrls 即字幕轨。同一 titleId 只重放一次；
+  // 切集产生新 titleId 自然重来。重放的是站点自己刚发过的只读请求，无副作用。
+  function installAmazonHook() {
+    var captured = Object.create(null); // titleId -> { url, body, done }
+    function noteUrl(url) {
+      var c = A.amazonCapture(url);
+      if (!c) return null;
+      var slot = captured[c.titleId] || (captured[c.titleId] = {});
+      slot.url = url;
+      return c;
+    }
+    function noteBody(titleId, body) {
+      var slot = captured[titleId];
+      if (!slot || !body) return;
+      slot.body = body;
+      maybeReplay(titleId);
+    }
+    function maybeReplay(titleId) {
+      var slot = captured[titleId];
+      if (!slot || !slot.url || !slot.body || slot.done) return;
+      slot.done = true;
+      try {
+        fetch(slot.url, {
+          method: 'POST',
+          body: slot.body,
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+        })
+          .then(function (r) { return r.json(); })
+          .then(function (json) { fetchTracks(A.amazonTracks(json)); })
+          .catch(function () {});
+      } catch (_) {}
+    }
+    var origOpen = window.XMLHttpRequest.prototype.open;
+    window.XMLHttpRequest.prototype.open = function () {
+      try {
+        var url = arguments[1];
+        if (typeof url === 'string') {
+          var c = noteUrl(url);
+          if (c) this.__hibikiVodTitleId = c.titleId;
+        }
+      } catch (_) {}
+      return origOpen.apply(this, arguments);
+    };
+    var origSend = window.XMLHttpRequest.prototype.send;
+    window.XMLHttpRequest.prototype.send = function () {
+      try {
+        if (this.__hibikiVodTitleId && typeof arguments[0] === 'string') {
+          noteBody(this.__hibikiVodTitleId, arguments[0]);
+        }
+      } catch (_) {}
+      return origSend.apply(this, arguments);
+    };
+    var origFetch = window.fetch;
+    window.fetch = function (input, init) {
+      try {
+        var url = typeof input === 'string' ? input : ((input && input.url) || '');
+        var c = url ? noteUrl(url) : null;
+        if (c) {
+          if (init && typeof init.body === 'string') {
+            noteBody(c.titleId, init.body);
+          } else if (input && typeof input.clone === 'function') {
+            // 请求体在 Request 对象上：clone 后读，绝不消耗站点自己的 body。
+            input.clone().text()
+              .then(function (b) { noteBody(c.titleId, b); })
+              .catch(function () {});
+          }
+        }
+      } catch (_) {}
+      return origFetch.apply(this, arguments);
+    };
+  }
+
+  if (site === 'tver') installJsonHook(A.tverTracks);
+  else if (site === 'bilibili') installJsonHook(A.bilibiliTracks);
+  else if (site === 'hulu-jp') installHuluJpHook();
+  else if (site === 'prime') installAmazonHook();
+})();

--- a/hibiki/assets/browser_extension/stream-bridge.js
+++ b/hibiki/assets/browser_extension/stream-bridge.js
@@ -4,7 +4,8 @@
 // window.hibikiEpisodeCues（`${host+path}|${label}` 轨）。字幕面板 / 覆盖层 / 查词 / 快捷键
 // 零站点特例地消费这些轨。
 //
-// 四类手法全部来自 asbplayer（extension/src/entrypoints/*-page.ts，MIT）：
+// 四类手法全部来自 asbplayer（extension/src/entrypoints/*-page.ts，MIT；
+// 完整版权与许可文本见随扩展分发的 THIRD_PARTY_LICENSES.md）：
 //   · TVer / Bilibili.tv —— JSON.parse 纯透传 hook，从站点自己的播放数据里嗅探字幕轨；
 //   · Hulu JP —— XMLHttpRequest load 旁路读响应（播放元数据带 tracks）；
 //   · Prime Video —— 捕获 GetVodPlaybackResources 请求（URL+body），原样重放一次拿

--- a/hibiki/assets/browser_extension/subtitle-adapters.js
+++ b/hibiki/assets/browser_extension/subtitle-adapters.js
@@ -172,6 +172,22 @@ function parseTtml(xml) {
   return out;
 }
 
+// Bilibili.tv 字幕 JSON（asb 伪扩展名 bbjson）→ cues。形状：{body:[{from,to,content}]}，
+// from/to 是秒（浮点）。与其它解析器同约：纯函数、坏输入回空数组。
+function parseBilibiliJson(text) {
+  const out = [];
+  let data = null;
+  try { data = JSON.parse(String(text || '')); } catch (_) { return out; }
+  const body = data && Array.isArray(data.body) ? data.body : [];
+  for (const item of body) {
+    if (!item || typeof item.from !== 'number' || typeof item.to !== 'number') continue;
+    const t = String(item.content || '').trim();
+    if (!t) continue;
+    out.push({ startMs: Math.round(item.from * 1000), endMs: Math.round(item.to * 1000), text: t });
+  }
+  return out;
+}
+
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     extractNetflixCueText,
@@ -183,6 +199,7 @@ if (typeof module !== 'undefined' && module.exports) {
     stripCueTags,
     parseWebVtt,
     parseTtml,
+    parseBilibiliJson,
     netflixDocumentTitle,
   };
 }

--- a/hibiki/assets/browser_extension/subtitle-panel.js
+++ b/hibiki/assets/browser_extension/subtitle-panel.js
@@ -554,7 +554,10 @@
           st.hoverPaused = false;
           var v = videoEl();
           if (v && typeof v.play === 'function') {
-            try { v.play(); } catch (_) {}
+            var resumed = v.play();
+            if (resumed && typeof resumed.catch === 'function') {
+              resumed.catch(function () {});
+            }
           }
         }
       });

--- a/hibiki/assets/browser_extension/subtitle-panel.js
+++ b/hibiki/assets/browser_extension/subtitle-panel.js
@@ -35,10 +35,18 @@
     langSelect: null, builtLang: null, builtLen: -1, builtCues: null,
     pushedEl: null, prevWidth: '', prevWidthPriority: '', tickTimer: null,
     pushSuspended: false, enabled: false,
-    // B（外挂字幕）：用户主动打开面板（即使暂无轨也不自动拆）；已加载外挂轨的原始 cue + 时轴偏移。
-    forceOpen: false, extTracks: Object.create(null), offsetBar: null, offsetLabel: null,
+    // B（外挂字幕）：用户主动打开面板（即使暂无轨也不自动拆）。
+    forceOpen: false, offsetBar: null, offsetLabel: null,
     overlayEnabled: true, dragDropEnabled: true, autoPause: false, condensedPlayback: false,
     overlayEl: null, overlayCue: null, dropHint: null, lastCondensedTargetMs: -1,
+    // asb 移植：任意轨（检测轨/外挂轨）的读取侧时轴偏移。store 永远存原始 cue，偏移只在
+    // 面板/覆盖层/快捷键**读取时**套用——provider（textTracks 收割 / live 采样 / 整集拦截）
+    // 增量刷新 store 不会与偏移打架。key = `${videoKey}|${lang}`，会话内记忆。
+    trackOffsets: Object.create(null), builtOffset: 0,
+    // asb 移植：句首自动暂停 / 快进无字幕段 / 悬停暂停 / 覆盖层防剧透模糊 / 全轨覆盖层。
+    autoPauseAtStart: false, fastForward: false, hoverPause: false,
+    overlayBlur: false, overlayAllTracks: false,
+    hoverPaused: false, overlayHovered: false, ffSavedRate: -1, lastAutoPauseIdx: -1,
   };
   var EXT_PREFIX = '外挂:';
 
@@ -134,6 +142,30 @@
       return a.lang < b.lang ? -1 : (a.lang > b.lang ? 1 : 0);
     });
     return out;
+  }
+
+  // ── asb 移植：读取侧时轴偏移（任意轨，subtitle-controller.ts offset() 的无破坏版） ──
+  function activeTrackKey() {
+    return st.activeLang ? (videoKey() + '|' + st.activeLang) : null;
+  }
+  function trackOffset(key) {
+    return (key && st.trackOffsets[key]) || 0;
+  }
+  function shiftedCues(base, off) {
+    if (!off) return base;
+    var out = [];
+    for (var i = 0; i < base.length; i++) {
+      var c = base[i];
+      out.push({
+        startMs: Math.max(0, c.startMs + off),
+        endMs: Math.max(0, c.endMs + off),
+        text: c.text,
+      });
+    }
+    return out;
+  }
+  function fmtOffset(ms) {
+    return (ms >= 0 ? '+' : '') + (ms / 1000).toFixed(1) + 's';
   }
 
   function cueIndexAt(cues, t) {
@@ -256,7 +288,7 @@
     st.langSelect = langSelect;
     header.appendChild(langSelect);
 
-    // B（asb 招牌）：外挂字幕时轴偏移条——仅当前轨是外挂字幕时显示。−/＋ 微调让字幕对齐视频。
+    // asb 移植：字幕时轴偏移条——任意当前轨（检测轨/外挂轨）都可偏移。−/＋ 微调让字幕对齐视频。
     var offsetBar = document.createElement('div');
     offsetBar.className = 'hibiki-sub-offset';
     offsetBar.style.display = 'none';
@@ -321,13 +353,37 @@
     st.autoScroll = c.subtitleAutoScroll !== false;
     st.autoPause = c.subtitleAutoPause === true;
     st.condensedPlayback = c.subtitleCondensedPlayback === true;
+    // asb 移植的扩展偏好（全部默认关，除快捷键在 video-shortcuts.js 自持默认开）。
+    st.autoPauseAtStart = c.subtitleAutoPauseAtStart === true;
+    st.fastForward = c.subtitleFastForwardPlayback === true;
+    st.hoverPause = c.subtitleHoverPause === true;
+    st.overlayBlur = c.subtitleOverlayBlur === true;
+    st.overlayAllTracks = c.subtitleOverlayAllTracks === true;
     if (!st.overlayEnabled) hideSubtitleOverlay();
+  }
+
+  // 当前偏好快照（快捷键 toggle 用：改一个键、其余保持现值，绝不把用户已关的项刷回默认）。
+  function prefsSnapshot() {
+    return {
+      subtitleOverlayEnabled: st.overlayEnabled,
+      subtitleDragDropEnabled: st.dragDropEnabled,
+      subtitleAutoScroll: st.autoScroll,
+      subtitleAutoPause: st.autoPause,
+      subtitleCondensedPlayback: st.condensedPlayback,
+      subtitleAutoPauseAtStart: st.autoPauseAtStart,
+      subtitleFastForwardPlayback: st.fastForward,
+      subtitleHoverPause: st.hoverPause,
+      subtitleOverlayBlur: st.overlayBlur,
+      subtitleOverlayAllTracks: st.overlayAllTracks,
+    };
   }
 
   function readSubtitlePreferences() {
     var keys = [
       'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
       'subtitleAutoPause', 'subtitleCondensedPlayback',
+      'subtitleAutoPauseAtStart', 'subtitleFastForwardPlayback', 'subtitleHoverPause',
+      'subtitleOverlayBlur', 'subtitleOverlayAllTracks',
     ];
     try {
       var p = chrome.storage.local.get(keys);
@@ -364,9 +420,12 @@
   function rebuildList(tracks) {
     var active = null;
     for (var i = 0; i < tracks.length; i++) if (tracks[i].lang === st.activeLang) active = tracks[i];
-    st.cues = active ? active.cues : [];
-    if (st.builtLang === st.activeLang && st.builtLen === st.cues.length &&
-        st.builtCues === st.cues) {
+    // asb 移植：偏移在读取侧套用——store 里 base cues 不动，st.cues 是（必要时）平移后的视图。
+    var base = active ? active.cues : [];
+    var off = trackOffset(active ? active.key : null);
+    st.cues = shiftedCues(base, off);
+    if (st.builtLang === st.activeLang && st.builtLen === base.length &&
+        st.builtCues === base && st.builtOffset === off) {
       // BUG-1029：live cue 逐字扩长时数组和长度都不变。沿用行节点，只刷新文本/时间戳；
       // 这样不会重建长列表，也不会把每个中间快照追加成一行。
       for (var n = 0; n < st.cues.length; n++) {
@@ -395,7 +454,8 @@
       list.appendChild(empty);
       st.builtLang = st.activeLang;
       st.builtLen = 0;
-      st.builtCues = st.cues;
+      st.builtCues = base;
+      st.builtOffset = off;
       return;
     }
     var frag = document.createDocumentFragment();
@@ -404,8 +464,9 @@
     }
     list.appendChild(frag);
     st.builtLang = st.activeLang;
-    st.builtLen = st.cues.length;
-    st.builtCues = st.cues;
+    st.builtLen = base.length;
+    st.builtCues = base;
+    st.builtOffset = off;
   }
 
   function buildRow(cue, idx) {
@@ -474,11 +535,41 @@
           });
         }
       });
+      // asb 移植：悬停暂停（pause-on-hover）——鼠标进覆盖层即暂停，方便查词；移出且确实是
+      // 因悬停而暂停时恢复播放（用户自己按的暂停不动）。防剧透模糊（blur）同一对监听里处理。
+      el.addEventListener('mouseenter', function () {
+        st.overlayHovered = true;
+        applyOverlayBlur(el);
+        if (st.hoverPause) {
+          var v = videoEl();
+          if (v && !v.paused && typeof v.pause === 'function') {
+            try { v.pause(); st.hoverPaused = true; } catch (_) {}
+          }
+        }
+      });
+      el.addEventListener('mouseleave', function () {
+        st.overlayHovered = false;
+        applyOverlayBlur(el);
+        if (st.hoverPaused) {
+          st.hoverPaused = false;
+          var v = videoEl();
+          if (v && typeof v.play === 'function') {
+            try { v.play(); } catch (_) {}
+          }
+        }
+      });
       st.overlayEl = el;
     }
     var parent = parentForOverlay();
     if (st.overlayEl.parentNode !== parent) parent.appendChild(st.overlayEl);
     return st.overlayEl;
+  }
+
+  // asb 移植：防剧透模糊——覆盖层默认糊住，悬停即清晰（顺带触发悬停暂停，看+查一体）。
+  function applyOverlayBlur(el) {
+    if (!el || !el.style) return;
+    var blurred = st.overlayBlur && !st.overlayHovered;
+    try { el.style.filter = blurred ? 'blur(6px)' : ''; } catch (_) {}
   }
 
   function hideSubtitleOverlay() {
@@ -487,7 +578,10 @@
   }
 
   function updateSubtitleOverlay(cue) {
-    if (!st.overlayEnabled || !isExternalLang(st.activeLang) || !cue) {
+    // 外挂轨恒显示；检测轨（站点自带字幕）默认不重复叠字，除非用户开了「全轨覆盖层」
+    // （overlayAllTracks，配合防剧透模糊/悬停暂停使用）。
+    if (!st.overlayEnabled || !cue ||
+        (!isExternalLang(st.activeLang) && !st.overlayAllTracks)) {
       hideSubtitleOverlay();
       return;
     }
@@ -502,6 +596,7 @@
     el.style.left = (rect.left + rect.width / 2) + 'px';
     el.style.top = (rect.top + rect.height * 0.84) + 'px';
     el.style.maxWidth = Math.max(240, rect.width * 0.9) + 'px';
+    applyOverlayBlur(el);
   }
 
   function firstCueAfter(ms) {
@@ -517,11 +612,23 @@
     var video = videoEl();
     if (!video) return;
     var previous = st.currentIndex;
-    if (st.autoPause && previous >= 0 && idx < 0 &&
+    // 自动暂停·句尾（既有默认）：上一句刚结束、尚未进入下一句时暂停。
+    if (st.autoPause && !st.autoPauseAtStart && previous >= 0 && idx < 0 &&
         nowMs >= st.cues[previous].endMs && typeof video.pause === 'function') {
       try { video.pause(); } catch (_) {}
       return;
     }
+    // asb 移植（AutoPausePreference.atStart）：自动暂停·句首——新句刚开播（<400ms，避免
+    // seek 进句中被误暂停）时暂停一次；同一句只暂停一次（用户继续播放后不再回按）。
+    if (st.autoPause && st.autoPauseAtStart && idx >= 0 && idx !== previous &&
+        idx !== st.lastAutoPauseIdx && nowMs - st.cues[idx].startMs < 400 &&
+        !video.paused && typeof video.pause === 'function') {
+      try { video.pause(); } catch (_) {}
+      st.lastAutoPauseIdx = idx;
+      return;
+    }
+    if (idx < 0) st.lastAutoPauseIdx = -1;
+    applyFastForward(video, idx, nowMs);
     if (!st.condensedPlayback || st.autoPause || idx >= 0 || video.paused) {
       if (idx >= 0) st.lastCondensedTargetMs = -1;
       return;
@@ -532,6 +639,27 @@
     if (target - nowMs < 800 || target === st.lastCondensedTargetMs) return;
     st.lastCondensedTargetMs = target;
     seekTo(target);
+  }
+
+  // asb 移植（fastForward 播放模式）：无字幕区间倍速播过（asb 默认 2.7x），进句恢复原速。
+  // 与精简播放（直接跳过）互斥——精简开启时优先跳过；自动暂停开启时两者都不动。
+  function applyFastForward(video, idx, nowMs) {
+    var eligible = st.fastForward && !st.autoPause && !st.condensedPlayback &&
+        typeof video.playbackRate === 'number';
+    var inGap = false;
+    if (eligible && idx < 0 && !video.paused && st.cues.length) {
+      var next = firstCueAfter(nowMs + 250);
+      if (next >= 0 && st.cues[next].startMs - nowMs >= 800) inGap = true;
+    }
+    if (inGap) {
+      if (st.ffSavedRate < 0) {
+        st.ffSavedRate = video.playbackRate > 0 ? video.playbackRate : 1;
+        try { video.playbackRate = 2.7; } catch (_) {}
+      }
+    } else if (st.ffSavedRate >= 0) {
+      try { video.playbackRate = st.ffSavedRate; } catch (_) {}
+      st.ffSavedRate = -1;
+    }
   }
 
   function ensureMounted() {
@@ -652,8 +780,10 @@
     if (!base.length) { toast('字幕为空'); return; }
     var label = EXT_PREFIX + String(filename).replace(/\|/g, '_');
     var key = videoKey() + '|' + label;
-    st.extTracks[key] = { baseCues: base, offsetMs: 0 };
-    writeExternalTrack(key);
+    // 外挂轨与检测轨同构：store 存原始 cue，偏移走统一的读取侧 trackOffsets（重新加载即归零）。
+    var store = window.hibikiEpisodeCues || (window.hibikiEpisodeCues = Object.create(null));
+    store[key] = base;
+    delete st.trackOffsets[key];
     st.activeLang = label;
     st.builtLang = null;
     st.forceOpen = true;
@@ -724,53 +854,138 @@
     }
     for (var i = 0; i < files.length; i++) loadSubtitleFile(files[i]);
   }, true);
-  // 把外挂轨（原始 cue + 当前偏移）写进 store，供面板/查词消费。偏移让字幕对齐视频时轴。
-  function writeExternalTrack(key) {
-    var t = st.extTracks[key];
-    if (!t) return;
-    var store = window.hibikiEpisodeCues || (window.hibikiEpisodeCues = Object.create(null));
-    var out = [];
-    for (var i = 0; i < t.baseCues.length; i++) {
-      var c = t.baseCues[i];
-      out.push({
-        startMs: Math.max(0, c.startMs + t.offsetMs),
-        endMs: Math.max(0, c.endMs + t.offsetMs),
-        text: c.text,
-      });
-    }
-    store[key] = out;
-  }
-  function activeExternalKey() {
-    if (!isExternalLang(st.activeLang)) return null;
-    var key = videoKey() + '|' + st.activeLang;
-    return st.extTracks[key] ? key : null;
-  }
+  // asb 移植：偏移操作对**任意当前轨**生效（读取侧 trackOffsets，见 st 定义处注释）。
   function nudgeOffset(deltaMs) {
-    var key = activeExternalKey();
+    var key = activeTrackKey();
     if (!key) return;
-    st.extTracks[key].offsetMs += deltaMs;
-    writeExternalTrack(key);
+    st.trackOffsets[key] = (st.trackOffsets[key] || 0) + deltaMs;
     st.builtLang = null; // 时间戳变了 → 强制列表重建
     refresh();
   }
   function resetOffset() {
-    var key = activeExternalKey();
+    var key = activeTrackKey();
     if (!key) return;
-    st.extTracks[key].offsetMs = 0;
-    writeExternalTrack(key);
+    delete st.trackOffsets[key];
     st.builtLang = null;
     refresh();
   }
   function updateOffsetBar() {
     if (!st.offsetBar) return;
-    var key = activeExternalKey();
-    if (!key) { st.offsetBar.style.display = 'none'; return; }
+    var key = activeTrackKey();
+    if (!key || !st.cues.length) { st.offsetBar.style.display = 'none'; return; }
     st.offsetBar.style.display = '';
-    var ms = st.extTracks[key].offsetMs;
-    if (st.offsetLabel) {
-      st.offsetLabel.textContent = (ms >= 0 ? '+' : '') + (ms / 1000).toFixed(1) + 's';
-    }
+    if (st.offsetLabel) st.offsetLabel.textContent = fmtOffset(trackOffset(key));
   }
+
+  // ── asb 移植：快捷键执行端 ──
+  // video-shortcuts.js（同隔离世界、本文件之后加载）判定按键 → 调这里执行。面板持有轨/偏移/
+  // 模式状态，所以动作收敛在本文件；面板未打开（甚至未启用）时快捷键也要能用——此时隐式选
+  // 当前视频的第一条轨。返回 true = 已接管（调用方 preventDefault），false = 放行给站点。
+  function lastCueStartBefore(ms) {
+    var lo = 0, hi = st.cues.length - 1, ans = -1;
+    while (lo <= hi) {
+      var mid = (lo + hi) >> 1;
+      if (st.cues[mid].startMs < ms) { ans = mid; lo = mid + 1; } else { hi = mid - 1; }
+    }
+    return ans;
+  }
+  // 面板没开时 st.cues 可能为空/过期：从 store 重取当前轨（含读取侧偏移）。
+  function recomputeShortcutCues() {
+    var tracks = tracksForVideo();
+    var active = null;
+    for (var i = 0; i < tracks.length; i++) if (tracks[i].lang === st.activeLang) active = tracks[i];
+    if (!active && tracks.length) { st.activeLang = tracks[0].lang; active = tracks[0]; }
+    st.cues = active ? shiftedCues(active.cues, trackOffset(active.key)) : [];
+  }
+  function shortcutSeekPrev() {
+    if (!st.cues.length) return false;
+    // 上一句：开播 >600ms 时先回本句句首（与播放器「上一曲」惯例一致），再按一次才到上一句。
+    var i = lastCueStartBefore(videoTimeMs() - 600);
+    if (i < 0) return false;
+    seekTo(st.cues[i].startMs);
+    return true;
+  }
+  function shortcutSeekNext() {
+    if (!st.cues.length) return false;
+    var i = firstCueAfter(videoTimeMs());
+    if (i < 0) return false;
+    seekTo(st.cues[i].startMs);
+    return true;
+  }
+  function shortcutReplay() {
+    if (!st.cues.length) return false;
+    var now = videoTimeMs();
+    var idx = cueIndexAt(st.cues, now);
+    if (idx < 0) idx = lastCueStartBefore(now);
+    if (idx < 0) return false;
+    seekTo(st.cues[idx].startMs);
+    return true;
+  }
+  function shortcutOffset(deltaMs) {
+    var key = activeTrackKey();
+    if (!key || !st.cues.length) return false;
+    if (deltaMs === 0) delete st.trackOffsets[key];
+    else st.trackOffsets[key] = (st.trackOffsets[key] || 0) + deltaMs;
+    if (st.panel && st.panel.parentNode && !st.hidden) { st.builtLang = null; refresh(); }
+    else recomputeShortcutCues();
+    toast('字幕偏移 ' + fmtOffset(trackOffset(key)));
+    return true;
+  }
+  function shortcutCopyCue() {
+    if (!st.cues.length) return false;
+    var now = videoTimeMs();
+    var idx = cueIndexAt(st.cues, now);
+    if (idx < 0) idx = lastCueStartBefore(now);
+    if (idx < 0) return false;
+    var text = st.cues[idx].text;
+    try {
+      if (typeof navigator === 'undefined' || !navigator.clipboard ||
+          typeof navigator.clipboard.writeText !== 'function') return false;
+      navigator.clipboard.writeText(text);
+    } catch (_) { return false; }
+    toast('已复制字幕：' + (text.length > 30 ? text.slice(0, 30) + '…' : text));
+    return true;
+  }
+  function togglePref(key, label) {
+    var snap = prefsSnapshot();
+    var next = snap[key] !== true;
+    snap[key] = next;
+    applySubtitlePreferences(snap); // 先行生效（无 chrome 环境的单测同样生效）
+    try { var patch = {}; patch[key] = next; chrome.storage.local.set(patch); } catch (_) {}
+    toast(label + (next ? '：开' : '：关'));
+    return true;
+  }
+  function shortcutTogglePanel() {
+    if (!st.enabled) {
+      st.forceOpen = true;
+      try { chrome.storage.local.set({ netflixSubtitlePanel: true }); } catch (_) {}
+      applyEnabled(true);
+    } else if (st.hidden || !st.panel || !st.panel.parentNode) {
+      st.forceOpen = true;
+      showPanel();
+    } else {
+      hidePanel();
+    }
+    return true;
+  }
+  window.hibikiSubtitleShortcut = function (action) {
+    if (!videoEl()) return false;
+    if (!st.cues.length) recomputeShortcutCues();
+    switch (action) {
+      case 'prev-cue': return shortcutSeekPrev();
+      case 'next-cue': return shortcutSeekNext();
+      case 'replay-cue': return shortcutReplay();
+      case 'offset-minus': return shortcutOffset(-100);
+      case 'offset-plus': return shortcutOffset(100);
+      case 'offset-reset': return shortcutOffset(0);
+      case 'copy-cue': return shortcutCopyCue();
+      case 'toggle-autopause': return togglePref('subtitleAutoPause', '自动暂停');
+      case 'toggle-condensed': return togglePref('subtitleCondensedPlayback', '精简播放');
+      case 'toggle-fastforward': return togglePref('subtitleFastForwardPlayback', '快进无字幕段');
+      case 'toggle-panel': return shortcutTogglePanel();
+    }
+    return false;
+  };
 
   // TODO-1219 P3：Netflix 批量录制（content.js hibikiRunNetflixBatch）录整标签页前调用，撤销推挤让
   // 播放器全宽（录制画面不带面板黑边）；录完调 resume 重挂。挂起期间 applyPush 被 pushSuspended 门控。
@@ -808,20 +1023,19 @@
     chrome.storage.onChanged.addListener(function (changes, area) {
       if (area !== 'local' || !changes) return;
       if (changes[SETTING_KEY]) applyEnabled(changes[SETTING_KEY].newValue === true);
-      var prefs = {};
+      // 以当前值快照为底、只覆盖真正变化的键——单键变更绝不把其它偏好刷回默认。
+      var prefs = prefsSnapshot();
       var changed = false;
-      var keys = ['subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll', 'subtitleAutoPause', 'subtitleCondensedPlayback'];
+      var keys = [
+        'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
+        'subtitleAutoPause', 'subtitleCondensedPlayback',
+        'subtitleAutoPauseAtStart', 'subtitleFastForwardPlayback', 'subtitleHoverPause',
+        'subtitleOverlayBlur', 'subtitleOverlayAllTracks',
+      ];
       for (var i = 0; i < keys.length; i++) {
         if (changes[keys[i]]) { prefs[keys[i]] = changes[keys[i]].newValue; changed = true; }
       }
-      if (changed) {
-        prefs.subtitleOverlayEnabled = prefs.subtitleOverlayEnabled == null ? st.overlayEnabled : prefs.subtitleOverlayEnabled;
-        prefs.subtitleDragDropEnabled = prefs.subtitleDragDropEnabled == null ? st.dragDropEnabled : prefs.subtitleDragDropEnabled;
-        prefs.subtitleAutoScroll = prefs.subtitleAutoScroll == null ? st.autoScroll : prefs.subtitleAutoScroll;
-        prefs.subtitleAutoPause = prefs.subtitleAutoPause == null ? st.autoPause : prefs.subtitleAutoPause;
-        prefs.subtitleCondensedPlayback = prefs.subtitleCondensedPlayback == null ? st.condensedPlayback : prefs.subtitleCondensedPlayback;
-        applySubtitlePreferences(prefs);
-      }
+      if (changed) applySubtitlePreferences(prefs);
     });
   } catch (_) {}
 

--- a/hibiki/assets/browser_extension/subtitle-panel.js
+++ b/hibiki/assets/browser_extension/subtitle-panel.js
@@ -554,10 +554,7 @@
           st.hoverPaused = false;
           var v = videoEl();
           if (v && typeof v.play === 'function') {
-            var resumed = v.play();
-            if (resumed && typeof resumed.catch === 'function') {
-              resumed.catch(function () {});
-            }
+            Promise.resolve(v.play()).catch(function () {});
           }
         }
       });
@@ -941,11 +938,9 @@
     if (idx < 0) idx = lastCueStartBefore(now);
     if (idx < 0) return false;
     var text = st.cues[idx].text;
-    try {
-      if (typeof navigator === 'undefined' || !navigator.clipboard ||
-          typeof navigator.clipboard.writeText !== 'function') return false;
-      navigator.clipboard.writeText(text);
-    } catch (_) { return false; }
+    if (typeof navigator === 'undefined' || !navigator.clipboard ||
+        typeof navigator.clipboard.writeText !== 'function') return false;
+    Promise.resolve(navigator.clipboard.writeText(text)).catch(function () {});
     toast('已复制字幕：' + (text.length > 30 ? text.slice(0, 30) + '…' : text));
     return true;
   }

--- a/hibiki/assets/browser_extension/video-shortcuts.js
+++ b/hibiki/assets/browser_extension/video-shortcuts.js
@@ -1,0 +1,147 @@
+// asb 移植：视频页快捷键（content script 隔离世界，manifest bundle 里排在 subtitle-panel.js
+// 之后加载）。键位与 asbplayer 默认键对齐（差异见 README「快捷键」表）：
+//   ←/→        上一句 / 下一句字幕（仅当前视频有字幕轨时接管，否则放行给站点）
+//   ↑           回当前句句首重播
+//   Shift+P/O/F 开关 自动暂停 / 精简播放 / 快进无字幕段
+//   Shift+S     开关字幕列表面板
+//   Ctrl+Shift+←/→/↓  字幕时轴偏移 −100ms / ＋100ms / 重置
+//   Ctrl+Shift+Z      复制当前字幕句到剪贴板（配合 Hibiki 剪贴板监看即查词）
+//   Ctrl+Shift+[ / ]  播放速度 −0.25x / ＋0.25x
+// 判定是纯函数 decide()（node 可测）；执行端是 subtitle-panel.js 暴露的
+// window.hibikiSubtitleShortcut(action)（面板持有轨/偏移/模式状态），播放速度直接操作 <video>。
+// 输入框/可编辑区一律放行；options 的 videoShortcutsEnabled（默认开）可整体关闭。
+(function (root, factory) {
+  var api = factory();
+  try { if (typeof module !== 'undefined' && module.exports) module.exports = api; } catch (_) { /* no-op */ }
+  if (root) root.HIBIKI_VIDEO_SHORTCUTS = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // 纯函数按键判定。ev = {key, code, ctrl, shift, alt, editable}；
+  // ctx = {enabled, hasVideo, hasTrack}。返回 {action} 或 null（null = 不接管，放行给站点）。
+  function decide(ev, ctx) {
+    if (!ev || !ctx || !ctx.enabled || ev.editable || !ctx.hasVideo) return null;
+    if (ev.alt) return null;
+    var key = ev.key || '';
+    var code = ev.code || '';
+    if (ev.ctrl && ev.shift) {
+      if (key === 'ArrowLeft') return ctx.hasTrack ? { action: 'offset-minus' } : null;
+      if (key === 'ArrowRight') return ctx.hasTrack ? { action: 'offset-plus' } : null;
+      if (key === 'ArrowDown') return ctx.hasTrack ? { action: 'offset-reset' } : null;
+      if (code === 'KeyZ') return ctx.hasTrack ? { action: 'copy-cue' } : null;
+      // 括号键在 Shift 下 e.key 会变成 '{' / '}'，用布局无关的 e.code。
+      if (code === 'BracketLeft') return { action: 'rate-down' };
+      if (code === 'BracketRight') return { action: 'rate-up' };
+      return null;
+    }
+    if (ev.ctrl) return null;
+    if (ev.shift) {
+      if (code === 'KeyP') return { action: 'toggle-autopause' };
+      if (code === 'KeyO') return { action: 'toggle-condensed' };
+      if (code === 'KeyF') return { action: 'toggle-fastforward' };
+      if (code === 'KeyS') return { action: 'toggle-panel' };
+      return null;
+    }
+    if (key === 'ArrowLeft') return ctx.hasTrack ? { action: 'prev-cue' } : null;
+    if (key === 'ArrowRight') return ctx.hasTrack ? { action: 'next-cue' } : null;
+    if (key === 'ArrowUp') return ctx.hasTrack ? { action: 'replay-cue' } : null;
+    return null;
+  }
+
+  // 播放速度步进（clamp 0.25–4，步长由调用方传）。返回 clamp 后的新值。
+  function nextRate(current, delta) {
+    var cur = typeof current === 'number' && current > 0 ? current : 1;
+    return Math.round(Math.min(4, Math.max(0.25, cur + delta)) * 100) / 100;
+  }
+
+  return { decide: decide, nextRate: nextRate };
+});
+
+// ── 浏览器运行时（node 单测里 window/document 缺省 → 整段跳过）──
+(function () {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  var api = (typeof self !== 'undefined' ? self : window).HIBIKI_VIDEO_SHORTCUTS;
+  var enabled = true;
+
+  function applyEnabled(saved) {
+    // 缺省/非 false 一律视为开启（默认开）。
+    enabled = !(saved && saved.videoShortcutsEnabled === false);
+  }
+  try {
+    var p = chrome.storage.local.get('videoShortcutsEnabled');
+    if (p && typeof p.then === 'function') p.then(applyEnabled, function () {});
+    else chrome.storage.local.get('videoShortcutsEnabled', applyEnabled);
+  } catch (_) {}
+  try {
+    chrome.storage.onChanged.addListener(function (changes, area) {
+      if (area !== 'local' || !changes || !changes.videoShortcutsEnabled) return;
+      enabled = changes.videoShortcutsEnabled.newValue !== false;
+    });
+  } catch (_) {}
+
+  function isEditable(t) {
+    if (!t) return false;
+    if (t.isContentEditable) return true;
+    var tag = String(t.tagName || '').toUpperCase();
+    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+  }
+
+  // 当前视频是否已有任一字幕轨（store key 前缀匹配，与 subtitle-panel 同一契约）。
+  function hasTrackForVideo() {
+    var store = window.hibikiEpisodeCues;
+    if (!store || typeof window.hibikiVideoKey !== 'function') return false;
+    var vid;
+    try { vid = String(window.hibikiVideoKey()); } catch (_) { return false; }
+    if (!vid) return false;
+    for (var k in store) {
+      if (k.indexOf(vid + '|') === 0 && store[k] && store[k].length) return true;
+    }
+    return false;
+  }
+
+  function adjustRate(delta) {
+    var v = document.querySelector('video');
+    if (!v || typeof v.playbackRate !== 'number') return false;
+    var next = api.nextRate(v.playbackRate, delta);
+    try { v.playbackRate = next; } catch (_) { return false; }
+    try {
+      if (typeof window.hibikiToast === 'function') window.hibikiToast('播放速度 ' + next + 'x');
+    } catch (_) {}
+    return true;
+  }
+
+  // capture 阶段监听，接管时 stopPropagation 压过站点自己的键位（asb 同款策略）；
+  // 未接管（decide 返回 null / 执行端没接住）绝不动事件，站点行为原样。
+  window.addEventListener('keydown', function (e) {
+    // 廉价预筛：绝大多数按键（无修饰的普通打字）直接跳过，不查 DOM。
+    if (!e.shiftKey && !e.ctrlKey && !e.metaKey &&
+        e.key !== 'ArrowLeft' && e.key !== 'ArrowRight' && e.key !== 'ArrowUp') {
+      return;
+    }
+    var decision = api.decide(
+      {
+        key: e.key,
+        code: e.code,
+        ctrl: e.ctrlKey || e.metaKey,
+        shift: e.shiftKey,
+        alt: e.altKey,
+        editable: isEditable(e.target),
+      },
+      {
+        enabled: enabled,
+        hasVideo: !!document.querySelector('video'),
+        hasTrack: hasTrackForVideo(),
+      });
+    if (!decision) return;
+    var handled = false;
+    if (decision.action === 'rate-up') handled = adjustRate(0.25);
+    else if (decision.action === 'rate-down') handled = adjustRate(-0.25);
+    else if (typeof window.hibikiSubtitleShortcut === 'function') {
+      handled = window.hibikiSubtitleShortcut(decision.action) === true;
+    }
+    if (handled) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }, true);
+})();

--- a/hibiki/assets/browser_extension/video-shortcuts.js
+++ b/hibiki/assets/browser_extension/video-shortcuts.js
@@ -36,6 +36,7 @@
     }
     if (ev.ctrl) return null;
     if (ev.shift) {
+      if (!ctx.hasTrack) return null;
       if (code === 'KeyP') return { action: 'toggle-autopause' };
       if (code === 'KeyO') return { action: 'toggle-condensed' };
       if (code === 'KeyF') return { action: 'toggle-fastforward' };

--- a/hibiki/test/lookup/browser_extension_installer_test.dart
+++ b/hibiki/test/lookup/browser_extension_installer_test.dart
@@ -14,13 +14,13 @@ void main() {
   });
 
   // 漂移守卫（TODO-1000）：随 app 打包的 assets/browser_extension/ 必须与真源
-  // tools/browser-extension/ 逐字节一致（排除 *.test.js 测试文件与 scripts/ 构建工具）。
-  // 改了扩展源却忘同步 bundle → 助手装出的是旧扩展；此守卫强制同步。重新同步：把
-  // tools/browser-extension 下非 *.test.js、非 scripts/ 文件复制进
-  // hibiki/assets/browser_extension/（含 vendor/）。
-  // scripts/（TODO-1267 的 generate-content-css.mjs + content-css-overlay.css）是**构建期
-  // 生成器**：manifest 不加载、只用于把 popup.css 重生成成 scoped content.css，属 dev 工具，
-  // 与 *.test.js 同类不进发布 bundle。
+  // tools/browser-extension/ 逐字节一致（排除 *.test.js 测试文件、scripts/ 构建工具与
+  // README.md 文档）。改了扩展源却忘同步 bundle → 助手装出的是旧扩展；此守卫强制同步。
+  // 重新同步：跑 `node tools/browser-extension/scripts/sync-mirrors.mjs`（同样的排除规则，
+  // `--check` 只校验）。
+  // scripts/（TODO-1267 的 generate-content-css.mjs + content-css-overlay.css + 同步脚本）是
+  // **构建期工具**：manifest 不加载，与 *.test.js 同类不进发布 bundle。README.md 是开发文档，
+  // 不进 bundle——否则内容指纹会随文档改动翻新，触发无意义的扩展自更新 reload。
   group('bundled extension matches source', () {
     final Directory srcDir = Directory('../tools/browser-extension');
     final Directory bundleDir = Directory('assets/browser_extension');
@@ -39,6 +39,7 @@ void main() {
             .replaceFirst(RegExp(r'^/'), '');
         if (rel.endsWith('.test.js')) continue; // 测试文件不进 bundle
         if (rel.startsWith('scripts/')) continue; // 构建期生成器/overlay 不进 bundle
+        if (rel == 'README.md') continue; // 开发文档不进 bundle（防指纹随文档翻新）
         final File bundled = File('${bundleDir.path}/$rel');
         expect(bundled.existsSync(), isTrue,
             reason: 'not bundled: $rel (run the re-sync copy)');

--- a/tools/browser-extension/README.md
+++ b/tools/browser-extension/README.md
@@ -1,0 +1,128 @@
+# Hibiki 浏览器扩展（Hibiki Reader Bridge）
+
+在任意网页上用 Hibiki 的词典查词、采集/加载流媒体字幕、批量制卡。扩展本身没有词典和
+Anki 能力——一切经本机 Hibiki 桌面 App 内置的 yomitan API server（默认
+`http://127.0.0.1:19633`，HTTP + Basic auth）完成。**没有构建步骤**：纯 JS 散文件，MV3。
+
+## 文件地图
+
+| 文件 | 世界 | 职责 |
+|---|---|---|
+| `manifest.json` | — | MV3 清单；content script 注入顺序有语义（先桥后消费者） |
+| `background.js` | service worker | 唯一网络出口：查词/制卡/字幕等所有 HTTP 请求 + 连接诊断 + 自更新执行 + 心跳 + Netflix 录制编排 |
+| `content.js` | 隔离 | Shift 悬停查词、弹窗渲染/定位、高亮、挖词队列、字幕轨 provider（textTracks 收割 / DOM 采样 / 整集拦截接收端）、Netflix/YouTube 批量制卡驱动 |
+| `subtitle-panel.js` | 隔离 | 字幕列表侧栏 + 视频覆盖层 + 外挂字幕加载 + 全轨时轴偏移 + 播放模式（自动暂停/精简/快进）+ 悬停暂停/防剧透模糊 + 快捷键执行端 |
+| `video-shortcuts.js` | 隔离 | 视频页快捷键判定（纯函数）+ 绑定；动作交 subtitle-panel 执行 |
+| `netflix-bridge.js` | MAIN | Netflix 专用：JSON.parse hook 抓整集字幕 + 官方 player.seek（避开 DRM M7375） |
+| `stream-bridge.js` | MAIN | 通用流媒体字幕桥（asb 移植）：TVer / Bilibili.tv / Hulu JP / Prime Video 整集字幕拦截 |
+| `subtitle-adapters.js` | 隔离 | 纯函数字幕解析器：WebVTT/SRT、TTML、Bilibili JSON + Netflix 取词/标题 |
+| `bridge-shim.js` | 隔离 | 垫掉 app 内 WebView 桥（`flutter_inappwebview.callHandler`）→ chrome 消息，复用 vendor/popup.js |
+| `scan.js` | 隔离 | 取词纯函数（词窗扩展/句子抽取） |
+| `self-update.js` | SW/options | 自更新决策纯状态机 + 状态文案（node 可测） |
+| `connection-diagnostics.js` | SW/options | 连接六态分类 + 中文文案（纯函数） |
+| `hibiki-defaults.js` | SW/options | 安装助手写入的自动配置（host/port/token/build 指纹） |
+| `offscreen.html/js` | offscreen | tabCapture MediaRecorder（Netflix 逐句回放录制） |
+| `options.html/css/js` | options | 设置页：连接、字幕/播放偏好、快捷键开关、版本与更新卡片 |
+| `vendor/` | — | `popup.{js,css,html}`+`selection.js` = app 查词弹窗原样拷贝（上游 `hibiki/assets/popup/`）；`dict-media.js` 允许扩展分叉；`content.css` 由生成器产出；`action-popup.*` 扩展独有 |
+| `scripts/` | 开发 | `generate-content-css.mjs`（popup.css → 零特异性重根 content.css）、`sync-mirrors.mjs`（镜像同步） |
+
+## 三份镜像与同步（改代码必读）
+
+```
+hibiki/assets/popup/  ──(手动 cp，方向固定)──▶  vendor/popup.js 等四件套
+tools/browser-extension/（真源，本目录） ──(node scripts/sync-mirrors.mjs)──▶ hibiki/assets/browser_extension/（Flutter asset）
+scripts/generate-content-css.mjs ──▶ 两处 vendor/content.css
+```
+
+- **任何改动后跑 `node scripts/sync-mirrors.mjs`**（或 `--check` 只校验）。`*.test.js`、
+  `scripts/`、`README.md` 不进 bundle。
+- Dart 守卫（`hibiki/test/build/browser_extension_*` 等 30+ 个）会把「两镜像字节一致」当
+  最后防线，漏同步 CI 必红。
+- 新增文件放本目录**平级**（或 `vendor/`）——`hibiki/pubspec.yaml` 只声明了这两层 asset 目录。
+
+## 安装（导入浏览器）流水线
+
+1. 本目录随 app 以 Flutter asset 打包（镜像 `hibiki/assets/browser_extension/`）。
+2. app 扩展页「准备扩展」→ `browser_extension_installer.dart` 解压到
+   `<appSupport>/hibiki-browser-extension/`，并把**当前 server 真值**（host/port/token）与
+   **内容指纹 build**（全部文件排除 `hibiki-defaults.js` 的 sha256 前 16 hex）写进
+   `hibiki-defaults.js` → 用户浏览器「加载已解压」后零配置可用。
+3. 用户可在 options 页覆盖连接参数（chrome.storage.local 优先于内置默认）。
+
+## 自更新流水线
+
+```
+app 升级
+  └─ 启动时 refreshBundledBrowserExtensionIfStale()：磁盘副本指纹 ≠ 内置 → 整目录重解压（新 build）
+浏览器侧（background.js + self-update.js 纯状态机）
+  └─ SW 唤醒 / onStartup / onInstalled / 60s 心跳 / 每次查词响应 → 拿 server 下发的 extensionBuild
+       decide(remote, local, reloadedFor, recording)：
+         remote == local        → clear（清 stale 提示/角标）
+         首见新 build           → chrome.runtime.reload()（从磁盘拉新；先置重注入标记）
+         已 reload 过仍不一致    → stale：图标「↑」角标 + action-popup 提示 + options「版本与更新」卡片
+         录制中                 → 跳过本轮（reload 会杀 offscreen 录制）
+  └─ reload 后：hibikiReinjectPending → 向已打开页面补注 content script（无需手动刷新）
+可视化：options 页「版本与更新」卡片实时显示 当前 build / 自动更新状态 / 失效指引
+        （self-update.js describeUpdateState，扩展自报版本走 /api/extension/status 请求体）
+```
+
+## 与 App 的通信（endpoint 速览）
+
+全部 `POST http://<host>:<port>/api/...`，`Authorization: Basic base64('hibiki:'+token)`。
+查词 `/api/lookup/dictionary` · 单词音频 `/api/lookup/audio` · 制卡 `/api/mine` · 查重
+`/api/duplicate` · 状态/心跳 `/api/extension/status` · 弹窗尺寸 `/api/extension/popup-size` ·
+YouTube 整集字幕 `/api/youtube/captions` · 外挂字幕解析 `/api/subtitle/parse`。
+服务端实现：`hibiki/lib/src/sync/yomitan_api_server.dart`。
+
+## 字幕轨数据流（面板零站点特例）
+
+所有来源写同一个 store：`window.hibikiEpisodeCues['${videoKey}|${lang}'] = [{startMs,endMs,text}]`，
+新数据到达调 `window.hibikiSubtitlePanelOnCues(key)`。来源：
+① Netflix 整集拦截（netflix-bridge）② 通用流媒体桥（stream-bridge，见下表）③ YouTube 服务端
+整集字幕 ④ 原生 `video.textTracks` 收割 ⑤ DOM 字幕采样 live 轨 ⑥ 用户外挂文件（`外挂:` 前缀轨）。
+时轴偏移是**读取侧**的（store 永远存原始 cue），任意轨可偏移，会话内记忆。
+
+## 站点适配状态
+
+| 站点 | 机制 | 验证状态 |
+|---|---|---|
+| Netflix | JSON.parse hook + 官方 seek（netflix-bridge） | ✅ 已真站点验证（既有） |
+| YouTube | 服务端 androidVr 解析（/api/youtube/captions）+ live 采样兜底 | ✅ 已真站点验证（既有） |
+| TVer | JSON.parse hook（stream-bridge，asb tver-page 移植） | ⚠️ implemented_unverified |
+| Bilibili.tv（国际站） | JSON.parse hook，srt/bbjson | ⚠️ implemented_unverified |
+| Hulu（日本） | XHR 响应旁路（ref_id + tracks） | ⚠️ implemented_unverified |
+| Prime Video | 捕获 GetVodPlaybackResources 重放 → TTML | ⚠️ implemented_unverified |
+| 其它站点 | 通用：textTracks 收割 + DOM live 采样 + 外挂字幕 | ✅ 通用路径既有 |
+
+⚠️ = 提取逻辑逐行对照 asbplayer 已上线适配器移植、纯函数有 node 单测，但本仓库开发环境无对应
+账号，未做真站点端到端验证；上线前请在真站点各过一遍（打开视频 → 字幕列表出现整集轨）。
+
+**新增站点适配器步骤**：① `stream-bridge.js` 加纯函数提取器 + `siteForHost` 路由 + 对应
+hook 安装；② `manifest.json` 的 stream-bridge matches 加域名；③ 新格式则在
+`subtitle-adapters.js` 加解析器并在 `content.js` `hibikiOnStreamCues` 分派；④ 加
+`stream-bridge.test.js` 样例 JSON 测试；⑤ 跑 sync-mirrors。参考 asbplayer
+`extension/src/entrypoints/*-page.ts`（MIT）。
+
+## 快捷键（视频页，options 可整体关闭）
+
+| 键 | 动作 |
+|---|---|
+| ← / → | 上一句 / 下一句字幕（仅当前视频有字幕轨时接管） |
+| ↑ | 回当前句句首重播 |
+| Shift+P / O / F | 开关 自动暂停 / 精简播放 / 快进无字幕段 |
+| Shift+S | 开关字幕列表面板 |
+| Ctrl+Shift+← / → / ↓ | 字幕偏移 −100ms / ＋100ms / 重置 |
+| Ctrl+Shift+Z | 复制当前字幕句（配合 Hibiki 剪贴板监看即查词） |
+| Ctrl+Shift+[ / ] | 播放速度 −0.25x / ＋0.25x（0.25–4x） |
+
+与 asbplayer 默认键位对齐（asb 用 hotkeys-js + 可改键；这里是固定键位 + 纯函数判定，站点
+输入框/可编辑区一律放行，无轨时方向键放行给站点原生行为）。
+
+## 测试
+
+```
+node --test            # 本目录全部 *.test.js（node 内置 runner，零依赖）
+```
+
+Dart 侧守卫（跑法见仓库根 CLAUDE.md）：`hibiki/test/{build,lookup,mining,sync,...}/browser_extension_*`
+做镜像字节一致 + 功能链存在性扫描。扩展 JS 单测目前不在 CI，提 PR 前请本地跑过。

--- a/tools/browser-extension/README.md
+++ b/tools/browser-extension/README.md
@@ -15,6 +15,7 @@ Anki 能力——一切经本机 Hibiki 桌面 App 内置的 yomitan API server�
 | `video-shortcuts.js` | 隔离 | 视频页快捷键判定（纯函数）+ 绑定；动作交 subtitle-panel 执行 |
 | `netflix-bridge.js` | MAIN | Netflix 专用：JSON.parse hook 抓整集字幕 + 官方 player.seek（避开 DRM M7375） |
 | `stream-bridge.js` | MAIN | 通用流媒体字幕桥（asb 移植）：TVer / Bilibili.tv / Hulu JP / Prime Video 整集字幕拦截 |
+| `THIRD_PARTY_LICENSES.md` | — | 随扩展分发的第三方版权与许可文本（当前含 asbplayer MIT） |
 | `subtitle-adapters.js` | 隔离 | 纯函数字幕解析器：WebVTT/SRT、TTML、Bilibili JSON + Netflix 取词/标题 |
 | `bridge-shim.js` | 隔离 | 垫掉 app 内 WebView 桥（`flutter_inappwebview.callHandler`）→ chrome 消息，复用 vendor/popup.js |
 | `scan.js` | 隔离 | 取词纯函数（词窗扩展/句子抽取） |
@@ -35,7 +36,7 @@ scripts/generate-content-css.mjs ──▶ 两处 vendor/content.css
 ```
 
 - **任何改动后跑 `node scripts/sync-mirrors.mjs`**（或 `--check` 只校验）。`*.test.js`、
-  `scripts/`、`README.md` 不进 bundle。
+  `scripts/`、`README.md` 不进 bundle；`THIRD_PARTY_LICENSES.md` 必须进入 bundle 与安装目录。
 - Dart 守卫（`hibiki/test/build/browser_extension_*` 等 30+ 个）会把「两镜像字节一致」当
   最后防线，漏同步 CI 必红。
 - 新增文件放本目录**平级**（或 `vendor/`）——`hibiki/pubspec.yaml` 只声明了这两层 asset 目录。
@@ -109,14 +110,14 @@ hook 安装；② `manifest.json` 的 stream-bridge matches 加域名；③ 新�
 |---|---|
 | ← / → | 上一句 / 下一句字幕（仅当前视频有字幕轨时接管） |
 | ↑ | 回当前句句首重播 |
-| Shift+P / O / F | 开关 自动暂停 / 精简播放 / 快进无字幕段 |
-| Shift+S | 开关字幕列表面板 |
+| Shift+P / O / F | 开关 自动暂停 / 精简播放 / 快进无字幕段（当前视频有 Hibiki 字幕轨时） |
+| Shift+S | 开关字幕列表面板（当前视频有 Hibiki 字幕轨时） |
 | Ctrl+Shift+← / → / ↓ | 字幕偏移 −100ms / ＋100ms / 重置 |
 | Ctrl+Shift+Z | 复制当前字幕句（配合 Hibiki 剪贴板监看即查词） |
 | Ctrl+Shift+[ / ] | 播放速度 −0.25x / ＋0.25x（0.25–4x） |
 
 与 asbplayer 默认键位对齐（asb 用 hotkeys-js + 可改键；这里是固定键位 + 纯函数判定，站点
-输入框/可编辑区一律放行，无轨时方向键放行给站点原生行为）。
+输入框/可编辑区一律放行；无轨时方向键及 Shift+P/O/F/S 均放行给站点原生行为）。
 
 ## 测试
 

--- a/tools/browser-extension/THIRD_PARTY_LICENSES.md
+++ b/tools/browser-extension/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,32 @@
+# Third-party licenses
+
+## asbplayer
+
+Portions of `stream-bridge.js` and the associated streaming-site adapters are
+derived from asbplayer:
+
+- Source: https://github.com/asbplayer/asbplayer
+- Upstream files: `extension/src/entrypoints/*-page.ts`
+- License: MIT
+
+MIT License
+
+Copyright (c) 2020-2026 asbplayer authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -219,6 +219,31 @@ window.addEventListener('message', (e) => {
 // 面板只剩预取的下一集轨（列表空）。接收端就位后立刻请求 bridge 重放已存档的 cue 消息，消除时序运气。
 try { window.postMessage({ __hibikiNf: 'replayCues' }, '/'); } catch (_) {}
 
+// ── asb 移植：通用流媒体字幕桥（stream-bridge.js，MAIN 世界）→ store ──
+// TVer / Bilibili.tv / Hulu JP / Prime Video 的主世界桥抓到整集字幕原文后经
+// {__hibikiStream:'cues'} 送到这里，按 format 分派解析器写进 hibikiEpisodeCues。
+// 轨 key 用桥捕获时的 host+path（与 hibikiVideoKey 的通用回落同构）——SPA 换集后
+// 消息晚到也落在正确的视频 key 下。存档/重放握手与 netflix-bridge 相同。
+function hibikiOnStreamCues(msg) {
+  try {
+    let cues;
+    if (msg.format === 'ttml') cues = parseTtml(msg.text);
+    else if (msg.format === 'bbjson') cues = parseBilibiliJson(msg.text);
+    else cues = parseWebVtt(msg.text); // webvtt / srt（parseWebVtt 兼容 SRT 块）
+    if (!cues || !cues.length) return;
+    const vidKey = (location.hostname + (msg.path || location.pathname)).replace(/\|/g, '_');
+    const lang = String(msg.lang || 'und').replace(/\|/g, '_');
+    const key = vidKey + '|' + lang;
+    hibikiEpisodeCues[key] = cues;
+    hibikiNotifyPanel(key);
+  } catch (_) {}
+}
+window.addEventListener('message', (e) => {
+  if (e.source !== window || !e.data || e.data.__hibikiStream !== 'cues') return;
+  hibikiOnStreamCues(e.data);
+});
+try { window.postMessage({ __hibikiStream: 'replayCues' }, '/'); } catch (_) {}
+
 // ── TODO-1363：通用字幕轨 provider（所有站点） ──
 // 数据契约不变：window.hibikiEpisodeCues[`${videoKey}|${lang}`] = [{startMs,endMs,text}]，新数据到达
 // 即调 window.hibikiSubtitlePanelOnCues(key)。Netflix 整集拦截之外新增两条通用通道，站点差异全部

--- a/tools/browser-extension/external-subtitle.test.js
+++ b/tools/browser-extension/external-subtitle.test.js
@@ -175,7 +175,7 @@ test('① 选文件→server 解析→外挂轨写进 store 并成为当前轨',
   assert.ok(h.toasts.some((t) => t.indexOf('已加载') >= 0), '必须提示加载成功');
 });
 
-test('② 时轴偏移：nudge 让整轨 cue 时间平移', () => {
+test('② 时轴偏移：读取侧平移（面板/seek 用偏移值，store 保持原始 cue）', () => {
   const h = loadPanel({
     hostname: 'example.com', pathname: '/video/1', stored: { netflixSubtitlePanel: true },
     response: OK([{ text: 'a', startMs: 1000, endMs: 2000 }]),
@@ -184,16 +184,22 @@ test('② 时轴偏移：nudge 让整轨 cue 时间平移', () => {
   const key = 'example.com/video/1|外挂:x.srt';
   const store = h.windowObj.hibikiEpisodeCues;
   assert.strictEqual(store[key][0].startMs, 1000);
-  // 偏移条可见（当前轨为外挂），点 +0.5s 按钮。
+  // 偏移条可见（asb 移植后任意当前轨都显示），点 +0.5s 按钮。
   const panel = h.panel();
   const offsetBar = findByClassDeep(panel, 'hibiki-sub-offset')[0];
-  assert.ok(offsetBar, '外挂轨必须显示时轴偏移条');
+  assert.ok(offsetBar, '当前轨必须显示时轴偏移条');
   assert.notStrictEqual(offsetBar.style._props.display, 'none');
   const plus = findBtnByTitle(offsetBar, '＋0.5')[0];
   assert.ok(plus, '缺 ＋0.5 偏移按钮');
   plus.handlers.click[0]({ stopPropagation() {} });
-  assert.strictEqual(store[key][0].startMs, 1500, '偏移 +0.5s 后 cue 起点平移 500ms');
-  assert.strictEqual(store[key][0].endMs, 2500);
+  // asb 移植后偏移在读取侧套用：store 原始 cue 不动（provider 增量刷新不会打架），
+  // 面板行 seek 与时间戳用偏移后的值。
+  assert.strictEqual(store[key][0].startMs, 1000, 'store 必须保持原始 cue（读取侧偏移）');
+  assert.strictEqual(store[key][0].endMs, 2000);
+  const ts = findByClassDeep(h.panel(), 'hibiki-sub-ts')[0];
+  assert.ok(ts, '缺行时间戳按钮');
+  ts.handlers.click[0]({ stopPropagation() {} });
+  assert.strictEqual(h.video.currentTime, 1.5, '行点击 seek 必须用偏移后的 1500ms');
 });
 
 test('③ 不支持格式 → 提示、不造轨', () => {

--- a/tools/browser-extension/manifest.json
+++ b/tools/browser-extension/manifest.json
@@ -9,12 +9,30 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["bridge-shim.js", "subtitle-adapters.js", "vendor/dict-media.js", "vendor/selection.js", "vendor/popup.js", "scan.js", "content.js", "subtitle-panel.js"],
+      "js": ["bridge-shim.js", "subtitle-adapters.js", "vendor/dict-media.js", "vendor/selection.js", "vendor/popup.js", "scan.js", "content.js", "subtitle-panel.js", "video-shortcuts.js"],
       "css": ["vendor/content.css"]
     },
     {
       "matches": ["*://*.netflix.com/*"],
       "js": ["netflix-bridge.js"],
+      "world": "MAIN",
+      "run_at": "document_start"
+    },
+    {
+      "matches": [
+        "*://*.tver.jp/*",
+        "*://*.bilibili.tv/*",
+        "*://www.hulu.jp/*",
+        "*://*.primevideo.com/*",
+        "*://*.amazon.com/*",
+        "*://*.amazon.co.jp/*",
+        "*://*.amazon.co.uk/*",
+        "*://*.amazon.de/*",
+        "*://*.amazon.fr/*",
+        "*://*.amazon.it/*",
+        "*://*.amazon.es/*"
+      ],
+      "js": ["stream-bridge.js"],
       "world": "MAIN",
       "run_at": "document_start"
     }

--- a/tools/browser-extension/options.html
+++ b/tools/browser-extension/options.html
@@ -48,6 +48,27 @@
               </span>
               <span class="switch"><input id="subtitleAutoScroll" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
+            <label class="setting-row" for="subtitleOverlayAllTracks">
+              <span class="setting-copy">
+                <strong>所有字幕轨都用扩展覆盖层显示</strong>
+                <small>站点检测到的字幕轨也叠到视频上，配合防剧透模糊与悬停暂停使用。</small>
+              </span>
+              <span class="switch"><input id="subtitleOverlayAllTracks" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="subtitleOverlayBlur">
+              <span class="setting-copy">
+                <strong>防剧透模糊</strong>
+                <small>覆盖层字幕默认模糊，鼠标悬停即清晰——先听再看。</small>
+              </span>
+              <span class="switch"><input id="subtitleOverlayBlur" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="subtitleHoverPause">
+              <span class="setting-copy">
+                <strong>悬停字幕时暂停</strong>
+                <small>鼠标移到覆盖层字幕上自动暂停，移开继续播放，方便查词。</small>
+              </span>
+              <span class="switch"><input id="subtitleHoverPause" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
           </div>
         </section>
 
@@ -73,6 +94,27 @@
               </span>
               <span class="switch"><input id="subtitleCondensedPlayback" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
+            <label class="setting-row" for="subtitleAutoPauseAtStart">
+              <span class="setting-copy">
+                <strong>自动暂停改在句首</strong>
+                <small>开启「自动暂停」时改为每句开播即暂停（先猜再听），默认是句尾暂停。</small>
+              </span>
+              <span class="switch"><input id="subtitleAutoPauseAtStart" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="subtitleFastForwardPlayback">
+              <span class="setting-copy">
+                <strong>快进无字幕段</strong>
+                <small>无字幕区间以 2.7 倍速播过（保留画面连续性），进句自动恢复原速。</small>
+              </span>
+              <span class="switch"><input id="subtitleFastForwardPlayback" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutsEnabled">
+              <span class="setting-copy">
+                <strong>视频页快捷键</strong>
+                <small>←/→ 上一句/下一句 · ↑ 重播本句 · Shift+P/O/F 暂停/精简/快进 · Shift+S 面板 · Ctrl+Shift+←/→/↓ 偏移 · Ctrl+Shift+Z 复制字幕 · Ctrl+Shift+[ ] 变速。</small>
+              </span>
+              <span class="switch"><input id="videoShortcutsEnabled" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
           </div>
         </section>
 
@@ -80,17 +122,23 @@
           <div class="section-heading compact">
             <div>
               <p class="section-kicker">站点适配</p>
-              <h2 id="site-heading">Netflix</h2>
+              <h2 id="site-heading">流媒体站点</h2>
             </div>
           </div>
           <div class="setting-list">
             <label class="setting-row" for="nfHideNext">
               <span class="setting-copy">
-                <strong>隐藏“下一集”和分级遮挡</strong>
+                <strong>Netflix：隐藏“下一集”和分级遮挡</strong>
                 <small>避免剧末按钮、后播层和开场分级标识进入制卡截图。</small>
               </span>
               <span class="switch"><input id="nfHideNext" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
+            <div class="setting-row">
+              <span class="setting-copy">
+                <strong>整集字幕自动检测</strong>
+                <small>Netflix、YouTube、TVer、Bilibili.tv、Hulu（日本）、Prime Video 播放时自动抓取整集字幕进字幕列表；其它站点走通用采集（原生字幕轨收割 + 实时采样）。</small>
+              </span>
+            </div>
           </div>
         </section>
       </main>
@@ -136,6 +184,12 @@
           </form>
         </details>
 
+        <div class="tip" id="updateCard">
+          <strong id="updTitle">版本与更新</strong>
+          <p id="updDetail">正在读取扩展版本信息…</p>
+          <code id="updBuild"></code>
+        </div>
+
         <div class="tip">
           <strong>加载自己的字幕</strong>
           <p>开启字幕列表后，点侧栏中的“＋”，或直接把字幕文件拖到视频上。</p>
@@ -147,6 +201,7 @@
   <div class="save-toast" id="status" role="status" aria-live="polite"></div>
   <script src="hibiki-defaults.js"></script>
   <script src="connection-diagnostics.js"></script>
+  <script src="self-update.js"></script>
   <script src="options.js"></script>
 </body>
 </html>

--- a/tools/browser-extension/options.js
+++ b/tools/browser-extension/options.js
@@ -9,6 +9,13 @@ const subtitleDefaults = Object.freeze({
   subtitleAutoPause: false,
   subtitleCondensedPlayback: false,
   netflixHideNextEpisode: true,
+  // asb 移植（默认关，快捷键默认开）。
+  subtitleAutoPauseAtStart: false,
+  subtitleFastForwardPlayback: false,
+  subtitleHoverPause: false,
+  subtitleOverlayBlur: false,
+  subtitleOverlayAllTracks: false,
+  videoShortcutsEnabled: true,
 });
 const toggleIds = Object.freeze({
   nfSubList: 'netflixSubtitlePanel',
@@ -18,6 +25,12 @@ const toggleIds = Object.freeze({
   subtitleAutoPause: 'subtitleAutoPause',
   subtitleCondensedPlayback: 'subtitleCondensedPlayback',
   nfHideNext: 'netflixHideNextEpisode',
+  subtitleAutoPauseAtStart: 'subtitleAutoPauseAtStart',
+  subtitleFastForwardPlayback: 'subtitleFastForwardPlayback',
+  subtitleHoverPause: 'subtitleHoverPause',
+  subtitleOverlayBlur: 'subtitleOverlayBlur',
+  subtitleOverlayAllTracks: 'subtitleOverlayAllTracks',
+  videoShortcutsEnabled: 'videoShortcutsEnabled',
 });
 
 let toastTimer = null;
@@ -130,6 +143,23 @@ $('showToken').addEventListener('click', () => {
 
 $('check').addEventListener('click', () => refreshConnection(true));
 
+// 「版本与更新」卡片：把自更新链路状态翻成人话（self-update.js describeUpdateState），
+// 让「扩展怎么更新、现在是不是最新」在设置页一眼可见，不再只有失效时的角标。
+async function refreshUpdateCard() {
+  const titleEl = $('updTitle');
+  const detailEl = $('updDetail');
+  const buildEl = $('updBuild');
+  if (!titleEl || !self.HIBIKI_SELF_UPDATE) return;
+  let stale = null;
+  try {
+    stale = (await chrome.storage.local.get('hibikiUpdateStale')).hibikiUpdateStale || null;
+  } catch (_) { /* storage 不可用：按无 stale 渲染 */ }
+  const s = self.HIBIKI_SELF_UPDATE.describeUpdateState(self.HIBIKI_DEFAULTS, stale);
+  titleEl.textContent = '版本与更新 · ' + s.title;
+  if (detailEl) detailEl.textContent = s.detail;
+  if (buildEl) buildEl.textContent = s.build ? 'build ' + s.build : '';
+}
+
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area !== 'local') return;
   for (const [id, key] of Object.entries(toggleIds)) {
@@ -137,8 +167,10 @@ chrome.storage.onChanged.addListener((changes, area) => {
     const input = $(id);
     if (input) input.checked = changes[key].newValue === true;
   }
+  if (changes.hibikiUpdateStale) refreshUpdateCard();
 });
 
 // BUG-1036：选项页每次打开都应报告当前真状态，不能复用 background 最多 5 秒的离线缓存；
 // 手动“重新检测”本来就是 force=true，首次自动检测保持同一语义。
 loadSettings().then(() => refreshConnection(true));
+refreshUpdateCard();

--- a/tools/browser-extension/scripts/sync-mirrors.mjs
+++ b/tools/browser-extension/scripts/sync-mirrors.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// 扩展镜像一键同步：tools/browser-extension（真源）→ hibiki/assets/browser_extension（Flutter
+// asset 打包镜像）。此前同步靠「手动 cp + Dart 字节守卫兜底」，漏拷任一文件守卫即红且提示晦涩；
+// 现在改动扩展后跑一次本脚本即可，守卫只做最后防线。
+//
+//   node scripts/sync-mirrors.mjs          # 同步（新增/更新/删除多余文件）
+//   node scripts/sync-mirrors.mjs --check  # 只校验不写盘；有漂移 exit 1（可挂 CI/pre-commit）
+//
+// 排除项（不进 app bundle）：*.test.js、scripts/、README.md。
+// 另外校验 vendor/ 四件套（popup.js/popup.css/popup.html/selection.js）与其上游
+// hibiki/assets/popup/ 是否字节一致——它们的真源在 app 侧，方向是 assets/popup → 两处 vendor/，
+// 本脚本**绝不**反向覆盖，只报告漂移（同步命令见输出提示）。vendor/dict-media.js 允许有
+// 扩展侧分叉（image:// → http 重写），不在校验列表。
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const HERE = path.dirname(url.fileURLToPath(import.meta.url));
+const SRC = path.resolve(HERE, '..'); // tools/browser-extension
+const REPO = path.resolve(SRC, '..', '..'); // 仓库根
+const DEST = path.join(REPO, 'hibiki', 'assets', 'browser_extension');
+const POPUP_UPSTREAM = path.join(REPO, 'hibiki', 'assets', 'popup');
+const VENDOR_FROM_POPUP = ['popup.js', 'popup.css', 'popup.html', 'selection.js'];
+
+const checkOnly = process.argv.includes('--check');
+
+function excluded(rel) {
+  const top = rel.split(/[\\/]/)[0];
+  return top === 'scripts' || /\.test\.js$/i.test(rel) || rel === 'README.md';
+}
+
+function walk(dir, base, out) {
+  base = base || dir;
+  out = out || [];
+  if (!fs.existsSync(dir)) return out;
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, base, out);
+    else out.push(path.relative(base, p).replace(/\\/g, '/'));
+  }
+  return out;
+}
+
+function sameBytes(a, b) {
+  if (!fs.existsSync(a) || !fs.existsSync(b)) return false;
+  const ba = fs.readFileSync(a);
+  const bb = fs.readFileSync(b);
+  return ba.equals(bb);
+}
+
+let drift = 0;
+const actions = [];
+
+// ── 真源 → assets 镜像 ──
+const srcFiles = walk(SRC).filter((rel) => !excluded(rel));
+const destFiles = walk(DEST);
+
+for (const rel of srcFiles) {
+  const from = path.join(SRC, rel);
+  const to = path.join(DEST, rel);
+  if (sameBytes(from, to)) continue;
+  drift++;
+  if (checkOnly) {
+    actions.push(`漂移: ${rel}`);
+  } else {
+    fs.mkdirSync(path.dirname(to), { recursive: true });
+    fs.copyFileSync(from, to);
+    actions.push(`已同步: ${rel}`);
+  }
+}
+for (const rel of destFiles) {
+  if (srcFiles.includes(rel)) continue;
+  drift++;
+  if (checkOnly) {
+    actions.push(`镜像多余文件: ${rel}`);
+  } else {
+    fs.rmSync(path.join(DEST, rel));
+    actions.push(`已删除镜像多余文件: ${rel}`);
+  }
+}
+
+// ── vendor 四件套 ↔ assets/popup 上游校验（只报告，不写盘）──
+let vendorDrift = 0;
+for (const name of VENDOR_FROM_POPUP) {
+  const upstream = path.join(POPUP_UPSTREAM, name);
+  const vendor = path.join(SRC, 'vendor', name);
+  if (!sameBytes(upstream, vendor)) {
+    vendorDrift++;
+    actions.push(
+      `vendor 漂移: vendor/${name} ≠ hibiki/assets/popup/${name}` +
+      `（上游在 assets/popup，手动: cp hibiki/assets/popup/${name} tools/browser-extension/vendor/${name} 后重跑本脚本）`);
+  }
+}
+
+for (const line of actions) console.log(line);
+if (checkOnly) {
+  if (drift + vendorDrift === 0) {
+    console.log('镜像一致 ✓');
+  } else {
+    console.error(`共 ${drift + vendorDrift} 处漂移（--check 模式未写盘）`);
+    process.exit(1);
+  }
+} else {
+  console.log(drift === 0 ? '镜像本已一致 ✓' : `已同步 ${drift} 个文件 → hibiki/assets/browser_extension`);
+  if (vendorDrift > 0) {
+    console.error(`注意：${vendorDrift} 个 vendor 文件与 assets/popup 上游不一致（见上，需手动处理）`);
+    process.exit(1);
+  }
+}

--- a/tools/browser-extension/self-update.js
+++ b/tools/browser-extension/self-update.js
@@ -45,5 +45,42 @@
     return JSON.stringify(body);
   }
 
-  return { actions: actions, decide: decide, statusRequestBody: statusRequestBody };
+  // options 页「版本与更新」卡片：把自更新链路的状态翻成用户可读文案（纯函数，node 可测）。
+  // 三态：stale（自动更新失效，需手动重载）/ dev（无内容指纹的开发副本，不参与自动更新）/
+  // ok（正常：Hibiki 升级 → 磁盘副本刷新 → 扩展自动 reload）。
+  function describeUpdateState(defaults, stale) {
+    var build = (defaults && typeof defaults.build === 'string' && defaults.build)
+        ? defaults.build : '';
+    var short = function (s) { return String(s || '').slice(0, 8); };
+    if (stale && stale.remote) {
+      return {
+        tone: 'warn',
+        title: '自动更新未生效',
+        detail: 'Hibiki 已内置新版扩展（' + short(stale.remote) + '），请到 chrome://extensions '
+            + '找到本扩展点「重新加载」。当前加载：' + (short(stale.local) || '未知') + '。',
+        build: build,
+      };
+    }
+    if (!build) {
+      return {
+        tone: 'neutral',
+        title: '开发副本（不参与自动更新）',
+        detail: '此副本没有内容指纹（未经 Hibiki 安装助手解压），不会自动跟随 Hibiki 更新。',
+        build: '',
+      };
+    }
+    return {
+      tone: 'ok',
+      title: '随 Hibiki 自动更新',
+      detail: 'Hibiki 升级后会刷新磁盘副本，扩展在下次心跳/查词时自动重载到最新版。',
+      build: build,
+    };
+  }
+
+  return {
+    actions: actions,
+    decide: decide,
+    statusRequestBody: statusRequestBody,
+    describeUpdateState: describeUpdateState,
+  };
 });

--- a/tools/browser-extension/self-update.test.js
+++ b/tools/browser-extension/self-update.test.js
@@ -112,3 +112,29 @@ test('action-popup 渲染 stale 提示并随 storage 实时显隐', () => {
   assert.match(js, /chrome\.storage\.local\.get\(\['hibikiUpdateStale'\]/);
   assert.match(js, /changes\.hibikiUpdateStale/);
 });
+
+// ── describeUpdateState（options 页「版本与更新」卡片文案）──
+
+test('describeUpdateState: stale → 警示 + 双指纹', () => {
+  const s = selfUpdate.describeUpdateState(
+    { build: 'aaaa1111bbbb2222' },
+    { remote: 'cccc3333dddd4444', local: 'aaaa1111bbbb2222' });
+  assert.equal(s.tone, 'warn');
+  assert.ok(s.detail.includes('cccc3333'), '提示需含最新指纹短形式');
+  assert.ok(s.detail.includes('aaaa1111'), '提示需含当前指纹短形式');
+  assert.ok(s.detail.includes('重新加载'), '必须指引手动重载');
+});
+
+test('describeUpdateState: 无 build（开发副本）→ 不参与自动更新', () => {
+  const s = selfUpdate.describeUpdateState({ host: '127.0.0.1' }, null);
+  assert.equal(s.tone, 'neutral');
+  assert.equal(s.build, '');
+  assert.ok(s.title.includes('开发副本'));
+});
+
+test('describeUpdateState: 正常 → 自动更新说明 + build', () => {
+  const s = selfUpdate.describeUpdateState({ build: 'aaaa1111bbbb2222' }, null);
+  assert.equal(s.tone, 'ok');
+  assert.equal(s.build, 'aaaa1111bbbb2222');
+  assert.ok(s.detail.includes('自动重载'));
+});

--- a/tools/browser-extension/stream-bridge.js
+++ b/tools/browser-extension/stream-bridge.js
@@ -157,12 +157,10 @@
   function fetchTrack(track) {
     if (!track || !track.url || seenUrls[track.url]) return;
     seenUrls[track.url] = 1;
-    try {
-      fetch(track.url, { credentials: 'include' })
-        .then(function (r) { return r.text(); })
-        .then(function (text) { if (text) postCues(track.label, track.format, text); })
-        .catch(function () {});
-    } catch (_) {}
+    fetch(track.url, { credentials: 'include' })
+      .then(function (r) { return r.text(); })
+      .then(function (text) { if (text) postCues(track.label, track.format, text); })
+      .catch(function () {});
   }
   function fetchTracks(tracks) {
     if (!tracks) return;
@@ -229,17 +227,15 @@
       var slot = captured[titleId];
       if (!slot || !slot.url || !slot.body || slot.done) return;
       slot.done = true;
-      try {
-        fetch(slot.url, {
-          method: 'POST',
-          body: slot.body,
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-        })
-          .then(function (r) { return r.json(); })
-          .then(function (json) { fetchTracks(A.amazonTracks(json)); })
-          .catch(function () {});
-      } catch (_) {}
+      fetch(slot.url, {
+        method: 'POST',
+        body: slot.body,
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+      })
+        .then(function (r) { return r.json(); })
+        .then(function (json) { fetchTracks(A.amazonTracks(json)); })
+        .catch(function () {});
     }
     var origOpen = window.XMLHttpRequest.prototype.open;
     window.XMLHttpRequest.prototype.open = function () {

--- a/tools/browser-extension/stream-bridge.js
+++ b/tools/browser-extension/stream-bridge.js
@@ -1,0 +1,287 @@
+// asb 移植：通用流媒体字幕桥（manifest 里 world:MAIN、document_start 注入，站点见 manifest
+// matches）。做的事与 netflix-bridge.js 同构——在页面主世界拦截站点自己的网络层，拿到字幕轨
+// URL 后用页面身份（cookie）抓字幕原文，postMessage 送隔离世界 content.js 解析进
+// window.hibikiEpisodeCues（`${host+path}|${label}` 轨）。字幕面板 / 覆盖层 / 查词 / 快捷键
+// 零站点特例地消费这些轨。
+//
+// 四类手法全部来自 asbplayer（extension/src/entrypoints/*-page.ts，MIT）：
+//   · TVer / Bilibili.tv —— JSON.parse 纯透传 hook，从站点自己的播放数据里嗅探字幕轨；
+//   · Hulu JP —— XMLHttpRequest load 旁路读响应（播放元数据带 tracks）；
+//   · Prime Video —— 捕获 GetVodPlaybackResources 请求（URL+body），原样重放一次拿
+//     timedTextUrls（TTML）。
+// 红线与 netflix-bridge 相同：所有 hook 纯透传、异常绝不外泄、绝不影响站点自身播放。
+//
+// 时序竞态同 netflix-bridge：本脚本 document_start 抓字幕，content.js document_idle 才注册
+// 接收端 → 抓到的 payload 一律存档，content.js 就绪后发 {__hibikiStream:'replayCues'} 整批重放。
+//
+// 验证状态（诚实标注）：Netflix/YouTube 走既有已验证路径；本文件四站点为 implemented_unverified
+// ——提取逻辑逐行对照 asbplayer 已上线代码移植、纯函数部分有 node 单测，但本仓库开发环境无
+// 各站点账号，未做真站点端到端验证。
+(function (root, factory) {
+  var api = factory();
+  try { if (typeof module !== 'undefined' && module.exports) module.exports = api; } catch (_) { /* 页面自带 module 时忽略 */ }
+  if (root) root.HIBIKI_STREAM_ADAPTERS = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // ── 纯函数 track 提取器（node 可测）──
+  // 统一输出 [{ label, url, format }]；format ∈ webvtt|srt|ttml|bbjson（content.js 按此分派解析器）。
+
+  function urlParam(url, name) {
+    try { return new URL(url, 'https://invalid.example').searchParams.get(name); } catch (_) { return null; }
+  }
+
+  // TVer（asb tver-page.ts）：播放数据 JSON 的 tracks[] 里 kind==='captions' 且 type text/vtt。
+  function tverTracks(value) {
+    var out = [];
+    var tracks = value && Array.isArray(value.tracks) ? value.tracks : null;
+    if (!tracks) return out;
+    for (var i = 0; i < tracks.length; i++) {
+      var t = tracks[i];
+      if (!t || t.kind !== 'captions') continue;
+      if (t.type !== 'text/vtt' && t.type !== 'text/webvtt') continue;
+      if (typeof t.src !== 'string' || !t.src || typeof t.srclang !== 'string') continue;
+      var label = (typeof t.label === 'string' && t.label) ? (t.srclang + ' - ' + t.label) : t.srclang;
+      out.push({ label: label, url: t.src.replace(/^http:\/\//, 'https://'), format: 'webvtt' });
+    }
+    return out;
+  }
+
+  // Bilibili.tv（asb bilibili-page.ts）：data.subtitles[]，url 以 .json 结尾是 bbjson，否则 srt。
+  function bilibiliTracks(value) {
+    var out = [];
+    var subs = value && value.data && Array.isArray(value.data.subtitles) ? value.data.subtitles : null;
+    if (!subs) return out;
+    for (var i = 0; i < subs.length; i++) {
+      var t = subs[i];
+      if (!t || typeof t.lang !== 'string' || !t.lang) continue;
+      var url = (t.srt && typeof t.srt === 'object' && typeof t.srt.url === 'string') ? t.srt.url
+          : (typeof t.url === 'string' ? t.url : '');
+      if (!url) continue;
+      var format = /\.json([?#]|$)/i.test(url) ? 'bbjson' : 'srt';
+      out.push({ label: t.lang, url: url, format: format });
+    }
+    return out;
+  }
+
+  // Hulu JP（asb hulu-jp-page.ts）：播放元数据 {ref_id, tracks[]}，kind==='subtitles'。
+  function huluJpTracks(value) {
+    if (!value || typeof value.ref_id !== 'string' || !Array.isArray(value.tracks)) return null;
+    var out = [];
+    for (var i = 0; i < value.tracks.length; i++) {
+      var t = value.tracks[i];
+      if (!t || t.kind !== 'subtitles') continue;
+      if (typeof t.src !== 'string' || !t.src || typeof t.srclang !== 'string') continue;
+      out.push({ label: String(t.label || t.srclang), url: t.src, format: 'webvtt' });
+    }
+    return out.length ? { videoId: value.ref_id, tracks: out } : null;
+  }
+
+  // Prime Video（asb amazon-prime-page.ts）：识别 GetVodPlaybackResources 请求（titleId 在
+  // query）；捕齐 URL+body 后重放一次，从响应 timedTextUrls.result.subtitleUrls[] 取轨。
+  function amazonCapture(url) {
+    if (typeof url !== 'string' || url.indexOf('GetVodPlaybackResources') < 0) return null;
+    var titleId = urlParam(url, 'titleId');
+    return titleId ? { kind: 'vod', titleId: titleId } : null;
+  }
+  function amazonTracks(json) {
+    var out = [];
+    var urls = json && json.timedTextUrls && json.timedTextUrls.result &&
+        json.timedTextUrls.result.subtitleUrls;
+    if (!Array.isArray(urls)) return out;
+    for (var i = 0; i < urls.length; i++) {
+      var t = urls[i];
+      if (!t || typeof t.url !== 'string' || !t.url) continue;
+      out.push({
+        label: String(t.displayName || t.languageCode || 'und'),
+        url: t.url,
+        format: 'ttml',
+      });
+    }
+    return out;
+  }
+
+  function siteForHost(host) {
+    var h = String(host || '');
+    if (/(^|\.)tver\.jp$/.test(h)) return 'tver';
+    if (/(^|\.)bilibili\.tv$/.test(h)) return 'bilibili';
+    if (/^www\.hulu\.jp$/.test(h)) return 'hulu-jp';
+    if (/(^|\.)primevideo\.com$/.test(h)) return 'prime';
+    if (/(^|\.)amazon\.(com|co\.jp|co\.uk|de|fr|it|es)$/.test(h)) return 'prime';
+    return null;
+  }
+
+  return {
+    tverTracks: tverTracks,
+    bilibiliTracks: bilibiliTracks,
+    huluJpTracks: huluJpTracks,
+    amazonCapture: amazonCapture,
+    amazonTracks: amazonTracks,
+    siteForHost: siteForHost,
+    urlParam: urlParam,
+  };
+});
+
+// ── 浏览器运行时（node 单测里 window/document 缺省 → 整段跳过）──
+(function () {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (window.__hibikiStreamBridge) return; // 防重复注入
+  window.__hibikiStreamBridge = true;
+  var A = (typeof self !== 'undefined' ? self : window).HIBIKI_STREAM_ADAPTERS;
+  var site = A.siteForHost(location.hostname);
+  if (!site) return;
+
+  // BUG-769 同款：跨世界自投消息用 targetOrigin '/'，接收端比对 window.origin。
+  var ORIGIN = window.origin;
+  var seenUrls = Object.create(null); // 字幕 URL 去重，同一轨只抓一次
+  var archive = [];
+  var ARCHIVE_MAX = 120;
+
+  function post(payload) {
+    try { window.postMessage(payload, '/'); } catch (_) {}
+  }
+  function postCues(label, format, text) {
+    var payload = {
+      __hibikiStream: 'cues',
+      path: location.pathname,
+      lang: label,
+      format: format,
+      text: text,
+    };
+    archive.push(payload);
+    if (archive.length > ARCHIVE_MAX) archive.shift();
+    post(payload);
+  }
+  // 拿到轨 URL → 页面身份抓字幕原文 → 送隔离世界。best-effort，失败静默（不影响站点播放）。
+  function fetchTrack(track) {
+    if (!track || !track.url || seenUrls[track.url]) return;
+    seenUrls[track.url] = 1;
+    try {
+      fetch(track.url, { credentials: 'include' })
+        .then(function (r) { return r.text(); })
+        .then(function (text) { if (text) postCues(track.label, track.format, text); })
+        .catch(function () {});
+    } catch (_) {}
+  }
+  function fetchTracks(tracks) {
+    if (!tracks) return;
+    for (var i = 0; i < tracks.length; i++) fetchTrack(tracks[i]);
+  }
+
+  window.addEventListener('message', function (e) {
+    if (e.origin !== ORIGIN || e.source !== window || !e.data) return;
+    if (e.data.__hibikiStream === 'replayCues') {
+      // content.js（隔离世界）接收端就绪：重放全部已存档 cue，消除注入时序竞态。
+      for (var i = 0; i < archive.length; i++) post(archive[i]);
+    }
+  });
+
+  // JSON.parse 纯透传 hook（TVer / Bilibili）：先原样返回站点自己的解析结果，再旁路嗅探。
+  function installJsonHook(extract) {
+    var orig = JSON.parse;
+    JSON.parse = function () {
+      var r = orig.apply(this, arguments);
+      try { fetchTracks(extract(r)); } catch (_) {}
+      return r;
+    };
+  }
+
+  // Hulu JP：XHR load 旁路读响应（站点用 XHR 拉播放元数据）。
+  function installHuluJpHook() {
+    var origSend = window.XMLHttpRequest.prototype.send;
+    window.XMLHttpRequest.prototype.send = function () {
+      try {
+        this.addEventListener('load', function () {
+          try {
+            var body = this.response;
+            if (typeof body === 'string') {
+              try { body = JSON.parse(body); } catch (_) { body = null; }
+            }
+            var got = A.huluJpTracks(body);
+            if (got) fetchTracks(got.tracks);
+          } catch (_) {}
+        });
+      } catch (_) {}
+      return origSend.apply(this, arguments);
+    };
+  }
+
+  // Prime Video：XHR + fetch 双通道捕获 GetVodPlaybackResources 的 URL 与请求体，捕齐后
+  // 原样重放一次（POST，同凭据）→ 响应里的 timedTextUrls 即字幕轨。同一 titleId 只重放一次；
+  // 切集产生新 titleId 自然重来。重放的是站点自己刚发过的只读请求，无副作用。
+  function installAmazonHook() {
+    var captured = Object.create(null); // titleId -> { url, body, done }
+    function noteUrl(url) {
+      var c = A.amazonCapture(url);
+      if (!c) return null;
+      var slot = captured[c.titleId] || (captured[c.titleId] = {});
+      slot.url = url;
+      return c;
+    }
+    function noteBody(titleId, body) {
+      var slot = captured[titleId];
+      if (!slot || !body) return;
+      slot.body = body;
+      maybeReplay(titleId);
+    }
+    function maybeReplay(titleId) {
+      var slot = captured[titleId];
+      if (!slot || !slot.url || !slot.body || slot.done) return;
+      slot.done = true;
+      try {
+        fetch(slot.url, {
+          method: 'POST',
+          body: slot.body,
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+        })
+          .then(function (r) { return r.json(); })
+          .then(function (json) { fetchTracks(A.amazonTracks(json)); })
+          .catch(function () {});
+      } catch (_) {}
+    }
+    var origOpen = window.XMLHttpRequest.prototype.open;
+    window.XMLHttpRequest.prototype.open = function () {
+      try {
+        var url = arguments[1];
+        if (typeof url === 'string') {
+          var c = noteUrl(url);
+          if (c) this.__hibikiVodTitleId = c.titleId;
+        }
+      } catch (_) {}
+      return origOpen.apply(this, arguments);
+    };
+    var origSend = window.XMLHttpRequest.prototype.send;
+    window.XMLHttpRequest.prototype.send = function () {
+      try {
+        if (this.__hibikiVodTitleId && typeof arguments[0] === 'string') {
+          noteBody(this.__hibikiVodTitleId, arguments[0]);
+        }
+      } catch (_) {}
+      return origSend.apply(this, arguments);
+    };
+    var origFetch = window.fetch;
+    window.fetch = function (input, init) {
+      try {
+        var url = typeof input === 'string' ? input : ((input && input.url) || '');
+        var c = url ? noteUrl(url) : null;
+        if (c) {
+          if (init && typeof init.body === 'string') {
+            noteBody(c.titleId, init.body);
+          } else if (input && typeof input.clone === 'function') {
+            // 请求体在 Request 对象上：clone 后读，绝不消耗站点自己的 body。
+            input.clone().text()
+              .then(function (b) { noteBody(c.titleId, b); })
+              .catch(function () {});
+          }
+        }
+      } catch (_) {}
+      return origFetch.apply(this, arguments);
+    };
+  }
+
+  if (site === 'tver') installJsonHook(A.tverTracks);
+  else if (site === 'bilibili') installJsonHook(A.bilibiliTracks);
+  else if (site === 'hulu-jp') installHuluJpHook();
+  else if (site === 'prime') installAmazonHook();
+})();

--- a/tools/browser-extension/stream-bridge.js
+++ b/tools/browser-extension/stream-bridge.js
@@ -4,7 +4,8 @@
 // window.hibikiEpisodeCues（`${host+path}|${label}` 轨）。字幕面板 / 覆盖层 / 查词 / 快捷键
 // 零站点特例地消费这些轨。
 //
-// 四类手法全部来自 asbplayer（extension/src/entrypoints/*-page.ts，MIT）：
+// 四类手法全部来自 asbplayer（extension/src/entrypoints/*-page.ts，MIT；
+// 完整版权与许可文本见随扩展分发的 THIRD_PARTY_LICENSES.md）：
 //   · TVer / Bilibili.tv —— JSON.parse 纯透传 hook，从站点自己的播放数据里嗅探字幕轨；
 //   · Hulu JP —— XMLHttpRequest load 旁路读响应（播放元数据带 tracks）；
 //   · Prime Video —— 捕获 GetVodPlaybackResources 请求（URL+body），原样重放一次拿

--- a/tools/browser-extension/stream-bridge.test.js
+++ b/tools/browser-extension/stream-bridge.test.js
@@ -1,0 +1,109 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const A = require('./stream-bridge.js');
+
+// asb 移植：通用流媒体字幕桥的纯函数 track 提取器。样例 JSON 形状逐一对照
+// asbplayer extension/src/entrypoints/*-page.ts 的判定条件构造。
+
+test('tverTracks：kind=captions 且 text/vtt 才收，label = srclang - label，http 升 https', () => {
+  const tracks = A.tverTracks({
+    name: '番組名',
+    tracks: [
+      { kind: 'captions', type: 'text/vtt', src: 'http://cdn.example/ja.vtt', srclang: 'ja', label: '日本語' },
+      { kind: 'captions', type: 'text/webvtt', src: 'https://cdn.example/ja2.vtt', srclang: 'ja' },
+      { kind: 'thumbnails', type: 'text/vtt', src: 'https://cdn.example/thumb.vtt', srclang: 'ja' },
+      { kind: 'captions', type: 'application/x-mpegURL', src: 'https://cdn.example/x.m3u8', srclang: 'ja' },
+      { kind: 'captions', type: 'text/vtt', srclang: 'ja' }, // 缺 src
+    ],
+  });
+  assert.strictEqual(tracks.length, 2);
+  assert.deepStrictEqual(tracks[0], { label: 'ja - 日本語', url: 'https://cdn.example/ja.vtt', format: 'webvtt' });
+  assert.deepStrictEqual(tracks[1], { label: 'ja', url: 'https://cdn.example/ja2.vtt', format: 'webvtt' });
+});
+
+test('tverTracks：无 tracks / 非对象 → 空', () => {
+  assert.deepStrictEqual(A.tverTracks(null), []);
+  assert.deepStrictEqual(A.tverTracks({}), []);
+  assert.deepStrictEqual(A.tverTracks({ tracks: 'x' }), []);
+});
+
+test('bilibiliTracks：data.subtitles[]，srt.url 优先，.json 判为 bbjson', () => {
+  const tracks = A.bilibiliTracks({
+    data: {
+      subtitles: [
+        { lang: '中文（简体）', lang_key: 'zh-Hans', url: 'https://cdn.example/zh.json?x=1' },
+        { lang: '日本語', lang_key: 'ja', srt: { url: 'https://cdn.example/ja.srt' } },
+        { lang_key: 'en', url: 'https://cdn.example/en.srt' }, // 缺 lang → 丢
+        { lang: 'ko' },                                        // 缺 url → 丢
+      ],
+    },
+  });
+  assert.strictEqual(tracks.length, 2);
+  assert.deepStrictEqual(tracks[0], { label: '中文（简体）', url: 'https://cdn.example/zh.json?x=1', format: 'bbjson' });
+  assert.deepStrictEqual(tracks[1], { label: '日本語', url: 'https://cdn.example/ja.srt', format: 'srt' });
+});
+
+test('huluJpTracks：需 ref_id + kind=subtitles；返回 {videoId, tracks}', () => {
+  const got = A.huluJpTracks({
+    ref_id: 'ep123',
+    name: 'ep123:タイトル',
+    tracks: [
+      { kind: 'subtitles', src: 'https://cdn.example/ja.vtt', srclang: 'ja', label: '日本語字幕' },
+      { kind: 'audio', src: 'https://cdn.example/a.m4a', srclang: 'ja' },
+      { kind: 'subtitles', srclang: 'ja' }, // 缺 src
+    ],
+  });
+  assert.ok(got);
+  assert.strictEqual(got.videoId, 'ep123');
+  assert.strictEqual(got.tracks.length, 1);
+  assert.deepStrictEqual(got.tracks[0], { label: '日本語字幕', url: 'https://cdn.example/ja.vtt', format: 'webvtt' });
+});
+
+test('huluJpTracks：无 ref_id / 无字幕轨 → null', () => {
+  assert.strictEqual(A.huluJpTracks({ tracks: [] }), null);
+  assert.strictEqual(A.huluJpTracks({ ref_id: 'x', tracks: [{ kind: 'audio' }] }), null);
+  assert.strictEqual(A.huluJpTracks(null), null);
+});
+
+test('amazonCapture：只认 GetVodPlaybackResources 且带 titleId', () => {
+  assert.deepStrictEqual(
+    A.amazonCapture('https://atv-ps.amazon.co.jp/cdp/catalog/GetVodPlaybackResources?titleId=T123&x=1'),
+    { kind: 'vod', titleId: 'T123' });
+  assert.strictEqual(A.amazonCapture('https://atv-ps.amazon.co.jp/other?titleId=T123'), null);
+  assert.strictEqual(A.amazonCapture('https://x/GetVodPlaybackResources?foo=1'), null);
+  assert.strictEqual(A.amazonCapture(null), null);
+});
+
+test('amazonTracks：timedTextUrls.result.subtitleUrls[] → ttml 轨', () => {
+  const tracks = A.amazonTracks({
+    timedTextUrls: {
+      result: {
+        subtitleUrls: [
+          { displayName: '日本語', languageCode: 'ja-jp', url: 'https://cdn.example/ja.dfxp' },
+          { languageCode: 'en-us', url: 'https://cdn.example/en.dfxp' },
+          { displayName: '坏轨' }, // 缺 url → 丢
+        ],
+      },
+    },
+  });
+  assert.strictEqual(tracks.length, 2);
+  assert.deepStrictEqual(tracks[0], { label: '日本語', url: 'https://cdn.example/ja.dfxp', format: 'ttml' });
+  assert.deepStrictEqual(tracks[1], { label: 'en-us', url: 'https://cdn.example/en.dfxp', format: 'ttml' });
+});
+
+test('amazonTracks：stale session（无 result）→ 空', () => {
+  assert.deepStrictEqual(A.amazonTracks({ timedTextUrls: {} }), []);
+  assert.deepStrictEqual(A.amazonTracks(null), []);
+});
+
+test('siteForHost：站点路由（含 amazon 各区域 + primevideo）', () => {
+  assert.strictEqual(A.siteForHost('tver.jp'), 'tver');
+  assert.strictEqual(A.siteForHost('www.tver.jp'), 'tver');
+  assert.strictEqual(A.siteForHost('www.bilibili.tv'), 'bilibili');
+  assert.strictEqual(A.siteForHost('www.hulu.jp'), 'hulu-jp');
+  assert.strictEqual(A.siteForHost('www.amazon.co.jp'), 'prime');
+  assert.strictEqual(A.siteForHost('www.primevideo.com'), 'prime');
+  assert.strictEqual(A.siteForHost('www.bilibili.com'), null); // 大陆站 API 不同，未适配
+  assert.strictEqual(A.siteForHost('www.hulu.com'), null);     // 美国站未适配
+  assert.strictEqual(A.siteForHost('example.com'), null);
+});

--- a/tools/browser-extension/stream-bridge.test.js
+++ b/tools/browser-extension/stream-bridge.test.js
@@ -1,5 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
 const A = require('./stream-bridge.js');
 
 // asb 移植：通用流媒体字幕桥的纯函数 track 提取器。样例 JSON 形状逐一对照
@@ -106,4 +108,19 @@ test('siteForHost：站点路由（含 amazon 各区域 + primevideo）', () => 
   assert.strictEqual(A.siteForHost('www.bilibili.com'), null); // 大陆站 API 不同，未适配
   assert.strictEqual(A.siteForHost('www.hulu.com'), null);     // 美国站未适配
   assert.strictEqual(A.siteForHost('example.com'), null);
+});
+
+test('asbplayer MIT notice is retained in source and bundled extension', () => {
+  const sourceNotice = path.join(__dirname, 'THIRD_PARTY_LICENSES.md');
+  const bundledNotice = path.resolve(
+    __dirname,
+    '../../hibiki/assets/browser_extension/THIRD_PARTY_LICENSES.md',
+  );
+  const expected = 'Copyright (c) 2020-2026 asbplayer authors';
+  assert.match(fs.readFileSync(sourceNotice, 'utf8'), /MIT License/);
+  assert.match(fs.readFileSync(sourceNotice, 'utf8'), new RegExp(expected.replace(/[()]/g, '\\$&')));
+  assert.strictEqual(
+    fs.readFileSync(bundledNotice, 'utf8'),
+    fs.readFileSync(sourceNotice, 'utf8'),
+  );
 });

--- a/tools/browser-extension/subtitle-adapters.js
+++ b/tools/browser-extension/subtitle-adapters.js
@@ -172,6 +172,22 @@ function parseTtml(xml) {
   return out;
 }
 
+// Bilibili.tv 字幕 JSON（asb 伪扩展名 bbjson）→ cues。形状：{body:[{from,to,content}]}，
+// from/to 是秒（浮点）。与其它解析器同约：纯函数、坏输入回空数组。
+function parseBilibiliJson(text) {
+  const out = [];
+  let data = null;
+  try { data = JSON.parse(String(text || '')); } catch (_) { return out; }
+  const body = data && Array.isArray(data.body) ? data.body : [];
+  for (const item of body) {
+    if (!item || typeof item.from !== 'number' || typeof item.to !== 'number') continue;
+    const t = String(item.content || '').trim();
+    if (!t) continue;
+    out.push({ startMs: Math.round(item.from * 1000), endMs: Math.round(item.to * 1000), text: t });
+  }
+  return out;
+}
+
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     extractNetflixCueText,
@@ -183,6 +199,7 @@ if (typeof module !== 'undefined' && module.exports) {
     stripCueTags,
     parseWebVtt,
     parseTtml,
+    parseBilibiliJson,
     netflixDocumentTitle,
   };
 }

--- a/tools/browser-extension/subtitle-adapters.test.js
+++ b/tools/browser-extension/subtitle-adapters.test.js
@@ -8,6 +8,7 @@ const {
   stripCueTags,
   parseWebVtt,
   parseTtml,
+  parseBilibiliJson,
   netflixDocumentTitle,
 } = require('./subtitle-adapters.js');
 
@@ -170,4 +171,35 @@ test('netflixDocumentTitle falls back to document.title minus Netflix suffix', (
 test('netflixDocumentTitle null/empty doc -> empty string', () => {
   assert.strictEqual(netflixDocumentTitle(null), '');
   assert.strictEqual(netflixDocumentTitle(nfDoc(null, '')), '');
+});
+
+// ── asb 移植：stream-bridge 送来的两种新格式 ──
+
+test('parseBilibiliJson: body[{from,to,content}] 秒 → cues 毫秒', () => {
+  const text = JSON.stringify({
+    body: [
+      { from: 1.5, to: 3.25, content: 'こんにちは' },
+      { from: 4, to: 5, content: '  ' },      // 空白句丢弃
+      { from: 'x', to: 6, content: '坏行' },   // 非数值丢弃
+      { from: 6.1, to: 7.9, content: '次の句' },
+    ],
+  });
+  const cues = parseBilibiliJson(text);
+  assert.strictEqual(cues.length, 2);
+  assert.deepStrictEqual(cues[0], { startMs: 1500, endMs: 3250, text: 'こんにちは' });
+  assert.deepStrictEqual(cues[1], { startMs: 6100, endMs: 7900, text: '次の句' });
+});
+
+test('parseBilibiliJson: 坏 JSON / 无 body → 空数组', () => {
+  assert.deepStrictEqual(parseBilibiliJson('not json'), []);
+  assert.deepStrictEqual(parseBilibiliJson('{}'), []);
+  assert.deepStrictEqual(parseBilibiliJson(''), []);
+});
+
+// Bilibili srt 轨直接走 parseWebVtt：SRT 块（序号行 + 逗号毫秒）本就兼容。
+test('parseWebVtt 兼容 SRT 块（bilibili srt 轨复用同一解析器）', () => {
+  const srt = '1\n00:00:01,000 --> 00:00:02,500\n走り出した\n\n2\n00:00:04,000 --> 00:00:05,000\nこんにちは\n';
+  const cues = parseWebVtt(srt);
+  assert.strictEqual(cues.length, 2);
+  assert.deepStrictEqual(cues[0], { startMs: 1000, endMs: 2500, text: '走り出した' });
 });

--- a/tools/browser-extension/subtitle-modes.test.js
+++ b/tools/browser-extension/subtitle-modes.test.js
@@ -1,0 +1,234 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+// asb 移植行为守卫：全轨读取侧偏移 / 句首自动暂停 / 快进无字幕段 / 悬停暂停 / 防剧透模糊 /
+// 全轨覆盖层 / 快捷键执行端（window.hibikiSubtitleShortcut）。
+// 在受控 vm 里真加载 subtitle-panel.js，store 预置「检测轨」（非外挂），驱动 200ms tick。
+
+const PANEL = path.join(__dirname, 'subtitle-panel.js');
+
+function makeEl(tag) {
+  const el = {
+    tagName: (tag || 'div').toUpperCase(),
+    _id: '', _attrs: {}, className: '', value: '', title: '', type: '',
+    accept: '', files: null, children: [], parentNode: null, handlers: {},
+    style: { _props: {}, setProperty(k, v) { this._props[k] = v; }, getPropertyValue(k) { return this._props[k] || ''; } },
+    setAttribute(k, v) { el._attrs[k] = String(v); if (k === 'id') el._id = String(v); },
+    getAttribute(k) { return k in el._attrs ? el._attrs[k] : null; },
+    addEventListener(t, fn) { (el.handlers[t] = el.handlers[t] || []).push(fn); },
+    fire(t, ev) { for (const fn of el.handlers[t] || []) fn(ev || { stopPropagation() {} }); },
+    appendChild(child) {
+      if (child.parentNode) child.parentNode.removeChild(child);
+      child.parentNode = el; el.children.push(child); return child;
+    },
+    removeChild(child) {
+      const i = el.children.indexOf(child);
+      if (i >= 0) el.children.splice(i, 1);
+      child.parentNode = null; return child;
+    },
+    scrollIntoView() {},
+    click() {},
+  };
+  el.classList = {
+    _set: new Set(), add(c) { el.classList._set.add(c); }, remove(c) { el.classList._set.delete(c); },
+    toggle(c, on) { on ? el.classList._set.add(c) : el.classList._set.delete(c); }, contains(c) { return el.classList._set.has(c); },
+  };
+  Object.defineProperty(el, 'id', { get: () => el._id, set: (v) => { el._id = v; el._attrs.id = v; } });
+  let text = '';
+  Object.defineProperty(el, 'textContent', { get: () => text, set: (v) => { text = v; if (v === '') el.children.length = 0; } });
+  return el;
+}
+
+function findByIdDeep(el, id) {
+  if (el._id === id) return el;
+  for (const c of el.children || []) { const hit = findByIdDeep(c, id); if (hit) return hit; }
+  return null;
+}
+function findByClassDeep(el, cls, out) {
+  out = out || [];
+  if (el.className === cls) out.push(el);
+  for (const c of el.children || []) findByClassDeep(c, cls, out);
+  return out;
+}
+function findBtnByTitle(el, kw, out) {
+  out = out || [];
+  if (el.tagName === 'BUTTON' && String(el.title || '').indexOf(kw) >= 0) out.push(el);
+  for (const c of el.children || []) findBtnByTitle(c, kw, out);
+  return out;
+}
+
+function loadPanel(opts) {
+  opts = opts || {};
+  const src = fs.readFileSync(PANEL, 'utf8');
+  const body = makeEl('body');
+  const video = {
+    currentTime: 0,
+    paused: false,
+    playbackRate: 1,
+    pauseCount: 0,
+    playCount: 0,
+    pause() { this.paused = true; this.pauseCount++; },
+    play() { this.paused = false; this.playCount++; },
+    getBoundingClientRect() { return { left: 100, top: 50, width: 800, height: 450 }; },
+  };
+  const storageListeners = [];
+  const intervals = [];
+  const toasts = [];
+  const storageSets = [];
+  const clipboard = [];
+  const windowObj = {
+    hibikiEpisodeCues: opts.store || {},
+    postMessage() {},
+    addEventListener() {},
+    hibikiToast: (m) => toasts.push(m),
+  };
+  const documentObj = {
+    body,
+    fullscreenElement: null,
+    addEventListener() {},
+    getElementById: (id) => findByIdDeep(body, id),
+    querySelector: (sel) => (sel === 'video' ? video : null),
+    querySelectorAll: () => [],
+    createElement: (t) => makeEl(t),
+    createDocumentFragment: () => makeEl('fragment'),
+  };
+  const sandbox = {
+    window: windowObj,
+    document: documentObj,
+    location: { hostname: opts.hostname || 'example.com', pathname: opts.pathname || '/video/1', origin: 'https://example.com' },
+    setInterval: (fn, ms) => { intervals.push({ fn, ms }); return intervals.length; },
+    clearInterval() {},
+    navigator: { clipboard: { writeText: (t) => { clipboard.push(t); return { then() {} }; } } },
+    chrome: {
+      storage: {
+        local: {
+          get: (key, cb) => { if (typeof cb === 'function') { cb(opts.stored || {}); return undefined; } return { then(res) { res(opts.stored || {}); } }; },
+          set: (obj) => { storageSets.push(obj); },
+        },
+        onChanged: { addListener: (fn) => storageListeners.push(fn) },
+      },
+      runtime: { lastError: null, sendMessage() {} },
+    },
+  };
+  vm.runInNewContext(src, sandbox, { filename: 'subtitle-panel.js' });
+  return {
+    body, video, windowObj, toasts, storageSets, clipboard,
+    panel: () => findByIdDeep(body, 'hibiki-subtitle-panel'),
+    overlay: () => findByIdDeep(body, 'hibiki-subtitle-overlay'),
+    tick: () => { const t = intervals.find((it) => it.ms === 200); if (t) t.fn(); },
+    shortcut: (a) => windowObj.hibikiSubtitleShortcut(a),
+  };
+}
+
+// 预置「检测轨」（非外挂）：ja 轨两句 1.0–2.0s / 4.0–5.0s。
+function jaStore() {
+  return {
+    'example.com/video/1|ja': [
+      { startMs: 1000, endMs: 2000, text: '走り出した' },
+      { startMs: 4000, endMs: 5000, text: 'こんにちは' },
+    ],
+  };
+}
+
+test('检测轨也有时轴偏移：读取侧平移，store 不动', () => {
+  const h = loadPanel({ stored: { netflixSubtitlePanel: true }, store: jaStore() });
+  const panel = h.panel();
+  assert.ok(panel, '有轨时面板应显示');
+  const offsetBar = findByClassDeep(panel, 'hibiki-sub-offset')[0];
+  assert.ok(offsetBar, '检测轨也必须显示时轴偏移条（asb 全轨偏移）');
+  assert.notStrictEqual(offsetBar.style._props.display, 'none');
+  findBtnByTitle(offsetBar, '＋0.5')[0].fire('click');
+  assert.strictEqual(h.windowObj.hibikiEpisodeCues['example.com/video/1|ja'][0].startMs, 1000,
+    'store 保持原始 cue');
+  const ts = findByClassDeep(h.panel(), 'hibiki-sub-ts')[0];
+  ts.fire('click');
+  assert.strictEqual(h.video.currentTime, 1.5, '行 seek 用偏移后的 1500ms');
+});
+
+test('句首自动暂停：新句开播即暂停一次，恢复播放后同句不再回按', () => {
+  const h = loadPanel({
+    stored: { netflixSubtitlePanel: true, subtitleAutoPause: true, subtitleAutoPauseAtStart: true },
+    store: jaStore(),
+  });
+  h.video.currentTime = 1.1; // 句 1 开播 100ms（<400ms 句首窗）
+  h.tick();
+  assert.strictEqual(h.video.pauseCount, 1, '句首应暂停一次');
+  h.video.paused = false; // 用户继续播放
+  h.tick();
+  assert.strictEqual(h.video.pauseCount, 1, '同句不得再次暂停');
+  h.video.currentTime = 4.05; // 进句 2 句首
+  h.tick();
+  assert.strictEqual(h.video.pauseCount, 2, '下一句句首再暂停');
+});
+
+test('快进无字幕段：间隙 2.7x，进句恢复原速', () => {
+  const h = loadPanel({
+    stored: { netflixSubtitlePanel: true, subtitleFastForwardPlayback: true },
+    store: jaStore(),
+  });
+  h.video.currentTime = 2.5; // 句 1 之后的长间隙（距句 2 还有 1.5s）
+  h.tick();
+  assert.strictEqual(h.video.playbackRate, 2.7, '无字幕段应提速到 2.7x');
+  h.video.currentTime = 4.2; // 进句 2
+  h.tick();
+  assert.strictEqual(h.video.playbackRate, 1, '进句应恢复原速');
+});
+
+test('全轨覆盖层 + 防剧透模糊 + 悬停暂停', () => {
+  const off = loadPanel({ stored: { netflixSubtitlePanel: true }, store: jaStore() });
+  off.video.currentTime = 1.5;
+  off.tick();
+  assert.strictEqual(off.overlay(), null, '未开全轨覆盖层时检测轨不叠字');
+
+  const h = loadPanel({
+    stored: {
+      netflixSubtitlePanel: true, subtitleOverlayAllTracks: true,
+      subtitleOverlayBlur: true, subtitleHoverPause: true,
+    },
+    store: jaStore(),
+  });
+  h.video.currentTime = 1.5;
+  h.tick();
+  const overlay = h.overlay();
+  assert.ok(overlay, '开启全轨覆盖层后检测轨应叠字');
+  assert.strictEqual(overlay.textContent, '走り出した');
+  assert.strictEqual(overlay.style.filter, 'blur(6px)', '防剧透默认模糊');
+  overlay.fire('mouseenter');
+  assert.strictEqual(overlay.style.filter, '', '悬停即清晰');
+  assert.strictEqual(h.video.paused, true, '悬停暂停');
+  overlay.fire('mouseleave');
+  assert.strictEqual(h.video.paused, false, '移开恢复播放');
+  assert.strictEqual(overlay.style.filter, 'blur(6px)', '移开重新模糊');
+});
+
+test('快捷键执行端：上一句/下一句/重播/复制/切换模式', () => {
+  const h = loadPanel({ stored: { netflixSubtitlePanel: true }, store: jaStore() });
+  // 下一句：0ms → 句 1 句首。
+  assert.strictEqual(h.shortcut('next-cue'), true);
+  assert.strictEqual(h.video.currentTime, 1);
+  // 上一句：句 2 中间 → 句 1 句首（4500-600=3900 前最近句首是 1000）。
+  h.video.currentTime = 4.5;
+  assert.strictEqual(h.shortcut('prev-cue'), true);
+  assert.strictEqual(h.video.currentTime, 1);
+  // 重播本句：句内任意位置回句首。
+  h.video.currentTime = 1.8;
+  assert.strictEqual(h.shortcut('replay-cue'), true);
+  assert.strictEqual(h.video.currentTime, 1);
+  // 复制当前句到剪贴板（Hibiki 剪贴板监看联动）。
+  h.video.currentTime = 1.5;
+  assert.strictEqual(h.shortcut('copy-cue'), true);
+  assert.deepStrictEqual(h.clipboard, ['走り出した']);
+  // 切换精简播放：写穿 chrome.storage（options 页开关保持同步）。
+  assert.strictEqual(h.shortcut('toggle-condensed'), true);
+  assert.ok(h.storageSets.some((s) => s.subtitleCondensedPlayback === true), '必须写穿 storage');
+  // 偏移快捷键：+100ms 两次 → 行 seek 用 1200ms。
+  assert.strictEqual(h.shortcut('offset-plus'), true);
+  assert.strictEqual(h.shortcut('offset-plus'), true);
+  const ts = findByClassDeep(h.panel(), 'hibiki-sub-ts')[0];
+  ts.fire('click');
+  assert.strictEqual(h.video.currentTime, 1.2);
+  assert.ok(h.toasts.some((t) => t.indexOf('+0.2s') >= 0), '偏移量应有 toast 反馈');
+});

--- a/tools/browser-extension/subtitle-panel.js
+++ b/tools/browser-extension/subtitle-panel.js
@@ -554,7 +554,10 @@
           st.hoverPaused = false;
           var v = videoEl();
           if (v && typeof v.play === 'function') {
-            try { v.play(); } catch (_) {}
+            var resumed = v.play();
+            if (resumed && typeof resumed.catch === 'function') {
+              resumed.catch(function () {});
+            }
           }
         }
       });

--- a/tools/browser-extension/subtitle-panel.js
+++ b/tools/browser-extension/subtitle-panel.js
@@ -35,10 +35,18 @@
     langSelect: null, builtLang: null, builtLen: -1, builtCues: null,
     pushedEl: null, prevWidth: '', prevWidthPriority: '', tickTimer: null,
     pushSuspended: false, enabled: false,
-    // B（外挂字幕）：用户主动打开面板（即使暂无轨也不自动拆）；已加载外挂轨的原始 cue + 时轴偏移。
-    forceOpen: false, extTracks: Object.create(null), offsetBar: null, offsetLabel: null,
+    // B（外挂字幕）：用户主动打开面板（即使暂无轨也不自动拆）。
+    forceOpen: false, offsetBar: null, offsetLabel: null,
     overlayEnabled: true, dragDropEnabled: true, autoPause: false, condensedPlayback: false,
     overlayEl: null, overlayCue: null, dropHint: null, lastCondensedTargetMs: -1,
+    // asb 移植：任意轨（检测轨/外挂轨）的读取侧时轴偏移。store 永远存原始 cue，偏移只在
+    // 面板/覆盖层/快捷键**读取时**套用——provider（textTracks 收割 / live 采样 / 整集拦截）
+    // 增量刷新 store 不会与偏移打架。key = `${videoKey}|${lang}`，会话内记忆。
+    trackOffsets: Object.create(null), builtOffset: 0,
+    // asb 移植：句首自动暂停 / 快进无字幕段 / 悬停暂停 / 覆盖层防剧透模糊 / 全轨覆盖层。
+    autoPauseAtStart: false, fastForward: false, hoverPause: false,
+    overlayBlur: false, overlayAllTracks: false,
+    hoverPaused: false, overlayHovered: false, ffSavedRate: -1, lastAutoPauseIdx: -1,
   };
   var EXT_PREFIX = '外挂:';
 
@@ -134,6 +142,30 @@
       return a.lang < b.lang ? -1 : (a.lang > b.lang ? 1 : 0);
     });
     return out;
+  }
+
+  // ── asb 移植：读取侧时轴偏移（任意轨，subtitle-controller.ts offset() 的无破坏版） ──
+  function activeTrackKey() {
+    return st.activeLang ? (videoKey() + '|' + st.activeLang) : null;
+  }
+  function trackOffset(key) {
+    return (key && st.trackOffsets[key]) || 0;
+  }
+  function shiftedCues(base, off) {
+    if (!off) return base;
+    var out = [];
+    for (var i = 0; i < base.length; i++) {
+      var c = base[i];
+      out.push({
+        startMs: Math.max(0, c.startMs + off),
+        endMs: Math.max(0, c.endMs + off),
+        text: c.text,
+      });
+    }
+    return out;
+  }
+  function fmtOffset(ms) {
+    return (ms >= 0 ? '+' : '') + (ms / 1000).toFixed(1) + 's';
   }
 
   function cueIndexAt(cues, t) {
@@ -256,7 +288,7 @@
     st.langSelect = langSelect;
     header.appendChild(langSelect);
 
-    // B（asb 招牌）：外挂字幕时轴偏移条——仅当前轨是外挂字幕时显示。−/＋ 微调让字幕对齐视频。
+    // asb 移植：字幕时轴偏移条——任意当前轨（检测轨/外挂轨）都可偏移。−/＋ 微调让字幕对齐视频。
     var offsetBar = document.createElement('div');
     offsetBar.className = 'hibiki-sub-offset';
     offsetBar.style.display = 'none';
@@ -321,13 +353,37 @@
     st.autoScroll = c.subtitleAutoScroll !== false;
     st.autoPause = c.subtitleAutoPause === true;
     st.condensedPlayback = c.subtitleCondensedPlayback === true;
+    // asb 移植的扩展偏好（全部默认关，除快捷键在 video-shortcuts.js 自持默认开）。
+    st.autoPauseAtStart = c.subtitleAutoPauseAtStart === true;
+    st.fastForward = c.subtitleFastForwardPlayback === true;
+    st.hoverPause = c.subtitleHoverPause === true;
+    st.overlayBlur = c.subtitleOverlayBlur === true;
+    st.overlayAllTracks = c.subtitleOverlayAllTracks === true;
     if (!st.overlayEnabled) hideSubtitleOverlay();
+  }
+
+  // 当前偏好快照（快捷键 toggle 用：改一个键、其余保持现值，绝不把用户已关的项刷回默认）。
+  function prefsSnapshot() {
+    return {
+      subtitleOverlayEnabled: st.overlayEnabled,
+      subtitleDragDropEnabled: st.dragDropEnabled,
+      subtitleAutoScroll: st.autoScroll,
+      subtitleAutoPause: st.autoPause,
+      subtitleCondensedPlayback: st.condensedPlayback,
+      subtitleAutoPauseAtStart: st.autoPauseAtStart,
+      subtitleFastForwardPlayback: st.fastForward,
+      subtitleHoverPause: st.hoverPause,
+      subtitleOverlayBlur: st.overlayBlur,
+      subtitleOverlayAllTracks: st.overlayAllTracks,
+    };
   }
 
   function readSubtitlePreferences() {
     var keys = [
       'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
       'subtitleAutoPause', 'subtitleCondensedPlayback',
+      'subtitleAutoPauseAtStart', 'subtitleFastForwardPlayback', 'subtitleHoverPause',
+      'subtitleOverlayBlur', 'subtitleOverlayAllTracks',
     ];
     try {
       var p = chrome.storage.local.get(keys);
@@ -364,9 +420,12 @@
   function rebuildList(tracks) {
     var active = null;
     for (var i = 0; i < tracks.length; i++) if (tracks[i].lang === st.activeLang) active = tracks[i];
-    st.cues = active ? active.cues : [];
-    if (st.builtLang === st.activeLang && st.builtLen === st.cues.length &&
-        st.builtCues === st.cues) {
+    // asb 移植：偏移在读取侧套用——store 里 base cues 不动，st.cues 是（必要时）平移后的视图。
+    var base = active ? active.cues : [];
+    var off = trackOffset(active ? active.key : null);
+    st.cues = shiftedCues(base, off);
+    if (st.builtLang === st.activeLang && st.builtLen === base.length &&
+        st.builtCues === base && st.builtOffset === off) {
       // BUG-1029：live cue 逐字扩长时数组和长度都不变。沿用行节点，只刷新文本/时间戳；
       // 这样不会重建长列表，也不会把每个中间快照追加成一行。
       for (var n = 0; n < st.cues.length; n++) {
@@ -395,7 +454,8 @@
       list.appendChild(empty);
       st.builtLang = st.activeLang;
       st.builtLen = 0;
-      st.builtCues = st.cues;
+      st.builtCues = base;
+      st.builtOffset = off;
       return;
     }
     var frag = document.createDocumentFragment();
@@ -404,8 +464,9 @@
     }
     list.appendChild(frag);
     st.builtLang = st.activeLang;
-    st.builtLen = st.cues.length;
-    st.builtCues = st.cues;
+    st.builtLen = base.length;
+    st.builtCues = base;
+    st.builtOffset = off;
   }
 
   function buildRow(cue, idx) {
@@ -474,11 +535,41 @@
           });
         }
       });
+      // asb 移植：悬停暂停（pause-on-hover）——鼠标进覆盖层即暂停，方便查词；移出且确实是
+      // 因悬停而暂停时恢复播放（用户自己按的暂停不动）。防剧透模糊（blur）同一对监听里处理。
+      el.addEventListener('mouseenter', function () {
+        st.overlayHovered = true;
+        applyOverlayBlur(el);
+        if (st.hoverPause) {
+          var v = videoEl();
+          if (v && !v.paused && typeof v.pause === 'function') {
+            try { v.pause(); st.hoverPaused = true; } catch (_) {}
+          }
+        }
+      });
+      el.addEventListener('mouseleave', function () {
+        st.overlayHovered = false;
+        applyOverlayBlur(el);
+        if (st.hoverPaused) {
+          st.hoverPaused = false;
+          var v = videoEl();
+          if (v && typeof v.play === 'function') {
+            try { v.play(); } catch (_) {}
+          }
+        }
+      });
       st.overlayEl = el;
     }
     var parent = parentForOverlay();
     if (st.overlayEl.parentNode !== parent) parent.appendChild(st.overlayEl);
     return st.overlayEl;
+  }
+
+  // asb 移植：防剧透模糊——覆盖层默认糊住，悬停即清晰（顺带触发悬停暂停，看+查一体）。
+  function applyOverlayBlur(el) {
+    if (!el || !el.style) return;
+    var blurred = st.overlayBlur && !st.overlayHovered;
+    try { el.style.filter = blurred ? 'blur(6px)' : ''; } catch (_) {}
   }
 
   function hideSubtitleOverlay() {
@@ -487,7 +578,10 @@
   }
 
   function updateSubtitleOverlay(cue) {
-    if (!st.overlayEnabled || !isExternalLang(st.activeLang) || !cue) {
+    // 外挂轨恒显示；检测轨（站点自带字幕）默认不重复叠字，除非用户开了「全轨覆盖层」
+    // （overlayAllTracks，配合防剧透模糊/悬停暂停使用）。
+    if (!st.overlayEnabled || !cue ||
+        (!isExternalLang(st.activeLang) && !st.overlayAllTracks)) {
       hideSubtitleOverlay();
       return;
     }
@@ -502,6 +596,7 @@
     el.style.left = (rect.left + rect.width / 2) + 'px';
     el.style.top = (rect.top + rect.height * 0.84) + 'px';
     el.style.maxWidth = Math.max(240, rect.width * 0.9) + 'px';
+    applyOverlayBlur(el);
   }
 
   function firstCueAfter(ms) {
@@ -517,11 +612,23 @@
     var video = videoEl();
     if (!video) return;
     var previous = st.currentIndex;
-    if (st.autoPause && previous >= 0 && idx < 0 &&
+    // 自动暂停·句尾（既有默认）：上一句刚结束、尚未进入下一句时暂停。
+    if (st.autoPause && !st.autoPauseAtStart && previous >= 0 && idx < 0 &&
         nowMs >= st.cues[previous].endMs && typeof video.pause === 'function') {
       try { video.pause(); } catch (_) {}
       return;
     }
+    // asb 移植（AutoPausePreference.atStart）：自动暂停·句首——新句刚开播（<400ms，避免
+    // seek 进句中被误暂停）时暂停一次；同一句只暂停一次（用户继续播放后不再回按）。
+    if (st.autoPause && st.autoPauseAtStart && idx >= 0 && idx !== previous &&
+        idx !== st.lastAutoPauseIdx && nowMs - st.cues[idx].startMs < 400 &&
+        !video.paused && typeof video.pause === 'function') {
+      try { video.pause(); } catch (_) {}
+      st.lastAutoPauseIdx = idx;
+      return;
+    }
+    if (idx < 0) st.lastAutoPauseIdx = -1;
+    applyFastForward(video, idx, nowMs);
     if (!st.condensedPlayback || st.autoPause || idx >= 0 || video.paused) {
       if (idx >= 0) st.lastCondensedTargetMs = -1;
       return;
@@ -532,6 +639,27 @@
     if (target - nowMs < 800 || target === st.lastCondensedTargetMs) return;
     st.lastCondensedTargetMs = target;
     seekTo(target);
+  }
+
+  // asb 移植（fastForward 播放模式）：无字幕区间倍速播过（asb 默认 2.7x），进句恢复原速。
+  // 与精简播放（直接跳过）互斥——精简开启时优先跳过；自动暂停开启时两者都不动。
+  function applyFastForward(video, idx, nowMs) {
+    var eligible = st.fastForward && !st.autoPause && !st.condensedPlayback &&
+        typeof video.playbackRate === 'number';
+    var inGap = false;
+    if (eligible && idx < 0 && !video.paused && st.cues.length) {
+      var next = firstCueAfter(nowMs + 250);
+      if (next >= 0 && st.cues[next].startMs - nowMs >= 800) inGap = true;
+    }
+    if (inGap) {
+      if (st.ffSavedRate < 0) {
+        st.ffSavedRate = video.playbackRate > 0 ? video.playbackRate : 1;
+        try { video.playbackRate = 2.7; } catch (_) {}
+      }
+    } else if (st.ffSavedRate >= 0) {
+      try { video.playbackRate = st.ffSavedRate; } catch (_) {}
+      st.ffSavedRate = -1;
+    }
   }
 
   function ensureMounted() {
@@ -652,8 +780,10 @@
     if (!base.length) { toast('字幕为空'); return; }
     var label = EXT_PREFIX + String(filename).replace(/\|/g, '_');
     var key = videoKey() + '|' + label;
-    st.extTracks[key] = { baseCues: base, offsetMs: 0 };
-    writeExternalTrack(key);
+    // 外挂轨与检测轨同构：store 存原始 cue，偏移走统一的读取侧 trackOffsets（重新加载即归零）。
+    var store = window.hibikiEpisodeCues || (window.hibikiEpisodeCues = Object.create(null));
+    store[key] = base;
+    delete st.trackOffsets[key];
     st.activeLang = label;
     st.builtLang = null;
     st.forceOpen = true;
@@ -724,53 +854,138 @@
     }
     for (var i = 0; i < files.length; i++) loadSubtitleFile(files[i]);
   }, true);
-  // 把外挂轨（原始 cue + 当前偏移）写进 store，供面板/查词消费。偏移让字幕对齐视频时轴。
-  function writeExternalTrack(key) {
-    var t = st.extTracks[key];
-    if (!t) return;
-    var store = window.hibikiEpisodeCues || (window.hibikiEpisodeCues = Object.create(null));
-    var out = [];
-    for (var i = 0; i < t.baseCues.length; i++) {
-      var c = t.baseCues[i];
-      out.push({
-        startMs: Math.max(0, c.startMs + t.offsetMs),
-        endMs: Math.max(0, c.endMs + t.offsetMs),
-        text: c.text,
-      });
-    }
-    store[key] = out;
-  }
-  function activeExternalKey() {
-    if (!isExternalLang(st.activeLang)) return null;
-    var key = videoKey() + '|' + st.activeLang;
-    return st.extTracks[key] ? key : null;
-  }
+  // asb 移植：偏移操作对**任意当前轨**生效（读取侧 trackOffsets，见 st 定义处注释）。
   function nudgeOffset(deltaMs) {
-    var key = activeExternalKey();
+    var key = activeTrackKey();
     if (!key) return;
-    st.extTracks[key].offsetMs += deltaMs;
-    writeExternalTrack(key);
+    st.trackOffsets[key] = (st.trackOffsets[key] || 0) + deltaMs;
     st.builtLang = null; // 时间戳变了 → 强制列表重建
     refresh();
   }
   function resetOffset() {
-    var key = activeExternalKey();
+    var key = activeTrackKey();
     if (!key) return;
-    st.extTracks[key].offsetMs = 0;
-    writeExternalTrack(key);
+    delete st.trackOffsets[key];
     st.builtLang = null;
     refresh();
   }
   function updateOffsetBar() {
     if (!st.offsetBar) return;
-    var key = activeExternalKey();
-    if (!key) { st.offsetBar.style.display = 'none'; return; }
+    var key = activeTrackKey();
+    if (!key || !st.cues.length) { st.offsetBar.style.display = 'none'; return; }
     st.offsetBar.style.display = '';
-    var ms = st.extTracks[key].offsetMs;
-    if (st.offsetLabel) {
-      st.offsetLabel.textContent = (ms >= 0 ? '+' : '') + (ms / 1000).toFixed(1) + 's';
-    }
+    if (st.offsetLabel) st.offsetLabel.textContent = fmtOffset(trackOffset(key));
   }
+
+  // ── asb 移植：快捷键执行端 ──
+  // video-shortcuts.js（同隔离世界、本文件之后加载）判定按键 → 调这里执行。面板持有轨/偏移/
+  // 模式状态，所以动作收敛在本文件；面板未打开（甚至未启用）时快捷键也要能用——此时隐式选
+  // 当前视频的第一条轨。返回 true = 已接管（调用方 preventDefault），false = 放行给站点。
+  function lastCueStartBefore(ms) {
+    var lo = 0, hi = st.cues.length - 1, ans = -1;
+    while (lo <= hi) {
+      var mid = (lo + hi) >> 1;
+      if (st.cues[mid].startMs < ms) { ans = mid; lo = mid + 1; } else { hi = mid - 1; }
+    }
+    return ans;
+  }
+  // 面板没开时 st.cues 可能为空/过期：从 store 重取当前轨（含读取侧偏移）。
+  function recomputeShortcutCues() {
+    var tracks = tracksForVideo();
+    var active = null;
+    for (var i = 0; i < tracks.length; i++) if (tracks[i].lang === st.activeLang) active = tracks[i];
+    if (!active && tracks.length) { st.activeLang = tracks[0].lang; active = tracks[0]; }
+    st.cues = active ? shiftedCues(active.cues, trackOffset(active.key)) : [];
+  }
+  function shortcutSeekPrev() {
+    if (!st.cues.length) return false;
+    // 上一句：开播 >600ms 时先回本句句首（与播放器「上一曲」惯例一致），再按一次才到上一句。
+    var i = lastCueStartBefore(videoTimeMs() - 600);
+    if (i < 0) return false;
+    seekTo(st.cues[i].startMs);
+    return true;
+  }
+  function shortcutSeekNext() {
+    if (!st.cues.length) return false;
+    var i = firstCueAfter(videoTimeMs());
+    if (i < 0) return false;
+    seekTo(st.cues[i].startMs);
+    return true;
+  }
+  function shortcutReplay() {
+    if (!st.cues.length) return false;
+    var now = videoTimeMs();
+    var idx = cueIndexAt(st.cues, now);
+    if (idx < 0) idx = lastCueStartBefore(now);
+    if (idx < 0) return false;
+    seekTo(st.cues[idx].startMs);
+    return true;
+  }
+  function shortcutOffset(deltaMs) {
+    var key = activeTrackKey();
+    if (!key || !st.cues.length) return false;
+    if (deltaMs === 0) delete st.trackOffsets[key];
+    else st.trackOffsets[key] = (st.trackOffsets[key] || 0) + deltaMs;
+    if (st.panel && st.panel.parentNode && !st.hidden) { st.builtLang = null; refresh(); }
+    else recomputeShortcutCues();
+    toast('字幕偏移 ' + fmtOffset(trackOffset(key)));
+    return true;
+  }
+  function shortcutCopyCue() {
+    if (!st.cues.length) return false;
+    var now = videoTimeMs();
+    var idx = cueIndexAt(st.cues, now);
+    if (idx < 0) idx = lastCueStartBefore(now);
+    if (idx < 0) return false;
+    var text = st.cues[idx].text;
+    try {
+      if (typeof navigator === 'undefined' || !navigator.clipboard ||
+          typeof navigator.clipboard.writeText !== 'function') return false;
+      navigator.clipboard.writeText(text);
+    } catch (_) { return false; }
+    toast('已复制字幕：' + (text.length > 30 ? text.slice(0, 30) + '…' : text));
+    return true;
+  }
+  function togglePref(key, label) {
+    var snap = prefsSnapshot();
+    var next = snap[key] !== true;
+    snap[key] = next;
+    applySubtitlePreferences(snap); // 先行生效（无 chrome 环境的单测同样生效）
+    try { var patch = {}; patch[key] = next; chrome.storage.local.set(patch); } catch (_) {}
+    toast(label + (next ? '：开' : '：关'));
+    return true;
+  }
+  function shortcutTogglePanel() {
+    if (!st.enabled) {
+      st.forceOpen = true;
+      try { chrome.storage.local.set({ netflixSubtitlePanel: true }); } catch (_) {}
+      applyEnabled(true);
+    } else if (st.hidden || !st.panel || !st.panel.parentNode) {
+      st.forceOpen = true;
+      showPanel();
+    } else {
+      hidePanel();
+    }
+    return true;
+  }
+  window.hibikiSubtitleShortcut = function (action) {
+    if (!videoEl()) return false;
+    if (!st.cues.length) recomputeShortcutCues();
+    switch (action) {
+      case 'prev-cue': return shortcutSeekPrev();
+      case 'next-cue': return shortcutSeekNext();
+      case 'replay-cue': return shortcutReplay();
+      case 'offset-minus': return shortcutOffset(-100);
+      case 'offset-plus': return shortcutOffset(100);
+      case 'offset-reset': return shortcutOffset(0);
+      case 'copy-cue': return shortcutCopyCue();
+      case 'toggle-autopause': return togglePref('subtitleAutoPause', '自动暂停');
+      case 'toggle-condensed': return togglePref('subtitleCondensedPlayback', '精简播放');
+      case 'toggle-fastforward': return togglePref('subtitleFastForwardPlayback', '快进无字幕段');
+      case 'toggle-panel': return shortcutTogglePanel();
+    }
+    return false;
+  };
 
   // TODO-1219 P3：Netflix 批量录制（content.js hibikiRunNetflixBatch）录整标签页前调用，撤销推挤让
   // 播放器全宽（录制画面不带面板黑边）；录完调 resume 重挂。挂起期间 applyPush 被 pushSuspended 门控。
@@ -808,20 +1023,19 @@
     chrome.storage.onChanged.addListener(function (changes, area) {
       if (area !== 'local' || !changes) return;
       if (changes[SETTING_KEY]) applyEnabled(changes[SETTING_KEY].newValue === true);
-      var prefs = {};
+      // 以当前值快照为底、只覆盖真正变化的键——单键变更绝不把其它偏好刷回默认。
+      var prefs = prefsSnapshot();
       var changed = false;
-      var keys = ['subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll', 'subtitleAutoPause', 'subtitleCondensedPlayback'];
+      var keys = [
+        'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
+        'subtitleAutoPause', 'subtitleCondensedPlayback',
+        'subtitleAutoPauseAtStart', 'subtitleFastForwardPlayback', 'subtitleHoverPause',
+        'subtitleOverlayBlur', 'subtitleOverlayAllTracks',
+      ];
       for (var i = 0; i < keys.length; i++) {
         if (changes[keys[i]]) { prefs[keys[i]] = changes[keys[i]].newValue; changed = true; }
       }
-      if (changed) {
-        prefs.subtitleOverlayEnabled = prefs.subtitleOverlayEnabled == null ? st.overlayEnabled : prefs.subtitleOverlayEnabled;
-        prefs.subtitleDragDropEnabled = prefs.subtitleDragDropEnabled == null ? st.dragDropEnabled : prefs.subtitleDragDropEnabled;
-        prefs.subtitleAutoScroll = prefs.subtitleAutoScroll == null ? st.autoScroll : prefs.subtitleAutoScroll;
-        prefs.subtitleAutoPause = prefs.subtitleAutoPause == null ? st.autoPause : prefs.subtitleAutoPause;
-        prefs.subtitleCondensedPlayback = prefs.subtitleCondensedPlayback == null ? st.condensedPlayback : prefs.subtitleCondensedPlayback;
-        applySubtitlePreferences(prefs);
-      }
+      if (changed) applySubtitlePreferences(prefs);
     });
   } catch (_) {}
 

--- a/tools/browser-extension/subtitle-panel.js
+++ b/tools/browser-extension/subtitle-panel.js
@@ -554,10 +554,7 @@
           st.hoverPaused = false;
           var v = videoEl();
           if (v && typeof v.play === 'function') {
-            var resumed = v.play();
-            if (resumed && typeof resumed.catch === 'function') {
-              resumed.catch(function () {});
-            }
+            Promise.resolve(v.play()).catch(function () {});
           }
         }
       });
@@ -941,11 +938,9 @@
     if (idx < 0) idx = lastCueStartBefore(now);
     if (idx < 0) return false;
     var text = st.cues[idx].text;
-    try {
-      if (typeof navigator === 'undefined' || !navigator.clipboard ||
-          typeof navigator.clipboard.writeText !== 'function') return false;
-      navigator.clipboard.writeText(text);
-    } catch (_) { return false; }
+    if (typeof navigator === 'undefined' || !navigator.clipboard ||
+        typeof navigator.clipboard.writeText !== 'function') return false;
+    Promise.resolve(navigator.clipboard.writeText(text)).catch(function () {});
     toast('已复制字幕：' + (text.length > 30 ? text.slice(0, 30) + '…' : text));
     return true;
   }

--- a/tools/browser-extension/video-shortcuts.js
+++ b/tools/browser-extension/video-shortcuts.js
@@ -1,0 +1,147 @@
+// asb 移植：视频页快捷键（content script 隔离世界，manifest bundle 里排在 subtitle-panel.js
+// 之后加载）。键位与 asbplayer 默认键对齐（差异见 README「快捷键」表）：
+//   ←/→        上一句 / 下一句字幕（仅当前视频有字幕轨时接管，否则放行给站点）
+//   ↑           回当前句句首重播
+//   Shift+P/O/F 开关 自动暂停 / 精简播放 / 快进无字幕段
+//   Shift+S     开关字幕列表面板
+//   Ctrl+Shift+←/→/↓  字幕时轴偏移 −100ms / ＋100ms / 重置
+//   Ctrl+Shift+Z      复制当前字幕句到剪贴板（配合 Hibiki 剪贴板监看即查词）
+//   Ctrl+Shift+[ / ]  播放速度 −0.25x / ＋0.25x
+// 判定是纯函数 decide()（node 可测）；执行端是 subtitle-panel.js 暴露的
+// window.hibikiSubtitleShortcut(action)（面板持有轨/偏移/模式状态），播放速度直接操作 <video>。
+// 输入框/可编辑区一律放行；options 的 videoShortcutsEnabled（默认开）可整体关闭。
+(function (root, factory) {
+  var api = factory();
+  try { if (typeof module !== 'undefined' && module.exports) module.exports = api; } catch (_) { /* no-op */ }
+  if (root) root.HIBIKI_VIDEO_SHORTCUTS = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // 纯函数按键判定。ev = {key, code, ctrl, shift, alt, editable}；
+  // ctx = {enabled, hasVideo, hasTrack}。返回 {action} 或 null（null = 不接管，放行给站点）。
+  function decide(ev, ctx) {
+    if (!ev || !ctx || !ctx.enabled || ev.editable || !ctx.hasVideo) return null;
+    if (ev.alt) return null;
+    var key = ev.key || '';
+    var code = ev.code || '';
+    if (ev.ctrl && ev.shift) {
+      if (key === 'ArrowLeft') return ctx.hasTrack ? { action: 'offset-minus' } : null;
+      if (key === 'ArrowRight') return ctx.hasTrack ? { action: 'offset-plus' } : null;
+      if (key === 'ArrowDown') return ctx.hasTrack ? { action: 'offset-reset' } : null;
+      if (code === 'KeyZ') return ctx.hasTrack ? { action: 'copy-cue' } : null;
+      // 括号键在 Shift 下 e.key 会变成 '{' / '}'，用布局无关的 e.code。
+      if (code === 'BracketLeft') return { action: 'rate-down' };
+      if (code === 'BracketRight') return { action: 'rate-up' };
+      return null;
+    }
+    if (ev.ctrl) return null;
+    if (ev.shift) {
+      if (code === 'KeyP') return { action: 'toggle-autopause' };
+      if (code === 'KeyO') return { action: 'toggle-condensed' };
+      if (code === 'KeyF') return { action: 'toggle-fastforward' };
+      if (code === 'KeyS') return { action: 'toggle-panel' };
+      return null;
+    }
+    if (key === 'ArrowLeft') return ctx.hasTrack ? { action: 'prev-cue' } : null;
+    if (key === 'ArrowRight') return ctx.hasTrack ? { action: 'next-cue' } : null;
+    if (key === 'ArrowUp') return ctx.hasTrack ? { action: 'replay-cue' } : null;
+    return null;
+  }
+
+  // 播放速度步进（clamp 0.25–4，步长由调用方传）。返回 clamp 后的新值。
+  function nextRate(current, delta) {
+    var cur = typeof current === 'number' && current > 0 ? current : 1;
+    return Math.round(Math.min(4, Math.max(0.25, cur + delta)) * 100) / 100;
+  }
+
+  return { decide: decide, nextRate: nextRate };
+});
+
+// ── 浏览器运行时（node 单测里 window/document 缺省 → 整段跳过）──
+(function () {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  var api = (typeof self !== 'undefined' ? self : window).HIBIKI_VIDEO_SHORTCUTS;
+  var enabled = true;
+
+  function applyEnabled(saved) {
+    // 缺省/非 false 一律视为开启（默认开）。
+    enabled = !(saved && saved.videoShortcutsEnabled === false);
+  }
+  try {
+    var p = chrome.storage.local.get('videoShortcutsEnabled');
+    if (p && typeof p.then === 'function') p.then(applyEnabled, function () {});
+    else chrome.storage.local.get('videoShortcutsEnabled', applyEnabled);
+  } catch (_) {}
+  try {
+    chrome.storage.onChanged.addListener(function (changes, area) {
+      if (area !== 'local' || !changes || !changes.videoShortcutsEnabled) return;
+      enabled = changes.videoShortcutsEnabled.newValue !== false;
+    });
+  } catch (_) {}
+
+  function isEditable(t) {
+    if (!t) return false;
+    if (t.isContentEditable) return true;
+    var tag = String(t.tagName || '').toUpperCase();
+    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+  }
+
+  // 当前视频是否已有任一字幕轨（store key 前缀匹配，与 subtitle-panel 同一契约）。
+  function hasTrackForVideo() {
+    var store = window.hibikiEpisodeCues;
+    if (!store || typeof window.hibikiVideoKey !== 'function') return false;
+    var vid;
+    try { vid = String(window.hibikiVideoKey()); } catch (_) { return false; }
+    if (!vid) return false;
+    for (var k in store) {
+      if (k.indexOf(vid + '|') === 0 && store[k] && store[k].length) return true;
+    }
+    return false;
+  }
+
+  function adjustRate(delta) {
+    var v = document.querySelector('video');
+    if (!v || typeof v.playbackRate !== 'number') return false;
+    var next = api.nextRate(v.playbackRate, delta);
+    try { v.playbackRate = next; } catch (_) { return false; }
+    try {
+      if (typeof window.hibikiToast === 'function') window.hibikiToast('播放速度 ' + next + 'x');
+    } catch (_) {}
+    return true;
+  }
+
+  // capture 阶段监听，接管时 stopPropagation 压过站点自己的键位（asb 同款策略）；
+  // 未接管（decide 返回 null / 执行端没接住）绝不动事件，站点行为原样。
+  window.addEventListener('keydown', function (e) {
+    // 廉价预筛：绝大多数按键（无修饰的普通打字）直接跳过，不查 DOM。
+    if (!e.shiftKey && !e.ctrlKey && !e.metaKey &&
+        e.key !== 'ArrowLeft' && e.key !== 'ArrowRight' && e.key !== 'ArrowUp') {
+      return;
+    }
+    var decision = api.decide(
+      {
+        key: e.key,
+        code: e.code,
+        ctrl: e.ctrlKey || e.metaKey,
+        shift: e.shiftKey,
+        alt: e.altKey,
+        editable: isEditable(e.target),
+      },
+      {
+        enabled: enabled,
+        hasVideo: !!document.querySelector('video'),
+        hasTrack: hasTrackForVideo(),
+      });
+    if (!decision) return;
+    var handled = false;
+    if (decision.action === 'rate-up') handled = adjustRate(0.25);
+    else if (decision.action === 'rate-down') handled = adjustRate(-0.25);
+    else if (typeof window.hibikiSubtitleShortcut === 'function') {
+      handled = window.hibikiSubtitleShortcut(decision.action) === true;
+    }
+    if (handled) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }, true);
+})();

--- a/tools/browser-extension/video-shortcuts.js
+++ b/tools/browser-extension/video-shortcuts.js
@@ -36,6 +36,7 @@
     }
     if (ev.ctrl) return null;
     if (ev.shift) {
+      if (!ctx.hasTrack) return null;
       if (code === 'KeyP') return { action: 'toggle-autopause' };
       if (code === 'KeyO') return { action: 'toggle-condensed' };
       if (code === 'KeyF') return { action: 'toggle-fastforward' };

--- a/tools/browser-extension/video-shortcuts.test.js
+++ b/tools/browser-extension/video-shortcuts.test.js
@@ -1,0 +1,72 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { decide, nextRate } = require('./video-shortcuts.js');
+
+// asb 移植：视频页快捷键判定矩阵。decide 是纯函数：ev={key,code,ctrl,shift,alt,editable}，
+// ctx={enabled,hasVideo,hasTrack}，返回 {action} 或 null（null = 放行给站点）。
+
+const CTX = { enabled: true, hasVideo: true, hasTrack: true };
+
+function ev(over) {
+  return Object.assign({ key: '', code: '', ctrl: false, shift: false, alt: false, editable: false }, over);
+}
+
+test('←/→/↑：有轨时接管为上一句/下一句/重播本句', () => {
+  assert.deepStrictEqual(decide(ev({ key: 'ArrowLeft' }), CTX), { action: 'prev-cue' });
+  assert.deepStrictEqual(decide(ev({ key: 'ArrowRight' }), CTX), { action: 'next-cue' });
+  assert.deepStrictEqual(decide(ev({ key: 'ArrowUp' }), CTX), { action: 'replay-cue' });
+});
+
+test('←/→/↑：无字幕轨一律放行（站点自己的 5s 快进/音量不被抢）', () => {
+  const noTrack = { enabled: true, hasVideo: true, hasTrack: false };
+  assert.strictEqual(decide(ev({ key: 'ArrowLeft' }), noTrack), null);
+  assert.strictEqual(decide(ev({ key: 'ArrowRight' }), noTrack), null);
+  assert.strictEqual(decide(ev({ key: 'ArrowUp' }), noTrack), null);
+});
+
+test('Shift+P/O/F/S：切换播放模式与面板（无轨也可用）', () => {
+  const noTrack = { enabled: true, hasVideo: true, hasTrack: false };
+  assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyP' }), noTrack), { action: 'toggle-autopause' });
+  assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyO' }), CTX), { action: 'toggle-condensed' });
+  assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyF' }), CTX), { action: 'toggle-fastforward' });
+  assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyS' }), CTX), { action: 'toggle-panel' });
+});
+
+test('Ctrl+Shift+←/→/↓/Z：偏移与复制（需字幕轨）', () => {
+  assert.deepStrictEqual(decide(ev({ ctrl: true, shift: true, key: 'ArrowLeft' }), CTX), { action: 'offset-minus' });
+  assert.deepStrictEqual(decide(ev({ ctrl: true, shift: true, key: 'ArrowRight' }), CTX), { action: 'offset-plus' });
+  assert.deepStrictEqual(decide(ev({ ctrl: true, shift: true, key: 'ArrowDown' }), CTX), { action: 'offset-reset' });
+  assert.deepStrictEqual(decide(ev({ ctrl: true, shift: true, code: 'KeyZ' }), CTX), { action: 'copy-cue' });
+  const noTrack = { enabled: true, hasVideo: true, hasTrack: false };
+  assert.strictEqual(decide(ev({ ctrl: true, shift: true, code: 'KeyZ' }), noTrack), null);
+});
+
+test('Ctrl+Shift+[ / ]：变速用布局无关的 e.code（Shift 下 e.key 是 { }）', () => {
+  assert.deepStrictEqual(
+    decide(ev({ ctrl: true, shift: true, key: '{', code: 'BracketLeft' }), CTX),
+    { action: 'rate-down' });
+  assert.deepStrictEqual(
+    decide(ev({ ctrl: true, shift: true, key: '}', code: 'BracketRight' }), CTX),
+    { action: 'rate-up' });
+});
+
+test('输入框/可编辑区/Alt 组合/关闭开关/无视频：一律放行', () => {
+  assert.strictEqual(decide(ev({ key: 'ArrowLeft', editable: true }), CTX), null);
+  assert.strictEqual(decide(ev({ key: 'ArrowLeft', alt: true }), CTX), null);
+  assert.strictEqual(decide(ev({ key: 'ArrowLeft' }), { enabled: false, hasVideo: true, hasTrack: true }), null);
+  assert.strictEqual(decide(ev({ key: 'ArrowLeft' }), { enabled: true, hasVideo: false, hasTrack: true }), null);
+});
+
+test('普通打字（Shift+字母之外）不接管', () => {
+  assert.strictEqual(decide(ev({ key: 'a', code: 'KeyA' }), CTX), null);
+  assert.strictEqual(decide(ev({ shift: true, code: 'KeyQ' }), CTX), null);
+  assert.strictEqual(decide(ev({ ctrl: true, code: 'KeyC' }), CTX), null); // Ctrl+C 复制绝不抢
+});
+
+test('nextRate：0.25 步进、clamp 0.25–4', () => {
+  assert.strictEqual(nextRate(1, 0.25), 1.25);
+  assert.strictEqual(nextRate(1, -0.25), 0.75);
+  assert.strictEqual(nextRate(0.25, -0.25), 0.25);
+  assert.strictEqual(nextRate(4, 0.25), 4);
+  assert.strictEqual(nextRate(undefined, 0.25), 1.25); // 坏输入按 1x 起步
+});

--- a/tools/browser-extension/video-shortcuts.test.js
+++ b/tools/browser-extension/video-shortcuts.test.js
@@ -1,5 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const vm = require('node:vm');
 const { decide, nextRate } = require('./video-shortcuts.js');
 
 // asb 移植：视频页快捷键判定矩阵。decide 是纯函数：ev={key,code,ctrl,shift,alt,editable}，
@@ -24,9 +26,13 @@ test('←/→/↑：无字幕轨一律放行（站点自己的 5s 快进/音量�
   assert.strictEqual(decide(ev({ key: 'ArrowUp' }), noTrack), null);
 });
 
-test('Shift+P/O/F/S：切换播放模式与面板（无轨也可用）', () => {
+test('Shift+P/O/F/S：仅有 Hibiki 字幕轨时切换播放模式与面板', () => {
   const noTrack = { enabled: true, hasVideo: true, hasTrack: false };
-  assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyP' }), noTrack), { action: 'toggle-autopause' });
+  assert.strictEqual(decide(ev({ shift: true, code: 'KeyP' }), noTrack), null);
+  assert.strictEqual(decide(ev({ shift: true, code: 'KeyO' }), noTrack), null);
+  assert.strictEqual(decide(ev({ shift: true, code: 'KeyF' }), noTrack), null);
+  assert.strictEqual(decide(ev({ shift: true, code: 'KeyS' }), noTrack), null);
+  assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyP' }), CTX), { action: 'toggle-autopause' });
   assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyO' }), CTX), { action: 'toggle-condensed' });
   assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyF' }), CTX), { action: 'toggle-fastforward' });
   assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyS' }), CTX), { action: 'toggle-panel' });
@@ -69,4 +75,49 @@ test('nextRate：0.25 步进、clamp 0.25–4', () => {
   assert.strictEqual(nextRate(0.25, -0.25), 0.25);
   assert.strictEqual(nextRate(4, 0.25), 4);
   assert.strictEqual(nextRate(undefined, 0.25), 1.25); // 坏输入按 1x 起步
+});
+
+test('runtime leaves site Shift shortcuts untouched without a Hibiki track', () => {
+  const source = fs.readFileSync(require.resolve('./video-shortcuts.js'), 'utf8');
+  let keydown;
+  const fakeWindow = {
+    addEventListener(type, handler) {
+      if (type === 'keydown') keydown = handler;
+    },
+  };
+  const context = {
+    self: fakeWindow,
+    window: fakeWindow,
+    document: {
+      querySelector(selector) {
+        return selector === 'video' ? { playbackRate: 1 } : null;
+      },
+    },
+    chrome: {
+      storage: {
+        local: { get: () => Promise.resolve({ videoShortcutsEnabled: true }) },
+        onChanged: { addListener() {} },
+      },
+    },
+  };
+  vm.runInNewContext(source, context);
+  assert.strictEqual(typeof keydown, 'function');
+
+  for (const code of ['KeyP', 'KeyO', 'KeyF', 'KeyS']) {
+    let prevented = false;
+    let stopped = false;
+    keydown({
+      key: code.slice(-1),
+      code,
+      shiftKey: true,
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      target: null,
+      preventDefault() { prevented = true; },
+      stopPropagation() { stopped = true; },
+    });
+    assert.strictEqual(prevented, false, `${code} must remain available to the site`);
+    assert.strictEqual(stopped, false, `${code} must continue propagating`);
+  }
 });


### PR DESCRIPTION
## 概要

浏览器扩展重构两条线：**① 移植 asbplayer（MIT）核心功能**；**② 扩展「导入浏览器 / 自更新」链路易懂化**。纯 JS + 文档 + 1 个 Dart 守卫测试排除项，无 Dart 生产代码改动。

## ① asbplayer 功能移植

### 通用流媒体字幕桥 `stream-bridge.js`（新，MAIN world）
与 netflix-bridge 同构的第二条主世界桥，四类手法逐行对照 asb `extension/src/entrypoints/*-page.ts` 移植：

| 站点 | 手法 | 状态 |
|---|---|---|
| TVer | JSON.parse 纯透传 hook → text/vtt 轨 | ⚠️ implemented_unverified |
| Bilibili.tv（国际站） | JSON.parse hook → srt / bbjson | ⚠️ implemented_unverified |
| Hulu（日本） | XHR load 旁路读播放元数据 | ⚠️ implemented_unverified |
| Prime Video | 捕获 GetVodPlaybackResources 原样重放 → TTML | ⚠️ implemented_unverified |

⚠️ = 开发环境无对应站点账号，未做真站点 E2E；提取器为纯函数、有 node 单测（样例 JSON 按 asb 判定条件构造）。数据流入既有 `hibikiEpisodeCues` store，面板/查词/制卡零改动即消费。新增 `parseBilibiliJson`；SRT 复用既有 `parseWebVtt`（块结构兼容）。

### 全轨时轴偏移（读取侧）
偏移从「外挂轨专属、写穿 store」改为「任意轨（检测轨/外挂轨）、读取侧套用」：store 永远存原始 cue，provider（textTracks 收割 / live 采样 / 整集拦截）的增量刷新不再与偏移互相覆盖。面板行 seek / 覆盖层 / 制卡精确窗全部用偏移后的值。

### 播放模式增强（asb PlayModeManager / pause-on-hover 对应）
- 自动暂停支持 **句首**（atStart，先猜再听）/ 句尾（默认，原行为）
- **快进无字幕段**：无字幕区间 2.7x 播过、进句恢复原速（与精简播放互斥）
- **悬停暂停**：鼠标进覆盖层字幕即暂停、移开续播（方便查词）
- **防剧透模糊**：覆盖层默认 blur、悬停清晰
- **全轨覆盖层**：站点检测轨也可用扩展覆盖层显示（配合上两项）

全部默认关，options 可开，chrome.storage 实时生效。

### 视频页快捷键 `video-shortcuts.js`（新，默认开、可整体关闭）
键位对齐 asb 默认键：←/→ 上一句/下一句、↑ 重播本句、Shift+P/O/F 暂停/精简/快进、Shift+S 面板、Ctrl+Shift+←/→/↓ 偏移、**Ctrl+Shift+Z 复制当前字幕**（配合 Hibiki 剪贴板监看即查词）、Ctrl+Shift+[ ] 变速。判定是纯函数（node 全矩阵单测）；无字幕轨时方向键放行给站点原生行为，输入框一律放行。

## ② 导入/更新链路易懂化

- **`tools/browser-extension/README.md`**（新）：文件地图、三镜像同步模型、安装（导入）流水线、自更新流水线全图、endpoint 速览、站点适配状态表（含验证状态诚实标注）、新增站点适配器步骤、快捷键表。
- **`scripts/sync-mirrors.mjs`**（新）：镜像同步从「手动 cp + 30 个字节守卫兜底」变成一条命令（`--check` 可挂 CI）；同时校验 vendor 四件套与 assets/popup 上游一致性。
- **options「版本与更新」卡片**：显示当前加载 build 与自更新状态三态（随 Hibiki 自动更新 / 开发副本 / 自动更新失效+手动重载指引），`self-update.js` 新增纯函数 `describeUpdateState`。更新机制从「只有失效时的角标」变成设置页一眼可见。
- installer 守卫新增 README.md 排除项（文档不进 bundle，防内容指纹随文档改动翻新、触发无意义自更新 reload）。

## 验证

- 扩展 JS：`node --test` **152 全过**（新增 28：快捷键判定矩阵 / 站点提取器 / 面板新模式 vm 行为 / bbjson+SRT 解析 / describeUpdateState）。
- Dart 守卫：扩展相关 49 个测试文件（installer 全量镜像互比、dict-media/popup/heartbeat 字节守卫、update-stale/auto-refresh/startup-check、netflix 系列、install dialog、yomitan endpoints、theme 等）**443 全过**（本地 Flutter 3.41.6，`--no-pub`）。
- `flutter analyze` 全量：无新增告警（本地 3.41.6 对 develop 基线的 2 条 use_build_context_synchronously 噪音除外）。
- 镜像：`node scripts/sync-mirrors.mjs --check` 一致 ✓。
- ⚠️ 四个新站点适配器未做真站点 E2E（无账号）；合并前建议各在真站点过一遍「打开视频 → 字幕列表出现整集轨」。Netflix/YouTube 既有路径未动。

## 审阅注意点

- `manifest.json` 新增一组 MAIN world content script（stream-bridge，仅列出的流媒体域名 + amazon 各区域）；所有 hook 纯透传、异常不外泄（红线同 netflix-bridge）。
- 外挂字幕偏移行为变化：旧实现偏移写穿 store，新实现读取侧套用（`external-subtitle.test.js` ② 已按新语义改写并断言 store 不动）。
- options 新增 6 个偏好键 + `videoShortcutsEnabled`（默认开）；无 i18n 改动（扩展 UI 本就是中文硬编码）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
