### PR TITLE
fix(gal): 捕获音频完整性四层防混入 + 工作台音轨体验收口 (BUG-1135)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1101 条。点号进各自文件。
+> 共 1102 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1135](bugs/BUG-1135-gal-clipnear-bypasses-track-exclusion.md) | ✅ | ✅ | gal 制卡兜底 grabClipNear 绕过选轨/排除集——排除的 BGM 轨会从兜底混回卡片 |
 | [BUG-1134](bugs/BUG-1134-gal-line-track-preview-timestamp.md) | ✅ | ✅ | 逐句选轨试听与确认使用了不同台词时间戳 |
 | [BUG-1133](bugs/BUG-1133-gal-capture-parallel-text-duplicate.md) | ✅ | ✅ | 全部文本线程把同一台词显示两遍 |
 | [BUG-1132](bugs/BUG-1132-gal-capture-stale-text-thread.md) | ✅ | ✅ | 捕获工作台混入上次进程的 TextRender 文本线程 |

--- a/docs/bugs/BUG-1135-gal-clipnear-bypasses-track-exclusion.md
+++ b/docs/bugs/BUG-1135-gal-clipnear-bypasses-track-exclusion.md
@@ -7,5 +7,6 @@
 - **[x] ① 已修复** — `GrabClipNear` 增加 `target_source` / `exclude_sources` 参数并与 `GrabUtterance` 同契约过滤（`hibiki/windows/runner/voice_hook_reader.cpp` / `.h`、`flutter_window.cpp` 的 `grabClipNear` handler 解析 `sourcePtr`/`exclude`）；Dart 侧 `grabClipNear` 缺省沿用 `selectedAudioSourcePtr` / `excludedAudioSourcePtrs`（`galgame_audio_source.dart`），两处调用点自动获得同一契约。method channel 契约变更两侧同 PR 落地。
 - **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_capture_audio_integrity_test.dart`：假 method channel 断言 `grabClipNear` 调用携带当前排除集与选轨；及排除后兜底不返回被排除源的 clip。
 - **备注**：
-  - 同轮相邻加固（非本 bug 本体）：无配音句与疑似漏抓分类（`line_has_no_voice`）、超长切片门（`slice_overlong_suspect`）、会话音轨面板入口上移、跨会话 BGM 排除记忆（弱指纹，只恢复排除、绝不自动选轨）。
+  - 同轮相邻加固（非本 bug 本体）：无配音句与疑似漏抓分类（`line_has_no_voice`）、超长切片门（`slice_overlong_suspect`）、会话音轨面板入口上移、跨会话记忆（弱指纹）。**记忆恢复语音轨的取舍**：初版刻意只恢复排除、不自动选轨（怕指纹漂了静默配错音）；用户明确要求「每个游戏默认持久化音轨」后改为也恢复，安全性由三点兜住——被排除的轨不得同时被恢复成语音轨、恢复各记结构化事件、逐句音轨面板实时显示本句实际用的是哪条轨且一键可改。
   - 撞号风险：PR#447 占用了另一含义的 BUG-1115，PR#449 占用 1115/1116——本条开在 1118（本分支基于 PR#452，1115-1117 已被其占用）；合并/rebase 时按纪律重核号段。
+  - 后续同批（用户 2026-07-27 追加）：捕获工作台右栏「最新台词 + 健康状态」两张只读卡换成**逐句音轨面板**（按该行自己的时间戳取快照，排除 BGM 不再是盲操作）；同标签文本线程补可区分后缀（用户实拍 6 条线程全叫 `CodeX · 0x459f50`）；每游戏持久化文本线程 / 语音轨 / 排除集（`GalCaptureMemory`）。

--- a/docs/bugs/BUG-1135-gal-clipnear-bypasses-track-exclusion.md
+++ b/docs/bugs/BUG-1135-gal-clipnear-bypasses-track-exclusion.md
@@ -1,0 +1,11 @@
+## BUG-1135 · gal 制卡兜底 grabClipNear 绕过选轨/排除集——排除的 BGM 轨会从兜底混回卡片
+- **报告**：2026-07-27（用户：「怎么保证不会混入错误音频」——排查捕获工作台防混入链路时发现）
+- **真实性**：✅ 真 bug（代码路径直接可证，native 注释自己写明「交调用方回退」而回退不认排除集）：
+  - 制卡/逐行取音链 `hibiki/lib/src/mining/gal_hook_session_controller.dart`（`_captureAudioBytesNow` 与 `_attachLineAudio`）都是 `grabUtterance(ts) ?? grabClipNear(ts)`；
+  - `grabUtterance` 尊重 `selectedAudioSourcePtr` / `excludedAudioSourcePtrs`（native `VoiceHookReader::GrabUtterance`，全被排除时返回空「交调用方回退」）；
+  - 旧 `grabClipNear`（`galgame_audio_source.dart` → native `VoiceHookReader::GrabClipNear`）**不带任何源过滤**，从任意轨取最近 clip——用户在工作台排除了 BGM 轨后，只要该句在语音轨窗口内没抓到 PCM，兜底就把 BGM clip 塞进卡片，排除功能被自己的降级链拆台。
+- **[x] ① 已修复** — `GrabClipNear` 增加 `target_source` / `exclude_sources` 参数并与 `GrabUtterance` 同契约过滤（`hibiki/windows/runner/voice_hook_reader.cpp` / `.h`、`flutter_window.cpp` 的 `grabClipNear` handler 解析 `sourcePtr`/`exclude`）；Dart 侧 `grabClipNear` 缺省沿用 `selectedAudioSourcePtr` / `excludedAudioSourcePtrs`（`galgame_audio_source.dart`），两处调用点自动获得同一契约。method channel 契约变更两侧同 PR 落地。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_capture_audio_integrity_test.dart`：假 method channel 断言 `grabClipNear` 调用携带当前排除集与选轨；及排除后兜底不返回被排除源的 clip。
+- **备注**：
+  - 同轮相邻加固（非本 bug 本体）：无配音句与疑似漏抓分类（`line_has_no_voice`）、超长切片门（`slice_overlong_suspect`）、会话音轨面板入口上移、跨会话 BGM 排除记忆（弱指纹，只恢复排除、绝不自动选轨）。
+  - 撞号风险：PR#447 占用了另一含义的 BUG-1115，PR#449 占用 1115/1116——本条开在 1118（本分支基于 PR#452，1115-1117 已被其占用）；合并/rebase 时按纪律重核号段。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 44693 (2629 per locale)
+/// Strings: 44744 (2632 per locale)
 ///
-/// Built on 2026-07-27 at 07:20 UTC
+/// Built on 2026-07-27 at 07:23 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3502,6 +3502,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'System-mix fallback; may include BGM';
   String get game_line_recapture => 'Recapture voice';
   String get game_line_recapture_stop => 'Finish recapture';
+  String get game_line_tracks => 'Tracks for this line';
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -9481,6 +9485,13 @@ class _StringsAr extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -15528,6 +15539,13 @@ class _StringsDe extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -21591,6 +21609,13 @@ class _StringsEs extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -27665,6 +27690,13 @@ class _StringsFr extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -33668,6 +33700,13 @@ class _StringsId extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -39717,6 +39756,13 @@ class _StringsIt extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -45582,6 +45628,13 @@ class _StringsJa extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -51449,6 +51502,13 @@ class _StringsKo extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -57478,6 +57538,13 @@ class _StringsNl extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -63520,6 +63587,13 @@ class _StringsPtBr extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -69546,6 +69620,13 @@ class _StringsRu extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -75520,6 +75601,13 @@ class _StringsTh extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -81526,6 +81614,13 @@ class _StringsTr extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -87517,6 +87612,13 @@ class _StringsVi extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 // Path: <root>
@@ -93098,6 +93200,12 @@ class _StringsZhCn extends _StringsEn {
   String get game_line_recapture => '补录语音';
   @override
   String get game_line_recapture_stop => '完成补录';
+  @override
+  String get game_line_tracks => '本句音轨';
+  @override
+  String get game_line_tracks_hint => '按本句时刻试听各轨，确认是 BGM 就排除';
+  @override
+  String get game_line_track_use => '用于本句';
 }
 
 // Path: <root>
@@ -98885,6 +98993,13 @@ class _StringsZhHk extends _StringsEn {
   String get game_line_recapture => 'Recapture voice';
   @override
   String get game_line_recapture_stop => 'Finish recapture';
+  @override
+  String get game_line_tracks => 'Tracks for this line';
+  @override
+  String get game_line_tracks_hint =>
+      'Preview each track at this line\'s moment, then exclude the BGM ones';
+  @override
+  String get game_line_track_use => 'Use for this line';
 }
 
 /// Flat map(s) containing all translations.
