### PR TITLE
feat(bug-tool): renumber 命令 + 跨分支取号，治并发撞号

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 - 函数和新增 Dart helper 要有明确类型签名。
 - 不从零重写现有功能；在当前实现上删减、合并、修正。
 - 发现问题直接说，不要为了顺滑把风险说轻。
-- 用户报 bug：按 [docs/BUGS.md](docs/BUGS.md)（文件头有完整流程）——先沿真实代码路径**验真伪**。**一 bug 一文件**：真 bug 用 `dart run tool/bug.dart new <slug> [标题...]` 新建独立文件 `docs/bugs/BUG-NNN[-slug].md`（自动取下一个空号、生成骨架、重建索引；**禁止手动往 `docs/BUGS.md` 加正文**——它只是头部约定 + 自动索引表），在该文件里记根因 `file:line`，再 **① 根因修复**、**② 在最强可落地层加自动化测试**（widget 行为 / CSS 生成器 / 源码扫描守卫），两步各把 `[ ]` 勾成 `[x]` 并记提交哈希/测试文件，改完跑 `dart run tool/bug.dart reindex` 重建索引；非真 bug/无法复现也建一条标「未复现」。这套 per-file 结构消除并发 agent 撞号 + 顶部插入的 git 冲突（守卫 `hibiki/test/tools/bugs_per_file_guard_test.dart`）。与本地不入库的 `docs/REGRESSION_BUGS.md` 区分。
+- 用户报 bug：按 [docs/BUGS.md](docs/BUGS.md)（文件头有完整流程）——先沿真实代码路径**验真伪**。**一 bug 一文件**：真 bug 用 `dart run tool/bug.dart new <slug> [标题...]` 新建独立文件 `docs/bugs/BUG-NNN[-slug].md`（自动取下一个空号、生成骨架、重建索引；**禁止手动往 `docs/BUGS.md` 加正文**——它只是头部约定 + 自动索引表），在该文件里记根因 `file:line`，再 **① 根因修复**、**② 在最强可落地层加自动化测试**（widget 行为 / CSS 生成器 / 源码扫描守卫），两步各把 `[ ]` 勾成 `[x]` 并记提交哈希/测试文件，改完跑 `dart run tool/bug.dart reindex` 重建索引；**撞号别手改**——跑 `dart run tool/bug.dart renumber <old> <new>`（文件名/正文 H2/代码引用/测试名四处一起改 + reindex + 自校验零残留；只改文件名不改正文 H2 会让守卫测试 CI 红）。取号已扩到扫全部本地+远端分支，但那不是分布式锁，开 PR 前和每次 rebase 后仍要重跑 `check`；非真 bug/无法复现也建一条标「未复现」。这套 per-file 结构消除并发 agent 撞号 + 顶部插入的 git 冲突（守卫 `hibiki/test/tools/bugs_per_file_guard_test.dart`）。与本地不入库的 `docs/REGRESSION_BUGS.md` 区分。
 
 ## 仓库地图
 

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -7,7 +7,9 @@
 > 这样并发 agent 各写各的文件，永不在同一处产生 git 冲突；撞号也只是两个不同文件名，
 > 改个名即可，不再有冲突标记手术。
 >
-> 新建一条：`dart run tool/bug.dart new <slug> [标题...]`（自动取下一个空号、生成骨架、重建索引）。
+> 新建一条：`dart run tool/bug.dart new <slug> [标题...]`（跨本地+远端分支取下一个空号、生成骨架、重建索引）。
+> 撞号了：`dart run tool/bug.dart renumber <old> <new>`（文件名 + 正文 H2 + 代码/测试引用一把改 + 自校验；
+> 别手改——只改文件名不改正文 H2 会让 `bugs_per_file_guard_test` 变红）。
 > 改完某条 bug 文件后：`dart run tool/bug.dart reindex` 重建下面的索引表。
 >
 > 每条 bug 文件里：

