### PR TITLE
fix(gal): 启动失败必须带结构化原因，消灭无信息兜底文案（BUG-1142）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,10 +33,10 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1142](bugs/BUG-1142-gal-launch-failure-unclassified.md) | ✅ | ✅ | gal 启动失败只报无信息兜底文案，失败原因在 launchGame 的 bool 返回值处被丢弃 |
 | [BUG-1141](bugs/BUG-1141-download-discovery-timeout-too-short.md) | ✅ | ✅ | 代理下「发现」搜索 20s 超时太短，请求本可成功却被掐断 |
 | [BUG-1140](bugs/BUG-1140-cross-chapter-turn-latency.md) | ✅ | ✅ | 跨章翻页耗时实测与提速（遮罩口径） |
 | [BUG-1139](bugs/BUG-1139-overlay-ctrl-wheel-zoom.md) | ✅ | ✅ | app 外查词浮窗 Ctrl+滚轮触发 WebView2 原生页面缩放，窗口/region 几何按 zoom=1 计算导致卡片被切、露出底下应用 |
-| [BUG-1138](bugs/BUG-1138-gal-launch-failure-unclassified.md) | ✅ | ✅ | gal 启动失败只报无信息兜底文案，失败原因在 launchGame 的 bool 返回值处被丢弃 |
 | [BUG-1138](bugs/BUG-1138-gal-clipboard-overlay-ruby-markup.md) | ✅ | ✅ | gal 台词浮窗/剪切板文字窗把注音标记当正文显示，污染查词与字数 |
 | [BUG-1137](bugs/BUG-1137-gal-mining-video-tag.md) | ✅ | ✅ | gal 制卡分类标签误标 video：来源枚举缺 game 且默认值静默兜底 |
 | [BUG-1136](bugs/BUG-1136-ios-reader-scroll-lookup.md) | ✅ | ✅ | iPhone 阅读滑动被误判为点词查词 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,13 +29,14 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1107 条。点号进各自文件。
+> 共 1109 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1141](bugs/BUG-1141-download-discovery-timeout-too-short.md) | ✅ | ✅ | 代理下「发现」搜索 20s 超时太短，请求本可成功却被掐断 |
 | [BUG-1140](bugs/BUG-1140-cross-chapter-turn-latency.md) | ✅ | ✅ | 跨章翻页耗时实测与提速（遮罩口径） |
 | [BUG-1139](bugs/BUG-1139-overlay-ctrl-wheel-zoom.md) | ✅ | ✅ | app 外查词浮窗 Ctrl+滚轮触发 WebView2 原生页面缩放，窗口/region 几何按 zoom=1 计算导致卡片被切、露出底下应用 |
+| [BUG-1138](bugs/BUG-1138-gal-launch-failure-unclassified.md) | ✅ | ✅ | gal 启动失败只报无信息兜底文案，失败原因在 launchGame 的 bool 返回值处被丢弃 |
 | [BUG-1138](bugs/BUG-1138-gal-clipboard-overlay-ruby-markup.md) | ✅ | ✅ | gal 台词浮窗/剪切板文字窗把注音标记当正文显示，污染查词与字数 |
 | [BUG-1137](bugs/BUG-1137-gal-mining-video-tag.md) | ✅ | ✅ | gal 制卡分类标签误标 video：来源枚举缺 game 且默认值静默兜底 |
 | [BUG-1136](bugs/BUG-1136-ios-reader-scroll-lookup.md) | ✅ | ✅ | iPhone 阅读滑动被误判为点词查词 |

--- a/docs/bugs/BUG-1138-gal-launch-failure-unclassified.md
+++ b/docs/bugs/BUG-1138-gal-launch-failure-unclassified.md
@@ -1,0 +1,47 @@
+## BUG-1138 · gal 启动失败只报无信息兜底文案，失败原因在 launchGame 的 bool 返回值处被丢弃
+
+- **报告**：2026-07-27（用户）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/mining/gal_hook_session_controller.dart:891`（`Future<bool> launchGame`）与 `hibiki/lib/src/mining/gal_hook_failure_text.dart:62`（`reason ?? lastError ?? t.game_capture_launch_failed`）。
+
+### 现象
+
+用户启动 galgame 失败，toast 只有一句「游戏启动或捕获失败」，没有任何可执行处置。用户无法自愈，排障时也判断不出会话停在哪一步。
+
+### 根因
+
+`launchGame` 返回 `bool`，把五种语义完全不同的结局压成一个比特：
+
+| 出口 | 真实语义 | 旧实现携带的原因 |
+|---|---|---|
+| `!_isWindows` | 平台不支持 | 无 |
+| `injector == null` | 缺 helper | `state.injectorFailure`（有） |
+| `generation != _operationGeneration`（4 处） | **被更新的操作取代，本次已作废** | 无，且**完全不碰 state** |
+| `_fail(engine.launch_or_inject_failed)` | 注入失败 | `state.injectorFailure`，归类不出时为 `unknown` |
+
+抢占那四条出口既不设 `injectorFailure` 也不设 `lastError`，而 `launchGame` 开头刚 `clearLastError: true`。于是 UI 侧 `galHookLaunchOutcomeMessage` 拿到 `failure == none` + `lastError == null`，三级兜底 `reason ?? lastError ?? 兜底文案` 必然落到最后一级——**那句话不含任何信息**。
+
+原因是在 `return false` 那一刻丢掉的，下游只拿得到一个比特，任何文案层补丁都救不回来。
+
+次生问题两条：
+
+1. 被抢占的那次操作会**抢先弹一句「启动失败」**，把真正生效的那次操作的结果盖掉——用户看到的失败其实来自一次已作废的操作。
+2. `diagnostics.stderrTail`（injector 的 native 一手证据）明明有内容，却停在 controller 内部，从不进入 UI。
+
+### 修复
+
+修在返回类型上，让编译期强制每条出口说明原因：
+
+- 新增 `GalHookLaunchFailureReason`（`unsupportedPlatform` / `helperMissing` / `injectionFailed` / `superseded`）与 `GalHookLaunchResult`；`failed()` 构造断言原因不得为 `none`——「没有原因的失败」在构造处就被挡掉。
+- `launchGame` 返回 `GalHookLaunchResult`，八条 return 全部携带原因与 native 诊断。
+- 新增 `GalHookLaunchOutcome.superseded`，`galHookLaunchOutcomeMessage` 对它返回 `null` = **不播报**（取代它的那次操作会播报自己的结果）。
+- 归类不出来时把 native 诊断（`exit=<码>` + stderr 最后一行结论）附进文案，信息不再被丢弃。
+- 零新增 i18n key。
+
+- **[x] ① 已修复** — `hibiki/lib/src/mining/gal_hook_session_controller.dart`（新增 `GalHookLaunchFailureReason` / `GalHookLaunchResult`、`launchGame` 改返回结构化结果、`classifyGalHookLaunchOutcome` 改吃结果）、`hibiki/lib/src/mining/gal_hook_failure_text.dart`（`galHookLaunchOutcomeMessage` 返回可空 + `galHookDiagnosticsDetail`）、三个调用点 `galgame_home_page.dart` / `games_library_page.dart` / `texthooker_page.dart`。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_hook_launch_outcome_and_encoding_test.dart` 新增 group「启动失败必须带原因 (BUG-1138)」7 例：失败不允许留空原因（构造断言）、被取代 → `superseded` 且不播报、每个原因都有确定分级、**归类不出来时 native 诊断必须进入文案**、诊断摘要取 stderr 结论行而非中途进度、无诊断时不编造原因、源码守卫禁止 `launchGame` 退回 `bool`。另在 `gal_hook_session_controller_test.dart` 的提权失败用例上补断言 `reason == injectionFailed` 且诊断保留 `elevationRequired`。
+
+### 备注
+
+本 bug 由「用户报启动失败但现场无法定位」引出：当时 injector 侧全链路实测健康（`OK hooked`、共享内存五个版本字段与 app 常量逐字节一致、`sample_rate=44100 hooked=1` 音频在写、关上一局立刻开下一局也通），失败只可能在 app 编排层，而 app 恰好只给出这句无信息兜底文案，导致无从追查。修复后同一现场会直接给出结构化原因或 native 诊断。
+
+未随本 bug 修复的相邻问题（另行立项）：`voice_hook_reader.cpp:204` 的 `ProtocolMatches` 把 magic/version/ipc/luna_bridge/luna_vendored 五个字段全等作为唯一判据，任一不符即整块拒绝，而 UI 提示是「捕获通道无法打开，请重启 Hibiki」——版本不匹配时重启无效，且不区分「映射不存在」与「版本不符」、不打印双方版本号。

