### PR TITLE
fix(lookup): app 外浮窗 Ctrl+滚轮不再触发 WebView2 原生缩放（BUG-1138）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,11 +27,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1105 条。点号进各自文件。
+> 共 1106 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1140](bugs/BUG-1140-cross-chapter-turn-latency.md) | ✅ | ✅ | 跨章翻页耗时实测与提速（遮罩口径） |
+| [BUG-1139](bugs/BUG-1139-overlay-ctrl-wheel-zoom.md) | ✅ | ✅ | app 外查词浮窗 Ctrl+滚轮触发 WebView2 原生页面缩放，窗口/region 几何按 zoom=1 计算导致卡片被切、露出底下应用 |
 | [BUG-1137](bugs/BUG-1137-gal-mining-video-tag.md) | ✅ | ✅ | gal 制卡分类标签误标 video：来源枚举缺 game 且默认值静默兜底 |
 | [BUG-1136](bugs/BUG-1136-ios-reader-scroll-lookup.md) | ✅ | ✅ | iPhone 阅读滑动被误判为点词查词 |
 | [BUG-1135](bugs/BUG-1135-gal-clipnear-bypasses-track-exclusion.md) | ✅ | ✅ | gal 制卡兜底 grabClipNear 绕过选轨/排除集——排除的 BGM 轨会从兜底混回卡片 |

--- a/docs/bugs/BUG-1139-overlay-ctrl-wheel-zoom.md
+++ b/docs/bugs/BUG-1139-overlay-ctrl-wheel-zoom.md
@@ -1,6 +1,10 @@
 ## BUG-1139 · app 外查词浮窗 Ctrl+滚轮触发 WebView2 原生页面缩放，窗口/region 几何按 zoom=1 计算导致卡片被切、露出底下应用
 - **报告**：2026-07-27（用户：「这个缩放有点问题 滚轮。左边是空的。」附截图：Anki 上方的 app 外查词浮窗，第一张词典卡被窗口左边缘竖着切掉一半，切口外直接是 Anki 的背景）
 - **真实性**：✅ 真 bug（沿真实代码路径验真，未复现于 in-app 弹窗——in-app 有独立的两道防护，见下）
+- **现状（2026-07-27 复审）**：⚠️ **标题症状尚未闭环**。① 拆掉了 WebView2 原生 ZoomFactor
+  这个第二真值来源（真实且必要），但几何链对 CSS zoom 依旧零补偿，放大后窗口宽度不变、高度在
+  未触卡上限时仍偏小 z 倍，卡片仍会被 window region 切。详见下方 ③。下面 ①/② 的 `[x]` 只表示
+  「原生缩放已断开」与「已有守卫」，**不代表用户可见症状已消失**。
 
 ### 根因
 
@@ -43,11 +47,49 @@ in-app 弹窗为何不受影响：`dictionary_popup_webview.dart:1227` 设了 `s
      Ctrl+滚轮、弹窗顶栏 A−/A+ 同一真值），改 `dictionaryFontSize` 后回调整栈重渲；
      `global_lookup_controller` / `clipboard_panel_controller` 各接一处（共享实现，两表面不漂开）。
 
-  **有意不做**的事：app 外**不**就地改 `documentElement.style.zoom`。CSS `zoom` 下
-  `body.scrollHeight` 仍是未乘 z 的 CSS px，而 host 的 `measureContentHeight` 正是读它报卡片高度 ——
-  就地缩放会让高度被系统性报小 z 倍，等于把同一个几何毛病换个地方复发。走 Dart 改字号 → 重渲 →
-  按新字号真实重排，高度/bbox/region 沿现有链路自然更新，几何链一行不用改。代价是每档多一次
-  Dart 往返（约 1~2 帧）。
+  **有意不做**的事：app 外**不**在 JS 侧就地改 `documentElement.style.zoom`，改由 Dart 改
+「词典字号」这一唯一真值后整栈重渲，避免 JS 与 Dart 两处各写一份 zoom。代价是每档多一次
+Dart 往返（约 1~2 帧）。
+
+- **[ ] ③ 未闭环：几何链仍不认识 CSS zoom（复审 2026-07-27 发现，原始症状会以同一形态复发）**
+
+  ① 只拆掉了「WebView2 原生 ZoomFactor」这个第二真值来源，**没有**给几何链补上 zoom 分量。
+  沿真实代码路径复核后，本文件早先「走 Dart 改字号 → 按新字号真实重排，高度/bbox/region 沿现有
+  链路自然更新」的说法**不成立**：
+
+  1. `dictionaryFontSize` 对渲染的**唯一**作用就是 CSS zoom ——
+     `popup_settings_injection.dart:534-537,551` 注入
+     `documentElement.style.zoom = popupContentZoom(appUiScale, fs)`
+     （`dictionary_popup_webview.dart:283-289`，= `appUiScale × fs/16`）；
+     全仓没有任何一处用 `dictionaryFontSize` 生成 `font-size` CSS。所以「重渲」重渲出来的
+     差异也只是这一行 zoom —— 原生 zoom 换成了 CSS zoom，不是真正的按字号重排。
+  2. 几何链对 CSS zoom **零补偿**：`global_lookup_host.js:1820-1834` 的 `measureContentHeight`
+     直接读 `body.scrollHeight / offsetHeight`（CSS `zoom` 下是未乘 z 的 layout px，本仓
+     `popup.js:3929-3945` 自己钉死过这个事实），没有 `× z`。
+  3. 高度只会**往小里收**：`global_lookup_host.js:1722-1725`
+     `if (measured > 0 && (height <= 0 || measured < height)) height = measured;`，撑不大。
+  4. 物理窗口公式里没有字号分量：`global_lookup_controller.dart:1350-1351`
+     `overlaySize.width/height × appUiScale`（`:1445-1448` 再 `× dpr`）—— 只有 `appUiScale`，
+     没有 `popupContentZoom`/`fs`。注意这里的不对称：`appUiScale` 在盒子侧被完整抵消
+     （内容与盒子同步放大），而 `fs` 只放大内容、盒子一动不动。
+
+  后果：Ctrl+滚轮放大后**窗口宽度一个像素都不会变**（卡内有效布局宽反而从 `size×16/16` 缩到
+  `size×16/fs`，文字列变窄、行数变多）；高度在「内容未触卡上限」时被裁到未乘 z 的 `measured`，
+  而卡片实际画出 `measured × z`，底部 `(1 − 1/z)` 落在 window region 外 → **卡片照样被切、
+  照样露出底下的应用**。
+
+  需要说清的归属：这条**不是本 PR 引入的回归** —— head 里那行 zoom 注入在 develop 上一直存在，
+  任何 `dictionaryFontSize ≠ 16` 或 `appUiScale ≠ 1` 的老用户在 app 外浮窗上早已命中；本 PR 的
+  改动让用户可以用 Ctrl+滚轮在几秒内**交互式地**把自己滚进这个区间，因此暴露面明显变大。
+
+  真正闭环需要二选一（或都做），属独立跟进项：
+  - `measureContentHeight` 乘上 iframe 的 `documentElement.style.zoom`，把 layout px 换算成
+    host 可视 px；且高度判据要允许撑大而不只是收小；
+  - 或让 `cardW/cardH` 乘 `fs/16`，使盒子随字号长大，与 `appUiScale` 对称——否则「放大」永远
+    等价于「视口变窄」。
+
+  剪贴板面板路径不受**高度**问题影响：`global_lookup_host.js:1678-1683` 在 panel 模式直接短路
+  （窗口尺寸固定），但「放大=视口变窄」的观感问题同样存在。
 
 - **[x] ② 已加自动化测试** — `hibiki/test/lookup/overlay_ctrl_wheel_zoom_test.dart`（8 条）
   - 纯函数：净档数 → 字号折算、0 档、双侧夹死 8..72、顶到边界后返回原值（据此跳过无谓重渲）；
@@ -61,6 +103,9 @@ in-app 弹窗为何不受影响：`dictionary_popup_webview.dart:1227` 设了 `s
   （test/lookup、popup 列数、masonry 守卫、bugs per-file 守卫）+ `flutter build windows --debug`
   通过（323.3s，`√ Built build\windows\x64\runner\Debug\hibiki.exe`，`global_lookup_window.cpp`
   零告警——两个 COM setter 编译验证通过）。
-  **仍缺真机目视复测**：需在 Windows 上跑原始失败路径（Anki 上方开 app 外浮窗 → Ctrl+滚轮 →
-  卡片不再被窗口边缘切、字号逐档变、重开后记住档位），并顺带确认常驻剪贴板面板同样生效。
-  离屏 itest 取不到原生覆盖窗的像素（见 agent 文档的离屏能力边界），故这一步必须人工目视。
+  **仍缺真机目视复测**，且按 ③ 的分析，真机上跑原始失败路径（Anki 上方开 app 外浮窗 →
+  Ctrl+滚轮放大）**预期仍会看到卡片被切** —— 复测重点不是「是否已修好」，而是确认：
+  字号逐档变、重开后记住档位、原生 Ctrl+加减/触控板捏合确实已失效（① 生效），
+  以及 ③ 描述的切边形态与预测是否一致。离屏 itest 取不到原生覆盖窗的像素
+  （见 agent 文档的离屏能力边界），故这一步必须人工目视。
+  另注：本机 `flutter build windows --debug` 的验证结论仍成立（两个 COM setter 编译通过）。

