### PR TITLE
fix(gal): 浮窗穿透拆成双窗，点击真正落到游戏（BUG-951）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -254,7 +254,7 @@
 | [BUG-954](bugs/BUG-954-texthooker-mine-sentence-empty-non-windows.md) | ✅ | ✅ | 非外部窗口模式制卡 sentence 字段恒空 |
 | [BUG-953](bugs/BUG-953-texthooker-popup-overlay-cross-tab-residue.md) | ✅ | ✅ | games tab 保活时查词弹窗与 barrier 跨 tab 残留遮挡 |
 | [BUG-952](bugs/BUG-952-texthooker-thread-dropdown-value-mismatch.md) | ✅ | ✅ | texthooker 线程下拉 value 与动态 items 失配触发 debug 断言红屏 |
-| [BUG-951](bugs/BUG-951-gal-overlay-click-through-cross-process.md) | 🚧 | 🚧 | Hook 浮窗鼠标穿透 HTTRANSPARENT 跨进程不生效存疑须真机验证 |
+| [BUG-951](bugs/BUG-951-gal-overlay-click-through-cross-process.md) | ✅ | ✅ | Hook 浮窗鼠标穿透 HTTRANSPARENT 跨进程不生效存疑须真机验证 |
 | [BUG-950](bugs/BUG-950-gal-hook-session-stale-line-bleed.md) | ✅ | ✅ | galgame hook 会话重启后旧行串入新会话且新文本被当重复静默丢弃 |
 | [BUG-949](bugs/BUG-949-unity-resource-audio-extractor-stall.md) | ✅ | ✅ | Unity 资源音频提取队列阻塞后持续降级 |
 | [BUG-948](bugs/BUG-948-dual-game-capture-acceptance.md) | ✅ | ✅ | Galgame 捕获不能稳定将正确文本与游戏资源语音一一配对并制卡 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -254,7 +254,7 @@
 | [BUG-954](bugs/BUG-954-texthooker-mine-sentence-empty-non-windows.md) | ✅ | ✅ | 非外部窗口模式制卡 sentence 字段恒空 |
 | [BUG-953](bugs/BUG-953-texthooker-popup-overlay-cross-tab-residue.md) | ✅ | ✅ | games tab 保活时查词弹窗与 barrier 跨 tab 残留遮挡 |
 | [BUG-952](bugs/BUG-952-texthooker-thread-dropdown-value-mismatch.md) | ✅ | ✅ | texthooker 线程下拉 value 与动态 items 失配触发 debug 断言红屏 |
-| [BUG-951](bugs/BUG-951-gal-overlay-click-through-cross-process.md) | ✅ | ✅ | Hook 浮窗鼠标穿透 HTTRANSPARENT 跨进程不生效存疑须真机验证 |
+| [BUG-951](bugs/BUG-951-gal-overlay-click-through-cross-process.md) | 🚧 | 🚧 | Hook 浮窗鼠标穿透 HTTRANSPARENT 跨进程不生效存疑须真机验证 |
 | [BUG-950](bugs/BUG-950-gal-hook-session-stale-line-bleed.md) | ✅ | ✅ | galgame hook 会话重启后旧行串入新会话且新文本被当重复静默丢弃 |
 | [BUG-949](bugs/BUG-949-unity-resource-audio-extractor-stall.md) | ✅ | ✅ | Unity 资源音频提取队列阻塞后持续降级 |
 | [BUG-948](bugs/BUG-948-dual-game-capture-acceptance.md) | ✅ | ✅ | Galgame 捕获不能稳定将正确文本与游戏资源语音一一配对并制卡 |

--- a/docs/bugs/BUG-951-gal-overlay-click-through-cross-process.md
+++ b/docs/bugs/BUG-951-gal-overlay-click-through-cross-process.md
@@ -1,6 +1,25 @@
 ## BUG-951 · Hook 浮窗鼠标穿透 HTTRANSPARENT 跨进程不生效存疑须真机验证
 - **报告**：2026-07-21（PR#295 落地审查 H2，fable5）
-- **真实性**：⚠️ 待真机验证（静态可疑）。疑点 `hibiki/windows/runner/floating_lyric_window.cpp:617-622`：穿透仅靠 WM_NCHITTEST 返回 `HTTRANSPARENT`，Win32 契约中它只在同线程窗口间下传，对另一进程的游戏窗口不生效（层窗口 ~2% alpha 体表命中测试不透明），穿透模式下点击可能被浮窗吞掉而非落到游戏。
-- **[ ] ① 未修复** — 若真机复现：正解是穿透态切 `WS_EX_TRANSPARENT`（或体表 alpha=0），而非 HTTRANSPARENT。
-- **[ ] ② 未加自动化测试** — 真机手动验收（浮窗开穿透后点击游戏正文区能触达游戏）。
+- **真实性**：✅ 已确定性复现为真（2026-07-27）。最小跨进程 Win32 装置（两组对照，每组一对全新进程 + 一次真实 SendInput 点击）：体表 alpha=5/200 配 `HTTRANSPARENT` 时点击被完全吞掉（游戏和浮窗都收不到）；换 `WS_EX_TRANSPARENT` 后另一进程正常收到，与逐像素 alpha 无关。根因：`HTTRANSPARENT` 按 Win32 契约只在**同线程**窗口间下传，游戏是另一进程。
+  - 一直没被发现的原因：旧代码只在「背景不透明度=0」时看起来能用，那是层窗口逐像素命中测试的功劳；点在不透明的文字笔画上照样被吞。
+- **[x] ① 已修复** — 双窗设计（本轮）。
+  - 修前：`hibiki/windows/runner/floating_lyric_window.cpp` 的 `WM_NCHITTEST` 在穿透态对正文返回 `HTTRANSPARENT`，跨进程无效。
+  - 中途被否的一版（PR#460，已 revert）：按光标位置 16ms 轮询开关整窗 `WS_EX_TRANSPARENT`。它命中既有守卫 `interactivity is not driven by a hover timer`，且被证明**本质竞态**——定时器可被饿死，期间用户快速甩到工具条点一下会穿过去点进游戏，推进台词或选中分支破坏存档。
+  - 本轮定案：**不再让一个窗口同时当两种东西**。
+    - 正文窗（`FloatingLyricWindow`）在穿透态**静态**置 `WS_EX_TRANSPARENT`，纯视觉，整窗对鼠标不存在；`WM_NCHITTEST` 里的 `HTTRANSPARENT` 分支整块删除。
+    - 工具条搬进独立顶层窗 `HookToolbarWindow`（`hibiki/windows/runner/hook_toolbar_window.{h,cpp}`），**永不**带 `WS_EX_TRANSPARENT`，因此永远可点。没有状态可翻转，也就没有竞态可输。
+  - 关键不变量（写进代码而非只写文档）：`ApplyPassThroughExStyle()` 是唯一入口，**先**把工具条窗放上屏、**再**让正文停止接收点击；工具条建不出来就退回不进穿透并把 `pass_through_` 摁回 false（宁可忽略这次切换，也不把用户关在一个点不动的浮窗后面）。
+  - 顺带收敛：8 个槽位的 action / 字形 / 高亮态收进共享表 `hook_toolbar::kSlotActions` + `SlotGlyph/SlotActive`，两个窗口同表索引，物理上无法对「第 3 个按钮是什么」产生分歧；按钮执行逻辑收进单一 `DispatchControlAction()`。
+  - 行为差异（有意）：穿透态下正文窗不再自绘顶部工具条带与拖拽把手（它们已不接收鼠标，画出来就是骗人）；独立工具条在静止时以约 42% 不透明度常驻——它是唯一的退出口，隐形的退出口等于没有退出口。穿透态挡住游戏的死区从「整窗宽 × 约 34dip」缩小为「约 320dip × 40dip 的药丸」。
+  - 非 hook 实例（有声书歌词条 / 剪贴板文本窗）完全不进这条分支，窗口样式与渲染逐像素不变。
+- **[x] ② 已加自动化测试** — `hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart`（新增，源码扫描守卫）：
+  - `WS_EX_TRANSPARENT` 只允许在 `SetBodyExTransparent` 内被应用，且必须配 `SWP_FRAMECHANGED`；`SetBodyExTransparent` 只允许被 `ApplyPassThroughExStyle` 调用；
+  - `return HTTRANSPARENT;` 在两个文件中都不得出现；`SetTimer(` / `KillTimer(` / 轮询符号在两个文件中都不得出现（PR#460 回归门）；
+  - **顺序不变量**：`pass_through_toolbar_.Show(` 必须出现在 `SetBodyExTransparent(true)` 之前，且失败路径必须把 `pass_through_` 摁回 false；
+  - 工具条窗建窗 flags 不含 `WS_EX_TRANSPARENT`、含 `WS_EX_NOACTIVATE` / `WS_EX_TOPMOST`，且全文件没有 `GWL_EXSTYLE` 改写；
+  - 两窗共表（8 个 action 顺序逐个比对）、共字形、共派发、几何由正文窗单向下发；
+  - `CMakeLists.txt` 真的编了新 TU。
+  - 同时把 `hibiki/test/media/audiobook/floating_lyric_click_through_guard_test.dart` 里那条「禁止一切 `WS_EX_TRANSPARENT` 改写」的旧断言换成新契约：**保留**反定时器四条（那才是 PR#460 的真教训），把「禁用该位」换成「必须走唯一 applier + 必须有逃生工具条」。旧断言正是浮窗长期带着一个跨进程无效的穿透模式的原因，如实记录在测试注释里。
+  - **局限（如实说明）**：源码扫描锁的是接线，不是运行时行为。跨进程点击真的落到游戏、以及工具条在任意时刻都可点，仍需下面的 Windows 真机验收。C++ 进不了 Dart 单测；更强的 Windows itest 层因本机冒烟门长期红而受阻，属成本取舍，不是跳过。
+- **待真机验收（Windows）**：①开穿透 → 点浮窗覆盖的游戏正文区 → 游戏推进台词；②穿透态下点工具条 `↗` → 立刻退出穿透（不需要精准时机）；③穿透态下拖工具条 → 整个浮窗跟着移动，松手位置被记住；④关穿透 → 正文区恢复查词与拖拽。
 - **备注**：核心特性验证项，列入 Windows 真机验收清单。

--- a/docs/bugs/BUG-951-gal-overlay-click-through-cross-process.md
+++ b/docs/bugs/BUG-951-gal-overlay-click-through-cross-process.md
@@ -2,7 +2,7 @@
 - **报告**：2026-07-21（PR#295 落地审查 H2，fable5）
 - **真实性**：✅ 已确定性复现为真（2026-07-27）。最小跨进程 Win32 装置（两组对照，每组一对全新进程 + 一次真实 SendInput 点击）：体表 alpha=5/200 配 `HTTRANSPARENT` 时点击被完全吞掉（游戏和浮窗都收不到）；换 `WS_EX_TRANSPARENT` 后另一进程正常收到，与逐像素 alpha 无关。根因：`HTTRANSPARENT` 按 Win32 契约只在**同线程**窗口间下传，游戏是另一进程。
   - 一直没被发现的原因：旧代码只在「背景不透明度=0」时看起来能用，那是层窗口逐像素命中测试的功劳；点在不透明的文字笔画上照样被吞。
-- **[x] ① 已修复** — 双窗设计（本轮）。
+- **[ ] ① 已实现，未验收（implemented_unverified）** — 双窗设计（本轮，PR#481）。代码已落地但**没有任何一条真机验收跑过**，按本仓 galgame 硬规则不得记为已修复。
   - 修前：`hibiki/windows/runner/floating_lyric_window.cpp` 的 `WM_NCHITTEST` 在穿透态对正文返回 `HTTRANSPARENT`，跨进程无效。
   - 中途被否的一版（PR#460，已 revert）：按光标位置 16ms 轮询开关整窗 `WS_EX_TRANSPARENT`。它命中既有守卫 `interactivity is not driven by a hover timer`，且被证明**本质竞态**——定时器可被饿死，期间用户快速甩到工具条点一下会穿过去点进游戏，推进台词或选中分支破坏存档。
   - 本轮定案：**不再让一个窗口同时当两种东西**。
@@ -12,7 +12,7 @@
   - 顺带收敛：8 个槽位的 action / 字形 / 高亮态收进共享表 `hook_toolbar::kSlotActions` + `SlotGlyph/SlotActive`，两个窗口同表索引，物理上无法对「第 3 个按钮是什么」产生分歧；按钮执行逻辑收进单一 `DispatchControlAction()`。
   - 行为差异（有意）：穿透态下正文窗不再自绘顶部工具条带与拖拽把手（它们已不接收鼠标，画出来就是骗人）；独立工具条在静止时以约 42% 不透明度常驻——它是唯一的退出口，隐形的退出口等于没有退出口。穿透态挡住游戏的死区从「整窗宽 × 约 34dip」缩小为「约 320dip × 40dip 的药丸」。
   - 非 hook 实例（有声书歌词条 / 剪贴板文本窗）完全不进这条分支，窗口样式与渲染逐像素不变。
-- **[x] ② 已加自动化测试** — `hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart`（新增，源码扫描守卫）：
+- **[ ] ② 只有源码扫描守卫，缺运行时验证** — `hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart`（新增，源码扫描守卫）：
   - `WS_EX_TRANSPARENT` 只允许在 `SetBodyExTransparent` 内被应用，且必须配 `SWP_FRAMECHANGED`；`SetBodyExTransparent` 只允许被 `ApplyPassThroughExStyle` 调用；
   - `return HTTRANSPARENT;` 在两个文件中都不得出现；`SetTimer(` / `KillTimer(` / 轮询符号在两个文件中都不得出现（PR#460 回归门）；
   - **顺序不变量**：`pass_through_toolbar_.Show(` 必须出现在 `SetBodyExTransparent(true)` 之前，且失败路径必须把 `pass_through_` 摁回 false；
