### PR TITLE
test(torrent): 落盘后再比对字节，消除 CI Windows 24% flaky（BUG-1147）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1123 条。点号进各自文件。
+> 共 1124 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1162](bugs/BUG-1162-torrent-pipeline-disk-flush-race.md) | ✅ | ✅ | hibiki_torrent 端到端测试在字节落盘前就比对，CI Windows 约 24% 概率红 |
 | [BUG-1156](bugs/BUG-1156-manga-spread-cropped-janky.md) | ✅ | ✅ | 漫画双页图片裁切且翻页卡顿 |
 | [BUG-1155](bugs/BUG-1155-manga-popup-pagination-focus.md) | ✅ | ✅ | 漫画查词弹窗吞掉滚轮和左右翻页 |
 | [BUG-1154](bugs/BUG-1154-manga-page-jump-controller-lifecycle.md) | ✅ | ✅ | 漫画页码跳转关闭弹窗后红屏 |

--- a/docs/bugs/BUG-1114-local-rig-rate-limit-flake.md
+++ b/docs/bugs/BUG-1114-local-rig-rate-limit-flake.md
@@ -57,7 +57,7 @@ TODO-1961-a（resume 持久化）无关，硬塞进同一个 PR 会把审查面�
   的 windows job 现在先用 vcpkg 编出 DLL，再跑
   `Run hibiki_torrent FFI tests against the freshly built DLL`（该步骤无
   `continue-on-error`）—— 本 flaky 从此**也能把 CI 判红**，优先级要按 CI flaky
-  重估，不再是纯本地噪声。（发现于 BUG-1147 的验证：本地连跑 10 次整包套件，
+  重估，不再是纯本地噪声。（发现于 BUG-1162 的验证：本地连跑 10 次整包套件，
   这条挂了 1 次。）
 - 本地跑 `packages/hibiki_torrent` 测试时会看到这条偶发红，**不要**误判成自己
   改动引入的回归；先按上面的对照实验法验一次。

--- a/docs/bugs/BUG-1114-local-rig-rate-limit-flake.md
+++ b/docs/bugs/BUG-1114-local-rig-rate-limit-flake.md
@@ -51,8 +51,14 @@ TODO-1961-a（resume 持久化）无关，硬塞进同一个 PR 会把审查面�
 
 ### 影响面
 
-- CI **不受影响**：`packages/hibiki_torrent` 的测试要 `HIBIKI_TORRENT_LIB`
-  指向已构建的 DLL，CI 没有该 DLL → 整组 skip。纯本地噪声。
+- ~~CI **不受影响**：`packages/hibiki_torrent` 的测试要 `HIBIKI_TORRENT_LIB`
+  指向已构建的 DLL，CI 没有该 DLL → 整组 skip。纯本地噪声。~~
+  **2026-07-27 更正：这条已过期。** `.github/workflows/build-multiplatform.yml`
+  的 windows job 现在先用 vcpkg 编出 DLL，再跑
+  `Run hibiki_torrent FFI tests against the freshly built DLL`（该步骤无
+  `continue-on-error`）—— 本 flaky 从此**也能把 CI 判红**，优先级要按 CI flaky
+  重估，不再是纯本地噪声。（发现于 BUG-1147 的验证：本地连跑 10 次整包套件，
+  这条挂了 1 次。）
 - 本地跑 `packages/hibiki_torrent` 测试时会看到这条偶发红，**不要**误判成自己
   改动引入的回归；先按上面的对照实验法验一次。
 

