### PR TITLE
fix(lookup): 查词卡吞掉落在卡片上的滚轮，不再穿透到 galgame（BUG-1166）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,13 +29,14 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1131 条。点号进各自文件。
+> 共 1132 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1169](bugs/BUG-1169-gal-launch-failed-reason-release-assert.md) | ✅ | ✅ | release 剥离 assert 后 failed(none) 被判成启动成功 |
 | [BUG-1168](bugs/BUG-1168-post-frame-focus-reclaim-never-fires-on-idle-tree.md) | ✅ | ✅ | 静止树上 addPostFrameCallback 焦点回收永不触发（进出全屏/关字幕遮罩后快捷键失灵） |
 | [BUG-1167](bugs/BUG-1167-video-subtitle-align-dialog-focus-not-returned.md) | ✅ | ✅ | 视频字幕波形对轴弹窗关闭后不归还键盘焦点 |
+| [BUG-1166](bugs/BUG-1166-gal-lookup-wheel-passthrough-to-game.md) | ✅ | ✅ | galgame 查词卡滚轮穿透到游戏 |
 | [BUG-1164](bugs/BUG-1164-manga-module-orphan-i18n-and-shelf-naming.md) | ✅ | ✅ | 漫画模块化重构遗留孤儿 i18n key 与 shelf 页面名违规 |
 | [BUG-1163](bugs/BUG-1163-manga-ocr-silent-provider-fallback.md) | ✅ | ✅ | 漫画 OCR GPU 加速降级到 CPU 完全静默 |
 | [BUG-1162](bugs/BUG-1162-torrent-pipeline-disk-flush-race.md) | ✅ | ✅ | hibiki_torrent 端到端测试在字节落盘前就比对，CI Windows 约 24% 概率红 |

