### PR TITLE
fix(video): show covers in episode panel

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1082 条。点号进各自文件。
+> 共 1083 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1126](bugs/BUG-1126-video-episode-panel-missing-covers.md) | ✅ | ✅ | 视频剧集侧栏只传标题导致本地与互联封面全部丢失 |
 | [BUG-1115](bugs/BUG-1115-default-documents-root-flat.md) | ✅ | ✅ | 默认数据根时 16 个 Hibiki 目录直接摊在用户文档根下 |
 | [BUG-1114](bugs/BUG-1114-local-rig-rate-limit-flake.md) | 🚧 | 🚧 | 内置引擎本地 rig 测试：限速对 loopback peer 不生效导致 peer 观察窗口消失（flaky） |
 | [BUG-1113](bugs/BUG-1113-galgame-no-tags.md) | 🚧 | 🚧 | 游戏没有标签：schema 缺 GalgameTagMappings 表 |

--- a/docs/bugs/BUG-1126-video-episode-panel-missing-covers.md
+++ b/docs/bugs/BUG-1126-video-episode-panel-missing-covers.md
@@ -1,0 +1,18 @@
+## BUG-1126 · 视频剧集侧栏只传标题导致本地与互联封面全部丢失
+- **报告**：2026-07-26（用户：「封面的互联写了吗，把这些封面、名字等来源统一，不要每个地方编码一堆。比如视频里面的剧集列表，少了封面。」）
+- **真实性**：✅ 真 bug，且是数据结构层恒丢，不是图片加载偶发失败：
+  - `hibiki/lib/src/pages/implementations/video_hibiki_page.dart:357` 的 `_PlaylistEpisodeRef` 修复前只有 `bookUid/title/path`；本地 `VideoBookRow.coverPath` 与互联 `RemoteVideoInfo.coverUrl/id` 在组装播放列表时都被丢弃。
+  - `hibiki/lib/src/media/video/video_episode_panel.dart:13` 的 `VideoEpisodePanel` 修复前只接收 `List<String> episodeTitles`，接口本身装不下封面，因此任一本地或互联合集都只能渲染「序号 + 标题」。
+  - 互联取图能力此前已存在（`RemoteCoverImage` + `RemoteCoverFetcher` + 稳定 cacheKey），缺的是把远端成员封面身份带到面板并复用统一的显示侧来源解析器；旧 `RemoteVideoEpisode` 单行 playlist 模型确实不下发封面，仍应安全退回纯序号。
+- **[x] ① 已修复** —
+  - 新增 `hibiki/lib/src/media/media_cover_source.dart`，统一“书 override 链 / 互联钉扎取图 / 本机封面文件”的 `ImageProvider` 来源优先级；与写入侧 `MediaCoverService`、渲染侧 `PosterCoverImage` 分工，不在各面板重写远端/本地分支。
+  - `_PlaylistEpisodeRef` 增加 `coverPath/coverUrl/coverCacheKey`：本地合集从 `VideoBookRow.coverPath` 带入；互联合集从 `RemoteVideoInfo.coverUrl/id` 带入。
+  - `episode.part.dart:227` 的 `_episodePanelEntries` 统一调用 `resolveMediaCoverImage`；`VideoEpisodePanel` 改接 `VideoEpisodeEntry(title, cover)` 并显示 56×32 缩略图。无封面或加载失败仍保留序号/播放标记与电影占位图标。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/media/media_cover_source_test.dart`：验证互联优先级与稳定缓存键、互联 fetcher 不可用时回退本地、无封面与按媒体类型占位。
+  - `hibiki/test/media/video/video_episode_panel_test.dart`：真实 widget 断言剧集封面出现在对应 `ListTile`，尺寸为 56×32，既有点击/高亮/空态/大字号序号测试全部迁移到结构化条目。
+  - `hibiki/test/pages/video_episode_list_push_aside_guard_test.dart`：源码守卫本地与互联封面字段没有在播放列表组装时再次丢失，且面板来源必须走 `resolveMediaCoverImage`。
+- **备注**：
+  - 定向与相邻守卫共 30 项测试已通过；全量 `flutter analyze --no-pub` 通过。
+  - 设备肉眼复测待补：需打开一个带封面的本地视频合集与一个互联合集，确认右侧剧集面板缩略图、当前集高亮与窄栏标题布局。
+  - 本条只修剧集列表的真实缺口并建立显示侧统一入口；其它既有封面消费点后续迁移时应复用该入口，不再新增手写来源分支。

--- a/hibiki/lib/src/media/media_cover_source.dart
+++ b/hibiki/lib/src/media/media_cover_source.dart
@@ -1,0 +1,87 @@
+/// 封面**显示侧**统一来源解析（读路径）。
+///
+/// # 为什么需要这个文件
+///
+/// 此前「一张封面从哪来」是在**每个显示点各写一遍**的：远端就 `RemoteCoverImage`、
+/// 视频/游戏就 `File(path).existsSync() ? Image.file : 占位`、书就
+/// `getDisplayThumbnailFromMediaItem`。同一段四路分支散在约 20 个文件里，后果是
+/// 新增媒体种类要挨个改，漏掉一处就是「这里有封面那里没有」——用户报的
+/// 「剧集列表少了封面」「活动里没有封面」都是这么来的。
+///
+/// 本文件只回答**一个**问题：给定媒体身份，封面的 [ImageProvider] 是什么。
+///
+/// # 三者分工（不要混淆）
+///
+/// - **写入**：`MediaCoverService`（选图 / 覆盖 / 落盘 / 缓存驱逐）。
+/// - **来源解析**：本文件。
+/// - **渲染**：`PosterCoverImage`（竖图 cover / 横图模糊垫底 + contain），它明确
+///   「不关心来源」，接收本文件解析出的 provider。
+///
+/// # 互联（远端）封面
+///
+/// 远端封面**不是**另一条平行世界：它只是本解析器的一个来源分支
+/// （[RemoteCoverImage] + [RemoteCoverFetcher] + 稳定 cacheKey 的磁盘缓存）。
+/// 调用方不该再自己判断「这条是不是远端」。
+library;
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:hibiki_core/hibiki_core.dart' show MediaKind;
+
+import 'package:hibiki/src/media/media_item.dart' show MediaItem;
+import 'package:hibiki/src/models/app_model.dart' show AppModel;
+import 'package:hibiki/src/sync/remote_cover_image.dart';
+import 'package:hibiki/src/utils/cover_image.dart'
+    show kLocalCoverDecodePixelWidth, resizedFileImage;
+
+/// 解析一条媒体的封面图源；返回 null = 无封面可显示，调用方画占位
+/// （占位图标用 [mediaCoverFallbackIcon]）。
+///
+/// 优先级（**刻意固定**，调用方不得自己另排）：
+/// 1. [book] 非空 → 走书自己的 override 缩略图链（`MediaSource` 内部已处理
+///    override 封面 / 内嵌封面 / [fallbackUrl] 三级），书的链路自成体系不拆开；
+/// 2. [remoteUrl] + [remoteFetcher] 齐备 → [RemoteCoverImage]（互联/远端）；
+/// 3. [localPath] 非空 → 本机文件（视频抽帧 / 游戏目录图或 exe 图标 / 刮削下载）；
+/// 4. 都没有 → null。
+///
+/// **不做 `existsSync`**：那是每帧一次同步 IO，而文件缺失由渲染层的
+/// `errorBuilder` 兜底即可（见 [resizedFileImage] 注释）。
+///
+/// 本机文件恒过 [resizedFileImage] 套解码上限——整帧原生分辨率解进内存只为画一个
+/// 卡槽是纯浪费；[decodeWidth] 只在调用方确知需要更大图时才调。
+ImageProvider? resolveMediaCoverImage({
+  required MediaKind kind,
+  MediaItem? book,
+  AppModel? appModel,
+  String? localPath,
+  String? remoteUrl,
+  RemoteCoverFetcher? remoteFetcher,
+  String? remoteCacheKey,
+  String? fallbackUrl,
+  int decodeWidth = kLocalCoverDecodePixelWidth,
+}) {
+  if (book != null && appModel != null) {
+    return book
+        .getMediaSource(appModel: appModel)
+        .getDisplayThumbnailFromMediaItem(
+          appModel: appModel,
+          item: book,
+          fallbackUrl: fallbackUrl,
+        );
+  }
+  if (remoteUrl != null && remoteUrl.isNotEmpty && remoteFetcher != null) {
+    return RemoteCoverImage(remoteUrl, remoteFetcher, cacheKey: remoteCacheKey);
+  }
+  if (localPath != null && localPath.isNotEmpty) {
+    return resizedFileImage(File(localPath), width: decodeWidth);
+  }
+  return null;
+}
+
+/// 无封面时的占位图标——**按媒体种类**，不是所有东西都画一本书。
+IconData mediaCoverFallbackIcon(MediaKind kind) => switch (kind) {
+      MediaKind.video => Icons.movie_outlined,
+      MediaKind.game => Icons.videogame_asset_outlined,
+      MediaKind.epub || MediaKind.srt => Icons.menu_book_outlined,
+    };

--- a/hibiki/lib/src/media/video/video_episode_panel.dart
+++ b/hibiki/lib/src/media/video/video_episode_panel.dart
@@ -4,13 +4,28 @@ import 'package:flutter/material.dart';
 import 'package:hibiki/src/media/video/video_chrome_colors.dart';
 import 'package:hibiki/src/media/video/video_panel_auto_scroll.dart';
 
+/// 剧集面板的一条：标题 + 可选封面。
+///
+/// 此前面板的入参是 `List<String> episodeTitles`——**接口只收字符串，结构上就装
+/// 不下封面**，于是剧集列表恒无图（用户报「视频里面的剧集列表，少了封面」）。
+/// 封面源由调用方经 `resolveMediaCoverImage` 解析好再传进来：本组件只管画，不关心
+/// 这一集是本地文件还是互联远端（与 `PosterCoverImage` 同一分工原则）。
+class VideoEpisodeEntry {
+  const VideoEpisodeEntry({required this.title, this.cover});
+
+  final String title;
+
+  /// 已解析好的封面图源；null = 该集无封面可用，画占位图标。
+  final ImageProvider? cover;
+}
+
 /// 视频播放列表「剧集列表」push-aside 侧栏面板（TODO-638）。
 ///
 /// 此前剧集列表是 `showModalBottomSheet`（底部弹层），与其它侧栏（字幕列表 push-aside、
 /// 设置 / 倍速等 overlay）显示风格不一致。改成与字幕列表同款的 push-aside 侧栏后，三者
 /// 视觉统一：顶部带标题 + 右上角 × 关闭按钮的 header，下面是可滚动的剧集列表。
 ///
-/// 本 widget 只负责渲染——把每集标题列成「序号 / 当前集播放图标 + 标题」
+/// 本 widget 只负责渲染——把每集列成「序号 / 当前集播放图标 + 封面缩略图 + 标题」
 /// 一行，点击 [onTapEpisode] 切到该集（页面层 `_switchEpisode`），高亮 [currentIndex]
 /// 当前集。可见性与互斥由页面层（`_episodeListVisible` / `_videoWithSubtitlePanel`）管。
 ///
@@ -20,7 +35,7 @@ import 'package:hibiki/src/media/video/video_panel_auto_scroll.dart';
 class VideoEpisodePanel extends StatefulWidget {
   const VideoEpisodePanel({
     super.key,
-    required this.episodeTitles,
+    required this.episodes,
     required this.currentIndex,
     required this.onTapEpisode,
     required this.onClose,
@@ -31,10 +46,10 @@ class VideoEpisodePanel extends StatefulWidget {
     this.width = 320,
   });
 
-  /// 播放列表各集标题（有序）。空列表（单视频）时显示 [emptyHint]（剧集入口仅在播放
-  /// 列表出现，故正常不会空；空态作防御兜底）。统一合集 Phase 3：只需标题，与内部集
-  /// 表示解耦。
-  final List<String> episodeTitles;
+  /// 播放列表各集（有序，标题 + 可选封面）。空列表（单视频）时显示 [emptyHint]
+  /// （剧集入口仅在播放列表出现，故正常不会空；空态作防御兜底）。与内部集表示解耦：
+  /// 页面层把本地行 / 互联远端行都解析成 [VideoEpisodeEntry] 再传进来。
+  final List<VideoEpisodeEntry> episodes;
 
   /// 当前播放集下标（[episodes] 内）；负 / 越界视为「无当前集」。
   final int currentIndex;
@@ -90,7 +105,7 @@ class _VideoEpisodePanelState extends State<VideoEpisodePanel> {
   void _scrollToCurrentEpisode() {
     _autoScroller.scrollToIndex(
       widget.currentIndex,
-      itemCount: widget.episodeTitles.length,
+      itemCount: widget.episodes.length,
     );
   }
 
@@ -112,9 +127,7 @@ class _VideoEpisodePanelState extends State<VideoEpisodePanel> {
             _buildHeader(cs),
             const Divider(height: 1),
             Expanded(
-              child: widget.episodeTitles.isEmpty
-                  ? _buildEmpty(cs)
-                  : _buildList(cs),
+              child: widget.episodes.isEmpty ? _buildEmpty(cs) : _buildList(cs),
             ),
           ],
         ),
@@ -172,35 +185,66 @@ class _VideoEpisodePanelState extends State<VideoEpisodePanel> {
     return ListView.builder(
       controller: _autoScroller.controller,
       padding: const EdgeInsets.symmetric(vertical: 8),
-      itemCount: widget.episodeTitles.length,
+      itemCount: widget.episodes.length,
       itemBuilder: (BuildContext _, int i) {
-        final String episodeTitle = widget.episodeTitles[i];
+        final VideoEpisodeEntry entry = widget.episodes[i];
+        final String episodeTitle = entry.title;
         final bool selected = i == widget.currentIndex;
+        // 序号/播放标记 + 封面缩略图。封面缺失（旧单行 playlist 远端模型不下发
+        // 封面、或本集确实没图）时**不占位撑宽**，退回原来的纯序号形态——列表
+        // 宽度只有 240~420，给一列空占位会白吃走标题的横向空间。
+        final Widget indicator = selected
+            ? Icon(Icons.play_arrow, color: cs.primary)
+            : SizedBox(
+                // 序号列宽随字号缩放（对齐 TODO-567 字幕时间戳列范式）：固定 24px
+                // 在放大字号下放不下两位数序号（tabular figures，10 起约字号×1.2），
+                // Text 默认换行被 dense ListTile 行高纵向裁切。改为 `字号 + 12` 估宽
+                // 留余量，下界 24 保证窄字号像素不变（向后兼容）。配合 Text 单行不
+                // 换行（`maxLines:1` / `softWrap:false`），序号永不溢出 / 被裁。
+                width: math.max(24.0, widget.fontSize + 12),
+                child: Text(
+                  '${i + 1}',
+                  textAlign: TextAlign.center,
+                  maxLines: 1,
+                  softWrap: false,
+                  style: TextStyle(
+                    color: cs.onSurfaceVariant,
+                    fontSize: widget.fontSize,
+                    fontFeatures: const <FontFeature>[
+                      FontFeature.tabularFigures(),
+                    ],
+                  ),
+                ),
+              );
+        final ImageProvider? cover = entry.cover;
         return ListTile(
           dense: true,
-          // 当前集用 play_arrow 取代序号（与原 bottom sheet 一致）；其余集显示序号。
-          leading: selected
-              ? Icon(Icons.play_arrow, color: cs.primary)
-              : SizedBox(
-                  // 序号列宽随字号缩放（对齐 TODO-567 字幕时间戳列范式）：固定 24px
-                  // 在放大字号下放不下两位数序号（tabular figures，10 起约字号×1.2），
-                  // Text 默认换行被 dense ListTile 行高纵向裁切。改为 `字号 + 12` 估宽
-                  // 留余量，下界 24 保证窄字号像素不变（向后兼容）。配合 Text 单行不
-                  // 换行（`maxLines:1` / `softWrap:false`），序号永不溢出 / 被裁。
-                  width: math.max(24.0, widget.fontSize + 12),
-                  child: Text(
-                    '${i + 1}',
-                    textAlign: TextAlign.center,
-                    maxLines: 1,
-                    softWrap: false,
-                    style: TextStyle(
-                      color: cs.onSurfaceVariant,
-                      fontSize: widget.fontSize,
-                      fontFeatures: const <FontFeature>[
-                        FontFeature.tabularFigures(),
-                      ],
+          leading: cover == null
+              ? indicator
+              : Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    indicator,
+                    const SizedBox(width: 8),
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(4),
+                      child: SizedBox(
+                        // 16:9 小图：视频封面现状是抽帧横图，按横版给位不裁脸。
+                        width: 56,
+                        height: 32,
+                        child: Image(
+                          image: cover,
+                          fit: BoxFit.cover,
+                          // 文件缺失 / 解码失败 / 远端拉不到 → 退占位图标，不炸列表。
+                          errorBuilder: (_, __, ___) => Icon(
+                            Icons.movie_outlined,
+                            size: 18,
+                            color: cs.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
                     ),
-                  ),
+                  ],
                 ),
           title: Text(
             episodeTitle,

--- a/hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart
@@ -218,6 +218,30 @@ extension _VideoEpisode on _VideoHibikiPageState {
   /// [_subtitleJumpSidePanel] 同结构：[AnimatedSize] 让列宽在 0 ↔ panelWidth 平滑伸缩，
   /// 可见时渲染 [VideoEpisodePanel]，隐藏时收成 0（[ClipRect] + [OverflowBox] 保证伸缩
   /// 动画里内容布局稳定）。与字幕列表互斥，故两列同时只有一列非零宽。
+  /// 把内部集表示 [_PlaylistEpisodeRef] 解析成面板要的 [VideoEpisodeEntry]。
+  ///
+  /// 封面来源判断**不在这里手写分支**——统一走 [resolveMediaCoverImage]：本地集给
+  /// `coverPath`、互联远端集给 `coverUrl` + 稳定缓存键，解析器按固定优先级出图。
+  /// 旧单行 playlist 远端模型（`RemoteVideoEpisode`）不下发封面，两者皆空 →
+  /// 返回 null，面板退回纯序号形态。
+  List<VideoEpisodeEntry> _episodePanelEntries() {
+    final RemoteCoverFetcher? fetcher =
+        remoteCoverFetcherFor(widget.remoteClient ?? _resolvedStreamClient);
+    return <VideoEpisodeEntry>[
+      for (final _PlaylistEpisodeRef e in _episodes)
+        VideoEpisodeEntry(
+          title: e.title,
+          cover: resolveMediaCoverImage(
+            kind: MediaKind.video,
+            localPath: e.coverPath,
+            remoteUrl: e.coverUrl,
+            remoteFetcher: fetcher,
+            remoteCacheKey: e.coverCacheKey,
+          ),
+        ),
+    ];
+  }
+
   Widget _episodeSidePanel(bool visible) {
     final ColorScheme cs = _videoChromeColorScheme(context);
     final double screenWidth = MediaQuery.sizeOf(context).width;
@@ -245,10 +269,7 @@ extension _VideoEpisode on _VideoHibikiPageState {
                       left: false,
                       child: VideoEpisodePanel(
                         key: const ValueKey<String>('video-episode-panel'),
-                        episodeTitles: <String>[
-                          for (final _PlaylistEpisodeRef e in _episodes)
-                            e.title,
-                        ],
+                        episodes: _episodePanelEntries(),
                         currentIndex: _currentEpisode,
                         onTapEpisode: _handleEpisodeListTap,
                         onClose: _closeEpisodeList,

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -30,6 +30,7 @@ import 'package:hibiki/src/utils/misc/swipe_dismiss_wrapper.dart';
 import 'package:hibiki/src/media/drag_drop/drop_classification.dart';
 import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
 import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
+import 'package:hibiki/src/media/media_cover_source.dart';
 import 'package:hibiki/src/media/video/dandanplay_client.dart';
 import 'package:hibiki/src/media/video/danmaku_manual_match_panel.dart';
 import 'package:hibiki/src/media/video/stream_video_launch.dart';
@@ -114,6 +115,7 @@ import 'package:hibiki/src/pages/implementations/dictionary_popup_webview.dart'
 import 'package:hibiki/src/pages/implementations/stat_activity.dart';
 import 'package:hibiki/src/sync/hibiki_client_sync_backend.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/remote_cover_fetcher.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki/src/mining/immersion_mining_engine.dart';
 import 'package:hibiki/src/mining/immersion_mining_request.dart';
@@ -353,11 +355,26 @@ enum _VideoLoadPhase { connecting, downloadingSubtitle, buffering, preparing }
 /// 该集的单视频页）、[path] = 该集视频路径（预热用）。远端播放列表：[bookUid] = null、
 /// [path] = ''（换集靠 episodeIndex 向 host 建流，不走 pushReplacement）。
 class _PlaylistEpisodeRef {
-  const _PlaylistEpisodeRef(
-      {this.bookUid, required this.title, this.path = ''});
+  const _PlaylistEpisodeRef({
+    this.bookUid,
+    required this.title,
+    this.path = '',
+    this.coverPath,
+    this.coverUrl,
+    this.coverCacheKey,
+  });
   final String? bookUid;
   final String title;
   final String path;
+
+  /// 本机封面文件路径（本地集：`video_books.coverPath`）。
+  final String? coverPath;
+
+  /// 互联/远端封面 URL（远端合集成员：`RemoteVideoInfo.coverUrl`）。
+  final String? coverUrl;
+
+  /// 远端封面的稳定磁盘缓存键（用 `RemoteVideoInfo.id`）。
+  final String? coverCacheKey;
 }
 
 class VideoHibikiPage extends ConsumerStatefulWidget {
@@ -1901,7 +1918,11 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
         final VideoBookRow? er = await widget.repo.getByBookUid(m.entryKey);
         if (er == null) continue; // 孤儿成员（集行已删）→ 读取期过滤。
         refs.add(_PlaylistEpisodeRef(
-            bookUid: er.bookUid, title: er.title, path: er.videoPath));
+          bookUid: er.bookUid,
+          title: er.title,
+          path: er.videoPath,
+          coverPath: er.coverPath,
+        ));
       }
       _episodes = refs;
       final int idx = refs
@@ -1945,7 +1966,13 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
           (widget.initialEpisodeIndex ?? 0).clamp(0, _remoteMembers.length - 1);
       _episodes = <_PlaylistEpisodeRef>[
         for (final RemoteVideoInfo m in _remoteMembers)
-          _PlaylistEpisodeRef(title: m.title),
+          // 远端合集成员自带封面（host 下发 coverUrl + 稳定 id 作缓存键）——
+          // 此前这里只取 title，剧集列表因此对远端也恒无图。
+          _PlaylistEpisodeRef(
+            title: m.title,
+            coverUrl: m.coverUrl,
+            coverCacheKey: m.id,
+          ),
       ];
       _activeRemoteMember = _remoteMembers[startIndex];
       _delayMs = _remoteMembers[startIndex].delayMs;

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+940
+version: 1.2.0+941
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/media_cover_source_test.dart
+++ b/hibiki/test/media/media_cover_source_test.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart' show MediaKind;
+
+import 'package:hibiki/src/media/media_cover_source.dart';
+import 'package:hibiki/src/sync/remote_cover_image.dart';
+
+class _FakeRemoteCoverFetcher implements RemoteCoverFetcher {
+  @override
+  Future<Uint8List> fetchRemoteCover(String coverUrl) async => Uint8List(0);
+}
+
+void main() {
+  test('remote cover wins over local path and keeps the stable cache key', () {
+    final _FakeRemoteCoverFetcher fetcher = _FakeRemoteCoverFetcher();
+
+    final ImageProvider? result = resolveMediaCoverImage(
+      kind: MediaKind.video,
+      localPath: r'C:\covers\episode.jpg',
+      remoteUrl: 'https://peer.example/cover/episode',
+      remoteFetcher: fetcher,
+      remoteCacheKey: 'video-episode-42',
+    );
+
+    expect(result, isA<RemoteCoverImage>());
+    final RemoteCoverImage image = result! as RemoteCoverImage;
+    expect(image.coverUrl, 'https://peer.example/cover/episode');
+    expect(image.fetcher, same(fetcher));
+    expect(image.cacheKey, 'video-episode-42');
+  });
+
+  test('local cover is used when the remote client cannot fetch covers', () {
+    const String path = r'C:\covers\episode.jpg';
+
+    final ImageProvider? result = resolveMediaCoverImage(
+      kind: MediaKind.video,
+      localPath: path,
+      remoteUrl: 'https://peer.example/cover/episode',
+    );
+
+    expect(result, isA<ResizeImage>());
+    final ResizeImage resized = result! as ResizeImage;
+    expect(resized.imageProvider, isA<FileImage>());
+    expect((resized.imageProvider as FileImage).file.path, File(path).path);
+  });
+
+  test('missing cover returns null and fallback icon follows media kind', () {
+    expect(
+      resolveMediaCoverImage(kind: MediaKind.video),
+      isNull,
+    );
+    expect(mediaCoverFallbackIcon(MediaKind.video), Icons.movie_outlined);
+    expect(
+      mediaCoverFallbackIcon(MediaKind.game),
+      Icons.videogame_asset_outlined,
+    );
+    expect(mediaCoverFallbackIcon(MediaKind.epub), Icons.menu_book_outlined);
+  });
+}

--- a/hibiki/test/media/video/video_episode_panel_test.dart
+++ b/hibiki/test/media/video/video_episode_panel_test.dart
@@ -1,13 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:transparent_image/transparent_image.dart';
 
 import 'package:hibiki/src/media/video/video_episode_panel.dart';
 
 void main() {
   Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
 
-  List<String> episodes(int n) => <String>[
-        for (int i = 0; i < n; i++) 'Episode ${i + 1}',
+  List<VideoEpisodeEntry> episodes(
+    int n, {
+    ImageProvider? cover,
+  }) =>
+      <VideoEpisodeEntry>[
+        for (int i = 0; i < n; i++)
+          VideoEpisodeEntry(title: 'Episode ${i + 1}', cover: cover),
       ];
 
   testWidgets('lists episodes; tap reports the episode index (TODO-638)',
@@ -15,7 +21,7 @@ void main() {
     final List<int> tapped = <int>[];
     await tester.pumpWidget(wrap(
       VideoEpisodePanel(
-        episodeTitles: episodes(3),
+        episodes: episodes(3),
         currentIndex: 1,
         onTapEpisode: tapped.add,
         onClose: () {},
@@ -38,7 +44,7 @@ void main() {
       '(TODO-638)', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       VideoEpisodePanel(
-        episodeTitles: episodes(3),
+        episodes: episodes(3),
         currentIndex: 1,
         onTapEpisode: (_) {},
         onClose: () {},
@@ -75,7 +81,7 @@ void main() {
     int closed = 0;
     await tester.pumpWidget(wrap(
       VideoEpisodePanel(
-        episodeTitles: episodes(2),
+        episodes: episodes(2),
         currentIndex: 0,
         onTapEpisode: (_) {},
         onClose: () => closed++,
@@ -94,7 +100,7 @@ void main() {
       (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       VideoEpisodePanel(
-        episodeTitles: const <String>[],
+        episodes: const <VideoEpisodeEntry>[],
         currentIndex: -1,
         onTapEpisode: (_) {},
         onClose: () {},
@@ -118,7 +124,7 @@ void main() {
     const double largeFontSize = 42; // 14 * appUiScale(3.0)
     await tester.pumpWidget(wrap(
       VideoEpisodePanel(
-        episodeTitles: episodes(12),
+        episodes: episodes(12),
         currentIndex: 0, // 当前集 0 用 play_arrow；序号从「2」起全是显式 Text。
         onTapEpisode: (_) {},
         onClose: () {},
@@ -155,5 +161,31 @@ void main() {
     final SizedBox box = tester.widget<SizedBox>(leadingBox.first);
     expect(box.width, isNotNull);
     expect(box.width!, greaterThanOrEqualTo(largeFontSize + 12));
+  });
+
+  testWidgets('renders an episode cover next to the indicator',
+      (WidgetTester tester) async {
+    final MemoryImage cover = MemoryImage(kTransparentImage);
+    await tester.pumpWidget(wrap(
+      VideoEpisodePanel(
+        episodes: episodes(2, cover: cover),
+        currentIndex: 0,
+        onTapEpisode: (_) {},
+        onClose: () {},
+        colorScheme: const ColorScheme.light(),
+        title: 'Episodes',
+        emptyHint: 'No episodes',
+      ),
+    ));
+
+    final Finder firstTile = find.ancestor(
+      of: find.text('Episode 1'),
+      matching: find.byType(ListTile),
+    );
+    final Finder image =
+        find.descendant(of: firstTile, matching: find.byType(Image));
+    expect(image, findsOneWidget);
+    expect(tester.widget<Image>(image).image, same(cover));
+    expect(tester.getSize(image), const Size(56, 32));
   });
 }

--- a/hibiki/test/pages/video_episode_list_push_aside_guard_test.dart
+++ b/hibiki/test/pages/video_episode_list_push_aside_guard_test.dart
@@ -173,6 +173,25 @@ void main() {
     );
   });
 
+  test('剧集面板封面统一走 resolveMediaCoverImage，兼容本地与互联成员', () {
+    expect(src.contains('this.coverPath,'), isTrue,
+        reason: '_PlaylistEpisodeRef 应承载本地封面路径');
+    expect(src.contains('this.coverUrl,'), isTrue,
+        reason: '_PlaylistEpisodeRef 应承载互联封面 URL');
+    expect(src.contains('this.coverCacheKey,'), isTrue,
+        reason: '_PlaylistEpisodeRef 应承载远端稳定缓存键');
+    expect(src.contains('coverPath: er.coverPath'), isTrue,
+        reason: '本地合集成员应把 video_books.coverPath 带进面板');
+    expect(src.contains('coverUrl: m.coverUrl'), isTrue,
+        reason: '互联合集成员应把 RemoteVideoInfo.coverUrl 带进面板');
+    expect(src.contains('coverCacheKey: m.id'), isTrue,
+        reason: '互联封面应使用 RemoteVideoInfo.id 作稳定缓存键');
+    expect(src.contains('resolveMediaCoverImage('), isTrue,
+        reason: '封面来源应统一走显示侧解析器，不在剧集面板手写来源分支');
+    expect(src.contains('episodes: _episodePanelEntries()'), isTrue,
+        reason: 'VideoEpisodePanel 应接收解析后的标题与封面条目');
+  });
+
   test('剧集列表 push-aside 也门控控制条 / rail 可见性（与字幕列表一致）', () {
     // _applyControlsVisibilityFromMediaKit 的 gated 应含 _episodeListVisible。
     final int start =


### PR DESCRIPTION
## Summary
- add a display-side media cover resolver so local files, interconnect covers, and book thumbnail overrides share one source contract
- preserve local `coverPath` and remote `coverUrl`/stable cache key when building video playlist episode refs
- render optional 56x32 thumbnails in the push-aside episode panel while keeping the old number/play-marker fallback for entries without covers
- record the verified structural bug as BUG-1115

## Verification
- `flutter analyze --no-pub` (full app): passed
- targeted + adjacent Flutter tests: 30 passed
  - `test/media/media_cover_source_test.dart`
  - `test/media/video/video_episode_panel_test.dart`
  - `test/pages/video_episode_list_push_aside_guard_test.dart`
  - `test/pages/video_subtitle_list_cursor_reveal_guard_test.dart`
- `git diff --cached --check`: passed

## Remaining verification
- device visual check is still required for one local collection and one interconnect collection; confirm thumbnails, current-episode highlight, and narrow-panel title layout