### PR TITLE
fix(anki): 收 PR#457 审查 §10 的 4 条 Lapis 纯缺陷（A 类）

### DIFF
--- a/hibiki/lib/src/anki/lapis_template_service.dart
+++ b/hibiki/lib/src/anki/lapis_template_service.dart
@@ -174,6 +174,10 @@ class LapisTemplateService {
   ///   里，`lapisFontScalePercent` 归 100），期望态 == 恢复态。
   /// - 备份无用户区段 → 清空客制化并**清掉指纹**：若恢复的是出厂基线，漂移
   ///   判定本就允许升级；若是手改快照，判定变 foreignEdit，自动迁移不再动它。
+  ///
+  /// 写入顺序 styling → 对齐 settings → 卡模板：三步任意一步失败都抛给调用方
+  /// 提示，**不静默降级成「恢复成功」**。卡模板失败时 styling 与 settings 已一致
+  /// （非半态），只是卡模板仍是旧的，用户可重试恢复。
   Future<void> restoreBackup(File file) async {
     final AnkiNoteTypeDefinition? def = await readBackup(file);
     if (def == null) {
@@ -188,9 +192,10 @@ class LapisTemplateService {
     final bool stylingOk =
         await _repository.updateNoteTypeStyling(def.name, def.css);
     if (!stylingOk) throw StateError('Backend rejected styling update');
-    if (def.templates.isNotEmpty) {
-      await _repository.updateNoteTypeTemplates(def.name, def.templates);
-    }
+    // styling 一旦落地，Hibiki 侧客制化状态必须**立刻**对齐：settings 里
+    // lapisCustomCss / lapisAppliedCssSha 描述的就是 styling，晚一步对齐就有一段
+    // 「Anki 是恢复态、Hibiki 期望态还是旧的」窗口，下次启动的漂移判定读到过期
+    // 期望态。所以对齐排在卡模板写入之前——卡模板失败不该连累 styling 状态。
     final String? body = extractLapisUserSectionBody(def.css);
     await _repository.updateSettings((AnkiSettings s) => s.copyWith(
           lapisFontScalePercent: 100,
@@ -198,6 +203,15 @@ class LapisTemplateService {
           lapisAppliedCssSha: body != null ? lapisCssSha256(def.css) : null,
           clearLapisAppliedCssSha: body == null,
         ));
+    // 卡模板（settings 不持有其状态）单独写。返回 false = 后端拒写，必须上抛
+    // 让 UI 报「恢复失败」——吞掉它会把「只恢复了 styling」谎报成完整恢复。
+    if (def.templates.isNotEmpty) {
+      final bool templatesOk =
+          await _repository.updateNoteTypeTemplates(def.name, def.templates);
+      if (!templatesOk) {
+        throw StateError('Backend rejected card template update');
+      }
+    }
   }
 
   /// 备份 [def] → 推送 [css] → 记指纹。写模板的唯一通道（备份门在这里）。

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -445,6 +445,17 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       AnkiSettings settings, AnkiViewModel vm) async {
     final TextEditingController controller =
         TextEditingController(text: settings.lapisCustomCss);
+    try {
+      await _showLapisCustomCssDialog(controller, vm);
+    } finally {
+      // 保存路径抛错（写偏好失败）时也必须释放 controller，否则 Flutter 的
+      // leak tracking 会把它记成泄漏，且每次打开都多留一个 listener。
+      controller.dispose();
+    }
+  }
+
+  Future<void> _showLapisCustomCssDialog(
+      TextEditingController controller, AnkiViewModel vm) async {
     final String? result = await showDialog<String>(
       context: context,
       builder: (BuildContext context) => AlertDialog(
@@ -478,7 +489,6 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       ),
     );
     if (result != null) await vm.setLapisCustomCss(result);
-    controller.dispose();
   }
 
   Future<void> _applyLapisStyling(AnkiViewModel vm,
@@ -551,6 +561,18 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
   }
 
   Future<void> _restoreLapisBackup(AnkiViewModel vm) async {
+    // 在第一个 await 之前就占住 _lapisBusy：列备份是异步的，这段窗口里
+    // `_lapisBusy ? null : ...` 的门还是开的，第二次点击能进来并开出第二条
+    // 恢复流程，两条流程写同一个 note type。占位必须先于任何 await。
+    setState(() => _lapisBusy = true);
+    try {
+      await _runRestoreLapisBackup(vm);
+    } finally {
+      if (mounted) setState(() => _lapisBusy = false);
+    }
+  }
+
+  Future<void> _runRestoreLapisBackup(AnkiViewModel vm) async {
     final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final List<File> backups = await vm.lapisTemplateService.listBackups();
     if (!mounted) return;
@@ -591,17 +613,17 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       ),
     );
     if (ok != true || !mounted) return;
-    setState(() => _lapisBusy = true);
     try {
       await vm.lapisTemplateService.restoreBackup(chosen);
-      await vm.refreshSettingsFromStore();
       messenger
           .showSnackBar(SnackBar(content: Text(t.anki_lapis_restore_done)));
     } catch (e) {
       messenger.showSnackBar(
           SnackBar(content: Text(t.anki_lapis_restore_failed(error: '$e'))));
     } finally {
-      if (mounted) setState(() => _lapisBusy = false);
+      // 失败也要刷：restoreBackup 在卡模板失败前已经把 styling 与 settings 写
+      // 穿了，只刷成功路径会让页面继续显示恢复前的字号/自定义 CSS。
+      await vm.refreshSettingsFromStore();
     }
   }
 

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -613,18 +613,28 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       ),
     );
     if (ok != true || !mounted) return;