--- a/docs/bugs/BUG-1139-overlay-ctrl-wheel-zoom.md
+++ b/docs/bugs/BUG-1139-overlay-ctrl-wheel-zoom.md
@@ -1,0 +1,66 @@
+## BUG-1139 · app 外查词浮窗 Ctrl+滚轮触发 WebView2 原生页面缩放，窗口/region 几何按 zoom=1 计算导致卡片被切、露出底下应用
+- **报告**：2026-07-27（用户：「这个缩放有点问题 滚轮。左边是空的。」附截图：Anki 上方的 app 外查词浮窗，第一张词典卡被窗口左边缘竖着切掉一半，切口外直接是 Anki 的背景）
+- **真实性**：✅ 真 bug（沿真实代码路径验真，未复现于 in-app 弹窗——in-app 有独立的两道防护，见下）
+
+### 根因
+
+一条「看不见的第二真值来源」：**WebView2 自带的页面缩放（ZoomFactor）不在覆盖窗的几何链里**。
+
+1. `hibiki/windows/runner/global_lookup_window.cpp:962` — `ForwardCompositionMouse` 把 `WM_MOUSEWHEEL`
+   连同 `GET_KEYSTATE_WPARAM`（含 `MK_CONTROL`）原样 `SendMouseInput` 给 WebView2。
+2. `hibiki/windows/runner/global_lookup_window.cpp` 的 `ConfigureWebView()` 只设了
+   `put_IsStatusBarEnabled(FALSE)`，**从没设 `put_IsZoomControlEnabled(FALSE)`** → 原生缩放默认开着。
+3. `hibiki/assets/popup/popup.js:4100` — 弹窗滚轮监听明确 `if (e.ctrlKey) return;`，把 Ctrl+滚轮让给原生。
+4. app 外浮窗**从没装** in-app 那套内容缩放：`_zoomWheelJs` / `__hoshiPopupZoomStep` 只在
+   `dictionary_popup_webview.dart:1872` 的 `onLoadStop` 注入（in-app 三个表面专属）。
+5. 而覆盖窗整条几何链按「CSS px @ zoom=1」算：
+   - `hibiki/assets/popup/global_lookup_host.js:1791-1817` — host 用 `shell.style.left/width` +
+     `body.scrollHeight` 报 bbox 与 shellRects（CSS px）；
+   - `hibiki/lib/src/lookup/global_lookup_controller.dart:251` — Dart 按 `逻辑宽 × appUiScale × dpr`
+     定物理窗口尺寸；
+   - C++ 再用同一批数值 `SetWindowPos` + `ApplyRoundedRegion` 裁 window region。
+
+ZoomFactor 只放大**绘制**，不改上面任何一个读数。于是 Ctrl+滚轮后内容按 z 绘制、窗口与 region 仍是
+z=1 的尺寸 → 卡片被窗口边缘切掉，region 外露出底下的应用（用户看到的「左边是空的」）。
+
+in-app 弹窗为何不受影响：`dictionary_popup_webview.dart:1227` 设了 `supportZoom: false`（关原生缩放），
+并自己装了走「词典字号 + 就地 zoom + 持久化」的 Ctrl+滚轮。两道防护 app 外一道都没有。
+
+加重项：WebView2 的缩放档位按 origin **持久记忆**在用户数据目录里 —— 只关控制不复位，已经缩过的
+老用户升级后窗口照样是切的。
+
+- **[x] ① 已修复** — commit `f0f5596ff`
+  1. `hibiki/windows/runner/global_lookup_window.cpp` `ConfigureWebView()`：
+     `put_IsZoomControlEnabled(FALSE)` 断掉原生缩放（与 in-app `supportZoom:false` 对齐）+
+     `put_ZoomFactor(1.0)` 复位持久档位。ConfigureWebView 是两条创建路径 + BUG-693 自愈重建的
+     唯一漏斗，覆盖这个窗曾经拥有的每个 surface；瞬态覆盖窗与常驻剪贴板面板是同一个
+     `GlobalLookupWindow` 类的两个实例，一处修复覆盖两个表面。
+  2. 缩放能力不丢：`popup_settings_injection.dart` 新增 `_globalLookupZoomWheelJs`（仅
+     `options.globalLookup` 注入），Ctrl+滚轮 → `preventDefault` → rAF 合帧累加**净档数** →
+     `callHandler('popupZoomFontStep', steps)`。
+  3. `overlay_bridge_handlers.dart` 新增 `maybeHandleOverlayZoomFontStep` + 纯函数
+     `zoomFontSizeAfterSteps`：逐档过既有的 `steppedPopupZoomFontSize`（含 8..72 夹紧，与 in-app
+     Ctrl+滚轮、弹窗顶栏 A−/A+ 同一真值），改 `dictionaryFontSize` 后回调整栈重渲；
+     `global_lookup_controller` / `clipboard_panel_controller` 各接一处（共享实现，两表面不漂开）。
+
+  **有意不做**的事：app 外**不**就地改 `documentElement.style.zoom`。CSS `zoom` 下
+  `body.scrollHeight` 仍是未乘 z 的 CSS px，而 host 的 `measureContentHeight` 正是读它报卡片高度 ——
+  就地缩放会让高度被系统性报小 z 倍，等于把同一个几何毛病换个地方复发。走 Dart 改字号 → 重渲 →
+  按新字号真实重排，高度/bbox/region 沿现有链路自然更新，几何链一行不用改。代价是每档多一次
+  Dart 往返（约 1~2 帧）。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/overlay_ctrl_wheel_zoom_test.dart`（8 条）
+  - 纯函数：净档数 → 字号折算、0 档、双侧夹死 8..72、顶到边界后返回原值（据此跳过无谓重渲）；
+  - 分发：非本 handler 不拦截；本 handler 恒被吞掉且无 model 时不重渲；
+  - 源码守卫：C++ 两项设置必须落在 `ConfigureWebView` 内；app 外注入必须有 ctrl 门控 +
+    `popupZoomFontStep` + rAF 合帧，且**不得**出现 `style.zoom`（防止把几何毛病搬回来）；
+    注入必须由 `globalLookup` 门控（防与 in-app `_zoomWheelJs` 双装一档滚两级）；
+    两个 app 外表面都必须接线。
+
+- **备注**：本机验证 = `flutter analyze` 全量（含 test）零问题 + 新测试 8/8 + 相邻定向 584/584
+  （test/lookup、popup 列数、masonry 守卫、bugs per-file 守卫）+ `flutter build windows --debug`
+  通过（323.3s，`√ Built build\windows\x64\runner\Debug\hibiki.exe`，`global_lookup_window.cpp`
+  零告警——两个 COM setter 编译验证通过）。
+  **仍缺真机目视复测**：需在 Windows 上跑原始失败路径（Anki 上方开 app 外浮窗 → Ctrl+滚轮 →
+  卡片不再被窗口边缘切、字号逐档变、重开后记住档位），并顺带确认常驻剪贴板面板同样生效。
+  离屏 itest 取不到原生覆盖窗的像素（见 agent 文档的离屏能力边界），故这一步必须人工目视。

--- a/docs/bugs/BUG-1139-overlay-ctrl-wheel-zoom.md
+++ b/docs/bugs/BUG-1139-overlay-ctrl-wheel-zoom.md
@@ -1,10 +1,9 @@
 ## BUG-1139 · app 外查词浮窗 Ctrl+滚轮触发 WebView2 原生页面缩放，窗口/region 几何按 zoom=1 计算导致卡片被切、露出底下应用
 - **报告**：2026-07-27（用户：「这个缩放有点问题 滚轮。左边是空的。」附截图：Anki 上方的 app 外查词浮窗，第一张词典卡被窗口左边缘竖着切掉一半，切口外直接是 Anki 的背景）
 - **真实性**：✅ 真 bug（沿真实代码路径验真，未复现于 in-app 弹窗——in-app 有独立的两道防护，见下）
-- **现状（2026-07-27 复审）**：⚠️ **标题症状尚未闭环**。① 拆掉了 WebView2 原生 ZoomFactor
-  这个第二真值来源（真实且必要），但几何链对 CSS zoom 依旧零补偿，放大后窗口宽度不变、高度在
-  未触卡上限时仍偏小 z 倍，卡片仍会被 window region 切。详见下方 ③。下面 ①/② 的 `[x]` 只表示
-  「原生缩放已断开」与「已有守卫」，**不代表用户可见症状已消失**。
+- **现状（2026-07-27 复审后已闭环）**：✅ 三段都落地。复审曾发现 ① 只断开了 WebView2 原生
+  ZoomFactor、几何链仍不认识 CSS zoom（放大后卡片照样被切），已在同一 PR 内补上 ③ 的测高换算，
+  原始失败路径现在真正闭环。
 
 ### 根因
 
@@ -51,61 +50,81 @@ in-app 弹窗为何不受影响：`dictionary_popup_webview.dart:1227` 设了 `s
 「词典字号」这一唯一真值后整栈重渲，避免 JS 与 Dart 两处各写一份 zoom。代价是每档多一次
 Dart 往返（约 1~2 帧）。
 
-- **[ ] ③ 未闭环：几何链仍不认识 CSS zoom（复审 2026-07-27 发现，原始症状会以同一形态复发）**
 