--- a/hibiki/test/tools/bug_tool_number_pool_test.dart
+++ b/hibiki/test/tools/bug_tool_number_pool_test.dart
@@ -1,0 +1,393 @@
+// 守卫 + 行为测试：`tool/bug.dart` 的号池并发防撞（跨分支取号）与 `renumber` 改号。
+//
+// 背景：一天内连撞两轮、涉及四个 PR（#461/#462 抢 1138，#463 也 1138，#464 与 #462
+// 改号后的 1139 相撞）。根因是取号只看本地工作区，而并发 agent 各自在独立 worktree
+// 的独立分支上开工，彼此不可见。这里守两件事：
+//   ① `new` 取号要看得见「本地分支 + 远端分支」上已占的号（网络断了要**显式警告**，不许静默降级）；
+//   ② 真撞上时 `renumber` 一条命令把四处（文件名 / 正文 H2 / 代码引用 / 测试名与测试文件名）
+//      一起改掉并自校验零残留——只改文件名不改正文 H2 出过 CI 红。
+//
+// 全部用临时目录里的真 git 仓库做 fixture，不碰仓库里真实的 docs/bugs/*.md，也不依赖网络
+// （remote 用本地路径的 bare repo）。
+//
+// ignore_for_file: always_use_package_imports
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../tool/bug.dart' as bug;
+
+/// 在 [dir] 里跑 git，失败直接 fail（fixture 出问题要立刻炸，不要静默）。
+void git(Directory dir, List<String> args) {
+  final r = Process.runSync('git', args, workingDirectory: dir.path);
+  if (r.exitCode != 0) {
+    fail('git ${args.join(' ')} 在 ${dir.path} 失败：${r.stdout}${r.stderr}');
+  }
+}
+
+/// 写一个文件（自动建父目录）。
+void writeFile(Directory root, String rel, String content) {
+  final f = File('${root.path}/$rel');
+  f.parent.createSync(recursive: true);
+  f.writeAsStringSync(content);
+}
+
+String readFile(Directory root, String rel) => File('${root.path}/$rel').readAsStringSync();
+
+bool exists(Directory root, String rel) => File('${root.path}/$rel').existsSync();
+
+const String indexShell = '# Bug 跟踪\n\n---\n\n'
+    '<!-- BUGS-INDEX:BEGIN -->\n<!-- BUGS-INDEX:END -->\n';
+
+String bugDoc(int n, String title) =>
+    '## BUG-${n.toString().padLeft(3, '0')} · $title\n- **[ ] ① 未修复** —\n';
+
+/// 建一个带 docs/BUGS.md 骨架的临时目录（不含 git）。
+Directory makeBareFixture(String prefix) {
+  final dir = Directory.systemTemp.createTempSync(prefix);
+  writeFile(dir, 'docs/BUGS.md', indexShell);
+  Directory('${dir.path}/docs/bugs').createSync(recursive: true);
+  return dir;
+}
+
+/// 固定返回给定号池的假扫描器（不碰 git）。
+bug.BranchScanner stubScanner(
+  bug.BranchScanStatus status,
+  Set<int> numbers, {
+  String detail = '测试桩',
+  int refCount = 3,
+}) =>
+    () async => bug.BranchScan(status, numbers, detail, refCount: refCount);
+
+void main() {
+  final Directory originalCwd = Directory.current;
+  late List<String> out;
+  late List<String> warn;
+  final List<Directory> temps = <Directory>[];
+
+  setUp(() {
+    out = <String>[];
+    warn = <String>[];
+    bug.logOut = out.add;
+    bug.logWarn = warn.add;
+  });
+
+  tearDown(() {
+    Directory.current = originalCwd;
+    bug.logOut = stdout.writeln;
+    bug.logWarn = stderr.writeln;
+    for (final d in temps) {
+      try {
+        if (d.existsSync()) d.deleteSync(recursive: true);
+      } on FileSystemException {
+        // Windows 上 git 进程句柄偶尔滞留，清理失败不影响断言。
+      }
+    }
+    temps.clear();
+  });
+
+  /// 建一个「已经有 BUG-005（含代码引用 + 同名测试文件）」的 git 仓库 fixture 并切进去。
+  Directory enterRenumberFixture() {
+    final root = makeBareFixture('bug_renumber_');
+    temps.add(root);
+    writeFile(root, 'docs/bugs/BUG-005-foo.md',
+        '## BUG-005 · 示例标题\n- **[x] ① 已修复** — abc123\n'
+        '- **[x] ② 已加自动化测试** — hibiki/test/tools/bug_005_foo_test.dart\n');
+    writeFile(root, 'docs/bugs/BUG-006-bar.md', bugDoc(6, '另一条'));
+    writeFile(root, 'lib/foo.dart',
+        '// 修 BUG-005：根因在 foo.dart:42。debug-005 与 BUG-0055 都不该被改。\nvoid main() {}\n');
+    writeFile(root, 'hibiki/test/tools/bug_005_foo_test.dart',
+        "void main() {\n  test('BUG-005 回归守卫', () {});\n}\n");
+    git(root, <String>['init', '-q', '.']);
+    git(root, <String>['config', 'user.email', 'fixture@example.com']);
+    git(root, <String>['config', 'user.name', 'fixture']);
+    // 本机全局 commit.gpgsign=true 会让 fixture 提交失败，显式关掉。
+    git(root, <String>['config', 'commit.gpgsign', 'false']);
+    git(root, <String>['add', '-A']);
+    git(root, <String>['commit', '-qm', 'fixture']);
+    Directory.current = root;
+    return root;
+  }
+
+  group('bug.dart renumber：一条命令改四处 + 自校验', () {
+    test('文件名 / 正文 H2 / 代码引用 / 测试名与测试文件名四处同步改，且 git 记为改名', () async {
+      final root = enterRenumberFixture();
+      await bug.cmdRenumber(
+        <String>['5', '9'],
+        scanner: stubScanner(bug.BranchScanStatus.fresh, <int>{5, 6}),
+      );
+
+      // ① 文件名
+      expect(exists(root, 'docs/bugs/BUG-005-foo.md'), isFalse);
+      expect(exists(root, 'docs/bugs/BUG-009-foo.md'), isTrue);
+      // ② 正文 H2（守卫测试按 H2 判重号，只改文件名会 CI 红）
+      expect(readFile(root, 'docs/bugs/BUG-009-foo.md'), startsWith('## BUG-009 · '));
+      // ③ 代码引用；同时不许误伤 debug-005 / BUG-0055
+      final lib = readFile(root, 'lib/foo.dart');
+      expect(lib, contains('修 BUG-009：'));
+      expect(lib, contains('debug-005'));
+      expect(lib, contains('BUG-0055'));
+      // ④ 测试名 + 测试文件名
+      expect(exists(root, 'hibiki/test/tools/bug_009_foo_test.dart'), isTrue);
+      expect(readFile(root, 'hibiki/test/tools/bug_009_foo_test.dart'),
+          contains("test('BUG-009 回归守卫'"));
+      // bug 文件正文里指向测试文件的路径也跟着改
+      expect(readFile(root, 'docs/bugs/BUG-009-foo.md'),
+          contains('hibiki/test/tools/bug_009_foo_test.dart'));
+      // 索引自动重建
+      expect(readFile(root, 'docs/BUGS.md'), contains('[BUG-009](bugs/BUG-009-foo.md)'));
+      expect(readFile(root, 'docs/BUGS.md'), isNot(contains('BUG-005')));
+      // git mv 保留历史（porcelain 里是 R）
+      final status = Process.runSync('git', <String>['status', '--porcelain'],
+          workingDirectory: root.path);
+      expect(status.stdout as String, contains('R'));
+      expect(bug.cmdCheck(), 0);
+    });
+
+    test('自校验口径：改号前扫得到残留，改号后归零', () async {
+      enterRenumberFixture();
+      expect(await bug.findResidualRefs(5), isNotEmpty);
+      await bug.cmdRenumber(
+        <String>['5', '9'],
+        scanner: stubScanner(bug.BranchScanStatus.fresh, <int>{5, 6}),
+      );
+      expect(await bug.findResidualRefs(5), isEmpty);
+      expect(await bug.findResidualRefs(9), isNotEmpty);
+    });
+  });
+
+  group('bug.dart renumber：前置校验不通过就整体退出', () {
+    test('目标号本地已被占用 → 抛错且一个文件都不动', () async {
+      final root = enterRenumberFixture();
+      await expectLater(
+        bug.cmdRenumber(
+          <String>['5', '6'],
+          scanner: stubScanner(bug.BranchScanStatus.fresh, <int>{5, 6}),
+        ),
+        throwsA(isA<bug.BugToolError>()
+            .having((bug.BugToolError e) => e.message, 'message', contains('本地已被占用'))),
+      );
+      expect(exists(root, 'docs/bugs/BUG-005-foo.md'), isTrue);
+      expect(readFile(root, 'lib/foo.dart'), contains('BUG-005'));
+      expect(exists(root, 'hibiki/test/tools/bug_005_foo_test.dart'), isTrue);
+    });
+
+    test('目标号被其它分支占用（跨分支扫描口径）→ 抛错且不动文件', () async {
+      final root = enterRenumberFixture();
+      await expectLater(
+        bug.cmdRenumber(
+          <String>['5', '9'],
+          scanner: stubScanner(bug.BranchScanStatus.fresh, <int>{5, 6, 9}),
+        ),
+        throwsA(isA<bug.BugToolError>().having(
+            (bug.BugToolError e) => e.message, 'message', contains('已被其它分支占用'))),
+      );
+      expect(exists(root, 'docs/bugs/BUG-005-foo.md'), isTrue);
+      expect(exists(root, 'docs/bugs/BUG-009-foo.md'), isFalse);
+    });
+
+    test('<old> 不存在 → 抛错', () async {
+      enterRenumberFixture();
+      await expectLater(
+        bug.cmdRenumber(
+          <String>['404', '405'],
+          scanner: stubScanner(bug.BranchScanStatus.fresh, <int>{}),
+        ),
+        throwsA(isA<bug.BugToolError>()
+            .having((bug.BugToolError e) => e.message, 'message', contains('不存在'))),
+      );
+    });
+
+    test('非纯数字参数 → 抛错', () async {
+      enterRenumberFixture();
+      await expectLater(
+        bug.cmdRenumber(
+          <String>['BUG-005', '9'],
+          scanner: stubScanner(bug.BranchScanStatus.fresh, <int>{}),
+        ),
+        throwsA(isA<bug.BugToolError>()
+            .having((bug.BugToolError e) => e.message, 'message', contains('纯数字'))),
+      );
+    });
+  });
+
+  group('bug.dart renumber --dry-run', () {
+    test('列出要改的文件与行，但一个字节都不落盘', () async {
+      final root = enterRenumberFixture();
+      final beforeLib = readFile(root, 'lib/foo.dart');
+      final beforeDoc = readFile(root, 'docs/bugs/BUG-005-foo.md');
+      final beforeIndex = readFile(root, 'docs/BUGS.md');
+
+      await bug.cmdRenumber(
+        <String>['5', '9', '--dry-run'],
+        scanner: stubScanner(bug.BranchScanStatus.fresh, <int>{5, 6}),
+      );
+
+      final printed = out.join('\n');
+      expect(printed, contains('[dry-run]'));
+      expect(printed, contains('docs/bugs/BUG-005-foo.md  →  docs/bugs/BUG-009-foo.md'));
+      expect(printed, contains('hibiki/test/tools/bug_005_foo_test.dart'));
+      expect(printed, contains('lib/foo.dart:1'));
+      // 落盘检查：文件名与内容全部原样
+      expect(exists(root, 'docs/bugs/BUG-005-foo.md'), isTrue);
+      expect(exists(root, 'docs/bugs/BUG-009-foo.md'), isFalse);
+      expect(exists(root, 'hibiki/test/tools/bug_005_foo_test.dart'), isTrue);
+      expect(readFile(root, 'lib/foo.dart'), beforeLib);
+      expect(readFile(root, 'docs/bugs/BUG-005-foo.md'), beforeDoc);
+      expect(readFile(root, 'docs/BUGS.md'), beforeIndex);
+    });
+  });
+
+  group('bug 号引用正则口径', () {
+    test('认 BUG-005 / bug_005 / bug-005，不认 debug-005 / BUG-0055 / BUG-5x', () {
+      final re = bug.bugRefPattern(5);
+      expect(re.hasMatch('修 BUG-005 的根因'), isTrue);
+      expect(re.hasMatch('BUG-5'), isTrue);
+      expect(re.hasMatch('bug_005_foo_test.dart'), isTrue);
+      expect(re.hasMatch('bug-005-slug'), isTrue);
+      expect(re.hasMatch('debug-005'), isFalse);
+      expect(re.hasMatch('BUG-0055'), isFalse);
+      expect(re.hasMatch('BUG-50'), isFalse);
+      expect(re.hasMatch('XBUG-005'), isFalse);
+    });
+
+    test('renameNumberInPath 只动文件名部分', () {
+      expect(bug.renameNumberInPath('docs/bugs/BUG-005-foo.md', 5, 9),
+          'docs/bugs/BUG-009-foo.md');
+      expect(bug.renameNumberInPath('bug-005/inner/other.dart', 5, 9), isNull);
+      expect(bug.renameNumberInPath('lib/foo.dart', 5, 9), isNull);
+    });
+  });
+
+  /// 建「bare origin + 已 push 一条 BUG-003 的 worker clone」；
+  /// [pushPeerBeforeClone] 决定并发分支 BUG-020 是在 clone 之前还是之后 push——
+  /// 之后 push 意味着只有真的 fetch 才看得见它。返回 worker 工作区。
+  Directory makeRemoteFixture({required bool pushPeerBeforeClone}) {
+    final base = Directory.systemTemp.createTempSync('bug_remote_');
+    temps.add(base);
+    final origin = Directory('${base.path}/origin.git')..createSync();
+    git(origin, <String>['init', '-q', '--bare', '.']);
+
+    final seed = Directory('${base.path}/seed')..createSync();
+    git(seed, <String>['clone', '-q', origin.path, '.']);
+    git(seed, <String>['config', 'user.email', 'fixture@example.com']);
+    git(seed, <String>['config', 'user.name', 'fixture']);
+    // 本机全局 commit.gpgsign=true 会让 fixture 提交失败，显式关掉。
+    git(seed, <String>['config', 'commit.gpgsign', 'false']);
+    writeFile(seed, 'docs/BUGS.md', indexShell);
+    writeFile(seed, 'docs/bugs/BUG-003-base.md', bugDoc(3, '基线'));
+    git(seed, <String>['add', '-A']);
+    git(seed, <String>['commit', '-qm', 'base']);
+    git(seed, <String>['push', '-q', 'origin', 'HEAD:refs/heads/main']);
+
+    void pushPeer() {
+      git(seed, <String>['checkout', '-q', '-b', 'peer']);
+      writeFile(seed, 'docs/bugs/BUG-020-peer.md', bugDoc(20, '并发分支已占的号'));
+      git(seed, <String>['add', '-A']);
+      git(seed, <String>['commit', '-qm', 'peer']);
+      git(seed, <String>['push', '-q', 'origin', 'peer']);
+    }
+
+    if (pushPeerBeforeClone) pushPeer();
+    final worker = Directory('${base.path}/worker')..createSync();
+    git(worker, <String>['clone', '-q', '-b', 'main', origin.path, '.']);
+    git(worker, <String>['config', 'user.email', 'fixture@example.com']);
+    git(worker, <String>['config', 'user.name', 'fixture']);
+    // 本机全局 commit.gpgsign=true 会让 fixture 提交失败，显式关掉。
+    git(worker, <String>['config', 'commit.gpgsign', 'false']);
+    if (!pushPeerBeforeClone) pushPeer();
+    return worker;
+  }
+
+  group('bug.dart new：跨分支取号', () {
+    test('clone 之后别人才 push 的号也能扫到（真 fetch）→ 取全局最大 +1，无降级警告', () async {
+      final worker = makeRemoteFixture(pushPeerBeforeClone: false);
+      Directory.current = worker;
+
+      await bug.cmdNew(<String>['some-slug', '标题']);
+
+      // 本地只看得到 BUG-003；远端 peer 分支占了 020 → 必须取 021 而不是 004。
+      expect(exists(worker, 'docs/bugs/BUG-021-some-slug.md'), isTrue);
+      expect(exists(worker, 'docs/bugs/BUG-004-some-slug.md'), isFalse);
+      expect(out.join('\n'), contains('BUG-021'));
+      expect(warn, isEmpty, reason: '远端扫描成功时不该有降级警告，实际：$warn');
+    });
+
+    test('远端不可达（fetch 失败）→ 降级到已缓存的 remote-tracking 引用，并显式警告可能撞号', () async {
+      final worker = makeRemoteFixture(pushPeerBeforeClone: true);
+      Directory.current = worker;
+      git(worker, <String>['remote', 'set-url', 'origin', '${worker.path}/does-not-exist.git']);
+
+      await bug.cmdNew(<String>['offline-slug', '标题']);
+
+      final warned = warn.join('\n');
+      expect(warned, contains('未能刷新远端分支'));
+      expect(warned, contains('可能与并发分支相撞'),
+          reason: '静默降级会让人误以为已经防住了撞号');
+      // 缓存的 origin/peer 里有 020，所以仍然取 021。
+      expect(exists(worker, 'docs/bugs/BUG-021-offline-slug.md'), isTrue);
+    });
+
+    test('完全不在 git 仓库里 → 只用本地号，且显式警告未能扫描远端分支', () async {
+      final root = makeBareFixture('bug_nogit_');
+      temps.add(root);
+      writeFile(root, 'docs/bugs/BUG-003-base.md', bugDoc(3, '基线'));
+      Directory.current = root;
+
+      await bug.cmdNew(<String>['nogit-slug', '标题']);
+
+      final warned = warn.join('\n');
+      expect(warned, contains('未能扫描远端分支'));
+      expect(warned, contains('可能与并发分支相撞'));
+      expect(exists(root, 'docs/bugs/BUG-004-nogit-slug.md'), isTrue);
+    });
+
+    test('扫描器返回 stale/unavailable 时仍取号，fresh 时不警告', () async {
+      final root = makeBareFixture('bug_stub_');
+      temps.add(root);
+      writeFile(root, 'docs/bugs/BUG-003-base.md', bugDoc(3, '基线'));
+      Directory.current = root;
+
+      await bug.cmdNew(
+        <String>['stub-slug'],
+        scanner: stubScanner(bug.BranchScanStatus.fresh, <int>{3, 41}),
+      );
+      expect(exists(root, 'docs/bugs/BUG-042-stub-slug.md'), isTrue,
+          reason: '要取「本地最大与跨分支最大」的全局最大 +1');
+      expect(warn, isEmpty);
+    });
+  });
+
+  group('bug.dart renumber：还没 commit 的新 bug 文件', () {
+    test('untracked 文件 git mv 会失败，退回普通改名，四处照样改到', () async {
+      final root = makeBareFixture('bug_untracked_');
+      temps.add(root);
+      // 只把 lib/ 入库；bug 文件与测试文件保持 untracked（刚 `new` 出来还没 commit 的真实状态）。
+      writeFile(root, 'lib/foo.dart', '// 见 BUG-005。\nvoid main() {}\n');
+      git(root, <String>['init', '-q', '.']);
+      git(root, <String>['config', 'user.email', 'fixture@example.com']);
+      git(root, <String>['config', 'user.name', 'fixture']);
+      // 本机全局 commit.gpgsign=true 会让 fixture 提交失败，显式关掉。
+      git(root, <String>['config', 'commit.gpgsign', 'false']);
+      git(root, <String>['add', 'lib/foo.dart', 'docs/BUGS.md']);
+      git(root, <String>['commit', '-qm', 'partial']);
+      writeFile(root, 'docs/bugs/BUG-005-foo.md', bugDoc(5, '刚建还没提交'));
+      writeFile(root, 'hibiki/test/tools/bug_005_foo_test.dart', '// BUG-005 守卫\n');
+      Directory.current = root;
+
+      await bug.cmdRenumber(
+        <String>['5', '9'],
+        scanner: stubScanner(bug.BranchScanStatus.fresh, <int>{}),
+      );
+
+      expect(exists(root, 'docs/bugs/BUG-009-foo.md'), isTrue);
+      expect(exists(root, 'docs/bugs/BUG-005-foo.md'), isFalse);
+      expect(readFile(root, 'docs/bugs/BUG-009-foo.md'), startsWith('## BUG-009 · '));
+      expect(exists(root, 'hibiki/test/tools/bug_009_foo_test.dart'), isTrue);
+      expect(readFile(root, 'lib/foo.dart'), contains('BUG-009'));
+      expect(await bug.findResidualRefs(5), isEmpty);
+      expect(bug.cmdCheck(), 0);
+    });
+  });
+}

