### PR TITLE
fix(gal): GalHookLaunchResult 非法状态类型层消除 (BUG-1169)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1124 条。点号进各自文件。
+> 共 1125 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1169](bugs/BUG-1169-gal-launch-failed-reason-release-assert.md) | ✅ | ✅ | release 剥离 assert 后 failed(none) 被判成启动成功 |
 | [BUG-1162](bugs/BUG-1162-torrent-pipeline-disk-flush-race.md) | ✅ | ✅ | hibiki_torrent 端到端测试在字节落盘前就比对，CI Windows 约 24% 概率红 |
 | [BUG-1156](bugs/BUG-1156-manga-spread-cropped-janky.md) | ✅ | ✅ | 漫画双页图片裁切且翻页卡顿 |
 | [BUG-1155](bugs/BUG-1155-manga-popup-pagination-focus.md) | ✅ | ✅ | 漫画查词弹窗吞掉滚轮和左右翻页 |

--- a/docs/bugs/BUG-1169-gal-launch-failed-reason-release-assert.md
+++ b/docs/bugs/BUG-1169-gal-launch-failed-reason-release-assert.md
@@ -1,0 +1,38 @@
+## BUG-1169 · release 剥离 assert 后 failed(none) 被判成启动成功
+- **报告**：2026-07-28（用户：代码审查）
+- **真实性**：✅ 真 bug（潜伏隐患，非当前可复现路径）。根因
+  `hibiki/lib/src/mining/gal_hook_session_controller.dart:209`（PR#466 引入）：
+  `GalHookLaunchResult.failed()` 只用 `assert(reason != none)` 拦「没有原因的失败」，
+  而 `launched` 的判据是 `reason == GalHookLaunchFailureReason.none`。**assert 在 release
+  构建里被整个剥离**，届时 `failed(none)` 可以正常构造，`launched` 读成 `true` ——
+  一次失败的启动被当成成功播报：界面说「启动成功」，游戏没起来，且没有任何失败原因。
+  防御性断言恰好在用户实际运行的那个构建里不存在。
+  当前分类器不中一律落 `unknown`，`none` 走不到失败分支，所以尚不可复现；但值域里留着
+  哨兵 = 非法状态可构造，只靠 debug-only 检查约束。
+- **[x] ① 已修复** — 提交 `be8ad407b`。类型层消除非法状态，不再依赖运行期断言：
+  - `GalHookLaunchFailureReason` 删除 `none` 成员，枚举**只列失败**；
+  - `GalHookLaunchResult.reason` 改 `GalHookLaunchFailureReason?`，`null` 是「启动成功」
+    的唯一表示；`launched => reason == null`；
+  - `failed()` 形参为非空 `GalHookLaunchFailureReason`，空安全在**编译期**挡住 `null`，
+    枚举里又没有成功哨兵 ⇒ 「读起来像成功的失败」根本构造不出来，assert 随之删除；
+  - 两个命名构造器都重定向到私有生成式构造器 `GalHookLaunchResult._`，外部只有
+    `launched`（reason 恒 null）/ `failed`（reason 恒非 null）两条路，写不出第三种状态；
+  - `gal_hook_failure_text.dart` 的 `_failedMessage` switch 去掉 `none` 分支、补 `null`
+    分支（落兜底事实，绝不编造原因）。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_hook_launch_outcome_and_encoding_test.dart`
+  新增 3 条，**刻意不用 `throwsA(isA<AssertionError>())`**——那种断言只在 assert 生效时成立，
+  等于用「本 bug 里失效的那个机制」证明自己没事：
+  1. 值域守卫：`GalHookLaunchFailureReason.values` 不得含 `none`/`success` 哨兵（纯结构，
+     debug/release 语义相同）；
+  2. 行为守卫：遍历全部 `values` 构造 `failed(v)`，断言 `launched == false` 且分级不为
+     `running`——assert 被剥离时由 `expect` 抓，assert 生效时由 assert 抓，两种语义都红；
+  3. 源码守卫：`failed()` 构造器体内不得出现 `assert(`，且 `launched` 判据必须是
+     `reason == null`。
+  负向验证（临时改回旧实现）：① 旧实现原样 → 4 红；② **旧实现 + 删掉 assert（= release
+  语义）→ 仍 4 红，且日志里零 AssertionError**，失败来自
+  `Expected: false / Actual: <true>`（`launched` 把失败读成成功）与
+  `Expected: failed / Actual: windowMissing`（误判继续传到分级）。还原后全绿。
+- **备注**：同类型其它状态已核——`superseded` 在 `_failedMessage` 里同样走不到，但后果只是
+  落兜底文案，不构成「失败报成成功」；`GalHookInjectorDiagnostics.failure == none` 是合法
+  状态（失败早于 injector 运行时诊断本就为空），不是非法组合。`lib/src/mining/` 全目录
+  原本只有这一个 `assert`，修复后为零。

--- a/hibiki/lib/src/mining/gal_hook_failure_text.dart
+++ b/hibiki/lib/src/mining/gal_hook_failure_text.dart
@@ -94,9 +94,11 @@ String _failedMessage(
       t.game_hook_reason_helper_missing,
     // injectionFailed 的可执行处置在 injector 诊断里，由 [injectorReason] 提供。
     GalHookLaunchFailureReason.injectionFailed => injectorReason,
-    // 这两个不会走到 failed 分支（superseded 已早退，none 不是失败），列出只为穷举。
+    // superseded 已在 [classifyGalHookLaunchOutcome] 早退，走不到 failed 分级；列出只为穷举。
     GalHookLaunchFailureReason.superseded => null,
-    GalHookLaunchFailureReason.none => null,
+    // reason == null 即「启动成功」，同样到不了 failed 分级。真到了也**只**落到下面的
+    // 兜底事实（lastError / native 诊断），绝不会因此编造一句原因（BUG-1169）。
+    null => null,
   };
   if (reasonLabel != null) return reasonLabel;
   final String base = lastError ?? t.game_capture_launch_failed;

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -170,10 +170,11 @@ GalTrackEmptyHint galTrackEmptyHintFor(GalHookAudioBackend backend) =>
 ///
 /// 原因是在 `return false` 那一刻被丢掉的，任何下游补丁都救不回来（下游只能拿到一个
 /// 比特）。所以修在返回类型上：**每条失败出口必须携带一个原因，由编译期强制**。
+/// 本枚举**只列失败**，刻意不含 `none` 之类「未失败」哨兵（BUG-1169）：成功由
+/// [GalHookLaunchResult.reason] 取 `null` 表达。哨兵留在值域里就等于允许构造
+/// `failed(none)`——一个 `launched` 读起来是 `true` 的失败。当初拦住它的只有一个
+/// `assert`，而 release 构建会把 assert 整个剥掉：最需要它的那个构建里它恰好不在。
 enum GalHookLaunchFailureReason {
-  /// 未失败。
-  none,
-
   /// 非 Windows 平台，整条 Hook 链不可用。
   unsupportedPlatform,
 
@@ -197,28 +198,39 @@ enum GalHookLaunchFailureReason {
 @immutable
 class GalHookLaunchResult {
   /// 启动成功（含「游戏在跑但音频降级」——那仍然是启动成功，降级由 outcome 分级表达）。
-  const GalHookLaunchResult.launched()
-      : reason = GalHookLaunchFailureReason.none,
-        diagnostics = const GalHookInjectorDiagnostics();
+  const GalHookLaunchResult.launched() : this._();
 
-  /// 启动未成功。[reason] 不得为 [GalHookLaunchFailureReason.none]——那正是本 bug 的
-  /// 形态：一个没有原因的失败。
+  /// 启动未成功。[reason] 形参是**非空**的 [GalHookLaunchFailureReason]：该枚举已不含
+  /// 「未失败」哨兵，`null` 又被空安全在编译期挡住，所以「没有原因的失败」在这里
+  /// 根本构造不出来（BUG-1169）。这是类型约束而非运行期检查，不随 release 剥离 assert
+  /// 而失效——上一版的 `assert` 恰恰在用户实际运行的构建里不存在。
   const GalHookLaunchResult.failed(
-    this.reason, {
-    this.diagnostics = const GalHookInjectorDiagnostics(),
-  }) : assert(
-          reason != GalHookLaunchFailureReason.none,
-          'failed() 必须给出真实原因；启动成功请用 GalHookLaunchResult.launched()',
-        );
+    GalHookLaunchFailureReason reason, {
+    GalHookInjectorDiagnostics diagnostics = const GalHookInjectorDiagnostics(),
+  }) : this._(reason: reason, diagnostics: diagnostics);
 
-  final GalHookLaunchFailureReason reason;
+  /// 唯一的生成式构造器。私有：外部只能经 [launched]（reason 恒为 null）或
+  /// [failed]（reason 恒非 null）二选一进入，两条路都写不出第三种状态。
+  const GalHookLaunchResult._({
+    this.reason,
+    this.diagnostics = const GalHookInjectorDiagnostics(),
+  });
+
+  /// 失败原因；`null` **就是**「启动成功」这一个事实的唯一表示。
+  ///
+  /// 用 `null` 而不是枚举里的哨兵值：哨兵会同时出现在 `failed()` 的入参值域和
+  /// `launched` 的判据里，两边一旦对不上就产生「读起来像成功的失败」。`null` 只能由
+  /// [GalHookLaunchResult.launched] 写入，失败构造器压根拿不到它。
+  final GalHookLaunchFailureReason? reason;
 
   /// injector 的结构化诊断（分类原因 + 退出码 + stderr 尾部原文）。
   /// 即便 [GalHookInjectorFailure] 归类不出来，这里的 stderr 尾部仍是唯一的一手证据，
   /// 必须让它到达用户和日志，而不是像旧实现那样停在 controller 内部。
   final GalHookInjectorDiagnostics diagnostics;
 
-  bool get launched => reason == GalHookLaunchFailureReason.none;
+  /// 启动是否成功。判据是「没有失败原因」，而**每一个**失败原因都让它为 false——
+  /// 这由值域本身保证（枚举里没有任何值代表成功），不依赖任何运行期断言。
+  bool get launched => reason == null;
 }
 
 /// 一次「启动游戏」结束后**必须**告知用户的结果分级（BUG-1089，纯函数可单测）。

--- a/hibiki/test/mining/gal_hook_launch_outcome_and_encoding_test.dart
+++ b/hibiki/test/mining/gal_hook_launch_outcome_and_encoding_test.dart
@@ -205,11 +205,74 @@ void main() {
   // 失败」——零可执行信息。原因是在 `return false` 那一刻丢的，下游补丁救不回来
   // （下游只拿得到一个比特），所以修在返回类型上。
   group('启动失败必须带原因 (BUG-1142)', () {
-    test('失败结果不允许把原因留空', () {
+    // BUG-1169：上一版把「没有原因的失败」交给 `assert` 拦。assert 只活在 debug/test，
+    // release 会被整个剥掉——用户实际在跑的构建里，`failed(none)` 的 `launched` 会读成
+    // true，一次失败的启动被当成成功报出去：界面说启动了，游戏没起来，还没有任何原因。
+    // 所以下面这一组**刻意不用 `throwsA(isA<AssertionError>())`**：那种断言只有在 assert
+    // 生效时才成立，等于用「本 bug 里失效的那个机制」去证明自己没事。改成断言值域与
+    // 返回值本身，assert 在不在都一样红。
+    test('失败原因值域里不得存在「未失败」哨兵（assert 剥离后仍成立）', () {
+      final List<String> names = GalHookLaunchFailureReason.values
+          .map((GalHookLaunchFailureReason reason) => reason.name)
+          .toList();
       expect(
-        () => GalHookLaunchResult.failed(GalHookLaunchFailureReason.none),
-        throwsA(isA<AssertionError>()),
-        reason: '「没有原因的失败」正是本 bug 的形态，必须在构造处就挡掉',
+        names,
+        isNot(contains('none')),
+        reason: '哨兵一旦回到值域，failed(none) 又能被构造，'
+            '而 release 里没有 assert 兜底 —— 失败会被读成成功',
+      );
+      expect(
+        names,
+        isNot(contains('success')),
+        reason: '换个名字的哨兵是同一个洞',
+      );
+    });
+
+    test('每个可构造的失败原因都不能被判成启动成功（assert 剥离后仍成立）', () {
+      expect(
+        GalHookLaunchFailureReason.values,
+        isNotEmpty,
+        reason: '值域空了这条守卫就变成空转，必须先保证它真的在遍历',
+      );
+      for (final GalHookLaunchFailureReason reason
+          in GalHookLaunchFailureReason.values) {
+        final GalHookLaunchResult result = GalHookLaunchResult.failed(reason);
+        expect(
+          result.launched,
+          isFalse,
+          reason: '$reason 是失败，launched 读成 true 就等于把失败播报成成功',
+        );
+        expect(
+          classifyGalHookLaunchOutcome(
+            result: result,
+            hasBoundWindow: true,
+            injectorFailure: GalHookInjectorFailure.none,
+          ),
+          isNot(GalHookLaunchOutcome.running),
+          reason: '$reason 绝不能分级成「注入成功、窗口已绑定」',
+        );
+      }
+    });
+
+    test('源码守卫：失败构造器不得靠 assert 拦非法原因', () {
+      final File source =
+          File('lib/src/mining/gal_hook_session_controller.dart');
+      expect(source.existsSync(), isTrue, reason: '测试须在 hibiki/ 下运行才能读到源码');
+      final String code = source.readAsStringSync();
+      final int start = code.indexOf('const GalHookLaunchResult.failed(');
+      expect(start, greaterThan(-1), reason: '失败构造器没了，本守卫失去锚点');
+      final int end = code.indexOf('bool get launched', start);
+      expect(end, greaterThan(start));
+      expect(
+        code.substring(start, end).contains('assert('),
+        isFalse,
+        reason: 'assert 在 release 被剥离，非法状态必须由类型系统挡掉而不是运行期断言'
+            '（BUG-1169）',
+      );
+      expect(
+        RegExp(r'bool get launched => reason == null;').hasMatch(code),
+        isTrue,
+        reason: '成功的唯一表示是「没有失败原因」；换回哨兵比较就把洞开回来了',
       );
     });
 
@@ -237,7 +300,6 @@ void main() {
     test('每个失败原因都有确定分级，不留未定义组合', () {
       for (final GalHookLaunchFailureReason reason
           in GalHookLaunchFailureReason.values) {
-        if (reason == GalHookLaunchFailureReason.none) continue;
         expect(
           classifyGalHookLaunchOutcome(
             result: GalHookLaunchResult.failed(reason),


### PR DESCRIPTION
## 问题

PR#466 引入的 `GalHookLaunchResult` 设计本身是对的（8 条 return 全带原因，强制力来自类型系统），但留了一个洞：

```dart
const GalHookLaunchResult.failed(this.reason, {...})
    : assert(reason != GalHookLaunchFailureReason.none, ...);
...
bool get launched => reason == GalHookLaunchFailureReason.none;
```

`failed(none)` 这个非法状态**只靠 `assert` 拦**。而 **assert 在 release 构建里会被整个剥离**——届时 `failed(none)` 可以正常构造，`launched` 读成 `true`，等于**把一次失败的启动当成功报给用户**：界面说「启动成功」，游戏没起来，而且不会有任何失败原因可看。

防御性断言恰好在**用户实际在跑的那个构建**里失效——最需要它的时候它不在。

当前不算紧急：分类器不中一律落 `unknown`，`none` 在现有代码路径下走不到失败分支。但值域里留着哨兵 = 非法状态可构造，仅由 debug-only 检查约束。

## 修复（首选方向：类型层不可构造，而不是 getter 兜底）

- `GalHookLaunchFailureReason` **删除 `none` 成员**，枚举只列失败；
- `GalHookLaunchResult.reason` 改 `GalHookLaunchFailureReason?`，`null` 是「启动成功」的唯一表示，`launched => reason == null`；
- `failed()` 形参为**非空** `GalHookLaunchFailureReason`：空安全在**编译期**挡住 `null`，枚举里又没有成功哨兵 ⇒「读起来像成功的失败」根本构造不出来。`assert` 随之删除；
- 两个命名构造器重定向到私有生成式构造器 `GalHookLaunchResult._`，外部只有 `launched`（reason 恒 null）/ `failed`（reason 恒非 null）两条入口，写不出第三种状态；
- `gal_hook_failure_text.dart` 的 `_failedMessage` switch 去掉 `none` 分支、补 `null` 分支（落兜底事实，绝不编造原因）。

为什么不选「getter 对 `none` 显式返回 false」：那是把非法状态留在值域里再补一道判断，`failed(none)` 仍可构造，下一个消费点照样可能按 `reason == none` 自己判一遍。删掉哨兵是从源头消除。

## 测试如何保证在 assert 失效的语义下仍能抓到

被替换掉的旧测试正是反面教材：

```dart
expect(() => GalHookLaunchResult.failed(GalHookLaunchFailureReason.none),
       throwsA(isA<AssertionError>()));
```

它**只在 assert 生效时成立**——等于用「本 bug 里失效的那个机制」去证明自己没事。新增 3 条全部避开 `throwsA(isA<AssertionError>())`：

1. **值域守卫**：`GalHookLaunchFailureReason.values` 的 name 不得含 `none` / `success`。纯结构断言，debug/release 语义完全相同。
2. **行为守卫**：遍历全部 `values` 构造 `failed(v)`，断言 `launched == false` 且分级不为 `running`。assert 生效时由 assert 抓，assert 被剥离时由 `expect` 抓 —— **两种语义都红**。（附带 `values` 非空断言，防值域变空让循环空转。）
3. **源码守卫**：`failed()` 构造器体内不得出现 `assert(`，且 `launched` 判据必须是 `reason == null`。

## 负向验证（两阶段，测试文件保持新版不动）

| 变体 | 结果 |
|---|---|
| A：旧实现原样（enum 含 `none` + assert） | 4 红，但关键那条是被 `_AssertionError._throwNew` 打红的 |
| **B：旧实现 + 删掉 assert（= release 语义）** | **仍 4 红，日志里零 AssertionError**，全部来自 `expect` |

变体 B 的关键输出：

```
每个可构造的失败原因都不能被判成启动成功（assert 剥离后仍成立） [E]
  Expected: false
    Actual: <true>
  GalHookLaunchFailureReason.none 是失败，launched 读成 true 就等于把失败播报成成功

每个失败原因都有确定分级，不留未定义组合 [E]
  Expected: GalHookLaunchOutcome:<failed>
    Actual: GalHookLaunchOutcome:<windowMissing>
```

第一条就是 bug 在 release 语义下的原形；第二条证明误判会继续传到分级（`failed` 被读成 `windowMissing`，即「已启动但没窗口」——正是「说启动成功、游戏没起来」）。还原后该文件全绿。

## 同类型其它非法组合核查

已核过，结论：

- `lib/src/mining/` 全目录原本**只有这一个 `assert`**，修复后为 0；
- `superseded` 在 `_failedMessage` 里同样走不到（`classifyGalHookLaunchOutcome` 已早退），只由注释约束——但后果是落兜底文案，**不构成「失败报成成功」**，且它是合法的 `failed()` 入参，不能从值域删。保留并注明；
- `null => null` 分支同理，只落兜底事实，不编造原因；
- `GalHookInjectorDiagnostics.failure == none` **不是**非法组合：失败早于 injector 运行（如 `helperMissing`）时诊断本就为空；
- `classifyGalHookLaunchOutcome` 其余分支无残留非法组合（`launched()` 恒 reason==null，不可能同时是 `superseded`）。

## 影响面

`GalHookLaunchResult` + `gal_hook_failure_text.dart`。三个 UI 消费点（`texthooker_page` / `games_library_page` / `galgame_home_page`）只读 `result.launched`，**无需改动**。未触碰 PR#470 / PR#471 的捕获链路文件。仅 Windows galgame 端。

## 验证

- `flutter analyze`（含 test）：**No issues found!**
- 全量 `flutter test --no-pub`：见评论区（develop 基底当前已有 PR#474 引入的 8 条红，另有本机 flaky）。

BUG-1169（`dart run tool/bug.dart new` 取号，开 PR 前已跨 424 个远端分支复核唯一）

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