@@ -104259,6 +104374,12 @@ extension on _StringsEn {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -109631,6 +109752,12 @@ extension on _StringsAr {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -115024,6 +115151,12 @@ extension on _StringsDe {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -120416,6 +120549,12 @@ extension on _StringsEs {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -125814,6 +125953,12 @@ extension on _StringsFr {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -131194,6 +131339,12 @@ extension on _StringsId {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -136589,6 +136740,12 @@ extension on _StringsIt {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -141946,6 +142103,12 @@ extension on _StringsJa {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -147307,6 +147470,12 @@ extension on _StringsKo {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -152695,6 +152864,12 @@ extension on _StringsNl {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -158080,6 +158255,12 @@ extension on _StringsPtBr {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -163470,6 +163651,12 @@ extension on _StringsRu {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -168844,6 +169031,12 @@ extension on _StringsTh {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -174227,6 +174420,12 @@ extension on _StringsTr {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -179605,6 +179804,12 @@ extension on _StringsVi {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }
@@ -184937,6 +185142,12 @@ extension on _StringsZhCn {
         return '补录语音';
       case 'game_line_recapture_stop':
         return '完成补录';
+      case 'game_line_tracks':
+        return '本句音轨';
+      case 'game_line_tracks_hint':
+        return '按本句时刻试听各轨，确认是 BGM 就排除';
+      case 'game_line_track_use':
+        return '用于本句';
       default:
         return null;
     }
@@ -190289,6 +190500,12 @@ extension on _StringsZhHk {
         return 'Recapture voice';
       case 'game_line_recapture_stop':
         return 'Finish recapture';
+      case 'game_line_tracks':
+        return 'Tracks for this line';
+      case 'game_line_tracks_hint':
+        return 'Preview each track at this line\'s moment, then exclude the BGM ones';
+      case 'game_line_track_use':
+        return 'Use for this line';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 44591 (2623 per locale)
+/// Strings: 44693 (2629 per locale)
 ///
-/// Built on 2026-07-27 at 07:06 UTC
+/// Built on 2026-07-27 at 07:20 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3494,6 +3494,14 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get yomitan_port_kill_self_instance =>
       'This process is another running instance of this app.';
   String get game_track_bgm => 'BGM / excluded';
+  String get game_line_audio_no_voice => 'No voice';
+  String get game_line_audio_overlong => 'Overlong clip';
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  String get game_line_recapture => 'Recapture voice';
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -9459,6 +9467,20 @@ class _StringsAr extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -15492,6 +15514,20 @@ class _StringsDe extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -21541,6 +21577,20 @@ class _StringsEs extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -27601,6 +27651,20 @@ class _StringsFr extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -33590,6 +33654,20 @@ class _StringsId extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -39625,6 +39703,20 @@ class _StringsIt extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -45476,6 +45568,20 @@ class _StringsJa extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -51329,6 +51435,20 @@ class _StringsKo extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -57344,6 +57464,20 @@ class _StringsNl extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -63372,6 +63506,20 @@ class _StringsPtBr extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -69384,6 +69532,20 @@ class _StringsRu extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -75344,6 +75506,20 @@ class _StringsTh extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -81336,6 +81512,20 @@ class _StringsTr extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -87313,6 +87503,20 @@ class _StringsVi extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 // Path: <root>
@@ -92882,6 +93086,18 @@ class _StringsZhCn extends _StringsEn {
   String get yomitan_port_kill_self_instance => '该进程是本应用的另一个正在运行的实例。';
   @override
   String get game_track_bgm => 'BGM / 已排除';
+  @override
+  String get game_line_audio_no_voice => '无配音';
+  @override
+  String get game_line_audio_overlong => '超长片段';
+  @override
+  String get game_line_audio_overlong_hint => '远超单句时长，可能混入 BGM 或其它混音';
+  @override
+  String get game_line_audio_loopback_hint => '整机混音兜底，可能混入 BGM';
+  @override
+  String get game_line_recapture => '补录语音';
+  @override
+  String get game_line_recapture_stop => '完成补录';
 }
 
 // Path: <root>
@@ -98655,6 +98871,20 @@ class _StringsZhHk extends _StringsEn {
       'This process is another running instance of this app.';
   @override
   String get game_track_bgm => 'BGM / excluded';
+  @override
+  String get game_line_audio_no_voice => 'No voice';
+  @override
+  String get game_line_audio_overlong => 'Overlong clip';
+  @override
+  String get game_line_audio_overlong_hint =>
+      'Far longer than a single line; may include BGM or other mixed audio';
+  @override
+  String get game_line_audio_loopback_hint =>
+      'System-mix fallback; may include BGM';
+  @override
+  String get game_line_recapture => 'Recapture voice';
+  @override
+  String get game_line_recapture_stop => 'Finish recapture';
 }
 
 /// Flat map(s) containing all translations.
@@ -104017,6 +104247,18 @@ extension on _StringsEn {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -109377,6 +109619,18 @@ extension on _StringsAr {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -114758,6 +115012,18 @@ extension on _StringsDe {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -120138,6 +120404,18 @@ extension on _StringsEs {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -125524,6 +125802,18 @@ extension on _StringsFr {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -130892,6 +131182,18 @@ extension on _StringsId {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -136275,6 +136577,18 @@ extension on _StringsIt {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -141620,6 +141934,18 @@ extension on _StringsJa {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -146969,6 +147295,18 @@ extension on _StringsKo {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -152345,6 +152683,18 @@ extension on _StringsNl {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -157718,6 +158068,18 @@ extension on _StringsPtBr {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -163096,6 +163458,18 @@ extension on _StringsRu {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -168458,6 +168832,18 @@ extension on _StringsTh {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -173829,6 +174215,18 @@ extension on _StringsTr {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -179195,6 +179593,18 @@ extension on _StringsVi {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }
@@ -184515,6 +184925,18 @@ extension on _StringsZhCn {
         return '该进程是本应用的另一个正在运行的实例。';
       case 'game_track_bgm':
         return 'BGM / 已排除';
+      case 'game_line_audio_no_voice':
+        return '无配音';
+      case 'game_line_audio_overlong':
+        return '超长片段';
+      case 'game_line_audio_overlong_hint':
+        return '远超单句时长，可能混入 BGM 或其它混音';
+      case 'game_line_audio_loopback_hint':
+        return '整机混音兜底，可能混入 BGM';
+      case 'game_line_recapture':
+        return '补录语音';
+      case 'game_line_recapture_stop':
+        return '完成补录';
       default:
         return null;
     }
@@ -189855,6 +190277,18 @@ extension on _StringsZhHk {
         return 'This process is another running instance of this app.';
       case 'game_track_bgm':
         return 'BGM / excluded';
+      case 'game_line_audio_no_voice':
+        return 'No voice';
+      case 'game_line_audio_overlong':
+        return 'Overlong clip';
+      case 'game_line_audio_overlong_hint':
+        return 'Far longer than a single line; may include BGM or other mixed audio';
+      case 'game_line_audio_loopback_hint':
+        return 'System-mix fallback; may include BGM';
+      case 'game_line_recapture':
+        return 'Recapture voice';
+      case 'game_line_recapture_stop':
+        return 'Finish recapture';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "无法结束 $process，请手动结束该进程后重试。",
   "yomitan_port_kill_protected": "$process 是关键系统进程，Hibiki 不会结束它；请改用其他端口。",
   "yomitan_port_kill_self_instance": "该进程是本应用的另一个正在运行的实例。",
-  "game_track_bgm": "BGM / 已排除"
+  "game_track_bgm": "BGM / 已排除",
+  "game_line_audio_no_voice": "无配音",
+  "game_line_audio_overlong": "超长片段",
+  "game_line_audio_overlong_hint": "远超单句时长，可能混入 BGM 或其它混音",
+  "game_line_audio_loopback_hint": "整机混音兜底，可能混入 BGM",
+  "game_line_recapture": "补录语音",
+  "game_line_recapture_stop": "完成补录"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "远超单句时长，可能混入 BGM 或其它混音",
   "game_line_audio_loopback_hint": "整机混音兜底，可能混入 BGM",
   "game_line_recapture": "补录语音",
-  "game_line_recapture_stop": "完成补录"
+  "game_line_recapture_stop": "完成补录",
+  "game_line_tracks": "本句音轨",
+  "game_line_tracks_hint": "按本句时刻试听各轨，确认是 BGM 就排除",
+  "game_line_track_use": "用于本句"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2621,5 +2621,11 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Hibiki will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "game_track_bgm": "BGM / excluded"
+  "game_track_bgm": "BGM / excluded",
+  "game_line_audio_no_voice": "No voice",
+  "game_line_audio_overlong": "Overlong clip",
+  "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
+  "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
+  "game_line_recapture": "Recapture voice",
+  "game_line_recapture_stop": "Finish recapture"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2627,5 +2627,8 @@
   "game_line_audio_overlong_hint": "Far longer than a single line; may include BGM or other mixed audio",
   "game_line_audio_loopback_hint": "System-mix fallback; may include BGM",
   "game_line_recapture": "Recapture voice",
-  "game_line_recapture_stop": "Finish recapture"
+  "game_line_recapture_stop": "Finish recapture",
+  "game_line_tracks": "Tracks for this line",
+  "game_line_tracks_hint": "Preview each track at this line's moment, then exclude the BGM ones",
+  "game_line_track_use": "Use for this line"
 }

--- a/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -134,27 +134,30 @@ class GalHookTextOverlayController extends ChangeNotifier {
           confirmMagpieDownload(appModel, prompt),
     );
     _session.attachMagpieUpscaling(magpie);
-    // 跨会话 BGM 排除记忆：真值落偏好表（每游戏一个 key，值为指纹 JSON 数组）。
-    // source_ptr 跨启动会变，能持久化的只有弱指纹（orderIndex+格式），错排除
-    // 可在音轨面板一键恢复且恢复会同步删除记忆——见 session 侧注释。
-    _session.attachTrackExclusionMemory(
+    // 每游戏捕获选择记忆（文本线程 / 语音轨 / BGM 排除集）：真值落偏好表，每游戏
+    // 一个 key，值是 [GalCaptureMemory] 的 JSON。会话内 id（source_ptr、native
+    // thread_id）跨启动全都会变，能持久化的只有弱指纹——错恢复可在工作台一键改，
+    // 且用户一改就同步覆盖记忆，见 session 侧注释。
+    _session.attachCaptureMemory(
       load: (String gameKey) {
         final Object? stored = appModel.prefsRepo
-            .getPref('gal_excluded_tracks::$gameKey', defaultValue: '');
-        if (stored is! String || stored.isEmpty) return const <String>[];
+            .getPref('gal_capture_memory::$gameKey', defaultValue: '');
+        if (stored is! String || stored.isEmpty) {
+          return const GalCaptureMemory();
+        }
         try {
           final Object? decoded = jsonDecode(stored);
-          if (decoded is List) {
-            return decoded.whereType<String>().toList(growable: false);
+          if (decoded is Map) {
+            return GalCaptureMemory.fromJson(decoded.cast<Object?, Object?>());
           }
         } catch (_) {}
-        return const <String>[];
+        return const GalCaptureMemory();
       },
-      save: (String gameKey, List<String> fingerprints) {
+      save: (String gameKey, GalCaptureMemory memory) {
         unawaited(
           appModel.prefsRepo.setPref(
-            'gal_excluded_tracks::$gameKey',
-            jsonEncode(fingerprints),
+            'gal_capture_memory::$gameKey',
+            jsonEncode(memory.toJson()),
           ),
         );
       },

--- a/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -134,6 +134,31 @@ class GalHookTextOverlayController extends ChangeNotifier {
           confirmMagpieDownload(appModel, prompt),
     );
     _session.attachMagpieUpscaling(magpie);
+    // 跨会话 BGM 排除记忆：真值落偏好表（每游戏一个 key，值为指纹 JSON 数组）。
+    // source_ptr 跨启动会变，能持久化的只有弱指纹（orderIndex+格式），错排除
+    // 可在音轨面板一键恢复且恢复会同步删除记忆——见 session 侧注释。
+    _session.attachTrackExclusionMemory(
+      load: (String gameKey) {
+        final Object? stored = appModel.prefsRepo
+            .getPref('gal_excluded_tracks::$gameKey', defaultValue: '');
+        if (stored is! String || stored.isEmpty) return const <String>[];
+        try {
+          final Object? decoded = jsonDecode(stored);
+          if (decoded is List) {
+            return decoded.whereType<String>().toList(growable: false);
+          }
+        } catch (_) {}
+        return const <String>[];
+      },
+      save: (String gameKey, List<String> fingerprints) {
+        unawaited(
+          appModel.prefsRepo.setPref(
+            'gal_excluded_tracks::$gameKey',
+            jsonEncode(fingerprints),
+          ),
+        );
+      },
+    );
     // 启动期对账：上次崩溃 / 被任务管理器结束时，退出清理根本没跑过，配置里会留着
     // `autoScale=Fullscreen` 的 `Hibiki: ` profile（外加可能还活着的 Magpie 进程）。
     // 不对账 = 用户下次不经 Hibiki 双击游戏也被自动全屏超分。fire-and-forget：它自身

--- a/hibiki/lib/src/mining/gal_audio_tracks_panel.dart
+++ b/hibiki/lib/src/mining/gal_audio_tracks_panel.dart
@@ -127,58 +127,61 @@ class GalTrackTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final PcmFormat format = track.format;
-    final ColorScheme colors = Theme.of(context).colorScheme;
     // 近窗内一个片段都没有的轨：留在列表里（用户需要知道它存在），但明确标注并置灰，
     // 不再让它看起来和真能取到语音的轨一样（BUG-1102 ②）。
     final bool silent = track.clipCount <= 0;
-    return ListTile(
-      contentPadding: EdgeInsets.zero,
-      enabled: !silent,
-      leading: Icon(excluded ? Icons.music_off_outlined : Icons.graphic_eq),
-      title: Text(
-        '${t.game_track_voice} ${track.orderIndex + 1} · ${format.sampleRate} Hz · ${format.channels} ch',
-      ),
-      subtitle: Text(
-        <String>[
-          '0x${track.sourcePtr.toRadixString(16)}',
-          '${t.game_track_clips} ${track.clipCount}',
-          '${t.game_track_energy} ${track.avgEnergy.toStringAsFixed(1)}',
-          if (excluded) t.game_track_bgm,
-          if (silent) t.game_track_no_clips,
-        ].join(' · '),
-        style: silent
-            ? Theme.of(context)
-                .textTheme
-                .bodyMedium
-                ?.copyWith(color: colors.outline)
-            : null,
-      ),
-      trailing: Wrap(
-        spacing: 4,
-        children: <Widget>[
-          // BUG-1027：逐轨试听——抓该轨最近整句 PCM 播放，帮用户判断这条轨
-          // 是语音还是 BGM，再决定选轨/排除。播放中变停止按钮。
-          HibikiIconButton(
-            icon: previewing
-                ? Icons.stop_circle_outlined
-                : Icons.play_circle_outline,
-            tooltip:
-                previewing ? t.game_track_preview_stop : t.game_track_preview,
-            onTap: onPreview,
+    return IgnorePointer(
+      ignoring: silent,
+      child: Opacity(
+        opacity: silent ? 0.56 : 1,
+        child: HibikiListItem(
+          padding: EdgeInsets.zero,
+          selected: selected,
+          leading: Icon(
+            excluded ? Icons.music_off_outlined : Icons.graphic_eq,
           ),
-          HibikiIconButton(
-            icon: selected ? Icons.check_circle : Icons.circle_outlined,
-            tooltip: selectTooltip ?? t.game_track_select_as_voice,
-            enabled: selectable && !excluded,
-            onTap: onSelect,
+          title: Text(
+            '${t.game_track_voice} ${track.orderIndex + 1} · ${format.sampleRate} Hz · ${format.channels} ch',
           ),
-          HibikiIconButton(
-            icon: excluded ? Icons.undo : Icons.music_off_outlined,
-            tooltip: excluded ? t.game_track_restore : t.game_track_exclude_bgm,
-            enabled: selectable,
-            onTap: () => onToggleExcluded(!excluded),
+          subtitle: Text(
+            <String>[
+              '0x${track.sourcePtr.toRadixString(16)}',
+              '${t.game_track_clips} ${track.clipCount}',
+              '${t.game_track_energy} ${track.avgEnergy.toStringAsFixed(1)}',
+              if (excluded) t.game_track_bgm,
+              if (silent) t.game_track_no_clips,
+            ].join(' · '),
           ),
-        ],
+          trailing: Wrap(
+            spacing: 4,
+            children: <Widget>[
+              // BUG-1027：逐轨试听——抓该轨最近整句 PCM 播放，帮用户判断这条轨
+              // 是语音还是 BGM，再决定选轨/排除。播放中变停止按钮。
+              HibikiIconButton(
+                icon: previewing
+                    ? Icons.stop_circle_outlined
+                    : Icons.play_circle_outline,
+                tooltip: previewing
+                    ? t.game_track_preview_stop
+                    : t.game_track_preview,
+                onTap: onPreview,
+              ),
+              HibikiIconButton(
+                icon: selected ? Icons.check_circle : Icons.circle_outlined,
+                tooltip: selectTooltip ?? t.game_track_select_as_voice,
+                enabled: selectable && !excluded,
+                onTap: onSelect,
+              ),
+              HibikiIconButton(
+                icon: excluded ? Icons.undo : Icons.music_off_outlined,
+                tooltip:
+                    excluded ? t.game_track_restore : t.game_track_exclude_bgm,
+                enabled: selectable,
+                onTap: () => onToggleExcluded(!excluded),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }
@@ -194,17 +197,18 @@ class _PanelHintBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     return Container(
-      margin: const EdgeInsets.only(top: 8),
-      padding: const EdgeInsets.all(10),
+      margin: EdgeInsets.only(top: tokens.spacing.gap),
+      padding: EdgeInsets.all(tokens.spacing.gap + 2),
       decoration: BoxDecoration(
         color: colors.secondaryContainer,
-        borderRadius: BorderRadius.circular(10),
+        borderRadius: tokens.radii.cardRadius,
       ),
       child: Row(
         children: <Widget>[
           Icon(icon, color: colors.onSecondaryContainer, size: 18),
-          const SizedBox(width: 8),
+          SizedBox(width: tokens.spacing.gap),
           Expanded(
             child: Text(
               text,

--- a/hibiki/lib/src/mining/gal_audio_tracks_panel.dart
+++ b/hibiki/lib/src/mining/gal_audio_tracks_panel.dart
@@ -102,6 +102,7 @@ class GalTrackTile extends StatelessWidget {
     required this.onSelect,
     required this.onPreview,
     required this.onToggleExcluded,
+    this.selectTooltip,
   });
 
   final GalAudioTrack track;
@@ -118,6 +119,10 @@ class GalTrackTile extends StatelessWidget {
   final VoidCallback onSelect;
   final VoidCallback onPreview;
   final ValueChanged<bool> onToggleExcluded;
+
+  /// 「设为语音轨」按钮的文案。会话面板是「选为会话语音轨」，逐句面板是「用于本句」
+  /// ——同一个控件两种作用域，文案必须说清改的是哪个，否则用户以为点了会话级。
+  final String? selectTooltip;
 
   @override
   Widget build(BuildContext context) {
@@ -163,7 +168,7 @@ class GalTrackTile extends StatelessWidget {
           ),
           HibikiIconButton(
             icon: selected ? Icons.check_circle : Icons.circle_outlined,
-            tooltip: t.game_track_select_as_voice,
+            tooltip: selectTooltip ?? t.game_track_select_as_voice,
             enabled: selectable && !excluded,
             onTap: onSelect,
           ),

--- a/hibiki/lib/src/mining/gal_audio_tracks_panel.dart
+++ b/hibiki/lib/src/mining/gal_audio_tracks_panel.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/mining/galgame_audio_encode.dart';
+import 'package:hibiki/src/mining/galgame_audio_source.dart';
+import 'package:hibiki/utils.dart';
+
+/// 会话音轨面板（共享内容组件）：轨列表 + 逐轨试听 + 设为语音轨 + 排除 BGM/恢复。
+///
+/// 同一份 UI 挂两处——诊断页的音轨卡片、捕获工作台顶栏的音轨对话框。此前排除 BGM
+/// 只能从「某一句的选轨对话框」进（先随便找一句点改轨才能排除，入口藏反了）；抽成
+/// 共享组件后工作台一键直达，两处不再各写一份轨列表。
+///
+/// 交互契约（沿诊断页既有语义，BUG-1027/1102）：
+/// - 试听不经过选轨/排除字段（显式传 sourcePtr），任何后端都可用；
+/// - 「设为语音轨」「排除」只在引擎 PCM 后端可用（[galTrackSelectionAffectsCapture]），
+///   其余后端禁用并给解释态，不渲染点了没反应的死控件；
+/// - 近窗零片段的轨照样列出但置灰标注（用户需要知道它存在）。
+class GalAudioTracksPanel extends StatelessWidget {
+  const GalAudioTracksPanel({
+    super.key,
+    required this.state,
+    required this.onSelectVoice,
+    required this.onToggleExcluded,
+    required this.onPreviewTrack,
+    required this.previewingSourcePtr,
+  });
+
+  final GalHookSessionState state;
+  final ValueChanged<int> onSelectVoice;
+  final void Function(int sourcePtr, bool excluded) onToggleExcluded;
+  final ValueChanged<GalAudioTrack> onPreviewTrack;
+  final int? previewingSourcePtr;
+
+  @override
+  Widget build(BuildContext context) {
+    // BUG-1027：gameResource / 纯 Loopback 模式下 PCM 音轨列表**本就不存在**，
+    // 通用「尚无音轨数据」会误导用户以为音频链路故障——改为按后端给解释态，
+    // 且不再渲染只对引擎 PCM 有意义的「自动选择」radio。
+    //
+    // BUG-1102：解释态与禁用判据都必须看**后端**，不是看列表空不空。
+    final GalTrackEmptyHint emptyHint =
+        galTrackEmptyHintFor(state.audioBackend);
+    final bool selectionEffective =
+        galTrackSelectionAffectsCapture(state.audioBackend);
+    final String? backendHint = selectionEffective
+        ? null
+        : switch (emptyHint) {
+            GalTrackEmptyHint.resourceMode => t.game_tracks_resource_mode_hint,
+            GalTrackEmptyHint.loopbackMode => t.game_tracks_loopback_hint,
+            GalTrackEmptyHint.generic =>
+              state.audioTracks.isEmpty ? null : t.game_tracks_pcm_only_hint,
+          };
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        if (backendHint != null)
+          _PanelHintBox(icon: Icons.info_outline, text: backendHint),
+        // 「自动选择」只对引擎 PCM 有意义；其余后端不渲染它，免得暗示能选。
+        if (selectionEffective)
+          RadioListTile<int>(
+            contentPadding: EdgeInsets.zero,
+            value: 0,
+            groupValue: state.selectedAudioSourcePtr,
+            onChanged: (int? value) => onSelectVoice(value ?? 0),
+            title: Text(t.game_track_auto),
+            secondary: const Icon(Icons.auto_awesome_outlined),
+          ),
+        if (state.audioTracks.isEmpty && backendHint == null)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            child: Text(t.game_no_tracks),
+          )
+        else
+          // 抓不到片段的轨照样列出来（用户需要知道它存在），但明确标注并置灰，
+          // 不再让它看起来和可用轨一样（BUG-1102 ②）。
+          for (final GalAudioTrack track in state.audioTracks)
+            GalTrackTile(
+              track: track,
+              selected: state.selectedAudioSourcePtr == track.sourcePtr,
+              excluded: state.excludedAudioSourcePtrs.contains(track.sourcePtr),
+              previewing: previewingSourcePtr == track.sourcePtr,
+              selectable: selectionEffective,
+              onSelect: () => onSelectVoice(track.sourcePtr),
+              onPreview: () => onPreviewTrack(track),
+              onToggleExcluded: (bool excluded) =>
+                  onToggleExcluded(track.sourcePtr, excluded),
+            ),
+      ],
+    );
+  }
+}
+
+/// 单条音轨行：格式/片段数/能量元数据 + 试听 / 设为语音轨 / 排除 BGM 三操作。
+class GalTrackTile extends StatelessWidget {
+  const GalTrackTile({
+    super.key,
+    required this.track,
+    required this.selected,
+    required this.excluded,
+    required this.previewing,
+    required this.selectable,
+    required this.onSelect,
+    required this.onPreview,
+    required this.onToggleExcluded,
+  });
+
+  final GalAudioTrack track;
+  final bool selected;
+  final bool excluded;
+
+  /// 该轨是否正在试听（按钮显示为停止）。
+  final bool previewing;
+
+  /// 当前音频后端是否真的消费选轨/排除（BUG-1102）。false 时这两个控件禁用——
+  /// 让用户点一个不会生效的按钮比直接说清楚更糟。试听仍可用（它显式传 sourcePtr、
+  /// 不经过这两个字段），用户仍能靠它判断哪条是语音。
+  final bool selectable;
+  final VoidCallback onSelect;
+  final VoidCallback onPreview;
+  final ValueChanged<bool> onToggleExcluded;
+
+  @override
+  Widget build(BuildContext context) {
+    final PcmFormat format = track.format;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    // 近窗内一个片段都没有的轨：留在列表里（用户需要知道它存在），但明确标注并置灰，
+    // 不再让它看起来和真能取到语音的轨一样（BUG-1102 ②）。
+    final bool silent = track.clipCount <= 0;
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      enabled: !silent,
+      leading: Icon(excluded ? Icons.music_off_outlined : Icons.graphic_eq),
+      title: Text(
+        '${t.game_track_voice} ${track.orderIndex + 1} · ${format.sampleRate} Hz · ${format.channels} ch',
+      ),
+      subtitle: Text(
+        <String>[
+          '0x${track.sourcePtr.toRadixString(16)}',
+          '${t.game_track_clips} ${track.clipCount}',
+          '${t.game_track_energy} ${track.avgEnergy.toStringAsFixed(1)}',
+          if (excluded) t.game_track_bgm,
+          if (silent) t.game_track_no_clips,
+        ].join(' · '),
+        style: silent
+            ? Theme.of(context)
+                .textTheme
+                .bodyMedium
+                ?.copyWith(color: colors.outline)
+            : null,
+      ),
+      trailing: Wrap(
+        spacing: 4,
+        children: <Widget>[
+          // BUG-1027：逐轨试听——抓该轨最近整句 PCM 播放，帮用户判断这条轨
+          // 是语音还是 BGM，再决定选轨/排除。播放中变停止按钮。
+          HibikiIconButton(
+            icon: previewing
+                ? Icons.stop_circle_outlined
+                : Icons.play_circle_outline,
+            tooltip:
+                previewing ? t.game_track_preview_stop : t.game_track_preview,
+            onTap: onPreview,
+          ),
+          HibikiIconButton(
+            icon: selected ? Icons.check_circle : Icons.circle_outlined,
+            tooltip: t.game_track_select_as_voice,
+            enabled: selectable && !excluded,
+            onTap: onSelect,
+          ),
+          HibikiIconButton(
+            icon: excluded ? Icons.undo : Icons.music_off_outlined,
+            tooltip: excluded ? t.game_track_restore : t.game_track_exclude_bgm,
+            enabled: selectable,
+            onTap: () => onToggleExcluded(!excluded),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 面板内解释态信息条（样式对齐诊断页 `_DetailBox` 的非错误形态）。
+class _PanelHintBox extends StatelessWidget {
+  const _PanelHintBox({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return Container(
+      margin: const EdgeInsets.only(top: 8),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: colors.secondaryContainer,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        children: <Widget>[
+          Icon(icon, color: colors.onSecondaryContainer, size: 18),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              text,
+              style: TextStyle(color: colors.onSecondaryContainer),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -1840,8 +1840,8 @@ class GalHookSessionController extends ChangeNotifier {
 
   /// 音轨的跨会话弱指纹。`source_ptr` 只在会话内稳定（跨启动是新指针），能锚的只有
   /// [GalAudioTrack.orderIndex]（创建顺序，跨启动相对稳定）+ PCM 格式。指纹可能撞/漂
-  /// ——所以记忆只用于**恢复排除**（错排除可一键恢复、且会话内立即可见），绝不用于
-  /// 自动选定语音轨（错选会静默混错音频）。
+  /// ——所以记忆只恢复用户显式选择的排除项和语音轨；排除优先，恢复结果在工作台可见，
+  /// 用户可在映射漂移时立即纠正。
   @visibleForTesting
   static String trackFingerprint(GalAudioTrack track) =>
       '${track.orderIndex}:${track.format.sampleRate}:'

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -61,6 +61,20 @@ enum GalHookAudioBackend { none, gameResource, enginePcm, systemLoopback }
 /// 「后端是不是引擎 PCM」（[galTrackSelectionAffectsCapture]），不是「列表空不空」。
 enum GalTrackEmptyHint { generic, resourceMode, loopbackMode }
 
+/// 单句语音的合理时长上限（毫秒）。超过它的切片多半不是「一句台词」而是长段混音
+/// （典型：制卡时才收束的 loopback 回取，见 [_flushLoopbackFreeze]），入卡前换成
+/// [kGalOverlongSliceSuspectReason] 让 UI 亮黄提醒，而不是静默当正常语音。
+const int kGalOverlongSliceSuspectMs = 20000;
+
+/// 跨会话 BGM 排除记忆的持久化端口（真值放偏好表，由
+/// [GalHookSessionController.attachTrackExclusionMemory] 注入）。gameKey 是
+/// 启动 exe 全路径小写；指纹见 [GalHookSessionController.trackFingerprint]。
+typedef GalTrackExclusionLoad = List<String> Function(String gameKey);
+typedef GalTrackExclusionSave = void Function(
+  String gameKey,
+  List<String> fingerprints,
+);
+
 /// 会话级选轨 / 排除是否真的影响取音（纯函数，可单测）。
 ///
 /// 只有引擎 PCM 后端会走 `grabUtterance`，也只有它读
@@ -529,6 +543,14 @@ class GalHookSessionController extends ChangeNotifier {
   final Map<String, DateTime> _loopbackFreezeStartedAt = <String, DateTime>{};
 
   final Map<String, GalAudioSlice> _lineVoiceCache = <String, GalAudioSlice>{};
+
+  // 跨会话 BGM 排除记忆（见 [attachTrackExclusionMemory]）。
+  GalTrackExclusionLoad? _exclusionMemoryLoad;
+  GalTrackExclusionSave? _exclusionMemorySave;
+  bool _exclusionMemoryApplied = false;
+  bool _exclusionMemoryLoaded = false;
+  String? _exclusionMemoryGameKey;
+  final Set<String> _persistedExclusionFps = <String>{};
   final Map<String, int> _lineTimestampCache = <String, int>{};
   final Map<String, int> _lineTextEventIdCache = <String, int>{};
   final Map<String, ({int timestampMs, int textEventId})>
@@ -1081,6 +1103,7 @@ class GalHookSessionController extends ChangeNotifier {
         excludedAudioSourcePtrs: const <int>{},
       ),
     );
+    _resetExclusionMemorySession();
     _record(
       GalHookEventSeverity.success,
       'session',
@@ -1121,6 +1144,10 @@ class GalHookSessionController extends ChangeNotifier {
     final bool membershipChanged =
         !sameTrackMembership(_state.audioTracks, tracks);
     _setState(_state.copyWith(audioTracks: tracks));
+    if (tracks.isNotEmpty && !_exclusionMemoryApplied) {
+      _exclusionMemoryApplied = true;
+      _applyPersistedExclusions(engine, tracks);
+    }
     // BUG-1027：刷新已由定时器/状态迁移自动驱动，只有轨成员变化才记事件，
     // 避免 5s 一条「已刷新」把事件日志淹掉。
     if (membershipChanged) {
@@ -1671,6 +1698,7 @@ class GalHookSessionController extends ChangeNotifier {
         ),
       ),
     );
+    _persistTrackExclusion(sourcePtr, excluded);
     _record(
       GalHookEventSeverity.info,
       'audio',
@@ -1678,6 +1706,112 @@ class GalHookSessionController extends ChangeNotifier {
       excluded ? 'Audio track marked as BGM/excluded' : 'Audio track restored',
       details: <String, Object?>{'sourcePtr': sourcePtr},
     );
+  }
+
+  /// 注入跨会话 BGM 排除记忆的持久化端口（桌面启动流程
+  /// [GalHookTextOverlayController.start] 调用一次，真值落偏好表）。不注入 =
+  /// 排除只活在会话内，行为与旧版一致。
+  void attachTrackExclusionMemory({
+    required GalTrackExclusionLoad load,
+    required GalTrackExclusionSave save,
+  }) {
+    _exclusionMemoryLoad = load;
+    _exclusionMemorySave = save;
+  }
+
+  /// 音轨的跨会话弱指纹。`source_ptr` 只在会话内稳定（跨启动是新指针），能锚的只有
+  /// [GalAudioTrack.orderIndex]（创建顺序，跨启动相对稳定）+ PCM 格式。指纹可能撞/漂
+  /// ——所以记忆只用于**恢复排除**（错排除可一键恢复、且会话内立即可见），绝不用于
+  /// 自动选定语音轨（错选会静默混错音频）。
+  @visibleForTesting
+  static String trackFingerprint(GalAudioTrack track) =>
+      '${track.orderIndex}:${track.format.sampleRate}:'
+      '${track.format.channels}:${track.format.bitsPerSample}:'
+      '${track.format.isFloat ? 1 : 0}';
+
+  String? _exclusionGameKey() {
+    final String? exe = _state.launchExe;
+    if (exe == null || exe.isEmpty) return null;
+    return exe.toLowerCase();
+  }
+
+  /// 惰性加载当前游戏的持久化排除指纹（每会话一次）。没有游戏身份（窗口附着、
+  /// 非启动路径）就没有记忆——宁可少记，不猜身份。
+  bool _ensureExclusionMemoryLoaded() {
+    if (_exclusionMemoryLoaded) return _exclusionMemoryGameKey != null;
+    _exclusionMemoryLoaded = true;
+    final GalTrackExclusionLoad? load = _exclusionMemoryLoad;
+    final String? gameKey = _exclusionGameKey();
+    if (load == null || gameKey == null) return false;
+    _exclusionMemoryGameKey = gameKey;
+    _persistedExclusionFps
+      ..clear()
+      ..addAll(load(gameKey));
+    return true;
+  }
+
+  /// 首个非空音轨快照到达时，把上次会话的排除按指纹套回当前轨。只应用一次：
+  /// 环形越新鲜 orderIndex 越贴近真实创建序，越晚匹配越容易漂。
+  void _applyPersistedExclusions(
+    EngineHookGalAudioSource engine,
+    List<GalAudioTrack> tracks,
+  ) {
+    if (!_ensureExclusionMemoryLoaded() || _persistedExclusionFps.isEmpty) {
+      return;
+    }
+    int applied = 0;
+    for (final GalAudioTrack track in tracks) {
+      if (!_persistedExclusionFps.contains(trackFingerprint(track))) continue;
+      if (!engine.excludedAudioSourcePtrs.add(track.sourcePtr)) continue;
+      applied++;
+    }
+    if (applied == 0) return;
+    _setState(
+      _state.copyWith(
+        excludedAudioSourcePtrs: Set<int>.unmodifiable(
+          engine.excludedAudioSourcePtrs,
+        ),
+      ),
+    );
+    _record(
+      GalHookEventSeverity.info,
+      'audio',
+      'audio.track_exclusions_restored',
+      'Restored BGM track exclusions from the previous session',
+      details: <String, Object?>{'count': applied},
+    );
+  }
+
+  /// 用户显式排除/恢复后同步持久化。恢复会把指纹从记忆里删掉——用户说了这条轨
+  /// 不是 BGM，下次会话不得再自动排除它。
+  void _persistTrackExclusion(int sourcePtr, bool excluded) {
+    if (!_ensureExclusionMemoryLoaded()) return;
+    final GalTrackExclusionSave? save = _exclusionMemorySave;
+    final String? gameKey = _exclusionMemoryGameKey;
+    if (save == null || gameKey == null) return;
+    GalAudioTrack? track;
+    for (final GalAudioTrack candidate in _state.audioTracks) {
+      if (candidate.sourcePtr == sourcePtr) {
+        track = candidate;
+        break;
+      }
+    }
+    if (track == null) return; // 快照里已不存在的轨谈不上指纹。
+    final String fingerprint = trackFingerprint(track);
+    final bool changed = excluded
+        ? _persistedExclusionFps.add(fingerprint)
+        : _persistedExclusionFps.remove(fingerprint);
+    if (changed) {
+      save(gameKey, _persistedExclusionFps.toList()..sort());
+    }
+  }
+
+  /// 会话结束时复位记忆的会话内状态（持久化真值不动）。
+  void _resetExclusionMemorySession() {
+    _exclusionMemoryApplied = false;
+    _exclusionMemoryLoaded = false;
+    _exclusionMemoryGameKey = null;
+    _persistedExclusionFps.clear();
   }
 
   Future<Uint8List?> captureAudioBytes({
@@ -1807,7 +1941,13 @@ class GalHookSessionController extends ChangeNotifier {
           await engine.grabClipNear(timestamp);
     }
     if (slice == null || slice.isEmpty) {
-      _markLineAudioMissing(lineId, 'line_audio_not_cached');
+      // 制卡时刻仍两手空空：能给证据就给证据——引擎 PCM 会话下按「该句时刻
+      // 是否有候选轨在响」区分无配音与疑似漏抓，别一律顶红标。
+      final String reason =
+          engine != null && identical(source, engine) && timestamp > 0
+              ? await _classifyEnginePcmMiss(engine, timestamp)
+              : 'line_audio_not_cached';
+      _markLineAudioMissing(lineId, reason);
       return null;
     }
     return _encodeLineSlice(
@@ -1820,6 +1960,24 @@ class GalHookSessionController extends ChangeNotifier {
     );
   }
 
+  /// 超长切片门（纯函数）：一句台词的语音极少超过 [kGalOverlongSliceSuspectMs]。
+  /// 超长的多半是「制卡时才收束的 loopback 回取」把几十秒混音整段塞了进来
+  /// （[_flushLoopbackFreeze] 的 backMs 上限是环容量 60s）。不丢数据——照样入卡，
+  /// 但把 fallbackReason 换成明确的可疑标注让 UI 亮黄，别让一段混着 BGM 的长音频
+  /// 顶着正常标签混过去。用户显式裁决（补录/选轨）是有意为之，不二次质疑。
+  @visibleForTesting
+  static String? sliceFallbackReasonFor({
+    required int durationMs,
+    required String? fallbackReason,
+  }) {
+    final bool userAdjudicated = fallbackReason == 'manual_recapture' ||
+        fallbackReason == 'manual_track_override';
+    if (!userAdjudicated && durationMs > kGalOverlongSliceSuspectMs) {
+      return kGalOverlongSliceSuspectReason;
+    }
+    return fallbackReason;
+  }
+
   /// 把一段冻结 PCM 切片转成制卡容器字节，并把该行标成 encoded。
   /// 制卡链路上「有切片了」之后的收尾只有这一份实现（PCM 兜底与手动补录共用）。
   Future<Uint8List?> _encodeLineSlice({
@@ -1829,6 +1987,20 @@ class GalHookSessionController extends ChangeNotifier {
     required String outputExtension,
     required String? fallbackReason,
   }) async {
+    final int durationMs = (slice.pcm.length * 1000) ~/ slice.format.byteRate;
+    final String? effectiveReason = sliceFallbackReasonFor(
+      durationMs: durationMs,
+      fallbackReason: fallbackReason,
+    );
+    if (effectiveReason != fallbackReason) {
+      _record(
+        GalHookEventSeverity.warning,
+        'encode',
+        'audio.slice_overlong',
+        'Captured slice is suspiciously long for a single line',
+        details: <String, Object?>{'lineId': lineId, 'durationMs': durationMs},
+      );
+    }
     final Directory jobDirectory = await Directory.systemTemp.createTemp(
       'hibiki-gal-mining-job-',
     );
@@ -1847,8 +2019,8 @@ class GalHookSessionController extends ChangeNotifier {
         lineId,
         status: TexthookerLineAudioStatus.encoded,
         backend: backend,
-        durationMs: (slice.pcm.length * 1000) ~/ slice.format.byteRate,
-        fallbackReason: fallbackReason,
+        durationMs: durationMs,
+        fallbackReason: effectiveReason,
       );
       _record(
         GalHookEventSeverity.success,
@@ -2939,18 +3111,56 @@ class GalHookSessionController extends ChangeNotifier {
       return;
     }
     if (!resourceReady) {
+      final String reason =
+          await _classifyEnginePcmMiss(engine, line.timestampMs);
+      if (engine != _engineSource || !isLineInCurrentSession(entry)) return;
       _textService.updateLineAudio(
         entry.id,
         status: TexthookerLineAudioStatus.missing,
-        fallbackReason: 'utterance_not_found',
+        fallbackReason: reason,
       );
       _record(
-        GalHookEventSeverity.warning,
+        reason == kGalLineNoVoiceReason
+            ? GalHookEventSeverity.info
+            : GalHookEventSeverity.warning,
         'match',
-        'audio.utterance_not_found',
-        'No engine utterance matched the captured line',
+        reason == kGalLineNoVoiceReason
+            ? 'audio.line_no_voice'
+            : 'audio.utterance_not_found',
+        reason == kGalLineNoVoiceReason
+            ? 'No PCM was active at this line; treating it as unvoiced'
+            : 'No engine utterance matched the captured line',
         details: <String, Object?>{'lineId': entry.id, 'seq': line.seq},
       );
+    }
+  }
+
+  /// 引擎 PCM 窗口内没抓到这句语音时，区分「这句本来就没配音」与「疑似漏抓」。
+  ///
+  /// 证据来自 [EngineHookGalAudioSource.listAudioTracks]：`avgEnergy >= 0` 表示该轨
+  /// 在**该句文本时刻窗**（native `[ts-150, ts+450]`）内确有 16-bit clip——
+  /// - 候选轨（未被排除、且未被逐轨锁定到别的轨）在该时刻有能量 → 疑似漏抓，红标提醒；
+  /// - 候选轨全部沉默（声音只在被排除的 BGM 轨上，或根本没有）→ 判无配音，灰标不告警。
+  /// 这样旁白/选项句不再顶着「missing」红标吓人，真正的抓取失败也不会被无配音淹没。
+  Future<String> _classifyEnginePcmMiss(
+    EngineHookGalAudioSource engine,
+    int timestampMs,
+  ) async {
+    if (timestampMs <= 0) return 'utterance_not_found';
+    try {
+      final List<GalAudioTrack> tracks =
+          await engine.listAudioTracks(timestampMs);
+      final Set<int> excluded = engine.excludedAudioSourcePtrs;
+      final int selected = engine.selectedAudioSourcePtr;
+      final bool candidateActive = tracks.any(
+        (GalAudioTrack track) =>
+            !excluded.contains(track.sourcePtr) &&
+            (selected == 0 || track.sourcePtr == selected) &&
+            track.avgEnergy >= 0,
+      );
+      return candidateActive ? 'utterance_not_found' : kGalLineNoVoiceReason;
+    } catch (_) {
+      return 'utterance_not_found';
     }
   }
 

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -66,13 +66,79 @@ enum GalTrackEmptyHint { generic, resourceMode, loopbackMode }
 /// [kGalOverlongSliceSuspectReason] 让 UI 亮黄提醒，而不是静默当正常语音。
 const int kGalOverlongSliceSuspectMs = 20000;
 
-/// 跨会话 BGM 排除记忆的持久化端口（真值放偏好表，由
-/// [GalHookSessionController.attachTrackExclusionMemory] 注入）。gameKey 是
-/// 启动 exe 全路径小写；指纹见 [GalHookSessionController.trackFingerprint]。
-typedef GalTrackExclusionLoad = List<String> Function(String gameKey);
-typedef GalTrackExclusionSave = void Function(
+/// 每个游戏的捕获选择记忆（跨会话持久化的真值放偏好表）。
+///
+/// 三项都用**弱指纹**而非会话内 id：`source_ptr` 每次启动都变、native 文本
+/// `thread_id` 混了 processId 同样每次都变，能跨会话锚住的只有
+/// [GalHookSessionController.trackFingerprint]（音轨创建序 + PCM 格式）与
+/// [GalHookSessionController.textThreadFingerprint]（LunaHook 的 hook code /
+/// 标签）。指纹可能漂或撞，因此恢复必须是**可见且一键可改**的：三项恢复各记一条
+/// 结构化事件，且工作台面板实时显示当前生效的选择。
+@immutable
+class GalCaptureMemory {
+  const GalCaptureMemory({
+    this.excludedTrackFingerprints = const <String>[],
+    this.voiceTrackFingerprint,
+    this.textThreadFingerprint,
+  });
+
+  factory GalCaptureMemory.fromJson(Map<Object?, Object?> json) {
+    final Object? excluded = json['excludedTracks'];
+    return GalCaptureMemory(
+      excludedTrackFingerprints: excluded is List
+          ? excluded.whereType<String>().toList(growable: false)
+          : const <String>[],
+      voiceTrackFingerprint: json['voiceTrack'] as String?,
+      textThreadFingerprint: json['textThread'] as String?,
+    );
+  }
+
+  /// 用户标记为 BGM 的音轨指纹集合。
+  final List<String> excludedTrackFingerprints;
+
+  /// 用户选定的会话语音轨指纹；null = 自动选源。
+  final String? voiceTrackFingerprint;
+
+  /// 用户选定的文本线程指纹；null = 自动选线程。
+  final String? textThreadFingerprint;
+
+  bool get isEmpty =>
+      excludedTrackFingerprints.isEmpty &&
+      voiceTrackFingerprint == null &&
+      textThreadFingerprint == null;
+
+  GalCaptureMemory copyWith({
+    List<String>? excludedTrackFingerprints,
+    String? voiceTrackFingerprint,
+    String? textThreadFingerprint,
+    bool clearVoiceTrack = false,
+    bool clearTextThread = false,
+  }) =>
+      GalCaptureMemory(
+        excludedTrackFingerprints:
+            excludedTrackFingerprints ?? this.excludedTrackFingerprints,
+        voiceTrackFingerprint: clearVoiceTrack
+            ? null
+            : voiceTrackFingerprint ?? this.voiceTrackFingerprint,
+        textThreadFingerprint: clearTextThread
+            ? null
+            : textThreadFingerprint ?? this.textThreadFingerprint,
+      );
+
+  Map<String, Object?> toJson() => <String, Object?>{
+        'excludedTracks': excludedTrackFingerprints,
+        if (voiceTrackFingerprint != null) 'voiceTrack': voiceTrackFingerprint,
+        if (textThreadFingerprint != null) 'textThread': textThreadFingerprint,
+      };
+}
+
+/// [GalCaptureMemory] 的持久化端口（由
+/// [GalHookSessionController.attachCaptureMemory] 注入）。gameKey 是启动 exe
+/// 全路径小写——只有 launch 路径有稳定游戏身份，attach（绑窗口）没有，不猜。
+typedef GalCaptureMemoryLoad = GalCaptureMemory Function(String gameKey);
+typedef GalCaptureMemorySave = void Function(
   String gameKey,
-  List<String> fingerprints,
+  GalCaptureMemory memory,
 );
 
 /// 会话级选轨 / 排除是否真的影响取音（纯函数，可单测）。
@@ -544,13 +610,23 @@ class GalHookSessionController extends ChangeNotifier {
 
   final Map<String, GalAudioSlice> _lineVoiceCache = <String, GalAudioSlice>{};
 
-  // 跨会话 BGM 排除记忆（见 [attachTrackExclusionMemory]）。
-  GalTrackExclusionLoad? _exclusionMemoryLoad;
-  GalTrackExclusionSave? _exclusionMemorySave;
-  bool _exclusionMemoryApplied = false;
-  bool _exclusionMemoryLoaded = false;
-  String? _exclusionMemoryGameKey;
-  final Set<String> _persistedExclusionFps = <String>{};
+  // 每游戏捕获选择记忆（见 [attachCaptureMemory]）。
+  GalCaptureMemoryLoad? _captureMemoryLoad;
+  GalCaptureMemorySave? _captureMemorySave;
+  bool _captureMemoryLoaded = false;
+  String? _captureMemoryGameKey;
+  GalCaptureMemory _captureMemory = const GalCaptureMemory();
+
+  /// 音轨记忆（排除集 + 语音轨）已对本会话首个非空快照应用过。
+  bool _trackMemoryApplied = false;
+
+  /// 文本线程记忆已在本会话应用过（或用户已手动选过线程）——两者都终止自动恢复。
+  bool _textThreadMemoryApplied = false;
+
+  /// 记忆恢复文本线程所需的最小行数：native 线程 id 混了 processId，跨会话不稳定，
+  /// 同一 hook 往往有多条并行线程共用同一指纹，只能靠「真的在出台词」来消歧。
+  /// 门限设 3 行而不是 1 行，避免开局个别 UI 线程抢先蹦一行就把选择钉死。
+  static const int _textThreadRestoreMinLines = 3;
   final Map<String, int> _lineTimestampCache = <String, int>{};
   final Map<String, int> _lineTextEventIdCache = <String, int>{};
   final Map<String, ({int timestampMs, int textEventId})>
@@ -1103,7 +1179,7 @@ class GalHookSessionController extends ChangeNotifier {
         excludedAudioSourcePtrs: const <int>{},
       ),
     );
-    _resetExclusionMemorySession();
+    _resetCaptureMemorySession();
     _record(
       GalHookEventSeverity.success,
       'session',
@@ -1144,9 +1220,9 @@ class GalHookSessionController extends ChangeNotifier {
     final bool membershipChanged =
         !sameTrackMembership(_state.audioTracks, tracks);
     _setState(_state.copyWith(audioTracks: tracks));
-    if (tracks.isNotEmpty && !_exclusionMemoryApplied) {
-      _exclusionMemoryApplied = true;
-      _applyPersistedExclusions(engine, tracks);
+    if (tracks.isNotEmpty && !_trackMemoryApplied) {
+      _trackMemoryApplied = true;
+      _applyTrackMemory(engine, tracks);
     }
     // BUG-1027：刷新已由定时器/状态迁移自动驱动，只有轨成员变化才记事件，
     // 避免 5s 一条「已刷新」把事件日志淹掉。
@@ -1542,6 +1618,7 @@ class GalHookSessionController extends ChangeNotifier {
     }
     engine.selectedAudioSourcePtr = sourcePtr;
     _setState(_state.copyWith(selectedAudioSourcePtr: sourcePtr));
+    _persistVoiceTrack(sourcePtr);
     _record(
       GalHookEventSeverity.success,
       'audio',
@@ -1553,9 +1630,14 @@ class GalHookSessionController extends ChangeNotifier {
     );
   }
 
+  /// 选择文本线程。
+  ///
+  /// [remember] = true（用户在 UI 里主动选）时把选择写进每游戏记忆，并锁死本会话的
+  /// 自动恢复；记忆恢复自身调用时传 false，免得把「恢复」当成一次新的用户选择再写回。
   Future<bool> selectTextThread(
     int? threadId, {
     String? threadKey,
+    bool remember = false,
   }) async {
     final EngineHookGalAudioSource? engine = _engineSource;
     // WebSocket/剪贴板等外部 Hook 线程没有 native helper，也仍需由 app 级状态
@@ -1567,6 +1649,18 @@ class GalHookSessionController extends ChangeNotifier {
           threadKey == null || threadKey.isEmpty ? null : threadKey;
       _selectedNativeTextThreadId =
           threadId == null || threadId == 0 ? null : threadId;
+      if (remember) {
+        // 用户已亲自表态：本会话不再自动恢复，并把这次选择记成新的真值。
+        _textThreadMemoryApplied = true;
+        TexthookerTextThread? chosen;
+        for (final TexthookerTextThread thread in _textService.textThreads) {
+          if (thread.key == _selectedTextThreadKey) {
+            chosen = thread;
+            break;
+          }
+        }
+        _persistTextThread(chosen);
+      }
     }
     _record(
       selected ? GalHookEventSeverity.success : GalHookEventSeverity.warning,
@@ -1675,6 +1769,31 @@ class GalHookSessionController extends ChangeNotifier {
     return true;
   }
 
+  /// **这一句**当前生效的音轨（用户逐行选轨的结果）；null = 未逐行指定，走会话
+  /// 级选轨 / 自动选源。捕获工作台的逐句音轨面板据此显示"本句用的是哪条轨"。
+  int? lineVoiceSourcePtr(String lineId) => _lineVoiceSourcePtr[lineId];
+
+  /// 取**这一句时刻**的音轨快照（工作台逐句音轨面板的数据源）。
+  ///
+  /// 与会话级 [refreshAudioTracks] 的区别只在时间戳：那个用最近一条台词的 ts
+  /// 做会话级概览，这里必须用该行自己的 ts——不然用户看到的能量/片段数属于别的
+  /// 句子，"排除这句里的 BGM"就成了盲操作。行不属于当前会话 / 无时间戳时返回空。
+  Future<List<GalAudioTrack>> tracksForLine(String lineId) async {
+    final EngineHookGalAudioSource? engine = _engineSource;
+    final TexthookerLineEntry? entry = _textService.entryById(lineId);
+    final int timestamp = _lineTimestampCache[lineId] ?? 0;
+    if (engine == null ||
+        entry == null ||
+        !isLineInCurrentSession(entry) ||
+        timestamp <= 0) {
+      return const <GalAudioTrack>[];
+    }
+    final List<GalAudioTrack> tracks = await engine.listAudioTracks(timestamp);
+    // await 期间会话可能已停止/重启：旧 engine 的快照不落地（同 BUG-950 范式）。
+    if (engine != _engineSource) return const <GalAudioTrack>[];
+    return tracks;
+  }
+
   /// 本行的语音是否由用户显式裁决过（手动补录或逐行选轨）。自动配对一律让路。
   bool _isUserAdjudicated(String lineId) =>
       _manualRecaptureLines.contains(lineId) ||
@@ -1708,15 +1827,15 @@ class GalHookSessionController extends ChangeNotifier {
     );
   }
 
-  /// 注入跨会话 BGM 排除记忆的持久化端口（桌面启动流程
+  /// 注入每游戏捕获选择记忆的持久化端口（桌面启动流程
   /// [GalHookTextOverlayController.start] 调用一次，真值落偏好表）。不注入 =
-  /// 排除只活在会话内，行为与旧版一致。
-  void attachTrackExclusionMemory({
-    required GalTrackExclusionLoad load,
-    required GalTrackExclusionSave save,
+  /// 选择只活在会话内，行为与旧版一致。
+  void attachCaptureMemory({
+    required GalCaptureMemoryLoad load,
+    required GalCaptureMemorySave save,
   }) {
-    _exclusionMemoryLoad = load;
-    _exclusionMemorySave = save;
+    _captureMemoryLoad = load;
+    _captureMemorySave = save;
   }
 
   /// 音轨的跨会话弱指纹。`source_ptr` 只在会话内稳定（跨启动是新指针），能锚的只有
@@ -1729,89 +1848,202 @@ class GalHookSessionController extends ChangeNotifier {
       '${track.format.channels}:${track.format.bitsPerSample}:'
       '${track.format.isFloat ? 1 : 0}';
 
-  String? _exclusionGameKey() {
+  /// 文本线程的跨会话弱指纹。native `thread_id` 混了 processId（injector 侧
+  /// FNV-1a），跨启动必变；能锚的只有 LunaHook 的 hook code（同一 hook 稳定）。
+  /// 没有 hook code 的来源（GDI / Unity / WebSocket）退回标签。
+  ///
+  /// 同一 hook code 常有多条并行线程（ctx/ctx2 不同，未透出到 Dart），因此指纹
+  /// **不足以唯一定位线程**——恢复时还要靠「谁真的在出台词」消歧，见
+  /// [_maybeRestoreTextThread]。
+  @visibleForTesting
+  static String? textThreadFingerprint(TexthookerTextThread thread) {
+    final String? code = thread.hookCode?.trim();
+    if (code != null && code.isNotEmpty) return 'code:$code';
+    final String label = thread.label.trim();
+    return label.isEmpty ? null : 'label:$label';
+  }
+
+  String? _captureMemoryKeyForGame() {
     final String? exe = _state.launchExe;
     if (exe == null || exe.isEmpty) return null;
     return exe.toLowerCase();
   }
 
-  /// 惰性加载当前游戏的持久化排除指纹（每会话一次）。没有游戏身份（窗口附着、
-  /// 非启动路径）就没有记忆——宁可少记，不猜身份。
-  bool _ensureExclusionMemoryLoaded() {
-    if (_exclusionMemoryLoaded) return _exclusionMemoryGameKey != null;
-    _exclusionMemoryLoaded = true;
-    final GalTrackExclusionLoad? load = _exclusionMemoryLoad;
-    final String? gameKey = _exclusionGameKey();
+  /// 惰性加载当前游戏的记忆（每会话一次）。没有游戏身份（窗口附着、非启动路径）
+  /// 就没有记忆——宁可少记，不猜身份。
+  bool _ensureCaptureMemoryLoaded() {
+    if (_captureMemoryLoaded) return _captureMemoryGameKey != null;
+    _captureMemoryLoaded = true;
+    final GalCaptureMemoryLoad? load = _captureMemoryLoad;
+    final String? gameKey = _captureMemoryKeyForGame();
     if (load == null || gameKey == null) return false;
-    _exclusionMemoryGameKey = gameKey;
-    _persistedExclusionFps
-      ..clear()
-      ..addAll(load(gameKey));
+    _captureMemoryGameKey = gameKey;
+    _captureMemory = load(gameKey);
     return true;
   }
 
-  /// 首个非空音轨快照到达时，把上次会话的排除按指纹套回当前轨。只应用一次：
-  /// 环形越新鲜 orderIndex 越贴近真实创建序，越晚匹配越容易漂。
-  void _applyPersistedExclusions(
+  void _saveCaptureMemory(GalCaptureMemory memory) {
+    _captureMemory = memory;
+    final GalCaptureMemorySave? save = _captureMemorySave;
+    final String? gameKey = _captureMemoryGameKey;
+    if (save == null || gameKey == null) return;
+    save(gameKey, memory);
+  }
+
+  /// 首个非空音轨快照到达时，把上次会话的排除集与语音轨按指纹套回当前轨。
+  /// 只应用一次：环形越新鲜 orderIndex 越贴近真实创建序，越晚匹配越容易漂。
+  void _applyTrackMemory(
     EngineHookGalAudioSource engine,
     List<GalAudioTrack> tracks,
   ) {
-    if (!_ensureExclusionMemoryLoaded() || _persistedExclusionFps.isEmpty) {
-      return;
-    }
-    int applied = 0;
+    if (!_ensureCaptureMemoryLoaded() || _captureMemory.isEmpty) return;
+    final Set<String> excludedFps =
+        _captureMemory.excludedTrackFingerprints.toSet();
+    final String? voiceFp = _captureMemory.voiceTrackFingerprint;
+    int excluded = 0;
+    int? restoredVoicePtr;
     for (final GalAudioTrack track in tracks) {
-      if (!_persistedExclusionFps.contains(trackFingerprint(track))) continue;
-      if (!engine.excludedAudioSourcePtrs.add(track.sourcePtr)) continue;
-      applied++;
+      final String fingerprint = trackFingerprint(track);
+      if (excludedFps.contains(fingerprint) &&
+          engine.excludedAudioSourcePtrs.add(track.sourcePtr)) {
+        excluded++;
+      }
+      if (voiceFp != null && fingerprint == voiceFp) {
+        restoredVoicePtr ??= track.sourcePtr;
+      }
     }
-    if (applied == 0) return;
+    // 被排除的轨不能同时是语音轨（用户后来把它标成了 BGM）：排除优先。
+    if (restoredVoicePtr != null &&
+        engine.excludedAudioSourcePtrs.contains(restoredVoicePtr)) {
+      restoredVoicePtr = null;
+    }
+    if (excluded == 0 && restoredVoicePtr == null) return;
+    if (restoredVoicePtr != null) {
+      engine.selectedAudioSourcePtr = restoredVoicePtr;
+    }
     _setState(
       _state.copyWith(
         excludedAudioSourcePtrs: Set<int>.unmodifiable(
           engine.excludedAudioSourcePtrs,
         ),
+        selectedAudioSourcePtr:
+            restoredVoicePtr ?? _state.selectedAudioSourcePtr,
       ),
     );
     _record(
       GalHookEventSeverity.info,
       'audio',
-      'audio.track_exclusions_restored',
-      'Restored BGM track exclusions from the previous session',
-      details: <String, Object?>{'count': applied},
+      'audio.track_memory_restored',
+      'Restored per-game track choices from the previous session',
+      details: <String, Object?>{
+        'excluded': excluded,
+        if (restoredVoicePtr != null) 'voiceSourcePtr': restoredVoicePtr,
+      },
     );
   }
 
   /// 用户显式排除/恢复后同步持久化。恢复会把指纹从记忆里删掉——用户说了这条轨
   /// 不是 BGM，下次会话不得再自动排除它。
   void _persistTrackExclusion(int sourcePtr, bool excluded) {
-    if (!_ensureExclusionMemoryLoaded()) return;
-    final GalTrackExclusionSave? save = _exclusionMemorySave;
-    final String? gameKey = _exclusionMemoryGameKey;
-    if (save == null || gameKey == null) return;
-    GalAudioTrack? track;
-    for (final GalAudioTrack candidate in _state.audioTracks) {
-      if (candidate.sourcePtr == sourcePtr) {
-        track = candidate;
-        break;
-      }
-    }
-    if (track == null) return; // 快照里已不存在的轨谈不上指纹。
-    final String fingerprint = trackFingerprint(track);
+    if (!_ensureCaptureMemoryLoaded()) return;
+    final String? fingerprint = _fingerprintForSourcePtr(sourcePtr);
+    if (fingerprint == null) return; // 快照里已不存在的轨谈不上指纹。
+    final Set<String> fingerprints =
+        _captureMemory.excludedTrackFingerprints.toSet();
     final bool changed = excluded
-        ? _persistedExclusionFps.add(fingerprint)
-        : _persistedExclusionFps.remove(fingerprint);
-    if (changed) {
-      save(gameKey, _persistedExclusionFps.toList()..sort());
+        ? fingerprints.add(fingerprint)
+        : fingerprints.remove(fingerprint);
+    if (!changed) return;
+    _saveCaptureMemory(
+      _captureMemory.copyWith(
+        excludedTrackFingerprints: fingerprints.toList()..sort(),
+      ),
+    );
+  }
+
+  /// 用户显式选定/取消会话语音轨后同步持久化（0 = 自动选源，清掉记忆）。
+  void _persistVoiceTrack(int sourcePtr) {
+    if (!_ensureCaptureMemoryLoaded()) return;
+    if (sourcePtr == 0) {
+      if (_captureMemory.voiceTrackFingerprint == null) return;
+      _saveCaptureMemory(_captureMemory.copyWith(clearVoiceTrack: true));
+      return;
     }
+    final String? fingerprint = _fingerprintForSourcePtr(sourcePtr);
+    if (fingerprint == null ||
+        _captureMemory.voiceTrackFingerprint == fingerprint) {
+      return;
+    }
+    _saveCaptureMemory(
+      _captureMemory.copyWith(voiceTrackFingerprint: fingerprint),
+    );
+  }
+
+  String? _fingerprintForSourcePtr(int sourcePtr) {
+    for (final GalAudioTrack track in _state.audioTracks) {
+      if (track.sourcePtr == sourcePtr) return trackFingerprint(track);
+    }
+    return null;
+  }
+
+  /// 每次线程目录变动时尝试恢复上次会话选定的文本线程。
+  ///
+  /// 只在**用户本会话尚未手动选过**且恢复尚未发生时生效，且要求候选线程已出
+  /// [_textThreadRestoreMinLines] 行——指纹只能锚到 hook 而锚不到具体并行线程
+  /// （ctx 未透出），靠「谁真的在出台词」消歧。选中后本会话不再自动改，避免
+  /// 行数此消彼长导致选择反复跳动。
+  void _maybeRestoreTextThread() {
+    if (_textThreadMemoryApplied || _selectedTextThreadKey != null) return;
+    if (!_ensureCaptureMemoryLoaded()) return;
+    final String? wanted = _captureMemory.textThreadFingerprint;
+    if (wanted == null) return;
+    TexthookerTextThread? best;
+    for (final TexthookerTextThread thread in _textService.textThreads) {
+      if (textThreadFingerprint(thread) != wanted) continue;
+      if (thread.lineCount < _textThreadRestoreMinLines) continue;
+      if (best == null || thread.lineCount > best.lineCount) best = thread;
+    }
+    if (best == null) return;
+    _textThreadMemoryApplied = true;
+    unawaited(
+      selectTextThread(best.nativeThreadId, threadKey: best.key).then((
+        bool selected,
+      ) {
+        if (!selected) return;
+        _record(
+          GalHookEventSeverity.info,
+          'text',
+          'text.thread_memory_restored',
+          'Restored the text thread remembered for this game',
+          details: <String, Object?>{'threadKey': best!.key},
+        );
+      }),
+    );
+  }
+
+  /// 用户显式选定/取消文本线程后同步持久化（null = 自动，清掉记忆）。
+  void _persistTextThread(TexthookerTextThread? thread) {
+    if (!_ensureCaptureMemoryLoaded()) return;
+    final String? fingerprint =
+        thread == null ? null : textThreadFingerprint(thread);
+    if (fingerprint == null) {
+      if (_captureMemory.textThreadFingerprint == null) return;
+      _saveCaptureMemory(_captureMemory.copyWith(clearTextThread: true));
+      return;
+    }
+    if (_captureMemory.textThreadFingerprint == fingerprint) return;
+    _saveCaptureMemory(
+      _captureMemory.copyWith(textThreadFingerprint: fingerprint),
+    );
   }
 
   /// 会话结束时复位记忆的会话内状态（持久化真值不动）。
-  void _resetExclusionMemorySession() {
-    _exclusionMemoryApplied = false;
-    _exclusionMemoryLoaded = false;
-    _exclusionMemoryGameKey = null;
-    _persistedExclusionFps.clear();
+  void _resetCaptureMemorySession() {
+    _trackMemoryApplied = false;
+    _textThreadMemoryApplied = false;
+    _captureMemoryLoaded = false;
+    _captureMemoryGameKey = null;
+    _captureMemory = const GalCaptureMemory();
   }
 
   Future<Uint8List?> captureAudioBytes({
@@ -2827,6 +3059,8 @@ class GalHookSessionController extends ChangeNotifier {
             textSignalReceived: true,
           ),
         );
+        // 行数变了才值得重评：恢复要求候选线程已出够行数（见 [_maybeRestoreTextThread]）。
+        _maybeRestoreTextThread();
       }
     } finally {
       _pollInFlight = false;

--- a/hibiki/lib/src/mining/galgame_audio_source.dart
+++ b/hibiki/lib/src/mining/galgame_audio_source.dart
@@ -1304,12 +1304,28 @@ class EngineHookGalAudioSource implements GalAudioSource {
   /// v2 **按句取语音**：取时间戳与 [tsMs]（GetTickCount64，来自 [pollText] 的行 ts）最近、差
   /// <= [tolMs] 的语音 clip PCM —— 就是「这句台词对应的那段语音」，**自动选取、替代手动波形
   /// 选区**。找不到返回 null。
-  Future<GalAudioSlice?> grabClipNear(int tsMs, {int tolMs = 8000}) async {
+  ///
+  /// 选轨/排除契约与 [grabUtterance] 一致：缺省沿用 [selectedAudioSourcePtr] /
+  /// [excludedAudioSourcePtrs]。本方法是 grabUtterance 的兜底（BUG-1118）——兜底若不认
+  /// 排除集，用户在工作台标掉的 BGM 轨会从这里绕回制卡链。
+  Future<GalAudioSlice?> grabClipNear(
+    int tsMs, {
+    int tolMs = 8000,
+    int? sourcePtr,
+    List<int>? exclude,
+  }) async {
+    final int src = sourcePtr ?? selectedAudioSourcePtr;
+    final List<int> ex = exclude ?? excludedAudioSourcePtrs.toList();
     try {
       final Map<Object?, Object?>? r =
           await _channel.invokeMethod<Map<Object?, Object?>>(
         'grabClipNear',
-        <String, Object?>{'tsMs': tsMs, 'tolMs': tolMs},
+        <String, Object?>{
+          'tsMs': tsMs,
+          'tolMs': tolMs,
+          'sourcePtr': src,
+          'exclude': ex,
+        },
       );
       if (r == null || r['error'] != null) {
         return null;

--- a/hibiki/lib/src/pages/implementations/game_diagnostics_page.dart
+++ b/hibiki/lib/src/pages/implementations/game_diagnostics_page.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/mining/gal_audio_tracks_panel.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
-import 'package:hibiki/src/mining/galgame_audio_encode.dart';
 import 'package:hibiki/src/mining/galgame_audio_source.dart';
 import 'package:hibiki/src/pages/implementations/game_shared.dart';
 import 'package:hibiki/src/pages/implementations/stat_kpi_strip.dart';
@@ -457,25 +457,8 @@ class _AudioTracksCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // BUG-1027：gameResource / 纯 Loopback 模式下 PCM 音轨列表**本就不存在**，
-    // 通用「尚无音轨数据」会误导用户以为音频链路故障——改为按后端给解释态，
-    // 且不再渲染只对引擎 PCM 有意义的「自动选择」radio。
-    //
-    // BUG-1102：解释态与禁用判据都必须看**后端**，不是看列表空不空。用户机器上列表非空
-    // （PCM 环里还有残留可枚举）却照样点不动选轨，正是因为当前后端根本不消费
-    // selectedAudioSourcePtr；旧实现只在 isEmpty 时解释，于是整套死控件照常渲染。
-    final GalTrackEmptyHint emptyHint =
-        galTrackEmptyHintFor(state.audioBackend);
-    final bool selectionEffective =
-        galTrackSelectionAffectsCapture(state.audioBackend);
-    final String? backendHint = selectionEffective
-        ? null
-        : switch (emptyHint) {
-            GalTrackEmptyHint.resourceMode => t.game_tracks_resource_mode_hint,
-            GalTrackEmptyHint.loopbackMode => t.game_tracks_loopback_hint,
-            GalTrackEmptyHint.generic =>
-              state.audioTracks.isEmpty ? null : t.game_tracks_pcm_only_hint,
-          };
+    // 轨列表/选轨/排除/试听的内容体抽到共享组件 [GalAudioTracksPanel]（捕获工作台
+    // 顶栏的音轨对话框复用同一份），这里只保留诊断页的卡片壳与刷新入口。
     return _SectionCard(
       title: t.game_audio_tracks,
       icon: Icons.multitrack_audio_outlined,
@@ -484,129 +467,12 @@ class _AudioTracksCard extends StatelessWidget {
         tooltip: t.game_refresh_tracks,
         onTap: onRefresh,
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          if (backendHint != null)
-            _DetailBox(icon: Icons.info_outline, text: backendHint),
-          // 「自动选择」只对引擎 PCM 有意义；其余后端不渲染它，免得暗示能选。
-          if (selectionEffective)
-            RadioListTile<int>(
-              contentPadding: EdgeInsets.zero,
-              value: 0,
-              groupValue: state.selectedAudioSourcePtr,
-              onChanged: (int? value) => onSelectVoice(value ?? 0),
-              title: Text(t.game_track_auto),
-              secondary: const Icon(Icons.auto_awesome_outlined),
-            ),
-          if (state.audioTracks.isEmpty && backendHint == null)
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 12),
-              child: Text(t.game_no_tracks),
-            )
-          else
-            // 抓不到片段的轨照样列出来（用户需要知道它存在），但明确标注并置灰，
-            // 不再让它看起来和可用轨一样（BUG-1102 ②）。
-            for (final GalAudioTrack track in state.audioTracks)
-              _TrackTile(
-                track: track,
-                selected: state.selectedAudioSourcePtr == track.sourcePtr,
-                excluded:
-                    state.excludedAudioSourcePtrs.contains(track.sourcePtr),
-                previewing: previewingSourcePtr == track.sourcePtr,
-                selectable: selectionEffective,
-                onSelect: () => onSelectVoice(track.sourcePtr),
-                onPreview: () => onPreviewTrack(track),
-                onToggleExcluded: (bool excluded) =>
-                    onToggleExcluded(track.sourcePtr, excluded),
-              ),
-        ],
-      ),
-    );
-  }
-}
-
-class _TrackTile extends StatelessWidget {
-  const _TrackTile({
-    required this.track,
-    required this.selected,
-    required this.excluded,
-    required this.previewing,
-    required this.selectable,
-    required this.onSelect,
-    required this.onPreview,
-    required this.onToggleExcluded,
-  });
-
-  final GalAudioTrack track;
-  final bool selected;
-  final bool excluded;
-
-  /// 该轨是否正在试听（按钮显示为停止）。
-  final bool previewing;
-
-  /// 当前音频后端是否真的消费选轨/排除（BUG-1102）。false 时这两个控件禁用——
-  /// 让用户点一个不会生效的按钮比直接说清楚更糟。试听仍可用（它显式传 sourcePtr、
-  /// 不经过这两个字段），用户仍能靠它判断哪条是语音。
-  final bool selectable;
-  final VoidCallback onSelect;
-  final VoidCallback onPreview;
-  final ValueChanged<bool> onToggleExcluded;
-
-  @override
-  Widget build(BuildContext context) {
-    final PcmFormat format = track.format;
-    final ColorScheme colors = Theme.of(context).colorScheme;
-    // 近窗内一个片段都没有的轨：留在列表里（用户需要知道它存在），但明确标注并置灰，
-    // 不再让它看起来和真能取到语音的轨一样（BUG-1102 ②）。
-    final bool silent = track.clipCount <= 0;
-    return ListTile(
-      contentPadding: EdgeInsets.zero,
-      enabled: !silent,
-      leading: Icon(excluded ? Icons.music_off_outlined : Icons.graphic_eq),
-      title: Text(
-        '${t.game_track_voice} ${track.orderIndex + 1} · ${format.sampleRate} Hz · ${format.channels} ch',
-      ),
-      subtitle: Text(
-        <String>[
-          '0x${track.sourcePtr.toRadixString(16)}',
-          '${t.game_track_clips} ${track.clipCount}',
-          '${t.game_track_energy} ${track.avgEnergy.toStringAsFixed(1)}',
-          if (silent) t.game_track_no_clips,
-        ].join(' · '),
-        style: silent
-            ? Theme.of(context)
-                .textTheme
-                .bodyMedium
-                ?.copyWith(color: colors.outline)
-            : null,
-      ),
-      trailing: Wrap(
-        spacing: 4,
-        children: <Widget>[
-          // BUG-1027：逐轨试听——抓该轨最近整句 PCM 播放，帮用户判断这条轨
-          // 是语音还是 BGM，再决定选轨/排除。播放中变停止按钮。
-          HibikiIconButton(
-            icon: previewing
-                ? Icons.stop_circle_outlined
-                : Icons.play_circle_outline,
-            tooltip:
-                previewing ? t.game_track_preview_stop : t.game_track_preview,
-            onTap: onPreview,
-          ),
-          HibikiIconButton(
-            icon: selected ? Icons.check_circle : Icons.circle_outlined,
-            tooltip: t.game_track_select_as_voice,
-            enabled: selectable && !excluded,
-            onTap: onSelect,
-          ),
-          HibikiIconButton(
-            icon: excluded ? Icons.undo : Icons.music_off_outlined,
-            tooltip: excluded ? t.game_track_restore : t.game_track_exclude_bgm,
-            enabled: selectable,
-            onTap: () => onToggleExcluded(!excluded),
-          ),
-        ],
+      child: GalAudioTracksPanel(
+        state: state,
+        onSelectVoice: onSelectVoice,
+        onToggleExcluded: onToggleExcluded,
+        onPreviewTrack: onPreviewTrack,
+        previewingSourcePtr: previewingSourcePtr,
       ),
     );
   }

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -14,6 +14,7 @@ import 'package:hibiki/src/lookup/gal_hook_text_overlay_controller.dart';
 import 'package:hibiki/src/mining/gal_hook_failure_text.dart';
 import 'package:hibiki/src/mining/magpie_upscaling_service.dart';
 import 'package:hibiki/src/mining/magpie_upscaling_text.dart';
+import 'package:hibiki/src/mining/gal_audio_tracks_panel.dart';
 import 'package:hibiki/src/mining/gal_hook_mining_coordinator.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
 import 'package:hibiki/src/mining/galgame_audio_source.dart';
@@ -382,6 +383,105 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     if (!await DesktopAudioPlayback.playFile(preview.filePath)) {
       HibikiToast.show(msg: t.game_track_preview_failed);
     }
+  }
+
+  /// 会话音轨对话框：内容复用 [GalAudioTracksPanel]（与诊断页同一份），随会话
+  /// 状态实时刷新。逐轨试听按最近一条台词时间戳整句抓取（与诊断页同语义——这里
+  /// 是会话级判断「哪条轨是语音/BGM」，不针对具体某句；针对某句改轨走行内改轨）。
+  Future<void> _showSessionTrackPanel() async {
+    unawaited(_session.refreshAudioTracks());
+    int? previewingPtr;
+    Timer? previewReset;
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext dialogContext) {
+        return StatefulBuilder(
+          builder: (BuildContext context, StateSetter setDialogState) {
+            Future<void> handlePreview(GalAudioTrack track) async {
+              if (previewingPtr == track.sourcePtr) {
+                previewReset?.cancel();
+                setDialogState(() => previewingPtr = null);
+                await DesktopAudioPlayback.stop();
+                return;
+              }
+              final GalTrackPreview? preview =
+                  await _session.exportTrackPreview(track.sourcePtr);
+              if (!dialogContext.mounted) return;
+              if (preview == null) {
+                HibikiToast.show(msg: t.game_track_preview_failed);
+                return;
+              }
+              final bool started =
+                  await DesktopAudioPlayback.playFile(preview.filePath);
+              if (!dialogContext.mounted) return;
+              if (!started) {
+                HibikiToast.show(msg: t.game_track_preview_failed);
+                return;
+              }
+              previewReset?.cancel();
+              setDialogState(() => previewingPtr = track.sourcePtr);
+              previewReset = Timer(
+                Duration(milliseconds: preview.durationMs + 300),
+                () {
+                  if (dialogContext.mounted) {
+                    setDialogState(() => previewingPtr = null);
+                  }
+                },
+              );
+            }
+
+            return AlertDialog(
+              title: Text(t.game_audio_tracks),
+              content: SizedBox(
+                width: 520,
+                child: ListenableBuilder(
+                  listenable: _session,
+                  builder: (BuildContext context, Widget? child) {
+                    return SingleChildScrollView(
+                      child: GalAudioTracksPanel(
+                        state: _session.state,
+                        onSelectVoice: _session.selectVoiceTrack,
+                        onToggleExcluded: _session.setTrackExcluded,
+                        onPreviewTrack: (GalAudioTrack track) =>
+                            unawaited(handlePreview(track)),
+                        previewingSourcePtr: previewingPtr,
+                      ),
+                    );
+                  },
+                ),
+              ),
+              actions: <Widget>[
+                TextButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(),
+                  child: Text(t.dialog_close),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+    previewReset?.cancel();
+    unawaited(DesktopAudioPlayback.stop());
+  }
+
+  /// 行内补录开/收：missing/兜底行的一键补救。开窗后回游戏里点一次语音重播，
+  /// 再点停止（或等窗口到点自动收束）。与浮窗「重播并录音」同一条控制器出口，
+  /// 结果标注 manual_recapture，自动配对不得再覆盖（用户裁决优先）。
+  Future<void> _toggleLineRecapture(TexthookerLineEntry line) async {
+    if (_session.recapturingLineId == line.id) {
+      final bool ok = await _session.finishLineRecapture();
+      HibikiToast.show(
+        msg: ok ? t.game_hook_recapture_saved : t.game_hook_recapture_empty,
+      );
+      return;
+    }
+    final bool started = await _session.startLineRecapture(line.id);
+    HibikiToast.show(
+      msg: started
+          ? t.game_hook_recapture_started
+          : t.game_hook_recapture_unavailable,
+    );
   }
 
   /// 分词结果缓存：行文本按 id 不可变，缓存 textToWords 避免每次 rebuild 重复分词
@@ -1013,6 +1113,16 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
           label: labelOf(t.game_stop_listening),
           onTap: () => unawaited(_session.stopCapture()),
         ),
+      // 会话音轨面板直达入口：排除 BGM 是会话级操作，此前只能从「某一句的
+      // 选轨对话框」绕进去（先随便找一句才能排除，入口藏反了）。
+      if (Platform.isWindows && state.isActive)
+        HibikiIconButton(
+          icon: Icons.multitrack_audio_outlined,
+          tooltip: t.game_audio_tracks,
+          label: labelOf(t.game_audio_tracks),
+          focusId: const HibikiFocusId('game-toolbar-tracks'),
+          onTap: () => unawaited(_showSessionTrackPanel()),
+        ),
       HibikiIconButton(
         icon: Icons.delete_outline,
         tooltip: t.clear,
@@ -1448,6 +1558,10 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                         canPickTrack: _session.hasEngineSource &&
                             _session.state.audioTracks.isNotEmpty &&
                             _session.isLineInCurrentSession(line),
+                        canRecapture: Platform.isWindows &&
+                            _session.state.isActive &&
+                            _session.isLineInCurrentSession(line),
+                        recapturing: _session.recapturingLineId == line.id,
                         onSelectLine: _selectLine,
                         onWordTap: _onWordTap,
                         onToggleFavorite: _toggleLineFavorite,
@@ -1455,6 +1569,8 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                             unawaited(_toggleLinePreview(l)),
                         onPickTrack: (TexthookerLineEntry l) =>
                             unawaited(_pickLineTrack(l)),
+                        onRecapture: (TexthookerLineEntry l) =>
+                            unawaited(_toggleLineRecapture(l)),
                       );
                     },
                   ),
@@ -2046,11 +2162,14 @@ class _TexthookerLine extends StatelessWidget {
     required this.selected,
     required this.previewingAudio,
     required this.canPickTrack,
+    required this.canRecapture,
+    required this.recapturing,
     required this.onSelectLine,
     required this.onWordTap,
     required this.onToggleFavorite,
     required this.onPreviewAudio,
     required this.onPickTrack,
+    required this.onRecapture,
   });
 
   final TexthookerLineEntry line;
@@ -2062,6 +2181,12 @@ class _TexthookerLine extends StatelessWidget {
 
   /// 是否显示「改音轨」按钮：会话有 engine helper、有音轨快照、且本行属于当前会话。
   final bool canPickTrack;
+
+  /// 是否显示「补录」按钮：Windows 会话进行中且本行属于当前会话。
+  final bool canRecapture;
+
+  /// 本行是否正开着补录窗口（按钮显示为停止收束）。
+  final bool recapturing;
   final ValueChanged<TexthookerLineEntry> onSelectLine;
   final ValueChanged<TexthookerLineEntry> onToggleFavorite;
 
@@ -2070,6 +2195,9 @@ class _TexthookerLine extends StatelessWidget {
 
   /// 为本行单独改选语音轨（自动配对配错时的用户裁决出口）。
   final ValueChanged<TexthookerLineEntry> onPickTrack;
+
+  /// 开/收本行补录窗口（missing/兜底行的一键补救，与浮窗「重播并录音」同出口）。
+  final ValueChanged<TexthookerLineEntry> onRecapture;
   final void Function(
     TexthookerLineEntry line,
     String word,
@@ -2112,7 +2240,11 @@ class _TexthookerLine extends StatelessWidget {
                   const _LineMinedChip(),
                   const SizedBox(width: 6),
                 ],
-                _LineAudioChip(status: line.audioStatus),
+                _LineAudioChip(
+                  status: line.audioStatus,
+                  backend: line.audioBackend,
+                  fallbackReason: line.fallbackReason,
+                ),
                 const SizedBox(width: 4),
                 // 行内试听已配音频（用户实拍：音频就绪却听不了）。仅 hasAudio 行显示；
                 // 试听中变停止钮。样式对齐收藏星。
@@ -2140,6 +2272,23 @@ class _TexthookerLine extends StatelessWidget {
                     size: 18,
                     focusId: HibikiFocusId('game-line-track-${line.id}'),
                     onTap: () => onPickTrack(line),
+                  ),
+                  const SizedBox(width: 4),
+                ],
+                // 行内补录：missing/兜底行的一键补救此前只在浮窗有入口，工作台里
+                // 用户对着红标没有任何补救手段。录音中变停止钮（收束并落定）。
+                if (canRecapture) ...<Widget>[
+                  HibikiIconButton(
+                    icon: recapturing
+                        ? Icons.stop_circle_outlined
+                        : Icons.mic_none_outlined,
+                    tooltip: recapturing
+                        ? t.game_line_recapture_stop
+                        : t.game_line_recapture,
+                    size: 18,
+                    enabledColor: recapturing ? colors.error : null,
+                    focusId: HibikiFocusId('game-line-recapture-${line.id}'),
+                    onTap: () => onRecapture(line),
                   ),
                   const SizedBox(width: 4),
                 ],
@@ -2222,13 +2371,46 @@ class _LineMinedChip extends StatelessWidget {
 }
 
 class _LineAudioChip extends StatelessWidget {
-  const _LineAudioChip({required this.status});
+  const _LineAudioChip({
+    required this.status,
+    this.backend,
+    this.fallbackReason,
+  });
 
   final TexthookerLineAudioStatus status;
+
+  /// 音频来源（engine_pcm / game_resource / system_loopback），用于把「整机混音
+  /// 兜底（可能混 BGM）」从正常绿标里分出来提示。
+  final String? backend;
+
+  /// 语义化 fallbackReason（见 [kGalLineNoVoiceReason] / [kGalOverlongSliceSuspectReason]）：
+  /// 「无配音」灰标不吓人、「超长可疑切片」亮黄提醒。
+  final String? fallbackReason;
 
   @override
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
+    // 语义化 reason 优先于通用状态：无配音是常态不是故障；超长切片是可疑不是正常。
+    if (status == TexthookerLineAudioStatus.missing &&
+        fallbackReason == kGalLineNoVoiceReason) {
+      return _chip(
+        context,
+        t.game_line_audio_no_voice,
+        colors.surfaceContainerHighest,
+        colors.onSurfaceVariant,
+      );
+    }
+    if (fallbackReason == kGalOverlongSliceSuspectReason) {
+      return Tooltip(
+        message: t.game_line_audio_overlong_hint,
+        child: _chip(
+          context,
+          t.game_line_audio_overlong,
+          colors.tertiaryContainer,
+          colors.onTertiaryContainer,
+        ),
+      );
+    }
     final (String, Color, Color) appearance = switch (status) {
       TexthookerLineAudioStatus.pending => (
           t.game_line_audio_pending,
@@ -2261,17 +2443,31 @@ class _LineAudioChip extends StatelessWidget {
           colors.onSurfaceVariant,
         ),
     };
+    final Widget chip =
+        _chip(context, appearance.$1, appearance.$2, appearance.$3);
+    // loopback 是整机混音兜底：状态标签照旧，但悬停要说清「可能混入 BGM」。
+    if (backend == 'system_loopback') {
+      return Tooltip(message: t.game_line_audio_loopback_hint, child: chip);
+    }
+    return chip;
+  }
+
+  Widget _chip(
+    BuildContext context,
+    String label,
+    Color background,
+    Color foreground,
+  ) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(
-        color: appearance.$2,
+        color: background,
         borderRadius: BorderRadius.circular(999),
       ),
       child: Text(
-        appearance.$1,
-        style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              color: appearance.$3,
-            ),
+        label,
+        style:
+            Theme.of(context).textTheme.labelSmall?.copyWith(color: foreground),
       ),
     );
   }

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -260,7 +260,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     unawaited(_session.refreshAudioTracks());
     int? previewingPtr;
     Timer? previewReset;
-    await showDialog<void>(
+    await showAppDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) {
         return StatefulBuilder(
@@ -1054,7 +1054,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   /// 会话健康状态对话框（原右栏常驻卡的新家）。内容仍是 [_CaptureHealthCard]，
   /// 随会话状态实时刷新；Anki 配置态来自 app 级 AnkiViewModel（BUG-1007 的接线）。
   Future<void> _showHealthDialog() async {
-    await showDialog<void>(
+    await showAppDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) => AlertDialog(
         title: Text(t.game_health),

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -55,7 +55,7 @@ Map<String, String> injectActiveSentence(
 /// 消除嵌入/独立两套按钮定义的特殊分支。
 enum _GalHookToolbarMenuAction {
   audioFallback,
-  manageTracks,
+  health,
   showOverlay,
   externalWindow,
 }
@@ -238,138 +238,6 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     HibikiToast.show(
       msg: applied ? t.game_line_track_applied : t.game_line_track_failed,
     );
-  }
-
-  /// 捕获工作台内的「排除音轨」对话框：列出会话当前音轨，逐轨试听 + 标记为 BGM /
-  /// 恢复。复用会话已有的 `setTrackExcluded`（诊断页同一通道）。排除某条 BGM 轨后，
-  /// 自动选源在**任何一句**（尤其是没有语音的那一句）都不会再选它——这正是「没音频
-  /// 时不读到 BGM」的直接手段，无需改 native。
-  ///
-  /// 排除集合只在**引擎 PCM** 后端参与取音（资源原件走逐句文件、纯 loopback 是整机单
-  /// 流，都不消费排除集合）；因此非引擎 PCM 时给出说明而非让用户点一个不生效的开关，
-  /// 与诊断页 `galTrackSelectionAffectsCapture` 门控口径一致。
-  Future<void> _showTrackManagerDialog() async {
-    unawaited(_session.refreshAudioTracks());
-    await showAppDialog<void>(
-      context: context,
-      builder: (BuildContext dialogContext) {
-        return AnimatedBuilder(
-          animation: _session,
-          builder: (BuildContext context, _) {
-            final GalHookSessionState state = _session.state;
-            final bool effective =
-                galTrackSelectionAffectsCapture(state.audioBackend);
-            final List<GalAudioTrack> tracks = state.audioTracks;
-            return AlertDialog(
-              title: Text(t.game_track_exclusion_title),
-              content: SizedBox(
-                width: 360,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: <Widget>[
-                    Text(
-                      t.game_track_exclusion_hint,
-                      style: Theme.of(context).textTheme.bodySmall,
-                    ),
-                    if (!effective) ...<Widget>[
-                      const SizedBox(height: 8),
-                      Text(
-                        t.game_tracks_pcm_only_hint,
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: Theme.of(context).colorScheme.tertiary,
-                            ),
-                      ),
-                    ],
-                    const SizedBox(height: 8),
-                    if (tracks.isEmpty)
-                      Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        child: Text(t.game_no_tracks),
-                      )
-                    else
-                      Flexible(
-                        child: ListView(
-                          shrinkWrap: true,
-                          children: <Widget>[
-                            for (final GalAudioTrack track in tracks)
-                              _buildTrackManagerTile(track, effective, state),
-                          ],
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-              actions: <Widget>[
-                TextButton(
-                  onPressed: () => Navigator.of(dialogContext).pop(),
-                  child: Text(t.dialog_close),
-                ),
-              ],
-            );
-          },
-        );
-      },
-    );
-    if (_previewingLineId != null && mounted) {
-      // 对话框里的试听走的是共享播放器；关闭对话框顺手停掉，避免残留播放。
-      await DesktopAudioPlayback.stop();
-    }
-  }
-
-  Widget _buildTrackManagerTile(
-    GalAudioTrack track,
-    bool effective,
-    GalHookSessionState state,
-  ) {
-    final bool excluded =
-        state.excludedAudioSourcePtrs.contains(track.sourcePtr);
-    final bool silent = track.clipCount <= 0;
-    return ListTile(
-      contentPadding: EdgeInsets.zero,
-      enabled: !silent,
-      leading: Icon(excluded ? Icons.music_off_outlined : Icons.graphic_eq),
-      title: Text(
-        '${t.game_track_voice} ${track.orderIndex + 1} · '
-        '${track.format.sampleRate} Hz · ${track.format.channels} ch',
-      ),
-      subtitle: Text(
-        <String>[
-          '${t.game_track_clips} ${track.clipCount}',
-          '${t.game_track_energy} ${track.avgEnergy.toStringAsFixed(1)}',
-          if (silent) t.game_track_no_clips,
-        ].join(' · '),
-      ),
-      trailing: Wrap(
-        spacing: 4,
-        children: <Widget>[
-          HibikiIconButton(
-            icon: Icons.play_circle_outline,
-            tooltip: t.game_track_preview,
-            onTap: () => unawaited(_previewTrackInDialog(track.sourcePtr)),
-          ),
-          HibikiIconButton(
-            icon: excluded ? Icons.undo : Icons.music_off_outlined,
-            tooltip: excluded ? t.game_track_restore : t.game_track_exclude_bgm,
-            enabled: effective,
-            onTap: () => _session.setTrackExcluded(track.sourcePtr, !excluded),
-          ),
-        ],
-      ),
-    );
-  }
-
-  /// 选轨对话框里的逐轨试听：复用诊断页同一条 `exportTrackPreview` 通道。
-  Future<void> _previewTrackInDialog(int sourcePtr) async {
-    final GalTrackPreview? preview =
-        await _session.exportTrackPreview(sourcePtr);
-    if (preview == null) {
-      HibikiToast.show(msg: t.game_track_preview_failed);
-      return;
-    }
-    if (!await DesktopAudioPlayback.playFile(preview.filePath)) {
-      HibikiToast.show(msg: t.game_track_preview_failed);
-    }
   }
 
   /// 选轨对话框里的逐轨试听：与确认选择共用当前行时间戳，避免试听偷播最新一句。
@@ -1147,8 +1015,8 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
         switch (action) {
           case _GalHookToolbarMenuAction.audioFallback:
             _session.setAllowAudioFallback(!state.allowAudioFallback);
-          case _GalHookToolbarMenuAction.manageTracks:
-            unawaited(_showTrackManagerDialog());
+          case _GalHookToolbarMenuAction.health:
+            unawaited(_showHealthDialog());
           case _GalHookToolbarMenuAction.showOverlay:
             unawaited(GalHookTextOverlayController.instance.showManually());
           case _GalHookToolbarMenuAction.externalWindow:
@@ -1162,12 +1030,11 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
           checked: state.allowAudioFallback,
           child: Text(t.game_audio_fallback_allow),
         ),
-        // 排除音轨：把 BGM/环境音轨标记为排除，自动选源便不再把它当成语音——
-        // 一句没有语音时不会再误读到 BGM（用户实拍反馈）。诊断页已有逐轨排除，
-        // 但排查语音配对时用户就在工作台，把入口也放到这里。
+        // 健康状态从右栏常驻卡改为按需打开：它是「偶尔查一眼」的静态信息，
+        // 不值得长期占着逐句操作要用的横向空间（完整版仍在「兼容性诊断」页签）。
         PopupMenuItem<_GalHookToolbarMenuAction>(
-          value: _GalHookToolbarMenuAction.manageTracks,
-          child: Text(t.game_manage_tracks),
+          value: _GalHookToolbarMenuAction.health,
+          child: Text(t.game_health),
         ),
         if (Platform.isWindows)
           PopupMenuItem<_GalHookToolbarMenuAction>(
@@ -1181,6 +1048,43 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
             child: Text(t.external_window_mining),
           ),
       ],
+    );
+  }
+
+  /// 会话健康状态对话框（原右栏常驻卡的新家）。内容仍是 [_CaptureHealthCard]，
+  /// 随会话状态实时刷新；Anki 配置态来自 app 级 AnkiViewModel（BUG-1007 的接线）。
+  Future<void> _showHealthDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext dialogContext) => AlertDialog(
+        title: Text(t.game_health),
+        content: SizedBox(
+          width: 460,
+          child: ListenableBuilder(
+            listenable: _session,
+            builder: (BuildContext context, Widget? child) =>
+                SingleChildScrollView(
+              child: _CaptureHealthCard(
+                state: _session.state,
+                endpoints: _session.endpointStatuses,
+                // BUG-1007 根因修复：健康卡 Anki 行此前写死「未配置」，不反映真实
+                // 配置。接 app 级 AnkiViewModel 的已配置判定（牌组 + 笔记类型均已选）。
+                ankiConfigured: ref.watch(
+                  ankiViewModelProvider.select(
+                    (AnkiUiState uiState) => uiState.isConfigured,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(t.dialog_close),
+          ),
+        ],
+      ),
     );
   }
 
@@ -1204,12 +1108,6 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     String? selectedTextThreadKey,
   ) {
     final GalHookSessionState state = _session.state;
-    // BUG-1007 根因修复：健康卡 Anki 行此前写死「未配置」，不反映真实配置。
-    // 接 app 级 AnkiViewModel 的已配置判定（牌组 + 笔记类型均已选中）。
-    final bool ankiConfigured = ref.watch(
-      ankiViewModelProvider
-          .select((AnkiUiState uiState) => uiState.isConfigured),
-    );
     return Column(
       children: <Widget>[
         _buildExperimentalBanner(context),
@@ -1225,13 +1123,13 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                   textThreads,
                   selectedTextThreadKey,
                 );
-                final Widget latest = _LatestLineCard(
+                // 右栏改成逐句音轨面板（原「最新台词」只读卡 + 「健康状态」静态卡
+                // 让位）：正文与音频元信息并进本面板，健康状态移到工具栏「更多」→
+                // 对话框（同页签栏的「兼容性诊断」也有完整版），把这块常驻空间还给
+                // 「听 → 判断 → 排除 BGM」这条真正需要反复操作的动线。
+                final Widget lineTracks = _LineTracksCard(
+                  session: _session,
                   line: _selectedOrLatestLine(lines),
-                );
-                final Widget health = _CaptureHealthCard(
-                  state: state,
-                  endpoints: _session.endpointStatuses,
-                  ankiConfigured: ankiConfigured,
                 );
                 if (box.maxWidth >= 1280) {
                   return Column(
@@ -1242,11 +1140,9 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                         child: Row(
                           crossAxisAlignment: CrossAxisAlignment.stretch,
                           children: <Widget>[
-                            Expanded(flex: 5, child: live),
+                            Expanded(flex: 7, child: live),
                             const SizedBox(width: 12),
-                            Expanded(flex: 3, child: latest),
-                            const SizedBox(width: 12),
-                            Expanded(flex: 3, child: health),
+                            Expanded(flex: 4, child: lineTracks),
                           ],
                         ),
                       ),
@@ -1264,24 +1160,15 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                           children: <Widget>[
                             Expanded(flex: 2, child: live),
                             const SizedBox(width: 12),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.stretch,
-                                children: <Widget>[
-                                  Expanded(child: latest),
-                                  const SizedBox(height: 12),
-                                  Expanded(child: health),
-                                ],
-                              ),
-                            ),
+                            Expanded(child: lineTracks),
                           ],
                         ),
                       ),
                     ],
                   );
                 }
-                // 窄屏不再整块丢弃 latest/health 两面板（巡检 G7），折叠成
-                // 可展开区放在实时行下方，默认收起不抢纵向空间。
+                // 窄屏不整块丢弃逐句音轨面板（巡检 G7），折叠成可展开区放在实时行
+                // 下方，默认收起不抢纵向空间。
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: <Widget>[
@@ -1289,24 +1176,14 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                     const SizedBox(height: 12),
                     Expanded(child: live),
                     ExpansionTile(
-                      title: Text(t.game_latest_line),
+                      title: Text(t.game_line_tracks),
                       tilePadding: EdgeInsets.zero,
                       children: <Widget>[
-                        // 上限高度：卡片内自带 SingleChildScrollView，超长台词
+                        // 上限高度：卡片内自带 SingleChildScrollView，超长台词/多轨
                         // 在卡内滚动而不是把实时行区挤到 0。
                         ConstrainedBox(
-                          constraints: const BoxConstraints(maxHeight: 280),
-                          child: latest,
-                        ),
-                      ],
-                    ),
-                    ExpansionTile(
-                      title: Text(t.game_health),
-                      tilePadding: EdgeInsets.zero,
-                      children: <Widget>[
-                        ConstrainedBox(
-                          constraints: const BoxConstraints(maxHeight: 280),
-                          child: health,
+                          constraints: const BoxConstraints(maxHeight: 320),
+                          child: lineTracks,
                         ),
                       ],
                     ),
@@ -1496,6 +1373,8 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                       _session.selectTextThread(
                         selectedThread?.nativeThreadId,
                         threadKey: selectedThread?.key,
+                        // 用户亲自选的线程记进本游戏记忆，下次开同一个游戏自动选回。
+                        remember: true,
                       ),
                     );
                   },
@@ -1845,74 +1724,217 @@ class _SessionOverviewCard extends StatelessWidget {
   }
 }
 
-class _LatestLineCard extends StatelessWidget {
-  const _LatestLineCard({required this.line});
+/// 逐句音轨面板：右栏的常驻主面板（取代原「最新台词」只读卡）。
+///
+/// 「哪条轨是 BGM」是**逐句**才能判断的事——会话级音轨快照用最近一条台词的时间戳，
+/// 用户看着它排除 BGM 等于盲操作。本面板按**当前选中行自己的时间戳**取快照
+/// （[GalHookSessionController.tracksForLine]），于是每条轨的片段数/能量都是这一句
+/// 说话瞬间的真实情况：试听→确认是 BGM→当场排除，排除立刻对后续所有句生效并
+/// 记进本游戏记忆。同时保留原「最新台词」的核心信息（正文 + 音频来源/时长），
+/// 不丢可读性。
+class _LineTracksCard extends StatefulWidget {
+  const _LineTracksCard({required this.session, required this.line});
 
+  final GalHookSessionController session;
   final TexthookerLineEntry? line;
 
   @override
+  State<_LineTracksCard> createState() => _LineTracksCardState();
+}
+
+class _LineTracksCardState extends State<_LineTracksCard> {
+  List<GalAudioTrack> _tracks = const <GalAudioTrack>[];
+
+  /// 已取过快照的行 id：同一行不重复拉，换行才重取。
+  String? _tracksLineId;
+  bool _loading = false;
+  int? _previewingSourcePtr;
+  Timer? _previewResetTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _syncTracks();
+  }
+
+  @override
+  void didUpdateWidget(_LineTracksCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _syncTracks();
+  }
+
+  @override
+  void dispose() {
+    _previewResetTimer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _syncTracks({bool force = false}) async {
+    final TexthookerLineEntry? line = widget.line;
+    if (line == null) {
+      if (_tracks.isNotEmpty || _tracksLineId != null) {
+        setState(() {
+          _tracks = const <GalAudioTrack>[];
+          _tracksLineId = null;
+        });
+      }
+      return;
+    }
+    if (!force && _tracksLineId == line.id) return;
+    if (_loading) return;
+    _loading = true;
+    final List<GalAudioTrack> tracks =
+        await widget.session.tracksForLine(line.id);
+    _loading = false;
+    if (!mounted) return;
+    setState(() {
+      _tracks = tracks;
+      _tracksLineId = line.id;
+    });
+  }
+
+  Future<void> _preview(String lineId, GalAudioTrack track) async {
+    if (_previewingSourcePtr == track.sourcePtr) {
+      _previewResetTimer?.cancel();
+      setState(() => _previewingSourcePtr = null);
+      await DesktopAudioPlayback.stop();
+      return;
+    }
+    final GalTrackPreview? preview =
+        await widget.session.exportLineTrackPreview(lineId, track.sourcePtr);
+    if (!mounted) return;
+    if (preview == null) {
+      HibikiToast.show(msg: t.game_track_preview_failed);
+      return;
+    }
+    final bool started = await DesktopAudioPlayback.playFile(preview.filePath);
+    if (!mounted) return;
+    if (!started) {
+      HibikiToast.show(msg: t.game_track_preview_failed);
+      return;
+    }
+    _previewResetTimer?.cancel();
+    setState(() => _previewingSourcePtr = track.sourcePtr);
+    _previewResetTimer = Timer(
+      Duration(milliseconds: preview.durationMs + 300),
+      () {
+        if (mounted) setState(() => _previewingSourcePtr = null);
+      },
+    );
+  }
+
+  Future<void> _useForLine(String lineId, int sourcePtr) async {
+    final bool applied = await widget.session.setLineVoiceTrack(
+      lineId,
+      sourcePtr,
+    );
+    if (!mounted) return;
+    HibikiToast.show(
+      msg: applied ? t.game_line_track_applied : t.game_line_track_failed,
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final TexthookerLineEntry? value = line;
+    final TexthookerLineEntry? line = widget.line;
+    final GalHookSessionState state = widget.session.state;
+    final int? lineVoicePtr =
+        line == null ? null : widget.session.lineVoiceSourcePtr(line.id);
     return HibikiCard(
-      child: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            Row(
-              children: <Widget>[
-                const Icon(Icons.subtitles_outlined, size: 20),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    t.game_latest_line,
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              const Icon(Icons.graphic_eq, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  t.game_line_tracks,
+                  style: Theme.of(context).textTheme.titleMedium,
                 ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            if (value == null)
-              Text(t.game_no_active_line)
-            else ...<Widget>[
-              Text(
-                value.text,
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      height: 1.6,
-                    ),
               ),
-              const SizedBox(height: 14),
-              _MetadataRow(
-                label: t.game_health_text,
-                value: value.sourceLabel ??
-                    texthookerLineSourceLabel(
-                      value.source,
-                    ),
+              HibikiIconButton(
+                icon: Icons.refresh,
+                tooltip: t.game_refresh_tracks,
+                size: 18,
+                focusId: const HibikiFocusId('game-line-tracks-refresh'),
+                onTap: () => unawaited(_syncTracks(force: true)),
               ),
-              _MetadataRow(
-                label: t.game_health_audio,
-                value: value.audioBackend ??
-                    texthookerLineAudioStatusLabel(value.audioStatus),
-              ),
-              if (value.audioResourceId != null)
-                _MetadataRow(
-                  label: t.game_audio_resource_id,
-                  value: value.audioResourceId!,
-                ),
-              if (value.audioDurationMs != null)
-                // 值是时长不是格式，标签用 game_audio_duration（巡检 G7）。
-                _MetadataRow(
-                  label: t.game_audio_duration,
-                  value:
-                      '${(value.audioDurationMs! / 1000).toStringAsFixed(2)}s',
-                ),
-              if (value.fallbackReason != null)
-                _MetadataRow(
-                  label: t.game_line_audio_fallback,
-                  value: value.fallbackReason!,
-                ),
             ],
-          ],
-        ),
+          ),
+          const SizedBox(height: 12),
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  if (line == null)
+                    Text(t.game_no_active_line)
+                  else ...<Widget>[
+                    // 正文 + 音频元信息：原「最新台词」卡的核心内容，不因换面板丢失。
+                    Text(
+                      line.text,
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                            height: 1.5,
+                          ),
+                    ),
+                    const SizedBox(height: 10),
+                    _MetadataRow(
+                      label: t.game_health_audio,
+                      value: line.audioBackend ??
+                          texthookerLineAudioStatusLabel(line.audioStatus),
+                    ),
+                    if (line.audioDurationMs != null)
+                      _MetadataRow(
+                        label: t.game_audio_duration,
+                        value:
+                            '${(line.audioDurationMs! / 1000).toStringAsFixed(2)}s',
+                      ),
+                    if (line.fallbackReason != null)
+                      _MetadataRow(
+                        label: t.game_line_audio_fallback,
+                        value: line.fallbackReason!,
+                      ),
+                    const Divider(height: 24),
+                    Text(
+                      t.game_line_tracks_hint,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color:
+                                Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                    ),
+                    const SizedBox(height: 4),
+                    if (_tracks.isEmpty)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        child: Text(t.game_no_tracks),
+                      )
+                    else
+                      for (final GalAudioTrack track in _tracks)
+                        GalTrackTile(
+                          track: track,
+                          // 这里的「选中」是**本句**用哪条轨，不是会话级默认选源。
+                          selected: lineVoicePtr == track.sourcePtr,
+                          excluded: state.excludedAudioSourcePtrs
+                              .contains(track.sourcePtr),
+                          previewing: _previewingSourcePtr == track.sourcePtr,
+                          // 逐行选轨与逐行排除都绕开「当前后端是否消费会话级选源」
+                          // 那道自动门（它防的是自动误配），只要有 engine 就能用。
+                          selectable: widget.session.hasEngineSource,
+                          selectTooltip: t.game_line_track_use,
+                          onSelect: () =>
+                              unawaited(_useForLine(line.id, track.sourcePtr)),
+                          onPreview: () => unawaited(_preview(line.id, track)),
+                          onToggleExcluded: (bool excluded) => widget.session
+                              .setTrackExcluded(track.sourcePtr, excluded),
+                        ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/hibiki/lib/src/sync/texthooker_service.dart
+++ b/hibiki/lib/src/sync/texthooker_service.dart
@@ -131,6 +131,12 @@ enum TexthookerLineAudioStatus {
   encoded,
 }
 
+/// [TexthookerLineEntry.fallbackReason] 的两个**语义化**值（其余 reason 是诊断字符串）：
+/// UI 靠它们把「这句本来就没配音」从「疑似漏抓」的红标里分出来、把「超长可疑切片」
+/// 从正常兜底里分出来。生产与消费两侧共用本常量，别在别处重复字面量。
+const String kGalLineNoVoiceReason = 'line_has_no_voice';
+const String kGalOverlongSliceSuspectReason = 'slice_overlong_suspect';
+
 /// 实时台词列表的筛选维度。单一枚举驱动 [lineMatchesFilter] 一个 predicate，
 /// 消除「有音频 / 已制卡 / 已收藏」各写一条 if 分支的特殊情况。与线程下拉筛选正交：
 /// 先按线程取行，再按本枚举过滤。

--- a/hibiki/lib/src/sync/texthooker_service.dart
+++ b/hibiki/lib/src/sync/texthooker_service.dart
@@ -341,7 +341,50 @@ class TexthookerService extends ChangeNotifier {
     }
     final List<TexthookerTextThread> result = byKey.values.toList()
       ..sort(_compareTextThreads);
-    return List<TexthookerTextThread>.unmodifiable(result);
+    return List<TexthookerTextThread>.unmodifiable(
+      disambiguateThreadLabels(result),
+    );
+  }
+
+  /// 同标签线程补可区分后缀。
+  ///
+  /// 标签 = `hookName · 0x<线程地址>`（见 `GalHookedLine.textThreadLabel`），而同一个
+  /// hook 常有多条并行线程只在 ctx/ctx2 上不同——ctx 没透出到 Dart，于是下拉里出现
+  /// 一串**完全相同**的 `CodeX · 0x459f50`，用户只能靠行数猜哪条是自己要的。
+  /// 这里给重名的每条补上 key 里那段线程 id 的短哈希（`· #1a2b`），让它们至少可指认；
+  /// 唯一的标签保持原样，不给不重名的线程加噪音。
+  @visibleForTesting
+  static List<TexthookerTextThread> disambiguateThreadLabels(
+    List<TexthookerTextThread> threads,
+  ) {
+    final Map<String, int> labelCounts = <String, int>{};
+    for (final TexthookerTextThread thread in threads) {
+      labelCounts[thread.label] = (labelCounts[thread.label] ?? 0) + 1;
+    }
+    if (!labelCounts.values.any((int count) => count > 1)) return threads;
+    return <TexthookerTextThread>[
+      for (final TexthookerTextThread thread in threads)
+        if ((labelCounts[thread.label] ?? 0) <= 1)
+          thread
+        else
+          TexthookerTextThread(
+            key: thread.key,
+            label: '${thread.label} · #${_threadKeySuffix(thread.key)}',
+            hookCode: thread.hookCode,
+            nativeThreadId: thread.nativeThreadId,
+            lineCount: thread.lineCount,
+            latestAt: thread.latestAt,
+            latestText: thread.latestText,
+            audioLineCount: thread.audioLineCount,
+          ),
+    ];
+  }
+
+  /// 线程 key（`<来源>:<线程 id 十六进制>`）里取末 4 位十六进制作可指认后缀。
+  static String _threadKeySuffix(String key) {
+    final int colon = key.lastIndexOf(':');
+    final String tail = colon >= 0 ? key.substring(colon + 1) : key;
+    return tail.length <= 4 ? tail : tail.substring(tail.length - 4);
   }
 
   /// 线程列表排序：**有台词的线程恒排在 0 行线程之前**，其次句音行数多者优先，

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+946
+version: 1.2.0+947
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/mining/gal_audio_degrade_track_test.dart
+++ b/hibiki/test/mining/gal_audio_degrade_track_test.dart
@@ -270,28 +270,32 @@ void main() {
     );
     expect(galTrackSelectionAffectsCapture(GalHookAudioBackend.none), isFalse);
 
-    final String page = File(
-      'lib/src/pages/implementations/game_diagnostics_page.dart',
+    // 轨列表内容体已抽到共享面板（诊断页与捕获工作台音轨对话框同一份），
+    // BUG-1102 的判据守卫跟着真相走：扫共享面板文件，另确认诊断页在消费它。
+    final String panel = File(
+      'lib/src/mining/gal_audio_tracks_panel.dart',
     ).readAsStringSync();
-    final int cardAt = page.indexOf('class _AudioTracksCard');
-    expect(cardAt, greaterThan(0));
-    final String card = page.substring(cardAt);
     expect(
-      card.contains('galTrackSelectionAffectsCapture(state.audioBackend)'),
+      panel.contains('galTrackSelectionAffectsCapture(state.audioBackend)'),
       isTrue,
       reason: '解释/禁用判据必须是后端，不能再是 audioTracks.isEmpty',
     );
     expect(
-      card.contains('state.audioTracks.isEmpty && emptyHint'),
+      panel.contains('state.audioTracks.isEmpty && emptyHint'),
       isFalse,
       reason: '列表非空时解释态被跳过，正是 BUG-1102 里整套死控件照常渲染的原因',
     );
-    expect(card.contains('selectable: selectionEffective'), isTrue);
-    expect(card.contains('enabled: selectable && !excluded'), isTrue,
+    expect(panel.contains('selectable: selectionEffective'), isTrue);
+    expect(panel.contains('enabled: selectable && !excluded'), isTrue,
         reason: '非引擎 PCM 后端必须禁用「选为语音轨」');
-    expect(card.contains('t.game_track_no_clips'), isTrue,
+    expect(panel.contains('t.game_track_no_clips'), isTrue,
         reason: 'clipCount == 0 的轨必须标注，而不是和可用轨长一个样');
-    expect(card.contains('t.game_tracks_pcm_only_hint'), isTrue);
+    expect(panel.contains('t.game_tracks_pcm_only_hint'), isTrue);
+    final String page = File(
+      'lib/src/pages/implementations/game_diagnostics_page.dart',
+    ).readAsStringSync();
+    expect(page.contains('GalAudioTracksPanel('), isTrue,
+        reason: '诊断页必须消费共享面板，不得另写一份轨列表');
 
     final String workbench = File(
       'lib/src/pages/implementations/texthooker_page.dart',
@@ -582,7 +586,12 @@ class _FakeEngine extends EngineHookGalAudioSource {
   }
 
   @override
-  Future<GalAudioSlice?> grabClipNear(int tsMs, {int tolMs = 8000}) async =>
+  Future<GalAudioSlice?> grabClipNear(
+    int tsMs, {
+    int tolMs = 8000,
+    int? sourcePtr,
+    List<int>? exclude,
+  }) async =>
       null;
 
   @override

--- a/hibiki/test/mining/gal_capture_audio_integrity_test.dart
+++ b/hibiki/test/mining/gal_capture_audio_integrity_test.dart
@@ -1,0 +1,399 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/mining/galgame_audio_encode.dart';
+import 'package:hibiki/src/mining/galgame_audio_source.dart';
+import 'package:hibiki/src/sync/texthooker_service.dart';
+import 'package:hibiki/src/sync/texthooker_ws_client.dart';
+
+/// BUG-1118 防混入 BGM 的完整性链：
+/// - `grabClipNear` 兜底与 `grabUtterance` 同一份选轨/排除契约（不再绕过排除集）；
+/// - 无配音句与疑似漏抓按「该句时刻候选轨是否有能量」分类，不再一律红标；
+/// - 超长切片门把几十秒混音标成可疑，不顶正常标签入卡；
+/// - 跨会话 BGM 排除记忆按弱指纹恢复，用户恢复某轨后记忆同步删除。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const PcmFormat kPcm = PcmFormat(
+    sampleRate: 48000,
+    channels: 2,
+    bitsPerSample: 16,
+    isFloat: false,
+  );
+
+  GalAudioTrack track({
+    required int sourcePtr,
+    required int orderIndex,
+    double avgEnergy = 100,
+    int clipCount = 3,
+  }) =>
+      GalAudioTrack(
+        sourcePtr: sourcePtr,
+        format: kPcm,
+        avgBytes: 4096,
+        avgEnergy: avgEnergy,
+        orderIndex: orderIndex,
+        clipCount: clipCount,
+      );
+
+  Future<void> waitUntil(bool Function() done, {int ticks = 400}) async {
+    for (int i = 0; i < ticks && !done(); i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+  }
+
+  group('grabClipNear 选轨/排除契约（BUG-1118 ①）', () {
+    const String channelName = 'app.hibiki.reader/voice_hook';
+
+    void setHandler(Future<Object?>? Function(MethodCall)? handler) {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(const MethodChannel(channelName), handler);
+    }
+
+    tearDown(() => setHandler(null));
+
+    test('缺省沿用 selectedAudioSourcePtr / excludedAudioSourcePtrs', () async {
+      final List<MethodCall> calls = <MethodCall>[];
+      setHandler((MethodCall call) async {
+        calls.add(call);
+        return <String, Object?>{
+          'pcm': Uint8List.fromList(List<int>.filled(96, 1)),
+          'sampleRate': 48000,
+          'channels': 2,
+          'bitsPerSample': 16,
+          'isFloat': false,
+        };
+      });
+      final EngineHookGalAudioSource source = EngineHookGalAudioSource(
+        targetPid: 1,
+        injectorPath: 'fake.exe',
+      );
+      source.selectedAudioSourcePtr = 0x11;
+      source.excludedAudioSourcePtrs.add(0x22);
+      final GalAudioSlice? slice = await source.grabClipNear(1000);
+      expect(slice, isNotNull);
+      expect(calls, hasLength(1));
+      final Map<Object?, Object?> args =
+          calls.single.arguments as Map<Object?, Object?>;
+      expect(args['sourcePtr'], 0x11, reason: '兜底必须与 grabUtterance 用同一条选轨');
+      expect(args['exclude'], <int>[0x22],
+          reason: '兜底必须携带排除集，否则排除的 BGM 从这里绕回制卡');
+    });
+
+    test('显式 sourcePtr/exclude 覆盖缺省（逐行选轨语义）', () async {
+      final List<MethodCall> calls = <MethodCall>[];
+      setHandler((MethodCall call) async {
+        calls.add(call);
+        return <String, Object?>{'error': 'none'};
+      });
+      final EngineHookGalAudioSource source = EngineHookGalAudioSource(
+        targetPid: 1,
+        injectorPath: 'fake.exe',
+      );
+      source.selectedAudioSourcePtr = 0x11;
+      source.excludedAudioSourcePtrs.add(0x22);
+      await source.grabClipNear(1000, sourcePtr: 0x33, exclude: const <int>[]);
+      final Map<Object?, Object?> args =
+          calls.single.arguments as Map<Object?, Object?>;
+      expect(args['sourcePtr'], 0x33);
+      expect(args['exclude'], isEmpty);
+    });
+  });
+
+  group('超长切片门', () {
+    test('自动兜底超长 -> 换成可疑标注；正常时长 -> 原样', () {
+      expect(
+        GalHookSessionController.sliceFallbackReasonFor(
+          durationMs: kGalOverlongSliceSuspectMs + 1,
+          fallbackReason: 'engine_utterance_unavailable',
+        ),
+        kGalOverlongSliceSuspectReason,
+      );
+      expect(
+        GalHookSessionController.sliceFallbackReasonFor(
+          durationMs: 4000,
+          fallbackReason: 'engine_utterance_unavailable',
+        ),
+        'engine_utterance_unavailable',
+      );
+    });
+
+    test('用户裁决（补录/选轨）不被二次质疑', () {
+      expect(
+        GalHookSessionController.sliceFallbackReasonFor(
+          durationMs: kGalOverlongSliceSuspectMs * 2,
+          fallbackReason: 'manual_recapture',
+        ),
+        'manual_recapture',
+      );
+      expect(
+        GalHookSessionController.sliceFallbackReasonFor(
+          durationMs: kGalOverlongSliceSuspectMs * 2,
+          fallbackReason: 'manual_track_override',
+        ),
+        'manual_track_override',
+      );
+    });
+  });
+
+  test('trackFingerprint 只依赖 orderIndex + 格式（跨会话可锚字段）', () {
+    expect(
+      GalHookSessionController.trackFingerprint(
+        track(sourcePtr: 0xAA, orderIndex: 2),
+      ),
+      '2:48000:2:16:0',
+    );
+    // 同一条轨换了 source_ptr（跨启动的常态）指纹不变。
+    expect(
+      GalHookSessionController.trackFingerprint(
+        track(sourcePtr: 0xBB, orderIndex: 2),
+      ),
+      GalHookSessionController.trackFingerprint(
+        track(sourcePtr: 0xAA, orderIndex: 2),
+      ),
+    );
+  });
+
+  group('会话级行为（launch 会话 + 引擎 PCM）', () {
+    GalHookSessionController build({
+      required TexthookerService service,
+      required Listenable endpoints,
+      required _FakeEngine engine,
+    }) =>
+        GalHookSessionController(
+          textService: service,
+          isWindows: true,
+          targetWow64Probe: (_) async => false,
+          injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+          engineSourceFactory: ({
+            required int targetPid,
+            required String? launchExe,
+            required String injectorPath,
+            required bool lunaPcHooks,
+            int? lunaCodepage,
+            List<String> launchArguments = const <String>[],
+            String launchWorkdir = '',
+          }) =>
+              engine,
+          loopbackSourceFactory: () => _NullLoopback(),
+          textPollInterval: const Duration(milliseconds: 5),
+          trackRefreshInterval: const Duration(milliseconds: 20),
+          endpointListenable: endpoints,
+          endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+        );
+
+    test('跨会话排除记忆：按指纹恢复排除；用户恢复后记忆同步删除', () async {
+      final TexthookerService service = TexthookerService.test();
+      final ChangeNotifier endpoints = ChangeNotifier();
+      final _FakeEngine engine = _FakeEngine(readyFormat: kPcm)
+        ..tracks = <GalAudioTrack>[
+          track(sourcePtr: 0x100, orderIndex: 0),
+          track(sourcePtr: 0x200, orderIndex: 1),
+        ];
+      final GalHookSessionController controller = build(
+        service: service,
+        endpoints: endpoints,
+        engine: engine,
+      );
+      final Map<String, List<String>> store = <String, List<String>>{
+        r'd:\games\fake.exe': <String>[
+          GalHookSessionController.trackFingerprint(
+            track(sourcePtr: 0x999, orderIndex: 1),
+          ),
+        ],
+      };
+      controller.attachTrackExclusionMemory(
+        load: (String gameKey) => store[gameKey] ?? const <String>[],
+        save: (String gameKey, List<String> fingerprints) =>
+            store[gameKey] = fingerprints,
+      );
+
+      await controller.launchGame(r'D:\Games\fake.exe');
+      await waitUntil(
+        () => controller.state.excludedAudioSourcePtrs.isNotEmpty,
+      );
+      expect(
+        controller.state.excludedAudioSourcePtrs,
+        <int>{0x200},
+        reason: '上次会话排除的轨按指纹（orderIndex+格式）套回新 source_ptr',
+      );
+
+      // 用户说这条轨不是 BGM：恢复后记忆必须删掉，下次会话不得再自动排除。
+      controller.setTrackExcluded(0x200, false);
+      expect(controller.state.excludedAudioSourcePtrs, isEmpty);
+      expect(store[r'd:\games\fake.exe'], isEmpty);
+
+      // 重新排除另一条轨：指纹写回。
+      controller.setTrackExcluded(0x100, true);
+      expect(
+        store[r'd:\games\fake.exe'],
+        <String>[
+          GalHookSessionController.trackFingerprint(
+            track(sourcePtr: 0x100, orderIndex: 0),
+          ),
+        ],
+      );
+
+      await controller.close();
+      endpoints.dispose();
+    });
+
+    test('无配音 vs 疑似漏抓：按该句时刻候选轨能量分类', () async {
+      final TexthookerService service = TexthookerService.test();
+      final ChangeNotifier endpoints = ChangeNotifier();
+      final _FakeEngine engine = _FakeEngine(readyFormat: kPcm);
+      final GalHookSessionController controller = build(
+        service: service,
+        endpoints: endpoints,
+        engine: engine,
+      );
+      await controller.launchGame(r'D:\Games\fake.exe');
+
+      // (a) 候选轨在该句时刻有能量但整句抓取失败 -> 疑似漏抓，保留告警红标。
+      engine.tracks = <GalAudioTrack>[
+        track(sourcePtr: 0x100, orderIndex: 0, avgEnergy: 88),
+      ];
+      engine.enqueue(const GalHookedLine(
+        seq: 1,
+        timestampMs: 1000,
+        text: '一句目',
+        threadId: 5,
+        hookName: 'fake',
+      ));
+      await waitUntil(() => service.entries.isNotEmpty);
+      await waitUntil(
+        () => service.entries.first.fallbackReason == 'utterance_not_found',
+      );
+      expect(
+          service.entries.first.audioStatus, TexthookerLineAudioStatus.missing);
+      expect(service.entries.first.fallbackReason, 'utterance_not_found');
+
+      // (b) 声音只在被排除的 BGM 轨上 -> 判无配音（灰标不吓人）。
+      controller.setTrackExcluded(0x100, true);
+      engine.enqueue(const GalHookedLine(
+        seq: 2,
+        timestampMs: 2000,
+        text: '二句目',
+        threadId: 5,
+        hookName: 'fake',
+      ));
+      await waitUntil(() => service.entries.length >= 2);
+      await waitUntil(
+        () => service.entries.last.fallbackReason == kGalLineNoVoiceReason,
+      );
+      expect(
+          service.entries.last.audioStatus, TexthookerLineAudioStatus.missing);
+      expect(service.entries.last.fallbackReason, kGalLineNoVoiceReason);
+
+      await controller.close();
+      endpoints.dispose();
+    });
+  });
+}
+
+/// 引擎 helper 替身：文本可排队、PCM 立即就绪、音轨快照可配置、整句抓取恒失败
+/// （逼出 miss 分类与兜底链）。
+class _FakeEngine extends EngineHookGalAudioSource {
+  _FakeEngine({
+    this.readyFormat,
+  }) : super(targetPid: 0, launchExe: 'fake.exe', injectorPath: 'fake.exe');
+
+  final PcmFormat? readyFormat;
+  List<GalAudioTrack> tracks = <GalAudioTrack>[];
+  final List<GalHookedLine> _pending = <GalHookedLine>[];
+
+  void enqueue(GalHookedLine line) => _pending.add(line);
+
+  @override
+  int? get gamePid => 4242;
+
+  @override
+  bool get textHookReady => true;
+
+  @override
+  bool get rawVoiceReady => false;
+
+  @override
+  PcmFormat? get readyPcmFormat => readyFormat;
+
+  @override
+  bool get pcmReady => readyFormat != null;
+
+  @override
+  Future<PcmFormat?> start() async => readyFormat;
+
+  @override
+  Future<bool> refreshReadiness() async => false;
+
+  @override
+  Future<GalTextPoll?> pollText(int fromSeq) async {
+    final List<GalHookedLine> fresh = _pending
+        .where((GalHookedLine line) => line.seq > fromSeq)
+        .toList(growable: false);
+    return GalTextPoll(count: _pending.length, lines: fresh);
+  }
+
+  @override
+  Future<bool> selectTextThread(int? threadId) async => true;
+
+  @override
+  Future<GalAudioSlice?> grabUtterance(
+    int tsMs, {
+    int? sourcePtr,
+    List<int>? exclude,
+  }) async =>
+      null;
+
+  @override
+  Future<GalAudioSlice?> grabClipNear(
+    int tsMs, {
+    int tolMs = 8000,
+    int? sourcePtr,
+    List<int>? exclude,
+  }) async =>
+      null;
+
+  @override
+  Future<List<GalAudioTrack>> listAudioTracks(int tsMs) async => tracks;
+
+  @override
+  String? findPairedVoiceResourceId(
+    int textTsMs, {
+    int? textEventId,
+    bool allowLatestSessionFallback = true,
+  }) =>
+      null;
+
+  @override
+  Future<Uint8List?> grabPairedVoiceBytes(
+    int textTsMs, {
+    required String outputExtension,
+    int? textEventId,
+    String? resourceId,
+    bool allowLatestSessionFallback = true,
+  }) async =>
+      null;
+
+  @override
+  Future<void> stop() async {}
+}
+
+/// 永不产声的 loopback 替身（本测试只关心引擎 PCM 路径）。
+class _NullLoopback extends LoopbackGalAudioSource {
+  @override
+  Future<PcmFormat?> start() async => kNullPcm;
+
+  static const PcmFormat kNullPcm = PcmFormat(
+    sampleRate: 48000,
+    channels: 2,
+    bitsPerSample: 16,
+    isFloat: false,
+  );
+
+  @override
+  Future<GalAudioSlice?> grabRecent(int backMs) async => null;
+
+  @override
+  Future<void> stop() async {}
+}

--- a/hibiki/test/mining/gal_capture_audio_integrity_test.dart
+++ b/hibiki/test/mining/gal_capture_audio_integrity_test.dart
@@ -196,17 +196,19 @@ void main() {
         endpoints: endpoints,
         engine: engine,
       );
-      final Map<String, List<String>> store = <String, List<String>>{
-        r'd:\games\fake.exe': <String>[
-          GalHookSessionController.trackFingerprint(
-            track(sourcePtr: 0x999, orderIndex: 1),
-          ),
-        ],
+      final Map<String, GalCaptureMemory> store = <String, GalCaptureMemory>{
+        r'd:\games\fake.exe': GalCaptureMemory(
+          excludedTrackFingerprints: <String>[
+            GalHookSessionController.trackFingerprint(
+              track(sourcePtr: 0x999, orderIndex: 1),
+            ),
+          ],
+        ),
       };
-      controller.attachTrackExclusionMemory(
-        load: (String gameKey) => store[gameKey] ?? const <String>[],
-        save: (String gameKey, List<String> fingerprints) =>
-            store[gameKey] = fingerprints,
+      controller.attachCaptureMemory(
+        load: (String gameKey) => store[gameKey] ?? const GalCaptureMemory(),
+        save: (String gameKey, GalCaptureMemory memory) =>
+            store[gameKey] = memory,
       );
 
       await controller.launchGame(r'D:\Games\fake.exe');
@@ -222,18 +224,134 @@ void main() {
       // 用户说这条轨不是 BGM：恢复后记忆必须删掉，下次会话不得再自动排除。
       controller.setTrackExcluded(0x200, false);
       expect(controller.state.excludedAudioSourcePtrs, isEmpty);
-      expect(store[r'd:\games\fake.exe'], isEmpty);
+      expect(
+        store[r'd:\games\fake.exe']!.excludedTrackFingerprints,
+        isEmpty,
+      );
 
       // 重新排除另一条轨：指纹写回。
       controller.setTrackExcluded(0x100, true);
       expect(
-        store[r'd:\games\fake.exe'],
+        store[r'd:\games\fake.exe']!.excludedTrackFingerprints,
         <String>[
           GalHookSessionController.trackFingerprint(
             track(sourcePtr: 0x100, orderIndex: 0),
           ),
         ],
       );
+
+      // 会话语音轨也按同一份记忆持久化（用户明确要求「每个游戏默认持久化音轨」）。
+      controller.selectVoiceTrack(0x100);
+      expect(
+        store[r'd:\games\fake.exe']!.voiceTrackFingerprint,
+        GalHookSessionController.trackFingerprint(
+          track(sourcePtr: 0x100, orderIndex: 0),
+        ),
+      );
+      controller.selectVoiceTrack(0);
+      expect(
+        store[r'd:\games\fake.exe']!.voiceTrackFingerprint,
+        isNull,
+        reason: '改回自动选源要清掉记忆，否则下次仍被钉在旧轨上',
+      );
+
+      await controller.close();
+      endpoints.dispose();
+    });
+
+    test('语音轨记忆按指纹恢复；被排除的轨不得同时当语音轨', () async {
+      final TexthookerService service = TexthookerService.test();
+      final ChangeNotifier endpoints = ChangeNotifier();
+      final _FakeEngine engine = _FakeEngine(readyFormat: kPcm)
+        ..tracks = <GalAudioTrack>[
+          track(sourcePtr: 0x100, orderIndex: 0),
+          track(sourcePtr: 0x200, orderIndex: 1),
+        ];
+      final GalHookSessionController controller = build(
+        service: service,
+        endpoints: endpoints,
+        engine: engine,
+      );
+      final String voiceFp = GalHookSessionController.trackFingerprint(
+        track(sourcePtr: 0x777, orderIndex: 1),
+      );
+      controller.attachCaptureMemory(
+        load: (String gameKey) => GalCaptureMemory(
+          // 同一条轨既在排除集又是记忆里的语音轨：排除必须赢。
+          excludedTrackFingerprints: <String>[voiceFp],
+          voiceTrackFingerprint: voiceFp,
+        ),
+        save: (String gameKey, GalCaptureMemory memory) {},
+      );
+      await controller.launchGame(r'D:\Games\fake.exe');
+      await waitUntil(
+        () => controller.state.excludedAudioSourcePtrs.isNotEmpty,
+      );
+      expect(controller.state.excludedAudioSourcePtrs, <int>{0x200});
+      expect(
+        controller.state.selectedAudioSourcePtr,
+        0,
+        reason: '被排除的轨不能被记忆恢复成语音轨，否则排除等于没排',
+      );
+
+      await controller.close();
+      endpoints.dispose();
+    });
+
+    test('文本线程记忆：指纹匹配且够行数才恢复，用户手选覆盖记忆', () async {
+      final TexthookerService service = TexthookerService.test();
+      final ChangeNotifier endpoints = ChangeNotifier();
+      final _FakeEngine engine = _FakeEngine(readyFormat: kPcm);
+      final GalHookSessionController controller = build(
+        service: service,
+        endpoints: endpoints,
+        engine: engine,
+      );
+      final Map<String, GalCaptureMemory> store = <String, GalCaptureMemory>{
+        r'd:\games\fake.exe': const GalCaptureMemory(
+          textThreadFingerprint: 'code:HB4@459F50',
+        ),
+      };
+      controller.attachCaptureMemory(
+        load: (String gameKey) => store[gameKey] ?? const GalCaptureMemory(),
+        save: (String gameKey, GalCaptureMemory memory) =>
+            store[gameKey] = memory,
+      );
+      await controller.launchGame(r'D:\Games\fake.exe');
+
+      // 前两行不足门限（3 行）：不得恢复，避免开局蹦一行的 UI 线程把选择钉死。
+      for (int i = 1; i <= 2; i++) {
+        engine.enqueue(
+          GalHookedLine(
+            seq: i,
+            timestampMs: 1000 * i,
+            text: 'せりふ$i',
+            threadId: 7,
+            hookName: 'CodeX',
+            hookCode: 'HB4@459F50',
+          ),
+        );
+      }
+      await waitUntil(() => service.entries.length >= 2);
+      expect(controller.selectedTextThreadKey, isNull);
+
+      // 第三行到达 -> 达到门限，按指纹恢复。
+      engine.enqueue(
+        const GalHookedLine(
+          seq: 3,
+          timestampMs: 3000,
+          text: 'せりふ3',
+          threadId: 7,
+          hookName: 'CodeX',
+          hookCode: 'HB4@459F50',
+        ),
+      );
+      await waitUntil(() => controller.selectedTextThreadKey != null);
+      expect(controller.selectedTextThreadKey, isNotNull);
+
+      // 用户改选「全部」：记忆被清掉，不再自动恢复。
+      await controller.selectTextThread(null, remember: true);
+      expect(store[r'd:\games\fake.exe']!.textThreadFingerprint, isNull);
 
       await controller.close();
       endpoints.dispose();

--- a/hibiki/test/mining/gal_hook_line_latency_recapture_test.dart
+++ b/hibiki/test/mining/gal_hook_line_latency_recapture_test.dart
@@ -335,7 +335,12 @@ class _LatencyEngine extends EngineHookGalAudioSource {
   }
 
   @override
-  Future<GalAudioSlice?> grabClipNear(int tsMs, {int tolMs = 8000}) async =>
+  Future<GalAudioSlice?> grabClipNear(
+    int tsMs, {
+    int tolMs = 8000,
+    int? sourcePtr,
+    List<int>? exclude,
+  }) async =>
       null;
 
   @override

--- a/hibiki/test/mining/gal_hook_session_controller_test.dart
+++ b/hibiki/test/mining/gal_hook_session_controller_test.dart
@@ -1663,6 +1663,8 @@ class _FakeEngineSource extends EngineHookGalAudioSource {
   Future<GalAudioSlice?> grabClipNear(
     int tsMs, {
     int tolMs = 8000,
+    int? sourcePtr,
+    List<int>? exclude,
   }) async =>
       null;
 

--- a/hibiki/test/mining/gal_hook_track_autorefresh_test.dart
+++ b/hibiki/test/mining/gal_hook_track_autorefresh_test.dart
@@ -92,7 +92,12 @@ class _TrackFakeEngine extends EngineHookGalAudioSource {
   }
 
   @override
-  Future<GalAudioSlice?> grabClipNear(int tsMs, {int tolMs = 8000}) async =>
+  Future<GalAudioSlice?> grabClipNear(
+    int tsMs, {
+    int tolMs = 8000,
+    int? sourcePtr,
+    List<int>? exclude,
+  }) async =>
       null;
 
   @override

--- a/hibiki/test/mining/gal_utterance_settle_test.dart
+++ b/hibiki/test/mining/gal_utterance_settle_test.dart
@@ -472,7 +472,12 @@ class _GrowingEngine extends EngineHookGalAudioSource {
   }
 
   @override
-  Future<GalAudioSlice?> grabClipNear(int tsMs, {int tolMs = 8000}) async =>
+  Future<GalAudioSlice?> grabClipNear(
+    int tsMs, {
+    int tolMs = 8000,
+    int? sourcePtr,
+    List<int>? exclude,
+  }) async =>
       null;
 
   @override

--- a/hibiki/test/pages/texthooker_narrow_degrade_reason_guard_test.dart
+++ b/hibiki/test/pages/texthooker_narrow_degrade_reason_guard_test.dart
@@ -25,7 +25,7 @@ void main() {
     final int start = source.indexOf('class _SessionOverviewCard');
     expect(start, greaterThanOrEqualTo(0),
         reason: '找不到 _SessionOverviewCard，测试锚点过期');
-    final int end = source.indexOf('class _LatestLineCard', start);
+    final int end = source.indexOf('class _LineTracksCard', start);
     expect(end, greaterThan(start), reason: '找不到类体结束锚点');
     cardSource = source.substring(start, end);
   });

--- a/hibiki/test/pages/texthooker_page_test.dart
+++ b/hibiki/test/pages/texthooker_page_test.dart
@@ -197,15 +197,17 @@ void main() {
 
       expect(tester.takeException(), isNull);
       expect(find.textContaining('Live lines'), findsOneWidget);
+      // 右栏常驻面板已从「最新台词 + 健康状态」两张只读卡换成逐句音轨面板
+      // （排除 BGM 要按本句时刻判断，见 _LineTracksCard）；健康状态移入工具栏
+      // 「更多」菜单的对话框，不再常驻。
+      expect(find.text('Health status'), findsNothing);
       if (size.width >= 840) {
-        expect(find.text('Latest line'), findsOneWidget);
-        expect(find.text('Health status'), findsOneWidget);
+        expect(find.text('Tracks for this line'), findsOneWidget);
         expect(find.byType(ExpansionTile), findsNothing);
       } else {
-        // 窄屏不再丢弃两面板：折叠为可展开区（默认收起，仅标题可见）。
-        expect(find.byType(ExpansionTile), findsNWidgets(2));
-        expect(find.text('Latest line'), findsOneWidget);
-        expect(find.text('Health status'), findsOneWidget);
+        // 窄屏不丢弃面板：折叠为可展开区（默认收起，仅标题可见）。
+        expect(find.byType(ExpansionTile), findsOneWidget);
+        expect(find.text('Tracks for this line'), findsOneWidget);
       }
     });
   }

--- a/hibiki/test/pages/texthooker_page_test.dart
+++ b/hibiki/test/pages/texthooker_page_test.dart
@@ -127,7 +127,7 @@ void main() {
     expect(find.textContaining('TextRender · 0xf94600 · 0'), findsWidgets);
   });
 
-  testWidgets('workbench overflow menu opens the exclude-tracks dialog',
+  testWidgets('inactive workbench keeps audio tracks out of overflow menu',
       (WidgetTester tester) async {
     await tester.pumpWidget(
       _wrapPage(const TexthookerPage()),
@@ -136,20 +136,11 @@ void main() {
 
     await tester.tap(find.byKey(const ValueKey<String>('game-toolbar-more')));
     await tester.pumpAndSettle();
-    expect(find.text('Manage audio tracks'), findsOneWidget,
-        reason: '溢出菜单必须暴露「管理音轨」入口');
-
-    await tester.tap(find.text('Manage audio tracks'));
-    await tester.pumpAndSettle();
-
-    expect(find.byType(AlertDialog), findsOneWidget);
-    expect(find.text('Exclude audio tracks'), findsOneWidget);
-    // 无 native 会话（默认后端 none）：无音轨 + 明示排除只在引擎 PCM 生效。
-    expect(find.text('No audio-track data yet'), findsOneWidget);
-
-    await tester.tap(find.text('CLOSE'));
-    await tester.pumpAndSettle();
-    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.text('Health status'), findsOneWidget);
+    expect(find.text('Manage audio tracks'), findsNothing,
+        reason: 'PR #455 将会话音轨改为仅在活动会话显示的工具栏直达入口');
+    expect(find.byKey(const ValueKey<String>('game-toolbar-tracks')),
+        findsNothing);
   });
 
   testWidgets('embedded mode reuses parent scaffold and exposes back action',

--- a/hibiki/test/sync/texthooker_service_test.dart
+++ b/hibiki/test/sync/texthooker_service_test.dart
@@ -362,4 +362,43 @@ void main() {
       reason: '只折叠同一渲染瞬间、不同 Hook 线程双写的那一份',
     );
   });
+
+  test('同标签文本线程补可区分后缀，唯一标签保持原样', () {
+    // 用户实拍：下拉里 6 条线程全叫 `CodeX · 0x459f50`——同一 hook 的并行线程只在
+    // ctx/ctx2 上不同，而 ctx 没透出到 Dart，标签完全撞车，只能靠行数猜。
+    final DateTime now = DateTime(2026, 7, 27, 12);
+    final List<TexthookerTextThread> threads = <TexthookerTextThread>[
+      TexthookerTextThread(
+        key: 'luna:1a2b3c4d',
+        label: 'CodeX · 0x459f50',
+        lineCount: 160,
+        latestAt: now,
+      ),
+      TexthookerTextThread(
+        key: 'luna:99ff00e1',
+        label: 'CodeX · 0x459f50',
+        lineCount: 2,
+        latestAt: now,
+      ),
+      TexthookerTextThread(
+        key: 'luna:5566',
+        label: 'GetGlyphOutlineA · 0x755ebf10',
+        lineCount: 7,
+        latestAt: now,
+      ),
+    ];
+    final List<TexthookerTextThread> disambiguated =
+        TexthookerService.disambiguateThreadLabels(threads);
+    expect(disambiguated[0].label, 'CodeX · 0x459f50 · #3c4d');
+    expect(disambiguated[1].label, 'CodeX · 0x459f50 · #00e1');
+    expect(
+      disambiguated[2].label,
+      'GetGlyphOutlineA · 0x755ebf10',
+      reason: '不重名的线程不加后缀噪音',
+    );
+    // key / 行数等身份字段不得被改写。
+    expect(disambiguated.map((t) => t.key).toList(),
+        threads.map((t) => t.key).toList());
+    expect(disambiguated[0].lineCount, 160);
+  });
 }

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -1847,14 +1847,34 @@ void FlutterWindow::RegisterVoiceHookChannel() {
         }
         if (method == "grabClipNear") {
           // 按句取语音：找时间戳与 tsMs 最近（差 <= tolMs）的语音 clip PCM。
+          // 选轨/排除参数与 grabUtterance 同契约：本方法是它的兜底，必须同样遵守。
           const uint64_t ts = static_cast<uint64_t>(read_long("tsMs"));
           uint64_t tol = static_cast<uint64_t>(read_long("tolMs"));
           if (tol == 0) {
             tol = 3000;  // 缺省 ±3s
           }
+          const uint64_t target =
+              static_cast<uint64_t>(read_long("sourcePtr"));
+          std::vector<uint64_t> exclude;
+          const auto* cargs =
+              std::get_if<flutter::EncodableMap>(call.arguments());
+          if (cargs != nullptr) {
+            const auto ex_it = cargs->find(flutter::EncodableValue("exclude"));
+            if (ex_it != cargs->end()) {
+              const auto* list =
+                  std::get_if<flutter::EncodableList>(&ex_it->second);
+              if (list != nullptr) {
+                for (const auto& e : *list) {
+                  exclude.push_back(
+                      static_cast<uint64_t>(e.TryGetLongValue().value_or(0)));
+                }
+              }
+            }
+          }
           std::vector<uint8_t> pcm;
           const hibiki::VoiceHookStatus s =
-              hibiki::VoiceHookReader::Instance().GrabClipNear(ts, tol, pcm);
+              hibiki::VoiceHookReader::Instance().GrabClipNear(ts, tol, target,
+                                                               exclude, pcm);
           if (!s.ok || pcm.empty()) {
             result->Success(flutter::EncodableValue(flutter::EncodableMap{
                 {flutter::EncodableValue("error"),

--- a/hibiki/windows/runner/voice_hook_reader.cpp
+++ b/hibiki/windows/runner/voice_hook_reader.cpp
@@ -354,9 +354,9 @@ bool VoiceHookReader::SelectTextThread(uint64_t thread_id) {
   return true;
 }
 
-VoiceHookStatus VoiceHookReader::GrabClipNear(uint64_t ts_ms,
-                                              uint64_t tolerance_ms,
-                                              std::vector<uint8_t>& out) {
+VoiceHookStatus VoiceHookReader::GrabClipNear(
+    uint64_t ts_ms, uint64_t tolerance_ms, uint64_t target_source,
+    const std::vector<uint64_t>& exclude_sources, std::vector<uint8_t>& out) {
   out.clear();
   ReaderState& st = State();
   std::lock_guard<std::mutex> lock(st.mutex);
@@ -382,6 +382,20 @@ VoiceHookStatus VoiceHookReader::GrabClipNear(uint64_t ts_ms,
     const auto* c = reinterpret_cast<const hibiki_voice_hook::VoiceClip*>(
         clip_base + static_cast<size_t>(idx) * sizeof(hibiki_voice_hook::VoiceClip));
     if (c->seq != seq || c->byte_len == 0 || c->byte_len > cap) {
+      continue;
+    }
+    // 选轨/排除契约与 GrabUtterance 一致：指定轨只取该轨，排除轨一律跳过。
+    if (target_source != 0 && c->source_ptr != target_source) {
+      continue;
+    }
+    bool excluded = false;
+    for (const uint64_t ex : exclude_sources) {
+      if (ex == c->source_ptr) {
+        excluded = true;
+        break;
+      }
+    }
+    if (excluded) {
       continue;
     }
     // 已被环形覆盖（写该 clip 之后又写了几乎一整圈）则跳过。

--- a/hibiki/windows/runner/voice_hook_reader.h
+++ b/hibiki/windows/runner/voice_hook_reader.h
@@ -99,7 +99,13 @@ class VoiceHookReader {
   // **按句取语音**：找时间戳与 [ts_ms] 最近（且差 <= [tolerance_ms]）的语音 clip，把它那段 PCM
   // 从音频环形拷进 [out]（clip 已被环形覆盖则跳过）。找不到则 [out] 空、返回 ok=false。
   // 这是「该句的语音」自动选取——替代手动波形选区。
+  //   - [target_source] 非 0：只考虑该源的 clip（用户手动选定的语音轨）。
+  //   - [exclude_sources]：这些源的 clip 一律跳过（用户标记的 BGM）。本方法是
+  //     [GrabUtterance] 的兜底，兜底若不认排除集，用户排除的 BGM 会从这里绕回制卡
+  //     ——两个入口必须遵守同一份选轨/排除契约。
   VoiceHookStatus GrabClipNear(uint64_t ts_ms, uint64_t tolerance_ms,
+                               uint64_t target_source,
+                               const std::vector<uint64_t>& exclude_sources,
                                std::vector<uint8_t>& out);
 
   // **按句取「整句」语音**（[GrabClipNear] 的整句版，替代 ~125ms 碎片）：游戏多条 source voice


### PR DESCRIPTION
> **Stacked on PR #452**（基于 `codex/fix-gal-capture-residuals`）：#452 合入后本 PR 自动只剩一个 commit；若最终取 #449 为基底，本 PR 需 rebase。

## 用户诉求
「怎么优化捕获工作台操作逻辑/体验、怎么保证不混入错误音频（BGM）、没音频时怎么兜底正常」。

## 防混入四层（批1，正确性）
1. **BUG-1118 真漏洞**：制卡链 `grabUtterance(ts) ?? grabClipNear(ts)` 的兜底 `grabClipNear` 不带任何源过滤——用户排除了 BGM 轨后，只要该句语音轨窗口没抓到 PCM，兜底就把 BGM clip 塞进卡片。修复：`GrabClipNear` 增加 `target_source`/`exclude_sources` 并与 `GrabUtterance` 同契约（runner C++ / method channel / Dart 三处同 PR；这是 app 内 runner 的 reader，不涉 helper、无需重发 helper release）。
2. **无配音 vs 疑似漏抓**：抓取失败时用 `listAudioTracks(ts)` 的文本时刻窗能量作证据——候选轨有能量 = 疑似漏抓（红标告警）；声音只在被排除轨或根本没有 = 无配音（灰标不吓人）。
3. **超长切片门**：>20s 的自动兜底切片（典型是制卡时才收束的 loopback 回取，上限 60s 环容量）标 `slice_overlong_suspect` 亮黄入卡；用户裁决（补录/选轨）不二次质疑。
4. **跨会话 BGM 排除记忆**：按弱指纹（`orderIndex`+格式）持久化到偏好表（每游戏一 key，launch 路径才有身份；attach 无身份不猜）。只用于**恢复排除**（错了可一键恢复且恢复即删记忆），绝不自动选轨。

## 体验收口（批2）
- 会话音轨面板抽共享组件 `GalAudioTracksPanel`（诊断页与工作台同一份），**BGM 排除入口上移到工作台顶栏**——此前只能从某一句的选轨对话框绕进。
- 行内音频徽章带语义：无配音灰标、超长亮黄（带悬停解释）、loopback 悬停提示「可能混 BGM」。
- 行内补录钮：missing/兜底行一键开补录窗（与浮窗「重播并录音」同一控制器出口），录音中变停止收束。

## 刻意不做
「疑似 BGM」自动标签：`refreshAudioTracks` 用最后一句台词的 ts，语音轨在该时刻同样活跃，单快照区分不了 BGM 与常配音语音轨——贴可能出错的标签不如不贴（防混入由上述四层保证）。

## 验证
- `flutter analyze` 全量零 issue；`flutter build windows --debug` 编译通过（C++ 契约两侧）。
- 新测试 `test/mining/gal_capture_audio_integrity_test.dart`（7 用例：兜底契约透传/覆盖、超长门、指纹、记忆恢复+删除、无配音/漏抓分类）。
- 定向回归：`test/mining` 823 绿、texthooker/game 页面 47 绿、`test/lookup` 547 绿、i18n+bug 守卫 22 绿。
- BUG-1102 源码守卫改盯共享面板文件（判据本体随抽取迁移，意图不变）。
- 未真机验证真实游戏路径：本轮为消费端/UI 改动，engine-support 状态未动；真机验收项——排除 BGM 后制卡、无配音句灰标、跨会话记忆恢复。

## 撞号提示
PR#447 占用了另一含义的 BUG-1115，PR#449 占用 1115/1116；本分支基于 #452（已占 1115-1117），本 PR 开在 **BUG-1118**。合并/rebase 时按纪律重核号段。

https://claude.ai/code/session_01GHDd483vuePK2hmXXZcT59