--- a/docs/bugs/BUG-1147-torrent-pipeline-disk-flush-race.md
+++ b/docs/bugs/BUG-1147-torrent-pipeline-disk-flush-race.md
@@ -1,0 +1,33 @@
+## BUG-1147 · hibiki_torrent 端到端测试在字节落盘前就比对，CI Windows 约 24% 概率红
+- **报告**：2026-07-27（用户：CI 巡检）
+- **真实性**：✅ 真 bug（测试自身的时序假设错，不是引擎功能坏）。根因
+  `packages/hibiki_torrent/test/embedded_pipeline_test.dart:151`（修复前）——
+  测试等到 `isFinished` / `progress>=1.0` / `left==0` / `haveCount==numPieces`
+  就直接 `File(contentPath).readAsBytesSync()` 逐字节比对。这四个信号说的都是
+  「piece 已在内存里校验通过」，**不是**「字节已经躺在文件系统里」：写盘 job 还
+  排在 libtorrent 的 disk io 线程上，且 2.x 的 mmap 磁盘后端写进去的是映射视图，
+  Windows 不保证映射视图与 `ReadFile` 之间的一致性；内容文件又是稀疏的，尚未落
+  实的尾部区域直接读成 0。
+  表现（workflow `Build and Test …` 的 windows job，步骤
+  `Run hibiki_torrent FFI tests against the freshly built DLL`）：
+  `downloaded bytes must equal seeded bytes` → `at location [8273920] is <0>
+  instead of <38>`，8MiB 文件距尾约 114KB 处一串 0。近 17 次 develop 运行挂 4 次
+  （约 24%），失败偏移恒定落在文件尾部（`8273920` ×2、`8257536` ×2）。
+  它是该 workflow 唯一会判红的失败源（android job 有 `continue-on-error`）。
+- **[x] ① 已修复** — 把「读盘比对」挪到 `leecher.close()` **之后**：销毁
+  `lt::session` 会走完关停流程，等 disk io 线程把写盘 job 做完、解除映射并关句柄，
+  这是唯一确定性的落盘完成信号（没有加任何 sleep / 重试 / 超时放宽）。原来排在
+  比对之后的「移除（连数据）」用例改为用 rig 的 .torrent 把同一个种子加进一个
+  不联网的新 session（零 peer）再删，删除路径覆盖面不变。
+  改动：`packages/hibiki_torrent/test/embedded_pipeline_test.dart`。
+- **[x] ② 已加自动化测试** —
+  `hibiki/test/media/torrent/torrent_disk_flush_order_guard_test.dart`：纯文本
+  守卫，钉住「`readAsBytesSync` 必须排在 `leecher.close()` 之后」「逐字节比对断言
+  不许被删」「close 与比对之间不许出现 `Future.delayed` / `sleep` / `_pollUntil`
+  这类『等它落盘』的补丁」。放在主 app 测试套件里，因为
+  `packages/hibiki_torrent` 自己的测试在没有 DLL 的平台整组 skip，只有 Windows
+  CI 会真跑。
+- **备注**：本机（NVMe，负载轻）复现不出这个竞态 —— 专门写的探针在关闭 session
+  **之前**读盘，8MiB × 8 次、128MiB × 3 次全部字节一致，说明本地写盘快到窗口关不
+  上；证据只在 CI 上。因此「本地连跑 N 次全绿」不能证明根除，真正的依据是读盘
+  被挪到了确定性的落盘屏障之后。

--- a/docs/bugs/BUG-1162-torrent-pipeline-disk-flush-race.md
+++ b/docs/bugs/BUG-1162-torrent-pipeline-disk-flush-race.md
@@ -1,4 +1,4 @@
-## BUG-1147 · hibiki_torrent 端到端测试在字节落盘前就比对，CI Windows 约 24% 概率红
+## BUG-1162 · hibiki_torrent 端到端测试在字节落盘前就比对，CI Windows 约 24% 概率红
 - **报告**：2026-07-27（用户：CI 巡检）
 - **真实性**：✅ 真 bug（测试自身的时序假设错，不是引擎功能坏）。根因
   `packages/hibiki_torrent/test/embedded_pipeline_test.dart:151`（修复前）——

--- a/hibiki/test/media/torrent/torrent_disk_flush_order_guard_test.dart
+++ b/hibiki/test/media/torrent/torrent_disk_flush_order_guard_test.dart
@@ -1,7 +1,7 @@
 // 守卫：`embedded_pipeline_test` 里「下载内容的逐字节比对」必须发生在
 // **leecher session 关闭之后**。
 //