--- a/docs/bugs/BUG-1142-gal-launch-failure-unclassified.md
+++ b/docs/bugs/BUG-1142-gal-launch-failure-unclassified.md
@@ -1,4 +1,4 @@
-## BUG-1138 · gal 启动失败只报无信息兜底文案，失败原因在 launchGame 的 bool 返回值处被丢弃
+## BUG-1142 · gal 启动失败只报无信息兜底文案，失败原因在 launchGame 的 bool 返回值处被丢弃
 
 - **报告**：2026-07-27（用户）
 - **真实性**：✅ 真 bug。根因 `hibiki/lib/src/mining/gal_hook_session_controller.dart:891`（`Future<bool> launchGame`）与 `hibiki/lib/src/mining/gal_hook_failure_text.dart:62`（`reason ?? lastError ?? t.game_capture_launch_failed`）。
@@ -38,7 +38,7 @@
 - 零新增 i18n key。
 
 - **[x] ① 已修复** — `hibiki/lib/src/mining/gal_hook_session_controller.dart`（新增 `GalHookLaunchFailureReason` / `GalHookLaunchResult`、`launchGame` 改返回结构化结果、`classifyGalHookLaunchOutcome` 改吃结果）、`hibiki/lib/src/mining/gal_hook_failure_text.dart`（`galHookLaunchOutcomeMessage` 返回可空 + `galHookDiagnosticsDetail`）、三个调用点 `galgame_home_page.dart` / `games_library_page.dart` / `texthooker_page.dart`。
-- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_hook_launch_outcome_and_encoding_test.dart` 新增 group「启动失败必须带原因 (BUG-1138)」7 例：失败不允许留空原因（构造断言）、被取代 → `superseded` 且不播报、每个原因都有确定分级、**归类不出来时 native 诊断必须进入文案**、诊断摘要取 stderr 结论行而非中途进度、无诊断时不编造原因、源码守卫禁止 `launchGame` 退回 `bool`。另在 `gal_hook_session_controller_test.dart` 的提权失败用例上补断言 `reason == injectionFailed` 且诊断保留 `elevationRequired`。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_hook_launch_outcome_and_encoding_test.dart` 新增 group「启动失败必须带原因 (BUG-1142)」7 例：失败不允许留空原因（构造断言）、被取代 → `superseded` 且不播报、每个原因都有确定分级、**归类不出来时 native 诊断必须进入文案**、诊断摘要取 stderr 结论行而非中途进度、无诊断时不编造原因、源码守卫禁止 `launchGame` 退回 `bool`。另在 `gal_hook_session_controller_test.dart` 的提权失败用例上补断言 `reason == injectionFailed` 且诊断保留 `elevationRequired`。
 
 ### 备注
 

--- a/hibiki/lib/src/mining/gal_hook_failure_text.dart
+++ b/hibiki/lib/src/mining/gal_hook_failure_text.dart
@@ -43,7 +43,7 @@ String? galHookFailureLabel(GalHookInjectorFailure failure) =>
         t.game_hook_reason_handshake_timeout,
     };
 
-/// 一次「启动游戏」结束后要 toast 给用户的话（BUG-1089 / BUG-1138）。
+/// 一次「启动游戏」结束后要 toast 给用户的话（BUG-1089 / BUG-1142）。
 ///
 /// 唯一的启动结果播报口：游戏库页和 texthooker 页都走这里，不再各写一套、也不再出现
 /// 「游戏库页一个字都不提示」。**成功也说**，因为「点了按钮什么都没发生」本身就是
@@ -73,7 +73,7 @@ String? galHookLaunchOutcomeMessage({
   };
 }
 
-/// 「启动彻底失败」要说的话（BUG-1138）。
+/// 「启动彻底失败」要说的话（BUG-1142）。
 ///
 /// 分三级取信息，**每一级都来自真实事实，绝不编造**：
 /// 1. [GalHookLaunchResult.reason]——它是编译期强制填写的，不会缺；

--- a/hibiki/lib/src/mining/gal_hook_failure_text.dart
+++ b/hibiki/lib/src/mining/gal_hook_failure_text.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
 import 'package:hibiki/src/mining/galgame_audio_source.dart';
@@ -42,24 +43,28 @@ String? galHookFailureLabel(GalHookInjectorFailure failure) =>
         t.game_hook_reason_handshake_timeout,
     };
 
-/// 一次「启动游戏」结束后要 toast 给用户的话（BUG-1089）。
+/// 一次「启动游戏」结束后要 toast 给用户的话（BUG-1089 / BUG-1138）。
 ///
 /// 唯一的启动结果播报口：游戏库页和 texthooker 页都走这里，不再各写一套、也不再出现