+    // 两步都可能失败，两步的失败都必须让用户看见：把「第一个失败」收进
+    // failure，最后统一出一条 snackbar。刷新**不能**放 finally——finally 里的
+    // await 抛出就成了没人接的异步异常（页面继续显示恢复前的值，用户只看到
+    // 什么都没发生），正是本 PR 要修的「谎报」同一类问题。
+    Object? failure;
     try {
       await vm.lapisTemplateService.restoreBackup(chosen);
-      messenger
-          .showSnackBar(SnackBar(content: Text(t.anki_lapis_restore_done)));
     } catch (e) {
-      messenger.showSnackBar(
-          SnackBar(content: Text(t.anki_lapis_restore_failed(error: '$e'))));
-    } finally {
-      // 失败也要刷：restoreBackup 在卡模板失败前已经把 styling 与 settings 写
-      // 穿了，只刷成功路径会让页面继续显示恢复前的字号/自定义 CSS。
-      await vm.refreshSettingsFromStore();
+      failure = e;
     }
+    // 成功失败都要刷：restoreBackup 在卡模板失败前已经把 styling 与 settings
+    // 写穿了，只刷成功路径会让页面继续显示恢复前的字号/自定义 CSS。
+    try {
+      await vm.refreshSettingsFromStore();
+    } catch (e) {
+      failure ??= e; // 恢复本身的错更接近根因，优先呈现它。
+    }
+    messenger.showSnackBar(SnackBar(
+      content: Text(failure == null
+          ? t.anki_lapis_restore_done
+          : t.anki_lapis_restore_failed(error: '$failure')),
+    ));
   }
 
   /// 备份文件名 `lapis-<ISO时间戳(冒号→'-')>.json` → 本地可读时间标签；

--- a/hibiki/test/anki/lapis_settings_page_guard_test.dart
+++ b/hibiki/test/anki/lapis_settings_page_guard_test.dart
@@ -22,6 +22,11 @@ String _stripLineComments(String source) => const LineSplitter()
     .join(' ');
 
 /// 从 [source] 里截取名为 [name] 的方法体（从签名行到与之配对的右花括号）。
