### PR TITLE
feat(tracking): 媒体记录接入 Bangumi 游戏收藏 + 注册入口

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45492 (2676 per locale)
+/// Strings: 45543 (2679 per locale)
 ///
-/// Built on 2026-07-27 at 18:12 UTC
+/// Built on 2026-07-27 at 18:27 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3583,6 +3583,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  String get media_tracking_status => 'Collection status';
+  String get media_tracking_signup => 'Create a Bangumi account';
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -9690,6 +9693,12 @@ class _StringsAr extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -15865,6 +15874,12 @@ class _StringsDe extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -22056,6 +22071,12 @@ class _StringsEs extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -28258,6 +28279,12 @@ class _StringsFr extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -34389,6 +34416,12 @@ class _StringsId extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -40566,6 +40599,12 @@ class _StringsIt extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -46560,6 +46599,12 @@ class _StringsJa extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -52556,6 +52601,12 @@ class _StringsKo extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -58713,6 +58764,12 @@ class _StringsNl extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -64883,6 +64940,12 @@ class _StringsPtBr extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -71037,6 +71100,12 @@ class _StringsRu extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -77139,6 +77208,12 @@ class _StringsTh extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -83273,6 +83348,12 @@ class _StringsTr extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -89392,6 +89473,12 @@ class _StringsVi extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 // Path: <root>
@@ -95086,6 +95173,12 @@ class _StringsZhCn extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU 加速不可用，OCR 改用 ${engine} 运行：${reason}';
+  @override
+  String get media_tracking_status => '收藏状态';
+  @override
+  String get media_tracking_signup => '注册 Bangumi 账号';
+  @override
+  String get media_tracking_game => '游戏';
 }
 
 // Path: <root>
@@ -101001,6 +101094,12 @@ class _StringsZhHk extends _StringsEn {
   String manga_ocr_acceleration_degraded(
           {required Object engine, required Object reason}) =>
       'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+  @override
+  String get media_tracking_status => 'Collection status';
+  @override
+  String get media_tracking_signup => 'Create a Bangumi account';
+  @override
+  String get media_tracking_game => 'Game';
 }
 
 /// Flat map(s) containing all translations.
