### PR TITLE
fix(clipboard): 补上剪贴板复制历史的采集点 (BUG-1145)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1109 条。点号进各自文件。
+> 共 1110 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1145](bugs/BUG-1145-clipboard-history-never-captured.md) | ✅ | ✅ | 桌面剪贴板复制历史永远为空（采集回调从未触发） |
 | [BUG-1142](bugs/BUG-1142-gal-launch-failure-unclassified.md) | ✅ | ✅ | gal 启动失败只报无信息兜底文案，失败原因在 launchGame 的 bool 返回值处被丢弃 |
 | [BUG-1141](bugs/BUG-1141-download-discovery-timeout-too-short.md) | ✅ | ✅ | 代理下「发现」搜索 20s 超时太短，请求本可成功却被掐断 |
 | [BUG-1140](bugs/BUG-1140-cross-chapter-turn-latency.md) | ✅ | ✅ | 跨章翻页耗时实测与提速（遮罩口径） |

--- a/docs/bugs/BUG-1145-clipboard-history-never-captured.md
+++ b/docs/bugs/BUG-1145-clipboard-history-never-captured.md
@@ -1,0 +1,27 @@
+## BUG-1145 · 桌面剪贴板复制历史永远为空（采集回调从未触发）
+- **报告**：2026-07-27（用户：桌面查词浮窗/面板的 🕘「复制历史」点开永远是空列表）
+- **真实性**：✅ 真 bug，既有缺陷、非任何 PR 引入。根因是**写侧从来没写出来过**（不是后来被删）：
+  - `hibiki/lib/src/sync/desktop_lookup_service.dart:128` 声明 `void Function(String text)? onClipboardCaptured;`
+  - `hibiki/lib/src/models/app_model.dart:4934` 赋值 `DesktopLookupService.instance.onClipboardCaptured = addClipboardHistoryEntry;`
+  - **全仓零 `?.call()`**——回调被声明、被接上实现，但没有任何人触发它。
+  引入 commit `24e6443bb`（2026-07-19，「剪贴板复制历史数据层与采集点」）；`git log -S onClipboardCaptured --all` 只有这一个 commit，其 diff 里该符号也只出现在声明行 + 赋值行。commit message 自称「采集点（origin=clipboard、去重通过后落历史）」，但代码里只留了个空插槽——读侧后续阶段全做了，回头没补写侧。
+  写入链完整但断头：表 `clipboard_history` ← `replaceAllClipboardHistory` ← `_flush` ← `_schedulePersist` ← `ClipboardHistoryRepository.add` ← `AppModel.addClipboardHistoryEntry`(`app_model.dart:1412`) ← 只赋值给那个零调用的回调。
+  读侧则**完全可达**：🕘 按钮无条件渲染于面板栏（`hibiki/assets/popup/global_lookup_host.js:494-511`）与瞬态浮窗（`:1157-1163`），Dart 两个 controller 都接（`clipboard_panel_controller.dart:547` / `global_lookup_controller.dart:495`），i18n 三个 key 齐备。于是用户每次点开都恒命中 `clipboard_history_empty` 空态，「清空」按钮也永远无事发生（清一张恒空的表）。属用户可见功能性缺陷，不是不可达残留。
+  该路径**此前 0 测试覆盖**（`onClipboardCaptured` / `addClipboardHistoryEntry` / `clipboardHistoryRepo` 在 `test/` 与 `integration_test/` 零命中），这正是它潜伏至今而 CI 一直绿的原因。
+- **[x] ① 已修复** — `hibiki/lib/src/sync/desktop_lookup_service.dart:215`（commit `c348f8345`）：在 `_queueLookupRequest` 的**去重通过点之后**补上唯一采集点 `onClipboardCaptured?.call(deduped)`，并用 `origin == DesktopLookupOrigin.clipboard` 收窄。
+  - **单点收口即可**：`_queueLookupRequest` 全部 3 个调用方中，`dedupe: false` 的提前返回分支只有热键（`:404`，origin=hotkey）与悬浮字幕点词（`:453`，origin=explicit），两者压根到不了这一行；clipboard 来源（`submitText`）恒走去重分支。故不必在 `dedupe:false` 分支重复埋点，也不会误采热键查词 / 点词 / texthooker / gal hook 的文本。`origin` 判定是显式契约，防将来有别的来源改走去重分支时污染复制历史。
+  - **落在去重之后**是关键：挖词 / 抓选区写回剪贴板的自触发回声被 `dedupeClipboard`（800ms 时间窗，BUG-1025）判 null 直接 return，因而不进历史；更上游还有 `clipboardIgnores.consume` 精确拦截 Hibiki 自产写入。同一段文本超窗口再复制则如实触发，仓库侧 `ClipboardHistoryRepository.add` 的「同文本去重到最新」把它移到队尾，不堆重复行。
+  - 记的是 `deduped`——注音标记已剥（BUG-1138）、超长已截断（BUG-442）的纯基准文本，与本条链路其余消费面同一坐标系。
+  - 顺带让 `debugReset()`（`:254`）清空该回调，避免用例间捕获器泄漏（生产侧不调 `debugReset`，行为不受影响）。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/desktop_lookup_service_test.dart` 新增 group「剪贴板复制历史采集 (BUG-1145)」6 项，**直接打在真实 `ClipboardHistoryRepository` + 内存 Drift 库上**（不是 mock 回调计数），覆盖：
+  - 剪贴板复制的文本真的进仓库、且 `flushNow()` 后真有行落到 `clipboard_history` 表；查词管线不受影响（采集是旁路副作用）。
+  - 多次复制不同文本按时间顺序累积（队尾 = 最新）。
+  - **负向**：热键（`debugTriggerHotKey`）与悬浮字幕点词（`triggerLookup`）查词照常发生但**不写**复制历史；同一用例内再用 `submitText` 作正向对照，证明「空」不是装配没接上。
+  - 去重窗口内的自触发回声不写进历史。
+  - 超窗口重复复制同一文本去重到最新、不堆重复行（内存 + 落库双断言）。
+  - 源码守卫：`AppModel` 仍把 `addClipboardHistoryEntry` 接到 `onClipboardCaptured`（钉住链路的另一半）。
+  **负向验证已实测**：注释掉 `onClipboardCaptured?.call(deduped)` → 前 5 项全红；单独摘掉 `app_model.dart` 的赋值行 → 第 6 项红。两半各自可失效、各自有守卫。
+- **备注**：
+  - 该 group 用普通 `async test` 而非 `testWidgets`——`ClipboardHistoryRepository.add` 会起真实 debounce 刷盘 Timer，`testWidgets` 的 FakeAsync 收尾时会因「仍有 pending Timer」判红（该 Timer 由 tearDown 的 `repo.dispose()` 取消）。
+  - 采集只在**桌面**发生（`DesktopLookupService` 是桌面剪贴板 + 全局热键触发器），移动端不受影响。
+  - 未做真机验收：本修复的可观测面是单测已钉死的仓库/DB 写入；面板里 🕘 实际列出条目的目视确认留给用户在桌面 app 上完成。

--- a/hibiki/lib/src/sync/desktop_lookup_service.dart
+++ b/hibiki/lib/src/sync/desktop_lookup_service.dart
@@ -199,6 +199,21 @@ class DesktopLookupService extends ChangeNotifier
     if (deduped == null) return;
     _lastText = deduped;
     _lastTextTime = nowTs;
+    // BUG-1145：剪贴板复制历史的唯一采集点。落在**去重通过之后**，所以被
+    // dedupeClipboard 判为自触发回声（挖词/抓选区写回）的那次不会进历史；同一段
+    // 文本超窗口再复制则如实记一条，仓库侧 [ClipboardHistoryRepository.add] 再做
+    // 「同文本去重到最新」把它移到队尾而不是堆重复行。
+    //
+    // `origin == clipboard` 是真实剪贴板变化的判据：热键（origin=hotkey）与悬浮
+    // 字幕点词（origin=explicit）都走上面 `dedupe: false` 的提前返回分支，本行不
+    // 可达；这道显式判定保证即使将来有别的来源改走去重分支，也不会把非「复制」
+    // 动作污染进复制历史（守卫见 desktop_lookup_service_test.dart 的 BUG-1145 组）。
+    //
+    // 记的是 [deduped]——注音标记已剥、超长已截断的纯基准文本，与本条链路
+    // （透明文字窗 / 悬浮面板 / 瞬态卡 / 剪贴板历史）其余消费面同一坐标系。
+    if (origin == DesktopLookupOrigin.clipboard) {
+      onClipboardCaptured?.call(deduped);
+    }
     _pendingRequest = DesktopLookupRequest(
       text: deduped,
       origin: origin,
@@ -234,6 +249,9 @@ class DesktopLookupService extends ChangeNotifier
     _pendingRequest = null;
     _lastText = null;
     _lastTextTime = null;
+    // BUG-1145：采集回调是单例上的长命字段，不清会让上一个用例装的捕获器
+    // 漏进后续用例（写到已经析构的仓库上）。生产侧不调 debugReset，行为不受影响。
+    onClipboardCaptured = null;
     // BUG-700：跑过 start()/stop() 的用例可能留下非零计数 + 已挂的 Dart 侧监听器，
     // 若不清会漏进后续用例。仅在确有累计计数时同步摘除监听并归零（未 start 的用例
     // 计数恒 0，此块跳过，行为不变）。removeListener 对未注册的监听器是安全 no-op。

--- a/hibiki/test/sync/desktop_lookup_service_test.dart
+++ b/hibiki/test/sync/desktop_lookup_service_test.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/services.dart';
 import 'dart:io';
 
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:hibiki/src/models/clipboard_history_repository.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/sync/desktop_foreground_guard.dart';
 import 'package:hibiki/src/sync/desktop_lookup_service.dart';
@@ -670,6 +673,179 @@ void main() {
     for (final String g in pending.characters) {
       expect(g, emoji);
     }
+  });
+
+  // BUG-1145：桌面「剪贴板复制历史」🕘 面板永远是空的。根因不是读侧——DB 表、
+  // 仓库、payload、面板 UI、i18n 全都在——而是 [DesktopLookupService.onClipboardCaptured]
+  // 这个采集回调自 24e6443bb 引入起就只有声明 + AppModel 的赋值，**零调用点**，
+  // 于是 add() 永不发生，用户每次点开都命中空态。本组是该路径的首个覆盖（此前 0
+  // 测试，正是它潜伏这么久、CI 一直绿的原因），直接打到真实
+  // [ClipboardHistoryRepository] + 内存 Drift 库上，钉死「剪贴板来源写穿到历史 /
+  // 非剪贴板来源不写 / 重复复制不堆重复行」三条契约。
+  group('剪贴板复制历史采集 (BUG-1145)', () {
+    late HibikiDatabase db;
+    late ClipboardHistoryRepository repo;
+    late DateTime fakeNow;
+
+    setUp(() {
+      // 外层 setUp 已跑过 debugReset（会把 onClipboardCaptured 清成 null），故本组的
+      // 装配必须在它之后——group 的 setUp 恒后于外层 setUp 执行。
+      db = HibikiDatabase.forTesting(NativeDatabase.memory());
+      repo = ClipboardHistoryRepository(db);
+      fakeNow = DateTime(2026, 7, 27, 9, 0, 0);
+      final DesktopLookupService service = DesktopLookupService.instance;
+      service.clock = () => fakeNow;
+      // 与 AppModel.addClipboardHistoryEntry 同构的装配（生产侧那行赋值由本组末尾的
+      // 源码守卫单独钉住）；时刻用假时钟保证顺序断言确定。
+      service.onClipboardCaptured = (String text) => repo.add(text, fakeNow);
+    });
+
+    tearDown(() async {
+      DesktopLookupService.instance.onClipboardCaptured = null;
+      DesktopLookupService.instance.clock = DateTime.now;
+      repo.dispose();
+      await db.close();
+    });
+
+    test('剪贴板复制的文本真的写进历史仓库并落库', () async {
+      final DesktopLookupService service = DesktopLookupService.instance;
+
+      service.submitText('  見る ');
+
+      // 内存层：进了仓库，且是 trim 后的纯基准文本。
+      expect(
+        repo.entries.map((ClipboardHistoryEntry e) => e.text),
+        <String>['見る'],
+        reason: '这正是 BUG-1145 的用户症状——采集点缺失时这里恒为空',
+      );
+      expect(repo.entries.single.copiedAt, fakeNow);
+      // 查词管线不受影响（采集是旁路副作用，不能吃掉原有行为）。
+      expect(service.pendingText, '見る');
+
+      // 写穿层：debounce 刷盘后真的有行落到 clipboard_history 表。
+      await repo.flushNow();
+      final List<ClipboardHistoryRow> rows = await db.getAllClipboardHistory();
+      expect(rows.map((ClipboardHistoryRow r) => r.content), <String>['見る']);
+    });
+
+    test('多次复制不同文本按时间顺序累积（队尾 = 最新）', () async {
+      final DesktopLookupService service = DesktopLookupService.instance;
+
+      service.submitText('見る');
+      fakeNow = fakeNow.add(const Duration(seconds: 5));
+      service.submitText('読む');
+      fakeNow = fakeNow.add(const Duration(seconds: 5));
+      service.submitText('走る');
+
+      expect(
+        repo.entries.map((ClipboardHistoryEntry e) => e.text),
+        <String>['見る', '読む', '走る'],
+      );
+    });
+
+    // 负向契约：热键查词 / 悬浮字幕点词是「查词」不是「复制」，不得污染复制历史。
+    // 用普通 async test 而非 testWidgets：ClipboardHistoryRepository.add 会起一个真实
+    // 的 debounce 刷盘 Timer，testWidgets 的 FakeAsync 收尾时会因「仍有 pending Timer」
+    // 直接判红（该 Timer 由 tearDown 的 repo.dispose() 取消）。
+    // 两者都走 dedupe:false 分支，压根到不了采集点；本用例守住这条边界，防止有人
+    // 把采集点上移到 _queueLookupRequest 顶部或删掉 origin 判定。
+    test('热键与悬浮字幕点词不写进复制历史', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform,
+              (MethodCall call) async {
+        if (call.method == 'Clipboard.getData') {
+          return <String, Object?>{'text': '  早い  '};
+        }
+        return null;
+      });
+
+      final DesktopLookupService service = DesktopLookupService.instance;
+
+      // ① 全局热键（origin=hotkey）。
+      await service.debugTriggerHotKey();
+      expect(service.pendingRequest?.origin, DesktopLookupOrigin.hotkey);
+      expect(service.pendingText, '早い', reason: '热键查词本身必须照常发生');
+      expect(repo.entries, isEmpty, reason: '热键查词不是「复制」，不计入复制历史');
+
+      // ② 悬浮字幕点词（origin=explicit）。
+      service.triggerLookup('良い');
+      expect(service.pendingRequest?.origin, DesktopLookupOrigin.explicit);
+      expect(service.pendingText, '良い', reason: '点词查词本身必须照常发生');
+      expect(repo.entries, isEmpty, reason: '点词查词不是「复制」，不计入复制历史');
+
+      // 只有真正的剪贴板来源才落历史（同一组里作正向对照，证明上面的空不是装配没接上）。
+      service.submitText('見る');
+      expect(
+        repo.entries.map((ClipboardHistoryEntry e) => e.text),
+        <String>['見る'],
+      );
+    });
+
+    test('去重窗口内的自触发回声不写进历史', () {
+      final DesktopLookupService service = DesktopLookupService.instance;
+
+      service.submitText('見る');
+      expect(repo.entries, hasLength(1));
+      service.clearPending();
+
+      // 窗口内（<800ms）的同词 = 挖词/抓选区写回的回声，dedupeClipboard 判 null，
+      // 采集点在其后故一并跳过。
+      fakeNow = fakeNow.add(const Duration(milliseconds: 100));
+      service.submitText('見る');
+
+      expect(service.pendingText, isNull, reason: '回声本来就不该触发查词');
+      expect(repo.entries, hasLength(1), reason: '回声更不该在历史里堆出第二条');
+    });
+
+    test('超窗口重复复制同一文本去重到最新，不堆重复行', () async {
+      final DesktopLookupService service = DesktopLookupService.instance;
+
+      service.submitText('見る');
+      fakeNow = fakeNow.add(const Duration(seconds: 5));
+      service.submitText('読む');
+      expect(
+        repo.entries.map((ClipboardHistoryEntry e) => e.text),
+        <String>['見る', '読む'],
+      );
+
+      // 用户隔了几秒再复制一次「見る」：查词要重新排队（BUG-1025），历史侧则由
+      // ClipboardHistoryRepository.add 的「同文本去重到最新」把它移到队尾，
+      // 而不是留下两条一样的行。
+      fakeNow = fakeNow.add(const Duration(seconds: 5));
+      service.submitText('見る');
+
+      expect(service.pendingText, '見る', reason: '超窗口的同词是用户显式重查，必须放行');
+      expect(
+        repo.entries.map((ClipboardHistoryEntry e) => e.text),
+        <String>['読む', '見る'],
+        reason: '同文本去重到最新：只剩一条「見る」且被移到队尾',
+      );
+      expect(repo.entries.last.copiedAt, fakeNow);
+
+      await repo.flushNow();
+      final List<ClipboardHistoryRow> rows = await db.getAllClipboardHistory();
+      expect(
+        rows.map((ClipboardHistoryRow r) => r.content),
+        <String>['読む', '見る'],
+      );
+    });
+
+    // 采集链路的另一半：AppModel 必须把 addClipboardHistoryEntry 接到回调上。
+    // 上面的行为用例是自己装的捕获器，接不上生产装配也照样绿；这条源码守卫补上
+    // 那一环，删掉赋值行即红。
+    test('AppModel 仍把 addClipboardHistoryEntry 接到 onClipboardCaptured', () {
+      final String model =
+          File('lib/src/models/app_model.dart').readAsStringSync();
+      expect(
+        // Dart RegExp 的 \s 覆盖换行，故这条能跨行匹配 app_model.dart 里
+        // `onClipboardCaptured =` 换行再接 `addClipboardHistoryEntry;` 的写法。
+        model.contains(
+          RegExp(r'onClipboardCaptured\s*=\s*addClipboardHistoryEntry'),
+        ),
+        isTrue,
+        reason: '生产侧的采集装配丢了，复制历史又会永远为空（BUG-1145）',
+      );
+    });
   });
 }
 


### PR DESCRIPTION
## 症状

桌面查词面板 / 瞬态浮窗的 🕘「复制历史」点开**永远是空列表**，「清空」按钮点了也永远无事发生。

## 根因

**写侧从来没写出来过**（不是后来被删）。`DesktopLookupService.onClipboardCaptured` 自引入 commit `24e6443bb`（2026-07-19）起就只有两处出现：

- 字段声明 `desktop_lookup_service.dart:128`
- AppModel 赋值 `app_model.dart:4934`

**全仓零 `?.call()`**。`git log -S onClipboardCaptured --all` 只有那一个 commit，其 diff 里也只有声明行 + 赋值行——commit message 自称「采集点（origin=clipboard、去重通过后落历史）」，但代码里只留了个空插槽。

写入链完整但断头：
`clipboard_history` 表 ← `replaceAllClipboardHistory` ← `_flush` ← `_schedulePersist` ← `ClipboardHistoryRepository.add` ← `AppModel.addClipboardHistoryEntry` ← 只赋值给那个零调用的回调 ✗

读侧则**完全可达**（🕘 按钮无条件渲染、两个 controller 都接、i18n 三个 key 齐备），所以用户每次点开都恒命中空态。属用户可见功能性缺陷，不是不可达残留。

该路径**此前 0 测试覆盖**，这正是它潜伏至今而 CI 一直绿的原因。

## 修复

`desktop_lookup_service.dart:215` — 在 `_queueLookupRequest` 的**去重通过点之后**补上唯一采集点，用 `origin == DesktopLookupOrigin.clipboard` 收窄：

- **单点收口即可**：`_queueLookupRequest` 的 3 个调用方中，`dedupe: false` 提前返回分支只有热键（origin=hotkey）与悬浮字幕点词（origin=explicit），两者压根到不了这一行；clipboard 来源恒走去重分支。故不会误采热键查词 / 点词 / texthooker / gal hook 的文本。`origin` 判定是显式契约，防将来有别的来源改走去重分支时污染复制历史。
- **落在去重之后**是关键：挖词 / 抓选区写回剪贴板的自触发回声被 `dedupeClipboard`（800ms 窗，BUG-1025）判 null 直接 return，因而不进历史；超窗口的同词复制则由仓库既有的「同文本去重到最新」移到队尾，不堆重复行。
- 记的是 `deduped`——注音标记已剥（BUG-1138）、超长已截断（BUG-442）的纯基准文本，与本条链路其余消费面同一坐标系。
- 顺带让 `debugReset()` 清空该回调，避免用例间捕获器泄漏（生产侧不调 `debugReset`）。

**没有另起写库路径**，走的就是既有的 `addClipboardHistoryEntry` → `repo.add` → debounce 写穿 → 退出刷盘链路。

## 测试

`test/sync/desktop_lookup_service_test.dart` 新增 group「剪贴板复制历史采集 (BUG-1145)」**6 项**，直接打在**真实 `ClipboardHistoryRepository` + 内存 Drift 库**上（不是 mock 回调计数）：

1. 剪贴板复制的文本真的进仓库，`flushNow()` 后真有行落到 `clipboard_history` 表；查词管线不受影响
2. 多次复制不同文本按时间顺序累积（队尾 = 最新）
3. **负向**：热键 + 悬浮字幕点词查词照常发生但**不写**历史；同用例内再用 `submitText` 作正向对照，证明「空」不是装配没接上
4. 去重窗口内的自触发回声不写进历史
5. 超窗口重复复制同一文本去重到最新、不堆重复行（内存 + 落库双断言）
6. 源码守卫：`AppModel` 仍把 `addClipboardHistoryEntry` 接到 `onClipboardCaptured`

**负向验证已实测**：注释掉 `onClipboardCaptured?.call(deduped)` → 前 5 项全红；单独摘掉 `app_model.dart` 的赋值行 → 第 6 项红。链路两半各自可失效、各自有守卫。

## 验证

- `flutter analyze`（含 test）→ **No issues found**
- 全量 `flutter test --no-pub` → 见下方评论
- 未做真机验收：可观测面已被单测钉死；面板里 🕘 实际列出条目的目视确认留给用户在桌面 app 上完成。

bug 记录：`docs/bugs/BUG-1145-clipboard-history-never-captured.md`（`bug.dart new` 取号，扫 965 个分支）

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb