### PR TITLE
fix(gal): 浮窗穿透改用 WS_EX_TRANSPARENT，点击真正落到游戏 (BUG-951)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -203,7 +203,7 @@
 | [BUG-954](bugs/BUG-954-texthooker-mine-sentence-empty-non-windows.md) | ✅ | ✅ | 非外部窗口模式制卡 sentence 字段恒空 |
 | [BUG-953](bugs/BUG-953-texthooker-popup-overlay-cross-tab-residue.md) | ✅ | ✅ | games tab 保活时查词弹窗与 barrier 跨 tab 残留遮挡 |
 | [BUG-952](bugs/BUG-952-texthooker-thread-dropdown-value-mismatch.md) | ✅ | ✅ | texthooker 线程下拉 value 与动态 items 失配触发 debug 断言红屏 |
-| [BUG-951](bugs/BUG-951-gal-overlay-click-through-cross-process.md) | 🚧 | 🚧 | Hook 浮窗鼠标穿透 HTTRANSPARENT 跨进程不生效存疑须真机验证 |
+| [BUG-951](bugs/BUG-951-gal-overlay-click-through-cross-process.md) | ✅ | ✅ | Hook 浮窗鼠标穿透 HTTRANSPARENT 跨进程不生效 |
 | [BUG-950](bugs/BUG-950-gal-hook-session-stale-line-bleed.md) | ✅ | ✅ | galgame hook 会话重启后旧行串入新会话且新文本被当重复静默丢弃 |
 | [BUG-949](bugs/BUG-949-unity-resource-audio-extractor-stall.md) | ✅ | ✅ | Unity 资源音频提取队列阻塞后持续降级 |
 | [BUG-948](bugs/BUG-948-dual-game-capture-acceptance.md) | ✅ | ✅ | Galgame 捕获不能稳定将正确文本与游戏资源语音一一配对并制卡 |

--- a/docs/bugs/BUG-951-gal-overlay-click-through-cross-process.md
+++ b/docs/bugs/BUG-951-gal-overlay-click-through-cross-process.md
@@ -1,6 +1,48 @@
-## BUG-951 · Hook 浮窗鼠标穿透 HTTRANSPARENT 跨进程不生效存疑须真机验证
+## BUG-951 · Hook 浮窗鼠标穿透 HTTRANSPARENT 跨进程不生效
 - **报告**：2026-07-21（PR#295 落地审查 H2，fable5）
