### PR TITLE
feat(galgame): 游戏接入共享用户标签池（schema v59 · BUG-1113）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@
 - reader source：`hibiki/lib/src/media/sources/reader_hibiki_source.dart`（`ReaderHibikiSource`）。
 - 阅读器 JS/CSS：`hibiki/lib/src/reader/`（17 个 JS/CSS 注入封装，`reader_pagination_scripts.dart` 等）；JS 桥接全局是 `window.hoshiReader`（历史命名，是真实符号，勿改）。
 - 全局状态：`hibiki/lib/src/models/app_model.dart`（`AppModel`，~5150 行，初始化流程 + 子系统委托核心，改前先理解）。
-- Drift 数据库：`packages/hibiki_core/lib/src/database/database.dart` 和 `tables.dart`（schema v57，50 张表，WAL）。
+- Drift 数据库：`packages/hibiki_core/lib/src/database/database.dart` 和 `tables.dart`（schema v59，53 张表，WAL）。
 - 词典：Dart 封装 `packages/hibiki_dictionary/lib/src/engine/hoshidicts.dart` + FFI 绑定 `lib/src/ffi/hoshidicts_ffi_bindings.dart`；C++ 引擎源码全在 `native/hoshidicts/`（包内已无 C++），`hoshidicts_external/` 是 vendored 第三方，上游同步基线见 `native/hoshidicts/UPSTREAM.md`。
 - 有声书：`packages/hibiki_audio/` + `hibiki/lib/src/media/audiobook/`（导入入口 `book_import_dialog.dart` / `audiobook_import_dialog.dart`）。
 - 互联/同步：`hibiki/lib/src/sync/`（`interconnect_*.dart`、`aggregate_sync_service.dart`、`backup_*`）。
@@ -44,7 +44,7 @@
 - Flutter 版本分两处：本地钉 `.fvmrc` = `3.41.6`（pubspec `flutter: "^3.41.6"`），CI workflows 用 `3.44.0`；Dart SDK 约束 `>=3.5.0 <4.0.0`。最低 Android API 24，`compileSdk 36` / `targetSdk 35`。
 - 状态管理 Riverpod；音频 just_audio（桌面经 just_audio_media_kit）；录音 record 6.0.0；视频播放走 **media_kit**（third_party vendored 全套）+ youtube_explode_dart。
 - torrent 走内部包 `packages/hibiki_torrent`（libtorrent 2.x C ABI FFI，native 在 `native/hibiki_torrent/`；Windows 预编译 DLL 随包，缺失时回退外接 qBittorrent）。
-- 主存储是 Drift SQLite（`HibikiDatabase`，schema v57），偏好落 Drift `preferences` 表 + `profile_settings` 每 Profile 快照。**已无 Isar/Hive 依赖**；旧注释里的 Isar/Hive 不代表当前事实，先查代码再判断。
+- 主存储是 Drift SQLite（`HibikiDatabase`，schema v59），偏好落 Drift `preferences` 表 + `profile_settings` 每 Profile 快照。**已无 Isar/Hive 依赖**；旧注释里的 Isar/Hive 不代表当前事实，先查代码再判断。
 - EPUB 阅读器走 reader_hibiki 实现（见仓库地图）。`reader_ttu` key、`setTtu*` 方法、`ttu_*` i18n 只是旧数据兼容残留，不代表还有 TTU 阅读器；没有迁移方案别随手改这些持久化 key。（旧文档提过的 `ttuBookId` 列在当前 schema 已不存在，只活在迁移阶梯里。）
 - 旧 TTU 迁移代码已移除（develop `90c37b472`：`TtuMigrationServer` / `TtuIdbReader` / `assets/ttu-ebook-reader` 均已删除）；只剩上述命名残留作旧数据兼容。阅读器渲染/交互问题按 reader_hibiki 路径修，不要去上游 ttu fork 仓库改。
 - 词典导入/查询核心走 `hoshidicts` C++ FFI；格式 UI 或旧 Dart format 类不一定是真实导入路径。

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -54,7 +54,7 @@
 | [BUG-1116](bugs/BUG-1116-reader-settings-prefcodec-one-way.md) | ✅ | ✅ | reader-settings-prefcodec-one-way |
 | [BUG-1115](bugs/BUG-1115-default-documents-root-flat.md) | ✅ | ✅ | 默认数据根时 16 个 Hibiki 目录直接摊在用户文档根下 |
 | [BUG-1114](bugs/BUG-1114-local-rig-rate-limit-flake.md) | 🚧 | 🚧 | 内置引擎本地 rig 测试：限速对 loopback peer 不生效导致 peer 观察窗口消失（flaky） |
-| [BUG-1113](bugs/BUG-1113-galgame-no-tags.md) | 🚧 | 🚧 | 游戏没有标签：schema 缺 GalgameTagMappings 表 |
+| [BUG-1113](bugs/BUG-1113-galgame-no-tags.md) | ✅ | ✅ | 游戏没有标签：schema 缺 GalgameTagMappings 表 |
 | [BUG-1112](bugs/BUG-1112-activity-timeline-game-no-cover.md) | ✅ | ✅ | 活动时间轴游戏条目只有图标没有封面 |
 | [BUG-1111](bugs/BUG-1111-dashboard-continue-recent-missing-games.md) | ✅ | ✅ | 首页继续与最近添加装不下游戏：_ContinueEntry 用 isVideo 二元标志 |
 | [BUG-1110](bugs/BUG-1110-narrow-screen-hides-degrade-reason.md) | ✅ | ✅ | 捕获工作台窄屏时藏掉降级原因，只留一个「已降级」徽章 |

--- a/docs/bugs/BUG-1113-galgame-no-tags.md
+++ b/docs/bugs/BUG-1113-galgame-no-tags.md
@@ -19,6 +19,7 @@
   - 故映射表**刻意不带 `addedAt`**（书/视频那一列是 LWW-element-set 的 add 时钟，只为同步裁决而存在），`BookTagMembershipTombstones` 也不覆盖游戏。范式对齐 `CollectionTagMappings`（同样无时钟无墓碑）。
   - 全量备份恢复走整库文件拷贝，本表随之原样还原，无需额外工作。
   - 将来若真要同步游戏标签，先决条件是先给游戏一个跨设备稳定身份（内容派生 key）；在那之前加时钟只会让人误以为它在同步。
+- **⚠️ schema 版本撞号（落地前必读）**：PR#451（`codex/media-auto-tracking`，Bangumi 自动记录，同为 draft）**也占了 schemaVersion 57**，其 `if (from < 57)` 建 `media_tracking_mappings` / `media_tracking_outbox`。两套迁移互不相干（不同表、无共用列），仅版本号需串行化：谁先合谁占 57，**后落地的一方改成 58**（`schemaVersion => 58` + `if (from < 58)` + 各迁移测试里的版本字面量）。
 - **备注**：
   - 本条**刻意不与** [BUG-1111](BUG-1111-dashboard-continue-recent-missing-games.md) / [BUG-1112](BUG-1112-activity-timeline-game-no-cover.md) 同 PR：那两条是纯展示层收口（无 schema 变更），本条要动 schema + 迁移 + 同步语义，混在一起会让一个 PR 同时承担「不可逆的 DB 迁移」和「UI 改动」两种风险。
   - 游戏有**两套标签**，本次刻意不合并：① 用户标签（本 BUG，共享 `BookTags` 彩色标签池，与书/字幕书/视频/合集同一份）；② 元数据标签（bgm/vndb 刮削来的作品标签，存 `GalgameSources.dataJson` + `Galgames.customDataJson`，由库页筛选面板按名筛）。后者动辄上百个且随刮削变动，塞进共享池会污染书/视频的手工标签。两条轴 AND 生效。

--- a/docs/bugs/BUG-1113-galgame-no-tags.md
+++ b/docs/bugs/BUG-1113-galgame-no-tags.md
@@ -4,8 +4,22 @@
   - `packages/hibiki_core/lib/src/database/tables.dart` 里标签映射表只有四张：`BookTagMappings` / `SrtBookTagMappings` / `VideoBookTagMappings` / `CollectionTagMappings`，**没有游戏的**。
   - 标签池 `BookTags` 是共享的，筛选 UI（`tag_filter_bar.dart` / `tag_filter_sheet.dart` / `selectedTagIdsProvider`）也已是书架与视频页共用——即上层早已统一，唯独游戏没有落表就接不进来。
   - 因此这条**不能靠改 UI 修**：要加表 + schema 迁移，属独立工程。
