### PR TITLE
fix(gal): 修复捕获工作台文本线程与逐句选轨

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1098 条。点号进各自文件。
+> 共 1101 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1134](bugs/BUG-1134-gal-line-track-preview-timestamp.md) | ✅ | ✅ | 逐句选轨试听与确认使用了不同台词时间戳 |
+| [BUG-1133](bugs/BUG-1133-gal-capture-parallel-text-duplicate.md) | ✅ | ✅ | 全部文本线程把同一台词显示两遍 |
+| [BUG-1132](bugs/BUG-1132-gal-capture-stale-text-thread.md) | ✅ | ✅ | 捕获工作台混入上次进程的 TextRender 文本线程 |
 | [BUG-1131](bugs/BUG-1131-book-tracking-status-semantics.md) | ✅ | ✅ | Bangumi 小说/漫画阅读进度未按语义切换在读与读过 |
 | [BUG-1130](bugs/BUG-1130-bangumi-watched-progress-stays-wish.md) | ✅ | ✅ | Bangumi 已有想看收藏在记录进度后未切换为在看 |
 | [BUG-1129](bugs/BUG-1129-gal-textthread-list-luna-parity.md) | ✅ | ✅ | 文本线程列表对齐 Luna 选择文本：预览折叠/排序/重名消歧 + TextRender 0 行 |

--- a/docs/bugs/BUG-1132-gal-capture-stale-text-thread.md
+++ b/docs/bugs/BUG-1132-gal-capture-stale-text-thread.md
@@ -1,0 +1,12 @@
+## BUG-1132 · 捕获工作台混入上次进程的 TextRender 文本线程
+- **报告**：2026-07-27（用户：「Hibiki 的 TextRender 没文本，需要对齐 Luna 选择文本的行为」）
+- **真实性**：✅ 真 bug（会话边界丢失）
+  - `TexthookerService` 同时保存跨会话的 `_discoveredTextThreads` 与台词 buffer；旧工作台直接读取完整 `textThreads`，启动新游戏时没有按 `sessionStartedAt` 投影候选。
+  - Luna 的线程标识包含进程内线程身份。上次进程留下的同名 `TextRender` 能继续出现在下拉框，但当前 helper 不可能再为它发布台词，于是表现为「可选择、0 行」。
+- **[x] ① 已修复** — 提交 `2eb06aadb`：
+  - `hibiki/lib/src/sync/texthooker_service.dart:216` 新增 `textThreadsSince`，同时约束发现目录和已有台词。
+  - `hibiki/lib/src/mining/gal_hook_session_controller.dart:428` 以本次 `sessionStartedAt` 暴露线程候选；`:432` 的工作台台词投影也使用相同会话边界。
+  - `hibiki/lib/src/pages/implementations/texthooker_page.dart:803` 改为消费 controller 的会话级候选与台词，不再绕过会话状态读取 service 全历史。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/texthooker_service_test.dart:160`：
+  - 构造旧进程 `TextRender` 与本次进程零行候选，验证旧候选被排除、本次零行候选仍可选择。
+- **备注**：Windows 真游戏原路径尚待复验；自动化已经覆盖造成死候选的数据边界。

--- a/docs/bugs/BUG-1133-gal-capture-parallel-text-duplicate.md
+++ b/docs/bugs/BUG-1133-gal-capture-parallel-text-duplicate.md
@@ -1,0 +1,11 @@
+## BUG-1133 · 全部文本线程把同一台词显示两遍
+- **报告**：2026-07-27（用户：「捕获工作台里面感觉一句话重复了两遍」）
+- **真实性**：✅ 真 bug（同一 Luna hook 的平行线程双写没有展示层语义）
+  - native 自动选择按 hook code 记赢家并放行同 hook code（`native/galgame_hook/include/luna_text_selector.h:91-96`），同一渲染瞬间的多个 Luna 线程可能各发布一份相同台词。
+  - 原工作台「全部文本线程」直接渲染原始 buffer；因此平行线程双写会显示两行。不能在 buffer 层去重，否则会破坏逐线程选择、稳定行 id 与各自音频。
+- **[x] ① 已修复** — 提交 `2eb06aadb`：
+  - `hibiki/lib/src/sync/texthooker_service.dart:398` 新增只用于 UI 的 `collapseParallelTextThreadDuplicates`：仅折叠不同 engine-hook 线程、同文、hook/接收时间紧邻的记录；同线程稍后重说与非引擎来源都保留。
+  - 若两份中只有一份已配到音频，投影保留有音频的记录。`hibiki/lib/src/mining/gal_hook_session_controller.dart:432` 仅在「全部线程」使用该投影，选择具体线程时仍返回原始记录。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/texthooker_service_test.dart:199`：
+  - 验证同时跨线程同文折叠，而同线程稍后真实重说仍保留；同时断言底层 buffer 未被删除。
+- **备注**：Windows 真游戏原路径尚待复验；折叠窗口刻意收窄，避免把剧情中的真实重复台词吞掉。

