### PR TITLE
feat(lookup): gal 台词浮窗 / 剪切板文字窗支持注音（振假名）标记（BUG-1138）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -27,12 +27,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1106 条。点号进各自文件。
+> 共 1107 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1140](bugs/BUG-1140-cross-chapter-turn-latency.md) | ✅ | ✅ | 跨章翻页耗时实测与提速（遮罩口径） |
 | [BUG-1139](bugs/BUG-1139-overlay-ctrl-wheel-zoom.md) | ✅ | ✅ | app 外查词浮窗 Ctrl+滚轮触发 WebView2 原生页面缩放，窗口/region 几何按 zoom=1 计算导致卡片被切、露出底下应用 |
+| [BUG-1138](bugs/BUG-1138-gal-clipboard-overlay-ruby-markup.md) | ✅ | ✅ | gal 台词浮窗/剪切板文字窗把注音标记当正文显示，污染查词与字数 |
 | [BUG-1137](bugs/BUG-1137-gal-mining-video-tag.md) | ✅ | ✅ | gal 制卡分类标签误标 video：来源枚举缺 game 且默认值静默兜底 |
 | [BUG-1136](bugs/BUG-1136-ios-reader-scroll-lookup.md) | ✅ | ✅ | iPhone 阅读滑动被误判为点词查词 |
 | [BUG-1135](bugs/BUG-1135-gal-clipnear-bypasses-track-exclusion.md) | ✅ | ✅ | gal 制卡兜底 grabClipNear 绕过选轨/排除集——排除的 BGM 轨会从兜底混回卡片 |