-- **[ ] ① 未修复** — 需要：新增 `GalgameTagMappings`(gameId → tagId，FK cascade 对齐 `GalgameSources`/`GalgameSessions` 的做法) + schema 版本迁移；游戏库页接入既有 `tag_filter_bar` / `tag_filter_sheet`；标签管理页把游戏纳入统计；同步/备份侧确认标签墓碑（`BookTagMembershipTombstones`）是否需要覆盖游戏——注意游戏是**本机局域身份**（`galgames.id`），跨端同步语义要先定，不能照抄书的做法。
-- **[ ] ② 未加自动化测试** —
+- **[x] ① 已修复** — schema v58→**v59**：
+  - 新表 `GalgameTagMappings`（`packages/hibiki_core/lib/src/database/tables.dart`：gameId→`Galgames.id` cascade、tagId→`BookTags.id` cascade、`{gameId,tagId}` UNIQUE），`database.dart` 的 `if (from < 57)` 守卫建表 + `_ensureIndexes` 两个索引。
+  - DB API 一组：`getTagsForGame` / `addTagToGame` / `removeTagFromGame` / `setTagsForGame` / `getGameIdsForAllTags` / `getAllGameTagMappings`；`countBooksForTag` 把游戏计入标签管理页统计（否则只给游戏打的标签在管理页恒显示 0，与旧的视频漏计同型）。
+  - UI：`games_library_page.dart` 接既有 `HibikiTagFilterBar`（共享同一个 `selectedTagIdsProvider`）、卡片菜单加「标签」→ 共享 `TagPickerPage(media: MediaRef(kind: MediaKind.game, ...))`、`galgame_detail_page.dart` 的 meta 网格加「我的标签」格；`tag_filter_sheet.dart` 补 `gameTagMapProvider` / `filteredGameIdsProvider`。
+  - 用户标签白名单在纯函数 `applyGalgameLibraryView(..., allowedIds:)` 一处收口，不在页面里二次过滤。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/database/galgame_tags_test.dart`（CRUD 幂等 / 差集 set / AND 筛选 / 双向 cascade / `countBooksForTag` 含游戏）
+  - `hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart`（真实 v58→v59 迁移：既有游戏行零破坏、升级后无标签、新表可写、fresh 库 onCreate 也建出）
+  - `hibiki/test/pages/games_library_user_tags_test.dart`（真页面：标签栏渲染、点 chip 真筛掉不匹配的游戏、空态文案、卡片菜单「标签」进 `TagPickerPage` 并真写穿 DB）
+  - `hibiki/test/mining/galgame_library_query_test.dart`（`allowedIds` 三例：null 不过滤 / 白名单 / 与元数据标签+搜索 AND）
+- **跨端同步语义（先决问题，已定契约）**：**游戏标签不跨端传播、不建墓碑**。判据是真凭据而非偏好：
+  - `galgames` 整张表**不进** live-sync 清单（`hibiki/lib/src/sync/app_model_library_host_service.dart` 只导出书与视频的标签），也**不进**备份合并导入（`backup_merge_engine.dart` 零 galgame 语句）。游戏身份 `galgames.id` 是添加时刻微秒戳 = 本机局域身份，对端根本没有对应行可挂。
+  - 故映射表**刻意不带 `addedAt`**（书/视频那一列是 LWW-element-set 的 add 时钟，只为同步裁决而存在），`BookTagMembershipTombstones` 也不覆盖游戏。范式对齐 `CollectionTagMappings`（同样无时钟无墓碑）。
+  - 全量备份恢复走整库文件拷贝，本表随之原样还原，无需额外工作。
+  - 将来若真要同步游戏标签，先决条件是先给游戏一个跨设备稳定身份（内容派生 key）；在那之前加时钟只会让人误以为它在同步。
 - **备注**：
   - 本条**刻意不与** [BUG-1111](BUG-1111-dashboard-continue-recent-missing-games.md) / [BUG-1112](BUG-1112-activity-timeline-game-no-cover.md) 同 PR：那两条是纯展示层收口（无 schema 变更），本条要动 schema + 迁移 + 同步语义，混在一起会让一个 PR 同时承担「不可逆的 DB 迁移」和「UI 改动」两种风险。
-  - 跨端同步语义是先决问题：对端没有对应 `galgames` 行时，游戏标签成员该静默忽略还是不同步，需先定契约。
+  - 游戏有**两套标签**，本次刻意不合并：① 用户标签（本 BUG，共享 `BookTags` 彩色标签池，与书/字幕书/视频/合集同一份）；② 元数据标签（bgm/vndb 刮削来的作品标签，存 `GalgameSources.dataJson` + `Galgames.customDataJson`，由库页筛选面板按名筛）。后者动辄上百个且随刮削变动，塞进共享池会污染书/视频的手工标签。两条轴 AND 生效。
+  - 已知遗留（非本 BUG 范围）：游戏海报卡 `GalgamePosterCard` 无标签 chip 槽位（固定 0.62 槽比，加 chip 行要改共享组件布局）。当前用户标签在**详情页**与**筛选栏**可见，网格卡上不显示。

--- a/docs/bugs/BUG-1113-galgame-no-tags.md
+++ b/docs/bugs/BUG-1113-galgame-no-tags.md
@@ -19,7 +19,7 @@
   - 故映射表**刻意不带 `addedAt`**（书/视频那一列是 LWW-element-set 的 add 时钟，只为同步裁决而存在），`BookTagMembershipTombstones` 也不覆盖游戏。范式对齐 `CollectionTagMappings`（同样无时钟无墓碑）。
   - 全量备份恢复走整库文件拷贝，本表随之原样还原，无需额外工作。
   - 将来若真要同步游戏标签，先决条件是先给游戏一个跨设备稳定身份（内容派生 key）；在那之前加时钟只会让人误以为它在同步。
-- **⚠️ schema 版本撞号（落地前必读）**：PR#451（`codex/media-auto-tracking`，Bangumi 自动记录，同为 draft）**也占了 schemaVersion 57**，其 `if (from < 57)` 建 `media_tracking_mappings` / `media_tracking_outbox`。两套迁移互不相干（不同表、无共用列），仅版本号需串行化：谁先合谁占 57，**后落地的一方改成 58**（`schemaVersion => 58` + `if (from < 58)` + 各迁移测试里的版本字面量）。
+- **schema 版本串行化结果**：命名统一占 v57、PR#451 的 Bangumi 自动记录占 v58；本修复最终使用 v59，新建 `galgame_tag_mappings`。
 - **备注**：
   - 本条**刻意不与** [BUG-1111](BUG-1111-dashboard-continue-recent-missing-games.md) / [BUG-1112](BUG-1112-activity-timeline-game-no-cover.md) 同 PR：那两条是纯展示层收口（无 schema 变更），本条要动 schema + 迁移 + 同步语义，混在一起会让一个 PR 同时承担「不可逆的 DB 迁移」和「UI 改动」两种风险。
   - 游戏有**两套标签**，本次刻意不合并：① 用户标签（本 BUG，共享 `BookTags` 彩色标签池，与书/字幕书/视频/合集同一份）；② 元数据标签（bgm/vndb 刮削来的作品标签，存 `GalgameSources.dataJson` + `Galgames.customDataJson`，由库页筛选面板按名筛）。后者动辄上百个且随刮削变动，塞进共享池会污染书/视频的手工标签。两条轴 AND 生效。

--- a/hibiki/CLAUDE.md
+++ b/hibiki/CLAUDE.md
@@ -159,7 +159,7 @@ Hibiki 的 Flutter 多平台主应用：日语 EPUB 阅读器，集成划词查�
 
 ## 数据模型
 
-数据模型全部定义在 `hibiki_core`（50 张 Drift 表，schema v55），本模块仅消费。互联配对设备表 `HibikiPairedPeers` 也在其中。
+数据模型全部定义在 `hibiki_core`（53 张 Drift 表，schema v59），本模块仅消费。互联配对设备表 `HibikiPairedPeers` 也在其中。
 
 ## 测试与质量
 

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 44744 (2632 per locale)
+/// Strings: 44761 (2633 per locale)
 ///
-/// Built on 2026-07-27 at 07:23 UTC
+/// Built on 2026-07-27 at 08:00 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3506,6 +3506,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get game_line_tracks_hint =>
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   String get game_line_track_use => 'Use for this line';
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -9492,6 +9493,8 @@ class _StringsAr extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -15546,6 +15549,8 @@ class _StringsDe extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -21616,6 +21621,8 @@ class _StringsEs extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -27697,6 +27704,8 @@ class _StringsFr extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -33707,6 +33716,8 @@ class _StringsId extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -39763,6 +39774,8 @@ class _StringsIt extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -45635,6 +45648,8 @@ class _StringsJa extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -51509,6 +51524,8 @@ class _StringsKo extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -57545,6 +57562,8 @@ class _StringsNl extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -63594,6 +63613,8 @@ class _StringsPtBr extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -69627,6 +69648,8 @@ class _StringsRu extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -75608,6 +75631,8 @@ class _StringsTh extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -81621,6 +81646,8 @@ class _StringsTr extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -87619,6 +87646,8 @@ class _StringsVi extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 // Path: <root>
@@ -93206,6 +93235,8 @@ class _StringsZhCn extends _StringsEn {
   String get game_line_tracks_hint => '按本句时刻试听各轨，确认是 BGM 就排除';
   @override
   String get game_line_track_use => '用于本句';
+  @override
+  String get game_user_tags_title => '我的标签';
 }
 
 // Path: <root>
@@ -99000,6 +99031,8 @@ class _StringsZhHk extends _StringsEn {
       'Preview each track at this line\'s moment, then exclude the BGM ones';
   @override
   String get game_line_track_use => 'Use for this line';
+  @override
+  String get game_user_tags_title => 'My tags';
 }
 
 /// Flat map(s) containing all translations.
@@ -104380,6 +104413,8 @@ extension on _StringsEn {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -109758,6 +109793,8 @@ extension on _StringsAr {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -115157,6 +115194,8 @@ extension on _StringsDe {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -120555,6 +120594,8 @@ extension on _StringsEs {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -125959,6 +126000,8 @@ extension on _StringsFr {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -131345,6 +131388,8 @@ extension on _StringsId {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -136746,6 +136791,8 @@ extension on _StringsIt {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -142109,6 +142156,8 @@ extension on _StringsJa {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -147476,6 +147525,8 @@ extension on _StringsKo {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -152870,6 +152921,8 @@ extension on _StringsNl {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -158261,6 +158314,8 @@ extension on _StringsPtBr {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -163657,6 +163712,8 @@ extension on _StringsRu {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -169037,6 +169094,8 @@ extension on _StringsTh {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -174426,6 +174485,8 @@ extension on _StringsTr {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -179810,6 +179871,8 @@ extension on _StringsVi {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }
@@ -185148,6 +185211,8 @@ extension on _StringsZhCn {
         return '按本句时刻试听各轨，确认是 BGM 就排除';
       case 'game_line_track_use':
         return '用于本句';
+      case 'game_user_tags_title':
+        return '我的标签';
       default:
         return null;
     }
@@ -190506,6 +190571,8 @@ extension on _StringsZhHk {
         return 'Preview each track at this line\'s moment, then exclude the BGM ones';
       case 'game_line_track_use':
         return 'Use for this line';
+      case 'game_user_tags_title':
+        return 'My tags';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "完成补录",
   "game_line_tracks": "本句音轨",
   "game_line_tracks_hint": "按本句时刻试听各轨，确认是 BGM 就排除",
-  "game_line_track_use": "用于本句"
+  "game_line_track_use": "用于本句",
+  "game_user_tags_title": "我的标签"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2630,5 +2630,6 @@
   "game_line_recapture_stop": "Finish recapture",
   "game_line_tracks": "Tracks for this line",
   "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
-  "game_line_track_use": "Use for this line"
+  "game_line_track_use": "Use for this line",
+  "game_user_tags_title": "My tags"
 }

--- a/hibiki/lib/src/mining/galgame_library_query.dart
+++ b/hibiki/lib/src/mining/galgame_library_query.dart
@@ -268,13 +268,20 @@ int _compareTitleThenId(GalgameEntry a, GalgameEntry b) {
 }
 
 /// 筛选 + 搜索 + 排序，一步得到库页要渲染的列表。纯函数，不改入参。
+///
+/// [allowedIds] 是**用户标签**（共享 [BookTags] 池，BUG-1113）筛出的游戏 id 白名单：
+/// null = 没选任何用户标签 = 不过滤；非 null = 只保留集合内的游戏。它来自 DB 查询
+/// （`getGameIdsForAllTags`）而不是 [GalgameLibraryView] 里的元数据标签集，两条轴
+/// 正交、可同时生效；在这里收口是为了让库页只有一处过滤逻辑，不必在页面里再筛一遍。
 List<GalgameEntry> applyGalgameLibraryView(
   List<GalgameEntry> games,
-  GalgameLibraryView view,
-) {
+  GalgameLibraryView view, {
+  Set<String>? allowedIds,
+}) {
   final List<GalgameEntry> out = <GalgameEntry>[
     for (final GalgameEntry game in games)
-      if (matchesGalgameFilters(game, view) &&
+      if ((allowedIds == null || allowedIds.contains(game.id)) &&
+          matchesGalgameFilters(game, view) &&
           matchesGalgameSearch(game, view.search))
         game,
   ];

--- a/hibiki/lib/src/pages/implementations/galgame_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_detail_page.dart
@@ -18,6 +18,9 @@ import 'package:hibiki/src/mining/metadata/galgame_metadata_merge.dart';
 import 'package:hibiki/src/mining/metadata/galgame_metadata_source.dart';
 import 'package:hibiki/src/pages/implementations/games_library_page.dart'
     show formatGalgameDate, galgamePlayStatusLabel;
+import 'package:hibiki/src/pages/implementations/tag_filter_sheet.dart'
+    show allTagsProvider, filteredGameIdsProvider, gameTagMapProvider;
+import 'package:hibiki/src/pages/implementations/tag_picker_page.dart';
 import 'package:hibiki/src/pages/implementations/stat_charts.dart';
 import 'package:hibiki/src/pages/implementations/stat_shared.dart'
     show formatStatTime;
@@ -85,6 +88,9 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
   /// 折叠前展示的标签上限（契约 §2）。
   static const int _kTagLimit = 40;
 
+  /// 本游戏挂的共享用户标签，与 bgm/vndb 元数据标签分开。
+  List<BookTagRow> _userTags = const <BookTagRow>[];
+
   bool _loading = true;
 
   @override
@@ -114,6 +120,8 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
     }
     final List<GalgameSessionRow> sessions = await _repo.sessions(game.id);
     final List<GalgameSourceRow> sources = await _repo.sourcesOf(game.id);
+    final List<BookTagRow> userTags =
+        await _appModel.database.getTagsForGame(game.id);
     final Map<String, int> daily = await _loadRange(game.id, _rangeDays);
     final String todayKey = formatGalgameDate(DateTime.now());
     final Map<String, int> today = await _repo.dailySeconds(
@@ -126,6 +134,7 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
       _game = game;
       _sessions = sessions;
       _sources = sources;
+      _userTags = userTags;
       _dailyRange = daily;
       _todaySeconds = today[todayKey] ?? 0;
       _loading = false;
@@ -339,6 +348,51 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
     );
   }
 
+  Widget _userTagsCell(BuildContext context, GalgameEntry game) {
+    return _metaCell(
+      context,
+      t.game_user_tags_title,
+      Wrap(
+        spacing: 6,
+        runSpacing: 4,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: <Widget>[
+          for (final BookTagRow tag in _userTags)
+            HibikiTagChip(
+              label: tag.name,
+              color: Color(tag.colorValue),
+              tone: HibikiTagChipTone.surface,
+            ),
+          HibikiActionChip(
+            label: t.tag_manage,
+            icon: Icons.sell_outlined,
+            onPressed: () => unawaited(_editUserTags(game)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _editUserTags(GalgameEntry game) async {
+    await Navigator.push(
+      context,
+      adaptivePageRoute(
+        context: context,
+        builder: (_) => TagPickerPage(
+          media: MediaRef(kind: MediaKind.game, entryKey: game.id),
+        ),
+      ),
+    );
+    if (!mounted) return;
+    final List<BookTagRow> tags =
+        await _appModel.database.getTagsForGame(game.id);
+    if (!mounted) return;
+    setState(() => _userTags = tags);
+    ref.invalidate(allTagsProvider);
+    ref.invalidate(gameTagMapProvider);
+    ref.invalidate(filteredGameIdsProvider);
+  }
+
   /// 元信息网格：每项「粗体 label + 下方 value」，flex-wrap（契约 §2）。
   Widget _metaGrid(BuildContext context, GalgameEntry game) {
     final GalgameMetadataDraft meta = game.metadata;
@@ -361,6 +415,7 @@ class _GalgameDetailPageState extends ConsumerState<GalgameDetailPage>
             '${meta.averageHours!.toStringAsFixed(1)} h'),
       if (meta.rank != null)
         _metaTextCell(context, t.game_meta_ranking, '#${meta.rank}'),
+      _userTagsCell(context, game),
     ];
     return Wrap(runSpacing: 4, children: cells);
   }

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -26,6 +26,9 @@ import 'package:hibiki/src/pages/implementations/galgame_detail_page.dart';
 import 'package:hibiki/src/pages/implementations/media_collection_grid_detail_page.dart';
 import 'package:hibiki/src/pages/implementations/media_item_dialog_page.dart'
     show DialogDangerAction, DialogQuickAction, MediaItemDialogFrame;
+import 'package:hibiki/src/pages/implementations/tag_filter_bar.dart';
+import 'package:hibiki/src/pages/implementations/tag_filter_sheet.dart';
+import 'package:hibiki/src/pages/implementations/tag_picker_page.dart';
 import 'package:hibiki/utils.dart';
 
 // 游戏进合集（统一媒体库）：mediaType 用 [MediaKind.game]（P5 枚举地基，取代旧
@@ -141,7 +144,8 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   }
 
   /// 当前要渲染的列表（筛选 + 搜索 + 排序，纯函数）。
-  List<GalgameEntry> get _visible => applyGalgameLibraryView(_games, _view);
+  List<GalgameEntry> _visibleFor(Set<String>? allowedIds) =>
+      applyGalgameLibraryView(_games, _view, allowedIds: allowedIds);
 
   /// 添加游戏：文件选择器选一个 `.exe`，以文件名去扩展名作默认名，追加进列表。
   ///
@@ -460,7 +464,11 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
 
   @override
   Widget build(BuildContext context) {
-    final List<GalgameEntry> visible = _visible;
+    final List<BookTagRow> allTags =
+        ref.watch(allTagsProvider).valueOrNull ?? const <BookTagRow>[];
+    final Set<String>? allowedIds =
+        ref.watch(filteredGameIdsProvider).valueOrNull;
+    final List<GalgameEntry> visible = _visibleFor(allowedIds);
     final Widget grid = _games.isEmpty
         ? _buildEmpty(context)
         : (visible.isEmpty
@@ -473,6 +481,7 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
       child: Column(
         children: <Widget>[
           if (_games.isNotEmpty) _buildToolbar(context),
+          if (_games.isNotEmpty) _buildTagFilterBar(allTags),
           Expanded(child: grid),
         ],
       ),
@@ -577,6 +586,47 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
         ],
       ),
     );
+  }
+
+  Widget _buildTagFilterBar(List<BookTagRow> tags) {
+    return HibikiTagFilterBar(
+      tags: tags,
+      onToggleFilter: _toggleTagFilter,
+      onReorder: _reorderTags,
+      onTagsChanged: () => ref.invalidate(gameTagMapProvider),
+    );
+  }
+
+  void _toggleTagFilter(int tagId) {
+    final Set<int> next = Set<int>.from(ref.read(selectedTagIdsProvider));
+    if (!next.remove(tagId)) next.add(tagId);
+    ref.read(selectedTagIdsProvider.notifier).state = next;
+  }
+
+  Future<void> _reorderTags(int oldIndex, int newIndex) async {
+    final List<BookTagRow>? tags = ref.read(allTagsProvider).valueOrNull;
+    if (tags == null) return;
+    final List<BookTagRow> reordered = List<BookTagRow>.from(tags);
+    final BookTagRow moved = reordered.removeAt(oldIndex);
+    reordered.insert(newIndex, moved);
+    await _appModel.database
+        .reorderTags(reordered.map((BookTagRow tag) => tag.id).toList());
+    ref.invalidate(allTagsProvider);
+  }
+
+  Future<void> _openTagPicker(GalgameEntry game) async {
+    await Navigator.push(
+      context,
+      adaptivePageRoute(
+        context: context,
+        builder: (_) => TagPickerPage(
+          media: MediaRef(kind: MediaKind.game, entryKey: game.id),
+        ),
+      ),
+    );
+    ref.invalidate(allTagsProvider);
+    ref.invalidate(gameTagMapProvider);
+    ref.invalidate(filteredGameIdsProvider);
   }
 
   /// 筛选面板：状态 / 本地·在线 / 标签多选 / NSFW 隐藏。改动即时生效并持久化。
@@ -882,6 +932,7 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
       onDetail: () => unawaited(_openDetail(game)),
       onScrape: () => unawaited(_openDetail(game, initialTab: 2)),
       onAddToCollection: () => unawaited(_addGameToCollection(game)),
+      onEditTags: () => unawaited(_openTagPicker(game)),
     );
   }
 }
@@ -1051,6 +1102,7 @@ class _GameCard extends StatelessWidget {
     required this.onDetail,
     required this.onScrape,
     required this.onAddToCollection,
+    required this.onEditTags,
     this.sortLabel,
   });
 
@@ -1068,6 +1120,7 @@ class _GameCard extends StatelessWidget {
   final VoidCallback onDetail;
   final VoidCallback onScrape;
   final VoidCallback onAddToCollection;
+  final VoidCallback onEditTags;
 
   /// 长按 / 右键的上下文菜单：与书卡/视频卡同款 [MediaItemDialogFrame]（封面块 +
   /// 快捷动作 chips + 底部危险区），替代旧手搓 SimpleDialog。菜单项与封面溢出菜单
@@ -1176,6 +1229,12 @@ class _GameCard extends StatelessWidget {
           danger: false,
         ),
         (
+          action: 'tags',
+          label: t.tag_label,
+          icon: Icons.sell_outlined,
+          danger: false,
+        ),
+        (
           action: 'remove',
           label: t.game_remove,
           icon: Icons.delete_outline,
@@ -1199,6 +1258,8 @@ class _GameCard extends StatelessWidget {
         onAutoCover();
       case 'collect':
         onAddToCollection();
+      case 'tags':
+        onEditTags();
       case 'remove':
         onRemove();
     }

--- a/hibiki/lib/src/pages/implementations/tag_filter_sheet.dart
+++ b/hibiki/lib/src/pages/implementations/tag_filter_sheet.dart
@@ -107,6 +107,37 @@ final filteredVideoBookUidsProvider = FutureProvider<Set<String>?>((ref) async {
   return db.getVideoBookUidsForAllTags(tagIds);
 });
 
+/// 游戏 → 用户标签列表（keyed by `galgames.id`）。与 [bookTagMapProvider] /
+/// [videoBookTagMapProvider] 同形，共用同一 [BookTags] 标签池（BUG-1113：游戏此前
+/// 根本没有映射表，接不进这套共享标签体系）。
+///
+/// 注意与游戏的**元数据标签**（bgm/vndb 刮削来的字符串，`GalgameEntry.tags`）区分：
+/// 那是外部事实、另一条筛选轴，由游戏库筛选面板按名筛，不进这个用户标签池。
+final gameTagMapProvider =
+    FutureProvider<Map<String, List<BookTagRow>>>((ref) async {
+  final db = ref.watch(appProvider).database;
+  final tags = await db.getAllTags();
+  final mappings = await db.getAllGameTagMappings();
+  final tagById = {for (final t in tags) t.id: t};
+  final Map<String, List<BookTagRow>> result = {};
+  for (final m in mappings) {
+    final tag = tagById[m.tagId];
+    if (tag != null) {
+      result.putIfAbsent(m.gameId, () => []).add(tag);
+    }
+  }
+  return result;
+});
+
+/// 当前标签筛选下命中的游戏 id 集合（共享 [selectedTagIdsProvider]，与书架 / 视频
+/// 联动）；无筛选时返回 null（= 不过滤）。
+final filteredGameIdsProvider = FutureProvider<Set<String>?>((ref) async {
+  final tagIds = ref.watch(selectedTagIdsProvider);
+  if (tagIds.isEmpty) return null;
+  final db = ref.watch(appProvider).database;
+  return db.getGameIdsForAllTags(tagIds);
+});
+
 /// 含【全部】选中标签的合集 id（无选中标签时 null = 不过滤）。合集卡按此显隐。
 final filteredCollectionIdsProvider = FutureProvider<Set<int>?>((ref) async {
   final Set<int> tagIds = ref.watch(selectedTagIdsProvider);

--- a/hibiki/lib/src/pages/implementations/tag_picker_page.dart
+++ b/hibiki/lib/src/pages/implementations/tag_picker_page.dart
@@ -8,13 +8,11 @@ import 'package:hibiki/utils.dart';
 
 class TagPickerPage extends ConsumerStatefulWidget {
   /// 两种目标二选一，共用同一标签池：媒体条目传 [media]（统一媒体身份
-  /// [MediaRef]：epub=bookKey / srt=SrtBooks.uid / video=bookUid；game 无标签
-  /// 体系，不支持）；合集传 [collectionId]（media_collections 主键）。
+  /// [MediaRef]：epub=bookKey / srt=SrtBooks.uid / video=bookUid /
+  /// game=galgames.id）；合集传 [collectionId]（media_collections 主键）。
   ///
   /// 命名统一 Phase 3.3：取代旧的 bookKey / srtBookId / videoBookUid 三个可空
   /// 参数 + isSrtBook bool 分派链。
-  // game 无标签体系：不在 const 构造里 assert（const 求值不允许读属性），由
-  // 运行时分派 switch 的 game 分支抛 UnsupportedError 拦截。
   const TagPickerPage({
     this.media,
     this.collectionId,
@@ -65,7 +63,7 @@ class _TagPickerPageState extends ConsumerState<TagPickerPage> {
       case MediaKind.video:
         return _db.getTagsForVideoBook(media.entryKey);
       case MediaKind.game:
-        throw UnsupportedError('game entries have no tag picker');
+        return _db.getTagsForGame(media.entryKey);
     }
   }
 
@@ -83,7 +81,7 @@ class _TagPickerPageState extends ConsumerState<TagPickerPage> {
       case MediaKind.video:
         return _db.addTagToVideoBook(media.entryKey, tagId);
       case MediaKind.game:
-        throw UnsupportedError('game entries have no tag picker');
+        return _db.addTagToGame(media.entryKey, tagId);
     }
   }
 
@@ -102,7 +100,7 @@ class _TagPickerPageState extends ConsumerState<TagPickerPage> {
       case MediaKind.video:
         return _db.removeTagFromVideoBook(media.entryKey, tagId);
       case MediaKind.game:
-        throw UnsupportedError('game entries have no tag picker');
+        return _db.removeTagFromGame(media.entryKey, tagId);
     }
   }
 

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+948
+version: 1.2.0+949
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/database/galgame_tags_test.dart
+++ b/hibiki/test/database/galgame_tags_test.dart
@@ -1,0 +1,197 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// BUG-1113「游戏没有标签」：游戏 ↔ 共享 `book_tags` 标签池的映射表（v57）。
+///
+/// 这套测试钉的是**上层筛选栏 / 标签管理页早已共用、唯独游戏接不进来**的那个缺口：
+/// 游戏必须与书 / 字幕书 / 视频走同一个标签池、同一套 AND 语义筛选、同一份计数。
+Future<HibikiDatabase> _openDb() async {
+  final HibikiDatabase db = HibikiDatabase.forTesting(NativeDatabase.memory());
+  addTearDown(db.close);
+  return db;
+}
+
+/// 真实文件库：`HibikiDatabase(dir)` 才会走 `PRAGMA foreign_keys = ON`，
+/// cascade 断言必须用这个（内存 forTesting 不开外键）。
+Future<HibikiDatabase> _openRealDb() async {
+  final Directory dir =
+      await Directory.systemTemp.createTemp('hibiki_galgame_tags_test_');
+  addTearDown(() async => dir.delete(recursive: true));
+  final HibikiDatabase db = HibikiDatabase(dir.path);
+  addTearDown(db.close);
+  return db;
+}
+
+Future<String> _insertGame(HibikiDatabase db, String id) async {
+  await db.upsertGalgame(GalgamesCompanion.insert(
+    id: id,
+    name: id,
+    exePath: 'Z:\\vn\\$id.exe',
+    workdir: 'Z:\\vn',
+    addedAt: 1700000000000,
+  ));
+  return id;
+}
+
+void main() {
+  group('游戏标签 CRUD', () {
+    test('加标签后可读回，且与书/视频共用同一个标签池', () async {
+      final HibikiDatabase db = await _openDb();
+      final String game = await _insertGame(db, 'g1');
+      final int tagId = await db.createTag('神作', 0xFFEF5350);
+
+      await db.addTagToGame(game, tagId);
+
+      final List<BookTagRow> tags = await db.getTagsForGame(game);
+      expect(tags, hasLength(1));
+      expect(tags.single.id, tagId, reason: '标签定义来自共享 book_tags，不是游戏私有表');
+      expect(tags.single.name, '神作');
+      expect(tags.single.colorValue, 0xFFEF5350);
+    });
+
+    test('重复 addTagToGame 幂等（撞 {gameId, tagId} UNIQUE 不抛、不重复行）', () async {
+      final HibikiDatabase db = await _openDb();
+      final String game = await _insertGame(db, 'g1');
+      final int tagId = await db.createTag('神作', 0xFF000000);
+
+      await db.addTagToGame(game, tagId);
+      await db.addTagToGame(game, tagId);
+
+      expect(await db.getTagsForGame(game), hasLength(1));
+      expect(await db.getAllGameTagMappings(), hasLength(1));
+    });
+
+    test('removeTagFromGame 只摘这一条，同标签的其它游戏不受影响', () async {
+      final HibikiDatabase db = await _openDb();
+      final String a = await _insertGame(db, 'g1');
+      final String b = await _insertGame(db, 'g2');
+      final int tagId = await db.createTag('神作', 0xFF000000);
+      await db.addTagToGame(a, tagId);
+      await db.addTagToGame(b, tagId);
+
+      await db.removeTagFromGame(a, tagId);
+
+      expect(await db.getTagsForGame(a), isEmpty);
+      expect(await db.getTagsForGame(b), hasLength(1));
+    });
+
+    test('setTagsForGame 按差集增删（不整表重建，不动其它游戏）', () async {
+      final HibikiDatabase db = await _openDb();
+      final String game = await _insertGame(db, 'g1');
+      final String other = await _insertGame(db, 'g2');
+      final int keep = await db.createTag('保留', 0xFF000000);
+      final int drop = await db.createTag('移除', 0xFF000001);
+      final int add = await db.createTag('新增', 0xFF000002);
+      await db.addTagToGame(game, keep);
+      await db.addTagToGame(game, drop);
+      await db.addTagToGame(other, drop);
+
+      await db.setTagsForGame(game, <int>{keep, add});
+
+      expect(
+        (await db.getTagsForGame(game)).map((BookTagRow t) => t.id).toSet(),
+        <int>{keep, add},
+      );
+      expect((await db.getTagsForGame(other)).single.id, drop,
+          reason: '差集更新只作用于目标游戏');
+    });
+
+    test('setTagsForGame 传空集 = 清空该游戏全部标签', () async {
+      final HibikiDatabase db = await _openDb();
+      final String game = await _insertGame(db, 'g1');
+      await db.addTagToGame(game, await db.createTag('a', 0xFF000000));
+      await db.addTagToGame(game, await db.createTag('b', 0xFF000001));
+
+      await db.setTagsForGame(game, <int>{});
+
+      expect(await db.getTagsForGame(game), isEmpty);
+    });
+  });
+
+  group('AND 语义筛选（getGameIdsForAllTags）', () {
+    test('只返回同时含全部选中标签的游戏', () async {
+      final HibikiDatabase db = await _openDb();
+      final String both = await _insertGame(db, 'both');
+      final String onlyA = await _insertGame(db, 'onlyA');
+      await _insertGame(db, 'none');
+      final int a = await db.createTag('A', 0xFF000000);
+      final int b = await db.createTag('B', 0xFF000001);
+      await db.addTagToGame(both, a);
+      await db.addTagToGame(both, b);
+      await db.addTagToGame(onlyA, a);
+
+      expect(await db.getGameIdsForAllTags(<int>{a}), <String>{both, onlyA});
+      expect(await db.getGameIdsForAllTags(<int>{a, b}), <String>{both},
+          reason: 'AND 而非 OR：与书架 getBookKeysForAllTags 同语义');
+    });
+
+    test('空标签集返回空集（调用方据此判定「不过滤」）', () async {
+      final HibikiDatabase db = await _openDb();
+      final String game = await _insertGame(db, 'g1');
+      await db.addTagToGame(game, await db.createTag('A', 0xFF000000));
+
+      expect(await db.getGameIdsForAllTags(<int>{}), isEmpty);
+    });
+  });
+
+  group('外键 cascade（真实库，foreign_keys=ON）', () {
+    test('删游戏自动清掉它的标签映射，不留孤儿', () async {
+      final HibikiDatabase db = await _openRealDb();
+      final String game = await _insertGame(db, 'g1');
+      final int tagId = await db.createTag('神作', 0xFF000000);
+      await db.addTagToGame(game, tagId);
+
+      await db.deleteGalgame(game);
+
+      expect(await db.getAllGameTagMappings(), isEmpty);
+      expect((await db.getAllTags()).single.id, tagId,
+          reason: '删游戏不该连坐删掉共享标签池里的标签');
+    });
+
+    test('删标签自动清掉全部游戏上的该标签映射', () async {
+      final HibikiDatabase db = await _openRealDb();
+      final String a = await _insertGame(db, 'g1');
+      final String b = await _insertGame(db, 'g2');
+      final int tagId = await db.createTag('神作', 0xFF000000);
+      await db.addTagToGame(a, tagId);
+      await db.addTagToGame(b, tagId);
+
+      await db.deleteTag(tagId);
+
+      expect(await db.getAllGameTagMappings(), isEmpty);
+      expect(await db.getGalgame(a), isNotNull, reason: '删标签不该连坐删游戏');
+      expect(await db.getGalgame(b), isNotNull);
+    });
+  });
+
+  group('标签管理页统计（countBooksForTag）', () {
+    test('游戏计入总数，与 EPUB / 视频相加不重不漏', () async {
+      final HibikiDatabase db = await _openDb();
+      final int tagId = await db.createTag('神作', 0xFF000000);
+
+      expect(await db.countBooksForTag(tagId), 0);
+
+      await db.addTagToGame(await _insertGame(db, 'g1'), tagId);
+      expect(await db.countBooksForTag(tagId), 1,
+          reason: 'BUG-1113：只给游戏打的标签在管理页不能恒显示 0');
+
+      await db.addTagToGame(await _insertGame(db, 'g2'), tagId);
+      expect(await db.countBooksForTag(tagId), 2);
+
+      await db.insertEpubBook(EpubBooksCompanion.insert(
+        bookKey: 'book-1',
+        title: 'book-1',
+        epubPath: '/tmp/book-1.epub',
+        extractDir: '/tmp/book-1',
+        chapterCount: 1,
+        chaptersJson: '[]',
+        importedAt: 1700000000000,
+      ));
+      await db.addTagToBook('book-1', tagId);
+      expect(await db.countBooksForTag(tagId), 3, reason: '四种媒体互不重叠，直接相加');
+    });
+  });
+}

--- a/hibiki/test/database/migration_test.dart
+++ b/hibiki/test/database/migration_test.dart
@@ -1079,7 +1079,7 @@ void main() {
       // now 31 (v30 series/shelf_entries + v31 hibiki_paired_peers). This v28 DB
       // upgrades all the way to current; TODO-894's backfill still ran (asserted
       // below). The literal had to track the bump.
-      expect(db.schemaVersion, 58,
+      expect(db.schemaVersion, 59,
           reason: 'global schemaVersion is now 38 (TODO-616 v30 + TODO-1017 '
               'v31 + TODO-1195 v32 + TODO-1204 v33 + v34 statistics_tombstones + '
               'TODO-1157 v35 stream_spec_json + TODO-1252 v36 favorite_words '
@@ -1156,7 +1156,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 58,
+      expect(db.schemaVersion, 59,
           reason:
               'TODO-1288 bumps schema to v37 (audiobook srt_books self-heal)');
 
@@ -1316,7 +1316,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 58,
+      expect(db.schemaVersion, 59,
           reason: 'global schemaVersion is now 38 (…v35 + TODO-1252 v36 + '
               'TODO-1288 v37 audiobook srt_books self-heal + v38 unified '
               'media_collections); v29->v30 '
@@ -1367,7 +1367,7 @@ void main() {
           .map((r) => r.data['name'] as String)
           .toSet();
       expect(tableNames, containsAll(['series', 'shelf_entries']));
-      expect(db.schemaVersion, 58);
+      expect(db.schemaVersion, 59);
     });
 
     test(
@@ -1376,7 +1376,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 58,
+      expect(db.schemaVersion, 59,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1410,7 +1410,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 58,
+      expect(db.schemaVersion, 59,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1450,7 +1450,7 @@ void main() {
     test('fresh DB (v35) has video_books.stream_spec_json column (TODO-1157)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 58);
+      expect(db.schemaVersion, 59);
       final cols =
           await db.customSelect("PRAGMA table_info('video_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1481,7 +1481,7 @@ void main() {
 
     test('fresh DB (v45) has media_collections.anilist_id column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 58);
+      expect(db.schemaVersion, 59);
       final cols =
           await db.customSelect("PRAGMA table_info('media_collections')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1515,7 +1515,7 @@ void main() {
 
     test('fresh DB (v46) has epub_books.completed_at column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 58);
+      expect(db.schemaVersion, 59);
       final cols =
           await db.customSelect("PRAGMA table_info('epub_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1527,7 +1527,7 @@ void main() {
         'fresh DB (v36) has favorite_words.book_key + title columns (TODO-1252)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 58);
+      expect(db.schemaVersion, 59);
       final cols =
           await db.customSelect("PRAGMA table_info('favorite_words')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();

--- a/hibiki/test/database/migration_v40_collections_test.dart
+++ b/hibiki/test/database/migration_v40_collections_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 58);
+    expect(db.schemaVersion, 59);
   });
 }

--- a/hibiki/test/database/migration_v51_pdf_format_test.dart
+++ b/hibiki/test/database/migration_v51_pdf_format_test.dart
@@ -110,6 +110,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 58);
+    expect(db.schemaVersion, 59);
   });
 }

--- a/hibiki/test/database/migration_v53_manga_reading_mode_test.dart
+++ b/hibiki/test/database/migration_v53_manga_reading_mode_test.dart
@@ -117,6 +117,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 58);
+    expect(db.schemaVersion, 59);
   });
 }

--- a/hibiki/test/database/migration_v54_video_scrape_meta_test.dart
+++ b/hibiki/test/database/migration_v54_video_scrape_meta_test.dart
@@ -154,6 +154,6 @@ CREATE TABLE video_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 58);
+    expect(db.schemaVersion, 59);
   });
 }

--- a/hibiki/test/database/migration_v55_galgame_library_test.dart
+++ b/hibiki/test/database/migration_v55_galgame_library_test.dart
@@ -122,7 +122,7 @@ CREATE TABLE preferences (
     final String? pref = await db.getPref('galgame_library');
     expect(pref, isNotNull);
 
-    expect(await userVersionOf(db), 58);
+    expect(await userVersionOf(db), 59);
   });
 
   test('脏数据被逐条跳过，不让整个迁移失败', () async {
@@ -158,7 +158,7 @@ CREATE TABLE preferences (
 
     final List<GalgameRow> rows = await db.getAllGalgames();
     expect(rows.map((GalgameRow r) => r.id), <String>['ok-1', 'ok-2']);
-    expect(await userVersionOf(db), 58);
+    expect(await userVersionOf(db), 59);
   });
 
   test('整串 JSON 损坏 / 非数组 / 空串时迁移仍然成功，只是回填为空', () async {
@@ -169,7 +169,7 @@ CREATE TABLE preferences (
     ]) {
       final HibikiDatabase db = await openV53Db(raw);
       expect(await db.getAllGalgames(), isEmpty, reason: 'raw=$raw');
-      expect(await userVersionOf(db), 58, reason: 'raw=$raw');
+      expect(await userVersionOf(db), 59, reason: 'raw=$raw');
       await db.close();
     }
   });
@@ -177,7 +177,7 @@ CREATE TABLE preferences (
   test('偏好里根本没有 galgame_library 时迁移正常，表为空', () async {
     final HibikiDatabase db = await openV53Db(null);
     expect(await db.getAllGalgames(), isEmpty);
-    expect(await userVersionOf(db), 58);
+    expect(await userVersionOf(db), 59);
   });
 
   test('回填幂等：表里已有行就不再重复回填', () async {
@@ -227,7 +227,7 @@ CREATE TABLE preferences (
       ),
     );
     expect(await db.getAllGalgames(), hasLength(1));
-    expect(await userVersionOf(db), 58);
+    expect(await userVersionOf(db), 59);
   });
 
   test('删游戏经 FK cascade 连带清掉 sources 与 sessions', () async {

--- a/hibiki/test/database/migration_v56_galgame_launch_args_test.dart
+++ b/hibiki/test/database/migration_v56_galgame_launch_args_test.dart
@@ -73,7 +73,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 58,
+    expect(db.schemaVersion, 59,
         reason: 'v56 给 galgames 加 launch_args（可配置游戏启动参数）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/hibiki/test/database/migration_v57_naming_unification_test.dart
+++ b/hibiki/test/database/migration_v57_naming_unification_test.dart
@@ -154,7 +154,8 @@ CREATE TABLE book_tag_membership_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 58, reason: 'v57 = 命名统一 Phase 4；v58 = 外部媒体自动记录');
+    expect(db.schemaVersion, 59,
+        reason: 'v57 = 命名统一；v58 = 外部媒体自动记录；v59 = 游戏标签');
 
     final Set<String> mapping = await columnsOf(db, 'video_book_tag_mappings');
     expect(mapping, contains('book_uid'));

--- a/hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart
+++ b/hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart
@@ -1,0 +1,122 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// v59 迁移（BUG-1113「游戏没有标签」）：新建 `galgame_tag_mappings`，把游戏接进书 /
+/// 字幕书 / 视频 / 合集早已共用的那一个 `book_tags` 标签池。
+///
+/// 打开一个 user_version=58 的库（v58 shape：galgames 三表 + launch_args 在场，
+/// **无** galgame_tag_mappings），触发真实的 `if (from < 59)` 建表，验证：
+///  ① 既有 galgames 行零破坏，升级后新表为空 = 全部游戏无用户标签 = 与旧版一致；
+///  ② 新表可写可读，AND 语义筛选可用；
+///  ③ 外键 cascade 双向生效（删游戏 / 删标签都自动清映射，不留孤儿）；
+///  ④ user_version 升到当前代码 schemaVersion。
+void main() {
+  Future<HibikiDatabase> openV58Db() async {
+    final HibikiDatabase db = HibikiDatabase.forTesting(
+      NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute('PRAGMA foreign_keys = OFF');
+          // v58 shape：galgames 全列在场（含 launch_args），但没有标签映射表。
+          rawDb.execute('''
+CREATE TABLE galgames (
+  id TEXT NOT NULL PRIMARY KEY,
+  name TEXT NOT NULL,
+  exe_path TEXT NOT NULL,
+  workdir TEXT NOT NULL,
+  launch_args TEXT NOT NULL DEFAULT '',
+  cover_path TEXT,
+  added_at INTEGER NOT NULL,
+  play_status INTEGER NOT NULL DEFAULT 0,
+  primary_source TEXT,
+  release_date TEXT,
+  custom_data_json TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0
+)
+''');
+          rawDb.execute('''
+CREATE TABLE galgame_sources (
+  game_id TEXT NOT NULL,
+  source TEXT NOT NULL,
+  external_id TEXT,
+  data_json TEXT NOT NULL,
+  score REAL,
+  rank INTEGER,
+  fetched_at INTEGER NOT NULL,
+  PRIMARY KEY (game_id, source)
+)
+''');
+          // 共享标签池自 v1 就在（新表要 FK 引用它），真实 v58 库必有此表。
+          rawDb.execute('''
+CREATE TABLE book_tags (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  color_value INTEGER NOT NULL DEFAULT 4288585374,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL
+)
+''');
+          rawDb.execute('''
+CREATE TABLE galgame_sessions (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  game_id TEXT NOT NULL,
+  start_ms INTEGER NOT NULL,
+  end_ms INTEGER NOT NULL,
+  duration_seconds INTEGER NOT NULL,
+  date_key TEXT NOT NULL
+)
+''');
+          rawDb.execute(
+            'INSERT INTO galgames '
+            '(id, name, exe_path, workdir, added_at, play_status, sort_order) '
+            r"VALUES ('legacy_game', '旧游戏', 'Z:\vn\game.exe', 'Z:\vn', "
+            '1700000000000, 3, 0)',
+          );
+          rawDb.execute('PRAGMA user_version = 58');
+        },
+      ),
+    );
+    addTearDown(db.close);
+    return db;
+  }
+
+  test('v59：建出 galgame_tag_mappings，既有游戏行零破坏且升级后无任何用户标签', () async {
+    final HibikiDatabase db = await openV58Db();
+
+    final version = await db.customSelect('PRAGMA user_version').getSingle();
+    expect(version.read<int>('user_version'), db.schemaVersion);
+    expect(db.schemaVersion, 59,
+        reason: 'v59 新建 galgame_tag_mappings（BUG-1113 游戏接入共享标签池）');
+
+    final GalgameRow? legacy = await db.getGalgame('legacy_game');
+    expect(legacy, isNotNull, reason: '旧游戏行原样保留');
+    expect(legacy!.name, '旧游戏');
+    expect(legacy.playStatus, 3);
+
+    // 关键的向后兼容断言：升级后新表为空 = 旧库观感逐像素不变。
+    expect(await db.getAllGameTagMappings(), isEmpty);
+    expect(await db.getTagsForGame('legacy_game'), isEmpty);
+  });
+
+  test('v59：新表可写可读，标签挂到升级前就存在的游戏上', () async {
+    final HibikiDatabase db = await openV58Db();
+
+    final int tagId = await db.createTag('通关', 0xFF00FF00);
+    await db.addTagToGame('legacy_game', tagId);
+
+    final List<BookTagRow> tags = await db.getTagsForGame('legacy_game');
+    expect(tags, hasLength(1));
+    expect(tags.single.name, '通关');
+    expect(
+        await db.getGameIdsForAllTags(<int>{tagId}), <String>{'legacy_game'});
+  });
+
+  test('v59：fresh 库由 onCreate 直接建出该表（不依赖迁移梯子）', () async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    expect(await db.getAllGameTagMappings(), isEmpty,
+        reason: 'onCreate 的 createAll 必须包含 galgame_tag_mappings');
+  });
+}

--- a/hibiki/test/mining/galgame_library_query_test.dart
+++ b/hibiki/test/mining/galgame_library_query_test.dart
@@ -214,6 +214,62 @@ void main() {
           games, const GalgameLibraryView(sortField: GalgameSortField.name));
       expect(out.map((GalgameEntry g) => g.id).toList(), <String>['a', 'z']);
     });
+
+    // BUG-1113：共享用户标签筛出的 id 白名单（DB 查询结果）与页内元数据标签筛选
+    // 是两条正交轴，都在这个纯函数里收口，同时生效。
+    test('allowedIds 为 null = 不过滤（未选任何用户标签时的行为不变）', () {
+      final List<GalgameEntry> games = <GalgameEntry>[
+        entry(id: 'a', name: 'alpha'),
+        entry(id: 'b', name: 'beta'),
+      ];
+      final List<GalgameEntry> out = applyGalgameLibraryView(
+        games,
+        const GalgameLibraryView(sortField: GalgameSortField.name),
+      );
+      expect(out.map((GalgameEntry g) => g.id).toList(), <String>['a', 'b']);
+    });
+
+    test('allowedIds 只保留白名单内的游戏，空集 = 一个都不留', () {
+      final List<GalgameEntry> games = <GalgameEntry>[
+        entry(id: 'a', name: 'alpha'),
+        entry(id: 'b', name: 'beta'),
+      ];
+      expect(
+        applyGalgameLibraryView(
+          games,
+          const GalgameLibraryView(sortField: GalgameSortField.name),
+          allowedIds: <String>{'b'},
+        ).map((GalgameEntry g) => g.id).toList(),
+        <String>['b'],
+      );
+      expect(
+        applyGalgameLibraryView(
+          games,
+          const GalgameLibraryView(sortField: GalgameSortField.name),
+          allowedIds: <String>{},
+        ),
+        isEmpty,
+      );
+    });
+
+    test('allowedIds 与元数据标签/搜索是 AND 关系，不互相覆盖', () {
+      final List<GalgameEntry> games = <GalgameEntry>[
+        entry(id: 'a', name: 'alpha', tags: <String>['学园']),
+        entry(id: 'b', name: 'alphabet', tags: <String>['学园']),
+        entry(id: 'c', name: 'alpha2'),
+      ];
+      final List<GalgameEntry> out = applyGalgameLibraryView(
+        games,
+        const GalgameLibraryView(
+          search: 'alpha',
+          tags: <String>{'学园'},
+          sortField: GalgameSortField.name,
+        ),
+        allowedIds: <String>{'b', 'c'},
+      );
+      // a 被 allowedIds 挡掉；c 没有元数据标签「学园」被挡掉；只剩 b 三条都过。
+      expect(out.map((GalgameEntry g) => g.id).toList(), <String>['b']);
+    });
   });
 
   group('视图偏好编解码', () {

--- a/hibiki/test/pages/games_library_user_tags_test.dart
+++ b/hibiki/test/pages/games_library_user_tags_test.dart
@@ -1,0 +1,175 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/mining/galgame_library.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/games_library_page.dart';
+import 'package:hibiki/src/pages/implementations/tag_filter_bar.dart';
+import 'package:hibiki/src/pages/implementations/tag_picker_page.dart';
+import 'package:hibiki/utils.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// BUG-1113「游戏没有标签」的 UI 侧守卫：游戏库页必须接上书架 / 视频页那套**共享**
+/// 用户标签体系——同一个 [HibikiTagFilterBar]、同一个标签池、同一套 AND 筛选、
+/// 同一个 [TagPickerPage] 打标签入口。
+///
+/// 全部经真 [GamesLibraryPage] + 真 Drift 表（内存库）走，不 mock：接没接上、筛没筛
+/// 中、入口通不通，由这一层钉死。
+void main() {
+  late GlobalKey<NavigatorState> navKey;
+
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  Future<(AppModel, HibikiDatabase)> buildModel() async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final PreferencesRepository prefsRepo = PreferencesRepository(db);
+    await prefsRepo.loadFromDb();
+    final Directory tmpDir =
+        Directory.systemTemp.createTempSync('hibiki_games_user_tags_');
+    addTearDown(() {
+      try {
+        tmpDir.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+    final AppModel appModel = AppModel(testPlatformServices())
+      ..wireLocalAudioForTesting(
+          prefsRepo: prefsRepo, databaseDirectory: tmpDir)
+      ..wireDatabaseForTesting(db);
+
+    await appModel.setGalgames(<GalgameEntry>[
+      GalgameEntry(
+        id: 'g1',
+        name: 'alpha',
+        exePath: r'Z:\a\alpha.exe',
+        workdir: r'Z:\a',
+        addedAt: DateTime(2026, 1, 1),
+      ),
+      GalgameEntry(
+        id: 'g2',
+        name: 'beta',
+        exePath: r'Z:\b\beta.exe',
+        workdir: r'Z:\b',
+        addedAt: DateTime(2026, 1, 2),
+      ),
+    ]);
+    return (appModel, db);
+  }
+
+  Finder cardTitle(String title) => find.descendant(
+        of: find.byType(CustomScrollView),
+        matching: find.text(title),
+      );
+
+  Future<void> pumpPage(WidgetTester tester, AppModel appModel) async {
+    navKey = GlobalKey<NavigatorState>();
+    HibikiToast.navigatorKey = navKey;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[appProvider.overrideWith((_) => appModel)],
+        child: TranslationProvider(
+          child: MaterialApp(
+            navigatorKey: navKey,
+            home: const HibikiFocusRoot(child: GamesLibraryPage()),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('游戏库顶部渲染共享标签筛选栏，标签 chip 出自共享标签池', (WidgetTester tester) async {
+    final (AppModel appModel, HibikiDatabase db) = await buildModel();
+    await db.createTag('神作', 0xFFEF5350);
+    await pumpPage(tester, appModel);
+
+    expect(find.byType(HibikiTagFilterBar), findsOneWidget,
+        reason: '必须复用书架/视频页同一组件，而不是游戏页自己手搓一条');
+    expect(
+      find.descendant(
+        of: find.byType(HibikiTagFilterBar),
+        matching: find.text('神作'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('点标签 chip 只留挂了该标签的游戏，再点取消恢复全部', (WidgetTester tester) async {
+    final (AppModel appModel, HibikiDatabase db) = await buildModel();
+    final int tagId = await db.createTag('神作', 0xFFEF5350);
+    await db.addTagToGame('g1', tagId);
+    await pumpPage(tester, appModel);
+
+    expect(cardTitle('alpha'), findsOneWidget);
+    expect(cardTitle('beta'), findsOneWidget);
+
+    await tester.tap(find.descendant(
+      of: find.byType(HibikiTagFilterBar),
+      matching: find.text('神作'),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(cardTitle('alpha'), findsOneWidget, reason: 'g1 挂了该标签');
+    expect(cardTitle('beta'), findsNothing, reason: 'g2 没挂，必须被筛掉');
+
+    await tester.tap(find.descendant(
+      of: find.byType(HibikiTagFilterBar),
+      matching: find.text('神作'),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(cardTitle('alpha'), findsOneWidget);
+    expect(cardTitle('beta'), findsOneWidget);
+  });
+
+  testWidgets('全部游戏都不挂选中标签时给「没有符合筛选」空态，而不是空库文案', (WidgetTester tester) async {
+    final (AppModel appModel, HibikiDatabase db) = await buildModel();
+    await db.createTag('神作', 0xFFEF5350);
+    await pumpPage(tester, appModel);
+
+    await tester.tap(find.descendant(
+      of: find.byType(HibikiTagFilterBar),
+      matching: find.text('神作'),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.games_no_match), findsOneWidget);
+    expect(find.text(t.games_empty), findsNothing);
+  });
+
+  testWidgets('卡片菜单有「标签」项，点开进共享 TagPickerPage 并真写穿 DB',
+      (WidgetTester tester) async {
+    final (AppModel appModel, HibikiDatabase db) = await buildModel();
+    final int tagId = await db.createTag('神作', 0xFFEF5350);
+    await pumpPage(tester, appModel);
+
+    await tester.tap(find.byIcon(Icons.more_vert).first);
+    await tester.pumpAndSettle();
+    expect(find.text(t.tag_label), findsOneWidget);
+
+    await tester.tap(find.text(t.tag_label));
+    await tester.pumpAndSettle();
+    expect(find.byType(TagPickerPage), findsOneWidget,
+        reason: '复用书/视频/合集那张选择器，不另做一套游戏专用的');
+
+    // 勾上标签：必须真落 galgame_tag_mappings（不是只改本地 state）。
+    await tester.tap(find.text('神作'));
+    await tester.pumpAndSettle();
+
+    final List<BookTagRow> tags = await db.getTagsForGame('g1');
+    expect(tags.map((BookTagRow t) => t.id).toList(), <int>[tagId]);
+  });
+}

--- a/packages/hibiki_core/CLAUDE.md
+++ b/packages/hibiki_core/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## 模块职责
 
-共享核心模块：定义 Drift SQLite 数据库 schema（50 张表，当前 schemaVersion=55）、表迁移逻辑、偏好键值编解码器（PrefCodec）、语言配置模型和文本选区模型。是所有其他 packages 的基础依赖。
+共享核心模块：定义 Drift SQLite 数据库 schema（53 张表，当前 schemaVersion=59）、表迁移逻辑、偏好键值编解码器（PrefCodec）、语言配置模型和文本选区模型。是所有其他 packages 的基础依赖。
 
 ## 入口与启动
 
@@ -26,7 +26,7 @@
 
 ## 数据模型
 
-50 张 Drift 表（按功能分组，以 `database.dart` 的 `@DriftDatabase(tables: [...])` 注册清单为准）：
+53 张 Drift 表（按功能分组，以 `database.dart` 的 `@DriftDatabase(tables: [...])` 注册清单为准）：
 
 | 分组 | 表名 |
 |------|------|
@@ -49,7 +49,7 @@
 | 收藏/制卡 | `FavoriteWords`, `MiningStatistics`, `MinedSentences`, `LookupMiningCounters` |
 | 合集/系列 | `MediaCollections`, `MediaCollectionItems`, `Series`, `ShelfEntries` |
 | 互联 | `HibikiPairedPeers` |
-| 游戏库 | `Galgames`, `GalgameSources`, `GalgameSessions` |
+| 游戏库 | `Galgames`, `GalgameSources`, `GalgameSessions`, `GalgameTagMappings` |
 | 删除墓碑 | `BookTombstones`, `StatisticsTombstones`, `CollectionMemberTombstones`, `BookTagMembershipTombstones`, `SyncDeletionTombstones` |
 
 新增表（相对旧文档的 28 张补齐的 18 张）用途：
@@ -75,8 +75,9 @@
 - `Galgames` -- v55 galgame 游戏库真相源，取代旧偏好 key `galgame_library` 的 6 字段 JSON；TEXT 主键沿用旧微秒时间戳（封面文件名与之绑定）。
 - `GalgameSources` -- 游戏元数据源纵表（`(gameId, source)` 复合键 + JSON 快照 + 上提的 score/rank），加数据源零 schema 变更。
 - `GalgameSessions` -- 游玩会话事实表，由前台窗口计时器写入（脱离 hook 文本）。**刻意无统计投影表**，时长/次数/最后游玩一律现算 GROUP BY。
+- `GalgameTagMappings` -- v59（BUG-1113）游戏 ↔ 用户标签映射（复用共享 `BookTags` 池）。**无 `addedAt` 时钟、无移除墓碑**：游戏是本机局域身份，整套游戏数据不进 live-sync 也不进备份合并导入，标签跟随宿主不跨端传播。与游戏**元数据标签**（bgm/vndb 刮削字符串）是两条正交轴。
 
-迁移策略：`onUpgrade` 逐版本增量迁移（v1->v55），支持降级时自动备份并重建。
+迁移策略：`onUpgrade` 逐版本增量迁移（v1->v57），支持降级时自动备份并重建。
 
 ## 测试与质量
 

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -395,6 +395,7 @@ _MergedTagState _mergeTagClocks(
   Galgames,
   GalgameSources,
   GalgameSessions,
+  GalgameTagMappings,
 ])
 class HibikiDatabase extends _$HibikiDatabase {
   /// [isMainProcess] gates the TODO-905 sidecar rebuild: the main app passes
@@ -413,7 +414,7 @@ class HibikiDatabase extends _$HibikiDatabase {
   HibikiDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 58;
+  int get schemaVersion => 59;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1212,6 +1213,14 @@ class HibikiDatabase extends _$HibikiDatabase {
               await m.createTable(mediaTrackingOutbox);
             }
           }
+          if (from < 59) {
+            // v59（BUG-1113「游戏没有标签」）：把游戏接进共享 BookTags 标签池。
+            // 纯新增映射表；游戏与标签均为本机局域数据，不进入 live-sync。
+            if (!await _tableExists('galgame_tag_mappings')) {
+              await m.createTable(galgameTagMappings);
+            }
+            await _ensureIndexes();
+          }
         },
         onCreate: (m) async {
           await m.createAll();
@@ -1311,8 +1320,8 @@ class HibikiDatabase extends _$HibikiDatabase {
       // tag_id lookups: countBooksForTag on each mapping table runs
       // `WHERE tag_id IN (...) GROUP BY <owner> HAVING COUNT(DISTINCT tag_id)`.
       // The existing indexes only cover the owner-key side (book_key / etc.),
-      // leaving the tag_id filter to a full scan. Add a tag_id index to all
-      // three mapping tables.
+      // leaving the tag_id filter to a full scan. Add a tag_id index to every
+      // mapping table.
       [
         'book_tag_mappings',
         'CREATE INDEX IF NOT EXISTS idx_book_tag_mappings_tag_id '
@@ -1327,6 +1336,16 @@ class HibikiDatabase extends _$HibikiDatabase {
         'video_book_tag_mappings',
         'CREATE INDEX IF NOT EXISTS idx_video_book_tag_mappings_tag_id '
             'ON video_book_tag_mappings (tag_id)'
+      ],
+      [
+        'galgame_tag_mappings',
+        'CREATE INDEX IF NOT EXISTS idx_galgame_tag_mappings_tag_id '
+            'ON galgame_tag_mappings (tag_id)'
+      ],
+      [
+        'galgame_tag_mappings',
+        'CREATE INDEX IF NOT EXISTS idx_galgame_tag_mappings_game_id '
+            'ON galgame_tag_mappings (game_id)'
       ],
       // favorite_words is filtered by source_type ('book' | 'video') in
       // getFavoritesBySource; the table had no index on it.
@@ -4841,13 +4860,13 @@ class HibikiDatabase extends _$HibikiDatabase {
         }
       });
 
-  /// 某标签下的书数量 = EPUB + 有声书(SRT) + 视频三张映射表各自命中该 tagId 的行数之和。
-  /// 标签是三种媒体共享的**同一标签池**，每张映射表按 {bookX, tagId} 唯一，其行数即该
-  /// 类型下被打此标签的书数；不同媒体类型互不重叠，直接相加即总书数。
+  /// 某标签下的条目数量 = EPUB + 有声书(SRT) + 视频 + 游戏四张映射表各自命中该
+  /// tagId 的行数之和。
   ///
   /// BUG（用户报「标签管理器显示 0 本，实际 2 本」）：旧实现只 COUNT `book_tag_mappings`
   /// （EPUB）一张表，给有声书 / 视频打的标签在管理器里恒显示 0——卡片走分类型正确查询能
-  /// 显示标签，计数却漏了另外两张表。
+  /// 显示标签，计数却漏了另外两张表。BUG-1113 同型：游戏也必须计入。
+  /// 合集刻意不计：合集是容器而非条目。
   Future<int> countBooksForTag(int tagId) async {
     final epubCnt = countAll();
     final epubRow = await (selectOnly(bookTagMappings)
@@ -4864,10 +4883,16 @@ class HibikiDatabase extends _$HibikiDatabase {
           ..where(videoBookTagMappings.tagId.equals(tagId))
           ..addColumns([videoCnt]))
         .getSingle();
+    final gameCnt = countAll();
+    final gameRow = await (selectOnly(galgameTagMappings)
+          ..where(galgameTagMappings.tagId.equals(tagId))
+          ..addColumns([gameCnt]))
+        .getSingle();
     final int epub = epubRow.read(epubCnt) ?? 0;
     final int srt = srtRow.read(srtCnt) ?? 0;
     final int video = videoRow.read(videoCnt) ?? 0;
-    return epub + srt + video;
+    final int game = gameRow.read(gameCnt) ?? 0;
+    return epub + srt + video + game;
   }
 
   // ── srt book tags ───────────────────────────────────────────────
@@ -5004,6 +5029,70 @@ class HibikiDatabase extends _$HibikiDatabase {
     ).get();
     return rows.map((row) => row.read<int>('collection_id')).toSet();
   }
+
+  // ── 游戏标签（v59 / BUG-1113；复用 BookTags 池；仅本机）──────────────
+
+  Future<List<BookTagRow>> getTagsForGame(String gameId) {
+    final query = select(bookTags).join([
+      innerJoin(
+        galgameTagMappings,
+        galgameTagMappings.tagId.equalsExp(bookTags.id),
+      ),
+    ])
+      ..where(galgameTagMappings.gameId.equals(gameId))
+      ..orderBy([OrderingTerm.asc(bookTags.createdAt)]);
+    return query.map((row) => row.readTable(bookTags)).get();
+  }
+
+  Future<void> addTagToGame(String gameId, int tagId) async {
+    await into(galgameTagMappings).insert(
+      GalgameTagMappingsCompanion.insert(gameId: gameId, tagId: tagId),
+      mode: InsertMode.insertOrIgnore,
+    );
+  }
+
+  Future<void> removeTagFromGame(String gameId, int tagId) async {
+    await (delete(galgameTagMappings)
+          ..where((t) => t.gameId.equals(gameId) & t.tagId.equals(tagId)))
+        .go();
+  }
+
+  Future<void> setTagsForGame(String gameId, Set<int> tagIds) =>
+      transaction(() async {
+        final List<GalgameTagMappingRow> existing =
+            await (select(galgameTagMappings)
+                  ..where((t) => t.gameId.equals(gameId)))
+                .get();
+        final Set<int> existingTagIds =
+            existing.map((GalgameTagMappingRow e) => e.tagId).toSet();
+        for (final int tagId in existingTagIds.difference(tagIds)) {
+          await removeTagFromGame(gameId, tagId);
+        }
+        for (final int tagId in tagIds.difference(existingTagIds)) {
+          await addTagToGame(gameId, tagId);
+        }
+      });
+
+  Future<Set<String>> getGameIdsForAllTags(Set<int> tagIds) async {
+    if (tagIds.isEmpty) return <String>{};
+    final int tagCount = tagIds.length;
+    final String placeholders = List.generate(tagCount, (_) => '?').join(',');
+    final List<Variable> variables = <Variable>[
+      ...tagIds.map((id) => Variable<int>(id)),
+      Variable<int>(tagCount),
+    ];
+    final rows = await customSelect(
+      'SELECT game_id FROM galgame_tag_mappings '
+      'WHERE tag_id IN ($placeholders) '
+      'GROUP BY game_id '
+      'HAVING COUNT(DISTINCT tag_id) = ?',
+      variables: variables,
+    ).get();
+    return rows.map((row) => row.read<String>('game_id')).toSet();
+  }
+
+  Future<List<GalgameTagMappingRow>> getAllGameTagMappings() =>
+      select(galgameTagMappings).get();
 
   Future<void> setTagsForVideoBook(String videoBookUid, Set<int> tagIds) =>
       transaction(() async {

--- a/packages/hibiki_core/lib/src/database/database.g.dart
+++ b/packages/hibiki_core/lib/src/database/database.g.dart
@@ -20631,6 +20631,234 @@ class GalgameSessionsCompanion extends UpdateCompanion<GalgameSessionRow> {
   }
 }
 
+class $GalgameTagMappingsTable extends GalgameTagMappings
+    with TableInfo<$GalgameTagMappingsTable, GalgameTagMappingRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $GalgameTagMappingsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _gameIdMeta = const VerificationMeta('gameId');
+  @override
+  late final GeneratedColumn<String> gameId = GeneratedColumn<String>(
+      'game_id', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'REFERENCES galgames (id) ON DELETE CASCADE'));
+  static const VerificationMeta _tagIdMeta = const VerificationMeta('tagId');
+  @override
+  late final GeneratedColumn<int> tagId = GeneratedColumn<int>(
+      'tag_id', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'REFERENCES book_tags (id) ON DELETE CASCADE'));
+  @override
+  List<GeneratedColumn> get $columns => [id, gameId, tagId];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'galgame_tag_mappings';
+  @override
+  VerificationContext validateIntegrity(
+      Insertable<GalgameTagMappingRow> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('game_id')) {
+      context.handle(_gameIdMeta,
+          gameId.isAcceptableOrUnknown(data['game_id']!, _gameIdMeta));
+    } else if (isInserting) {
+      context.missing(_gameIdMeta);
+    }
+    if (data.containsKey('tag_id')) {
+      context.handle(
+          _tagIdMeta, tagId.isAcceptableOrUnknown(data['tag_id']!, _tagIdMeta));
+    } else if (isInserting) {
+      context.missing(_tagIdMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+        {gameId, tagId},
+      ];
+  @override
+  GalgameTagMappingRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return GalgameTagMappingRow(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      gameId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}game_id'])!,
+      tagId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}tag_id'])!,
+    );
+  }
+
+  @override
+  $GalgameTagMappingsTable createAlias(String alias) {
+    return $GalgameTagMappingsTable(attachedDatabase, alias);
+  }
+}
+
+class GalgameTagMappingRow extends DataClass
+    implements Insertable<GalgameTagMappingRow> {
+  final int id;
+  final String gameId;
+  final int tagId;
+  const GalgameTagMappingRow(
+      {required this.id, required this.gameId, required this.tagId});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['game_id'] = Variable<String>(gameId);
+    map['tag_id'] = Variable<int>(tagId);
+    return map;
+  }
+
+  GalgameTagMappingsCompanion toCompanion(bool nullToAbsent) {
+    return GalgameTagMappingsCompanion(
+      id: Value(id),
+      gameId: Value(gameId),
+      tagId: Value(tagId),
+    );
+  }
+
+  factory GalgameTagMappingRow.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return GalgameTagMappingRow(
+      id: serializer.fromJson<int>(json['id']),
+      gameId: serializer.fromJson<String>(json['gameId']),
+      tagId: serializer.fromJson<int>(json['tagId']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'gameId': serializer.toJson<String>(gameId),
+      'tagId': serializer.toJson<int>(tagId),
+    };
+  }
+
+  GalgameTagMappingRow copyWith({int? id, String? gameId, int? tagId}) =>
+      GalgameTagMappingRow(
+        id: id ?? this.id,
+        gameId: gameId ?? this.gameId,
+        tagId: tagId ?? this.tagId,
+      );
+  GalgameTagMappingRow copyWithCompanion(GalgameTagMappingsCompanion data) {
+    return GalgameTagMappingRow(
+      id: data.id.present ? data.id.value : this.id,
+      gameId: data.gameId.present ? data.gameId.value : this.gameId,
+      tagId: data.tagId.present ? data.tagId.value : this.tagId,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('GalgameTagMappingRow(')
+          ..write('id: $id, ')
+          ..write('gameId: $gameId, ')
+          ..write('tagId: $tagId')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, gameId, tagId);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is GalgameTagMappingRow &&
+          other.id == this.id &&
+          other.gameId == this.gameId &&
+          other.tagId == this.tagId);
+}
+
+class GalgameTagMappingsCompanion
+    extends UpdateCompanion<GalgameTagMappingRow> {
+  final Value<int> id;
+  final Value<String> gameId;
+  final Value<int> tagId;
+  const GalgameTagMappingsCompanion({
+    this.id = const Value.absent(),
+    this.gameId = const Value.absent(),
+    this.tagId = const Value.absent(),
+  });
+  GalgameTagMappingsCompanion.insert({
+    this.id = const Value.absent(),
+    required String gameId,
+    required int tagId,
+  })  : gameId = Value(gameId),
+        tagId = Value(tagId);
+  static Insertable<GalgameTagMappingRow> custom({
+    Expression<int>? id,
+    Expression<String>? gameId,
+    Expression<int>? tagId,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (gameId != null) 'game_id': gameId,
+      if (tagId != null) 'tag_id': tagId,
+    });
+  }
+
+  GalgameTagMappingsCompanion copyWith(
+      {Value<int>? id, Value<String>? gameId, Value<int>? tagId}) {
+    return GalgameTagMappingsCompanion(
+      id: id ?? this.id,
+      gameId: gameId ?? this.gameId,
+      tagId: tagId ?? this.tagId,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (gameId.present) {
+      map['game_id'] = Variable<String>(gameId.value);
+    }
+    if (tagId.present) {
+      map['tag_id'] = Variable<int>(tagId.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('GalgameTagMappingsCompanion(')
+          ..write('id: $id, ')
+          ..write('gameId: $gameId, ')
+          ..write('tagId: $tagId')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$HibikiDatabase extends GeneratedDatabase {
   _$HibikiDatabase(QueryExecutor e) : super(e);
   $HibikiDatabaseManager get managers => $HibikiDatabaseManager(this);
@@ -20714,6 +20942,8 @@ abstract class _$HibikiDatabase extends GeneratedDatabase {
   late final $GalgameSourcesTable galgameSources = $GalgameSourcesTable(this);
   late final $GalgameSessionsTable galgameSessions =
       $GalgameSessionsTable(this);
+  late final $GalgameTagMappingsTable galgameTagMappings =
+      $GalgameTagMappingsTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -20770,7 +21000,8 @@ abstract class _$HibikiDatabase extends GeneratedDatabase {
         mediaTrackingOutbox,
         galgames,
         galgameSources,
-        galgameSessions
+        galgameSessions,
+        galgameTagMappings
       ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules(
@@ -20920,6 +21151,20 @@ abstract class _$HibikiDatabase extends GeneratedDatabase {
                 limitUpdateKind: UpdateKind.delete),
             result: [
               TableUpdate('galgame_sessions', kind: UpdateKind.delete),
+            ],
+          ),
+          WritePropagation(
+            on: TableUpdateQuery.onTableName('galgames',
+                limitUpdateKind: UpdateKind.delete),
+            result: [
+              TableUpdate('galgame_tag_mappings', kind: UpdateKind.delete),
+            ],
+          ),
+          WritePropagation(
+            on: TableUpdateQuery.onTableName('book_tags',
+                limitUpdateKind: UpdateKind.delete),
+            result: [
+              TableUpdate('galgame_tag_mappings', kind: UpdateKind.delete),
             ],
           ),
         ],
@@ -25109,6 +25354,23 @@ final class $$BookTagsTableReferences
     return ProcessedTableManager(
         manager.$state.copyWith(prefetchedData: cache));
   }
+
+  static MultiTypedResultKey<$GalgameTagMappingsTable,
+      List<GalgameTagMappingRow>> _galgameTagMappingsRefsTable(
+          _$HibikiDatabase db) =>
+      MultiTypedResultKey.fromTable(db.galgameTagMappings,
+          aliasName: 'book_tags__id__galgame_tag_mappings__tag_id');
+
+  $$GalgameTagMappingsTableProcessedTableManager get galgameTagMappingsRefs {
+    final manager =
+        $$GalgameTagMappingsTableTableManager($_db, $_db.galgameTagMappings)
+            .filter((f) => f.tagId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache =
+        $_typedResult.readTableOrNull(_galgameTagMappingsRefsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
 }
 
 class $$BookTagsTableFilterComposer
@@ -25219,6 +25481,27 @@ class $$BookTagsTableFilterComposer
                   $removeJoinBuilderFromRootComposer:
                       $removeJoinBuilderFromRootComposer,
                 ));
+    return f(composer);
+  }
+
+  Expression<bool> galgameTagMappingsRefs(
+      Expression<bool> Function($$GalgameTagMappingsTableFilterComposer f) f) {
+    final $$GalgameTagMappingsTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $db.galgameTagMappings,
+        getReferencedColumn: (t) => t.tagId,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$GalgameTagMappingsTableFilterComposer(
+              $db: $db,
+              $table: $db.galgameTagMappings,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
     return f(composer);
   }
 }
@@ -25360,6 +25643,28 @@ class $$BookTagsTableAnnotationComposer
                 ));
     return f(composer);
   }
+
+  Expression<T> galgameTagMappingsRefs<T extends Object>(
+      Expression<T> Function($$GalgameTagMappingsTableAnnotationComposer a) f) {
+    final $$GalgameTagMappingsTableAnnotationComposer composer =
+        $composerBuilder(
+            composer: this,
+            getCurrentColumn: (t) => t.id,
+            referencedTable: $db.galgameTagMappings,
+            getReferencedColumn: (t) => t.tagId,
+            builder: (joinBuilder,
+                    {$addJoinBuilderToRootComposer,
+                    $removeJoinBuilderFromRootComposer}) =>
+                $$GalgameTagMappingsTableAnnotationComposer(
+                  $db: $db,
+                  $table: $db.galgameTagMappings,
+                  $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                  joinBuilder: joinBuilder,
+                  $removeJoinBuilderFromRootComposer:
+                      $removeJoinBuilderFromRootComposer,
+                ));
+    return f(composer);
+  }
 }
 
 class $$BookTagsTableTableManager extends RootTableManager<
@@ -25377,7 +25682,8 @@ class $$BookTagsTableTableManager extends RootTableManager<
         {bool bookTagMappingsRefs,
         bool srtBookTagMappingsRefs,
         bool videoBookTagMappingsRefs,
-        bool collectionTagMappingsRefs})> {
+        bool collectionTagMappingsRefs,
+        bool galgameTagMappingsRefs})> {
   $$BookTagsTableTableManager(_$HibikiDatabase db, $BookTagsTable table)
       : super(TableManagerState(
           db: db,
@@ -25424,14 +25730,16 @@ class $$BookTagsTableTableManager extends RootTableManager<
               {bookTagMappingsRefs = false,
               srtBookTagMappingsRefs = false,
               videoBookTagMappingsRefs = false,
-              collectionTagMappingsRefs = false}) {
+              collectionTagMappingsRefs = false,
+              galgameTagMappingsRefs = false}) {
             return PrefetchHooks(
               db: db,
               explicitlyWatchedTables: [
                 if (bookTagMappingsRefs) db.bookTagMappings,
                 if (srtBookTagMappingsRefs) db.srtBookTagMappings,
                 if (videoBookTagMappingsRefs) db.videoBookTagMappings,
-                if (collectionTagMappingsRefs) db.collectionTagMappings
+                if (collectionTagMappingsRefs) db.collectionTagMappings,
+                if (galgameTagMappingsRefs) db.galgameTagMappings
               ],
               addJoins: null,
               getPrefetchedDataCallback: (items) async {
@@ -25487,6 +25795,19 @@ class $$BookTagsTableTableManager extends RootTableManager<
                         referencedItemsForCurrentItem: (item,
                                 referencedItems) =>
                             referencedItems.where((e) => e.tagId == item.id),
+                        typedResults: items),
+                  if (galgameTagMappingsRefs)
+                    await $_getPrefetchedData<BookTagRow, $BookTagsTable,
+                            GalgameTagMappingRow>(
+                        currentTable: table,
+                        referencedTable: $$BookTagsTableReferences
+                            ._galgameTagMappingsRefsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$BookTagsTableReferences(db, table, p0)
+                                .galgameTagMappingsRefs,
+                        referencedItemsForCurrentItem: (item,
+                                referencedItems) =>
+                            referencedItems.where((e) => e.tagId == item.id),
                         typedResults: items)
                 ];
               },
@@ -25510,7 +25831,8 @@ typedef $$BookTagsTableProcessedTableManager = ProcessedTableManager<
         {bool bookTagMappingsRefs,
         bool srtBookTagMappingsRefs,
         bool videoBookTagMappingsRefs,
-        bool collectionTagMappingsRefs})>;
+        bool collectionTagMappingsRefs,
+        bool galgameTagMappingsRefs})>;
 typedef $$BookTagMappingsTableCreateCompanionBuilder = BookTagMappingsCompanion
     Function({
   Value<int> id,
@@ -34125,6 +34447,23 @@ final class $$GalgamesTableReferences
     return ProcessedTableManager(
         manager.$state.copyWith(prefetchedData: cache));
   }
+
+  static MultiTypedResultKey<$GalgameTagMappingsTable,
+      List<GalgameTagMappingRow>> _galgameTagMappingsRefsTable(
+          _$HibikiDatabase db) =>
+      MultiTypedResultKey.fromTable(db.galgameTagMappings,
+          aliasName: 'galgames__id__galgame_tag_mappings__game_id');
+
+  $$GalgameTagMappingsTableProcessedTableManager get galgameTagMappingsRefs {
+    final manager =
+        $$GalgameTagMappingsTableTableManager($_db, $_db.galgameTagMappings)
+            .filter((f) => f.gameId.id.sqlEquals($_itemColumn<String>('id')!));
+
+    final cache =
+        $_typedResult.readTableOrNull(_galgameTagMappingsRefsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
 }
 
 class $$GalgamesTableFilterComposer
@@ -34207,6 +34546,27 @@ class $$GalgamesTableFilterComposer
             $$GalgameSessionsTableFilterComposer(
               $db: $db,
               $table: $db.galgameSessions,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return f(composer);
+  }
+
+  Expression<bool> galgameTagMappingsRefs(
+      Expression<bool> Function($$GalgameTagMappingsTableFilterComposer f) f) {
+    final $$GalgameTagMappingsTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $db.galgameTagMappings,
+        getReferencedColumn: (t) => t.gameId,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$GalgameTagMappingsTableFilterComposer(
+              $db: $db,
+              $table: $db.galgameTagMappings,
               $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
               joinBuilder: joinBuilder,
               $removeJoinBuilderFromRootComposer:
@@ -34350,6 +34710,28 @@ class $$GalgamesTableAnnotationComposer
             ));
     return f(composer);
   }
+
+  Expression<T> galgameTagMappingsRefs<T extends Object>(
+      Expression<T> Function($$GalgameTagMappingsTableAnnotationComposer a) f) {
+    final $$GalgameTagMappingsTableAnnotationComposer composer =
+        $composerBuilder(
+            composer: this,
+            getCurrentColumn: (t) => t.id,
+            referencedTable: $db.galgameTagMappings,
+            getReferencedColumn: (t) => t.gameId,
+            builder: (joinBuilder,
+                    {$addJoinBuilderToRootComposer,
+                    $removeJoinBuilderFromRootComposer}) =>
+                $$GalgameTagMappingsTableAnnotationComposer(
+                  $db: $db,
+                  $table: $db.galgameTagMappings,
+                  $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                  joinBuilder: joinBuilder,
+                  $removeJoinBuilderFromRootComposer:
+                      $removeJoinBuilderFromRootComposer,
+                ));
+    return f(composer);
+  }
 }
 
 class $$GalgamesTableTableManager extends RootTableManager<
@@ -34364,7 +34746,9 @@ class $$GalgamesTableTableManager extends RootTableManager<
     (GalgameRow, $$GalgamesTableReferences),
     GalgameRow,
     PrefetchHooks Function(
-        {bool galgameSourcesRefs, bool galgameSessionsRefs})> {
+        {bool galgameSourcesRefs,
+        bool galgameSessionsRefs,
+        bool galgameTagMappingsRefs})> {
   $$GalgamesTableTableManager(_$HibikiDatabase db, $GalgamesTable table)
       : super(TableManagerState(
           db: db,
@@ -34440,12 +34824,15 @@ class $$GalgamesTableTableManager extends RootTableManager<
                   (e.readTable(table), $$GalgamesTableReferences(db, table, e)))
               .toList(),
           prefetchHooksCallback: (
-              {galgameSourcesRefs = false, galgameSessionsRefs = false}) {
+              {galgameSourcesRefs = false,
+              galgameSessionsRefs = false,
+              galgameTagMappingsRefs = false}) {
             return PrefetchHooks(
               db: db,
               explicitlyWatchedTables: [
                 if (galgameSourcesRefs) db.galgameSources,
-                if (galgameSessionsRefs) db.galgameSessions
+                if (galgameSessionsRefs) db.galgameSessions,
+                if (galgameTagMappingsRefs) db.galgameTagMappings
               ],
               addJoins: null,
               getPrefetchedDataCallback: (items) async {
@@ -34475,6 +34862,19 @@ class $$GalgamesTableTableManager extends RootTableManager<
                         referencedItemsForCurrentItem: (item,
                                 referencedItems) =>
                             referencedItems.where((e) => e.gameId == item.id),
+                        typedResults: items),
+                  if (galgameTagMappingsRefs)
+                    await $_getPrefetchedData<GalgameRow, $GalgamesTable,
+                            GalgameTagMappingRow>(
+                        currentTable: table,
+                        referencedTable: $$GalgamesTableReferences
+                            ._galgameTagMappingsRefsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$GalgamesTableReferences(db, table, p0)
+                                .galgameTagMappingsRefs,
+                        referencedItemsForCurrentItem: (item,
+                                referencedItems) =>
+                            referencedItems.where((e) => e.gameId == item.id),
                         typedResults: items)
                 ];
               },
@@ -34495,7 +34895,9 @@ typedef $$GalgamesTableProcessedTableManager = ProcessedTableManager<
     (GalgameRow, $$GalgamesTableReferences),
     GalgameRow,
     PrefetchHooks Function(
-        {bool galgameSourcesRefs, bool galgameSessionsRefs})>;
+        {bool galgameSourcesRefs,
+        bool galgameSessionsRefs,
+        bool galgameTagMappingsRefs})>;
 typedef $$GalgameSourcesTableCreateCompanionBuilder = GalgameSourcesCompanion
     Function({
   required String gameId,
@@ -35089,6 +35491,322 @@ typedef $$GalgameSessionsTableProcessedTableManager = ProcessedTableManager<
     (GalgameSessionRow, $$GalgameSessionsTableReferences),
     GalgameSessionRow,
     PrefetchHooks Function({bool gameId})>;
+typedef $$GalgameTagMappingsTableCreateCompanionBuilder
+    = GalgameTagMappingsCompanion Function({
+  Value<int> id,
+  required String gameId,
+  required int tagId,
+});
+typedef $$GalgameTagMappingsTableUpdateCompanionBuilder
+    = GalgameTagMappingsCompanion Function({
+  Value<int> id,
+  Value<String> gameId,
+  Value<int> tagId,
+});
+
+final class $$GalgameTagMappingsTableReferences extends BaseReferences<
+    _$HibikiDatabase, $GalgameTagMappingsTable, GalgameTagMappingRow> {
+  $$GalgameTagMappingsTableReferences(
+      super.$_db, super.$_table, super.$_typedResult);
+
+  static $GalgamesTable _gameIdTable(_$HibikiDatabase db) =>
+      db.galgames.createAlias('galgame_tag_mappings__game_id__galgames__id');
+
+  $$GalgamesTableProcessedTableManager get gameId {
+    final $_column = $_itemColumn<String>('game_id')!;
+
+    final manager = $$GalgamesTableTableManager($_db, $_db.galgames)
+        .filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_gameIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
+
+  static $BookTagsTable _tagIdTable(_$HibikiDatabase db) =>
+      db.bookTags.createAlias('galgame_tag_mappings__tag_id__book_tags__id');
+
+  $$BookTagsTableProcessedTableManager get tagId {
+    final $_column = $_itemColumn<int>('tag_id')!;
+
+    final manager = $$BookTagsTableTableManager($_db, $_db.bookTags)
+        .filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_tagIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
+}
+
+class $$GalgameTagMappingsTableFilterComposer
+    extends Composer<_$HibikiDatabase, $GalgameTagMappingsTable> {
+  $$GalgameTagMappingsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnFilters(column));
+
+  $$GalgamesTableFilterComposer get gameId {
+    final $$GalgamesTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.gameId,
+        referencedTable: $db.galgames,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$GalgamesTableFilterComposer(
+              $db: $db,
+              $table: $db.galgames,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+
+  $$BookTagsTableFilterComposer get tagId {
+    final $$BookTagsTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.tagId,
+        referencedTable: $db.bookTags,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$BookTagsTableFilterComposer(
+              $db: $db,
+              $table: $db.bookTags,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$GalgameTagMappingsTableOrderingComposer
+    extends Composer<_$HibikiDatabase, $GalgameTagMappingsTable> {
+  $$GalgameTagMappingsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnOrderings(column));
+
+  $$GalgamesTableOrderingComposer get gameId {
+    final $$GalgamesTableOrderingComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.gameId,
+        referencedTable: $db.galgames,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$GalgamesTableOrderingComposer(
+              $db: $db,
+              $table: $db.galgames,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+
+  $$BookTagsTableOrderingComposer get tagId {
+    final $$BookTagsTableOrderingComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.tagId,
+        referencedTable: $db.bookTags,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$BookTagsTableOrderingComposer(
+              $db: $db,
+              $table: $db.bookTags,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$GalgameTagMappingsTableAnnotationComposer
+    extends Composer<_$HibikiDatabase, $GalgameTagMappingsTable> {
+  $$GalgameTagMappingsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  $$GalgamesTableAnnotationComposer get gameId {
+    final $$GalgamesTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.gameId,
+        referencedTable: $db.galgames,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$GalgamesTableAnnotationComposer(
+              $db: $db,
+              $table: $db.galgames,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+
+  $$BookTagsTableAnnotationComposer get tagId {
+    final $$BookTagsTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.tagId,
+        referencedTable: $db.bookTags,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$BookTagsTableAnnotationComposer(
+              $db: $db,
+              $table: $db.bookTags,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$GalgameTagMappingsTableTableManager extends RootTableManager<
+    _$HibikiDatabase,
+    $GalgameTagMappingsTable,
+    GalgameTagMappingRow,
+    $$GalgameTagMappingsTableFilterComposer,
+    $$GalgameTagMappingsTableOrderingComposer,
+    $$GalgameTagMappingsTableAnnotationComposer,
+    $$GalgameTagMappingsTableCreateCompanionBuilder,
+    $$GalgameTagMappingsTableUpdateCompanionBuilder,
+    (GalgameTagMappingRow, $$GalgameTagMappingsTableReferences),
+    GalgameTagMappingRow,
+    PrefetchHooks Function({bool gameId, bool tagId})> {
+  $$GalgameTagMappingsTableTableManager(
+      _$HibikiDatabase db, $GalgameTagMappingsTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$GalgameTagMappingsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$GalgameTagMappingsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$GalgameTagMappingsTableAnnotationComposer(
+                  $db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> gameId = const Value.absent(),
+            Value<int> tagId = const Value.absent(),
+          }) =>
+              GalgameTagMappingsCompanion(
+            id: id,
+            gameId: gameId,
+            tagId: tagId,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String gameId,
+            required int tagId,
+          }) =>
+              GalgameTagMappingsCompanion.insert(
+            id: id,
+            gameId: gameId,
+            tagId: tagId,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (
+                    e.readTable(table),
+                    $$GalgameTagMappingsTableReferences(db, table, e)
+                  ))
+              .toList(),
+          prefetchHooksCallback: ({gameId = false, tagId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins: <
+                  T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (gameId) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.gameId,
+                    referencedTable:
+                        $$GalgameTagMappingsTableReferences._gameIdTable(db),
+                    referencedColumn:
+                        $$GalgameTagMappingsTableReferences._gameIdTable(db).id,
+                  ) as T;
+                }
+                if (tagId) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.tagId,
+                    referencedTable:
+                        $$GalgameTagMappingsTableReferences._tagIdTable(db),
+                    referencedColumn:
+                        $$GalgameTagMappingsTableReferences._tagIdTable(db).id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ));
+}
+
+typedef $$GalgameTagMappingsTableProcessedTableManager = ProcessedTableManager<
+    _$HibikiDatabase,
+    $GalgameTagMappingsTable,
+    GalgameTagMappingRow,
+    $$GalgameTagMappingsTableFilterComposer,
+    $$GalgameTagMappingsTableOrderingComposer,
+    $$GalgameTagMappingsTableAnnotationComposer,
+    $$GalgameTagMappingsTableCreateCompanionBuilder,
+    $$GalgameTagMappingsTableUpdateCompanionBuilder,
+    (GalgameTagMappingRow, $$GalgameTagMappingsTableReferences),
+    GalgameTagMappingRow,
+    PrefetchHooks Function({bool gameId, bool tagId})>;
 
 class $HibikiDatabaseManager {
   final _$HibikiDatabase _db;
@@ -35202,4 +35920,6 @@ class $HibikiDatabaseManager {
       $$GalgameSourcesTableTableManager(_db, _db.galgameSources);
   $$GalgameSessionsTableTableManager get galgameSessions =>
       $$GalgameSessionsTableTableManager(_db, _db.galgameSessions);
+  $$GalgameTagMappingsTableTableManager get galgameTagMappings =>
+      $$GalgameTagMappingsTableTableManager(_db, _db.galgameTagMappings);
 }

--- a/packages/hibiki_core/lib/src/database/tables.dart
+++ b/packages/hibiki_core/lib/src/database/tables.dart
@@ -1292,3 +1292,37 @@ class GalgameSessions extends Table {
   /// 与其它统计表 dateKey 同源，避免读取端为分组反算。
   TextColumn get dateKey => text()();
 }
+
+// ── galgame_tag_mappings ────────────────────────────────────────────
+/// v57（BUG-1113「游戏没有标签」）：游戏 ↔ **用户标签** 多对多映射。标签定义复用
+/// 共享的 [BookTags]，与 EPUB（[BookTagMappings]）、SRT（[SrtBookTagMappings]）、
+/// 视频（[VideoBookTagMappings]）、合集（[CollectionTagMappings]）**同一个标签池**
+/// ——这正是本表存在的理由：上层筛选栏 / 标签管理页早已是四种媒体共用，唯独游戏
+/// 没有落表，于是接不进来（不是 UI 忘接，是 schema 缺口）。
+///
+/// 与游戏**元数据标签**（bgm/vndb 刮削来的字符串，存 [GalgameSources].dataJson +
+/// [Galgames].customDataJson，由 `galgame_library_query.dart` 按名筛选）是两个正交
+/// 维度，刻意不合并：元数据标签是外部事实、动辄上百个且随刮削变动，塞进用户标签池
+/// 会污染书/视频共享的那份手工标签。
+///
+/// **刻意不带 `addedAt`**（对比 [BookTagMappings] / [VideoBookTagMappings]）：那一列
+/// 是 LWW-element-set 的 add 时钟，只为跨端同步裁决而存在。游戏身份 [Galgames].id 是
+/// 添加时刻微秒戳，**本机局域身份**——`galgames` 整张表既不进 live-sync 清单也不进
+/// 备份合并导入，故游戏标签同样不跨端传播、不需要墓碑（[BookTagMembershipTombstones]
+/// 不覆盖游戏）。全量备份恢复走整库文件拷贝，本表随之原样还原。加一个没有消费者的
+/// 时钟列只会让人误以为它在同步。同款取舍见 [CollectionTagMappings]。
+///
+/// 删游戏 / 删标签经外键 cascade 自动清理本表。
+@DataClassName('GalgameTagMappingRow')
+class GalgameTagMappings extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get gameId =>
+      text().references(Galgames, #id, onDelete: KeyAction.cascade)();
+  IntColumn get tagId =>
+      integer().references(BookTags, #id, onDelete: KeyAction.cascade)();
+
+  @override
+  List<Set<Column>> get uniqueKeys => [
+        {gameId, tagId},
+      ];
+}


### PR DESCRIPTION
## 问题

用户报「游戏的标签呢」「全是因为各个地方代码不统一」（BUG-1113）。

沿真实代码路径验真：**是 schema 缺口，不是 UI 忘接**。`tables.dart` 里标签映射表只有四张（EPUB / 字幕书 / 视频 / 合集），没有游戏的。标签池 `BookTags` 与筛选 UI（`tag_filter_bar` / `tag_filter_sheet` / `selectedTagIdsProvider`）早已是几种媒体共用——上层已经统一了，唯独游戏没落表就接不进来。所以这条改 UI 修不了。

## 先决问题：跨端同步语义（已定契约）

**游戏标签不跨端传播、不建墓碑。** 判据是真凭据不是偏好：

- `galgames` 整张表**不进** live-sync 清单（`app_model_library_host_service.dart` 只导出书与视频的标签），也**不进**备份合并导入（`backup_merge_engine.dart` 零 galgame 语句）。游戏身份是添加时刻微秒戳 = 本机局域身份，对端根本没有对应行可挂。
- 故映射表**刻意不带 `addedAt`**——那一列是 LWW-element-set 的 add 时钟，只为同步裁决存在；`BookTagMembershipTombstones` 也不覆盖游戏。范式对齐 `CollectionTagMappings`（同样无时钟无墓碑）。加个没有消费者的时钟只会让人误以为它在同步。
- 全量备份恢复走整库文件拷贝，本表随之原样还原，零额外工作。
- 将来若真要同步，先决条件是先给游戏一个跨设备稳定身份；在那之前不预留。

## 改了什么

| 层 | 改动 |
|---|---|
| schema | v56→**v57**：`GalgameTagMappings`（gameId→`galgames.id` cascade、tagId→`book_tags.id` cascade、`{gameId,tagId}` UNIQUE）+ 守卫式建表 + 两个索引 |
| DB API | `getTagsForGame` / `addTagToGame` / `removeTagFromGame` / `setTagsForGame` / `getGameIdsForAllTags` / `getAllGameTagMappings`；`countBooksForTag` 计入游戏 |
| UI | 游戏库接既有 `HibikiTagFilterBar`（共享同一 `selectedTagIdsProvider`）；卡片菜单加「标签」→ 共享 `TagPickerPage(gameId:)`（第五种目标）；详情页 meta 网格加「我的标签」格 |
| 纯函数 | 用户标签白名单在 `applyGalgameLibraryView(..., allowedIds:)` 一处收口，页面不二次过滤 |
| i18n | 新增 `game_user_tags_title`（走 `i18n_sync.dart`，17 语言 + `dart run slang`） |

**两套标签刻意不合并**：① 用户标签（本 PR，共享彩色标签池）；② 元数据标签（bgm/vndb 刮削来的作品标签，库页筛选面板按名筛）。后者动辄上百个且随刮削变动，塞进共享池会污染书/视频的手工标签。两条轴 AND 生效。

## 向后兼容

旧库升级后新表为空 = 全部游戏无用户标签 = 与旧版逐像素相同；建表守卫幂等（fresh DB 由 `onCreate` 建好，重复升级 `_tableExists` 短路 no-op）；不动任何既有表或列。

## 验证

- `flutter analyze`（含 test 目录）**干净**
- `flutter test` **全量 14520 项通过**（schema 变更爆炸半径大，跑了全套；连带把各迁移测试里的版本字面量 56→57）
- 新增测试：
  - `hibiki/test/database/galgame_tags_test.dart` — CRUD 幂等 / 差集 set / AND 筛选 / 双向 cascade / `countBooksForTag` 含游戏
  - `hibiki/test/database/migration_v57_galgame_tag_mappings_test.dart` — 真实 v56→v57：既有游戏行零破坏、升级后无标签、新表可写、fresh 库 onCreate 也建出
  - `hibiki/test/pages/games_library_user_tags_test.dart` — 真页面：标签栏渲染、点 chip 真筛掉不匹配的游戏、空态文案、卡片菜单进 `TagPickerPage` 并真写穿 DB
  - `galgame_library_query_test.dart` — `allowedIds` 三例（null 不过滤 / 白名单 / 与元数据标签+搜索 AND）

## 已知遗留（非本 PR 范围）

游戏海报卡 `GalgamePosterCard` 无标签 chip 槽位（固定 0.62 槽比，加 chip 行要改共享组件布局）。当前用户标签在**详情页**与**筛选栏**可见，网格卡上不显示。

未跑真机目视：本 PR 无平台特定路径，widget 测试已覆盖真页面交互与 DB 写穿。

https://claude.ai/code/session_01PPqLkTtf3cZ7DWTfehMcPs