@@ -106482,6 +106581,12 @@ extension on _StringsEn {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -111961,6 +112066,12 @@ extension on _StringsAr {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -117461,6 +117572,12 @@ extension on _StringsDe {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -122960,6 +123077,12 @@ extension on _StringsEs {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -128465,6 +128588,12 @@ extension on _StringsFr {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -133952,6 +134081,12 @@ extension on _StringsId {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -139454,6 +139589,12 @@ extension on _StringsIt {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -144918,6 +145059,12 @@ extension on _StringsJa {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -150386,6 +150533,12 @@ extension on _StringsKo {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -155881,6 +156034,12 @@ extension on _StringsNl {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -161373,6 +161532,12 @@ extension on _StringsPtBr {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -166870,6 +167035,12 @@ extension on _StringsRu {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -172351,6 +172522,12 @@ extension on _StringsTh {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -177841,6 +178018,12 @@ extension on _StringsTr {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -183326,6 +183509,12 @@ extension on _StringsVi {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }
@@ -188765,6 +188954,12 @@ extension on _StringsZhCn {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU 加速不可用，OCR 改用 ${engine} 运行：${reason}';
+      case 'media_tracking_status':
+        return '收藏状态';
+      case 'media_tracking_signup':
+        return '注册 Bangumi 账号';
+      case 'media_tracking_game':
+        return '游戏';
       default:
         return null;
     }
@@ -194224,6 +194419,12 @@ extension on _StringsZhHk {
       case 'manga_ocr_acceleration_degraded':
         return ({required Object engine, required Object reason}) =>
             'GPU acceleration unavailable, running OCR on ${engine}: ${reason}';
+      case 'media_tracking_status':
+        return 'Collection status';
+      case 'media_tracking_signup':
+        return 'Create a Bangumi account';
+      case 'media_tracking_game':
+        return 'Game';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "从库中移除此游戏？不会删除磁盘上的游戏文件。",
   "delete_collection_also_games": "同时把其中的游戏移出库（不会删除磁盘上的游戏文件）",
   "manga_ocr_acceleration_status": "OCR 加速：${engine}",
-  "manga_ocr_acceleration_degraded": "GPU 加速不可用，OCR 改用 ${engine} 运行：${reason}"
+  "manga_ocr_acceleration_degraded": "GPU 加速不可用，OCR 改用 ${engine} 运行：${reason}",
+  "media_tracking_status": "收藏状态",
+  "media_tracking_signup": "注册 Bangumi 账号",
+  "media_tracking_game": "游戏"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2674,5 +2674,8 @@
   "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
   "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)",
   "manga_ocr_acceleration_status": "OCR acceleration: ${engine}",
-  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}"
+  "manga_ocr_acceleration_degraded": "GPU acceleration unavailable, running OCR on ${engine}: ${reason}",
+  "media_tracking_status": "Collection status",
+  "media_tracking_signup": "Create a Bangumi account",
+  "media_tracking_game": "Game"
 }

--- a/hibiki/lib/src/media/tracking/bangumi_api_client.dart
+++ b/hibiki/lib/src/media/tracking/bangumi_api_client.dart
@@ -92,12 +92,16 @@ int _int(dynamic value, [int fallback = 0]) {
 
 String _string(dynamic value) => value is String ? value : '';
 
+/// 本层支持的 Bangumi 条目类型：1 书籍（含漫画/轻小说）/ 2 动画 / 4 游戏。
+/// 音乐(3)与三次元(6)没有对应的本地媒体，解析阶段丢弃。
+const Set<int> kSupportedBangumiSubjectTypes = <int>{1, 2, 4};
+
 BangumiSubject? _parseBangumiSubjectValue(dynamic item) {
   final Map<String, dynamic>? value = _map(item);
   if (value == null) return null;
   final int id = _int(value['id']);
   final int type = _int(value['type']);
-  if (id <= 0 || (type != 1 && type != 2)) return null;
+  if (id <= 0 || !kSupportedBangumiSubjectTypes.contains(type)) return null;
   final Map<String, dynamic>? images = _map(value['images']);
   return BangumiSubject(
     id: id,
@@ -223,6 +227,10 @@ class BangumiApiClient implements BangumiTrackingApi {
 
   static const String apiBase = 'https://api.bgm.tv';
   static const String accessTokenUrl = 'https://next.bgm.tv/demo/access-token';
+
+  /// 注册入口。[accessTokenUrl] 需要先登录才能生成令牌，没有账号的用户在那里会被
+  /// 挡在登录页，因此另给一个注册入口，两者并存而不是互相替代。
+  static const String signupUrl = 'https://bgm.tv/signup';
 
   final String _accessToken;
   final String _userAgent;

--- a/hibiki/lib/src/media/tracking/media_tracking_repository.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_repository.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:math' as math;
 
 import 'package:drift/drift.dart';
+import 'package:hibiki/src/mining/metadata/galgame_metadata_source.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
 const String kTrackingProviderBangumi = 'bangumi';
@@ -10,7 +11,8 @@ enum TrackingMediaType {
   book('book'),
   bookChapter('book_chapter'),
   video('video'),
-  videoCollection('video_collection');
+  videoCollection('video_collection'),
+  game('game');
 
   const TrackingMediaType(this.value);
   final String value;
@@ -19,7 +21,8 @@ enum TrackingMediaType {
 enum TrackingKind {
   anime('anime'),
   novel('novel'),
-  manga('manga');
+  manga('manga'),
+  game('game');
 
   const TrackingKind(this.value);
   final String value;
@@ -28,7 +31,15 @@ enum TrackingKind {
 enum TrackingProgressMode {
   episode('episode'),
   chapter('chapter'),
-  volume('volume');
+  volume('volume'),
+
+  /// 只同步收藏状态，没有话数/卷数进度。
+  ///
+  /// Bangumi 游戏条目 `eps`/`volumes` 恒为 0，唯一可写的是收藏 `type`。此模式下
+  /// [MediaTrackingOutboxRow.progress] 存的**不是进度而是 Bangumi 收藏 type**
+  /// （1 想玩 / 2 玩过 / 3 在玩 / 4 搁置 / 5 弃坑），由本字段唯一确定其解释方式，
+  /// 与 episode/chapter/volume 决定 progress 落 `ep_status` 还是 `vol_status` 同构。
+  status('status');
 
   const TrackingProgressMode(this.value);
   final String value;
@@ -45,6 +56,19 @@ typedef AutoVideoTrackingSource = ({
 typedef AutoBookTrackingSource = ({
   String title,
   String format,
+});
+
+typedef AutoGameTrackingSource = ({
+  String name,
+  int? bangumiSubjectId,
+});
+
+typedef PersistedGameTrackingStatus = ({
+  String gameId,
+  String name,
+  int? bangumiSubjectId,
+  int status,
+  int evidenceAt,
 });
 
 typedef CompletedVideoTrackingProgress = ({
@@ -335,6 +359,74 @@ class MediaTrackingRepository {
     return (title: book.title, format: book.format);
   }
 
+  /// 游戏刮削源里的 Bangumi 条目 id。
+  ///
+  /// `galgame_sources.source` 用的是刮削源 key（`bgm`），与本层的 provider 名
+  /// （`bangumi`）不是同一个值域，不能互相套用。VNDB 的 `externalId` 形如 `v12345`，
+  /// 不是 Bangumi subject id，必须按 source 过滤后再解析。
+  int? _bangumiSubjectIdOf(List<GalgameSourceRow> sources) {
+    for (final GalgameSourceRow row in sources) {
+      if (row.source != GalgameMetadataSource.bgm.key) continue;
+      final int? id = int.tryParse((row.externalId ?? '').trim());
+      if (id != null && id > 0) return id;
+    }
+    return null;
+  }
+
+  Future<AutoGameTrackingSource?> loadAutoGameSource(String gameId) async {
+    final GalgameRow? game = await _db.getGalgame(gameId);
+    if (game == null) return null;
+    return (
+      name: game.name,
+      bangumiSubjectId:
+          _bangumiSubjectIdOf(await _db.getGalgameSources(gameId)),
+    );
+  }
+
+  /// 返回自 [afterMs] 之后需要重新对齐的游戏收藏状态。
+  ///
+  /// 游戏状态是用户显式设置的离散值，正常路径在设置当下即时入队；本方法只兜两种
+  /// 「事件已经发生过但当时发不出去」的情况：换账号后水位归零的全量重建，以及先设
+  /// 状态、之后才刮到 Bangumi 条目或才建立映射。`galgames` 表没有「最后修改时刻」列，
+  /// 因此 evidence 取 `max(mapping.updatedAt, addedAt)`——足以覆盖新增游戏与新建/
+  /// 改动映射，状态本身的变更由即时入队负责，不依赖这里。
+  Future<List<PersistedGameTrackingStatus>> loadPersistedGameTrackingStatus({
+    required int afterMs,
+  }) async {
+    final List<GalgameRow> games = await _db.getAllGalgames();
+    if (games.isEmpty) return const <PersistedGameTrackingStatus>[];
+    final Map<String, List<GalgameSourceRow>> sources =
+        await _db.getAllGalgameSources();
+    final Map<String, MediaTrackingMappingRow> mappings =
+        <String, MediaTrackingMappingRow>{};
+    for (final MediaTrackingMappingRow mapping in await listMappings()) {
+      if (mapping.provider != kTrackingProviderBangumi) continue;
+      if (mapping.mediaType != TrackingMediaType.game.value) continue;
+      mappings[mapping.mediaKey] = mapping;
+    }
+
+    final List<PersistedGameTrackingStatus> result =
+        <PersistedGameTrackingStatus>[];
+    for (final GalgameRow game in games) {
+      // 0 = 未设置：用户从没表态过，不能凭空往远端写一个收藏状态。
+      if (game.playStatus <= 0) continue;
+      final int evidenceAt = math.max(
+        mappings[game.id]?.updatedAt ?? 0,
+        game.addedAt,
+      );
+      if (evidenceAt <= afterMs) continue;
+      result.add((
+        gameId: game.id,
+        name: game.name,
+        bangumiSubjectId:
+            _bangumiSubjectIdOf(sources[game.id] ?? const <GalgameSourceRow>[]),
+        status: game.playStatus,
+        evidenceAt: evidenceAt,
+      ));
+    }
+    return result;
+  }
+
   Future<int> loadBookChapterProgress({
     required String bookKey,
     required int fallbackProgress,
@@ -519,11 +611,17 @@ class MediaTrackingRepository {
 
   /// 将本地 0-based [localProgress] 翻译为远端进度并入队。没有映射返回 false；
   /// 调用方据此无声跳过，播放/阅读主路径不受外部服务影响。
+  ///
+  /// [monotonic] 为 true（默认）时沿用“进度只增不减”的合并：观看/阅读进度天然单调，
+  /// 取 max 可以让乱序到达的事件收敛到最新位置。收藏状态类事件必须传 false——它是
+  /// 离散状态而非进度，取 max 会让「弃坑(5) → 在玩(3)」这种正当回退被永久吃掉，
+  /// 用户再也改不回来。此时按最后写入者胜（LWW）覆盖。
   Future<bool> enqueueProgress({
     required TrackingMediaType mediaType,
     required String mediaKey,
     required int localProgress,
     required bool completed,
+    bool monotonic = true,
   }) async {
     final MediaTrackingMappingRow? mapping = await findMapping(
       mediaType: mediaType,
@@ -548,8 +646,10 @@ class MediaTrackingRepository {
             );
         return;
       }
-      final int mergedProgress = math.max(existing.progress, progress);
-      final bool mergedCompleted = existing.completed || completed;
+      final int mergedProgress =
+          monotonic ? math.max(existing.progress, progress) : progress;
+      final bool mergedCompleted =
+          monotonic ? (existing.completed || completed) : completed;
       // 毫秒时钟可能在同一 tick 连收两次事件；乐观锁版本必须严格递增，不能只写 now。
       final int eventVersion = math.max(now, existing.updatedAt + 1);
       await (_db.update(_db.mediaTrackingOutbox)

--- a/hibiki/lib/src/media/tracking/media_tracking_service.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_service.dart
@@ -14,6 +14,8 @@ const String kVideoTrackingReconcileWatermarkPref =
     'media_tracking_video_reconcile_watermark_v1';
 const String kBookTrackingReconcileWatermarkPref =
     'media_tracking_book_reconcile_watermark_v1';
+const String kGameTrackingReconcileWatermarkPref =
+    'media_tracking_game_reconcile_watermark_v1';
 
 typedef BangumiApiFactory = BangumiTrackingApi Function(String accessToken);
 
@@ -61,6 +63,13 @@ _PreparedTrackingTitle _prepareTrackingTitle(String rawTitle) {
   );
 }
 
+/// Bangumi 条目类型：1 书籍（含漫画/轻小说）/ 2 动画 / 4 游戏。
+int bangumiSubjectTypeOf(TrackingKind kind) => switch (kind) {
+      TrackingKind.anime => 2,
+      TrackingKind.game => 4,
+      TrackingKind.novel || TrackingKind.manga => 1,
+    };
+
 BangumiSubject? _uniqueHighConfidenceSubject(
   String query,
   List<BangumiSubject> subjects,
@@ -68,7 +77,8 @@ BangumiSubject? _uniqueHighConfidenceSubject(
 ) {
   if (query.trim().isEmpty || subjects.isEmpty) return null;
   final List<BangumiSubject> kindMatches = subjects.where((subject) {
-    if (kind == TrackingKind.anime) return true;
+    // 动画与游戏在搜索阶段已按 subject type 精确过滤，无需再按 platform 二次筛。
+    if (kind == TrackingKind.anime || kind == TrackingKind.game) return true;
     final String platform = subject.platform.toLowerCase();
     if (kind == TrackingKind.manga) {
       return platform.contains('漫画') ||
@@ -159,6 +169,7 @@ class MediaTrackingService {
       // 新账号必须从全部本地已完成事实重新对齐，不能继承旧账号的校正水位。
       await _preferences.setPref(kVideoTrackingReconcileWatermarkPref, 0);
       await _preferences.setPref(kBookTrackingReconcileWatermarkPref, 0);
+      await _preferences.setPref(kGameTrackingReconcileWatermarkPref, 0);
     }
   }
 
@@ -179,7 +190,7 @@ class MediaTrackingService {
     try {
       return await api.searchSubjects(
         keyword: keyword,
-        subjectType: kind == TrackingKind.anime ? 2 : 1,
+        subjectType: bangumiSubjectTypeOf(kind),
       );
     } finally {
       api.close();
@@ -280,6 +291,82 @@ class MediaTrackingService {
       localProgress: logicalChapterProgress,
       // 章节伴随映射只负责 ep_status；整部作品是否读完由主卷映射判断。
       completed: false,
+    );
+  }
+
+  /// 上报游戏收藏状态。[status] 直接是 Bangumi 收藏 type（1 想玩 / 2 玩过 /
+  /// 3 在玩 / 4 搁置 / 5 弃坑），`galgames.playStatus` 的值域与之刻意对齐，无需换算。
+  ///
+  /// 状态 0（未设置）不上报：用户从没表态过，不能凭空在远端建一条收藏。
+  Future<void> recordGameStatus({
+    required String gameId,
+    required int status,
+  }) async {
+    if (status < 1 || status > 5) return;
+    final MediaTrackingMappingRow? mapping =
+        await _ensureAutoGameMapping(gameId);
+    if (mapping == null) return;
+    await _enqueueAndSync(
+      mediaType: TrackingMediaType.game,
+      mediaKey: gameId,
+      localProgress: status,
+      completed: status == 2,
+      monotonic: false,
+    );
+  }
+
+  Future<MediaTrackingMappingRow?> _ensureAutoGameMapping(
+    String gameId,
+  ) async {
+    final MediaTrackingMappingRow? existing = await _repository.findMapping(
+      mediaType: TrackingMediaType.game,
+      mediaKey: gameId,
+    );
+    if (existing != null) return existing;
+    return _singleFlightAutoMapping(
+      '${TrackingMediaType.game.value}:$gameId',
+      () async {
+        final AutoGameTrackingSource? source =
+            await _repository.loadAutoGameSource(gameId);
+        if (source == null) return null;
+        final int? scrapedId = source.bangumiSubjectId;
+        if (scrapedId != null && scrapedId > 0) {
+          return _repository.saveMappingIfAbsent(
+            mediaType: TrackingMediaType.game,
+            mediaKey: gameId,
+            mediaTitle: source.name,
+            kind: TrackingKind.game,
+            subjectId: scrapedId,
+            subjectName: source.name,
+            progressMode: TrackingProgressMode.status,
+            progressOffset: 0,
+          );
+        }
+        if (!isConfigured) return null;
+        // 未刮削时只能按名字兜底。游戏的本地名默认取自 exe 文件名，噪声大，
+        // 因此沿用与视频/书籍相同的高置信度门槛：匹配不唯一就不建映射，
+        // 宁可不同步也不把进度写到别人的条目上；用户可在设置页手工指定。
+        final List<BangumiSubject> subjects = await searchSubjects(
+          keyword: source.name,
+          kind: TrackingKind.game,
+        );
+        final BangumiSubject? subject = _uniqueHighConfidenceSubject(
+          source.name,
+          subjects,
+          TrackingKind.game,
+        );
+        if (subject == null) return null;
+        return _repository.saveMappingIfAbsent(
+          mediaType: TrackingMediaType.game,
+          mediaKey: gameId,
+          mediaTitle: source.name,
+          kind: TrackingKind.game,
+          subjectId: subject.id,
+          subjectName: subject.displayName,
+          progressMode: TrackingProgressMode.status,
+          progressOffset: 0,
+        );
+      },
     );
   }
 
@@ -477,25 +564,33 @@ class MediaTrackingService {
     required String mediaKey,
     required int localProgress,
     required bool completed,
+    bool monotonic = true,
   }) async {
     final String cacheKey = '${mediaType.value}:$mediaKey';
     final ({int progress, bool completed})? previous = _lastQueued[cacheKey];
-    if (previous != null &&
-        previous.progress >= localProgress &&
-        (previous.completed || !completed)) {
-      return;
-    }
+    // 单调事件按“没有前进就不必重复入队”去重；离散状态只在值真的没变时才跳过，
+    // 否则状态回退（弃坑→在玩）会被这层内存缓存吃掉，连 outbox 都进不去。
+    final bool unchanged = previous != null &&
+        (monotonic
+            ? (previous.progress >= localProgress &&
+                (previous.completed || !completed))
+            : (previous.progress == localProgress &&
+                previous.completed == completed));
+    if (unchanged) return;
     try {
       final bool mapped = await _repository.enqueueProgress(
         mediaType: mediaType,
         mediaKey: mediaKey,
         localProgress: localProgress,
         completed: completed,
+        monotonic: monotonic,
       );
       if (!mapped) return;
       _lastQueued[cacheKey] = (
         progress: localProgress,
-        completed: completed || (previous?.completed ?? false),
+        completed: monotonic
+            ? (completed || (previous?.completed ?? false))
+            : completed,
       );
       if (_syncInFlight == null) {
         unawaited(syncNow());
@@ -538,7 +633,40 @@ class MediaTrackingService {
   }) async {
     await _reconcileCompletedVideoProgress();
     await _reconcilePersistedBookProgress();
+    await _reconcileGameStatus();
     return _sync(force: force);
+  }
+
+  /// 补发本地已设置但尚未成功上报的游戏收藏状态。
+  ///
+  /// 正常路径在用户改状态的当下即时入队；这里只兜「当时发不出去」的两类：换账号后
+  /// 水位归零的全量重建，以及先设了状态、之后才刮到 Bangumi 条目/才建映射。
+  Future<void> _reconcileGameStatus() async {
+    if (!isConfigured) return;
+    final Object? stored = _preferences.getPref(
+      kGameTrackingReconcileWatermarkPref,
+      defaultValue: 0,
+    );
+    final int watermark = stored is int ? stored : int.tryParse('$stored') ?? 0;
+    final List<PersistedGameTrackingStatus> statuses =
+        await _repository.loadPersistedGameTrackingStatus(afterMs: watermark);
+
+    int nextWatermark = watermark;
+    for (final PersistedGameTrackingStatus item in statuses) {
+      // 走完整入队路径：没有映射时它会尝试用刮削出的 Bangumi 条目补建。
+      await recordGameStatus(gameId: item.gameId, status: item.status);
+      nextWatermark =
+          item.evidenceAt > nextWatermark ? item.evidenceAt : nextWatermark;
+    }
+    if (statuses.isEmpty) {
+      nextWatermark = DateTime.now().millisecondsSinceEpoch;
+    }
+    if (nextWatermark != watermark) {
+      await _preferences.setPref(
+        kGameTrackingReconcileWatermarkPref,
+        nextWatermark,
+      );
+    }
   }
 
   Future<void> _reconcileCompletedVideoProgress() async {
@@ -682,11 +810,47 @@ class MediaTrackingService {
     final MediaTrackingMappingRow mapping = update.mapping;
     final BangumiUserCollection? collection =
         await api.getCollection(user.username, mapping.subjectId);
+    if (mapping.progressMode == TrackingProgressMode.status.value) {
+      await _syncCollectionStatus(api, mapping, update.outbox, collection);
+      return;
+    }
     if (mapping.progressMode == TrackingProgressMode.episode.value) {
       await _syncEpisodeProgress(api, mapping, update.outbox, collection);
       return;
     }
     await _syncBookProgress(api, mapping, update.outbox, collection);
+  }
+
+  /// 只写收藏状态（游戏条目没有话数/卷数可报）。
+  ///
+  /// 与观看/阅读进度不同，这里**不套用「已完成不降级」规则**：状态是用户在库页显式
+  /// 选定的意图，从「玩过」改回「在玩」或标记「弃坑」都必须如实同步，否则用户会发现
+  /// 状态改不回来。单调保护只适用于自动推断出来的进度，不适用于人工选择的状态。
+  Future<void> _syncCollectionStatus(
+    BangumiTrackingApi api,
+    MediaTrackingMappingRow mapping,
+    MediaTrackingOutboxRow outbox,
+    BangumiUserCollection? collection,
+  ) async {
+    final int targetType = outbox.progress;
+    if (targetType < 1 || targetType > 5) {
+      throw StateError(
+        'Invalid Bangumi collection type $targetType '
+        'for subject ${mapping.subjectId}',
+      );
+    }
+    if (collection == null) {
+      await api.createCollection(
+        mapping.subjectId,
+        payload: <String, dynamic>{'type': targetType},
+      );
+      return;
+    }
+    if (collection.type == targetType) return;
+    await api.patchCollection(
+      mapping.subjectId,
+      payload: <String, dynamic>{'type': targetType},
+    );
   }
 
   Future<void> _syncEpisodeProgress(

--- a/hibiki/lib/src/media/tracking/media_tracking_settings_body.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_settings_body.dart
@@ -155,6 +155,17 @@ class _MediaTrackingSettingsBodyState extends State<MediaTrackingSettingsBody> {
                 ),
               ),
             ),
+            AdaptiveSettingsRow(
+              title: t.media_tracking_signup,
+              trailing: TextButton.icon(
+                onPressed: () => launchUrl(
+                  Uri.parse(BangumiApiClient.signupUrl),
+                  mode: LaunchMode.externalApplication,
+                ),
+                icon: const Icon(Icons.person_add_alt),
+                label: Text(t.media_tracking_signup),
+              ),
+            ),
             if (_connectedAccount != null)
               AdaptiveSettingsRow(
                 title: t.media_tracking_connected_as,
@@ -243,6 +254,8 @@ String _kindLabel(String value) {
       return t.media_tracking_anime;
     case 'manga':
       return t.media_tracking_manga;
+    case 'game':
+      return t.media_tracking_game;
     default:
       return t.media_tracking_novel;
   }
@@ -254,6 +267,8 @@ String _modeLabel(String value) {
       return t.media_tracking_episode;
     case 'volume':
       return t.media_tracking_volume;
+    case 'status':
+      return t.media_tracking_status;
     default:
       return t.media_tracking_chapter;
   }
@@ -271,6 +286,8 @@ class _LocalTrackingTarget {
   final String title;
 
   bool get isBook => type == TrackingMediaType.book;
+
+  bool get isGame => type == TrackingMediaType.game;
 }
 
 class _AddMappingDialog extends StatefulWidget {
@@ -317,6 +334,7 @@ class _AddMappingDialogState extends State<_AddMappingDialog> {
   Future<void> _loadTargets() async {
     final List<EpubBookRow> books = await widget.database.getAllEpubBooks();
     final List<VideoBookRow> videos = await widget.database.allVideoBooks();
+    final List<GalgameRow> games = await widget.database.getAllGalgames();
     final List<MediaCollectionRow> collections =
         await widget.database.getAllMediaCollections();
     final List<MediaCollectionItemRow> members =
@@ -346,6 +364,12 @@ class _AddMappingDialogState extends State<_AddMappingDialog> {
           key: book.bookKey,
           title: book.title,
         ),
+      for (final GalgameRow game in games)
+        _LocalTrackingTarget(
+          type: TrackingMediaType.game,
+          key: game.id,
+          title: game.name,
+        ),
     ];
     if (!mounted) return;
     setState(() {
@@ -358,10 +382,16 @@ class _AddMappingDialogState extends State<_AddMappingDialog> {
   void _selectTarget(_LocalTrackingTarget target) {
     setState(() {
       _target = target;
-      _kind = target.isBook ? TrackingKind.novel : TrackingKind.anime;
-      _mode = target.isBook
-          ? TrackingProgressMode.volume
-          : TrackingProgressMode.episode;
+      _kind = switch (target.type) {
+        TrackingMediaType.game => TrackingKind.game,
+        TrackingMediaType.book => TrackingKind.novel,
+        _ => TrackingKind.anime,
+      };
+      _mode = switch (target.type) {
+        TrackingMediaType.game => TrackingProgressMode.status,
+        TrackingMediaType.book => TrackingProgressMode.volume,
+        _ => TrackingProgressMode.episode,
+      };
       _offsetController.text = '1';
       _searchController.text = target.title;
       _results = const <BangumiSubject>[];
@@ -392,8 +422,12 @@ class _AddMappingDialogState extends State<_AddMappingDialog> {
   Future<void> _save(BangumiSubject subject) async {
     final _LocalTrackingTarget? target = _target;
     if (target == null) return;
-    final int offset = int.tryParse(_offsetController.text) ??
-        (_mode == TrackingProgressMode.chapter ? 0 : 1);
+    // status 模式下 outbox.progress 存的是收藏 type 本身，任何非零 offset 都会把
+    // 它算成另一个状态，必须钉死为 0。
+    final int offset = _mode == TrackingProgressMode.status
+        ? 0
+        : (int.tryParse(_offsetController.text) ??
+            (_mode == TrackingProgressMode.chapter ? 0 : 1));
     await widget.repository.saveMapping(
       mediaType: target.type,
       mediaKey: target.key,
@@ -440,7 +474,13 @@ class _AddMappingDialogState extends State<_AddMappingDialog> {
                 initialValue: _kind,
                 decoration: InputDecoration(labelText: t.media_tracking_kind),
                 items: <DropdownMenuItem<TrackingKind>>[
-                  if (!(_target?.isBook ?? false))
+                  if (_target?.isGame ?? false)
+                    DropdownMenuItem<TrackingKind>(
+                      value: TrackingKind.game,
+                      child: Text(t.media_tracking_game),
+                    ),
+                  if (!(_target?.isBook ?? false) &&
+                      !(_target?.isGame ?? false))
                     DropdownMenuItem<TrackingKind>(
                       value: TrackingKind.anime,
                       child: Text(t.media_tracking_anime),
@@ -468,7 +508,13 @@ class _AddMappingDialogState extends State<_AddMappingDialog> {
                   labelText: t.media_tracking_progress_mode,
                 ),
                 items: <DropdownMenuItem<TrackingProgressMode>>[
-                  if (!(_target?.isBook ?? false))
+                  if (_target?.isGame ?? false)
+                    DropdownMenuItem<TrackingProgressMode>(
+                      value: TrackingProgressMode.status,
+                      child: Text(t.media_tracking_status),
+                    ),
+                  if (!(_target?.isBook ?? false) &&
+                      !(_target?.isGame ?? false))
                     DropdownMenuItem<TrackingProgressMode>(
                       value: TrackingProgressMode.episode,
                       child: Text(t.media_tracking_episode),
@@ -490,18 +536,25 @@ class _AddMappingDialogState extends State<_AddMappingDialog> {
                   setState(() {
                     _mode = value;
                     _offsetController.text =
-                        value == TrackingProgressMode.chapter ? '0' : '1';
+                        value == TrackingProgressMode.chapter ||
+                                value == TrackingProgressMode.status
+                            ? '0'
+                            : '1';
                   });
                 },
               ),
-              const SizedBox(height: 12),
-              TextField(
-                controller: _offsetController,
-                keyboardType: TextInputType.number,
-                decoration: InputDecoration(
-                  labelText: t.media_tracking_progress_offset,
+              // 收藏状态模式没有进度可偏移（Bangumi 游戏条目无话数/卷数），
+              // 保留输入框只会让用户填出一个被忽略的值。
+              if (_mode != TrackingProgressMode.status) ...<Widget>[
+                const SizedBox(height: 12),
+                TextField(
+                  controller: _offsetController,
+                  keyboardType: TextInputType.number,
+                  decoration: InputDecoration(
+                    labelText: t.media_tracking_progress_offset,
+                  ),
                 ),
-              ),
+              ],
               const SizedBox(height: 12),
               TextField(
                 controller: _searchController,

--- a/hibiki/lib/src/mining/galgame_repository.dart
+++ b/hibiki/lib/src/mining/galgame_repository.dart
@@ -96,9 +96,15 @@ GalgamesCompanion galgamesCompanionFromEntry(GalgameEntry entry) {
 /// 整库规模是几百条，全量重载三个查询在 SQLite 上是毫秒级；换来「缓存与表恒一致」，
 /// 不用维护一套增量更新 + 校验兜底（就是契约 §1.4 拒绝统计投影表的同一个理由）。
 class GalgameRepository extends ChangeNotifier {
-  GalgameRepository(this._db);
+  GalgameRepository(this._db, {this.onPlayStatusChanged});
 
   final HibikiDatabase _db;
+
+  /// 游玩状态落库后的通知钩子（可选，测试与纯本地场景可不接）。
+  ///
+  /// 用回调而不是直接依赖媒体记录服务：游戏库不该知道有没有外部同步这回事，
+  /// 接线由 AppModel 统一负责。
+  final void Function(String id, GalgamePlayStatus status)? onPlayStatusChanged;
 
   List<GalgameEntry> _games = const <GalgameEntry>[];
 
@@ -194,9 +200,13 @@ class GalgameRepository extends ChangeNotifier {
   }
 
   /// 只改游玩状态。
+  ///
+  /// 落库后通知 [onPlayStatusChanged]（媒体记录据此上报 Bangumi 收藏状态）。回调
+  /// 失败不影响本地状态：外部服务不可用时本地照常改，后续同步会重试。
   Future<void> setPlayStatus(String id, GalgamePlayStatus status) async {
     await _db.setGalgamePlayStatus(id, status.value);
     await load();
+    onPlayStatusChanged?.call(id, status);
   }
 
   /// 只改用户覆盖层（全空 → 写 null 清空自定义）。

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4889,8 +4889,19 @@ class AppModel with ChangeNotifier {
   ///
   /// 懒建：绑的是 [database]，只有真正用到游戏库的路径才会碰它，冷启动不多跑查询。
   /// 库页/详情页直接用这个仓储做增删改与会话查询。
-  GalgameRepository get galgameRepo =>
-      _galgameRepo ??= GalgameRepository(database);
+  GalgameRepository get galgameRepo => _galgameRepo ??= GalgameRepository(
+        database,
+        // 游玩状态改动上报媒体记录（Bangumi 收藏 type）。fail-open：同步不可用时
+        // 本地状态照常生效，事件留在 outbox 由后续同步重试。
+        onPlayStatusChanged: (String id, GalgamePlayStatus status) {
+          unawaited(
+            mediaTrackingService.recordGameStatus(
+              gameId: id,
+              status: status.value,
+            ),
+          );
+        },
+      );
   GalgameRepository? _galgameRepo;
 
   /// 当前缓存的游戏库列表（同步读，供 widget 首帧渲染）。首次进页面为空表，

--- a/hibiki/test/media/tracking/bangumi_api_client_test.dart
+++ b/hibiki/test/media/tracking/bangumi_api_client_test.dart
@@ -78,6 +78,62 @@ void main() {
     expect(results.single.episodeCount, 28);
   });
 
+  test('游戏条目(type 4)不被解析器丢弃，音乐(3)/三次元(6)仍然丢弃', () async {
+    final BangumiApiClient client = BangumiApiClient(
+      accessToken: 'token',
+      userAgent: 'test-agent',
+      client: MockClient((http.Request request) async {
+        return http.Response.bytes(
+          utf8.encode(jsonEncode(<String, dynamic>{
+            'data': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'id': 13,
+                'type': 4,
+                'name': 'CLANNAD',
+                'name_cn': '团子大家族',
+                'platform': '游戏',
+                'eps': 0,
+                'volumes': 0,
+              },
+              <String, dynamic>{
+                'id': 99,
+                'type': 3,
+                'name': 'Some album',
+                'name_cn': '',
+                'platform': '音乐',
+                'eps': 0,
+                'volumes': 0,
+              },
+              <String, dynamic>{
+                'id': 98,
+                'type': 6,
+                'name': 'Some drama',
+                'name_cn': '',
+                'platform': '三次元',
+                'eps': 0,
+                'volumes': 0,
+              },
+            ],
+          })),
+          200,
+          headers: const <String, String>{
+            'content-type': 'application/json; charset=utf-8',
+          },
+        );
+      }),
+    );
+    addTearDown(client.close);
+
+    final List<BangumiSubject> results =
+        await client.searchSubjects(keyword: 'CLANNAD', subjectType: 4);
+
+    expect(results.map((BangumiSubject s) => s.id), <int>[13]);
+    expect(results.single.displayName, '团子大家族');
+    // 游戏条目没有话数/卷数，正是 status 模式存在的理由。
+    expect(results.single.episodeCount, 0);
+    expect(results.single.volumeCount, 0);
+  });
+
   test('getSubject reads official chapter and volume totals', () async {
     late http.Request captured;
     final BangumiApiClient client = BangumiApiClient(

--- a/hibiki/test/media/tracking/media_tracking_repository_test.dart
+++ b/hibiki/test/media/tracking/media_tracking_repository_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/tracking/media_tracking_repository.dart';
@@ -175,5 +176,175 @@ void main() {
 
     expect(await repository.pendingCount(), 1);
     expect((await repository.dueUpdates()).single.outbox.progress, 3);
+  });
+
+  group('游戏收藏状态', () {
+    Future<void> insertGame(
+      String id, {
+      required String name,
+      int playStatus = 0,
+      int addedAt = 1000,
+    }) =>
+        db.upsertGalgame(
+          GalgamesCompanion.insert(
+            id: id,
+            name: name,
+            exePath: 'C:\\games\\$id.exe',
+            workdir: 'C:\\games',
+            addedAt: addedAt,
+            playStatus: Value<int>(playStatus),
+          ),
+        );
+
+    Future<void> insertSource(
+      String gameId, {
+      required String source,
+      required String? externalId,
+    }) =>
+        db.upsertGalgameSource(
+          GalgameSourcesCompanion.insert(
+            gameId: gameId,
+            source: source,
+            externalId: Value<String?>(externalId),
+            dataJson: '{}',
+            fetchedAt: 1000,
+          ),
+        );
+
+    Future<int> gameMappingId(String gameId) => repository.saveMapping(
+          mediaType: TrackingMediaType.game,
+          mediaKey: gameId,
+          mediaTitle: 'Game',
+          kind: TrackingKind.game,
+          subjectId: 77,
+          subjectName: 'Remote game',
+          progressMode: TrackingProgressMode.status,
+          progressOffset: 0,
+        );
+
+    test('状态回退不被单调合并吃掉（弃坑 → 在玩）', () async {
+      await gameMappingId('g1');
+      await repository.enqueueProgress(
+        mediaType: TrackingMediaType.game,
+        mediaKey: 'g1',
+        localProgress: 5,
+        completed: false,
+        monotonic: false,
+      );
+      await repository.enqueueProgress(
+        mediaType: TrackingMediaType.game,
+        mediaKey: 'g1',
+        localProgress: 3,
+        completed: false,
+        monotonic: false,
+      );
+
+      expect(await repository.pendingCount(), 1);
+      expect((await repository.dueUpdates()).single.outbox.progress, 3);
+    });
+
+    test('completed 在非单调模式下同样如实覆盖（玩过 → 在玩）', () async {
+      await gameMappingId('g1');
+      await repository.enqueueProgress(
+        mediaType: TrackingMediaType.game,
+        mediaKey: 'g1',
+        localProgress: 2,
+        completed: true,
+        monotonic: false,
+      );
+      await repository.enqueueProgress(
+        mediaType: TrackingMediaType.game,
+        mediaKey: 'g1',
+        localProgress: 3,
+        completed: false,
+        monotonic: false,
+      );
+
+      final MediaTrackingOutboxRow outbox =
+          (await repository.dueUpdates()).single.outbox;
+      expect(outbox.progress, 3);
+      expect(outbox.completed, isFalse);
+    });
+
+    test('单调模式仍然只增不减（不破坏观看/阅读进度语义）', () async {
+      await repository.saveMapping(
+        mediaType: TrackingMediaType.video,
+        mediaKey: 'v1',
+        mediaTitle: 'Video',
+        kind: TrackingKind.anime,
+        subjectId: 9,
+        subjectName: 'Remote',
+        progressMode: TrackingProgressMode.episode,
+        progressOffset: 0,
+      );
+      await repository.enqueueProgress(
+        mediaType: TrackingMediaType.video,
+        mediaKey: 'v1',
+        localProgress: 8,
+        completed: true,
+      );
+      await repository.enqueueProgress(
+        mediaType: TrackingMediaType.video,
+        mediaKey: 'v1',
+        localProgress: 3,
+        completed: false,
+      );
+
+      final MediaTrackingOutboxRow outbox =
+          (await repository.dueUpdates()).single.outbox;
+      expect(outbox.progress, 8);
+      expect(outbox.completed, isTrue);
+    });
+
+    test('只认 bgm 源的 externalId，VNDB 的 v 前缀 id 不当 subject id 用', () async {
+      await insertGame('g1', name: 'Sakura');
+      await insertSource('g1', source: 'vndb', externalId: 'v12345');
+
+      expect((await repository.loadAutoGameSource('g1'))?.bangumiSubjectId,
+          isNull);
+
+      await insertSource('g1', source: 'bgm', externalId: '4242');
+      final AutoGameTrackingSource? source =
+          await repository.loadAutoGameSource('g1');
+      expect(source?.name, 'Sakura');
+      expect(source?.bangumiSubjectId, 4242);
+    });
+
+    test('未设置状态(0)的游戏不参与对账，不会凭空建远端收藏', () async {
+      await insertGame('g0', name: 'Untouched');
+      await insertGame('g1', name: 'Playing', playStatus: 3);
+      await insertSource('g1', source: 'bgm', externalId: '4242');
+
+      final List<PersistedGameTrackingStatus> statuses =
+          await repository.loadPersistedGameTrackingStatus(afterMs: 0);
+
+      expect(statuses.map((s) => s.gameId), <String>['g1']);
+      expect(statuses.single.status, 3);
+      expect(statuses.single.bangumiSubjectId, 4242);
+    });
+
+    test('对账水位过滤掉已经对齐过的游戏', () async {
+      await insertGame('g1', name: 'Playing', playStatus: 3, addedAt: 5000);
+
+      expect(
+        await repository.loadPersistedGameTrackingStatus(afterMs: 5000),
+        isEmpty,
+      );
+      expect(
+        await repository.loadPersistedGameTrackingStatus(afterMs: 4999),
+        hasLength(1),
+      );
+    });
+
+    test('新建映射会让老游戏重新进入对账（映射 updatedAt 抬高 evidence）', () async {
+      await insertGame('g1', name: 'Playing', playStatus: 3, addedAt: 1000);
+      await gameMappingId('g1');
+
+      // 映射刚建，updatedAt 是当下，远高于 addedAt=1000。
+      expect(
+        await repository.loadPersistedGameTrackingStatus(afterMs: 2000),
+        hasLength(1),
+      );
+    });
   });
 }

--- a/hibiki/test/media/tracking/media_tracking_service_test.dart
+++ b/hibiki/test/media/tracking/media_tracking_service_test.dart
@@ -1001,4 +1001,165 @@ void main() {
       isNull,
     );
   });
+
+  group('游戏收藏状态同步', () {
+    Future<void> insertGame(
+      String id, {
+      required String name,
+      int playStatus = 0,
+    }) =>
+        db.upsertGalgame(
+          GalgamesCompanion.insert(
+            id: id,
+            name: name,
+            exePath: 'C:\\games\\$id.exe',
+            workdir: 'C:\\games',
+            addedAt: 1000,
+            playStatus: Value<int>(playStatus),
+          ),
+        );
+
+    Future<void> scrapeBangumi(String gameId, String subjectId) =>
+        db.upsertGalgameSource(
+          GalgameSourcesCompanion.insert(
+            gameId: gameId,
+            source: 'bgm',
+            externalId: Value<String?>(subjectId),
+            dataJson: '{}',
+            fetchedAt: 1000,
+          ),
+        );
+
+    test('已刮削的游戏用 Bangumi 条目建映射并创建收藏', () async {
+      await insertGame('g1', name: 'Sakura no Uta');
+      await scrapeBangumi('g1', '4242');
+
+      await service.recordGameStatus(gameId: 'g1', status: 3);
+      // recordGameStatus 内部是 unawaited(syncNow())；syncNow 会返回同一个
+      // in-flight future，await 它即可等到后台同步真正跑完。
+      await service.syncNow();
+
+      final MediaTrackingMappingRow? mapping = await repository.findMapping(
+        mediaType: TrackingMediaType.game,
+        mediaKey: 'g1',
+      );
+      expect(mapping, isNotNull);
+      expect(mapping!.subjectId, 4242);
+      expect(mapping.kind, TrackingKind.game.value);
+      expect(mapping.progressMode, TrackingProgressMode.status.value);
+      // offset 必须是 0，否则收藏 type 会被算成另一个状态。
+      expect(mapping.progressOffset, 0);
+      expect(api.creates, <Map<String, dynamic>>[
+        <String, dynamic>{'type': 3},
+      ]);
+      // 游戏条目没有话数，绝不能去动 ep_status。
+      expect(api.episodePatches, isEmpty);
+    });
+
+    test('状态回退如实同步：玩过 → 在玩', () async {
+      await insertGame('g1', name: 'Sakura no Uta');
+      await scrapeBangumi('g1', '4242');
+      api.collection = const BangumiUserCollection(
+        type: 2,
+        episodeProgress: 0,
+        volumeProgress: 0,
+      );
+
+      await service.recordGameStatus(gameId: 'g1', status: 3);
+      await service.syncNow();
+
+      expect(api.patches, <Map<String, dynamic>>[
+        <String, dynamic>{'type': 3},
+      ]);
+    });
+
+    test('远端状态已经一致时不发多余请求', () async {
+      await insertGame('g1', name: 'Sakura no Uta');
+      await scrapeBangumi('g1', '4242');
+      api.collection = const BangumiUserCollection(
+        type: 3,
+        episodeProgress: 0,
+        volumeProgress: 0,
+      );
+
+      await service.recordGameStatus(gameId: 'g1', status: 3);
+      await service.syncNow();
+
+      expect(api.patches, isEmpty);
+      expect(api.creates, isEmpty);
+    });
+
+    test('未设置状态(0)不上报', () async {
+      await insertGame('g1', name: 'Sakura no Uta', playStatus: 0);
+      await scrapeBangumi('g1', '4242');
+
+      await service.recordGameStatus(gameId: 'g1', status: 0);
+
+      expect(
+        await repository.findMapping(
+          mediaType: TrackingMediaType.game,
+          mediaKey: 'g1',
+        ),
+        isNull,
+      );
+      expect(api.creates, isEmpty);
+      expect(api.patches, isEmpty);
+    });
+
+    test('未刮削时按名字搜游戏条目(type 4)，匹配不唯一就不建映射', () async {
+      await insertGame('g1', name: 'Generic Title');
+      api.searchResults = const <BangumiSubject>[
+        BangumiSubject(
+          id: 11,
+          type: 4,
+          name: 'Generic Title',
+          nameCn: '',
+          platform: '游戏',
+          episodeCount: 0,
+          volumeCount: 0,
+        ),
+        BangumiSubject(
+          id: 12,
+          type: 4,
+          name: 'Generic Title',
+          nameCn: '',
+          platform: '游戏',
+          episodeCount: 0,
+          volumeCount: 0,
+        ),
+      ];
+
+      await service.recordGameStatus(gameId: 'g1', status: 3);
+
+      expect(api.searches.single.subjectType, 4);
+      expect(
+        await repository.findMapping(
+          mediaType: TrackingMediaType.game,
+          mediaKey: 'g1',
+        ),
+        isNull,
+      );
+      expect(api.creates, isEmpty);
+    });
+
+    test('连上账号后对账补发此前已设置的状态', () async {
+      await insertGame('g1', name: 'Sakura no Uta', playStatus: 4);
+      await scrapeBangumi('g1', '4242');
+
+      // 换账号会把水位归零，强制从本地事实重建一次。
+      await service.setAccessToken('token');
+      await service.syncNow(force: true);
+
+      expect(api.creates, <Map<String, dynamic>>[
+        <String, dynamic>{'type': 4},
+      ]);
+    });
+  });
+
+  test('Bangumi 条目类型按 kind 映射', () {
+    expect(bangumiSubjectTypeOf(TrackingKind.anime), 2);
+    expect(bangumiSubjectTypeOf(TrackingKind.game), 4);
+    expect(bangumiSubjectTypeOf(TrackingKind.novel), 1);
+    expect(bangumiSubjectTypeOf(TrackingKind.manga), 1);
+  });
 }


### PR DESCRIPTION
## 为什么是 Bangumi 而不是新接一家

用户问「有没有更齐全、包含书籍/漫画/游戏的记录服务」。核实下来：**Bangumi 就是那家**，而且已经接了一半。它覆盖 书籍(含漫画/轻小说)/动画/音乐/**游戏**/三次元，是同时满足「书+漫+游」且开放个人写入 API 的唯一选择。AniList/MAL/Kitsu 没有游戏；VNDB 只有视觉小说；Bookmeter 无个人写入 API；Backloggd/IGDB/Steam 没有开放的个人清单写入。

所以缺口不在服务选型，在于 Hibiki 只用了 Bangumi 的 type 1/2，从没用过 type 4（游戏）。

## 为什么成本低

地基本来就铺好了，本 PR 没有新表、没有换算层：

- `galgame_library.dart:6` 的注释写着「数值**故意对齐 Bangumi 收藏 type**」——`GalgamePlayStatus` 的 1/2/3/4/5 就是想玩/玩过/在玩/搁置/弃坑
- `GalgameSources` 已存 `source='bgm'` + `externalId`，游戏的 Bangumi 条目 ID 本地已有
- `MediaTrackingMappings` 本就有 `provider` 列

## 主要改动

- `TrackingKind`/`TrackingMediaType` 加 `game`；`TrackingProgressMode` 加 `status`（游戏条目 `eps`/`volumes` 恒为 0，唯一可写的是收藏 `type`）
- **`enqueueProgress` 加 `monotonic` 参数**。outbox 原本对 `progress` 取 max——这对观看/阅读进度是对的，对离散状态是错的：「弃坑(5) → 在玩(3)」会被 max 永久吃掉，用户再也改不回来。状态类事件改走 LWW 覆盖，`_enqueueAndSync` 的内存去重缓存同步修正
- **收藏状态如实同步，不套用「已完成不降级」**。那条规则只适用于自动推断的进度；状态是用户在库页显式选定的意图，从「玩过」改回「在玩」必须生效
- `GalgameRepository.setPlayStatus` 加可选回调，由 AppModel 接线——游戏库本身不依赖同步子系统
- 对账兜两种「当时发不出去」：换账号后水位归零、先设状态后刮削
- 未设置状态(0)不上报，不凭空在远端建收藏

## 顺带修的既有 bug

`parseBangumiSubject` 只放行 type 1/2，**type 4 被无条件丢弃**——游戏搜索恒返回空列表，设置页手动搜游戏也永远搜不到。我的 Fake API 测试绕过了真实解析器所以没抓到，已补 client 层测试覆盖 type 4 放行、type 3/6 丢弃。

## Bangumi 链接

令牌页 `next.bgm.tv/demo/access-token` 需要先登录（实测 302 到登录页），没账号的用户会被挡住。新增 `bgm.tv/signup` 注册入口，两者并存而非替代（两个 URL 均实测 200）。

## 验证

- `flutter analyze` 零问题（含 test 目录）
- tracking 定向 45 例全绿；galgame 仓储 + i18n 完整性 80 例全绿
- 全量套件跑到 14827 通过后卡在 `log_panel_scroll_select_guard_test`；其间 2 个失败经对照实验确认为**既有时间敏感 flaky**，与本 PR 无关：`home_video_remote_download_register_test` 的 `tapDownloadAwaitRow` 是 30 秒墙钟轮询、超时后静默放弃导致断言拿到 null（单独跑 3/3 通过、基线同组合通过、负载高时失败）；另一个是 `Cannot close sink while adding stream` 的 harness 崩溃

## 未包含（另议）

用户报告「整个库的进度都是 0」，诊断出两个**既有**缺口，与本 PR 正交，未在此修：

1. **视频**：`recordVideoCompleted` 唯一入口被 `shouldMarkCompleted`（≥90%）门死，没看完的视频完全不进 tracking 管道，远端 0 条收藏；对账路径同样要求 `completedAt != null`，手动建映射也补不回来
2. **书籍**：`_prepareTrackingTitle` 只去结尾的版本/卷号后缀，不剥离 `[组名]` 前缀与副标题，自动映射命中率低（`< 0.92` 相似度即放弃），且失败后有 10 分钟内存冷却

https://claude.ai/code/session_01VwyZAwyCWyzoFk4CdTuNDo