@@ -21,5 +21,9 @@
   - `CMakeLists.txt` 真的编了新 TU。
   - 同时把 `hibiki/test/media/audiobook/floating_lyric_click_through_guard_test.dart` 里那条「禁止一切 `WS_EX_TRANSPARENT` 改写」的旧断言换成新契约：**保留**反定时器四条（那才是 PR#460 的真教训），把「禁用该位」换成「必须走唯一 applier + 必须有逃生工具条」。旧断言正是浮窗长期带着一个跨进程无效的穿透模式的原因，如实记录在测试注释里。
   - **局限（如实说明）**：源码扫描锁的是接线，不是运行时行为。跨进程点击真的落到游戏、以及工具条在任意时刻都可点，仍需下面的 Windows 真机验收。C++ 进不了 Dart 单测；更强的 Windows itest 层因本机冒烟门长期红而受阻，属成本取舍，不是跳过。
-- **待真机验收（Windows）**：①开穿透 → 点浮窗覆盖的游戏正文区 → 游戏推进台词；②穿透态下点工具条 `↗` → 立刻退出穿透（不需要精准时机）；③穿透态下拖工具条 → 整个浮窗跟着移动，松手位置被记住；④关穿透 → 正文区恢复查词与拖拽。
+- 🔴 **还差什么（这条 bug 未完成的全部原因）**：Windows 真机四条验收**一条都没做**。跨进程点击是否真的落到游戏、工具条是否在任意时刻都可点，源码扫描一个字也证明不了。四条如下，全部通过前本条保持未完成：
+  1. 开穿透 → 点浮窗覆盖的游戏正文区 → **游戏推进台词**（这条是 BUG-951 本身，其余三条都是它的配套）；
+  2. 穿透态下点工具条 `↗` → 立刻退出穿透（不需要精准时机、不需要连点）；
+  3. 穿透态下拖工具条 → 整个浮窗跟着移动且**不跳位**，松手位置被记住（审查中已修一处锚点错位：工具条曾拿自己的窗矩形当正文窗原点，第一帧会把正文窗平移约 205dip 并把药丸甩出光标）；
+  4. 关穿透 → 正文区恢复查词与拖拽。
 - **备注**：核心特性验证项，列入 Windows 真机验收清单。

--- a/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -179,6 +179,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
       onReplayVoice: replayCurrentLine,
       onRecaptureVoice: recaptureCurrentLine,
       onLockChanged: _onLockChanged,
+      onPassThroughChanged: _onPassThroughChanged,
       onBoundsChanged: _onBoundsChanged,
     );
     _session.addListener(_scheduleSync);
@@ -415,6 +416,15 @@ class GalHookTextOverlayController extends ChangeNotifier {
 
   Future<void> _onLockChanged(bool locked) async {
     _locked = locked;
+    notifyListeners();
+  }
+
+  /// native 拒绝进入穿透（逃生工具条窗建不出来）时的对账（BUG-951）。不跟着退回，
+  /// Dart 的标志会卡在 true，用户下一次按 `↗` 只会发一条 setPassThrough(false)
+  /// 到已经是 false 的 native —— 表现成「点了没反应」。
+  Future<void> _onPassThroughChanged(bool passThrough) async {
+    if (_passThrough == passThrough) return;
+    _passThrough = passThrough;
     notifyListeners();
   }
 

--- a/hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart
+++ b/hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart
@@ -49,6 +49,13 @@ typedef GalHookTextLookupHandler = FutureOr<void> Function(
 );
 typedef GalHookTextEventHandler = FutureOr<void> Function();
 typedef GalHookTextLockHandler = FutureOr<void> Function(bool locked);
+
+/// native 侧穿透态被否决 / 变更时的回传（BUG-951）。native 建不出逃生工具条窗
+/// 时会拒绝进入穿透并把自己摁回 false；Dart 必须跟着退回，否则它的标志卡在
+/// true，用户下一次按 `↗` 会变成一次看不出反应的空点击。
+typedef GalHookTextPassThroughHandler = FutureOr<void> Function(
+  bool passThrough,
+);
 typedef GalHookTextBoundsHandler = FutureOr<void> Function(
   GalHookTextWindowRect rect,
 );
@@ -86,6 +93,7 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
   static GalHookTextEventHandler? _onReplayVoice;
   static GalHookTextEventHandler? _onRecaptureVoice;
   static GalHookTextLockHandler? _onLockChanged;
+  static GalHookTextPassThroughHandler? _onPassThroughChanged;
   static GalHookTextBoundsHandler? _onBoundsChanged;
 
   static void setEventHandlers({
@@ -98,6 +106,7 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     GalHookTextEventHandler? onReplayVoice,
     GalHookTextEventHandler? onRecaptureVoice,
     GalHookTextLockHandler? onLockChanged,
+    GalHookTextPassThroughHandler? onPassThroughChanged,
     GalHookTextBoundsHandler? onBoundsChanged,
   }) {
     _onLookupText = onLookupText;
@@ -109,6 +118,7 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     _onReplayVoice = onReplayVoice;
     _onRecaptureVoice = onRecaptureVoice;
     _onLockChanged = onLockChanged;
+    _onPassThroughChanged = onPassThroughChanged;
     _onBoundsChanged = onBoundsChanged;
     _instance.channel.setMethodCallHandler(_handleNativeCall);
   }
@@ -123,6 +133,7 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     _onReplayVoice = null;
     _onRecaptureVoice = null;
     _onLockChanged = null;
+    _onPassThroughChanged = null;
     _onBoundsChanged = null;
     _instance.channel.setMethodCallHandler(null);
   }
@@ -163,6 +174,9 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
         break;
       case 'lockChanged':
         await _onLockChanged?.call(args['locked'] == true);
+        break;
+      case 'passThroughChanged':
+        await _onPassThroughChanged?.call(args['passThrough'] == true);
         break;
       case 'windowRectChanged':
         final GalHookTextWindowRect? rect = GalHookTextWindowRect.fromMap(args);

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+954
+version: 1.3.1+955
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/lookup/gal_hook_text_overlay_channel_test.dart
+++ b/hibiki/test/lookup/gal_hook_text_overlay_channel_test.dart
@@ -94,6 +94,7 @@ void main() {
       onOpenWorkbench: () => events.add('workbench'),
       onClose: () => events.add('close'),
       onLockChanged: (bool locked) => events.add('lock:$locked'),
+      onPassThroughChanged: (bool value) => events.add('passThrough:$value'),
       onBoundsChanged: (GalHookTextWindowRect value) => rect = value,
     );
 
