### PR TITLE
fix(mining): gal 制卡分类标签改标 game，消灭 source 静默 video 默认值（BUG-1137）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,10 +27,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1103 条。点号进各自文件。
+> 共 1104 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1137](bugs/BUG-1137-gal-mining-video-tag.md) | ✅ | ✅ | gal 制卡分类标签误标 video：来源枚举缺 game 且默认值静默兜底 |
 | [BUG-1136](bugs/BUG-1136-ios-reader-scroll-lookup.md) | ✅ | ✅ | iPhone 阅读滑动被误判为点词查词 |
 | [BUG-1135](bugs/BUG-1135-gal-clipnear-bypasses-track-exclusion.md) | ✅ | ✅ | gal 制卡兜底 grabClipNear 绕过选轨/排除集——排除的 BGM 轨会从兜底混回卡片 |
 | [BUG-1134](bugs/BUG-1134-gal-line-track-preview-timestamp.md) | ✅ | ✅ | 逐句选轨试听与确认使用了不同台词时间戳 |

--- a/docs/bugs/BUG-1137-gal-mining-video-tag.md
+++ b/docs/bugs/BUG-1137-gal-mining-video-tag.md
@@ -1,0 +1,17 @@
+## BUG-1137 · gal 制卡分类标签误标 video：来源枚举缺 game 且默认值静默兜底
+- **报告**：2026-07-27（用户：gal 一键制卡的卡片在 Anki 里标签仍是 `hibiki video`，要求统一这块代码，不再每次手动补标签）
+- **真实性**：✅ 真 bug。根因两层：
+  1. `AnkiMiningSource` 枚举只有 `book` / `video`（`packages/hibiki_anki/lib/src/anki_models.dart:413`），游戏来源根本没有对应分类标签；
+  2. `ImmersionMiningRequest.source`（`hibiki/lib/src/mining/immersion_mining_request.dart:74`）与 `buildExternalWindowRequest`（`hibiki/lib/src/mining/external_window_mining.dart:38`）都带 `= AnkiMiningSource.video` 默认值，gal 场景卡协调器 `gal_hook_mining_coordinator.dart:224` 构造请求时没传 `source`，被静默兜底成 video → 卡片打上 `video` 标签。texthooker 页无绑定窗口时的 fallback 纯文本卡走 `dictionary_page_mixin` 默认映射，同理被标成 `book`。
+- **[x] ① 已修复** — 本分支（PR 随附）：
+  - 枚举加 `game`，`BaseAnkiRepository` 加 `gameTag = 'game'` 并入 `_categoryTagForSource` 映射；
+  - **消灭默认值**：`ImmersionMiningRequest.source` 与 `buildExternalWindowRequest` 的 `source` 改必填，所有调用点显式声明来源（漏传=编译错，不再静默 video）；
+  - gal 场景卡协调器显式 `source: AnkiMiningSource.game`，并按「自动添加书名到标签」开关把游戏窗口标题接入 `bookTitleTag`（与 reader 书名 / video 番名同语义，同走 `sanitizeTitleTag`）；
+  - texthooker 页覆写 mixin 新开的 `miningSource` getter 为 `game`（统计口径不动，标签与统计两个维度）；
+  - 互联转发 `_forwardedSourceFromName` 补 `'game'`；17 语言 `anki_tag_include_category_hint` 文案补 game 描述。
+  - 既有误标 `video` 的旧卡不迁移不重写（Never break userspace）。
+- **[x] ② 已加自动化测试** —
+  - `packages/hibiki_anki/test/mining_tag_and_parallel_test.dart`：game 来源 → `['hibiki','game']` 两后端行为测试；
+  - `hibiki/test/pages/mining_default_tags_wiring_static_test.dart`：新增守卫「gal 制卡链路显式声明 game 来源，source 无静默默认值」（③处：request 必填、协调器 game、texthooker 覆写）+ `gameTag` 存在 + i18n 文案含 game；
+  - `hibiki/test/mining/external_window_mining_test.dart`：source 显式透传断言。
+- **备注**：坏数据结构（枚举缺值）+ 隐式默认值（漏传不报错）是根因；修法是补值域并把「来源」变成编译器强制的显式声明，而不是在 gal 调用点打一个 `source: video→game` 补丁完事。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 44761 (2633 per locale)
 ///
-/// Built on 2026-07-27 at 08:00 UTC
+/// Built on 2026-07-27 at 08:08 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -347,7 +347,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get anki_tag_default_section => 'Default tags';
   String get anki_tag_include_category => 'Add source category tag';
   String get anki_tag_include_category_hint =>
-      'Books get "book", videos get "video"';
+      'Books get "book", videos get "video", games get "game"';
   String get anki_tag_include_hibiki => 'Add "hibiki" tag';
   String get anki_tag_include_hibiki_hint => 'Mark every card mined by Hibiki';
   String get anki_tags => 'Tags';