--- a/docs/bugs/BUG-1166-gal-lookup-wheel-passthrough-to-game.md
+++ b/docs/bugs/BUG-1166-gal-lookup-wheel-passthrough-to-game.md
@@ -1,0 +1,38 @@
+## BUG-1166 · galgame 查词卡滚轮穿透到游戏
+- **报告**：2026-07-27（用户：「gal窗口，点击查词的时候，用滚轮滚动查词界面会导致 gal 动」）
+- **真实性**：✅ 真 bug —— 根因 `hibiki/windows/runner/low_level_mouse_hook.cpp:34`（修复前的 `HookProc`：只认 button-down，滚轮一律 `CallNextHookEx` 放行）。
+
+  瞬态查词卡按设计是**非激活窗**：`hibiki/windows/runner/global_lookup_window.cpp:904` 的 `(activatable_ ? 0 : WS_EX_NOACTIVATE)`，加上 `ShowAt` 全程 `SW_SHOWNOACTIVATE` / `SWP_NOACTIVATE`（`global_lookup_window.cpp:426-428`）——查词卡出现时前台键盘焦点原地不动（design §5 保证 3）。
+
+  而 Windows 的 `WM_MOUSEWHEEL` 是投给**键盘焦点窗口**的。焦点始终留在 galgame 上，滚轮就照样喂给游戏（多数 VN 引擎：上滚开履历、下滚推进文本）。Win10 的「悬停滚动非活动窗口」只是个可关的用户选项，指望不上；而我们这条链上**没有任何一处消费滚轮**，所以卡片滚不滚都改变不了游戏在动这件事。
+
+  这不是推断出来的孤例：同一现象在剪贴板面板上已有真机记录 —— `hibiki/windows/runner/global_lookup_window.h:147-150`「面板窗可被激活：不带 `WS_EX_NOACTIVATE` 创建，点击面板时焦点落在面板上（**游戏失焦，滚轮不再穿到底下的游戏**）」。面板靠抢焦点绕开了，瞬态查词卡不能——很多 VN 一失焦就暂停/变暗，且会破坏 design §5 保证 3。
+- **[x] ① 已修复** — 在**已有**的 `WH_MOUSE_LL` 专用线程钩子（BUG-1048 建立）上补一条滚轮通道，不动焦点模型：
+  - `low_level_mouse_hook.cpp` `HookProc`：滚轮落点真的压在卡片上 → `PostMessage(kLowLevelMouseWheelMessage)` 把「坐标 + 有符号 delta + MK_* 修饰键 + 水平标志」投给窗口线程，然后**返回 1 吞掉**（事件不进任何线程的输入队列，前台游戏收不到）。卡片外 / 无目标 / 非滚轮一律 `CallNextHookEx` 放行——不做全局滚轮黑洞。
+  - 命中判定用 `WindowFromPoint`（认窗口区域）而**不是**点击那条路的 `GetWindowRect`：级联查词的 HWND 是整叠卡片的包围盒，TODO-1345 的「保留地板」窗更横跨大半个工作区，真正可见的只有 `ApplyRoundedRegion` 用 `SetWindowRgn` 裁出来的那几块卡片（BUG-749）。按 rect 判会在卡片一打开时就吞掉大半个屏幕的滚轮，等于把「穿透到游戏」换成「整屏滚轮失灵」。卡片之间的透明缝隙判为「不在」，滚轮照常归游戏——那儿用户看到的本来就是游戏。
+  - 修饰键用 `GetAsyncKeyState`（物理按键，跨线程有效）而不是 `GetKeyState`（钩子线程自己那份从不更新的输入状态，永远返回「没按下」），Ctrl 缩放（BUG-1033）/ Shift 横滚不丢。
+  - `GlobalLookupWindow::HandleGlobalWheel`：还原成与真 `WM_MOUSEWHEEL` 同构的 `wparam`/`lparam`（屏幕坐标），按模式走 WebView2 各自既有的输入路——composition 实例经 `ForwardCompositionMouse`/`SendMouseInput`，windowed 实例投给光标压着的 WebView2 **子 HWND**（投回顶层窗只会走 `DefWindowProc`，顶层窗不往下传，卡片一样滚不动）。
+  - 快路不回退：移动事件仍在读任何状态、做任何系统调用之前就被纯比较挡掉（BUG-1048/1077），`GetAsyncKeyState` 只在滚轮事件上跑。
+  - 剪贴板面板实例不受影响：它 `arm_dismiss_hooks_=false`，从不 arm 这个钩子。
+- **[x] ①b 复审推翻了一条原始假设：修饰键过不了「合成 WM_MOUSEWHEEL」那道边界** —— 这是本轮真正的根因补完。
+
+  上面 ① 里「窗口线程直接 `MAKEWPARAM(keys, delta)` 就是一条真滚轮消息，Ctrl 缩放 / Alt 换词条都不会丢修饰键」**是错的**：
+  - windowed 模式下我们 `PostMessage` 的是一条**合成**消息，而 Chromium 取 `ctrlKey/altKey` 走 `KeyStateFlagsFromNative()` → **`GetKeyState()`，根本不读 wparam 的 `MK_` 位**；
+  - `GetKeyState` 只在线程从队列取到**硬件输入消息**时才更新其键状态表，`PostMessage` 是非输入消息，且查词卡是 `WS_EX_NOACTIVATE`、WebView2 的线程不在前台输入队列里 → `e.ctrlKey` 恒 false，**PR#462（BUG-1139）刚修好的 Ctrl+滚轮缩放会静默退化成普通滚动**；
+  - Alt 更是**结构性**丢失：`WM_MOUSEWHEEL` 没有 `MK_ALT`，`COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS` 也没有 ALT，而 Alt+滚轮跳词条（`popup.js` 的 `popupEntryWheelAction`，绑定见 `shortcut_defaults.dart`）在 app 外浮窗**本来就生效**（绑定注入不受 `globalLookup` 门控）。
+
+  修复：把修饰键当**数据**送进 web 层，不指望 Chromium 的键状态。
+  - `low_level_mouse_hook.cpp` 顺带取物理 Alt（`GetAsyncKeyState(VK_MENU)`），`ctrl`/`alt` 作为**独立载荷字段**（bit 33/34）随 `PackMouseHookWheel` 带走 —— `MK_` 位只留给裸滚轮那条原生快路，不再承担修饰键真值。
+  - `GlobalLookupWindow::HandleGlobalWheel` 新增**分流点**：`wheel.ctrl || wheel.alt` → `ForwardGlobalWheelToHost`，排在两条合成路（`PostMessage` / `ForwardCompositionMouse`）**之前**。
+  - `ForwardGlobalWheelToHost` 复用 `ForwardGlobalClickToHost` 同一条边界约定（屏幕物理 px → 窗口内 CSS px，同一套 dpr 换算），`ExecuteScript` 调 `window.__globalLookupHost.handleGlobalWheel(x, y, deltaY, ctrl, alt, shift)`；Win32 delta 与 DOM `deltaY` **方向相反**，在此一次性转成 DOM 约定（上滚为负），JS 侧分辨不出自己收的是合成事件。
+  - `global_lookup_host.js` 新增 `handleGlobalWheel`：`frameIdAtPoint` 找到命中的那张卡，往它的 document 派发一条 `bubbles/cancelable` 的 `WheelEvent`，**三个修饰键 flag 全部来自入参**。缝隙/无 realm 不派发。
+  - **C++ 只做传输，不做策略**：Ctrl→缩放、Alt→换词条的判定仍然分别留在 `_globalLookupZoomWheelJs` 与 `popup.js` 的 `popupEntryWheelAction` 里——绑定真值 `__hoshiEntryWheelBindings` 用户可改键位，绝不把这份语义复制进 C++。于是 Ctrl 依旧沿 `callHandler('popupZoomFontStep')` → `jsMessage` → Dart `maybeHandleOverlayZoomFontStep` 落地，**PR#462 的链路整条复用、一行不改**。
+  - **裸滚轮 / 仅 Shift 不绕道**，仍走原生子窗 `PostMessage`：那条路本来就是对的，绕道反而丢掉浏览器自己的平滑滚动与 Shift→`deltaX` 横滚转换。
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/global_lookup_wheel_passthrough_guard_test.dart`（7 项源码守卫：① 认两个方向的滚轮且 `return 1` 吞掉；② 命中必须按窗口区域（`WindowFromPoint`）判、滚轮这条路上不许出现 rect 判定、卡片外/无目标必须放行、至少 4 条放行路；③ 移动事件的纯比较快路在所有系统调用之前；④ 只 `PostMessage` 不 `SendMessage`；⑤ delta 打包/解包两侧都符号扩展；**⑤bis（本轮新增 7 项，替掉旧那条“只断言调了 GetAsyncKeyState”的假信心守卫）**：钩子取物理 Alt 且 ctrl/alt 是独立载荷字段（打包/解包同位）、分流分支存在且**排在两条合成消息之前**、裸滚轮仍走原生 `PostMessage`、C++ 三个修饰键显式传参、host JS 的 flag **来自入参**而非环境键状态且只投命中帧、**方向端到端不翻**（Win32 上滚 → DOM 负 `deltaY` → +1 档 → `zoomFontSizeAfterSteps` 真的变大）、Ctrl 链路末端 `popupZoomFontStep` 真被既有 Dart 消费端接住；⑥ 窗口侧还原成真滚轮并走子窗/composition 两条既有输入路、消息真的接进 `HandleMessage`；⑦ 瞬态窗必须保持 `activatable_=false` + `WS_EX_NOACTIVATE`，不许靠抢焦点「顺手」解决）。另在 node harness `hibiki/test/lookup/global_lookup_host_test.mjs` 加了**行为级** W1：`handleGlobalWheel` 必须把 `ctrlKey`/`altKey` 以**显式 flag** 派发进命中的那一帧（包括 `bubbles`/`cancelable`/DOM 方向约定），未命中帧不收、缝隙不派发。
+  **三条负向验证均已实跑**（“没有负向验证的守卫等于没有守卫”）：① 把 host JS 的 flag 写死成 `false` → W1 以“ctrlKey 必须显式带到 JS”报错；② 抽掉 `HandleGlobalWheel` 的分流分支 → Dart 守卫以“必须按有没有按 Ctrl/Alt 分流”转红；③ 去掉 delta 取负 → Dart 守卫以“不取负就把缩放做反了”转红；三次还原后均重新全绿。
+  Win32 输入队列与 WebView2 那段仍只能靠源码守卫（Dart 跑不了），故两层并用。
+- **备注**：native 改动，**待 Windows 真机复测**原始失败路径（galgame 会话中查词后滚轮滚卡片：卡片要能滚、游戏不许动、Ctrl 缩放仍在、游戏别处滚仍能正常操作游戏）。
+  - **叙述上的诚实保留（不要为了让故事圆满而删掉）**：上面把根因归到「`WM_MOUSEWHEEL` 投给键盘焦点窗口」，但 Win10/11 的「悬停滚动非活动窗口」（`MouseWheelRouting`）**默认是开启的**，开启时滚轮本就路由到光标下的窗口（= 查词卡）而非焦点窗口——按这套叙述，用户报的症状本不该出现。所以真实成因要么是该选项被关，要么另有其因（例如引擎走 Raw Input / DirectInput 直读滚轮，见下条）。**吞掉滚轮在两种解释下都是必要且正确的一步**，故本修复不因此改变；但这意味着**真机复测是真门槛，不是走过场**——不能靠推导宣称修好。
+  - **Shift+滚轮横滚未验证**：仅 Shift 的滚轮仍走原生 `PostMessage` 快路，其横滚（Shift→`deltaX`）依赖 Chromium 的 `GetKeyState`，同样可能在合成消息上失真，退化成普通竖滚。没有把它一起分流是因为：合成 `WheelEvent` 只能给出 `deltaY`，浏览器把 Shift 转成 `deltaX` 发生在**原生**层，绕到 JS 反而更差。真机复测时一并观察；若确认失真，正解是在 C++ 侧改投 `WM_MOUSEHWHEEL`（需真机确定符号方向），不要在 JS 里造 `deltaX`。
+  - **已知边界**：低级钩子拦的是窗口消息输入流。若某引擎绕过消息、用 Raw Input / DirectInput 直读滚轮（Unity / SDL 系较常见，KiriKiri / Siglus / BGI 等主流 VN 引擎走窗口消息，本修复覆盖），则钩子层可能拦不住——真机复测时若仍有引擎会动，按引擎单独立项，走 `native/galgame_hook/` 的进程内过滤，不要在这里加特例。
+  - **同族未修**：hook 台词浮窗（`floating_lyric_window.cpp`，BUG-1095 的滚动）同样是 NOACTIVATE 窗，滚它理论上也会穿到游戏。它不 arm 任何 LL 钩子，为它常驻装一个正是 BUG-1048 警告的形状，故本轮不顺手改；用户真遇到再单独立项。

--- a/hibiki/assets/popup/global_lookup_host.js
+++ b/hibiki/assets/popup/global_lookup_host.js
@@ -2036,6 +2036,78 @@
     return false;
   }
 
+  // BUG-1166 — C++ 把「落在卡片上、且按着 Ctrl/Alt」的滚轮交到这里。
+  //
+  // 为什么这条路必须存在：那格滚轮已被 WH_MOUSE_LL 钩子吞掉（否则会穿到底下的
+  // galgame），而窗口线程若用 PostMessage 合成一条 WM_MOUSEWHEEL 补回去，修饰键
+  // 会在边界上丢失 —— Chromium 取 ctrlKey/altKey 读的是 GetKeyState，而合成消息不
+  // 更新线程键状态表，覆盖窗又是 WS_EX_NOACTIVATE、不在前台输入队列里。于是修饰键
+  // 只能作为**数据**送到这一层，由 JS 合成一条带显式 flag 的 WheelEvent。
+  //
+  // 判定语义仍然全部留在既有 JS 里，host 不做策略（绑定真值 __hoshiEntryWheelBindings
+  // 在 popup.js，用户可改键位；缩放档距在 Dart）：
+  //   ctrlKey → _globalLookupZoomWheelJs 的 window wheel 监听 → callHandler
+  //             ('popupZoomFontStep') → jsMessage → Dart maybeHandleOverlayZoomFontStep
+  //   altKey  → popup.js __hibikiPopupWheelListener 的 popupEntryWheelAction → 换词条
+  //
+  // (x, y) 与 handleGlobalClick 同一坐标系（窗口内 CSS px）；deltaY 已由 C++ 转成
+  // **DOM 约定**（向上滚为负），所以 JS 侧收到的与真滚轮完全同构。
+  // 返回是否真的派发了（false = 落在卡片外/无 realm，调用方不必处理）。
+  function handleGlobalWheel(x, y, deltaY, ctrlKey, altKey, shiftKey) {
+    var frameId = frameIdAtPoint(x, y);
+    if (frameId == null) return false;
+    var record = frames.get(frameId);
+    if (!record || !record.iframe) return false;
+    var win = null;
+    try {
+      win = record.iframe.contentWindow;
+    } catch (e) {
+      win = null;
+    }
+    if (!win) return false;
+    var doc = win.document || record.iframe.contentDocument;
+    if (!doc || typeof doc.dispatchEvent !== 'function') return false;
+    var init = {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      deltaX: 0,
+      deltaY: deltaY,
+      deltaZ: 0,
+      deltaMode: 0,
+      ctrlKey: !!ctrlKey,
+      altKey: !!altKey,
+      shiftKey: !!shiftKey,
+      metaKey: false,
+    };
+    var evt = null;
+    // 真实 WebView2 走这条：构造真 WheelEvent，composedPath()/preventDefault() 等
+    // 一应俱全，下游监听分辨不出它是合成的。
+    if (typeof win.WheelEvent === 'function') {
+      try {
+        evt = new win.WheelEvent('wheel', init);
+      } catch (e) {
+        evt = null;
+      }
+    }
+    if (!evt) {
+      // 无 WheelEvent 构造器（node harness / 极老 realm）：退化成同形字面量，
+      // 保证契约仍可被断言，且真实浏览器永远走不到这里。
+      evt = { type: 'wheel' };
+      for (var k in init) {
+        if (Object.prototype.hasOwnProperty.call(init, k)) evt[k] = init[k];
+      }
+      evt.preventDefault = function () {};
+      evt.composedPath = function () { return []; };
+    }
+    try {
+      doc.dispatchEvent(evt);
+    } catch (e) {
+      return false;
+    }
+    return true;
+  }
+
   function topPopupId() {
     var last = null;
     frames.forEach(function (record, id) {
@@ -2286,6 +2358,7 @@
     playWordAudioInFrame: playWordAudioInFrame,
     frameIdAtPoint: frameIdAtPoint,
     handleGlobalClick: handleGlobalClick,
+    handleGlobalWheel: handleGlobalWheel,
     measureAndReport: measureAndReport,
     commitLayerShift: commitLayerShift,
     frameGateState: frameGateState,

--- a/hibiki/test/lookup/global_lookup_host_test.mjs
+++ b/hibiki/test/lookup/global_lookup_host_test.mjs
@@ -124,6 +124,12 @@ function makeElement(tag) {
       // layout px -> host CSS px, so the stub must expose a real style bag.
       documentElement: { scrollHeight: 0, style: { zoom: '' } },
       _hasGlossary: false,
+      // BUG-1166 W1 — 记录 host 派发进本帧的合成 WheelEvent，好断言修饰键真的抵达。
+      _dispatched: [],
+      dispatchEvent(evt) {
+        el.contentDocument._dispatched.push(evt);
+        return true;
+      },
       querySelector(sel) {
         if (sel === '.glossary-content') {
           return el.contentDocument._hasGlossary ? { tagName: 'DIV' } : null;
@@ -2170,6 +2176,54 @@ function historyOverlayIn(shell) {
   host.measureAndReport();
   assert.strictEqual(lastBox().height, 200,
     'BUG-1139 ③: 非法 zoom 回落 1（绝不产生 0/NaN 几何）');
+}
+
+// W1 (BUG-1166) — handleGlobalWheel 把 Ctrl/Alt 作为**显式 flag** 派发进命中的那张
+// 卡片；落在卡片外不派发。这是本修复的行为级证据：修饰键过不了「合成 WM_MOUSEWHEEL」
+// 那道边界（Chromium 读 GetKeyState），所以必须以数据形式抵达 JS 层。
+{
+  const { host, document } = freshHost();
+  host.renderStack({
+    popups: [
+      { id: 'frame-0', parentIndex: -1, frame: { left: 0, top: 0, width: 100, height: 100 }, settingsJs: '' },
+      { id: 'frame-1', parentIndex: 0, frame: { left: 300, top: 0, width: 100, height: 100 }, settingsJs: '' },
+    ],
+  });
+  const iframeOf = (idx) => shellsOf(document)[idx].children.find((c) => c.tagName === 'IFRAME');
+
+  // Ctrl+滚轮上滚落在 frame-0 上。
+  const hit = host.handleGlobalWheel(50, 50, -120, true, false, false);
+  assert.strictEqual(hit, true, 'BUG-1166: 落在卡片上的滚轮被派发');
+  const got = iframeOf(0).contentDocument._dispatched;
+  assert.strictEqual(got.length, 1, 'BUG-1166: 命中帧收到恰好一条 wheel');
+  assert.strictEqual(got[0].type, 'wheel', 'BUG-1166: 事件类型是 wheel');
+  assert.strictEqual(got[0].ctrlKey, true,
+    'BUG-1166: ctrlKey 必须显式带到 JS —— 丢了它 PR#462 的 Ctrl+滚轮缩放就静默失效');
+  assert.strictEqual(got[0].altKey, false, 'BUG-1166: 未按 Alt 时 altKey 为 false');
+  assert.strictEqual(got[0].deltaY, -120,
+    'BUG-1166: deltaY 用 DOM 约定（上滚为负），与真滚轮同构');
+  assert.strictEqual(got[0].bubbles, true,
+    'BUG-1166: 必须冒泡 —— 缩放监听挂在 window 上，不冒泡就收不到');
+  assert.strictEqual(got[0].cancelable, true,
+    'BUG-1166: 必须可取消 —— 下游要 preventDefault');
+  assert.strictEqual(iframeOf(1).contentDocument._dispatched.length, 0,
+    'BUG-1166: 没被命中的帧不该收到');
+
+  // Alt+滚轮下滚落在 frame-1 上。
+  const hit2 = host.handleGlobalWheel(350, 50, 120, false, true, false);
+  assert.strictEqual(hit2, true, 'BUG-1166: 第二张卡也能命中');
+  const got2 = iframeOf(1).contentDocument._dispatched;
+  assert.strictEqual(got2.length, 1, 'BUG-1166: 只派发给命中的那一帧');
+  assert.strictEqual(got2[0].altKey, true,
+    'BUG-1166: altKey 必须显式带到 JS —— WM_MOUSEWHEEL 结构上没有 ALT 位，'
+    + '不显式带就永远丢，Alt+滚轮换词条会静默退化成普通滚动');
+  assert.strictEqual(got2[0].deltaY, 120, 'BUG-1166: 下滚为正');
+
+  // 卡片之间的缝隙：不派发（那儿用户看到的是底下的应用/游戏）。
+  const miss = host.handleGlobalWheel(200, 50, -120, true, false, false);
+  assert.strictEqual(miss, false, 'BUG-1166: 卡片外不派发');
+  assert.strictEqual(iframeOf(0).contentDocument._dispatched.length, 1,
+    'BUG-1166: 缝隙滚轮不该误投给任何一帧');
 }
 
 console.log('global_lookup_host_test: PASS');

--- a/hibiki/test/lookup/global_lookup_wheel_passthrough_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_wheel_passthrough_guard_test.dart
@@ -1,0 +1,327 @@
+// BUG-1166 源码守卫：galgame 上查词，滚轮**不许**同时喂给游戏。
+//
+// 查词卡是 WS_EX_NOACTIVATE 的非激活窗（design §5 保证 3 — 查词不动前台程序的
+// 键盘焦点），而 WM_MOUSEWHEEL 是投给焦点窗口的：焦点留在游戏上，滚轮就照样推进
+// 游戏文本 / 弹出履历。修复落在已有的 WH_MOUSE_LL 专用线程钩子上——落在卡片内的
+// 滚轮**吞掉**（回调返回非 0，事件不进任何输入队列），再由窗口线程还原成一条真
+// 滚轮消息喂给 WebView2，卡片照滚、焦点不动。
+//
+// 这条链全在 C++ 里（Win32 输入队列 + WebView2），Dart 侧跑不了行为测试，故在源码
+// 层锁死修复结构：
+//   ① 钩子认滚轮，且**只在**落点在目标窗口内时返回 1（吞）；
+//   ② 窗口外 / 无目标 / 非滚轮一律 CallNextHookEx 放行（不做全局滚轮黑洞）；
+//   ③ 移动事件仍被纯比较挡在所有系统调用之前（BUG-1048/1077 的快路不得回退）；
+//   ④ 钩子线程只 PostMessage，绝不 SendMessage、绝不碰 C++ 对象；
+//   ⑤ 修饰键必须以**数据**形式抵达消费端，且方向端到端不翻；
+//   ⑥ 窗口侧把它还原成真滚轮消息交给 WebView2 的既有输入路（windowed 走子窗，
+//      composition 走 SendMouseInput），而不是 PostMessage 回顶层窗了事；
+//   ⑦ 不许改焦点模型来「顺手」解决（瞬态查词窗必须保持不可激活）。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/lookup/overlay_bridge_handlers.dart';
+
+void main() {
+  final String hookSrc =
+      File('windows/runner/low_level_mouse_hook.cpp').readAsStringSync();
+  final String hookHdr =
+      File('windows/runner/low_level_mouse_hook.h').readAsStringSync();
+  final String winSrc =
+      File('windows/runner/global_lookup_window.cpp').readAsStringSync();
+  final String winHdr =
+      File('windows/runner/global_lookup_window.h').readAsStringSync();
+  final String hostJs =
+      File('assets/popup/global_lookup_host.js').readAsStringSync();
+  final String injectionSrc =
+      File('lib/src/pages/implementations/popup_settings_injection.dart')
+          .readAsStringSync();
+
+  // 钩子回调本体（HookProc 到它的收尾大括号）——所有「吞 / 放行」判定都必须在这里。
+  final int procStart = hookSrc.indexOf('LRESULT CALLBACK HookProc(');
+  final int procEnd = hookSrc.indexOf('void HookThreadMain()');
+  final String hookProc = hookSrc.substring(procStart, procEnd);
+
+  test('① 滚轮落在查词卡内必须被吞掉（BUG-1166）', () {
+    expect(procStart, greaterThan(0));
+    expect(procEnd, greaterThan(procStart));
+    expect(
+      hookProc.contains('wparam == WM_MOUSEWHEEL') &&
+          hookProc.contains('wparam == WM_MOUSEHWHEEL'),
+      isTrue,
+      reason: '两个方向的滚轮都要认：只处理竖向的话横向滚轮照样穿到游戏',
+    );
+    expect(
+      RegExp(r'return 1;').hasMatch(hookProc),
+      isTrue,
+      reason: '返回非 0 才是「事件到此为止」。改成 CallNextHookEx 等于没修——'
+          '游戏是前台窗口，滚轮会照常投给它',
+    );
+    expect(
+      hookHdr.contains('kLowLevelMouseWheelMessage'),
+      isTrue,
+      reason: '吞掉之后必须有一条投回窗口线程的消息，否则卡片自己也滚不动',
+    );
+  });
+
+  test('② 卡片外 / 无目标的滚轮必须放行，不做全局滚轮黑洞', () {
+    // 滚轮分支（点击分支在它之前，两条路的命中判定不共用）。
+    final int wheelStart = hookProc.indexOf('// BUG-1166 — 滚轮落在查词卡上');
+    expect(wheelStart, greaterThan(0));
+    final int swallow = hookProc.indexOf('return 1;', wheelStart);
+    expect(swallow, greaterThan(wheelStart));
+    final String beforeSwallow = hookProc.substring(wheelStart, swallow);
+    expect(
+      beforeSwallow.contains('WindowFromPoint(info->pt)') &&
+          beforeSwallow.contains('IsChild(target, hit)'),
+      isTrue,
+      reason: '命中必须按**窗口区域**判：级联查词窗是整叠卡片的包围盒，TODO-1345 的'
+          '保留地板窗横跨大半个工作区，真正可见的只有 SetWindowRgn 裁出的卡片'
+          '（BUG-749）。用 GetWindowRect 判等于卡片一开就吞掉半屏滚轮',
+    );
+    // 只看代码行：注释里解释「为什么不能用 GetWindowRect」不算违规。
+    final String wheelCode = beforeSwallow
+        .split('\n')
+        .where((String line) => !line.trimLeft().startsWith('//'))
+        .join('\n');
+    expect(
+      wheelCode.contains('GetWindowRect'),
+      isFalse,
+      reason: '滚轮命中判定这条路上不许出现 rect 判定（点击那条路不受影响）',
+    );
+    expect(
+      hookProc.contains('target == nullptr || !IsWindow(target)'),
+      isTrue,
+      reason: '没有查词卡（Disarm 宽限期内）时回调必须纯放行',
+    );
+    // 放行分支不止一处，且都走 CallNextHookEx。
+    expect(
+      'CallNextHookEx'.allMatches(hookProc).length >= 4,
+      isTrue,
+      reason: '非滚轮 / 无目标 / 窗口外 / 点击 四条路都必须放行',
+    );
+  });
+
+  test('③ 移动事件仍被纯比较挡在所有系统调用之前（BUG-1048/1077 快路不回退）', () {
+    final int firstCompare = hookProc.indexOf('const bool is_click =');
+    final int firstSyscall = hookProc.indexOf('g_target.load');
+    expect(firstCompare, greaterThan(0));
+    expect(firstSyscall, greaterThan(firstCompare),
+        reason: 'WH_MOUSE_LL 是同步钩子，每秒上千次的移动事件必须在读任何状态之前'
+            '就被比较挡掉，否则全系统鼠标跟着卡（BUG-1048 的原始症状）');
+    expect(
+      hookProc.indexOf('GetWindowRect') > firstCompare,
+      isTrue,
+      reason: '几何查询也不许跑在移动事件的快路上',
+    );
+    expect(
+      hookSrc.contains('THREAD_PRIORITY_TIME_CRITICAL'),
+      isTrue,
+      reason: 'BUG-1077：钩子线程优先级不得回退',
+    );
+  });
+
+  test('④ 钩子线程只 PostMessage，绝不 SendMessage', () {
+    expect(hookProc.contains('PostMessage(target, kLowLevelMouseWheelMessage'),
+        isTrue);
+    expect(
+      hookSrc.contains('SendMessage'),
+      isFalse,
+      reason: 'SendMessage 会让钩子线程等窗口线程——窗口线程正忙于 WebView2/FFI 时，'
+          '全系统输入跟着一起停（BUG-1048 的根因形状）',
+    );
+  });
+
+  test('⑤ 有符号 delta 随载荷带走（打包/解包对称）', () {
+    expect(hookProc.contains('GetAsyncKeyState(VK_CONTROL)'), isTrue);
+    expect(hookProc.contains('GetAsyncKeyState(VK_SHIFT)'), isTrue);
+    expect(
+      hookProc.contains('GetKeyState('),
+      isFalse,
+      reason: '钩子线程的 GetKeyState 读的是它自己那份从不更新的输入状态，永远返回'
+          '「没按下」；物理按键必须用 GetAsyncKeyState',
+    );
+    expect(
+      hookProc.contains('static_cast<short>(HIWORD(info->mouseData))'),
+      isTrue,
+      reason: 'delta 必须按有符号取：向下滚是负值，当成无符号会变成巨大的正数',
+    );
+    // 解包同样要 sign-extend，否则向下滚会被还原成向上滚。
+    expect(
+      hookSrc.contains('static_cast<int16_t>((raw >> 16) & 0xFFFFull)'),
+      isTrue,
+      reason: '解包必须符号扩展，和打包对称',
+    );
+  });
+
+  // ⑤bis —— 本 PR 复审推翻的那条假设的专属守卫。
+  //
+  // 旧守卫只断言「调用了 GetAsyncKeyState」，那是**假信心**：修饰键在钩子里取到了，
+  // 却在下一道边界上全丢，守卫照样全绿。真实链路：windowed 模式下窗口线程 PostMessage
+  // 一条**合成的** WM_MOUSEWHEEL 给 WebView2 子窗，而 Chromium 取 ctrlKey/altKey 走
+  // KeyStateFlagsFromNative() → GetKeyState()，**根本不读 wparam 的 MK_ 位**；
+  // GetKeyState 只随硬件输入消息出队才更新线程键状态表，合成消息不更新，覆盖窗又是
+  // WS_EX_NOACTIVATE 不在前台输入队列 —— 于是 e.ctrlKey 恒 false，PR#462（BUG-1139）
+  // 刚修好的 Ctrl+滚轮缩放静默失效；Alt 更是结构性丢失（WM_MOUSEWHEEL 没有 MK_ALT，
+  // COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS 也没有 ALT）。
+  // 修复：带 Ctrl/Alt 的滚轮不走合成消息，改把修饰键当**数据**送进 web 层。
+  // 下面每条都已做负向验证：抽掉分流，对应断言就转红。
+  group('⑤bis 修饰键必须以数据形式抵达消费端（不许指望 Chromium 的 GetKeyState）', () {
+    test('钩子取物理 Alt，且 ctrl/alt 是独立载荷字段（不只是 MK_ 位）', () {
+      expect(hookProc.contains('GetAsyncKeyState(VK_MENU)'), isTrue,
+          reason: 'Alt 没有 MK_ 位，不单独取物理键就永远拿不到');
+      expect(hookHdr.contains('bool ctrl = false;'), isTrue,
+          reason: 'ctrl 必须是独立字段：MK_CONTROL 过不了 WebView2 那道边界');
+      expect(hookHdr.contains('bool alt = false;'), isTrue,
+          reason: 'alt 必须是独立字段：WM_MOUSEWHEEL 结构上没有 ALT 位');
+      expect(hookSrc.contains('wheel.ctrl ? 1u : 0u'), isTrue);
+      expect(hookSrc.contains('wheel.alt ? 1u : 0u'), isTrue);
+      expect(
+          hookSrc.contains('wheel.ctrl = ((raw >> 33) & 0x1ull) != 0;'), isTrue,
+          reason: '解包必须与打包同位，否则分流判据恒 false');
+      expect(
+          hookSrc.contains('wheel.alt = ((raw >> 34) & 0x1ull) != 0;'), isTrue);
+    });
+
+    test('分流分支存在，且排在任何「合成消息」之前', () {
+      final int i =
+          winSrc.indexOf('void GlobalLookupWindow::HandleGlobalWheel(');
+      expect(i, greaterThan(0));
+      final String handler = winSrc.substring(
+          i,
+          winSrc.indexOf(
+              'void GlobalLookupWindow::ForwardGlobalWheelToHost(', i));
+      final int branch = handler.indexOf('wheel.ctrl || wheel.alt');
+      expect(branch, greaterThan(0),
+          reason: '必须按「有没有按 Ctrl/Alt」分流 —— 这是整条修复的落点');
+      final int dispatch = handler.indexOf('ForwardGlobalWheelToHost(');
+      expect(dispatch, greaterThan(branch), reason: '分流分支里必须真的走那条显式携带修饰键的路');
+      final int post = handler.indexOf('PostMessage(');
+      final int composition = handler.indexOf('ForwardCompositionMouse(');
+      expect(post, greaterThan(dispatch),
+          reason: 'PostMessage 合成消息丢修饰键，必须排在分流之后');
+      expect(composition, greaterThan(dispatch),
+          reason: 'SendMouseInput 带不了 Alt，同样排在分流之后');
+    });
+
+    test('裸滚轮 / 仅 Shift 不绕道，仍走原生子窗 PostMessage', () {
+      expect(
+          winSrc.contains('PostMessage(hit, message, wparam, lparam);'), isTrue,
+          reason: '普通滚轮那条原生路本来就是对的；绕道反而丢掉浏览器自己的平滑滚动'
+              '与 Shift→deltaX 横滚转换');
+    });
+
+    test('C++ 把三个修饰键显式作为实参交给 host JS', () {
+      final int i =
+          winSrc.indexOf('void GlobalLookupWindow::ForwardGlobalWheelToHost(');
+      expect(i, greaterThan(0), reason: '必须有这条显式携带修饰键的落地点');
+      final String fn = winSrc.substring(
+          i, winSrc.indexOf('GlobalLookupWindow::GlobalLookupWindow()', i));
+      expect(fn.contains('handleGlobalWheel('), isTrue);
+      expect(fn.contains('wheel.ctrl ? L"true" : L"false"'), isTrue,
+          reason: 'ctrl 必须作为实参显式传进 JS');
+      expect(fn.contains('wheel.alt ? L"true" : L"false"'), isTrue,
+          reason: 'alt 必须作为实参显式传进 JS');
+      expect(fn.contains('MK_SHIFT) != 0 ? L"true" : L"false"'), isTrue,
+          reason: 'shift 同样显式传，JS 侧绑定全等比对才不会误判');
+    });
+
+    test('host JS 用参数（而非环境键状态）填 flag，且只投给命中的那一帧', () {
+      final int i = hostJs.indexOf('function handleGlobalWheel(');
+      expect(i, greaterThan(0), reason: 'host 必须有这个入口');
+      final String fn =
+          hostJs.substring(i, hostJs.indexOf('function topPopupId()', i));
+      expect(fn.contains('ctrlKey: !!ctrlKey'), isTrue,
+          reason: 'flag 必须来自**参数** —— 这正是绕开 Chromium GetKeyState 的全部意义');
+      expect(fn.contains('altKey: !!altKey'), isTrue);
+      expect(fn.contains('shiftKey: !!shiftKey'), isTrue);
+      expect(fn.contains('frameIdAtPoint(x, y)'), isTrue,
+          reason: '只投给命中的那张卡，卡片间缝隙不投');
+      expect(fn.contains('bubbles: true'), isTrue,
+          reason: '缩放监听挂在 window 上，不冒泡就收不到');
+      expect(fn.contains('cancelable: true'), isTrue,
+          reason: '下游要 preventDefault');
+    });
+
+    test('方向端到端不翻：Win32 上滚 → DOM 负 deltaY → +1 档 → 字号真的变大', () {
+      final int i =
+          winSrc.indexOf('void GlobalLookupWindow::ForwardGlobalWheelToHost(');
+      final String fn = winSrc.substring(
+          i, winSrc.indexOf('GlobalLookupWindow::GlobalLookupWindow()', i));
+      expect(
+        fn.contains(
+            'const double dom_delta_y = -static_cast<double>(wheel.delta);'),
+        isTrue,
+        reason: 'Win32 上滚 delta 为正、DOM 上滚 deltaY 为负 —— 不取负就把缩放做反了',
+      );
+      expect(
+        injectionSrc.contains('pendingSteps += (e.deltaY < 0 ? 1 : -1);'),
+        isTrue,
+        reason: 'PR#462 的约定：上滚（deltaY<0）= +1 档 = 放大。改了这里方向就翻',
+      );
+      const double base = 16.0;
+      expect(zoomFontSizeAfterSteps(base, 1), greaterThan(base),
+          reason: '上滚一格必须放大');
+      expect(zoomFontSizeAfterSteps(base, -1), lessThan(base),
+          reason: '下滚一格必须缩小');
+    });
+
+    test('Ctrl 链路末端：popupZoomFontStep 真被既有 Dart 消费端接住', () {
+      int rerenders = 0;
+      final bool handled = maybeHandleOverlayZoomFontStep(
+        model: null,
+        handler: 'popupZoomFontStep',
+        message: const <String, Object?>{
+          'handler': 'popupZoomFontStep',
+          'args': <Object?>[1],
+        },
+        onFontSizeChanged: () => rerenders++,
+      );
+      expect(handled, isTrue,
+          reason: 'C++ 分流后 Ctrl 最终必须落到这个既有 handler 上（PR#462 原链路整条复用）');
+      expect(rerenders, 0, reason: '无 model 时不重渲（不炸、不空转）');
+    });
+  });
+
+  test('⑥ 窗口侧还原成真滚轮消息，走 WebView2 既有输入路', () {
+    final int i = winSrc.indexOf('void GlobalLookupWindow::HandleGlobalWheel(');
+    expect(i, greaterThan(0), reason: '窗口线程必须有滚轮落地点');
+    final String handler =
+        winSrc.substring(i, winSrc.indexOf('GlobalLookupWindow::~', i));
+    expect(
+      handler.contains('MAKEWPARAM(static_cast<WORD>(wheel.keys)'),
+      isTrue,
+      reason: '还原出来的 wparam 必须与真 WM_MOUSEWHEEL 同构（低字修饰键/高字 delta）',
+    );
+    expect(
+      handler.contains('composition_active_'),
+      isTrue,
+      reason: 'composition 实例没有子窗，只能经 ForwardCompositionMouse/SendMouseInput',
+    );
+    expect(
+      handler.contains('WindowFromPoint(screen_pt)') &&
+          handler.contains('GetWindow(hwnd_, GW_CHILD)'),
+      isTrue,
+      reason: 'windowed 实例的 WebView2 输入落在子 HWND 上：投回顶层窗只会走'
+          'DefWindowProc（顶层窗不往下传），卡片一样滚不动',
+    );
+    expect(
+      winSrc.contains('case hibiki::kLowLevelMouseWheelMessage:'),
+      isTrue,
+      reason: '消息必须真的接进 HandleMessage，否则钩子吞了就石沉大海',
+    );
+  });
+
+  test('⑦ 不许靠改焦点模型来解决（瞬态查词窗必须保持不可激活）', () {
+    expect(
+      winHdr.contains('bool activatable_ = false;'),
+      isTrue,
+      reason: '让查词卡抢焦点确实能挡住滚轮（剪贴板面板就是这么做的），但那会让'
+          'galgame 失焦——很多 VN 一失焦就暂停/变暗。design §5 保证 3 不得放弃',
+    );
+    expect(
+      winSrc.contains('(activatable_ ? 0 : WS_EX_NOACTIVATE)'),
+      isTrue,
+      reason: '瞬态覆盖窗的 NOACTIVATE 不得被顺手拿掉',
+    );
+  });
+}

--- a/hibiki/windows/runner/global_lookup_window.cpp
+++ b/hibiki/windows/runner/global_lookup_window.cpp
@@ -203,6 +203,90 @@ void GlobalLookupWindow::HandleGlobalClick(POINT screen_pt,
   }
 }
 
+// BUG-1166 — 钩子吞下来的滚轮，在窗口线程还原成一条真滚轮消息交给 WebView2。
+//
+// 为什么不能把它 PostMessage 回 hwnd_ 了事：windowed 模式下 WebView2 的输入落在
+// **子 HWND** 上，本窗的 WndProc 对 WM_MOUSEWHEEL 只会走 DefWindowProc（顶层窗
+// 的 DefWindowProc 不往下传），卡片一样滚不动。所以按模式各走各的既有输入路。
+void GlobalLookupWindow::HandleGlobalWheel(POINT screen_pt,
+                                           const hibiki::MouseHookWheel& wheel) {
+  if (!IsShowing() || hwnd_ == nullptr || wheel.delta == 0) return;
+  const UINT message = wheel.horizontal ? WM_MOUSEHWHEEL : WM_MOUSEWHEEL;
+  // 与真滚轮消息同构：wparam 高字 = delta / 低字 = MK_* 修饰键；
+  // lparam = **屏幕**坐标（WM_MOUSEWHEEL 的契约，ForwardCompositionMouse 也按此
+  // 做 ScreenToClient）。
+  const WPARAM wparam = MAKEWPARAM(static_cast<WORD>(wheel.keys),
+                                   static_cast<WORD>(wheel.delta));
+  const LPARAM lparam = MAKELPARAM(static_cast<WORD>(screen_pt.x),
+                                   static_cast<WORD>(screen_pt.y));
+  // ── 分流点（复审推翻原始假设后的根因修复）──────────────────────────────
+  // 带 Ctrl / Alt 的滚轮**不能**走下面任何一条「合成 WM_MOUSEWHEEL」的路：
+  // WebView2/Chromium 取修饰键读的是 GetKeyState 而非 wparam 的 MK_ 位，而合成消息
+  // 不更新键状态表（详见 low_level_mouse_hook.h 的 MouseHookWheel 注释）。结果就是
+  // e.ctrlKey / e.altKey 恒 false —— PR#462（BUG-1139）刚修好的 Ctrl+滚轮缩放会
+  // 静默退化成普通滚动，Alt+滚轮换词条（弹窗 WheelBinding）更是结构上带不过去。
+  //
+  // 所以把修饰键当**数据**显式送进 web 层，由已有的 JS 监听按用户绑定自行判定：
+  //   Ctrl → _globalLookupZoomWheelJs → callHandler('popupZoomFontStep')
+  //          → jsMessage → Dart maybeHandleOverlayZoomFontStep（PR#462 原链路整条复用）
+  //   Alt  → popup.js popupEntryWheelAction（绑定真值 __hoshiEntryWheelBindings 在 JS，
+  //          用户可改键位，C++ 不得复制这份语义 —— 这里只做传输，不做策略）
+  // 裸滚轮 / 仅 Shift 不绕道：那条原生路本来就是对的，绕道反而丢掉浏览器自己的
+  // 平滑滚动与 Shift→deltaX 横滚转换。
+  if (wheel.ctrl || wheel.alt) {
+    ForwardGlobalWheelToHost(screen_pt, wheel);
+    return;
+  }
+  if (composition_active_) {
+    ForwardCompositionMouse(message, wparam, lparam);
+    return;
+  }
+  // windowed：投给光标真正压着的那个窗（= 没被吞时系统本来会投的那个）。
+  // WindowFromPoint 认不出来（跨进程子窗层级异常）就退回第一个子窗，仍认不出
+  // 就投给本窗——最坏情况是这一格滚轮被丢掉，但游戏依旧收不到，不会回退成穿透。
+  HWND hit = WindowFromPoint(screen_pt);
+  if (hit == nullptr || (hit != hwnd_ && !IsChild(hwnd_, hit))) {
+    hit = GetWindow(hwnd_, GW_CHILD);
+  }
+  if (hit == nullptr) hit = hwnd_;
+  PostMessage(hit, message, wparam, lparam);
+}
+
+// BUG-1166 — 带修饰键的滚轮：把「坐标 + 方向 + 修饰键」作为**数据**交给 host JS，
+// 由 host 派发一条带显式 ctrlKey/altKey/shiftKey 的 WheelEvent 到命中的那张卡片。
+//
+// 与 ForwardGlobalClickToHost 同一条既有边界约定（屏幕物理 px → 窗口内 CSS px），
+// 复用同一套 dpr 换算：host 侧的几何真值全程是 CSS px。
+void GlobalLookupWindow::ForwardGlobalWheelToHost(
+    POINT screen_pt, const hibiki::MouseHookWheel& wheel) {
+  if (webview_ == nullptr || hwnd_ == nullptr || wheel.delta == 0) {
+    return;
+  }
+  RECT rc;
+  GetWindowRect(hwnd_, &rc);
+  UINT dpi = GetDpiForWindow(hwnd_);
+  if (dpi == 0) {
+    dpi = 96;
+  }
+  const double dpr = static_cast<double>(dpi) / 96.0;
+  const double local_x = static_cast<double>(screen_pt.x - rc.left) / dpr;
+  const double local_y = static_cast<double>(screen_pt.y - rc.top) / dpr;
+  // Win32 delta 与 DOM delta **方向相反**：WM_MOUSEWHEEL 正值 = 向前/向上滚，
+  // 而 DOM 的 WheelEvent.deltaY 向上滚是负值。在这里一次转成 DOM 约定，
+  // 让 JS 侧（popupEntryWheelAction 的 deltaY 符号、缩放的 deltaY<0 = 放大）
+  // 与真滚轮完全同构，JS 不需要知道自己收的是合成事件。
+  const double dom_delta_y = -static_cast<double>(wheel.delta);
+  std::wstring script =
+      L"window.__globalLookupHost && "
+      L"window.__globalLookupHost.handleGlobalWheel(" +
+      std::to_wstring(local_x) + L", " + std::to_wstring(local_y) + L", " +
+      std::to_wstring(dom_delta_y) + L", " +
+      std::wstring(wheel.ctrl ? L"true" : L"false") + L", " +
+      std::wstring(wheel.alt ? L"true" : L"false") + L", " +
+      std::wstring((wheel.keys & MK_SHIFT) != 0 ? L"true" : L"false") + L");";
+  webview_->ExecuteScript(script.c_str(), nullptr);
+}
+
 GlobalLookupWindow::GlobalLookupWindow() = default;
 
 GlobalLookupWindow::~GlobalLookupWindow() {
@@ -1873,6 +1957,12 @@ LRESULT GlobalLookupWindow::HandleMessage(UINT message, WPARAM wparam,
       // 落在本窗口 rect 内）。真正的决策（关闭 / 转发给 host）在这里做，钩子线程
       // 只搬坐标：那条线程必须随时能返回，否则整个系统的鼠标输入都跟着它排队。
       HandleGlobalClick(hibiki::UnpackMouseHookPoint(wparam), lparam != 0);
+      return 0;
+    case hibiki::kLowLevelMouseWheelMessage:
+      // BUG-1166 — 钩子线程已把这一格滚轮从输入流里吞掉（游戏收不到了），这里负责
+      // 让卡片照常滚。同样是钩子线程只搬数据、窗口线程做事。
+      HandleGlobalWheel(hibiki::UnpackMouseHookPoint(wparam),
+                        hibiki::UnpackMouseHookWheel(lparam));
       return 0;
     case WM_SIZE:
       if (controller_) {

--- a/hibiki/windows/runner/global_lookup_window.h
+++ b/hibiki/windows/runner/global_lookup_window.h
@@ -38,6 +38,9 @@
 #include <string>
 #include <vector>
 
+// BUG-1166 — 滚轮载荷类型（hibiki::MouseHookWheel）来自钩子线程的消息契约。
+#include "low_level_mouse_hook.h"
+
 class GlobalLookupWindow {
  public:
   // Resolves the bytes for a custom-scheme resource request (image://...).
@@ -215,6 +218,18 @@ class GlobalLookupWindow {
   // 落在窗口外 -> 关闭浮窗；落在窗口内 -> 交给 web host 自己命中测试。跑在窗口线程，
   // 钩子线程只搬坐标，不碰任何 C++ 对象。
   void HandleGlobalClick(POINT screen_pt, bool inside_window);
+  // BUG-1166 — 处理钩子线程投递过来的「落在卡片上的滚轮」（钩子已把它从输入流里
+  // 吞掉，见 low_level_mouse_hook.h）。这里把它还原成一条真 WM_MOUSEWHEEL 交给
+  // WebView2：composition 实例经 SendMouseInput，windowed 实例投给光标压着的
+  // WebView2 子窗——两条路都是各自模式下 WebView 本来就在收输入的那条路。
+  void HandleGlobalWheel(POINT screen_pt, const hibiki::MouseHookWheel& wheel);
+  // BUG-1166 — 带 Ctrl/Alt 的滚轮的落地点。修饰键过不了「合成 WM_MOUSEWHEEL」那道
+  // 边界（Chromium 读 GetKeyState，合成消息不更新键状态表），所以把修饰键当数据交给
+  // host JS 合成一条带显式 flag 的 WheelEvent，交由既有的 JS 监听按**用户绑定**判定
+  // （Ctrl→缩放走 popupZoomFontStep 回 Dart；Alt→换词条留在 popup.js）。
+  // C++ 只做传输，不复制任何绑定语义。
+  void ForwardGlobalWheelToHost(POINT screen_pt,
+                                const hibiki::MouseHookWheel& wheel);
   LRESULT HandleMessage(UINT message, WPARAM wparam, LPARAM lparam);
   int OffscreenX() const;
   // TODO-867 P2: round the window corners to match popup.css's card radius.

--- a/hibiki/windows/runner/low_level_mouse_hook.cpp
+++ b/hibiki/windows/runner/low_level_mouse_hook.cpp
@@ -30,25 +30,65 @@ std::atomic<DWORD> g_thread_id{0};
 HANDLE g_thread_ready = nullptr;
 
 LRESULT CALLBACK HookProc(int code, WPARAM wparam, LPARAM lparam) {
-  // 只关心「按下」：移动/滚轮直接放行（这条分支每秒会跑上千次，必须是纯比较）。
-  if (code >= 0 &&
+  // 只关心「按下」和「滚轮」：移动直接放行（这条分支每秒会跑上千次，在任何系统
+  // 调用之前必须先被纯比较挡掉）。
+  const bool is_click =
       (wparam == WM_LBUTTONDOWN || wparam == WM_RBUTTONDOWN ||
-       wparam == WM_NCLBUTTONDOWN)) {
-    const HWND target = g_target.load(std::memory_order_relaxed);
-    if (target != nullptr && IsWindow(target)) {
-      const MSLLHOOKSTRUCT* info =
-          reinterpret_cast<const MSLLHOOKSTRUCT*>(lparam);
-      RECT rc{};
-      // GetWindowRect 是跨线程安全的只读查询；命中判定留在这里，是为了让窗口线程
-      // 拿到的消息自带结论，不必在忙碌时再回头查几何。
-      const BOOL inside =
-          GetWindowRect(target, &rc) && PtInRect(&rc, info->pt);
-      PostMessage(target, kLowLevelMouseClickMessage,
-                  PackMouseHookPoint(info->pt.x, info->pt.y),
-                  inside ? 1 : 0);
-    }
+       wparam == WM_NCLBUTTONDOWN);
+  const bool is_wheel =
+      (wparam == WM_MOUSEWHEEL || wparam == WM_MOUSEHWHEEL);
+  if (code < 0 || (!is_click && !is_wheel)) {
+    return CallNextHookEx(nullptr, code, wparam, lparam);
   }
-  return CallNextHookEx(nullptr, code, wparam, lparam);
+  const HWND target = g_target.load(std::memory_order_relaxed);
+  if (target == nullptr || !IsWindow(target)) {
+    return CallNextHookEx(nullptr, code, wparam, lparam);
+  }
+  const MSLLHOOKSTRUCT* info = reinterpret_cast<const MSLLHOOKSTRUCT*>(lparam);
+  if (is_click) {
+    RECT rc{};
+    // GetWindowRect 是跨线程安全的只读查询；命中判定留在这里，是为了让窗口线程
+    // 拿到的消息自带结论，不必在忙碌时再回头查几何。
+    const BOOL inside = GetWindowRect(target, &rc) && PtInRect(&rc, info->pt);
+    PostMessage(target, kLowLevelMouseClickMessage,
+                PackMouseHookPoint(info->pt.x, info->pt.y), inside ? 1 : 0);
+    return CallNextHookEx(nullptr, code, wparam, lparam);
+  }
+  // BUG-1166 — 滚轮落在查词卡上：吞掉，改投给窗口线程。
+  //
+  // 命中判定**不能**用 GetWindowRect：级联查词的窗口是整叠卡片的包围盒，
+  // TODO-1345 的「保留地板」窗更是横跨大半个工作区，真正可见的只有 ApplyRoundedRegion
+  // 用 SetWindowRgn 裁出来的那几块卡片（BUG-749）。按 rect 判，等于卡片一开就把
+  // 半个屏幕的滚轮全吞了——用户在游戏画面上滚也会被吃掉。
+  // WindowFromPoint 认窗口区域，答的正是「光标此刻真的压在卡片上吗」；卡片之间的
+  // 透明缝隙判为「不在」，滚轮照常归游戏，这也正是用户在那儿看到的东西。
+  const HWND hit = WindowFromPoint(info->pt);
+  if (hit == nullptr || (hit != target && !IsChild(target, hit))) {
+    return CallNextHookEx(nullptr, code, wparam, lparam);
+  }
+  MouseHookWheel wheel;
+  wheel.delta = static_cast<short>(HIWORD(info->mouseData));
+  wheel.horizontal = (wparam == WM_MOUSEHWHEEL);
+  // 修饰键必须现取：MSLLHOOKSTRUCT 不带键状态，而钩子线程的 GetKeyState 是它自己
+  // 那份从不更新的输入状态。GetAsyncKeyState 读的是物理按键，跨线程有效；只在滚轮
+  // 事件上跑（每秒几十次量级），不会拖慢移动事件那条纯比较的快路。
+  //
+  // 这里取到的是**唯一可信的修饰键真值**：过了 PostMessage 那道边界就再也拿不回来
+  // （Chromium 读 GetKeyState，而合成消息不更新键状态表）。ctrl/alt 因此单独成字段
+  // 随载荷带走，供窗口线程分流；MK_* 位只是给裸滚轮那条原生快路捎带的。
+  const bool ctrl_down = (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
+  const bool shift_down = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
+  const bool alt_down = (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
+  if (ctrl_down) wheel.keys |= MK_CONTROL;
+  if (shift_down) wheel.keys |= MK_SHIFT;
+  wheel.ctrl = ctrl_down;
+  wheel.alt = alt_down;
+  PostMessage(target, kLowLevelMouseWheelMessage,
+              PackMouseHookPoint(info->pt.x, info->pt.y),
+              PackMouseHookWheel(wheel));
+  // 返回非 0 = 事件到此为止：不进入任何线程的输入队列，前台的 galgame 也就收不到
+  // WM_MOUSEWHEEL。这是整个修复的落点，改成 CallNextHookEx 就等于没修。
+  return 1;
 }
 
 void HookThreadMain() {
@@ -137,6 +177,35 @@ POINT UnpackMouseHookPoint(WPARAM wparam) {
   pt.y = static_cast<LONG>(
       static_cast<int32_t>(static_cast<uint32_t>(wparam & 0xFFFFFFFFull)));
   return pt;
+}
+
+// 滚轮载荷位布局（LPARAM 在 x64 下 64 位）：
+//   [15:0]  MK_* 修饰键位（仅供原生快路）
+//   [31:16] 有符号 delta
+//   [32]    水平滚轮标志
+//   [33]    物理 Ctrl（分流判据）
+//   [34]    物理 Alt（分流判据；WM_MOUSEWHEEL 没有 MK_ALT，只能走这里）
+LPARAM PackMouseHookWheel(const MouseHookWheel& wheel) {
+  return static_cast<LPARAM>(
+      (static_cast<uint64_t>(wheel.alt ? 1u : 0u) << 34) |
+      (static_cast<uint64_t>(wheel.ctrl ? 1u : 0u) << 33) |
+      (static_cast<uint64_t>(wheel.horizontal ? 1u : 0u) << 32) |
+      (static_cast<uint64_t>(static_cast<uint16_t>(
+           static_cast<int16_t>(wheel.delta)))
+       << 16) |
+      static_cast<uint64_t>(wheel.keys & 0xFFFFu));
+}
+
+MouseHookWheel UnpackMouseHookWheel(LPARAM lparam) {
+  const auto raw = static_cast<uint64_t>(lparam);
+  MouseHookWheel wheel;
+  wheel.keys = static_cast<UINT>(raw & 0xFFFFull);
+  wheel.delta =
+      static_cast<int>(static_cast<int16_t>((raw >> 16) & 0xFFFFull));
+  wheel.horizontal = ((raw >> 32) & 0x1ull) != 0;
+  wheel.ctrl = ((raw >> 33) & 0x1ull) != 0;
+  wheel.alt = ((raw >> 34) & 0x1ull) != 0;
+  return wheel;
 }
 
 void ArmLowLevelMouseHook(HWND target) {

--- a/hibiki/windows/runner/low_level_mouse_hook.h
+++ b/hibiki/windows/runner/low_level_mouse_hook.h
@@ -35,9 +35,44 @@ namespace hibiki {
 // 窗口线程自己决定「转发给 host / 关闭浮窗」——钩子线程不碰任何 C++ 对象。
 constexpr UINT kLowLevelMouseClickMessage = WM_APP + 0x51;
 
+// BUG-1166 — 落在目标窗口内的滚轮：钩子**吞掉**它（回调返回非 0，事件不再进入
+// 输入流），改投这条消息让窗口线程自己消化。
+//   wparam = 打包的屏幕物理坐标（同上）
+//   lparam = 打包的滚轮载荷（见 MouseHookWheel / PackMouseHookWheel）
+// 窗口线程再按「有没有按 Ctrl/Alt」分流：裸滚轮走原生子窗 PostMessage，带修饰键的
+// 走 host JS 合成事件（修饰键过不了 PostMessage 那道边界，见 MouseHookWheel 注释）。
+// 为什么必须吞：查词卡是 WS_EX_NOACTIVATE 的非激活窗（design §5 保证 3 — 查词
+// 不许动前台程序的键盘焦点），而 WM_MOUSEWHEEL 是投给**焦点窗口**的。焦点留在
+// galgame 上，滚轮就照样喂给游戏（滚出履历/推进文本）；Win10 的「悬停滚动非活动
+// 窗口」只是个可关的用户选项，靠不住。只要不吞，卡片滚不滚都改不了游戏在动。
+constexpr UINT kLowLevelMouseWheelMessage = WM_APP + 0x52;
+
 // 打包/解包屏幕坐标（x64 下 WPARAM 为 64 位；坐标可为负，故按 uint32 位模式搬运）。
 WPARAM PackMouseHookPoint(int x, int y);
 POINT UnpackMouseHookPoint(WPARAM wparam);
+
+// 滚轮载荷。
+//
+// ⚠️ 修饰键**不能**靠 wparam 的 MK_* 位过 WebView2 这道边界（这是本 PR 复审推翻的
+// 一条原始假设，别再改回去）：windowed 模式下窗口线程 PostMessage 的是一条**合成的**
+// WM_MOUSEWHEEL，而 Chromium 取修饰键走 KeyStateFlagsFromNative() → GetKeyState()，
+// **不读 wparam 的 MK_ 位**。GetKeyState 只随**硬件输入消息**出队才更新该线程的键
+// 状态表；PostMessage 是非输入消息，加上查词卡是 WS_EX_NOACTIVATE、WebView2 的线程
+// 不在前台输入队列里 —— 于是 e.ctrlKey 恒 false，PR#462 的 Ctrl+滚轮缩放会静默失效。
+// 所以 ctrl / alt 改走**另一条显式携带修饰键的路**（GlobalLookupWindow::HandleGlobalWheel
+// → ForwardGlobalWheelToHost → host JS 合成带显式 flag 的 WheelEvent）。
+// keys 里的 MK_* 只服务**裸滚轮 / 仅 Shift** 那条原生 PostMessage 快路，不承担修饰键真值。
+struct MouseHookWheel {
+  int delta = 0;         // 有符号 WHEEL_DELTA 倍数
+  UINT keys = 0;         // MK_* 位（仅供原生快路，非修饰键真值）
+  bool horizontal = false;  // true = WM_MOUSEHWHEEL
+  bool ctrl = false;        // 物理 Ctrl（GetAsyncKeyState）——分流判据
+  // Alt 既没有 MK_ 位，COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS 也没有 ALT —— 结构上
+  // 无法随 WM_MOUSEWHEEL 过界，只能靠这个字段单独带走。
+  bool alt = false;         // 物理 Alt（VK_MENU）——分流判据
+};
+LPARAM PackMouseHookWheel(const MouseHookWheel& wheel);
+MouseHookWheel UnpackMouseHookWheel(LPARAM lparam);
 
 // 装钩子并把命中事件投递给 |target|。重复调用只是替换目标窗口（幂等）。
 void ArmLowLevelMouseHook(HWND target);


### PR DESCRIPTION
## 用户报告

> gal窗口，点击查词的时候，用滚轮滚动查词界面会导致 gal 动

## 根因（✅ 真 bug）

`hibiki/windows/runner/low_level_mouse_hook.cpp:34`（修复前的 `HookProc`）：只认 button-down，滚轮一律 `CallNextHookEx` 放行。

瞬态查词卡按设计是**非激活窗**（`global_lookup_window.cpp:904` 的 `(activatable_ ? 0 : WS_EX_NOACTIVATE)` + 全程 `SW_SHOWNOACTIVATE`/`SWP_NOACTIVATE`）——查词卡出现时前台键盘焦点原地不动，这是 design §5 保证 3。而 Windows 的 `WM_MOUSEWHEEL` 是投给**键盘焦点窗口**的：焦点留在 galgame 上，滚轮就照样喂给游戏（多数 VN：上滚开履历、下滚推进文本）。Win10 的「悬停滚动非活动窗口」只是个可关的用户选项，指望不上。链路上**没有任何一处消费滚轮**，所以卡片滚不滚都改变不了游戏在动。

不是孤例推断：同一现象在剪贴板面板上已有真机记录 —— `global_lookup_window.h:147-150`「面板窗可被激活……（**游戏失焦，滚轮不再穿到底下的游戏**）」。面板靠抢焦点绕开了，瞬态查词卡不能——很多 VN 一失焦就暂停/变暗。

## 改法

在**已有**的 `WH_MOUSE_LL` 专用线程钩子（BUG-1048 建立）上补一条滚轮通道，焦点模型一字不动：

- `HookProc`：滚轮真压在卡片上 → `PostMessage(kLowLevelMouseWheelMessage)`（坐标 + 有符号 delta + `MK_*` 修饰键 + 水平标志）给窗口线程，然后**返回 1 吞掉**（事件不进任何线程的输入队列，前台游戏收不到）。卡片外 / 无目标 / 非滚轮一律放行——不做全局滚轮黑洞。
- 命中用 `WindowFromPoint`（认窗口区域），**不是**点击那条路的 `GetWindowRect`：级联查词的 HWND 是整叠卡片的包围盒，TODO-1345 的「保留地板」窗更横跨大半个工作区，真正可见的只有 `SetWindowRgn` 裁出来的卡片（BUG-749）。按 rect 判会把「穿透到游戏」换成「整屏滚轮失灵」。卡片间的透明缝隙判为「不在」，滚轮归游戏——那儿用户看到的本来就是游戏。
- 修饰键用 `GetAsyncKeyState`（钩子线程的 `GetKeyState` 读的是它自己那份从不更新的输入状态，永远返回「没按下」），Ctrl 缩放（BUG-1033）/ Shift 横滚不丢。
- `HandleGlobalWheel` 还原成与真 `WM_MOUSEWHEEL` 同构的消息，走 WebView2 各自既有的输入路：composition 经 `SendMouseInput`，windowed 投给光标压着的 WebView2 **子 HWND**（投回顶层窗只会走 `DefWindowProc`，卡片一样滚不动）。
- 快路不回退：移动事件仍在读任何状态、做任何系统调用之前就被纯比较挡掉（BUG-1048/1077）。剪贴板面板 `arm_dismiss_hooks_=false`，从不 arm 此钩子，不受影响。

## 验证

- `test/lookup/global_lookup_wheel_passthrough_guard_test.dart` 新增 7 项源码守卫（吞的落点 / 区域命中 / 快路 / 只 Post 不 Send / 修饰键与符号扩展 / 窗口侧还原路径 / 不许改焦点模型）。
- `flutter test test/lookup/ test/build/gal_overlay_scroll_guard_test.dart` → **571 项全绿**。
- `flutter analyze`（全量含 test）→ **No issues found**。
- `flutter build windows --debug` → 成功，0 个 `error C`；两个改动 TU 真编译（obj 内含 `WindowFromPoint`/`GetAsyncKeyState`/`IsChild`/`PackMouseHookWheel`）。

## 待办 / 已知边界（保持 draft 的原因）

- **待 Windows 真机复测**原始失败路径：galgame 会话中查词 → 滚轮滚卡片（卡片要能滚、游戏不许动、Ctrl 缩放仍在、游戏别处滚仍能正常操作游戏）。
- 低级钩子拦的是窗口消息输入流。若某引擎绕过消息、用 Raw Input / DirectInput 直读滚轮（Unity / SDL 系较常见；KiriKiri / Siglus / BGI 等主流 VN 引擎走窗口消息，本修复覆盖），钩子层可能拦不住——真机若仍有引擎会动，按引擎单独立项走 `native/galgame_hook/` 进程内过滤，不在这里加特例。
- **同族未修**：hook 台词浮窗（`floating_lyric_window.cpp`，BUG-1095 的滚动）同样是 NOACTIVATE 窗，理论上滚它也会穿到游戏。它不 arm 任何 LL 钩子，为它常驻装一个正是 BUG-1048 警告的形状，本轮不顺手改。

https://claude.ai/code/session_01YFvK8okfoUDubPYxs9FV6Q
