### PR TITLE
feat(library): 统一三库页右键菜单/合集菜单/刮削入口 + Bangumi 映射直连改绑；移除书籍在线目录入口

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45713 (2689 per locale)
+/// Strings: 45781 (2693 per locale)
 ///
-/// Built on 2026-07-27 at 13:35 UTC
+/// Built on 2026-07-27 at 14:41 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -1436,7 +1436,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get game_scrape_applied => 'Metadata updated';
   String get game_scrape_failed => 'Metadata fetch failed';
   String get game_scrape_no_result => 'No matching entry found';
-  String get game_scrape_pick => 'Pick the matching entry';
   String get game_scrape_query => 'Title or source ID';
   String get game_search => 'Search games';
   String get game_session_events => 'Session events';
@@ -3592,6 +3591,14 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_import_direct => 'Import without OCR';
   String get manga_library => 'Manga';
   String get manga_import_action => 'Import Manga';
+  String get game_scrape_search => 'Search';
+  String get game_scrape_use => 'Use';
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -5826,8 +5833,6 @@ class _StringsAr extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -9721,6 +9726,19 @@ class _StringsAr extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -11983,8 +12001,6 @@ class _StringsDe extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -15918,6 +15934,19 @@ class _StringsDe extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -18181,8 +18210,6 @@ class _StringsEs extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -22131,6 +22158,19 @@ class _StringsEs extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -24402,8 +24442,6 @@ class _StringsFr extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -28355,6 +28393,19 @@ class _StringsFr extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -30592,8 +30643,6 @@ class _StringsId extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -34508,6 +34557,19 @@ class _StringsId extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -36765,8 +36827,6 @@ class _StringsIt extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -40707,6 +40767,19 @@ class _StringsIt extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -42909,8 +42982,6 @@ class _StringsJa extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -46723,6 +46794,19 @@ class _StringsJa extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -48925,8 +49009,6 @@ class _StringsKo extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -52741,6 +52823,19 @@ class _StringsKo extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -54992,8 +55087,6 @@ class _StringsNl extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -58920,6 +59013,19 @@ class _StringsNl extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -61179,8 +61285,6 @@ class _StringsPtBr extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -65112,6 +65216,19 @@ class _StringsPtBr extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -67363,8 +67480,6 @@ class _StringsRu extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -71288,6 +71403,19 @@ class _StringsRu extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -73517,8 +73645,6 @@ class _StringsTh extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -77412,6 +77538,19 @@ class _StringsTh extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -79659,8 +79798,6 @@ class _StringsTr extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -83568,6 +83705,19 @@ class _StringsTr extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -85808,8 +85958,6 @@ class _StringsVi extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -89709,6 +89857,19 @@ class _StringsVi extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 // Path: <root>
@@ -91790,8 +91951,6 @@ class _StringsZhCn extends _StringsEn {
   String get game_scrape_failed => '元数据获取失败';
   @override
   String get game_scrape_no_result => '没有找到匹配条目';
-  @override
-  String get game_scrape_pick => '选择匹配的条目';
   @override
   String get game_scrape_query => '标题或源 ID';
   @override
@@ -95427,6 +95586,16 @@ class _StringsZhCn extends _StringsEn {
   String get manga_library => '漫画';
   @override
   String get manga_import_action => '导入漫画';
+  @override
+  String get game_scrape_search => '搜索';
+  @override
+  String get game_scrape_use => '使用';
+  @override
+  String get game_scrape_search_failed => '搜索失败，请检查网络后重试';
+  @override
+  String get game_remove_confirm => '从库中移除此游戏？不会删除磁盘上的游戏文件。';
+  @override
+  String get delete_collection_also_games => '同时把其中的游戏移出库（不会删除磁盘上的游戏文件）';
 }
 
 // Path: <root>
@@ -97599,8 +97768,6 @@ class _StringsZhHk extends _StringsEn {
   String get game_scrape_failed => 'Metadata fetch failed';
   @override
   String get game_scrape_no_result => 'No matching entry found';
-  @override
-  String get game_scrape_pick => 'Pick the matching entry';
   @override
   String get game_scrape_query => 'Title or source ID';
   @override
@@ -101364,6 +101531,19 @@ class _StringsZhHk extends _StringsEn {
   String get manga_library => 'Manga';
   @override
   String get manga_import_action => 'Import Manga';
+  @override
+  String get game_scrape_search => 'Search';
+  @override
+  String get game_scrape_use => 'Use';
+  @override
+  String get game_scrape_search_failed =>
+      'Search failed. Check your network and try again.';
+  @override
+  String get game_remove_confirm =>
+      'Remove this game from the library? Game files on disk will not be deleted.';
+  @override
+  String get delete_collection_also_games =>
+      'Also remove the games in it from the library (game files on disk are kept)';
 }
 
 /// Flat map(s) containing all translations.
@@ -103337,8 +103517,6 @@ extension on _StringsEn {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -106870,6 +107048,16 @@ extension on _StringsEn {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -108844,8 +109032,6 @@ extension on _StringsAr {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -112374,6 +112560,16 @@ extension on _StringsAr {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -114351,8 +114547,6 @@ extension on _StringsDe {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -117899,6 +118093,16 @@ extension on _StringsDe {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -119877,8 +120081,6 @@ extension on _StringsEs {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -123423,6 +123625,16 @@ extension on _StringsEs {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -125404,8 +125616,6 @@ extension on _StringsFr {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -128953,6 +129163,16 @@ extension on _StringsFr {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -130929,8 +131149,6 @@ extension on _StringsId {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -134465,6 +134683,16 @@ extension on _StringsId {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -136443,8 +136671,6 @@ extension on _StringsIt {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -139992,6 +140218,16 @@ extension on _StringsIt {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -141959,8 +142195,6 @@ extension on _StringsJa {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -145481,6 +145715,16 @@ extension on _StringsJa {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -147449,8 +147693,6 @@ extension on _StringsKo {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -150974,6 +151216,16 @@ extension on _StringsKo {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -152951,8 +153203,6 @@ extension on _StringsNl {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -156494,6 +156744,16 @@ extension on _StringsNl {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -158470,8 +158730,6 @@ extension on _StringsPtBr {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -162011,6 +162269,16 @@ extension on _StringsPtBr {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -163990,8 +164258,6 @@ extension on _StringsRu {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -167533,6 +167799,16 @@ extension on _StringsRu {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -169505,8 +169781,6 @@ extension on _StringsTh {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -173039,6 +173313,16 @@ extension on _StringsTh {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -175016,8 +175300,6 @@ extension on _StringsTr {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -178554,6 +178836,16 @@ extension on _StringsTr {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -180528,8 +180820,6 @@ extension on _StringsVi {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -184064,6 +184354,16 @@ extension on _StringsVi {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }
@@ -186022,8 +186322,6 @@ extension on _StringsZhCn {
         return '元数据获取失败';
       case 'game_scrape_no_result':
         return '没有找到匹配条目';
-      case 'game_scrape_pick':
-        return '选择匹配的条目';
       case 'game_scrape_query':
         return '标题或源 ID';
       case 'game_search':
@@ -189528,6 +189826,16 @@ extension on _StringsZhCn {
         return '漫画';
       case 'manga_import_action':
         return '导入漫画';
+      case 'game_scrape_search':
+        return '搜索';
+      case 'game_scrape_use':
+        return '使用';
+      case 'game_scrape_search_failed':
+        return '搜索失败，请检查网络后重试';
+      case 'game_remove_confirm':
+        return '从库中移除此游戏？不会删除磁盘上的游戏文件。';
+      case 'delete_collection_also_games':
+        return '同时把其中的游戏移出库（不会删除磁盘上的游戏文件）';
       default:
         return null;
     }
@@ -191494,8 +191802,6 @@ extension on _StringsZhHk {
         return 'Metadata fetch failed';
       case 'game_scrape_no_result':
         return 'No matching entry found';
-      case 'game_scrape_pick':
-        return 'Pick the matching entry';
       case 'game_scrape_query':
         return 'Title or source ID';
       case 'game_search':
@@ -195012,6 +195318,16 @@ extension on _StringsZhHk {
         return 'Manga';
       case 'manga_import_action':
         return 'Import Manga';
+      case 'game_scrape_search':
+        return 'Search';
+      case 'game_scrape_use':
+        return 'Use';
+      case 'game_scrape_search_failed':
+        return 'Search failed. Check your network and try again.';
+      case 'game_remove_confirm':
+        return 'Remove this game from the library? Game files on disk will not be deleted.';
+      case 'delete_collection_also_games':
+        return 'Also remove the games in it from the library (game files on disk are kept)';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "元数据已更新",
   "game_scrape_failed": "元数据获取失败",
   "game_scrape_no_result": "没有找到匹配条目",
-  "game_scrape_pick": "选择匹配的条目",
   "game_scrape_query": "标题或源 ID",
   "game_search": "搜索游戏",
   "game_session_events": "会话事件",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "页码（1-${total}）",
   "manga_import_direct": "直接导入",
   "manga_library": "漫画",
-  "manga_import_action": "导入漫画"
+  "manga_import_action": "导入漫画",
+  "game_scrape_search": "搜索",
+  "game_scrape_use": "使用",
+  "game_scrape_search_failed": "搜索失败，请检查网络后重试",
+  "game_remove_confirm": "从库中移除此游戏？不会删除磁盘上的游戏文件。",
+  "delete_collection_also_games": "同时把其中的游戏移出库（不会删除磁盘上的游戏文件）"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -955,7 +955,6 @@
   "game_scrape_applied": "Metadata updated",
   "game_scrape_failed": "Metadata fetch failed",
   "game_scrape_no_result": "No matching entry found",
-  "game_scrape_pick": "Pick the matching entry",
   "game_scrape_query": "Title or source ID",
   "game_search": "Search games",
   "game_session_events": "Session events",
@@ -2687,5 +2686,10 @@
   "manga_page_number_hint": "Page number (1-${total})",
   "manga_import_direct": "Import without OCR",
   "manga_library": "Manga",
-  "manga_import_action": "Import Manga"
+  "manga_import_action": "Import Manga",
+  "game_scrape_search": "Search",
+  "game_scrape_use": "Use",
+  "game_scrape_search_failed": "Search failed. Check your network and try again.",
+  "game_remove_confirm": "Remove this game from the library? Game files on disk will not be deleted.",
+  "delete_collection_also_games": "Also remove the games in it from the library (game files on disk are kept)"
 }

--- a/hibiki/lib/src/media/audiobook/book_import_dialog.dart
+++ b/hibiki/lib/src/media/audiobook/book_import_dialog.dart
@@ -207,12 +207,7 @@ class _BookImportDialogState extends State<BookImportDialog>
               onPressed: importing ? null : _openOcrWizard,
               child: Text(t.manga_ocr_wizard_title),
             ),
-          // 漫画「在线目录」（O1 mokuro.moe 目录源）：卷级下载 → 现有导入链落库。
-          adaptiveDialogAction(
-            context: context,
-            onPressed: importing ? null : _openOnlineCatalog,
-            child: Text(t.manga_online_catalog_title),
-          ),
+          // 漫画「在线目录」入口已从书籍导入框移除（属漫画域，入口收敛到下载页）。
           adaptiveDialogAction(
             context: context,
             onPressed: () => Navigator.pop(context),
@@ -238,16 +233,6 @@ class _BookImportDialogState extends State<BookImportDialog>
     if (bookKey != null && mounted) {
       Navigator.pop(context, true);
     }
-  }
-
-  /// 打开漫画「在线目录」（O1 mokuro.moe 目录源）。下载/导入在共享队列后台
-  /// 进行（统一下载中心，关对话框不中断），书架刷新由书架页的队列监听触发，
-  /// 本导入框不再需要「导入发生则连带关闭回传」。
-  Future<void> _openOnlineCatalog() async {
-    await MangaModule.openOnlineCatalog(
-      context: context,
-      db: widget.db,
-    );
   }
 
   /// 拖文件进本对话框 → 分类 → 按字段覆盖（仅填命中类，不清用户已选）。

--- a/hibiki/lib/src/media/collections/collection_context_dialog.dart
+++ b/hibiki/lib/src/media/collections/collection_context_dialog.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+
+import 'package:hibiki/src/pages/implementations/collection_name_dialog.dart'
+    show showCollectionNameDialog;
+import 'package:hibiki/src/pages/implementations/media_item_dialog_page.dart';
+import 'package:hibiki/src/pages/implementations/tag_picker_page.dart';
+import 'package:hibiki/utils.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 统一三库页合集入口的右键 / 长按菜单（书架横排行、视频合集封面卡、游戏库
+/// 横排行共用）：打开详情 / 重命名 / 标签 / 删除合集。
+///
+/// 此前合集管理动作只存在于合集详情页 AppBar，三页的合集入口本身没有任何
+/// 上下文菜单（与单卡的长按对话框割裂，用户实报）。本对话框复用单卡同款
+/// [MediaItemDialogFrame] 骨架，动作语义与详情页 AppBar 完全同源：
+/// 重命名走 [HibikiDatabase.renameMediaCollection]，标签走 [TagPickerPage]
+/// （合集路），删除走 [HibikiDatabase.deleteMediaCollection]（纯解链，可选
+/// 「连同成员本体一起删」勾选，与详情页 `_delete` 同一纪律）。
+///
+/// [context] 必须是**页面**级 context（对话框内部动作先关自身再用它续跑）。
+/// [onChanged] 在任何写库动作（重命名/标签/删除）后调用，页面自刷。
+/// [onDeleteMembersMedia] 非 null 且合集有成员时，删除确认框提供
+/// [deleteMembersCheckboxLabel] 勾选行（调用方按媒体域传
+/// `delete_collection_also_books` / `delete_collection_also_videos` 等文案）。
+Future<void> showCollectionContextDialog({
+  required BuildContext context,
+  required HibikiDatabase db,
+  required MediaCollectionRow collection,
+  required VoidCallback onOpenDetail,
+  required VoidCallback onChanged,
+  Future<void> Function(List<MediaCollectionItemRow> members)?
+      onDeleteMembersMedia,
+  String? deleteMembersCheckboxLabel,
+  Widget? cover,
+}) async {
+  await showAppDialog<void>(
+    context: context,
+    builder: (BuildContext dialogContext) {
+      void closeThen(void Function() action) {
+        Navigator.pop(dialogContext);
+        action();
+      }
+
+      return MediaItemDialogFrame(
+        cover: cover,
+        title: collection.name,
+        // 顶部主按钮 = 打开详情（与行头/卡片单击同路径，键盘/手柄用户可达）。
+        launchLabel: t.collection_view_all,
+        onLaunch: () => closeThen(onOpenDetail),
+        listActions: <DialogListAction>[
+          DialogListAction(
+            label: t.rename_collection,
+            icon: Icons.drive_file_rename_outline,
+            onPressed: () => closeThen(
+              () => _renameCollection(
+                context: context,
+                db: db,
+                collection: collection,
+                onChanged: onChanged,
+              ),
+            ),
+          ),
+          DialogListAction(
+            label: t.tag_label,
+            icon: Icons.sell_outlined,
+            onPressed: () => closeThen(
+              () => _editCollectionTags(
+                context: context,
+                collection: collection,
+                onChanged: onChanged,
+              ),
+            ),
+          ),
+        ],
+        dangerActions: <DialogDangerAction>[
+          DialogDangerAction(
+            label: t.delete_collection,
+            onPressed: () => closeThen(
+              () => _deleteCollection(
+                context: context,
+                db: db,
+                collection: collection,
+                onChanged: onChanged,
+                onDeleteMembersMedia: onDeleteMembersMedia,
+                deleteMembersCheckboxLabel: deleteMembersCheckboxLabel,
+              ),
+            ),
+          ),
+        ],
+      );
+    },
+  );
+}
+
+/// 重命名合集：命名弹窗 → [HibikiDatabase.renameMediaCollection]。与
+/// `CollectionDetailShared.renameDetailCollection` 同语义（那边还要同步页题，
+/// 库页语境由 [onChanged] 整页重载覆盖）。
+Future<void> _renameCollection({
+  required BuildContext context,
+  required HibikiDatabase db,
+  required MediaCollectionRow collection,
+  required VoidCallback onChanged,
+}) async {
+  final String? newName = await showCollectionNameDialog(
+    context: context,
+    title: t.rename_collection,
+    initialName: collection.name,
+  );
+  if (newName == null || newName == collection.name) return;
+  await db.renameMediaCollection(collection.id, newName);
+  onChanged();
+}
+
+/// 编辑合集标签：复用共享标签池的 [TagPickerPage]（合集路）。返回后 [onChanged]
+/// 让页面失效 `collectionTagMapProvider` 刷新行头/卡面 chip。
+Future<void> _editCollectionTags({
+  required BuildContext context,
+  required MediaCollectionRow collection,
+  required VoidCallback onChanged,
+}) async {
+  await Navigator.of(context).push<void>(
+    MaterialPageRoute<void>(
+      builder: (_) => TagPickerPage(collectionId: collection.id),
+    ),
+  );
+  onChanged();
+}
+
+/// 删除合集：确认（可选「连同成员本体一起删」勾选）→ 先删成员本体（调用方注入，
+/// 按媒体域删 DB 行 + 磁盘副本）→ [HibikiDatabase.deleteMediaCollection]
+/// 解散容器（清引用行 + 写合集级墓碑）。与两个合集详情页的 `_delete` 同一顺序。
+Future<void> _deleteCollection({
+  required BuildContext context,
+  required HibikiDatabase db,
+  required MediaCollectionRow collection,
+  required VoidCallback onChanged,
+  required Future<void> Function(List<MediaCollectionItemRow> members)?
+      onDeleteMembersMedia,
+  required String? deleteMembersCheckboxLabel,
+}) async {
+  final List<MediaCollectionItemRow> members =
+      await db.getCollectionItems(collection.id);
+  if (!context.mounted) return;
+  final bool canDeleteMembers =
+      onDeleteMembersMedia != null && members.isNotEmpty;
+  final HibikiDestructiveConfirmResult? result =
+      await showAppDialog<HibikiDestructiveConfirmResult>(
+    context: context,
+    builder: (_) => HibikiDestructiveConfirmDialog(
+      title: t.delete_collection,
+      message: t.delete_collection_confirm,
+      confirmLabel: t.delete_collection,
+      checkboxLabel: canDeleteMembers ? deleteMembersCheckboxLabel : null,
+    ),
+  );
+  if (result == null || !context.mounted) return;
+  if (result.checked && onDeleteMembersMedia != null) {
+    await onDeleteMembersMedia(List<MediaCollectionItemRow>.of(members));
+  }
+  await db.deleteMediaCollection(collection.id);
+  onChanged();
+}

--- a/hibiki/lib/src/media/collections/collection_shelf_row.dart
+++ b/hibiki/lib/src/media/collections/collection_shelf_row.dart
@@ -35,6 +35,7 @@ class CollectionShelfRow extends StatefulWidget {
     this.onToggleSelected,
     this.onTagDropped,
     this.tags,
+    this.onContextMenu,
     super.key,
   });
 
@@ -94,6 +95,11 @@ class CollectionShelfRow extends StatefulWidget {
   /// 不占位。调用方 `ref.watch(collectionTagMapProvider)` 后传该合集的列表；打标签
   /// 后失效该 provider 即刷新。
   final List<BookTagRow>? tags;
+
+  /// 行头长按 / 桌面右键 → 合集上下文菜单（统一三库页合集菜单：打开/重命名/
+  /// 标签/删除，见 `showCollectionContextDialog`）。多选态（[selectionCheckbox]
+  /// 非 null）自动压制——与单卡多选态禁长按菜单同一纪律。null = 行头无菜单。
+  final VoidCallback? onContextMenu;
 
   @override
   State<CollectionShelfRow> createState() => _CollectionShelfRowState();
@@ -201,10 +207,15 @@ class _CollectionShelfRowState extends State<CollectionShelfRow> {
     final bool selectionMode = selectionCheckbox != null;
     final VoidCallback headerTap =
         widget.onToggleSelected ?? widget.onOpenDetail;
+    // 行头长按/右键 = 合集上下文菜单（多选态压制，行头点击专注整选）。
+    final VoidCallback? contextMenu =
+        selectionMode ? null : widget.onContextMenu;
     final Widget header = InkWell(
       canRequestFocus: false,
       borderRadius: tokens.radii.controlRadius,
       onTap: headerTap,
+      onLongPress: contextMenu,
+      onSecondaryTap: contextMenu,
       child: Padding(
         padding: EdgeInsets.symmetric(
           horizontal: tokens.spacing.gap / 2,

--- a/hibiki/lib/src/media/metadata/bangumi_api_client.dart
+++ b/hibiki/lib/src/media/metadata/bangumi_api_client.dart
@@ -24,6 +24,34 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+/// 纯函数：把用户粘贴的 Bangumi 条目 **URL** 解析为 subject id（数字串）。
+///
+/// 「添加/修改 Bangumi 映射」共享入口：三媒体域（书/视频/游戏）的刮削弹窗都允许
+/// 直接贴条目 URL 改绑映射。接受 `bgm.tv` / `bangumi.tv` / `chii.in`（含 `www.`
+/// 前缀、http/https、无 scheme）下的 `/subject/<数字>` 路径，容忍尾随路径段 /
+/// query / fragment。**纯数字输入不在此认定**——数字既可能是 id 也可能是标题
+/// （如动画《86》），由各弹窗按「关键词搜索 + id 直取并列」策略自行处理。
+/// 其它输入返回 null（按关键词搜索处理）。
+String? parseBangumiSubjectUrl(String input) {
+  final String trimmed = input.trim();
+  if (trimmed.isEmpty) return null;
+  // 无 scheme 的裸域名形态（如 `bgm.tv/subject/123`）补上 scheme 再解析。
+  final String candidate =
+      trimmed.contains('://') ? trimmed : 'https://$trimmed';
+  final Uri? uri = Uri.tryParse(candidate);
+  if (uri == null) return null;
+  final String host = uri.host.toLowerCase();
+  final String bareHost =
+      host.startsWith('www.') ? host.substring('www.'.length) : host;
+  const Set<String> knownHosts = <String>{'bgm.tv', 'bangumi.tv', 'chii.in'};
+  if (!knownHosts.contains(bareHost)) return null;
+  final List<String> segments = uri.pathSegments;
+  final int subjectIndex = segments.indexOf('subject');
+  if (subjectIndex < 0 || subjectIndex + 1 >= segments.length) return null;
+  final String id = segments[subjectIndex + 1];
+  return RegExp(r'^\d+$').hasMatch(id) ? id : null;
+}
+
 /// Bangumi `filter.type` 条目类型常量（避免各处散落魔法数字）。
 const int kBangumiSubjectTypeBook = 1;
 const int kBangumiSubjectTypeAnime = 2;

--- a/hibiki/lib/src/media/metadata/book_cover_scrape_dialog.dart
+++ b/hibiki/lib/src/media/metadata/book_cover_scrape_dialog.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import 'package:hibiki/src/media/metadata/bangumi_api_client.dart'
+    show parseBangumiSubjectUrl;
 import 'package:hibiki/src/media/metadata/book_metadata_scraper.dart';
 import 'package:hibiki/src/media/metadata/image_download.dart';
 import 'package:hibiki/utils.dart';
@@ -83,7 +85,7 @@ class _BookCoverScrapeDialogState extends State<BookCoverScrapeDialog> {
     List<BookScrapeCandidate> results;
     bool failed = false;
     try {
-      results = await _scraper.search(keyword);
+      results = await _resolveCandidates(keyword);
     } catch (_) {
       results = const <BookScrapeCandidate>[];
       failed = true;
@@ -94,6 +96,36 @@ class _BookCoverScrapeDialogState extends State<BookCoverScrapeDialog> {
       _searching = false;
       _searchFailed = failed;
     });
+  }
+
+  /// 关键词 → 候选。添加/修改 Bangumi 映射：贴条目 URL = 按 id 直取（跳过关键词
+  /// 搜索）；纯数字既可能是 id 也可能是书名（如《1984》）——搜索 + id 直取并列，
+  /// 直取命中置顶、按 subjectId 去重；其余走关键词搜索。
+  Future<List<BookScrapeCandidate>> _resolveCandidates(String keyword) async {
+    final String? mappedSubjectId = parseBangumiSubjectUrl(keyword);
+    if (mappedSubjectId != null) {
+      final BookScrapeCandidate? candidate =
+          await _scraper.fetchById(mappedSubjectId);
+      return candidate == null
+          ? const <BookScrapeCandidate>[]
+          : <BookScrapeCandidate>[candidate];
+    }
+    if (RegExp(r'^\d+$').hasMatch(keyword)) {
+      final List<BookScrapeCandidate> searched = await _scraper.search(keyword);
+      BookScrapeCandidate? direct;
+      try {
+        direct = await _scraper.fetchById(keyword);
+      } catch (_) {
+        direct = null; // 直取失败不拖垮关键词结果。
+      }
+      if (direct == null) return searched;
+      final String directId = direct.subjectId;
+      return <BookScrapeCandidate>[
+        direct,
+        ...searched.where((BookScrapeCandidate c) => c.subjectId != directId),
+      ];
+    }
+    return _scraper.search(keyword);
   }
 
   Future<void> _use(BookScrapeCandidate candidate) async {

--- a/hibiki/lib/src/media/metadata/book_metadata_scraper.dart
+++ b/hibiki/lib/src/media/metadata/book_metadata_scraper.dart
@@ -108,8 +108,45 @@ class BookMetadataScraper {
     return parseBookSearchResponse(response.body);
   }
 
+  /// 按 Bangumi subject id 直取条目并映射为候选（添加/修改 Bangumi 映射：用户在
+  /// 弹窗贴 ID/URL 直连，不走关键词搜索）。
+  ///
+  /// 404（条目不存在/被删）或条目无封面 → null；其余非 2xx / 网络失败 → 抛
+  /// [BookScrapeException]。
+  Future<BookScrapeCandidate?> fetchById(String subjectId) async {
+    final BangumiRawResponse response;
+    try {
+      response = await _api.fetchSubject(subjectId);
+    } on BangumiTransportException catch (e) {
+      throw BookScrapeException('Bangumi book subject ${e.message}');
+    }
+    if (response.statusCode == 404) return null;
+    if (!response.isOk) {
+      throw BookScrapeException(
+        'Bangumi book subject HTTP ${response.statusCode}',
+        statusCode: response.statusCode,
+      );
+    }
+    return parseBookSubjectResponse(response.body);
+  }
+
   /// 关闭内部 client（若为默认自建）。
   void close() => _api.close();
+}
+
+/// 纯函数：把 Bangumi `/v0/subjects/{id}` **详情**响应体解析为单个候选（id 直连
+/// 改绑映射路径用）。详情响应的 images/name/name_cn/date/summary 字段形态与搜索
+/// 条目一致，直接复用 [mapBookSubject]；无封面/无标题 → null；JSON 解码失败 →
+/// 抛 [BookScrapeException]。
+BookScrapeCandidate? parseBookSubjectResponse(String body) {
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(body);
+  } catch (e) {
+    throw BookScrapeException('Bangumi book subject JSON decode failed: $e');
+  }
+  if (decoded is! Map<String, Object?>) return null;
+  return mapBookSubject(decoded);
 }
 
 /// 纯函数：把 Bangumi `/v0/search/subjects`（书籍）响应体解析为候选列表。

--- a/hibiki/lib/src/media/video/cover_ui/cover_match_dialog.dart
+++ b/hibiki/lib/src/media/video/cover_ui/cover_match_dialog.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:hibiki/src/media/metadata/bangumi_api_client.dart'
+    show parseBangumiSubjectUrl;
 import 'package:hibiki/src/media/video/scraper/cover_scraper_service.dart';
 import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
 import 'package:hibiki/src/media/video/scraper/tmdb_client.dart';
@@ -113,6 +115,31 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
   Future<void> _search() async {
     final String keyword = _queryCtrl.text.trim();
     if (keyword.isEmpty) return;
+    // 添加/修改 Bangumi 映射：贴条目 URL = 直接按 id 取该条目改绑（跳过关键词
+    // 搜索与 TMDB key 门，无论当前在哪个数据源分段）。
+    final String? mappedSubjectId = parseBangumiSubjectUrl(keyword);
+    if (mappedSubjectId != null) {
+      setState(() {
+        _searching = true;
+        _searched = true;
+      });
+      List<ScrapeCandidate> results;
+      try {
+        final ScrapeCandidate? candidate =
+            await widget.service.fetchBangumiCandidateById(mappedSubjectId);
+        results = candidate == null
+            ? const <ScrapeCandidate>[]
+            : <ScrapeCandidate>[candidate];
+      } catch (_) {
+        results = const <ScrapeCandidate>[];
+      }
+      if (!mounted) return;
+      setState(() {
+        _results = results;
+        _searching = false;
+      });
+      return;
+    }
     // TMDB 分段但无 key：展开输入行，不搜。
     if (_source == ScrapeSource.tmdb && _storedTmdbKey().isEmpty) {
       setState(() => _showTmdbKeyField = true);
@@ -148,6 +175,26 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
       } finally {
         client.close();
       }
+    }
+    // 纯数字输入既可能是 Bangumi subject id（用户改绑映射）也可能就是标题
+    // （如动画《86》）：两路并发，id 直取命中置顶、与同 id 搜索结果去重——
+    // 不牺牲任何一种意图。
+    if (_source == ScrapeSource.bangumi && RegExp(r'^\d+$').hasMatch(keyword)) {
+      final List<ScrapeCandidate> searched = await widget.service
+          .searchCandidates(source: _source, keyword: keyword)
+          .catchError((Object _) => const <ScrapeCandidate>[]);
+      ScrapeCandidate? direct;
+      try {
+        direct = await widget.service.fetchBangumiCandidateById(keyword);
+      } catch (_) {
+        direct = null;
+      }
+      if (direct == null) return searched;
+      final String directId = direct.entryId;
+      return <ScrapeCandidate>[
+        direct,
+        ...searched.where((ScrapeCandidate c) => c.entryId != directId),
+      ];
     }
     return widget.service.searchCandidates(source: _source, keyword: keyword);
   }

--- a/hibiki/lib/src/media/video/cover_ui/scrape_info_dialog.dart
+++ b/hibiki/lib/src/media/video/cover_ui/scrape_info_dialog.dart
@@ -19,6 +19,7 @@ Future<void> showScrapeInfoDialog({
   required String fallbackTitle,
   required ScrapeMetadata? metadata,
   Future<void> Function()? onRescrape,
+  VoidCallback? onEditMapping,
 }) {
   return showAppDialog<void>(
     context: context,
@@ -26,6 +27,7 @@ Future<void> showScrapeInfoDialog({
       fallbackTitle: fallbackTitle,
       metadata: metadata,
       onRescrape: onRescrape,
+      onEditMapping: onEditMapping,
     ),
   );
 }
@@ -36,6 +38,7 @@ class ScrapeInfoDialog extends StatelessWidget {
     required this.fallbackTitle,
     required this.metadata,
     this.onRescrape,
+    this.onEditMapping,
     super.key,
   });
 
@@ -44,6 +47,10 @@ class ScrapeInfoDialog extends StatelessWidget {
 
   final ScrapeMetadata? metadata;
   final Future<void> Function()? onRescrape;
+
+  /// 「添加/修改映射」：打开在线匹配弹窗（可搜索/贴 Bangumi ID/URL 改绑条目）。
+  /// 复用「在线匹配封面」文案——那个弹窗就是映射编辑器。null = 不显示。
+  final VoidCallback? onEditMapping;
 
   /// 资料表最多展示的行数：Bangumi infobox 动辄二三十行（每个声优一行），全列会把
   /// 弹窗撑成长名单。取前若干条（源本身按重要度排：中文名/话数/放送/导演/制作…）。
@@ -70,6 +77,15 @@ class ScrapeInfoDialog extends StatelessWidget {
               ),
       ),
       actions: <Widget>[
+        if (onEditMapping != null)
+          TextButton(
+            key: const ValueKey<String>('scrape_info_edit_mapping'),
+            onPressed: () {
+              Navigator.of(context).pop();
+              onEditMapping!();
+            },
+            child: Text(t.video_scrape_online_match),
+          ),
         if (onRescrape != null)
           TextButton(
             key: const ValueKey<String>('scrape_info_rescrape'),

--- a/hibiki/lib/src/media/video/scraper/bangumi_client.dart
+++ b/hibiki/lib/src/media/video/scraper/bangumi_client.dart
@@ -101,8 +101,58 @@ class BangumiClient {
     return parseBangumiSubjectResponse(response.body);
   }
 
+  /// 按 subject id 直取条目并映射为**候选**（添加/修改 Bangumi 映射：用户在匹配
+  /// 弹窗贴 ID/URL 直连改绑，不走关键词搜索）。
+  ///
+  /// 404（条目不存在/被删）或条目无海报 → null（UI 按空结果处理）；其余非 2xx /
+  /// 网络失败 → 抛 [ScrapeNetworkException]。
+  Future<ScrapeCandidate?> fetchSubjectCandidate(String subjectId) async {
+    final BangumiRawResponse response;
+    try {
+      response = await _api.fetchSubject(subjectId);
+    } on BangumiTransportException catch (e) {
+      throw ScrapeNetworkException('Bangumi subject ${e.message}');
+    }
+    if (response.statusCode == 404) return null;
+    if (!response.isOk) {
+      throw ScrapeNetworkException(
+        'Bangumi subject HTTP ${response.statusCode}',
+        statusCode: response.statusCode,
+      );
+    }
+    return parseBangumiSubjectDetailAsCandidate(response.body);
+  }
+
   /// 关闭内部 client（若为默认自建）。测试注入的 mock client 由调用方自行管理。
   void close() => _api.close();
+}
+
+/// 纯函数：把 Bangumi `/v0/subjects/{id}` **详情**响应体解析为 [ScrapeCandidate]
+/// （id 直连改绑映射路径用；与搜索候选同一映射器，保证「使用」后落库路径零分叉）。
+///
+/// 详情端点与搜索端点字段有两处形态差异，先归一再复用 [_mapBangumiSubject]：
+/// 评分在 `rating.score`（搜索是扁平 `score`）；话数补 `total_episodes` 回退。
+/// 无海报/无标题 → null；JSON 结构异常 → 抛 [ScrapeNetworkException]。
+ScrapeCandidate? parseBangumiSubjectDetailAsCandidate(String body) {
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(body);
+  } catch (e) {
+    throw ScrapeNetworkException('Bangumi subject JSON decode failed: $e');
+  }
+  if (decoded is! Map<String, Object?>) {
+    throw const ScrapeNetworkException('Bangumi subject not a JSON object');
+  }
+  final Map<String, Object?> subject = Map<String, Object?>.of(decoded);
+  final Object? ratingNode = subject['rating'];
+  if (_asDouble(subject['score']) == null &&
+      ratingNode is Map<String, Object?>) {
+    subject['score'] = ratingNode['score'];
+  }
+  if ((_asInt(subject['eps']) ?? 0) <= 0) {
+    subject['eps'] = subject['total_episodes'];
+  }
+  return _mapBangumiSubject(subject);
 }
 
 /// 纯函数：把 Bangumi `/v0/subjects/{id}` 响应体解析为 [ScrapeMetadata]。

--- a/hibiki/lib/src/media/video/scraper/cover_scraper_service.dart
+++ b/hibiki/lib/src/media/video/scraper/cover_scraper_service.dart
@@ -357,6 +357,11 @@ class CoverScraperService {
     }
   }
 
+  /// 添加/修改 Bangumi 映射：按 subject id 直取条目映射为候选（用户贴 ID/URL
+  /// 改绑）。404/无海报 → null；网络失败抛 [ScrapeNetworkException] 由弹窗降级。
+  Future<ScrapeCandidate?> fetchBangumiCandidateById(String subjectId) =>
+      _bangumi.fetchSubjectCandidate(subjectId);
+
   /// 用户在弹窗里点「使用」某候选：下载海报落封面 + `updateCover` + 记 scraped 元数据 +
   /// 记别名缓存（[aliasKey] 非空时）。[bookUids] 多于一个 = 同时应用到整个合集（每个
   /// 成员各落一份封面文件，海报只下载一次后复制分发）。

--- a/hibiki/lib/src/mining/galgame_cover_download.dart
+++ b/hibiki/lib/src/mining/galgame_cover_download.dart
@@ -31,6 +31,15 @@ bool shouldAutoDownloadScrapedCover({
   return coverUrl != null && coverUrl.trim().isNotEmpty;
 }
 
+/// 纯函数：用户在统一刮削弹窗里**显式选中**候选后是否下载封面。
+///
+/// 与 [shouldAutoDownloadScrapedCover]（隐式路径：已有可用封面绝不覆盖）语义
+/// 不同：显式选择 = 用户点名要这一条 → 只要源给了 URL 就下载并**覆盖**现有封面
+/// （与视频「在线匹配海报」的手动「使用」同语义）。隐式规则保持原样，仅继续
+/// 服务将来的自动刮削路径；两条路径的分界由各自纯函数钉死，禁止互相借用。
+bool shouldDownloadExplicitScrapedCover({required String? coverUrl}) =>
+    coverUrl != null && coverUrl.trim().isNotEmpty;
+
 /// 纯函数：从响应 Content-Type / URL 路径推导落盘扩展名（小写、含点）。
 ///
 /// 优先信 Content-Type（服务器端真相）；拿不到或不认识再看 URL 路径后缀是否在

--- a/hibiki/lib/src/mining/galgame_cover_download.dart
+++ b/hibiki/lib/src/mining/galgame_cover_download.dart
@@ -18,11 +18,17 @@ const int kGalgameCoverMaxDownloadBytes = 20 * 1024 * 1024;
 /// 下载体积下限：小于它的响应不可能是可用封面图（多为错误页/空响应）。
 const int kGalgameCoverMinDownloadBytes = 1024;
 
-/// 纯函数：刮削成功后是否要自动下载封面。
+/// 纯函数：刮削成功后是否要下载封面。
 ///
 /// 规则只有一条：**已有可用封面文件（手选/自动/上次下载）绝不覆盖**；没有可用
 /// 封面且合并层给出了 URL 才下载。[hasUsableCoverFile] 由调用方按
 /// 「coverPath 非空且文件真实存在」判定（与卡片渲染的 existsSync 短路同判据）。
+///
+/// 这是游戏岛封面保护的**唯一判据**（游戏岛没有视频岛的 [CoverOrigin] 元数据，
+/// 只能以「封面文件是否存在」保护用户手选的图），详情页的自动刮削路径与统一刮削
+/// 弹窗的显式「使用」路径共用它——两条路径都不许覆盖既有封面，与
+/// `media_cover_service.dart` 的封面纪律表逐字一致。想换封面走「选择封面图片」/
+/// 「自动封面」，那两条是用户显式点名的封面写入口。
 bool shouldAutoDownloadScrapedCover({
   required bool hasUsableCoverFile,
   required String? coverUrl,
@@ -30,15 +36,6 @@ bool shouldAutoDownloadScrapedCover({
   if (hasUsableCoverFile) return false;
   return coverUrl != null && coverUrl.trim().isNotEmpty;
 }
-
-/// 纯函数：用户在统一刮削弹窗里**显式选中**候选后是否下载封面。
-///
-/// 与 [shouldAutoDownloadScrapedCover]（隐式路径：已有可用封面绝不覆盖）语义
-/// 不同：显式选择 = 用户点名要这一条 → 只要源给了 URL 就下载并**覆盖**现有封面
-/// （与视频「在线匹配海报」的手动「使用」同语义）。隐式规则保持原样，仅继续
-/// 服务将来的自动刮削路径；两条路径的分界由各自纯函数钉死，禁止互相借用。
-bool shouldDownloadExplicitScrapedCover({required String? coverUrl}) =>
-    coverUrl != null && coverUrl.trim().isNotEmpty;
 
 /// 纯函数：从响应 Content-Type / URL 路径推导落盘扩展名（小写、含点）。
 ///

--- a/hibiki/lib/src/mining/galgame_scrape_dialog.dart
+++ b/hibiki/lib/src/mining/galgame_scrape_dialog.dart
@@ -1,0 +1,468 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:hibiki_core/hibiki_core.dart' show GalgameSourceRow;
+
+import 'package:hibiki/src/mining/galgame_cover_download.dart';
+import 'package:hibiki/src/mining/galgame_library.dart';
+import 'package:hibiki/src/mining/galgame_repository.dart';
+import 'package:hibiki/src/mining/galgame_scrape_controller.dart';
+import 'package:hibiki/src/mining/metadata/galgame_metadata_adapter.dart';
+import 'package:hibiki/src/mining/metadata/galgame_metadata_draft.dart';
+import 'package:hibiki/src/mining/metadata/galgame_metadata_source.dart';
+import 'package:hibiki/utils.dart';
+
+/// 游戏「刮削元数据」统一弹窗（对齐视频 `cover_match_dialog.dart` 的单弹窗闭环）。
+///
+/// 此前游戏刮削是三跳：库页卡菜单 → 详情页编辑 tab → 刮削按钮 → 再串行弹
+/// 「输入关键词」「纯文本候选」两个对话框，封面还只在无封面时隐式附带。本弹窗
+/// 一步到位：打开即按当前显示名自动首搜，搜索框可改词重搜，候选带封面缩略图 +
+/// `源 · ID · 发行日` 副行，每行「使用」行内转圈；点「使用」= `fetchById` 补全
+/// → [GalgameRepository.saveScrapeResult]（多源 primarySource 记 mixed 规则不变）
+/// → **封面与元数据一起落**（显式语义：覆盖现有封面，见
+/// [shouldDownloadExplicitScrapedCover]）。
+///
+/// 返回 true = 已成功落库（调用方据此刷新库页 / 重载详情页）；false/取消 = 无写库。
+Future<bool> showGalgameScrapeDialog({
+  required BuildContext context,
+  required GalgameEntry game,
+  required GalgameRepository repo,
+  String? initialQuery,
+}) async {
+  final bool? applied = await showAppDialog<bool>(
+    context: context,
+    builder: (BuildContext ctx) => GalgameScrapeDialog(
+      game: game,
+      repo: repo,
+      initialQuery: initialQuery,
+    ),
+  );
+  return applied ?? false;
+}
+
+/// 纯函数：把用户贴进搜索框的**条目页 URL** 归一化成源裸 ID，其余输入原样透传。
+///
+/// 「添加/修改 Bangumi 映射」需求的游戏侧一环：用户从浏览器地址栏复制条目 URL
+/// 直接贴进来即可改绑，无需自己抠 ID。[GalgameScrapeController.search] 的
+/// validateId 链路已认裸 ID（命中即跳过搜索直取详情），缺的只是 URL 形态——
+/// 本函数补上这一步，归一化后交给既有链路，controller 零改动。
+///
+/// - Bangumi 条目页（`bgm.tv` / `bangumi.tv` / `chii.in` 的 `/subject/<数字>`，
+///   允许尾随斜杠/多余路径段/query/fragment）→ 数字串裸 ID；
+/// - VNDB 条目页（`vndb.org` 的 `/v<数字>`，同样宽容尾随内容）→ `v<数字>`；
+/// - 其它输入（裸 ID、普通关键词、非条目 URL）**原样返回，零行为变化**。
+String normalizeGalgameScrapeQuery(String input) {
+  final Uri? uri = _tryParseEntryUrl(input);
+  if (uri == null) return input;
+  final String rawHost = uri.host.toLowerCase();
+  final String host =
+      rawHost.startsWith('www.') ? rawHost.substring(4) : rawHost;
+  final List<String> segments = <String>[
+    for (final String s in uri.pathSegments)
+      if (s.isNotEmpty) s,
+  ];
+  const Set<String> bangumiHosts = <String>{'bgm.tv', 'bangumi.tv', 'chii.in'};
+  if (bangumiHosts.contains(host) &&
+      segments.length >= 2 &&
+      segments[0] == 'subject' &&
+      RegExp(r'^\d+$').hasMatch(segments[1])) {
+    return segments[1];
+  }
+  if (host == 'vndb.org' && segments.isNotEmpty) {
+    final RegExpMatch? m =
+        RegExp(r'^v(\d+)$', caseSensitive: false).firstMatch(segments[0]);
+    if (m != null) return 'v${m.group(1)!}';
+  }
+  return input;
+}
+
+/// 把输入解析成 http/https URL；解析不出（裸词/裸 ID/含空格）返回 null。
+/// 用户从地址栏复制偶尔丢协议（`bgm.tv/subject/4885`）：无 scheme 但长得像
+/// 「域名/路径」时补 `https://` 再试一次。
+Uri? _tryParseEntryUrl(String input) {
+  final String trimmed = input.trim();
+  if (trimmed.isEmpty || trimmed.contains(' ')) return null;
+  final Uri? direct = Uri.tryParse(trimmed);
+  if (direct != null &&
+      (direct.isScheme('http') || direct.isScheme('https')) &&
+      direct.host.isNotEmpty) {
+    return direct;
+  }
+  if (!trimmed.contains('://') &&
+      trimmed.contains('.') &&
+      trimmed.contains('/')) {
+    final Uri? prefixed = Uri.tryParse('https://$trimmed');
+    if (prefixed != null && prefixed.host.isNotEmpty) return prefixed;
+  }
+  return null;
+}
+
+/// 落库一条**用户显式选中**的候选（库页与详情页共用，取代旧 `_scrape()` 的落库段）：
+/// `fetchById` 补全 draft → [GalgameRepository.saveScrapeResult]（多源快照时
+/// primarySource 记 [kGalgamePrimarySourceMixed]，单源记该源 key——规则不变）→
+/// 显式封面下载（覆盖现有封面；下载失败静默降级，不影响返回值）。
+///
+/// 返回 false = 该 ID 在源上未找到（draft 为 null）；网络/解析失败由
+/// [GalgameMetadataException] 上抛给调用方提示。
+Future<bool> applyGalgameScrapeCandidate({
+  required GalgameRepository repo,
+  required String gameId,
+  required SourceCandidate candidate,
+  GalgameScrapeController? controller,
+}) async {
+  final GalgameScrapeController used =
+      controller ?? GalgameScrapeController.instance;
+  final GalgameMetadataDraft? draft =
+      await used.fetchById(candidate.source, candidate.externalId);
+  if (draft == null) return false;
+  // 多个源都有快照时主显示源记 mixed（契约 §1.1）。
+  final List<GalgameSourceRow> existing = await repo.sourcesOf(gameId);
+  final Set<String> sources = <String>{
+    for (final GalgameSourceRow row in existing) row.source,
+    candidate.source.key,
+  };
+  await repo.saveScrapeResult(
+    gameId: gameId,
+    source: candidate.source,
+    draft: draft,
+    primarySource:
+        sources.length > 1 ? kGalgamePrimarySourceMixed : candidate.source.key,
+  );
+  await _downloadExplicitCover(
+    repo: repo,
+    gameId: gameId,
+    draft: draft,
+    candidate: candidate,
+  );
+  return true;
+}
+
+/// 显式路径的封面落地：优先 draft 的完整封面 URL，缺了退回候选缩略图 URL；
+/// 有 URL 就下载并覆盖 coverPath（用户点名选了这条 = 封面也要这条）。下载失败
+/// 静默降级不打断（原因由 [downloadGalgameCoverToFile] 记 debug 日志）。
+Future<void> _downloadExplicitCover({
+  required GalgameRepository repo,
+  required String gameId,
+  required GalgameMetadataDraft draft,
+  required SourceCandidate candidate,
+}) async {
+  final String? coverUrl = (draft.coverUrl?.trim().isNotEmpty ?? false)
+      ? draft.coverUrl
+      : candidate.coverUrl;
+  if (!shouldDownloadExplicitScrapedCover(coverUrl: coverUrl)) return;
+  final String? saved = await downloadGalgameCoverToFile(
+    gameId: gameId,
+    url: coverUrl!,
+  );
+  if (saved == null) return; // 失败静默：原因已进 debug 日志。
+  // 下载期间条目可能已被移除：仓储按 id 更新，行不在就不写。
+  if (repo.byId(gameId) == null) return;
+  await repo.setCoverPath(gameId, saved);
+}
+
+/// 弹窗主体（导出便于 widget 测试直接构造并注入 [controllerOverride]）。
+class GalgameScrapeDialog extends StatefulWidget {
+  const GalgameScrapeDialog({
+    super.key,
+    required this.game,
+    required this.repo,
+    this.initialQuery,
+    this.controllerOverride,
+  });
+
+  final GalgameEntry game;
+  final GalgameRepository repo;
+
+  /// 搜索框预填词；null 用 [GalgameEntry.displayName]。
+  final String? initialQuery;
+
+  /// 测试注入的编排层；null 用 [GalgameScrapeController.instance]。
+  final GalgameScrapeController? controllerOverride;
+
+  @override
+  State<GalgameScrapeDialog> createState() => _GalgameScrapeDialogState();
+}
+
+class _GalgameScrapeDialogState extends State<GalgameScrapeDialog> {
+  late final TextEditingController _queryCtrl = TextEditingController(
+    text: (widget.initialQuery?.trim().isNotEmpty ?? false)
+        ? widget.initialQuery!.trim()
+        : widget.game.displayName,
+  );
+
+  GalgameScrapeController get _controller =>
+      widget.controllerOverride ?? GalgameScrapeController.instance;
+
+  List<SourceCandidate> _candidates = const <SourceCandidate>[];
+  bool _searching = false;
+  bool _searched = false;
+
+  /// 上一次搜索是否整体失败（全源失败 / 网络异常）。失败态在结果区显示错误行
+  /// （区别于「无匹配」空态），用户可改词或直接重搜——不允许静默塌缩成空列表，
+  /// 也不再是旧实现那样弹个 toast 后无处重试。
+  bool _searchFailed = false;
+
+  /// 正在应用的候选（在其「使用」按钮上转圈；null = 无进行中）。
+  SourceCandidate? _applyingCandidate;
+
+  @override
+  void initState() {
+    super.initState();
+    // 首帧后按预填词自动首搜（与书/视频刮削弹窗同款省一次点击）。
+    WidgetsBinding.instance.addPostFrameCallback((_) => _search());
+  }
+
+  @override
+  void dispose() {
+    _queryCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _search() async {
+    // 贴条目 URL 先归一成源裸 ID（validateId 命中即直取详情），其余输入原样。
+    final String keyword = normalizeGalgameScrapeQuery(_queryCtrl.text.trim());
+    if (keyword.isEmpty || _searching) return;
+    setState(() {
+      _searching = true;
+      _searched = true;
+      _searchFailed = false;
+    });
+    List<SourceCandidate> candidates;
+    bool failed = false;
+    try {
+      // 单源失败已在编排层降级为空（§2.5）；抛出 = 全源失败，必须给可重试的错误态。
+      candidates = (await _controller.search(keyword)).candidates;
+    } catch (_) {
+      candidates = const <SourceCandidate>[];
+      failed = true;
+    }
+    if (!mounted) return;
+    setState(() {
+      _candidates = candidates;
+      _searching = false;
+      _searchFailed = failed;
+    });
+  }
+
+  Future<void> _use(SourceCandidate candidate) async {
+    if (_applyingCandidate != null) return; // 再入守卫：一次应用含多次网络往返。
+    setState(() => _applyingCandidate = candidate);
+    bool applied = false;
+    String? failureMessage;
+    try {
+      applied = await applyGalgameScrapeCandidate(
+        repo: widget.repo,
+        gameId: widget.game.id,
+        candidate: candidate,
+        controller: _controller,
+      );
+    } on GalgameMetadataException catch (e) {
+      failureMessage = '${t.game_scrape_failed}: ${e.message}';
+    } catch (e) {
+      failureMessage = '${t.game_scrape_failed}: $e';
+    }
+    if (!mounted) return;
+    if (!applied) {
+      // 失败：复位转圈（否则按钮永久禁用），弹窗保留让用户改选/重试。
+      setState(() => _applyingCandidate = null);
+      HibikiToast.show(msg: failureMessage ?? t.game_scrape_no_result);
+      return;
+    }
+    Navigator.of(context).pop(true);
+    HibikiToast.show(msg: t.game_scrape_applied);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return HibikiDialogFrame(
+      maxWidth: 480,
+      scrollable: false,
+      child: HibikiModalSheetFrame(
+        title: t.game_scrape,
+        leadingIcon: Icons.cloud_download_outlined,
+        bodyPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          0,
+          tokens.spacing.card,
+          tokens.spacing.gap,
+        ),
+        footerPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          tokens.spacing.gap,
+          tokens.spacing.card,
+          tokens.spacing.card,
+        ),
+        body: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            _buildSearchRow(),
+            SizedBox(height: tokens.spacing.gap),
+            Flexible(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 120),
+                child: _buildResults(Theme.of(context), tokens),
+              ),
+            ),
+          ],
+        ),
+        footer: Wrap(
+          alignment: WrapAlignment.end,
+          spacing: tokens.spacing.gap,
+          runSpacing: tokens.spacing.gap,
+          children: <Widget>[
+            adaptiveDialogAction(
+              context: context,
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(t.dialog_cancel),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSearchRow() {
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: TextField(
+            controller: _queryCtrl,
+            decoration: InputDecoration(
+              isDense: true,
+              hintText: t.game_scrape_query,
+              border: const OutlineInputBorder(),
+            ),
+            onSubmitted: (_) => _search(),
+          ),
+        ),
+        const SizedBox(width: 8),
+        FilledButton(
+          onPressed: _searching ? null : _search,
+          child: Text(t.game_scrape_search),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildResults(ThemeData theme, HibikiDesignTokens tokens) {
+    if (_searching) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_searchFailed) {
+      // 搜索失败错误行：可见反馈 + 重试指引（搜索按钮此时已恢复可点）。
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(Icons.error_outline, color: theme.colorScheme.error),
+            const SizedBox(height: 8),
+            Text(
+              t.game_scrape_search_failed,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: theme.colorScheme.error),
+            ),
+          ],
+        ),
+      );
+    }
+    if (_searched && _candidates.isEmpty) {
+      // 空态收进弹窗内（旧实现 toast 完就散场，用户无处改词重试）。
+      return Center(child: Text(t.game_scrape_no_result));
+    }
+    return ListView.separated(
+      shrinkWrap: true,
+      itemCount: _candidates.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (BuildContext context, int index) =>
+          _buildCandidateTile(theme, tokens, _candidates[index]),
+    );
+  }
+
+  Widget _buildCandidateTile(
+    ThemeData theme,
+    HibikiDesignTokens tokens,
+    SourceCandidate candidate,
+  ) {
+    final String metaLine = <String>[
+      candidate.source.label,
+      candidate.externalId,
+      if (candidate.releaseDate != null) candidate.releaseDate!,
+    ].join(' · ');
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          _buildThumb(tokens, candidate.coverUrl),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  candidate.displayName,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 2),
+                  child: Text(
+                    metaLine,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          FilledButton.tonal(
+            onPressed:
+                _applyingCandidate != null ? null : () => _use(candidate),
+            child: identical(_applyingCandidate, candidate)
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Text(t.game_scrape_use),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 46×66 封面缩略图：无 URL / 加载失败降级为占位图标（不进网络加载路径）。
+  Widget _buildThumb(HibikiDesignTokens tokens, String? coverUrl) {
+    final Widget placeholder = Container(
+      color: tokens.surfaces.overlay,
+      child: Icon(
+        Icons.image_not_supported_outlined,
+        size: 20,
+        color: tokens.surfaces.onVariant,
+      ),
+    );
+    return SizedBox(
+      width: 46,
+      height: 66,
+      child: ClipRRect(
+        // 行内小缩略图与书籍刮削弹窗同级，用 chip 语义圆角。
+        borderRadius: HibikiBorderRadius.chip,
+        child: (coverUrl == null || coverUrl.trim().isEmpty)
+            ? placeholder
+            : Image.network(
+                coverUrl,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => placeholder,
+              ),
+      ),
+    );
+  }
+}

--- a/hibiki/lib/src/mining/galgame_scrape_dialog.dart
+++ b/hibiki/lib/src/mining/galgame_scrape_dialog.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:hibiki_core/hibiki_core.dart' show GalgameSourceRow;
@@ -19,8 +20,8 @@ import 'package:hibiki/utils.dart';
 /// 一步到位：打开即按当前显示名自动首搜，搜索框可改词重搜，候选带封面缩略图 +
 /// `源 · ID · 发行日` 副行，每行「使用」行内转圈；点「使用」= `fetchById` 补全
 /// → [GalgameRepository.saveScrapeResult]（多源 primarySource 记 mixed 规则不变）
-/// → **封面与元数据一起落**（显式语义：覆盖现有封面，见
-/// [shouldDownloadExplicitScrapedCover]）。
+/// → **封面与元数据一起落**（遵守游戏岛封面纪律：只在无可用封面文件时下载，
+/// 既有封面绝不覆盖，见 [shouldAutoDownloadScrapedCover]）。
 ///
 /// 返回 true = 已成功落库（调用方据此刷新库页 / 重载详情页）；false/取消 = 无写库。
 Future<bool> showGalgameScrapeDialog({
@@ -100,7 +101,7 @@ Uri? _tryParseEntryUrl(String input) {
 /// 落库一条**用户显式选中**的候选（库页与详情页共用，取代旧 `_scrape()` 的落库段）：
 /// `fetchById` 补全 draft → [GalgameRepository.saveScrapeResult]（多源快照时
 /// primarySource 记 [kGalgamePrimarySourceMixed]，单源记该源 key——规则不变）→
-/// 显式封面下载（覆盖现有封面；下载失败静默降级，不影响返回值）。
+/// 封面下载（**只在该游戏还没有可用封面文件时**；下载失败静默降级，不影响返回值）。
 ///
 /// 返回 false = 该 ID 在源上未找到（draft 为 null）；网络/解析失败由
 /// [GalgameMetadataException] 上抛给调用方提示。
@@ -128,7 +129,7 @@ Future<bool> applyGalgameScrapeCandidate({
     primarySource:
         sources.length > 1 ? kGalgamePrimarySourceMixed : candidate.source.key,
   );
-  await _downloadExplicitCover(
+  await _downloadScrapedCover(
     repo: repo,
     gameId: gameId,
     draft: draft,
@@ -137,19 +138,33 @@ Future<bool> applyGalgameScrapeCandidate({
   return true;
 }
 
-/// 显式路径的封面落地：优先 draft 的完整封面 URL，缺了退回候选缩略图 URL；
-/// 有 URL 就下载并覆盖 coverPath（用户点名选了这条 = 封面也要这条）。下载失败
-/// 静默降级不打断（原因由 [downloadGalgameCoverToFile] 记 debug 日志）。
-Future<void> _downloadExplicitCover({
+/// 刮削候选落地后的封面补齐：优先 draft 的完整封面 URL，缺了退回候选缩略图 URL。
+///
+/// 决策走 [shouldAutoDownloadScrapedCover]——游戏岛只有「封面文件是否存在」这一条
+/// 保护判据（无 [CoverOrigin] 元数据），所以**已有可用封面一律不覆盖**，用户手选
+/// 的封面不会被刮削悄悄换掉。想换封面走卡菜单的「选择封面图片」/「自动封面」。
+/// 下载失败静默降级不打断（原因由 [downloadGalgameCoverToFile] 记 debug 日志）。
+Future<void> _downloadScrapedCover({
   required GalgameRepository repo,
   required String gameId,
   required GalgameMetadataDraft draft,
   required SourceCandidate candidate,
 }) async {
+  // 读**落库后**的最新条目：saveScrapeResult 可能刚写过 coverPath。
+  final GalgameEntry? latest = repo.byId(gameId);
+  if (latest == null) return;
+  final String? existing = latest.coverPath;
+  final bool hasUsableCoverFile =
+      existing != null && existing.isNotEmpty && File(existing).existsSync();
   final String? coverUrl = (draft.coverUrl?.trim().isNotEmpty ?? false)
       ? draft.coverUrl
       : candidate.coverUrl;
-  if (!shouldDownloadExplicitScrapedCover(coverUrl: coverUrl)) return;
+  if (!shouldAutoDownloadScrapedCover(
+    hasUsableCoverFile: hasUsableCoverFile,
+    coverUrl: coverUrl,
+  )) {
+    return;
+  }
   final String? saved = await downloadGalgameCoverToFile(
     gameId: gameId,
     url: coverUrl!,

--- a/hibiki/lib/src/pages/implementations/downloads_page.dart
+++ b/hibiki/lib/src/pages/implementations/downloads_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:hibiki/src/media/manga/online/mokuro_moe_catalog_dialog.dart';
+import 'package:hibiki/src/media/manga/manga_module.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_tasks_section.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/pages/implementations/anime_download_dialog.dart';
@@ -30,11 +30,14 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
   late bool _showSettings = widget.initialShowSettings;
 
   /// 漫画「在线目录」入口（统一下载中心：书/漫画获取入口与 torrent 并列）。
+  ///
+  /// 书架页与书籍导入框的旧入口已收敛到这里，故本页是
+  /// [MangaModule.openOnlineCatalog] 的唯一消费方——目录弹窗的构造统一收在
+  /// 漫画模块里，不在页面层直接 new 它。
   Future<void> _openMangaCatalog() async {
-    await showAppDialog<void>(
+    await MangaModule.openOnlineCatalog(
       context: context,
-      builder: (_) =>
-          MokuroMoeCatalogDialog(db: ref.read(appProvider).database),
+      db: ref.read(appProvider).database,
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/galgame_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_detail_page.dart
@@ -8,11 +8,10 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'package:hibiki/models.dart';
 import 'package:hibiki/src/media/collections/add_to_collection_dialog.dart';
-import 'package:hibiki/src/mining/galgame_cover_download.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/mining/galgame_repository.dart';
 import 'package:hibiki/src/mining/galgame_scrape_controller.dart';
-import 'package:hibiki/src/mining/metadata/galgame_metadata_adapter.dart';
+import 'package:hibiki/src/mining/galgame_scrape_dialog.dart';
 import 'package:hibiki/src/mining/metadata/galgame_metadata_draft.dart';
 import 'package:hibiki/src/mining/metadata/galgame_metadata_merge.dart';
 import 'package:hibiki/src/mining/metadata/galgame_metadata_source.dart';
@@ -845,8 +844,6 @@ class _GalgameEditTabState extends State<_GalgameEditTab> {
       TextEditingController(text: widget.game.launchArgs);
   late bool _nsfw = widget.game.customData.nsfw ?? false;
 
-  bool _scraping = false;
-
   @override
   void dispose() {
     for (final TextEditingController c in <TextEditingController>[
@@ -909,106 +906,20 @@ class _GalgameEditTabState extends State<_GalgameEditTab> {
     HibikiToast.show(msg: t.game_edit_saved);
   }
 
-  /// 刮削：输入标题或源 ID → 搜索 → 多结果让用户选 → 取详情 → 落库。
+  /// 刮削：打开统一刮削弹窗（与库页卡菜单「刮削元数据」同一个入口，
+  /// [showGalgameScrapeDialog]）。搜索/候选/落库/封面全部在弹窗内闭环；
+  /// 预填词取编辑框里的名字（用户可能刚改过），空则退回当前显示名。
   Future<void> _scrape() async {
-    if (_scraping) return; // 再入守卫：一次刮削含多次网络往返。
-    final String? query = await showAppDialog<String>(
+    final bool applied = await showGalgameScrapeDialog(
       context: context,
-      builder: (BuildContext ctx) => _ScrapeQueryDialog(
-        initial: _name.text.trim().isEmpty
-            ? widget.game.displayName
-            : _name.text.trim(),
-      ),
+      game: widget.game,
+      repo: widget.repo,
+      initialQuery: _name.text.trim().isEmpty
+          ? widget.game.displayName
+          : _name.text.trim(),
     );
-    if (query == null || query.isEmpty) return;
-    _scraping = true;
-    setState(() {});
-    try {
-      final GalgameScrapeSearchResult result =
-          await GalgameScrapeController.instance.search(query);
-      if (!mounted) return;
-      if (result.isEmpty) {
-        HibikiToast.show(msg: t.game_scrape_no_result);
-        return;
-      }
-      SourceCandidate? picked = result.candidates.length == 1
-          ? result.candidates.first
-          : await showAppDialog<SourceCandidate>(
-              context: context,
-              builder: (BuildContext ctx) =>
-                  _SourcePickerDialog(candidates: result.candidates),
-            );
-      if (picked == null || !mounted) return;
-      final GalgameMetadataDraft? draft = await GalgameScrapeController.instance
-          .fetchById(picked.source, picked.externalId);
-      if (!mounted) return;
-      if (draft == null) {
-        HibikiToast.show(msg: t.game_scrape_no_result);
-        return;
-      }
-      // 多个源都有快照时主显示源记 mixed（契约 §1.1）。
-      final List<GalgameSourceRow> existing =
-          await widget.repo.sourcesOf(widget.game.id);
-      final Set<String> sources = <String>{
-        for (final GalgameSourceRow row in existing) row.source,
-        picked.source.key,
-      };
-      await widget.repo.saveScrapeResult(
-        gameId: widget.game.id,
-        source: picked.source,
-        draft: draft,
-        primarySource:
-            sources.length > 1 ? kGalgamePrimarySourceMixed : picked.source.key,
-      );
-      await widget.onSaved();
-      if (!mounted) return;
-      HibikiToast.show(msg: t.game_scrape_applied);
-      // 刮削封面落地：仅当该游戏当前无可用封面文件时自动下载 coverUrl 并写
-      // coverPath；已有封面（手选/自动/上次下载）绝不覆盖。失败静默降级（元数据
-      // 本身已成功），原因由下载函数记 debug 日志。
-      await _maybeDownloadScrapedCover();
-    } on GalgameMetadataException catch (e) {
-      if (!mounted) return;
-      HibikiToast.show(msg: '${t.game_scrape_failed}: ${e.message}');
-    } catch (e) {
-      if (!mounted) return;
-      HibikiToast.show(msg: '${t.game_scrape_failed}: $e');
-    } finally {
-      _scraping = false;
-      if (mounted) setState(() {});
-    }
-  }
-
-  /// 刮削成功后的封面落地（决策纯函数 [shouldAutoDownloadScrapedCover] 可单测）：
-  /// 读**重载后**的最新条目（合并层已按优先级/手选源算好 coverUrl），无可用封面
-  /// 文件才下载；落盘（含双键驱逐旧解码缓存）由 [downloadGalgameCoverToFile] →
-  /// `MediaCoverService.applyCoverBytes` 收口结构性保证，随后写 coverPath 并复用
-  /// `t.game_cover_updated` 提示。
-  Future<void> _maybeDownloadScrapedCover() async {
-    final GalgameEntry? latest = widget.repo.byId(widget.game.id);
-    if (latest == null) return;
-    final String? coverPath = latest.coverPath;
-    final bool hasUsableCoverFile = coverPath != null &&
-        coverPath.isNotEmpty &&
-        File(coverPath).existsSync();
-    final String? coverUrl = latest.metadata.coverUrl;
-    if (!shouldAutoDownloadScrapedCover(
-      hasUsableCoverFile: hasUsableCoverFile,
-      coverUrl: coverUrl,
-    )) {
-      return;
-    }
-    final String? saved = await downloadGalgameCoverToFile(
-      gameId: latest.id,
-      url: coverUrl!,
-    );
-    if (saved == null) return; // 失败静默：原因已进 debug 日志。
-    // 下载期间条目可能已被移除：仓储按 id 更新，行不在就不写。
-    if (widget.repo.byId(latest.id) == null) return;
-    await widget.repo.setCoverPath(latest.id, saved);
+    if (!applied || !mounted) return;
     await widget.onSaved();
-    if (!mounted) return;
-    HibikiToast.show(msg: t.game_cover_updated);
   }
 
   @override
@@ -1020,7 +931,8 @@ class _GalgameEditTabState extends State<_GalgameEditTab> {
           children: <Widget>[
             Expanded(
               child: OutlinedButton.icon(
-                onPressed: _scraping ? null : () => unawaited(_scrape()),
+                // 再入守卫在统一弹窗内（每行「使用」行内转圈），按钮无需禁用态。
+                onPressed: () => unawaited(_scrape()),
                 icon: const Icon(Icons.cloud_download_outlined),
                 label: Text(t.game_scrape),
               ),
@@ -1113,114 +1025,5 @@ double? parseGalgameRating(String raw) {
   return value.clamp(0, 10).toDouble();
 }
 
-/// 刮削关键词输入框（标题或源 ID）。
-class _ScrapeQueryDialog extends StatefulWidget {
-  const _ScrapeQueryDialog({required this.initial});
-
-  final String initial;
-
-  @override
-  State<_ScrapeQueryDialog> createState() => _ScrapeQueryDialogState();
-}
-
-class _ScrapeQueryDialogState extends State<_ScrapeQueryDialog> {
-  late final TextEditingController _controller =
-      TextEditingController(text: widget.initial);
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
-    return HibikiDialogFrame(
-      maxWidth: 420,
-      scrollable: false,
-      child: HibikiModalSheetFrame(
-        title: t.game_scrape,
-        scrollable: true,
-        bodyPadding: EdgeInsets.fromLTRB(
-          tokens.spacing.card,
-          0,
-          tokens.spacing.card,
-          tokens.spacing.gap,
-        ),
-        footerPadding: EdgeInsets.fromLTRB(
-          tokens.spacing.card,
-          tokens.spacing.gap,
-          tokens.spacing.card,
-          tokens.spacing.card,
-        ),
-        body: HibikiTextField(
-          controller: _controller,
-          labelText: t.game_scrape_query,
-          autofocus: true,
-          onSubmitted: (String v) => Navigator.of(context).pop(v.trim()),
-        ),
-        footer: Wrap(
-          alignment: WrapAlignment.end,
-          spacing: tokens.spacing.gap,
-          runSpacing: tokens.spacing.gap,
-          children: <Widget>[
-            adaptiveDialogAction(
-              context: context,
-              onPressed: () => Navigator.of(context).pop(),
-              child: Text(t.dialog_cancel),
-            ),
-            adaptiveDialogAction(
-              context: context,
-              isDefaultAction: true,
-              onPressed: () =>
-                  Navigator.of(context).pop(_controller.text.trim()),
-              child: Text(t.dialog_ok),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-/// 多结果候选列表（契约 §2.5）：选中后由调用方 `fetchById` 补全。
-class _SourcePickerDialog extends StatelessWidget {
-  const _SourcePickerDialog({required this.candidates});
-
-  final List<SourceCandidate> candidates;
-
-  @override
-  Widget build(BuildContext context) {
-    return SimpleDialog(
-      title: Text(t.game_scrape_pick),
-      children: <Widget>[
-        for (final SourceCandidate c in candidates)
-          SimpleDialogOption(
-            onPressed: () => Navigator.of(context).pop(c),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  c.displayName,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.bodyLarge,
-                ),
-                Text(
-                  <String>[
-                    c.source.label,
-                    c.externalId,
-                    if (c.releaseDate != null) c.releaseDate!,
-                  ].join('  ·  '),
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      ),
-                ),
-              ],
-            ),
-          ),
-      ],
-    );
-  }
-}
+// （旧 `_ScrapeQueryDialog` / `_SourcePickerDialog` 已被统一刮削弹窗
+// `showGalgameScrapeDialog` 取代：单弹窗内搜索 + 带缩略图候选 + 行内应用。）

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -955,8 +955,9 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
         headerFocusId: HibikiFocusId('games-collection-${collection.id}'),
         onOpenDetail: () => _openCollectionDetail(collection),
         // 合集行右键/长按：三库页统一的合集上下文菜单（打开详情/重命名/标签/
-        // 删除合集）。不传 onDeleteMembersMedia——删合集绝不删游戏本体（游戏
-        // 本体是用户安装目录，与 [_openCollectionDetail] 的保守端纪律一致）。
+        // 删除合集）。删除支持「连同游戏一起删」勾选，与书/视频对称；语义同
+        // [_removeGame]：**只从库移除**，绝不删磁盘上的游戏安装目录（确认框
+        // 勾选文案明说这点）。
         onContextMenu: () => unawaited(
           showCollectionContextDialog(
             context: context,
@@ -964,6 +965,8 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
             collection: collection,
             onOpenDetail: () => _openCollectionDetail(collection),
             onChanged: () => unawaited(_reload()),
+            onDeleteMembersMedia: _removeCollectionMemberGames,
+            deleteMembersCheckboxLabel: t.delete_collection_also_games,
           ),
         ),
         collapsed: _appModel.prefsRepo.gamesCollapsedCollectionIds
@@ -973,6 +976,21 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
             _buildGameCard(group.items[i].payload),
       ),
     );
+  }
+
+  /// 删合集时勾选「连同游戏一起删」的成员处置（与书/视频合集菜单对称）。
+  ///
+  /// 语义与卡菜单「移除游戏」完全一致：[GalgameRepository.remove] 只删库行
+  /// （元数据源/游玩会话经 FK cascade 连带清理），**绝不碰磁盘上的游戏安装
+  /// 目录**。混合合集里的书/视频成员跳过不误删（与视频页同一道防御）。
+  Future<void> _removeCollectionMemberGames(
+    List<MediaCollectionItemRow> members,
+  ) async {
+    for (final MediaCollectionItemRow m in members) {
+      if (MediaKind.tryParse(m.mediaType) != MediaKind.game) continue;
+      if (_repo.byId(m.entryKey) == null) continue;
+      await _repo.remove(m.entryKey);
+    }
   }
 
   /// 单张游戏卡（散卡网格与合集行内共用同一构造，回调全量接线）。

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -9,6 +9,7 @@ import 'package:hibiki_core/hibiki_core.dart';
 import 'package:hibiki/models.dart';
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
 import 'package:hibiki/src/media/collections/add_to_collection_dialog.dart';
+import 'package:hibiki/src/media/collections/collection_context_dialog.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart'
     show CollectionShelfRow;
@@ -22,6 +23,7 @@ import 'package:hibiki/src/mining/galgame_helper_installer.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/mining/galgame_library_query.dart';
 import 'package:hibiki/src/mining/galgame_repository.dart';
+import 'package:hibiki/src/mining/galgame_scrape_dialog.dart';
 import 'package:hibiki/src/pages/implementations/galgame_detail_page.dart';
 import 'package:hibiki/src/pages/implementations/media_collection_grid_detail_page.dart';
 import 'package:hibiki/src/pages/implementations/media_item_dialog_page.dart'
@@ -251,7 +253,21 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   }
 
   /// 移除一个游戏（按 id 定位；元数据源与游玩会话经 FK cascade 连带清理）。
+  ///
+  /// 先弹统一确认框（与书架/合集同款 [HibikiDestructiveConfirmDialog]）：语义
+  /// 只是**从库移除**，绝不删磁盘上的游戏文件——确认文案明说这点，免得用户
+  /// 不敢点或误以为会连本体一起没。
   Future<void> _removeGame(GalgameEntry game) async {
+    final HibikiDestructiveConfirmResult? result =
+        await showAppDialog<HibikiDestructiveConfirmResult>(
+      context: context,
+      builder: (_) => HibikiDestructiveConfirmDialog(
+        title: t.game_remove,
+        message: t.game_remove_confirm,
+        confirmLabel: t.game_remove,
+      ),
+    );
+    if (result == null || !mounted) return;
     await _repo.remove(game.id);
     _refresh();
   }
@@ -277,33 +293,49 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   }
 
   /// 弹状态选择对话框（菜单顺序：想玩 → 在玩 → 玩过 → 搁置 → 弃坑 + 未设置）。
+  /// 走设计系统骨架（HibikiDialogFrame + HibikiModalSheetFrame + HibikiListItem，
+  /// 替代旧裸 SimpleDialog）；radio 行为不变：点任意行即 pop 该状态。
   Future<void> _promptPlayStatus(GalgameEntry game) async {
     final GalgamePlayStatus? picked = await showAppDialog<GalgamePlayStatus>(
       context: context,
-      builder: (BuildContext ctx) => SimpleDialog(
-        title: Text(t.game_play_status),
-        children: <Widget>[
-          for (final GalgamePlayStatus status in <GalgamePlayStatus>[
-            ...kGalgamePlayStatusMenuOrder,
-            GalgamePlayStatus.unset,
-          ])
-            SimpleDialogOption(
-              onPressed: () => Navigator.of(ctx).pop(status),
-              child: Row(
-                children: <Widget>[
-                  Icon(
-                    game.playStatus == status
-                        ? Icons.radio_button_checked
-                        : Icons.radio_button_unchecked,
-                    size: 18,
-                  ),
-                  const SizedBox(width: 12),
-                  Text(galgamePlayStatusLabel(status)),
-                ],
-              ),
+      builder: (BuildContext ctx) {
+        final HibikiDesignTokens tokens = HibikiDesignTokens.of(ctx);
+        return HibikiDialogFrame(
+          maxWidth: 420,
+          scrollable: false,
+          child: HibikiModalSheetFrame(
+            title: t.game_play_status,
+            leadingIcon: Icons.flag_outlined,
+            scrollable: true,
+            bodyPadding: EdgeInsets.fromLTRB(
+              tokens.spacing.gap,
+              0,
+              tokens.spacing.gap,
+              tokens.spacing.card,
             ),
-        ],
-      ),
+            body: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                for (final GalgamePlayStatus status in <GalgamePlayStatus>[
+                  ...kGalgamePlayStatusMenuOrder,
+                  GalgamePlayStatus.unset,
+                ])
+                  HibikiListItem(
+                    density: HibikiListDensity.compact,
+                    leading: Icon(
+                      game.playStatus == status
+                          ? Icons.radio_button_checked
+                          : Icons.radio_button_unchecked,
+                      size: 18,
+                    ),
+                    title: Text(galgamePlayStatusLabel(status)),
+                    onTap: () => Navigator.of(ctx).pop(status),
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
     );
     if (picked == null || picked == game.playStatus) return;
     await _setPlayStatus(game, picked);
@@ -323,6 +355,18 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
         ),
       ),
     );
+    await _reload();
+  }
+
+  /// 卡菜单「刮削元数据」：直接打开统一刮削弹窗（消灭旧「先进详情页编辑 tab
+  /// 再点一次刮削」的二跳）。落库成功后整页重载（含合集分组映射）。
+  Future<void> _scrapeGame(GalgameEntry game) async {
+    final bool applied = await showGalgameScrapeDialog(
+      context: context,
+      game: game,
+      repo: _repo,
+    );
+    if (!applied || !mounted) return;
     await _reload();
   }
 
@@ -910,6 +954,18 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
         itemGap: 16,
         headerFocusId: HibikiFocusId('games-collection-${collection.id}'),
         onOpenDetail: () => _openCollectionDetail(collection),
+        // 合集行右键/长按：三库页统一的合集上下文菜单（打开详情/重命名/标签/
+        // 删除合集）。不传 onDeleteMembersMedia——删合集绝不删游戏本体（游戏
+        // 本体是用户安装目录，与 [_openCollectionDetail] 的保守端纪律一致）。
+        onContextMenu: () => unawaited(
+          showCollectionContextDialog(
+            context: context,
+            db: _appModel.database,
+            collection: collection,
+            onOpenDetail: () => _openCollectionDetail(collection),
+            onChanged: () => unawaited(_reload()),
+          ),
+        ),
         collapsed: _appModel.prefsRepo.gamesCollapsedCollectionIds
             .contains(collection.id),
         onToggleCollapsed: () => _toggleCollectionCollapsed(collection.id),
@@ -931,7 +987,7 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
       onAutoCover: () => unawaited(_autoCover(game)),
       onPlayStatus: () => unawaited(_promptPlayStatus(game)),
       onDetail: () => unawaited(_openDetail(game)),
-      onScrape: () => unawaited(_openDetail(game, initialTab: 2)),
+      onScrape: () => unawaited(_scrapeGame(game)),
       onAddToCollection: () => unawaited(_addGameToCollection(game)),
       onEditTags: () => unawaited(_openTagPicker(game)),
     );
@@ -1186,6 +1242,9 @@ class _GameCard extends StatelessWidget {
 
   /// 卡片菜单项单一真相源：`(action, 文案, 图标, 危险区)`。溢出菜单与长按/右键
   /// 对话框都从这一份生成，任一处漏项测试即红。
+  ///
+  /// 次序遵守三库页统一约定：重命名 → 封面类 → 刮削 → 加入合集 → 标签 → 删除；
+  /// 游戏特有的「查看详情 / 游玩状态」保持最前。
   List<_GameMenuItem> get _menuItems => <_GameMenuItem>[
         (
           action: 'detail',
@@ -1197,12 +1256,6 @@ class _GameCard extends StatelessWidget {
           action: 'status',
           label: t.game_play_status,
           icon: Icons.flag_outlined,
-          danger: false,
-        ),
-        (
-          action: 'scrape',
-          label: t.game_scrape,
-          icon: Icons.cloud_download_outlined,
           danger: false,
         ),
         (
@@ -1221,6 +1274,12 @@ class _GameCard extends StatelessWidget {
           action: 'autocover',
           label: t.game_auto_cover,
           icon: Icons.image_search,
+          danger: false,
+        ),
+        (
+          action: 'scrape',
+          label: t.game_scrape,
+          icon: Icons.cloud_download_outlined,
           danger: false,
         ),
         (

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -46,6 +46,7 @@ import 'package:hibiki/src/pages/implementations/book_drag_target.dart';
 import 'package:hibiki/src/pages/implementations/collections_page.dart';
 import 'package:hibiki/src/media/collections/add_to_collection_dialog.dart';
 import 'package:hibiki/src/media/collections/batch_combine.dart';
+import 'package:hibiki/src/media/collections/collection_context_dialog.dart';
 import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
@@ -1522,15 +1523,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         cover: _buildCover(book),
         title: book.title,
         showLaunchAction: false,
+        // 统一三库页卡菜单次序：重命名 → 封面/刮削 → 媒体特有 → 加入合集 →
+        // 标签 → 删除（与书卡/游戏卡同一约定；「标签」原在首位，移到合集后）。
         quickActions: <DialogQuickAction>[
-          DialogQuickAction(
-            label: t.tag_label,
-            icon: Icons.sell_outlined,
-            onPressed: () {
-              Navigator.pop(dialogContext);
-              _editTags(book);
-            },
-          ),
           DialogQuickAction(
             label: t.video_rename,
             icon: Icons.drive_file_rename_outline,
@@ -1577,6 +1572,14 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
             onPressed: () {
               Navigator.pop(dialogContext);
               _addToCollection(book);
+            },
+          ),
+          DialogQuickAction(
+            label: t.tag_label,
+            icon: Icons.sell_outlined,
+            onPressed: () {
+              Navigator.pop(dialogContext);
+              _editTags(book);
             },
           ),
         ],
@@ -1769,6 +1772,8 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         _autoScrape?.forget(book.bookUid);
         await _maybeAutoScrape();
       },
+      // 添加/修改 Bangumi 映射：跳到在线匹配弹窗（可搜索或贴条目 ID/URL 改绑）。
+      onEditMapping: () => _openCoverMatch(book),
     );
   }
 
@@ -2498,6 +2503,12 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       onTap: _selectionMode
           ? () => _toggleCollectionSelection(collection.id)
           : () => _openCollectionDetail(collection),
+      // 合集卡长按/右键 = 合集上下文菜单（统一三库页：打开/重命名/标签/删除）；
+      // 多选态压制，与散卡长按菜单同一纪律。
+      onLongPress:
+          _selectionMode ? null : () => _showCollectionContextMenu(collection),
+      onSecondaryTap:
+          _selectionMode ? null : () => _showCollectionContextMenu(collection),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
@@ -3127,6 +3138,41 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         itemCount: cells.length,
         itemBuilder: (BuildContext context, int i) => cells[i](),
       ),
+    );
+  }
+
+  /// 合集封面卡长按/右键菜单（统一三库页合集菜单）：打开/重命名/标签/删除，动作
+  /// 语义与合集详情页 AppBar 同源；删除支持「连同视频一起删」勾选（与详情页
+  /// `onDeleteMembersMedia` 同一删除纪律）。
+  Future<void> _showCollectionContextMenu(MediaCollectionRow collection) {
+    final VideoBookRepository repo = widget.repo;
+    final HibikiDatabase db = ref.read(appProvider).database;
+    return showCollectionContextDialog(
+      context: context,
+      db: db,
+      collection: collection,
+      onOpenDetail: () => _openCollectionDetail(collection),
+      onChanged: () {
+        ref.invalidate(collectionTagMapProvider);
+        ref.invalidate(filteredCollectionIdsProvider);
+        _refresh();
+      },
+      onDeleteMembersMedia: (List<MediaCollectionItemRow> members) async {
+        bool anyVideo = false;
+        for (final MediaCollectionItemRow m in members) {
+          // 视频合集理论上只含 video 成员；混入的未知/跨域成员跳过不误删。
+          if (MediaKind.tryParse(m.mediaType) != MediaKind.video) continue;
+          await repo.deleteVideoBookAndReclaimAssets(
+            m.entryKey,
+            compactDatabase: false,
+          );
+          anyVideo = true;
+        }
+        if (anyVideo) {
+          await repo.compactAfterVideoDeleteBestEffort();
+        }
+      },
+      deleteMembersCheckboxLabel: t.delete_collection_also_videos,
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -1903,15 +1903,6 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
           icon: Icons.collections_bookmark_outlined,
           onPressed: () => _addEpubToCollection(item, bookKey),
         ),
-      // 统一三库页卡菜单：书卡补「标签」项（视频/游戏卡菜单已有；书此前只能
-      // 拖标签或批量打标签）。
-      DialogListAction(
-        label: t.tag_label,
-        icon: Icons.sell_outlined,
-        onPressed: () => _openMediaTagPicker(
-          MediaRef(kind: MediaKind.epub, entryKey: bookKey),
-        ),
-      ),
       DialogListAction(
         label: t.profile_book_profile,
         icon: Icons.account_circle_outlined,
@@ -1957,24 +1948,6 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     ref.invalidate(hibikiBooksProvider(JapaneseLanguage.instance));
     ref.invalidate(srtBooksProvider);
     _rebuild(() {});
-  }
-
-  /// 单卡「标签」（统一三库页卡菜单）：先收起长按菜单，进共享标签池的
-  /// [TagPickerPage]（媒体路，epub/srt 通用）；返回后失效标签 map 与筛选
-  /// provider，卡面 chip 与标签过滤立即刷新。
-  Future<void> _openMediaTagPicker(MediaRef media) async {
-    Navigator.pop(context);
-    await Navigator.push(
-      context,
-      adaptivePageRoute<void>(
-        context: context,
-        builder: (_) => TagPickerPage(media: media),
-      ),
-    );
-    if (!mounted) return;
-    ref.invalidate(bookTagMapProvider);
-    ref.invalidate(filteredBookIdsProvider);
-    ref.invalidate(filteredSrtBookIdsProvider);
   }
 
   /// 单卡「加入合集」（EPUB 卡菜单入口）：先收起长按菜单，再弹共享的合集选择

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -20,7 +20,6 @@ import 'package:hibiki/src/media/drag_drop/drop_decision.dart';
 import 'package:hibiki/src/media/display_title.dart';
 import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
 import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
-import 'package:hibiki/src/media/manga/online/mokuro_moe_catalog_dialog.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_download_queue.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/media/video/video_feature_flags.dart';
@@ -39,6 +38,9 @@ import 'package:hibiki/src/pages/implementations/book_css_editor_page.dart';
 import 'package:hibiki/src/pages/implementations/illustrations_viewer_page.dart';
 import 'package:hibiki/src/media/collections/add_to_collection_dialog.dart';
 import 'package:hibiki/src/media/collections/batch_combine.dart';
+import 'package:hibiki/src/media/collections/collection_context_dialog.dart';
+import 'package:hibiki/src/media/media_cover_service.dart';
+import 'package:hibiki/src/media/metadata/book_cover_scrape_dialog.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
 import 'package:hibiki/src/media/media_search_text.dart';
@@ -565,14 +567,9 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             icon: Icons.folder_copy_outlined,
             onTap: _openManageSources,
           ),
-        // 漫画「在线目录」（O1 mokuro.moe 目录源）：浏览/搜索 → 卷级下载 →
-        // 现有 .mokuro 导入链落库。
-        if (_mangaOnly)
-          _headerAction(
-            tooltip: t.manga_online_catalog_title,
-            icon: Icons.cloud_download_outlined,
-            onTap: _openOnlineCatalog,
-          ),
+        // 漫画「在线目录」入口已从书架移除（属漫画域，入口收敛到下载页）；
+        // mokuro.moe 下载队列监听仍保留在 initState——下载页触发的后台落库
+        // 依赖它刷新书架。
         // 视频导入入口**只属于视频 tab**（HomeVideoPage），书架不放视频导入——
         // 书架是书的地方。这里保留编译期常量门控（默认关）只为旧调试路径，运行时
         // 实验开关不再在书架放出视频导入（用户反馈：书架不该有视频导入入口）。
@@ -620,16 +617,6 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     if (!mounted) return;
     ref.invalidate(hibikiBooksProvider(JapaneseLanguage.instance));
     ref.invalidate(srtBooksProvider);
-  }
-
-  /// 打开漫画「在线目录」对话框。下载/导入在共享队列后台进行（统一下载中心，
-  /// 关对话框不中断）；书架刷新由 initState 挂的队列监听按 importedCount 增量
-  /// 触发，不再依赖对话框关闭回传。
-  Future<void> _openOnlineCatalog() async {
-    await showAppDialog<void>(
-      context: context,
-      builder: (_) => MokuroMoeCatalogDialog(db: appModel.database),
-    );
   }
 
   void _openCollections() {
@@ -1420,6 +1407,8 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
         // 拖标签到行头 = 给整个合集打标签（与散书书级拖放一致）。
         onTagDropped: (BookTagRow tag) =>
             _addTagToCollection(collection.id, tag),
+        // 行头长按/右键 = 合集上下文菜单（统一三库页：打开/重命名/标签/删除）。
+        onContextMenu: () => _showCollectionContextMenu(collection),
         // 行头下方展示该合集已打的标签 chip（与散书标签列同形）。
         tags: ref.watch(collectionTagMapProvider).valueOrNull?[collection.id],
         itemBuilder: (BuildContext _, int i) => _buildShelfMemberCard(
@@ -1532,6 +1521,29 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
       ),
       alignment: Alignment.topCenter,
       fit: _bookCardCoverFit,
+    );
+  }
+
+  /// 合集行头长按/右键菜单（统一三库页合集菜单）：打开/重命名/标签/删除，动作
+  /// 语义与合集详情页 AppBar 同源；删除支持「连同书一起删」勾选（复用
+  /// [_deleteCollectionMembersMedia] 分派纪律）。
+  Future<void> _showCollectionContextMenu(MediaCollectionRow collection) {
+    return showCollectionContextDialog(
+      context: context,
+      db: appModel.database,
+      collection: collection,
+      onOpenDetail: () => _openCollectionDetail(collection),
+      onChanged: () {
+        // 改名/删除影响折叠映射；标签影响行头 chip；删本体影响书架条目。
+        ref.invalidate(collectionTagMapProvider);
+        ref.invalidate(filteredCollectionIdsProvider);
+        ref.invalidate(hibikiBooksProvider(JapaneseLanguage.instance));
+        ref.invalidate(srtBooksProvider);
+        _shelfMapsFuture = _loadShelfMaps();
+        if (mounted) setState(() {});
+      },
+      onDeleteMembersMedia: _deleteCollectionMembersMedia,
+      deleteMembersCheckboxLabel: t.delete_collection_also_books,
     );
   }
 
@@ -1876,6 +1888,13 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             : Icons.check_circle_outline,
         onPressed: () => _toggleBookCompleted(bookKey),
       ),
+      // 统一三库页刮削入口：书卡菜单直达「在线刮削封面」（视频/游戏的刮削都在
+      // 卡菜单一层，书此前必须绕「编辑信息→封面字段小图标」两层，用户实报）。
+      DialogListAction(
+        label: t.book_scrape_cover,
+        icon: Icons.image_search_outlined,
+        onPressed: () => _scrapeEpubCover(item),
+      ),
       // 单卡「加入合集」：与批量三档共用同一 DAO 路径；entryKey 编码与
       // shelfSelectionToEntry 对 epub 选择键的解码一致（= bookKey）。
       if (!inCollectionDetail)
@@ -1884,6 +1903,15 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
           icon: Icons.collections_bookmark_outlined,
           onPressed: () => _addEpubToCollection(item, bookKey),
         ),
+      // 统一三库页卡菜单：书卡补「标签」项（视频/游戏卡菜单已有；书此前只能
+      // 拖标签或批量打标签）。
+      DialogListAction(
+        label: t.tag_label,
+        icon: Icons.sell_outlined,
+        onPressed: () => _openMediaTagPicker(
+          MediaRef(kind: MediaKind.epub, entryKey: bookKey),
+        ),
+      ),
       DialogListAction(
         label: t.profile_book_profile,
         icon: Icons.account_circle_outlined,
@@ -1905,6 +1933,48 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
           onPressed: () => _toggleFloatingLyricFromShelf(bookKey),
         ),
     ];
+  }
+
+  /// 单卡「在线刮削封面」（统一三库页刮削入口）：先收起长按菜单，弹既有
+  /// [BookCoverScrapeDialog]（Bangumi 书籍条目，选中即下载临时文件），选中后
+  /// 立即走与「编辑信息」保存完全相同的 override 通道落封面，卡面即时刷新。
+  Future<void> _scrapeEpubCover(MediaItem item) async {
+    Navigator.pop(context);
+    final MediaSource mediaSource = item.getMediaSource(appModel: appModel);
+    final File? scraped = await showBookCoverScrapeDialog(
+      context: context,
+      initialQuery: displayTitleForBook(item: item, rawTitle: item.title),
+    );
+    if (scraped == null || !mounted) return;
+    await MediaCoverService.applyBookCoverOverride(
+      appModel: appModel,
+      mediaSource: mediaSource,
+      item: item,
+      file: scraped,
+      clearOverrideImage: false,
+    );
+    if (!mounted) return;
+    ref.invalidate(hibikiBooksProvider(JapaneseLanguage.instance));
+    ref.invalidate(srtBooksProvider);
+    _rebuild(() {});
+  }
+
+  /// 单卡「标签」（统一三库页卡菜单）：先收起长按菜单，进共享标签池的
+  /// [TagPickerPage]（媒体路，epub/srt 通用）；返回后失效标签 map 与筛选
+  /// provider，卡面 chip 与标签过滤立即刷新。
+  Future<void> _openMediaTagPicker(MediaRef media) async {
+    Navigator.pop(context);
+    await Navigator.push(
+      context,
+      adaptivePageRoute<void>(
+        context: context,
+        builder: (_) => TagPickerPage(media: media),
+      ),
+    );
+    if (!mounted) return;
+    ref.invalidate(bookTagMapProvider);
+    ref.invalidate(filteredBookIdsProvider);
+    ref.invalidate(filteredSrtBookIdsProvider);
   }
 
   /// 单卡「加入合集」（EPUB 卡菜单入口）：先收起长按菜单，再弹共享的合集选择

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -240,6 +240,15 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
             await _addSrtToCollection(book);
           },
         ),
+      // 统一三库页卡菜单：SRT 卡与 EPUB/视频/游戏卡对称补「标签」项（内部自行
+      // 收起本对话框）。身份 = SrtBooks.uid（与合集/批量选择键解码一致）。
+      DialogListAction(
+        label: t.tag_label,
+        icon: Icons.sell_outlined,
+        onPressed: () => _openMediaTagPicker(
+          MediaRef(kind: MediaKind.srt, entryKey: book.uid),
+        ),
+      ),
       if (bookKey.isNotEmpty) ...[
         // 与 EPUB 卡菜单对称：手动「标记为已读完 / 取消」。有声书完成状态与 EPUB 共用
         // 同一 EpubBooks.completedAt（按配对 bookKey），故复用同一 [_toggleBookCompleted]。

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -240,15 +240,6 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
             await _addSrtToCollection(book);
           },
         ),
-      // 统一三库页卡菜单：SRT 卡与 EPUB/视频/游戏卡对称补「标签」项（内部自行
-      // 收起本对话框）。身份 = SrtBooks.uid（与合集/批量选择键解码一致）。
-      DialogListAction(
-        label: t.tag_label,
-        icon: Icons.sell_outlined,
-        onPressed: () => _openMediaTagPicker(
-          MediaRef(kind: MediaKind.srt, entryKey: book.uid),
-        ),
-      ),
       if (bookKey.isNotEmpty) ...[
         // 与 EPUB 卡菜单对称：手动「标记为已读完 / 取消」。有声书完成状态与 EPUB 共用
         // 同一 EpubBooks.completedAt（按配对 bookKey），故复用同一 [_toggleBookCompleted]。

--- a/hibiki/test/media/collection_context_dialog_test.dart
+++ b/hibiki/test/media/collection_context_dialog_test.dart
@@ -1,0 +1,259 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import 'package:hibiki/src/media/collections/collection_context_dialog.dart';
+import 'package:hibiki/utils.dart';
+
+/// 三库页统一合集上下文菜单的**行为**守卫（破坏性分支优先）。
+///
+/// 该弹窗是书/视频/游戏三页共用的唯一合集菜单，含「删除合集」这条不可撤销动作，
+/// 且删除有两条语义完全不同的路径：
+///   1. 只删合集容器（解链）——成员媒体一条不动；
+///   2. 勾选「连同成员一起删」——先由调用方注入的 `onDeleteMembersMedia` 删成员
+///      本体，再解散容器。
+/// 两条路径混淆 = 用户数据丢失，故必须有行为测试钉死，而不是只靠源码扫描。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => LocaleSettings.setLocale(AppLocale.en));
+
+  Future<(HibikiDatabase, MediaCollectionRow)> buildCollection({
+    bool withMembers = true,
+  }) async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final int id = await db.createMediaCollection('collection-a');
+    if (withMembers) {
+      await db.addToCollection(id, MediaKind.epub, 'book-1');
+      await db.addToCollection(id, MediaKind.epub, 'book-2');
+    }
+    final MediaCollectionRow row = (await db.getAllMediaCollections())
+        .firstWhere((MediaCollectionRow r) => r.id == id);
+    return (db, row);
+  }
+
+  /// 挂一个真页面 context 打开被测弹窗，返回收集到的回调证据。
+  Future<_Probe> pumpAndOpen(
+    WidgetTester tester, {
+    required HibikiDatabase db,
+    required MediaCollectionRow collection,
+    required bool injectDeleteMembers,
+  }) async {
+    final _Probe probe = _Probe();
+    final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+    HibikiToast.navigatorKey = navKey;
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          navigatorKey: navKey,
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext ctx) => TextButton(
+                onPressed: () => showCollectionContextDialog(
+                  context: ctx,
+                  db: db,
+                  collection: collection,
+                  onOpenDetail: () => probe.openedDetail = true,
+                  onChanged: () => probe.changedCount++,
+                  onDeleteMembersMedia: injectDeleteMembers
+                      ? (List<MediaCollectionItemRow> members) async {
+                          probe.deletedMembers = members
+                              .map((MediaCollectionItemRow m) => m.entryKey)
+                              .toList();
+                        }
+                      : null,
+                  deleteMembersCheckboxLabel: injectDeleteMembers
+                      ? t.delete_collection_also_books
+                      : null,
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    return probe;
+  }
+
+  /// 点菜单里的「删除合集」危险动作 → 进确认框。菜单项渲染成 TextButton，
+  /// 确认框的确认键是 isDestructiveAction 的 FilledButton，两者同文案不同控件，
+  /// 各自按控件类型定位就不会认错。
+  Future<void> tapDeleteAction(WidgetTester tester) async {
+    await tester.tap(find.widgetWithText(TextButton, t.delete_collection));
+    await tester.pumpAndSettle();
+  }
+
+  /// 点确认框里的「删除合集」确认键（销毁按钮 = FilledButton）。
+  Future<void> tapConfirm(WidgetTester tester) async {
+    await tester.tap(find.widgetWithText(FilledButton, t.delete_collection));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('删合集不勾选：只解散容器，成员本体回调一次都不调', (WidgetTester tester) async {
+    final (HibikiDatabase db, MediaCollectionRow collection) =
+        await buildCollection();
+    final _Probe probe = await pumpAndOpen(
+      tester,
+      db: db,
+      collection: collection,
+      injectDeleteMembers: true,
+    );
+
+    await tapDeleteAction(tester);
+    // 有成员 + 注入了删成员回调 → 确认框必须给出勾选行（默认不勾）。
+    expect(
+      find.text(t.delete_collection_also_books),
+      findsOneWidget,
+      reason: '有成员且调用方支持删本体时必须提供勾选，否则用户无从选择。',
+    );
+
+    await tapConfirm(tester);
+
+    // 成员本体一条没删；合集容器已解散；页面被通知刷新。
+    expect(probe.deletedMembers, isNull, reason: '不勾选绝不能删成员媒体本体。');
+    expect(await db.getAllMediaCollections(), isEmpty);
+    expect(probe.changedCount, 1);
+  });
+
+  testWidgets('删合集勾选「连同成员一起删」：先删成员本体再解散容器', (WidgetTester tester) async {
+    final (HibikiDatabase db, MediaCollectionRow collection) =
+        await buildCollection();
+    final _Probe probe = await pumpAndOpen(
+      tester,
+      db: db,
+      collection: collection,
+      injectDeleteMembers: true,
+    );
+
+    await tapDeleteAction(tester);
+    // 勾选行整行可点（Checkbox 本身 IgnorePointer）。
+    await tester.tap(find.text(t.delete_collection_also_books));
+    await tester.pumpAndSettle();
+    await tapConfirm(tester);
+
+    // 成员快照在解散容器之前取得——否则 deleteMediaCollection 清完引用行就取不到了。
+    expect(probe.deletedMembers, <String>['book-1', 'book-2']);
+    expect(await db.getAllMediaCollections(), isEmpty);
+    expect(probe.changedCount, 1);
+  });
+
+  testWidgets('取消确认框：合集与成员都不动，页面也不刷新', (WidgetTester tester) async {
+    final (HibikiDatabase db, MediaCollectionRow collection) =
+        await buildCollection();
+    final _Probe probe = await pumpAndOpen(
+      tester,
+      db: db,
+      collection: collection,
+      injectDeleteMembers: true,
+    );
+
+    await tapDeleteAction(tester);
+    await tester.tap(find.widgetWithText(TextButton, t.dialog_cancel));
+    await tester.pumpAndSettle();
+
+    expect(probe.deletedMembers, isNull);
+    expect((await db.getAllMediaCollections()).length, 1);
+    expect(await db.getCollectionItems(collection.id), hasLength(2));
+    expect(probe.changedCount, 0);
+  });
+
+  testWidgets('调用方未注入删成员回调：确认框不给勾选（不许暗示能删本体）', (WidgetTester tester) async {
+    final (HibikiDatabase db, MediaCollectionRow collection) =
+        await buildCollection();
+    await pumpAndOpen(
+      tester,
+      db: db,
+      collection: collection,
+      injectDeleteMembers: false,
+    );
+
+    await tapDeleteAction(tester);
+    expect(find.text(t.delete_collection_also_books), findsNothing);
+    expect(find.byType(Checkbox), findsNothing);
+  });
+
+  testWidgets('空合集：即使注入了删成员回调也不给勾选（无成员可删）', (WidgetTester tester) async {
+    final (HibikiDatabase db, MediaCollectionRow collection) =
+        await buildCollection(withMembers: false);
+    await pumpAndOpen(
+      tester,
+      db: db,
+      collection: collection,
+      injectDeleteMembers: true,
+    );
+
+    await tapDeleteAction(tester);
+    expect(find.byType(Checkbox), findsNothing);
+  });
+
+  testWidgets('顶部主按钮 = 打开详情（不写库、不触发 onChanged）', (WidgetTester tester) async {
+    final (HibikiDatabase db, MediaCollectionRow collection) =
+        await buildCollection();
+    final _Probe probe = await pumpAndOpen(
+      tester,
+      db: db,
+      collection: collection,
+      injectDeleteMembers: true,
+    );
+
+    await tester.tap(find.text(t.collection_view_all));
+    await tester.pumpAndSettle();
+
+    expect(probe.openedDetail, isTrue);
+    expect(probe.changedCount, 0);
+    expect((await db.getAllMediaCollections()).length, 1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 三库页接线对账（源码扫描）：合集菜单只有一份实现，但「删成员本体」这条支线
+  // 靠调用方注入，漏注入就静默退化成「只能解散合集」——正是游戏页此前的状态。
+  // 逐页钉住三件事：走统一菜单、注入了 onDeleteMembersMedia、给了对应勾选文案。
+  // ---------------------------------------------------------------------------
+  group('三库页合集菜单接线对账', () {
+    const Map<String, String> pages = <String, String>{
+      'lib/src/pages/implementations/reader_hibiki_history_page.dart':
+          't.delete_collection_also_books',
+      'lib/src/pages/implementations/home_video_page.dart':
+          't.delete_collection_also_videos',
+      'lib/src/pages/implementations/games_library_page.dart':
+          't.delete_collection_also_games',
+    };
+
+    pages.forEach((String path, String checkboxLabel) {
+      test('$path 走统一合集菜单并注入删成员本体支线', () {
+        final String src = File(path).readAsStringSync();
+        expect(
+          src,
+          contains('showCollectionContextDialog('),
+          reason: '合集入口的右键/长按菜单必须走唯一实现，不许各页自建。',
+        );
+        expect(
+          src,
+          contains('onDeleteMembersMedia:'),
+          reason: '漏注入 onDeleteMembersMedia = 该页删合集永远无法连成员一起删，'
+              '与另外两页行为不一致（游戏页曾漏）。',
+        );
+        expect(
+          src,
+          contains('deleteMembersCheckboxLabel: $checkboxLabel'),
+          reason: '勾选文案必须按媒体域给，否则用户看不清会删掉什么。',
+        );
+      });
+    });
+  });
+}
+
+/// 回调证据收集器（比一堆散落局部变量更好读）。
+class _Probe {
+  bool openedDetail = false;
+  int changedCount = 0;
+  List<String>? deletedMembers;
+}

--- a/hibiki/test/media/metadata/bangumi_api_client_test.dart
+++ b/hibiki/test/media/metadata/bangumi_api_client_test.dart
@@ -12,7 +12,8 @@ import 'package:http/testing.dart';
 /// 由各调用方自己的测试覆盖，不在此重复。
 void main() {
   group('BangumiApiClient.searchSubjects', () {
-    test('POST /search/subjects：UA/Content-Type 头、body 含 keyword+filter.type、limit query',
+    test(
+        'POST /search/subjects：UA/Content-Type 头、body 含 keyword+filter.type、limit query',
         () async {
       Map<String, String>? headers;
       Object? body;
@@ -50,8 +51,10 @@ void main() {
         uri = req.url;
         return http.Response.bytes(utf8.encode('{}'), 200);
       });
-      await BangumiApiClient(client: client, userAgent: 'ua')
-          .searchSubjects('x', subjectType: kBangumiSubjectTypeAnime, limit: 999);
+      await BangumiApiClient(client: client, userAgent: 'ua').searchSubjects(
+          'x',
+          subjectType: kBangumiSubjectTypeAnime,
+          limit: 999);
       expect(uri?.queryParameters['limit'], '50');
     });
 
@@ -171,6 +174,36 @@ void main() {
         baseUrl: 'https://mirror.example/v0',
       ).fetchSubject('9');
       expect(uri.toString(), 'https://mirror.example/v0/subjects/9');
+    });
+  });
+
+  group('parseBangumiSubjectUrl（添加/修改映射的 URL 直连解析）', () {
+    test('三个已知域名的 /subject/<id> 均解析出数字 id', () {
+      expect(parseBangumiSubjectUrl('https://bgm.tv/subject/253'), '253');
+      expect(parseBangumiSubjectUrl('https://bangumi.tv/subject/253'), '253');
+      expect(parseBangumiSubjectUrl('https://chii.in/subject/253'), '253');
+      expect(parseBangumiSubjectUrl('http://www.bgm.tv/subject/253'), '253');
+    });
+
+    test('容忍无 scheme / 尾随路径段 / query / fragment', () {
+      expect(parseBangumiSubjectUrl('bgm.tv/subject/4885'), '4885');
+      expect(
+        parseBangumiSubjectUrl('https://bgm.tv/subject/253/comments?x=1#top'),
+        '253',
+      );
+    });
+
+    test('纯数字不在此认定（数字可能是标题，由弹窗并列策略处理）', () {
+      expect(parseBangumiSubjectUrl('253'), isNull);
+      expect(parseBangumiSubjectUrl('86'), isNull);
+    });
+
+    test('未知域名 / 非条目路径 / 非数字 id / 空串 → null', () {
+      expect(parseBangumiSubjectUrl('https://example.com/subject/253'), isNull);
+      expect(parseBangumiSubjectUrl('https://bgm.tv/user/foo'), isNull);
+      expect(parseBangumiSubjectUrl('https://bgm.tv/subject/abc'), isNull);
+      expect(parseBangumiSubjectUrl(''), isNull);
+      expect(parseBangumiSubjectUrl('星际牛仔'), isNull);
     });
   });
 }

--- a/hibiki/test/media/metadata/book_metadata_scraper_test.dart
+++ b/hibiki/test/media/metadata/book_metadata_scraper_test.dart
@@ -104,4 +104,54 @@ void main() {
       );
     });
   });
+
+  group('fetchById / parseBookSubjectResponse（id 直连改绑映射）', () {
+    test('详情体复用 mapBookSubject：候选字段正确', () {
+      const String body = '{"id":9999,"name":"よつばと！","name_cn":"四叶妹妹！",'
+          '"images":{"large":"https://img/large.jpg"},'
+          '"date":"2003-08-10","summary":"s"}';
+      final BookScrapeCandidate? c = parseBookSubjectResponse(body);
+      expect(c, isNotNull);
+      expect(c!.subjectId, '9999');
+      expect(c.title, '四叶妹妹！');
+      expect(c.coverUrl, 'https://img/large.jpg');
+      expect(c.year, 2003);
+    });
+
+    test('无封面 → null；JSON 解码失败 → 抛 BookScrapeException', () {
+      expect(parseBookSubjectResponse('{"id":1,"name":"x"}'), isNull);
+      expect(
+        () => parseBookSubjectResponse('not json'),
+        throwsA(isA<BookScrapeException>()),
+      );
+    });
+
+    test('fetchById：GET /subjects/{id}；404 → null；500 → 抛', () async {
+      Uri? uri;
+      final MockClient ok = MockClient((http.Request req) async {
+        uri = req.url;
+        return http.Response.bytes(
+          utf8.encode('{"id":7,"name":"n",'
+              '"images":{"large":"https://img/l.jpg"}}'),
+          200,
+        );
+      });
+      final BookScrapeCandidate? c =
+          await BookMetadataScraper(client: ok).fetchById('7');
+      expect(uri?.path, '/v0/subjects/7');
+      expect(c?.subjectId, '7');
+
+      final MockClient notFound =
+          MockClient((http.Request req) async => http.Response('x', 404));
+      expect(
+          await BookMetadataScraper(client: notFound).fetchById('7'), isNull);
+
+      final MockClient err =
+          MockClient((http.Request req) async => http.Response('x', 500));
+      await expectLater(
+        BookMetadataScraper(client: err).fetchById('7'),
+        throwsA(isA<BookScrapeException>()),
+      );
+    });
+  });
 }

--- a/hibiki/test/media/video/scraper/bangumi_subject_test.dart
+++ b/hibiki/test/media/video/scraper/bangumi_subject_test.dart
@@ -187,4 +187,58 @@ void main() {
       );
     });
   });
+
+  group('parseBangumiSubjectDetailAsCandidate（id 直连改绑映射）', () {
+    test('详情体映射为候选：评分取 rating.score、话数回退 total_episodes', () {
+      const String body = '{"id":253,"name":"カウボーイビバップ",'
+          '"name_cn":"星际牛仔","date":"1998-04-03","platform":"TV",'
+          '"eps":0,"total_episodes":26,'
+          '"rating":{"score":8.4,"total":1234},'
+          '"images":{"large":"https://img/l.jpg"}}';
+      final ScrapeCandidate? c = parseBangumiSubjectDetailAsCandidate(body);
+      expect(c, isNotNull);
+      expect(c!.entryId, '253');
+      expect(c.title, '星际牛仔');
+      expect(c.posterUrl, 'https://img/l.jpg');
+      expect(c.year, 1998);
+      expect(c.type, ScrapeEntryType.tv);
+      expect(c.episodeCount, 26);
+      expect(c.ratingText, 'Bangumi 8.4');
+    });
+
+    test('无海报 → null（对封面刮削无用）；结构异常 → 抛异常', () {
+      expect(
+        parseBangumiSubjectDetailAsCandidate('{"id":1,"name":"x"}'),
+        isNull,
+      );
+      expect(
+        () => parseBangumiSubjectDetailAsCandidate('not json'),
+        throwsA(isA<ScrapeNetworkException>()),
+      );
+    });
+  });
+
+  group('BangumiClient.fetchSubjectCandidate', () {
+    test('200 → 候选；404 → null（条目不存在按空处理，不抛）', () async {
+      const String body = '{"id":9,"name":"n","name_cn":"中文名",'
+          '"images":{"large":"https://img/l.jpg"}}';
+      final BangumiClient ok = BangumiClient(client: _client(body));
+      final ScrapeCandidate? c = await ok.fetchSubjectCandidate('9');
+      expect(c?.entryId, '9');
+      expect(c?.title, '中文名');
+
+      final BangumiClient missing =
+          BangumiClient(client: _client('{}', status: 404));
+      expect(await missing.fetchSubjectCandidate('999999'), isNull);
+    });
+
+    test('非 2xx（非 404）→ 抛 ScrapeNetworkException', () async {
+      final BangumiClient bad =
+          BangumiClient(client: _client('{}', status: 500));
+      await expectLater(
+        bad.fetchSubjectCandidate('9'),
+        throwsA(isA<ScrapeNetworkException>()),
+      );
+    });
+  });
 }

--- a/hibiki/test/mining/galgame_cover_download_test.dart
+++ b/hibiki/test/mining/galgame_cover_download_test.dart
@@ -45,35 +45,29 @@ void main() {
     });
   });
 
-  group('shouldDownloadExplicitScrapedCover', () {
-    test('用户显式选中候选：有 URL 即下载（即使已有封面也覆盖）', () {
-      // 显式路径的签名里根本没有 hasUsableCoverFile——「是否已有封面」不参与
-      // 决策，这正是与隐式路径的分界：显式选择 = 用户点名要这条，封面一起换。
+  group('刷削不覆盖用户现有封面（游戏岛封面纪律）', () {
+    // 回归守卫：统一刷削弹窗的「使用」曾被改成无条件覆盖封面（与
+    // media_cover_service.dart 的纪律表相矛）。游戏岛没有 CoverOrigin
+    // 元数据，「封面文件是否存在」是唯一保护判据，刷削两条路径
+    // （详情页自动 / 弹窗显式使用）必须共用同一约束。
+    test('已有可用封面 + 有 URL → 不下载（无论哪条刷削路径）', () {
       expect(
-        shouldDownloadExplicitScrapedCover(
+        shouldAutoDownloadScrapedCover(
+          hasUsableCoverFile: true,
+          coverUrl: 'https://example.com/cover.jpg',
+        ),
+        isFalse,
+      );
+    });
+
+    test('没有可用封面 + 有 URL → 下载补齐', () {
+      expect(
+        shouldAutoDownloadScrapedCover(
+          hasUsableCoverFile: false,
           coverUrl: 'https://example.com/cover.jpg',
         ),
         isTrue,
       );
-    });
-
-    test('无 URL / 空白 URL → 不下载', () {
-      expect(shouldDownloadExplicitScrapedCover(coverUrl: null), isFalse);
-      expect(shouldDownloadExplicitScrapedCover(coverUrl: '   '), isFalse);
-    });
-
-    test('显式覆盖 vs 隐式不覆盖：同一「已有封面 + 有 URL」情形两函数分道', () {
-      const String url = 'https://example.com/cover.jpg';
-      // 隐式（自动刮削路径）：已有可用封面绝不覆盖。
-      expect(
-        shouldAutoDownloadScrapedCover(
-          hasUsableCoverFile: true,
-          coverUrl: url,
-        ),
-        isFalse,
-      );
-      // 显式（统一刮削弹窗「使用」）：照样下载覆盖。
-      expect(shouldDownloadExplicitScrapedCover(coverUrl: url), isTrue);
     });
   });
 

--- a/hibiki/test/mining/galgame_cover_download_test.dart
+++ b/hibiki/test/mining/galgame_cover_download_test.dart
@@ -45,6 +45,38 @@ void main() {
     });
   });
 
+  group('shouldDownloadExplicitScrapedCover', () {
+    test('用户显式选中候选：有 URL 即下载（即使已有封面也覆盖）', () {
+      // 显式路径的签名里根本没有 hasUsableCoverFile——「是否已有封面」不参与
+      // 决策，这正是与隐式路径的分界：显式选择 = 用户点名要这条，封面一起换。
+      expect(
+        shouldDownloadExplicitScrapedCover(
+          coverUrl: 'https://example.com/cover.jpg',
+        ),
+        isTrue,
+      );
+    });
+
+    test('无 URL / 空白 URL → 不下载', () {
+      expect(shouldDownloadExplicitScrapedCover(coverUrl: null), isFalse);
+      expect(shouldDownloadExplicitScrapedCover(coverUrl: '   '), isFalse);
+    });
+
+    test('显式覆盖 vs 隐式不覆盖：同一「已有封面 + 有 URL」情形两函数分道', () {
+      const String url = 'https://example.com/cover.jpg';
+      // 隐式（自动刮削路径）：已有可用封面绝不覆盖。
+      expect(
+        shouldAutoDownloadScrapedCover(
+          hasUsableCoverFile: true,
+          coverUrl: url,
+        ),
+        isFalse,
+      );
+      // 显式（统一刮削弹窗「使用」）：照样下载覆盖。
+      expect(shouldDownloadExplicitScrapedCover(coverUrl: url), isTrue);
+    });
+  });
+
   group('galgameCoverExtension', () {
     test('Content-Type 优先于 URL 后缀', () {
       expect(

--- a/hibiki/test/mining/galgame_scrape_dialog_test.dart
+++ b/hibiki/test/mining/galgame_scrape_dialog_test.dart
@@ -1,0 +1,336 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import 'package:hibiki/src/mining/galgame_library.dart';
+import 'package:hibiki/src/mining/galgame_repository.dart';
+import 'package:hibiki/src/mining/galgame_scrape_controller.dart';
+import 'package:hibiki/src/mining/galgame_scrape_dialog.dart';
+import 'package:hibiki/src/mining/metadata/galgame_metadata_adapter.dart';
+import 'package:hibiki/src/mining/metadata/galgame_metadata_draft.dart';
+import 'package:hibiki/src/mining/metadata/galgame_metadata_source.dart';
+import 'package:hibiki/utils.dart';
+
+/// 统一刮削弹窗守卫（对齐视频 cover_match_dialog 的单弹窗闭环）：
+/// 1. 打开即按预填词自动首搜，候选带「源 · ID · 发行日」副行与每行「使用」按钮；
+/// 2. 点「使用」→ fetchById 补全 → saveScrapeResult 真写穿 DB（primarySource
+///    单源记该源 key），弹窗以 true 关闭；
+/// 3. 空结果给弹窗内空态（可改词重试），全源失败给错误行且重搜可恢复。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+  });
+
+  Future<(GalgameRepository, GalgameEntry)> buildRepo() async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final GalgameRepository repo = GalgameRepository(db);
+    final GalgameEntry entry = GalgameEntry(
+      id: 'g1',
+      name: 'alpha',
+      exePath: r'Z:\a\alpha.exe',
+      workdir: r'Z:\a',
+      addedAt: DateTime(2026),
+    );
+    await repo.addAll(<GalgameEntry>[entry]);
+    return (repo, repo.byId('g1')!);
+  }
+
+  Future<Future<bool?> Function()> pumpDialogOpener(
+    WidgetTester tester, {
+    required GalgameRepository repo,
+    required GalgameEntry game,
+    required GalgameScrapeController controller,
+  }) async {
+    Future<bool?>? result;
+    final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+    HibikiToast.navigatorKey = navKey;
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          navigatorKey: navKey,
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext ctx) => TextButton(
+                onPressed: () {
+                  result = showAppDialog<bool>(
+                    context: ctx,
+                    builder: (_) => GalgameScrapeDialog(
+                      game: game,
+                      repo: repo,
+                      controllerOverride: controller,
+                    ),
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    return () => result ?? Future<bool?>.value();
+  }
+
+  testWidgets('打开即自动首搜；点「使用」落库 primarySource 并以 true 关闭',
+      (WidgetTester tester) async {
+    final (GalgameRepository repo, GalgameEntry game) = await buildRepo();
+    final _FakeAdapter bgm = _FakeAdapter(GalgameMetadataSource.bgm)
+      ..results = const <SourceCandidate>[
+        SourceCandidate(
+          source: GalgameMetadataSource.bgm,
+          externalId: '4885',
+          name: 'alpha',
+          nameCn: '阿尔法物语',
+          releaseDate: '2024-03-15',
+        ),
+      ]
+      ..draft = const GalgameMetadataDraft(
+        name: 'alpha',
+        nameCn: '阿尔法物语',
+        summary: '简介',
+        externalId: '4885',
+      );
+    final GalgameScrapeController controller =
+        GalgameScrapeController(adapters: <GalgameMetadataAdapter>[bgm]);
+    final Future<bool?> Function() applied = await pumpDialogOpener(
+      tester,
+      repo: repo,
+      game: game,
+      controller: controller,
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // 自动首搜已按显示名跑过一次并渲染候选（无需手点搜索）。
+    expect(bgm.searchedNames, <String>['alpha']);
+    expect(find.text('阿尔法物语'), findsOneWidget);
+    // 副行：源 label · externalId · releaseDate。
+    expect(
+      find.text('Bangumi · 4885 · 2024-03-15'),
+      findsOneWidget,
+      reason: '候选副行必须是「源 · ID · 发行日」',
+    );
+
+    await tester.tap(find.text(t.game_scrape_use));
+    await tester.pumpAndSettle();
+
+    // 真写穿 DB：源快照 + 单源 primarySource 记该源 key。
+    final GalgameEntry saved = repo.byId('g1')!;
+    expect(saved.primarySource, GalgameMetadataSource.bgm.key);
+    expect(saved.displayName, '阿尔法物语');
+    final List<GalgameSourceRow> sources = await repo.sourcesOf('g1');
+    expect(sources, hasLength(1));
+    expect(sources.single.externalId, '4885');
+    // 弹窗以 true 关闭（调用方据此刷新）。
+    expect(await applied(), isTrue);
+    expect(find.byType(GalgameScrapeDialog), findsNothing);
+    await tester.pump(const Duration(seconds: 4)); // 放掉桌面 toast 计时器
+  });
+
+  testWidgets('已有他源快照时落库 primarySource 记 mixed', (WidgetTester tester) async {
+    final (GalgameRepository repo, GalgameEntry game) = await buildRepo();
+    // 预置一份 vndb 快照：再落 bgm 就是多源。
+    await repo.saveScrapeResult(
+      gameId: 'g1',
+      source: GalgameMetadataSource.vndb,
+      draft: const GalgameMetadataDraft(name: 'alpha', externalId: 'v99'),
+      primarySource: GalgameMetadataSource.vndb.key,
+    );
+    final _FakeAdapter bgm = _FakeAdapter(GalgameMetadataSource.bgm)
+      ..results = const <SourceCandidate>[
+        SourceCandidate(source: GalgameMetadataSource.bgm, externalId: '4885'),
+      ]
+      ..draft = const GalgameMetadataDraft(name: 'alpha', externalId: '4885');
+    final GalgameScrapeController controller =
+        GalgameScrapeController(adapters: <GalgameMetadataAdapter>[bgm]);
+    await pumpDialogOpener(
+      tester,
+      repo: repo,
+      game: game,
+      controller: controller,
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(t.game_scrape_use));
+    await tester.pumpAndSettle();
+
+    expect(repo.byId('g1')!.primarySource, kGalgamePrimarySourceMixed);
+    expect(await repo.sourcesOf('g1'), hasLength(2));
+    await tester.pump(const Duration(seconds: 4)); // 放掉桌面 toast 计时器
+  });
+
+  testWidgets('空结果给弹窗内空态（不再 toast 后散场）', (WidgetTester tester) async {
+    final (GalgameRepository repo, GalgameEntry game) = await buildRepo();
+    final _FakeAdapter bgm = _FakeAdapter(GalgameMetadataSource.bgm);
+    final GalgameScrapeController controller =
+        GalgameScrapeController(adapters: <GalgameMetadataAdapter>[bgm]);
+    await pumpDialogOpener(
+      tester,
+      repo: repo,
+      game: game,
+      controller: controller,
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(GalgameScrapeDialog), findsOneWidget);
+    expect(find.text(t.game_scrape_no_result), findsOneWidget);
+    // 弹窗仍在：搜索框可改词重试。
+    expect(find.byType(TextField), findsOneWidget);
+  });
+
+  group('normalizeGalgameScrapeQuery（贴条目 URL 归一成源裸 ID）', () {
+    test('Bangumi 条目 URL（三个域名）→ 数字裸 ID', () {
+      expect(
+        normalizeGalgameScrapeQuery('https://bgm.tv/subject/4885'),
+        '4885',
+      );
+      expect(
+        normalizeGalgameScrapeQuery('https://bangumi.tv/subject/4885/'),
+        '4885',
+      );
+      expect(
+        normalizeGalgameScrapeQuery('http://chii.in/subject/4885'),
+        '4885',
+      );
+      expect(
+        normalizeGalgameScrapeQuery('https://www.bgm.tv/subject/4885'),
+        '4885',
+      );
+    });
+
+    test('带 query / fragment / 多余路径段照样归一', () {
+      expect(
+        normalizeGalgameScrapeQuery(
+          'https://bgm.tv/subject/4885?tab=comments#top',
+        ),
+        '4885',
+      );
+      expect(
+        normalizeGalgameScrapeQuery('https://bgm.tv/subject/4885/comments'),
+        '4885',
+      );
+      expect(
+        normalizeGalgameScrapeQuery('https://vndb.org/v17/chars?f=x#y'),
+        'v17',
+      );
+    });
+
+    test('VNDB 条目 URL → v<数字>（允许尾随斜杠/多余路径段）', () {
+      expect(normalizeGalgameScrapeQuery('https://vndb.org/v17'), 'v17');
+      expect(normalizeGalgameScrapeQuery('https://vndb.org/v17/'), 'v17');
+      expect(normalizeGalgameScrapeQuery('https://vndb.org/V17'), 'v17');
+    });
+
+    test('丢协议的地址栏复制形态（bgm.tv/subject/…）也认', () {
+      expect(normalizeGalgameScrapeQuery('bgm.tv/subject/4885'), '4885');
+      expect(normalizeGalgameScrapeQuery('vndb.org/v17'), 'v17');
+    });
+
+    test('非条目 URL 原样透传', () {
+      expect(
+        normalizeGalgameScrapeQuery('https://bgm.tv/user/foo'),
+        'https://bgm.tv/user/foo',
+      );
+      expect(
+        normalizeGalgameScrapeQuery('https://vndb.org/g123'),
+        'https://vndb.org/g123',
+      );
+      // 域名不认识：即使路径形似 subject 也不动。
+      expect(
+        normalizeGalgameScrapeQuery('https://example.com/subject/4885'),
+        'https://example.com/subject/4885',
+      );
+      // subject 后不是纯数字：不动。
+      expect(
+        normalizeGalgameScrapeQuery('https://bgm.tv/subject/abc'),
+        'https://bgm.tv/subject/abc',
+      );
+    });
+
+    test('裸词 / 裸 ID 零行为变化', () {
+      expect(normalizeGalgameScrapeQuery('clannad'), 'clannad');
+      expect(normalizeGalgameScrapeQuery('4885'), '4885');
+      expect(normalizeGalgameScrapeQuery('v17'), 'v17');
+      expect(normalizeGalgameScrapeQuery('CLANNAD 完整版'), 'CLANNAD 完整版');
+      expect(normalizeGalgameScrapeQuery(''), '');
+    });
+  });
+
+  testWidgets('全源失败给错误行，改好后重搜可恢复', (WidgetTester tester) async {
+    final (GalgameRepository repo, GalgameEntry game) = await buildRepo();
+    final _FakeAdapter bgm = _FakeAdapter(GalgameMetadataSource.bgm)
+      ..failSearch = true;
+    final GalgameScrapeController controller =
+        GalgameScrapeController(adapters: <GalgameMetadataAdapter>[bgm]);
+    await pumpDialogOpener(
+      tester,
+      repo: repo,
+      game: game,
+      controller: controller,
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // 全源失败：错误行（区别于空态），不是静默空列表。
+    expect(find.text(t.game_scrape_search_failed), findsOneWidget);
+    expect(find.text(t.game_scrape_no_result), findsNothing);
+
+    // 网络恢复后点「搜索」重试即出候选。
+    bgm
+      ..failSearch = false
+      ..results = const <SourceCandidate>[
+        SourceCandidate(
+          source: GalgameMetadataSource.bgm,
+          externalId: '4885',
+          name: 'alpha',
+        ),
+      ];
+    await tester.tap(find.text(t.game_scrape_search));
+    await tester.pumpAndSettle();
+    expect(find.text(t.game_scrape_search_failed), findsNothing);
+    expect(find.text(t.game_scrape_use), findsOneWidget);
+  });
+}
+
+/// 可控假 adapter：searchByName / fetchById 的结果与失败全由测试摆布。
+class _FakeAdapter implements GalgameMetadataAdapter {
+  _FakeAdapter(this.source);
+
+  @override
+  final GalgameMetadataSource source;
+
+  List<SourceCandidate> results = const <SourceCandidate>[];
+  GalgameMetadataDraft? draft;
+  bool failSearch = false;
+
+  /// 收到过的搜索词（断言自动首搜用）。
+  final List<String> searchedNames = <String>[];
+
+  @override
+  bool validateId(String id) => false;
+
+  @override
+  String externalUrl(String id) => 'https://example.com/$id';
+
+  @override
+  Future<GalgameMetadataDraft?> fetchById(String id) async => draft;
+
+  @override
+  Future<List<SourceCandidate>> searchByName(String name, {int? limit}) async {
+    searchedNames.add(name);
+    if (failSearch) {
+      throw const GalgameMetadataException('boom', source: null);
+    }
+    return results;
+  }
+
+  @override
+  void close() {}
+}

--- a/hibiki/test/mining/galgame_scrape_dialog_test.dart
+++ b/hibiki/test/mining/galgame_scrape_dialog_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -129,6 +131,69 @@ void main() {
     // 弹窗以 true 关闭（调用方据此刷新）。
     expect(await applied(), isTrue);
     expect(find.byType(GalgameScrapeDialog), findsNothing);
+    await tester.pump(const Duration(seconds: 4)); // 放掉桌面 toast 计时器
+  });
+
+  testWidgets('已有可用封面时点「使用」不碰网络、不覆盖封面（游戏岛封面纪律）', (WidgetTester tester) async {
+    // 回归守卫：本弹窗曾把「使用」改成无条件下载并覆盖 coverPath，直接
+    // 盖掉用户手选的封面（游戏岛无 CoverOrigin 保护、无确认、无备份、不可撤销），
+    // 与 media_cover_service.dart 的封面纪律表直接矛盾。
+    //
+    // “没覆盖”光看 coverPath 不算数——下载失败也会保留旧值。这里把 HttpClient
+    // 构造堆成地雷（[_ExplodingHttpOverrides]）：只要走到下载就抛，落库会被弹窗
+    // 的 catch 接住→弹窗不关。因此「弹窗以 true 关闭」= 一次网络都没发。
+    final HttpOverrides? previous = HttpOverrides.current;
+    HttpOverrides.global = _ExplodingHttpOverrides();
+    addTearDown(() => HttpOverrides.global = previous);
+
+    final Directory dir = Directory.systemTemp.createTempSync('gal_cover_');
+    addTearDown(() => dir.deleteSync(recursive: true));
+    final File cover = File('${dir.path}/manual.png')
+      ..writeAsBytesSync(<int>[1, 2, 3]);
+    final (GalgameRepository repo, GalgameEntry game) = await buildRepo();
+    await repo.setCoverPath('g1', cover.path);
+
+    const String url = 'https://example.invalid/should-not-be-fetched.jpg';
+    final _FakeAdapter bgm = _FakeAdapter(GalgameMetadataSource.bgm)
+      ..results = const <SourceCandidate>[
+        SourceCandidate(
+          source: GalgameMetadataSource.bgm,
+          externalId: '4885',
+          coverUrl: url,
+        ),
+      ]
+      ..draft = const GalgameMetadataDraft(
+        name: 'alpha',
+        externalId: '4885',
+        coverUrl: url,
+      );
+    final GalgameScrapeController controller =
+        GalgameScrapeController(adapters: <GalgameMetadataAdapter>[bgm]);
+    final Future<bool?> Function() applied = await pumpDialogOpener(
+      tester,
+      repo: repo,
+      game: repo.byId('g1')!,
+      controller: controller,
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.game_scrape_use));
+    await tester.pumpAndSettle();
+
+    // 元数据落了、弹窗正常关闭（= 没碰网络）、封面原封不动。
+    expect(await repo.sourcesOf('g1'), hasLength(1));
+    expect(
+      find.byType(GalgameScrapeDialog),
+      findsNothing,
+      reason: '已有可用封面时不得发封面下载请求（发了就会抛、弹窗不会关）。',
+    );
+    expect(await applied(), isTrue);
+    expect(
+      repo.byId('g1')!.coverPath,
+      cover.path,
+      reason: '刷削绝不得覆盖用户已有的封面文件。',
+    );
+    expect(cover.readAsBytesSync(), <int>[1, 2, 3]);
     await tester.pump(const Duration(seconds: 4)); // 放掉桌面 toast 计时器
   });
 
@@ -333,4 +398,13 @@ class _FakeAdapter implements GalgameMetadataAdapter {
 
   @override
   void close() {}
+}
+
+/// 构造 HttpClient 即抛：用来证明某条路径**一次网络都没发**（比断言结果没变强，
+/// 后者被「下载失败也保留旧值」掩盖）。
+class _ExplodingHttpOverrides extends HttpOverrides {
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    throw StateError('unexpected network access');
+  }
 }

--- a/hibiki/test/pages/booklongpress_floating_lyric_toggle_test.dart
+++ b/hibiki/test/pages/booklongpress_floating_lyric_toggle_test.dart
@@ -46,7 +46,7 @@ void main() {
     );
   });
 
-  test('书籍长按动作移除标签按钮但保留其它管理动作', () {
+  test('书籍长按菜单含「标签」项（统一三库页卡菜单）并保留其它管理动作', () {
     final String epubActions = _sectionSource(
       src,
       'List<DialogAction> extraActions(MediaItem item) {',
@@ -58,14 +58,31 @@ void main() {
       '  Future<void> _showSrtBookDialog(',
     );
 
+    // 统一三库页卡菜单（2026-07 右键菜单统一）：视频/游戏卡菜单均有「标签」，
+    // 书卡对称补回（推翻 TODO-455 的移除决策——当年无跨页统一约定）。两侧走
+    // 共享标签池 TagPickerPage（媒体路，MediaRef 身份）。
     for (final String actions in <String>[epubActions, srtActions]) {
       expect(
         actions,
-        isNot(contains('t.tag_label')),
-        reason: 'TODO-455 removes the Tag button from book long-press menus.',
+        contains('t.tag_label'),
+        reason: '统一三库页卡菜单：书卡与视频/游戏卡对称含「标签」项。',
       );
-      expect(actions, isNot(contains('Icons.sell_outlined')));
+      expect(actions, contains('Icons.sell_outlined'));
+      expect(
+        actions,
+        contains('_openMediaTagPicker'),
+        reason: '书卡「标签」走共享 TagPickerPage 入口。',
+      );
     }
+    expect(epubActions, contains('kind: MediaKind.epub'));
+    expect(srtActions, contains('kind: MediaKind.srt'));
+
+    // 统一三库页刮削入口：书卡菜单直挂「在线刮削封面」（不再必须绕编辑信息弹窗）。
+    expect(
+      epubActions,
+      contains('t.book_scrape_cover'),
+      reason: '书卡菜单必须直挂「在线刮削封面」（统一刮削入口层级）。',
+    );
 
     expect(epubActions, contains('t.view_illustrations'));
     expect(epubActions, contains('t.audiobook_import'));

--- a/hibiki/test/pages/booklongpress_floating_lyric_toggle_test.dart
+++ b/hibiki/test/pages/booklongpress_floating_lyric_toggle_test.dart
@@ -46,7 +46,7 @@ void main() {
     );
   });
 
-  test('书籍长按菜单含「标签」项（统一三库页卡菜单）并保留其它管理动作', () {
+  test('书籍长按动作移除标签按钮但保留其它管理动作', () {
     final String epubActions = _sectionSource(
       src,
       'List<DialogAction> extraActions(MediaItem item) {',
@@ -58,24 +58,17 @@ void main() {
       '  Future<void> _showSrtBookDialog(',
     );
 
-    // 统一三库页卡菜单（2026-07 右键菜单统一）：视频/游戏卡菜单均有「标签」，
-    // 书卡对称补回（推翻 TODO-455 的移除决策——当年无跨页统一约定）。两侧走
-    // 共享标签池 TagPickerPage（媒体路，MediaRef 身份）。
+    // TODO-455 已拍板：书卡长按菜单不放「标签」。本轮「统一三库页右键
+    // 菜单」曾把它补回并反转本守卫——推翻既有决策不能靠改守卫测试自我批准，
+    // 已回退。书卡打标签仍走拖标签 / 批量打标签两条旧路径。
     for (final String actions in <String>[epubActions, srtActions]) {
       expect(
         actions,
-        contains('t.tag_label'),
-        reason: '统一三库页卡菜单：书卡与视频/游戏卡对称含「标签」项。',
+        isNot(contains('t.tag_label')),
+        reason: 'TODO-455 removes the Tag button from book long-press menus.',
       );
-      expect(actions, contains('Icons.sell_outlined'));
-      expect(
-        actions,
-        contains('_openMediaTagPicker'),
-        reason: '书卡「标签」走共享 TagPickerPage 入口。',
-      );
+      expect(actions, isNot(contains('Icons.sell_outlined')));
     }
-    expect(epubActions, contains('kind: MediaKind.epub'));
-    expect(srtActions, contains('kind: MediaKind.srt'));
 
     // 统一三库页刮削入口：书卡菜单直挂「在线刮削封面」（不再必须绕编辑信息弹窗）。
     expect(

--- a/hibiki/test/pages/games_library_cover_menu_test.dart
+++ b/hibiki/test/pages/games_library_cover_menu_test.dart
@@ -70,16 +70,19 @@ void main() {
     await tester.pump();
   }
 
-  /// 卡片菜单应含的全部项（与 `_GameCard._menuItems` 单一真相源对账：任一处漏项
-  /// 本表即断言失败）。'remove' 在长按对话框落危险区，但文案仍必须在场。
+  /// 卡片菜单应含的全部项，**按三库页统一次序**（重命名 → 封面类 → 刮削 →
+  /// 加入合集 → 标签 → 删除；游戏特有的详情/状态保持最前）。与
+  /// `_GameCard._menuItems` 单一真相源对账：漏项或乱序本表即断言失败。
+  /// 'remove' 在长按对话框落危险区，但文案仍必须在场。
   List<String> menuLabels() => <String>[
         t.game_view_detail,
         t.game_play_status,
-        t.game_scrape,
         t.game_rename,
         t.game_set_cover,
         t.game_auto_cover,
+        t.game_scrape,
         t.add_to_collection,
+        t.tag_label,
         t.game_remove,
       ];
 
@@ -101,6 +104,13 @@ void main() {
     for (final String label in menuLabels()) {
       expect(find.text(label), findsOneWidget, reason: '溢出菜单缺「$label」');
     }
+
+    // 次序也要钉住（统一约定：重命名 → 封面类 → 刮削 → 加入合集 → 标签 → 删除）。
+    final List<String> shown = tester
+        .widgetList<PopupMenuItem<String>>(find.byType(PopupMenuItem<String>))
+        .map((PopupMenuItem<String> item) => (item.child! as Text).data!)
+        .toList();
+    expect(shown, menuLabels(), reason: '溢出菜单次序偏离三库页统一约定');
   });
 
   testWidgets('长按菜单走 MediaItemDialogFrame 且与溢出菜单项一致',

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -277,12 +277,15 @@ void main() {
       'HibikiModalSheetFrame',
       'adaptiveDialogAction',
     ],
+    // 刮削二跳收口后，详情页的刮削 UI 全部委托统一弹窗（galgame_scrape_dialog）。
     'lib/src/pages/implementations/galgame_detail_page.dart': <String>[
-      'showAppDialog<String>(',
-      'showAppDialog<SourceCandidate>(',
+      'showGalgameScrapeDialog(',
+    ],
+    // 统一刮削弹窗本体（库页卡菜单与详情页编辑 tab 共用）走共享对话框骨架。
+    'lib/src/mining/galgame_scrape_dialog.dart': <String>[
+      'showAppDialog<bool>(',
       'HibikiDialogFrame',
       'HibikiModalSheetFrame',
-      'HibikiTextField',
       'adaptiveDialogAction',
     ],
     'lib/src/pages/implementations/games_library_page.dart': <String>[
@@ -294,6 +297,11 @@ void main() {
       'HibikiTextField',
       'adaptiveDialogAction',
       'AdaptiveSettingsSwitchRow',
+      // 卡菜单「刮削元数据」直开统一弹窗；「移除」先过统一销毁确认框；
+      // 合集横排行长按/右键有统一合集上下文菜单。
+      'showGalgameScrapeDialog(',
+      'HibikiDestructiveConfirmDialog(',
+      'showCollectionContextDialog(',
     ],
     'lib/src/pages/implementations/texthooker_page.dart': <String>[
       'showAppDialog<int>(',
@@ -604,10 +612,18 @@ void main() {
       'lib/src/pages/implementations/galgame_detail_page.dart': <String>[
         'showDialog<',
         'AlertDialog(',
+        'SimpleDialog(',
+      ],
+      'lib/src/mining/galgame_scrape_dialog.dart': <String>[
+        'showDialog<',
+        'AlertDialog(',
+        'SimpleDialog(',
       ],
       'lib/src/pages/implementations/games_library_page.dart': <String>[
         'showDialog<',
         'AlertDialog(',
+        // 游玩状态选择框已收口设计系统骨架（HibikiListItem 行），不再裸 SimpleDialog。
+        'SimpleDialog(',
         'showModalBottomSheet<',
         'SwitchListTile(',
       ],


### PR DESCRIPTION
## 背景
用户诉求（2026-07-27）：统一书籍/视频/游戏三库页的单卡右键菜单、合集右键菜单、右上角按钮和刮削体验；删除书籍页「在线目录」（属漫画域，漫画侧他人进行中）；追加「添加/修改 Bangumi 映射」。

## 改动
### 1. 在线目录入口移除（书籍侧）
- 书架页头按钮 + 「导入书」对话框底部按钮删除；漫画本体与下载页入口不动。
- 书架页保留 mokuro 下载队列监听（下载页路径落库后书架自动刷新依赖它）。

### 2. 合集右键菜单（三页此前全无）
- 新建共享 `showCollectionContextDialog`（collection_context_dialog.dart）：打开 / 重命名 / 标签 / 删除合集；删除支持「连同成员本体一起删」勾选，动作语义与合集详情页 AppBar 完全同源。
- `CollectionShelfRow` 加 `onContextMenu` 长按/右键通道（多选态自动压制）；书架合集行、视频合集封面卡、游戏合集行三处接线。游戏合集不提供删本体（删合集绝不删游戏，既有纪律）。

### 3. 游戏刮削重构（对齐视频式闭环）
- 旧「卡菜单→详情页编辑 tab→再点按钮→两个串行弹窗（候选纯文本）」收敛为单弹窗 `showGalgameScrapeDialog`：自动首搜、改词重搜、Bangumi+VNDB 合并候选带封面缩略图、行内应用转圈、弹窗内搜索中/失败可重试/空态三态。
- 卡菜单「刮削元数据」与详情页编辑 tab 按钮直开弹窗，消灭二跳。
- 「使用」= 元数据 + 封面一起落：显式选择候选覆盖现有封面（与视频手动匹配同语义）；隐式路径「已有封面绝不覆盖」保持不变（新纯函数 `shouldDownloadExplicitScrapedCover` + 显式/隐式对照测试）。

### 4. 添加/修改 Bangumi 映射（三域统一）
- 共享纯函数 `parseBangumiSubjectUrl`（bgm.tv / bangumi.tv / chii.in 的 /subject/<id>，容忍无 scheme/query/fragment）。
- 书/视频刮削弹窗：贴条目 URL 直连改绑；纯数字输入按「关键词搜索 + id 直取置顶去重」并列（数字可能就是标题，如《86》《1984》，两种意图都不牺牲）。
- 视频「条目信息」弹窗新增改绑按钮（复用「在线匹配封面」文案）跳在线匹配弹窗。
- 游戏弹窗 `normalizeGalgameScrapeQuery`：Bangumi/VNDB 条目 URL 归一成源 ID 走既有 validateId 直取。

### 5. 菜单项统一（次序约定：重命名→封面/刮削→媒体特有→加入合集→标签→删除）
- 书卡（EPUB/SRT）补「标签」项（走共享 TagPickerPage；推翻 TODO-455 旧决策）+ EPUB 卡直挂「在线刮削封面」。
- 视频卡菜单重排（标签从首位移到合集后）。
- 游戏卡菜单同序重排；「移除」补 `HibikiDestructiveConfirmDialog` 确认（说明只移出库不删磁盘文件）；「游玩状态」弹窗从裸 SimpleDialog 改设计系统骨架。

### i18n
+`game_scrape_search` / `game_scrape_use` / `game_scrape_search_failed` / `game_remove_confirm`；-`game_scrape_pick`（孤儿）。全部经 i18n_sync + `dart run slang`。

## 验证
- `flutter analyze` 全量（含 test）零 issue。
- `flutter test test/media --no-pub`：3411 通过。
- `flutter test test/pages --no-pub`：2295 通过（含更新后的书卡菜单守卫、游戏 ⋮/长按菜单一致性+次序守卫、MD3 静态守卫）。
- test/mining + 游戏定向套件：848+ 通过（含刮削弹窗 4 widget 守卫 + URL 归一化 6 纯函数测试、显式/隐式封面对照测试）。
- UI 交互路径（长按/右键弹窗、合集菜单、真机刮削联网）未真机复测——按仓库纪律不宣称「已修好」，待真机验收。

## 风险与兼容
- 全部为入口层/UI 层改动，无 schema 迁移、无持久化 key 变更。
- 旧「在线目录」功能本体未删，下载页入口照常。
- 游戏刮削落库逻辑从 `_scrape()` 抽取复用，多源 mixed 快照规则不变。

https://claude.ai/code/session_012pke15UjHkBG853yn8v2of