--- a/tool/bug.dart
+++ b/tool/bug.dart
@@ -6,15 +6,35 @@
 // 「头部约定 + 自动生成的索引表」。并发新建落成两个不同文件名（无冲突），
 // 撞号的代价从「解冲突」降到「重命名一个文件」。
 //
-// 用法：
-//   dart run tool/bug.dart new <slug> [标题...]   # 新建一条 bug（自动取下一个空号 + 重建索引）
-//   dart run tool/bug.dart reindex                # 扫 docs/bugs/*.md 重建 docs/BUGS.md 索引
-//   dart run tool/bug.dart migrate                # 一次性：把旧单文件 BUGS.md 拆成 per-file
-//   dart run tool/bug.dart check                  # 守卫：校验 per-file 不变式 + 索引是否同步
+// 撞号本身还是要治：`new` 取号时把可见范围从「本地工作区」扩到
+// **所有本地分支 + 远端分支**（其它 worktree 的分支就是本仓的 `refs/heads/*`，
+// 别人已 push 的分支就是 `refs/remotes/origin/*`）；真撞上了用 `renumber` 一条命令改号。
 //
-// 零外部依赖（只用 dart:io）。运行目录 = 仓库根（docs/ 在其下）。
+// ⚠️ 已知残留风险（不要宣称已彻底解决）：
+//   1. TOCTOU——两个 agent 同一秒各自取号、都还没 commit/push 时谁也看不见谁，仍会撞。
+//      开 PR 前和每次 rebase 后重跑 `check` 是最后一道闸。
+//   2. 远端扫描依赖网络；网络不通时会**显式警告**并降级到「本地分支 + 已缓存的
+//      remote-tracking 引用」，降级后取到的号仍可能与并发分支相撞。
+//
+// 用法：
+//   dart run tool/bug.dart new <slug> [标题...]        # 新建一条 bug（跨分支取下一个空号 + 重建索引）
+//   dart run tool/bug.dart renumber <old> <new> [--dry-run]
+//                                                     # 改号：文件名 + 正文 H2 + 代码/测试引用一把改，
+//                                                     #      改完自动 reindex 并自校验零残留
+//   dart run tool/bug.dart reindex                     # 扫 docs/bugs/*.md 重建 docs/BUGS.md 索引
+//   dart run tool/bug.dart migrate                     # 一次性：把旧单文件 BUGS.md 拆成 per-file
+//   dart run tool/bug.dart check                       # 守卫：校验 per-file 不变式 + 索引是否同步
+//
+// 环境变量（都可不设）：
+//   HIBIKI_BUG_REMOTE=origin              远端名
+//   HIBIKI_BUG_SKIP_REMOTE_FETCH=1        跳过 git fetch（离线/急用；仍扫已缓存 remote-tracking 并警告）
+//   HIBIKI_BUG_REMOTE_TIMEOUT=25          fetch 超时秒数
+//
+// 零外部依赖（只用 dart:*）。运行目录 = 仓库根（docs/ 在其下）。
 