-// 为什么需要它（BUG-1147）：`isFinished` / `progress==1.0` / `left==0` /
+// 为什么需要它（BUG-1162）：`isFinished` / `progress==1.0` / `left==0` /
 // `haveCount==numPieces` 说的都是「piece 已在内存里校验通过」，**不是**「字节
 // 已经躺在文件系统里」——写盘 job 还排在 libtorrent 的 disk io 线程上，且 2.x
 // 的 mmap 磁盘后端写进去的是映射视图，Windows 不保证映射视图与 ReadFile 之间

--- a/hibiki/test/media/torrent/torrent_disk_flush_order_guard_test.dart
+++ b/hibiki/test/media/torrent/torrent_disk_flush_order_guard_test.dart
@@ -1,0 +1,64 @@
+// 守卫：`embedded_pipeline_test` 里「下载内容的逐字节比对」必须发生在
+// **leecher session 关闭之后**。
+//
+// 为什么需要它（BUG-1147）：`isFinished` / `progress==1.0` / `left==0` /
+// `haveCount==numPieces` 说的都是「piece 已在内存里校验通过」，**不是**「字节
+// 已经躺在文件系统里」——写盘 job 还排在 libtorrent 的 disk io 线程上，且 2.x
+// 的 mmap 磁盘后端写进去的是映射视图，Windows 不保证映射视图与 ReadFile 之间
+// 的一致性；内容文件又是稀疏的，尚未落实的尾部区域会被读成 0。CI 的 Windows
+// job 因此约 24% 的跑次挂在那条比对上（失败偏移恒在距文件尾 ~114KB）。
+//
+// 唯一确定性的落盘完成信号是销毁 session：`lt::session` 析构会等 disk io 线程
+// 把写盘 job 做完、解除映射并关句柄。这条守卫钉住这个顺序，并禁止有人把它
+// 「改回去」或者用 sleep / 重试来等落盘。
+//
+// 纯文本扫描：不需要 DLL、不需要 native 工具链，因此能跟着主 app 测试套件在任何
+// 平台的 CI 上跑 —— `packages/hibiki_torrent` 自己的测试在无 DLL 的平台整组 skip。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // 测试的工作目录是 `hibiki/`，packages 在它的上一级。
+  final File pipelineTest =
+      File('../packages/hibiki_torrent/test/embedded_pipeline_test.dart');
+
+  test('下载内容的逐字节比对必须排在 leecher.close() 之后', () {
+    expect(pipelineTest.existsSync(), isTrue,
+        reason: '找不到 ${pipelineTest.path} —— 守卫失去意义，先修路径');
+    final String source = pipelineTest.readAsStringSync();
+
+    const String compareMarker =
+        "reason: 'downloaded bytes must equal seeded bytes'";
+    final int compareAt = source.indexOf(compareMarker);
+    expect(compareAt, greaterThanOrEqualTo(0),
+        reason: '逐字节比对断言不见了。它是「引擎报完成 = 磁盘上真有这些字节」'
+            '的唯一证明，不能删；要改先想清楚拿什么替代。');
+
+    final int closeAt = source.indexOf('leecher.close();');
+    expect(closeAt, greaterThanOrEqualTo(0),
+        reason: '找不到 leecher.close() —— 比对前必须先销毁 session 让 '
+            'libtorrent 把写盘 job 落完，否则 Windows 上会读到未落盘的 0。');
+
+    final int readAt = source.indexOf('readAsBytesSync()');
+    expect(readAt, greaterThan(closeAt),
+        reason: '读盘比对排在了 leecher.close() 之前。isFinished / progress==1.0 '
+            '/ left==0 / haveCount==numPieces 都只反映内存里的 piece 状态，'
+            '写盘 job 可能还在 disk io 线程上排队 —— 这正是 CI Windows job '
+            '约 24% 概率挂在字节比对上的原因。');
+
+    // 关掉 session 到比对之间不许塞任何「等它落盘」的延时/重试。
+    final String between = source.substring(closeAt, compareAt);
+    for (final String banned in const <String>[
+      'Future<void>.delayed',
+      'Future.delayed',
+      'sleep(',
+      '_pollUntil',
+    ]) {
+      expect(between.contains(banned), isFalse,
+          reason: '关闭 session 与字节比对之间出现了 `$banned`。落盘竞态只能用'
+              '确定性的完成信号（销毁 session）消除，延时/重试只是把概率压小。');
+    }
+  });
+}