-- **真实性**：⚠️ 待真机验证（静态可疑）。疑点 `hibiki/windows/runner/floating_lyric_window.cpp:617-622`：穿透仅靠 WM_NCHITTEST 返回 `HTTRANSPARENT`，Win32 契约中它只在同线程窗口间下传，对另一进程的游戏窗口不生效（层窗口 ~2% alpha 体表命中测试不透明），穿透模式下点击可能被浮窗吞掉而非落到游戏。
-- **[ ] ① 未修复** — 若真机复现：正解是穿透态切 `WS_EX_TRANSPARENT`（或体表 alpha=0），而非 HTTRANSPARENT。
-- **[ ] ② 未加自动化测试** — 真机手动验收（浮窗开穿透后点击游戏正文区能触达游戏）。
-- **备注**：核心特性验证项，列入 Windows 真机验收清单。
+- **真实性**：✅ **已确定性复现（为真）**。2026-07-27 用跨进程最小 Win32 装置 +
+  真实 `SendInput` 点击验证，不再是静态推测。
+- **根因**：`hibiki/windows/runner/floating_lyric_window.cpp:732-751`（修前）——
+  穿透仅靠 `WM_NCHITTEST` 返回 `HTTRANSPARENT`。Win32 契约中它**只在同线程窗口间
+  下传**；游戏属于另一进程，所以浮窗声明“这不是我的”之后系统找不到下一个
+  同线程窗口，点击**整个消失**——既不给游戏，也不给浮窗。
+  旧实现在部分场景“看上去能用”，只是因为背景不透明度为 0 时体表像素 alpha=0，
+  是**层窗口的逐像素命中测试**把点击放下去的，与 `HTTRANSPARENT` 无关。因此：
+  用户一旦把背景不透明度调成非 0（`_backgroundColor = alpha << 24`，
+  `gal_hook_text_overlay_controller.dart:336`），整个正文区吞点击；即便为 0，
+  点在**不透明的文字笔画**上照样被吞。
+- **复现矩阵**（每格 = 一对全新跨进程窗口 + 一次真实 `SendInput` 点击）：
+
+  | overlay 配置 | 点正文区 | 点顶部恢复带 |
+  |---|---|---|
+  | alpha=0，`HTTRANSPARENT` | 游戏收到 ✅ | 游戏收到 ❌（工具条点不到）|
+  | alpha=5（2%），`HTTRANSPARENT` | **两边都没收到，点击被吞 ❌** | 同左 ❌ |
+  | alpha=200，`HTTRANSPARENT` | **两边都没收到，点击被吞 ❌** | 同左 ❌ |
+  | alpha=200，静态 `WS_EX_TRANSPARENT` | 游戏收到 ✅ | 游戏收到 ❌（工具条点不到）|
+  | `WS_EX_TRANSPARENT` + 光标在恢复带时清位 | **游戏收到 ✅** | **浮窗收到 ✅** |
+
+  复现装置与完整日志：`C:\Users\wrds\.claude\jobs\ef81236c\tmp\bug951-repro.md`
+  （装置源码 `tmp\bug951\Repro.cs`，不入库）。
+- **[x] ① 已修复** —— 穿透态改用 `WS_EX_TRANSPARENT`（真跨进程，与像素 alpha 无关）。
+  该位是**整窗属性**，永久开着会把顶部恢复带（那里才有退出穿透的按钮）一起穿掉，
+  全屏 galgame 下等于把用户锁死；所以按光标位置动态开关：只在光标悬停在恢复带时清掉
+  该位。透明窗收不到任何鼠标消息，“光标进入恢复带”只能靠轮询发现（仅在穿透开启
+  期间起 16ms 定时器）。恢复带几何收成单一谓词
+  `PassThroughRecoveryContainsClientY`，`WM_NCHITTEST` 与轮询共用，不会漂开。
+  `HTTRANSPARENT` 降为同线程兼容兵——覆盖光标离开恢复带到该位被置上的那一个轮询
+  tick，这段时间里拒接点击好过把它吞成一次用户没要的查词。
+  实现：`hibiki/windows/runner/floating_lyric_window.cpp`
+  （`ApplyPassThroughHitTest` / `UpdatePassThroughFromCursor` /
+  `PassThroughRecoveryContainsClientY` / `SetPassThrough` / `Show` / `Hide` / `WM_TIMER`）。
+  坑：`SetWindowLongPtr(GWL_EXSTYLE)` 改完必须再
+  `SetWindowPos(..., SWP_FRAMECHANGED)` 提交，否则位读回已变而命中测试还用旧值。
+- **[x] ② 已加自动化测试** —— 源码扫描守卫
+  `hibiki/test/tools/hook_overlay_passthrough_ex_transparent_guard_test.dart`（5 条）：
+  ① 穿透态真的设/清 `WS_EX_TRANSPARENT`；② 改完走 `SWP_FRAMECHANGED` 提交；
+  ③ 定时器 + `WM_TIMER` 轮询成对启停；④ 退出穿透 / `Hide` 无条件把点击还给浮窗
+  （最大回归风险：别把浮窗自己的交互一起穿透掉）；⑤ 恢复带几何只有一份。
+  负向对照已验：对修复前源码跑为 0 通过 / 5 失败。
+  旁边的 BUG-1046 守卫（`hook_overlay_hittest_alpha_floor_guard_test.dart`）仍全绿。
+- **备注**：核心特性验证项。自动化层只能锁住源码接线（native C++ 跑不进 Dart 测试），
+  真机验收仍需在真实 galgame 上走一遍：开穿透 → 点浮窗遮住的正文区 → 游戏推进对话；
+  再把光标移到浮窗顶部 → 工具条出现且可点（能退出穿透）。

--- a/hibiki/test/tools/hook_overlay_passthrough_ex_transparent_guard_test.dart
+++ b/hibiki/test/tools/hook_overlay_passthrough_ex_transparent_guard_test.dart
@@ -100,6 +100,35 @@ void main() {
         reason: 'Hide 必须清掉透明位，避免重新 show 继承陈旧命中态');
   });
 