+import 'dart:convert';
 import 'dart:io';
+import 'dart:math' as math;
 
 const String bugsDir = 'docs/bugs'; // 仓库根相对路径，文件读写用
 const String linkDir = 'bugs'; // docs/BUGS.md 相对链接用（BUGS.md 在 docs/ 下）
@@ -22,6 +42,23 @@ const String indexFile = 'docs/BUGS.md';
 const String beginMarker =
     '<!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->';
 const String endMarker = '<!-- BUGS-INDEX:END -->';
+
+/// 本地不入库、但同样会引用 BUG 号的文件（`git ls-files` 看不到，改号时单独带上）。
+const List<String> extraScanPaths = <String>['docs/REGRESSION_BUGS.md'];
+
+/// 可注入的输出/警告 sink（测试替换用；默认写 stdout / stderr）。
+void Function(String) logOut = stdout.writeln;
+void Function(String) logWarn = stderr.writeln;
+
+/// 工具级错误：`main` 捕获后写 stderr + 非 0 退出；测试可直接断言消息。
+class BugToolError implements Exception {
+  BugToolError(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
 
 /// docs/BUGS.md 头部约定（迁移时重写；reindex 只改 marker 之间，不动这段）。
 const String headerTemplate = '''# Bug 跟踪
@@ -33,7 +70,9 @@ const String headerTemplate = '''# Bug 跟踪
 > 这样并发 agent 各写各的文件，永不在同一处产生 git 冲突；撞号也只是两个不同文件名，
 > 改个名即可，不再有冲突标记手术。
 >
-> 新建一条：`dart run tool/bug.dart new <slug> [标题...]`（自动取下一个空号、生成骨架、重建索引）。
+> 新建一条：`dart run tool/bug.dart new <slug> [标题...]`（跨本地+远端分支取下一个空号、生成骨架、重建索引）。
+> 撞号了：`dart run tool/bug.dart renumber <old> <new>`（文件名 + 正文 H2 + 代码/测试引用一把改 + 自校验；
+> 别手改——只改文件名不改正文 H2 会让 `bugs_per_file_guard_test` 变红）。
 > 改完某条 bug 文件后：`dart run tool/bug.dart reindex` 重建下面的索引表。
 >
 > 每条 bug 文件里：
@@ -80,6 +119,9 @@ class BugEntry {
 
 final RegExp _headingRe = RegExp(r'^##\s+BUG-(\d+)\s*·\s*(.*)$');
 
+/// 3 位补零（>999 时按实际位数）。
+String padNum(int n) => n.toString().padLeft(3, '0');
+
 /// 从一段 bug 正文里解析出号 + 标题（取第一行 `## BUG-NNN · 标题`）。
 /// 返回 (number, paddedNum, title)；解析失败返回 null。
 (int, String, String)? parseHeading(String body) {
@@ -88,7 +130,7 @@ final RegExp _headingRe = RegExp(r'^##\s+BUG-(\d+)\s*·\s*(.*)$');
     if (m != null) {
       final raw = m.group(1)!;
       final n = int.parse(raw);
-      return (n, n.toString().padLeft(3, '0'), m.group(2)!.trim());
+      return (n, padNum(n), m.group(2)!.trim());
     }
   }
   return null;
@@ -153,7 +195,7 @@ List<BugEntry> scanBugs() {
     final body = f.readAsStringSync();
     final parsed = parseHeading(body);
     if (parsed == null) {
-      stderr.writeln('警告：$name 无法解析 BUG-NNN 标题，已跳过');
+      logWarn('警告：$name 无法解析 BUG-NNN 标题，已跳过');
       continue;
     }
     final (n, pad, title) = parsed;
@@ -192,8 +234,7 @@ void writeIndex(List<BugEntry> entries) {
   final beginIdx = content.indexOf('BUGS-INDEX:BEGIN');
   final endIdx = content.indexOf('BUGS-INDEX:END');
   if (beginIdx < 0 || endIdx < 0) {
-    stderr.writeln('错误：$indexFile 缺少索引 marker，先跑 migrate');
-    exit(1);
+    throw BugToolError('$indexFile 缺少索引 marker，先跑 migrate');
   }
   // 定位 begin marker 行的结尾与 end marker 行的开头。
   final beginLineEnd = content.indexOf('\n', beginIdx);
@@ -207,72 +248,274 @@ void writeIndex(List<BugEntry> entries) {
 void cmdReindex() {
   final entries = scanBugs();
   writeIndex(entries);
-  stdout.writeln('reindex 完成：${entries.length} 条 → $indexFile');
+  logOut('reindex 完成：${entries.length} 条 → $indexFile');
 }
 
 void cmdMigrate() {
   final file = File(indexFile);
   if (!file.existsSync()) {
-    stderr.writeln('错误：找不到 $indexFile');
-    exit(1);
+    throw BugToolError('找不到 $indexFile');
   }
   final (_, blocks) = splitMonolith(file.readAsStringSync());
   if (blocks.isEmpty) {
-    stderr.writeln('错误：$indexFile 里没有 `## BUG-NNN` 段落，无需迁移');
-    exit(1);
+    throw BugToolError('$indexFile 里没有 `## BUG-NNN` 段落，无需迁移');
   }
   Directory(bugsDir).createSync(recursive: true);
   final seen = <String>{};
   for (final block in blocks) {
     final parsed = parseHeading(block);
     if (parsed == null) {
-      stderr.writeln('警告：某段落无法解析 BUG-NNN，已跳过');
+      logWarn('警告：某段落无法解析 BUG-NNN，已跳过');
       continue;
     }
     final (_, pad, _) = parsed;
     if (!seen.add(pad)) {
-      stderr.writeln('警告：BUG-$pad 出现多次，后者覆盖前者');
+      logWarn('警告：BUG-$pad 出现多次，后者覆盖前者');
     }
     File('$bugsDir/BUG-$pad.md').writeAsStringSync(block);
   }
   // 重写 docs/BUGS.md = 新头部 + 空索引 marker，再 reindex 填充。
   file.writeAsStringSync('$headerTemplate\n---\n\n$beginMarker\n$endMarker\n');
   cmdReindex();
-  stdout.writeln('migrate 完成：${seen.length} 条已拆成 $bugsDir/BUG-*.md');
+  logOut('migrate 完成：${seen.length} 条已拆成 $bugsDir/BUG-*.md');
 }
 
-void cmdNew(List<String> args) {
-  if (args.isEmpty) {
-    stderr.writeln('用法：dart run tool/bug.dart new <slug> [标题...]');
-    stderr.writeln('  slug 是 ascii kebab（如 reader-internal-link），让并发新建落成不同文件名');
-    exit(1);
+// ---------------------------------------------------------------------------
+// git 薄封装
+// ---------------------------------------------------------------------------
+
+/// 跑 git；失败（git 不存在 / 超时）返回 null，不抛。
+/// stdout 按 latin1 解码：`cat-file --batch` 会吐二进制 tree，latin1 是无损字节映射，
+/// 我们只在里面正则找 ASCII 文件名；其它子命令输出是 ASCII 路径，同样安全。
+Future<ProcessResult?> runGit(
+  List<String> args, {
+  Duration timeout = const Duration(seconds: 30),
+  String? stdinData,
+}) async {
+  try {
+    final proc = await Process.start(
+      'git',
+      args,
+      environment: const <String, String>{'GIT_TERMINAL_PROMPT': '0'},
+    );
+    final out = StringBuffer();
+    final err = StringBuffer();
+    final outDone = proc.stdout.transform(latin1.decoder).forEach(out.write);
+    final errDone = proc.stderr.transform(latin1.decoder).forEach(err.write);
+    if (stdinData != null) {
+      proc.stdin.write(stdinData);
+    }
+    await proc.stdin.close().catchError((Object _) {});
+    var timedOut = false;
+    final code = await proc.exitCode.timeout(timeout, onTimeout: () {
+      timedOut = true;
+      proc.kill(ProcessSignal.sigkill);
+      return -1;
+    });
+    await outDone.catchError((Object _) {});
+    await errDone.catchError((Object _) {});
+    if (timedOut) return null;
+    return ProcessResult(proc.pid, code, out.toString(), err.toString());
+  } on ProcessException {
+    return null;
   }
-  final slug = _sanitizeSlug(args.first);
+}
+
+// ---------------------------------------------------------------------------
+// 跨分支号池扫描（防并发撞号）
+// ---------------------------------------------------------------------------
+
+/// 分支扫描的可信度。`fresh` = 已成功刷新远端；`stale` = 只用了本地缓存的
+/// remote-tracking 引用；`unavailable` = 完全没扫到（不在 git 仓库 / 没有引用）。
+enum BranchScanStatus { fresh, stale, unavailable }
+
+/// 跨分支扫描到的号池。
+class BranchScan {
+  BranchScan(this.status, this.numbers, this.detail, {this.refCount = 0});
+
+  final BranchScanStatus status;
+  final Set<int> numbers;
+
+  /// 降级/失败原因（`fresh` 时是空串）。
+  final String detail;
+  final int refCount;
+
+  int get maxNumber => numbers.isEmpty ? 0 : numbers.reduce(math.max);
+  bool get degraded => status != BranchScanStatus.fresh;
+
+  /// 降级时的显式警告文案——**绝不静默降级**，否则会让人误以为已经防住了。
+  String? get warning {
+    switch (status) {
+      case BranchScanStatus.fresh:
+        return null;
+      case BranchScanStatus.stale:
+        return '⚠ 警告：未能刷新远端分支（$detail）。'
+            '只用了本地分支 + 已缓存的 remote-tracking 引用（$refCount 个），'
+            '别人刚 push 的号看不见——取到的号可能与并发分支相撞。';
+      case BranchScanStatus.unavailable:
+        return '⚠ 警告：未能扫描远端分支（$detail）。'
+            '取号只看了本地工作区，**取到的号可能与并发分支相撞**；'
+            '联网后重跑 `dart run tool/bug.dart check` 复核。';
+    }
+  }
+}
+
+/// 只用本地工作区、没扫到任何分支时的结果（降级路径与测试共用）。
+BranchScan localOnlyScan(String reason) =>
+    BranchScan(BranchScanStatus.unavailable, <int>{}, reason);
+
+/// 扫「所有本地分支 + 远端分支」上 `docs/bugs/` 里的 BUG 号。
+///
+/// 为什么连本地分支一起扫：并发 agent 的 worktree 共用同一个 `.git`，它们的分支就是
+/// 本仓的 `refs/heads/*`——这是**不依赖网络**就能防住的大头。远端分支覆盖别人已 push 的号。
+///
+/// 性能：固定只起 4 个 git 进程（fetch / for-each-ref / cat-file --batch-check /
+/// cat-file --batch），与分支数无关。先用 `--batch-check` 把每个 `<ref>:docs/bugs`
+/// 折成 tree sha 去重，再只对少数唯一 tree 跑 `--batch`，避免吐几百份重复目录列表。
+/// 本仓 ~950 个引用时，非网络部分 < 1s；网络部分（fetch）有超时 + 降级。
+Future<BranchScan> scanBranchBugNumbers() async {
+  final env = Platform.environment;
+  final remote = env['HIBIKI_BUG_REMOTE'] ?? 'origin';
+  final skipRaw = env['HIBIKI_BUG_SKIP_REMOTE_FETCH'] ?? '';
+  final skipFetch = skipRaw.isNotEmpty && skipRaw != '0';
+  final timeoutSeconds = int.tryParse(env['HIBIKI_BUG_REMOTE_TIMEOUT'] ?? '') ?? 25;
+
+  final inRepo = await runGit(
+    <String>['rev-parse', '--is-inside-work-tree'],
+    timeout: const Duration(seconds: 10),
+  );
+  if (inRepo == null || inRepo.exitCode != 0) {
+    return localOnlyScan('不在 git 仓库里，或找不到 git 可执行文件');
+  }
+
+  var fetched = false;
+  var fetchNote = '';
+  if (skipFetch) {
+    fetchNote = 'HIBIKI_BUG_SKIP_REMOTE_FETCH 已设，主动跳过 fetch';
+  } else {
+    final fetch = await runGit(
+      <String>['fetch', '--quiet', remote, '+refs/heads/*:refs/remotes/$remote/*'],
+      timeout: Duration(seconds: timeoutSeconds),
+    );
+    fetched = fetch != null && fetch.exitCode == 0;
+    if (!fetched) {
+      fetchNote = fetch == null
+          ? 'git fetch $remote 超时（>${timeoutSeconds}s）或 git 不可用'
+          : 'git fetch $remote 失败：${firstLine(fetch.stderr as String)}';
+    }
+  }
+
+  final refsResult = await runGit(<String>[
+    'for-each-ref',
+    '--format=%(refname)',
+    'refs/heads',
+    'refs/remotes/$remote',
+  ]);
+  if (refsResult == null || refsResult.exitCode != 0) {
+    return localOnlyScan('git for-each-ref 失败');
+  }
+  final refs = (refsResult.stdout as String)
+      .split('\n')
+      .map((String l) => l.trim())
+      .where((String l) => l.isNotEmpty && !l.endsWith('/HEAD'))
+      .toList();
+  if (refs.isEmpty) {
+    return localOnlyScan('本地/远端都没有可扫的分支引用');
+  }
+
+  final numbers = await bugNumbersInTrees(refs);
+  if (numbers == null) {
+    return localOnlyScan('git cat-file 读分支树失败');
+  }
+  final status = fetched ? BranchScanStatus.fresh : BranchScanStatus.stale;
+  return BranchScan(status, numbers, fetchNote, refCount: refs.length);
+}
+
+/// 取多行文本的第一行（错误信息用）。
+String firstLine(String s) {
+  final t = s.trim();
+  if (t.isEmpty) return '（无输出）';
+  final i = t.indexOf('\n');
+  return i < 0 ? t : t.substring(0, i);
+}
+
+final RegExp _treeBugNameRe = RegExp(r'BUG-(\d+)');
+
+/// 对一批 ref 取 `<ref>:docs/bugs` 目录里的 BUG 号；git 出错返回 null。
+Future<Set<int>?> bugNumbersInTrees(List<String> refs) async {
+  final check = await runGit(
+    <String>['cat-file', '--batch-check'],
+    stdinData: refs.map((String r) => '$r:$bugsDir\n').join(),
+    timeout: const Duration(seconds: 60),
+  );
+  if (check == null || check.exitCode != 0) return null;
+  final treeShas = <String>{};
+  for (final line in (check.stdout as String).split('\n')) {
+    final parts = line.trim().split(' ');
+    // 命中格式：`<sha> tree <size>`；分支上没有该目录时是 `<input> missing`，跳过。
+    if (parts.length >= 2 && parts[1] == 'tree') treeShas.add(parts[0]);
+  }
+  if (treeShas.isEmpty) return <int>{};
+  final batch = await runGit(
+    <String>['cat-file', '--batch'],
+    stdinData: treeShas.map((String s) => '$s\n').join(),
+    timeout: const Duration(seconds: 60),
+  );
+  if (batch == null || batch.exitCode != 0) return null;
+  final numbers = <int>{};
+  for (final m in _treeBugNameRe.allMatches(batch.stdout as String)) {
+    final n = int.tryParse(m.group(1)!);
+    if (n != null) numbers.add(n);
+  }
+  return numbers;
+}
+
+// ---------------------------------------------------------------------------
+// new
+// ---------------------------------------------------------------------------
+
+/// 取号时的分支扫描器（测试注入假实现用）。
+typedef BranchScanner = Future<BranchScan> Function();
+
+Future<void> cmdNew(List<String> args, {BranchScanner? scanner}) async {
+  if (args.isEmpty) {
+    throw BugToolError('用法：dart run tool/bug.dart new <slug> [标题...]\n'
+        '  slug 是 ascii kebab（如 reader-internal-link），让并发新建落成不同文件名');
+  }
+  final slug = sanitizeSlug(args.first);
   if (slug.isEmpty) {
-    stderr.writeln('错误：slug 清洗后为空，请用 ascii 字母/数字/连字符');
-    exit(1);
+    throw BugToolError('slug 清洗后为空，请用 ascii 字母/数字/连字符');
   }
   final title = args.length > 1 ? args.sublist(1).join(' ') : slug;
   final entries = scanBugs();
-  final maxNum = entries.isEmpty ? 0 : entries.first.number;
-  final next = maxNum + 1;
-  final pad = next.toString().padLeft(3, '0');
+  final localMax = entries.isEmpty ? 0 : entries.first.number;
+
+  final scan = await (scanner ?? scanBranchBugNumbers)();
+  final warning = scan.warning;
+  if (warning != null) logWarn(warning);
+
+  final next = math.max(localMax, scan.maxNumber) + 1;
+  final pad = padNum(next);
   Directory(bugsDir).createSync(recursive: true);
   final path = '$bugsDir/BUG-$pad-$slug.md';
   if (File(path).existsSync()) {
-    stderr.writeln('错误：$path 已存在');
-    exit(1);
+    throw BugToolError('$path 已存在');
   }
   final now = DateTime.now();
   final dateIso =
       '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
   File(path).writeAsStringSync(bugSkeleton(pad, title, dateIso));
   cmdReindex();
-  stdout.writeln('已建 $path');
-  stdout.writeln('填完根因/修复/测试后再跑 `dart run tool/bug.dart reindex`');
+  final branchNote = scan.status == BranchScanStatus.unavailable
+      ? ''
+      : '，跨 ${scan.refCount} 个分支最大 ${padNum(scan.maxNumber)}';
+  logOut('取号：本地最大 ${padNum(localMax)}$branchNote → BUG-$pad');
+  logOut('已建 $path');
+  logOut('填完根因/修复/测试后再跑 `dart run tool/bug.dart reindex`');
 }
 
-String _sanitizeSlug(String s) {
+/// slug 清洗成 ascii kebab。
+String sanitizeSlug(String s) {
   final lower = s.toLowerCase();
   final buf = StringBuffer();
   for (final ch in lower.codeUnits) {
@@ -286,31 +529,361 @@ String _sanitizeSlug(String s) {
   return buf.toString().replaceAll(RegExp(r'-+'), '-').replaceAll(RegExp(r'^-|-$'), '');
 }
 
-/// 守卫：校验 per-file 不变式 + 索引是否与文件同步。返回非 0 表示有问题。
+// ---------------------------------------------------------------------------
+// renumber
+// ---------------------------------------------------------------------------
+
+/// 号引用的**唯一口径**：`BUG-1138` / `bug_1138` / `bug-1138`（允许前导 0；禁止数字粘连，
+/// 也不误伤 `debug-1138` 这种词尾）。替换、预览、自校验三处共用同一个正则，口径不会漂。
+RegExp bugRefPattern(int number) =>
+    RegExp('(?<![0-9A-Za-z])(BUG|Bug|bug)([-_])0*$number(?![0-9])');
+
+/// 一处待改的引用。
+class BugRefEdit {
+  BugRefEdit(this.path, this.line, this.before, this.after);
+
+  final String path;
+  final int line; // 1-based
+  final String before;
+  final String after;
+}
+
+/// 一次文件改名。
+class BugFileRename {
+  BugFileRename(this.from, this.to);
+
+  final String from;
+  final String to;
+}
+
+/// renumber 的完整计划（`--dry-run` 直接打印它）。
+class RenumberPlan {
+  RenumberPlan(this.oldNumber, this.newNumber, this.edits, this.renames);
+
+  final int oldNumber;
+  final int newNumber;
+  final List<BugRefEdit> edits;
+  final List<BugFileRename> renames;
+}
+
+/// 把 path 的**文件名部分**里的号换掉；文件名不含该号则返回 null。
+String? renameNumberInPath(String path, int oldNumber, int newNumber) {
+  final sepIdx = math.max(path.lastIndexOf('/'), path.lastIndexOf(r'\'));
+  final dir = sepIdx < 0 ? '' : path.substring(0, sepIdx + 1);
+  final base = path.substring(sepIdx + 1);
+  final re = bugRefPattern(oldNumber);
+  if (!re.hasMatch(base)) return null;
+  final pad = padNum(newNumber);
+  return dir + base.replaceAllMapped(re, (Match m) => '${m[1]}${m[2]}$pad');
+}
+
+/// 认得出的纯文本扩展名（二进制不读、不改）。
+const Set<String> textExtensions = <String>{
+  '.dart', '.md', '.yaml', '.yml', '.json', '.txt', '.ps1', '.sh', '.bat', '.cmd',
+  '.js', '.mjs', '.ts', '.html', '.css', '.kt', '.kts', '.java', '.cpp', '.cc',
+  '.h', '.hpp', '.mm', '.m', '.swift', '.gradle', '.xml', '.py', '.rb', '.go',
+  '.rs', '.toml', '.ini', '.cfg', '.properties', '.podspec', '.plist', '.pro',
+  '.patch', '.diff', '.sql', '.csv',
+};
+
+bool looksTextual(String path) {
+  final dot = path.lastIndexOf('.');
+  if (dot < 0) return false;
+  return textExtensions.contains(path.substring(dot).toLowerCase());
+}
+
+/// 取路径的文件名部分。
+String baseName(String path) {
+  final sepIdx = math.max(path.lastIndexOf('/'), path.lastIndexOf(r'\'));
+  return sepIdx < 0 ? path : path.substring(sepIdx + 1);
+}
+
+/// git 不可用时的兜底遍历要跳过的目录。
+const Set<String> skipDirs = <String>{
+  '.git', '.dart_tool', 'build', 'node_modules', '.worktrees', '.claude',
+  '.codex-test', 'Pods', '.gradle', '.idea',
+};
+
+List<String> walkFallback() {
+  final out = <String>[];
+  void walk(Directory dir, String prefix) {
+    for (final e in dir.listSync(followLinks: false)) {
+      final name = baseName(e.path);
+      final rel = prefix.isEmpty ? name : '$prefix/$name';
+      if (e is Directory) {
+        if (skipDirs.contains(name)) continue;
+        walk(e, rel);
+      } else if (e is File) {
+        out.add(rel);
+      }
+    }
+  }
+
+  walk(Directory.current, '');
+  return out;
+}
+
+/// 仓库里所有「可能引用 BUG 号」的文本文件路径：tracked + 未被 ignore 的 untracked
+/// （新建但还没 commit 的 bug 文件/测试也在内）+ 本地不入库的已知 bug 文档。
+/// git 不可用时退回目录遍历。
+Future<List<String>> repoScanPaths() async {
+  final paths = <String>{};
+  final tracked = await runGit(<String>['ls-files', '-z'], timeout: const Duration(seconds: 60));
+  final others = await runGit(
+    <String>['ls-files', '-z', '--others', '--exclude-standard'],
+    timeout: const Duration(seconds: 60),
+  );
+  if (tracked != null && tracked.exitCode == 0) {
+    for (final r in <ProcessResult?>[tracked, others]) {
+      if (r == null || r.exitCode != 0) continue;
+      paths.addAll(
+        (r.stdout as String).split('\u0000').where((String p) => p.isNotEmpty),
+      );
+    }
+  } else {
+    paths.addAll(walkFallback());
+  }
+  for (final extra in extraScanPaths) {
+    if (File(extra).existsSync()) paths.add(extra);
+  }
+  final list = paths.where(looksTextual).where((String p) => File(p).existsSync()).toList()
+    ..sort();
+  return list;
+}
+
+/// 扫出所有仍在引用 `number` 的位置（`path:line` 或 `path（文件名）`）。
+/// renumber 的自校验用这个，口径与替换完全一致（同一个 [bugRefPattern]）。
+/// 只看工作区文件——git 历史里的旧号是历史，不算残留。
+Future<List<String>> findResidualRefs(int number, {List<String>? paths}) async {
+  final files = paths ?? await repoScanPaths();
+  final re = bugRefPattern(number);
+  final hits = <String>[];
+  for (final p in files) {
+    final f = File(p);
+    if (!f.existsSync()) continue;
+    String content;
+    try {
+      content = f.readAsStringSync();
+    } on FileSystemException {
+      continue;
+    } on FormatException {
+      continue; // 非 UTF-8 文本（GBK 等），不可能是我们要改的 BUG 引用载体，跳过
+    }
+    if (re.hasMatch(content)) {
+      final lines = content.split('\n');
+      for (var i = 0; i < lines.length; i++) {
+        if (re.hasMatch(lines[i])) hits.add('$p:${i + 1}');
+      }
+    }
+    if (re.hasMatch(baseName(p))) hits.add('$p（文件名）');
+  }
+  return hits;
+}
+
+/// 组装 renumber 计划（不落盘）。
+Future<RenumberPlan> buildRenumberPlan(int oldNumber, int newNumber) async {
+  final paths = await repoScanPaths();
+  final re = bugRefPattern(oldNumber);
+  final newPad = padNum(newNumber);
+  final edits = <BugRefEdit>[];
+  final renames = <BugFileRename>[];
+  for (final p in paths) {
+    String content;
+    try {
+      content = File(p).readAsStringSync();
+    } on FileSystemException {
+      continue;
+    } on FormatException {
+      continue; // 非 UTF-8 文本（GBK 等），不可能是我们要改的 BUG 引用载体，跳过
+    }
+    if (re.hasMatch(content)) {
+      final lines = content.split('\n');
+      for (var i = 0; i < lines.length; i++) {
+        if (!re.hasMatch(lines[i])) continue;
+        edits.add(BugRefEdit(
+          p,
+          i + 1,
+          lines[i].trimRight(),
+          lines[i].replaceAllMapped(re, (Match m) => '${m[1]}${m[2]}$newPad').trimRight(),
+        ));
+      }
+    }
+    final renamed = renameNumberInPath(p, oldNumber, newNumber);
+    if (renamed != null && renamed != p) renames.add(BugFileRename(p, renamed));
+  }
+  return RenumberPlan(oldNumber, newNumber, edits, renames);
+}
+
+/// 找承载 `number` 的 bug 文件（正文 H2 或文件名任一命中即算——文件名与 H2 不一致
+/// 正是要修的坏状态）。返回相对仓库根的路径；找不到或多于一个都抛。
+String locateBugFile(int number) {
+  final dir = Directory(bugsDir);
+  if (!dir.existsSync()) throw BugToolError('找不到 $bugsDir 目录');
+  final matches = <String>[];
+  for (final f in dir.listSync().whereType<File>()) {
+    final name = baseName(f.path);
+    if (!name.endsWith('.md') || name.startsWith('_')) continue;
+    final byName = RegExp(r'^BUG-0*(\d+)').firstMatch(name);
+    final headingNum = parseHeading(f.readAsStringSync())?.$1;
+    final nameNum = byName == null ? null : int.tryParse(byName.group(1)!);
+    if (headingNum == number || nameNum == number) matches.add('$bugsDir/$name');
+  }
+  if (matches.isEmpty) throw BugToolError('BUG-${padNum(number)} 在 $bugsDir/ 里不存在');
+  if (matches.length > 1) {
+    throw BugToolError('BUG-${padNum(number)} 命中多个文件：${matches.join('、')}——先人工归并');
+  }
+  return matches.first;
+}
+
+String clipLine(String s) => s.length <= 160 ? s : '${s.substring(0, 157)}...';
+
+/// 优先 `git mv` 保留历史；文件还没入库（untracked）时 git mv 必失败，退回普通改名。
+Future<void> renameTracked(String from, String to) async {
+  final mv = await runGit(<String>['mv', from, to]);
+  if (mv != null && mv.exitCode == 0) return;
+  File(from).renameSync(to);
+}
+
+/// 改号：文件名 + 正文 H2 + 代码注释 + 测试名/测试文件名，四处一把改，
+/// 改完自动 reindex 并**自校验旧号零残留**。前置校验不通过就整体退出，不做半截修改。
+Future<void> cmdRenumber(List<String> args, {BranchScanner? scanner}) async {
+  final positional = args.where((String a) => !a.startsWith('--')).toList();
+  final dryRun = args.contains('--dry-run');
+  final unknown = args.where((String a) => a.startsWith('--') && a != '--dry-run').toList();
+  if (unknown.isNotEmpty) {
+    throw BugToolError('未知选项：${unknown.join(' ')}');
+  }
+  if (positional.length != 2) {
+    throw BugToolError('用法：dart run tool/bug.dart renumber <old> <new> [--dry-run]');
+  }
+  if (!RegExp(r'^\d+$').hasMatch(positional[0]) || !RegExp(r'^\d+$').hasMatch(positional[1])) {
+    throw BugToolError('<old> 与 <new> 必须是纯数字（拿到 ${positional[0]} / ${positional[1]}）');
+  }
+  final oldNumber = int.parse(positional[0]);
+  final newNumber = int.parse(positional[1]);
+  if (oldNumber <= 0 || newNumber <= 0) {
+    throw BugToolError('<old> 与 <new> 必须是正整数');
+  }
+  if (oldNumber == newNumber) {
+    throw BugToolError('<old> 与 <new> 相同（${padNum(oldNumber)}），无事可做');
+  }
+
+  // —— 前置校验：old 必须存在；new 必须没被占用（本地 + 跨分支同一口径）。
+  final oldPath = locateBugFile(oldNumber);
+  final localNumbers = scanBugs().map((BugEntry e) => e.number).toSet();
+  final localNames = Directory(bugsDir)
+      .listSync()
+      .whereType<File>()
+      .map((File f) => baseName(f.path))
+      .where((String n) => n.endsWith('.md') && !n.startsWith('_'));
+  for (final n in localNames) {
+    final m = RegExp(r'^BUG-0*(\d+)').firstMatch(n);
+    final parsed = m == null ? null : int.tryParse(m.group(1)!);
+    if (parsed != null) localNumbers.add(parsed);
+  }
+  if (localNumbers.contains(newNumber)) {
+    throw BugToolError('BUG-${padNum(newNumber)} 本地已被占用（${locateBugFile(newNumber)}）——换一个号');
+  }
+  final scan = await (scanner ?? scanBranchBugNumbers)();
+  final warning = scan.warning;
+  if (warning != null) logWarn(warning);
+  if (scan.numbers.contains(newNumber)) {
+    throw BugToolError('BUG-${padNum(newNumber)} 已被其它分支占用'
+        '（跨 ${scan.refCount} 个本地/远端分支扫描）——换一个号；'
+        '当前跨分支最大号是 ${padNum(scan.maxNumber)}');
+  }
+
+  final plan = await buildRenumberPlan(oldNumber, newNumber);
+  for (final r in plan.renames) {
+    if (File(r.to).existsSync()) {
+      throw BugToolError('目标文件已存在：${r.to}——换一个号');
+    }
+  }
+  if (plan.edits.isEmpty && plan.renames.isEmpty) {
+    throw BugToolError('没扫到任何 BUG-${padNum(oldNumber)} 引用（$oldPath 也没匹配？）——中止');
+  }
+
+  if (dryRun) {
+    logOut('[dry-run] BUG-${padNum(oldNumber)} → BUG-${padNum(newNumber)}：'
+        '${plan.edits.length} 处引用 / ${plan.renames.length} 个文件改名（未落盘）');
+    for (final r in plan.renames) {
+      logOut('  改名   ${r.from}  →  ${r.to}');
+    }
+    for (final e in plan.edits) {
+      logOut('  改内容 ${e.path}:${e.line}');
+      logOut('    -${clipLine(e.before)}');
+      logOut('    +${clipLine(e.after)}');
+    }
+    logOut('[dry-run] 未写任何文件；去掉 --dry-run 才真正执行');
+    return;
+  }
+
+  // —— 落盘：先改内容，再改名（改名后路径变了，内容已改完不受影响）。
+  final re = bugRefPattern(oldNumber);
+  final newPad = padNum(newNumber);
+  final touched = plan.edits.map((BugRefEdit e) => e.path).toSet();
+  for (final path in touched) {
+    final f = File(path);
+    final content = f.readAsStringSync();
+    f.writeAsStringSync(content.replaceAllMapped(re, (Match m) => '${m[1]}${m[2]}$newPad'));
+  }
+  for (final r in plan.renames) {
+    await renameTracked(r.from, r.to);
+  }
+
+  cmdReindex();
+
+  // —— 自校验：同口径重扫，确认旧号在工作区零残留。
+  final residual = await findResidualRefs(oldNumber);
+  if (residual.isNotEmpty) {
+    throw BugToolError('改号后仍有 BUG-${padNum(oldNumber)} 残留，请人工处理：\n  '
+        '${residual.join('\n  ')}');
+  }
+  logOut('renumber 完成：BUG-${padNum(oldNumber)} → BUG-${padNum(newNumber)}'
+      '（${plan.edits.length} 处引用 / ${plan.renames.length} 个文件改名，自校验零残留）');
+  for (final r in plan.renames) {
+    logOut('  ${r.from} → ${r.to}');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// check
+// ---------------------------------------------------------------------------
+
+/// 守卫：校验 per-file 不变式 + 索引是否同步。返回非 0 表示有问题。
 int cmdCheck() {
   var ok = true;
   // 1) docs/BUGS.md 不应再含任何 `## BUG-` 标题（全部已 per-file）。
   final indexContent = File(indexFile).readAsStringSync();
   if (RegExp(r'^##\s+BUG-\d+', multiLine: true).hasMatch(indexContent)) {
-    stderr.writeln('✗ $indexFile 仍含 `## BUG-NNN` 标题——应只放索引表，正文须在 $bugsDir/');
+    logWarn('✗ $indexFile 仍含 `## BUG-NNN` 标题——应只放索引表，正文须在 $bugsDir/');
     ok = false;
   }
-  // 2) 每个文件可解析，号唯一。
+  // 2) 每个文件可解析、号唯一，且文件名的号与正文 H2 的号一致
+  //    （只改文件名不改 H2 出过 CI 红；`renumber` 会一起改，别手改）。
   final entries = scanBugs();
   final byNum = <int, String>{};
   for (final e in entries) {
     final prev = byNum[e.number];
     if (prev != null) {
-      stderr.writeln('✗ 号撞了：BUG-${e.paddedNum} 出现在 $prev 与 ${e.fileName}（改名其一）');
+      logWarn('✗ 号撞了：BUG-${e.paddedNum} 出现在 $prev 与 ${e.fileName}'
+          '（跑 `dart run tool/bug.dart renumber <old> <new>` 改号）');
       ok = false;
     }
     byNum[e.number] = e.fileName;
+    final nameMatch = RegExp(r'^BUG-0*(\d+)').firstMatch(e.fileName);
+    final nameNum = nameMatch == null ? null : int.tryParse(nameMatch.group(1)!);
+    if (nameNum != null && nameNum != e.number) {
+      logWarn('✗ ${e.fileName} 文件名是 BUG-${padNum(nameNum)} 但正文 H2 是 BUG-${e.paddedNum}'
+          '——两者必须一致（`renumber` 会同步改）');
+      ok = false;
+    }
   }
   // 3) 索引是否同步（reindex 应为 no-op）。
   final beginIdx = indexContent.indexOf('BUGS-INDEX:BEGIN');
   final endIdx = indexContent.indexOf('BUGS-INDEX:END');
   if (beginIdx < 0 || endIdx < 0) {
-    stderr.writeln('✗ $indexFile 缺少索引 marker');
+    logWarn('✗ $indexFile 缺少索引 marker');
     ok = false;
   } else {
     final beginLineEnd = indexContent.indexOf('\n', beginIdx);
@@ -318,33 +891,50 @@ int cmdCheck() {
     final current = indexContent.substring(beginLineEnd + 1, endLineStart).trim();
     final expected = buildIndexTable(entries).trim();
     if (current != expected) {
-      stderr.writeln('✗ 索引与 $bugsDir/ 不同步——跑 `dart run tool/bug.dart reindex`');
+      logWarn('✗ 索引与 $bugsDir/ 不同步——跑 `dart run tool/bug.dart reindex`');
       ok = false;
     }
   }
   if (ok) {
-    stdout.writeln('check 通过：${entries.length} 条，号唯一，索引同步');
+    logOut('check 通过：${entries.length} 条，号唯一，索引同步');
     return 0;
   }
   return 1;
 }
 
-void main(List<String> args) {
+const String usage = '用法：dart run tool/bug.dart <new|renumber|reindex|migrate|check> ...\n'
+    '  new <slug> [标题...]                 新建（跨本地+远端分支取下一个空号）\n'
+    '  renumber <old> <new> [--dry-run]     改号（文件名 + 正文 H2 + 代码/测试引用 + reindex + 自校验）\n'
+    '  reindex                              重建 docs/BUGS.md 索引\n'
+    '  migrate                              一次性：旧单文件拆 per-file\n'
+    '  check                                守卫：号唯一 / 文件名与 H2 一致 / 索引同步\n'
+    '\n'
+    '注意：取号会扫所有本地分支 + 远端分支，但这**不是**分布式锁——两个 agent 同一秒取号\n'
+    '仍可能撞（TOCTOU）；网络不通时会显式警告并降级。开 PR 前和每次 rebase 后重跑 check。';
+
+Future<void> main(List<String> args) async {
   if (args.isEmpty) {
-    stderr.writeln('用法：dart run tool/bug.dart <new|reindex|migrate|check> ...');
+    logWarn(usage);
     exit(2);
   }
-  switch (args.first) {
-    case 'new':
-      cmdNew(args.sublist(1));
-    case 'reindex':
-      cmdReindex();
-    case 'migrate':
-      cmdMigrate();
-    case 'check':
-      exit(cmdCheck());
-    default:
-      stderr.writeln('未知子命令：${args.first}');
-      exit(2);
+  try {
+    switch (args.first) {
+      case 'new':
+        await cmdNew(args.sublist(1));
+      case 'renumber':
+        await cmdRenumber(args.sublist(1));
+      case 'reindex':
+        cmdReindex();
+      case 'migrate':
+        cmdMigrate();
+      case 'check':
+        exit(cmdCheck());
+      default:
+        logWarn('未知子命令：${args.first}\n$usage');
+        exit(2);
+    }
+  } on BugToolError catch (e) {
+    logWarn('错误：${e.message}');
+    exit(1);
   }
 }


### PR DESCRIPTION
## 问题（真实发生过）

一天内连撞两轮、涉及四个 PR：#461（`BUG-1138-cross-chapter-turn-latency`）与 #462（`BUG-1138-overlay-ctrl-wheel-zoom`）抢 1138；#463（`BUG-1138-gal-clipboard-overlay-ruby-markup`）也是 1138，#464（`BUG-1139-download-discovery-timeout-too-short`）与 #462 改号后的 1139 相撞。

根因：`bug.dart new` 取号只扫本地工作区/develop，而并发 agent 各自在独立 worktree 的独立分支上开工，**彼此的分支互不可见**，都算出同一个「下一个空号」。

## ① `renumber <old> <new> [--dry-run]`

把改号从「人工改四处 + 容易漏」降成一条命令：

- **四处同步改**：文件名（`git mv` 保历史；untracked 退回 `File.rename`）、正文 H2、代码/文档引用、测试名与测试文件名。
- **单一正则口径** `(?<![0-9A-Za-z])(BUG|Bug|bug)([-_])0*N(?![0-9])`：认 `BUG-005`/`bug_005`/`bug-005`，不误伤 `debug-005`/`BUG-0055`/`BUG-50`。替换、预览、自校验三处共用，口径不会漂。
- **前置校验**：`<old>` 必须存在、`<new>` 本地与跨分支口径都未占用、两者纯数字正整数 —— 任一不过整体退出，不做半截修改。
- **改完自动 reindex**（复用现成 `cmdReindex`，没另写一份），再**自校验旧号零残留**，有残留报 `path:line` 并抛错。
- **`--dry-run`** 打印每个改名与每处 `path:line` 的 `-旧/+新`，零字节落盘。

扫描范围 = `git ls-files` + `git ls-files --others --exclude-standard`（覆盖还没 commit 的新文件）+ `docs/REGRESSION_BUGS.md`；git 不可用时退回目录遍历。

只改文件名不改正文 H2 出过 CI 红（守卫 `bugs_per_file_guard_test` 按 H2 判重号），这条命令正是消掉那个手工缺口；`check` 也补了「文件名的号与正文 H2 的号必须一致」断言。

## ② `new` 取号扫全部分支

`scanBranchBugNumbers()` 扫 **所有本地分支 `refs/heads/*` + 远端 `refs/remotes/origin/*`**，取全局最大 +1。

连本地分支一起扫是关键：并发 agent 的 worktree 共用同一个 `.git`，它们的分支就是本仓 local ref —— 这半**完全不依赖网络**。

实现固定 4 个 git 进程，与分支数无关：`fetch` → `for-each-ref` → `cat-file --batch-check`（把每个 `<ref>:docs/bugs` 折成 tree sha 去重）→ `cat-file --batch`（只读少数唯一 tree）。

本仓实测（949 个引用）：

| 场景 | 耗时 |
|---|---|
| 带 fetch | 4.0s |
| `HIBIKI_BUG_SKIP_REMOTE_FETCH=1`（不联网） | 1.04s |

扫出的跨分支最大号是 **1141**，而本地 develop 只有 1137 —— 立刻证明已有 4 个号被未合并分支占用。

**网络不可用显式警告，绝不静默降级**（静默降级会让人误以为已经防住了）：

- `fresh`（fetch 成功）→ 无警告
- `stale`（fetch 失败/被跳过但有缓存 remote-tracking）→ `⚠ 警告：未能刷新远端分支（原因）…取到的号可能与并发分支相撞`
- `unavailable`（不在 git 仓库/无引用）→ `⚠ 警告：未能扫描远端分支（原因）…**取到的号可能与并发分支相撞**`

## 残留风险（如实写明，未宣称彻底解决）

TOCTOU：两个 agent 同一秒各自取号、都还没 commit/push 时谁也看不见谁，仍会撞。这条写在 `tool/bug.dart` 文件头注释、`usage` 帮助文本、`docs/BUGS.md` 头部三处，并提示开 PR 前和每次 rebase 后重跑 `check`。

## 测试

新增 `hibiki/test/tools/bug_tool_number_pool_test.dart`，14 条，全部用**临时目录里的真 git 仓库** fixture（remote 是本地路径的 bare repo，不依赖网络），不碰仓库里任何真实 `docs/bugs/BUG-*.md`：

- renumber：四处齐全 + git 记为 R(改名) + `check` 通过；自校验红→绿；目标号本地占用报错且零改动；目标号被其它分支占用报错；`<old>` 不存在；非纯数字；`--dry-run` 零落盘；untracked 文件走 rename 兜底
- 正则口径：认 3 形、不误伤 4 形；`renameNumberInPath` 只动文件名
- new：**clone 之后别人才 push 的号也扫得到**（真 fetch，取 021 而非 004）且无警告；远端不可达 → stale 警告含「可能与并发分支相撞」；完全不在 git 仓库 → unavailable 警告；桩扫描器取全局最大 +1

## 验证

- `flutter analyze`（hibiki/ 全量含 test）：**No issues found!**
- 全量 `flutter test --no-pub`：**14754 通过 / 9 skip / 1 失败**。唯一失败是 `test/sync/hibiki_library_host_service_books_test.dart` 的 `exportBook 产出非空 .epub 文件`，报 `PathAccessException: Deletion failed ... 另一个程序正在使用此文件`（Windows tearDown 临时目录文件锁），**单跑该文件 26/26 全绿** —— 全量并发下的既有 Windows flake，与本 PR 无关（本 PR 只动 `tool/bug.dart` + 新测试文件 + 两处文档）。
- `dart run tool/bug.dart check` 在真仓库：`check 通过：1104 条，号唯一，索引同步`
- 真仓库 `renumber 1137 1500 --dry-run`：6.7s 扫出 17 处引用 + 1 个改名，零落盘