-/// 「游戏库页一个字都不提示」。四种 [GalHookLaunchOutcome] 都有话说——**成功也说**，
-/// 因为「点了按钮什么都没发生」本身就是这个 bug 的用户表征。
+/// 「游戏库页一个字都不提示」。**成功也说**，因为「点了按钮什么都没发生」本身就是
+/// BUG-1089 的用户表征。
+///
+/// 返回 `null` 表示**本次结果不该播报**（[GalHookLaunchOutcome.superseded]）：这次操作
+/// 已被更新的操作取代，取代它的那次会播报自己的结果。旧实现让作废的那次也弹一句
+/// 「游戏启动或捕获失败」，反而把真实结局盖掉。
 ///
 /// [failure] 非 [GalHookInjectorFailure.none] 时把可执行处置作为后缀带上：知道「窗口
 /// 没出现」不够，还得知道是缺组件、要管理员，还是握手超时。
-String galHookLaunchOutcomeMessage({
+String? galHookLaunchOutcomeMessage({
   required GalHookLaunchOutcome outcome,
+  required GalHookLaunchResult result,
   required GalHookInjectorFailure failure,
   String? lastError,
 }) {
   final String? reason = galHookFailureLabel(failure);
   return switch (outcome) {
-    // 彻底失败：处置优先，内部英文消息只作最后兜底，绝不编造原因。
-    GalHookLaunchOutcome.failed =>
-      reason ?? lastError ?? t.game_capture_launch_failed,
+    GalHookLaunchOutcome.superseded => null,
+    GalHookLaunchOutcome.failed => _failedMessage(result, reason, lastError),
     GalHookLaunchOutcome.windowMissing =>
       _withReason(t.game_capture_window_missing, reason),
     GalHookLaunchOutcome.degradedLoopback =>
@@ -68,8 +73,67 @@ String galHookLaunchOutcomeMessage({
   };
 }
 
+/// 「启动彻底失败」要说的话（BUG-1138）。
+///
+/// 分三级取信息，**每一级都来自真实事实，绝不编造**：
+/// 1. [GalHookLaunchResult.reason]——它是编译期强制填写的，不会缺；
+/// 2. injector 的结构化处置（缺组件 / 要管理员 / 位数不符…）；
+/// 3. 都归类不出来时，附上 native 一手诊断（退出码 + stderr 尾行）。
+///
+/// 第 3 级正是本 bug 的修复点：旧实现在这里只剩一句「游戏启动或捕获失败」，而
+/// `diagnostics.stderrTail` 明明有内容，却停在 controller 内部从不进入 UI——用户既
+/// 无法自愈，报障时也提供不出任何可用线索。
+String _failedMessage(
+  GalHookLaunchResult result,
+  String? injectorReason,
+  String? lastError,
+) {
+  final String? reasonLabel = switch (result.reason) {
+    GalHookLaunchFailureReason.unsupportedPlatform => t.game_launch_unsupported,
+    GalHookLaunchFailureReason.helperMissing =>
+      t.game_hook_reason_helper_missing,
+    // injectionFailed 的可执行处置在 injector 诊断里，由 [injectorReason] 提供。
+    GalHookLaunchFailureReason.injectionFailed => injectorReason,
+    // 这两个不会走到 failed 分支（superseded 已早退，none 不是失败），列出只为穷举。
+    GalHookLaunchFailureReason.superseded => null,
+    GalHookLaunchFailureReason.none => null,
+  };
+  if (reasonLabel != null) return reasonLabel;
+  final String base = lastError ?? t.game_capture_launch_failed;
+  final String detail = galHookDiagnosticsDetail(result.diagnostics);
+  return detail.isEmpty ? base : '$base（$detail）';
+}
+
+/// native 诊断压成一行可展示的证据：`exit=<码> <stderr 最后一行非空内容>`。
+///
+/// 取**最后一行**：injector 失败即退，最后写出的那行就是它停下的地方；早期的
+/// `[luna] ... 已注入` 之类是进度而非结论。长诊断从尾部截断（保留结论侧）。
+@visibleForTesting
+String galHookDiagnosticsDetail(GalHookInjectorDiagnostics diagnostics) {
+  const int maxLength = 160;
+  final List<String> parts = <String>[];
+  if (diagnostics.exitCode != null) {
+    parts.add('exit=${diagnostics.exitCode}');
+  }
+  final List<String> lines = diagnostics.stderrTail
+      .split(RegExp(r'[\r\n]+'))
+      .map((String line) => line.trim())
+      .where((String line) => line.isNotEmpty)
+      .toList();
+  if (lines.isNotEmpty) {
+    final String last = lines.last;
+    parts.add(
+      last.length <= maxLength
+          ? last
+          : '…${last.substring(last.length - maxLength)}',
+    );
+  }
+  return parts.join(' ');
+}
+
 String _withReason(String message, String? reason) =>
     reason == null ? message : '$message（$reason）';
+
 /// 会话降级原因（`GalHookSessionState.fallbackReason` 的内部代码）→ 人话文案。
 ///
 /// BUG-1100：`_activateTextWithLoopback` 这条路径显式把 `injectorFailure` 置成

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -160,7 +160,7 @@ GalTrackEmptyHint galTrackEmptyHintFor(GalHookAudioBackend backend) =>
       _ => GalTrackEmptyHint.generic,
     };
 
-/// 一次启动失败的**结构化原因**（BUG-1138）。
+/// 一次启动失败的**结构化原因**（BUG-1142）。
 ///
 /// 存在的理由：[GalHookSessionController.launchGame] 曾经返回 `bool`，而它有五条
 /// `return false` 出口，其中四条**根本不设置任何原因**——会话被抢占那几条连
@@ -191,7 +191,7 @@ enum GalHookLaunchFailureReason {
   superseded,
 }
 
-/// [GalHookSessionController.launchGame] 的结构化结果（BUG-1138）。
+/// [GalHookSessionController.launchGame] 的结构化结果（BUG-1142）。
 ///
 /// 取代原来的 `bool`：成功只有一种，失败必须说明是哪一种，并把 native 诊断一起带走。
 @immutable

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -160,6 +160,67 @@ GalTrackEmptyHint galTrackEmptyHintFor(GalHookAudioBackend backend) =>
       _ => GalTrackEmptyHint.generic,
     };
 
+/// 一次启动失败的**结构化原因**（BUG-1138）。
+///
+/// 存在的理由：[GalHookSessionController.launchGame] 曾经返回 `bool`，而它有五条
+/// `return false` 出口，其中四条**根本不设置任何原因**——会话被抢占那几条连
+/// [GalHookSessionState] 都不碰。于是 UI 只能事后去 state 里翻，翻到的是
+/// `injectorFailure == none` + `lastError == null`，最终甩给用户一句「游戏启动或捕获
+/// 失败」：一个字的可执行信息都没有，用户无法自愈，排障时也判断不出到底停在哪一步。
+///
+/// 原因是在 `return false` 那一刻被丢掉的，任何下游补丁都救不回来（下游只能拿到一个
+/// 比特）。所以修在返回类型上：**每条失败出口必须携带一个原因，由编译期强制**。
+enum GalHookLaunchFailureReason {
+  /// 未失败。
+  none,
+
+  /// 非 Windows 平台，整条 Hook 链不可用。
+  unsupportedPlatform,
+
+  /// 找不到与游戏架构匹配的 injector helper。
+  helperMissing,
+
+  /// 游戏没能起来，或早期注入失败且拿不到运行中的 PID。
+  /// native 诊断在 [GalHookLaunchResult.diagnostics] 里，必须一路带到 UI。
+  injectionFailed,
+
+  /// **这不是失败**：本次启动被更新的会话操作取代（用户又点了一次、切到附着捕获、
+  /// 或停止了捕获）。旧实现把它和真失败压成同一个 `false`，于是被取代的那次会抢先
+  /// 弹一句「启动失败」，把真正生效的那次结果盖掉——用户看到的失败其实来自一次
+  /// 已经作废的操作。
+  superseded,
+}
+
+/// [GalHookSessionController.launchGame] 的结构化结果（BUG-1138）。
+///
+/// 取代原来的 `bool`：成功只有一种，失败必须说明是哪一种，并把 native 诊断一起带走。
+@immutable
+class GalHookLaunchResult {
+  /// 启动成功（含「游戏在跑但音频降级」——那仍然是启动成功，降级由 outcome 分级表达）。
+  const GalHookLaunchResult.launched()
+      : reason = GalHookLaunchFailureReason.none,
+        diagnostics = const GalHookInjectorDiagnostics();
+
+  /// 启动未成功。[reason] 不得为 [GalHookLaunchFailureReason.none]——那正是本 bug 的
+  /// 形态：一个没有原因的失败。
+  const GalHookLaunchResult.failed(
+    this.reason, {
+    this.diagnostics = const GalHookInjectorDiagnostics(),
+  }) : assert(
+          reason != GalHookLaunchFailureReason.none,
+          'failed() 必须给出真实原因；启动成功请用 GalHookLaunchResult.launched()',
+        );
+
+  final GalHookLaunchFailureReason reason;
+
+  /// injector 的结构化诊断（分类原因 + 退出码 + stderr 尾部原文）。
+  /// 即便 [GalHookInjectorFailure] 归类不出来，这里的 stderr 尾部仍是唯一的一手证据，
+  /// 必须让它到达用户和日志，而不是像旧实现那样停在 controller 内部。
+  final GalHookInjectorDiagnostics diagnostics;
+
+  bool get launched => reason == GalHookLaunchFailureReason.none;
+}
+
 /// 一次「启动游戏」结束后**必须**告知用户的结果分级（BUG-1089，纯函数可单测）。
 ///
 /// 存在的理由：[GalHookSessionController.launchGame] 返回 `bool`，把三种结果压成两个值
@@ -181,6 +242,10 @@ enum GalHookLaunchOutcome {
 
   /// 注入成功、窗口已绑定。
   running,
+
+  /// 本次启动被更新的操作取代：**不得向用户播报任何结果**。取代它的那次操作会播报
+  /// 自己的结果；这里再弹一句只会用一个作废操作的结局盖掉真实结局。
+  superseded,
 }
 
 /// 把一次启动的结果判成 [GalHookLaunchOutcome]（纯函数，无 i18n、无 IO）。
@@ -189,12 +254,17 @@ enum GalHookLaunchOutcome {
 /// `_activateTextWithLoopback`（文本 hook 就绪、音频用 Loopback）同样把 phase 设成
 /// `degraded`，但它显式把 injectorFailure 清成 [GalHookInjectorFailure.none]——那是
 /// 「有台词、音频兜底」的可接受模式，不该报成降级去烦用户。
+/// 被取代（[GalHookLaunchFailureReason.superseded]）先于一切判定：它既不是失败也不是
+/// 成功，而是「这次操作的结论已经作废」，唯一正确的处置是闭嘴。
 GalHookLaunchOutcome classifyGalHookLaunchOutcome({
-  required bool launched,
+  required GalHookLaunchResult result,
   required bool hasBoundWindow,
   required GalHookInjectorFailure injectorFailure,
 }) {
-  if (!launched) return GalHookLaunchOutcome.failed;
+  if (result.reason == GalHookLaunchFailureReason.superseded) {
+    return GalHookLaunchOutcome.superseded;
+  }
+  if (!result.launched) return GalHookLaunchOutcome.failed;
   if (!hasBoundWindow) return GalHookLaunchOutcome.windowMissing;
   if (injectorFailure != GalHookInjectorFailure.none) {
     return GalHookLaunchOutcome.degradedLoopback;
@@ -888,14 +958,25 @@ class GalHookSessionController extends ChangeNotifier {
   /// [launchArguments] 是用户为该游戏配置的启动参数（已按 Windows 规则拆成 argv
   /// token，见 `parseGameLaunchArguments`），[workdir] 是工作目录。两者都可省略：
   /// 省略即维持旧行为（不发 `--arg` / 不发 `--workdir`，injector 缺省用 exe 所在目录）。
-  Future<bool> launchGame(
+  Future<GalHookLaunchResult> launchGame(
     String executablePath, {
     List<String> launchArguments = const <String>[],
     String workdir = '',
   }) async {
     final int generation = ++_operationGeneration;
     await _stopSources();
-    if (!_isWindows || generation != _operationGeneration) return false;
+    // 两种早退原因必须分开：非 Windows 是「这台机器不支持」，被抢占是「这次操作作废」。
+    // 旧实现用同一个 `false` 表达，于是 UI 对二者说同一句无信息的话。
+    if (!_isWindows) {
+      return const GalHookLaunchResult.failed(
+        GalHookLaunchFailureReason.unsupportedPlatform,
+      );
+    }
+    if (generation != _operationGeneration) {
+      return const GalHookLaunchResult.failed(
+        GalHookLaunchFailureReason.superseded,
+      );
+    }
     _selectedTextThreadKey = null;
     _selectedNativeTextThreadId = null;
     _setState(
@@ -926,7 +1007,9 @@ class GalHookSessionController extends ChangeNotifier {
         details: <String, Object?>{'arch': is32Bit == true ? 'x86' : 'x64'},
         failure: GalHookInjectorFailure.helperMissing,
       );
-      return false;
+      return const GalHookLaunchResult.failed(
+        GalHookLaunchFailureReason.helperMissing,
+      );
     }
     final bool lunaPcHooks = shouldUseLunaPcHooksForExecutable(executablePath);
     _setState(_state.copyWith(phase: GalHookSessionPhase.launching));
@@ -956,7 +1039,9 @@ class GalHookSessionController extends ChangeNotifier {
     final PcmFormat? format = await engine.start();
     if (generation != _operationGeneration) {
       await engine.stop();
-      return false;
+      return const GalHookLaunchResult.failed(
+        GalHookLaunchFailureReason.superseded,
+      );
     }
     if (format == null && !engine.textHookReady) {
       final GalHookInjectorDiagnostics diagnostics = engine.lastFailure;
@@ -984,14 +1069,18 @@ class GalHookSessionController extends ChangeNotifier {
           fallbackReason: 'launch_injection_failed',
           failure: diagnostics.failure,
         );
-        if (generation != _operationGeneration) return false;
+        if (generation != _operationGeneration) {
+          return const GalHookLaunchResult.failed(
+            GalHookLaunchFailureReason.superseded,
+          );
+        }
         _startWindowRebindWatch(generation, runningPid);
         _scheduleEngineRecovery(
           generation,
           pid: runningPid,
           diagnostics: diagnostics,
         );
-        return true;
+        return const GalHookLaunchResult.launched();
       }
       _fail(
         'inject',
@@ -1000,7 +1089,12 @@ class GalHookSessionController extends ChangeNotifier {
         details: diagnostics.toDetails(),
         failure: diagnostics.failure,
       );
-      return false;
+      // 诊断随结果一起返回：`diagnostics.failure` 归类不出来时（unknown），stderr 尾部
+      // 就是唯一的一手证据，绝不能停在这里。
+      return GalHookLaunchResult.failed(
+        GalHookLaunchFailureReason.injectionFailed,
+        diagnostics: diagnostics,
+      );
     }
     final int? gamePid = engine.gamePid;
     if (format != null) {
@@ -1018,7 +1112,11 @@ class GalHookSessionController extends ChangeNotifier {
       engine,
       gamePid: gamePid,
     )) {
-      return false;
+      // _activateTextWithLoopback 只在会话被抢占时返回 false（音频源起不来它仍返回
+      // true，走 all_audio_sources_failed 降级）。所以这里唯一的语义就是「已作废」。
+      return const GalHookLaunchResult.failed(
+        GalHookLaunchFailureReason.superseded,
+      );
     }
     ExternalWindowInfo? window;
     if (gamePid != null) {
@@ -1037,7 +1135,11 @@ class GalHookSessionController extends ChangeNotifier {
         }
       }
     }
-    if (generation != _operationGeneration) return false;
+    if (generation != _operationGeneration) {
+      return const GalHookLaunchResult.failed(
+        GalHookLaunchFailureReason.superseded,
+      );
+    }
     if (window != null) {
       _setState(_state.copyWith(boundWindow: window, gamePid: gamePid));
       _record(
@@ -1068,7 +1170,7 @@ class GalHookSessionController extends ChangeNotifier {
       // gamePid 为空表示 hook 根本没拿到目标进程，没有可重试的匹配依据。
       if (gamePid != null) _startWindowRebindWatch(generation, gamePid);
     }
-    return true;
+    return const GalHookLaunchResult.launched();
   }
 
   /// launch 会话的窗口重绑监视：周期性按 [gamePid] 找顶层窗口，找到就补上绑定并把

--- a/hibiki/lib/src/pages/implementations/galgame_home_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_home_page.dart
@@ -271,7 +271,7 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
       }
       final GalHookSessionController controller =
           widget.sessionController ?? GalHookSessionController.instance;
-      final bool launched = await controller.launchGame(
+      final GalHookLaunchResult result = await controller.launchGame(
         game.exePath,
         launchArguments: game.launchArgumentTokens,
         workdir: game.workdir,
@@ -282,18 +282,19 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
       // 既看不到游戏也看不到任何提示 —— 用户感知就是「点了没反应」。
       final GalHookSessionState state = controller.state;
       final GalHookLaunchOutcome outcome = classifyGalHookLaunchOutcome(
-        launched: launched,
+        result: result,
         hasBoundWindow: state.boundWindow != null,
         injectorFailure: state.injectorFailure,
       );
-      HibikiToast.show(
-        msg: galHookLaunchOutcomeMessage(
-          outcome: outcome,
-          failure: state.injectorFailure,
-          lastError: state.lastError,
-        ),
+      // message 为 null = 本次启动已被更新的操作取代，不该播报（BUG-1138）。
+      final String? message = galHookLaunchOutcomeMessage(
+        outcome: outcome,
+        result: result,
+        failure: state.injectorFailure,
+        lastError: state.lastError,
       );
-      if (!launched) return;
+      if (message != null) HibikiToast.show(msg: message);
+      if (!result.launched) return;
       widget.onLaunched?.call();
     } finally {
       _launching = false;

--- a/hibiki/lib/src/pages/implementations/galgame_home_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_home_page.dart
@@ -286,7 +286,7 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
         hasBoundWindow: state.boundWindow != null,
         injectorFailure: state.injectorFailure,
       );
-      // message 为 null = 本次启动已被更新的操作取代，不该播报（BUG-1138）。
+      // message 为 null = 本次启动已被更新的操作取代，不该播报（BUG-1142）。
       final String? message = galHookLaunchOutcomeMessage(
         outcome: outcome,
         result: result,

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -433,7 +433,7 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
       }
       final GalHookSessionController session =
           widget.sessionController ?? GalHookSessionController.instance;
-      final bool launched = await session.launchGame(
+      final GalHookLaunchResult result = await session.launchGame(
         game.exePath,
         launchArguments: game.launchArgumentTokens,
         workdir: game.workdir,
@@ -444,18 +444,19 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
       // 既看不到游戏也看不到任何提示 —— 用户感知就是「点了没反应」。
       final GalHookSessionState state = session.state;
       final GalHookLaunchOutcome outcome = classifyGalHookLaunchOutcome(
-        launched: launched,
+        result: result,
         hasBoundWindow: state.boundWindow != null,
         injectorFailure: state.injectorFailure,
       );
-      HibikiToast.show(
-        msg: galHookLaunchOutcomeMessage(
-          outcome: outcome,
-          failure: state.injectorFailure,
-          lastError: state.lastError,
-        ),
+      // message 为 null = 本次启动已被更新的操作取代，不该播报（BUG-1138）。
+      final String? message = galHookLaunchOutcomeMessage(
+        outcome: outcome,
+        result: result,
+        failure: state.injectorFailure,
+        lastError: state.lastError,
       );
-      if (!launched) return;
+      if (message != null) HibikiToast.show(msg: message);
+      if (!result.launched) return;
       widget.onLaunched?.call();
     } finally {
       _launching = false;

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -448,7 +448,7 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
         hasBoundWindow: state.boundWindow != null,
         injectorFailure: state.injectorFailure,
       );
-      // message 为 null = 本次启动已被更新的操作取代，不该播报（BUG-1138）。
+      // message 为 null = 本次启动已被更新的操作取代，不该播报（BUG-1142）。
       final String? message = galHookLaunchOutcomeMessage(
         outcome: outcome,
         result: result,

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -670,7 +670,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
         _appModel.galgameRepo.games,
         executable,
       );
-      final bool launched = await _session.launchGame(
+      final GalHookLaunchResult result = await _session.launchGame(
         executable,
         launchArguments: known?.launchArgumentTokens ?? const <String>[],
         workdir: known?.workdir ?? '',
@@ -681,17 +681,18 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       // 主线程还挂着、根本没跑起来，说成「已运行」会让用户以为没事。
       final GalHookSessionState state = _session.state;
       final GalHookLaunchOutcome outcome = classifyGalHookLaunchOutcome(
-        launched: launched,
+        result: result,
         hasBoundWindow: state.boundWindow != null,
         injectorFailure: state.injectorFailure,
       );
-      HibikiToast.show(
-        msg: galHookLaunchOutcomeMessage(
-          outcome: outcome,
-          failure: state.injectorFailure,
-          lastError: state.lastError,
-        ),
+      // message 为 null = 本次启动已被更新的操作取代，不该播报（BUG-1138）。
+      final String? message = galHookLaunchOutcomeMessage(
+        outcome: outcome,
+        result: result,
+        failure: state.injectorFailure,
+        lastError: state.lastError,
       );
+      if (message != null) HibikiToast.show(msg: message);
     } finally {
       _launchingGalHook = false;
     }

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -685,7 +685,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
         hasBoundWindow: state.boundWindow != null,
         injectorFailure: state.injectorFailure,
       );
-      // message 为 null = 本次启动已被更新的操作取代，不该播报（BUG-1138）。
+      // message 为 null = 本次启动已被更新的操作取代，不该播报（BUG-1142）。
       final String? message = galHookLaunchOutcomeMessage(
         outcome: outcome,
         result: result,

--- a/hibiki/test/mining/gal_hook_launch_outcome_and_encoding_test.dart
+++ b/hibiki/test/mining/gal_hook_launch_outcome_and_encoding_test.dart
@@ -199,12 +199,12 @@ void main() {
     });
   });
 
-  // BUG-1138：launchGame 曾返回 `bool`，五条 `return false` 出口里有四条**不带任何
+  // BUG-1142：launchGame 曾返回 `bool`，五条 `return false` 出口里有四条**不带任何
   // 原因**（会话被抢占那几条连 state 都不碰）。UI 只能事后去 state 里翻，翻到
   // `injectorFailure == none` + `lastError == null`，于是甩给用户一句「游戏启动或捕获
   // 失败」——零可执行信息。原因是在 `return false` 那一刻丢的，下游补丁救不回来
   // （下游只拿得到一个比特），所以修在返回类型上。
-  group('启动失败必须带原因 (BUG-1138)', () {
+  group('启动失败必须带原因 (BUG-1142)', () {
     test('失败结果不允许把原因留空', () {
       expect(
         () => GalHookLaunchResult.failed(GalHookLaunchFailureReason.none),
@@ -307,7 +307,7 @@ void main() {
       expect(
         code.contains('Future<GalHookLaunchResult> launchGame('),
         isTrue,
-        reason: '返回 bool 会让失败原因重新在 return 处丢失（BUG-1138 根因）',
+        reason: '返回 bool 会让失败原因重新在 return 处丢失（BUG-1142 根因）',
       );
       expect(
         RegExp(r'Future<bool>\s+launchGame\(').hasMatch(code),

--- a/hibiki/test/mining/gal_hook_launch_outcome_and_encoding_test.dart
+++ b/hibiki/test/mining/gal_hook_launch_outcome_and_encoding_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/gal_hook_failure_text.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
 import 'package:hibiki/src/mining/galgame_audio_source.dart';
 
@@ -110,10 +111,12 @@ void main() {
   // 三种结果压成两个值，于是每个调用方自己去 state 里翻，翻得还不一样——游戏库页
   // 一个字都不提示。用户点完「启动游戏」既看不到游戏也看不到报错。
   group('classifyGalHookLaunchOutcome (BUG-1089)', () {
-    test('launchGame 返回 false → failed', () {
+    test('launchGame 返回失败结果 → failed', () {
       expect(
         classifyGalHookLaunchOutcome(
-          launched: false,
+          result: const GalHookLaunchResult.failed(
+            GalHookLaunchFailureReason.helperMissing,
+          ),
           hasBoundWindow: false,
           injectorFailure: GalHookInjectorFailure.helperMissing,
         ),
@@ -127,7 +130,7 @@ void main() {
       // 出现。用户感知就是「点了没反应、游戏没打开」，必须报出来。
       expect(
         classifyGalHookLaunchOutcome(
-          launched: true,
+          result: const GalHookLaunchResult.launched(),
           hasBoundWindow: false,
           injectorFailure: GalHookInjectorFailure.handshakeTimeout,
         ),
@@ -139,7 +142,7 @@ void main() {
       // 两者同时成立时，用户首要感知是「游戏没打开」，不是「音频降级了」。
       expect(
         classifyGalHookLaunchOutcome(
-          launched: true,
+          result: const GalHookLaunchResult.launched(),
           hasBoundWindow: false,
           injectorFailure: GalHookInjectorFailure.injectionFailed,
         ),
@@ -150,7 +153,7 @@ void main() {
     test('有窗口 + 注入失败 → degradedLoopback', () {
       expect(
         classifyGalHookLaunchOutcome(
-          launched: true,
+          result: const GalHookLaunchResult.launched(),
           hasBoundWindow: true,
           injectorFailure: GalHookInjectorFailure.injectionFailed,
         ),
@@ -164,7 +167,7 @@ void main() {
       // 而不是 phase，就是为了不拿这个去烦用户。
       expect(
         classifyGalHookLaunchOutcome(
-          launched: true,
+          result: const GalHookLaunchResult.launched(),
           hasBoundWindow: true,
           injectorFailure: GalHookInjectorFailure.none,
         ),
@@ -177,7 +180,7 @@ void main() {
           in GalHookInjectorFailure.values) {
         for (final bool hasWindow in <bool>[true, false]) {
           final GalHookLaunchOutcome outcome = classifyGalHookLaunchOutcome(
-            launched: true,
+            result: const GalHookLaunchResult.launched(),
             hasBoundWindow: hasWindow,
             injectorFailure: failure,
           );
@@ -193,6 +196,124 @@ void main() {
           }
         }
       }
+    });
+  });
+
+  // BUG-1138：launchGame 曾返回 `bool`，五条 `return false` 出口里有四条**不带任何
+  // 原因**（会话被抢占那几条连 state 都不碰）。UI 只能事后去 state 里翻，翻到
+  // `injectorFailure == none` + `lastError == null`，于是甩给用户一句「游戏启动或捕获
+  // 失败」——零可执行信息。原因是在 `return false` 那一刻丢的，下游补丁救不回来
+  // （下游只拿得到一个比特），所以修在返回类型上。
+  group('启动失败必须带原因 (BUG-1138)', () {
+    test('失败结果不允许把原因留空', () {
+      expect(
+        () => GalHookLaunchResult.failed(GalHookLaunchFailureReason.none),
+        throwsA(isA<AssertionError>()),
+        reason: '「没有原因的失败」正是本 bug 的形态，必须在构造处就挡掉',
+      );
+    });
+
+    test('被取代的启动 → superseded，且不播报任何文案', () {
+      const GalHookLaunchResult result = GalHookLaunchResult.failed(
+        GalHookLaunchFailureReason.superseded,
+      );
+      final GalHookLaunchOutcome outcome = classifyGalHookLaunchOutcome(
+        result: result,
+        hasBoundWindow: false,
+        injectorFailure: GalHookInjectorFailure.none,
+      );
+      expect(outcome, GalHookLaunchOutcome.superseded);
+      expect(
+        galHookLaunchOutcomeMessage(
+          outcome: outcome,
+          result: result,
+          failure: GalHookInjectorFailure.none,
+        ),
+        isNull,
+        reason: '取代它的那次操作会播报自己的结果；这里再弹一句会把真实结局盖掉',
+      );
+    });
+
+    test('每个失败原因都有确定分级，不留未定义组合', () {
+      for (final GalHookLaunchFailureReason reason
+          in GalHookLaunchFailureReason.values) {
+        if (reason == GalHookLaunchFailureReason.none) continue;
+        expect(
+          classifyGalHookLaunchOutcome(
+            result: GalHookLaunchResult.failed(reason),
+            hasBoundWindow: false,
+            injectorFailure: GalHookInjectorFailure.none,
+          ),
+          reason == GalHookLaunchFailureReason.superseded
+              ? GalHookLaunchOutcome.superseded
+              : GalHookLaunchOutcome.failed,
+          reason: '$reason 必须有确定分级',
+        );
+      }
+    });
+
+    // 本组的核心断言：即便 injector 诊断归类不出来（unknown），native 的一手证据也
+    // 必须到达用户。旧实现在这条路径上只剩一句兜底文案，stderr 尾部停在 controller
+    // 内部——用户无法自愈，报障时也提供不出线索。
+    test('归类不出来时，native 诊断必须进入文案', () {
+      const GalHookLaunchResult result = GalHookLaunchResult.failed(
+        GalHookLaunchFailureReason.injectionFailed,
+        diagnostics: GalHookInjectorDiagnostics(
+          failure: GalHookInjectorFailure.unknown,
+          exitCode: 3,
+          stderrTail: '[luna] LunaHook32.dll 已注入 pid=1234，等待连接...\n'
+              'engine bootstrap aborted: unexpected module layout',
+        ),
+      );
+      final String? message = galHookLaunchOutcomeMessage(
+        outcome: GalHookLaunchOutcome.failed,
+        result: result,
+        failure: GalHookInjectorFailure.unknown,
+      );
+      expect(message, isNotNull);
+      expect(message, contains('exit=3'));
+      expect(message, contains('engine bootstrap aborted'));
+    });
+
+    test('诊断摘要取 stderr 最后一行结论，不是中途进度', () {
+      const GalHookInjectorDiagnostics diagnostics = GalHookInjectorDiagnostics(
+        failure: GalHookInjectorFailure.unknown,
+        exitCode: 1,
+        stderrTail: '[luna] connected pid=1\n\n  final failure line  \n',
+      );
+      final String detail = galHookDiagnosticsDetail(diagnostics);
+      expect(detail, 'exit=1 final failure line');
+      expect(detail, isNot(contains('connected')));
+    });
+
+    test('没有任何诊断时不编造原因，只给兜底文案', () {
+      const GalHookLaunchResult result = GalHookLaunchResult.failed(
+        GalHookLaunchFailureReason.injectionFailed,
+      );
+      final String? message = galHookLaunchOutcomeMessage(
+        outcome: GalHookLaunchOutcome.failed,
+        result: result,
+        failure: GalHookInjectorFailure.unknown,
+      );
+      expect(message, isNotNull);
+      expect(message, isNot(contains('exit=')));
+    });
+
+    test('源码守卫：launchGame 不得退回 bool 返回值', () {
+      final File source =
+          File('lib/src/mining/gal_hook_session_controller.dart');
+      expect(source.existsSync(), isTrue, reason: '测试须在 hibiki/ 下运行才能读到源码');
+      final String code = source.readAsStringSync();
+      expect(
+        code.contains('Future<GalHookLaunchResult> launchGame('),
+        isTrue,
+        reason: '返回 bool 会让失败原因重新在 return 处丢失（BUG-1138 根因）',
+      );
+      expect(
+        RegExp(r'Future<bool>\s+launchGame\(').hasMatch(code),
+        isFalse,
+        reason: 'bool 返回值把五种失败压成一个比特，正是本 bug 的根因',
+      );
     });
   });
 }

--- a/hibiki/test/mining/gal_hook_session_controller_test.dart
+++ b/hibiki/test/mining/gal_hook_session_controller_test.dart
@@ -1554,7 +1554,7 @@ void _bug950Guard() {
       final GalHookLaunchResult result =
           await controller.launchGame(r'D:\gal\x\x.exe');
       expect(result.launched, isFalse);
-      // BUG-1138：注入失败必须带结构化原因 + native 诊断，不能退化成无信息兜底。
+      // BUG-1142：注入失败必须带结构化原因 + native 诊断，不能退化成无信息兜底。
       expect(result.reason, GalHookLaunchFailureReason.injectionFailed);
       expect(
           result.diagnostics.failure, GalHookInjectorFailure.elevationRequired);

--- a/hibiki/test/mining/gal_hook_session_controller_test.dart
+++ b/hibiki/test/mining/gal_hook_session_controller_test.dart
@@ -110,7 +110,10 @@ void main() {
       endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
     );
 
-    expect(await controller.launchGame(r'D:\anemoi\SiglusEngine.exe'), isTrue);
+    expect(
+      (await controller.launchGame(r'D:\anemoi\SiglusEngine.exe')).launched,
+      isTrue,
+    );
     final TexthookerLineEntry entry = service.appendLine('siglus line')!;
     final Uint8List? bytes = await controller.captureAudioBytes(
       lineId: entry.id,
@@ -160,7 +163,10 @@ void main() {
       endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
     );
 
-    expect(await controller.launchGame(r'D:\anemoi\SiglusEngine.exe'), isTrue);
+    expect(
+      (await controller.launchGame(r'D:\anemoi\SiglusEngine.exe')).launched,
+      isTrue,
+    );
     final TexthookerLineEntry entry = service.appendLine('late resource line')!;
     final Uint8List? bytes = await controller.captureAudioBytes(
       lineId: entry.id,
@@ -211,7 +217,10 @@ void main() {
       endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
     );
 
-    expect(await controller.launchGame(r'D:\anemoi\SiglusEngine.exe'), isTrue);
+    expect(
+      (await controller.launchGame(r'D:\anemoi\SiglusEngine.exe')).launched,
+      isTrue,
+    );
     final TexthookerLineEntry entry = service.appendLine('resource only')!;
     controller.setAllowAudioFallback(false);
     expect(controller.state.allowAudioFallback, isFalse);
@@ -272,7 +281,7 @@ void main() {
     );
 
     try {
-      expect(await controller.launchGame(exe.path), isTrue);
+      expect((await controller.launchGame(exe.path)).launched, isTrue);
       expect(capturedLunaPcHooks, isTrue);
       final GalHookEvent launch = controller.events.firstWhere(
         (GalHookEvent event) => event.code == 'game.launch_started',
@@ -831,7 +840,10 @@ void main() {
       endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
     );
 
-    expect(await controller.launchGame(r'D:\anemoi\SiglusEngine.exe'), isTrue);
+    expect(
+      (await controller.launchGame(r'D:\anemoi\SiglusEngine.exe')).launched,
+      isTrue,
+    );
     final TexthookerLineEntry entry = service.appendLine('siglus line')!;
     await controller.captureAudioBytes(
       lineId: entry.id,
@@ -882,7 +894,10 @@ void main() {
       endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
     );
 
-    expect(await controller.launchGame(r'D:\anemoi\SiglusEngine.exe'), isTrue);
+    expect(
+      (await controller.launchGame(r'D:\anemoi\SiglusEngine.exe')).launched,
+      isTrue,
+    );
     expect(controller.state.boundWindow, isNull);
     expect(controller.state.phase, GalHookSessionPhase.degraded);
     expect(controller.state.fallbackReason, 'window_not_found');
@@ -939,7 +954,10 @@ void main() {
       endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
     );
 
-    expect(await controller.launchGame(r'D:\anemoi\SiglusEngine.exe'), isTrue);
+    expect(
+      (await controller.launchGame(r'D:\anemoi\SiglusEngine.exe')).launched,
+      isTrue,
+    );
     await controller.stopCapture(keepBinding: false);
     windows = const <ExternalWindowInfo>[
       ExternalWindowInfo(hwnd: 34, pid: 4242, title: '天使☆騒々 RE-BOOT!'),
@@ -1481,7 +1499,9 @@ void _bug950Guard() {
 
       // 游戏确实被拉起来了（injector 回报 LAUNCH pid），只是注入没成：会话必须活着。
       expect(
-          await controller.launchGame(r'D:\gal\manosaba\manosaba.exe'), isTrue);
+        (await controller.launchGame(r'D:\gal\manosaba\manosaba.exe')).launched,
+        isTrue,
+      );
       expect(controller.state.phase, GalHookSessionPhase.degraded);
       expect(controller.state.gamePid, 20096);
       expect(controller.state.fallbackReason, 'launch_injection_failed');
@@ -1531,7 +1551,13 @@ void _bug950Guard() {
         endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
       );
 
-      expect(await controller.launchGame(r'D:\gal\x\x.exe'), isFalse);
+      final GalHookLaunchResult result =
+          await controller.launchGame(r'D:\gal\x\x.exe');
+      expect(result.launched, isFalse);
+      // BUG-1138：注入失败必须带结构化原因 + native 诊断，不能退化成无信息兜底。
+      expect(result.reason, GalHookLaunchFailureReason.injectionFailed);
+      expect(
+          result.diagnostics.failure, GalHookInjectorFailure.elevationRequired);
       expect(controller.state.phase, GalHookSessionPhase.error);
       expect(
         controller.state.injectorFailure,


### PR DESCRIPTION
## 问题

用户启动 galgame 失败，toast 只有一句「游戏启动或捕获失败」，零可执行信息 —— 用户无法自愈，排障也判断不出会话停在哪一步。

## 根因

`launchGame` 返回 `bool`，把五种语义完全不同的结局压成一个比特：

| 出口 | 真实语义 | 旧实现携带的原因 |
|---|---|---|
| `!_isWindows` | 平台不支持 | 无 |
| `injector == null` | 缺 helper | 有 |
| `generation != _operationGeneration`（4 处） | **被更新的操作取代，本次已作废** | 无，且完全不碰 state |
| `_fail(launch_or_inject_failed)` | 注入失败 | 有，归类不出时为 `unknown` |

抢占那四条出口既不设 `injectorFailure` 也不设 `lastError`，而 `launchGame` 开头刚 `clearLastError: true`。于是 UI 的三级兜底 `reason ?? lastError ?? 兜底文案` 必然落到最后一级。

**原因是在 `return false` 那一刻丢掉的**，下游只拿得到一个比特，文案层怎么补都救不回来。

次生问题两条：被抢占的那次会抢先弹「启动失败」，把真正生效那次的结果盖掉；`diagnostics.stderrTail`（native 一手证据）有内容却停在 controller 内部，从不进入 UI。

## 修复

修在返回类型上，让编译期强制每条出口说明原因：

- 新增 `GalHookLaunchFailureReason`（`unsupportedPlatform` / `helperMissing` / `injectionFailed` / `superseded`）与 `GalHookLaunchResult`；`failed()` 构造断言原因不得为 `none` —— 「没有原因的失败」在构造处挡掉。
- `launchGame` 返回结构化结果，八条 return 全部携带原因与 native 诊断。
- 新增 `GalHookLaunchOutcome.superseded`，`galHookLaunchOutcomeMessage` 对它返回 `null` = 不播报（取代它的那次会播报自己的结果）。
- 归类不出来时把 native 诊断（`exit=<码>` + stderr 结论行）附进文案。
- **零新增 i18n key。**

## 测试

新增 group「启动失败必须带原因 (BUG-1138)」7 例：失败不允许留空原因（构造断言）、被取代 → `superseded` 且不播报、每个原因都有确定分级、**归类不出来时 native 诊断必须进入文案**、诊断摘要取 stderr 结论行而非中途进度、无诊断时不编造原因、源码守卫禁止 `launchGame` 退回 `bool`。另在 session controller 提权失败用例补断言 `reason == injectionFailed` 且诊断保留 `elevationRequired`。

验证：`flutter analyze` 干净；`flutter test test/mining/ test/pages/game_module_focus_test.dart` → **838 passed / 3 skipped / 0 failed**；bug 文档守卫通过。

## 背景

本 bug 由「用户报启动失败但现场无法定位」引出。当时 injector 侧全链路实测健康（`OK hooked`、共享内存五个版本字段与 app 常量逐字节一致、`sample_rate=44100 hooked=1` 音频在写、关掉上一局立刻开下一局也通），失败只可能在 app 编排层 —— 而 app 恰好只给出这句无信息兜底文案，导致无从追查。

未随本 PR 修复的相邻问题（另行立项）：`voice_hook_reader.cpp:204` 的 `ProtocolMatches` 五字段全等耦合，任一不符即整块拒绝，UI 却提示「捕获通道无法打开，请重启 Hibiki」—— 版本不匹配时重启无效，且不区分「映射不存在」与「版本不符」、不打印双方版本号。

https://claude.ai/code/session_01G8NFvnV7dyxhaMCk9Kkn5B