@@ -3811,7 +3811,7 @@ class _StringsAr extends _StringsEn {
   String get anki_tag_include_category => 'إضافة وسم فئة المصدر';
   @override
   String get anki_tag_include_category_hint =>
-      'تحصل الكتب على "book" والفيديوهات على "video"';
+      'تحصل الكتب على "book" والفيديوهات على "video" والألعاب على "game"';
   @override
   String get anki_tag_include_hibiki => 'إضافة وسم "hibiki"';
   @override
@@ -9799,7 +9799,7 @@ class _StringsDe extends _StringsEn {
   String get anki_tag_include_category => 'Tag für Quellkategorie hinzufügen';
   @override
   String get anki_tag_include_category_hint =>
-      'Bücher erhalten „book“, Videos „video“';
+      'Bücher erhalten „book“, Videos „video“, Spiele „game“';
   @override
   String get anki_tag_include_hibiki => 'Tag „hibiki“ hinzufügen';
   @override
@@ -15855,7 +15855,7 @@ class _StringsEs extends _StringsEn {
       'Añadir etiqueta de categoría de origen';
   @override
   String get anki_tag_include_category_hint =>
-      'Los libros llevan «book» y los vídeos «video»';
+      'Los libros llevan «book», los vídeos «video» y los juegos «game»';
   @override
   String get anki_tag_include_hibiki => 'Añadir la etiqueta «hibiki»';
   @override
@@ -21927,7 +21927,7 @@ class _StringsFr extends _StringsEn {
       'Ajouter une étiquette de catégorie source';
   @override
   String get anki_tag_include_category_hint =>
-      'Les livres reçoivent « book », les vidéos « video »';
+      'Les livres reçoivent « book », les vidéos « video », les jeux « game »';
   @override
   String get anki_tag_include_hibiki => 'Ajouter l\'étiquette « hibiki »';
   @override
@@ -28010,7 +28010,7 @@ class _StringsId extends _StringsEn {
   String get anki_tag_include_category => 'Tambahkan tag kategori sumber';
   @override
   String get anki_tag_include_category_hint =>
-      'Buku diberi "book", video diberi "video"';
+      'Buku diberi "book", video diberi "video", gim diberi "game"';
   @override
   String get anki_tag_include_hibiki => 'Tambahkan tag "hibiki"';
   @override
@@ -34022,7 +34022,7 @@ class _StringsIt extends _StringsEn {
       'Aggiungi etichetta categoria di origine';
   @override
   String get anki_tag_include_category_hint =>
-      'I libri ricevono "book", i video "video"';
+      'I libri ricevono "book", i video "video", i giochi "game"';
   @override
   String get anki_tag_include_hibiki => 'Aggiungi etichetta "hibiki"';
   @override
@@ -40072,7 +40072,8 @@ class _StringsJa extends _StringsEn {
   @override
   String get anki_tag_include_category => 'ソース分類タグを追加';
   @override
-  String get anki_tag_include_category_hint => '書籍には「book」、動画には「video」';
+  String get anki_tag_include_category_hint =>
+      '書籍には「book」、動画には「video」、ゲームには「game」';
   @override
   String get anki_tag_include_hibiki => '「hibiki」タグを追加';
   @override
@@ -45945,7 +45946,8 @@ class _StringsKo extends _StringsEn {
   @override
   String get anki_tag_include_category => '소스 분류 태그 추가';
   @override
-  String get anki_tag_include_category_hint => '책은 "book", 비디오는 "video"';
+  String get anki_tag_include_category_hint =>
+      '책은 "book", 비디오는 "video", 게임은 "game"';
   @override
   String get anki_tag_include_hibiki => '"hibiki" 태그 추가';
   @override
@@ -51830,7 +51832,7 @@ class _StringsNl extends _StringsEn {
   String get anki_tag_include_category => 'Tag voor broncategorie toevoegen';
   @override
   String get anki_tag_include_category_hint =>
-      'Boeken krijgen "book", video\'s krijgen "video"';
+      'Boeken krijgen "book", video\'s krijgen "video", games krijgen "game"';
   @override
   String get anki_tag_include_hibiki => 'Tag "hibiki" toevoegen';
   @override
@@ -57869,7 +57871,7 @@ class _StringsPtBr extends _StringsEn {
       'Adicionar tag de categoria de origem';
   @override
   String get anki_tag_include_category_hint =>
-      'Livros recebem "book", vídeos recebem "video"';
+      'Livros recebem "book", vídeos recebem "video", jogos recebem "game"';
   @override
   String get anki_tag_include_hibiki => 'Adicionar tag "hibiki"';
   @override
@@ -63918,7 +63920,7 @@ class _StringsRu extends _StringsEn {
   String get anki_tag_include_category => 'Добавлять тег категории источника';
   @override
   String get anki_tag_include_category_hint =>
-      'Книги получают «book», видео — «video»';
+      'Книги получают «book», видео — «video», игры — «game»';
   @override
   String get anki_tag_include_hibiki => 'Добавлять тег «hibiki»';
   @override
@@ -69952,7 +69954,7 @@ class _StringsTh extends _StringsEn {
   String get anki_tag_include_category => 'เพิ่มแท็กหมวดหมู่แหล่งที่มา';
   @override
   String get anki_tag_include_category_hint =>
-      'หนังสือได้แท็ก "book" วิดีโอได้แท็ก "video"';
+      'หนังสือได้แท็ก "book" วิดีโอได้แท็ก "video" เกมได้แท็ก "game"';
   @override
   String get anki_tag_include_hibiki => 'เพิ่มแท็ก "hibiki"';
   @override
@@ -75937,7 +75939,7 @@ class _StringsTr extends _StringsEn {
   String get anki_tag_include_category => 'Kaynak kategorisi etiketi ekle';
   @override
   String get anki_tag_include_category_hint =>
-      'Kitaplara "book", videolara "video"';
+      'Kitaplara "book", videolara "video", oyunlara "game"';
   @override
   String get anki_tag_include_hibiki => '"hibiki" etiketi ekle';
   @override
@@ -81952,7 +81954,7 @@ class _StringsVi extends _StringsEn {
   String get anki_tag_include_category => 'Thêm thẻ phân loại nguồn';
   @override
   String get anki_tag_include_category_hint =>
-      'Sách gắn "book", video gắn "video"';
+      'Sách gắn "book", video gắn "video", trò chơi gắn "game"';
   @override
   String get anki_tag_include_hibiki => 'Thêm thẻ "hibiki"';
   @override
@@ -87927,7 +87929,7 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get anki_tag_include_category => '添加来源分类标签';
   @override
-  String get anki_tag_include_category_hint => '书籍标「book」、视频标「video」';
+  String get anki_tag_include_category_hint => '书籍标「book」、视频标「video」、游戏标「game」';
   @override
   String get anki_tag_include_hibiki => '添加「hibiki」标签';
   @override
@@ -93527,7 +93529,7 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anki_tag_include_category => '加入來源分類標籤';
   @override
-  String get anki_tag_include_category_hint => '書籍標「book」、影片標「video」';
+  String get anki_tag_include_category_hint => '書籍標「book」、影片標「video」、遊戲標「game」';
   @override
   String get anki_tag_include_hibiki => '加入「hibiki」標籤';
   @override
@@ -99274,7 +99276,7 @@ extension on _StringsEn {
       case 'anki_tag_include_category':
         return 'Add source category tag';
       case 'anki_tag_include_category_hint':
-        return 'Books get "book", videos get "video"';
+        return 'Books get "book", videos get "video", games get "game"';
       case 'anki_tag_include_hibiki':
         return 'Add "hibiki" tag';
       case 'anki_tag_include_hibiki_hint':
@@ -104657,7 +104659,7 @@ extension on _StringsAr {
       case 'anki_tag_include_category':
         return 'إضافة وسم فئة المصدر';
       case 'anki_tag_include_category_hint':
-        return 'تحصل الكتب على "book" والفيديوهات على "video"';
+        return 'تحصل الكتب على "book" والفيديوهات على "video" والألعاب على "game"';
       case 'anki_tag_include_hibiki':
         return 'إضافة وسم "hibiki"';
       case 'anki_tag_include_hibiki_hint':
@@ -110037,7 +110039,7 @@ extension on _StringsDe {
       case 'anki_tag_include_category':
         return 'Tag für Quellkategorie hinzufügen';
       case 'anki_tag_include_category_hint':
-        return 'Bücher erhalten „book“, Videos „video“';
+        return 'Bücher erhalten „book“, Videos „video“, Spiele „game“';
       case 'anki_tag_include_hibiki':
         return 'Tag „hibiki“ hinzufügen';
       case 'anki_tag_include_hibiki_hint':
@@ -115438,7 +115440,7 @@ extension on _StringsEs {
       case 'anki_tag_include_category':
         return 'Añadir etiqueta de categoría de origen';
       case 'anki_tag_include_category_hint':
-        return 'Los libros llevan «book» y los vídeos «video»';
+        return 'Los libros llevan «book», los vídeos «video» y los juegos «game»';
       case 'anki_tag_include_hibiki':
         return 'Añadir la etiqueta «hibiki»';
       case 'anki_tag_include_hibiki_hint':
@@ -120839,7 +120841,7 @@ extension on _StringsFr {
       case 'anki_tag_include_category':
         return 'Ajouter une étiquette de catégorie source';
       case 'anki_tag_include_category_hint':
-        return 'Les livres reçoivent « book », les vidéos « video »';
+        return 'Les livres reçoivent « book », les vidéos « video », les jeux « game »';
       case 'anki_tag_include_hibiki':
         return 'Ajouter l\'étiquette « hibiki »';
       case 'anki_tag_include_hibiki_hint':
@@ -126244,7 +126246,7 @@ extension on _StringsId {
       case 'anki_tag_include_category':
         return 'Tambahkan tag kategori sumber';
       case 'anki_tag_include_category_hint':
-        return 'Buku diberi "book", video diberi "video"';
+        return 'Buku diberi "book", video diberi "video", gim diberi "game"';
       case 'anki_tag_include_hibiki':
         return 'Tambahkan tag "hibiki"';
       case 'anki_tag_include_hibiki_hint':
@@ -131632,7 +131634,7 @@ extension on _StringsIt {
       case 'anki_tag_include_category':
         return 'Aggiungi etichetta categoria di origine';
       case 'anki_tag_include_category_hint':
-        return 'I libri ricevono "book", i video "video"';
+        return 'I libri ricevono "book", i video "video", i giochi "game"';
       case 'anki_tag_include_hibiki':
         return 'Aggiungi etichetta "hibiki"';
       case 'anki_tag_include_hibiki_hint':
@@ -137034,7 +137036,7 @@ extension on _StringsJa {
       case 'anki_tag_include_category':
         return 'ソース分類タグを追加';
       case 'anki_tag_include_category_hint':
-        return '書籍には「book」、動画には「video」';
+        return '書籍には「book」、動画には「video」、ゲームには「game」';
       case 'anki_tag_include_hibiki':
         return '「hibiki」タグを追加';
       case 'anki_tag_include_hibiki_hint':
@@ -142399,7 +142401,7 @@ extension on _StringsKo {
       case 'anki_tag_include_category':
         return '소스 분류 태그 추가';
       case 'anki_tag_include_category_hint':
-        return '책은 "book", 비디오는 "video"';
+        return '책은 "book", 비디오는 "video", 게임은 "game"';
       case 'anki_tag_include_hibiki':
         return '"hibiki" 태그 추가';
       case 'anki_tag_include_hibiki_hint':
@@ -147769,7 +147771,7 @@ extension on _StringsNl {
       case 'anki_tag_include_category':
         return 'Tag voor broncategorie toevoegen';
       case 'anki_tag_include_category_hint':
-        return 'Boeken krijgen "book", video\'s krijgen "video"';
+        return 'Boeken krijgen "book", video\'s krijgen "video", games krijgen "game"';
       case 'anki_tag_include_hibiki':
         return 'Tag "hibiki" toevoegen';
       case 'anki_tag_include_hibiki_hint':
@@ -153165,7 +153167,7 @@ extension on _StringsPtBr {
       case 'anki_tag_include_category':
         return 'Adicionar tag de categoria de origem';
       case 'anki_tag_include_category_hint':
-        return 'Livros recebem "book", vídeos recebem "video"';
+        return 'Livros recebem "book", vídeos recebem "video", jogos recebem "game"';
       case 'anki_tag_include_hibiki':
         return 'Adicionar tag "hibiki"';
       case 'anki_tag_include_hibiki_hint':
@@ -158558,7 +158560,7 @@ extension on _StringsRu {
       case 'anki_tag_include_category':
         return 'Добавлять тег категории источника';
       case 'anki_tag_include_category_hint':
-        return 'Книги получают «book», видео — «video»';
+        return 'Книги получают «book», видео — «video», игры — «game»';
       case 'anki_tag_include_hibiki':
         return 'Добавлять тег «hibiki»';
       case 'anki_tag_include_hibiki_hint':
@@ -163955,7 +163957,7 @@ extension on _StringsTh {
       case 'anki_tag_include_category':
         return 'เพิ่มแท็กหมวดหมู่แหล่งที่มา';
       case 'anki_tag_include_category_hint':
-        return 'หนังสือได้แท็ก "book" วิดีโอได้แท็ก "video"';
+        return 'หนังสือได้แท็ก "book" วิดีโอได้แท็ก "video" เกมได้แท็ก "game"';
       case 'anki_tag_include_hibiki':
         return 'เพิ่มแท็ก "hibiki"';
       case 'anki_tag_include_hibiki_hint':
@@ -169338,7 +169340,7 @@ extension on _StringsTr {
       case 'anki_tag_include_category':
         return 'Kaynak kategorisi etiketi ekle';
       case 'anki_tag_include_category_hint':
-        return 'Kitaplara "book", videolara "video"';
+        return 'Kitaplara "book", videolara "video", oyunlara "game"';
       case 'anki_tag_include_hibiki':
         return '"hibiki" etiketi ekle';
       case 'anki_tag_include_hibiki_hint':
@@ -174729,7 +174731,7 @@ extension on _StringsVi {
       case 'anki_tag_include_category':
         return 'Thêm thẻ phân loại nguồn';
       case 'anki_tag_include_category_hint':
-        return 'Sách gắn "book", video gắn "video"';
+        return 'Sách gắn "book", video gắn "video", trò chơi gắn "game"';
       case 'anki_tag_include_hibiki':
         return 'Thêm thẻ "hibiki"';
       case 'anki_tag_include_hibiki_hint':
@@ -180111,7 +180113,7 @@ extension on _StringsZhCn {
       case 'anki_tag_include_category':
         return '添加来源分类标签';
       case 'anki_tag_include_category_hint':
-        return '书籍标「book」、视频标「video」';
+        return '书籍标「book」、视频标「video」、游戏标「game」';
       case 'anki_tag_include_hibiki':
         return '添加「hibiki」标签';
       case 'anki_tag_include_hibiki_hint':
@@ -185454,7 +185456,7 @@ extension on _StringsZhHk {
       case 'anki_tag_include_category':
         return '加入來源分類標籤';
       case 'anki_tag_include_category_hint':
-        return '書籍標「book」、影片標「video」';
+        return '書籍標「book」、影片標「video」、遊戲標「game」';
       case 'anki_tag_include_hibiki':
         return '加入「hibiki」標籤';
       case 'anki_tag_include_hibiki_hint':

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Anki settings",
   "anki_tag_default_section": "Default tags",
   "anki_tag_include_category": "Add source category tag",
-  "anki_tag_include_category_hint": "Books get \"book\", videos get \"video\"",
+  "anki_tag_include_category_hint": "Books get \"book\", videos get \"video\", games get \"game\"",
   "anki_tag_include_hibiki": "Add \"hibiki\" tag",
   "anki_tag_include_hibiki_hint": "Mark every card mined by Hibiki",
   "anki_tags": "Tags",

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "إعدادات Anki",
   "anki_tag_default_section": "الوسوم الافتراضية",
   "anki_tag_include_category": "إضافة وسم فئة المصدر",
-  "anki_tag_include_category_hint": "تحصل الكتب على \"book\" والفيديوهات على \"video\"",
+  "anki_tag_include_category_hint": "تحصل الكتب على \"book\" والفيديوهات على \"video\" والألعاب على \"game\"",
   "anki_tag_include_hibiki": "إضافة وسم \"hibiki\"",
   "anki_tag_include_hibiki_hint": "وسم كل بطاقة أنشأها Hibiki",
   "anki_tags": "الوسوم",

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Anki-Einstellungen",
   "anki_tag_default_section": "Standard-Tags",
   "anki_tag_include_category": "Tag für Quellkategorie hinzufügen",
-  "anki_tag_include_category_hint": "Bücher erhalten „book“, Videos „video“",
+  "anki_tag_include_category_hint": "Bücher erhalten „book“, Videos „video“, Spiele „game“",
   "anki_tag_include_hibiki": "Tag „hibiki“ hinzufügen",
   "anki_tag_include_hibiki_hint": "Jede von Hibiki erstellte Karte kennzeichnen",
   "anki_tags": "Tags",

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Configuración de Anki",
   "anki_tag_default_section": "Etiquetas predeterminadas",
   "anki_tag_include_category": "Añadir etiqueta de categoría de origen",
-  "anki_tag_include_category_hint": "Los libros llevan «book» y los vídeos «video»",
+  "anki_tag_include_category_hint": "Los libros llevan «book», los vídeos «video» y los juegos «game»",
   "anki_tag_include_hibiki": "Añadir la etiqueta «hibiki»",
   "anki_tag_include_hibiki_hint": "Marca todas las tarjetas creadas por Hibiki",
   "anki_tags": "Etiquetas",

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Paramètres Anki",
   "anki_tag_default_section": "Étiquettes par défaut",
   "anki_tag_include_category": "Ajouter une étiquette de catégorie source",
-  "anki_tag_include_category_hint": "Les livres reçoivent « book », les vidéos « video »",
+  "anki_tag_include_category_hint": "Les livres reçoivent « book », les vidéos « video », les jeux « game »",
   "anki_tag_include_hibiki": "Ajouter l'étiquette « hibiki »",
   "anki_tag_include_hibiki_hint": "Marquer chaque carte créée par Hibiki",
   "anki_tags": "Étiquettes",

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Pengaturan Anki",
   "anki_tag_default_section": "Tag default",
   "anki_tag_include_category": "Tambahkan tag kategori sumber",
-  "anki_tag_include_category_hint": "Buku diberi \"book\", video diberi \"video\"",
+  "anki_tag_include_category_hint": "Buku diberi \"book\", video diberi \"video\", gim diberi \"game\"",
   "anki_tag_include_hibiki": "Tambahkan tag \"hibiki\"",
   "anki_tag_include_hibiki_hint": "Tandai setiap kartu yang dibuat oleh Hibiki",
   "anki_tags": "Tag",

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Impostazioni Anki",
   "anki_tag_default_section": "Etichette predefinite",
   "anki_tag_include_category": "Aggiungi etichetta categoria di origine",
-  "anki_tag_include_category_hint": "I libri ricevono \"book\", i video \"video\"",
+  "anki_tag_include_category_hint": "I libri ricevono \"book\", i video \"video\", i giochi \"game\"",
   "anki_tag_include_hibiki": "Aggiungi etichetta \"hibiki\"",
   "anki_tag_include_hibiki_hint": "Contrassegna ogni carta creata con Hibiki",
   "anki_tags": "Tag",

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Anki 設定",
   "anki_tag_default_section": "デフォルトのタグ",
   "anki_tag_include_category": "ソース分類タグを追加",
-  "anki_tag_include_category_hint": "書籍には「book」、動画には「video」",
+  "anki_tag_include_category_hint": "書籍には「book」、動画には「video」、ゲームには「game」",
   "anki_tag_include_hibiki": "「hibiki」タグを追加",
   "anki_tag_include_hibiki_hint": "Hibiki で作成したすべてのカードに目印を付けます",
   "anki_tags": "タグ",

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Anki 설정",
   "anki_tag_default_section": "기본 태그",
   "anki_tag_include_category": "소스 분류 태그 추가",
-  "anki_tag_include_category_hint": "책은 \"book\", 비디오는 \"video\"",
+  "anki_tag_include_category_hint": "책은 \"book\", 비디오는 \"video\", 게임은 \"game\"",
   "anki_tag_include_hibiki": "\"hibiki\" 태그 추가",
   "anki_tag_include_hibiki_hint": "Hibiki로 만든 모든 카드에 표시합니다",
   "anki_tags": "태그",

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Anki-instellingen",
   "anki_tag_default_section": "Standaardtags",
   "anki_tag_include_category": "Tag voor broncategorie toevoegen",
-  "anki_tag_include_category_hint": "Boeken krijgen \"book\", video's krijgen \"video\"",
+  "anki_tag_include_category_hint": "Boeken krijgen \"book\", video's krijgen \"video\", games krijgen \"game\"",
   "anki_tag_include_hibiki": "Tag \"hibiki\" toevoegen",
   "anki_tag_include_hibiki_hint": "Markeer elke kaart die met Hibiki is gemaakt",
   "anki_tags": "Tags",

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Configurações do Anki",
   "anki_tag_default_section": "Tags padrão",
   "anki_tag_include_category": "Adicionar tag de categoria de origem",
-  "anki_tag_include_category_hint": "Livros recebem \"book\", vídeos recebem \"video\"",
+  "anki_tag_include_category_hint": "Livros recebem \"book\", vídeos recebem \"video\", jogos recebem \"game\"",
   "anki_tag_include_hibiki": "Adicionar tag \"hibiki\"",
   "anki_tag_include_hibiki_hint": "Marca todo cartão criado pelo Hibiki",
   "anki_tags": "Etiquetas",

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Настройки Anki",
   "anki_tag_default_section": "Теги по умолчанию",
   "anki_tag_include_category": "Добавлять тег категории источника",
-  "anki_tag_include_category_hint": "Книги получают «book», видео — «video»",
+  "anki_tag_include_category_hint": "Книги получают «book», видео — «video», игры — «game»",
   "anki_tag_include_hibiki": "Добавлять тег «hibiki»",
   "anki_tag_include_hibiki_hint": "Помечать каждую карточку, созданную в Hibiki",
   "anki_tags": "Теги",

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "ตั้งค่า Anki",
   "anki_tag_default_section": "แท็กเริ่มต้น",
   "anki_tag_include_category": "เพิ่มแท็กหมวดหมู่แหล่งที่มา",
-  "anki_tag_include_category_hint": "หนังสือได้แท็ก \"book\" วิดีโอได้แท็ก \"video\"",
+  "anki_tag_include_category_hint": "หนังสือได้แท็ก \"book\" วิดีโอได้แท็ก \"video\" เกมได้แท็ก \"game\"",
   "anki_tag_include_hibiki": "เพิ่มแท็ก \"hibiki\"",
   "anki_tag_include_hibiki_hint": "ทำเครื่องหมายทุกการ์ดที่สร้างโดย Hibiki",
   "anki_tags": "แท็ก",

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Anki ayarları",
   "anki_tag_default_section": "Varsayılan etiketler",
   "anki_tag_include_category": "Kaynak kategorisi etiketi ekle",
-  "anki_tag_include_category_hint": "Kitaplara \"book\", videolara \"video\"",
+  "anki_tag_include_category_hint": "Kitaplara \"book\", videolara \"video\", oyunlara \"game\"",
   "anki_tag_include_hibiki": "\"hibiki\" etiketi ekle",
   "anki_tag_include_hibiki_hint": "Hibiki ile çıkarılan her kartı işaretle",
   "anki_tags": "Etiketler",

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Cài đặt Anki",
   "anki_tag_default_section": "Thẻ mặc định",
   "anki_tag_include_category": "Thêm thẻ phân loại nguồn",
-  "anki_tag_include_category_hint": "Sách gắn \"book\", video gắn \"video\"",
+  "anki_tag_include_category_hint": "Sách gắn \"book\", video gắn \"video\", trò chơi gắn \"game\"",
   "anki_tag_include_hibiki": "Thêm thẻ \"hibiki\"",
   "anki_tag_include_hibiki_hint": "Đánh dấu mọi thẻ được tạo bởi Hibiki",
   "anki_tags": "Thẻ tag",

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Anki 设置",
   "anki_tag_default_section": "默认标签",
   "anki_tag_include_category": "添加来源分类标签",
-  "anki_tag_include_category_hint": "书籍标「book」、视频标「video」",
+  "anki_tag_include_category_hint": "书籍标「book」、视频标「video」、游戏标「game」",
   "anki_tag_include_hibiki": "添加「hibiki」标签",
   "anki_tag_include_hibiki_hint": "为每张 Hibiki 制出的卡片打上标记",
   "anki_tags": "标签",

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -113,7 +113,7 @@
   "anki_settings_label": "Anki 設定",
   "anki_tag_default_section": "預設標籤",
   "anki_tag_include_category": "加入來源分類標籤",
-  "anki_tag_include_category_hint": "書籍標「book」、影片標「video」",
+  "anki_tag_include_category_hint": "書籍標「book」、影片標「video」、遊戲標「game」",
   "anki_tag_include_hibiki": "加入「hibiki」標籤",
   "anki_tag_include_hibiki_hint": "為每張由 Hibiki 製作的卡片打上標記",
   "anki_tags": "標籤",

--- a/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -593,6 +593,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
       ),
       repo: repo,
       updateNoteId: updateNoteId,
+      addTitleTag: model.autoAddBookNameToTags,
     );
     if (result.aborted) {
       HibikiToast.showMine(

--- a/hibiki/lib/src/mining/external_window_mining.dart
+++ b/hibiki/lib/src/mining/external_window_mining.dart
@@ -35,7 +35,9 @@ ImmersionMiningRequest buildExternalWindowRequest({
   String? audioName,
   String? cueSentence,
   String? documentTitle,
-  AnkiMiningSource source = AnkiMiningSource.video,
+  // BUG-1137：不给默认值（曾默认 video，gal 一键制卡因此被误标成视频标签）。
+  // 来源由调用点显式声明：gal Hook 场景卡传 [AnkiMiningSource.game]。
+  required AnkiMiningSource source,
   String? bookTitleTag,
   int? updateNoteId,
 }) {

--- a/hibiki/lib/src/mining/gal_hook_mining_coordinator.dart
+++ b/hibiki/lib/src/mining/gal_hook_mining_coordinator.dart
@@ -116,6 +116,7 @@ class GalHookMiningCoordinator {
     required MiningMediaCompression compression,
     required BaseAnkiRepository repo,
     int? updateNoteId,
+    bool addTitleTag = false,
   }) {
     // 串行化 + 永不毒化（BUG-956）：单次制卡异常（含错误日志自身抛）不得让后续制卡永久挂起。
     return _miningQueue.enqueue<GalHookMiningResult>(
@@ -125,6 +126,7 @@ class GalHookMiningCoordinator {
         compression: compression,
         repo: repo,
         updateNoteId: updateNoteId,
+        addTitleTag: addTitleTag,
       ),
       buildFailure: (Object error, StackTrace stack) =>
           GalHookMiningResult(failureReason: error.toString()),
@@ -142,6 +144,7 @@ class GalHookMiningCoordinator {
     required MiningMediaCompression compression,
     required BaseAnkiRepository repo,
     required int? updateNoteId,
+    required bool addTitleTag,
   }) async {
     final TexthookerLineEntry? entry = _lineLookup(lineId);
     if (entry == null || !_lineValidator(entry)) {
@@ -231,6 +234,12 @@ class GalHookMiningCoordinator {
               sentenceAudioMissing ? null : 'galgame_audio.$audioExtension',
           documentTitle:
               window.title.isEmpty ? 'External window' : window.title,
+          // BUG-1137：gal 场景卡归「游戏」分类标签（曾吃默认 video 被误标）。
+          source: AnkiMiningSource.game,
+          // 「自动添加书名到标签」开启时把游戏窗口标题作为标题标签（与 reader 书名 /
+          // video 番名同语义，同走 sanitizeTitleTag 清洗去重）。
+          bookTitleTag:
+              addTitleTag && window.title.isNotEmpty ? window.title : null,
           updateNoteId: updateNoteId,
         ),
         compression: compression,

--- a/hibiki/lib/src/mining/immersion_mining_request.dart
+++ b/hibiki/lib/src/mining/immersion_mining_request.dart
@@ -71,7 +71,9 @@ class ImmersionMiningRequest {
     this.documentTitle,
     this.audioStreamIndex,
     this.audioStreamCount,
-    this.source = AnkiMiningSource.video,
+    // BUG-1137：不给默认值。曾默认 video，gal 场景卡忘传 source 就被静默标成
+    // 视频；来源必须由每个调用点显式声明，漏传直接编译不过。
+    required this.source,
     this.bookTitleTag,
     this.collectionTag,
     this.updateNoteId,

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -5788,6 +5788,8 @@ class _AppModelRemoteLookupService
         return AnkiMiningSource.book;
       case 'video':
         return AnkiMiningSource.video;
+      case 'game':
+        return AnkiMiningSource.game;
       default:
         return null;
     }

--- a/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -267,7 +267,11 @@ mixin DictionaryPageMixin {
   /// 把统计来源标识（[kStatSourceBook]/[kStatSourceVideo]）映射成 [AnkiMiningSource]，
   /// 用于给制出的卡片追加分类标签（书籍→`book`，视频→`video`）。未知来源返回
   /// [AnkiMiningSource.book]（保守归书籍，与默认 [dictionarySourceType] 一致）。
-  AnkiMiningSource get _miningSource => dictionarySourceType == kStatSourceVideo
+  ///
+  /// 可覆写（BUG-1137）：统计来源与制卡分类标签是两个维度——texthooker 页统计仍归
+  /// 书籍桶，但制出的卡应打 `game` 分类标签，故覆写本 getter 而非动统计口径。
+  @protected
+  AnkiMiningSource get miningSource => dictionarySourceType == kStatSourceVideo
       ? AnkiMiningSource.video
       : AnkiMiningSource.book;
 
@@ -275,7 +279,7 @@ mixin DictionaryPageMixin {
     final repo = ref.read(ankiRepositoryProvider);
     final miningContext = AnkiMiningContext(
       sentence: fields['sentence'] ?? '',
-      source: _miningSource,
+      source: miningSource,
     );
     // TODO-1325 #6：制卡可能要走网络（AnkiConnect）+ 下音频，先弹「制卡中…」蓝色
     // pending toast 给即时反馈；结果 toast 会顶替它。
@@ -321,7 +325,7 @@ mixin DictionaryPageMixin {
     final repo = ref.read(ankiRepositoryProvider);
     final miningContext = AnkiMiningContext(
       sentence: fields['sentence'] ?? '',
-      source: _miningSource,
+      source: miningSource,
     );
     // TODO-1325 #6：覆写同样先弹 pending。
     HibikiToast.showMine(

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -445,6 +445,13 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   @visibleForTesting
   bool get debugOverlayInert => _overlayInert;
 
+  /// BUG-1137：texthooker 页制出的卡归「游戏」分类标签——外部窗口模式走
+  /// [GalHookMiningCoordinator]（自带 game 来源），fallback 纯文本卡走 mixin 的
+  /// super.onMineEntry / onUpdateEntry，也必须同标 game，不能吃默认 book。
+  /// 统计口径（[dictionarySourceType]）不动，标签与统计是两个维度。
+  @override
+  AnkiMiningSource get miningSource => AnkiMiningSource.game;
+
   @override
   Future<MinePopupResult> onMineEntry(Map<String, String> fields) async {
     final GalHookSessionState sessionState = _session.state;
@@ -511,6 +518,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       ),
       repo: repo,
       updateNoteId: updateNoteId,
+      addTitleTag: mixinAppModel.autoAddBookNameToTags,
     );
     if (result.aborted) {
       HibikiToast.showMine(

--- a/hibiki/lib/src/sync/forwarded_mine_payload.dart
+++ b/hibiki/lib/src/sync/forwarded_mine_payload.dart
@@ -43,7 +43,7 @@ class ForwardedMinePayload {
   final String? documentTitle;
   final int? sentenceOffset;
 
-  /// `AnkiMiningSource.name`（`'book'` / `'video'`）；null = 不追加分类标签。
+  /// `AnkiMiningSource.name`（`'book'` / `'video'` / `'game'`）；null = 不追加分类标签。
   final String? source;
   final String? bookTitleTag;
 

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+949
+version: 1.2.0+950
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/mining/external_window_mining_test.dart
+++ b/hibiki/test/mining/external_window_mining_test.dart
@@ -5,6 +5,8 @@ import 'package:hibiki_anki/hibiki_anki.dart' show AnkiMiningSource;
 import 'package:hibiki/src/mining/external_window_mining.dart';
 
 /// TODO-1162 外部窗口挖矿 M0：`buildExternalWindowRequest` 纯函数契约。
+/// BUG-1137：`source` 已改必填（曾默认 video 把 gal 卡误标成视频标签），
+/// 各用例显式声明来源并断言原样透传。
 void main() {
   group('buildExternalWindowRequest', () {
     test('有截图字节 -> providedCoverBytes=截图，PNG 名，无音频不中止', () {
@@ -13,6 +15,7 @@ void main() {
         sentence: '彼は走る',
         screenshotBytes: Uint8List.fromList([1, 2, 3]),
         documentTitle: 'ある galgame',
+        source: AnkiMiningSource.game,
       );
       expect(req.providedCoverBytes, [1, 2, 3]);
       expect(req.providedCoverName, 'external_window.png');
@@ -26,8 +29,8 @@ void main() {
       expect(req.clipStartMs, 0);
       expect(req.clipEndMs, 0);
       expect(req.hasRange, false);
-      // 外部窗口挖矿归「视频/沉浸」来源标签。
-      expect(req.source, AnkiMiningSource.video);
+      // BUG-1137：gal Hook 场景卡归「游戏」来源标签，不再吃 video 默认值。
+      expect(req.source, AnkiMiningSource.game);
     });
 
     test('截图为 null（抓帧失败）-> providedCoverBytes=null 且无名（引擎将 fail-open 中止）', () {
@@ -35,6 +38,7 @@ void main() {
         fields: const {'expression': 'テスト'},
         sentence: 'これはテスト',
         screenshotBytes: null,
+        source: AnkiMiningSource.game,
       );
       expect(req.providedCoverBytes, isNull);
       expect(req.providedCoverName, isNull);
@@ -66,6 +70,7 @@ void main() {
         sentence: '君の声',
         screenshotBytes: Uint8List.fromList([9, 9]),
         audioBytes: Uint8List.fromList([1, 2, 3, 4]),
+        source: AnkiMiningSource.game,
       );
       expect(req.providedAudioBytes, [1, 2, 3, 4]);
       // 桌面/Android 默认 aac；iOS m4a。两种都以 galgame_audio. 前缀。
@@ -80,6 +85,7 @@ void main() {
         sentence: '君の声',
         audioBytes: Uint8List.fromList([1, 2]),
         audioName: 'custom_voice.m4a',
+        source: AnkiMiningSource.game,
       );
       expect(req.providedAudioName, 'custom_voice.m4a');
     });
@@ -90,6 +96,7 @@ void main() {
         sentence: '君の声',
         screenshotBytes: Uint8List.fromList([9]),
         audioBytes: Uint8List(0),
+        source: AnkiMiningSource.game,
       );
       expect(req.providedAudioBytes, isNull);
       expect(req.providedAudioName, isNull);

--- a/hibiki/test/mining/immersion_mining_audio_materialize_test.dart
+++ b/hibiki/test/mining/immersion_mining_audio_materialize_test.dart
@@ -188,6 +188,7 @@ void main() {
       );
       await engine.mine(
           const ImmersionMiningRequest(
+              source: AnkiMiningSource.video,
               fields: {'expression': 'x'},
               mediaSource: 'https://muxed.example/v',
               clipStartMs: 0,
@@ -230,6 +231,7 @@ void main() {
       );
       await engine.mine(
           const ImmersionMiningRequest(
+              source: AnkiMiningSource.video,
               fields: {'expression': 'x'},
               mediaSource: 'https://video-only.example/v',
               audioSource: 'https://audio-only.example/a',

--- a/hibiki/test/mining/immersion_mining_engine_test.dart
+++ b/hibiki/test/mining/immersion_mining_engine_test.dart
@@ -117,6 +117,7 @@ void main() {
     final repo = _FakeRepo();
     final res = await build(gif: okGif, audio: okAudio, frame: okFrame).mine(
         const ImmersionMiningRequest(
+            source: AnkiMiningSource.video,
             fields: {'expression': '走る'},
             mediaSource: '/fake/video.mp4',
             clipStartMs: 1000,
@@ -156,6 +157,7 @@ void main() {
     final res =
         await build(gif: okGif, audio: trackingAudio, frame: okFrame).mine(
             ImmersionMiningRequest(
+              source: AnkiMiningSource.video,
               fields: const {'expression': '走る'},
               // 互联 host 自签 https 流：client ffmpeg 打不开，改走 host 端裁。
               mediaSource:
@@ -205,6 +207,7 @@ void main() {
     final res =
         await build(gif: okGif, audio: trackingAudio, frame: okFrame).mine(
             ImmersionMiningRequest(
+              source: AnkiMiningSource.video,
               fields: const {'expression': '走る'},
               mediaSource:
                   'https://host.example:38765/api/library/videos/v/stream?token=x',
@@ -234,6 +237,7 @@ void main() {
     final repo = _FakeRepo();
     await build(gif: nullGif, audio: nullAudio, frame: nullFrame).mine(
         ImmersionMiningRequest(
+            source: AnkiMiningSource.video,
             fields: const {'expression': 'x'},
             clipStartMs: 0,
             clipEndMs: 0,
@@ -250,6 +254,7 @@ void main() {
     final repo = _FakeRepo();
     final res = await build(gif: nullGif, audio: okAudio, frame: okFrame).mine(
         const ImmersionMiningRequest(
+            source: AnkiMiningSource.video,
             fields: {'expression': 'x'},
             mediaSource: '/v.mp4',
             clipStartMs: 0,
@@ -267,6 +272,7 @@ void main() {
     final res = await build(gif: okGif, audio: nullAudio, frame: nullFrame)
         .mine(
             const ImmersionMiningRequest(
+                source: AnkiMiningSource.video,
                 fields: {'expression': 'x'},
                 mediaSource: '/v.mp4',
                 clipStartMs: 0,
@@ -284,6 +290,7 @@ void main() {
     final res = await build(gif: nullGif, audio: nullAudio, frame: okFrame)
         .mine(
             const ImmersionMiningRequest(
+                source: AnkiMiningSource.video,
                 fields: {'expression': 'x'},
                 mediaSource: '/v.mp4',
                 clipStartMs: 0,
@@ -349,6 +356,7 @@ void main() {
             materializer: capMaterialize)
         .mine(
             const ImmersionMiningRequest(
+                source: AnkiMiningSource.video,
                 fields: {'expression': 'x'},
                 mediaSource: 'https://video-only.example/v',
                 audioSource: 'https://audio-only.example/a',
@@ -368,6 +376,7 @@ void main() {
     final repo = _FakeRepo();
     await build(gif: okGif, audio: okAudio, frame: okFrame).mine(
         const ImmersionMiningRequest(
+            source: AnkiMiningSource.video,
             fields: {'expression': 'x'},
             mediaSource: '/v.mp4',
             clipStartMs: 0,
@@ -389,6 +398,7 @@ void main() {
     final res = await build(gif: nullGif, audio: nullAudio, frame: nullFrame)
         .mine(
             ImmersionMiningRequest(
+                source: AnkiMiningSource.video,
                 fields: const {'expression': 'x'},
                 clipStartMs: 0,
                 clipEndMs: 0,
@@ -411,6 +421,7 @@ void main() {
     final res = await build(gif: nullGif, audio: nullAudio, frame: nullFrame)
         .mine(
             const ImmersionMiningRequest(
+                source: AnkiMiningSource.video,
                 fields: {'expression': 'x'},
                 clipStartMs: 0,
                 clipEndMs: 0,
@@ -449,6 +460,7 @@ void main() {
 
     final res = await build(gif: flagGif, audio: okAudio, frame: okFrame).mine(
         ImmersionMiningRequest(
+            source: AnkiMiningSource.video,
             fields: const {'expression': 'x'},
             mediaSource: '/v.mp4',
             clipStartMs: 1000,
@@ -485,6 +497,7 @@ void main() {
 
     final res = await build(gif: flagGif, audio: okAudio, frame: okFrame).mine(
         const ImmersionMiningRequest(
+            source: AnkiMiningSource.video,
             fields: {'expression': 'x'},
             mediaSource: '/v.mp4',
             clipStartMs: 1000,
@@ -506,6 +519,7 @@ void main() {
     final repo = _FakeRepo();
     final res = await build(gif: nullGif, audio: okAudio, frame: okFrame).mine(
         const ImmersionMiningRequest(
+            source: AnkiMiningSource.video,
             fields: {'expression': 'x'},
             mediaSource: '/v.mp4',
             clipStartMs: 1000,
@@ -526,6 +540,7 @@ void main() {
     final repo = _FakeRepo();
     final res = await build(gif: okGif, audio: okAudio, frame: nullFrame).mine(
         ImmersionMiningRequest(
+            source: AnkiMiningSource.video,
             fields: const {'expression': 'x'},
             mediaSource: '/v.mp4',
             clipStartMs: 1000,

--- a/hibiki/test/mining/immersion_mining_ffmpeg_integration_test.dart
+++ b/hibiki/test/mining/immersion_mining_ffmpeg_integration_test.dart
@@ -108,6 +108,7 @@ void main() {
       final _FakeRepo repo = _FakeRepo();
       final ImmersionMiningResult res = await ImmersionMiningEngine().mine(
         ImmersionMiningRequest(
+          source: AnkiMiningSource.video,
           fields: const <String, String>{'expression': '走る'},
           mediaSource: videoPath,
           clipStartMs: 1000,

--- a/hibiki/test/mining/youtube_immersion_live_engine_test.dart
+++ b/hibiki/test/mining/youtube_immersion_live_engine_test.dart
@@ -59,6 +59,7 @@ void main() {
       final _CaptureRepo repo = _CaptureRepo();
       final ImmersionMiningResult res = await ImmersionMiningEngine().mine(
         ImmersionMiningRequest(
+          source: AnkiMiningSource.video,
           fields: const <String, String>{'expression': 'アンキ'},
           mediaSource: miningVideo,
           audioSource: miningAudio,

--- a/hibiki/test/pages/mining_default_tags_wiring_static_test.dart
+++ b/hibiki/test/pages/mining_default_tags_wiring_static_test.dart
@@ -42,6 +42,8 @@ void main() {
         reason: 'buildNoteTags 必须接受来源参数');
     expect(src, contains("static const String bookTag = 'book';"));
     expect(src, contains("static const String videoTag = 'video';"));
+    expect(src, contains("static const String gameTag = 'game';"),
+        reason: 'BUG-1137：gal Hook 来源必须有自己的 game 分类标签');
     expect(src, contains("static const String hibikiTag = 'hibiki';"),
         reason: 'hibiki 固定标签不得丢（TODO-062）');
   });
@@ -76,12 +78,43 @@ void main() {
     final String src =
         File('lib/src/pages/implementations/dictionary_page_mixin.dart')
             .readAsStringSync();
-    expect(src, contains('AnkiMiningSource get _miningSource'),
-        reason: 'mixin 应把统计来源映射成制卡来源');
-    expect(src, contains('source: _miningSource'),
+    expect(src, contains('AnkiMiningSource get miningSource'),
+        reason: 'mixin 应把统计来源映射成制卡来源（可被 texthooker 页覆写成 game）');
+    expect(src, contains('source: miningSource'),
         reason: 'mixin 的 onMineEntry 必须把来源传进 context');
     expect(src, contains('AnkiMiningSource.video'));
     expect(src, contains('AnkiMiningSource.book'));
+  });
+
+  // BUG-1137：gal Hook 制卡曾吃 buildExternalWindowRequest 的 video 默认值被误标。
+  // 三道守卫：① 请求构造的 source 不再有默认值（漏传=编译错，不是静默 video）；
+  // ② gal 场景卡协调器显式声明 game 来源；③ texthooker 页 fallback 纯文本卡覆写
+  // mixin 来源为 game（统计口径不动，标签与统计两个维度）。
+  test('gal 制卡链路显式声明 game 来源，source 无静默默认值', () {
+    final String requestSrc =
+        File('lib/src/mining/immersion_mining_request.dart').readAsStringSync();
+    expect(requestSrc, contains('required this.source'),
+        reason: 'ImmersionMiningRequest.source 必须必填，禁止恢复 video 默认值');
+    expect(requestSrc, isNot(contains('this.source = AnkiMiningSource')),
+        reason: 'source 默认值是 BUG-1137 根因，不得回归');
+
+    final String builderSrc =
+        File('lib/src/mining/external_window_mining.dart').readAsStringSync();
+    expect(builderSrc, contains('required AnkiMiningSource source'),
+        reason: 'buildExternalWindowRequest 的来源必须由调用点显式声明');
+
+    final String coordinatorSrc =
+        File('lib/src/mining/gal_hook_mining_coordinator.dart')
+            .readAsStringSync();
+    expect(coordinatorSrc, contains('source: AnkiMiningSource.game'),
+        reason: 'gal 场景卡应标记游戏来源 → game 分类标签');
+
+    final String texthookerSrc =
+        File('lib/src/pages/implementations/texthooker_page.dart')
+            .readAsStringSync();
+    expect(texthookerSrc,
+        contains('AnkiMiningSource get miningSource => AnkiMiningSource.game'),
+        reason: 'texthooker fallback 纯文本卡同样归 game，不得吃默认 book');
   });
 
   // TODO-295 / BUG-242：设置页「添加来源分类标签」开关的提示文案，必须如实描述
@@ -99,11 +132,15 @@ void main() {
         reason: 'EN 提示应说明视频卡片得到 "video" 标签');
     expect(enHint.toLowerCase().contains('anime'), isFalse,
         reason: 'EN 提示不得再把视频标签写成 "anime"（实际写入的是 video）');
+    expect(enHint.contains('game'), isTrue,
+        reason: 'BUG-1137：EN 提示应说明游戏卡片得到 "game" 标签');
 
     expect(zhHint.contains('video'), isTrue,
         reason: 'zh-CN 提示应说明视频卡片得到「video」标签');
     expect(zhHint.contains('anime'), isFalse, reason: 'zh-CN 提示不得再出现 "anime"');
     expect(zhHint.contains('动漫'), isFalse,
         reason: 'zh-CN 提示不得把视频写成「动漫」（视频≠动画）');
+    expect(zhHint.contains('game'), isTrue,
+        reason: 'BUG-1137：zh-CN 提示应说明游戏卡片得到「game」标签');
   });
 }

--- a/packages/hibiki_anki/lib/src/anki_models.dart
+++ b/packages/hibiki_anki/lib/src/anki_models.dart
@@ -416,6 +416,11 @@ enum AnkiMiningSource {
 
   /// 视频字幕查词 —— 归「视频」分类标签（写入 Anki 的标签字面量为 `video`）。
   video,
+
+  /// galgame Hook 制卡（场景卡 / texthooker 行卡）—— 归「游戏」分类标签
+  /// （写入 Anki 的标签字面量为 `game`）。BUG-1137：此前枚举没有游戏来源，
+  /// gal 制卡链路吃 `video` 默认值，卡片被误标成视频。
+  game,
 }
 
 class AnkiMiningContext {

--- a/packages/hibiki_anki/lib/src/base_anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/base_anki_repository.dart
@@ -217,6 +217,10 @@ abstract class BaseAnkiRepository {
   /// 或重写用户 Anki 中的既有卡片，避免碰旧数据。
   static const String videoTag = 'video';
 
+  /// galgame Hook 来源的分类标签（BUG-1137）。仅决定新制卡默认标签，既有误标
+  /// `video` 的旧卡不迁移不重写。
+  static const String gameTag = 'game';
+
   /// 把制卡来源类别映射成分类标签；`null`（未指定来源）时返回 `null`（不追加）。
   static String? _categoryTagForSource(AnkiMiningSource? source) {
     switch (source) {
@@ -224,6 +228,8 @@ abstract class BaseAnkiRepository {
         return bookTag;
       case AnkiMiningSource.video:
         return videoTag;
+      case AnkiMiningSource.game:
+        return gameTag;
       case null:
         return null;
     }
@@ -233,8 +239,8 @@ abstract class BaseAnkiRepository {
   /// **追加** [hibikiTag] 与 [source] 对应的分类标签后去重（保序）。
   ///
   /// - 追加而非覆盖：用户已配置的 tag 全部保留，只是按开关额外多 `hibiki` + 分类标签。
-  /// - 顺序：用户 tag → `hibiki` → 分类标签（`book`/`video`）。
-  /// - 去重：用户若已手动配置了 `hibiki`/`book`/`video`，不会出现两个。
+  /// - 顺序：用户 tag → `hibiki` → 分类标签（`book`/`video`/`game`）。
+  /// - 去重：用户若已手动配置了 `hibiki`/`book`/`video`/`game`，不会出现两个。
   /// - [includeHibiki]（TODO-117 开关）为 `false` 时不追加 `hibiki`。
   /// - [includeCategory]（TODO-117 开关）为 `false` 时不追加分类标签；为 `true` 但
   ///   [source] 为 `null`（未指定来源，如独立查词/悬浮窗）时本就没有分类标签可加。

--- a/packages/hibiki_anki/test/mining_tag_and_parallel_test.dart
+++ b/packages/hibiki_anki/test/mining_tag_and_parallel_test.dart
@@ -209,6 +209,12 @@ void main() {
           <String>['hibiki', 'video']);
     });
 
+    // BUG-1137：gal Hook 制卡曾因来源枚举缺 game + 请求默认 video 被误标成视频。
+    test('game source -> appends both hibiki and game (AnkiConnect)', () async {
+      expect(await tagsForConnect('', source: AnkiMiningSource.game),
+          <String>['hibiki', 'game']);
+    });
+
     test('null source -> only hibiki, no category tag (AnkiConnect)', () async {
       expect(await tagsForConnect('', source: null), <String>['hibiki']);
     });
@@ -230,6 +236,8 @@ void main() {
           <String>['hibiki', 'book']);
       expect(await tagsForDroid('', source: AnkiMiningSource.video),
           <String>['hibiki', 'video']);
+      expect(await tagsForDroid('', source: AnkiMiningSource.game),
+          <String>['hibiki', 'game']);
       expect(
           await tagsForDroid('foo', source: null), <String>['foo', 'hibiki']);
     });


### PR DESCRIPTION
## 问题（用户报告）

gal 一键制卡出来的卡片在 Anki 里分类标签仍是 `hibiki video`（见 BUG-1127 截图场景），用户被迫每次手动写标签区分游戏卡。

## 根因

两层，都在数据结构：

1. `AnkiMiningSource` 枚举只有 `book` / `video` —— 游戏来源根本没有值域，想标对也无处可标。
2. `ImmersionMiningRequest.source` 与 `buildExternalWindowRequest` 都带 `= AnkiMiningSource.video` 默认值。gal 场景卡协调器（`gal_hook_mining_coordinator.dart`）构造请求时没传 `source`，被**静默兜底成 video**。texthooker fallback 纯文本卡同理吃 mixin 默认被标成 `book`。

## 修复

- 枚举补 `game`，`BaseAnkiRepository` 映射 `gameTag = 'game'`（旧误标卡不迁移不重写，Never break）。
- **消灭默认值**：两处 `source` 改必填——来源由每个调用点显式声明，漏传是编译错误而不是静默错标。
- gal 场景卡协调器显式 `source: AnkiMiningSource.game`；顺手统一「自动添加书名到标签」：开关开启时游戏窗口标题作为标题标签接入 `bookTitleTag`（与 reader 书名 / video 番名同语义、同走 `sanitizeTitleTag`），用户不再需要手动补游戏名标签。
- texthooker 页覆写 mixin 新开的 `miningSource` getter 为 `game`（统计口径不动——标签与统计是两个维度）。
- 互联转发 `_forwardedSourceFromName` 补 `'game'`；17 语言 `anki_tag_include_category_hint` 文案补 game 描述（`dart run slang` 已重新生成）。

## 测试

- `packages/hibiki_anki` 行为测试：game 来源 → `['hibiki','game']`（AnkiConnect + AnkiDroid 两后端），全包 205 过。
- 源码守卫新增「gal 制卡链路显式声明 game 来源，source 无静默默认值」：request 必填不得回归默认值、协调器 game、texthooker 覆写三处接线。
- `flutter analyze` 0 issue；定向 `flutter test`（test/mining + test/anki + gal overlay/texthooker 相关 + 标签守卫）988 过。

BUG 文件：`docs/bugs/BUG-1127-gal-mining-video-tag.md`（①②已勾）。

https://claude.ai/code/session_01S5a2kKj91YK8e9TvqKndiR