### PR TITLE
fix(gal): 三态降级策略 + 音轨静音判据修正（BUG-1187/1165）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1150 条。点号进各自文件。
+> 共 1152 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1187](bugs/BUG-1187-gal-unvoiced-line-gets-bgm.md) | ✅ | ✅ | galgame 无配音句被整机混音兜底成 BGM |
 | [BUG-1186](bugs/BUG-1186-appbar-actions-collapse-uses-window-width.md) | ✅ | ✅ | AppBar 动作折叠判据读整窗宽，分栏/受限宽容器里永不折叠 |
 | [BUG-1185](bugs/BUG-1185-remote-mining-duplicate-auth-swallowed.md) | ✅ | ✅ | 远端制卡查重吞掉认证失败，静默答「不重复」 |
 | [BUG-1184](bugs/BUG-1184-narrow-screen-segmented-clipped.md) | ✅ | ✅ | 窄屏/小窗口下多处内容显示不全（说明文字、分段控件、书名、对话框标题） |
@@ -54,6 +55,7 @@
 | [BUG-1168](bugs/BUG-1168-post-frame-focus-reclaim-never-fires-on-idle-tree.md) | ✅ | ✅ | 静止树上 addPostFrameCallback 焦点回收永不触发（进出全屏/关字幕遮罩后快捷键失灵） |
 | [BUG-1167](bugs/BUG-1167-video-subtitle-align-dialog-focus-not-returned.md) | ✅ | ✅ | 视频字幕波形对轴弹窗关闭后不归还键盘焦点 |
 | [BUG-1166](bugs/BUG-1166-gal-lookup-wheel-passthrough-to-game.md) | ✅ | ✅ | galgame 查词卡滚轮穿透到游戏 |
+| [BUG-1165](bugs/BUG-1165-gal-track-panel-silent-predicate.md) | ✅ | ✅ | 音轨面板静音判据用错字段，空白轨从不置灰 |
 | [BUG-1164](bugs/BUG-1164-manga-module-orphan-i18n-and-shelf-naming.md) | ✅ | ✅ | 漫画模块化重构遗留孤儿 i18n key 与 shelf 页面名违规 |
 | [BUG-1163](bugs/BUG-1163-manga-ocr-silent-provider-fallback.md) | ✅ | ✅ | 漫画 OCR GPU 加速降级到 CPU 完全静默 |
 | [BUG-1162](bugs/BUG-1162-torrent-pipeline-disk-flush-race.md) | ✅ | ✅ | hibiki_torrent 端到端测试在字节落盘前就比对，CI Windows 约 24% 概率红 |

--- a/docs/bugs/BUG-1165-gal-track-panel-silent-predicate.md
+++ b/docs/bugs/BUG-1165-gal-track-panel-silent-predicate.md
@@ -1,0 +1,17 @@
+## BUG-1165 · 音轨面板静音判据用错字段，空白轨从不置灰
+- **报告**：2026-07-27（用户：音轨列表里总是有空白的轨，点了播放不了却一直挂在那）
+- **真实性**：✅ 真 bug，两层原因叠加：
+  - **列表里为什么总有那么多轨**：`hibiki/windows/runner/voice_hook_reader.cpp:593` 起按 `source_ptr` 聚合**整个环形缓冲**里出现过的每一个音频源。galgame 的 XAudio2/DirectSound 引擎常年维护一池 source voice（SE、系统音、播完的旧语音都在 60 秒环里），所以列表里挂一堆此刻并不发声的轨是**正常形态**，不是故障。
+  - **为什么它们没被标注/置灰**：`gal_audio_tracks_panel.dart` 的判据是 `track.clipCount <= 0`，而 native 的 `clip_count` 是**全环累计**（`voice_hook_reader.cpp:605` 的 `clip_count++` 不带时间窗过滤；时间窗 `[ts-150, ts+450]` 只用于 `avg_energy`）。一条轨能出现在列表里，前提就是环里至少有它的一个片段 → **该条件恒为假**，BUG-1102 ② 想做的「置灰 + 标注 + 不可点」从来没生效过。
+  - 于是这些轨看起来和真能取到语音的轨一模一样，而试听走 `grabUtterance(该句时刻, sourcePtr)`（`gal_hook_session_controller.dart` 的 `_exportTrackPreviewAt`）用的正是同一个时刻窗 → 抓不到 → 只弹一句「试听失败」。
+  - 附带：Dart 侧 `GalAudioTrack` 的 `clipCount` / `avgBytes` / `orderIndex` 文档注释都写成「近窗内」，与 native 实现脱钩，正是判据选错字段的诱因。
+- **[x] ① 已修复** — 判据换成真正表达「此刻有没有响」的字段，且**在 native 侧补出这个字段**：
+  - runner 新增 `VoiceTrackInfo::clip_count_at_cue`（`voice_hook_reader.h` / `.cpp` 在文本时刻窗内无条件计数、`flutter_window.cpp` 编码成 `clipCountAtCue`）。**这是纯 runner 侧统计，只读共享内存里已有的 `timestamp_ms`，不动 IPC 契约、不碰 injector/hook DLL、无需跨仓**（首轮记录误判为「要改共享内存结构」，实为读取端就能算）。
+  - `GalAudioTrack.isSilentAtCue` = `clipCountAtCue == 0`；`clipCountAtCue < 0`（老 runner 不发该字段）时退回能量判据，且只对 16-bit 下结论——宁可不置灰也不误伤。
+  - 为什么必须新开字段：**`avgEnergy == -1` 有两义**——① 时刻窗内真没片段；② 该轨不是 16-bit，native `ClipEnergy16Locked` 算不了能量。只按正负判会把非 16-bit 的**可用**轨也锁成不可点。有了片段数，非 16-bit 轨也能被正确判定。
+  - 副标题不再无条件打印「能量 -1.0」（那是内部哨兵值，不是给用户看的），只在 `avgEnergy >= 0` 时显示。
+  - 文案 `game_track_no_clips`「近窗内没有片段」→ 新 key `game_track_silent_at_cue`「这句时刻没有声音」；`clipCount` / `avgBytes` / `orderIndex` 的 Dart 与 native 注释统一改回「环内累计」。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_audio_degrade_track_test.dart`：
+  - 行为测试 `BUG-1165：此刻静音判据走时刻窗片段数，clipCount 不参与、非 16-bit 不误伤`（覆盖新 runner 精确判定、非 16-bit 两个方向、`clipCount=99` 仍判静音、老 runner 缺字段回退，以及 `fromMap` 缺字段解析成 -1 而非 0）；
+  - 同文件源码守卫加断言：`track.clipCount <= 0` 不得再出现、`silent` 必须走 `isSilentAtCue`。
+- **备注**：C++ 侧无单测框架，靠 `flutter build windows --debug` 编译验证 + 上述 Dart 契约测试。真机验收待补：需确认列表里此刻不发声的轨确实置灰且不可点、非 16-bit 轨不被误灰。同 PR：[BUG-1187](BUG-1187-gal-unvoiced-line-gets-bgm.md)（BUG-1160「制卡封面可选静态截图」是新增能力不是缺陷，已按用户要求拆到独立 PR）。

--- a/docs/bugs/BUG-1187-gal-unvoiced-line-gets-bgm.md
+++ b/docs/bugs/BUG-1187-gal-unvoiced-line-gets-bgm.md
@@ -1,0 +1,22 @@
+## BUG-1187 · galgame 无配音句被整机混音兜底成 BGM
+- **报告**：2026-07-27（用户：部分游戏只有一部分句子有配音，没配音的句子制卡后音频是 BGM；「禁止 BGM」能标掉音轨，「禁止降级」不知道怎么弄）
+- **真实性**：✅ 真 bug。根因不是「降级开关缺失」（开关存在），是**开关管不到真正产生 BGM 的那一层**：
+  - `hibiki/lib/src/mining/gal_hook_session_controller.dart:2650` `_activateResourceWithLoopback` 把资源模式会话的 `_audioSource` 指向 system loopback（原始资源是首选、混音只作兜底）。
+  - 于是 `gal_hook_session_controller.dart:3460` `_attachLineAudio` 对**每一行**无差别排 `_scheduleLoopbackFreeze`，到点把整机混音冻结成该行语音。没有配音的句子（旁白/心理描写/选项）冻到的必然是纯 BGM/环境音。
+  - 旧 `allowAudioFallback` 只在制卡期 `_captureAudioBytesNow`（同文件 2204）一处生效，逐行捕获期完全不受管；且它的语义是「只接受 game_resource 原始文件」，把混音前抓的**干净引擎 PCM** 一并禁掉，没有资源 hook 的引擎一关就全灭。
+  - 关掉它还会让 `gal_hook_mining_coordinator.dart:219` 把整张卡判失败，用户被迫在「收一段 BGM」和「这张卡做不了」之间二选一。
+- **[x] ① 已修复** — 用三态 `GalAudioFallbackPolicy`（`full` / `cleanOnly` / `resourceOnly`）取代 bool，把「干净与否」和「有没有原件」拆开；gate 补到真正产生混音的那一层：
+  - `_scheduleLoopbackFreeze` 自身加策略守卫（覆盖 `_attachLineAudio` 与 `_settleLineUtterance` 两个调用点，漏一个就等于策略静默失效）；
+  - `_captureAudioBytesNow` 与 `_attachLineAudio` 按**音源类型**（`source is LoopbackGalAudioSource`）判定这条兜底链只能取到混音，`cleanOnly` 下不再塞一段 BGM；
+  - 抑制之后**报什么按证据判**（`_classifySuppressedLoopbackMiss`）：原件配对在途（`_pendingResourceMatches`）→ `utterance_not_found`（疑似漏抓）；引擎能枚举出该句时刻窗的**非空**候选轨 → `_hasSoundingCandidateTrack`（有轨响过=漏抓、全静默=无配音）；两种证据都没有 → 新常量 `kGalCleanSourceSuppressedReason`，UI 单独渲染「已跳过混音」并在 tooltip 明说「不代表这句没有配音」。**绝不允许**零证据时冒充 `line_has_no_voice`：那会把纯 loopback 降级会话的每一行都说成游戏没配音，也会把资源模式的真漏抓一起盖掉（违反「不得用前一阶段推断后一阶段」）；
+  - 候选轨判据用 `GalAudioTrack.isSilentAtCue` 而非 `avgEnergy >= 0`：后者的 -1 有两义（窗内无片段 / 非 16-bit 算不了能量，见 BUG-1165），拿它当有无判据会把真响过的非 16-bit 语音轨判成静默，进而把整句宣布成「无配音」——同一类「把判不出说成没有」的错误；
+  - coordinator 只在最严格的 `resourceOnly` 下拒绝制卡，`cleanOnly` 缺音频照常成卡（无音频）。
+  - 策略随 `GalCaptureMemory` 按游戏持久化，会话启动即恢复（不能搭 `_applyTrackMemory` 的便车——资源模式根本不枚举音轨，等音轨快照永远等不到）。
+  - 顺带修一个既有隐患：`_resetCaptureMemorySession` 原先只在 `stopCapture` 里调，用户不点「停止监听」直接启动下一个游戏时，上一个游戏的排除集/语音轨会套到新游戏上、而新游戏的选择又写回旧 key。改为在 `_beginActivitySession` 重置（launch / attach 两条开新会话路径共用）。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_hook_session_controller_test.dart`：
+  - `clean-source policy refuses loopback mix for a line with no voice`（断言 `grabRecentCalls == 0`——一次都不许去环里取混音）；
+  - `audio fallback policy is remembered per game and restored on launch`（含「换游戏不得继承上一个游戏策略」）；
+  - `clean-source policy still reports a missed utterance as a miss`（cleanOnly 下「有配音但漏抓」必须仍报 `utterance_not_found`，不得说成无配音）；
+  - `hibiki/test/mining/gal_hook_mining_coordinator_test.dart`：`clean-source mode still mines the card when the line has no voice`。
+- **UI**：只在捕获工作台原有的「更多」溢出菜单里，把旧的 bool 开关项换成三档策略入口（菜单项显示当前档位，点开是带代价说明的单选对话框）。顶栏其余入口（启动并捕获 / 活跃音轨 / 溢出菜单本身）一律不动——那是本 bug 之外的 UI 偏好，删用户能力和改守卫都需要显式授权。
+- **备注**：原编号 BUG-1144，与外部 PR#474 带入的 manga bug 撞号让至 1164；rebase 到最新 develop 时 1164 又被已合入的 manga bug（BUG-1164-manga-module-orphan-i18n-and-shelf-naming）占用，再让号至 1187（文件名 + 正文 H2 + 交叉引用同步改，`bug.dart check` 通过）。真机验收待补：需在只有部分句子配音的游戏上确认「无配音」灰标 /「已跳过混音」/ 真漏抓红标三分，且不再收进 BGM。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45815 (2695 per locale)
+/// Strings: 45951 (2703 per locale)
 ///