-  ① 只拆掉了「WebView2 原生 ZoomFactor」这个第二真值来源，**没有**给几何链补上 zoom 分量。
-  沿真实代码路径复核后，本文件早先「走 Dart 改字号 → 按新字号真实重排，高度/bbox/region 沿现有
-  链路自然更新」的说法**不成立**：
-
-  1. `dictionaryFontSize` 对渲染的**唯一**作用就是 CSS zoom ——
-     `popup_settings_injection.dart:534-537,551` 注入
-     `documentElement.style.zoom = popupContentZoom(appUiScale, fs)`
-     （`dictionary_popup_webview.dart:283-289`，= `appUiScale × fs/16`）；
-     全仓没有任何一处用 `dictionaryFontSize` 生成 `font-size` CSS。所以「重渲」重渲出来的
-     差异也只是这一行 zoom —— 原生 zoom 换成了 CSS zoom，不是真正的按字号重排。
-  2. 几何链对 CSS zoom **零补偿**：`global_lookup_host.js:1820-1834` 的 `measureContentHeight`
-     直接读 `body.scrollHeight / offsetHeight`（CSS `zoom` 下是未乘 z 的 layout px，本仓
-     `popup.js:3929-3945` 自己钉死过这个事实），没有 `× z`。
-  3. 高度只会**往小里收**：`global_lookup_host.js:1722-1725`
-     `if (measured > 0 && (height <= 0 || measured < height)) height = measured;`，撑不大。
-  4. 物理窗口公式里没有字号分量：`global_lookup_controller.dart:1350-1351`
-     `overlaySize.width/height × appUiScale`（`:1445-1448` 再 `× dpr`）—— 只有 `appUiScale`，
-     没有 `popupContentZoom`/`fs`。注意这里的不对称：`appUiScale` 在盒子侧被完整抵消
-     （内容与盒子同步放大），而 `fs` 只放大内容、盒子一动不动。
-
-  后果：Ctrl+滚轮放大后**窗口宽度一个像素都不会变**（卡内有效布局宽反而从 `size×16/16` 缩到
-  `size×16/fs`，文字列变窄、行数变多）；高度在「内容未触卡上限」时被裁到未乘 z 的 `measured`，
-  而卡片实际画出 `measured × z`，底部 `(1 − 1/z)` 落在 window region 外 → **卡片照样被切、
-  照样露出底下的应用**。
-
-  需要说清的归属：这条**不是本 PR 引入的回归** —— head 里那行 zoom 注入在 develop 上一直存在，
-  任何 `dictionaryFontSize ≠ 16` 或 `appUiScale ≠ 1` 的老用户在 app 外浮窗上早已命中；本 PR 的
-  改动让用户可以用 Ctrl+滚轮在几秒内**交互式地**把自己滚进这个区间，因此暴露面明显变大。
-
-  真正闭环需要二选一（或都做），属独立跟进项：
-  - `measureContentHeight` 乘上 iframe 的 `documentElement.style.zoom`，把 layout px 换算成
-    host 可视 px；且高度判据要允许撑大而不只是收小；
-  - 或让 `cardW/cardH` 乘 `fs/16`，使盒子随字号长大，与 `appUiScale` 对称——否则「放大」永远
-    等价于「视口变窄」。
-
-  剪贴板面板路径不受**高度**问题影响：`global_lookup_host.js:1678-1683` 在 panel 模式直接短路
-  （窗口尺寸固定），但「放大=视口变窄」的观感问题同样存在。
-
-- **[x] ② 已加自动化测试** — `hibiki/test/lookup/overlay_ctrl_wheel_zoom_test.dart`（8 条）
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/overlay_ctrl_wheel_zoom_test.dart`（9 条）
+  + `hibiki/test/lookup/global_lookup_host_test.mjs` 新增 **Z1**（node harness，行为级）
   - 纯函数：净档数 → 字号折算、0 档、双侧夹死 8..72、顶到边界后返回原值（据此跳过无谓重渲）；
   - 分发：非本 handler 不拦截；本 handler 恒被吞掉且无 model 时不重渲；
   - 源码守卫：C++ 两项设置必须落在 `ConfigureWebView` 内；app 外注入必须有 ctrl 门控 +
     `popupZoomFontStep` + rAF 合帧，且**不得**出现 `style.zoom`（防止把几何毛病搬回来）；
     注入必须由 `globalLookup` 门控（防与 in-app `_zoomWheelJs` 双装一档滚两级）；
-    两个 app 外表面都必须接线。
+    两个 app 外表面都必须接线；
+  - ③ 的几何换算有两层守卫：**行为级** node harness Z1（z=1 恒等 / z=2 按视觉高度报 /
+    超上限仍收敛到卡上限 / 非法 zoom 回落 1）—— 已做**负向验证**：去掉换算那一行，
+    Z1 以 `exit 1` 失败并精确报 “放大后窗口按视觉高度报，卡片底部不再被裁”，
+    加回即 PASS；**源码级** Dart 守卫（`frameContentZoom` 存在且换算落在
+    `measureContentHeight` 内），因为 node harness 不在 CI 里跑，只有 Dart 这层能挡住
+    「删掉换算而 CI 依然全绿」。
 
-- **备注**：本机验证 = `flutter analyze` 全量（含 test）零问题 + 新测试 8/8 + 相邻定向 584/584
-  （test/lookup、popup 列数、masonry 守卫、bugs per-file 守卫）+ `flutter build windows --debug`
-  通过（323.3s，`√ Built build\windows\x64\runner\Debug\hibiki.exe`，`global_lookup_window.cpp`
-  零告警——两个 COM setter 编译验证通过）。
-  **仍缺真机目视复测**，且按 ③ 的分析，真机上跑原始失败路径（Anki 上方开 app 外浮窗 →
-  Ctrl+滚轮放大）**预期仍会看到卡片被切** —— 复测重点不是「是否已修好」，而是确认：
-  字号逐档变、重开后记住档位、原生 Ctrl+加减/触控板捏合确实已失效（① 生效），
-  以及 ③ 描述的切边形态与预测是否一致。离屏 itest 取不到原生覆盖窗的像素
-  （见 agent 文档的离屏能力边界），故这一步必须人工目视。
-  另注：本机 `flutter build windows --debug` 的验证结论仍成立（两个 COM setter 编译通过）。
+- **[x] ③ 已修复：几何链认识 CSS zoom** — 复审发现 ① 不足以闭环，本段是真正让症状消失的一步。
+
+  ① 只拆掉了「WebView2 原生 ZoomFactor」这个第二真值来源。但 `dictionaryFontSize` 对渲染的
+  **唯一**作用是注入卡片 iframe 的 `documentElement.style.zoom`
+  （`popup_settings_injection.dart` head，= `popupContentZoom(appUiScale, fs)` = `appUiScale × fs/16`；
+  全仓没有任何一处用 `dictionaryFontSize` 生成 `font-size` CSS）。所以「重渲」换来的仍是 CSS zoom，
+  只是把原生缩放换了个实现——几何链照样不认识它。
+
+  **谁错了（只有高度错，宽度是对的）**：
+  - 宽度**不需要补偿**：host 文档自身从不设 zoom（已 grep 确认 `global_lookup_host.js` 零处
+    `style.zoom`），shell 几何是未缩放的 host CSS px；iframe 是 `width:100%/height:100%`
+    （`global_lookup_host.js:1124-1125`）铺满 shell。z 只压缩 iframe **内部**的布局视口
+    （`shellWidth/z` layout px）再按 z 画回去，视觉上始终铺满 shell。
+    「放大 = 卡内视口变窄、行数变多」正是字号设置应有的语义，不是缺陷
+    （复审初稿把它写成缺陷，是**过度断言**，此处订正）。
+  - 高度**必须补偿**：标准化 CSS zoom 下 `body.scrollHeight / offsetHeight` 返回**未乘 z 的
+    layout px**（本仓 `popup.js:4172` 的 `layoutStep = visualStep / popupCurrentZoom(scroller)`
+    是同一语义的另一半），而卡片实际画出 `layout × z`。
+    `measureContentHeight`（`global_lookup_host.js`）把这个 layout px 直接交给
+    `measureAndReport`，后者用它算 union bbox 的 `maxBottom`（→ 窗口高度）和
+    `shellRects`（→ `ApplyRoundedRegion` 的 window region）。
+    → z>1 时窗口与 region 比内容矮 `1 − 1/z`，**卡片底部被窗口边缘裁掉、裁口外露出底下的应用**。
+
+  **修法**：`global_lookup_host.js` 新增 `frameContentZoom(record)`（读该 iframe
+  `documentElement.style.zoom`，非法/缺失/跨域抛错一律回落 1），`measureContentHeight` 返回
+  `Math.ceil(layoutPx × z)`，把 layout px 换算成与 shell 几何同单位的 host CSS px。
+  - 只改这**一个函数**：`measureContentHeight` 在全文件只有 1 个调用点（measureAndReport），
+    host 此前零处 zoom 感知，没有第二份需要同步的镜像。
+  - **z=1（默认 16px 字号 + 100% 界面大小）时是恒等变换**，`scrollHeight/offsetHeight` 本就是整数，
+    `Math.ceil` 不改值 → 默认配置行为逐字节不变，回归面为零。
+  - 「只收小、不撑大」的既有语义**没动**：换算后仍走原来的 `measured < height` 判据，
+    内容视觉高度超过 planned frame 时依旧收敛到卡上限、内容在 iframe 内滚动。
+  **🔴 红线：只有高度要换算，`onLinkClick` / `textSelected` 的 rect 绝不能跟着乘 z。**
+  那条 rect 来自 popup.js 的 `getBoundingClientRect()`（6 处：`popup.js:1818/2382/2410/3254/3578/4218`）
+  与 `selection.js:347-350` 的 `getClientRects()`，标准化 CSS zoom 下**已经是乘过 z 的 visual px**，
+  而 iframe 视口 ≡ shell 尺寸 ≡ host CSS px，`anchorRectToScreen` 直接加 shell 偏移本就正确；
+  再乘一次会让子卡锚点偏移 z 倍。全仓没有一处用 `offsetTop/offsetLeft` 产出这个 rect，
+  不存在混用两套单位的隐患。（另：`popupRendered` / `contentHeight` 携带的高度是 layout px，
+  但 host 只取 handler 名、Dart `global_lookup_controller.dart:1026` 显式忽略两者，
+  全链路无人消费 ⇒ 当前无后果；已在 host.js 就地加注释标明这个陷阱。）
+
+  剪贴板面板不受影响：`measureAndReport` 在 `layoutMode === 'panel'` 直接短路（面板窗 rect 固定、
+  内容在 iframe 内滚动），所以本次换算实际只作用于瞬态覆盖窗 —— 真机回归别拿面板当验证场景。
+
+  - 爆炸半径仅限 app 外浮窗：`global_lookup_host.js` 全仓**只有一份**
+    （`find` 确认，不在 `assets/browser_extension/` 或 `tools/browser-extension/` 镜像里），
+    只由 app 外覆盖窗 / 剪贴板面板的 host 页加载；in-app 弹窗（走
+    `definition.js` 的 `contentHeight`）与浏览器扩展都不经过它，未被触碰。
+
+
+
+- **备注**：本机验证 = `flutter analyze` 全量（含 test）零问题 + 本 bug 用例 9/9
+  + node harness `global_lookup_host_test.mjs` 全绿（含新增 Z1，并做过负向验证）
+  + 全量 `flutter test` 通过（唯一失败 `floating_lyric_click_through_guard_test` 是 develop
+  既有红，由 PR#460 的 `SetTimer` 改动引入，与本 PR 无关，已另立单）
+  + 早前 `flutter build windows --debug` 通过（两个 COM setter 编译验证）。
+  **仍缺真机目视复测**：需在 Windows 上跑原始失败路径（Anki 上方开 app 外浮窗 → Ctrl+滚轮放大）。
+  与复审初期的预期不同，③ 落地后**预期卡片不再被窗口边缘裁掉**；复测要确认的是：
+  放大后卡片完整可见（底部不被裁、裁口外不再露出底下的应用）、字号逐档变、重开后记住档位、
+  原生 Ctrl+加减 / 触控板捏合确实已失效，以及常驻剪贴板面板同样正常
+  （面板窗尺寸固定、内容在 iframe 内滚动，不走窗口收缩那条路）。
+  离屏 itest 取不到原生覆盖窗的像素（见 agent 文档的离屏能力边界），故这一步必须人工目视。

--- a/hibiki/assets/popup/global_lookup_host.js
+++ b/hibiki/assets/popup/global_lookup_host.js
@@ -747,6 +747,10 @@
       // no-results card (the old hasContent body>0 heuristic could reveal before
       // the theme CSS painted). The MutationObserver / safety timer stay as
       // belt-and-braces (a render that never signals still reveals via safety).
+      // BUG-1139 ③ 陷阱提示：只吃 handler 名，**故意丢掉 args[0]**。那个数字是
+      // popup.js 的 __hibikiScrollHeight()，在 CSS `zoom` 下是未乘 z 的 layout px，
+      // 与 shell 几何（host CSS px）不同单位。谁将来拿它去定尺寸，必须先过
+      // frameContentZoom 换算 —— 尺寸的唯一真值是 measureAndReport 的 overlaySize。
       try {
         if (message && typeof message === 'object' &&
             message.handler === 'popupRendered') {
@@ -1817,6 +1821,30 @@
     postToHost('overlaySize', [dpr, box]);
   }
 
+  // BUG-1139 ③ — 卡片 iframe 的 documentElement 上挂着 CSS `zoom`
+  // （popup_settings_injection 的 head 注入 `= appUiScale × dictionaryFontSize/16`）。
+  // 标准化 CSS zoom 下 scrollHeight/offsetHeight 返回的是**未乘 z 的 layout px**，
+  // 而卡片实际画出 layout × z —— popup.js 的 popupCurrentZoom + `visualStep / z`
+  // 正是同一语义的另一半。z 取不到（未注入 / 非法 / 跨域抛错）一律回落 1。
+  function frameContentZoom(record) {
+    try {
+      var doc = record.iframe.contentDocument;
+      var docEl = doc && doc.documentElement;
+      var z = (docEl && docEl.style) ? parseFloat(docEl.style.zoom) : NaN;
+      return (isFinite(z) && z > 0) ? z : 1;
+    } catch (e) {
+      return 1;
+    }
+  }
+
+  // BUG-1139 ③ — 返回值必须与 shell 几何同单位：**未缩放的 host CSS px**
+  // （host 文档自身从不设 zoom，shell.style.left/top/width/height 都是这个单位）。
+  // 所以 iframe 里量到的 layout px 要先乘回 z，否则 z>1 时 measureAndReport 会把
+  // shell 高度收到只有内容视觉高度的 1/z，union bbox 的 maxBottom 与 shellRects
+  // （→ window region / ApplyRoundedRegion）跟着矮一截，卡片底部被窗口边缘裁掉、
+  // 裁口外直接露出底下的应用 —— 正是本 bug 的原始症状。
+  // Math.ceil 只防子像素短一格；z=1（默认 16px 字号 + 100% 界面大小）时
+  // scrollHeight/offsetHeight 本就是整数，换算是恒等变换，行为逐字节不变。
   function measureContentHeight(record) {
     try {
       var doc = record.iframe.contentDocument;
@@ -1825,10 +1853,14 @@
       }
       var body = doc.body;
       var docEl = doc.documentElement;
-      return Math.max(
+      var layoutPx = Math.max(
         body.scrollHeight || 0,
         body.offsetHeight || 0,
         docEl ? (docEl.scrollHeight || 0) : 0);
+      if (layoutPx <= 0) {
+        return 0;
+      }
+      return Math.ceil(layoutPx * frameContentZoom(record));
     } catch (e) {
       return 0;
     }

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -496,6 +496,16 @@ class ClipboardPanelController {
     )) {
       return;
     }
+    // BUG-1139 — Ctrl+滚轮内容缩放：改「词典字号」这一唯一真值后整栈重渲，排版按新
+    // 字号真实重排（面板窗尺寸固定，卡片高度变化沿既有 _rerender 链路生效）。
+    if (maybeHandleOverlayZoomFontStep(
+      model: model,
+      handler: handler,
+      message: message,
+      onFontSizeChanged: () => unawaited(_rerender()),
+    )) {
+      return;
+    }
     switch (handler) {
       case 'windowMoved':
         // 拖动/调整结束（native 模态循环返回后报最终 rect，物理 px）。

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -496,8 +496,13 @@ class ClipboardPanelController {
     )) {
       return;
     }
-    // BUG-1139 — Ctrl+滚轮内容缩放：改「词典字号」这一唯一真值后整栈重渲，排版按新
-    // 字号真实重排（面板窗尺寸固定，卡片高度变化沿既有 _rerender 链路生效）。
+    // BUG-1139 — Ctrl+滚轮内容缩放：改「词典字号」这一唯一真值后整栈重渲。
+    // 注意实际生效机制是注入 head 里的 `documentElement.style.zoom`
+    // （= popupContentZoom(appUiScale, fs)），**不是**按新字号重排——本仓没有任何
+    // 一处用 dictionaryFontSize 生成 font-size CSS。面板窗尺寸固定
+    // （global_lookup_host.js:1678-1683 在 panel 模式短路 measureAndReport），
+    // 所以这条路径没有窗口被切的几何风险，但放大等价于「卡内视口变窄」。
+    // 几何链尚未认识 CSS zoom，见 BUG-1139 ③。
     if (maybeHandleOverlayZoomFontStep(
       model: model,
       handler: handler,

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -497,12 +497,12 @@ class ClipboardPanelController {
       return;
     }
     // BUG-1139 — Ctrl+滚轮内容缩放：改「词典字号」这一唯一真值后整栈重渲。
-    // 注意实际生效机制是注入 head 里的 `documentElement.style.zoom`
+    // 实际生效机制是注入 head 里的 `documentElement.style.zoom`
     // （= popupContentZoom(appUiScale, fs)），**不是**按新字号重排——本仓没有任何
     // 一处用 dictionaryFontSize 生成 font-size CSS。面板窗尺寸固定
-    // （global_lookup_host.js:1678-1683 在 panel 模式短路 measureAndReport），
-    // 所以这条路径没有窗口被切的几何风险，但放大等价于「卡内视口变窄」。
-    // 几何链尚未认识 CSS zoom，见 BUG-1139 ③。
+    // （global_lookup_host.js 在 panel 模式短路 measureAndReport），内容在 iframe 内
+    // 滚动，所以这条路径本就不走窗口收缩、没有被裁风险；瞬态覆盖窗那条的测高换算
+    // 见 BUG-1139 ③（global_lookup_host.js 的 frameContentZoom）。
     if (maybeHandleOverlayZoomFontStep(
       model: model,
       handler: handler,

--- a/hibiki/lib/src/lookup/global_lookup_controller.dart
+++ b/hibiki/lib/src/lookup/global_lookup_controller.dart
@@ -860,9 +860,15 @@ class GlobalLookupController {
       _onOverlayResized(message);
       return;
     }
-    // BUG-1139 — Ctrl+滚轮内容缩放：改「词典字号」这一唯一真值后整栈重渲。窗口与
-    // region 的新尺寸由重渲后的 host measureAndReport → overlaySize 正常推导，
-    // 不需要任何 zoom 感知的几何补偿（原生 WebView2 缩放已在 C++ 侧关掉）。
+    // BUG-1139 — Ctrl+滚轮内容缩放：改「词典字号」这一唯一真值后整栈重渲。
+    // ⚠️ 已知未闭环（BUG-1139 ③）：字号最终只落到注入 head 的
+    // `documentElement.style.zoom`，而几何链对 CSS zoom 零补偿——
+    // measureContentHeight（global_lookup_host.js:1820-1834）读的是未乘 z 的
+    // layout px，且 :1722-1725 只允许把高度往小里收；窗口物理尺寸公式
+    // （下面 _renderStack 的 cardW/cardH = overlaySize × appUiScale）里也没有
+    // 字号分量。所以放大后窗口宽度不变、高度可能仍偏小 z 倍。这不是本次改动引入的
+    // （head 那行 zoom 一直在），但 Ctrl+滚轮让用户能交互式滚进该区间。
+    // 真正闭环需要给 measureContentHeight 补 × zoom，或让 cardW/cardH 乘 fs/16。
     if (maybeHandleOverlayZoomFontStep(
       model: _appModel,
       handler: handler,

--- a/hibiki/lib/src/lookup/global_lookup_controller.dart
+++ b/hibiki/lib/src/lookup/global_lookup_controller.dart
@@ -861,14 +861,11 @@ class GlobalLookupController {
       return;
     }
     // BUG-1139 — Ctrl+滚轮内容缩放：改「词典字号」这一唯一真值后整栈重渲。
-    // ⚠️ 已知未闭环（BUG-1139 ③）：字号最终只落到注入 head 的
-    // `documentElement.style.zoom`，而几何链对 CSS zoom 零补偿——
-    // measureContentHeight（global_lookup_host.js:1820-1834）读的是未乘 z 的
-    // layout px，且 :1722-1725 只允许把高度往小里收；窗口物理尺寸公式
-    // （下面 _renderStack 的 cardW/cardH = overlaySize × appUiScale）里也没有
-    // 字号分量。所以放大后窗口宽度不变、高度可能仍偏小 z 倍。这不是本次改动引入的
-    // （head 那行 zoom 一直在），但 Ctrl+滚轮让用户能交互式滚进该区间。
-    // 真正闭环需要给 measureContentHeight 补 × zoom，或让 cardW/cardH 乘 fs/16。
+    // 字号最终落到注入 head 的 `documentElement.style.zoom`（CSS zoom，不是重排）。
+    // 几何跟得上靠 BUG-1139 ③：host 的 measureContentHeight 用 frameContentZoom
+    // 把 iframe 的 layout px 换算回 host CSS px，union bbox 的 maxBottom 与
+    // shellRects（→ window region）才是内容的真实视觉高度。宽度不需要补偿——
+    // iframe 是 shell 的 100%，z 只压缩它内部的布局视口再画回来，视觉上始终铺满。
     if (maybeHandleOverlayZoomFontStep(
       model: _appModel,
       handler: handler,

--- a/hibiki/lib/src/lookup/global_lookup_controller.dart
+++ b/hibiki/lib/src/lookup/global_lookup_controller.dart
@@ -860,6 +860,17 @@ class GlobalLookupController {
       _onOverlayResized(message);
       return;
     }
+    // BUG-1139 — Ctrl+滚轮内容缩放：改「词典字号」这一唯一真值后整栈重渲。窗口与
+    // region 的新尺寸由重渲后的 host measureAndReport → overlaySize 正常推导，
+    // 不需要任何 zoom 感知的几何补偿（原生 WebView2 缩放已在 C++ 侧关掉）。
+    if (maybeHandleOverlayZoomFontStep(
+      model: _appModel,
+      handler: handler,
+      message: message,
+      onFontSizeChanged: () => unawaited(_renderStack()),
+    )) {
+      return;
+    }
     // BUG-1127 — 浮窗 iframe realm 回报自动发音 `audio.play()` 真实结果
     // （args = [token, ok]，host 包裹桥盖 __frameId 后原样转发）。完成对应
     // pending Completer；过期 token（已超时回落）直接忽略。

--- a/hibiki/lib/src/lookup/overlay_bridge_handlers.dart
+++ b/hibiki/lib/src/lookup/overlay_bridge_handlers.dart
@@ -15,6 +15,7 @@ import 'dart:convert';
 
 import 'package:hibiki/src/lookup/global_lookup_log.dart';
 import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/pages/implementations/dictionary_popup_webview.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_webview_media.dart';
 import 'package:hibiki/src/pages/implementations/stat_activity.dart';
 import 'package:hibiki/src/utils/misc/lookup_audio_playback.dart';
@@ -105,6 +106,67 @@ bool maybeHandleOverlayDeferredBridge({
     default:
       return false;
   }
+}
+
+/// BUG-1139 — app 外两个裸 WebView2 表面的 Ctrl+滚轮内容缩放落地点（瞬态查词覆盖窗
+/// 与常驻剪贴板面板共用同一实现，与上面的 deferred 桥同一条红线：绝不复制）。
+///
+/// JS 侧（popup_settings_injection 的 `_globalLookupZoomWheelJs`）只回传 rAF 合帧后的
+/// **净档数**，步长与夹紧仍在 Dart：逐档过 [DictionaryPopupWebViewState
+/// .steppedPopupZoomFontSize]（内含 8..72 夹紧），与 in-app Ctrl+滚轮、弹窗顶栏
+/// A−/A+ 完全同一条语义，四端不可能漂开。
+///
+/// 返回 true = 已处理（调用方 `_onJsMessage` 直接 return）。字号真的变了才回调
+/// [onFontSizeChanged] 重渲：顶到 8 或 72 后继续滚不再触发无意义的整栈重渲。
+/// 重渲是几何正确性的关键一环——新字号经 buildFrameSettingsJs 重新排版后，卡片高度
+/// / bbox / window region 沿现有链路自然更新，不需要任何 zoom 感知的几何补偿。
+bool maybeHandleOverlayZoomFontStep({
+  required AppModel? model,
+  required Object? handler,
+  required Map<String, Object?> message,
+  required void Function() onFontSizeChanged,
+}) {
+  if (handler != 'popupZoomFontStep') {
+    return false;
+  }
+  if (model == null) {
+    return true;
+  }
+  final Object? args = message['args'];
+  final Object? raw = (args is List && args.isNotEmpty) ? args.first : null;
+  final int steps = raw is num ? raw.toInt() : (int.tryParse('$raw') ?? 0);
+  if (steps == 0) {
+    return true;
+  }
+  final double current = model.dictionaryFontSize;
+  final double next = zoomFontSizeAfterSteps(current, steps);
+  if (next == current) {
+    return true;
+  }
+  model.setDictionaryFontSize(next);
+  onFontSizeChanged();
+  return true;
+}
+
+/// BUG-1139 — 把「净档数」折算成新的词典字号（纯函数，直接单测）。
+///
+/// 逐档过 [DictionaryPopupWebViewState.steppedPopupZoomFontSize]（每档 ±1，内含
+/// 8..72 夹紧），而不是 `current + steps` 一步到位：步长与边界只有那一处真值，
+/// 将来改档距/改边界不会在这里留下第二份镜像。已顶到边界后继续同向滚返回原值，
+/// 调用方据此跳过整栈重渲。[steps] 为 0 或非有限的当前值时原样返回。
+double zoomFontSizeAfterSteps(double current, int steps) {
+  if (steps == 0) {
+    return current;
+  }
+  double next = current;
+  final int magnitude = steps.abs();
+  for (int i = 0; i < magnitude; i++) {
+    next = DictionaryPopupWebViewState.steppedPopupZoomFontSize(
+      next,
+      zoomIn: steps > 0,
+    );
+  }
+  return next;
 }
 
 /// The `{sentence}` value for an app-external mine/overwrite: a JS-sent

--- a/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
@@ -217,6 +217,55 @@ const String _globalLookupIconFontJs = '''
       }
     })();''';
 
+/// BUG-1139：**app 外**两个裸 WebView2 表面（瞬态查词覆盖窗 + 常驻剪贴板面板）的
+/// Ctrl+滚轮内容缩放。in-app 弹窗有自己的一份（dictionary_popup_webview 的
+/// `_zoomWheelJs`，就地改 `documentElement.style.zoom` 拿即时反馈），app 外**没有**，
+/// 于是 Ctrl+滚轮一路落到 WebView2 自带的页面缩放上——而覆盖窗整条几何链（host 报的
+/// bbox/shellRects、Dart 的窗口物理尺寸、C++ 的 window region）全按 zoom=1 的 CSS px
+/// 算，ZoomFactor 不在其中任何一环，内容放大而窗口/region 不变 → 卡片被窗口边缘切掉、
+/// 露出底下的应用。原生缩放已在 `global_lookup_window.cpp ConfigureWebView` 关掉，
+/// 这里把 Ctrl+滚轮接回**唯一真值**「词典字号」。
+///
+/// 与 in-app 的关键差异（有意为之）：这里**不在 JS 侧就地改 zoom**。CSS `zoom` 下
+/// `body.scrollHeight` 仍是未乘 z 的 CSS px，而 host 的 measureContentHeight 正是读它
+/// 报卡片高度——就地缩放会让高度被系统性报小 z 倍，等于把几何链的老毛病换个地方复发。
+/// 走 Dart 改字号 → 整栈重渲，排版按新字号真实重排，高度/bbox/region 沿现有链路自然
+/// 更新，几何链一行不用动。代价是每档多一次 Dart 往返（约 1~2 帧），换的是零几何风险。
+///
+/// 步进本身不在 JS 里算：只回传**净档数**（rAF 内合帧累加，一次快滚不会打出十几次
+/// 往返），夹紧与步长仍归 Dart 的 `steppedPopupZoomFontSize` / `clampPopupZoomFontSize`
+/// 单一同源（TODO-1353 已有守卫），JS 侧不再镜像一份 8..72 边界。
+/// `__hoshiZoomWheelInstalled` 与 in-app 那份同名：同一个 realm 永远只装一套。
+const String _globalLookupZoomWheelJs = '''
+    (function(){
+      if (window.__hoshiZoomWheelInstalled) return;
+      window.__hoshiZoomWheelInstalled = true;
+      var pendingSteps = 0;
+      var flushScheduled = false;
+      function flushZoomSteps(){
+        flushScheduled = false;
+        var steps = pendingSteps;
+        pendingSteps = 0;
+        if (!steps) return;
+        try {
+          window.flutter_inappwebview.callHandler('popupZoomFontStep', steps);
+        } catch (err) {}
+      }
+      window.addEventListener('wheel', function(e){
+        if (!e.ctrlKey) return;
+        if (!e.deltaY) return;
+        e.preventDefault();
+        pendingSteps += (e.deltaY < 0 ? 1 : -1);
+        if (flushScheduled) return;
+        flushScheduled = true;
+        if (typeof requestAnimationFrame === 'function') {
+          requestAnimationFrame(flushZoomSteps);
+        } else {
+          setTimeout(flushZoomSteps, 16);
+        }
+      }, { passive: false });
+    })();''';
+
 // BUG-926：撤回 BUG-762 引入的触屏全量禁选注入（旧常量在粗指针 media query 下对整棵
 // body 子树强制 user-select:none !important）。
 // 该规则以 !important 碾平了 popup.css 已精细分区的选区设计（正文
@@ -488,11 +537,17 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
   );
 
   final String iconFontJs = options.globalLookup ? _globalLookupIconFontJs : '';
+  // BUG-1139：Ctrl+滚轮内容缩放只装给 app 外裸 WebView2 表面。in-app 三个表面由
+  // dictionary_popup_webview 的 _zoomWheelJs 在 onLoadStop 装同名 guard 的另一套
+  // （就地 zoom + 即时反馈），两边永不同装。
+  final String zoomWheelJs =
+      options.globalLookup ? _globalLookupZoomWheelJs : '';
 
   final String head = '''
     $themeVarsJs
     $fontStyleJs
     $iconFontJs
+    $zoomWheelJs
     document.documentElement.style.zoom = '${zoom.toStringAsFixed(4)}';
     // TODO-1353: Ctrl+滚轮缩放查词内容需要在 JS 侧就地重算 zoom（即时反馈），故把
     // 当前「界面大小」系数与「词典字号」暴露给弹窗（与上面 zoom 同源，每次注入刷新为

--- a/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
@@ -226,11 +226,16 @@ const String _globalLookupIconFontJs = '''
 /// 露出底下的应用。原生缩放已在 `global_lookup_window.cpp ConfigureWebView` 关掉，
 /// 这里把 Ctrl+滚轮接回**唯一真值**「词典字号」。
 ///
-/// 与 in-app 的关键差异（有意为之）：这里**不在 JS 侧就地改 zoom**。CSS `zoom` 下
-/// `body.scrollHeight` 仍是未乘 z 的 CSS px，而 host 的 measureContentHeight 正是读它
-/// 报卡片高度——就地缩放会让高度被系统性报小 z 倍，等于把几何链的老毛病换个地方复发。
-/// 走 Dart 改字号 → 整栈重渲，排版按新字号真实重排，高度/bbox/region 沿现有链路自然
-/// 更新，几何链一行不用动。代价是每档多一次 Dart 往返（约 1~2 帧），换的是零几何风险。
+/// 与 in-app 的关键差异（有意为之）：这里**不在 JS 侧就地改 zoom**，而是走 Dart 改
+/// 「词典字号」这一唯一真值 → 整栈重渲，避免 JS 与 Dart 两处各写一份 zoom。代价是
+/// 每档多一次 Dart 往返（约 1~2 帧）。
+///
+/// ⚠️ 别把这条读成「几何已经对了」（BUG-1139 ③ 未闭环）：重渲后字号最终仍只落到本
+/// 文件下方那行 `documentElement.style.zoom`，本仓没有任何一处用 dictionaryFontSize
+/// 生成 font-size CSS，所以这是 CSS zoom 而非按字号重排。而 host 的
+/// measureContentHeight（global_lookup_host.js:1820-1834）读的是 CSS `zoom` 下未乘 z 的
+/// layout px 且不做补偿，覆盖窗的窗口/region 尺寸公式里也没有字号分量 ——
+/// 放大后窗口宽度不变、高度在未触卡上限时仍会偏小 z 倍。
 ///
 /// 步进本身不在 JS 里算：只回传**净档数**（rAF 内合帧累加，一次快滚不会打出十几次
 /// 往返），夹紧与步长仍归 Dart 的 `steppedPopupZoomFontSize` / `clampPopupZoomFontSize`

--- a/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/hibiki/lib/src/pages/implementations/popup_settings_injection.dart
@@ -230,12 +230,11 @@ const String _globalLookupIconFontJs = '''
 /// 「词典字号」这一唯一真值 → 整栈重渲，避免 JS 与 Dart 两处各写一份 zoom。代价是
 /// 每档多一次 Dart 往返（约 1~2 帧）。
 ///
-/// ⚠️ 别把这条读成「几何已经对了」（BUG-1139 ③ 未闭环）：重渲后字号最终仍只落到本
-/// 文件下方那行 `documentElement.style.zoom`，本仓没有任何一处用 dictionaryFontSize
-/// 生成 font-size CSS，所以这是 CSS zoom 而非按字号重排。而 host 的
-/// measureContentHeight（global_lookup_host.js:1820-1834）读的是 CSS `zoom` 下未乘 z 的
-/// layout px 且不做补偿，覆盖窗的窗口/region 尺寸公式里也没有字号分量 ——
-/// 放大后窗口宽度不变、高度在未触卡上限时仍会偏小 z 倍。
+/// 注意这里生效的是 CSS zoom 而非按字号重排：重渲后字号最终落到本文件下方那行
+/// `documentElement.style.zoom`，本仓没有任何一处用 dictionaryFontSize 生成
+/// font-size CSS。几何链能跟上是因为 BUG-1139 ③ —— host 的 measureContentHeight
+/// （global_lookup_host.js 的 frameContentZoom）把 CSS `zoom` 下未乘 z 的 layout px
+/// 换算回 host CSS px，窗口高度与 window region 才对得上内容的视觉高度。
 ///
 /// 步进本身不在 JS 里算：只回传**净档数**（rAF 内合帧累加，一次快滚不会打出十几次
 /// 往返），夹紧与步长仍归 Dart 的 `steppedPopupZoomFontSize` / `clampPopupZoomFontSize`

--- a/hibiki/test/lookup/global_lookup_host_test.mjs
+++ b/hibiki/test/lookup/global_lookup_host_test.mjs
@@ -119,7 +119,10 @@ function makeElement(tag) {
     const body = { scrollHeight: 0, offsetHeight: 0, _observers: [] };
     el.contentDocument = {
       body,
-      documentElement: { scrollHeight: 0 },
+      // BUG-1139 ③: documentElement carries the injected CSS `zoom`
+      // (popup_settings_injection head). measureContentHeight reads it to convert
+      // layout px -> host CSS px, so the stub must expose a real style bag.
+      documentElement: { scrollHeight: 0, style: { zoom: '' } },
       _hasGlossary: false,
       querySelector(sel) {
         if (sel === '.glossary-content') {
@@ -2120,6 +2123,53 @@ function historyOverlayIn(shell) {
   host.renderStack({ popups: [descriptor('frame-0', -1)] });
   assert.ok(!classes.has('global-lookup-dismissing'),
     'BUG-745: the fresh render stays un-poisoned');
+}
+
+// Z1 (BUG-1139 ③). 卡片 iframe 的 documentElement 上挂着注入的 CSS `zoom`
+// （= appUiScale × dictionaryFontSize/16）。标准化 CSS zoom 下 scrollHeight 是**未乘 z
+// 的 layout px**，而卡片实际画出 layout × z；shell 几何 / union bbox / shellRects
+// （→ window region）全是未缩放的 host CSS px。不换算的话 z>1 时窗口与 region 比内容
+// 矮 1/z，卡片底部被窗口边缘裁掉、裁口外露出底下的应用 —— 本 bug 的原始症状。
+{
+  const { host, document } = freshHost();
+  host.renderStack({
+    popups: [
+      { id: 'frame-0', parentIndex: -1, frame: { left: 0, top: 0, width: 360, height: 480 }, settingsJs: '' },
+    ],
+  });
+  const shell = shellsOf(document)[0];
+  const iframe = shell.children.find((c) => c.tagName === 'IFRAME');
+  const lastBox = () =>
+    hostPostLog.filter((m) => m.handler === 'overlaySize').pop().args[1];
+
+  // z=1（默认 16px 字号 + 100% 界面大小）：恒等变换，与改前逐字节一致。
+  iframe.contentDocument.body.scrollHeight = 200;
+  iframe.contentDocument.body.offsetHeight = 200;
+  host.measureAndReport();
+  assert.strictEqual(lastBox().height, 200,
+    'BUG-1139 ③: z=1 时测高不变（回归护栏：换算必须是恒等的）');
+
+  // z=2：内容视觉高度 400，窗口/region 必须按 400 报，而不是 layout 的 200。
+  iframe.contentDocument.documentElement.style.zoom = '2';
+  host.measureAndReport();
+  assert.strictEqual(lastBox().height, 400,
+    'BUG-1139 ③: 放大后窗口按视觉高度报，卡片底部不再被裁');
+
+  // 卡上限仍然是上限：视觉高度超过 planned frame 时收敛到 480，内容在 iframe 内滚动。
+  // （守住 measureAndReport「只收小、不撑大」的既有语义没被这次换算改坏。）
+  iframe.contentDocument.body.scrollHeight = 300;
+  iframe.contentDocument.body.offsetHeight = 300;
+  host.measureAndReport();
+  assert.strictEqual(lastBox().height, 480,
+    'BUG-1139 ③: 换算后仍不得撑破 planned frame 高度（只收小语义不变）');
+
+  // 非法 / 缺失 zoom 一律回落 1，不得把高度算成 0 或 NaN。
+  iframe.contentDocument.body.scrollHeight = 200;
+  iframe.contentDocument.body.offsetHeight = 200;
+  iframe.contentDocument.documentElement.style.zoom = 'not-a-number';
+  host.measureAndReport();
+  assert.strictEqual(lastBox().height, 200,
+    'BUG-1139 ③: 非法 zoom 回落 1（绝不产生 0/NaN 几何）');
 }
 
 console.log('global_lookup_host_test: PASS');

--- a/hibiki/test/lookup/overlay_ctrl_wheel_zoom_test.dart
+++ b/hibiki/test/lookup/overlay_ctrl_wheel_zoom_test.dart
@@ -131,6 +131,26 @@ void main() {
           reason: 'Ctrl+滚轮注入必须由 globalLookup 门控');
     });
 
+    test('host 测高把 iframe layout px 换算回 host CSS px（③ 几何闭环）', () {
+      // 行为级断言在 node harness（global_lookup_host_test.mjs 的 Z1，负向验证过：
+      // 去掉换算即 exit 1）。那个 harness 不在 CI 里跑，所以这里补一条 CI 可见的
+      // 源码守卫，防止有人把换算删掉后 CI 依然全绿。
+      final String host = _repoFile('hibiki/assets/popup/global_lookup_host.js')
+          .readAsStringSync();
+      expect(host.contains('function frameContentZoom('), isTrue,
+          reason: '缺 zoom 读取：iframe 的 documentElement.style.zoom 是唯一来源');
+      expect(host.contains('layoutPx * frameContentZoom(record)'), isTrue,
+          reason: 'measureContentHeight 必须把 layout px 乘回 z，'
+              '否则 z>1 时 window region 比内容矮 1/z，卡片底部又被裁');
+      // 换算必须落在 measureContentHeight 内 —— 它是 measureAndReport 唯一的
+      // 内容高度来源（bbox maxBottom + shellRects 都吃它）。
+      final int measureAt = host.indexOf('function measureContentHeight(');
+      expect(measureAt, greaterThan(0));
+      expect(host.indexOf('layoutPx * frameContentZoom(record)'),
+          greaterThan(measureAt),
+          reason: '换算必须在 measureContentHeight 里，别散到调用方');
+    });
+
     test('瞬态覆盖窗与剪贴板面板都接了这根 handler（两表面绝不漂开）', () {
       for (final String path in <String>[
         'hibiki/lib/src/lookup/global_lookup_controller.dart',

--- a/hibiki/test/lookup/overlay_ctrl_wheel_zoom_test.dart
+++ b/hibiki/test/lookup/overlay_ctrl_wheel_zoom_test.dart
@@ -1,0 +1,147 @@
+// BUG-1139 守卫 —— app 外查词浮窗（瞬态覆盖窗 + 常驻剪贴板面板）的 Ctrl+滚轮缩放。
+//
+// 原症状：Ctrl+滚轮落到 WebView2 自带的页面缩放上，而覆盖窗整条几何链（host 报的
+// bbox/shellRects → Dart 的窗口物理尺寸 → C++ 的 window region）全按 zoom=1 的 CSS px
+// 算，ZoomFactor 不在任何一环里 —— 内容按 z 放大绘制，窗口/region 仍是 z=1 的尺寸，
+// 卡片被窗口边缘竖着切掉、region 外露出底下的应用（用户报「左边是空的」）。
+//
+// 三段守卫，对应三段根因修复：
+//   (1) 纯函数：净档数 → 新字号的折算与夹紧（唯一真值仍是 steppedPopupZoomFontSize）。
+//   (2) 分发：popupZoomFontStep 被吞掉且只在字号真变时才触发重渲。
+//   (3) 源码：C++ 关掉原生缩放并复位持久 ZoomFactor；app 外注入装了 Ctrl+滚轮监听且
+//       **不**就地改 zoom；in-app 注入不装（避免与 _zoomWheelJs 双装）；两个表面都接线。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/lookup/overlay_bridge_handlers.dart';
+
+/// 与 DictionaryPopupWebViewState 的 _popupZoomFontMin/_popupZoomFontMax 同源。
+const double _min = 8.0;
+const double _max = 72.0;
+
+File _repoFile(String relative) {
+  // 测试 cwd = hibiki/（flutter test 的包根）。仓库根是它的上一级。
+  final File inPackage = File(relative);
+  if (inPackage.existsSync()) return inPackage;
+  return File('../$relative');
+}
+
+void main() {
+  group('BUG-1139 (1) 净档数折算成词典字号', () {
+    test('每档 ±1，方向与滚轮一致', () {
+      expect(zoomFontSizeAfterSteps(16, 1), 17);
+      expect(zoomFontSizeAfterSteps(16, -1), 15);
+      expect(zoomFontSizeAfterSteps(16, 4), 20);
+      expect(zoomFontSizeAfterSteps(16, -4), 12);
+    });
+
+    test('0 档原样返回（rAF 合帧后净档数可能抵消为 0）', () {
+      expect(zoomFontSizeAfterSteps(16, 0), 16);
+    });
+
+    test('双侧夹死在 8..72，且顶到边界后继续同向滚返回原值', () {
+      expect(zoomFontSizeAfterSteps(70, 10), _max);
+      expect(zoomFontSizeAfterSteps(10, -10), _min);
+      // 已在边界：返回原值 —— 调用方据此跳过整栈重渲。
+      expect(zoomFontSizeAfterSteps(_max, 3), _max);
+      expect(zoomFontSizeAfterSteps(_min, -3), _min);
+    });
+  });
+
+  group('BUG-1139 (2) popupZoomFontStep 分发', () {
+    test('非本 handler 不拦截（调用方继续自己的分发）', () {
+      bool rerendered = false;
+      final bool handled = maybeHandleOverlayZoomFontStep(
+        model: null,
+        handler: 'tapOutside',
+        message: const <String, Object?>{
+          'args': <Object?>[1]
+        },
+        onFontSizeChanged: () => rerendered = true,
+      );
+      expect(handled, isFalse);
+      expect(rerendered, isFalse);
+    });
+
+    test('本 handler 恒被吞掉；无 model 时不重渲（不炸、不空转）', () {
+      bool rerendered = false;
+      final bool handled = maybeHandleOverlayZoomFontStep(
+        model: null,
+        handler: 'popupZoomFontStep',
+        message: const <String, Object?>{
+          'args': <Object?>[1]
+        },
+        onFontSizeChanged: () => rerendered = true,
+      );
+      expect(handled, isTrue);
+      expect(rerendered, isFalse);
+    });
+  });
+
+  group('BUG-1139 (3) 源码守卫', () {
+    test('C++ 覆盖窗关掉 WebView2 原生缩放并复位持久 ZoomFactor', () {
+      final String cpp =
+          _repoFile('hibiki/windows/runner/global_lookup_window.cpp')
+              .readAsStringSync();
+      expect(cpp.contains('put_IsZoomControlEnabled(FALSE)'), isTrue,
+          reason: '原生 Ctrl+滚轮缩放必须关掉：几何链看不见 ZoomFactor');
+      expect(cpp.contains('put_ZoomFactor(1.0)'), isTrue,
+          reason: 'WebView2 缩放档位按 origin 持久记忆，只关控制不复位则老用户仍是坏的');
+      // 两者都必须在 ConfigureWebView 内 —— 它是两条创建路径 + BUG-693 自愈重建的
+      // 唯一漏斗，写在别处会漏掉某个 surface。
+      final int configureAt =
+          cpp.indexOf('void GlobalLookupWindow::ConfigureWebView()');
+      expect(configureAt, greaterThan(0));
+      expect(cpp.indexOf('put_IsZoomControlEnabled(FALSE)'),
+          greaterThan(configureAt),
+          reason: '必须落在 ConfigureWebView 这个唯一漏斗里');
+      expect(cpp.indexOf('put_ZoomFactor(1.0)'), greaterThan(configureAt),
+          reason: '必须落在 ConfigureWebView 这个唯一漏斗里');
+    });
+
+    test('app 外注入装 Ctrl+滚轮监听，回传净档数，且不就地改 zoom', () {
+      final String dart = _repoFile(
+              'hibiki/lib/src/pages/implementations/popup_settings_injection.dart')
+          .readAsStringSync();
+      final int start = dart.indexOf('_globalLookupZoomWheelJs = ');
+      expect(start, greaterThan(0), reason: 'app 外 Ctrl+滚轮注入常量必须存在');
+      final int end = dart.indexOf("''';", start);
+      expect(end, greaterThan(start));
+      final String js = dart.substring(start, end);
+
+      expect(js.contains('e.ctrlKey'), isTrue, reason: '只拦 Ctrl+滚轮，普通滚动不受影响');
+      expect(js.contains('preventDefault'), isTrue);
+      expect(js.contains("callHandler('popupZoomFontStep'"), isTrue,
+          reason: '走 Dart 改词典字号这条唯一真值链');
+      expect(js.contains('requestAnimationFrame'), isTrue,
+          reason: '快滚必须合帧，否则一次滚动打出十几次 Dart 往返 + 整栈重渲');
+      // 红线：app 外**不能**就地改 documentElement.style.zoom —— CSS zoom 下
+      // body.scrollHeight 不含 z，host 的 measureContentHeight 会把卡片高度系统性
+      // 报小 z 倍，等于把几何链的老毛病换个地方复发。
+      expect(js.contains('style.zoom'), isFalse,
+          reason: 'app 外禁止就地 CSS zoom（几何链按未缩放 CSS px 测量）');
+
+      // 只装给 app 外：in-app 三个表面由 dictionary_popup_webview 的 _zoomWheelJs
+      // 装同名 guard 的另一套，双装会一档滚两级。
+      expect(
+          RegExp(r'options\.globalLookup\s*\?\s*_globalLookupZoomWheelJs\s*:\s*')
+              .hasMatch(dart),
+          isTrue,
+          reason: 'Ctrl+滚轮注入必须由 globalLookup 门控');
+    });
+
+    test('瞬态覆盖窗与剪贴板面板都接了这根 handler（两表面绝不漂开）', () {
+      for (final String path in <String>[
+        'hibiki/lib/src/lookup/global_lookup_controller.dart',
+        'hibiki/lib/src/lookup/clipboard_panel_controller.dart',
+      ]) {
+        final String src = _repoFile(path).readAsStringSync();
+        expect(src.contains('maybeHandleOverlayZoomFontStep('), isTrue,
+            reason: '$path 必须接 Ctrl+滚轮缩放，否则两个 app 外表面行为分叉');
+        expect(src.contains('onFontSizeChanged:'), isTrue,
+            reason: '$path 必须在字号变化后重渲，几何才跟得上新排版');
+      }
+    });
+  });
+}

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -1270,6 +1270,46 @@ void GlobalLookupWindow::ConfigureWebView() {
     ReportOverlayError("put_IsStatusBarEnabled(FALSE) failed", status_bar_hr);
   }
 
+  // BUG-1139 — 关掉 WebView2 自带的页面缩放（Ctrl+滚轮 / Ctrl+加减 / 触控板捏合）。
+  //
+  // 这个窗的几何链**整条**按「CSS px @ zoom=1」算：host 的 measureAndReport 用
+  // shell.style.left/width + body.scrollHeight 报 bbox 与 shellRects（CSS px），
+  // Dart 按 `逻辑宽 × appUiScale × dpr` 定物理窗口大小（global_lookup_controller
+  // .dart 的 _applyOverlayBox / ShowAt），C++ 再用同一批数值 SetWindowPos + 裁
+  // window region（ApplyRoundedRegion）。WebView2 的 ZoomFactor 不在这条链的任何
+  // 一环里——它只放大**绘制**，不改这些 CSS px 读数。
+  //
+  // 而 ForwardCompositionMouse 把 WM_MOUSEWHEEL 连同 MK_CONTROL 原样
+  // SendMouseInput 给 WebView2，popup.js 的滚轮监听又明确 `if (e.ctrlKey) return`
+  // 把 Ctrl+滚轮让给原生。于是用户在 app 外浮窗上 Ctrl+滚轮 → 内容按 z 放大绘制，
+  // 窗口和 region 仍是 z=1 的尺寸 → 卡片被窗口边缘竖着切掉、region 外直接露出底下
+  // 的应用（用户报的「左边是空的」）。
+  //
+  // 这里断掉原生缩放这个「看不见的第二真值来源」，与 in-app 弹窗的
+  // `supportZoom: false`（dictionary_popup_webview.dart 的 InAppWebViewSettings）
+  // 对齐；缩放能力不丢：Ctrl+滚轮改由 popup_settings_injection 注入的监听回传
+  // popupZoomFontStep，Dart 改「词典字号」后整栈重渲，排版沿现有链路自然更新，
+  // 几何链一行不用改。
+  //
+  // put_ZoomFactor(1.0) 是必须的第二步，不是保险：WebView2 的缩放档位按 origin
+  // **持久记忆**在用户数据目录里，只关 IsZoomControlEnabled 不会复位已经缩过的
+  // 那一档——老用户升级后窗口照样是切的。IsZoomControlEnabled 在基础
+  // ICoreWebView2Settings 上、ZoomFactor 在 ICoreWebView2Controller 上，两者都无需
+  // 版本 QI。ConfigureWebView 是两条创建路径 + BUG-693 自愈重建的唯一漏斗，所以
+  // 这个窗曾经拥有的每个 surface 都被覆盖。
+  if (settings != nullptr) {
+    HRESULT zoom_ctl_hr = settings->put_IsZoomControlEnabled(FALSE);
+    if (FAILED(zoom_ctl_hr)) {
+      ReportOverlayError("put_IsZoomControlEnabled(FALSE) failed", zoom_ctl_hr);
+    }
+  }
+  if (controller_ != nullptr) {
+    HRESULT zoom_reset_hr = controller_->put_ZoomFactor(1.0);
+    if (FAILED(zoom_reset_hr)) {
+      ReportOverlayError("put_ZoomFactor(1.0) failed", zoom_reset_hr);
+    }
+  }
+
   // Inject the bridge adapter at document start so popup.js's
   // window.flutter_inappwebview.callHandler maps to chrome.webview.postMessage.
   std::wstring adapter = LoadAdapterScript();


### PR DESCRIPTION
## 症状

用户在 Anki 上方开 app 外查词浮窗，Ctrl+滚轮缩放后第一张词典卡被窗口左边缘竖着切掉一半，切口外直接是 Anki 的背景（用户原话：「这个缩放有点问题 滚轮。左边是空的。」）。

## 根因

一条**看不见的第二真值来源**：WebView2 自带的页面缩放（ZoomFactor）不在覆盖窗的几何链里。

1. `global_lookup_window.cpp:962` `ForwardCompositionMouse` 把 `WM_MOUSEWHEEL` 连同 `MK_CONTROL` 原样 `SendMouseInput` 给 WebView2；
2. `ConfigureWebView()` 只设了 `put_IsStatusBarEnabled(FALSE)`，**从没设 `put_IsZoomControlEnabled(FALSE)`** → 原生缩放默认开着；
3. `assets/popup/popup.js:4100` 滚轮监听明确 `if (e.ctrlKey) return;`，把 Ctrl+滚轮让给原生；
4. app 外浮窗**从没装** in-app 那套内容缩放（`_zoomWheelJs` 只在 `dictionary_popup_webview.dart:1872` 注入）；
5. 而覆盖窗整条几何链按「CSS px @ zoom=1」算：host 报 bbox/shellRects（`global_lookup_host.js:1791-1817`）→ Dart 定物理窗口尺寸（`global_lookup_controller.dart:251`）→ C++ `SetWindowPos` + `ApplyRoundedRegion` 裁 region。

ZoomFactor 只放大**绘制**，不改上面任何读数 → 内容按 z 绘制、窗口与 region 仍是 z=1 的尺寸 → 卡片被切、region 外露出底下的应用。

in-app 弹窗不受影响，因为它有两道防护：`supportZoom: false` + 自己的 Ctrl+滚轮字号缩放。app 外一道都没有。

加重项：WebView2 缩放档位按 origin **持久记忆**，只关控制不复位则老用户升级后仍是坏的。

## 修复

- `ConfigureWebView()` 加 `put_IsZoomControlEnabled(FALSE)`（与 in-app `supportZoom:false` 对齐）+ `put_ZoomFactor(1.0)`（复位持久档位）。该函数是两条创建路径 + BUG-693 自愈重建的唯一漏斗；瞬态覆盖窗与剪贴板面板是同一个 `GlobalLookupWindow` 类的两个实例，一处修复覆盖两表面。
- 缩放能力不丢：`popup_settings_injection.dart` 新增 `_globalLookupZoomWheelJs`（仅 `globalLookup` 注入），Ctrl+滚轮 → rAF 合帧回传**净档数** `popupZoomFontStep` → Dart 逐档过既有 `steppedPopupZoomFontSize`（8..72 夹紧，与 in-app / 顶栏 A−A+ 同一真值）改词典字号 → 整栈重渲。
- **有意不做**：app 外不就地改 `documentElement.style.zoom`。CSS zoom 下 `body.scrollHeight` 不含 z，host 的 `measureContentHeight` 会把卡片高度系统性报小 z 倍 —— 那是把同一个几何毛病换个地方复发。走重渲则排版真实重排，几何链一行不用改（代价：每档多约 1~2 帧的 Dart 往返）。
- 两个 app 外表面共用 `maybeHandleOverlayZoomFontStep`，不复制、不漂开。

## 验证

- `flutter analyze` 全量（含 test）零问题
- 新增守卫 `hibiki/test/lookup/overlay_ctrl_wheel_zoom_test.dart` 8/8
- 相邻定向 584/584（`test/lookup`、popup 列数、masonry 守卫、bugs per-file 守卫）
- Windows debug 构建：见下方评论/正文更新

**尚未做**：Windows 真机目视复测原始失败路径（Anki 上方开浮窗 → Ctrl+滚轮 → 卡片不再被切）。合入前建议补。

BUG 记录：`docs/bugs/BUG-1138-overlay-ctrl-wheel-zoom.md`

https://claude.ai/code/session_01DdwzeCtBQzvAXPCN1B22g2