@@ -103,6 +104,11 @@ void main() {
     await invokeFromNative('openWorkbench');
     await invokeFromNative('close');
     await invokeFromNative('lockChanged', <String, Object?>{'locked': true});
+    // BUG-951: native 拒绝进入穿透时的对账事件，Dart 必须收得到。
+    await invokeFromNative(
+      'passThroughChanged',
+      <String, Object?>{'passThrough': false},
+    );
     await invokeFromNative('windowRectChanged', <String, Object?>{
       'left': 10,
       'top': 20,
@@ -116,7 +122,8 @@ void main() {
       'transparent',
       'workbench',
       'close',
-      'lock:true'
+      'lock:true',
+      'passThrough:false',
     ]);
     expect(rect?.toMap(), <String, Object?>{
       'left': 10,

--- a/hibiki/test/media/audiobook/floating_lyric_click_through_guard_test.dart
+++ b/hibiki/test/media/audiobook/floating_lyric_click_through_guard_test.dart
@@ -45,14 +45,29 @@ void main() {
     test('interactivity is not driven by a hover timer', () {
       // A timer-driven transparent/interactive flip is inherently racy: a fast
       // mouse-enter + click can arrive while WS_EX_TRANSPARENT is still set.
+      // This is the invariant that killed PR#460 and it still holds.
       expect(cpp.contains('PollCursorInteractivity'), isFalse);
       expect(cpp.contains('ApplyInteractive'), isFalse);
       expect(cpp.contains('SetTimer('), isFalse);
       expect(cpp.contains('KillTimer('), isFalse);
-      expect(cpp.contains('&= ~static_cast<LONG_PTR>(WS_EX_TRANSPARENT)'),
-          isFalse);
-      expect(
-          cpp.contains('|= static_cast<LONG_PTR>(WS_EX_TRANSPARENT)'), isFalse);
+
+      // BUG-951 UPDATE — this test used to also forbid touching
+      // WS_EX_TRANSPARENT at all. That blanket ban was the reason the overlay
+      // shipped a pass-through mode that did nothing across processes: the bit
+      // is the ONLY cross-process click-through mechanism Win32 has. What was
+      // actually unsafe was flipping it by cursor position on a timer, which
+      // the four assertions above already forbid.
+      //
+      // The bit is now applied statically for as long as the user keeps
+      // pass-through on, with the toolbar moved into its own always-clickable
+      // window so there is nothing to be locked out of. The full contract —
+      // one applier, escape hatch shown first, refuse the toggle if it cannot
+      // be — is pinned by
+      // test/tools/gal_overlay_passthrough_dual_window_guard_test.dart.
+      expect(cpp.contains('ApplyPassThroughExStyle'), isTrue,
+          reason: 'Pass-through must go through the single applier that also '
+              'puts the escape-hatch toolbar on screen.');
+      expect(cpp.contains('pass_through_toolbar_.Show('), isTrue);
     });
 
     test('word lookup is preserved — taps still report a char index', () {

--- a/hibiki/test/tools/gal_hook_overlay_buttons_guard_test.dart
+++ b/hibiki/test/tools/gal_hook_overlay_buttons_guard_test.dart
@@ -6,54 +6,87 @@ import 'package:path/path.dart' as p;
 /// Hook 台词浮窗工具栏的绘制与命中必须来自同一个槽数：Render() 画 N 个按钮，
 /// ControlActionAt() 就得给出 N 个 action，否则点击会落到看不见的按钮上，或者
 /// 整排按钮相对居中布局漂移（浮窗是独立 native 窗口，Dart 侧测不到这层）。
+///
+/// BUG-951 起工具栏是两个窗口（正文窗内嵌一份 + 穿透态的独立 HookToolbarWindow），
+/// 槽表因此上移到 `hook_toolbar_window.h` 的 `kSlotActions`；两窗同表索引，本守卫
+/// 也随之改成「槽数 / 槽表 / 字形 / 命中四者对齐」，而不是数已经不存在的
+/// `hook_button(N,` 与 `case N:` 字面量。
 void main() {
   final String runner = p.join('windows', 'runner');
   final File window = File(p.join(runner, 'floating_lyric_window.cpp'));
+  final File toolbarHeader = File(p.join(runner, 'hook_toolbar_window.h'));
+  final File toolbar = File(p.join(runner, 'hook_toolbar_window.cpp'));
   final File host = File(p.join(runner, 'flutter_window.cpp'));
 
   test('hook 工具栏槽数与绘制、命中映射三者一致', () {
     final String source = window.readAsStringSync();
-    final RegExp slotCount =
-        RegExp(r'kHookTextControlSlotCount\s*=\s*(\d+)\s*;');
-    final Match? declared = slotCount.firstMatch(source);
-    expect(declared, isNotNull, reason: '找不到 kHookTextControlSlotCount 声明');
+    final String header = toolbarHeader.readAsStringSync();
+
+    final Match? declared =
+        RegExp(r'kSlotCount\s*=\s*(\d+)\s*;').firstMatch(header);
+    expect(declared, isNotNull, reason: '找不到 hook_toolbar::kSlotCount 声明');
     final int slots = int.parse(declared!.group(1)!);
 
-    final List<int> drawn = RegExp(r'hook_button\((\d+),')
-        .allMatches(source)
-        .map((Match m) => int.parse(m.group(1)!))
-        .toList()
-      ..sort();
+    // 正文窗不得再持有自己的槽数：必须从共享表推导。
     expect(
-      drawn,
-      List<int>.generate(slots, (int i) => i),
-      reason: 'Render() 必须正好画出 0..N-1 全部槽位',
+      source.contains('kHookTextControlSlotCount = hook_toolbar::kSlotCount'),
+      isTrue,
+      reason: '正文窗的槽数必须由 hook_toolbar::kSlotCount 推导，不得另开一份',
     );
 
-    final int hookHitStart = source.indexOf('if (hook_text_mode_) {',
-        source.indexOf('std::string FloatingLyricWindow::ControlActionAt'));
-    expect(hookHitStart, greaterThan(0));
-    // 只截 hook 分支自身：后面还有 clipboard / 歌词条的槽位 switch，混进来会误判。
-    final int hookHitEnd = source.indexOf('const float lock_x', hookHitStart);
-    expect(hookHitEnd, greaterThan(hookHitStart));
-    final String hookHit = source.substring(hookHitStart, hookHitEnd);
-    final List<int> mapped = RegExp(r'case (\d+):')
-        .allMatches(hookHit)
+    // 槽表必须正好有 N 个 action。
+    final int tableStart = header.indexOf('kSlotActions');
+    expect(tableStart, greaterThan(0));
+    final String table =
+        header.substring(tableStart, header.indexOf('};', tableStart));
+    expect(
+      RegExp('"([a-zA-Z]+)"').allMatches(table).length,
+      slots,
+      reason: 'kSlotActions 必须为每个槽位给出 action',
+    );
+
+    // 字形表必须覆盖 0..N-1（default 分支只是兜底，不算覆盖）。
+    final String toolbarSource = toolbar.readAsStringSync();
+    final int glyphStart = toolbarSource.indexOf('const wchar_t* SlotGlyph');
+    final int glyphEnd = toolbarSource.indexOf('bool SlotActive', glyphStart);
+    expect(glyphStart, greaterThan(0), reason: '找不到 SlotGlyph 定义');
+    expect(glyphEnd, greaterThan(glyphStart));
+    final String glyphBody = toolbarSource.substring(glyphStart, glyphEnd);
+    final List<int> glyphCases = RegExp(r'case (\d+):')
+        .allMatches(glyphBody)
         .map((Match m) => int.parse(m.group(1)!))
         .toList()
       ..sort();
     expect(
-      mapped,
+      glyphCases,
       List<int>.generate(slots, (int i) => i),
-      reason: 'ControlActionAt() 必须为每个绘制出来的槽位给出 action',
+      reason: 'SlotGlyph 必须为 0..N-1 每个槽位给出字形',
+    );
+
+    // 两个窗口的绘制与命中都必须遍历同一个槽数并索引同一张表。
+    expect(
+      source.contains('for (int slot = 0; slot < kHookTextControlSlotCount;'),
+      isTrue,
+      reason: '正文窗 Render() 必须按槽数循环画出全部槽位',
+    );
+    expect(
+      source.contains('hook_toolbar::kSlotActions[slot]'),
+      isTrue,
+      reason: 'ControlActionAt() 必须索引共享槽表，不得另抄一份映射',
+    );
+    expect(
+      toolbarSource.contains('hook_toolbar::kSlotActions[slot]'),
+      isTrue,
+      reason: '独立工具条窗的命中同样必须索引共享槽表',
     );
   });
 
   test('语音控件 action 与 native 状态方法齐全', () {
     final String source = window.readAsStringSync();
+    final String header = toolbarHeader.readAsStringSync();
     for (final String action in <String>['replayVoice', 'recaptureVoice']) {
       expect(
-        source,
+        header,
         contains('"$action"'),
         reason: '浮窗必须能把「$action」按钮点击回传给 Dart',
       );

--- a/hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart
+++ b/hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart
@@ -32,6 +32,7 @@ void main() {
   late String toolbarHeader;
   late String bodyHeader;
   late String cmake;
+  late String host;
 
   setUpAll(() {
     body = File('windows/runner/floating_lyric_window.cpp').readAsStringSync();
@@ -41,6 +42,7 @@ void main() {
     toolbarHeader =
         File('windows/runner/hook_toolbar_window.h').readAsStringSync();
     cmake = File('windows/runner/CMakeLists.txt').readAsStringSync();
+    host = File('windows/runner/flutter_window.cpp').readAsStringSync();
   });
 
   /// Returns the body of `signature { ... }`, brace-matched, so an assertion
@@ -184,6 +186,13 @@ void main() {
       expect(applier.contains('pass_through_ = false;'), isTrue,
           reason: 'Better to drop the toggle than to strand the user behind '
               'an overlay they can no longer click.');
+      // ...and the veto must be reported, or Dart's own flag stays true and the
+      // user's next press on the button is a press that does nothing visible.
+      expect(applier.contains('on_pass_through_(false)'), isTrue,
+          reason: 'A silently vetoed toggle desyncs Dart and eats the next '
+              'press on the escape-hatch button.');
+      expect(host.contains('"passThroughChanged"'), isTrue,
+          reason: 'The veto must reach Dart over the gal_hook_text channel.');
     });
 
     test('the toolbar window is never mouse-transparent', () {

--- a/hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart
+++ b/hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart
@@ -64,6 +64,14 @@ void main() {
   int countOf(String haystack, String needle) =>
       needle.allMatches(haystack).length;
 
+  /// Drops `// ...` comments so a call-site count cannot be thrown off (in
+  /// either direction) by prose that mentions the symbol.
+  String stripLineComments(String source) =>
+      source.split('\n').map((String line) {
+        final int slashes = line.indexOf('//');
+        return slashes < 0 ? line : line.substring(0, slashes);
+      }).join('\n');
+
   group('BUG-951 · the body window is really click-through', () {
     test('WS_EX_TRANSPARENT is applied, and only from one function', () {
       // The whole point of the fix: HTTRANSPARENT does not cross a process
@@ -114,11 +122,28 @@ void main() {
 
     test('pass-through is not driven by a timer (PR#460 regression)', () {
       for (final String source in <String>[body, toolbar]) {
-        expect(source.contains('SetTimer('), isFalse);
-        expect(source.contains('KillTimer('), isFalse);
+        // Any Win32 timer entry point at all, not just SetTimer/KillTimer:
+        // SetCoalescableTimer would otherwise re-create PR#460 verbatim while
+        // passing a SetTimer-only ban. Neither file has a legitimate timer.
+        expect(source.contains('Timer('), isFalse,
+            reason: 'No timer of any kind may drive pass-through.');
+        expect(source.contains('WM_TIMER'), isFalse);
+        // Nor a mouse hook, the other way to poll the cursor off-thread.
+        expect(source.contains('SetWindowsHookEx'), isFalse);
         expect(source.contains('PollCursorInteractivity'), isFalse);
         expect(source.contains('ApplyPassThroughHitTest'), isFalse);
       }
+    });
+
+    test('only the three lifecycle edges may re-apply pass-through', () {
+      // SetBodyExTransparent being funnelled through ApplyPassThroughExStyle is
+      // worth nothing if some cursor-driven poller may call the funnel itself.
+      // Show / Hide / SetPassThrough are the only legal callers; anything else
+      // means the "no state to race over" property has been given up.
+      final String code = stripLineComments(body);
+      expect(countOf(code, 'ApplyPassThroughExStyle()'), 3 + 1 /* definition */,
+          reason: 'Callers must stay exactly Show(), Hide(), SetPassThrough(). '
+              'A fourth caller is how a hover race gets back in.');
     });
 
     test('show / hide both route through the single applier', () {

--- a/hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart
+++ b/hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart
@@ -1,0 +1,283 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-951 — source-scan guards for the galgame hook overlay's pass-through
+/// design.
+///
+/// Why a source scan: the load-bearing code is a pair of Win32 windows in
+/// `windows/runner/`. It cannot be instantiated from `flutter test` (no message
+/// loop, no Direct2D, and the failure is defined by another PROCESS receiving a
+/// click). These guards therefore pin the wiring whose loss would silently
+/// re-introduce one of the two failure modes we have already shipped:
+///
+///  1. HTTRANSPARENT-only pass-through — swallowed the click entirely, because
+///     that hit-test result only walks same-thread windows and the game is a
+///     different process (the original BUG-951).
+///  2. Timer-driven WS_EX_TRANSPARENT flipping — a starved timer leaves the bit
+///     set while the cursor is already over the toolbar, so the click falls
+///     into the game and advances dialogue / picks a branch (PR#460, reverted).
+///
+/// The shipped design has no state to lose a race over: the body window is
+/// click-through for exactly as long as the user keeps pass-through on, and the
+/// toolbar is a separate window that is never transparent.
+///
+/// Limitation, stated plainly: a text scan pins the WIRING, not the runtime
+/// behaviour. Cross-process click delivery and the "toolbar always clickable"
+/// property still need the Windows real-device pass recorded in
+/// `docs/bugs/BUG-951-gal-overlay-click-through-cross-process.md`.
+void main() {
+  late String body;
+  late String toolbar;
+  late String toolbarHeader;
+  late String bodyHeader;
+  late String cmake;
+
+  setUpAll(() {
+    body = File('windows/runner/floating_lyric_window.cpp').readAsStringSync();
+    bodyHeader =
+        File('windows/runner/floating_lyric_window.h').readAsStringSync();
+    toolbar = File('windows/runner/hook_toolbar_window.cpp').readAsStringSync();
+    toolbarHeader =
+        File('windows/runner/hook_toolbar_window.h').readAsStringSync();
+    cmake = File('windows/runner/CMakeLists.txt').readAsStringSync();
+  });
+
+  /// Returns the body of `signature { ... }`, brace-matched, so an assertion
+  /// about "inside function X" cannot be satisfied by a match elsewhere.
+  String functionBody(String source, String signature) {
+    final int start = source.indexOf(signature);
+    expect(start, isNot(-1), reason: 'missing $signature');
+    int i = source.indexOf('{', start);
+    expect(i, isNot(-1), reason: 'no opening brace after $signature');
+    int depth = 0;
+    for (int j = i; j < source.length; j++) {
+      if (source[j] == '{') depth++;
+      if (source[j] == '}') {
+        depth--;
+        if (depth == 0) return source.substring(i, j + 1);
+      }
+    }
+    fail('unbalanced braces after $signature');
+  }
+
+  int countOf(String haystack, String needle) =>
+      needle.allMatches(haystack).length;
+
+  group('BUG-951 · the body window is really click-through', () {
+    test('WS_EX_TRANSPARENT is applied, and only from one function', () {
+      // The whole point of the fix: HTTRANSPARENT does not cross a process
+      // boundary, WS_EX_TRANSPARENT does. The bit must actually be used.
+      expect(body.contains('WS_EX_TRANSPARENT'), isTrue,
+          reason: 'Cross-process pass-through needs the ex-style bit.');
+
+      // ...but from exactly one place, so there can never be a second code path
+      // that strips clicks without also putting the escape hatch on screen.
+      // Count the *expression*, not the word: the token also appears in
+      // explanatory comments, which are harmless. The cast is the only way the
+      // bit reaches an ex-style, and it must exist exactly once, inside the
+      // single setter.
+      const String applyExpr = 'static_cast<LONG_PTR>(WS_EX_TRANSPARENT)';
+      final String setter = functionBody(
+          body, 'void FloatingLyricWindow::SetBodyExTransparent(bool enabled)');
+      expect(countOf(setter, applyExpr), 1);
+      expect(countOf(body, applyExpr), 1,
+          reason: 'The ex-style bit must only be applied inside '
+              'SetBodyExTransparent.');
+      expect(setter.contains('SetWindowLongPtr(hwnd_, GWL_EXSTYLE'), isTrue);
+      expect(setter.contains('SWP_FRAMECHANGED'), isTrue,
+          reason: 'Without SWP_FRAMECHANGED the window keeps hit-testing with '
+              'the old ex-style.');
+    });
+
+    test('SetBodyExTransparent is only ever called by ApplyPassThroughExStyle',
+        () {
+      final String applier = functionBody(
+          body, 'void FloatingLyricWindow::ApplyPassThroughExStyle()');
+      // 3 call sites total: the two inside ApplyPassThroughExStyle (off-path,
+      // failure-path) plus the enable at its end. Any call from elsewhere means
+      // some other code path can take clicks away.
+      expect(countOf(applier, 'SetBodyExTransparent('), 3,
+          reason: 'off-path, toolbar-failed path, enable path');
+      expect(countOf(body, 'SetBodyExTransparent('), 3 + 1 /* definition */,
+          reason: 'unexpected extra caller outside ApplyPassThroughExStyle');
+      expect(bodyHeader.contains('void SetBodyExTransparent(bool enabled);'),
+          isTrue);
+    });
+
+    test('the discredited HTTRANSPARENT mechanism is gone', () {
+      expect(body.contains('return HTTRANSPARENT;'), isFalse,
+          reason: 'HTTRANSPARENT never reaches another process — that IS '
+              'BUG-951.');
+      expect(toolbar.contains('return HTTRANSPARENT;'), isFalse);
+    });
+
+    test('pass-through is not driven by a timer (PR#460 regression)', () {
+      for (final String source in <String>[body, toolbar]) {
+        expect(source.contains('SetTimer('), isFalse);
+        expect(source.contains('KillTimer('), isFalse);
+        expect(source.contains('PollCursorInteractivity'), isFalse);
+        expect(source.contains('ApplyPassThroughHitTest'), isFalse);
+      }
+    });
+
+    test('show / hide both route through the single applier', () {
+      expect(
+          functionBody(body, 'bool FloatingLyricWindow::Show(HWND owner)')
+              .contains('ApplyPassThroughExStyle()'),
+          isTrue);
+      expect(
+          functionBody(body, 'void FloatingLyricWindow::Hide()')
+              .contains('ApplyPassThroughExStyle()'),
+          isTrue);
+      expect(
+          functionBody(body,
+                  'void FloatingLyricWindow::SetPassThrough(bool enabled)')
+              .contains('ApplyPassThroughExStyle()'),
+          isTrue);
+    });
+  });
+
+  group('BUG-951 · the user can always get back out', () {
+    test('the escape hatch is shown BEFORE the body stops taking clicks', () {
+      final String applier = functionBody(
+          body, 'void FloatingLyricWindow::ApplyPassThroughExStyle()');
+      final int show = applier.indexOf('pass_through_toolbar_.Show(');
+      final int enable = applier.indexOf('SetBodyExTransparent(true)');
+      expect(show, isNot(-1));
+      expect(enable, isNot(-1));
+      expect(show < enable, isTrue,
+          reason: 'Ordering is the invariant: the body may only go '
+              'click-through once the toolbar window exists.');
+    });
+
+    test('a toolbar that cannot be created cancels pass-through', () {
+      final String applier = functionBody(
+          body, 'void FloatingLyricWindow::ApplyPassThroughExStyle()');
+      expect(applier.contains('if (!pass_through_toolbar_.Show('), isTrue,
+          reason: 'The Show() result must be checked, not ignored.');
+      expect(applier.contains('pass_through_ = false;'), isTrue,
+          reason: 'Better to drop the toggle than to strand the user behind '
+              'an overlay they can no longer click.');
+    });
+
+    test('the toolbar window is never mouse-transparent', () {
+      final int create = toolbar.indexOf('CreateWindowExW(');
+      expect(create, isNot(-1));
+      final String flags = toolbar.substring(
+          create, toolbar.indexOf('kWindowClassName', create));
+      expect(flags.contains('WS_EX_TRANSPARENT'), isFalse,
+          reason: 'This window IS the escape hatch; it must always be '
+              'clickable.');
+      expect(flags.contains('WS_EX_NOACTIVATE'), isTrue,
+          reason: 'Clicking a button must not steal focus from the game.');
+      expect(flags.contains('WS_EX_TOPMOST'), isTrue,
+          reason: 'It has to float above both the game and the overlay body.');
+      // Nowhere else either — not even a later SetWindowLongPtr.
+      expect(toolbar.contains('SetWindowLongPtr(hwnd_, GWL_EXSTYLE'), isFalse);
+    });
+
+    test('the overlay can still be moved while the body takes no input', () {
+      // With the body click-through, dragging it is impossible; the toolbar
+      // carries the drag and asks the owner to move (which clamps to the work
+      // area, so the overlay cannot be dragged off-screen).
+      expect(toolbar.contains('on_drag_('), isTrue);
+      expect(toolbarHeader.contains('using DragCallback'), isTrue);
+      expect(
+          body.contains('void FloatingLyricWindow::MoveBodyTo(int x, int y)'),
+          isTrue);
+      expect(
+          functionBody(
+                  body, 'void FloatingLyricWindow::MoveBodyTo(int x, int y)')
+              .contains('ClampOriginToWorkArea('),
+          isTrue);
+    });
+  });
+
+  group('BUG-951 · the two windows cannot drift apart', () {
+    test('slot -> action is one shared table', () {
+      // Both windows index hook_toolbar::kSlotActions, so button 3 is
+      // togglePassThrough in both or in neither.
+      expect(toolbarHeader.contains('kSlotActions'), isTrue);
+      expect(body.contains('hook_toolbar::kSlotActions[slot]'), isTrue,
+          reason: 'The body must not keep a private copy of the mapping.');
+      expect(toolbar.contains('hook_toolbar::kSlotActions[slot]'), isTrue);
+
+      final String table = toolbarHeader.substring(
+          toolbarHeader.indexOf('kSlotActions'),
+          toolbarHeader.indexOf('};', toolbarHeader.indexOf('kSlotActions')));
+      const List<String> expected = <String>[
+        'replayVoice',
+        'recaptureVoice',
+        'toggleFollow',
+        'togglePassThrough',
+        'toggleTransparency',
+        'lock',
+        'openWorkbench',
+        'close',
+      ];
+      final List<String> found = RegExp('"([a-zA-Z]+)"')
+          .allMatches(table)
+          .map((RegExpMatch m) => m.group(1)!)
+          .toList();
+      expect(found, expected,
+          reason: 'Slot order is the wire contract with the Dart controller.');
+      expect(toolbarHeader.contains('constexpr int kSlotCount = 8'), isTrue);
+      expect(
+          body.contains('kHookTextControlSlotCount = hook_toolbar::kSlotCount'),
+          isTrue,
+          reason: 'The body must derive its slot count from the shared table.');
+    });
+
+    test('glyph + active tint are shared too', () {
+      expect(body.contains('hook_toolbar::SlotGlyph(slot, tb_states)'), isTrue);
+      expect(
+          body.contains('hook_toolbar::SlotActive(slot, tb_states)'), isTrue);
+      expect(
+          toolbar.contains('hook_toolbar::SlotGlyph(slot, states_)'), isTrue);
+    });
+
+    test('one dispatcher runs a button, whichever window was clicked', () {
+      expect(bodyHeader.contains('void DispatchControlAction('), isTrue);
+      final String applier = functionBody(
+          body, 'void FloatingLyricWindow::ApplyPassThroughExStyle()');
+      expect(applier.contains('DispatchControlAction(action)'), isTrue,
+          reason: 'The toolbar action callback must reuse the body dispatcher, '
+              'not a second copy of the lock / topmost logic.');
+      // The lock + topmost toggles live in the dispatcher only.
+      final String dispatcher = functionBody(body,
+          'void FloatingLyricWindow::DispatchControlAction(const std::string& action)');
+      expect(dispatcher.contains('on_lock_'), isTrue);
+      expect(dispatcher.contains('topmost_ = !topmost_'), isTrue);
+    });
+
+    test('geometry is pushed from the body, not recomputed in the toolbar', () {
+      expect(
+          body.contains(
+              'hook_toolbar::Layout FloatingLyricWindow::ComputePassThroughToolbarLayout()'),
+          isTrue);
+      // The toolbar hit-tests against the layout it was given; if it grew its
+      // own dip constants the two toolbars could disagree about where a button
+      // is, which is exactly the class of bug that makes a click land on the
+      // wrong function.
+      expect(toolbar.contains('layout_.button_px'), isTrue);
+      expect(toolbar.contains('kButtonSizeDip'), isFalse);
+      expect(toolbar.contains('kControlsTopDip'), isFalse);
+    });
+
+    test('the in-body toolbar is not painted while the body is click-through',
+        () {
+      expect(
+          body.contains(
+              'const bool draw_body_toolbar = !(hook_text_mode_ && pass_through_);'),
+          isTrue,
+          reason: 'Two toolbars drawn at the same spot, one of them dead, is '
+              'the UI lie this design exists to remove.');
+    });
+  });
+
+  test('the new translation unit is actually built', () {
+    expect(cmake.contains('"hook_toolbar_window.cpp"'), isTrue,
+        reason: 'A file missing from CMakeLists silently never ships.');
+  });
+}

--- a/hibiki/windows/runner/CMakeLists.txt
+++ b/hibiki/windows/runner/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(${BINARY_NAME} WIN32
   "floating_lyric_window.cpp"
   "foreground_selection.cpp"
   "global_lookup_window.cpp"
+  "hook_toolbar_window.cpp"
   "low_level_mouse_hook.cpp"
   "main.cpp"
   "utils.cpp"

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -562,6 +562,12 @@ void FloatingLyricWindow::ApplyPassThroughExStyle() {
                                   ToolbarStyle(), ToolbarStates())) {
     SetBodyExTransparent(false);
     pass_through_ = false;
+    // Tell Dart the toggle was refused. Without this its own flag stays true,
+    // and the user's next press on the button sends setPassThrough(false) into
+    // an already-false native state — a press that visibly does nothing.
+    if (on_pass_through_) {
+      on_pass_through_(false);
+    }
     return;
   }
   SetBodyExTransparent(true);

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -75,7 +75,12 @@ constexpr int kControlSlotCount = 5;
 // two leading slots are the voice controls (replay the line's captured audio;
 // open a recapture window so the user can replay the line inside the game and
 // have it recorded onto that line).
-constexpr int kHookTextControlSlotCount = 8;
+constexpr int kHookTextControlSlotCount = hook_toolbar::kSlotCount;
+// BUG-951: padding between the standalone pass-through toolbar window's edge
+// and its button row. Small on purpose — this window sits ON TOP of the game
+// and every pixel of it is a pixel the player cannot click — but non-zero so
+// there is a background strip to grab when dragging the overlay.
+constexpr float kToolbarWindowMarginDip = 5.0f;
 
 // Text-only clipboard window (Luna-style hover toolbar). A thin top strip is
 // ALWAYS a mouse catch (drawn at ~2% alpha across the full width) so the fully
@@ -330,6 +335,9 @@ bool FloatingLyricWindow::Show(HWND owner) {
   SetWindowPos(hwnd_, topmost_ ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
   visible_ = true;
+  // BUG-951: a re-show while pass-through is still on must re-create the
+  // escape-hatch toolbar and re-arm the body's click-through in one place.
+  ApplyPassThroughExStyle();
   RequestRender();
   return true;
 }
@@ -339,6 +347,10 @@ void FloatingLyricWindow::Hide() {
   hovered_ = false;
   tracking_mouse_leave_ = false;
   dragging_ = false;
+  // BUG-951: hand clicks back unconditionally and take the toolbar down with
+  // the body. A hidden window that is still WS_EX_TRANSPARENT would come back
+  // click-through even if pass-through was switched off while hidden.
+  ApplyPassThroughExStyle();
   if (hwnd_ != nullptr) {
     ShowWindow(hwnd_, SW_HIDE);
   }
@@ -460,8 +472,9 @@ void FloatingLyricWindow::SetClickLookupEnabled(bool enabled) {
 bool FloatingLyricWindow::ScrollBy(float delta_px) {
   // 三个前置条件写在一处，调用方（WM_MOUSEWHEEL）不必再抄一遍：
   //  * 只有 hook 台词能滚——歌词条 / 剪贴板文本窗保持历史行为，一字不改；
-  //  * 穿透模式下鼠标整个属于游戏，滚轮不归我们（WM_NCHITTEST 已经对正文返回
-  //    HTTRANSPARENT，这里再挡一道是为了顶部“恢复带”那几十像素也不例外）；
+  //  * 穿透模式下鼠标整个属于游戏，滚轮不归我们（BUG-951 之后正文窗直接带
+  //    WS_EX_TRANSPARENT，系统压根不往这儿投鼠标消息；这条判据留着是为了
+  //    「先置位、还没走到应用 ex-style」那一瞬也不例外）；
   //  * 没有溢出就没有行程，返回 false 让事件继续往下传。
   if (!hook_text_mode_ || pass_through_ || scroll_max_px_ <= 0.0f) {
     return false;
@@ -504,7 +517,159 @@ void FloatingLyricWindow::SetPassThrough(bool enabled) {
   if (GetCapture() == hwnd_) {
     ReleaseCapture();
   }
+  // A click-through body receives no mouse messages at all, so it will never
+  // see the WM_MOUSELEAVE that would normally clear the hover state. Clear it
+  // here or the body would render its hovered appearance forever.
+  hovered_ = false;
+  tracking_mouse_leave_ = false;
+  ApplyPassThroughExStyle();
   RequestRender();
+}
+
+void FloatingLyricWindow::ApplyPassThroughExStyle() {
+  if (hwnd_ == nullptr) {
+    return;
+  }
+  // Only the galgame hook overlay has a pass-through mode. The audiobook lyric
+  // strip and the clipboard text window never reach the branch below, so their
+  // window styles are byte-for-byte what they always were.
+  const bool want = hook_text_mode_ && pass_through_ && visible_;
+  if (!want) {
+    pass_through_toolbar_.Hide();
+    SetBodyExTransparent(false);
+    return;
+  }
+  if (!toolbar_callbacks_bound_) {
+    pass_through_toolbar_.SetActionCallback(
+        [this](const std::string& action) { DispatchControlAction(action); });
+    pass_through_toolbar_.SetDragCallback(
+        [this](int x, int y) { MoveBodyTo(x, y); });
+    pass_through_toolbar_.SetDragEndCallback([this]() {
+      SyncStripSizeFromWindow();
+      // The clamp can still nudge the body (e.g. the drag ended half off a
+      // monitor edge), so re-sync the toolbar before reporting the bounds —
+      // otherwise the pill would sit a few px away from the body it belongs to.
+      ClampCurrentPositionToWindowMonitor();
+      SyncPassThroughToolbar();
+      NotifyBoundsChanged();
+    });
+    toolbar_callbacks_bound_ = true;
+  }
+  // Escape hatch FIRST. The body may only stop taking clicks once the window
+  // that can switch pass-through back off is actually on screen; if it cannot
+  // be created we refuse the toggle instead of stranding the user.
+  if (!pass_through_toolbar_.Show(ComputePassThroughToolbarLayout(),
+                                  ToolbarStyle(), ToolbarStates())) {
+    SetBodyExTransparent(false);
+    pass_through_ = false;
+    return;
+  }
+  SetBodyExTransparent(true);
+}
+
+void FloatingLyricWindow::SetBodyExTransparent(bool enabled) {
+  if (hwnd_ == nullptr || ex_transparent_ == enabled) {
+    return;
+  }
+  const LONG_PTR bit = static_cast<LONG_PTR>(WS_EX_TRANSPARENT);
+  LONG_PTR ex = GetWindowLongPtr(hwnd_, GWL_EXSTYLE);
+  ex = enabled ? (ex | bit) : (ex & ~bit);
+  SetWindowLongPtr(hwnd_, GWL_EXSTYLE, ex);
+  // An ex-style change is not picked up until the frame is revalidated; without
+  // SWP_FRAMECHANGED the window keeps hit-testing with the OLD style.
+  SetWindowPos(hwnd_, nullptr, 0, 0, 0, 0,
+               SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE |
+                   SWP_FRAMECHANGED);
+  ex_transparent_ = enabled;
+}
+
+hook_toolbar::Layout FloatingLyricWindow::ComputePassThroughToolbarLayout()
+    const {
+  hook_toolbar::Layout layout;
+  if (hwnd_ == nullptr) {
+    return layout;
+  }
+  RECT wr = {};
+  if (!GetWindowRect(hwnd_, &wr)) {
+    return layout;
+  }
+  const float btn = ScaleForDpi(kButtonSizeDip);
+  const float gap = ScaleForDpi(kButtonGapDip);
+  const float margin = ScaleForDpi(kToolbarWindowMarginDip);
+  const float row_w = btn * kHookTextControlSlotCount +
+                      gap * (kHookTextControlSlotCount - 1);
+  // Same origin the in-body toolbar draws at (centred row, kControlsTopDip from
+  // the top), grown by |margin| so the pill has an edge to grab for dragging.
+  const float body_w = static_cast<float>(wr.right - wr.left);
+  const float row_x = wr.left + (body_w - row_w) / 2.0f;
+  const float row_y = wr.top + ScaleForDpi(kControlsTopDip);
+  layout.rect.left = static_cast<LONG>(std::lround(row_x - margin));
+  layout.rect.top = static_cast<LONG>(std::lround(row_y - margin));
+  layout.rect.right =
+      layout.rect.left + static_cast<LONG>(std::lround(row_w + margin * 2));
+  layout.rect.bottom =
+      layout.rect.top + static_cast<LONG>(std::lround(btn + margin * 2));
+  layout.button_px = btn;
+  layout.gap_px = gap;
+  layout.margin_px = margin;
+  return layout;
+}
+
+hook_toolbar::Style FloatingLyricWindow::ToolbarStyle() const {
+  hook_toolbar::Style style;
+  style.button_text_color = style_.button_text_color;
+  style.button_bg_color = style_.button_bg_color;
+  style.active_color = style_.active_color;
+  style.bg_color = style_.bg_color;
+  return style;
+}
+
+hook_toolbar::States FloatingLyricWindow::ToolbarStates() const {
+  hook_toolbar::States states;
+  states.replaying = replaying_;
+  states.recapturing = recapturing_;
+  states.playing = playing_;
+  states.pass_through = pass_through_;
+  states.locked = locked_;
+  return states;
+}
+
+void FloatingLyricWindow::SyncPassThroughToolbar() {
+  if (!pass_through_toolbar_.IsShowing()) {
+    return;
+  }
+  pass_through_toolbar_.Sync(ComputePassThroughToolbarLayout(), ToolbarStyle(),
+                             ToolbarStates());
+}
+
+void FloatingLyricWindow::MoveBodyTo(int x, int y) {
+  if (hwnd_ == nullptr) {
+    return;
+  }
+  RECT rc;
+  if (!GetWindowRect(hwnd_, &rc)) {
+    return;
+  }
+  const int width = rc.right - rc.left;
+  const int height = rc.bottom - rc.top;
+  // Clamp against the monitor under the cursor, exactly like the body's own
+  // drag path (TODO-832), so dragging by the toolbar cannot push the overlay
+  // off-screen and can still slide it across displays.
+  POINT cursor;
+  if (GetCursorPos(&cursor)) {
+    HMONITOR monitor = MonitorFromPoint(cursor, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO mi = {};
+    mi.cbSize = sizeof(mi);
+    if (GetMonitorInfo(monitor, &mi)) {
+      const POINT clamped =
+          ClampOriginToWorkArea(x, y, width, height, mi.rcWork);
+      x = clamped.x;
+      y = clamped.y;
+    }
+  }
+  SetWindowPos(hwnd_, topmost_ ? HWND_TOPMOST : HWND_NOTOPMOST, x, y, 0, 0,
+               SWP_NOSIZE | SWP_NOACTIVATE);
+  SyncPassThroughToolbar();
 }
 
 void FloatingLyricWindow::SetInitialBounds(int left, int top, int width,
@@ -640,34 +805,8 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
 
       // 1. Control buttons (prev / play-pause / next / lock / close) win first.
       const std::string action = ControlActionAt(x, y);
-      if (action == "lock") {
-        // The lock button toggles the position lock locally and reports the new
-        // state to Dart; it is never a no-op (unlike the old desktop strip).
-        locked_ = !locked_;
-        if (locked_ && (pressed_ || dragging_)) {
-          pressed_ = false;
-          dragging_ = false;
-        }
-        if (on_lock_) {
-          on_lock_(locked_);
-        }
-        RequestRender();
-        return 0;
-      }
-      if (action == "topmost") {
-        // The text-only Luna toolbar pin button: toggle always-on-top locally
-        // (LunaTranslator #36). Handled natively — no Dart round-trip — and every
-        // window-Z SetWindowPos reads topmost_ so the new state sticks.
-        topmost_ = !topmost_;
-        SetWindowPos(hwnd_, topmost_ ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
-                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
-        RequestRender();
-        return 0;
-      }
       if (!action.empty()) {
-        if (on_control_) {
-          on_control_(action);
-        }
+        DispatchControlAction(action);
         return 0;
       }
 
@@ -750,16 +889,16 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       // drag the corner to grow / shrink the bar (QQ-Music style). Everywhere
       // else stays HTCLIENT so our own mouse handlers (lookup / drag / control
       // buttons) keep receiving WM_LBUTTON*.
+      //
+      // BUG-951: there is deliberately NO pass-through branch here any more.
+      // HTTRANSPARENT only walks same-thread windows, so it never reached the
+      // galgame (a different process) — the click was simply swallowed. Real
+      // pass-through is WS_EX_TRANSPARENT on the whole body window, applied in
+      // ApplyPassThroughExStyle(); while it is set this handler is not called
+      // at all, which is exactly the point.
       POINT screen = {GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam)};
       POINT client = screen;
       ScreenToClient(hwnd_, &client);
-      if (hook_text_mode_ && pass_through_) {
-        const float recovery_height =
-            ScaleForDpi(kControlsTopDip + kButtonSizeDip);
-        if (static_cast<float>(client.y) > recovery_height) {
-          return HTTRANSPARENT;
-        }
-      }
       if (ResizeGripContains(static_cast<float>(client.x),
                              static_cast<float>(client.y))) {
         return HTBOTTOMRIGHT;
@@ -771,9 +910,9 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       //
       //  * **接管条件**全在 ScrollBy 里（hook 模式 + 非穿透 + 真有溢出）。不满足
       //    就落回 DefWindowProc，歌词条 / 剪贴板文本窗的行为一字不改。
-      //  * **穿透模式**下 WM_NCHITTEST 已经对正文返回 HTTRANSPARENT，滚轮压根到
-      //    不了这里；顶部那条“恢复带”仍能收到消息，ScrollBy 的 pass_through_
-      //    判据把它也挡掉——穿透就是「鼠标整个属于游戏」，不留半个例外。
+      //  * **穿透模式**下正文窗带 WS_EX_TRANSPARENT，系统不投递任何鼠标消息，
+      //    滚轮压根到不了这里（BUG-951）；工具条独立窗自己不吃滚轮。穿透就是
+      //    「鼠标整个属于游戏」，不留半个例外。
       //  * **和工具条不打架**：那八个按钮只吃 WM_LBUTTONDOWN，从不吃滚轮。所以
       //    滚轮的命中区可以是整个窗口，不需要「避开按钮」这种特例分支——鼠标停
       //    在按钮上滚也照样翻文本，这正是用户预期。
@@ -1198,6 +1337,12 @@ void FloatingLyricWindow::Render() {
     const float t_top = ScaleForDpi(kControlsTopDip);
     const float strip_h = t_top + t_btn;
 
+    // BUG-951: while the hook body is click-through the toolbar lives in its
+    // own always-clickable window (HookToolbarWindow). Painting the band here
+    // as well would both double it visually and advertise a grab handle that
+    // takes no mouse input any more — the body is purely visual in that mode.
+    const bool draw_body_toolbar = !(hook_text_mode_ && pass_through_);
+
     // Full-width strip background: near-invisible at rest (still catches the
     // mouse so the top edge is always grabbable), a visible band on hover so the
     // whole strip stays catchable while sliding across to the buttons.
@@ -1208,7 +1353,9 @@ void FloatingLyricWindow::Render() {
     D2D1_ROUNDED_RECT strip_rect = D2D1::RoundedRect(
         D2D1::RectF(0, 0, static_cast<float>(width), strip_h),
         ScaleForDpi(6), ScaleForDpi(6));
-    render_target_->FillRoundedRectangle(strip_rect, strip_bg.Get());
+    if (draw_body_toolbar) {
+      render_target_->FillRoundedRectangle(strip_rect, strip_bg.Get());
+    }
 
     // Centre grip pill — the visible move handle (brighter on hover).
     const float grip_w = ScaleForDpi(kTextGripWidthDip);
@@ -1222,13 +1369,15 @@ void FloatingLyricWindow::Render() {
     D2D1_ROUNDED_RECT grip_rect = D2D1::RoundedRect(
         D2D1::RectF(grip_x, grip_y, grip_x + grip_w, grip_y + grip_h),
         grip_h / 2.0f, grip_h / 2.0f);
-    render_target_->FillRoundedRectangle(grip_rect, grip_brush.Get());
+    if (draw_body_toolbar) {
+      render_target_->FillRoundedRectangle(grip_rect, grip_brush.Get());
+    }
 
     // Controls appear only on hover. Clipboard mode keeps its historical
     // right-aligned buttons (transparency, pin/topmost, lock); Hook mode uses a
     // centred six-button core toolbar. Their hit areas in ControlActionAt() are
     // gated on hovered_ too, so a click can never hit an invisible button.
-    if (hovered_) {
+    if (hovered_ && draw_body_toolbar) {
       Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> tb_bg;
       Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> tb_fg;
       Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> tb_active;
@@ -1261,17 +1410,15 @@ void FloatingLyricWindow::Render() {
             t_btn * kHookTextControlSlotCount +
             t_gap * (kHookTextControlSlotCount - 1);
         const float left = (width - controls_total) / 2.0f;
-        auto hook_button = [&](int slot, const wchar_t* glyph, bool active) {
-          draw_tbtn(left + slot * (t_btn + t_gap), glyph, active);
-        };
-        hook_button(0, L"↺", replaying_);
-        hook_button(1, L"⏺", recapturing_);
-        hook_button(2, playing_ ? L"⏸" : L"▶", !playing_);
-        hook_button(3, L"↗", pass_through_);
-        hook_button(4, L"◐", false);
-        hook_button(5, locked_ ? L"\U0001F512" : L"\U0001F513", locked_);
-        hook_button(6, L"▣", false);
-        hook_button(7, L"✕", false);
+        // Glyph + active tint come from the shared slot table, so the in-body
+        // toolbar and the standalone pass-through toolbar always draw the same
+        // eight buttons in the same order (BUG-951).
+        const hook_toolbar::States tb_states = ToolbarStates();
+        for (int slot = 0; slot < kHookTextControlSlotCount; ++slot) {
+          draw_tbtn(left + slot * (t_btn + t_gap),
+                    hook_toolbar::SlotGlyph(slot, tb_states),
+                    hook_toolbar::SlotActive(slot, tb_states));
+        }
       } else {
         const float lock_x = width - t_pad - t_btn;
         const float top_x = lock_x - t_gap - t_btn;
@@ -1394,6 +1541,45 @@ void FloatingLyricWindow::Render() {
   DeleteObject(dib);
   DeleteDC(mem_dc);
   ReleaseDC(nullptr, screen_dc);
+
+  // BUG-951: one funnel keeps the standalone toolbar in step with the body.
+  // Every state change already ends in a render, and Sync() is a no-op when
+  // nothing it cares about moved — so per-line caption updates do not turn into
+  // toolbar repaints.
+  SyncPassThroughToolbar();
+}
+
+void FloatingLyricWindow::DispatchControlAction(const std::string& action) {
+  if (action.empty()) {
+    return;
+  }
+  if (action == "lock") {
+    // The lock button toggles the position lock locally and reports the new
+    // state to Dart; it is never a no-op (unlike the old desktop strip).
+    locked_ = !locked_;
+    if (locked_ && (pressed_ || dragging_)) {
+      pressed_ = false;
+      dragging_ = false;
+    }
+    if (on_lock_) {
+      on_lock_(locked_);
+    }
+    RequestRender();
+    return;
+  }
+  if (action == "topmost") {
+    // The text-only Luna toolbar pin button: toggle always-on-top locally
+    // (LunaTranslator #36). Handled natively — no Dart round-trip — and every
+    // window-Z SetWindowPos reads topmost_ so the new state sticks.
+    topmost_ = !topmost_;
+    SetWindowPos(hwnd_, topmost_ ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+    RequestRender();
+    return;
+  }
+  if (on_control_) {
+    on_control_(action);
+  }
 }
 
 std::string FloatingLyricWindow::ControlActionAt(float x, float y) {
@@ -1423,26 +1609,10 @@ std::string FloatingLyricWindow::ControlActionAt(float x, float y) {
       for (int slot = 0; slot < kHookTextControlSlotCount; ++slot) {
         const float bx = left + slot * (btn + gap);
         if (x < bx || x > bx + btn) continue;
-        switch (slot) {
-          case 0:
-            return "replayVoice";
-          case 1:
-            return "recaptureVoice";
-          case 2:
-            return "toggleFollow";
-          case 3:
-            return "togglePassThrough";
-          case 4:
-            return "toggleTransparency";
-          case 5:
-            return "lock";
-          case 6:
-            return "openWorkbench";
-          case 7:
-            return "close";
-          default:
-            return std::string();
-        }
+        // Shared slot table (hook_toolbar::kSlotActions): the standalone
+        // pass-through toolbar indexes the very same array, so the two windows
+        // physically cannot disagree about what a button does.
+        return hook_toolbar::kSlotActions[slot];
       }
       return std::string();
     }

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -609,6 +609,7 @@ hook_toolbar::Layout FloatingLyricWindow::ComputePassThroughToolbarLayout()
       layout.rect.left + static_cast<LONG>(std::lround(row_w + margin * 2));
   layout.rect.bottom =
       layout.rect.top + static_cast<LONG>(std::lround(btn + margin * 2));
+  layout.owner_origin = POINT{wr.left, wr.top};
   layout.button_px = btn;
   layout.gap_px = gap;
   layout.margin_px = margin;

--- a/hibiki/windows/runner/floating_lyric_window.h
+++ b/hibiki/windows/runner/floating_lyric_window.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <vector>
 
+#include "hook_toolbar_window.h"
+
 // A standalone always-on-top "QQ Music style" desktop lyric strip.
 //
 // This is a self-owned Win32 layered top-level window — NOT a Flutter view and
@@ -165,6 +167,12 @@ class FloatingLyricWindow {
   // Android FloatingLyricService position lock — drag-only restriction).
   void SetLocked(bool locked);
   bool IsLocked() const { return locked_; }
+  // BUG-951 — galgame hook mode only. Pass-through makes the overlay BODY
+  // click-through for real (WS_EX_TRANSPARENT, the only cross-process
+  // mechanism), and hands the toolbar to a separate always-clickable window so
+  // the user is never locked out. Non-hook instances keep their historical
+  // behaviour: the flag is stored, no ex-style is touched, no second window is
+  // created.
   void SetPassThrough(bool enabled);
   bool IsPassThrough() const { return pass_through_; }
   // Restores a physical-pixel window rectangle before the next Show. Invalid
@@ -201,6 +209,37 @@ class FloatingLyricWindow {
 
   // Returns the control action at the client point, or empty when none.
   std::string ControlActionAt(float x, float y);
+
+  // Runs a toolbar action. Single dispatcher shared by the in-body toolbar
+  // (WM_LBUTTONDOWN) and the standalone pass-through toolbar window, so a
+  // button behaves identically no matter which window the click landed in.
+  void DispatchControlAction(const std::string& action);
+
+  // ── BUG-951: pass-through as two windows ─────────────────────────────────
+  //
+  // Applies the CURRENT pass-through intent to the OS. This is the only place
+  // that decides whether the body is click-through, and it enforces the
+  // invariant that makes the whole design safe: the body only ever goes
+  // click-through AFTER the always-clickable toolbar window is on screen. If
+  // that window cannot be created the body stays interactive and pass_through_
+  // is dropped back to false — better to ignore the toggle than to strand the
+  // user behind an overlay they can no longer click.
+  void ApplyPassThroughExStyle();
+  // Adds / removes WS_EX_TRANSPARENT on the body window. Called ONLY from
+  // ApplyPassThroughExStyle (see the guard test).
+  void SetBodyExTransparent(bool enabled);
+  // Toolbar geometry, derived from the body's own control-row constants so the
+  // floating buttons land exactly where the in-body toolbar drew them.
+  hook_toolbar::Layout ComputePassThroughToolbarLayout() const;
+  hook_toolbar::Style ToolbarStyle() const;
+  hook_toolbar::States ToolbarStates() const;
+  // Pushes geometry / colours / states to the toolbar window (no-op when it is
+  // not showing, and a no-op repaint when nothing changed).
+  void SyncPassThroughToolbar();
+  // Moves the body window to |x|,|y| (screen physical px), clamped to the work
+  // area, and drags the toolbar along. Used by the toolbar's own drag: while
+  // pass-through is on the body receives no mouse input at all.
+  void MoveBodyTo(int x, int y);
 
   // True when the client point falls inside the bottom-right resize grip — used
   // by WM_NCHITTEST to hand the corner to the system resize loop.
@@ -265,6 +304,12 @@ class FloatingLyricWindow {
   bool text_only_ = false;
   bool hook_text_mode_ = false;
   bool pass_through_ = false;
+  // Mirrors the WS_EX_TRANSPARENT bit currently on hwnd_ so the ex-style is
+  // only rewritten when it actually changes.
+  bool ex_transparent_ = false;
+  // The toolbar's callbacks are bound lazily on first use (the toolbar object
+  // itself is inert until pass-through is switched on).
+  bool toolbar_callbacks_bound_ = false;
   bool hovered_ = false;
   bool tracking_mouse_leave_ = false;
   // Position lock: drag disabled, everything else (lookup + controls) still
@@ -334,6 +379,10 @@ class FloatingLyricWindow {
   // 样式变化时一起 Reset，下一帧按新字号重建。
   Microsoft::WRL::ComPtr<IDWriteTextFormat> ruby_format_;
   Microsoft::WRL::ComPtr<IDWriteTextLayout> text_layout_;
+
+  // BUG-951: the always-clickable toolbar used while the body is click-through.
+  // Only ever created / shown for hook_text_mode_ instances in pass-through.
+  HookToolbarWindow pass_through_toolbar_;
 
   LookupCallback on_lookup_;
   ContextLookupCallback on_context_lookup_;

--- a/hibiki/windows/runner/floating_lyric_window.h
+++ b/hibiki/windows/runner/floating_lyric_window.h
@@ -54,6 +54,11 @@ class FloatingLyricWindow {
   // Reports the new locked state after the user toggles the lock button, so the
   // Dart side can persist it and refresh any in-app mirror of the strip state.
   using LockCallback = std::function<void(bool locked)>;
+  // BUG-951 — native vetoed pass-through (the escape-hatch toolbar window could
+  // not be created, so turning the body click-through would strand the user).
+  // Dart must hear about it or its own flag stays stuck on "enabled" and the
+  // user's next press on the button does nothing visible.
+  using PassThroughCallback = std::function<void(bool enabled)>;
   using BoundsCallback =
       std::function<void(int left, int top, int width, int height)>;
 
@@ -109,6 +114,9 @@ class FloatingLyricWindow {
   }
   void SetLockCallback(LockCallback callback) {
     on_lock_ = std::move(callback);
+  }
+  void SetPassThroughCallback(PassThroughCallback callback) {
+    on_pass_through_ = std::move(callback);
   }
   void SetBoundsCallback(BoundsCallback callback) {
     on_bounds_ = std::move(callback);
@@ -388,6 +396,7 @@ class FloatingLyricWindow {
   ContextLookupCallback on_context_lookup_;
   ControlCallback on_control_;
   LockCallback on_lock_;
+  PassThroughCallback on_pass_through_;
   BoundsCallback on_bounds_;
 };
 

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -978,6 +978,15 @@ void FlutterWindow::RegisterGalHookTextChannel() {
         "lockChanged",
         std::make_unique<flutter::EncodableValue>(std::move(map)));
   });
+  gal_hook_text_window_->SetPassThroughCallback([this](bool enabled) {
+    flutter::EncodableMap map{
+        {flutter::EncodableValue("passThrough"),
+         flutter::EncodableValue(enabled)},
+    };
+    gal_hook_text_channel_->InvokeMethod(
+        "passThroughChanged",
+        std::make_unique<flutter::EncodableValue>(std::move(map)));
+  });
   gal_hook_text_window_->SetBoundsCallback(
       [this](int left, int top, int width, int height) {
         flutter::EncodableMap map{

--- a/hibiki/windows/runner/hook_toolbar_window.cpp
+++ b/hibiki/windows/runner/hook_toolbar_window.cpp
@@ -1,0 +1,512 @@
+#include "hook_toolbar_window.h"
+
+#include <d2d1helper.h>
+#include <windowsx.h>
+
+#include <algorithm>
+#include <cmath>
+
+#pragma comment(lib, "d2d1.lib")
+#pragma comment(lib, "dwrite.lib")
+
+namespace {
+
+constexpr wchar_t kWindowClassName[] = L"HibikiHookToolbarWindow";
+
+// A press must travel this far (physical px at 96 DPI, scaled by the owner via
+// Layout::button_px staying proportional) before it becomes an owner drag
+// rather than a button-miss. Same idea as the body window's kDragThresholdDip.
+constexpr float kDragThresholdPx = 6.0f;
+
+// Opacity of the toolbar while the cursor is elsewhere. Unlike the in-body
+// toolbar (which is invisible until hovered, because the body itself is a
+// visible bar the user can aim at), this window is the ONLY way out of
+// pass-through: an invisible escape hatch over a fully transparent overlay is
+// an escape hatch the user cannot find. So it stays dimly visible at rest.
+constexpr float kRestOpacity = 0.42f;
+constexpr float kHoverOpacity = 1.0f;
+
+// ARGB (0xAARRGGBB) -> D2D1_COLOR_F (straight alpha).
+D2D1_COLOR_F ColorFromArgb(uint32_t argb) {
+  const float a = ((argb >> 24) & 0xFF) / 255.0f;
+  const float r = ((argb >> 16) & 0xFF) / 255.0f;
+  const float g = ((argb >> 8) & 0xFF) / 255.0f;
+  const float b = (argb & 0xFF) / 255.0f;
+  return D2D1::ColorF(r, g, b, a);
+}
+
+UINT32 GlyphLength(const wchar_t* glyph) {
+  if (glyph == nullptr) {
+    return 0;
+  }
+  return static_cast<UINT32>(std::char_traits<wchar_t>::length(glyph));
+}
+
+bool SameLayout(const hook_toolbar::Layout& a, const hook_toolbar::Layout& b) {
+  return a.rect.left == b.rect.left && a.rect.top == b.rect.top &&
+         a.rect.right == b.rect.right && a.rect.bottom == b.rect.bottom &&
+         a.button_px == b.button_px && a.gap_px == b.gap_px &&
+         a.margin_px == b.margin_px;
+}
+
+bool SameStyle(const hook_toolbar::Style& a, const hook_toolbar::Style& b) {
+  return a.button_text_color == b.button_text_color &&
+         a.button_bg_color == b.button_bg_color &&
+         a.active_color == b.active_color && a.bg_color == b.bg_color;
+}
+
+bool SameStates(const hook_toolbar::States& a, const hook_toolbar::States& b) {
+  return a.replaying == b.replaying && a.recapturing == b.recapturing &&
+         a.playing == b.playing && a.pass_through == b.pass_through &&
+         a.locked == b.locked;
+}
+
+}  // namespace
+
+namespace hook_toolbar {
+
+const wchar_t* SlotGlyph(int slot, const States& states) {
+  switch (slot) {
+    case 0:
+      return L"↺";  // ↺ replay voice
+    case 1:
+      return L"⏺";  // ⏺ recapture
+    case 2:
+      return states.playing ? L"⏸" : L"▶";  // ⏸ / ▶ follow
+    case 3:
+      return L"↗";  // ↗ pass-through
+    case 4:
+      return L"◐";  // ◐ transparency
+    case 5:
+      return states.locked ? L"\U0001F512" : L"\U0001F513";  // 🔒 / 🔓
+    case 6:
+      return L"▣";  // ▣ workbench
+    case 7:
+      return L"✕";  // ✕ close
+    default:
+      return L"";
+  }
+}
+
+bool SlotActive(int slot, const States& states) {
+  switch (slot) {
+    case 0:
+      return states.replaying;
+    case 1:
+      return states.recapturing;
+    case 2:
+      return !states.playing;
+    case 3:
+      return states.pass_through;
+    case 5:
+      return states.locked;
+    default:
+      return false;
+  }
+}
+
+}  // namespace hook_toolbar
+
+HookToolbarWindow::HookToolbarWindow() = default;
+
+HookToolbarWindow::~HookToolbarWindow() {
+  if (hwnd_ != nullptr) {
+    DestroyWindow(hwnd_);
+    hwnd_ = nullptr;
+  }
+  if (class_registered_) {
+    UnregisterClassW(kWindowClassName, GetModuleHandle(nullptr));
+  }
+}
+
+void HookToolbarWindow::EnsureWindowClass() {
+  if (class_registered_) {
+    return;
+  }
+  WNDCLASSEXW wc = {};
+  wc.cbSize = sizeof(wc);
+  wc.style = CS_HREDRAW | CS_VREDRAW;
+  wc.lpfnWndProc = HookToolbarWindow::WndProc;
+  wc.hInstance = GetModuleHandle(nullptr);
+  wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
+  wc.lpszClassName = kWindowClassName;
+  RegisterClassExW(&wc);
+  class_registered_ = true;
+}
+
+bool HookToolbarWindow::EnsureDeviceResources() {
+  if (d2d_factory_ == nullptr) {
+    if (FAILED(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED,
+                                 d2d_factory_.GetAddressOf()))) {
+      return false;
+    }
+  }
+  if (dwrite_factory_ == nullptr) {
+    if (FAILED(DWriteCreateFactory(
+            DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory),
+            reinterpret_cast<IUnknown**>(dwrite_factory_.GetAddressOf())))) {
+      return false;
+    }
+  }
+  if (render_target_ == nullptr) {
+    D2D1_RENDER_TARGET_PROPERTIES props = D2D1::RenderTargetProperties(
+        D2D1_RENDER_TARGET_TYPE_DEFAULT,
+        D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM,
+                          D2D1_ALPHA_MODE_PREMULTIPLIED),
+        0, 0, D2D1_RENDER_TARGET_USAGE_NONE, D2D1_FEATURE_LEVEL_DEFAULT);
+    if (FAILED(d2d_factory_->CreateDCRenderTarget(
+            &props, render_target_.GetAddressOf()))) {
+      render_target_.Reset();
+      return false;
+    }
+  }
+  return true;
+}
+
+bool HookToolbarWindow::Show(const hook_toolbar::Layout& layout,
+                             const hook_toolbar::Style& style,
+                             const hook_toolbar::States& states) {
+  const int width = layout.rect.right - layout.rect.left;
+  const int height = layout.rect.bottom - layout.rect.top;
+  if (width <= 0 || height <= 0) {
+    return false;
+  }
+  EnsureWindowClass();
+  if (!EnsureDeviceResources()) {
+    return false;
+  }
+  if (hwnd_ == nullptr) {
+    // Deliberately WITHOUT WS_EX_TRANSPARENT: this window is the escape hatch
+    // out of pass-through and must be clickable at every instant. WS_EX_LAYERED
+    // for per-pixel alpha (rounded pill over the game), WS_EX_TOPMOST to float
+    // above both the game and the overlay body, WS_EX_NOACTIVATE so clicking a
+    // button never steals keyboard focus from the game, WS_EX_TOOLWINDOW to
+    // stay out of the taskbar / Alt+Tab.
+    hwnd_ = CreateWindowExW(
+        WS_EX_LAYERED | WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
+        kWindowClassName, L"Hibiki Hook Toolbar", WS_POPUP, layout.rect.left,
+        layout.rect.top, width, height, nullptr, nullptr,
+        GetModuleHandle(nullptr), this);
+    if (hwnd_ == nullptr) {
+      return false;
+    }
+  }
+  layout_ = layout;
+  style_ = style;
+  states_ = states;
+  has_layout_ = true;
+  SetWindowPos(hwnd_, HWND_TOPMOST, layout.rect.left, layout.rect.top, width,
+               height, SWP_NOACTIVATE);
+  ShowWindow(hwnd_, SW_SHOWNOACTIVATE);
+  visible_ = true;
+  Render();
+  return true;
+}
+
+void HookToolbarWindow::Hide() {
+  visible_ = false;
+  hovered_ = false;
+  tracking_mouse_leave_ = false;
+  pressed_ = false;
+  dragging_ = false;
+  if (hwnd_ != nullptr) {
+    if (GetCapture() == hwnd_) {
+      ReleaseCapture();
+    }
+    ShowWindow(hwnd_, SW_HIDE);
+  }
+}
+
+bool HookToolbarWindow::IsShowing() const {
+  return visible_ && hwnd_ != nullptr && IsWindowVisible(hwnd_);
+}
+
+void HookToolbarWindow::Sync(const hook_toolbar::Layout& layout,
+                             const hook_toolbar::Style& style,
+                             const hook_toolbar::States& states) {
+  if (hwnd_ == nullptr || !visible_) {
+    return;
+  }
+  const bool moved = !has_layout_ || !SameLayout(layout, layout_);
+  const bool repaint =
+      moved || !SameStyle(style, style_) || !SameStates(states, states_);
+  if (!repaint) {
+    // Still re-assert Z: the body window raises itself to HWND_TOPMOST on show
+    // / clamp / DPI change, which would otherwise tint this pill from above.
+    SetWindowPos(hwnd_, HWND_TOPMOST, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+    return;
+  }
+  layout_ = layout;
+  style_ = style;
+  states_ = states;
+  has_layout_ = true;
+  if (moved) {
+    SetWindowPos(hwnd_, HWND_TOPMOST, layout.rect.left, layout.rect.top,
+                 layout.rect.right - layout.rect.left,
+                 layout.rect.bottom - layout.rect.top, SWP_NOACTIVATE);
+  } else {
+    SetWindowPos(hwnd_, HWND_TOPMOST, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+  }
+  Render();
+}
+
+int HookToolbarWindow::SlotAt(float x, float y) const {
+  if (!has_layout_ || layout_.button_px <= 0.0f) {
+    return -1;
+  }
+  const float top = layout_.margin_px;
+  if (y < top || y > top + layout_.button_px) {
+    return -1;
+  }
+  for (int slot = 0; slot < hook_toolbar::kSlotCount; ++slot) {
+    const float bx =
+        layout_.margin_px + slot * (layout_.button_px + layout_.gap_px);
+    if (x >= bx && x <= bx + layout_.button_px) {
+      return slot;
+    }
+  }
+  return -1;
+}
+
+LRESULT CALLBACK HookToolbarWindow::WndProc(HWND hwnd, UINT message,
+                                            WPARAM wparam,
+                                            LPARAM lparam) noexcept {
+  if (message == WM_NCCREATE) {
+    auto* create = reinterpret_cast<CREATESTRUCT*>(lparam);
+    SetWindowLongPtr(hwnd, GWLP_USERDATA,
+                     reinterpret_cast<LONG_PTR>(create->lpCreateParams));
+    auto* self = static_cast<HookToolbarWindow*>(create->lpCreateParams);
+    self->hwnd_ = hwnd;
+    return DefWindowProc(hwnd, message, wparam, lparam);
+  }
+  auto* self =
+      reinterpret_cast<HookToolbarWindow*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
+  if (self != nullptr) {
+    return self->HandleMessage(message, wparam, lparam);
+  }
+  return DefWindowProc(hwnd, message, wparam, lparam);
+}
+
+LRESULT HookToolbarWindow::HandleMessage(UINT message, WPARAM wparam,
+                                         LPARAM lparam) noexcept {
+  switch (message) {
+    case WM_MOUSEMOVE: {
+      if (!hovered_) {
+        hovered_ = true;
+        Render();
+      }
+      if (!tracking_mouse_leave_) {
+        TRACKMOUSEEVENT tme = {};
+        tme.cbSize = sizeof(tme);
+        tme.dwFlags = TME_LEAVE;
+        tme.hwndTrack = hwnd_;
+        if (TrackMouseEvent(&tme)) {
+          tracking_mouse_leave_ = true;
+        }
+      }
+      if (dragging_) {
+        POINT cursor;
+        GetCursorPos(&cursor);
+        if (on_drag_) {
+          on_drag_(cursor.x - owner_drag_anchor_.x,
+                   cursor.y - owner_drag_anchor_.y);
+        }
+        return 0;
+      }
+      if (pressed_) {
+        POINT cursor;
+        GetCursorPos(&cursor);
+        const int dx = cursor.x - press_origin_.x;
+        const int dy = cursor.y - press_origin_.y;
+        if (dx * dx + dy * dy >=
+            static_cast<int>(kDragThresholdPx * kDragThresholdPx)) {
+          dragging_ = true;
+        }
+      }
+      return 0;
+    }
+    case WM_MOUSELEAVE: {
+      tracking_mouse_leave_ = false;
+      if (hovered_ && !dragging_) {
+        hovered_ = false;
+        Render();
+      }
+      return 0;
+    }
+    case WM_LBUTTONDOWN: {
+      const float x = static_cast<float>(GET_X_LPARAM(lparam));
+      const float y = static_cast<float>(GET_Y_LPARAM(lparam));
+      const int slot = SlotAt(x, y);
+      if (slot >= 0) {
+        // Buttons fire on press, exactly like the in-body toolbar, so the
+        // escape hatch responds to the same gesture the user already knows.
+        if (on_action_) {
+          on_action_(hook_toolbar::kSlotActions[slot]);
+        }
+        return 0;
+      }
+      // A press on the pill background starts a move of the OWNER window: while
+      // pass-through is on the body takes no mouse input at all, so this is the
+      // only remaining way to reposition the overlay.
+      POINT cursor;
+      GetCursorPos(&cursor);
+      pressed_ = true;
+      dragging_ = false;
+      press_origin_ = cursor;
+      // The owner's top-left is derived from the toolbar rect the owner itself
+      // gave us, so the anchor stays correct without a second GetWindowRect.
+      owner_drag_anchor_.x = cursor.x - layout_.rect.left;
+      owner_drag_anchor_.y = cursor.y - layout_.rect.top;
+      SetCapture(hwnd_);
+      return 0;
+    }
+    case WM_LBUTTONUP: {
+      const bool was_dragging = dragging_;
+      pressed_ = false;
+      dragging_ = false;
+      if (GetCapture() == hwnd_) {
+        ReleaseCapture();
+      }
+      if (was_dragging && on_drag_end_) {
+        on_drag_end_();
+      }
+      return 0;
+    }
+    case WM_NCHITTEST:
+      // Everything is client area: this window has no resize grip and never
+      // hands anything to the system loops. It also never returns
+      // HTTRANSPARENT — that is precisely the cross-process no-op this whole
+      // window exists to replace.
+      return HTCLIENT;
+    default:
+      return DefWindowProc(hwnd_, message, wparam, lparam);
+  }
+}
+
+void HookToolbarWindow::Render() {
+  if (hwnd_ == nullptr || !has_layout_ || !EnsureDeviceResources()) {
+    return;
+  }
+  RECT rc;
+  GetClientRect(hwnd_, &rc);
+  const int width = rc.right - rc.left;
+  const int height = rc.bottom - rc.top;
+  if (width <= 0 || height <= 0) {
+    return;
+  }
+
+  HDC screen_dc = GetDC(nullptr);
+  HDC mem_dc = CreateCompatibleDC(screen_dc);
+  BITMAPINFO bmi = {};
+  bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+  bmi.bmiHeader.biWidth = width;
+  bmi.bmiHeader.biHeight = -height;  // top-down
+  bmi.bmiHeader.biPlanes = 1;
+  bmi.bmiHeader.biBitCount = 32;
+  bmi.bmiHeader.biCompression = BI_RGB;
+  void* bits = nullptr;
+  HBITMAP dib =
+      CreateDIBSection(mem_dc, &bmi, DIB_RGB_COLORS, &bits, nullptr, 0);
+  HBITMAP old_bmp = static_cast<HBITMAP>(SelectObject(mem_dc, dib));
+
+  RECT bind_rect = {0, 0, width, height};
+  if (FAILED(render_target_->BindDC(mem_dc, &bind_rect))) {
+    SelectObject(mem_dc, old_bmp);
+    DeleteObject(dib);
+    DeleteDC(mem_dc);
+    ReleaseDC(nullptr, screen_dc);
+    return;
+  }
+
+  const float opacity = hovered_ ? kHoverOpacity : kRestOpacity;
+  const float corner = std::max(2.0f, layout_.margin_px * 1.5f);
+
+  render_target_->BeginDraw();
+  render_target_->Clear(D2D1::ColorF(0, 0, 0, 0));
+
+  // Pill background. The alpha comes from the overlay's own background colour
+  // so the escape hatch matches the caption bar the user configured; it is
+  // floored to a visible value because a fully transparent escape hatch over a
+  // fully transparent overlay cannot be found.
+  uint32_t pill = style_.bg_color;
+  if ((pill >> 24) < 0x99) {
+    pill = 0x99000000u | (pill & 0x00FFFFFFu);
+  }
+  Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> pill_brush;
+  render_target_->CreateSolidColorBrush(ColorFromArgb(pill),
+                                        pill_brush.GetAddressOf());
+  if (pill_brush != nullptr) {
+    pill_brush->SetOpacity(opacity);
+    render_target_->FillRoundedRectangle(
+        D2D1::RoundedRect(D2D1::RectF(0, 0, static_cast<float>(width),
+                                      static_cast<float>(height)),
+                          corner, corner),
+        pill_brush.Get());
+  }
+
+  Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> btn_bg;
+  Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> btn_fg;
+  Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> btn_active;
+  render_target_->CreateSolidColorBrush(ColorFromArgb(style_.button_bg_color),
+                                        btn_bg.GetAddressOf());
+  render_target_->CreateSolidColorBrush(ColorFromArgb(style_.button_text_color),
+                                        btn_fg.GetAddressOf());
+  render_target_->CreateSolidColorBrush(ColorFromArgb(style_.active_color),
+                                        btn_active.GetAddressOf());
+  if (btn_bg != nullptr) btn_bg->SetOpacity(opacity);
+  if (btn_fg != nullptr) btn_fg->SetOpacity(opacity);
+  if (btn_active != nullptr) btn_active->SetOpacity(opacity);
+
+  const float btn = layout_.button_px;
+  Microsoft::WRL::ComPtr<IDWriteTextFormat> glyph_fmt;
+  dwrite_factory_->CreateTextFormat(
+      L"Segoe UI Symbol", nullptr, DWRITE_FONT_WEIGHT_NORMAL,
+      DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
+      std::max(1.0f, btn * 0.5f), L"", glyph_fmt.GetAddressOf());
+  if (glyph_fmt != nullptr) {
+    glyph_fmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+    glyph_fmt->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+  }
+
+  for (int slot = 0; slot < hook_toolbar::kSlotCount; ++slot) {
+    const float bx = layout_.margin_px + slot * (btn + layout_.gap_px);
+    const float by = layout_.margin_px;
+    const D2D1_RECT_F cell = D2D1::RectF(bx, by, bx + btn, by + btn);
+    if (btn_bg != nullptr) {
+      render_target_->FillRoundedRectangle(
+          D2D1::RoundedRect(cell, corner * 0.5f, corner * 0.5f), btn_bg.Get());
+    }
+    if (glyph_fmt == nullptr) {
+      continue;
+    }
+    const wchar_t* glyph = hook_toolbar::SlotGlyph(slot, states_);
+    ID2D1SolidColorBrush* brush = hook_toolbar::SlotActive(slot, states_)
+                                      ? btn_active.Get()
+                                      : btn_fg.Get();
+    if (brush != nullptr) {
+      // Full UTF-16 length: the padlock glyphs are surrogate pairs and would be
+      // truncated to a lone high surrogate by a hard-coded length of 1.
+      render_target_->DrawTextW(glyph, GlyphLength(glyph), glyph_fmt.Get(),
+                                cell, brush);
+    }
+  }
+
+  render_target_->EndDraw();
+
+  POINT dst = {layout_.rect.left, layout_.rect.top};
+  POINT src = {0, 0};
+  SIZE size = {width, height};
+  BLENDFUNCTION blend = {};
+  blend.BlendOp = AC_SRC_OVER;
+  blend.SourceConstantAlpha = 255;
+  blend.AlphaFormat = AC_SRC_ALPHA;
+  UpdateLayeredWindow(hwnd_, screen_dc, &dst, &size, mem_dc, &src, 0, &blend,
+                      ULW_ALPHA);
+
+  SelectObject(mem_dc, old_bmp);
+  DeleteObject(dib);
+  DeleteDC(mem_dc);
+  ReleaseDC(nullptr, screen_dc);
+}

--- a/hibiki/windows/runner/hook_toolbar_window.cpp
+++ b/hibiki/windows/runner/hook_toolbar_window.cpp
@@ -45,6 +45,8 @@ UINT32 GlyphLength(const wchar_t* glyph) {
 bool SameLayout(const hook_toolbar::Layout& a, const hook_toolbar::Layout& b) {
   return a.rect.left == b.rect.left && a.rect.top == b.rect.top &&
          a.rect.right == b.rect.right && a.rect.bottom == b.rect.bottom &&
+         a.owner_origin.x == b.owner_origin.x &&
+         a.owner_origin.y == b.owner_origin.y &&
          a.button_px == b.button_px && a.gap_px == b.gap_px &&
          a.margin_px == b.margin_px;
 }
@@ -355,10 +357,14 @@ LRESULT HookToolbarWindow::HandleMessage(UINT message, WPARAM wparam,
       pressed_ = true;
       dragging_ = false;
       press_origin_ = cursor;
-      // The owner's top-left is derived from the toolbar rect the owner itself
-      // gave us, so the anchor stays correct without a second GetWindowRect.
-      owner_drag_anchor_.x = cursor.x - layout_.rect.left;
-      owner_drag_anchor_.y = cursor.y - layout_.rect.top;
+      // Anchor on the OWNER's top-left, which the owner pushes down with the
+      // layout. Anchoring on the toolbar rect instead would make the first drag
+      // move jump the body by the (centred-row) toolbar offset — several
+      // hundred px — which also yanks the pill out from under the cursor and
+      // kills the drag, since a WS_EX_NOACTIVATE window only gets background
+      // capture while the cursor is over it.
+      owner_drag_anchor_.x = cursor.x - layout_.owner_origin.x;
+      owner_drag_anchor_.y = cursor.y - layout_.owner_origin.y;
       SetCapture(hwnd_);
       return 0;
     }

--- a/hibiki/windows/runner/hook_toolbar_window.h
+++ b/hibiki/windows/runner/hook_toolbar_window.h
@@ -1,0 +1,180 @@
+#ifndef RUNNER_HOOK_TOOLBAR_WINDOW_H_
+#define RUNNER_HOOK_TOOLBAR_WINDOW_H_
+
+#include <windows.h>
+
+#include <d2d1.h>
+#include <dwrite.h>
+#include <wrl/client.h>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
+// BUG-951 — the galgame hook overlay's pass-through escape hatch.
+//
+// Why this window exists at all
+// -----------------------------
+// The overlay body must become *genuinely* click-through in pass-through mode:
+// the user is reading captions on top of a galgame that lives in ANOTHER
+// PROCESS, and clicks have to advance that game's dialogue. The only Win32
+// mechanism that does this across processes is WS_EX_TRANSPARENT (returning
+// HTTRANSPARENT from WM_NCHITTEST only walks same-thread windows, which is the
+// original bug). WS_EX_TRANSPARENT is a WHOLE-WINDOW property — it cannot spare
+// a toolbar band — so a single-window overlay has exactly two options: keep the
+// user locked out of the toolbar, or flip the bit by cursor position on a timer.
+// The timer variant was implemented, reviewed and reverted: a starved timer
+// leaves the bit set while the user is already over the toolbar, so the click
+// falls through into the game and advances dialogue / picks a branch.
+//
+// The structural fix is to stop asking one window to be two things. The body
+// window becomes purely visual while pass-through is on, and this window — a
+// separate, small, never-transparent top-level window — carries the toolbar.
+// It is always clickable because it is never transparent; there is no state to
+// flip, therefore no race to lose.
+//
+// Contract with FloatingLyricWindow
+// ---------------------------------
+//  * geometry is pushed in (HookToolbarLayout), never recomputed here, so the
+//    two windows cannot drift apart about where the buttons are;
+//  * slot -> action mapping lives in kSlotActions below and is shared with the
+//    body window's ControlActionAt(), so button 3 means the same thing in both;
+//  * dragging the toolbar background drags the OWNER window (the body), which
+//    is the only way to move the overlay while the body takes no mouse input.
+//
+// All methods must be called on the thread owning the message loop.
+
+namespace hook_toolbar {
+
+// Draw / hit-test order of the galgame hook toolbar. Single source of truth:
+// FloatingLyricWindow::ControlActionAt() indexes the same table, so the body
+// window and the standalone toolbar can never disagree about what a slot does.
+constexpr int kSlotCount = 8;
+constexpr const char* kSlotActions[kSlotCount] = {
+    "replayVoice",         // 0 replay the line's captured audio
+    "recaptureVoice",      // 1 open a recapture window
+    "toggleFollow",        // 2 follow / pause caption updates
+    "togglePassThrough",   // 3 mouse pass-through  <- the escape hatch
+    "toggleTransparency",  // 4 one-click background transparency
+    "lock",                // 5 position lock
+    "openWorkbench",       // 6 capture workbench
+    "close",               // 7 close the overlay
+};
+
+// Button states that change a slot's glyph or its active tint.
+struct States {
+  bool replaying = false;
+  bool recapturing = false;
+  bool playing = false;
+  bool pass_through = false;
+  bool locked = false;
+};
+
+// Colours, mirrored from the body window's Style so both toolbars look alike.
+struct Style {
+  uint32_t button_text_color = 0xFFFFFFFF;
+  uint32_t button_bg_color = 0x33000000;
+  uint32_t active_color = 0xFFFFD54F;
+  uint32_t bg_color = 0xCC000000;
+};
+
+// Where to put the toolbar, in screen / client PHYSICAL px. Computed by the
+// owner from its own layout constants (see
+// FloatingLyricWindow::ComputePassThroughToolbarLayout) so the floating buttons
+// land exactly where the in-body toolbar used to draw them.
+struct Layout {
+  RECT rect = {0, 0, 0, 0};  // toolbar window rect, screen px
+  float button_px = 0.0f;    // button edge length
+  float gap_px = 0.0f;       // gap between two buttons
+  float margin_px = 0.0f;    // padding between the window edge and the row
+};
+
+// Glyph drawn for |slot| under |states| (never null).
+const wchar_t* SlotGlyph(int slot, const States& states);
+// Whether |slot| draws with the active (highlight) colour under |states|.
+bool SlotActive(int slot, const States& states);
+
+}  // namespace hook_toolbar
+
+class HookToolbarWindow {
+ public:
+  // Reports a toolbar button press. The string is one of
+  // hook_toolbar::kSlotActions and is dispatched through exactly the same
+  // owner-side handler as a press on the in-body toolbar.
+  using ActionCallback = std::function<void(const std::string& action)>;
+  // Requested new top-left for the OWNER window (screen physical px) while the
+  // user drags the toolbar background. The owner clamps it to the work area and
+  // moves both windows; this window never moves itself.
+  using DragCallback = std::function<void(int owner_x, int owner_y)>;
+  // The drag finished — the owner persists the new bounds.
+  using DragEndCallback = std::function<void()>;
+
+  HookToolbarWindow();
+  ~HookToolbarWindow();
+
+  HookToolbarWindow(const HookToolbarWindow&) = delete;
+  HookToolbarWindow& operator=(const HookToolbarWindow&) = delete;
+
+  void SetActionCallback(ActionCallback callback) {
+    on_action_ = std::move(callback);
+  }
+  void SetDragCallback(DragCallback callback) { on_drag_ = std::move(callback); }
+  void SetDragEndCallback(DragEndCallback callback) {
+    on_drag_end_ = std::move(callback);
+  }
+
+  // Creates (if needed), positions and shows the toolbar. Returns false when
+  // the OS window could not be created — the caller MUST then refuse to make
+  // the body click-through, otherwise the user is locked out with no way back.
+  bool Show(const hook_toolbar::Layout& layout,
+            const hook_toolbar::Style& style,
+            const hook_toolbar::States& states);
+  void Hide();
+  bool IsShowing() const;
+
+  // Idempotent re-sync of geometry / colours / states. No-op (not even a
+  // repaint) when nothing changed, so the owner can call it from every render
+  // without turning caption updates into toolbar redraws.
+  void Sync(const hook_toolbar::Layout& layout,
+            const hook_toolbar::Style& style,
+            const hook_toolbar::States& states);
+
+ private:
+  static LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam,
+                                  LPARAM lparam) noexcept;
+  LRESULT HandleMessage(UINT message, WPARAM wparam, LPARAM lparam) noexcept;
+
+  void EnsureWindowClass();
+  bool EnsureDeviceResources();
+  void Render();
+  // Slot under the client point, or -1.
+  int SlotAt(float x, float y) const;
+
+  HWND hwnd_ = nullptr;
+  bool class_registered_ = false;
+  bool visible_ = false;
+  bool hovered_ = false;
+  bool tracking_mouse_leave_ = false;
+
+  // Owner-drag state. |dragging_| only becomes true once the press travelled
+  // past the threshold, so a still press on the background is not a 1px drag.
+  bool pressed_ = false;
+  bool dragging_ = false;
+  POINT press_origin_ = {0, 0};   // screen point where the press began
+  POINT owner_drag_anchor_ = {0, 0};  // cursor offset inside the OWNER rect
+
+  hook_toolbar::Layout layout_;
+  hook_toolbar::Style style_;
+  hook_toolbar::States states_;
+  bool has_layout_ = false;
+
+  Microsoft::WRL::ComPtr<ID2D1Factory> d2d_factory_;
+  Microsoft::WRL::ComPtr<IDWriteFactory> dwrite_factory_;
+  Microsoft::WRL::ComPtr<ID2D1DCRenderTarget> render_target_;
+
+  ActionCallback on_action_;
+  DragCallback on_drag_;
+  DragEndCallback on_drag_end_;
+};
+
+#endif  // RUNNER_HOOK_TOOLBAR_WINDOW_H_

--- a/hibiki/windows/runner/hook_toolbar_window.h
+++ b/hibiki/windows/runner/hook_toolbar_window.h
@@ -84,9 +84,14 @@ struct Style {
 // land exactly where the in-body toolbar used to draw them.
 struct Layout {
   RECT rect = {0, 0, 0, 0};  // toolbar window rect, screen px
-  float button_px = 0.0f;    // button edge length
-  float gap_px = 0.0f;       // gap between two buttons
-  float margin_px = 0.0f;    // padding between the window edge and the row
+  // Top-left of the OWNER (body) window, screen px. The toolbar rect is offset
+  // from it (the row is centred in the body and sits kControlsTopDip down), so
+  // an owner drag MUST anchor on this, not on |rect| — anchoring on the toolbar
+  // rect teleports the body by that offset the moment the drag starts.
+  POINT owner_origin = {0, 0};
+  float button_px = 0.0f;  // button edge length
+  float gap_px = 0.0f;     // gap between two buttons
+  float margin_px = 0.0f;  // padding between the window edge and the row
 };
 
 // Glyph drawn for |slot| under |states| (never null).


### PR DESCRIPTION
## 问题

galgame Hook 浮窗的「鼠标穿透」模式**跨进程无效**：穿透只靠 `WM_NCHITTEST` 返回 `HTTRANSPARENT`，而该结果按 Win32 契约只在**同线程**窗口间下传。游戏是另一个进程，于是点击被浮窗整个吞掉——既没到游戏，也没到浮窗。

已用最小跨进程 Win32 装置确定性复现（两组对照，各一对全新进程 + 一次真实 `SendInput` 点击）：体表 alpha=5/200 配 `HTTRANSPARENT` 时点击完全消失；换 `WS_EX_TRANSPARENT` 后另一进程正常收到，与逐像素 alpha 无关。

一直没被发现的原因：旧代码只在「背景不透明度=0」时看起来能用，那是层窗口逐像素命中测试的功劳；点在不透明的文字笔画上照样被吞。

## 为什么不是 PR#460 那版

PR#460 按光标位置 16ms 轮询开关整窗 `WS_EX_TRANSPARENT`，命中既有守卫 `interactivity is not driven by a hover timer`，且被证明**本质竞态**：定时器可被饿死，期间用户快速甩到工具条点的那一下会穿过去点进游戏，推进台词或选中分支破坏存档。已 revert。

## 本次做法：不再让一个窗口同时当两种东西

- **正文窗**穿透态**静态**置 `WS_EX_TRANSPARENT`，纯视觉，整窗对鼠标不存在；`WM_NCHITTEST` 里的 `HTTRANSPARENT` 分支删除。
- **工具条**搬进独立顶层窗 `HookToolbarWindow`（`windows/runner/hook_toolbar_window.{h,cpp}`），**永不**带 `WS_EX_TRANSPARENT`，因此永远可点。没有状态可翻转，也就没有竞态可输。**零定时器。**
- **不变量写进代码**：`ApplyPassThroughExStyle()` 是唯一入口，**先**把工具条放上屏、**再**让正文停止接收点击；工具条建不出来就退回不进穿透并把 `pass_through_` 摁回 false——宁可忽略这次切换，也不把用户关在一个点不动的浮窗后面。
- **消除漂移**：8 个槽位的 action / 字形 / 高亮态收进共享表 `hook_toolbar::kSlotActions` + `SlotGlyph/SlotActive`，两窗同表索引，物理上无法对「第 3 个按钮是什么」产生分歧；按钮执行收进单一 `DispatchControlAction()`；工具条几何由正文窗单向下发，工具条不自带任何 dip 常量。
- **保住能力**：穿透态改由拖工具条移动整个浮窗（正文已不收鼠标），复用正文窗的 `ClampOriginToWorkArea`，仍不会被拖出屏幕。

## 有意的观感差异

- 穿透态下正文窗不再自绘顶部工具条带与拖拽把手——它们已不接收鼠标，画出来就是骗人。
- 独立工具条静止时约 42% 不透明度常驻：它是唯一退出口，隐形的退出口等于没有退出口。
- 挡住游戏的死区反而**变小**：从「整窗宽 × 约 34dip」缩到约 320×40dip 的药丸。
- 非 hook 实例（有声书歌词条 / 剪贴板文本窗）不进这条分支，窗口样式与渲染逐像素不变。

## 守卫

新增 `hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart`：唯一 applier + 必须配 `SWP_FRAMECHANGED`、`SetBodyExTransparent` 只允许被 `ApplyPassThroughExStyle` 调用、**顺序不变量**（`Show(` 必须在 `SetBodyExTransparent(true)` 之前）、失败退路、反定时器（PR#460 回归门）、`return HTTRANSPARENT;` 禁止出现、两窗共表（8 个 action 逐个比对）/共字形/共派发、新 TU 真的进了 CMakeLists。

同时把旧 `floating_lyric_click_through_guard_test.dart` 里「禁止一切 `WS_EX_TRANSPARENT` 改写」的断言换成新契约：**保留**反定时器四条（那才是 PR#460 的真教训），把「禁用该位」换成「必须走唯一 applier + 必须有逃生工具条」。那条旧断言正是浮窗长期带着一个跨进程无效的穿透模式的原因，已在测试注释里如实写明。

## 验证

- `flutter analyze` 全量 **No issues found**
- 定向 `flutter test`（4 个相关守卫文件）**35/35 All tests passed**
- **负向对照**：把正文窗回退到 HEAD 后跑新守卫 → **2 通过 / 13 失败**（通过的 2 条只检查新工具条文件本身）
- `flutter build windows --debug` **exit 0**，`√ Built ...\Debug\hibiki.exe`，日志 0 编译/链接错误

## 仍缺（如实说明）

源码扫描锁的是**接线**，不是运行时行为。C++ 进不了 Dart 单测；更强的 Windows itest 层因本机冒烟门长期红而受阻，属成本取舍。仍需 Windows 真机 E2E 四条（已写进 bug 文件）：

1. 开穿透 → 点浮窗覆盖的游戏正文区 → 游戏推进台词
2. 穿透态点工具条 `↗` → 立刻退出穿透（不需要精准时机）
3. 穿透态拖工具条 → 整个浮窗跟随，松手位置被记住
4. 关穿透 → 正文区恢复查词与拖拽

https://claude.ai/code/session_014xoSEw2Lw7ibwGAitoPSjk