-/// Built on 2026-07-28 at 05:37 UTC
+/// Built on 2026-07-28 at 05:54 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -1217,7 +1217,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get game_audio_backend_none => 'No audio source';
   String get game_audio_backend_resource => 'Game resource audio';
   String get game_audio_duration => 'Audio duration';
-  String get game_audio_fallback_allow => 'Allow audio fallback';
   String get game_audio_fallback_disabled_missing =>
       'No matching game resource audio; fallback is disabled';
   String get game_audio_resource_id => 'Audio resource ID';
@@ -1497,7 +1496,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get game_track_exclusion_hint =>
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  String get game_track_no_clips => 'No clips in the recent window';
   String get game_track_preview => 'Preview this track';
   String get game_track_preview_failed =>
       'No recent audio could be captured from this track';
@@ -3615,6 +3613,20 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  String get game_audio_fallback_policy => 'Audio fallback';
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  String get game_audio_fallback_clean => 'Clean sources only';
+  String get game_audio_fallback_resource => 'Original resources only';
+  String get game_track_silent_at_cue => 'No sound at this line';
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  String get game_line_audio_suppressed => 'Mix skipped';
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -5458,8 +5470,6 @@ class _StringsAr extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -5966,8 +5976,6 @@ class _StringsAr extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -9773,6 +9781,30 @@ class _StringsAr extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -11644,8 +11676,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -12152,8 +12182,6 @@ class _StringsDe extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -15999,6 +16027,30 @@ class _StringsDe extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -17871,8 +17923,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -18379,8 +18429,6 @@ class _StringsEs extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -22241,6 +22289,30 @@ class _StringsEs extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -24121,8 +24193,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -24629,8 +24699,6 @@ class _StringsFr extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -28494,6 +28562,30 @@ class _StringsFr extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -30340,8 +30432,6 @@ class _StringsId extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -30848,8 +30938,6 @@ class _StringsId extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -34676,6 +34764,30 @@ class _StringsId extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -36542,8 +36654,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -37050,8 +37160,6 @@ class _StringsIt extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -40904,6 +41012,30 @@ class _StringsIt extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -42715,8 +42847,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -43223,8 +43353,6 @@ class _StringsJa extends _StringsEn {
       'BGM／環境音のトラックを除外に設定すると、自動選択がそれを音声として扱わなくなります——音声のないセリフで BGM を拾わなくなります。';
   @override
   String get game_track_exclusion_title => '音声トラックを除外';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -46949,6 +47077,30 @@ class _StringsJa extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -48760,8 +48912,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -49268,8 +49418,6 @@ class _StringsKo extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -52996,6 +53144,30 @@ class _StringsKo extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -54856,8 +55028,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -55364,8 +55534,6 @@ class _StringsNl extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -59204,6 +59372,30 @@ class _StringsNl extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -61072,8 +61264,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -61580,8 +61770,6 @@ class _StringsPtBr extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -65425,6 +65613,30 @@ class _StringsPtBr extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -67285,8 +67497,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -67793,8 +68003,6 @@ class _StringsRu extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -71630,6 +71838,30 @@ class _StringsRu extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -73468,8 +73700,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -73976,8 +74206,6 @@ class _StringsTh extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -77783,6 +78011,30 @@ class _StringsTh extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -79639,8 +79891,6 @@ class _StringsTr extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -80147,8 +80397,6 @@ class _StringsTr extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -83968,6 +84216,30 @@ class _StringsTr extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -85817,8 +86089,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -86325,8 +86595,6 @@ class _StringsVi extends _StringsEn {
       'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
   @override
   String get game_track_exclusion_title => 'Exclude audio tracks';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -90138,6 +90406,30 @@ class _StringsVi extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 // Path: <root>
@@ -91855,8 +92147,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get game_audio_duration => '音频时长';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -92333,8 +92623,6 @@ class _StringsZhCn extends _StringsEn {
       '把 BGM/环境音轨标记为排除，自动选源便不会把它当成语音——没有语音的台词也不会再读到 BGM。';
   @override
   String get game_track_exclusion_title => '排除音轨';
-  @override
-  String get game_track_no_clips => '近窗内没有片段';
   @override
   String get game_track_preview => '试听该音轨';
   @override
@@ -95877,6 +96165,28 @@ class _StringsZhCn extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       '已备份到 ${path}（按「保留 90 天、至少留 10 份」清理了 ${count} 份旧备份）';
+  @override
+  String get game_audio_fallback_policy => '音频降级';
+  @override
+  String get game_audio_fallback_full => '允许混音兜底';
+  @override
+  String get game_audio_fallback_clean => '只用干净语音';
+  @override
+  String get game_audio_fallback_resource => '只用游戏原始资源';
+  @override
+  String get game_track_silent_at_cue => '这句时刻没有声音';
+  @override
+  String get game_audio_fallback_full_hint => '抓不到干净语音时用系统混音兜底，可能混入 BGM 和音效。';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      '只用游戏资源音频和引擎 PCM。没有配音的句子照常制卡，只是不带音频，不会收进 BGM。';
+  @override
+  String get game_audio_fallback_resource_hint => '必须拿到游戏自带的原始语音文件，缺失时拒绝制卡。';
+  @override
+  String get game_line_audio_suppressed => '已跳过混音';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      '本句没有干净音源可用，整机混音已按你选的降级策略跳过。这不代表这句没有配音。';
 }
 
 // Path: <root>
@@ -97658,8 +97968,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get game_audio_duration => 'Audio duration';
   @override
-  String get game_audio_fallback_allow => '允许音频降级';
-  @override
   String get game_audio_fallback_disabled_missing =>
       '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
   @override
@@ -98166,8 +98474,6 @@ class _StringsZhHk extends _StringsEn {
       '把 BGM/環境音軌標記為排除，自動選源便不會把它當成語音——沒有語音的台詞也不會再讀到 BGM。';
   @override
   String get game_track_exclusion_title => '排除音軌';
-  @override
-  String get game_track_no_clips => 'No clips in the recent window';
   @override
   String get game_track_preview => 'Preview this track';
   @override
@@ -101843,6 +102149,30 @@ class _StringsZhHk extends _StringsEn {
   String anki_lapis_backup_done_pruned(
           {required Object path, required Object count}) =>
       'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+  @override
+  String get game_audio_fallback_policy => 'Audio fallback';
+  @override
+  String get game_audio_fallback_full => 'Allow mixed audio';
+  @override
+  String get game_audio_fallback_clean => 'Clean sources only';
+  @override
+  String get game_audio_fallback_resource => 'Original resources only';
+  @override
+  String get game_track_silent_at_cue => 'No sound at this line';
+  @override
+  String get game_audio_fallback_full_hint =>
+      'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+  @override
+  String get game_audio_fallback_clean_hint =>
+      'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+  @override
+  String get game_audio_fallback_resource_hint =>
+      'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+  @override
+  String get game_line_audio_suppressed => 'Mix skipped';
+  @override
+  String get game_line_audio_suppressed_hint =>
+      'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
 }
 
 /// Flat map(s) containing all translations.
@@ -103468,8 +103798,6 @@ extension on _StringsEn {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return 'Allow audio fallback';
       case 'game_audio_fallback_disabled_missing':
         return 'No matching game resource audio; fallback is disabled';
       case 'game_audio_resource_id':
@@ -103928,8 +104256,6 @@ extension on _StringsEn {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -107365,6 +107691,26 @@ extension on _StringsEn {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -108991,8 +109337,6 @@ extension on _StringsAr {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -109451,8 +109795,6 @@ extension on _StringsAr {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -112885,6 +113227,26 @@ extension on _StringsAr {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -114514,8 +114876,6 @@ extension on _StringsDe {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -114974,8 +115334,6 @@ extension on _StringsDe {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -118426,6 +118784,26 @@ extension on _StringsDe {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -120056,8 +120434,6 @@ extension on _StringsEs {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -120516,8 +120892,6 @@ extension on _StringsEs {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -123966,6 +124340,26 @@ extension on _StringsEs {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -125599,8 +125993,6 @@ extension on _StringsFr {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -126059,8 +126451,6 @@ extension on _StringsFr {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -129512,6 +129902,26 @@ extension on _StringsFr {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -131140,8 +131550,6 @@ extension on _StringsId {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -131600,8 +132008,6 @@ extension on _StringsId {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -135040,6 +135446,26 @@ extension on _StringsId {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -136670,8 +137096,6 @@ extension on _StringsIt {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -137130,8 +137554,6 @@ extension on _StringsIt {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -140583,6 +141005,26 @@ extension on _StringsIt {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -142202,8 +142644,6 @@ extension on _StringsJa {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -142662,8 +143102,6 @@ extension on _StringsJa {
         return 'BGM／環境音のトラックを除外に設定すると、自動選択がそれを音声として扱わなくなります——音声のないセリフで BGM を拾わなくなります。';
       case 'game_track_exclusion_title':
         return '音声トラックを除外';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -146088,6 +146526,26 @@ extension on _StringsJa {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -147708,8 +148166,6 @@ extension on _StringsKo {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -148168,8 +148624,6 @@ extension on _StringsKo {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -151597,6 +152051,26 @@ extension on _StringsKo {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -153226,8 +153700,6 @@ extension on _StringsNl {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -153686,8 +154158,6 @@ extension on _StringsNl {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -157133,6 +157603,26 @@ extension on _StringsNl {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -158761,8 +159251,6 @@ extension on _StringsPtBr {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -159221,8 +159709,6 @@ extension on _StringsPtBr {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -162666,6 +163152,26 @@ extension on _StringsPtBr {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -164297,8 +164803,6 @@ extension on _StringsRu {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -164757,8 +165261,6 @@ extension on _StringsRu {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -168204,6 +168706,26 @@ extension on _StringsRu {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -169828,8 +170350,6 @@ extension on _StringsTh {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -170288,8 +170808,6 @@ extension on _StringsTh {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -173726,6 +174244,26 @@ extension on _StringsTh {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -175355,8 +175893,6 @@ extension on _StringsTr {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -175815,8 +176351,6 @@ extension on _StringsTr {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -179257,6 +179791,26 @@ extension on _StringsTr {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -180883,8 +181437,6 @@ extension on _StringsVi {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -181343,8 +181895,6 @@ extension on _StringsVi {
         return 'Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.';
       case 'game_track_exclusion_title':
         return 'Exclude audio tracks';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -184783,6 +185333,26 @@ extension on _StringsVi {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }
@@ -186394,8 +186964,6 @@ extension on _StringsZhCn {
         return '游戏资源音频';
       case 'game_audio_duration':
         return '音频时长';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -186853,8 +187421,6 @@ extension on _StringsZhCn {
         return '把 BGM/环境音轨标记为排除，自动选源便不会把它当成语音——没有语音的台词也不会再读到 BGM。';
       case 'game_track_exclusion_title':
         return '排除音轨';
-      case 'game_track_no_clips':
-        return '近窗内没有片段';
       case 'game_track_preview':
         return '试听该音轨';
       case 'game_track_preview_failed':
@@ -190263,6 +190829,26 @@ extension on _StringsZhCn {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             '已备份到 ${path}（按「保留 90 天、至少留 10 份」清理了 ${count} 份旧备份）';
+      case 'game_audio_fallback_policy':
+        return '音频降级';
+      case 'game_audio_fallback_full':
+        return '允许混音兜底';
+      case 'game_audio_fallback_clean':
+        return '只用干净语音';
+      case 'game_audio_fallback_resource':
+        return '只用游戏原始资源';
+      case 'game_track_silent_at_cue':
+        return '这句时刻没有声音';
+      case 'game_audio_fallback_full_hint':
+        return '抓不到干净语音时用系统混音兜底，可能混入 BGM 和音效。';
+      case 'game_audio_fallback_clean_hint':
+        return '只用游戏资源音频和引擎 PCM。没有配音的句子照常制卡，只是不带音频，不会收进 BGM。';
+      case 'game_audio_fallback_resource_hint':
+        return '必须拿到游戏自带的原始语音文件，缺失时拒绝制卡。';
+      case 'game_line_audio_suppressed':
+        return '已跳过混音';
+      case 'game_line_audio_suppressed_hint':
+        return '本句没有干净音源可用，整机混音已按你选的降级策略跳过。这不代表这句没有配音。';
       default:
         return null;
     }
@@ -191881,8 +192467,6 @@ extension on _StringsZhHk {
         return 'Game resource audio';
       case 'game_audio_duration':
         return 'Audio duration';
-      case 'game_audio_fallback_allow':
-        return '允许音频降级';
       case 'game_audio_fallback_disabled_missing':
         return '未找到与该句匹配的游戏资源音频；已关闭降级，未制卡';
       case 'game_audio_resource_id':
@@ -192341,8 +192925,6 @@ extension on _StringsZhHk {
         return '把 BGM/環境音軌標記為排除，自動選源便不會把它當成語音——沒有語音的台詞也不會再讀到 BGM。';
       case 'game_track_exclusion_title':
         return '排除音軌';
-      case 'game_track_no_clips':
-        return 'No clips in the recent window';
       case 'game_track_preview':
         return 'Preview this track';
       case 'game_track_preview_failed':
@@ -195763,6 +196345,26 @@ extension on _StringsZhHk {
       case 'anki_lapis_backup_done_pruned':
         return ({required Object path, required Object count}) =>
             'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
+      case 'game_audio_fallback_policy':
+        return 'Audio fallback';
+      case 'game_audio_fallback_full':
+        return 'Allow mixed audio';
+      case 'game_audio_fallback_clean':
+        return 'Clean sources only';
+      case 'game_audio_fallback_resource':
+        return 'Original resources only';
+      case 'game_track_silent_at_cue':
+        return 'No sound at this line';
+      case 'game_audio_fallback_full_hint':
+        return 'Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.';
+      case 'game_audio_fallback_clean_hint':
+        return 'Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.';
+      case 'game_audio_fallback_resource_hint':
+        return 'Requires the original voice file shipped with the game; mining is refused when it is missing.';
+      case 'game_line_audio_suppressed':
+        return 'Mix skipped';
+      case 'game_line_audio_suppressed_hint':
+        return 'No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "Allow audio fallback",
   "game_audio_fallback_disabled_missing": "No matching game resource audio; fallback is disabled",
   "game_audio_resource_id": "Audio resource ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "BGM／環境音のトラックを除外に設定すると、自動選択がそれを音声として扱わなくなります——音声のないセリフで BGM を拾わなくなります。",
   "game_track_exclusion_title": "音声トラックを除外",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "Mark a BGM/ambience track as excluded so auto-selection never treats it as voice — lines without speech no longer pick up BGM.",
   "game_track_exclusion_title": "Exclude audio tracks",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "无音频源",
   "game_audio_backend_resource": "游戏资源音频",
   "game_audio_duration": "音频时长",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "活跃音轨",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "标记为 BGM",
   "game_track_exclusion_hint": "把 BGM/环境音轨标记为排除，自动选源便不会把它当成语音——没有语音的台词也不会再读到 BGM。",
   "game_track_exclusion_title": "排除音轨",
-  "game_track_no_clips": "近窗内没有片段",
   "game_track_preview": "试听该音轨",
   "game_track_preview_failed": "未能从该音轨抓到最近的音频片段",
   "game_track_preview_stop": "停止试听",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "发现 $count 个重复的 Anki 媒体文件（可释放 $size）",
   "anki_dedup_auto_review": "查看",
   "anki_dedup_auto_done": "已删除 $count 个重复的 Anki 媒体文件，释放 $size",
-  "anki_lapis_backup_done_pruned": "已备份到 $path（按「保留 90 天、至少留 10 份」清理了 $count 份旧备份）"
+  "anki_lapis_backup_done_pruned": "已备份到 $path（按「保留 90 天、至少留 10 份」清理了 $count 份旧备份）",
+  "game_audio_fallback_policy": "音频降级",
+  "game_audio_fallback_full": "允许混音兜底",
+  "game_audio_fallback_clean": "只用干净语音",
+  "game_audio_fallback_resource": "只用游戏原始资源",
+  "game_track_silent_at_cue": "这句时刻没有声音",
+  "game_audio_fallback_full_hint": "抓不到干净语音时用系统混音兜底，可能混入 BGM 和音效。",
+  "game_audio_fallback_clean_hint": "只用游戏资源音频和引擎 PCM。没有配音的句子照常制卡，只是不带音频，不会收进 BGM。",
+  "game_audio_fallback_resource_hint": "必须拿到游戏自带的原始语音文件，缺失时拒绝制卡。",
+  "game_line_audio_suppressed": "已跳过混音",
+  "game_line_audio_suppressed_hint": "本句没有干净音源可用，整机混音已按你选的降级策略跳过。这不代表这句没有配音。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -782,7 +782,6 @@
   "game_audio_backend_none": "No audio source",
   "game_audio_backend_resource": "Game resource audio",
   "game_audio_duration": "Audio duration",
-  "game_audio_fallback_allow": "允许音频降级",
   "game_audio_fallback_disabled_missing": "未找到与该句匹配的游戏资源音频；已关闭降级，未制卡",
   "game_audio_resource_id": "音频资源 ID",
   "game_audio_tracks": "Active audio tracks",
@@ -1011,7 +1010,6 @@
   "game_track_exclude_bgm": "Mark as BGM",
   "game_track_exclusion_hint": "把 BGM/環境音軌標記為排除，自動選源便不會把它當成語音——沒有語音的台詞也不會再讀到 BGM。",
   "game_track_exclusion_title": "排除音軌",
-  "game_track_no_clips": "No clips in the recent window",
   "game_track_preview": "Preview this track",
   "game_track_preview_failed": "No recent audio could be captured from this track",
   "game_track_preview_stop": "Stop preview",
@@ -2693,5 +2691,15 @@
   "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
   "anki_dedup_auto_review": "Review",
   "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
-  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)",
+  "game_audio_fallback_policy": "Audio fallback",
+  "game_audio_fallback_full": "Allow mixed audio",
+  "game_audio_fallback_clean": "Clean sources only",
+  "game_audio_fallback_resource": "Original resources only",
+  "game_track_silent_at_cue": "No sound at this line",
+  "game_audio_fallback_full_hint": "Falls back to the system mix when no clean voice is captured; the clip may contain BGM and effects.",
+  "game_audio_fallback_clean_hint": "Uses game resource audio and engine PCM only. Lines with no voice are mined without audio instead of picking up BGM.",
+  "game_audio_fallback_resource_hint": "Requires the original voice file shipped with the game; mining is refused when it is missing.",
+  "game_line_audio_suppressed": "Mix skipped",
+  "game_line_audio_suppressed_hint": "No clean audio source produced audio for this line, and the system mix was skipped by your audio fallback policy. This does not mean the line has no voice."
 }

--- a/hibiki/lib/src/mining/gal_audio_tracks_panel.dart
+++ b/hibiki/lib/src/mining/gal_audio_tracks_panel.dart
@@ -127,9 +127,15 @@ class GalTrackTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final PcmFormat format = track.format;
-    // 近窗内一个片段都没有的轨：留在列表里（用户需要知道它存在），但明确标注并置灰，
-    // 不再让它看起来和真能取到语音的轨一样（BUG-1102 ②）。
-    final bool silent = track.clipCount <= 0;
+    // 当前这句时刻窗内一个片段都没有的轨：留在列表里（用户需要知道它存在），但明确
+    // 标注并置灰，不再让它看起来和真能取到语音的轨一样（BUG-1102 ②）。
+    //
+    // BUG-1165：原判据是 `clipCount <= 0`，而 native 的 clip_count 是**全环累计**
+    // （voice_hook_reader.cpp 的 clip_count++ 无时间窗过滤），一条轨能被列出就至少
+    // 有 1 个片段——条件恒假，置灰从来没生效过。游戏音频引擎常年维护一池 source
+    // voice（SE、系统音、播完的旧语音都在环里），于是列表里永远挂着一堆点了没声音
+    // 的轨。真正表达「此刻有没有响」的是时刻窗内片段数，见 [GalAudioTrack.isSilentAtCue]。
+    final bool silent = track.isSilentAtCue;
     return IgnorePointer(
       ignoring: silent,
       child: Opacity(
@@ -147,9 +153,12 @@ class GalTrackTile extends StatelessWidget {
             <String>[
               '0x${track.sourcePtr.toRadixString(16)}',
               '${t.game_track_clips} ${track.clipCount}',
-              '${t.game_track_energy} ${track.avgEnergy.toStringAsFixed(1)}',
+              // 能量只在真算得出来时显示。旧实现无条件打印，非 16-bit 轨和此刻
+              // 没响的轨都显示「能量 -1.0」——那是内部哨兵值，不是给用户看的。
+              if (track.avgEnergy >= 0)
+                '${t.game_track_energy} ${track.avgEnergy.toStringAsFixed(1)}',
               if (excluded) t.game_track_bgm,
-              if (silent) t.game_track_no_clips,
+              if (silent) t.game_track_silent_at_cue,
             ].join(' · '),
           ),
           trailing: Wrap(

--- a/hibiki/lib/src/mining/gal_hook_mining_coordinator.dart
+++ b/hibiki/lib/src/mining/gal_hook_mining_coordinator.dart
@@ -212,7 +212,11 @@ class GalHookMiningCoordinator {
       outputExtension: audioExtension,
     );
     final bool sentenceAudioMissing = audioBytes == null || audioBytes.isEmpty;
-    if (sentenceAudioMissing && !state.allowAudioFallback) {
+    // 只有最严格的 resourceOnly 才因为「没抓到音频」拒绝制卡。cleanOnly 的立场是
+    // 「这句本来就没配音很正常」——旁白/心理描写句照样成卡，只是不带音频；把它也
+    // 拦成制卡失败，等于逼用户在「收一段 BGM」和「这张卡做不了」之间二选一。
+    if (sentenceAudioMissing &&
+        state.audioFallbackPolicy.blocksMiningWhenMissing) {
       return const GalHookMiningResult(
         failureReason:
             'no matching game resource audio; audio fallback is disabled',

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -66,6 +66,46 @@ enum GalTrackEmptyHint { generic, resourceMode, loopbackMode }
 /// [kGalOverlongSliceSuspectReason] 让 UI 亮黄提醒，而不是静默当正常语音。
 const int kGalOverlongSliceSuspectMs = 20000;
 
+/// 自动降级链允许走到哪一级（取代旧的 bool `allowAudioFallback`）。
+///
+/// 旧 bool 把两件不同的事捆成一个开关：`false` 既禁掉了**整机混音**（真会混进 BGM），
+/// 也顺手禁掉了**引擎 PCM**（混音前抓的干净语音，物理上不含 BGM），于是没有资源
+/// hook 的引擎一关就一句音频都没有。三态把「干净与否」和「有没有原件」拆开：
+///
+/// - [full]：资源 → 引擎 PCM → 系统混音。抓不到就拿混音兜底（旧 `allow=true`）。
+/// - [cleanOnly]：资源 → 引擎 PCM，**绝不碰系统混音**。都没有 = 这句没配音，
+///   灰标 + 无音频成卡（旁白/心理描写句本来就该是这个结果）。
+/// - [resourceOnly]：只认游戏原始资源文件；缺音频时拒绝制卡（旧 `allow=false`）。
+///
+/// 用户**显式裁决**（浮窗「重播并录音」、逐行选轨）不受本策略约束——那不是降级，
+/// 是用户指定音源，见 [GalHookSessionController._captureAudioBytesNow] 的裁决分支。
+enum GalAudioFallbackPolicy {
+  full,
+  cleanOnly,
+  resourceOnly;
+
+  /// 是否允许把引擎 PCM（混音前的干净语音）当作资源缺失时的兜底。
+  bool get allowsEnginePcm => this != GalAudioFallbackPolicy.resourceOnly;
+
+  /// 是否允许把系统 loopback 整机混音当作兜底（唯一会混进 BGM/SE 的一路）。
+  bool get allowsLoopback => this == GalAudioFallbackPolicy.full;
+
+  /// 抓不到音频时是否拒绝制卡。只有最严格的 [resourceOnly] 拒绝——[cleanOnly] 的
+  /// 立场是「这句没配音很正常」，卡照做、只是不带音频。
+  bool get blocksMiningWhenMissing =>
+      this == GalAudioFallbackPolicy.resourceOnly;
+
+  /// 偏好/记忆里的稳定存储名（枚举 index 会随重排漂移，不入库）。
+  String get storageKey => name;
+
+  static GalAudioFallbackPolicy fromStorageKey(String? key) {
+    for (final GalAudioFallbackPolicy policy in GalAudioFallbackPolicy.values) {
+      if (policy.storageKey == key) return policy;
+    }
+    return GalAudioFallbackPolicy.full;
+  }
+}
+
 /// 每个游戏的捕获选择记忆（跨会话持久化的真值放偏好表）。
 ///
 /// 三项都用**弱指纹**而非会话内 id：`source_ptr` 每次启动都变、native 文本
@@ -80,6 +120,7 @@ class GalCaptureMemory {
     this.excludedTrackFingerprints = const <String>[],
     this.voiceTrackFingerprint,
     this.textThreadFingerprint,
+    this.audioFallbackPolicy = GalAudioFallbackPolicy.full,
   });
 
   factory GalCaptureMemory.fromJson(Map<Object?, Object?> json) {
@@ -90,6 +131,9 @@ class GalCaptureMemory {
           : const <String>[],
       voiceTrackFingerprint: json['voiceTrack'] as String?,
       textThreadFingerprint: json['textThread'] as String?,
+      audioFallbackPolicy: GalAudioFallbackPolicy.fromStorageKey(
+        json['audioFallback'] as String?,
+      ),
     );
   }
 
@@ -102,15 +146,21 @@ class GalCaptureMemory {
   /// 用户选定的文本线程指纹；null = 自动选线程。
   final String? textThreadFingerprint;
 
+  /// 用户为这个游戏选定的降级策略。与「标记 BGM」同规格按游戏记住——两者都是
+  /// 「这个游戏的音频该怎么抓」的判断，只记一半会让用户每次开游戏重设一遍。
+  final GalAudioFallbackPolicy audioFallbackPolicy;
+
   bool get isEmpty =>
       excludedTrackFingerprints.isEmpty &&
       voiceTrackFingerprint == null &&
-      textThreadFingerprint == null;
+      textThreadFingerprint == null &&
+      audioFallbackPolicy == GalAudioFallbackPolicy.full;
 
   GalCaptureMemory copyWith({
     List<String>? excludedTrackFingerprints,
     String? voiceTrackFingerprint,
     String? textThreadFingerprint,
+    GalAudioFallbackPolicy? audioFallbackPolicy,
     bool clearVoiceTrack = false,
     bool clearTextThread = false,
   }) =>
@@ -123,12 +173,15 @@ class GalCaptureMemory {
         textThreadFingerprint: clearTextThread
             ? null
             : textThreadFingerprint ?? this.textThreadFingerprint,
+        audioFallbackPolicy: audioFallbackPolicy ?? this.audioFallbackPolicy,
       );
 
   Map<String, Object?> toJson() => <String, Object?>{
         'excludedTracks': excludedTrackFingerprints,
         if (voiceTrackFingerprint != null) 'voiceTrack': voiceTrackFingerprint,
         if (textThreadFingerprint != null) 'textThread': textThreadFingerprint,
+        if (audioFallbackPolicy != GalAudioFallbackPolicy.full)
+          'audioFallback': audioFallbackPolicy.storageKey,
       };
 }
 
@@ -328,7 +381,7 @@ class GalHookSessionState {
   const GalHookSessionState({
     this.phase = GalHookSessionPhase.idle,
     this.externalWindowMode = false,
-    this.allowAudioFallback = true,
+    this.audioFallbackPolicy = GalAudioFallbackPolicy.full,
     this.boundWindow,
     this.gamePid,
     this.launchExe,
@@ -348,7 +401,10 @@ class GalHookSessionState {
 
   final GalHookSessionPhase phase;
   final bool externalWindowMode;
-  final bool allowAudioFallback;
+
+  /// 自动降级链的上限（见 [GalAudioFallbackPolicy]）。会话内可改，按游戏持久化到
+  /// [GalCaptureMemory]。
+  final GalAudioFallbackPolicy audioFallbackPolicy;
   final ExternalWindowInfo? boundWindow;
   final int? gamePid;
   final String? launchExe;
@@ -378,7 +434,7 @@ class GalHookSessionState {
   GalHookSessionState copyWith({
     GalHookSessionPhase? phase,
     bool? externalWindowMode,
-    bool? allowAudioFallback,
+    GalAudioFallbackPolicy? audioFallbackPolicy,
     ExternalWindowInfo? boundWindow,
     bool clearBoundWindow = false,
     int? gamePid,
@@ -405,7 +461,7 @@ class GalHookSessionState {
     return GalHookSessionState(
       phase: phase ?? this.phase,
       externalWindowMode: externalWindowMode ?? this.externalWindowMode,
-      allowAudioFallback: allowAudioFallback ?? this.allowAudioFallback,
+      audioFallbackPolicy: audioFallbackPolicy ?? this.audioFallbackPolicy,
       boundWindow: clearBoundWindow ? null : boundWindow ?? this.boundWindow,
       gamePid: clearGamePid ? null : gamePid ?? this.gamePid,
       launchExe: clearLaunchExe ? null : launchExe ?? this.launchExe,
@@ -1009,6 +1065,10 @@ class GalHookSessionController extends ChangeNotifier {
       title: _displayNameForExecutable(executablePath),
       mediaKey: executablePath,
     );
+    // 降级策略必须在这里恢复，不能搭 [_applyTrackMemory] 的便车：资源模式压根不枚举
+    // 音轨（native 只枚举 PCM 环），等音轨快照就等不到，用户上次选的「禁止降级」会
+    // 在最需要它的资源模式游戏里静默失效。
+    _restoreAudioFallbackPolicy();
     final bool? is32Bit = await _exe32BitProbe(executablePath);
     final String? injector = _injectorResolver(is32Bit: is32Bit ?? false);
     if (injector == null) {
@@ -2255,7 +2315,7 @@ class GalHookSessionController extends ChangeNotifier {
           details: <String, Object?>{'lineId': lineId},
         );
       }
-      if (!_state.allowAudioFallback) {
+      if (!_state.audioFallbackPolicy.allowsEnginePcm) {
         _textService.updateLineAudio(
           lineId,
           status: TexthookerLineAudioStatus.missing,
@@ -2271,6 +2331,34 @@ class GalHookSessionController extends ChangeNotifier {
         );
         return null;
       }
+    }
+    // 干净源策略：会话音源是 Loopback 就说明下面整条兜底链只能取到**整机混音**
+    // （资源模式把 `_audioSource` 指向 loopback，降级会话更是如此）。用户已经说了
+    // 不要混音，就不能拿一段 BGM 冒充这句的语音——这条兜底链到此为止，卡以「无音频」落地。
+    // 判据用音源类型而不是「缓存里有没有东西」：策略中途改时，早先冻结的切片同样
+    // 是混音，必须一并失效。用户显式裁决（补录/选轨）走上面的分支，不受此限。
+    // 但**报什么**必须按证据来：抑制掉唯一可用音源不等于「这句没配音」，
+    // 见 [_classifySuppressedLoopbackMiss]。
+    final bool loopbackSourced = source is LoopbackGalAudioSource;
+    if (loopbackSourced && !_state.audioFallbackPolicy.allowsLoopback) {
+      final String reason = await _classifySuppressedLoopbackMiss(
+        lineId: lineId,
+        engine: engine,
+        timestampMs: timestamp,
+      );
+      _markLineAudioMissing(lineId, reason);
+      _record(
+        GalHookEventSeverity.info,
+        'match',
+        'audio.loopback_suppressed',
+        'System loopback audio was suppressed by the clean-source policy',
+        details: <String, Object?>{
+          'lineId': lineId,
+          'policy': _state.audioFallbackPolicy.storageKey,
+          'reason': reason,
+        },
+      );
+      return null;
     }
     // BUG-1101：这行的 loopback 冻结可能还在等窗口到点。制卡就是「现在就要这段声音」，
     // 因此提前收束（按真实已等待时长回取），而不是拿一份还没冻的空缓存报 missing。
@@ -2441,17 +2529,43 @@ class GalHookSessionController extends ChangeNotifier {
     return null;
   }
 
-  void setAllowAudioFallback(bool value) {
-    if (_state.allowAudioFallback == value) return;
-    _setState(_state.copyWith(allowAudioFallback: value));
+  /// 用户切换降级策略：立即生效 + 按游戏记住。已排定的 loopback 冻结定时器必须
+  /// 一并取消——策略改成「不许混音」的那一刻，还在等窗口到点的冻结就是待落地的
+  /// 混音，留着等于让用户的选择晚一句才生效。
+  void setAudioFallbackPolicy(GalAudioFallbackPolicy policy) {
+    if (_state.audioFallbackPolicy == policy) return;
+    _setState(_state.copyWith(audioFallbackPolicy: policy));
+    if (!policy.allowsLoopback) _cancelLoopbackFreezes();
+    _persistAudioFallbackPolicy(policy);
     _record(
       GalHookEventSeverity.info,
       'audio',
-      value ? 'audio.fallback_enabled' : 'audio.fallback_disabled_by_user',
-      value
-          ? 'Audio fallback enabled'
-          : 'Audio fallback disabled; game resource audio is required',
+      'audio.fallback_policy_changed',
+      'Audio fallback policy changed to ${policy.storageKey}',
+      details: <String, Object?>{'policy': policy.storageKey},
     );
+  }
+
+  /// 会话启动时把上次为这个游戏选的策略套回来（没有记忆 = 保持 [GalAudioFallbackPolicy.full]）。
+  void _restoreAudioFallbackPolicy() {
+    if (!_ensureCaptureMemoryLoaded()) return;
+    final GalAudioFallbackPolicy remembered =
+        _captureMemory.audioFallbackPolicy;
+    if (remembered == _state.audioFallbackPolicy) return;
+    _setState(_state.copyWith(audioFallbackPolicy: remembered));
+    _record(
+      GalHookEventSeverity.info,
+      'audio',
+      'audio.fallback_policy_restored',
+      'Restored the audio fallback policy remembered for this game',
+      details: <String, Object?>{'policy': remembered.storageKey},
+    );
+  }
+
+  void _persistAudioFallbackPolicy(GalAudioFallbackPolicy policy) {
+    if (!_ensureCaptureMemoryLoaded()) return;
+    if (_captureMemory.audioFallbackPolicy == policy) return;
+    _saveCaptureMemory(_captureMemory.copyWith(audioFallbackPolicy: policy));
   }
 
   void clearEvents() {
@@ -2503,6 +2617,11 @@ class GalHookSessionController extends ChangeNotifier {
   /// 绑定本会话的游戏标题/稳定 id。会话开始（attach / launch）时调用。
   void _beginActivitySession({required String title, String? mediaKey}) {
     _flushGameActivity();
+    // 捕获记忆按**游戏身份**锚定，所以新会话必须重新加载：只在 [stopCapture] 里重置
+    // 是漏的——用户不点「停止监听」直接从库里启动下一个游戏时，`_captureMemoryLoaded`
+    // 还是 true，上一个游戏的排除集/语音轨/降级策略会原样套到新游戏上，而用户在新
+    // 游戏里做的选择又会被写回**上一个游戏**的 key（`_captureMemoryGameKey` 没换）。
+    _resetCaptureMemorySession();
     _activityAccumulator.reset();
     _activityCharCounter.reset();
     _engineTextCounted = false;
@@ -3450,7 +3569,12 @@ class GalHookSessionController extends ChangeNotifier {
       );
       return;
     }
-    if (_audioSource is LoopbackGalAudioSource) {
+    final bool loopbackSourced = _audioSource is LoopbackGalAudioSource;
+    // 干净源策略下这一步整个跳过：这里排的每一个定时器到点后都会把一段整机混音
+    // 写进本行缓存，没配音的句子（旁白/心理描写）拿到的必然是纯 BGM。
+    final bool loopbackSuppressed =
+        loopbackSourced && !_state.audioFallbackPolicy.allowsLoopback;
+    if (loopbackSourced && !loopbackSuppressed) {
       // Loopback 必须按本行自己的时间窗冻结环形片段；制卡时再抓“最近声音”会把
       // 后续台词/BGM 错配给旧行。BUG-1101：窗口必须是前向的，故只在这里排定时器，
       // 到点后才冻结（见 [_scheduleLoopbackFreeze]）。资源音频尚未落盘时也先保留这份
@@ -3459,25 +3583,43 @@ class GalHookSessionController extends ChangeNotifier {
       return;
     }
     if (!resourceReady) {
-      final String reason =
-          await _classifyEnginePcmMiss(engine, line.timestampMs);
+      // 混音被策略挡掉时走「抑制」分类器：有证据才敢说无配音，没证据就如实说是
+      // 策略抑制（见 [_classifySuppressedLoopbackMiss]）。引擎 PCM 会话仍走原分类器。
+      final String reason = loopbackSuppressed
+          ? await _classifySuppressedLoopbackMiss(
+              lineId: entry.id,
+              engine: engine,
+              timestampMs: line.timestampMs,
+            )
+          : await _classifyEnginePcmMiss(engine, line.timestampMs);
       if (engine != _engineSource || !isLineInCurrentSession(entry)) return;
       _textService.updateLineAudio(
         entry.id,
         status: TexthookerLineAudioStatus.missing,
         fallbackReason: reason,
       );
+      final (GalHookEventSeverity, String, String) event = switch (reason) {
+        kGalLineNoVoiceReason => (
+            GalHookEventSeverity.info,
+            'audio.line_no_voice',
+            'No PCM was active at this line; treating it as unvoiced',
+          ),
+        kGalCleanSourceSuppressedReason => (
+            GalHookEventSeverity.info,
+            'audio.loopback_suppressed',
+            'System loopback audio was suppressed by the clean-source policy',
+          ),
+        _ => (
+            GalHookEventSeverity.warning,
+            'audio.utterance_not_found',
+            'No engine utterance matched the captured line',
+          ),
+      };
       _record(
-        reason == kGalLineNoVoiceReason
-            ? GalHookEventSeverity.info
-            : GalHookEventSeverity.warning,
+        event.$1,
         'match',
-        reason == kGalLineNoVoiceReason
-            ? 'audio.line_no_voice'
-            : 'audio.utterance_not_found',
-        reason == kGalLineNoVoiceReason
-            ? 'No PCM was active at this line; treating it as unvoiced'
-            : 'No engine utterance matched the captured line',
+        event.$2,
+        event.$3,
         details: <String, Object?>{'lineId': entry.id, 'seq': line.seq},
       );
     }
@@ -3498,18 +3640,72 @@ class GalHookSessionController extends ChangeNotifier {
     try {
       final List<GalAudioTrack> tracks =
           await engine.listAudioTracks(timestampMs);
-      final Set<int> excluded = engine.excludedAudioSourcePtrs;
-      final int selected = engine.selectedAudioSourcePtr;
-      final bool candidateActive = tracks.any(
-        (GalAudioTrack track) =>
-            !excluded.contains(track.sourcePtr) &&
-            (selected == 0 || track.sourcePtr == selected) &&
-            track.avgEnergy >= 0,
-      );
-      return candidateActive ? 'utterance_not_found' : kGalLineNoVoiceReason;
+      return _hasSoundingCandidateTrack(engine, tracks)
+          ? 'utterance_not_found'
+          : kGalLineNoVoiceReason;
     } catch (_) {
       return 'utterance_not_found';
     }
+  }
+
+  /// 候选轨（未被排除、且未被逐轨锁定到别的轨）在该句时刻窗内是否响过。抽出来供
+  /// [_classifyEnginePcmMiss] 与 [_classifySuppressedLoopbackMiss] 共用，保证两条路径
+  /// 用的是同一套「什么算候选轨」的定义。
+  ///
+  /// 判据用 [GalAudioTrack.isSilentAtCue] 而不是 `avgEnergy >= 0`：`avgEnergy == -1`
+  /// 有两义（窗内无片段 / 该轨不是 16-bit 算不了能量，见 BUG-1165）。拿它当「有没有
+  /// 声音」用，会把一条**真响过的非 16-bit 语音轨**判成静默，于是整句被宣布「无配音」
+  /// ——和本 bug 要修的正是同一类错误：把「我判不出」说成「它没有」。
+  bool _hasSoundingCandidateTrack(
+    EngineHookGalAudioSource engine,
+    List<GalAudioTrack> tracks,
+  ) {
+    final Set<int> excluded = engine.excludedAudioSourcePtrs;
+    final int selected = engine.selectedAudioSourcePtr;
+    return tracks.any(
+      (GalAudioTrack track) =>
+          !excluded.contains(track.sourcePtr) &&
+          (selected == 0 || track.sourcePtr == selected) &&
+          !track.isSilentAtCue,
+    );
+  }
+
+  /// 干净源策略把整机混音挡掉之后，这一行到底该报什么。
+  ///
+  /// 铁律：**只有拿到证据才敢说「这句没配音」**。抑制掉唯一可用音源本身不是证据——
+  /// 纯 loopback 降级会话里每一行都会走到这里，全标成「无配音」等于把用户的显式降级
+  /// 说成「这游戏没配音」；资源模式下的真漏抓也会被同一句话盖掉。
+  ///
+  /// 证据只认两种：
+  /// - 这行还挂着**原件配对在途**（[_pendingResourceMatches]）= 引擎原件通道是活的、
+  ///   这行还在等配对，属于「抓过但没配上」，报疑似漏抓而不是没配音；
+  /// - 引擎能枚举出该句时刻窗的**非空**候选轨列表 = 能用 [_hasSoundingCandidateTrack] 判有没有
+  ///   声音。空列表不是证据（资源模式根本不枚举 PCM 环），不得据此宣称无配音。
+  ///
+  /// 两种都拿不到 → [kGalCleanSourceSuppressedReason]，如实说是策略挡掉了本会话唯一
+  /// 可用的音源，而不是替游戏宣布这句没有配音。
+  Future<String> _classifySuppressedLoopbackMiss({
+    required String lineId,
+    required EngineHookGalAudioSource? engine,
+    required int timestampMs,
+  }) async {
+    if (_pendingResourceMatches.containsKey(lineId)) {
+      return 'utterance_not_found';
+    }
+    if (engine != null && timestampMs > 0) {
+      try {
+        final List<GalAudioTrack> tracks =
+            await engine.listAudioTracks(timestampMs);
+        if (tracks.isNotEmpty) {
+          return _hasSoundingCandidateTrack(engine, tracks)
+              ? 'utterance_not_found'
+              : kGalLineNoVoiceReason;
+        }
+      } catch (_) {
+        // 枚举失败同样不是「没配音」的证据，落到下面的如实说明。
+      }
+    }
+    return kGalCleanSourceSuppressedReason;
   }
 
   void _promoteLateResourceAudio(EngineHookGalAudioSource engine) {
@@ -3624,7 +3820,10 @@ class GalHookSessionController extends ChangeNotifier {
   /// 等待刻意放在串行音频队列**之外**：在队列里 sleep 会把后续台词的抓取和制卡一起堵住。
   /// 文本上屏完全不受影响，只有音频后补。
   void _scheduleLoopbackFreeze(TexthookerLineEntry entry) {
-    if (_audioSource is! LoopbackGalAudioSource ||
+    // 策略守卫放在这里而不是只放调用点：[_settleLineUtterance] 的收敛路径也会排
+    // 冻结，漏一个调用点就等于「禁止降级」在某条路径上静默失效。
+    if (!_state.audioFallbackPolicy.allowsLoopback ||
+        _audioSource is! LoopbackGalAudioSource ||
         !isLineInCurrentSession(entry) ||
         _isUserAdjudicated(entry.id) ||
         _loopbackFreezeTimers.containsKey(entry.id) ||

--- a/hibiki/lib/src/mining/galgame_audio_source.dart
+++ b/hibiki/lib/src/mining/galgame_audio_source.dart
@@ -1808,6 +1808,7 @@ class GalAudioTrack {
     required this.avgEnergy,
     required this.orderIndex,
     required this.clipCount,
+    this.clipCountAtCue = -1,
   });
 
   /// 源指针（会话内稳定；跨启动会变——UI 宜把用户选择映射到 [orderIndex] 或格式签名）。
@@ -1816,17 +1817,46 @@ class GalAudioTrack {
   /// 该源 PCM 格式（采样率/声道/位深）；解析失败该轨被丢弃。
   final PcmFormat format;
 
-  /// 近窗内该源每段平均字节数（缓冲规模）。
+  /// **环内**该源每段平均字节数（缓冲规模）。
   final int avgBytes;
 
-  /// 文本时刻窗平均能量（16-bit 平均绝对幅值；非 16-bit 为 -1）。越高越可能是当前在说话的语音源。
+  /// 文本时刻窗（native `[ts-150, ts+450]`）平均能量：16-bit 平均绝对幅值。
+  /// **-1 有两义**，别只判正负——见 [isSilentAtCue] / [energyUnknown]：
+  /// ① 该窗内这条轨一个片段都没有（真·此刻没响）；② 该轨不是 16-bit，
+  /// native `ClipEnergy16Locked` 算不了能量。
   final double avgEnergy;
 
-  /// 近窗内按首次出现排的创建顺序，0-based（跨启动相对稳定，宜作用户选择的持久锚）。
+  /// **环内**按首次出现排的创建顺序，0-based（跨启动相对稳定，宜作用户选择的持久锚）。
   final int orderIndex;
 
-  /// 近窗内该源的段数。
+  /// **环内**该源的段数——注意是整个环形缓冲的累计，不是「当前这句附近」。
+  ///
+  /// 一条轨能出现在列表里，前提就是环里至少有它的一个片段，所以这个值恒 >= 1：
+  /// 拿它判「这条轨此刻有没有声音」永远为假（BUG-1165 的原判据就栽在这）。
+  /// 判「此刻有没有响」只能用 [isSilentAtCue]。
   final int clipCount;
+
+  /// 文本时刻窗（native `[ts-150, ts+450]`）内该源的段数——**与位深无关**。
+  ///
+  /// native `VoiceTrackInfo::clip_count_at_cue`。这是「此刻这条轨响没响」的唯一
+  /// 正确依据：[avgEnergy] 只在 16-bit 上算得出来，用它兼作有无判据会误伤非 16-bit
+  /// 的可用轨（BUG-1165）。老版本 runner 不发这个字段 → 解析为 -1（未知）。
+  final int clipCountAtCue;
+
+  /// 该轨的能量是否**无法判定**（非 16-bit 轨，native 不计能量）。
+  /// 能量只用来排语音/BGM 的可能性次序，不参与「有没有声音」的判断。
+  bool get energyUnknown => format.bitsPerSample != 16;
+
+  /// 该轨在**当前这句的时刻窗**内是否一个片段都没有（试听必然抓不到）。
+  ///
+  /// 试听走 `grabUtterance(该句时刻, sourcePtr)`，与 native 统计这个窗用的是同一个
+  /// 区间，所以「窗内无片段」与「试听出不了声」是同一件事。
+  ///
+  /// [clipCountAtCue] < 0 表示 runner 没发这个字段（老版本）——此时退回能量判据，
+  /// 且只对能算出能量的 16-bit 轨下结论，宁可不置灰也不误伤（向后兼容）。
+  bool get isSilentAtCue => clipCountAtCue >= 0
+      ? clipCountAtCue == 0
+      : !energyUnknown && avgEnergy < 0;
 
   /// 从 native map 解析；缺格式（sr/ch/bits 非法）或缺 sourcePtr 返回 null。
   static GalAudioTrack? fromMap(Map<Object?, Object?> m) {
@@ -1842,6 +1872,8 @@ class GalAudioTrack {
       avgEnergy: (m['avgEnergy'] as num?)?.toDouble() ?? -1.0,
       orderIndex: (m['orderIndex'] as int?) ?? 0,
       clipCount: (m['clipCount'] as int?) ?? 0,
+      // 缺字段 = 老 runner，用 -1 显式表达「未知」，别拿 0 冒充「窗内没段」。
+      clipCountAtCue: (m['clipCountAtCue'] as int?) ?? -1,
     );
   }
 }

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -1010,10 +1010,12 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     ];
   }
 
-  /// 低频开关收纳菜单：允许音频降级 / 显示 Hook 文本浮窗（Win）/ 外部窗口挖矿（Win）。
-  /// 两个真开关（音频降级、外部窗口挖矿）用 [CheckedPopupMenuItem] 反映当前开关态；
-  /// 「显示 Hook 文本浮窗」是一次性动作（showManually），用普通菜单项。onSelected 由
-  /// 枚举驱动，无特殊分支；各动作调用与旧按钮完全一致。
+  /// 低频开关收纳菜单：音频降级策略 / 显示 Hook 文本浮窗（Win）/ 外部窗口挖矿（Win）。
+  /// 「外部窗口挖矿」是真开关，用 [CheckedPopupMenuItem] 反映当前开关态；「显示 Hook
+  /// 文本浮窗」是一次性动作（showManually），用普通菜单项；「音频降级策略」是三选一
+  /// （[GalAudioFallbackPolicy]），菜单项直接显示当前档位、点开是带说明的单选对话框
+  /// ——三档代价各不相同（收 BGM / 丢音频 / 不出卡），不做「点一下换一档」的循环钮。
+  /// onSelected 由枚举驱动，无特殊分支；各动作调用与旧按钮完全一致。
   Widget _buildToolbarOverflowMenu(BuildContext context) {
     final GalHookSessionState state = _session.state;
     return PopupMenuButton<_GalHookToolbarMenuAction>(
@@ -1023,7 +1025,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       onSelected: (_GalHookToolbarMenuAction action) {
         switch (action) {
           case _GalHookToolbarMenuAction.audioFallback:
-            _session.setAllowAudioFallback(!state.allowAudioFallback);
+            unawaited(_showAudioFallbackPolicyDialog());
           case _GalHookToolbarMenuAction.health:
             unawaited(_showHealthDialog());
           case _GalHookToolbarMenuAction.showOverlay:
@@ -1034,10 +1036,10 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       },
       itemBuilder: (BuildContext context) =>
           <PopupMenuEntry<_GalHookToolbarMenuAction>>[
-        CheckedPopupMenuItem<_GalHookToolbarMenuAction>(
+        PopupMenuItem<_GalHookToolbarMenuAction>(
           value: _GalHookToolbarMenuAction.audioFallback,
-          checked: state.allowAudioFallback,
-          child: Text(t.game_audio_fallback_allow),
+          child: Text('${t.game_audio_fallback_policy} · '
+              '${_audioFallbackPolicyLabel(state.audioFallbackPolicy)}'),
         ),
         // 健康状态从右栏常驻卡改为按需打开：它是「偶尔查一眼」的静态信息，
         // 不值得长期占着逐句操作要用的横向空间（完整版仍在「兼容性诊断」页签）。
@@ -1059,6 +1061,68 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       ],
     );
   }
+
+  /// 三档选择对话框。每档都写清代价——这不是「高级选项」，是用户每局都要按游戏
+  /// 有没有逐句语音来定的判断。
+  Future<void> _showAudioFallbackPolicyDialog() async {
+    await showAppDialog<void>(
+      context: context,
+      builder: (BuildContext dialogContext) => AlertDialog(
+        title: Text(t.game_audio_fallback_policy),
+        content: SizedBox(
+          width: 460,
+          child: ListenableBuilder(
+            listenable: _session,
+            builder: (BuildContext context, Widget? child) {
+              final GalAudioFallbackPolicy current =
+                  _session.state.audioFallbackPolicy;
+              return SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    for (final GalAudioFallbackPolicy policy
+                        in GalAudioFallbackPolicy.values)
+                      RadioListTile<GalAudioFallbackPolicy>(
+                        value: policy,
+                        groupValue: current,
+                        title: Text(_audioFallbackPolicyLabel(policy)),
+                        subtitle: Text(_audioFallbackPolicyDescription(policy)),
+                        onChanged: (GalAudioFallbackPolicy? picked) {
+                          if (picked != null) {
+                            _session.setAudioFallbackPolicy(picked);
+                          }
+                        },
+                      ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(t.dialog_close),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _audioFallbackPolicyLabel(GalAudioFallbackPolicy policy) =>
+      switch (policy) {
+        GalAudioFallbackPolicy.full => t.game_audio_fallback_full,
+        GalAudioFallbackPolicy.cleanOnly => t.game_audio_fallback_clean,
+        GalAudioFallbackPolicy.resourceOnly => t.game_audio_fallback_resource,
+      };
+
+  String _audioFallbackPolicyDescription(GalAudioFallbackPolicy policy) =>
+      switch (policy) {
+        GalAudioFallbackPolicy.full => t.game_audio_fallback_full_hint,
+        GalAudioFallbackPolicy.cleanOnly => t.game_audio_fallback_clean_hint,
+        GalAudioFallbackPolicy.resourceOnly =>
+          t.game_audio_fallback_resource_hint,
+      };
 
   /// 会话健康状态对话框（原右栏常驻卡的新家）。内容仍是 [_CaptureHealthCard]，
   /// 随会话状态实时刷新；Anki 配置态来自 app 级 AnkiViewModel（BUG-1007 的接线）。
@@ -2414,8 +2478,9 @@ class _LineAudioChip extends StatelessWidget {
   /// 兜底（可能混 BGM）」从正常绿标里分出来提示。
   final String? backend;
 
-  /// 语义化 fallbackReason（见 [kGalLineNoVoiceReason] / [kGalOverlongSliceSuspectReason]）：
-  /// 「无配音」灰标不吓人、「超长可疑切片」亮黄提醒。
+  /// 语义化 fallbackReason（见 [kGalLineNoVoiceReason] / [kGalOverlongSliceSuspectReason]
+  /// / [kGalCleanSourceSuppressedReason]）：「无配音」灰标不吓人、「超长可疑切片」亮黄
+  /// 提醒、「已按策略抑制混音」如实说明是用户的策略挡掉了唯一可用音源。
   final String? fallbackReason;
 
   @override
@@ -2429,6 +2494,20 @@ class _LineAudioChip extends StatelessWidget {
         t.game_line_audio_no_voice,
         colors.surfaceContainerHighest,
         colors.onSurfaceVariant,
+      );
+    }
+    // 「已按干净源策略抑制」绝不能和「无配音」共用灰标：前者是「没证据」，后者是
+    // 「有证据判定没配音」。混成一句会让用户以为游戏这句本来就没语音。
+    if (status == TexthookerLineAudioStatus.missing &&
+        fallbackReason == kGalCleanSourceSuppressedReason) {
+      return Tooltip(
+        message: t.game_line_audio_suppressed_hint,
+        child: _chip(
+          context,
+          t.game_line_audio_suppressed,
+          colors.secondaryContainer,
+          colors.onSecondaryContainer,
+        ),
       );
     }
     if (fallbackReason == kGalOverlongSliceSuspectReason) {

--- a/hibiki/lib/src/sync/texthooker_service.dart
+++ b/hibiki/lib/src/sync/texthooker_service.dart
@@ -132,11 +132,20 @@ enum TexthookerLineAudioStatus {
   encoded,
 }
 
-/// [TexthookerLineEntry.fallbackReason] 的两个**语义化**值（其余 reason 是诊断字符串）：
+/// [TexthookerLineEntry.fallbackReason] 的三个**语义化**值（其余 reason 是诊断字符串）：
 /// UI 靠它们把「这句本来就没配音」从「疑似漏抓」的红标里分出来、把「超长可疑切片」
-/// 从正常兜底里分出来。生产与消费两侧共用本常量，别在别处重复字面量。
+/// 从正常兜底里分出来、把「用户策略主动抑制了唯一可用音源」从前两者里分出来。
+/// 生产与消费两侧共用本常量，别在别处重复字面量。
 const String kGalLineNoVoiceReason = 'line_has_no_voice';
 const String kGalOverlongSliceSuspectReason = 'slice_overlong_suspect';
+
+/// 干净源策略把整机混音挡掉、且**没有任何证据**能判断这句到底有没有配音时用它。
+///
+/// 与 [kGalLineNoVoiceReason] 的区别是硬性的：那个是有证据的结论（候选轨在该句时刻
+/// 窗内全静默），这个只是「你禁用了本会话唯一可用的音源」。把没证据的抑制说成
+/// 「这句没配音」等于用前一阶段推断后一阶段——纯 loopback 降级会话下会把每一行都
+/// 说成没配音，资源模式的**真漏抓**也会被这句话盖过去。
+const String kGalCleanSourceSuppressedReason = 'clean_source_suppressed';
 
 /// 实时台词列表的筛选维度。单一枚举驱动 [lineMatchesFilter] 一个 predicate，
 /// 消除「有音频 / 已制卡 / 已收藏」各写一条 if 分支的特殊情况。与线程下拉筛选正交：

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.0+952
+version: 1.3.1+953
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/mining/gal_audio_degrade_track_test.dart
+++ b/hibiki/test/mining/gal_audio_degrade_track_test.dart
@@ -288,8 +288,14 @@ void main() {
     expect(panel.contains('selectable: selectionEffective'), isTrue);
     expect(panel.contains('enabled: selectable && !excluded'), isTrue,
         reason: '非引擎 PCM 后端必须禁用「选为语音轨」');
-    expect(panel.contains('t.game_track_no_clips'), isTrue,
-        reason: 'clipCount == 0 的轨必须标注，而不是和可用轨长一个样');
+    expect(panel.contains('t.game_track_silent_at_cue'), isTrue,
+        reason: '此刻没有声音的轨必须标注，而不是和可用轨长一个样');
+    // BUG-1165：判据不得再用 clipCount——native 的 clip_count 是全环累计，一条轨
+    // 能被列出就至少有 1 个片段，`clipCount <= 0` 恒假，置灰从来没生效过。
+    expect(panel.contains('track.clipCount <= 0'), isFalse,
+        reason: 'clipCount 是全环累计，拿它判「此刻有没有声音」恒为假');
+    expect(panel.contains('final bool silent = track.isSilentAtCue'), isTrue,
+        reason: '静音判据必须走文本时刻窗能量（与试听抓取用同一个窗）');
     expect(panel.contains('t.game_tracks_pcm_only_hint'), isTrue);
     final String page = File(
       'lib/src/pages/implementations/game_diagnostics_page.dart',
@@ -511,6 +517,61 @@ void main() {
 
     await controller.close();
     endpoints.dispose();
+  });
+
+  test('BUG-1165：此刻静音判据走时刻窗片段数，clipCount 不参与、非 16-bit 不误伤', () {
+    GalAudioTrack track({
+      required int bits,
+      required double energy,
+      int clips = 5,
+      int clipsAtCue = -1,
+    }) =>
+        GalAudioTrack(
+          sourcePtr: 0x1234,
+          format: PcmFormat(
+            sampleRate: 48000,
+            channels: 2,
+            bitsPerSample: bits,
+            isFloat: bits == 32,
+          ),
+          avgBytes: 1024,
+          avgEnergy: energy,
+          orderIndex: 0,
+          clipCount: clips,
+          clipCountAtCue: clipsAtCue,
+        );
+
+    // 新 runner：时刻窗片段数是唯一判据，与位深、与能量都无关。
+    expect(track(bits: 16, energy: -1, clipsAtCue: 0).isSilentAtCue, isTrue);
+    expect(
+        track(bits: 16, energy: 120.5, clipsAtCue: 3).isSilentAtCue, isFalse);
+    // 非 16-bit 轨 native 算不出能量（恒 -1），但窗内确实有段 = 此刻在响，不得置灰。
+    expect(track(bits: 32, energy: -1, clipsAtCue: 4).isSilentAtCue, isFalse);
+    expect(track(bits: 32, energy: -1, clipsAtCue: 0).isSilentAtCue, isTrue,
+        reason: '有了片段数，非 16-bit 轨也能被正确判定为此刻静音');
+    // clipCount 是全环累计、恒 >= 1，绝不参与判据（原实现就栽在这）。
+    expect(track(bits: 16, energy: 9, clips: 99, clipsAtCue: 0).isSilentAtCue,
+        isTrue);
+
+    // 老 runner 不发该字段（-1 = 未知）：退回能量判据，且只对 16-bit 下结论——
+    // 宁可不置灰也不误伤非 16-bit 的可用轨。
+    expect(track(bits: 16, energy: -1).isSilentAtCue, isTrue);
+    expect(track(bits: 16, energy: 120.5).isSilentAtCue, isFalse);
+    expect(track(bits: 32, energy: -1).energyUnknown, isTrue);
+    expect(track(bits: 32, energy: -1).isSilentAtCue, isFalse);
+
+    // 缺字段的 native map 必须解析成 -1（未知），不能拿 0 冒充「窗内没段」。
+    final GalAudioTrack? legacy = GalAudioTrack.fromMap(<Object?, Object?>{
+      'sourcePtr': 0x99,
+      'sampleRate': 48000,
+      'channels': 2,
+      'bitsPerSample': 16,
+      'isFloat': false,
+      'avgEnergy': 42.0,
+      'clipCount': 7,
+    });
+    expect(legacy?.clipCountAtCue, -1);
+    expect(legacy?.isSilentAtCue, isFalse);
   });
 }
 

--- a/hibiki/test/mining/gal_hook_mining_coordinator_test.dart
+++ b/hibiki/test/mining/gal_hook_mining_coordinator_test.dart
@@ -341,7 +341,9 @@ void main() {
 
   test('resource-only mode rejects a card when sentence audio is missing',
       () async {
-    activeState = activeState.copyWith(allowAudioFallback: false);
+    activeState = activeState.copyWith(
+      audioFallbackPolicy: GalAudioFallbackPolicy.resourceOnly,
+    );
     final TexthookerLineEntry entry = service.appendLine('必须匹配资源音频')!;
     final _RecordingRepo repo = _RecordingRepo();
 
@@ -364,6 +366,37 @@ void main() {
     expect(result.audioFallbackDisabled, isTrue);
     expect(result.sentenceAudioMissing, isTrue);
     expect(repo.contexts, isEmpty);
+  });
+
+  test('clean-source mode still mines the card when the line has no voice',
+      () async {
+    activeState = activeState.copyWith(
+      audioFallbackPolicy: GalAudioFallbackPolicy.cleanOnly,
+    );
+    final TexthookerLineEntry entry = service.appendLine('無声の地の文')!;
+    final _RecordingRepo repo = _RecordingRepo();
+
+    final GalHookMiningResult result = await coordinator(
+      validator: (_) => true,
+      audio: ({
+        required String lineId,
+        required String sentence,
+        required String outputExtension,
+      }) async =>
+          null,
+    ).mineLine(
+      lineId: entry.id,
+      fields: const <String, String>{'expression': '地の文'},
+      compression: MiningMediaCompression.compressed,
+      repo: repo,
+    );
+
+    // 「这句没配音」是常态而不是故障：卡照做，只是不带音频。把它也拦成制卡失败
+    // 等于逼用户在「收一段 BGM」和「这张卡做不了」之间二选一。
+    expect(result.aborted, isFalse);
+    expect(result.audioFallbackDisabled, isFalse);
+    expect(result.sentenceAudioMissing, isTrue);
+    expect(repo.contexts, isNotEmpty);
   });
 
   test('concurrent jobs serialize and use isolated temporary directories',

--- a/hibiki/test/mining/gal_hook_session_controller_test.dart
+++ b/hibiki/test/mining/gal_hook_session_controller_test.dart
@@ -222,8 +222,11 @@ void main() {
       isTrue,
     );
     final TexthookerLineEntry entry = service.appendLine('resource only')!;
-    controller.setAllowAudioFallback(false);
-    expect(controller.state.allowAudioFallback, isFalse);
+    controller.setAudioFallbackPolicy(GalAudioFallbackPolicy.resourceOnly);
+    expect(
+      controller.state.audioFallbackPolicy,
+      GalAudioFallbackPolicy.resourceOnly,
+    );
 
     final Uint8List? bytes = await controller.captureAudioBytes(
       lineId: entry.id,
@@ -243,6 +246,233 @@ void main() {
     );
 
     await controller.close();
+    endpoints.dispose();
+  });
+
+  test('clean-source policy refuses loopback mix for a line with no voice',
+      () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    final _FakeEngineSource engine = _FakeEngineSource(
+      pairedBytes: Uint8List(0),
+      rawReady: true,
+    );
+    final _FakeLoopbackSource loopback = _FakeLoopbackSource();
+    final GalHookSessionController controller = GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      exe32BitProbe: (_) async => true,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+        List<String> launchArguments = const <String>[],
+        String launchWorkdir = '',
+      }) =>
+          engine,
+      loopbackSourceFactory: () => loopback,
+      windowListLoader: () async => const <ExternalWindowInfo>[],
+      windowPollAttempts: 1,
+      resourceAudioWait: Duration.zero,
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+
+    expect(
+      (await controller.launchGame(r'D:\anemoi\SiglusEngine.exe')).launched,
+      isTrue,
+    );
+    // 资源模式会话把 `_audioSource` 指向 loopback（原始资源是首选，混音只是兜底），
+    // 于是没有配对资源的句子在旧实现里必然拿到一段整机混音 = 纯 BGM。
+    final TexthookerLineEntry entry = service.appendLine('無声のモノローグ')!;
+    controller.setAudioFallbackPolicy(GalAudioFallbackPolicy.cleanOnly);
+
+    final Uint8List? bytes = await controller.captureAudioBytes(
+      lineId: entry.id,
+      sentence: entry.text,
+      outputExtension: 'aac',
+    );
+
+    expect(bytes, isNull, reason: '干净源策略下不得拿混音冒充这句的语音');
+    expect(
+      loopback.grabRecentCalls,
+      0,
+      reason: '一次都不该去环形缓冲取混音——取了就说明降级链还活着',
+    );
+    // 这条会话拿不到任何证据（无原件配对在途、引擎枚举不出候选轨），所以只能如实
+    // 说「策略挡掉了唯一可用音源」。**绝不能**说成「这句没配音」：那是有证据才能下
+    // 的结论，冒充它会把纯 loopback 降级会话的每一行都说成游戏没配音，也会把资源
+    // 模式下的真漏抓一起盖掉。
+    expect(
+      service.entries.single.fallbackReason,
+      kGalCleanSourceSuppressedReason,
+      reason: '零证据时必须报「已按策略抑制」，不得冒充「无配音」',
+    );
+    expect(
+      service.entries.single.fallbackReason,
+      isNot(kGalLineNoVoiceReason),
+    );
+    expect(
+      controller.events.map((GalHookEvent event) => event.code),
+      contains('audio.loopback_suppressed'),
+    );
+
+    await controller.close();
+    endpoints.dispose();
+  });
+
+  test('clean-source policy still reports a missed utterance as a miss',
+      () async {
+    // 「有配音但漏抓」在 cleanOnly 下必须仍然报疑似漏抓：原件通道是活的、这行还挂着
+    // 配对在途，就是证据。把它也说成「无配音」等于用「我没抓到」冒充「它没有」，
+    // 用户报的「部分句子有配音」那类游戏首当其冲。
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    final _FakeEngineSource engine = _FakeEngineSource(
+      pairedBytes: Uint8List(0),
+      textReady: true,
+      rawReady: true,
+      polledLines: const <GalHookedLine>[
+        GalHookedLine(
+          seq: 1,
+          timestampMs: 987654,
+          text: '声のあるはずの台詞',
+          threadId: 3,
+          threadAddress: 0xabcdef,
+          sourceKind: 2,
+          hookName: 'TextRender',
+          hookCode: 'HS932@abcdef',
+        ),
+      ],
+    );
+    final _FakeLoopbackSource loopback = _FakeLoopbackSource();
+    final GalHookSessionController controller = GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      exe32BitProbe: (_) async => true,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+        List<String> launchArguments = const <String>[],
+        String launchWorkdir = '',
+      }) =>
+          engine,
+      loopbackSourceFactory: () => loopback,
+      windowListLoader: () async => const <ExternalWindowInfo>[],
+      windowPollAttempts: 1,
+      resourceAudioWait: Duration.zero,
+      textPollInterval: const Duration(milliseconds: 5),
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+
+    expect(
+      (await controller.launchGame(r'D:\anemoi\SiglusEngine.exe')).launched,
+      isTrue,
+    );
+    controller.setAudioFallbackPolicy(GalAudioFallbackPolicy.cleanOnly);
+    for (int i = 0; i < 40 && service.entries.isEmpty; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+    expect(service.entries, hasLength(1));
+    final TexthookerLineEntry entry = service.entries.single;
+
+    final Uint8List? bytes = await controller.captureAudioBytes(
+      lineId: entry.id,
+      sentence: entry.text,
+      outputExtension: 'aac',
+    );
+
+    expect(bytes, isNull);
+    expect(loopback.grabRecentCalls, 0, reason: '策略仍然禁止取整机混音');
+    expect(
+      service.entries.single.fallbackReason,
+      'utterance_not_found',
+      reason: '原件配对在途 = 有证据说明这行本该有语音，必须报漏抓而不是无配音',
+    );
+
+    await controller.close();
+    endpoints.dispose();
+  });
+
+  test('audio fallback policy is remembered per game and restored on launch',
+      () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    final Map<String, GalCaptureMemory> store = <String, GalCaptureMemory>{};
+    GalHookSessionController build() {
+      final GalHookSessionController controller = GalHookSessionController(
+        textService: service,
+        isWindows: true,
+        exe32BitProbe: (_) async => true,
+        injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+        engineSourceFactory: ({
+          required int targetPid,
+          required String? launchExe,
+          required String injectorPath,
+          required bool lunaPcHooks,
+          int? lunaCodepage,
+          List<String> launchArguments = const <String>[],
+          String launchWorkdir = '',
+        }) =>
+            _FakeEngineSource(pairedBytes: Uint8List(0), rawReady: true),
+        loopbackSourceFactory: _FakeLoopbackSource.new,
+        windowListLoader: () async => const <ExternalWindowInfo>[],
+        windowPollAttempts: 1,
+        resourceAudioWait: Duration.zero,
+        endpointListenable: endpoints,
+        endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+      );
+      controller.attachCaptureMemory(
+        load: (String gameKey) => store[gameKey] ?? const GalCaptureMemory(),
+        save: (String gameKey, GalCaptureMemory memory) =>
+            store[gameKey] = memory,
+      );
+      return controller;
+    }
+
+    final GalHookSessionController first = build();
+    expect(
+      (await first.launchGame(r'D:\anemoi\SiglusEngine.exe')).launched,
+      isTrue,
+    );
+    first.setAudioFallbackPolicy(GalAudioFallbackPolicy.cleanOnly);
+    expect(
+      store[r'd:\anemoi\siglusengine.exe']?.audioFallbackPolicy,
+      GalAudioFallbackPolicy.cleanOnly,
+    );
+    await first.close();
+
+    final GalHookSessionController second = build();
+    expect(
+      (await second.launchGame(r'D:\anemoi\SiglusEngine.exe')).launched,
+      isTrue,
+    );
+    expect(
+      second.state.audioFallbackPolicy,
+      GalAudioFallbackPolicy.cleanOnly,
+      reason: '策略必须在会话启动时就恢复——资源模式不枚举音轨，等音轨快照就等不到',
+    );
+
+    // 另一个游戏不得继承上一个游戏的策略（`_beginActivitySession` 重置记忆会话）。
+    expect(
+      (await second.launchGame(r'D:\other\Game.exe')).launched,
+      isTrue,
+    );
+    expect(
+      second.state.audioFallbackPolicy,
+      GalAudioFallbackPolicy.full,
+      reason: '换游戏必须按新 exe 重新加载记忆，不能串上一个游戏的选择',
+    );
+
+    await second.close();
     endpoints.dispose();
   });
 

--- a/hibiki/test/pages/texthooker_page_test.dart
+++ b/hibiki/test/pages/texthooker_page_test.dart
@@ -141,6 +141,11 @@ void main() {
         reason: 'PR #455 将会话音轨改为仅在活动会话显示的工具栏直达入口');
     expect(find.byKey(const ValueKey<String>('game-toolbar-tracks')),
         findsNothing);
+    // 降级策略入口取代了旧的 bool 开关项，菜单项上直接显示当前档位（默认 full）。
+    expect(find.text('Audio fallback · Allow mixed audio'), findsOneWidget,
+        reason: '三档策略入口必须显示当前档位，否则用户不知道自己在哪一档');
+    expect(find.text('Allow audio fallback'), findsNothing,
+        reason: '旧的 bool「允许音频降级」开关已被三档策略取代');
   });
 
   testWidgets('embedded mode reuses parent scaffold and exposes back action',

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -1993,6 +1993,8 @@ void FlutterWindow::RegisterVoiceHookChannel() {
                  flutter::EncodableValue(tk.order_index)},
                 {flutter::EncodableValue("clipCount"),
                  flutter::EncodableValue(tk.clip_count)},
+                {flutter::EncodableValue("clipCountAtCue"),
+                 flutter::EncodableValue(tk.clip_count_at_cue)},
             }));
           }
           result->Success(flutter::EncodableValue(flutter::EncodableMap{

--- a/hibiki/windows/runner/voice_hook_reader.cpp
+++ b/hibiki/windows/runner/voice_hook_reader.cpp
@@ -588,7 +588,8 @@ void VoiceHookReader::ListAudioTracks(uint64_t ts_ms,
   std::map<uint64_t, VoiceTrackInfo> tracks;
   std::map<uint64_t, uint64_t> sum_bytes;    // 段字节累计
   std::map<uint64_t, double> sum_energy_at;  // 文本时刻窗能量累计
-  std::map<uint64_t, int> n_energy_at;       // 文本时刻窗计数
+  std::map<uint64_t, int> n_energy_at;       // 文本时刻窗**能算出能量**的段数（仅 16-bit）
+  std::map<uint64_t, int> n_clips_at;        // 文本时刻窗内的段数（与位深无关，BUG-1165）
   int next_order = 0;
   for (const auto* c : valid) {
     auto it = tracks.find(c->source_ptr);
@@ -607,6 +608,10 @@ void VoiceHookReader::ListAudioTracks(uint64_t ts_ms,
     const int64_t d =
         static_cast<int64_t>(c->timestamp_ms) - static_cast<int64_t>(ts_ms);
     if (d >= -150 && d <= 450) {
+      // 先无条件计数：这条轨在这句时刻窗内**有没有出声**与能不能算能量无关。
+      // 能量只在 16-bit 上算得出来（ClipEnergy16Locked 其余返回 -1），拿能量兼作
+      // 「有没有段」的判据会把非 16-bit 的可用轨误判成静音（BUG-1165）。
+      n_clips_at[c->source_ptr]++;
       const double e = ClipEnergy16Locked(h, ring, c);
       if (e >= 0) {
         sum_energy_at[c->source_ptr] += e;
@@ -622,6 +627,8 @@ void VoiceHookReader::ListAudioTracks(uint64_t ts_ms,
     }
     const int ne = n_energy_at.count(kv.first) ? n_energy_at[kv.first] : 0;
     info.avg_energy = (ne > 0) ? sum_energy_at[kv.first] / ne : -1.0;
+    info.clip_count_at_cue =
+        n_clips_at.count(kv.first) ? n_clips_at[kv.first] : 0;
     out.push_back(info);
   }
   // 按创建顺序返回（UI 稳定展示）。

--- a/hibiki/windows/runner/voice_hook_reader.h
+++ b/hibiki/windows/runner/voice_hook_reader.h
@@ -62,10 +62,14 @@ struct VoiceTrackInfo {
   int channels = 0;
   int bits_per_sample = 0;
   bool is_float = false;
-  uint64_t avg_bytes = 0;     // 近窗内该源每段平均字节数（缓冲规模，代理该源是否持续流式）
+  uint64_t avg_bytes = 0;     // **环内**该源每段平均字节数（缓冲规模，代理该源是否持续流式）
   double avg_energy = 0.0;    // 文本时刻窗 [ts-150,ts+450] 平均能量（16-bit 平均绝对幅值；非 16-bit=-1）
-  int order_index = 0;        // 近窗内按首次出现（clip seq 升序）排的创建顺序，0-based
-  int clip_count = 0;         // 近窗内该源的段数
+  int order_index = 0;        // **环内**按首次出现（clip seq 升序）排的创建顺序，0-based
+  int clip_count = 0;         // **环内**该源的总段数——注意不是「当前这句附近」，恒 >= 1
+  // 文本时刻窗 [ts-150,ts+450] 内该源的段数。avg_energy 的 -1 有两义（窗内没段 /
+  // 非 16-bit 算不了能量），拿它判「此刻这条轨响没响」会把非 16-bit 的可用轨也误判成
+  // 静音；本字段与位深无关，是该判断的唯一正确依据（BUG-1165）。
+  int clip_count_at_cue = 0;
 };
 
 // 单例：整个进程一路引擎-hook 读取。所有方法可从 UI 线程调用，绝不抛异常（全 HRESULT/句柄校验）。


### PR DESCRIPTION
## 已按用户要求拆分：本 PR 只保留 bug 修复

原本这个 PR 混了两条 bug 修复和一条**新增能力**（「制卡封面可选静态截图」），规模从 11 个文件涨到 39 个。用户拍板拆开：

- **本 PR（#471）**：只保留 BUG-1187 + BUG-1165 两条 bug 修复，35 个文件。
- **新功能移到 #507**（`feat/gal-mining-image-mode`，draft）：BUG-1160「制卡封面可选静态截图」独立审查、独立验收。

两个 PR **各自基于 develop、无代码依赖**，可任意顺序合入；唯一会撞的是 i18n 文件尾部追加和 `pubspec.yaml` 的 `+build`，属本仓所有 PR 的常规合并冲突。

### 从本 PR 移除的东西（全部去了 #507）

`app_model.dart` / `preferences_repository.dart`（`galMiningImageMode` 偏好）、`anki_settings_page.dart`（设置页选择器）、`gal_hook_mining_coordinator.dart` 的 `imageMode` 参数与 `captureStillWithDiagnostics()` 重构、`texthooker_page.dart` 的 `imageMode:` 透传、3 个 `gal_mining_image_mode*` i18n key、2 个封面模式测试、`docs/bugs/BUG-1160-*.md`。

### 🔴 BUG 号变更：1164 → 1187

rebase 到最新 develop 时发现 **BUG-1164 已被 develop 上已合入的 manga bug 占用**（`docs/bugs/BUG-1164-manga-module-orphan-i18n-and-shelf-naming.md`，且有 6 处代码/测试引用）。不改号会让 `bug.dart check` 与守卫测试 CI 红。

本条已让号至 **BUG-1187**（develop + 全部 441 个远端分支扫描后的最大号是 1186）：文件名、正文 H2 标题、交叉引用四处同步改，`dart run tool/bug.dart check` 通过（1152 条，号唯一，索引同步）。BUG-1165 / BUG-1160 未撞号，保持不动。

### 保留不动的东西（第 ③ 点，逐项复核过）

- 工具栏「更多」溢出菜单 `_buildToolbarOverflowMenu` — 在；只把里面那个 bool 开关项换成三档策略入口，其余菜单项不动。
- 工作台音轨直达入口 `HibikiFocusId('game-toolbar-tracks')` — 在（`texthooker_page.dart:1000`）。
- 任意 exe 直启入口（`FileType.custom` + `allowedExtensions: ['exe']` → `_session.launchGame`）— 在（`texthooker_page.dart:647-673`）。
- 两个守卫测试 `hibiki/test/pages/texthooker_toolbar_warmslot_guard_test.dart` 与 `hibiki/test/tools/gal_workbench_track_manager_guard_test.dart` — 与 develop **逐字一致**（`git diff origin/develop..HEAD -- <两文件>` 为空）。

### 验证

- `flutter analyze`（含 test 目录）：**No issues found!**
- 定向套件（`dart run tool/flutter_test_failures.dart --no-pub`）：`FLUTTER TEST VERDICT: PASSED - 115 tests ran, all tests passed`
  - `gal_audio_degrade_track_test` / `gal_hook_mining_coordinator_test` / `gal_hook_session_controller_test` / `texthooker_page_test` / `texthooker_toolbar_warmslot_guard_test` / `gal_workbench_track_manager_guard_test` / `gal_capture_audio_integrity_test` / `external_window_mining_test` / `gal_hook_launch_outcome_and_encoding_test` / `gal_voice_pairing_window_parity_test`
- 全量套件交由 PR CI 兜底。C++ runner 改动无单测框架，靠编译验证 + Dart 契约测试。

平台范围：Windows only（galgame hook 硬规则），未触碰其它平台实现。

---

<details>
<summary>原始 PR 描述（拆分前，供对照）</summary>

## 用户诉求

> 加个禁止降级按钮，因为有的游戏，有的句子有音频，然后有部分句子没音频，会跑到 bgm 或者降级。（bgm 可以通过禁止来禁止）。降级不知道怎么弄。
> 删右上角的启动并捕获，删掉活动音轨。把更多里面的东西拿出来。

## 根因（BUG-1144）

「禁止降级」开关**本来就存在**（⋮ 菜单 →「允许音频降级」），但它管不到真正产生 BGM 的那一层：

| 层 | 位置 | 旧开关管不管 |
|---|---|---|
| 会话级降级 | `_activateLoopback` | ❌ |
| **逐行捕获期** | `_activateResourceWithLoopback` 把 `_audioSource` 指向 loopback → `_attachLineAudio` 对**每一行**排 `_scheduleLoopbackFreeze` | ❌ **BGM 就是这里来的** |
| 制卡期 | `_captureAudioBytesNow` | ✅ 唯一生效点 |

没配音的句子（旁白/心理描写/选项）冻到的必然是纯 BGM/环境音。而旧 bool 的语义是「只接受 game_resource 原始文件」，把混音前抓的**干净引擎 PCM** 也一并禁掉（没有资源 hook 的引擎一关就全灭），关掉之后 coordinator 还会让**整张卡制卡失败**——用户被迫在「收一段 BGM」和「这张卡做不了」之间二选一。

## 改动

**三态 `GalAudioFallbackPolicy` 取代 bool**，把「干净与否」和「有没有原件」拆开：

| 策略 | 链路 | 抓不到时 |
|---|---|---|
| `full`（默认，= 旧 `allow=true`） | 资源 → PCM → 系统混音 | 混音兜底 |
| **`cleanOnly`（新增，用户要的那档）** | 资源 → 引擎 PCM，**绝不碰混音** | 判无配音，**无音频成卡** |
| `resourceOnly`（= 旧 `allow=false`） | 只认原始资源文件 | 拒绝制卡 |

- gate 补到 `_scheduleLoopbackFreeze` **自身**（覆盖 `_attachLineAudio` 与 `_settleLineUtterance` 两个调用点——漏一个就等于策略静默失效）
- 制卡期判据用**音源类型**（`source is LoopbackGalAudioSource`）而非「缓存里有没有东西」：策略中途改时，早先冻结的切片同样是混音，必须一并失效
- 用户**显式裁决**（补录 / 逐行选轨）不受策略约束——那不是降级，是用户指定音源
- 策略随 `GalCaptureMemory` 按游戏持久化，**会话启动即恢复**（不能搭 `_applyTrackMemory` 的便车：资源模式根本不枚举音轨，等音轨快照永远等不到）

**顺带修一个既有隐患**：`_resetCaptureMemorySession` 原先只在 `stopCapture` 里调。用户不点「停止监听」直接启动下一个游戏时，上一个游戏的排除集/语音轨会套到新游戏上，而新游戏里做的选择又写回**上一个游戏**的 key。改到 `_beginActivitySession`（launch / attach 两条开新会话路径共用）。

**UI**：
- 删「更多」溢出菜单——它收着的四项全是会话进行中随手要用的东西（尤其降级策略），藏在二级菜单里等于没有，现在全部平铺
- 删「启动并捕获」——它只能临时挑一个裸 exe，而游戏库两页（`games_library_page.dart:436` / `galgame_home_page.dart:274`）走同一条 `launchGame`、同一份启动参数配置，还带游戏身份（捕获记忆按 exe 路径锚定）
- 删「活跃音轨」——同一份 `GalAudioTracksPanel` 仍在「兼容性诊断」页签（平级 tab，一点即到）

## 守卫测试处理

两个源码守卫断言的是被删掉的符号。按守卫自身的方法论（守用户能力、不守实现符号）**搬到仍然真实存在的实现上**，覆盖面不降反升：
- `galgame_helper_launch_guard`：`texthooker_page._launchGalgameEngineHook` → `galgame_home_page._launchGame`（原本漏掉的第二条真实启动路径，实测它有完整 `_launching` 再入守卫）
- `gal_workbench_track_manager_guard`：工作台顶栏 → 诊断页常驻音轨卡（同一条 `setTrackExcluded` 通道）

## 验证

- `flutter analyze`（含 test 目录）：**No issues found**
- `flutter test test/mining test/tools test/i18n`：**959 passed**
- `flutter test test/pages/texthooker_page_test.dart test/pages/home_game_page_test.dart test/pages/game_module_focus_test.dart`：**23 passed**
- 新增测试：
  - `clean-source policy refuses loopback mix for a line with no voice`（断言 `grabRecentCalls == 0`——一次都不许去环里取混音）
  - `audio fallback policy is remembered per game and restored on launch`（含「换游戏不得继承上一个游戏策略」）
  - `clean-source mode still mines the card when the line has no voice`

**真机验收待补**：需在只有部分句子配音的游戏上确认无配音句灰标、且不再收进 BGM。

https://claude.ai/code/session_01PX6jhJWfptQiMQorEtaUrq


</details>