+///
+/// **前置条件**：[source] 必须已经过 [_stripLineComments]——否则注释里的花括号
+/// 会把配平算错。剩余约束：方法体内的字符串字面量若含**不配对**的花括号
+/// （如 `'{'`），配平同样会错；当前被扫的两个方法没有这种字面量，真加了就得把
+/// 这里升级成带字符串状态机的扫描。
 String _methodBody(String source, String name) {
   final int start = source.indexOf('Future<void> $name(');
   expect(start, greaterThanOrEqualTo(0), reason: '找不到方法 $name');
@@ -45,12 +50,11 @@ void main() {
 
   setUpAll(() {
     expect(file.existsSync(), isTrue, reason: '路径变了就更新本守卫');
-    source = file.readAsStringSync();
+    source = _stripLineComments(file.readAsStringSync());
   });
 
   test('_restoreLapisBackup 在第一个 await 之前就置 _lapisBusy', () {
-    final String body =
-        _stripLineComments(_methodBody(source, '_restoreLapisBackup'));
+    final String body = _methodBody(source, '_restoreLapisBackup');
     final int busyAt = body.indexOf('_lapisBusy = true');
     final int awaitAt = body.indexOf('await ');
     expect(busyAt, greaterThanOrEqualTo(0), reason: '在途标记没了？');
@@ -61,9 +65,22 @@ void main() {
         reason: '置位后必须在 finally 里复位，异常路径不能把按钮永久卡死');
   });
 
+  test('_runRestoreLapisBackup 的刷新失败仍会呈现给用户（不落 finally）', () {
+    // 回归守卫：把 refreshSettingsFromStore 放进 finally 会让它跑到 catch 之外，
+    // 抛出即成为没人接的异步异常——页面继续显示恢复前的值，用户什么也看不到。
+    // 那正是本 PR 要修的「谎报」同一类问题，不能在修它的过程中引入。
+    final String body = _methodBody(source, '_runRestoreLapisBackup');
+    expect(body.contains('finally'), isFalse,
+        reason: 'finally 里的 await 抛出会绕过 catch，变成未捕获异步异常');
+    final int refreshAt = body.indexOf('refreshSettingsFromStore');
+    expect(refreshAt, greaterThanOrEqualTo(0), reason: '刷新调用没了？');
+    expect(body.indexOf('catch', refreshAt), greaterThan(refreshAt),
+        reason: '刷新必须被 catch 包住，失败要走 restore_failed 提示');
+    expect(body, contains('anki_lapis_restore_failed'));
+  });
+
   test('_editLapisCustomCss 在 finally 里 dispose controller', () {
-    final String body =
-        _stripLineComments(_methodBody(source, '_editLapisCustomCss'));
+    final String body = _methodBody(source, '_editLapisCustomCss');
     expect(body, contains('finally'));
     final int finallyAt = body.indexOf('finally');
     final int disposeAt = body.indexOf('controller.dispose()');

--- a/hibiki/test/anki/lapis_settings_page_guard_test.dart
+++ b/hibiki/test/anki/lapis_settings_page_guard_test.dart
@@ -1,0 +1,73 @@
+// PR#457 审查 §10-5 守卫（源码扫描层）：设置页 Lapis 区两个真缺陷不得回归。
+//
+// 1. `_restoreLapisBackup` 的在途标记 `_lapisBusy` 原本在 `listBackups()` 之后
+//    才置位 —— 那段异步窗口里 `_lapisBusy ? null : ...` 的门还开着，连点两下
+//    会开出两条恢复流程写同一个 note type。要求：置位必须先于本方法的第一个
+//    `await`。
+// 2. `_editLapisCustomCss` 原本在 `setLapisCustomCss` 之后才 dispose
+//    controller —— 保存抛错就漏掉 dispose。要求：dispose 在 `finally` 里。
+//
+// 这两条都是时序/生命周期，widget 测试要真跑整个 Anki 设置页（依赖 AppModel /
+// 平台通道），源码扫描是本仓能落地的最强层。
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 去掉整行 `//` 注释：本守卫按「先后顺序」判定，注释里出现 `await` /
+/// `dispose` 这些词会污染下标比较（守卫自己的说明文字就带这些词）。
+String _stripLineComments(String source) => const LineSplitter()
+    .convert(source)
+    .where((String line) => !line.trimLeft().startsWith('//'))
+    .join(' ');
+
+/// 从 [source] 里截取名为 [name] 的方法体（从签名行到与之配对的右花括号）。
+String _methodBody(String source, String name) {
+  final int start = source.indexOf('Future<void> $name(');
+  expect(start, greaterThanOrEqualTo(0), reason: '找不到方法 $name');
+  final int braceStart = source.indexOf('{', start);
+  int depth = 0;
+  for (int i = braceStart; i < source.length; i++) {
+    final String c = source[i];
+    if (c == '{') depth++;
+    if (c == '}') {
+      depth--;
+      if (depth == 0) return source.substring(braceStart, i + 1);
+    }
+  }
+  fail('方法 $name 的括号不配对');
+}
+
+void main() {
+  final File file =
+      File('lib/src/pages/implementations/anki_settings_page.dart');
+  late String source;
+
+  setUpAll(() {
+    expect(file.existsSync(), isTrue, reason: '路径变了就更新本守卫');
+    source = file.readAsStringSync();
+  });
+
+  test('_restoreLapisBackup 在第一个 await 之前就置 _lapisBusy', () {
+    final String body =
+        _stripLineComments(_methodBody(source, '_restoreLapisBackup'));
+    final int busyAt = body.indexOf('_lapisBusy = true');
+    final int awaitAt = body.indexOf('await ');
+    expect(busyAt, greaterThanOrEqualTo(0), reason: '在途标记没了？');
+    expect(awaitAt, greaterThanOrEqualTo(0));
+    expect(busyAt, lessThan(awaitAt),
+        reason: '_lapisBusy 必须先于任何 await 置位，否则连点两下能开两条恢复流程');
+    expect(body, contains('finally'),
+        reason: '置位后必须在 finally 里复位，异常路径不能把按钮永久卡死');
+  });
+
+  test('_editLapisCustomCss 在 finally 里 dispose controller', () {
+    final String body =
+        _stripLineComments(_methodBody(source, '_editLapisCustomCss'));
+    expect(body, contains('finally'));
+    final int finallyAt = body.indexOf('finally');
+    final int disposeAt = body.indexOf('controller.dispose()');
+    expect(disposeAt, greaterThan(finallyAt),
+        reason: 'dispose 必须在 finally 内，保存抛错时也要释放');
+  });
+}

--- a/hibiki/test/anki/lapis_template_service_restore_test.dart
+++ b/hibiki/test/anki/lapis_template_service_restore_test.dart
@@ -1,0 +1,175 @@
+// PR#457 审查 §10-4 守卫：从备份恢复时，卡模板写入失败被静默吞掉，UI 仍报
+// 「恢复成功」；且 Hibiki 侧客制化状态（settings）与已落地的 styling 之间存在
+// 顺序造成的过期窗口。这里锁死修复后的契约：
+//   styling 写成功 → 立刻对齐 settings → 再写卡模板 → 卡模板失败必须上抛。
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/anki/lapis_template_service.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+/// 只把备份目录换成临时目录，其余走真实实现（避开 AppPaths 的平台通道）。
+class _TempDirLapisService extends LapisTemplateService {
+  _TempDirLapisService(super.repository, this._dir);
+
+  final Directory _dir;
+
+  @override
+  Future<Directory> backupDirectory() async => _dir;
+}
+
+class _FakeRepo extends BaseAnkiRepository {
+  _FakeRepo({required this.definition, this.templatesOk = true});
+
+  final AnkiNoteTypeDefinition definition;
+  final bool templatesOk;
+
+  AnkiSettings settings = const AnkiSettings(
+    lapisFontScalePercent: 130,
+    lapisCustomCss: '.stale { color: red; }',
+    lapisAppliedCssSha: 'stale-sha',
+  );
+  String? pushedCss;
+  int templateWriteCalls = 0;
+
+  @override
+  bool get supportsNoteTypeEditing => true;
+
+  @override
+  Future<AnkiSettings> loadSettings() async => settings;
+
+  @override
+  Future<void> saveSettings(AnkiSettings s) async => settings = s;
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+          String modelName) async =>
+      definition;
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async {
+    pushedCss = css;
+    return true;
+  }
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+      String modelName, List<AnkiCardTemplate> templates) async {
+    templateWriteCalls++;
+    return templatesOk;
+  }
+
+  @override
+  Future<AnkiFetchResult> fetchConfiguration() async =>
+      const AnkiFetchResult.error('unused');
+
+  @override
+  Future<MineOutcome> mineEntry({
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) async =>
+      MineOutcome.failure('unused');
+
+  @override
+  Future<bool> isDuplicate(String expression, String reading) async => false;
+
+  @override
+  Future<bool> createNoteType(AnkiNoteTypeTemplate template) async => true;
+
+  @override
+  Future<bool> createDeck(String name) async => true;
+}
+
+AnkiNoteTypeDefinition _definition(String css) => AnkiNoteTypeDefinition(
+      name: LapisNoteType.modelName,
+      fields: LapisNoteType.fields,
+      templates: const <AnkiCardTemplate>[
+        AnkiCardTemplate(
+            name: 'Card 1', front: '{{Expression}}', back: '{{Meaning}}'),
+      ],
+      css: css,
+    );
+
+Future<File> _writeBackup(Directory dir, AnkiNoteTypeDefinition def) async {
+  final File file =
+      File('${dir.path}${Platform.pathSeparator}lapis-backup.json');
+  await file.writeAsString(jsonEncode(<String, dynamic>{
+    'version': 1,
+    'exportedAt': DateTime.now().toUtc().toIso8601String(),
+    'noteType': def.toJson(),
+  }));
+  return file;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory dir;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('lapis_restore_test');
+  });
+
+  tearDown(() async {
+    if (await dir.exists()) await dir.delete(recursive: true);
+  });
+
+  test('恢复成功：styling 写穿 + settings 与备份对齐', () async {
+    final String backupCss = composeLapisCss(
+        fontScalePercent: 100, customCss: '.mine { color: #0f0; }');
+    final AnkiNoteTypeDefinition def = _definition(backupCss);
+    final _FakeRepo repo = _FakeRepo(definition: def);
+    final File file = await _writeBackup(dir, def);
+
+    await _TempDirLapisService(repo, dir).restoreBackup(file);
+
+    expect(repo.pushedCss, backupCss);
+    expect(repo.templateWriteCalls, 1);
+    expect(repo.settings.lapisFontScalePercent, 100);
+    expect(repo.settings.lapisCustomCss, contains('.mine { color: #0f0; }'));
+    expect(repo.settings.lapisAppliedCssSha, lapisCssSha256(backupCss));
+    // 对齐后期望态 == Anki 态：下次启动的漂移判定必须是 upToDate，
+    // 不能把刚恢复的内容再覆写回去。
+    expect(
+      decideLapisStylingAction(
+        ankiCss: repo.pushedCss!,
+        expectedCss: composeLapisCss(
+          fontScalePercent: repo.settings.lapisFontScalePercent,
+          customCss: repo.settings.lapisCustomCss,
+        ),
+        lastAppliedSha: repo.settings.lapisAppliedCssSha,
+      ),
+      LapisStylingDecision.upToDate,
+    );
+  });
+
+  test('卡模板写入被后端拒绝：上抛而不是谎报成功', () async {
+    final String backupCss =
+        composeLapisCss(fontScalePercent: 100, customCss: '.mine { }');
+    final AnkiNoteTypeDefinition def = _definition(backupCss);
+    final _FakeRepo repo = _FakeRepo(definition: def, templatesOk: false);
+    final File file = await _writeBackup(dir, def);
+
+    await expectLater(
+      _TempDirLapisService(repo, dir).restoreBackup(file),
+      throwsA(isA<StateError>()),
+    );
+    expect(repo.templateWriteCalls, 1);
+    // styling 已落地 → settings 必须已经对齐（不留过期期望态半态）。
+    expect(repo.settings.lapisAppliedCssSha, lapisCssSha256(backupCss));
+    expect(repo.settings.lapisFontScalePercent, 100);
+  });
+
+  test('备份无用户区段：清空客制化并清掉指纹', () async {
+    final AnkiNoteTypeDefinition def = _definition(LapisNoteType.template.css);
+    final _FakeRepo repo = _FakeRepo(definition: def);
+    final File file = await _writeBackup(dir, def);
+
+    await _TempDirLapisService(repo, dir).restoreBackup(file);
+
+    expect(repo.settings.lapisCustomCss, isEmpty);
+    expect(repo.settings.lapisFontScalePercent, 100);
+    expect(repo.settings.lapisAppliedCssSha, isNull);
+  });
+}

--- a/packages/hibiki_anki/lib/src/lapis_styling.dart
+++ b/packages/hibiki_anki/lib/src/lapis_styling.dart
@@ -29,15 +29,21 @@ const String lapisUserCssEndMarker = '/* HIBIKI-LAPIS-USER END */';
 ///
 /// 上游 Lapis 的字号变量命名**不统一**：多数叫 `--pc-*-font-size` /
 /// `--mobile-*-font-size`，但释义字号叫 `--pc-main-def-size` /
-/// `--mobile-main-def-size`（没有 `font-` 中缀）。所以判据是「以 `-size` 结尾」，
-/// `font-` 只是可选中缀——只认 `font-size` 会静默漏掉释义字号，界面缩放对释义
-/// 不生效，与「Scales every Lapis font size」的文案不符（本函数原始缺陷）。
+/// `--mobile-main-def-size`（没有 `font-` 中缀）。所以判据只是「以 `-size`
+/// 结尾」（`[a-z-]*` already 吃掉 `font-`，不需要额外分组）——只认 `font-size`
+/// 会静默漏掉释义字号，界面缩放对释义不生效，与「Scales every Lapis font size」
+/// 的文案不符（本函数原始缺陷）。
 /// 守卫见 `lapis_styling_test.dart`：断言 vendored CSS 里**每一个** px 取值的
 /// `--pc-*` / `--mobile-*` 变量都被本函数覆盖，vendored 升级新增变量即打红。
+///
+/// **上游同步须留意的前瞻风险**：本函数 + 守卫一起把「`pc-`/`mobile-` 前缀 +
+/// px 取值 == 字号」制度化了。上游若新增 `--pc-main-picture-size: 240px` 这类
+/// **非字号**变量，正则会误伤把它一起缩放，守卫还会反过来强制要求它被纳入。
+/// 同步 vendored Lapis 时必须人工过一遍新增的 `--pc-*` / `--mobile-*` px 变量：
+/// 真是字号就放行，不是字号就得给本函数加排除表，别顺手把守卫改绿。
 String buildLapisFontScaleCss(int percent) {
   if (percent == 100) return '';
-  final RegExp pattern =
-      RegExp(r'--((?:pc|mobile)-[a-z-]*(?:font-)?size):\s*(\d+)px');
+  final RegExp pattern = RegExp(r'--((?:pc|mobile)-[a-z-]*size):\s*(\d+)px');
   final List<String> lines = <String>[];
   final Set<String> seen = <String>{};
   for (final RegExpMatch m in pattern.allMatches(LapisNoteType.css)) {

--- a/packages/hibiki_anki/lib/src/lapis_styling.dart
+++ b/packages/hibiki_anki/lib/src/lapis_styling.dart
@@ -22,14 +22,22 @@ const String lapisUserCssBeginMarker = '/* HIBIKI-LAPIS-USER BEGIN */';
 /// 用户客制化区段结束标记。
 const String lapisUserCssEndMarker = '/* HIBIKI-LAPIS-USER END */';
 
-/// 从 vendored Lapis CSS 里提取全部字号变量（`--pc-*-font-size` /
-/// `--mobile-*-font-size`）并按 [percent]（百分比，100 = 原样）缩放，产出一个
-/// `:root` 覆写块。基准值直接解析自 [LapisNoteType.css]（单一真相源），vendored
-/// 版本升级后无需改这里。[percent] == 100 或未解析到任何变量时返回空串。
+/// 从 vendored Lapis CSS 里提取全部字号变量并按 [percent]（百分比，100 = 原样）
+/// 缩放，产出一个 `:root` 覆写块。基准值直接解析自 [LapisNoteType.css]（单一
+/// 真相源），vendored 版本升级后无需改这里。[percent] == 100 或未解析到任何变量
+/// 时返回空串。
+///
+/// 上游 Lapis 的字号变量命名**不统一**：多数叫 `--pc-*-font-size` /
+/// `--mobile-*-font-size`，但释义字号叫 `--pc-main-def-size` /
+/// `--mobile-main-def-size`（没有 `font-` 中缀）。所以判据是「以 `-size` 结尾」，
+/// `font-` 只是可选中缀——只认 `font-size` 会静默漏掉释义字号，界面缩放对释义
+/// 不生效，与「Scales every Lapis font size」的文案不符（本函数原始缺陷）。
+/// 守卫见 `lapis_styling_test.dart`：断言 vendored CSS 里**每一个** px 取值的
+/// `--pc-*` / `--mobile-*` 变量都被本函数覆盖，vendored 升级新增变量即打红。
 String buildLapisFontScaleCss(int percent) {
   if (percent == 100) return '';
   final RegExp pattern =
-      RegExp(r'--((?:pc|mobile)-[a-z-]*font-size):\s*(\d+)px');
+      RegExp(r'--((?:pc|mobile)-[a-z-]*(?:font-)?size):\s*(\d+)px');
   final List<String> lines = <String>[];
   final Set<String> seen = <String>{};
   for (final RegExpMatch m in pattern.allMatches(LapisNoteType.css)) {

--- a/packages/hibiki_anki/test/lapis_styling_test.dart
+++ b/packages/hibiki_anki/test/lapis_styling_test.dart
@@ -80,6 +80,9 @@ void main() {
         for (final String name in baselines.keys)
           if (!css.contains('--$name:')) name,
       ];
+      // 前瞻风险留痕：本断言把「pc-/mobile- 前缀 + px 取值 == 字号」制度化了。
+      // 上游若新增非字号的 px 变量（如 --pc-main-picture-size），正确做法是给
+      // buildLapisFontScaleCss 加排除表并在这里显式豁免，**不是**把守卫改绿。
       expect(missing, isEmpty, reason: '这些 Lapis 字号变量没被缩放覆盖: $missing');
       // 释义字号显式断言基准与缩放结果（pc 20px、mobile 16px @125%）。
       expect(baselines['pc-main-def-size'], 20);

--- a/packages/hibiki_anki/test/lapis_styling_test.dart
+++ b/packages/hibiki_anki/test/lapis_styling_test.dart
@@ -62,6 +62,32 @@ void main() {
       expect(css, contains('--mobile-sentence-font-size:'));
     });
 
+    test('覆盖 vendored CSS 里每一个 px 取值的 pc/mobile 变量（漏一个即红）', () {
+      // 守卫 PR#457 审查 §10-1 的原始缺陷：正则只认 `font-size`，把上游命名
+      // 例外 `--pc-main-def-size` / `--mobile-main-def-size` 漏在缩放之外，
+      // 释义字号不跟随「界面缩放」。判据不写死变量清单，而是直接从
+      // LapisNoteType.css 反推：**所有** px 取值的 --pc-* / --mobile-* 变量
+      // 都必须出现在缩放块里，vendored 升级新增变量同样会打红。
+      final RegExp declared =
+          RegExp(r'--((?:pc|mobile)-[a-z0-9-]+):\s*(\d+)px');
+      final Map<String, int> baselines = <String, int>{
+        for (final RegExpMatch m in declared.allMatches(LapisNoteType.css))
+          m.group(1)!: int.parse(m.group(2)!),
+      };
+      expect(baselines, isNotEmpty);
+      final String css = buildLapisFontScaleCss(125);
+      final List<String> missing = <String>[
+        for (final String name in baselines.keys)
+          if (!css.contains('--$name:')) name,
+      ];
+      expect(missing, isEmpty, reason: '这些 Lapis 字号变量没被缩放覆盖: $missing');
+      // 释义字号显式断言基准与缩放结果（pc 20px、mobile 16px @125%）。
+      expect(baselines['pc-main-def-size'], 20);
+      expect(baselines['mobile-main-def-size'], 16);
+      expect(css, contains('--pc-main-def-size: 25px;'));
+      expect(css, contains('--mobile-main-def-size: 20px;'));
+    });
+
     test('缩放值有下限保护（不会缩成 0px）', () {
       // 1% 时最小的 16px 变量 → 0.16 → round 0 → clamp 1。
       expect(buildLapisFontScaleCss(1), contains(': 1px;'));


### PR DESCRIPTION
收 PR#457（已合入 develop）审查报告 §10 记录的 5 条非阻塞遗留。先按「是否有产品取舍空间」分类，**只修 A 类**；B 类只出结论，不在本 PR 拍板。

## 分类

| # | §10 原文 | 类别 | 本 PR |
|---|---|---|---|
| 1 | `buildLapisFontScaleCss` 正则漏 `--pc-main-def-size` / `--mobile-main-def-size` | A·纯缺陷 | ✅ 修 |
| 2 | restore 后强制 `lapisFontScalePercent: 100` + 旧缩放块塞进 `lapisCustomCss` → 字号选择器失灵 | B·产品取舍 | ❌ 不动 |
| 3 | 无 Apply 也会推送（下次启动自动迁移静默写 Anki） | B·产品取舍 | ❌ 不动 |
| 4 | restore 中 templates 写失败留半态 | A（可判定部分） | ✅ 修 |
| 5a | 备份文件永不清理 | B·产品取舍 | ❌ 不动 |
| 5b | `_restoreLapisBackup` 双击窗口 | A·纯缺陷 | ✅ 修 |
| 5c | `_editLapisCustomCss` 抛错时 controller 未 dispose | A·纯缺陷 | ✅ 修 |

## A 类根因

1. **字号缩放漏释义字号** — 正则 `--((?:pc|mobile)-[a-z-]*font-size)` 只认 `font-size` 后缀，而上游 Lapis 的释义字号命名是例外 `--pc-main-def-size` / `--mobile-main-def-size`（无 `font-` 中缀）。16 个 px 字号变量漏了 2 个。判据改为「以 `-size` 结尾、`font-` 可选中缀」。
2. **restore 吞掉卡模板写入失败** — `updateNoteTypeTemplates` 的 `bool` 返回值被丢弃（同方法里 `updateNoteTypeStyling` 是检查并 `throw` 的），后端拒写时 UI 仍报「恢复成功」；且 settings 对齐排在写卡模板之后，卡模板一失败就跳过对齐。改为 **styling → 立刻对齐 settings → 卡模板**，卡模板返回 `false` 直接上抛；UI 侧 `refreshSettingsFromStore` 从成功路径挪进 `finally`。
3. **restore 双击重入** — `_lapisBusy` 在 `await listBackups()` 之后才置位，那段窗口里点击门还开着，连点两下能开两条恢复流程写同一个 note type。拆薄壳，置位先于任何 `await`。
4. **controller 泄漏** — `dispose()` 排在 `await vm.setLapisCustomCss()` 之后，保存抛错就漏掉。拆出对话框方法，`dispose` 进 `finally`。

## 测试

- `packages/hibiki_anki/test/lapis_styling_test.dart`：新增覆盖守卫——不写死变量清单，从 `LapisNoteType.css` 反推**所有** px 取值的 `--pc-*` / `--mobile-*` 变量，漏一个即红（vendored 升级新增变量同样打红）。
- `hibiki/test/anki/lapis_template_service_restore_test.dart`（新，3 例）：恢复成功后 `decideLapisStylingAction == upToDate`（不会覆写刚恢复的内容）／卡模板拒写必须上抛且 settings 已对齐／无用户区段清空客制化 + 清指纹。
- `hibiki/test/anki/lapis_settings_page_guard_test.dart`（新，源码扫描层）：`_lapisBusy` 置位先于第一个 `await`；`dispose` 在 `finally` 内。

三条守卫均做过**负向验证**（改回旧代码 → 真红），不是只跑绿。

## 验证

- `flutter analyze`（`hibiki/`，含 test）→ **No issues found**。
- `flutter test --no-pub`（`packages/hibiki_anki/`）→ **+221 全绿**。
- `flutter test --no-pub`（`hibiki/` 全量）→ 见下方评论。

## ⚠️ 与本 PR 无关的 develop 现状

`hibiki/test/media/audiobook/floating_lyric_click_through_guard_test.dart` 的
`interactivity is not driven by a hover timer` 在 develop 上**已经红**：

- 该守卫（TODO-038）禁止 `floating_lyric_window.cpp` 里出现 `SetTimer(` / `KillTimer(`；
- PR#460（`9640948dc` / 合并点 `1b64393d9`）为 BUG-951 重新引入了 `WS_EX_TRANSPARENT` + `SetTimer`；
- 最后一次绿的 `Build Release APK` 是 `02e264e96`，**早于** PR#460 合入。硬证据：`02e264e96` 的该 cpp 里 `SetTimer(` 计数 = 0，`origin/develop` = 1。

本 PR 的 6 个改动文件与该测试、该 cpp 无任何交集。两条守卫的契约互相矛盾，需要 BUG-951 的负责人裁决（是旧守卫过时该改，还是 PR#460 的方案要换）。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
