### PR TITLE
perf(reader): 跨章遮罩时长 849ms→101ms（插图解码转入章内异步）+ 迟到图片语义重锚（BUG-1140 第二轮）

### DIFF
--- a/docs/bugs/BUG-1140-cross-chapter-turn-latency.md
+++ b/docs/bugs/BUG-1140-cross-chapter-turn-latency.md
@@ -87,6 +87,44 @@ before / after 两轮均在无并发负载下跑。`xchapter-rebased`（rebase �
 **没有删**的守卫（查证后确认不是无用）：TODO-1229 那套跨章冷却窗 / 在飞守卫对应用户复诉三次的「跳两章」；
 `[xchapter]` 系列诊断埋点被 `test/reader/diagnostic_logging_guard_test.dart` 明确钉住（跨章 bug 的取证来源）。
 
+### 追加一轮：带插图的章（用户复诉「体感至少 0.5s」）
+
+**首轮测量的盲区**：合成 fixture 的「图片章」用的是内联 SVG，解码几乎免费，于是 `js.images` 恒为
+0ms、`docLoad` 也测不到图片这一段——101ms 只代表纯文本章。用户指出带图跨章体感远不止这个数。
+
+补了真实体量的素材（`integration_test/helpers/generate_test_image.dart` 生成 1600×2400 RGB PNG，
+渐变叠低频噪声：像素数决定解码成本、噪声决定压缩后体积），`EpubGenerator(withRealImages: true)`
+追加两章——纯整页插图章（3 张）与图文混排章（4 张）。实测（18 次跨章）：
+
+| 章 | 原始 | 修复后 |
+|---|---|---|
+| 图文混排章 首次（4 张插图） | **849ms**（docLoad 717ms） | **101ms**（docLoad 29ms） |
+| 纯整页插图章 首次（3 张插图） | **879ms**（docLoad 689ms） | 355~541ms（不稳定，见下） |
+| total 中位数 | 184ms | **132ms** |
+
+**根因**：`nav.dcl` 只有 15~20ms 而 `nav.load` 687~717ms——DOM 早就解析完了，剩下 670ms 全是在等
+图片读盘+解码，而遮罩正好盖住这整段（setup 脚本挂在 `window.load` 之后才注入）。
+
+`initialize` 里 TODO-1074 那段本来就想给每张 `<img>` 挂 `loading="lazy"`，理由写的正是「不再拖住
+window.load」——**但它跑得太晚**：脚本在 `load` 之后注入，浏览器早已按标签原始属性把整章图片
+（含离屏的）全部加载完毕。那行 lazy 迟到了一整个加载周期，只是给一笔已经付掉的账贴标签。
+
+**修复**：
+1. `ReaderResourceSanitizer.markImagesLazy` —— 把 lazy/decoding 的判定上移到 **Dart 生成 HTML 时**
+   写进标签，属性才对本次加载生效。保持 eager 的例外与 JS 侧同款且更保守（这里 eager 的集合是
+   JS 侧的超集，不会出现「Dart 挂 lazy 而 JS 想 eager」的倒挂）：纯图片章整章 eager（分页几何要靠
+   插图真实撑开，TODO-1349）、`gaiji` 内联小图 eager、原书已写 `loading=` 的尊重原值。
+2. `_prefetchAdjacentChapterImages` —— 跨章落地后用隐藏 `new Image()` 把下一章插图按同样 URL 请求
+   一遍，走同一个拦截器与同一份缓存条目（图片响应本就带 `max-age=3600`）。**位置很关键**：必须挂在
+   遮罩撤除之后的收尾块；第一版挂在 `_onChapterLoadComplete`（遮罩之前），parse 整章 HTML +
+   读几张大 PNG 全压在热路径上，实测把 `jsInitRestore` 顶到 520ms、`overlayGone` 顶到 312ms——
+   成本只是换了个口袋。挪到遮罩后即回落到 36ms / 69ms。
+
+**未解决 / 如实说明**：纯整页插图章仍要 355~541ms 且不稳定。它按设计不能挂 lazy（分页几何依赖插图
+真实尺寸），只能靠预热覆盖，而预热是否命中取决于用户在上一章停留多久、以及 WebView 缓存是否保留
+（实测同章二次进入有时 109ms 命中、有时 330ms 未命中，样本内不稳定）。要根治仍得让 setup 脚本不等
+`window.load`（见下「仍未做」第一项）——那样图片解码与恢复可以并行，而不是串行等完再开始。
+
 ### 仍未做（下一步，风险与收益都更大）
 
 - `evalSetupScript` 剩余 ~24ms 是**每次跨章重新编译整份引擎 JS**：`evaluateJavascript` 的字符串没有 V8 code

--- a/docs/bugs/BUG-1140-cross-chapter-turn-latency.md
+++ b/docs/bugs/BUG-1140-cross-chapter-turn-latency.md
@@ -94,13 +94,20 @@ before / after 两轮均在无并发负载下跑。`xchapter-rebased`（rebase �
 
 补了真实体量的素材（`integration_test/helpers/generate_test_image.dart` 生成 1600×2400 RGB PNG，
 渐变叠低频噪声：像素数决定解码成本、噪声决定压缩后体积），`EpubGenerator(withRealImages: true)`
-追加两章——纯整页插图章（3 张）与图文混排章（4 张）。实测（18 次跨章）：
+追加两章——纯整页插图章（3 张）与图文混排章（4 张）。实测（Windows 离屏 itest、debug build、
+同机同书、18 次跨章的单点值，非中位数）：
 
-| 章 | 原始 | 修复后 |
+| 章 | 原始 | 改后 |
 |---|---|---|
-| 图文混排章 首次（4 张插图） | **849ms**（docLoad 717ms） | **101ms**（docLoad 29ms） |
-| 纯整页插图章 首次（3 张插图） | **879ms**（docLoad 689ms） | 355~541ms（不稳定，见下） |
+| 图文混排章 首次（4 张插图）**遮罩时长** | **849ms**（docLoad 717ms） | **101ms**（docLoad 29ms） |
+| 纯整页插图章 首次（3 张插图）**遮罩时长** | **879ms**（docLoad 689ms） | 355~541ms（不稳定，见下） |
 | total 中位数 | 184ms | **132ms** |
+
+**这个数字的性质必须说清楚，别当成 8 倍加速**：849→101ms 量的是「遮罩出现到撤除」，而本轮
+修复的本质是**把插图解码从遮罩之前挪到遮罩之后**——总的读盘+解码工作量一点没少，只是不再
+串在「新章可见」的关键路径上。用户拿到的是「翻页立刻见到文字」，插图在章内异步补上；
+不是「机器少干了 8 倍的活」。诚实的表述是：**跨章遮罩时长 849→101ms（插图解码转入章内异步）**。
+`total 中位数 184→132ms` 才是覆盖全部章型的整体口径，收益远没有标题数字那么夸张。
 
 **根因**：`nav.dcl` 只有 15~20ms 而 `nav.load` 687~717ms——DOM 早就解析完了，剩下 670ms 全是在等
 图片读盘+解码，而遮罩正好盖住这整段（setup 脚本挂在 `window.load` 之后才注入）。
@@ -114,16 +121,39 @@ window.load」——**但它跑得太晚**：脚本在 `load` 之后注入，浏
    写进标签，属性才对本次加载生效。保持 eager 的例外与 JS 侧同款且更保守（这里 eager 的集合是
    JS 侧的超集，不会出现「Dart 挂 lazy 而 JS 想 eager」的倒挂）：纯图片章整章 eager（分页几何要靠
    插图真实撑开，TODO-1349）、`gaiji` 内联小图 eager、原书已写 `loading=` 的尊重原值。
-2. `_prefetchAdjacentChapterImages` —— 跨章落地后用隐藏 `new Image()` 把下一章插图按同样 URL 请求
-   一遍，走同一个拦截器与同一份缓存条目（图片响应本就带 `max-age=3600`）。**位置很关键**：必须挂在
-   遮罩撤除之后的收尾块；第一版挂在 `_onChapterLoadComplete`（遮罩之前），parse 整章 HTML +
-   读几张大 PNG 全压在热路径上，实测把 `jsInitRestore` 顶到 520ms、`overlayGone` 顶到 312ms——
-   成本只是换了个口袋。挪到遮罩后即回落到 36ms / 69ms。
+2. `_prefetchAdjacentChapterImages` —— 跨章落地后用隐藏 `new Image()` 把**阅读方向上**下一章的
+   插图按同样 URL 请求一遍，走同一个拦截器与同一份缓存条目（图片响应本就带 `max-age=3600`）。
+   **位置很关键**：必须挂在遮罩撤除之后的收尾块；第一版挂在 `_onChapterLoadComplete`（遮罩之前），
+   parse 整章 HTML + 读几张大 PNG 全压在热路径上，实测把 `jsInitRestore` 顶到 520ms、
+   `overlayGone` 顶到 312ms——成本只是换了个口袋。挪到遮罩后即回落到 36ms / 69ms。
+   预热带**配额**（`_kImagePrefetchMaxCount` 4 张 / `_kImagePrefetchMaxBytes` 8MB，按磁盘字节计），
+   方向由 `_beginNavigation` 采样（倒着读时预热上一章，而不是刚离开的那一章）。
+3. **迟到图片的语义重锚**（`reader_pagination_scripts.dart` `registerImageLateAnchor` /
+   `reapplyImageLateAnchor`）—— 第 1 条把「插图未 decode」变成了恢复时刻的**常态**，于是恢复
+   把语义锚（char / progress / fragment）换算成 scrollTop 时用的是「插图 0×0」的塌缩布局；
+   插图随后 load、几何后移，冻结的 scrollTop 指向别的内容，进度轮询还会把这个漂掉的读数落库。
+   原有的 `__imgReanchorProgress` 只覆盖章首(0)/章末(≥0.99) 两个粗粒度分支，中段 progress 与
+   精确字符锚**完全裸奔**。现在三种锚全部登记，图片 load 后按同一个语义锚重算落点——终态与
+   「插图本来就在」等价；重锚走既有 `onReaderScroll` 通道把**修正后**的位置落库。
+   用户翻页（`paginate`）清资格，不把已翻走的位置拽回。
+4. 合并前导插图（TODO-1339）的 eager 改成**显式** `loading="eager"` 属性，不再依赖
+   `markImagesLazy` 与 `_injectMergedChapterImages` 的调用顺序。
 
 **未解决 / 如实说明**：纯整页插图章仍要 355~541ms 且不稳定。它按设计不能挂 lazy（分页几何依赖插图
 真实尺寸），只能靠预热覆盖，而预热是否命中取决于用户在上一章停留多久、以及 WebView 缓存是否保留
 （实测同章二次进入有时 109ms 命中、有时 330ms 未命中，样本内不稳定）。要根治仍得让 setup 脚本不等
 `window.load`（见下「仍未做」第一项）——那样图片解码与恢复可以并行，而不是串行等完再开始。
+
+图文混排章的 101ms **是否依赖预热命中**同样没有单独拆开量：itest 里每次跨章后停留 1500ms
+（判据是 settle 尾沿 + 450ms 跨章冷却窗，不是「等预热跑完」），快速连翻 / 目录跳转时预热必然
+不命中，那种情况下的数字未单独测量。**不要**把 itest 的等待时长调长去凑一个更好看的稳态数字。
+
+守卫：`test/reader/chapter_jump_late_load_reanchor_test.dart`（三种语义锚都登记 + 翻页清资格 +
+load 回调分派顺序）、`test/reader/reader_image_lazy_pipeline_guard_test.dart`（Dart 侧 lazy 流水线
+——既有三条图片守卫全是扫 JS 源码的，管不到 Dart 侧这份判定）、
+`test/reader/reader_image_lazy_markup_test.dart`（`markImagesLazy` 字符串改写）。
+行为端：`integration_test/reader_cross_chapter_perf_itest.dart` 的「中段落点回归」用例
+（真实退出重进 → 图文混排插图章中段锚 → 重进落点偏差必须在一页之内）。
 
 ### 仍未做（下一步，风险与收益都更大）
 