--- a/docs/bugs/BUG-1134-gal-line-track-preview-timestamp.md
+++ b/docs/bugs/BUG-1134-gal-line-track-preview-timestamp.md
@@ -1,0 +1,11 @@
+## BUG-1134 · 逐句选轨试听与确认使用了不同台词时间戳
+- **报告**：2026-07-27（用户：「选择这句话的音轨，点击播放能播放，但是选中时可能说没有获取到音轨」）
+- **真实性**：✅ 真 bug（试听和确认取音窗口不一致）
+  - 原逐句弹窗试听调用通用 `exportTrackPreview(sourcePtr)`，该方法取 `_lineTimestampCache.values.last`（最新一句）。
+  - 确认则调用 `setLineVoiceTrack(lineId, sourcePtr)`，按所选行 `_lineTimestampCache[lineId]` 取音。选择较早行时，试听可能播放最新句的 PCM，确认却在正确的较早窗口找不到该轨。
+- **[x] ① 已修复** — 提交 `2eb06aadb`：
+  - `hibiki/lib/src/mining/gal_hook_session_controller.dart:1177` 新增 `exportLineTrackPreview`，校验行属于当前会话，并与 `setLineVoiceTrack` 共用同一个行时间戳。
+  - `hibiki/lib/src/pages/implementations/texthooker_page.dart:235` 试听时同时传 `line.id` 与 `sourcePtr`。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_audio_degrade_track_test.dart:380`：
+  - 先后放入时间戳 4321/9876 的两句，再试听并确认第一句，断言两次取音均使用 4321 和同一 source ptr。
+- **备注**：Windows 真游戏原路径尚待复验；自动化直接锁定了此前错位的两个取音调用。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 44574 (2622 per locale)
+/// Strings: 44591 (2623 per locale)
 ///
-/// Built on 2026-07-27 at 06:19 UTC
+/// Built on 2026-07-27 at 07:06 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3493,6 +3493,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -9456,6 +9457,8 @@ class _StringsAr extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -15487,6 +15490,8 @@ class _StringsDe extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -21534,6 +21539,8 @@ class _StringsEs extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -27592,6 +27599,8 @@ class _StringsFr extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -33579,6 +33588,8 @@ class _StringsId extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -39612,6 +39623,8 @@ class _StringsIt extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -45461,6 +45474,8 @@ class _StringsJa extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -51312,6 +51327,8 @@ class _StringsKo extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -57325,6 +57342,8 @@ class _StringsNl extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -63351,6 +63370,8 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -69361,6 +69382,8 @@ class _StringsRu extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -75319,6 +75342,8 @@ class _StringsTh extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -81309,6 +81334,8 @@ class _StringsTr extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -87284,6 +87311,8 @@ class _StringsVi extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 // Path: <root>
@@ -92851,6 +92880,8 @@ class _StringsZhCn extends _StringsEn {
       '${process} 是关键系统进程，Hibiki 不会结束它；请改用其他端口。';
   @override
   String get yomitan_port_kill_self_instance => '该进程是本应用的另一个正在运行的实例。';
+  @override
+  String get game_track_bgm => 'BGM / 已排除';
 }
 
 // Path: <root>
@@ -98622,6 +98653,8 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
+  @override
+  String get game_track_bgm => 'BGM / excluded';
 }
 
 /// Flat map(s) containing all translations.
@@ -103982,6 +104015,8 @@ extension on _StringsEn {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -109340,6 +109375,8 @@ extension on _StringsAr {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -114719,6 +114756,8 @@ extension on _StringsDe {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -120097,6 +120136,8 @@ extension on _StringsEs {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -125481,6 +125522,8 @@ extension on _StringsFr {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -130847,6 +130890,8 @@ extension on _StringsId {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -136228,6 +136273,8 @@ extension on _StringsIt {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -141571,6 +141618,8 @@ extension on _StringsJa {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -146918,6 +146967,8 @@ extension on _StringsKo {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -152292,6 +152343,8 @@ extension on _StringsNl {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -157663,6 +157716,8 @@ extension on _StringsPtBr {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -163039,6 +163094,8 @@ extension on _StringsRu {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -168399,6 +168456,8 @@ extension on _StringsTh {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -173768,6 +173827,8 @@ extension on _StringsTr {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -179132,6 +179193,8 @@ extension on _StringsVi {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }
@@ -184450,6 +184513,8 @@ extension on _StringsZhCn {
             '${process} 是关键系统进程，Hibiki 不会结束它；请改用其他端口。';
       case 'yomitan_port_kill_self_instance':
         return '该进程是本应用的另一个正在运行的实例。';
+      case 'game_track_bgm':
+        return 'BGM / 已排除';
       default:
         return null;
     }
@@ -189788,6 +189853,8 @@ extension on _StringsZhHk {
             '${process} is a critical system process — Hibiki will not end it. Change the port instead.';
       case 'yomitan_port_kill_self_instance':
         return 'This process is another running instance of this app.';
+      case 'game_track_bgm':
+        return 'BGM / excluded';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "结束占用端口 $port 的进程？",
   "yomitan_port_kill_failed": "无法结束 $process，请手动结束该进程后重试。",
   "yomitan_port_kill_protected": "$process 是关键系统进程，Hibiki 不会结束它；请改用其他端口。",
-  "yomitan_port_kill_self_instance": "该进程是本应用的另一个正在运行的实例。"
+  "yomitan_port_kill_self_instance": "该进程是本应用的另一个正在运行的实例。",
+  "game_track_bgm": "BGM / 已排除"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2620,5 +2620,6 @@
   "yomitan_port_kill_confirm_title": "End the process using port $port?",
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
-  "yomitan_port_kill_self_instance": "This process is another running instance of this app."
+  "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
+  "game_track_bgm": "BGM / excluded"
 }

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -424,7 +424,27 @@ class GalHookSessionController extends ChangeNotifier {
   GalHookSessionState _state = const GalHookSessionState();
   GalHookSessionState get state => _state;
   List<TexthookerLineEntry> get lines => _textService.entries;
-  List<TexthookerTextThread> get textThreads => _textService.textThreads;
+  List<TexthookerTextThread> get textThreads =>
+      _textService.textThreadsSince(_state.sessionStartedAt);
+
+  /// 捕获工作台当前应展示的行。捕获中只看本次会话，避免上一个进程的 Luna 线程/台词
+  /// 混进当前选择；「全部线程」再折叠同一渲染瞬间的跨线程双写。底层 buffer 不删。
+  List<TexthookerLineEntry> get workbenchLines {
+    final DateTime? startedAt = _state.sessionStartedAt;
+    Iterable<TexthookerLineEntry> scoped =
+        _textService.entriesForTextThread(selectedTextThreadKey);
+    if (startedAt != null) {
+      scoped = scoped.where(
+        (TexthookerLineEntry entry) => !entry.receivedAt.isBefore(startedAt),
+      );
+    }
+    final List<TexthookerLineEntry> materialized =
+        scoped.toList(growable: false);
+    return selectedTextThreadKey == null
+        ? collapseParallelTextThreadDuplicates(materialized)
+        : List<TexthookerLineEntry>.unmodifiable(materialized);
+  }
+
   String? get selectedTextThreadKey {
     final String? selected = _selectedTextThreadKey;
     if (selected == null) return null;
@@ -1145,11 +1165,45 @@ class GalHookSessionController extends ChangeNotifier {
   /// 器可直接播（无需 ffmpeg 转码）。无 engine / 尚无台词时间戳 / 该轨窗口内无 PCM /
   /// 写盘失败时返回 null 并记结构化事件（调用方 toast 提示，不静默）。
   Future<GalTrackPreview?> exportTrackPreview(int sourcePtr) async {
-    final EngineHookGalAudioSource? engine = _engineSource;
-    if (engine == null) return null;
     final int timestamp = _lineTimestampCache.values.isEmpty
         ? 0
         : _lineTimestampCache.values.last;
+    return _exportTrackPreviewAt(sourcePtr, timestamp);
+  }
+
+  /// 逐句选轨弹窗的试听必须与确认选轨共用同一 [lineId] 时间戳。旧实现调用
+  /// [exportTrackPreview] 偷用了最新一句，导致用户能听见最新句，却为较早行确认时收到
+  /// 「该句没有音轨」。
+  Future<GalTrackPreview?> exportLineTrackPreview(
+    String lineId,
+    int sourcePtr,
+  ) async {
+    final TexthookerLineEntry? entry = _textService.entryById(lineId);
+    final int timestamp = _lineTimestampCache[lineId] ?? 0;
+    if (entry == null || !isLineInCurrentSession(entry) || timestamp <= 0) {
+      _record(
+        GalHookEventSeverity.warning,
+        'audio',
+        'audio.line_track_preview_unavailable',
+        'Per-line track preview needs a current hooked line timestamp',
+        details: <String, Object?>{
+          'lineId': lineId,
+          'sourcePtr': sourcePtr,
+          'tsMs': timestamp,
+        },
+      );
+      return null;
+    }
+    return _exportTrackPreviewAt(sourcePtr, timestamp, lineId: lineId);
+  }
+
+  Future<GalTrackPreview?> _exportTrackPreviewAt(
+    int sourcePtr,
+    int timestamp, {
+    String? lineId,
+  }) async {
+    final EngineHookGalAudioSource? engine = _engineSource;
+    if (engine == null) return null;
     final GalAudioSlice? slice = await engine.grabUtterance(
       timestamp,
       sourcePtr: sourcePtr,
@@ -1161,7 +1215,11 @@ class GalHookSessionController extends ChangeNotifier {
         'audio',
         'audio.track_preview_empty',
         'No recent PCM was available on the selected track',
-        details: <String, Object?>{'sourcePtr': sourcePtr, 'tsMs': timestamp},
+        details: <String, Object?>{
+          'sourcePtr': sourcePtr,
+          'tsMs': timestamp,
+          if (lineId != null) 'lineId': lineId,
+        },
       );
       return null;
     }

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -162,28 +162,73 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     }
     final int? picked = await showAppDialog<int>(
       context: context,
-      builder: (BuildContext dialogContext) => SimpleDialog(
-        title: Text(t.game_line_track_dialog_title),
-        children: <Widget>[
-          for (final GalAudioTrack track in tracks)
-            ListTile(
-              leading: const Icon(Icons.graphic_eq),
-              title: Text(
-                '${t.game_track_voice} ${track.orderIndex + 1} · '
-                '${track.format.sampleRate} Hz · ${track.format.channels} ch',
+      builder: (BuildContext dialogContext) => StatefulBuilder(
+        builder: (BuildContext context, StateSetter setDialogState) =>
+            SimpleDialog(
+          title: Text(t.game_line_track_dialog_title),
+          children: <Widget>[
+            for (final GalAudioTrack track in tracks)
+              Builder(
+                builder: (BuildContext context) {
+                  final bool excluded = _session.state.excludedAudioSourcePtrs
+                      .contains(track.sourcePtr);
+                  return ListTile(
+                    leading: Icon(
+                      excluded ? Icons.music_off_outlined : Icons.graphic_eq,
+                    ),
+                    title: Text(
+                      '${t.game_track_voice} ${track.orderIndex + 1} · '
+                      '${track.format.sampleRate} Hz · '
+                      '${track.format.channels} ch',
+                    ),
+                    subtitle: Text(
+                      <String>[
+                        '${t.game_track_clips} ${track.clipCount}',
+                        '${t.game_track_energy} '
+                            '${track.avgEnergy.toStringAsFixed(1)}',
+                        if (excluded) t.game_track_bgm,
+                      ].join(' · '),
+                    ),
+                    trailing: Wrap(
+                      spacing: 4,
+                      children: <Widget>[
+                        HibikiIconButton(
+                          icon: Icons.play_circle_outline,
+                          tooltip: t.game_track_preview,
+                          onTap: () => unawaited(
+                            _previewLineTrackInDialog(
+                              line.id,
+                              track.sourcePtr,
+                            ),
+                          ),
+                        ),
+                        HibikiIconButton(
+                          icon:
+                              excluded ? Icons.undo : Icons.music_off_outlined,
+                          tooltip: excluded
+                              ? t.game_track_restore
+                              : t.game_track_exclude_bgm,
+                          onTap: () {
+                            _session.setTrackExcluded(
+                              track.sourcePtr,
+                              !excluded,
+                            );
+                            setDialogState(() {});
+                          },
+                        ),
+                      ],
+                    ),
+                    // 已明确标为 BGM 的轨不能再被误点成这句语音；仍可试听与恢复。
+                    enabled: !excluded,
+                    onTap: excluded
+                        ? null
+                        : () =>
+                            Navigator.of(dialogContext).pop(track.sourcePtr),
+                  );
+                },
               ),
-              subtitle: Text(
-                '${t.game_track_clips} ${track.clipCount} · '
-                '${t.game_track_energy} ${track.avgEnergy.toStringAsFixed(1)}',
-              ),
-              trailing: HibikiIconButton(
-                icon: Icons.play_circle_outline,
-                tooltip: t.game_track_preview,
-                onTap: () => unawaited(_previewTrackInDialog(track.sourcePtr)),
-              ),
-              onTap: () => Navigator.of(dialogContext).pop(track.sourcePtr),
-            ),
-        ],
+          ],
+        ),
       ),
     );
     if (picked == null || !mounted) return;
@@ -317,6 +362,19 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   Future<void> _previewTrackInDialog(int sourcePtr) async {
     final GalTrackPreview? preview =
         await _session.exportTrackPreview(sourcePtr);
+    if (preview == null) {
+      HibikiToast.show(msg: t.game_track_preview_failed);
+      return;
+    }
+    if (!await DesktopAudioPlayback.playFile(preview.filePath)) {
+      HibikiToast.show(msg: t.game_track_preview_failed);
+    }
+  }
+
+  /// 选轨对话框里的逐轨试听：与确认选择共用当前行时间戳，避免试听偷播最新一句。
+  Future<void> _previewLineTrackInDialog(String lineId, int sourcePtr) async {
+    final GalTrackPreview? preview =
+        await _session.exportLineTrackPreview(lineId, sourcePtr);
     if (preview == null) {
       HibikiToast.show(msg: t.game_track_preview_failed);
       return;
@@ -882,11 +940,9 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
 
   @override
   Widget build(BuildContext context) {
-    final TexthookerService texthooker = TexthookerService.instance;
-    final List<TexthookerTextThread> textThreads = texthooker.textThreads;
+    final List<TexthookerTextThread> textThreads = _session.textThreads;
     final String? selectedTextThreadKey = _session.selectedTextThreadKey;
-    final List<TexthookerLineEntry> lines =
-        texthooker.entriesForTextThread(selectedTextThreadKey);
+    final List<TexthookerLineEntry> lines = _session.workbenchLines;
     WidgetsBinding.instance.addPostFrameCallback((_) => _syncPopupOverlay());
     if (widget.embedded) {
       return Column(

--- a/hibiki/lib/src/sync/texthooker_service.dart
+++ b/hibiki/lib/src/sync/texthooker_service.dart
@@ -298,14 +298,25 @@ class TexthookerService extends ChangeNotifier {
     return null;
   }
 
-  /// 当前会话已发现的可选文本线程，最近活跃的排在前面。
+  /// 已发现的可选文本线程，最近活跃的排在前面。
   ///
   /// Luna 的 ThreadCreate 事件会先放入 [_discoveredTextThreads]，因此被自动赢家过滤、当前
   /// 尚无已发布台词的候选也会以 0 行显示；已有台词再从 [_entries] 聚合计数。
-  List<TexthookerTextThread> get textThreads {
+  List<TexthookerTextThread> get textThreads => textThreadsSince(null);
+
+  /// [startedAt] 之后的会话级线程目录。Luna thread id 含进程身份，旧捕获会话里的
+  /// `TextRender` 即使标签相同也不再对应当前 helper；把它混进选择器会出现「可选、选择
+  /// 成功、但永远 0 行」的死候选。null 保留完整历史目录，供会话外查看。
+  List<TexthookerTextThread> textThreadsSince(DateTime? startedAt) {
     final Map<String, TexthookerTextThread> byKey =
-        Map<String, TexthookerTextThread>.from(_discoveredTextThreads);
+        <String, TexthookerTextThread>{
+      for (final MapEntry<String, TexthookerTextThread> entry
+          in _discoveredTextThreads.entries)
+        if (startedAt == null || !entry.value.latestAt.isBefore(startedAt))
+          entry.key: entry.value,
+    };
     for (final TexthookerLineEntry entry in _entries) {
+      if (startedAt != null && entry.receivedAt.isBefore(startedAt)) continue;
       final String? key = entry.textThreadKey;
       if (key == null || key.isEmpty) continue;
       final TexthookerTextThread? previous = byKey[key];
@@ -490,3 +501,47 @@ bool lineMatchesFilter(
       TexthookerLineFilter.mined => entry.mined,
       TexthookerLineFilter.favorited => entry.favorited,
     };
+
+/// 「全部文本线程」的展示投影：折叠同一渲染瞬间被不同 Luna 线程各回传一次的同文行。
+///
+/// 原始 buffer 不删，线程选择、逐行音频和稳定 id 仍消费完整数据；这里只处理 UI 投影。
+/// 仅当来源都是 engine hook、线程不同、文本相同，且 hook/接收时间都紧邻时才视为并行
+/// 双写。同线程稍后重说同一句、外部来源重复、缺时间戳的行一律保留。
+List<TexthookerLineEntry> collapseParallelTextThreadDuplicates(
+  Iterable<TexthookerLineEntry> entries, {
+  Duration hookWindow = const Duration(milliseconds: 100),
+  Duration receiveWindow = const Duration(milliseconds: 500),
+}) {
+  final List<TexthookerLineEntry> result = <TexthookerLineEntry>[];
+  for (final TexthookerLineEntry entry in entries) {
+    if (result.isEmpty) {
+      result.add(entry);
+      continue;
+    }
+    final TexthookerLineEntry previous = result.last;
+    final int? previousHookAt = previous.hookTimestampMs;
+    final int? currentHookAt = entry.hookTimestampMs;
+    final String? previousThread = previous.textThreadKey;
+    final String? currentThread = entry.textThreadKey;
+    final bool parallelDuplicate = previous.source ==
+            TexthookerLineSource.engineHook &&
+        entry.source == TexthookerLineSource.engineHook &&
+        previousThread != null &&
+        currentThread != null &&
+        previousThread != currentThread &&
+        previous.text == entry.text &&
+        previousHookAt != null &&
+        currentHookAt != null &&
+        (currentHookAt - previousHookAt).abs() <= hookWindow.inMilliseconds &&
+        entry.receivedAt.difference(previous.receivedAt).abs() <= receiveWindow;
+    if (!parallelDuplicate) {
+      result.add(entry);
+      continue;
+    }
+    // 两份里若只有一份已经配到音频，展示那份，避免折叠后把播放/制卡能力藏掉。
+    if (!previous.hasAudio && entry.hasAudio) {
+      result[result.length - 1] = entry;
+    }
+  }
+  return List<TexthookerLineEntry>.unmodifiable(result);
+}

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+945
+version: 1.2.0+946
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/mining/gal_audio_degrade_track_test.dart
+++ b/hibiki/test/mining/gal_audio_degrade_track_test.dart
@@ -292,6 +292,14 @@ void main() {
     expect(card.contains('t.game_track_no_clips'), isTrue,
         reason: 'clipCount == 0 的轨必须标注，而不是和可用轨长一个样');
     expect(card.contains('t.game_tracks_pcm_only_hint'), isTrue);
+
+    final String workbench = File(
+      'lib/src/pages/implementations/texthooker_page.dart',
+    ).readAsStringSync();
+    expect(workbench.contains('_session.setTrackExcluded'), isTrue,
+        reason: '捕获工作台逐句选轨弹窗必须能直接把 BGM 轨加入排除集合');
+    expect(workbench.contains('t.game_track_exclude_bgm'), isTrue);
+    expect(workbench.contains('t.game_track_restore'), isTrue);
   });
 
   test('单条台词改音轨：绕开自动门取音，且延迟资源匹配不得改回去', () async {
@@ -353,6 +361,65 @@ void main() {
       outputExtension: 'aac',
     );
     expect(engine.pairedRequests, isEmpty);
+
+    await controller.close();
+    endpoints.dispose();
+  });
+
+  test('逐句选轨试听与确认必须使用同一句时间戳', () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    DateTime clock = DateTime(2020, 1, 1, 12);
+    final _FakeEngine engine = _FakeEngine(
+      rawVoice: true,
+      pairedCandidate: true,
+      utterance: GalAudioSlice(pcm: Uint8List(9600), format: kPcm),
+      lines: const <GalHookedLine>[
+        GalHookedLine(
+          seq: 1,
+          timestampMs: 4321,
+          text: '先に表示された台詞',
+          threadId: 5,
+          hookName: 'fake',
+        ),
+        GalHookedLine(
+          seq: 2,
+          timestampMs: 9876,
+          text: 'いま一番新しい台詞',
+          threadId: 5,
+          hookName: 'fake',
+        ),
+      ],
+    );
+    final _RecordingLoopback loopback = _RecordingLoopback();
+    final GalHookSessionController controller = build(
+      service: service,
+      endpoints: endpoints,
+      engine: engine,
+      loopback: loopback,
+      now: () => clock,
+    );
+
+    await controller.startAttachedCapture(
+      const ExternalWindowInfo(hwnd: 3, pid: 4242, title: 'Game'),
+    );
+    await waitUntil(() => service.entries.length == 2);
+    final TexthookerLineEntry first = service.entries.first;
+    engine.utteranceTimestamps.clear();
+    engine.utteranceSourcePtrs.clear();
+
+    final GalTrackPreview? preview =
+        await controller.exportLineTrackPreview(first.id, 0xABC);
+    expect(preview, isNotNull);
+    expect(await controller.setLineVoiceTrack(first.id, 0xABC), isTrue);
+    expect(engine.utteranceTimestamps, <int>[4321, 4321],
+        reason: '试听若偷用最新句 9876，用户会听见声音但确认当前句时却得到无音轨');
+    expect(engine.utteranceSourcePtrs, <int>[0xABC, 0xABC]);
+    final String? previewPath = preview?.filePath;
+    if (previewPath != null) {
+      final File previewFile = File(previewPath);
+      if (previewFile.existsSync()) previewFile.deleteSync();
+    }
 
     await controller.close();
     endpoints.dispose();
@@ -463,6 +530,7 @@ class _FakeEngine extends EngineHookGalAudioSource {
 
   int pollCalls = 0;
   int stopCalls = 0;
+  final List<int> utteranceTimestamps = <int>[];
   final List<int> utteranceSourcePtrs = <int>[];
   final List<int> pairedRequests = <int>[];
 
@@ -508,6 +576,7 @@ class _FakeEngine extends EngineHookGalAudioSource {
     int? sourcePtr,
     List<int>? exclude,
   }) async {
+    utteranceTimestamps.add(tsMs);
     if (sourcePtr != null) utteranceSourcePtrs.add(sourcePtr);
     return utterance;
   }

--- a/hibiki/test/sync/texthooker_service_test.dart
+++ b/hibiki/test/sync/texthooker_service_test.dart
@@ -291,6 +291,8 @@ void main() {
       expect(labels['b'], 'TextRender · 0x9c7c571 #2');
       expect(labels['c'], 'TextRender · 0x9c7c571 #3');
     });
+  });
+
   test('current session thread catalog excludes stale process-bound candidates',
       () {
     final DateTime oldSession = DateTime(2026, 7, 26, 12);

--- a/hibiki/test/sync/texthooker_service_test.dart
+++ b/hibiki/test/sync/texthooker_service_test.dart
@@ -291,5 +291,73 @@ void main() {
       expect(labels['b'], 'TextRender · 0x9c7c571 #2');
       expect(labels['c'], 'TextRender · 0x9c7c571 #3');
     });
+  test('current session thread catalog excludes stale process-bound candidates',
+      () {
+    final DateTime oldSession = DateTime(2026, 7, 26, 12);
+    final DateTime currentSession = oldSession.add(const Duration(hours: 1));
+    TexthookerService.instance.registerTextThread(
+      key: 'luna:old-textrender',
+      label: 'TextRender · 0x9c7c571',
+      nativeThreadId: 0x10,
+      discoveredAt: oldSession,
+    );
+    TexthookerService.instance.appendLine(
+      '旧会话台词',
+      textThreadKey: 'luna:old-textrender',
+      textThreadLabel: 'TextRender · 0x9c7c571',
+      nativeTextThreadId: 0x10,
+      receivedAt: oldSession.add(const Duration(seconds: 1)),
+    );
+    TexthookerService.instance.registerTextThread(
+      key: 'luna:current-textrender',
+      label: 'TextRender · 0x9c7c571',
+      nativeThreadId: 0x20,
+      discoveredAt: currentSession,
+    );
+
+    final List<TexthookerTextThread> current =
+        TexthookerService.instance.textThreadsSince(currentSession);
+    expect(current, hasLength(1));
+    expect(current.single.key, 'luna:current-textrender');
+    expect(current.single.nativeThreadId, 0x20);
+    expect(current.single.lineCount, 0,
+        reason: '当前 TextRender 尚无输出时仍可选，但不得借旧进程的历史行');
+  });
+
+  test('all-thread projection folds only simultaneous cross-thread duplicates',
+      () {
+    final DateTime at = DateTime(2026, 7, 27, 10);
+    final TexthookerLineEntry first = TexthookerService.instance.appendLine(
+      '同一句台词',
+      source: TexthookerLineSource.engineHook,
+      hookTimestampMs: 123000,
+      textThreadKey: 'luna:kiri-a',
+      receivedAt: at,
+    )!;
+    TexthookerService.instance.appendLine(
+      '同一句台词',
+      source: TexthookerLineSource.engineHook,
+      hookTimestampMs: 123008,
+      textThreadKey: 'luna:kiri-b',
+      receivedAt: at.add(const Duration(milliseconds: 8)),
+    );
+    final TexthookerLineEntry legitimateRepeat =
+        TexthookerService.instance.appendLine(
+      '同一句台词',
+      source: TexthookerLineSource.engineHook,
+      hookTimestampMs: 125000,
+      textThreadKey: 'luna:kiri-a',
+      receivedAt: at.add(const Duration(seconds: 2)),
+    )!;
+
+    expect(TexthookerService.instance.entries, hasLength(3),
+        reason: '底层逐行身份不能丢，线程选择和音频状态仍需各自的原始行');
+    expect(
+      collapseParallelTextThreadDuplicates(
+        TexthookerService.instance.entries,
+      ).map((TexthookerLineEntry entry) => entry.id),
+      <String>[first.id, legitimateRepeat.id],
+      reason: '只折叠同一渲染瞬间、不同 Hook 线程双写的那一份',
+    );
   });
 }


### PR DESCRIPTION
## 改动

- 在捕获工作台的逐句音轨选择器中加入“排除 BGM / 恢复”操作；被排除的轨不会再被选成语音轨，但仍可试听和恢复。
- 文本线程候选和工作台台词按本次捕获会话投影，避免上一个游戏进程留下的 `TextRender` 死候选。
- “全部文本线程”只在展示层折叠同一渲染瞬间、不同 Luna 线程产生的同文双写；保留原始行、稳定 id、具体线程选择和音频状态。
- 逐句音轨试听改为使用所选台词的时间戳，与确认选轨共用同一取音窗口。
- 记录 BUG-1115、BUG-1116、BUG-1117 并同步 BUG 索引。

## 根因

- 捕获页此前直接读取 `TexthookerService` 的跨会话线程目录和台词 buffer，旧进程候选会进入当前选择器。
- native 自动赢家按 hook code 放行；同一 hook code 的平行 Luna 线程可能在同一时刻各发布一份相同台词，而“全部线程”此前直接展示原始 buffer。
- 逐句试听调用通用 `exportTrackPreview`，使用最新一句时间戳；确认选轨则按当前行时间戳取音，两者可能错位。
- BGM 排除能力已存在于会话控制器，但捕获工作台缺少直接入口。

## 用户影响

- 可以在捕获工作台直接排除 BGM 轨，减少后续台词误导入背景音乐。
- TextRender 选择行为与当前 Luna 会话对齐，不再选到旧进程的零行候选。
- 同一句不会因平行 hook 线程在“全部线程”视图中显示两遍。
- 不再出现“试听有声音，确认该句却提示没有音轨”的时间窗口错位。

## 验证

- `flutter test --no-pub test/sync/texthooker_service_test.dart test/mining/gal_audio_degrade_track_test.dart test/pages/texthooker_page_test.dart test/mining/gal_hook_track_autorefresh_test.dart`（40 项通过）
- `flutter analyze --no-pub`（无问题）
- `dart run tool/bug.dart check`（1084 条，编号唯一、索引同步）

## 待验证

- 仍需在 Windows 真实游戏链路复验 TextRender、重复台词、BGM 排除和逐句选轨。