--- a/packages/hibiki_torrent/test/embedded_pipeline_test.dart
+++ b/packages/hibiki_torrent/test/embedded_pipeline_test.dart
@@ -148,13 +148,7 @@ void main() {
           .listTorrents()
           .firstWhere((HtTorrentStatus t) => t.id == rig.infoHash);
       expect(snap.contentPath, isNotEmpty);
-      final File downloaded = File(snap.contentPath);
-      expect(downloaded.existsSync(), isTrue,
-          reason: 'content_path should point at the downloaded file');
-      final Uint8List got = downloaded.readAsBytesSync();
-      final Uint8List want = LocalSeedRig.deterministicBytes(8 * 1024 * 1024);
-      expect(got.length, want.length);
-      expect(got, want, reason: 'downloaded bytes must equal seeded bytes');
+      final String contentPath = snap.contentPath;
 
       // ── 顺序性：完成事件序应基本递增 ──────────────────────────────
       // 首尾提优/截止期会把个别 piece 拉到前面；剔除每文件首尾 piece 后，
@@ -176,10 +170,47 @@ void main() {
               'order (got ratio $ratio, order sample: '
               '${pieceOrder.take(16).toList()})');
 
+      // ── 落盘校验：比对前必须先关掉 session ────────────────────────
+      // isFinished / progress==1.0 / left==0 / haveCount==numPieces 说的都是
+      // 「piece 已在内存里校验通过」，**不是**「字节已经躺在文件系统里」：
+      // 写盘 job 还排在 libtorrent 的 disk io 线程上，且 2.x 的 mmap 磁盘后端
+      // 写进去的是映射视图 —— Windows 明确不保证映射视图与 ReadFile
+      // 之间的一致性，而内容文件又是稀疏的，于是尚未落实的尾部区域会被读成 0。
+      // CI 上约 24% 的跑次就挂在下面这条比对上（失败偏移恒在距文件尾
+      // ~114KB 处，读出一串 0）。
+      //
+      // 唯一确定性的落盘完成信号是**销毁 session**：lt::session 析构会走完
+      // 关停流程，等 disk io 线程把所有写盘 job 做完、解除映射并关句柄，之
+      // 后普通文件读才看得到全部字节。不得用 sleep / 重试去「等它落盘」
+      // —— 那只是把概率压小，并没消除竞态。
+      leecher.close();
+
+      final File downloaded = File(contentPath);
+      expect(downloaded.existsSync(), isTrue,
+          reason: 'content_path should point at the downloaded file');
+      final Uint8List got = downloaded.readAsBytesSync();
+      final Uint8List want = LocalSeedRig.deterministicBytes(8 * 1024 * 1024);
+      expect(got.length, want.length);
+      expect(got, want, reason: 'downloaded bytes must equal seeded bytes');
+
       // ── 移除（连数据） ────────────────────────────────────────────
-      expect(leecher.removeTorrent(rig.infoHash, deleteFiles: true), isTrue);
+      // 上面的比对已经把下载 session 关了，数据完整躺在 dlDir 里：直接用
+      // rig 的 .torrent 把同一个种子加回一个不联网的新 session（listenInterfaces
+      // 为空 = 零 peer，也不需要再换元数据），再验「连数据删除」。删除路径的
+      // 覆盖面一点没少，又不会反过来把待比对的文件删掉。
+      final EmbeddedTorrentSession? remover =
+          EmbeddedTorrentSession.open(engine, listenInterfaces: '');
+      expect(remover, isNotNull);
+      addTearDown(remover!.close);
+
+      final HtAddResult readded =
+          remover.addTorrentFile(rig.torrentPath, savePath: dlDir.path);
+      expect(readded.ok, isTrue, reason: 'addTorrentFile: ${readded.error}');
+      expect(readded.id, rig.infoHash);
+
+      expect(remover.removeTorrent(rig.infoHash, deleteFiles: true), isTrue);
       await _pollUntil(
-        () => leecher.listTorrents().isEmpty,
+        () => remover.listTorrents().isEmpty,
         timeout: const Duration(seconds: 10),
         what: 'torrent removal',
       );


### PR DESCRIPTION
## 问题

workflow `Build and Test Android / macOS / Linux / Windows` 的 **windows** job，步骤
`Run hibiki_torrent FFI tests against the freshly built DLL` 近 17 次 develop 运行挂 4 次（约 24%），
恒定挂在同一条断言：

```
downloaded bytes must equal seeded bytes
Which: at location [8273920] is <0> instead of <38>
```

8MiB 文件距尾约 114KB 处读出一串 0。DLL 构建/加载正常（15 个用例跑满）。

## 根因（BUG-1147）

`embedded_pipeline_test.dart` 等到 `isFinished` / `progress>=1.0` / `left==0` /
`haveCount==numPieces` 就直接 `readAsBytesSync()` 比对。这四个信号说的都是
「piece 已在内存里校验通过」，**不是**「字节已经躺在文件系统里」——写盘 job 还排在
libtorrent 的 disk io 线程上，2.x 的 mmap 磁盘后端写进去的是映射视图，Windows 不保证
它与 `ReadFile` 一致；内容文件又是稀疏的，尚未落实的尾部区域直接读成 0。

## 修法

把读盘比对挪到 `leecher.close()` **之后**：销毁 `lt::session` 会走完关停流程，等 disk io
线程把写盘 job 做完、解除映射并关句柄 —— 这是唯一确定性的落盘完成信号。
**没有加任何 sleep / 重试 / 超时放宽**，也没动 C ABI（不触发 FFI 绑定对齐守卫）。

原本排在比对之后的「移除（连数据）」用例改为：用 rig 的 `.torrent` 把同一个种子加进一个
不联网的新 session（`listenInterfaces: ''`，零 peer，无需再换元数据）再删。删除路径的
覆盖面一点没少，又不会反过来把待比对的文件删掉。

## 防回归

新增 `hibiki/test/media/torrent/torrent_disk_flush_order_guard_test.dart`：纯文本守卫，钉住
「`readAsBytesSync` 必须排在 `leecher.close()` 之后」「逐字节比对断言不许被删」「close 与
比对之间不许出现 `Future.delayed` / `sleep` / `_pollUntil` 这类『等它落盘』的补丁」。
放在主 app 测试套件里，因为 `packages/hibiki_torrent` 自己的测试在没有 DLL 的平台整组 skip。
已做负向验证：把测试恢复成修复前的顺序，守卫确实变红。

## 验证

- `packages/hibiki_torrent` 整包套件连跑 **10 次**：目标用例（`magnet → … completion`）
  **10/10 通过**，字节比对零失败。第 4 次整体红是**另一条既有 flaky**
  （BUG-1114，`ip_filter` 用例的 `maxSeenDownload` 观察窗口塌陷，根因是 libtorrent 的
  local peer class 不受全局限速约束），与本改动无关。
- 诚实说明：本机（NVMe、负载轻）**复现不出**这个落盘竞态 —— 专门写的探针在关闭 session
  之前读盘，8MiB × 8 次、128MiB × 3 次全部字节一致。所以「本地 10 次全绿」不能证明根除；
  真正的依据是读盘被挪到了确定性的落盘屏障之后。
- `flutter analyze`（含 test）：No issues found。
- 全量 `flutter test --no-pub`：见下方评论补充。

## 顺带

`docs/bugs/BUG-1114` 里「CI 不受影响（无 DLL → 整组 skip）」这句已过期：windows job 现在
自己编 DLL 并真跑这些测试，那条 flaky 从此也能把 CI 判红。本 PR 只更正该说明，不修它。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