--- a/hibiki/integration_test/helpers/generate_test_epub.dart
+++ b/hibiki/integration_test/helpers/generate_test_epub.dart
@@ -12,6 +12,8 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'generate_test_image.dart';
+
 // Minimal ZIP implementation for EPUB generation (no external deps).
 
 void main() {
@@ -24,7 +26,29 @@ void main() {
 }
 
 class EpubGenerator {
+  /// [withRealImages] = true 时额外生成两章带**真实体量**插图的章节（1600×2400 PNG，
+  /// 见 [TestImageGenerator]）：一章纯整页插图（走 eager 路径），一章图文混排（走
+  /// lazy 路径）。默认 false —— 既有测试的书一字不变。
+  const EpubGenerator({this.withRealImages = false});
+
+  final bool withRealImages;
+
   static const int standardChapterMarkerCount = 420;
+
+  /// 真实插图章的文件名（spine 顺序在最后两章）。
+  static const List<String> realImageChapters = <String>[
+    'chapter_09_photo_only',
+    'chapter_10_photo_text',
+  ];
+
+  static const List<String> realImageTitles = <String>[
+    '第九章　実寸挿絵のみ',
+    '第十章　実寸挿絵と本文',
+  ];
+
+  /// 纯插图章的图片张数 / 图文混排章的图片张数。
+  static const int photoOnlyCount = 3;
+  static const int photoTextCount = 4;
 
   static const _lookupLead = 'testword 猫 testword 猫 testword 猫。';
 
@@ -98,6 +122,31 @@ class EpubGenerator {
     // exact DOM shape where base chars live in <rb> and furigana in <rtc><rt>.
     files['OEBPS/chapter_08_monoruby.xhtml'] =
         _utf8(_buildChapter('第八章　連番振り仮名テスト', _generateWithMonoRuby(120)));
+
+    if (withRealImages) {
+      const TestImageGenerator gen = TestImageGenerator();
+      int seed = 1;
+      final StringBuffer photoOnly = StringBuffer();
+      for (int i = 1; i <= photoOnlyCount; i++) {
+        files['OEBPS/images/photo_$i.png'] = gen.pngBytes(seed: seed++);
+        photoOnly
+            .writeln('  <div class="illust"><img src="images/photo_$i.png" '
+                'alt="挿絵$i"/></div>');
+      }
+      files['OEBPS/chapter_09_photo_only.xhtml'] =
+          _utf8(_buildChapter(realImageTitles[0], photoOnly.toString()));
+
+      final StringBuffer photoText = StringBuffer();
+      for (int i = 1; i <= photoTextCount; i++) {
+        files['OEBPS/images/inline_$i.png'] = gen.pngBytes(seed: seed++);
+        photoText
+            .writeln('  <div class="illust"><img src="images/inline_$i.png" '
+                'alt="挿絵$i"/></div>');
+        photoText.write(_generateStandard(25));
+      }
+      files['OEBPS/chapter_10_photo_text.xhtml'] =
+          _utf8(_buildChapter(realImageTitles[1], photoText.toString()));
+    }
 
     return _buildZip(files);
   }
@@ -267,21 +316,35 @@ $body
 </html>''';
   }
 
+  List<String> get _chapterFiles => <String>[
+        'chapter_01_standard',
+        'chapter_02_short',
+        'chapter_03_images',
+        'chapter_04_ruby',
+        'chapter_05_vertical',
+        'chapter_06_mixed',
+        'chapter_07_long',
+        'chapter_08_monoruby',
+        if (withRealImages) ...realImageChapters,
+      ];
+
   String _buildOpf() {
-    final chapters = [
-      'chapter_01_standard',
-      'chapter_02_short',
-      'chapter_03_images',
-      'chapter_04_ruby',
-      'chapter_05_vertical',
-      'chapter_06_mixed',
-      'chapter_07_long',
-      'chapter_08_monoruby',
+    final chapters = _chapterFiles;
+    final List<String> imageItems = <String>[
+      if (withRealImages)
+        for (int i = 1; i <= photoOnlyCount; i++)
+          '    <item id="photo_$i" href="images/photo_$i.png" '
+              'media-type="image/png"/>',
+      if (withRealImages)
+        for (int i = 1; i <= photoTextCount; i++)
+          '    <item id="inline_$i" href="images/inline_$i.png" '
+              'media-type="image/png"/>',
     ];
-    final items = chapters
-        .map((c) => '    <item id="$c" href="$c.xhtml" '
-            'media-type="application/xhtml+xml"/>')
-        .join('\n');
+    final items = <String>[
+      ...chapters.map((c) => '    <item id="$c" href="$c.xhtml" '
+          'media-type="application/xhtml+xml"/>'),
+      ...imageItems,
+    ].join('\n');
     final refs = chapters.map((c) => '    <itemref idref="$c"/>').join('\n');
     return '''<?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
@@ -313,17 +376,9 @@ $refs
       '第六章　混合要素テスト',
       '第七章　長文テスト',
       '第八章　連番振り仮名テスト',
+      if (withRealImages) ...realImageTitles,
     ];
-    final files = [
-      'chapter_01_standard',
-      'chapter_02_short',
-      'chapter_03_images',
-      'chapter_04_ruby',
-      'chapter_05_vertical',
-      'chapter_06_mixed',
-      'chapter_07_long',
-      'chapter_08_monoruby',
-    ];
+    final files = _chapterFiles;
     final points = StringBuffer();
     for (int i = 0; i < titles.length; i++) {
       points.writeln('''    <navPoint id="nav${i + 1}" playOrder="${i + 1}">

--- a/hibiki/integration_test/helpers/generate_test_image.dart
+++ b/hibiki/integration_test/helpers/generate_test_image.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+/// 生成**真实体量**的 PNG，用于让性能测试面对与真实书插图同量级的读盘 + 解码成本。
+///
+/// 合成 EPUB 此前的「图片章」用的是内联 SVG——解码几乎免费，于是跨章计时里
+/// `docLoad` 完全测不到图片这一段，跟真实书（整页插图 1600×2400、几百 KB~MB 级）
+/// 差了一个数量级。这里按坐标生成渐变叠低频噪声的 RGB 像素：像素数决定解码成本、
+/// 噪声决定压缩后体积，两者都能落到真实插图的量级。
+class TestImageGenerator {
+  const TestImageGenerator();
+
+  /// 生成 [width]×[height] 的 RGB PNG 字节。[seed] 改变噪声花纹，让同一本书里的
+  /// 多张插图字节不同（避免 WebView 按同一 URL/内容走缓存而测不到真实成本）。
+  Uint8List pngBytes({
+    int width = 1600,
+    int height = 2400,
+    int seed = 1,
+  }) {
+    // 每行 1 字节 filter(0=None) + width*3 字节 RGB。
+    final Uint8List raw = Uint8List(height * (1 + width * 3));
+    int p = 0;
+    int rnd = seed * 2654435761 & 0x7fffffff;
+    for (int y = 0; y < height; y++) {
+      raw[p++] = 0; // filter: None
+      for (int x = 0; x < width; x++) {
+        // 低频渐变（可压缩）+ 每像素噪声（不可压缩），让压缩后体积落在真实插图量级。
+        rnd = (rnd * 1103515245 + 12345) & 0x7fffffff;
+        final int noise = (rnd >> 16) & 0x1f;
+        raw[p++] = ((x * 255) ~/ width + noise) & 0xff;
+        raw[p++] = ((y * 255) ~/ height + noise) & 0xff;
+        raw[p++] = (((x + y) * 255) ~/ (width + height) + noise) & 0xff;
+      }
+    }
+
+    final BytesBuilder out = BytesBuilder();
+    out.add(<int>[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+    out.add(_chunk('IHDR', _ihdr(width, height)));
+    out.add(_chunk('IDAT', Uint8List.fromList(zlib.encode(raw))));
+    out.add(_chunk('IEND', Uint8List(0)));
+    return out.toBytes();
+  }
+
+  Uint8List _ihdr(int width, int height) {
+    final ByteData d = ByteData(13);
+    d.setUint32(0, width);
+    d.setUint32(4, height);
+    d.setUint8(8, 8); // bit depth
+    d.setUint8(9, 2); // color type: truecolour RGB
+    d.setUint8(10, 0); // compression
+    d.setUint8(11, 0); // filter
+    d.setUint8(12, 0); // interlace
+    return d.buffer.asUint8List();
+  }
+
+  Uint8List _chunk(String type, Uint8List data) {
+    final Uint8List typeBytes = Uint8List.fromList(ascii.encode(type));
+    final BytesBuilder b = BytesBuilder();
+    final ByteData len = ByteData(4)..setUint32(0, data.length);
+    b.add(len.buffer.asUint8List());
+    b.add(typeBytes);
+    b.add(data);
+    final ByteData crc = ByteData(4)
+      ..setUint32(0, _crc32(<int>[...typeBytes, ...data]));
+    b.add(crc.buffer.asUint8List());
+    return b.toBytes();
+  }
+
+  static final List<int> _crcTable = _buildCrcTable();
+
+  static List<int> _buildCrcTable() {
+    final List<int> table = List<int>.filled(256, 0);
+    for (int n = 0; n < 256; n++) {
+      int c = n;
+      for (int k = 0; k < 8; k++) {
+        c = (c & 1) != 0 ? 0xEDB88320 ^ (c >> 1) : c >> 1;
+      }
+      table[n] = c;
+    }
+    return table;
+  }
+
+  static int _crc32(List<int> bytes) {
+    int c = 0xFFFFFFFF;
+    for (final int b in bytes) {
+      c = _crcTable[(c ^ b) & 0xFF] ^ (c >> 8);
+    }
+    return (c ^ 0xFFFFFFFF) & 0xFFFFFFFF;
+  }
+}

--- a/hibiki/integration_test/reader_cross_chapter_perf_itest.dart
+++ b/hibiki/integration_test/reader_cross_chapter_perf_itest.dart
@@ -123,14 +123,16 @@ void main() {
       // 落点正确性基线：跨章不只要快，还必须落对章、落对位置（前进=章首、
       // 后退=章末）。每次跨章后读真实 DOM（baseURI = 当前章文档）与 JS 侧
       // calculateProgress()，任何优化都必须保住这两条。
+      // 注意：一律走 `ReaderHibikiPage.debugEvaluateJavascript` 的**当下**值，不缓存
+      // 闭包——中段落点用例会 pop + 重新 push 阅读器，缓存的旧引用指向已销毁的控制器。
       Future<String> currentChapterFile() async {
-        final dynamic raw =
-            await runInWebView!("(document.baseURI || '').split('/').pop()");
+        final dynamic raw = await ReaderHibikiPage.debugEvaluateJavascript!(
+            "(document.baseURI || '').split('/').pop()");
         return raw?.toString() ?? '';
       }
 
       Future<double> currentProgress() async {
-        final dynamic raw = await runInWebView!(
+        final dynamic raw = await ReaderHibikiPage.debugEvaluateJavascript!(
             'window.hoshiReader ? window.hoshiReader.calculateProgress() : -1');
         if (raw is num) return raw.toDouble();
         return double.tryParse(raw?.toString() ?? '') ?? -1;
@@ -159,11 +161,12 @@ void main() {
         // 让新章 settle（重锚/进度刷新等尾沿）跑完，并越过 450ms 跨章冷却窗，
         // 避免下一次 onBoundarySwipe 被当成同一手势的残余惯性丢弃。
         //
-        // 同时这段停留就是「用户在读当前章」的时间窗——下一章插图的预热
-        // （_prefetchAdjacentChapterImages）正是在这里跑。真实阅读一章是几十秒，
-        // 预热有充足时间；测试里取 4s，够几张 1600×2400 PNG 读盘+解码跑完，
-        // 让带插图章的跨章测到「预热已就绪」这个真实稳态而不是半路状态。
-        await tester.pump(const Duration(seconds: 4));
+        // 停留时长保持 1500ms 不动：这个值的判据是「settle 尾沿 + 冷却窗」，不是
+        // 「预热跑完」。把它拉长到 4s 会让每次跨章都稳稳命中下一章插图预热 —— 那是把
+        // 测量条件调到最有利于新代码的稳态，测出来的数字不再代表用户快速翻章 /
+        // 目录跳转时的表现。预热命中与否的差异应当从逐次 `[chapter-perf]` 的分布里读，
+        // 不该由测试的等待时长预先决定。
+        await tester.pump(const Duration(milliseconds: 1500));
 
         final String to = await currentChapterFile();
         final double progress = await currentProgress();
@@ -182,6 +185,102 @@ void main() {
       }
 
       ReaderChapterPerfTrace.enabled = false;
+
+      // ── 中段落点回归（BUG-1140 第二轮审查）──────────────────────────────
+      //
+      // 上面的循环只断言「前进落章首 / 后退落章末」，恰好是两个已被
+      // forceLoadPendingImages / scroll-0 天然安全覆盖的分支。真正新增风险的是
+      // **章内中段**的精确字符锚恢复：`loading="lazy"` 提前写进 HTML 源码后，恢复
+      // 必然跑在插图 decode 之前，锚换算用的是「插图 0×0」的塌缩布局；插图随后 load、
+      // 几何后移，冻结的 scrollTop 就指向别的内容，而进度轮询会把这个漂掉的读数落库。
+      //
+      // 这里走**真实的退出重进路径**（pop 阅读器 → 重新 push 同一本书），在图文混排
+      // 的真实插图章中段取锚，重进后要求落回同一位置。容差自校准：用同一章、同一版式
+      // 下「翻一页」实测跨过的字符数当上界 —— 漂一张整页插图 ≥ 一页，必然超出。
+      Future<int> firstVisibleChar() async {
+        final dynamic raw = await ReaderHibikiPage.debugEvaluateJavascript!(
+            'window.hoshiReader ? window.hoshiReader.getFirstVisibleCharOffset() : -1');
+        if (raw is num) return raw.toInt();
+        return int.tryParse(raw?.toString() ?? '') ?? -1;
+      }
+
+      Future<void> swipe(String dir) async {
+        final int before = ReaderChapterPerfTrace.completed.length;
+        await ReaderHibikiPage.debugEvaluateJavascript!(
+          "window.flutter_inappwebview.callHandler('onBoundarySwipe', '$dir');",
+        );
+        for (int p = 0; p < 1500; p++) {
+          await tester.pump(const Duration(milliseconds: 20));
+          if (ReaderChapterPerfTrace.completed.length > before) break;
+        }
+        await tester.pump(const Duration(milliseconds: 1200));
+      }
+
+      // 回到图文混排的真实插图章（fixture 最后一章 chapter_10_photo_text）。
+      for (int i = 0; i < forwardTurns; i++) {
+        await swipe('forward');
+      }
+      final String midChapter = await currentChapterFile();
+      debugPrint('[xchapter-mid] landed chapter=$midChapter');
+
+      // 翻进章内中段（不是章首、不是章末）。
+      for (int i = 0; i < 3; i++) {
+        await ReaderHibikiPage.debugEvaluateJavascript!(
+            "window.hoshiReader.paginate('forward');");
+        await tester.pump(const Duration(milliseconds: 400));
+      }
+      final int anchorChar = await firstVisibleChar();
+      // 位置落库走 500ms 去抖 + 进度轮询，留足窗口。
+      await tester.pump(const Duration(seconds: 3));
+      debugPrint('[xchapter-mid] anchor char=$anchorChar in $midChapter');
+
+      // 退出重进：真实的「关书 → 再开」恢复路径。
+      navigator.pop();
+      await tester.pump(const Duration(seconds: 2));
+      for (int i = 0;
+          i < 40 && ReaderHibikiPage.debugEvaluateJavascript != null;
+          i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      unawaited(navigator.push<void>(MaterialPageRoute<void>(
+        builder: (_) => source.buildLaunchPage(item: item),
+      )));
+      await tester.pump(const Duration(seconds: 3));
+      bool reopened = false;
+      for (int i = 0; i < 140; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (find.byKey(contentReadyKey).evaluate().isNotEmpty) {
+          reopened = true;
+          break;
+        }
+      }
+      expect(reopened, isTrue, reason: '重进后阅读器必须就绪');
+      // 留出插图真正 load + 语义重锚落定的窗口（重锚由图片 load 事件驱动）。
+      await tester.pump(const Duration(seconds: 5));
+
+      final String restoredChapter = await currentChapterFile();
+      final int restoredChar = await firstVisibleChar();
+      // 自校准容差：同章同版式下翻一页跨过多少字符。
+      await ReaderHibikiPage
+          .debugEvaluateJavascript!("window.hoshiReader.paginate('forward');");
+      await tester.pump(const Duration(milliseconds: 600));
+      final int nextPageChar = await firstVisibleChar();
+      final int pageSpan = (nextPageChar - restoredChar).abs();
+      debugPrint('[xchapter-mid] restored chapter=$restoredChapter '
+          'char=$restoredChar anchor=$anchorChar pageSpan=$pageSpan');
+
+      expect(restoredChapter, equals(midChapter), reason: '重进必须落回同一章');
+      expect(anchorChar, greaterThan(0), reason: '中段锚必须非章首，否则这条用例测不到中段落点');
+      expect(restoredChar, greaterThan(0),
+          reason: '重进落点不得塌缩回章首（插图 0×0 塌缩布局的典型症状）');
+      // restoreToCharOffset 把锚所在页对齐到页首 → 首可见字符 <= 锚，且相差不超过一页。
+      expect(restoredChar, lessThanOrEqualTo(anchorChar + 1),
+          reason: '恢复落点不应越过锚');
+      if (pageSpan > 0) {
+        expect(anchorChar - restoredChar, lessThanOrEqualTo(pageSpan),
+            reason: '重进落点与中段锚的偏差必须在一页之内——超出即恢复算在了'
+                '插图未 decode 的塌缩布局上（BUG-1140 第二轮）');
+      }
 
       final List<Map<String, int>> runs = ReaderChapterPerfTrace.completed;
       debugPrint('[xchapter-perf] turns=${runs.length}');

--- a/hibiki/integration_test/reader_cross_chapter_perf_itest.dart
+++ b/hibiki/integration_test/reader_cross_chapter_perf_itest.dart
@@ -56,10 +56,14 @@ void main() {
           .setPref('src:reader_ttu:ttu_writing_mode', 'horizontal-tb');
       await ReaderHibikiSource.readerSettings?.refreshFromDb();
 
+      // 带**真实体量**插图（1600×2400 PNG）的书：合成 fixture 原来的「图片章」是内联
+      // SVG，解码几乎免费，跨章计时里完全测不到图片这一段——而真实书的整页插图正是
+      // 用户感知「跨章要半秒」的主因。withRealImages 追加两章：纯整页插图（eager 路径）
+      // 与图文混排（lazy 路径）。
       final String bookKey = await EpubImporter.import(
         db: appModel.database,
-        bytes: EpubGenerator().generate(),
-        fileName: 'perf_cross_chapter.epub',
+        bytes: const EpubGenerator(withRealImages: true).generate(),
+        fileName: 'perf_cross_chapter_images.epub',
       );
 
       final ReaderHibikiSource source = ReaderHibikiSource.instance;
@@ -112,8 +116,10 @@ void main() {
       // 恢复，与前进的章首恢复是两条不同的 JS restore 路径）。章体量差异很大
       // （420 markers 长章 / 5 markers 短章 / 图片章 / ruby 章 / 500 markers 最长章），
       // 逐章日志里的 `chapter=N` 可用来看耗时是否随章体量线性增长。
-      const int forwardTurns = 7;
-      const int backwardTurns = 7;
+      // 10 章：前 8 章同旧 fixture（文本/短章/SVG/ruby），第 9、10 章是真实插图章。
+      // 一路前进到末章再退回来，日志里的 chapter=8/9 就是带真实插图的两章。
+      const int forwardTurns = 9;
+      const int backwardTurns = 9;
       // 落点正确性基线：跨章不只要快，还必须落对章、落对位置（前进=章首、
       // 后退=章末）。每次跨章后读真实 DOM（baseURI = 当前章文档）与 JS 侧
       // calculateProgress()，任何优化都必须保住这两条。
@@ -152,7 +158,12 @@ void main() {
         }
         // 让新章 settle（重锚/进度刷新等尾沿）跑完，并越过 450ms 跨章冷却窗，
         // 避免下一次 onBoundarySwipe 被当成同一手势的残余惯性丢弃。
-        await tester.pump(const Duration(milliseconds: 1500));
+        //
+        // 同时这段停留就是「用户在读当前章」的时间窗——下一章插图的预热
+        // （_prefetchAdjacentChapterImages）正是在这里跑。真实阅读一章是几十秒，
+        // 预热有充足时间；测试里取 4s，够几张 1600×2400 PNG 读盘+解码跑完，
+        // 让带插图章的跨章测到「预热已就绪」这个真实稳态而不是半路状态。
+        await tester.pump(const Duration(seconds: 4));
 
         final String to = await currentChapterFile();
         final double progress = await currentProgress();

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -226,6 +226,12 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
       _refreshProgress();
       _startProgressPoll();
       _diag718ProbeViewportDrift();
+      // TODO-perf（跨章·图片）：预热下一章插图进 WebView 缓存。必须放在这里（遮罩已撤、
+      // 新章已可见）而不是 _onChapterLoadComplete —— 它要 parse 整章 HTML 找图片引用，
+      // 放在恢复完成之前就等于把成本加回跨章热路径。HTML 预取省的是磁盘读+净化，这里
+      // 省的是读盘+解码，后者在带插图的章里大一个数量级（见
+      // _prefetchAdjacentChapterImages 的实测注释）。
+      _prefetchAdjacentChapterImages(_currentChapter + 1);
     });
   }
 

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -226,12 +226,14 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
       _refreshProgress();
       _startProgressPoll();
       _diag718ProbeViewportDrift();
-      // TODO-perf（跨章·图片）：预热下一章插图进 WebView 缓存。必须放在这里（遮罩已撤、
-      // 新章已可见）而不是 _onChapterLoadComplete —— 它要 parse 整章 HTML 找图片引用，
-      // 放在恢复完成之前就等于把成本加回跨章热路径。HTML 预取省的是磁盘读+净化，这里
-      // 省的是读盘+解码，后者在带插图的章里大一个数量级（见
-      // _prefetchAdjacentChapterImages 的实测注释）。
-      _prefetchAdjacentChapterImages(_currentChapter + 1);
+      // TODO-perf（跨章·图片）：预热**阅读方向上**下一章的插图进 WebView 缓存。必须放在
+      // 这里（遮罩已撤、新章已可见）而不是 _onChapterLoadComplete —— 它要 parse 整章 HTML
+      // 找图片引用，放在恢复完成之前就等于把成本加回跨章热路径。HTML 预取省的是磁盘读+
+      // 净化，这里省的是读盘+解码，后者在带插图的章里大一个数量级（见
+      // _prefetchAdjacentChapterImages 的实测注释与配额）。方向来自 _beginNavigation 的
+      // 采样：倒着读时预热上一章，而不是刚离开的那一章。
+      _prefetchAdjacentChapterImages(
+          _currentChapter + _chapterAdvanceDirection);
     });
   }
 
@@ -393,6 +395,12 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
       _restoreCompleter!.complete(false);
     }
     _restoreCompleter = Completer<bool>();
+    // TODO-perf（跨章·图片）：所有导航都经过这里，故这是「阅读方向」的唯一采样点。
+    // 同章重恢复（换字号/重排版/保不动点）不改方向——方向属于「读到哪儿去了」，
+    // 不属于重排版。方向只喂给插图预热（见 _prefetchAdjacentChapterImages）。
+    if (chapter != _currentChapter) {
+      _chapterAdvanceDirection = chapter > _currentChapter ? 1 : -1;
+    }
     _currentChapter = chapter;
     _initialProgress = progress;
     _initialCharOffset = charOffset;

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -303,8 +303,9 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     // 才对本次加载生效（JS 侧那次 lazy 跑在 load 之后，来不及，见 markImagesLazy）。
     // 纯图片章整章 eager：它的分页几何要靠插图真实撑开（TODO-1349）。判据用 EpubBook
     // 的 isImageOnlyChapter（比 JS 侧「正文无任何可匹配字符」宽松），保证这里 eager 的
-    // 集合是 JS 侧 eager 集合的超集，不会倒挂。放在合并注入之前，故 .hoshi-merged-image
-    // 里的前导插图天然保持 eager（TODO-1339）。
+    // 集合是 JS 侧 eager 集合的超集，不会倒挂。合并注入的前导插图自带显式
+    // `loading="eager"`（见 [_injectMergedChapterImages]），故 TODO-1339 的 eager 不依赖
+    // 本行与注入行的先后顺序；守卫 `test/reader/reader_image_lazy_pipeline_guard_test.dart`。
     html = ReaderResourceSanitizer.markImagesLazy(
       html,
       eagerAll: _isImageOnlyChapterCached(chapterIndex),
@@ -370,9 +371,16 @@ extension _ReaderWebView on _ReaderHibikiPageState {
             ? src
             : ReaderHibikiSource.epubUrl(
                 p.posix.normalize(p.posix.join(chapterDir, src)));
+        // TODO-1339 / BUG-1140 第二轮：显式 `loading="eager"`。这些前导插图是章首
+        // **结构性**内容（firstContentEdge 只计入非零尺寸媒体，挂 lazy 会让章首锚跳过
+        // 第一张）。JS 侧靠 `.hoshi-merged-image` 放行，Dart 侧原本只靠「markImagesLazy
+        // 排在本方法之前」这一条**调用顺序**——谁把两行调个个儿，守卫全绿而 bug 复活。
+        // 写成显式 loading 属性后 [ReaderResourceSanitizer.markImagesLazy] 的
+        // 「已有 loading= 就尊重原书」分支会跳过它们，顺序不再是正确性的承重墙。
         figures.write(
           '<div class="hoshi-merged-image">'
-          '<img src="${htmlEscape.convert(absoluteUrl)}" class="block-img"/>'
+          '<img src="${htmlEscape.convert(absoluteUrl)}" class="block-img" '
+          'loading="eager"/>'
           '</div>',
         );
       }
@@ -461,6 +469,13 @@ extension _ReaderWebView on _ReaderHibikiPageState {
   /// URL 请求一遍：走的是同一个 `hoshi.local` 拦截器、同一份缓存条目，等用户真的翻过去
   /// 时那些图已经在缓存里。纯预热，不改 DOM、不参与任何几何计算；失败静默（预热不到就
   /// 退回原来的现付现取）。
+  ///
+  /// **配额**（PR#469 审查）：预热是把整解码后的位图塞进 WebView 图片缓存，整页插图书
+  /// （1600×2400 PNG × N）在移动端是实打实的内存压力，而 HTML 预取那边早有
+  /// `_kChapterHtmlCacheLimit` LRU 上限。这里同样封顶：最多
+  /// [_ReaderHibikiPageState._kImagePrefetchMaxCount] 张、累计原始字节不超过
+  /// [_ReaderHibikiPageState._kImagePrefetchMaxBytes]（按磁盘文件大小计，读 stat 不读内容），
+  /// 超出即停——预热本就是尽力而为，少热几张只是少省一点，不影响正确性。
   void _prefetchAdjacentChapterImages(int index) {
     final EpubBook? book = _book;
     final InAppWebViewController? controller = _controller;
@@ -468,16 +483,21 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     if (index < 0 || index >= book.chapters.length) return;
     final List<String> srcs = book.chapterImageSrcs(index);
     if (srcs.isEmpty) return;
+    final String? extractDir = _extractDir;
     final String chapterDir =
         p.posix.dirname(normalizeHref(book.chapters[index].href));
     final List<String> urls = <String>[];
+    int budget = _ReaderHibikiPageState._kImagePrefetchMaxBytes;
     for (final String src in srcs) {
+      if (urls.length >= _ReaderHibikiPageState._kImagePrefetchMaxCount) break;
+      if (budget <= 0) break;
       final String trimmed = src.trim();
       if (trimmed.isEmpty) continue;
       // data: / 绝对 URL 不经我们的拦截器，预热无意义。
       if (trimmed.startsWith('data:') || trimmed.contains('://')) continue;
-      urls.add(ReaderHibikiSource.epubUrl(
-          p.posix.normalize(p.posix.join(chapterDir, trimmed))));
+      final String rel = p.posix.normalize(p.posix.join(chapterDir, trimmed));
+      budget -= _imageFileSizeBytes(extractDir, rel);
+      urls.add(ReaderHibikiSource.epubUrl(rel));
     }
     if (urls.isEmpty) return;
     final String json = jsonEncode(urls);
@@ -488,6 +508,23 @@ extension _ReaderWebView on _ReaderHibikiPageState {
               'im.decoding="async";im.src=u[i];}}catch(e){}})();',
         )
         .catchError((Object _) => null));
+  }
+
+  /// 预热配额用的磁盘体量（只 stat 不读内容）。解出的路径必须仍在 extractDir 内
+  /// （与 [_chapterFilePath] 同一条越界判据）；解析不到就按 0 计——配额是保护，不是
+  /// 正确性依赖，宁可少扣也不因为一次 stat 失败把整章预热掐掉。
+  int _imageFileSizeBytes(String? extractDir, String relativeHref) {
+    if (extractDir == null) return 0;
+    try {
+      final String root = p.canonicalize(extractDir);
+      final String filePath = p.canonicalize(p.join(root, relativeHref));
+      if (!p.isWithin(root, filePath)) return 0;
+      final File file = File(filePath);
+      if (!file.existsSync()) return 0;
+      return file.lengthSync();
+    } catch (_) {
+      return 0;
+    }
   }
 
   static bool _isValidFontData(Uint8List data) => isValidFontData(data);

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -299,6 +299,16 @@ extension _ReaderWebView on _ReaderHibikiPageState {
   }) {
     String html = utf8.decode(rawData, allowMalformed: true);
     html = ReaderResourceSanitizer.sanitizeXhtml(html);
+    // TODO-perf（跨章·图片）：离屏插图不该拖住 window.load —— 属性必须写进 HTML 源码
+    // 才对本次加载生效（JS 侧那次 lazy 跑在 load 之后，来不及，见 markImagesLazy）。
+    // 纯图片章整章 eager：它的分页几何要靠插图真实撑开（TODO-1349）。判据用 EpubBook
+    // 的 isImageOnlyChapter（比 JS 侧「正文无任何可匹配字符」宽松），保证这里 eager 的
+    // 集合是 JS 侧 eager 集合的超集，不会倒挂。放在合并注入之前，故 .hoshi-merged-image
+    // 里的前导插图天然保持 eager（TODO-1339）。
+    html = ReaderResourceSanitizer.markImagesLazy(
+      html,
+      eagerAll: _isImageOnlyChapterCached(chapterIndex),
+    );
     // TODO-1128 / TODO-1174: when this text chapter absorbs the preceding
     // single-image chapters (merge-image on), prepend their <img> to the *start*
     // of the flow before the reader style is injected, so the illustrations
@@ -422,6 +432,62 @@ extension _ReaderWebView on _ReaderHibikiPageState {
         }
       }
     });
+  }
+
+  /// [EpubBook.isImageOnlyChapter] 要 parse 整章 HTML，而章节 HTML 在一次阅读会话里
+  /// 不变，故按章号记忆化。章号非法 / 书未就绪时返回 true（保守走 eager，宁可慢一点也
+  /// 不冒「该 eager 的图被挂 lazy」导致分页几何塌缩的风险）。
+  bool _isImageOnlyChapterCached(int chapterIndex) {
+    if (chapterIndex < 0) return true;
+    final EpubBook? book = _book;
+    if (book == null) return true;
+    final bool? cached = _imageOnlyChapterCache[chapterIndex];
+    if (cached != null) return cached;
+    final bool value = book.isImageOnlyChapter(chapterIndex);
+    _imageOnlyChapterCache[chapterIndex] = value;
+    return value;
+  }
+
+  /// TODO-perf（跨章·图片）：把下一章的插图预热进 WebView 的 HTTP 缓存。
+  ///
+  /// 实测（`[chapter-perf]`，1600×2400 PNG × 3~4 张的章节）：**首次**进入带插图的章
+  /// docLoad 689~717ms，其中 `nav.dcl` 只有 15~20ms——DOM 早就解析完了，剩下 670ms
+  /// 全是在等图片读盘+解码；而**再次**进入同一章只要 66ms，因为图片命中了 WebView 缓存
+  /// （图片响应带 `Cache-Control: max-age=3600`，见 [_readerResourcePayload]）。
+  /// 遮罩正好盖住这整段（setup 脚本挂在 `window.load` 之后），所以带插图的跨章体感是
+  /// 「翻一下要大半秒」。
+  ///
+  /// 这里在**当前章已经读起来之后**，用一个隐藏的 `new Image()` 把下一章的图按同样的
+  /// URL 请求一遍：走的是同一个 `hoshi.local` 拦截器、同一份缓存条目，等用户真的翻过去
+  /// 时那些图已经在缓存里。纯预热，不改 DOM、不参与任何几何计算；失败静默（预热不到就
+  /// 退回原来的现付现取）。
+  void _prefetchAdjacentChapterImages(int index) {
+    final EpubBook? book = _book;
+    final InAppWebViewController? controller = _controller;
+    if (book == null || controller == null) return;
+    if (index < 0 || index >= book.chapters.length) return;
+    final List<String> srcs = book.chapterImageSrcs(index);
+    if (srcs.isEmpty) return;
+    final String chapterDir =
+        p.posix.dirname(normalizeHref(book.chapters[index].href));
+    final List<String> urls = <String>[];
+    for (final String src in srcs) {
+      final String trimmed = src.trim();
+      if (trimmed.isEmpty) continue;
+      // data: / 绝对 URL 不经我们的拦截器，预热无意义。
+      if (trimmed.startsWith('data:') || trimmed.contains('://')) continue;
+      urls.add(ReaderHibikiSource.epubUrl(
+          p.posix.normalize(p.posix.join(chapterDir, trimmed))));
+    }
+    if (urls.isEmpty) return;
+    final String json = jsonEncode(urls);
+    unawaited(controller
+        .evaluateJavascript(
+          source: '(function(){try{var u=$json;'
+              'for(var i=0;i<u.length;i++){var im=new Image();'
+              'im.decoding="async";im.src=u[i];}}catch(e){}})();',
+        )
+        .catchError((Object _) => null));
   }
 
   static bool _isValidFontData(Uint8List data) => isValidFontData(data);

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -1220,6 +1220,11 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   final LinkedHashMap<String, Uint8List> _sanitizedHtmlCache =
       LinkedHashMap<String, Uint8List>();
 
+  /// TODO-perf（跨章·图片）：`EpubBook.isImageOnlyChapter` 每次都要 parse 整章 HTML，
+  /// 而它的答案在一次阅读会话里不变（章节文件不变）。按章号记忆化，避免拦截器热路径
+  /// （每次跨章 + 每次预取）重复解析。换书会连同本 State 一起重建。
+  final Map<int, bool> _imageOnlyChapterCache = <int, bool>{};
+
   // BUG-270: in-flight prefetch dedup — the file path currently being warmed in
   // the background, so a navigation that lands on it does not race a second read.
   String? _prefetchingHtmlPath;

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -1225,6 +1225,18 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   /// （每次跨章 + 每次预取）重复解析。换书会连同本 State 一起重建。
   final Map<int, bool> _imageOnlyChapterCache = <int, bool>{};
 
+  /// TODO-perf（跨章·图片）预热配额（PR#469 审查）：`_prefetchAdjacentChapterImages`
+  /// 把整解码后的位图塞进 WebView 图片缓存，整页插图书（1600×2400 PNG × N）在移动端
+  /// 是实打实的内存压力。对齐 [_kChapterHtmlCacheLimit] 那侧的上限思路，这里按张数 +
+  /// 磁盘字节双封顶；预热是尽力而为，超配额停下只是少省一点，不影响正确性。
+  static const int _kImagePrefetchMaxCount = 4;
+  static const int _kImagePrefetchMaxBytes = 8 * 1024 * 1024;
+
+  /// TODO-perf（跨章·图片）阅读方向（PR#469 审查）：预热必须跟着用户读的方向走，写死
+  /// `+1` 会在倒着翻章时预热**刚离开的那一章**（纯反效果）。每次 [_beginNavigation]
+  /// 按目标章与当前章的相对位置更新；同章重恢复（换字号/重排版）不改方向。
+  int _chapterAdvanceDirection = 1;
+
   // BUG-270: in-flight prefetch dedup — the file path currently being warmed in
   // the background, so a navigation that lands on it does not race a second read.
   String? _prefetchingHtmlPath;

--- a/hibiki/lib/src/reader/reader_pagination_scripts.dart
+++ b/hibiki/lib/src/reader/reader_pagination_scripts.dart
@@ -1035,6 +1035,68 @@ class ReaderPaginationScripts {
       imgs[i].setAttribute('loading', 'eager');
     }
   },
+  // ── 迟到图片的语义重锚（TODO-1229 案B 的一般化 · BUG-1140 第二轮）─────────
+  //
+  // 恢复落点由「章内**语义锚**」定义：精确字符偏移（restoreToCharOffset）、粗粒度
+  // progress（restoreProgress —— progressStops 同样是字符域）、或 fragment 目标元素。
+  // 这三种锚本身与图片是否已 decode 无关，但把锚**换算成 scroll** 的那一步依赖当下
+  // 几何：锚之前若有尚未 load 的懒图（0×0），换算结果就少了那些图的高度。图片随后
+  // load、几何后移，冻结的 scroll 便指向别的内容——用户看到的位置漂了，随后
+  // onReaderScroll 还会把这个漂掉的读数落库。
+  //
+  // 修法不是「恢复前等图片」（那正是要消除的整个加载周期），而是**图片 load 后按同一个
+  // 语义锚重算一次**：终态与「图片本来就在」等价。仅在恢复落地后、用户尚未翻页的窗口内
+  // 有效（paginate 清资格），且只由真正改变几何的 block 图 load 触发。重锚是程序化滚动，
+  // 走既有 onReaderScroll 通道把**修正后**的位置落库（既有 >=0.99 章末重锚同一条路）。
+  registerImageLateAnchor: function(anchor) {
+    this.clearImageLateAnchor();
+    if (!anchor) return;
+    if (typeof anchor.charOffset === 'number') {
+      this.__imgReanchorCharOffset = anchor.charOffset;
+      this.__imgReanchorCharOffsetEnd = anchor.endCharOffset;
+    } else if (typeof anchor.progress === 'number') {
+      this.__imgReanchorProgress = anchor.progress;
+    } else if (anchor.fragment) {
+      this.__imgReanchorFragment = anchor.fragment;
+    }
+  },
+  clearImageLateAnchor: function() {
+    this.__imgReanchorProgress = null;
+    this.__imgReanchorCharOffset = null;
+    this.__imgReanchorCharOffsetEnd = -1;
+    this.__imgReanchorFragment = null;
+  },
+  // 连续 shell 独有 scrollToChapterEnd —— 与既有重锚回调同一条判别（不能用
+  // scrollToProgressPaged，那是 _sharedJs 两 shell 都有的，连续会误走分页分支）。
+  _isContinuousShell: function() {
+    return typeof this.scrollToChapterEnd === 'function';
+  },
+  reapplyImageLateAnchor: function() {
+    var co = this.__imgReanchorCharOffset;
+    if (typeof co === 'number' && co > 0) {
+      if (this._isContinuousShell()) {
+        this.scrollToCharOffset(co, this.__imgReanchorCharOffsetEnd);
+      } else {
+        this.scrollToCharOffset(co);
+      }
+      return true;
+    }
+    if (this.__imgReanchorFragment) {
+      return this.alignToFragmentTarget(this.__imgReanchorFragment);
+    }
+    var p = this.__imgReanchorProgress;
+    if (typeof p !== 'number') return false;
+    if (this._isContinuousShell()) {
+      if (p >= 0.99) this.scrollToChapterEnd();
+      else if (p <= 0) this.scrollToChapterStart();
+      else this.scrollToProgressContinuous(p);
+      return true;
+    }
+    var rctx = this.getScrollContext();
+    if (!rctx || rctx.pageSize <= 0) return false;
+    this.scrollToProgressPaged(rctx, p);
+    return true;
+  },
   notifyRestoreComplete: function() {
     this.perfMark('restoreDone');
     if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
@@ -1787,24 +1849,13 @@ $blurFn
         if (_hoshiClassifyBlockImg(img)) {
           var r = window.hoshiReader;
           if (r && r.paginationMetrics !== undefined) r.paginationMetrics = null;
-          // TODO-1229 案B：懒加载 block 图 load 后整章几何后移，冻结的 restore scrollTop
-          // 错一行（Chromium 只在 scrollTop=0 自愈）。若最近落点是章首/章末粗粒度语义
-          // 且其后无用户翻页(__imgReanchorProgress 非 null)，用刚失效的 metrics 重建几何
-          // 后重放 scrollToProgressPaged 语义重锚。属程序化滚动，不污染 TODO-798
-          // userDriven 因果门；有用户输入(paginate 已清资格)则不动。
-          if (r && r.__imgReanchorProgress != null) {
-            // TODO-1349（续）：判别连续 vs 分页用 scrollToChapterEnd（连续 shell 独有）——
-            // scrollToProgressPaged 在 _sharedJs 里两 shell 都有，不能用它判别（否则连续误走
-            // 分页分支，getScrollContext.pageSize 非分页量纲 → 不重锚，停章首）。
-            if (typeof r.scrollToChapterEnd === 'function') {
-              // 连续模式：尾部懒图 load 后重锚到章末；章首(<=0)不重锚——内容向下增长不移动 scroll 0。
-              if (r.__imgReanchorProgress >= 0.99) r.scrollToChapterEnd();
-            } else if (typeof r.scrollToProgressPaged === 'function') {
-              var rctx = r.getScrollContext();
-              if (rctx && rctx.pageSize > 0) {
-                r.scrollToProgressPaged(rctx, r.__imgReanchorProgress);
-              }
-            }
+          // TODO-1229 案B / BUG-1140 第二轮：懒加载 block 图 load 后整章几何后移，冻结的
+          // restore scrollTop 错位（Chromium 只在 scrollTop=0 自愈）。按本次恢复登记的
+          // **语义锚**（char / progress / fragment）重算一次落点，终态与「图片本来就在」
+          // 等价。属程序化滚动，不污染 TODO-798 userDriven 因果门；有用户输入
+          // （paginate 已 clearImageLateAnchor）则不动。三种锚的分派见 reapplyImageLateAnchor。
+          if (r && typeof r.reapplyImageLateAnchor === 'function') {
+            r.reapplyImageLateAnchor();
           }
         }
       });
@@ -2287,10 +2338,14 @@ $_sharedJs
     // 图 load 后 __imgReanchorProgress 回调按含真实尾图几何的 maxScroll 重锚。
     if (progress >= 0.99) this.forceLoadPendingImages();
     this.scrollToProgressPaged(context, progress);
-    // TODO-1229 案B：记录本次是章首(0)/章末(>=0.99)粗粒度 progress 落点，允许懒加载
-    // block 图 load 后（整章几何后移、冻结 scrollTop 错一行）语义重锚。中段 progress 与
-    // 精确 char 锚不登记（重锚到粗 progress 反更差）。任一用户翻页(paginate)清资格。
-    this.__imgReanchorProgress = (progress <= 0 || progress >= 0.99) ? progress : null;
+    // BUG-1140 第二轮：登记本次 progress 落点供懒图 load 后语义重锚，**含中段**。
+    // 旧实现只登记章首(0)/章末(>=0.99)，理由是「中段重锚到粗 progress 反更差」——那成立
+    // 的前提是恢复时几何已终态（initialize 挂在 window.load，图片必已 decode），中段重锚
+    // 只会把已经正确的位置白抖一下。把 loading="lazy" 写进 HTML 源码之后这个前提没了：
+    // 恢复跑在图片 decode 之前，中段落点同样会被随后 load 的图顶走。progressStops 是字符域，
+    // 按同一 progress 重算 = 落回同一批字符所在页，严格优于停在漂掉的 scroll 上。
+    // 任一用户翻页(paginate)清资格。
+    this.registerImageLateAnchor({progress: progress});
     var pos = this.getPagePosition(context);
     this._settleAndNotify(context, pos);
   },
@@ -2312,34 +2367,49 @@ $_sharedJs
     // 重锚时不再跳页）。>0 的精确锚行为不变。
     if (charOffset <= 0 || !this.charOffsetInRange(charOffset)) {
       this.scrollToProgressPaged(context, 0);
+      this.registerImageLateAnchor({progress: 0});
     } else {
       this.scrollToCharOffset(charOffset);
+      // BUG-1140 第二轮：字符锚是**布局无关**的真相，迟到图片 load 后按同一个 charOffset
+      // 重算即回到「图片本来就在」的落点。旧实现在这里什么都不登记 → 精确锚恢复（退出重进 /
+      // 收藏跳转 / 有声书 seek 落中段）在图文混排章完全裸奔，位置漂了还会被落库。
+      this.registerImageLateAnchor({charOffset: charOffset});
     }
     var pos = this.getPagePosition(context);
     this._settleAndNotify(context, pos);
   },
-  jumpToFragment: async function(fragment) {
-    await document.fonts.ready;
+  // fragment 落点的纯几何对齐（jumpToFragment 与迟到图片重锚共用同一份换算，避免
+  // 重锚复制一份会漂开的算法）。命中返 true 并已 setPagePosition，未命中返 false。
+  alignToFragmentTarget: function(fragment) {
     var context = this.getScrollContext();
     var rawFragment = (fragment || '').trim();
     var target = rawFragment && (document.getElementById(rawFragment) || document.getElementsByName(rawFragment)[0]);
-    if (context.pageSize <= 0 || !target) {
+    if (context.pageSize <= 0 || !target) return false;
+    var rect = this.getRect(target);
+    var currentScroll = this.getPagePosition(context);
+    var anchor = (context.vertical ? rect.top : rect.left) + currentScroll;
+    this.setPagePosition(context, this.alignToPage(context, anchor));
+    return true;
+  },
+  jumpToFragment: async function(fragment) {
+    await document.fonts.ready;
+    var context = this.getScrollContext();
+    if (!this.alignToFragmentTarget(fragment)) {
+      this.clearImageLateAnchor();
       this.registerSnapScroll(this.getPagePosition(context));
       this.notifyRestoreComplete();
       return false;
     }
-    var rect = this.getRect(target);
-    var currentScroll = this.getPagePosition(context);
-    var anchor = (context.vertical ? rect.top : rect.left) + currentScroll;
-    var targetScroll = this.alignToPage(context, anchor);
-    this.setPagePosition(context, targetScroll);
-    this._settleAndNotify(context, targetScroll);
+    // BUG-1140 第二轮：目录/内链跳转同样在图片 decode 之前落点，登记 fragment 锚让迟到
+    // 图片 load 后按同一个目标元素重新对齐。
+    this.registerImageLateAnchor({fragment: fragment});
+    this._settleAndNotify(context, this.getPagePosition(context));
     return true;
   },
   paginate: function(direction) {
     // TODO-1229 案B：用户翻页即放弃图片 late-load 重锚资格——避免把用户已翻走的位置
-    // 拽回章首/章末（重锚只在恢复落地后、用户尚未翻页的窗口内有效）。
-    this.__imgReanchorProgress = null;
+    // 拽回恢复锚（重锚只在恢复落地后、用户尚未翻页的窗口内有效）。
+    this.clearImageLateAnchor();
     var context = this.getScrollContext();
     if (context.pageSize <= 0) return "limit";
     var currentScroll = this.getPagePosition(context);
@@ -2830,7 +2900,10 @@ $_sharedJs
     await document.fonts.ready;
     var self = this;
     if (progress <= 0) {
-      this.__imgReanchorProgress = null;
+      // BUG-1140 第二轮：章首也登记。内容向下增长不移动 scroll 0，重锚
+      // scrollToChapterStart 幂等；但章首之前若有前导插图（合并注入 / 封面），图 load
+      // 后正文整体下移，不重锚就会停在图与正文之间的错位。
+      this.registerImageLateAnchor({progress: 0});
       this.scrollToChapterStart();
       setTimeout(function() {
         self.scrollToChapterStart();
@@ -2847,7 +2920,7 @@ $_sharedJs
       // TODO-1349（续）：登记章末重锚资格 + 强制 load 尾部懒图（打破鸡生蛋，见
       // forceLoadPendingImages）。16ms 双发太快等不到图 load，故尾图 load 后由
       // _sharedInitImages 的 load 回调重锚 scrollToChapterEnd（连续分支）落到含尾图的真实章末。
-      this.__imgReanchorProgress = progress;
+      this.registerImageLateAnchor({progress: progress});
       this.forceLoadPendingImages();
       this.scrollToChapterEnd();
       setTimeout(function() {
@@ -2856,26 +2929,34 @@ $_sharedJs
       }, 16);
       return;
     }
-    this.__imgReanchorProgress = null;
+    // BUG-1140 第二轮：中段 progress 同样登记（理由见分页版 restoreProgress 长注释）。
+    this.registerImageLateAnchor({progress: progress});
     this.scrollToProgressContinuous(progress);
     this._settleAndNotify();
   },
-  jumpToFragment: async function(fragment) {
-    await document.fonts.ready;
+  // fragment 落点的纯几何对齐（jumpToFragment 与迟到图片重锚共用），见分页版同名方法。
+  alignToFragmentTarget: function(fragment) {
     var rawFragment = (fragment || '').trim();
     var target = rawFragment && (document.getElementById(rawFragment) || document.getElementsByName(rawFragment)[0]);
-    if (!target) {
+    if (!target) return false;
+    target.scrollIntoView();
+    return true;
+  },
+  jumpToFragment: async function(fragment) {
+    await document.fonts.ready;
+    if (!this.alignToFragmentTarget(fragment)) {
+      this.clearImageLateAnchor();
       this.notifyRestoreComplete();
       return false;
     }
-    target.scrollIntoView();
+    this.registerImageLateAnchor({fragment: fragment});
     this._settleAndNotify();
     return true;
   },
   paginate: function(direction) {
-    // TODO-1349（续）：用户翻页即放弃章末尾图 late-load 重锚资格（镜像分页 paginate），
-    // 避免尾图 load 回调把用户已翻走的位置拽回章末。
-    this.__imgReanchorProgress = null;
+    // TODO-1349（续）：用户翻页即放弃 late-load 重锚资格（镜像分页 paginate），
+    // 避免图 load 回调把用户已翻走的位置拽回恢复锚。
+    this.clearImageLateAnchor();
     var vertical = this.isVertical();
     var root = document.scrollingElement || document.documentElement;
     var before = vertical ? window.scrollX : root.scrollTop;
@@ -3055,7 +3136,10 @@ $_sharedJs
     await document.fonts.ready;
     // TODO-1229 (BUG-594)：charOffset 0 == 章首（0 字已读）。连续模式章首插图同理不得越过，
     // scrollToChapterStart 滚到顶（含前导图），与 restoreProgress 章首语义一致。>0 走精确锚不变。
-    if (charOffset <= 0) { this.scrollToChapterStart(); }
+    if (charOffset <= 0) {
+      this.scrollToChapterStart();
+      this.registerImageLateAnchor({progress: 0});
+    }
     else {
       // BUG-492 (TODO-1053 Bug A) 越界兜底：护住旧脏收藏记录。写入端曾把某句错记成
       // 相邻章 sectionIndex（_currentChapter 漂移），恢复端忠实加载该错章 DOM 后，本 charOffset
@@ -3065,8 +3149,12 @@ $_sharedJs
       // （确定性落点），比静默停错位可诊断。锚在范围内（含新写入 / 已修数据）走精确对齐，行为不变。
       if (!this.charOffsetInRange(charOffset)) {
         this.scrollToChapterStart();
+        this.registerImageLateAnchor({progress: 0});
       } else {
         this.scrollToCharOffset(charOffset, endCharOffset);
+        // BUG-1140 第二轮：精确字符锚登记重锚资格（理由见分页版 restoreToCharOffset）。
+        this.registerImageLateAnchor(
+            {charOffset: charOffset, endCharOffset: endCharOffset});
       }
     }
     this._settleAndNotify();

--- a/hibiki/lib/src/reader/reader_pagination_scripts.dart
+++ b/hibiki/lib/src/reader/reader_pagination_scripts.dart
@@ -3139,8 +3139,7 @@ $_sharedJs
     if (charOffset <= 0) {
       this.scrollToChapterStart();
       this.registerImageLateAnchor({progress: 0});
-    }
-    else {
+    } else {
       // BUG-492 (TODO-1053 Bug A) 越界兜底：护住旧脏收藏记录。写入端曾把某句错记成
       // 相邻章 sectionIndex（_currentChapter 漂移），恢复端忠实加载该错章 DOM 后，本 charOffset
       // 是「另一章」的绝对偏移，在当前（错）章内可能超出本章可匹配字符总数 →

--- a/hibiki/lib/src/reader/reader_resource_sanitizer.dart
+++ b/hibiki/lib/src/reader/reader_resource_sanitizer.dart
@@ -10,8 +10,21 @@ class ReaderResourceSanitizer {
   // text/html. Everything else that ships self-closed in XHTML must be expanded
   // to a paired tag (see [_selfClosingElementPattern] / [sanitizeXhtml]).
   static const Set<String> _voidElements = <String>{
-    'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'keygen',
-    'link', 'meta', 'param', 'source', 'track', 'wbr',
+    'area',
+    'base',
+    'br',
+    'col',
+    'embed',
+    'hr',
+    'img',
+    'input',
+    'keygen',
+    'link',
+    'meta',
+    'param',
+    'source',
+    'track',
+    'wbr',
   };
 
   // XHTML served as text/html: the HTML5 tokenizer IGNORES the self-closing
@@ -43,6 +56,48 @@ class ReaderResourceSanitizer {
 
   static final RegExp _bodyOpenPattern =
       RegExp(r'<body[^>]*>', caseSensitive: false);
+
+  // 属性部分与 [_selfClosingElementPattern] 同款：把整段引号串（"…" / '…'）当单个
+  // token，这样属性值里的字面 `>`（如 `alt="a>b"`）不会被误当成标签结束。
+  static final RegExp _imgTagPattern = RegExp(
+    '<img\\b((?:"[^"]*"|\'[^\']*\'|[^>"\'])*)>',
+    caseSensitive: false,
+  );
+  static final RegExp _loadingAttrPattern =
+      RegExp(r'\bloading\s*=', caseSensitive: false);
+  static final RegExp _gaijiClassPattern = RegExp(
+      r'''\bclass\s*=\s*(?:"[^"]*\bgaiji|'[^']*\bgaiji|gaiji)''',
+      caseSensitive: false);
+
+  /// TODO-perf（跨章·图片）：在**生成 HTML 时**就给正文插图标上 `loading="lazy"` /
+  /// `decoding="async"`。
+  ///
+  /// 阅读器 JS（`initialize` 里 TODO-1074 那段）本来就想给每张 `<img>` 挂 lazy，理由写的
+  /// 也正是「不再拖住 window.load」——但那段脚本是在 `onLoadStop`（即 `load` 事件**之后**）
+  /// 注入的，浏览器早已按标签里的原始属性把整章图片全部读盘+解码完毕。换句话说那行 lazy
+  /// 迟到了一整个加载周期，只是给一笔已经付掉的账贴了张标签。实测带插图的章 `nav.dcl`
+  /// 15~20ms 而 `nav.load` 687~717ms，遮罩全程盖在这段等待上。
+  ///
+  /// 属性只有写进 HTML 源码才能影响本次加载，所以判定上移到 Dart 侧。保持 eager 的例外与
+  /// JS 侧同款、且**更保守**（这里 eager 的集合是 JS 侧 eager 集合的超集，绝不会出现
+  /// 「Dart 挂了 lazy 而 JS 想要 eager」的倒挂）：
+  /// - [eagerAll] = true（纯图片章：整章就是几张整页插图，分页几何要靠它们真实撑开，见
+  ///   TODO-1349）→ 整章一律 eager，原样返回。
+  /// - `class` 含 `gaiji` 的内联小图参与文字排版几何，必须同步解码 → 跳过。
+  /// - 已显式写了 `loading=` 的标签 → 尊重原书，跳过。
+  ///
+  /// 合并注入的前导插图（`.hoshi-merged-image`）不经过这里——调用点在
+  /// `_injectMergedChapterImages` **之前**，那些图天然保持 eager（TODO-1339）。
+  static String markImagesLazy(String html, {bool eagerAll = false}) {
+    if (eagerAll) return html;
+    return html.replaceAllMapped(_imgTagPattern, (Match m) {
+      final String whole = m.group(0)!;
+      final String attrs = m.group(1) ?? '';
+      if (_loadingAttrPattern.hasMatch(attrs)) return whole;
+      if (_gaijiClassPattern.hasMatch(attrs)) return whole;
+      return '<img loading="lazy" decoding="async"$attrs>';
+    });
+  }
 
   /// TODO-1174: insert [imagesHtml] immediately after the document's `<body>`
   /// open tag, so merged single-image chapters render at the very *top* of the

--- a/hibiki/test/reader/chapter_jump_late_load_reanchor_test.dart
+++ b/hibiki/test/reader/chapter_jump_late_load_reanchor_test.dart
@@ -1,19 +1,27 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 
-/// BUG-568 / TODO-1229 案B 源码/生成产物守卫：跳章落点冻结快照 → 图片 late-load 重锚。
+/// BUG-568 / TODO-1229 案B + BUG-1140 第二轮 源码/生成产物守卫：
+/// 恢复落点冻结快照 → 图片 late-load 语义重锚。
 ///
-/// backward 跳章走 restoreProgress(0.99) 落 contentLastPageScroll（restore 瞬间布局），
-/// 章首懒加载 block 图 load 后整章几何后移 → 冻结 scrollTop 错一行（Chromium 只在
-/// scrollTop=0 自愈）。旧图片 load 回调只失效 paginationMetrics 不重锚。
+/// 恢复把「章内语义锚」换算成 scrollTop 的那一步依赖当下几何。锚之前若有尚未 load 的
+/// 懒图（0×0），换算结果就少了那些图的高度；图片随后 load、几何后移，冻结的 scrollTop
+/// 便指向别的内容（Chromium 只在 scrollTop=0 自愈），随后 onReaderScroll 还会把这个漂
+/// 掉的读数落库。
 ///
-/// 修复：paginated restoreProgress 记录章首(0)/章末(≥0.99)重锚资格 __imgReanchorProgress；
-/// 用户翻页 paginate 入口清资格（不把已翻走的位置拽回）；图片 load 回调命中资格时用
-/// 刚失效的 metrics 重建几何后重放 scrollToProgressPaged 语义重锚（程序化滚动，不污染
-/// TODO-798 userDriven 因果门）。
+/// 案B 初版只覆盖分页 shell 的章首(0)/章末(≥0.99) 粗粒度 progress。BUG-1140 第二轮把
+/// `loading="lazy"` 提前写进 HTML 源码（webview.part.dart `markImagesLazy`），恢复从此
+/// **必然**跑在图片 decode 之前，于是覆盖面必须扩到全部恢复入口：
+///   - 中段 progress（旧存档无精确锚）
+///   - 精确字符锚 restoreToCharOffset（退出重进 / 收藏跳转 / 有声书 seek 落中段）
+///   - fragment 跳转（目录 / 内链）
+///   - 连续 shell 的同名三条路径
 ///
-/// headless WebView 在 CI 跑不到，故锁死生成 JS 的关键编排结构不回退；真机 4 截图
-/// 法证由集成 owner / 用户复测。
+/// 用户翻页 (paginate) 清资格（不把已翻走的位置拽回）；图片 load 回调命中资格时先失效
+/// metrics 再按**同一个语义锚**重算落点（程序化滚动，不污染 TODO-798 userDriven 因果门）。
+///
+/// headless WebView 在 CI 跑不到，故锁死生成 JS 的关键编排结构不回退；真机法证由集成
+/// owner / 用户复测。
 void main() {
   late String paginated;
   late String continuous;
@@ -32,72 +40,141 @@ void main() {
 
   String norm(String s) => s.replaceAll(RegExp(r'\s+'), ' ');
 
-  group('案B：restoreProgress 记录章首/章末重锚资格', () {
-    test('分页 restoreProgress 按 progress 是否 0/≥0.99 设 __imgReanchorProgress',
-        () {
-      final String n = norm(paginated);
+  /// 取 [src] 中从 [start] 标记起、到下一个顶层方法名 [end] 之前的函数体。
+  String bodyBetween(String src, String start, String end) {
+    final int i = src.indexOf(start);
+    expect(i, isNonNegative, reason: '生成脚本必须含 $start');
+    final int j = src.indexOf(end, i);
+    expect(j, greaterThan(i), reason: '$start 之后必须能找到 $end');
+    return src.substring(i, j);
+  }
+
+  group('重锚资格：三种语义锚都登记（BUG-1140 第二轮）', () {
+    test('分页 restoreProgress 登记 progress（含中段，不再只 0/0.99）', () {
+      final String body = bodyBetween(
+          paginated, 'restoreProgress: async function', 'restoreToCharOffset:');
       expect(
-        n.contains(
-            'this.__imgReanchorProgress = (progress <= 0 || progress >= 0.99) ? progress : null;'),
+        norm(body)
+            .contains('this.registerImageLateAnchor({progress: progress})'),
         isTrue,
-        reason: '仅章首(0)/章末(≥0.99)粗粒度落点登记重锚资格，中段/精确锚不登记',
+        reason: '恢复跑在图片 decode 之前后，中段 progress 同样会被后 load 的图顶走',
       );
-    });
-  });
-
-  group('案B：用户翻页清资格', () {
-    test('分页 paginate 入口把 __imgReanchorProgress 清 null', () {
-      // paginate 入口那句紧跟 getScrollContext，锁死清资格出现在 paginator 主体前。
-      final int clearIdx =
-          paginated.indexOf('this.__imgReanchorProgress = null;');
-      expect(clearIdx, isNonNegative, reason: '用户翻页必须放弃图片 late-load 重锚资格');
-      final int paginateIdx =
-          paginated.indexOf('paginate: function(direction)');
-      expect(paginateIdx, isNonNegative);
-      // 清资格位于 paginate 函数体开头（其后紧跟 getScrollContext / pageSize 判定）。
-      final String body = paginated.substring(
-        paginateIdx,
-        paginated.indexOf('getFirstVisibleCharOffset', paginateIdx),
-      );
-      expect(body.contains('this.__imgReanchorProgress = null;'), isTrue,
-          reason: 'paginate 函数体内必须清资格');
-    });
-  });
-
-  group('案B：图片 load 回调命中资格时重放语义重锚', () {
-    test('load 回调先失效 metrics 再按资格重放 scrollToProgressPaged', () {
-      final String n = norm(paginated);
-      // 失效 metrics（保留 TODO-1074 行为）
-      expect(n.contains('r.paginationMetrics = null'), isTrue);
-      // 命中资格判定 + 重放
+      // 负向：旧的「只登记 0/0.99」条件表达式必须已消失。
       expect(
-        n.contains('r.__imgReanchorProgress != null'),
-        isTrue,
-        reason: '仅在最近落点是章首/章末且用户未翻页时重锚',
-      );
-      expect(
-        n.contains('r.scrollToProgressPaged(rctx, r.__imgReanchorProgress)'),
-        isTrue,
-        reason: '用刚失效的 metrics 重建几何后重放语义重锚',
-      );
-    });
-
-    test('重放前守卫 pageSize>0（避免未就绪 context 误锚）', () {
-      final String n = norm(paginated);
-      expect(n.contains('rctx.pageSize > 0'), isTrue);
-    });
-  });
-
-  group('案B：连续 shell 不误触（不同 restore/ paginate 路径）', () {
-    test('连续 shell 的 restoreProgress 不登记 __imgReanchorProgress', () {
-      // 连续版 restoreProgress 走 scrollToChapterStart / scrollToProgressContinuous，
-      // 从不设 __imgReanchorProgress → 共享的图片 load 回调在连续模式 no-op。
-      expect(
-        norm(continuous).contains(
+        norm(paginated).contains(
             'this.__imgReanchorProgress = (progress <= 0 || progress >= 0.99)'),
         isFalse,
-        reason: '案B 仅分页跳章语义，连续模式不登记资格',
+        reason: '旧的窄资格判定必须被 registerImageLateAnchor 取代',
       );
+    });
+
+    test('分页 restoreToCharOffset 精确锚登记 charOffset', () {
+      final String body = bodyBetween(paginated,
+          'restoreToCharOffset: async function', 'alignToFragmentTarget:');
+      final String n = norm(body);
+      expect(n.contains('this.scrollToCharOffset(charOffset);'), isTrue);
+      expect(
+        n.contains('this.registerImageLateAnchor({charOffset: charOffset})'),
+        isTrue,
+        reason: '字符锚是布局无关真相，图 load 后必须按同一个 charOffset 重算',
+      );
+      expect(n.contains('this.registerImageLateAnchor({progress: 0})'), isTrue,
+          reason: '越界/<=0 回退章首的分支同样要登记（章首前导插图会下推正文）');
+    });
+
+    test('分页 jumpToFragment 登记 fragment 并复用同一份对齐换算', () {
+      final String n = norm(paginated);
+      expect(n.contains('alignToFragmentTarget: function(fragment)'), isTrue,
+          reason: 'fragment 对齐必须抽成共享方法，重锚不得复制一份会漂开的算法');
+      expect(
+        n.contains('this.registerImageLateAnchor({fragment: fragment})'),
+        isTrue,
+      );
+      expect(n.contains('if (!this.alignToFragmentTarget(fragment))'), isTrue,
+          reason: 'jumpToFragment 必须走共享对齐方法');
+    });
+
+    test('连续 shell 三条恢复路径同样登记', () {
+      final String n = norm(continuous);
+      expect(n.contains('this.registerImageLateAnchor({progress: 0})'), isTrue,
+          reason: '连续章首/越界回退登记');
+      expect(
+        n.contains('this.registerImageLateAnchor({progress: progress})'),
+        isTrue,
+        reason: '连续章末(≥0.99) 与中段登记',
+      );
+      expect(
+        n.contains(
+            'this.registerImageLateAnchor( {charOffset: charOffset, endCharOffset: endCharOffset})'),
+        isTrue,
+        reason: '连续精确锚必须连句尾锚一起登记（BUG-461 整句区间对齐）',
+      );
+      expect(
+        n.contains('this.registerImageLateAnchor({fragment: fragment})'),
+        isTrue,
+      );
+    });
+  });
+
+  group('用户翻页清资格', () {
+    for (final MapEntry<String, String> e in <String, String>{
+      '分页': 'paginated',
+      '连续': 'continuous',
+    }.entries) {
+      test('${e.key} paginate 入口清资格', () {
+        final String src = e.value == 'paginated' ? paginated : continuous;
+        final String body = bodyBetween(
+            src, 'paginate: function(direction)', 'getFirstVisibleCharOffset');
+        expect(body.contains('this.clearImageLateAnchor();'), isTrue,
+            reason: '用户翻页必须放弃图片 late-load 重锚资格');
+      });
+    }
+
+    test('clearImageLateAnchor 清掉全部三种锚（不留半个活锚）', () {
+      final String body = bodyBetween(
+          paginated, 'clearImageLateAnchor: function', '_isContinuousShell:');
+      for (final String field in <String>[
+        '__imgReanchorProgress',
+        '__imgReanchorCharOffset',
+        '__imgReanchorCharOffsetEnd',
+        '__imgReanchorFragment',
+      ]) {
+        expect(body.contains(field), isTrue, reason: '$field 必须被清');
+      }
+    });
+  });
+
+  group('图片 load 回调：失效 metrics + 按语义锚重算', () {
+    test('load 回调先失效 metrics 再调 reapplyImageLateAnchor', () {
+      final String n = norm(paginated);
+      expect(n.contains('r.paginationMetrics = null'), isTrue);
+      expect(n.contains('r.reapplyImageLateAnchor()'), isTrue,
+          reason: '迟到图片 load 必须触发语义重锚，而不是只失效 metrics');
+    });
+
+    test('reapply 分派：char 锚优先 → fragment → progress', () {
+      final String body = bodyBetween(
+          paginated,
+          'reapplyImageLateAnchor: function',
+          'notifyRestoreComplete: function');
+      final String n = norm(body);
+      final int charIdx = n.indexOf('this.scrollToCharOffset(co)');
+      final int fragIdx = n.indexOf('this.alignToFragmentTarget(');
+      final int progIdx = n.indexOf('this.scrollToProgressPaged(rctx, p)');
+      expect(charIdx, isNonNegative);
+      expect(fragIdx, greaterThan(charIdx), reason: '精确字符锚必须优先于 fragment');
+      expect(progIdx, greaterThan(fragIdx), reason: '粗粒度 progress 是最后的兜底');
+      expect(n.contains('rctx.pageSize <= 0'), isTrue,
+          reason: '重放前守卫 pageSize>0（避免未就绪 context 误锚）');
+    });
+
+    test('连续 / 分页分派用 scrollToChapterEnd 判别 shell（不能用共享方法）', () {
+      final String body = bodyBetween(
+          paginated, '_isContinuousShell: function', 'reapplyImageLateAnchor:');
+      expect(body.contains("typeof this.scrollToChapterEnd === 'function'"),
+          isTrue,
+          reason:
+              'scrollToProgressPaged 是 _sharedJs 两 shell 都有的，用它判别会让连续误走分页分支');
     });
   });
 }

--- a/hibiki/test/reader/chapter_start_illustration_charoffset_guard_test.dart
+++ b/hibiki/test/reader/chapter_start_illustration_charoffset_guard_test.dart
@@ -29,20 +29,27 @@ void main() {
   test('分页 restoreToCharOffset 把 charOffset<=0 当章首走 scrollToProgressPaged(0)',
       () {
     // 分页恢复入口：<=0 或越界 → scrollToProgressPaged(context, 0)（含前导插图的 minScroll）。
+    // 只钉「判据 + 该分支的落点调用」，分支体内后续语句（BUG-1140 第二轮的
+    // registerImageLateAnchor 重锚登记）不参与判定——本守卫管的是章首判据，不是语句序列。
     expect(
       n.contains(
-          'if (charOffset <= 0 || !this.charOffsetInRange(charOffset)) { this.scrollToProgressPaged(context, 0); } else { this.scrollToCharOffset(charOffset); }'),
+          'if (charOffset <= 0 || !this.charOffsetInRange(charOffset)) { this.scrollToProgressPaged(context, 0);'),
       isTrue,
       reason:
           '分页 restoreToCharOffset 必须以 charOffset<=0 判据落章首（minScroll，不越章首插图），'
           '不得回退成 charOffset<0（漏掉 0 → scrollToCharOffset(0) 跳过插图）',
+    );
+    expect(
+      n.contains('} else { this.scrollToCharOffset(charOffset);'),
+      isTrue,
+      reason: 'charOffset>0 仍走精确锚 scrollToCharOffset',
     );
   });
 
   test('连续 restoreToCharOffset 把 charOffset<=0 当章首走 scrollToChapterStart()',
       () {
     expect(
-      n.contains('if (charOffset <= 0) { this.scrollToChapterStart(); }'),
+      n.contains('if (charOffset <= 0) { this.scrollToChapterStart();'),
       isTrue,
       reason: '连续 restoreToCharOffset 必须以 charOffset<=0 判据落章首（滚到顶含前导图）',
     );

--- a/hibiki/test/reader/reader_image_lazy_markup_test.dart
+++ b/hibiki/test/reader/reader_image_lazy_markup_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/reader/reader_resource_sanitizer.dart';
+
+/// TODO-perf（跨章·图片）：`loading="lazy"` 必须在**生成 HTML 时**写进标签才对本次加载
+/// 生效（JS 侧那次跑在 `load` 之后，来不及）。这条规则跑在每次跨章的热路径上，标错一张
+/// 图就是分页几何塌缩或首屏空白，故把判定钉死。
+void main() {
+  group('ReaderResourceSanitizer.markImagesLazy', () {
+    test('普通插图挂 lazy + async 解码', () {
+      const String html = '<body><p>本文</p><img src="images/a.png"/></body>';
+      final String out = ReaderResourceSanitizer.markImagesLazy(html);
+      expect(out, contains('<img loading="lazy" decoding="async" src='));
+      expect(out, contains('images/a.png'));
+    });
+
+    test('纯图片章整章 eager（分页几何要靠插图真实撑开）', () {
+      const String html = '<body><img src="images/p1.png"/></body>';
+      expect(
+        ReaderResourceSanitizer.markImagesLazy(html, eagerAll: true),
+        html,
+      );
+    });
+
+    test('gaiji 内联小图保持 eager（参与文字排版几何）', () {
+      const String html = '<p>文<img class="gaiji" src="g.png"/>字</p>';
+      expect(ReaderResourceSanitizer.markImagesLazy(html), html);
+      const String html2 = "<p><img class='gaiji-line' src='g.png'/></p>";
+      expect(ReaderResourceSanitizer.markImagesLazy(html2), html2);
+    });
+
+    test('原书已写 loading= 的标签尊重原值', () {
+      const String html = '<img loading="eager" src="a.png"/>';
+      expect(ReaderResourceSanitizer.markImagesLazy(html), html);
+    });
+
+    test('多张图逐一处理，非 img 标签不受影响', () {
+      const String html = '<body><img src="a.png"/><p>文</p>'
+          '<image href="b.png"/><img src="c.png"/></body>';
+      final String out = ReaderResourceSanitizer.markImagesLazy(html);
+      expect('loading="lazy"'.allMatches(out).length, 2);
+      expect(out, contains('<image href="b.png"/>'));
+    });
+
+    test('幂等：再跑一次不会重复加属性', () {
+      const String html = '<img src="a.png"/>';
+      final String once = ReaderResourceSanitizer.markImagesLazy(html);
+      final String twice = ReaderResourceSanitizer.markImagesLazy(once);
+      expect(twice, once);
+    });
+
+    test('属性值里的字面 > 不会被当成标签结束', () {
+      const String html = '<img alt="a>b" src="a.png"/>';
+      expect(
+        ReaderResourceSanitizer.markImagesLazy(html),
+        '<img loading="lazy" decoding="async" alt="a>b" src="a.png"/>',
+      );
+    });
+
+    test('单引号属性同样按整串处理', () {
+      const String html = "<img alt='x>y' src='b.png'/>";
+      expect(
+        ReaderResourceSanitizer.markImagesLazy(html),
+        '<img loading="lazy" decoding="async" alt=\'x>y\' src=\'b.png\'/>',
+      );
+    });
+  });
+}

--- a/hibiki/test/reader/reader_image_lazy_pipeline_guard_test.dart
+++ b/hibiki/test/reader/reader_image_lazy_pipeline_guard_test.dart
@@ -1,0 +1,134 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/reader/reader_resource_sanitizer.dart';
+
+/// BUG-1140 第二轮守卫：`loading` 属性的**Dart 侧**流水线。
+///
+/// 为什么单独一条守卫：仓库里三条既有图片守卫
+/// （`image_chapter_lazy_load_guard_test` / `merged_image_eager_guard_test` /
+/// `prev_chapter_landing_guard_test`）**全是扫 `reader_pagination_scripts.dart` 这份 JS
+/// 源码**的。BUG-1140 第二轮把「哪些图挂 lazy」的判定提前到 Dart 侧
+/// （`webview.part.dart` → `ReaderResourceSanitizer.markImagesLazy`），因为属性只有写进
+/// HTML 源码才对**本次**加载生效。于是同一条业务规则有了第二份实现，而那三条守卫对它
+/// 一个字都管不到 —— 改坏了 CI 照样全绿。这条守卫补的就是这个洞。
+///
+/// 钉三件事：
+///   1. 合并前导插图（TODO-1339）必须自带显式 `loading="eager"`，让「保持 eager」不再
+///      依赖 `markImagesLazy` 与 `_injectMergedChapterImages` 的**调用顺序**。
+///   2. `markImagesLazy` 尊重已有 `loading=`（第 1 条成立的另一半）。
+///   3. 调用顺序本身仍锁住（第二道防线：万一有人删了显式 eager，顺序还在）。
+void main() {
+  final File webviewFile = File(
+    'lib/src/pages/implementations/reader_hibiki/webview.part.dart',
+  );
+  String webviewSrc() => webviewFile.readAsStringSync();
+
+  /// 去掉 `//` 行注释再扫——否则「注释里写了 `loading="eager"`」也能让守卫变绿，
+  /// 而真正 emit 的标签已经没有这个属性了（本守卫的负向验证踩过这个坑）。
+  String stripLineComments(String s) => s
+      .split('\n')
+      .where((String l) => !l.trimLeft().startsWith('//'))
+      .join('\n');
+
+  group('TODO-1339：合并前导插图的 eager 不再靠调用顺序', () {
+    test('_injectMergedChapterImages 注入的 <img> 自带 loading="eager"', () {
+      final String src = webviewSrc();
+      final int injectIdx = src.indexOf('String _injectMergedChapterImages(');
+      expect(injectIdx, isNonNegative, reason: '合并注入方法必须存在');
+      final int endIdx = src.indexOf('String? _chapterFilePath(', injectIdx);
+      expect(endIdx, greaterThan(injectIdx));
+      final String body = stripLineComments(src.substring(injectIdx, endIdx));
+      expect(body.contains('class="hoshi-merged-image"'), isTrue,
+          reason: 'JS 侧靠这个 marker 放行，两端接线必须一致');
+      expect(body.contains('loading="eager"'), isTrue,
+          reason: '注入的前导插图必须显式 eager —— 否则 eager 只由调用顺序保证，'
+              '谁调换顺序 TODO-1339 就复活而三条 JS 守卫全绿');
+    });
+
+    test('markImagesLazy 跳过显式 loading="eager"（顺序无关的另一半）', () {
+      const String merged = '<body><div class="hoshi-merged-image">'
+          '<img src="hoshi://a.png" class="block-img" loading="eager"/>'
+          '</div><p>本文</p><img src="b.png"/></body>';
+      final String out = ReaderResourceSanitizer.markImagesLazy(merged);
+      // 前导插图原样保留 eager；正文普通插图仍挂 lazy（不回退 TODO-1074）。
+      expect(out, contains('class="block-img" loading="eager"'));
+      expect(
+          out, isNot(contains('loading="lazy" decoding="async" src="hoshi:')));
+      expect('loading="lazy"'.allMatches(out).length, 1,
+          reason: '只有正文那张普通插图该被挂 lazy');
+    });
+
+    test('顺序仍锁住（第二道防线）：markImagesLazy 早于 _injectMergedChapterImages', () {
+      final String src = webviewSrc();
+      final int buildIdx =
+          src.indexOf('Uint8List _buildSanitizedChapterHtmlBytes(');
+      expect(buildIdx, isNonNegative);
+      final int endIdx =
+          src.indexOf('String _injectMergedChapterImages(', buildIdx);
+      expect(endIdx, greaterThan(buildIdx));
+      final String body = src.substring(buildIdx, endIdx);
+      final int lazyIdx =
+          body.indexOf('ReaderResourceSanitizer.markImagesLazy(');
+      final int injectIdx = body.indexOf('_injectMergedChapterImages(html');
+      expect(lazyIdx, isNonNegative, reason: 'Dart 侧 lazy 标记必须接在净化流水线里');
+      expect(injectIdx, isNonNegative);
+      expect(lazyIdx, lessThan(injectIdx),
+          reason: 'markImagesLazy 必须先于 _injectMergedChapterImages');
+    });
+  });
+
+  group('Dart 侧 eager 集合与 JS 侧不倒挂', () {
+    test('eagerAll 绑定纯图片章判定（TODO-1349 几何要靠插图真实撑开）', () {
+      final String src = webviewSrc();
+      final int lazyIdx =
+          src.indexOf('ReaderResourceSanitizer.markImagesLazy(');
+      expect(lazyIdx, isNonNegative);
+      final String call = src.substring(lazyIdx, lazyIdx + 200);
+      expect(call.contains('eagerAll: _isImageOnlyChapterCached('), isTrue,
+          reason: '纯图片章必须整章 eager，否则离屏图 0 尺寸 → maxScroll 塌缩');
+    });
+
+    test('纯图片章：eagerAll 下一个 lazy 都不加', () {
+      const String html = '<body><img src="p1.png"/><img src="p2.png"/></body>';
+      expect(
+          ReaderResourceSanitizer.markImagesLazy(html, eagerAll: true), html);
+    });
+
+    test('gaiji 内联小图无论哪条路径都不挂 lazy（参与文字排版几何）', () {
+      const String html = '<p>文<img class="gaiji-line" src="g.png"/>字</p>';
+      expect(ReaderResourceSanitizer.markImagesLazy(html), html);
+    });
+  });
+
+  group('预热配额与阅读方向（PR#469 审查）', () {
+    test('预热按张数 + 字节双封顶', () {
+      final String src = webviewSrc();
+      final int idx = src.indexOf('void _prefetchAdjacentChapterImages(');
+      expect(idx, isNonNegative);
+      final String body = src.substring(idx, idx + 1800);
+      expect(body.contains('_kImagePrefetchMaxCount'), isTrue,
+          reason: '预热必须有张数上限');
+      expect(body.contains('_kImagePrefetchMaxBytes'), isTrue,
+          reason: '预热必须有字节上限（整页插图书的内存压力是实打实的）');
+    });
+
+    test('预热跟随阅读方向，而不是写死 +1', () {
+      final File navFile = File(
+        'lib/src/pages/implementations/reader_hibiki/navigation.part.dart',
+      );
+      final String src =
+          navFile.readAsStringSync().replaceAll(RegExp(r'\s+'), ' ');
+      expect(
+          src.contains(
+              '_prefetchAdjacentChapterImages( _currentChapter + _chapterAdvanceDirection)'),
+          isTrue,
+          reason: '倒着读时必须预热上一章，而不是刚离开的那一章');
+      expect(
+          src.contains(
+              '_chapterAdvanceDirection = chapter > _currentChapter ? 1 : -1;'),
+          isTrue,
+          reason: '方向必须在唯一的导航采样点 _beginNavigation 更新');
+    });
+  });
+}

--- a/hibiki/test/reader/sparse_chapter_landing_guard_test.dart
+++ b/hibiki/test/reader/sparse_chapter_landing_guard_test.dart
@@ -48,41 +48,49 @@ void main() {
 
     test('continuous restoreProgress(>=0.99) registers reanchor + force-loads',
         () {
+      // BUG-1140 第二轮：重锚资格的登记收敛到 registerImageLateAnchor（三种语义锚统一），
+      // 章末分支的语义不变——登记 + 强制 load + 落章末，三件事仍在同一条链上。
       expect(
           continuous.contains(
-              'this.__imgReanchorProgress = progress; this.forceLoadPendingImages(); this.scrollToChapterEnd();'),
+              'this.registerImageLateAnchor({progress: progress}); this.forceLoadPendingImages(); this.scrollToChapterEnd();'),
           isTrue,
           reason: '连续 restoreProgress 章末分支须置重锚资格 + 强制 load + 落章末');
     });
 
     test('image load callback reanchors continuous via scrollToChapterEnd', () {
-      // 判别必须先查 scrollToChapterEnd（连续独有），再回退 scrollToProgressPaged（两 shell 共有）。
+      // BUG-1140 第二轮：分派从 load 回调内联搬进共享的 reapplyImageLateAnchor，
+      // 但「连续判别必须先于分页」这条不变——scrollToProgressPaged 两 shell 都有，
+      // 用它判别会让连续误走分页分支不重锚。
       for (final String shell in <String>[paged, continuous]) {
-        final int endIdx =
-            shell.indexOf("typeof r.scrollToChapterEnd === 'function'");
+        expect(shell.contains('r.reapplyImageLateAnchor()'), isTrue,
+            reason: 'load 回调须触发语义重锚');
+        final int reapplyIdx =
+            shell.indexOf('reapplyImageLateAnchor: function');
+        expect(reapplyIdx, greaterThan(0));
+        final int contIdx =
+            shell.indexOf('this._isContinuousShell()', reapplyIdx);
         final int pagedIdx =
-            shell.indexOf("typeof r.scrollToProgressPaged === 'function'");
-        expect(endIdx, greaterThan(0),
-            reason: 'load 回调须有连续重锚分支（scrollToChapterEnd 判别）');
-        expect(pagedIdx, greaterThan(0),
-            reason: 'load 回调须保留分页重锚分支（scrollToProgressPaged）');
-        expect(endIdx < pagedIdx, isTrue,
-            reason:
-                'scrollToChapterEnd 判别须在 scrollToProgressPaged 之前（否则连续误走分页分支不重锚）');
+            shell.indexOf('this.scrollToProgressPaged(rctx, p)', reapplyIdx);
+        expect(contIdx, greaterThan(0),
+            reason: 'reapply 须有连续分支（_isContinuousShell 判别）');
+        expect(pagedIdx, greaterThan(0), reason: 'reapply 须保留分页分支');
+        expect(contIdx < pagedIdx, isTrue,
+            reason: '连续判别须在分页 scrollToProgressPaged 之前');
+        expect(shell.contains("typeof this.scrollToChapterEnd === 'function'"),
+            isTrue,
+            reason: '判别判据必须是连续独有的 scrollToChapterEnd');
+        expect(
+            shell.contains('if (p >= 0.99) this.scrollToChapterEnd();'), isTrue,
+            reason: '连续重锚分支须在 >=0.99 时调 scrollToChapterEnd');
       }
-      expect(
-          continuous.contains(
-              'if (r.__imgReanchorProgress >= 0.99) r.scrollToChapterEnd();'),
-          isTrue,
-          reason: '连续重锚分支须在 >=0.99 时调 scrollToChapterEnd');
     });
 
-    test('continuous paginate clears __imgReanchorProgress', () {
+    test('continuous paginate clears the image late anchor', () {
       final int pIdx = continuous.indexOf('paginate: function(direction) {');
       expect(pIdx, greaterThan(0));
       final String window =
           continuous.substring(pIdx, (pIdx + 200).clamp(0, continuous.length));
-      expect(window.contains('this.__imgReanchorProgress = null;'), isTrue,
+      expect(window.contains('this.clearImageLateAnchor();'), isTrue,
           reason: '连续 paginate 须清重锚资格（避免尾图 late-load 拽回用户已翻走的位置）');
     });
 


### PR DESCRIPTION
## 这个 PR 做什么

带插图的跨章，**遮罩时长** 849ms → 101ms（图文混排章，4 张 1600×2400 PNG）。

**这不是 8 倍加速，请按延迟转移读。** 849→101ms 量的是「遮罩出现到撤除」。修复的本质是把
插图的读盘+解码从遮罩**之前**挪到遮罩**之后**——总工作量一点没少，只是不再串在「新章可见」
的关键路径上。用户拿到的是「翻页立刻见到文字，插图在章内异步补上」。
覆盖全部章型的整体口径是 `total 中位数 184 → 132ms`，收益远没有标题数字那么夸张。

样本口径：Windows 离屏 itest、debug build、同机同书、18 次跨章的**单点值**（非中位数）。

## 根因

`nav.dcl` 只有 15~20ms 而 `nav.load` 687~717ms —— DOM 早就解析完了，剩下 670ms 全在等图片
读盘+解码，而遮罩正好盖住这整段（setup 脚本挂在 `window.load` 之后才注入）。

`initialize` 里 TODO-1074 那段本来就想给每张 `<img>` 挂 `loading="lazy"`，理由写的正是
「不再拖住 window.load」——**但它跑得太晚**：脚本在 `load` 之后注入，浏览器早已按标签原始
属性把整章图片全部加载完毕。那行 lazy 迟到了一整个加载周期。

## 改动

1. **`ReaderResourceSanitizer.markImagesLazy`** —— lazy/decoding 的判定上移到 Dart 生成 HTML 时
   写进标签，属性才对本次加载生效。eager 例外与 JS 侧同款且更保守（Dart 的 eager 集合是 JS 的
   超集，不会倒挂）。
2. **`_prefetchAdjacentChapterImages`** —— 跨章落地后预热**阅读方向上**下一章的插图。
   带配额（4 张 / 8MB 磁盘字节），方向由 `_beginNavigation` 采样。
   位置很关键：必须挂在遮罩撤除之后，挂在之前只是把成本换个口袋（实测 `jsInitRestore` 顶到 520ms）。
3. **迟到图片的语义重锚**（第二轮审查退回后新增）—— 第 1 条把「插图未 decode」变成了恢复
   时刻的**常态**，于是把语义锚换算成 scrollTop 用的是「插图 0×0」的塌缩布局；插图随后 load、
   几何后移，冻结的 scrollTop 指向别的内容，进度轮询还会把这个漂掉的读数落库。
   原有的 `__imgReanchorProgress` 只覆盖章首(0)/章末(≥0.99)，**中段 progress、精确字符锚、
   fragment 跳转全部裸奔**。现在三种锚统一登记（`registerImageLateAnchor` /
   `reapplyImageLateAnchor`），两 shell × 全部恢复入口；字符偏移是布局无关的真相，按同一个锚
   重算即回到「插图本来就在」的落点。重锚走既有 `onReaderScroll` 通道把**修正后**的位置落库。
4. **合并前导插图改带显式 `loading="eager"`** —— TODO-1339 的 eager 不再由
   `markImagesLazy` / `_injectMergedChapterImages` 的调用顺序承重。

### 为什么不做「lazy 图尺寸预留」

审查建议优先给 lazy 图写 `aspect-ratio` / 宽高。查证后这条给不出精确保证：
`img.block-img` 的 CSS 是 `width:auto!important; height:auto!important`，宽高属性只在
`img:not(.block-img)` 阶段生效；而且 `_hoshiClassifyBlockImg` 在 load 后才把 img 包进
`.block-img-wrapper`（flex 盒），这个 DOM 变更本身就改几何。要精确就得在 Dart 侧重算整条
CSS 级联并预包 wrapper，而预包 wrapper 会让 `_hoshiBlurImage` 的图片防剧透遮罩永远不再应用。
尺寸预留只能让位移变小，消不掉；字符锚重锚能给等价终态。

## 测试

- `test/reader/chapter_jump_late_load_reanchor_test.dart`（重写）：三种语义锚全登记 +
  翻页清资格 + reapply 分派顺序 + 负向「旧的窄资格表达式必须已消失」
- `test/reader/reader_image_lazy_pipeline_guard_test.dart`（新）：补上「三条既有图片守卫全是
  扫 JS 源码、管不到 Dart 侧同一份判定」的洞。**已做负向验证**：调换 `markImagesLazy` /
  `_injectMergedChapterImages` 顺序 + 删掉显式 eager 后，新守卫 2 条转红，旧三条
  （`merged_image_eager_guard` / `prev_chapter_landing_guard` / `image_chapter_lazy_load_guard`）
  **全绿** —— 这就是逃逸本身。还原后全绿。
- `integration_test/reader_cross_chapter_perf_itest.dart`：settle **调回 1500ms**（判据是
  settle 尾沿 + 450ms 跨章冷却窗，不是「等预热跑完」；调长等于把测量条件调到最有利于新代码
  的稳态）。新增**中段落点回归**用例：真实退出重进 → 图文混排插图章中段锚 → 重进落点与锚的
  偏差必须在一页之内，容差用同章同版式实测 `pageSpan` 自校准。

## 未解决 / 未测量（如实）

- 纯整页插图章仍要 355~541ms 且不稳定：它按设计不能挂 lazy（分页几何依赖插图真实尺寸），
  只能靠预热覆盖，命中与否取决于用户在上一章停留多久 + WebView 缓存是否保留。
- 图文混排章的 101ms **是否依赖预热命中**没有单独拆开量；快速连翻 / 目录跳转时预热必然不命中，
  那种情况的数字未测量。
- 中段落点 itest 本轮未在真机 / 离屏跑（Windows 离屏冒烟目标已知红），只保证编译 + analyze 通过。