--- a/docs/bugs/BUG-1138-gal-clipboard-overlay-ruby-markup.md
+++ b/docs/bugs/BUG-1138-gal-clipboard-overlay-ruby-markup.md
@@ -1,0 +1,23 @@
+## BUG-1138 · gal 台词浮窗/剪切板文字窗把注音标记当正文显示，污染查词与字数
+- **报告**：2026-07-27（用户：截图 WITCH ON THE HOLY NIGHT，浮窗显示 `今もピリピリと空気を<rふる>震</r>わせている。`，游戏本体是把 `ふる` 渲染在「震」上方）
+- **真实性**：✅ 真 bug。根因不是渲染，而是**全链路从来没有注音标记这一层**：
+  - LunaHook 侧只做重复/伪影过滤（`native/galgame_hook/include/luna_text_selector.h:33`），不认注音标记；
+  - `hibiki/windows/runner/voice_hook_reader.cpp:308` 只截断不改写；
+  - Dart 第一落点 `hibiki/lib/src/mining/galgame_audio_source.dart:1259` 原样构造 `GalHookedLine`；
+  - 唯一的正文改写是 `hibiki/lib/src/sync/texthooker_service.dart:457` 的 `trim()`。
+  于是原始标记一路进 `entry.text`，而 `entry.text` 同时是**浮窗显示串、点字查词 `wordFromIndex` 的输入、制卡 sentence、字数统计输入**（`gal_hook_text_overlay_controller.dart:302/325/546`、`gal_hook_mining_coordinator.dart:164`、`gal_hook_session_controller.dart:2416`）。
+  三处可见后果：① 浮窗显示原始标记；② 点到 `<`/`r`/`ふ` 等标记字符时分词从标记切起，查出垃圾；③ `countGalgameChars`（`galgame_char_count.dart:48`）把注音假名按 CJK 逐码点计入阅读字数，字数虚高。
+  剪切板链路同理：`desktop_lookup_service.dart` 的文本未经任何标记处理即进透明文字窗、悬浮面板与 `clipboard_history.content`。
+- **[x] ① 已修复** — 新增纯函数解析器 `hibiki/lib/src/utils/misc/ruby_markup.dart`（`parseRubyMarkup` → `RubyMarkupText{text, spans}`，抄字幕侧 `parseSubtitleMarkup` 的「正文不加不减 + 旁路下标区间」范式，坐标单位改用 **UTF-16 code unit** 以对齐 DirectWrite `HitTestPoint`）。
+  - 剥离点选在**文本成为下游唯一坐标系之前**：gal hook 在 `texthooker_service.dart` 的 `appendLine`，剪切板在 `desktop_lookup_service.dart` 的 `_queueLookupRequest`（三个来源共同收口，且必须先于按字素截断，否则截断会把标记拦腰切断）。放到显示层剥会让 `gal_hook_text_overlay_controller.dart:541` 的 `entry.text != text` 守卫恒真，点字直接弹「行不可用」。
+  - native 渲染复用既有 `HitTestTextRange`（与高亮背景框同一套几何）在基准字上方画小号假名，并用 `SetLineSpacing` 加高行盒让位：`text_` 里不含任何注音字符，**点字 index / 高亮 range / dim range 三个既有契约零改动**。`rubySpans` 缺省即完全走老路径，逐像素与今天一致。
+  - 支持语法：`<rふる>震</r>`（截图实例 / BGI 系）、`<ruby>震<rt>ふる</rt></ruby>`（含 `<rb>`/`<rp>`/`<rtc>`）、`｜震《ふる》`、裸 `震《ふる》`、`震[ふる]`。歧义形式（裸 `《》`、`[かな]`）要求「注音全假名 + 前面紧挨汉字串」；认不出的标记一律原样保留，绝不猜着删。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/utils/ruby_markup_test.dart`（28 项）：语法矩阵、误伤防御（`<red>`、`《LONDON》`、`[2026/07/27]`）、混排偏移、`rebase` 偏移守恒。
+  - `hibiki/test/sync/ruby_markup_pipeline_test.dart`（10 项）：两条链路上 `entry.text` / `request.text` 确为纯基准文本且区间对齐、无注音时零变化、`copyWith` 不丢注音、字数口径修正。
+  - `hibiki/test/build/overlay_ruby_render_guard_test.dart`（4 项）：C++ 无法在 Dart 测试里执行，故在源码层锁死「复用 HitTestTextRange 不自建排版」「`text_` 不含注音、`CharIndexAt` 仍直回 `textPosition`」「无注音时不走任何注音分支」「两通道解包 + 越界区间丢弃 + 缺省参数」。
+- **备注**：
+  - **行为变化（有意）**：注音假名不再计入 `charsDelta`，历史阅读字数统计会有一处小幅断层——这是口径修正，不是回归。
+  - app 内悬浮面板 / 瞬态卡本轮只拿到剥干净的文本，**不渲染振假名**（它们是 Flutter 侧另一套渲染，仓库已有 `RubyTextData`/`RubyText` 可复用）；本轮范围按用户所述限定在 gal 弹窗与剪切板弹窗两个 native 浮窗。
+  - 顺带发现的**另一个既有真 bug（本轮未夹带）**：字幕侧 `packages/hibiki_audio/lib/src/parsers/strip_html_tags.dart:15` 只删标签保留内容，VTT/SRT 里的 `<ruby>震<rt>ふる</rt></ruby>` 会被拼成 `震ふる` 污染 `plainText`、进而污染查词与制卡。应另立条目按同一 `RubyMarkupText` 结构修。
+  - native 振假名的**像素观感未经真机验收**：本机可跑的 Windows 离屏 itest 取不到原生覆盖窗截图（见 `docs/agent/integration-testing.md`），且没有该游戏样本。Dart 侧契约与 C++ 编译已验证，渲染效果需用户在真实浮窗上目视确认。

--- a/docs/bugs/BUG-1138-gal-clipboard-overlay-ruby-markup.md
+++ b/docs/bugs/BUG-1138-gal-clipboard-overlay-ruby-markup.md
@@ -11,9 +11,10 @@
 - **[x] ① 已修复** — 新增纯函数解析器 `hibiki/lib/src/utils/misc/ruby_markup.dart`（`parseRubyMarkup` → `RubyMarkupText{text, spans}`，抄字幕侧 `parseSubtitleMarkup` 的「正文不加不减 + 旁路下标区间」范式，坐标单位改用 **UTF-16 code unit** 以对齐 DirectWrite `HitTestPoint`）。
   - 剥离点选在**文本成为下游唯一坐标系之前**：gal hook 在 `texthooker_service.dart` 的 `appendLine`，剪切板在 `desktop_lookup_service.dart` 的 `_queueLookupRequest`（三个来源共同收口，且必须先于按字素截断，否则截断会把标记拦腰切断）。放到显示层剥会让 `gal_hook_text_overlay_controller.dart:541` 的 `entry.text != text` 守卫恒真，点字直接弹「行不可用」。
   - native 渲染复用既有 `HitTestTextRange`（与高亮背景框同一套几何）在基准字上方画小号假名，并用 `SetLineSpacing` 加高行盒让位：`text_` 里不含任何注音字符，**点字 index / 高亮 range / dim range 三个既有契约零改动**。`rubySpans` 缺省即完全走老路径，逐像素与今天一致。
+  - **歧义方括号式只认平假名**（审查期发现并修）：`_isRubyReading` 早期版本对 `[…]` 也放行片假名读音，于是「汉字 + 片假名方括号」这类**普通日文标签**会被当注音，括号内容直接从正文里删掉——实测 `配信[アーカイブ]の話` → `配信の話`（丢 7 字）、`限定[コラボ]グッズ` → `限定グッズ`。剪贴板链路喂进来的是任意文本，撞车概率不低，且这与本模块「认不出的标记原样保留，绝不猜着删」的底线直接冲突。现方括号式要求读音全平假名；`《》` 不受影响（义训片假名读音 `本気《マジ》` 是轻小说常规写法，必须继续认）。
   - 支持语法：`<rふる>震</r>`（截图实例 / BGI 系）、`<ruby>震<rt>ふる</rt></ruby>`（含 `<rb>`/`<rp>`/`<rtc>`）、`｜震《ふる》`、裸 `震《ふる》`、`震[ふる]`。歧义形式（裸 `《》`、`[かな]`）要求「注音全假名 + 前面紧挨汉字串」；认不出的标记一律原样保留，绝不猜着删。
 - **[x] ② 已加自动化测试** —
-  - `hibiki/test/utils/ruby_markup_test.dart`（28 项）：语法矩阵、误伤防御（`<red>`、`《LONDON》`、`[2026/07/27]`）、混排偏移、`rebase` 偏移守恒。
+  - `hibiki/test/utils/ruby_markup_test.dart`（31 项）：语法矩阵、误伤防御（`<red>`、`《LONDON》`、`[2026/07/27]`、**片假名标签 `配信[アーカイブ]` 等 4 例不许吃正文**）、平假名读音收紧后仍认、`《》` 义训片假名仍认、混排偏移、`rebase` 偏移守恒。
   - `hibiki/test/sync/ruby_markup_pipeline_test.dart`（10 项）：两条链路上 `entry.text` / `request.text` 确为纯基准文本且区间对齐、无注音时零变化、`copyWith` 不丢注音、字数口径修正。
   - `hibiki/test/build/overlay_ruby_render_guard_test.dart`（4 项）：C++ 无法在 Dart 测试里执行，故在源码层锁死「复用 HitTestTextRange 不自建排版」「`text_` 不含注音、`CharIndexAt` 仍直回 `textPosition`」「无注音时不走任何注音分支」「两通道解包 + 越界区间丢弃 + 缺省参数」。
 - **备注**：

--- a/hibiki/lib/src/lookup/clipboard_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_text_overlay_controller.dart
@@ -12,6 +12,7 @@ import 'package:hibiki/src/media/audiobook/floating_lyric_lookup_routing.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/platform/clipboard_text_overlay_channel.dart';
 import 'package:hibiki/src/sync/desktop_lookup_service.dart';
+import 'package:hibiki/src/utils/misc/ruby_markup.dart';
 
 /// 背景不透明度（0.0–1.0）→ ARGB 背景色：alpha=opacity*255 的纯黑；opacity=0 即
 /// `0x00000000` 完全透明背景（文字始终由 native textColor 决定，恒实心）。纯函数，
@@ -68,14 +69,21 @@ class ClipboardTextOverlayController {
   /// 空文本忽略（不弹空窗）。
   Future<void> update(DesktopLookupRequest request) async {
     if (!_started) return;
-    final String text = request.text.trim();
+    // 注音标记已在 DesktopLookupService 侧剥掉，这里只剩最后一次 trim；用
+    // [RubyMarkupText.trimmed] 让注音区间跟着平移，而不是各自 trim 后错位。
+    final RubyMarkupText ruby =
+        RubyMarkupText(text: request.text, spans: request.rubySpans).trimmed();
+    final String text = ruby.text;
     if (text.isEmpty) return;
     await ClipboardTextOverlayChannel.show(
       bgColor: _bgColor(),
       textColor: _textColor(),
       windowTitle: t.clipboard_text_window_title,
     );
-    await ClipboardTextOverlayChannel.updateText(text);
+    await ClipboardTextOverlayChannel.updateText(
+      text,
+      rubySpans: ruby.toChannelSpans(),
+    );
     _visible = true;
   }
 

--- a/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -19,6 +19,7 @@ import 'package:hibiki/src/pages/implementations/home_page.dart';
 import 'package:hibiki/src/platform/gal_hook_text_overlay_channel.dart';
 import 'package:hibiki/src/sync/desktop_lookup_service.dart';
 import 'package:hibiki/src/sync/texthooker_service.dart';
+import 'package:hibiki/src/utils/misc/ruby_markup.dart';
 import 'package:hibiki/utils.dart';
 
 typedef GalHookPreferenceReader = Object? Function(
@@ -302,6 +303,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
       await GalHookTextOverlayChannel.updateText(
         lineId: latest.id,
         text: latest.text,
+        rubySpans: rubySpansToChannel(latest.rubySpans),
       );
       _visible = await GalHookTextOverlayChannel.show(
         rect: _savedRect,
@@ -324,6 +326,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
       await GalHookTextOverlayChannel.updateText(
         lineId: latest.id,
         text: latest.text,
+        rubySpans: rubySpansToChannel(latest.rubySpans),
       );
       _displayedLineId = latest.id;
       notifyListeners();

--- a/hibiki/lib/src/platform/clipboard_text_overlay_channel.dart
+++ b/hibiki/lib/src/platform/clipboard_text_overlay_channel.dart
@@ -105,9 +105,17 @@ class ClipboardTextOverlayChannel extends FloatingOverlayChannel {
 
   static Future<bool> isShowing() => _instance.isShowingImpl();
 
-  static Future<void> updateText(String text) async {
+  /// [rubySpans] 是可选的注音区间（`{start, length, ruby}`，start/length 为 [text]
+  /// 的 UTF-16 下标）。不传或传空时 native 走老渲染路径，逐像素与今天一致。
+  static Future<void> updateText(
+    String text, {
+    List<Map<String, Object?>>? rubySpans,
+  }) async {
     if (!_instance.isSupported) return;
-    await _instance.channel.invokeMethod<void>('updateText', {'text': text});
+    await _instance.channel.invokeMethod<void>('updateText', {
+      'text': text,
+      if (rubySpans != null && rubySpans.isNotEmpty) 'rubySpans': rubySpans,
+    });
   }
 
   static Future<void> updateStyle({

--- a/hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart
+++ b/hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart
@@ -217,14 +217,19 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
 
   static Future<bool> isShowing() => _instance.isShowingImpl();
 
+  /// [rubySpans] 是可选的注音区间（`{start, length, ruby}`，start/length 为 [text]
+  /// 的 UTF-16 下标，与 native `HitTestPoint` 回传的 index 同坐标系）。不传或传空
+  /// 时 native 完全走老渲染路径，逐像素与今天一致（never break userspace）。
   static Future<void> updateText({
     required String lineId,
     required String text,
+    List<Map<String, Object?>>? rubySpans,
   }) async {
     if (!_instance.isSupported) return;
     await _instance.channel.invokeMethod<void>('updateText', <String, Object?>{
       'lineId': lineId,
       'text': text,
+      if (rubySpans != null && rubySpans.isNotEmpty) 'rubySpans': rubySpans,
     });
   }
 

--- a/hibiki/lib/src/sync/desktop_lookup_service.dart
+++ b/hibiki/lib/src/sync/desktop_lookup_service.dart
@@ -11,6 +11,7 @@ import 'package:window_manager/window_manager.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/sync/clipboard_dedupe.dart';
 import 'package:hibiki/src/utils/misc/lookup_input_limits.dart';
+import 'package:hibiki/src/utils/misc/ruby_markup.dart';
 import 'package:hibiki/src/utils/window_caption_channel.dart';
 import 'package:hibiki/src/sync/desktop_foreground_guard.dart';
 
@@ -32,9 +33,15 @@ class DesktopLookupRequest {
     this.foregroundPolicy = DesktopLookupForegroundPolicy.bringToFront,
     this.showSourcePanel = true,
     this.passiveStream = false,
+    this.rubySpans = const <RubySpan>[],
   });
 
+  /// 纯基准文本：注音标记已在 [DesktopLookupService._queueLookupRequest] 剥掉
+  /// （注音落在 [rubySpans]）。本条链路的唯一坐标系。
   final String text;
+
+  /// 注音（振假名）区间，下标落在 [text] 上（UTF-16 code unit）。空 = 无注音。
+  final List<RubySpan> rubySpans;
   final DesktopLookupOrigin origin;
   final DesktopLookupForegroundPolicy foregroundPolicy;
   final bool showSourcePanel;
@@ -154,10 +161,20 @@ class DesktopLookupService extends ChangeNotifier
     bool dedupe = true,
     bool passiveStream = false,
   }) {
+    // 注音标记在这里剥，且必须**先于**下面的截断：先截断会把 `<rふる>` 这类标记
+    // 拦腰切断，解析器认不出就只能把半截标记当正文留下。剥完得到的纯基准文本是
+    // 本条链路（透明文字窗 / 悬浮面板 / 瞬态卡 / 剪贴板历史）唯一的坐标系，注音
+    // 以旁路区间随 [DesktopLookupRequest.rubySpans] 下发。
+    //
+    // 放在 _queueLookupRequest 而不是 processClipboardText，是因为这里是剪贴板 /
+    // 全局热键 / 悬浮字幕点词三个来源的共同收口，一处生效即可；而自产回声拦截
+    // （clipboardIgnores.consume）必须留在上游比对**原始串**——登记侧写进剪贴板的
+    // 就是原始串。
+    final RubyMarkupText parsed = parseRubyMarkup(raw);
     // BUG-442：剪贴板/热键/显式查词的统一入口。所有来源在排队前先按同一码点上限
     // 截断（用 characters 不切碎代理对 / 字素簇），避免超长串一路流到逐字渲染的
     // SourceLookupTextPanel 把主 isolate 撑爆，也省掉对超长串做线性清洗。
-    raw = _capLookupInput(raw);
+    raw = _capLookupInput(parsed.text);
     if (!dedupe) {
       final String trimmed = raw.trim();
       if (trimmed.isEmpty) return;
@@ -169,6 +186,7 @@ class DesktopLookupService extends ChangeNotifier
         foregroundPolicy: foregroundPolicy,
         showSourcePanel: showSourcePanel,
         passiveStream: passiveStream,
+        rubySpans: parsed.rebase(trimmed).spans,
       );
       notifyListeners();
       return;
@@ -187,6 +205,7 @@ class DesktopLookupService extends ChangeNotifier
       foregroundPolicy: foregroundPolicy,
       showSourcePanel: showSourcePanel,
       passiveStream: passiveStream,
+      rubySpans: parsed.rebase(deduped).spans,
     );
     notifyListeners();
   }

--- a/hibiki/lib/src/sync/texthooker_service.dart
+++ b/hibiki/lib/src/sync/texthooker_service.dart
@@ -1,5 +1,6 @@
 import 'package:characters/characters.dart';
 import 'package:flutter/foundation.dart';
+import 'package:hibiki/src/utils/misc/ruby_markup.dart';
 
 enum TexthookerLineSource { websocket, engineHook, unknown }
 
@@ -195,9 +196,14 @@ class TexthookerLineEntry {
     this.fallbackReason,
     this.mined = false,
     this.favorited = false,
+    this.rubySpans = const <RubySpan>[],
   });
 
   final String id;
+
+  /// 纯基准文本：注音标记已在 [TexthookerService.appendLine] 剥掉（注音落在
+  /// [rubySpans]）。**全链路唯一坐标系**——浮窗显示、点字查词的 native index、
+  /// 制卡 sentence、字数统计都以它为准，任何一处换成别的串都会立刻错位。
   final String text;
   final TexthookerLineSource source;
   final String? sourceLabel;
@@ -223,6 +229,10 @@ class TexthookerLineEntry {
 
   /// 本行是否已被用户收藏（会话内存态，不落 DB；重启即失）。
   final bool favorited;
+
+  /// 本行的注音（振假名）区间，下标落在 [text] 上（UTF-16 code unit）。
+  /// 空表示这行没有可识别的注音标记。
+  final List<RubySpan> rubySpans;
 
   /// 本行是否已有可用句音：matched（配到游戏资源）/ encoded（音频已提取进卡）/
   /// fallback（回退环回声）三态即有音频；pending/missing/unavailable 视作无。
@@ -269,6 +279,7 @@ class TexthookerLineEntry {
           clearFallbackReason ? null : fallbackReason ?? this.fallbackReason,
       mined: mined ?? this.mined,
       favorited: favorited ?? this.favorited,
+      rubySpans: rubySpans,
     );
   }
 }
@@ -454,12 +465,18 @@ class TexthookerService extends ChangeNotifier {
     TexthookerLineAudioStatus audioStatus =
         TexthookerLineAudioStatus.unavailable,
   }) {
-    final String trimmed = line.trim();
+    // 注音标记在这里、也只在这里剥。这是所有下游消费方（浮窗显示 / 点字查词 /
+    // 制卡 sentence / 字数统计 / 跨线程折叠）拿到 `entry.text` 之前的唯一收口，
+    // 剥在这里才能保证它们天然共用同一坐标系；放到显示层剥会让
+    // `_onLookupText` 的 `entry.text != text` 守卫恒真，点字直接失效。
+    final RubyMarkupText parsed = parseRubyMarkup(line).trimmed();
+    final String trimmed = parsed.text;
     if (trimmed.isEmpty) return null;
     final DateTime now = receivedAt ?? DateTime.now();
     final TexthookerLineEntry entry = TexthookerLineEntry(
       id: '${now.microsecondsSinceEpoch}-${_nextId++}',
       text: trimmed,
+      rubySpans: parsed.spans,
       source: source,
       sourceLabel: sourceLabel,
       sourceSequence: sourceSequence,

--- a/hibiki/lib/src/utils/misc/ruby_markup.dart
+++ b/hibiki/lib/src/utils/misc/ruby_markup.dart
@@ -1,0 +1,333 @@
+// 注音（振假名）标记解析：把 galgame Hook 台词 / 剪贴板文本里的注音标记拆成
+// 「纯基准文本 + 旁路下标区间」，正文一个字符不加不减。
+//
+// 为什么是这个形状：仓库里字幕侧已有同款范式（`parseSubtitleMarkup` 产出
+// `plainText` + `SubtitleSpan` 区间，见 packages/hibiki_audio/.../subtitle_markup.dart），
+// 下游查词 / 制卡 sentence / 字数统计全靠「正文即唯一坐标系」才不漂移。注音走同一
+// 形状，就不会重演「显示串 ≠ 查询串」那类偏移 bug。
+//
+// 唯一的差别是坐标单位用 **UTF-16 code unit** 而不是字素簇：本模块的消费端是
+// Windows 原生浮窗，DirectWrite `HitTestPoint` 回传的 `textPosition` 就是 UTF-16
+// 下标（windows/runner/floating_lyric_window.cpp:1465），而 Dart `String` 下标同单位，
+// 两侧天然对齐，`JapaneseLanguage.wordFromIndex` 也是按 UTF-16 切。字素簇在这里
+// 反而要多一层换算，是白送的错位风险。
+//
+// 设计底线（Never break userspace）：
+// - 认不出的标记**原样保留**，绝不猜着删——宁可显示一个多余的尖括号，也不能吃掉
+//   用户真正想看的正文。
+// - 歧义形式（裸 `《》`、`[かな]`）必须同时满足「注音全是假名」+「前面紧挨着汉字
+//   串」才成立，否则按普通文本处理。显式形式（`<ruby>`、`<r…>`、`｜…《》`）结构
+//   无歧义，不需要这层保险。
+
+import 'package:flutter/foundation.dart';
+
+/// 一段注音：`ruby` 注在纯文本 [RubyMarkupText.text] 的 `[start, start+length)` 上方。
+/// 下标单位是 UTF-16 code unit（与 Dart `String` 下标、DirectWrite `textPosition` 同单位）。
+@immutable
+class RubySpan {
+  const RubySpan({
+    required this.start,
+    required this.length,
+    required this.ruby,
+  });
+
+  final int start;
+  final int length;
+  final String ruby;
+
+  int get end => start + length;
+
+  RubySpan shifted(int delta) =>
+      RubySpan(start: start + delta, length: length, ruby: ruby);
+
+  /// MethodChannel 载荷（native 侧按同名字段解包，见 windows/runner/flutter_window.cpp）。
+  Map<String, Object?> toChannelMap() => <String, Object?>{
+        'start': start,
+        'length': length,
+        'ruby': ruby,
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RubySpan &&
+          start == other.start &&
+          length == other.length &&
+          ruby == other.ruby;
+
+  @override
+  int get hashCode => Object.hash(start, length, ruby);
+
+  @override
+  String toString() => 'RubySpan($start,$length,$ruby)';
+}
+
+/// 解析结果：[text] 是剥掉注音标记后的纯基准文本，[spans] 是挂在它上面的注音区间。
+@immutable
+class RubyMarkupText {
+  const RubyMarkupText({required this.text, required this.spans});
+
+  /// 无注音的直通结果（绝大多数行走这条路）。
+  factory RubyMarkupText.plain(String text) =>
+      RubyMarkupText(text: text, spans: const <RubySpan>[]);
+
+  final String text;
+  final List<RubySpan> spans;
+
+  bool get hasRuby => spans.isNotEmpty;
+
+  /// 把区间重新基准化到 [candidate] 上。
+  ///
+  /// 管线里文本还会被继续加工（`trim()`、`_capLookupInput` 的尾部截断、去重返回
+  /// trim 过的串），每处都可能让下标漂移。与其在每个加工点各写一遍偏移修正，不如
+  /// 统一走这一个函数：[candidate] 必须是 [text] 的**连续子串**（trim 和截断都满足），
+  /// 命中就整体平移并丢掉越界区间；一旦不是子串（说明发生了预期外的改写）就**退回
+  /// 无注音**——宁可不显示振假名，也绝不显示错位的振假名。
+  RubyMarkupText rebase(String candidate) {
+    if (candidate == text) return this;
+    if (spans.isEmpty) return RubyMarkupText.plain(candidate);
+    final int offset = candidate.isEmpty ? -1 : text.indexOf(candidate);
+    if (offset < 0) return RubyMarkupText.plain(candidate);
+    final List<RubySpan> moved = <RubySpan>[];
+    for (final RubySpan span in spans) {
+      final int start = span.start - offset;
+      if (start < 0 || start + span.length > candidate.length) continue;
+      moved.add(RubySpan(start: start, length: span.length, ruby: span.ruby));
+    }
+    return RubyMarkupText(text: candidate, spans: moved);
+  }
+
+  /// `trim()` 并同步平移区间。
+  RubyMarkupText trimmed() => rebase(text.trim());
+
+  /// MethodChannel 载荷；无注音时返回 `null`，native 侧因此完全走老路径
+  /// （缺省参数 = 今天逐像素一致）。
+  List<Map<String, Object?>>? toChannelSpans() => rubySpansToChannel(spans);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RubyMarkupText &&
+          text == other.text &&
+          listEquals(spans, other.spans);
+
+  @override
+  int get hashCode => Object.hash(text, Object.hashAll(spans));
+
+  @override
+  String toString() => 'RubyMarkupText($text, $spans)';
+}
+
+/// 注音区间 → MethodChannel 载荷；空列表返回 `null`，让调用方直接省掉该字段，
+/// native 因此完全走老渲染路径。
+List<Map<String, Object?>>? rubySpansToChannel(List<RubySpan> spans) => spans
+        .isEmpty
+    ? null
+    : spans.map((RubySpan span) => span.toChannelMap()).toList(growable: false);
+
+/// 一个基准段及其注音（注音为空表示这段只是普通文本）。
+typedef _RubyUnit = ({String base, String ruby});
+
+/// 某个标记被吃掉后的结果：下一个扫描位置 + 产出的基准/注音段。
+typedef _Consumed = ({int next, List<_RubyUnit> units});
+
+/// 快速否定：一行里连注音标记的起始符都没有就直接直通，省掉整趟扫描。
+/// galgame 台词绝大多数不带注音，这条捷径决定了本模块在 80ms 轮询里可以白跑。
+final RegExp _rubyMarkerHint = RegExp(r'[<《｜|\[]');
+
+/// `<ruby>漢字<rt>かんじ</rt></ruby>`（HTML / Web texthooker / 浏览器扩展常见）。
+final RegExp _htmlRubyPattern = RegExp(
+  r'<ruby\b[^>]*>(.*?)</ruby\s*>',
+  caseSensitive: false,
+  dotAll: true,
+);
+
+/// `<rp>（）</rp>` 是给不支持 ruby 的渲染器看的回退括号，整段丢弃（与 EPUB 侧
+/// `EpubBook._removeRubyAnnotations` 同口径）。
+final RegExp _rpElementPattern = RegExp(
+  r'<rp\b[^>]*>.*?</rp\s*>',
+  caseSensitive: false,
+  dotAll: true,
+);
+
+/// `<rb>` / `<rtc>` 只是分组壳，去掉标签保留内容。
+final RegExp _rubyShellTagPattern = RegExp(
+  r'</?(?:rb|rtc)\b[^>]*>',
+  caseSensitive: false,
+);
+
+final RegExp _rtElementPattern = RegExp(
+  r'<rt\b[^>]*>(.*?)</rt\s*>',
+  caseSensitive: false,
+  dotAll: true,
+);
+
+/// `<rふる>震</r>`：注音写在标签里、基准是标签内容。截图里 WITCH ON THE HOLY NIGHT
+/// 用的就是这一种，BGI/Ethornell 系的 `<R…>…</R>` 同形。
+final RegExp _taggedRubyPattern =
+    RegExp(r'<[rR]\s*([^<>]*?)\s*>([^<>]*)</[rR]\s*>');
+
+/// 青空文庫式显式形：`｜震《ふる》`（全角竖线，也兼容 ASCII `|`）。有竖线定界，
+/// 基准范围无歧义。
+final RegExp _pipeAozoraPattern = RegExp(r'[｜|]([^｜|《》]+)《([^》]*)》');
+
+/// 裸 `《ふる》` / `[ふる]`：基准靠「前面紧挨着的汉字串」倒推，是歧义形式，
+/// 必须过假名判据。
+final RegExp _bareAozoraPattern = RegExp(r'《([^》]*)》');
+final RegExp _bracketReadingPattern = RegExp(r'\[([^\[\]]*)\]');
+
+const int _kMaxRubyReadingLength = 16;
+
+bool _isKanaRune(int rune) =>
+    // 平假名（含濁点/半濁点/繰り返し記号）
+    (rune >= 0x3041 && rune <= 0x309F) ||
+    // 片假名（含長音符 ー / 中黒 ・）
+    (rune >= 0x30A0 && rune <= 0x30FF) ||
+    // 半角片假名
+    (rune >= 0xFF66 && rune <= 0xFF9D);
+
+/// 歧义形式的保险丝：注音必须是一串不太长的假名。真实注音永远满足；而普通文本里
+/// 恰好出现的 `《…》`（书名号）、`[…]`（编号/时间）几乎必然不满足，于是被原样留下。
+bool _isRubyReading(String reading) {
+  if (reading.isEmpty || reading.length > _kMaxRubyReadingLength) return false;
+  for (final int rune in reading.runes) {
+    if (!_isKanaRune(rune)) return false;
+  }
+  return true;
+}
+
+/// 可以被裸注音倒推为基准的字符：汉字 + 々〆〇 + 兼容汉字。
+/// 只认 BMP——扩展 B 区汉字要代理对，倒推会切碎；那种字上基本也不会出现裸注音，
+/// 认不出就当普通文本，属于安全失败方向。
+bool _isBaseUnit(int unit) =>
+    (unit >= 0x4E00 && unit <= 0x9FFF) ||
+    (unit >= 0x3005 && unit <= 0x3007) ||
+    (unit >= 0xF900 && unit <= 0xFAFF);
+
+/// 把 `<ruby>` 元素内部拆成交替的「基准段 + `<rt>` 注音」。
+/// 支持 mono-ruby（`<ruby>漢<rt>かん</rt>字<rt>じ</rt></ruby>` → 两段各自注音）。
+List<_RubyUnit> _splitRubyElement(String inner) {
+  final String cleaned = inner
+      .replaceAll(_rpElementPattern, '')
+      .replaceAll(_rubyShellTagPattern, '');
+  final List<_RubyUnit> units = <_RubyUnit>[];
+  int cursor = 0;
+  for (final Match match in _rtElementPattern.allMatches(cleaned)) {
+    units.add((
+      base: cleaned.substring(cursor, match.start),
+      ruby: match.group(1) ?? '',
+    ));
+    cursor = match.end;
+  }
+  if (cursor < cleaned.length) {
+    units.add((base: cleaned.substring(cursor), ruby: ''));
+  }
+  return units;
+}
+
+_Consumed? _tryHtmlRuby(String raw, int at) {
+  final Match? match = _htmlRubyPattern.matchAsPrefix(raw, at);
+  if (match == null) return null;
+  final List<_RubyUnit> units = _splitRubyElement(match.group(1) ?? '');
+  // `<ruby>` 的结构无歧义（rt 就是注音），所以不过假名判据：英文/罗马字注音一样
+  // 该被抬到上方，而不是拼进正文。
+  return (next: match.end, units: units);
+}
+
+_Consumed? _tryTaggedRuby(String raw, int at) {
+  final Match? match = _taggedRubyPattern.matchAsPrefix(raw, at);
+  if (match == null) return null;
+  final String reading = match.group(1) ?? '';
+  final String base = match.group(2) ?? '';
+  // `<r…>` 的标签名太短，普通文本里也可能撞上（`<red>` 之类），过一道假名判据。
+  if (base.isEmpty || !_isRubyReading(reading)) return null;
+  return (next: match.end, units: <_RubyUnit>[(base: base, ruby: reading)]);
+}
+
+_Consumed? _tryPipeAozora(String raw, int at) {
+  final Match? match = _pipeAozoraPattern.matchAsPrefix(raw, at);
+  if (match == null) return null;
+  final String base = match.group(1) ?? '';
+  final String reading = match.group(2) ?? '';
+  if (base.isEmpty || reading.isEmpty) return null;
+  // 有 `｜` 显式定界，基准范围无歧义，不需要假名判据。
+  return (next: match.end, units: <_RubyUnit>[(base: base, ruby: reading)]);
+}
+
+/// 裸注音（`《…》` / `[…]`）：基准要从**已经产出的正文**里倒推。
+/// [floor] 是上一段注音的结束位置，倒推不许跨过它，否则会把已注音的字再吃一次。
+int _lookbackBaseStart(List<int> out, int floor) {
+  int start = out.length;
+  while (start > floor && _isBaseUnit(out[start - 1])) {
+    start--;
+  }
+  return start;
+}
+
+/// 解析注音标记。[raw] 原样返回时表示这行不含（可识别的）注音。
+RubyMarkupText parseRubyMarkup(String raw) {
+  if (raw.isEmpty || !_rubyMarkerHint.hasMatch(raw)) {
+    return RubyMarkupText.plain(raw);
+  }
+
+  final List<int> out = <int>[];
+  final List<RubySpan> spans = <RubySpan>[];
+
+  void emit(List<_RubyUnit> units) {
+    for (final _RubyUnit unit in units) {
+      if (unit.base.isEmpty) continue;
+      final int start = out.length;
+      out.addAll(unit.base.codeUnits);
+      if (unit.ruby.isNotEmpty) {
+        spans.add(
+          RubySpan(start: start, length: out.length - start, ruby: unit.ruby),
+        );
+      }
+    }
+  }
+
+  int i = 0;
+  while (i < raw.length) {
+    final int unit = raw.codeUnitAt(i);
+
+    if (unit == 0x3C /* < */) {
+      final _Consumed? consumed =
+          _tryHtmlRuby(raw, i) ?? _tryTaggedRuby(raw, i);
+      if (consumed != null) {
+        emit(consumed.units);
+        i = consumed.next;
+        continue;
+      }
+    } else if (unit == 0xFF5C /* ｜ */ || unit == 0x7C /* | */) {
+      final _Consumed? consumed = _tryPipeAozora(raw, i);
+      if (consumed != null) {
+        emit(consumed.units);
+        i = consumed.next;
+        continue;
+      }
+    } else if (unit == 0x300A /* 《 */ || unit == 0x5B /* [ */) {
+      final RegExp pattern =
+          unit == 0x300A ? _bareAozoraPattern : _bracketReadingPattern;
+      final Match? match = pattern.matchAsPrefix(raw, i);
+      final String reading = match?.group(1) ?? '';
+      if (match != null && _isRubyReading(reading)) {
+        final int floor = spans.isEmpty ? 0 : spans.last.end;
+        final int start = _lookbackBaseStart(out, floor);
+        if (start < out.length) {
+          spans.add(
+            RubySpan(start: start, length: out.length - start, ruby: reading),
+          );
+          i = match.end;
+          continue;
+        }
+      }
+    }
+
+    out.add(unit);
+    i++;
+  }
+
+  // 注意不能在 spans 为空时直接返回 raw：`<ruby>` 里 `<rt>` 为空这类输入会剥掉标记
+  // 却不产生注音，此时 out 已经与 raw 不同，返回 raw 等于把标记又塞回正文。
+  return RubyMarkupText(text: String.fromCharCodes(out), spans: spans);
+}

--- a/hibiki/lib/src/utils/misc/ruby_markup.dart
+++ b/hibiki/lib/src/utils/misc/ruby_markup.dart
@@ -37,9 +37,6 @@ class RubySpan {
 
   int get end => start + length;
 
-  RubySpan shifted(int delta) =>
-      RubySpan(start: start + delta, length: length, ruby: ruby);
-
   /// MethodChannel 载荷（native 侧按同名字段解包，见 windows/runner/flutter_window.cpp）。
   Map<String, Object?> toChannelMap() => <String, Object?>{
         'start': start,
@@ -80,9 +77,15 @@ class RubyMarkupText {
   ///
   /// 管线里文本还会被继续加工（`trim()`、`_capLookupInput` 的尾部截断、去重返回
   /// trim 过的串），每处都可能让下标漂移。与其在每个加工点各写一遍偏移修正，不如
-  /// 统一走这一个函数：[candidate] 必须是 [text] 的**连续子串**（trim 和截断都满足），
+  /// 统一走这一个函数：[candidate] 必须是 [text] 经 **trim 和/或尾部截断** 得到的子串，
   /// 命中就整体平移并丢掉越界区间；一旦不是子串（说明发生了预期外的改写）就**退回
   /// 无注音**——宁可不显示振假名，也绝不显示错位的振假名。
+  ///
+  /// 这个前置条件不是随口一提：下面用 `indexOf` 取**首个**匹配，只有「trim + 前缀
+  /// 截断」这一类 candidate 才保证首个匹配就是真实偏移（candidate 的首字符非空白，
+  /// 而它前面被切掉的全是空白，更早的匹配不可能存在）。将来若有人改成传中段或后缀
+  /// 子串（例如打字机式增量），`indexOf` 会挑到错误的重复位置，注音就会平移到别的
+  /// 字上——那种改法必须同时把真实偏移显式传进来。
   RubyMarkupText rebase(String candidate) {
     if (candidate == text) return this;
     if (spans.isEmpty) return RubyMarkupText.plain(candidate);
@@ -178,9 +181,13 @@ final RegExp _bracketReadingPattern = RegExp(r'\[([^\[\]]*)\]');
 
 const int _kMaxRubyReadingLength = 16;
 
+/// 平假名（含濁点/半濁点/繰り返し記号）+ 長音符 `ー`：振假名**读音**的字母表。
+bool _isHiraganaRune(int rune) =>
+    (rune >= 0x3041 && rune <= 0x309F) || rune == 0x30FC;
+
 bool _isKanaRune(int rune) =>
     // 平假名（含濁点/半濁点/繰り返し記号）
-    (rune >= 0x3041 && rune <= 0x309F) ||
+    _isHiraganaRune(rune) ||
     // 片假名（含長音符 ー / 中黒 ・）
     (rune >= 0x30A0 && rune <= 0x30FF) ||
     // 半角片假名
@@ -188,10 +195,20 @@ bool _isKanaRune(int rune) =>
 
 /// 歧义形式的保险丝：注音必须是一串不太长的假名。真实注音永远满足；而普通文本里
 /// 恰好出现的 `《…》`（书名号）、`[…]`（编号/时间）几乎必然不满足，于是被原样留下。
-bool _isRubyReading(String reading) {
+///
+/// [hiraganaOnly] 收紧到只认平假名，给方括号式用。两种歧义形式的误伤面差一个数量级：
+/// `《》` 在日文里几乎专用于注音，义训片假名读音（`本気《マジ》`）是轻小说常规写法，
+/// 必须认；而 `[]` 是普通文本里最通用的定界符，「汉字 + 片假名方括号」恰恰是外来语
+/// 标签的高频写法（`配信[アーカイブ]`、`限定[コラボ]`、`第1話[ネタバレ]`）。片假名是
+/// 外来语**标签**的字母表，不是振假名**读音**的字母表；方括号式若认片假名，这些普通
+/// 文本的括号内容会直接从正文里消失，违反本模块「认不出的标记原样保留，绝不猜着删」
+/// 的底线。
+bool _isRubyReading(String reading, {bool hiraganaOnly = false}) {
   if (reading.isEmpty || reading.length > _kMaxRubyReadingLength) return false;
   for (final int rune in reading.runes) {
-    if (!_isKanaRune(rune)) return false;
+    if (hiraganaOnly ? !_isHiraganaRune(rune) : !_isKanaRune(rune)) {
+      return false;
+    }
   }
   return true;
 }
@@ -310,7 +327,8 @@ RubyMarkupText parseRubyMarkup(String raw) {
           unit == 0x300A ? _bareAozoraPattern : _bracketReadingPattern;
       final Match? match = pattern.matchAsPrefix(raw, i);
       final String reading = match?.group(1) ?? '';
-      if (match != null && _isRubyReading(reading)) {
+      if (match != null &&
+          _isRubyReading(reading, hiraganaOnly: unit == 0x5B /* [ */)) {
         final int floor = spans.isEmpty ? 0 : spans.last.end;
         final int start = _lookbackBaseStart(out, floor);
         if (start < out.length) {

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.2.0+950
+version: 1.2.0+951
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/build/overlay_ruby_render_guard_test.dart
+++ b/hibiki/test/build/overlay_ruby_render_guard_test.dart
@@ -1,0 +1,126 @@
+// 源码守卫：gal 台词浮窗 / 剪切板文字窗的振假名渲染结构。
+//
+// 两个浮窗都不是 Flutter widget，而是 runner 自有的 Win32 分层窗（Direct2D +
+// DirectWrite 直绘），C++ 无法在 Dart 测试里执行，故在源码层锁死这次改动赖以成立
+// 的四条结构性前提：
+//   ① 注音几何复用 HitTestTextRange（与高亮背景框同一套），不自建第二套排版；
+//   ② text_ 里**不含**任何注音字符，CharIndexAt 仍直接回传 DirectWrite 的
+//      textPosition —— 点字查词的 UTF-16 index 契约一个字都没改；
+//   ③ 没有注音时完全不走注音分支（行距不动、不额外绘制），逐像素回到今天；
+//   ④ 两个通道的 updateText 都把 rubySpans 解包下发，且越界区间被丢弃。
+//
+// ① 是这次能用「附加绘制」而不是「重写渲染路径」的全部原因：一旦有人改成自建
+// 布局或自定义 IDWriteTextRenderer，折行 / 滚动 / 高亮 / dim 四处几何就会各走各的，
+// 点字 index 也会跟着漂。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final String window =
+      File('windows/runner/floating_lyric_window.cpp').readAsStringSync();
+  final String header =
+      File('windows/runner/floating_lyric_window.h').readAsStringSync();
+  final String channelHost =
+      File('windows/runner/flutter_window.cpp').readAsStringSync();
+
+  test('① 注音几何复用 HitTestTextRange，不自建排版', () {
+    expect(
+      window.contains('ruby_spans_'),
+      isTrue,
+      reason: '注音区间成员必须存在，否则这套渲染根本没接上',
+    );
+    // 注音绘制段必须出现在同一个 text_layout_ 上的 HitTestTextRange 调用。
+    expect(
+      RegExp(r'for \(const RubySpan& span : ruby_spans_\)[\s\S]{0,400}?'
+              r'text_layout_->HitTestTextRange')
+          .hasMatch(window),
+      isTrue,
+      reason: '注音必须问 text_layout_ 要基准字矩形（与高亮框同一套几何）；'
+          '自己排版会让折行/滚动/高亮/dim 四处几何分叉',
+    );
+    for (final String forbidden in <String>[
+      'IDWriteTextRenderer',
+      'SetInlineObject',
+    ]) {
+      expect(
+        window.contains(forbidden),
+        isFalse,
+        reason: '$forbidden 会改变布局位置与原文位置的对应关系，'
+            '必须同时补一张 index 映射表，CharIndexAt 契约就守不住了',
+      );
+    }
+  });
+
+  test('② text_ 只存纯基准文本，CharIndexAt 仍直回 textPosition', () {
+    expect(
+      window.contains('return static_cast<int>(metrics.textPosition);'),
+      isTrue,
+      reason: '点字 index 必须仍是 DirectWrite 的 UTF-16 textPosition；'
+          '一旦这里变成经过映射的值，Dart 侧的 wordFromIndex 就会错位',
+    );
+    // 注音文本只从 span.ruby 取，绝不拼进 text_。
+    expect(
+      RegExp(r'text_\s*(\+=|\.append|\.insert)').hasMatch(window),
+      isFalse,
+      reason: 'text_ 一旦被追加注音字符，显示串就不再等于 Dart 侧的 entry.text，'
+          'gal 浮窗 _onLookupText 的等值守卫会恒真，点字直接失效',
+    );
+  });
+
+  test('③ 无注音时不走任何注音分支', () {
+    expect(
+      window.contains('const bool has_ruby = !ruby_spans_.empty();'),
+      isTrue,
+      reason: '必须有一个统一的 has_ruby 门，空注音时行距与绘制都不动',
+    );
+    expect(
+      RegExp(r'if \(has_ruby && text_layout_ != nullptr\)[\s\S]{0,600}?'
+              r'SetLineSpacing')
+          .hasMatch(window),
+      isTrue,
+      reason: '加高行距必须挂在 has_ruby 门后；无条件改行距会让所有老浮窗观感变化',
+    );
+    expect(
+      RegExp(r'if \(has_ruby && ruby_format_ != nullptr\)').hasMatch(window),
+      isTrue,
+      reason: '注音绘制同样必须挂在 has_ruby 门后',
+    );
+  });
+
+  test('④ 两个通道解包 rubySpans，且越界区间被丢弃', () {
+    expect(
+      'rubySpans'.allMatches(channelHost).length,
+      greaterThanOrEqualTo(2),
+      reason: 'gal 台词窗与剪切板文字窗两处 updateText 都要解包 rubySpans',
+    );
+    expect(
+      RegExp(r'gal_hook_text_window_->UpdateText\([\s\S]{0,200}?'
+              r'RubySpansFromValue\(args, "rubySpans"\)')
+          .hasMatch(channelHost),
+      isTrue,
+      reason: 'gal 台词浮窗必须下发注音区间',
+    );
+    expect(
+      RegExp(r'clipboard_text_window_->UpdateText\([\s\S]{0,200}?'
+              r'RubySpansFromValue\(args, "rubySpans"\)')
+          .hasMatch(channelHost),
+      isTrue,
+      reason: '剪切板文字窗必须下发注音区间',
+    );
+    // 越界保护：UpdateText 必须按最终文本长度过滤，绝不让错位注音飘在别的字上。
+    expect(
+      RegExp(r'span\.start \+ span\.length > text_length').hasMatch(window),
+      isTrue,
+      reason: '注音区间必须按新文本长度校验；越界的要丢掉而不是照画',
+    );
+    // 缺省参数 = 老 payload 行为不变。
+    expect(
+      RegExp(r'const std::vector<RubySpan>& ruby_spans =\s*'
+              r'std::vector<RubySpan>\(\)')
+          .hasMatch(header),
+      isTrue,
+      reason: 'UpdateText 的注音参数必须有空缺省值，旧调用点（歌词条）零改动',
+    );
+  });
+}

--- a/hibiki/test/sync/ruby_markup_pipeline_test.dart
+++ b/hibiki/test/sync/ruby_markup_pipeline_test.dart
@@ -1,0 +1,126 @@
+// 注音标记在两条真实链路上的落地契约。
+//
+// 解析器本身的语法矩阵在 test/utils/ruby_markup_test.dart；这里只守一件事，也是
+// 整个改动的命门：**剥离必须发生在文本成为下游唯一坐标系之前**。
+//
+// gal hook 链路上，`entry.text` 同时是浮窗显示串、点字查词的 `wordFromIndex` 输入、
+// 制卡 sentence 和字数统计输入，而 `_onLookupText` 有一道
+// `entry.text != text`（native 回传串）的等值守卫。若在显示层才剥标记，这道守卫
+// 会恒真，点字直接弹「行不可用」——所以剥离点必须在 appendLine。
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/desktop_lookup_service.dart';
+import 'package:hibiki/src/sync/texthooker_service.dart';
+import 'package:hibiki/src/utils/misc/ruby_markup.dart';
+
+/// 断言注音区间确实落在该行纯文本的期望基准上。
+void expectAlignedSpan(
+  String text,
+  List<RubySpan> spans,
+  int index, {
+  required String base,
+  required String ruby,
+}) {
+  expect(spans.length, greaterThan(index), reason: '缺少第 $index 段注音：$spans');
+  final RubySpan span = spans[index];
+  expect(span.ruby, ruby);
+  expect(
+    text.substring(span.start, span.end),
+    base,
+    reason: 'span $span 没有落在 "$base" 上（文本 "$text"）',
+  );
+}
+
+void main() {
+  group('gal hook：TexthookerService.appendLine 是唯一剥离点', () {
+    test('台词行存的是纯基准文本，注音落到旁路区间', () {
+      final TexthookerService service = TexthookerService.test();
+      final TexthookerLineEntry? entry = service.appendLine(
+        '今もピリピリと空気を<rふる>震</r>わせている。',
+        source: TexthookerLineSource.engineHook,
+      );
+      expect(entry, isNotNull);
+      // 显示串 / 查词串 / 制卡 sentence 共用的这一份，必须已经没有标记。
+      expect(entry!.text, '今もピリピリと空気を震わせている。');
+      expectAlignedSpan(entry.text, entry.rubySpans, 0, base: '震', ruby: 'ふる');
+    });
+
+    test('无注音的行逐字不变（never break userspace）', () {
+      final TexthookerService service = TexthookerService.test();
+      const String raw = '良かれと思って案内役に優等生を選んでみたものの。';
+      final TexthookerLineEntry? entry = service.appendLine(raw);
+      expect(entry!.text, raw);
+      expect(entry.rubySpans, isEmpty);
+    });
+
+    test('前后空白被 trim 后注音区间跟着平移', () {
+      final TexthookerService service = TexthookerService.test();
+      final TexthookerLineEntry? entry =
+          service.appendLine('   <rふる>震</r>わせる   ');
+      expect(entry!.text, '震わせる');
+      expectAlignedSpan(entry.text, entry.rubySpans, 0, base: '震', ruby: 'ふる');
+    });
+
+    test('只剩标记的行仍按空行丢弃', () {
+      final TexthookerService service = TexthookerService.test();
+      expect(service.appendLine('<ruby><rt>ふる</rt></ruby>'), isNull);
+    });
+
+    test('copyWith（配音状态回写等）不得丢掉注音', () {
+      final TexthookerService service = TexthookerService.test();
+      final TexthookerLineEntry entry = service.appendLine('<rふる>震</r>')!;
+      final TexthookerLineEntry updated = entry.copyWith(mined: true);
+      expect(updated.mined, isTrue);
+      expect(updated.rubySpans, entry.rubySpans);
+    });
+
+    test('剥离后的文本才是字数统计口径（注音假名不再被算成正文）', () {
+      final TexthookerService service = TexthookerService.test();
+      final TexthookerLineEntry entry = service.appendLine('空気を<rふる>震</r>わせる')!;
+      // 若不剥标记，这行会多出 `<r`/`>`/`</r>` 与 `ふる` 两个假名。
+      expect(entry.text.length, '空気を震わせる'.length);
+    });
+  });
+
+  group('剪切板：DesktopLookupService 请求携带纯文本 + 注音区间', () {
+    setUp(() => DesktopLookupService.instance.debugReset());
+    tearDown(() => DesktopLookupService.instance.debugReset());
+
+    test('剪贴板文本剥标记后进请求，区间对齐', () {
+      DesktopLookupService.instance.processClipboardText('空気を<rふる>震</r>わせる');
+      final DesktopLookupRequest? request =
+          DesktopLookupService.instance.pendingRequest;
+      expect(request, isNotNull);
+      expect(request!.text, '空気を震わせる');
+      expectAlignedSpan(request.text, request.rubySpans, 0,
+          base: '震', ruby: 'ふる');
+    });
+
+    test('无注音时请求不带区间（native 走老渲染路径）', () {
+      DesktopLookupService.instance.processClipboardText('ただの文章');
+      final DesktopLookupRequest? request =
+          DesktopLookupService.instance.pendingRequest;
+      expect(request!.text, 'ただの文章');
+      expect(request.rubySpans, isEmpty);
+    });
+
+    test('热键 / 点词来源同样收口（解析在 _queueLookupRequest 一处生效）', () {
+      DesktopLookupService.instance.triggerLookup('<rふる>震</r>');
+      final DesktopLookupRequest? request =
+          DesktopLookupService.instance.pendingRequest;
+      expect(request!.text, '震');
+      expectAlignedSpan(request.text, request.rubySpans, 0,
+          base: '震', ruby: 'ふる');
+    });
+
+    test('青空文庫式长文也认（剪贴板会喂到任意文本）', () {
+      DesktopLookupService.instance
+          .processClipboardText('その優等生《ゆうとうせい》はご機嫌ななめ。');
+      final DesktopLookupRequest? request =
+          DesktopLookupService.instance.pendingRequest;
+      expect(request!.text, 'その優等生はご機嫌ななめ。');
+      expectAlignedSpan(request.text, request.rubySpans, 0,
+          base: '優等生', ruby: 'ゆうとうせい');
+    });
+  });
+}

--- a/hibiki/test/utils/ruby_markup_test.dart
+++ b/hibiki/test/utils/ruby_markup_test.dart
@@ -175,6 +175,35 @@ void main() {
       expect(parsed.text, raw);
       expect(parsed.hasRuby, isFalse);
     });
+
+    // 方括号式只认平假名读音。片假名是外来语**标签**的字母表：日文里「汉字 +
+    // 片假名方括号」是标签的高频写法，一旦当成注音，括号内容会被从正文里删掉，
+    // 而剪贴板链路喂进来的是任意文本，撞车概率不低。这一组钉死「宁可不显示注音，
+    // 也绝不吃掉正文」。
+    test('方括号里是片假名标签时原样保留（不吃掉正文）', () {
+      for (final String raw in <String>[
+        '配信[アーカイブ]の話',
+        '限定[コラボ]グッズ',
+        '第1話[ネタバレ]注意',
+        '新作[リメイク]',
+      ]) {
+        final RubyMarkupText parsed = parseRubyMarkup(raw);
+        expect(parsed.text, raw, reason: '$raw 的括号内容不许从正文里消失');
+        expect(parsed.hasRuby, isFalse, reason: '$raw 不是注音');
+      }
+    });
+
+    test('平假名读音仍照常认（收紧不误杀真注音）', () {
+      final RubyMarkupText parsed = parseRubyMarkup('注[ちゅう]を読む');
+      expect(parsed.text, '注を読む');
+      expectSpan(parsed, 0, base: '注', ruby: 'ちゅう');
+    });
+
+    test('裸《》仍认义训片假名读音（轻小说常规写法，不被收紧波及）', () {
+      final RubyMarkupText parsed = parseRubyMarkup('本気《マジ》で');
+      expect(parsed.text, '本気で');
+      expectSpan(parsed, 0, base: '本気', ruby: 'マジ');
+    });
   });
 
   group('混排与偏移', () {

--- a/hibiki/test/utils/ruby_markup_test.dart
+++ b/hibiki/test/utils/ruby_markup_test.dart
@@ -1,0 +1,253 @@
+// 注音标记解析的语法矩阵与偏移契约。
+//
+// 这套测试守的是两条命：
+// 1. 正文即坐标系——剥完标记后 span 的 start/length 必须精确落在纯文本上，
+//    因为浮窗点字查词的 index 与它同一坐标系（UTF-16 code unit）。
+// 2. 认不出就别动——歧义形式必须被普通文本挡回去，绝不吃掉正文。
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/utils/misc/ruby_markup.dart';
+
+/// 断言注音区间确实落在纯文本的期望基准上。
+void expectSpan(
+  RubyMarkupText parsed,
+  int index, {
+  required String base,
+  required String ruby,
+}) {
+  expect(parsed.spans.length, greaterThan(index),
+      reason: '缺少第 $index 段注音：${parsed.spans}');
+  final RubySpan span = parsed.spans[index];
+  expect(span.ruby, ruby);
+  expect(
+    parsed.text.substring(span.start, span.end),
+    base,
+    reason: 'span $span 没有落在 "$base" 上（文本 "${parsed.text}"）',
+  );
+}
+
+void main() {
+  group('无标记直通', () {
+    test('普通台词原样返回且不产生注音', () {
+      const String raw = '良かれと思って案内役に優等生を選んでみたものの。';
+      final RubyMarkupText parsed = parseRubyMarkup(raw);
+      expect(parsed.text, raw);
+      expect(parsed.hasRuby, isFalse);
+      expect(parsed.toChannelSpans(), isNull);
+    });
+
+    test('空串不炸', () {
+      final RubyMarkupText parsed = parseRubyMarkup('');
+      expect(parsed.text, '');
+      expect(parsed.hasRuby, isFalse);
+    });
+  });
+
+  group('<r注音>基准</r>（截图实例 / BGI 系）', () {
+    test('WITCH ON THE HOLY NIGHT 原句', () {
+      // 截图里浮窗显示的原始串，游戏本体把 ふる 渲染在「震」上方。
+      const String raw = '今もピリピリと空気を<rふる>震</r>わせている。';
+      final RubyMarkupText parsed = parseRubyMarkup(raw);
+      expect(parsed.text, '今もピリピリと空気を震わせている。');
+      expect(parsed.spans.single,
+          const RubySpan(start: 10, length: 1, ruby: 'ふる'));
+      expectSpan(parsed, 0, base: '震', ruby: 'ふる');
+    });
+
+    test('大写 <R> 与标签内空格都认', () {
+      final RubyMarkupText parsed = parseRubyMarkup('<R かんじ>漢字</R>です');
+      expect(parsed.text, '漢字です');
+      expectSpan(parsed, 0, base: '漢字', ruby: 'かんじ');
+    });
+
+    test('注音不是假名时原样保留（不误吃 <red> 之类）', () {
+      const String raw = '<red>危険</red>';
+      final RubyMarkupText parsed = parseRubyMarkup(raw);
+      expect(parsed.text, raw);
+      expect(parsed.hasRuby, isFalse);
+    });
+
+    test('空注音的 <r> 原样保留', () {
+      const String raw = '<r>震</r>';
+      final RubyMarkupText parsed = parseRubyMarkup(raw);
+      expect(parsed.text, raw);
+      expect(parsed.hasRuby, isFalse);
+    });
+  });
+
+  group('HTML <ruby>', () {
+    test('单段 rt', () {
+      final RubyMarkupText parsed =
+          parseRubyMarkup('空気を<ruby>震<rt>ふる</rt></ruby>わせる');
+      expect(parsed.text, '空気を震わせる');
+      expectSpan(parsed, 0, base: '震', ruby: 'ふる');
+    });
+
+    test('mono-ruby 拆成逐字两段', () {
+      final RubyMarkupText parsed =
+          parseRubyMarkup('<ruby>漢<rt>かん</rt>字<rt>じ</rt></ruby>');
+      expect(parsed.text, '漢字');
+      expect(parsed.spans.length, 2);
+      expectSpan(parsed, 0, base: '漢', ruby: 'かん');
+      expectSpan(parsed, 1, base: '字', ruby: 'じ');
+    });
+
+    test('<rb> 壳保留内容、<rp> 回退括号整段丢弃', () {
+      final RubyMarkupText parsed = parseRubyMarkup(
+        '<ruby><rb>漢字</rb><rp>（</rp><rt>かんじ</rt><rp>）</rp></ruby>',
+      );
+      expect(parsed.text, '漢字');
+      expectSpan(parsed, 0, base: '漢字', ruby: 'かんじ');
+    });
+
+    test('非假名注音也抬到上方（<ruby> 结构无歧义）', () {
+      final RubyMarkupText parsed =
+          parseRubyMarkup('<ruby>東京<rt>Tokyo</rt></ruby>');
+      expect(parsed.text, '東京');
+      expectSpan(parsed, 0, base: '東京', ruby: 'Tokyo');
+    });
+
+    test('空 rt 只剥标记、不产生注音，且不把标记塞回正文', () {
+      final RubyMarkupText parsed = parseRubyMarkup('<ruby>漢字<rt></rt></ruby>');
+      expect(parsed.text, '漢字');
+      expect(parsed.hasRuby, isFalse);
+    });
+  });
+
+  group('青空文庫式', () {
+    test('｜ 显式定界', () {
+      final RubyMarkupText parsed = parseRubyMarkup('空気を｜震《ふる》わせる');
+      expect(parsed.text, '空気を震わせる');
+      expectSpan(parsed, 0, base: '震', ruby: 'ふる');
+    });
+
+    test('ASCII 竖线同样认', () {
+      final RubyMarkupText parsed = parseRubyMarkup('|震《ふる》');
+      expect(parsed.text, '震');
+      expectSpan(parsed, 0, base: '震', ruby: 'ふる');
+    });
+
+    test('裸《》倒推前面的汉字串', () {
+      final RubyMarkupText parsed = parseRubyMarkup('その優等生《ゆうとうせい》は');
+      expect(parsed.text, 'その優等生は');
+      expectSpan(parsed, 0, base: '優等生', ruby: 'ゆうとうせい');
+    });
+
+    test('裸《》前面没有汉字时原样保留（书名号不误吃）', () {
+      const String raw = 'これは《ろんどん》だ';
+      final RubyMarkupText parsed = parseRubyMarkup(raw);
+      expect(parsed.text, raw);
+      expect(parsed.hasRuby, isFalse);
+    });
+
+    test('裸《》内容不是假名时原样保留', () {
+      const String raw = '書名《LONDON》';
+      final RubyMarkupText parsed = parseRubyMarkup(raw);
+      expect(parsed.text, raw);
+      expect(parsed.hasRuby, isFalse);
+    });
+
+    test('连续两段裸注音不互相吃字', () {
+      final RubyMarkupText parsed = parseRubyMarkup('魔術《まじゅつ》師《し》');
+      expect(parsed.text, '魔術師');
+      expectSpan(parsed, 0, base: '魔術', ruby: 'まじゅつ');
+      expectSpan(parsed, 1, base: '師', ruby: 'し');
+    });
+  });
+
+  group('漢字[かんじ] 方括号式', () {
+    test('倒推汉字串', () {
+      final RubyMarkupText parsed = parseRubyMarkup('空気を震[ふる]わせる');
+      expect(parsed.text, '空気を震わせる');
+      expectSpan(parsed, 0, base: '震', ruby: 'ふる');
+    });
+
+    test('方括号里不是假名时原样保留（编号/时间不误吃）', () {
+      const String raw = '第3話[2026/07/27]';
+      final RubyMarkupText parsed = parseRubyMarkup(raw);
+      expect(parsed.text, raw);
+      expect(parsed.hasRuby, isFalse);
+    });
+
+    test('方括号前没有汉字时原样保留', () {
+      const String raw = 'えっと[ふる]';
+      final RubyMarkupText parsed = parseRubyMarkup(raw);
+      expect(parsed.text, raw);
+      expect(parsed.hasRuby, isFalse);
+    });
+  });
+
+  group('混排与偏移', () {
+    test('一行多种语法混排，偏移逐段正确', () {
+      final RubyMarkupText parsed = parseRubyMarkup(
+        '<rふる>震</r>える<ruby>魔術<rt>まじゅつ</rt></ruby>と｜夜《よる》',
+      );
+      expect(parsed.text, '震える魔術と夜');
+      expect(parsed.spans.length, 3);
+      expectSpan(parsed, 0, base: '震', ruby: 'ふる');
+      expectSpan(parsed, 1, base: '魔術', ruby: 'まじゅつ');
+      expectSpan(parsed, 2, base: '夜', ruby: 'よる');
+    });
+
+    test('区间按 UTF-16 下标排列且互不重叠', () {
+      final RubyMarkupText parsed =
+          parseRubyMarkup('<rあ>亜</r><rい>以</r><rう>宇</r>');
+      expect(parsed.text, '亜以宇');
+      int previousEnd = 0;
+      for (final RubySpan span in parsed.spans) {
+        expect(span.start, greaterThanOrEqualTo(previousEnd));
+        expect(span.length, greaterThan(0));
+        previousEnd = span.end;
+      }
+      expect(previousEnd, lessThanOrEqualTo(parsed.text.length));
+    });
+  });
+
+  group('rebase：文本被继续加工时的偏移守恒', () {
+    test('trim 后区间整体平移', () {
+      final RubyMarkupText parsed =
+          parseRubyMarkup('  <rふる>震</r>わせる  ').trimmed();
+      expect(parsed.text, '震わせる');
+      expectSpan(parsed, 0, base: '震', ruby: 'ふる');
+    });
+
+    test('尾部截断丢掉越界区间、保留仍在范围内的', () {
+      final RubyMarkupText parsed = parseRubyMarkup('<rふる>震</r>える<rよる>夜</r>');
+      expect(parsed.text, '震える夜');
+      expect(parsed.spans.length, 2);
+      final RubyMarkupText clipped = parsed.rebase('震える');
+      expect(clipped.text, '震える');
+      expect(clipped.spans.length, 1);
+      expectSpan(clipped, 0, base: '震', ruby: 'ふる');
+    });
+
+    test('候选串不是子串时整体退回无注音（宁可不显示也不错位）', () {
+      final RubyMarkupText parsed = parseRubyMarkup('<rふる>震</r>わせる');
+      final RubyMarkupText rebased = parsed.rebase('まったく別の文');
+      expect(rebased.text, 'まったく別の文');
+      expect(rebased.hasRuby, isFalse);
+    });
+
+    test('空串退回无注音', () {
+      final RubyMarkupText parsed = parseRubyMarkup('<rふる>震</r>');
+      expect(parsed.rebase('').hasRuby, isFalse);
+    });
+  });
+
+  group('通道载荷', () {
+    test('无注音时不发结构化字段（native 走老路径）', () {
+      expect(parseRubyMarkup('ただの台詞').toChannelSpans(), isNull);
+    });
+
+    test('有注音时按 start/length/ruby 三字段编码', () {
+      final List<Map<String, Object?>>? encoded =
+          parseRubyMarkup('<rふる>震</r>').toChannelSpans();
+      expect(encoded, isNotNull);
+      expect(encoded!.single, <String, Object?>{
+        'start': 0,
+        'length': 1,
+        'ruby': 'ふる',
+      });
+    });
+  });
+}

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -42,6 +42,11 @@ constexpr float kMaxStripHeightDip = 480.0f;
 // A press must travel this far (logical px) before it becomes a drag rather
 // than a word-lookup tap — lets the bar be dragged from anywhere on the text.
 constexpr float kDragThresholdDip = 6.0f;
+// 振假名相对基准字的字号比例，以及为它加高的行盒比例（相对注音字号）。
+// 0.45 是日文排版里 ruby 的常用比例（约基准的一半再收一点），行盒留 1.25 倍
+// 注音高度，假名与基准字之间因此有一条细缝，不会贴在一起。
+constexpr float kRubyFontScale = 0.45f;
+constexpr float kRubyLineGapScale = 1.25f;
 // Base logical font size the lyric text was authored at; the rendered font
 // scales with the bar height so growing the bar enlarges the text too.
 constexpr float kBaseStripHeightForFontDip = 96.0f;
@@ -346,8 +351,18 @@ bool FloatingLyricWindow::IsShowing() const {
 void FloatingLyricWindow::UpdateText(const std::wstring& text,
                                     int current_line_start,
                                     int current_line_length,
-                                    const std::string& context_id) {
+                                    const std::string& context_id,
+                                    const std::vector<RubySpan>& ruby_spans) {
   text_ = text;
+  // 注音区间只信任落在新文本范围内的那些：越界的一律丢掉，绝不让一段错位的
+  // 振假名飘在别的字上面（宁可不显示）。
+  ruby_spans_.clear();
+  const int text_length = static_cast<int>(text.size());
+  for (const RubySpan& span : ruby_spans) {
+    if (span.start < 0 || span.length <= 0 || span.ruby.empty()) continue;
+    if (span.start + span.length > text_length) continue;
+    ruby_spans_.push_back(span);
+  }
   context_id_ = context_id;
   current_line_start_ = current_line_start;
   current_line_length_ = current_line_length;
@@ -373,6 +388,7 @@ void FloatingLyricWindow::Highlight(int start, int length) {
 void FloatingLyricWindow::UpdateStyle(const Style& style) {
   style_ = style;
   text_format_.Reset();
+  ruby_format_.Reset();
   text_layout_.Reset();
   ApplyStyleWidth();
   RequestRender();
@@ -778,6 +794,7 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       // logical strip size and re-render so the text + controls follow.
       SyncStripSizeFromWindow();
       text_format_.Reset();
+      ruby_format_.Reset();
       text_layout_.Reset();
       RequestRender();
       return 0;
@@ -890,12 +907,18 @@ void FloatingLyricWindow::Render() {
   // enlarges the lyric text too. Hook mode does NOT (BUG-1095): its font size is
   // an independent user preference, so dragging the overlay taller buys visible
   // LINES instead of re-inflating the same two lines.
+  const float height_scale =
+      hook_text_mode_ ? 1.0f : strip_height_dip_ / kBaseStripHeightForFontDip;
+  const float scaled_font = static_cast<float>(style_.font_size) *
+                            std::max(0.5f, height_scale);
+  // 注音字号与行盒加高量（物理 px）。ruby_spans_ 为空时下面所有注音分支都不执行，
+  // 排版与绘制逐像素回到引入注音之前。
+  const float ruby_font_px =
+      static_cast<float>(ScaleForDpi(scaled_font * kRubyFontScale));
+  const float ruby_gap_px = ruby_font_px * kRubyLineGapScale;
+  const bool has_ruby = !ruby_spans_.empty();
+
   if (text_format_ == nullptr) {
-    const float height_scale =
-        hook_text_mode_ ? 1.0f
-                        : strip_height_dip_ / kBaseStripHeightForFontDip;
-    const float scaled_font = static_cast<float>(style_.font_size) *
-                              std::max(0.5f, height_scale);
     dwrite_factory_->CreateTextFormat(
         L"Yu Gothic UI", nullptr, DWRITE_FONT_WEIGHT_NORMAL,
         DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
@@ -909,6 +932,21 @@ void FloatingLyricWindow::Render() {
                           : DWRITE_WORD_WRAPPING_NO_WRAP);
     }
     text_layout_.Reset();
+  }
+
+  // 振假名的小号 format：居中 + 不换行。注音比基准字窄时居中压在基准上方；比
+  // 基准宽时向两侧对称溢出（DrawText 不带 CLIP 选项不会自己裁，外层已经用
+  // PushAxisAlignedClip 把一切文字绘制框在 text_rect_ 里，绝不会画到控件带上）。
+  if (has_ruby && ruby_format_ == nullptr) {
+    dwrite_factory_->CreateTextFormat(
+        L"Yu Gothic UI", nullptr, DWRITE_FONT_WEIGHT_NORMAL,
+        DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL, ruby_font_px,
+        L"", ruby_format_.GetAddressOf());
+    if (ruby_format_ != nullptr) {
+      ruby_format_->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+      ruby_format_->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+      ruby_format_->SetWordWrapping(DWRITE_WORD_WRAPPING_NO_WRAP);
+    }
   }
 
   const float pad = ScaleForDpi(kHorizontalPaddingDip);
@@ -934,6 +972,25 @@ void FloatingLyricWindow::Render() {
                                         text_format_.Get(), text_rect_.width,
                                         text_rect_.height,
                                         text_layout_.GetAddressOf());
+      // 有注音就把每行的行盒整体加高、基线整体下压 ruby_gap_px：多出来的空间
+      // 正好落在每行字的**正上方**，注音画进去既不遮基准字，也不会压到上一行。
+      // 只加高、不改宽，所以自动折行的断点与没有注音时完全一致。
+      if (has_ruby && text_layout_ != nullptr) {
+        // 先问行数再按数分配：缓冲区不足时 DirectWrite 只回填 actualLineCount，
+        // 并不写入 metrics，拿一个未初始化的行高去设行距会直接把排版搞乱。
+        UINT32 line_count = 0;
+        text_layout_->GetLineMetrics(nullptr, 0, &line_count);
+        if (line_count > 0) {
+          std::vector<DWRITE_LINE_METRICS> lines(line_count);
+          if (SUCCEEDED(text_layout_->GetLineMetrics(lines.data(), line_count,
+                                                     &line_count)) &&
+              line_count > 0) {
+            text_layout_->SetLineSpacing(DWRITE_LINE_SPACING_METHOD_UNIFORM,
+                                         lines[0].height + ruby_gap_px,
+                                         lines[0].baseline + ruby_gap_px);
+          }
+        }
+      }
     }
     if (text_layout_ != nullptr) {
       // BUG-1095: with scrolling added (phase 2) the strip no longer loses the
@@ -1045,6 +1102,42 @@ void FloatingLyricWindow::Render() {
       render_target_->DrawTextLayout(
           D2D1::Point2F(text_rect_.left, text_origin_y), text_layout_.Get(),
           brush.Get(), D2D1_DRAW_TEXT_OPTIONS_NONE);
+
+      // 振假名：画在基准字所在行盒的顶部那条留白里（行距已在建 layout 时加高）。
+      //
+      // 几何全部问 text_layout_ 要，用的是高亮背景框同一套 HitTestTextRange —— 这
+      // 意味着注音不需要任何自己的排版：折行、居中、滚动偏移怎么动，注音就怎么
+      // 跟着动。text_ 里也**不含**任何注音字符，所以 CharIndexAt 的 textPosition、
+      // Highlight 的 range、dim 的 range 三个既有契约一个都没被碰。
+      //
+      // 一段注音跨行时（基准被折行切开）只取第一个矩形：把读音压在句首那半边，
+      // 比在两行上各画半个假名可读。
+      if (has_ruby && ruby_format_ != nullptr) {
+        for (const RubySpan& span : ruby_spans_) {
+          UINT32 hit_count = 0;
+          text_layout_->HitTestTextRange(static_cast<UINT32>(span.start),
+                                         static_cast<UINT32>(span.length), 0, 0,
+                                         nullptr, 0, &hit_count);
+          if (hit_count == 0) continue;
+          std::vector<DWRITE_HIT_TEST_METRICS> boxes(hit_count);
+          if (FAILED(text_layout_->HitTestTextRange(
+                  static_cast<UINT32>(span.start),
+                  static_cast<UINT32>(span.length), 0, 0, boxes.data(),
+                  hit_count, &hit_count)) ||
+              hit_count == 0) {
+            continue;
+          }
+          const DWRITE_HIT_TEST_METRICS& box = boxes[0];
+          const D2D1_RECT_F ruby_rect = D2D1::RectF(
+              text_rect_.left + box.left, text_origin_y + box.top,
+              text_rect_.left + box.left + box.width,
+              text_origin_y + box.top + ruby_gap_px);
+          render_target_->DrawTextW(
+              span.ruby.c_str(), static_cast<UINT32>(span.ruby.size()),
+              ruby_format_.Get(), ruby_rect, brush.Get(),
+              D2D1_DRAW_TEXT_OPTIONS_NONE);
+        }
+      }
       // BUG-1070: balance the PushAxisAlignedClip that fenced the text to
       // text_rect_ (must pop before the control band / toolbar is drawn so the
       // buttons are unaffected).

--- a/hibiki/windows/runner/floating_lyric_window.h
+++ b/hibiki/windows/runner/floating_lyric_window.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <vector>
 
 // A standalone always-on-top "QQ Music style" desktop lyric strip.
 //
@@ -53,6 +54,17 @@ class FloatingLyricWindow {
   using LockCallback = std::function<void(bool locked)>;
   using BoundsCallback =
       std::function<void(int left, int top, int width, int height)>;
+
+  // 一段振假名（ruby）：|ruby| 画在 text 的 [start, start + length) 上方。
+  //
+  // start / length 与 |text| 同为 UTF-16 code unit 下标，也就是 CharIndexAt()
+  // 回传给 Dart 的那个坐标系 —— 三者共用一套下标，注音不需要任何偏移映射表，
+  // 点字查词的 index 契约一个字都不用改。
+  struct RubySpan {
+    int start = 0;
+    int length = 0;
+    std::wstring ruby;
+  };
 
   struct Style {
     double font_size = 20.0;
@@ -109,9 +121,13 @@ class FloatingLyricWindow {
 
   // TODO-708 P4: 多行上下文文本 + 块内当前行区间。current_line_start<0 = 无行
   // 标记（N=0 单行/旧 payload），整块满色 = 今天观感（never-break userspace）。
+  // |ruby_spans| 为空 = 没有注音，排版与绘制与引入注音之前逐像素一致
+  // （旧 payload / 不带注音的行都走这条路，never-break userspace）。
   void UpdateText(const std::wstring& text, int current_line_start = -1,
                   int current_line_length = 0,
-                  const std::string& context_id = std::string());
+                  const std::string& context_id = std::string(),
+                  const std::vector<RubySpan>& ruby_spans =
+                      std::vector<RubySpan>());
   // Highlights [start, start + length) UTF-16 code units of the current text.
   void Highlight(int start, int length);
   void UpdateStyle(const Style& style);
@@ -272,6 +288,9 @@ class FloatingLyricWindow {
   RECT initial_bounds_ = {0, 0, 0, 0};
 
   std::wstring text_;
+  // 当前文本的注音区间（下标落在 text_ 上）。空 = 无注音，Render 完全跳过注音
+  // 相关的行距加高与附加绘制。
+  std::vector<RubySpan> ruby_spans_;
   std::string context_id_;
   // Taskbar / Alt+Tab label; seeds CreateWindowExW and retitles the live window.
   std::wstring window_title_ = L"Hibiki Lyric";
@@ -311,6 +330,9 @@ class FloatingLyricWindow {
   Microsoft::WRL::ComPtr<IDWriteFactory> dwrite_factory_;
   Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> render_target_;
   Microsoft::WRL::ComPtr<IDWriteTextFormat> text_format_;
+  // 振假名用的小号 format（居中、不换行）。与 text_format_ 同生命周期：字号 /
+  // 样式变化时一起 Reset，下一帧按新字号重建。
+  Microsoft::WRL::ComPtr<IDWriteTextFormat> ruby_format_;
   Microsoft::WRL::ComPtr<IDWriteTextLayout> text_layout_;
 
   LookupCallback on_lookup_;

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -650,6 +650,43 @@ std::string StringFromValue(const flutter::EncodableMap* args, const char* key,
   return s != nullptr ? *s : fallback;
 }
 
+// 解包可选的注音区间列表（`[{start, length, ruby}, ...]`）。
+//
+// 字段缺失、类型不对、区间非法都只是「这条没有注音」，绝不让整条 updateText 失败：
+// 旧 Dart 端不会带这个字段，浮窗必须照常显示文本（never-break userspace）。
+// start / length 的越界校验放在 FloatingLyricWindow::UpdateText 里做，因为只有那里
+// 才知道最终文本长度。
+std::vector<FloatingLyricWindow::RubySpan> RubySpansFromValue(
+    const flutter::EncodableMap* args, const char* key) {
+  std::vector<FloatingLyricWindow::RubySpan> spans;
+  if (args == nullptr) {
+    return spans;
+  }
+  const auto it = args->find(flutter::EncodableValue(key));
+  if (it == args->end()) {
+    return spans;
+  }
+  const auto* list = std::get_if<flutter::EncodableList>(&it->second);
+  if (list == nullptr) {
+    return spans;
+  }
+  for (const auto& item : *list) {
+    const auto* map = std::get_if<flutter::EncodableMap>(&item);
+    if (map == nullptr) {
+      continue;
+    }
+    FloatingLyricWindow::RubySpan span;
+    span.start = IntFromValue(map, "start", -1);
+    span.length = IntFromValue(map, "length", 0);
+    span.ruby = WideFromValue(map, "ruby", L"");
+    if (span.start < 0 || span.length <= 0 || span.ruby.empty()) {
+      continue;
+    }
+    spans.push_back(std::move(span));
+  }
+  return spans;
+}
+
 FloatingLyricWindow::Style StyleFromArgs(const flutter::EncodableMap* args) {
   FloatingLyricWindow::Style style;
   style.font_size = DoubleFromValue(args, "fontSize", style.font_size);
@@ -874,8 +911,10 @@ void FlutterWindow::RegisterClipboardTextChannel() {
         } else if (method == "updateText") {
           // Clipboard text is a single string with no "current line" concept, so
           // the multi-line dim range stays at the default (-1/0 = whole string
-          // full colour).
-          clipboard_text_window_->UpdateText(WideFromValue(args, "text", L""));
+          // full colour). rubySpans 缺省 = 无注音，排版逐像素与今天一致。
+          clipboard_text_window_->UpdateText(
+              WideFromValue(args, "text", L""), -1, 0, std::string(),
+              RubySpansFromValue(args, "rubySpans"));
           result->Success();
         } else if (method == "updateStyle") {
           clipboard_text_window_->UpdateStyle(StyleFromArgs(args));
@@ -989,7 +1028,8 @@ void FlutterWindow::RegisterGalHookTextChannel() {
         } else if (method == "updateText") {
           gal_hook_text_window_->UpdateText(
               WideFromValue(args, "text", L""), -1, 0,
-              StringFromValue(args, "lineId", ""));
+              StringFromValue(args, "lineId", ""),
+              RubySpansFromValue(args, "rubySpans"));
           result->Success();
         } else if (method == "updateStyle") {
           gal_hook_text_window_->UpdateStyle(StyleFromArgs(args));


### PR DESCRIPTION
## 用户诉求

截图（WITCH ON THE HOLY NIGHT）里 gal 台词浮窗把游戏原文的注音标记原样显示成
`今もピリピリと空気を<rふる>震</r>わせている。`，而游戏本体是把 `ふる` 渲染在「震」上方。
诉求：gal 弹窗与剪切板弹窗支持假名之类的语法。

## 根因（BUG-1138）

不是渲染问题，而是**全链路从来没有注音标记这一层**：LunaHook 只做重复/伪影过滤，
`voice_hook_reader.cpp` 只截断不改写，Dart 第一落点原样构造 `GalHookedLine`，唯一的正文改写
是 `texthooker_service.dart` 的 `trim()`。原始标记因此一路进 `entry.text`——而这一串同时是
**浮窗显示串、点字查词 `wordFromIndex` 的输入、制卡 sentence、字数统计输入**。

三处可见后果：① 浮窗显示原始标记；② 点到 `<`/`r`/`ふ` 等标记字符时分词从标记切起，查出垃圾；
③ `countGalgameChars` 把注音假名按 CJK 逐码点计入阅读字数，字数虚高。剪切板链路同理，且会把
标记写进 `clipboard_history.content`。

## 做法

**数据结构**抄仓库字幕侧 `parseSubtitleMarkup` 的成熟范式——「正文一个字符不加不减 + 旁路下标
区间」，只把坐标单位从字素簇换成 **UTF-16 code unit**，因为消费端是 native 浮窗，DirectWrite
`HitTestPoint` 回传的 `textPosition` 就是 UTF-16 下标，Dart `String` 下标同单位，两侧天然对齐。

**剥离点选在文本成为下游唯一坐标系之前**，这是本 PR 的命门：
- gal hook → `TexthookerService.appendLine`
- 剪切板 → `DesktopLookupService._queueLookupRequest`（剪贴板/热键/点词三来源共同收口，且必须
  **先于**按字素截断，否则截断会把 `<rふる>` 拦腰切断）

放到显示层剥会让 `gal_hook_text_overlay_controller.dart:541` 的 `entry.text != text` 守卫恒真，
点字直接弹「行不可用」，查词整个失效。

**native 渲染复用既有 `HitTestTextRange`**（与高亮背景框同一套几何）在基准字上方画小号假名，
`SetLineSpacing` 加高行盒让位。关键收益：`text_` 里不含任何注音字符，**点字 index / 高亮 range /
dim range 三个既有契约一行都没改**，不需要自定义 `IDWriteTextRenderer`，也不需要「布局位置 ↔
原文位置」映射表。`rubySpans` 缺省即完全走老渲染路径，逐像素与今天一致。

## 支持语法

| 语法 | 出处 |
|---|---|
| `<rふる>震</r>` / `<R…>…</R>` | 截图实例、BGI/Ethornell 系 |
| `<ruby>震<rt>ふる</rt></ruby>`（含 `<rb>`/`<rp>`/`<rtc>`、mono-ruby） | HTML / Web texthooker |
| `｜震《ふる》`（兼容 ASCII `\|`） | 青空文庫显式形 |
| 裸 `震《ふる》` | 青空文庫歧义形 |
| `震[ふる]` | Anki/Yomitan 注音纯文本（仓库 `constructFuriganaPlain` 已在产这种格式） |

歧义形式（裸 `《》`、`[かな]`）要求「注音全是假名 + 前面紧挨汉字串」；认不出的标记**一律原样
保留**，宁可多显示一个尖括号也不吃掉正文。

## 验证

- `flutter analyze` 全量 **0 issue**
- 新增 **42 项测试全绿**：解析器语法矩阵与误伤防御 28 项、两条链路落地契约 10 项、native 源码
  结构守卫 4 项（C++ 不能在 Dart 测试里执行，故锁死「复用 HitTestTextRange 不自建排版」「`text_`
  不含注音、`CharIndexAt` 仍直回 `textPosition`」「无注音时不走任何注音分支」「两通道解包 +
  越界丢弃 + 缺省参数」）
- `flutter build windows --debug` 退出码 0，改动的三个 C++ 文件**零告警零错误**
- 全量 `flutter test`：**14782 通过 / 9 跳过 / 1 失败**。失败项是 `hibiki_library_host_service_books_test.dart`
  的 epub 导出用例，单跑 26/26 全绿、`test/sync` 全目录 1699 项全绿，与本轮零代码路径交集 ——
  判为高负载 flaky，如实记录

## 行为变化与未验证项

- **有意的口径修正**：注音假名不再计入 `charsDelta`，历史阅读字数统计会有一处小幅断层。
- **native 振假名的像素观感未经真机验收**：本机 Windows 离屏 itest 取不到原生覆盖窗截图，且无
  该游戏样本。Dart 侧契约与 C++ 编译已验证，渲染效果（字号比例 0.45、行盒 1.25 倍）需在真实
  浮窗上目视确认，必要时调 `kRubyFontScale` / `kRubyLineGapScale` 两个常量即可。
- **范围**：`_queueLookupRequest` 收口意味着 app 内悬浮面板 / 瞬态卡 / 剪贴板历史也都拿到剥干净
  的文本（本身是修正），但**渲染**振假名本轮只做了两个 native 浮窗；app 内面板走 popup HTML 那
  套「三镜像」资产，是另一块工作，未夹带。
- **顺带发现的另一个既有真 bug（未夹带）**：`packages/hibiki_audio/.../strip_html_tags.dart:15` 只删
  标签保留内容，VTT/SRT 的 `<ruby>震<rt>ふる</rt></ruby>` 会被拼成 `震ふる` 污染 `plainText`、进而
  污染查词与制卡。建议另立条目按同一 `RubyMarkupText` 结构修。

不涉及 galgame hook 的 IPC 契约、引擎适配或支持状态声明（`engine-support.yaml` 未动）。

https://claude.ai/code/session_011AjtRi58MftDqJd1TDc2rC
