### PR TITLE
feat(anki): Anki 媒体字节级去重（定期存储优化）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,7 +1,7 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45305 (2665 per locale)
+/// Strings: 45356 (2668 per locale)
 ///
 /// Built on 2026-07-27 at 10:10 UTC
 
@@ -3537,13 +3537,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
   String get anki_dedup_section => 'Anki media storage optimization';
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   String get anki_dedup_run => 'Deduplicate now';
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   String get anki_dedup_report_title => 'Media deduplication report';
   String anki_dedup_report_body(
           {required Object groups,
@@ -3559,6 +3554,19 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Deduplication failed: ${error}';
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  String get anki_dedup_plan_title => 'Files to delete';
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  String get anki_dedup_plan_delete => 'Delete these files';
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -9599,17 +9607,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -9631,6 +9631,25 @@ class _StringsAr extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -15739,17 +15758,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -15771,6 +15782,25 @@ class _StringsDe extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -21895,17 +21925,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -21927,6 +21949,25 @@ class _StringsEs extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -28062,17 +28103,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -28094,6 +28127,25 @@ class _StringsFr extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -34158,17 +34210,9 @@ class _StringsId extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -34190,6 +34234,25 @@ class _StringsId extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -40300,17 +40363,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -40332,6 +40387,25 @@ class _StringsIt extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -46259,17 +46333,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -46291,6 +46357,25 @@ class _StringsJa extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -52220,17 +52305,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -52252,6 +52329,25 @@ class _StringsKo extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -58342,17 +58438,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -58374,6 +58462,25 @@ class _StringsNl extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -64477,17 +64584,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -64509,6 +64608,25 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -70596,17 +70714,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -70628,6 +70738,25 @@ class _StringsRu extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -76663,17 +76792,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -76695,6 +76816,25 @@ class _StringsTh extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -82762,17 +82902,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -82794,6 +82926,25 @@ class _StringsTr extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -88846,17 +88997,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -88878,6 +89021,25 @@ class _StringsVi extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 // Path: <root>
@@ -94513,16 +94675,9 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki 媒体存储优化';
   @override
-  String get anki_dedup_auto => '每周自动媒体去重';
-  @override
-  String get anki_dedup_auto_hint =>
-      '找出字节完全相同的重复媒体文件，把所有引用统一指向一份后删除多余副本。绝不重编码、不降画质。';
-  @override
   String get anki_dedup_scan => '扫描重复项（不做改动）';
   @override
   String get anki_dedup_run => '立即去重';
-  @override
-  String get anki_dedup_run_confirm => '改写引用并删除字节完全相同的重复文件？操作记录会先写入备份目录。';
   @override
   String get anki_dedup_report_title => '媒体去重报告';
   @override
@@ -94542,6 +94697,23 @@ class _StringsZhCn extends _StringsEn {
   String anki_dedup_failed({required Object error}) => '去重失败：${error}';
   @override
   String get anki_dedup_unavailable => '需要本机运行 Anki（AnkiConnect）。';
+  @override
+  String get anki_dedup_run_hint => '先扫描并列出将要删除的文件，你确认之后才会真正删除。';
+  @override
+  String get anki_dedup_plan_title => '将要删除的文件';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '共 ${count} 个多余副本，可回收 ${size}。每个文件都保留一份，所有引用先改指到保留的那一份；不重新编码任何文件。';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      '删除 ${file}（${size}）——保留 ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => '删除这些文件';
+  @override
+  String get anki_dedup_plan_journal => '每一次改写和删除都会先记进备份文件夹里的日志。';
 }
 
 // Path: <root>
@@ -100390,17 +100562,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anki_dedup_section => 'Anki media storage optimization';
   @override
-  String get anki_dedup_auto => 'Deduplicate media weekly';
-  @override
-  String get anki_dedup_auto_hint =>
-      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
-  @override
   String get anki_dedup_scan => 'Scan for duplicates (no changes)';
   @override
   String get anki_dedup_run => 'Deduplicate now';
-  @override
-  String get anki_dedup_run_confirm =>
-      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
   @override
   String get anki_dedup_report_title => 'Media deduplication report';
   @override
@@ -100422,6 +100586,25 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anki_dedup_unavailable =>
       'Requires Anki running on this machine (AnkiConnect).';
+  @override
+  String get anki_dedup_run_hint =>
+      'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+  @override
+  String get anki_dedup_plan_title => 'Files to delete';
+  @override
+  String anki_dedup_plan_intro({required Object count, required Object size}) =>
+      '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+  @override
+  String anki_dedup_plan_entry(
+          {required Object file,
+          required Object size,
+          required Object canonical}) =>
+      'Delete ${file} (${size}) - keeping ${canonical}';
+  @override
+  String get anki_dedup_plan_delete => 'Delete these files';
+  @override
+  String get anki_dedup_plan_journal =>
+      'A journal of every rewrite and deletion is written to the backup folder first.';
 }
 
 /// Flat map(s) containing all translations.
@@ -105846,16 +106029,10 @@ extension on _StringsEn {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -105875,6 +106052,23 @@ extension on _StringsEn {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -111297,16 +111491,10 @@ extension on _StringsAr {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -111326,6 +111514,23 @@ extension on _StringsAr {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -116769,16 +116974,10 @@ extension on _StringsDe {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -116798,6 +116997,23 @@ extension on _StringsDe {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -122240,16 +122456,10 @@ extension on _StringsEs {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -122269,6 +122479,23 @@ extension on _StringsEs {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -127717,16 +127944,10 @@ extension on _StringsFr {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -127746,6 +127967,23 @@ extension on _StringsFr {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -133176,16 +133414,10 @@ extension on _StringsId {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -133205,6 +133437,23 @@ extension on _StringsId {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -138650,16 +138899,10 @@ extension on _StringsIt {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -138679,6 +138922,23 @@ extension on _StringsIt {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -144086,16 +144346,10 @@ extension on _StringsJa {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -144115,6 +144369,23 @@ extension on _StringsJa {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -149526,16 +149797,10 @@ extension on _StringsKo {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -149555,6 +149820,23 @@ extension on _StringsKo {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -154993,16 +155275,10 @@ extension on _StringsNl {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -155022,6 +155298,23 @@ extension on _StringsNl {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -160457,16 +160750,10 @@ extension on _StringsPtBr {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -160486,6 +160773,23 @@ extension on _StringsPtBr {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -165926,16 +166230,10 @@ extension on _StringsRu {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -165955,6 +166253,23 @@ extension on _StringsRu {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -171379,16 +171694,10 @@ extension on _StringsTh {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -171408,6 +171717,23 @@ extension on _StringsTh {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -176841,16 +177167,10 @@ extension on _StringsTr {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -176870,6 +177190,23 @@ extension on _StringsTr {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -182298,16 +182635,10 @@ extension on _StringsVi {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -182327,6 +182658,23 @@ extension on _StringsVi {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }
@@ -187709,16 +188057,10 @@ extension on _StringsZhCn {
         return ({required Object error}) => '恢复失败：${error}';
       case 'anki_dedup_section':
         return 'Anki 媒体存储优化';
-      case 'anki_dedup_auto':
-        return '每周自动媒体去重';
-      case 'anki_dedup_auto_hint':
-        return '找出字节完全相同的重复媒体文件，把所有引用统一指向一份后删除多余副本。绝不重编码、不降画质。';
       case 'anki_dedup_scan':
         return '扫描重复项（不做改动）';
       case 'anki_dedup_run':
         return '立即去重';
-      case 'anki_dedup_run_confirm':
-        return '改写引用并删除字节完全相同的重复文件？操作记录会先写入备份目录。';
       case 'anki_dedup_report_title':
         return '媒体去重报告';
       case 'anki_dedup_report_body':
@@ -187738,6 +188080,23 @@ extension on _StringsZhCn {
         return ({required Object error}) => '去重失败：${error}';
       case 'anki_dedup_unavailable':
         return '需要本机运行 Anki（AnkiConnect）。';
+      case 'anki_dedup_run_hint':
+        return '先扫描并列出将要删除的文件，你确认之后才会真正删除。';
+      case 'anki_dedup_plan_title':
+        return '将要删除的文件';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '共 ${count} 个多余副本，可回收 ${size}。每个文件都保留一份，所有引用先改指到保留的那一份；不重新编码任何文件。';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            '删除 ${file}（${size}）——保留 ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return '删除这些文件';
+      case 'anki_dedup_plan_journal':
+        return '每一次改写和删除都会先记进备份文件夹里的日志。';
       default:
         return null;
     }
@@ -193140,16 +193499,10 @@ extension on _StringsZhHk {
         return ({required Object error}) => 'Restore failed: ${error}';
       case 'anki_dedup_section':
         return 'Anki media storage optimization';
-      case 'anki_dedup_auto':
-        return 'Deduplicate media weekly';
-      case 'anki_dedup_auto_hint':
-        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
       case 'anki_dedup_scan':
         return 'Scan for duplicates (no changes)';
       case 'anki_dedup_run':
         return 'Deduplicate now';
-      case 'anki_dedup_run_confirm':
-        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
       case 'anki_dedup_report_title':
         return 'Media deduplication report';
       case 'anki_dedup_report_body':
@@ -193169,6 +193522,23 @@ extension on _StringsZhHk {
         return ({required Object error}) => 'Deduplication failed: ${error}';
       case 'anki_dedup_unavailable':
         return 'Requires Anki running on this machine (AnkiConnect).';
+      case 'anki_dedup_run_hint':
+        return 'Scans first and lists exactly what would be deleted; nothing is removed until you confirm.';
+      case 'anki_dedup_plan_title':
+        return 'Files to delete';
+      case 'anki_dedup_plan_intro':
+        return ({required Object count, required Object size}) =>
+            '${count} extra copies, ${size} reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.';
+      case 'anki_dedup_plan_entry':
+        return (
+                {required Object file,
+                required Object size,
+                required Object canonical}) =>
+            'Delete ${file} (${size}) - keeping ${canonical}';
+      case 'anki_dedup_plan_delete':
+        return 'Delete these files';
+      case 'anki_dedup_plan_journal':
+        return 'A journal of every rewrite and deletion is written to the backup folder first.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45101 (2653 per locale)
+/// Strings: 45305 (2665 per locale)
 ///
-/// Built on 2026-07-27 at 08:32 UTC
+/// Built on 2026-07-27 at 10:10 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3536,6 +3536,29 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get anki_lapis_restore_done => 'Template restored.';
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  String get anki_dedup_section => 'Anki media storage optimization';
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  String get anki_dedup_run => 'Deduplicate now';
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  String get anki_dedup_report_title => 'Media deduplication report';
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -9573,6 +9596,41 @@ class _StringsAr extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -15678,6 +15736,41 @@ class _StringsDe extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -21799,6 +21892,41 @@ class _StringsEs extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -27931,6 +28059,41 @@ class _StringsFr extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -33992,6 +34155,41 @@ class _StringsId extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -40099,6 +40297,41 @@ class _StringsIt extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -46023,6 +46256,41 @@ class _StringsJa extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -51949,6 +52217,41 @@ class _StringsKo extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -58036,6 +58339,41 @@ class _StringsNl extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -64136,6 +64474,41 @@ class _StringsPtBr extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -70220,6 +70593,41 @@ class _StringsRu extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -76252,6 +76660,41 @@ class _StringsTh extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -82316,6 +82759,41 @@ class _StringsTr extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -88365,6 +88843,41 @@ class _StringsVi extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 // Path: <root>
@@ -93997,6 +94510,38 @@ class _StringsZhCn extends _StringsEn {
   String get anki_lapis_restore_done => '模板已恢复。';
   @override
   String anki_lapis_restore_failed({required Object error}) => '恢复失败：${error}';
+  @override
+  String get anki_dedup_section => 'Anki 媒体存储优化';
+  @override
+  String get anki_dedup_auto => '每周自动媒体去重';
+  @override
+  String get anki_dedup_auto_hint =>
+      '找出字节完全相同的重复媒体文件，把所有引用统一指向一份后删除多余副本。绝不重编码、不降画质。';
+  @override
+  String get anki_dedup_scan => '扫描重复项（不做改动）';
+  @override
+  String get anki_dedup_run => '立即去重';
+  @override
+  String get anki_dedup_run_confirm => '改写引用并删除字节完全相同的重复文件？操作记录会先写入备份目录。';
+  @override
+  String get anki_dedup_report_title => '媒体去重报告';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} 组重复；多余副本 ${removed} 个（${size}）；改写笔记 ${notes} 张、模板 ${models} 个；跳过 ${skipped} 个。';
+  @override
+  String get anki_dedup_report_dry_note => '仅扫描——未做任何改动。';
+  @override
+  String get anki_dedup_report_clean => '没有发现字节完全相同的重复文件。';
+  @override
+  String anki_dedup_failed({required Object error}) => '去重失败：${error}';
+  @override
+  String get anki_dedup_unavailable => '需要本机运行 Anki（AnkiConnect）。';
 }
 
 // Path: <root>
@@ -99842,6 +100387,41 @@ class _StringsZhHk extends _StringsEn {
   @override
   String anki_lapis_restore_failed({required Object error}) =>
       'Restore failed: ${error}';
+  @override
+  String get anki_dedup_section => 'Anki media storage optimization';
+  @override
+  String get anki_dedup_auto => 'Deduplicate media weekly';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+  @override
+  String get anki_dedup_scan => 'Scan for duplicates (no changes)';
+  @override
+  String get anki_dedup_run => 'Deduplicate now';
+  @override
+  String get anki_dedup_run_confirm =>
+      'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+  @override
+  String get anki_dedup_report_title => 'Media deduplication report';
+  @override
+  String anki_dedup_report_body(
+          {required Object groups,
+          required Object removed,
+          required Object size,
+          required Object notes,
+          required Object models,
+          required Object skipped}) =>
+      '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+  @override
+  String get anki_dedup_report_dry_note => 'Scan only - nothing was changed.';
+  @override
+  String get anki_dedup_report_clean => 'No byte-identical duplicates found.';
+  @override
+  String anki_dedup_failed({required Object error}) =>
+      'Deduplication failed: ${error}';
+  @override
+  String get anki_dedup_unavailable =>
+      'Requires Anki running on this machine (AnkiConnect).';
 }
 
 /// Flat map(s) containing all translations.
@@ -105264,6 +105844,37 @@ extension on _StringsEn {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -110684,6 +111295,37 @@ extension on _StringsAr {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -116125,6 +116767,37 @@ extension on _StringsDe {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -121565,6 +122238,37 @@ extension on _StringsEs {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -127011,6 +127715,37 @@ extension on _StringsFr {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -132439,6 +133174,37 @@ extension on _StringsId {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -137882,6 +138648,37 @@ extension on _StringsIt {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -143287,6 +144084,37 @@ extension on _StringsJa {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -148696,6 +149524,37 @@ extension on _StringsKo {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -154132,6 +154991,37 @@ extension on _StringsNl {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -159565,6 +160455,37 @@ extension on _StringsPtBr {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -165003,6 +165924,37 @@ extension on _StringsRu {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -170425,6 +171377,37 @@ extension on _StringsTh {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -175856,6 +176839,37 @@ extension on _StringsTr {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -181282,6 +182296,37 @@ extension on _StringsVi {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }
@@ -186662,6 +187707,37 @@ extension on _StringsZhCn {
         return '模板已恢复。';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => '恢复失败：${error}';
+      case 'anki_dedup_section':
+        return 'Anki 媒体存储优化';
+      case 'anki_dedup_auto':
+        return '每周自动媒体去重';
+      case 'anki_dedup_auto_hint':
+        return '找出字节完全相同的重复媒体文件，把所有引用统一指向一份后删除多余副本。绝不重编码、不降画质。';
+      case 'anki_dedup_scan':
+        return '扫描重复项（不做改动）';
+      case 'anki_dedup_run':
+        return '立即去重';
+      case 'anki_dedup_run_confirm':
+        return '改写引用并删除字节完全相同的重复文件？操作记录会先写入备份目录。';
+      case 'anki_dedup_report_title':
+        return '媒体去重报告';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} 组重复；多余副本 ${removed} 个（${size}）；改写笔记 ${notes} 张、模板 ${models} 个；跳过 ${skipped} 个。';
+      case 'anki_dedup_report_dry_note':
+        return '仅扫描——未做任何改动。';
+      case 'anki_dedup_report_clean':
+        return '没有发现字节完全相同的重复文件。';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => '去重失败：${error}';
+      case 'anki_dedup_unavailable':
+        return '需要本机运行 Anki（AnkiConnect）。';
       default:
         return null;
     }
@@ -192062,6 +193138,37 @@ extension on _StringsZhHk {
         return 'Template restored.';
       case 'anki_lapis_restore_failed':
         return ({required Object error}) => 'Restore failed: ${error}';
+      case 'anki_dedup_section':
+        return 'Anki media storage optimization';
+      case 'anki_dedup_auto':
+        return 'Deduplicate media weekly';
+      case 'anki_dedup_auto_hint':
+        return 'Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.';
+      case 'anki_dedup_scan':
+        return 'Scan for duplicates (no changes)';
+      case 'anki_dedup_run':
+        return 'Deduplicate now';
+      case 'anki_dedup_run_confirm':
+        return 'Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.';
+      case 'anki_dedup_report_title':
+        return 'Media deduplication report';
+      case 'anki_dedup_report_body':
+        return (
+                {required Object groups,
+                required Object removed,
+                required Object size,
+                required Object notes,
+                required Object models,
+                required Object skipped}) =>
+            '${groups} duplicate groups; ${removed} extra copies (${size}); ${notes} notes and ${models} note types rewritten; ${skipped} skipped.';
+      case 'anki_dedup_report_dry_note':
+        return 'Scan only - nothing was changed.';
+      case 'anki_dedup_report_clean':
+        return 'No byte-identical duplicates found.';
+      case 'anki_dedup_failed':
+        return ({required Object error}) => 'Deduplication failed: ${error}';
+      case 'anki_dedup_unavailable':
+        return 'Requires Anki running on this machine (AnkiConnect).';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "模板已恢复。",
   "anki_lapis_restore_failed": "恢复失败：$error",
   "anki_dedup_section": "Anki 媒体存储优化",
-  "anki_dedup_auto": "每周自动媒体去重",
-  "anki_dedup_auto_hint": "找出字节完全相同的重复媒体文件，把所有引用统一指向一份后删除多余副本。绝不重编码、不降画质。",
   "anki_dedup_scan": "扫描重复项（不做改动）",
   "anki_dedup_run": "立即去重",
-  "anki_dedup_run_confirm": "改写引用并删除字节完全相同的重复文件？操作记录会先写入备份目录。",
   "anki_dedup_report_title": "媒体去重报告",
   "anki_dedup_report_body": "$groups 组重复；多余副本 $removed 个（$size）；改写笔记 $notes 张、模板 $models 个；跳过 $skipped 个。",
   "anki_dedup_report_dry_note": "仅扫描——未做任何改动。",
   "anki_dedup_report_clean": "没有发现字节完全相同的重复文件。",
   "anki_dedup_failed": "去重失败：$error",
-  "anki_dedup_unavailable": "需要本机运行 Anki（AnkiConnect）。"
+  "anki_dedup_unavailable": "需要本机运行 Anki（AnkiConnect）。",
+  "anki_dedup_run_hint": "先扫描并列出将要删除的文件，你确认之后才会真正删除。",
+  "anki_dedup_plan_title": "将要删除的文件",
+  "anki_dedup_plan_intro": "共 $count 个多余副本，可回收 $size。每个文件都保留一份，所有引用先改指到保留的那一份；不重新编码任何文件。",
+  "anki_dedup_plan_entry": "删除 $file（$size）——保留 $canonical",
+  "anki_dedup_plan_delete": "删除这些文件",
+  "anki_dedup_plan_journal": "每一次改写和删除都会先记进备份文件夹里的日志。"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "还没有备份。",
   "anki_lapis_restore_confirm": "用该备份覆盖 Anki 里的 Lapis 模板？当前状态会先自动备份。",
   "anki_lapis_restore_done": "模板已恢复。",
-  "anki_lapis_restore_failed": "恢复失败：$error"
+  "anki_lapis_restore_failed": "恢复失败：$error",
+  "anki_dedup_section": "Anki 媒体存储优化",
+  "anki_dedup_auto": "每周自动媒体去重",
+  "anki_dedup_auto_hint": "找出字节完全相同的重复媒体文件，把所有引用统一指向一份后删除多余副本。绝不重编码、不降画质。",
+  "anki_dedup_scan": "扫描重复项（不做改动）",
+  "anki_dedup_run": "立即去重",
+  "anki_dedup_run_confirm": "改写引用并删除字节完全相同的重复文件？操作记录会先写入备份目录。",
+  "anki_dedup_report_title": "媒体去重报告",
+  "anki_dedup_report_body": "$groups 组重复；多余副本 $removed 个（$size）；改写笔记 $notes 张、模板 $models 个；跳过 $skipped 个。",
+  "anki_dedup_report_dry_note": "仅扫描——未做任何改动。",
+  "anki_dedup_report_clean": "没有发现字节完全相同的重复文件。",
+  "anki_dedup_failed": "去重失败：$error",
+  "anki_dedup_unavailable": "需要本机运行 Anki（AnkiConnect）。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2653,15 +2653,18 @@
   "anki_lapis_restore_done": "Template restored.",
   "anki_lapis_restore_failed": "Restore failed: $error",
   "anki_dedup_section": "Anki media storage optimization",
-  "anki_dedup_auto": "Deduplicate media weekly",
-  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
   "anki_dedup_scan": "Scan for duplicates (no changes)",
   "anki_dedup_run": "Deduplicate now",
-  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
   "anki_dedup_report_title": "Media deduplication report",
   "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
   "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
   "anki_dedup_report_clean": "No byte-identical duplicates found.",
   "anki_dedup_failed": "Deduplication failed: $error",
-  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect).",
+  "anki_dedup_run_hint": "Scans first and lists exactly what would be deleted; nothing is removed until you confirm.",
+  "anki_dedup_plan_title": "Files to delete",
+  "anki_dedup_plan_intro": "$count extra copies, $size reclaimable. One copy of each file is kept and every reference is repointed to it first; nothing is ever re-encoded.",
+  "anki_dedup_plan_entry": "Delete $file ($size) - keeping $canonical",
+  "anki_dedup_plan_delete": "Delete these files",
+  "anki_dedup_plan_journal": "A journal of every rewrite and deletion is written to the backup folder first."
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2651,5 +2651,17 @@
   "anki_lapis_restore_empty": "No backups yet.",
   "anki_lapis_restore_confirm": "Overwrite the Lapis template in Anki with this backup? The current state is backed up first.",
   "anki_lapis_restore_done": "Template restored.",
-  "anki_lapis_restore_failed": "Restore failed: $error"
+  "anki_lapis_restore_failed": "Restore failed: $error",
+  "anki_dedup_section": "Anki media storage optimization",
+  "anki_dedup_auto": "Deduplicate media weekly",
+  "anki_dedup_auto_hint": "Finds byte-identical duplicate media files, points every reference at one copy, then deletes the extras. Never re-encodes anything.",
+  "anki_dedup_scan": "Scan for duplicates (no changes)",
+  "anki_dedup_run": "Deduplicate now",
+  "anki_dedup_run_confirm": "Rewrite references and delete byte-identical duplicate files? A journal is written to the backup folder first.",
+  "anki_dedup_report_title": "Media deduplication report",
+  "anki_dedup_report_body": "$groups duplicate groups; $removed extra copies ($size); $notes notes and $models note types rewritten; $skipped skipped.",
+  "anki_dedup_report_dry_note": "Scan only - nothing was changed.",
+  "anki_dedup_report_clean": "No byte-identical duplicates found.",
+  "anki_dedup_failed": "Deduplication failed: $error",
+  "anki_dedup_unavailable": "Requires Anki running on this machine (AnkiConnect)."
 }

--- a/hibiki/lib/src/anki/anki_media_dedup_runner.dart
+++ b/hibiki/lib/src/anki/anki_media_dedup_runner.dart
@@ -1,30 +1,24 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:hibiki/src/storage/app_paths.dart';
 
-/// Anki 媒体字节级去重的应用层编排：journal 落盘 + 上次运行时间持久化 +
-/// 启动周期触发（每 7 天）。
+/// Anki 媒体字节级去重的应用层编排：journal 落盘 + 上次运行时间持久化。
+///
+/// **没有任何自动/周期触发路径**（用户拍板方案 A）：唯一入口是设置页的手动
+/// 触发，而且必须先跑 [runNow] 的干跑拿到删除清单、由用户在弹窗里确认之后，
+/// 才会以 `dryRun: false` 再跑一次真删。Hibiki 不会在用户没点之前动任何文件。
 ///
 /// 真实的扫描/改写/删除在 `BaseAnkiRepository.runMediaDedup`
 /// （AnkiConnect 实现）；本类只负责「每次真实改写/删除前把可回溯记录写进
-/// `<supportRoot>/backups/media_dedup/<时间戳>.jsonl`」这条保险带，以及
-/// check-due 周期门。
+/// `<supportRoot>/backups/media_dedup/<时间戳>.jsonl`」这条保险带。
 class AnkiMediaDedupRunner {
   AnkiMediaDedupRunner(this._repository);
 
   final BaseAnkiRepository _repository;
-
-  /// 启动周期触发的会话级闸门（HomePage 重建不重跑）。
-  static bool _ranThisSession = false;
-
-  /// 测试用：重置会话级闸门。
-  @visibleForTesting
-  static void resetSessionGate() => _ranThisSession = false;
 
   Future<Directory> journalDirectory() async {
     final Directory support = await AppPaths.supportRootDirectory();
@@ -34,8 +28,9 @@ class AnkiMediaDedupRunner {
     return dir;
   }
 
-  /// 跑一轮去重（设置页手动入口与周期触发共用）。[dryRun] = 只扫描不改动
-  /// （不写 journal、不更新时间戳）。后端不支持返回 null。
+  /// 跑一轮去重。[dryRun] = 只扫描规划、不改动任何东西（不写 journal、不更新
+  /// 时间戳），产出的 `AnkiMediaDedupReport.deletions` 就是给用户看的删除清单。
+  /// 后端不支持返回 null。
   Future<AnkiMediaDedupReport?> runNow({required bool dryRun}) async {
     if (!_repository.supportsMediaMaintenance) return null;
     if (dryRun) return _repository.runMediaDedup(dryRun: true);
@@ -63,30 +58,6 @@ class AnkiMediaDedupRunner {
       await sink.close();
       // 这一轮啥也没改（无重复/全跳过）：不留空 journal 文件。
       if (!wroteAny && await journal.exists()) await journal.delete();
-    }
-  }
-
-  /// 启动周期触发：开关开启 + 距上次 ≥7 天才真正跑。Anki 未运行/不可达是
-  /// 常态，静默跳过（时间戳不更新，下次启动再试）。
-  Future<void> maybeRunPeriodic() async {
-    if (_ranThisSession) return;
-    _ranThisSession = true;
-    if (!_repository.supportsMediaMaintenance) return;
-    final AnkiSettings settings = await _repository.loadSettings();
-    if (!settings.mediaDedupAutoEnabled) return;
-    if (!shouldRunPeriodicMediaDedup(
-      lastRunMs: settings.lastMediaDedupAtMs,
-      nowMs: DateTime.now().millisecondsSinceEpoch,
-    )) {
-      return;
-    }
-    try {
-      final AnkiMediaDedupReport? report = await runNow(dryRun: false);
-      if (report != null) {
-        debugPrint('AnkiMediaDedupRunner.periodic: ${report.toJson()}');
-      }
-    } catch (e) {
-      debugPrint('AnkiMediaDedupRunner.periodic: skipped (unreachable?): $e');
     }
   }
 }

--- a/hibiki/lib/src/anki/anki_media_dedup_runner.dart
+++ b/hibiki/lib/src/anki/anki_media_dedup_runner.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki/src/storage/app_paths.dart';
+
+/// Anki 媒体字节级去重的应用层编排：journal 落盘 + 上次运行时间持久化 +
+/// 启动周期触发（每 7 天）。
+///
+/// 真实的扫描/改写/删除在 `BaseAnkiRepository.runMediaDedup`
+/// （AnkiConnect 实现）；本类只负责「每次真实改写/删除前把可回溯记录写进
+/// `<supportRoot>/backups/media_dedup/<时间戳>.jsonl`」这条保险带，以及
+/// check-due 周期门。
+class AnkiMediaDedupRunner {
+  AnkiMediaDedupRunner(this._repository);
+
+  final BaseAnkiRepository _repository;
+
+  /// 启动周期触发的会话级闸门（HomePage 重建不重跑）。
+  static bool _ranThisSession = false;
+
+  /// 测试用：重置会话级闸门。
+  @visibleForTesting
+  static void resetSessionGate() => _ranThisSession = false;
+
+  Future<Directory> journalDirectory() async {
+    final Directory support = await AppPaths.supportRootDirectory();
+    final Directory dir =
+        Directory(p.join(support.path, 'backups', 'media_dedup'));
+    if (!await dir.exists()) await dir.create(recursive: true);
+    return dir;
+  }
+
+  /// 跑一轮去重（设置页手动入口与周期触发共用）。[dryRun] = 只扫描不改动
+  /// （不写 journal、不更新时间戳）。后端不支持返回 null。
+  Future<AnkiMediaDedupReport?> runNow({required bool dryRun}) async {
+    if (!_repository.supportsMediaMaintenance) return null;
+    if (dryRun) return _repository.runMediaDedup(dryRun: true);
+
+    final Directory dir = await journalDirectory();
+    final String stamp =
+        DateTime.now().toUtc().toIso8601String().replaceAll(':', '-');
+    final File journal = File(p.join(dir.path, 'dedup-$stamp.jsonl'));
+    final IOSink sink = journal.openWrite();
+    bool wroteAny = false;
+    try {
+      final AnkiMediaDedupReport? report = await _repository.runMediaDedup(
+        onJournal: (Map<String, dynamic> entry) async {
+          wroteAny = true;
+          sink.writeln(jsonEncode(entry));
+        },
+      );
+      if (report != null) {
+        await _repository.updateSettings((AnkiSettings s) => s.copyWith(
+            lastMediaDedupAtMs: DateTime.now().millisecondsSinceEpoch));
+      }
+      return report;
+    } finally {
+      await sink.flush();
+      await sink.close();
+      // 这一轮啥也没改（无重复/全跳过）：不留空 journal 文件。
+      if (!wroteAny && await journal.exists()) await journal.delete();
+    }
+  }
+
+  /// 启动周期触发：开关开启 + 距上次 ≥7 天才真正跑。Anki 未运行/不可达是
+  /// 常态，静默跳过（时间戳不更新，下次启动再试）。
+  Future<void> maybeRunPeriodic() async {
+    if (_ranThisSession) return;
+    _ranThisSession = true;
+    if (!_repository.supportsMediaMaintenance) return;
+    final AnkiSettings settings = await _repository.loadSettings();
+    if (!settings.mediaDedupAutoEnabled) return;
+    if (!shouldRunPeriodicMediaDedup(
+      lastRunMs: settings.lastMediaDedupAtMs,
+      nowMs: DateTime.now().millisecondsSinceEpoch,
+    )) {
+      return;
+    }
+    try {
+      final AnkiMediaDedupReport? report = await runNow(dryRun: false);
+      if (report != null) {
+        debugPrint('AnkiMediaDedupRunner.periodic: ${report.toJson()}');
+      }
+    } catch (e) {
+      debugPrint('AnkiMediaDedupRunner.periodic: skipped (unreachable?): $e');
+    }
+  }
+}

--- a/hibiki/lib/src/anki/anki_view_model.dart
+++ b/hibiki/lib/src/anki/anki_view_model.dart
@@ -272,12 +272,6 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
   /// 与当前仓库绑定的去重编排器（无状态，随用随建）。
   AnkiMediaDedupRunner get mediaDedupRunner =>
       AnkiMediaDedupRunner(_repository);
-
-  Future<void> setMediaDedupAutoEnabled(bool value) async {
-    final updated = await _repository
-        .updateSettings((s) => s.copyWith(mediaDedupAutoEnabled: value));
-    state = state.copyWith(settings: updated);
-  }
 }
 
 /// 把用户敲/粘进 AnkiConnect **主机**字段的自由文本规范化成裸主机 + 可选端口。

--- a/hibiki/lib/src/anki/anki_view_model.dart
+++ b/hibiki/lib/src/anki/anki_view_model.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:hibiki_anki/hibiki_anki.dart';
+import 'package:hibiki/src/anki/anki_media_dedup_runner.dart';
 import 'package:hibiki/src/anki/lapis_template_service.dart';
 import 'package:hibiki/src/anki/remote_mining_anki_repository.dart';
 import 'package:hibiki/src/models/app_model.dart';
@@ -261,6 +262,21 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
   Future<void> refreshSettingsFromStore() async {
     final settings = await _repository.loadSettings();
     state = state.copyWith(settings: settings);
+  }
+
+  // ── 媒体存储优化（字节级去重）──────────────────────────────────────
+
+  /// 当前后端能否做媒体去重（AnkiConnect 且与 Anki 同机；设置页据此隐藏区块）。
+  bool get supportsMediaMaintenance => _repository.supportsMediaMaintenance;
+
+  /// 与当前仓库绑定的去重编排器（无状态，随用随建）。
+  AnkiMediaDedupRunner get mediaDedupRunner =>
+      AnkiMediaDedupRunner(_repository);
+
+  Future<void> setMediaDedupAutoEnabled(bool value) async {
+    final updated = await _repository
+        .updateSettings((s) => s.copyWith(mediaDedupAutoEnabled: value));
+    state = state.copyWith(settings: updated);
   }
 }
 

--- a/hibiki/lib/src/anki/remote_mining_anki_repository.dart
+++ b/hibiki/lib/src/anki/remote_mining_anki_repository.dart
@@ -224,4 +224,15 @@ class RemoteMiningAnkiRepository extends BaseAnkiRepository {
   Future<bool> updateNoteTypeTemplates(
           String modelName, List<AnkiCardTemplate> templates) =>
       _local.updateNoteTypeTemplates(modelName, templates);
+
+  // 媒体去重同为配置/维护类：作用于本机 Anki，委派本地仓库。
+  @override
+  bool get supportsMediaMaintenance => _local.supportsMediaMaintenance;
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({
+    bool dryRun = false,
+    Future<void> Function(Map<String, dynamic> entry)? onJournal,
+  }) =>
+      _local.runMediaDedup(dryRun: dryRun, onJournal: onJournal);
 }

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -43,6 +43,9 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
   /// type，互斥防重入。
   bool _lapisBusy = false;
 
+  /// 媒体去重在途标记（扫描/执行互斥防重入）。
+  bool _dedupBusy = false;
+
   @override
   Widget build(BuildContext context) {
     final uiState = ref.watch(ankiViewModelProvider);
@@ -150,6 +153,44 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
                 showIcon: true,
                 title: t.anki_lapis_restore,
                 onTap: _lapisBusy ? null : () => _restoreLapisBackup(vm),
+              ),
+            ],
+          ),
+        // 媒体存储优化：字节级去重（只删字节相同的多余副本，绝不重编码）。
+        // 需要与 Anki 同机（本机可直读 collection.media），后端不支持时整区隐藏。
+        if (vm.supportsMediaMaintenance)
+          AdaptiveSettingsSection(
+            title: t.anki_dedup_section,
+            children: [
+              AdaptiveSettingsSwitchRow(
+                icon: Icons.filter_none_outlined,
+                showIcon: true,
+                title: t.anki_dedup_auto,
+                subtitle: t.anki_dedup_auto_hint,
+                value: settings.mediaDedupAutoEnabled,
+                onChanged: vm.setMediaDedupAutoEnabled,
+              ),
+              AdaptiveSettingsRow(
+                icon: Icons.search_outlined,
+                showIcon: true,
+                title: t.anki_dedup_scan,
+                trailing: _dedupBusy
+                    ? SizedBox(
+                        width: 20,
+                        height: 20,
+                        child:
+                            adaptiveIndicator(context: context, strokeWidth: 2),
+                      )
+                    : null,
+                onTap:
+                    _dedupBusy ? null : () => _runMediaDedup(vm, dryRun: true),
+              ),
+              AdaptiveSettingsRow(
+                icon: Icons.cleaning_services_outlined,
+                showIcon: true,
+                title: t.anki_dedup_run,
+                onTap:
+                    _dedupBusy ? null : () => _runMediaDedup(vm, dryRun: false),
               ),
             ],
           ),
@@ -603,6 +644,81 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
     } finally {
       if (mounted) setState(() => _lapisBusy = false);
     }
+  }
+
+  Future<void> _runMediaDedup(AnkiViewModel vm, {required bool dryRun}) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    if (!dryRun) {
+      final bool? ok = await showDialog<bool>(
+        context: context,
+        builder: (BuildContext context) => AlertDialog(
+          title: Text(t.anki_dedup_run),
+          content: Text(t.anki_dedup_run_confirm),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: Text(t.dialog_cancel),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: Text(t.dialog_ok),
+            ),
+          ],
+        ),
+      );
+      if (ok != true || !mounted) return;
+    }
+    setState(() => _dedupBusy = true);
+    final AnkiMediaDedupReport? report;
+    try {
+      report = await vm.mediaDedupRunner.runNow(dryRun: dryRun);
+    } catch (e) {
+      messenger.showSnackBar(
+          SnackBar(content: Text(t.anki_dedup_failed(error: '$e'))));
+      return;
+    } finally {
+      if (mounted) setState(() => _dedupBusy = false);
+    }
+    if (!mounted) return;
+    // try 块内赋值的局部变量 flow analysis 不做空促断：拷进非空局部再用。
+    final AnkiMediaDedupReport? nullable = report;
+    if (nullable == null) {
+      messenger.showSnackBar(SnackBar(content: Text(t.anki_dedup_unavailable)));
+      return;
+    }
+    final AnkiMediaDedupReport result = nullable;
+    final String body = result.groupCount == 0
+        ? t.anki_dedup_report_clean
+        : t.anki_dedup_report_body(
+            groups: '${result.groupCount}',
+            removed: '${result.duplicatesRemoved}',
+            size: _formatBytes(result.bytesSaved),
+            notes: '${result.notesRewritten}',
+            models: '${result.modelsRewritten}',
+            skipped: '${result.skipped}',
+          );
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: Text(t.anki_dedup_report_title),
+        content: Text(
+            result.dryRun ? '$body\n\n${t.anki_dedup_report_dry_note}' : body),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(t.dialog_ok),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _formatBytes(int bytes) {
+    if (bytes >= 1024 * 1024) {
+      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+    }
+    if (bytes >= 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    return '$bytes B';
   }
 
   /// 备份文件名 `lapis-<ISO时间戳(冒号→'-')>.json` → 本地可读时间标签；

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -158,18 +158,12 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
           ),
         // 媒体存储优化：字节级去重（只删字节相同的多余副本，绝不重编码）。
         // 需要与 Anki 同机（本机可直读 collection.media），后端不支持时整区隐藏。
+        // 用户拍板方案 A：**没有任何自动/周期路径**，只有这里的手动触发，且
+        // 真删前必须先看干跑清单并确认。
         if (vm.supportsMediaMaintenance)
           AdaptiveSettingsSection(
             title: t.anki_dedup_section,
             children: [
-              AdaptiveSettingsSwitchRow(
-                icon: Icons.filter_none_outlined,
-                showIcon: true,
-                title: t.anki_dedup_auto,
-                subtitle: t.anki_dedup_auto_hint,
-                value: settings.mediaDedupAutoEnabled,
-                onChanged: vm.setMediaDedupAutoEnabled,
-              ),
               AdaptiveSettingsRow(
                 icon: Icons.search_outlined,
                 showIcon: true,
@@ -182,15 +176,14 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
                             adaptiveIndicator(context: context, strokeWidth: 2),
                       )
                     : null,
-                onTap:
-                    _dedupBusy ? null : () => _runMediaDedup(vm, dryRun: true),
+                onTap: _dedupBusy ? null : () => _scanMediaDedup(vm),
               ),
               AdaptiveSettingsRow(
                 icon: Icons.cleaning_services_outlined,
                 showIcon: true,
                 title: t.anki_dedup_run,
-                onTap:
-                    _dedupBusy ? null : () => _runMediaDedup(vm, dryRun: false),
+                subtitle: t.anki_dedup_run_hint,
+                onTap: _dedupBusy ? null : () => _runMediaDedup(vm),
               ),
             ],
           ),
@@ -646,47 +639,129 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
     }
   }
 
-  Future<void> _runMediaDedup(AnkiViewModel vm, {required bool dryRun}) async {
+  /// 「扫描重复（不改动）」：只跑干跑并把清单摊给用户看，不提供删除按钮。
+  Future<void> _scanMediaDedup(AnkiViewModel vm) async {
+    final AnkiMediaDedupReport? plan = await _runDedupPass(vm, dryRun: true);
+    if (plan == null || !mounted) return;
+    await _showDedupPlanDialog(plan, offerDelete: false);
+  }
+
+  /// 「立即去重」：**永远先干跑**，把「删哪些文件、各占多少空间、保留的是哪
+  /// 一份」逐条列给用户；用户在弹窗里点确认之后才跑真删。用户没确认之前一个
+  /// 文件都不会动。
+  Future<void> _runMediaDedup(AnkiViewModel vm) async {
+    final AnkiMediaDedupReport? plan = await _runDedupPass(vm, dryRun: true);
+    if (plan == null || !mounted) return;
+    final bool confirmed = await _showDedupPlanDialog(plan, offerDelete: true);
+    if (!confirmed || !mounted) return;
+    final AnkiMediaDedupReport? result = await _runDedupPass(vm, dryRun: false);
+    if (result == null || !mounted) return;
+    await _showDedupReportDialog(result);
+  }
+
+  /// 跑一遍去重（干跑或真跑）。后端不支持 / 出错时给出提示并返回 null。
+  Future<AnkiMediaDedupReport?> _runDedupPass(
+    AnkiViewModel vm, {
+    required bool dryRun,
+  }) async {
     final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-    if (!dryRun) {
-      final bool? ok = await showDialog<bool>(
+    setState(() => _dedupBusy = true);
+    AnkiMediaDedupReport? report;
+    try {
+      report = await vm.mediaDedupRunner.runNow(dryRun: dryRun);
+    } catch (e) {
+      messenger.showSnackBar(
+          SnackBar(content: Text(t.anki_dedup_failed(error: '$e'))));
+      return null;
+    } finally {
+      if (mounted) setState(() => _dedupBusy = false);
+    }
+    if (report == null) {
+      messenger.showSnackBar(SnackBar(content: Text(t.anki_dedup_unavailable)));
+      return null;
+    }
+    return report;
+  }
+
+  /// 干跑清单弹窗。[offerDelete] = 提供「删除这些文件」确认按钮（返回 true 才
+  /// 执行真删）；false 时只是只读报告。没有可删的东西时不给删除按钮。
+  Future<bool> _showDedupPlanDialog(
+    AnkiMediaDedupReport plan, {
+    required bool offerDelete,
+  }) async {
+    if (plan.deletions.isEmpty) {
+      await showDialog<void>(
         context: context,
         builder: (BuildContext context) => AlertDialog(
-          title: Text(t.anki_dedup_run),
-          content: Text(t.anki_dedup_run_confirm),
+          title: Text(t.anki_dedup_plan_title),
+          content: Text(t.anki_dedup_report_clean),
           actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(t.dialog_ok),
+            ),
+          ],
+        ),
+      );
+      return false;
+    }
+    final bool? ok = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: Text(t.anki_dedup_plan_title),
+        content: SizedBox(
+          width: 420,
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(t.anki_dedup_plan_intro(
+                  count: '${plan.duplicatesRemoved}',
+                  size: _formatBytes(plan.bytesSaved),
+                )),
+                const SizedBox(height: 12),
+                for (final MediaDedupDeletion d in plan.deletions)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Text(t.anki_dedup_plan_entry(
+                      file: d.filename,
+                      size: _formatBytes(d.bytes),
+                      canonical: d.canonical,
+                    )),
+                  ),
+                const SizedBox(height: 12),
+                Text(offerDelete
+                    ? t.anki_dedup_plan_journal
+                    : t.anki_dedup_report_dry_note),
+              ],
+            ),
+          ),
+        ),
+        actions: [
+          if (!offerDelete)
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: Text(t.dialog_ok),
+            ),
+          if (offerDelete) ...[
             TextButton(
               onPressed: () => Navigator.pop(context, false),
               child: Text(t.dialog_cancel),
             ),
             TextButton(
               onPressed: () => Navigator.pop(context, true),
-              child: Text(t.dialog_ok),
+              child: Text(t.anki_dedup_plan_delete),
             ),
           ],
-        ),
-      );
-      if (ok != true || !mounted) return;
-    }
-    setState(() => _dedupBusy = true);
-    final AnkiMediaDedupReport? report;
-    try {
-      report = await vm.mediaDedupRunner.runNow(dryRun: dryRun);
-    } catch (e) {
-      messenger.showSnackBar(
-          SnackBar(content: Text(t.anki_dedup_failed(error: '$e'))));
-      return;
-    } finally {
-      if (mounted) setState(() => _dedupBusy = false);
-    }
-    if (!mounted) return;
-    // try 块内赋值的局部变量 flow analysis 不做空促断：拷进非空局部再用。
-    final AnkiMediaDedupReport? nullable = report;
-    if (nullable == null) {
-      messenger.showSnackBar(SnackBar(content: Text(t.anki_dedup_unavailable)));
-      return;
-    }
-    final AnkiMediaDedupReport result = nullable;
+        ],
+      ),
+    );
+    return ok == true;
+  }
+
+  /// 真跑之后的结果报告。
+  Future<void> _showDedupReportDialog(AnkiMediaDedupReport result) async {
     final String body = result.groupCount == 0
         ? t.anki_dedup_report_clean
         : t.anki_dedup_report_body(
@@ -701,8 +776,7 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       context: context,
       builder: (BuildContext context) => AlertDialog(
         title: Text(t.anki_dedup_report_title),
-        content: Text(
-            result.dryRun ? '$body\n\n${t.anki_dedup_report_dry_note}' : body),
+        content: Text(body),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),

--- a/hibiki/lib/src/pages/implementations/home_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_page.dart
@@ -14,7 +14,6 @@ import 'package:macos_ui/macos_ui.dart'
         MacosBackButton,
         MacosIcon;
 import 'package:flutter/services.dart' hide ModifierKey;
-import 'package:hibiki/src/anki/anki_media_dedup_runner.dart';
 import 'package:hibiki/src/anki/anki_view_model.dart'
     show ankiRepositoryProvider;
 import 'package:hibiki/src/anki/lapis_template_service.dart';
@@ -324,13 +323,6 @@ class _HomePageState extends BasePageState<HomePage>
             .maybeAutoMigrateOnStartup()
             .catchError((Object e, StackTrace s) {
           ErrorLogService.instance.log('HomePage.lapisAutoMigrate', e, s);
-        }));
-        // 媒体字节级去重周期触发（每 7 天，开关可关；只删字节相同的多余
-        // 副本，绝不重编码）。同为每进程一次、Anki 不可达静默跳过。
-        unawaited(AnkiMediaDedupRunner(ref.read(ankiRepositoryProvider))
-            .maybeRunPeriodic()
-            .catchError((Object e, StackTrace s) {
-          ErrorLogService.instance.log('HomePage.mediaDedupPeriodic', e, s);
         }));
       }
     });

--- a/hibiki/lib/src/pages/implementations/home_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_page.dart
@@ -14,6 +14,7 @@ import 'package:macos_ui/macos_ui.dart'
         MacosBackButton,
         MacosIcon;
 import 'package:flutter/services.dart' hide ModifierKey;
+import 'package:hibiki/src/anki/anki_media_dedup_runner.dart';
 import 'package:hibiki/src/anki/anki_view_model.dart'
     show ankiRepositoryProvider;
 import 'package:hibiki/src/anki/lapis_template_service.dart';
@@ -323,6 +324,13 @@ class _HomePageState extends BasePageState<HomePage>
             .maybeAutoMigrateOnStartup()
             .catchError((Object e, StackTrace s) {
           ErrorLogService.instance.log('HomePage.lapisAutoMigrate', e, s);
+        }));
+        // 媒体字节级去重周期触发（每 7 天，开关可关；只删字节相同的多余
+        // 副本，绝不重编码）。同为每进程一次、Anki 不可达静默跳过。
+        unawaited(AnkiMediaDedupRunner(ref.read(ankiRepositoryProvider))
+            .maybeRunPeriodic()
+            .catchError((Object e, StackTrace s) {
+          ErrorLogService.instance.log('HomePage.mediaDedupPeriodic', e, s);
         }));
       }
     });

--- a/hibiki/test/settings/settings_flatten_anki_profile_test.dart
+++ b/hibiki/test/settings/settings_flatten_anki_profile_test.dart
@@ -185,11 +185,11 @@ void main() {
     //    并入一个无条件显示的区块。未配置 Anki 时它们也都露出——故恰有三个 SwitchRow。
     //    TODO-1650 把旧「压缩制卡媒体」开关换成「图片/GIF 清晰度 + 音频质量」两滑块，
     //    紧随其后的独立无标题区（同样无条件显示）。
-    expect(find.byType(AdaptiveSettingsSwitchRow), findsNWidgets(4),
-        reason: 'TODO-135 方案A 三开关（hibiki / 来源分类 / 自动添加书名）+ 媒体去重'
-            '周期开关（AnkiConnect 桌面端露出），未配置 Anki 时都应显示（旧「压缩」'
-            '开关已换成两滑块，不再是 SwitchRow；「制卡到已配对设备」已移到 Hibiki '
-            '互联分类）');
+    expect(find.byType(AdaptiveSettingsSwitchRow), findsNWidgets(3),
+        reason: 'TODO-135 方案A 三开关（hibiki / 来源分类 / 自动添加书名），未配置 Anki '
+            '时都应显示（旧「压缩」开关已换成两滑块，不再是 SwitchRow；「制卡到已配对'
+            '设备」已移到 Hibiki 互联分类）。媒体去重区只有两个可点行、没有开关——'
+            '方案 A 没有任何自动/周期路径，不存在可拨的自动开关。');
     expect(find.byType(AdaptiveSettingsSliderRow), findsNWidgets(2),
         reason: 'TODO-1650「图片/GIF 清晰度」+「音频质量」两滑块应无条件显示');
     expect(find.textContaining('Image / GIF quality'), findsOneWidget,

--- a/hibiki/test/settings/settings_flatten_anki_profile_test.dart
+++ b/hibiki/test/settings/settings_flatten_anki_profile_test.dart
@@ -185,10 +185,11 @@ void main() {
     //    并入一个无条件显示的区块。未配置 Anki 时它们也都露出——故恰有三个 SwitchRow。
     //    TODO-1650 把旧「压缩制卡媒体」开关换成「图片/GIF 清晰度 + 音频质量」两滑块，
     //    紧随其后的独立无标题区（同样无条件显示）。
-    expect(find.byType(AdaptiveSettingsSwitchRow), findsNWidgets(3),
-        reason: 'TODO-135 方案A 三开关（hibiki / 来源分类 / 自动添加书名），未配置 Anki '
-            '时都应显示（旧「压缩」开关已换成两滑块，不再是 SwitchRow；「制卡到已配对'
-            '设备」已移到 Hibiki 互联分类）');
+    expect(find.byType(AdaptiveSettingsSwitchRow), findsNWidgets(4),
+        reason: 'TODO-135 方案A 三开关（hibiki / 来源分类 / 自动添加书名）+ 媒体去重'
+            '周期开关（AnkiConnect 桌面端露出），未配置 Anki 时都应显示（旧「压缩」'
+            '开关已换成两滑块，不再是 SwitchRow；「制卡到已配对设备」已移到 Hibiki '
+            '互联分类）');
     expect(find.byType(AdaptiveSettingsSliderRow), findsNWidgets(2),
         reason: 'TODO-1650「图片/GIF 清晰度」+「音频质量」两滑块应无条件显示');
     expect(find.textContaining('Image / GIF quality'), findsOneWidget,

--- a/hibiki/test/settings/settings_schema_coverage_test.dart
+++ b/hibiki/test/settings/settings_schema_coverage_test.dart
@@ -168,6 +168,12 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
       'packages/hibiki_anki/test/mining_tag_and_parallel_test.dart',
   'cardCreation/Add source category tag':
       'packages/hibiki_anki/test/mining_tag_and_parallel_test.dart',
+  // 媒体字节级去重周期开关：与上两行同理写 AnkiSettings（经 SharedPreferences，
+  // 非本测试的内存 DB），故 changed=false；周期判定/分组规划/引用改写行为本体
+  // 由 hibiki_anki 纯函数测试咬住，编排（journal + 时间戳 + 会话闸门）在
+  // AnkiMediaDedupRunner。
+  'cardCreation/Deduplicate media weekly':
+      'packages/hibiki_anki/test/anki_media_dedup_test.dart',
   // PR#343: 互联「制卡到服务端」开关。写 prefsRepo mine_to_server（changed=true），
   // 生效点在 ankiRepositoryProvider——开关开时把本地仓库包一层 RemoteMiningAnkiRepository，
   // mineEntry/isDuplicate 经互联链路转发到已配对主机（用主机 Anki 落卡），配置类方法仍委派

--- a/hibiki/test/settings/settings_schema_coverage_test.dart
+++ b/hibiki/test/settings/settings_schema_coverage_test.dart
@@ -168,12 +168,6 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
       'packages/hibiki_anki/test/mining_tag_and_parallel_test.dart',
   'cardCreation/Add source category tag':
       'packages/hibiki_anki/test/mining_tag_and_parallel_test.dart',
-  // 媒体字节级去重周期开关：与上两行同理写 AnkiSettings（经 SharedPreferences，
-  // 非本测试的内存 DB），故 changed=false；周期判定/分组规划/引用改写行为本体
-  // 由 hibiki_anki 纯函数测试咬住，编排（journal + 时间戳 + 会话闸门）在
-  // AnkiMediaDedupRunner。
-  'cardCreation/Deduplicate media weekly':
-      'packages/hibiki_anki/test/anki_media_dedup_test.dart',
   // PR#343: 互联「制卡到服务端」开关。写 prefsRepo mine_to_server（changed=true），
   // 生效点在 ankiRepositoryProvider——开关开时把本地仓库包一层 RemoteMiningAnkiRepository，
   // mineEntry/isDuplicate 经互联链路转发到已配对主机（用主机 Anki 落卡），配置类方法仍委派

--- a/packages/hibiki_anki/lib/hibiki_anki.dart
+++ b/packages/hibiki_anki/lib/hibiki_anki.dart
@@ -1,5 +1,6 @@
 library hibiki_anki;
 
+export 'src/anki_media_dedup.dart';
 export 'src/anki_models.dart';
 export 'src/anki_note_type_definition.dart';
 export 'src/base_anki_repository.dart';

--- a/packages/hibiki_anki/lib/src/anki_media_dedup.dart
+++ b/packages/hibiki_anki/lib/src/anki_media_dedup.dart
@@ -1,8 +1,9 @@
-/// Anki 媒体字节级去重的纯函数层：分组规划、规范名选择、引用改写、周期判定。
+/// Anki 媒体字节级去重的纯函数层：分组规划、规范名选择、引用改写/探测。
 ///
-/// 范围（用户拍板）：**只去重、只删字节完全相同的多余副本**——引用全部改指
-/// 到保留的那一份之后再删副本，零信息损失。**绝不重编码/压缩任何文件**
-/// （画质一个字节都不动），也不做按年龄的清理。
+/// 范围（用户拍板方案 A）：**默认不跑、手动触发、先出干跑报告让用户确认**；
+/// 只删字节完全相同的多余副本——引用全部改指到保留的那一份之后再删，零信息
+/// 损失。**绝不重编码/压缩任何文件**（画质一个字节都不动），也不做按年龄的
+/// 清理，更没有任何后台自动删除路径。
 ///
 /// 「重复代码」也天然覆盖：模板资产（`_` 前缀的 js/css/字体）同样按字节去重，
 /// 模板/styling 里的引用一并改写。
@@ -20,16 +21,54 @@ class MediaDedupGroup {
   final List<String> duplicates;
 }
 
-/// 从「文件名 → 内容哈希」规划去重组（哈希相同 = 字节相同；调用方只对
-/// 「大小相同的候选」计算哈希，这里不关心怎么算的）。单文件组不产出。
-/// 组内与组间均按文件名排序，输出确定性可测。
-List<MediaDedupGroup> planMediaDedupGroups(Map<String, String> nameToHash) {
-  final Map<String, List<String>> byHash = <String, List<String>>{};
+/// 一条「删除某个多余副本」的计划/结果：干跑时 = 将要删，实跑时 = 已删。
+///
+/// 用户确认弹窗直接渲染这个列表——「删哪些文件、各占多少空间、保留的是哪
+/// 一份」三样都在这里，用户点确认前心里有数。
+class MediaDedupDeletion {
+  const MediaDedupDeletion({
+    required this.filename,
+    required this.canonical,
+    required this.bytes,
+  });
+
+  /// 被删除（或将被删除）的多余副本文件名。
+  final String filename;
+
+  /// 保留下来的那一份文件名——所有引用都会改指到它。
+  final String canonical;
+
+  /// [filename] 占用的字节数（= 释放的空间）。
+  final int bytes;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'filename': filename,
+        'canonical': canonical,
+        'bytes': bytes,
+      };
+}
+
+/// 从「文件名 → 内容哈希」+「文件名 → 字节数」规划去重组。
+///
+/// 分组键是 **(字节数, 内容哈希)** 而不是裸哈希：调用方只对「大小相同的候选」
+/// 算哈希，长度本就是判等的一部分；把它显式并进分组键，即使调用方哪天喂进
+/// 跨大小的哈希表、或哈希被截断，也不可能把不同长度的文件归成一组。单文件组
+/// 不产出。组内与组间均按文件名排序，输出确定性可测。
+///
+/// [sizes] 必须覆盖 [nameToHash] 的每个键；缺失的条目直接丢弃（宁可不去重，
+/// 也不在长度未知的情况下判等）。
+List<MediaDedupGroup> planMediaDedupGroups(
+  Map<String, String> nameToHash, {
+  required Map<String, int> sizes,
+}) {
+  final Map<String, List<String>> byIdentity = <String, List<String>>{};
   for (final MapEntry<String, String> e in nameToHash.entries) {
-    byHash.putIfAbsent(e.value, () => <String>[]).add(e.key);
+    final int? size = sizes[e.key];
+    if (size == null) continue;
+    byIdentity.putIfAbsent('$size:${e.value}', () => <String>[]).add(e.key);
   }
   final List<MediaDedupGroup> groups = <MediaDedupGroup>[];
-  for (final List<String> names in byHash.values) {
+  for (final List<String> names in byIdentity.values) {
     if (names.length < 2) continue;
     final String canonical = chooseCanonicalMediaName(names);
     final List<String> dupes = (names.toList()..remove(canonical))..sort();
@@ -59,28 +98,55 @@ String chooseCanonicalMediaName(List<String> names) {
   return sorted.first;
 }
 
-/// 把文本（笔记字段 / 卡模板 / styling）里对 [from] 的引用改写为 [to]。
+/// 文件名边界安全的引用匹配正则：[filename] 前后都不能紧邻文件名合法字符
+/// （字母/数字/`.`/`_`/`-`），否则 `a.jpg` 会误伤 `ba.jpg` / `a.jpg.bak`。
 ///
-/// 只在**文件名边界**上替换：前后不能紧邻文件名合法字符（字母/数字/./_/-），
-/// 否则 `a.jpg` 会误伤 `ba.jpg` / `a.jpg.bak` 这类名字。覆盖
-/// `src="a.jpg"`、`[sound:a.jpg]`、`url(a.jpg)` 等全部引用形态（它们的边界
-/// 字符都不在文件名字符集里）。
+/// 覆盖 `src="a.jpg"`、`[sound:a.jpg]`、`url(a.jpg)`、`url("./a.jpg")`、
+/// `@import 'a.css'` 等全部引用形态——它们的边界字符（引号/括号/斜杠/冒号/
+/// 空白）都不在文件名字符集里。
+RegExp mediaReferencePattern(String filename) => RegExp(
+      '(?<![A-Za-z0-9._-])${RegExp.escape(filename)}(?![A-Za-z0-9._-])',
+    );
+
+/// 把文本（笔记字段 / 卡模板 / styling / 媒体文件正文）里对 [from] 的引用
+/// 改写为 [to]。只在文件名边界上替换，见 [mediaReferencePattern]。
 String rewriteMediaReferences(String text, String from, String to) {
   if (from == to || !text.contains(from)) return text;
-  final RegExp pattern = RegExp(
-    '(?<![A-Za-z0-9._-])${RegExp.escape(from)}(?![A-Za-z0-9._-])',
-  );
-  return text.replaceAll(pattern, to);
+  return text.replaceAll(mediaReferencePattern(from), to);
 }
 
-/// 周期去重的到期判定（默认每 7 天）。[lastRunMs] null = 从未跑过 → 到期。
-bool shouldRunPeriodicMediaDedup({
-  required int? lastRunMs,
-  required int nowMs,
-  Duration interval = const Duration(days: 7),
-}) {
-  if (lastRunMs == null) return true;
-  return nowMs - lastRunMs >= interval.inMilliseconds;
+/// [text] 里是否存在对 [filename] 的引用（边界安全，与 [rewriteMediaReferences]
+/// 同一判据——凡是会被改写的形态都能被探到）。
+bool textReferencesMediaName(String text, String filename) =>
+    text.contains(filename) && mediaReferencePattern(filename).hasMatch(text);
+
+/// 会在**媒体文件内部**携带对其它媒体文件引用的文本格式。
+///
+/// 必须扫这一层的根因：本模块优先保留 `_` 前缀的模板资产（见
+/// [chooseCanonicalMediaName]），而 `_x.css` 里的 `url(_font.woff2)` /
+/// `@import` 既不在笔记字段里、也不在卡模板/styling 里——只扫那三处会判定
+/// 「无引用」而把仍在用的字体静默删掉。
+///
+/// 只列真正会引用别的资源的文本格式：图片/音频/字体不引用别人，无需读盘；
+/// 这个集合直接决定去重要多读多少字节。
+const Set<String> kReferencingMediaExtensions = <String>{
+  'css',
+  'less',
+  'scss',
+  'js',
+  'mjs',
+  'html',
+  'htm',
+  'xhtml',
+  'svg',
+};
+
+/// [filename] 是否属于 [kReferencingMediaExtensions]（大小写不敏感）。
+bool isReferencingMediaFile(String filename) {
+  final int dot = filename.lastIndexOf('.');
+  if (dot < 0 || dot == filename.length - 1) return false;
+  return kReferencingMediaExtensions
+      .contains(filename.substring(dot + 1).toLowerCase());
 }
 
 /// 一轮去重的结果汇总（UI 报告 + 日志）。
@@ -88,8 +154,7 @@ class AnkiMediaDedupReport {
   const AnkiMediaDedupReport({
     required this.dryRun,
     required this.groupCount,
-    required this.duplicatesRemoved,
-    required this.bytesSaved,
+    required this.deletions,
     required this.notesRewritten,
     required this.modelsRewritten,
     required this.skipped,
@@ -101,11 +166,8 @@ class AnkiMediaDedupReport {
   /// 重复组数（每组 ≥2 个字节相同的文件）。
   final int groupCount;
 
-  /// 实际删除（dryRun 时 = 将会删除）的多余副本数。
-  final int duplicatesRemoved;
-
-  /// 删除副本释放（dryRun 时 = 将会释放）的字节数。
-  final int bytesSaved;
+  /// 实际删除（[dryRun] 时 = 将会删除）的多余副本逐条明细。
+  final List<MediaDedupDeletion> deletions;
 
   /// 引用被改写的笔记数（去重计数）。
   final int notesRewritten;
@@ -116,6 +178,13 @@ class AnkiMediaDedupReport {
   /// 因引用清不干净等原因跳过删除的副本数（宁可留着也不冒险）。
   final int skipped;
 
+  /// 实际删除（[dryRun] 时 = 将会删除）的多余副本数。
+  int get duplicatesRemoved => deletions.length;
+
+  /// 删除副本释放（[dryRun] 时 = 将会释放）的字节数。
+  int get bytesSaved =>
+      deletions.fold<int>(0, (int sum, MediaDedupDeletion d) => sum + d.bytes);
+
   Map<String, dynamic> toJson() => <String, dynamic>{
         'dryRun': dryRun,
         'groupCount': groupCount,
@@ -124,5 +193,8 @@ class AnkiMediaDedupReport {
         'notesRewritten': notesRewritten,
         'modelsRewritten': modelsRewritten,
         'skipped': skipped,
+        'deletions': deletions
+            .map((MediaDedupDeletion d) => d.toJson())
+            .toList(growable: false),
       };
 }

--- a/packages/hibiki_anki/lib/src/anki_media_dedup.dart
+++ b/packages/hibiki_anki/lib/src/anki_media_dedup.dart
@@ -1,0 +1,128 @@
+/// Anki 媒体字节级去重的纯函数层：分组规划、规范名选择、引用改写、周期判定。
+///
+/// 范围（用户拍板）：**只去重、只删字节完全相同的多余副本**——引用全部改指
+/// 到保留的那一份之后再删副本，零信息损失。**绝不重编码/压缩任何文件**
+/// （画质一个字节都不动），也不做按年龄的清理。
+///
+/// 「重复代码」也天然覆盖：模板资产（`_` 前缀的 js/css/字体）同样按字节去重，
+/// 模板/styling 里的引用一并改写。
+///
+/// IO 编排（扫描媒体目录 / 改笔记 / 删文件）在 AnkiConnectRepository；本文件
+/// 全部纯函数，可单测。
+library;
+
+/// 一组字节完全相同的媒体文件：保留 [canonical]，[duplicates] 在引用改写
+/// 干净后删除。
+class MediaDedupGroup {
+  const MediaDedupGroup({required this.canonical, required this.duplicates});
+
+  final String canonical;
+  final List<String> duplicates;
+}
+
+/// 从「文件名 → 内容哈希」规划去重组（哈希相同 = 字节相同；调用方只对
+/// 「大小相同的候选」计算哈希，这里不关心怎么算的）。单文件组不产出。
+/// 组内与组间均按文件名排序，输出确定性可测。
+List<MediaDedupGroup> planMediaDedupGroups(Map<String, String> nameToHash) {
+  final Map<String, List<String>> byHash = <String, List<String>>{};
+  for (final MapEntry<String, String> e in nameToHash.entries) {
+    byHash.putIfAbsent(e.value, () => <String>[]).add(e.key);
+  }
+  final List<MediaDedupGroup> groups = <MediaDedupGroup>[];
+  for (final List<String> names in byHash.values) {
+    if (names.length < 2) continue;
+    final String canonical = chooseCanonicalMediaName(names);
+    final List<String> dupes = (names.toList()..remove(canonical))..sort();
+    groups.add(MediaDedupGroup(canonical: canonical, duplicates: dupes));
+  }
+  groups.sort((MediaDedupGroup a, MediaDedupGroup b) =>
+      a.canonical.compareTo(b.canonical));
+  return groups;
+}
+
+/// 选保留哪一份：
+/// 1. `_` 前缀优先——Anki 的「检查媒体」不会把 `_` 前缀文件当未使用清掉，
+///    模板资产（js/css/字体）只有保留 `_` 名才安全；
+/// 2. 其余取最短文件名（内容寻址的长哈希名与人类命名并存时留人类可读性
+///    不重要，短名减少字段体积）；
+/// 3. 平手取字典序最小，保证确定性。
+String chooseCanonicalMediaName(List<String> names) {
+  assert(names.isNotEmpty);
+  final List<String> sorted = names.toList()
+    ..sort((String a, String b) {
+      final bool ua = a.startsWith('_');
+      final bool ub = b.startsWith('_');
+      if (ua != ub) return ua ? -1 : 1;
+      if (a.length != b.length) return a.length - b.length;
+      return a.compareTo(b);
+    });
+  return sorted.first;
+}
+
+/// 把文本（笔记字段 / 卡模板 / styling）里对 [from] 的引用改写为 [to]。
+///
+/// 只在**文件名边界**上替换：前后不能紧邻文件名合法字符（字母/数字/./_/-），
+/// 否则 `a.jpg` 会误伤 `ba.jpg` / `a.jpg.bak` 这类名字。覆盖
+/// `src="a.jpg"`、`[sound:a.jpg]`、`url(a.jpg)` 等全部引用形态（它们的边界
+/// 字符都不在文件名字符集里）。
+String rewriteMediaReferences(String text, String from, String to) {
+  if (from == to || !text.contains(from)) return text;
+  final RegExp pattern = RegExp(
+    '(?<![A-Za-z0-9._-])${RegExp.escape(from)}(?![A-Za-z0-9._-])',
+  );
+  return text.replaceAll(pattern, to);
+}
+
+/// 周期去重的到期判定（默认每 7 天）。[lastRunMs] null = 从未跑过 → 到期。
+bool shouldRunPeriodicMediaDedup({
+  required int? lastRunMs,
+  required int nowMs,
+  Duration interval = const Duration(days: 7),
+}) {
+  if (lastRunMs == null) return true;
+  return nowMs - lastRunMs >= interval.inMilliseconds;
+}
+
+/// 一轮去重的结果汇总（UI 报告 + 日志）。
+class AnkiMediaDedupReport {
+  const AnkiMediaDedupReport({
+    required this.dryRun,
+    required this.groupCount,
+    required this.duplicatesRemoved,
+    required this.bytesSaved,
+    required this.notesRewritten,
+    required this.modelsRewritten,
+    required this.skipped,
+  });
+
+  /// true = 只扫描规划，没有改写/删除任何东西。
+  final bool dryRun;
+
+  /// 重复组数（每组 ≥2 个字节相同的文件）。
+  final int groupCount;
+
+  /// 实际删除（dryRun 时 = 将会删除）的多余副本数。
+  final int duplicatesRemoved;
+
+  /// 删除副本释放（dryRun 时 = 将会释放）的字节数。
+  final int bytesSaved;
+
+  /// 引用被改写的笔记数（去重计数）。
+  final int notesRewritten;
+
+  /// 模板/styling 被改写的 note type 数。
+  final int modelsRewritten;
+
+  /// 因引用清不干净等原因跳过删除的副本数（宁可留着也不冒险）。
+  final int skipped;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'dryRun': dryRun,
+        'groupCount': groupCount,
+        'duplicatesRemoved': duplicatesRemoved,
+        'bytesSaved': bytesSaved,
+        'notesRewritten': notesRewritten,
+        'modelsRewritten': modelsRewritten,
+        'skipped': skipped,
+      };
+}

--- a/packages/hibiki_anki/lib/src/anki_models.dart
+++ b/packages/hibiki_anki/lib/src/anki_models.dart
@@ -172,7 +172,6 @@ class AnkiSettings {
     this.lapisFontScalePercent = 100,
     this.lapisCustomCss = '',
     this.lapisAppliedCssSha,
-    this.mediaDedupAutoEnabled = true,
     this.lastMediaDedupAtMs,
   });
 
@@ -207,7 +206,6 @@ class AnkiSettings {
         lapisFontScalePercent: json['lapisFontScalePercent'] as int? ?? 100,
         lapisCustomCss: json['lapisCustomCss'] as String? ?? '',
         lapisAppliedCssSha: json['lapisAppliedCssSha'] as String?,
-        mediaDedupAutoEnabled: json['mediaDedupAutoEnabled'] as bool? ?? true,
         lastMediaDedupAtMs: json['lastMediaDedupAtMs'] as int?,
       );
   final int? selectedDeckId;
@@ -252,11 +250,10 @@ class AnkiSettings {
   /// 与「被用户手改（不得静默覆盖）」。
   final String? lapisAppliedCssSha;
 
-  /// 是否启用每 7 天一次的媒体字节级去重（只删字节完全相同的多余副本，
-  /// 引用改写干净后才删；绝不重编码）。
-  final bool mediaDedupAutoEnabled;
-
-  /// 上次媒体去重完成时刻（epoch ms）。null = 从未跑过。
+  /// 上次媒体字节级去重完成时刻（epoch ms）。null = 从未跑过。
+  ///
+  /// 去重**只有用户在设置页手动触发**这一条路径（先出干跑报告、确认后才删），
+  /// 没有任何后台自动调度；这个时刻只是「上次跑过」的记录。
   final int? lastMediaDedupAtMs;
 
   bool get isConfigured => selectedDeckId != null && selectedNoteTypeId != null;
@@ -291,7 +288,6 @@ class AnkiSettings {
     String? lapisCustomCss,
     String? lapisAppliedCssSha,
     bool clearLapisAppliedCssSha = false,
-    bool? mediaDedupAutoEnabled,
     int? lastMediaDedupAtMs,
   }) =>
       AnkiSettings(
@@ -321,8 +317,6 @@ class AnkiSettings {
         lapisAppliedCssSha: clearLapisAppliedCssSha
             ? null
             : (lapisAppliedCssSha ?? this.lapisAppliedCssSha),
-        mediaDedupAutoEnabled:
-            mediaDedupAutoEnabled ?? this.mediaDedupAutoEnabled,
         lastMediaDedupAtMs: lastMediaDedupAtMs ?? this.lastMediaDedupAtMs,
       );
 
@@ -349,7 +343,6 @@ class AnkiSettings {
         'lapisFontScalePercent': lapisFontScalePercent,
         'lapisCustomCss': lapisCustomCss,
         'lapisAppliedCssSha': lapisAppliedCssSha,
-        'mediaDedupAutoEnabled': mediaDedupAutoEnabled,
         'lastMediaDedupAtMs': lastMediaDedupAtMs,
       };
 }

--- a/packages/hibiki_anki/lib/src/anki_models.dart
+++ b/packages/hibiki_anki/lib/src/anki_models.dart
@@ -172,6 +172,8 @@ class AnkiSettings {
     this.lapisFontScalePercent = 100,
     this.lapisCustomCss = '',
     this.lapisAppliedCssSha,
+    this.mediaDedupAutoEnabled = true,
+    this.lastMediaDedupAtMs,
   });
 
   factory AnkiSettings.fromJson(Map<String, dynamic> json) => AnkiSettings(
@@ -205,6 +207,8 @@ class AnkiSettings {
         lapisFontScalePercent: json['lapisFontScalePercent'] as int? ?? 100,
         lapisCustomCss: json['lapisCustomCss'] as String? ?? '',
         lapisAppliedCssSha: json['lapisAppliedCssSha'] as String?,
+        mediaDedupAutoEnabled: json['mediaDedupAutoEnabled'] as bool? ?? true,
+        lastMediaDedupAtMs: json['lastMediaDedupAtMs'] as int?,
       );
   final int? selectedDeckId;
   final String? selectedDeckName;
@@ -248,6 +252,13 @@ class AnkiSettings {
   /// 与「被用户手改（不得静默覆盖）」。
   final String? lapisAppliedCssSha;
 
+  /// 是否启用每 7 天一次的媒体字节级去重（只删字节完全相同的多余副本，
+  /// 引用改写干净后才删；绝不重编码）。
+  final bool mediaDedupAutoEnabled;
+
+  /// 上次媒体去重完成时刻（epoch ms）。null = 从未跑过。
+  final int? lastMediaDedupAtMs;
+
   bool get isConfigured => selectedDeckId != null && selectedNoteTypeId != null;
 
   AnkiNoteType? get selectedNoteType =>
@@ -280,6 +291,8 @@ class AnkiSettings {
     String? lapisCustomCss,
     String? lapisAppliedCssSha,
     bool clearLapisAppliedCssSha = false,
+    bool? mediaDedupAutoEnabled,
+    int? lastMediaDedupAtMs,
   }) =>
       AnkiSettings(
         selectedDeckId: selectedDeckId ?? this.selectedDeckId,
@@ -308,6 +321,9 @@ class AnkiSettings {
         lapisAppliedCssSha: clearLapisAppliedCssSha
             ? null
             : (lapisAppliedCssSha ?? this.lapisAppliedCssSha),
+        mediaDedupAutoEnabled:
+            mediaDedupAutoEnabled ?? this.mediaDedupAutoEnabled,
+        lastMediaDedupAtMs: lastMediaDedupAtMs ?? this.lastMediaDedupAtMs,
       );
 
   Map<String, dynamic> toJson() => {
@@ -333,6 +349,8 @@ class AnkiSettings {
         'lapisFontScalePercent': lapisFontScalePercent,
         'lapisCustomCss': lapisCustomCss,
         'lapisAppliedCssSha': lapisAppliedCssSha,
+        'mediaDedupAutoEnabled': mediaDedupAutoEnabled,
+        'lastMediaDedupAtMs': lastMediaDedupAtMs,
       };
 }
 

--- a/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -4,9 +4,11 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:collection/collection.dart';
+import 'package:crypto/crypto.dart' as crypto;
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
+import '../anki_media_dedup.dart';
 import '../anki_models.dart';
 import '../anki_note_type_definition.dart';
 import '../base_anki_repository.dart';
@@ -921,6 +923,178 @@ class AnkiConnectRepository extends BaseAnkiRepository {
     final service = await _getService();
     await service.updateModelTemplates(modelName, templates);
     return true;
+  }
+
+  // ── 媒体存储优化（字节级去重）──────────────────────────────────────
+
+  @override
+  bool get supportsMediaMaintenance => true;
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({
+    bool dryRun = false,
+    Future<void> Function(Map<String, dynamic> entry)? onJournal,
+  }) async {
+    final service = await _getService();
+    final String mediaPath = await service.getMediaDirPath();
+    final Directory mediaDir = Directory(mediaPath);
+    // AnkiConnect 在远程主机上时拿到的路径本机不存在——按不支持处理，绝不
+    // 盲扫错误目录。
+    if (!mediaDir.existsSync()) return null;
+
+    // 1) 按大小初筛（大小不同不可能字节相同），只对大小撞车的候选算 sha256。
+    final Map<String, int> sizes = <String, int>{};
+    await for (final FileSystemEntity entity
+        in mediaDir.list(followLinks: false)) {
+      if (entity is! File) continue;
+      final String name = entity.uri.pathSegments.last;
+      if (name.isEmpty) continue;
+      sizes[name] = await entity.length();
+    }
+    final Map<int, List<String>> bySize = <int, List<String>>{};
+    sizes.forEach(
+        (String n, int s) => bySize.putIfAbsent(s, () => <String>[]).add(n));
+    final Map<String, String> nameToHash = <String, String>{};
+    for (final MapEntry<int, List<String>> entry in bySize.entries) {
+      if (entry.value.length < 2) continue;
+      for (final String name in entry.value) {
+        final Uint8List bytes =
+            await File('${mediaDir.path}${Platform.pathSeparator}$name')
+                .readAsBytes();
+        nameToHash[name] = crypto.sha256.convert(bytes).toString();
+      }
+    }
+    final List<MediaDedupGroup> groups = planMediaDedupGroups(nameToHash);
+
+    // 2) 模板/styling 快照一次抓全（随改写更新，避免每个副本重复拉取）。
+    final List<String> modelNames = await service.getModelNames();
+    final Map<String, List<AnkiCardTemplate>> modelTemplates =
+        <String, List<AnkiCardTemplate>>{};
+    final Map<String, String> modelCss = <String, String>{};
+    for (final String m in modelNames) {
+      modelTemplates[m] = await service.modelTemplates(m);
+      modelCss[m] = await service.modelStyling(m);
+    }
+
+    int duplicatesRemoved = 0;
+    int bytesSaved = 0;
+    int skippedCount = 0;
+    final Set<int> notesRewritten = <int>{};
+    final Set<String> modelsRewritten = <String>{};
+
+    for (final MediaDedupGroup group in groups) {
+      for (final String dupe in group.duplicates) {
+        // 保守原则：任何一处引用改不干净就不删这份副本（宁可留着）。
+        bool cleanupOk = true;
+
+        // a) 笔记字段引用：全库文本检索该文件名 → 边界安全改写。
+        final List<int> ids = await service.findNotesByQuery('"$dupe"');
+        for (final int id in ids) {
+          final Map<String, String>? fields = await service.notesInfo(id);
+          if (fields == null) {
+            cleanupOk = false;
+            continue;
+          }
+          final Map<String, String> changed = <String, String>{};
+          final Map<String, String> before = <String, String>{};
+          fields.forEach((String key, String value) {
+            final String rewritten =
+                rewriteMediaReferences(value, dupe, group.canonical);
+            if (rewritten != value) {
+              changed[key] = rewritten;
+              before[key] = value;
+            }
+          });
+          if (changed.isEmpty) {
+            // 检索命中但边界改写不动它：引用形态无法识别（或恰是别的更长
+            // 文件名的子串，检索分不出来）——不删这份副本。
+            cleanupOk = false;
+            continue;
+          }
+          if (!dryRun) {
+            await onJournal?.call(<String, dynamic>{
+              'type': 'noteFields',
+              'noteId': id,
+              'from': dupe,
+              'to': group.canonical,
+              'before': before,
+            });
+            await service.updateNoteFields(id, changed);
+          }
+          notesRewritten.add(id);
+        }
+
+        // b) 卡模板/styling 引用（模板资产 js/css/字体的「重复代码」走这里）。
+        for (final String m in modelNames) {
+          final List<AnkiCardTemplate> tmpls = modelTemplates[m]!;
+          bool templatesChanged = false;
+          final List<AnkiCardTemplate> newTmpls =
+              tmpls.map((AnkiCardTemplate tpl) {
+            final String front =
+                rewriteMediaReferences(tpl.front, dupe, group.canonical);
+            final String back =
+                rewriteMediaReferences(tpl.back, dupe, group.canonical);
+            if (front != tpl.front || back != tpl.back) {
+              templatesChanged = true;
+            }
+            return AnkiCardTemplate(name: tpl.name, front: front, back: back);
+          }).toList();
+          final String css = modelCss[m]!;
+          final String newCss =
+              rewriteMediaReferences(css, dupe, group.canonical);
+          final bool cssChanged = newCss != css;
+          if (!templatesChanged && !cssChanged) continue;
+          if (!dryRun) {
+            await onJournal?.call(<String, dynamic>{
+              'type': 'model',
+              'model': m,
+              'from': dupe,
+              'to': group.canonical,
+            });
+            if (templatesChanged) {
+              await service.updateModelTemplates(m, newTmpls);
+            }
+            if (cssChanged) await service.updateModelStyling(m, newCss);
+          }
+          modelTemplates[m] = newTmpls;
+          modelCss[m] = newCss;
+          modelsRewritten.add(m);
+        }
+
+        // c) 复核干净才删；dryRun 只计数。
+        if (dryRun) {
+          if (!cleanupOk) {
+            skippedCount++;
+            continue;
+          }
+        } else {
+          final List<int> remaining = await service.findNotesByQuery('"$dupe"');
+          if (!cleanupOk || remaining.isNotEmpty) {
+            skippedCount++;
+            continue;
+          }
+          await onJournal?.call(<String, dynamic>{
+            'type': 'delete',
+            'filename': dupe,
+            'canonical': group.canonical,
+            'bytes': sizes[dupe],
+          });
+          await service.deleteMediaFile(dupe);
+        }
+        duplicatesRemoved++;
+        bytesSaved += sizes[dupe] ?? 0;
+      }
+    }
+
+    return AnkiMediaDedupReport(
+      dryRun: dryRun,
+      groupCount: groups.length,
+      duplicatesRemoved: duplicatesRemoved,
+      bytesSaved: bytesSaved,
+      notesRewritten: notesRewritten.length,
+      modelsRewritten: modelsRewritten.length,
+      skipped: skippedCount,
+    );
   }
 
   Future<String?> _storeLocalMedia(

--- a/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -13,6 +13,7 @@ import '../anki_models.dart';
 import '../anki_note_type_definition.dart';
 import '../base_anki_repository.dart';
 import '../lapis_note_type.dart';
+import '../lapis_styling.dart';
 import 'ankiconnect_service.dart';
 
 const int _uint32Mask = 0xffffffff;
@@ -271,6 +272,15 @@ String _sha256Hex(List<int> bytes) {
 
 int _rotr32(int value, int shift) =>
     ((value >> shift) | (value << (32 - shift))) & _uint32Mask;
+
+/// 一条笔记的字段改写计划：[before] 是改写前的原值（journal 用来回溯），
+/// [after] 是要写进 Anki 的新值。两者键集相同，只含真正会变的字段。
+class _NoteFieldRewrite {
+  const _NoteFieldRewrite({required this.before, required this.after});
+
+  final Map<String, String> before;
+  final Map<String, String> after;
+}
 
 class AnkiConnectRepository extends BaseAnkiRepository {
   AnkiConnectRepository({AnkiConnectService? service})
@@ -930,19 +940,12 @@ class AnkiConnectRepository extends BaseAnkiRepository {
   @override
   bool get supportsMediaMaintenance => true;
 
-  @override
-  Future<AnkiMediaDedupReport?> runMediaDedup({
-    bool dryRun = false,
-    Future<void> Function(Map<String, dynamic> entry)? onJournal,
-  }) async {
-    final service = await _getService();
-    final String mediaPath = await service.getMediaDirPath();
-    final Directory mediaDir = Directory(mediaPath);
-    // AnkiConnect 在远程主机上时拿到的路径本机不存在——按不支持处理，绝不
-    // 盲扫错误目录。
-    if (!mediaDir.existsSync()) return null;
+  /// 媒体目录里的一个文件（媒体目录是扁平的，文件名即相对路径）。
+  File _mediaFile(Directory mediaDir, String name) =>
+      File('${mediaDir.path}${Platform.pathSeparator}$name');
 
-    // 1) 按大小初筛（大小不同不可能字节相同），只对大小撞车的候选算 sha256。
+  /// 媒体目录里每个文件的字节数（只 stat，不读内容）。
+  Future<Map<String, int>> _scanMediaSizes(Directory mediaDir) async {
     final Map<String, int> sizes = <String, int>{};
     await for (final FileSystemEntity entity
         in mediaDir.list(followLinks: false)) {
@@ -951,6 +954,15 @@ class AnkiConnectRepository extends BaseAnkiRepository {
       if (name.isEmpty) continue;
       sizes[name] = await entity.length();
     }
+    return sizes;
+  }
+
+  /// 只对「大小撞车」的候选算**全文件** sha256（大小不同不可能字节相同）。
+  /// 判等永远是全文件哈希 + 删除前逐字节复核，绝不用截断哈希或感知哈希。
+  Future<Map<String, String>> _hashSizeCollisions(
+    Directory mediaDir,
+    Map<String, int> sizes,
+  ) async {
     final Map<int, List<String>> bySize = <int, List<String>>{};
     sizes.forEach(
         (String n, int s) => bySize.putIfAbsent(s, () => <String>[]).add(n));
@@ -958,15 +970,144 @@ class AnkiConnectRepository extends BaseAnkiRepository {
     for (final MapEntry<int, List<String>> entry in bySize.entries) {
       if (entry.value.length < 2) continue;
       for (final String name in entry.value) {
-        final Uint8List bytes =
-            await File('${mediaDir.path}${Platform.pathSeparator}$name')
-                .readAsBytes();
+        final Uint8List bytes = await _mediaFile(mediaDir, name).readAsBytes();
         nameToHash[name] = crypto.sha256.convert(bytes).toString();
       }
     }
-    final List<MediaDedupGroup> groups = planMediaDedupGroups(nameToHash);
+    return nameToHash;
+  }
 
-    // 2) 模板/styling 快照一次抓全（随改写更新，避免每个副本重复拉取）。
+  /// 读出所有「会引用别的资源」的文本媒体（css/js/html/svg…）正文。
+  ///
+  /// 这是引用扫描的第四个面（前三个是笔记字段 / 卡模板 / styling）。缺了它，
+  /// `_x.css` 里的 `url(_font.woff2)` 谁都查不到，而本模块又恰好优先保留 `_`
+  /// 前缀资产，结果就是把仍在用的字体静默删掉。
+  ///
+  /// 用 `allowMalformed` 解码：正文可能不是合法 UTF-8（半个序列/别的编码），
+  /// 解不动的部分变成替换字符，绝不因为一个坏文件抛异常中断整轮。
+  Future<Map<String, String>> _readReferencingMedia(
+    Directory mediaDir,
+    Iterable<String> names,
+  ) async {
+    final Map<String, String> out = <String, String>{};
+    for (final String name in names) {
+      if (!isReferencingMediaFile(name)) continue;
+      final File file = _mediaFile(mediaDir, name);
+      if (!file.existsSync()) continue;
+      out[name] = utf8.decode(await file.readAsBytes(), allowMalformed: true);
+    }
+    return out;
+  }
+
+  /// 删除前的最后一道闸：把副本与保留份**逐字节**比一遍。
+  ///
+  /// 哈希已经是全文件 sha256，这一步兜的是「扫描完到删除前文件被改动」的时间
+  /// 差，以及任何哈希实现被换弱时的兜底。读不到或有一个字节不同就绝不删。
+  Future<bool> _mediaBytesIdentical(
+    Directory mediaDir,
+    String a,
+    String b,
+  ) async {
+    final File fa = _mediaFile(mediaDir, a);
+    final File fb = _mediaFile(mediaDir, b);
+    if (!fa.existsSync() || !fb.existsSync()) return false;
+    final Uint8List ba = await fa.readAsBytes();
+    final Uint8List bb = await fb.readAsBytes();
+    if (ba.length != bb.length) return false;
+    for (int i = 0; i < ba.length; i++) {
+      if (ba[i] != bb[i]) return false;
+    }
+    return true;
+  }
+
+  /// styling 被去重改写后，把 Lapis 客制化指纹跟着对齐。
+  ///
+  /// 根因：`decideLapisStylingAction` 用 `lapisAppliedCssSha` 认「Anki 端这份
+  /// CSS 是 Hibiki 自己推的产物」。去重改写 styling 后 Anki 端内容变了而指纹
+  /// 没变，判定退化成 `foreignEdit` —— Lapis 的启动自动迁移从此**永久停手**，
+  /// 用户完全无感知（模板再也不自动更新）。改写的确实是 Hibiki 自己的产物，
+  /// 指纹理应跟着走。
+  ///
+  /// 只在改写前的内容确实等于已记录指纹时才对齐：本来就是用户手改（指纹对
+  /// 不上）就保持对不上，不伪造一个「这是我推的」。
+  Future<void> _realignLapisCssShaAfterRewrite({
+    required String modelName,
+    required String cssBefore,
+    required String cssAfter,
+  }) async {
+    if (modelName != LapisNoteType.modelName) return;
+    final AnkiSettings settings = await loadSettings();
+    final String? recorded = settings.lapisAppliedCssSha;
+    if (recorded == null || recorded != lapisCssSha256(cssBefore)) return;
+    await updateSettings((AnkiSettings s) =>
+        s.copyWith(lapisAppliedCssSha: lapisCssSha256(cssAfter)));
+  }
+
+  /// 一条笔记的字段改写计划（null = 这条笔记清不干净，整份副本不许删）。
+  Future<_NoteFieldRewrite?> _planNoteFieldRewrite(
+    AnkiConnectService service,
+    int noteId,
+    String dupe,
+    String canonical,
+  ) async {
+    final Map<String, String>? fields = await service.notesInfo(noteId);
+    if (fields == null) return null;
+    final Map<String, String> before = <String, String>{};
+    final Map<String, String> after = <String, String>{};
+    fields.forEach((String key, String value) {
+      final String rewritten = rewriteMediaReferences(value, dupe, canonical);
+      if (rewritten == value) return;
+      before[key] = value;
+      after[key] = rewritten;
+    });
+    // 检索命中却一处也改不动：引用形态无法识别（或恰是别的更长文件名的子串，
+    // 检索分不出来）——不删这份副本。
+    if (after.isEmpty) return null;
+    return _NoteFieldRewrite(before: before, after: after);
+  }
+
+  /// 干跑用：哪些 note type 的模板/styling 引用了 [dupe]（不改写，只统计）。
+  Set<String> _modelsReferencing(
+    List<String> modelNames,
+    Map<String, List<AnkiCardTemplate>> modelTemplates,
+    Map<String, String> modelCss,
+    String dupe,
+  ) {
+    final Set<String> hits = <String>{};
+    for (final String m in modelNames) {
+      final bool inTemplates = modelTemplates[m]!.any((AnkiCardTemplate tpl) =>
+          textReferencesMediaName(tpl.front, dupe) ||
+          textReferencesMediaName(tpl.back, dupe));
+      if (inTemplates || textReferencesMediaName(modelCss[m]!, dupe)) {
+        hits.add(m);
+      }
+    }
+    return hits;
+  }
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({
+    bool dryRun = false,
+    Future<void> Function(Map<String, dynamic> entry)? onJournal,
+  }) async {
+    final AnkiConnectService service = await _getService();
+    final String mediaPath = await service.getMediaDirPath();
+    final Directory mediaDir = Directory(mediaPath);
+    // AnkiConnect 在远程主机上时拿到的路径本机不存在——按不支持处理，绝不
+    // 盲扫错误目录。
+    if (!mediaDir.existsSync()) return null;
+
+    final Map<String, int> sizes = await _scanMediaSizes(mediaDir);
+    final List<MediaDedupGroup> groups = planMediaDedupGroups(
+      await _hashSizeCollisions(mediaDir, sizes),
+      sizes: sizes,
+    );
+    // 媒体文件**内部**的引用只作为「不许删」的证据：本轮不改写媒体正文，
+    // 所以只要还有人从里面引用，这份副本就留着。
+    final Map<String, String> referencingMedia =
+        await _readReferencingMedia(mediaDir, sizes.keys);
+
+    // 模板/styling 快照一次抓全（随改写更新，避免每个副本重复拉取）。
     final List<String> modelNames = await service.getModelNames();
     final Map<String, List<AnkiCardTemplate>> modelTemplates =
         <String, List<AnkiCardTemplate>>{};
@@ -976,55 +1117,85 @@ class AnkiConnectRepository extends BaseAnkiRepository {
       modelCss[m] = await service.modelStyling(m);
     }
 
-    int duplicatesRemoved = 0;
-    int bytesSaved = 0;
     int skippedCount = 0;
+    final List<MediaDedupDeletion> deletions = <MediaDedupDeletion>[];
     final Set<int> notesRewritten = <int>{};
     final Set<String> modelsRewritten = <String>{};
 
     for (final MediaDedupGroup group in groups) {
       for (final String dupe in group.duplicates) {
-        // 保守原则：任何一处引用改不干净就不删这份副本（宁可留着）。
-        bool cleanupOk = true;
-
-        // a) 笔记字段引用：全库文本检索该文件名 → 边界安全改写。
-        final List<int> ids = await service.findNotesByQuery('"$dupe"');
-        for (final int id in ids) {
-          final Map<String, String>? fields = await service.notesInfo(id);
-          if (fields == null) {
-            cleanupOk = false;
+        // ── 阶段一：全部判定与计划，一个字节都不写 ────────────────────
+        // 顺序是刻意的：先把所有「不许删」的证据收齐再动手。上一版把模板/
+        // styling 改写放在判定之前，跳过删除时已经把 Anki 端改脏了（Lapis
+        // 指纹随之漂掉，自动迁移永久停手）。
+        final List<int> noteIds = await service.findNotesByQuery('"$dupe"');
+        final Map<int, _NoteFieldRewrite> notePlan = <int, _NoteFieldRewrite>{};
+        bool referencesResolvable = true;
+        for (final int id in noteIds) {
+          final _NoteFieldRewrite? planned =
+              await _planNoteFieldRewrite(service, id, dupe, group.canonical);
+          if (planned == null) {
+            referencesResolvable = false;
             continue;
           }
-          final Map<String, String> changed = <String, String>{};
-          final Map<String, String> before = <String, String>{};
-          fields.forEach((String key, String value) {
-            final String rewritten =
-                rewriteMediaReferences(value, dupe, group.canonical);
-            if (rewritten != value) {
-              changed[key] = rewritten;
-              before[key] = value;
-            }
-          });
-          if (changed.isEmpty) {
-            // 检索命中但边界改写不动它：引用形态无法识别（或恰是别的更长
-            // 文件名的子串，检索分不出来）——不删这份副本。
-            cleanupOk = false;
-            continue;
-          }
-          if (!dryRun) {
-            await onJournal?.call(<String, dynamic>{
-              'type': 'noteFields',
-              'noteId': id,
-              'from': dupe,
-              'to': group.canonical,
-              'before': before,
-            });
-            await service.updateNoteFields(id, changed);
-          }
-          notesRewritten.add(id);
+          notePlan[id] = planned;
         }
 
-        // b) 卡模板/styling 引用（模板资产 js/css/字体的「重复代码」走这里）。
+        // 媒体文件内部引用（css/js/svg 的 url()/@import/相对引用）。
+        final bool referencedByMedia = referencingMedia.entries.any(
+            (MapEntry<String, String> e) =>
+                e.key != dupe && textReferencesMediaName(e.value, dupe));
+
+        if (!referencesResolvable || referencedByMedia) {
+          skippedCount++;
+          continue;
+        }
+
+        // 字节级复核：与保留份必须逐字节相同才允许进入删除路径。
+        if (!await _mediaBytesIdentical(mediaDir, dupe, group.canonical)) {
+          skippedCount++;
+          continue;
+        }
+
+        final MediaDedupDeletion planned = MediaDedupDeletion(
+          filename: dupe,
+          canonical: group.canonical,
+          bytes: sizes[dupe] ?? 0,
+        );
+
+        if (dryRun) {
+          deletions.add(planned);
+          notesRewritten.addAll(notePlan.keys);
+          modelsRewritten.addAll(
+              _modelsReferencing(modelNames, modelTemplates, modelCss, dupe));
+          continue;
+        }
+
+        // ── 阶段二：落地。笔记字段先写，复核通过后才动模板与文件 ────────
+        for (final MapEntry<int, _NoteFieldRewrite> e in notePlan.entries) {
+          // journal 带上改写**前**的原值：这是出事后能把字段还原回去的唯一
+          // 依据，只记字段名等于没有保险带。
+          await onJournal?.call(<String, dynamic>{
+            'type': 'noteFields',
+            'noteId': e.key,
+            'from': dupe,
+            'to': group.canonical,
+            'before': e.value.before,
+          });
+          await service.updateNoteFields(e.key, e.value.after);
+          notesRewritten.add(e.key);
+        }
+
+        // 复核：字段里彻底没有这个文件名了才继续。没清干净就到此为止——
+        // 模板/styling 一个字都没动，Lapis 指纹不会漂。
+        final List<int> remaining = await service.findNotesByQuery('"$dupe"');
+        if (remaining.isNotEmpty) {
+          skippedCount++;
+          continue;
+        }
+
+        // 模板与 styling：模板先写（写坏了不影响指纹），styling 后写并当场
+        // 对齐 Lapis 指纹。
         for (final String m in modelNames) {
           final List<AnkiCardTemplate> tmpls = modelTemplates[m]!;
           bool templatesChanged = false;
@@ -1044,53 +1215,43 @@ class AnkiConnectRepository extends BaseAnkiRepository {
               rewriteMediaReferences(css, dupe, group.canonical);
           final bool cssChanged = newCss != css;
           if (!templatesChanged && !cssChanged) continue;
-          if (!dryRun) {
-            await onJournal?.call(<String, dynamic>{
-              'type': 'model',
-              'model': m,
-              'from': dupe,
-              'to': group.canonical,
-            });
-            if (templatesChanged) {
-              await service.updateModelTemplates(m, newTmpls);
-            }
-            if (cssChanged) await service.updateModelStyling(m, newCss);
+          await onJournal?.call(<String, dynamic>{
+            'type': 'model',
+            'model': m,
+            'from': dupe,
+            'to': group.canonical,
+          });
+          if (templatesChanged) {
+            await service.updateModelTemplates(m, newTmpls);
+            modelTemplates[m] = newTmpls;
           }
-          modelTemplates[m] = newTmpls;
-          modelCss[m] = newCss;
+          if (cssChanged) {
+            await service.updateModelStyling(m, newCss);
+            modelCss[m] = newCss;
+            await _realignLapisCssShaAfterRewrite(
+              modelName: m,
+              cssBefore: css,
+              cssAfter: newCss,
+            );
+          }
           modelsRewritten.add(m);
         }
 
-        // c) 复核干净才删；dryRun 只计数。
-        if (dryRun) {
-          if (!cleanupOk) {
-            skippedCount++;
-            continue;
-          }
-        } else {
-          final List<int> remaining = await service.findNotesByQuery('"$dupe"');
-          if (!cleanupOk || remaining.isNotEmpty) {
-            skippedCount++;
-            continue;
-          }
-          await onJournal?.call(<String, dynamic>{
-            'type': 'delete',
-            'filename': dupe,
-            'canonical': group.canonical,
-            'bytes': sizes[dupe],
-          });
-          await service.deleteMediaFile(dupe);
-        }
-        duplicatesRemoved++;
-        bytesSaved += sizes[dupe] ?? 0;
+        await onJournal?.call(<String, dynamic>{
+          'type': 'delete',
+          'filename': dupe,
+          'canonical': group.canonical,
+          'bytes': planned.bytes,
+        });
+        await service.deleteMediaFile(dupe);
+        deletions.add(planned);
       }
     }
 
     return AnkiMediaDedupReport(
       dryRun: dryRun,
       groupCount: groups.length,
-      duplicatesRemoved: duplicatesRemoved,
-      bytesSaved: bytesSaved,
+      deletions: deletions,
       notesRewritten: notesRewritten.length,
       modelsRewritten: modelsRewritten.length,
       skipped: skippedCount,

--- a/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_service.dart
+++ b/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_service.dart
@@ -362,6 +362,41 @@ class AnkiConnectService {
     });
   }
 
+  // ── 媒体维护（字节级去重）────────────────────────────────────────────
+  // getMediaDirPath / findNotes 读取类幂等；deleteMediaFile 同名重删是 no-op，
+  // 也幂等——均不列入 [_nonIdempotentActions]。
+
+  /// Anki 当前 profile 的 collection.media 绝对路径（本机扫描用，避免把
+  /// 整个媒体库经 base64 拉过 HTTP）。
+  Future<String> getMediaDirPath() async {
+    final result = await _request('getMediaDirPath');
+    if (result is! String || result.isEmpty) {
+      throw AnkiConnectException(
+        'Unexpected AnkiConnect response for getMediaDirPath',
+      );
+    }
+    return result;
+  }
+
+  /// 删除媒体文件（按文件名）。只在引用已全部改写干净后调用。
+  Future<void> deleteMediaFile(String filename) async {
+    await _request('deleteMediaFile', {'filename': filename});
+  }
+
+  /// 按任意 Anki 搜索式查 note id（去重用 `"<文件名>"` 全字段文本检索）。
+  Future<List<int>> findNotesByQuery(String query) async {
+    final result = await _request('findNotes', {'query': query});
+    if (result is! List) {
+      throw AnkiConnectException(
+        'Unexpected AnkiConnect response for findNotes (expected a list)',
+      );
+    }
+    return result.map((dynamic id) {
+      if (id is int) return id;
+      return int.parse(id.toString());
+    }).toList();
+  }
+
   Future<void> createModel(AnkiNoteTypeTemplate template) async {
     await _request('createModel', {
       'modelName': template.name,

--- a/packages/hibiki_anki/lib/src/base_anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/base_anki_repository.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'anki_media_dedup.dart';
 import 'anki_models.dart';
 import 'anki_note_type_definition.dart';
 import 'lapis_note_type.dart';
@@ -193,6 +194,24 @@ abstract class BaseAnkiRepository {
   Future<bool> updateNoteTypeTemplates(
           String modelName, List<AnkiCardTemplate> templates) async =>
       false;
+
+  // ── 媒体存储优化（字节级去重，见 anki_media_dedup.dart）────────────────
+
+  /// 本后端能否做媒体字节级去重。需要**本机可直读** collection.media +
+  /// 全库检索 + 字段/模板改写；默认 false，仅 AnkiConnect（Anki 与 Hibiki
+  /// 同机）支持。
+  bool get supportsMediaMaintenance => false;
+
+  /// 跑一轮媒体字节级去重：找出字节完全相同的文件组 → 把笔记字段与卡模板/
+  /// styling 里的引用统一改指保留份 → 复核引用清干净后删除多余副本。
+  /// **绝不重编码任何文件**。[dryRun] = 只扫描规划，不改动。[onJournal] 在
+  /// 每次真实改写/删除**之前**收到一条可回溯记录（调用方负责落盘）。
+  /// **默认实现 = 优雅降级**：返回 null。
+  Future<AnkiMediaDedupReport?> runMediaDedup({
+    bool dryRun = false,
+    Future<void> Function(Map<String, dynamic> entry)? onJournal,
+  }) async =>
+      null;
 
   @protected
   AnkiDeck selectDeckAfterFetch(List<AnkiDeck> decks, AnkiSettings current) =>

--- a/packages/hibiki_anki/test/anki_media_dedup_orchestration_test.dart
+++ b/packages/hibiki_anki/test/anki_media_dedup_orchestration_test.dart
@@ -1,0 +1,424 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// `AnkiConnectRepository.runMediaDedup` 的**编排**测试。
+///
+/// 纯函数层已在 `anki_media_dedup_test.dart` 覆盖；这里测真正会删文件的那条
+/// 路径：什么情况下删、什么情况下坚决不删、删完卡片还取不取得到媒体、失败
+/// 路径有没有把 Anki 端改脏。
+///
+/// 手法：`AnkiConnectService` 的网络方法全部可覆写，且默认 HTTP client 是
+/// **首次请求时**才构造的，所以子类覆写掉所有用到的方法就等于一个不触网的
+/// 假 Anki；媒体目录用真的临时目录 + 真的文件，删除是真删。
+class _FakeAnkiConnectService extends AnkiConnectService {
+  _FakeAnkiConnectService({
+    required this.mediaDirPath,
+    required this.notes,
+    this.templates = const <String, List<AnkiCardTemplate>>{},
+    Map<String, String>? styling,
+    this.onFindNotes,
+  }) : styling = styling ?? <String, String>{};
+
+  final String mediaDirPath;
+
+  /// noteId → 字段表（真会被 [updateNoteFields] 改写）。
+  final Map<int, Map<String, String>> notes;
+  final Map<String, List<AnkiCardTemplate>> templates;
+  final Map<String, String> styling;
+
+  /// 在第一次 findNotes 时插一脚（用来模拟「扫描完到删除前文件被改动」）。
+  final Future<void> Function()? onFindNotes;
+
+  final List<String> deleted = <String>[];
+  final List<String> stylingWrites = <String>[];
+  final List<String> templateWrites = <String>[];
+  bool _findNotesHookFired = false;
+
+  late final Map<String, List<AnkiCardTemplate>> _templates =
+      Map<String, List<AnkiCardTemplate>>.from(templates);
+
+  @override
+  Future<String> getMediaDirPath() async => mediaDirPath;
+
+  @override
+  Future<List<String>> getModelNames() async =>
+      <String>{..._templates.keys, ...styling.keys}.toList()..sort();
+
+  @override
+  Future<List<AnkiCardTemplate>> modelTemplates(String modelName) async =>
+      _templates[modelName] ?? const <AnkiCardTemplate>[];
+
+  @override
+  Future<String> modelStyling(String modelName) async =>
+      styling[modelName] ?? '';
+
+  /// 去重只用 `findNotes("<文件名>")`：朴素子串检索，和真 Anki 一样**不做**
+  /// 文件名边界判断——正是这一点让「命中但改不动」的保守分支有意义。
+  @override
+  Future<List<int>> findNotesByQuery(String query) async {
+    if (!_findNotesHookFired && onFindNotes != null) {
+      _findNotesHookFired = true;
+      await onFindNotes!();
+    }
+    final String needle = query.replaceAll('"', '');
+    return notes.entries
+        .where((MapEntry<int, Map<String, String>> e) =>
+            e.value.values.any((String v) => v.contains(needle)))
+        .map((MapEntry<int, Map<String, String>> e) => e.key)
+        .toList()
+      ..sort();
+  }
+
+  @override
+  Future<Map<String, String>?> notesInfo(int noteId) async => notes[noteId];
+
+  @override
+  Future<void> updateNoteFields(int noteId, Map<String, String> fields) async {
+    notes[noteId]!.addAll(fields);
+  }
+
+  @override
+  Future<void> updateModelTemplates(
+      String modelName, List<AnkiCardTemplate> tmpls) async {
+    _templates[modelName] = tmpls;
+    templateWrites.add(modelName);
+  }
+
+  @override
+  Future<void> updateModelStyling(String modelName, String css) async {
+    styling[modelName] = css;
+    stylingWrites.add(modelName);
+  }
+
+  @override
+  Future<void> deleteMediaFile(String filename) async {
+    deleted.add(filename);
+    final File f = File('$mediaDirPath${Platform.pathSeparator}$filename');
+    if (f.existsSync()) f.deleteSync();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory mediaDir;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    mediaDir = Directory.systemTemp.createTempSync('hibiki_dedup_test');
+  });
+
+  tearDown(() {
+    if (mediaDir.existsSync()) mediaDir.deleteSync(recursive: true);
+  });
+
+  void writeMedia(String name, List<int> bytes) {
+    File('${mediaDir.path}${Platform.pathSeparator}$name')
+        .writeAsBytesSync(Uint8List.fromList(bytes));
+  }
+
+  bool mediaExists(String name) =>
+      File('${mediaDir.path}${Platform.pathSeparator}$name').existsSync();
+
+  /// 「卡片仍能取到媒体」的硬断言：把改写后的笔记字段 + 卡模板 + styling 全
+  /// 拼起来，凡是还引用着 [allNames] 里某个文件名的，那个文件必须真的还在
+  /// 媒体目录里。出现问号方框/放不出声就是这条挂掉。
+  void expectEveryReferenceResolves(
+    _FakeAnkiConnectService service,
+    Iterable<String> allNames,
+  ) {
+    final StringBuffer buf = StringBuffer();
+    for (final Map<String, String> fields in service.notes.values) {
+      fields.values.forEach(buf.writeln);
+    }
+    for (final List<AnkiCardTemplate> tmpls in service._templates.values) {
+      for (final AnkiCardTemplate tpl in tmpls) {
+        buf
+          ..writeln(tpl.front)
+          ..writeln(tpl.back);
+      }
+    }
+    service.styling.values.forEach(buf.writeln);
+    final String all = buf.toString();
+    for (final String name in allNames) {
+      if (!textReferencesMediaName(all, name)) continue;
+      expect(mediaExists(name), isTrue,
+          reason: '仍被引用的媒体 $name 不在媒体目录里（卡片会显示问号方框）');
+    }
+  }
+
+  test('真删：引用改指保留份、副本被删、每个引用仍能取到媒体', () async {
+    writeMedia('a.jpg', <int>[1, 2, 3]);
+    writeMedia('bbbb.jpg', <int>[1, 2, 3]);
+    writeMedia('other.jpg', <int>[9, 9, 9]);
+    final _FakeAnkiConnectService service = _FakeAnkiConnectService(
+      mediaDirPath: mediaDir.path,
+      notes: <int, Map<String, String>>{
+        1: <String, String>{'Front': '<img src="bbbb.jpg">'},
+        2: <String, String>{'Front': '<img src="other.jpg">'},
+      },
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(service: service);
+
+    final AnkiMediaDedupReport? report = await repo.runMediaDedup();
+
+    expect(report, isNotNull);
+    expect(report!.deletions, hasLength(1));
+    expect(report.deletions.single.filename, 'bbbb.jpg');
+    expect(report.deletions.single.canonical, 'a.jpg');
+    expect(report.deletions.single.bytes, 3);
+    expect(report.bytesSaved, 3);
+    expect(report.skipped, 0);
+    expect(service.deleted, <String>['bbbb.jpg']);
+    expect(mediaExists('bbbb.jpg'), isFalse);
+    expect(mediaExists('a.jpg'), isTrue);
+    expect(service.notes[1]!['Front'], '<img src="a.jpg">');
+    expect(service.notes[2]!['Front'], '<img src="other.jpg">');
+    expectEveryReferenceResolves(
+        service, <String>['a.jpg', 'bbbb.jpg', 'other.jpg']);
+  });
+
+  test('大小相同但字节不同 → 不成组、绝不删', () async {
+    writeMedia('a.jpg', <int>[1, 2, 3]);
+    writeMedia('b.jpg', <int>[1, 2, 4]);
+    final _FakeAnkiConnectService service = _FakeAnkiConnectService(
+      mediaDirPath: mediaDir.path,
+      notes: <int, Map<String, String>>{
+        1: <String, String>{'Front': '<img src="a.jpg"><img src="b.jpg">'},
+      },
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(service: service);
+
+    final AnkiMediaDedupReport? report = await repo.runMediaDedup();
+
+    expect(report!.groupCount, 0);
+    expect(report.deletions, isEmpty);
+    expect(service.deleted, isEmpty);
+    expect(mediaExists('a.jpg'), isTrue);
+    expect(mediaExists('b.jpg'), isTrue);
+    expectEveryReferenceResolves(service, <String>['a.jpg', 'b.jpg']);
+  });
+
+  test('计划之后、删除之前副本被改动 → 逐字节复核挡住删除', () async {
+    writeMedia('a.jpg', <int>[1, 2, 3]);
+    writeMedia('bbbb.jpg', <int>[1, 2, 3]);
+    final _FakeAnkiConnectService service = _FakeAnkiConnectService(
+      mediaDirPath: mediaDir.path,
+      notes: <int, Map<String, String>>{
+        1: <String, String>{'Front': '<img src="bbbb.jpg">'},
+      },
+      // 哈希已经算完，此刻把副本内容换掉：只有删除前的 memcmp 能发现。
+      onFindNotes: () async => writeMedia('bbbb.jpg', <int>[7, 7, 7]),
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(service: service);
+
+    final AnkiMediaDedupReport? report = await repo.runMediaDedup();
+
+    expect(report!.deletions, isEmpty);
+    expect(report.skipped, 1);
+    expect(service.deleted, isEmpty);
+    expect(mediaExists('bbbb.jpg'), isTrue);
+    // 笔记也没被改写（判定阶段就拦下了，一个字节都没写）。
+    expect(service.notes[1]!['Front'], '<img src="bbbb.jpg">');
+  });
+
+  test('必修①：媒体文件内部的 url() 引用挡住删除（不静默删掉在用字体）', () async {
+    // `_x.css` 里的 `url(font.woff2)` 既不在笔记字段、也不在卡模板/styling
+    // 里——只扫那三处会判定「无引用」，把仍在用的字体删掉。
+    writeMedia('_font.woff2', <int>[5, 5, 5, 5]);
+    writeMedia('font.woff2', <int>[5, 5, 5, 5]);
+    File('${mediaDir.path}${Platform.pathSeparator}_x.css')
+        .writeAsStringSync('@font-face { src: url(font.woff2); }');
+    final _FakeAnkiConnectService service = _FakeAnkiConnectService(
+      mediaDirPath: mediaDir.path,
+      notes: <int, Map<String, String>>{},
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(service: service);
+
+    final AnkiMediaDedupReport? report = await repo.runMediaDedup();
+
+    // 组是成立的（字节确实相同），但 `_font.woff2` 是规范名、`font.woff2`
+    // 还被 CSS 引用着 → 保守不删。
+    expect(report!.groupCount, 1);
+    expect(report.deletions, isEmpty);
+    expect(report.skipped, 1);
+    expect(service.deleted, isEmpty);
+    expect(mediaExists('font.woff2'), isTrue);
+    expect(mediaExists('_font.woff2'), isTrue);
+  });
+
+  test('必修②：跳过删除时模板/styling 一个字都不写，Lapis 指纹不漂', () async {
+    writeMedia('a.jpg', <int>[1, 2, 3]);
+    writeMedia('bbbb.jpg', <int>[1, 2, 3]);
+    const String css = 'body { background: url(bbbb.jpg); }';
+    final _FakeAnkiConnectService service = _FakeAnkiConnectService(
+      mediaDirPath: mediaDir.path,
+      // 检索命中却改不动（`xbbbb.jpg` 是更长的名字，边界安全改写不碰它）：
+      // 引用清不干净 → 整份副本不删。
+      notes: <int, Map<String, String>>{
+        1: <String, String>{'Front': '<img src="xbbbb.jpg">'},
+      },
+      styling: <String, String>{LapisNoteType.modelName: css},
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(service: service);
+    final String shaBefore = lapisCssSha256(css);
+    await repo.updateSettings(
+        (AnkiSettings s) => s.copyWith(lapisAppliedCssSha: shaBefore));
+
+    final AnkiMediaDedupReport? report = await repo.runMediaDedup();
+
+    expect(report!.deletions, isEmpty);
+    expect(report.skipped, 1);
+    expect(service.stylingWrites, isEmpty);
+    expect(service.templateWrites, isEmpty);
+    expect(service.styling[LapisNoteType.modelName], css);
+    // 指纹仍与 Anki 侧实际 CSS 一致 → 下次启动自动迁移照常判定，不会因为
+    // 一次失败的去重而永久停手。
+    final AnkiSettings after = await repo.loadSettings();
+    expect(after.lapisAppliedCssSha, shaBefore);
+    expect(lapisCssSha256(service.styling[LapisNoteType.modelName]!),
+        after.lapisAppliedCssSha);
+  });
+
+  test('必修②：styling 真被改写时指纹跟着对齐（自动迁移不退化成 foreignEdit）', () async {
+    writeMedia('a.jpg', <int>[1, 2, 3]);
+    writeMedia('bbbb.jpg', <int>[1, 2, 3]);
+    const String css = 'body { background: url(bbbb.jpg); }';
+    final _FakeAnkiConnectService service = _FakeAnkiConnectService(
+      mediaDirPath: mediaDir.path,
+      notes: <int, Map<String, String>>{},
+      styling: <String, String>{LapisNoteType.modelName: css},
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(service: service);
+    await repo.updateSettings((AnkiSettings s) =>
+        s.copyWith(lapisAppliedCssSha: lapisCssSha256(css)));
+
+    final AnkiMediaDedupReport? report = await repo.runMediaDedup();
+
+    expect(report!.deletions, hasLength(1));
+    expect(service.styling[LapisNoteType.modelName],
+        'body { background: url(a.jpg); }');
+    final AnkiSettings after = await repo.loadSettings();
+    expect(after.lapisAppliedCssSha,
+        lapisCssSha256(service.styling[LapisNoteType.modelName]!));
+    expectEveryReferenceResolves(service, <String>['a.jpg', 'bbbb.jpg']);
+  });
+
+  test('必修②：本就是用户手改（指纹对不上）时不伪造指纹', () async {
+    writeMedia('a.jpg', <int>[1, 2, 3]);
+    writeMedia('bbbb.jpg', <int>[1, 2, 3]);
+    final _FakeAnkiConnectService service = _FakeAnkiConnectService(
+      mediaDirPath: mediaDir.path,
+      notes: <int, Map<String, String>>{},
+      styling: <String, String>{
+        LapisNoteType.modelName: 'body { background: url(bbbb.jpg); }',
+      },
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(service: service);
+    await repo.updateSettings(
+        (AnkiSettings s) => s.copyWith(lapisAppliedCssSha: 'stale-sha'));
+
+    await repo.runMediaDedup();
+
+    final AnkiSettings after = await repo.loadSettings();
+    expect(after.lapisAppliedCssSha, 'stale-sha');
+  });
+
+  test('干跑：一个文件/字段都不动，但给出完整删除清单', () async {
+    writeMedia('a.jpg', <int>[1, 2, 3]);
+    writeMedia('bbbb.jpg', <int>[1, 2, 3]);
+    final _FakeAnkiConnectService service = _FakeAnkiConnectService(
+      mediaDirPath: mediaDir.path,
+      notes: <int, Map<String, String>>{
+        1: <String, String>{'Front': '<img src="bbbb.jpg">'},
+      },
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(service: service);
+
+    final AnkiMediaDedupReport? report = await repo.runMediaDedup(dryRun: true);
+
+    expect(report!.dryRun, isTrue);
+    expect(report.deletions, hasLength(1));
+    expect(report.deletions.single.filename, 'bbbb.jpg');
+    expect(report.deletions.single.canonical, 'a.jpg');
+    expect(report.deletions.single.bytes, 3);
+    expect(service.deleted, isEmpty);
+    expect(service.stylingWrites, isEmpty);
+    expect(service.templateWrites, isEmpty);
+    expect(mediaExists('bbbb.jpg'), isTrue);
+    expect(service.notes[1]!['Front'], '<img src="bbbb.jpg">');
+  });
+
+  test('媒体目录本机不存在（AnkiConnect 在远程） → 返回 null，不盲扫', () async {
+    final Directory gone = Directory.systemTemp.createTempSync('hibiki_gone');
+    gone.deleteSync();
+    final _FakeAnkiConnectService service = _FakeAnkiConnectService(
+      mediaDirPath: gone.path,
+      notes: <int, Map<String, String>>{},
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(service: service);
+
+    expect(await repo.runMediaDedup(), isNull);
+  });
+
+  test('卡模板里的引用也改指保留份，改完仍取得到媒体', () async {
+    writeMedia('_lib.js', <int>[8, 8]);
+    writeMedia('lib.js', <int>[8, 8]);
+    final _FakeAnkiConnectService service = _FakeAnkiConnectService(
+      mediaDirPath: mediaDir.path,
+      notes: <int, Map<String, String>>{},
+      templates: <String, List<AnkiCardTemplate>>{
+        'Basic': <AnkiCardTemplate>[
+          const AnkiCardTemplate(
+            name: 'Card 1',
+            front: '<script src="lib.js"></script>',
+            back: '{{FrontSide}}',
+          ),
+        ],
+      },
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(service: service);
+
+    final AnkiMediaDedupReport? report = await repo.runMediaDedup();
+
+    expect(report!.deletions.single.filename, 'lib.js');
+    expect(report.modelsRewritten, 1);
+    expect(service._templates['Basic']!.single.front,
+        '<script src="_lib.js"></script>');
+    expect(mediaExists('lib.js'), isFalse);
+    expectEveryReferenceResolves(service, <String>['_lib.js', 'lib.js']);
+  });
+
+  test('journal 记下改写前的原值与删除条目（出事能还原）', () async {
+    writeMedia('a.jpg', <int>[1, 2, 3]);
+    writeMedia('bbbb.jpg', <int>[1, 2, 3]);
+    final _FakeAnkiConnectService service = _FakeAnkiConnectService(
+      mediaDirPath: mediaDir.path,
+      notes: <int, Map<String, String>>{
+        1: <String, String>{'Front': '<img src="bbbb.jpg">'},
+      },
+    );
+    final AnkiConnectRepository repo = AnkiConnectRepository(service: service);
+    final List<Map<String, dynamic>> journal = <Map<String, dynamic>>[];
+
+    await repo.runMediaDedup(
+        onJournal: (Map<String, dynamic> e) async => journal.add(e));
+
+    final Map<String, dynamic> noteEntry = journal
+        .firstWhere((Map<String, dynamic> e) => e['type'] == 'noteFields');
+    expect(noteEntry['noteId'], 1);
+    expect(
+        noteEntry['before'], <String, String>{'Front': '<img src="bbbb.jpg">'});
+    final Map<String, dynamic> deleteEntry =
+        journal.firstWhere((Map<String, dynamic> e) => e['type'] == 'delete');
+    expect(deleteEntry['filename'], 'bbbb.jpg');
+    expect(deleteEntry['canonical'], 'a.jpg');
+    expect(deleteEntry['bytes'], 3);
+    // journal 必须在真改之前落：删除条目排在改写条目之后、且都在 journal 里。
+    expect(journal.indexOf(noteEntry), lessThan(journal.indexOf(deleteEntry)));
+  });
+}

--- a/packages/hibiki_anki/test/anki_media_dedup_test.dart
+++ b/packages/hibiki_anki/test/anki_media_dedup_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+void main() {
+  group('planMediaDedupGroups', () {
+    test('哈希相同的分成一组，单文件不产出，输出确定有序', () {
+      final List<MediaDedupGroup> groups =
+          planMediaDedupGroups(<String, String>{
+        'b.jpg': 'h1',
+        'a.jpg': 'h1',
+        'c.jpg': 'h2',
+        'z.png': 'h3',
+        'y.png': 'h3',
+        'x.png': 'h3',
+      });
+      expect(groups, hasLength(2));
+      expect(groups[0].canonical, 'a.jpg');
+      expect(groups[0].duplicates, <String>['b.jpg']);
+      expect(groups[1].canonical, 'x.png');
+      expect(groups[1].duplicates, <String>['y.png', 'z.png']);
+    });
+  });
+
+  group('chooseCanonicalMediaName', () {
+    test('下划线前缀优先（Anki 不清 _ 前缀的模板资产）', () {
+      expect(
+        chooseCanonicalMediaName(<String>['aaa.js', '_lib.js', 'shorter.js']),
+        '_lib.js',
+      );
+    });
+
+    test('无下划线时取最短名，平手取字典序', () {
+      expect(chooseCanonicalMediaName(<String>['longer-name.jpg', 'ab.jpg']),
+          'ab.jpg');
+      expect(chooseCanonicalMediaName(<String>['bb.jpg', 'aa.jpg']), 'aa.jpg');
+    });
+  });
+
+  group('rewriteMediaReferences', () {
+    test('覆盖 src= / [sound:] / url() 三种引用形态', () {
+      expect(
+        rewriteMediaReferences('<img src="a.jpg">', 'a.jpg', 'b.jpg'),
+        '<img src="b.jpg">',
+      );
+      expect(
+        rewriteMediaReferences('[sound:a.mp3]', 'a.mp3', 'b.mp3'),
+        '[sound:b.mp3]',
+      );
+      expect(
+        rewriteMediaReferences('background: url(a.png);', 'a.png', 'b.png'),
+        'background: url(b.png);',
+      );
+    });
+
+    test('文件名边界安全：不误伤更长的名字', () {
+      expect(
+        rewriteMediaReferences('<img src="ba.jpg">', 'a.jpg', 'c.jpg'),
+        '<img src="ba.jpg">',
+      );
+      expect(
+        rewriteMediaReferences('<img src="a.jpg.bak">', 'a.jpg', 'c.jpg'),
+        '<img src="a.jpg.bak">',
+      );
+      // 正则元字符文件名不炸。
+      expect(
+        rewriteMediaReferences('<img src="a(1).jpg">', 'a(1).jpg', 'c.jpg'),
+        '<img src="c.jpg">',
+      );
+    });
+
+    test('同名/无命中时原样返回', () {
+      expect(rewriteMediaReferences('x', 'a.jpg', 'a.jpg'), 'x');
+      expect(rewriteMediaReferences('nothing here', 'a.jpg', 'b.jpg'),
+          'nothing here');
+    });
+  });
+
+  group('shouldRunPeriodicMediaDedup', () {
+    const int day = 24 * 60 * 60 * 1000;
+
+    test('从未跑过 → 到期', () {
+      expect(shouldRunPeriodicMediaDedup(lastRunMs: null, nowMs: 0), isTrue);
+    });
+
+    test('不满 7 天不跑，满 7 天跑', () {
+      expect(
+        shouldRunPeriodicMediaDedup(lastRunMs: 0, nowMs: 6 * day),
+        isFalse,
+      );
+      expect(
+        shouldRunPeriodicMediaDedup(lastRunMs: 0, nowMs: 7 * day),
+        isTrue,
+      );
+    });
+  });
+
+  group('AnkiSettings 媒体去重字段', () {
+    test('默认开启 + JSON 往返', () {
+      const AnkiSettings fresh = AnkiSettings();
+      expect(fresh.mediaDedupAutoEnabled, isTrue);
+      expect(fresh.lastMediaDedupAtMs, isNull);
+
+      final AnkiSettings round = AnkiSettings.fromJson(fresh
+          .copyWith(mediaDedupAutoEnabled: false, lastMediaDedupAtMs: 123)
+          .toJson());
+      expect(round.mediaDedupAutoEnabled, isFalse);
+      expect(round.lastMediaDedupAtMs, 123);
+    });
+  });
+}

--- a/packages/hibiki_anki/test/anki_media_dedup_test.dart
+++ b/packages/hibiki_anki/test/anki_media_dedup_test.dart
@@ -4,20 +4,45 @@ import 'package:hibiki_anki/hibiki_anki.dart';
 void main() {
   group('planMediaDedupGroups', () {
     test('哈希相同的分成一组，单文件不产出，输出确定有序', () {
-      final List<MediaDedupGroup> groups =
-          planMediaDedupGroups(<String, String>{
-        'b.jpg': 'h1',
-        'a.jpg': 'h1',
-        'c.jpg': 'h2',
-        'z.png': 'h3',
-        'y.png': 'h3',
-        'x.png': 'h3',
-      });
+      final List<MediaDedupGroup> groups = planMediaDedupGroups(
+        <String, String>{
+          'b.jpg': 'h1',
+          'a.jpg': 'h1',
+          'c.jpg': 'h2',
+          'z.png': 'h3',
+          'y.png': 'h3',
+          'x.png': 'h3',
+        },
+        sizes: <String, int>{
+          'b.jpg': 10,
+          'a.jpg': 10,
+          'c.jpg': 20,
+          'z.png': 30,
+          'y.png': 30,
+          'x.png': 30,
+        },
+      );
       expect(groups, hasLength(2));
       expect(groups[0].canonical, 'a.jpg');
       expect(groups[0].duplicates, <String>['b.jpg']);
       expect(groups[1].canonical, 'x.png');
       expect(groups[1].duplicates, <String>['y.png', 'z.png']);
+    });
+
+    test('哈希撞车但字节数不同 → 绝不归为一组', () {
+      final List<MediaDedupGroup> groups = planMediaDedupGroups(
+        <String, String>{'a.jpg': 'same', 'b.jpg': 'same'},
+        sizes: <String, int>{'a.jpg': 10, 'b.jpg': 11},
+      );
+      expect(groups, isEmpty);
+    });
+
+    test('缺字节数的条目直接丢弃（长度未知不判等）', () {
+      final List<MediaDedupGroup> groups = planMediaDedupGroups(
+        <String, String>{'a.jpg': 'h', 'b.jpg': 'h'},
+        sizes: <String, int>{'a.jpg': 10},
+      );
+      expect(groups, isEmpty);
     });
   });
 
@@ -75,35 +100,60 @@ void main() {
     });
   });
 
-  group('shouldRunPeriodicMediaDedup', () {
-    const int day = 24 * 60 * 60 * 1000;
-
-    test('从未跑过 → 到期', () {
-      expect(shouldRunPeriodicMediaDedup(lastRunMs: null, nowMs: 0), isTrue);
+  group('textReferencesMediaName', () {
+    test('CSS url() / @import / 相对引用都算引用', () {
+      expect(
+          textReferencesMediaName('src: url(_f.woff2);', '_f.woff2'), isTrue);
+      expect(
+          textReferencesMediaName("@import '_base.css';", '_base.css'), isTrue);
+      expect(textReferencesMediaName('url("./_f.woff2")', '_f.woff2'), isTrue);
     });
 
-    test('不满 7 天不跑，满 7 天跑', () {
-      expect(
-        shouldRunPeriodicMediaDedup(lastRunMs: 0, nowMs: 6 * day),
-        isFalse,
+    test('边界安全：更长的名字不算引用', () {
+      expect(textReferencesMediaName('url(_f.woff2.bak)', '_f.woff2'), isFalse);
+      expect(textReferencesMediaName('url(x_f.woff2)', '_f.woff2'), isFalse);
+    });
+  });
+
+  group('isReferencingMediaFile', () {
+    test('只把会引用别人的文本格式算进扫描面', () {
+      expect(isReferencingMediaFile('_style.CSS'), isTrue);
+      expect(isReferencingMediaFile('a.js'), isTrue);
+      expect(isReferencingMediaFile('a.svg'), isTrue);
+      expect(isReferencingMediaFile('a.jpg'), isFalse);
+      expect(isReferencingMediaFile('a.woff2'), isFalse);
+      expect(isReferencingMediaFile('noext'), isFalse);
+      expect(isReferencingMediaFile('trailing.'), isFalse);
+    });
+  });
+
+  group('AnkiMediaDedupReport', () {
+    test('数量与字节数从明细派生，JSON 带逐条清单', () {
+      const AnkiMediaDedupReport report = AnkiMediaDedupReport(
+        dryRun: true,
+        groupCount: 1,
+        deletions: <MediaDedupDeletion>[
+          MediaDedupDeletion(filename: 'b.jpg', canonical: 'a.jpg', bytes: 30),
+          MediaDedupDeletion(filename: 'c.jpg', canonical: 'a.jpg', bytes: 12),
+        ],
+        notesRewritten: 2,
+        modelsRewritten: 0,
+        skipped: 1,
       );
-      expect(
-        shouldRunPeriodicMediaDedup(lastRunMs: 0, nowMs: 7 * day),
-        isTrue,
-      );
+      expect(report.duplicatesRemoved, 2);
+      expect(report.bytesSaved, 42);
+      expect(report.toJson()['deletions'], hasLength(2));
     });
   });
 
   group('AnkiSettings 媒体去重字段', () {
-    test('默认开启 + JSON 往返', () {
+    test('只留「上次跑过」的时刻，没有任何自动开关', () {
       const AnkiSettings fresh = AnkiSettings();
-      expect(fresh.mediaDedupAutoEnabled, isTrue);
       expect(fresh.lastMediaDedupAtMs, isNull);
+      expect(fresh.toJson().containsKey('mediaDedupAutoEnabled'), isFalse);
 
-      final AnkiSettings round = AnkiSettings.fromJson(fresh
-          .copyWith(mediaDedupAutoEnabled: false, lastMediaDedupAtMs: 123)
-          .toJson());
-      expect(round.mediaDedupAutoEnabled, isFalse);
+      final AnkiSettings round = AnkiSettings.fromJson(
+          fresh.copyWith(lastMediaDedupAtMs: 123).toJson());
       expect(round.lastMediaDedupAtMs, 123);
     });
   });


### PR DESCRIPTION
## 概要

四件套的最后一件（stacked on #457，基分支合并后自动重定向 develop）。用户拍板的范围：

- **只去重**：找出 collection.media 里**字节完全相同**的重复文件组，把所有引用（笔记字段 `src=` / `[sound:]`、卡模板、styling `url()`）统一改指保留的那一份，复核检索清零后删除多余副本——字节一致，删副本零信息损失。
- **重复代码同机制覆盖**：`_` 前缀的模板资产（js/css/字体）同样按字节去重，规范名选择让 `_` 前缀优先（Anki「检查媒体」不清 `_` 文件，模板资产只有保留 `_` 名才安全）。
- **绝不重编码/压缩任何图片，零画质损失；不做按年龄清理，不删任何非重复文件。**
- **定期**：每 7 天启动时自动跑一轮（开关默认开，可关）；另有「扫描报告（不改动）」与「立即去重」手动入口。

## 安全设计

- 保守原则：某个副本的任何一处引用改不干净（检索命中但边界改写识别不了的形态），**跳过删除**并计入报告 skipped，宁可留着。
- 引用改写带文件名边界（前后不能紧邻 `[A-Za-z0-9._-]`）：`a.jpg` 不会误伤 `ba.jpg` / `a.jpg.bak`。
- 每次真实改写/删除**之前**逐条 journal 落 `<supportRoot>/backups/media_dedup/*.jsonl`（含字段原值），可人工回溯。
- 仅 AnkiConnect 且与 Anki **同机**时启用（`getMediaDirPath` 指向的目录本机不存在按不支持处理，绝不盲扫）；AnkiDroid/AnkiMobile/远程主机整区隐藏。
- 大小初筛 + 只对大小撞车的候选算 sha256，大媒体库不全量读盘。

## 验证

- `flutter analyze`：hibiki 0 issue（hibiki_anki 仍只有那 1 个与本系列无关的既有 warning）。
- 包测试：anki_media_dedup（分组/规范名/边界改写/周期判定/设置往返）+ 全包通过。
- 应用侧定向：test/anki + anki_settings_page + settings schema 覆盖率 harness（新开关已按惯例登记 kCoveredElsewhere）+ flatten_anki_profile（SwitchRow 计数 3→4 契约更新）+ test/i18n：184 pass。
- i18n：12 个 `anki_dedup_*` key 经 i18n_sync + slang。

## 待办 / 风险

- 真机（Windows + 本机 Anki）实测一轮真实 collection 的 dry-run / 真删路径——draft 待验收。
- 笔记字段内联重复样式块「上提到模板」未做（需真实收藏数据先扫描定型，避免凭空设计 HTML 手术）；本 PR 的 dry-run 报告可先提供数据。

https://claude.ai/code/session_01GdskoY6Fe2WuF4XyiHec93