+  test('⑥ SetTimer 失败时不得进穿透态（否则没有 tick 能再清掉透明位）', () {
+    expect(
+      RegExp(r'bool\s+FloatingLyricWindow::StartPassThroughCursorPoll')
+          .hasMatch(src),
+      isTrue,
+      reason: '轮询启动必须能上报失败，否则调用方无从得知',
+    );
+    expect(
+      src.contains('void FloatingLyricWindow::AbortPassThroughWithoutPoll()'),
+      isTrue,
+      reason: 'SetTimer 失败后必须有一条退路：'
+          '置上 WS_EX_TRANSPARENT 却没有 tick 能清掉它 = 把用户锁死在穿透态',
+    );
+    // SetPassThrough 与 Show 两个启动点都必须真的处理失败。
+    expect(
+      'AbortPassThroughWithoutPoll();'.allMatches(src).length,
+      greaterThanOrEqualTo(2),
+      reason: 'SetPassThrough 和 Show 两条启动路径都要处理 SetTimer 失败',
+    );
+    final int abortStart =
+        src.indexOf('void FloatingLyricWindow::AbortPassThroughWithoutPoll()');
+    final int abortEnd = src.indexOf('\n}', abortStart);
+    final String abortBody = src.substring(abortStart, abortEnd);
+    expect(abortBody.contains('pass_through_ = false;'), isTrue,
+        reason: '退路必须真的把穿透态摸下来，而不是只清个 ex-style');
+    expect(abortBody.contains('ApplyPassThroughHitTest(true);'), isTrue,
+        reason: '退路必须把点击还给浮窗');
+  });
+
   test('⑤ 恢复带几何只有一份（WM_NCHITTEST 与轮询不得各算各的）', () {
     expect(
       RegExp(r'bool\s+FloatingLyricWindow::PassThroughRecoveryContainsClientY')

--- a/hibiki/test/tools/hook_overlay_passthrough_ex_transparent_guard_test.dart
+++ b/hibiki/test/tools/hook_overlay_passthrough_ex_transparent_guard_test.dart
@@ -1,0 +1,123 @@
+// BUG-951 源码守卫：Hook 浮窗开鼠标穿透后，点击必须真的落到游戏窗口。
+//
+// 根因：WM_NCHITTEST 返回 HTTRANSPARENT 在 Win32 契约里**只在同线程窗口间下传**。
+// 游戏是另一个进程，所以浮窗说“这不是我的”之后系统找不到下一个接手的同线程
+// 窗口，点击**整个消失**（既不给游戏，也不给浮窗）。旧实现之所以在部分场景
+// “看上去能用”，只是因为背景不透明度为 0 时体表像素 alpha=0，是**层窗口的逐像素
+// 命中测试**让点击落下去的，跟 HTTRANSPARENT 无关；一旦用户把背景不透明度调成
+// 非 0，整个正文区吞点击，即便为 0，点在不透明的文字笔画上照样被吞。
+//
+// 修复：穿透态改用 WS_EX_TRANSPARENT（真跨进程，与像素 alpha 无关）。但该位是整窗
+// 属性，永久开着会把顶部“恢复带”（那里有退出穿透的按钮）一起穿掉，全屏 galgame
+// 下等于把用户锁死；所以按光标位置动态开关。native C++ 无法在 Dart 测试里执行，
+// 此守卫锁定源码接线不被退化。
+//
+// 完整复现矩阵（跨进程真实 SendInput 点击）见 BUG-951 文件。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final String src =
+      File('windows/runner/floating_lyric_window.cpp').readAsStringSync();
+  final String header =
+      File('windows/runner/floating_lyric_window.h').readAsStringSync();
+
+  test('① 穿透态必须真的设 WS_EX_TRANSPARENT（不能只靠 HTTRANSPARENT）', () {
+    expect(
+      src.contains('WS_EX_TRANSPARENT'),
+      isTrue,
+      reason: 'HTTRANSPARENT 只在同线程窗口间下传，对另一进程的游戏窗口无效；'
+          '穿透必须落到 WS_EX_TRANSPARENT 上',
+    );
+    expect(
+      RegExp(r'ex\s*\|\s*static_cast<LONG_PTR>\(WS_EX_TRANSPARENT\)')
+          .hasMatch(src),
+      isTrue,
+      reason: '穿透时必须把 WS_EX_TRANSPARENT 加进 ex-style',
+    );
+    expect(
+      RegExp(r'ex\s*&\s*~static_cast<LONG_PTR>\(WS_EX_TRANSPARENT\)')
+          .hasMatch(src),
+      isTrue,
+      reason: '退出穿透时必须把 WS_EX_TRANSPARENT 去掉，'
+          '否则浮窗自己的交互永远回不来',
+    );
+    expect(src.contains('SetWindowLongPtr(hwnd_, GWL_EXSTYLE, ex);'), isTrue,
+        reason: 'ex-style 写回路径不得被移除');
+  });
+
+  test('② ex-style 改完必须用 SWP_FRAMECHANGED 提交', () {
+    // 实测：光 SetWindowLongPtr 时位读回已变，命中测试却还用旧值。
+    final int applyStart = src.indexOf('void FloatingLyricWindow::ApplyPassThroughHitTest');
+    expect(applyStart, greaterThan(-1),
+        reason: 'ApplyPassThroughHitTest 是穿透命中测试的唯一写入点，不得被移除');
+    final int applyEnd = src.indexOf('\nvoid FloatingLyricWindow::', applyStart + 1);
+    final String body =
+        src.substring(applyStart, applyEnd > 0 ? applyEnd : src.length);
+    expect(body.contains('SWP_FRAMECHANGED'), isTrue,
+        reason: '不走 SWP_FRAMECHANGED 提交，WS_EX_TRANSPARENT 的改动不会真正生效');
+  });
+
+  test('③ 靠光标轮询驱动（透明窗收不到任何鼠标消息）', () {
+    expect(
+      RegExp(r'constexpr\s+UINT_PTR\s+kPassThroughPollTimerId').hasMatch(src),
+      isTrue,
+      reason: '穿透态下窗口收不到 WM_MOUSEMOVE，'
+          '“光标进入恢复带”只能靠轮询发现',
+    );
+    expect(src.contains('case WM_TIMER:'), isTrue,
+        reason: '轮询定时器必须有对应的 WM_TIMER 处理分支');
+    expect(src.contains('UpdatePassThroughFromCursor'), isTrue,
+        reason: 'WM_TIMER 必须真的重算命中态');
+    expect(
+      RegExp(r'SetTimer\(hwnd_,\s*kPassThroughPollTimerId').hasMatch(src) &&
+          RegExp(r'KillTimer\(hwnd_,\s*kPassThroughPollTimerId').hasMatch(src),
+      isTrue,
+      reason: '定时器必须成对启停，不能只开不关',
+    );
+  });
+
+  test('④ 退出穿透必须无条件把点击还给浮窗（最大回归风险）', () {
+    final int start = src.indexOf('void FloatingLyricWindow::SetPassThrough');
+    expect(start, greaterThan(-1));
+    final int end = src.indexOf('\nvoid FloatingLyricWindow::', start + 1);
+    final String body = src.substring(start, end > 0 ? end : src.length);
+    expect(
+      body.contains('ApplyPassThroughHitTest(true)'),
+      isTrue,
+      reason: '关掉穿透时必须显式清掉 WS_EX_TRANSPARENT，'
+          '否则浮窗的拖拽/查词/工具条全部失效',
+    );
+    expect(body.contains('StopPassThroughCursorPoll()'), isTrue,
+        reason: '退出穿透后不应再留着轮询定时器');
+    // Hide 同样不能把窗口留在透明态，否则重新 show 会继承陈旧命中态。
+    final int hideStart = src.indexOf('void FloatingLyricWindow::Hide()');
+    final int hideEnd = src.indexOf('\nbool FloatingLyricWindow::', hideStart + 1);
+    final String hideBody =
+        src.substring(hideStart, hideEnd > 0 ? hideEnd : src.length);
+    expect(hideBody.contains('ApplyPassThroughHitTest(true)'), isTrue,
+        reason: 'Hide 必须清掉透明位，避免重新 show 继承陈旧命中态');
+  });
+
+  test('⑤ 恢复带几何只有一份（WM_NCHITTEST 与轮询不得各算各的）', () {
+    expect(
+      RegExp(r'bool\s+FloatingLyricWindow::PassThroughRecoveryContainsClientY')
+          .hasMatch(src),
+      isTrue,
+      reason: '恢复带必须是单一谓词，否则“画出来的工具条”和'
+          '“能点的工具条”会漂开',
+    );
+    // WM_NCHITTEST 与轮询两处调用，加上定义本身 = 3 次。
+    expect(
+      'PassThroughRecoveryContainsClientY'.allMatches(src).length,
+      greaterThanOrEqualTo(3),
+      reason: 'WM_NCHITTEST 和光标轮询必须调同一个谓词',
+    );
+    expect(
+      header.contains('bool PassThroughRecoveryContainsClientY(float client_y) const;'),
+      isTrue,
+      reason: '谓词声明不得被移除',
+    );
+  });
+}

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -337,7 +337,9 @@ bool FloatingLyricWindow::Show(HWND owner) {
   // BUG-951: "show" carries passThrough, so SetPassThrough usually runs while
   // hwnd_ is still null on the first show. Arm the poll here, once the window
   // really exists.
-  StartPassThroughCursorPoll();
+  if (!StartPassThroughCursorPoll()) {
+    AbortPassThroughWithoutPoll();
+  }
   RequestRender();
   return true;
 }
@@ -554,16 +556,33 @@ void FloatingLyricWindow::UpdatePassThroughFromCursor() {
   }
 }
 
-void FloatingLyricWindow::StartPassThroughCursorPoll() {
-  if (hwnd_ == nullptr || !pass_through_ || !hook_text_mode_) {
-    return;
+bool FloatingLyricWindow::StartPassThroughCursorPoll() {
+  if (!pass_through_ || !hook_text_mode_) {
+    return true;  // Nothing to arm; not a failure.
   }
-  if (!pass_through_poll_active_ &&
-      SetTimer(hwnd_, kPassThroughPollTimerId, kPassThroughPollIntervalMs,
-               nullptr) != 0) {
+  if (hwnd_ == nullptr) {
+    // SetPassThrough usually runs before the first Show(). Nothing has been
+    // applied yet (ApplyPassThroughHitTest is a no-op on a null window), and
+    // Show() arms the poll once the window exists.
+    return true;
+  }
+  if (!pass_through_poll_active_) {
+    if (SetTimer(hwnd_, kPassThroughPollTimerId, kPassThroughPollIntervalMs,
+                 nullptr) == 0) {
+      // Do NOT fall through to UpdatePassThroughFromCursor(): setting
+      // WS_EX_TRANSPARENT here would be a one-way door.
+      return false;
+    }
     pass_through_poll_active_ = true;
   }
   UpdatePassThroughFromCursor();
+  return true;
+}
+
+void FloatingLyricWindow::AbortPassThroughWithoutPoll() {
+  pass_through_ = false;
+  StopPassThroughCursorPoll();
+  ApplyPassThroughHitTest(true);
 }
 
 void FloatingLyricWindow::StopPassThroughCursorPoll() {
@@ -585,7 +604,9 @@ void FloatingLyricWindow::SetPassThrough(bool enabled) {
   }
   if (pass_through_ && hook_text_mode_) {
     // May be called before Show() has created the window; Show() re-arms.
-    StartPassThroughCursorPoll();
+    if (!StartPassThroughCursorPoll()) {
+      AbortPassThroughWithoutPoll();
+    }
   } else {
     StopPassThroughCursorPoll();
     // Leaving pass-through must always hand the window its own clicks back,

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -101,6 +101,14 @@ constexpr uint32_t kHookTextMinCatchAlpha = 5;  // ~2%, invisible but hittable
 // 指示条压不到任何一个字，也就不必为它缩窄换行宽度——缩窄宽度会反过来改变
 // metrics.height，从而改变可滚行程，形成回环。轨道底端让开右下角 resize grip，
 // 免得两个可拖拽的东西叠在同一块像素上。
+// BUG-951 - pass-through cursor poll. A WS_EX_TRANSPARENT window gets no mouse
+// messages at all, so the only way to notice the cursor entering the top
+// recovery band is to ask. One tick per display frame is enough for a hover
+// affordance and costs a GetCursorPos plus two compares; the timer only exists
+// while pass-through is actually on.
+constexpr UINT_PTR kPassThroughPollTimerId = 1;
+constexpr UINT kPassThroughPollIntervalMs = 16;
+
 constexpr float kScrollBarWidthDip = 4.0f;
 constexpr float kScrollBarMinThumbDip = 16.0f;
 constexpr float kScrollWheelStepDip = 40.0f;
@@ -126,6 +134,7 @@ UINT32 GlyphLength(const wchar_t* glyph) {
 FloatingLyricWindow::FloatingLyricWindow() = default;
 
 FloatingLyricWindow::~FloatingLyricWindow() {
+  StopPassThroughCursorPoll();
   if (hwnd_ != nullptr) {
     DestroyWindow(hwnd_);
     hwnd_ = nullptr;
@@ -325,6 +334,10 @@ bool FloatingLyricWindow::Show(HWND owner) {
   SetWindowPos(hwnd_, topmost_ ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
   visible_ = true;
+  // BUG-951: "show" carries passThrough, so SetPassThrough usually runs while
+  // hwnd_ is still null on the first show. Arm the poll here, once the window
+  // really exists.
+  StartPassThroughCursorPoll();
   RequestRender();
   return true;
 }
@@ -334,6 +347,11 @@ void FloatingLyricWindow::Hide() {
   hovered_ = false;
   tracking_mouse_leave_ = false;
   dragging_ = false;
+  // BUG-951: a hidden window has no cursor to track. Drop the timer, and clear
+  // WS_EX_TRANSPARENT so a re-Show never starts from a stale hit-test state
+  // (Show -> StartPassThroughCursorPoll re-applies it from the live cursor).
+  StopPassThroughCursorPoll();
+  ApplyPassThroughHitTest(true);
   if (hwnd_ != nullptr) {
     ShowWindow(hwnd_, SW_HIDE);
   }
@@ -478,6 +496,83 @@ void FloatingLyricWindow::SetLocked(bool locked) {
   RequestRender();
 }
 
+bool FloatingLyricWindow::PassThroughRecoveryContainsClientY(
+    float client_y) const {
+  // The band is exactly the strip Render() paints (t_top + t_btn) and exactly
+  // the row ControlActionAt() accepts, so "visible toolbar", "clickable
+  // toolbar" and "not click-through" are one rectangle by construction.
+  return client_y >= 0.0f &&
+         client_y <= ScaleForDpi(kControlsTopDip + kButtonSizeDip);
+}
+
+void FloatingLyricWindow::ApplyPassThroughHitTest(bool interactive) {
+  if (hwnd_ == nullptr) {
+    return;
+  }
+  const bool want_transparent = !interactive;
+  if (ex_transparent_ == want_transparent) {
+    return;
+  }
+  LONG_PTR ex = GetWindowLongPtr(hwnd_, GWL_EXSTYLE);
+  ex = want_transparent
+           ? (ex | static_cast<LONG_PTR>(WS_EX_TRANSPARENT))
+           : (ex & ~static_cast<LONG_PTR>(WS_EX_TRANSPARENT));
+  SetWindowLongPtr(hwnd_, GWL_EXSTYLE, ex);
+  // A bare SetWindowLongPtr is NOT committed until the frame is recalculated -
+  // without this the bit reads back changed while hit-testing still uses the
+  // old value.
+  SetWindowPos(hwnd_, nullptr, 0, 0, 0, 0,
+               SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE |
+                   SWP_FRAMECHANGED);
+  ex_transparent_ = want_transparent;
+}
+
+void FloatingLyricWindow::UpdatePassThroughFromCursor() {
+  if (hwnd_ == nullptr || !pass_through_ || !hook_text_mode_) {
+    return;
+  }
+  // A press or drag that began in the band owns the mouse until it ends;
+  // turning the window transparent underneath a live gesture would strand it.
+  if (pressed_ || dragging_) {
+    return;
+  }
+  POINT cursor = {};
+  RECT rc = {};
+  if (!GetCursorPos(&cursor) || !GetWindowRect(hwnd_, &rc)) {
+    return;
+  }
+  const bool interactive =
+      PtInRect(&rc, cursor) != FALSE &&
+      PassThroughRecoveryContainsClientY(static_cast<float>(cursor.y - rc.top));
+  ApplyPassThroughHitTest(interactive);
+  // The toolbar only draws (Render) and only accepts hits (ControlActionAt)
+  // while hovered_; drive it from the poll rather than from WM_MOUSEMOVE, which
+  // the window cannot receive while it is transparent.
+  if (hovered_ != interactive) {
+    hovered_ = interactive;
+    RequestRender();
+  }
+}
+
+void FloatingLyricWindow::StartPassThroughCursorPoll() {
+  if (hwnd_ == nullptr || !pass_through_ || !hook_text_mode_) {
+    return;
+  }
+  if (!pass_through_poll_active_ &&
+      SetTimer(hwnd_, kPassThroughPollTimerId, kPassThroughPollIntervalMs,
+               nullptr) != 0) {
+    pass_through_poll_active_ = true;
+  }
+  UpdatePassThroughFromCursor();
+}
+
+void FloatingLyricWindow::StopPassThroughCursorPoll() {
+  if (hwnd_ != nullptr && pass_through_poll_active_) {
+    KillTimer(hwnd_, kPassThroughPollTimerId);
+  }
+  pass_through_poll_active_ = false;
+}
+
 void FloatingLyricWindow::SetPassThrough(bool enabled) {
   if (pass_through_ == enabled) {
     return;
@@ -487,6 +582,15 @@ void FloatingLyricWindow::SetPassThrough(bool enabled) {
   dragging_ = false;
   if (GetCapture() == hwnd_) {
     ReleaseCapture();
+  }
+  if (pass_through_ && hook_text_mode_) {
+    // May be called before Show() has created the window; Show() re-arms.
+    StartPassThroughCursorPoll();
+  } else {
+    StopPassThroughCursorPoll();
+    // Leaving pass-through must always hand the window its own clicks back,
+    // whatever the cursor happens to be doing.
+    ApplyPassThroughHitTest(true);
   }
   RequestRender();
 }
@@ -609,6 +713,13 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
         }
       }
       return 0;
+    }
+    case WM_TIMER: {
+      if (wparam == kPassThroughPollTimerId) {
+        UpdatePassThroughFromCursor();
+        return 0;
+      }
+      return DefWindowProc(hwnd_, message, wparam, lparam);
     }
     case WM_MOUSELEAVE: {
       tracking_mouse_leave_ = false;
@@ -737,12 +848,15 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       POINT screen = {GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam)};
       POINT client = screen;
       ScreenToClient(hwnd_, &client);
-      if (hook_text_mode_ && pass_through_) {
-        const float recovery_height =
-            ScaleForDpi(kControlsTopDip + kButtonSizeDip);
-        if (static_cast<float>(client.y) > recovery_height) {
-          return HTTRANSPARENT;
-        }
+      // BUG-951: the real cross-process pass-through is WS_EX_TRANSPARENT,
+      // applied by UpdatePassThroughFromCursor - while the body is transparent
+      // this case is not even reached. HTTRANSPARENT stays only as the
+      // same-thread fallback covering the one poll tick between the cursor
+      // leaving the recovery band and the bit being set: declining the click is
+      // strictly better than swallowing it into a word lookup nobody asked for.
+      if (hook_text_mode_ && pass_through_ &&
+          !PassThroughRecoveryContainsClientY(static_cast<float>(client.y))) {
+        return HTTRANSPARENT;
       }
       if (ResizeGripContains(static_cast<float>(client.x),
                              static_cast<float>(client.y))) {

--- a/hibiki/windows/runner/floating_lyric_window.h
+++ b/hibiki/windows/runner/floating_lyric_window.h
@@ -151,6 +151,9 @@ class FloatingLyricWindow {
   bool IsLocked() const { return locked_; }
   void SetPassThrough(bool enabled);
   bool IsPassThrough() const { return pass_through_; }
+  // BUG-951 test seam: is WS_EX_TRANSPARENT currently applied? Pass-through is
+  // only genuinely cross-process while this bit is set.
+  bool IsExTransparentForTesting() const { return ex_transparent_; }
   // Restores a physical-pixel window rectangle before the next Show. Invalid
   // rectangles are ignored and Show uses its DPI-aware default.
   void SetInitialBounds(int left, int top, int width, int height);
@@ -166,6 +169,34 @@ class FloatingLyricWindow {
   bool EnsureTextResources();
   void Render();
   void RequestRender();
+
+  // BUG-951 — pass-through hit-testing.
+  //
+  // WM_NCHITTEST -> HTTRANSPARENT only walks on to windows on the SAME THREAD
+  // (documented Win32 contract). Over a game owned by another process it hands
+  // the click to nobody: the overlay declines it, the search finds no further
+  // same-thread window, and the click is swallowed. Only WS_EX_TRANSPARENT
+  // makes a window genuinely invisible to the mouse across processes, and
+  // unlike the layered per-pixel alpha rule it holds for opaque pixels too
+  // (a visible background, and the glyph strokes themselves).
+  //
+  // The bit is a whole-window property, so it cannot be left on permanently:
+  // the top recovery band carries the button that LEAVES pass-through, and a
+  // permanently transparent overlay would strand the user in a fullscreen
+  // game. The band is therefore kept live by tracking the cursor and clearing
+  // the bit only while it hovers there.
+  //
+  // |interactive| true = the window takes its own clicks (bit cleared).
+  void ApplyPassThroughHitTest(bool interactive);
+  // Single geometry predicate for the always-live recovery band, shared by
+  // WM_NCHITTEST and the cursor poll so the two can never drift apart.
+  bool PassThroughRecoveryContainsClientY(float client_y) const;
+  // Re-evaluates the band predicate against the live cursor position. A
+  // WS_EX_TRANSPARENT window receives no mouse messages, so entering the band
+  // is only observable by polling.
+  void UpdatePassThroughFromCursor();
+  void StartPassThroughCursorPoll();
+  void StopPassThroughCursorPoll();
 
   // Geometry of the lyric text area in client (DIP-equivalent physical px),
   // computed during the last Render. Used for tap hit-testing.
@@ -249,6 +280,10 @@ class FloatingLyricWindow {
   bool text_only_ = false;
   bool hook_text_mode_ = false;
   bool pass_through_ = false;
+  // BUG-951: mirrors the live WS_EX_TRANSPARENT bit so the ex-style is only
+  // rewritten when it actually changes (the poll runs every frame).
+  bool ex_transparent_ = false;
+  bool pass_through_poll_active_ = false;
   bool hovered_ = false;
   bool tracking_mouse_leave_ = false;
   // Position lock: drag disabled, everything else (lookup + controls) still

--- a/hibiki/windows/runner/floating_lyric_window.h
+++ b/hibiki/windows/runner/floating_lyric_window.h
@@ -151,9 +151,6 @@ class FloatingLyricWindow {
   bool IsLocked() const { return locked_; }
   void SetPassThrough(bool enabled);
   bool IsPassThrough() const { return pass_through_; }
-  // BUG-951 test seam: is WS_EX_TRANSPARENT currently applied? Pass-through is
-  // only genuinely cross-process while this bit is set.
-  bool IsExTransparentForTesting() const { return ex_transparent_; }
   // Restores a physical-pixel window rectangle before the next Show. Invalid
   // rectangles are ignored and Show uses its DPI-aware default.
   void SetInitialBounds(int left, int top, int width, int height);
@@ -195,8 +192,15 @@ class FloatingLyricWindow {
   // WS_EX_TRANSPARENT window receives no mouse messages, so entering the band
   // is only observable by polling.
   void UpdatePassThroughFromCursor();
-  void StartPassThroughCursorPoll();
+  // Returns false ONLY when the poll could not be armed (SetTimer failed).
+  // "Nothing to arm" (not in pass-through, or window not created yet - Show()
+  // re-arms) is success: nothing has been applied in that case.
+  bool StartPassThroughCursorPoll();
   void StopPassThroughCursorPoll();
+  // No tick means no way back: once WS_EX_TRANSPARENT is set nothing could ever
+  // clear it again and the user is locked inside an overlay whose own toolbar
+  // is unclickable. Refuse to enter pass-through at all instead.
+  void AbortPassThroughWithoutPoll();
 
   // Geometry of the lyric text area in client (DIP-equivalent physical px),
   // computed during the last Render. Used for tap hit-testing.


### PR DESCRIPTION
## BUG-951：浮窗开鼠标穿透后，点击落不到游戏

**结论：确定性复现为真**（不再是「静态可疑」）。用跨进程最小 Win32 装置 + 真实 `SendInput` 点击验证。

### 根因

`hibiki/windows/runner/floating_lyric_window.cpp`（修前 732-751）穿透仅靠 `WM_NCHITTEST` 返回 `HTTRANSPARENT`。Win32 契约中它**只在同线程窗口间下传**。游戏属于另一进程，所以浮窗声明「这不是我的」之后，系统找不到下一个同线程窗口接手，点击**整个消失**——既不给游戏，也不给浮窗。

旧实现在部分场景「看起来能用」，只是因为背景不透明度为 0 时体表像素 alpha=0，是**层窗口的逐像素命中测试**把点击放下去的，与 `HTTRANSPARENT` 无关。于是：

- 用户把背景不透明度调成非 0（`_backgroundColor = alpha << 24`）→ 整个正文区吞点击；
- 即便为 0，**文字笔画像素是不透明的** → 点在字上照样被吞。

### 复现矩阵

每格 = 一对全新跨进程窗口 + 一次真实 `SendInput` 点击。

| overlay 配置 | 点正文区 | 点顶部恢复带 |
|---|---|---|
| alpha=0，`HTTRANSPARENT` | 游戏收到 ✅ | 游戏收到 ❌（工具条点不到）|
| alpha=5（2%），`HTTRANSPARENT` | **两边都没收到，点击被吞 ❌** | 同左 ❌ |
| alpha=200，`HTTRANSPARENT` | **两边都没收到，点击被吞 ❌** | 同左 ❌ |
| alpha=200，静态 `WS_EX_TRANSPARENT` | 游戏收到 ✅ | 游戏收到 ❌（工具条点不到）|
| `WS_EX_TRANSPARENT` + 光标在恢复带时清位 | **游戏收到 ✅** | **浮窗收到 ✅** |

装置与完整日志留在本机 `tmp/bug951-repro.md`（不入库）。

### 修复

穿透态改用 `WS_EX_TRANSPARENT`（真跨进程，与像素 alpha 无关）。该位是**整窗属性**，永久开启会把顶部恢复带（退出穿透的按钮就在那里）一起穿掉，全屏 galgame 下等于把用户锁死；因此按光标位置动态开关，仅当光标悬停在恢复带时清位。

- 透明窗收不到任何鼠标消息，「光标进入恢复带」只能靠轮询发现 → 16ms 定时器，**仅在穿透开启期间存在**。
- 恢复带几何收成单一谓词 `PassThroughRecoveryContainsClientY`，`WM_NCHITTEST` 与轮询共用，不会漂开。
- `HTTRANSPARENT` 降为同线程兜底，覆盖光标离开恢复带到该位被置上之间的那一个 tick——那段时间里拒接点击好过把它吞成一次用户没要的查词。
- 退出穿透 / `Hide` 无条件 `ApplyPassThroughHitTest(true)`，把点击还给浮窗（**最大回归风险**：别把浮窗自己的拖拽/查词/工具条一起穿透掉）。

**坑**：`SetWindowLongPtr(GWL_EXSTYLE)` 改完必须再 `SetWindowPos(..., SWP_FRAMECHANGED)` 提交，否则位读回已变而命中测试仍用旧值（实测踩过）。

### 测试

- 新增源码扫描守卫 `hibiki/test/tools/hook_overlay_passthrough_ex_transparent_guard_test.dart`（5 条）。**负向对照已验**：对修复前源码跑为 0 通过 / 5 失败。
- 旁边的 BUG-1046 alpha 下限守卫仍全绿（两者改的不是同几行）。
- 定向 `flutter test` 34/34 通过；`flutter build windows --debug` exit 0。

### 仍需真机验收

native C++ 跑不进 Dart 测试，自动化层只能锁源码接线。真机需在真实 galgame 上走一遍：开穿透 → 点浮窗遮住的正文区 → 游戏推进对话；再把光标移到浮窗顶部 → 工具条出现且可点（能退出穿透）。

### 顺带发现（不在本 PR 范围）

`develop` 当前 `flutter analyze` 有 2 个 **既有** error，来自 `d2b5e1f62`（BUG-1113 游戏用户标签池）：`test/pages/games_library_user_tags_test.dart:149,150` 引用了 `games_no_match` / `games_empty`，而这两个 key 在 17 个 i18n 文件里**都不存在**。与本 PR 无关，但 CI 把 warning 当致命，建议尽快补 key。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
